### PR TITLE
Implement Validity for SparseArray, make scalar_at for bitpacked array respect patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ benchmarks/.out
 
 # Scratch
 *.txt
+*.vortex

--- a/vortex-alp/src/compress.rs
+++ b/vortex-alp/src/compress.rs
@@ -7,6 +7,7 @@ use vortex::compress::{CompressConfig, CompressCtx, EncodingCompression};
 use vortex::compute::flatten::flatten_primitive;
 use vortex::compute::patch::patch;
 use vortex::ptype::{NativePType, PType};
+use vortex::scalar::Scalar;
 use vortex_error::{vortex_bail, vortex_err, VortexResult};
 
 use crate::alp::ALPFloat;
@@ -99,6 +100,7 @@ where
                 PrimitiveArray::from(exc_pos).into_array(),
                 PrimitiveArray::from(exc).into_array(),
                 len,
+                Scalar::null(values.dtype()),
             )
             .into_array()
         }),

--- a/vortex-alp/src/compress.rs
+++ b/vortex-alp/src/compress.rs
@@ -89,6 +89,11 @@ where
     T::ALPInt: NativePType,
 {
     let (exponents, encoded, exc_pos, exc) = T::encode(values.typed_data::<T>(), exponents);
+    let fill_value = if values.dtype().is_nullable() {
+        Scalar::null(values.dtype())
+    } else {
+        T::default().into()
+    };
     let len = encoded.len();
     (
         exponents,
@@ -100,7 +105,7 @@ where
                 PrimitiveArray::from(exc_pos).into_array(),
                 PrimitiveArray::from(exc).into_array(),
                 len,
-                Scalar::null(values.dtype()),
+                fill_value,
             )
             .into_array()
         }),

--- a/vortex-alp/src/compress.rs
+++ b/vortex-alp/src/compress.rs
@@ -89,11 +89,6 @@ where
     T::ALPInt: NativePType,
 {
     let (exponents, encoded, exc_pos, exc) = T::encode(values.typed_data::<T>(), exponents);
-    let fill_value = if values.dtype().is_nullable() {
-        Scalar::null(values.dtype())
-    } else {
-        T::default().into()
-    };
     let len = encoded.len();
     (
         exponents,
@@ -105,7 +100,7 @@ where
                 PrimitiveArray::from(exc_pos).into_array(),
                 PrimitiveArray::from(exc).into_array(),
                 len,
-                fill_value,
+                Scalar::null(&values.dtype().as_nullable()),
             )
             .into_array()
         }),

--- a/vortex-array/src/array/sparse/compress.rs
+++ b/vortex-array/src/array/sparse/compress.rs
@@ -4,7 +4,6 @@ use crate::array::downcast::DowncastArrayBuiltin;
 use crate::array::sparse::{SparseArray, SparseEncoding};
 use crate::array::{Array, ArrayRef};
 use crate::compress::{CompressConfig, CompressCtx, EncodingCompression};
-use crate::scalar::{NullScalar, Scalar};
 
 impl EncodingCompression for SparseEncoding {
     fn cost(&self) -> u8 {
@@ -33,7 +32,7 @@ impl EncodingCompression for SparseEncoding {
             ctx.named("values")
                 .compress(sparse_array.values(), sparse_like.map(|sa| sa.values()))?,
             sparse_array.len(),
-            Scalar::Null(NullScalar::new()),
+            sparse_array.fill_value.clone(),
         )
         .into_array())
     }

--- a/vortex-array/src/array/sparse/compress.rs
+++ b/vortex-array/src/array/sparse/compress.rs
@@ -4,6 +4,7 @@ use crate::array::downcast::DowncastArrayBuiltin;
 use crate::array::sparse::{SparseArray, SparseEncoding};
 use crate::array::{Array, ArrayRef};
 use crate::compress::{CompressConfig, CompressCtx, EncodingCompression};
+use crate::scalar::{NullScalar, Scalar};
 
 impl EncodingCompression for SparseEncoding {
     fn cost(&self) -> u8 {
@@ -32,6 +33,7 @@ impl EncodingCompression for SparseEncoding {
             ctx.named("values")
                 .compress(sparse_array.values(), sparse_like.map(|sa| sa.values()))?,
             sparse_array.len(),
+            Scalar::Null(NullScalar::new()),
         )
         .into_array())
     }

--- a/vortex-array/src/array/sparse/compute.rs
+++ b/vortex-array/src/array/sparse/compute.rs
@@ -62,7 +62,6 @@ impl AsContiguousFn for SparseArray {
     }
 }
 
-#[allow(unreachable_code)]
 impl FlattenFn for SparseArray {
     fn flatten(&self) -> VortexResult<FlattenedArray> {
         // Resolve our indices into a vector of usize applying the offset

--- a/vortex-array/src/array/sparse/compute.rs
+++ b/vortex-array/src/array/sparse/compute.rs
@@ -69,7 +69,7 @@ impl FlattenFn for SparseArray {
         let mut validity = BooleanBufferBuilder::new(self.len());
         validity.append_n(self.len(), false);
         let values = flatten(self.values())?;
-        let null_fill = self.fill_value.is_null();
+        let null_fill = self.fill_value().is_null();
         if let FlattenedArray::Primitive(ref parray) = values {
             match_each_native_ptype!(parray.ptype(), |$P| {
                 flatten_primitive::<$P>(

--- a/vortex-array/src/array/sparse/compute.rs
+++ b/vortex-array/src/array/sparse/compute.rs
@@ -12,6 +12,7 @@ use crate::compute::scalar_at::{scalar_at, ScalarAtFn};
 use crate::compute::search_sorted::{search_sorted, SearchSortedSide};
 use crate::compute::ArrayCompute;
 use crate::match_each_native_ptype;
+use crate::ptype::NativePType;
 use crate::scalar::Scalar;
 
 impl ArrayCompute for SparseArray {
@@ -30,14 +31,12 @@ impl ArrayCompute for SparseArray {
 
 impl AsContiguousFn for SparseArray {
     fn as_contiguous(&self, arrays: &[ArrayRef]) -> VortexResult<ArrayRef> {
-        let fill_types = arrays
+        let all_fill_types_are_equal = arrays
             .iter()
-            .map(|a| a.as_sparse().clone().fill_value)
-            .dedup()
-            .collect_vec();
-        assert_eq!(
-            1,
-            fill_types.len(),
+            .map(|a| a.as_sparse().fill_value())
+            .all_equal();
+        assert!(
+            all_fill_types_are_equal,
             "Cannot concatenate SparseArrays with differing fill values"
         );
         Ok(SparseArray::new(
@@ -56,7 +55,7 @@ impl AsContiguousFn for SparseArray {
                     .collect_vec(),
             )?,
             arrays.iter().map(|a| a.len()).sum(),
-            fill_types.first().unwrap().clone(),
+            self.fill_value().clone(),
         )
         .into_array())
     }
@@ -71,39 +70,51 @@ impl FlattenFn for SparseArray {
         validity.append_n(self.len(), false);
         let values = flatten(self.values())?;
         let null_fill = self.fill_value.is_null();
-        if let FlattenedArray::Primitive(parray) = values {
+        if let FlattenedArray::Primitive(ref parray) = values {
             match_each_native_ptype!(parray.ptype(), |$P| {
-                let mut values = if null_fill {
-                    vec![$P::default(); self.len()]
-                } else {
-                    let p_fill_value: $P = self.fill_value.clone().try_into()?;
-                    vec![p_fill_value; self.len()]
-                };
-                let mut offset = 0;
-
-                for v in parray.typed_data::<$P>() {
-                    let idx = indices[offset];
-                    values[idx] = *v;
-                    validity.set_bit(idx, true);
-                    offset += 1;
-                }
-
-                let validity = validity.finish();
-                if null_fill {
-                    Ok(FlattenedArray::Primitive(PrimitiveArray::from_nullable(
-                    values,
-                    Some(validity.into()),
-                    )))
-                } else {
-                    Ok(FlattenedArray::Primitive(PrimitiveArray::from(values)))
-                }
-
+                flatten_primitive::<$P>(
+                    self,
+                    parray,
+                    indices,
+                    null_fill,
+                    validity
+                )
             })
         } else {
             Err(vortex_err!(
                 "Cannot flatten SparseArray with non-primitive values"
             ))
         }
+    }
+}
+fn flatten_primitive<T: NativePType>(
+    sparse_array: &SparseArray,
+    parray: &PrimitiveArray,
+    indices: Vec<usize>,
+    null_fill: bool,
+    mut validity: BooleanBufferBuilder,
+) -> VortexResult<FlattenedArray> {
+    let fill_value = if null_fill {
+        T::default()
+    } else {
+        sparse_array.fill_value.clone().try_into()?
+    };
+    let mut values = vec![fill_value; sparse_array.len()];
+
+    for (offset, v) in parray.typed_data::<T>().iter().enumerate() {
+        let idx = indices[offset];
+        values[idx] = *v;
+        validity.set_bit(idx, true);
+    }
+
+    let validity = validity.finish();
+    if null_fill {
+        Ok(FlattenedArray::Primitive(PrimitiveArray::from_nullable(
+            values,
+            Some(validity.into()),
+        )))
+    } else {
+        Ok(FlattenedArray::Primitive(PrimitiveArray::from(values)))
     }
 }
 
@@ -113,19 +124,15 @@ impl ScalarAtFn for SparseArray {
         // First, get the index of the patch index array that is the first index
         // greater than or equal to the true index
         let true_patch_index = index + self.indices_offset;
-        search_sorted(self.indices(), true_patch_index, SearchSortedSide::Left).and_then(|idx| {
-            // If the value at this index is equal to the true index, then it exists in the patch index array,
-            // and we should return the value at the corresponding index in the patch values array
-            scalar_at(self.indices(), idx)
-                .or_else(|_| Ok(Scalar::null(self.values().dtype())))
-                .and_then(usize::try_from)
-                .and_then(|patch_index| {
-                    if patch_index == true_patch_index {
-                        scalar_at(self.values(), idx)
-                    } else {
-                        Ok(Scalar::null(self.values().dtype()))
-                    }
-                })
-        })
+        let idx = search_sorted(self.indices(), true_patch_index, SearchSortedSide::Left)?;
+
+        // If the value at this index is equal to the true index, then it exists in the patch index array,
+        // and we should return the value at the corresponding index in the patch values array
+        let patch_index: usize = scalar_at(self.indices(), idx)?.try_into()?;
+        if patch_index == true_patch_index {
+            scalar_at(self.values(), idx)?.cast(self.dtype())
+        } else {
+            Ok(self.fill_value().clone())
+        }
     }
 }

--- a/vortex-array/src/array/sparse/compute.rs
+++ b/vortex-array/src/array/sparse/compute.rs
@@ -1,6 +1,6 @@
 use arrow_buffer::BooleanBufferBuilder;
 use itertools::Itertools;
-use vortex_error::{vortex_err, VortexResult};
+use vortex_error::{vortex_bail, vortex_err, VortexResult};
 
 use crate::array::downcast::DowncastArrayBuiltin;
 use crate::array::primitive::PrimitiveArray;
@@ -35,10 +35,10 @@ impl AsContiguousFn for SparseArray {
             .iter()
             .map(|a| a.as_sparse().fill_value())
             .all_equal();
-        assert!(
-            all_fill_types_are_equal,
-            "Cannot concatenate SparseArrays with differing fill values"
-        );
+        if !all_fill_types_are_equal {
+            vortex_bail!("Cannot concatenate SparseArrays with differing fill values");
+        }
+
         Ok(SparseArray::new(
             as_contiguous(
                 &arrays

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -47,10 +47,10 @@ impl SparseArray {
         len: usize,
         fill_value: Scalar,
     ) -> VortexResult<Self> {
-        Self::new_with_offset(indices, values, len, 0, fill_value)
+        Self::try_new_with_offset(indices, values, len, 0, fill_value)
     }
 
-    pub(crate) fn new_with_offset(
+    pub(crate) fn try_new_with_offset(
         indices: ArrayRef,
         values: ArrayRef,
         len: usize,

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -86,6 +86,11 @@ impl SparseArray {
         &self.indices
     }
 
+    #[inline]
+    fn fill_value(&self) -> &Scalar {
+        &self.fill_value
+    }
+
     /// Return indices as a vector of usize with the indices_offset applied.
     pub fn resolved_indices(&self) -> Vec<usize> {
         flatten_primitive(cast(self.indices(), PType::U64.into()).unwrap().as_ref())

--- a/vortex-array/src/array/sparse/serde.rs
+++ b/vortex-array/src/array/sparse/serde.rs
@@ -38,7 +38,7 @@ impl EncodingSerde for SparseEncoding {
             values,
             len,
             offset,
-            // N.B. we should deserialize the fill value from the source, but currently do not,
+            // NB: We should deserialize the fill value from the source, but currently do not,
             // so everything that goes through this read path is nullable
             Scalar::null(&fill_type),
         )

--- a/vortex-array/src/array/sparse/serde.rs
+++ b/vortex-array/src/array/sparse/serde.rs
@@ -1,6 +1,3 @@
-use std::io;
-use std::io::ErrorKind;
-
 use vortex_error::VortexResult;
 use vortex_schema::DType;
 
@@ -35,15 +32,14 @@ impl EncodingSerde for SparseEncoding {
         let offset = ctx.read_usize()?;
         let indices = ctx.with_schema(&DType::IDX).read()?;
         let values = ctx.read()?;
-        Ok(SparseArray::new_with_offset(
+        SparseArray::try_new_with_offset(
             indices,
             values,
             len,
             offset,
             Scalar::Null(NullScalar::new()),
         )
-        .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?
-        .into_array())
+        .map(|a| a.into_array())
     }
 }
 

--- a/vortex-array/src/scalar/mod.rs
+++ b/vortex-array/src/scalar/mod.rs
@@ -132,6 +132,35 @@ impl Scalar {
             DType::Composite(..) => unimplemented!("CompositeScalar"),
         }
     }
+
+    pub fn non_null(dtype: &DType) -> Self {
+        assert!(!dtype.is_nullable());
+        match dtype {
+            DType::Null => NullScalar::new().into(),
+            DType::Bool(_) => BoolScalar::none().into(),
+            DType::Int(w, s, _) => match (w, s) {
+                (IntWidth::_8, Signedness::Signed) => PrimitiveScalar::none::<i8>().into(),
+                (IntWidth::_16, Signedness::Signed) => PrimitiveScalar::none::<i16>().into(),
+                (IntWidth::_32, Signedness::Signed) => PrimitiveScalar::none::<i32>().into(),
+                (IntWidth::_64, Signedness::Signed) => PrimitiveScalar::none::<i64>().into(),
+                (IntWidth::_8, Signedness::Unsigned) => PrimitiveScalar::none::<u8>().into(),
+                (IntWidth::_16, Signedness::Unsigned) => PrimitiveScalar::none::<u16>().into(),
+                (IntWidth::_32, Signedness::Unsigned) => PrimitiveScalar::none::<u32>().into(),
+                (IntWidth::_64, Signedness::Unsigned) => PrimitiveScalar::none::<u64>().into(),
+            },
+            DType::Decimal(..) => unimplemented!("DecimalScalar"),
+            DType::Float(w, _) => match w {
+                FloatWidth::_16 => PrimitiveScalar::none::<f16>().into(),
+                FloatWidth::_32 => PrimitiveScalar::none::<f32>().into(),
+                FloatWidth::_64 => PrimitiveScalar::none::<f64>().into(),
+            },
+            DType::Utf8(_) => Utf8Scalar::none().into(),
+            DType::Binary(_) => BinaryScalar::none().into(),
+            DType::Struct(..) => StructScalar::new(dtype.clone(), vec![]).into(),
+            DType::List(..) => ListScalar::new(dtype.clone(), None).into(),
+            DType::Composite(..) => unimplemented!("CompositeScalar"),
+        }
+    }
 }
 
 impl Display for Scalar {

--- a/vortex-array/src/scalar/mod.rs
+++ b/vortex-array/src/scalar/mod.rs
@@ -132,35 +132,6 @@ impl Scalar {
             DType::Composite(..) => unimplemented!("CompositeScalar"),
         }
     }
-
-    pub fn non_null(dtype: &DType) -> Self {
-        assert!(!dtype.is_nullable());
-        match dtype {
-            DType::Null => NullScalar::new().into(),
-            DType::Bool(_) => BoolScalar::none().into(),
-            DType::Int(w, s, _) => match (w, s) {
-                (IntWidth::_8, Signedness::Signed) => PrimitiveScalar::none::<i8>().into(),
-                (IntWidth::_16, Signedness::Signed) => PrimitiveScalar::none::<i16>().into(),
-                (IntWidth::_32, Signedness::Signed) => PrimitiveScalar::none::<i32>().into(),
-                (IntWidth::_64, Signedness::Signed) => PrimitiveScalar::none::<i64>().into(),
-                (IntWidth::_8, Signedness::Unsigned) => PrimitiveScalar::none::<u8>().into(),
-                (IntWidth::_16, Signedness::Unsigned) => PrimitiveScalar::none::<u16>().into(),
-                (IntWidth::_32, Signedness::Unsigned) => PrimitiveScalar::none::<u32>().into(),
-                (IntWidth::_64, Signedness::Unsigned) => PrimitiveScalar::none::<u64>().into(),
-            },
-            DType::Decimal(..) => unimplemented!("DecimalScalar"),
-            DType::Float(w, _) => match w {
-                FloatWidth::_16 => PrimitiveScalar::none::<f16>().into(),
-                FloatWidth::_32 => PrimitiveScalar::none::<f32>().into(),
-                FloatWidth::_64 => PrimitiveScalar::none::<f64>().into(),
-            },
-            DType::Utf8(_) => Utf8Scalar::none().into(),
-            DType::Binary(_) => BinaryScalar::none().into(),
-            DType::Struct(..) => StructScalar::new(dtype.clone(), vec![]).into(),
-            DType::List(..) => ListScalar::new(dtype.clone(), None).into(),
-            DType::Composite(..) => unimplemented!("CompositeScalar"),
-        }
-    }
 }
 
 impl Display for Scalar {

--- a/vortex-fastlanes/src/bitpacking/compress.rs
+++ b/vortex-fastlanes/src/bitpacking/compress.rs
@@ -12,7 +12,6 @@ use vortex::compute::patch::patch;
 use vortex::match_each_integer_ptype;
 use vortex::ptype::PType::{I16, I32, I64, I8, U16, U32, U64, U8};
 use vortex::ptype::{NativePType, PType};
-use vortex::scalar::NullScalar;
 use vortex::scalar::{ListScalarVec, Scalar};
 use vortex::stats::Stat;
 use vortex_error::{vortex_bail, vortex_err, VortexResult};
@@ -159,7 +158,7 @@ fn bitpack_patches(
                 values.push(*v);
             }
         }
-        SparseArray::new(indices.into_array(), values.into_array(), parray.len(), Scalar::Null(NullScalar::new())).into_array()
+        SparseArray::new(indices.into_array(), values.into_array(), parray.len(), Scalar::null(&parray.dtype().as_nullable())).into_array()
     })
 }
 
@@ -268,12 +267,8 @@ pub(crate) fn unpack_single(array: &BitPackedArray, index: usize) -> VortexResul
         }?
     };
 
-    // Cast to signed if necessary
-    if ptype.is_signed_int() {
-        scalar.cast(&ptype.into())
-    } else {
-        Ok(scalar)
-    }
+    // Cast to fix signedness and nullability
+    scalar.cast(array.dtype())
 }
 
 /// # Safety

--- a/vortex-fastlanes/src/bitpacking/compress.rs
+++ b/vortex-fastlanes/src/bitpacking/compress.rs
@@ -12,6 +12,7 @@ use vortex::compute::patch::patch;
 use vortex::match_each_integer_ptype;
 use vortex::ptype::PType::{I16, I32, I64, I8, U16, U32, U64, U8};
 use vortex::ptype::{NativePType, PType};
+use vortex::scalar::NullScalar;
 use vortex::scalar::{ListScalarVec, Scalar};
 use vortex::stats::Stat;
 use vortex_error::{vortex_bail, vortex_err, VortexResult};
@@ -158,7 +159,7 @@ fn bitpack_patches(
                 values.push(*v);
             }
         }
-        SparseArray::new(indices.into_array(), values.into_array(), parray.len()).into_array()
+        SparseArray::new(indices.into_array(), values.into_array(), parray.len(), Scalar::Null(NullScalar::new())).into_array()
     })
 }
 

--- a/vortex-fastlanes/src/bitpacking/compute.rs
+++ b/vortex-fastlanes/src/bitpacking/compute.rs
@@ -39,18 +39,13 @@ impl ScalarAtFn for BitPackedArray {
         if index >= self.len() {
             return Err(vortex_err!(OutOfBounds:index, 0, self.len()));
         }
-        if self.bit_width() == 0 {
-            let ptype = self.dtype().try_into()?;
-            match_each_integer_ptype!(&ptype, |$P| {
-                return Ok(Scalar::from(0 as $P));
-            })
-        }
+
         if let Some(patches) = self.patches() {
-            if patches.is_valid(index) {
-                return scalar_at(patches, index);
+            if self.bit_width == 0 || patches.is_valid(index) {
+                return scalar_at(patches, index)?.cast(self.dtype());
             }
         }
-        unpack_single(self, index)
+        unpack_single(self, index)?.cast(self.dtype())
     }
 }
 

--- a/vortex-fastlanes/src/bitpacking/compute.rs
+++ b/vortex-fastlanes/src/bitpacking/compute.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use vortex::array::downcast::DowncastArrayBuiltin;
 use vortex::array::primitive::PrimitiveArray;
 use vortex::array::{Array, ArrayRef};
 use vortex::compute::as_contiguous::as_contiguous;
@@ -45,7 +46,17 @@ impl ScalarAtFn for BitPackedArray {
                 return Ok(Scalar::from(0 as $P));
             })
         }
-        unpack_single(self, index)
+
+        match self.patches.clone() {
+            None => unpack_single(self, index),
+            Some(patch) => {
+                if patch.is_valid(index) {
+                    ScalarAtFn::scalar_at(patch.as_sparse(), index)
+                } else {
+                    unpack_single(self, index)
+                }
+            }
+        }
     }
 }
 

--- a/vortex-fastlanes/src/bitpacking/compute.rs
+++ b/vortex-fastlanes/src/bitpacking/compute.rs
@@ -41,6 +41,7 @@ impl ScalarAtFn for BitPackedArray {
         }
 
         if let Some(patches) = self.patches() {
+            // NB: All non-null values are considered patches
             if self.bit_width == 0 || patches.is_valid(index) {
                 return scalar_at(patches, index)?.cast(self.dtype());
             }

--- a/vortex-fastlanes/src/bitpacking/mod.rs
+++ b/vortex-fastlanes/src/bitpacking/mod.rs
@@ -19,6 +19,7 @@ mod compress;
 mod compute;
 mod serde;
 
+/// NB: All non-null in the patches array are considered patches
 #[derive(Debug, Clone)]
 pub struct BitPackedArray {
     encoded: ArrayRef,

--- a/vortex-fastlanes/src/bitpacking/mod.rs
+++ b/vortex-fastlanes/src/bitpacking/mod.rs
@@ -19,7 +19,7 @@ mod compress;
 mod compute;
 mod serde;
 
-/// NB: All non-null in the patches array are considered patches
+/// NB: All non-null values in the patches array are considered patches
 #[derive(Debug, Clone)]
 pub struct BitPackedArray {
     encoded: ArrayRef,


### PR DESCRIPTION
before:
Issue: https://github.com/fulcrum-so/vortex/issues/193

https://github.com/fulcrum-so/vortex/pull/147 uncovered that we did not respect patches in scalar_at calculations, causing a panic when REE ends arrays were bitpacked with patches.


After:
* We have a validity is implementation for BitPackedArray
* ScalarAtFn for BitPackedArray no longer ignores patches
* benches/compress no longer panics
* flatten respects fill_value