### PR TITLE
Support arbitrary slicing of Bitpacked arrays

### DIFF
--- a/vortex-fastlanes/benches/bitpacking.rs
+++ b/vortex-fastlanes/benches/bitpacking.rs
@@ -33,6 +33,10 @@ fn pack_unpack(c: &mut Criterion) {
         b.iter(|| black_box(unpack_primitive::<u32>(&packed, bits, 0, values.len())));
     });
 
+    c.bench_function("unpack_1M_offset", |b| {
+        b.iter(|| black_box(unpack_primitive::<u32>(&packed, bits, 768, values.len())));
+    });
+
     c.bench_function("unpack_1M_singles", |b| {
         b.iter(|| black_box(unpack_singles(&packed, 8, values.len())));
     });
@@ -43,11 +47,25 @@ fn pack_unpack(c: &mut Criterion) {
         b.iter(|| black_box(unpack_primitive::<u32>(&packed, bits, 0, values.len())));
     });
 
+    c.bench_function("unpack_1024_alloc_offset", |b| {
+        b.iter(|| black_box(unpack_primitive::<u32>(&packed, bits, 768, values.len())));
+    });
+
     let mut output: Vec<u32> = Vec::with_capacity(1024);
     c.bench_function("unpack_1024_noalloc", |b| {
         b.iter(|| {
             output.clear();
             TryBitPack::try_unpack_into(packed_1024, bits, &mut output).unwrap();
+            black_box(output[0])
+        })
+    });
+
+    let mut output: Vec<u32> = Vec::with_capacity(1024);
+    c.bench_function("unpack_1024_noalloc_offset", |b| {
+        b.iter(|| {
+            output.clear();
+            TryBitPack::try_unpack_into(packed_1024, bits, &mut output).unwrap();
+            output.drain(0..768);
             black_box(output[0])
         })
     });

--- a/vortex-fastlanes/benches/bitpacking.rs
+++ b/vortex-fastlanes/benches/bitpacking.rs
@@ -30,7 +30,7 @@ fn pack_unpack(c: &mut Criterion) {
 
     let packed = bitpack_primitive(&values, bits);
     c.bench_function("unpack_1M", |b| {
-        b.iter(|| black_box(unpack_primitive::<u32>(&packed, bits, values.len())));
+        b.iter(|| black_box(unpack_primitive::<u32>(&packed, bits, 0, values.len())));
     });
 
     c.bench_function("unpack_1M_singles", |b| {
@@ -40,7 +40,7 @@ fn pack_unpack(c: &mut Criterion) {
     // 1024 elements pack into `128 * bits` bytes
     let packed_1024 = &packed[0..128 * bits];
     c.bench_function("unpack_1024_alloc", |b| {
-        b.iter(|| black_box(unpack_primitive::<u32>(&packed, bits, values.len())));
+        b.iter(|| black_box(unpack_primitive::<u32>(&packed, bits, 0, values.len())));
     });
 
     let mut output: Vec<u32> = Vec::with_capacity(1024);

--- a/vortex-fastlanes/src/bitpacking/compress.rs
+++ b/vortex-fastlanes/src/bitpacking/compress.rs
@@ -263,6 +263,14 @@ pub fn unpack_primitive<T: NativePType + TryBitPack>(
     if output.len() < 1024 {
         output.shrink_to_fit();
     }
+
+    assert_eq!(
+        output.len(),
+        length,
+        "Expected unpacked array to be of length {} but got {}",
+        length,
+        output.len()
+    );
     output
 }
 

--- a/vortex-fastlanes/src/bitpacking/compress.rs
+++ b/vortex-fastlanes/src/bitpacking/compress.rs
@@ -225,7 +225,8 @@ pub fn unpack_primitive<T: NativePType + TryBitPack>(
     }
 
     // How many fastlanes vectors we will process.
-    let num_chunks = (length + 1023) / 1024;
+    // Packed array might not start at 0 when the array is sliced. Offset is guaranteed to be < 1024.
+    let num_chunks = (offset + length + 1023) / 1024;
     let bytes_per_chunk = 128 * bit_width;
     assert_eq!(
         packed.len(),

--- a/vortex-fastlanes/src/bitpacking/compute.rs
+++ b/vortex-fastlanes/src/bitpacking/compute.rs
@@ -1,3 +1,5 @@
+use std::cmp::min;
+
 use itertools::Itertools;
 use vortex::array::primitive::PrimitiveArray;
 use vortex::array::{Array, ArrayRef};
@@ -37,7 +39,7 @@ impl FlattenFn for BitPackedArray {
 impl ScalarAtFn for BitPackedArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         if index >= self.len() {
-            return Err(vortex_err!(OutOfBounds:index, 0, self.len()));
+            return Err(vortex_err!(OutOfBounds: index, 0, self.len()));
         }
         if let Some(patches) = self.patches() {
             // NB: All non-null values are considered patches
@@ -67,7 +69,7 @@ impl TakeFn for BitPackedArray {
         let taken = relative_indices
             .into_iter()
             .map(|(chunk, offsets)| {
-                let sliced = self.slice(chunk * 1024, (chunk + 1) * 1024)?;
+                let sliced = self.slice(chunk * 1024, min((chunk + 1) * 1024, self.len()))?;
 
                 take(
                     &unpack(sliced.as_bitpacked())?,

--- a/vortex-fastlanes/src/bitpacking/mod.rs
+++ b/vortex-fastlanes/src/bitpacking/mod.rs
@@ -1,10 +1,9 @@
-use std::cmp::min;
+use std::cmp::max;
 use std::sync::{Arc, RwLock};
 
 pub use compress::*;
-use vortex::array::{Array, ArrayRef};
+use vortex::array::{check_slice_bounds, Array, ArrayRef};
 use vortex::compress::EncodingCompression;
-use vortex::compute::flatten::flatten_primitive;
 use vortex::compute::ArrayCompute;
 use vortex::encoding::{Encoding, EncodingId, EncodingRef};
 use vortex::formatter::{ArrayDisplay, ArrayFormatter};
@@ -27,6 +26,7 @@ pub struct BitPackedArray {
     encoded: ArrayRef,
     validity: Option<Validity>,
     patches: Option<ArrayRef>,
+    offset: usize,
     len: usize,
     bit_width: usize,
     dtype: DType,
@@ -44,6 +44,18 @@ impl BitPackedArray {
         bit_width: usize,
         dtype: DType,
         len: usize,
+    ) -> VortexResult<Self> {
+        Self::try_new_from_offset(encoded, validity, patches, bit_width, dtype, len, 0)
+    }
+
+    pub(crate) fn try_new_from_offset(
+        encoded: ArrayRef,
+        validity: Option<Validity>,
+        patches: Option<ArrayRef>,
+        bit_width: usize,
+        dtype: DType,
+        len: usize,
+        offset: usize,
     ) -> VortexResult<Self> {
         if encoded.dtype() != &Self::ENCODED_DTYPE {
             vortex_bail!(MismatchedTypes: Self::ENCODED_DTYPE, encoded.dtype());
@@ -71,8 +83,9 @@ impl BitPackedArray {
             encoded,
             validity,
             patches,
-            bit_width,
+            offset,
             len,
+            bit_width,
             dtype,
             stats: Arc::new(RwLock::new(StatsSet::new())),
         })
@@ -91,6 +104,11 @@ impl BitPackedArray {
     #[inline]
     pub fn patches(&self) -> Option<&ArrayRef> {
         self.patches.as_ref()
+    }
+
+    #[inline]
+    pub fn offset(&self) -> usize {
+        self.offset
     }
 }
 
@@ -125,31 +143,21 @@ impl Array for BitPackedArray {
     }
 
     fn slice(&self, start: usize, stop: usize) -> VortexResult<ArrayRef> {
-        if start % 1024 != 0 || stop % 1024 != 0 {
-            return flatten_primitive(self)?.slice(start, stop);
-        }
+        check_slice_bounds(self, start, stop)?;
+        let offset = start % 1024;
+        let block_start = max(0, start - offset);
+        let block_stop = ((stop + 1023) / 1024) * 1024;
 
-        if start > self.len() {
-            vortex_bail!(OutOfBounds: start, 0, self.len());
-        }
-        // If we are slicing more than one 1024 element chunk beyond end, we consider this out of bounds
-        if stop / 1024 > ((self.len() + 1023) / 1024) {
-            vortex_bail!(OutOfBounds: stop, 0, self.len());
-        }
-
-        let encoded_start = (start / 8) * self.bit_width;
-        let encoded_stop = (stop / 8) * self.bit_width;
-        Self::try_new(
+        let encoded_start = (block_start / 8) * self.bit_width;
+        let encoded_stop = (block_stop / 8) * self.bit_width;
+        Self::try_new_from_offset(
             self.encoded().slice(encoded_start, encoded_stop)?,
-            self.validity()
-                .map(|v| v.slice(start, min(stop, self.len())))
-                .transpose()?,
-            self.patches()
-                .map(|p| p.slice(start, min(stop, self.len())))
-                .transpose()?,
+            self.validity().map(|v| v.slice(start, stop)).transpose()?,
+            self.patches().map(|p| p.slice(start, stop)).transpose()?,
             self.bit_width(),
             self.dtype().clone(),
-            min(stop - start, self.len()),
+            stop - start,
+            offset,
         )
         .map(|a| a.into_array())
     }
@@ -185,6 +193,7 @@ impl OwnedValidity for BitPackedArray {
 
 impl ArrayDisplay for BitPackedArray {
     fn fmt(&self, f: &mut ArrayFormatter) -> std::fmt::Result {
+        f.property("offset", self.offset)?;
         f.property("packed", format!("u{}", self.bit_width()))?;
         f.child("encoded", self.encoded())?;
         f.maybe_child("patches", self.patches())?;
@@ -217,4 +226,10 @@ impl Encoding for BitPackedEncoding {
     fn serde(&self) -> Option<&dyn EncodingSerde> {
         Some(self)
     }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn slice() {}
 }

--- a/vortex-fastlanes/src/bitpacking/serde.rs
+++ b/vortex-fastlanes/src/bitpacking/serde.rs
@@ -11,7 +11,8 @@ impl ArraySerde for BitPackedArray {
         ctx.write_validity(self.validity())?;
         ctx.write_optional_array(self.patches())?;
         ctx.write_usize(self.bit_width())?;
-        ctx.write_usize(self.len())
+        ctx.write_usize(self.len())?;
+        ctx.write_usize(self.offset())
     }
 
     fn metadata(&self) -> VortexResult<Option<Vec<u8>>> {
@@ -19,6 +20,7 @@ impl ArraySerde for BitPackedArray {
         let mut ctx = WriteCtx::new(&mut vec);
         ctx.write_usize(self.bit_width())?;
         ctx.write_usize(self.len())?;
+        ctx.write_usize(self.offset())?;
         Ok(Some(vec))
     }
 }
@@ -30,15 +32,16 @@ impl EncodingSerde for BitPackedEncoding {
         let patches = ctx.read_optional_array()?;
         let bit_width = ctx.read_usize()?;
         let len = ctx.read_usize()?;
-        Ok(BitPackedArray::try_new(
+        let offset = ctx.read_usize()?;
+        Ok(BitPackedArray::try_new_from_offset(
             encoded,
             validity,
             patches,
             bit_width,
             ctx.schema().clone(),
             len,
-        )
-        .unwrap()
+            offset,
+        )?
         .into_array())
     }
 }


### PR DESCRIPTION
This follows the pattern we use elsewhere where we do the maximum possible work in slice and for anything irreducible we keep extra state, in this case offset, and apply it when we take value out of the encoded array.

Still need to add tests