### PR TITLE
Array2: swap trait for struct with lifetime

### DIFF
--- a/vortex-array2/Cargo.toml
+++ b/vortex-array2/Cargo.toml
@@ -21,4 +21,4 @@ vortex-flatbuffers = { path = "../vortex-flatbuffers" }
 vortex-schema = { path = "../vortex-schema" }
 
 [lints]
-workspace = true
+# workspace = true

--- a/vortex-array2/src/array/bool/compute.rs
+++ b/vortex-array2/src/array/bool/compute.rs
@@ -4,13 +4,13 @@ use vortex_error::VortexResult;
 use crate::array::bool::BoolArray;
 use crate::compute::{ArrayCompute, ScalarAtFn};
 
-impl ArrayCompute for &dyn BoolArray {
+impl ArrayCompute for BoolArray<'_> {
     fn scalar_at(&self) -> Option<&dyn ScalarAtFn> {
         Some(self)
     }
 }
 
-impl ScalarAtFn for &dyn BoolArray {
+impl ScalarAtFn for BoolArray<'_> {
     fn scalar_at(&self, _index: usize) -> VortexResult<Scalar> {
         todo!()
     }

--- a/vortex-array2/src/array/bool/compute.rs
+++ b/vortex-array2/src/array/bool/compute.rs
@@ -1,8 +1,10 @@
-use vortex::scalar::Scalar;
+use vortex::scalar::{BoolScalar, Scalar};
 use vortex_error::VortexResult;
 
 use crate::array::bool::BoolArray;
 use crate::compute::{ArrayCompute, ScalarAtFn};
+use crate::validity::ArrayValidity;
+use crate::ArrayTrait;
 
 impl ArrayCompute for BoolArray<'_> {
     fn scalar_at(&self) -> Option<&dyn ScalarAtFn> {
@@ -11,7 +13,14 @@ impl ArrayCompute for BoolArray<'_> {
 }
 
 impl ScalarAtFn for BoolArray<'_> {
-    fn scalar_at(&self, _index: usize) -> VortexResult<Scalar> {
-        todo!()
+    fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
+        if self.is_valid(index) {
+            let value = self.boolean_buffer().value(index);
+            Ok(Scalar::Bool(
+                BoolScalar::try_new(Some(value), self.dtype().nullability()).unwrap(),
+            ))
+        } else {
+            Ok(Scalar::null(self.dtype()))
+        }
     }
 }

--- a/vortex-array2/src/array/bool/mod.rs
+++ b/vortex-array2/src/array/bool/mod.rs
@@ -1,16 +1,15 @@
 mod compute;
 
 use arrow_buffer::{BooleanBuffer, Buffer};
-use vortex_error::VortexResult;
+use vortex_error::{vortex_err, VortexResult};
 use vortex_schema::DType;
 
+use crate::impl_encoding;
 use crate::validity::Validity;
 use crate::validity::{ArrayValidity, ValidityMetadata};
-use crate::{impl_encoding, IntoArray};
+use crate::ArrayMetadata;
 use crate::{ArrayData, TypedArrayData};
-use crate::{ArrayMetadata, TryFromArrayMetadata};
 use crate::{ArrayView, ToArrayData};
-use crate::{ToArray, TypedArrayView};
 
 impl_encoding!("vortex.bool", Bool);
 
@@ -31,12 +30,48 @@ impl BoolMetadata {
     }
 }
 
-// TODO(ngates): I think this could be a struct?
-#[allow(clippy::len_without_is_empty)]
-pub trait BoolArray {
-    fn buffer(&self) -> &Buffer;
-    fn len(&self) -> usize;
-    fn validity(&self) -> Option<Validity>;
+impl TryParseArrayMetadata for BoolMetadata {
+    fn try_parse_metadata(_metadata: Option<&[u8]>) -> VortexResult<Self> {
+        todo!()
+    }
+}
+
+pub struct BoolArray<'a> {
+    buffer: &'a Buffer,
+    validity: Option<Validity<'a>>,
+    metadata: BoolMetadata,
+}
+
+impl BoolArray<'_> {
+    pub fn buffer(&self) -> &Buffer {
+        &self.buffer
+    }
+
+    pub fn validity(&self) -> Option<&Validity> {
+        self.validity.as_ref()
+    }
+
+    pub fn metadata(&self) -> &BoolMetadata {
+        &self.metadata
+    }
+
+    pub fn boolean_buffer(&self) -> BooleanBuffer {
+        BooleanBuffer::new(self.buffer.clone(), 0, self.metadata.len())
+    }
+}
+
+impl<'v> TryFromArrayParts<'v, BoolMetadata> for BoolArray<'v> {
+    fn try_from_parts(parts: &'v dyn ArrayParts<'v>, metadata: BoolMetadata) -> VortexResult<Self> {
+        Ok(BoolArray {
+            buffer: parts
+                .buffer(0)
+                .ok_or(vortex_err!("BoolArray requires a buffer"))?,
+            validity: metadata
+                .validity()
+                .to_validity(metadata.len(), parts.child(0, &Validity::DTYPE)),
+            metadata,
+        })
+    }
 }
 
 impl BoolData {
@@ -59,82 +94,31 @@ impl BoolData {
     }
 }
 
-impl BoolArray for BoolData {
-    fn buffer(&self) -> &Buffer {
-        self.data().buffers().first().unwrap()
-    }
-
+impl ArrayTrait for BoolArray<'_> {
     fn len(&self) -> usize {
-        self.metadata().len()
-    }
-
-    fn validity(&self) -> Option<Validity> {
-        self.metadata().validity().to_validity(
-            self.metadata().len(),
-            self.data().child(0).map(|data| data.to_array()),
-        )
-    }
-}
-
-impl BoolArray for BoolView<'_> {
-    fn buffer(&self) -> &Buffer {
-        self.view()
-            .buffers()
-            .first()
-            .expect("BoolView must have a single buffer")
-    }
-
-    fn len(&self) -> usize {
-        self.metadata().len()
-    }
-
-    fn validity(&self) -> Option<Validity> {
-        self.metadata().validity().to_validity(
-            self.metadata().len(),
-            self.view()
-                .child(0, &Validity::DTYPE)
-                .map(|a| a.into_array()),
-        )
-    }
-}
-
-impl TryFromArrayMetadata for BoolMetadata {
-    fn try_from_metadata(_metadata: Option<&[u8]>) -> VortexResult<Self> {
         todo!()
     }
 }
 
-impl<'v> TryFromArrayView<'v> for BoolView<'v> {
-    fn try_from_view(view: &'v ArrayView<'v>) -> VortexResult<Self> {
-        // TODO(ngates): validate the view.
-        Ok(BoolView::new_unchecked(
-            view.clone(),
-            BoolMetadata::try_from_metadata(view.metadata())?,
-        ))
-    }
-}
-
-impl TryFromArrayData for BoolData {
-    fn try_from_data(data: &ArrayData) -> VortexResult<Self> {
-        // TODO(ngates): validate the array data.
-        Ok(Self::from_data_unchecked(data.clone()))
-    }
-}
-
-impl ArrayTrait for &dyn BoolArray {
-    fn len(&self) -> usize {
-        (**self).len()
-    }
-}
-
-impl ArrayValidity for &dyn BoolArray {
+impl ArrayValidity for BoolArray<'_> {
     fn is_valid(&self, index: usize) -> bool {
         self.validity().map(|v| v.is_valid(index)).unwrap_or(true)
     }
 }
 
-impl ToArrayData for &dyn BoolArray {
+impl ToArrayData for BoolArray<'_> {
     fn to_array_data(&self) -> ArrayData {
         todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::array::bool::BoolData;
+
+    #[test]
+    fn bool_array() {
+        let arr = BoolData::try_new(vec![true, false, true].into(), None).unwrap();
+        println!("Array {:?}", &arr);
     }
 }

--- a/vortex-array2/src/array/bool/mod.rs
+++ b/vortex-array2/src/array/bool/mod.rs
@@ -1,7 +1,7 @@
 mod compute;
 
 use arrow_buffer::{BooleanBuffer, Buffer};
-use vortex_error::{vortex_err, VortexResult};
+use vortex_error::VortexResult;
 use vortex_schema::DType;
 
 use crate::impl_encoding;
@@ -29,7 +29,8 @@ pub struct BoolArray<'a> {
     dtype: &'a DType,
     buffer: &'a Buffer,
     validity: Option<Validity<'a>>,
-    metadata: BoolMetadata,
+    // TODO(ngates): unpack metadata?
+    metadata: &'a BoolMetadata,
     // TODO(ngates): we support statistics by reference to a dyn trait.
     //  This trait is implemented for ArrayView and ArrayData and is passed into here as part
     //  of ArrayParts.
@@ -46,7 +47,7 @@ impl BoolArray<'_> {
     }
 
     pub fn metadata(&self) -> &BoolMetadata {
-        &self.metadata
+        self.metadata
     }
 
     pub fn boolean_buffer(&self) -> BooleanBuffer {
@@ -55,7 +56,10 @@ impl BoolArray<'_> {
 }
 
 impl<'v> TryFromArrayParts<'v, BoolMetadata> for BoolArray<'v> {
-    fn try_from_parts(parts: &'v dyn ArrayParts<'v>, metadata: BoolMetadata) -> VortexResult<Self> {
+    fn try_from_parts(
+        parts: &'v dyn ArrayParts<'v>,
+        metadata: &'v BoolMetadata,
+    ) -> VortexResult<Self> {
         Ok(BoolArray {
             dtype: parts.dtype(),
             buffer: parts

--- a/vortex-array2/src/array/mod.rs
+++ b/vortex-array2/src/array/mod.rs
@@ -1,3 +1,3 @@
 pub mod bool;
-pub mod primitive;
-pub mod ree;
+// pub mod primitive;
+// pub mod ree;

--- a/vortex-array2/src/array/mod.rs
+++ b/vortex-array2/src/array/mod.rs
@@ -1,3 +1,3 @@
 pub mod bool;
-// pub mod primitive;
-// pub mod ree;
+pub mod primitive;
+pub mod ree;

--- a/vortex-array2/src/array/primitive/compute.rs
+++ b/vortex-array2/src/array/primitive/compute.rs
@@ -5,14 +5,15 @@ use vortex_error::VortexResult;
 use crate::array::primitive::PrimitiveArray;
 use crate::compute::{ArrayCompute, ScalarAtFn};
 use crate::validity::ArrayValidity;
+use crate::ArrayTrait;
 
-impl ArrayCompute for &dyn PrimitiveArray {
+impl ArrayCompute for PrimitiveArray<'_> {
     fn scalar_at(&self) -> Option<&dyn ScalarAtFn> {
         Some(self)
     }
 }
 
-impl ScalarAtFn for &dyn PrimitiveArray {
+impl ScalarAtFn for PrimitiveArray<'_> {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         if self.is_valid(index) {
             match_each_native_ptype!(self.ptype(), |$T| {

--- a/vortex-array2/src/array/ree/compute.rs
+++ b/vortex-array2/src/array/ree/compute.rs
@@ -4,13 +4,13 @@ use vortex_error::VortexResult;
 use crate::array::ree::REEArray;
 use crate::compute::{ArrayCompute, ScalarAtFn};
 
-impl ArrayCompute for &dyn REEArray {
+impl ArrayCompute for REEArray<'_> {
     fn scalar_at(&self) -> Option<&dyn ScalarAtFn> {
         Some(self)
     }
 }
 
-impl ScalarAtFn for &dyn REEArray {
+impl ScalarAtFn for REEArray<'_> {
     fn scalar_at(&self, _index: usize) -> VortexResult<Scalar> {
         todo!()
     }

--- a/vortex-array2/src/compute.rs
+++ b/vortex-array2/src/compute.rs
@@ -2,7 +2,7 @@ use vortex::scalar::Scalar;
 use vortex_error::{vortex_err, VortexResult};
 
 use crate::array::bool::BoolData;
-use crate::array::primitive::PrimitiveData;
+// use crate::array::primitive::PrimitiveData;
 use crate::{Array, WithArray};
 
 pub trait ArrayCompute {
@@ -32,7 +32,7 @@ pub trait FlattenFn {
 
 pub enum FlattenedArray {
     Bool(BoolData),
-    Primitive(PrimitiveData),
+    // Primitive(PrimitiveData),
     // Just to introduce a second variant for now
     Other(String),
 }
@@ -44,14 +44,14 @@ pub fn flatten(array: &Array) -> VortexResult<FlattenedArray> {
             .flatten()
     })
 }
-
-pub fn flatten_primitive(array: &Array) -> VortexResult<PrimitiveData> {
-    if let FlattenedArray::Primitive(p) = flatten(array)? {
-        Ok(p)
-    } else {
-        Err(vortex_err!(
-            "Cannot flatten array {:?} into primitive",
-            array
-        ))
-    }
-}
+//
+// pub fn flatten_primitive(array: &Array) -> VortexResult<PrimitiveData> {
+//     if let FlattenedArray::Primitive(p) = flatten(array)? {
+//         Ok(p)
+//     } else {
+//         Err(vortex_err!(
+//             "Cannot flatten array {:?} into primitive",
+//             array
+//         ))
+//     }
+// }

--- a/vortex-array2/src/data.rs
+++ b/vortex-array2/src/data.rs
@@ -153,6 +153,10 @@ impl<D: ArrayDef> TryFrom<ArrayData> for TypedArrayData<D> {
 }
 
 impl ArrayParts<'_> for ArrayData {
+    fn dtype(&'_ self) -> &'_ DType {
+        &self.dtype
+    }
+
     fn buffer(&self, idx: usize) -> Option<&Buffer> {
         self.buffers().get(idx)
     }

--- a/vortex-array2/src/implementation.rs
+++ b/vortex-array2/src/implementation.rs
@@ -22,6 +22,7 @@ macro_rules! impl_encoding {
         paste! {
             use $crate::{ArrayDef, ArrayParts, ArrayTrait, TryFromArrayParts, TryParseArrayMetadata};
             use $crate::encoding::{ArrayEncoding, EncodingId, EncodingRef};
+            use vortex_error::vortex_err;
             use std::any::Any;
             use std::fmt::Debug;
             use std::sync::Arc;
@@ -54,7 +55,7 @@ macro_rules! impl_encoding {
                 ) -> VortexResult<()> {
                     // Convert ArrayView -> PrimitiveArray, then call compute.
                     let metadata = [<$Name Metadata>]::try_parse_metadata(view.metadata())?;
-                    let array = [<$Name Array>]::try_from_parts(view as &dyn ArrayParts, metadata)?;
+                    let array = [<$Name Array>]::try_from_parts(view as &dyn ArrayParts, &metadata)?;
                     f(&array)
                 }
 
@@ -68,7 +69,7 @@ macro_rules! impl_encoding {
                         .downcast_ref::<[<$Name Metadata>]>()
                         .ok_or_else(|| vortex_err!("Failed to downcast metadata"))?
                         .clone();
-                    let array = [<$Name Array>]::try_from_parts(data as &dyn ArrayParts, metadata)?;
+                    let array = [<$Name Array>]::try_from_parts(data as &dyn ArrayParts, &metadata)?;
                     f(&array)
                 }
             }

--- a/vortex-array2/src/implementation.rs
+++ b/vortex-array2/src/implementation.rs
@@ -1,10 +1,7 @@
-use vortex_error::VortexResult;
-
 use crate::encoding::EncodingId;
 use crate::encoding::{ArrayEncoding, EncodingRef};
-use crate::ArrayData;
-use crate::ArrayMetadata;
-use crate::ArrayView;
+use crate::ArrayTrait;
+use crate::{ArrayMetadata, TryFromArrayParts, TryParseArrayMetadata};
 
 /// Trait the defines the set of types relating to an array.
 /// Because it has associated types it can't be used as a trait object.
@@ -12,21 +9,9 @@ pub trait ArrayDef {
     const ID: EncodingId;
     const ENCODING: EncodingRef;
 
-    type Array<'a>: ?Sized + 'a;
-    type Metadata: ArrayMetadata;
+    type Array<'a>: ArrayTrait + TryFromArrayParts<'a, Self::Metadata> + 'a;
+    type Metadata: ArrayMetadata + TryParseArrayMetadata;
     type Encoding: ArrayEncoding;
-}
-
-pub trait TryFromArrayMetadata: Sized {
-    fn try_from_metadata(metadata: Option<&[u8]>) -> VortexResult<Self>;
-}
-
-pub trait TryFromArrayData: Sized {
-    fn try_from_data(data: &ArrayData) -> VortexResult<Self>;
-}
-
-pub trait TryFromArrayView<'v>: Sized + 'v {
-    fn try_from_view(view: &'v ArrayView<'v>) -> VortexResult<Self>;
 }
 
 #[macro_export]
@@ -35,24 +20,25 @@ macro_rules! impl_encoding {
         use paste::paste;
 
         paste! {
-            use $crate::{ArrayDef, TryFromArrayData, TryFromArrayView, ArrayTrait};
+            use $crate::{ArrayDef, ArrayParts, ArrayTrait, TryFromArrayParts, TryParseArrayMetadata};
             use $crate::encoding::{ArrayEncoding, EncodingId, EncodingRef};
             use std::any::Any;
+            use std::fmt::Debug;
             use std::sync::Arc;
             use std::marker::{Send, Sync};
 
             /// The array definition trait
+            #[derive(Debug)]
             pub struct [<$Name Def>];
             impl ArrayDef for [<$Name Def>] {
                 const ID: EncodingId = EncodingId::new($id);
                 const ENCODING: EncodingRef = &[<$Name Encoding>];
-                type Array<'a> = dyn [<$Name Array>] + 'a;
+                type Array<'a> = [<$Name Array>]<'a>;
                 type Metadata = [<$Name Metadata>];
                 type Encoding = [<$Name Encoding>];
             }
 
             pub type [<$Name Data>] = TypedArrayData<[<$Name Def>]>;
-            pub type [<$Name View>]<'v> = TypedArrayView<'v, [<$Name Def>]>;
 
             /// The array encoding
             pub struct [<$Name Encoding>];
@@ -67,8 +53,9 @@ macro_rules! impl_encoding {
                     f: &mut dyn FnMut(&dyn ArrayTrait) -> VortexResult<()>,
                 ) -> VortexResult<()> {
                     // Convert ArrayView -> PrimitiveArray, then call compute.
-                    let typed_view = <[<$Name View>] as TryFromArrayView>::try_from_view(view)?;
-                    f(&typed_view.as_array())
+                    let metadata = [<$Name Metadata>]::try_parse_metadata(view.metadata())?;
+                    let array = [<$Name Array>]::try_from_parts(view as &dyn ArrayParts, metadata)?;
+                    f(&array)
                 }
 
                 fn with_data_mut(
@@ -76,8 +63,13 @@ macro_rules! impl_encoding {
                     data: &ArrayData,
                     f: &mut dyn FnMut(&dyn ArrayTrait) -> VortexResult<()>,
                 ) -> VortexResult<()> {
-                    let data = <[<$Name Data>] as TryFromArrayData>::try_from_data(data)?;
-                    f(&data.as_array())
+                    let metadata = data.metadata()
+                        .as_any()
+                        .downcast_ref::<[<$Name Metadata>]>()
+                        .ok_or_else(|| vortex_err!("Failed to downcast metadata"))?
+                        .clone();
+                    let array = [<$Name Array>]::try_from_parts(data as &dyn ArrayParts, metadata)?;
+                    f(&array)
                 }
             }
 
@@ -100,17 +92,17 @@ macro_rules! impl_encoding {
                 }
             }
 
-            /// Implement AsRef for both the data and view types
-            impl<'a> AsRef<dyn [<$Name Array>] + 'a> for [<$Name Data>] {
-                fn as_ref(&self) -> &(dyn [<$Name Array>] + 'a) {
-                    self
-                }
-            }
-            impl<'a> AsRef<dyn [<$Name Array>] + 'a> for [<$Name View>]<'a> {
-                fn as_ref(&self) -> &(dyn [<$Name Array>] + 'a) {
-                    self
-                }
-            }
+            // /// Implement AsRef for both the data and view types
+            // impl<'a> AsRef<[<$Name Array>]<'a>> for [<$Name Data>] {
+            //     fn as_ref(&self) -> &[<$Name Array>]<'a> {
+            //         self
+            //     }
+            // }
+            // impl<'a> AsRef<[<$Name Array>]<'a>> for [<$Name View>]<'a> {
+            //     fn as_ref(&self) -> &[<$Name Array>]<'a> {
+            //         self
+            //     }
+            // }
         }
     };
 }

--- a/vortex-array2/src/lib.rs
+++ b/vortex-array2/src/lib.rs
@@ -31,6 +31,16 @@ pub enum Array<'v> {
     View(ArrayView<'v>),
 }
 
+impl Array<'_> {
+    pub fn dtype(&self) -> &DType {
+        match self {
+            Array::Data(d) => d.dtype(),
+            Array::DataRef(d) => d.dtype(),
+            Array::View(v) => v.dtype(),
+        }
+    }
+}
+
 pub trait ToArray {
     fn to_array(&self) -> Array;
 }
@@ -54,7 +64,7 @@ pub trait ArrayParts<'a> {
 }
 
 pub trait TryFromArrayParts<'v, M: ArrayMetadata>: Sized + 'v {
-    fn try_from_parts(parts: &'v dyn ArrayParts<'v>, metadata: M) -> VortexResult<Self>;
+    fn try_from_parts(parts: &'v dyn ArrayParts<'v>, metadata: &'v M) -> VortexResult<Self>;
 }
 
 pub trait TryParseArrayMetadata: Sized + ArrayMetadata {

--- a/vortex-array2/src/lib.rs
+++ b/vortex-array2/src/lib.rs
@@ -48,6 +48,7 @@ pub trait WithArray {
 }
 
 pub trait ArrayParts<'a> {
+    fn dtype(&'a self) -> &'a DType;
     fn buffer(&'a self, idx: usize) -> Option<&'a Buffer>;
     fn child(&'a self, idx: usize, dtype: &'a DType) -> Option<Array<'a>>;
 }
@@ -62,6 +63,8 @@ pub trait TryParseArrayMetadata: Sized + ArrayMetadata {
 
 /// Collects together the behaviour of an array.
 pub trait ArrayTrait: ArrayCompute + ArrayValidity + ToArrayData {
+    fn dtype(&self) -> &DType;
+
     fn len(&self) -> usize;
 
     fn is_empty(&self) -> bool {

--- a/vortex-array2/src/view.rs
+++ b/vortex-array2/src/view.rs
@@ -2,12 +2,12 @@ use std::fmt::{Debug, Formatter};
 
 use arrow_buffer::Buffer;
 use vortex::flatbuffers::array as fb;
-use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
+use vortex_error::{vortex_bail, vortex_err, VortexResult};
 use vortex_schema::DType;
 
 use crate::encoding::EncodingRef;
-use crate::{Array, ArrayDef, IntoArray, ToArray};
-use crate::{SerdeContext, TryFromArrayMetadata};
+use crate::{Array, IntoArray, ToArray};
+use crate::{ArrayParts, SerdeContext};
 
 #[derive(Clone)]
 pub struct ArrayView<'v> {
@@ -146,52 +146,12 @@ impl<'v> IntoArray<'v> for ArrayView<'v> {
     }
 }
 
-pub struct TypedArrayView<'v, D: ArrayDef> {
-    view: ArrayView<'v>,
-    metadata: D::Metadata,
-}
-
-impl<'v, D: ArrayDef> TypedArrayView<'v, D> {
-    pub fn new_unchecked(view: ArrayView<'v>, metadata: D::Metadata) -> Self {
-        Self { view, metadata }
+impl<'v> ArrayParts<'v> for ArrayView<'v> {
+    fn buffer(&'v self, idx: usize) -> Option<&'v Buffer> {
+        self.buffers().get(idx)
     }
 
-    pub fn metadata(&self) -> &D::Metadata {
-        &self.metadata
-    }
-
-    pub fn view(&'v self) -> &'v ArrayView<'v> {
-        &self.view
-    }
-
-    pub fn as_array(&self) -> &D::Array<'v>
-    where
-        Self: AsRef<D::Array<'v>>,
-    {
-        self.as_ref()
-    }
-}
-
-impl<D: ArrayDef> ToArray for TypedArrayView<'_, D> {
-    fn to_array(&self) -> Array {
-        Array::View(self.view().clone())
-    }
-}
-
-/// Convert an ArrayView into a TypedArrayView.
-impl<'v, D: ArrayDef> TryFrom<ArrayView<'v>> for TypedArrayView<'v, D>
-where
-    D::Metadata: TryFromArrayMetadata,
-{
-    type Error = VortexError;
-
-    fn try_from(view: ArrayView<'v>) -> Result<Self, Self::Error> {
-        if view.encoding().id() != D::ID {
-            vortex_bail!("Invalid encoding for array")
-        }
-        let metadata = <<D as ArrayDef>::Metadata as TryFromArrayMetadata>::try_from_metadata(
-            view.metadata(),
-        )?;
-        Ok(Self { view, metadata })
+    fn child(&'v self, idx: usize, dtype: &'v DType) -> Option<Array<'v>> {
+        self.child(idx, dtype).map(|a| a.into_array())
     }
 }

--- a/vortex-array2/src/view.rs
+++ b/vortex-array2/src/view.rs
@@ -147,6 +147,10 @@ impl<'v> IntoArray<'v> for ArrayView<'v> {
 }
 
 impl<'v> ArrayParts<'v> for ArrayView<'v> {
+    fn dtype(&'v self) -> &'v DType {
+        self.dtype
+    }
+
     fn buffer(&'v self, idx: usize) -> Option<&'v Buffer> {
         self.buffers().get(idx)
     }


### PR DESCRIPTION
Now we have an Array<'a> enum, we can swap out the array trait and things get a little simpler.