### PR TITLE
Add BenchmarkDataset abstraction and PBI datasets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown",
  "num",
 ]
 
@@ -214,7 +214,7 @@ dependencies = [
  "arrow-schema 51.0.0",
  "chrono",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown",
  "num",
 ]
 
@@ -453,7 +453,7 @@ dependencies = [
  "arrow-data 50.0.0",
  "arrow-schema 50.0.0",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -468,7 +468,7 @@ dependencies = [
  "arrow-data 51.0.0",
  "arrow-schema 51.0.0",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -548,24 +548,6 @@ dependencies = [
  "num",
  "regex",
  "regex-syntax",
-]
-
-[[package]]
-name = "async-compression"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86a9249d1447a85f95810c620abea82e001fe58a31713fcce614caf52499f905"
-dependencies = [
- "bzip2",
- "flate2",
- "futures-core",
- "futures-io",
- "memchr",
- "pin-project-lite",
- "tokio",
- "xz2",
- "zstd",
- "zstd-safe",
 ]
 
 [[package]]
@@ -980,6 +962,7 @@ dependencies = [
  "csv",
  "itertools 0.12.1",
  "lance",
+ "lazy_static",
  "log",
  "parquet 50.0.0",
  "parquet 51.0.0",
@@ -1088,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytecount"
@@ -1186,9 +1169,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
 dependencies = [
  "jobserver",
  "libc",
@@ -1319,12 +1302,12 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.1.0"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c64043d6c7b7a4c58e39e7efccfdea7b93d885a795d0c054a69dbbf4dd52686"
+checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
 dependencies = [
- "strum 0.25.0",
- "strum_macros 0.25.3",
+ "strum",
+ "strum_macros",
  "unicode-width",
 ]
 
@@ -1527,7 +1510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.3",
+ "hashbrown",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1544,43 +1527,35 @@ dependencies = [
  "arrow-array 50.0.0",
  "arrow-ipc 50.0.0",
  "arrow-schema 50.0.0",
- "async-compression",
  "async-trait",
  "bytes",
- "bzip2",
  "chrono",
  "dashmap",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions",
- "datafusion-functions-array",
  "datafusion-optimizer",
  "datafusion-physical-expr",
  "datafusion-physical-plan",
  "datafusion-sql",
- "flate2",
  "futures",
  "glob",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown",
  "indexmap",
  "itertools 0.12.1",
  "log",
  "num_cpus",
  "object_store",
  "parking_lot",
- "parquet 50.0.0",
  "pin-project-lite",
  "rand",
  "sqlparser",
  "tempfile",
  "tokio",
- "tokio-util",
  "url",
  "uuid",
- "xz2",
- "zstd",
 ]
 
 [[package]]
@@ -1599,7 +1574,6 @@ dependencies = [
  "libc",
  "num_cpus",
  "object_store",
- "parquet 50.0.0",
  "sqlparser",
 ]
 
@@ -1615,7 +1589,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "futures",
- "hashbrown 0.14.3",
+ "hashbrown",
  "log",
  "object_store",
  "parking_lot",
@@ -1636,8 +1610,8 @@ dependencies = [
  "datafusion-common",
  "paste",
  "sqlparser",
- "strum 0.26.2",
- "strum_macros 0.26.2",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]
@@ -1656,20 +1630,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion-functions-array"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d16a0ddf2c991526f6ffe2f47a72c6da0b7354d6c32411dd20631fe2e38937"
-dependencies = [
- "arrow 50.0.0",
- "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
- "log",
- "paste",
-]
-
-[[package]]
 name = "datafusion-optimizer"
 version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,7 +1641,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-physical-expr",
- "hashbrown 0.14.3",
+ "hashbrown",
  "itertools 0.12.1",
  "log",
  "regex-syntax",
@@ -1708,7 +1668,7 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown",
  "hex",
  "indexmap",
  "itertools 0.12.1",
@@ -1742,7 +1702,7 @@ dependencies = [
  "datafusion-physical-expr",
  "futures",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown",
  "indexmap",
  "itertools 0.12.1",
  "log",
@@ -1766,22 +1726,6 @@ dependencies = [
  "datafusion-expr",
  "log",
  "sqlparser",
-]
-
-[[package]]
-name = "datafusion-substrait"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aab89c01ef66a59ec92d2360db63893224b4f7e085e2ee6351e0bb77f88931f0"
-dependencies = [
- "async-recursion",
- "chrono",
- "datafusion",
- "itertools 0.12.1",
- "object_store",
- "prost",
- "prost-types",
- "substrait",
 ]
 
 [[package]]
@@ -1855,12 +1799,6 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "either"
@@ -2136,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2152,19 +2090,6 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
-
-[[package]]
-name = "git2"
-version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
-dependencies = [
- "bitflags 2.5.0",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
 
 [[package]]
 name = "glob"
@@ -2223,15 +2148,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -2245,6 +2161,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2495,7 +2417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2538,15 +2460,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -2580,9 +2493,9 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4295762ec291eeab46223533d12828ccbc460fdf22814e18c80dbbf47d1d30c0"
+checksum = "c98b63628fcea2758905f904658e55216d71727d981f096a5bcf0d89a2fdc05e"
 dependencies = [
  "arrow 50.0.0",
  "arrow-arith 50.0.0",
@@ -2638,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d50ac53bb56a03372d7a768c6ebfb858053221ec5096c71f2694fc074c2d6f0"
+checksum = "925c99b16e32debe8ecd506f348c2ba295905e52f61a76ecf3e686b960a7f548"
 dependencies = [
  "arrow-array 50.0.0",
  "arrow-buffer 50.0.0",
@@ -2657,9 +2570,9 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e36a15ecf978faa2ab7b7f6b4a250cff54e385f56bd8c161cd8a23f78165435"
+checksum = "442480abf2854a75c8679e6219bacb783541e3efe7fa4c14b1bcab6e5d760f46"
 dependencies = [
  "arrow-array 50.0.0",
  "arrow-buffer 50.0.0",
@@ -2692,9 +2605,9 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831405562122e06b342b841eb138e92786508fdf9e3e6124446fe05a83ea0bfe"
+checksum = "c6beda2d782f9f6a51fb27400bfeed44de700cecd5cca7c80d7566339c4649d2"
 dependencies = [
  "arrow 50.0.0",
  "arrow-array 50.0.0",
@@ -2704,7 +2617,6 @@ dependencies = [
  "datafusion",
  "datafusion-common",
  "datafusion-physical-expr",
- "datafusion-substrait",
  "futures",
  "lance-arrow",
  "lance-core",
@@ -2715,9 +2627,9 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724b88bca6dbea4a5b52898775489129f29cee6c07a6c6e0f9867d145b36a855"
+checksum = "65e4664b07bfd2bc8244440d6061e2045790993b7dbbcb3176fb434f96672852"
 dependencies = [
  "arrow 50.0.0",
  "arrow-array 50.0.0",
@@ -2730,10 +2642,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "lance-file"
-version = "0.10.9"
+name = "lance-encoding"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3943a8ec121fdd4c907102fccb334d453e7c2e5b269af8f4f87ea6949b76edf6"
+checksum = "49fc1e71d9e55728fe5a2eb16f42b0443e243a06b0650d1b27ac7f552371d402"
+dependencies = [
+ "arrow-arith 50.0.0",
+ "arrow-array 50.0.0",
+ "arrow-buffer 50.0.0",
+ "arrow-cast 50.0.0",
+ "arrow-schema 50.0.0",
+ "arrow-select 50.0.0",
+ "bytes",
+ "futures",
+ "lance-arrow",
+ "lance-core",
+ "lance-datagen",
+ "log",
+ "num_cpus",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "snafu",
+ "tokio",
+]
+
+[[package]]
+name = "lance-file"
+version = "0.10.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf97c4b7ffa77b7bbfb112443a59c02f6d49b6e810f0d9669881c1c3c572d82"
 dependencies = [
  "arrow-arith 50.0.0",
  "arrow-array 50.0.0",
@@ -2742,16 +2680,19 @@ dependencies = [
  "arrow-select 50.0.0",
  "async-recursion",
  "async-trait",
+ "bytes",
  "datafusion-common",
  "futures",
  "lance-arrow",
  "lance-core",
+ "lance-encoding",
  "lance-io",
  "num-traits",
  "num_cpus",
  "object_store",
  "prost",
  "prost-build",
+ "prost-types",
  "roaring",
  "snafu",
  "tokio",
@@ -2760,9 +2701,9 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1277c48fb2b7ccbb9c67ca6f4d67607949a31876f8862eaea1320535e397078e"
+checksum = "1e56f45cdea0bc572137d10f2df312da3c6a2b8315e77b3c50030135af667395"
 dependencies = [
  "arrow 50.0.0",
  "arrow-array 50.0.0",
@@ -2806,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc527575e311dd162257abbe99d50baa7f58122b4a33c43c71784d12e9b465c1"
+checksum = "e89d5f037379dea94a698604dcb67180fde93c401276ad2eef0895bd7ee063d9"
 dependencies = [
  "arrow 50.0.0",
  "arrow-arith 50.0.0",
@@ -2844,9 +2785,9 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae368482bc41d2bf7606d0353ecf91543961cebed227850b9fb2d2c801164dc9"
+checksum = "5af3dc5774dd5c268782547d9f0b9a6e801a6f4d4fed8e586e1d9b4a6238bf43"
 dependencies = [
  "arrow-array 50.0.0",
  "arrow-ord 50.0.0",
@@ -2867,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbc4567414b5250125bd3f38b2bb2cdaa53301b451002db7ec40c55877eb959"
+checksum = "39acb106ab5855a4d14e5d7d575426bc2d68a3d62d7220ab812cee8dbbbddf27"
 dependencies = [
  "arrow-array 50.0.0",
  "arrow-buffer 50.0.0",
@@ -3015,18 +2956,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.16.2+1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3050,18 +2979,6 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -3119,17 +3036,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 dependencies = [
  "twox-hash",
-]
-
-[[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -3247,9 +3153,9 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.8.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "native-tls"
@@ -3479,7 +3385,7 @@ dependencies = [
  "rand",
  "reqwest 0.11.27",
  "ring 0.17.8",
- "rustls-pemfile 2.1.1",
+ "rustls-pemfile 2.1.2",
  "serde",
  "serde_json",
  "snafu",
@@ -3623,18 +3529,15 @@ dependencies = [
  "bytes",
  "chrono",
  "flate2",
- "futures",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown",
  "lz4_flex",
  "num",
  "num-bigint",
- "object_store",
  "paste",
  "seq-macro",
  "snap",
  "thrift",
- "tokio",
  "twox-hash",
  "zstd",
 ]
@@ -3659,7 +3562,7 @@ dependencies = [
  "chrono",
  "flate2",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown",
  "lz4_flex",
  "num",
  "num-bigint",
@@ -3870,9 +3773,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+checksum = "d0f5d036824e4761737860779c906171497f6d55681139d8312388f8fe398922"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3880,13 +3783,13 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
+checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
- "heck",
- "itertools 0.11.0",
+ "heck 0.5.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -3897,7 +3800,6 @@ dependencies = [
  "regex",
  "syn 2.0.58",
  "tempfile",
- "which",
 ]
 
 [[package]]
@@ -3915,9 +3817,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
+checksum = "3235c33eb02c1f1e212abdbe34c78b264b038fb58ca612664343271e36e55ffe"
 dependencies = [
  "prost",
 ]
@@ -4000,7 +3902,7 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -4187,16 +4089,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
-name = "regress"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed9969cad8051328011596bf549629f1b800cf1731e7964b1eef8dfc480d2c2"
-dependencies = [
- "hashbrown 0.13.2",
- "memchr",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4266,7 +4158,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 2.1.1",
+ "rustls-pemfile 2.1.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4391,11 +4283,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "rustls-pki-types",
 ]
 
@@ -4417,9 +4309,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
 name = "ryu"
@@ -4452,30 +4344,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
  "parking_lot",
-]
-
-[[package]]
-name = "schemars"
-version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4553,17 +4421,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive_internals"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "serde_json"
 version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4572,18 +4429,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_tokenstream"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a00ffd23fd882d096f09fcaae2a9de8329a328628e86027e049ee051dc1621f"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "syn 2.0.58",
 ]
 
 [[package]]
@@ -4596,19 +4441,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4701,7 +4533,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -4770,30 +4602,11 @@ checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-
-[[package]]
-name = "strum"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
- "strum_macros 0.26.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.58",
+ "strum_macros",
 ]
 
 [[package]]
@@ -4802,33 +4615,11 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
  "syn 2.0.58",
-]
-
-[[package]]
-name = "substrait"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8ffb7a3e7505bb835513e77ebfe67d359e57d684a5972323e3bdefbecc1f25"
-dependencies = [
- "git2",
- "heck",
- "prettyplease",
- "prost",
- "prost-build",
- "prost-types",
- "schemars",
- "semver",
- "serde",
- "serde_json",
- "serde_yaml",
- "syn 2.0.58",
- "typify",
- "walkdir",
 ]
 
 [[package]]
@@ -5217,50 +5008,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
-name = "typify"
-version = "0.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ed4d717aa95e598e2f9183376b060e95669ef8f444701ea6afb990fde1cf69"
-dependencies = [
- "typify-impl",
- "typify-macro",
-]
-
-[[package]]
-name = "typify-impl"
-version = "0.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89057244dfade7c58af9e62beccbcbeb7a7e7701697a33b06dbe0b7331fb79cf"
-dependencies = [
- "heck",
- "log",
- "proc-macro2",
- "quote",
- "regress",
- "schemars",
- "serde_json",
- "syn 2.0.58",
- "thiserror",
- "unicode-ident",
-]
-
-[[package]]
-name = "typify-macro"
-version = "0.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ddade397f5957d2cd7fb27f905a9a569db20e8e1e3ea589edce40be07b92825"
-dependencies = [
- "proc-macro2",
- "quote",
- "schemars",
- "serde",
- "serde_json",
- "serde_tokenstream",
- "syn 2.0.58",
- "typify-impl",
-]
-
-[[package]]
 name = "unicase"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5313,12 +5060,6 @@ name = "uninit"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "359fdaaabedff944f100847f2e0ea88918d8012fe64baf5b54c191ad010168c9"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -5459,7 +5200,7 @@ dependencies = [
  "ahash",
  "criterion",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown",
  "linkme",
  "log",
  "num-traits",
@@ -5921,15 +5662,6 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
-]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,6 +960,7 @@ dependencies = [
  "bzip2",
  "criterion",
  "csv",
+ "enum-iterator",
  "itertools 0.12.1",
  "lance",
  "lazy_static",
@@ -1813,6 +1814,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-iterator"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "600536cfe9e2da0820aa498e570f6b2b9223eec3ce2f835c8ae4861304fa4794"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03cdc46ec28bd728e67540c528013c6a10eb69a02eb31078a1bda695438cbfb8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ zigzag = "0.1.0"
 bzip2 = "0.4.4"
 csv = "1.3.0"
 arrow-csv = "51.0.0"
+lazy_static = "1.4.0"
 
 [workspace.lints.rust]
 warnings = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ bzip2 = "0.4.4"
 csv = "1.3.0"
 arrow-csv = "51.0.0"
 lazy_static = "1.4.0"
+enum-iterator = "2.0.0"
 
 [workspace.lints.rust]
 warnings = "deny"

--- a/bench-vortex/Cargo.toml
+++ b/bench-vortex/Cargo.toml
@@ -41,6 +41,7 @@ bzip2 = { workspace = true }
 csv = { workspace = true }
 arrow-csv = { workspace = true }
 arrow = {workspace = true }
+lazy_static = {workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/bench-vortex/Cargo.toml
+++ b/bench-vortex/Cargo.toml
@@ -40,8 +40,9 @@ tokio = "1.0.1"
 bzip2 = { workspace = true }
 csv = { workspace = true }
 arrow-csv = { workspace = true }
-arrow = {workspace = true }
-lazy_static = {workspace = true }
+arrow = { workspace = true }
+lazy_static = { workspace = true }
+enum-iterator = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/bench-vortex/src/bin/compress.rs
+++ b/bench-vortex/src/bin/compress.rs
@@ -14,11 +14,12 @@ use vortex::formatter::display_tree;
 
 #[allow(unreachable_code)]
 pub fn main() {
-    setup_logger(LevelFilter::Error);
+    setup_logger(LevelFilter::Info);
 
     // compress_pbi(PBIDataset::CMSprovider);
+    compress_pbi(PBIDataset::Bimbo);
     // compress_pbi(PBIDataset::Medicare1);
-    compress_pbi(PBIDataset::SalariesFrance);
+    // compress_pbi(PBIDataset::SalariesFrance);
     // compress_pbi(PBIDataset::MedPayment1);
     // compress_pbi(PBIDataset::Redfin1);
     panic!("done");

--- a/bench-vortex/src/bin/compress.rs
+++ b/bench-vortex/src/bin/compress.rs
@@ -12,17 +12,9 @@ use log::LevelFilter;
 use vortex::array::Array;
 use vortex::formatter::display_tree;
 
-#[allow(unreachable_code)]
 pub fn main() {
     setup_logger(LevelFilter::Info);
-
-    // compress_pbi(PBIDataset::CMSprovider);
-    compress_pbi(PBIDataset::Bimbo);
-    // compress_pbi(PBIDataset::Medicare1);
-    // compress_pbi(PBIDataset::SalariesFrance);
-    // compress_pbi(PBIDataset::MedPayment1);
-    // compress_pbi(PBIDataset::Redfin1);
-    panic!("done");
+    compress_pbi(PBIDataset::Medicare1);
     compress_taxi();
 }
 

--- a/bench-vortex/src/bin/compress.rs
+++ b/bench-vortex/src/bin/compress.rs
@@ -7,7 +7,7 @@ use bench_vortex::public_bi_data::BenchmarkDatasets::PBI;
 use bench_vortex::public_bi_data::PBIDataset;
 use bench_vortex::reader::{open_vortex, rewrite_parquet_as_vortex};
 use bench_vortex::taxi_data::taxi_data_parquet;
-use bench_vortex::{data_path, setup_logger};
+use bench_vortex::{setup_logger, IdempotentPath};
 use log::{info, LevelFilter};
 use vortex::array::Array;
 use vortex::formatter::display_tree;
@@ -19,7 +19,7 @@ pub fn main() {
 }
 
 fn compress_taxi() {
-    let path: PathBuf = data_path("taxi_data.vortex");
+    let path: PathBuf = "taxi_data.vortex".to_idempotent_path();
     {
         let mut write = File::create(&path).unwrap();
         rewrite_parquet_as_vortex(taxi_data_parquet(), &mut write).unwrap();

--- a/bench-vortex/src/bin/compress.rs
+++ b/bench-vortex/src/bin/compress.rs
@@ -8,7 +8,7 @@ use bench_vortex::public_bi_data::PBIDataset;
 use bench_vortex::reader::{open_vortex, rewrite_parquet_as_vortex};
 use bench_vortex::taxi_data::taxi_data_parquet;
 use bench_vortex::{data_path, setup_logger};
-use log::LevelFilter;
+use log::{info, LevelFilter};
 use vortex::array::Array;
 use vortex::formatter::display_tree;
 
@@ -30,9 +30,9 @@ fn compress_taxi() {
     let pq_size = taxi_data_parquet().metadata().unwrap().size();
     let vx_size = taxi_vortex.nbytes();
 
-    println!("{}\n\n", display_tree(taxi_vortex.as_ref()));
-    println!("Parquet size: {}, Vortex size: {}", pq_size, vx_size);
-    println!("Compression ratio: {}", vx_size as f32 / pq_size as f32);
+    info!("{}\n\n", display_tree(taxi_vortex.as_ref()));
+    info!("Parquet size: {}, Vortex size: {}", pq_size, vx_size);
+    info!("Compression ratio: {}", vx_size as f32 / pq_size as f32);
 }
 
 fn compress_pbi(which_pbi: PBIDataset) {

--- a/bench-vortex/src/bin/compress.rs
+++ b/bench-vortex/src/bin/compress.rs
@@ -2,22 +2,27 @@ use std::fs::File;
 use std::os::unix::prelude::MetadataExt;
 use std::path::PathBuf;
 
-use bench_vortex::medicare_data::medicare_data_csv;
-use bench_vortex::reader::{
-    compress_csv_to_vortex, default_csv_format, open_vortex, rewrite_parquet_as_vortex,
-    write_csv_as_parquet,
-};
+use bench_vortex::data_downloads::BenchmarkDataset;
+use bench_vortex::public_bi_data::BenchmarkDatasets::PBI;
+use bench_vortex::public_bi_data::PBIDataset;
+use bench_vortex::reader::{open_vortex, rewrite_parquet_as_vortex};
 use bench_vortex::taxi_data::taxi_data_parquet;
 use bench_vortex::{data_path, setup_logger};
 use log::LevelFilter;
 use vortex::array::Array;
 use vortex::formatter::display_tree;
 
+#[allow(unreachable_code)]
 pub fn main() {
-    setup_logger(LevelFilter::Debug);
+    setup_logger(LevelFilter::Error);
+
+    compress_pbi(PBIDataset::CMSprovider);
+    compress_pbi(PBIDataset::Medicare1);
+    compress_pbi(PBIDataset::SalariesFrance);
+    compress_pbi(PBIDataset::MLB);
+    compress_pbi(PBIDataset::Redfin1);
+    panic!("done");
     compress_taxi();
-    compress_medicare();
-    write_medicare_as_parquet();
 }
 
 fn compress_taxi() {
@@ -37,33 +42,9 @@ fn compress_taxi() {
     println!("Compression ratio: {}", vx_size as f32 / pq_size as f32);
 }
 
-fn compress_medicare() {
-    let path: PathBuf = data_path("medicare.vortex");
-    {
-        let mut write = File::create(&path).unwrap();
-        let delimiter = u8::try_from('|').unwrap();
-        compress_csv_to_vortex(
-            medicare_data_csv(),
-            default_csv_format().with_delimiter(delimiter),
-            &mut write,
-        )
-        .unwrap();
-    }
-
-    let medicare_vortex = open_vortex(&path).unwrap();
-
-    let pq_size = medicare_data_csv().metadata().unwrap().size();
-    let vx_size = medicare_vortex.nbytes();
-
-    println!("{}\n\n", display_tree(medicare_vortex.as_ref()));
-    println!("Csv size: {}, Vortex size: {}", pq_size, vx_size);
-    println!("Compression ratio: {}", vx_size as f32 / pq_size as f32);
-}
-
-pub fn write_medicare_as_parquet() {
-    let path = data_path("medicare.parquet");
-    let delimiter = u8::try_from('|').unwrap();
-    let format = default_csv_format().with_delimiter(delimiter);
-    let file = File::create(path).unwrap();
-    write_csv_as_parquet(medicare_data_csv(), format, file).unwrap();
+fn compress_pbi(which_pbi: PBIDataset) {
+    let dataset = PBI(which_pbi);
+    dataset.uncompressed();
+    dataset.write_as_vortex();
+    dataset.write_as_parquet();
 }

--- a/bench-vortex/src/bin/compress.rs
+++ b/bench-vortex/src/bin/compress.rs
@@ -16,11 +16,11 @@ use vortex::formatter::display_tree;
 pub fn main() {
     setup_logger(LevelFilter::Error);
 
-    compress_pbi(PBIDataset::CMSprovider);
-    compress_pbi(PBIDataset::Medicare1);
+    // compress_pbi(PBIDataset::CMSprovider);
+    // compress_pbi(PBIDataset::Medicare1);
     compress_pbi(PBIDataset::SalariesFrance);
-    compress_pbi(PBIDataset::MLB);
-    compress_pbi(PBIDataset::Redfin1);
+    // compress_pbi(PBIDataset::MedPayment1);
+    // compress_pbi(PBIDataset::Redfin1);
     panic!("done");
     compress_taxi();
 }

--- a/bench-vortex/src/data_downloads.rs
+++ b/bench-vortex/src/data_downloads.rs
@@ -22,7 +22,7 @@ use crate::idempotent;
 use crate::reader::BATCH_SIZE;
 
 pub fn download_data(fname: PathBuf, data_url: &str) -> PathBuf {
-    idempotent(fname.clone(), |path| {
+    idempotent(&fname, |path| {
         info!("Downloading {} from {}", fname.to_str().unwrap(), data_url);
         let mut file = File::create(path).unwrap();
         reqwest::blocking::get(data_url).unwrap().copy_to(&mut file)
@@ -73,7 +73,7 @@ pub fn data_vortex_uncompressed(fname_out: &str, downloaded_data: PathBuf) -> Pa
 }
 
 pub fn decompress_bz2(input_path: PathBuf, output_path: PathBuf) -> PathBuf {
-    idempotent(output_path.clone(), |path| {
+    idempotent(&output_path, |path| {
         info!(
             "Decompressing bzip from {} to {}",
             input_path.to_str().unwrap(),

--- a/bench-vortex/src/data_downloads.rs
+++ b/bench-vortex/src/data_downloads.rs
@@ -18,11 +18,11 @@ use vortex::serde::WriteCtx;
 use vortex_error::VortexError;
 use vortex_schema::DType;
 
+use crate::idempotent;
 use crate::reader::BATCH_SIZE;
-use crate::{idempotent, idempotent2};
 
 pub fn download_data(fname: PathBuf, data_url: &str) -> PathBuf {
-    idempotent2(&fname, |path| {
+    idempotent(fname.clone(), |path| {
         info!("Downloading {} from {}", fname.to_str().unwrap(), data_url);
         let mut file = File::create(path).unwrap();
         reqwest::blocking::get(data_url).unwrap().copy_to(&mut file)
@@ -73,7 +73,7 @@ pub fn data_vortex_uncompressed(fname_out: &str, downloaded_data: PathBuf) -> Pa
 }
 
 pub fn decompress_bz2(input_path: PathBuf, output_path: PathBuf) -> PathBuf {
-    idempotent2(&output_path, |path| {
+    idempotent(output_path.clone(), |path| {
         info!(
             "Decompressing bzip from {} to {}",
             input_path.to_str().unwrap(),

--- a/bench-vortex/src/data_downloads.rs
+++ b/bench-vortex/src/data_downloads.rs
@@ -23,7 +23,7 @@ use crate::{data_path, idempotent};
 pub fn download_data(fname: &str, data_url: &str) -> PathBuf {
     idempotent(fname, |path| {
         let mut file = File::create(path).unwrap();
-
+        println!("Downloading {} from {}", fname, data_url);
         reqwest::blocking::get(data_url).unwrap().copy_to(&mut file)
     })
     .unwrap()
@@ -73,6 +73,7 @@ pub fn data_vortex_uncompressed(fname_out: &str, downloaded_data: PathBuf) -> Pa
 
 pub fn decompress_bz2(input_path: &str, output_path: &str) -> PathBuf {
     idempotent(output_path, |path| {
+        println!("Decompressing bzip from {} to {}", input_path, output_path);
         let input_file = File::open(data_path(input_path)).unwrap();
         let mut decoder = BzDecoder::new(input_file);
 
@@ -84,4 +85,12 @@ pub fn decompress_bz2(input_path: &str, output_path: &str) -> PathBuf {
         Ok::<PathBuf, VortexError>(data_path(output_path))
     })
     .unwrap()
+}
+
+pub trait BenchmarkDataset {
+    fn uncompressed(&self);
+    fn write_as_parquet(&self);
+    fn write_as_vortex(&self);
+    fn list_files(&self) -> Vec<String>;
+    fn directory_location(&self) -> String;
 }

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -37,10 +37,24 @@ pub mod public_bi_data;
 pub mod reader;
 pub mod taxi_data;
 
+/// Creates a file in the data directory if it doesn't already exist.
+/// NB: Takes a relative path (name) and creates a path in the data directory.
 pub fn idempotent<T, E>(name: &str, f: impl FnOnce(&Path) -> Result<T, E>) -> Result<PathBuf, E> {
     let path = data_path(name);
     if !path.exists() {
         f(&path)?;
+    }
+    Ok(path.to_path_buf())
+}
+
+/// Creates a file if it doesn't already exist.
+/// NB: Does NOT modify the given path to ensure that it resides in the data directory.
+pub fn idempotent2<T, E>(path: &Path, f: impl FnOnce(&Path) -> Result<T, E>) -> Result<PathBuf, E> {
+    if !path.parent().unwrap().exists() {
+        create_dir_all(path.parent().unwrap()).unwrap();
+    }
+    if !path.exists() {
+        f(path)?;
     }
     Ok(path.to_path_buf())
 }

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -47,7 +47,7 @@ pub fn idempotent<T, E, P: IdempotentPath + ?Sized>(
     if !path.exists() {
         f(path.as_path())?;
     }
-    Ok(path.to_path_buf())
+    Ok(path)
 }
 
 pub trait IdempotentPath {

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -59,6 +59,10 @@ pub fn idempotent2<T, E>(path: &Path, f: impl FnOnce(&Path) -> Result<T, E>) -> 
     Ok(path.to_path_buf())
 }
 
+pub trait IdempotentPath {
+    fn to_path(&self) -> Path;
+}
+
 pub fn data_path(name: &str) -> PathBuf {
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("data")

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -31,8 +31,9 @@ use crate::medicare_data::medicare_data_csv;
 use crate::reader::BATCH_SIZE;
 use crate::taxi_data::taxi_data_parquet;
 
-mod data_downloads;
+pub mod data_downloads;
 pub mod medicare_data;
+pub mod public_bi_data;
 pub mod reader;
 pub mod taxi_data;
 

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -39,8 +39,8 @@ pub mod taxi_data;
 
 /// Creates a file if it doesn't already exist.
 /// NB: Does NOT modify the given path to ensure that it resides in the data directory.
-pub fn idempotent<T, E, P: IdempotentPath>(
-    path: P,
+pub fn idempotent<T, E, P: IdempotentPath + ?Sized>(
+    path: &P,
     f: impl FnOnce(&Path) -> Result<T, E>,
 ) -> Result<PathBuf, E> {
     let path = path.to_idempotent_path();
@@ -57,7 +57,7 @@ pub trait IdempotentPath {
     fn to_idempotent_path(&self) -> PathBuf;
 }
 
-impl IdempotentPath for &str {
+impl IdempotentPath for str {
     fn to_idempotent_path(&self) -> PathBuf {
         let path = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("data")
@@ -66,15 +66,6 @@ impl IdempotentPath for &str {
             create_dir_all(path.parent().unwrap()).unwrap();
         }
         path
-    }
-}
-
-impl IdempotentPath for &Path {
-    fn to_idempotent_path(&self) -> PathBuf {
-        if !self.parent().unwrap().exists() {
-            create_dir_all(self.parent().unwrap()).unwrap();
-        }
-        self.to_path_buf()
     }
 }
 

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -66,15 +66,6 @@ impl IdempotentPath for str {
     }
 }
 
-impl IdempotentPath for Path {
-    fn to_idempotent_path(&self) -> PathBuf {
-        if !self.parent().unwrap().exists() {
-            create_dir_all(self.parent().unwrap()).unwrap();
-        }
-        self.to_path_buf()
-    }
-}
-
 impl IdempotentPath for PathBuf {
     fn to_idempotent_path(&self) -> PathBuf {
         if !self.parent().unwrap().exists() {

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -44,9 +44,6 @@ pub fn idempotent<T, E, P: IdempotentPath + ?Sized>(
     f: impl FnOnce(&Path) -> Result<T, E>,
 ) -> Result<PathBuf, E> {
     let path = path.to_idempotent_path();
-    if !path.parent().unwrap().exists() {
-        create_dir_all(path.parent().unwrap()).unwrap();
-    }
     if !path.exists() {
         f(path.as_path())?;
     }

--- a/bench-vortex/src/medicare_data.rs
+++ b/bench-vortex/src/medicare_data.rs
@@ -15,15 +15,18 @@ use vortex_schema::DType;
 
 use crate::data_downloads::{decompress_bz2, download_data, parquet_to_lance};
 use crate::reader::{compress_csv_to_vortex, default_csv_format, write_csv_as_parquet};
-use crate::{data_path, idempotent};
+use crate::{idempotent, IdempotentPath};
 
 pub fn medicare_data_csv() -> PathBuf {
     let fname = "Medicare1_1.csv.bz2";
     download_data(
-        data_path(fname),
+        fname.to_idempotent_path(),
         "http://www.cwi.nl/~boncz/PublicBIbenchmark/Medicare1/Medicare1_1.csv.bz2",
     );
-    decompress_bz2(data_path(fname), data_path("Medicare1_1.csv"))
+    decompress_bz2(
+        fname.to_idempotent_path(),
+        "Medicare1_1.csv".to_idempotent_path(),
+    )
 }
 
 pub fn medicare_data_lance() -> PathBuf {

--- a/bench-vortex/src/medicare_data.rs
+++ b/bench-vortex/src/medicare_data.rs
@@ -14,16 +14,16 @@ use vortex_error::VortexError;
 use vortex_schema::DType;
 
 use crate::data_downloads::{decompress_bz2, download_data, parquet_to_lance};
-use crate::idempotent;
 use crate::reader::{compress_csv_to_vortex, default_csv_format, write_csv_as_parquet};
+use crate::{data_path, idempotent};
 
 pub fn medicare_data_csv() -> PathBuf {
     let fname = "Medicare1_1.csv.bz2";
     download_data(
-        fname,
+        data_path(fname),
         "http://www.cwi.nl/~boncz/PublicBIbenchmark/Medicare1/Medicare1_1.csv.bz2",
     );
-    decompress_bz2(fname, "Medicare1_1.csv")
+    decompress_bz2(data_path(fname), data_path("Medicare1_1.csv"))
 }
 
 pub fn medicare_data_lance() -> PathBuf {

--- a/bench-vortex/src/public_bi_data.rs
+++ b/bench-vortex/src/public_bi_data.rs
@@ -438,7 +438,7 @@ impl BenchmarkDataset for BenchmarkDatasets {
             )
             .expect("Failed to compress to parquet");
             let pq_size = compressed.metadata().unwrap().size();
-            println!("Parquet size: {}", pq_size);
+            info!("Parquet size: {}", pq_size);
         }
     }
 
@@ -470,8 +470,8 @@ impl BenchmarkDataset for BenchmarkDatasets {
             let from_vortex = open_vortex(&compressed).unwrap();
             let vx_size = from_vortex.nbytes();
 
-            println!("Vortex size: {}", vx_size);
-            println!("{}\n\n", display_tree(from_vortex.as_ref()));
+            info!("Vortex size: {}", vx_size);
+            info!("{}\n\n", display_tree(from_vortex.as_ref()));
         }
     }
 

--- a/bench-vortex/src/public_bi_data.rs
+++ b/bench-vortex/src/public_bi_data.rs
@@ -3,6 +3,7 @@ use std::fs::File;
 use std::hash::Hash;
 use std::os::unix::fs::MetadataExt;
 
+use enum_iterator::Sequence;
 use itertools::Itertools;
 use vortex::formatter::display_tree;
 
@@ -309,58 +310,6 @@ impl PBIDataset {
         url.split('/').last().unwrap().to_string()
     }
 
-    pub fn all_values() -> Vec<PBIDataset> {
-        vec![
-            AirlineSentiment,
-            Arade,
-            Bimbo,
-            CMSprovider,
-            CityMaxCapita,
-            CommonGovernment,
-            Corporations,
-            Eixo,
-            Euro2016,
-            Food,
-            Generico,
-            HashTags,
-            Hatred,
-            IGlocations1,
-            IGlocations2,
-            IUBLibrary,
-            MLB,
-            MedPayment1,
-            MedPayment2,
-            Medicare1,
-            Medicare2,
-            Medicare3,
-            Motos,
-            MulheresMil,
-            NYC,
-            PanCreactomy1,
-            PanCreactomy2,
-            Physicians,
-            Provider,
-            RealEstate1,
-            RealEstate2,
-            Redfin1,
-            Redfin2,
-            Redfin3,
-            Redfin4,
-            Rentabilidad,
-            Romance,
-            SalariesFrance,
-            TableroSistemaPenal,
-            Taxpayer,
-            Telco,
-            TrainsUK1,
-            TrainsUK2,
-            USCensus,
-            Uberlandia,
-            Wins,
-            YaleLanguages,
-        ]
-    }
-
     fn csv_files(&self) -> Vec<String> {
         let urls = URLS.get(self).unwrap();
         self.dataset_name();
@@ -419,7 +368,7 @@ impl PBIUrl {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Sequence)]
 pub enum PBIDataset {
     AirlineSentiment,
     Arade,
@@ -534,6 +483,7 @@ impl BenchmarkDataset for BenchmarkDatasets {
                 },
             )
             .expect("Failed to compress to vortex");
+            println!("Compressed asdf: {:?}", compressed);
             let from_vortex = open_vortex(&compressed).unwrap();
             let vx_size = from_vortex.nbytes();
 

--- a/bench-vortex/src/public_bi_data.rs
+++ b/bench-vortex/src/public_bi_data.rs
@@ -279,13 +279,9 @@ lazy_static::lazy_static! {
 }
 
 impl PBIDataset {
-    pub fn dataset_name(&self) -> String {
+    pub fn dataset_name(&self) -> &str {
         let url = URLS.get(self).unwrap();
-        url.first().unwrap().dataset_name.clone()
-    }
-
-    pub fn fname_from_url(url: String) -> String {
-        url.split('/').last().unwrap().to_string()
+        url.first().unwrap().dataset_name
     }
 
     fn csv_files(&self) -> Vec<PathBuf> {
@@ -314,7 +310,7 @@ impl PBIDataset {
         data_path("PBI")
             .join(self.dataset_name())
             .join("bzip2")
-            .join(url.file_name.clone())
+            .join(url.file_name)
     }
 
     fn unzip(&self) {
@@ -328,24 +324,24 @@ impl PBIDataset {
 
 #[derive(Debug)]
 struct PBIUrl {
-    dataset_name: String,
-    file_name: String,
+    dataset_name: &'static str,
+    file_name: &'static str,
 }
 
 impl PBIUrl {
-    fn new(dataset_name: &str, file_name: &str) -> Self {
+    fn new(dataset_name: &'static str, file_name: &'static str) -> Self {
         PBIUrl {
-            dataset_name: dataset_name.to_string(),
-            file_name: file_name.to_string(),
+            dataset_name,
+            file_name,
         }
     }
-    fn to_url_string(&self) -> String {
-        let url_str = format!(
-            "https://homepages.cwi.nl/~boncz/PublicBIbenchmark/{}/{}",
-            self.dataset_name, self.file_name
-        );
-        // roundtrip through url to validate
-        Url::parse(url_str.as_str()).unwrap().to_string()
+    fn to_url_string(&self) -> Url {
+        Url::parse("https://homepages.cwi.nl/~boncz/PublicBIbenchmark")
+            .unwrap()
+            .join(self.dataset_name)
+            .unwrap()
+            .join(self.file_name)
+            .unwrap()
     }
 }
 

--- a/bench-vortex/src/public_bi_data.rs
+++ b/bench-vortex/src/public_bi_data.rs
@@ -422,7 +422,7 @@ impl BenchmarkDataset for BenchmarkDatasets {
                 .strip_suffix(".csv")
                 .unwrap();
             let compressed = idempotent(
-                path_for_file_type(self, output_fname, "parquet"),
+                &path_for_file_type(self, output_fname, "parquet"),
                 |output_path| {
                     let mut write = File::create(output_path).unwrap();
                     let delimiter = u8::try_from('|').unwrap();
@@ -452,7 +452,7 @@ impl BenchmarkDataset for BenchmarkDatasets {
                 .unwrap();
 
             let compressed = idempotent(
-                path_for_file_type(self, output_fname, "vortex"),
+                &path_for_file_type(self, output_fname, "vortex"),
                 |output_path| {
                     let mut write = File::create(output_path).unwrap();
                     let delimiter = u8::try_from('|').unwrap();

--- a/bench-vortex/src/public_bi_data.rs
+++ b/bench-vortex/src/public_bi_data.rs
@@ -1,0 +1,556 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::hash::Hash;
+use std::os::unix::fs::MetadataExt;
+
+use itertools::Itertools;
+use vortex::formatter::display_tree;
+
+use crate::data_downloads::{decompress_bz2, download_data, BenchmarkDataset};
+use crate::public_bi_data::PBIDataset::*;
+use crate::reader::{
+    compress_csv_to_vortex, default_csv_format, open_vortex, write_csv_as_parquet,
+};
+use crate::{data_path, idempotent};
+
+lazy_static::lazy_static! {
+    // NB: we do not expect this to change, otherwise we'd crawl the site and populate it at runtime
+    // We will eventually switch over to self-hosting this data, at which time this map will need
+    // to be updated once.
+    static ref URLS: HashMap<PBIDataset, Vec<PBIUrl>> = HashMap::from([
+            (AirlineSentiment, vec!(
+                PBIUrl::new("AirlineSentiment", "AirlineSentiment_1.csv.bz2"))),
+            (Arade, vec!(PBIUrl::new("Arade","Arade_1.csv.bz2"))),
+            (Bimbo, vec!(
+                PBIUrl::new("Bimbo", "Bimbo_1.csv.bz2"))),
+            (CMSprovider, vec!(
+                PBIUrl::new("CMSprovider", "CMSprovider_1.csv.bz2"),
+                PBIUrl::new("CMSprovider", "CMSprovider_2.csv.bz2"))),
+            (CityMaxCapita, vec!(
+                PBIUrl::new("CityMaxCapita", "CityMaxCapita_1.csv.bz2"))),
+            (CommonGovernment, vec!(
+                PBIUrl::new("CommonGovernment", "CommonGovernment_1.csv.bz2"),
+                PBIUrl::new("CommonGovernment", "CommonGovernment_2.csv.bz2"),
+                PBIUrl::new("CommonGovernment", "CommonGovernment_3.csv.bz2"),
+                PBIUrl::new("CommonGovernment", "CommonGovernment_4.csv.bz2"),
+                PBIUrl::new("CommonGovernment", "CommonGovernment_5.csv.bz2"),
+                PBIUrl::new("CommonGovernment", "CommonGovernment_6.csv.bz2"),
+                PBIUrl::new("CommonGovernment", "CommonGovernment_7.csv.bz2"),
+                PBIUrl::new("CommonGovernment", "CommonGovernment_8.csv.bz2"),
+                PBIUrl::new("CommonGovernment", "CommonGovernment_9.csv.bz2"),
+                PBIUrl::new("CommonGovernment", "CommonGovernment_10.csv.bz2"),
+                PBIUrl::new("CommonGovernment", "CommonGovernment_11.csv.bz2"),
+                PBIUrl::new("CommonGovernment", "CommonGovernment_12.csv.bz2"),
+                PBIUrl::new("CommonGovernment", "CommonGovernment_13.csv.bz2"),
+            )),
+            (Corporations, vec!(
+                PBIUrl::new("Corporations", "Corporations_1.csv.bz2"))),
+            (Eixo, vec!(
+                PBIUrl::new("Eixo", "Eixo_1.csv.bz2"))),
+            (Euro2016, vec!(
+                PBIUrl::new("Euro2016", "Euro2016_1.csv.bz2"))),
+            (Food, vec!(
+                PBIUrl::new("Food", "Food_1.csv.bz2"))),
+            (Generico, vec!(
+                PBIUrl::new("Generico", "Generico_1.csv.bz2"),
+                PBIUrl::new("Generico", "Generico_2.csv.bz2"),
+                PBIUrl::new("Generico", "Generico_3.csv.bz2"),
+                PBIUrl::new("Generico", "Generico_4.csv.bz2"),
+                PBIUrl::new("Generico", "Generico_5.csv.bz2"),
+            )),
+            (HashTags, vec!(
+                PBIUrl::new("HashTags", "HashTags_1.csv.bz2"))),
+            (Hatred, vec!(
+                PBIUrl::new("Hatred", "Hatred_1.csv.bz2"))),
+            (IGlocations1, vec!(
+                PBIUrl::new("IGlocations1", "IGlocations1_1.csv.bz2"))),
+            (IGlocations2, vec!(
+                PBIUrl::new("IGlocations2", "IGlocations2_1.csv.bz2"),
+                PBIUrl::new("IGlocations2", "IGlocations2_2.csv.bz2"),
+            )),
+            (IUBLibrary, vec!(
+                PBIUrl::new("IUBLibrary", "IUBLibrary_1.csv.bz2"))),
+            (MLB, vec!(
+                PBIUrl::new("MLB", "MLB_1.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_2.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_3.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_4.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_5.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_6.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_7.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_8.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_9.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_10.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_11.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_12.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_13.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_14.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_15.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_16.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_17.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_18.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_19.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_20.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_21.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_22.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_23.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_24.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_25.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_26.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_27.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_28.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_29.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_30.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_31.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_32.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_33.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_34.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_35.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_36.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_37.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_38.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_39.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_40.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_41.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_42.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_43.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_44.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_45.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_46.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_47.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_48.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_49.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_50.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_51.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_52.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_53.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_54.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_55.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_56.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_57.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_58.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_59.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_60.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_61.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_62.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_63.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_64.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_65.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_66.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_67.csv.bz2"),
+                PBIUrl::new("MLB", "MLB_68.csv.bz2"),
+            )),
+            (MedPayment1, vec!(
+                PBIUrl::new("MedPayment1", "MedPayment1_1.csv.bz2"))),
+            (MedPayment2, vec!(
+                PBIUrl::new("MedPayment2", "MedPayment2_1.csv.bz2"))),
+            (Medicare1, vec!(
+                PBIUrl::new("Medicare1", "Medicare1_1.csv.bz2"),
+                PBIUrl::new("Medicare1", "Medicare1_2.csv.bz2"),
+            )),
+            (Medicare2, vec!(
+                PBIUrl::new("Medicare2", "Medicare2_1.csv.bz2"),
+                PBIUrl::new("Medicare2", "Medicare2_2.csv.bz2"),
+            )),
+            (Medicare3, vec!(
+                PBIUrl::new("Medicare3", "Medicare3_1.csv.bz2"))),
+            (Motos, vec!(
+                PBIUrl::new("Motos", "Motos_1.csv.bz2"),
+                PBIUrl::new("Motos", "Motos_2.csv.bz2"),
+            )),
+            (MulheresMil, vec!(
+                PBIUrl::new("MulheresMil", "MulheresMil_1.csv.bz2"))),
+            (NYC, vec!(
+                PBIUrl::new("NYC", "NYC_1.csv.bz2"),
+                PBIUrl::new("NYC", "NYC_2.csv.bz2"),
+            )),
+            (PanCreactomy1, vec!(
+                PBIUrl::new("PanCreactomy1", "PanCreactomy1_1.csv.bz2"))),
+            (PanCreactomy2, vec!(
+                PBIUrl::new("PanCreactomy2", "PanCreactomy2_1.csv.bz2"),
+                PBIUrl::new("PanCreactomy2", "PanCreactomy2_2.csv.bz2"),
+            )),
+            (Physicians, vec!(
+                PBIUrl::new("Physicians", "Physicians_1.csv.bz2"))),
+            (Provider, vec!(
+                PBIUrl::new("Provider", "Provider_1.csv.bz2"),
+                PBIUrl::new("Provider", "Provider_2.csv.bz2"),
+                PBIUrl::new("Provider", "Provider_3.csv.bz2"),
+                PBIUrl::new("Provider", "Provider_4.csv.bz2"),
+                PBIUrl::new("Provider", "Provider_5.csv.bz2"),
+                PBIUrl::new("Provider", "Provider_6.csv.bz2"),
+                PBIUrl::new("Provider", "Provider_7.csv.bz2"),
+                PBIUrl::new("Provider", "Provider_8.csv.bz2"),
+            )),
+            (RealEstate1, vec!(
+                PBIUrl::new("RealEstate1", "RealEstate1_1.csv.bz2"),
+                PBIUrl::new("RealEstate1", "RealEstate1_2.csv.bz2"),
+            )),
+            (RealEstate2, vec!(
+                PBIUrl::new("RealEstate2", "RealEstate2_1.csv.bz2"),
+                PBIUrl::new("RealEstate2", "RealEstate2_2.csv.bz2"),
+                PBIUrl::new("RealEstate2", "RealEstate2_3.csv.bz2"),
+                PBIUrl::new("RealEstate2", "RealEstate2_4.csv.bz2"),
+                PBIUrl::new("RealEstate2", "RealEstate2_5.csv.bz2"),
+                PBIUrl::new("RealEstate2", "RealEstate2_6.csv.bz2"),
+                PBIUrl::new("RealEstate2", "RealEstate2_7.csv.bz2"),
+            )),
+            (Redfin1, vec!(
+                PBIUrl::new("Redfin1", "Redfin1_1.csv.bz2"),
+                PBIUrl::new("Redfin1", "Redfin1_2.csv.bz2"),
+                PBIUrl::new("Redfin1", "Redfin1_3.csv.bz2"),
+                PBIUrl::new("Redfin1", "Redfin1_4.csv.bz2"),
+            )),
+            (Redfin2, vec!(
+                PBIUrl::new("Redfin2", "Redfin2_1.csv.bz2"),
+                PBIUrl::new("Redfin2", "Redfin2_2.csv.bz2"),
+                PBIUrl::new("Redfin2", "Redfin2_3.csv.bz2"),
+            )),
+            (Redfin3, vec!(
+                PBIUrl::new("Redfin3", "Redfin3_1.csv.bz2"),
+                PBIUrl::new("Redfin3", "Redfin3_2.csv.bz2"),
+            )),
+            (Redfin4, vec!(
+                PBIUrl::new("Redfin4", "Redfin4_1.csv.bz2"))),
+            (Rentabilidad, vec!(
+                PBIUrl::new("Rentabilidad", "Rentabilidad_1.csv.bz2"),
+                PBIUrl::new("Rentabilidad", "Rentabilidad_2.csv.bz2"),
+                PBIUrl::new("Rentabilidad", "Rentabilidad_3.csv.bz2"),
+                PBIUrl::new("Rentabilidad", "Rentabilidad_4.csv.bz2"),
+                PBIUrl::new("Rentabilidad", "Rentabilidad_5.csv.bz2"),
+                PBIUrl::new("Rentabilidad", "Rentabilidad_6.csv.bz2"),
+                PBIUrl::new("Rentabilidad", "Rentabilidad_7.csv.bz2"),
+                PBIUrl::new("Rentabilidad", "Rentabilidad_8.csv.bz2"),
+                PBIUrl::new("Rentabilidad", "Rentabilidad_9.csv.bz2"),
+            )),
+            (Romance, vec!(
+                PBIUrl::new("Romance", "Romance_1.csv.bz2"),
+                PBIUrl::new("Romance", "Romance_2.csv.bz2"),
+            )),
+            (SalariesFrance, vec!(
+                PBIUrl::new("SalariesFrance", "SalariesFrance_1.csv.bz2"),
+                PBIUrl::new("SalariesFrance", "SalariesFrance_2.csv.bz2"),
+                PBIUrl::new("SalariesFrance", "SalariesFrance_3.csv.bz2"),
+                PBIUrl::new("SalariesFrance", "SalariesFrance_4.csv.bz2"),
+                PBIUrl::new("SalariesFrance", "SalariesFrance_5.csv.bz2"),
+                PBIUrl::new("SalariesFrance", "SalariesFrance_6.csv.bz2"),
+                PBIUrl::new("SalariesFrance", "SalariesFrance_7.csv.bz2"),
+                PBIUrl::new("SalariesFrance", "SalariesFrance_8.csv.bz2"),
+                PBIUrl::new("SalariesFrance", "SalariesFrance_9.csv.bz2"),
+                PBIUrl::new("SalariesFrance", "SalariesFrance_10.csv.bz2"),
+                PBIUrl::new("SalariesFrance", "SalariesFrance_11.csv.bz2"),
+                PBIUrl::new("SalariesFrance", "SalariesFrance_12.csv.bz2"),
+                PBIUrl::new("SalariesFrance", "SalariesFrance_13.csv.bz2"),
+            )),
+            (TableroSistemaPenal, vec!(
+                PBIUrl::new("TableroSistemaPenal", "TableroSistemaPenal_1.csv.bz2"),
+                PBIUrl::new("TableroSistemaPenal", "TableroSistemaPenal_2.csv.bz2"),
+                PBIUrl::new("TableroSistemaPenal", "TableroSistemaPenal_3.csv.bz2"),
+                PBIUrl::new("TableroSistemaPenal", "TableroSistemaPenal_4.csv.bz2"),
+                PBIUrl::new("TableroSistemaPenal", "TableroSistemaPenal_5.csv.bz2"),
+                PBIUrl::new("TableroSistemaPenal", "TableroSistemaPenal_6.csv.bz2"),
+                PBIUrl::new("TableroSistemaPenal", "TableroSistemaPenal_7.csv.bz2"),
+                PBIUrl::new("TableroSistemaPenal", "TableroSistemaPenal_8.csv.bz2"),
+            )),
+            (Taxpayer, vec!(
+                PBIUrl::new("Taxpayer", "Taxpayer_1.csv.bz2"),
+                PBIUrl::new("Taxpayer", "Taxpayer_2.csv.bz2"),
+                PBIUrl::new("Taxpayer", "Taxpayer_3.csv.bz2"),
+                PBIUrl::new("Taxpayer", "Taxpayer_4.csv.bz2"),
+                PBIUrl::new("Taxpayer", "Taxpayer_5.csv.bz2"),
+                PBIUrl::new("Taxpayer", "Taxpayer_6.csv.bz2"),
+                PBIUrl::new("Taxpayer", "Taxpayer_7.csv.bz2"),
+                PBIUrl::new("Taxpayer", "Taxpayer_8.csv.bz2"),
+                PBIUrl::new("Taxpayer", "Taxpayer_9.csv.bz2"),
+                PBIUrl::new("Taxpayer", "Taxpayer_10.csv.bz2"),
+            )),
+            (Telco, vec!(
+                PBIUrl::new("Telco", "Telco_1.csv.bz2"))),
+            (TrainsUK1, vec!(
+                PBIUrl::new("TrainsUK1", "TrainsUK1_1.csv.bz2"),
+                PBIUrl::new("TrainsUK1", "TrainsUK1_2.csv.bz2"),
+                PBIUrl::new("TrainsUK1", "TrainsUK1_3.csv.bz2"),
+                PBIUrl::new("TrainsUK1", "TrainsUK1_4.csv.bz2"),
+            )),
+            (TrainsUK2, vec!(
+                PBIUrl::new("TrainsUK2", "TrainsUK2_1.csv.bz2"),
+                PBIUrl::new("TrainsUK2", "TrainsUK2_2.csv.bz2"),
+            )),
+            (USCensus, vec!(
+                PBIUrl::new("USCensus", "USCensus_1.csv.bz2"),
+                PBIUrl::new("USCensus", "USCensus_2.csv.bz2"),
+                PBIUrl::new("USCensus", "USCensus_3.csv.bz2"),
+            )),
+            (Uberlandia, vec!(
+                PBIUrl::new("Uberlandia", "Uberlandia_1.csv.bz2"))),
+            (Wins, vec!(
+                PBIUrl::new("Wins", "Wins_1.csv.bz2"),
+                PBIUrl::new("Wins", "Wins_2.csv.bz2"),
+                PBIUrl::new("Wins", "Wins_3.csv.bz2"),
+                PBIUrl::new("Wins", "Wins_4.csv.bz2"),
+            )),
+            (YaleLanguages, vec!(
+                PBIUrl::new("YaleLanguages", "YaleLanguages_1.csv.bz2"),
+                PBIUrl::new("YaleLanguages", "YaleLanguages_2.csv.bz2"),
+                PBIUrl::new("YaleLanguages", "YaleLanguages_3.csv.bz2"),
+                PBIUrl::new("YaleLanguages", "YaleLanguages_4.csv.bz2"),
+                PBIUrl::new("YaleLanguages", "YaleLanguages_5.csv.bz2"),
+            )),
+        ]);
+}
+
+impl PBIDataset {
+    pub fn dataset_name(&self) -> String {
+        let url = URLS.get(self).unwrap();
+        url.first().unwrap().dataset_name.clone()
+    }
+
+    pub fn fname_from_url(url: String) -> String {
+        url.split('/').last().unwrap().to_string()
+    }
+
+    pub fn all_values() -> Vec<PBIDataset> {
+        vec![
+            AirlineSentiment,
+            Arade,
+            Bimbo,
+            CMSprovider,
+            CityMaxCapita,
+            CommonGovernment,
+            Corporations,
+            Eixo,
+            Euro2016,
+            Food,
+            Generico,
+            HashTags,
+            Hatred,
+            IGlocations1,
+            IGlocations2,
+            IUBLibrary,
+            MLB,
+            MedPayment1,
+            MedPayment2,
+            Medicare1,
+            Medicare2,
+            Medicare3,
+            Motos,
+            MulheresMil,
+            NYC,
+            PanCreactomy1,
+            PanCreactomy2,
+            Physicians,
+            Provider,
+            RealEstate1,
+            RealEstate2,
+            Redfin1,
+            Redfin2,
+            Redfin3,
+            Redfin4,
+            Rentabilidad,
+            Romance,
+            SalariesFrance,
+            TableroSistemaPenal,
+            Taxpayer,
+            Telco,
+            TrainsUK1,
+            TrainsUK2,
+            USCensus,
+            Uberlandia,
+            Wins,
+            YaleLanguages,
+        ]
+    }
+
+    fn csv_files(&self) -> Vec<String> {
+        let urls = URLS.get(self).unwrap();
+        self.dataset_name();
+        urls.iter().map(|url| self.get_csv_path(url)).collect_vec()
+    }
+
+    fn get_csv_path(&self, url: &PBIUrl) -> String {
+        format!(
+            "PBI/{}/csv/{}",
+            self.dataset_name(),
+            url.file_name.strip_suffix(".bz2").unwrap()
+        )
+    }
+
+    fn download_bzip(&self) {
+        let urls = URLS.get(self).unwrap();
+        self.dataset_name();
+        urls.iter().for_each(|url| {
+            let fname = self.get_bzip_path(url);
+            download_data(fname.as_str(), url.to_url_string().as_str());
+        });
+    }
+
+    fn get_bzip_path(&self, url: &PBIUrl) -> String {
+        let fname = format!("PBI/{}/bzip2/{}", self.dataset_name(), url.file_name);
+        fname
+    }
+
+    fn unzip(&self) {
+        for url in URLS.get(self).unwrap() {
+            let bzipped = self.get_bzip_path(url);
+            let unzipped_csv = self.get_csv_path(url);
+            decompress_bz2(bzipped.as_str(), unzipped_csv.as_str());
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PBIUrl {
+    dataset_name: String,
+    file_name: String,
+}
+
+impl PBIUrl {
+    fn new(dataset_name: &str, file_name: &str) -> Self {
+        PBIUrl {
+            dataset_name: dataset_name.to_string(),
+            file_name: file_name.to_string(),
+        }
+    }
+    fn to_url_string(&self) -> String {
+        format!(
+            "https://homepages.cwi.nl/~boncz/PublicBIbenchmark/{}/{}",
+            self.dataset_name, self.file_name
+        )
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum PBIDataset {
+    AirlineSentiment,
+    Arade,
+    Bimbo,
+    CMSprovider,
+    CityMaxCapita,
+    CommonGovernment,
+    Corporations,
+    Eixo,
+    Euro2016,
+    Food,
+    Generico,
+    HashTags,
+    Hatred,
+    IGlocations1,
+    IGlocations2,
+    IUBLibrary,
+    MLB,
+    MedPayment1,
+    MedPayment2,
+    Medicare1,
+    Medicare2,
+    Medicare3,
+    Motos,
+    MulheresMil,
+    NYC,
+    PanCreactomy1,
+    PanCreactomy2,
+    Physicians,
+    Provider,
+    RealEstate1,
+    RealEstate2,
+    Redfin1,
+    Redfin2,
+    Redfin3,
+    Redfin4,
+    Rentabilidad,
+    Romance,
+    SalariesFrance,
+    TableroSistemaPenal,
+    Taxpayer,
+    Telco,
+    TrainsUK1,
+    TrainsUK2,
+    USCensus,
+    Uberlandia,
+    Wins,
+    YaleLanguages,
+}
+
+pub enum BenchmarkDatasets {
+    PBI(PBIDataset),
+}
+
+impl BenchmarkDataset for BenchmarkDatasets {
+    fn uncompressed(&self) {
+        match self {
+            BenchmarkDatasets::PBI(dataset) => {
+                dataset.download_bzip();
+                dataset.unzip();
+            }
+        }
+    }
+
+    fn write_as_parquet(&self) {
+        for f in self.list_files() {
+            let output_fname = f.split('/').last().unwrap().strip_suffix(".csv").unwrap();
+            let compressed = idempotent(
+                format!(
+                    "{}/parquet/{}.parquet",
+                    self.directory_location(),
+                    output_fname
+                )
+                .as_str(),
+                |output_path| {
+                    let mut write = File::create(output_path).unwrap();
+                    let delimiter = u8::try_from('|').unwrap();
+                    let csv_input = data_path(f.as_str());
+                    write_csv_as_parquet(
+                        csv_input,
+                        default_csv_format().with_delimiter(delimiter),
+                        &mut write,
+                    )
+                },
+            )
+            .expect("Failed to compress to parquet");
+            let pq_size = compressed.metadata().unwrap().size();
+            println!("Parquet size: {}", pq_size);
+        }
+    }
+
+    fn write_as_vortex(&self) {
+        for f in self.list_files() {
+            println!("Compressing {} to vortex", f);
+            let output_fname = f.split('/').last().unwrap().strip_suffix(".csv").unwrap();
+            let compressed = idempotent(
+                format!(
+                    "{}/vortex/{}.vortex",
+                    self.directory_location(),
+                    output_fname
+                )
+                .as_str(),
+                |output_path| {
+                    let mut write = File::create(output_path).unwrap();
+                    let delimiter = u8::try_from('|').unwrap();
+                    let csv_input = data_path(f.as_str());
+                    compress_csv_to_vortex(
+                        csv_input,
+                        default_csv_format().with_delimiter(delimiter),
+                        &mut write,
+                    )
+                },
+            )
+            .expect("Failed to compress to vortex");
+            let from_vortex = open_vortex(&compressed).unwrap();
+            let vx_size = from_vortex.nbytes();
+
+            println!("Vortex size: {}", vx_size);
+            println!("{}\n\n", display_tree(from_vortex.as_ref()));
+        }
+    }
+
+    fn list_files(&self) -> Vec<String> {
+        match self {
+            BenchmarkDatasets::PBI(dataset) => dataset.csv_files(),
+        }
+    }
+
+    fn directory_location(&self) -> String {
+        match self {
+            BenchmarkDatasets::PBI(dataset) => format!("PBI/{}", dataset.dataset_name()),
+        }
+    }
+}

--- a/bench-vortex/src/public_bi_data.rs
+++ b/bench-vortex/src/public_bi_data.rs
@@ -19,17 +19,17 @@ lazy_static::lazy_static! {
     // We will eventually switch over to self-hosting this data, at which time this map will need
     // to be updated once.
     static ref URLS: HashMap<PBIDataset, Vec<PBIUrl>> = HashMap::from([
-            (AirlineSentiment, vec!(
-                PBIUrl::new("AirlineSentiment", "AirlineSentiment_1.csv.bz2"))),
+            (AirlineSentiment, vec![
+                PBIUrl::new("AirlineSentiment", "AirlineSentiment_1.csv.bz2")]),
             (Arade, vec!(PBIUrl::new("Arade","Arade_1.csv.bz2"))),
-            (Bimbo, vec!(
-                PBIUrl::new("Bimbo", "Bimbo_1.csv.bz2"))),
-            (CMSprovider, vec!(
+            (Bimbo, vec![
+                PBIUrl::new("Bimbo", "Bimbo_1.csv.bz2")]),
+            (CMSprovider, vec![
                 PBIUrl::new("CMSprovider", "CMSprovider_1.csv.bz2"),
-                PBIUrl::new("CMSprovider", "CMSprovider_2.csv.bz2"))),
-            (CityMaxCapita, vec!(
-                PBIUrl::new("CityMaxCapita", "CityMaxCapita_1.csv.bz2"))),
-            (CommonGovernment, vec!(
+                PBIUrl::new("CMSprovider", "CMSprovider_2.csv.bz2")]),
+            (CityMaxCapita, vec![
+                PBIUrl::new("CityMaxCapita", "CityMaxCapita_1.csv.bz2")]),
+            (CommonGovernment, vec![
                 PBIUrl::new("CommonGovernment", "CommonGovernment_1.csv.bz2"),
                 PBIUrl::new("CommonGovernment", "CommonGovernment_2.csv.bz2"),
                 PBIUrl::new("CommonGovernment", "CommonGovernment_3.csv.bz2"),
@@ -42,36 +42,33 @@ lazy_static::lazy_static! {
                 PBIUrl::new("CommonGovernment", "CommonGovernment_10.csv.bz2"),
                 PBIUrl::new("CommonGovernment", "CommonGovernment_11.csv.bz2"),
                 PBIUrl::new("CommonGovernment", "CommonGovernment_12.csv.bz2"),
-                PBIUrl::new("CommonGovernment", "CommonGovernment_13.csv.bz2"),
-            )),
-            (Corporations, vec!(
-                PBIUrl::new("Corporations", "Corporations_1.csv.bz2"))),
-            (Eixo, vec!(
-                PBIUrl::new("Eixo", "Eixo_1.csv.bz2"))),
-            (Euro2016, vec!(
-                PBIUrl::new("Euro2016", "Euro2016_1.csv.bz2"))),
-            (Food, vec!(
-                PBIUrl::new("Food", "Food_1.csv.bz2"))),
-            (Generico, vec!(
+                PBIUrl::new("CommonGovernment", "CommonGovernment_13.csv.bz2")]),
+            (Corporations, vec![
+                PBIUrl::new("Corporations", "Corporations_1.csv.bz2")]),
+            (Eixo, vec![
+                PBIUrl::new("Eixo", "Eixo_1.csv.bz2")]),
+            (Euro2016, vec![
+                PBIUrl::new("Euro2016", "Euro2016_1.csv.bz2")]),
+            (Food, vec![
+                PBIUrl::new("Food", "Food_1.csv.bz2")]),
+            (Generico, vec![
                 PBIUrl::new("Generico", "Generico_1.csv.bz2"),
                 PBIUrl::new("Generico", "Generico_2.csv.bz2"),
                 PBIUrl::new("Generico", "Generico_3.csv.bz2"),
                 PBIUrl::new("Generico", "Generico_4.csv.bz2"),
-                PBIUrl::new("Generico", "Generico_5.csv.bz2"),
-            )),
-            (HashTags, vec!(
-                PBIUrl::new("HashTags", "HashTags_1.csv.bz2"))),
-            (Hatred, vec!(
-                PBIUrl::new("Hatred", "Hatred_1.csv.bz2"))),
-            (IGlocations1, vec!(
-                PBIUrl::new("IGlocations1", "IGlocations1_1.csv.bz2"))),
-            (IGlocations2, vec!(
+                PBIUrl::new("Generico", "Generico_5.csv.bz2"),]),
+            (HashTags, vec![
+                PBIUrl::new("HashTags", "HashTags_1.csv.bz2")]),
+            (Hatred, vec![
+                PBIUrl::new("Hatred", "Hatred_1.csv.bz2")]),
+            (IGlocations1, vec![
+                PBIUrl::new("IGlocations1", "IGlocations1_1.csv.bz2")]),
+            (IGlocations2, vec![
                 PBIUrl::new("IGlocations2", "IGlocations2_1.csv.bz2"),
-                PBIUrl::new("IGlocations2", "IGlocations2_2.csv.bz2"),
-            )),
-            (IUBLibrary, vec!(
-                PBIUrl::new("IUBLibrary", "IUBLibrary_1.csv.bz2"))),
-            (MLB, vec!(
+                PBIUrl::new("IGlocations2", "IGlocations2_2.csv.bz2")]),
+            (IUBLibrary, vec![
+                PBIUrl::new("IUBLibrary", "IUBLibrary_1.csv.bz2")]),
+            (MLB, vec![
                 PBIUrl::new("MLB", "MLB_1.csv.bz2"),
                 PBIUrl::new("MLB", "MLB_2.csv.bz2"),
                 PBIUrl::new("MLB", "MLB_3.csv.bz2"),
@@ -139,41 +136,35 @@ lazy_static::lazy_static! {
                 PBIUrl::new("MLB", "MLB_65.csv.bz2"),
                 PBIUrl::new("MLB", "MLB_66.csv.bz2"),
                 PBIUrl::new("MLB", "MLB_67.csv.bz2"),
-                PBIUrl::new("MLB", "MLB_68.csv.bz2"),
-            )),
-            (MedPayment1, vec!(
-                PBIUrl::new("MedPayment1", "MedPayment1_1.csv.bz2"))),
-            (MedPayment2, vec!(
-                PBIUrl::new("MedPayment2", "MedPayment2_1.csv.bz2"))),
-            (Medicare1, vec!(
+                PBIUrl::new("MLB", "MLB_68.csv.bz2")]),
+            (MedPayment1, vec![
+                PBIUrl::new("MedPayment1", "MedPayment1_1.csv.bz2")]),
+            (MedPayment2, vec![
+                PBIUrl::new("MedPayment2", "MedPayment2_1.csv.bz2")]),
+            (Medicare1, vec![
                 PBIUrl::new("Medicare1", "Medicare1_1.csv.bz2"),
-                PBIUrl::new("Medicare1", "Medicare1_2.csv.bz2"),
-            )),
-            (Medicare2, vec!(
+                PBIUrl::new("Medicare1", "Medicare1_2.csv.bz2")]),
+            (Medicare2, vec![
                 PBIUrl::new("Medicare2", "Medicare2_1.csv.bz2"),
-                PBIUrl::new("Medicare2", "Medicare2_2.csv.bz2"),
-            )),
-            (Medicare3, vec!(
-                PBIUrl::new("Medicare3", "Medicare3_1.csv.bz2"))),
-            (Motos, vec!(
+                PBIUrl::new("Medicare2", "Medicare2_2.csv.bz2")]),
+            (Medicare3, vec![
+                PBIUrl::new("Medicare3", "Medicare3_1.csv.bz2")]),
+            (Motos, vec![
                 PBIUrl::new("Motos", "Motos_1.csv.bz2"),
-                PBIUrl::new("Motos", "Motos_2.csv.bz2"),
-            )),
-            (MulheresMil, vec!(
-                PBIUrl::new("MulheresMil", "MulheresMil_1.csv.bz2"))),
-            (NYC, vec!(
+                PBIUrl::new("Motos", "Motos_2.csv.bz2")]),
+            (MulheresMil, vec![
+                PBIUrl::new("MulheresMil", "MulheresMil_1.csv.bz2")]),
+            (NYC, vec![
                 PBIUrl::new("NYC", "NYC_1.csv.bz2"),
-                PBIUrl::new("NYC", "NYC_2.csv.bz2"),
-            )),
-            (PanCreactomy1, vec!(
-                PBIUrl::new("PanCreactomy1", "PanCreactomy1_1.csv.bz2"))),
-            (PanCreactomy2, vec!(
+                PBIUrl::new("NYC", "NYC_2.csv.bz2")]),
+            (PanCreactomy1, vec![
+                PBIUrl::new("PanCreactomy1", "PanCreactomy1_1.csv.bz2")]),
+            (PanCreactomy2, vec![
                 PBIUrl::new("PanCreactomy2", "PanCreactomy2_1.csv.bz2"),
-                PBIUrl::new("PanCreactomy2", "PanCreactomy2_2.csv.bz2"),
-            )),
-            (Physicians, vec!(
-                PBIUrl::new("Physicians", "Physicians_1.csv.bz2"))),
-            (Provider, vec!(
+                PBIUrl::new("PanCreactomy2", "PanCreactomy2_2.csv.bz2")]),
+            (Physicians, vec![
+                PBIUrl::new("Physicians", "Physicians_1.csv.bz2")]),
+            (Provider, vec![
                 PBIUrl::new("Provider", "Provider_1.csv.bz2"),
                 PBIUrl::new("Provider", "Provider_2.csv.bz2"),
                 PBIUrl::new("Provider", "Provider_3.csv.bz2"),
@@ -181,39 +172,33 @@ lazy_static::lazy_static! {
                 PBIUrl::new("Provider", "Provider_5.csv.bz2"),
                 PBIUrl::new("Provider", "Provider_6.csv.bz2"),
                 PBIUrl::new("Provider", "Provider_7.csv.bz2"),
-                PBIUrl::new("Provider", "Provider_8.csv.bz2"),
-            )),
-            (RealEstate1, vec!(
+                PBIUrl::new("Provider", "Provider_8.csv.bz2")]),
+            (RealEstate1, vec![
                 PBIUrl::new("RealEstate1", "RealEstate1_1.csv.bz2"),
-                PBIUrl::new("RealEstate1", "RealEstate1_2.csv.bz2"),
-            )),
-            (RealEstate2, vec!(
+                PBIUrl::new("RealEstate1", "RealEstate1_2.csv.bz2")]),
+            (RealEstate2, vec![
                 PBIUrl::new("RealEstate2", "RealEstate2_1.csv.bz2"),
                 PBIUrl::new("RealEstate2", "RealEstate2_2.csv.bz2"),
                 PBIUrl::new("RealEstate2", "RealEstate2_3.csv.bz2"),
                 PBIUrl::new("RealEstate2", "RealEstate2_4.csv.bz2"),
                 PBIUrl::new("RealEstate2", "RealEstate2_5.csv.bz2"),
                 PBIUrl::new("RealEstate2", "RealEstate2_6.csv.bz2"),
-                PBIUrl::new("RealEstate2", "RealEstate2_7.csv.bz2"),
-            )),
-            (Redfin1, vec!(
+                PBIUrl::new("RealEstate2", "RealEstate2_7.csv.bz2")]),
+            (Redfin1, vec![
                 PBIUrl::new("Redfin1", "Redfin1_1.csv.bz2"),
                 PBIUrl::new("Redfin1", "Redfin1_2.csv.bz2"),
                 PBIUrl::new("Redfin1", "Redfin1_3.csv.bz2"),
-                PBIUrl::new("Redfin1", "Redfin1_4.csv.bz2"),
-            )),
-            (Redfin2, vec!(
+                PBIUrl::new("Redfin1", "Redfin1_4.csv.bz2")]),
+            (Redfin2, vec![
                 PBIUrl::new("Redfin2", "Redfin2_1.csv.bz2"),
                 PBIUrl::new("Redfin2", "Redfin2_2.csv.bz2"),
-                PBIUrl::new("Redfin2", "Redfin2_3.csv.bz2"),
-            )),
-            (Redfin3, vec!(
+                PBIUrl::new("Redfin2", "Redfin2_3.csv.bz2")]),
+            (Redfin3, vec![
                 PBIUrl::new("Redfin3", "Redfin3_1.csv.bz2"),
-                PBIUrl::new("Redfin3", "Redfin3_2.csv.bz2"),
-            )),
-            (Redfin4, vec!(
-                PBIUrl::new("Redfin4", "Redfin4_1.csv.bz2"))),
-            (Rentabilidad, vec!(
+                PBIUrl::new("Redfin3", "Redfin3_2.csv.bz2")]),
+            (Redfin4, vec![
+                PBIUrl::new("Redfin4", "Redfin4_1.csv.bz2")]),
+            (Rentabilidad, vec![
                 PBIUrl::new("Rentabilidad", "Rentabilidad_1.csv.bz2"),
                 PBIUrl::new("Rentabilidad", "Rentabilidad_2.csv.bz2"),
                 PBIUrl::new("Rentabilidad", "Rentabilidad_3.csv.bz2"),
@@ -222,13 +207,11 @@ lazy_static::lazy_static! {
                 PBIUrl::new("Rentabilidad", "Rentabilidad_6.csv.bz2"),
                 PBIUrl::new("Rentabilidad", "Rentabilidad_7.csv.bz2"),
                 PBIUrl::new("Rentabilidad", "Rentabilidad_8.csv.bz2"),
-                PBIUrl::new("Rentabilidad", "Rentabilidad_9.csv.bz2"),
-            )),
-            (Romance, vec!(
+                PBIUrl::new("Rentabilidad", "Rentabilidad_9.csv.bz2")]),
+            (Romance, vec![
                 PBIUrl::new("Romance", "Romance_1.csv.bz2"),
-                PBIUrl::new("Romance", "Romance_2.csv.bz2"),
-            )),
-            (SalariesFrance, vec!(
+                PBIUrl::new("Romance", "Romance_2.csv.bz2")]),
+            (SalariesFrance, vec![
                 PBIUrl::new("SalariesFrance", "SalariesFrance_1.csv.bz2"),
                 PBIUrl::new("SalariesFrance", "SalariesFrance_2.csv.bz2"),
                 PBIUrl::new("SalariesFrance", "SalariesFrance_3.csv.bz2"),
@@ -241,9 +224,8 @@ lazy_static::lazy_static! {
                 PBIUrl::new("SalariesFrance", "SalariesFrance_10.csv.bz2"),
                 PBIUrl::new("SalariesFrance", "SalariesFrance_11.csv.bz2"),
                 PBIUrl::new("SalariesFrance", "SalariesFrance_12.csv.bz2"),
-                PBIUrl::new("SalariesFrance", "SalariesFrance_13.csv.bz2"),
-            )),
-            (TableroSistemaPenal, vec!(
+                PBIUrl::new("SalariesFrance", "SalariesFrance_13.csv.bz2")]),
+            (TableroSistemaPenal, vec![
                 PBIUrl::new("TableroSistemaPenal", "TableroSistemaPenal_1.csv.bz2"),
                 PBIUrl::new("TableroSistemaPenal", "TableroSistemaPenal_2.csv.bz2"),
                 PBIUrl::new("TableroSistemaPenal", "TableroSistemaPenal_3.csv.bz2"),
@@ -251,9 +233,8 @@ lazy_static::lazy_static! {
                 PBIUrl::new("TableroSistemaPenal", "TableroSistemaPenal_5.csv.bz2"),
                 PBIUrl::new("TableroSistemaPenal", "TableroSistemaPenal_6.csv.bz2"),
                 PBIUrl::new("TableroSistemaPenal", "TableroSistemaPenal_7.csv.bz2"),
-                PBIUrl::new("TableroSistemaPenal", "TableroSistemaPenal_8.csv.bz2"),
-            )),
-            (Taxpayer, vec!(
+                PBIUrl::new("TableroSistemaPenal", "TableroSistemaPenal_8.csv.bz2")]),
+            (Taxpayer, vec![
                 PBIUrl::new("Taxpayer", "Taxpayer_1.csv.bz2"),
                 PBIUrl::new("Taxpayer", "Taxpayer_2.csv.bz2"),
                 PBIUrl::new("Taxpayer", "Taxpayer_3.csv.bz2"),
@@ -263,40 +244,34 @@ lazy_static::lazy_static! {
                 PBIUrl::new("Taxpayer", "Taxpayer_7.csv.bz2"),
                 PBIUrl::new("Taxpayer", "Taxpayer_8.csv.bz2"),
                 PBIUrl::new("Taxpayer", "Taxpayer_9.csv.bz2"),
-                PBIUrl::new("Taxpayer", "Taxpayer_10.csv.bz2"),
-            )),
-            (Telco, vec!(
-                PBIUrl::new("Telco", "Telco_1.csv.bz2"))),
-            (TrainsUK1, vec!(
+                PBIUrl::new("Taxpayer", "Taxpayer_10.csv.bz2")]),
+            (Telco, vec![
+                PBIUrl::new("Telco", "Telco_1.csv.bz2")]),
+            (TrainsUK1, vec![
                 PBIUrl::new("TrainsUK1", "TrainsUK1_1.csv.bz2"),
                 PBIUrl::new("TrainsUK1", "TrainsUK1_2.csv.bz2"),
                 PBIUrl::new("TrainsUK1", "TrainsUK1_3.csv.bz2"),
-                PBIUrl::new("TrainsUK1", "TrainsUK1_4.csv.bz2"),
-            )),
-            (TrainsUK2, vec!(
+                PBIUrl::new("TrainsUK1", "TrainsUK1_4.csv.bz2")]),
+            (TrainsUK2, vec![
                 PBIUrl::new("TrainsUK2", "TrainsUK2_1.csv.bz2"),
-                PBIUrl::new("TrainsUK2", "TrainsUK2_2.csv.bz2"),
-            )),
-            (USCensus, vec!(
+                PBIUrl::new("TrainsUK2", "TrainsUK2_2.csv.bz2")]),
+            (USCensus, vec![
                 PBIUrl::new("USCensus", "USCensus_1.csv.bz2"),
                 PBIUrl::new("USCensus", "USCensus_2.csv.bz2"),
-                PBIUrl::new("USCensus", "USCensus_3.csv.bz2"),
-            )),
-            (Uberlandia, vec!(
-                PBIUrl::new("Uberlandia", "Uberlandia_1.csv.bz2"))),
-            (Wins, vec!(
+                PBIUrl::new("USCensus", "USCensus_3.csv.bz2")]),
+            (Uberlandia, vec![
+                PBIUrl::new("Uberlandia", "Uberlandia_1.csv.bz2")]),
+            (Wins, vec![
                 PBIUrl::new("Wins", "Wins_1.csv.bz2"),
                 PBIUrl::new("Wins", "Wins_2.csv.bz2"),
                 PBIUrl::new("Wins", "Wins_3.csv.bz2"),
-                PBIUrl::new("Wins", "Wins_4.csv.bz2"),
-            )),
-            (YaleLanguages, vec!(
+                PBIUrl::new("Wins", "Wins_4.csv.bz2")]),
+            (YaleLanguages, vec![
                 PBIUrl::new("YaleLanguages", "YaleLanguages_1.csv.bz2"),
                 PBIUrl::new("YaleLanguages", "YaleLanguages_2.csv.bz2"),
                 PBIUrl::new("YaleLanguages", "YaleLanguages_3.csv.bz2"),
                 PBIUrl::new("YaleLanguages", "YaleLanguages_4.csv.bz2"),
-                PBIUrl::new("YaleLanguages", "YaleLanguages_5.csv.bz2"),
-            )),
+                PBIUrl::new("YaleLanguages", "YaleLanguages_5.csv.bz2")]),
         ]);
 }
 

--- a/bench-vortex/src/reader.rs
+++ b/bench-vortex/src/reader.rs
@@ -17,6 +17,7 @@ use arrow_select::take::take_record_batch;
 use itertools::Itertools;
 use lance::Dataset;
 use lance_arrow_array::RecordBatch as LanceRecordBatch;
+use log::info;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
@@ -36,7 +37,7 @@ use vortex_schema::DType;
 use crate::compress_ctx;
 
 pub const BATCH_SIZE: usize = 65_536;
-const CSV_SCHEMA_SAMPLE_ROWS: usize = 1_000_000;
+const CSV_SCHEMA_SAMPLE_ROWS: usize = 10_000_000;
 const DEFAULT_DELIMITER: u8 = b',';
 
 pub fn open_vortex(path: &Path) -> VortexResult<ArrayRef> {
@@ -129,7 +130,7 @@ pub fn write_csv_as_parquet<W: Write + Send + Sync>(
     format: Format,
     write: W,
 ) -> VortexResult<()> {
-    println!(
+    info!(
         "Compressing {} to parquet",
         csv_path.as_path().to_str().unwrap()
     );

--- a/bench-vortex/src/reader.rs
+++ b/bench-vortex/src/reader.rs
@@ -36,7 +36,7 @@ use vortex_schema::DType;
 use crate::compress_ctx;
 
 pub const BATCH_SIZE: usize = 65_536;
-const CSV_SCHEMA_SAMPLE_ROWS: usize = 100;
+const CSV_SCHEMA_SAMPLE_ROWS: usize = 1_000_000;
 const DEFAULT_DELIMITER: u8 = b',';
 
 pub fn open_vortex(path: &Path) -> VortexResult<ArrayRef> {
@@ -129,6 +129,10 @@ pub fn write_csv_as_parquet<W: Write + Send + Sync>(
     format: Format,
     write: W,
 ) -> VortexResult<()> {
+    println!(
+        "Compressing {} to parquet",
+        csv_path.as_path().to_str().unwrap()
+    );
     let file_handle_for_schema_inference = File::open(csv_path.clone()).unwrap();
 
     // Infer the schema of the CSV file

--- a/bench-vortex/src/taxi_data.rs
+++ b/bench-vortex/src/taxi_data.rs
@@ -5,10 +5,10 @@ use vortex_error::VortexError;
 
 use crate::data_downloads::{data_vortex_uncompressed, download_data, parquet_to_lance};
 use crate::reader::rewrite_parquet_as_vortex;
-use crate::{data_path, idempotent};
+use crate::{idempotent, IdempotentPath};
 
 fn download_taxi_data() -> PathBuf {
-    let taxi_parquet_fpath = data_path("yellow-tripdata-2023-11.parquet");
+    let taxi_parquet_fpath = "yellow-tripdata-2023-11.parquet".to_idempotent_path();
     let taxi_data_url =
         "https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2023-11.parquet";
     download_data(taxi_parquet_fpath, taxi_data_url)

--- a/bench-vortex/src/taxi_data.rs
+++ b/bench-vortex/src/taxi_data.rs
@@ -4,11 +4,11 @@ use std::path::PathBuf;
 use vortex_error::VortexError;
 
 use crate::data_downloads::{data_vortex_uncompressed, download_data, parquet_to_lance};
-use crate::idempotent;
 use crate::reader::rewrite_parquet_as_vortex;
+use crate::{data_path, idempotent};
 
 fn download_taxi_data() -> PathBuf {
-    let taxi_parquet_fpath = "yellow-tripdata-2023-11.parquet";
+    let taxi_parquet_fpath = data_path("yellow-tripdata-2023-11.parquet");
     let taxi_data_url =
         "https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2023-11.parquet";
     download_data(taxi_parquet_fpath, taxi_data_url)


### PR DESCRIPTION
In order to ensure wide coverage of real-world data, we need some more sophisticated rails around curating and managing benchmark data. This PR:

- Adds a BenchmarkDataset trait with methods for downloading data, writing it to vortex and parquet
- Adds a PBI (public BI) implementation of the Benchmark Dataset trait with support for all ~50 PBI datasets

Resolves https://github.com/fulcrum-so/vortex/issues/219


FOLLOWUPS:
- [ ] Implement Date32 arrow data type (this type exists in the MLB & Redfin datasets, maybe more, I haven't tried all of them yet)
- [x] Add as_lance to BenchmarkDataset and implement for PBI (this PR got too big, didn't want to do this here)
- [x] Remove old medicare dataset implementation, no longer needed once we have as_lance for new impl