### PR TITLE
Comparison artifacts & analysis

### DIFF
--- a/bench-vortex/README.md
+++ b/bench-vortex/README.md
@@ -1,0 +1,12 @@
+# Benchmarks
+
+There are a number of benchmarks in this repository that can be run using the `cargo bench` command. These behave more
+or less how you'd expect.
+
+There are also some binaries that are not run by default, but produce some reporting artifacts that can be useful for comparing vortex compression to parquet and debugging vortex compression performance. These are:
+* _compress.rs_
+  * This binary compresses a file using vortex compression and writes the compressed file to disk where it can be examined or used for other operations.
+* _comparison.rs_
+  * This binary compresses a dataset using vortex compression and parquet, taking some stats on the compression performance of each run, and writes out these stats to a csv.
+    * This csv can then be loaded into duckdb and analyzed with the included comparison.sql script.
+

--- a/bench-vortex/src/bin/comparison.rs
+++ b/bench-vortex/src/bin/comparison.rs
@@ -1,0 +1,62 @@
+use bench_vortex::data_downloads::{BenchmarkDataset, FileType};
+use bench_vortex::parquet_utils::sum_column_chunk_sizes;
+use bench_vortex::public_bi_data::BenchmarkDatasets::PBI;
+use bench_vortex::public_bi_data::PBIDataset;
+use bench_vortex::{setup_logger, CompressionRunResults};
+use csv::Writer;
+use itertools::Itertools;
+use log::LevelFilter;
+
+pub fn main() {
+    setup_logger(LevelFilter::Info);
+    export_comparison_info(PBIDataset::Medicare1);
+}
+
+fn export_comparison_info(which_pbi: PBIDataset) {
+    let dataset = PBI(which_pbi);
+    let mut from_vortex = dataset
+        .compress_to_vortex()
+        .into_iter()
+        .flat_map(|(_, size)| size.to_results(which_pbi.dataset_name().to_string()))
+        .collect_vec();
+    let mut from_parquet: Vec<CompressionRunResults> = dataset
+        .list_files(FileType::Parquet)
+        .into_iter()
+        .flat_map(|file| {
+            sum_column_chunk_sizes(&file)
+                .unwrap()
+                .to_results(which_pbi.dataset_name().to_string())
+        })
+        .collect_vec();
+
+    from_parquet.append(&mut from_vortex);
+
+    let mut writer =
+        Writer::from_path(dataset.directory_location().join("comparison_results.csv")).unwrap();
+    writer
+        .write_record([
+            "dataset_name",
+            "file",
+            "file_type",
+            "column",
+            "column_type",
+            "uncompressed_size",
+            "total_compressed_size",
+            "column_compressed_size",
+        ])
+        .unwrap();
+
+    for result in from_parquet {
+        let record: Vec<String> = vec![
+            result.dataset_name,
+            result.file_name,
+            result.file_type.to_string(),
+            result.column_name,
+            result.column_type,
+            result.uncompressed_size.unwrap_or(0).to_string(),
+            result.total_compressed_size.unwrap_or(0).to_string(),
+            result.compressed_size.to_string(),
+        ];
+        writer.write_record(&record).unwrap();
+    }
+}

--- a/bench-vortex/src/comparison.sql
+++ b/bench-vortex/src/comparison.sql
@@ -1,0 +1,25 @@
+create table parquet as select * from comparison_results.csv
+                        where file_type =='parquet';
+create table vortex as select * from comparison_results.csv
+                       where file_type =='vortex';
+create table comparison as select vortex.dataset_name,
+                                  vortex.file,
+                                  vortex.column as column_name,
+                                  vortex.column_type,
+                                  vortex.column_compressed_size as vortex_column_size,
+                                  parquet.column_compressed_size as parquet_column_compressed_size,
+                                  vortex."column_compressed_size" / parquet."column_compressed_size" as relative_compression,
+                                  vortex."column_compressed_size"/vortex."total_compressed_size" as ratio_total_compressed_size,
+                                  vortex."total_compressed_size"/vortex."uncompressed_size" as vortex_column_compression_ratio,
+                                  vortex.uncompressed_size as total_uncompressed_size,
+                                  vortex.total_compressed_size as vortex_total_size,
+                                  parquet.total_compressed_size as parquet_total_size,
+                                  vortex.total_compressed_size/parquet.total_compressed_size as overall_rel_compress_ratio
+
+                           from
+                               vortex join parquet
+                                           on vortex.file == parquet.file
+        and vortex.column == parquet.column;
+
+
+select * from comparison where relative_compression < 1.0 order by column_name;

--- a/bench-vortex/src/parquet_utils.rs
+++ b/bench-vortex/src/parquet_utils.rs
@@ -1,0 +1,46 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+
+use parquet::file::reader::{FileReader, SerializedFileReader};
+use vortex_error::VortexResult;
+
+use crate::data_downloads::FileType;
+use crate::CompressionRunStats;
+
+pub fn sum_column_chunk_sizes(path: &Path) -> VortexResult<CompressionRunStats> {
+    let file = File::open(path)?;
+    let total_compressed_size = file.metadata()?.size();
+    let reader = SerializedFileReader::new(file).unwrap();
+    let metadata = reader.metadata();
+
+    let mut compressed_sizes: HashMap<u64, u64> = HashMap::new();
+
+    for i in 0..metadata.num_row_groups() {
+        let row_group_metadata = metadata.row_group(i);
+
+        // For each row group, iterate over its columns
+        for j in 0..row_group_metadata.num_columns() {
+            let column_chunk_metadata = row_group_metadata.column(j);
+            // Add the sizes to the corresponding entries in the hash maps
+            *compressed_sizes.entry(j as u64).or_insert(0) +=
+                column_chunk_metadata.compressed_size() as u64;
+        }
+    }
+
+    let stats = CompressionRunStats {
+        schema: None,
+        file_type: FileType::Parquet,
+        uncompressed_size: None,
+        total_compressed_size: Some(total_compressed_size),
+        compressed_sizes,
+        file_name: path
+            .with_extension("")
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .to_string(),
+    };
+    Ok(stats)
+}

--- a/bench-vortex/src/public_bi_data.rs
+++ b/bench-vortex/src/public_bi_data.rs
@@ -20,7 +20,7 @@ use crate::public_bi_data::PBIDataset::*;
 use crate::reader::{
     compress_csv_to_vortex, open_vortex, pbi_csv_format, write_csv_as_parquet, write_csv_to_vortex,
 };
-use crate::{idempotent, IdempotentPath};
+use crate::{idempotent, CompressionRunStats, IdempotentPath};
 
 lazy_static::lazy_static! {
     // NB: we do not expect this to change, otherwise we'd crawl the site and populate it at runtime
@@ -455,12 +455,13 @@ impl BenchmarkDataset for BenchmarkDatasets {
 
     /// Compresses the CSV files to Vortex format. Does NOT write any data to disk.
     /// Used for benchmarking.
-    fn compress_to_vortex(&self) -> Vec<ArrayRef> {
+    fn compress_to_vortex(&self) -> Vec<(ArrayRef, CompressionRunStats)> {
         self.list_files(FileType::Csv)
             .into_iter()
             .map(|csv_input| {
                 info!("Compressing {} to vortex", csv_input.to_str().unwrap());
-                compress_csv_to_vortex(csv_input, pbi_csv_format()).1
+                let (_, arr_ref, stats) = compress_csv_to_vortex(csv_input, pbi_csv_format());
+                (arr_ref, stats)
             })
             .collect_vec()
     }

--- a/vortex-array/src/scalar/utf8.rs
+++ b/vortex-array/src/scalar/utf8.rs
@@ -74,7 +74,7 @@ impl Display for Utf8Scalar {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self.value() {
             None => write!(f, "<none>"),
-            Some(v) => Display::fmt(v, f),
+            Some(v) => write!(f, "\"{}\"", v),
         }
     }
 }


### PR DESCRIPTION
This code is not very polished, but it is useful for enabling a simple workflow for comparative analysis between parquet and vortex compression performance, which tells us where to explore next w/r/t improving compression perf.

Includes: 
- Bin script to generate per-column compression stats for vortex and parquet
- Mechanism for serializing these stats to disc in a csv
- sql script to calculate some useful metrics from said csv