### PR TITLE
IPC Terminator

### DIFF
--- a/vortex-flatbuffers/src/lib.rs
+++ b/vortex-flatbuffers/src/lib.rs
@@ -1,8 +1,7 @@
 use std::io;
-use std::io::{Read, Write};
+use std::io::Write;
 
-use flatbuffers::{root, FlatBufferBuilder, Follow, Verifiable, WIPOffset};
-use vortex_error::{vortex_err, VortexResult};
+use flatbuffers::{FlatBufferBuilder, WIPOffset};
 
 pub trait FlatBufferRoot {}
 
@@ -32,35 +31,6 @@ impl<F: WriteFlatBuffer + FlatBufferRoot> FlatBufferToBytes for F {
         let root_offset = self.write_flatbuffer(&mut fbb);
         fbb.finish_minimal(root_offset);
         f(fbb.finished_data())
-    }
-}
-
-pub trait FlatBufferReader {
-    /// Returns Ok(None) if the reader has reached EOF.
-    fn read_message<'a, F>(&mut self, buffer: &'a mut Vec<u8>) -> VortexResult<Option<F>>
-    where
-        F: 'a + Follow<'a, Inner = F> + Verifiable;
-}
-
-impl<R: Read> FlatBufferReader for R {
-    fn read_message<'a, F>(&mut self, buffer: &'a mut Vec<u8>) -> VortexResult<Option<F>>
-    where
-        F: 'a + Follow<'a, Inner = F> + Verifiable,
-    {
-        let mut msg_size: [u8; 4] = [0; 4];
-        if let Err(e) = self.read_exact(&mut msg_size) {
-            return match e.kind() {
-                io::ErrorKind::UnexpectedEof => Ok(None),
-                _ => Err(vortex_err!(IOError: e)),
-            };
-        }
-        let msg_size = u32::from_le_bytes(msg_size) as u64;
-        if msg_size == 0 {
-            // Signifies the end of a stream of messages. For example, the end of an Array.
-            return Ok(None);
-        }
-        self.take(msg_size).read_to_end(buffer)?;
-        Ok(Some(root::<F>(buffer)?))
     }
 }
 

--- a/vortex-flatbuffers/src/lib.rs
+++ b/vortex-flatbuffers/src/lib.rs
@@ -56,7 +56,7 @@ impl<R: Read> FlatBufferReader for R {
         }
         let msg_size = u32::from_le_bytes(msg_size) as u64;
         if msg_size == 0 {
-            // FIXME(ngates): I think this is wrong.
+            // Signifies the end of a stream of messages. For example, the end of an Array.
             return Ok(None);
         }
         self.take(msg_size).read_to_end(buffer)?;

--- a/vortex-ipc/benches/ipc_take.rs
+++ b/vortex-ipc/benches/ipc_take.rs
@@ -33,6 +33,8 @@ fn ipc_take(c: &mut Criterion) {
             while let Some(array_chunk) = array_reader.next().unwrap() {
                 black_box(take(&array_chunk, &indices).unwrap());
             }
+            assert!(reader.next().unwrap().is_some());
+            assert!(reader.next().unwrap().is_none());
         });
     });
 }

--- a/vortex-ipc/benches/ipc_take.rs
+++ b/vortex-ipc/benches/ipc_take.rs
@@ -22,6 +22,7 @@ fn ipc_take(c: &mut Criterion) {
         let mut cursor = Cursor::new(&mut buffer);
         let mut writer = StreamWriter::try_new(&mut cursor, SerdeContext::default()).unwrap();
         writer.write_array(&data).unwrap();
+        writer.write_array(&data).unwrap();
     }
 
     c.bench_function("take_view", |b| {
@@ -29,8 +30,9 @@ fn ipc_take(c: &mut Criterion) {
             let mut cursor = Cursor::new(&buffer);
             let mut reader = StreamReader::try_new(&mut cursor).unwrap();
             let mut array_reader = reader.next().unwrap().unwrap();
-            let array_view = array_reader.next().unwrap().unwrap();
-            black_box(take(&array_view, &indices))
+            while let Some(array_chunk) = array_reader.next().unwrap() {
+                black_box(take(&array_chunk, &indices).unwrap());
+            }
         });
     });
 }

--- a/vortex-ipc/benches/ipc_take.rs
+++ b/vortex-ipc/benches/ipc_take.rs
@@ -22,7 +22,6 @@ fn ipc_take(c: &mut Criterion) {
         let mut cursor = Cursor::new(&mut buffer);
         let mut writer = StreamWriter::try_new(&mut cursor, SerdeContext::default()).unwrap();
         writer.write_array(&data).unwrap();
-        writer.write_array(&data).unwrap();
     }
 
     c.bench_function("take_view", |b| {
@@ -30,11 +29,8 @@ fn ipc_take(c: &mut Criterion) {
             let mut cursor = Cursor::new(&buffer);
             let mut reader = StreamReader::try_new(&mut cursor).unwrap();
             let mut array_reader = reader.next().unwrap().unwrap();
-            while let Some(array_chunk) = array_reader.next().unwrap() {
-                black_box(take(&array_chunk, &indices).unwrap());
-            }
-            assert!(reader.next().unwrap().is_some());
-            assert!(reader.next().unwrap().is_none());
+            let array_view = array_reader.next().unwrap().unwrap();
+            black_box(take(&array_view, &indices))
         });
     });
 }

--- a/vortex-ipc/src/lib.rs
+++ b/vortex-ipc/src/lib.rs
@@ -70,8 +70,10 @@ mod tests {
 
         let mut cursor = Cursor::new(Vec::new());
         let ctx = SerdeContext::default();
-        let mut writer = StreamWriter::try_new_unbuffered(&mut cursor, ctx).unwrap();
-        writer.write_array(&arr).unwrap();
+        {
+            let mut writer = StreamWriter::try_new_unbuffered(&mut cursor, ctx).unwrap();
+            writer.write_array(&arr).unwrap();
+        }
         cursor.flush().unwrap();
         cursor.set_position(0);
 

--- a/vortex-ipc/src/reader.rs
+++ b/vortex-ipc/src/reader.rs
@@ -290,7 +290,7 @@ mod tests {
         }
         // Push some extra bytes to test that the reader is well-behaved and doesn't read past the
         // end of the stream.
-        cursor.write(b"hello").unwrap();
+        let _ = cursor.write(b"hello").unwrap();
 
         cursor.set_position(0);
         {

--- a/vortex-ipc/src/reader.rs
+++ b/vortex-ipc/src/reader.rs
@@ -175,7 +175,7 @@ impl<'iter, R: Read> FallibleLendingIterator for StreamArrayReader<'iter, R> {
         // After reading the buffers we're now able to load the next message.
         let col_array = self
             .messages
-            .next(&mut self.read)?
+            .next(self.read)?
             .header_as_chunk()
             .unwrap()
             .array()
@@ -221,7 +221,7 @@ impl<R: Read> StreamMessageReader<R> {
             message: Vec::new(),
             prev_message: Vec::new(),
             finished: false,
-            phantom: PhantomData::default(),
+            phantom: PhantomData,
         };
         reader.load_next_message(read)?;
         Ok(reader)

--- a/vortex-ipc/src/reader.rs
+++ b/vortex-ipc/src/reader.rs
@@ -19,10 +19,8 @@ use crate::iter::{FallibleLendingIterator, FallibleLendingIteratorඞItem};
 #[allow(dead_code)]
 pub struct StreamReader<R: Read> {
     read: R,
+    messages: StreamMessageReader,
     ctx: SerdeContext,
-    next_message: Vec<u8>,
-    // Flag set when we encounter the stream termination marker.
-    finished: bool,
 }
 
 impl<R: Read> StreamReader<BufReader<R>> {
@@ -33,11 +31,11 @@ impl<R: Read> StreamReader<BufReader<R>> {
 
 impl<R: Read> StreamReader<R> {
     pub fn try_new_unbuffered(mut read: R) -> VortexResult<Self> {
-        let mut next_message = Vec::new();
-        if !read.read_length_prefixed(&mut next_message)? {
-            return Err(vortex_err!(InvalidSerde: "Unexpected EOF reading IPC format"));
+        let mut messages = StreamMessageReader::new();
+        if !messages.load_next_message(&mut read)? {
+            vortex_bail!("Unexpected EOF reading IPC format");
         }
-        let fb_msg = root::<Message>(&next_message)?;
+        let fb_msg = root::<Message>(messages.message())?;
         let fb_ctx = fb_msg.header_as_context().ok_or_else(
             || vortex_err!(InvalidSerde: "Expected IPC Context as first message in stream"),
         )?;
@@ -45,9 +43,8 @@ impl<R: Read> StreamReader<R> {
 
         Ok(Self {
             read,
+            messages,
             ctx,
-            next_message,
-            finished: false,
         })
     }
 
@@ -77,15 +74,15 @@ impl<R: Read> FallibleLendingIterator for StreamReader<R> {
     type Item<'next> =  StreamArrayReader<'next, R> where Self: 'next;
 
     fn next(&mut self) -> Result<Option<StreamArrayReader<'_, R>>, Self::Error> {
-        if self.finished || !self.read.read_length_prefixed(&mut self.next_message)? {
-            // End of stream
-            self.finished = true;
+        if !self.messages.load_next_message(self.read.by_ref())? {
             return Ok(None);
         }
-
-        let msg = root::<Message>(&self.next_message)?;
+        let msg = root::<Message>(self.messages.message())?;
         let schema = match msg.header_as_schema() {
-            None => return Ok(None),
+            None => {
+                self.messages.put_back();
+                return Ok(None);
+            }
             Some(header) => header,
         };
         // TODO(ngates): construct this from the SerdeContext.
@@ -102,8 +99,7 @@ impl<R: Read> FallibleLendingIterator for StreamReader<R> {
         Ok(Some(StreamArrayReader {
             ctx: &self.ctx,
             read: &mut self.read,
-            next_message: &mut self.next_message,
-            finished: &mut self.finished,
+            messages: &mut self.messages,
             dtype,
             buffers: vec![],
         }))
@@ -114,8 +110,7 @@ impl<R: Read> FallibleLendingIterator for StreamReader<R> {
 pub struct StreamArrayReader<'a, R: Read> {
     ctx: &'a SerdeContext,
     read: &'a mut R,
-    next_message: &'a mut Vec<u8>,
-    finished: &'a mut bool,
+    messages: &'a mut StreamMessageReader,
     dtype: DType,
     buffers: Vec<Buffer<'a>>,
 }
@@ -142,52 +137,44 @@ impl<'iter, R: Read> FallibleLendingIterator for StreamArrayReader<'iter, R> {
     type Error = VortexError;
     type Item<'next> = Array<'next> where Self: 'next;
 
-    fn next(&mut self) -> Result<Option<Array<'_>>, Self::Error> {
-        if *self.finished || !self.read.read_length_prefixed(&mut self.next_message)? {
-            // End of stream
-            *self.finished = true;
+    fn next<'next>(&'next mut self) -> Result<Option<Array<'next>>, Self::Error> {
+        if !self.messages.load_next_message(&mut self.read)? {
             return Ok(None);
         }
 
-        let msg = root::<Message>(&self.next_message)?;
-        let chunk_msg = match msg.header_as_chunk() {
-            None => return Ok(None),
-            Some(header) => header,
-        };
+        if !root::<Message>(self.messages.message())?
+            .header_as_chunk()
+            .is_some()
+        {
+            self.messages.put_back();
+            return Ok(None);
+        }
+
+        let chunk_msg = root::<Message>(self.messages.message())?
+            .header_as_chunk()
+            .unwrap();
         let col_array = chunk_msg
             .array()
             .ok_or_else(|| vortex_err!(InvalidSerde: "Chunk column missing Array"))
             .unwrap();
 
         // Read all the column's buffers
-        // TODO(ngates): read into a single buffer, then Arc::clone and slice
         self.buffers.clear();
         let mut offset = 0;
         for buffer in chunk_msg.buffers().unwrap_or_default().iter() {
-            let to_kill = buffer.offset() - offset;
-            io::copy(&mut self.read.take(to_kill), &mut io::sink()).unwrap();
+            self.read.skip(buffer.offset() - offset)?;
 
-            let buffer_length = buffer.length();
-            let mut bytes = Vec::with_capacity(buffer_length as usize);
-            let bytes_read = self
-                .read
-                .take(buffer.length())
-                .read_to_end(&mut bytes)
-                .unwrap();
-            if bytes_read < buffer_length as usize {
-                return Err(vortex_err!(InvalidSerde: "Unexpected EOF reading buffer"));
-            }
-
+            // TODO(ngates): read into a single buffer, then Arc::clone and slice
+            let mut bytes = Vec::with_capacity(buffer.length() as usize);
+            self.read.read_into(buffer.length(), &mut bytes)?;
             let arrow_buffer = ArrowBuffer::from_vec(bytes);
-            assert_eq!(arrow_buffer.len(), buffer_length as usize);
             self.buffers.push(Buffer::Owned(arrow_buffer));
 
             offset = buffer.offset() + buffer.length();
         }
 
         // Consume any remaining padding after the final buffer.
-        let to_kill = chunk_msg.buffer_size() - offset;
-        io::copy(&mut self.read.take(to_kill), &mut io::sink()).unwrap();
+        self.read.skip(chunk_msg.buffer_size() - offset)?;
 
         let view = ArrayView::try_new(&self.ctx, &self.dtype, col_array, self.buffers.as_slice())?;
 
@@ -198,30 +185,124 @@ impl<'iter, R: Read> FallibleLendingIterator for StreamArrayReader<'iter, R> {
     }
 }
 
-pub trait LengthPrefixedReader: Read {
-    fn read_length_prefixed(&mut self, buffer: &mut Vec<u8>) -> io::Result<bool> {
-        buffer.clear();
+pub trait ReadExtensions: Read {
+    /// Skip n bytes in the stream.
+    fn skip(&mut self, nbytes: u64) -> io::Result<()> {
+        io::copy(&mut self.take(nbytes), &mut io::sink())?;
+        Ok(())
+    }
+
+    /// Read exactly nbytes into the buffer.
+    fn read_into(&mut self, nbytes: u64, buffer: &mut Vec<u8>) -> io::Result<()> {
+        buffer.reserve_exact(nbytes as usize);
+        unsafe { buffer.set_len(nbytes as usize) };
+        self.read_exact(buffer.as_mut_slice())
+    }
+}
+
+impl<R: Read> ReadExtensions for R {}
+
+struct StreamMessageReader {
+    message: Vec<u8>,
+    peeked: bool,
+    finished: bool,
+}
+
+impl StreamMessageReader {
+    pub fn new() -> Self {
+        Self {
+            message: Vec::new(),
+            peeked: false,
+            finished: false,
+        }
+    }
+
+    pub fn message(&self) -> &[u8] {
+        &self.message
+    }
+
+    pub fn put_back(&mut self) {
+        self.peeked = true;
+    }
+
+    pub fn load_next_message<R: Read>(&mut self, read: &mut R) -> io::Result<bool> {
+        if self.finished {
+            return Ok(false);
+        }
+
+        if self.peeked {
+            self.peeked = false;
+            return Ok(true);
+        }
 
         let mut len_buf = [0u8; 4];
-        match self.read_exact(&mut len_buf) {
+        match read.read_exact(&mut len_buf) {
             Ok(_) => {}
-            Err(e) => match e.kind() {
-                io::ErrorKind::UnexpectedEof => return Ok(false),
-                _ => {
-                    return Err(e);
+            Err(e) => {
+                return match e.kind() {
+                    io::ErrorKind::UnexpectedEof => Ok(false),
+                    _ => Err(e),
                 }
-            },
+            }
         }
 
         let len = u32::from_le_bytes(len_buf);
         if len == u32::MAX {
             // Marker for no more messages.
+            self.finished = true;
             return Ok(false);
         }
 
-        self.take(len as u64).read_to_end(buffer)?;
+        self.message.clear();
+        self.message.reserve(len as usize);
+        unsafe { self.message.set_len(len as usize) };
+        read.read_exact(self.message.as_mut_slice())?;
         Ok(true)
     }
 }
 
-impl<R: Read> LengthPrefixedReader for R {}
+#[cfg(test)]
+mod tests {
+    use std::io::{Cursor, Read, Write};
+
+    use vortex::array::chunked::{Chunked, ChunkedArray};
+    use vortex::array::primitive::{Primitive, PrimitiveArray};
+    use vortex::{ArrayDType, ArrayDef, IntoArray, SerdeContext};
+
+    use crate::reader::StreamReader;
+    use crate::writer::StreamWriter;
+
+    #[test]
+    fn test_read_write() {
+        let array = PrimitiveArray::from(vec![0, 1, 2]).into_array();
+        let chunked_array =
+            ChunkedArray::try_new(vec![array.clone(), array.clone()], array.dtype().clone())
+                .unwrap()
+                .into_array();
+
+        let mut buffer = vec![];
+        let mut cursor = Cursor::new(&mut buffer);
+        {
+            let mut writer = StreamWriter::try_new(&mut cursor, SerdeContext::default()).unwrap();
+            writer.write_array(&array).unwrap();
+            writer.write_array(&chunked_array).unwrap();
+        }
+        // Push some extra bytes to test that the reader is well-behaved and doesn't read past the
+        // end of the stream.
+        cursor.write(b"hello").unwrap();
+
+        cursor.set_position(0);
+        {
+            let mut reader = StreamReader::try_new_unbuffered(&mut cursor).unwrap();
+            let first = reader.read_array().unwrap();
+            assert_eq!(first.encoding().id(), Primitive::ID);
+            let second = reader.read_array().unwrap();
+            assert_eq!(second.encoding().id(), Chunked::ID);
+        }
+        let _pos = cursor.position();
+        // Test our termination bytes exist
+        let mut terminator = [0u8; 5];
+        cursor.read_exact(&mut terminator).unwrap();
+        assert_eq!(&terminator, b"hello");
+    }
+}

--- a/vortex-ipc/src/reader.rs
+++ b/vortex-ipc/src/reader.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::io::{BufReader, Read};
 
 use arrow_buffer::Buffer as ArrowBuffer;
+use flatbuffers::root;
 use nougat::gat;
 use vortex::array::chunked::ChunkedArray;
 use vortex::array::composite::VORTEX_COMPOSITE_EXTENSIONS;
@@ -9,7 +10,7 @@ use vortex::buffer::Buffer;
 use vortex::stats::{ArrayStatistics, Stat};
 use vortex::{Array, ArrayView, IntoArray, OwnedArray, SerdeContext, ToArray, ToStatic};
 use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
-use vortex_flatbuffers::{FlatBufferReader, ReadFlatBuffer};
+use vortex_flatbuffers::ReadFlatBuffer;
 use vortex_schema::{DType, DTypeSerdeContext};
 
 use crate::flatbuffers::ipc::Message;
@@ -18,9 +19,10 @@ use crate::iter::{FallibleLendingIterator, FallibleLendingIteratorඞItem};
 #[allow(dead_code)]
 pub struct StreamReader<R: Read> {
     read: R,
-
-    pub(crate) ctx: SerdeContext,
-    // Optionally take a projection?
+    ctx: SerdeContext,
+    next_message: Vec<u8>,
+    // Flag set when we encounter the stream termination marker.
+    finished: bool,
 }
 
 impl<R: Read> StreamReader<BufReader<R>> {
@@ -31,16 +33,22 @@ impl<R: Read> StreamReader<BufReader<R>> {
 
 impl<R: Read> StreamReader<R> {
     pub fn try_new_unbuffered(mut read: R) -> VortexResult<Self> {
-        let mut msg_vec = Vec::new();
-        let fb_msg = read
-            .read_message::<Message>(&mut msg_vec)?
-            .ok_or_else(|| vortex_err!(InvalidSerde: "Unexpected EOF reading IPC format"))?;
+        let mut next_message = Vec::new();
+        if !read.read_length_prefixed(&mut next_message)? {
+            return Err(vortex_err!(InvalidSerde: "Unexpected EOF reading IPC format"));
+        }
+        let fb_msg = root::<Message>(&next_message)?;
         let fb_ctx = fb_msg.header_as_context().ok_or_else(
             || vortex_err!(InvalidSerde: "Expected IPC Context as first message in stream"),
         )?;
         let ctx: SerdeContext = fb_ctx.try_into()?;
 
-        Ok(Self { read, ctx })
+        Ok(Self {
+            read,
+            ctx,
+            next_message,
+            finished: false,
+        })
     }
 
     /// Read a single array from the IPC stream.
@@ -69,19 +77,17 @@ impl<R: Read> FallibleLendingIterator for StreamReader<R> {
     type Item<'next> =  StreamArrayReader<'next, R> where Self: 'next;
 
     fn next(&mut self) -> Result<Option<StreamArrayReader<'_, R>>, Self::Error> {
-        let mut fb_vec = Vec::new();
-        let msg = self.read.read_message::<Message>(&mut fb_vec)?;
-        if msg.is_none() {
-            // End of the stream
+        if self.finished || !self.read.read_length_prefixed(&mut self.next_message)? {
+            // End of stream
+            self.finished = true;
             return Ok(None);
         }
-        let msg = msg.unwrap();
 
-        // FIXME(ngates): parse the schema?
-        let schema = msg
-            .header_as_schema()
-            .ok_or_else(|| vortex_err!(InvalidSerde: "Expected IPC Schema message"))?;
-
+        let msg = root::<Message>(&self.next_message)?;
+        let schema = match msg.header_as_schema() {
+            None => return Ok(None),
+            Some(header) => header,
+        };
         // TODO(ngates): construct this from the SerdeContext.
         let dtype_ctx =
             DTypeSerdeContext::new(VORTEX_COMPOSITE_EXTENSIONS.iter().map(|e| e.id()).collect());
@@ -93,24 +99,25 @@ impl<R: Read> FallibleLendingIterator for StreamReader<R> {
         )
         .map_err(|e| vortex_err!(InvalidSerde: "Failed to parse DType: {}", e))?;
 
-        // Figure out how many columns we have and therefore how many buffers there?
         Ok(Some(StreamArrayReader {
-            read: &mut self.read,
             ctx: &self.ctx,
+            read: &mut self.read,
+            next_message: &mut self.next_message,
+            finished: &mut self.finished,
             dtype,
             buffers: vec![],
-            column_msg_buffer: vec![],
         }))
     }
 }
 
 #[allow(dead_code)]
 pub struct StreamArrayReader<'a, R: Read> {
-    read: &'a mut R,
     ctx: &'a SerdeContext,
+    read: &'a mut R,
+    next_message: &'a mut Vec<u8>,
+    finished: &'a mut bool,
     dtype: DType,
     buffers: Vec<Buffer<'a>>,
-    column_msg_buffer: Vec<u8>,
 }
 
 impl<'a, R: Read> StreamArrayReader<'a, R> {
@@ -136,20 +143,17 @@ impl<'iter, R: Read> FallibleLendingIterator for StreamArrayReader<'iter, R> {
     type Item<'next> = Array<'next> where Self: 'next;
 
     fn next(&mut self) -> Result<Option<Array<'_>>, Self::Error> {
-        self.column_msg_buffer.clear();
-        let msg = self
-            .read
-            .read_message::<Message>(&mut self.column_msg_buffer)?;
-        if msg.is_none() {
-            // End of the stream
+        if *self.finished || !self.read.read_length_prefixed(&mut self.next_message)? {
+            // End of stream
+            *self.finished = true;
             return Ok(None);
         }
-        let msg = msg.unwrap();
 
-        let chunk_msg = msg
-            .header_as_chunk()
-            .ok_or_else(|| vortex_err!(InvalidSerde: "Expected IPC Chunk message"))
-            .unwrap();
+        let msg = root::<Message>(&self.next_message)?;
+        let chunk_msg = match msg.header_as_chunk() {
+            None => return Ok(None),
+            Some(header) => header,
+        };
         let col_array = chunk_msg
             .array()
             .ok_or_else(|| vortex_err!(InvalidSerde: "Chunk column missing Array"))
@@ -185,7 +189,7 @@ impl<'iter, R: Read> FallibleLendingIterator for StreamArrayReader<'iter, R> {
         let to_kill = chunk_msg.buffer_size() - offset;
         io::copy(&mut self.read.take(to_kill), &mut io::sink()).unwrap();
 
-        let view = ArrayView::try_new(self.ctx, &self.dtype, col_array, self.buffers.as_slice())?;
+        let view = ArrayView::try_new(&self.ctx, &self.dtype, col_array, self.buffers.as_slice())?;
 
         // Validate it
         view.to_array().with_dyn(|_| Ok::<(), VortexError>(()))?;
@@ -193,3 +197,31 @@ impl<'iter, R: Read> FallibleLendingIterator for StreamArrayReader<'iter, R> {
         Ok(Some(view.into_array()))
     }
 }
+
+pub trait LengthPrefixedReader: Read {
+    fn read_length_prefixed(&mut self, buffer: &mut Vec<u8>) -> io::Result<bool> {
+        buffer.clear();
+
+        let mut len_buf = [0u8; 4];
+        match self.read_exact(&mut len_buf) {
+            Ok(_) => {}
+            Err(e) => match e.kind() {
+                io::ErrorKind::UnexpectedEof => return Ok(false),
+                _ => {
+                    return Err(e);
+                }
+            },
+        }
+
+        let len = u32::from_le_bytes(len_buf);
+        if len == u32::MAX {
+            // Marker for no more messages.
+            return Ok(false);
+        }
+
+        self.take(len as u64).read_to_end(buffer)?;
+        Ok(true)
+    }
+}
+
+impl<R: Read> LengthPrefixedReader for R {}

--- a/vortex-ipc/src/writer.rs
+++ b/vortex-ipc/src/writer.rs
@@ -73,12 +73,6 @@ impl<W: Write> StreamWriter<W> {
 
         Ok(())
     }
-
-    pub fn finish_array(&mut self) -> VortexResult<()> {
-        self.write
-            .write_all(&[0u8; ALIGNMENT])
-            .map_err(VortexError::from)
-    }
 }
 
 impl<W: Write> Drop for StreamWriter<W> {

--- a/vortex-ipc/src/writer.rs
+++ b/vortex-ipc/src/writer.rs
@@ -3,7 +3,7 @@ use std::io::{BufWriter, Write};
 use itertools::Itertools;
 use vortex::array::chunked::ChunkedArray;
 use vortex::{Array, ArrayDType, SerdeContext, ToArrayData};
-use vortex_error::{VortexError, VortexResult};
+use vortex_error::VortexResult;
 use vortex_flatbuffers::FlatBufferWriter;
 use vortex_schema::DType;
 

--- a/vortex-ipc/src/writer.rs
+++ b/vortex-ipc/src/writer.rs
@@ -39,11 +39,7 @@ impl<W: Write> StreamWriter<W> {
                 Ok(())
             }
             Err(_) => self.write_batch(array),
-        }?;
-        // TODO(ngates): rewrite the reader logic to avoid a terminator for each array, instead
-        //  just write one terminator at the end of the stream. This can be done by sharing a
-        //  message buffer between the StreamReader and StreamArrayReader.
-        self.finish_array()
+        }
     }
 
     pub fn write_schema(&mut self, dtype: &DType) -> VortexResult<()> {
@@ -87,7 +83,7 @@ impl<W: Write> StreamWriter<W> {
 
 impl<W: Write> Drop for StreamWriter<W> {
     fn drop(&mut self) {
-        // Terminate the stream with an empty message length.
-        let _ = self.finish_array();
+        // Terminate the stream
+        let _ = self.write.write_all(&[u8::MAX; 4]);
     }
 }


### PR DESCRIPTION
This PR adds an end-of-stream marker to the IPC format such that the format itself can be embedded within other streams without consuming any further bytes.

It also fixes a bug whereby an ArrayStreamReader would return an error if it saw anything but a ChunkMessage, which would occur whenever we wrote multiple arrays into a single stream. There is now a StreamMessageReader that essentially allows peeking at the next message in order to check if it should be processed.