### PR TITLE
Make DType::Struct a struct

### DIFF
--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -184,13 +184,13 @@ pub struct CompressionRunStats {
 
 impl CompressionRunStats {
     pub fn to_results(&self, dataset_name: String) -> Vec<CompressionRunResults> {
-        let DType::Struct(ns, fs) = &self.schema else {
+        let DType::Struct { names, dtypes } = &self.schema else {
             unreachable!()
         };
 
         self.compressed_sizes
             .iter()
-            .zip_eq(ns.iter().zip_eq(fs))
+            .zip_eq(names.iter().zip_eq(dtypes))
             .map(
                 |(&size, (column_name, column_type))| CompressionRunResults {
                     dataset_name: dataset_name.clone(),

--- a/bench-vortex/src/vortex_utils.rs
+++ b/bench-vortex/src/vortex_utils.rs
@@ -16,11 +16,11 @@ pub fn vortex_chunk_sizes(path: &Path) -> VortexResult<CompressionRunStats> {
     let file = File::open(path)?;
     let total_compressed_size = file.metadata()?.size();
     let vortex = open_vortex(path)?;
-    let DType::Struct(ns, _) = vortex.dtype() else {
+    let DType::Struct { names, .. } = vortex.dtype() else {
         unreachable!()
     };
 
-    let mut compressed_sizes = vec![0; ns.len()];
+    let mut compressed_sizes = vec![0; names.len()];
     let chunked_array = ChunkedArray::try_from(vortex).unwrap();
     for chunk in chunked_array.chunks() {
         let struct_arr = StructArray::try_from(chunk).unwrap();

--- a/vortex-array/src/array/composite/mod.rs
+++ b/vortex-array/src/array/composite/mod.rs
@@ -13,7 +13,7 @@ pub static VORTEX_COMPOSITE_EXTENSIONS: [&'static dyn CompositeExtension] = [..]
 pub fn find_extension(id: &str) -> Option<&'static dyn CompositeExtension> {
     VORTEX_COMPOSITE_EXTENSIONS
         .iter()
-        .find(|ext| ext.id().0 == id)
+        .find(|ext| ext.id().as_ref() == id)
         .copied()
 }
 

--- a/vortex-array/src/array/composite/typed.rs
+++ b/vortex-array/src/array/composite/typed.rs
@@ -88,7 +88,7 @@ macro_rules! impl_composite {
             pub struct [<$T Extension>];
 
             impl [<$T Extension>] {
-                pub const ID: CompositeID = CompositeID($id);
+                pub const ID: CompositeID = CompositeID::new($id);
 
                 pub fn dtype(nullability: Nullability) -> DType {
                     DType::Composite(Self::ID, nullability)

--- a/vortex-array/src/array/struct/mod.rs
+++ b/vortex-array/src/array/struct/mod.rs
@@ -19,25 +19,25 @@ pub struct StructMetadata {
 
 impl StructArray<'_> {
     pub fn child(&self, idx: usize) -> Option<Array> {
-        let DType::Struct(_, fields) = self.dtype() else {
+        let DType::Struct { dtypes, .. } = self.dtype() else {
             unreachable!()
         };
-        let dtype = fields.get(idx)?;
+        let dtype = dtypes.get(idx)?;
         self.array().child(idx, dtype)
     }
 
     pub fn names(&self) -> &FieldNames {
-        let DType::Struct(names, _fields) = self.dtype() else {
+        let DType::Struct { names, .. } = self.dtype() else {
             unreachable!()
         };
         names
     }
 
     pub fn fields(&self) -> &[DType] {
-        let DType::Struct(_names, fields) = self.dtype() else {
+        let DType::Struct { dtypes, .. } = self.dtype() else {
             unreachable!()
         };
-        fields.as_slice()
+        dtypes.as_slice()
     }
 
     pub fn nfields(&self) -> usize {
@@ -61,9 +61,9 @@ impl StructArray<'_> {
             vortex_bail!("Expected all struct fields to have length {}", length);
         }
 
-        let field_dtypes: Vec<_> = fields.iter().map(|d| d.dtype()).cloned().collect();
+        let dtypes: Vec<_> = fields.iter().map(|d| d.dtype()).cloned().collect();
         Self::try_from_parts(
-            DType::Struct(names, field_dtypes),
+            DType::Struct { names, dtypes },
             StructMetadata { length },
             fields.into_iter().map(|a| a.into_array_data()).collect(),
             HashMap::default(),

--- a/vortex-array/src/arrow/dtype.rs
+++ b/vortex-array/src/arrow/dtype.rs
@@ -40,18 +40,18 @@ impl TryFromArrowType<&DataType> for PType {
 
 impl FromArrowType<SchemaRef> for DType {
     fn from_arrow(value: SchemaRef) -> Self {
-        DType::Struct(
-            value
+        DType::Struct {
+            names: value
                 .fields()
                 .iter()
                 .map(|f| Arc::new(f.name().clone()))
                 .collect(),
-            value
+            dtypes: value
                 .fields()
                 .iter()
                 .map(|f| DType::from_arrow(f.as_ref()))
                 .collect_vec(),
-        )
+        }
     }
 }
 
@@ -81,13 +81,13 @@ impl FromArrowType<&Field> for DType {
             DataType::List(e) | DataType::LargeList(e) => {
                 List(Box::new(DType::from_arrow(e.as_ref())), nullability)
             }
-            DataType::Struct(f) => Struct(
-                f.iter().map(|f| Arc::new(f.name().clone())).collect(),
-                f.iter()
+            DataType::Struct(f) => Struct {
+                names: f.iter().map(|f| Arc::new(f.name().clone())).collect(),
+                dtypes: f
+                    .iter()
                     .map(|f| DType::from_arrow(f.as_ref()))
                     .collect_vec(),
-            ),
-            DataType::Decimal128(p, s) | DataType::Decimal256(p, s) => Decimal(*p, *s, nullability),
+            },
             _ => unimplemented!("Arrow data type not yet supported: {:?}", field.data_type()),
         }
     }

--- a/vortex-dtype/Cargo.toml
+++ b/vortex-dtype/Cargo.toml
@@ -21,7 +21,7 @@ half = { workspace = true }
 itertools = { workspace = true }
 linkme = { workspace = true }
 num-traits = { workspace = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true, optional = true, features = ["rc"] }
 thiserror = { workspace = true }
 vortex-error = { path = "../vortex-error" }
 vortex-flatbuffers = { path = "../vortex-flatbuffers" }

--- a/vortex-dtype/src/composite.rs
+++ b/vortex-dtype/src/composite.rs
@@ -1,0 +1,62 @@
+use std::fmt::{Display, Formatter};
+
+use linkme::distributed_slice;
+use serde::{Deserialize, Deserializer};
+use vortex_error::{vortex_err, VortexError};
+
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(::serde::Serialize))]
+pub struct CompositeID(&'static str);
+
+impl CompositeID {
+    pub const fn new(id: &'static str) -> Self {
+        Self(id)
+    }
+}
+
+impl<'a> TryFrom<&'a str> for CompositeID {
+    type Error = VortexError;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        find_composite_dtype(value)
+            .map(|cdt| CompositeID(cdt.id()))
+            .ok_or_else(|| vortex_err!("CompositeID not found for the given id: {}", value))
+    }
+}
+
+impl AsRef<str> for CompositeID {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl Display for CompositeID {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for CompositeID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        CompositeID::try_from(<&'de str>::deserialize(deserializer)?)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+pub trait CompositeDType {
+    fn id(&self) -> &'static str;
+}
+
+#[distributed_slice]
+pub static VORTEX_COMPOSITE_DTYPES: [&'static dyn CompositeDType] = [..];
+
+pub fn find_composite_dtype(id: &str) -> Option<&'static dyn CompositeDType> {
+    VORTEX_COMPOSITE_DTYPES
+        .iter()
+        .find(|ext| ext.id() == id)
+        .copied()
+}

--- a/vortex-dtype/src/composite.rs
+++ b/vortex-dtype/src/composite.rs
@@ -1,7 +1,6 @@
 use std::fmt::{Display, Formatter};
 
 use linkme::distributed_slice;
-use serde::{Deserialize, Deserializer};
 use vortex_error::{vortex_err, VortexError};
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
@@ -33,17 +32,6 @@ impl AsRef<str> for CompositeID {
 impl Display for CompositeID {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for CompositeID {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        CompositeID::try_from(<&'de str>::deserialize(deserializer)?)
-            .map_err(serde::de::Error::custom)
     }
 }
 

--- a/vortex-dtype/src/composite.rs
+++ b/vortex-dtype/src/composite.rs
@@ -26,7 +26,7 @@ impl<'a> TryFrom<&'a str> for CompositeID {
 
 impl AsRef<str> for CompositeID {
     fn as_ref(&self) -> &str {
-        self.0.as_ref()
+        self.0
     }
 }
 

--- a/vortex-dtype/src/deserialize.rs
+++ b/vortex-dtype/src/deserialize.rs
@@ -10,7 +10,7 @@ impl ReadFlatBuffer<()> for DType {
     type Source<'a> = fb::DType<'a>;
     type Error = VortexError;
 
-    fn read_flatbuffer(ctx: &(), fb: &Self::Source<'_>) -> Result<Self, Self::Error> {
+    fn read_flatbuffer(_ctx: &(), fb: &Self::Source<'_>) -> Result<Self, Self::Error> {
         match fb.type_type() {
             fb::Type::Null => Ok(DType::Null),
             fb::Type::Bool => Ok(DType::Bool(
@@ -31,7 +31,7 @@ impl ReadFlatBuffer<()> for DType {
             )),
             fb::Type::List => {
                 let fb_list = fb.type__as_list().unwrap();
-                let element_dtype = DType::read_flatbuffer(ctx, &fb_list.element_type().unwrap())?;
+                let element_dtype = DType::read_flatbuffer(&(), &fb_list.element_type().unwrap())?;
                 Ok(DType::List(
                     Box::new(element_dtype),
                     fb_list.nullability().try_into()?,
@@ -49,7 +49,7 @@ impl ReadFlatBuffer<()> for DType {
                     .fields()
                     .unwrap()
                     .iter()
-                    .map(|f| DType::read_flatbuffer(ctx, &f))
+                    .map(|f| DType::read_flatbuffer(&(), &f))
                     .collect::<VortexResult<Vec<_>>>()?;
                 Ok(DType::Struct { names, dtypes })
             }

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -16,7 +16,7 @@ pub type Metadata = Vec<u8>;
 pub enum DType {
     Null,
     Bool(Nullability),
-    #[serde(with = "primitive_serde")]
+    #[serde(with = "crate::serde::dtype_primitive")]
     Primitive(PType, Nullability),
     Utf8(Nullability),
     Binary(Nullability),
@@ -26,38 +26,6 @@ pub enum DType {
     },
     List(Box<DType>, Nullability),
     Composite(CompositeID, Nullability),
-}
-
-#[cfg(feature = "serde")]
-mod primitive_serde {
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    use crate::{Nullability, PType};
-
-    #[derive(Serialize, Deserialize)]
-    struct PrimitiveSerde {
-        ptype: PType,
-        n: Nullability,
-    }
-
-    pub fn serialize<S>(ptype: &PType, n: &Nullability, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        PrimitiveSerde {
-            ptype: *ptype,
-            n: *n,
-        }
-        .serialize(serializer)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<(PType, Nullability), D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let PrimitiveSerde { ptype, n } = PrimitiveSerde::deserialize(deserializer)?;
-        Ok((ptype, n))
-    }
 }
 
 impl DType {

--- a/vortex-dtype/src/lib.rs
+++ b/vortex-dtype/src/lib.rs
@@ -1,25 +1,16 @@
-use std::fmt::{Display, Formatter};
-
 pub use dtype::*;
 pub use half;
 pub use ptype::*;
 mod deserialize;
+pub use composite::*;
 mod dtype;
 mod ptype;
-mod serde;
+// mod serde;
+mod composite;
+mod nullability;
 mod serialize;
 
-pub use deserialize::*;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
-pub struct CompositeID(pub &'static str);
-
-impl Display for CompositeID {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
+pub use nullability::*;
 
 pub mod flatbuffers {
     #[allow(unused_imports)]

--- a/vortex-dtype/src/lib.rs
+++ b/vortex-dtype/src/lib.rs
@@ -3,11 +3,11 @@ pub use half;
 pub use ptype::*;
 mod deserialize;
 pub use composite::*;
-mod dtype;
-mod ptype;
-// mod serde;
 mod composite;
+mod dtype;
 mod nullability;
+mod ptype;
+mod serde;
 mod serialize;
 
 pub use nullability::*;

--- a/vortex-dtype/src/nullability.rs
+++ b/vortex-dtype/src/nullability.rs
@@ -1,0 +1,62 @@
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub enum Nullability {
+    #[default]
+    NonNullable,
+    Nullable,
+}
+
+impl From<bool> for Nullability {
+    fn from(value: bool) -> Self {
+        if value {
+            Nullability::Nullable
+        } else {
+            Nullability::NonNullable
+        }
+    }
+}
+
+impl From<Nullability> for bool {
+    fn from(value: Nullability) -> Self {
+        match value {
+            Nullability::NonNullable => false,
+            Nullability::Nullable => true,
+        }
+    }
+}
+
+impl Display for Nullability {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Nullability::NonNullable => write!(f, ""),
+            Nullability::Nullable => write!(f, "?"),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Nullability {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Nullability::NonNullable => serializer.serialize_bool(false),
+            Nullability::Nullable => serializer.serialize_bool(true),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Nullability {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(match bool::deserialize(deserializer)? {
+            true => Nullability::Nullable,
+            false => Nullability::NonNullable,
+        })
+    }
+}

--- a/vortex-dtype/src/nullability.rs
+++ b/vortex-dtype/src/nullability.rs
@@ -34,29 +34,3 @@ impl Display for Nullability {
         }
     }
 }
-
-#[cfg(feature = "serde")]
-impl serde::Serialize for Nullability {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        match self {
-            Nullability::NonNullable => serializer.serialize_bool(false),
-            Nullability::Nullable => serializer.serialize_bool(true),
-        }
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for Nullability {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        Ok(match bool::deserialize(deserializer)? {
-            true => Nullability::Nullable,
-            false => Nullability::NonNullable,
-        })
-    }
-}

--- a/vortex-dtype/src/serde.rs
+++ b/vortex-dtype/src/serde.rs
@@ -1,63 +1,7 @@
 #![cfg(feature = "serde")]
-/// We hand-write the serde implementation for DType so we can retain more ergonomic tuple variants.
-use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::{DType, Nullability};
-
-impl Serialize for DType {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match self {
-            DType::Null => serializer
-                .serialize_map(Some(1))?
-                .serialize_entry("type", "null"),
-            DType::Bool(n) => serializer
-                .serialize_map(Some(2))?
-                .serialize_entry("type", "null")?
-                .serialize_entry("n", n),
-            DType::Primitive(ptype, n) => serializer
-                .serialize_map(Some(3))?
-                .serialize_entry("type", "primitive")?
-                .serialize_entry("ptype", *ptype)?
-                .serialize_entry("n", n),
-            DType::Utf8(n) => serializer
-                .serialize_map(Some(2))?
-                .serialize_entry("type", "utf8")?
-                .serialize_entry("n", n),
-            DType::Binary(n) => serializer
-                .serialize_map(Some(2))?
-                .serialize_entry("type", "binary")?
-                .serialize_entry("n", n),
-            DType::Struct { names, dtypes } => serializer
-                .serialize_map(Some(3))?
-                .serialize_entry("type", "struct")?
-                .serialize_entry("names", names)?
-                .serialize_entry("dtypes", dtypes),
-            DType::List(element, n) => serializer
-                .serialize_map(Some(3))?
-                .serialize_entry("type", "primitive")?
-                .serialize_entry("element", element)?
-                .serialize_entry("n", n),
-            DType::Composite(id, n) => serializer
-                .serialize_map(Some(3))?
-                .serialize_entry("type", "composite")?
-                .serialize_entry("id", id)?
-                .serialize_entry("n", n),
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for DType {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        todo!()
-    }
-}
+use crate::{CompositeID, Nullability};
 
 impl Serialize for Nullability {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -80,5 +24,16 @@ impl<'de> Deserialize<'de> for Nullability {
             true => Nullability::Nullable,
             false => Nullability::NonNullable,
         })
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for CompositeID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        CompositeID::try_from(<&'de str>::deserialize(deserializer)?)
+            .map_err(serde::de::Error::custom)
     }
 }

--- a/vortex-dtype/src/serde.rs
+++ b/vortex-dtype/src/serde.rs
@@ -37,3 +37,36 @@ impl<'de> Deserialize<'de> for CompositeID {
             .map_err(serde::de::Error::custom)
     }
 }
+
+/// Implement custom serde to retain the ergonomics of a tuple enum variant.
+/// Essentially, we use this wrapper to name the fields of the DType::Primitive enum variant.
+pub mod dtype_primitive {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    use crate::{Nullability, PType};
+
+    #[derive(Serialize, Deserialize)]
+    struct PrimitiveSerde {
+        ptype: PType,
+        n: Nullability,
+    }
+
+    pub fn serialize<S>(ptype: &PType, n: &Nullability, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        PrimitiveSerde {
+            ptype: *ptype,
+            n: *n,
+        }
+        .serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<(PType, Nullability), D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let PrimitiveSerde { ptype, n } = PrimitiveSerde::deserialize(deserializer)?;
+        Ok((ptype, n))
+    }
+}

--- a/vortex-ipc/src/reader.rs
+++ b/vortex-ipc/src/reader.rs
@@ -7,7 +7,6 @@ use flatbuffers::{root, root_unchecked};
 use itertools::Itertools;
 use nougat::gat;
 use vortex::array::chunked::ChunkedArray;
-use vortex::array::composite::VORTEX_COMPOSITE_EXTENSIONS;
 use vortex::array::primitive::PrimitiveArray;
 use vortex::buffer::Buffer;
 use vortex::compute::search_sorted::{search_sorted, SearchSortedSide};
@@ -17,7 +16,7 @@ use vortex::stats::{ArrayStatistics, Stat};
 use vortex::{
     Array, ArrayDType, ArrayView, IntoArray, OwnedArray, SerdeContext, ToArray, ToStatic,
 };
-use vortex_dtype::{match_each_integer_ptype, DType, DTypeSerdeContext};
+use vortex_dtype::{match_each_integer_ptype, DType};
 use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
 use vortex_flatbuffers::ReadFlatBuffer;
 
@@ -103,11 +102,8 @@ impl<R: Read> FallibleLendingIterator for StreamReader<R> {
             .header_as_schema()
             .unwrap();
 
-        // TODO(ngates): construct this from the SerdeContext.
-        let dtype_ctx =
-            DTypeSerdeContext::new(VORTEX_COMPOSITE_EXTENSIONS.iter().map(|e| e.id()).collect());
         let dtype = DType::read_flatbuffer(
-            &dtype_ctx,
+            &(),
             &schema_msg
                 .dtype()
                 .ok_or_else(|| vortex_err!(InvalidSerde: "Schema missing DType"))?,

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -126,10 +126,9 @@ impl Scalar {
             DType::Null => NullScalar::new().into(),
             DType::Bool(_) => BoolScalar::none().into(),
             DType::Primitive(p, _) => PrimitiveScalar::none_from_ptype(*p).into(),
-            DType::Decimal(..) => unimplemented!("DecimalScalar"),
             DType::Utf8(_) => Utf8Scalar::none().into(),
             DType::Binary(_) => BinaryScalar::none().into(),
-            DType::Struct(..) => StructScalar::new(dtype.clone(), vec![]).into(),
+            DType::Struct { .. } => StructScalar::new(dtype.clone(), vec![]).into(),
             DType::List(..) => ListScalar::new(dtype.clone(), None).into(),
             DType::Composite(..) => unimplemented!("CompositeScalar"),
         }

--- a/vortex-scalar/src/serde.rs
+++ b/vortex-scalar/src/serde.rs
@@ -4,7 +4,7 @@ use flatbuffers::{root, FlatBufferBuilder, WIPOffset};
 use serde::de::Visitor;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use vortex_dtype::match_each_native_ptype;
-use vortex_dtype::{DTypeSerdeContext, Nullability};
+use vortex_dtype::Nullability;
 use vortex_error::{vortex_bail, VortexError};
 use vortex_flatbuffers::{FlatBufferRoot, FlatBufferToBytes, ReadFlatBuffer, WriteFlatBuffer};
 
@@ -90,14 +90,11 @@ impl WriteFlatBuffer for Scalar {
     }
 }
 
-impl ReadFlatBuffer<DTypeSerdeContext> for Scalar {
+impl ReadFlatBuffer<()> for Scalar {
     type Source<'a> = fb::Scalar<'a>;
     type Error = VortexError;
 
-    fn read_flatbuffer(
-        _ctx: &DTypeSerdeContext,
-        fb: &Self::Source<'_>,
-    ) -> Result<Self, Self::Error> {
+    fn read_flatbuffer(_ctx: &(), fb: &Self::Source<'_>) -> Result<Self, Self::Error> {
         let nullability = Nullability::from(fb.nullability());
         match fb.type_type() {
             fb::Type::Binary => {
@@ -153,7 +150,7 @@ impl Serialize for Scalar {
     }
 }
 
-struct ScalarDeserializer(DTypeSerdeContext);
+struct ScalarDeserializer;
 
 impl<'de> Visitor<'de> for ScalarDeserializer {
     type Value = Scalar;
@@ -167,7 +164,7 @@ impl<'de> Visitor<'de> for ScalarDeserializer {
         E: serde::de::Error,
     {
         let fb = root::<fb::Scalar>(v).map_err(E::custom)?;
-        Scalar::read_flatbuffer(&self.0, &fb).map_err(E::custom)
+        Scalar::read_flatbuffer(&(), &fb).map_err(E::custom)
     }
 }
 
@@ -177,8 +174,7 @@ impl<'de> Deserialize<'de> for Scalar {
     where
         D: Deserializer<'de>,
     {
-        let ctx = DTypeSerdeContext::new(vec![]);
-        deserializer.deserialize_bytes(ScalarDeserializer(ctx))
+        deserializer.deserialize_bytes(ScalarDeserializer)
     }
 }
 


### PR DESCRIPTION
This allows us to store e.g. a DType::Struct instead of just a DType when we want to ensure we have a struct dtype.

There are lots of FLUPs here related to #174 