### PR TITLE
Minimal expressions API for vortex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5118,6 +5118,7 @@ dependencies = [
 name = "vortex-expr"
 version = "0.1.0"
 dependencies = [
+ "serde",
  "vortex-dtype",
  "vortex-error",
  "vortex-scalar",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5115,6 +5115,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "vortex-expr"
+version = "0.1.0"
+dependencies = [
+ "vortex-dtype",
+ "vortex-error",
+ "vortex-scalar",
+]
+
+[[package]]
 name = "vortex-fastlanes"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "vortex-datetime-parts",
     "vortex-dict",
     "vortex-error",
+    "vortex-expr",
     "vortex-fastlanes",
     "vortex-flatbuffers",
     "vortex-ipc",

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -8,7 +8,8 @@ use DType::*;
 use crate::nullability::Nullability;
 use crate::{ExtDType, PType};
 
-pub type FieldNames = Arc<[Arc<str>]>;
+pub type FieldName = Arc<str>;
+pub type FieldNames = Arc<[FieldName]>;
 
 pub type Metadata = Vec<u8>;
 

--- a/vortex-dtype/src/ptype.rs
+++ b/vortex-dtype/src/ptype.rs
@@ -91,26 +91,6 @@ macro_rules! match_each_native_ptype {
 }
 
 #[macro_export]
-macro_rules! match_each_potentially_negative_ptype {
-    ($self:expr, | $_:tt $enc:ident | $($body:tt)*) => ({
-        macro_rules! __with__ {( $_ $enc:ident ) => ( $($body)* )}
-        use $crate::PType;
-        use $crate::half::f16;
-        match $self {
-            PType::I8 => __with__! { i8 },
-            PType::I16 => __with__! { i16 },
-            PType::I32 => __with__! { i32 },
-            PType::I64 => __with__! { i64 },
-            PType::F16 => __with__! { f16 },
-            PType::F32 => __with__! { f32 },
-            PType::F64 => __with__! { f64 },
-            _ => panic!("Unsupported ptype {}", $self),
-
-        }
-    })
-}
-
-#[macro_export]
 macro_rules! match_each_integer_ptype {
     ($self:expr, | $_:tt $enc:ident | $($body:tt)*) => ({
         macro_rules! __with__ {( $_ $enc:ident ) => ( $($body)* )}

--- a/vortex-dtype/src/ptype.rs
+++ b/vortex-dtype/src/ptype.rs
@@ -91,6 +91,26 @@ macro_rules! match_each_native_ptype {
 }
 
 #[macro_export]
+macro_rules! match_each_signed_ptype {
+    ($self:expr, | $_:tt $enc:ident | $($body:tt)*) => ({
+        macro_rules! __with__ {( $_ $enc:ident ) => ( $($body)* )}
+        use $crate::PType;
+        use $crate::half::f16;
+        match $self {
+            PType::I8 => __with__! { i8 },
+            PType::I16 => __with__! { i16 },
+            PType::I32 => __with__! { i32 },
+            PType::I64 => __with__! { i64 },
+            PType::F16 => __with__! { f16 },
+            PType::F32 => __with__! { f32 },
+            PType::F64 => __with__! { f64 },
+            _ => panic!("Unsupported ptype {}", $self),
+
+        }
+    })
+}
+
+#[macro_export]
 macro_rules! match_each_integer_ptype {
     ($self:expr, | $_:tt $enc:ident | $($body:tt)*) => ({
         macro_rules! __with__ {( $_ $enc:ident ) => ( $($body)* )}

--- a/vortex-dtype/src/ptype.rs
+++ b/vortex-dtype/src/ptype.rs
@@ -91,7 +91,7 @@ macro_rules! match_each_native_ptype {
 }
 
 #[macro_export]
-macro_rules! match_each_signed_ptype {
+macro_rules! match_each_potentially_negative_ptype {
     ($self:expr, | $_:tt $enc:ident | $($body:tt)*) => ({
         macro_rules! __with__ {( $_ $enc:ident ) => ( $($body)* )}
         use $crate::PType;

--- a/vortex-expr/Cargo.toml
+++ b/vortex-expr/Cargo.toml
@@ -15,9 +15,10 @@ rust-version = { workspace = true }
 workspace = true
 
 [dependencies]
-vortex-dtype = { path = "../vortex-dtype" }
+vortex-dtype = { path = "../vortex-dtype", features = ["serde"] }
 vortex-error = { path = "../vortex-error" }
-vortex-scalar = { path = "../vortex-scalar" }
+vortex-scalar = { path = "../vortex-scalar", features = ["serde"] }
+serde = { version = "1.0.200", features = ["derive"] }
 
 
 [dev-dependencies]

--- a/vortex-expr/Cargo.toml
+++ b/vortex-expr/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "vortex-expr"
+version = { workspace = true }
+description = "Vortex Expressions"
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+keywords = { workspace = true }
+include = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
+
+[lints]
+workspace = true
+
+[dependencies]
+vortex-dtype = { path = "../vortex-dtype" }
+vortex-error = { path = "../vortex-error" }
+vortex-scalar = { path = "../vortex-scalar" }
+
+
+[dev-dependencies]

--- a/vortex-expr/README.md
+++ b/vortex-expr/README.md
@@ -1,7 +1,6 @@
 # Vortex Expressions
 
-Expressions for querying vortex arrays, designed to express a minimal
-superset of the row predicates that can be pushed down to vortex metadata.
+A crate defining serializable predicate expressions. Used predominantly for filter push-down.
 
 Takes inspiration from postgres https://www.postgresql.org/docs/current/sql-expressions.html
 and datafusion https://github.com/apache/datafusion/tree/5fac581efbaffd0e6a9edf931182517524526afd/datafusion/expr

--- a/vortex-expr/README.md
+++ b/vortex-expr/README.md
@@ -1,0 +1,8 @@
+# Vortex Expressions
+
+Expressions for querying vortex arrays. The query algebra is designed to express a minimal
+superset of linear operations that can be pushed down to vortex metadata. Conversely, not all
+operations that can be expressed in this algebra can be pushed down to metadata.
+
+Takes inspiration from postgres https://www.postgresql.org/docs/current/sql-expressions.html
+and datafusion https://github.com/apache/datafusion/tree/5fac581efbaffd0e6a9edf931182517524526afd/datafusion/expr

--- a/vortex-expr/README.md
+++ b/vortex-expr/README.md
@@ -1,8 +1,7 @@
 # Vortex Expressions
 
-Expressions for querying vortex arrays. The query algebra is designed to express a minimal
-superset of linear operations that can be pushed down to vortex metadata. Conversely, not all
-operations that can be expressed in this algebra can be pushed down to metadata.
+Expressions for querying vortex arrays, designed to express a minimal
+superset of the row predicates that can be pushed down to vortex metadata.
 
 Takes inspiration from postgres https://www.postgresql.org/docs/current/sql-expressions.html
 and datafusion https://github.com/apache/datafusion/tree/5fac581efbaffd0e6a9edf931182517524526afd/datafusion/expr

--- a/vortex-expr/src/display.rs
+++ b/vortex-expr/src/display.rs
@@ -1,0 +1,160 @@
+use core::fmt;
+use std::fmt::{Display, Formatter};
+
+use vortex_dtype::{match_each_native_ptype, DType};
+use vortex_scalar::{BoolScalar, PrimitiveScalar};
+
+use crate::expressions::{BinaryExpr, Expr};
+use crate::operators::{Associativity, Operator};
+use crate::scalar::ScalarDisplayWrapper;
+
+impl Display for Expr {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Expr::BinaryExpr(expr) => write!(f, "{expr}"),
+            Expr::Field(d) => write!(f, "{d}"),
+            Expr::Literal(v) => {
+                let wrapped = ScalarDisplayWrapper(v);
+                write!(f, "{wrapped}")
+            }
+            Expr::Not(expr) => write!(f, "NOT {expr}"),
+            Expr::Minus(expr) => write!(f, "(- {expr})"),
+            Expr::IsNull(expr) => write!(f, "{expr} IS NULL"),
+        }
+    }
+}
+
+enum Side {
+    Left,
+    Right,
+}
+
+impl Display for BinaryExpr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fn write_inner(
+            f: &mut Formatter<'_>,
+            outer: &Expr,
+            outer_op: Operator,
+            side: Side,
+        ) -> fmt::Result {
+            if let Expr::BinaryExpr(inner) = outer {
+                let inner_op_precedence = inner.op.precedence();
+                // if the inner operator has higher precedence than the outer expression,
+                // wrap it in parentheses to prevent inversion of priority
+                if inner_op_precedence > outer_op.precedence() ||
+                    // if the inner and outer operators have the same precedence, we need to
+                    // account for operator associativity when determining grouping
+                    (inner_op_precedence == outer_op.precedence() &&
+                        match side {
+                            Side::Left => {
+                                outer_op.associativity() == Associativity::Left
+                            }
+                            Side::Right => {
+                                outer_op.associativity() == Associativity::Right
+                            }
+                        })
+                {
+                    write!(f, "({inner})")?;
+                } else {
+                    write!(f, "{inner}")?;
+                }
+            } else if let Expr::Literal(scalar) = outer {
+                // use alternative formatting for scalars
+                let wrapped = ScalarDisplayWrapper(scalar);
+                write!(f, "{wrapped}")?;
+            } else {
+                write!(f, "{outer}")?;
+            }
+            Ok(())
+        }
+
+        write_inner(f, self.left.as_ref(), self.op, Side::Left)?;
+        write!(f, " {} ", self.op)?;
+        write_inner(f, self.right.as_ref(), self.op, Side::Right)
+    }
+}
+
+/// Alternative display for scalars
+impl Display for ScalarDisplayWrapper<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self.0.dtype() {
+            DType::Null => write!(f, "null"),
+            DType::Bool(_) => match BoolScalar::try_from(self.0).expect("bool").value() {
+                None => write!(f, "null"),
+                Some(b) => write!(f, "{}", b),
+            },
+            DType::Primitive(ptype, _) => match_each_native_ptype!(ptype, |$T| {
+                match PrimitiveScalar::try_from(self.0).expect("primitive").typed_value::<$T>() {
+                    None => write!(f, "null"),
+                    Some(v) => write!(f, "{}{}", v,  std::any::type_name::<$T>()),
+                }
+            }),
+            DType::Utf8(_) => todo!(),
+            DType::Binary(_) => todo!(),
+            DType::Struct(..) => todo!(),
+            DType::List(..) => todo!(),
+            DType::Extension(..) => todo!(),
+        }
+    }
+}
+
+impl Display for Operator {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let display = match &self {
+            Operator::And => "AND",
+            Operator::Or => "OR",
+            Operator::EqualTo => "=",
+            Operator::NotEqualTo => "!=",
+            Operator::GreaterThan => ">",
+            Operator::GreaterThanOrEqualTo => ">=",
+            Operator::LessThan => "<",
+            Operator::LessThanOrEqualTo => "<=",
+            Operator::Plus => "+",
+            Operator::Minus | Operator::UnaryMinus => "-",
+            Operator::Multiplication => "*",
+            Operator::Division => "/",
+            Operator::Modulo => "%",
+        };
+        write!(f, "{display}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::expression_fns::{equals, field};
+    use crate::literal::lit;
+
+    #[test]
+    fn test_formatting() {
+        // Addition
+        assert_eq!(format!("{}", lit(1u32) + lit(2u32)), "1u32 + 2u32");
+        // Subtraction
+        assert_eq!(format!("{}", lit(1u32) - lit(2u32)), "1u32 - 2u32");
+        // Multiplication
+        assert_eq!(format!("{}", lit(1u32) * lit(2u32)), "1u32 * 2u32");
+        // Division
+        assert_eq!(format!("{}", lit(1u32) / lit(2u32)), "1u32 / 2u32");
+        // Modulus
+        assert_eq!(format!("{}", lit(1u32) % lit(2u32)), "1u32 % 2u32");
+        // Negate
+        assert_eq!(format!("{}", -lit(1u32)), "(- 1u32)");
+
+        // And
+        let string = format!("{}", lit(true).and(lit(false)));
+        assert_eq!(string, "true AND false");
+        // Or
+        let string = format!("{}", lit(true).or(lit(false)));
+        assert_eq!(string, "true OR false");
+        // Not
+        let string = format!("{}", !lit(1u32));
+        assert_eq!(string, "NOT 1u32");
+    }
+
+    #[test]
+    fn test_format_respects_operator_associativity() {
+        let left = field("id").eq(lit(1));
+        let right = field("id2").eq(-lit(2));
+        let s = format!("{}", equals(left, right));
+        assert_eq!(s, "id = 1i32 = (id2 = (- 2i32))")
+    }
+}

--- a/vortex-expr/src/display.rs
+++ b/vortex-expr/src/display.rs
@@ -11,7 +11,7 @@ use crate::scalar::ScalarDisplayWrapper;
 impl Display for Expr {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            Expr::BinaryExpr(expr) => write!(f, "{expr}"),
+            Expr::Binary(expr) => write!(f, "{expr}"),
             Expr::Field(d) => write!(f, "{d}"),
             Expr::Literal(v) => {
                 let wrapped = ScalarDisplayWrapper(v);
@@ -37,7 +37,7 @@ impl Display for BinaryExpr {
             outer_op: Operator,
             side: Side,
         ) -> fmt::Result {
-            if let Expr::BinaryExpr(inner) = outer {
+            if let Expr::Binary(inner) = outer {
                 let inner_op_precedence = inner.op.precedence();
                 // if the inner operator has higher precedence than the outer expression,
                 // wrap it in parentheses to prevent inversion of priority

--- a/vortex-expr/src/display.rs
+++ b/vortex-expr/src/display.rs
@@ -18,7 +18,6 @@ impl Display for Expr {
                 write!(f, "{wrapped}")
             }
             Expr::Not(expr) => write!(f, "NOT {expr}"),
-            Expr::Minus(expr) => write!(f, "(- {expr})"),
             Expr::IsNull(expr) => write!(f, "{expr} IS NULL"),
         }
     }
@@ -109,11 +108,6 @@ impl Display for Operator {
             Operator::GreaterThanOrEqualTo => ">=",
             Operator::LessThan => "<",
             Operator::LessThanOrEqualTo => "<=",
-            Operator::Plus => "+",
-            Operator::Minus | Operator::UnaryMinus => "-",
-            Operator::Multiplication => "*",
-            Operator::Division => "/",
-            Operator::Modulo => "%",
         };
         write!(f, "{display}")
     }
@@ -126,19 +120,6 @@ mod tests {
 
     #[test]
     fn test_formatting() {
-        // Addition
-        assert_eq!(format!("{}", lit(1u32) + lit(2u32)), "1u32 + 2u32");
-        // Subtraction
-        assert_eq!(format!("{}", lit(1u32) - lit(2u32)), "1u32 - 2u32");
-        // Multiplication
-        assert_eq!(format!("{}", lit(1u32) * lit(2u32)), "1u32 * 2u32");
-        // Division
-        assert_eq!(format!("{}", lit(1u32) / lit(2u32)), "1u32 / 2u32");
-        // Modulus
-        assert_eq!(format!("{}", lit(1u32) % lit(2u32)), "1u32 % 2u32");
-        // Negate
-        assert_eq!(format!("{}", -lit(1u32)), "(- 1u32)");
-
         // And
         let string = format!("{}", lit(true).and(lit(false)));
         assert_eq!(string, "true AND false");
@@ -153,8 +134,8 @@ mod tests {
     #[test]
     fn test_format_respects_operator_associativity() {
         let left = field("id").eq(lit(1));
-        let right = field("id2").eq(-lit(2));
+        let right = field("id2").eq(lit(2));
         let s = format!("{}", equals(left, right));
-        assert_eq!(s, "id = 1i32 = (id2 = (- 2i32))")
+        assert_eq!(s, "id = 1i32 = (id2 = 2i32)")
     }
 }

--- a/vortex-expr/src/expression_fns.rs
+++ b/vortex-expr/src/expression_fns.rs
@@ -1,21 +1,20 @@
+#![allow(dead_code)]
+
 use vortex_dtype::FieldName;
 
 use crate::expressions::BinaryExpr;
 use crate::expressions::Expr;
 use crate::operators::Operator;
 
-#[allow(dead_code)]
 pub fn binary_expr(left: Expr, op: Operator, right: Expr) -> Expr {
     Expr::Binary(BinaryExpr::new(Box::new(left), op, Box::new(right)))
 }
 
 /// Create a field expression based on a qualified field name.
-#[allow(dead_code)]
 pub fn field(field: impl Into<FieldName>) -> Expr {
     Expr::Field(field.into())
 }
 
-#[allow(dead_code)]
 pub fn equals(left: Expr, right: Expr) -> Expr {
     Expr::Binary(BinaryExpr::new(
         Box::new(left),
@@ -24,7 +23,6 @@ pub fn equals(left: Expr, right: Expr) -> Expr {
     ))
 }
 
-#[allow(dead_code)]
 pub fn and(left: Expr, right: Expr) -> Expr {
     Expr::Binary(BinaryExpr::new(
         Box::new(left),
@@ -33,7 +31,6 @@ pub fn and(left: Expr, right: Expr) -> Expr {
     ))
 }
 
-#[allow(dead_code)]
 pub fn or(left: Expr, right: Expr) -> Expr {
     Expr::Binary(BinaryExpr::new(
         Box::new(left),

--- a/vortex-expr/src/expression_fns.rs
+++ b/vortex-expr/src/expression_fns.rs
@@ -1,0 +1,43 @@
+use vortex_dtype::FieldName;
+
+use crate::expressions::BinaryExpr;
+use crate::expressions::Expr;
+use crate::operators::Operator;
+
+#[allow(dead_code)]
+pub fn binary_expr(left: Expr, op: Operator, right: Expr) -> Expr {
+    Expr::BinaryExpr(BinaryExpr::new(Box::new(left), op, Box::new(right)))
+}
+
+/// Create a field expression based on a qualified field name.
+#[allow(dead_code)]
+pub fn field(field: impl Into<FieldName>) -> Expr {
+    Expr::Field(field.into())
+}
+
+#[allow(dead_code)]
+pub fn equals(left: Expr, right: Expr) -> Expr {
+    Expr::BinaryExpr(BinaryExpr::new(
+        Box::new(left),
+        Operator::EqualTo,
+        Box::new(right),
+    ))
+}
+
+#[allow(dead_code)]
+pub fn and(left: Expr, right: Expr) -> Expr {
+    Expr::BinaryExpr(BinaryExpr::new(
+        Box::new(left),
+        Operator::And,
+        Box::new(right),
+    ))
+}
+
+#[allow(dead_code)]
+pub fn or(left: Expr, right: Expr) -> Expr {
+    Expr::BinaryExpr(BinaryExpr::new(
+        Box::new(left),
+        Operator::Or,
+        Box::new(right),
+    ))
+}

--- a/vortex-expr/src/expression_fns.rs
+++ b/vortex-expr/src/expression_fns.rs
@@ -6,7 +6,7 @@ use crate::operators::Operator;
 
 #[allow(dead_code)]
 pub fn binary_expr(left: Expr, op: Operator, right: Expr) -> Expr {
-    Expr::BinaryExpr(BinaryExpr::new(Box::new(left), op, Box::new(right)))
+    Expr::Binary(BinaryExpr::new(Box::new(left), op, Box::new(right)))
 }
 
 /// Create a field expression based on a qualified field name.
@@ -17,7 +17,7 @@ pub fn field(field: impl Into<FieldName>) -> Expr {
 
 #[allow(dead_code)]
 pub fn equals(left: Expr, right: Expr) -> Expr {
-    Expr::BinaryExpr(BinaryExpr::new(
+    Expr::Binary(BinaryExpr::new(
         Box::new(left),
         Operator::EqualTo,
         Box::new(right),
@@ -26,7 +26,7 @@ pub fn equals(left: Expr, right: Expr) -> Expr {
 
 #[allow(dead_code)]
 pub fn and(left: Expr, right: Expr) -> Expr {
-    Expr::BinaryExpr(BinaryExpr::new(
+    Expr::Binary(BinaryExpr::new(
         Box::new(left),
         Operator::And,
         Box::new(right),
@@ -35,7 +35,7 @@ pub fn and(left: Expr, right: Expr) -> Expr {
 
 #[allow(dead_code)]
 pub fn or(left: Expr, right: Expr) -> Expr {
-    Expr::BinaryExpr(BinaryExpr::new(
+    Expr::Binary(BinaryExpr::new(
         Box::new(left),
         Operator::Or,
         Box::new(right),

--- a/vortex-expr/src/expressions.rs
+++ b/vortex-expr/src/expressions.rs
@@ -1,0 +1,86 @@
+use vortex_dtype::FieldName;
+use vortex_scalar::Scalar;
+
+use crate::expression_fns::binary_expr;
+use crate::operators::Operator;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Expr {
+    /// A binary expression such as "duration_seconds == 100"
+    BinaryExpr(BinaryExpr),
+
+    /// A named reference to a qualified field in a dtype.
+    Field(FieldName),
+
+    /// True if argument is NULL, false otherwise. This expression itself is never NULL.
+    IsNull(Box<Expr>),
+
+    /// A constant scalar value.
+    Literal(Scalar),
+
+    /// Additive inverse of an expression. The expression's type must be numeric.
+    Minus(Box<Expr>),
+
+    /// Negation of an expression. The expression's type must be a boolean.
+    Not(Box<Expr>),
+}
+
+impl Expr {
+    // binary logic
+
+    pub fn and(self, other: Expr) -> Expr {
+        binary_expr(self, Operator::And, other)
+    }
+
+    pub fn or(self, other: Expr) -> Expr {
+        binary_expr(self, Operator::Or, other)
+    }
+
+    // comparisons
+
+    pub fn eq(self, other: Expr) -> Expr {
+        binary_expr(self, Operator::EqualTo, other)
+    }
+
+    pub fn not_eq(self, other: Expr) -> Expr {
+        binary_expr(self, Operator::NotEqualTo, other)
+    }
+
+    pub fn gt(self, other: Expr) -> Expr {
+        binary_expr(self, Operator::GreaterThan, other)
+    }
+
+    pub fn gt_eq(self, other: Expr) -> Expr {
+        binary_expr(self, Operator::GreaterThanOrEqualTo, other)
+    }
+
+    pub fn lt(self, other: Expr) -> Expr {
+        binary_expr(self, Operator::LessThan, other)
+    }
+
+    pub fn lt_eq(self, other: Expr) -> Expr {
+        binary_expr(self, Operator::LessThanOrEqualTo, other)
+    }
+
+    // misc
+    pub fn is_null(self) -> Expr {
+        Expr::IsNull(Box::new(self))
+    }
+
+    pub fn minus(self) -> Self {
+        Expr::Minus(Box::new(self))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct BinaryExpr {
+    pub left: Box<Expr>,
+    pub op: Operator,
+    pub right: Box<Expr>,
+}
+
+impl BinaryExpr {
+    pub fn new(left: Box<Expr>, op: Operator, right: Box<Expr>) -> Self {
+        Self { left, op, right }
+    }
+}

--- a/vortex-expr/src/expressions.rs
+++ b/vortex-expr/src/expressions.rs
@@ -1,10 +1,11 @@
+use serde::{Deserialize, Serialize};
 use vortex_dtype::FieldName;
 use vortex_scalar::Scalar;
 
 use crate::expression_fns::binary_expr;
 use crate::operators::Operator;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum Expr {
     /// A binary expression such as "duration_seconds == 100"
     Binary(BinaryExpr),
@@ -64,7 +65,7 @@ impl Expr {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct BinaryExpr {
     pub left: Box<Expr>,
     pub op: Operator,

--- a/vortex-expr/src/expressions.rs
+++ b/vortex-expr/src/expressions.rs
@@ -18,9 +18,6 @@ pub enum Expr {
     /// A constant scalar value.
     Literal(Scalar),
 
-    /// Additive inverse of an expression. The expression's type must be numeric.
-    Minus(Box<Expr>),
-
     /// Negation of an expression. The expression's type must be a boolean.
     Not(Box<Expr>),
 }
@@ -50,7 +47,7 @@ impl Expr {
         binary_expr(self, Operator::GreaterThan, other)
     }
 
-    pub fn gt_eq(self, other: Expr) -> Expr {
+    pub fn gte(self, other: Expr) -> Expr {
         binary_expr(self, Operator::GreaterThanOrEqualTo, other)
     }
 
@@ -58,17 +55,12 @@ impl Expr {
         binary_expr(self, Operator::LessThan, other)
     }
 
-    pub fn lt_eq(self, other: Expr) -> Expr {
+    pub fn lte(self, other: Expr) -> Expr {
         binary_expr(self, Operator::LessThanOrEqualTo, other)
     }
 
-    // misc
     pub fn is_null(self) -> Expr {
         Expr::IsNull(Box::new(self))
-    }
-
-    pub fn minus(self) -> Self {
-        Expr::Minus(Box::new(self))
     }
 }
 

--- a/vortex-expr/src/expressions.rs
+++ b/vortex-expr/src/expressions.rs
@@ -7,7 +7,7 @@ use crate::operators::Operator;
 #[derive(Clone, Debug, PartialEq)]
 pub enum Expr {
     /// A binary expression such as "duration_seconds == 100"
-    BinaryExpr(BinaryExpr),
+    Binary(BinaryExpr),
 
     /// A named reference to a qualified field in a dtype.
     Field(FieldName),

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -1,0 +1,8 @@
+extern crate core;
+
+mod display;
+mod expression_fns;
+pub mod expressions;
+mod literal;
+pub mod operators;
+pub mod scalar;

--- a/vortex-expr/src/literal.rs
+++ b/vortex-expr/src/literal.rs
@@ -21,9 +21,6 @@ mod test {
         let scalar: Scalar = 1.into();
         let rhs: Expr = lit(scalar);
         let expr = field("id").eq(rhs);
-        assert_eq!(
-            format!("{}", expr),
-            "id = 1i32"
-        );
+        assert_eq!(format!("{}", expr), "id = 1i32");
     }
 }

--- a/vortex-expr/src/literal.rs
+++ b/vortex-expr/src/literal.rs
@@ -1,0 +1,29 @@
+use vortex_scalar::Scalar;
+
+use crate::expressions::Expr;
+
+pub trait Literal {
+    fn lit(&self) -> Expr;
+}
+
+#[allow(dead_code)]
+pub fn lit<T: Into<Scalar>>(n: T) -> Expr {
+    n.into().lit()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::expression_fns::field;
+
+    #[test]
+    fn test_lit() {
+        let scalar: Scalar = 1.into();
+        let rhs: Expr = lit(scalar);
+        let expr = field("id").eq(rhs);
+        assert_eq!(
+            format!("{}", expr),
+            "id = 1i32"
+        );
+    }
+}

--- a/vortex-expr/src/operators.rs
+++ b/vortex-expr/src/operators.rs
@@ -1,8 +1,10 @@
 use std::ops;
 
+use serde::{Deserialize, Serialize};
+
 use crate::expressions::Expr;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Deserialize, Serialize)]
 pub enum Operator {
     // binary logic
     And,

--- a/vortex-expr/src/operators.rs
+++ b/vortex-expr/src/operators.rs
@@ -1,17 +1,9 @@
 use std::ops;
 
-use crate::expression_fns::binary_expr;
 use crate::expressions::Expr;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd)]
 pub enum Operator {
-    // arithmetic
-    Plus,
-    Minus,
-    UnaryMinus,
-    Multiplication,
-    Division,
-    Modulo,
     // binary logic
     And,
     Or,
@@ -44,81 +36,21 @@ impl Operator {
             | Operator::LessThanOrEqualTo
             | Operator::GreaterThan
             | Operator::GreaterThanOrEqualTo => 4,
-            Operator::Plus | Operator::Minus => 13,
-            Operator::Multiplication | Operator::Division | Operator::Modulo => 14,
-            Operator::UnaryMinus => 17,
         }
     }
 
     pub fn associativity(&self) -> Associativity {
         match self {
-            Operator::Or
-            | Operator::And
-            | Operator::Plus
-            | Operator::Minus
-            | Operator::Multiplication
-            | Operator::Division
-            | Operator::Modulo => Associativity::Left,
+            Operator::Or | Operator::And => Associativity::Left,
             Operator::LessThanOrEqualTo
             | Operator::GreaterThan
             | Operator::GreaterThanOrEqualTo => Associativity::Neither,
-            Operator::NotEqualTo
-            | Operator::EqualTo
-            | Operator::LessThan
-            | Operator::UnaryMinus => Associativity::Right,
+            Operator::NotEqualTo | Operator::EqualTo | Operator::LessThan => Associativity::Right,
         }
     }
 }
 
 /// Various operator support
-impl ops::Add for Expr {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self {
-        binary_expr(self, Operator::Plus, rhs)
-    }
-}
-
-impl ops::Sub for Expr {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Self {
-        binary_expr(self, Operator::Minus, rhs)
-    }
-}
-
-impl ops::Mul for Expr {
-    type Output = Self;
-
-    fn mul(self, rhs: Self) -> Self {
-        binary_expr(self, Operator::Multiplication, rhs)
-    }
-}
-
-impl ops::Div for Expr {
-    type Output = Self;
-
-    fn div(self, rhs: Self) -> Self {
-        binary_expr(self, Operator::Division, rhs)
-    }
-}
-
-impl ops::Rem for Expr {
-    type Output = Self;
-
-    fn rem(self, rhs: Self) -> Self {
-        binary_expr(self, Operator::Modulo, rhs)
-    }
-}
-
-impl ops::Neg for Expr {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        Expr::Minus(Box::new(self))
-    }
-}
-
 impl ops::Not for Expr {
     type Output = Self;
 

--- a/vortex-expr/src/operators.rs
+++ b/vortex-expr/src/operators.rs
@@ -1,0 +1,128 @@
+use std::ops;
+
+use crate::expression_fns::binary_expr;
+use crate::expressions::Expr;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd)]
+pub enum Operator {
+    // arithmetic
+    Plus,
+    Minus,
+    UnaryMinus,
+    Multiplication,
+    Division,
+    Modulo,
+    // binary logic
+    And,
+    Or,
+    // comparison
+    EqualTo,
+    NotEqualTo,
+    GreaterThan,
+    GreaterThanOrEqualTo,
+    LessThan,
+    LessThanOrEqualTo,
+}
+
+#[derive(PartialEq)]
+pub enum Associativity {
+    Left,
+    Right,
+    Neither,
+}
+
+/// Magic numbers from postgres docs:
+/// <https://www.postgresql.org/docs/7.0/operators.htm#AEN2026>
+impl Operator {
+    pub fn precedence(&self) -> u8 {
+        match self {
+            Operator::Or => 1,
+            Operator::And => 2,
+            Operator::NotEqualTo
+            | Operator::EqualTo
+            | Operator::LessThan
+            | Operator::LessThanOrEqualTo
+            | Operator::GreaterThan
+            | Operator::GreaterThanOrEqualTo => 4,
+            Operator::Plus | Operator::Minus => 13,
+            Operator::Multiplication | Operator::Division | Operator::Modulo => 14,
+            Operator::UnaryMinus => 17,
+        }
+    }
+
+    pub fn associativity(&self) -> Associativity {
+        match self {
+            Operator::Or
+            | Operator::And
+            | Operator::Plus
+            | Operator::Minus
+            | Operator::Multiplication
+            | Operator::Division
+            | Operator::Modulo => Associativity::Left,
+            Operator::LessThanOrEqualTo
+            | Operator::GreaterThan
+            | Operator::GreaterThanOrEqualTo => Associativity::Neither,
+            Operator::NotEqualTo
+            | Operator::EqualTo
+            | Operator::LessThan
+            | Operator::UnaryMinus => Associativity::Right,
+        }
+    }
+}
+
+/// Various operator support
+impl ops::Add for Expr {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        binary_expr(self, Operator::Plus, rhs)
+    }
+}
+
+impl ops::Sub for Expr {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self {
+        binary_expr(self, Operator::Minus, rhs)
+    }
+}
+
+impl ops::Mul for Expr {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self {
+        binary_expr(self, Operator::Multiplication, rhs)
+    }
+}
+
+impl ops::Div for Expr {
+    type Output = Self;
+
+    fn div(self, rhs: Self) -> Self {
+        binary_expr(self, Operator::Division, rhs)
+    }
+}
+
+impl ops::Rem for Expr {
+    type Output = Self;
+
+    fn rem(self, rhs: Self) -> Self {
+        binary_expr(self, Operator::Modulo, rhs)
+    }
+}
+
+impl ops::Neg for Expr {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Expr::Minus(Box::new(self))
+    }
+}
+
+impl ops::Not for Expr {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        Expr::Not(Box::new(self))
+    }
+}

--- a/vortex-expr/src/scalar.rs
+++ b/vortex-expr/src/scalar.rs
@@ -1,0 +1,12 @@
+use vortex_scalar::Scalar;
+
+use crate::expressions::Expr;
+use crate::literal::Literal;
+
+pub struct ScalarDisplayWrapper<'a>(pub &'a Scalar);
+
+impl Literal for Scalar {
+    fn lit(&self) -> Expr {
+        Expr::Literal(self.clone())
+    }
+}


### PR DESCRIPTION
Minimal set of expressions and operators for defining expressions over vortex arrays. Takes inspiration from [datafusion](https://github.com/apache/datafusion/tree/490fdf99e77a02a2d5952cd6634c269d14d862b4/datafusion/expr)  but is restricted to filter predicates and rewritten to use the vortex type system.

I tried to restrict this to a manageable set of expressions that we will definitely need as to avoid bloat; the expectation here is that this may grow over time. 

Subsequent changes will introduce:

- [ ] Aggregation functions that we can push down to vortex metadata
- [ ] A 'canonicalizer' mechanism to flatten expression trees
- [ ] A pushdown API for vortex arrays
- [ ] Array pushdown implementations for the various expressions