### PR TITLE
Remove array lifetimes

### DIFF
--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -16,7 +16,7 @@ use vortex::array::chunked::ChunkedArray;
 use vortex::arrow::FromArrowType;
 use vortex::compress::Compressor;
 use vortex::encoding::EncodingRef;
-use vortex::{Context, IntoArray, OwnedArray, ToArrayData};
+use vortex::{Array, Context, IntoArray, ToArrayData};
 use vortex_alp::ALPEncoding;
 use vortex_datetime_parts::DateTimePartsEncoding;
 use vortex_dict::DictEncoding;
@@ -120,7 +120,7 @@ pub fn setup_logger(level: LevelFilter) {
     .unwrap();
 }
 
-pub fn compress_taxi_data() -> OwnedArray {
+pub fn compress_taxi_data() -> Array {
     let file = File::open(taxi_data_parquet()).unwrap();
     let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
     let _mask = ProjectionMask::roots(builder.parquet_schema(), [6]);

--- a/bench-vortex/src/reader.rs
+++ b/bench-vortex/src/reader.rs
@@ -21,7 +21,7 @@ use vortex::array::chunked::ChunkedArray;
 use vortex::arrow::FromArrowType;
 use vortex::compress::Compressor;
 use vortex::compute::take::take;
-use vortex::{IntoArray, OwnedArray, ToArrayData, ToStatic};
+use vortex::{Array, IntoArray, ToArrayData, ToStatic};
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 use vortex_ipc::iter::FallibleLendingIterator;
@@ -32,7 +32,7 @@ use crate::CTX;
 
 pub const BATCH_SIZE: usize = 65_536;
 
-pub fn open_vortex(path: &Path) -> VortexResult<OwnedArray> {
+pub fn open_vortex(path: &Path) -> VortexResult<Array> {
     let mut file = File::open(path)?;
 
     let mut reader = StreamReader::try_new(&mut file, &CTX)?;
@@ -93,7 +93,7 @@ pub fn write_csv_as_parquet(csv_path: PathBuf, output_path: &Path) -> VortexResu
     Ok(())
 }
 
-pub fn take_vortex(path: &Path, indices: &[u64]) -> VortexResult<OwnedArray> {
+pub fn take_vortex(path: &Path, indices: &[u64]) -> VortexResult<Array> {
     let array = open_vortex(path)?;
     let taken = take(&array, &indices.to_vec().into_array())?;
     // For equivalence.... we flatten to make sure we're not cheating too much.

--- a/bench-vortex/src/reader.rs
+++ b/bench-vortex/src/reader.rs
@@ -56,7 +56,7 @@ pub fn rewrite_parquet_as_vortex<W: Write>(
     Ok(())
 }
 
-pub fn compress_parquet_to_vortex(parquet_path: &Path) -> VortexResult<ChunkedArray<'static>> {
+pub fn compress_parquet_to_vortex(parquet_path: &Path) -> VortexResult<ChunkedArray> {
     let taxi_pq = File::open(parquet_path)?;
     let builder = ParquetRecordBatchReaderBuilder::try_new(taxi_pq)?;
 

--- a/bench-vortex/src/reader.rs
+++ b/bench-vortex/src/reader.rs
@@ -21,7 +21,7 @@ use vortex::array::chunked::ChunkedArray;
 use vortex::arrow::FromArrowType;
 use vortex::compress::Compressor;
 use vortex::compute::take::take;
-use vortex::{Array, IntoArray, ToArrayData, ToStatic};
+use vortex::{Array, IntoArray, ToArrayData};
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 use vortex_ipc::iter::FallibleLendingIterator;
@@ -40,7 +40,7 @@ pub fn open_vortex(path: &Path) -> VortexResult<Array> {
     let dtype = reader.dtype().clone();
     let mut chunks = vec![];
     while let Some(chunk) = reader.next()? {
-        chunks.push(chunk.to_static())
+        chunks.push(chunk)
     }
     Ok(ChunkedArray::try_new(chunks, dtype)?.into_array())
 }

--- a/pyvortex/src/array.rs
+++ b/pyvortex/src/array.rs
@@ -10,7 +10,7 @@ use vortex::array::varbin::{VarBin, VarBinArray, VarBinEncoding};
 use vortex::array::varbinview::{VarBinView, VarBinViewArray, VarBinViewEncoding};
 use vortex::compute::take::take;
 use vortex::encoding::EncodingRef;
-use vortex::ToStatic;
+use vortex::ToArray;
 use vortex::{Array, ArrayDType, ArrayData, IntoArray};
 use vortex::{ArrayDef, IntoArrayData};
 use vortex_alp::{ALPArray, ALPEncoding, ALP};
@@ -47,7 +47,7 @@ macro_rules! pyarray {
 
            impl [<Py $T>] {
                pub fn wrap(py: Python<'_>, inner: $T) -> PyResult<Py<Self>> {
-                   let init = PyClassInitializer::from(PyArray { inner: inner.array().to_static() })
+                   let init = PyClassInitializer::from(PyArray { inner: inner.to_array().clone() })
                         .add_subclass([<Py $T>] { inner, encoding: &$E });
                    Py::new(py, init)
                }

--- a/pyvortex/src/array.rs
+++ b/pyvortex/src/array.rs
@@ -1,32 +1,30 @@
 use paste::paste;
 use pyo3::prelude::*;
-use vortex::array::bool::{Bool, BoolArray, BoolEncoding, OwnedBoolArray};
-use vortex::array::chunked::{Chunked, ChunkedArray, ChunkedEncoding, OwnedChunkedArray};
-use vortex::array::constant::{Constant, ConstantArray, ConstantEncoding, OwnedConstantArray};
-use vortex::array::primitive::{OwnedPrimitiveArray, Primitive, PrimitiveArray, PrimitiveEncoding};
-use vortex::array::r#struct::{OwnedStructArray, Struct, StructArray, StructEncoding};
-use vortex::array::sparse::{OwnedSparseArray, Sparse, SparseArray, SparseEncoding};
-use vortex::array::varbin::{OwnedVarBinArray, VarBin, VarBinArray, VarBinEncoding};
-use vortex::array::varbinview::{
-    OwnedVarBinViewArray, VarBinView, VarBinViewArray, VarBinViewEncoding,
-};
+use vortex::array::bool::{Bool, BoolArray, BoolEncoding};
+use vortex::array::chunked::{Chunked, ChunkedArray, ChunkedEncoding};
+use vortex::array::constant::{Constant, ConstantArray, ConstantEncoding};
+use vortex::array::primitive::{Primitive, PrimitiveArray, PrimitiveEncoding};
+use vortex::array::r#struct::{Struct, StructArray, StructEncoding};
+use vortex::array::sparse::{Sparse, SparseArray, SparseEncoding};
+use vortex::array::varbin::{VarBin, VarBinArray, VarBinEncoding};
+use vortex::array::varbinview::{VarBinView, VarBinViewArray, VarBinViewEncoding};
 use vortex::compute::take::take;
 use vortex::encoding::EncodingRef;
 use vortex::ToStatic;
-use vortex::{ArrayDType, ArrayData, IntoArray, OwnedArray};
+use vortex::{Array, ArrayDType, ArrayData, IntoArray};
 use vortex::{ArrayDef, IntoArrayData};
-use vortex_alp::{ALPArray, ALPEncoding, OwnedALPArray, ALP};
-use vortex_dict::{Dict, DictArray, DictEncoding, OwnedDictArray};
+use vortex_alp::{ALPArray, ALPEncoding, ALP};
+use vortex_dict::{Dict, DictArray, DictEncoding};
 use vortex_fastlanes::{
     BitPacked, BitPackedArray, BitPackedEncoding, Delta, DeltaArray, DeltaEncoding, FoR, FoRArray,
-    FoREncoding, OwnedBitPackedArray, OwnedDeltaArray, OwnedFoRArray,
+    FoREncoding,
 };
-use vortex_ree::{OwnedREEArray, REEArray, REEEncoding, REE};
+use vortex_ree::{REEArray, REEEncoding, REE};
 use vortex_roaring::{
-    OwnedRoaringBoolArray, OwnedRoaringIntArray, RoaringBool, RoaringBoolArray,
-    RoaringBoolEncoding, RoaringInt, RoaringIntArray, RoaringIntEncoding,
+    RoaringBool, RoaringBoolArray, RoaringBoolEncoding, RoaringInt, RoaringIntArray,
+    RoaringIntEncoding,
 };
-use vortex_zigzag::{OwnedZigZagArray, ZigZag, ZigZagArray, ZigZagEncoding};
+use vortex_zigzag::{ZigZag, ZigZagArray, ZigZagEncoding};
 
 use crate::dtype::PyDType;
 use crate::error::PyVortexError;
@@ -34,7 +32,7 @@ use crate::vortex_arrow;
 
 #[pyclass(name = "Array", module = "vortex", sequence, subclass)]
 pub struct PyArray {
-    inner: OwnedArray,
+    inner: Array,
 }
 
 macro_rules! pyarray {
@@ -42,13 +40,13 @@ macro_rules! pyarray {
         paste! {
             #[pyclass(name = $TName, module = "vortex", extends = PyArray, sequence, subclass)]
             pub struct [<Py $T>] {
-                inner: [<Owned $T>],
+                inner: $T,
                 #[allow(dead_code)]
                 encoding: EncodingRef,
             }
 
            impl [<Py $T>] {
-               pub fn wrap(py: Python<'_>, inner: [<Owned $T>]) -> PyResult<Py<Self>> {
+               pub fn wrap(py: Python<'_>, inner: $T) -> PyResult<Py<Self>> {
                    let init = PyClassInitializer::from(PyArray { inner: inner.array().to_static() })
                         .add_subclass([<Py $T>] { inner, encoding: &$E });
                    Py::new(py, init)
@@ -87,93 +85,88 @@ impl PyArray {
         match inner.encoding().id() {
             Bool::ID => PyBoolArray::wrap(
                 py,
-                OwnedBoolArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
+                BoolArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
             )?
             .extract(py),
             Chunked::ID => PyChunkedArray::wrap(
                 py,
-                OwnedChunkedArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
+                ChunkedArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
             )?
             .extract(py),
             Constant::ID => PyConstantArray::wrap(
                 py,
-                OwnedConstantArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
+                ConstantArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
             )?
             .extract(py),
             Primitive::ID => PyPrimitiveArray::wrap(
                 py,
-                OwnedPrimitiveArray::try_from(inner.into_array())
-                    .map_err(PyVortexError::map_err)?,
+                PrimitiveArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
             )?
             .extract(py),
             Sparse::ID => PySparseArray::wrap(
                 py,
-                OwnedSparseArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
+                SparseArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
             )?
             .extract(py),
             Struct::ID => PyStructArray::wrap(
                 py,
-                OwnedStructArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
+                StructArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
             )?
             .extract(py),
             VarBin::ID => PyVarBinArray::wrap(
                 py,
-                OwnedVarBinArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
+                VarBinArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
             )?
             .extract(py),
             VarBinView::ID => PyVarBinViewArray::wrap(
                 py,
-                OwnedVarBinViewArray::try_from(inner.into_array())
-                    .map_err(PyVortexError::map_err)?,
+                VarBinViewArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
             )?
             .extract(py),
             Dict::ID => PyDictArray::wrap(
                 py,
-                OwnedDictArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
+                DictArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
             )?
             .extract(py),
             REE::ID => PyREEArray::wrap(
                 py,
-                OwnedREEArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
+                REEArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
             )?
             .extract(py),
             Delta::ID => PyDeltaArray::wrap(
                 py,
-                OwnedDeltaArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
+                DeltaArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
             )?
             .extract(py),
             FoR::ID => PyFoRArray::wrap(
                 py,
-                OwnedFoRArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
+                FoRArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
             )?
             .extract(py),
             BitPacked::ID => PyBitPackedArray::wrap(
                 py,
-                OwnedBitPackedArray::try_from(inner.into_array())
-                    .map_err(PyVortexError::map_err)?,
+                BitPackedArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
             )?
             .extract(py),
 
             ALP::ID => PyALPArray::wrap(
                 py,
-                OwnedALPArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
+                ALPArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
             )?
             .extract(py),
             RoaringBool::ID => PyBitPackedArray::wrap(
                 py,
-                OwnedBitPackedArray::try_from(inner.into_array())
-                    .map_err(PyVortexError::map_err)?,
+                BitPackedArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
             )?
             .extract(py),
             RoaringInt::ID => PyBitPackedArray::wrap(
                 py,
-                OwnedBitPackedArray::try_from(inner.into_array())
-                    .map_err(PyVortexError::map_err)?,
+                BitPackedArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
             )?
             .extract(py),
             ZigZag::ID => PyZigZagArray::wrap(
                 py,
-                OwnedZigZagArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
+                ZigZagArray::try_from(inner.into_array()).map_err(PyVortexError::map_err)?,
             )?
             .extract(py),
             _ => Py::new(
@@ -208,7 +201,7 @@ impl PyArray {
         }
     }
 
-    pub fn unwrap(&self) -> &OwnedArray {
+    pub fn unwrap(&self) -> &Array {
         &self.inner
     }
 }

--- a/pyvortex/src/vortex_arrow.rs
+++ b/pyvortex/src/vortex_arrow.rs
@@ -13,7 +13,7 @@ pub fn map_arrow_err(error: ArrowError) -> PyErr {
     PyValueError::new_err(error.to_string())
 }
 
-pub fn export_array<'py>(py: Python<'py>, array: &Array<'_>) -> PyResult<&'py PyAny> {
+pub fn export_array<'py>(py: Python<'py>, array: &Array) -> PyResult<&'py PyAny> {
     // NOTE(ngates): for struct arrays, we could also return a RecordBatchStreamReader.
     // NOTE(robert): Return RecordBatchStreamReader always?
     let chunks = as_arrow_chunks(array).map_err(PyVortexError::map_err)?;

--- a/vortex-alp/src/array.rs
+++ b/vortex-alp/src/array.rs
@@ -19,7 +19,7 @@ pub struct ALPMetadata {
     patches_dtype: Option<DType>,
 }
 
-impl ALPArray<'_> {
+impl ALPArray {
     pub fn try_new(
         encoded: Array,
         exponents: Exponents,
@@ -50,7 +50,7 @@ impl ALPArray<'_> {
         )
     }
 
-    pub fn encode(array: Array<'_>) -> VortexResult<OwnedArray> {
+    pub fn encode(array: Array) -> VortexResult<OwnedArray> {
         if let Ok(parray) = PrimitiveArray::try_from(array) {
             Ok(alp_encode(&parray)?.into_array())
         } else {
@@ -77,7 +77,7 @@ impl ALPArray<'_> {
     }
 }
 
-impl ArrayValidity for ALPArray<'_> {
+impl ArrayValidity for ALPArray {
     fn is_valid(&self, index: usize) -> bool {
         self.encoded().with_dyn(|a| a.is_valid(index))
     }
@@ -87,7 +87,7 @@ impl ArrayValidity for ALPArray<'_> {
     }
 }
 
-impl ArrayFlatten for ALPArray<'_> {
+impl ArrayFlatten for ALPArray {
     fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
     where
         Self: 'a,
@@ -96,7 +96,7 @@ impl ArrayFlatten for ALPArray<'_> {
     }
 }
 
-impl AcceptArrayVisitor for ALPArray<'_> {
+impl AcceptArrayVisitor for ALPArray {
     fn accept(&self, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         visitor.visit_child("encoded", &self.encoded())?;
         if self.patches().is_some() {
@@ -109,9 +109,9 @@ impl AcceptArrayVisitor for ALPArray<'_> {
     }
 }
 
-impl ArrayStatisticsCompute for ALPArray<'_> {}
+impl ArrayStatisticsCompute for ALPArray {}
 
-impl ArrayTrait for ALPArray<'_> {
+impl ArrayTrait for ALPArray {
     fn len(&self) -> usize {
         self.encoded().len()
     }

--- a/vortex-alp/src/array.rs
+++ b/vortex-alp/src/array.rs
@@ -88,10 +88,7 @@ impl ArrayValidity for ALPArray {
 }
 
 impl ArrayFlatten for ALPArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
+    fn flatten(self) -> VortexResult<Flattened> {
         decompress(self).map(Flattened::Primitive)
     }
 }

--- a/vortex-alp/src/array.rs
+++ b/vortex-alp/src/array.rs
@@ -3,7 +3,7 @@ use vortex::array::primitive::PrimitiveArray;
 use vortex::stats::ArrayStatisticsCompute;
 use vortex::validity::{ArrayValidity, LogicalValidity};
 use vortex::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use vortex::{impl_encoding, ArrayDType, ArrayFlatten, IntoArrayData, OwnedArray, ToArrayData};
+use vortex::{impl_encoding, ArrayDType, ArrayFlatten, IntoArrayData, ToArrayData};
 use vortex_dtype::PType;
 use vortex_error::vortex_bail;
 
@@ -50,7 +50,7 @@ impl ALPArray {
         )
     }
 
-    pub fn encode(array: Array) -> VortexResult<OwnedArray> {
+    pub fn encode(array: Array) -> VortexResult<Array> {
         if let Ok(parray) = PrimitiveArray::try_from(array) {
             Ok(alp_encode(&parray)?.into_array())
         } else {

--- a/vortex-alp/src/compress.rs
+++ b/vortex-alp/src/compress.rs
@@ -131,7 +131,7 @@ pub fn decompress(array: ALPArray) -> VortexResult<PrimitiveArray> {
     }
 }
 
-fn patch_decoded<'a>(array: PrimitiveArray, patches: &Array) -> VortexResult<PrimitiveArray> {
+fn patch_decoded(array: PrimitiveArray, patches: &Array) -> VortexResult<PrimitiveArray> {
     match patches.encoding().id() {
         Sparse::ID => {
             match_each_alp_float_ptype!(array.ptype(), |$T| {

--- a/vortex-alp/src/compress.rs
+++ b/vortex-alp/src/compress.rs
@@ -3,14 +3,14 @@ use vortex::array::primitive::PrimitiveArray;
 use vortex::array::sparse::{Sparse, SparseArray};
 use vortex::compress::{CompressConfig, Compressor, EncodingCompression};
 use vortex::validity::Validity;
-use vortex::{Array, ArrayDType, ArrayDef, AsArray, IntoArray, OwnedArray};
+use vortex::{Array, ArrayDType, ArrayDef, AsArray, IntoArray};
 use vortex_dtype::{NativePType, PType};
 use vortex_error::{vortex_bail, vortex_err, VortexResult};
 use vortex_scalar::Scalar;
 
 use crate::alp::ALPFloat;
 use crate::array::{ALPArray, ALPEncoding};
-use crate::{Exponents, OwnedALPArray};
+use crate::Exponents;
 
 #[macro_export]
 macro_rules! match_each_alp_float_ptype {
@@ -83,7 +83,7 @@ impl EncodingCompression for ALPEncoding {
 fn encode_to_array<T>(
     values: &PrimitiveArray,
     exponents: Option<&Exponents>,
-) -> (Exponents, OwnedArray, Option<OwnedArray>)
+) -> (Exponents, Array, Option<Array>)
 where
     T: ALPFloat + NativePType,
     T::ALPInt: NativePType,
@@ -105,7 +105,7 @@ where
     )
 }
 
-pub(crate) fn alp_encode(parray: &PrimitiveArray) -> VortexResult<OwnedALPArray> {
+pub(crate) fn alp_encode(parray: &PrimitiveArray) -> VortexResult<ALPArray> {
     let (exponents, encoded, patches) = match parray.ptype() {
         PType::F32 => encode_to_array::<f32>(parray, None),
         PType::F64 => encode_to_array::<f64>(parray, None),

--- a/vortex-alp/src/compress.rs
+++ b/vortex-alp/src/compress.rs
@@ -49,7 +49,7 @@ impl EncodingCompression for ALPEncoding {
         array: &Array,
         like: Option<&Array>,
         ctx: Compressor,
-    ) -> VortexResult<Array<'static>> {
+    ) -> VortexResult<Array> {
         let like_alp = like.map(|like_array| like_array.as_array_ref());
         let like_exponents = like
             .map(|like_array| ALPArray::try_from(like_array).unwrap())
@@ -131,10 +131,7 @@ pub fn decompress(array: ALPArray) -> VortexResult<PrimitiveArray> {
     }
 }
 
-fn patch_decoded<'a>(
-    array: PrimitiveArray<'a>,
-    patches: &Array,
-) -> VortexResult<PrimitiveArray<'a>> {
+fn patch_decoded<'a>(array: PrimitiveArray, patches: &Array) -> VortexResult<PrimitiveArray> {
     match patches.encoding().id() {
         Sparse::ID => {
             match_each_alp_float_ptype!(array.ptype(), |$T| {

--- a/vortex-alp/src/compute.rs
+++ b/vortex-alp/src/compute.rs
@@ -8,7 +8,7 @@ use vortex_scalar::Scalar;
 
 use crate::{match_each_alp_float_ptype, ALPArray};
 
-impl ArrayCompute for ALPArray<'_> {
+impl ArrayCompute for ALPArray {
     fn scalar_at(&self) -> Option<&dyn ScalarAtFn> {
         Some(self)
     }
@@ -22,7 +22,7 @@ impl ArrayCompute for ALPArray<'_> {
     }
 }
 
-impl ScalarAtFn for ALPArray<'_> {
+impl ScalarAtFn for ALPArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         if let Some(patch) = self.patches().and_then(|p| scalar_at(&p, index).ok()) {
             return Ok(patch);
@@ -39,7 +39,7 @@ impl ScalarAtFn for ALPArray<'_> {
     }
 }
 
-impl TakeFn for ALPArray<'_> {
+impl TakeFn for ALPArray {
     fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
         // TODO(ngates): wrap up indices in an array that caches decompression?
         Ok(ALPArray::try_new(
@@ -51,7 +51,7 @@ impl TakeFn for ALPArray<'_> {
     }
 }
 
-impl SliceFn for ALPArray<'_> {
+impl SliceFn for ALPArray {
     fn slice(&self, start: usize, end: usize) -> VortexResult<OwnedArray> {
         Ok(ALPArray::try_new(
             slice(&self.encoded(), start, end)?,

--- a/vortex-alp/src/compute.rs
+++ b/vortex-alp/src/compute.rs
@@ -2,7 +2,7 @@ use vortex::compute::scalar_at::{scalar_at, ScalarAtFn};
 use vortex::compute::slice::{slice, SliceFn};
 use vortex::compute::take::{take, TakeFn};
 use vortex::compute::ArrayCompute;
-use vortex::{Array, ArrayDType, IntoArray, OwnedArray};
+use vortex::{Array, ArrayDType, IntoArray};
 use vortex_error::VortexResult;
 use vortex_scalar::Scalar;
 
@@ -40,7 +40,7 @@ impl ScalarAtFn for ALPArray {
 }
 
 impl TakeFn for ALPArray {
-    fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
+    fn take(&self, indices: &Array) -> VortexResult<Array> {
         // TODO(ngates): wrap up indices in an array that caches decompression?
         Ok(ALPArray::try_new(
             take(&self.encoded(), indices)?,
@@ -52,7 +52,7 @@ impl TakeFn for ALPArray {
 }
 
 impl SliceFn for ALPArray {
-    fn slice(&self, start: usize, end: usize) -> VortexResult<OwnedArray> {
+    fn slice(&self, start: usize, end: usize) -> VortexResult<Array> {
         Ok(ALPArray::try_new(
             slice(&self.encoded(), start, end)?,
             self.exponents().clone(),

--- a/vortex-array/src/array/bool/compute/as_arrow.rs
+++ b/vortex-array/src/array/bool/compute/as_arrow.rs
@@ -7,7 +7,7 @@ use crate::array::bool::BoolArray;
 use crate::compute::as_arrow::AsArrowArray;
 use crate::validity::ArrayValidity;
 
-impl AsArrowArray for BoolArray<'_> {
+impl AsArrowArray for BoolArray {
     fn as_arrow(&self) -> VortexResult<ArrowArrayRef> {
         Ok(Arc::new(ArrowBoolArray::new(
             self.boolean_buffer().clone(),

--- a/vortex-array/src/array/bool/compute/as_contiguous.rs
+++ b/vortex-array/src/array/bool/compute/as_contiguous.rs
@@ -4,10 +4,10 @@ use vortex_error::VortexResult;
 use crate::array::bool::BoolArray;
 use crate::compute::as_contiguous::AsContiguousFn;
 use crate::validity::Validity;
-use crate::{Array, ArrayDType, IntoArray, OwnedArray};
+use crate::{Array, ArrayDType, IntoArray};
 
 impl AsContiguousFn for BoolArray {
-    fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<OwnedArray> {
+    fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<Array> {
         let validity = if self.dtype().is_nullable() {
             Validity::from_iter(arrays.iter().map(|a| a.with_dyn(|a| a.logical_validity())))
         } else {

--- a/vortex-array/src/array/bool/compute/as_contiguous.rs
+++ b/vortex-array/src/array/bool/compute/as_contiguous.rs
@@ -6,7 +6,7 @@ use crate::compute::as_contiguous::AsContiguousFn;
 use crate::validity::Validity;
 use crate::{Array, ArrayDType, IntoArray, OwnedArray};
 
-impl AsContiguousFn for BoolArray<'_> {
+impl AsContiguousFn for BoolArray {
     fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<OwnedArray> {
         let validity = if self.dtype().is_nullable() {
             Validity::from_iter(arrays.iter().map(|a| a.with_dyn(|a| a.logical_validity())))

--- a/vortex-array/src/array/bool/compute/fill.rs
+++ b/vortex-array/src/array/bool/compute/fill.rs
@@ -6,7 +6,7 @@ use crate::compute::fill::FillForwardFn;
 use crate::validity::ArrayValidity;
 use crate::{ArrayDType, IntoArray, OwnedArray, ToArrayData};
 
-impl FillForwardFn for BoolArray<'_> {
+impl FillForwardFn for BoolArray {
     fn fill_forward(&self) -> VortexResult<OwnedArray> {
         if self.dtype().nullability() == Nullability::NonNullable {
             return Ok(self.to_array_data().into_array());

--- a/vortex-array/src/array/bool/compute/fill.rs
+++ b/vortex-array/src/array/bool/compute/fill.rs
@@ -4,10 +4,10 @@ use vortex_error::VortexResult;
 use crate::array::bool::BoolArray;
 use crate::compute::fill::FillForwardFn;
 use crate::validity::ArrayValidity;
-use crate::{ArrayDType, IntoArray, OwnedArray, ToArrayData};
+use crate::{Array, ArrayDType, IntoArray, ToArrayData};
 
 impl FillForwardFn for BoolArray {
-    fn fill_forward(&self) -> VortexResult<OwnedArray> {
+    fn fill_forward(&self) -> VortexResult<Array> {
         if self.dtype().nullability() == Nullability::NonNullable {
             return Ok(self.to_array_data().into_array());
         }

--- a/vortex-array/src/array/bool/compute/mod.rs
+++ b/vortex-array/src/array/bool/compute/mod.rs
@@ -15,7 +15,7 @@ mod scalar_at;
 mod slice;
 mod take;
 
-impl ArrayCompute for BoolArray<'_> {
+impl ArrayCompute for BoolArray {
     fn as_arrow(&self) -> Option<&dyn AsArrowArray> {
         Some(self)
     }

--- a/vortex-array/src/array/bool/compute/scalar_at.rs
+++ b/vortex-array/src/array/bool/compute/scalar_at.rs
@@ -6,7 +6,7 @@ use crate::compute::scalar_at::ScalarAtFn;
 use crate::validity::ArrayValidity;
 use crate::ArrayDType;
 
-impl ScalarAtFn for BoolArray<'_> {
+impl ScalarAtFn for BoolArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         if self.is_valid(index) {
             Ok(self.boolean_buffer().value(index).into())

--- a/vortex-array/src/array/bool/compute/slice.rs
+++ b/vortex-array/src/array/bool/compute/slice.rs
@@ -4,7 +4,7 @@ use crate::array::bool::BoolArray;
 use crate::compute::slice::SliceFn;
 use crate::{IntoArray, OwnedArray};
 
-impl SliceFn for BoolArray<'_> {
+impl SliceFn for BoolArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
         BoolArray::try_new(
             self.boolean_buffer().slice(start, stop - start),

--- a/vortex-array/src/array/bool/compute/slice.rs
+++ b/vortex-array/src/array/bool/compute/slice.rs
@@ -2,10 +2,10 @@ use vortex_error::VortexResult;
 
 use crate::array::bool::BoolArray;
 use crate::compute::slice::SliceFn;
-use crate::{IntoArray, OwnedArray};
+use crate::{Array, IntoArray};
 
 impl SliceFn for BoolArray {
-    fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
+    fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         BoolArray::try_new(
             self.boolean_buffer().slice(start, stop - start),
             self.validity().slice(start, stop)?,

--- a/vortex-array/src/array/bool/compute/take.rs
+++ b/vortex-array/src/array/bool/compute/take.rs
@@ -5,12 +5,12 @@ use vortex_error::VortexResult;
 
 use crate::array::bool::BoolArray;
 use crate::compute::take::TakeFn;
+use crate::Array;
 use crate::AsArray;
 use crate::IntoArray;
-use crate::{Array, OwnedArray};
 
 impl TakeFn for BoolArray {
-    fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
+    fn take(&self, indices: &Array) -> VortexResult<Array> {
         let validity = self.validity();
         let indices = indices.clone().flatten_primitive()?;
         match_each_integer_ptype!(indices.ptype(), |$I| {

--- a/vortex-array/src/array/bool/compute/take.rs
+++ b/vortex-array/src/array/bool/compute/take.rs
@@ -9,7 +9,7 @@ use crate::AsArray;
 use crate::IntoArray;
 use crate::{Array, OwnedArray};
 
-impl TakeFn for BoolArray<'_> {
+impl TakeFn for BoolArray {
     fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
         let validity = self.validity();
         let indices = indices.clone().flatten_primitive()?;

--- a/vortex-array/src/array/bool/mod.rs
+++ b/vortex-array/src/array/bool/mod.rs
@@ -57,19 +57,19 @@ impl BoolArray {
     }
 }
 
-impl From<BooleanBuffer> for OwnedBoolArray {
+impl From<BooleanBuffer> for BoolArray {
     fn from(value: BooleanBuffer) -> Self {
         BoolArray::try_new(value, Validity::NonNullable).unwrap()
     }
 }
 
-impl From<Vec<bool>> for OwnedBoolArray {
+impl From<Vec<bool>> for BoolArray {
     fn from(value: Vec<bool>) -> Self {
         BoolArray::from_vec(value, Validity::NonNullable)
     }
 }
 
-impl FromIterator<Option<bool>> for OwnedBoolArray {
+impl FromIterator<Option<bool>> for BoolArray {
     fn from_iter<I: IntoIterator<Item = Option<bool>>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let (lower, _) = iter.size_hint();

--- a/vortex-array/src/array/bool/mod.rs
+++ b/vortex-array/src/array/bool/mod.rs
@@ -19,7 +19,7 @@ pub struct BoolMetadata {
     length: usize,
 }
 
-impl BoolArray<'_> {
+impl BoolArray {
     pub fn buffer(&self) -> &Buffer {
         self.array().buffer().expect("missing buffer")
     }
@@ -35,7 +35,7 @@ impl BoolArray<'_> {
     }
 }
 
-impl BoolArray<'_> {
+impl BoolArray {
     pub fn try_new(buffer: BooleanBuffer, validity: Validity) -> VortexResult<Self> {
         Ok(Self {
             typed: TypedArray::try_from_parts(
@@ -86,13 +86,13 @@ impl FromIterator<Option<bool>> for OwnedBoolArray {
     }
 }
 
-impl ArrayTrait for BoolArray<'_> {
+impl ArrayTrait for BoolArray {
     fn len(&self) -> usize {
         self.metadata().length
     }
 }
 
-impl ArrayFlatten for BoolArray<'_> {
+impl ArrayFlatten for BoolArray {
     fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
     where
         Self: 'a,
@@ -101,7 +101,7 @@ impl ArrayFlatten for BoolArray<'_> {
     }
 }
 
-impl ArrayValidity for BoolArray<'_> {
+impl ArrayValidity for BoolArray {
     fn is_valid(&self, index: usize) -> bool {
         self.validity().is_valid(index)
     }
@@ -111,7 +111,7 @@ impl ArrayValidity for BoolArray<'_> {
     }
 }
 
-impl AcceptArrayVisitor for BoolArray<'_> {
+impl AcceptArrayVisitor for BoolArray {
     fn accept(&self, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         visitor.visit_buffer(self.buffer())?;
         visitor.visit_validity(&self.validity())

--- a/vortex-array/src/array/bool/mod.rs
+++ b/vortex-array/src/array/bool/mod.rs
@@ -93,10 +93,7 @@ impl ArrayTrait for BoolArray {
 }
 
 impl ArrayFlatten for BoolArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
+    fn flatten(self) -> VortexResult<Flattened> {
         Ok(Flattened::Bool(self))
     }
 }

--- a/vortex-array/src/array/bool/stats.rs
+++ b/vortex-array/src/array/bool/stats.rs
@@ -6,7 +6,7 @@ use crate::array::bool::BoolArray;
 use crate::stats::{ArrayStatisticsCompute, Stat, StatsSet};
 use crate::ArrayTrait;
 
-impl ArrayStatisticsCompute for BoolArray<'_> {
+impl ArrayStatisticsCompute for BoolArray {
     fn compute_statistics(&self, _stat: Stat) -> VortexResult<StatsSet> {
         if self.is_empty() {
             return Ok(StatsSet::from(HashMap::from([

--- a/vortex-array/src/array/chunked/compute/mod.rs
+++ b/vortex-array/src/array/chunked/compute/mod.rs
@@ -8,7 +8,7 @@ use crate::compute::scalar_subtract::SubtractScalarFn;
 use crate::compute::slice::SliceFn;
 use crate::compute::take::TakeFn;
 use crate::compute::ArrayCompute;
-use crate::{Array, ToStatic};
+use crate::Array;
 
 mod slice;
 mod take;
@@ -41,7 +41,7 @@ impl AsContiguousFn for ChunkedArray {
         let mut chunks = Vec::with_capacity(self.nchunks());
         for array in arrays {
             for chunk in ChunkedArray::try_from(array).unwrap().chunks() {
-                chunks.push(chunk.to_static());
+                chunks.push(chunk);
             }
         }
         as_contiguous(&chunks)

--- a/vortex-array/src/array/chunked/compute/mod.rs
+++ b/vortex-array/src/array/chunked/compute/mod.rs
@@ -13,7 +13,7 @@ use crate::{Array, OwnedArray, ToStatic};
 mod slice;
 mod take;
 
-impl ArrayCompute for ChunkedArray<'_> {
+impl ArrayCompute for ChunkedArray {
     fn as_contiguous(&self) -> Option<&dyn AsContiguousFn> {
         Some(self)
     }
@@ -35,7 +35,7 @@ impl ArrayCompute for ChunkedArray<'_> {
     }
 }
 
-impl AsContiguousFn for ChunkedArray<'_> {
+impl AsContiguousFn for ChunkedArray {
     fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<OwnedArray> {
         // Combine all the chunks into one, then call as_contiguous again.
         let mut chunks = Vec::with_capacity(self.nchunks());
@@ -48,7 +48,7 @@ impl AsContiguousFn for ChunkedArray<'_> {
     }
 }
 
-impl ScalarAtFn for ChunkedArray<'_> {
+impl ScalarAtFn for ChunkedArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         let (chunk_index, chunk_offset) = self.find_chunk_idx(index);
         scalar_at(&self.chunk(chunk_index).unwrap(), chunk_offset)

--- a/vortex-array/src/array/chunked/compute/mod.rs
+++ b/vortex-array/src/array/chunked/compute/mod.rs
@@ -8,7 +8,7 @@ use crate::compute::scalar_subtract::SubtractScalarFn;
 use crate::compute::slice::SliceFn;
 use crate::compute::take::TakeFn;
 use crate::compute::ArrayCompute;
-use crate::{Array, OwnedArray, ToStatic};
+use crate::{Array, ToStatic};
 
 mod slice;
 mod take;
@@ -36,7 +36,7 @@ impl ArrayCompute for ChunkedArray {
 }
 
 impl AsContiguousFn for ChunkedArray {
-    fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<OwnedArray> {
+    fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<Array> {
         // Combine all the chunks into one, then call as_contiguous again.
         let mut chunks = Vec::with_capacity(self.nchunks());
         for array in arrays {

--- a/vortex-array/src/array/chunked/compute/slice.rs
+++ b/vortex-array/src/array/chunked/compute/slice.rs
@@ -2,10 +2,10 @@ use vortex_error::VortexResult;
 
 use crate::array::chunked::ChunkedArray;
 use crate::compute::slice::{slice, SliceFn};
-use crate::{ArrayDType, IntoArray, OwnedArray};
+use crate::{Array, ArrayDType, IntoArray};
 
 impl SliceFn for ChunkedArray {
-    fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
+    fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         let (offset_chunk, offset_in_first_chunk) = self.find_chunk_idx(start);
         let (length_chunk, length_in_last_chunk) = self.find_chunk_idx(stop);
 

--- a/vortex-array/src/array/chunked/compute/slice.rs
+++ b/vortex-array/src/array/chunked/compute/slice.rs
@@ -4,7 +4,7 @@ use crate::array::chunked::ChunkedArray;
 use crate::compute::slice::{slice, SliceFn};
 use crate::{ArrayDType, IntoArray, OwnedArray};
 
-impl SliceFn for ChunkedArray<'_> {
+impl SliceFn for ChunkedArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
         let (offset_chunk, offset_in_first_chunk) = self.find_chunk_idx(start);
         let (length_chunk, length_in_last_chunk) = self.find_chunk_idx(stop);

--- a/vortex-array/src/array/chunked/compute/take.rs
+++ b/vortex-array/src/array/chunked/compute/take.rs
@@ -7,7 +7,7 @@ use crate::compute::take::{take, TakeFn};
 use crate::{Array, IntoArray, OwnedArray, ToArray, ToStatic};
 use crate::{ArrayDType, ArrayTrait};
 
-impl TakeFn for ChunkedArray<'_> {
+impl TakeFn for ChunkedArray {
     fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
         if self.len() == indices.len() {
             return Ok(self.to_array().to_static());

--- a/vortex-array/src/array/chunked/compute/take.rs
+++ b/vortex-array/src/array/chunked/compute/take.rs
@@ -4,13 +4,13 @@ use vortex_error::VortexResult;
 use crate::array::chunked::ChunkedArray;
 use crate::compute::cast::cast;
 use crate::compute::take::{take, TakeFn};
-use crate::{Array, IntoArray, ToArray, ToStatic};
+use crate::{Array, IntoArray, ToArray};
 use crate::{ArrayDType, ArrayTrait};
 
 impl TakeFn for ChunkedArray {
     fn take(&self, indices: &Array) -> VortexResult<Array> {
         if self.len() == indices.len() {
-            return Ok(self.to_array().to_static());
+            return Ok(self.to_array());
         }
 
         let indices = cast(indices, PType::U64.into())?.flatten_primitive()?;

--- a/vortex-array/src/array/chunked/compute/take.rs
+++ b/vortex-array/src/array/chunked/compute/take.rs
@@ -4,11 +4,11 @@ use vortex_error::VortexResult;
 use crate::array::chunked::ChunkedArray;
 use crate::compute::cast::cast;
 use crate::compute::take::{take, TakeFn};
-use crate::{Array, IntoArray, OwnedArray, ToArray, ToStatic};
+use crate::{Array, IntoArray, ToArray, ToStatic};
 use crate::{ArrayDType, ArrayTrait};
 
 impl TakeFn for ChunkedArray {
-    fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
+    fn take(&self, indices: &Array) -> VortexResult<Array> {
         if self.len() == indices.len() {
             return Ok(self.to_array().to_static());
         }

--- a/vortex-array/src/array/chunked/mod.rs
+++ b/vortex-array/src/array/chunked/mod.rs
@@ -11,7 +11,7 @@ use crate::compute::search_sorted::{search_sorted, SearchSortedSide};
 use crate::validity::Validity::NonNullable;
 use crate::validity::{ArrayValidity, LogicalValidity};
 use crate::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use crate::{impl_encoding, ArrayDType, ArrayFlatten, IntoArrayData, OwnedArray, ToArrayData};
+use crate::{impl_encoding, ArrayDType, ArrayFlatten, IntoArrayData, ToArrayData};
 
 mod compute;
 mod stats;
@@ -93,9 +93,9 @@ impl<'a> ChunkedArray {
     }
 }
 
-impl FromIterator<OwnedArray> for OwnedChunkedArray {
-    fn from_iter<T: IntoIterator<Item = OwnedArray>>(iter: T) -> Self {
-        let chunks: Vec<OwnedArray> = iter.into_iter().collect();
+impl FromIterator<Array> for ChunkedArray {
+    fn from_iter<T: IntoIterator<Item = Array>>(iter: T) -> Self {
+        let chunks: Vec<Array> = iter.into_iter().collect();
         let dtype = chunks
             .first()
             .map(|c| c.dtype().clone())
@@ -139,7 +139,7 @@ impl ArrayValidity for ChunkedArray {
 impl EncodingCompression for ChunkedEncoding {}
 
 impl SubtractScalarFn for ChunkedArray {
-    fn subtract_scalar(&self, to_subtract: &Scalar) -> VortexResult<OwnedArray> {
+    fn subtract_scalar(&self, to_subtract: &Scalar) -> VortexResult<Array> {
         self.chunks()
             .map(|chunk| subtract_scalar(&chunk, to_subtract))
             .collect::<VortexResult<Vec<_>>>()
@@ -156,12 +156,12 @@ mod test {
     use vortex_dtype::{DType, Nullability};
     use vortex_dtype::{NativePType, PType};
 
-    use crate::array::chunked::{ChunkedArray, OwnedChunkedArray};
+    use crate::array::chunked::ChunkedArray;
     use crate::compute::scalar_subtract::subtract_scalar;
     use crate::compute::slice::slice;
     use crate::{Array, IntoArray, ToArray};
 
-    fn chunked_array() -> OwnedChunkedArray {
+    fn chunked_array() -> ChunkedArray {
         ChunkedArray::try_new(
             vec![
                 vec![1u64, 2, 3].into_array(),

--- a/vortex-array/src/array/chunked/mod.rs
+++ b/vortex-array/src/array/chunked/mod.rs
@@ -105,10 +105,7 @@ impl FromIterator<OwnedArray> for OwnedChunkedArray {
 }
 
 impl ArrayFlatten for ChunkedArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
+    fn flatten(self) -> VortexResult<Flattened> {
         Ok(Flattened::Chunked(self))
     }
 }

--- a/vortex-array/src/array/chunked/stats.rs
+++ b/vortex-array/src/array/chunked/stats.rs
@@ -4,7 +4,7 @@ use crate::array::chunked::ChunkedArray;
 use crate::stats::ArrayStatistics;
 use crate::stats::{ArrayStatisticsCompute, Stat, StatsSet};
 
-impl ArrayStatisticsCompute for ChunkedArray<'_> {
+impl ArrayStatisticsCompute for ChunkedArray {
     fn compute_statistics(&self, stat: Stat) -> VortexResult<StatsSet> {
         Ok(self
             .chunks()

--- a/vortex-array/src/array/constant/compute.rs
+++ b/vortex-array/src/array/constant/compute.rs
@@ -7,7 +7,7 @@ use crate::compute::as_contiguous::AsContiguousFn;
 use crate::compute::scalar_at::ScalarAtFn;
 use crate::compute::take::TakeFn;
 use crate::compute::ArrayCompute;
-use crate::{Array, ArrayTrait, IntoArray, OwnedArray};
+use crate::{Array, ArrayTrait, IntoArray};
 
 impl ArrayCompute for ConstantArray {
     fn as_contiguous(&self) -> Option<&dyn AsContiguousFn> {
@@ -24,7 +24,7 @@ impl ArrayCompute for ConstantArray {
 }
 
 impl AsContiguousFn for ConstantArray {
-    fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<OwnedArray> {
+    fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<Array> {
         let chunks = arrays
             .iter()
             .map(|a| ConstantArray::try_from(a).unwrap())
@@ -52,7 +52,7 @@ impl ScalarAtFn for ConstantArray {
 }
 
 impl TakeFn for ConstantArray {
-    fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
+    fn take(&self, indices: &Array) -> VortexResult<Array> {
         Ok(ConstantArray::new(self.scalar().clone(), indices.len()).into_array())
     }
 }

--- a/vortex-array/src/array/constant/compute.rs
+++ b/vortex-array/src/array/constant/compute.rs
@@ -9,7 +9,7 @@ use crate::compute::take::TakeFn;
 use crate::compute::ArrayCompute;
 use crate::{Array, ArrayTrait, IntoArray, OwnedArray};
 
-impl ArrayCompute for ConstantArray<'_> {
+impl ArrayCompute for ConstantArray {
     fn as_contiguous(&self) -> Option<&dyn AsContiguousFn> {
         Some(self)
     }
@@ -23,7 +23,7 @@ impl ArrayCompute for ConstantArray<'_> {
     }
 }
 
-impl AsContiguousFn for ConstantArray<'_> {
+impl AsContiguousFn for ConstantArray {
     fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<OwnedArray> {
         let chunks = arrays
             .iter()
@@ -45,13 +45,13 @@ impl AsContiguousFn for ConstantArray<'_> {
     }
 }
 
-impl ScalarAtFn for ConstantArray<'_> {
+impl ScalarAtFn for ConstantArray {
     fn scalar_at(&self, _index: usize) -> VortexResult<Scalar> {
         Ok(self.scalar().clone())
     }
 }
 
-impl TakeFn for ConstantArray<'_> {
+impl TakeFn for ConstantArray {
     fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
         Ok(ConstantArray::new(self.scalar().clone(), indices.len()).into_array())
     }

--- a/vortex-array/src/array/constant/flatten.rs
+++ b/vortex-array/src/array/constant/flatten.rs
@@ -10,10 +10,7 @@ use crate::{ArrayDType, ArrayTrait};
 use crate::{ArrayFlatten, Flattened};
 
 impl ArrayFlatten for ConstantArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
+    fn flatten(self) -> VortexResult<Flattened> {
         let validity = match self.dtype().nullability() {
             Nullability::NonNullable => Validity::NonNullable,
             Nullability::Nullable => match self.scalar().is_null() {

--- a/vortex-array/src/array/constant/flatten.rs
+++ b/vortex-array/src/array/constant/flatten.rs
@@ -9,7 +9,7 @@ use crate::validity::Validity;
 use crate::{ArrayDType, ArrayTrait};
 use crate::{ArrayFlatten, Flattened};
 
-impl ArrayFlatten for ConstantArray<'_> {
+impl ArrayFlatten for ConstantArray {
     fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
     where
         Self: 'a,

--- a/vortex-array/src/array/constant/mod.rs
+++ b/vortex-array/src/array/constant/mod.rs
@@ -19,7 +19,7 @@ pub struct ConstantMetadata {
     length: usize,
 }
 
-impl ConstantArray<'_> {
+impl ConstantArray {
     pub fn new<S>(scalar: S, length: usize) -> Self
     where
         Scalar: From<S>,
@@ -46,7 +46,7 @@ impl ConstantArray<'_> {
     }
 }
 
-impl ArrayValidity for ConstantArray<'_> {
+impl ArrayValidity for ConstantArray {
     fn is_valid(&self, _index: usize) -> bool {
         match self.metadata().scalar.dtype().is_nullable() {
             true => !self.scalar().is_null(),
@@ -62,13 +62,13 @@ impl ArrayValidity for ConstantArray<'_> {
     }
 }
 
-impl AcceptArrayVisitor for ConstantArray<'_> {
+impl AcceptArrayVisitor for ConstantArray {
     fn accept(&self, _visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         Ok(())
     }
 }
 
-impl ArrayTrait for ConstantArray<'_> {
+impl ArrayTrait for ConstantArray {
     fn len(&self) -> usize {
         self.metadata().length
     }

--- a/vortex-array/src/array/constant/stats.rs
+++ b/vortex-array/src/array/constant/stats.rs
@@ -7,7 +7,7 @@ use crate::array::constant::ConstantArray;
 use crate::stats::{ArrayStatisticsCompute, Stat, StatsSet};
 use crate::ArrayTrait;
 
-impl ArrayStatisticsCompute for ConstantArray<'_> {
+impl ArrayStatisticsCompute for ConstantArray {
     fn compute_statistics(&self, _stat: Stat) -> VortexResult<StatsSet> {
         if let Ok(b) = BoolScalar::try_from(self.scalar()) {
             let true_count = if b.value().unwrap_or(false) {

--- a/vortex-array/src/array/datetime/localdatetime.rs
+++ b/vortex-array/src/array/datetime/localdatetime.rs
@@ -19,12 +19,12 @@ lazy_static! {
     static ref ID: ExtID = ExtID::from(LocalDateTimeArray::ID);
 }
 
-pub struct LocalDateTimeArray<'a> {
-    ext: ExtensionArray<'a>,
+pub struct LocalDateTimeArray {
+    ext: ExtensionArray,
     time_unit: TimeUnit,
 }
 
-impl LocalDateTimeArray<'_> {
+impl LocalDateTimeArray {
     pub const ID: &'static str = "vortex.localdatetime";
 
     pub fn try_new(time_unit: TimeUnit, timestamps: Array) -> VortexResult<Self> {
@@ -54,10 +54,10 @@ impl LocalDateTimeArray<'_> {
     }
 }
 
-impl<'a> TryFrom<&ExtensionArray<'a>> for LocalDateTimeArray<'a> {
+impl<'a> TryFrom<&ExtensionArray> for LocalDateTimeArray {
     type Error = VortexError;
 
-    fn try_from(value: &ExtensionArray<'a>) -> Result<Self, Self::Error> {
+    fn try_from(value: &ExtensionArray) -> Result<Self, Self::Error> {
         LocalDateTimeArray::try_new(
             try_parse_time_unit(value.ext_dtype())?,
             value.storage().clone(),
@@ -65,7 +65,7 @@ impl<'a> TryFrom<&ExtensionArray<'a>> for LocalDateTimeArray<'a> {
     }
 }
 
-impl AsArrowArray for LocalDateTimeArray<'_> {
+impl AsArrowArray for LocalDateTimeArray {
     fn as_arrow(&self) -> VortexResult<ArrowArrayRef> {
         // A LocalDateTime maps to an Arrow Timestamp array with no timezone.
         let timestamps = cast(&self.timestamps(), PType::I64.into())?.flatten_primitive()?;
@@ -81,16 +81,16 @@ impl AsArrowArray for LocalDateTimeArray<'_> {
     }
 }
 
-impl<'a> TryFrom<&Array<'a>> for LocalDateTimeArray<'a> {
+impl<'a> TryFrom<&Array> for LocalDateTimeArray {
     type Error = VortexError;
 
-    fn try_from(value: &Array<'a>) -> Result<Self, Self::Error> {
+    fn try_from(value: &Array) -> Result<Self, Self::Error> {
         let ext = ExtensionArray::try_from(value)?;
         LocalDateTimeArray::try_new(try_parse_time_unit(ext.ext_dtype())?, ext.storage())
     }
 }
 
-impl IntoArrayData for LocalDateTimeArray<'_> {
+impl IntoArrayData for LocalDateTimeArray {
     fn into_array_data(self) -> ArrayData {
         self.ext.into_array_data()
     }

--- a/vortex-array/src/array/datetime/localdatetime.rs
+++ b/vortex-array/src/array/datetime/localdatetime.rs
@@ -54,7 +54,7 @@ impl LocalDateTimeArray {
     }
 }
 
-impl<'a> TryFrom<&ExtensionArray> for LocalDateTimeArray {
+impl TryFrom<&ExtensionArray> for LocalDateTimeArray {
     type Error = VortexError;
 
     fn try_from(value: &ExtensionArray) -> Result<Self, Self::Error> {
@@ -81,7 +81,7 @@ impl AsArrowArray for LocalDateTimeArray {
     }
 }
 
-impl<'a> TryFrom<&Array> for LocalDateTimeArray {
+impl TryFrom<&Array> for LocalDateTimeArray {
     type Error = VortexError;
 
     fn try_from(value: &Array) -> Result<Self, Self::Error> {

--- a/vortex-array/src/array/extension/compute.rs
+++ b/vortex-array/src/array/extension/compute.rs
@@ -13,7 +13,7 @@ use crate::compute::take::{take, TakeFn};
 use crate::compute::ArrayCompute;
 use crate::{Array, IntoArray, OwnedArray, ToStatic};
 
-impl ArrayCompute for ExtensionArray<'_> {
+impl ArrayCompute for ExtensionArray {
     fn as_arrow(&self) -> Option<&dyn AsArrowArray> {
         Some(self)
     }
@@ -42,7 +42,7 @@ impl ArrayCompute for ExtensionArray<'_> {
     }
 }
 
-impl AsArrowArray for ExtensionArray<'_> {
+impl AsArrowArray for ExtensionArray {
     /// To support full compatability with Arrow, we hard-code the conversion of our datetime
     /// arrays to Arrow's Timestamp arrays here. For all other extension arrays, we return an
     /// Arrow extension array with the same definition.
@@ -54,7 +54,7 @@ impl AsArrowArray for ExtensionArray<'_> {
     }
 }
 
-impl AsContiguousFn for ExtensionArray<'_> {
+impl AsContiguousFn for ExtensionArray {
     fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<OwnedArray> {
         let storage_arrays = arrays
             .iter()
@@ -73,7 +73,7 @@ impl AsContiguousFn for ExtensionArray<'_> {
     }
 }
 
-impl ScalarAtFn for ExtensionArray<'_> {
+impl ScalarAtFn for ExtensionArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         Ok(Scalar::extension(
             self.ext_dtype().clone(),
@@ -82,7 +82,7 @@ impl ScalarAtFn for ExtensionArray<'_> {
     }
 }
 
-impl SliceFn for ExtensionArray<'_> {
+impl SliceFn for ExtensionArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
         Ok(ExtensionArray::new(
             self.ext_dtype().clone(),
@@ -92,7 +92,7 @@ impl SliceFn for ExtensionArray<'_> {
     }
 }
 
-impl TakeFn for ExtensionArray<'_> {
+impl TakeFn for ExtensionArray {
     fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
         Ok(
             ExtensionArray::new(self.ext_dtype().clone(), take(&self.storage(), indices)?)

--- a/vortex-array/src/array/extension/compute.rs
+++ b/vortex-array/src/array/extension/compute.rs
@@ -11,7 +11,7 @@ use crate::compute::scalar_at::{scalar_at, ScalarAtFn};
 use crate::compute::slice::{slice, SliceFn};
 use crate::compute::take::{take, TakeFn};
 use crate::compute::ArrayCompute;
-use crate::{Array, IntoArray, ToStatic};
+use crate::{Array, IntoArray};
 
 impl ArrayCompute for ExtensionArray {
     fn as_arrow(&self) -> Option<&dyn AsArrowArray> {
@@ -62,7 +62,6 @@ impl AsContiguousFn for ExtensionArray {
                 ExtensionArray::try_from(a)
                     .expect("not an extension array")
                     .storage()
-                    .to_static()
             })
             .collect::<Vec<_>>();
 

--- a/vortex-array/src/array/extension/compute.rs
+++ b/vortex-array/src/array/extension/compute.rs
@@ -11,7 +11,7 @@ use crate::compute::scalar_at::{scalar_at, ScalarAtFn};
 use crate::compute::slice::{slice, SliceFn};
 use crate::compute::take::{take, TakeFn};
 use crate::compute::ArrayCompute;
-use crate::{Array, IntoArray, OwnedArray, ToStatic};
+use crate::{Array, IntoArray, ToStatic};
 
 impl ArrayCompute for ExtensionArray {
     fn as_arrow(&self) -> Option<&dyn AsArrowArray> {
@@ -55,7 +55,7 @@ impl AsArrowArray for ExtensionArray {
 }
 
 impl AsContiguousFn for ExtensionArray {
-    fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<OwnedArray> {
+    fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<Array> {
         let storage_arrays = arrays
             .iter()
             .map(|a| {
@@ -83,7 +83,7 @@ impl ScalarAtFn for ExtensionArray {
 }
 
 impl SliceFn for ExtensionArray {
-    fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
+    fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         Ok(ExtensionArray::new(
             self.ext_dtype().clone(),
             slice(&self.storage(), start, stop)?,
@@ -93,7 +93,7 @@ impl SliceFn for ExtensionArray {
 }
 
 impl TakeFn for ExtensionArray {
-    fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
+    fn take(&self, indices: &Array) -> VortexResult<Array> {
         Ok(
             ExtensionArray::new(self.ext_dtype().clone(), take(&self.storage(), indices)?)
                 .into_array(),

--- a/vortex-array/src/array/extension/mod.rs
+++ b/vortex-array/src/array/extension/mod.rs
@@ -15,7 +15,7 @@ pub struct ExtensionMetadata {
     storage_dtype: DType,
 }
 
-impl ExtensionArray<'_> {
+impl ExtensionArray {
     pub fn new(ext_dtype: ExtDType, storage: Array) -> Self {
         Self::try_from_parts(
             DType::Extension(ext_dtype, storage.dtype().nullability()),
@@ -49,7 +49,7 @@ impl ExtensionArray<'_> {
     }
 }
 
-impl ArrayFlatten for ExtensionArray<'_> {
+impl ArrayFlatten for ExtensionArray {
     fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
     where
         Self: 'a,
@@ -58,7 +58,7 @@ impl ArrayFlatten for ExtensionArray<'_> {
     }
 }
 
-impl ArrayValidity for ExtensionArray<'_> {
+impl ArrayValidity for ExtensionArray {
     fn is_valid(&self, index: usize) -> bool {
         self.storage().with_dyn(|a| a.is_valid(index))
     }
@@ -68,17 +68,17 @@ impl ArrayValidity for ExtensionArray<'_> {
     }
 }
 
-impl AcceptArrayVisitor for ExtensionArray<'_> {
+impl AcceptArrayVisitor for ExtensionArray {
     fn accept(&self, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         visitor.visit_child("storage", &self.storage())
     }
 }
 
-impl ArrayStatisticsCompute for ExtensionArray<'_> {
+impl ArrayStatisticsCompute for ExtensionArray {
     // TODO(ngates): pass through stats to the underlying and cast the scalars.
 }
 
-impl ArrayTrait for ExtensionArray<'_> {
+impl ArrayTrait for ExtensionArray {
     fn len(&self) -> usize {
         self.storage().len()
     }

--- a/vortex-array/src/array/extension/mod.rs
+++ b/vortex-array/src/array/extension/mod.rs
@@ -50,11 +50,8 @@ impl ExtensionArray {
 }
 
 impl ArrayFlatten for ExtensionArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
-        todo!()
+    fn flatten(self) -> VortexResult<Flattened> {
+        Ok(Flattened::Extension(self))
     }
 }
 

--- a/vortex-array/src/array/primitive/accessor.rs
+++ b/vortex-array/src/array/primitive/accessor.rs
@@ -5,7 +5,7 @@ use crate::accessor::ArrayAccessor;
 use crate::array::primitive::PrimitiveArray;
 use crate::validity::ArrayValidity;
 
-impl<T: NativePType> ArrayAccessor<T> for PrimitiveArray<'_> {
+impl<T: NativePType> ArrayAccessor<T> for PrimitiveArray {
     fn with_iterator<F, R>(&self, f: F) -> VortexResult<R>
     where
         F: for<'a> FnOnce(&mut (dyn Iterator<Item = Option<&'a T>>)) -> R,

--- a/vortex-array/src/array/primitive/compute/as_arrow.rs
+++ b/vortex-array/src/array/primitive/compute/as_arrow.rs
@@ -12,7 +12,7 @@ use crate::compute::as_arrow::AsArrowArray;
 use crate::validity::ArrayValidity;
 use crate::ArrayTrait;
 
-impl AsArrowArray for PrimitiveArray<'_> {
+impl AsArrowArray for PrimitiveArray {
     fn as_arrow(&self) -> VortexResult<ArrowArrayRef> {
         use arrow_array::types::*;
         Ok(match self.ptype() {

--- a/vortex-array/src/array/primitive/compute/as_contiguous.rs
+++ b/vortex-array/src/array/primitive/compute/as_contiguous.rs
@@ -6,10 +6,10 @@ use crate::array::primitive::PrimitiveArray;
 use crate::compute::as_contiguous::AsContiguousFn;
 use crate::validity::Validity;
 use crate::ArrayDType;
-use crate::{Array, IntoArray, OwnedArray};
+use crate::{Array, IntoArray};
 
 impl AsContiguousFn for PrimitiveArray {
-    fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<OwnedArray> {
+    fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<Array> {
         let validity = if self.dtype().is_nullable() {
             Validity::from_iter(arrays.iter().map(|a| a.with_dyn(|a| a.logical_validity())))
         } else {

--- a/vortex-array/src/array/primitive/compute/as_contiguous.rs
+++ b/vortex-array/src/array/primitive/compute/as_contiguous.rs
@@ -8,7 +8,7 @@ use crate::validity::Validity;
 use crate::ArrayDType;
 use crate::{Array, IntoArray, OwnedArray};
 
-impl AsContiguousFn for PrimitiveArray<'_> {
+impl AsContiguousFn for PrimitiveArray {
     fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<OwnedArray> {
         let validity = if self.dtype().is_nullable() {
             Validity::from_iter(arrays.iter().map(|a| a.with_dyn(|a| a.logical_validity())))

--- a/vortex-array/src/array/primitive/compute/cast.rs
+++ b/vortex-array/src/array/primitive/compute/cast.rs
@@ -8,7 +8,7 @@ use crate::validity::Validity;
 use crate::ArrayDType;
 use crate::{IntoArray, OwnedArray};
 
-impl CastFn for PrimitiveArray<'_> {
+impl CastFn for PrimitiveArray {
     fn cast(&self, dtype: &DType) -> VortexResult<OwnedArray> {
         let ptype = PType::try_from(dtype)?;
 

--- a/vortex-array/src/array/primitive/compute/cast.rs
+++ b/vortex-array/src/array/primitive/compute/cast.rs
@@ -5,11 +5,11 @@ use vortex_error::{vortex_err, VortexResult};
 use crate::array::primitive::PrimitiveArray;
 use crate::compute::cast::CastFn;
 use crate::validity::Validity;
-use crate::ArrayDType;
-use crate::{IntoArray, OwnedArray};
+use crate::IntoArray;
+use crate::{Array, ArrayDType};
 
 impl CastFn for PrimitiveArray {
-    fn cast(&self, dtype: &DType) -> VortexResult<OwnedArray> {
+    fn cast(&self, dtype: &DType) -> VortexResult<Array> {
         let ptype = PType::try_from(dtype)?;
 
         // Short-cut if we can just change the nullability

--- a/vortex-array/src/array/primitive/compute/fill.rs
+++ b/vortex-array/src/array/primitive/compute/fill.rs
@@ -6,7 +6,7 @@ use crate::compute::fill::FillForwardFn;
 use crate::validity::ArrayValidity;
 use crate::{IntoArray, OwnedArray, ToArrayData};
 
-impl FillForwardFn for PrimitiveArray<'_> {
+impl FillForwardFn for PrimitiveArray {
     fn fill_forward(&self) -> VortexResult<OwnedArray> {
         let validity = self.logical_validity();
         let Some(nulls) = validity.to_null_buffer()? else {

--- a/vortex-array/src/array/primitive/compute/fill.rs
+++ b/vortex-array/src/array/primitive/compute/fill.rs
@@ -4,10 +4,10 @@ use vortex_error::VortexResult;
 use crate::array::primitive::PrimitiveArray;
 use crate::compute::fill::FillForwardFn;
 use crate::validity::ArrayValidity;
-use crate::{IntoArray, OwnedArray, ToArrayData};
+use crate::{Array, IntoArray, ToArrayData};
 
 impl FillForwardFn for PrimitiveArray {
-    fn fill_forward(&self) -> VortexResult<OwnedArray> {
+    fn fill_forward(&self) -> VortexResult<Array> {
         let validity = self.logical_validity();
         let Some(nulls) = validity.to_null_buffer()? else {
             return Ok(self.to_array_data().into_array());

--- a/vortex-array/src/array/primitive/compute/mod.rs
+++ b/vortex-array/src/array/primitive/compute/mod.rs
@@ -20,7 +20,7 @@ mod slice;
 mod subtract_scalar;
 mod take;
 
-impl ArrayCompute for PrimitiveArray<'_> {
+impl ArrayCompute for PrimitiveArray {
     fn as_arrow(&self) -> Option<&dyn AsArrowArray> {
         Some(self)
     }

--- a/vortex-array/src/array/primitive/compute/scalar_at.rs
+++ b/vortex-array/src/array/primitive/compute/scalar_at.rs
@@ -7,7 +7,7 @@ use crate::compute::scalar_at::ScalarAtFn;
 use crate::validity::ArrayValidity;
 use crate::ArrayDType;
 
-impl ScalarAtFn for PrimitiveArray<'_> {
+impl ScalarAtFn for PrimitiveArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         match_each_native_ptype!(self.ptype(), |$T| {
             if self.is_valid(index) {

--- a/vortex-array/src/array/primitive/compute/search_sorted.rs
+++ b/vortex-array/src/array/primitive/compute/search_sorted.rs
@@ -6,7 +6,7 @@ use crate::array::primitive::PrimitiveArray;
 use crate::compute::search_sorted::{SearchResult, SearchSorted};
 use crate::compute::search_sorted::{SearchSortedFn, SearchSortedSide};
 
-impl SearchSortedFn for PrimitiveArray<'_> {
+impl SearchSortedFn for PrimitiveArray {
     fn search_sorted(&self, value: &Scalar, side: SearchSortedSide) -> VortexResult<SearchResult> {
         match_each_native_ptype!(self.ptype(), |$T| {
             let pvalue: $T = value.try_into()?;

--- a/vortex-array/src/array/primitive/compute/slice.rs
+++ b/vortex-array/src/array/primitive/compute/slice.rs
@@ -6,7 +6,7 @@ use crate::compute::slice::SliceFn;
 use crate::IntoArray;
 use crate::OwnedArray;
 
-impl SliceFn for PrimitiveArray<'_> {
+impl SliceFn for PrimitiveArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
         match_each_native_ptype!(self.ptype(), |$T| {
             Ok(PrimitiveArray::try_new(

--- a/vortex-array/src/array/primitive/compute/slice.rs
+++ b/vortex-array/src/array/primitive/compute/slice.rs
@@ -3,11 +3,11 @@ use vortex_error::VortexResult;
 
 use crate::array::primitive::PrimitiveArray;
 use crate::compute::slice::SliceFn;
+use crate::Array;
 use crate::IntoArray;
-use crate::OwnedArray;
 
 impl SliceFn for PrimitiveArray {
-    fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
+    fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         match_each_native_ptype!(self.ptype(), |$T| {
             Ok(PrimitiveArray::try_new(
                 self.scalar_buffer::<$T>().slice(start, stop - start),

--- a/vortex-array/src/array/primitive/compute/subtract_scalar.rs
+++ b/vortex-array/src/array/primitive/compute/subtract_scalar.rs
@@ -13,7 +13,7 @@ use crate::stats::{ArrayStatistics, Stat};
 use crate::validity::ArrayValidity;
 use crate::{ArrayDType, ArrayTrait, IntoArray, OwnedArray, ToStatic};
 
-impl SubtractScalarFn for PrimitiveArray<'_> {
+impl SubtractScalarFn for PrimitiveArray {
     fn subtract_scalar(&self, to_subtract: &Scalar) -> VortexResult<OwnedArray> {
         if self.dtype() != to_subtract.dtype() {
             vortex_bail!(MismatchedTypes: self.dtype(), to_subtract.dtype())
@@ -52,9 +52,9 @@ fn subtract_scalar_integer<
     'a,
     T: NativePType + OverflowingSub + SaturatingSub + for<'b> TryFrom<&'b Scalar, Error = VortexError>,
 >(
-    subtract_from: &PrimitiveArray<'a>,
+    subtract_from: &PrimitiveArray,
     to_subtract: T,
-) -> VortexResult<PrimitiveArray<'a>> {
+) -> VortexResult<PrimitiveArray> {
     if to_subtract.is_zero() {
         // if to_subtract is zero, skip operation
         return Ok(subtract_from.clone());

--- a/vortex-array/src/array/primitive/compute/subtract_scalar.rs
+++ b/vortex-array/src/array/primitive/compute/subtract_scalar.rs
@@ -11,10 +11,10 @@ use crate::array::primitive::PrimitiveArray;
 use crate::compute::scalar_subtract::SubtractScalarFn;
 use crate::stats::{ArrayStatistics, Stat};
 use crate::validity::ArrayValidity;
-use crate::{ArrayDType, ArrayTrait, IntoArray, OwnedArray, ToStatic};
+use crate::{Array, ArrayDType, ArrayTrait, IntoArray, ToStatic};
 
 impl SubtractScalarFn for PrimitiveArray {
-    fn subtract_scalar(&self, to_subtract: &Scalar) -> VortexResult<OwnedArray> {
+    fn subtract_scalar(&self, to_subtract: &Scalar) -> VortexResult<Array> {
         if self.dtype() != to_subtract.dtype() {
             vortex_bail!(MismatchedTypes: self.dtype(), to_subtract.dtype())
         }

--- a/vortex-array/src/array/primitive/compute/subtract_scalar.rs
+++ b/vortex-array/src/array/primitive/compute/subtract_scalar.rs
@@ -11,7 +11,7 @@ use crate::array::primitive::PrimitiveArray;
 use crate::compute::scalar_subtract::SubtractScalarFn;
 use crate::stats::{ArrayStatistics, Stat};
 use crate::validity::ArrayValidity;
-use crate::{Array, ArrayDType, ArrayTrait, IntoArray, ToStatic};
+use crate::{Array, ArrayDType, ArrayTrait, IntoArray};
 
 impl SubtractScalarFn for PrimitiveArray {
     fn subtract_scalar(&self, to_subtract: &Scalar) -> VortexResult<Array> {
@@ -44,7 +44,7 @@ impl SubtractScalarFn for PrimitiveArray {
                 PrimitiveArray::from(sub_vec)
             })
         };
-        Ok(result.into_array().to_static())
+        Ok(result.into_array())
     }
 }
 

--- a/vortex-array/src/array/primitive/compute/take.rs
+++ b/vortex-array/src/array/primitive/compute/take.rs
@@ -8,7 +8,7 @@ use crate::compute::take::TakeFn;
 use crate::IntoArray;
 use crate::{Array, OwnedArray};
 
-impl TakeFn for PrimitiveArray<'_> {
+impl TakeFn for PrimitiveArray {
     fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
         let validity = self.validity();
         let indices = indices.clone().flatten_primitive()?;

--- a/vortex-array/src/array/primitive/compute/take.rs
+++ b/vortex-array/src/array/primitive/compute/take.rs
@@ -5,11 +5,11 @@ use vortex_error::VortexResult;
 
 use crate::array::primitive::PrimitiveArray;
 use crate::compute::take::TakeFn;
+use crate::Array;
 use crate::IntoArray;
-use crate::{Array, OwnedArray};
 
 impl TakeFn for PrimitiveArray {
-    fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
+    fn take(&self, indices: &Array) -> VortexResult<Array> {
         let validity = self.validity();
         let indices = indices.clone().flatten_primitive()?;
         match_each_native_ptype!(self.ptype(), |$T| {

--- a/vortex-array/src/array/primitive/mod.rs
+++ b/vortex-array/src/array/primitive/mod.rs
@@ -152,7 +152,7 @@ impl PrimitiveArray {
             vortex_bail!(MismatchedTypes: self.dtype(), T::PTYPE)
         }
 
-        let validity = self.validity().to_static();
+        let validity = self.validity();
 
         let mut own_values = self.into_typed_data();
         // TODO(robert): Also patch validity

--- a/vortex-array/src/array/primitive/mod.rs
+++ b/vortex-array/src/array/primitive/mod.rs
@@ -11,7 +11,7 @@ use vortex_error::vortex_bail;
 use crate::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use crate::visitor::{AcceptArrayVisitor, ArrayVisitor};
 use crate::ArrayFlatten;
-use crate::{impl_encoding, ArrayDType, OwnedArray};
+use crate::{impl_encoding, ArrayDType};
 
 mod accessor;
 mod compute;
@@ -176,7 +176,7 @@ impl<T: NativePType> From<Vec<T>> for PrimitiveArray {
 }
 
 impl<T: NativePType> IntoArray for Vec<T> {
-    fn into_array(self) -> OwnedArray {
+    fn into_array(self) -> Array {
         PrimitiveArray::from(self).into_array()
     }
 }

--- a/vortex-array/src/array/primitive/mod.rs
+++ b/vortex-array/src/array/primitive/mod.rs
@@ -24,7 +24,7 @@ pub struct PrimitiveMetadata {
     validity: ValidityMetadata,
 }
 
-impl PrimitiveArray<'_> {
+impl PrimitiveArray {
     // TODO(ngates): remove the Arrow types from this API.
     pub fn try_new<T: NativePType + ArrowNativeType>(
         buffer: ScalarBuffer<T>,
@@ -169,19 +169,19 @@ impl PrimitiveArray<'_> {
     }
 }
 
-impl<T: NativePType> From<Vec<T>> for PrimitiveArray<'_> {
+impl<T: NativePType> From<Vec<T>> for PrimitiveArray {
     fn from(values: Vec<T>) -> Self {
         PrimitiveArray::from_vec(values, Validity::NonNullable)
     }
 }
 
-impl<T: NativePType> IntoArray<'static> for Vec<T> {
+impl<T: NativePType> IntoArray for Vec<T> {
     fn into_array(self) -> OwnedArray {
         PrimitiveArray::from(self).into_array()
     }
 }
 
-impl ArrayFlatten for PrimitiveArray<'_> {
+impl ArrayFlatten for PrimitiveArray {
     fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
     where
         Self: 'a,
@@ -190,13 +190,13 @@ impl ArrayFlatten for PrimitiveArray<'_> {
     }
 }
 
-impl ArrayTrait for PrimitiveArray<'_> {
+impl ArrayTrait for PrimitiveArray {
     fn len(&self) -> usize {
         self.buffer().len() / self.ptype().byte_width()
     }
 }
 
-impl ArrayValidity for PrimitiveArray<'_> {
+impl ArrayValidity for PrimitiveArray {
     fn is_valid(&self, index: usize) -> bool {
         self.validity().is_valid(index)
     }
@@ -206,15 +206,15 @@ impl ArrayValidity for PrimitiveArray<'_> {
     }
 }
 
-impl AcceptArrayVisitor for PrimitiveArray<'_> {
+impl AcceptArrayVisitor for PrimitiveArray {
     fn accept(&self, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         visitor.visit_buffer(self.buffer())?;
         visitor.visit_validity(&self.validity())
     }
 }
 
-impl<'a> Array<'a> {
-    pub fn into_primitive(self) -> PrimitiveArray<'a> {
+impl<'a> Array {
+    pub fn into_primitive(self) -> PrimitiveArray {
         PrimitiveArray::try_from(self).expect("expected primitive array")
     }
 

--- a/vortex-array/src/array/primitive/mod.rs
+++ b/vortex-array/src/array/primitive/mod.rs
@@ -182,10 +182,7 @@ impl<T: NativePType> IntoArray for Vec<T> {
 }
 
 impl ArrayFlatten for PrimitiveArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
+    fn flatten(self) -> VortexResult<Flattened> {
         Ok(Flattened::Primitive(self))
     }
 }

--- a/vortex-array/src/array/primitive/mod.rs
+++ b/vortex-array/src/array/primitive/mod.rs
@@ -213,7 +213,7 @@ impl AcceptArrayVisitor for PrimitiveArray {
     }
 }
 
-impl<'a> Array {
+impl Array {
     pub fn into_primitive(self) -> PrimitiveArray {
         PrimitiveArray::try_from(self).expect("expected primitive array")
     }

--- a/vortex-array/src/array/primitive/stats.rs
+++ b/vortex-array/src/array/primitive/stats.rs
@@ -18,7 +18,7 @@ use crate::IntoArray;
 trait PStatsType: NativePType + Into<Scalar> + BitWidth {}
 impl<T: NativePType + Into<Scalar> + BitWidth> PStatsType for T {}
 
-impl ArrayStatisticsCompute for PrimitiveArray<'_> {
+impl ArrayStatisticsCompute for PrimitiveArray {
     fn compute_statistics(&self, stat: Stat) -> VortexResult<StatsSet> {
         match_each_native_ptype!(self.ptype(), |$P| {
             match self.logical_validity() {

--- a/vortex-array/src/array/sparse/compress.rs
+++ b/vortex-array/src/array/sparse/compress.rs
@@ -2,7 +2,7 @@ use vortex_error::VortexResult;
 
 use crate::array::sparse::{Sparse, SparseArray, SparseEncoding};
 use crate::compress::{CompressConfig, Compressor, EncodingCompression};
-use crate::{Array, ArrayDef, ArrayTrait, IntoArray, OwnedArray};
+use crate::{Array, ArrayDef, ArrayTrait, IntoArray};
 
 impl EncodingCompression for SparseEncoding {
     fn cost(&self) -> u8 {
@@ -22,7 +22,7 @@ impl EncodingCompression for SparseEncoding {
         array: &Array,
         like: Option<&Array>,
         ctx: Compressor,
-    ) -> VortexResult<OwnedArray> {
+    ) -> VortexResult<Array> {
         let sparse_array = SparseArray::try_from(array)?;
         let sparse_like = like.map(|la| SparseArray::try_from(la).unwrap());
         Ok(SparseArray::new(

--- a/vortex-array/src/array/sparse/compute/mod.rs
+++ b/vortex-array/src/array/sparse/compute/mod.rs
@@ -16,7 +16,7 @@ use crate::{Array, ArrayDType, ArrayTrait, IntoArray, OwnedArray};
 
 mod slice;
 
-impl ArrayCompute for SparseArray<'_> {
+impl ArrayCompute for SparseArray {
     fn as_contiguous(&self) -> Option<&dyn AsContiguousFn> {
         Some(self)
     }
@@ -34,7 +34,7 @@ impl ArrayCompute for SparseArray<'_> {
     }
 }
 
-impl AsContiguousFn for SparseArray<'_> {
+impl AsContiguousFn for SparseArray {
     fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<OwnedArray> {
         let sparse = arrays
             .iter()
@@ -55,7 +55,7 @@ impl AsContiguousFn for SparseArray<'_> {
     }
 }
 
-impl ScalarAtFn for SparseArray<'_> {
+impl ScalarAtFn for SparseArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         match self.find_index(index)? {
             None => self.fill_value().clone().cast(self.dtype()),
@@ -64,7 +64,7 @@ impl ScalarAtFn for SparseArray<'_> {
     }
 }
 
-impl TakeFn for SparseArray<'_> {
+impl TakeFn for SparseArray {
     fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
         let flat_indices = indices.clone().flatten_primitive()?;
         // if we are taking a lot of values we should build a hashmap

--- a/vortex-array/src/array/sparse/compute/slice.rs
+++ b/vortex-array/src/array/sparse/compute/slice.rs
@@ -5,7 +5,7 @@ use crate::compute::search_sorted::{search_sorted, SearchSortedSide};
 use crate::compute::slice::{slice, SliceFn};
 use crate::{IntoArray, OwnedArray};
 
-impl SliceFn for SparseArray<'_> {
+impl SliceFn for SparseArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
         // Find the index of the first patch index that is greater than or equal to the offset of this array
         let index_start_index =

--- a/vortex-array/src/array/sparse/compute/slice.rs
+++ b/vortex-array/src/array/sparse/compute/slice.rs
@@ -3,10 +3,10 @@ use vortex_error::VortexResult;
 use crate::array::sparse::SparseArray;
 use crate::compute::search_sorted::{search_sorted, SearchSortedSide};
 use crate::compute::slice::{slice, SliceFn};
-use crate::{IntoArray, OwnedArray};
+use crate::{Array, IntoArray};
 
 impl SliceFn for SparseArray {
-    fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
+    fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         // Find the index of the first patch index that is greater than or equal to the offset of this array
         let index_start_index =
             search_sorted(&self.indices(), start, SearchSortedSide::Left)?.to_index();

--- a/vortex-array/src/array/sparse/flatten.rs
+++ b/vortex-array/src/array/sparse/flatten.rs
@@ -10,10 +10,7 @@ use crate::validity::Validity;
 use crate::{ArrayFlatten, ArrayTrait, Flattened};
 
 impl ArrayFlatten for SparseArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
+    fn flatten(self) -> VortexResult<Flattened> {
         // Resolve our indices into a vector of usize applying the offset
         let indices = self.resolved_indices();
 
@@ -38,7 +35,7 @@ fn flatten_sparse_values<T: NativePType + for<'a> TryFrom<&'a Scalar, Error = Vo
     len: usize,
     fill_value: &Scalar,
     mut validity: BooleanBufferBuilder,
-) -> VortexResult<Flattened<'static>> {
+) -> VortexResult<Flattened> {
     let primitive_fill = if fill_value.is_null() {
         T::default()
     } else {

--- a/vortex-array/src/array/sparse/flatten.rs
+++ b/vortex-array/src/array/sparse/flatten.rs
@@ -9,7 +9,7 @@ use crate::array::sparse::SparseArray;
 use crate::validity::Validity;
 use crate::{ArrayFlatten, ArrayTrait, Flattened};
 
-impl ArrayFlatten for SparseArray<'_> {
+impl ArrayFlatten for SparseArray {
     fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
     where
         Self: 'a,

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -184,7 +184,7 @@ mod test {
     use crate::compute::cast::cast;
     use crate::compute::scalar_at::scalar_at;
     use crate::compute::slice::slice;
-    use crate::{Array, IntoArray, OwnedArray};
+    use crate::{Array, IntoArray};
 
     fn nullable_fill() -> Scalar {
         Scalar::null(DType::Primitive(PType::I32, Nullable))
@@ -195,7 +195,7 @@ mod test {
         Scalar::from(42i32)
     }
 
-    fn sparse_array(fill_value: Scalar) -> OwnedArray {
+    fn sparse_array(fill_value: Scalar) -> Array {
         // merged array: [null, null, 100, null, null, 200, null, null, 300, null]
         let mut values = vec![100i32, 200, 300].into_array();
         values = cast(&values, fill_value.dtype()).unwrap();

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -25,14 +25,14 @@ pub struct SparseMetadata {
     fill_value: Scalar,
 }
 
-impl<'a> SparseArray<'a> {
-    pub fn new(indices: Array<'a>, values: Array<'a>, len: usize, fill_value: Scalar) -> Self {
+impl<'a> SparseArray {
+    pub fn new(indices: Array, values: Array, len: usize, fill_value: Scalar) -> Self {
         Self::try_new(indices, values, len, fill_value).unwrap()
     }
 
     pub fn try_new(
-        indices: Array<'a>,
-        values: Array<'a>,
+        indices: Array,
+        values: Array,
         len: usize,
         fill_value: Scalar,
     ) -> VortexResult<Self> {
@@ -40,8 +40,8 @@ impl<'a> SparseArray<'a> {
     }
 
     pub(crate) fn try_new_with_offset(
-        indices: Array<'a>,
-        values: Array<'a>,
+        indices: Array,
+        values: Array,
         len: usize,
         indices_offset: usize,
         fill_value: Scalar,
@@ -71,7 +71,7 @@ impl<'a> SparseArray<'a> {
     }
 }
 
-impl SparseArray<'_> {
+impl SparseArray {
     #[inline]
     pub fn indices_offset(&self) -> usize {
         self.metadata().indices_offset
@@ -119,22 +119,22 @@ impl SparseArray<'_> {
     }
 }
 
-impl ArrayTrait for SparseArray<'_> {
+impl ArrayTrait for SparseArray {
     fn len(&self) -> usize {
         self.metadata().len
     }
 }
 
-impl AcceptArrayVisitor for SparseArray<'_> {
+impl AcceptArrayVisitor for SparseArray {
     fn accept(&self, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         visitor.visit_child("indices", &self.indices())?;
         visitor.visit_child("values", &self.values())
     }
 }
 
-impl ArrayStatisticsCompute for SparseArray<'_> {}
+impl ArrayStatisticsCompute for SparseArray {}
 
-impl ArrayValidity for SparseArray<'_> {
+impl ArrayValidity for SparseArray {
     fn is_valid(&self, index: usize) -> bool {
         match self.find_index(index).unwrap() {
             None => !self.fill_value().is_null(),

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -25,7 +25,7 @@ pub struct SparseMetadata {
     fill_value: Scalar,
 }
 
-impl<'a> SparseArray {
+impl SparseArray {
     pub fn new(indices: Array, values: Array, len: usize, fill_value: Scalar) -> Self {
         Self::try_new(indices, values, len, fill_value).unwrap()
     }

--- a/vortex-array/src/array/struct/compute.rs
+++ b/vortex-array/src/array/struct/compute.rs
@@ -17,7 +17,7 @@ use crate::compute::take::{take, TakeFn};
 use crate::compute::ArrayCompute;
 use crate::validity::Validity;
 use crate::ArrayTrait;
-use crate::{Array, ArrayDType, IntoArray, OwnedArray};
+use crate::{Array, ArrayDType, IntoArray};
 
 impl ArrayCompute for StructArray {
     fn as_arrow(&self) -> Option<&dyn AsArrowArray> {
@@ -70,7 +70,7 @@ impl AsArrowArray for StructArray {
 }
 
 impl AsContiguousFn for StructArray {
-    fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<OwnedArray> {
+    fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<Array> {
         let struct_arrays = arrays
             .iter()
             .map(StructArray::try_from)
@@ -113,7 +113,7 @@ impl ScalarAtFn for StructArray {
 }
 
 impl TakeFn for StructArray {
-    fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
+    fn take(&self, indices: &Array) -> VortexResult<Array> {
         StructArray::try_new(
             self.names().clone(),
             self.children()
@@ -127,7 +127,7 @@ impl TakeFn for StructArray {
 }
 
 impl SliceFn for StructArray {
-    fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
+    fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         let fields = self
             .children()
             .map(|field| slice(&field, start, stop))

--- a/vortex-array/src/array/struct/compute.rs
+++ b/vortex-array/src/array/struct/compute.rs
@@ -19,7 +19,7 @@ use crate::validity::Validity;
 use crate::ArrayTrait;
 use crate::{Array, ArrayDType, IntoArray, OwnedArray};
 
-impl ArrayCompute for StructArray<'_> {
+impl ArrayCompute for StructArray {
     fn as_arrow(&self) -> Option<&dyn AsArrowArray> {
         Some(self)
     }
@@ -41,7 +41,7 @@ impl ArrayCompute for StructArray<'_> {
     }
 }
 
-impl AsArrowArray for StructArray<'_> {
+impl AsArrowArray for StructArray {
     fn as_arrow(&self) -> VortexResult<ArrowArrayRef> {
         let field_arrays: Vec<ArrowArrayRef> =
             self.children().map(|f| as_arrow(&f)).try_collect()?;
@@ -69,7 +69,7 @@ impl AsArrowArray for StructArray<'_> {
     }
 }
 
-impl AsContiguousFn for StructArray<'_> {
+impl AsContiguousFn for StructArray {
     fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<OwnedArray> {
         let struct_arrays = arrays
             .iter()
@@ -101,7 +101,7 @@ impl AsContiguousFn for StructArray<'_> {
     }
 }
 
-impl ScalarAtFn for StructArray<'_> {
+impl ScalarAtFn for StructArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         Ok(Scalar::r#struct(
             self.dtype().clone(),
@@ -112,7 +112,7 @@ impl ScalarAtFn for StructArray<'_> {
     }
 }
 
-impl TakeFn for StructArray<'_> {
+impl TakeFn for StructArray {
     fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
         StructArray::try_new(
             self.names().clone(),
@@ -126,7 +126,7 @@ impl TakeFn for StructArray<'_> {
     }
 }
 
-impl SliceFn for StructArray<'_> {
+impl SliceFn for StructArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
         let fields = self
             .children()

--- a/vortex-array/src/array/struct/mod.rs
+++ b/vortex-array/src/array/struct/mod.rs
@@ -18,7 +18,7 @@ pub struct StructMetadata {
     validity: ValidityMetadata,
 }
 
-impl StructArray<'_> {
+impl StructArray {
     pub fn field(&self, idx: usize) -> Option<Array> {
         let DType::Struct(st, _) = self.dtype() else {
             unreachable!()
@@ -52,13 +52,13 @@ impl StructArray<'_> {
     }
 }
 
-impl<'a> StructArray<'a> {
-    pub fn children(&'a self) -> impl Iterator<Item = Array<'a>> {
+impl<'a> StructArray {
+    pub fn children(&'a self) -> impl Iterator<Item = Array> + '_ {
         (0..self.nfields()).map(move |idx| self.field(idx).unwrap())
     }
 }
 
-impl StructArray<'_> {
+impl StructArray {
     pub fn try_new(
         names: FieldNames,
         fields: Vec<Array>,
@@ -98,7 +98,7 @@ impl StructArray<'_> {
     }
 }
 
-impl ArrayFlatten for StructArray<'_> {
+impl ArrayFlatten for StructArray {
     fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
     where
         Self: 'a,
@@ -119,13 +119,13 @@ impl ArrayFlatten for StructArray<'_> {
     }
 }
 
-impl ArrayTrait for StructArray<'_> {
+impl ArrayTrait for StructArray {
     fn len(&self) -> usize {
         self.metadata().length
     }
 }
 
-impl ArrayValidity for StructArray<'_> {
+impl ArrayValidity for StructArray {
     fn is_valid(&self, _index: usize) -> bool {
         todo!()
     }
@@ -135,7 +135,7 @@ impl ArrayValidity for StructArray<'_> {
     }
 }
 
-impl AcceptArrayVisitor for StructArray<'_> {
+impl AcceptArrayVisitor for StructArray {
     fn accept(&self, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         for (idx, name) in self.names().iter().enumerate() {
             let child = self.field(idx).unwrap();
@@ -145,6 +145,6 @@ impl AcceptArrayVisitor for StructArray<'_> {
     }
 }
 
-impl ArrayStatisticsCompute for StructArray<'_> {}
+impl ArrayStatisticsCompute for StructArray {}
 
 impl EncodingCompression for StructEncoding {}

--- a/vortex-array/src/array/struct/mod.rs
+++ b/vortex-array/src/array/struct/mod.rs
@@ -99,10 +99,7 @@ impl StructArray {
 }
 
 impl ArrayFlatten for StructArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
+    fn flatten(self) -> VortexResult<Flattened> {
         Ok(Flattened::Struct(StructArray::try_new(
             self.names().clone(),
             (0..self.nfields())

--- a/vortex-array/src/array/varbin/accessor.rs
+++ b/vortex-array/src/array/varbin/accessor.rs
@@ -5,7 +5,7 @@ use crate::accessor::ArrayAccessor;
 use crate::array::varbin::VarBinArray;
 use crate::validity::ArrayValidity;
 
-impl ArrayAccessor<[u8]> for VarBinArray<'_> {
+impl ArrayAccessor<[u8]> for VarBinArray {
     fn with_iterator<F, R>(&self, f: F) -> VortexResult<R>
     where
         F: for<'a> FnOnce(&mut (dyn Iterator<Item = Option<&'a [u8]>>)) -> R,

--- a/vortex-array/src/array/varbin/array.rs
+++ b/vortex-array/src/array/varbin/array.rs
@@ -5,7 +5,7 @@ use crate::validity::{ArrayValidity, LogicalValidity};
 use crate::visitor::{AcceptArrayVisitor, ArrayVisitor};
 use crate::ArrayTrait;
 
-impl ArrayValidity for VarBinArray<'_> {
+impl ArrayValidity for VarBinArray {
     fn is_valid(&self, index: usize) -> bool {
         self.validity().is_valid(index)
     }
@@ -15,7 +15,7 @@ impl ArrayValidity for VarBinArray<'_> {
     }
 }
 
-impl AcceptArrayVisitor for VarBinArray<'_> {
+impl AcceptArrayVisitor for VarBinArray {
     fn accept(&self, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         visitor.visit_child("offsets", &self.offsets())?;
         visitor.visit_child("bytes", &self.bytes())?;
@@ -23,7 +23,7 @@ impl AcceptArrayVisitor for VarBinArray<'_> {
     }
 }
 
-impl ArrayTrait for VarBinArray<'_> {
+impl ArrayTrait for VarBinArray {
     fn len(&self) -> usize {
         self.offsets().len() - 1
     }

--- a/vortex-array/src/array/varbin/builder.rs
+++ b/vortex-array/src/array/varbin/builder.rs
@@ -5,7 +5,7 @@ use vortex_dtype::DType;
 use vortex_dtype::NativePType;
 
 use crate::array::primitive::PrimitiveArray;
-use crate::array::varbin::{OwnedVarBinArray, VarBinArray};
+use crate::array::varbin::VarBinArray;
 use crate::validity::Validity;
 use crate::IntoArray;
 
@@ -48,7 +48,7 @@ impl<O: NativePType> VarBinBuilder<O> {
         self.validity.append_null();
     }
 
-    pub fn finish(&mut self, dtype: DType) -> OwnedVarBinArray {
+    pub fn finish(&mut self, dtype: DType) -> VarBinArray {
         let offsets = PrimitiveArray::from(mem::take(&mut self.offsets));
         let data = PrimitiveArray::from(mem::take(&mut self.data));
 

--- a/vortex-array/src/array/varbin/compress.rs
+++ b/vortex-array/src/array/varbin/compress.rs
@@ -4,7 +4,7 @@ use crate::array::downcast::DowncastArrayBuiltin;
 use crate::array::varbin::{VarBinArray, VarBinEncoding};
 use crate::array::{Array, ArrayRef};
 use crate::compress::{CompressConfig, CompressCtx, EncodingCompression};
-use crate::validity::OwnedValidity;
+use crate::validity::Validity;
 
 impl EncodingCompression for VarBinEncoding {
     fn cost(&self) -> u8 {

--- a/vortex-array/src/array/varbin/compute/mod.rs
+++ b/vortex-array/src/array/varbin/compute/mod.rs
@@ -20,7 +20,7 @@ use crate::compute::slice::SliceFn;
 use crate::compute::take::TakeFn;
 use crate::compute::ArrayCompute;
 use crate::validity::{ArrayValidity, Validity};
-use crate::{Array, ArrayDType, IntoArray, OwnedArray, ToArray};
+use crate::{Array, ArrayDType, IntoArray, ToArray};
 
 mod slice;
 mod take;
@@ -48,7 +48,7 @@ impl ArrayCompute for VarBinArray {
 }
 
 impl AsContiguousFn for VarBinArray {
-    fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<OwnedArray> {
+    fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<Array> {
         let bytes_chunks: Vec<Array> = arrays
             .iter()
             .map(|a| VarBinArray::try_from(a).unwrap().sliced_bytes())

--- a/vortex-array/src/array/varbin/compute/mod.rs
+++ b/vortex-array/src/array/varbin/compute/mod.rs
@@ -25,7 +25,7 @@ use crate::{Array, ArrayDType, IntoArray, OwnedArray, ToArray};
 mod slice;
 mod take;
 
-impl ArrayCompute for VarBinArray<'_> {
+impl ArrayCompute for VarBinArray {
     fn as_arrow(&self) -> Option<&dyn AsArrowArray> {
         Some(self)
     }
@@ -47,7 +47,7 @@ impl ArrayCompute for VarBinArray<'_> {
     }
 }
 
-impl AsContiguousFn for VarBinArray<'_> {
+impl AsContiguousFn for VarBinArray {
     fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<OwnedArray> {
         let bytes_chunks: Vec<Array> = arrays
             .iter()
@@ -83,7 +83,7 @@ impl AsContiguousFn for VarBinArray<'_> {
     }
 }
 
-impl AsArrowArray for VarBinArray<'_> {
+impl AsArrowArray for VarBinArray {
     fn as_arrow(&self) -> VortexResult<ArrowArrayRef> {
         // Ensure the offsets are either i32 or i64
         let offsets = self.offsets().flatten_primitive()?;
@@ -133,7 +133,7 @@ impl AsArrowArray for VarBinArray<'_> {
     }
 }
 
-impl ScalarAtFn for VarBinArray<'_> {
+impl ScalarAtFn for VarBinArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         if self.is_valid(index) {
             Ok(varbin_scalar(

--- a/vortex-array/src/array/varbin/compute/slice.rs
+++ b/vortex-array/src/array/varbin/compute/slice.rs
@@ -2,10 +2,10 @@ use vortex_error::VortexResult;
 
 use crate::array::varbin::VarBinArray;
 use crate::compute::slice::{slice, SliceFn};
-use crate::{ArrayDType, IntoArray, OwnedArray};
+use crate::{Array, ArrayDType, IntoArray};
 
 impl SliceFn for VarBinArray {
-    fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
+    fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         VarBinArray::try_new(
             slice(&self.offsets(), start, stop + 1)?,
             self.bytes().clone(),

--- a/vortex-array/src/array/varbin/compute/slice.rs
+++ b/vortex-array/src/array/varbin/compute/slice.rs
@@ -4,7 +4,7 @@ use crate::array::varbin::VarBinArray;
 use crate::compute::slice::{slice, SliceFn};
 use crate::{ArrayDType, IntoArray, OwnedArray};
 
-impl SliceFn for VarBinArray<'_> {
+impl SliceFn for VarBinArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
         VarBinArray::try_new(
             slice(&self.offsets(), start, stop + 1)?,

--- a/vortex-array/src/array/varbin/compute/take.rs
+++ b/vortex-array/src/array/varbin/compute/take.rs
@@ -12,7 +12,7 @@ use crate::ArrayDType;
 use crate::IntoArray;
 use crate::{Array, OwnedArray};
 
-impl TakeFn for VarBinArray<'_> {
+impl TakeFn for VarBinArray {
     fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
         // TODO(ngates): support i64 indices.
         assert!(

--- a/vortex-array/src/array/varbin/compute/take.rs
+++ b/vortex-array/src/array/varbin/compute/take.rs
@@ -5,15 +5,15 @@ use vortex_dtype::NativePType;
 use vortex_error::VortexResult;
 
 use crate::array::varbin::builder::VarBinBuilder;
-use crate::array::varbin::{OwnedVarBinArray, VarBinArray};
+use crate::array::varbin::VarBinArray;
 use crate::compute::take::TakeFn;
 use crate::validity::Validity;
+use crate::Array;
 use crate::ArrayDType;
 use crate::IntoArray;
-use crate::{Array, OwnedArray};
 
 impl TakeFn for VarBinArray {
-    fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
+    fn take(&self, indices: &Array) -> VortexResult<Array> {
         // TODO(ngates): support i64 indices.
         assert!(
             indices.len() < i32::MAX as usize,
@@ -43,7 +43,7 @@ fn take<I: NativePType, O: NativePType>(
     data: &[u8],
     indices: &[I],
     validity: Validity,
-) -> VortexResult<OwnedVarBinArray> {
+) -> VortexResult<VarBinArray> {
     let logical_validity = validity.to_logical(offsets.len() - 1);
     if let Some(v) = logical_validity.to_null_buffer()? {
         return Ok(take_nullable(dtype, offsets, data, indices, v));
@@ -65,7 +65,7 @@ fn take_nullable<I: NativePType, O: NativePType>(
     data: &[u8],
     indices: &[I],
     null_buffer: NullBuffer,
-) -> OwnedVarBinArray {
+) -> VarBinArray {
     let mut builder = VarBinBuilder::<I>::with_capacity(indices.len());
     for &idx in indices {
         let idx = idx.to_usize().unwrap();

--- a/vortex-array/src/array/varbin/flatten.rs
+++ b/vortex-array/src/array/varbin/flatten.rs
@@ -4,10 +4,7 @@ use crate::array::varbin::VarBinArray;
 use crate::{ArrayFlatten, Flattened};
 
 impl ArrayFlatten for VarBinArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
+    fn flatten(self) -> VortexResult<Flattened> {
         Ok(Flattened::VarBin(self))
     }
 }

--- a/vortex-array/src/array/varbin/flatten.rs
+++ b/vortex-array/src/array/varbin/flatten.rs
@@ -3,7 +3,7 @@ use vortex_error::VortexResult;
 use crate::array::varbin::VarBinArray;
 use crate::{ArrayFlatten, Flattened};
 
-impl ArrayFlatten for VarBinArray<'_> {
+impl ArrayFlatten for VarBinArray {
     fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
     where
         Self: 'a,

--- a/vortex-array/src/array/varbin/mod.rs
+++ b/vortex-array/src/array/varbin/mod.rs
@@ -31,7 +31,7 @@ pub struct VarBinMetadata {
     offsets_dtype: DType,
 }
 
-impl VarBinArray<'_> {
+impl VarBinArray {
     pub fn try_new(
         offsets: Array,
         bytes: Array,
@@ -159,49 +159,49 @@ impl VarBinArray<'_> {
     }
 }
 
-impl From<Vec<&[u8]>> for VarBinArray<'_> {
+impl From<Vec<&[u8]>> for VarBinArray {
     fn from(value: Vec<&[u8]>) -> Self {
         VarBinArray::from_vec(value, DType::Binary(Nullability::NonNullable))
     }
 }
 
-impl From<Vec<Vec<u8>>> for VarBinArray<'_> {
+impl From<Vec<Vec<u8>>> for VarBinArray {
     fn from(value: Vec<Vec<u8>>) -> Self {
         VarBinArray::from_vec(value, DType::Binary(Nullability::NonNullable))
     }
 }
 
-impl From<Vec<String>> for VarBinArray<'_> {
+impl From<Vec<String>> for VarBinArray {
     fn from(value: Vec<String>) -> Self {
         VarBinArray::from_vec(value, DType::Utf8(Nullability::NonNullable))
     }
 }
 
-impl From<Vec<&str>> for VarBinArray<'_> {
+impl From<Vec<&str>> for VarBinArray {
     fn from(value: Vec<&str>) -> Self {
         VarBinArray::from_vec(value, DType::Utf8(Nullability::NonNullable))
     }
 }
 
-impl<'a> FromIterator<Option<&'a [u8]>> for VarBinArray<'_> {
+impl<'a> FromIterator<Option<&'a [u8]>> for VarBinArray {
     fn from_iter<T: IntoIterator<Item = Option<&'a [u8]>>>(iter: T) -> Self {
         VarBinArray::from_iter(iter, DType::Binary(Nullability::Nullable))
     }
 }
 
-impl FromIterator<Option<Vec<u8>>> for VarBinArray<'_> {
+impl FromIterator<Option<Vec<u8>>> for VarBinArray {
     fn from_iter<T: IntoIterator<Item = Option<Vec<u8>>>>(iter: T) -> Self {
         VarBinArray::from_iter(iter, DType::Binary(Nullability::Nullable))
     }
 }
 
-impl FromIterator<Option<String>> for VarBinArray<'_> {
+impl FromIterator<Option<String>> for VarBinArray {
     fn from_iter<T: IntoIterator<Item = Option<String>>>(iter: T) -> Self {
         VarBinArray::from_iter(iter, DType::Utf8(Nullability::Nullable))
     }
 }
 
-impl<'a> FromIterator<Option<&'a str>> for VarBinArray<'_> {
+impl<'a> FromIterator<Option<&'a str>> for VarBinArray {
     fn from_iter<T: IntoIterator<Item = Option<&'a str>>>(iter: T) -> Self {
         VarBinArray::from_iter(iter, DType::Utf8(Nullability::Nullable))
     }

--- a/vortex-array/src/array/varbin/mod.rs
+++ b/vortex-array/src/array/varbin/mod.rs
@@ -9,7 +9,7 @@ use crate::array::varbin::builder::VarBinBuilder;
 use crate::compute::scalar_at::scalar_at;
 use crate::compute::slice::slice;
 use crate::validity::{Validity, ValidityMetadata};
-use crate::{impl_encoding, ArrayDType, OwnedArray, ToArrayData};
+use crate::{impl_encoding, ArrayDType, ToArrayData};
 
 mod accessor;
 mod array;
@@ -93,7 +93,7 @@ impl VarBinArray {
             .to_validity(self.array().child(2, &Validity::DTYPE))
     }
 
-    pub fn sliced_bytes(&self) -> VortexResult<OwnedArray> {
+    pub fn sliced_bytes(&self) -> VortexResult<Array> {
         let first_offset: usize = scalar_at(&self.offsets(), 0)?.as_ref().try_into()?;
         let last_offset: usize = scalar_at(&self.offsets(), self.offsets().len() - 1)?
             .as_ref()
@@ -227,9 +227,9 @@ mod test {
     use crate::compute::scalar_at::scalar_at;
     use crate::compute::slice::slice;
     use crate::validity::Validity;
-    use crate::{IntoArray, OwnedArray};
+    use crate::{Array, IntoArray};
 
-    fn binary_array() -> OwnedArray {
+    fn binary_array() -> Array {
         let values = PrimitiveArray::from(
             "hello worldhello world this is a long string"
                 .as_bytes()

--- a/vortex-array/src/array/varbin/stats.rs
+++ b/vortex-array/src/array/varbin/stats.rs
@@ -10,7 +10,7 @@ use crate::array::varbin::{varbin_scalar, VarBinArray};
 use crate::stats::{ArrayStatisticsCompute, Stat, StatsSet};
 use crate::{ArrayDType, ArrayTrait};
 
-impl ArrayStatisticsCompute for VarBinArray<'_> {
+impl ArrayStatisticsCompute for VarBinArray {
     fn compute_statistics(&self, _stat: Stat) -> VortexResult<StatsSet> {
         if self.is_empty() {
             return Ok(StatsSet::new());

--- a/vortex-array/src/array/varbin/stats.rs
+++ b/vortex-array/src/array/varbin/stats.rs
@@ -129,10 +129,10 @@ mod test {
     use vortex_buffer::{Buffer, BufferString};
     use vortex_dtype::{DType, Nullability};
 
-    use crate::array::varbin::{OwnedVarBinArray, VarBinArray};
+    use crate::array::varbin::VarBinArray;
     use crate::stats::{ArrayStatistics, Stat};
 
-    fn array(dtype: DType) -> OwnedVarBinArray {
+    fn array(dtype: DType) -> VarBinArray {
         VarBinArray::from_vec(
             vec!["hello world", "hello world this is a long string"],
             dtype,

--- a/vortex-array/src/array/varbinview/accessor.rs
+++ b/vortex-array/src/array/varbinview/accessor.rs
@@ -5,7 +5,7 @@ use crate::array::primitive::PrimitiveArray;
 use crate::array::varbinview::VarBinViewArray;
 use crate::validity::ArrayValidity;
 
-impl ArrayAccessor<[u8]> for VarBinViewArray<'_> {
+impl ArrayAccessor<[u8]> for VarBinViewArray {
     fn with_iterator<F: for<'a> FnOnce(&mut dyn Iterator<Item = Option<&'a [u8]>>) -> R, R>(
         &self,
         f: F,

--- a/vortex-array/src/array/varbinview/builder.rs
+++ b/vortex-array/src/array/varbinview/builder.rs
@@ -6,9 +6,7 @@ use arrow_buffer::NullBufferBuilder;
 use vortex_dtype::DType;
 
 use crate::array::primitive::PrimitiveArray;
-use crate::array::varbinview::{
-    BinaryView, Inlined, OwnedVarBinViewArray, Ref, VarBinViewArray, VIEW_SIZE,
-};
+use crate::array::varbinview::{BinaryView, Inlined, Ref, VarBinViewArray, VIEW_SIZE};
 use crate::validity::Validity;
 use crate::{ArrayData, IntoArray, IntoArrayData, ToArray};
 
@@ -82,7 +80,7 @@ impl<T: AsRef<[u8]>> VarBinViewBuilder<T> {
         self.nulls.append_null();
     }
 
-    pub fn finish(mut self, dtype: DType) -> OwnedVarBinViewArray {
+    pub fn finish(mut self, dtype: DType) -> VarBinViewArray {
         let mut completed = self
             .completed
             .into_iter()

--- a/vortex-array/src/array/varbinview/compute.rs
+++ b/vortex-array/src/array/varbinview/compute.rs
@@ -16,7 +16,7 @@ use crate::compute::scalar_at::ScalarAtFn;
 use crate::compute::slice::{slice, SliceFn};
 use crate::compute::ArrayCompute;
 use crate::validity::ArrayValidity;
-use crate::{ArrayDType, IntoArray, IntoArrayData, OwnedArray};
+use crate::{Array, ArrayDType, IntoArray, IntoArrayData};
 
 impl ArrayCompute for VarBinViewArray {
     fn as_arrow(&self) -> Option<&dyn AsArrowArray> {
@@ -81,7 +81,7 @@ impl AsArrowArray for VarBinViewArray {
 }
 
 impl SliceFn for VarBinViewArray {
-    fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
+    fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         Ok(VarBinViewArray::try_new(
             slice(&self.views(), start * VIEW_SIZE, stop * VIEW_SIZE)?
                 .into_array_data()

--- a/vortex-array/src/array/varbinview/compute.rs
+++ b/vortex-array/src/array/varbinview/compute.rs
@@ -18,7 +18,7 @@ use crate::compute::ArrayCompute;
 use crate::validity::ArrayValidity;
 use crate::{ArrayDType, IntoArray, IntoArrayData, OwnedArray};
 
-impl ArrayCompute for VarBinViewArray<'_> {
+impl ArrayCompute for VarBinViewArray {
     fn as_arrow(&self) -> Option<&dyn AsArrowArray> {
         Some(self)
     }
@@ -32,7 +32,7 @@ impl ArrayCompute for VarBinViewArray<'_> {
     }
 }
 
-impl ScalarAtFn for VarBinViewArray<'_> {
+impl ScalarAtFn for VarBinViewArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         if self.is_valid(index) {
             self.bytes_at(index)
@@ -43,7 +43,7 @@ impl ScalarAtFn for VarBinViewArray<'_> {
     }
 }
 
-impl AsArrowArray for VarBinViewArray<'_> {
+impl AsArrowArray for VarBinViewArray {
     fn as_arrow(&self) -> VortexResult<ArrowArrayRef> {
         // Views should be buffer of u8
         let views = self.views().flatten_primitive()?;
@@ -80,7 +80,7 @@ impl AsArrowArray for VarBinViewArray<'_> {
     }
 }
 
-impl SliceFn for VarBinViewArray<'_> {
+impl SliceFn for VarBinViewArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
         Ok(VarBinViewArray::try_new(
             slice(&self.views(), start * VIEW_SIZE, stop * VIEW_SIZE)?

--- a/vortex-array/src/array/varbinview/mod.rs
+++ b/vortex-array/src/array/varbinview/mod.rs
@@ -104,7 +104,7 @@ pub struct VarBinViewMetadata {
     n_children: usize,
 }
 
-impl VarBinViewArray<'_> {
+impl VarBinViewArray {
     pub fn try_new(
         views: Array,
         data: Vec<Array>,
@@ -217,7 +217,7 @@ impl VarBinViewArray<'_> {
     }
 }
 
-impl ArrayFlatten for VarBinViewArray<'_> {
+impl ArrayFlatten for VarBinViewArray {
     fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
     where
         Self: 'a,
@@ -226,7 +226,7 @@ impl ArrayFlatten for VarBinViewArray<'_> {
     }
 }
 
-impl ArrayValidity for VarBinViewArray<'_> {
+impl ArrayValidity for VarBinViewArray {
     fn is_valid(&self, index: usize) -> bool {
         self.validity().is_valid(index)
     }
@@ -236,7 +236,7 @@ impl ArrayValidity for VarBinViewArray<'_> {
     }
 }
 
-impl AcceptArrayVisitor for VarBinViewArray<'_> {
+impl AcceptArrayVisitor for VarBinViewArray {
     fn accept(&self, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         visitor.visit_child("views", &self.views())?;
         for i in 0..self.metadata().n_children {
@@ -246,55 +246,55 @@ impl AcceptArrayVisitor for VarBinViewArray<'_> {
     }
 }
 
-impl ArrayTrait for VarBinViewArray<'_> {
+impl ArrayTrait for VarBinViewArray {
     fn len(&self) -> usize {
         self.view_slice().len()
     }
 }
 
-impl From<Vec<&[u8]>> for VarBinViewArray<'_> {
+impl From<Vec<&[u8]>> for VarBinViewArray {
     fn from(value: Vec<&[u8]>) -> Self {
         VarBinViewArray::from_vec(value, DType::Binary(Nullability::NonNullable))
     }
 }
 
-impl From<Vec<Vec<u8>>> for VarBinViewArray<'_> {
+impl From<Vec<Vec<u8>>> for VarBinViewArray {
     fn from(value: Vec<Vec<u8>>) -> Self {
         VarBinViewArray::from_vec(value, DType::Binary(Nullability::NonNullable))
     }
 }
 
-impl From<Vec<String>> for VarBinViewArray<'_> {
+impl From<Vec<String>> for VarBinViewArray {
     fn from(value: Vec<String>) -> Self {
         VarBinViewArray::from_vec(value, DType::Utf8(Nullability::NonNullable))
     }
 }
 
-impl From<Vec<&str>> for VarBinViewArray<'_> {
+impl From<Vec<&str>> for VarBinViewArray {
     fn from(value: Vec<&str>) -> Self {
         VarBinViewArray::from_vec(value, DType::Utf8(Nullability::NonNullable))
     }
 }
 
-impl<'a> FromIterator<Option<&'a [u8]>> for VarBinViewArray<'_> {
+impl<'a> FromIterator<Option<&'a [u8]>> for VarBinViewArray {
     fn from_iter<T: IntoIterator<Item = Option<&'a [u8]>>>(iter: T) -> Self {
         VarBinViewArray::from_iter(iter, DType::Binary(Nullability::NonNullable))
     }
 }
 
-impl FromIterator<Option<Vec<u8>>> for VarBinViewArray<'_> {
+impl FromIterator<Option<Vec<u8>>> for VarBinViewArray {
     fn from_iter<T: IntoIterator<Item = Option<Vec<u8>>>>(iter: T) -> Self {
         VarBinViewArray::from_iter(iter, DType::Binary(Nullability::NonNullable))
     }
 }
 
-impl FromIterator<Option<String>> for VarBinViewArray<'_> {
+impl FromIterator<Option<String>> for VarBinViewArray {
     fn from_iter<T: IntoIterator<Item = Option<String>>>(iter: T) -> Self {
         VarBinViewArray::from_iter(iter, DType::Utf8(Nullability::NonNullable))
     }
 }
 
-impl<'a> FromIterator<Option<&'a str>> for VarBinViewArray<'_> {
+impl<'a> FromIterator<Option<&'a str>> for VarBinViewArray {
     fn from_iter<T: IntoIterator<Item = Option<&'a str>>>(iter: T) -> Self {
         VarBinViewArray::from_iter(iter, DType::Utf8(Nullability::NonNullable))
     }

--- a/vortex-array/src/array/varbinview/mod.rs
+++ b/vortex-array/src/array/varbinview/mod.rs
@@ -218,10 +218,7 @@ impl VarBinViewArray {
 }
 
 impl ArrayFlatten for VarBinViewArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
+    fn flatten(self) -> VortexResult<Flattened> {
         Ok(Flattened::VarBinView(self))
     }
 }

--- a/vortex-array/src/array/varbinview/stats.rs
+++ b/vortex-array/src/array/varbinview/stats.rs
@@ -6,7 +6,7 @@ use crate::array::varbinview::VarBinViewArray;
 use crate::stats::{ArrayStatisticsCompute, Stat, StatsSet};
 use crate::{ArrayDType, ArrayTrait};
 
-impl ArrayStatisticsCompute for VarBinViewArray<'_> {
+impl ArrayStatisticsCompute for VarBinViewArray {
     fn compute_statistics(&self, _stat: Stat) -> VortexResult<StatsSet> {
         if self.is_empty() {
             return Ok(StatsSet::new());

--- a/vortex-array/src/arrow/wrappers.rs
+++ b/vortex-array/src/arrow/wrappers.rs
@@ -4,14 +4,14 @@ use vortex_dtype::NativePType;
 use crate::array::primitive::PrimitiveArray;
 
 pub fn as_scalar_buffer<T: NativePType + ArrowNativeType>(
-    array: PrimitiveArray<'_>,
+    array: PrimitiveArray,
 ) -> ScalarBuffer<T> {
     assert_eq!(array.ptype(), T::PTYPE);
     ScalarBuffer::from(ArrowBuffer::from(array.buffer()))
 }
 
 pub fn as_offset_buffer<T: NativePType + ArrowNativeType>(
-    array: PrimitiveArray<'_>,
+    array: PrimitiveArray,
 ) -> OffsetBuffer<T> {
     OffsetBuffer::new(as_scalar_buffer(array))
 }

--- a/vortex-array/src/compress.rs
+++ b/vortex-array/src/compress.rs
@@ -13,7 +13,7 @@ use crate::encoding::{ArrayEncoding, EncodingRef};
 use crate::sampling::stratified_slices;
 use crate::stats::ArrayStatistics;
 use crate::validity::Validity;
-use crate::{compute, Array, ArrayDType, ArrayDef, ArrayTrait, Context, IntoArray, ToStatic};
+use crate::{compute, Array, ArrayDType, ArrayDef, ArrayTrait, Context, IntoArray};
 
 pub trait EncodingCompression: ArrayEncoding {
     fn cost(&self) -> u8 {
@@ -134,7 +134,7 @@ impl<'a> Compressor<'a> {
 
     pub fn compress(&self, arr: &Array, like: Option<&Array>) -> VortexResult<Array> {
         if arr.is_empty() {
-            return Ok(arr.to_static());
+            return Ok(arr.clone());
         }
 
         // Attempt to compress using the "like" array, otherwise fall back to sampled compression
@@ -199,7 +199,7 @@ impl<'a> Compressor<'a> {
             }
             Constant::ID => {
                 // Not much better we can do than constant!
-                Ok(arr.to_static())
+                Ok(arr.clone())
             }
             Struct::ID => {
                 // For struct arrays, we compress each field individually
@@ -220,7 +220,7 @@ impl<'a> Compressor<'a> {
             _ => {
                 // Otherwise, we run sampled compression over pluggable encodings
                 let sampled = sampled_compression(arr, self)?;
-                Ok(sampled.unwrap_or_else(|| arr.to_static()))
+                Ok(sampled.unwrap_or_else(|| arr.clone()))
             }
         }
     }

--- a/vortex-array/src/compress.rs
+++ b/vortex-array/src/compress.rs
@@ -178,7 +178,7 @@ impl<'a> Compressor<'a> {
         Ok(compressed)
     }
 
-    pub fn compress_validity<'v>(&self, validity: Validity<'v>) -> VortexResult<Validity<'v>> {
+    pub fn compress_validity(&self, validity: Validity) -> VortexResult<Validity> {
         match validity {
             Validity::Array(a) => Ok(Validity::Array(self.compress(&a, None)?)),
             a => Ok(a),

--- a/vortex-array/src/compute/as_contiguous.rs
+++ b/vortex-array/src/compute/as_contiguous.rs
@@ -1,13 +1,13 @@
 use itertools::Itertools;
 use vortex_error::{vortex_bail, vortex_err, VortexResult};
 
-use crate::{Array, ArrayDType, OwnedArray};
+use crate::{Array, ArrayDType};
 
 pub trait AsContiguousFn {
-    fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<OwnedArray>;
+    fn as_contiguous(&self, arrays: &[Array]) -> VortexResult<Array>;
 }
 
-pub fn as_contiguous(arrays: &[Array]) -> VortexResult<OwnedArray> {
+pub fn as_contiguous(arrays: &[Array]) -> VortexResult<Array> {
     if arrays.is_empty() {
         vortex_bail!(ComputeError: "No arrays to concatenate");
     }

--- a/vortex-array/src/compute/cast.rs
+++ b/vortex-array/src/compute/cast.rs
@@ -1,7 +1,7 @@
 use vortex_dtype::DType;
 use vortex_error::{vortex_err, VortexResult};
 
-use crate::{Array, ArrayDType, ToStatic};
+use crate::{Array, ArrayDType};
 
 pub trait CastFn {
     fn cast(&self, dtype: &DType) -> VortexResult<Array>;
@@ -9,7 +9,7 @@ pub trait CastFn {
 
 pub fn cast(array: &Array, dtype: &DType) -> VortexResult<Array> {
     if array.dtype() == dtype {
-        return Ok(array.to_static());
+        return Ok(array.clone());
     }
 
     // TODO(ngates): check for null_count if dtype is non-nullable

--- a/vortex-array/src/compute/cast.rs
+++ b/vortex-array/src/compute/cast.rs
@@ -1,13 +1,13 @@
 use vortex_dtype::DType;
 use vortex_error::{vortex_err, VortexResult};
 
-use crate::{Array, ArrayDType, OwnedArray, ToStatic};
+use crate::{Array, ArrayDType, ToStatic};
 
 pub trait CastFn {
-    fn cast(&self, dtype: &DType) -> VortexResult<OwnedArray>;
+    fn cast(&self, dtype: &DType) -> VortexResult<Array>;
 }
 
-pub fn cast(array: &Array, dtype: &DType) -> VortexResult<OwnedArray> {
+pub fn cast(array: &Array, dtype: &DType) -> VortexResult<Array> {
     if array.dtype() == dtype {
         return Ok(array.to_static());
     }

--- a/vortex-array/src/compute/fill.rs
+++ b/vortex-array/src/compute/fill.rs
@@ -1,6 +1,6 @@
 use vortex_error::{vortex_err, VortexResult};
 
-use crate::{Array, ArrayDType, ToStatic};
+use crate::{Array, ArrayDType};
 
 pub trait FillForwardFn {
     fn fill_forward(&self) -> VortexResult<Array>;
@@ -8,7 +8,7 @@ pub trait FillForwardFn {
 
 pub fn fill_forward(array: &Array) -> VortexResult<Array> {
     if !array.dtype().is_nullable() {
-        return Ok(array.to_static());
+        return Ok(array.clone());
     }
 
     array.with_dyn(|a| {

--- a/vortex-array/src/compute/fill.rs
+++ b/vortex-array/src/compute/fill.rs
@@ -1,12 +1,12 @@
 use vortex_error::{vortex_err, VortexResult};
 
-use crate::{Array, ArrayDType, OwnedArray, ToStatic};
+use crate::{Array, ArrayDType, ToStatic};
 
 pub trait FillForwardFn {
-    fn fill_forward(&self) -> VortexResult<OwnedArray>;
+    fn fill_forward(&self) -> VortexResult<Array>;
 }
 
-pub fn fill_forward(array: &Array) -> VortexResult<OwnedArray> {
+pub fn fill_forward(array: &Array) -> VortexResult<Array> {
     if !array.dtype().is_nullable() {
         return Ok(array.to_static());
     }

--- a/vortex-array/src/compute/patch.rs
+++ b/vortex-array/src/compute/patch.rs
@@ -1,13 +1,13 @@
 use vortex_error::{vortex_bail, vortex_err, VortexResult};
 
-use crate::{Array, ArrayDType, OwnedArray};
+use crate::{Array, ArrayDType};
 
 pub trait PatchFn {
-    fn patch(&self, patch: &Array) -> VortexResult<OwnedArray>;
+    fn patch(&self, patch: &Array) -> VortexResult<Array>;
 }
 
 /// Returns a new array where the non-null values from the patch array are replaced in the original.
-pub fn patch(array: &Array, patch: &Array) -> VortexResult<OwnedArray> {
+pub fn patch(array: &Array, patch: &Array) -> VortexResult<Array> {
     if array.len() != patch.len() {
         vortex_bail!(
             "patch array {} must have the same length as the original array {}",

--- a/vortex-array/src/compute/scalar_subtract.rs
+++ b/vortex-array/src/compute/scalar_subtract.rs
@@ -2,13 +2,13 @@ use vortex_dtype::DType;
 use vortex_error::{vortex_err, VortexResult};
 use vortex_scalar::Scalar;
 
-use crate::{Array, ArrayDType, OwnedArray};
+use crate::{Array, ArrayDType};
 
 pub trait SubtractScalarFn {
-    fn subtract_scalar(&self, to_subtract: &Scalar) -> VortexResult<OwnedArray>;
+    fn subtract_scalar(&self, to_subtract: &Scalar) -> VortexResult<Array>;
 }
 
-pub fn subtract_scalar(array: &Array, to_subtract: &Scalar) -> VortexResult<OwnedArray> {
+pub fn subtract_scalar(array: &Array, to_subtract: &Scalar) -> VortexResult<Array> {
     if let Some(subtraction_result) =
         array.with_dyn(|c| c.subtract_scalar().map(|t| t.subtract_scalar(to_subtract)))
     {

--- a/vortex-array/src/compute/search_sorted.rs
+++ b/vortex-array/src/compute/search_sorted.rs
@@ -180,7 +180,7 @@ fn search_sorted_side_idx<F: FnMut(usize) -> Ordering>(
     SearchResult::NotFound(left)
 }
 
-impl IndexOrd<Scalar> for Array<'_> {
+impl IndexOrd<Scalar> for Array {
     fn index_cmp(&self, idx: usize, elem: &Scalar) -> Option<Ordering> {
         let scalar_a = scalar_at(self, idx).ok()?;
         scalar_a.partial_cmp(elem)
@@ -194,7 +194,7 @@ impl<T: PartialOrd> IndexOrd<T> for [T] {
     }
 }
 
-impl Len for Array<'_> {
+impl Len for Array {
     fn len(&self) -> usize {
         Array::len(self)
     }

--- a/vortex-array/src/compute/slice.rs
+++ b/vortex-array/src/compute/slice.rs
@@ -1,13 +1,13 @@
 use vortex_error::{vortex_bail, vortex_err, VortexResult};
 
-use crate::{Array, OwnedArray};
+use crate::Array;
 
 /// Limit array to start..stop range
 pub trait SliceFn {
-    fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray>;
+    fn slice(&self, start: usize, stop: usize) -> VortexResult<Array>;
 }
 
-pub fn slice(array: &Array, start: usize, stop: usize) -> VortexResult<OwnedArray> {
+pub fn slice(array: &Array, start: usize, stop: usize) -> VortexResult<Array> {
     check_slice_bounds(array, start, stop)?;
 
     array.with_dyn(|c| {

--- a/vortex-array/src/compute/take.rs
+++ b/vortex-array/src/compute/take.rs
@@ -1,13 +1,13 @@
 use log::info;
 use vortex_error::{vortex_err, VortexResult};
 
-use crate::{Array, IntoArray, OwnedArray};
+use crate::{Array, IntoArray};
 
 pub trait TakeFn {
-    fn take(&self, indices: &Array) -> VortexResult<OwnedArray>;
+    fn take(&self, indices: &Array) -> VortexResult<Array>;
 }
 
-pub fn take(array: &Array, indices: &Array) -> VortexResult<OwnedArray> {
+pub fn take(array: &Array, indices: &Array) -> VortexResult<Array> {
     array.with_dyn(|a| {
         if let Some(take) = a.take() {
             return take.take(indices);

--- a/vortex-array/src/data.rs
+++ b/vortex-array/src/data.rs
@@ -131,7 +131,7 @@ impl ToArray for ArrayData {
     }
 }
 
-impl IntoArray<'static> for ArrayData {
+impl IntoArray for ArrayData {
     fn into_array(self) -> OwnedArray {
         Array::Data(self)
     }

--- a/vortex-array/src/data.rs
+++ b/vortex-array/src/data.rs
@@ -7,7 +7,7 @@ use vortex_scalar::Scalar;
 
 use crate::encoding::EncodingRef;
 use crate::stats::{Stat, Statistics, StatsSet};
-use crate::{Array, ArrayMetadata, IntoArray, OwnedArray, ToArray};
+use crate::{Array, ArrayMetadata, IntoArray, ToArray};
 
 #[derive(Clone, Debug)]
 pub struct ArrayData {
@@ -132,7 +132,7 @@ impl ToArray for ArrayData {
 }
 
 impl IntoArray for ArrayData {
-    fn into_array(self) -> OwnedArray {
+    fn into_array(self) -> Array {
         Array::Data(self)
     }
 }

--- a/vortex-array/src/encoding.rs
+++ b/vortex-array/src/encoding.rs
@@ -39,12 +39,12 @@ pub trait ArrayEncoding: 'static + Sync + Send + Debug {
     fn id(&self) -> EncodingId;
 
     /// Flatten the given array.
-    fn flatten<'a>(&self, array: Array<'a>) -> VortexResult<Flattened<'a>>;
+    fn flatten<'a>(&self, array: Array) -> VortexResult<Flattened<'a>>;
 
     /// Unwrap the provided array into an implementation of ArrayTrait
     fn with_dyn<'a>(
         &self,
-        array: &'a Array<'a>,
+        array: &'a Array,
         f: &mut dyn for<'b> FnMut(&'b (dyn ArrayTrait + 'a)) -> VortexResult<()>,
     ) -> VortexResult<()>;
 
@@ -68,21 +68,21 @@ impl Hash for dyn ArrayEncoding + '_ {
 pub trait ArrayEncodingExt {
     type D: ArrayDef;
 
-    fn flatten<'a>(array: Array<'a>) -> VortexResult<Flattened<'a>>
+    fn flatten<'a>(array: Array) -> VortexResult<Flattened<'a>>
     where
         <Self as ArrayEncodingExt>::D: 'a,
     {
-        let typed = <<Self::D as ArrayDef>::Array<'a> as TryFrom<Array>>::try_from(array)?;
+        let typed = <<Self::D as ArrayDef>::Array as TryFrom<Array>>::try_from(array)?;
         ArrayFlatten::flatten(typed)
     }
 
-    fn with_dyn<'a, R, F>(array: &'a Array<'a>, mut f: F) -> R
+    fn with_dyn<'a, R, F>(array: &'a Array, mut f: F) -> R
     where
         F: for<'b> FnMut(&'b (dyn ArrayTrait + 'a)) -> R,
         <Self as ArrayEncodingExt>::D: 'a,
     {
         let typed =
-            <<Self::D as ArrayDef>::Array<'a> as TryFrom<Array>>::try_from(array.clone()).unwrap();
+            <<Self::D as ArrayDef>::Array as TryFrom<Array>>::try_from(array.clone()).unwrap();
         f(&typed)
     }
 }

--- a/vortex-array/src/encoding.rs
+++ b/vortex-array/src/encoding.rs
@@ -42,11 +42,10 @@ pub trait ArrayEncoding: 'static + Sync + Send + Debug {
     fn flatten(&self, array: Array) -> VortexResult<Flattened>;
 
     /// Unwrap the provided array into an implementation of ArrayTrait
-    #[allow(clippy::needless_lifetimes)]
-    fn with_dyn<'a>(
+    fn with_dyn(
         &self,
-        array: &'a Array,
-        f: &mut dyn for<'b> FnMut(&'b (dyn ArrayTrait + 'a)) -> VortexResult<()>,
+        array: &Array,
+        f: &mut dyn for<'b> FnMut(&'b (dyn ArrayTrait + 'b)) -> VortexResult<()>,
     ) -> VortexResult<()>;
 
     /// Return a compressor for this encoding.
@@ -74,10 +73,9 @@ pub trait ArrayEncodingExt {
         ArrayFlatten::flatten(typed)
     }
 
-    fn with_dyn<'a, R, F>(array: &'a Array, mut f: F) -> R
+    fn with_dyn<R, F>(array: &Array, mut f: F) -> R
     where
-        F: for<'b> FnMut(&'b (dyn ArrayTrait + 'a)) -> R,
-        <Self as ArrayEncodingExt>::D: 'a,
+        F: for<'b> FnMut(&'b (dyn ArrayTrait + 'b)) -> R,
     {
         let typed =
             <<Self::D as ArrayDef>::Array as TryFrom<Array>>::try_from(array.clone()).unwrap();

--- a/vortex-array/src/encoding.rs
+++ b/vortex-array/src/encoding.rs
@@ -42,6 +42,7 @@ pub trait ArrayEncoding: 'static + Sync + Send + Debug {
     fn flatten<'a>(&self, array: Array) -> VortexResult<Flattened<'a>>;
 
     /// Unwrap the provided array into an implementation of ArrayTrait
+    #[allow(clippy::needless_lifetimes)]
     fn with_dyn<'a>(
         &self,
         array: &'a Array,

--- a/vortex-array/src/encoding.rs
+++ b/vortex-array/src/encoding.rs
@@ -39,7 +39,7 @@ pub trait ArrayEncoding: 'static + Sync + Send + Debug {
     fn id(&self) -> EncodingId;
 
     /// Flatten the given array.
-    fn flatten<'a>(&self, array: Array) -> VortexResult<Flattened<'a>>;
+    fn flatten(&self, array: Array) -> VortexResult<Flattened>;
 
     /// Unwrap the provided array into an implementation of ArrayTrait
     #[allow(clippy::needless_lifetimes)]
@@ -69,10 +69,7 @@ impl Hash for dyn ArrayEncoding + '_ {
 pub trait ArrayEncodingExt {
     type D: ArrayDef;
 
-    fn flatten<'a>(array: Array) -> VortexResult<Flattened<'a>>
-    where
-        <Self as ArrayEncodingExt>::D: 'a,
-    {
+    fn flatten(array: Array) -> VortexResult<Flattened> {
         let typed = <<Self::D as ArrayDef>::Array as TryFrom<Array>>::try_from(array)?;
         ArrayFlatten::flatten(typed)
     }

--- a/vortex-array/src/flatten.rs
+++ b/vortex-array/src/flatten.rs
@@ -11,7 +11,7 @@ use crate::encoding::ArrayEncoding;
 use crate::{Array, IntoArray};
 
 /// The set of encodings that can be converted to Arrow with zero-copy.
-pub enum Flattened<'a> {
+pub enum Flattened {
     Bool(BoolArray),
     Chunked(ChunkedArray),
     Primitive(PrimitiveArray),
@@ -19,17 +19,14 @@ pub enum Flattened<'a> {
     VarBin(VarBinArray),
     VarBinView(VarBinViewArray),
     Extension(ExtensionArray),
-    Phantom(&'a ()),
 }
 
 pub trait ArrayFlatten {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a;
+    fn flatten(self) -> VortexResult<Flattened>;
 }
 
 impl<'a> Array {
-    pub fn flatten(self) -> VortexResult<Flattened<'a>> {
+    pub fn flatten(self) -> VortexResult<Flattened> {
         ArrayEncoding::flatten(self.encoding(), self)
     }
 
@@ -46,7 +43,7 @@ impl<'a> Array {
     }
 }
 
-impl<'a> IntoArray for Flattened<'a> {
+impl IntoArray for Flattened {
     fn into_array(self) -> Array {
         match self {
             Flattened::Bool(a) => a.into_array(),
@@ -56,7 +53,6 @@ impl<'a> IntoArray for Flattened<'a> {
             Flattened::VarBin(a) => a.into_array(),
             Flattened::Extension(a) => a.into_array(),
             Flattened::VarBinView(a) => a.into_array(),
-            Flattened::Phantom(_) => unreachable!(),
         }
     }
 }

--- a/vortex-array/src/flatten.rs
+++ b/vortex-array/src/flatten.rs
@@ -12,13 +12,14 @@ use crate::{Array, IntoArray};
 
 /// The set of encodings that can be converted to Arrow with zero-copy.
 pub enum Flattened<'a> {
-    Bool(BoolArray<'a>),
-    Chunked(ChunkedArray<'a>),
-    Primitive(PrimitiveArray<'a>),
-    Struct(StructArray<'a>),
-    VarBin(VarBinArray<'a>),
-    VarBinView(VarBinViewArray<'a>),
-    Extension(ExtensionArray<'a>),
+    Bool(BoolArray),
+    Chunked(ChunkedArray),
+    Primitive(PrimitiveArray),
+    Struct(StructArray),
+    VarBin(VarBinArray),
+    VarBinView(VarBinViewArray),
+    Extension(ExtensionArray),
+    Phantom(&'a ()),
 }
 
 pub trait ArrayFlatten {
@@ -27,26 +28,26 @@ pub trait ArrayFlatten {
         Self: 'a;
 }
 
-impl<'a> Array<'a> {
+impl<'a> Array {
     pub fn flatten(self) -> VortexResult<Flattened<'a>> {
         ArrayEncoding::flatten(self.encoding(), self)
     }
 
-    pub fn flatten_bool(self) -> VortexResult<BoolArray<'a>> {
+    pub fn flatten_bool(self) -> VortexResult<BoolArray> {
         BoolArray::try_from(self.flatten()?.into_array())
     }
 
-    pub fn flatten_primitive(self) -> VortexResult<PrimitiveArray<'a>> {
+    pub fn flatten_primitive(self) -> VortexResult<PrimitiveArray> {
         PrimitiveArray::try_from(self.flatten()?.into_array())
     }
 
-    pub fn flatten_varbin(self) -> VortexResult<VarBinArray<'a>> {
+    pub fn flatten_varbin(self) -> VortexResult<VarBinArray> {
         VarBinArray::try_from(self.flatten()?.into_array())
     }
 }
 
-impl<'a> IntoArray<'a> for Flattened<'a> {
-    fn into_array(self) -> Array<'a> {
+impl<'a> IntoArray for Flattened<'a> {
+    fn into_array(self) -> Array {
         match self {
             Flattened::Bool(a) => a.into_array(),
             Flattened::Primitive(a) => a.into_array(),
@@ -55,6 +56,7 @@ impl<'a> IntoArray<'a> for Flattened<'a> {
             Flattened::VarBin(a) => a.into_array(),
             Flattened::Extension(a) => a.into_array(),
             Flattened::VarBinView(a) => a.into_array(),
+            Flattened::Phantom(_) => unreachable!(),
         }
     }
 }

--- a/vortex-array/src/flatten.rs
+++ b/vortex-array/src/flatten.rs
@@ -25,7 +25,7 @@ pub trait ArrayFlatten {
     fn flatten(self) -> VortexResult<Flattened>;
 }
 
-impl<'a> Array {
+impl Array {
     pub fn flatten(self) -> VortexResult<Flattened> {
         ArrayEncoding::flatten(self.encoding(), self)
     }

--- a/vortex-array/src/implementation.rs
+++ b/vortex-array/src/implementation.rs
@@ -144,7 +144,7 @@ macro_rules! impl_encoding {
                     $Name::ID
                 }
 
-                fn flatten<'a>(&self, array: Array) -> VortexResult<Flattened<'a>> {
+                fn flatten(&self, array: Array) -> VortexResult<Flattened> {
                     <Self as ArrayEncodingExt>::flatten(array)
                 }
 

--- a/vortex-array/src/implementation.rs
+++ b/vortex-array/src/implementation.rs
@@ -196,6 +196,7 @@ impl<T: AsArray> ArrayDType for T {
         match self.as_array_ref() {
             Array::Data(d) => d.dtype(),
             Array::View(v) => v.dtype(),
+            Array::Phantom(_) => unreachable!(),
         }
     }
 }
@@ -205,6 +206,7 @@ impl<T: AsArray> ArrayStatistics for T {
         match self.as_array_ref() {
             Array::Data(d) => d.statistics(),
             Array::View(v) => v.statistics(),
+            Array::Phantom(_) => unreachable!(),
         }
     }
 }
@@ -253,6 +255,7 @@ impl<'a, T: IntoArray<'a> + ArrayEncodingRef + ArrayStatistics + GetArrayMetadat
                 )
                 .unwrap()
             }
+            Array::Phantom(_) => unreachable!(),
         }
     }
 }

--- a/vortex-array/src/implementation.rs
+++ b/vortex-array/src/implementation.rs
@@ -146,12 +146,11 @@ macro_rules! impl_encoding {
                     <Self as ArrayEncodingExt>::flatten(array)
                 }
 
-                #[allow(clippy::needless_lifetimes)]
                 #[inline]
-                fn with_dyn<'a>(
+                fn with_dyn(
                     &self,
-                    array: &'a Array,
-                    f: &mut dyn for<'b> FnMut(&'b (dyn ArrayTrait + 'a)) -> VortexResult<()>,
+                    array: &Array,
+                    f: &mut dyn for<'b> FnMut(&'b (dyn ArrayTrait + 'b)) -> VortexResult<()>,
                 ) -> VortexResult<()> {
                     <Self as ArrayEncodingExt>::with_dyn(array, f)
                 }

--- a/vortex-array/src/implementation.rs
+++ b/vortex-array/src/implementation.rs
@@ -148,6 +148,7 @@ macro_rules! impl_encoding {
                     <Self as ArrayEncodingExt>::flatten(array)
                 }
 
+                #[allow(clippy::needless_lifetimes)]
                 #[inline]
                 fn with_dyn<'a>(
                     &self,
@@ -179,7 +180,7 @@ macro_rules! impl_encoding {
     };
 }
 
-impl<'a> AsArray for Array {
+impl AsArray for Array {
     fn as_array_ref(&self) -> &Array {
         self
     }
@@ -209,7 +210,7 @@ impl<T: AsArray> ArrayStatistics for T {
     }
 }
 
-impl<'a, T: IntoArray + ArrayEncodingRef + ArrayStatistics + GetArrayMetadata> IntoArrayData for T {
+impl<T: IntoArray + ArrayEncodingRef + ArrayStatistics + GetArrayMetadata> IntoArrayData for T {
     fn into_array_data(self) -> ArrayData {
         let encoding = self.encoding();
         let metadata = self.metadata();

--- a/vortex-array/src/implementation.rs
+++ b/vortex-array/src/implementation.rs
@@ -72,8 +72,6 @@ macro_rules! impl_encoding {
             pub struct [<$Name Array>] {
                 typed: TypedArray<$Name>
             }
-            #[allow(dead_code)]
-            pub type [<Owned $Name Array>] = [<$Name Array>];
             impl [<$Name Array>] {
                 pub fn array(&self) -> &Array {
                     self.typed.array()

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -64,7 +64,8 @@ pub mod flatbuffers {
 #[derive(Debug, Clone)]
 pub enum Array<'v> {
     Data(ArrayData),
-    View(ArrayView<'v>),
+    View(ArrayView),
+    Phantom(&'v ()),
 }
 
 pub type OwnedArray = Array<'static>;
@@ -74,6 +75,7 @@ impl Array<'_> {
         match self {
             Array::Data(d) => d.encoding(),
             Array::View(v) => v.encoding(),
+            Array::Phantom(_) => unreachable!(),
         }
     }
 
@@ -93,6 +95,7 @@ impl Array<'_> {
         match self {
             Array::Data(d) => d.child(idx, dtype).cloned().map(Array::Data),
             Array::View(v) => v.child(idx, dtype).map(Array::View),
+            Array::Phantom(_) => unreachable!(),
         }
     }
 
@@ -100,6 +103,7 @@ impl Array<'_> {
         match self {
             Array::Data(d) => d.buffer(),
             Array::View(v) => v.buffer(),
+            Array::Phantom(_) => unreachable!(),
         }
     }
 }
@@ -109,6 +113,7 @@ impl<'a> Array<'a> {
         match self {
             Array::Data(d) => d.into_buffer(),
             Array::View(v) => v.buffer().cloned(),
+            Array::Phantom(_) => unreachable!(),
         }
     }
 }
@@ -215,6 +220,7 @@ impl Display for Array<'_> {
         let prefix = match self {
             Array::Data(_) => "",
             Array::View(_) => "$",
+            Array::Phantom(_) => unreachable!(),
         };
         write!(
             f,
@@ -232,6 +238,7 @@ impl IntoArrayData for Array<'_> {
         match self {
             Array::Data(d) => d,
             Array::View(_) => self.with_dyn(|a| a.to_array_data()),
+            Array::Phantom(_) => unreachable!(),
         }
     }
 }

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -67,8 +67,6 @@ pub enum Array {
     View(ArrayView),
 }
 
-pub type OwnedArray = Array;
-
 impl Array {
     pub fn encoding(&self) -> EncodingRef {
         match self {
@@ -114,7 +112,7 @@ impl Array {
 }
 
 impl ToStatic for Array {
-    type Static = OwnedArray;
+    type Static = Array;
 
     fn to_static(&self) -> Self::Static {
         Array::Data(self.to_array_data())

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -111,14 +111,6 @@ impl Array {
     }
 }
 
-impl ToStatic for Array {
-    type Static = Array;
-
-    fn to_static(&self) -> Self::Static {
-        Array::Data(self.to_array_data())
-    }
-}
-
 pub trait ToArray {
     fn to_array(&self) -> Array;
 }
@@ -133,12 +125,6 @@ pub trait ToArrayData {
 
 pub trait IntoArrayData {
     fn into_array_data(self) -> ArrayData;
-}
-
-pub trait ToStatic {
-    type Static;
-
-    fn to_static(&self) -> Self::Static;
 }
 
 pub trait AsArray {

--- a/vortex-array/src/tree.rs
+++ b/vortex-array/src/tree.rs
@@ -9,15 +9,15 @@ use crate::array::chunked::ChunkedArray;
 use crate::visitor::ArrayVisitor;
 use crate::{Array, ToArrayData};
 
-impl Array<'_> {
+impl Array {
     pub fn tree_display(&self) -> TreeDisplayWrapper {
         TreeDisplayWrapper(self)
     }
 }
 
-pub struct TreeDisplayWrapper<'a>(&'a Array<'a>);
+pub struct TreeDisplayWrapper<'a>(&'a Array);
 impl<'a> TreeDisplayWrapper<'a> {
-    pub fn new(array: &'a Array<'a>) -> Self {
+    pub fn new(array: &'a Array) -> Self {
         Self(array)
     }
 }

--- a/vortex-array/src/typed.rs
+++ b/vortex-array/src/typed.rs
@@ -8,12 +8,12 @@ use crate::stats::StatsSet;
 use crate::{Array, ArrayData, ArrayDef, AsArray, IntoArray, ToArray, TryDeserializeArrayMetadata};
 
 #[derive(Debug, Clone)]
-pub struct TypedArray<'a, D: ArrayDef> {
-    array: Array<'a>,
+pub struct TypedArray<D: ArrayDef> {
+    array: Array,
     metadata: D::Metadata,
 }
 
-impl<D: ArrayDef> TypedArray<'_, D> {
+impl<D: ArrayDef> TypedArray<D> {
     pub fn try_from_parts(
         dtype: DType,
         metadata: D::Metadata,
@@ -37,16 +37,16 @@ impl<D: ArrayDef> TypedArray<'_, D> {
     }
 }
 
-impl<'a, 'b, D: ArrayDef> TypedArray<'b, D> {
-    pub fn array(&'a self) -> &'a Array<'b> {
+impl<'a, 'b, D: ArrayDef> TypedArray<D> {
+    pub fn array(&'a self) -> &'a Array {
         &self.array
     }
 }
 
-impl<'a, D: ArrayDef> TryFrom<Array<'a>> for TypedArray<'a, D> {
+impl<'a, D: ArrayDef> TryFrom<Array> for TypedArray<D> {
     type Error = VortexError;
 
-    fn try_from(array: Array<'a>) -> Result<Self, Self::Error> {
+    fn try_from(array: Array) -> Result<Self, Self::Error> {
         if array.encoding().id() != D::ENCODING.id() {
             return Err(vortex_err!("incorrect encoding"));
         }
@@ -58,34 +58,33 @@ impl<'a, D: ArrayDef> TryFrom<Array<'a>> for TypedArray<'a, D> {
                 .unwrap()
                 .clone(),
             Array::View(v) => D::Metadata::try_deserialize_metadata(v.metadata())?,
-            Array::Phantom(_) => unreachable!(),
         };
         Ok(TypedArray { array, metadata })
     }
 }
 
-impl<'a, D: ArrayDef> TryFrom<&'a Array<'a>> for TypedArray<'a, D> {
+impl<'a, D: ArrayDef> TryFrom<&'a Array> for TypedArray<D> {
     type Error = VortexError;
 
-    fn try_from(value: &'a Array<'a>) -> Result<Self, Self::Error> {
+    fn try_from(value: &'a Array) -> Result<Self, Self::Error> {
         value.clone().try_into()
     }
 }
 
-impl<'a, D: ArrayDef> AsArray for TypedArray<'a, D> {
+impl<'a, D: ArrayDef> AsArray for TypedArray<D> {
     fn as_array_ref(&self) -> &Array {
         &self.array
     }
 }
 
-impl<D: ArrayDef> ToArray for TypedArray<'_, D> {
+impl<D: ArrayDef> ToArray for TypedArray<D> {
     fn to_array(&self) -> Array {
         self.array.clone()
     }
 }
 
-impl<'a, D: ArrayDef> IntoArray<'a> for TypedArray<'a, D> {
-    fn into_array(self) -> Array<'a> {
+impl<'a, D: ArrayDef> IntoArray for TypedArray<D> {
+    fn into_array(self) -> Array {
         self.array
     }
 }

--- a/vortex-array/src/typed.rs
+++ b/vortex-array/src/typed.rs
@@ -58,6 +58,7 @@ impl<'a, D: ArrayDef> TryFrom<Array<'a>> for TypedArray<'a, D> {
                 .unwrap()
                 .clone(),
             Array::View(v) => D::Metadata::try_deserialize_metadata(v.metadata())?,
+            Array::Phantom(_) => unreachable!(),
         };
         Ok(TypedArray { array, metadata })
     }

--- a/vortex-array/src/typed.rs
+++ b/vortex-array/src/typed.rs
@@ -37,13 +37,13 @@ impl<D: ArrayDef> TypedArray<D> {
     }
 }
 
-impl<'a, 'b, D: ArrayDef> TypedArray<D> {
-    pub fn array(&'a self) -> &'a Array {
+impl<D: ArrayDef> TypedArray<D> {
+    pub fn array(&self) -> &Array {
         &self.array
     }
 }
 
-impl<'a, D: ArrayDef> TryFrom<Array> for TypedArray<D> {
+impl<D: ArrayDef> TryFrom<Array> for TypedArray<D> {
     type Error = VortexError;
 
     fn try_from(array: Array) -> Result<Self, Self::Error> {
@@ -71,7 +71,7 @@ impl<'a, D: ArrayDef> TryFrom<&'a Array> for TypedArray<D> {
     }
 }
 
-impl<'a, D: ArrayDef> AsArray for TypedArray<D> {
+impl<D: ArrayDef> AsArray for TypedArray<D> {
     fn as_array_ref(&self) -> &Array {
         &self.array
     }
@@ -83,7 +83,7 @@ impl<D: ArrayDef> ToArray for TypedArray<D> {
     }
 }
 
-impl<'a, D: ArrayDef> IntoArray for TypedArray<D> {
+impl<D: ArrayDef> IntoArray for TypedArray<D> {
     fn into_array(self) -> Array {
         self.array
     }

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -136,15 +136,6 @@ impl Validity {
             }
         }
     }
-
-    pub fn to_static(&self) -> Validity {
-        match self {
-            Validity::NonNullable => Validity::NonNullable,
-            Validity::AllValid => Validity::AllValid,
-            Validity::AllInvalid => Validity::AllInvalid,
-            Validity::Array(a) => Validity::Array(a.to_array_data().into_array()),
-        }
-    }
 }
 
 impl PartialEq for Validity {

--- a/vortex-array/src/view.rs
+++ b/vortex-array/src/view.rs
@@ -248,8 +248,8 @@ impl ToArray for ArrayView {
     }
 }
 
-impl<'v> IntoArray<'v> for ArrayView {
-    fn into_array(self) -> Array<'v> {
+impl<'v> IntoArray for ArrayView {
+    fn into_array(self) -> Array {
         Array::View(self)
     }
 }

--- a/vortex-array/src/view.rs
+++ b/vortex-array/src/view.rs
@@ -248,7 +248,7 @@ impl ToArray for ArrayView {
     }
 }
 
-impl<'v> IntoArray for ArrayView {
+impl IntoArray for ArrayView {
     fn into_array(self) -> Array {
         Array::View(self)
     }

--- a/vortex-datetime-parts/src/array.rs
+++ b/vortex-datetime-parts/src/array.rs
@@ -80,10 +80,7 @@ impl DateTimePartsArray {
 }
 
 impl ArrayFlatten for DateTimePartsArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
+    fn flatten(self) -> VortexResult<Flattened> {
         // TODO(ngates): flatten into vortex.localdatetime or appropriate per dtype
         todo!()
     }

--- a/vortex-datetime-parts/src/array.rs
+++ b/vortex-datetime-parts/src/array.rs
@@ -16,7 +16,7 @@ pub struct DateTimePartsMetadata {
     subseconds_dtype: DType,
 }
 
-impl DateTimePartsArray<'_> {
+impl DateTimePartsArray {
     pub fn try_new(
         dtype: DType,
         days: Array,
@@ -79,7 +79,7 @@ impl DateTimePartsArray<'_> {
     }
 }
 
-impl ArrayFlatten for DateTimePartsArray<'_> {
+impl ArrayFlatten for DateTimePartsArray {
     fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
     where
         Self: 'a,
@@ -89,7 +89,7 @@ impl ArrayFlatten for DateTimePartsArray<'_> {
     }
 }
 
-impl ArrayValidity for DateTimePartsArray<'_> {
+impl ArrayValidity for DateTimePartsArray {
     fn is_valid(&self, index: usize) -> bool {
         self.days().with_dyn(|a| a.is_valid(index))
     }
@@ -99,7 +99,7 @@ impl ArrayValidity for DateTimePartsArray<'_> {
     }
 }
 
-impl AcceptArrayVisitor for DateTimePartsArray<'_> {
+impl AcceptArrayVisitor for DateTimePartsArray {
     fn accept(&self, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         visitor.visit_child("days", &self.days())?;
         visitor.visit_child("seconds", &self.seconds())?;
@@ -107,9 +107,9 @@ impl AcceptArrayVisitor for DateTimePartsArray<'_> {
     }
 }
 
-impl ArrayStatisticsCompute for DateTimePartsArray<'_> {}
+impl ArrayStatisticsCompute for DateTimePartsArray {}
 
-impl ArrayTrait for DateTimePartsArray<'_> {
+impl ArrayTrait for DateTimePartsArray {
     fn len(&self) -> usize {
         self.days().len()
     }

--- a/vortex-datetime-parts/src/compress.rs
+++ b/vortex-datetime-parts/src/compress.rs
@@ -2,7 +2,7 @@ use vortex::array::datetime::{LocalDateTimeArray, TimeUnit};
 use vortex::array::primitive::PrimitiveArray;
 use vortex::compress::{CompressConfig, Compressor, EncodingCompression};
 use vortex::compute::cast::cast;
-use vortex::{Array, ArrayTrait, IntoArray, OwnedArray};
+use vortex::{Array, ArrayTrait, IntoArray};
 use vortex_dtype::PType;
 use vortex_error::VortexResult;
 
@@ -25,7 +25,7 @@ impl EncodingCompression for DateTimePartsEncoding {
         array: &Array,
         like: Option<&Array>,
         ctx: Compressor,
-    ) -> VortexResult<OwnedArray> {
+    ) -> VortexResult<Array> {
         compress_localdatetime(
             LocalDateTimeArray::try_from(array)?,
             like.map(|l| DateTimePartsArray::try_from(l).unwrap()),
@@ -38,7 +38,7 @@ fn compress_localdatetime(
     array: LocalDateTimeArray,
     like: Option<DateTimePartsArray>,
     ctx: Compressor,
-) -> VortexResult<OwnedArray> {
+) -> VortexResult<Array> {
     let timestamps = cast(&array.timestamps(), PType::I64.into())?.flatten_primitive()?;
 
     let divisor = match array.time_unit() {

--- a/vortex-datetime-parts/src/compute.rs
+++ b/vortex-datetime-parts/src/compute.rs
@@ -1,7 +1,7 @@
 use vortex::compute::slice::{slice, SliceFn};
 use vortex::compute::take::{take, TakeFn};
 use vortex::compute::ArrayCompute;
-use vortex::{Array, ArrayDType, IntoArray, OwnedArray};
+use vortex::{Array, ArrayDType, IntoArray};
 use vortex_error::VortexResult;
 
 use crate::DateTimePartsArray;
@@ -17,7 +17,7 @@ impl ArrayCompute for DateTimePartsArray {
 }
 
 impl TakeFn for DateTimePartsArray {
-    fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
+    fn take(&self, indices: &Array) -> VortexResult<Array> {
         Ok(DateTimePartsArray::try_new(
             self.dtype().clone(),
             take(&self.days(), indices)?,
@@ -29,7 +29,7 @@ impl TakeFn for DateTimePartsArray {
 }
 
 impl SliceFn for DateTimePartsArray {
-    fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
+    fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         Ok(DateTimePartsArray::try_new(
             self.dtype().clone(),
             slice(&self.days(), start, stop)?,

--- a/vortex-datetime-parts/src/compute.rs
+++ b/vortex-datetime-parts/src/compute.rs
@@ -6,7 +6,7 @@ use vortex_error::VortexResult;
 
 use crate::DateTimePartsArray;
 
-impl ArrayCompute for DateTimePartsArray<'_> {
+impl ArrayCompute for DateTimePartsArray {
     fn slice(&self) -> Option<&dyn SliceFn> {
         Some(self)
     }
@@ -16,7 +16,7 @@ impl ArrayCompute for DateTimePartsArray<'_> {
     }
 }
 
-impl TakeFn for DateTimePartsArray<'_> {
+impl TakeFn for DateTimePartsArray {
     fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
         Ok(DateTimePartsArray::try_new(
             self.dtype().clone(),
@@ -28,7 +28,7 @@ impl TakeFn for DateTimePartsArray<'_> {
     }
 }
 
-impl SliceFn for DateTimePartsArray<'_> {
+impl SliceFn for DateTimePartsArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
         Ok(DateTimePartsArray::try_new(
             self.dtype().clone(),

--- a/vortex-dict/benches/dict_compress.rs
+++ b/vortex-dict/benches/dict_compress.rs
@@ -8,7 +8,7 @@ use vortex::ArrayTrait;
 use vortex_dict::dict_encode_typed_primitive;
 use vortex_dtype::match_each_native_ptype;
 
-fn gen_primitive_dict<'a>(len: usize, uniqueness: f64) -> PrimitiveArray<'a> {
+fn gen_primitive_dict<'a>(len: usize, uniqueness: f64) -> PrimitiveArray {
     let mut rng = thread_rng();
     let value_range = len as f64 * uniqueness;
     let range = Uniform::new(-(value_range / 2.0) as i32, (value_range / 2.0) as i32);
@@ -17,7 +17,7 @@ fn gen_primitive_dict<'a>(len: usize, uniqueness: f64) -> PrimitiveArray<'a> {
     PrimitiveArray::from(data)
 }
 
-fn gen_varbin_dict<'a>(len: usize, uniqueness: f64) -> VarBinArray<'a> {
+fn gen_varbin_dict<'a>(len: usize, uniqueness: f64) -> VarBinArray {
     let mut rng = thread_rng();
     let uniq_cnt = (len as f64 * uniqueness) as usize;
     let dict: Vec<String> = (0..uniq_cnt)

--- a/vortex-dict/benches/dict_compress.rs
+++ b/vortex-dict/benches/dict_compress.rs
@@ -8,7 +8,7 @@ use vortex::ArrayTrait;
 use vortex_dict::dict_encode_typed_primitive;
 use vortex_dtype::match_each_native_ptype;
 
-fn gen_primitive_dict<'a>(len: usize, uniqueness: f64) -> PrimitiveArray {
+fn gen_primitive_dict(len: usize, uniqueness: f64) -> PrimitiveArray {
     let mut rng = thread_rng();
     let value_range = len as f64 * uniqueness;
     let range = Uniform::new(-(value_range / 2.0) as i32, (value_range / 2.0) as i32);
@@ -17,7 +17,7 @@ fn gen_primitive_dict<'a>(len: usize, uniqueness: f64) -> PrimitiveArray {
     PrimitiveArray::from(data)
 }
 
-fn gen_varbin_dict<'a>(len: usize, uniqueness: f64) -> VarBinArray {
+fn gen_varbin_dict(len: usize, uniqueness: f64) -> VarBinArray {
     let mut rng = thread_rng();
     let uniq_cnt = (len as f64 * uniqueness) as usize;
     let dict: Vec<String> = (0..uniq_cnt)

--- a/vortex-dict/src/compress.rs
+++ b/vortex-dict/src/compress.rs
@@ -108,7 +108,7 @@ impl<T: ToBytes> Eq for Value<T> {}
 
 /// Dictionary encode primitive array with given PType.
 /// Null values in the original array are encoded in the dictionary.
-pub fn dict_encode_typed_primitive<'a, T: NativePType>(
+pub fn dict_encode_typed_primitive<T: NativePType>(
     array: &PrimitiveArray,
 ) -> (PrimitiveArray, PrimitiveArray) {
     let mut lookup_dict: HashMap<Value<T>, u64> = HashMap::new();
@@ -172,7 +172,7 @@ fn lookup_bytes<'a, T: NativePType + AsPrimitive<usize>>(
     &bytes[begin..end]
 }
 
-fn dict_encode_typed_varbin<'a, I, U>(dtype: DType, values: I) -> (PrimitiveArray, VarBinArray)
+fn dict_encode_typed_varbin<I, U>(dtype: DType, values: I) -> (PrimitiveArray, VarBinArray)
 where
     I: Iterator<Item = Option<U>>,
     U: AsRef<[u8]>,

--- a/vortex-dict/src/compress.rs
+++ b/vortex-dict/src/compress.rs
@@ -156,7 +156,7 @@ pub fn dict_encode_typed_primitive<'a, T: NativePType>(
 }
 
 /// Dictionary encode varbin array. Specializes for primitive byte arrays to avoid double copying
-pub fn dict_encode_varbin<'a>(array: &'a VarBinArray) -> (PrimitiveArray, VarBinArray) {
+pub fn dict_encode_varbin(array: &VarBinArray) -> (PrimitiveArray, VarBinArray) {
     array
         .with_iterator(|iter| dict_encode_typed_varbin(array.dtype().clone(), iter))
         .unwrap()

--- a/vortex-dict/src/compress.rs
+++ b/vortex-dict/src/compress.rs
@@ -109,8 +109,8 @@ impl<T: ToBytes> Eq for Value<T> {}
 /// Dictionary encode primitive array with given PType.
 /// Null values in the original array are encoded in the dictionary.
 pub fn dict_encode_typed_primitive<'a, T: NativePType>(
-    array: &PrimitiveArray<'a>,
-) -> (PrimitiveArray<'a>, PrimitiveArray<'a>) {
+    array: &PrimitiveArray,
+) -> (PrimitiveArray, PrimitiveArray) {
     let mut lookup_dict: HashMap<Value<T>, u64> = HashMap::new();
     let mut codes: Vec<u64> = Vec::new();
     let mut values: Vec<T> = Vec::new();
@@ -156,7 +156,7 @@ pub fn dict_encode_typed_primitive<'a, T: NativePType>(
 }
 
 /// Dictionary encode varbin array. Specializes for primitive byte arrays to avoid double copying
-pub fn dict_encode_varbin<'a>(array: &'a VarBinArray) -> (PrimitiveArray<'a>, VarBinArray<'a>) {
+pub fn dict_encode_varbin<'a>(array: &'a VarBinArray) -> (PrimitiveArray, VarBinArray) {
     array
         .with_iterator(|iter| dict_encode_typed_varbin(array.dtype().clone(), iter))
         .unwrap()
@@ -172,10 +172,7 @@ fn lookup_bytes<'a, T: NativePType + AsPrimitive<usize>>(
     &bytes[begin..end]
 }
 
-fn dict_encode_typed_varbin<'a, I, U>(
-    dtype: DType,
-    values: I,
-) -> (PrimitiveArray<'a>, VarBinArray<'a>)
+fn dict_encode_typed_varbin<'a, I, U>(dtype: DType, values: I) -> (PrimitiveArray, VarBinArray)
 where
     I: Iterator<Item = Option<U>>,
     U: AsRef<[u8]>,

--- a/vortex-dict/src/compress.rs
+++ b/vortex-dict/src/compress.rs
@@ -10,7 +10,7 @@ use vortex::array::varbin::{VarBin, VarBinArray};
 use vortex::compress::{CompressConfig, Compressor, EncodingCompression};
 use vortex::stats::ArrayStatistics;
 use vortex::validity::Validity;
-use vortex::{Array, ArrayDType, ArrayDef, IntoArray, OwnedArray, ToArray};
+use vortex::{Array, ArrayDType, ArrayDef, IntoArray, ToArray};
 use vortex_dtype::{match_each_native_ptype, DType};
 use vortex_dtype::{NativePType, ToBytes};
 use vortex_error::VortexResult;
@@ -46,7 +46,7 @@ impl EncodingCompression for DictEncoding {
         array: &Array,
         like: Option<&Array>,
         ctx: Compressor,
-    ) -> VortexResult<OwnedArray> {
+    ) -> VortexResult<Array> {
         let dict_like = like.map(|like_arr| DictArray::try_from(like_arr).unwrap());
         let dict_like_ref = dict_like.as_ref();
 

--- a/vortex-dict/src/compute.rs
+++ b/vortex-dict/src/compute.rs
@@ -8,7 +8,7 @@ use vortex_scalar::Scalar;
 
 use crate::DictArray;
 
-impl ArrayCompute for DictArray<'_> {
+impl ArrayCompute for DictArray {
     fn scalar_at(&self) -> Option<&dyn ScalarAtFn> {
         Some(self)
     }
@@ -22,14 +22,14 @@ impl ArrayCompute for DictArray<'_> {
     }
 }
 
-impl ScalarAtFn for DictArray<'_> {
+impl ScalarAtFn for DictArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         let dict_index: usize = scalar_at(&self.codes(), index)?.as_ref().try_into()?;
         scalar_at(&self.values(), dict_index)
     }
 }
 
-impl TakeFn for DictArray<'_> {
+impl TakeFn for DictArray {
     fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
         // Dict
         //   codes: 0 0 1
@@ -39,7 +39,7 @@ impl TakeFn for DictArray<'_> {
     }
 }
 
-impl SliceFn for DictArray<'_> {
+impl SliceFn for DictArray {
     // TODO(robert): Add function to trim the dictionary
     fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
         DictArray::try_new(slice(&self.codes(), start, stop)?, self.values())

--- a/vortex-dict/src/compute.rs
+++ b/vortex-dict/src/compute.rs
@@ -2,7 +2,7 @@ use vortex::compute::scalar_at::{scalar_at, ScalarAtFn};
 use vortex::compute::slice::{slice, SliceFn};
 use vortex::compute::take::{take, TakeFn};
 use vortex::compute::ArrayCompute;
-use vortex::{Array, IntoArray, OwnedArray};
+use vortex::{Array, IntoArray};
 use vortex_error::VortexResult;
 use vortex_scalar::Scalar;
 
@@ -30,7 +30,7 @@ impl ScalarAtFn for DictArray {
 }
 
 impl TakeFn for DictArray {
-    fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
+    fn take(&self, indices: &Array) -> VortexResult<Array> {
         // Dict
         //   codes: 0 0 1
         //   dict: a b c d e f g h
@@ -41,7 +41,7 @@ impl TakeFn for DictArray {
 
 impl SliceFn for DictArray {
     // TODO(robert): Add function to trim the dictionary
-    fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
+    fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         DictArray::try_new(slice(&self.codes(), start, stop)?, self.values())
             .map(|a| a.into_array())
     }

--- a/vortex-dict/src/dict.rs
+++ b/vortex-dict/src/dict.rs
@@ -46,10 +46,7 @@ impl DictArray {
 }
 
 impl ArrayFlatten for DictArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
+    fn flatten(self) -> VortexResult<Flattened> {
         take(&self.values(), &self.codes())?.flatten()
     }
 }

--- a/vortex-dict/src/dict.rs
+++ b/vortex-dict/src/dict.rs
@@ -17,7 +17,7 @@ pub struct DictMetadata {
     codes_dtype: DType,
 }
 
-impl DictArray<'_> {
+impl DictArray {
     pub fn try_new(codes: Array, values: Array) -> VortexResult<Self> {
         if !codes.dtype().is_unsigned_int() {
             vortex_bail!(MismatchedTypes: "unsigned int", codes.dtype());
@@ -45,7 +45,7 @@ impl DictArray<'_> {
     }
 }
 
-impl ArrayFlatten for DictArray<'_> {
+impl ArrayFlatten for DictArray {
     fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
     where
         Self: 'a,
@@ -54,7 +54,7 @@ impl ArrayFlatten for DictArray<'_> {
     }
 }
 
-impl ArrayValidity for DictArray<'_> {
+impl ArrayValidity for DictArray {
     fn is_valid(&self, index: usize) -> bool {
         let values_index = scalar_at(&self.codes(), index)
             .unwrap()
@@ -82,14 +82,14 @@ impl ArrayValidity for DictArray<'_> {
     }
 }
 
-impl AcceptArrayVisitor for DictArray<'_> {
+impl AcceptArrayVisitor for DictArray {
     fn accept(&self, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         visitor.visit_child("values", &self.values())?;
         visitor.visit_child("codes", &self.codes())
     }
 }
 
-impl ArrayTrait for DictArray<'_> {
+impl ArrayTrait for DictArray {
     fn len(&self) -> usize {
         self.codes().len()
     }

--- a/vortex-dict/src/stats.rs
+++ b/vortex-dict/src/stats.rs
@@ -6,7 +6,7 @@ use vortex_scalar::Scalar;
 
 use crate::dict::DictArray;
 
-impl ArrayStatisticsCompute for DictArray<'_> {
+impl ArrayStatisticsCompute for DictArray {
     fn compute_statistics(&self, _stat: Stat) -> VortexResult<StatsSet> {
         let mut stats: HashMap<Stat, Scalar> = HashMap::new();
 

--- a/vortex-fastlanes/src/bitpacking/compress.rs
+++ b/vortex-fastlanes/src/bitpacking/compress.rs
@@ -88,7 +88,7 @@ impl EncodingCompression for BitPackedEncoding {
 }
 
 pub(crate) fn bitpack_encode(
-    array: PrimitiveArray<'_>,
+    array: PrimitiveArray,
     bit_width: usize,
 ) -> VortexResult<OwnedBitPackedArray> {
     let bit_width_freq = array.statistics().compute_bit_width_freq()?;
@@ -180,7 +180,7 @@ fn bitpack_patches(
     })
 }
 
-pub fn unpack<'a>(array: BitPackedArray) -> VortexResult<PrimitiveArray<'a>> {
+pub fn unpack<'a>(array: BitPackedArray) -> VortexResult<PrimitiveArray> {
     let bit_width = array.bit_width();
     let length = array.len();
     let offset = array.offset();
@@ -206,10 +206,7 @@ pub fn unpack<'a>(array: BitPackedArray) -> VortexResult<PrimitiveArray<'a>> {
     }
 }
 
-fn patch_unpacked<'a>(
-    array: PrimitiveArray<'a>,
-    patches: &Array,
-) -> VortexResult<PrimitiveArray<'a>> {
+fn patch_unpacked<'a>(array: PrimitiveArray, patches: &Array) -> VortexResult<PrimitiveArray> {
     match patches.encoding().id() {
         Sparse::ID => {
             match_each_integer_ptype!(array.ptype(), |$T| {

--- a/vortex-fastlanes/src/bitpacking/compress.rs
+++ b/vortex-fastlanes/src/bitpacking/compress.rs
@@ -6,7 +6,7 @@ use vortex::compress::{CompressConfig, Compressor, EncodingCompression};
 use vortex::compute::cast::cast;
 use vortex::stats::ArrayStatistics;
 use vortex::validity::Validity;
-use vortex::{Array, ArrayDType, ArrayDef, ArrayTrait, IntoArray, ToStatic};
+use vortex::{Array, ArrayDType, ArrayDef, ArrayTrait, IntoArray};
 use vortex_dtype::PType::U8;
 use vortex_dtype::{
     match_each_integer_ptype, match_each_unsigned_integer_ptype, NativePType, PType,
@@ -61,7 +61,7 @@ impl EncodingCompression for BitPackedEncoding {
 
         if bit_width == parray.ptype().bit_width() {
             // Nothing we can do
-            return Ok(array.to_static());
+            return Ok(array.clone());
         }
 
         let validity = ctx.compress_validity(parray.validity())?;

--- a/vortex-fastlanes/src/bitpacking/compress.rs
+++ b/vortex-fastlanes/src/bitpacking/compress.rs
@@ -180,7 +180,7 @@ fn bitpack_patches(
     })
 }
 
-pub fn unpack<'a>(array: BitPackedArray) -> VortexResult<PrimitiveArray> {
+pub fn unpack(array: BitPackedArray) -> VortexResult<PrimitiveArray> {
     let bit_width = array.bit_width();
     let length = array.len();
     let offset = array.offset();
@@ -206,7 +206,7 @@ pub fn unpack<'a>(array: BitPackedArray) -> VortexResult<PrimitiveArray> {
     }
 }
 
-fn patch_unpacked<'a>(array: PrimitiveArray, patches: &Array) -> VortexResult<PrimitiveArray> {
+fn patch_unpacked(array: PrimitiveArray, patches: &Array) -> VortexResult<PrimitiveArray> {
     match patches.encoding().id() {
         Sparse::ID => {
             match_each_integer_ptype!(array.ptype(), |$T| {

--- a/vortex-fastlanes/src/bitpacking/compute/mod.rs
+++ b/vortex-fastlanes/src/bitpacking/compute/mod.rs
@@ -9,7 +9,7 @@ use vortex::compute::scalar_at::{scalar_at, ScalarAtFn};
 use vortex::compute::slice::{slice, SliceFn};
 use vortex::compute::take::{take, TakeFn};
 use vortex::compute::ArrayCompute;
-use vortex::{Array, ArrayDType, ArrayTrait, IntoArray, OwnedArray};
+use vortex::{Array, ArrayDType, ArrayTrait, IntoArray};
 use vortex_dtype::{match_each_integer_ptype, match_each_unsigned_integer_ptype, NativePType};
 use vortex_error::{vortex_err, VortexResult};
 use vortex_scalar::Scalar;
@@ -49,7 +49,7 @@ impl ScalarAtFn for BitPackedArray {
 }
 
 impl TakeFn for BitPackedArray {
-    fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
+    fn take(&self, indices: &Array) -> VortexResult<Array> {
         let ptype = self.dtype().try_into()?;
         let validity = self.validity();
         let taken_validity = validity.take(indices)?;

--- a/vortex-fastlanes/src/bitpacking/compute/mod.rs
+++ b/vortex-fastlanes/src/bitpacking/compute/mod.rs
@@ -19,7 +19,7 @@ use crate::{unpack_single_primitive, BitPackedArray};
 
 mod slice;
 
-impl ArrayCompute for BitPackedArray<'_> {
+impl ArrayCompute for BitPackedArray {
     fn scalar_at(&self) -> Option<&dyn ScalarAtFn> {
         Some(self)
     }
@@ -33,7 +33,7 @@ impl ArrayCompute for BitPackedArray<'_> {
     }
 }
 
-impl ScalarAtFn for BitPackedArray<'_> {
+impl ScalarAtFn for BitPackedArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         if index >= self.len() {
             return Err(vortex_err!(OutOfBounds: index, 0, self.len()));
@@ -48,7 +48,7 @@ impl ScalarAtFn for BitPackedArray<'_> {
     }
 }
 
-impl TakeFn for BitPackedArray<'_> {
+impl TakeFn for BitPackedArray {
     fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
         let ptype = self.dtype().try_into()?;
         let validity = self.validity();

--- a/vortex-fastlanes/src/bitpacking/compute/slice.rs
+++ b/vortex-fastlanes/src/bitpacking/compute/slice.rs
@@ -1,13 +1,13 @@
 use std::cmp::max;
 
 use vortex::compute::slice::{slice, SliceFn};
-use vortex::{ArrayDType, IntoArray, OwnedArray, ToStatic};
+use vortex::{Array, ArrayDType, IntoArray, ToStatic};
 use vortex_error::VortexResult;
 
 use crate::BitPackedArray;
 
 impl SliceFn for BitPackedArray {
-    fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
+    fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         let offset = start % 1024;
         let block_start = max(0, start - offset);
         let block_stop = ((stop + 1023) / 1024) * 1024;

--- a/vortex-fastlanes/src/bitpacking/compute/slice.rs
+++ b/vortex-fastlanes/src/bitpacking/compute/slice.rs
@@ -1,7 +1,7 @@
 use std::cmp::max;
 
 use vortex::compute::slice::{slice, SliceFn};
-use vortex::{Array, ArrayDType, IntoArray, ToStatic};
+use vortex::{Array, ArrayDType, IntoArray};
 use vortex_error::VortexResult;
 
 use crate::BitPackedArray;
@@ -23,6 +23,6 @@ impl SliceFn for BitPackedArray {
             stop - start,
             offset,
         )
-        .map(|a| a.into_array().to_static())
+        .map(|a| a.into_array())
     }
 }

--- a/vortex-fastlanes/src/bitpacking/compute/slice.rs
+++ b/vortex-fastlanes/src/bitpacking/compute/slice.rs
@@ -6,7 +6,7 @@ use vortex_error::VortexResult;
 
 use crate::BitPackedArray;
 
-impl SliceFn for BitPackedArray<'_> {
+impl SliceFn for BitPackedArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
         let offset = start % 1024;
         let block_start = max(0, start - offset);

--- a/vortex-fastlanes/src/bitpacking/mod.rs
+++ b/vortex-fastlanes/src/bitpacking/mod.rs
@@ -22,7 +22,7 @@ pub struct BitPackedMetadata {
 }
 
 /// NB: All non-null values in the patches array are considered patches
-impl BitPackedArray<'_> {
+impl BitPackedArray {
     pub fn try_new(
         packed: Array,
         validity: Validity,
@@ -119,7 +119,7 @@ impl BitPackedArray<'_> {
         ))
     }
 
-    pub fn encode(array: &Array<'_>, bit_width: usize) -> VortexResult<OwnedBitPackedArray> {
+    pub fn encode(array: &Array, bit_width: usize) -> VortexResult<OwnedBitPackedArray> {
         if let Ok(parray) = PrimitiveArray::try_from(array) {
             Ok(bitpack_encode(parray, bit_width)?)
         } else {
@@ -128,7 +128,7 @@ impl BitPackedArray<'_> {
     }
 }
 
-impl ArrayFlatten for BitPackedArray<'_> {
+impl ArrayFlatten for BitPackedArray {
     fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
     where
         Self: 'a,
@@ -137,7 +137,7 @@ impl ArrayFlatten for BitPackedArray<'_> {
     }
 }
 
-impl ArrayValidity for BitPackedArray<'_> {
+impl ArrayValidity for BitPackedArray {
     fn is_valid(&self, index: usize) -> bool {
         self.validity().is_valid(index)
     }
@@ -147,7 +147,7 @@ impl ArrayValidity for BitPackedArray<'_> {
     }
 }
 
-impl AcceptArrayVisitor for BitPackedArray<'_> {
+impl AcceptArrayVisitor for BitPackedArray {
     fn accept(&self, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         visitor.visit_child("packed", &self.packed())?;
         if self.metadata().patches_dtype.is_some() {
@@ -160,9 +160,9 @@ impl AcceptArrayVisitor for BitPackedArray<'_> {
     }
 }
 
-impl ArrayStatisticsCompute for BitPackedArray<'_> {}
+impl ArrayStatisticsCompute for BitPackedArray {}
 
-impl ArrayTrait for BitPackedArray<'_> {
+impl ArrayTrait for BitPackedArray {
     fn len(&self) -> usize {
         self.metadata().length
     }

--- a/vortex-fastlanes/src/bitpacking/mod.rs
+++ b/vortex-fastlanes/src/bitpacking/mod.rs
@@ -119,7 +119,7 @@ impl BitPackedArray {
         ))
     }
 
-    pub fn encode(array: &Array, bit_width: usize) -> VortexResult<OwnedBitPackedArray> {
+    pub fn encode(array: &Array, bit_width: usize) -> VortexResult<BitPackedArray> {
         if let Ok(parray) = PrimitiveArray::try_from(array) {
             Ok(bitpack_encode(parray, bit_width)?)
         } else {

--- a/vortex-fastlanes/src/bitpacking/mod.rs
+++ b/vortex-fastlanes/src/bitpacking/mod.rs
@@ -129,10 +129,7 @@ impl BitPackedArray {
 }
 
 impl ArrayFlatten for BitPackedArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
+    fn flatten(self) -> VortexResult<Flattened> {
         unpack(self).map(Flattened::Primitive)
     }
 }

--- a/vortex-fastlanes/src/delta/compress.rs
+++ b/vortex-fastlanes/src/delta/compress.rs
@@ -7,7 +7,7 @@ use vortex::array::primitive::PrimitiveArray;
 use vortex::compress::{CompressConfig, Compressor, EncodingCompression};
 use vortex::compute::fill::fill_forward;
 use vortex::validity::Validity;
-use vortex::{Array, IntoArray, OwnedArray};
+use vortex::{Array, IntoArray};
 use vortex_dtype::Nullability;
 use vortex_dtype::{match_each_integer_ptype, NativePType};
 use vortex_error::VortexResult;
@@ -36,7 +36,7 @@ impl EncodingCompression for DeltaEncoding {
         array: &Array,
         like: Option<&Array>,
         ctx: Compressor,
-    ) -> VortexResult<OwnedArray> {
+    ) -> VortexResult<Array> {
         let parray = PrimitiveArray::try_from(array)?;
         let like_delta = like.map(|l| DeltaArray::try_from(l).unwrap());
 

--- a/vortex-fastlanes/src/delta/compute.rs
+++ b/vortex-fastlanes/src/delta/compute.rs
@@ -2,4 +2,4 @@ use vortex::compute::ArrayCompute;
 
 use crate::DeltaArray;
 
-impl ArrayCompute for DeltaArray<'_> {}
+impl ArrayCompute for DeltaArray {}

--- a/vortex-fastlanes/src/delta/mod.rs
+++ b/vortex-fastlanes/src/delta/mod.rs
@@ -20,7 +20,7 @@ pub struct DeltaMetadata {
     len: usize,
 }
 
-impl DeltaArray<'_> {
+impl DeltaArray {
     pub fn try_new(
         len: usize,
         bases: Array,
@@ -94,7 +94,7 @@ impl DeltaArray<'_> {
     }
 }
 
-impl ArrayFlatten for DeltaArray<'_> {
+impl ArrayFlatten for DeltaArray {
     fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
     where
         Self: 'a,
@@ -103,7 +103,7 @@ impl ArrayFlatten for DeltaArray<'_> {
     }
 }
 
-impl ArrayValidity for DeltaArray<'_> {
+impl ArrayValidity for DeltaArray {
     fn is_valid(&self, index: usize) -> bool {
         self.validity().is_valid(index)
     }
@@ -113,16 +113,16 @@ impl ArrayValidity for DeltaArray<'_> {
     }
 }
 
-impl AcceptArrayVisitor for DeltaArray<'_> {
+impl AcceptArrayVisitor for DeltaArray {
     fn accept(&self, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         visitor.visit_child("bases", &self.bases())?;
         visitor.visit_child("deltas", &self.deltas())
     }
 }
 
-impl ArrayStatisticsCompute for DeltaArray<'_> {}
+impl ArrayStatisticsCompute for DeltaArray {}
 
-impl ArrayTrait for DeltaArray<'_> {
+impl ArrayTrait for DeltaArray {
     fn len(&self) -> usize {
         self.metadata().len
     }

--- a/vortex-fastlanes/src/delta/mod.rs
+++ b/vortex-fastlanes/src/delta/mod.rs
@@ -95,10 +95,7 @@ impl DeltaArray {
 }
 
 impl ArrayFlatten for DeltaArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
+    fn flatten(self) -> VortexResult<Flattened> {
         decompress(self).map(Flattened::Primitive)
     }
 }

--- a/vortex-fastlanes/src/for/compress.rs
+++ b/vortex-fastlanes/src/for/compress.rs
@@ -4,7 +4,7 @@ use vortex::array::constant::ConstantArray;
 use vortex::array::primitive::PrimitiveArray;
 use vortex::compress::{CompressConfig, Compressor, EncodingCompression};
 use vortex::stats::{ArrayStatistics, Stat};
-use vortex::{Array, ArrayDType, ArrayTrait, IntoArray, OwnedArray};
+use vortex::{Array, ArrayDType, ArrayTrait, IntoArray};
 use vortex_dtype::{match_each_integer_ptype, NativePType, PType};
 use vortex_error::{vortex_err, VortexResult};
 
@@ -43,7 +43,7 @@ impl EncodingCompression for FoREncoding {
         array: &Array,
         like: Option<&Array>,
         ctx: Compressor,
-    ) -> VortexResult<OwnedArray> {
+    ) -> VortexResult<Array> {
         let parray = PrimitiveArray::try_from(array)?;
         let shift = trailing_zeros(array);
         let min = parray

--- a/vortex-fastlanes/src/for/compute.rs
+++ b/vortex-fastlanes/src/for/compute.rs
@@ -2,7 +2,7 @@ use vortex::compute::scalar_at::{scalar_at, ScalarAtFn};
 use vortex::compute::slice::{slice, SliceFn};
 use vortex::compute::take::{take, TakeFn};
 use vortex::compute::ArrayCompute;
-use vortex::{Array, IntoArray, OwnedArray};
+use vortex::{Array, IntoArray};
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::{vortex_bail, VortexResult};
 use vortex_scalar::{PrimitiveScalar, Scalar};
@@ -24,7 +24,7 @@ impl ArrayCompute for FoRArray {
 }
 
 impl TakeFn for FoRArray {
-    fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
+    fn take(&self, indices: &Array) -> VortexResult<Array> {
         FoRArray::try_new(
             take(&self.encoded(), indices)?,
             self.reference().clone(),
@@ -55,7 +55,7 @@ impl ScalarAtFn for FoRArray {
 }
 
 impl SliceFn for FoRArray {
-    fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
+    fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         FoRArray::try_new(
             slice(&self.encoded(), start, stop)?,
             self.reference().clone(),

--- a/vortex-fastlanes/src/for/compute.rs
+++ b/vortex-fastlanes/src/for/compute.rs
@@ -9,7 +9,7 @@ use vortex_scalar::{PrimitiveScalar, Scalar};
 
 use crate::FoRArray;
 
-impl ArrayCompute for FoRArray<'_> {
+impl ArrayCompute for FoRArray {
     fn scalar_at(&self) -> Option<&dyn ScalarAtFn> {
         Some(self)
     }
@@ -23,7 +23,7 @@ impl ArrayCompute for FoRArray<'_> {
     }
 }
 
-impl TakeFn for FoRArray<'_> {
+impl TakeFn for FoRArray {
     fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
         FoRArray::try_new(
             take(&self.encoded(), indices)?,
@@ -34,7 +34,7 @@ impl TakeFn for FoRArray<'_> {
     }
 }
 
-impl ScalarAtFn for FoRArray<'_> {
+impl ScalarAtFn for FoRArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         let encoded_scalar = scalar_at(&self.encoded(), index)?;
         let encoded = PrimitiveScalar::try_from(&encoded_scalar)?;
@@ -54,7 +54,7 @@ impl ScalarAtFn for FoRArray<'_> {
     }
 }
 
-impl SliceFn for FoRArray<'_> {
+impl SliceFn for FoRArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
         FoRArray::try_new(
             slice(&self.encoded(), start, stop)?,

--- a/vortex-fastlanes/src/for/mod.rs
+++ b/vortex-fastlanes/src/for/mod.rs
@@ -19,7 +19,7 @@ pub struct FoRMetadata {
     shift: u8,
 }
 
-impl FoRArray<'_> {
+impl FoRArray {
     pub fn try_new(child: Array, reference: Scalar, shift: u8) -> VortexResult<Self> {
         if reference.is_null() {
             vortex_bail!("Reference value cannot be null",);
@@ -51,7 +51,7 @@ impl FoRArray<'_> {
     }
 }
 
-impl ArrayValidity for FoRArray<'_> {
+impl ArrayValidity for FoRArray {
     fn is_valid(&self, index: usize) -> bool {
         self.encoded().with_dyn(|a| a.is_valid(index))
     }
@@ -61,7 +61,7 @@ impl ArrayValidity for FoRArray<'_> {
     }
 }
 
-impl ArrayFlatten for FoRArray<'_> {
+impl ArrayFlatten for FoRArray {
     fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
     where
         Self: 'a,
@@ -70,15 +70,15 @@ impl ArrayFlatten for FoRArray<'_> {
     }
 }
 
-impl AcceptArrayVisitor for FoRArray<'_> {
+impl AcceptArrayVisitor for FoRArray {
     fn accept(&self, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         visitor.visit_child("encoded", &self.encoded())
     }
 }
 
-impl ArrayStatisticsCompute for FoRArray<'_> {}
+impl ArrayStatisticsCompute for FoRArray {}
 
-impl ArrayTrait for FoRArray<'_> {
+impl ArrayTrait for FoRArray {
     fn len(&self) -> usize {
         self.encoded().len()
     }

--- a/vortex-fastlanes/src/for/mod.rs
+++ b/vortex-fastlanes/src/for/mod.rs
@@ -62,10 +62,7 @@ impl ArrayValidity for FoRArray {
 }
 
 impl ArrayFlatten for FoRArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
+    fn flatten(self) -> VortexResult<Flattened> {
         decompress(self).map(Flattened::Primitive)
     }
 }

--- a/vortex-ipc/src/codecs/array_reader.rs
+++ b/vortex-ipc/src/codecs/array_reader.rs
@@ -5,7 +5,7 @@ use std::task::Poll;
 use flatbuffers::root;
 use futures_util::Stream;
 use pin_project::pin_project;
-use vortex::{Array, ArrayView, IntoArray, OwnedArray, ToArray, ToStatic, ViewContext};
+use vortex::{Array, ArrayView, IntoArray, ToArray, ToStatic, ViewContext};
 use vortex_buffer::Buffer;
 use vortex_dtype::DType;
 use vortex_error::{vortex_err, VortexError, VortexResult};
@@ -15,7 +15,7 @@ use crate::codecs::message_reader::MessageReader;
 /// A stream of array chunks along with a DType.
 ///
 /// Can be thought of as equivalent to Arrow's RecordBatchReader.
-pub trait ArrayReader: Stream<Item = VortexResult<OwnedArray>> {
+pub trait ArrayReader: Stream<Item = VortexResult<Array>> {
     fn dtype(&self) -> &DType;
 }
 
@@ -29,7 +29,7 @@ struct ArrayReaderAdapter<S> {
 
 impl<S> ArrayReader for ArrayReaderAdapter<S>
 where
-    S: Stream<Item = VortexResult<OwnedArray>>,
+    S: Stream<Item = VortexResult<Array>>,
 {
     fn dtype(&self) -> &DType {
         &self.dtype
@@ -38,9 +38,9 @@ where
 
 impl<S> Stream for ArrayReaderAdapter<S>
 where
-    S: Stream<Item = VortexResult<OwnedArray>>,
+    S: Stream<Item = VortexResult<Array>>,
 {
-    type Item = VortexResult<OwnedArray>;
+    type Item = VortexResult<Array>;
 
     fn poll_next(
         self: Pin<&mut Self>,

--- a/vortex-ipc/src/codecs/array_reader.rs
+++ b/vortex-ipc/src/codecs/array_reader.rs
@@ -5,7 +5,7 @@ use std::task::Poll;
 use flatbuffers::root;
 use futures_util::Stream;
 use pin_project::pin_project;
-use vortex::{Array, ArrayView, IntoArray, ToArray, ToStatic, ViewContext};
+use vortex::{Array, ArrayView, IntoArray, ToArray, ViewContext};
 use vortex_buffer::Buffer;
 use vortex_dtype::DType;
 use vortex_error::{vortex_err, VortexError, VortexResult};
@@ -81,7 +81,7 @@ impl<'m, M: MessageReader> MessageArrayReader<'m, M> {
 
         let inner = futures_util::stream::unfold(self, move |mut reader| async move {
             match reader.next().await {
-                Ok(Some(array)) => Some((Ok(array.to_static()), reader)),
+                Ok(Some(array)) => Some((Ok(array), reader)),
                 Ok(None) => None,
                 Err(e) => Some((Err(e), reader)),
             }

--- a/vortex-ipc/src/reader.rs
+++ b/vortex-ipc/src/reader.rs
@@ -869,7 +869,6 @@ mod tests {
 
         let mut cursor = Cursor::new(&buffer);
         let mut reader = StreamReader::try_new(&mut cursor, &context).unwrap();
-        let data = reader.read_array().unwrap();
-        data
+        reader.read_array().unwrap()
     }
 }

--- a/vortex-ipc/src/reader.rs
+++ b/vortex-ipc/src/reader.rs
@@ -14,9 +14,7 @@ use vortex::compute::search_sorted::{search_sorted, SearchSortedSide};
 use vortex::compute::slice::slice;
 use vortex::compute::take::take;
 use vortex::stats::{ArrayStatistics, Stat};
-use vortex::{
-    Array, ArrayDType, ArrayView, Context, IntoArray, OwnedArray, ToArray, ToStatic, ViewContext,
-};
+use vortex::{Array, ArrayDType, ArrayView, Context, IntoArray, ToArray, ToStatic, ViewContext};
 use vortex_buffer::Buffer;
 use vortex_dtype::{match_each_integer_ptype, DType};
 use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
@@ -206,7 +204,7 @@ impl<'a, R: Read> Drop for StreamArrayReader<'a, R> {
 /// to avoid this work happening at exipry, users can just consume the rest of the iterator
 /// themselves when they see fit.
 impl<'a, R: Read> FallibleIterator for TakeIterator<'a, R> {
-    type Item = OwnedArray;
+    type Item = Array;
     type Error = VortexError;
 
     fn next(&mut self) -> VortexResult<Option<Self::Item>> {
@@ -402,7 +400,7 @@ mod tests {
     use vortex::array::primitive::{Primitive, PrimitiveArray, PrimitiveEncoding};
     use vortex::encoding::{ArrayEncoding, EncodingId, EncodingRef};
     use vortex::stats::{ArrayStatistics, Stat};
-    use vortex::{Array, ArrayDType, ArrayDef, Context, IntoArray, OwnedArray, ToStatic};
+    use vortex::{Array, ArrayDType, ArrayDef, Context, IntoArray, ToStatic};
     use vortex_alp::{ALPArray, ALPEncoding};
     use vortex_dtype::NativePType;
     use vortex_error::VortexResult;
@@ -780,7 +778,7 @@ mod tests {
     fn test_read_write_single_chunk_array<'a>(
         data: &'a Array,
         indices: &'a Array,
-    ) -> VortexResult<OwnedArray> {
+    ) -> VortexResult<Array> {
         let ctx =
             Context::default().with_encodings([&ALPEncoding as EncodingRef, &BitPackedEncoding]);
 

--- a/vortex-ipc/src/reader.rs
+++ b/vortex-ipc/src/reader.rs
@@ -858,7 +858,7 @@ mod tests {
             .expect_err("Should not be able to calculate true count for non-boolean array");
     }
 
-    fn round_trip<'a>(chunked_array: &'a Array) -> Array {
+    fn round_trip(chunked_array: &Array) -> Array {
         let context = Context::default();
         let mut buffer = vec![];
         {

--- a/vortex-ipc/src/reader.rs
+++ b/vortex-ipc/src/reader.rs
@@ -136,7 +136,7 @@ impl<'a, R: Read> StreamArrayReader<'a, R> {
         &self.dtype
     }
 
-    pub fn take(self, indices: &'a Array<'_>) -> VortexResult<TakeIterator<'a, R>> {
+    pub fn take(self, indices: &'a Array) -> VortexResult<TakeIterator<'a, R>> {
         if !indices.is_empty() {
             if !indices.statistics().compute_is_sorted()? {
                 vortex_bail!("Indices must be sorted to take from IPC stream")
@@ -171,7 +171,7 @@ impl<'a, R: Read> StreamArrayReader<'a, R> {
 
 pub struct TakeIterator<'a, R: Read> {
     reader: StreamArrayReader<'a, R>,
-    indices: &'a Array<'a>,
+    indices: &'a Array,
     row_offset: usize,
 }
 
@@ -244,9 +244,9 @@ impl<'a, R: Read> FallibleIterator for TakeIterator<'a, R> {
 #[gat]
 impl<'iter, R: Read> FallibleLendingIterator for StreamArrayReader<'iter, R> {
     type Error = VortexError;
-    type Item<'next> = Array<'next> where Self: 'next;
+    type Item<'next> = Array where Self: 'next;
 
-    fn next(&mut self) -> Result<Option<Array<'_>>, Self::Error> {
+    fn next(&mut self) -> Result<Option<Array>, Self::Error> {
         let Some(chunk_msg) = self.messages.peek().and_then(|msg| msg.header_as_chunk()) else {
             return Ok(None);
         };
@@ -858,7 +858,7 @@ mod tests {
             .expect_err("Should not be able to calculate true count for non-boolean array");
     }
 
-    fn round_trip<'a>(chunked_array: &'a Array<'a>) -> Array<'a> {
+    fn round_trip<'a>(chunked_array: &'a Array) -> Array {
         let context = Context::default();
         let mut buffer = vec![];
         {

--- a/vortex-ipc/src/reader.rs
+++ b/vortex-ipc/src/reader.rs
@@ -14,7 +14,7 @@ use vortex::compute::search_sorted::{search_sorted, SearchSortedSide};
 use vortex::compute::slice::slice;
 use vortex::compute::take::take;
 use vortex::stats::{ArrayStatistics, Stat};
-use vortex::{Array, ArrayDType, ArrayView, Context, IntoArray, ToArray, ToStatic, ViewContext};
+use vortex::{Array, ArrayDType, ArrayView, Context, IntoArray, ToArray, ViewContext};
 use vortex_buffer::Buffer;
 use vortex_dtype::{match_each_integer_ptype, DType};
 use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
@@ -69,7 +69,7 @@ impl<R: Read> StreamReader<R> {
 
         let mut chunks = vec![];
         while let Some(chunk) = array_reader.next()? {
-            chunks.push(chunk.to_static());
+            chunks.push(chunk);
         }
 
         if chunks.len() == 1 {
@@ -400,7 +400,7 @@ mod tests {
     use vortex::array::primitive::{Primitive, PrimitiveArray, PrimitiveEncoding};
     use vortex::encoding::{ArrayEncoding, EncodingId, EncodingRef};
     use vortex::stats::{ArrayStatistics, Stat};
-    use vortex::{Array, ArrayDType, ArrayDef, Context, IntoArray, ToStatic};
+    use vortex::{Array, ArrayDType, ArrayDef, Context, IntoArray};
     use vortex_alp::{ALPArray, ALPEncoding};
     use vortex_dtype::NativePType;
     use vortex_error::VortexResult;
@@ -870,6 +870,6 @@ mod tests {
         let mut cursor = Cursor::new(&buffer);
         let mut reader = StreamReader::try_new(&mut cursor, &context).unwrap();
         let data = reader.read_array().unwrap();
-        data.to_static()
+        data
     }
 }

--- a/vortex-ree/src/compress.rs
+++ b/vortex-ree/src/compress.rs
@@ -6,7 +6,7 @@ use vortex::array::primitive::{Primitive, PrimitiveArray};
 use vortex::compress::{CompressConfig, Compressor, EncodingCompression};
 use vortex::stats::{ArrayStatistics, Stat};
 use vortex::validity::Validity;
-use vortex::{Array, ArrayDType, ArrayDef, ArrayTrait, IntoArray, OwnedArray};
+use vortex::{Array, ArrayDType, ArrayDef, ArrayTrait, IntoArray};
 use vortex_dtype::Nullability;
 use vortex_dtype::{match_each_integer_ptype, match_each_native_ptype, NativePType};
 use vortex_error::VortexResult;
@@ -40,7 +40,7 @@ impl EncodingCompression for REEEncoding {
         array: &Array,
         like: Option<&Array>,
         ctx: Compressor,
-    ) -> VortexResult<OwnedArray> {
+    ) -> VortexResult<Array> {
         let ree_like = like.map(|like_arr| REEArray::try_from(like_arr).unwrap());
         let ree_like_ref = ree_like.as_ref();
         let primitive_array = array.as_primitive();

--- a/vortex-ree/src/compress.rs
+++ b/vortex-ree/src/compress.rs
@@ -64,7 +64,7 @@ impl EncodingCompression for REEEncoding {
     }
 }
 
-pub fn ree_encode<'a>(array: &PrimitiveArray) -> (PrimitiveArray, PrimitiveArray) {
+pub fn ree_encode(array: &PrimitiveArray) -> (PrimitiveArray, PrimitiveArray) {
     let validity = if array.validity().nullability() == Nullability::NonNullable {
         Validity::NonNullable
     } else {
@@ -118,7 +118,7 @@ fn ree_encode_primitive<T: NativePType>(elements: &[T]) -> (Vec<u64>, Vec<T>) {
     (ends, values)
 }
 
-pub fn ree_decode<'a>(
+pub fn ree_decode(
     ends: &PrimitiveArray,
     values: &PrimitiveArray,
     validity: Validity,

--- a/vortex-ree/src/compress.rs
+++ b/vortex-ree/src/compress.rs
@@ -64,7 +64,7 @@ impl EncodingCompression for REEEncoding {
     }
 }
 
-pub fn ree_encode<'a>(array: &PrimitiveArray) -> (PrimitiveArray<'a>, PrimitiveArray<'a>) {
+pub fn ree_encode<'a>(array: &PrimitiveArray) -> (PrimitiveArray, PrimitiveArray) {
     let validity = if array.validity().nullability() == Nullability::NonNullable {
         Validity::NonNullable
     } else {
@@ -124,7 +124,7 @@ pub fn ree_decode<'a>(
     validity: Validity,
     offset: usize,
     length: usize,
-) -> VortexResult<PrimitiveArray<'a>> {
+) -> VortexResult<PrimitiveArray> {
     match_each_native_ptype!(values.ptype(), |$P| {
         match_each_integer_ptype!(ends.ptype(), |$E| {
             Ok(PrimitiveArray::from_vec(ree_decode_primitive(

--- a/vortex-ree/src/compute.rs
+++ b/vortex-ree/src/compute.rs
@@ -10,7 +10,7 @@ use vortex_scalar::Scalar;
 
 use crate::REEArray;
 
-impl ArrayCompute for REEArray<'_> {
+impl ArrayCompute for REEArray {
     fn scalar_at(&self) -> Option<&dyn ScalarAtFn> {
         Some(self)
     }
@@ -24,13 +24,13 @@ impl ArrayCompute for REEArray<'_> {
     }
 }
 
-impl ScalarAtFn for REEArray<'_> {
+impl ScalarAtFn for REEArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         scalar_at(&self.values(), self.find_physical_index(index)?)
     }
 }
 
-impl TakeFn for REEArray<'_> {
+impl TakeFn for REEArray {
     fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
         let primitive_indices = indices.clone().flatten_primitive()?;
         let physical_indices = match_each_integer_ptype!(primitive_indices.ptype(), |$P| {
@@ -50,7 +50,7 @@ impl TakeFn for REEArray<'_> {
     }
 }
 
-impl SliceFn for REEArray<'_> {
+impl SliceFn for REEArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
         let slice_begin = self.find_physical_index(start)?;
         let slice_end = self.find_physical_index(stop)?;

--- a/vortex-ree/src/compute.rs
+++ b/vortex-ree/src/compute.rs
@@ -3,7 +3,7 @@ use vortex::compute::scalar_at::{scalar_at, ScalarAtFn};
 use vortex::compute::slice::{slice, SliceFn};
 use vortex::compute::take::{take, TakeFn};
 use vortex::compute::ArrayCompute;
-use vortex::{Array, IntoArray, OwnedArray};
+use vortex::{Array, IntoArray};
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexResult;
 use vortex_scalar::Scalar;
@@ -31,7 +31,7 @@ impl ScalarAtFn for REEArray {
 }
 
 impl TakeFn for REEArray {
-    fn take(&self, indices: &Array) -> VortexResult<OwnedArray> {
+    fn take(&self, indices: &Array) -> VortexResult<Array> {
         let primitive_indices = indices.clone().flatten_primitive()?;
         let physical_indices = match_each_integer_ptype!(primitive_indices.ptype(), |$P| {
             primitive_indices
@@ -51,7 +51,7 @@ impl TakeFn for REEArray {
 }
 
 impl SliceFn for REEArray {
-    fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
+    fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         let slice_begin = self.find_physical_index(start)?;
         let slice_end = self.find_physical_index(stop)?;
         Ok(REEArray::with_offset_and_size(

--- a/vortex-ree/src/ree.rs
+++ b/vortex-ree/src/ree.rs
@@ -20,7 +20,7 @@ pub struct REEMetadata {
     length: usize,
 }
 
-impl REEArray<'_> {
+impl REEArray {
     pub fn try_new(ends: Array, values: Array, validity: Validity) -> VortexResult<Self> {
         let length: usize = scalar_at(&ends, ends.len() - 1)?.as_ref().try_into()?;
         Self::with_offset_and_size(ends, values, validity, length, 0)
@@ -101,7 +101,7 @@ impl REEArray<'_> {
     }
 }
 
-impl ArrayValidity for REEArray<'_> {
+impl ArrayValidity for REEArray {
     fn is_valid(&self, index: usize) -> bool {
         self.validity().is_valid(index)
     }
@@ -111,7 +111,7 @@ impl ArrayValidity for REEArray<'_> {
     }
 }
 
-impl ArrayFlatten for REEArray<'_> {
+impl ArrayFlatten for REEArray {
     fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
     where
         Self: 'a,
@@ -123,7 +123,7 @@ impl ArrayFlatten for REEArray<'_> {
     }
 }
 
-impl AcceptArrayVisitor for REEArray<'_> {
+impl AcceptArrayVisitor for REEArray {
     fn accept(&self, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         visitor.visit_child("ends", &self.ends())?;
         visitor.visit_child("values", &self.values())?;
@@ -131,9 +131,9 @@ impl AcceptArrayVisitor for REEArray<'_> {
     }
 }
 
-impl ArrayStatisticsCompute for REEArray<'_> {}
+impl ArrayStatisticsCompute for REEArray {}
 
-impl ArrayTrait for REEArray<'_> {
+impl ArrayTrait for REEArray {
     fn len(&self) -> usize {
         self.metadata().length
     }

--- a/vortex-ree/src/ree.rs
+++ b/vortex-ree/src/ree.rs
@@ -112,10 +112,7 @@ impl ArrayValidity for REEArray {
 }
 
 impl ArrayFlatten for REEArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
+    fn flatten(self) -> VortexResult<Flattened> {
         let pends = self.ends().flatten_primitive()?;
         let pvalues = self.values().flatten_primitive()?;
         ree_decode(&pends, &pvalues, self.validity(), self.offset(), self.len())

--- a/vortex-roaring/src/boolean/compress.rs
+++ b/vortex-roaring/src/boolean/compress.rs
@@ -1,13 +1,12 @@
 use croaring::Bitmap;
 use vortex::array::bool::BoolArray;
 use vortex::compress::{CompressConfig, Compressor, EncodingCompression};
-use vortex::{Array, ArrayDType, ArrayDef, ArrayTrait, IntoArray, OwnedArray};
+use vortex::{Array, ArrayDType, ArrayDef, ArrayTrait, IntoArray};
 use vortex_dtype::DType;
 use vortex_dtype::Nullability::NonNullable;
 use vortex_error::VortexResult;
 
-use crate::boolean::RoaringBoolArray;
-use crate::{OwnedRoaringBoolArray, RoaringBool, RoaringBoolEncoding};
+use crate::{RoaringBool, RoaringBoolArray, RoaringBoolEncoding};
 
 impl EncodingCompression for RoaringBoolEncoding {
     fn can_compress(
@@ -37,12 +36,12 @@ impl EncodingCompression for RoaringBoolEncoding {
         array: &Array,
         _like: Option<&Array>,
         _ctx: Compressor,
-    ) -> VortexResult<OwnedArray> {
+    ) -> VortexResult<Array> {
         roaring_encode(array.clone().flatten_bool()?).map(move |a| a.into_array())
     }
 }
 
-pub fn roaring_encode(bool_array: BoolArray) -> VortexResult<OwnedRoaringBoolArray> {
+pub fn roaring_encode(bool_array: BoolArray) -> VortexResult<RoaringBoolArray> {
     let mut bitmap = Bitmap::new();
     bitmap.extend(
         bool_array

--- a/vortex-roaring/src/boolean/compute.rs
+++ b/vortex-roaring/src/boolean/compute.rs
@@ -8,7 +8,7 @@ use vortex_scalar::Scalar;
 
 use crate::RoaringBoolArray;
 
-impl ArrayCompute for RoaringBoolArray<'_> {
+impl ArrayCompute for RoaringBoolArray {
     fn scalar_at(&self) -> Option<&dyn ScalarAtFn> {
         Some(self)
     }
@@ -18,7 +18,7 @@ impl ArrayCompute for RoaringBoolArray<'_> {
     }
 }
 
-impl ScalarAtFn for RoaringBoolArray<'_> {
+impl ScalarAtFn for RoaringBoolArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         if self.bitmap().contains(index as u32) {
             Ok(true.into())
@@ -28,7 +28,7 @@ impl ScalarAtFn for RoaringBoolArray<'_> {
     }
 }
 
-impl SliceFn for RoaringBoolArray<'_> {
+impl SliceFn for RoaringBoolArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
         let slice_bitmap = Bitmap::from_range(start as u32..stop as u32);
         let bitmap = self.bitmap().and(&slice_bitmap).add_offset(-(start as i64));

--- a/vortex-roaring/src/boolean/compute.rs
+++ b/vortex-roaring/src/boolean/compute.rs
@@ -2,7 +2,7 @@ use croaring::Bitmap;
 use vortex::compute::scalar_at::ScalarAtFn;
 use vortex::compute::slice::SliceFn;
 use vortex::compute::ArrayCompute;
-use vortex::{IntoArray, OwnedArray};
+use vortex::{Array, IntoArray};
 use vortex_error::VortexResult;
 use vortex_scalar::Scalar;
 
@@ -29,7 +29,7 @@ impl ScalarAtFn for RoaringBoolArray {
 }
 
 impl SliceFn for RoaringBoolArray {
-    fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
+    fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         let slice_bitmap = Bitmap::from_range(start as u32..stop as u32);
         let bitmap = self.bitmap().and(&slice_bitmap).add_offset(-(start as i64));
 

--- a/vortex-roaring/src/boolean/mod.rs
+++ b/vortex-roaring/src/boolean/mod.rs
@@ -7,7 +7,7 @@ use vortex::array::bool::{Bool, BoolArray};
 use vortex::stats::ArrayStatisticsCompute;
 use vortex::validity::{ArrayValidity, LogicalValidity, Validity};
 use vortex::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use vortex::{impl_encoding, ArrayDType, ArrayFlatten, OwnedArray};
+use vortex::{impl_encoding, ArrayDType, ArrayFlatten};
 use vortex_buffer::Buffer;
 use vortex_dtype::Nullability::NonNullable;
 use vortex_dtype::Nullability::Nullable;
@@ -50,7 +50,7 @@ impl RoaringBoolArray {
         )
     }
 
-    pub fn encode(array: OwnedArray) -> VortexResult<OwnedArray> {
+    pub fn encode(array: Array) -> VortexResult<Array> {
         if array.encoding().id() == Bool::ID {
             roaring_encode(BoolArray::try_from(array)?).map(|a| a.into_array())
         } else {

--- a/vortex-roaring/src/boolean/mod.rs
+++ b/vortex-roaring/src/boolean/mod.rs
@@ -23,7 +23,7 @@ pub struct RoaringBoolMetadata {
     length: usize,
 }
 
-impl RoaringBoolArray<'_> {
+impl RoaringBoolArray {
     pub fn try_new(bitmap: Bitmap, length: usize) -> VortexResult<Self> {
         if length < bitmap.cardinality() as usize {
             vortex_bail!("RoaringBoolArray length is less than bitmap cardinality")
@@ -58,7 +58,7 @@ impl RoaringBoolArray<'_> {
         }
     }
 }
-impl AcceptArrayVisitor for RoaringBoolArray<'_> {
+impl AcceptArrayVisitor for RoaringBoolArray {
     fn accept(&self, _visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         // TODO(ngates): should we store a buffer in memory? Or delay serialization?
         //  Or serialize into metadata? The only reason we support buffers is so we can write to
@@ -68,15 +68,15 @@ impl AcceptArrayVisitor for RoaringBoolArray<'_> {
     }
 }
 
-impl ArrayTrait for RoaringBoolArray<'_> {
+impl ArrayTrait for RoaringBoolArray {
     fn len(&self) -> usize {
         self.metadata().length
     }
 }
 
-impl ArrayStatisticsCompute for RoaringBoolArray<'_> {}
+impl ArrayStatisticsCompute for RoaringBoolArray {}
 
-impl ArrayValidity for RoaringBoolArray<'_> {
+impl ArrayValidity for RoaringBoolArray {
     fn logical_validity(&self) -> LogicalValidity {
         LogicalValidity::AllValid(self.len())
     }
@@ -86,7 +86,7 @@ impl ArrayValidity for RoaringBoolArray<'_> {
     }
 }
 
-impl ArrayFlatten for RoaringBoolArray<'_> {
+impl ArrayFlatten for RoaringBoolArray {
     fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
     where
         Self: 'a,

--- a/vortex-roaring/src/boolean/mod.rs
+++ b/vortex-roaring/src/boolean/mod.rs
@@ -87,10 +87,7 @@ impl ArrayValidity for RoaringBoolArray {
 }
 
 impl ArrayFlatten for RoaringBoolArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
+    fn flatten(self) -> VortexResult<Flattened> {
         // TODO(ngates): benchmark the fastest conversion from BitMap.
         //  Via bitset requires two copies.
         let bitset = self

--- a/vortex-roaring/src/integer/compress.rs
+++ b/vortex-roaring/src/integer/compress.rs
@@ -4,7 +4,7 @@ use num_traits::NumCast;
 use vortex::array::primitive::PrimitiveArray;
 use vortex::compress::{CompressConfig, Compressor, EncodingCompression};
 use vortex::stats::ArrayStatistics;
-use vortex::{Array, ArrayDType, ArrayDef, IntoArray, ToStatic};
+use vortex::{Array, ArrayDType, ArrayDef, IntoArray};
 use vortex_dtype::{NativePType, PType};
 use vortex_error::VortexResult;
 
@@ -53,7 +53,7 @@ impl EncodingCompression for RoaringIntEncoding {
         _ctx: Compressor,
     ) -> VortexResult<Array> {
         let parray = array.clone().flatten_primitive()?;
-        Ok(roaring_encode(parray).into_array().to_static())
+        Ok(roaring_encode(parray).into_array())
     }
 }
 

--- a/vortex-roaring/src/integer/compress.rs
+++ b/vortex-roaring/src/integer/compress.rs
@@ -4,11 +4,11 @@ use num_traits::NumCast;
 use vortex::array::primitive::PrimitiveArray;
 use vortex::compress::{CompressConfig, Compressor, EncodingCompression};
 use vortex::stats::ArrayStatistics;
-use vortex::{Array, ArrayDType, ArrayDef, IntoArray, OwnedArray, ToStatic};
+use vortex::{Array, ArrayDType, ArrayDef, IntoArray, ToStatic};
 use vortex_dtype::{NativePType, PType};
 use vortex_error::VortexResult;
 
-use crate::{OwnedRoaringIntArray, RoaringInt, RoaringIntArray, RoaringIntEncoding};
+use crate::{RoaringInt, RoaringIntArray, RoaringIntEncoding};
 
 impl EncodingCompression for RoaringIntEncoding {
     fn can_compress(
@@ -51,7 +51,7 @@ impl EncodingCompression for RoaringIntEncoding {
         array: &Array,
         _like: Option<&Array>,
         _ctx: Compressor,
-    ) -> VortexResult<OwnedArray> {
+    ) -> VortexResult<Array> {
         let parray = array.clone().flatten_primitive()?;
         Ok(roaring_encode(parray).into_array().to_static())
     }
@@ -67,7 +67,7 @@ pub fn roaring_encode(parray: PrimitiveArray) -> RoaringIntArray {
     }
 }
 
-fn roaring_encode_primitive<T: NumCast + NativePType>(values: &[T]) -> OwnedRoaringIntArray {
+fn roaring_encode_primitive<T: NumCast + NativePType>(values: &[T]) -> RoaringIntArray {
     let mut bitmap = Bitmap::new();
     bitmap.extend(values.iter().map(|i| i.to_u32().unwrap()));
     bitmap.run_optimize();

--- a/vortex-roaring/src/integer/compute.rs
+++ b/vortex-roaring/src/integer/compute.rs
@@ -6,13 +6,13 @@ use vortex_scalar::Scalar;
 
 use crate::RoaringIntArray;
 
-impl ArrayCompute for RoaringIntArray<'_> {
+impl ArrayCompute for RoaringIntArray {
     fn scalar_at(&self) -> Option<&dyn ScalarAtFn> {
         Some(self)
     }
 }
 
-impl ScalarAtFn for RoaringIntArray<'_> {
+impl ScalarAtFn for RoaringIntArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         // Unwrap since we know the index is valid
         let bitmap_value = self.bitmap().select(index as u32).unwrap();

--- a/vortex-roaring/src/integer/mod.rs
+++ b/vortex-roaring/src/integer/mod.rs
@@ -24,7 +24,7 @@ pub struct RoaringIntMetadata {
     length: usize,
 }
 
-impl RoaringIntArray<'_> {
+impl RoaringIntArray {
     pub fn new(bitmap: Bitmap, ptype: PType) -> Self {
         Self::try_new(bitmap, ptype).unwrap()
     }
@@ -70,7 +70,7 @@ impl RoaringIntArray<'_> {
     }
 }
 
-impl ArrayValidity for RoaringIntArray<'_> {
+impl ArrayValidity for RoaringIntArray {
     fn logical_validity(&self) -> LogicalValidity {
         LogicalValidity::AllValid(self.bitmap().iter().count())
     }
@@ -80,7 +80,7 @@ impl ArrayValidity for RoaringIntArray<'_> {
     }
 }
 
-impl ArrayFlatten for RoaringIntArray<'_> {
+impl ArrayFlatten for RoaringIntArray {
     fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
     where
         Self: 'a,
@@ -89,15 +89,15 @@ impl ArrayFlatten for RoaringIntArray<'_> {
     }
 }
 
-impl AcceptArrayVisitor for RoaringIntArray<'_> {
+impl AcceptArrayVisitor for RoaringIntArray {
     fn accept(&self, _visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         todo!()
     }
 }
 
-impl ArrayStatisticsCompute for RoaringIntArray<'_> {}
+impl ArrayStatisticsCompute for RoaringIntArray {}
 
-impl ArrayTrait for RoaringIntArray<'_> {
+impl ArrayTrait for RoaringIntArray {
     fn len(&self) -> usize {
         self.metadata().length
     }

--- a/vortex-roaring/src/integer/mod.rs
+++ b/vortex-roaring/src/integer/mod.rs
@@ -81,10 +81,7 @@ impl ArrayValidity for RoaringIntArray {
 }
 
 impl ArrayFlatten for RoaringIntArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
+    fn flatten(self) -> VortexResult<Flattened> {
         todo!()
     }
 }

--- a/vortex-roaring/src/integer/mod.rs
+++ b/vortex-roaring/src/integer/mod.rs
@@ -5,7 +5,7 @@ use vortex::array::primitive::{Primitive, PrimitiveArray};
 use vortex::stats::ArrayStatisticsCompute;
 use vortex::validity::{ArrayValidity, LogicalValidity};
 use vortex::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use vortex::{impl_encoding, ArrayFlatten, OwnedArray};
+use vortex::{impl_encoding, ArrayFlatten};
 use vortex_buffer::Buffer;
 use vortex_dtype::Nullability::NonNullable;
 use vortex_dtype::PType;
@@ -61,7 +61,7 @@ impl RoaringIntArray {
         self.metadata().ptype
     }
 
-    pub fn encode(array: OwnedArray) -> VortexResult<OwnedArray> {
+    pub fn encode(array: Array) -> VortexResult<Array> {
         if array.encoding().id() == Primitive::ID {
             Ok(roaring_encode(PrimitiveArray::try_from(array)?).into_array())
         } else {

--- a/vortex-zigzag/src/compress.rs
+++ b/vortex-zigzag/src/compress.rs
@@ -50,7 +50,7 @@ impl EncodingCompression for ZigZagEncoding {
     }
 }
 
-pub fn zigzag_encode(parray: &PrimitiveArray<'_>) -> VortexResult<OwnedZigZagArray> {
+pub fn zigzag_encode(parray: &PrimitiveArray) -> VortexResult<OwnedZigZagArray> {
     let encoded = match parray.ptype() {
         PType::I8 => zigzag_encode_primitive::<i8>(parray.typed_data(), parray.validity()),
         PType::I16 => zigzag_encode_primitive::<i16>(parray.typed_data(), parray.validity()),
@@ -64,7 +64,7 @@ pub fn zigzag_encode(parray: &PrimitiveArray<'_>) -> VortexResult<OwnedZigZagArr
 fn zigzag_encode_primitive<'a, T: ExternalZigZag + NativePType>(
     values: &'a [T],
     validity: Validity<'a>,
-) -> PrimitiveArray<'a>
+) -> PrimitiveArray
 where
     <T as ExternalZigZag>::UInt: NativePType,
 {
@@ -74,7 +74,7 @@ where
 }
 
 #[allow(dead_code)]
-pub fn zigzag_decode<'a>(parray: &'a PrimitiveArray<'a>) -> PrimitiveArray<'a> {
+pub fn zigzag_decode<'a>(parray: &'a PrimitiveArray) -> PrimitiveArray {
     match parray.ptype() {
         PType::U8 => zigzag_decode_primitive::<i8>(parray.typed_data(), parray.validity()),
         PType::U16 => zigzag_decode_primitive::<i16>(parray.typed_data(), parray.validity()),
@@ -88,7 +88,7 @@ pub fn zigzag_decode<'a>(parray: &'a PrimitiveArray<'a>) -> PrimitiveArray<'a> {
 fn zigzag_decode_primitive<'a, T: ExternalZigZag + NativePType>(
     values: &'a [T::UInt],
     validity: Validity<'a>,
-) -> PrimitiveArray<'a>
+) -> PrimitiveArray
 where
     <T as ExternalZigZag>::UInt: NativePType,
 {

--- a/vortex-zigzag/src/compress.rs
+++ b/vortex-zigzag/src/compress.rs
@@ -61,9 +61,9 @@ pub fn zigzag_encode(parray: &PrimitiveArray) -> VortexResult<OwnedZigZagArray> 
     OwnedZigZagArray::try_new(encoded.into_array())
 }
 
-fn zigzag_encode_primitive<'a, T: ExternalZigZag + NativePType>(
-    values: &'a [T],
-    validity: Validity<'a>,
+fn zigzag_encode_primitive<T: ExternalZigZag + NativePType>(
+    values: &[T],
+    validity: Validity,
 ) -> PrimitiveArray
 where
     <T as ExternalZigZag>::UInt: NativePType,
@@ -85,9 +85,9 @@ pub fn zigzag_decode(parray: &PrimitiveArray) -> PrimitiveArray {
 }
 
 #[allow(dead_code)]
-fn zigzag_decode_primitive<'a, T: ExternalZigZag + NativePType>(
-    values: &'a [T::UInt],
-    validity: Validity<'a>,
+fn zigzag_decode_primitive<T: ExternalZigZag + NativePType>(
+    values: &[T::UInt],
+    validity: Validity,
 ) -> PrimitiveArray
 where
     <T as ExternalZigZag>::UInt: NativePType,

--- a/vortex-zigzag/src/compress.rs
+++ b/vortex-zigzag/src/compress.rs
@@ -74,7 +74,7 @@ where
 }
 
 #[allow(dead_code)]
-pub fn zigzag_decode<'a>(parray: &'a PrimitiveArray) -> PrimitiveArray {
+pub fn zigzag_decode(parray: &PrimitiveArray) -> PrimitiveArray {
     match parray.ptype() {
         PType::U8 => zigzag_decode_primitive::<i8>(parray.typed_data(), parray.validity()),
         PType::U16 => zigzag_decode_primitive::<i16>(parray.typed_data(), parray.validity()),

--- a/vortex-zigzag/src/compute.rs
+++ b/vortex-zigzag/src/compute.rs
@@ -9,7 +9,7 @@ use zigzag::ZigZag as ExternalZigZag;
 
 use crate::ZigZagArray;
 
-impl ArrayCompute for ZigZagArray<'_> {
+impl ArrayCompute for ZigZagArray {
     fn scalar_at(&self) -> Option<&dyn ScalarAtFn> {
         Some(self)
     }
@@ -19,7 +19,7 @@ impl ArrayCompute for ZigZagArray<'_> {
     }
 }
 
-impl ScalarAtFn for ZigZagArray<'_> {
+impl ScalarAtFn for ZigZagArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         let scalar = scalar_at(&self.encoded(), index)?;
         let pscalar = PrimitiveScalar::try_from(&scalar)?;
@@ -33,7 +33,7 @@ impl ScalarAtFn for ZigZagArray<'_> {
     }
 }
 
-impl SliceFn for ZigZagArray<'_> {
+impl SliceFn for ZigZagArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
         Ok(ZigZagArray::try_new(slice(&self.encoded(), start, stop)?)?.into_array())
     }

--- a/vortex-zigzag/src/compute.rs
+++ b/vortex-zigzag/src/compute.rs
@@ -1,7 +1,7 @@
 use vortex::compute::scalar_at::{scalar_at, ScalarAtFn};
 use vortex::compute::slice::{slice, SliceFn};
 use vortex::compute::ArrayCompute;
-use vortex::{IntoArray, OwnedArray};
+use vortex::{Array, IntoArray};
 use vortex_dtype::PType;
 use vortex_error::VortexResult;
 use vortex_scalar::{PrimitiveScalar, Scalar};
@@ -34,7 +34,7 @@ impl ScalarAtFn for ZigZagArray {
 }
 
 impl SliceFn for ZigZagArray {
-    fn slice(&self, start: usize, stop: usize) -> VortexResult<OwnedArray> {
+    fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         Ok(ZigZagArray::try_new(slice(&self.encoded(), start, stop)?)?.into_array())
     }
 }

--- a/vortex-zigzag/src/zigzag.rs
+++ b/vortex-zigzag/src/zigzag.rs
@@ -16,7 +16,7 @@ pub struct ZigZagMetadata {
     encoded_dtype: DType,
 }
 
-impl ZigZagArray<'_> {
+impl ZigZagArray {
     pub fn new(encoded: Array) -> Self {
         Self::try_new(encoded).unwrap()
     }
@@ -36,7 +36,7 @@ impl ZigZagArray<'_> {
         Self::try_from_parts(dtype, metadata, children.into(), StatsSet::new())
     }
 
-    pub fn encode<'a>(array: &'a Array<'a>) -> VortexResult<Array<'a>> {
+    pub fn encode<'a>(array: &'a Array) -> VortexResult<Array> {
         PrimitiveArray::try_from(array)
             .map_err(|_| vortex_err!("ZigZag can only encoding primitive arrays"))
             .map(|parray| zigzag_encode(&parray))?
@@ -50,7 +50,7 @@ impl ZigZagArray<'_> {
     }
 }
 
-impl ArrayValidity for ZigZagArray<'_> {
+impl ArrayValidity for ZigZagArray {
     fn is_valid(&self, index: usize) -> bool {
         self.encoded().with_dyn(|a| a.is_valid(index))
     }
@@ -60,15 +60,15 @@ impl ArrayValidity for ZigZagArray<'_> {
     }
 }
 
-impl AcceptArrayVisitor for ZigZagArray<'_> {
+impl AcceptArrayVisitor for ZigZagArray {
     fn accept(&self, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         visitor.visit_child("encoded", &self.encoded())
     }
 }
 
-impl ArrayStatisticsCompute for ZigZagArray<'_> {}
+impl ArrayStatisticsCompute for ZigZagArray {}
 
-impl ArrayFlatten for ZigZagArray<'_> {
+impl ArrayFlatten for ZigZagArray {
     fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
     where
         Self: 'a,
@@ -77,7 +77,7 @@ impl ArrayFlatten for ZigZagArray<'_> {
     }
 }
 
-impl ArrayTrait for ZigZagArray<'_> {
+impl ArrayTrait for ZigZagArray {
     fn len(&self) -> usize {
         self.encoded().len()
     }

--- a/vortex-zigzag/src/zigzag.rs
+++ b/vortex-zigzag/src/zigzag.rs
@@ -36,7 +36,7 @@ impl ZigZagArray {
         Self::try_from_parts(dtype, metadata, children.into(), StatsSet::new())
     }
 
-    pub fn encode<'a>(array: &'a Array) -> VortexResult<Array> {
+    pub fn encode(array: &Array) -> VortexResult<Array> {
         PrimitiveArray::try_from(array)
             .map_err(|_| vortex_err!("ZigZag can only encoding primitive arrays"))
             .map(|parray| zigzag_encode(&parray))?

--- a/vortex-zigzag/src/zigzag.rs
+++ b/vortex-zigzag/src/zigzag.rs
@@ -69,10 +69,7 @@ impl AcceptArrayVisitor for ZigZagArray {
 impl ArrayStatisticsCompute for ZigZagArray {}
 
 impl ArrayFlatten for ZigZagArray {
-    fn flatten<'a>(self) -> VortexResult<Flattened<'a>>
-    where
-        Self: 'a,
-    {
+    fn flatten(self) -> VortexResult<Flattened> {
         todo!("ZigZagArray::flatten")
     }
 }


### PR DESCRIPTION
Instead of passing around references everywhere, we've refactored ArrayView to internally use Arc'd buffers. While this does introduce reference counting, it's relatively cheap compared to heap copies and allows to better fit in with the wider ecosystem without having to deal with LendingIterator or its (not really implemented by anyone) async equivalent.

This PR:
* Removes lifetime from Array, Flattened, and Validity
* Removes OwnedX alias types
* Removes ToStatic trait and functions