### PR TITLE
Introduce FieldPath abstraction, restrict predicates to Field, Op, (Field|Scalar)

### DIFF
--- a/vortex-dtype/src/field_paths.rs
+++ b/vortex-dtype/src/field_paths.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Formatter};
 
 use vortex_error::{vortex_bail, VortexResult};
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FieldPath {
     field_names: Vec<FieldIdentifier>,
@@ -15,7 +15,7 @@ impl FieldPath {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FieldIdentifier {
     Name(String),
@@ -79,12 +79,11 @@ impl From<u64> for FieldIdentifier {
 }
 
 impl Display for FieldIdentifier {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let formatted = match self {
-            FieldIdentifier::Name(name) => format! {"${name}"},
-            FieldIdentifier::ListIndex(idx) => format! {"[{idx}]"},
-        };
-        write!(f, "{}", formatted)
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            FieldIdentifier::Name(name) => write!(f, "${name}"),
+            FieldIdentifier::ListIndex(idx) => write!(f, "[{idx}]"),
+        }
     }
 }
 

--- a/vortex-dtype/src/field_paths.rs
+++ b/vortex-dtype/src/field_paths.rs
@@ -31,13 +31,11 @@ impl FieldPathBuilder {
         }
     }
 
-    // Adds a field identifier to the path.
     pub fn join<T: Into<FieldIdentifier>>(mut self, identifier: T) -> Self {
         self.field_names.push(identifier.into());
         self
     }
 
-    // Builds the FieldPath object.
     pub fn build(self) -> FieldPath {
         FieldPath {
             field_names: self.field_names,

--- a/vortex-dtype/src/field_paths.rs
+++ b/vortex-dtype/src/field_paths.rs
@@ -1,6 +1,8 @@
 use core::fmt;
 use std::fmt::{Display, Formatter};
 
+use vortex_error::{vortex_bail, VortexResult};
+
 #[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FieldPath {
@@ -36,10 +38,13 @@ impl FieldPathBuilder {
         self
     }
 
-    pub fn build(self) -> FieldPath {
-        FieldPath {
-            field_names: self.field_names,
+    pub fn build(self) -> VortexResult<FieldPath> {
+        if self.field_names.is_empty() {
+            vortex_bail!("Cannot build empty path");
         }
+        Ok(FieldPath {
+            field_names: self.field_names,
+        })
     }
 }
 

--- a/vortex-dtype/src/field_paths.rs
+++ b/vortex-dtype/src/field_paths.rs
@@ -1,0 +1,98 @@
+use core::fmt;
+use std::fmt::{Display, Formatter};
+
+#[derive(Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct FieldPath {
+    pub field_names: Vec<FieldIdentifier>,
+}
+
+impl FieldPath {
+    pub fn builder() -> FieldPathBuilder {
+        FieldPathBuilder::default()
+    }
+}
+
+#[derive(Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum FieldIdentifier {
+    Name(String),
+    ListIndex(u64),
+}
+
+pub struct FieldPathBuilder {
+    field_names: Vec<FieldIdentifier>,
+}
+
+impl FieldPathBuilder {
+    pub fn new() -> Self {
+        Self {
+            field_names: Vec::new(),
+        }
+    }
+
+    // Adds a field identifier to the path.
+    pub fn join<T: Into<FieldIdentifier>>(mut self, identifier: T) -> Self {
+        self.field_names.push(identifier.into());
+        self
+    }
+
+    // Builds the FieldPath object.
+    pub fn build(self) -> FieldPath {
+        FieldPath {
+            field_names: self.field_names,
+        }
+    }
+}
+
+impl Default for FieldPathBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn field(x: impl Into<FieldIdentifier>) -> FieldPath {
+    x.into().into()
+}
+
+impl From<FieldIdentifier> for FieldPath {
+    fn from(value: FieldIdentifier) -> Self {
+        FieldPath {
+            field_names: vec![value],
+        }
+    }
+}
+
+impl From<&str> for FieldIdentifier {
+    fn from(value: &str) -> Self {
+        FieldIdentifier::Name(value.to_string())
+    }
+}
+
+impl From<u64> for FieldIdentifier {
+    fn from(value: u64) -> Self {
+        FieldIdentifier::ListIndex(value)
+    }
+}
+
+impl Display for FieldIdentifier {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let formatted = match self {
+            FieldIdentifier::Name(name) => format! {"${name}"},
+            FieldIdentifier::ListIndex(idx) => format! {"[{idx}]"},
+        };
+        write!(f, "{}", formatted)
+    }
+}
+
+impl Display for FieldPath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let formatted = self
+            .field_names
+            .iter()
+            .map(|fid| format!("{fid}"))
+            .collect::<Vec<_>>()
+            .join(".");
+        write!(f, "{}", formatted)
+    }
+}

--- a/vortex-dtype/src/field_paths.rs
+++ b/vortex-dtype/src/field_paths.rs
@@ -6,7 +6,7 @@ use vortex_error::{vortex_bail, VortexResult};
 #[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FieldPath {
-    pub field_names: Vec<FieldIdentifier>,
+    field_names: Vec<FieldIdentifier>,
 }
 
 impl FieldPath {

--- a/vortex-dtype/src/lib.rs
+++ b/vortex-dtype/src/lib.rs
@@ -1,7 +1,5 @@
 #![cfg(target_endian = "little")]
 
-extern crate core;
-
 pub use dtype::*;
 pub use extension::*;
 pub use half;

--- a/vortex-dtype/src/lib.rs
+++ b/vortex-dtype/src/lib.rs
@@ -1,12 +1,16 @@
 #![cfg(target_endian = "little")]
 
+extern crate core;
+
 pub use dtype::*;
 pub use extension::*;
 pub use half;
 pub use nullability::*;
 pub use ptype::*;
+
 mod dtype;
 mod extension;
+pub mod field_paths;
 mod nullability;
 mod ptype;
 mod serde;
@@ -28,5 +32,6 @@ pub mod flatbuffers {
     mod generated {
         include!(concat!(env!("OUT_DIR"), "/flatbuffers/dtype.rs"));
     }
+
     pub use generated::vortex::dtype::*;
 }

--- a/vortex-expr/src/display.rs
+++ b/vortex-expr/src/display.rs
@@ -33,8 +33,8 @@ impl Display for Predicate {
 impl Display for Value {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Value::Field(field_path) => field_path.fmt(f),
-            Value::Literal(scalar) => std::fmt::Display::fmt(&scalar, f),
+            Value::Field(field_path) => Display::fmt(field_path, f),
+            Value::Literal(scalar) => Display::fmt(&scalar, f),
         }
     }
 }
@@ -63,10 +63,10 @@ mod tests {
     #[test]
     fn test_predicate_formatting() {
         let f1 = field("field");
-        assert_eq!(format!("{}", lit(1u32).lt(f1.clone())), "($field < 1)");
-        assert_eq!(format!("{}", lit(1u32).gte(f1.clone())), "($field >= 1)");
-        assert_eq!(format!("{}", !lit(1u32).lte(f1.clone())), "($field > 1)");
-        assert_eq!(format!("{}", !f1.lte(lit(1u32))), "($field > 1)");
+        assert_eq!(format!("{}", f1.clone().lt(lit(1u32))), "($field < 1)");
+        assert_eq!(format!("{}", f1.clone().gte(lit(1u32))), "($field >= 1)");
+        assert_eq!(format!("{}", !f1.clone().lte(lit(1u32))), "($field > 1)");
+        assert_eq!(format!("{}", !lit(1u32).lte(f1)), "($field <= 1)");
 
         // nested field path
         let f2 = FieldPath::builder().join("field").join(0).build().unwrap();
@@ -79,7 +79,7 @@ mod tests {
         let d1 = Conjunction {
             predicates: vec![
                 lit(1u32).lt(path.clone()),
-                lit(1u32).gte(path.clone()),
+                path.clone().gte(lit(1u32)),
                 !lit(1u32).lte(path),
             ],
         };
@@ -100,8 +100,8 @@ mod tests {
         print!("{}", string);
         assert_eq!(
             string,
-            "([2].$col1 < 1) AND ([2].$col1 >= 1) AND ([2].$col1 > 1)\nOR \
-            \n($col1.[2] < 2) AND ([2] >= 3) AND ($col2 > 5)"
+            "([2].$col1 >= 1) AND ([2].$col1 >= 1) AND ([2].$col1 <= 1)\nOR \
+            \n($col1.[2] >= 2) AND ([2] < 3) AND ($col2 <= 5)"
         );
     }
 }

--- a/vortex-expr/src/display.rs
+++ b/vortex-expr/src/display.rs
@@ -26,15 +26,15 @@ impl Display for Conjunction {
 
 impl Display for Predicate {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "({} {} {})", self.left, self.op, self.right)
+        write!(f, "({} {} {})", self.field, self.op, self.value)
     }
 }
 
 impl Display for Value {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Value::Field(expr) => std::fmt::Display::fmt(expr, f),
-            Value::Literal(scalar) => scalar.fmt(f),
+            Value::Field(field_path) => field_path.fmt(f),
+            Value::Literal(scalar) => std::fmt::Display::fmt(&scalar, f),
         }
     }
 }
@@ -55,32 +55,40 @@ impl Display for Operator {
 
 #[cfg(test)]
 mod tests {
+    use vortex_dtype::field_paths::{field, FieldPath};
+
     use crate::expressions::{lit, Conjunction, Disjunction};
+    use crate::field_paths::FieldPathOperator;
 
     #[test]
     fn test_predicate_formatting() {
-        // And
-        assert_eq!(format!("{}", lit(1u32).lt(lit(2u32))), "(1 < 2)");
-        // Or
-        assert_eq!(format!("{}", lit(1u32).gte(lit(2u32))), "(1 >= 2)");
-        // Not
-        assert_eq!(format!("{}", !lit(1u32).lte(lit(2u32))), "(1 > 2)");
+        let f1 = field("field");
+        assert_eq!(format!("{}", lit(1u32).lt(f1.clone())), "($field < 1)");
+        assert_eq!(format!("{}", lit(1u32).gte(f1.clone())), "($field >= 1)");
+        assert_eq!(format!("{}", !lit(1u32).lte(f1.clone())), "($field > 1)");
+        assert_eq!(format!("{}", !f1.lte(lit(1u32))), "($field > 1)");
+
+        // nested field path
+        let f2 = FieldPath::builder().join("field").join(0).build();
+        assert_eq!(format!("{}", !f2.lte(lit(1u32))), "($field.[0] > 1)");
     }
 
     #[test]
     fn test_dnf_formatting() {
+        let path = FieldPath::builder().join(2).join("col1").build();
         let d1 = Conjunction {
             predicates: vec![
-                lit(1u32).lt(lit(2u32)),
-                lit(1u32).gte(lit(2u32)),
-                !lit(1u32).lte(lit(2u32)),
+                lit(1u32).lt(path.clone()),
+                lit(1u32).gte(path.clone()),
+                !lit(1u32).lte(path),
             ],
         };
+        let path2 = FieldPath::builder().join("col1").join(2).build();
         let d2 = Conjunction {
             predicates: vec![
-                lit(2u32).lt(lit(3u32)),
-                lit(3u32).gte(lit(4u32)),
-                !lit(5u32).lte(lit(6u32)),
+                lit(2u32).lt(path2),
+                lit(3u32).gte(field(2)),
+                !lit(5u32).lte(field("col2")),
             ],
         };
 
@@ -92,7 +100,8 @@ mod tests {
         print!("{}", string);
         assert_eq!(
             string,
-            "(1 < 2) AND (1 >= 2) AND (1 > 2)\nOR \n(2 < 3) AND (3 >= 4) AND (5 > 6)"
+            "([2].$col1 < 1) AND ([2].$col1 >= 1) AND ([2].$col1 > 1)\nOR \
+            \n($col1.[2] < 2) AND ([2] >= 3) AND ($col2 > 5)"
         );
     }
 }

--- a/vortex-expr/src/display.rs
+++ b/vortex-expr/src/display.rs
@@ -58,7 +58,7 @@ mod tests {
     use vortex_dtype::field_paths::{field, FieldPath};
 
     use crate::expressions::{lit, Conjunction, Disjunction};
-    use crate::field_paths::FieldPathOperator;
+    use crate::field_paths::FieldPathOperations;
 
     #[test]
     fn test_predicate_formatting() {

--- a/vortex-expr/src/display.rs
+++ b/vortex-expr/src/display.rs
@@ -26,7 +26,7 @@ impl Display for Conjunction {
 
 impl Display for Predicate {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "({} {} {})", self.field, self.op, self.value)
+        write!(f, "({} {} {})", self.left, self.op, self.right)
     }
 }
 

--- a/vortex-expr/src/display.rs
+++ b/vortex-expr/src/display.rs
@@ -69,13 +69,13 @@ mod tests {
         assert_eq!(format!("{}", !f1.lte(lit(1u32))), "($field > 1)");
 
         // nested field path
-        let f2 = FieldPath::builder().join("field").join(0).build();
+        let f2 = FieldPath::builder().join("field").join(0).build().unwrap();
         assert_eq!(format!("{}", !f2.lte(lit(1u32))), "($field.[0] > 1)");
     }
 
     #[test]
     fn test_dnf_formatting() {
-        let path = FieldPath::builder().join(2).join("col1").build();
+        let path = FieldPath::builder().join(2).join("col1").build().unwrap();
         let d1 = Conjunction {
             predicates: vec![
                 lit(1u32).lt(path.clone()),
@@ -83,7 +83,7 @@ mod tests {
                 !lit(1u32).lte(path),
             ],
         };
-        let path2 = FieldPath::builder().join("col1").join(2).build();
+        let path2 = FieldPath::builder().join("col1").join(2).build().unwrap();
         let d2 = Conjunction {
             predicates: vec![
                 lit(2u32).lt(path2),

--- a/vortex-expr/src/expressions.rs
+++ b/vortex-expr/src/expressions.rs
@@ -5,24 +5,24 @@ use crate::operators::Operator;
 
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
+    derive(Debug, serde::Serialize, serde::Deserialize),
     serde(transparent)
 )]
 pub struct Disjunction {
     pub conjunctions: Vec<Conjunction>,
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
+    derive(Debug, serde::Serialize, serde::Deserialize),
     serde(transparent)
 )]
 pub struct Conjunction {
     pub predicates: Vec<Predicate>,
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Value {
     /// A named reference to a qualified field in a dtype.
@@ -31,7 +31,7 @@ pub enum Value {
     Literal(Scalar),
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Predicate {
     pub left: FieldPath,
@@ -44,7 +44,8 @@ pub fn lit<T: Into<Scalar>>(n: T) -> Value {
 }
 
 impl Value {
-    // comparisons
+    // NB: We rewrite predicates to be Field-op-predicate, so these methods all must
+    // use the inverse operator.
     pub fn eq(self, field: impl Into<FieldPath>) -> Predicate {
         Predicate {
             left: field.into(),
@@ -56,7 +57,7 @@ impl Value {
     pub fn not_eq(self, field: impl Into<FieldPath>) -> Predicate {
         Predicate {
             left: field.into(),
-            op: Operator::NotEqualTo,
+            op: Operator::NotEqualTo.inverse(),
             right: self,
         }
     }
@@ -64,7 +65,7 @@ impl Value {
     pub fn gt(self, field: impl Into<FieldPath>) -> Predicate {
         Predicate {
             left: field.into(),
-            op: Operator::GreaterThan,
+            op: Operator::GreaterThan.inverse(),
             right: self,
         }
     }
@@ -72,7 +73,7 @@ impl Value {
     pub fn gte(self, field: impl Into<FieldPath>) -> Predicate {
         Predicate {
             left: field.into(),
-            op: Operator::GreaterThanOrEqualTo,
+            op: Operator::GreaterThanOrEqualTo.inverse(),
             right: self,
         }
     }
@@ -80,7 +81,7 @@ impl Value {
     pub fn lt(self, field: impl Into<FieldPath>) -> Predicate {
         Predicate {
             left: field.into(),
-            op: Operator::LessThan,
+            op: Operator::LessThan.inverse(),
             right: self,
         }
     }
@@ -88,7 +89,7 @@ impl Value {
     pub fn lte(self, field: impl Into<FieldPath>) -> Predicate {
         Predicate {
             left: field.into(),
-            op: Operator::LessThanOrEqualTo,
+            op: Operator::LessThanOrEqualTo.inverse(),
             right: self,
         }
     }

--- a/vortex-expr/src/expressions.rs
+++ b/vortex-expr/src/expressions.rs
@@ -34,9 +34,9 @@ pub enum Value {
 #[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Predicate {
-    pub field: FieldPath,
+    pub left: FieldPath,
     pub op: Operator,
-    pub value: Value,
+    pub right: Value,
 }
 
 pub fn lit<T: Into<Scalar>>(n: T) -> Value {
@@ -47,49 +47,49 @@ impl Value {
     // comparisons
     pub fn eq(self, field: impl Into<FieldPath>) -> Predicate {
         Predicate {
-            field: field.into(),
+            left: field.into(),
             op: Operator::EqualTo,
-            value: self,
+            right: self,
         }
     }
 
     pub fn not_eq(self, field: impl Into<FieldPath>) -> Predicate {
         Predicate {
-            field: field.into(),
+            left: field.into(),
             op: Operator::NotEqualTo,
-            value: self,
+            right: self,
         }
     }
 
     pub fn gt(self, field: impl Into<FieldPath>) -> Predicate {
         Predicate {
-            field: field.into(),
+            left: field.into(),
             op: Operator::GreaterThan,
-            value: self,
+            right: self,
         }
     }
 
     pub fn gte(self, field: impl Into<FieldPath>) -> Predicate {
         Predicate {
-            field: field.into(),
+            left: field.into(),
             op: Operator::GreaterThanOrEqualTo,
-            value: self,
+            right: self,
         }
     }
 
     pub fn lt(self, field: impl Into<FieldPath>) -> Predicate {
         Predicate {
-            field: field.into(),
+            left: field.into(),
             op: Operator::LessThan,
-            value: self,
+            right: self,
         }
     }
 
     pub fn lte(self, field: impl Into<FieldPath>) -> Predicate {
         Predicate {
-            field: field.into(),
+            left: field.into(),
             op: Operator::LessThanOrEqualTo,
-            value: self,
+            right: self,
         }
     }
 }
@@ -106,9 +106,9 @@ mod test {
         let value: Value = lit(scalar);
         let field = field("id");
         let expr = Predicate {
-            field,
+            left: field,
             op: Operator::EqualTo,
-            value,
+            right: value,
         };
         assert_eq!(format!("{}", expr), "($id = 1)");
     }

--- a/vortex-expr/src/expressions.rs
+++ b/vortex-expr/src/expressions.rs
@@ -3,10 +3,11 @@ use vortex_scalar::Scalar;
 
 use crate::operators::Operator;
 
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
-    derive(Debug, serde::Serialize, serde::Deserialize),
-    serde(transparent)
+feature = "serde",
+derive(serde::Serialize, serde::Deserialize),
+serde(transparent)
 )]
 pub struct Disjunction {
     pub conjunctions: Vec<Conjunction>,
@@ -14,9 +15,9 @@ pub struct Disjunction {
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
-    derive(Debug, serde::Serialize, serde::Deserialize),
-    serde(transparent)
+feature = "serde",
+derive(serde::Serialize, serde::Deserialize),
+serde(transparent)
 )]
 pub struct Conjunction {
     pub predicates: Vec<Predicate>,

--- a/vortex-expr/src/expressions.rs
+++ b/vortex-expr/src/expressions.rs
@@ -5,9 +5,9 @@ use crate::operators::Operator;
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-feature = "serde",
-derive(serde::Serialize, serde::Deserialize),
-serde(transparent)
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(transparent)
 )]
 pub struct Disjunction {
     pub conjunctions: Vec<Conjunction>,
@@ -15,9 +15,9 @@ pub struct Disjunction {
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-feature = "serde",
-derive(serde::Serialize, serde::Deserialize),
-serde(transparent)
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(transparent)
 )]
 pub struct Conjunction {
     pub predicates: Vec<Predicate>,

--- a/vortex-expr/src/field_paths.rs
+++ b/vortex-expr/src/field_paths.rs
@@ -3,7 +3,7 @@ use vortex_dtype::field_paths::FieldPath;
 use crate::expressions::{Predicate, Value};
 use crate::operators::Operator;
 
-pub trait FieldPathOperator {
+pub trait FieldPathOperations {
     fn eq(self, other: Value) -> Predicate;
     fn not_eq(self, other: Value) -> Predicate;
     fn gt(self, other: Value) -> Predicate;
@@ -12,7 +12,7 @@ pub trait FieldPathOperator {
     fn lte(self, other: Value) -> Predicate;
 }
 
-impl FieldPathOperator for FieldPath {
+impl FieldPathOperations for FieldPath {
     // comparisons
     fn eq(self, other: Value) -> Predicate {
         Predicate {

--- a/vortex-expr/src/field_paths.rs
+++ b/vortex-expr/src/field_paths.rs
@@ -16,49 +16,49 @@ impl FieldPathOperations for FieldPath {
     // comparisons
     fn eq(self, other: Value) -> Predicate {
         Predicate {
-            field: self,
+            left: self,
             op: Operator::EqualTo,
-            value: other,
+            right: other,
         }
     }
 
     fn not_eq(self, other: Value) -> Predicate {
         Predicate {
-            field: self,
+            left: self,
             op: Operator::NotEqualTo,
-            value: other,
+            right: other,
         }
     }
 
     fn gt(self, other: Value) -> Predicate {
         Predicate {
-            field: self,
+            left: self,
             op: Operator::GreaterThan,
-            value: other,
+            right: other,
         }
     }
 
     fn gte(self, other: Value) -> Predicate {
         Predicate {
-            field: self,
+            left: self,
             op: Operator::GreaterThanOrEqualTo,
-            value: other,
+            right: other,
         }
     }
 
     fn lt(self, other: Value) -> Predicate {
         Predicate {
-            field: self,
+            left: self,
             op: Operator::LessThan,
-            value: other,
+            right: other,
         }
     }
 
     fn lte(self, other: Value) -> Predicate {
         Predicate {
-            field: self,
+            left: self,
             op: Operator::LessThanOrEqualTo,
-            value: other,
+            right: other,
         }
     }
 }

--- a/vortex-expr/src/field_paths.rs
+++ b/vortex-expr/src/field_paths.rs
@@ -1,0 +1,64 @@
+use vortex_dtype::field_paths::FieldPath;
+
+use crate::expressions::{Predicate, Value};
+use crate::operators::Operator;
+
+pub trait FieldPathOperator {
+    fn eq(self, other: Value) -> Predicate;
+    fn not_eq(self, other: Value) -> Predicate;
+    fn gt(self, other: Value) -> Predicate;
+    fn gte(self, other: Value) -> Predicate;
+    fn lt(self, other: Value) -> Predicate;
+    fn lte(self, other: Value) -> Predicate;
+}
+
+impl FieldPathOperator for FieldPath {
+    // comparisons
+    fn eq(self, other: Value) -> Predicate {
+        Predicate {
+            field: self,
+            op: Operator::EqualTo,
+            value: other,
+        }
+    }
+
+    fn not_eq(self, other: Value) -> Predicate {
+        Predicate {
+            field: self,
+            op: Operator::NotEqualTo,
+            value: other,
+        }
+    }
+
+    fn gt(self, other: Value) -> Predicate {
+        Predicate {
+            field: self,
+            op: Operator::GreaterThan,
+            value: other,
+        }
+    }
+
+    fn gte(self, other: Value) -> Predicate {
+        Predicate {
+            field: self,
+            op: Operator::GreaterThanOrEqualTo,
+            value: other,
+        }
+    }
+
+    fn lt(self, other: Value) -> Predicate {
+        Predicate {
+            field: self,
+            op: Operator::LessThan,
+            value: other,
+        }
+    }
+
+    fn lte(self, other: Value) -> Predicate {
+        Predicate {
+            field: self,
+            op: Operator::LessThanOrEqualTo,
+            value: other,
+        }
+    }
+}

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -3,4 +3,5 @@ extern crate core;
 
 mod display;
 pub mod expressions;
+pub mod field_paths;
 pub mod operators;

--- a/vortex-expr/src/operators.rs
+++ b/vortex-expr/src/operators.rs
@@ -33,3 +33,16 @@ impl ops::Not for Predicate {
         }
     }
 }
+
+impl Operator {
+    pub fn inverse(self) -> Self {
+        match self {
+            Operator::EqualTo => Operator::NotEqualTo,
+            Operator::NotEqualTo => Operator::EqualTo,
+            Operator::GreaterThan => Operator::LessThanOrEqualTo,
+            Operator::GreaterThanOrEqualTo => Operator::LessThan,
+            Operator::LessThan => Operator::GreaterThanOrEqualTo,
+            Operator::LessThanOrEqualTo => Operator::GreaterThan,
+        }
+    }
+}

--- a/vortex-expr/src/operators.rs
+++ b/vortex-expr/src/operators.rs
@@ -27,9 +27,9 @@ impl ops::Not for Predicate {
             Operator::LessThanOrEqualTo => Operator::GreaterThan,
         };
         Predicate {
-            field: self.field,
+            left: self.left,
             op: inverse_op,
-            value: self.value,
+            right: self.right,
         }
     }
 }

--- a/vortex-expr/src/operators.rs
+++ b/vortex-expr/src/operators.rs
@@ -27,9 +27,9 @@ impl ops::Not for Predicate {
             Operator::LessThanOrEqualTo => Operator::GreaterThan,
         };
         Predicate {
-            left: self.left,
+            field: self.field,
             op: inverse_op,
-            right: self.right,
+            value: self.value,
         }
     }
 }


### PR DESCRIPTION
We need an abstraction to handle addressing nested fields, hence FieldPath.

Also disallows scalar-scalar comparisons, which are useless. 