### PR TITLE
ChunkedArray is not a flat encoding

### DIFF
--- a/vortex-array/src/array/chunked/mod.rs
+++ b/vortex-array/src/array/chunked/mod.rs
@@ -6,6 +6,7 @@ use vortex_error::vortex_bail;
 use vortex_scalar::Scalar;
 
 use crate::array::primitive::PrimitiveArray;
+use crate::compute::as_contiguous::as_contiguous;
 use crate::compute::scalar_at::scalar_at;
 use crate::compute::scalar_subtract::{subtract_scalar, SubtractScalarFn};
 use crate::compute::search_sorted::{search_sorted, SearchSortedSide};
@@ -115,7 +116,12 @@ impl FromIterator<Array> for ChunkedArray {
 
 impl ArrayFlatten for ChunkedArray {
     fn flatten(self) -> VortexResult<Flattened> {
-        Ok(Flattened::Chunked(self))
+        let chunks = self.chunks().collect_vec();
+        if chunks.is_empty() {
+            // TODO(ngates): return an empty FlattenedArray with the correct DType.
+            panic!("Cannot yet flatten an empty chunked array");
+        }
+        as_contiguous(chunks.as_slice())?.flatten()
     }
 }
 

--- a/vortex-array/src/flatten.rs
+++ b/vortex-array/src/flatten.rs
@@ -1,7 +1,6 @@
 use vortex_error::VortexResult;
 
 use crate::array::bool::BoolArray;
-use crate::array::chunked::ChunkedArray;
 use crate::array::extension::ExtensionArray;
 use crate::array::primitive::PrimitiveArray;
 use crate::array::r#struct::StructArray;
@@ -13,7 +12,6 @@ use crate::{Array, IntoArray};
 /// The set of encodings that can be converted to Arrow with zero-copy.
 pub enum Flattened {
     Bool(BoolArray),
-    Chunked(ChunkedArray),
     Primitive(PrimitiveArray),
     Struct(StructArray),
     VarBin(VarBinArray),
@@ -49,7 +47,6 @@ impl IntoArray for Flattened {
             Self::Bool(a) => a.into_array(),
             Self::Primitive(a) => a.into_array(),
             Self::Struct(a) => a.into_array(),
-            Self::Chunked(a) => a.into_array(),
             Self::VarBin(a) => a.into_array(),
             Self::Extension(a) => a.into_array(),
             Self::VarBinView(a) => a.into_array(),


### PR DESCRIPTION
1. Since it cannot be zero-copied to Arrow.
1. It's awkward for a DType::Primitive to not have just one flattened representation. This isn't true for all DTypes, e.g. VarBin can be VarBin or VarBinView, but still...