### PR TITLE
Add Page message to Vortex IPC

### DIFF
--- a/vortex-ipc/flatbuffers/message.fbs
+++ b/vortex-ipc/flatbuffers/message.fbs
@@ -35,10 +35,16 @@ table Chunk {
     buffer_size: uint64;
 }
 
+table Page {
+    buffer_size: uint32;
+    padding: uint16;
+}
+
 union MessageHeader {
   Context,
   Schema,
   Chunk,
+  Page,
 }
 
 table Message {

--- a/vortex-ipc/src/lib.rs
+++ b/vortex-ipc/src/lib.rs
@@ -3,6 +3,13 @@ extern crate core;
 pub use message_reader::*;
 pub use message_writer::*;
 use vortex_error::{vortex_err, VortexError};
+pub mod chunked_reader;
+pub mod io;
+mod message_reader;
+mod message_writer;
+mod messages;
+pub mod stream_reader;
+pub mod writer;
 
 pub const ALIGNMENT: usize = 64;
 
@@ -32,14 +39,6 @@ pub mod flatbuffers {
         }
     }
 }
-
-pub mod chunked_reader;
-pub mod io;
-mod message_reader;
-mod message_writer;
-mod messages;
-pub mod stream_reader;
-pub mod writer;
 
 pub(crate) const fn missing(field: &'static str) -> impl FnOnce() -> VortexError {
     move || vortex_err!(InvalidSerde: "missing field: {}", field)

--- a/vortex-ipc/src/message_reader.rs
+++ b/vortex-ipc/src/message_reader.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use bytes::{Buf, BytesMut};
 use flatbuffers::{root, root_unchecked};
 use futures_util::stream::try_unfold;
-use futures_util::Stream;
 use itertools::Itertools;
 use vortex::stream::{ArrayStream, ArrayStreamAdapter};
 use vortex::{Array, ArrayView, Context, IntoArray, ToArray, ViewContext};
@@ -273,9 +272,9 @@ impl<R: VortexRead> MessageReader<R> {
         )
     }
 
-    pub async fn read_page(&mut self) -> VortexResult<Buffer> {
+    pub async fn maybe_read_page(&mut self) -> VortexResult<Option<Buffer>> {
         if self.peek().and_then(|m| m.header_as_page()).is_none() {
-            vortex_bail!("Expected page message")
+            return Ok(None);
         }
         let page_msg = self.next().await?.header_as_page().unwrap();
 
@@ -287,18 +286,6 @@ impl<R: VortexRead> MessageReader<R> {
             .read_into(BytesMut::with_capacity(total_len))
             .await?;
         buffer.truncate(buffer_len);
-        Ok(Buffer::from(buffer.freeze()))
-    }
-
-    pub async fn page_stream(&mut self) -> impl Stream<Item = VortexResult<Buffer>> + '_ {
-        try_unfold(self, |state| async move {
-            if state.peek().and_then(|m| m.header_as_page()).is_none() {
-                return Ok(None);
-            }
-            match state.read_page().await {
-                Ok(page) => Ok(Some((page, state))),
-                Err(e) => Err(e),
-            }
-        })
+        Ok(Some(Buffer::from(buffer.freeze())))
     }
 }


### PR DESCRIPTION
A page holds arbitrary bytes. This can be used by consumers to add custom data into a Vortex stream / file.