### PR TITLE
ArrayData can contain child Arrays instead of just ArrayData

### DIFF
--- a/encodings/alp/src/array.rs
+++ b/encodings/alp/src/array.rs
@@ -3,7 +3,7 @@ use vortex::array::primitive::PrimitiveArray;
 use vortex::stats::ArrayStatisticsCompute;
 use vortex::validity::{ArrayValidity, LogicalValidity};
 use vortex::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use vortex::{impl_encoding, ArrayDType, ArrayFlatten, IntoArrayData};
+use vortex::{impl_encoding, ArrayDType, ArrayFlatten};
 use vortex_dtype::PType;
 use vortex_error::vortex_bail;
 
@@ -34,9 +34,9 @@ impl ALPArray {
 
         let patches_dtype = patches.as_ref().map(|a| a.dtype().as_nullable());
         let mut children = Vec::with_capacity(2);
-        children.push(encoded.into_array_data());
+        children.push(encoded);
         if let Some(patch) = patches {
-            children.push(patch.into_array_data());
+            children.push(patch);
         }
 
         Self::try_from_parts(

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use vortex::stats::ArrayStatisticsCompute;
 use vortex::validity::{ArrayValidity, LogicalValidity};
 use vortex::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use vortex::{impl_encoding, ArrayDType, ArrayFlatten, IntoArrayData};
+use vortex::{impl_encoding, ArrayDType, ArrayFlatten};
 use vortex_error::vortex_bail;
 
 use crate::compute::decode_to_localdatetime;
@@ -52,12 +52,7 @@ impl DateTimePartsArray {
                 seconds_dtype: seconds.dtype().clone(),
                 subseconds_dtype: subsecond.dtype().clone(),
             },
-            [
-                days.into_array_data(),
-                seconds.into_array_data(),
-                subsecond.into_array_data(),
-            ]
-            .into(),
+            [days, seconds, subsecond].into(),
             StatsSet::new(),
         )
     }

--- a/encodings/dict/src/dict.rs
+++ b/encodings/dict/src/dict.rs
@@ -5,7 +5,6 @@ use vortex::compute::scalar_at::scalar_at;
 use vortex::compute::take::take;
 use vortex::validity::{ArrayValidity, LogicalValidity};
 use vortex::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use vortex::IntoArrayData;
 use vortex::{impl_encoding, ArrayDType, ArrayFlatten};
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::vortex_bail;
@@ -27,7 +26,7 @@ impl DictArray {
             DictMetadata {
                 codes_dtype: codes.dtype().clone(),
             },
-            [values.into_array_data(), codes.into_array_data()].into(),
+            [values, codes].into(),
             StatsSet::new(),
         )
     }
@@ -68,7 +67,7 @@ impl ArrayValidity for DictArray {
                 ArrayAccessor::<$P>::with_iterator(&primitive_codes, |iter| {
                     LogicalValidity::Array(
                         BoolArray::from(iter.flatten().map(|c| *c != 0).collect::<Vec<_>>())
-                            .into_array_data(),
+                            .into_array(),
                     )
                 })
                 .unwrap()

--- a/encodings/fastlanes/src/bitpacking/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/mod.rs
@@ -4,7 +4,7 @@ use vortex::array::primitive::{Primitive, PrimitiveArray};
 use vortex::stats::ArrayStatisticsCompute;
 use vortex::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use vortex::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use vortex::{impl_encoding, ArrayDType, ArrayFlatten, IntoArrayData};
+use vortex::{impl_encoding, ArrayDType, ArrayFlatten};
 use vortex_dtype::{Nullability, PType};
 use vortex_error::{vortex_bail, vortex_err};
 
@@ -71,11 +71,11 @@ impl BitPackedArray {
         };
 
         let mut children = Vec::with_capacity(3);
-        children.push(packed.into_array_data());
+        children.push(packed);
         if let Some(p) = patches {
-            children.push(p.into_array_data());
+            children.push(p);
         }
-        if let Some(a) = validity.into_array_data() {
+        if let Some(a) = validity.into_array() {
             children.push(a)
         }
 

--- a/encodings/fastlanes/src/delta/mod.rs
+++ b/encodings/fastlanes/src/delta/mod.rs
@@ -3,7 +3,7 @@ use vortex::stats::ArrayStatisticsCompute;
 use vortex::validity::ValidityMetadata;
 use vortex::validity::{ArrayValidity, LogicalValidity, Validity};
 use vortex::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use vortex::{impl_encoding, ArrayDType, ArrayFlatten, IntoArrayData};
+use vortex::{impl_encoding, ArrayDType, ArrayFlatten};
 use vortex_dtype::match_each_unsigned_integer_ptype;
 use vortex_error::vortex_bail;
 
@@ -48,7 +48,7 @@ impl DeltaArray {
                 validity: validity.to_metadata(len)?,
                 len,
             },
-            [bases.into_array_data(), deltas.into_array_data()].into(),
+            [bases, deltas].into(),
             StatsSet::new(),
         )?;
 

--- a/encodings/fastlanes/src/for/mod.rs
+++ b/encodings/fastlanes/src/for/mod.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use vortex::stats::ArrayStatisticsCompute;
 use vortex::validity::{ArrayValidity, LogicalValidity};
 use vortex::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use vortex::{impl_encoding, ArrayDType, ArrayFlatten, IntoArrayData};
+use vortex::{impl_encoding, ArrayDType, ArrayFlatten};
 use vortex_error::vortex_bail;
 use vortex_scalar::Scalar;
 
@@ -28,7 +28,7 @@ impl FoRArray {
         Self::try_from_parts(
             child.dtype().clone(),
             FoRMetadata { reference, shift },
-            [child.into_array_data()].into(),
+            [child].into(),
             StatsSet::new(),
         )
     }

--- a/encodings/runend/src/ree.rs
+++ b/encodings/runend/src/ree.rs
@@ -5,7 +5,7 @@ use vortex::compute::search_sorted::{search_sorted, SearchSortedSide};
 use vortex::stats::{ArrayStatistics, ArrayStatisticsCompute};
 use vortex::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use vortex::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use vortex::{impl_encoding, ArrayDType, ArrayFlatten, IntoArrayData};
+use vortex::{impl_encoding, ArrayDType, ArrayFlatten};
 use vortex_error::vortex_bail;
 
 use crate::compress::{ree_decode, ree_encode};
@@ -49,9 +49,9 @@ impl REEArray {
         };
 
         let mut children = Vec::with_capacity(3);
-        children.push(ends.into_array_data());
-        children.push(values.into_array_data());
-        if let Some(a) = validity.into_array_data() {
+        children.push(ends);
+        children.push(values);
+        if let Some(a) = validity.into_array() {
             children.push(a)
         }
 

--- a/encodings/zigzag/src/zigzag.rs
+++ b/encodings/zigzag/src/zigzag.rs
@@ -3,7 +3,7 @@ use vortex::array::primitive::PrimitiveArray;
 use vortex::stats::ArrayStatisticsCompute;
 use vortex::validity::{ArrayValidity, LogicalValidity};
 use vortex::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use vortex::{impl_encoding, ArrayDType, ArrayFlatten, IntoArrayData};
+use vortex::{impl_encoding, ArrayDType, ArrayFlatten};
 use vortex_dtype::PType;
 use vortex_error::{vortex_bail, vortex_err};
 
@@ -28,7 +28,7 @@ impl ZigZagArray {
         let dtype = DType::from(PType::try_from(&encoded_dtype).expect("ptype").to_signed())
             .with_nullability(encoded_dtype.nullability());
 
-        let children = vec![encoded.into_array_data()];
+        let children = [encoded];
         Self::try_from_parts(dtype, ZigZagMetadata, children.into(), StatsSet::new())
     }
 

--- a/vortex-array/src/array/bool/mod.rs
+++ b/vortex-array/src/array/bool/mod.rs
@@ -45,7 +45,7 @@ impl BoolArray {
                     length: buffer.len(),
                 },
                 Some(Buffer::from(buffer.into_inner())),
-                validity.into_array_data().into_iter().collect_vec().into(),
+                validity.into_array().into_iter().collect_vec().into(),
                 StatsSet::new(),
             )?,
         })

--- a/vortex-array/src/array/bool/stats.rs
+++ b/vortex-array/src/array/bool/stats.rs
@@ -6,7 +6,7 @@ use vortex_error::VortexResult;
 use crate::array::bool::BoolArray;
 use crate::stats::{ArrayStatisticsCompute, Stat, StatsSet};
 use crate::validity::{ArrayValidity, LogicalValidity};
-use crate::{ArrayDType, ArrayTrait, IntoArray};
+use crate::{ArrayDType, ArrayTrait};
 
 impl ArrayStatisticsCompute for BoolArray {
     fn compute_statistics(&self, stat: Stat) -> VortexResult<StatsSet> {
@@ -19,7 +19,7 @@ impl ArrayStatisticsCompute for BoolArray {
             LogicalValidity::AllInvalid(v) => Ok(StatsSet::nulls(v, self.dtype())),
             LogicalValidity::Array(a) => NullableBools(
                 &self.boolean_buffer(),
-                &a.into_array().flatten_bool()?.boolean_buffer(),
+                &a.clone().flatten_bool()?.boolean_buffer(),
             )
             .compute_statistics(stat),
         }

--- a/vortex-array/src/array/chunked/mod.rs
+++ b/vortex-array/src/array/chunked/mod.rs
@@ -14,7 +14,7 @@ use crate::stream::{ArrayStream, ArrayStreamAdapter};
 use crate::validity::Validity::NonNullable;
 use crate::validity::{ArrayValidity, LogicalValidity};
 use crate::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use crate::{impl_encoding, ArrayDType, IntoArrayData};
+use crate::{impl_encoding, ArrayDType};
 
 mod compute;
 mod flatten;
@@ -47,8 +47,8 @@ impl ChunkedArray {
             NonNullable,
         );
 
-        let mut children = vec![chunk_ends.into_array_data()];
-        children.extend(chunks.into_iter().map(|a| a.into_array_data()));
+        let mut children = vec![chunk_ends.into_array()];
+        children.extend(chunks);
 
         Self::try_from_parts(dtype, ChunkedMetadata, children.into(), StatsSet::new())
     }

--- a/vortex-array/src/array/extension/mod.rs
+++ b/vortex-array/src/array/extension/mod.rs
@@ -1,12 +1,12 @@
-mod compute;
-
 use serde::{Deserialize, Serialize};
 use vortex_dtype::{ExtDType, ExtID};
 
 use crate::stats::ArrayStatisticsCompute;
 use crate::validity::{ArrayValidity, LogicalValidity};
 use crate::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use crate::{impl_encoding, ArrayDType, ArrayFlatten, IntoArrayData};
+use crate::{impl_encoding, ArrayDType, ArrayFlatten};
+
+mod compute;
 
 impl_encoding!("vortex.ext", Extension);
 
@@ -22,7 +22,7 @@ impl ExtensionArray {
             ExtensionMetadata {
                 storage_dtype: storage.dtype().clone(),
             },
-            [storage.into_array_data()].into(),
+            [storage].into(),
             Default::default(),
         )
         .expect("Invalid ExtensionArray")

--- a/vortex-array/src/array/primitive/mod.rs
+++ b/vortex-array/src/array/primitive/mod.rs
@@ -35,7 +35,7 @@ impl PrimitiveArray {
                     validity: validity.to_metadata(buffer.len())?,
                 },
                 Some(Buffer::from(buffer.into_inner())),
-                validity.into_array_data().into_iter().collect_vec().into(),
+                validity.into_array().into_iter().collect_vec().into(),
                 StatsSet::new(),
             )?,
         })

--- a/vortex-array/src/array/primitive/stats.rs
+++ b/vortex-array/src/array/primitive/stats.rs
@@ -13,7 +13,6 @@ use crate::stats::{ArrayStatisticsCompute, Stat, StatsSet};
 use crate::validity::ArrayValidity;
 use crate::validity::LogicalValidity;
 use crate::ArrayDType;
-use crate::IntoArray;
 
 trait PStatsType: NativePType + Into<Scalar> + BitWidth {}
 
@@ -27,7 +26,7 @@ impl ArrayStatisticsCompute for PrimitiveArray {
                 LogicalValidity::AllInvalid(v) => Ok(StatsSet::nulls(v, self.dtype())),
                 LogicalValidity::Array(a) => NullableValues(
                     self.maybe_null_slice::<$P>(),
-                    &a.into_array().flatten_bool()?.boolean_buffer(),
+                    &a.clone().flatten_bool()?.boolean_buffer(),
                 )
                 .compute_statistics(stat),
             }

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -8,7 +8,7 @@ use crate::compute::search_sorted::{search_sorted, SearchSortedSide};
 use crate::stats::ArrayStatisticsCompute;
 use crate::validity::{ArrayValidity, LogicalValidity};
 use crate::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use crate::{impl_encoding, ArrayDType, IntoArrayData};
+use crate::{impl_encoding, ArrayDType};
 
 mod compress;
 mod compute;
@@ -65,7 +65,7 @@ impl SparseArray {
                 len,
                 fill_value,
             },
-            [indices.into_array_data(), values.into_array_data()].into(),
+            [indices, values].into(),
             StatsSet::new(),
         )
     }
@@ -167,7 +167,7 @@ impl ArrayValidity for SparseArray {
         }
         .unwrap();
 
-        LogicalValidity::Array(validity.into_array_data())
+        LogicalValidity::Array(validity.into_array())
     }
 }
 

--- a/vortex-array/src/array/struct/mod.rs
+++ b/vortex-array/src/array/struct/mod.rs
@@ -5,8 +5,8 @@ use vortex_error::vortex_bail;
 use crate::stats::ArrayStatisticsCompute;
 use crate::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use crate::visitor::{AcceptArrayVisitor, ArrayVisitor};
+use crate::ArrayFlatten;
 use crate::{impl_encoding, ArrayDType};
-use crate::{ArrayFlatten, IntoArrayData};
 
 mod compute;
 
@@ -77,9 +77,9 @@ impl StructArray {
 
         let validity_metadata = validity.to_metadata(length)?;
 
-        let mut children = vec![];
-        children.extend(fields.into_iter().map(|a| a.into_array_data()));
-        if let Some(v) = validity.into_array_data() {
+        let mut children = Vec::with_capacity(fields.len() + 1);
+        children.extend(fields);
+        if let Some(v) = validity.into_array() {
             children.push(v);
         }
 

--- a/vortex-array/src/array/varbin/mod.rs
+++ b/vortex-array/src/array/varbin/mod.rs
@@ -1,15 +1,18 @@
 use num_traits::AsPrimitive;
 use serde::{Deserialize, Serialize};
+pub use stats::compute_stats;
+use vortex_buffer::Buffer;
 use vortex_dtype::Nullability;
 use vortex_dtype::{match_each_native_ptype, NativePType};
 use vortex_error::vortex_bail;
 use vortex_scalar::Scalar;
 
+use crate::array::primitive::PrimitiveArray;
 use crate::array::varbin::builder::VarBinBuilder;
 use crate::compute::scalar_at::scalar_at;
 use crate::compute::slice::slice;
 use crate::validity::{Validity, ValidityMetadata};
-use crate::{impl_encoding, ArrayDType, IntoArrayData};
+use crate::{impl_encoding, ArrayDType};
 
 mod accessor;
 mod array;
@@ -17,11 +20,6 @@ pub mod builder;
 mod compute;
 mod flatten;
 mod stats;
-
-pub use stats::compute_stats;
-use vortex_buffer::Buffer;
-
-use crate::array::primitive::PrimitiveArray;
 
 impl_encoding!("vortex.varbin", VarBin);
 
@@ -57,9 +55,9 @@ impl VarBinArray {
         };
 
         let mut children = Vec::with_capacity(3);
-        children.push(offsets.into_array_data());
-        children.push(bytes.into_array_data());
-        if let Some(a) = validity.into_array_data() {
+        children.push(offsets);
+        children.push(bytes);
+        if let Some(a) = validity.into_array() {
             children.push(a)
         }
 

--- a/vortex-array/src/array/varbinview/mod.rs
+++ b/vortex-array/src/array/varbinview/mod.rs
@@ -11,7 +11,7 @@ use crate::compute::slice::slice;
 use crate::validity::Validity;
 use crate::validity::{ArrayValidity, LogicalValidity, ValidityMetadata};
 use crate::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use crate::{impl_encoding, ArrayDType, ArrayFlatten, IntoArrayData};
+use crate::{impl_encoding, ArrayDType, ArrayFlatten};
 
 mod accessor;
 mod builder;
@@ -135,9 +135,9 @@ impl VarBinViewArray {
         };
 
         let mut children = Vec::with_capacity(data.len() + 2);
-        children.push(views.into_array_data());
-        children.extend(data.into_iter().map(|d| d.into_array_data()));
-        if let Some(a) = validity.into_array_data() {
+        children.push(views);
+        children.extend(data);
+        if let Some(a) = validity.into_array() {
             children.push(a)
         }
 

--- a/vortex-array/src/implementation.rs
+++ b/vortex-array/src/implementation.rs
@@ -31,7 +31,6 @@ macro_rules! impl_encoding {
         paste! {
             use $crate::{
                 Array,
-                ArrayData,
                 ArrayDef,
                 ArrayMetadata,
                 ArrayTrait,
@@ -84,7 +83,7 @@ macro_rules! impl_encoding {
                 fn try_from_parts(
                     dtype: DType,
                     metadata: [<$Name Metadata>],
-                    children: Arc<[ArrayData]>,
+                    children: Arc<[Array]>,
                     stats: StatsSet,
                 ) -> VortexResult<Self> {
                     Ok(Self { typed: TypedArray::try_from_parts(dtype, metadata, None, children, stats)? })
@@ -218,11 +217,11 @@ impl<T: IntoArray + ArrayEncodingRef + ArrayStatistics + GetArrayMetadata> IntoA
             Array::View(_) => {
                 struct Visitor {
                     buffer: Option<Buffer>,
-                    children: Vec<ArrayData>,
+                    children: Vec<Array>,
                 }
                 impl ArrayVisitor for Visitor {
                     fn visit_child(&mut self, _name: &str, array: &Array) -> VortexResult<()> {
-                        self.children.push(array.to_array_data());
+                        self.children.push(array.clone());
                         Ok(())
                     }
 

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -8,6 +8,30 @@
 //! Every data type recognized by Vortex also has a canonical physical encoding format, which
 //! arrays can be [flattened](Flattened) into for ease of access in compute functions.
 //!
+use std::fmt::{Debug, Display, Formatter};
+use std::future::ready;
+
+pub use ::paste;
+pub use context::*;
+pub use data::*;
+pub use flatten::*;
+pub use implementation::*;
+use itertools::Itertools;
+pub use metadata::*;
+pub use typed::*;
+pub use view::*;
+use vortex_buffer::Buffer;
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+
+use crate::compute::ArrayCompute;
+use crate::encoding::{ArrayEncodingRef, EncodingRef};
+use crate::iter::{ArrayIterator, ArrayIteratorAdapter};
+use crate::stats::{ArrayStatistics, ArrayStatisticsCompute};
+use crate::stream::{ArrayStream, ArrayStreamAdapter};
+use crate::validity::ArrayValidity;
+use crate::visitor::{AcceptArrayVisitor, ArrayVisitor};
+
 pub mod accessor;
 pub mod array;
 pub mod arrow;
@@ -29,29 +53,6 @@ pub mod validity;
 pub mod vendored;
 mod view;
 pub mod visitor;
-
-use std::fmt::{Debug, Display, Formatter};
-use std::future::ready;
-
-pub use ::paste;
-pub use context::*;
-pub use data::*;
-pub use flatten::*;
-pub use implementation::*;
-pub use metadata::*;
-pub use typed::*;
-pub use view::*;
-use vortex_buffer::Buffer;
-use vortex_dtype::DType;
-use vortex_error::VortexResult;
-
-use crate::compute::ArrayCompute;
-use crate::encoding::{ArrayEncodingRef, EncodingRef};
-use crate::iter::{ArrayIterator, ArrayIteratorAdapter};
-use crate::stats::{ArrayStatistics, ArrayStatisticsCompute};
-use crate::stream::{ArrayStream, ArrayStreamAdapter};
-use crate::validity::ArrayValidity;
-use crate::visitor::{AcceptArrayVisitor, ArrayVisitor};
 
 pub mod flatbuffers {
     pub use generated::vortex::array::*;
@@ -105,8 +106,15 @@ impl Array {
 
     pub fn child<'a>(&'a self, idx: usize, dtype: &'a DType) -> Option<Self> {
         match self {
-            Self::Data(d) => d.child(idx, dtype).cloned().map(Array::Data),
+            Self::Data(d) => d.child(idx, dtype).cloned(),
             Self::View(v) => v.child(idx, dtype).map(Array::View),
+        }
+    }
+
+    pub fn children(&self) -> Vec<Array> {
+        match self {
+            Array::Data(d) => d.children().iter().cloned().collect_vec(),
+            Array::View(v) => v.children(),
         }
     }
 
@@ -115,6 +123,30 @@ impl Array {
             Self::Data(d) => d.nchildren(),
             Self::View(v) => v.nchildren(),
         }
+    }
+
+    pub fn depth_first_traversal(&self) -> ArrayChildrenIterator {
+        ArrayChildrenIterator::new(self.clone())
+    }
+
+    /// Return the buffer offsets and the total length of all buffers, assuming the given alignment.
+    /// This includes all child buffers.
+    pub fn all_buffer_offsets(&self, alignment: usize) -> Vec<u64> {
+        let mut offsets = vec![];
+        let mut offset = 0;
+
+        for col_data in self.depth_first_traversal() {
+            if let Some(buffer) = col_data.buffer() {
+                offsets.push(offset as u64);
+
+                let buffer_size = buffer.len();
+                let aligned_size = (buffer_size + (alignment - 1)) & !(alignment - 1);
+                offset += aligned_size;
+            }
+        }
+        offsets.push(offset as u64);
+
+        offsets
     }
 
     pub fn buffer(&self) -> Option<&Buffer> {
@@ -140,6 +172,29 @@ impl Array {
             self.dtype().clone(),
             futures_util::stream::once(ready(Ok(self))),
         )
+    }
+}
+
+/// A depth-first pre-order iterator over a ArrayData.
+pub struct ArrayChildrenIterator {
+    stack: Vec<Array>,
+}
+
+impl ArrayChildrenIterator {
+    pub fn new(array: Array) -> Self {
+        Self { stack: vec![array] }
+    }
+}
+
+impl Iterator for ArrayChildrenIterator {
+    type Item = Array;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.stack.pop()?;
+        for child in next.children().into_iter().rev() {
+            self.stack.push(child);
+        }
+        Some(next)
     }
 }
 

--- a/vortex-array/src/typed.rs
+++ b/vortex-array/src/typed.rs
@@ -18,7 +18,7 @@ impl<D: ArrayDef> TypedArray<D> {
         dtype: DType,
         metadata: D::Metadata,
         buffer: Option<Buffer>,
-        children: Arc<[ArrayData]>,
+        children: Arc<[Array]>,
         stats: StatsSet,
     ) -> VortexResult<Self> {
         let array = Array::Data(ArrayData::try_new(

--- a/vortex-array/src/view.rs
+++ b/vortex-array/src/view.rs
@@ -12,6 +12,7 @@ use vortex_scalar::{PValue, Scalar, ScalarValue};
 use crate::encoding::{EncodingId, EncodingRef};
 use crate::flatbuffers as fb;
 use crate::stats::{Stat, Statistics, StatsSet};
+use crate::visitor::ArrayVisitor;
 use crate::Context;
 use crate::{Array, IntoArray, ToArray};
 
@@ -143,6 +144,14 @@ impl ArrayView {
         self.flatbuffer().children().map(|c| c.len()).unwrap_or(0)
     }
 
+    pub fn children(&self) -> Vec<Array> {
+        let mut collector = ChildrenCollector::default();
+        Array::View(self.clone())
+            .with_dyn(|a| a.accept(&mut collector))
+            .unwrap();
+        collector.children
+    }
+
     /// Whether the current Array makes use of a buffer
     pub fn has_buffer(&self) -> bool {
         self.flatbuffer().has_buffer()
@@ -163,6 +172,18 @@ impl ArrayView {
 
     pub fn statistics(&self) -> &dyn Statistics {
         self
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct ChildrenCollector {
+    children: Vec<Array>,
+}
+
+impl ArrayVisitor for ChildrenCollector {
+    fn visit_child(&mut self, _name: &str, array: &Array) -> VortexResult<()> {
+        self.children.push(array.clone());
+        Ok(())
     }
 }
 

--- a/vortex-ipc/src/message_writer.rs
+++ b/vortex-ipc/src/message_writer.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use flatbuffers::FlatBufferBuilder;
 use itertools::Itertools;
-use vortex::{ArrayData, ViewContext};
+use vortex::{Array, ViewContext};
 use vortex_buffer::io_buf::IoBuf;
 use vortex_buffer::Buffer;
 use vortex_dtype::DType;
@@ -57,7 +57,7 @@ impl<W: VortexWrite> MessageWriter<W> {
         &mut self,
         view_ctx: &ViewContext,
         // TODO(ngates): should we support writing from an ArrayView?
-        chunk: ArrayData,
+        chunk: Array,
     ) -> io::Result<()> {
         let buffer_offsets = chunk.all_buffer_offsets(self.alignment);
 

--- a/vortex-ipc/src/writer.rs
+++ b/vortex-ipc/src/writer.rs
@@ -1,7 +1,7 @@
 use futures_util::{Stream, TryStreamExt};
 use vortex::array::chunked::ChunkedArray;
 use vortex::stream::ArrayStream;
-use vortex::{Array, IntoArrayData, ViewContext};
+use vortex::{Array, ViewContext};
 use vortex_buffer::Buffer;
 use vortex_dtype::DType;
 use vortex_error::{vortex_bail, VortexResult};
@@ -77,9 +77,7 @@ impl<W: VortexWrite> ArrayWriter<W> {
         while let Some(chunk) = stream.try_next().await? {
             row_offset += chunk.len() as u64;
             row_offsets.push(row_offset);
-            self.msgs
-                .write_chunk(&self.view_ctx, chunk.into_array_data())
-                .await?;
+            self.msgs.write_chunk(&self.view_ctx, chunk).await?;
             byte_offsets.push(self.msgs.tell());
         }
 


### PR DESCRIPTION
If we end up slicing an Array we don't have to immediately convert it to
ArrayData anymore. ArrayData is less special and some methods are moved
to the Array enum
