### PR TITLE
pin to nightly 2024-06-19

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-06-19"
 components = ["rust-src", "rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
Avoids issues where different contributors are on different nightly versions and seeing different `cargo build` output.

This is what Polars does, among others: https://github.com/pola-rs/polars/blob/main/rust-toolchain.toml