### PR TITLE
FoR array holds encoded values as unsinged

### DIFF
--- a/encodings/fastlanes/src/for/compress.rs
+++ b/encodings/fastlanes/src/for/compress.rs
@@ -6,7 +6,7 @@ use vortex::compress::{CompressConfig, Compressor, EncodingCompression};
 use vortex::stats::{ArrayStatistics, Stat};
 use vortex::validity::ArrayValidity;
 use vortex::{Array, ArrayDType, ArrayTrait, IntoArray, IntoArrayVariant};
-use vortex_dtype::{match_each_integer_ptype, NativePType, PType};
+use vortex_dtype::{match_each_integer_ptype, NativePType};
 use vortex_error::{vortex_err, VortexResult};
 use vortex_scalar::Scalar;
 
@@ -109,7 +109,7 @@ fn compress_primitive<T: NativePType + WrappingSub + PrimInt>(
 
 pub fn decompress(array: FoRArray) -> VortexResult<PrimitiveArray> {
     let shift = array.shift();
-    let ptype: PType = array.dtype().try_into()?;
+    let ptype = array.ptype();
     let encoded = array.encoded().into_primitive()?.reinterpret_cast(ptype);
     Ok(match_each_integer_ptype!(ptype, |$T| {
         let reference: $T = array.reference().try_into()?;

--- a/encodings/fastlanes/src/for/compress.rs
+++ b/encodings/fastlanes/src/for/compress.rs
@@ -60,9 +60,12 @@ impl EncodingCompression for FoREncoding {
 
         let child = match_each_integer_ptype!(parray.ptype(), |$T| {
             if shift == <$T>::PTYPE.bit_width() as u8 {
-                let unsigned_dtype =
-                    DType::Primitive(parray.ptype().to_unsigned(), parray.dtype().nullability());
-                ConstantArray::new(Scalar::zero::<$T>(parray.dtype().nullability()).cast(&unsigned_dtype).unwrap(), parray.len()).into_array()
+                ConstantArray::new(
+                    Scalar::zero::<$T>(parray.dtype().nullability())
+                        .reinterpret_cast(parray.ptype().to_unsigned()),
+                    parray.len(),
+                )
+                .into_array()
             } else {
                 compress_primitive::<$T>(&parray, shift, $T::try_from(&min)?)
                     .reinterpret_cast(parray.ptype().to_unsigned())

--- a/encodings/fastlanes/src/for/compute.rs
+++ b/encodings/fastlanes/src/for/compute.rs
@@ -36,7 +36,7 @@ impl TakeFn for FoRArray {
 
 impl ScalarAtFn for FoRArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
-        let encoded_scalar = scalar_at(&self.encoded(), index)?;
+        let encoded_scalar = scalar_at(&self.encoded(), index)?.reinterpret_cast(self.ptype());
         let encoded = PrimitiveScalar::try_from(&encoded_scalar)?;
         let reference = PrimitiveScalar::try_from(self.reference())?;
 

--- a/encodings/fastlanes/src/for/mod.rs
+++ b/encodings/fastlanes/src/for/mod.rs
@@ -40,13 +40,8 @@ impl FoRArray {
 
     #[inline]
     pub fn encoded(&self) -> Array {
-        let dtype = if self.reference().dtype().is_signed_int() {
-            &DType::Primitive(
-                PType::try_from(self.reference().dtype())
-                    .unwrap()
-                    .to_unsigned(),
-                self.reference().dtype().nullability(),
-            )
+        let dtype = if self.ptype().is_signed_int() {
+            &DType::Primitive(self.ptype().to_unsigned(), self.dtype().nullability())
         } else {
             self.dtype()
         };

--- a/encodings/fastlanes/src/for/mod.rs
+++ b/encodings/fastlanes/src/for/mod.rs
@@ -3,6 +3,7 @@ use vortex::stats::ArrayStatisticsCompute;
 use vortex::validity::{ArrayValidity, LogicalValidity};
 use vortex::visitor::{AcceptArrayVisitor, ArrayVisitor};
 use vortex::{impl_encoding, ArrayDType, Canonical, IntoCanonical};
+use vortex_dtype::PType;
 use vortex_error::vortex_bail;
 use vortex_scalar::Scalar;
 
@@ -24,9 +25,13 @@ impl FoRArray {
         if reference.is_null() {
             vortex_bail!("Reference value cannot be null",);
         }
-        let reference = reference.cast(child.dtype())?;
+        let reference = reference.cast(
+            &reference
+                .dtype()
+                .with_nullability(child.dtype().nullability()),
+        )?;
         Self::try_from_parts(
-            child.dtype().clone(),
+            reference.dtype().clone(),
             FoRMetadata { reference, shift },
             [child].into(),
             StatsSet::new(),
@@ -35,9 +40,17 @@ impl FoRArray {
 
     #[inline]
     pub fn encoded(&self) -> Array {
-        self.array()
-            .child(0, self.dtype())
-            .expect("Missing FoR child")
+        let dtype = if self.reference().dtype().is_signed_int() {
+            &DType::Primitive(
+                PType::try_from(self.reference().dtype())
+                    .unwrap()
+                    .to_unsigned(),
+                self.reference().dtype().nullability(),
+            )
+        } else {
+            self.dtype()
+        };
+        self.array().child(0, dtype).expect("Missing FoR child")
     }
 
     #[inline]
@@ -48,6 +61,11 @@ impl FoRArray {
     #[inline]
     pub fn shift(&self) -> u8 {
         self.metadata().shift
+    }
+
+    #[inline]
+    pub fn ptype(&self) -> PType {
+        self.dtype().try_into().unwrap()
     }
 }
 

--- a/vortex-scalar/src/primitive.rs
+++ b/vortex-scalar/src/primitive.rs
@@ -96,13 +96,16 @@ impl Scalar {
             "can't reinterpret cast between integers of two different widths"
         );
 
-        Self {
-            dtype: DType::Primitive(ptype, self.dtype.nullability()),
-            value: primitive
-                .pvalue
-                .map(ScalarValue::Primitive)
-                .unwrap_or_else(|| ScalarValue::Null),
-        }
+        match_each_native_ptype!(ptype, |$P| {
+            Self {
+                dtype: DType::Primitive(ptype, self.dtype.nullability()),
+                value: primitive
+                    .pvalue
+                    .map(|p| p.reinterpret_cast::<$P>())
+                    .map(ScalarValue::Primitive)
+                    .unwrap_or_else(|| ScalarValue::Null),
+            }
+        })
     }
 
     pub fn zero<T: NativePType + Into<PValue>>(nullability: Nullability) -> Self {

--- a/vortex-scalar/src/primitive.rs
+++ b/vortex-scalar/src/primitive.rs
@@ -96,16 +96,14 @@ impl Scalar {
             "can't reinterpret cast between integers of two different widths"
         );
 
-        match_each_native_ptype!(ptype, |$P| {
-            Self {
-                dtype: DType::Primitive(ptype, self.dtype.nullability()),
-                value: primitive
-                    .pvalue
-                    .map(|p| p.reinterpret_cast::<$P>())
-                    .map(ScalarValue::Primitive)
-                    .unwrap_or_else(|| ScalarValue::Null),
-            }
-        })
+        Self {
+            dtype: DType::Primitive(ptype, self.dtype.nullability()),
+            value: primitive
+                .pvalue
+                .map(|p| p.reinterpret_cast(ptype))
+                .map(ScalarValue::Primitive)
+                .unwrap_or_else(|| ScalarValue::Null),
+        }
     }
 
     pub fn zero<T: NativePType + Into<PValue>>(nullability: Nullability) -> Self {

--- a/vortex-scalar/src/primitive.rs
+++ b/vortex-scalar/src/primitive.rs
@@ -96,14 +96,14 @@ impl Scalar {
             "can't reinterpret cast between integers of two different widths"
         );
 
-        Self {
-            dtype: DType::Primitive(ptype, self.dtype.nullability()),
-            value: primitive
+        Scalar::new(
+            DType::Primitive(ptype, self.dtype.nullability()),
+            primitive
                 .pvalue
                 .map(|p| p.reinterpret_cast(ptype))
                 .map(ScalarValue::Primitive)
                 .unwrap_or_else(|| ScalarValue::Null),
-        }
+        )
     }
 
     pub fn zero<T: NativePType + Into<PValue>>(nullability: Nullability) -> Self {

--- a/vortex-scalar/src/primitive.rs
+++ b/vortex-scalar/src/primitive.rs
@@ -189,11 +189,3 @@ impl TryFrom<&Scalar> for usize {
         .map(|v| v as Self)
     }
 }
-
-impl TryFrom<Scalar> for usize {
-    type Error = VortexError;
-
-    fn try_from(value: Scalar) -> Result<Self, Self::Error> {
-        usize::try_from(&value)
-    }
-}

--- a/vortex-scalar/src/pvalue.rs
+++ b/vortex-scalar/src/pvalue.rs
@@ -44,12 +44,12 @@ impl PValue {
         }
 
         assert!(T::PTYPE.is_int(), "Can only reinterpret cast integers");
-
         assert_eq!(
             T::PTYPE.byte_width(),
             self.ptype().byte_width(),
             "Cannot reinterpret cast between types of different widths"
         );
+
         match self {
             PValue::U8(v) => unsafe { mem::transmute::<u8, i8>(*v) }.into(),
             PValue::U16(v) => unsafe { mem::transmute::<u16, i16>(*v) }.into(),

--- a/vortex-scalar/src/pvalue.rs
+++ b/vortex-scalar/src/pvalue.rs
@@ -38,6 +38,7 @@ impl PValue {
         }
     }
 
+    #[allow(clippy::transmute_int_to_float, clippy::transmute_float_to_int)]
     pub fn reinterpret_cast(&self, ptype: PType) -> Self {
         if ptype == self.ptype() {
             return *self;
@@ -53,48 +54,48 @@ impl PValue {
             PValue::U8(v) => unsafe { mem::transmute::<u8, i8>(*v) }.into(),
             PValue::U16(v) => match ptype {
                 PType::I16 => unsafe { mem::transmute::<u16, i16>(*v) }.into(),
-                PType::F16 => f16::from_bits(*v).into(),
+                PType::F16 => unsafe { mem::transmute::<u16, f16>(*v) }.into(),
                 _ => unreachable!("Only same width type are allowed to be reinterpreted"),
             },
             PValue::U32(v) => match ptype {
                 PType::I32 => unsafe { mem::transmute::<u32, i32>(*v) }.into(),
-                PType::F32 => f32::from_bits(*v).into(),
+                PType::F32 => unsafe { mem::transmute::<u32, f32>(*v) }.into(),
                 _ => unreachable!("Only same width type are allowed to be reinterpreted"),
             },
             PValue::U64(v) => match ptype {
                 PType::I64 => unsafe { mem::transmute::<u64, i64>(*v) }.into(),
-                PType::F64 => f64::from_bits(*v).into(),
+                PType::F64 => unsafe { mem::transmute::<u64, f64>(*v) }.into(),
                 _ => unreachable!("Only same width type are allowed to be reinterpreted"),
             },
             PValue::I8(v) => unsafe { mem::transmute::<i8, u8>(*v) }.into(),
             PValue::I16(v) => match ptype {
                 PType::U16 => unsafe { mem::transmute::<i16, u16>(*v) }.into(),
-                PType::F16 => f16::from_bits(unsafe { mem::transmute::<i16, u16>(*v) }).into(),
+                PType::F16 => unsafe { mem::transmute::<i16, f16>(*v) }.into(),
                 _ => unreachable!("Only same width type are allowed to be reinterpreted"),
             },
             PValue::I32(v) => match ptype {
                 PType::U32 => unsafe { mem::transmute::<i32, u32>(*v) }.into(),
-                PType::F32 => f32::from_bits(unsafe { mem::transmute::<i32, u32>(*v) }).into(),
+                PType::F32 => unsafe { mem::transmute::<i32, f32>(*v) }.into(),
                 _ => unreachable!("Only same width type are allowed to be reinterpreted"),
             },
             PValue::I64(v) => match ptype {
                 PType::U64 => unsafe { mem::transmute::<i64, u64>(*v) }.into(),
-                PType::F64 => f64::from_bits(unsafe { mem::transmute::<i64, u64>(*v) }).into(),
+                PType::F64 => unsafe { mem::transmute::<i64, f64>(*v) }.into(),
                 _ => unreachable!("Only same width type are allowed to be reinterpreted"),
             },
             PValue::F16(v) => match ptype {
-                PType::U16 => v.to_bits().into(),
-                PType::I16 => unsafe { mem::transmute::<u16, i16>(v.to_bits()) }.into(),
+                PType::U16 => unsafe { mem::transmute::<f16, u16>(*v) }.into(),
+                PType::I16 => unsafe { mem::transmute::<f16, i16>(*v) }.into(),
                 _ => unreachable!("Only same width type are allowed to be reinterpreted"),
             },
             PValue::F32(v) => match ptype {
-                PType::U32 => v.to_bits().into(),
-                PType::I32 => unsafe { mem::transmute::<u32, i32>(v.to_bits()) }.into(),
+                PType::U32 => unsafe { mem::transmute::<f32, u32>(*v) }.into(),
+                PType::I32 => unsafe { mem::transmute::<f32, i32>(*v) }.into(),
                 _ => unreachable!("Only same width type are allowed to be reinterpreted"),
             },
             PValue::F64(v) => match ptype {
-                PType::U64 => v.to_bits().into(),
-                PType::I64 => unsafe { mem::transmute::<u64, i64>(v.to_bits()) }.into(),
+                PType::U64 => unsafe { mem::transmute::<f64, u64>(*v) }.into(),
+                PType::I64 => unsafe { mem::transmute::<f64, i64>(*v) }.into(),
                 _ => unreachable!("Only same width type are allowed to be reinterpreted"),
             },
         }


### PR DESCRIPTION
fixes #400. With this change the underlying encoded array is always sorted after for encoding