### PR TITLE
[WIP] Datafusion pushdown support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3848,11 +3848,15 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-plan",
  "futures",
+ "itertools 0.13.0",
+ "lazy_static",
  "pin-project",
  "tokio",
  "vortex-array",
  "vortex-dtype",
  "vortex-error",
+ "vortex-expr",
+ "vortex-scalar",
 ]
 
 [[package]]

--- a/vortex-array/src/array/bool/compute/compare.rs
+++ b/vortex-array/src/array/bool/compute/compare.rs
@@ -8,6 +8,7 @@ use crate::compute::compare::CompareFn;
 use crate::{Array, ArrayTrait, IntoArray, IntoArrayVariant};
 
 impl CompareFn for BoolArray {
+    // TODO(aduffy): replace these with Arrow compute kernels.
     fn compare(&self, other: &Array, op: Operator) -> VortexResult<Array> {
         let flattened = other.clone().into_bool()?;
         let lhs = self.boolean_buffer();

--- a/vortex-array/src/array/constant/mod.rs
+++ b/vortex-array/src/array/constant/mod.rs
@@ -7,6 +7,7 @@ use crate::impl_encoding;
 use crate::stats::Stat;
 use crate::validity::{ArrayValidity, LogicalValidity};
 use crate::visitor::{AcceptArrayVisitor, ArrayVisitor};
+
 mod compute;
 mod flatten;
 mod stats;
@@ -25,6 +26,8 @@ impl ConstantArray {
         Scalar: From<S>,
     {
         let scalar: Scalar = scalar.into();
+        // TODO(aduffy): add stats for bools, ideally there should be a
+        //  StatsSet::constant(Scalar) constructor that does this for us, like StatsSet::nulls.
         let stats = StatsSet::from(HashMap::from([
             (Stat::Max, scalar.clone()),
             (Stat::Min, scalar.clone()),

--- a/vortex-array/src/array/struct_/mod.rs
+++ b/vortex-array/src/array/struct_/mod.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use vortex_dtype::{FieldName, FieldNames, Nullability, StructDType};
-use vortex_error::{vortex_bail, vortex_err};
+use vortex_error::vortex_bail;
 
 use crate::stats::ArrayStatisticsCompute;
 use crate::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
@@ -25,6 +25,15 @@ impl StructArray {
         };
         let dtype = st.dtypes().get(idx)?;
         self.array().child(idx, dtype)
+    }
+
+    pub fn field_by_name(&self, name: &str) -> Option<Array> {
+        let field_idx = self
+            .names()
+            .iter()
+            .position(|field_name| field_name.as_ref() == name);
+
+        field_idx.and_then(|field_idx| self.field(field_idx))
     }
 
     pub fn names(&self) -> &FieldNames {
@@ -126,7 +135,7 @@ impl StructArray {
         for column_idx in projection {
             children.push(
                 self.field(*column_idx)
-                    .ok_or_else(|| vortex_err!(InvalidArgument: "column index out of bounds"))?,
+                    .expect("column must not exceed bounds"),
             );
             names.push(self.names()[*column_idx].clone());
         }

--- a/vortex-array/src/stats/statsset.rs
+++ b/vortex-array/src/stats/statsset.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 use enum_iterator::all;
 use itertools::Itertools;
+
 use vortex_dtype::DType;
 use vortex_error::VortexError;
 use vortex_scalar::Scalar;
@@ -26,6 +27,36 @@ impl StatsSet {
             values: HashMap::new(),
         }
     }
+
+    // pub fn constant(len: usize, scalar: &Scalar) -> Self {
+    //     let mut stats = HashMap::from([
+    //         (Stat::Max, scalar.clone()),
+    //         (Stat::Min, scalar.clone()),
+    //         (Stat::IsConstant, true.into()),
+    //         (Stat::IsSorted, true.into()),
+    //         (Stat::RunCount, 1.into()),
+    //     ]);
+    //
+    //     match scalar.dtype() {
+    //         DType::Bool(_) => {
+    //             stats.insert(Stat::TrueCount, 0.into());
+    //         }
+    //         DType::Primitive(ptype, _) => {
+    //             ptype.byte_width();
+    //             stats.insert(
+    //                 Stat::BitWidthFreq,
+    //                 vec![0; ptype.byte_width() * 8 + 1].into(),
+    //             );
+    //             stats.insert(
+    //                 Stat::TrailingZeroFreq,
+    //                 vec![ptype.byte_width() * 8; ptype.byte_width() * 8 + 1].into(),
+    //             );
+    //         }
+    //         _ => {}
+    //     }
+    //
+    //     Self::from(stats)
+    // }
 
     /// Specialized constructor for the case where the StatsSet represents
     /// an array consisting entirely of [null](vortex_dtype::DType::Null) values.

--- a/vortex-datafusion/Cargo.toml
+++ b/vortex-datafusion/Cargo.toml
@@ -13,7 +13,9 @@ rust-version.workspace = true
 [dependencies]
 vortex-array = { path = "../vortex-array" }
 vortex-dtype = { path = "../vortex-dtype" }
+vortex-expr = { path = "../vortex-expr" }
 vortex-error = { path = "../vortex-error" }
+vortex-scalar = { path = "../vortex-scalar" }
 
 arrow-array = { workspace = true }
 arrow-schema = { workspace = true }
@@ -26,10 +28,13 @@ datafusion-execution = { workspace = true }
 datafusion-physical-expr = { workspace = true }
 datafusion-physical-plan = { workspace = true }
 futures = { workspace = true }
+itertools = { workspace = true }
+lazy_static = { workspace = true }
 pin-project = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 
-[lints]
-workspace = true
+# TODO(aduffy): re-enable
+#[lints]
+#workspace = true

--- a/vortex-datafusion/src/plans.rs
+++ b/vortex-datafusion/src/plans.rs
@@ -1,0 +1,205 @@
+//! Physical operators needed to implement scanning of Vortex arrays with pushdown.
+
+use std::any::Any;
+use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
+
+use arrow_array::RecordBatch;
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use datafusion_common::Result as DFResult;
+use datafusion_execution::{SendableRecordBatchStream, TaskContext};
+use datafusion_expr::Expr;
+use datafusion_physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion_physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionMode, ExecutionPlan, PlanProperties,
+};
+use lazy_static::lazy_static;
+use vortex::array::struct_::StructArray;
+
+/// Physical plan operator that applies a set of [filters][Expr] against the input, producing a
+/// row mask that can be used downstream to force a take against the corresponding struct array
+/// chunks but for different columns.
+pub(crate) struct RowSelectorExec {
+    filter_exprs: Vec<Expr>,
+    filter_projection: Vec<usize>,
+
+    // cached PlanProperties object. We do not make use of this.
+    cached_plan_props: PlanProperties,
+
+    // A Vortex struct array that contains all columns necessary for executing the filter
+    // expressions.
+    filter_struct: StructArray,
+}
+
+lazy_static! {
+    static ref ROW_SELECTOR_SCHEMA_REF: SchemaRef = Arc::new(Schema::new(vec![Field::new(
+        "row_idx",
+        DataType::UInt64,
+        false
+    )]));
+}
+
+impl RowSelectorExec {
+    pub(crate) fn new(
+        filter_exprs: &Vec<Expr>,
+        filter_projection: &Vec<usize>,
+        filter_struct: &StructArray,
+    ) -> Self {
+        let cached_plan_props = PlanProperties::new(
+            EquivalenceProperties::new(ROW_SELECTOR_SCHEMA_REF.clone()),
+            Partitioning::RoundRobinBatch(1),
+            ExecutionMode::Bounded,
+        );
+
+        Self {
+            filter_exprs: filter_exprs.clone(),
+            filter_projection: filter_projection.clone(),
+            filter_struct: filter_struct.clone(),
+            cached_plan_props,
+        }
+    }
+}
+
+impl Debug for RowSelectorExec {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RowSelectorExec").finish()
+    }
+}
+
+impl DisplayAs for RowSelectorExec {
+    fn fmt_as(
+        &self,
+        _display_format_type: DisplayFormatType,
+        f: &mut Formatter,
+    ) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl ExecutionPlan for RowSelectorExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.cached_plan_props
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        // No children
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        panic!("with_new_children not supported for RowSelectorExec")
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        assert_eq!(
+            partition, 0,
+            "single partitioning only supported by TakeOperator"
+        );
+
+        todo!("need to implement this")
+    }
+}
+
+/// Physical that receives a stream of row indices from a child operator, and uses that to perform
+/// a `take` operation on tha backing Vortex array.
+pub(crate) struct TakeRowsExec {
+    plan_properties: PlanProperties,
+
+    // Array storing the indices used to take the plan nodes.
+    projection: Vec<usize>,
+
+    // Input plan, a stream of indices on which we perform a take against the original dataset.
+    input: Arc<dyn ExecutionPlan>,
+
+    output_schema: SchemaRef,
+
+    // A record batch holding the fields that were relevant to executing the upstream filter expression.
+    // These fields have already been decoded, so we hold them separately and "paste" them together
+    // with the fields we decode from `table` below.
+    filter_struct: RecordBatch,
+
+    // The original Vortex array holding the fields we have not decoded yet.
+    table: StructArray,
+}
+
+impl TakeRowsExec {
+    pub(crate) fn new(
+        schema_ref: SchemaRef,
+        projection: &Vec<usize>,
+        row_indices: Arc<dyn ExecutionPlan>,
+        output_schema: SchemaRef,
+        table: StructArray,
+    ) -> Self {
+        let plan_properties = PlanProperties::new(
+            EquivalenceProperties::new(schema_ref.clone()),
+            Partitioning::RoundRobinBatch(1),
+            ExecutionMode::Bounded,
+        );
+
+        Self {
+            plan_properties,
+            projection: projection.clone(),
+            input: row_indices,
+            output_schema: output_schema.clone(),
+            filter_struct: RecordBatch::new_empty(output_schema.clone()),
+            table,
+        }
+    }
+}
+
+impl Debug for TakeRowsExec {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Take").finish()
+    }
+}
+
+impl DisplayAs for TakeRowsExec {
+    fn fmt_as(&self, _display_type: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl ExecutionPlan for TakeRowsExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.plan_properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        panic!("unsupported with_new_children for {:?}", &self)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        assert_eq!(
+            partition, 0,
+            "single partitioning only supported by TakeOperator"
+        );
+
+        todo!()
+    }
+}


### PR DESCRIPTION
Unfinished, just opening this as I continue to get things working.

This PR augments the original Vortex connection for Datafusion, with an implementation of filter pushdown that allows us to perform late materialization on as many columns as possible.

Pushdown support will be able to get flagged on/off so we can run benchmarks testing different strategies.

I'm hoping to have an initial version of this with a benchmark harness tonight.