### PR TITLE
Chunked take

### DIFF
--- a/vortex-array/src/array/chunked/canonical.rs
+++ b/vortex-array/src/array/chunked/canonical.rs
@@ -1,6 +1,6 @@
-use arrow_buffer::{BooleanBuffer, MutableBuffer, ScalarBuffer};
+use arrow_buffer::{BooleanBuffer, Buffer, MutableBuffer};
 use itertools::Itertools;
-use vortex_dtype::{match_each_native_ptype, DType, Nullability, PType, StructDType};
+use vortex_dtype::{DType, Nullability, PType, StructDType};
 use vortex_error::{vortex_bail, ErrString, VortexResult};
 
 use crate::accessor::ArrayAccessor;
@@ -152,12 +152,11 @@ fn pack_primitives(
         buffer.extend_from_slice(chunk.buffer());
     }
 
-    match_each_native_ptype!(ptype, |$T| {
-        Ok(PrimitiveArray::try_new(
-            ScalarBuffer::<$T>::from(buffer),
-            validity,
-        )?)
-    })
+    Ok(PrimitiveArray::new(
+        Buffer::from(buffer).into(),
+        ptype,
+        validity,
+    ))
 }
 
 /// Builds a new [VarBinArray] by repacking the values from the chunks into a single

--- a/vortex-array/src/array/chunked/compute/take.rs
+++ b/vortex-array/src/array/chunked/compute/take.rs
@@ -1,19 +1,35 @@
+use itertools::Itertools;
 use vortex_dtype::PType;
 use vortex_error::VortexResult;
 
 use crate::array::chunked::ChunkedArray;
 use crate::array::primitive::PrimitiveArray;
+use crate::compute::search_sorted::{search_sorted, SearchSortedSide};
+use crate::compute::slice::slice;
 use crate::compute::take::{take, TakeFn};
 use crate::compute::unary::cast::try_cast;
+use crate::compute::unary::scalar_at::scalar_at;
+use crate::compute::unary::scalar_subtract::subtract_scalar;
+use crate::stats::ArrayStatistics;
 use crate::ArrayDType;
 use crate::{Array, IntoArray, ToArray};
 
 impl TakeFn for ChunkedArray {
     fn take(&self, indices: &Array) -> VortexResult<Array> {
-        if self.len() == indices.len() {
-            return Ok(self.to_array());
+        // Fast path for strict sorted indices.
+        if indices
+            .statistics()
+            .compute_is_strict_sorted()
+            .unwrap_or(false)
+        {
+            if self.len() == indices.len() {
+                return Ok(self.to_array());
+            }
+
+            return take_strict_sorted(self, indices);
         }
 
+        // FIXME(ngates): this is wrong, need to canonicalise
         let indices = PrimitiveArray::try_from(try_cast(indices, PType::U64.into())?)?;
 
         // While the chunk idx remains the same, accumulate a list of chunk indices.
@@ -49,6 +65,50 @@ impl TakeFn for ChunkedArray {
 
         Ok(Self::try_new(chunks, self.dtype().clone())?.into_array())
     }
+}
+
+/// When the indices are non-null and strict-sorted, we can do better
+fn take_strict_sorted(chunked: &ChunkedArray, indices: &Array) -> VortexResult<Array> {
+    let mut indices_by_chunk = vec![None; chunked.nchunks()];
+
+    // Track our position in the indices array
+    let mut pos = 0;
+    while pos < indices.len() {
+        // Locate the chunk index for the current index
+        let idx = usize::try_from(&scalar_at(indices, pos)?).unwrap();
+        let (chunk_idx, _idx_in_chunk) = chunked.find_chunk_idx(idx);
+
+        // Find the end of this chunk, and locate that position in the indices array.
+        let chunk_begin = usize::try_from(&scalar_at(&chunked.chunk_ends(), chunk_idx)?).unwrap();
+        let chunk_end = usize::try_from(&scalar_at(&chunked.chunk_ends(), chunk_idx + 1)?).unwrap();
+        let chunk_end_pos = search_sorted(indices, chunk_end, SearchSortedSide::Left)
+            .unwrap()
+            .to_index();
+
+        // Now we can say the slice of indices belonging to this chunk is [pos, chunk_end_pos)
+        let chunk_indices = slice(indices, pos, chunk_end_pos)?;
+
+        // Adjust the indices so they're relative to the chunk
+        let chunk_indices = subtract_scalar(&chunk_indices, &chunk_begin.into())?;
+        indices_by_chunk[chunk_idx] = Some(chunk_indices);
+
+        pos = chunk_end_pos;
+    }
+
+    // Now we can take the chunks
+    let chunks = indices_by_chunk
+        .iter()
+        .enumerate()
+        .filter_map(|(chunk_idx, indices)| indices.as_ref().map(|i| (chunk_idx, i)))
+        .map(|(chunk_idx, chunk_indices)| {
+            take(
+                &chunked.chunk(chunk_idx).expect("chunk not found"),
+                chunk_indices,
+            )
+        })
+        .try_collect()?;
+
+    Ok(ChunkedArray::try_new(chunks, chunked.dtype().clone())?.into_array())
 }
 
 #[cfg(test)]

--- a/vortex-array/src/array/primitive/compute/cast.rs
+++ b/vortex-array/src/array/primitive/compute/cast.rs
@@ -14,12 +14,12 @@ impl CastFn for PrimitiveArray {
 
         // Short-cut if we can just change the nullability
         if self.ptype() == ptype && !self.dtype().is_nullable() && dtype.is_nullable() {
-            match_each_native_ptype!(self.ptype(), |$T| {
-                return Ok(
-                    PrimitiveArray::try_new(self.scalar_buffer::<$T>(), Validity::AllValid)?
-                        .into_array(),
-                );
-            })
+            return Ok(PrimitiveArray::new(
+                self.buffer().clone(),
+                self.ptype(),
+                Validity::AllValid,
+            )
+            .into_array());
         }
 
         // FIXME(ngates): #260 - check validity and nullability

--- a/vortex-array/src/array/primitive/compute/slice.rs
+++ b/vortex-array/src/array/primitive/compute/slice.rs
@@ -1,4 +1,3 @@
-use vortex_dtype::match_each_native_ptype;
 use vortex_error::VortexResult;
 
 use crate::array::primitive::PrimitiveArray;
@@ -8,12 +7,12 @@ use crate::IntoArray;
 
 impl SliceFn for PrimitiveArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
-        match_each_native_ptype!(self.ptype(), |$T| {
-            Ok(PrimitiveArray::try_new(
-                self.scalar_buffer::<$T>().slice(start, stop - start),
-                self.validity().slice(start, stop)?,
-            )?
-            .into_array())
-        })
+        assert!(start <= stop, "start must be <= stop");
+        let byte_width = self.ptype().byte_width();
+        let buffer = self.buffer().slice(start * byte_width..stop * byte_width);
+        Ok(
+            PrimitiveArray::new(buffer, self.ptype(), self.validity().slice(start, stop)?)
+                .into_array(),
+        )
     }
 }

--- a/vortex-buffer/src/lib.rs
+++ b/vortex-buffer/src/lib.rs
@@ -56,6 +56,13 @@ impl Buffer {
             Self::Bytes(_) => Err(self),
         }
     }
+
+    pub fn from_vec<T>(values: Vec<T>) -> Self
+    where
+        T: ArrowNativeType,
+    {
+        Self::Arrow(ArrowBuffer::from_vec(values))
+    }
 }
 
 impl Deref for Buffer {

--- a/vortex-buffer/src/lib.rs
+++ b/vortex-buffer/src/lib.rs
@@ -56,13 +56,6 @@ impl Buffer {
             Self::Bytes(_) => Err(self),
         }
     }
-
-    pub fn from_vec<T>(values: Vec<T>) -> Self
-    where
-        T: ArrowNativeType,
-    {
-        Self::Arrow(ArrowBuffer::from_vec(values))
-    }
 }
 
 impl Deref for Buffer {


### PR DESCRIPTION
* Improves the performance of ChunkedArray::take for strict-sorted indices.
* Makes subtraction wrapping instead of doing an expensive statistics test
* Fixes PrimitiveArray slice to be zero-copy