### PR TITLE
Make into_arrow truly zero-copy, rewrite DataFusion operators

### DIFF
--- a/bench-vortex/src/bin/tpch_benchmark.rs
+++ b/bench-vortex/src/bin/tpch_benchmark.rs
@@ -55,10 +55,13 @@ async fn q1_vortex(base_dir: &PathBuf) -> anyhow::Result<()> {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
+    // uncomment the below to enable trace logging of datafusion execution
+    // setup_logger(LevelFilter::Trace);
+
     // Run TPC-H data gen.
     let data_dir = DBGen::new(DBGenOptions::default()).generate().unwrap();
 
-    // q1_csv(&data_dir).await.unwrap();
+    q1_csv(&data_dir).await.unwrap();
     q1_arrow(&data_dir).await.unwrap();
-    // q1_vortex(&data_dir).await.unwrap();
+    q1_vortex(&data_dir).await.unwrap();
 }

--- a/bench-vortex/src/bin/tpch_benchmark.rs
+++ b/bench-vortex/src/bin/tpch_benchmark.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use std::path::PathBuf;
 use std::time::SystemTime;
 
@@ -33,7 +34,13 @@ async fn q1_arrow(base_dir: &PathBuf) -> anyhow::Result<()> {
 }
 
 async fn q1_vortex(base_dir: &PathBuf) -> anyhow::Result<()> {
-    let ctx = load_datasets(base_dir, Format::VortexUncompressed).await?;
+    let ctx = load_datasets(
+        base_dir,
+        Format::Vortex {
+            disable_pushdown: true,
+        },
+    )
+    .await?;
 
     println!("BEGIN: Q1(VORTEX)");
     let start = SystemTime::now();
@@ -46,12 +53,12 @@ async fn q1_vortex(base_dir: &PathBuf) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     // Run TPC-H data gen.
     let data_dir = DBGen::new(DBGenOptions::default()).generate().unwrap();
 
-    q1_csv(&data_dir).await.unwrap();
+    // q1_csv(&data_dir).await.unwrap();
     q1_arrow(&data_dir).await.unwrap();
-    q1_vortex(&data_dir).await.unwrap();
+    // q1_vortex(&data_dir).await.unwrap();
 }

--- a/bench-vortex/src/tpch/mod.rs
+++ b/bench-vortex/src/tpch/mod.rs
@@ -7,7 +7,7 @@ use datafusion::datasource::MemTable;
 use datafusion::prelude::{CsvReadOptions, SessionContext};
 use vortex::array::chunked::ChunkedArray;
 use vortex::arrow::FromArrowArray;
-use vortex::{Array, ArrayDType, ArrayData, IntoArray, IntoCanonical};
+use vortex::{Array, ArrayDType, ArrayData, IntoArray};
 use vortex_datafusion::{SessionContextExt, VortexMemTableOptions};
 
 pub mod dbgen;
@@ -146,17 +146,11 @@ async fn register_vortex(
         .collect();
 
     let dtype = chunks[0].dtype().clone();
-    let chunked_array = ChunkedArray::try_new(chunks, dtype)?
-        .into_canonical()?
-        .into_array();
-
-    // Convert to Arrow to concat all chunks, then flip back to Vortex for processing.
-    let arrow = chunked_array.into_canonical()?.into_arrow();
-    let array = ArrayData::from_arrow(arrow, false).into_array();
+    let chunked_array = ChunkedArray::try_new(chunks, dtype)?.into_array();
 
     session.register_vortex_opts(
         name,
-        array,
+        chunked_array,
         VortexMemTableOptions::default().with_disable_pushdown(disable_pushdown),
     )?;
 

--- a/vortex-array/src/arrow/wrappers.rs
+++ b/vortex-array/src/arrow/wrappers.rs
@@ -1,4 +1,4 @@
-use arrow_buffer::{ArrowNativeType, Buffer as ArrowBuffer, OffsetBuffer, ScalarBuffer};
+use arrow_buffer::{ArrowNativeType, OffsetBuffer, ScalarBuffer};
 use vortex_dtype::NativePType;
 
 use crate::array::primitive::PrimitiveArray;
@@ -7,7 +7,7 @@ pub fn as_scalar_buffer<T: NativePType + ArrowNativeType>(
     array: PrimitiveArray,
 ) -> ScalarBuffer<T> {
     assert_eq!(array.ptype(), T::PTYPE);
-    ScalarBuffer::from(ArrowBuffer::from(array.buffer()))
+    ScalarBuffer::from(array.buffer().clone().into_arrow())
 }
 
 pub fn as_offset_buffer<T: NativePType + ArrowNativeType>(

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -294,7 +294,7 @@ fn local_date_time_to_arrow(local_date_time_array: LocalDateTimeArray) -> ArrayR
         .to_null_buffer()
         .expect("null buffer");
     let timestamps_len = timestamps.len();
-    let buffer = ScalarBuffer::<i64>::new(timestamps.into_buffer().into(), 0, timestamps_len);
+    let buffer = ScalarBuffer::<i64>::new(timestamps.into_buffer().into_arrow(), 0, timestamps_len);
 
     match local_date_time_array.time_unit() {
         TimeUnit::Ns => Arc::new(TimestampNanosecondArray::new(buffer, validity)),

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -152,7 +152,7 @@ fn primitive_to_arrow(primitive_array: PrimitiveArray) -> ArrayRef {
         array: &PrimitiveArray,
     ) -> ArrowPrimitiveArray<T> {
         ArrowPrimitiveArray::new(
-            ScalarBuffer::<T::Native>::new(array.buffer().clone().into(), 0, array.len()),
+            ScalarBuffer::<T::Native>::new(array.buffer().clone().into_arrow(), 0, array.len()),
             array
                 .logical_validity()
                 .to_null_buffer()
@@ -242,29 +242,37 @@ fn varbin_to_arrow(varbin_array: VarBinArray) -> ArrayRef {
     // Switch on Arrow DType.
     match varbin_array.dtype() {
         DType::Binary(_) => match offsets.ptype() {
-            PType::I32 => Arc::new(BinaryArray::new(
-                as_offset_buffer::<i32>(offsets),
-                data.into(),
-                nulls,
-            )),
-            PType::I64 => Arc::new(LargeBinaryArray::new(
-                as_offset_buffer::<i64>(offsets),
-                data.into(),
-                nulls,
-            )),
+            PType::I32 => Arc::new(unsafe {
+                BinaryArray::new_unchecked(
+                    as_offset_buffer::<i32>(offsets),
+                    data.clone().into_arrow(),
+                    nulls,
+                )
+            }),
+            PType::I64 => Arc::new(unsafe {
+                LargeBinaryArray::new_unchecked(
+                    as_offset_buffer::<i64>(offsets),
+                    data.clone().into_arrow(),
+                    nulls,
+                )
+            }),
             _ => panic!("Invalid offsets type"),
         },
         DType::Utf8(_) => match offsets.ptype() {
-            PType::I32 => Arc::new(StringArray::new(
-                as_offset_buffer::<i32>(offsets),
-                data.into(),
-                nulls,
-            )),
-            PType::I64 => Arc::new(LargeStringArray::new(
-                as_offset_buffer::<i64>(offsets),
-                data.into(),
-                nulls,
-            )),
+            PType::I32 => Arc::new(unsafe {
+                StringArray::new_unchecked(
+                    as_offset_buffer::<i32>(offsets),
+                    data.clone().into_arrow(),
+                    nulls,
+                )
+            }),
+            PType::I64 => Arc::new(unsafe {
+                LargeStringArray::new_unchecked(
+                    as_offset_buffer::<i64>(offsets),
+                    data.clone().into_arrow(),
+                    nulls,
+                )
+            }),
             _ => panic!("Invalid offsets type"),
         },
         _ => panic!(

--- a/vortex-buffer/src/lib.rs
+++ b/vortex-buffer/src/lib.rs
@@ -1,12 +1,12 @@
-mod flexbuffers;
-pub mod io_buf;
-mod string;
-
 use std::cmp::Ordering;
 use std::ops::{Deref, Range};
 
 use arrow_buffer::{ArrowNativeType, Buffer as ArrowBuffer};
 pub use string::*;
+
+mod flexbuffers;
+pub mod io_buf;
+mod string;
 
 #[derive(Debug, Clone)]
 pub enum Buffer {
@@ -54,6 +54,18 @@ impl Buffer {
             Self::Arrow(buffer) => buffer.into_vec::<T>().map_err(Buffer::Arrow),
             // Cannot convert bytes into a mutable vec
             Self::Bytes(_) => Err(self),
+        }
+    }
+
+    /// Convert a Buffer into an ArrowBuffer with no copying.
+    pub fn into_arrow(self) -> ArrowBuffer {
+        match self {
+            Buffer::Arrow(a) => a,
+            Buffer::Bytes(b) => {
+                let v: Vec<u8> = b.into();
+
+                ArrowBuffer::from_vec(v)
+            }
         }
     }
 }

--- a/vortex-datafusion/src/plans.rs
+++ b/vortex-datafusion/src/plans.rs
@@ -139,7 +139,7 @@ impl ExecutionPlan for RowSelectorExec {
 /// [RecordBatchStream] of row indices, emitted by the [RowSelectorExec] physical plan node.
 #[pin_project::pin_project]
 pub(crate) struct RowIndicesStream<F> {
-    /// The inner future that returns `DFResult<RecordBatch>`.
+    /// The inner future that returns `DFResult<Array>`.
     /// This future should only poll one time.
     #[pin]
     one_shot: F,


### PR DESCRIPTION
Before we would go through the ArrowBuffer::from(&[u8]) constructor, which would actually do a full data copy.

Now we're just doing pointer tricks. Shaved about 30ms (~7%) off of the tpc-h benchmark.