### PR TITLE
Run tpch_benchmark queries single-threaded in rayon pool

### DIFF
--- a/bench-vortex/benches/tpch_benchmark.rs
+++ b/bench-vortex/benches/tpch_benchmark.rs
@@ -9,7 +9,7 @@ fn benchmark(c: &mut Criterion) {
     // Run TPC-H data gen.
     let data_dir = DBGen::new(DBGenOptions::default()).generate().unwrap();
 
-    let vortex_no_pushdown_ctx = runtime
+    let vortex_pushdown_disabled_ctx = runtime
         .block_on(load_datasets(
             &data_dir,
             Format::Vortex {
@@ -40,9 +40,9 @@ fn benchmark(c: &mut Criterion) {
         let mut group = c.benchmark_group(format!("tpch_q{q}"));
         group.sample_size(10);
 
-        group.bench_function("vortex-nopushdown", |b| {
+        group.bench_function("vortex-pushdown-disabled", |b| {
             b.to_async(&runtime).iter(|| async {
-                vortex_no_pushdown_ctx
+                vortex_pushdown_disabled_ctx
                     .sql(&query)
                     .await
                     .unwrap()
@@ -52,7 +52,7 @@ fn benchmark(c: &mut Criterion) {
             })
         });
 
-        group.bench_function("vortex-pushdown", |b| {
+        group.bench_function("vortex-pushdown-enabled", |b| {
             b.to_async(&runtime).iter(|| async {
                 vortex_ctx
                     .sql(&query)

--- a/bench-vortex/src/bin/tpch_benchmark.rs
+++ b/bench-vortex/src/bin/tpch_benchmark.rs
@@ -1,3 +1,4 @@
+use std::sync;
 use std::time::SystemTime;
 
 use bench_vortex::tpch::dbgen::{DBGen, DBGenOptions};
@@ -40,57 +41,86 @@ async fn main() {
 
     // Set up a results table
     let mut table = Table::new();
-    let mut cells = vec![Cell::new("Query")];
-    cells.extend(formats.iter().map(|f| Cell::new(&format!("{:?}", f))));
-    table.add_row(Row::new(cells));
+    {
+        let mut cells = vec![Cell::new("Query")];
+        cells.extend(formats.iter().map(|f| Cell::new(&format!("{:?}", f))));
+        table.add_row(Row::new(cells));
+    }
 
     // Setup a progress bar
     let progress = ProgressBar::new(22 * formats.len() as u64);
 
+    // Send back a channel with the results of Row.
+    let (rows_tx, rows_rx) = sync::mpsc::channel();
     for i in 1..=22 {
-        // Skip query 15 as it is not supported by DataFusion
         if i == 15 {
             continue;
         }
+        let _ctxs = ctxs.clone();
+        let _formats = formats.clone();
+        let _tx = rows_tx.clone();
+        let _progress = progress.clone();
+        rayon::spawn_fifo(move || {
+            let query = tpch_query(i);
+            let mut cells = Vec::with_capacity(formats.len());
+            cells.push(Cell::new(&format!("Q{}", i)));
 
-        let query = tpch_query(i);
-        let mut cells = Vec::with_capacity(formats.len());
-        cells.push(Cell::new(&format!("Q{}", i)));
-
-        let mut elapsed_us = Vec::new();
-        for (ctx, format) in ctxs.iter().zip(formats.iter()) {
-            let start = SystemTime::now();
-            ctx.sql(&query)
-                .await
-                .map_err(|e| println!("Failed to run {} {:?}: {}", i, format, e))
-                .unwrap()
-                .collect()
-                .await
-                .map_err(|e| println!("Failed to collect {} {:?}: {}", i, format, e))
+            let mut elapsed_us = Vec::new();
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
                 .unwrap();
-            let elapsed = start.elapsed().unwrap();
-            elapsed_us.push(elapsed);
-            progress.inc(1);
-        }
+            for (ctx, format) in _ctxs.iter().zip(_formats.iter()) {
+                let start = SystemTime::now();
+                rt.block_on(async {
+                    ctx.sql(&query)
+                        .await
+                        .map_err(|e| println!("Failed to run {} {:?}: {}", i, format, e))
+                        .unwrap()
+                        .collect()
+                        .await
+                        .map_err(|e| println!("Failed to collect {} {:?}: {}", i, format, e))
+                        .unwrap();
+                });
+                let elapsed = start.elapsed().unwrap();
+                elapsed_us.push(elapsed);
+                _progress.inc(1);
+            }
 
-        let baseline = elapsed_us.first().unwrap();
-        // yellow: 10% slower than baseline
-        let yellow = baseline.as_micros() + (baseline.as_micros() / 10);
-        // red: 50% slower than baseline
-        let red = baseline.as_micros() + (baseline.as_micros() / 50);
-        cells.push(Cell::new(&format!("{} us", baseline.as_micros())).style_spec("b"));
-        for measure in elapsed_us.iter().skip(1) {
-            let style_spec = if measure.as_micros() > red {
-                "bBr"
-            } else if measure.as_micros() > yellow {
-                "bFdBy"
-            } else {
-                "bFdBG"
-            };
-            cells.push(Cell::new(&format!("{} us", measure.as_micros())).style_spec(style_spec));
-        }
-        table.add_row(Row::new(cells));
+            let baseline = elapsed_us.first().unwrap();
+            // yellow: 10% slower than baseline
+            let yellow = baseline.as_micros() + (baseline.as_micros() / 10);
+            // red: 50% slower than baseline
+            let red = baseline.as_micros() + (baseline.as_micros() / 50);
+            cells.push(Cell::new(&format!("{} us", baseline.as_micros())).style_spec("b"));
+            for measure in elapsed_us.iter().skip(1) {
+                let style_spec = if measure.as_micros() > red {
+                    "bBr"
+                } else if measure.as_micros() > yellow {
+                    "bFdBy"
+                } else {
+                    "bFdBG"
+                };
+                cells
+                    .push(Cell::new(&format!("{} us", measure.as_micros())).style_spec(style_spec));
+            }
+
+            _tx.send((i, Row::new(cells))).unwrap();
+        });
     }
-    progress.clone().finish();
+
+    // delete parent handle to tx
+    drop(rows_tx);
+
+    let mut rows = vec![];
+    while let Ok((idx, row)) = rows_rx.recv() {
+        rows.push((idx, row));
+    }
+    rows.sort_by(|(idx0, _), (idx1, _)| idx0.cmp(idx1));
+    for (_, row) in rows {
+        table.add_row(row);
+    }
+
+    progress.finish();
     table.printstd();
 }

--- a/bench-vortex/src/bin/tpch_benchmark.rs
+++ b/bench-vortex/src/bin/tpch_benchmark.rs
@@ -1,4 +1,3 @@
-use std::ops::Div;
 use std::sync;
 use std::time::SystemTime;
 
@@ -84,8 +83,9 @@ async fn main() {
                             .unwrap();
                     })
                 }
-                let start = SystemTime::now();
-                for _ in 0..50 {
+                let mut measure = Vec::new();
+                for _ in 0..20 {
+                    let start = SystemTime::now();
                     rt.block_on(async {
                         ctx.sql(&query)
                             .await
@@ -96,10 +96,12 @@ async fn main() {
                             .map_err(|e| println!("Failed to collect {} {:?}: {}", i, format, e))
                             .unwrap();
                     });
+                    let elapsed = start.elapsed().unwrap();
+                    measure.push(elapsed);
                 }
+                let fastest = measure.iter().cloned().min().unwrap();
+                elapsed_us.push(fastest);
 
-                let elapsed = start.elapsed().unwrap();
-                elapsed_us.push(elapsed.div(50));
                 _progress.inc(1);
             }
 

--- a/vortex-datafusion/src/lib.rs
+++ b/vortex-datafusion/src/lib.rs
@@ -446,6 +446,10 @@ impl Stream for VortexRecordBatchStream {
 
         Poll::Ready(Some(Ok(batch)))
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.num_chunks, Some(self.num_chunks))
+    }
 }
 
 impl RecordBatchStream for VortexRecordBatchStream {


### PR DESCRIPTION
In #459 , we used an 8-thread pool and a single tokio runtime to run all of the queries in parallel.

There was huge variability on the values returned by those benchmarks. This PR

* Switches from using tokio global runtime for parallelism to using a Rayon pool
* Each query executes in a current-thread tokio runtime, which should be a bit more apples-to-apples
* Removed CSV measurements, and now have each query+format pair do 3 warmup runs, followed by 20 measured runs, then take the min over measurements
* Fixed the coloration logic for table (oops)
* A few small drive-bys