### PR TITLE
Avoid dtype comparison failure in `take` -- upcast indices in `take_strict_sorted` 

### DIFF
--- a/vortex-array/src/array/chunked/compute/take.rs
+++ b/vortex-array/src/array/chunked/compute/take.rs
@@ -1,6 +1,7 @@
 use itertools::Itertools;
 use vortex_dtype::PType;
 use vortex_error::VortexResult;
+use vortex_scalar::Scalar;
 
 use crate::array::chunked::ChunkedArray;
 use crate::array::primitive::PrimitiveArray;
@@ -88,8 +89,22 @@ fn take_strict_sorted(chunked: &ChunkedArray, indices: &Array) -> VortexResult<A
         // Now we can say the slice of indices belonging to this chunk is [pos, chunk_end_pos)
         let chunk_indices = slice(indices, pos, chunk_end_pos)?;
 
-        // Adjust the indices so they're relative to the chunk
-        let chunk_indices = subtract_scalar(&chunk_indices, &chunk_begin.into())?;
+        // Indices might not have a dtype big enough to fit chunk_begin after cast,
+        // if it does cast the scalar otherwise upcast the indices.
+        let chunk_indices = if chunk_begin < PType::try_from(chunk_indices.dtype())?.max_value() {
+            subtract_scalar(
+                &chunk_indices,
+                &Scalar::from(chunk_begin).cast(chunk_indices.dtype())?,
+            )?
+        } else {
+            // TODO: this is unnecessary, could instead upcast in the subtract.
+            let u64_chunk_indices = try_cast(&chunk_indices, PType::U64.into())
+                .expect("safe to upcast since all indices are positive");
+
+            // Adjust the indices so they're relative to the chunk
+            subtract_scalar(&u64_chunk_indices, &chunk_begin.into())?
+        };
+
         indices_by_chunk[chunk_idx] = Some(chunk_indices);
 
         pos = chunk_end_pos;
@@ -124,7 +139,7 @@ mod test {
             .unwrap();
         assert_eq!(arr.nchunks(), 3);
         assert_eq!(arr.len(), 9);
-        let indices = vec![0, 0, 6, 4].into_array();
+        let indices = vec![0u64, 0, 6, 4].into_array();
 
         let result = &ChunkedArray::try_from(take(arr.as_array_ref(), &indices).unwrap())
             .unwrap()

--- a/vortex-dtype/src/ptype.rs
+++ b/vortex-dtype/src/ptype.rs
@@ -104,7 +104,9 @@ macro_rules! match_each_integer_ptype {
             PType::U16 => __with__! { u16 },
             PType::U32 => __with__! { u32 },
             PType::U64 => __with__! { u64 },
-            _ => panic!("Unsupported ptype {}", $self),
+            PType::F16 =>  panic!("Unsupported ptype f16"),
+            PType::F32 =>  panic!("Unsupported ptype f32"),
+            PType::F64 =>  panic!("Unsupported ptype f64"),
         }
     })
 }
@@ -162,6 +164,10 @@ impl PType {
 
     pub const fn bit_width(&self) -> usize {
         self.byte_width() * 8
+    }
+
+    pub const fn max_value(&self) -> usize {
+        match_each_integer_ptype!(self, |$T| $T::MAX as usize)
     }
 
     pub fn to_signed(self) -> Self {


### PR DESCRIPTION
Upcast the indices in `take_strict_sorted` but first trying to upcast the scalar value, then the indices themselves.

Note. this is likely to be superseded by `array.filter(bool) -> array`.