### PR TITLE
Run `cargo doc` at CI time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
         run: cargo fmt --all --check
       - name: Rust Lint - Clippy
         run: cargo clippy --all-features --all-targets
+      - name: Docs
+        run: cargo doc --no-deps
       - name: Rust Test
         run: cargo test --workspace --all-features
 

--- a/encodings/dict/src/lib.rs
+++ b/encodings/dict/src/lib.rs
@@ -1,7 +1,7 @@
 //! Implementation of Dictionary encoding.
 //!
 //! Expose a [DictArray] which is zero-copy equivalent to Arrow's
-//! [arrow_array::array::DictionaryArray] type.
+//! [DictionaryArray](https://docs.rs/arrow/latest/arrow/array/struct.DictionaryArray.html).
 pub use compress::*;
 pub use dict::*;
 


### PR DESCRIPTION
As part of getting ready for publishing, check docs.rs will build properly