### PR TITLE
Lazy deserialize metadata from ArrayData and ArrayView

### DIFF
--- a/vortex-array/src/typed.rs
+++ b/vortex-array/src/typed.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use vortex_buffer::Buffer;
 use vortex_dtype::DType;
@@ -10,7 +10,7 @@ use crate::{Array, ArrayData, ArrayDef, AsArray, IntoArray, ToArray, TryDeserial
 #[derive(Debug, Clone)]
 pub struct TypedArray<D: ArrayDef> {
     array: Array,
-    metadata: D::Metadata,
+    meta_cell: OnceLock<D::Metadata>,
 }
 
 impl<D: ArrayDef> TypedArray<D> {
@@ -26,16 +26,24 @@ impl<D: ArrayDef> TypedArray<D> {
             D::ENCODING,
             dtype,
             len,
-            Arc::new(metadata.clone()),
+            Arc::new(metadata),
             buffer,
             children,
             stats,
         )?);
-        Ok(Self { array, metadata })
+        Ok(Self {
+            array,
+            meta_cell: OnceLock::new(),
+        })
     }
 
     pub fn metadata(&self) -> &D::Metadata {
-        &self.metadata
+        match &self.array {
+            Array::Data(d) => d.metadata().as_any().downcast_ref::<D::Metadata>().unwrap(),
+            Array::View(v) => self
+                .meta_cell
+                .get_or_init(|| D::Metadata::try_deserialize_metadata(v.metadata()).unwrap()),
+        }
     }
 }
 
@@ -56,16 +64,10 @@ impl<D: ArrayDef> TryFrom<Array> for TypedArray<D> {
                 D::ENCODING.id().as_ref(),
             );
         }
-        let metadata = match &array {
-            Array::Data(d) => d
-                .metadata()
-                .as_any()
-                .downcast_ref::<D::Metadata>()
-                .unwrap()
-                .clone(),
-            Array::View(v) => D::Metadata::try_deserialize_metadata(v.metadata())?,
-        };
-        Ok(Self { array, metadata })
+        Ok(Self {
+            array,
+            meta_cell: OnceLock::new(),
+        })
     }
 }
 


### PR DESCRIPTION
The motivation for this pr is to avoid forcing ArrayData and ArrayView to clone/deserialize metadata eagerly. The two cases are quite different but relatively easy to handle

1. We no longer store eager metadata in Array, instead we fetch it when necessary
2. For ArrayData we only have to cast metadata in ArrayData and don't need to clone it
3. For ArrayView we lazily deserialize on request and store the resolved result

The slightly not nice part here is that Array has something that only ArrayView uses but I saw no need to copy metadata if it's just a cast