### PR TITLE
Smoketest for SamplingCompressor, fix bug in varbin stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4323,6 +4323,7 @@ dependencies = [
 name = "vortex-sampling-compressor"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "log",
  "rand",
  "vortex-alp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ bindgen = "0.69.4"
 bytes = "1.6.0"
 bzip2 = "0.4.4"
 cargo_metadata = "0.18.1"
+chrono = "0.4.38"
 criterion = { version = "0.5.1", features = ["html_reports"] }
 croaring = "2.0.0"
 csv = "1.3.0"

--- a/vortex-array/src/array/varbin/stats.rs
+++ b/vortex-array/src/array/varbin/stats.rs
@@ -84,7 +84,10 @@ impl<'a> VarBinAccumulator<'a> {
         }
 
         match val.cmp(self.last_value) {
-            Ordering::Less => self.is_sorted = false,
+            Ordering::Less => {
+                self.is_sorted = false;
+                self.is_strict_sorted = false;
+            }
             Ordering::Equal => {
                 self.is_strict_sorted = false;
                 return;

--- a/vortex-sampling-compressor/Cargo.toml
+++ b/vortex-sampling-compressor/Cargo.toml
@@ -25,5 +25,8 @@ vortex-roaring = { path = "../encodings/roaring" }
 vortex-runend = { path = "../encodings/runend" }
 vortex-zigzag = { path = "../encodings/zigzag" }
 
+[dev-dependencies]
+chrono = { workspace = true }
+
 [lints]
 workspace = true

--- a/vortex-sampling-compressor/tests/smoketest.rs
+++ b/vortex-sampling-compressor/tests/smoketest.rs
@@ -1,0 +1,126 @@
+use std::collections::HashSet;
+use std::ops::Add;
+
+use chrono::TimeDelta;
+use vortex::array::bool::BoolArray;
+use vortex::array::datetime::{TemporalArray, TimeUnit};
+use vortex::array::primitive::PrimitiveArray;
+use vortex::array::struct_::StructArray;
+use vortex::array::varbin::builder::VarBinBuilder;
+use vortex::validity::Validity;
+use vortex::{Array, ArrayDType, IntoArray, IntoArrayData};
+use vortex_dtype::{DType, FieldName, FieldNames, Nullability};
+use vortex_sampling_compressor::compressors::alp::ALPCompressor;
+use vortex_sampling_compressor::compressors::bitpacked::BitPackedCompressor;
+use vortex_sampling_compressor::compressors::date_time_parts::DateTimePartsCompressor;
+use vortex_sampling_compressor::compressors::dict::DictCompressor;
+use vortex_sampling_compressor::compressors::r#for::FoRCompressor;
+use vortex_sampling_compressor::compressors::roaring_bool::RoaringBoolCompressor;
+use vortex_sampling_compressor::compressors::roaring_int::RoaringIntCompressor;
+use vortex_sampling_compressor::compressors::runend::DEFAULT_RUN_END_COMPRESSOR;
+use vortex_sampling_compressor::compressors::sparse::SparseCompressor;
+use vortex_sampling_compressor::compressors::zigzag::ZigZagCompressor;
+use vortex_sampling_compressor::compressors::CompressorRef;
+use vortex_sampling_compressor::{CompressConfig, SamplingCompressor};
+
+#[test]
+pub fn smoketest_compressor() {
+    let compressor = SamplingCompressor::new_with_options(
+        HashSet::from([
+            &ALPCompressor as CompressorRef,
+            &BitPackedCompressor,
+            // TODO(robert): Implement minimal compute for DeltaArrays - scalar_at and slice
+            // &DeltaCompressor,
+            &DictCompressor,
+            &FoRCompressor,
+            &DateTimePartsCompressor,
+            &RoaringBoolCompressor,
+            &RoaringIntCompressor,
+            &DEFAULT_RUN_END_COMPRESSOR,
+            &SparseCompressor,
+            &ZigZagCompressor,
+        ]),
+        CompressConfig::default(),
+    );
+
+    let def: &[(&str, Array)] = &[
+        ("prim_col", make_primitive_column(65536)),
+        ("bool_col", make_bool_column(65536)),
+        ("varbin_col", make_string_column(65536)),
+        ("binary_col", make_binary_column(65536)),
+        ("timestamp_col", make_timestamp_column(65536)),
+    ];
+
+    let fields: Vec<Array> = def.iter().map(|(_, arr)| arr.clone()).collect();
+    let field_names: FieldNames = FieldNames::from(
+        def.iter()
+            .map(|(name, _)| FieldName::from(*name))
+            .collect::<Vec<_>>(),
+    );
+
+    // Create new struct array
+    let to_compress = StructArray::try_new(field_names, fields, 65536, Validity::NonNullable)
+        .unwrap()
+        .into_array();
+
+    println!("uncompressed: {}", to_compress.tree_display());
+    let compressed = compressor
+        .compress(&to_compress, None)
+        .unwrap()
+        .into_array();
+
+    println!("compressed: {}", compressed.tree_display());
+    assert_eq!(compressed.dtype(), to_compress.dtype());
+}
+
+fn make_primitive_column(count: usize) -> Array {
+    PrimitiveArray::from_vec(
+        (0..count).map(|i| i as i64).collect::<Vec<i64>>(),
+        Validity::NonNullable,
+    )
+    .into_array()
+}
+
+fn make_bool_column(count: usize) -> Array {
+    let bools: Vec<bool> = (0..count).map(|_| rand::random::<bool>()).collect();
+    BoolArray::from_vec(bools, Validity::NonNullable).into_array()
+}
+
+fn make_string_column(count: usize) -> Array {
+    let values = ["zzzz", "bbbbbb", "cccccc", "ddddd"];
+    let mut builder = VarBinBuilder::<i64>::with_capacity(count);
+    for i in 0..count {
+        builder.push_value(values[i % values.len()].as_bytes());
+    }
+
+    builder
+        .finish(DType::Utf8(Nullability::NonNullable))
+        .into_array()
+}
+
+fn make_binary_column(count: usize) -> Array {
+    let mut builder = VarBinBuilder::<i64>::with_capacity(count);
+    let random: Vec<u8> = (0..count).map(|_| rand::random::<u8>()).collect();
+    for i in 1..=count {
+        builder.push_value(&random[0..i]);
+    }
+
+    builder
+        .finish(DType::Binary(Nullability::NonNullable))
+        .into_array()
+}
+
+fn make_timestamp_column(count: usize) -> Array {
+    // Make new timestamps in incrementing order from EPOCH.
+    let t0 = chrono::NaiveDateTime::default().and_utc();
+
+    let timestamps: Vec<i64> = (0..count)
+        .map(|inc| t0.add(TimeDelta::seconds(inc as i64)).timestamp_millis())
+        .collect();
+
+    let storage_array = PrimitiveArray::from_vec(timestamps, Validity::NonNullable).into_array();
+
+    TemporalArray::new_timestamp(storage_array, TimeUnit::Ms, None)
+        .into_array_data()
+        .into_array()
+}


### PR DESCRIPTION
There are a number of failures in the past few months that only show up in an ETE test like random_access benchmark. However, random_access benchmark is very slow to run in CI.

I'm adding a very tiny SamplingCompressor test that runs at CI time. It takes <1s on my macbook, and uses 65k rows of synthetic data to try and get the compressor to go down a few common paths.

It's not perfect, but it does trigger Constant, DateTimeParts, Dict and could trigger Bitpacking if we implement #509.

Bonus: after writing this test and examining the compressed output in a few scenarios, I was noticing that Dict compression was never kicking in for out-of-order arrays. It looks like we were computing the is_strict_sorted stat incorrectly for varbin.