### PR TITLE
FoR will compress signed array when min == 0 now

### DIFF
--- a/vortex-sampling-compressor/src/compressors/for.rs
+++ b/vortex-sampling-compressor/src/compressors/for.rs
@@ -35,7 +35,7 @@ impl EncodingCompressor for FoRCompressor {
         let shift = trailing_zeros(array);
         match_each_integer_ptype!(parray.ptype(), |$P| {
             let min: $P = parray.statistics().compute_min()?;
-            if min == 0 && shift == 0 {
+            if min == 0 && shift == 0 && parray.ptype().is_unsigned_int() {
                 return None;
             }
         });


### PR DESCRIPTION
Fixes #509 

Previously, FoR would bail out early if it detected that min == 0. However, we still want to FoR encode when the array is signed, so that we get a bitpackable unsigned array out of FoR compression