### PR TITLE
fix: tpc-h parquet writer deadlocks

### DIFF
--- a/bench-vortex/src/tpch/mod.rs
+++ b/bench-vortex/src/tpch/mod.rs
@@ -131,7 +131,6 @@ async fn register_parquet(
     file: &Path,
     schema: &Schema,
 ) -> anyhow::Result<()> {
-
     let csv_file = file.to_str().unwrap();
     let pq_file = idempotent_async(
         &file.with_extension("").with_extension("parquet"),


### PR DESCRIPTION
`block_on` is being called from within a `runtime.block_on`, leading the computer to take an infinite coffee break.

Added a new `idempotent_async` function to the benchlib to allow doing async stuff in the idempotent body