### PR TITLE
Run license check at the end of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
         run: cargo build --all-features --all-targets
 
       - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          rust-version: "${{ steps.rust-version.outputs.version }}"
 
       - uses: rustsec/audit-check@v1.4.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Rust Build
         run: cargo build --all-features --all-targets
 
-      - name: License Check
-        run: cargo install --locked cargo-deny && cargo deny check
+      - uses: EmbarkStudios/cargo-deny-action@v1
+
       - uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,17 +43,15 @@ jobs:
       - name: Rust Build
         run: cargo build --all-features --all-targets
 
-      - uses: EmbarkStudios/cargo-deny-action@v1
-        with:
-          rust-version: "${{ steps.rust-version.outputs.version }}"
-
-      - uses: rustsec/audit-check@v1.4.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Pytest - PyVortex
         run: rye run pytest --benchmark-disable test/
         working-directory: pyvortex/
+
+      - name: License Check
+        run: cargo install --locked cargo-deny && cargo deny check
+      - uses: rustsec/audit-check@v1.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   miri:
     name: 'miri'


### PR DESCRIPTION
Running cargo install that is updating crates.io index causes maturin to want to install new versions of packages even though nothing should have changed. We sidestep this problem by running maturin before cargo deny