### PR TITLE
run TPC-H benchmarks M-F on a schedule

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
 
-      - name: Bench - Vortex TPC-H
-        run: cargo bench --bench tpch_benchmark | tee bench-tpch.txt
+      - name: Bench - Vortex
+        run: cargo bench | tee bench.txt
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1.20.3
@@ -35,7 +35,7 @@ jobs:
           name: Vortex TPC-H Benchmarks
           tool: cargo
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          output-file-path: bench-tpch.txt
+          output-file-path: bench.txt
           summary-always: true
           auto-push: true
           fail-on-alert: false

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   bench:
     runs-on: ubuntu-latest-large
-    if: ${{ github.event_name == 'workflow_dispatch' || (contains(github.event.head_commit.message, '[benchmark]') && github.ref_name == 'develop') }}
+    if: ${{ github.ref_name == 'develop' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,15 +31,15 @@ jobs:
         uses: arduino/setup-protoc@v3
 
       - name: Bench - Vortex TPC-H
-        run: cargo bench --bench tpch_benchmark | tee bench.txt
+        run: cargo bench --bench tpch_benchmark | tee bench-tpch.txt
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1.20.3
         with:
-          name: Vortex Benchmarks
+          name: Vortex TPC-H Benchmarks
           tool: cargo
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          output-file-path: bench.txt
+          output-file-path: bench-tpch.txt
           summary-always: true
           auto-push: true
           fail-on-alert: false

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1.20.3
         with:
-          name: Vortex TPC-H Benchmarks
+          name: Vortex Benchmarks
           tool: cargo
           github-token: ${{ secrets.GITHUB_TOKEN }}
           output-file-path: bench.txt

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,9 +1,13 @@
+# Run benchmarks M-F first thing in the morning BST.
+#
+# If the last commit that triggered a workflow run is the same as the HEAD, we do not run.
+
 name: Benchmarks
 
 on:
-  push:
-    branches: [ "develop" ]
-  workflow_dispatch: { }
+  schedule:
+    # Run M-F at 9:30 UTC (either 9:30 or 10:30 British time depending on season).
+    - cron: "30 9 * * 1-5"
 
 permissions:
   actions: read
@@ -26,8 +30,8 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
 
-      - name: Bench - Vortex
-        run: cargo bench | tee bench.txt
+      - name: Bench - Vortex TPC-H
+        run: cargo bench --bench tpch_benchmark | tee bench.txt
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1.20.3

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,7 +1,3 @@
-# Run benchmarks M-F first thing in the morning BST.
-#
-# If the last commit that triggered a workflow run is the same as the HEAD, we do not run.
-
 name: Benchmarks
 
 on:


### PR DESCRIPTION
Just blanket run M-F. I can't find large runner cost, standard runner cost I'd expect this to set us back <$5/mo, even if large runners are 5x that we're not dealing with significant spend, can pause the schedule at any time.

![image](https://github.com/user-attachments/assets/4d5d2470-1139-4f7f-b02f-0d85d56ec6da)
