### PR TITLE
Follow up for 537

### DIFF
--- a/bench-vortex/benches/datafusion_benchmark.rs
+++ b/bench-vortex/benches/datafusion_benchmark.rs
@@ -177,7 +177,7 @@ fn bench_datafusion(c: &mut Criterion) {
     bench_vortex(
         c.benchmark_group("vortex-pushdown-compressed"),
         &SessionContext::new(),
-        false,
+        true,
         true,
     );
 
@@ -185,7 +185,7 @@ fn bench_datafusion(c: &mut Criterion) {
     bench_vortex(
         c.benchmark_group("vortex-pushdown-uncompressed"),
         &SessionContext::new(),
-        false,
+        true,
         false,
     );
 
@@ -193,7 +193,7 @@ fn bench_datafusion(c: &mut Criterion) {
     bench_vortex(
         c.benchmark_group("vortex-nopushdown-compressed"),
         &SessionContext::new(),
-        true,
+        false,
         true,
     );
 
@@ -201,7 +201,7 @@ fn bench_datafusion(c: &mut Criterion) {
     bench_vortex(
         c.benchmark_group("vortex-nopushdown-uncompressed"),
         &SessionContext::new(),
-        true,
+        false,
         false,
     );
 }

--- a/vortex-datafusion/src/lib.rs
+++ b/vortex-datafusion/src/lib.rs
@@ -48,9 +48,17 @@ const SUPPORTED_BINARY_OPS: &[Operator] = &[
 ];
 
 /// Optional configurations to pass when loading a [VortexMemTable].
-#[derive(Default, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct VortexMemTableOptions {
     pub enable_pushdown: bool,
+}
+
+impl Default for VortexMemTableOptions {
+    fn default() -> Self {
+        Self {
+            enable_pushdown: true,
+        }
+    }
 }
 
 impl VortexMemTableOptions {


### PR DESCRIPTION
Fix a couple of issues I missed in #537 - had to flip values for some benchmark and add a hand-rolled `Default` implementation as noted by @a10y 