### PR TITLE
use path specifiers for workspace deps in dev-dependencies

### DIFF
--- a/encodings/zigzag/Cargo.toml
+++ b/encodings/zigzag/Cargo.toml
@@ -20,7 +20,7 @@ vortex-scalar = { workspace = true }
 zigzag = { workspace = true }
 
 [dev-dependencies]
-vortex-fastlanes = { workspace = true }
+vortex-fastlanes = { path = "../fastlanes" }
 
 [lints]
 workspace = true

--- a/vortex-serde/Cargo.toml
+++ b/vortex-serde/Cargo.toml
@@ -41,9 +41,9 @@ futures-executor = { workspace = true }
 rand = { workspace = true }
 simplelog = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-vortex-alp = { workspace = true }
-vortex-fastlanes = { workspace = true }
-vortex-sampling-compressor = { workspace = true }
+vortex-alp = { path = "../encodings/alp" }
+vortex-fastlanes = { path = "../encodings/fastlanes" }
+vortex-sampling-compressor = { path = "../vortex-sampling-compressor" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
See https://github.com/MarcoIeni/release-plz/blob/main/crates/release_plz/Cargo.toml#L51-L53 for examples

Main point: if you have dev-dependencies, then you are compiling this from a checkout, which means you don't need to resolve these from crates.io

Our release automater, release-plz, doesn't order crates in dev-dependencies before release, and we can resolve from path instead for running benches

