### PR TITLE
Fix RunEnd take and scalar_at compute functions

### DIFF
--- a/encodings/runend-bool/src/array.rs
+++ b/encodings/runend-bool/src/array.rs
@@ -67,11 +67,17 @@ impl RunEndBoolArray {
     }
 
     pub fn find_physical_index(&self, index: usize) -> VortexResult<usize> {
-        if index > self.len() {
-            vortex_bail!("Index must be in array slice",);
+        if index >= self.len() {
+            vortex_bail!(OutOfBounds: index, 0, self.len())
         }
-        search_sorted(&self.ends(), index + self.offset(), SearchSortedSide::Right)
-            .map(|s| s.to_index())
+
+        let searched_index =
+            search_sorted(&self.ends(), index + self.offset(), SearchSortedSide::Right)?.to_index();
+        Ok(if searched_index == self.ends().len() {
+            searched_index - 1
+        } else {
+            searched_index
+        })
     }
 
     pub fn validity(&self) -> Validity {

--- a/encodings/runend-bool/src/array.rs
+++ b/encodings/runend-bool/src/array.rs
@@ -67,10 +67,6 @@ impl RunEndBoolArray {
     }
 
     pub fn find_physical_index(&self, index: usize) -> VortexResult<usize> {
-        if index >= self.len() {
-            vortex_bail!(OutOfBounds: index, 0, self.len())
-        }
-
         let searched_index =
             search_sorted(&self.ends(), index + self.offset(), SearchSortedSide::Right)?.to_index();
         Ok(if searched_index == self.ends().len() {

--- a/encodings/runend-bool/src/compute.rs
+++ b/encodings/runend-bool/src/compute.rs
@@ -60,12 +60,11 @@ impl SliceFn for RunEndBoolArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         let slice_begin = self.find_physical_index(start)?;
         let slice_end = self.find_physical_index(stop)?;
-        let bounded_slice_end = usize::min(slice_end + 1, self.ends().len());
 
         Ok(Self::with_offset_and_size(
-            slice(&self.ends(), slice_begin, bounded_slice_end)?,
+            slice(&self.ends(), slice_begin, slice_end + 1)?,
             value_at_index(slice_begin, self.start()),
-            self.validity().slice(slice_begin, bounded_slice_end)?,
+            self.validity().slice(slice_begin, slice_end + 1)?,
             stop - start,
             start,
         )?

--- a/encodings/runend-bool/src/compute.rs
+++ b/encodings/runend-bool/src/compute.rs
@@ -45,7 +45,7 @@ impl TakeFn for RunEndBoolArray {
                     if idx >= self.len() {
                         vortex_bail!(OutOfBounds: idx, 0, self.len())
                     }
-                    self.find_physical_index(idx).map(|loc| loc as u64)
+                    self.find_physical_index(idx)
                 })
                 .collect::<VortexResult<Vec<_>>>()?
         });

--- a/encodings/runend-bool/src/compute.rs
+++ b/encodings/runend-bool/src/compute.rs
@@ -3,7 +3,7 @@ use vortex::compute::unary::ScalarAtFn;
 use vortex::compute::{slice, ArrayCompute, SliceFn, TakeFn};
 use vortex::{Array, IntoArray, IntoArrayVariant, ToArray};
 use vortex_dtype::match_each_integer_ptype;
-use vortex_error::VortexResult;
+use vortex_error::{vortex_bail, VortexResult};
 use vortex_scalar::Scalar;
 
 use crate::compress::value_at_index;
@@ -40,8 +40,12 @@ impl TakeFn for RunEndBoolArray {
             primitive_indices
                 .maybe_null_slice::<$P>()
                 .iter()
+                .map(|idx| *idx as usize)
                 .map(|idx| {
-                    self.find_physical_index(*idx as usize)
+                    if idx >= self.len() {
+                        vortex_bail!(OutOfBounds: idx, 0, self.len())
+                    }
+                    self.find_physical_index(idx).map(|loc| loc as u64)
                 })
                 .collect::<VortexResult<Vec<_>>>()?
         });

--- a/encodings/runend/src/runend.rs
+++ b/encodings/runend/src/runend.rs
@@ -72,8 +72,17 @@ impl RunEndArray {
     }
 
     pub fn find_physical_index(&self, index: usize) -> VortexResult<usize> {
-        search_sorted(&self.ends(), index + self.offset(), SearchSortedSide::Right)
-            .map(|s| s.to_index())
+        if index >= self.len() {
+            vortex_bail!(OutOfBounds: index, 0, self.len())
+        }
+
+        let searched_index =
+            search_sorted(&self.ends(), index + self.offset(), SearchSortedSide::Right)?.to_index();
+        Ok(if searched_index == self.ends().len() {
+            searched_index - 1
+        } else {
+            searched_index
+        })
     }
 
     pub fn encode(array: Array) -> VortexResult<Self> {

--- a/encodings/runend/src/runend.rs
+++ b/encodings/runend/src/runend.rs
@@ -72,10 +72,6 @@ impl RunEndArray {
     }
 
     pub fn find_physical_index(&self, index: usize) -> VortexResult<usize> {
-        if index >= self.len() {
-            vortex_bail!(OutOfBounds: index, 0, self.len())
-        }
-
         let searched_index =
             search_sorted(&self.ends(), index + self.offset(), SearchSortedSide::Right)?.to_index();
         Ok(if searched_index == self.ends().len() {


### PR DESCRIPTION
When accessing the last element we would return out of bounds index
