### PR TITLE
`Exact` support for more expressions 

### DIFF
--- a/bench-vortex/src/bin/tpch_benchmark.rs
+++ b/bench-vortex/src/bin/tpch_benchmark.rs
@@ -112,7 +112,6 @@ async fn bench_main(queries: Option<Vec<usize>>, iterations: usize, warmup: bool
             for (ctx, format) in ctxs.iter().zip(formats.iter()) {
                 if warmup {
                     for i in 0..3 {
-                        // warmup
                         let row_count: usize = rt.block_on(async {
                             ctx.sql(&query)
                                 .await

--- a/bench-vortex/src/bin/tpch_benchmark.rs
+++ b/bench-vortex/src/bin/tpch_benchmark.rs
@@ -7,7 +7,7 @@ use std::time::SystemTime;
 
 use bench_vortex::tpch::dbgen::{DBGen, DBGenOptions};
 use bench_vortex::tpch::{load_datasets, tpch_queries, Format, EXPECTED_ROW_COUNTS};
-use clap::Parser;
+use clap::{ArgAction, Parser};
 use futures::future::try_join_all;
 use indicatif::ProgressBar;
 use itertools::Itertools;
@@ -20,6 +20,10 @@ struct Args {
     queries: Option<Vec<usize>>,
     #[arg(short, long)]
     threads: Option<usize>,
+    #[arg(short, long, default_value_t = true, default_missing_value = "true", action = ArgAction::Set)]
+    warmup: bool,
+    #[arg(short, long, default_value = "10")]
+    iterations: usize,
 }
 
 fn main() -> ExitCode {
@@ -40,10 +44,10 @@ fn main() -> ExitCode {
     }
     .expect("Failed building the Runtime");
 
-    runtime.block_on(bench_main(args.queries))
+    runtime.block_on(bench_main(args.queries, args.iterations, args.warmup))
 }
 
-async fn bench_main(queries: Option<Vec<usize>>) -> ExitCode {
+async fn bench_main(queries: Option<Vec<usize>>, iterations: usize, warmup: bool) -> ExitCode {
     // uncomment the below to enable trace logging of datafusion execution
     // setup_logger(LevelFilter::Trace);
 
@@ -106,27 +110,32 @@ async fn bench_main(queries: Option<Vec<usize>>) -> ExitCode {
                 .build()
                 .unwrap();
             for (ctx, format) in ctxs.iter().zip(formats.iter()) {
-                for i in 0..3 {
-                    // warmup
-                    let row_count: usize = rt.block_on(async {
-                        ctx.sql(&query)
-                            .await
-                            .map_err(|e| println!("Failed to run {} {:?}: {}", q, format, e))
-                            .unwrap()
-                            .collect()
-                            .await
-                            .map_err(|e| println!("Failed to collect {} {:?}: {}", q, format, e))
-                            .unwrap()
-                            .iter()
-                            .map(|r| r.num_rows())
-                            .sum()
-                    });
-                    if i == 0 {
-                        count_tx.send((q, *format, row_count)).unwrap();
+                if warmup {
+                    for i in 0..3 {
+                        // warmup
+                        let row_count: usize = rt.block_on(async {
+                            ctx.sql(&query)
+                                .await
+                                .map_err(|e| println!("Failed to run {} {:?}: {}", q, format, e))
+                                .unwrap()
+                                .collect()
+                                .await
+                                .map_err(|e| {
+                                    println!("Failed to collect {} {:?}: {}", q, format, e)
+                                })
+                                .unwrap()
+                                .iter()
+                                .map(|r| r.num_rows())
+                                .sum()
+                        });
+                        if i == 0 {
+                            count_tx.send((q, *format, row_count)).unwrap();
+                        }
                     }
                 }
+
                 let mut measure = Vec::new();
-                for _ in 0..10 {
+                for _ in 0..iterations {
                     let start = SystemTime::now();
                     rt.block_on(async {
                         ctx.sql(&query)

--- a/vortex-array/src/arrow/recordbatch.rs
+++ b/vortex-array/src/arrow/recordbatch.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use crate::array::StructArray;
 use crate::arrow::FromArrowArray;
 use crate::validity::Validity;
-use crate::{Array, IntoArray, IntoCanonical};
+use crate::{Array, IntoArrayVariant, IntoCanonical};
 
 impl From<RecordBatch> for Array {
     fn from(value: RecordBatch) -> Self {
@@ -33,17 +33,20 @@ impl From<RecordBatch> for Array {
 
 impl From<Array> for RecordBatch {
     fn from(value: Array) -> Self {
-        let array_ref = value
-            .into_canonical()
-            .expect("struct arrays must canonicalize")
-            .into_arrow();
-        let struct_array = as_struct_array(array_ref.as_ref());
-        RecordBatch::from(struct_array)
+        let struct_arr = value
+            .into_struct()
+            .expect("RecordBatch can only be constructed from a Vortex StructArray");
+        Self::from(struct_arr)
     }
 }
 
 impl From<StructArray> for RecordBatch {
     fn from(value: StructArray) -> Self {
-        RecordBatch::from(value.into_array())
+        let array_ref = value
+            .into_canonical()
+            .expect("Struct arrays must canonicalize")
+            .into_arrow();
+        let struct_array = as_struct_array(array_ref.as_ref());
+        Self::from(struct_array)
     }
 }

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -58,7 +58,7 @@ impl FileOpener for VortexFileOpener {
                 let vtx_expr = convert_expr_to_vortex(predicate, self.arrow_schema.as_ref())
                     .map_err(|e| DataFusionError::External(e.into()))?;
 
-                DFResult::Ok(vtx_expr)
+                Ok(vtx_expr)
             })
             .transpose()?;
 

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -53,12 +53,10 @@ impl FileOpener for VortexFileOpener {
             .predicate
             .clone()
             .map(|predicate| -> DFResult<Arc<dyn VortexPhysicalExpr>> {
-                // Extend the projection to include column only referenced by physical expressions
-
                 let vtx_expr = convert_expr_to_vortex(predicate, self.arrow_schema.as_ref())
                     .map_err(|e| DataFusionError::External(e.into()))?;
 
-                Ok(vtx_expr)
+                DFResult::Ok(vtx_expr)
             })
             .transpose()?;
 


### PR DESCRIPTION
Start moving from `TableProviderFilterPushDown::Inexact` support to `TableProviderFilterPushDown::Exact` to allow for better performance in supported expressions.