### PR TITLE
cargo-sort related maintenance 

### DIFF
--- a/vortex-datetime-dtype/Cargo.toml
+++ b/vortex-datetime-dtype/Cargo.toml
@@ -12,12 +12,12 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+arrow-schema = { workspace = true, optional = true }
 lazy_static = { workspace = true }
 num_enum = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 vortex-dtype = { workspace = true }
 vortex-error = { workspace = true }
-arrow-schema = { workspace = true, optional = true }
 
 [features]
 default = ["arrow"]

--- a/vortex-expr/Cargo.toml
+++ b/vortex-expr/Cargo.toml
@@ -20,10 +20,10 @@ bench = false
 workspace = true
 
 [dependencies]
+arrow-schema = { workspace = true, optional = true }
 datafusion-common = { workspace = true, optional = true }
 datafusion-expr = { workspace = true, optional = true }
 datafusion-physical-expr = { workspace = true, optional = true }
-arrow-schema = { workspace = true, optional = true }
 prost = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 vortex-array = { workspace = true }

--- a/vortex-proto/Cargo.toml
+++ b/vortex-proto/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "vortex-proto"
 description = "Protocol buffer definitions for Vortex types"
-version.workspace = true
-homepage.workspace = true
-repository.workspace = true
-authors.workspace = true
-license.workspace = true
-keywords.workspace = true
-include.workspace = true
-edition.workspace = true
-rust-version.workspace = true
+version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+keywords = { workspace = true }
+include = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 prost = { workspace = true }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,15 +2,15 @@
 name = "xtask"
 # This is an internal crate for project developers
 publish = false
-version.workspace = true
-homepage.workspace = true
-repository.workspace = true
-authors.workspace = true
-license.workspace = true
-keywords.workspace = true
-include.workspace = true
-edition.workspace = true
-rust-version.workspace = true
+version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+keywords = { workspace = true }
+include = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
seems like `cargo-sort` has some problems with values like `version.workspace = true`, so I changed all remaining ones and re-ran it