### PR TITLE
Fix query count in benchmark tool

### DIFF
--- a/bench-vortex/src/bin/tpch_benchmark.rs
+++ b/bench-vortex/src/bin/tpch_benchmark.rs
@@ -84,7 +84,7 @@ async fn bench_main(queries: Option<Vec<usize>>, iterations: usize, warmup: bool
         table.add_row(Row::new(cells));
     }
 
-    let query_count = queries.as_ref().map_or(21, |c| c.len());
+    let query_count = queries.as_ref().map_or(22, |c| c.len());
 
     // Setup a progress bar
     let progress = ProgressBar::new((query_count * formats.len()) as u64);


### PR DESCRIPTION
Now that @robert3005 got Q15 running, we have 22 queries and not 21, so the progress bar is too short.