### PR TITLE
Fix pack_varbin

### DIFF
--- a/vortex-array/src/array/chunked/canonical.rs
+++ b/vortex-array/src/array/chunked/canonical.rs
@@ -261,10 +261,10 @@ mod tests {
 
     fn varbin_array() -> VarBinArray {
         let mut builder = VarBinBuilder::<i32>::with_capacity(4);
-        builder.push_value("foo".as_bytes());
-        builder.push_value("bar".as_bytes());
-        builder.push_value("baz".as_bytes());
-        builder.push_value("quak".as_bytes());
+        builder.push_value("foo");
+        builder.push_value("bar");
+        builder.push_value("baz");
+        builder.push_value("quak");
         builder.finish(DType::Utf8(Nullability::NonNullable))
     }
 

--- a/vortex-array/src/array/chunked/canonical.rs
+++ b/vortex-array/src/array/chunked/canonical.rs
@@ -210,7 +210,7 @@ fn pack_varbin(chunks: &[Array], validity: Validity, dtype: &DType) -> VortexRes
     let len: usize = chunks.iter().map(|c| c.len()).sum();
     let mut offsets = Vec::with_capacity(len + 1);
     offsets.push(0);
-    let mut buffer = Vec::new();
+    let mut data_bytes = Vec::new();
 
     for chunk in chunks {
         let chunk = chunk.clone().into_varbin()?;
@@ -228,7 +228,7 @@ fn pack_varbin(chunks: &[Array], validity: Validity, dtype: &DType) -> VortexRes
         ))?;
         let primitive_bytes =
             slice(&chunk.bytes(), first_offset_value, last_offset_value)?.into_primitive()?;
-        buffer.extend_from_slice(primitive_bytes.buffer());
+        data_bytes.extend_from_slice(primitive_bytes.buffer());
 
         let adjustment_from_previous = *offsets.last().expect("offsets has at least one element");
         offsets.extend(
@@ -242,7 +242,7 @@ fn pack_varbin(chunks: &[Array], validity: Validity, dtype: &DType) -> VortexRes
 
     VarBinArray::try_new(
         PrimitiveArray::from(offsets).into_array(),
-        PrimitiveArray::from(buffer).into_array(),
+        PrimitiveArray::from(data_bytes).into_array(),
         dtype.clone(),
         validity,
     )

--- a/vortex-array/src/array/varbin/builder.rs
+++ b/vortex-array/src/array/varbin/builder.rs
@@ -34,10 +34,11 @@ impl<O: NativePType> VarBinBuilder<O> {
     }
 
     #[inline]
-    pub fn push_value(&mut self, value: &[u8]) {
+    pub fn push_value(&mut self, value: impl AsRef<[u8]>) {
+        let slice = value.as_ref();
         self.offsets
-            .push(O::from(self.data.len() + value.len()).unwrap());
-        self.data.extend_from_slice(value);
+            .push(O::from(self.data.len() + slice.len()).unwrap());
+        self.data.extend_from_slice(slice);
         self.validity.append_non_null();
     }
 


### PR DESCRIPTION
Sliced VarBin arrays don't rewrite offsets and bytes so we need to perform the
adjustment when concatenating them
