### PR TITLE
impl Display for StructValue

### DIFF
--- a/vortex-scalar/src/struct_.rs
+++ b/vortex-scalar/src/struct_.rs
@@ -17,6 +17,10 @@ impl<'a> StructScalar<'a> {
         self.dtype
     }
 
+    pub fn is_null(&self) -> bool {
+        self.fields.is_none();
+    }
+
     pub fn field_by_idx(&self, idx: usize) -> Option<Scalar> {
         let DType::Struct(st, _) = self.dtype() else {
             unreachable!()
@@ -56,7 +60,7 @@ impl<'a> TryFrom<&'a Scalar> for StructScalar<'a> {
     type Error = VortexError;
 
     fn try_from(value: &'a Scalar) -> Result<Self, Self::Error> {
-        if matches!(value.dtype(), DType::Struct(..)) {
+        if !matches!(value.dtype(), DType::Struct(..)) {
             vortex_bail!("Expected struct scalar, found {}", value.dtype())
         }
         Ok(Self {

--- a/vortex-scalar/src/value.rs
+++ b/vortex-scalar/src/value.rs
@@ -61,6 +61,7 @@ impl ScalarValue {
 
     pub fn as_list(&self) -> VortexResult<Option<&Arc<[Self]>>> {
         match self {
+            Self::Null => Ok(None),
             Self::List(l) => Ok(Some(l)),
             _ => Err(vortex_err!("Expected a list scalar, found {:?}", self)),
         }


### PR DESCRIPTION
- Further on #670.
- Fixes a bug in `sturct_.rs` wherein the failure condition was reversed.
- Permit `as_list` to convert a `Null` into a `None`.

Examples:

    {}

    {foo:3}

    {foo:3,bar:true}