### PR TITLE
Teach RunEnd take to respect its own validity

### DIFF
--- a/encodings/runend/src/compute.rs
+++ b/encodings/runend/src/compute.rs
@@ -1,4 +1,4 @@
-use vortex::array::{BoolArray, ConstantArray, PrimitiveArray, SparseArray};
+use vortex::array::{ConstantArray, PrimitiveArray, SparseArray};
 use vortex::compute::unary::{scalar_at, scalar_at_unchecked, ScalarAtFn};
 use vortex::compute::{filter, slice, take, ArrayCompute, SliceFn, TakeFn};
 use vortex::validity::Validity;
@@ -65,7 +65,9 @@ impl TakeFn for RunEndArray {
             Validity::Array(original_validity) => {
                 let dense_validity = take(&original_validity, indices)?;
                 let dense_nonnull_indices = PrimitiveArray::from(
-                    BoolArray::try_from(dense_validity.clone())?
+                    dense_validity
+                        .clone()
+                        .into_bool()?
                         .boolean_buffer()
                         .set_indices()
                         .map(|idx| idx as u64)

--- a/encodings/runend/src/compute.rs
+++ b/encodings/runend/src/compute.rs
@@ -1,7 +1,8 @@
-use vortex::array::PrimitiveArray;
+use vortex::array::{BoolArray, ConstantArray, PrimitiveArray, SparseArray};
 use vortex::compute::unary::{scalar_at, scalar_at_unchecked, ScalarAtFn};
-use vortex::compute::{slice, take, ArrayCompute, SliceFn, TakeFn};
-use vortex::{Array, IntoArray, IntoArrayVariant};
+use vortex::compute::{filter, slice, take, ArrayCompute, SliceFn, TakeFn};
+use vortex::validity::Validity;
+use vortex::{Array, ArrayDType, IntoArray, IntoArrayVariant};
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::{vortex_bail, VortexResult};
 use vortex_scalar::Scalar;
@@ -49,12 +50,39 @@ impl TakeFn for RunEndArray {
                     }
                     self.find_physical_index(idx).map(|loc| loc as u64)
                 })
+
                 .collect::<VortexResult<Vec<_>>>()?
         });
-        take(
-            &self.values(),
-            &PrimitiveArray::from(physical_indices).into_array(),
-        )
+        let physical_indices_array = PrimitiveArray::from(physical_indices).into_array();
+        let dense_values = take(&self.values(), &physical_indices_array)?;
+
+        Ok(match self.validity() {
+            Validity::NonNullable => dense_values,
+            Validity::AllValid => dense_values,
+            Validity::AllInvalid => {
+                ConstantArray::new(Scalar::null(self.dtype().clone()), indices.len()).into_array()
+            }
+            Validity::Array(original_validity) => {
+                let dense_validity = take(&original_validity, indices)?;
+                let dense_nonnull_indices = PrimitiveArray::from(
+                    BoolArray::try_from(dense_validity.clone())?
+                        .boolean_buffer()
+                        .set_indices()
+                        .map(|idx| idx as u64)
+                        .collect::<Vec<u64>>(),
+                )
+                .into_array();
+                let length = dense_validity.len();
+
+                SparseArray::try_new(
+                    dense_nonnull_indices,
+                    filter(&dense_values, &dense_validity)?,
+                    length,
+                    Scalar::null(self.dtype().clone()),
+                )?
+                .into_array()
+            }
+        })
     }
 }
 


### PR DESCRIPTION
Before this change, the validity is completely ignored. The test added in this PR fails in the develop branch. This change also takes the desired indices from the validity and converts from an array of Booleans to an array of set indices. This array of indices can be used as the indices of a sprase array with the fill values as null.

Resolves #609.