### PR TITLE
teach vortex.encode to also accept nullable arrays

### DIFF
--- a/pyvortex/src/encode.rs
+++ b/pyvortex/src/encode.rs
@@ -25,7 +25,8 @@ pub fn encode(obj: &Bound<PyAny>) -> PyResult<Py<PyArray>> {
 
     if obj.is_instance(&pa_array)? {
         let arrow_array = ArrowArrayData::from_pyarrow_bound(obj).map(make_array)?;
-        let enc_array = Array::from_arrow(arrow_array, false);
+        let is_nullable = arrow_array.is_nullable();
+        let enc_array = Array::from_arrow(arrow_array, is_nullable);
         PyArray::wrap(obj.py(), enc_array.into())
     } else if obj.is_instance(&chunked_array)? {
         let chunks: Vec<Bound<PyAny>> = obj.getattr("chunks")?.extract()?;

--- a/pyvortex/test/test_array.py
+++ b/pyvortex/test/test_array.py
@@ -11,7 +11,7 @@ def test_primitive_array_round_trip():
 def test_array_with_nulls():
     a = pa.array([b"123", None])
     arr = vortex.encode(a)
-    assert arr.to_pyarrow().combine_chunks() == a
+    assert arr.to_arrow().combine_chunks() == a
 
 
 def test_varbin_array_round_trip():

--- a/pyvortex/test/test_array.py
+++ b/pyvortex/test/test_array.py
@@ -9,6 +9,13 @@ def test_primitive_array_round_trip():
     assert arr.to_pyarrow().combine_chunks() == a
 
 
+def test_array_with_nulls():
+    a = pa.array([b'123', None])
+    arr = vortex.encode(a)
+    assert isinstance(arr, vortex.VarBinArray)
+    assert arr.to_pyarrow().combine_chunks() == a
+
+
 def test_varbin_array_round_trip():
     a = pa.array(["a", "b", "c"])
     arr = vortex.encode(a)

--- a/pyvortex/test/test_array.py
+++ b/pyvortex/test/test_array.py
@@ -11,7 +11,6 @@ def test_primitive_array_round_trip():
 def test_array_with_nulls():
     a = pa.array([b"123", None])
     arr = vortex.encode(a)
-    assert isinstance(arr, vortex.VarBinArray)
     assert arr.to_pyarrow().combine_chunks() == a
 
 


### PR DESCRIPTION
This new test fails on develop:

        def test_array_with_nulls():
            a = pa.array([b'123', None])
    >       arr = vortex.encode(a)
    E       pyo3_runtime.PanicException: assertion failed: nulls.is_none()

It seems odd that `from_array` has a nullability parameter, but, in principle, we could support an array which does not know its nullability.