### PR TITLE
teach from_arrow how to convert nullable struct arrays

### DIFF
--- a/vortex-array/src/array/struct_/mod.rs
+++ b/vortex-array/src/array/struct_/mod.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use vortex_dtype::field::Field;
-use vortex_dtype::{DType, FieldName, FieldNames, Nullability, StructDType};
+use vortex_dtype::{DType, FieldName, FieldNames, StructDType};
 use vortex_error::{vortex_bail, vortex_err, VortexResult};
 
 use crate::stats::{ArrayStatisticsCompute, StatsSet};
@@ -55,14 +55,14 @@ impl StructArray {
 
         let mut children = Vec::with_capacity(fields.len() + 1);
         children.extend(fields);
-        if let Some(v) = validity.into_array() {
+        if let Some(v) = validity.clone().into_array() {
             children.push(v);
         }
 
         Self::try_from_parts(
             DType::Struct(
                 StructDType::new(names, field_dtypes),
-                Nullability::NonNullable,
+                validity.nullability(),
             ),
             length,
             StructMetadata {

--- a/vortex-array/src/array/struct_/mod.rs
+++ b/vortex-array/src/array/struct_/mod.rs
@@ -41,6 +41,8 @@ impl StructArray {
         length: usize,
         validity: Validity,
     ) -> VortexResult<Self> {
+        let nullability = validity.nullability();
+
         if names.len() != fields.len() {
             vortex_bail!("Got {} names and {} fields", names.len(), fields.len());
         }
@@ -55,15 +57,12 @@ impl StructArray {
 
         let mut children = Vec::with_capacity(fields.len() + 1);
         children.extend(fields);
-        if let Some(v) = validity.clone().into_array() {
+        if let Some(v) = validity.into_array() {
             children.push(v);
         }
 
         Self::try_from_parts(
-            DType::Struct(
-                StructDType::new(names, field_dtypes),
-                validity.nullability(),
-            ),
+            DType::Struct(StructDType::new(names, field_dtypes), nullability),
             length,
             StructMetadata {
                 length,

--- a/vortex-array/src/arrow/array.rs
+++ b/vortex-array/src/arrow/array.rs
@@ -158,7 +158,6 @@ impl FromArrowArray<&ArrowBooleanArray> for Array {
 impl FromArrowArray<&ArrowStructArray> for Array {
     fn from_arrow(value: &ArrowStructArray, nullable: bool) -> Self {
         // TODO(ngates): how should we deal with Arrow "logical nulls"?
-        assert!(!nullable);
         StructArray::try_new(
             value
                 .column_names()

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -590,7 +590,8 @@ mod test {
         )
     }
 
-    fn roundtrip_struct() {
+    #[test]
+    fn test_roundtrip_struct() {
         let mut nulls = NullBufferBuilder::new(6);
         nulls.append_n_non_nulls(4);
         nulls.append_null();


### PR DESCRIPTION
The assertion in `from_arrow` prevented conversion of valid Arrow arrays.