### PR TITLE
Teach schema dtype() and into_dtype()

### DIFF
--- a/vortex-serde/src/layouts/read/schema.rs
+++ b/vortex-serde/src/layouts/read/schema.rs
@@ -19,4 +19,12 @@ impl Schema {
             }
         }
     }
+
+    pub fn dtype(&self) -> &DType {
+        &self.0
+    }
+
+    pub fn into_dtype(self) -> DType {
+        self.0
+    }
 }


### PR DESCRIPTION
I need these when reading because LayoutBatchStream does not expose its dtype.