### PR TITLE
Prefer "arrow" to "pyarrow"

### DIFF
--- a/pyvortex/src/array.rs
+++ b/pyvortex/src/array.rs
@@ -201,7 +201,7 @@ impl PyArray {
 
 #[pymethods]
 impl PyArray {
-    fn to_pyarrow(self_: PyRef<'_, Self>) -> PyResult<Bound<PyAny>> {
+    fn to_arrow(self_: PyRef<'_, Self>) -> PyResult<Bound<PyAny>> {
         vortex_arrow::export_array(self_.py(), &self_.inner)
     }
 

--- a/pyvortex/test/test_array.py
+++ b/pyvortex/test/test_array.py
@@ -6,19 +6,19 @@ def test_primitive_array_round_trip():
     a = pa.array([0, 1, 2, 3])
     arr = vortex.encode(a)
     assert isinstance(arr, vortex.PrimitiveArray)
-    assert arr.to_pyarrow().combine_chunks() == a
+    assert arr.to_arrow().combine_chunks() == a
 
 
 def test_varbin_array_round_trip():
     a = pa.array(["a", "b", "c"])
     arr = vortex.encode(a)
     assert isinstance(arr, vortex.VarBinArray)
-    assert arr.to_pyarrow().combine_chunks() == a
+    assert arr.to_arrow().combine_chunks() == a
 
 
 def test_varbin_array_take():
     a = vortex.encode(pa.array(["a", "b", "c", "d"]))
-    assert a.take(vortex.encode(pa.array([0, 2]))).to_pyarrow().combine_chunks() == pa.array(
+    assert a.take(vortex.encode(pa.array([0, 2]))).to_arrow().combine_chunks() == pa.array(
         ["a", "c"],
         type=pa.utf8(),
     )
@@ -27,4 +27,4 @@ def test_varbin_array_take():
 def test_empty_array():
     a = pa.array([], type=pa.uint8())
     primitive = vortex.encode(a)
-    assert primitive.to_pyarrow().type == pa.uint8()
+    assert primitive.to_arrow().type == pa.uint8()

--- a/pyvortex/test/test_compress.py
+++ b/pyvortex/test/test_compress.py
@@ -60,7 +60,7 @@ def test_chunked_encode():
     chunked = pa.chunked_array([pa.array([0, 1, 2]), pa.array([3, 4, 5])])
     encoded = vortex.encode(chunked)
     assert isinstance(encoded, vortex.ChunkedArray)
-    assert encoded.to_pyarrow().combine_chunks() == pa.array([0, 1, 2, 3, 4, 5])
+    assert encoded.to_arrow().combine_chunks() == pa.array([0, 1, 2, 3, 4, 5])
 
 
 def test_table_encode():
@@ -72,7 +72,7 @@ def test_table_encode():
     )
     encoded = vortex.encode(table)
     assert isinstance(encoded, vortex.ChunkedArray)
-    assert encoded.to_pyarrow().combine_chunks() == pa.StructArray.from_arrays(
+    assert encoded.to_arrow().combine_chunks() == pa.StructArray.from_arrays(
         [pa.array([0, 1, 2, 3, 4, 5]), pa.array(["a", "b", "c", "d", "e", "f"])], names=["number", "string"]
     )
 
@@ -82,5 +82,5 @@ def test_taxi():
     curdir = Path(os.path.dirname(__file__)).parent.parent
     table = pq.read_table(curdir / "bench-vortex/data/yellow-tripdata-2023-11.parquet")
     compressed = vortex.compress(vortex.encode(table[:100]))
-    decompressed = compressed.to_pyarrow()
+    decompressed = compressed.to_arrow()
     assert not decompressed


### PR DESCRIPTION
This matches PyTorch, Ray, datatable, and polars:
- https://pytorch.org/torcharrow/beta/generated/torcharrow.from_arrow.html
- https://docs.ray.io/en/latest/data/api/doc/ray.data.from_arrow.html
- https://datatable.readthedocs.io/en/latest/api/frame/to_arrow.html
- https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.to_arrow.html