### PR TITLE
Sphinx docs skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,7 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
+pyvortex/docs/_build/
 
 # PyBuilder
 .pybuilder/
@@ -196,3 +196,6 @@ data/
 
 # vscode
 .vscode/
+
+# Emacs
+*~

--- a/pyvortex/Cargo.toml
+++ b/pyvortex/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 [lib]
 name = "pyvortex"
 crate-type = ["rlib", "cdylib"]
+doctest = false
 
 [dependencies]
 arrow = { workspace = true, features = ["pyarrow"] }

--- a/pyvortex/docs/Makefile
+++ b/pyvortex/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?= -W --keep-going
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/pyvortex/docs/conf.py
+++ b/pyvortex/docs/conf.py
@@ -6,35 +6,35 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'Vortex'
-copyright = '2024, Spiral'
-author = 'Spiral'
+project = "Vortex"
+copyright = "2024, Spiral"
+author = "Spiral"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.doctest',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.doctest",
 ]
 
-templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3', None),
-    'pyarrow': ('https://arrow.apache.org/docs/', None),
-    'pandas': ('https://pandas.pydata.org/docs/', None),
-    'numpy': ('https://numpy.org/doc/stable/', None),
+    "python": ("https://docs.python.org/3", None),
+    "pyarrow": ("https://arrow.apache.org/docs/", None),
+    "pandas": ("https://pandas.pydata.org/docs/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
 }
 
 nitpicky = True  # ensures all :class:, :obj:, etc. links are valid
 
-doctest_global_setup = 'import pyarrow; import vortex'
+doctest_global_setup = "import pyarrow; import vortex"
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'pydata_sphinx_theme'
+html_theme = "pydata_sphinx_theme"
 # html_static_path = ['_static']  # no static files yet

--- a/pyvortex/docs/conf.py
+++ b/pyvortex/docs/conf.py
@@ -1,0 +1,40 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'Vortex'
+copyright = '2024, Spiral'
+author = 'Spiral'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.doctest',
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'pyarrow': ('https://arrow.apache.org/docs/', None),
+    'pandas': ('https://pandas.pydata.org/docs/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
+}
+
+nitpicky = True  # ensures all :class:, :obj:, etc. links are valid
+
+doctest_global_setup = 'import pyarrow; import vortex'
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'pydata_sphinx_theme'
+# html_static_path = ['_static']  # no static files yet

--- a/pyvortex/docs/index.rst
+++ b/pyvortex/docs/index.rst
@@ -1,0 +1,14 @@
+.. Vortex documentation master file, created by
+   sphinx-quickstart on Wed Aug 28 10:10:21 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Vortex documentation
+====================
+
+.. automodule:: vortex
+   :members:
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:

--- a/pyvortex/docs/make.bat
+++ b/pyvortex/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd


### PR DESCRIPTION
The Python ecosystem uses either Sphinx or MkDocs. The Astral folks use MkDocs, but Arrow and I suspect the majority of the Python ecosystem use Sphinx.

The most noticeable difference between the two is that MkDocs uses Markdown and Sphinx uses reStructuredText. I have used Sphinx too long to be bothered by rST but, IMO, a lot of people dislike the syntax at first.

Translating between rST and Markdown will be annoying so we should make a decision before too long. For now, I got the site started with the tool I knew, Sphinx, so that is what I have added here.