### PR TITLE
ALP compressor is better at roundtripping values

### DIFF
--- a/encodings/alp/src/alp.rs
+++ b/encodings/alp/src/alp.rs
@@ -106,10 +106,9 @@ pub trait ALPFloat: Float + Display + 'static {
     fn encode_single(value: Self, exponents: Exponents) -> Result<Self::ALPInt, Self> {
         let encoded = (value * Self::F10[exponents.e as usize] * Self::IF10[exponents.f as usize])
             .fast_round();
-        let decoded = encoded * Self::F10[exponents.f as usize] * Self::IF10[exponents.e as usize];
-
-        if decoded == value && encoded.trunc() == encoded {
-            if let Some(e) = encoded.as_int() {
+        if let Some(e) = encoded.as_int() {
+            let decoded = Self::decode_single(e, exponents);
+            if decoded == value {
                 return Ok(e);
             }
         }

--- a/encodings/alp/src/alp.rs
+++ b/encodings/alp/src/alp.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Display, Formatter};
 use std::mem::size_of;
 
 use itertools::Itertools;
@@ -12,7 +13,13 @@ pub struct Exponents {
     pub f: u8,
 }
 
-pub trait ALPFloat: Float + 'static {
+impl Display for Exponents {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "e: {}, f: {}", self.e, self.f)
+    }
+}
+
+pub trait ALPFloat: Float + Display + 'static {
     type ALPInt: PrimInt;
 
     const FRACTIONAL_BITS: u8;
@@ -77,7 +84,7 @@ pub trait ALPFloat: Float + 'static {
             .iter()
             .enumerate()
             .map(|(i, v)| {
-                match Self::encode_single(*v, &exp) {
+                match Self::encode_single(*v, exp) {
                     Ok(fi) => {
                         prev = fi;
                         fi
@@ -96,12 +103,12 @@ pub trait ALPFloat: Float + 'static {
     }
 
     #[inline]
-    fn encode_single(value: Self, exponents: &Exponents) -> Result<Self::ALPInt, Self> {
+    fn encode_single(value: Self, exponents: Exponents) -> Result<Self::ALPInt, Self> {
         let encoded = (value * Self::F10[exponents.e as usize] * Self::IF10[exponents.f as usize])
             .fast_round();
         let decoded = encoded * Self::F10[exponents.f as usize] * Self::IF10[exponents.e as usize];
 
-        if decoded == value {
+        if decoded == value && encoded.trunc() == encoded {
             if let Some(e) = encoded.as_int() {
                 return Ok(e);
             }

--- a/encodings/alp/src/compress.rs
+++ b/encodings/alp/src/compress.rs
@@ -62,7 +62,7 @@ pub fn decompress(array: ALPArray) -> VortexResult<PrimitiveArray> {
     let encoded = array.encoded().into_primitive()?;
     let validity = encoded.validity();
 
-    let decoded = match_each_alp_float_ptype!(array.dtype().try_into().unwrap(), |$T| {
+    let decoded = match_each_alp_float_ptype!(array.dtype().try_into()?, |$T| {
         PrimitiveArray::from_vec(
             decompress_primitive::<$T>(encoded.into_maybe_null_slice(), array.exponents()),
             validity,
@@ -189,5 +189,16 @@ mod tests {
         assert!(s.is_null());
 
         let _decoded = decompress(encoded).unwrap();
+    }
+
+    #[test]
+    fn roundtrips_close_fractional() {
+        let original = PrimitiveArray::from(vec![195.26274f32, 195.27837, -48.815685]);
+        let alp_arr = alp_encode(&original).unwrap();
+        let decompressed = alp_arr.into_primitive().unwrap();
+        assert_eq!(
+            original.maybe_null_slice::<f32>(),
+            decompressed.maybe_null_slice::<f32>()
+        );
     }
 }

--- a/encodings/alp/src/compute.rs
+++ b/encodings/alp/src/compute.rs
@@ -26,14 +26,11 @@ impl ScalarAtFn for ALPArray {
     }
 
     fn scalar_at_unchecked(&self, index: usize) -> Scalar {
-        if let Some(patches) = self.patches().and_then(|p| {
-            p.with_dyn(|arr| {
+        if let Some(patches) = self.patches() {
+            if patches.with_dyn(|a| a.is_valid(index)) {
                 // We need to make sure the value is actually in the patches array
-                arr.is_valid(index)
-            })
-            .then_some(p)
-        }) {
-            return scalar_at_unchecked(&patches, index);
+                return scalar_at_unchecked(&patches, index);
+            }
         }
 
         let encoded_val = scalar_at_unchecked(&self.encoded(), index);


### PR DESCRIPTION
For those wondering about the details of the change. `fast_round` as described in ALP paper still can leave the number as a float (found empirically by the fuzzer with the values committed in the test in this pr) and it's important to compare the decoded value after it has been converted to int and not just rounded.