### PR TITLE
ensure Sphinx can access the shared object file

### DIFF
--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -3,7 +3,6 @@ name: Python docs
 on:
   push:
     branches: [ develop ]
-  pull_request: {}
 
 permissions:
   actions: read

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -3,6 +3,7 @@ name: Python docs
 on:
   push:
     branches: [ develop ]
+  pull_request: {}
 
 permissions:
   actions: read

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -19,13 +19,16 @@ jobs:
       - uses: ./.github/actions/setup-python
 
       - name: build Python docs
+        working-directory: pyvortex
         run: |
           set -ex
 
-          rye sync
+          rye run maturin develop
+
+          cd docs
           rye run sphinx-build -M html . _build --fail-on-warning --keep-going
-        working-directory: pyvortex/docs
-      - run: |
+      - name: commit python docs to gh-pages-bench
+        run: |
           set -ex
 
           this_sha=$(git rev-parse HEAD)


### PR DESCRIPTION
Rye [claims](https://rye.astral.sh/guide/rust/#iterating) that `rye sync` is sufficient to build the Rust code but that does not appear to be true. `rye run maturin develop` builds rust and does the equivalent of `pip install --editable`.