### PR TITLE
Better implementation for `Validity::and`

### DIFF
--- a/encodings/byte-bool/src/compute/mod.rs
+++ b/encodings/byte-bool/src/compute/mod.rs
@@ -115,16 +115,7 @@ impl CompareFn for ByteBoolArray {
             Operator::Lte => lhs.not().bitor(&rhs),
         };
 
-        let mut validity = Vec::with_capacity(self.len());
-
-        let lhs_validity = self.validity();
-        let rhs_validity = canonical.validity();
-
-        for idx in 0..self.len() {
-            let l = lhs_validity.is_valid(idx);
-            let r = rhs_validity.is_valid(idx);
-            validity.push(l & r);
-        }
+        let validity = self.validity().and(canonical.validity())?;
 
         ByteBoolArray::try_from_vec(Vec::from_iter(result_buf.iter()), validity)
             .map(ByteBoolArray::into_array)

--- a/vortex-array/src/array/bool/compute/compare.rs
+++ b/vortex-array/src/array/bool/compute/compare.rs
@@ -63,7 +63,6 @@ mod test {
             .unwrap()
             .into_bool()
             .unwrap();
-        println!("0");
         assert_eq!(to_int_indices(matches), [1u64, 2, 3, 4]);
 
         let matches = compare(&arr, &arr, Operator::NotEq)

--- a/vortex-array/src/array/bool/compute/compare.rs
+++ b/vortex-array/src/array/bool/compute/compare.rs
@@ -63,6 +63,7 @@ mod test {
             .unwrap()
             .into_bool()
             .unwrap();
+        println!("0");
         assert_eq!(to_int_indices(matches), [1u64, 2, 3, 4]);
 
         let matches = compare(&arr, &arr, Operator::NotEq)

--- a/vortex-array/src/array/bool/compute/mod.rs
+++ b/vortex-array/src/array/bool/compute/mod.rs
@@ -1,6 +1,6 @@
 use crate::array::BoolArray;
 use crate::compute::unary::{FillForwardFn, ScalarAtFn};
-use crate::compute::{ArrayCompute, CompareFn, SliceFn, TakeFn};
+use crate::compute::{AndFn, ArrayCompute, CompareFn, OrFn, SliceFn, TakeFn};
 
 mod boolean;
 mod compare;
@@ -32,11 +32,11 @@ impl ArrayCompute for BoolArray {
         Some(self)
     }
 
-    fn and(&self) -> Option<&dyn crate::compute::AndFn> {
+    fn and(&self) -> Option<&dyn AndFn> {
         Some(self)
     }
 
-    fn or(&self) -> Option<&dyn crate::compute::OrFn> {
+    fn or(&self) -> Option<&dyn OrFn> {
         Some(self)
     }
 }


### PR DESCRIPTION
Previous implementation was actually buggy because it generated nullable arrays.