### PR TITLE
Fix benchmarks

### DIFF
--- a/vortex-array/src/array/primitive/compute/compare.rs
+++ b/vortex-array/src/array/primitive/compute/compare.rs
@@ -16,7 +16,7 @@ impl CompareFn for PrimitiveArray {
             apply_predicate(self.maybe_null_slice::<$T>(), other.maybe_null_slice::<$T>(), operator.to_fn::<$T>())
         });
 
-        let validity = self.validity().and(other.validity())?;
+        let validity = self.validity().and(other.validity())?.into_nullable();
 
         Ok(BoolArray::try_new(match_mask, validity)?.into_array())
     }

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -146,6 +146,8 @@ impl Validity {
     /// Logically & two Validity values of the same length
     pub fn and(self, rhs: Validity) -> VortexResult<Validity> {
         let validity = match (&self, &rhs) {
+            // Should be pretty clear
+            (Validity::NonNullable, Validity::NonNullable) => Validity::NonNullable,
             // Any `AllInvalid` makes the output all invalid values
             (Validity::AllInvalid, _) | (_, Validity::AllInvalid) => Validity::AllInvalid,
             // All truthy values on one side, which makes no effect on an `Array` variant
@@ -153,7 +155,6 @@ impl Validity {
             | (Validity::Array(a), Validity::NonNullable)
             | (Validity::NonNullable, Validity::Array(a))
             | (Validity::AllValid, Validity::Array(a)) => Validity::Array(a.clone()),
-            (Validity::NonNullable, Validity::NonNullable) => Validity::NonNullable,
             // Both sides are all valid
             (Validity::NonNullable, Validity::AllValid)
             | (Validity::AllValid, Validity::NonNullable)
@@ -171,6 +172,14 @@ impl Validity {
         };
 
         Ok(validity)
+    }
+
+    /// Convert into a nullable variant
+    pub fn into_nullable(self) -> Validity {
+        match self {
+            Self::NonNullable => Self::AllValid,
+            _ => self,
+        }
     }
 }
 


### PR DESCRIPTION
I broke `PrimitiveArray::compare` in an earlier PR by introducing a possibility of it returning a `NonNullable` result.