### PR TITLE
Fuzzer performs multiple operations on the underlying array instead of just one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4508,7 +4508,9 @@ name = "vortex-fuzz"
 version = "0.0.0"
 dependencies = [
  "libfuzzer-sys",
+ "num-traits",
  "vortex-array",
+ "vortex-buffer",
  "vortex-dtype",
  "vortex-error",
  "vortex-sampling-compressor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4508,7 +4508,6 @@ name = "vortex-fuzz"
 version = "0.0.0"
 dependencies = [
  "libfuzzer-sys",
- "num-traits",
  "vortex-array",
  "vortex-buffer",
  "vortex-dtype",

--- a/encodings/runend/src/compute.rs
+++ b/encodings/runend/src/compute.rs
@@ -96,7 +96,7 @@ impl SliceFn for RunEndArray {
         Ok(Self::with_offset_and_size(
             slice(&self.ends(), slice_begin, slice_end + 1)?,
             slice(&self.values(), slice_begin, slice_end + 1)?,
-            self.validity().slice(slice_begin, slice_end + 1)?,
+            self.validity().slice(start, stop)?,
             stop - start,
             start,
         )?
@@ -106,11 +106,12 @@ impl SliceFn for RunEndArray {
 
 #[cfg(test)]
 mod test {
-    use vortex::array::PrimitiveArray;
-    use vortex::compute::take;
+    use vortex::array::{BoolArray, PrimitiveArray};
     use vortex::compute::unary::{scalar_at, try_cast};
-    use vortex::validity::Validity;
-    use vortex::{ArrayDType, IntoArrayVariant, ToArray};
+    use vortex::compute::{slice, take};
+    use vortex::validity::{ArrayValidity, Validity};
+    use vortex::{ArrayDType, IntoArray, IntoArrayVariant, ToArray};
+    use vortex_dtype::{DType, Nullability, PType};
     use vortex_scalar::Scalar;
 
     use crate::RunEndArray;
@@ -167,5 +168,131 @@ mod test {
         .unwrap();
         let scalar = scalar_at(null_ree.array(), 11).unwrap();
         assert_eq!(scalar, Scalar::null(null_ree.dtype().clone()));
+    }
+
+    #[test]
+    fn slice_with_nulls() {
+        let array = RunEndArray::try_new(
+            PrimitiveArray::from(vec![3, 6, 8, 12]).into_array(),
+            PrimitiveArray::from_vec(vec![1, 4, 2, 5], Validity::AllValid).into_array(),
+            Validity::from(vec![
+                false, false, false, false, true, true, false, false, false, false, true, true,
+            ]),
+        )
+        .unwrap();
+        let sliced = slice(array.array(), 4, 10).unwrap();
+        let sliced_primitive = sliced.into_primitive().unwrap();
+        assert_eq!(
+            sliced_primitive.maybe_null_slice::<i32>(),
+            vec![4, 4, 2, 2, 5, 5]
+        );
+        assert_eq!(
+            sliced_primitive
+                .logical_validity()
+                .into_array()
+                .into_bool()
+                .unwrap()
+                .boolean_buffer()
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![true, true, false, false, false, false]
+        )
+    }
+
+    #[test]
+    fn slice_array() {
+        let arr = slice(
+            RunEndArray::try_new(
+                vec![2u32, 5, 10].into_array(),
+                vec![1i32, 2, 3].into_array(),
+                Validity::NonNullable,
+            )
+            .unwrap()
+            .array(),
+            3,
+            8,
+        )
+        .unwrap();
+        assert_eq!(
+            arr.dtype(),
+            &DType::Primitive(PType::I32, Nullability::NonNullable)
+        );
+        assert_eq!(arr.len(), 5);
+
+        assert_eq!(
+            arr.into_primitive().unwrap().maybe_null_slice::<i32>(),
+            vec![2, 2, 3, 3, 3]
+        );
+    }
+
+    #[test]
+    fn slice_end_inclusive() {
+        let arr = slice(
+            RunEndArray::try_new(
+                vec![2u32, 5, 10].into_array(),
+                vec![1i32, 2, 3].into_array(),
+                Validity::NonNullable,
+            )
+            .unwrap()
+            .array(),
+            4,
+            10,
+        )
+        .unwrap();
+        assert_eq!(
+            arr.dtype(),
+            &DType::Primitive(PType::I32, Nullability::NonNullable)
+        );
+        assert_eq!(arr.len(), 6);
+
+        assert_eq!(
+            arr.into_primitive().unwrap().maybe_null_slice::<i32>(),
+            vec![2, 3, 3, 3, 3, 3]
+        );
+    }
+
+    #[test]
+    fn decompress() {
+        let arr = RunEndArray::try_new(
+            vec![2u32, 5, 10].into_array(),
+            vec![1i32, 2, 3].into_array(),
+            Validity::NonNullable,
+        )
+        .unwrap();
+
+        assert_eq!(
+            arr.into_primitive().unwrap().maybe_null_slice::<i32>(),
+            vec![1, 1, 2, 2, 2, 3, 3, 3, 3, 3]
+        );
+    }
+
+    #[test]
+    fn take_with_nulls() {
+        let uncompressed = PrimitiveArray::from_vec(vec![1i32, 0, 3], Validity::AllValid);
+        let validity = BoolArray::from_vec(
+            vec![
+                true, true, false, false, false, true, true, true, true, true,
+            ],
+            Validity::NonNullable,
+        );
+        let arr = RunEndArray::try_new(
+            vec![2u32, 5, 10].into_array(),
+            uncompressed.into(),
+            Validity::Array(validity.into()),
+        )
+        .unwrap();
+
+        let test_indices = PrimitiveArray::from_vec(vec![0, 2, 4, 6], Validity::NonNullable);
+        let taken = take(arr.array(), test_indices.array()).unwrap();
+
+        assert_eq!(taken.len(), test_indices.len());
+
+        let parray = taken.into_primitive().unwrap();
+        assert_eq!(
+            (0..4)
+                .map(|idx| parray.is_valid(idx).then(|| parray.get_as_cast::<i32>(idx)))
+                .collect::<Vec<Option<i32>>>(),
+            vec![Some(1), None, None, Some(3),]
+        );
     }
 }

--- a/encodings/zigzag/src/compress.rs
+++ b/encodings/zigzag/src/compress.rs
@@ -7,49 +7,47 @@ use zigzag::ZigZag as ExternalZigZag;
 
 use crate::ZigZagArray;
 
-pub fn zigzag_encode(parray: &PrimitiveArray) -> VortexResult<ZigZagArray> {
+pub fn zigzag_encode(parray: PrimitiveArray) -> VortexResult<ZigZagArray> {
+    let validity = parray.validity();
     let encoded = match parray.ptype() {
-        PType::I8 => zigzag_encode_primitive::<i8>(parray.maybe_null_slice(), parray.validity()),
-        PType::I16 => zigzag_encode_primitive::<i16>(parray.maybe_null_slice(), parray.validity()),
-        PType::I32 => zigzag_encode_primitive::<i32>(parray.maybe_null_slice(), parray.validity()),
-        PType::I64 => zigzag_encode_primitive::<i64>(parray.maybe_null_slice(), parray.validity()),
+        PType::I8 => zigzag_encode_primitive::<i8>(parray.into_maybe_null_slice(), validity),
+        PType::I16 => zigzag_encode_primitive::<i16>(parray.into_maybe_null_slice(), validity),
+        PType::I32 => zigzag_encode_primitive::<i32>(parray.into_maybe_null_slice(), validity),
+        PType::I64 => zigzag_encode_primitive::<i64>(parray.into_maybe_null_slice(), validity),
         _ => vortex_bail!("Unsupported ptype {}", parray.ptype()),
     };
     ZigZagArray::try_new(encoded.into_array())
 }
 
 fn zigzag_encode_primitive<T: ExternalZigZag + NativePType>(
-    values: &[T],
+    values: Vec<T>,
     validity: Validity,
 ) -> PrimitiveArray
 where
     <T as ExternalZigZag>::UInt: NativePType,
 {
-    let mut encoded = Vec::with_capacity(values.len());
-    encoded.extend(values.iter().map(|v| T::encode(*v)));
-    PrimitiveArray::from_vec(encoded.to_vec(), validity)
+    PrimitiveArray::from_vec(values.into_iter().map(|v| T::encode(v)).collect(), validity)
 }
 
-pub fn zigzag_decode(parray: &PrimitiveArray) -> PrimitiveArray {
+pub fn zigzag_decode(parray: PrimitiveArray) -> PrimitiveArray {
+    let validity = parray.validity();
     match parray.ptype() {
-        PType::U8 => zigzag_decode_primitive::<i8>(parray.maybe_null_slice(), parray.validity()),
-        PType::U16 => zigzag_decode_primitive::<i16>(parray.maybe_null_slice(), parray.validity()),
-        PType::U32 => zigzag_decode_primitive::<i32>(parray.maybe_null_slice(), parray.validity()),
-        PType::U64 => zigzag_decode_primitive::<i64>(parray.maybe_null_slice(), parray.validity()),
+        PType::U8 => zigzag_decode_primitive::<i8>(parray.into_maybe_null_slice(), validity),
+        PType::U16 => zigzag_decode_primitive::<i16>(parray.into_maybe_null_slice(), validity),
+        PType::U32 => zigzag_decode_primitive::<i32>(parray.into_maybe_null_slice(), validity),
+        PType::U64 => zigzag_decode_primitive::<i64>(parray.into_maybe_null_slice(), validity),
         _ => panic!("Unsupported ptype {}", parray.ptype()),
     }
 }
 
 fn zigzag_decode_primitive<T: ExternalZigZag + NativePType>(
-    values: &[T::UInt],
+    values: Vec<T::UInt>,
     validity: Validity,
 ) -> PrimitiveArray
 where
     <T as ExternalZigZag>::UInt: NativePType,
 {
-    let mut encoded = Vec::with_capacity(values.len());
-    encoded.extend(values.iter().map(|v| T::decode(*v)));
-    PrimitiveArray::from_vec(encoded, validity)
+    PrimitiveArray::from_vec(values.into_iter().map(|v| T::decode(v)).collect(), validity)
 }
 
 #[cfg(test)]
@@ -61,7 +59,7 @@ mod test {
 
     #[test]
     fn test_compress() {
-        let compressed = zigzag_encode(&PrimitiveArray::from(Vec::from_iter(
+        let compressed = zigzag_encode(PrimitiveArray::from(Vec::from_iter(
             (-10_000..10_000).map(|i| i as i64),
         )))
         .unwrap();

--- a/encodings/zigzag/src/compute.rs
+++ b/encodings/zigzag/src/compute.rs
@@ -1,10 +1,10 @@
 use vortex::compute::unary::{scalar_at_unchecked, ScalarAtFn};
 use vortex::compute::{slice, ArrayCompute, SliceFn};
-use vortex::{Array, IntoArray};
-use vortex_dtype::PType;
+use vortex::{Array, ArrayDType, IntoArray};
+use vortex_dtype::match_each_unsigned_integer_ptype;
 use vortex_error::{vortex_err, VortexResult};
 use vortex_scalar::{PrimitiveScalar, Scalar};
-use zigzag::ZigZag as ExternalZigZag;
+use zigzag::{ZigZag as ExternalZigZag, ZigZag};
 
 use crate::ZigZagArray;
 
@@ -22,41 +22,21 @@ impl ScalarAtFn for ZigZagArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         let scalar = scalar_at_unchecked(&self.encoded(), index);
         if scalar.is_null() {
-            return Ok(scalar);
+            return Ok(scalar.reinterpret_cast(self.ptype()));
         }
 
         let pscalar = PrimitiveScalar::try_from(&scalar)?;
-        match pscalar.ptype() {
-            PType::U8 => Ok(i8::decode(pscalar.typed_value::<u8>().ok_or_else(|| {
-                vortex_err!(
-                    "Cannot decode provided scalar: expected u8, got ptype {}",
-                    pscalar.ptype()
-                )
-            })?)
-            .into()),
-            PType::U16 => Ok(i16::decode(pscalar.typed_value::<u16>().ok_or_else(|| {
-                vortex_err!(
-                    "Cannot decode provided scalar: expected u16, got ptype {}",
-                    pscalar.ptype()
-                )
-            })?)
-            .into()),
-            PType::U32 => Ok(i32::decode(pscalar.typed_value::<u32>().ok_or_else(|| {
-                vortex_err!(
-                    "Cannot decode provided scalar: expected u32, got ptype {}",
-                    pscalar.ptype()
-                )
-            })?)
-            .into()),
-            PType::U64 => Ok(i64::decode(pscalar.typed_value::<u64>().ok_or_else(|| {
-                vortex_err!(
-                    "Cannot decode provided scalar: expected u64, got ptype {}",
-                    pscalar.ptype()
-                )
-            })?)
-            .into()),
-            _ => unreachable!(),
-        }
+        match_each_unsigned_integer_ptype!(pscalar.ptype(), |$P| {
+            Ok(Scalar::primitive(
+                <<$P as ZigZagEncoded>::Int>::decode(pscalar.typed_value::<$P>().ok_or_else(|| {
+                    vortex_err!(
+                        "Cannot decode provided scalar: expected u8, got ptype {}",
+                        pscalar.ptype()
+                    )
+                })?),
+                self.dtype().nullability(),
+            ))
+        })
     }
 
     fn scalar_at_unchecked(&self, index: usize) -> Scalar {
@@ -64,8 +44,63 @@ impl ScalarAtFn for ZigZagArray {
     }
 }
 
+trait ZigZagEncoded {
+    type Int: ZigZag;
+}
+
+impl ZigZagEncoded for u8 {
+    type Int = i8;
+}
+
+impl ZigZagEncoded for u16 {
+    type Int = i16;
+}
+
+impl ZigZagEncoded for u32 {
+    type Int = i32;
+}
+
+impl ZigZagEncoded for u64 {
+    type Int = i64;
+}
+
 impl SliceFn for ZigZagArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         Ok(Self::try_new(slice(&self.encoded(), start, stop)?)?.into_array())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex::array::PrimitiveArray;
+    use vortex::compute::unary::scalar_at;
+    use vortex::compute::{search_sorted, SearchResult, SearchSortedSide};
+    use vortex::validity::Validity;
+    use vortex::IntoArray;
+    use vortex_dtype::Nullability;
+    use vortex_scalar::Scalar;
+
+    use crate::ZigZagArray;
+
+    #[test]
+    pub fn search_sorted_uncompressed() {
+        let zigzag =
+            ZigZagArray::encode(&PrimitiveArray::from(vec![-189, -160, 1]).into_array()).unwrap();
+        assert_eq!(
+            search_sorted(&zigzag, -169, SearchSortedSide::Right).unwrap(),
+            SearchResult::NotFound(1)
+        );
+    }
+
+    #[test]
+    pub fn nullable_scalar_at() {
+        let zigzag = ZigZagArray::encode(
+            &PrimitiveArray::from_vec(vec![-189, -160, 1], Validity::AllValid).into_array(),
+        )
+        .unwrap();
+        assert_eq!(
+            scalar_at(&zigzag, 1).unwrap(),
+            Scalar::primitive(-160, Nullability::Nullable)
+        );
     }
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,9 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = { workspace = true }
+num-traits = { workspace = true, features = [] }
 vortex-array = { workspace = true, features = ["arbitrary"] }
+vortex-buffer = { workspace = true }
 vortex-dtype = { workspace = true }
 vortex-error = { workspace = true }
 vortex-sampling-compressor = { workspace = true, features = ["arbitrary"] }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,6 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = { workspace = true }
-num-traits = { workspace = true, features = [] }
 vortex-array = { workspace = true, features = ["arbitrary"] }
 vortex-buffer = { workspace = true }
 vortex-dtype = { workspace = true }

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -18,7 +18,7 @@ fuzz_target!(|fuzz_action: FuzzArrayAction| -> Corpus {
     for (action, expected) in actions {
         match action {
             Action::Compress(c) => {
-                match fuzz_compress(&current_array.into_canonical().unwrap().into_array(), &c) {
+                match fuzz_compress(&current_array.into_canonical().unwrap().into(), &c) {
                     Some(compressed_array) => {
                         assert_array_eq(&expected.array(), &compressed_array);
                         current_array = compressed_array;

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -1,48 +1,61 @@
 #![no_main]
 
+use std::collections::HashSet;
+
 use libfuzzer_sys::{fuzz_target, Corpus};
+use vortex::array::{BoolEncoding, PrimitiveEncoding, VarBinEncoding, VarBinViewEncoding};
 use vortex::compute::unary::scalar_at;
-use vortex::compute::{search_sorted, slice, take, SearchResult, SearchSorted, SearchSortedSide};
-use vortex::encoding::EncodingId;
-use vortex::Array;
-use vortex_error::VortexResult;
-use vortex_fuzz::{Action, FuzzArrayAction};
+use vortex::compute::{search_sorted, slice, take, SearchResult, SearchSortedSide};
+use vortex::encoding::{EncodingId, EncodingRef};
+use vortex::{Array, IntoCanonical};
+use vortex_fuzz::{sort_canonical_array, Action, FuzzArrayAction};
 use vortex_sampling_compressor::SamplingCompressor;
 use vortex_scalar::{PValue, Scalar, ScalarValue};
 
 fuzz_target!(|fuzz_action: FuzzArrayAction| -> Corpus {
     let FuzzArrayAction { array, actions } = fuzz_action;
-    match &actions[0] {
-        Action::Compress(c) => match fuzz_compress(&array, c) {
-            Some(compressed_array) => {
-                assert_array_eq(&array, &compressed_array);
-                Corpus::Keep
+    let mut current_array = array.clone();
+    for (action, expected) in actions {
+        match action {
+            Action::Compress(c) => {
+                match fuzz_compress(&current_array.into_canonical().unwrap().into_array(), &c) {
+                    Some(compressed_array) => {
+                        assert_array_eq(&expected.array(), &compressed_array);
+                        current_array = compressed_array;
+                    }
+                    None => return Corpus::Reject,
+                }
             }
-            None => Corpus::Reject,
-        },
-        Action::Slice(range) => {
-            let slice = slice(&array, range.start, range.end).unwrap();
-            assert_slice(&array, &slice, range.start);
-            Corpus::Keep
-        }
-        Action::SearchSorted(s, side) => {
-            if !array_is_sorted(&array).unwrap() || s.is_null() {
-                return Corpus::Reject;
+            Action::Slice(range) => {
+                current_array = slice(&current_array, range.start, range.end).unwrap();
+                assert_array_eq(&expected.array(), &current_array);
             }
-
-            let search_result = search_sorted(&array, s.clone(), *side).unwrap();
-            assert_search_sorted(&array, s, *side, search_result);
-            Corpus::Keep
-        }
-        Action::Take(indices) => {
-            if indices.is_empty() {
-                return Corpus::Reject;
+            Action::Take(indices) => {
+                if indices.is_empty() {
+                    return Corpus::Reject;
+                }
+                current_array = take(&current_array, &indices).unwrap();
+                assert_array_eq(&expected.array(), &current_array);
             }
-            let taken = take(&array, indices).unwrap();
-            assert_take(&array, &taken, indices);
-            Corpus::Keep
+            Action::SearchSorted(s, side) => {
+                // TODO(robert): Ideally we'd preserve the encoding perfectly but this is close enough
+                let mut sorted = sort_canonical_array(&current_array);
+                if !HashSet::from([
+                    &PrimitiveEncoding as EncodingRef,
+                    &VarBinEncoding,
+                    &VarBinViewEncoding,
+                    &BoolEncoding,
+                ])
+                .contains(&current_array.encoding())
+                {
+                    sorted =
+                        fuzz_compress(&sorted, &SamplingCompressor::default()).unwrap_or(sorted);
+                }
+                assert_search_sorted(sorted, s, side, expected.search())
+            }
         }
     }
+    Corpus::Keep
 });
 
 fn fuzz_compress(array: &Array, compressor: &SamplingCompressor) -> Option<Array> {
@@ -54,39 +67,14 @@ fn fuzz_compress(array: &Array, compressor: &SamplingCompressor) -> Option<Array
         .then(|| compressed_array.into_array())
 }
 
-fn assert_search_sorted(
-    original: &Array,
-    value: &Scalar,
-    side: SearchSortedSide,
-    search_result: SearchResult,
-) {
-    let result = SearchSorted::search_sorted(original, value, side);
+fn assert_search_sorted(array: Array, s: Scalar, side: SearchSortedSide, expected: SearchResult) {
+    let search_result = search_sorted(&array, s.clone(), side).unwrap();
     assert_eq!(
-        result,
         search_result,
-        "Searching for {value} in {} from {side}",
-        original.encoding().id()
-    )
-}
-
-fn assert_take(original: &Array, taken: &Array, indices: &Array) {
-    assert_eq!(taken.len(), indices.len());
-    for idx in 0..indices.len() {
-        let to_take = usize::try_from(&scalar_at(indices, idx).unwrap()).unwrap();
-        let o = scalar_at(original, to_take).unwrap();
-        let s = scalar_at(taken, idx).unwrap();
-
-        fuzzing_scalar_cmp(o, s, original.encoding().id(), indices.encoding().id(), idx);
-    }
-}
-
-fn assert_slice(original: &Array, slice: &Array, start: usize) {
-    for idx in 0..slice.len() {
-        let o = scalar_at(original, start + idx).unwrap();
-        let s = scalar_at(slice, idx).unwrap();
-
-        fuzzing_scalar_cmp(o, s, original.encoding().id(), slice.encoding().id(), idx);
-    }
+        expected,
+        "Expected to find {s} at {expected} in ({}) but instead found it at {search_result}",
+        array.encoding().id()
+    );
 }
 
 fn assert_array_eq(lhs: &Array, rhs: &Array) {
@@ -125,20 +113,4 @@ fn fuzzing_scalar_cmp(
         "{l} != {r} at index {idx}, lhs is {lhs_encoding} rhs is {rhs_encoding}",
     );
     assert_eq!(l.is_valid(), r.is_valid());
-}
-
-fn array_is_sorted(array: &Array) -> VortexResult<bool> {
-    if array.is_empty() {
-        return Ok(true);
-    }
-
-    let mut last_value = scalar_at(array, 0)?;
-    for i in 1..array.len() {
-        let next_value = scalar_at(array, i)?;
-        if next_value < last_value {
-            return Ok(false);
-        }
-        last_value = next_value;
-    }
-    Ok(true)
 }

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,21 +1,50 @@
+use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::iter;
 use std::ops::Range;
 
 use libfuzzer_sys::arbitrary::Error::EmptyChoose;
 use libfuzzer_sys::arbitrary::{Arbitrary, Result, Unstructured};
-use vortex::array::PrimitiveArray;
+use vortex::accessor::ArrayAccessor;
+use vortex::array::{BoolArray, PrimitiveArray, VarBinArray};
 use vortex::compute::unary::scalar_at;
-use vortex::compute::SearchSortedSide;
-use vortex::{Array, ArrayDType};
+use vortex::compute::{IndexOrd, Len, SearchResult, SearchSorted, SearchSortedSide};
+use vortex::validity::{ArrayValidity, Validity};
+use vortex::{Array, ArrayDType, IntoArray, IntoArrayVariant};
+use vortex_buffer::{Buffer, BufferString};
+use vortex_dtype::{
+    match_each_float_ptype, match_each_integer_ptype, match_each_native_ptype, DType,
+};
 use vortex_sampling_compressor::SamplingCompressor;
 use vortex_scalar::arbitrary::random_scalar;
 use vortex_scalar::Scalar;
 
 #[derive(Debug)]
+pub enum ExpectedValue {
+    Array(Array),
+    Search(SearchResult),
+}
+
+impl ExpectedValue {
+    pub fn array(self) -> Array {
+        match self {
+            ExpectedValue::Array(array) => array,
+            _ => panic!("expected array"),
+        }
+    }
+
+    pub fn search(self) -> SearchResult {
+        match self {
+            ExpectedValue::Search(s) => s,
+            _ => panic!("expected search"),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct FuzzArrayAction {
     pub array: Array,
-    pub actions: Vec<Action>,
+    pub actions: Vec<(Action, ExpectedValue)>,
 }
 
 #[derive(Debug)]
@@ -29,55 +58,378 @@ pub enum Action {
 impl<'a> Arbitrary<'a> for FuzzArrayAction {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         let array = Array::arbitrary(u)?;
-        let len = array.len();
-        let action = match u.int_in_range(0..=3)? {
-            0 => Action::Compress(u.arbitrary()?),
-            1 => {
-                let start = u.choose_index(len)?;
-                let stop = u.int_in_range(start..=len)?;
-                Action::Slice(start..stop)
-            }
-            2 => {
-                if len == 0 {
-                    return Err(EmptyChoose);
+        let mut current_array = array.clone();
+        let mut actions = Vec::new();
+        for _ in 0..u.int_in_range(1..=4)? {
+            actions.push(match u.int_in_range(0..=3)? {
+                0 => {
+                    if actions
+                        .last()
+                        .map(|(l, _)| matches!(l, Action::Compress(_)))
+                        .unwrap_or(false)
+                    {
+                        continue;
+                    }
+                    (
+                        Action::Compress(u.arbitrary()?),
+                        ExpectedValue::Array(current_array.clone()),
+                    )
                 }
+                1 => {
+                    let start = u.choose_index(current_array.len())?;
+                    let stop = u.int_in_range(start..=current_array.len())?;
+                    current_array = slice_primitive_array(&current_array, start, stop);
 
-                let indices = PrimitiveArray::from(random_vec_in_range(u, 0, len - 1)?).into();
-                let compressed = SamplingCompressor::default()
-                    .compress(&indices, None)
-                    .unwrap();
-                Action::Take(compressed.into_array())
-            }
-            3 => {
-                let side = if u.arbitrary()? {
-                    SearchSortedSide::Left
-                } else {
-                    SearchSortedSide::Right
-                };
-                if u.arbitrary()? {
-                    let random_value_in_array = scalar_at(&array, u.choose_index(len)?).unwrap();
-                    Action::SearchSorted(random_value_in_array, side)
-                } else {
-                    Action::SearchSorted(random_scalar(u, array.dtype())?, side)
+                    (
+                        Action::Slice(start..stop),
+                        ExpectedValue::Array(current_array.clone()),
+                    )
                 }
-            }
-            _ => unreachable!(),
-        };
+                2 => {
+                    if current_array.is_empty() {
+                        return Err(EmptyChoose);
+                    }
 
-        Ok(Self {
-            array,
-            actions: vec![action],
-        })
+                    let indices = random_vec_in_range(u, 0, current_array.len() - 1)?;
+                    current_array = take_primitive_array(&current_array, &indices);
+                    let indices_array =
+                        PrimitiveArray::from(indices.iter().map(|i| *i as u64).collect::<Vec<_>>())
+                            .into();
+                    let compressed = SamplingCompressor::default()
+                        .compress(&indices_array, None)
+                        .unwrap();
+                    (
+                        Action::Take(compressed.into_array()),
+                        ExpectedValue::Array(current_array.clone()),
+                    )
+                }
+                3 => {
+                    let scalar = if u.arbitrary()? {
+                        scalar_at(&current_array, u.choose_index(current_array.len())?).unwrap()
+                    } else {
+                        random_scalar(u, current_array.dtype())?
+                    };
+
+                    if scalar.is_null() {
+                        return Err(EmptyChoose);
+                    }
+
+                    let sorted = sort_canonical_array(&current_array);
+
+                    let side = if u.arbitrary()? {
+                        SearchSortedSide::Left
+                    } else {
+                        SearchSortedSide::Right
+                    };
+                    (
+                        Action::SearchSorted(scalar.clone(), side),
+                        ExpectedValue::Search(search_values_in_primitive_array(
+                            &sorted, &scalar, side,
+                        )),
+                    )
+                }
+                _ => unreachable!(),
+            })
+        }
+
+        Ok(Self { array, actions })
     }
 }
 
-fn random_vec_in_range(u: &mut Unstructured<'_>, min: usize, max: usize) -> Result<Vec<u64>> {
+fn random_vec_in_range(u: &mut Unstructured<'_>, min: usize, max: usize) -> Result<Vec<usize>> {
     iter::from_fn(|| {
         if u.arbitrary().unwrap_or(false) {
-            Some(u.int_in_range(min..=max).map(|i| i as u64))
+            Some(u.int_in_range(min..=max))
         } else {
             None
         }
     })
     .collect::<Result<Vec<_>>>()
+}
+
+fn slice_primitive_array(array: &Array, start: usize, stop: usize) -> Array {
+    match array.dtype() {
+        DType::Bool(_) => {
+            let bool_array = array.clone().into_bool().unwrap();
+            let vec_values = bool_array.boolean_buffer().iter().collect::<Vec<_>>();
+            let vec_validity = bool_array
+                .logical_validity()
+                .into_array()
+                .into_bool()
+                .unwrap()
+                .boolean_buffer()
+                .iter()
+                .collect::<Vec<_>>();
+            BoolArray::from_vec(
+                Vec::from(&vec_values[start..stop]),
+                Validity::from(Vec::from(&vec_validity[start..stop])),
+            )
+            .into_array()
+        }
+        DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {
+            let primitive_array = array.clone().into_primitive().unwrap();
+            let vec_values = primitive_array
+                .maybe_null_slice::<$P>()
+                .iter()
+                .copied()
+                .collect::<Vec<_>>();
+            let vec_validity = primitive_array
+                .logical_validity()
+                .into_array()
+                .into_bool()
+                .unwrap()
+                .boolean_buffer()
+                .iter()
+                .collect::<Vec<_>>();
+            PrimitiveArray::from_vec(
+                Vec::from(&vec_values[start..stop]),
+                Validity::from(Vec::from(&vec_validity[start..stop])),
+            )
+            .into_array()
+        }),
+        DType::Utf8(_) | DType::Binary(_) => {
+            let utf8 = array.clone().into_varbin().unwrap();
+            let values = utf8
+                .with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())
+                .unwrap();
+            VarBinArray::from_iter(Vec::from(&values[start..stop]), array.dtype().clone())
+                .into_array()
+        }
+        _ => unreachable!("Array::arbitrary will not generate other dtypes"),
+    }
+}
+
+fn take_primitive_array(array: &Array, indices: &[usize]) -> Array {
+    match array.dtype() {
+        DType::Bool(_) => {
+            let bool_array = array.clone().into_bool().unwrap();
+            let vec_values = bool_array.boolean_buffer().iter().collect::<Vec<_>>();
+            let vec_validity = bool_array
+                .logical_validity()
+                .into_array()
+                .into_bool()
+                .unwrap()
+                .boolean_buffer()
+                .iter()
+                .collect::<Vec<_>>();
+            BoolArray::from_vec(
+                indices.iter().map(|i| vec_values[*i]).collect(),
+                Validity::from(indices.iter().map(|i| vec_validity[*i]).collect::<Vec<_>>()),
+            )
+            .into_array()
+        }
+        DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {
+            let primitive_array = array.clone().into_primitive().unwrap();
+            let vec_values = primitive_array
+                .maybe_null_slice::<$P>()
+                .iter()
+                .copied()
+                .collect::<Vec<_>>();
+            let vec_validity = primitive_array
+                .logical_validity()
+                .into_array()
+                .into_bool()
+                .unwrap()
+                .boolean_buffer()
+                .iter()
+                .collect::<Vec<_>>();
+            PrimitiveArray::from_vec(
+                indices.iter().map(|i| vec_values[*i]).collect(),
+                Validity::from(indices.iter().map(|i| vec_validity[*i]).collect::<Vec<_>>())
+            )
+            .into_array()
+        }),
+        DType::Utf8(_) | DType::Binary(_) => {
+            let utf8 = array.clone().into_varbin().unwrap();
+            let values = utf8
+                .with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())
+                .unwrap();
+            VarBinArray::from_iter(
+                indices.iter().map(|i| values[*i].clone()),
+                array.dtype().clone(),
+            )
+            .into_array()
+        }
+        _ => unreachable!("Array::arbitrary will not generate other dtypes"),
+    }
+}
+
+pub struct SearchNullableSlice<T>(Vec<Option<T>>);
+
+impl<T: PartialOrd> IndexOrd<Option<T>> for SearchNullableSlice<T> {
+    fn index_cmp(&self, idx: usize, elem: &Option<T>) -> Option<Ordering> {
+        match elem {
+            None => unreachable!("Can't search for None"),
+            Some(v) =>
+            // SAFETY: Used in search_sorted_by same as the standard library. The search_sorted ensures idx is in bounds
+            {
+                match unsafe { self.0.get_unchecked(idx) } {
+                    None => Some(Ordering::Greater),
+                    Some(i) => i.partial_cmp(v),
+                }
+            }
+        }
+    }
+}
+
+impl<T> Len for SearchNullableSlice<T> {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+fn search_values_in_primitive_array(
+    array: &Array,
+    scalar: &Scalar,
+    side: SearchSortedSide,
+) -> SearchResult {
+    match array.dtype() {
+        DType::Bool(_) => {
+            let bool_array = array.clone().into_bool().unwrap();
+            let opt_values = bool_array
+                .boolean_buffer()
+                .iter()
+                .zip(
+                    bool_array
+                        .logical_validity()
+                        .into_array()
+                        .into_bool()
+                        .unwrap()
+                        .boolean_buffer()
+                        .iter(),
+                )
+                .map(|(b, v)| v.then_some(b))
+                .collect::<Vec<_>>();
+            let to_find = scalar.try_into().unwrap();
+            SearchNullableSlice(opt_values).search_sorted(&Some(to_find), side)
+        }
+        DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {
+            let primitive_array = array.clone().into_primitive().unwrap();
+            let opt_values = primitive_array
+                .maybe_null_slice::<$P>()
+                .iter()
+                .copied()
+                .zip(
+                    primitive_array
+                        .logical_validity()
+                        .into_array()
+                        .into_bool()
+                        .unwrap()
+                        .boolean_buffer()
+                        .iter(),
+                )
+                            .map(|(b, v)| v.then_some(b))
+                .collect::<Vec<_>>();
+            let to_find: $P = scalar.try_into().unwrap();
+            SearchNullableSlice(opt_values).search_sorted(&Some(to_find), side)
+        }),
+        DType::Utf8(_) | DType::Binary(_) => {
+            let utf8 = array.clone().into_varbin().unwrap();
+            let opt_values = utf8
+                .with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())
+                .unwrap();
+            let to_find = if matches!(array.dtype(), DType::Utf8(_)) {
+                BufferString::try_from(scalar)
+                    .unwrap()
+                    .as_str()
+                    .as_bytes()
+                    .to_vec()
+            } else {
+                Buffer::try_from(scalar).unwrap().to_vec()
+            };
+            SearchNullableSlice(opt_values).search_sorted(&Some(to_find), side)
+        }
+        _ => unreachable!("Not a canonical array"),
+    }
+}
+
+pub fn sort_canonical_array(array: &Array) -> Array {
+    match array.dtype() {
+        DType::Bool(_) => {
+            let bool_array = array.clone().into_bool().unwrap();
+            let mut opt_values = bool_array
+                .boolean_buffer()
+                .iter()
+                .zip(
+                    bool_array
+                        .logical_validity()
+                        .into_array()
+                        .into_bool()
+                        .unwrap()
+                        .boolean_buffer()
+                        .iter(),
+                )
+                .map(|(b, v)| v.then_some(b))
+                .collect::<Vec<_>>();
+            sort_opt_slice(&mut opt_values);
+            BoolArray::from_iter(opt_values).into_array()
+        }
+        DType::Primitive(p, _) => {
+            let primitive_array = array.clone().into_primitive().unwrap();
+            if p.is_int() {
+                match_each_integer_ptype!(p, |$P| {
+                    let mut opt_values = primitive_array
+                        .maybe_null_slice::<$P>()
+                        .iter()
+                        .copied()
+                        .zip(
+                            primitive_array
+                                .logical_validity()
+                                .into_array()
+                                .into_bool()
+                                .unwrap()
+                                .boolean_buffer()
+                                .iter(),
+                        )
+                        .map(|(p, v)| v.then_some(p))
+                        .collect::<Vec<_>>();
+                    sort_opt_slice(&mut opt_values);
+                    PrimitiveArray::from_nullable_vec(opt_values).into_array()
+                })
+            } else {
+                match_each_float_ptype!(p, |$F| {
+                    let mut opt_values = primitive_array
+                        .maybe_null_slice::<$F>()
+                        .iter()
+                        .copied()
+                        .zip(
+                            primitive_array
+                                .logical_validity()
+                                .into_array()
+                                .into_bool()
+                                .unwrap()
+                                .boolean_buffer()
+                                .iter(),
+                        )
+                        .map(|(p, v)| v.then_some(p))
+                        .collect::<Vec<_>>();
+                    opt_values.sort_by(|a, b| match (a, b) {
+                        (Some(v), Some(w)) => v.to_bits().cmp(&w.to_bits()),
+                        (None, None) => Ordering::Equal,
+                        (None, Some(_)) => Ordering::Greater,
+                        (Some(_), None) => Ordering::Less,
+                    });
+                    PrimitiveArray::from_nullable_vec(opt_values).into_array()
+                })
+            }
+        }
+        DType::Utf8(_) | DType::Binary(_) => {
+            let utf8 = array.clone().into_varbin().unwrap();
+            let mut opt_values = utf8
+                .with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())
+                .unwrap();
+            sort_opt_slice(&mut opt_values);
+            VarBinArray::from_iter(opt_values, array.dtype().clone()).into_array()
+        }
+        _ => unreachable!("Not a canonical array"),
+    }
+}
+
+fn sort_opt_slice<T: Ord>(s: &mut [Option<T>]) {
+    s.sort_by(|a, b| match (a, b) {
+        (Some(v), Some(w)) => v.cmp(w),
+        (None, None) => Ordering::Equal,
+        (None, Some(_)) => Ordering::Greater,
+        (Some(_), None) => Ordering::Less,
+    });
 }

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -425,6 +425,7 @@ pub fn sort_canonical_array(array: &Array) -> Array {
     }
 }
 
+/// Reverse sorting of Option<T> such that None is last (Greatest)
 fn sort_opt_slice<T: Ord>(s: &mut [Option<T>]) {
     s.sort_by(|a, b| match (a, b) {
         (Some(v), Some(w)) => v.cmp(w),

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,23 +1,26 @@
-use std::cmp::Ordering;
+mod search_sorted;
+mod slice;
+mod sort;
+mod take;
+
 use std::fmt::Debug;
 use std::iter;
 use std::ops::Range;
 
 use libfuzzer_sys::arbitrary::Error::EmptyChoose;
 use libfuzzer_sys::arbitrary::{Arbitrary, Result, Unstructured};
-use vortex::accessor::ArrayAccessor;
-use vortex::array::{BoolArray, PrimitiveArray, VarBinArray};
+pub use sort::sort_canonical_array;
+use vortex::array::PrimitiveArray;
 use vortex::compute::unary::scalar_at;
-use vortex::compute::{IndexOrd, Len, SearchResult, SearchSorted, SearchSortedSide};
-use vortex::validity::{ArrayValidity, Validity};
-use vortex::{Array, ArrayDType, IntoArray, IntoArrayVariant};
-use vortex_buffer::{Buffer, BufferString};
-use vortex_dtype::{
-    match_each_float_ptype, match_each_integer_ptype, match_each_native_ptype, DType,
-};
+use vortex::compute::{SearchResult, SearchSortedSide};
+use vortex::{Array, ArrayDType};
 use vortex_sampling_compressor::SamplingCompressor;
 use vortex_scalar::arbitrary::random_scalar;
 use vortex_scalar::Scalar;
+
+use crate::search_sorted::search_sorted_canonical_array;
+use crate::slice::slice_canonical_array;
+use crate::take::take_canonical_array;
 
 #[derive(Debug)]
 pub enum ExpectedValue {
@@ -78,7 +81,7 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                 1 => {
                     let start = u.choose_index(current_array.len())?;
                     let stop = u.int_in_range(start..=current_array.len())?;
-                    current_array = slice_primitive_array(&current_array, start, stop);
+                    current_array = slice_canonical_array(&current_array, start, stop);
 
                     (
                         Action::Slice(start..stop),
@@ -91,7 +94,7 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                     }
 
                     let indices = random_vec_in_range(u, 0, current_array.len() - 1)?;
-                    current_array = take_primitive_array(&current_array, &indices);
+                    current_array = take_canonical_array(&current_array, &indices);
                     let indices_array =
                         PrimitiveArray::from(indices.iter().map(|i| *i as u64).collect::<Vec<_>>())
                             .into();
@@ -123,7 +126,7 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                     };
                     (
                         Action::SearchSorted(scalar.clone(), side),
-                        ExpectedValue::Search(search_values_in_primitive_array(
+                        ExpectedValue::Search(search_sorted_canonical_array(
                             &sorted, &scalar, side,
                         )),
                     )
@@ -145,292 +148,4 @@ fn random_vec_in_range(u: &mut Unstructured<'_>, min: usize, max: usize) -> Resu
         }
     })
     .collect::<Result<Vec<_>>>()
-}
-
-fn slice_primitive_array(array: &Array, start: usize, stop: usize) -> Array {
-    match array.dtype() {
-        DType::Bool(_) => {
-            let bool_array = array.clone().into_bool().unwrap();
-            let vec_values = bool_array.boolean_buffer().iter().collect::<Vec<_>>();
-            let vec_validity = bool_array
-                .logical_validity()
-                .into_array()
-                .into_bool()
-                .unwrap()
-                .boolean_buffer()
-                .iter()
-                .collect::<Vec<_>>();
-            BoolArray::from_vec(
-                Vec::from(&vec_values[start..stop]),
-                Validity::from(Vec::from(&vec_validity[start..stop])),
-            )
-            .into_array()
-        }
-        DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {
-            let primitive_array = array.clone().into_primitive().unwrap();
-            let vec_values = primitive_array
-                .maybe_null_slice::<$P>()
-                .iter()
-                .copied()
-                .collect::<Vec<_>>();
-            let vec_validity = primitive_array
-                .logical_validity()
-                .into_array()
-                .into_bool()
-                .unwrap()
-                .boolean_buffer()
-                .iter()
-                .collect::<Vec<_>>();
-            PrimitiveArray::from_vec(
-                Vec::from(&vec_values[start..stop]),
-                Validity::from(Vec::from(&vec_validity[start..stop])),
-            )
-            .into_array()
-        }),
-        DType::Utf8(_) | DType::Binary(_) => {
-            let utf8 = array.clone().into_varbin().unwrap();
-            let values = utf8
-                .with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())
-                .unwrap();
-            VarBinArray::from_iter(Vec::from(&values[start..stop]), array.dtype().clone())
-                .into_array()
-        }
-        _ => unreachable!("Array::arbitrary will not generate other dtypes"),
-    }
-}
-
-fn take_primitive_array(array: &Array, indices: &[usize]) -> Array {
-    match array.dtype() {
-        DType::Bool(_) => {
-            let bool_array = array.clone().into_bool().unwrap();
-            let vec_values = bool_array.boolean_buffer().iter().collect::<Vec<_>>();
-            let vec_validity = bool_array
-                .logical_validity()
-                .into_array()
-                .into_bool()
-                .unwrap()
-                .boolean_buffer()
-                .iter()
-                .collect::<Vec<_>>();
-            BoolArray::from_vec(
-                indices.iter().map(|i| vec_values[*i]).collect(),
-                Validity::from(indices.iter().map(|i| vec_validity[*i]).collect::<Vec<_>>()),
-            )
-            .into_array()
-        }
-        DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {
-            let primitive_array = array.clone().into_primitive().unwrap();
-            let vec_values = primitive_array
-                .maybe_null_slice::<$P>()
-                .iter()
-                .copied()
-                .collect::<Vec<_>>();
-            let vec_validity = primitive_array
-                .logical_validity()
-                .into_array()
-                .into_bool()
-                .unwrap()
-                .boolean_buffer()
-                .iter()
-                .collect::<Vec<_>>();
-            PrimitiveArray::from_vec(
-                indices.iter().map(|i| vec_values[*i]).collect(),
-                Validity::from(indices.iter().map(|i| vec_validity[*i]).collect::<Vec<_>>())
-            )
-            .into_array()
-        }),
-        DType::Utf8(_) | DType::Binary(_) => {
-            let utf8 = array.clone().into_varbin().unwrap();
-            let values = utf8
-                .with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())
-                .unwrap();
-            VarBinArray::from_iter(
-                indices.iter().map(|i| values[*i].clone()),
-                array.dtype().clone(),
-            )
-            .into_array()
-        }
-        _ => unreachable!("Array::arbitrary will not generate other dtypes"),
-    }
-}
-
-pub struct SearchNullableSlice<T>(Vec<Option<T>>);
-
-impl<T: PartialOrd> IndexOrd<Option<T>> for SearchNullableSlice<T> {
-    fn index_cmp(&self, idx: usize, elem: &Option<T>) -> Option<Ordering> {
-        match elem {
-            None => unreachable!("Can't search for None"),
-            Some(v) =>
-            // SAFETY: Used in search_sorted_by same as the standard library. The search_sorted ensures idx is in bounds
-            {
-                match unsafe { self.0.get_unchecked(idx) } {
-                    None => Some(Ordering::Greater),
-                    Some(i) => i.partial_cmp(v),
-                }
-            }
-        }
-    }
-}
-
-impl<T> Len for SearchNullableSlice<T> {
-    fn len(&self) -> usize {
-        self.0.len()
-    }
-}
-
-fn search_values_in_primitive_array(
-    array: &Array,
-    scalar: &Scalar,
-    side: SearchSortedSide,
-) -> SearchResult {
-    match array.dtype() {
-        DType::Bool(_) => {
-            let bool_array = array.clone().into_bool().unwrap();
-            let opt_values = bool_array
-                .boolean_buffer()
-                .iter()
-                .zip(
-                    bool_array
-                        .logical_validity()
-                        .into_array()
-                        .into_bool()
-                        .unwrap()
-                        .boolean_buffer()
-                        .iter(),
-                )
-                .map(|(b, v)| v.then_some(b))
-                .collect::<Vec<_>>();
-            let to_find = scalar.try_into().unwrap();
-            SearchNullableSlice(opt_values).search_sorted(&Some(to_find), side)
-        }
-        DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {
-            let primitive_array = array.clone().into_primitive().unwrap();
-            let opt_values = primitive_array
-                .maybe_null_slice::<$P>()
-                .iter()
-                .copied()
-                .zip(
-                    primitive_array
-                        .logical_validity()
-                        .into_array()
-                        .into_bool()
-                        .unwrap()
-                        .boolean_buffer()
-                        .iter(),
-                )
-                            .map(|(b, v)| v.then_some(b))
-                .collect::<Vec<_>>();
-            let to_find: $P = scalar.try_into().unwrap();
-            SearchNullableSlice(opt_values).search_sorted(&Some(to_find), side)
-        }),
-        DType::Utf8(_) | DType::Binary(_) => {
-            let utf8 = array.clone().into_varbin().unwrap();
-            let opt_values = utf8
-                .with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())
-                .unwrap();
-            let to_find = if matches!(array.dtype(), DType::Utf8(_)) {
-                BufferString::try_from(scalar)
-                    .unwrap()
-                    .as_str()
-                    .as_bytes()
-                    .to_vec()
-            } else {
-                Buffer::try_from(scalar).unwrap().to_vec()
-            };
-            SearchNullableSlice(opt_values).search_sorted(&Some(to_find), side)
-        }
-        _ => unreachable!("Not a canonical array"),
-    }
-}
-
-pub fn sort_canonical_array(array: &Array) -> Array {
-    match array.dtype() {
-        DType::Bool(_) => {
-            let bool_array = array.clone().into_bool().unwrap();
-            let mut opt_values = bool_array
-                .boolean_buffer()
-                .iter()
-                .zip(
-                    bool_array
-                        .logical_validity()
-                        .into_array()
-                        .into_bool()
-                        .unwrap()
-                        .boolean_buffer()
-                        .iter(),
-                )
-                .map(|(b, v)| v.then_some(b))
-                .collect::<Vec<_>>();
-            sort_opt_slice(&mut opt_values);
-            BoolArray::from_iter(opt_values).into_array()
-        }
-        DType::Primitive(p, _) => {
-            let primitive_array = array.clone().into_primitive().unwrap();
-            if p.is_int() {
-                match_each_integer_ptype!(p, |$P| {
-                    let mut opt_values = primitive_array
-                        .maybe_null_slice::<$P>()
-                        .iter()
-                        .copied()
-                        .zip(
-                            primitive_array
-                                .logical_validity()
-                                .into_array()
-                                .into_bool()
-                                .unwrap()
-                                .boolean_buffer()
-                                .iter(),
-                        )
-                        .map(|(p, v)| v.then_some(p))
-                        .collect::<Vec<_>>();
-                    sort_opt_slice(&mut opt_values);
-                    PrimitiveArray::from_nullable_vec(opt_values).into_array()
-                })
-            } else {
-                match_each_float_ptype!(p, |$F| {
-                    let mut opt_values = primitive_array
-                        .maybe_null_slice::<$F>()
-                        .iter()
-                        .copied()
-                        .zip(
-                            primitive_array
-                                .logical_validity()
-                                .into_array()
-                                .into_bool()
-                                .unwrap()
-                                .boolean_buffer()
-                                .iter(),
-                        )
-                        .map(|(p, v)| v.then_some(p))
-                        .collect::<Vec<_>>();
-                    opt_values.sort_by(|a, b| match (a, b) {
-                        (Some(v), Some(w)) => v.to_bits().cmp(&w.to_bits()),
-                        (None, None) => Ordering::Equal,
-                        (None, Some(_)) => Ordering::Greater,
-                        (Some(_), None) => Ordering::Less,
-                    });
-                    PrimitiveArray::from_nullable_vec(opt_values).into_array()
-                })
-            }
-        }
-        DType::Utf8(_) | DType::Binary(_) => {
-            let utf8 = array.clone().into_varbin().unwrap();
-            let mut opt_values = utf8
-                .with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())
-                .unwrap();
-            sort_opt_slice(&mut opt_values);
-            VarBinArray::from_iter(opt_values, array.dtype().clone()).into_array()
-        }
-        _ => unreachable!("Not a canonical array"),
-    }
-}
-
-/// Reverse sorting of Option<T> such that None is last (Greatest)
-fn sort_opt_slice<T: Ord>(s: &mut [Option<T>]) {
-    s.sort_by(|a, b| match (a, b) {
-        (Some(v), Some(w)) => v.cmp(w),
-        (None, None) => Ordering::Equal,
-        (None, Some(_)) => Ordering::Greater,
-        (Some(_), None) => Ordering::Less,
-    });
 }

--- a/fuzz/src/search_sorted.rs
+++ b/fuzz/src/search_sorted.rs
@@ -1,0 +1,98 @@
+use std::cmp::Ordering;
+
+use vortex::accessor::ArrayAccessor;
+use vortex::compute::{IndexOrd, Len, SearchResult, SearchSorted, SearchSortedSide};
+use vortex::validity::ArrayValidity;
+use vortex::{Array, ArrayDType, IntoArray, IntoArrayVariant};
+use vortex_buffer::{Buffer, BufferString};
+use vortex_dtype::{match_each_native_ptype, DType};
+use vortex_scalar::Scalar;
+
+struct SearchNullableSlice<T>(Vec<Option<T>>);
+
+impl<T: PartialOrd> IndexOrd<Option<T>> for SearchNullableSlice<T> {
+    fn index_cmp(&self, idx: usize, elem: &Option<T>) -> Option<Ordering> {
+        match elem {
+            None => unreachable!("Can't search for None"),
+            Some(v) =>
+            // SAFETY: Used in search_sorted_by same as the standard library. The search_sorted ensures idx is in bounds
+            {
+                match unsafe { self.0.get_unchecked(idx) } {
+                    None => Some(Ordering::Greater),
+                    Some(i) => i.partial_cmp(v),
+                }
+            }
+        }
+    }
+}
+
+impl<T> Len for SearchNullableSlice<T> {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn search_sorted_canonical_array(
+    array: &Array,
+    scalar: &Scalar,
+    side: SearchSortedSide,
+) -> SearchResult {
+    match array.dtype() {
+        DType::Bool(_) => {
+            let bool_array = array.clone().into_bool().unwrap();
+            let opt_values = bool_array
+                .boolean_buffer()
+                .iter()
+                .zip(
+                    bool_array
+                        .logical_validity()
+                        .into_array()
+                        .into_bool()
+                        .unwrap()
+                        .boolean_buffer()
+                        .iter(),
+                )
+                .map(|(b, v)| v.then_some(b))
+                .collect::<Vec<_>>();
+            let to_find = scalar.try_into().unwrap();
+            SearchNullableSlice(opt_values).search_sorted(&Some(to_find), side)
+        }
+        DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {
+            let primitive_array = array.clone().into_primitive().unwrap();
+            let opt_values = primitive_array
+                .maybe_null_slice::<$P>()
+                .iter()
+                .copied()
+                .zip(
+                    primitive_array
+                        .logical_validity()
+                        .into_array()
+                        .into_bool()
+                        .unwrap()
+                        .boolean_buffer()
+                        .iter(),
+                )
+                            .map(|(b, v)| v.then_some(b))
+                .collect::<Vec<_>>();
+            let to_find: $P = scalar.try_into().unwrap();
+            SearchNullableSlice(opt_values).search_sorted(&Some(to_find), side)
+        }),
+        DType::Utf8(_) | DType::Binary(_) => {
+            let utf8 = array.clone().into_varbin().unwrap();
+            let opt_values = utf8
+                .with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())
+                .unwrap();
+            let to_find = if matches!(array.dtype(), DType::Utf8(_)) {
+                BufferString::try_from(scalar)
+                    .unwrap()
+                    .as_str()
+                    .as_bytes()
+                    .to_vec()
+            } else {
+                Buffer::try_from(scalar).unwrap().to_vec()
+            };
+            SearchNullableSlice(opt_values).search_sorted(&Some(to_find), side)
+        }
+        _ => unreachable!("Not a canonical array"),
+    }
+}

--- a/fuzz/src/slice.rs
+++ b/fuzz/src/slice.rs
@@ -1,0 +1,57 @@
+use vortex::accessor::ArrayAccessor;
+use vortex::array::{BoolArray, PrimitiveArray, VarBinArray};
+use vortex::validity::{ArrayValidity, Validity};
+use vortex::{Array, ArrayDType, IntoArray, IntoArrayVariant};
+use vortex_dtype::{match_each_native_ptype, DType};
+
+pub fn slice_canonical_array(array: &Array, start: usize, stop: usize) -> Array {
+    match array.dtype() {
+        DType::Bool(_) => {
+            let bool_array = array.clone().into_bool().unwrap();
+            let vec_values = bool_array.boolean_buffer().iter().collect::<Vec<_>>();
+            let vec_validity = bool_array
+                .logical_validity()
+                .into_array()
+                .into_bool()
+                .unwrap()
+                .boolean_buffer()
+                .iter()
+                .collect::<Vec<_>>();
+            BoolArray::from_vec(
+                Vec::from(&vec_values[start..stop]),
+                Validity::from(Vec::from(&vec_validity[start..stop])),
+            )
+            .into_array()
+        }
+        DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {
+            let primitive_array = array.clone().into_primitive().unwrap();
+            let vec_values = primitive_array
+                .maybe_null_slice::<$P>()
+                .iter()
+                .copied()
+                .collect::<Vec<_>>();
+            let vec_validity = primitive_array
+                .logical_validity()
+                .into_array()
+                .into_bool()
+                .unwrap()
+                .boolean_buffer()
+                .iter()
+                .collect::<Vec<_>>();
+            PrimitiveArray::from_vec(
+                Vec::from(&vec_values[start..stop]),
+                Validity::from(Vec::from(&vec_validity[start..stop])),
+            )
+            .into_array()
+        }),
+        DType::Utf8(_) | DType::Binary(_) => {
+            let utf8 = array.clone().into_varbin().unwrap();
+            let values = utf8
+                .with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())
+                .unwrap();
+            VarBinArray::from_iter(Vec::from(&values[start..stop]), array.dtype().clone())
+                .into_array()
+        }
+        _ => unreachable!("Array::arbitrary will not generate other dtypes"),
+    }
+}

--- a/fuzz/src/sort.rs
+++ b/fuzz/src/sort.rs
@@ -1,0 +1,99 @@
+use std::cmp::Ordering;
+
+use vortex::accessor::ArrayAccessor;
+use vortex::array::{BoolArray, PrimitiveArray, VarBinArray};
+use vortex::validity::ArrayValidity;
+use vortex::{Array, ArrayDType, IntoArray, IntoArrayVariant};
+use vortex_dtype::{match_each_float_ptype, match_each_integer_ptype, DType};
+
+pub fn sort_canonical_array(array: &Array) -> Array {
+    match array.dtype() {
+        DType::Bool(_) => {
+            let bool_array = array.clone().into_bool().unwrap();
+            let mut opt_values = bool_array
+                .boolean_buffer()
+                .iter()
+                .zip(
+                    bool_array
+                        .logical_validity()
+                        .into_array()
+                        .into_bool()
+                        .unwrap()
+                        .boolean_buffer()
+                        .iter(),
+                )
+                .map(|(b, v)| v.then_some(b))
+                .collect::<Vec<_>>();
+            sort_opt_slice(&mut opt_values);
+            BoolArray::from_iter(opt_values).into_array()
+        }
+        DType::Primitive(p, _) => {
+            let primitive_array = array.clone().into_primitive().unwrap();
+            if p.is_int() {
+                match_each_integer_ptype!(p, |$P| {
+                    let mut opt_values = primitive_array
+                        .maybe_null_slice::<$P>()
+                        .iter()
+                        .copied()
+                        .zip(
+                            primitive_array
+                                .logical_validity()
+                                .into_array()
+                                .into_bool()
+                                .unwrap()
+                                .boolean_buffer()
+                                .iter(),
+                        )
+                        .map(|(p, v)| v.then_some(p))
+                        .collect::<Vec<_>>();
+                    sort_opt_slice(&mut opt_values);
+                    PrimitiveArray::from_nullable_vec(opt_values).into_array()
+                })
+            } else {
+                match_each_float_ptype!(p, |$F| {
+                    let mut opt_values = primitive_array
+                        .maybe_null_slice::<$F>()
+                        .iter()
+                        .copied()
+                        .zip(
+                            primitive_array
+                                .logical_validity()
+                                .into_array()
+                                .into_bool()
+                                .unwrap()
+                                .boolean_buffer()
+                                .iter(),
+                        )
+                        .map(|(p, v)| v.then_some(p))
+                        .collect::<Vec<_>>();
+                    opt_values.sort_by(|a, b| match (a, b) {
+                        (Some(v), Some(w)) => v.to_bits().cmp(&w.to_bits()),
+                        (None, None) => Ordering::Equal,
+                        (None, Some(_)) => Ordering::Greater,
+                        (Some(_), None) => Ordering::Less,
+                    });
+                    PrimitiveArray::from_nullable_vec(opt_values).into_array()
+                })
+            }
+        }
+        DType::Utf8(_) | DType::Binary(_) => {
+            let utf8 = array.clone().into_varbin().unwrap();
+            let mut opt_values = utf8
+                .with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())
+                .unwrap();
+            sort_opt_slice(&mut opt_values);
+            VarBinArray::from_iter(opt_values, array.dtype().clone()).into_array()
+        }
+        _ => unreachable!("Not a canonical array"),
+    }
+}
+
+/// Reverse sorting of Option<T> such that None is last (Greatest)
+fn sort_opt_slice<T: Ord>(s: &mut [Option<T>]) {
+    s.sort_by(|a, b| match (a, b) {
+        (Some(v), Some(w)) => v.cmp(w),
+        (None, None) => Ordering::Equal,
+        (None, Some(_)) => Ordering::Greater,
+        (Some(_), None) => Ordering::Less,
+    });
+}

--- a/fuzz/src/take.rs
+++ b/fuzz/src/take.rs
@@ -1,0 +1,60 @@
+use vortex::accessor::ArrayAccessor;
+use vortex::array::{BoolArray, PrimitiveArray, VarBinArray};
+use vortex::validity::{ArrayValidity, Validity};
+use vortex::{Array, ArrayDType, IntoArray, IntoArrayVariant};
+use vortex_dtype::{match_each_native_ptype, DType};
+
+pub fn take_canonical_array(array: &Array, indices: &[usize]) -> Array {
+    match array.dtype() {
+        DType::Bool(_) => {
+            let bool_array = array.clone().into_bool().unwrap();
+            let vec_values = bool_array.boolean_buffer().iter().collect::<Vec<_>>();
+            let vec_validity = bool_array
+                .logical_validity()
+                .into_array()
+                .into_bool()
+                .unwrap()
+                .boolean_buffer()
+                .iter()
+                .collect::<Vec<_>>();
+            BoolArray::from_vec(
+                indices.iter().map(|i| vec_values[*i]).collect(),
+                Validity::from(indices.iter().map(|i| vec_validity[*i]).collect::<Vec<_>>()),
+            )
+            .into_array()
+        }
+        DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {
+            let primitive_array = array.clone().into_primitive().unwrap();
+            let vec_values = primitive_array
+                .maybe_null_slice::<$P>()
+                .iter()
+                .copied()
+                .collect::<Vec<_>>();
+            let vec_validity = primitive_array
+                .logical_validity()
+                .into_array()
+                .into_bool()
+                .unwrap()
+                .boolean_buffer()
+                .iter()
+                .collect::<Vec<_>>();
+            PrimitiveArray::from_vec(
+                indices.iter().map(|i| vec_values[*i]).collect(),
+                Validity::from(indices.iter().map(|i| vec_validity[*i]).collect::<Vec<_>>())
+            )
+            .into_array()
+        }),
+        DType::Utf8(_) | DType::Binary(_) => {
+            let utf8 = array.clone().into_varbin().unwrap();
+            let values = utf8
+                .with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())
+                .unwrap();
+            VarBinArray::from_iter(
+                indices.iter().map(|i| values[*i].clone()),
+                array.dtype().clone(),
+            )
+            .into_array()
+        }
+        _ => unreachable!("Array::arbitrary will not generate other dtypes"),
+    }
+}

--- a/vortex-array/src/array/primitive/compute/subtract_scalar.rs
+++ b/vortex-array/src/array/primitive/compute/subtract_scalar.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use num_traits::WrappingSub;
 use vortex_dtype::{match_each_float_ptype, match_each_integer_ptype, NativePType};
-use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
+use vortex_error::{vortex_bail, vortex_err, VortexResult};
 use vortex_scalar::{PrimitiveScalar, Scalar};
 
 use crate::array::constant::ConstantArray;
@@ -45,10 +45,7 @@ impl SubtractScalarFn for PrimitiveArray {
     }
 }
 
-fn subtract_scalar_integer<
-    'a,
-    T: NativePType + WrappingSub + for<'b> TryFrom<&'b Scalar, Error = VortexError>,
->(
+fn subtract_scalar_integer<T: NativePType + WrappingSub>(
     subtract_from: &PrimitiveArray,
     to_subtract: T,
 ) -> VortexResult<PrimitiveArray> {

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -89,6 +89,18 @@ impl Canonical {
             }
         }
     }
+
+    /// Unwrap Canonical Array back into a regular Array
+    pub fn into_array(self) -> Array {
+        match self {
+            Canonical::Null(a) => a.into_array(),
+            Canonical::Bool(a) => a.into_array(),
+            Canonical::Primitive(a) => a.into_array(),
+            Canonical::Struct(a) => a.into_array(),
+            Canonical::VarBin(a) => a.into_array(),
+            Canonical::Extension(a) => a.into_array(),
+        }
+    }
 }
 
 // Unwrap canonical type back down to specialized type.

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -89,18 +89,6 @@ impl Canonical {
             }
         }
     }
-
-    /// Unwrap Canonical Array back into a regular Array
-    pub fn into_array(self) -> Array {
-        match self {
-            Canonical::Null(a) => a.into_array(),
-            Canonical::Bool(a) => a.into_array(),
-            Canonical::Primitive(a) => a.into_array(),
-            Canonical::Struct(a) => a.into_array(),
-            Canonical::VarBin(a) => a.into_array(),
-            Canonical::Extension(a) => a.into_array(),
-        }
-    }
 }
 
 // Unwrap canonical type back down to specialized type.

--- a/vortex-array/src/compute/search_sorted.rs
+++ b/vortex-array/src/compute/search_sorted.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 use std::cmp::Ordering::{Equal, Greater, Less};
-use std::fmt::{Display, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 
 use vortex_error::{vortex_bail, VortexResult};
 use vortex_scalar::Scalar;
@@ -41,6 +41,15 @@ impl SearchResult {
         match self {
             Self::Found(i) => i,
             Self::NotFound(i) => i,
+        }
+    }
+}
+
+impl Display for SearchResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SearchResult::Found(i) => write!(f, "Found({i})"),
+            SearchResult::NotFound(i) => write!(f, "NotFound({i})"),
         }
     }
 }
@@ -204,7 +213,7 @@ impl IndexOrd<Scalar> for Array {
     }
 }
 
-impl<T: PartialOrd> IndexOrd<T> for [T] {
+impl<T: PartialOrd + Debug> IndexOrd<T> for [T] {
     fn index_cmp(&self, idx: usize, elem: &T) -> Option<Ordering> {
         // SAFETY: Used in search_sorted_by same as the standard library. The search_sorted ensures idx is in bounds
         unsafe { self.get_unchecked(idx) }.partial_cmp(elem)

--- a/vortex-array/src/compute/search_sorted.rs
+++ b/vortex-array/src/compute/search_sorted.rs
@@ -213,7 +213,7 @@ impl IndexOrd<Scalar> for Array {
     }
 }
 
-impl<T: PartialOrd + Debug> IndexOrd<T> for [T] {
+impl<T: PartialOrd> IndexOrd<T> for [T] {
     fn index_cmp(&self, idx: usize, elem: &T) -> Option<Ordering> {
         // SAFETY: Used in search_sorted_by same as the standard library. The search_sorted ensures idx is in bounds
         unsafe { self.get_unchecked(idx) }.partial_cmp(elem)

--- a/vortex-sampling-compressor/src/arbitrary.rs
+++ b/vortex-sampling-compressor/src/arbitrary.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use arbitrary::Error::EmptyChoose;
 use arbitrary::{Arbitrary, Result, Unstructured};
 
 use crate::compressors::{CompressorRef, EncodingCompressor};
@@ -8,6 +9,9 @@ use crate::{SamplingCompressor, ALL_COMPRESSORS};
 impl<'a, 'b: 'a> Arbitrary<'a> for SamplingCompressor<'b> {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         let compressors: HashSet<CompressorRef> = u.arbitrary()?;
+        if compressors.is_empty() {
+            return Err(EmptyChoose);
+        }
         Ok(Self::new(compressors))
     }
 }

--- a/vortex-sampling-compressor/src/compressors/zigzag.rs
+++ b/vortex-sampling-compressor/src/compressors/zigzag.rs
@@ -46,11 +46,11 @@ impl EncodingCompressor for ZigZagCompressor {
         like: Option<CompressionTree<'a>>,
         ctx: SamplingCompressor<'a>,
     ) -> VortexResult<CompressedArray<'a>> {
-        let encoded = zigzag_encode(&array.as_primitive())?;
+        let encoded = zigzag_encode(PrimitiveArray::try_from(array)?)?;
         let compressed =
             ctx.compress(&encoded.encoded(), like.as_ref().and_then(|l| l.child(0)))?;
         Ok(CompressedArray::new(
-            ZigZagArray::new(compressed.array).into_array(),
+            ZigZagArray::try_new(compressed.array)?.into_array(),
             Some(CompressionTree::new(self, vec![compressed.path])),
         ))
     }

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -103,7 +103,7 @@ impl PartialEq for Scalar {
 
 impl PartialOrd for Scalar {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        if self.dtype() == other.dtype() {
+        if self.dtype().eq_ignore_nullability(other.dtype()) {
             self.value.partial_cmp(&other.value)
         } else {
             None


### PR DESCRIPTION
Includes fixes for
- ZigZagArray scalar_at returns wrong nullability
- RunEndArray slice wrongly slicing validity
- Scalar comparison is nullability invariant