### PR TITLE
implement FilterFn for SparseArray

### DIFF
--- a/vortex-array/src/array/sparse/compute/mod.rs
+++ b/vortex-array/src/array/sparse/compute/mod.rs
@@ -95,7 +95,7 @@ impl FilterFn for SparseArray {
             for (value_idx, coordinate) in indices.enumerate() {
                 if buffer.value(coordinate) {
                     // We count the number of truthy values between this coordinate and the previous truthy one
-                    let adjusted_coordinate = buffer.slice(last_inserted_index, coordinate).count_set_bits() as u64;
+                    let adjusted_coordinate = buffer.slice(last_inserted_index, coordinate - last_inserted_index).count_set_bits() as u64;
                     coordinate_indices.push(adjusted_coordinate);
                     last_inserted_index = coordinate;
 

--- a/vortex-array/src/array/sparse/compute/mod.rs
+++ b/vortex-array/src/array/sparse/compute/mod.rs
@@ -79,8 +79,8 @@ impl FilterFn for SparseArray {
     fn filter(&self, predicate: &Array) -> VortexResult<Array> {
         let predicate = predicate.clone().into_bool()?;
         let buffer = predicate.boolean_buffer();
-        let mut array_indices = Vec::new();
-        let mut indexes = Vec::new();
+        let mut coordinate_indices = Vec::new();
+        let mut value_indices = Vec::new();
 
         let flat_indices = self
             .indices()
@@ -91,17 +91,17 @@ impl FilterFn for SparseArray {
                 .maybe_null_slice::<$P>()
                 .iter()
                 .map(|v| (*v as usize) - self.indices_offset());
-            for (idx, sparse_idx) in indices.enumerate() {
-                if buffer.value(sparse_idx) {
-                    array_indices.push(sparse_idx as u64);
-                    indexes.push(idx as u64);
+            for (value_idx, coordinate) in indices.enumerate() {
+                if buffer.value(coordinate) {
+                    coordinate_indices.push(coordinate as u64);
+                    value_indices.push(value_idx as u64);
                 }
             }
         });
 
         Ok(SparseArray::try_new(
-            PrimitiveArray::from(array_indices).into_array(),
-            take(&self.values(), PrimitiveArray::from(indexes).array())?,
+            PrimitiveArray::from(coordinate_indices).into_array(),
+            take(&self.values(), PrimitiveArray::from(value_indices).array())?,
             self.len(),
             self.fill_value().clone(),
         )?

--- a/vortex-array/src/array/sparse/compute/mod.rs
+++ b/vortex-array/src/array/sparse/compute/mod.rs
@@ -77,8 +77,7 @@ impl SearchSortedFn for SparseArray {
 
 impl FilterFn for SparseArray {
     fn filter(&self, predicate: &Array) -> VortexResult<Array> {
-        let predicate = predicate.clone().into_bool()?;
-        let buffer = predicate.boolean_buffer();
+        let buffer = predicate.clone().into_bool()?.boolean_buffer();
         let mut coordinate_indices: Vec<u64> = Vec::new();
         let mut value_indices = Vec::new();
         let mut last_inserted_index = 0;
@@ -98,7 +97,6 @@ impl FilterFn for SparseArray {
                     let adjusted_coordinate = buffer.slice(last_inserted_index, coordinate - last_inserted_index).count_set_bits() as u64;
                     coordinate_indices.push(adjusted_coordinate + coordinate_indices.last().copied().unwrap_or_default());
                     last_inserted_index = coordinate;
-
                     value_indices.push(value_idx as u64);
                 }
             }

--- a/vortex-array/src/array/sparse/compute/mod.rs
+++ b/vortex-array/src/array/sparse/compute/mod.rs
@@ -208,7 +208,7 @@ mod test {
     }
 
     #[test]
-    fn whiteboard_test_case() {
+    fn true_fill_value() {
         let predicate = BoolArray::from_vec(
             vec![false, true, false, true, false, true, true],
             Validity::NonNullable,


### PR DESCRIPTION
Introduces `FilterFn` implementation for `SparseArray`. @robert3005 and I ran into some [flake](https://github.com/spiraldb/vortex/actions/runs/10833498279/job/30060436243?pr=797) in ALP/slicing that changed the underlying encoding due to canonicalization, so this change should take care of that.