### PR TITLE
Define consistent float ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4523,6 +4523,7 @@ version = "0.0.0"
 dependencies = [
  "arrow-buffer",
  "libfuzzer-sys",
+ "num-traits",
  "vortex-array",
  "vortex-buffer",
  "vortex-dtype",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,6 +11,7 @@ cargo-fuzz = true
 [dependencies]
 arrow-buffer = { workspace = true }
 libfuzzer-sys = { workspace = true }
+num-traits = { workspace = true }
 vortex-array = { workspace = true, features = ["arbitrary"] }
 vortex-buffer = { workspace = true }
 vortex-dtype = { workspace = true, features = ["arbitrary"] }

--- a/fuzz/src/search_sorted.rs
+++ b/fuzz/src/search_sorted.rs
@@ -6,7 +6,7 @@ use vortex::compute::{IndexOrd, Len, SearchResult, SearchSorted, SearchSortedSid
 use vortex::validity::ArrayValidity;
 use vortex::{Array, ArrayDType, IntoArray, IntoArrayVariant};
 use vortex_buffer::{Buffer, BufferString};
-use vortex_dtype::{match_each_native_ptype, DType};
+use vortex_dtype::{match_each_native_ptype, DType, NativePType};
 use vortex_scalar::Scalar;
 
 struct SearchNullableSlice<T>(Vec<Option<T>>);
@@ -27,6 +27,29 @@ impl<T: PartialOrd> IndexOrd<Option<T>> for SearchNullableSlice<T> {
 }
 
 impl<T> Len for SearchNullableSlice<T> {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+struct SearchPrimitiveSlice<T>(Vec<Option<T>>);
+
+impl<T: NativePType> IndexOrd<Option<T>> for SearchPrimitiveSlice<T> {
+    fn index_cmp(&self, idx: usize, elem: &Option<T>) -> Option<Ordering> {
+        match elem {
+            None => unreachable!("Can't search for None"),
+            Some(v) => {
+                // SAFETY: Used in search_sorted_by same as the standard library. The search_sorted ensures idx is in bounds
+                match unsafe { self.0.get_unchecked(idx) } {
+                    None => Some(Ordering::Greater),
+                    Some(i) => Some(i.compare(*v)),
+                }
+            }
+        }
+    }
+}
+
+impl<T> Len for SearchPrimitiveSlice<T> {
     fn len(&self) -> usize {
         self.0.len()
     }
@@ -55,7 +78,7 @@ pub fn search_sorted_canonical_array(
             let to_find = scalar.try_into().unwrap();
             SearchNullableSlice(opt_values).search_sorted(&Some(to_find), side)
         }
-        DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {
+        DType::Primitive(p, _) => {
             let primitive_array = array.clone().into_primitive().unwrap();
             let validity = primitive_array
                 .logical_validity()
@@ -63,16 +86,18 @@ pub fn search_sorted_canonical_array(
                 .into_bool()
                 .unwrap()
                 .boolean_buffer();
-            let opt_values = primitive_array
-                .maybe_null_slice::<$P>()
-                .iter()
-                .copied()
-                .zip(validity.iter())
-                .map(|(b, v)| v.then_some(b))
-                .collect::<Vec<_>>();
-            let to_find: $P = scalar.try_into().unwrap();
-            SearchNullableSlice(opt_values).search_sorted(&Some(to_find), side)
-        }),
+            match_each_native_ptype!(p, |$P| {
+                let opt_values = primitive_array
+                    .maybe_null_slice::<$P>()
+                    .iter()
+                    .copied()
+                    .zip(validity.iter())
+                    .map(|(b, v)| v.then_some(b))
+                    .collect::<Vec<_>>();
+                let to_find: $P = scalar.try_into().unwrap();
+                SearchPrimitiveSlice(opt_values).search_sorted(&Some(to_find), side)
+            })
+        }
         DType::Utf8(_) | DType::Binary(_) => {
             let utf8 = array.clone().into_varbin().unwrap();
             let opt_values = utf8

--- a/fuzz/src/sort.rs
+++ b/fuzz/src/sort.rs
@@ -5,7 +5,7 @@ use vortex::array::{BoolArray, PrimitiveArray, VarBinArray};
 use vortex::compute::unary::scalar_at;
 use vortex::validity::ArrayValidity;
 use vortex::{Array, ArrayDType, IntoArray, IntoArrayVariant};
-use vortex_dtype::{match_each_float_ptype, match_each_integer_ptype, DType};
+use vortex_dtype::{match_each_native_ptype, DType, NativePType};
 
 use crate::take::take_canonical_array;
 
@@ -32,52 +32,25 @@ pub fn sort_canonical_array(array: &Array) -> Array {
         }
         DType::Primitive(p, _) => {
             let primitive_array = array.clone().into_primitive().unwrap();
-            if p.is_int() {
-                match_each_integer_ptype!(p, |$P| {
-                    let mut opt_values = primitive_array
-                        .maybe_null_slice::<$P>()
-                        .iter()
-                        .copied()
-                        .zip(
-                            primitive_array
-                                .logical_validity()
-                                .into_array()
-                                .into_bool()
-                                .unwrap()
-                                .boolean_buffer()
-                                .iter(),
-                        )
-                        .map(|(p, v)| v.then_some(p))
-                        .collect::<Vec<_>>();
-                    sort_opt_slice(&mut opt_values);
-                    PrimitiveArray::from_nullable_vec(opt_values).into_array()
-                })
-            } else {
-                match_each_float_ptype!(p, |$F| {
-                    let mut opt_values = primitive_array
-                        .maybe_null_slice::<$F>()
-                        .iter()
-                        .copied()
-                        .zip(
-                            primitive_array
-                                .logical_validity()
-                                .into_array()
-                                .into_bool()
-                                .unwrap()
-                                .boolean_buffer()
-                                .iter(),
-                        )
-                        .map(|(p, v)| v.then_some(p))
-                        .collect::<Vec<_>>();
-                    opt_values.sort_by(|a, b| match (a, b) {
-                        (Some(v), Some(w)) => v.to_bits().cmp(&w.to_bits()),
-                        (None, None) => Ordering::Equal,
-                        (None, Some(_)) => Ordering::Greater,
-                        (Some(_), None) => Ordering::Less,
-                    });
-                    PrimitiveArray::from_nullable_vec(opt_values).into_array()
-                })
-            }
+            match_each_native_ptype!(p, |$P| {
+                let mut opt_values = primitive_array
+                    .maybe_null_slice::<$P>()
+                    .iter()
+                    .copied()
+                    .zip(
+                        primitive_array
+                            .logical_validity()
+                            .into_array()
+                            .into_bool()
+                            .unwrap()
+                            .boolean_buffer()
+                            .iter(),
+                    )
+                    .map(|(p, v)| v.then_some(p))
+                    .collect::<Vec<_>>();
+                sort_primitive_slice(&mut opt_values);
+                PrimitiveArray::from_nullable_vec(opt_values).into_array()
+            })
         }
         DType::Utf8(_) | DType::Binary(_) => {
             let utf8 = array.clone().into_varbin().unwrap();
@@ -99,6 +72,15 @@ pub fn sort_canonical_array(array: &Array) -> Array {
         }
         _ => unreachable!("Not a canonical array"),
     }
+}
+
+fn sort_primitive_slice<T: NativePType>(s: &mut [Option<T>]) {
+    s.sort_by(|a, b| match (a, b) {
+        (Some(v), Some(w)) => v.compare(*w),
+        (None, None) => Ordering::Equal,
+        (None, Some(_)) => Ordering::Greater,
+        (Some(_), None) => Ordering::Less,
+    });
 }
 
 /// Reverse sorting of Option<T> such that None is last (Greatest)

--- a/vortex-array/src/array/primitive/mod.rs
+++ b/vortex-array/src/array/primitive/mod.rs
@@ -197,13 +197,13 @@ impl<T: NativePType> Accessor<T> for PrimitiveArray {
         ArrayValidity::is_valid(self, index)
     }
 
-    fn array_validity(&self) -> Validity {
-        self.validity()
-    }
-
     #[inline]
     fn value_unchecked(&self, index: usize) -> T {
         self.maybe_null_slice::<T>()[index]
+    }
+
+    fn array_validity(&self) -> Validity {
+        self.validity()
     }
 
     #[inline]

--- a/vortex-array/src/array/primitive/stats.rs
+++ b/vortex-array/src/array/primitive/stats.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::mem::size_of;
 
@@ -189,7 +190,7 @@ impl<T: PStatsType> StatsAccumulator<T> {
             self.nan_count += 1;
         }
 
-        if self.prev == next {
+        if next.is_eq(self.prev) {
             self.is_strict_sorted = false;
         } else {
             if next < self.prev {
@@ -197,9 +198,9 @@ impl<T: PStatsType> StatsAccumulator<T> {
             }
             self.run_count += 1;
         }
-        if next < self.min {
+        if matches!(next.compare(self.min), Ordering::Less) {
             self.min = next;
-        } else if next > self.max {
+        } else if matches!(next.compare(self.max), Ordering::Greater) {
             self.max = next;
         }
         self.prev = next;
@@ -207,8 +208,7 @@ impl<T: PStatsType> StatsAccumulator<T> {
 
     pub fn finish(self) -> StatsSet {
         let is_constant = (self.min == self.max && self.null_count == 0 && self.nan_count == 0)
-            || self.null_count == self.len
-            || self.nan_count == self.len;
+            || self.null_count == self.len;
 
         StatsSet::from(HashMap::from([
             (Stat::Min, self.min.into()),

--- a/vortex-array/src/array/primitive/stats.rs
+++ b/vortex-array/src/array/primitive/stats.rs
@@ -193,7 +193,7 @@ impl<T: PStatsType> StatsAccumulator<T> {
         if next.is_eq(self.prev) {
             self.is_strict_sorted = false;
         } else {
-            if next < self.prev {
+            if matches!(next.compare(self.prev), Ordering::Less) {
                 self.is_sorted = false;
             }
             self.run_count += 1;

--- a/vortex-dtype/src/ptype.rs
+++ b/vortex-dtype/src/ptype.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
 use std::panic::RefUnwindSafe;
@@ -30,7 +31,6 @@ pub enum PType {
 pub trait NativePType:
     Send
     + Sync
-    + Sized
     + Clone
     + Copy
     + Debug
@@ -48,6 +48,10 @@ pub trait NativePType:
     const PTYPE: PType;
 
     fn is_nan(self) -> bool;
+
+    fn compare(self, other: Self) -> Ordering;
+
+    fn is_eq(self, other: Self) -> bool;
 }
 
 macro_rules! native_ptype {
@@ -57,6 +61,14 @@ macro_rules! native_ptype {
 
             fn is_nan(self) -> bool {
                 false
+            }
+
+            fn compare(self, other: Self) -> Ordering {
+                self.cmp(&other)
+            }
+
+            fn is_eq(self, other: Self) -> bool {
+                self == other
             }
         }
     };
@@ -69,6 +81,14 @@ macro_rules! native_float_ptype {
 
             fn is_nan(self) -> bool {
                 <$T>::is_nan(self)
+            }
+
+            fn compare(self, other: Self) -> Ordering {
+                self.total_cmp(&other)
+            }
+
+            fn is_eq(self, other: Self) -> bool {
+                self.to_bits() == other.to_bits()
             }
         }
     };

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -74,12 +74,15 @@ impl Scalar {
     }
 
     pub fn cast(&self, dtype: &DType) -> VortexResult<Self> {
-        if self.dtype() == dtype {
-            return Ok(self.clone());
-        }
-
         if self.is_null() && !dtype.is_nullable() {
             vortex_bail!("Can't cast null scalar to non-nullable type")
+        }
+
+        if self.dtype().eq_ignore_nullability(dtype) {
+            return Ok(Scalar {
+                dtype: dtype.clone(),
+                value: self.value.clone(),
+            });
         }
 
         match dtype {

--- a/vortex-scalar/src/pvalue.rs
+++ b/vortex-scalar/src/pvalue.rs
@@ -5,7 +5,7 @@ use std::mem;
 use num_traits::NumCast;
 use paste::paste;
 use vortex_dtype::half::f16;
-use vortex_dtype::PType;
+use vortex_dtype::{NativePType, PType};
 use vortex_error::{vortex_err, VortexError};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -26,17 +26,17 @@ pub enum PValue {
 impl PartialOrd for PValue {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match (self, other) {
-            (Self::U8(s), Self::U8(o)) => s.partial_cmp(o),
-            (Self::U16(s), Self::U16(o)) => s.partial_cmp(o),
-            (Self::U32(s), Self::U32(o)) => s.partial_cmp(o),
-            (Self::U64(s), Self::U64(o)) => s.partial_cmp(o),
-            (Self::I8(s), Self::I8(o)) => s.partial_cmp(o),
-            (Self::I16(s), Self::I16(o)) => s.partial_cmp(o),
-            (Self::I32(s), Self::I32(o)) => s.partial_cmp(o),
-            (Self::I64(s), Self::I64(o)) => s.partial_cmp(o),
-            (Self::F16(s), Self::F16(o)) => Some(s.total_cmp(o)),
-            (Self::F32(s), Self::F32(o)) => Some(s.total_cmp(o)),
-            (Self::F64(s), Self::F64(o)) => Some(s.total_cmp(o)),
+            (Self::U8(s), Self::U8(o)) => Some(s.compare(*o)),
+            (Self::U16(s), Self::U16(o)) => Some(s.compare(*o)),
+            (Self::U32(s), Self::U32(o)) => Some(s.compare(*o)),
+            (Self::U64(s), Self::U64(o)) => Some(s.compare(*o)),
+            (Self::I8(s), Self::I8(o)) => Some(s.compare(*o)),
+            (Self::I16(s), Self::I16(o)) => Some(s.compare(*o)),
+            (Self::I32(s), Self::I32(o)) => Some(s.compare(*o)),
+            (Self::I64(s), Self::I64(o)) => Some(s.compare(*o)),
+            (Self::F16(s), Self::F16(o)) => Some(s.compare(*o)),
+            (Self::F32(s), Self::F32(o)) => Some(s.compare(*o)),
+            (Self::F64(s), Self::F64(o)) => Some(s.compare(*o)),
             (..) => None,
         }
     }


### PR DESCRIPTION
We use total_cmp instead of partial_cmp to compare floating point numbers and use bit patern to determine float equality