### PR TITLE
feat: cache decompressed run-ends in TakeFn impl

### DIFF
--- a/encodings/runend/src/runend.rs
+++ b/encodings/runend/src/runend.rs
@@ -78,12 +78,6 @@ impl RunEndArray {
         Self::try_from_parts(dtype, length, metadata, children.into(), StatsSet::new())
     }
 
-    /// Convert the given logical index to an index into the `values` array
-    pub fn find_physical_index(&self, index: usize) -> VortexResult<usize> {
-        search_sorted(&self.ends(), index + self.offset(), SearchSortedSide::Right)
-            .map(|s| s.to_ends_index(self.ends().len()))
-    }
-
     /// Run the array through run-end encoding.
     pub fn encode(array: Array) -> VortexResult<Self> {
         if let Ok(parray) = PrimitiveArray::try_from(array) {
@@ -129,6 +123,16 @@ impl RunEndArray {
             .child(1, self.dtype(), self.metadata().num_runs)
             .vortex_expect("RunEndArray is missing its values")
     }
+}
+
+/// Convert the given logical index to an index into the `values` array
+pub(crate) fn find_physical_index(
+    ends: &Array,
+    index: usize,
+    offset: usize,
+) -> VortexResult<usize> {
+    search_sorted(ends, index + offset, SearchSortedSide::Right)
+        .map(|s| s.to_ends_index(ends.len()))
 }
 
 impl ArrayTrait for RunEndArray {}


### PR DESCRIPTION
Q4 time for vortex-file-compressed is currently dominated by executing `filter_indices` in the filter pushdown phase.

This in turn is spend most of its time uncompressing REE ends repeatedly for every index we're taking.

This PR decompresses to PrimitiveArray and caches so we don't pay the decompression overhead. The next step (not in this PR) is to specialize search_sorted for primitives to avoid the scalar conversion overhead.

Locally, leads to ~50% reduction of timing:

```
tpch_q4/vortex-file-compressed
                        time:   [471.18 ms 472.98 ms 475.23 ms]
                        change: [-53.433% -52.857% -52.310%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
```

Part of of #803 