### PR TITLE
Simplify/idiomize the way arrays return `&Array`

### DIFF
--- a/encodings/alp/src/array.rs
+++ b/encodings/alp/src/array.rs
@@ -82,7 +82,7 @@ impl ALPArray {
     }
 
     pub fn encoded(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(0, &self.metadata().encoded_dtype, self.len())
             .vortex_expect("Missing encoded child in ALPArray")
     }
@@ -94,7 +94,7 @@ impl ALPArray {
 
     pub fn patches(&self) -> Option<Array> {
         self.metadata().patches_dtype.as_ref().map(|dt| {
-            self.array().child(1, dt, self.len()).unwrap_or_else(|| {
+            self.as_ref().child(1, dt, self.len()).unwrap_or_else(|| {
                 vortex_panic!(
                     "Missing patches with present metadata flag; patches dtype: {}, patches_len: {}",
                     dt,

--- a/encodings/alp/src/compress.rs
+++ b/encodings/alp/src/compress.rs
@@ -110,7 +110,6 @@ mod tests {
     use core::f64;
 
     use vortex::compute::unary::scalar_at;
-    use vortex::AsArray;
 
     use super::*;
 
@@ -182,11 +181,11 @@ mod tests {
         assert_eq!(encoded.exponents(), Exponents { e: 3, f: 0 });
 
         for idx in 0..3 {
-            let s = scalar_at(encoded.as_array_ref(), idx).unwrap();
+            let s = scalar_at(encoded.as_ref(), idx).unwrap();
             assert!(s.is_valid());
         }
 
-        let s = scalar_at(encoded.as_array_ref(), 4).unwrap();
+        let s = scalar_at(encoded.as_ref(), 4).unwrap();
         assert!(s.is_null());
 
         let _decoded = decompress(encoded).unwrap();

--- a/encodings/alp/src/compute.rs
+++ b/encodings/alp/src/compute.rs
@@ -134,12 +134,12 @@ where
     match encoded {
         Ok(encoded) => {
             let s = ConstantArray::new(encoded, alp.len());
-            compare(&alp.encoded(), s.array(), operator)
+            compare(&alp.encoded(), s.as_ref(), operator)
         }
         Err(exception) => {
             if let Some(patches) = alp.patches().as_ref() {
                 let s = ConstantArray::new(exception, alp.len());
-                compare(patches, s.array(), operator)
+                compare(patches, s.as_ref(), operator)
             } else {
                 Ok(BoolArray::from_vec(vec![false; alp.len()], Validity::AllValid).into_array())
             }
@@ -212,7 +212,7 @@ mod tests {
         );
 
         let r = encoded
-            .maybe_compare(other.array(), Operator::Eq)
+            .maybe_compare(other.as_ref(), Operator::Eq)
             .unwrap()
             .unwrap()
             .into_bool()

--- a/encodings/bytebool/src/compute/mod.rs
+++ b/encodings/bytebool/src/compute/mod.rs
@@ -136,7 +136,6 @@ impl FillForwardFn for ByteBoolArray {
 mod tests {
     use vortex::compute::unary::{scalar_at, scalar_at_unchecked};
     use vortex::compute::{compare, slice, Operator};
-    use vortex::AsArray as _;
     use vortex_scalar::ScalarValue;
 
     use super::*;
@@ -146,18 +145,18 @@ mod tests {
         let original = vec![Some(true), Some(true), None, Some(false), None];
         let vortex_arr = ByteBoolArray::from(original.clone());
 
-        let sliced_arr = slice(vortex_arr.as_array_ref(), 1, 4).unwrap();
+        let sliced_arr = slice(vortex_arr.as_ref(), 1, 4).unwrap();
         let sliced_arr = ByteBoolArray::try_from(sliced_arr).unwrap();
 
-        let s = scalar_at_unchecked(sliced_arr.as_array_ref(), 0);
+        let s = scalar_at_unchecked(sliced_arr.as_ref(), 0);
         assert_eq!(s.into_value().as_bool().unwrap(), Some(true));
 
-        let s = scalar_at(sliced_arr.as_array_ref(), 1).unwrap();
+        let s = scalar_at(sliced_arr.as_ref(), 1).unwrap();
         assert!(!sliced_arr.is_valid(1));
         assert!(s.is_null());
         assert_eq!(s.into_value().as_bool().unwrap(), None);
 
-        let s = scalar_at_unchecked(sliced_arr.as_array_ref(), 2);
+        let s = scalar_at_unchecked(sliced_arr.as_ref(), 2);
         assert_eq!(s.into_value().as_bool().unwrap(), Some(false));
     }
 
@@ -166,10 +165,10 @@ mod tests {
         let lhs = ByteBoolArray::from(vec![true; 5]);
         let rhs = ByteBoolArray::from(vec![true; 5]);
 
-        let arr = compare(lhs.as_array_ref(), rhs.as_array_ref(), Operator::Eq).unwrap();
+        let arr = compare(lhs.as_ref(), rhs.as_ref(), Operator::Eq).unwrap();
 
         for i in 0..arr.len() {
-            let s = scalar_at_unchecked(arr.as_array_ref(), i);
+            let s = scalar_at_unchecked(arr.as_ref(), i);
             assert!(s.is_valid());
             assert_eq!(s.value(), &ScalarValue::Bool(true));
         }
@@ -180,7 +179,7 @@ mod tests {
         let lhs = ByteBoolArray::from(vec![false; 5]);
         let rhs = ByteBoolArray::from(vec![true; 5]);
 
-        let arr = compare(lhs.as_array_ref(), rhs.as_array_ref(), Operator::Eq).unwrap();
+        let arr = compare(lhs.as_ref(), rhs.as_ref(), Operator::Eq).unwrap();
 
         for i in 0..arr.len() {
             let s = scalar_at(&arr, i).unwrap();
@@ -194,7 +193,7 @@ mod tests {
         let lhs = ByteBoolArray::from(vec![true; 5]);
         let rhs = ByteBoolArray::from(vec![Some(true), Some(true), Some(true), Some(false), None]);
 
-        let arr = compare(lhs.as_array_ref(), rhs.as_array_ref(), Operator::Eq).unwrap();
+        let arr = compare(lhs.as_ref(), rhs.as_ref(), Operator::Eq).unwrap();
 
         for i in 0..3 {
             let s = scalar_at(&arr, i).unwrap();

--- a/encodings/bytebool/src/lib.rs
+++ b/encodings/bytebool/src/lib.rs
@@ -27,7 +27,7 @@ impl ByteBoolArray {
     pub fn validity(&self) -> Validity {
         self.metadata()
             .validity
-            .to_validity(self.array().child(0, &Validity::DTYPE, self.len()))
+            .to_validity(self.as_ref().child(0, &Validity::DTYPE, self.len()))
     }
 
     pub fn try_new(buffer: Buffer, validity: Validity) -> VortexResult<Self> {
@@ -64,7 +64,7 @@ impl ByteBoolArray {
     }
 
     pub fn buffer(&self) -> &Buffer {
-        self.array()
+        self.as_ref()
             .buffer()
             .vortex_expect("ByteBoolArray is missing the underlying buffer")
     }

--- a/encodings/bytebool/src/stats.rs
+++ b/encodings/bytebool/src/stats.rs
@@ -1,5 +1,5 @@
 use vortex::stats::{ArrayStatisticsCompute, Stat, StatsSet};
-use vortex::{AsArray, IntoArrayVariant};
+use vortex::IntoArrayVariant;
 use vortex_error::VortexResult;
 
 use super::ByteBoolArray;
@@ -11,7 +11,7 @@ impl ArrayStatisticsCompute for ByteBoolArray {
         }
 
         // TODO(adamgs): This is slightly wasteful and could be optimized in the future
-        let bools = self.as_array_ref().clone().into_bool()?;
+        let bools = self.as_ref().clone().into_bool()?;
         bools.compute_statistics(stat)
     }
 }

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -66,19 +66,19 @@ impl DateTimePartsArray {
     }
 
     pub fn days(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(0, &self.metadata().days_dtype, self.len())
             .vortex_expect("DatetimePartsArray missing days array")
     }
 
     pub fn seconds(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(1, &self.metadata().seconds_dtype, self.len())
             .vortex_expect("DatetimePartsArray missing seconds array")
     }
 
     pub fn subsecond(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(2, &self.metadata().subseconds_dtype, self.len())
             .vortex_expect("DatetimePartsArray missing subsecond array")
     }

--- a/encodings/dict/src/dict.rs
+++ b/encodings/dict/src/dict.rs
@@ -42,14 +42,14 @@ impl DictArray {
 
     #[inline]
     pub fn values(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(0, self.dtype(), self.metadata().values_len)
             .vortex_expect("DictArray is missing its values child array")
     }
 
     #[inline]
     pub fn codes(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(1, &self.metadata().codes_dtype, self.len())
             .vortex_expect("DictArray is missing its codes child array")
     }

--- a/encodings/fastlanes/benches/bitpacking_take.rs
+++ b/encodings/fastlanes/benches/bitpacking_take.rs
@@ -19,19 +19,19 @@ fn bench_take(c: &mut Criterion) {
     let uncompressed = PrimitiveArray::from(values.clone());
 
     let packed = BitPackedArray::encode(
-        uncompressed.array(),
+        uncompressed.as_ref(),
         find_best_bit_width(&uncompressed).unwrap(),
     )
     .unwrap();
 
     let stratified_indices: PrimitiveArray = (0..10).map(|i| i * 10_000).collect::<Vec<_>>().into();
     c.bench_function("take_10_stratified", |b| {
-        b.iter(|| black_box(take(packed.array(), stratified_indices.array()).unwrap()));
+        b.iter(|| black_box(take(packed.as_ref(), stratified_indices.as_ref()).unwrap()));
     });
 
     let contiguous_indices: PrimitiveArray = (0..10).collect::<Vec<_>>().into();
     c.bench_function("take_10_contiguous", |b| {
-        b.iter(|| black_box(take(packed.array(), contiguous_indices.array()).unwrap()));
+        b.iter(|| black_box(take(packed.as_ref(), contiguous_indices.as_ref()).unwrap()));
     });
 
     let rng = thread_rng();
@@ -43,12 +43,12 @@ fn bench_take(c: &mut Criterion) {
         .collect_vec()
         .into();
     c.bench_function("take_10K_random", |b| {
-        b.iter(|| black_box(take(packed.array(), random_indices.array()).unwrap()));
+        b.iter(|| black_box(take(packed.as_ref(), random_indices.as_ref()).unwrap()));
     });
 
     let contiguous_indices: PrimitiveArray = (0..10_000).collect::<Vec<_>>().into();
     c.bench_function("take_10K_contiguous", |b| {
-        b.iter(|| black_box(take(packed.array(), contiguous_indices.array()).unwrap()));
+        b.iter(|| black_box(take(packed.as_ref(), contiguous_indices.as_ref()).unwrap()));
     });
 }
 
@@ -59,7 +59,7 @@ fn bench_patched_take(c: &mut Criterion) {
 
     let uncompressed = PrimitiveArray::from(values.clone());
     let packed = BitPackedArray::encode(
-        uncompressed.array(),
+        uncompressed.as_ref(),
         find_best_bit_width(&uncompressed).unwrap(),
     )
     .unwrap();
@@ -74,12 +74,12 @@ fn bench_patched_take(c: &mut Criterion) {
 
     let stratified_indices: PrimitiveArray = (0..10).map(|i| i * 10_000).collect::<Vec<_>>().into();
     c.bench_function("patched_take_10_stratified", |b| {
-        b.iter(|| black_box(take(packed.array(), stratified_indices.array()).unwrap()));
+        b.iter(|| black_box(take(packed.as_ref(), stratified_indices.as_ref()).unwrap()));
     });
 
     let contiguous_indices: PrimitiveArray = (0..10).collect::<Vec<_>>().into();
     c.bench_function("patched_take_10_contiguous", |b| {
-        b.iter(|| black_box(take(packed.array(), contiguous_indices.array()).unwrap()));
+        b.iter(|| black_box(take(packed.as_ref(), contiguous_indices.as_ref()).unwrap()));
     });
 
     let rng = thread_rng();
@@ -91,7 +91,7 @@ fn bench_patched_take(c: &mut Criterion) {
         .collect_vec()
         .into();
     c.bench_function("patched_take_10K_random", |b| {
-        b.iter(|| black_box(take(packed.array(), random_indices.array()).unwrap()));
+        b.iter(|| black_box(take(packed.as_ref(), random_indices.as_ref()).unwrap()));
     });
 
     let not_patch_indices: PrimitiveArray = (0u32..num_exceptions)
@@ -100,7 +100,7 @@ fn bench_patched_take(c: &mut Criterion) {
         .collect_vec()
         .into();
     c.bench_function("patched_take_10K_contiguous_not_patches", |b| {
-        b.iter(|| black_box(take(packed.array(), not_patch_indices.array()).unwrap()));
+        b.iter(|| black_box(take(packed.as_ref(), not_patch_indices.as_ref()).unwrap()));
     });
 
     let patch_indices: PrimitiveArray = (big_base2..big_base2 + num_exceptions)
@@ -109,7 +109,7 @@ fn bench_patched_take(c: &mut Criterion) {
         .collect_vec()
         .into();
     c.bench_function("patched_take_10K_contiguous_patches", |b| {
-        b.iter(|| black_box(take(packed.array(), patch_indices.array()).unwrap()));
+        b.iter(|| black_box(take(packed.as_ref(), patch_indices.as_ref()).unwrap()));
     });
 
     // There are currently 2 magic parameters of note:
@@ -133,7 +133,7 @@ fn bench_patched_take(c: &mut Criterion) {
         .collect_vec()
         .into();
     c.bench_function("patched_take_10K_adversarial", |b| {
-        b.iter(|| black_box(take(packed.array(), adversarial_indices.array()).unwrap()));
+        b.iter(|| black_box(take(packed.as_ref(), adversarial_indices.as_ref()).unwrap()));
     });
 }
 

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -333,7 +333,7 @@ mod test {
         let valid_values = (0..24).map(|v| v < 1 << 4).collect::<Vec<_>>();
         let values =
             PrimitiveArray::from_vec((0..24).collect::<Vec<_>>(), Validity::from(valid_values));
-        let compressed = BitPackedArray::encode(values.array(), 4).unwrap();
+        let compressed = BitPackedArray::encode(values.as_ref(), 4).unwrap();
         assert!(compressed.patches().is_none());
         assert_eq!(
             (0..(1 << 4)).collect::<Vec<_>>(),
@@ -363,7 +363,7 @@ mod test {
 
     fn compression_roundtrip(n: usize) {
         let values = PrimitiveArray::from((0..n).map(|i| (i % 2047) as u16).collect::<Vec<_>>());
-        let compressed = BitPackedArray::encode(values.array(), 11).unwrap();
+        let compressed = BitPackedArray::encode(values.as_ref(), 11).unwrap();
         let decompressed = compressed.to_array().into_primitive().unwrap();
         assert_eq!(
             decompressed.maybe_null_slice::<u16>(),

--- a/encodings/fastlanes/src/bitpacking/compute/slice.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/slice.rs
@@ -58,7 +58,10 @@ mod test {
         .unwrap()
         .into_array();
         let sliced = BitPackedArray::try_from(slice(&arr, 1024, 2048).unwrap()).unwrap();
-        assert_eq!(scalar_at(sliced.as_ref(), 0).unwrap(), (1024u32 % 64).into());
+        assert_eq!(
+            scalar_at(sliced.as_ref(), 0).unwrap(),
+            (1024u32 % 64).into()
+        );
         assert_eq!(
             scalar_at(sliced.as_ref(), 1023).unwrap(),
             (2047u32 % 64).into()

--- a/encodings/fastlanes/src/bitpacking/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/mod.rs
@@ -113,7 +113,7 @@ impl BitPackedArray {
 
     #[inline]
     pub fn packed(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(
                 0,
                 &self.dtype().with_nullability(Nullability::NonNullable),
@@ -136,7 +136,7 @@ impl BitPackedArray {
         self.metadata()
             .has_patches
             .then(|| {
-                self.array().child(
+                self.as_ref().child(
                     1,
                     &self.dtype().with_nullability(Nullability::Nullable),
                     self.len(),
@@ -153,7 +153,7 @@ impl BitPackedArray {
     pub fn validity(&self) -> Validity {
         let validity_child_idx = if self.metadata().has_patches { 2 } else { 1 };
 
-        self.metadata().validity.to_validity(self.array().child(
+        self.metadata().validity.to_validity(self.as_ref().child(
             validity_child_idx,
             &Validity::DTYPE,
             self.len(),
@@ -240,7 +240,7 @@ mod test {
     fn test_encode() {
         let values = vec![Some(1), None, Some(1), None, Some(1), None, Some(u64::MAX)];
         let uncompressed = PrimitiveArray::from_nullable_vec(values);
-        let packed = BitPackedArray::encode(uncompressed.array(), 1).unwrap();
+        let packed = BitPackedArray::encode(uncompressed.as_ref(), 1).unwrap();
         let expected = &[1, 0, 1, 0, 1, 0, u64::MAX];
         let results = packed
             .into_array()
@@ -255,9 +255,9 @@ mod test {
     fn test_encode_too_wide() {
         let values = vec![Some(1u8), None, Some(1), None, Some(1), None];
         let uncompressed = PrimitiveArray::from_nullable_vec(values);
-        let _packed = BitPackedArray::encode(uncompressed.array(), 8)
+        let _packed = BitPackedArray::encode(uncompressed.as_ref(), 8)
             .expect_err("Cannot pack value into the same width");
-        let _packed = BitPackedArray::encode(uncompressed.array(), 9)
+        let _packed = BitPackedArray::encode(uncompressed.as_ref(), 9)
             .expect_err("Cannot pack value into larger width");
     }
 }

--- a/encodings/fastlanes/src/delta/compress.rs
+++ b/encodings/fastlanes/src/delta/compress.rs
@@ -12,7 +12,7 @@ use crate::DeltaArray;
 
 pub fn delta_compress(array: &PrimitiveArray) -> VortexResult<(PrimitiveArray, PrimitiveArray)> {
     // Fill forward nulls
-    let filled = fill_forward(array.array())?.into_primitive()?;
+    let filled = fill_forward(array.as_ref())?.into_primitive()?;
 
     // Compress the filled array
     let (bases, deltas) = match_each_unsigned_integer_ptype!(array.ptype(), |$T| {

--- a/encodings/fastlanes/src/delta/mod.rs
+++ b/encodings/fastlanes/src/delta/mod.rs
@@ -59,14 +59,14 @@ impl DeltaArray {
 
     #[inline]
     pub fn bases(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(0, self.dtype(), self.bases_len())
             .vortex_expect("DeltaArray is missing bases child array")
     }
 
     #[inline]
     pub fn deltas(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(1, self.dtype(), self.len())
             .vortex_expect("DeltaArray is missing deltas child array")
     }
@@ -88,7 +88,7 @@ impl DeltaArray {
     pub fn validity(&self) -> Validity {
         self.metadata()
             .validity
-            .to_validity(self.array().child(2, &Validity::DTYPE, self.len()))
+            .to_validity(self.as_ref().child(2, &Validity::DTYPE, self.len()))
     }
 
     fn bases_len(&self) -> usize {

--- a/encodings/fastlanes/src/for/compress.rs
+++ b/encodings/fastlanes/src/for/compress.rs
@@ -11,7 +11,7 @@ use vortex_scalar::Scalar;
 use crate::FoRArray;
 
 pub fn for_compress(array: &PrimitiveArray) -> VortexResult<Array> {
-    let shift = trailing_zeros(array.array());
+    let shift = trailing_zeros(array.as_ref());
     let min = array
         .statistics()
         .compute(Stat::Min)
@@ -162,7 +162,7 @@ mod test {
         let unsigned: Vec<u8> = (0..=u8::MAX).collect_vec();
         assert_eq!(encoded_bytes, unsigned.as_slice());
 
-        let decompressed = compressed.array().clone().into_primitive().unwrap();
+        let decompressed = compressed.as_ref().clone().into_primitive().unwrap();
         assert_eq!(
             decompressed.maybe_null_slice::<i8>(),
             array.maybe_null_slice::<i8>()

--- a/encodings/fastlanes/src/for/mod.rs
+++ b/encodings/fastlanes/src/for/mod.rs
@@ -48,7 +48,7 @@ impl FoRArray {
         } else {
             self.dtype()
         };
-        self.array()
+        self.as_ref()
             .child(0, dtype, self.len())
             .vortex_expect("FoRArray is missing encoded child array")
     }

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -91,28 +91,28 @@ impl FSSTArray {
 
     /// Access the symbol table array
     pub fn symbols(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(0, &SYMBOLS_DTYPE, self.metadata().symbols_len)
             .vortex_expect("FSSTArray symbols child")
     }
 
     /// Access the symbol table array
     pub fn symbol_lengths(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(1, &SYMBOL_LENS_DTYPE, self.metadata().symbols_len)
             .vortex_expect("FSSTArray symbol_lengths child")
     }
 
     /// Access the codes array
     pub fn codes(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(2, &self.metadata().codes_dtype, self.len())
             .vortex_expect("FSSTArray codes child")
     }
 
     /// Get the uncompressed length for each element in the array.
     pub fn uncompressed_lengths(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(3, &self.metadata().uncompressed_lengths_dtype, self.len())
             .vortex_expect("FSST uncompressed_lengths child")
     }

--- a/encodings/roaring/src/boolean/mod.rs
+++ b/encodings/roaring/src/boolean/mod.rs
@@ -59,7 +59,7 @@ impl RoaringBoolArray {
     }
 
     pub fn buffer(&self) -> &Buffer {
-        self.array()
+        self.as_ref()
             .buffer()
             .vortex_expect("Missing buffer in PrimitiveArray")
     }

--- a/encodings/roaring/src/integer/mod.rs
+++ b/encodings/roaring/src/integer/mod.rs
@@ -47,7 +47,7 @@ impl RoaringIntArray {
     pub fn bitmap(&self) -> Bitmap {
         //TODO(@jdcasale): figure out a way to avoid this deserialization per-call
         Bitmap::deserialize::<Portable>(
-            self.array()
+            self.as_ref()
                 .buffer()
                 .vortex_expect("RoaringBoolArray buffer is missing")
                 .as_ref(),

--- a/encodings/runend-bool/src/array.rs
+++ b/encodings/runend-bool/src/array.rs
@@ -74,7 +74,7 @@ impl RunEndBoolArray {
     pub fn validity(&self) -> Validity {
         self.metadata()
             .validity
-            .to_validity(self.array().child(2, &Validity::DTYPE, self.len()))
+            .to_validity(self.as_ref().child(2, &Validity::DTYPE, self.len()))
     }
 
     #[inline]
@@ -89,7 +89,7 @@ impl RunEndBoolArray {
 
     #[inline]
     pub fn ends(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(0, &self.metadata().ends_dtype, self.metadata().num_runs)
             .vortex_expect("RunEndBoolArray is missing its run ends")
     }
@@ -166,9 +166,9 @@ mod test {
         assert_eq!(arr.len(), 5);
         assert_eq!(arr.dtype(), &DType::Bool(Nullability::NonNullable));
 
-        assert_eq!(scalar_at(arr.array(), 0).unwrap(), false.into());
-        assert_eq!(scalar_at(arr.array(), 2).unwrap(), true.into());
-        assert_eq!(scalar_at(arr.array(), 4).unwrap(), false.into());
+        assert_eq!(scalar_at(arr.as_ref(), 0).unwrap(), false.into());
+        assert_eq!(scalar_at(arr.as_ref(), 2).unwrap(), true.into());
+        assert_eq!(scalar_at(arr.as_ref(), 4).unwrap(), false.into());
     }
 
     #[test]
@@ -181,7 +181,7 @@ mod test {
                 Validity::NonNullable,
             )
             .unwrap()
-            .array(),
+            .as_ref(),
             2,
             8,
         )

--- a/encodings/runend/src/compute.rs
+++ b/encodings/runend/src/compute.rs
@@ -125,8 +125,8 @@ mod test {
     #[test]
     fn ree_take() {
         let taken = take(
-            ree_array().array(),
-            PrimitiveArray::from(vec![9, 8, 1, 3]).array(),
+            ree_array().as_ref(),
+            PrimitiveArray::from(vec![9, 8, 1, 3]).as_ref(),
         )
         .unwrap();
         assert_eq!(
@@ -137,7 +137,7 @@ mod test {
 
     #[test]
     fn ree_take_end() {
-        let taken = take(ree_array().array(), PrimitiveArray::from(vec![11]).array()).unwrap();
+        let taken = take(ree_array().as_ref(), PrimitiveArray::from(vec![11]).as_ref()).unwrap();
         assert_eq!(
             taken.into_primitive().unwrap().maybe_null_slice::<i32>(),
             &[5]
@@ -147,12 +147,12 @@ mod test {
     #[test]
     #[should_panic]
     fn ree_take_out_of_bounds() {
-        take(ree_array().array(), PrimitiveArray::from(vec![12]).array()).unwrap();
+        take(ree_array().as_ref(), PrimitiveArray::from(vec![12]).as_ref()).unwrap();
     }
 
     #[test]
     fn ree_scalar_at_end() {
-        let scalar = scalar_at(ree_array().array(), 11).unwrap();
+        let scalar = scalar_at(ree_array().as_ref(), 11).unwrap();
         assert_eq!(scalar, 5.into());
     }
 
@@ -165,7 +165,7 @@ mod test {
             Validity::AllInvalid,
         )
         .unwrap();
-        let scalar = scalar_at(null_ree.array(), 11).unwrap();
+        let scalar = scalar_at(null_ree.as_ref(), 11).unwrap();
         assert_eq!(scalar, Scalar::null(null_ree.dtype().clone()));
     }
 
@@ -179,7 +179,7 @@ mod test {
             ]),
         )
         .unwrap();
-        let sliced = slice(array.array(), 4, 10).unwrap();
+        let sliced = slice(array.as_ref(), 4, 10).unwrap();
         let sliced_primitive = sliced.into_primitive().unwrap();
         assert_eq!(
             sliced_primitive.maybe_null_slice::<i32>(),
@@ -207,7 +207,7 @@ mod test {
                 Validity::NonNullable,
             )
             .unwrap()
-            .array(),
+            .as_ref(),
             3,
             8,
         )
@@ -233,7 +233,7 @@ mod test {
                 Validity::NonNullable,
             )
             .unwrap()
-            .array(),
+            .as_ref(),
             3,
             8,
         )
@@ -260,7 +260,7 @@ mod test {
                 Validity::NonNullable,
             )
             .unwrap()
-            .array(),
+            .as_ref(),
             4,
             10,
         )
@@ -309,7 +309,7 @@ mod test {
         .unwrap();
 
         let test_indices = PrimitiveArray::from_vec(vec![0, 2, 4, 6], Validity::NonNullable);
-        let taken = take(arr.array(), test_indices.array()).unwrap();
+        let taken = take(arr.as_ref(), test_indices.as_ref()).unwrap();
 
         assert_eq!(taken.len(), test_indices.len());
 

--- a/encodings/runend/src/compute.rs
+++ b/encodings/runend/src/compute.rs
@@ -137,7 +137,11 @@ mod test {
 
     #[test]
     fn ree_take_end() {
-        let taken = take(ree_array().as_ref(), PrimitiveArray::from(vec![11]).as_ref()).unwrap();
+        let taken = take(
+            ree_array().as_ref(),
+            PrimitiveArray::from(vec![11]).as_ref(),
+        )
+        .unwrap();
         assert_eq!(
             taken.into_primitive().unwrap().maybe_null_slice::<i32>(),
             &[5]
@@ -147,7 +151,11 @@ mod test {
     #[test]
     #[should_panic]
     fn ree_take_out_of_bounds() {
-        take(ree_array().as_ref(), PrimitiveArray::from(vec![12]).as_ref()).unwrap();
+        take(
+            ree_array().as_ref(),
+            PrimitiveArray::from(vec![12]).as_ref(),
+        )
+        .unwrap();
     }
 
     #[test]

--- a/encodings/runend/src/runend.rs
+++ b/encodings/runend/src/runend.rs
@@ -97,7 +97,7 @@ impl RunEndArray {
     pub fn validity(&self) -> Validity {
         self.metadata()
             .validity
-            .to_validity(self.array().child(2, &Validity::DTYPE, self.len()))
+            .to_validity(self.as_ref().child(2, &Validity::DTYPE, self.len()))
     }
 
     /// The offset that the `ends` is relative to.
@@ -114,7 +114,7 @@ impl RunEndArray {
     /// at `ends[i]` (inclusive) and terminating at `ends[i+1]` (exclusive).
     #[inline]
     pub fn ends(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(0, &self.metadata().ends_dtype, self.metadata().num_runs)
             .vortex_expect("RunEndArray is missing its run ends")
     }
@@ -125,7 +125,7 @@ impl RunEndArray {
     /// at `ends[i]` (inclusive) and terminates at `ends[i+1]` (exclusive).
     #[inline]
     pub fn values(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(1, self.dtype(), self.metadata().num_runs)
             .vortex_expect("RunEndArray is missing its values")
     }
@@ -196,9 +196,9 @@ mod tests {
         // 0, 1 => 1
         // 2, 3, 4 => 2
         // 5, 6, 7, 8, 9 => 3
-        assert_eq!(scalar_at(arr.array(), 0).unwrap(), 1.into());
-        assert_eq!(scalar_at(arr.array(), 2).unwrap(), 2.into());
-        assert_eq!(scalar_at(arr.array(), 5).unwrap(), 3.into());
-        assert_eq!(scalar_at(arr.array(), 9).unwrap(), 3.into());
+        assert_eq!(scalar_at(arr.as_ref(), 0).unwrap(), 1.into());
+        assert_eq!(scalar_at(arr.as_ref(), 2).unwrap(), 2.into());
+        assert_eq!(scalar_at(arr.as_ref(), 5).unwrap(), 3.into());
+        assert_eq!(scalar_at(arr.as_ref(), 9).unwrap(), 3.into());
     }
 }

--- a/encodings/zigzag/src/compress.rs
+++ b/encodings/zigzag/src/compress.rs
@@ -69,6 +69,6 @@ mod test {
             (-10_000..10_000).map(|i| i as i64),
         )))
         .unwrap();
-        assert_eq!(compressed.array().encoding().id(), ZigZagEncoding.id());
+        assert_eq!(compressed.as_ref().encoding().id(), ZigZagEncoding.id());
     }
 }

--- a/encodings/zigzag/src/zigzag.rs
+++ b/encodings/zigzag/src/zigzag.rs
@@ -49,7 +49,7 @@ impl ZigZagArray {
             vortex_panic!(err, "Failed to convert DType {} to PType", self.dtype())
         });
         let encoded = DType::from(ptype.to_unsigned()).with_nullability(self.dtype().nullability());
-        self.array()
+        self.as_ref()
             .child(0, &encoded, self.len())
             .vortex_expect("ZigZagArray is missing its encoded child array")
     }

--- a/vortex-array/src/array/bool/compute/slice.rs
+++ b/vortex-array/src/array/bool/compute/slice.rs
@@ -30,14 +30,14 @@ mod tests {
 
         assert_eq!(sliced_arr.len(), 3);
 
-        let s = scalar_at(sliced_arr.as_array_ref(), 0).unwrap();
+        let s = scalar_at(sliced_arr.as_ref(), 0).unwrap();
         assert_eq!(s.into_value().as_bool().unwrap(), Some(true));
 
-        let s = scalar_at(sliced_arr.as_array_ref(), 1).unwrap();
+        let s = scalar_at(sliced_arr.as_ref(), 1).unwrap();
         assert!(!sliced_arr.is_valid(1));
         assert!(s.is_null());
 
-        let s = scalar_at(sliced_arr.as_array_ref(), 2).unwrap();
+        let s = scalar_at(sliced_arr.as_ref(), 2).unwrap();
         assert_eq!(s.into_value().as_bool().unwrap(), Some(false));
     }
 }

--- a/vortex-array/src/array/bool/compute/slice.rs
+++ b/vortex-array/src/array/bool/compute/slice.rs
@@ -21,12 +21,11 @@ mod tests {
     use crate::compute::slice;
     use crate::compute::unary::scalar_at;
     use crate::validity::ArrayValidity;
-    use crate::AsArray;
 
     #[test]
     fn test_slice() {
         let arr = BoolArray::from_iter([Some(true), Some(true), None, Some(false), None]);
-        let sliced_arr = slice(arr.as_array_ref(), 1, 4).unwrap();
+        let sliced_arr = slice(arr.as_ref(), 1, 4).unwrap();
         let sliced_arr = BoolArray::try_from(sliced_arr).unwrap();
 
         assert_eq!(sliced_arr.len(), 3);

--- a/vortex-array/src/array/bool/compute/take.rs
+++ b/vortex-array/src/array/bool/compute/take.rs
@@ -5,7 +5,7 @@ use vortex_error::VortexResult;
 
 use crate::array::BoolArray;
 use crate::compute::TakeFn;
-use crate::{Array, AsArray, IntoArray, IntoArrayVariant};
+use crate::{Array, IntoArray, IntoArrayVariant};
 
 impl TakeFn for BoolArray {
     fn take(&self, indices: &Array) -> VortexResult<Array> {
@@ -14,7 +14,7 @@ impl TakeFn for BoolArray {
         match_each_integer_ptype!(indices.ptype(), |$I| {
             Ok(BoolArray::from_vec(
                 take_bool(&self.boolean_buffer(), indices.maybe_null_slice::<$I>()),
-                validity.take(indices.as_array_ref())?,
+                validity.take(indices.as_ref())?,
             ).into_array())
         })
     }

--- a/vortex-array/src/array/bool/mod.rs
+++ b/vortex-array/src/array/bool/mod.rs
@@ -27,7 +27,7 @@ pub struct BoolMetadata {
 
 impl BoolArray {
     pub fn buffer(&self) -> &Buffer {
-        self.array()
+        self.as_ref()
             .buffer()
             .vortex_expect("Missing buffer in BoolArray")
     }
@@ -43,7 +43,7 @@ impl BoolArray {
     pub fn validity(&self) -> Validity {
         self.metadata()
             .validity
-            .to_validity(self.array().child(0, &Validity::DTYPE, self.len()))
+            .to_validity(self.as_ref().child(0, &Validity::DTYPE, self.len()))
     }
 
     pub fn try_new(buffer: BooleanBuffer, validity: Validity) -> VortexResult<Self> {

--- a/vortex-array/src/array/chunked/canonical.rs
+++ b/vortex-array/src/array/chunked/canonical.rs
@@ -203,15 +203,15 @@ fn pack_varbin(chunks: &[Array], validity: Validity, dtype: &DType) -> VortexRes
     for chunk in chunks {
         let chunk = chunk.clone().into_varbin()?;
         let offsets_arr = try_cast(
-            chunk.offsets().into_primitive()?.array(),
+            chunk.offsets().into_primitive()?.as_ref(),
             &DType::Primitive(PType::I32, Nullability::NonNullable),
         )?
         .into_primitive()?;
 
         let first_offset_value: usize =
-            usize::try_from(&scalar_at_unchecked(offsets_arr.array(), 0))?;
+            usize::try_from(&scalar_at_unchecked(offsets_arr.as_ref(), 0))?;
         let last_offset_value: usize = usize::try_from(&scalar_at_unchecked(
-            offsets_arr.array(),
+            offsets_arr.as_ref(),
             offsets_arr.len() - 1,
         ))?;
         let primitive_bytes =
@@ -262,8 +262,8 @@ mod tests {
 
     #[test]
     pub fn pack_sliced_varbin() {
-        let array1 = slice(varbin_array().array(), 1, 3).unwrap();
-        let array2 = slice(varbin_array().array(), 2, 4).unwrap();
+        let array1 = slice(varbin_array().as_ref(), 1, 3).unwrap();
+        let array2 = slice(varbin_array().as_ref(), 2, 4).unwrap();
         let packed = pack_varbin(
             &[array1, array2],
             Validity::NonNullable,

--- a/vortex-array/src/array/chunked/compute/scalar_at.rs
+++ b/vortex-array/src/array/chunked/compute/scalar_at.rs
@@ -47,8 +47,8 @@ mod tests {
             DType::Primitive(PType::U64, Nullability::NonNullable),
         )
         .unwrap();
-        assert_eq!(scalar_at(array.array(), 0).unwrap(), 1u64.into());
-        assert_eq!(scalar_at(array.array(), 1).unwrap(), 2u64.into());
+        assert_eq!(scalar_at(array.as_ref(), 0).unwrap(), 1u64.into());
+        assert_eq!(scalar_at(array.as_ref(), 1).unwrap(), 2u64.into());
     }
 
     #[test]
@@ -63,10 +63,10 @@ mod tests {
             DType::Primitive(PType::U64, Nullability::NonNullable),
         )
         .unwrap();
-        assert_eq!(scalar_at(array.array(), 0).unwrap(), 1u64.into());
-        assert_eq!(scalar_at(array.array(), 1).unwrap(), 2u64.into());
-        assert_eq!(scalar_at(array.array(), 2).unwrap(), 3u64.into());
-        assert_eq!(scalar_at(array.array(), 3).unwrap(), 4u64.into());
+        assert_eq!(scalar_at(array.as_ref(), 0).unwrap(), 1u64.into());
+        assert_eq!(scalar_at(array.as_ref(), 1).unwrap(), 2u64.into());
+        assert_eq!(scalar_at(array.as_ref(), 2).unwrap(), 3u64.into());
+        assert_eq!(scalar_at(array.as_ref(), 3).unwrap(), 4u64.into());
     }
 
     #[test]
@@ -81,9 +81,9 @@ mod tests {
             DType::Primitive(PType::U64, Nullability::NonNullable),
         )
         .unwrap();
-        assert_eq!(scalar_at(array.array(), 0).unwrap(), 1u64.into());
-        assert_eq!(scalar_at(array.array(), 1).unwrap(), 2u64.into());
-        assert_eq!(scalar_at(array.array(), 2).unwrap(), 3u64.into());
-        assert_eq!(scalar_at(array.array(), 3).unwrap(), 4u64.into());
+        assert_eq!(scalar_at(array.as_ref(), 0).unwrap(), 1u64.into());
+        assert_eq!(scalar_at(array.as_ref(), 1).unwrap(), 2u64.into());
+        assert_eq!(scalar_at(array.as_ref(), 2).unwrap(), 3u64.into());
+        assert_eq!(scalar_at(array.as_ref(), 3).unwrap(), 4u64.into());
     }
 }

--- a/vortex-array/src/array/chunked/compute/slice.rs
+++ b/vortex-array/src/array/chunked/compute/slice.rs
@@ -71,34 +71,43 @@ mod tests {
 
     #[test]
     pub fn slice_middle() {
-        assert_equal_slices(slice(chunked_array().array(), 2, 5).unwrap(), &[3u64, 4, 5])
+        assert_equal_slices(
+            slice(chunked_array().as_ref(), 2, 5).unwrap(),
+            &[3u64, 4, 5],
+        )
     }
 
     #[test]
     pub fn slice_begin() {
-        assert_equal_slices(slice(chunked_array().array(), 1, 3).unwrap(), &[2u64, 3]);
+        assert_equal_slices(slice(chunked_array().as_ref(), 1, 3).unwrap(), &[2u64, 3]);
     }
 
     #[test]
     pub fn slice_aligned() {
-        assert_equal_slices(slice(chunked_array().array(), 3, 6).unwrap(), &[4u64, 5, 6]);
+        assert_equal_slices(
+            slice(chunked_array().as_ref(), 3, 6).unwrap(),
+            &[4u64, 5, 6],
+        );
     }
 
     #[test]
     pub fn slice_many_aligned() {
         assert_equal_slices(
-            slice(chunked_array().array(), 0, 6).unwrap(),
+            slice(chunked_array().as_ref(), 0, 6).unwrap(),
             &[1u64, 2, 3, 4, 5, 6],
         );
     }
 
     #[test]
     pub fn slice_end() {
-        assert_equal_slices(slice(chunked_array().array(), 7, 8).unwrap(), &[8u64]);
+        assert_equal_slices(slice(chunked_array().as_ref(), 7, 8).unwrap(), &[8u64]);
     }
 
     #[test]
     pub fn slice_exactly_end() {
-        assert_equal_slices(slice(chunked_array().array(), 6, 9).unwrap(), &[7u64, 8, 9]);
+        assert_equal_slices(
+            slice(chunked_array().as_ref(), 6, 9).unwrap(),
+            &[7u64, 8, 9],
+        );
     }
 }

--- a/vortex-array/src/array/chunked/compute/take.rs
+++ b/vortex-array/src/array/chunked/compute/take.rs
@@ -137,7 +137,7 @@ mod test {
         assert_eq!(arr.len(), 9);
         let indices = vec![0u64, 0, 6, 4].into_array();
 
-        let result = &ChunkedArray::try_from(take(arr.array(), &indices).unwrap())
+        let result = &ChunkedArray::try_from(take(arr.as_ref(), &indices).unwrap())
             .unwrap()
             .into_array()
             .into_primitive()

--- a/vortex-array/src/array/chunked/mod.rs
+++ b/vortex-array/src/array/chunked/mod.rs
@@ -75,8 +75,8 @@ impl ChunkedArray {
         let chunk_end = usize::try_from(&scalar_at(&self.chunk_offsets(), idx + 1).ok()?).ok()?;
 
         // Offset the index since chunk_ends is child 0.
-        self.array()
-            .child(idx + 1, self.array().dtype(), chunk_end - chunk_start)
+        self.as_ref()
+            .child(idx + 1, self.as_ref().dtype(), chunk_end - chunk_start)
     }
 
     pub fn nchunks(&self) -> usize {
@@ -85,7 +85,7 @@ impl ChunkedArray {
 
     #[inline]
     pub fn chunk_offsets(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(0, &Self::ENDS_DTYPE, self.nchunks() + 1)
             .vortex_expect("Missing chunk ends in ChunkedArray")
     }

--- a/vortex-array/src/array/constant/compute.rs
+++ b/vortex-array/src/array/constant/compute.rs
@@ -11,7 +11,7 @@ use crate::compute::{
     SearchSortedFn, SearchSortedSide, SliceFn, TakeFn,
 };
 use crate::stats::{ArrayStatistics, Stat};
-use crate::{Array, ArrayDType, AsArray, IntoArray};
+use crate::{Array, ArrayDType, IntoArray};
 
 impl ArrayCompute for ConstantArray {
     fn compare(&self, other: &Array, operator: Operator) -> Option<VortexResult<Array>> {

--- a/vortex-array/src/array/constant/compute.rs
+++ b/vortex-array/src/array/constant/compute.rs
@@ -152,7 +152,7 @@ fn constant_array_bool_impl(
         Ok(ConstantArray::new(scalar, constant_array.len()).into_array())
     } else {
         // try and use a the rhs specialized implementation if it exists
-        match fallback_fn(other, constant_array.as_array_ref()) {
+        match fallback_fn(other, constant_array.as_ref()) {
             Some(r) => r,
             None => vortex_bail!("Operation is not supported"),
         }

--- a/vortex-array/src/array/extension/compute.rs
+++ b/vortex-array/src/array/extension/compute.rs
@@ -45,7 +45,7 @@ impl MaybeCompareFn for ExtensionArray {
                     Scalar::new(self.storage().dtype().clone(), scalar_ext.value().clone()),
                     const_ext.len(),
                 );
-                compare(&self.storage(), const_storage.array(), operator)
+                compare(&self.storage(), const_storage.as_ref(), operator)
             });
         }
 

--- a/vortex-array/src/array/extension/mod.rs
+++ b/vortex-array/src/array/extension/mod.rs
@@ -32,7 +32,7 @@ impl ExtensionArray {
     }
 
     pub fn storage(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(0, &self.metadata().storage_dtype, self.len())
             .vortex_expect("Missing storage array for ExtensionArray")
     }

--- a/vortex-array/src/array/primitive/compute/filter.rs
+++ b/vortex-array/src/array/primitive/compute/filter.rs
@@ -60,7 +60,7 @@ mod test {
         let arr = PrimitiveArray::from(vec![1u32, 24, 54, 2, 3, 2, 3, 2]);
 
         let filtered =
-            filter_select_primitive(&arr, BoolArray::from(filter.clone()).array()).unwrap();
+            filter_select_primitive(&arr, BoolArray::from(filter.clone()).as_ref()).unwrap();
         assert_eq!(
             filtered.len(),
             filter.iter().filter(|x| **x).collect_vec().len()

--- a/vortex-array/src/array/primitive/compute/take.rs
+++ b/vortex-array/src/array/primitive/compute/take.rs
@@ -14,7 +14,7 @@ impl TakeFn for PrimitiveArray {
             match_each_integer_ptype!(indices.ptype(), |$I| {
                 Ok(PrimitiveArray::from_vec(
                     take_primitive(self.maybe_null_slice::<$T>(), indices.maybe_null_slice::<$I>()),
-                    validity.take(indices.array())?,
+                    validity.take(indices.as_ref())?,
                 ).into_array())
             })
         })

--- a/vortex-array/src/array/primitive/mod.rs
+++ b/vortex-array/src/array/primitive/mod.rs
@@ -87,7 +87,7 @@ impl PrimitiveArray {
     pub fn validity(&self) -> Validity {
         self.metadata()
             .validity
-            .to_validity(self.array().child(0, &Validity::DTYPE, self.len()))
+            .to_validity(self.as_ref().child(0, &Validity::DTYPE, self.len()))
     }
 
     pub fn ptype(&self) -> PType {
@@ -98,7 +98,7 @@ impl PrimitiveArray {
     }
 
     pub fn buffer(&self) -> &Buffer {
-        self.array()
+        self.as_ref()
             .buffer()
             .vortex_expect("Missing buffer in PrimitiveArray")
     }

--- a/vortex-array/src/array/sparse/compute/mod.rs
+++ b/vortex-array/src/array/sparse/compute/mod.rs
@@ -104,7 +104,7 @@ impl FilterFn for SparseArray {
 
         Ok(SparseArray::try_new(
             PrimitiveArray::from(coordinate_indices).into_array(),
-            take(&self.values(), PrimitiveArray::from(value_indices).array())?,
+            take(&self.values(), PrimitiveArray::from(value_indices).as_ref())?,
             buffer.count_set_bits(),
             self.fill_value().clone(),
         )?

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -92,14 +92,14 @@ impl SparseArray {
 
     #[inline]
     pub fn values(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(1, self.dtype(), self.metadata().indices_len)
             .vortex_expect("Missing child array in SparseArray")
     }
 
     #[inline]
     pub fn indices(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(
                 0,
                 &self.metadata().indices_dtype,

--- a/vortex-array/src/array/struct_/mod.rs
+++ b/vortex-array/src/array/struct_/mod.rs
@@ -21,7 +21,7 @@ pub struct StructMetadata {
 
 impl StructArray {
     pub fn validity(&self) -> Validity {
-        self.metadata().validity.to_validity(self.array().child(
+        self.metadata().validity.to_validity(self.as_ref().child(
             self.nfields(),
             &Validity::DTYPE,
             self.len(),
@@ -144,7 +144,7 @@ impl StructArrayTrait for StructArray {
     fn field(&self, idx: usize) -> Option<Array> {
         self.dtypes()
             .get(idx)
-            .and_then(|dtype| self.array().child(idx, dtype, self.len()))
+            .and_then(|dtype| self.as_ref().child(idx, dtype, self.len()))
     }
 }
 

--- a/vortex-array/src/array/varbin/mod.rs
+++ b/vortex-array/src/array/varbin/mod.rs
@@ -76,7 +76,7 @@ impl VarBinArray {
 
     #[inline]
     pub fn offsets(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(0, &self.metadata().offsets_dtype, self.len() + 1)
             .vortex_expect("Missing offsets in VarBinArray")
     }
@@ -92,7 +92,7 @@ impl VarBinArray {
 
     #[inline]
     pub fn bytes(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(1, &DType::BYTES, self.metadata().bytes_len)
             .vortex_expect("Missing bytes in VarBinArray")
     }
@@ -100,7 +100,7 @@ impl VarBinArray {
     pub fn validity(&self) -> Validity {
         self.metadata()
             .validity
-            .to_validity(self.array().child(2, &Validity::DTYPE, self.len()))
+            .to_validity(self.as_ref().child(2, &Validity::DTYPE, self.len()))
     }
 
     pub fn sliced_bytes(&self) -> VortexResult<Array> {

--- a/vortex-array/src/array/varbinview/mod.rs
+++ b/vortex-array/src/array/varbinview/mod.rs
@@ -174,20 +174,20 @@ impl VarBinViewArray {
 
     #[inline]
     pub fn views(&self) -> Array {
-        self.array()
+        self.as_ref()
             .child(0, &DType::BYTES, self.len() * VIEW_SIZE)
             .unwrap_or_else(|| vortex_panic!("VarBinViewArray is missing its views"))
     }
 
     #[inline]
     pub fn bytes(&self, idx: usize) -> Array {
-        self.array()
+        self.as_ref()
             .child(idx + 1, &DType::BYTES, self.metadata().data_lens[idx])
             .unwrap_or_else(|| vortex_panic!("VarBinViewArray is missing its data buffer"))
     }
 
     pub fn validity(&self) -> Validity {
-        self.metadata().validity.to_validity(self.array().child(
+        self.metadata().validity.to_validity(self.as_ref().child(
             self.metadata().data_lens.len() + 1,
             &Validity::DTYPE,
             self.len(),
@@ -377,11 +377,11 @@ mod test {
             VarBinViewArray::from_iter_str(["hello world", "hello world this is a long string"]);
         assert_eq!(binary_arr.len(), 2);
         assert_eq!(
-            scalar_at(binary_arr.array(), 0).unwrap(),
+            scalar_at(binary_arr.as_ref(), 0).unwrap(),
             Scalar::from("hello world")
         );
         assert_eq!(
-            scalar_at(binary_arr.array(), 1).unwrap(),
+            scalar_at(binary_arr.as_ref(), 1).unwrap(),
             Scalar::from("hello world this is a long string")
         );
     }

--- a/vortex-array/src/implementation.rs
+++ b/vortex-array/src/implementation.rs
@@ -250,3 +250,9 @@ where
         }
     }
 }
+
+impl AsRef<Array> for Array {
+    fn as_ref(&self) -> &Array {
+        self
+    }
+}

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -241,10 +241,6 @@ pub trait IntoArray {
     fn into_array(self) -> Array;
 }
 
-pub trait AsArray {
-    fn as_array_ref(&self) -> &Array;
-}
-
 pub trait ToArrayData {
     fn to_array_data(&self) -> ArrayData;
 }

--- a/vortex-array/src/typed.rs
+++ b/vortex-array/src/typed.rs
@@ -5,7 +5,7 @@ use vortex_dtype::DType;
 use vortex_error::{vortex_bail, vortex_panic, VortexError, VortexResult};
 
 use crate::stats::StatsSet;
-use crate::{Array, ArrayData, ArrayDef, AsArray, IntoArray, ToArray, TryDeserializeArrayMetadata};
+use crate::{Array, ArrayData, ArrayDef, IntoArray, ToArray, TryDeserializeArrayMetadata};
 
 #[derive(Debug, Clone)]
 pub struct TypedArray<D: ArrayDef> {
@@ -96,12 +96,6 @@ impl<'a, D: ArrayDef> TryFrom<&'a Array> for TypedArray<D> {
 
     fn try_from(value: &'a Array) -> Result<Self, Self::Error> {
         value.clone().try_into()
-    }
-}
-
-impl<D: ArrayDef> AsArray for TypedArray<D> {
-    fn as_array_ref(&self) -> &Array {
-        &self.array
     }
 }
 

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -78,7 +78,7 @@ impl Validity {
         }
     }
 
-    pub fn array(&self) -> Option<&Array> {
+    pub fn as_array(&self) -> Option<&Array> {
         match self {
             Self::Array(a) => Some(a),
             _ => None,

--- a/vortex-array/src/visitor.rs
+++ b/vortex-array/src/visitor.rs
@@ -17,7 +17,7 @@ pub trait ArrayVisitor {
 
     /// Utility for visiting Array validity.
     fn visit_validity(&mut self, validity: &Validity) -> VortexResult<()> {
-        if let Some(v) = validity.array() {
+        if let Some(v) = validity.as_array() {
             self.visit_child("validity", v)
         } else {
             Ok(())

--- a/vortex-datafusion/src/plans.rs
+++ b/vortex-datafusion/src/plans.rs
@@ -22,7 +22,7 @@ use pin_project::pin_project;
 use vortex::array::ChunkedArray;
 use vortex::arrow::FromArrowArray;
 use vortex::compute::take;
-use vortex::{Array, AsArray as _, IntoArray, IntoArrayVariant, IntoCanonical};
+use vortex::{Array, IntoArray, IntoArrayVariant, IntoCanonical};
 use vortex_dtype::field::Field;
 use vortex_error::{vortex_err, vortex_panic, VortexError};
 use vortex_expr::VortexExpr;
@@ -166,7 +166,7 @@ impl Stream for RowIndicesStream {
 
         let selection = this
             .conjunction_expr
-            .evaluate(vortex_struct.as_array_ref())
+            .evaluate(vortex_struct.as_ref())
             .map_err(|e| DataFusionError::External(e.into()))?
             .into_canonical()?
             .into_arrow()?;

--- a/vortex-sampling-compressor/src/compressors/delta.rs
+++ b/vortex-sampling-compressor/src/compressors/delta.rs
@@ -44,10 +44,10 @@ impl EncodingCompressor for DeltaCompressor {
         // Recursively compress the bases and deltas
         let bases = ctx
             .named("bases")
-            .compress(bases.array(), like.as_ref().and_then(|l| l.child(0)))?;
+            .compress(bases.as_ref(), like.as_ref().and_then(|l| l.child(0)))?;
         let deltas = ctx
             .named("deltas")
-            .compress(deltas.array(), like.as_ref().and_then(|l| l.child(1)))?;
+            .compress(deltas.as_ref(), like.as_ref().and_then(|l| l.child(1)))?;
 
         Ok(CompressedArray::new(
             DeltaArray::try_new(bases.array, deltas.array, validity)?.into_array(),

--- a/vortex-sampling-compressor/src/compressors/mod.rs
+++ b/vortex-sampling-compressor/src/compressors/mod.rs
@@ -170,11 +170,6 @@ impl<'a> CompressedArray<'a> {
     }
 
     #[inline]
-    pub fn array(&self) -> &Array {
-        &self.array
-    }
-
-    #[inline]
     pub fn into_array(self) -> Array {
         self.array
     }
@@ -192,5 +187,11 @@ impl<'a> CompressedArray<'a> {
     #[inline]
     pub fn nbytes(&self) -> usize {
         self.array.nbytes()
+    }
+}
+
+impl AsRef<Array> for CompressedArray<'_> {
+    fn as_ref(&self) -> &Array {
+        &self.array
     }
 }

--- a/vortex-sampling-compressor/src/lib.rs
+++ b/vortex-sampling-compressor/src/lib.rs
@@ -176,8 +176,8 @@ impl<'a> SamplingCompressor<'a> {
             if let Some(compressed) = l.compress(arr, self) {
                 let compressed = compressed?;
 
-                check_validity_unchanged(arr, compressed.array());
-                check_dtype_unchanged(arr, compressed.array());
+                check_validity_unchanged(arr, compressed.as_ref());
+                check_dtype_unchanged(arr, compressed.as_ref());
                 return Ok(compressed);
             } else {
                 warn!(
@@ -190,8 +190,8 @@ impl<'a> SamplingCompressor<'a> {
         // Otherwise, attempt to compress the array
         let compressed = self.compress_array(arr)?;
 
-        check_validity_unchanged(arr, compressed.array());
-        check_dtype_unchanged(arr, compressed.array());
+        check_validity_unchanged(arr, compressed.as_ref());
+        check_dtype_unchanged(arr, compressed.as_ref());
         Ok(compressed)
     }
 

--- a/vortex-serde/src/chunked_reader/take_rows.rs
+++ b/vortex-serde/src/chunked_reader/take_rows.rs
@@ -172,7 +172,7 @@ fn find_chunks(row_offsets: &Array, indices: &Array) -> VortexResult<Vec<ChunkIn
     let mut chunks = HashMap::new();
 
     for (pos, idx) in indices.maybe_null_slice::<u64>().iter().enumerate() {
-        let chunk_idx = search_sorted(row_offsets.array(), *idx, SearchSortedSide::Right)?
+        let chunk_idx = search_sorted(row_offsets.as_ref(), *idx, SearchSortedSide::Right)?
             .to_ends_index(row_offsets.len())
             .saturating_sub(1);
         chunks


### PR DESCRIPTION
per @robert3005 there used to be a lifetime issue with `AsArray`, but that's not longer true and it doesn't actually serve any other purpose + `AsRef` makes the code more rusty.