### PR TITLE
Use NativePType compare in bitpacked search

### DIFF
--- a/encodings/fastlanes/src/bitpacking/compute/search_sorted.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/search_sorted.rs
@@ -96,7 +96,7 @@ impl<T: BitPacking + NativePType> IndexOrd<T> for BitPackedSearch {
                 idx + self.offset,
             )
         };
-        val.partial_cmp(elem)
+        Some(val.compare(*elem))
     }
 }
 


### PR DESCRIPTION
For consistency, this comparison will never be a float