### PR TITLE
feat: implement search_sorted_many

### DIFF
--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -233,7 +233,6 @@ pub fn unpack_primitive<T: NativePType + BitPacking>(
 }
 
 pub fn unpack_single(array: &BitPackedArray, index: usize) -> VortexResult<Scalar> {
-    // println!("UNPACK_SINGLE: {:?}", Backtrace::capture());
     let bit_width = array.bit_width();
     let packed = array.packed().into_primitive()?;
     let index_in_encoded = index + array.offset();

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -233,6 +233,7 @@ pub fn unpack_primitive<T: NativePType + BitPacking>(
 }
 
 pub fn unpack_single(array: &BitPackedArray, index: usize) -> VortexResult<Scalar> {
+    // println!("UNPACK_SINGLE: {:?}", Backtrace::capture());
     let bit_width = array.bit_width();
     let packed = array.packed().into_primitive()?;
     let index_in_encoded = index + array.offset();

--- a/encodings/fastlanes/src/bitpacking/compute/search_sorted.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/search_sorted.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use std::cmp::Ordering;
 use std::cmp::Ordering::Greater;
 
@@ -6,7 +7,7 @@ use itertools::Itertools;
 use num_traits::AsPrimitive;
 use vortex::array::SparseArray;
 use vortex::compute::{
-    search_sorted, IndexOrd, Len, SearchResult, SearchSorted, SearchSortedFn, SearchSortedSide,
+    search_sorted_u64, IndexOrd, Len, SearchResult, SearchSorted, SearchSortedFn, SearchSortedSide,
 };
 use vortex::validity::Validity;
 use vortex::ArrayDType;
@@ -23,12 +24,21 @@ impl SearchSortedFn for BitPackedArray {
         })
     }
 
+    fn search_sorted_u64(&self, value: u64, side: SearchSortedSide) -> VortexResult<SearchResult> {
+        match_each_unsigned_integer_ptype!(self.ptype(), |$P| {
+            // NOTE: conversion may truncate silently.
+            let cast_value: $P = value as $P;
+
+            // Create a new scalar from this component.
+            search_sorted_native(self, cast_value, side)
+        })
+    }
+
     fn search_sorted_many(
         &self,
         values: &[Scalar],
         sides: &[SearchSortedSide],
     ) -> VortexResult<Vec<SearchResult>> {
-        // Construct searcher once upfront, since it is fairly expensive
         match_each_unsigned_integer_ptype!(self.ptype(), |$P| {
             let searcher = BitPackedSearch::<'_, $P>::new(self);
 
@@ -37,9 +47,30 @@ impl SearchSortedFn for BitPackedArray {
                 .zip(sides.iter().copied())
                 .map(|(value, side)| {
                     // Unwrap to native value
-                    let value: $P = value.cast(self.dtype())?.try_into()?;
+                    let unwrapped_value: $P = value.cast(self.dtype())?.try_into()?;
 
-                    Ok(searcher.search_sorted(&value, side))
+                    Ok(searcher.search_sorted(&unwrapped_value, side))
+                })
+                .try_collect()
+        })
+    }
+
+    fn search_sorted_u64_many(
+        &self,
+        values: &[u64],
+        sides: &[SearchSortedSide],
+    ) -> VortexResult<Vec<SearchResult>> {
+        match_each_unsigned_integer_ptype!(self.ptype(), |$P| {
+            let searcher = BitPackedSearch::<'_, $P>::new(self);
+
+            values
+                .iter()
+                .copied()
+                .zip(sides.iter().copied())
+                .map(|(value, side)| {
+                    // NOTE: truncating cast
+                    let cast_value: $P = value as $P;
+                    Ok(searcher.search_sorted(&cast_value, side))
                 })
                 .try_collect()
         })
@@ -52,19 +83,36 @@ fn search_sorted_typed<T>(
     side: SearchSortedSide,
 ) -> VortexResult<SearchResult>
 where
-    T: NativePType + TryFrom<Scalar, Error = VortexError> + BitPacking + AsPrimitive<usize>,
+    T: NativePType
+        + TryFrom<Scalar, Error = VortexError>
+        + BitPacking
+        + AsPrimitive<usize>
+        + AsPrimitive<u64>,
 {
-    let unwrapped_value: T = value.cast(array.dtype())?.try_into()?;
+    let native_value: T = value.cast(array.dtype())?.try_into()?;
+    search_sorted_native(array, native_value, side)
+}
+
+/// Native variant of search_sorted that operates over Rust unsigned integer types.
+fn search_sorted_native<T>(
+    array: &BitPackedArray,
+    value: T,
+    side: SearchSortedSide,
+) -> VortexResult<SearchResult>
+where
+    T: NativePType + BitPacking + AsPrimitive<usize> + AsPrimitive<u64>,
+{
     if let Some(patches_array) = array.patches() {
         // If patches exist they must be the last elements in the array, if the value we're looking for is greater than
         // max packed value just search the patches
-        if unwrapped_value.as_() > array.max_packed_value() {
-            search_sorted(&patches_array, value.clone(), side)
+        let usize_value: usize = value.as_();
+        if usize_value > array.max_packed_value() {
+            search_sorted_u64(&patches_array, value.as_(), side)
         } else {
-            Ok(BitPackedSearch::<'_, T>::new(array).search_sorted(&unwrapped_value, side))
+            Ok(BitPackedSearch::<'_, T>::new(array).search_sorted(&value, side))
         }
     } else {
-        Ok(BitPackedSearch::<'_, T>::new(array).search_sorted(&unwrapped_value, side))
+        Ok(BitPackedSearch::<'_, T>::new(array).search_sorted(&value, side))
     }
 }
 
@@ -72,17 +120,24 @@ where
 #[derive(Debug)]
 struct BitPackedSearch<'a, T> {
     // NOTE: caching this here is important for performance, as each call to `maybe_null_slice`
-    //  invokes a call to DType <> PType conversion.
+    //  invokes a call to DType <> PType conversion
     packed_maybe_null_slice: &'a [T],
     offset: usize,
     length: usize,
     bit_width: usize,
-    min_patch_offset: Option<usize>,
-    first_null_idx: usize,
+    first_invalid_idx: usize,
 }
 
-impl<'a, T: NativePType + BitPacking> BitPackedSearch<'a, T> {
+impl<'a, T: BitPacking + NativePType> BitPackedSearch<'a, T> {
     pub fn new(array: &'a BitPackedArray) -> Self {
+        let min_patch_offset = array
+            .patches()
+            .and_then(|p| {
+                SparseArray::try_from(p)
+                    .vortex_expect("Only sparse patches are supported")
+                    .min_index()
+            })
+            .unwrap_or_else(|| array.len());
         let first_null_idx = match array.validity() {
             Validity::NonNullable | Validity::AllValid => array.len(),
             Validity::AllInvalid => 0,
@@ -92,32 +147,21 @@ impl<'a, T: NativePType + BitPacking> BitPackedSearch<'a, T> {
             }
         };
 
+        let first_invalid_idx = cmp::min(min_patch_offset, first_null_idx);
+
         Self {
             packed_maybe_null_slice: array.packed_slice::<T>(),
             offset: array.offset(),
             length: array.len(),
             bit_width: array.bit_width(),
-            min_patch_offset: array.patches().and_then(|p| {
-                SparseArray::try_from(p)
-                    .vortex_expect("Only sparse patches are supported")
-                    .min_index()
-            }),
-            first_null_idx,
+            first_invalid_idx,
         }
     }
 }
 
 impl<T: BitPacking + NativePType> IndexOrd<T> for BitPackedSearch<'_, T> {
     fn index_cmp(&self, idx: usize, elem: &T) -> Option<Ordering> {
-        if let Some(min_patch) = self.min_patch_offset {
-            if idx >= min_patch {
-                return Some(Greater);
-            }
-        }
-
-        // Null is always at the end, and the value we're searching for is non-null, thus if we
-        // see a null, always branch to the left.
-        if idx >= self.first_null_idx {
+        if idx >= self.first_invalid_idx {
             return Some(Greater);
         }
 
@@ -142,7 +186,9 @@ impl<T> Len for BitPackedSearch<'_, T> {
 #[cfg(test)]
 mod test {
     use vortex::array::PrimitiveArray;
-    use vortex::compute::{search_sorted, slice, SearchResult, SearchSortedFn, SearchSortedSide};
+    use vortex::compute::{
+        search_sorted, search_sorted_many, slice, SearchResult, SearchSortedFn, SearchSortedSide,
+    };
     use vortex::IntoArray;
     use vortex_dtype::Nullability;
     use vortex_scalar::Scalar;
@@ -199,7 +245,7 @@ mod test {
     }
 
     #[test]
-    fn test_search_sorted_many_nulls() {
+    fn test_search_sorted_nulls() {
         let bitpacked = BitPackedArray::encode(
             PrimitiveArray::from_nullable_vec(vec![Some(1i64), None, None]).as_ref(),
             2,
@@ -213,5 +259,44 @@ mod test {
             )
             .unwrap();
         assert_eq!(found, SearchResult::Found(0));
+    }
+
+    #[test]
+    fn test_search_sorted_many() {
+        // Test search_sorted_many with an array that contains several null values.
+        let bitpacked = BitPackedArray::encode(
+            PrimitiveArray::from_nullable_vec(vec![
+                Some(1i64),
+                Some(2i64),
+                Some(3i64),
+                None,
+                None,
+                None,
+                None,
+            ])
+            .as_ref(),
+            3,
+        )
+        .unwrap();
+
+        let results = search_sorted_many(
+            bitpacked.as_ref(),
+            &[3i64, 2i64, 1i64],
+            &[
+                SearchSortedSide::Left,
+                SearchSortedSide::Left,
+                SearchSortedSide::Left,
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            results,
+            vec![
+                SearchResult::Found(2),
+                SearchResult::Found(1),
+                SearchResult::Found(0),
+            ]
+        );
     }
 }

--- a/encodings/fastlanes/src/bitpacking/compute/search_sorted.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/search_sorted.rs
@@ -201,7 +201,7 @@ mod test {
     #[test]
     fn test_search_sorted_many_nulls() {
         let bitpacked = BitPackedArray::encode(
-            PrimitiveArray::from_nullable_vec(vec![Some(1i64), None, None]).array(),
+            PrimitiveArray::from_nullable_vec(vec![Some(1i64), None, None]).as_ref(),
             2,
         )
         .unwrap();

--- a/encodings/fastlanes/src/bitpacking/compute/search_sorted.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/search_sorted.rs
@@ -23,7 +23,7 @@ impl SearchSortedFn for BitPackedArray {
         })
     }
 
-    fn search_sorted_bulk(
+    fn search_sorted_many(
         &self,
         values: &[Scalar],
         sides: &[SearchSortedSide],

--- a/encodings/runend/src/runend.rs
+++ b/encodings/runend/src/runend.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
 use vortex::array::PrimitiveArray;
 use vortex::compute::unary::scalar_at;
-use vortex::compute::{search_sorted, SearchSortedSide};
+use vortex::compute::{search_sorted, search_sorted_bulk, SearchSortedSide};
 use vortex::stats::{ArrayStatistics, ArrayStatisticsCompute, StatsSet};
 use vortex::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use vortex::variants::{ArrayVariants, PrimitiveArrayTrait};
@@ -82,6 +82,23 @@ impl RunEndArray {
     pub fn find_physical_index(&self, index: usize) -> VortexResult<usize> {
         search_sorted(&self.ends(), index + self.offset(), SearchSortedSide::Right)
             .map(|s| s.to_ends_index(self.ends().len()))
+    }
+
+    /// Convert a batch of logical indices into an index for the values.
+    ///
+    /// See: [find_physical_index][Self::find_physical_index].
+    pub fn find_physical_indices(&self, indices: &[usize]) -> VortexResult<Vec<usize>> {
+        search_sorted_bulk(
+            &self.ends(),
+            indices,
+            &vec![SearchSortedSide::Right; indices.len()],
+        )
+        .map(|results| {
+            results
+                .iter()
+                .map(|result| result.to_ends_index(self.ends().len()))
+                .collect()
+        })
     }
 
     /// Run the array through run-end encoding.

--- a/encodings/runend/src/runend.rs
+++ b/encodings/runend/src/runend.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
 use vortex::array::PrimitiveArray;
 use vortex::compute::unary::scalar_at;
-use vortex::compute::{search_sorted, search_sorted_many, SearchSortedSide};
+use vortex::compute::{search_sorted, search_sorted_u64_many, SearchSortedSide};
 use vortex::stats::{ArrayStatistics, ArrayStatisticsCompute, StatsSet};
 use vortex::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use vortex::variants::{ArrayVariants, PrimitiveArrayTrait};
@@ -87,8 +87,8 @@ impl RunEndArray {
     /// Convert a batch of logical indices into an index for the values.
     ///
     /// See: [find_physical_index][Self::find_physical_index].
-    pub fn find_physical_indices(&self, indices: &[usize]) -> VortexResult<Vec<usize>> {
-        search_sorted_many(
+    pub fn find_physical_indices(&self, indices: &[u64]) -> VortexResult<Vec<usize>> {
+        search_sorted_u64_many(
             &self.ends(),
             indices,
             &vec![SearchSortedSide::Right; indices.len()],

--- a/encodings/runend/src/runend.rs
+++ b/encodings/runend/src/runend.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
 use vortex::array::PrimitiveArray;
 use vortex::compute::unary::scalar_at;
-use vortex::compute::{search_sorted, search_sorted_bulk, SearchSortedSide};
+use vortex::compute::{search_sorted, search_sorted_many, SearchSortedSide};
 use vortex::stats::{ArrayStatistics, ArrayStatisticsCompute, StatsSet};
 use vortex::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use vortex::variants::{ArrayVariants, PrimitiveArrayTrait};
@@ -88,7 +88,7 @@ impl RunEndArray {
     ///
     /// See: [find_physical_index][Self::find_physical_index].
     pub fn find_physical_indices(&self, indices: &[usize]) -> VortexResult<Vec<usize>> {
-        search_sorted_bulk(
+        search_sorted_many(
             &self.ends(),
             indices,
             &vec![SearchSortedSide::Right; indices.len()],

--- a/vortex-array/src/array/primitive/compute/search_sorted.rs
+++ b/vortex-array/src/array/primitive/compute/search_sorted.rs
@@ -6,6 +6,7 @@ use vortex_error::VortexResult;
 use vortex_scalar::Scalar;
 
 use crate::array::primitive::PrimitiveArray;
+use crate::ArrayDType;
 use crate::compute::{IndexOrd, Len, SearchResult, SearchSorted, SearchSortedFn, SearchSortedSide};
 use crate::validity::Validity;
 
@@ -14,12 +15,12 @@ impl SearchSortedFn for PrimitiveArray {
         match_each_native_ptype!(self.ptype(), |$T| {
             match self.validity() {
                 Validity::NonNullable | Validity::AllValid => {
-                    let pvalue: $T = value.try_into()?;
+                    let pvalue: $T = value.cast(self.dtype())?.try_into()?;
                     Ok(SearchSortedPrimitive::new(self).search_sorted(&pvalue, side))
                 }
                 Validity::AllInvalid => Ok(SearchResult::NotFound(0)),
                 Validity::Array(_) => {
-                    let pvalue: $T = value.try_into()?;
+                    let pvalue: $T = value.cast(self.dtype())?.try_into()?;
                     Ok(SearchSortedNullsLast::new(self).search_sorted(&pvalue, side))
                 }
             }

--- a/vortex-array/src/array/primitive/compute/search_sorted.rs
+++ b/vortex-array/src/array/primitive/compute/search_sorted.rs
@@ -6,9 +6,9 @@ use vortex_error::VortexResult;
 use vortex_scalar::Scalar;
 
 use crate::array::primitive::PrimitiveArray;
-use crate::ArrayDType;
 use crate::compute::{IndexOrd, Len, SearchResult, SearchSorted, SearchSortedFn, SearchSortedSide};
 use crate::validity::Validity;
+use crate::ArrayDType;
 
 impl SearchSortedFn for PrimitiveArray {
     fn search_sorted(&self, value: &Scalar, side: SearchSortedSide) -> VortexResult<SearchResult> {

--- a/vortex-array/src/array/primitive/compute/search_sorted.rs
+++ b/vortex-array/src/array/primitive/compute/search_sorted.rs
@@ -26,6 +26,29 @@ impl SearchSortedFn for PrimitiveArray {
             }
         })
     }
+
+    #[allow(clippy::cognitive_complexity)]
+    fn search_sorted_u64(&self, value: u64, side: SearchSortedSide) -> VortexResult<SearchResult> {
+        match_each_native_ptype!(self.ptype(), |$T| {
+            if let Some(pvalue) = num_traits::cast::<u64, $T>(value) {
+                match self.validity() {
+                    Validity::NonNullable | Validity::AllValid => {
+                        // null-free search
+                        Ok(SearchSortedPrimitive::new(self).search_sorted(&pvalue, side))
+                    }
+                    Validity::AllInvalid => Ok(SearchResult::NotFound(0)),
+                    Validity::Array(_) => {
+                        // null-aware search
+                        Ok(SearchSortedNullsLast::new(self).search_sorted(&pvalue, side))
+                    }
+                }
+            } else {
+                // provided u64 is too large to fit in the provided PType, value must be off
+                // the right end of the array.
+                Ok(SearchResult::NotFound(self.len()))
+            }
+        })
+    }
 }
 
 struct SearchSortedPrimitive<'a, T> {
@@ -90,7 +113,7 @@ mod test {
     use crate::IntoArray;
 
     #[test]
-    fn test_searchsorted_primitive() {
+    fn test_search_sorted_primitive() {
         let values = vec![1u16, 2, 3].into_array();
 
         assert_eq!(

--- a/vortex-array/src/array/primitive/mod.rs
+++ b/vortex-array/src/array/primitive/mod.rs
@@ -1,6 +1,6 @@
 use std::mem::{transmute, MaybeUninit};
-use std::sync::Arc;
 use std::ptr;
+use std::sync::Arc;
 
 use arrow_buffer::{ArrowNativeType, Buffer as ArrowBuffer, MutableBuffer};
 use bytes::Bytes;
@@ -115,12 +115,7 @@ impl PrimitiveArray {
         let raw_slice = self.buffer().as_slice();
         let typed_len = raw_slice.len() / size_of::<T>();
         // SAFETY: alignment of Buffer is checked on construction
-        unsafe {
-            std::slice::from_raw_parts(raw_slice.as_ptr().cast(), typed_len)
-        }
-        // let (prefix, values, suffix) = unsafe { self.buffer().as_ref().align_to::<T>() };
-        // assert!(prefix.is_empty() && suffix.is_empty());
-        // values
+        unsafe { std::slice::from_raw_parts(raw_slice.as_ptr().cast(), typed_len) }
     }
 
     /// Convert the array into a mutable vec of the given type.

--- a/vortex-array/src/array/primitive/mod.rs
+++ b/vortex-array/src/array/primitive/mod.rs
@@ -1,6 +1,6 @@
 use std::mem::{transmute, MaybeUninit};
-use std::ptr;
 use std::sync::Arc;
+use std::ptr;
 
 use arrow_buffer::{ArrowNativeType, Buffer as ArrowBuffer, MutableBuffer};
 use bytes::Bytes;
@@ -112,9 +112,15 @@ impl PrimitiveArray {
             self.ptype(),
         );
 
-        let (prefix, values, suffix) = unsafe { self.buffer().as_ref().align_to::<T>() };
-        assert!(prefix.is_empty() && suffix.is_empty());
-        values
+        let raw_slice = self.buffer().as_slice();
+        let typed_len = raw_slice.len() / size_of::<T>();
+        // SAFETY: alignment of Buffer is checked on construction
+        unsafe {
+            std::slice::from_raw_parts(raw_slice.as_ptr().cast(), typed_len)
+        }
+        // let (prefix, values, suffix) = unsafe { self.buffer().as_ref().align_to::<T>() };
+        // assert!(prefix.is_empty() && suffix.is_empty());
+        // values
     }
 
     /// Convert the array into a mutable vec of the given type.

--- a/vortex-array/src/compute/search_sorted.rs
+++ b/vortex-array/src/compute/search_sorted.rs
@@ -347,7 +347,6 @@ fn search_sorted_side_idx<F: FnMut(usize) -> Ordering>(
 
 impl IndexOrd<Scalar> for Array {
     fn index_cmp(&self, idx: usize, elem: &Scalar) -> Option<Ordering> {
-        // println!("INDEX_CMP SLOW PATH (encoding={:?})", self.encoding().id());
         let scalar_a = scalar_at(self, idx).ok()?;
         scalar_a.partial_cmp(elem)
     }

--- a/vortex-array/src/compute/search_sorted.rs
+++ b/vortex-array/src/compute/search_sorted.rs
@@ -96,7 +96,7 @@ pub trait SearchSortedFn {
     fn search_sorted(&self, value: &Scalar, side: SearchSortedSide) -> VortexResult<SearchResult>;
 
     /// Bulk search for many values.
-    fn search_sorted_bulk(
+    fn search_sorted_many(
         &self,
         values: &[Scalar],
         sides: &[SearchSortedSide],
@@ -136,7 +136,7 @@ pub fn search_sorted<T: Into<Scalar>>(
 }
 
 /// Search for many elements in the array.
-pub fn search_sorted_bulk<T: Into<Scalar> + Clone>(
+pub fn search_sorted_many<T: Into<Scalar> + Clone>(
     array: &Array,
     targets: &[T],
     sides: &[SearchSortedSide],
@@ -148,7 +148,7 @@ pub fn search_sorted_bulk<T: Into<Scalar> + Clone>(
                 .map(|t| t.clone().into().cast(array.dtype()))
                 .try_collect()?;
 
-            search_sorted.search_sorted_bulk(&values, sides)
+            search_sorted.search_sorted_many(&values, sides)
         } else {
             // Call in loop and collect
             targets

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -8,6 +8,9 @@
 //! Every data type recognized by Vortex also has a canonical physical encoding format, which
 //! arrays can be [canonicalized](Canonical) into for ease of access in compute functions.
 //!
+
+extern crate core;
+
 use std::fmt::{Debug, Display, Formatter};
 use std::future::ready;
 

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -9,8 +9,6 @@
 //! arrays can be [canonicalized](Canonical) into for ease of access in compute functions.
 //!
 
-extern crate core;
-
 use std::fmt::{Debug, Display, Formatter};
 use std::future::ready;
 


### PR DESCRIPTION
Coming out of #823 , we find that search_sorted on BitPackedArray is slow due to wastefully re-building `BitPackedArray`

This PR creates a new `search_sorted_bulk` that allows arrays to do some up-front initialization before doing loops of repeated searches, like `RunEndArray::find_physical_indices`

We're still about ~50% slower than #823 , unpack_single + branch mispredicts (which I think is all of the self time in `search_sorted`) seem to be the slowdown

<img width="3312" alt="image" src="https://github.com/user-attachments/assets/f28fbe65-285e-4db7-a6d4-41a35391f6ea">
