### PR TITLE
Use R2 bucket to persist fuzz corpus

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -15,13 +15,14 @@ jobs:
       - uses: ./.github/actions/setup-rust
       - name: Install cargo fuzz
         run: cargo install cargo-fuzz
-      - uses: actions/cache@v4
-        name: Restore corpus
-        with:
-          path: fuzz/corpus
-          key: array_ops-${{ hashFiles('fuzz/corpus/array_ops/*') }}
-          restore-keys: |
-            array_ops-
+      - name: Restore corpus
+        shell: bash
+        run: |
+          aws s3 cp s3://vortex-fuzz-corpus/array_ops_corpus.tar.zst . --endpoint-url https://01e9655179bbec953276890b183039bc.r2.cloudflarestorage.com
+          tar -xf array_ops_corpus.tar.zst
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_FUZZ_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_FUZZ_SECRET_ACCESS_KEY }}
       - name: Run fuzzing target
         run: RUST_BACKTRACE=1 cargo fuzz run array_ops -- -max_total_time=1800
         continue-on-error: true
@@ -30,3 +31,11 @@ jobs:
         with:
           name: fuzzing-crash-artifacts
           path: fuzz/artifacts
+      - name: Persist corpus
+        shell: bash
+        run: |
+          tar -acf array_ops_corpus.tar.zst fuzz/corpus/array_ops
+          aws s3 cp array_ops_corpus.tar.zst s3://vortex-fuzz-corpus --endpoint-url https://01e9655179bbec953276890b183039bc.r2.cloudflarestorage.com
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_FUZZ_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_FUZZ_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Unfortunately github caches have annoying behaviour when it comes to updates

In our case we always want to restore what's there and after the run upload
augmented corpus which is annoying to do with github actions
