### PR TITLE
fix: vortex-serde benchmarks depend on the ipc feature in arrow

### DIFF
--- a/vortex-serde/Cargo.toml
+++ b/vortex-serde/Cargo.toml
@@ -32,7 +32,7 @@ vortex-scalar = { workspace = true, features = ["flatbuffers"] }
 vortex-schema = { workspace = true }
 
 [dev-dependencies]
-arrow = { workspace = true }
+arrow = { workspace = true, features = ["ipc"] }
 arrow-array = { workspace = true }
 arrow-ipc = { workspace = true, features = ["lz4"] }
 arrow-schema = { workspace = true }


### PR DESCRIPTION
Resolves:
```
   Compiling vortex-serde v0.8.0 (/home/runner/work/vortex/vortex/vortex-serde)
error[E0433]: failed to resolve: could not find `ipc` in `arrow`
   --> vortex-serde/benches/ipc_take.rs:4:12
    |
4   | use arrow::ipc::reader::StreamReader as ArrowStreamReader;
    |            ^^^ could not find `ipc` in `arrow`
    |
note: found an item that was configured out
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/arrow-53.0.0/src/lib.rs:384:22
    |
384 | pub use arrow_ipc as ipc;
    |                      ^^^
note: the item is gated behind the `ipc` feature
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/arrow-53.0.0/src/lib.rs:383:7
    |
383 | #[cfg(feature = "ipc")]
    |       ^^^^^^^^^^^^^^^
```