### PR TITLE
Update to rust 1.81 binary_search algorithm

### DIFF
--- a/vortex-array/src/compute/search_sorted.rs
+++ b/vortex-array/src/compute/search_sorted.rs
@@ -2,7 +2,6 @@ use std::cmp::Ordering;
 use std::cmp::Ordering::{Equal, Greater, Less};
 use std::fmt::{Debug, Display, Formatter};
 use std::hint;
-use std::intrinsics::select_unpredictable;
 
 use vortex_error::{vortex_bail, VortexResult};
 use vortex_scalar::Scalar;
@@ -241,7 +240,7 @@ fn search_sorted_side_idx<F: FnMut(usize) -> Ordering>(
         // Binary search interacts poorly with branch prediction, so force
         // the compiler to use conditional moves if supported by the target
         // architecture.
-        base = select_unpredictable(cmp == Greater, base, mid);
+        base = if cmp == Greater { base } else { mid };
 
         // This is imprecise in the case where `size` is odd and the
         // comparison returns Greater: the mid element still gets included

--- a/vortex-array/src/compute/search_sorted.rs
+++ b/vortex-array/src/compute/search_sorted.rs
@@ -256,13 +256,13 @@ fn search_sorted_side_idx<F: FnMut(usize) -> Ordering>(
     // SAFETY: base is always in [0, size) because base <= mid.
     let cmp = find(base);
     if cmp == Equal {
-        // SAFETY: same as the `get_unchecked` above.
+        // SAFETY: same as the call to `find` above.
         unsafe { hint::assert_unchecked(base < to) };
         SearchResult::Found(base)
     } else {
         let result = base + (cmp == Less) as usize;
-        // SAFETY: same as the `get_unchecked` above.
-        // Note that this is `<=`, unlike the assume in the `Ok` path.
+        // SAFETY: same as the call to `find` above.
+        // Note that this is `<=`, unlike the assert in the `Found` path.
         unsafe { hint::assert_unchecked(result <= to) };
         SearchResult::NotFound(result)
     }

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -8,6 +8,8 @@
 //! Every data type recognized by Vortex also has a canonical physical encoding format, which
 //! arrays can be [canonicalized](Canonical) into for ease of access in compute functions.
 //!
+#![allow(internal_features)]
+#![feature(core_intrinsics)]
 use std::fmt::{Debug, Display, Formatter};
 use std::future::ready;
 

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -8,8 +8,6 @@
 //! Every data type recognized by Vortex also has a canonical physical encoding format, which
 //! arrays can be [canonicalized](Canonical) into for ease of access in compute functions.
 //!
-#![allow(internal_features)]
-#![feature(core_intrinsics)]
 use std::fmt::{Debug, Display, Formatter};
 use std::future::ready;
 


### PR DESCRIPTION
For reference we still match standard library even without the intrisic instruction, at least on arm

```
search_sorted/std       time:   [18.631 ns 18.673 ns 18.724 ns]
                        change: [-4.3712% -1.4845% +0.1634%] (p = 0.34 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe
search_sorted/vortex    time:   [18.550 ns 18.574 ns 18.601 ns]
                        change: [-48.941% -47.404% -46.028%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe
```