### PR TITLE
fix: run publish-vortex.yml when release-plz releases

### DIFF
--- a/.github/workflows/publish-vortex.yml
+++ b/.github/workflows/publish-vortex.yml
@@ -1,8 +1,6 @@
 name: Publish to PyPI
 on:
-  push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+  workflow_call:
 
 jobs:
   macos:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -25,7 +25,11 @@ jobs:
       - uses: ./.github/actions/setup-python
 
       - name: Run release-plz
+        id: run-release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Release to PyPI
+        if: ${{ steps.run-release-plz.outputs.releases_created }}
+        uses: ./.github/workflows/publish-vortex.yml


### PR DESCRIPTION
When release plz pushses a tag it uses the GITHUB_TOKEN secret which [explicitly does not trigger any workflows](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow). Instead, we can call the publish-vortex workflow explicitly from the release-plz workflow whenever release-plz actually releases a crate.