### PR TITLE
fix: workflows can only be called as jobs not steps

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -13,6 +13,8 @@ jobs:
   release-plz:
     name: Release-plz
     runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.run-release-plz.outputs.releases_created }}  # Expose this step output as a job output
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,6 +32,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      - name: Release to PyPI
-        if: ${{ steps.run-release-plz.outputs.releases_created }}
-        uses: ./.github/workflows/publish-vortex.yml
+  release-to-pypi:
+    name: Release to PyPI
+    if: ${{ jobs.release-plz.outputs.releases_created }}
+    uses: ./.github/workflows/publish-vortex.yml


### PR DESCRIPTION
I missed this note:

> You call a reusable workflow by using the uses keyword. Unlike when you are using actions within a workflow, you call reusable workflows directly within a job, and not from within job steps.

[Calling a reusable workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#calling-a-reusable-workflow).