### PR TITLE
Make entry point compute functions accept generic arguments

### DIFF
--- a/encodings/alp/src/compute.rs
+++ b/encodings/alp/src/compute.rs
@@ -84,7 +84,7 @@ impl SliceFn for ALPArray {
 impl FilterFn for ALPArray {
     fn filter(&self, predicate: &Array) -> VortexResult<Array> {
         Ok(Self::try_new(
-            filter(&self.encoded(), predicate)?,
+            filter(self.encoded(), predicate)?,
             self.exponents(),
             self.patches().map(|p| filter(&p, predicate)).transpose()?,
         )?
@@ -134,7 +134,7 @@ where
     match encoded {
         Ok(encoded) => {
             let s = ConstantArray::new(encoded, alp.len());
-            compare(&alp.encoded(), s.as_ref(), operator)
+            compare(alp.encoded(), s.as_ref(), operator)
         }
         Err(exception) => {
             if let Some(patches) = alp.patches().as_ref() {

--- a/encodings/alp/src/compute.rs
+++ b/encodings/alp/src/compute.rs
@@ -62,7 +62,7 @@ impl TakeFn for ALPArray {
     fn take(&self, indices: &Array) -> VortexResult<Array> {
         // TODO(ngates): wrap up indices in an array that caches decompression?
         Ok(Self::try_new(
-            take(&self.encoded(), indices)?,
+            take(self.encoded(), indices)?,
             self.exponents(),
             self.patches().map(|p| take(&p, indices)).transpose()?,
         )?

--- a/encodings/alp/src/compute.rs
+++ b/encodings/alp/src/compute.rs
@@ -73,7 +73,7 @@ impl TakeFn for ALPArray {
 impl SliceFn for ALPArray {
     fn slice(&self, start: usize, end: usize) -> VortexResult<Array> {
         Ok(Self::try_new(
-            slice(&self.encoded(), start, end)?,
+            slice(self.encoded(), start, end)?,
             self.exponents(),
             self.patches().map(|p| slice(&p, start, end)).transpose()?,
         )?

--- a/encodings/datetime-parts/src/compute.rs
+++ b/encodings/datetime-parts/src/compute.rs
@@ -28,9 +28,9 @@ impl TakeFn for DateTimePartsArray {
     fn take(&self, indices: &Array) -> VortexResult<Array> {
         Ok(Self::try_new(
             self.dtype().clone(),
-            take(&self.days(), indices)?,
-            take(&self.seconds(), indices)?,
-            take(&self.subsecond(), indices)?,
+            take(self.days(), indices)?,
+            take(self.seconds(), indices)?,
+            take(self.subsecond(), indices)?,
         )?
         .into_array())
     }

--- a/encodings/datetime-parts/src/compute.rs
+++ b/encodings/datetime-parts/src/compute.rs
@@ -40,9 +40,9 @@ impl SliceFn for DateTimePartsArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         Ok(Self::try_new(
             self.dtype().clone(),
-            slice(&self.days(), start, stop)?,
-            slice(&self.seconds(), start, stop)?,
-            slice(&self.subsecond(), start, stop)?,
+            slice(self.days(), start, stop)?,
+            slice(self.seconds(), start, stop)?,
+            slice(self.subsecond(), start, stop)?,
         )?
         .into_array())
     }

--- a/encodings/dict/src/compute.rs
+++ b/encodings/dict/src/compute.rs
@@ -49,7 +49,7 @@ impl TakeFn for DictArray {
 impl SliceFn for DictArray {
     // TODO(robert): Add function to trim the dictionary
     fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
-        Self::try_new(slice(&self.codes(), start, stop)?, self.values()).map(|a| a.into_array())
+        Self::try_new(slice(self.codes(), start, stop)?, self.values()).map(|a| a.into_array())
     }
 }
 

--- a/encodings/dict/src/compute.rs
+++ b/encodings/dict/src/compute.rs
@@ -41,7 +41,7 @@ impl TakeFn for DictArray {
         // Dict
         //   codes: 0 0 1
         //   dict: a b c d e f g h
-        let codes = take(&self.codes(), indices)?;
+        let codes = take(self.codes(), indices)?;
         Self::try_new(codes, self.values()).map(|a| a.into_array())
     }
 }

--- a/encodings/dict/src/dict.rs
+++ b/encodings/dict/src/dict.rs
@@ -59,7 +59,7 @@ impl ArrayTrait for DictArray {}
 
 impl IntoCanonical for DictArray {
     fn into_canonical(self) -> VortexResult<Canonical> {
-        take(&self.values(), &self.codes())?.into_canonical()
+        take(self.values(), self.codes())?.into_canonical()
     }
 }
 

--- a/encodings/fastlanes/src/bitpacking/compute/search_sorted.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/search_sorted.rs
@@ -227,12 +227,8 @@ mod test {
     #[test]
     fn search_sliced() {
         let bitpacked = slice(
-            &BitPackedArray::encode(
-                &PrimitiveArray::from(vec![1u32, 2, 3, 4, 5]).into_array(),
-                2,
-            )
-            .unwrap()
-            .into_array(),
+            BitPackedArray::encode(PrimitiveArray::from(vec![1u32, 2, 3, 4, 5]).as_ref(), 2)
+                .unwrap(),
             2,
             4,
         )

--- a/encodings/fastlanes/src/bitpacking/compute/slice.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/slice.rs
@@ -18,7 +18,7 @@ impl SliceFn for BitPackedArray {
         let encoded_start = (block_start / 8) * self.bit_width() / self.ptype().byte_width();
         let encoded_stop = (block_stop / 8) * self.bit_width() / self.ptype().byte_width();
         Self::try_new_from_offset(
-            slice(&self.packed(), encoded_start, encoded_stop)?,
+            slice(self.packed(), encoded_start, encoded_stop)?,
             self.validity().slice(start, stop)?,
             self.patches()
                 .map(|p| slice(&p, start, stop))
@@ -171,7 +171,7 @@ mod test {
         assert_eq!(patch_indices.len(), 1);
 
         // Slicing drops the empty patches array.
-        let sliced = slice(&array.into_array(), 0, 64).unwrap();
+        let sliced = slice(array, 0, 64).unwrap();
         let sliced_bp = BitPackedArray::try_from(sliced).unwrap();
         assert!(sliced_bp.patches().is_none());
     }

--- a/encodings/fastlanes/src/for/compute.rs
+++ b/encodings/fastlanes/src/for/compute.rs
@@ -38,7 +38,7 @@ impl ArrayCompute for FoRArray {
 impl TakeFn for FoRArray {
     fn take(&self, indices: &Array) -> VortexResult<Array> {
         Self::try_new(
-            take(&self.encoded(), indices)?,
+            take(self.encoded(), indices)?,
             self.reference().clone(),
             self.shift(),
         )

--- a/encodings/fastlanes/src/for/compute.rs
+++ b/encodings/fastlanes/src/for/compute.rs
@@ -49,7 +49,7 @@ impl TakeFn for FoRArray {
 impl FilterFn for FoRArray {
     fn filter(&self, predicate: &Array) -> VortexResult<Array> {
         Self::try_new(
-            filter(&self.encoded(), predicate)?,
+            filter(self.encoded(), predicate)?,
             self.reference().clone(),
             self.shift(),
         )

--- a/encodings/fastlanes/src/for/compute.rs
+++ b/encodings/fastlanes/src/for/compute.rs
@@ -81,7 +81,7 @@ impl ScalarAtFn for FoRArray {
 impl SliceFn for FoRArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         Self::try_new(
-            slice(&self.encoded(), start, stop)?,
+            slice(self.encoded(), start, stop)?,
             self.reference().clone(),
             self.shift(),
         )

--- a/encodings/fsst/src/compute.rs
+++ b/encodings/fsst/src/compute.rs
@@ -81,8 +81,8 @@ impl FilterFn for FSSTArray {
             self.dtype().clone(),
             self.symbols(),
             self.symbol_lengths(),
-            filter(&self.codes(), predicate)?,
-            filter(&self.uncompressed_lengths(), predicate)?,
+            filter(self.codes(), predicate)?,
+            filter(self.uncompressed_lengths(), predicate)?,
         )?
         .into_array())
     }

--- a/encodings/fsst/src/compute.rs
+++ b/encodings/fsst/src/compute.rs
@@ -48,8 +48,8 @@ impl TakeFn for FSSTArray {
             self.dtype().clone(),
             self.symbols(),
             self.symbol_lengths(),
-            take(&self.codes(), indices)?,
-            take(&self.uncompressed_lengths(), indices)?,
+            take(self.codes(), indices)?,
+            take(self.uncompressed_lengths(), indices)?,
         )?
         .into_array())
     }

--- a/encodings/fsst/src/compute.rs
+++ b/encodings/fsst/src/compute.rs
@@ -34,8 +34,8 @@ impl SliceFn for FSSTArray {
             self.dtype().clone(),
             self.symbols(),
             self.symbol_lengths(),
-            slice(&self.codes(), start, stop)?,
-            slice(&self.uncompressed_lengths(), start, stop)?,
+            slice(self.codes(), start, stop)?,
+            slice(self.uncompressed_lengths(), start, stop)?,
         )?
         .into_array())
     }

--- a/encodings/runend-bool/src/array.rs
+++ b/encodings/runend-bool/src/array.rs
@@ -230,14 +230,13 @@ mod test {
     #[test]
     fn take_bool() {
         let arr = take(
-            &RunEndBoolArray::try_new(
+            RunEndBoolArray::try_new(
                 vec![2u32, 4, 5, 10].into_array(),
                 true,
                 Validity::NonNullable,
             )
-            .unwrap()
-            .to_array(),
-            &vec![0, 0, 6, 4].into_array(),
+            .unwrap(),
+            vec![0, 0, 6, 4].into_array(),
         )
         .unwrap();
 

--- a/encodings/runend-bool/src/compute.rs
+++ b/encodings/runend-bool/src/compute.rs
@@ -75,7 +75,7 @@ impl SliceFn for RunEndBoolArray {
         let slice_end = self.find_physical_index(stop)?;
 
         Ok(Self::with_offset_and_size(
-            slice(&self.ends(), slice_begin, slice_end + 1)?,
+            slice(self.ends(), slice_begin, slice_end + 1)?,
             value_at_index(slice_begin, self.start()),
             self.validity().slice(slice_begin, slice_end + 1)?,
             stop - start,

--- a/encodings/runend/src/compute.rs
+++ b/encodings/runend/src/compute.rs
@@ -60,7 +60,7 @@ impl TakeFn for RunEndArray {
             .map(|idx| *idx as u64)
             .collect();
         let physical_indices_array = PrimitiveArray::from(physical_indices).into_array();
-        let dense_values = take(&self.values(), &physical_indices_array)?;
+        let dense_values = take(self.values(), &physical_indices_array)?;
 
         Ok(match self.validity() {
             Validity::NonNullable => dense_values,

--- a/encodings/runend/src/compute.rs
+++ b/encodings/runend/src/compute.rs
@@ -100,8 +100,8 @@ impl SliceFn for RunEndArray {
         let slice_end = self.find_physical_index(stop)?;
 
         Ok(Self::with_offset_and_size(
-            slice(&self.ends(), slice_begin, slice_end + 1)?,
-            slice(&self.values(), slice_begin, slice_end + 1)?,
+            slice(self.ends(), slice_begin, slice_end + 1)?,
+            slice(self.values(), slice_begin, slice_end + 1)?,
             self.validity().slice(start, stop)?,
             stop - start,
             start + self.offset(),

--- a/encodings/zigzag/src/compute.rs
+++ b/encodings/zigzag/src/compute.rs
@@ -67,7 +67,7 @@ impl ZigZagEncoded for u64 {
 
 impl SliceFn for ZigZagArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
-        Ok(Self::try_new(slice(&self.encoded(), start, stop)?)?.into_array())
+        Ok(Self::try_new(slice(self.encoded(), start, stop)?)?.into_array())
     }
 }
 

--- a/vortex-array/src/array/bool/compute/take.rs
+++ b/vortex-array/src/array/bool/compute/take.rs
@@ -29,7 +29,6 @@ mod test {
     use crate::array::primitive::PrimitiveArray;
     use crate::array::BoolArray;
     use crate::compute::take;
-    use crate::IntoArray;
 
     #[test]
     fn take_nullable() {

--- a/vortex-array/src/array/bool/compute/take.rs
+++ b/vortex-array/src/array/bool/compute/take.rs
@@ -39,17 +39,10 @@ mod test {
             Some(false),
             None,
             Some(false),
-        ])
-        .into_array();
+        ]);
 
-        let b = BoolArray::try_from(
-            take(
-                &reference,
-                &PrimitiveArray::from(vec![0, 3, 4]).into_array(),
-            )
-            .unwrap(),
-        )
-        .unwrap();
+        let b = BoolArray::try_from(take(&reference, PrimitiveArray::from(vec![0, 3, 4])).unwrap())
+            .unwrap();
         assert_eq!(
             b.boolean_buffer(),
             BoolArray::from_iter(vec![Some(false), None, Some(false)]).boolean_buffer()

--- a/vortex-array/src/array/chunked/canonical.rs
+++ b/vortex-array/src/array/chunked/canonical.rs
@@ -215,7 +215,7 @@ fn pack_varbin(chunks: &[Array], validity: Validity, dtype: &DType) -> VortexRes
             offsets_arr.len() - 1,
         ))?;
         let primitive_bytes =
-            slice(&chunk.bytes(), first_offset_value, last_offset_value)?.into_primitive()?;
+            slice(chunk.bytes(), first_offset_value, last_offset_value)?.into_primitive()?;
         data_bytes.extend_from_slice(primitive_bytes.buffer());
 
         let adjustment_from_previous = *offsets

--- a/vortex-array/src/array/chunked/compute/filter.rs
+++ b/vortex-array/src/array/chunked/compute/filter.rs
@@ -172,8 +172,8 @@ fn filter_indices<'a>(
                     .chunk(current_chunk_id)
                     .vortex_expect("find_chunk_idx must return valid chunk ID");
                 let filtered_chunk = take(
-                    &chunk,
-                    &PrimitiveArray::from(chunk_indices.clone()).into_array(),
+                    chunk,
+                    PrimitiveArray::from(chunk_indices.clone()).into_array(),
                 )?;
                 result.push(filtered_chunk);
             }
@@ -192,7 +192,7 @@ fn filter_indices<'a>(
             .vortex_expect("find_chunk_idx must return valid chunk ID");
         let filtered_chunk = take(
             &chunk,
-            &PrimitiveArray::from(chunk_indices.clone()).into_array(),
+            PrimitiveArray::from(chunk_indices.clone()).into_array(),
         )?;
         result.push(filtered_chunk);
     }

--- a/vortex-array/src/array/chunked/compute/filter.rs
+++ b/vortex-array/src/array/chunked/compute/filter.rs
@@ -141,7 +141,7 @@ fn filter_slices<'a>(
             ChunkFilter::None => {}
             // Slices => turn the slices into a boolean buffer.
             ChunkFilter::Slices(slices) => {
-                result.push(filter(&chunk, &slices_to_predicate(slices, chunk.len()))?);
+                result.push(filter(&chunk, slices_to_predicate(slices, chunk.len()))?);
             }
         }
     }

--- a/vortex-array/src/array/chunked/compute/slice.rs
+++ b/vortex-array/src/array/chunked/compute/slice.rs
@@ -26,13 +26,13 @@ impl SliceFn for ChunkedArray {
             })
             .collect::<VortexResult<Vec<_>>>()?;
         if let Some(c) = chunks.first_mut() {
-            *c = slice(c, offset_in_first_chunk, c.len())?;
+            *c = slice(&*c, offset_in_first_chunk, c.len())?;
         }
 
         if length_in_last_chunk == 0 {
             chunks.pop();
         } else if let Some(c) = chunks.last_mut() {
-            *c = slice(c, 0, length_in_last_chunk)?;
+            *c = slice(&*c, 0, length_in_last_chunk)?;
         }
 
         Self::try_new(chunks, self.dtype().clone()).map(|a| a.into_array())

--- a/vortex-array/src/array/extension/compute.rs
+++ b/vortex-array/src/array/extension/compute.rs
@@ -77,7 +77,7 @@ impl SliceFn for ExtensionArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         Ok(Self::new(
             self.ext_dtype().clone(),
-            slice(&self.storage(), start, stop)?,
+            slice(self.storage(), start, stop)?,
         )
         .into_array())
     }

--- a/vortex-array/src/array/extension/compute.rs
+++ b/vortex-array/src/array/extension/compute.rs
@@ -45,12 +45,12 @@ impl MaybeCompareFn for ExtensionArray {
                     Scalar::new(self.storage().dtype().clone(), scalar_ext.value().clone()),
                     const_ext.len(),
                 );
-                compare(&self.storage(), const_storage.as_ref(), operator)
+                compare(self.storage(), const_storage, operator)
             });
         }
 
         if let Ok(rhs_ext) = ExtensionArray::try_from(array) {
-            return Some(compare(&self.storage(), &rhs_ext.storage(), operator));
+            return Some(compare(self.storage(), rhs_ext.storage(), operator));
         }
 
         None

--- a/vortex-array/src/array/extension/compute.rs
+++ b/vortex-array/src/array/extension/compute.rs
@@ -85,6 +85,6 @@ impl SliceFn for ExtensionArray {
 
 impl TakeFn for ExtensionArray {
     fn take(&self, indices: &Array) -> VortexResult<Array> {
-        Ok(Self::new(self.ext_dtype().clone(), take(&self.storage(), indices)?).into_array())
+        Ok(Self::new(self.ext_dtype().clone(), take(self.storage(), indices)?).into_array())
     }
 }

--- a/vortex-array/src/array/null/compute.rs
+++ b/vortex-array/src/array/null/compute.rs
@@ -79,9 +79,8 @@ mod test {
     #[test]
     fn test_take_nulls() {
         let nulls = NullArray::new(10).into_array();
-        let taken =
-            NullArray::try_from(take(&nulls, &vec![0u64, 2, 4, 6, 8].into_array()).unwrap())
-                .unwrap();
+        let taken = NullArray::try_from(take(&nulls, vec![0u64, 2, 4, 6, 8].into_array()).unwrap())
+            .unwrap();
 
         assert_eq!(taken.len(), 5);
         assert!(matches!(

--- a/vortex-array/src/array/sparse/compute/mod.rs
+++ b/vortex-array/src/array/sparse/compute/mod.rs
@@ -104,7 +104,7 @@ impl FilterFn for SparseArray {
 
         Ok(SparseArray::try_new(
             PrimitiveArray::from(coordinate_indices).into_array(),
-            take(&self.values(), PrimitiveArray::from(value_indices).as_ref())?,
+            take(self.values(), PrimitiveArray::from(value_indices))?,
             buffer.count_set_bits(),
             self.fill_value().clone(),
         )?

--- a/vortex-array/src/array/sparse/compute/slice.rs
+++ b/vortex-array/src/array/sparse/compute/slice.rs
@@ -11,8 +11,8 @@ impl SliceFn for SparseArray {
         let index_end_index = self.search_index(stop)?.to_index();
 
         Ok(Self::try_new_with_offset(
-            slice(&self.indices(), index_start_index, index_end_index)?,
-            slice(&self.values(), index_start_index, index_end_index)?,
+            slice(self.indices(), index_start_index, index_end_index)?,
+            slice(self.values(), index_start_index, index_end_index)?,
             stop - start,
             self.indices_offset() + start,
             self.fill_value().clone(),

--- a/vortex-array/src/array/sparse/compute/take.rs
+++ b/vortex-array/src/array/sparse/compute/take.rs
@@ -20,7 +20,7 @@ impl TakeFn for SparseArray {
             take_search_sorted(self, &flat_indices)?
         };
 
-        let taken_values = take(&self.values(), &physical_take_indices.into_array())?;
+        let taken_values = take(self.values(), physical_take_indices)?;
 
         Ok(Self::try_new(
             positions.into_array(),
@@ -110,7 +110,7 @@ mod test {
     fn sparse_take() {
         let sparse = sparse_array();
         let taken =
-            SparseArray::try_from(take(&sparse, &vec![0, 47, 47, 0, 99].into_array()).unwrap())
+            SparseArray::try_from(take(sparse, vec![0, 47, 47, 0, 99].into_array()).unwrap())
                 .unwrap();
         assert_eq!(
             taken
@@ -133,7 +133,7 @@ mod test {
     #[test]
     fn nonexistent_take() {
         let sparse = sparse_array();
-        let taken = SparseArray::try_from(take(&sparse, &vec![69].into_array()).unwrap()).unwrap();
+        let taken = SparseArray::try_from(take(sparse, vec![69].into_array()).unwrap()).unwrap();
         assert!(taken
             .indices()
             .into_primitive()
@@ -152,7 +152,7 @@ mod test {
     fn ordered_take() {
         let sparse = sparse_array();
         let taken =
-            SparseArray::try_from(take(&sparse, &vec![69, 37].into_array()).unwrap()).unwrap();
+            SparseArray::try_from(take(&sparse, vec![69, 37].into_array()).unwrap()).unwrap();
         assert_eq!(
             taken
                 .indices()

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -265,7 +265,7 @@ mod test {
     pub fn iter_sliced() {
         let p_fill_val = Some(non_nullable_fill().as_ref().try_into().unwrap());
         assert_sparse_array(
-            &slice(&sparse_array(non_nullable_fill()), 2, 7).unwrap(),
+            &slice(sparse_array(non_nullable_fill()), 2, 7).unwrap(),
             &[Some(100), p_fill_val, p_fill_val, Some(200), p_fill_val],
         );
     }
@@ -273,14 +273,14 @@ mod test {
     #[test]
     pub fn iter_sliced_nullable() {
         assert_sparse_array(
-            &slice(&sparse_array(nullable_fill()), 2, 7).unwrap(),
+            &slice(sparse_array(nullable_fill()), 2, 7).unwrap(),
             &[Some(100), None, None, Some(200), None],
         );
     }
 
     #[test]
     pub fn iter_sliced_twice() {
-        let sliced_once = slice(&sparse_array(nullable_fill()), 1, 8).unwrap();
+        let sliced_once = slice(sparse_array(nullable_fill()), 1, 8).unwrap();
         assert_sparse_array(
             &sliced_once,
             &[None, Some(100), None, None, Some(200), None, None],
@@ -316,7 +316,7 @@ mod test {
 
     #[test]
     pub fn scalar_at_sliced() {
-        let sliced = slice(&sparse_array(nullable_fill()), 2, 7).unwrap();
+        let sliced = slice(sparse_array(nullable_fill()), 2, 7).unwrap();
         assert_eq!(
             usize::try_from(&scalar_at(&sliced, 0).unwrap()).unwrap(),
             100
@@ -332,7 +332,7 @@ mod test {
 
     #[test]
     pub fn scalar_at_sliced_twice() {
-        let sliced_once = slice(&sparse_array(nullable_fill()), 1, 8).unwrap();
+        let sliced_once = slice(sparse_array(nullable_fill()), 1, 8).unwrap();
         assert_eq!(
             usize::try_from(&scalar_at(&sliced_once, 1).unwrap()).unwrap(),
             100

--- a/vortex-array/src/array/struct_/compute.rs
+++ b/vortex-array/src/array/struct_/compute.rs
@@ -104,7 +104,6 @@ mod tests {
     use crate::array::{BoolArray, StructArray};
     use crate::compute::filter;
     use crate::validity::Validity;
-    use crate::IntoArray;
 
     #[test]
     fn filter_empty_struct() {
@@ -113,7 +112,7 @@ mod tests {
         let mask = vec![
             false, true, false, true, false, true, false, true, false, true,
         ];
-        let filtered = filter(struct_arr.as_ref(), &BoolArray::from(mask).into_array()).unwrap();
+        let filtered = filter(struct_arr.as_ref(), BoolArray::from(mask)).unwrap();
         assert_eq!(filtered.len(), 5);
     }
 
@@ -121,7 +120,7 @@ mod tests {
     fn filter_empty_struct_with_empty_filter() {
         let struct_arr =
             StructArray::try_new(vec![].into(), vec![], 0, Validity::NonNullable).unwrap();
-        let filtered = filter(struct_arr.as_ref(), &BoolArray::from(vec![]).into_array()).unwrap();
+        let filtered = filter(struct_arr.as_ref(), BoolArray::from(vec![])).unwrap();
         assert_eq!(filtered.len(), 0);
     }
 }

--- a/vortex-array/src/array/varbin/compute/slice.rs
+++ b/vortex-array/src/array/varbin/compute/slice.rs
@@ -7,7 +7,7 @@ use crate::{Array, ArrayDType, IntoArray};
 impl SliceFn for VarBinArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         Self::try_new(
-            slice(&self.offsets(), start, stop + 1)?,
+            slice(self.offsets(), start, stop + 1)?,
             self.bytes(),
             self.dtype().clone(),
             self.validity().slice(start, stop)?,

--- a/vortex-array/src/array/varbin/mod.rs
+++ b/vortex-array/src/array/varbin/mod.rs
@@ -108,7 +108,7 @@ impl VarBinArray {
         let last_offset: usize = scalar_at(&self.offsets(), self.offsets().len() - 1)?
             .as_ref()
             .try_into()?;
-        slice(&self.bytes(), first_offset, last_offset)
+        slice(self.bytes(), first_offset, last_offset)
     }
 
     pub fn from_vec<T: AsRef<[u8]>>(vec: Vec<T>, dtype: DType) -> Self {
@@ -167,7 +167,7 @@ impl VarBinArray {
     pub fn bytes_at(&self, index: usize) -> VortexResult<Buffer> {
         let start = self.offset_at(index);
         let end = self.offset_at(index + 1);
-        let sliced = slice(&self.bytes(), start, end)?;
+        let sliced = slice(self.bytes(), start, end)?;
         Ok(sliced.into_primitive()?.buffer().clone())
     }
 }

--- a/vortex-array/src/array/varbinview/compute.rs
+++ b/vortex-array/src/array/varbinview/compute.rs
@@ -32,7 +32,7 @@ impl ScalarAtFn for VarBinViewArray {
 impl SliceFn for VarBinViewArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         Ok(Self::try_new(
-            slice(&self.views(), start * VIEW_SIZE, stop * VIEW_SIZE)?,
+            slice(self.views(), start * VIEW_SIZE, stop * VIEW_SIZE)?,
             (0..self.metadata().data_lens.len())
                 .map(|i| self.bytes(i))
                 .collect::<Vec<_>>(),

--- a/vortex-array/src/array/varbinview/mod.rs
+++ b/vortex-array/src/array/varbinview/mod.rs
@@ -244,7 +244,7 @@ impl VarBinViewArray {
         unsafe {
             if !view.is_inlined() {
                 let data_buf = slice(
-                    &self.bytes(view._ref.buffer_index as usize),
+                    self.bytes(view._ref.buffer_index as usize),
                     view._ref.offset as usize,
                     (view._ref.size + view._ref.offset) as usize,
                 )?
@@ -389,8 +389,7 @@ mod test {
     #[test]
     pub fn slice_array() {
         let binary_arr = slice(
-            &VarBinViewArray::from_iter_str(["hello world", "hello world this is a long string"])
-                .into(),
+            VarBinViewArray::from_iter_str(["hello world", "hello world this is a long string"]),
             1,
             2,
         )

--- a/vortex-array/src/compute/boolean.rs
+++ b/vortex-array/src/compute/boolean.rs
@@ -10,7 +10,10 @@ pub trait OrFn {
     fn or(&self, array: &Array) -> VortexResult<Array>;
 }
 
-pub fn and(lhs: &Array, rhs: &Array) -> VortexResult<Array> {
+pub fn and(lhs: impl AsRef<Array>, rhs: impl AsRef<Array>) -> VortexResult<Array> {
+    let lhs = lhs.as_ref();
+    let rhs = rhs.as_ref();
+
     if lhs.len() != rhs.len() {
         vortex_bail!("Boolean operations aren't supported on arrays of different lengths")
     }
@@ -33,7 +36,10 @@ pub fn and(lhs: &Array, rhs: &Array) -> VortexResult<Array> {
     lhs.and(rhs)
 }
 
-pub fn or(lhs: &Array, rhs: &Array) -> VortexResult<Array> {
+pub fn or(lhs: impl AsRef<Array>, rhs: impl AsRef<Array>) -> VortexResult<Array> {
+    let lhs = lhs.as_ref();
+    let rhs = rhs.as_ref();
+
     if lhs.len() != rhs.len() {
         vortex_bail!("Boolean operations aren't supported on arrays of different lengths")
     }

--- a/vortex-array/src/compute/compare.rs
+++ b/vortex-array/src/compute/compare.rs
@@ -79,7 +79,14 @@ pub trait MaybeCompareFn {
     fn maybe_compare(&self, other: &Array, operator: Operator) -> Option<VortexResult<Array>>;
 }
 
-pub fn compare(left: &Array, right: &Array, operator: Operator) -> VortexResult<Array> {
+pub fn compare(
+    left: impl AsRef<Array>,
+    right: impl AsRef<Array>,
+    operator: Operator,
+) -> VortexResult<Array> {
+    let left = left.as_ref();
+    let right = right.as_ref();
+
     if left.len() != right.len() {
         vortex_bail!("Compare operations only support arrays of the same length");
     }

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -20,7 +20,10 @@ pub trait FilterFn {
 ///
 /// The `predicate` must receive an Array with type non-nullable bool, and will panic if this is
 /// not the case.
-pub fn filter(array: &Array, predicate: &Array) -> VortexResult<Array> {
+pub fn filter(array: impl AsRef<Array>, predicate: impl AsRef<Array>) -> VortexResult<Array> {
+    let array = array.as_ref();
+    let predicate = predicate.as_ref();
+
     if predicate.dtype() != &DType::Bool(Nullability::NonNullable) {
         vortex_bail!(
             "predicate must be non-nullable bool, has dtype {}",

--- a/vortex-array/src/compute/slice.rs
+++ b/vortex-array/src/compute/slice.rs
@@ -19,7 +19,8 @@ pub trait SliceFn {
 ///
 /// Slicing returns an error if the underlying codec's [slice](SliceFn::slice()) implementation
 /// returns an error.
-pub fn slice(array: &Array, start: usize, stop: usize) -> VortexResult<Array> {
+pub fn slice(array: impl AsRef<Array>, start: usize, stop: usize) -> VortexResult<Array> {
+    let array = array.as_ref();
     check_slice_bounds(array, start, stop)?;
 
     array.with_dyn(|c| {

--- a/vortex-array/src/compute/take.rs
+++ b/vortex-array/src/compute/take.rs
@@ -7,7 +7,9 @@ pub trait TakeFn {
     fn take(&self, indices: &Array) -> VortexResult<Array>;
 }
 
-pub fn take(array: &Array, indices: &Array) -> VortexResult<Array> {
+pub fn take(array: impl AsRef<Array>, indices: impl AsRef<Array>) -> VortexResult<Array> {
+    let array = array.as_ref();
+    let indices = indices.as_ref();
     array.with_dyn(|a| {
         if let Some(take) = a.take() {
             return take.take(indices);

--- a/vortex-datafusion/src/plans.rs
+++ b/vortex-datafusion/src/plans.rs
@@ -22,7 +22,7 @@ use pin_project::pin_project;
 use vortex::array::ChunkedArray;
 use vortex::arrow::FromArrowArray;
 use vortex::compute::take;
-use vortex::{Array, IntoArray, IntoArrayVariant, IntoCanonical};
+use vortex::{Array, IntoArrayVariant, IntoCanonical};
 use vortex_dtype::field::Field;
 use vortex_error::{vortex_err, vortex_panic, VortexError};
 use vortex_expr::VortexExpr;
@@ -368,7 +368,7 @@ where
         //  We should find a way to avoid decoding the filter columns and only decode the other
         //  columns, then stitch the StructArray back together from those.
         let projected_for_output = chunk.project(this.output_projection)?;
-        let decoded = take(&projected_for_output.into_array(), &row_indices)?
+        let decoded = take(projected_for_output, &row_indices)?
             .into_canonical()?
             .into_arrow()?;
 


### PR DESCRIPTION
This change saves on a lot of `&`, `into_array` and other unnecessary array type wrangling