### PR TITLE
fix: release-plz.yml incorrect syntax for referencing another jobs output

### DIFF
--- a/.github/workflows/publish-vortex.yml
+++ b/.github/workflows/publish-vortex.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: osx-wheels
         path: target/wheels
   linux:
     runs-on: ubuntu-latest
@@ -85,7 +85,7 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: linux-wheels
         path: target/wheels
   release:
     runs-on: ubuntu-latest
@@ -98,8 +98,12 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: wheels
+        # https://github.com/actions/download-artifact?tab=readme-ov-file#download-all-artifacts
+        # "To download them to the same directory:"
         path: dist/
+        merge-multiple: true
+    - name: Display structure of downloaded files
+      run: ls -R dist/
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/publish-vortex.yml
+++ b/.github/workflows/publish-vortex.yml
@@ -1,7 +1,6 @@
 name: Publish to PyPI
 on:
   workflow_call:
-  pull_request: {}
 
 jobs:
   macos:

--- a/.github/workflows/publish-vortex.yml
+++ b/.github/workflows/publish-vortex.yml
@@ -1,6 +1,7 @@
 name: Publish to PyPI
 on:
   workflow_call:
+  pull_request: {}
 
 jobs:
   macos:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -34,5 +34,6 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   release-to-pypi:
     name: Release to PyPI
-    if: ${{ jobs.release-plz.outputs.releases_created }}
+    needs: release-plz
+    if: ${{ needs.release-plz.outputs.releases_created }}
     uses: ./.github/workflows/publish-vortex.yml

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -35,5 +35,7 @@ jobs:
   release-to-pypi:
     name: Release to PyPI
     needs: release-plz
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
     if: ${{ needs.release-plz.outputs.releases_created }}
     uses: ./.github/workflows/publish-vortex.yml

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - develop
-  pull_request: {}
 
 jobs:
   release-plz:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - develop
+  pull_request: {}
 
 jobs:
   release-plz:


### PR DESCRIPTION
You need to "needs" the previous job and refer to the job through the
needs context not the jobs context. [Explained here](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/passing-information-between-jobs#example-defining-outputs-for-a-job).


We also need the id-token write permission for Test PyPI (and normal PyPI) to authorize us to publish.