### PR TITLE
fix: job outputs are always strings

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -37,5 +37,5 @@ jobs:
     needs: release-plz
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
-    if: ${{ needs.release-plz.outputs.releases_created }}
+    if: ${{ needs.release-plz.outputs.releases_created == "true" }}
     uses: ./.github/workflows/publish-vortex.yml


### PR DESCRIPTION
Release-plz [documents the `releases_created` output as a "Boolean"](https://release-plz.ieni.dev/docs/github/output) but that is more semantic than literal. Job outputs [are always Unicode strings](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/passing-information-between-jobs). The `releases_created` output is created by the release-plz action [here](https://github.com/MarcoIeni/release-plz-action/blob/main/action.yml#L153-L158) and is clearly either the string `true` or the string `false`.

The [failure of the action](https://github.com/spiraldb/vortex/actions/runs/10926229122) occurred because the 0.9.0 Test PyPI package was already deployed. The if test is specifically there to avoid double-push-to-pypi, but because the string "false" is truthy, we ran the action anyway.