### PR TITLE
fix: single quotes for strings in github actions

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -37,5 +37,5 @@ jobs:
     needs: release-plz
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
-    if: ${{ needs.release-plz.outputs.releases_created == "true" }}
+    if: ${{ needs.release-plz.outputs.releases_created == 'true' }}
     uses: ./.github/workflows/publish-vortex.yml


### PR DESCRIPTION
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#literals

ugh.