### PR TITLE
fix: ID collision between vortex.ext and fastlanes.delta

### DIFF
--- a/encodings/alp/src/array.rs
+++ b/encodings/alp/src/array.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use vortex::array::PrimitiveArray;
+use vortex::encoding::ids;
 use vortex::iter::{Accessor, AccessorRef};
 use vortex::stats::ArrayStatisticsCompute;
 use vortex::validity::{ArrayValidity, LogicalValidity, Validity};
@@ -18,7 +19,7 @@ use crate::alp::Exponents;
 use crate::compress::{alp_encode, decompress};
 use crate::ALPFloat;
 
-impl_encoding!("vortex.alp", 13u16, ALP);
+impl_encoding!("vortex.alp", ids::ALP, ALP);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ALPMetadata {

--- a/encodings/bytebool/src/lib.rs
+++ b/encodings/bytebool/src/lib.rs
@@ -4,6 +4,7 @@ use std::mem::ManuallyDrop;
 use arrow_buffer::BooleanBuffer;
 use serde::{Deserialize, Serialize};
 use vortex::array::BoolArray;
+use vortex::encoding::ids;
 use vortex::stats::StatsSet;
 use vortex::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use vortex::variants::{ArrayVariants, BoolArrayTrait};
@@ -16,7 +17,7 @@ use vortex_error::{VortexExpect as _, VortexResult};
 mod compute;
 mod stats;
 
-impl_encoding!("vortex.bytebool", 12u16, ByteBool);
+impl_encoding!("vortex.bytebool", ids::BYTE_BOOL, ByteBool);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ByteBoolMetadata {

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 use vortex::array::StructArray;
+use vortex::encoding::ids;
 use vortex::stats::{ArrayStatisticsCompute, StatsSet};
 use vortex::validity::{ArrayValidity, LogicalValidity};
 use vortex::variants::{ArrayVariants, ExtensionArrayTrait};
@@ -14,7 +15,7 @@ use vortex_error::{vortex_bail, VortexExpect as _, VortexResult};
 
 use crate::compute::decode_to_temporal;
 
-impl_encoding!("vortex.datetimeparts", 22u16, DateTimeParts);
+impl_encoding!("vortex.datetimeparts", ids::DATE_TIME_PARTS, DateTimeParts);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DateTimePartsMetadata {

--- a/encodings/dict/src/dict.rs
+++ b/encodings/dict/src/dict.rs
@@ -5,6 +5,7 @@ use vortex::accessor::ArrayAccessor;
 use vortex::array::BoolArray;
 use vortex::compute::take;
 use vortex::compute::unary::scalar_at;
+use vortex::encoding::ids;
 use vortex::stats::StatsSet;
 use vortex::validity::{ArrayValidity, LogicalValidity};
 use vortex::visitor::{AcceptArrayVisitor, ArrayVisitor};
@@ -15,7 +16,7 @@ use vortex::{
 use vortex_dtype::{match_each_integer_ptype, DType};
 use vortex_error::{vortex_bail, vortex_panic, VortexExpect as _, VortexResult};
 
-impl_encoding!("vortex.dict", 20u16, Dict);
+impl_encoding!("vortex.dict", ids::DICT, Dict);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DictMetadata {

--- a/encodings/fastlanes/src/bitpacking/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/mod.rs
@@ -2,6 +2,7 @@ use ::serde::{Deserialize, Serialize};
 pub use compress::*;
 use fastlanes::BitPacking;
 use vortex::array::{PrimitiveArray, SparseArray};
+use vortex::encoding::ids;
 use vortex::stats::{ArrayStatisticsCompute, StatsSet};
 use vortex::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use vortex::variants::{ArrayVariants, PrimitiveArrayTrait};
@@ -18,7 +19,7 @@ use vortex_error::{
 mod compress;
 mod compute;
 
-impl_encoding!("fastlanes.bitpacked", 14u16, BitPacked);
+impl_encoding!("fastlanes.bitpacked", ids::FL_BITPACKED, BitPacked);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BitPackedMetadata {

--- a/encodings/fastlanes/src/delta/mod.rs
+++ b/encodings/fastlanes/src/delta/mod.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 pub use compress::*;
 use serde::{Deserialize, Serialize};
+use vortex::encoding::ids;
 use vortex::stats::{ArrayStatisticsCompute, StatsSet};
 use vortex::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use vortex::variants::{ArrayVariants, PrimitiveArrayTrait};
@@ -13,7 +14,7 @@ use vortex_error::{vortex_bail, vortex_panic, VortexExpect as _, VortexResult};
 mod compress;
 mod compute;
 
-impl_encoding!("fastlanes.delta", 16u16, Delta);
+impl_encoding!("fastlanes.delta", ids::FL_DELTA, Delta);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeltaMetadata {

--- a/encodings/fastlanes/src/for/mod.rs
+++ b/encodings/fastlanes/src/for/mod.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 pub use compress::*;
 use serde::{Deserialize, Serialize};
+use vortex::encoding::ids;
 use vortex::stats::{ArrayStatisticsCompute, StatsSet};
 use vortex::validity::{ArrayValidity, LogicalValidity};
 use vortex::variants::{ArrayVariants, PrimitiveArrayTrait};
@@ -14,7 +15,7 @@ use vortex_scalar::Scalar;
 mod compress;
 mod compute;
 
-impl_encoding!("fastlanes.for", 15u16, FoR);
+impl_encoding!("fastlanes.for", ids::FL_FOR, FoR);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FoRMetadata {

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use fsst::{Decompressor, Symbol};
 use serde::{Deserialize, Serialize};
 use vortex::array::VarBinArray;
+use vortex::encoding::ids;
 use vortex::stats::{ArrayStatisticsCompute, StatsSet};
 use vortex::validity::{ArrayValidity, LogicalValidity, Validity};
 use vortex::variants::{ArrayVariants, BinaryArrayTrait, Utf8ArrayTrait};
@@ -11,7 +12,7 @@ use vortex::{impl_encoding, Array, ArrayDType, ArrayDef, ArrayTrait, IntoCanonic
 use vortex_dtype::{DType, Nullability, PType};
 use vortex_error::{vortex_bail, VortexExpect, VortexResult};
 
-impl_encoding!("vortex.fsst", 24u16, FSST);
+impl_encoding!("vortex.fsst", ids::FSST, FSST);
 
 static SYMBOLS_DTYPE: DType = DType::Primitive(PType::U64, Nullability::NonNullable);
 static SYMBOL_LENS_DTYPE: DType = DType::Primitive(PType::U8, Nullability::NonNullable);

--- a/encodings/roaring/src/boolean/mod.rs
+++ b/encodings/roaring/src/boolean/mod.rs
@@ -7,6 +7,7 @@ use croaring::Native;
 pub use croaring::{Bitmap, Portable};
 use serde::{Deserialize, Serialize};
 use vortex::array::BoolArray;
+use vortex::encoding::ids;
 use vortex::stats::{Stat, StatsSet};
 use vortex::validity::{ArrayValidity, LogicalValidity, Validity};
 use vortex::variants::{ArrayVariants, BoolArrayTrait};
@@ -23,7 +24,7 @@ mod compress;
 mod compute;
 mod stats;
 
-impl_encoding!("vortex.roaring_bool", 17u16, RoaringBool);
+impl_encoding!("vortex.roaring_bool", ids::ROARING_BOOL, RoaringBool);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoaringBoolMetadata {

--- a/encodings/roaring/src/integer/mod.rs
+++ b/encodings/roaring/src/integer/mod.rs
@@ -4,6 +4,7 @@ pub use compress::*;
 use croaring::{Bitmap, Portable};
 use serde::{Deserialize, Serialize};
 use vortex::array::PrimitiveArray;
+use vortex::encoding::ids;
 use vortex::stats::{ArrayStatisticsCompute, StatsSet};
 use vortex::validity::{ArrayValidity, LogicalValidity};
 use vortex::variants::{ArrayVariants, PrimitiveArrayTrait};
@@ -19,7 +20,7 @@ use vortex_error::{vortex_bail, VortexExpect as _, VortexResult};
 mod compress;
 mod compute;
 
-impl_encoding!("vortex.roaring_int", 18u16, RoaringInt);
+impl_encoding!("vortex.roaring_int", ids::ROARING_INT, RoaringInt);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoaringIntMetadata {

--- a/encodings/runend-bool/src/array.rs
+++ b/encodings/runend-bool/src/array.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use vortex::compute::unary::scalar_at;
 use vortex::compute::{search_sorted, SearchSortedSide};
+use vortex::encoding::ids;
 use vortex::stats::{ArrayStatistics, ArrayStatisticsCompute, StatsSet};
 use vortex::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use vortex::variants::{ArrayVariants, BoolArrayTrait};
@@ -14,7 +15,7 @@ use vortex_error::{vortex_bail, VortexExpect as _, VortexResult};
 
 use crate::compress::runend_bool_decode;
 
-impl_encoding!("vortex.runendbool", 23u16, RunEndBool);
+impl_encoding!("vortex.runendbool", ids::RUN_END_BOOL, RunEndBool);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunEndBoolMetadata {

--- a/encodings/runend/src/runend.rs
+++ b/encodings/runend/src/runend.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use vortex::array::PrimitiveArray;
 use vortex::compute::unary::scalar_at;
 use vortex::compute::{search_sorted, search_sorted_u64_many, SearchSortedSide};
+use vortex::encoding::ids;
 use vortex::stats::{ArrayStatistics, ArrayStatisticsCompute, StatsSet};
 use vortex::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use vortex::variants::{ArrayVariants, PrimitiveArrayTrait};
@@ -17,7 +18,7 @@ use vortex_error::{vortex_bail, VortexExpect as _, VortexResult};
 
 use crate::compress::{runend_decode, runend_encode};
 
-impl_encoding!("vortex.runend", 19u16, RunEnd);
+impl_encoding!("vortex.runend", ids::RUN_END, RunEnd);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunEndMetadata {

--- a/encodings/zigzag/src/zigzag.rs
+++ b/encodings/zigzag/src/zigzag.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use vortex::array::PrimitiveArray;
+use vortex::encoding::ids;
 use vortex::stats::{ArrayStatisticsCompute, StatsSet};
 use vortex::validity::{ArrayValidity, LogicalValidity};
 use vortex::variants::{ArrayVariants, PrimitiveArrayTrait};
@@ -16,7 +17,7 @@ use vortex_error::{
 use crate::compress::zigzag_encode;
 use crate::zigzag_decode;
 
-impl_encoding!("vortex.zigzag", 21u16, ZigZag);
+impl_encoding!("vortex.zigzag", ids::ZIGZAG, ZigZag);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ZigZagMetadata;

--- a/vortex-array/src/array/bool/mod.rs
+++ b/vortex-array/src/array/bool/mod.rs
@@ -6,6 +6,7 @@ use vortex_buffer::Buffer;
 use vortex_dtype::DType;
 use vortex_error::{VortexExpect as _, VortexResult};
 
+use crate::encoding::ids;
 use crate::stats::StatsSet;
 use crate::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use crate::variants::{ArrayVariants, BoolArrayTrait};
@@ -16,7 +17,7 @@ mod accessors;
 mod compute;
 mod stats;
 
-impl_encoding!("vortex.bool", 2u16, Bool);
+impl_encoding!("vortex.bool", ids::BOOL, Bool);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BoolMetadata {

--- a/vortex-array/src/array/chunked/mod.rs
+++ b/vortex-array/src/array/chunked/mod.rs
@@ -12,6 +12,7 @@ use vortex_scalar::Scalar;
 use crate::array::primitive::PrimitiveArray;
 use crate::compute::unary::{scalar_at, subtract_scalar, SubtractScalarFn};
 use crate::compute::{search_sorted, SearchSortedSide};
+use crate::encoding::ids;
 use crate::iter::{ArrayIterator, ArrayIteratorAdapter};
 use crate::stats::StatsSet;
 use crate::stream::{ArrayStream, ArrayStreamAdapter};
@@ -25,7 +26,7 @@ mod compute;
 mod stats;
 mod variants;
 
-impl_encoding!("vortex.chunked", 11u16, Chunked);
+impl_encoding!("vortex.chunked", ids::CHUNKED, Chunked);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ChunkedMetadata {

--- a/vortex-array/src/array/constant/mod.rs
+++ b/vortex-array/src/array/constant/mod.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use vortex_error::{vortex_panic, VortexResult};
 use vortex_scalar::Scalar;
 
+use crate::encoding::ids;
 use crate::stats::{Stat, StatsSet};
 use crate::validity::{ArrayValidity, LogicalValidity};
 use crate::visitor::{AcceptArrayVisitor, ArrayVisitor};
@@ -14,7 +15,7 @@ mod compute;
 mod stats;
 mod variants;
 
-impl_encoding!("vortex.constant", 10u16, Constant);
+impl_encoding!("vortex.constant", ids::CONSTANT, Constant);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConstantMetadata {

--- a/vortex-array/src/array/extension/mod.rs
+++ b/vortex-array/src/array/extension/mod.rs
@@ -10,7 +10,7 @@ use crate::{impl_encoding, Array, ArrayDType, ArrayDef, ArrayTrait, Canonical, I
 
 mod compute;
 
-impl_encoding!("vortex.ext", 16u16, Extension);
+impl_encoding!("vortex.ext", 25u16, Extension);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExtensionMetadata {

--- a/vortex-array/src/array/extension/mod.rs
+++ b/vortex-array/src/array/extension/mod.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use vortex_dtype::{DType, ExtDType, ExtID};
 use vortex_error::{VortexExpect as _, VortexResult};
 
+use crate::encoding::ids;
 use crate::stats::ArrayStatisticsCompute;
 use crate::validity::{ArrayValidity, LogicalValidity};
 use crate::variants::{ArrayVariants, ExtensionArrayTrait};
@@ -10,7 +11,7 @@ use crate::{impl_encoding, Array, ArrayDType, ArrayDef, ArrayTrait, Canonical, I
 
 mod compute;
 
-impl_encoding!("vortex.ext", 25u16, Extension);
+impl_encoding!("vortex.ext", ids::EXTENSION, Extension);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExtensionMetadata {

--- a/vortex-array/src/array/null/mod.rs
+++ b/vortex-array/src/array/null/mod.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use vortex_dtype::DType;
 use vortex_error::{VortexExpect as _, VortexResult};
 
+use crate::encoding::ids;
 use crate::stats::{ArrayStatisticsCompute, Stat, StatsSet};
 use crate::validity::{ArrayValidity, LogicalValidity, Validity};
 use crate::variants::{ArrayVariants, NullArrayTrait};
@@ -12,7 +13,7 @@ use crate::{impl_encoding, ArrayDef, ArrayTrait, Canonical, IntoCanonical};
 
 mod compute;
 
-impl_encoding!("vortex.null", 1u16, Null);
+impl_encoding!("vortex.null", ids::NULL, Null);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NullMetadata {

--- a/vortex-array/src/array/primitive/mod.rs
+++ b/vortex-array/src/array/primitive/mod.rs
@@ -12,6 +12,7 @@ use vortex_dtype::{match_each_native_ptype, DType, NativePType, PType};
 use vortex_error::{vortex_bail, vortex_panic, VortexError, VortexExpect as _, VortexResult};
 
 use crate::elementwise::{dyn_cast_array_iter, BinaryFn, UnaryFn};
+use crate::encoding::ids;
 use crate::iter::{Accessor, AccessorRef, Batch, ITER_BATCH_SIZE};
 use crate::stats::StatsSet;
 use crate::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
@@ -26,7 +27,7 @@ mod accessor;
 mod compute;
 mod stats;
 
-impl_encoding!("vortex.primitive", 3u16, Primitive);
+impl_encoding!("vortex.primitive", ids::PRIMITIVE, Primitive);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PrimitiveMetadata {

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -6,6 +6,7 @@ use vortex_scalar::Scalar;
 use crate::array::constant::ConstantArray;
 use crate::compute::unary::scalar_at;
 use crate::compute::{search_sorted, SearchResult, SearchSortedSide};
+use crate::encoding::ids;
 use crate::stats::{ArrayStatisticsCompute, StatsSet};
 use crate::validity::{ArrayValidity, LogicalValidity};
 use crate::visitor::{AcceptArrayVisitor, ArrayVisitor};
@@ -15,7 +16,7 @@ mod compute;
 mod flatten;
 mod variants;
 
-impl_encoding!("vortex.sparse", 9u16, Sparse);
+impl_encoding!("vortex.sparse", ids::SPARSE, Sparse);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SparseMetadata {

--- a/vortex-array/src/array/struct_/mod.rs
+++ b/vortex-array/src/array/struct_/mod.rs
@@ -3,6 +3,7 @@ use vortex_dtype::field::Field;
 use vortex_dtype::{DType, FieldName, FieldNames, StructDType};
 use vortex_error::{vortex_bail, vortex_err, vortex_panic, VortexExpect as _, VortexResult};
 
+use crate::encoding::ids;
 use crate::stats::{ArrayStatisticsCompute, StatsSet};
 use crate::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use crate::variants::{ArrayVariants, StructArrayTrait};
@@ -11,7 +12,7 @@ use crate::{impl_encoding, Array, ArrayDType, ArrayDef, ArrayTrait, Canonical, I
 
 mod compute;
 
-impl_encoding!("vortex.struct", 8u16, Struct);
+impl_encoding!("vortex.struct", ids::STRUCT, Struct);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StructMetadata {

--- a/vortex-array/src/array/varbin/mod.rs
+++ b/vortex-array/src/array/varbin/mod.rs
@@ -15,6 +15,7 @@ use crate::array::primitive::PrimitiveArray;
 use crate::array::varbin::builder::VarBinBuilder;
 use crate::compute::slice;
 use crate::compute::unary::scalar_at;
+use crate::encoding::ids;
 use crate::stats::StatsSet;
 use crate::validity::{Validity, ValidityMetadata};
 use crate::{impl_encoding, Array, ArrayDType, ArrayDef, ArrayTrait, IntoArrayVariant};
@@ -27,7 +28,7 @@ mod flatten;
 mod stats;
 mod variants;
 
-impl_encoding!("vortex.varbin", 4u16, VarBin);
+impl_encoding!("vortex.varbin", ids::VAR_BIN, VarBin);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VarBinMetadata {

--- a/vortex-array/src/array/varbinview/mod.rs
+++ b/vortex-array/src/array/varbinview/mod.rs
@@ -15,6 +15,7 @@ use vortex_error::{vortex_bail, vortex_panic, VortexError, VortexExpect as _, Vo
 use crate::array::varbin::VarBinArray;
 use crate::arrow::FromArrowArray;
 use crate::compute::slice;
+use crate::encoding::ids;
 use crate::stats::StatsSet;
 use crate::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use crate::visitor::{AcceptArrayVisitor, ArrayVisitor};
@@ -106,7 +107,7 @@ impl Debug for BinaryView {
 // reminder: views are 16 bytes with 8-byte alignment
 pub(crate) const VIEW_SIZE: usize = mem::size_of::<BinaryView>();
 
-impl_encoding!("vortex.varbinview", 5u16, VarBinView);
+impl_encoding!("vortex.varbinview", ids::VAR_BIN_VIEW, VarBinView);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VarBinViewMetadata {

--- a/vortex-array/src/encoding.rs
+++ b/vortex-array/src/encoding.rs
@@ -10,9 +10,9 @@ use crate::{Array, ArrayDef, ArrayTrait};
 /// EncodingId is a unique name and numerical code of the array
 ///
 /// 0x0000 - reserved marker encoding
-/// 0x0001 - 0x04FF - vortex internal encodings
-/// 0x0401 - 0x7FFF - well known extension encodings
-/// 0x8000 - 0xFFFF - custom extension encodings
+/// 0x0001 - 0x0400 - vortex internal encodings (1 - 1024)
+/// 0x0401 - 0x7FFF - well known extension encodings (1025 - 32767)
+/// 0x8000 - 0xFFFF - custom extension encodings (32768 - 65535)
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct EncodingId(&'static str, u16);
 
@@ -98,27 +98,91 @@ pub trait ArrayEncodingRef {
 
 #[doc = "Encoding ID constants for all Vortex-provided encodings"]
 pub mod ids {
+    // reserved - 0x0000
+    pub const RESERVED: u16 = 0;
+
+    // Vortex built-in encodings (1 - 15)
+    // built-ins first
     pub const NULL: u16 = 1;
     pub const BOOL: u16 = 2;
     pub const PRIMITIVE: u16 = 3;
-    pub const VAR_BIN: u16 = 4;
-    pub const VAR_BIN_VIEW: u16 = 5;
-    pub const EXTENSION: u16 = 6;
-    pub const STRUCT: u16 = 7;
+    pub const STRUCT: u16 = 4;
+    pub const VAR_BIN: u16 = 5;
+    pub const VAR_BIN_VIEW: u16 = 6;
+    pub const EXTENSION: u16 = 7;
     pub const SPARSE: u16 = 8;
     pub const CONSTANT: u16 = 9;
     pub const CHUNKED: u16 = 10;
-    pub const BYTE_BOOL: u16 = 11;
-    pub const ALP: u16 = 12;
-    pub const FL_BITPACKED: u16 = 13;
-    pub const FL_FOR: u16 = 14;
-    pub const FL_DELTA: u16 = 15;
-    pub const ROARING_BOOL: u16 = 16;
-    pub const ROARING_INT: u16 = 17;
-    pub const RUN_END: u16 = 18;
-    pub const DICT: u16 = 19;
-    pub const ZIGZAG: u16 = 20;
-    pub const DATE_TIME_PARTS: u16 = 21;
-    pub const RUN_END_BOOL: u16 = 22;
-    pub const FSST: u16 = 23;
+
+    // currently unused, saved for future built-ins
+    // e.g., List, FixedList, Union, Tensor, etc.
+    pub const RESERVED_11: u16 = 11;
+    pub const RESERVED_12: u16 = 12;
+    pub const RESERVED_13: u16 = 13;
+    pub const RESERVED_14: u16 = 14;
+    pub const RESERVED_15: u16 = 15;
+    pub const RESERVED_16: u16 = 16;
+
+    // bundled extensions
+    pub const ALP: u16 = 17;
+    pub const BYTE_BOOL: u16 = 18;
+    pub const DATE_TIME_PARTS: u16 = 19;
+    pub const DICT: u16 = 20;
+    pub const FL_BITPACKED: u16 = 21;
+    pub const FL_DELTA: u16 = 22;
+    pub const FL_FOR: u16 = 23;
+    pub const FSST: u16 = 24;
+    pub const ROARING_BOOL: u16 = 25;
+    pub const ROARING_INT: u16 = 26;
+    pub const RUN_END: u16 = 27;
+    pub const RUN_END_BOOL: u16 = 28;
+    pub const ZIGZAG: u16 = 29;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::ids;
+
+    #[test]
+    fn test_encoding_id() {
+        let all_ids = [
+            ids::RESERVED,
+            ids::NULL,
+            ids::BOOL,
+            ids::PRIMITIVE,
+            ids::STRUCT,
+            ids::VAR_BIN,
+            ids::VAR_BIN_VIEW,
+            ids::EXTENSION,
+            ids::SPARSE,
+            ids::CONSTANT,
+            ids::CHUNKED,
+            ids::RESERVED_11,
+            ids::RESERVED_12,
+            ids::RESERVED_13,
+            ids::RESERVED_14,
+            ids::RESERVED_15,
+            ids::RESERVED_16,
+            ids::ALP,
+            ids::BYTE_BOOL,
+            ids::DATE_TIME_PARTS,
+            ids::DICT,
+            ids::FL_BITPACKED,
+            ids::FL_DELTA,
+            ids::FL_FOR,
+            ids::FSST,
+            ids::ROARING_BOOL,
+            ids::ROARING_INT,
+            ids::RUN_END,
+            ids::RUN_END_BOOL,
+            ids::ZIGZAG,
+        ];
+
+        let mut ids_set = HashSet::with_capacity(all_ids.len());
+        ids_set.extend(all_ids);
+        assert_eq!(ids_set.len(), all_ids.len());
+        assert!(ids_set.iter().max().unwrap() <= &0x0400);
+    }
 }

--- a/vortex-array/src/encoding.rs
+++ b/vortex-array/src/encoding.rs
@@ -183,6 +183,6 @@ mod tests {
         let mut ids_set = HashSet::with_capacity(all_ids.len());
         ids_set.extend(all_ids);
         assert_eq!(ids_set.len(), all_ids.len());
-        assert!(ids_set.iter().max().unwrap() <= &0x0400);
+        assert!(ids_set.iter().max().unwrap() <= &0x0400); // 1024
     }
 }

--- a/vortex-array/src/encoding.rs
+++ b/vortex-array/src/encoding.rs
@@ -97,9 +97,10 @@ pub trait ArrayEncodingRef {
 }
 
 #[doc = "Encoding ID constants for all Vortex-provided encodings"]
+#[allow(dead_code)]
 pub mod ids {
     // reserved - 0x0000
-    pub const RESERVED: u16 = 0;
+    pub(crate) const RESERVED: u16 = 0;
 
     // Vortex built-in encodings (1 - 15)
     // built-ins first
@@ -116,12 +117,12 @@ pub mod ids {
 
     // currently unused, saved for future built-ins
     // e.g., List, FixedList, Union, Tensor, etc.
-    pub const RESERVED_11: u16 = 11;
-    pub const RESERVED_12: u16 = 12;
-    pub const RESERVED_13: u16 = 13;
-    pub const RESERVED_14: u16 = 14;
-    pub const RESERVED_15: u16 = 15;
-    pub const RESERVED_16: u16 = 16;
+    pub(crate) const RESERVED_11: u16 = 11;
+    pub(crate) const RESERVED_12: u16 = 12;
+    pub(crate) const RESERVED_13: u16 = 13;
+    pub(crate) const RESERVED_14: u16 = 14;
+    pub(crate) const RESERVED_15: u16 = 15;
+    pub(crate) const RESERVED_16: u16 = 16;
 
     // bundled extensions
     pub const ALP: u16 = 17;
@@ -182,7 +183,10 @@ mod tests {
 
         let mut ids_set = HashSet::with_capacity(all_ids.len());
         ids_set.extend(all_ids);
-        assert_eq!(ids_set.len(), all_ids.len());
-        assert!(ids_set.iter().max().unwrap() <= &0x0400); // 1024
+        assert_eq!(ids_set.len(), all_ids.len()); // no duplicates
+        assert!(ids_set.iter().max().unwrap() <= &0x0400); // no ids are greater than 1024
+        for (i, id) in all_ids.iter().enumerate() { // monotonic with no gaps
+            assert_eq!(i as u16, *id, "id at index {} is not equal to index", i);
+        }
     }
 }

--- a/vortex-array/src/encoding.rs
+++ b/vortex-array/src/encoding.rs
@@ -95,3 +95,30 @@ pub trait ArrayEncodingExt {
 pub trait ArrayEncodingRef {
     fn encoding(&self) -> EncodingRef;
 }
+
+#[doc = "Encoding ID constants for all Vortex-provided encodings"]
+pub mod ids {
+    pub const NULL: u16 = 1;
+    pub const BOOL: u16 = 2;
+    pub const PRIMITIVE: u16 = 3;
+    pub const VAR_BIN: u16 = 4;
+    pub const VAR_BIN_VIEW: u16 = 5;
+    pub const EXTENSION: u16 = 6;
+    pub const STRUCT: u16 = 7;
+    pub const SPARSE: u16 = 8;
+    pub const CONSTANT: u16 = 9;
+    pub const CHUNKED: u16 = 10;
+    pub const BYTE_BOOL: u16 = 11;
+    pub const ALP: u16 = 12;
+    pub const FL_BITPACKED: u16 = 13;
+    pub const FL_FOR: u16 = 14;
+    pub const FL_DELTA: u16 = 15;
+    pub const ROARING_BOOL: u16 = 16;
+    pub const ROARING_INT: u16 = 17;
+    pub const RUN_END: u16 = 18;
+    pub const DICT: u16 = 19;
+    pub const ZIGZAG: u16 = 20;
+    pub const DATE_TIME_PARTS: u16 = 21;
+    pub const RUN_END_BOOL: u16 = 22;
+    pub const FSST: u16 = 23;
+}

--- a/vortex-array/src/encoding.rs
+++ b/vortex-array/src/encoding.rs
@@ -185,7 +185,8 @@ mod tests {
         ids_set.extend(all_ids);
         assert_eq!(ids_set.len(), all_ids.len()); // no duplicates
         assert!(ids_set.iter().max().unwrap() <= &0x0400); // no ids are greater than 1024
-        for (i, id) in all_ids.iter().enumerate() { // monotonic with no gaps
+        for (i, id) in all_ids.iter().enumerate() {
+            // monotonic with no gaps
             assert_eq!(i as u16, *id, "id at index {} is not equal to index", i);
         }
     }

--- a/vortex-array/src/implementation.rs
+++ b/vortex-array/src/implementation.rs
@@ -23,7 +23,7 @@ pub trait ArrayDef {
 
 #[macro_export]
 macro_rules! impl_encoding {
-    ($id:literal, $code:literal, $Name:ident) => {
+    ($id:literal, $code:expr, $Name:ident) => {
         $crate::vendored::paste::paste! {
             /// The array definition trait
             #[derive(std::fmt::Debug, Clone)]


### PR DESCRIPTION
Both were using ID code 16. I left `fastlanes.delta` as 16 to be contiguous with the other fastlanes codes, and pushed extension to the end