### PR TITLE
make miri tests fast again (take 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4531,7 +4531,6 @@ version = "0.9.0"
 dependencies = [
  "arrow-array",
  "fsst-rs",
- "rstest",
  "serde",
  "vortex-array",
  "vortex-buffer",

--- a/encodings/fsst/Cargo.toml
+++ b/encodings/fsst/Cargo.toml
@@ -14,9 +14,6 @@ rust-version = { workspace = true }
 [lints]
 workspace = true
 
-[dev-dependencies]
-rstest = { workspace = true }
-
 [dependencies]
 arrow-array = { workspace = true }
 fsst-rs = { workspace = true }


### PR DESCRIPTION
FSST array tests take ~7.5 minutes on recent develop builds (e.g., https://github.com/spiraldb/vortex/actions/runs/10948157580/job/30398557105)

This gets it down to <90s on my laptop

redo of #883 