### PR TITLE
feat: ArrayView::child will throw if encoding not found

### DIFF
--- a/encodings/alp/src/array.rs
+++ b/encodings/alp/src/array.rs
@@ -13,7 +13,7 @@ use vortex::{
     impl_encoding, Array, ArrayDType, ArrayDef, ArrayTrait, Canonical, IntoArray, IntoCanonical,
 };
 use vortex_dtype::{DType, PType};
-use vortex_error::{vortex_bail, vortex_panic, VortexExpect as _, VortexResult};
+use vortex_error::{vortex_bail, VortexExpect as _, VortexResult};
 
 use crate::alp::Exponents;
 use crate::compress::{alp_encode, decompress};
@@ -95,13 +95,14 @@ impl ALPArray {
 
     pub fn patches(&self) -> Option<Array> {
         self.metadata().patches_dtype.as_ref().map(|dt| {
-            self.as_ref().child(1, dt, self.len()).unwrap_or_else(|| {
-                vortex_panic!(
-                    "Missing patches with present metadata flag; patches dtype: {}, patches_len: {}",
+            self.as_ref().child(1, dt, self.len()).vortex_expect(
+                format!(
+                    "ALPArray: patches child missing: dtype: {}, len: {}",
                     dt,
                     self.len()
                 )
-            })
+                .as_str(),
+            )
         })
     }
 

--- a/encodings/alp/src/array.rs
+++ b/encodings/alp/src/array.rs
@@ -13,7 +13,7 @@ use vortex::{
     impl_encoding, Array, ArrayDType, ArrayDef, ArrayTrait, Canonical, IntoArray, IntoCanonical,
 };
 use vortex_dtype::{DType, PType};
-use vortex_error::{vortex_bail, VortexExpect as _, VortexResult};
+use vortex_error::{vortex_bail, vortex_panic, VortexExpect as _, VortexResult};
 
 use crate::alp::Exponents;
 use crate::compress::{alp_encode, decompress};
@@ -95,14 +95,14 @@ impl ALPArray {
 
     pub fn patches(&self) -> Option<Array> {
         self.metadata().patches_dtype.as_ref().map(|dt| {
-            self.as_ref().child(1, dt, self.len()).vortex_expect(
-                format!(
+            self.as_ref().child(1, dt, self.len()).unwrap_or_else(|e| {
+                vortex_panic!(
+                    e,
                     "ALPArray: patches child missing: dtype: {}, len: {}",
                     dt,
                     self.len()
                 )
-                .as_str(),
-            )
+            })
         })
     }
 

--- a/encodings/bytebool/src/lib.rs
+++ b/encodings/bytebool/src/lib.rs
@@ -26,9 +26,11 @@ pub struct ByteBoolMetadata {
 
 impl ByteBoolArray {
     pub fn validity(&self) -> Validity {
-        self.metadata()
-            .validity
-            .to_validity(self.as_ref().child(0, &Validity::DTYPE, self.len()))
+        self.metadata().validity.to_validity(|| {
+            self.as_ref()
+                .child(0, &Validity::DTYPE, self.len())
+                .vortex_expect("ByteBoolArray: accessing validity child")
+        })
     }
 
     pub fn try_new(buffer: Buffer, validity: Validity) -> VortexResult<Self> {

--- a/encodings/fastlanes/src/bitpacking/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/mod.rs
@@ -157,16 +157,15 @@ impl BitPackedArray {
     /// indices indicate the locations of patches. The indices must have non-zero length.
     #[inline]
     pub fn patches(&self) -> Option<Array> {
-        self.metadata()
-            .has_patches
-            .then(|| {
-                self.as_ref().child(
+        self.metadata().has_patches.then(|| {
+            self.as_ref()
+                .child(
                     0,
                     &self.dtype().with_nullability(Nullability::Nullable),
                     self.len(),
                 )
-            })
-            .flatten()
+                .vortex_expect("BitPackedArray: patches child")
+        })
     }
 
     #[inline]
@@ -177,11 +176,11 @@ impl BitPackedArray {
     pub fn validity(&self) -> Validity {
         let validity_child_idx = if self.metadata().has_patches { 1 } else { 0 };
 
-        self.metadata().validity.to_validity(self.as_ref().child(
-            validity_child_idx,
-            &Validity::DTYPE,
-            self.len(),
-        ))
+        self.metadata().validity.to_validity(|| {
+            self.as_ref()
+                .child(validity_child_idx, &Validity::DTYPE, self.len())
+                .vortex_expect("BitPackedArray: validity child")
+        })
     }
 
     pub fn encode(array: &Array, bit_width: usize) -> VortexResult<Self> {

--- a/encodings/fastlanes/src/delta/mod.rs
+++ b/encodings/fastlanes/src/delta/mod.rs
@@ -87,9 +87,11 @@ impl DeltaArray {
     }
 
     pub fn validity(&self) -> Validity {
-        self.metadata()
-            .validity
-            .to_validity(self.as_ref().child(2, &Validity::DTYPE, self.len()))
+        self.metadata().validity.to_validity(|| {
+            self.as_ref()
+                .child(2, &Validity::DTYPE, self.len())
+                .vortex_expect("DeltaArray: validity child")
+        })
     }
 
     fn bases_len(&self) -> usize {

--- a/encodings/runend-bool/src/array.rs
+++ b/encodings/runend-bool/src/array.rs
@@ -73,9 +73,11 @@ impl RunEndBoolArray {
     }
 
     pub fn validity(&self) -> Validity {
-        self.metadata()
-            .validity
-            .to_validity(self.as_ref().child(2, &Validity::DTYPE, self.len()))
+        self.metadata().validity.to_validity(|| {
+            self.as_ref()
+                .child(2, &Validity::DTYPE, self.len())
+                .vortex_expect("RunEndBoolArray: validity child")
+        })
     }
 
     #[inline]

--- a/encodings/runend/src/runend.rs
+++ b/encodings/runend/src/runend.rs
@@ -114,9 +114,11 @@ impl RunEndArray {
     }
 
     pub fn validity(&self) -> Validity {
-        self.metadata()
-            .validity
-            .to_validity(self.as_ref().child(2, &Validity::DTYPE, self.len()))
+        self.metadata().validity.to_validity(|| {
+            self.as_ref()
+                .child(2, &Validity::DTYPE, self.len())
+                .vortex_expect("RunEndArray: validity child")
+        })
     }
 
     /// The offset that the `ends` is relative to.

--- a/vortex-array/src/array/bool/mod.rs
+++ b/vortex-array/src/array/bool/mod.rs
@@ -42,9 +42,11 @@ impl BoolArray {
     }
 
     pub fn validity(&self) -> Validity {
-        self.metadata()
-            .validity
-            .to_validity(self.as_ref().child(0, &Validity::DTYPE, self.len()))
+        self.metadata().validity.to_validity(|| {
+            self.as_ref()
+                .child(0, &Validity::DTYPE, self.len())
+                .vortex_expect("BoolArray: validity child")
+        })
     }
 
     pub fn try_new(buffer: BooleanBuffer, validity: Validity) -> VortexResult<Self> {

--- a/vortex-array/src/array/chunked/compute/scalar_at.rs
+++ b/vortex-array/src/array/chunked/compute/scalar_at.rs
@@ -1,4 +1,4 @@
-use vortex_error::{vortex_err, vortex_panic, VortexResult};
+use vortex_error::{VortexExpect, VortexResult};
 use vortex_scalar::Scalar;
 
 use crate::array::ChunkedArray;
@@ -7,20 +7,18 @@ use crate::compute::unary::{scalar_at, scalar_at_unchecked, ScalarAtFn};
 impl ScalarAtFn for ChunkedArray {
     fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
         let (chunk_index, chunk_offset) = self.find_chunk_idx(index);
-        scalar_at(
-            &self
-                .chunk(chunk_index)
-                .ok_or_else(|| vortex_err!(OutOfBounds: chunk_index, 0, self.nchunks()))?,
-            chunk_offset,
-        )
+        scalar_at(&self.chunk(chunk_index)?, chunk_offset)
     }
 
     fn scalar_at_unchecked(&self, index: usize) -> Scalar {
         let (chunk_index, chunk_offset) = self.find_chunk_idx(index);
         scalar_at_unchecked(
-            &self
-                .chunk(chunk_index)
-                .unwrap_or_else(|| vortex_panic!(OutOfBounds: chunk_index, 0, self.nchunks())),
+            &self.chunk(chunk_index).vortex_expect(
+                format!(
+                "ChunkedArray: scalar_at_unchecked: failed to find chunk at index {chunk_index}"
+            )
+                .as_str(),
+            ),
             chunk_offset,
         )
     }

--- a/vortex-array/src/array/chunked/compute/scalar_at.rs
+++ b/vortex-array/src/array/chunked/compute/scalar_at.rs
@@ -1,4 +1,4 @@
-use vortex_error::{VortexExpect, VortexResult};
+use vortex_error::{vortex_panic, VortexResult};
 use vortex_scalar::Scalar;
 
 use crate::array::ChunkedArray;
@@ -13,12 +13,13 @@ impl ScalarAtFn for ChunkedArray {
     fn scalar_at_unchecked(&self, index: usize) -> Scalar {
         let (chunk_index, chunk_offset) = self.find_chunk_idx(index);
         scalar_at_unchecked(
-            &self.chunk(chunk_index).vortex_expect(
-                format!(
-                "ChunkedArray: scalar_at_unchecked: failed to find chunk at index {chunk_index}"
-            )
-                .as_str(),
-            ),
+            &self.chunk(chunk_index).unwrap_or_else(|e| {
+                vortex_panic!(
+                    e,
+                    "ChunkedArray: scalar_at_unchecked: failed to find chunk {}",
+                    chunk_index,
+                )
+            }),
             chunk_offset,
         )
     }

--- a/vortex-array/src/array/chunked/mod.rs
+++ b/vortex-array/src/array/chunked/mod.rs
@@ -6,7 +6,7 @@ use futures_util::stream;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use vortex_dtype::{DType, Nullability, PType};
-use vortex_error::{vortex_bail, vortex_panic, VortexExpect as _, VortexResult};
+use vortex_error::{vortex_bail, VortexExpect as _, VortexResult};
 use vortex_scalar::Scalar;
 
 use crate::array::primitive::PrimitiveArray;
@@ -71,9 +71,9 @@ impl ChunkedArray {
     }
 
     #[inline]
-    pub fn chunk(&self, idx: usize) -> Option<Array> {
-        let chunk_start = usize::try_from(&scalar_at(&self.chunk_offsets(), idx).ok()?).ok()?;
-        let chunk_end = usize::try_from(&scalar_at(&self.chunk_offsets(), idx + 1).ok()?).ok()?;
+    pub fn chunk(&self, idx: usize) -> VortexResult<Array> {
+        let chunk_start = usize::try_from(&scalar_at(&self.chunk_offsets(), idx)?)?;
+        let chunk_end = usize::try_from(&scalar_at(&self.chunk_offsets(), idx + 1)?)?;
 
         // Offset the index since chunk_ends is child 0.
         self.as_ref()
@@ -110,13 +110,14 @@ impl ChunkedArray {
 
     pub fn chunks(&self) -> impl Iterator<Item = Array> + '_ {
         (0..self.nchunks()).map(|c| {
-            self.chunk(c).unwrap_or_else(|| {
-                vortex_panic!(
-                    "Chunk should {} exist but doesn't (nchunks: {})",
+            self.chunk(c).vortex_expect(
+                format!(
+                    "ChunkedArray: chunks: chunk should {} exist (nchunks: {})",
                     c,
                     self.nchunks()
                 )
-            })
+                .as_str(),
+            )
         })
     }
 
@@ -200,7 +201,7 @@ impl ArrayValidity for ChunkedArray {
     fn is_valid(&self, index: usize) -> bool {
         let (chunk, offset_in_chunk) = self.find_chunk_idx(index);
         self.chunk(chunk)
-            .unwrap_or_else(|| vortex_panic!(OutOfBounds: chunk, 0, self.nchunks()))
+            .vortex_expect(format!("ChunkedArray: is_valid failed to find chunk {index}").as_str())
             .with_dyn(|a| a.is_valid(offset_in_chunk))
     }
 

--- a/vortex-array/src/array/primitive/mod.rs
+++ b/vortex-array/src/array/primitive/mod.rs
@@ -86,9 +86,11 @@ impl PrimitiveArray {
     }
 
     pub fn validity(&self) -> Validity {
-        self.metadata()
-            .validity
-            .to_validity(self.as_ref().child(0, &Validity::DTYPE, self.len()))
+        self.metadata().validity.to_validity(|| {
+            self.as_ref()
+                .child(0, &Validity::DTYPE, self.len())
+                .vortex_expect("PrimitiveArray: validity child")
+        })
     }
 
     pub fn ptype(&self) -> PType {

--- a/vortex-array/src/array/struct_/mod.rs
+++ b/vortex-array/src/array/struct_/mod.rs
@@ -146,7 +146,7 @@ impl StructArrayTrait for StructArray {
         self.dtypes().get(idx).map(|dtype| {
             self.as_ref()
                 .child(idx, dtype, self.len())
-                .vortex_expect(&format!("StructArray: field {idx} not found"))
+                .unwrap_or_else(|e| vortex_panic!(e, "StructArray: field {} not found", idx))
         })
     }
 }

--- a/vortex-array/src/array/struct_/mod.rs
+++ b/vortex-array/src/array/struct_/mod.rs
@@ -22,11 +22,11 @@ pub struct StructMetadata {
 
 impl StructArray {
     pub fn validity(&self) -> Validity {
-        self.metadata().validity.to_validity(self.as_ref().child(
-            self.nfields(),
-            &Validity::DTYPE,
-            self.len(),
-        ))
+        self.metadata().validity.to_validity(|| {
+            self.as_ref()
+                .child(self.nfields(), &Validity::DTYPE, self.len())
+                .vortex_expect("StructArray: validity child")
+        })
     }
 
     pub fn children(&self) -> impl Iterator<Item = Array> + '_ {
@@ -143,9 +143,11 @@ impl ArrayVariants for StructArray {
 
 impl StructArrayTrait for StructArray {
     fn field(&self, idx: usize) -> Option<Array> {
-        self.dtypes()
-            .get(idx)
-            .and_then(|dtype| self.as_ref().child(idx, dtype, self.len()))
+        self.dtypes().get(idx).map(|dtype| {
+            self.as_ref()
+                .child(idx, dtype, self.len())
+                .vortex_expect(&format!("StructArray: field {idx} not found"))
+        })
     }
 }
 

--- a/vortex-array/src/array/varbin/mod.rs
+++ b/vortex-array/src/array/varbin/mod.rs
@@ -106,9 +106,11 @@ impl VarBinArray {
     }
 
     pub fn validity(&self) -> Validity {
-        self.metadata()
-            .validity
-            .to_validity(self.as_ref().child(2, &Validity::DTYPE, self.len()))
+        self.metadata().validity.to_validity(|| {
+            self.as_ref()
+                .child(2, &Validity::DTYPE, self.len())
+                .vortex_expect("VarBinArray: validity child")
+        })
     }
 
     /// Access value bytes child array limited to values that are logically present in

--- a/vortex-array/src/array/varbinview/mod.rs
+++ b/vortex-array/src/array/varbinview/mod.rs
@@ -177,22 +177,26 @@ impl VarBinViewArray {
     pub fn views(&self) -> Array {
         self.as_ref()
             .child(0, &DType::BYTES, self.len() * VIEW_SIZE)
-            .unwrap_or_else(|| vortex_panic!("VarBinViewArray is missing its views"))
+            .vortex_expect("VarBinViewArray is missing its views")
     }
 
     #[inline]
     pub fn bytes(&self, idx: usize) -> Array {
         self.as_ref()
             .child(idx + 1, &DType::BYTES, self.metadata().data_lens[idx])
-            .unwrap_or_else(|| vortex_panic!("VarBinViewArray is missing its data buffer"))
+            .vortex_expect("VarBinViewArray is missing its data buffer")
     }
 
     pub fn validity(&self) -> Validity {
-        self.metadata().validity.to_validity(self.as_ref().child(
-            self.metadata().data_lens.len() + 1,
-            &Validity::DTYPE,
-            self.len(),
-        ))
+        self.metadata().validity.to_validity(|| {
+            self.as_ref()
+                .child(
+                    self.metadata().data_lens.len() + 1,
+                    &Validity::DTYPE,
+                    self.len(),
+                )
+                .vortex_expect("VarBinViewArray: validity child")
+        })
     }
 
     pub fn from_iter_str<T: AsRef<str>, I: IntoIterator<Item = T>>(iter: I) -> Self {

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -47,6 +47,7 @@ pub mod encoding;
 mod implementation;
 pub mod iter;
 mod metadata;
+pub mod opaque;
 pub mod stats;
 pub mod stream;
 mod tree;

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -94,7 +94,7 @@ impl Array {
         self.with_dyn(|a| a.nbytes())
     }
 
-    pub fn child<'a>(&'a self, idx: usize, dtype: &'a DType, len: usize) -> Option<Self> {
+    pub fn child<'a>(&'a self, idx: usize, dtype: &'a DType, len: usize) -> VortexResult<Self> {
         match self {
             Self::Data(d) => d.child(idx, dtype, len).cloned(),
             Self::View(v) => v.child(idx, dtype, len).map(Array::View),

--- a/vortex-array/src/opaque.rs
+++ b/vortex-array/src/opaque.rs
@@ -1,0 +1,37 @@
+use std::fmt::Debug;
+
+use vortex_error::{vortex_bail, VortexResult};
+
+use crate::encoding::{ArrayEncoding, EncodingId};
+use crate::{Array, ArrayTrait, Canonical};
+
+/// An encoding of an array that we cannot interpret.
+///
+/// Vortex allows for pluggable encodings. This can lead to issues when one process produces a file
+/// using a custom encoding, and then another process without knowledge of the encoding attempts
+/// to read it.
+///
+/// `OpaqueEncoding` allows deserializing these arrays. Many common operations will fail, but it
+/// allows deserialization and introspection in a type-erased manner on the children and metadata.
+#[derive(Debug, Clone, Copy)]
+pub struct OpaqueEncoding;
+
+pub const OPAQUE_ENCODING_ID: EncodingId = EncodingId::new("vortex.opaque", 0u16);
+
+impl ArrayEncoding for OpaqueEncoding {
+    fn id(&self) -> EncodingId {
+        OPAQUE_ENCODING_ID
+    }
+
+    fn canonicalize(&self, _array: Array) -> VortexResult<Canonical> {
+        vortex_bail!("OpaqueArray: canonicalize cannot be called for opaque arrays");
+    }
+
+    fn with_dyn(
+        &self,
+        _array: &Array,
+        _f: &mut dyn for<'b> FnMut(&'b (dyn ArrayTrait + 'b)) -> VortexResult<()>,
+    ) -> VortexResult<()> {
+        vortex_bail!("OpaqueEncoding: with_dyn cannot be called for opaque arrays")
+    }
+}

--- a/vortex-array/src/opaque.rs
+++ b/vortex-array/src/opaque.rs
@@ -13,18 +13,21 @@ use crate::{Array, ArrayTrait, Canonical};
 ///
 /// `OpaqueEncoding` allows deserializing these arrays. Many common operations will fail, but it
 /// allows deserialization and introspection in a type-erased manner on the children and metadata.
+///
+/// We hold the original 16-bit encoding ID for producing helpful error messages.
 #[derive(Debug, Clone, Copy)]
-pub struct OpaqueEncoding;
-
-pub const OPAQUE_ENCODING_ID: EncodingId = EncodingId::new("vortex.opaque", 0u16);
+pub struct OpaqueEncoding(pub u16);
 
 impl ArrayEncoding for OpaqueEncoding {
     fn id(&self) -> EncodingId {
-        OPAQUE_ENCODING_ID
+        EncodingId::new("vortex.opaque", self.0)
     }
 
     fn canonicalize(&self, _array: Array) -> VortexResult<Canonical> {
-        vortex_bail!("OpaqueArray: canonicalize cannot be called for opaque arrays");
+        vortex_bail!(
+            "OpaqueArray: canonicalize cannot be called for opaque array ({})",
+            self.0
+        );
     }
 
     fn with_dyn(
@@ -32,6 +35,9 @@ impl ArrayEncoding for OpaqueEncoding {
         _array: &Array,
         _f: &mut dyn for<'b> FnMut(&'b (dyn ArrayTrait + 'b)) -> VortexResult<()>,
     ) -> VortexResult<()> {
-        vortex_bail!("OpaqueEncoding: with_dyn cannot be called for opaque arrays")
+        vortex_bail!(
+            "OpaqueEncoding: with_dyn cannot be called for opaque array ({})",
+            self.0
+        )
     }
 }

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -27,15 +27,15 @@ pub enum ValidityMetadata {
 }
 
 impl ValidityMetadata {
-    pub fn to_validity(&self, array: Option<Array>) -> Validity {
+    pub fn to_validity<F>(&self, array_fn: F) -> Validity
+    where
+        F: FnOnce() -> Array,
+    {
         match self {
             Self::NonNullable => Validity::NonNullable,
             Self::AllValid => Validity::AllValid,
             Self::AllInvalid => Validity::AllInvalid,
-            Self::Array => match array {
-                None => vortex_panic!("Missing validity array"),
-                Some(a) => Validity::Array(a),
-            },
+            Self::Array => Validity::Array(array_fn()),
         }
     }
 }

--- a/vortex-array/src/view.rs
+++ b/vortex-array/src/view.rs
@@ -116,7 +116,14 @@ impl ArrayView {
         let child = self.array_child(idx)?;
         let flatbuffer_loc = child._tab.loc();
 
-        let encoding = self.ctx.lookup_encoding(child.encoding())?;
+        let encoding = self
+            .ctx
+            .lookup_encoding(child.encoding())
+            .vortex_expect(&format!(
+                "ArrayView({}) child at index {idx} has unknown encoding {}",
+                self.encoding.id().as_ref(),
+                child.encoding()
+            ));
 
         // Figure out how many buffers to skip...
         // We store them depth-first.

--- a/vortex-array/src/view.rs
+++ b/vortex-array/src/view.rs
@@ -10,6 +10,7 @@ use vortex_error::{vortex_bail, vortex_err, VortexError, VortexExpect as _, Vort
 use vortex_scalar::{PValue, Scalar, ScalarValue};
 
 use crate::encoding::EncodingRef;
+use crate::opaque::OpaqueEncoding;
 use crate::stats::{Stat, Statistics, StatsSet};
 use crate::visitor::ArrayVisitor;
 use crate::{flatbuffers as fb, Array, Context, IntoArray, ToArray};
@@ -118,13 +119,10 @@ impl ArrayView {
             .ok_or_else(|| vortex_err!("ArrayView: array_child({idx}) not found"))?;
         let flatbuffer_loc = child._tab.loc();
 
-        let encoding = self.ctx.lookup_encoding(child.encoding()).ok_or_else(|| {
-            vortex_err!(
-                "ArrayView({}) child at index {idx} has unknown encoding {}",
-                self.encoding.id().as_ref(),
-                child.encoding()
-            )
-        })?;
+        let encoding = self
+            .ctx
+            .lookup_encoding(child.encoding())
+            .unwrap_or(&OpaqueEncoding as _);
 
         // Figure out how many buffers to skip...
         // We store them depth-first.

--- a/vortex-datafusion/src/lib.rs
+++ b/vortex-datafusion/src/lib.rs
@@ -216,10 +216,7 @@ impl Stream for VortexRecordBatchStream {
         }
 
         // Grab next chunk, project and convert to Arrow.
-        let chunk = this
-            .chunks
-            .chunk(this.idx)
-            .ok_or_else(|| vortex_err!("nchunks should match precomputed"))?;
+        let chunk = this.chunks.chunk(this.idx)?;
         this.idx += 1;
 
         let struct_array = chunk

--- a/vortex-datafusion/src/plans.rs
+++ b/vortex-datafusion/src/plans.rs
@@ -150,13 +150,7 @@ impl Stream for RowIndicesStream {
             return Poll::Ready(None);
         }
 
-        let next_chunk = this.chunked_array.chunk(this.chunk_idx).ok_or_else(|| {
-            vortex_err!(
-                "Chunk not found for index {}, nchunks: {}",
-                this.chunk_idx,
-                this.chunked_array.nchunks()
-            )
-        })?;
+        let next_chunk = this.chunked_array.chunk(this.chunk_idx)?;
         this.chunk_idx += 1;
 
         // Get the unfiltered record batch.
@@ -350,17 +344,7 @@ where
             .map_err(DataFusionError::from)?)));
         }
 
-        let chunk = this
-            .vortex_array
-            .chunk(*this.chunk_idx)
-            .ok_or_else(|| {
-                vortex_err!(
-                    "Chunk not found for index {}, nchunks: {}",
-                    this.chunk_idx,
-                    this.vortex_array.nchunks()
-                )
-            })?
-            .into_struct()?;
+        let chunk = this.vortex_array.chunk(*this.chunk_idx)?.into_struct()?;
 
         *this.chunk_idx += 1;
 


### PR DESCRIPTION
Array::child returns an Option<Array>. The only time it should really ever return None is when you are passing the result to ValidityMetadata::to_validity.

Currently, if an array child is encoded with an unknown encoding ID (e.g. b/c it's not been linked into your binary) then you end up silently failing, and swalloing the reason why the None was returned.

IMO this is an irrecoverable error and is one of the times it's better to fail with a helpful message rather than forge on ahead.