### PR TITLE
Don't validate offset buffers when converting them to arrow

### DIFF
--- a/vortex-array/src/arrow/wrappers.rs
+++ b/vortex-array/src/arrow/wrappers.rs
@@ -13,5 +13,5 @@ pub fn as_scalar_buffer<T: NativePType + ArrowNativeType>(
 pub fn as_offset_buffer<T: NativePType + ArrowNativeType>(
     array: PrimitiveArray,
 ) -> OffsetBuffer<T> {
-    OffsetBuffer::new(as_scalar_buffer(array))
+    unsafe { OffsetBuffer::new_unchecked(as_scalar_buffer(array)) }
 }


### PR DESCRIPTION
This shows up as most expensive part of converting into arrow since OffsetBuffer::new validates that values are monotonic