### PR TITLE
fix: version -> benchmark in GHA bench.yml

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,7 +13,7 @@ jobs:
   bench:
     strategy:
       matrix:
-        version:
+        benchmark:
           - id: tpch_benchmark
             # this was the original name which we must preserve until we change the name of all the
             # records in the gh-pages-bench branch "Vortex benchmarks"


### PR DESCRIPTION
I renamed this in bench-pr.yml and changed the references to the matrix variable in both files, but forgot to rename it here in bench.yml