### PR TITLE
make CI bench tests faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,4 +81,4 @@ jobs:
         with:
           version: v1.0.0
       - name: Rust Bench as test
-        run: cargo bench --benches -- --test
+        run: cargo test --bench '*'


### PR DESCRIPTION
`cargo bench --benches -- --test` still builds in release mode and runs the benches multiple times, it just links libtest

`cargo test --bench '*'` builds in debug mode (like the other tests) and--as far as I can tell from the internet / running locally--only runs each benchmark closure once instead