### PR TITLE
faster ALP encode

### DIFF
--- a/encodings/alp/src/alp.rs
+++ b/encodings/alp/src/alp.rs
@@ -2,7 +2,7 @@ use std::fmt::{Display, Formatter};
 use std::mem::size_of;
 
 use itertools::Itertools;
-use num_traits::{CheckedSub, Float, NumCast, PrimInt, Saturating, ToPrimitive, Zero};
+use num_traits::{CheckedSub, Float, NumCast, PrimInt, ToPrimitive, Zero};
 use serde::{Deserialize, Serialize};
 use vortex_error::vortex_panic;
 

--- a/encodings/alp/src/alp.rs
+++ b/encodings/alp/src/alp.rs
@@ -110,8 +110,8 @@ pub trait ALPFloat: Float + Display + 'static {
         let mut fill_value: Option<Self::ALPInt> = None;
 
         // this is intentionally branchless
-        // we batch this into 16KB of values at a time to make it more L1 cache friendly
-        let encode_chunk_size: usize = (16 << 10) / size_of::<Self::ALPInt>();
+        // we batch this into 32KB of values at a time to make it more L1 cache friendly
+        let encode_chunk_size: usize = (32 << 10) / size_of::<Self::ALPInt>();
         for chunk in values.chunks(encode_chunk_size) {
             encode_chunk_unchecked(
                 chunk,
@@ -178,7 +178,7 @@ fn encode_chunk_unchecked<T: ALPFloat>(
     encoded_output.extend(chunk.iter().map(|v| {
         let encoded = unsafe { T::encode_single_unchecked(*v, exp) };
         let decoded = T::decode_single(encoded, exp);
-        let neq: usize = (decoded != *v) as usize;
+        let neq = (decoded != *v) as usize;
         chunk_patch_count += neq;
         encoded
     }));

--- a/encodings/alp/src/alp.rs
+++ b/encodings/alp/src/alp.rs
@@ -131,7 +131,7 @@ pub trait ALPFloat: Float + Display + 'static {
 
             // find the first successfully encoded value (i.e., not patched)
             let mut fill_value = Self::ALPInt::zero();
-            for (i, v) in encoded.iter().enumerate() {
+            for i in 0..encoded.len() {
                 if patch_indices[i] != i as u64 {
                     fill_value = encoded[i];
                     break;

--- a/encodings/alp/src/alp.rs
+++ b/encodings/alp/src/alp.rs
@@ -4,7 +4,6 @@ use std::mem::size_of;
 use itertools::Itertools;
 use num_traits::{CheckedSub, Float, PrimInt, ToPrimitive};
 use serde::{Deserialize, Serialize};
-use vortex_error::vortex_panic;
 
 const SAMPLE_SIZE: usize = 32;
 
@@ -138,15 +137,7 @@ pub trait ALPFloat: Float + Display + 'static {
 
     #[inline]
     fn decode_single(encoded: Self::ALPInt, exponents: Exponents) -> Self {
-        let encoded_float: Self = Self::from(encoded).unwrap_or_else(|| {
-            vortex_panic!(
-                "Failed to convert encoded value {} from {} to {} in ALPFloat::decode_single",
-                encoded,
-                std::any::type_name::<Self::ALPInt>(),
-                std::any::type_name::<Self>()
-            )
-        });
-        encoded_float * Self::F10[exponents.f as usize] * Self::IF10[exponents.e as usize]
+        Self::from_int(encoded) * Self::F10[exponents.f as usize] * Self::IF10[exponents.e as usize]
     }
 
     /// # Safety

--- a/encodings/alp/src/alp.rs
+++ b/encodings/alp/src/alp.rs
@@ -1,9 +1,8 @@
-use core::convert::FloatToInt;
 use std::fmt::{Display, Formatter};
 use std::mem::size_of;
 
 use itertools::Itertools;
-use num_traits::{Bounded, CheckedSub, Float, PrimInt, ToPrimitive};
+use num_traits::{CheckedSub, Float, PrimInt, ToPrimitive};
 use serde::{Deserialize, Serialize};
 use vortex_error::vortex_panic;
 
@@ -21,8 +20,8 @@ impl Display for Exponents {
     }
 }
 
-pub trait ALPFloat: Float + Display + FloatToInt<Self::ALPInt> + 'static {
-    type ALPInt: PrimInt + Bounded + Display + ToPrimitive;
+pub trait ALPFloat: Float + Display + 'static {
+    type ALPInt: PrimInt + Display + ToPrimitive;
 
     const FRACTIONAL_BITS: u8;
     const MAX_EXPONENT: u8;

--- a/encodings/alp/src/alp.rs
+++ b/encodings/alp/src/alp.rs
@@ -2,7 +2,7 @@ use std::fmt::{Display, Formatter};
 use std::mem::size_of;
 
 use itertools::Itertools;
-use num_traits::{Float, NumCast, PrimInt, Zero};
+use num_traits::{CheckedSub, Float, NumCast, PrimInt, Saturating, ToPrimitive, Zero};
 use serde::{Deserialize, Serialize};
 use vortex_error::vortex_panic;
 
@@ -21,7 +21,7 @@ impl Display for Exponents {
 }
 
 pub trait ALPFloat: Float + Display + 'static {
-    type ALPInt: PrimInt + Display;
+    type ALPInt: PrimInt + Display + ToPrimitive;
 
     const FRACTIONAL_BITS: u8;
     const MAX_EXPONENT: u8;
@@ -30,10 +30,12 @@ pub trait ALPFloat: Float + Display + 'static {
     const IF10: &'static [Self];
 
     /// Round to the nearest floating integer by shifting in and out of the low precision range.
+    #[inline]
     fn fast_round(self) -> Self {
         (self + Self::SWEET) - Self::SWEET
     }
 
+    #[inline]
     fn as_int(self) -> Option<Self::ALPInt> {
         <Self::ALPInt as NumCast>::from(self)
     }
@@ -50,16 +52,14 @@ pub trait ALPFloat: Float + Display + 'static {
                 .collect_vec()
         });
 
-        // TODO(wmanning): idea, start with highest e, then find the best f
-        //  after that, try e's in descending order, with a gap no larger than the original e - f
-        for e in 0..Self::MAX_EXPONENT {
+        for e in (0..Self::MAX_EXPONENT).rev() {
             for f in 0..e {
-                let (_, encoded, exc_pos, exc_patches) = Self::encode(
+                let (_, encoded, _, exc_patches) = Self::encode(
                     sample.as_deref().unwrap_or(values),
                     Some(Exponents { e, f }),
                 );
-                let size =
-                    (encoded.len() + exc_patches.len()) * size_of::<Self>() + (exc_pos.len() * 4);
+
+                let size = Self::estimate_encoded_size(&encoded, &exc_patches);
                 if size < best_nbytes {
                     best_nbytes = size;
                     best_exp = Exponents { e, f };
@@ -70,6 +70,31 @@ pub trait ALPFloat: Float + Display + 'static {
         }
 
         best_exp
+    }
+
+    #[inline(always)]
+    fn estimate_encoded_size(encoded: &[Self::ALPInt], patches: &[Self]) -> usize {
+        let bits_per_encoded = encoded
+            .iter()
+            .minmax()
+            .into_option()
+            // estimating bits per encoded value assuming frame-of-reference + bitpacking-without-patches
+            .and_then(|(min, max)| max.checked_sub(min))
+            .and_then(|range_size: <Self as ALPFloat>::ALPInt| range_size.to_u64())
+            .and_then(|range_size| {
+                range_size
+                    .checked_ilog2()
+                    .map(|bits| (bits + 1) as usize)
+                    .or(Some(0))
+            })
+            .unwrap_or(size_of::<Self::ALPInt>() * 8);
+
+        let encoded_bytes = (encoded.len() * bits_per_encoded + 7) / 8;
+        // each patch is a value + a position
+        // in practice, patch positions are in [0, u16::MAX] because of how we chunk
+        let patch_bytes = patches.len() * (size_of::<Self>() + size_of::<u16>());
+
+        encoded_bytes + patch_bytes
     }
 
     fn encode(
@@ -149,7 +174,7 @@ impl ALPFloat for f32 {
         10000000.0,
         100000000.0,
         1000000000.0,
-        10000000000.0,
+        10000000000.0, // 10^10
     ];
     const IF10: &'static [Self] = &[
         1.0,
@@ -162,7 +187,7 @@ impl ALPFloat for f32 {
         0.0000001,
         0.00000001,
         0.000000001,
-        0.0000000001,
+        0.0000000001, // 10^-10
     ];
 }
 
@@ -196,7 +221,7 @@ impl ALPFloat for f64 {
         100000000000000000000.0,
         1000000000000000000000.0,
         10000000000000000000000.0,
-        100000000000000000000000.0,
+        100000000000000000000000.0, // 10^23
     ];
 
     const IF10: &'static [Self] = &[
@@ -223,6 +248,6 @@ impl ALPFloat for f64 {
         0.00000000000000000001,
         0.000000000000000000001,
         0.0000000000000000000001,
-        0.00000000000000000000001,
+        0.00000000000000000000001, // 10^-23
     ];
 }

--- a/encodings/alp/src/compress.rs
+++ b/encodings/alp/src/compress.rs
@@ -2,7 +2,7 @@ use vortex::array::{PrimitiveArray, Sparse, SparseArray};
 use vortex::validity::Validity;
 use vortex::{Array, ArrayDType, ArrayDef, IntoArray, IntoArrayVariant};
 use vortex_dtype::{NativePType, PType};
-use vortex_error::{vortex_bail,VortexExpect as _, VortexResult};
+use vortex_error::{vortex_bail, VortexExpect as _, VortexResult};
 use vortex_scalar::Scalar;
 
 use crate::alp::ALPFloat;

--- a/encodings/alp/src/compress.rs
+++ b/encodings/alp/src/compress.rs
@@ -2,7 +2,7 @@ use vortex::array::{PrimitiveArray, Sparse, SparseArray};
 use vortex::validity::Validity;
 use vortex::{Array, ArrayDType, ArrayDef, IntoArray, IntoArrayVariant};
 use vortex_dtype::{NativePType, PType};
-use vortex_error::{vortex_bail, VortexExpect as _, VortexResult};
+use vortex_error::{vortex_bail,VortexExpect as _, VortexResult};
 use vortex_scalar::Scalar;
 
 use crate::alp::ALPFloat;
@@ -14,11 +14,12 @@ macro_rules! match_each_alp_float_ptype {
     ($self:expr, | $_:tt $enc:ident | $($body:tt)*) => ({
         macro_rules! __with__ {( $_ $enc:ident ) => ( $($body)* )}
         use vortex_dtype::PType;
+        use vortex_error::vortex_panic;
         let ptype = $self;
         match ptype {
             PType::F32 => __with__! { f32 },
             PType::F64 => __with__! { f64 },
-            _ => panic!("ALP can only encode f32 and f64"),
+            _ => vortex_panic!("ALP can only encode f32 and f64, got {}", ptype),
         }
     })
 }

--- a/encodings/alp/src/compress.rs
+++ b/encodings/alp/src/compress.rs
@@ -123,7 +123,7 @@ mod tests {
             encoded.encoded().as_primitive().maybe_null_slice::<i32>(),
             vec![1234; 1025]
         );
-        assert_eq!(encoded.exponents(), Exponents { e: 4, f: 1 });
+        assert_eq!(encoded.exponents(), Exponents { e: 9, f: 6 });
 
         let decoded = decompress(encoded).unwrap();
         assert_eq!(
@@ -141,7 +141,7 @@ mod tests {
             encoded.encoded().as_primitive().maybe_null_slice::<i32>(),
             vec![0, 1234, 0]
         );
-        assert_eq!(encoded.exponents(), Exponents { e: 4, f: 1 });
+        assert_eq!(encoded.exponents(), Exponents { e: 9, f: 6 });
 
         let decoded = decompress(encoded).unwrap();
         let expected = vec![0f32, 1.234f32, 0f32];
@@ -159,7 +159,7 @@ mod tests {
             encoded.encoded().as_primitive().maybe_null_slice::<i64>(),
             vec![1234i64, 2718, 2718, 4000] // fill forward
         );
-        assert_eq!(encoded.exponents(), Exponents { e: 3, f: 0 });
+        assert_eq!(encoded.exponents(), Exponents { e: 16, f: 13 });
 
         let decoded = decompress(encoded).unwrap();
         assert_eq!(values, decoded.maybe_null_slice::<f64>());
@@ -179,7 +179,7 @@ mod tests {
         let encoded = alp_encode(&array).unwrap();
         assert!(encoded.patches().is_some());
 
-        assert_eq!(encoded.exponents(), Exponents { e: 3, f: 0 });
+        assert_eq!(encoded.exponents(), Exponents { e: 16, f: 13 });
 
         for idx in 0..3 {
             let s = scalar_at(encoded.as_ref(), idx).unwrap();

--- a/encodings/alp/src/compress.rs
+++ b/encodings/alp/src/compress.rs
@@ -157,7 +157,7 @@ mod tests {
         assert!(encoded.patches().is_some());
         assert_eq!(
             encoded.encoded().as_primitive().maybe_null_slice::<i64>(),
-            vec![1234i64, 2718, 2718, 4000] // fill forward
+            vec![1234i64, 2718, 1234, 4000] // fill forward
         );
         assert_eq!(encoded.exponents(), Exponents { e: 16, f: 13 });
 

--- a/encodings/alp/src/lib.rs
+++ b/encodings/alp/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(convert_float_to_int)]
-
 pub use alp::*;
 pub use array::*;
 pub use compress::*;

--- a/encodings/alp/src/lib.rs
+++ b/encodings/alp/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(convert_float_to_int)]
+
 pub use alp::*;
 pub use array::*;
 pub use compress::*;


### PR DESCRIPTION
fixes #920 

Consistently cuts encoding time by 10-50%.

Before the change:

```
Running benches/alp_compress.rs (target/release/deps/alp_compress-abbdaefc5eabf343)
Timer precision: 41 ns
alp_compress          fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ alp_compress                     │               │               │               │         │
│  ├─ f32                           │               │               │               │         │
│  │  ├─ 100000       191.9 µs      │ 824.9 µs      │ 314.7 µs      │ 354 µs        │ 100     │ 100
│  │  ╰─ 10000000     21.39 ms      │ 28.95 ms      │ 21.71 ms      │ 21.89 ms      │ 100     │ 100
│  ╰─ f64                           │               │               │               │         │
│     ├─ 100000       236 µs        │ 353.7 µs      │ 238.4 µs      │ 246.4 µs      │ 100     │ 100
│     ╰─ 10000000     28.78 ms      │ 68.68 ms      │ 29.49 ms      │ 29.93 ms      │ 100     │ 100
```

After:

```
Running benches/alp_compress.rs (target/release/deps/alp_compress-abbdaefc5eabf343)
Timer precision: 41 ns
alp_compress          fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ alp_compress                     │               │               │               │         │
│  ├─ f32                           │               │               │               │         │
│  │  ├─ 100000       161 µs        │ 234.6 µs      │ 163.3 µs      │ 166 µs        │ 100     │ 100
│  │  ╰─ 10000000     18.72 ms      │ 21.54 ms      │ 19.07 ms      │ 19.14 ms      │ 100     │ 100
│  ╰─ f64                           │               │               │               │         │
│     ├─ 100000       182 µs        │ 346 µs        │ 183.9 µs      │ 187.9 µs      │ 100     │ 100
│     ╰─ 10000000     23.98 ms      │ 28.71 ms      │ 24.52 ms      │ 24.53 ms      │ 100     │ 100
```