### PR TITLE
Rechunk uncompressed vortex files in benchmarks

### DIFF
--- a/bench-vortex/src/tpch/mod.rs
+++ b/bench-vortex/src/tpch/mod.rs
@@ -36,6 +36,7 @@ pub const EXPECTED_ROW_COUNTS: [usize; 23] = [
     0, 4, 460, 11620, 5, 5, 1, 4, 2, 175, 37967, 1048, 2, 42, 1, 1, 18314, 1, 57, 1, 186, 411, 7,
 ];
 
+// Sizes match default compressor configuration
 const TARGET_BLOCK_BYTESIZE: usize = 16 * (1 << 20);
 const TARGET_BLOCK_SIZE: usize = 64 * (1 << 10);
 


### PR DESCRIPTION
makes benchmarks a bit more realistic. Right now uncompressed variants are worse because they have bad chunking