### PR TITLE
feat: teach DeltaArray slice and scalar_at

### DIFF
--- a/encodings/fastlanes/src/delta/compress.rs
+++ b/encodings/fastlanes/src/delta/compress.rs
@@ -100,7 +100,6 @@ where
 pub fn delta_decompress(array: DeltaArray) -> VortexResult<PrimitiveArray> {
     let bases = array.bases().into_primitive()?;
     let deltas = array.deltas().into_primitive()?;
-
     let decoded = match_each_unsigned_integer_ptype!(deltas.ptype(), |$T| {
         PrimitiveArray::from_vec(
             decompress_primitive::<$T>(bases.maybe_null_slice(), deltas.maybe_null_slice()),

--- a/encodings/fastlanes/src/delta/compress.rs
+++ b/encodings/fastlanes/src/delta/compress.rs
@@ -128,9 +128,7 @@ pub fn delta_decompress(array: DeltaArray) -> VortexResult<PrimitiveArray> {
             array.validity()
         )
     });
-    decoded
-        .slice(array.offset(), decoded.len() - array.trailing_garbage())?
-        .into_primitive()
+    decoded.slice(array.offset(), array.len())?.into_primitive()
 }
 
 fn decompress_primitive<T: NativePType + Delta + Transpose + WrappingAdd>(

--- a/encodings/fastlanes/src/delta/compress.rs
+++ b/encodings/fastlanes/src/delta/compress.rs
@@ -128,7 +128,10 @@ pub fn delta_decompress(array: DeltaArray) -> VortexResult<PrimitiveArray> {
             array.validity()
         )
     });
-    decoded.slice(array.offset(), array.len())?.into_primitive()
+
+    decoded
+        .slice(array.offset(), array.offset() + array.len())?
+        .into_primitive()
 }
 
 fn decompress_primitive<T: NativePType + Delta + Transpose + WrappingAdd>(
@@ -204,6 +207,7 @@ mod test {
 
     fn do_roundtrip_test<T: NativePType>(input: Vec<T>) {
         let delta = DeltaArray::try_from_vec(input.clone()).unwrap();
+        assert_eq!(delta.len(), input.len());
         let decompressed = delta_decompress(delta).unwrap();
         let decompressed_slice = decompressed.maybe_null_slice::<T>();
         assert_eq!(decompressed_slice.len(), input.len());

--- a/encodings/fastlanes/src/delta/compress.rs
+++ b/encodings/fastlanes/src/delta/compress.rs
@@ -103,10 +103,7 @@ pub fn delta_decompress(array: DeltaArray) -> VortexResult<PrimitiveArray> {
 
     let decoded = match_each_unsigned_integer_ptype!(deltas.ptype(), |$T| {
         PrimitiveArray::from_vec(
-            decompress_primitive::<$T>(
-                bases.reinterpret_cast(deltas.ptype()).maybe_null_slice(),
-                deltas.reinterpret_cast(deltas.ptype()).maybe_null_slice(),
-            ),
+            decompress_primitive::<$T>(bases.maybe_null_slice(), deltas.maybe_null_slice()),
             array.validity()
         )
     });

--- a/encodings/fastlanes/src/delta/compress.rs
+++ b/encodings/fastlanes/src/delta/compress.rs
@@ -101,12 +101,11 @@ pub fn delta_decompress(array: DeltaArray) -> VortexResult<PrimitiveArray> {
     let bases = array.bases().into_primitive()?;
     let deltas = array.deltas().into_primitive()?;
 
-    let ptype = bases.ptype();
-    let decoded = match_each_unsigned_integer_ptype!(ptype, |$T| {
+    let decoded = match_each_unsigned_integer_ptype!(deltas.ptype(), |$T| {
         PrimitiveArray::from_vec(
             decompress_primitive::<$T>(
-                bases.reinterpret_cast(ptype).maybe_null_slice(),
-                deltas.reinterpret_cast(ptype).maybe_null_slice(),
+                bases.reinterpret_cast(deltas.ptype()).maybe_null_slice(),
+                deltas.reinterpret_cast(deltas.ptype()).maybe_null_slice(),
             ),
             array.validity()
         )

--- a/encodings/fastlanes/src/delta/compute.rs
+++ b/encodings/fastlanes/src/delta/compute.rs
@@ -3,7 +3,7 @@ use std::cmp::min;
 use vortex::compute::unary::ScalarAtFn;
 use vortex::compute::{slice, ArrayCompute, SliceFn};
 use vortex::{Array, IntoArray, IntoArrayVariant};
-use vortex_error::{vortex_bail, VortexExpect, VortexResult};
+use vortex_error::{VortexExpect, VortexResult};
 use vortex_scalar::Scalar;
 
 use crate::DeltaArray;
@@ -60,10 +60,9 @@ impl SliceFn for DeltaArray {
 
         let new_validity = validity.slice(start, stop)?;
 
-        let limit = if physical_stop % 1024 == 0 {
-            None
-        } else {
-            Some(physical_stop % 1024)
+        let limit = match physical_stop % 1024 {
+            0 => 1024,
+            n => n,
         };
 
         let arr = DeltaArray::try_new(
@@ -73,6 +72,7 @@ impl SliceFn for DeltaArray {
             physical_start % 1024,
             limit,
         )?;
+
         if arr.len() != stop - start {
             vortex_bail!(
                 "slice produced wrong length: {} != {} - {}",

--- a/encodings/fastlanes/src/delta/compute.rs
+++ b/encodings/fastlanes/src/delta/compute.rs
@@ -1,5 +1,422 @@
-use vortex::compute::ArrayCompute;
+use std::cmp::min;
+
+use vortex::compute::unary::ScalarAtFn;
+use vortex::compute::{ArrayCompute, SliceFn};
+use vortex::{Array, IntoArray, IntoArrayVariant};
+use vortex_error::{vortex_bail, vortex_err, VortexExpect, VortexResult};
+use vortex_scalar::Scalar;
 
 use crate::DeltaArray;
 
-impl ArrayCompute for DeltaArray {}
+impl ArrayCompute for DeltaArray {
+    fn scalar_at(&self) -> Option<&dyn ScalarAtFn> {
+        Some(self)
+    }
+
+    fn slice(&self) -> Option<&dyn SliceFn> {
+        Some(self)
+    }
+}
+
+impl ScalarAtFn for DeltaArray {
+    fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
+        let decompressed = SliceFn::slice(self, index, index + 1)?.into_primitive()?;
+        ScalarAtFn::scalar_at(&decompressed, 0)
+    }
+
+    fn scalar_at_unchecked(&self, index: usize) -> Scalar {
+        let decompressed = SliceFn::slice(self, index, index + 1)
+            .vortex_expect("DeltaArray slice for one value should work")
+            .into_primitive()
+            .vortex_expect("Converting slice into primitive should work");
+        ScalarAtFn::scalar_at_unchecked(&decompressed, 0)
+    }
+}
+
+impl SliceFn for DeltaArray {
+    fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
+        let physical_start = start + self.offset();
+        let physical_stop = stop + self.offset();
+
+        let start_chunk = physical_start / 1024;
+        let stop_chunk = (physical_stop + 1024 - 1) / 1024;
+
+        let bases = self.bases();
+        let deltas = self.deltas();
+        let validity = self.validity();
+        let lanes = self.lanes();
+
+        let new_bases = bases.with_dyn(|a| {
+            a.slice()
+                .ok_or(vortex_err!("bases must be slice-able"))?
+                .slice(
+                    min(start_chunk * lanes, self.bases_len()),
+                    min(stop_chunk * lanes, self.bases_len()),
+                )
+        })?;
+
+        let new_deltas = deltas.with_dyn(|a| {
+            a.slice()
+                .ok_or(vortex_err!("deltas must be slice-able"))?
+                .slice(
+                    min(start_chunk * 1024, self.deltas_len()),
+                    min(stop_chunk * 1024, self.deltas_len()),
+                )
+        })?;
+
+        let new_validity = validity.slice(start, stop)?;
+
+        let limit = if physical_stop % 1024 == 0 {
+            None
+        } else {
+            Some(physical_stop % 1024)
+        };
+
+        let arr = DeltaArray::try_new(
+            new_bases,
+            new_deltas,
+            new_validity,
+            physical_start % 1024,
+            limit,
+        )?;
+        if arr.len() != stop - start {
+            vortex_bail!(
+                "slice produced wrong length: {} != {} - {}",
+                arr.len(),
+                stop,
+                start,
+            )
+        }
+        Ok(arr.into_array())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use vortex::compute::slice;
+    use vortex::compute::unary::{scalar_at, scalar_at_unchecked};
+    use vortex::IntoArrayVariant;
+    use vortex_error::VortexError;
+
+    use super::*;
+
+    #[test]
+    fn test_scalar_at_non_jagged_array() {
+        let delta = DeltaArray::try_from_vec((0u32..2048).collect())
+            .unwrap()
+            .into_array();
+
+        assert_eq!(scalar_at(&delta, 0).unwrap(), 0_u32.into());
+        assert_eq!(scalar_at_unchecked(&delta, 0), 0_u32.into());
+
+        assert_eq!(scalar_at(&delta, 1).unwrap(), 1_u32.into());
+        assert_eq!(scalar_at_unchecked(&delta, 1), 1_u32.into());
+
+        assert_eq!(scalar_at(&delta, 10).unwrap(), 10_u32.into());
+        assert_eq!(scalar_at_unchecked(&delta, 10), 10_u32.into());
+
+        assert_eq!(scalar_at(&delta, 1023).unwrap(), 1023_u32.into());
+        assert_eq!(scalar_at_unchecked(&delta, 1023), 1023_u32.into());
+
+        assert_eq!(scalar_at(&delta, 1024).unwrap(), 1024_u32.into());
+        assert_eq!(scalar_at_unchecked(&delta, 1024), 1024_u32.into());
+
+        assert_eq!(scalar_at(&delta, 1025).unwrap(), 1025_u32.into());
+        assert_eq!(scalar_at_unchecked(&delta, 1025), 1025_u32.into());
+
+        assert_eq!(scalar_at(&delta, 2047).unwrap(), 2047_u32.into());
+        assert_eq!(scalar_at_unchecked(&delta, 2047), 2047_u32.into());
+
+        assert!(matches!(
+            scalar_at(&delta, 2048),
+            Err(VortexError::OutOfBounds(2048, 0, 2048, _))
+        ));
+
+        assert!(matches!(
+            scalar_at(&delta, 2049),
+            Err(VortexError::OutOfBounds(2049, 0, 2048, _))
+        ));
+    }
+
+    #[test]
+    fn test_scalar_at_jagged_array() {
+        let delta = DeltaArray::try_from_vec((0u32..2000).collect())
+            .unwrap()
+            .into_array();
+
+        assert_eq!(scalar_at(&delta, 0).unwrap(), 0_u32.into());
+        assert_eq!(scalar_at_unchecked(&delta, 0), 0_u32.into());
+
+        assert_eq!(scalar_at(&delta, 1).unwrap(), 1_u32.into());
+        assert_eq!(scalar_at_unchecked(&delta, 1), 1_u32.into());
+
+        assert_eq!(scalar_at(&delta, 10).unwrap(), 10_u32.into());
+        assert_eq!(scalar_at_unchecked(&delta, 10), 10_u32.into());
+
+        assert_eq!(scalar_at(&delta, 1023).unwrap(), 1023_u32.into());
+        assert_eq!(scalar_at_unchecked(&delta, 1023), 1023_u32.into());
+
+        assert_eq!(scalar_at(&delta, 1024).unwrap(), 1024_u32.into());
+        assert_eq!(scalar_at_unchecked(&delta, 1024), 1024_u32.into());
+
+        assert_eq!(scalar_at(&delta, 1025).unwrap(), 1025_u32.into());
+        assert_eq!(scalar_at_unchecked(&delta, 1025), 1025_u32.into());
+
+        assert_eq!(scalar_at(&delta, 1999).unwrap(), 1999_u32.into());
+        assert_eq!(scalar_at_unchecked(&delta, 1999), 1999_u32.into());
+
+        assert!(matches!(
+            scalar_at(&delta, 2000),
+            Err(VortexError::OutOfBounds(2000, 0, 2000, _))
+        ));
+
+        assert!(matches!(
+            scalar_at(&delta, 2001),
+            Err(VortexError::OutOfBounds(2001, 0, 2000, _))
+        ));
+    }
+
+    #[test]
+    fn test_slice_non_jagged_array_first_chunk_of_two() {
+        let delta = DeltaArray::try_from_vec((0u32..2048).collect()).unwrap();
+
+        assert_eq!(
+            SliceFn::slice(&delta, 10, 250)
+                .unwrap()
+                .into_primitive()
+                .unwrap()
+                .maybe_null_slice::<u32>(),
+            (10u32..250).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_slice_non_jagged_array_second_chunk_of_two() {
+        let delta = DeltaArray::try_from_vec((0u32..2048).collect()).unwrap();
+
+        assert_eq!(
+            SliceFn::slice(&delta, 1024 + 10, 1024 + 250)
+                .unwrap()
+                .into_primitive()
+                .unwrap()
+                .maybe_null_slice::<u32>(),
+            ((1024 + 10u32)..(1024 + 250)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_slice_non_jagged_array_span_two_chunks_chunk_of_two() {
+        let delta = DeltaArray::try_from_vec((0u32..2048).collect()).unwrap();
+
+        assert_eq!(
+            SliceFn::slice(&delta, 1000, 1048)
+                .unwrap()
+                .into_primitive()
+                .unwrap()
+                .maybe_null_slice::<u32>(),
+            (1000u32..1048).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_slice_non_jagged_array_span_two_chunks_chunk_of_four() {
+        let delta = DeltaArray::try_from_vec((0u32..4096).collect()).unwrap();
+
+        assert_eq!(
+            SliceFn::slice(&delta, 2040, 2050)
+                .unwrap()
+                .into_primitive()
+                .unwrap()
+                .maybe_null_slice::<u32>(),
+            (2040u32..2050).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_slice_non_jagged_array_whole() {
+        let delta = DeltaArray::try_from_vec((0u32..4096).collect()).unwrap();
+
+        assert_eq!(
+            SliceFn::slice(&delta, 0, 4096)
+                .unwrap()
+                .into_primitive()
+                .unwrap()
+                .maybe_null_slice::<u32>(),
+            (0u32..4096).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_slice_non_jagged_array_empty() {
+        let delta = DeltaArray::try_from_vec((0u32..4096).collect()).unwrap();
+
+        assert_eq!(
+            SliceFn::slice(&delta, 0, 0)
+                .unwrap()
+                .into_primitive()
+                .unwrap()
+                .maybe_null_slice::<u32>(),
+            Vec::<u32>::new(),
+        );
+
+        assert_eq!(
+            SliceFn::slice(&delta, 4096, 4096)
+                .unwrap()
+                .into_primitive()
+                .unwrap()
+                .maybe_null_slice::<u32>(),
+            Vec::<u32>::new(),
+        );
+
+        assert_eq!(
+            SliceFn::slice(&delta, 1024, 1024)
+                .unwrap()
+                .into_primitive()
+                .unwrap()
+                .maybe_null_slice::<u32>(),
+            Vec::<u32>::new(),
+        );
+    }
+
+    #[test]
+    fn test_slice_jagged_array_second_chunk_of_two() {
+        let delta = DeltaArray::try_from_vec((0u32..2000).collect()).unwrap();
+
+        assert_eq!(
+            SliceFn::slice(&delta, 1024 + 10, 1024 + 250)
+                .unwrap()
+                .into_primitive()
+                .unwrap()
+                .maybe_null_slice::<u32>(),
+            ((1024 + 10u32)..(1024 + 250)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_slice_jagged_array_empty() {
+        let delta = DeltaArray::try_from_vec((0u32..4000).collect()).unwrap();
+
+        assert_eq!(
+            SliceFn::slice(&delta, 0, 0)
+                .unwrap()
+                .into_primitive()
+                .unwrap()
+                .maybe_null_slice::<u32>(),
+            Vec::<u32>::new(),
+        );
+
+        assert_eq!(
+            SliceFn::slice(&delta, 4096, 4096)
+                .unwrap()
+                .into_primitive()
+                .unwrap()
+                .maybe_null_slice::<u32>(),
+            Vec::<u32>::new(),
+        );
+
+        assert_eq!(
+            SliceFn::slice(&delta, 1024, 1024)
+                .unwrap()
+                .into_primitive()
+                .unwrap()
+                .maybe_null_slice::<u32>(),
+            Vec::<u32>::new(),
+        );
+    }
+
+    #[test]
+    fn test_slice_of_slice_of_non_jagged() {
+        let delta = DeltaArray::try_from_vec((0u32..2048).collect()).unwrap();
+
+        let sliced = SliceFn::slice(&delta, 10, 1013).unwrap();
+        let sliced_again = slice(sliced, 0, 2).unwrap();
+
+        assert_eq!(
+            sliced_again
+                .into_primitive()
+                .unwrap()
+                .maybe_null_slice::<u32>(),
+            vec![10, 11]
+        );
+    }
+
+    #[test]
+    fn test_slice_of_slice_of_jagged() {
+        let delta = DeltaArray::try_from_vec((0u32..2000).collect()).unwrap();
+
+        let sliced = SliceFn::slice(&delta, 10, 1013).unwrap();
+        let sliced_again = slice(sliced, 0, 2).unwrap();
+
+        assert_eq!(
+            sliced_again
+                .into_primitive()
+                .unwrap()
+                .maybe_null_slice::<u32>(),
+            vec![10, 11]
+        );
+    }
+
+    #[test]
+    fn test_slice_of_slice_second_chunk_of_non_jagged() {
+        let delta = DeltaArray::try_from_vec((0u32..2048).collect()).unwrap();
+
+        let sliced = SliceFn::slice(&delta, 1034, 1050).unwrap();
+        let sliced_again = slice(sliced, 0, 2).unwrap();
+
+        assert_eq!(
+            sliced_again
+                .into_primitive()
+                .unwrap()
+                .maybe_null_slice::<u32>(),
+            vec![1034, 1035]
+        );
+    }
+
+    #[test]
+    fn test_slice_of_slice_second_chunk_of_jagged() {
+        let delta = DeltaArray::try_from_vec((0u32..2000).collect()).unwrap();
+
+        let sliced = SliceFn::slice(&delta, 1034, 1050).unwrap();
+        let sliced_again = slice(sliced, 0, 2).unwrap();
+
+        assert_eq!(
+            sliced_again
+                .into_primitive()
+                .unwrap()
+                .maybe_null_slice::<u32>(),
+            vec![1034, 1035]
+        );
+    }
+
+    #[test]
+    fn test_slice_of_slice_spanning_two_chunks_of_non_jagged() {
+        let delta = DeltaArray::try_from_vec((0u32..2048).collect()).unwrap();
+
+        let sliced = SliceFn::slice(&delta, 1010, 1050).unwrap();
+        let sliced_again = slice(sliced, 5, 20).unwrap();
+
+        assert_eq!(
+            sliced_again
+                .into_primitive()
+                .unwrap()
+                .maybe_null_slice::<u32>(),
+            (1015..1030).collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn test_slice_of_slice_spanning_two_chunks_of_jagged() {
+        let delta = DeltaArray::try_from_vec((0u32..2000).collect()).unwrap();
+
+        let sliced = SliceFn::slice(&delta, 1010, 1050).unwrap();
+        let sliced_again = slice(sliced, 5, 20).unwrap();
+
+        assert_eq!(
+            sliced_again
+                .into_primitive()
+                .unwrap()
+                .maybe_null_slice::<u32>(),
+            (1015..1030).collect::<Vec<_>>(),
+        );
+    }
+}

--- a/encodings/fastlanes/src/delta/compute.rs
+++ b/encodings/fastlanes/src/delta/compute.rs
@@ -73,14 +73,6 @@ impl SliceFn for DeltaArray {
             limit,
         )?;
 
-        if arr.len() != stop - start {
-            vortex_bail!(
-                "slice produced wrong length: {} != {} - {}",
-                arr.len(),
-                stop,
-                start,
-            )
-        }
         Ok(arr.into_array())
     }
 }

--- a/encodings/fastlanes/src/delta/compute.rs
+++ b/encodings/fastlanes/src/delta/compute.rs
@@ -60,17 +60,14 @@ impl SliceFn for DeltaArray {
 
         let new_validity = validity.slice(start, stop)?;
 
-        let limit = match physical_stop % 1024 {
-            0 => 1024,
-            n => n,
-        };
+        let logical_len = stop - start;
 
         let arr = DeltaArray::try_new(
             new_bases,
             new_deltas,
             new_validity,
             physical_start % 1024,
-            limit,
+            logical_len,
         )?;
 
         Ok(arr.into_array())

--- a/encodings/fastlanes/src/delta/mod.rs
+++ b/encodings/fastlanes/src/delta/mod.rs
@@ -42,16 +42,16 @@ pub struct DeltaMetadata {
 ///
 /// # Details
 ///
-/// To facilitate slicing, this array has an [`offset`] and [`limit`]. Both values must be strictly
-/// less than 1,024. The offset is physical offset into the first chunk of deltas. The limit is a
+/// To facilitate slicing, this array has an `offset` and `limit`. Both values must be strictly less
+/// than 1,024. The `offset` is physical offset into the first chunk of deltas. The `limit` is a
 /// physical limit of the last chunk. These values permit logical slicing while preserving all
 /// values in any chunk containing a kept value. Logical slicing permits preservation of values
 /// necessary to decompress the delta-encoding, which is described in detail below. While later
 /// values in a chunk are not necsesary to decode earlier ones, a logical limit preserves full
 /// chunks which permits the decompression function go assume all chunks are exactly 1,024 values.
 ///
-/// A [`limit`] of `None` is a convenient alternative to computing the length of the last
-/// block. Internally, this array does not store the [`limit`]; instead it stores the number of
+/// A `limit` of `None` is a convenient alternative to computing the length of the last
+/// block. Internally, this array does not store the `limit`; instead it stores the number of
 /// trailing logically-excluded values: `trailing_garbage`.
 ///
 /// Each chunk is stored as a vector of bases and a vector of deltas. There are as many bases as there
@@ -188,13 +188,13 @@ impl DeltaArray {
     }
 
     #[inline]
-    /// The logical offset into the first chunk of [`deltas`].
+    /// The logical offset into the first chunk of [`Self::deltas`].
     pub fn offset(&self) -> usize {
         self.metadata().offset
     }
 
     #[inline]
-    /// The logical "right-offset" of the last chunk of [`deltas`].
+    /// The logical "right-offset" of the last chunk of [`Self::deltas`].
     pub fn trailing_garbage(&self) -> usize {
         self.metadata().trailing_garbage
     }

--- a/encodings/fastlanes/src/delta/mod.rs
+++ b/encodings/fastlanes/src/delta/mod.rs
@@ -40,14 +40,13 @@ pub struct DeltaMetadata {
 ///
 /// # Details
 ///
-/// To facilitate slicing, this array accepts an `offset` and `limit`. The offset must be strictly
-/// less than 1,024 and the limit must be less than or equal to 1,024. These values permit logical
-/// slicing while preserving all values in any chunk containing a kept value. Logical slicing allows
-/// deferment of decompresison until the array is canonicalized or indexed. The `offset` is a
-/// physical offset into the first chunk, which necessarily contains 1,024 values. The `limit` is
-/// likewise a physical limit of the last chunk after which values are not logically part of the
-/// array. If the last chunk has fewer than 1,024 values, then the limit must be less than the
-/// physical length of the last chunk.
+/// To facilitate slicing, this array accepts an `offset` and `logical_len`. The offset must be
+/// strictly less than 1,024 and the sum of `offset` and `logical_len` must not exceed the length of
+/// the `deltas` array. These values permit logical slicing without modifying any chunk containing a
+/// kept value. In particular, we may defer decompresison until the array is canonicalized or
+/// indexed. The `offset` is a physical offset into the first chunk, which necessarily contains
+/// 1,024 values. The `logical_len` is the number of logical values following the `offset`, which
+/// may be less than the number of physically stored values.
 ///
 /// Each chunk is stored as a vector of bases and a vector of deltas. If the chunk physically
 /// contains 1,024 vlaues, then there are as many bases as there are _lanes_ of this type in a

--- a/encodings/fastlanes/src/delta/mod.rs
+++ b/encodings/fastlanes/src/delta/mod.rs
@@ -179,14 +179,14 @@ impl DeltaArray {
 
     #[inline]
     fn lanes(&self) -> usize {
-        let ptype: PType = self.dtype().try_into().unwrap_or_else(|err| {
+        let ptype = self.dtype().try_into().unwrap_or_else(|err| {
             vortex_panic!(
                 err,
                 "Failed to convert DeltaArray DType {} to PType",
                 self.dtype()
             )
         });
-        match_each_unsigned_integer_ptype!(ptype.to_unsigned(), |$T| {
+        match_each_unsigned_integer_ptype!(ptype, |$T| {
             <$T as fastlanes::FastLanes>::LANES
         })
     }

--- a/encodings/fastlanes/src/delta/mod.rs
+++ b/encodings/fastlanes/src/delta/mod.rs
@@ -2,13 +2,16 @@ use std::fmt::Debug;
 
 pub use compress::*;
 use serde::{Deserialize, Serialize};
+use vortex::array::PrimitiveArray;
 use vortex::encoding::ids;
 use vortex::stats::{ArrayStatisticsCompute, StatsSet};
 use vortex::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use vortex::variants::{ArrayVariants, PrimitiveArrayTrait};
 use vortex::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use vortex::{impl_encoding, Array, ArrayDType, ArrayDef, ArrayTrait, Canonical, IntoCanonical};
-use vortex_dtype::match_each_unsigned_integer_ptype;
+use vortex::{
+    impl_encoding, Array, ArrayDType, ArrayDef, ArrayTrait, Canonical, IntoArray, IntoCanonical,
+};
+use vortex_dtype::{match_each_unsigned_integer_ptype, NativePType, PType};
 use vortex_error::{vortex_bail, vortex_panic, VortexExpect as _, VortexResult};
 
 mod compress;
@@ -19,11 +22,85 @@ impl_encoding!("fastlanes.delta", ids::FL_DELTA, Delta);
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeltaMetadata {
     validity: ValidityMetadata,
-    len: usize,
+    deltas_len: usize,
+    logical_len: usize,
+    offset: usize,           // must be <1024
+    trailing_garbage: usize, // must be <1024
 }
 
+/// A FastLanes-style delta-encoded array of primitive values.
+///
+/// A [`DeltaArray`] comprises a sequence of _chunks_ each representing 1,024 delta-encoded values,
+/// except the last chunk which may represent from one to 1,024 values.
+///
+/// # Examples
+///
+/// ```
+/// use vortex_fastlanes::DeltaArray;
+/// let array = DeltaArray::try_from_vec(vec![1_u32, 2, 3, 5, 10, 11]).unwrap();
+/// ```
+///
+/// # Details
+///
+/// To facilitate slicing, this array has an [`offset`] and [`limit`]. Both values must be strictly
+/// less than 1,024. The offset is physical offset into the first chunk of deltas. The limit is a
+/// physical limit of the last chunk. These values permit logical slicing while preserving all
+/// values in any chunk containing a kept value. Logical slicing permits preservation of values
+/// necessary to decompress the delta-encoding, which is described in detail below. While later
+/// values in a chunk are not necsesary to decode earlier ones, a logical limit preserves full
+/// chunks which permits the decompression function go assume all chunks are exactly 1,024 values.
+///
+/// A [`limit`] of `None` is a convenient alternative to computing the length of the last
+/// block. Internally, this array does not store the [`limit`]; instead it stores the number of
+/// trailing logically-excluded values: `trailing_garbage`.
+///
+/// Each chunk is stored as a vector of bases and a vector of deltas. There are as many bases as there
+/// are _lanes_ of this type in a 1024-bit register. For example, for 64-bit values, there are 16
+/// bases because there are 16 _lanes_. Each lane is a
+/// [delta-encoding](https://en.wikipedia.org/wiki/Delta_encoding) `1024 / bit_width` long vector of
+/// avlues. The deltas are stored in the
+/// [FastLanes](https://www.vldb.org/pvldb/vol16/p2132-afroozeh.pdf) order which splits the 1,024
+/// values into one contiguous sub-sequence per-lane, thus permitting delta encoding.
 impl DeltaArray {
-    pub fn try_new(bases: Array, deltas: Array, validity: Validity) -> VortexResult<Self> {
+    pub fn try_from_vec<T: NativePType>(vec: Vec<T>) -> VortexResult<Self> {
+        Self::try_from_primitive_array(&PrimitiveArray::from(vec))
+    }
+
+    pub fn try_from_primitive_array(array: &PrimitiveArray) -> VortexResult<Self> {
+        let (bases, deltas) = delta_compress(array)?;
+
+        Self::try_from_delta_compress_parts(
+            bases.into_array(),
+            deltas.into_array(),
+            Validity::NonNullable,
+        )
+    }
+
+    pub fn try_from_delta_compress_parts(
+        bases: Array,
+        deltas: Array,
+        validity: Validity,
+    ) -> VortexResult<Self> {
+        Self::try_new(bases, deltas, validity, 0, None)
+    }
+
+    pub fn try_new(
+        bases: Array,
+        deltas: Array,
+        validity: Validity,
+        offset: usize,
+        limit: Option<usize>,
+    ) -> VortexResult<Self> {
+        if offset >= 1024 {
+            vortex_bail!("offset must be less than 1024: {}", offset);
+        }
+
+        if let Some(l) = limit {
+            if l >= 1024 {
+                vortex_bail!("limit must be less than 1024: {}", l);
+            }
+        }
+
         if bases.dtype() != deltas.dtype() {
             vortex_bail!(
                 "DeltaArray: bases and deltas must have the same dtype, got {:?} and {:?}",
@@ -33,10 +110,18 @@ impl DeltaArray {
         }
 
         let dtype = bases.dtype().clone();
-        let len = deltas.len();
+        let trailing_garbage = match (limit, deltas.len() % 1024) {
+            (None, _) => 0,
+            (Some(l), 0) => 1024 - l,
+            (Some(l), remainder) => remainder - l,
+        };
+        let logical_len = deltas.len() - offset - trailing_garbage;
         let metadata = DeltaMetadata {
-            validity: validity.to_metadata(len)?,
-            len,
+            validity: validity.to_metadata(logical_len)?,
+            deltas_len: deltas.len(),
+            logical_len,
+            offset,
+            trailing_garbage,
         };
 
         let mut children = vec![bases, deltas];
@@ -44,14 +129,30 @@ impl DeltaArray {
             children.push(varray)
         }
 
-        let delta = Self::try_from_parts(dtype, len, metadata, children.into(), StatsSet::new())?;
+        let delta = Self::try_from_parts(
+            dtype,
+            logical_len,
+            metadata,
+            children.into(),
+            StatsSet::new(),
+        )?;
+
         if delta.bases().len() != delta.bases_len() {
             vortex_bail!(
                 "DeltaArray: bases.len() ({}) != expected_bases_len ({}), based on len ({}) and lane count ({})",
                 delta.bases().len(),
                 delta.bases_len(),
-                len,
+                logical_len,
                 delta.lanes()
+            );
+        }
+
+        if (delta.deltas_len() % 1024 == 0) != (delta.bases_len() % delta.lanes() == 0) {
+            vortex_bail!(
+                "deltas length ({}) is a multiple of 1024 iff bases length ({}) is a multiple of LANES ({})",
+                delta.deltas_len(),
+                delta.bases_len(),
+                delta.lanes(),
             );
         }
 
@@ -68,22 +169,34 @@ impl DeltaArray {
     #[inline]
     pub fn deltas(&self) -> Array {
         self.as_ref()
-            .child(1, self.dtype(), self.len())
+            .child(1, self.dtype(), self.metadata().deltas_len)
             .vortex_expect("DeltaArray is missing deltas child array")
     }
 
     #[inline]
     fn lanes(&self) -> usize {
-        let ptype = self.dtype().try_into().unwrap_or_else(|err| {
+        let ptype: PType = self.dtype().try_into().unwrap_or_else(|err| {
             vortex_panic!(
                 err,
                 "Failed to convert DeltaArray DType {} to PType",
                 self.dtype()
             )
         });
-        match_each_unsigned_integer_ptype!(ptype, |$T| {
+        match_each_unsigned_integer_ptype!(ptype.to_unsigned(), |$T| {
             <$T as fastlanes::FastLanes>::LANES
         })
+    }
+
+    #[inline]
+    /// The logical offset into the first chunk of [`deltas`].
+    pub fn offset(&self) -> usize {
+        self.metadata().offset
+    }
+
+    #[inline]
+    /// The logical "right-offset" of the last chunk of [`deltas`].
+    pub fn trailing_garbage(&self) -> usize {
+        self.metadata().trailing_garbage
     }
 
     pub fn validity(&self) -> Validity {
@@ -95,9 +208,13 @@ impl DeltaArray {
     }
 
     fn bases_len(&self) -> usize {
-        let num_chunks = self.len() / 1024;
-        let remainder_base_size = if self.len() % 1024 > 0 { 1 } else { 0 };
+        let num_chunks = self.deltas().len() / 1024;
+        let remainder_base_size = if self.deltas().len() % 1024 > 0 { 1 } else { 0 };
         num_chunks * self.lanes() + remainder_base_size
+    }
+
+    fn deltas_len(&self) -> usize {
+        self.metadata().deltas_len
     }
 }
 

--- a/encodings/fastlanes/src/delta/mod.rs
+++ b/encodings/fastlanes/src/delta/mod.rs
@@ -162,7 +162,7 @@ impl DeltaArray {
     #[inline]
     pub fn deltas(&self) -> Array {
         self.as_ref()
-            .child(1, self.dtype(), self.metadata().deltas_len)
+            .child(1, self.dtype(), self.deltas_len())
             .vortex_expect("DeltaArray is missing deltas child array")
     }
 

--- a/vortex-dtype/src/ptype.rs
+++ b/vortex-dtype/src/ptype.rs
@@ -165,21 +165,6 @@ macro_rules! match_each_unsigned_integer_ptype {
 }
 
 #[macro_export]
-macro_rules! match_each_signed_integer_ptype {
-    ($self:expr, | $_:tt $enc:ident | $($body:tt)*) => ({
-        macro_rules! __with__ {( $_ $enc:ident ) => ( $($body)* )}
-        use $crate::PType;
-        match $self {
-            PType::I8 => __with__! { i8 },
-            PType::I16 => __with__! { i16 },
-            PType::I32 => __with__! { i32 },
-            PType::I64 => __with__! { i64 },
-            _ => panic!("Unsupported ptype {}", $self),
-        }
-    })
-}
-
-#[macro_export]
 macro_rules! match_each_float_ptype {
     ($self:expr, | $_:tt $enc:ident | $($body:tt)*) => ({
         macro_rules! __with__ {( $_ $enc:ident ) => ( $($body)* )}

--- a/vortex-dtype/src/ptype.rs
+++ b/vortex-dtype/src/ptype.rs
@@ -165,6 +165,21 @@ macro_rules! match_each_unsigned_integer_ptype {
 }
 
 #[macro_export]
+macro_rules! match_each_signed_integer_ptype {
+    ($self:expr, | $_:tt $enc:ident | $($body:tt)*) => ({
+        macro_rules! __with__ {( $_ $enc:ident ) => ( $($body)* )}
+        use $crate::PType;
+        match $self {
+            PType::I8 => __with__! { i8 },
+            PType::I16 => __with__! { i16 },
+            PType::I32 => __with__! { i32 },
+            PType::I64 => __with__! { i64 },
+            _ => panic!("Unsupported ptype {}", $self),
+        }
+    })
+}
+
+#[macro_export]
 macro_rules! match_each_float_ptype {
     ($self:expr, | $_:tt $enc:ident | $($body:tt)*) => ({
         macro_rules! __with__ {( $_ $enc:ident ) => ( $($body)* )}

--- a/vortex-sampling-compressor/src/compressors/delta.rs
+++ b/vortex-sampling-compressor/src/compressors/delta.rs
@@ -50,7 +50,8 @@ impl EncodingCompressor for DeltaCompressor {
             .compress(deltas.as_ref(), like.as_ref().and_then(|l| l.child(1)))?;
 
         Ok(CompressedArray::new(
-            DeltaArray::try_new(bases.array, deltas.array, validity)?.into_array(),
+            DeltaArray::try_from_delta_compress_parts(bases.array, deltas.array, validity)?
+                .into_array(),
             Some(CompressionTree::new(self, vec![bases.path, deltas.path])),
         ))
     }


### PR DESCRIPTION
More subtle than I expected.

DeltaArray is a sequence of chunks. All chunks except the last must be "full", i.e. containing 1,024 values. The last chunk may contain as few as one value and is encoded differently from the rest.

In this PR, I introduced an "offset" and a "limit". Together they enable logical/lazy slicing while preserving full chunks for later decompression. The offset is a value, less than 1024, which offsets into the first chunk. The limit is either `None` or less than 1024. `None` represents no limit which allows callers to avoid computing the length of the last chunk [1]. Internally, the limit is converted to a "right-offset": `trailing_garbage` which is sliced away when decompression happens.

I also added support for signed values. I verify they're non-negative in `delta_compress`.

[1] Which is, a bit annoyingly, this:

```
match deltas.len() % 1024 {
    0 => 1024,
    n => n
}
```