### PR TITLE
fix: BitPackedArray must be unsigned

### DIFF
--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -348,7 +348,8 @@ mod test {
     fn null_patches() {
         let valid_values = (0..24).map(|v| v < 1 << 4).collect::<Vec<_>>();
         let values =
-            PrimitiveArray::from_vec((0..24).collect::<Vec<_>>(), Validity::from(valid_values));
+            PrimitiveArray::from_vec((0u32..24).collect::<Vec<_>>(), Validity::from(valid_values));
+        assert!(values.ptype().is_unsigned_int());
         let compressed = BitPackedArray::encode(values.as_ref(), 4).unwrap();
         assert!(compressed.patches().is_none());
         assert_eq!(

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -330,7 +330,6 @@ pub fn count_exceptions(bit_width: usize, bit_width_freq: &[usize]) -> usize {
 #[cfg(test)]
 mod test {
     use vortex::{IntoArrayVariant, ToArray};
-    use vortex_error::VortexError;
 
     use super::*;
 
@@ -398,12 +397,12 @@ mod test {
     }
 
     #[test]
+    #[should_panic(expected = "expected type: uint but instead got i64")]
     fn gh_issue_929() {
         let values: Vec<i64> = (-500..500).collect();
         let array = PrimitiveArray::from_vec(values, Validity::AllValid);
         assert!(array.ptype().is_signed_int());
 
-        let result = BitPackedArray::encode(array.as_ref(), 1024u32.ilog2() as usize);
-        assert!(matches!(result, Err(VortexError::MismatchedTypes(_, _, _))));
+        BitPackedArray::encode(array.as_ref(), 1024u32.ilog2() as usize).unwrap();
     }
 }

--- a/encodings/fastlanes/src/bitpacking/compute/search_sorted.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/search_sorted.rs
@@ -246,14 +246,14 @@ mod test {
     #[test]
     fn test_search_sorted_nulls() {
         let bitpacked = BitPackedArray::encode(
-            PrimitiveArray::from_nullable_vec(vec![Some(1i64), None, None]).as_ref(),
+            PrimitiveArray::from_nullable_vec(vec![Some(1u64), None, None]).as_ref(),
             2,
         )
         .unwrap();
 
         let found = bitpacked
             .search_sorted(
-                &Scalar::primitive(1i64, Nullability::Nullable),
+                &Scalar::primitive(1u64, Nullability::Nullable),
                 SearchSortedSide::Left,
             )
             .unwrap();
@@ -265,9 +265,9 @@ mod test {
         // Test search_sorted_many with an array that contains several null values.
         let bitpacked = BitPackedArray::encode(
             PrimitiveArray::from_nullable_vec(vec![
-                Some(1i64),
-                Some(2i64),
-                Some(3i64),
+                Some(1u64),
+                Some(2u64),
+                Some(3u64),
                 None,
                 None,
                 None,
@@ -280,7 +280,7 @@ mod test {
 
         let results = search_sorted_many(
             bitpacked.as_ref(),
-            &[3i64, 2i64, 1i64],
+            &[3u64, 2u64, 1u64],
             &[
                 SearchSortedSide::Left,
                 SearchSortedSide::Left,


### PR DESCRIPTION
fixes #929 