### PR TITLE
feat: slim down vortex-array metadata 

### DIFF
--- a/pyvortex/src/array.rs
+++ b/pyvortex/src/array.rs
@@ -204,7 +204,7 @@ impl PyArray {
     ///       metadata: PrimitiveMetadata { validity: Array }
     ///       buffer: 32 B
     ///       validity: vortex.bool(0x02)(bool, len=4) nbytes=1 B (3.03%)
-    ///         metadata: BoolMetadata { validity: NonNullable, length: 4, bit_offset: 0 }
+    ///         metadata: BoolMetadata { validity: NonNullable, bit_offset: 0 }
     ///         buffer: 1 B
     ///     <BLANKLINE>
     ///
@@ -217,7 +217,7 @@ impl PyArray {
     ///         metadata: BitPackedMetadata { validity: Array, bit_width: 2, offset: 0, length: 4, has_patches: false }
     ///         buffer: 256 B
     ///         validity: vortex.bool(0x02)(bool, len=4) nbytes=1 B (100.00%)
-    ///           metadata: BoolMetadata { validity: NonNullable, length: 4, bit_offset: 0 }
+    ///           metadata: BoolMetadata { validity: NonNullable, bit_offset: 0 }
     ///           buffer: 1 B
     ///     <BLANKLINE>
     ///

--- a/vortex-array/src/array/bool/mod.rs
+++ b/vortex-array/src/array/bool/mod.rs
@@ -22,7 +22,6 @@ impl_encoding!("vortex.bool", ids::BOOL, Bool);
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BoolMetadata {
     validity: ValidityMetadata,
-    length: usize,
     bit_offset: usize,
 }
 
@@ -65,7 +64,6 @@ impl BoolArray {
                 buffer_len,
                 BoolMetadata {
                     validity: validity.to_metadata(buffer_len)?,
-                    length: buffer_len,
                     bit_offset: last_byte_bit_offset,
                 },
                 Some(Buffer::from(inner)),

--- a/vortex-array/src/array/chunked/mod.rs
+++ b/vortex-array/src/array/chunked/mod.rs
@@ -30,7 +30,7 @@ impl_encoding!("vortex.chunked", ids::CHUNKED, Chunked);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ChunkedMetadata {
-    num_chunks: usize,
+    nchunks: usize,
 }
 
 impl ChunkedArray {
@@ -52,7 +52,7 @@ impl ChunkedArray {
             })
             .collect_vec();
 
-        let num_chunks = chunk_offsets.len() - 1;
+        let nchunks = chunk_offsets.len() - 1;
         let length = *chunk_offsets.last().unwrap_or_else(|| {
             unreachable!("Chunk ends is guaranteed to have at least one element")
         }) as usize;
@@ -64,7 +64,7 @@ impl ChunkedArray {
         Self::try_from_parts(
             dtype,
             length,
-            ChunkedMetadata { num_chunks },
+            ChunkedMetadata { nchunks },
             children.into(),
             StatsSet::new(),
         )
@@ -85,7 +85,7 @@ impl ChunkedArray {
     }
 
     pub fn nchunks(&self) -> usize {
-        self.metadata().num_chunks
+        self.metadata().nchunks
     }
 
     #[inline]

--- a/vortex-array/src/array/constant/canonical.rs
+++ b/vortex-array/src/array/constant/canonical.rs
@@ -1,13 +1,13 @@
 use std::iter;
 
-use vortex_dtype::{match_each_native_ptype, DType, Nullability, PType};
+use vortex_dtype::{match_each_native_ptype, DType, Nullability};
 use vortex_error::{vortex_bail, VortexResult};
-use vortex_scalar::{BinaryScalar, BoolScalar, Utf8Scalar};
+use vortex_scalar::ScalarValue;
 
 use crate::array::constant::ConstantArray;
 use crate::array::primitive::PrimitiveArray;
 use crate::array::varbin::VarBinArray;
-use crate::array::BoolArray;
+use crate::array::{BoolArray, NullArray};
 use crate::validity::Validity;
 use crate::{ArrayDType, Canonical, IntoCanonical};
 
@@ -15,48 +15,86 @@ impl IntoCanonical for ConstantArray {
     fn into_canonical(self) -> VortexResult<Canonical> {
         let validity = match self.dtype().nullability() {
             Nullability::NonNullable => Validity::NonNullable,
-            Nullability::Nullable => match self.scalar().is_null() {
+            Nullability::Nullable => match self.scalar_value().is_null() {
                 true => Validity::AllInvalid,
                 false => Validity::AllValid,
             },
         };
 
-        if let Ok(b) = BoolScalar::try_from(self.scalar()) {
-            return Ok(Canonical::Bool(BoolArray::from_vec(
-                vec![b.value().unwrap_or_default(); self.len()],
+        let dtype = self.dtype().clone();
+
+        match self.scalar_value() {
+            ScalarValue::Bool(b) => Ok(Canonical::Bool(BoolArray::from_vec(
+                vec![*b; self.len()],
                 validity,
-            )));
-        }
+            ))),
+            ScalarValue::Primitive(pvalue) => {
+                let ptype = if let DType::Primitive(ptype, _) = dtype {
+                    ptype
+                } else {
+                    vortex_bail!(
+                        "constant array with dtype {} but primitive value {}",
+                        dtype,
+                        pvalue
+                    );
+                };
 
-        if let Ok(s) = Utf8Scalar::try_from(self.scalar()) {
-            let value = s.value();
-            let const_value = value.as_ref().map(|v| v.as_bytes());
+                match_each_native_ptype!(ptype, |$P| {
+                    Ok(Canonical::Primitive(PrimitiveArray::from_vec::<$P>(
+                        vec![$P::try_from(*pvalue).unwrap_or_else(|_| $P::default()); self.len()],
+                        validity,
+                    )))
+                })
+            }
+            ScalarValue::Buffer(value) => {
+                let const_value = value.as_slice();
 
-            return Ok(Canonical::VarBin(VarBinArray::from_iter(
-                iter::repeat(const_value).take(self.len()),
-                DType::Utf8(validity.nullability()),
-            )));
-        }
-
-        if let Ok(b) = BinaryScalar::try_from(self.scalar()) {
-            let value = b.value();
-            let const_value = value.as_ref().map(|v| v.as_slice());
-
-            return Ok(Canonical::VarBin(VarBinArray::from_iter(
-                iter::repeat(const_value).take(self.len()),
-                DType::Binary(validity.nullability()),
-            )));
-        }
-
-        if let Ok(ptype) = PType::try_from(self.scalar().dtype()) {
-            return match_each_native_ptype!(ptype, |$P| {
-                Ok(Canonical::Primitive(PrimitiveArray::from_vec::<$P>(
-                    vec![$P::try_from(self.scalar()).unwrap_or_else(|_| $P::default()); self.len()],
-                    validity,
+                Ok(Canonical::VarBin(VarBinArray::from_iter_nonnull(
+                    iter::repeat(const_value).take(self.len()),
+                    dtype,
                 )))
-            });
-        }
+            }
+            ScalarValue::BufferString(value) => {
+                let const_value = value.as_bytes();
 
-        vortex_bail!("Unsupported scalar type {}", self.dtype())
+                Ok(Canonical::VarBin(VarBinArray::from_iter_nonnull(
+                    iter::repeat(const_value).take(self.len()),
+                    dtype,
+                )))
+            }
+            ScalarValue::List(_) => vortex_bail!("Unsupported scalar type {}", dtype),
+            ScalarValue::Null => {
+                if !dtype.is_nullable() {
+                    vortex_bail!("dtype is non-nullable but value is null: {}", dtype)
+                }
+
+                match dtype {
+                    DType::Null => Ok(Canonical::Null(NullArray::new(self.len()))),
+                    DType::Bool(_) => Ok(Canonical::Bool(BoolArray::from_vec(
+                        vec![true; self.len()],
+                        validity,
+                    ))),
+                    DType::Primitive(ptype, _) => {
+                        match_each_native_ptype!(ptype, |$P| {
+                            Ok(Canonical::Primitive(PrimitiveArray::from_vec::<$P>(
+                                vec![$P::default(); self.len()],
+                                validity,
+                            )))
+                        })
+                    }
+                    DType::Utf8(_) => Ok(Canonical::VarBin(VarBinArray::from_iter(
+                        iter::repeat::<Option<String>>(None).take(self.len()),
+                        dtype,
+                    ))),
+                    DType::Binary(_) => Ok(Canonical::VarBin(VarBinArray::from_iter(
+                        iter::repeat::<Option<Vec<u8>>>(None).take(self.len()),
+                        dtype,
+                    ))),
+                    DType::Struct(..) => vortex_bail!("Unsupported scalar type {}", dtype),
+                    DType::List(..) => vortex_bail!("Unsupported scalar type {}", dtype),
+                    DType::Extension(..) => vortex_bail!("Unsupported scalar type {}", dtype),
+                }
+            }
+        }
     }
 }

--- a/vortex-array/src/array/constant/canonical.rs
+++ b/vortex-array/src/array/constant/canonical.rs
@@ -1,100 +1,64 @@
 use std::iter;
 
-use vortex_dtype::{match_each_native_ptype, DType, Nullability};
+use vortex_dtype::{match_each_native_ptype, DType, Nullability, PType};
 use vortex_error::{vortex_bail, VortexResult};
-use vortex_scalar::ScalarValue;
+use vortex_scalar::{BinaryScalar, BoolScalar, Utf8Scalar};
 
 use crate::array::constant::ConstantArray;
 use crate::array::primitive::PrimitiveArray;
 use crate::array::varbin::VarBinArray;
-use crate::array::{BoolArray, NullArray};
+use crate::array::BoolArray;
 use crate::validity::Validity;
 use crate::{ArrayDType, Canonical, IntoCanonical};
 
 impl IntoCanonical for ConstantArray {
     fn into_canonical(self) -> VortexResult<Canonical> {
+        let scalar = self.owned_scalar();
+
         let validity = match self.dtype().nullability() {
             Nullability::NonNullable => Validity::NonNullable,
-            Nullability::Nullable => match self.scalar_value().is_null() {
+            Nullability::Nullable => match scalar.is_null() {
                 true => Validity::AllInvalid,
                 false => Validity::AllValid,
             },
         };
 
-        let dtype = self.dtype().clone();
-
-        match self.scalar_value() {
-            ScalarValue::Bool(b) => Ok(Canonical::Bool(BoolArray::from_vec(
-                vec![*b; self.len()],
+        if let Ok(b) = BoolScalar::try_from(scalar) {
+            return Ok(Canonical::Bool(BoolArray::from_vec(
+                vec![b.value().unwrap_or_default(); self.len()],
                 validity,
-            ))),
-            ScalarValue::Primitive(pvalue) => {
-                let ptype = if let DType::Primitive(ptype, _) = dtype {
-                    ptype
-                } else {
-                    vortex_bail!(
-                        "constant array with dtype {} but primitive value {}",
-                        dtype,
-                        pvalue
-                    );
-                };
-
-                match_each_native_ptype!(ptype, |$P| {
-                    Ok(Canonical::Primitive(PrimitiveArray::from_vec::<$P>(
-                        vec![$P::try_from(*pvalue).unwrap_or_else(|_| $P::default()); self.len()],
-                        validity,
-                    )))
-                })
-            }
-            ScalarValue::Buffer(value) => {
-                let const_value = value.as_slice();
-
-                Ok(Canonical::VarBin(VarBinArray::from_iter_nonnull(
-                    iter::repeat(const_value).take(self.len()),
-                    dtype,
-                )))
-            }
-            ScalarValue::BufferString(value) => {
-                let const_value = value.as_bytes();
-
-                Ok(Canonical::VarBin(VarBinArray::from_iter_nonnull(
-                    iter::repeat(const_value).take(self.len()),
-                    dtype,
-                )))
-            }
-            ScalarValue::List(_) => vortex_bail!("Unsupported scalar type {}", dtype),
-            ScalarValue::Null => {
-                if !dtype.is_nullable() {
-                    vortex_bail!("dtype is non-nullable but value is null: {}", dtype)
-                }
-
-                match dtype {
-                    DType::Null => Ok(Canonical::Null(NullArray::new(self.len()))),
-                    DType::Bool(_) => Ok(Canonical::Bool(BoolArray::from_vec(
-                        vec![true; self.len()],
-                        validity,
-                    ))),
-                    DType::Primitive(ptype, _) => {
-                        match_each_native_ptype!(ptype, |$P| {
-                            Ok(Canonical::Primitive(PrimitiveArray::from_vec::<$P>(
-                                vec![$P::default(); self.len()],
-                                validity,
-                            )))
-                        })
-                    }
-                    DType::Utf8(_) => Ok(Canonical::VarBin(VarBinArray::from_iter(
-                        iter::repeat::<Option<String>>(None).take(self.len()),
-                        dtype,
-                    ))),
-                    DType::Binary(_) => Ok(Canonical::VarBin(VarBinArray::from_iter(
-                        iter::repeat::<Option<Vec<u8>>>(None).take(self.len()),
-                        dtype,
-                    ))),
-                    DType::Struct(..) => vortex_bail!("Unsupported scalar type {}", dtype),
-                    DType::List(..) => vortex_bail!("Unsupported scalar type {}", dtype),
-                    DType::Extension(..) => vortex_bail!("Unsupported scalar type {}", dtype),
-                }
-            }
+            )));
         }
+
+        if let Ok(s) = Utf8Scalar::try_from(scalar) {
+            let value = s.value();
+            let const_value = value.as_ref().map(|v| v.as_bytes());
+
+            return Ok(Canonical::VarBin(VarBinArray::from_iter(
+                iter::repeat(const_value).take(self.len()),
+                DType::Utf8(validity.nullability()),
+            )));
+        }
+
+        if let Ok(b) = BinaryScalar::try_from(scalar) {
+            let value = b.value();
+            let const_value = value.as_ref().map(|v| v.as_slice());
+
+            return Ok(Canonical::VarBin(VarBinArray::from_iter(
+                iter::repeat(const_value).take(self.len()),
+                DType::Binary(validity.nullability()),
+            )));
+        }
+
+        if let Ok(ptype) = PType::try_from(scalar.dtype()) {
+            return match_each_native_ptype!(ptype, |$P| {
+                Ok(Canonical::Primitive(PrimitiveArray::from_vec::<$P>(
+                    vec![$P::try_from(scalar).unwrap_or_else(|_| $P::default()); self.len()],
+                    validity,
+                )))
+            });
+        }
+
+        vortex_bail!("Unsupported scalar type {}", self.dtype())
     }
 }

--- a/vortex-array/src/array/constant/canonical.rs
+++ b/vortex-array/src/array/constant/canonical.rs
@@ -13,7 +13,7 @@ use crate::{ArrayDType, Canonical, IntoCanonical};
 
 impl IntoCanonical for ConstantArray {
     fn into_canonical(self) -> VortexResult<Canonical> {
-        let scalar = self.owned_scalar();
+        let scalar = &self.owned_scalar();
 
         let validity = match self.dtype().nullability() {
             Nullability::NonNullable => Validity::NonNullable,

--- a/vortex-array/src/array/constant/stats.rs
+++ b/vortex-array/src/array/constant/stats.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use vortex_error::VortexResult;
-use vortex_scalar::BoolScalar;
+use vortex_scalar::ScalarValue;
 
 use crate::array::constant::ConstantArray;
 use crate::stats::{ArrayStatisticsCompute, Stat, StatsSet};
@@ -10,12 +10,8 @@ impl ArrayStatisticsCompute for ConstantArray {
     fn compute_statistics(&self, _stat: Stat) -> VortexResult<StatsSet> {
         let mut stats_map = HashMap::from([(Stat::IsConstant, true.into())]);
 
-        if let Ok(b) = BoolScalar::try_from(self.scalar()) {
-            let true_count = if b.value().unwrap_or_default() {
-                self.len() as u64
-            } else {
-                0
-            };
+        if let ScalarValue::Bool(b) = self.scalar_value() {
+            let true_count = if *b { self.len() as u64 } else { 0 };
 
             stats_map.insert(Stat::TrueCount, true_count.into());
         }

--- a/vortex-array/src/array/extension/compute.rs
+++ b/vortex-array/src/array/extension/compute.rs
@@ -38,8 +38,8 @@ impl ArrayCompute for ExtensionArray {
 impl MaybeCompareFn for ExtensionArray {
     fn maybe_compare(&self, other: &Array, operator: Operator) -> Option<VortexResult<Array>> {
         if let Ok(const_ext) = ConstantArray::try_from(other) {
-            let scalar_ext =
-                ExtScalar::try_from(const_ext.scalar()).vortex_expect("Expected ExtScalar");
+            let scalar_ext = ExtScalar::try_new(const_ext.dtype(), const_ext.scalar_value())
+                .vortex_expect("Expected ExtScalar");
             let const_storage = ConstantArray::new(
                 Scalar::new(self.storage().dtype().clone(), scalar_ext.value().clone()),
                 const_ext.len(),

--- a/vortex-array/src/array/null/mod.rs
+++ b/vortex-array/src/array/null/mod.rs
@@ -14,16 +14,14 @@ mod compute;
 impl_encoding!("vortex.null", ids::NULL, Null);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NullMetadata {
-    len: usize,
-}
+pub struct NullMetadata;
 
 impl NullArray {
     pub fn new(len: usize) -> Self {
         Self::try_from_parts(
             DType::Null,
             len,
-            NullMetadata { len },
+            NullMetadata,
             [].into(),
             StatsSet::nulls(len, &DType::Null),
         )

--- a/vortex-array/src/array/primitive/compute/compare.rs
+++ b/vortex-array/src/array/primitive/compute/compare.rs
@@ -7,7 +7,7 @@ use vortex_scalar::PrimitiveScalar;
 use crate::array::primitive::PrimitiveArray;
 use crate::array::{BoolArray, ConstantArray};
 use crate::compute::{MaybeCompareFn, Operator};
-use crate::{Array, IntoArray};
+use crate::{Array, ArrayDType, IntoArray};
 
 impl MaybeCompareFn for PrimitiveArray {
     fn maybe_compare(&self, other: &Array, operator: Operator) -> Option<VortexResult<Array>> {
@@ -41,8 +41,8 @@ fn primitive_const_compare(
     other: ConstantArray,
     operator: Operator,
 ) -> VortexResult<Array> {
-    let primitive_scalar =
-        PrimitiveScalar::try_from(other.scalar()).vortex_expect("Expected a primitive scalar");
+    let primitive_scalar = PrimitiveScalar::try_new(other.dtype(), other.scalar_value())
+        .vortex_expect("Expected a primitive scalar");
 
     let buffer = match_each_native_ptype!(this.ptype(), |$T| {
         let typed_value = primitive_scalar.typed_value::<$T>().unwrap();

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -1,5 +1,5 @@
 use ::serde::{Deserialize, Serialize};
-use vortex_dtype::{match_each_integer_ptype, DType, Nullability, PType};
+use vortex_dtype::{match_each_integer_ptype, DType, PType};
 use vortex_error::{vortex_bail, vortex_panic, VortexExpect as _, VortexResult};
 use vortex_scalar::Scalar;
 
@@ -75,7 +75,7 @@ impl SparseArray {
             values.dtype().clone(),
             len,
             SparseMetadata {
-                indices_ptype: *indices_ptype,
+                indices_ptype,
                 indices_offset,
                 indices_len: indices.len(),
                 fill_value,

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -44,15 +44,10 @@ impl SparseArray {
         indices_offset: usize,
         fill_value: Scalar,
     ) -> VortexResult<Self> {
-        let indices_dtype = indices.dtype();
-        let indices_ptype = if !matches!(indices_dtype, &DType::IDX) {
-            vortex_bail!("Cannot use {} as indices", indices_dtype);
-        } else {
-            match indices_dtype {
-                DType::Primitive(ptype, _) => ptype,
-                ptype => vortex_bail!("programmer error {}", ptype),
-            }
-        };
+        if !matches!(indices.dtype(), &DType::IDX) {
+            vortex_bail!("Cannot use {} as indices", indices.dtype());
+        }
+        let indices_ptype = PType::try_from(&DType::IDX)?;
         if values.dtype() != fill_value.dtype() {
             vortex_bail!(
                 "Mismatched fill value dtype {} and values dtype {}",
@@ -105,11 +100,7 @@ impl SparseArray {
     #[inline]
     pub fn indices(&self) -> Array {
         self.as_ref()
-            .child(
-                0,
-                &DType::Primitive(self.metadata().indices_ptype, Nullability::NonNullable),
-                self.metadata().indices_len,
-            )
+            .child(0, &DType::IDX, self.metadata().indices_len)
             .vortex_expect("Missing indices array in SparseArray")
     }
 

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -1,5 +1,5 @@
 use ::serde::{Deserialize, Serialize};
-use vortex_dtype::{match_each_integer_ptype, DType, PType};
+use vortex_dtype::{match_each_integer_ptype, DType};
 use vortex_error::{vortex_bail, vortex_panic, VortexExpect as _, VortexResult};
 use vortex_scalar::Scalar;
 
@@ -20,7 +20,6 @@ impl_encoding!("vortex.sparse", ids::SPARSE, Sparse);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SparseMetadata {
-    indices_ptype: PType,
     // Offset value for patch indices as a result of slicing
     indices_offset: usize,
     indices_len: usize,
@@ -47,7 +46,6 @@ impl SparseArray {
         if !matches!(indices.dtype(), &DType::IDX) {
             vortex_bail!("Cannot use {} as indices", indices.dtype());
         }
-        let indices_ptype = PType::try_from(&DType::IDX)?;
         if values.dtype() != fill_value.dtype() {
             vortex_bail!(
                 "Mismatched fill value dtype {} and values dtype {}",
@@ -75,7 +73,6 @@ impl SparseArray {
             values.dtype().clone(),
             len,
             SparseMetadata {
-                indices_ptype,
                 indices_offset,
                 indices_len: indices.len(),
                 fill_value,

--- a/vortex-array/src/array/struct_/mod.rs
+++ b/vortex-array/src/array/struct_/mod.rs
@@ -18,7 +18,6 @@ impl_encoding!("vortex.struct", ids::STRUCT, Struct);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StructMetadata {
-    length: usize,
     validity: ValidityMetadata,
 }
 
@@ -74,7 +73,6 @@ impl StructArray {
             DType::Struct(StructDType::new(names, field_dtypes), nullability),
             length,
             StructMetadata {
-                length,
                 validity: validity_metadata,
             },
             children.into(),

--- a/vortex-array/src/array/varbin/compute/compare.rs
+++ b/vortex-array/src/array/varbin/compute/compare.rs
@@ -28,7 +28,7 @@ fn compare_constant(
     operator: Operator,
 ) -> VortexResult<Array> {
     let arrow_lhs = lhs.clone().into_canonical()?.into_arrow()?;
-    let constant = Arc::<dyn Datum>::try_from(rhs.scalar())?;
+    let constant = Arc::<dyn Datum>::try_from(&rhs.owned_scalar())?;
 
     match arrow_lhs.data_type() {
         DataType::Binary => {

--- a/vortex-array/src/array/varbin/mod.rs
+++ b/vortex-array/src/array/varbin/mod.rs
@@ -4,7 +4,7 @@ use num_traits::AsPrimitive;
 use serde::{Deserialize, Serialize};
 pub use stats::compute_stats;
 use vortex_buffer::Buffer;
-use vortex_dtype::{match_each_native_ptype, DType, NativePType, Nullability};
+use vortex_dtype::{match_each_native_ptype, DType, NativePType, Nullability, PType};
 use vortex_error::{
     vortex_bail, vortex_err, vortex_panic, VortexError, VortexExpect as _, VortexResult,
     VortexUnwrap as _,
@@ -33,7 +33,7 @@ impl_encoding!("vortex.varbin", ids::VAR_BIN, VarBin);
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VarBinMetadata {
     validity: ValidityMetadata,
-    offsets_dtype: DType,
+    offsets_ptype: PType,
     bytes_len: usize,
 }
 
@@ -44,9 +44,22 @@ impl VarBinArray {
         dtype: DType,
         validity: Validity,
     ) -> VortexResult<Self> {
-        if !offsets.dtype().is_int() || offsets.dtype().is_nullable() {
-            vortex_bail!(MismatchedTypes: "non nullable int", offsets.dtype());
-        }
+        let offsets_ptype = match offsets.dtype() {
+            DType::Primitive(
+                ptype @ (PType::U8
+                | PType::U16
+                | PType::U32
+                | PType::U64
+                | PType::I8
+                | PType::I16
+                | PType::I32
+                | PType::I64),
+                Nullability::NonNullable,
+            ) => ptype,
+            _ => {
+                vortex_bail!(MismatchedTypes: "non nullable int", offsets.dtype())
+            }
+        };
         if !matches!(bytes.dtype(), &DType::BYTES) {
             vortex_bail!(MismatchedTypes: "u8", bytes.dtype());
         }
@@ -61,7 +74,7 @@ impl VarBinArray {
 
         let metadata = VarBinMetadata {
             validity: validity.to_metadata(offsets.len() - 1)?,
-            offsets_dtype: offsets.dtype().clone(),
+            offsets_ptype: *offsets_ptype,
             bytes_len: bytes.len(),
         };
 
@@ -78,7 +91,11 @@ impl VarBinArray {
     #[inline]
     pub fn offsets(&self) -> Array {
         self.as_ref()
-            .child(0, &self.metadata().offsets_dtype, self.len() + 1)
+            .child(
+                0,
+                &DType::Primitive(self.metadata().offsets_ptype, Nullability::NonNullable),
+                self.len() + 1,
+            )
             .vortex_expect("Missing offsets in VarBinArray")
     }
 
@@ -153,6 +170,18 @@ impl VarBinArray {
         let mut builder = VarBinBuilder::<u32>::with_capacity(iter.size_hint().0);
         for v in iter {
             builder.push(v.as_ref().map(|o| o.as_ref()));
+        }
+        builder.finish(dtype)
+    }
+
+    pub fn from_iter_nonnull<T: AsRef<[u8]>, I: IntoIterator<Item = T>>(
+        iter: I,
+        dtype: DType,
+    ) -> Self {
+        let iter = iter.into_iter();
+        let mut builder = VarBinBuilder::<u32>::with_capacity(iter.size_hint().0);
+        for v in iter {
+            builder.push_value(v);
         }
         builder.finish(dtype)
     }

--- a/vortex-array/src/array/varbin/mod.rs
+++ b/vortex-array/src/array/varbin/mod.rs
@@ -62,7 +62,7 @@ impl VarBinArray {
 
         let metadata = VarBinMetadata {
             validity: validity.to_metadata(offsets.len() - 1)?,
-            offsets_ptype: *offsets_ptype,
+            offsets_ptype,
             bytes_len: bytes.len(),
         };
 

--- a/vortex-array/src/array/varbin/mod.rs
+++ b/vortex-array/src/array/varbin/mod.rs
@@ -44,22 +44,10 @@ impl VarBinArray {
         dtype: DType,
         validity: Validity,
     ) -> VortexResult<Self> {
-        let offsets_ptype = match offsets.dtype() {
-            DType::Primitive(
-                ptype @ (PType::U8
-                | PType::U16
-                | PType::U32
-                | PType::U64
-                | PType::I8
-                | PType::I16
-                | PType::I32
-                | PType::I64),
-                Nullability::NonNullable,
-            ) => ptype,
-            _ => {
-                vortex_bail!(MismatchedTypes: "non nullable int", offsets.dtype())
-            }
-        };
+        if !offsets.dtype().is_int() || offsets.dtype().is_nullable() {
+            vortex_bail!(MismatchedTypes: "non nullable int", offsets.dtype());
+        }
+        let offsets_ptype = PType::try_from(offsets.dtype()).vortex_unwrap();
         if !matches!(bytes.dtype(), &DType::BYTES) {
             vortex_bail!(MismatchedTypes: "u8", bytes.dtype());
         }

--- a/vortex-scalar/src/extension.rs
+++ b/vortex-scalar/src/extension.rs
@@ -12,6 +12,14 @@ pub struct ExtScalar<'a> {
 }
 
 impl<'a> ExtScalar<'a> {
+    pub fn try_new(dtype: &'a DType, value: &'a ScalarValue) -> VortexResult<Self> {
+        if !matches!(dtype, DType::Extension(..)) {
+            vortex_bail!("Expected extension scalar, found {}", dtype)
+        }
+
+        Ok(Self { dtype, value })
+    }
+
     #[inline]
     pub fn dtype(&self) -> &'a DType {
         self.dtype
@@ -31,14 +39,7 @@ impl<'a> TryFrom<&'a Scalar> for ExtScalar<'a> {
     type Error = VortexError;
 
     fn try_from(value: &'a Scalar) -> Result<Self, Self::Error> {
-        if !matches!(value.dtype(), DType::Extension(..)) {
-            vortex_bail!("Expected extension scalar, found {}", value.dtype())
-        }
-
-        Ok(Self {
-            dtype: value.dtype(),
-            value: &value.value,
-        })
+        ExtScalar::try_new(value.dtype(), &value.value)
     }
 }
 

--- a/vortex-scalar/src/struct_.rs
+++ b/vortex-scalar/src/struct_.rs
@@ -13,6 +13,16 @@ pub struct StructScalar<'a> {
 }
 
 impl<'a> StructScalar<'a> {
+    pub fn try_new(dtype: &'a DType, value: &'a ScalarValue) -> VortexResult<Self> {
+        if !matches!(dtype, DType::Struct(..)) {
+            vortex_bail!("Expected struct scalar, found {}", dtype)
+        }
+        Ok(Self {
+            dtype,
+            fields: value.as_list()?.cloned(),
+        })
+    }
+
     #[inline]
     pub fn dtype(&self) -> &'a DType {
         self.dtype
@@ -127,12 +137,6 @@ impl<'a> TryFrom<&'a Scalar> for StructScalar<'a> {
     type Error = VortexError;
 
     fn try_from(value: &'a Scalar) -> Result<Self, Self::Error> {
-        if !matches!(value.dtype(), DType::Struct(..)) {
-            vortex_bail!("Expected struct scalar, found {}", value.dtype())
-        }
-        Ok(Self {
-            dtype: value.dtype(),
-            fields: value.value.as_list()?.cloned(),
-        })
+        Self::try_new(value.dtype(), &value.value)
     }
 }


### PR DESCRIPTION
1. Never store an array's own length in metadata.
   - In memory, it is stored in the `TypedArray`.
   - On disk/network, the top-level array length is in the flatbuffer `Batch`.
   - On disk/network, non-top-level array lengths are derivable from their parent's length and metadata.
2. DTypes can often be PType.
3. Scalar can often be ScalarValue (because the dtype is derivable by the Array's dtype).
