### PR TITLE
feat: cost of for is ~0

### DIFF
--- a/vortex-sampling-compressor/src/compressors/for.rs
+++ b/vortex-sampling-compressor/src/compressors/for.rs
@@ -20,6 +20,10 @@ impl EncodingCompressor for FoRCompressor {
         FoR::ID.as_ref()
     }
 
+    fn cost(&self) -> u8 {
+        0
+    }
+
     fn can_compress(&self, array: &Array) -> Option<&dyn EncodingCompressor> {
         // Only support primitive arrays
         let parray = PrimitiveArray::try_from(array).ok()?;


### PR DESCRIPTION
We fairly often perform FoR and then do not perform bitpacking because we have exceeded the depth. FoR is very cheap and only worthwhile in combination with bitpacking anyway, so setting its cost to zero should improve compression ratio with a minor decrease in compresssion speed.

I've been poking around trying to make the compressor reliably faster and along the way I noticed that this noticeably improves compression ratio with a minor impact on compression speed.