### PR TITLE
feat: add BENCH_VORTEX_RATIOS variable to filter ratio benchmarks

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           cargo install cargo-criterion
 
-          cargo criterion --bench ${{ matrix.benchmark.id }} --message-format=json 2>&1 | tee out.json
+          BENCH_VORTEX_RATIOS='.*' cargo criterion --bench ${{ matrix.benchmark.id }} --message-format=json 2>&1 | tee out.json
 
           cat out.json
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           cargo install cargo-criterion
 
-          cargo criterion --bench ${{ matrix.benchmark.id }} --message-format=json 2>&1 | tee out.json
+          BENCH_VORTEX_RATIOS='.*' cargo criterion --bench ${{ matrix.benchmark.id }} --message-format=json 2>&1 | tee out.json
 
           cat out.json
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,7 @@ dependencies = [
  "prettytable-rs",
  "rand",
  "rayon",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
@@ -3276,9 +3277,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3288,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3305,9 +3306,9 @@ checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relative-path"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ pyo3 = { version = "0.22.2", features = ["extension-module", "abi3-py311"] }
 pyo3-log = "0.11.0"
 rand = "0.8.5"
 rayon = "1.10.0"
+regex = "1.11.0"
 reqwest = { version = "0.12.0", features = ["blocking"] }
 rstest = "0.23"
 seq-macro = "0.3.5"

--- a/bench-vortex/Cargo.toml
+++ b/bench-vortex/Cargo.toml
@@ -46,6 +46,7 @@ parquet = { workspace = true, features = [] }
 prettytable-rs = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
+regex = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Ratio benchmarks are not supported by criterion. Instead, back in #882, I added some code to generate ratios and print them in the format expected by our GitHub Action. Unfortunately, this code currently runs unconditionally which is annoying when you are filtering benchmarks.

Now you can do this:

```
BENCH_VORTEX_RATIOS=AirlineSentiment cargo bench --bench compress_noci -- AirlineSentiment
```

And you'll receive both ratios and compression time benchmarks for AirlineSentiment and no output for other datasets.

But when you do this:

```
cargo bench --bench compress_noci -- AirlineSentiment
```

You only get compression time benchmarks for AirlineSentiment.