### PR TITLE
fix: BitWidthFreq must be u64/usize

### DIFF
--- a/vortex-array/src/stats/statsset.rs
+++ b/vortex-array/src/stats/statsset.rs
@@ -49,7 +49,7 @@ impl StatsSet {
                 ptype.byte_width();
                 stats.insert(
                     Stat::BitWidthFreq,
-                    vec![0; ptype.byte_width() * 8 + 1].into(),
+                    vec![0_u64; ptype.byte_width() * 8 + 1].into(),
                 );
                 stats.insert(
                     Stat::TrailingZeroFreq,


### PR DESCRIPTION
We assume elsewhere that this statistic is a u64 (usize is auto-converted to u64 when we convert to Scalar). I am not entirely sure how I triggered this, but it happens on PR #969.