### PR TITLE
Use foldhash in dict encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4416,7 +4416,6 @@ dependencies = [
 name = "vortex-dict"
 version = "0.12.0"
 dependencies = [
- "ahash",
  "criterion",
  "hashbrown 0.15.0",
  "log",

--- a/encodings/dict/Cargo.toml
+++ b/encodings/dict/Cargo.toml
@@ -14,7 +14,6 @@ categories = { workspace = true }
 readme = { workspace = true }
 
 [dependencies]
-ahash = { workspace = true }
 hashbrown = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }

--- a/encodings/dict/src/compress.rs
+++ b/encodings/dict/src/compress.rs
@@ -1,8 +1,7 @@
-use std::hash::{Hash, Hasher};
+use std::hash::{BuildHasher, Hash, Hasher};
 
-use ahash::RandomState;
 use hashbrown::hash_map::{Entry, RawEntryMut};
-use hashbrown::HashMap;
+use hashbrown::{DefaultHashBuilder, HashMap};
 use num_traits::AsPrimitive;
 use vortex::accessor::ArrayAccessor;
 use vortex::array::{PrimitiveArray, VarBinArray};
@@ -106,7 +105,7 @@ where
     U: AsRef<[u8]>,
 {
     let (lower, _) = values.size_hint();
-    let hasher = RandomState::new();
+    let hasher = DefaultHashBuilder::default();
     let mut lookup_dict: HashMap<u64, (), ()> = HashMap::with_hasher(());
     let mut codes: Vec<u64> = Vec::with_capacity(lower);
     let mut bytes: Vec<u8> = Vec::new();


### PR DESCRIPTION
This PR has two benefits:
1. Nice performance gains (on my laptop)
![Screenshot 2024-10-04 at 22 38 42](https://github.com/user-attachments/assets/5f620786-969b-42ca-86cc-4f15fce36e0f)
2. The hashbrown folks seem to be on top of the hashing game, and this PR pulls the hasher directly from it.
