### PR TITLE
feat: reduce compress time with smarter use and calculation of stats

### DIFF
--- a/vortex-sampling-compressor/src/compressors/dict.rs
+++ b/vortex-sampling-compressor/src/compressors/dict.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 
 use vortex::array::{Primitive, PrimitiveArray, VarBin, VarBinArray};
 use vortex::encoding::EncodingRef;
-use vortex::stats::ArrayStatistics;
 use vortex::{Array, ArrayDef, IntoArray};
 use vortex_dict::{dict_encode_primitive, dict_encode_varbin, Dict, DictArray, DictEncoding};
 use vortex_error::VortexResult;
@@ -23,16 +22,6 @@ impl EncodingCompressor for DictCompressor {
         if array.encoding().id() != Primitive::ID && array.encoding().id() != VarBin::ID {
             return None;
         };
-
-        // No point dictionary coding if the array is unique.
-        // We don't have a unique stat yet, but strict-sorted implies unique.
-        if array
-            .statistics()
-            .compute_is_strict_sorted()
-            .unwrap_or(false)
-        {
-            return None;
-        }
 
         Some(self)
     }


### PR DESCRIPTION
1. In VarBinArray (the most expensive kind of array on which to compute states due to copies for min/max), implement a short-circuiting is_constant algorithm.

2. In DictCompressor, let the sampling compressor learn that an array is all unique values by observing poor compression ratios.