### PR TITLE
feat: better error message when an array encoding id is unknown

### DIFF
--- a/vortex-array/src/view.rs
+++ b/vortex-array/src/view.rs
@@ -55,9 +55,16 @@ impl ArrayView {
         let array = flatbuffer_init(flatbuffer.as_ref())?;
         let flatbuffer_loc = array._tab.loc();
 
-        let encoding = ctx
-            .lookup_encoding(array.encoding())
-            .ok_or_else(|| vortex_err!(InvalidSerde: "Encoding ID out of bounds"))?;
+        let encoding = ctx.lookup_encoding(array.encoding()).ok_or_else(
+            || {
+                let pretty_known_encodings = ctx.encodings().map(|e| format!("- {}", e.id()))
+                    .collect::<Vec<String>>()
+                    .join("\n");
+                vortex_err!(InvalidSerde: "Unknown encoding with ID {:#02x}. Known encodings:\n{}", array.encoding(),
+                    pretty_known_encodings
+                )
+            },
+        )?;
 
         let view = Self {
             encoding,


### PR DESCRIPTION
I seem to run into this error a lot and I never have enough information to fix it. I can't think of a case where you wouldn't immediately wonder what are your known encodings.

Previously (in Python):
```
ValueError: Encoding ID out of bounds
```

This PR:

```
ValueError: Unknown encoding with ID 0x11. Known encodings:
- vortex.constant(0x09)
- vortex.sparse(0x08)
- vortex.ext(0x07)
- vortex.primitive(0x03)
- vortex.struct(0x04)
- vortex.chunked(0x0a)
- vortex.bool(0x02)
- vortex.varbinview(0x06)
- vortex.varbin(0x05)
```