### PR TITLE
feat: dict array slices values when slice is <=20%

### DIFF
--- a/encodings/dict/src/compute.rs
+++ b/encodings/dict/src/compute.rs
@@ -49,7 +49,12 @@ impl TakeFn for DictArray {
 impl SliceFn for DictArray {
     // TODO(robert): Add function to trim the dictionary
     fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
-        Self::try_new(slice(self.codes(), start, stop)?, self.values()).map(|a| a.into_array())
+        let new_codes = slice(self.codes(), start, stop)?;
+        if (stop - start) * 5 < self.values_len() {
+            take(self.values(), &new_codes)
+        } else {
+            Self::try_new(new_codes, self.values()).map(|a| a.into_array())
+        }
     }
 }
 

--- a/encodings/dict/src/dict.rs
+++ b/encodings/dict/src/dict.rs
@@ -49,9 +49,14 @@ impl DictArray {
     }
 
     #[inline]
+    pub fn values_len(&self) -> usize {
+        self.metadata().values_len
+    }
+
+    #[inline]
     pub fn values(&self) -> Array {
         self.as_ref()
-            .child(0, self.dtype(), self.metadata().values_len)
+            .child(0, self.dtype(), self.values_len())
             .vortex_expect("DictArray is missing its values child array")
     }
 


### PR DESCRIPTION
I noticed this when comparing Vortex to Parquet. We write files with fairly large dictionaries (~2M values). When reading, we refuse to read more than 64Ki values so we slice the dict array. This produces ~30 dict arrays sliced into the same dictionary. When we canonicalize these arrays (to send to Arrow) we `take` from this giant dictionary 30 times instead of once. In this case, the dictionaries are usually ALP-BitPacked floats which takes a meaningful amount of time to decode.

This is how I observed the expensive read. The timings here are from this PR. On develop, the wall time for Vortex read is around 3.6s.
```
In [1]: import pyarrow as pa
   ...: import pyarrow.parquet as pq
   ...: import vortex
   ...: import pandas as pd

In [2]: %%time
   ...: df2 = pd.read_parquet('bench-vortex/data/PBI/CMSprovider/parquet/CMSprovider_1.parquet')
CPU times: user 3.62 s, sys: 535 ms, total: 4.16 s
Wall time: 1.33 s

In [3]: vtx = vortex.array(pa.Table.from_pandas(df2))
   ...: compressed = vortex.encoding.compress(vtx)
   ...: vortex.io.write(compressed, 'bench-vortex/data/PBI/CMSprovider/vortex/CMSprovider_1.vortex')

In [4]: %%time
   ...: tmp = vortex.io.read('bench-vortex/data/PBI/CMSprovider/vortex/CMSprovider_1.vortex')
CPU times: user 1.7 s, sys: 105 ms, total: 1.8 s
Wall time: 1.83 s

```