### PR TITLE
feat: marginally faster From<Vec<T>> for Scalar

### DIFF
--- a/vortex-sampling-compressor/src/lib.rs
+++ b/vortex-sampling-compressor/src/lib.rs
@@ -361,6 +361,7 @@ fn find_best_compression<'a>(
 ) -> VortexResult<CompressedArray<'a>> {
     let mut best = None;
     let mut best_ratio = 1.0;
+
     for compression in candidates {
         debug!(
             "{} trying candidate {} for {}",

--- a/vortex-scalar/Cargo.toml
+++ b/vortex-scalar/Cargo.toml
@@ -19,7 +19,7 @@ arrow-array = { workspace = true }
 datafusion-common = { workspace = true, optional = true }
 flatbuffers = { workspace = true, optional = true }
 flexbuffers = { workspace = true, optional = true }
-half = { workspace = true, optional = true }
+half = { workspace = true }
 itertools = { workspace = true }
 jiff = { workspace = true }
 num-traits = { workspace = true }
@@ -55,7 +55,6 @@ flatbuffers = [
 proto = [
     "dep:prost",
     "dep:prost-types",
-    "dep:half",
     "vortex-dtype/proto",
     "vortex-proto/scalar",
 ]


### PR DESCRIPTION
When constructing stats, we convert into Scalars, which I suspect is unnecessary (given the element dtype, we should know the dtypes of all the stats). Nevertheless, as long as we are constructing Scalars, we should do it quickly!

At the cost of more macros and generated code, this reduced Bimbo compression runtime by 500ms (of 18s, so ~3%).