### PR TITLE
feat: introduce ScalarType, the trait for scalar-y Rust types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4620,6 +4620,7 @@ version = "0.12.0"
 dependencies = [
  "arbitrary",
  "arrow-array",
+ "bytes",
  "datafusion-common",
  "flatbuffers",
  "flexbuffers",

--- a/vortex-scalar/Cargo.toml
+++ b/vortex-scalar/Cargo.toml
@@ -19,7 +19,7 @@ arrow-array = { workspace = true }
 datafusion-common = { workspace = true, optional = true }
 flatbuffers = { workspace = true, optional = true }
 flexbuffers = { workspace = true, optional = true }
-half = { workspace = true, optional = true }
+half = { workspace = true }
 itertools = { workspace = true }
 jiff = { workspace = true }
 num-traits = { workspace = true }
@@ -55,7 +55,6 @@ flatbuffers = [
 proto = [
     "dep:prost",
     "dep:prost-types",
-    "dep:half",
     "vortex-dtype/proto",
     "vortex-proto/scalar",
 ]

--- a/vortex-scalar/Cargo.toml
+++ b/vortex-scalar/Cargo.toml
@@ -16,6 +16,7 @@ readme = { workspace = true }
 [dependencies]
 arbitrary = { workspace = true, optional = true }
 arrow-array = { workspace = true }
+bytes = { workspace = true }
 datafusion-common = { workspace = true, optional = true }
 flatbuffers = { workspace = true, optional = true }
 flexbuffers = { workspace = true, optional = true }

--- a/vortex-scalar/src/binary.rs
+++ b/vortex-scalar/src/binary.rs
@@ -57,3 +57,14 @@ impl<'a> TryFrom<&'a Scalar> for Buffer {
             .ok_or_else(|| vortex_err!("Can't extract present value from null scalar"))
     }
 }
+
+impl<'a> TryFrom<&'a Scalar> for bytes::Bytes {
+    type Error = VortexError;
+
+    fn try_from(value: &'a Scalar) -> VortexResult<Self> {
+        match Buffer::try_from(value)? {
+            Buffer::Arrow(b) => Ok(bytes::Bytes::from(b.as_slice().to_vec())),
+            Buffer::Bytes(b) => Ok(b),
+        }
+    }
+}

--- a/vortex-scalar/src/binary.rs
+++ b/vortex-scalar/src/binary.rs
@@ -57,14 +57,3 @@ impl<'a> TryFrom<&'a Scalar> for Buffer {
             .ok_or_else(|| vortex_err!("Can't extract present value from null scalar"))
     }
 }
-
-impl<'a> TryFrom<&'a Scalar> for bytes::Bytes {
-    type Error = VortexError;
-
-    fn try_from(value: &'a Scalar) -> VortexResult<Self> {
-        match Buffer::try_from(value)? {
-            Buffer::Arrow(b) => Ok(bytes::Bytes::from(b.as_slice().to_vec())),
-            Buffer::Bytes(b) => Ok(b),
-        }
-    }
-}

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 
+use scalar_type::ScalarType;
 use vortex_dtype::DType;
 
 #[cfg(feature = "arbitrary")]
@@ -13,6 +14,7 @@ mod extension;
 mod list;
 mod primitive;
 mod pvalue;
+mod scalar_type;
 #[cfg(feature = "serde")]
 mod serde;
 mod struct_;
@@ -117,5 +119,29 @@ impl PartialOrd for Scalar {
 impl AsRef<Self> for Scalar {
     fn as_ref(&self) -> &Self {
         self
+    }
+}
+
+impl<T> From<T> for Scalar
+where
+    T: ScalarType,
+    ScalarValue: From<T>,
+{
+    fn from(value: T) -> Self {
+        Scalar::new(T::dtype(), ScalarValue::from(value))
+    }
+}
+
+impl<T> From<Option<T>> for Scalar
+where
+    T: ScalarType,
+    ScalarValue: From<T>,
+    ScalarValue: From<Option<T>>,
+{
+    fn from(value: Option<T>) -> Self {
+        Scalar {
+            dtype: T::dtype().as_nullable(),
+            value: value.into(),
+        }
     }
 }

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -135,7 +135,6 @@ where
 impl<T> From<Option<T>> for Scalar
 where
     T: ScalarType,
-    ScalarValue: From<T>,
     ScalarValue: From<Option<T>>,
 {
     fn from(value: Option<T>) -> Self {

--- a/vortex-scalar/src/list.rs
+++ b/vortex-scalar/src/list.rs
@@ -1,9 +1,8 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
-use half::f16;
+use vortex_dtype::DType;
 use vortex_dtype::Nullability::NonNullable;
-use vortex_dtype::{DType, NativePType, PType};
 use vortex_error::{vortex_bail, VortexError, VortexResult};
 
 use crate::value::ScalarValue;
@@ -101,45 +100,5 @@ impl<'a, T: for<'b> TryFrom<&'b Scalar, Error = VortexError>> TryFrom<&'a Scalar
             elems.push(T::try_from(&e)?);
         }
         Ok(elems)
-    }
-}
-
-macro_rules! from_native_ptype_for_scalar {
-    ($T:ty) => {
-        impl From<Vec<$T>> for Scalar {
-            fn from(value: Vec<$T>) -> Self {
-                Self {
-                    dtype: DType::List(
-                        DType::Primitive(<$T>::PTYPE, NonNullable).into(),
-                        NonNullable,
-                    ),
-                    value: ScalarValue::List(value.into_iter().map(ScalarValue::from).collect()),
-                }
-            }
-        }
-    };
-}
-
-from_native_ptype_for_scalar!(u8);
-from_native_ptype_for_scalar!(u16);
-from_native_ptype_for_scalar!(u32);
-from_native_ptype_for_scalar!(u64);
-from_native_ptype_for_scalar!(i8);
-from_native_ptype_for_scalar!(i16);
-from_native_ptype_for_scalar!(i32);
-from_native_ptype_for_scalar!(i64);
-from_native_ptype_for_scalar!(f16);
-from_native_ptype_for_scalar!(f32);
-from_native_ptype_for_scalar!(f64);
-
-impl From<Vec<usize>> for Scalar {
-    fn from(value: Vec<usize>) -> Self {
-        Self {
-            dtype: DType::List(
-                DType::Primitive(PType::U64, NonNullable).into(),
-                NonNullable,
-            ),
-            value: ScalarValue::List(value.into_iter().map(ScalarValue::from).collect()),
-        }
     }
 }

--- a/vortex-scalar/src/primitive.rs
+++ b/vortex-scalar/src/primitive.rs
@@ -129,24 +129,6 @@ impl Scalar {
 
 macro_rules! primitive_scalar {
     ($T:ty) => {
-        impl From<$T> for Scalar {
-            fn from(value: $T) -> Self {
-                Scalar {
-                    dtype: DType::Primitive(<$T>::PTYPE, Nullability::NonNullable),
-                    value: value.into(),
-                }
-            }
-        }
-
-        impl From<Option<$T>> for Scalar {
-            fn from(value: Option<$T>) -> Self {
-                Scalar {
-                    dtype: DType::Primitive(<$T>::PTYPE, Nullability::Nullable),
-                    value: value.into(),
-                }
-            }
-        }
-
         impl TryFrom<&Scalar> for $T {
             type Error = VortexError;
 
@@ -168,14 +150,6 @@ macro_rules! primitive_scalar {
         impl From<$T> for ScalarValue {
             fn from(value: $T) -> Self {
                 ScalarValue::Primitive(value.into())
-            }
-        }
-
-        impl From<Option<$T>> for ScalarValue {
-            fn from(value: Option<$T>) -> Self {
-                value
-                    .map(|v| ScalarValue::Primitive(v.into()))
-                    .unwrap_or_else(|| ScalarValue::Null)
             }
         }
 
@@ -212,24 +186,12 @@ primitive_scalar!(f16);
 primitive_scalar!(f32);
 primitive_scalar!(f64);
 
-impl From<usize> for Scalar {
-    fn from(value: usize) -> Self {
-        Self::from(value as u64)
-    }
-}
-
 /// Read a scalar as usize. For usize only, we implicitly cast for better ergonomics.
 impl TryFrom<&Scalar> for usize {
     type Error = VortexError;
 
     fn try_from(value: &Scalar) -> Result<Self, Self::Error> {
         value.value().try_into()
-    }
-}
-
-impl From<usize> for ScalarValue {
-    fn from(value: usize) -> Self {
-        ScalarValue::Primitive(PValue::U64(value as u64))
     }
 }
 

--- a/vortex-scalar/src/pvalue.rs
+++ b/vortex-scalar/src/pvalue.rs
@@ -183,6 +183,7 @@ int_pvalue!(u8, U8);
 int_pvalue!(u16, U16);
 int_pvalue!(u32, U32);
 int_pvalue!(u64, U64);
+int_pvalue!(usize, U64);
 int_pvalue!(i8, I8);
 int_pvalue!(i16, I16);
 int_pvalue!(i32, I32);
@@ -237,6 +238,24 @@ macro_rules! impl_pvalue {
     };
 }
 
+impl_pvalue!(u8, U8);
+impl_pvalue!(u16, U16);
+impl_pvalue!(u32, U32);
+impl_pvalue!(u64, U64);
+impl_pvalue!(i8, I8);
+impl_pvalue!(i16, I16);
+impl_pvalue!(i32, I32);
+impl_pvalue!(i64, I64);
+impl_pvalue!(f16, F16);
+impl_pvalue!(f32, F32);
+impl_pvalue!(f64, F64);
+
+impl From<usize> for PValue {
+    fn from(value: usize) -> PValue {
+        PValue::U64(value as u64)
+    }
+}
+
 impl Display for PValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -254,18 +273,6 @@ impl Display for PValue {
         }
     }
 }
-
-impl_pvalue!(u8, U8);
-impl_pvalue!(u16, U16);
-impl_pvalue!(u32, U32);
-impl_pvalue!(u64, U64);
-impl_pvalue!(i8, I8);
-impl_pvalue!(i16, I16);
-impl_pvalue!(i32, I32);
-impl_pvalue!(i64, I64);
-impl_pvalue!(f16, F16);
-impl_pvalue!(f32, F32);
-impl_pvalue!(f64, F64);
 
 #[cfg(test)]
 mod test {

--- a/vortex-scalar/src/scalar_type.rs
+++ b/vortex-scalar/src/scalar_type.rs
@@ -1,0 +1,92 @@
+use std::sync::Arc;
+
+use half::f16;
+use vortex_buffer::{Buffer, BufferString};
+use vortex_dtype::{DType, NativePType, Nullability, PType};
+
+pub trait ScalarType {
+    fn dtype() -> DType;
+}
+
+macro_rules! scalar_type_for_vec {
+    ($T:ty) => {
+        impl ScalarType for Vec<$T> {
+            fn dtype() -> DType {
+                DType::List(Arc::new(<$T>::dtype()), Nullability::NonNullable)
+            }
+        }
+    };
+}
+
+macro_rules! scalar_type_for_native_ptype {
+    ($T:ty,without_vec) => {
+        impl ScalarType for $T {
+            fn dtype() -> DType {
+                DType::Primitive(<$T>::PTYPE, Nullability::NonNullable)
+            }
+        }
+    };
+    ($T:ty,with_vec) => {
+        scalar_type_for_native_ptype!($T, without_vec);
+        scalar_type_for_vec!($T);
+    };
+}
+
+scalar_type_for_native_ptype!(u8, without_vec); // Vec<u8> could be either Binary or List(U8)
+scalar_type_for_native_ptype!(u16, with_vec);
+scalar_type_for_native_ptype!(u32, with_vec);
+scalar_type_for_native_ptype!(u64, with_vec);
+scalar_type_for_native_ptype!(i8, with_vec);
+scalar_type_for_native_ptype!(i16, with_vec);
+scalar_type_for_native_ptype!(i32, with_vec);
+scalar_type_for_native_ptype!(i64, with_vec);
+scalar_type_for_native_ptype!(f32, with_vec);
+scalar_type_for_native_ptype!(f64, with_vec);
+
+impl ScalarType for f16 {
+    fn dtype() -> DType {
+        DType::Primitive(PType::F16, Nullability::NonNullable)
+    }
+}
+
+scalar_type_for_vec!(f16);
+
+impl ScalarType for usize {
+    fn dtype() -> DType {
+        DType::Primitive(PType::U64, Nullability::NonNullable)
+    }
+}
+
+scalar_type_for_vec!(usize);
+
+impl ScalarType for String {
+    fn dtype() -> DType {
+        DType::Utf8(Nullability::NonNullable)
+    }
+}
+
+scalar_type_for_vec!(String);
+
+impl ScalarType for BufferString {
+    fn dtype() -> DType {
+        DType::Utf8(Nullability::NonNullable)
+    }
+}
+
+scalar_type_for_vec!(BufferString);
+
+impl ScalarType for bytes::Bytes {
+    fn dtype() -> DType {
+        DType::Binary(Nullability::NonNullable)
+    }
+}
+
+scalar_type_for_vec!(bytes::Bytes);
+
+impl ScalarType for Buffer {
+    fn dtype() -> DType {
+        DType::Binary(Nullability::NonNullable)
+    }
+}
+
+scalar_type_for_vec!(Buffer);

--- a/vortex-scalar/src/utf8.rs
+++ b/vortex-scalar/src/utf8.rs
@@ -72,6 +72,14 @@ impl<'a> TryFrom<&'a Scalar> for BufferString {
     }
 }
 
+impl<'a> TryFrom<&'a Scalar> for String {
+    type Error = VortexError;
+
+    fn try_from(value: &'a Scalar) -> Result<Self, Self::Error> {
+        Ok(BufferString::try_from(value)?.to_string())
+    }
+}
+
 impl From<&str> for Scalar {
     fn from(value: &str) -> Self {
         Self {


### PR DESCRIPTION
I think now a type which is convertible to a Scalar should only implement:

1. `ScalarType` (defining its associated `DType`).
2. `From<T> for ScalarValue`.
3. `TryFrom<ScalarValue>`.
4. `TryFrom<Scalar>` (this is just 3 but additionally verifying the type).

In particular, converting from `Option<T>` and `Vec<T>`  or converting any of those three to `Scalar` should be handled by the infrastructure of `vortex-scalar`.