### PR TITLE
feat: concise benchmark names

### DIFF
--- a/bench-vortex/benches/compress_noci.rs
+++ b/bench-vortex/benches/compress_noci.rs
@@ -18,7 +18,6 @@ use regex::Regex;
 use vortex::array::{ChunkedArray, StructArray};
 use vortex::{Array, ArrayDType, IntoArray, IntoCanonical};
 use vortex_dtype::field::Field;
-use vortex_error::vortex_bail;
 use vortex_sampling_compressor::compressors::fsst::FSSTCompressor;
 use vortex_sampling_compressor::SamplingCompressor;
 use vortex_serde::layouts::LayoutWriter;


### PR DESCRIPTION
Currently the Taxi and l_comment datasets are their own Criterion "group" which causes them to be plotted separately. With this PR, there is one plot for "compress time" which is measured in seconds and has every dataset.

I also eliminated the comparison to uncompressed Parquet because (except for a tiny 1024 byte dataset) we always beat uncompressed Parquet. Parquet with ZSTD is a sufficient comparison.

Finally, I removed some characters from several benchmark names in hopes that the Markdown tables on GitHub are more legible.