### PR TITLE
feat: teach VarBinArray to only compute IsConstant when requested

### DIFF
--- a/vortex-sampling-compressor/src/compressors/dict.rs
+++ b/vortex-sampling-compressor/src/compressors/dict.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 
 use vortex::array::{Primitive, PrimitiveArray, VarBin, VarBinArray};
 use vortex::encoding::EncodingRef;
-use vortex::stats::ArrayStatistics;
 use vortex::{Array, ArrayDef, IntoArray};
 use vortex_dict::{dict_encode_primitive, dict_encode_varbin, Dict, DictArray, DictEncoding};
 use vortex_error::VortexResult;
@@ -23,16 +22,6 @@ impl EncodingCompressor for DictCompressor {
         if array.encoding().id() != Primitive::ID && array.encoding().id() != VarBin::ID {
             return None;
         };
-
-        // No point dictionary coding if the array is unique.
-        // We don't have a unique stat yet, but strict-sorted implies unique.
-        if array
-            .statistics()
-            .compute_is_strict_sorted()
-            .unwrap_or(false)
-        {
-            return None;
-        }
 
         Some(self)
     }


### PR DESCRIPTION
I also remove the is_strict_sorted check because it provides litle value and is rather expensive, particularly now that we need not compute all statistics to know if a VarBinArray is constant.