### PR TITLE
feat: faster Dict logical validity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4421,6 +4421,7 @@ dependencies = [
 name = "vortex-dict"
 version = "0.12.0"
 dependencies = [
+ "arrow-buffer",
  "criterion",
  "hashbrown 0.15.0",
  "log",

--- a/encodings/dict/Cargo.toml
+++ b/encodings/dict/Cargo.toml
@@ -14,6 +14,7 @@ categories = { workspace = true }
 readme = { workspace = true }
 
 [dependencies]
+arrow-buffer = { workspace = true }
 hashbrown = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }

--- a/encodings/dict/src/dict.rs
+++ b/encodings/dict/src/dict.rs
@@ -1,12 +1,13 @@
 use std::fmt::{Debug, Display};
 
+use arrow_buffer::BooleanBuffer;
 use serde::{Deserialize, Serialize};
 use vortex::array::BoolArray;
 use vortex::compute::take;
 use vortex::compute::unary::scalar_at;
 use vortex::encoding::ids;
 use vortex::stats::StatsSet;
-use vortex::validity::{ArrayValidity, LogicalValidity, Validity};
+use vortex::validity::{ArrayValidity, LogicalValidity};
 use vortex::visitor::{AcceptArrayVisitor, ArrayVisitor};
 use vortex::{
     impl_encoding, Array, ArrayDType, ArrayTrait, Canonical, IntoArray, IntoArrayVariant,
@@ -92,10 +93,10 @@ impl ArrayValidity for DictArray {
                 let is_valid = primitive_codes
                     .maybe_null_slice::<$P>()
                     .iter()
-                    .map(|c| * c != 0)
-                    .collect::<Vec<bool>>();
-                let bool_array = BoolArray::from(is_valid);
-                LogicalValidity::Array(bool_array.into_array())
+                    .copied()
+                    .map(|c| c != 0)
+                    .collect::<BooleanBuffer>();
+                LogicalValidity::Array(BoolArray::from(is_valid).into_array())
             })
         } else {
             LogicalValidity::AllValid(self.len())

--- a/encodings/dict/src/dict.rs
+++ b/encodings/dict/src/dict.rs
@@ -91,12 +91,11 @@ impl ArrayValidity for DictArray {
                 .vortex_expect("Failed to convert DictArray codes to primitive array");
             match_each_integer_ptype!(primitive_codes.ptype(), |$P| {
                 let is_valid = primitive_codes
-                    .maybe_null_slice::<$P>()
-                    .iter()
-                    .copied()
-                    .map(|c| c != 0)
-                    .collect::<BooleanBuffer>();
-                LogicalValidity::Array(BoolArray::from(is_valid).into_array())
+                    .maybe_null_slice::<$P>();
+                let is_valid_buffer = BooleanBuffer::collect_bool(is_valid.len(), |idx| {
+                    *is_valid[idx] != 0
+                })
+                LogicalValidity::Array(BoolArray::from(is_valid_buffer).into_array())
             })
         } else {
             LogicalValidity::AllValid(self.len())

--- a/encodings/dict/src/dict.rs
+++ b/encodings/dict/src/dict.rs
@@ -93,8 +93,8 @@ impl ArrayValidity for DictArray {
                 let is_valid = primitive_codes
                     .maybe_null_slice::<$P>();
                 let is_valid_buffer = BooleanBuffer::collect_bool(is_valid.len(), |idx| {
-                    *is_valid[idx] != 0
-                })
+                    is_valid[idx] != 0
+                });
                 LogicalValidity::Array(BoolArray::from(is_valid_buffer).into_array())
             })
         } else {


### PR DESCRIPTION
The codes are known to be non-null because we encode null as code `0`. It seems that rustc (reasonably) cannot fully eliminate the overhead of creating a `Some` for each element of the array.