### PR TITLE
feat: ~copy~ convert from Vortex to Pandas without copies

### DIFF
--- a/pyvortex/python/vortex/encoding.py
+++ b/pyvortex/python/vortex/encoding.py
@@ -1,5 +1,5 @@
-import pyarrow
 import pandas
+import pyarrow
 
 from ._lib import encoding as _encoding
 

--- a/pyvortex/python/vortex/encoding.py
+++ b/pyvortex/python/vortex/encoding.py
@@ -38,11 +38,11 @@ def _Array_to_pandas(self: _encoding.Array):
     ...     {'name': 'Mikhail', 'age': 57},
     ... ])
     >>> array.to_pandas()
-                                     x
-    0    {'age': 25, 'name': 'Joseph'}
-    1  {'age': 31, 'name': 'Narendra'}
-    2    {'age': 33, 'name': 'Angela'}
-    3   {'age': 57, 'name': 'Mikhail'}
+       age      name
+    0   25    Joseph
+    1   31  Narendra
+    2   33    Angela
+    3   57   Mikhail
 
     Lift the struct fields to the top-level in the dataframe:
 

--- a/pyvortex/python/vortex/encoding.py
+++ b/pyvortex/python/vortex/encoding.py
@@ -1,4 +1,5 @@
 import pyarrow
+import pandas
 
 from ._lib import encoding as _encoding
 
@@ -8,19 +9,18 @@ Array = _encoding.Array
 compress = _encoding.compress
 
 
-def _Array_to_pandas(self: _encoding.Array, *, name: str | None = None, flatten: bool = False):
+def _Array_to_pandas(self: _encoding.Array):
     """Construct a Pandas dataframe from this Vortex array.
+
+    Warning
+    -------
+
+    Only struct-typed arrays can be converted to Pandas dataframes.
 
     Parameters
     ----------
     obj : :class:`pyarrow.Array` or :class:`list`
         The elements of this array or list become the elements of the Vortex array.
-
-    name : :class:`str`, optional
-        The name of the column in the newly created dataframe. If unspecified, use `x`.
-
-    flatten : :class:`bool`
-        If :obj:`True`, Struct columns are flattened in the dataframe. See the examples.
 
     Returns
     -------
@@ -29,28 +29,7 @@ def _Array_to_pandas(self: _encoding.Array, *, name: str | None = None, flatten:
     Examples
     --------
 
-    Construct a :class:`.pandas.DataFrame` with one column named `animals` from the contents of a Vortex
-    array:
-
-    >>> array = vortex.encoding.array(['dog', 'cat', 'mouse', 'rat'])
-    >>> array.to_pandas(name='animals')
-      animals
-    0     dog
-    1     cat
-    2   mouse
-    3     rat
-
-    Construct a :class:`.pandas.DataFrame` with the default column name:
-
-    >>> array = vortex.encoding.array(['dog', 'cat', 'mouse', 'rat'])
-    >>> array.to_pandas()
-           x
-    0    dog
-    1    cat
-    2  mouse
-    3    rat
-
-    Construct a dataframe with a Struct-typed column:
+    Construct a dataframe from a Vortex array:
 
     >>> array = vortex.encoding.array([
     ...     {'name': 'Joseph', 'age': 25},
@@ -67,19 +46,18 @@ def _Array_to_pandas(self: _encoding.Array, *, name: str | None = None, flatten:
 
     Lift the struct fields to the top-level in the dataframe:
 
-    >>> array.to_pandas(flatten=True)
-       x.age    x.name
-    0     25    Joseph
-    1     31  Narendra
-    2     33    Angela
-    3     57   Mikhail
-
     """
-    name = name or "x"
-    table = pyarrow.Table.from_arrays([self.to_arrow()], [name])
-    if flatten:
-        table = table.flatten()
-    return table.to_pandas()
+    return table_from_struct_array(self.to_arrow()).to_pandas(types_mapper=pandas.ArrowDtype)
+
+
+def empty_table(schema: pyarrow.Schema) -> pyarrow.Table:
+    return pyarrow.Table.from_arrays([[] for _ in schema], schema=schema)
+
+
+def table_from_struct_array(array: pyarrow.StructArray | pyarrow.ChunkedArray):
+    if len(array) == 0:
+        return empty_table(pyarrow.schema(array.type))
+    return pyarrow.Table.from_struct_array(array)
 
 
 Array.to_pandas = _Array_to_pandas

--- a/pyvortex/python/vortex/encoding.py
+++ b/pyvortex/python/vortex/encoding.py
@@ -17,11 +17,6 @@ def _Array_to_pandas(self: _encoding.Array):
 
     Only struct-typed arrays can be converted to Pandas dataframes.
 
-    Parameters
-    ----------
-    obj : :class:`pyarrow.Array` or :class:`list`
-        The elements of this array or list become the elements of the Vortex array.
-
     Returns
     -------
     :class:`pandas.DataFrame`


### PR DESCRIPTION
`pyarrow.Table.from_struct_array` handles transposing the chunks such that each columns chunks are in one list. `pandas.ArrowDtype` forces the use of the [ArrowExtensionArray](https://pandas.pydata.org/docs/reference/api/pandas.arrays.ArrowExtensionArray.html) which need not be contiguous nor use the NumPy representation and is thus much faster.