### PR TITLE
feat: enable link-time optimization for release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,9 +202,9 @@ use_debug = "deny"
 
 [profile.release]
 codegen-units = 1
-lto = "fat" # attempts to perform optimizations across all crates within the dependency graph
+lto = true # attempts to perform optimizations across all crates within the dependency graph
 
 [profile.bench]
-inherits = "release"
-lto = "thin" # takes less time to run than "fat" while still achieving similar performance gains
+codegen-units = 16 # default for "release", which "bench" inherits
+lto = false # default
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,3 +199,14 @@ tests_outside_test_module = "deny"
 unwrap_in_result = "deny"
 unwrap_used = "deny"
 use_debug = "deny"
+
+[profile.release]
+codegen-units = 1
+lto = "fat" # attempts to perform optimizations across all crates within the dependency graph
+
+[profile.bench]
+lto = "thin" # takes substantially less time to run than "fat" while still achieving similar performance gains
+
+[profile.profiling]
+inherits = "bench"
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,6 +205,7 @@ codegen-units = 1
 lto = "fat" # attempts to perform optimizations across all crates within the dependency graph
 
 [profile.bench]
+inherits = "release"
 lto = "thin" # takes substantially less time to run than "fat" while still achieving similar performance gains
 
 [profile.profiling]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,8 +206,5 @@ lto = "fat" # attempts to perform optimizations across all crates within the dep
 
 [profile.bench]
 inherits = "release"
-lto = "thin" # takes substantially less time to run than "fat" while still achieving similar performance gains
-
-[profile.profiling]
-inherits = "bench"
+lto = "thin" # takes less time to run than "fat" while still achieving similar performance gains
 debug = true


### PR DESCRIPTION
The `release` profile shows a 10-20% improvement across many benchmarks (run locally) but definitely takes a bit longer to build (because "fat" lto is pretty slow). 

For reference on profiles (and for the source of the comments on different lto modes), see: https://doc.rust-lang.org/cargo/reference/profiles.html#lto