### PR TITLE
fix: StructArray::from_fields([]) is an error

### DIFF
--- a/vortex-array/src/array/struct_/mod.rs
+++ b/vortex-array/src/array/struct_/mod.rs
@@ -92,7 +92,10 @@ impl StructArray {
             .map(|(name, _)| FieldName::from(name.as_ref()))
             .collect();
         let fields: Vec<Array> = items.iter().map(|(_, array)| array.clone()).collect();
-        let len = fields.first().map(|f| f.len()).unwrap_or(0);
+        let len = fields
+            .first()
+            .map(|f| f.len())
+            .vortex_expect("StructArray cannot be constructed from an empty slice of arrays because the length is unspecified");
 
         Self::try_new(FieldNames::from(names), fields, len, Validity::NonNullable)
             .vortex_expect("Unexpected error while building StructArray from fields")


### PR DESCRIPTION
The length is unspecified and we should not assume it is zero.