### PR TITLE
Bring back setting of PYO3 python path

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -40,6 +40,13 @@ runs:
         path: .venv
         key: "venv-${{ runner.os }}-${{ runner.environment }}-${{ hashFiles('requirements**.lock') }}"
 
+    - name: Export PYO3 Path
+      shell: bash
+      # Figure out a way to dynamically get python version
+      run: |
+        echo "PYO3_PYTHON=/home/runner/work/vortex/vortex/.venv/bin/python" >> $GITHUB_ENV
+        echo "PYO3_ENVIRONMENT_SIGNATURE=cpython-3.11-64bit" >> $GITHUB_ENV
+
     - name: Rye Sync
       shell: bash
       # --no-lock prevents resolution of the lock file. The locks are still respected.
@@ -48,7 +55,6 @@ runs:
       env:
         MATURIN_PEP517_USE_BASE_PYTHON: "true"
         MATURIN_PEP517_ARGS: "--profile dev"
-        PYO3_ENVIRONMENT_SIGNATURE: cpython-3.11-64bit
 
     - name: Export Path
       shell: bash


### PR DESCRIPTION
Setting maturin to follow existing python path doesn't resolve the whole caching
issue. What happens is that pyO3 build scripts get run to discover python path
and include the python path as a out ouf dateness check when they finish running
and discover the python path the environment is out of date. We have to give the
python path to maturin from the start
