### PR TITLE
fix: disable roaring compressors

### DIFF
--- a/vortex-sampling-compressor/src/lib.rs
+++ b/vortex-sampling-compressor/src/lib.rs
@@ -33,8 +33,6 @@ use crate::compressors::constant::ConstantCompressor;
 use crate::compressors::date_time_parts::DateTimePartsCompressor;
 use crate::compressors::dict::DictCompressor;
 use crate::compressors::r#for::FoRCompressor;
-use crate::compressors::roaring_bool::RoaringBoolCompressor;
-use crate::compressors::roaring_int::RoaringIntCompressor;
 use crate::compressors::runend::DEFAULT_RUN_END_COMPRESSOR;
 use crate::compressors::sparse::SparseCompressor;
 use crate::compressors::zigzag::ZigZagCompressor;
@@ -48,7 +46,7 @@ mod constants;
 mod sampling;
 
 lazy_static! {
-    pub static ref DEFAULT_COMPRESSORS: [CompressorRef<'static>; 11] = [
+    pub static ref DEFAULT_COMPRESSORS: [CompressorRef<'static>; 9] = [
         &ALPCompressor as CompressorRef,
         &BITPACK_WITH_PATCHES,
         &DateTimePartsCompressor,
@@ -57,8 +55,8 @@ lazy_static! {
         &DictCompressor,
         &FoRCompressor,
         &FSSTCompressor,
-        &RoaringBoolCompressor,
-        &RoaringIntCompressor,
+        // &RoaringBoolCompressor,
+        // &RoaringIntCompressor,
         &SparseCompressor,
         &ZigZagCompressor,
     ];


### PR DESCRIPTION
Until the roaring compressors can deserialize quickly (i.e. without copies, see #1075), we disable them to improve the decompression throughput of Vortex.