### PR TITLE
feat: teach pyvortex Array to_polars (& some cleanup)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,7 @@ intersphinx_mapping = {
     "pyarrow": ("https://arrow.apache.org/docs/", None),
     "pandas": ("https://pandas.pydata.org/docs/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
+    "polars": ("https://docs.pola.rs/api/python/stable/", None),
 }
 
 nitpicky = True  # ensures all :class:, :obj:, etc. links are valid

--- a/pyvortex/pyproject.toml
+++ b/pyvortex/pyproject.toml
@@ -9,6 +9,17 @@ dependencies = [
 ]
 requires-python = ">= 3.11"
 
+[project.optional-dependencies]
+polars = [
+    "polars>=1.9.0",
+]
+pandas = [
+    "pandas>=2.2.0",
+]
+numpy = [
+    "numpy>=1.26.0",
+]
+
 [project.urls]
 Documentation = "https://spiraldb.github.io/vortex/docs/"
 Changelog = "https://github.com/spiraldb/vortex/blob/develop/CHANGELOG.md"
@@ -25,6 +36,7 @@ dev-dependencies = [
     "ipython>=8.26.0",
     "pandas>=2.2.2",
     "pip",
+    "pyright>=1.1.385",
 ]
 
 [tool.maturin]

--- a/pyvortex/python/vortex/encoding.py
+++ b/pyvortex/python/vortex/encoding.py
@@ -29,7 +29,7 @@ def _Array_to_arrow_table(self: _encoding.Array) -> pyarrow.Table:
     """Construct an Arrow table from this Vortex array.
 
     .. seealso::
-        :meth:`.to_arrow`
+        :meth:`.to_arrow_array`
 
     Warning
     -------
@@ -59,7 +59,7 @@ def _Array_to_arrow_table(self: _encoding.Array) -> pyarrow.Table:
     name: [["Joseph","Narendra","Angela","Mikhail"]]
 
     """
-    return arrow_table_from_struct_array(self.to_arrow())
+    return arrow_table_from_struct_array(self.to_arrow_array())
 
 
 Array.to_arrow_table = _Array_to_arrow_table
@@ -218,7 +218,7 @@ def _Array_to_polars_series(self: _encoding.Array):  # -> 'polars.Series':  # br
     """
     import polars
 
-    return polars.from_arrow(self.to_arrow())
+    return polars.from_arrow(self.to_arrow_array())
 
 
 Array.to_polars_series = _Array_to_polars_series
@@ -227,7 +227,7 @@ Array.to_polars_series = _Array_to_polars_series
 def _Array_to_numpy(self: _encoding.Array, *, zero_copy_only: bool = True) -> "numpy.ndarray":
     """Construct a NumPy array from this Vortex array.
 
-    This is an alias for :code:`self.to_arrow().to_numpy(zero_copy_only)`
+    This is an alias for :code:`self.to_arrow_array().to_numpy(zero_copy_only)`
 
     Returns
     -------
@@ -243,7 +243,7 @@ def _Array_to_numpy(self: _encoding.Array, *, zero_copy_only: bool = True) -> "n
     array([1, 0, 0, 1])
 
     """
-    return self.to_arrow().to_numpy(zero_copy_only=zero_copy_only)
+    return self.to_arrow_array().to_numpy(zero_copy_only=zero_copy_only)
 
 
 Array.to_numpy = _Array_to_numpy
@@ -268,7 +268,7 @@ def array(obj: pyarrow.Array | list) -> Array:
 
     A Vortex array containing the first three integers.
 
-    >>> vortex.encoding.array([1, 2, 3]).to_arrow()
+    >>> vortex.encoding.array([1, 2, 3]).to_arrow_array()
     <pyarrow.lib.Int64Array object at ...>
     [
       1,
@@ -278,7 +278,7 @@ def array(obj: pyarrow.Array | list) -> Array:
 
     The same Vortex array with a null value in the third position.
 
-    >>> vortex.encoding.array([1, 2, None, 3]).to_arrow()
+    >>> vortex.encoding.array([1, 2, None, 3]).to_arrow_array()
     <pyarrow.lib.Int64Array object at ...>
     [
       1,
@@ -290,7 +290,7 @@ def array(obj: pyarrow.Array | list) -> Array:
     Initialize a Vortex array from an Arrow array:
 
     >>> arrow = pyarrow.array(['Hello', 'it', 'is', 'me'])
-    >>> vortex.encoding.array(arrow).to_arrow()
+    >>> vortex.encoding.array(arrow).to_arrow_array()
     <pyarrow.lib.StringArray object at ...>
     [
       "Hello",

--- a/pyvortex/python/vortex/encoding.py
+++ b/pyvortex/python/vortex/encoding.py
@@ -1,12 +1,13 @@
 from typing import TYPE_CHECKING
+
 import pandas
 import pyarrow
 
 from ._lib import encoding as _encoding
 
 if TYPE_CHECKING:
-    import pandas
     import numpy
+    import pandas
 
 __doc__ = _encoding.__doc__
 
@@ -64,7 +65,7 @@ def _Array_to_arrow_table(self: _encoding.Array) -> pyarrow.Table:
 Array.to_arrow_table = _Array_to_arrow_table
 
 
-def _Array_to_pandas(self: _encoding.Array) -> 'pandas.DataFrame':
+def _Array_to_pandas(self: _encoding.Array) -> "pandas.DataFrame":
     """Construct a Pandas dataframe from this Vortex array.
 
     Warning
@@ -103,7 +104,9 @@ def _Array_to_pandas(self: _encoding.Array) -> 'pandas.DataFrame':
 Array.to_pandas = _Array_to_pandas
 
 
-def _Array_to_polars_dataframe(self: _encoding.Array): # -> 'polars.DataFrame':  # breaks docs due to Polars issue #7027
+def _Array_to_polars_dataframe(
+    self: _encoding.Array,
+):  # -> 'polars.DataFrame':  # breaks docs due to Polars issue #7027
     """Construct a Polars dataframe from this Vortex array.
 
     .. seealso::
@@ -153,7 +156,7 @@ def _Array_to_polars_dataframe(self: _encoding.Array): # -> 'polars.DataFrame': 
 Array.to_polars_dataframe = _Array_to_polars_dataframe
 
 
-def _Array_to_polars_series(self: _encoding.Array): # -> 'polars.Series':  # breaks docs due to Polars issue #7027
+def _Array_to_polars_series(self: _encoding.Array):  # -> 'polars.Series':  # breaks docs due to Polars issue #7027
     """Construct a Polars series from this Vortex array.
 
     .. seealso::
@@ -176,10 +179,10 @@ def _Array_to_polars_series(self: _encoding.Array): # -> 'polars.Series':  # bre
     shape: (4,)
     Series: '' [i64]
     [
-    	1
-    	null
-    	2
-    	3
+        1
+        null
+        2
+        3
     ]
 
     Convert a UTF-8 string array to a Polars Series:
@@ -188,10 +191,10 @@ def _Array_to_polars_series(self: _encoding.Array): # -> 'polars.Series':  # bre
     shape: (4,)
     Series: '' [str]
     [
-    	"hello, "
-    	"is"
-    	"it"
-    	"me?"
+        "hello, "
+        "is"
+        "it"
+        "me?"
     ]
 
     Convert a struct array to a Polars Series:
@@ -206,10 +209,10 @@ def _Array_to_polars_series(self: _encoding.Array): # -> 'polars.Series':  # bre
     shape: (4,)
     Series: '' [struct[2]]
     [
-    	{25,"Joseph"}
-    	{31,"Narendra"}
-    	{33,"Angela"}
-    	{57,"Mikhail"}
+        {25,"Joseph"}
+        {31,"Narendra"}
+        {33,"Angela"}
+        {57,"Mikhail"}
     ]
 
     """
@@ -221,7 +224,7 @@ def _Array_to_polars_series(self: _encoding.Array): # -> 'polars.Series':  # bre
 Array.to_polars_series = _Array_to_polars_series
 
 
-def _Array_to_numpy(self: _encoding.Array, *, zero_copy_only: bool = True) -> 'numpy.ndarray':
+def _Array_to_numpy(self: _encoding.Array, *, zero_copy_only: bool = True) -> "numpy.ndarray":
     """Construct a NumPy array from this Vortex array.
 
     This is an alias for :code:`self.to_arrow().to_numpy(zero_copy_only)`

--- a/pyvortex/src/array.rs
+++ b/pyvortex/src/array.rs
@@ -43,14 +43,14 @@ impl PyArray {
     ///
     /// Round-trip an Arrow array through a Vortex array:
     ///
-    ///     >>> vortex.encoding.array([1, 2, 3]).to_arrow()
+    ///     >>> vortex.encoding.array([1, 2, 3]).to_arrow_array()
     ///     <pyarrow.lib.Int64Array object at ...>
     ///     [
     ///       1,
     ///       2,
     ///       3
     ///     ]
-    fn to_arrow(self_: PyRef<'_, Self>) -> PyResult<Bound<PyAny>> {
+    fn to_arrow_array(self_: PyRef<'_, Self>) -> PyResult<Bound<PyAny>> {
         // NOTE(ngates): for struct arrays, we could also return a RecordBatchStreamReader.
         let py = self_.py();
         let vortex = &self_.inner;
@@ -151,7 +151,7 @@ impl PyArray {
     ///
     ///     >>> a = vortex.encoding.array(['a', 'b', 'c', 'd'])
     ///     >>> indices = vortex.encoding.array([0, 2])
-    ///     >>> a.take(indices).to_arrow()
+    ///     >>> a.take(indices).to_arrow_array()
     ///     <pyarrow.lib.StringArray object at ...>
     ///     [
     ///       "a",
@@ -162,7 +162,7 @@ impl PyArray {
     ///
     ///     >>> a = vortex.encoding.array(['a', 'b', 'c', 'd'])
     ///     >>> indices = vortex.encoding.array([0, 1, 1, 0])
-    ///     >>> a.take(indices).to_arrow()
+    ///     >>> a.take(indices).to_arrow_array()
     ///     <pyarrow.lib.StringArray object at ...>
     ///     [
     ///       "a",

--- a/pyvortex/src/array.rs
+++ b/pyvortex/src/array.rs
@@ -31,6 +31,9 @@ impl PyArray {
 impl PyArray {
     /// Convert this array to an Arrow array.
     ///
+    /// .. seealso::
+    ///     :meth:`.to_arrow_table`
+    ///
     /// Returns
     /// -------
     /// :class:`pyarrow.Array`

--- a/pyvortex/src/expr.rs
+++ b/pyvortex/src/expr.rs
@@ -30,7 +30,7 @@ use crate::dtype::PyDType;
 /// Read only those rows whose age column is greater than 35:
 ///
 /// >>> e = vortex.io.read("a.vortex", row_filter = vortex.expr.column("age") > 35)
-/// >>> e.to_arrow()
+/// >>> e.to_arrow_array()
 /// <pyarrow.lib.StructArray object at ...>
 /// -- is_valid: all not null
 /// -- child 0 type: int64
@@ -47,7 +47,7 @@ use crate::dtype::PyDType;
 ///
 /// >>> age = vortex.expr.column("age")
 /// >>> e = vortex.io.read("a.vortex", row_filter = (age > 21) & (age <= 33))
-/// >>> e.to_arrow()
+/// >>> e.to_arrow_array()
 /// <pyarrow.lib.StructArray object at ...>
 /// -- is_valid: all not null
 /// -- child 0 type: int64
@@ -65,7 +65,7 @@ use crate::dtype::PyDType;
 ///
 /// >>> name = vortex.expr.column("name")
 /// >>> e = vortex.io.read("a.vortex", row_filter = name == "Joseph")
-/// >>> e.to_arrow()
+/// >>> e.to_arrow_array()
 /// <pyarrow.lib.StructArray object at ...>
 /// -- is_valid: all not null
 /// -- child 0 type: int64
@@ -83,7 +83,7 @@ use crate::dtype::PyDType;
 ///
 /// >>> name = vortex.expr.column("name")
 /// >>> e = vortex.io.read("a.vortex", row_filter = (name == "Angela") | ((age >= 20) & (age <= 30)))
-/// >>> e.to_arrow()
+/// >>> e.to_arrow_array()
 /// <pyarrow.lib.StructArray object at ...>
 /// -- is_valid: all not null
 /// -- child 0 type: int64

--- a/pyvortex/src/io.rs
+++ b/pyvortex/src/io.rs
@@ -38,7 +38,7 @@ use crate::PyArray;
 /// ... ])
 /// >>> vortex.io.write(a, "a.vortex")
 /// >>> b = vortex.io.read("a.vortex")
-/// >>> b.to_arrow()
+/// >>> b.to_arrow_array()
 /// <pyarrow.lib.StructArray object at ...>
 /// -- is_valid: all not null
 /// -- child 0 type: int64
@@ -61,7 +61,7 @@ use crate::PyArray;
 /// Read just the age column:
 ///
 /// >>> c = vortex.io.read("a.vortex", projection = ["age"])
-/// >>> c.to_arrow()
+/// >>> c.to_arrow_array()
 /// <pyarrow.lib.StructArray object at ...>
 /// -- is_valid: all not null
 /// -- child 0 type: int64
@@ -76,7 +76,7 @@ use crate::PyArray;
 /// Read just the name column, by its index:
 ///
 /// >>> d = vortex.io.read("a.vortex", projection = [1])
-/// >>> d.to_arrow()
+/// >>> d.to_arrow_array()
 /// <pyarrow.lib.StructArray object at ...>
 /// -- is_valid: all not null
 /// -- child 0 type: string
@@ -92,7 +92,7 @@ use crate::PyArray;
 /// Keep rows with an age above 35. This will read O(N_KEPT) rows, when the file format allows.
 ///
 /// >>> e = vortex.io.read("a.vortex", row_filter = vortex.expr.column("age") > 35)
-/// >>> e.to_arrow()
+/// >>> e.to_arrow_array()
 /// <pyarrow.lib.StructArray object at ...>
 /// -- is_valid: all not null
 /// -- child 0 type: int64
@@ -109,7 +109,7 @@ use crate::PyArray;
 /// Read the age column by name, twice, and the name column by index, once:
 ///
 /// >>> # e = vortex.io.read("a.vortex", projection = ["age", 1, "age"])
-/// >>> # e.to_arrow()
+/// >>> # e.to_arrow_array()
 ///
 /// TODO(DK): Top-level nullness does not work.
 ///
@@ -123,7 +123,7 @@ use crate::PyArray;
 /// ... ])
 /// >>> vortex.io.write(a, "a.vortex")
 /// >>> b = vortex.io.read("a.vortex")
-/// >>> # b.to_arrow()
+/// >>> # b.to_arrow_array()
 ///
 #[pyfunction]
 #[pyo3(signature = (f, projection = None, row_filter = None))]

--- a/pyvortex/test/test_array.py
+++ b/pyvortex/test/test_array.py
@@ -5,24 +5,24 @@ import vortex
 def test_primitive_array_round_trip():
     a = pa.array([0, 1, 2, 3])
     arr = vortex.array(a)
-    assert arr.to_arrow() == a
+    assert arr.to_arrow_array() == a
 
 
 def test_array_with_nulls():
     a = pa.array([b"123", None])
     arr = vortex.array(a)
-    assert arr.to_arrow() == a
+    assert arr.to_arrow_array() == a
 
 
 def test_varbin_array_round_trip():
     a = pa.array(["a", "b", "c"])
     arr = vortex.array(a)
-    assert arr.to_arrow() == a
+    assert arr.to_arrow_array() == a
 
 
 def test_varbin_array_take():
     a = vortex.array(pa.array(["a", "b", "c", "d"]))
-    assert a.take(vortex.array(pa.array([0, 2]))).to_arrow() == pa.array(
+    assert a.take(vortex.array(pa.array([0, 2]))).to_arrow_array() == pa.array(
         ["a", "c"],
         type=pa.utf8(),
     )
@@ -31,4 +31,4 @@ def test_varbin_array_take():
 def test_empty_array():
     a = pa.array([], type=pa.uint8())
     primitive = vortex.array(a)
-    assert primitive.to_arrow().type == pa.uint8()
+    assert primitive.to_arrow_array().type == pa.uint8()

--- a/pyvortex/test/test_compress.py
+++ b/pyvortex/test/test_compress.py
@@ -59,7 +59,7 @@ def test_zigzag_encode():
 def test_chunked_encode():
     chunked = pa.chunked_array([pa.array([0, 1, 2]), pa.array([3, 4, 5])])
     encoded = vortex.array(chunked)
-    assert encoded.to_arrow().combine_chunks() == pa.array([0, 1, 2, 3, 4, 5])
+    assert encoded.to_arrow_array().combine_chunks() == pa.array([0, 1, 2, 3, 4, 5])
 
 
 def test_table_encode():
@@ -70,7 +70,7 @@ def test_table_encode():
         }
     )
     encoded = vortex.array(table)
-    assert encoded.to_arrow().combine_chunks() == pa.StructArray.from_arrays(
+    assert encoded.to_arrow_array().combine_chunks() == pa.StructArray.from_arrays(
         [pa.array([0, 1, 2, 3, 4, 5]), pa.array(["a", "b", "c", "d", "e", "f"])], names=["number", "string"]
     )
 
@@ -80,5 +80,5 @@ def test_taxi():
     curdir = Path(os.path.dirname(__file__)).parent.parent
     table = pq.read_table(curdir / "bench-vortex/data/yellow-tripdata-2023-11.parquet")
     compressed = vortex.compress(vortex.array(table[:100]))
-    decompressed = compressed.to_arrow()
+    decompressed = compressed.to_arrow_array()
     assert not decompressed

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -4,7 +4,7 @@
 # last locked with the following flags:
 #   pre: false
 #   features: []
-#   all-features: false
+#   all-features: true
 #   with-sources: false
 #   generate-hashes: false
 #   universal: false
@@ -59,12 +59,15 @@ matplotlib==3.9.2
 matplotlib-inline==0.1.7
     # via ipython
 maturin==1.7.4
+nodeenv==1.9.1
+    # via pyright
 numpy==1.26.4
     # via contourpy
     # via matplotlib
     # via pandas
     # via pyarrow
     # via pyvortex
+    # via vortex-array
     # via xarray
 packaging==24.0
     # via matplotlib
@@ -74,6 +77,7 @@ packaging==24.0
     # via xarray
 pandas==2.2.2
     # via pyvortex
+    # via vortex-array
     # via xarray
 parso==0.8.4
     # via jedi
@@ -84,6 +88,8 @@ pillow==10.4.0
 pip==24.0
 pluggy==1.4.0
     # via pytest
+polars==1.9.0
+    # via vortex-array
 prompt-toolkit==3.0.47
     # via ipython
 ptyprocess==0.7.0
@@ -102,6 +108,7 @@ pygments==2.17.2
     # via sphinx
 pyparsing==3.1.2
     # via matplotlib
+pyright==1.1.385
 pytest==8.1.1
     # via pytest-benchmark
 pytest-benchmark==4.0.0
@@ -143,6 +150,7 @@ traitlets==5.14.3
 typing-extensions==4.12.2
     # via ipython
     # via pydata-sphinx-theme
+    # via pyright
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2

--- a/requirements.lock
+++ b/requirements.lock
@@ -4,7 +4,7 @@
 # last locked with the following flags:
 #   pre: false
 #   features: []
-#   all-features: false
+#   all-features: true
 #   with-sources: false
 #   generate-hashes: false
 #   universal: false
@@ -51,6 +51,7 @@ numpy==2.1.1
     # via pandas
     # via pyarrow
     # via pyvortex
+    # via vortex-array
     # via xarray
 packaging==24.1
     # via matplotlib
@@ -59,9 +60,12 @@ packaging==24.1
     # via xarray
 pandas==2.2.2
     # via pyvortex
+    # via vortex-array
     # via xarray
 pillow==10.4.0
     # via matplotlib
+polars==1.9.0
+    # via vortex-array
 pyarrow==17.0.0
     # via vortex-array
 pydata-sphinx-theme==0.15.4


### PR DESCRIPTION
I split this into two methods: `to_polars_dataframe` and `to_polars_series` because, for a StructArray, we cannot unambiguously choose one or the other. I think we should also change `to_pandas` to `to_pandas_dataframe` for the same reason.

I also added missing optional dependencies and improved the return type information.