### PR TITLE
chore: remove `__lt__`, etc. from docs

### DIFF
--- a/docs/encoding.rst
+++ b/docs/encoding.rst
@@ -4,4 +4,4 @@ Arrays
 .. automodule:: vortex.encoding
    :members:
    :imported-members:
-   :special-members: __len__, __lt__, __le__, __eq__, __ne__, __ge__, __gt__
+   :special-members: __len__


### PR DESCRIPTION
This slipped into #1090. I wanted to document these, but CPython limitations prevent adding doc strings to them.