### PR TITLE
fix: even empty slices must be aligned properly

### DIFF
--- a/vortex-array/src/array/primitive/mod.rs
+++ b/vortex-array/src/array/primitive/mod.rs
@@ -45,8 +45,9 @@ impl PrimitiveArray {
         let length = match_each_native_ptype!(ptype, |$P| {
             let (prefix, values, suffix) = unsafe { buffer.align_to::<$P>() };
             assert!(
-                prefix.is_empty() && suffix.is_empty(),
-                "buffer is not aligned"
+                prefix.is_empty() && suffix.is_empty() && (buffer.as_ptr() as usize) % std::mem::size_of::<$P>() == 0,
+                "buffer is not aligned: {:?}",
+                buffer.as_ptr()
             );
             values.len()
         });

--- a/vortex-buffer/src/lib.rs
+++ b/vortex-buffer/src/lib.rs
@@ -65,7 +65,16 @@ impl Buffer {
             Self::Arrow(b) => {
                 Self::Arrow(b.slice_with_length(range.start, range.end - range.start))
             }
-            Self::Bytes(b) => Self::Bytes(b.slice(range)),
+            Self::Bytes(b) => {
+                if range.is_empty() {
+                    // bytes::Bytes::slice does not preserve alignment if the range is empty
+                    let mut empty_b = b.clone();
+                    empty_b.truncate(0);
+                    Self::Bytes(empty_b)
+                } else {
+                    Self::Bytes(b.slice(range))
+                }
+            }
         }
     }
 


### PR DESCRIPTION
bytes::Bytes::slice does not preserve alignment whtn the range is empty. Instead, it returns a pointer to a statically allocated byte slice. In debug builds, this slice is located at address 0x1 which is not aligned for most types. Our assertion is insufficient for empty slices.