### PR TITLE
feat: use buffer for VarBinView views

### DIFF
--- a/encodings/dict/Cargo.toml
+++ b/encodings/dict/Cargo.toml
@@ -36,3 +36,7 @@ simplelog = { workspace = true }
 [[bench]]
 name = "dict_compress"
 harness = false
+
+[[bench]]
+name = "dict_canonical"
+harness = false

--- a/encodings/dict/benches/dict_canonical.rs
+++ b/encodings/dict/benches/dict_canonical.rs
@@ -1,0 +1,34 @@
+#![allow(clippy::unwrap_used)]
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use vortex::array::VarBinArray;
+use vortex::{IntoArray, IntoCanonical};
+use vortex_dict::{dict_encode_varbin, DictArray};
+use vortex_dtype::{DType, Nullability};
+
+fn fixture(len: usize) -> DictArray {
+    let values = [
+        Some("inlined"),
+        None,
+        Some("not inlined but repeated often"),
+    ];
+
+    let strings = VarBinArray::from_iter(
+        values.into_iter().cycle().take(len),
+        DType::Utf8(Nullability::Nullable),
+    );
+
+    let (codes, values) = dict_encode_varbin(&strings);
+    DictArray::try_new(codes.into_array(), values.into_array()).unwrap()
+}
+
+fn bench_canonical(c: &mut Criterion) {
+    let dict_array = fixture(1024).into_array();
+
+    c.bench_function("canonical", |b| {
+        b.iter(|| dict_array.clone().into_canonical().unwrap())
+    });
+}
+
+criterion_group!(bench_dict_canonical, bench_canonical);
+criterion_main!(bench_dict_canonical);

--- a/encodings/dict/benches/dict_canonical.rs
+++ b/encodings/dict/benches/dict_canonical.rs
@@ -23,10 +23,10 @@ fn fixture(len: usize) -> DictArray {
 }
 
 fn bench_canonical(c: &mut Criterion) {
-    let dict_array = fixture(1024).into_array();
+    let dict_array = fixture(1024 * 1024).into_array();
 
     c.bench_function("canonical", |b| {
-        b.iter(|| dict_array.clone().into_canonical().unwrap())
+        b.iter(|| dict_array.clone().into_canonical())
     });
 }
 

--- a/encodings/dict/src/array.rs
+++ b/encodings/dict/src/array.rs
@@ -92,7 +92,7 @@ fn canonicalize_string(array: DictArray) -> VortexResult<Canonical> {
     VarBinViewArray::try_new(
         full_views.into(),
         values.buffers().collect(),
-        values.dtype().clone(),
+        array.dtype().clone(),
         array.logical_validity().into_validity(),
     )
     .map(Canonical::VarBinView)

--- a/encodings/dict/src/array.rs
+++ b/encodings/dict/src/array.rs
@@ -1,19 +1,19 @@
 use std::fmt::{Debug, Display};
 
-use arrow_buffer::BooleanBuffer;
+use arrow_buffer::{BooleanBuffer, ScalarBuffer};
 use serde::{Deserialize, Serialize};
 use vortex::array::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use vortex::array::BoolArray;
+use vortex::array::{BoolArray, VarBinViewArray};
 use vortex::compute::take;
-use vortex::compute::unary::scalar_at;
+use vortex::compute::unary::{scalar_at, try_cast};
 use vortex::encoding::ids;
 use vortex::stats::StatsSet;
-use vortex::validity::{ArrayValidity, LogicalValidity};
+use vortex::validity::{ArrayValidity, LogicalValidity, Validity};
 use vortex::{
     impl_encoding, Array, ArrayDType, ArrayTrait, Canonical, IntoArray, IntoArrayVariant,
     IntoCanonical,
 };
-use vortex_dtype::{match_each_integer_ptype, DType, PType};
+use vortex_dtype::{match_each_integer_ptype, DType, Nullability, PType};
 use vortex_error::{vortex_bail, vortex_panic, VortexExpect as _, VortexResult};
 
 impl_encoding!("vortex.dict", ids::DICT, Dict);
@@ -41,6 +41,7 @@ impl DictArray {
             DictMetadata {
                 codes_ptype: PType::try_from(codes.dtype())
                     .vortex_expect("codes dtype must be uint"),
+
                 values_len: values.len(),
             },
             [values, codes].into(),
@@ -67,9 +68,77 @@ impl ArrayTrait for DictArray {}
 
 impl IntoCanonical for DictArray {
     fn into_canonical(self) -> VortexResult<Canonical> {
-        let canonical_values: Array = self.values().into_canonical()?.into();
-        take(canonical_values, self.codes())?.into_canonical()
+        match self.dtype() {
+            DType::Utf8(nullability) | DType::Binary(nullability) => {
+                let values = self.values().into_varbinview()?;
+                let codes = try_cast(self.codes(), PType::U64.into())?.into_primitive()?;
+                let codes_u64 = codes.maybe_null_slice::<u64>();
+
+                if *nullability == Nullability::NonNullable {
+                    canonicalize_string_nonnull(codes_u64, values)
+                } else {
+                    canonicalize_string_nullable(
+                        codes_u64,
+                        values,
+                        self.logical_validity().into_validity(),
+                    )
+                }
+            }
+            _ => canonicalize_primitive(self),
+        }
     }
+}
+
+/// Canonicalize a set of codes and values.
+fn canonicalize_string_nonnull(codes: &[u64], values: VarBinViewArray) -> VortexResult<Canonical> {
+    let value_views = ScalarBuffer::<u128>::from(values.views().clone().into_arrow());
+
+    // Gather the views from value_views into full_views using the dictionary codes.
+    let full_views: Vec<u128> = codes
+        .iter()
+        .map(|code| value_views[*code as usize])
+        .collect();
+
+    VarBinViewArray::try_new(
+        full_views.into(),
+        values.buffers().collect(),
+        values.dtype().clone(),
+        Validity::NonNullable,
+    )
+    .map(Canonical::VarBinView)
+}
+
+fn canonicalize_string_nullable(
+    codes: &[u64],
+    values: VarBinViewArray,
+    validity: Validity,
+) -> VortexResult<Canonical> {
+    let value_views = ScalarBuffer::<u128>::from(values.views().clone().into_arrow());
+
+    // Gather the views from value_views into full_views using the dictionary codes.
+    let full_views: Vec<u128> = codes
+        .iter()
+        .map(|code| {
+            if *code == 0 {
+                0u128
+            } else {
+                value_views[(*code - 1) as usize]
+            }
+        })
+        .collect();
+
+    VarBinViewArray::try_new(
+        full_views.into(),
+        values.buffers().collect(),
+        values.dtype().clone(),
+        validity,
+    )
+    .map(Canonical::VarBinView)
+}
+
+fn canonicalize_primitive(array: DictArray) -> VortexResult<Canonical> {
+    let canonical_values: Array = array.values().into_canonical()?.into();
+    take(canonical_values, array.codes())?.into_canonical()
 }
 
 impl ArrayValidity for DictArray {

--- a/encodings/dict/src/compute.rs
+++ b/encodings/dict/src/compute.rs
@@ -42,9 +42,6 @@ impl ScalarAtFn for DictArray {
 
 impl TakeFn for DictArray {
     fn take(&self, indices: &Array) -> VortexResult<Array> {
-        // Dict
-        //   codes: 0 0 1
-        //   dict: a b c d e f g h
         let codes = take(self.codes(), indices)?;
         Self::try_new(codes, self.values()).map(|a| a.into_array())
     }

--- a/vortex-array/src/array/bool/compute/cast.rs
+++ b/vortex-array/src/array/bool/compute/cast.rs
@@ -1,0 +1,35 @@
+use vortex_dtype::{DType, Nullability};
+use vortex_error::{vortex_bail, VortexResult};
+
+use crate::array::BoolArray;
+use crate::compute::unary::CastFn;
+use crate::validity::Validity;
+use crate::{Array, ArrayDType, IntoArray};
+
+impl CastFn for BoolArray {
+    fn cast(&self, dtype: &DType) -> VortexResult<Array> {
+        if !dtype.is_boolean() {
+            vortex_bail!("Cannot cast BoolArray to non-Bool type");
+        }
+
+        match (self.dtype().nullability(), dtype.nullability()) {
+            // convert to same nullability => no-op
+            (Nullability::NonNullable, Nullability::NonNullable)
+            | (Nullability::Nullable, Nullability::Nullable) => Ok(self.clone().into_array()),
+
+            // convert non-nullable to nullable
+            (Nullability::NonNullable, Nullability::Nullable) => {
+                Ok(BoolArray::try_new(self.boolean_buffer(), Validity::AllValid)?.into_array())
+            }
+
+            // convert nullable to non-nullable, only safe if there are no nulls present.
+            (Nullability::Nullable, Nullability::NonNullable) => {
+                if self.validity() != Validity::AllValid {
+                    vortex_bail!("cannot cast bool array with nulls as non-nullable");
+                }
+
+                Ok(BoolArray::try_new(self.boolean_buffer(), Validity::NonNullable)?.into_array())
+            }
+        }
+    }
+}

--- a/vortex-array/src/array/bool/compute/mod.rs
+++ b/vortex-array/src/array/bool/compute/mod.rs
@@ -1,9 +1,10 @@
 use crate::array::BoolArray;
-use crate::compute::unary::{FillForwardFn, ScalarAtFn};
+use crate::compute::unary::{CastFn, FillForwardFn, ScalarAtFn};
 use crate::compute::{AndFn, ArrayCompute, OrFn, SliceFn, TakeFn};
 
 mod boolean;
 
+mod cast;
 mod fill;
 mod filter;
 mod flatten;
@@ -12,6 +13,10 @@ mod slice;
 mod take;
 
 impl ArrayCompute for BoolArray {
+    fn cast(&self) -> Option<&dyn CastFn> {
+        Some(self)
+    }
+
     fn fill_forward(&self) -> Option<&dyn FillForwardFn> {
         Some(self)
     }

--- a/vortex-array/src/array/chunked/canonical.rs
+++ b/vortex-array/src/array/chunked/canonical.rs
@@ -1,4 +1,4 @@
-use arrow_buffer::{BooleanBufferBuilder, Buffer, MutableBuffer, ScalarBuffer};
+use arrow_buffer::{BooleanBufferBuilder, MutableBuffer, ScalarBuffer};
 use vortex_dtype::{DType, PType, StructDType};
 use vortex_error::{vortex_bail, vortex_err, ErrString, VortexResult};
 
@@ -179,11 +179,7 @@ fn pack_primitives(
         buffer.extend_from_slice(chunk.buffer());
     }
 
-    Ok(PrimitiveArray::new(
-        Buffer::from(buffer).into(),
-        ptype,
-        validity,
-    ))
+    Ok(PrimitiveArray::new(buffer.into(), ptype, validity))
 }
 
 /// Builds a new [VarBinViewArray] by repacking the values from the chunks into a single
@@ -231,8 +227,8 @@ fn pack_views(
         }
     }
 
-    let views_buffer: Buffer = ScalarBuffer::<u128>::from(views).into_inner();
-    VarBinViewArray::try_new(Array::from(views_buffer), buffers, dtype.clone(), validity)
+    let views_buffer = ScalarBuffer::<u128>::from(views).into_inner();
+    VarBinViewArray::try_new(views_buffer.into(), buffers, dtype.clone(), validity)
 }
 
 #[cfg(test)]

--- a/vortex-array/src/array/varbin/mod.rs
+++ b/vortex-array/src/array/varbin/mod.rs
@@ -62,7 +62,7 @@ impl VarBinArray {
             vortex_bail!(MismatchedTypes: "utf8 or binary", dtype);
         }
         if dtype.is_nullable() == (validity == Validity::NonNullable) {
-            vortex_bail!("incorrect validity {:?}", validity);
+            vortex_bail!("incorrect validity {:?} for {}", validity, dtype);
         }
 
         let length = offsets.len() - 1;

--- a/vortex-array/src/array/varbinview/compute.rs
+++ b/vortex-array/src/array/varbinview/compute.rs
@@ -14,7 +14,7 @@ use crate::array::varbinview::{VarBinViewArray, VIEW_SIZE_BYTES};
 use crate::array::{varbinview_as_arrow, ConstantArray};
 use crate::arrow::FromArrowArray;
 use crate::compute::unary::ScalarAtFn;
-use crate::compute::{slice, ArrayCompute, MaybeCompareFn, Operator, SliceFn, TakeFn};
+use crate::compute::{ArrayCompute, MaybeCompareFn, Operator, SliceFn, TakeFn};
 use crate::{Array, ArrayDType, IntoArray, IntoCanonical};
 
 impl ArrayCompute for VarBinViewArray {
@@ -45,11 +45,8 @@ impl ScalarAtFn for VarBinViewArray {
 impl SliceFn for VarBinViewArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<Array> {
         Ok(Self::try_new(
-            slice(
-                self.views(),
-                start * VIEW_SIZE_BYTES,
-                stop * VIEW_SIZE_BYTES,
-            )?,
+            self.views()
+                .slice(start * VIEW_SIZE_BYTES..stop * VIEW_SIZE_BYTES),
             (0..self.metadata().buffer_lens.len())
                 .map(|i| self.buffer(i))
                 .collect::<Vec<_>>(),

--- a/vortex-array/src/array/varbinview/mod.rs
+++ b/vortex-array/src/array/varbinview/mod.rs
@@ -2,12 +2,12 @@ use std::fmt::{Debug, Display, Formatter};
 use std::slice;
 use std::sync::Arc;
 
-use ::serde::{Deserialize, Serialize};
 use arrow_array::builder::{BinaryViewBuilder, GenericByteViewBuilder, StringViewBuilder};
 use arrow_array::types::{BinaryViewType, ByteViewType, StringViewType};
 use arrow_array::{ArrayRef, BinaryViewArray, GenericByteViewArray, StringViewArray};
 use arrow_buffer::ScalarBuffer;
 use itertools::Itertools;
+use ::serde::{Deserialize, Serialize};
 use static_assertions::{assert_eq_align, assert_eq_size};
 use vortex_buffer::Buffer;
 use vortex_dtype::{DType, PType};
@@ -227,6 +227,10 @@ impl VarBinViewArray {
         dtype: DType,
         validity: Validity,
     ) -> VortexResult<Self> {
+        if views.as_ptr().align_offset(VIEW_SIZE_BYTES) != 0 {
+            vortex_bail!("views buffer must be aligned to 16 bytes");
+        }
+
         for d in buffers.iter() {
             if !matches!(d.dtype(), &DType::BYTES) {
                 vortex_bail!(MismatchedTypes: "u8", d.dtype());

--- a/vortex-array/src/array/varbinview/mod.rs
+++ b/vortex-array/src/array/varbinview/mod.rs
@@ -9,11 +9,11 @@ use arrow_array::{ArrayRef, BinaryViewArray, GenericByteViewArray, StringViewArr
 use arrow_buffer::ScalarBuffer;
 use itertools::Itertools;
 use static_assertions::{assert_eq_align, assert_eq_size};
+use vortex_buffer::Buffer;
 use vortex_dtype::{DType, PType};
 use vortex_error::{vortex_bail, vortex_err, vortex_panic, VortexExpect, VortexResult};
 
 use crate::array::visitor::{AcceptArrayVisitor, ArrayVisitor};
-use crate::array::PrimitiveArray;
 use crate::arrow::FromArrowArray;
 use crate::compute::slice;
 use crate::encoding::ids;
@@ -21,6 +21,7 @@ use crate::stats::StatsSet;
 use crate::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use crate::{
     impl_encoding, Array, ArrayDType, ArrayTrait, Canonical, IntoArrayVariant, IntoCanonical,
+    TypedArray,
 };
 
 mod accessor;
@@ -221,15 +222,11 @@ impl_encoding!("vortex.varbinview", ids::VAR_BIN_VIEW, VarBinView);
 
 impl VarBinViewArray {
     pub fn try_new(
-        views: Array,
+        views: Buffer,
         buffers: Vec<Array>,
         dtype: DType,
         validity: Validity,
     ) -> VortexResult<Self> {
-        if !matches!(views.dtype(), &DType::BYTES) {
-            vortex_bail!(MismatchedTypes: "u8", views.dtype());
-        }
-
         for d in buffers.iter() {
             if !matches!(d.dtype(), &DType::BYTES) {
                 vortex_bail!(MismatchedTypes: "u8", d.dtype());
@@ -258,13 +255,21 @@ impl VarBinViewArray {
         };
 
         let mut children = Vec::with_capacity(buffers.len() + 2);
-        children.push(views);
         children.extend(buffers);
         if let Some(a) = validity.into_array() {
             children.push(a)
         }
 
-        Self::try_from_parts(dtype, num_views, metadata, children.into(), StatsSet::new())
+        Ok(Self {
+            typed: TypedArray::try_from_parts(
+                dtype,
+                num_views,
+                metadata,
+                Some(views),
+                children.into(),
+                StatsSet::new(),
+            )?,
+        })
     }
 
     /// Number of raw string data buffers held by this array.
@@ -279,10 +284,7 @@ impl VarBinViewArray {
     pub fn view_slice(&self) -> &[BinaryView] {
         unsafe {
             slice::from_raw_parts(
-                PrimitiveArray::try_from(self.views())
-                    .vortex_expect("Views must be a primitive array")
-                    .maybe_null_slice::<u8>()
-                    .as_ptr() as _,
+                self.views().as_ptr() as _,
                 self.views().len() / VIEW_SIZE_BYTES,
             )
         }
@@ -298,10 +300,8 @@ impl VarBinViewArray {
     /// contain either a pointer into one of the array's owned `buffer`s OR an inlined copy of
     /// the string (if the string has 12 bytes or fewer).
     #[inline]
-    pub fn views(&self) -> Array {
-        self.as_ref()
-            .child(0, &DType::BYTES, self.len() * VIEW_SIZE_BYTES)
-            .vortex_expect("VarBinViewArray: views child")
+    pub fn views(&self) -> &Buffer {
+        self.as_ref().buffer().vortex_expect("views buffer")
     }
 
     /// Access one of the backing data buffers.
@@ -314,7 +314,7 @@ impl VarBinViewArray {
     pub fn buffer(&self, idx: usize) -> Array {
         self.as_ref()
             .child(
-                idx + 1,
+                idx,
                 &DType::BYTES,
                 self.metadata().buffer_lens[idx] as usize,
             )
@@ -346,7 +346,7 @@ impl VarBinViewArray {
         self.metadata().validity.to_validity(|| {
             self.as_ref()
                 .child(
-                    (self.metadata().buffer_lens.len() + 1) as _,
+                    self.metadata().buffer_lens.len(),
                     &Validity::DTYPE,
                     self.len(),
                 )
@@ -488,13 +488,6 @@ impl IntoCanonical for VarBinViewArray {
 }
 
 pub(crate) fn varbinview_as_arrow(var_bin_view: &VarBinViewArray) -> ArrayRef {
-    // Views should be buffer of u8
-    let views = var_bin_view
-        .views()
-        .into_primitive()
-        .vortex_expect("VarBinViewArray: views child must be primitive");
-    assert_eq!(views.ptype(), PType::U8);
-
     let nulls = var_bin_view
         .logical_validity()
         .to_null_buffer()
@@ -518,14 +511,14 @@ pub(crate) fn varbinview_as_arrow(var_bin_view: &VarBinViewArray) -> ArrayRef {
     match var_bin_view.dtype() {
         DType::Binary(_) => Arc::new(unsafe {
             BinaryViewArray::new_unchecked(
-                ScalarBuffer::<u128>::from(views.buffer().clone().into_arrow()),
+                ScalarBuffer::<u128>::from(var_bin_view.views().clone().into_arrow()),
                 data,
                 nulls,
             )
         }),
         DType::Utf8(_) => Arc::new(unsafe {
             StringViewArray::new_unchecked(
-                ScalarBuffer::<u128>::from(views.buffer().clone().into_arrow()),
+                ScalarBuffer::<u128>::from(var_bin_view.views().clone().into_arrow()),
                 data,
                 nulls,
             )
@@ -546,7 +539,7 @@ impl ArrayValidity for VarBinViewArray {
 
 impl AcceptArrayVisitor for VarBinViewArray {
     fn accept(&self, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
-        visitor.visit_child("views", &self.views())?;
+        visitor.visit_buffer(self.views())?;
         for i in 0..self.metadata().buffer_lens.len() {
             visitor.visit_child(format!("bytes_{i}").as_str(), &self.buffer(i))?;
         }

--- a/vortex-array/src/array/varbinview/mod.rs
+++ b/vortex-array/src/array/varbinview/mod.rs
@@ -238,7 +238,7 @@ impl VarBinViewArray {
         }
 
         if dtype.is_nullable() == (validity == Validity::NonNullable) {
-            vortex_bail!("incorrect validity {:?}", validity);
+            vortex_bail!("incorrect validity {:?} for {}", validity, dtype);
         }
 
         let num_views = views.len() / VIEW_SIZE_BYTES;

--- a/vortex-array/src/array/varbinview/mod.rs
+++ b/vortex-array/src/array/varbinview/mod.rs
@@ -2,12 +2,12 @@ use std::fmt::{Debug, Display, Formatter};
 use std::slice;
 use std::sync::Arc;
 
+use ::serde::{Deserialize, Serialize};
 use arrow_array::builder::{BinaryViewBuilder, GenericByteViewBuilder, StringViewBuilder};
 use arrow_array::types::{BinaryViewType, ByteViewType, StringViewType};
 use arrow_array::{ArrayRef, BinaryViewArray, GenericByteViewArray, StringViewArray};
 use arrow_buffer::ScalarBuffer;
 use itertools::Itertools;
-use ::serde::{Deserialize, Serialize};
 use static_assertions::{assert_eq_align, assert_eq_size};
 use vortex_buffer::Buffer;
 use vortex_dtype::{DType, PType};

--- a/vortex-array/src/compute/compare.rs
+++ b/vortex-array/src/compute/compare.rs
@@ -78,6 +78,21 @@ pub trait MaybeCompareFn {
     fn maybe_compare(&self, other: &Array, operator: Operator) -> Option<VortexResult<Array>>;
 }
 
+/// Binary comparison operation between two arrays.
+///
+/// The result of comparison is a `Bool` typed Array holding `true` where both of the operands
+/// satisfy the operation, `false` otherwise.
+///
+/// Nullability of the result is the union of the nullabilities of the operands.
+///
+/// ## Null semantics
+///
+/// All binary comparison operations where one of the operands is `NULL` will result in a `NULL`
+/// value being placed in the output.
+///
+/// This semantic is derived from [Apache Arrow's handling of nulls].
+///
+/// [Apache Arrow's handling of nulls]: https://arrow.apache.org/rust/arrow/compute/kernels/cmp/fn.eq.html
 pub fn compare(
     left: impl AsRef<Array>,
     right: impl AsRef<Array>,


### PR DESCRIPTION
Fixes #1111 

Also implements an enhanced `DictArray` canonicalize that canonicalizes the values then gathers them using the codes, accounting for nullability.

<img width="682" alt="image" src="https://github.com/user-attachments/assets/cf9af881-e851-4644-b0ef-7097efd9a4ef">
