### PR TITLE
fix: canonicalize null ConstantArray to VarBinViewArray

### DIFF
--- a/vortex-array/src/array/constant/canonical.rs
+++ b/vortex-array/src/array/constant/canonical.rs
@@ -3,11 +3,11 @@ use arrow_buffer::{BooleanBuffer, BufferBuilder};
 use vortex_buffer::Buffer;
 use vortex_dtype::{match_each_native_ptype, DType, Nullability, PType};
 use vortex_error::{vortex_bail, VortexResult};
-use vortex_scalar::{BinaryScalar, BoolScalar, Scalar, Utf8Scalar};
+use vortex_scalar::{BinaryScalar, BoolScalar, Utf8Scalar};
 
 use crate::array::constant::ConstantArray;
 use crate::array::primitive::PrimitiveArray;
-use crate::array::{BinaryView, BoolArray, VarBinViewArray};
+use crate::array::{BinaryView, BoolArray, VarBinViewArray, VIEW_SIZE_BYTES};
 use crate::validity::Validity;
 use crate::{ArrayDType, Canonical, IntoArray, IntoCanonical};
 
@@ -70,7 +70,7 @@ fn canonical_byte_view(
 ) -> VortexResult<VarBinViewArray> {
     match scalar_bytes {
         None => {
-            let views = ConstantArray::new(Scalar::null(dtype.clone()), len);
+            let views = ConstantArray::new(0u8, len * VIEW_SIZE_BYTES);
 
             VarBinViewArray::try_new(
                 views.into_array(),

--- a/vortex-array/src/array/varbinview/mod.rs
+++ b/vortex-array/src/array/varbinview/mod.rs
@@ -227,12 +227,12 @@ impl VarBinViewArray {
         validity: Validity,
     ) -> VortexResult<Self> {
         if !matches!(views.dtype(), &DType::BYTES) {
-            vortex_bail!(MismatchedTypes: "u8", views.dtype());
+            vortex_bail!(MismatchedTypes: "views u8", views.dtype());
         }
 
         for d in buffers.iter() {
             if !matches!(d.dtype(), &DType::BYTES) {
-                vortex_bail!(MismatchedTypes: "u8", d.dtype());
+                vortex_bail!(MismatchedTypes: "buffers u8", d.dtype());
             }
         }
 


### PR DESCRIPTION
previously we were using a null utf8 scalar, we should have been using a 0u8 scalar as that is the type of the views array.