### PR TITLE
fix: fix Sphinx syntax and build docs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,14 @@ jobs:
           make clean && make doctest
         working-directory: docs/
 
+      - name: Ensure docs build - PyVortex
+        run: |
+          set -ex
+
+          (cd pyvortex && uv run maturin develop)
+
+          cd docs
+          uv run sphinx-build -M html . _build --fail-on-warning --keep-going
       - name: License Check
         run: cargo install --locked cargo-deny && cargo deny check
       - uses: rustsec/audit-check@v2.0.0

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -W --keep-going
+SPHINXOPTS    ?= --fail-on-warning --keep-going
 SPHINXBUILD   ?= uv run sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/pyvortex/src/io.rs
+++ b/pyvortex/src/io.rs
@@ -17,7 +17,7 @@ use crate::{PyArray, TOKIO_RUNTIME};
 /// ----------
 /// path : :class:`str`
 ///     The file path to read from.
-/// projection : :class:`list`[:class:`str` ``|`` :class:`int`]
+/// projection : :class:`list` [ :class:`str` ``|`` :class:`int` ]
 ///     The columns to read identified either by their index or name.
 /// row_filter : :class:`.Expr`
 ///     Keep only the rows for which this expression evaluates to true.
@@ -143,7 +143,7 @@ pub fn read_path(
 /// ----------
 /// url : :class:`str`
 ///     The URL to read from.
-/// projection : :class:`list`[:class:`str` ``|`` :class:`int`]
+/// projection : :class:`list` [ :class:`str` ``|`` :class:`int` ]
 ///     The columns to read identified either by their index or name.
 /// row_filter : :class:`.Expr`
 ///     Keep only the rows for which this expression evaluates to true.


### PR DESCRIPTION
We tested the docs but did not verify the rST syntax was correct. Now we both test and verify the syntax is correct and all links are valid.