### PR TITLE
feat: FSSTArray::into_canonical directly build VarBinView

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4528,6 +4528,7 @@ name = "vortex-fsst"
 version = "0.12.0"
 dependencies = [
  "arrow-array",
+ "arrow-buffer",
  "fsst-rs",
  "serde",
  "vortex-array",

--- a/bench-vortex/src/bin/notimplemented.rs
+++ b/bench-vortex/src/bin/notimplemented.rs
@@ -45,7 +45,7 @@ fn fsst_array() -> Array {
 
 fn varbin_array() -> Array {
     let mut input_array = VarBinBuilder::<i32>::with_capacity(3);
-    input_array.push_value(b"The Greeks never said that the limit could not he overstepped");
+    input_array.push_value(b"The Greeks never said that the limit could not be overstepped");
     input_array.push_value(
         b"They said it existed and that whoever dared to exceed it was mercilessly struck down",
     );
@@ -57,7 +57,7 @@ fn varbin_array() -> Array {
 
 fn varbinview_array() -> Array {
     VarBinViewArray::from_iter_str(vec![
-        "The Greeks never said that the limit could not he overstepped",
+        "The Greeks never said that the limit could not be overstepped",
         "They said it existed and that whoever dared to exceed it was mercilessly struck down",
         "Nothing in present history can contradict them",
     ])

--- a/encodings/fsst/Cargo.toml
+++ b/encodings/fsst/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [dependencies]
 arrow-array = { workspace = true }
+arrow-buffer = { workspace = true }
 fsst-rs = { workspace = true }
 serde = { workspace = true }
 

--- a/encodings/fsst/tests/fsst_tests.rs
+++ b/encodings/fsst/tests/fsst_tests.rs
@@ -18,7 +18,7 @@ macro_rules! assert_nth_scalar {
 // this function is VERY slow on miri, so we only want to run it once
 fn build_fsst_array() -> Array {
     let mut input_array = VarBinBuilder::<i32>::with_capacity(3);
-    input_array.push_value(b"The Greeks never said that the limit could not he overstepped");
+    input_array.push_value(b"The Greeks never said that the limit could not be overstepped");
     input_array.push_value(
         b"They said it existed and that whoever dared to exceed it was mercilessly struck down",
     );
@@ -41,7 +41,7 @@ fn test_fsst_array_ops() {
     assert_nth_scalar!(
         fsst_array,
         0,
-        "The Greeks never said that the limit could not he overstepped"
+        "The Greeks never said that the limit could not be overstepped"
     );
     assert_nth_scalar!(
         fsst_array,
@@ -76,7 +76,7 @@ fn test_fsst_array_ops() {
     assert_nth_scalar!(
         fsst_taken,
         0,
-        "The Greeks never said that the limit could not he overstepped"
+        "The Greeks never said that the limit could not be overstepped"
     );
     assert_nth_scalar!(
         fsst_taken,

--- a/vortex-buffer/src/string.rs
+++ b/vortex-buffer/src/string.rs
@@ -1,10 +1,11 @@
+use std::fmt::{Debug, Formatter};
 use std::ops::Deref;
 use std::str::Utf8Error;
 
 use crate::Buffer;
 
 /// A wrapper around a [`Buffer`] that guarantees that the buffer contains valid UTF-8.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
+#[derive(Clone, PartialEq, Eq, PartialOrd)]
 pub struct BufferString(Buffer);
 
 impl BufferString {
@@ -20,6 +21,14 @@ impl BufferString {
     pub fn as_str(&self) -> &str {
         // SAFETY: We have already validated that the buffer is valid UTF-8
         unsafe { std::str::from_utf8_unchecked(self.0.as_ref()) }
+    }
+}
+
+impl Debug for BufferString {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BufferString")
+            .field("string", &self.as_str())
+            .finish()
     }
 }
 


### PR DESCRIPTION
Previously we had been building a VarBin and then using arrow_cast to cast into a VarBinView.

The implementation of arrow_cast for Utf8 -> Utf8View should be relatively efficient because it tries to reuse the buffer. However, it's likely more efficient to do the construction in a single-pass