### PR TITLE
Use BufResult

### DIFF
--- a/bench-vortex/src/reader.rs
+++ b/bench-vortex/src/reader.rs
@@ -140,14 +140,14 @@ pub async fn read_vortex_footer_format<R: VortexReadAt>(
 ) -> VortexResult<ChunkedArrayReader<R>> {
     let mut buf = BytesMut::with_capacity(8);
     unsafe { buf.set_len(8) }
-    buf = reader.read_at_into(len - 8, buf).await?;
+    let (res, mut buf) = reader.read_at_into(len - 8, buf).await;
+    res?;
     let footer_len = u64::from_le_bytes(buf.as_ref().try_into().unwrap()) as usize;
 
     buf.reserve(footer_len - buf.len());
-    unsafe { buf.set_len(footer_len) }
-    buf = reader
-        .read_at_into(len - footer_len as u64 - 8, buf)
-        .await?;
+    unsafe { buf.set_len(footer_len) };
+    let (res, mut buf) = reader.read_at_into(len - footer_len as u64 - 8, buf).await;
+    res?;
 
     let footer: VortexFooter = VortexFooter::deserialize(
         flexbuffers::Reader::get_root(buf.as_ref()).map_err(|e| vortex_err!("{}", e))?,
@@ -156,7 +156,8 @@ pub async fn read_vortex_footer_format<R: VortexReadAt>(
     let header_len = (footer.dtype_range.end - footer.dtype_range.start) as usize;
     buf.reserve(header_len - buf.len());
     unsafe { buf.set_len(header_len) }
-    buf = reader.read_at_into(footer.dtype_range.start, buf).await?;
+    let (res, buf) = reader.read_at_into(footer.dtype_range.start, buf).await;
+    res?;
     let dtype = DTypeReader::new(buf).await?.read_dtype().await?;
 
     ChunkedArrayReader::try_new(

--- a/pyvortex/src/dataset.rs
+++ b/pyvortex/src/dataset.rs
@@ -62,11 +62,12 @@ pub async fn read_array_from_reader<T: VortexReadAt + Unpin + 'static>(
 }
 
 pub async fn read_dtype_from_reader<T: VortexReadAt + Unpin>(reader: T) -> VortexResult<DType> {
+    let file_size = reader.size().await?;
     LayoutDescriptorReader::new(LayoutDeserializer::new(
         ALL_COMPRESSORS_CONTEXT.clone(),
         LayoutContext::default().into(),
     ))
-    .read_footer(&reader, reader.size().await)
+    .read_footer(&reader, file_size)
     .await?
     .dtype()
 }

--- a/vortex-error/src/lib.rs
+++ b/vortex-error/src/lib.rs
@@ -325,6 +325,16 @@ impl From<VortexError> for datafusion_common::arrow::error::ArrowError {
     }
 }
 
+// Conversion into io::Error for use with IO APIs.
+impl From<VortexError> for io::Error {
+    fn from(value: VortexError) -> Self {
+        match value {
+            VortexError::IOError(io) => io,
+            err => io::Error::new(io::ErrorKind::Other, err),
+        }
+    }
+}
+
 // Not public, referenced by macros only.
 #[doc(hidden)]
 pub mod __private {

--- a/vortex-serde/src/chunked_reader/take_rows.rs
+++ b/vortex-serde/src/chunked_reader/take_rows.rs
@@ -139,7 +139,8 @@ impl<R: VortexReadAt> ChunkedArrayReader<R> {
         // TODO(ngates): instead of reading the whole range into a buffer, we should stream
         //  the byte range (e.g. if its coming from an HTTP endpoint) and wrap that with an
         //  MesssageReader.
-        let buffer = self.read.read_at_into(byte_range.start, buffer).await?;
+        let (res, buffer) = self.read.read_at_into(byte_range.start, buffer).await;
+        res?;
 
         let reader = StreamArrayReader::try_new(buffer, self.context.clone())
             .await?

--- a/vortex-serde/src/io/futures.rs
+++ b/vortex-serde/src/io/futures.rs
@@ -1,17 +1,17 @@
 #![cfg(feature = "futures")]
 
-use std::io;
-
 use bytes::BytesMut;
 use futures_util::{AsyncRead, AsyncReadExt};
 
+use super::{BufResult, Discard};
 use crate::io::VortexRead;
 
+/// An adapter to allow `futures-util` readers to be used with [`VortexRead`]
 pub struct FuturesAdapter<IO>(pub IO);
 
 impl<R: AsyncRead + Unpin> VortexRead for FuturesAdapter<R> {
-    async fn read_into(&mut self, mut buffer: BytesMut) -> io::Result<BytesMut> {
-        self.0.read_exact(buffer.as_mut()).await?;
-        Ok(buffer)
+    async fn read_into(&mut self, mut buffer: BytesMut) -> BufResult<()> {
+        let res = self.0.read_exact(buffer.as_mut()).await.discard_ok();
+        (res, buffer)
     }
 }

--- a/vortex-serde/src/io/monoio.rs
+++ b/vortex-serde/src/io/monoio.rs
@@ -9,19 +9,17 @@ use monoio::buf::IoBufMut;
 use monoio::io::{AsyncReadRent, AsyncReadRentExt, AsyncWriteRent, AsyncWriteRentExt};
 use vortex_buffer::io_buf::IoBuf;
 
+use super::BufResult;
 use crate::io::{VortexRead, VortexWrite};
 
 pub struct MonoAdapter<IO>(IO);
 
 impl<R: AsyncReadRent> VortexRead for MonoAdapter<R> {
-    fn read_into(&mut self, buffer: BytesMut) -> impl Future<Output = io::Result<BytesMut>> {
+    fn read_into(&mut self, buffer: BytesMut) -> impl Future<Output = BufResult<()>> {
         let len = buffer.len();
         self.0
             .read_exact(buffer.slice_mut(0..len))
-            .map(|(result, buffer)| match result {
-                Ok(_len) => Ok(buffer.into_inner()),
-                Err(e) => Err(e),
-            })
+            .map(|(result, buffer)| (result.map(|_len| ()), buffer.into_inner()))
     }
 }
 

--- a/vortex-serde/src/io/object_store.rs
+++ b/vortex-serde/src/io/object_store.rs
@@ -17,8 +17,9 @@ use object_store::{ObjectStore, ObjectStoreScheme, WriteMultipart};
 use url::Url;
 use vortex_buffer::io_buf::IoBuf;
 use vortex_buffer::Buffer;
-use vortex_error::{vortex_bail, vortex_panic, VortexError, VortexResult};
+use vortex_error::{vortex_bail, VortexError, VortexResult};
 
+use super::BufResult;
 use crate::io::{VortexRead, VortexReadAt, VortexWrite};
 
 pub trait ObjectStoreExt {
@@ -109,29 +110,27 @@ impl ObjectStoreReadAt {
 }
 
 impl VortexReadAt for ObjectStoreReadAt {
-    async fn read_at_into(&self, pos: u64, mut buffer: BytesMut) -> io::Result<BytesMut> {
+    async fn read_at_into(&self, pos: u64, mut buffer: BytesMut) -> BufResult<()> {
         let start_range = pos as usize;
-        let bytes = self
+        match self
             .object_store
             .get_range(&self.location, start_range..(start_range + buffer.len()))
-            .await?;
-        buffer.as_mut().copy_from_slice(bytes.as_ref());
-        Ok(buffer)
+            .await
+        {
+            Ok(bytes) => {
+                buffer.as_mut().copy_from_slice(bytes.as_ref());
+                (Ok(()), buffer)
+            }
+            Err(err) => (Err(err.into()), buffer),
+        }
     }
 
-    async fn size(&self) -> u64 {
+    async fn size(&self) -> io::Result<u64> {
         self.object_store
             .head(&self.location)
             .await
-            .map_err(VortexError::ObjectStore)
-            .unwrap_or_else(|err| {
-                vortex_panic!(
-                    err,
-                    "Failed to get size of object at location {}",
-                    self.location
-                )
-            })
-            .size as u64
+            .map(|m| m.size as u64)
+            .map_err(|e| io::Error::from(VortexError::ObjectStore(e)))
     }
 }
 

--- a/vortex-serde/src/io/offset.rs
+++ b/vortex-serde/src/io/offset.rs
@@ -1,7 +1,9 @@
 use std::future::Future;
+use std::io;
 
 use bytes::BytesMut;
 
+use super::BufResult;
 use crate::io::VortexReadAt;
 
 /// An adapter that offsets all reads by a fixed amount.
@@ -17,11 +19,7 @@ impl<R: VortexReadAt> OffsetReadAt<R> {
 }
 
 impl<R: VortexReadAt> VortexReadAt for OffsetReadAt<R> {
-    fn read_at_into(
-        &self,
-        pos: u64,
-        buffer: BytesMut,
-    ) -> impl Future<Output = std::io::Result<BytesMut>> {
+    fn read_at_into(&self, pos: u64, buffer: BytesMut) -> impl Future<Output = BufResult<()>> {
         self.read.read_at_into(pos + self.offset, buffer)
     }
 
@@ -29,7 +27,7 @@ impl<R: VortexReadAt> VortexReadAt for OffsetReadAt<R> {
         self.read.performance_hint()
     }
 
-    async fn size(&self) -> u64 {
-        self.read.size().await - self.offset
+    async fn size(&self) -> io::Result<u64> {
+        Ok(self.read.size().await? - self.offset)
     }
 }

--- a/vortex-serde/src/io/read.rs
+++ b/vortex-serde/src/io/read.rs
@@ -7,17 +7,44 @@ use bytes::BytesMut;
 use vortex_buffer::Buffer;
 use vortex_error::vortex_err;
 
-pub trait VortexRead {
-    fn read_into(&mut self, buffer: BytesMut) -> impl Future<Output = io::Result<BytesMut>>;
+/// Result type for asynchronous IO operations that receive an owned buffer.
+///
+/// On error, to avoid leaking the buffer on error it must be returned separately
+/// from the IO operation result.
+pub type BufResult<T> = (io::Result<T>, BytesMut);
+
+pub trait Discard {
+    type Error;
+
+    fn discard_ok(self) -> Result<(), Self::Error>;
 }
 
-#[allow(clippy::len_without_is_empty)]
+impl<T, E> Discard for Result<T, E> {
+    type Error = E;
+
+    fn discard_ok(self) -> Result<(), E> {
+        self.map(|_| ())
+    }
+}
+
+/// A type that supports asynchronous read operations with an owned buffer.
+///
+/// The caller must provide an owned mutable buffer to the reader, which will take ownership
+/// of the buffer and return it afterward.
+///
+/// See also [`VortexReadAt`] for a variant that allows for positional read.
+pub trait VortexRead {
+    fn read_into(&mut self, buffer: BytesMut) -> impl Future<Output = BufResult<()>>;
+}
+
+// TODO(aduffy): remove the Send + Sync bound to allow for thread-per-core execution.
+/// A type that supports asynchronous positional reads
 pub trait VortexReadAt: Send + Sync {
     fn read_at_into(
         &self,
         pos: u64,
         buffer: BytesMut,
-    ) -> impl Future<Output = io::Result<BytesMut>> + Send;
+    ) -> impl Future<Output = BufResult<()>> + Send;
 
     // TODO(ngates): the read implementation should be able to hint at its latency/throughput
     //  allowing the caller to make better decisions about how to coalesce reads.
@@ -26,7 +53,7 @@ pub trait VortexReadAt: Send + Sync {
     }
 
     /// Size of the underlying file in bytes
-    fn size(&self) -> impl Future<Output = u64>;
+    fn size(&self) -> impl Future<Output = io::Result<u64>>;
 }
 
 impl<T: VortexReadAt> VortexReadAt for Arc<T> {
@@ -34,7 +61,7 @@ impl<T: VortexReadAt> VortexReadAt for Arc<T> {
         &self,
         pos: u64,
         buffer: BytesMut,
-    ) -> impl Future<Output = io::Result<BytesMut>> + Send {
+    ) -> impl Future<Output = BufResult<()>> + Send {
         T::read_at_into(self, pos, buffer)
     }
 
@@ -42,29 +69,37 @@ impl<T: VortexReadAt> VortexReadAt for Arc<T> {
         T::performance_hint(self)
     }
 
-    async fn size(&self) -> u64 {
+    async fn size(&self) -> io::Result<u64> {
         T::size(self).await
     }
 }
 
 impl VortexRead for BytesMut {
-    async fn read_into(&mut self, buffer: BytesMut) -> io::Result<BytesMut> {
+    async fn read_into(&mut self, buffer: BytesMut) -> BufResult<()> {
         if buffer.len() > self.len() {
-            Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                vortex_err!("unexpected eof"),
-            ))
+            (
+                Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    vortex_err!("unexpected eof"),
+                )),
+                buffer,
+            )
         } else {
-            Ok(self.split_to(buffer.len()))
+            (Ok(()), self.split_to(buffer.len()))
         }
     }
 }
 
 impl<R: VortexReadAt> VortexRead for Cursor<R> {
-    async fn read_into(&mut self, buffer: BytesMut) -> io::Result<BytesMut> {
-        let res = R::read_at_into(self.get_ref(), self.position(), buffer).await?;
-        self.set_position(self.position() + res.len() as u64);
-        Ok(res)
+    async fn read_into(&mut self, buffer: BytesMut) -> BufResult<()> {
+        let (res, buffer) = R::read_at_into(self.get_ref(), self.position(), buffer).await;
+        match res {
+            Ok(()) => {
+                self.set_position(self.position() + buffer.len() as u64);
+                (Ok(()), buffer)
+            }
+            err => (err.discard_ok(), buffer),
+        }
     }
 }
 
@@ -73,7 +108,7 @@ impl<R: ?Sized + VortexReadAt> VortexReadAt for &R {
         &self,
         pos: u64,
         buffer: BytesMut,
-    ) -> impl Future<Output = io::Result<BytesMut>> + Send {
+    ) -> impl Future<Output = BufResult<()>> + Send {
         R::read_at_into(*self, pos, buffer)
     }
 
@@ -81,62 +116,64 @@ impl<R: ?Sized + VortexReadAt> VortexReadAt for &R {
         R::performance_hint(*self)
     }
 
-    async fn size(&self) -> u64 {
+    async fn size(&self) -> io::Result<u64> {
         R::size(*self).await
     }
 }
 
 impl VortexReadAt for Vec<u8> {
-    fn read_at_into(
-        &self,
-        pos: u64,
-        buffer: BytesMut,
-    ) -> impl Future<Output = io::Result<BytesMut>> {
+    fn read_at_into(&self, pos: u64, buffer: BytesMut) -> impl Future<Output = BufResult<()>> {
         VortexReadAt::read_at_into(self.as_slice(), pos, buffer)
     }
 
-    async fn size(&self) -> u64 {
-        self.len() as u64
+    async fn size(&self) -> io::Result<u64> {
+        Ok(self.len() as u64)
     }
 }
 
 impl VortexReadAt for [u8] {
-    async fn read_at_into(&self, pos: u64, mut buffer: BytesMut) -> io::Result<BytesMut> {
+    async fn read_at_into(&self, pos: u64, mut buffer: BytesMut) -> BufResult<()> {
         if buffer.len() + pos as usize > self.len() {
-            Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                vortex_err!("unexpected eof"),
-            ))
+            (
+                Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    vortex_err!("unexpected eof"),
+                )),
+                buffer,
+            )
         } else {
             let buffer_len = buffer.len();
             buffer.copy_from_slice(&self[pos as usize..][..buffer_len]);
-            Ok(buffer)
+            (Ok(()), buffer)
         }
     }
 
-    async fn size(&self) -> u64 {
-        self.len() as u64
+    async fn size(&self) -> io::Result<u64> {
+        Ok(self.len() as u64)
     }
 }
 
 impl VortexReadAt for Buffer {
-    async fn read_at_into(&self, pos: u64, mut buffer: BytesMut) -> io::Result<BytesMut> {
+    async fn read_at_into(&self, pos: u64, mut buffer: BytesMut) -> BufResult<()> {
         if buffer.len() + pos as usize > self.len() {
-            Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                vortex_err!("unexpected eof"),
-            ))
+            (
+                Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    vortex_err!("unexpected eof"),
+                )),
+                buffer,
+            )
         } else {
             let buffer_len = buffer.len();
             buffer.copy_from_slice(
                 self.slice(pos as usize..pos as usize + buffer_len)
                     .as_slice(),
             );
-            Ok(buffer)
+            (Ok(()), buffer)
         }
     }
 
-    async fn size(&self) -> u64 {
-        self.len() as u64
+    async fn size(&self) -> io::Result<u64> {
+        Ok(self.len() as u64)
     }
 }

--- a/vortex-serde/src/io/tokio.rs
+++ b/vortex-serde/src/io/tokio.rs
@@ -9,17 +9,17 @@ use tokio::fs::File;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::runtime::Runtime;
 use vortex_buffer::io_buf::IoBuf;
-use vortex_error::{VortexError, VortexUnwrap as _};
 
+use super::{BufResult, Discard};
 use crate::io::{VortexRead, VortexReadAt, VortexWrite};
 use crate::layouts::AsyncRuntime;
 
 pub struct TokioAdapter<IO>(pub IO);
 
 impl<R: AsyncRead + Unpin> VortexRead for TokioAdapter<R> {
-    async fn read_into(&mut self, mut buffer: BytesMut) -> io::Result<BytesMut> {
-        self.0.read_exact(buffer.as_mut()).await?;
-        Ok(buffer)
+    async fn read_into(&mut self, mut buffer: BytesMut) -> BufResult<()> {
+        let res = self.0.read_exact(buffer.as_mut()).await.discard_ok();
+        (res, buffer)
     }
 }
 
@@ -39,25 +39,29 @@ impl<W: AsyncWrite + Unpin> VortexWrite for TokioAdapter<W> {
 }
 
 impl VortexRead for File {
-    async fn read_into(&mut self, mut buffer: BytesMut) -> io::Result<BytesMut> {
-        self.read_exact(buffer.as_mut()).await?;
-        Ok(buffer)
+    async fn read_into(&mut self, mut buffer: BytesMut) -> BufResult<()> {
+        let res = self.read_exact(buffer.as_mut()).await;
+        (res.discard_ok(), buffer)
     }
 }
 
 impl VortexReadAt for File {
-    async fn read_at_into(&self, pos: u64, mut buffer: BytesMut) -> io::Result<BytesMut> {
-        let std_file = self.try_clone().await?.into_std().await;
-        std_file.read_exact_at(buffer.as_mut(), pos)?;
-        Ok(buffer)
+    async fn read_at_into(&self, pos: u64, mut buffer: BytesMut) -> BufResult<()> {
+        match self.try_clone().await {
+            Ok(std_file) => (
+                std_file
+                    .into_std()
+                    .await
+                    .read_exact_at(buffer.as_mut(), pos)
+                    .discard_ok(),
+                buffer,
+            ),
+            Err(err) => (Err(err), buffer),
+        }
     }
 
-    async fn size(&self) -> u64 {
-        self.metadata()
-            .await
-            .map_err(|err| VortexError::IOError(err).with_context("Failed to get file metadata"))
-            .vortex_unwrap()
-            .len()
+    async fn size(&self) -> io::Result<u64> {
+        self.metadata().await.map(|m| m.len())
     }
 }
 

--- a/vortex-serde/src/layouts/read/builder.rs
+++ b/vortex-serde/src/layouts/read/builder.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::sync::{Arc, RwLock};
 
 use vortex::{Array, ArrayDType};
@@ -65,9 +66,10 @@ impl<R: VortexReadAt> LayoutReaderBuilder<R> {
         self
     }
 
+    // Build the stream, execute it, etc.
     pub async fn build(self) -> VortexResult<LayoutBatchStream<R>> {
         let footer = LayoutDescriptorReader::new(self.layout_serde.clone())
-            .read_footer(&self.reader, self.size().await as u64)
+            .read_footer(&self.reader, self.size().await?)
             .await?;
         let batch_size = self.batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
         // TODO(robert): Propagate projection immediately instead of delegating to layouts, needs more restructuring
@@ -126,9 +128,9 @@ impl<R: VortexReadAt> LayoutReaderBuilder<R> {
         ))
     }
 
-    async fn size(&self) -> u64 {
+    async fn size(&self) -> io::Result<u64> {
         match self.size {
-            Some(s) => s,
+            Some(s) => Ok(s),
             None => self.reader.size().await,
         }
     }

--- a/vortex-serde/src/layouts/read/footer.rs
+++ b/vortex-serde/src/layouts/read/footer.rs
@@ -155,7 +155,9 @@ impl LayoutDescriptorReader {
         unsafe { buf.set_len(read_size) }
 
         let read_offset = file_size - read_size as u64;
-        buf = read.read_at_into(read_offset, buf).await?;
+        let (res, buffer) = read.read_at_into(read_offset, buf).await;
+        res?;
+        buf = buffer;
 
         let eof_loc = read_size - EOF_SIZE;
 

--- a/vortex-serde/src/layouts/read/stream.rs
+++ b/vortex-serde/src/layouts/read/stream.rs
@@ -214,9 +214,8 @@ async fn read_ranges<R: VortexReadAt>(
 
             let read_ft = reader.read_at_into(range.begin, buf);
 
-            read_ft.map(|result| {
-                result
-                    .map(|res| (id, res.freeze()))
+            read_ft.map(|(res, buffer)| {
+                res.map(|_| (id, buffer.freeze()))
                     .map_err(VortexError::from)
             })
         })

--- a/vortex-serde/src/message_reader.rs
+++ b/vortex-serde/src/message_reader.rs
@@ -37,8 +37,9 @@ impl<R: VortexRead> MessageReader<R> {
     async fn load_next_message(&mut self) -> VortexResult<bool> {
         let mut buffer = std::mem::take(&mut self.message);
         buffer.resize(FLATBUFFER_SIZE_LENGTH, 0);
-        let mut buffer = match self.read.read_into(buffer).await {
-            Ok(b) => b,
+        let (res, buffer) = self.read.read_into(buffer).await;
+        let mut buffer = match res {
+            Ok(()) => buffer,
             Err(e) => {
                 return match e.kind() {
                     io::ErrorKind::UnexpectedEof => Ok(false),
@@ -57,7 +58,9 @@ impl<R: VortexRead> MessageReader<R> {
 
         buffer.reserve(len as usize);
         unsafe { buffer.set_len(len as usize) };
-        self.message = self.read.read_into(buffer).await?;
+        let (res, buffer) = self.read.read_into(buffer).await;
+        res?;
+        self.message = buffer;
 
         // Validate that the message is valid a flatbuffer.
         root::<fb::Message>(&self.message).map_err(
@@ -121,7 +124,8 @@ impl<R: VortexRead> MessageReader<R> {
         // Issue a single read to grab all buffers
         let mut all_buffers = BytesMut::with_capacity(all_buffers_size);
         unsafe { all_buffers.set_len(all_buffers_size) };
-        let all_buffers = self.read.read_into(all_buffers).await?;
+        let (res, all_buffers) = self.read.read_into(all_buffers).await;
+        res?;
 
         if array_reader.read(all_buffers.freeze())?.is_some() {
             unreachable!("This is an implementation bug")
@@ -197,7 +201,9 @@ impl<R: VortexRead> MessageReader<R> {
 
         let mut buffer = BytesMut::with_capacity(total_len);
         unsafe { buffer.set_len(total_len) }
-        buffer = self.read.read_into(buffer).await?;
+        let (res, buf) = self.read.read_into(buffer).await;
+        res?;
+        buffer = buf;
         buffer.truncate(buffer_len);
         let page_buffer = Ok(Some(Buffer::from(buffer.freeze())));
         let _ = self.next().await?;


### PR DESCRIPTION
Currently our async IO traits have methods that receive an owned buffer (in the form of `BytesMut`) and return an `io::Result<BytesMut>` which gives the buffer back at the end.

The trouble is, in the case of an error the buffer will leak. This is not a problem yet since we currently allocate a fresh buffer for every IO operation, but as we move toward buffer pools and completion-based IO operations, we don't want to leak these buffers when IO errors occur.

This PR makes a new `BufResult<T>` which is just a `(io::Result<T>, BytesMut)` to ensure that you always return ownership of the buffer to the caller even in the event of IO failures.

Currently this doesn't change any behavior, but when we swtich to pre-allocated buffers and IO operations using those, it will matter.