### PR TITLE
fix: release-plz release only runs on "chore: release" PRs

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -58,8 +58,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   macos:
-    needs: release-plz
-    if: ${{ needs.release-plz.outputs.releases_created == 'true' }}
+    needs: release-plz-release
+    if: ${{ needs.release-plz-release.outputs.releases_created == 'true' }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -107,8 +107,8 @@ jobs:
           name: osx-wheels
           path: target/wheels
   linux:
-    needs: release-plz
-    if: ${{ needs.release-plz.outputs.releases_created == 'true' }}
+    needs: release-plz-release
+    if: ${{ needs.release-plz-release.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -146,8 +146,8 @@ jobs:
           name: linux-wheels
           path: target/wheels
   release:
-    needs: [ release-plz, macos, linux ]
-    if: ${{ needs.release-plz.outputs.releases_created == 'true' }}
+    needs: [ release-plz-release, macos, linux ]
+    if: ${{ needs.release-plz-release.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -10,9 +10,12 @@ on:
       - develop
 
 jobs:
-  release-plz:
-    name: Release-plz
+
+  # Release unpublished packages.
+  release-plz-release:
+    name: Release-plz release
     runs-on: ubuntu-latest
+    if: startsWith(github.event.head_commit.message, "chore: release")
     outputs:
       releases_created: ${{ steps.run-release-plz.outputs.releases_created }}  # Expose this step output as a job output
     steps:
@@ -20,15 +23,37 @@ jobs:
         with:
           # Needed to pull full commit history for release version number inference
           fetch-depth: 0
-
       - uses: ./.github/actions/cleanup
-
       - uses: ./.github/actions/setup-rust
       - uses: spiraldb/actions/.github/actions/setup-uv@0.2.0
-
       - name: Run release-plz
         id: run-release-plz
         uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # Create a PR with the new versions and changelog, preparing the next release.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Needed to pull full commit history for release version number inference
+          fetch-depth: 0
+      - uses: ./.github/actions/cleanup
+      - uses: ./.github/actions/setup-rust
+      - uses: spiraldb/actions/.github/actions/setup-uv@0.2.0
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
I also updated to use the new release-pr command to generate PRs in a race-free way.