### PR TITLE
ci: split CI into separate moldy jobs

### DIFF
--- a/.github/actions/cleanup/action.yml
+++ b/.github/actions/cleanup/action.yml
@@ -15,8 +15,6 @@ runs:
           /opt/ghc \
           /usr/lib/mono \
           /usr/local/julia* \
-          /usr/local/lib/android \
-          /usr/local/lib/node_modules \
           /usr/local/share/chromium \
           /usr/local/share/powershell \
           /usr/share/dotnet \

--- a/.github/actions/setup-flatc/action.yml
+++ b/.github/actions/setup-flatc/action.yml
@@ -1,0 +1,12 @@
+name: "Setup flatc"
+description: "Download and install flatc binary"
+runs:
+  using: "composite"
+  steps:
+    - name: Download flatc
+      id: download-flatc
+      shell: bash
+      run: |
+        wget -O /tmp/flatc.zip https://github.com/google/flatbuffers/releases/download/v24.3.25/Linux.flatc.binary.clang++-15.zip
+        unzip /tmp/flatc.zip flatc
+        mv flatc /usr/local/bin/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,8 @@ jobs:
       # setup mold linker
       - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/cleanup
+      - uses: ./.github/actions/setup-rust
       - name: Rust Build (Default features)
         run: cargo build --all-targets
 
@@ -79,8 +79,8 @@ jobs:
     steps:
       - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/cleanup
+      - uses: ./.github/actions/setup-rust
       - name: Rust Build (All Features)
         run: cargo build --all-features --all-targets
 
@@ -130,8 +130,8 @@ jobs:
     steps:
       - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/cleanup
+      - uses: ./.github/actions/setup-rust
       - uses: spiraldb/actions/.github/actions/setup-uv@0.2.0
       # Required to run benchmarks
       - name: Install DuckDB

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,8 @@ jobs:
     steps:
       # setup mold linker
       - uses: rui314/setup-mold@v1
-      - uses: ./.github/actions/setup-rust
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/cleanup
       - name: Rust Build (Default features)
         run: cargo build --all-targets
@@ -79,6 +79,7 @@ jobs:
     steps:
       - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/cleanup
       - name: Rust Build (All Features)
         run: cargo build --all-features --all-targets
@@ -129,9 +130,8 @@ jobs:
     steps:
       - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/cleanup
-
       - uses: ./.github/actions/setup-rust
+      - uses: ./.github/actions/cleanup
       - uses: spiraldb/actions/.github/actions/setup-uv@0.2.0
       # Required to run benchmarks
       - name: Install DuckDB

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "develop" ]
-  pull_request: { }
-  workflow_dispatch: { }
+    branches: ["develop"]
+  pull_request: {}
+  workflow_dispatch: {}
 
 permissions:
   actions: read
@@ -15,14 +15,11 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  build:
-    name: 'build'
+  python-lint:
+    name: "Python (lint)"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/cleanup
-
-      - uses: ./.github/actions/setup-rust
       - uses: spiraldb/actions/.github/actions/setup-uv@0.2.0
 
       - name: Python Lint - Format
@@ -30,20 +27,12 @@ jobs:
       - name: Python Lint - Ruff
         run: uv run ruff check .
 
-      - name: Rust Lint - Format
-        run: cargo fmt --all --check
-      - name: Rust Lint - Clippy
-        run: cargo clippy --all-features --all-targets
-      - name: Docs
-        run: cargo doc --no-deps
-      - name: Rust Test
-        run: cargo test --workspace --all-features
-
-      - name: Rust Build (Default features)
-        run: cargo build --all-targets
-
-      - name: Rust Build (All Features)
-        run: cargo build --all-features --all-targets
+  python-test:
+    name: "Python (test)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: spiraldb/actions/.github/actions/setup-uv@0.2.0
 
       - name: Pytest - PyVortex
         run: |
@@ -62,6 +51,58 @@ jobs:
           (cd pyvortex && uv run maturin develop)
 
           (cd docs && uv run make html)
+
+  rust-docs:
+    name: "Rust (docs)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-rust
+      - name: Docs
+        run: cargo doc --no-deps
+
+  build-default:
+    name: "Build (default)"
+    runs-on: ubuntu-latest
+    steps:
+      # setup mold linker
+      - uses: rui314/setup-mold@v1
+      - uses: ./.github/actions/setup-rust
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cleanup
+      - name: Rust Build (Default features)
+        run: cargo build --all-targets
+
+  build-all:
+    name: "Build (all-features)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rui314/setup-mold@v1
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cleanup
+      - name: Rust Build (All Features)
+        run: cargo build --all-features --all-targets
+
+  rust-test:
+    name: "Rust (tests)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rui314/setup-mold@v1
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cleanup
+      - name: Rust Lint - Format
+        run: cargo fmt --all --check
+      - name: Rust Lint - Clippy
+        run: cargo clippy --all-features --all-targets
+      - name: Rust Test
+        run: cargo test --workspace --all-features
+
+  license-check:
+    name: License check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cleanup
       - name: License Check
         run: cargo install --locked cargo-deny && cargo deny check
       - uses: rustsec/audit-check@v2.0.0
@@ -70,11 +111,12 @@ jobs:
           ignore: "RUSTSEC-2023-0086"
 
   miri:
-    name: 'miri'
+    name: "miri"
     runs-on: ubuntu-latest
     env:
       MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-backtrace=full
     steps:
+      - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cleanup
       - uses: ./.github/actions/setup-rust
@@ -82,9 +124,10 @@ jobs:
         run: cargo miri test
 
   bench-test:
-    name: 'bench test'
+    name: "bench test"
     runs-on: ubuntu-latest
     steps:
+      - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cleanup
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
       # setup mold linker
       - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/cleanup
       - uses: ./.github/actions/setup-rust
       - name: Rust Build (Default features)
         run: cargo build --all-targets
@@ -78,6 +79,7 @@ jobs:
     steps:
       - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/cleanup
       - uses: ./.github/actions/setup-rust
       - name: Rust Build (All Features)
         run: cargo build --all-features --all-targets
@@ -126,6 +128,7 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
+      - uses: ./.github/actions/cleanup
       - uses: spiraldb/actions/.github/actions/setup-uv@0.2.0
       # Required to run benchmarks
       - name: Install DuckDB
@@ -141,6 +144,7 @@ jobs:
     steps:
       - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/cleanup
       - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/setup-flatc
       - name: Install Protoc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,3 +140,22 @@ jobs:
           version: v1.0.0
       - name: Rust Bench as test
         run: cargo bench --bench '*[!noci]' -- --test
+
+  generated-files:
+    name: "Check generated proto/fbs files are up to date"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rui314/setup-mold@v1
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cleanup
+      - uses: ./.github/actions/setup-rust
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+      - name: "regenerate all .fbs/.proto Rust code"
+        run: |
+          cargo xtask generate-fbs
+          cargo xtask generate-proto
+      - name: "Make sure no files changed after regenerating"
+        run: |
+          git status | grep 'working tree clean'
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,6 @@ jobs:
       # setup mold linker
       - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/cleanup
       - uses: ./.github/actions/setup-rust
       - name: Rust Build (Default features)
         run: cargo build --all-targets
@@ -79,7 +78,6 @@ jobs:
     steps:
       - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/cleanup
       - uses: ./.github/actions/setup-rust
       - name: Rust Build (All Features)
         run: cargo build --all-features --all-targets
@@ -90,7 +88,6 @@ jobs:
     steps:
       - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/cleanup
       - name: Rust Lint - Format
         run: cargo fmt --all --check
       - name: Rust Lint - Clippy
@@ -103,7 +100,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/cleanup
       - name: License Check
         run: cargo install --locked cargo-deny && cargo deny check
       - uses: rustsec/audit-check@v2.0.0
@@ -119,7 +115,6 @@ jobs:
     steps:
       - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/cleanup
       - uses: ./.github/actions/setup-rust
       - name: Run tests with Miri
         run: cargo miri test
@@ -130,7 +125,6 @@ jobs:
     steps:
       - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/cleanup
       - uses: ./.github/actions/setup-rust
       - uses: spiraldb/actions/.github/actions/setup-uv@0.2.0
       # Required to run benchmarks
@@ -147,8 +141,8 @@ jobs:
     steps:
       - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/cleanup
       - uses: ./.github/actions/setup-rust
+      - uses: ./.github/actions/setup-flatc
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
       - name: "regenerate all .fbs/.proto Rust code"
@@ -157,5 +151,5 @@ jobs:
           cargo xtask generate-proto
       - name: "Make sure no files changed after regenerating"
         run: |
-          git status | grep 'working tree clean'
+          test -z "$(git status --porcelain)"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,8 @@ jobs:
     steps:
       - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/cleanup
+      - uses: ./.github/actions/setup-rust
       - uses: spiraldb/actions/.github/actions/setup-uv@0.2.0
       # Required to run benchmarks
       - name: Install DuckDB

--- a/encodings/fsst/src/compute.rs
+++ b/encodings/fsst/src/compute.rs
@@ -170,6 +170,7 @@ mod tests {
     use crate::{fsst_compress, fsst_train_compressor};
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_compare_fsst() {
         let lhs = VarBinArray::from_iter(
             [


### PR DESCRIPTION
* use [`mold`](https://github.com/rui314/mold) linker for building Rust code
* Splits into several parallel jobs
* disables one test that was taking ~7 minutes with miri, cutting the miri time down considerably

Shaves ~40% off of CI times