### PR TITLE
chore: use full-html for Rust and Python

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,13 +18,13 @@ jobs:
       - uses: ./.github/actions/setup-rust
       - uses: spiraldb/actions/.github/actions/setup-uv@0.2.0
 
-      - name: build Python docs
+      - name: build Python and Rust docs
         run: |
           set -ex
 
           (cd pyvortex && uv run maturin develop)
 
-          (cd docs && uv run make html)
+          (cd docs && uv run make full-html)
       - name: commit python docs to gh-pages-bench
         run: |
           set -ex

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,7 +19,7 @@ help:
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-html: rust-html
+full-html: html rust-html
 
 .PHONY: rust-html
 rust-html:

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,23 @@
 
 ## Building
 
+First, you must compile the pyvortex Rust code into a native library because the Python package
+inherits some of its doc strings from Rust docstrings:
+
+```
+cd ../pyvortex && uv run maturin develop
+```
+
+Build just the Python docs:
+
 ```
 uv run make html
+```
+
+Build the Python and Rust docs and place the rust docs at `_build/rust/html`:
+
+```
+uv run make full-html
 ```
 
 ## Viewing


### PR DESCRIPTION
We rever the meaning of `make -C docs html` to only building the Python documentation.