### PR TITLE
fix: remove a release-plz race condition

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,6 +3,7 @@
 changelog_path = "./CHANGELOG.md"
 git_release_enable = false
 git_tag_enable = false
+release_always = false # https://github.com/MarcoIeni/release-plz/issues/1805#issuecomment-2453048989
 
 # This uses the single-changelog template from https://release-plz.ieni.dev/docs/extra/single-changelog
 [changelog]


### PR DESCRIPTION
Release-plz, by default, will attempt to publish any commit if the verison in that commit is not present in crates.io. This flag causes release-plz to only attempt to publish commits created by merging pull requests with a name matching `release-plz-.*`.

We observed this timeline:

1. The release-plz release pull request was squash-merged into main as Commit 1. [link](https://github.com/spiraldb/vortex/commit/453fa610f2279fd9e4c53431caabfa048ac61079)
2. The release-plz action runs on Commit 1. [link](https://github.com/spiraldb/vortex/actions/runs/11630848959/job/32390669039)
3. While (2) runs, another PR is squash-merged into main as Commit 2. [link](https://github.com/spiraldb/vortex/commit/f83a0933063e9d12f20938c0f0e9a94e4c43f652)
4. A second release-plz action starts running on Commit 2. [link](https://github.com/spiraldb/vortex/actions/runs/11630955081/job/32390985113)
5. These two actions race with one another to publish crates.
6. The action for Commit 2 rapidly notices that most crates are already published.
7. The action for Commit 1 and the action for Commit 2 are racing to publish some crate. If Commit 2 wins the race then the published crate will contain Commit 2 which is not in CHANGELOG.md!

See also:
1. My first report: https://spiraldb.slack.com/archives/C07BV3GKAJ2/p1730473883295019
2. Detailed explanation: https://spiraldb.slack.com/archives/C07BV3GKAJ2/p1730490564273719
3. An (in fact, unrelated) issue in which the release-plz dev suggested `release_always = False`: https://github.com/MarcoIeni/release-plz/issues/1805