### PR TITLE
fix: make target needs at least one rule

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ permissions:
   deployments: write
 
 jobs:
-  deploy-python-docs:
+  deploy-docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,6 +20,7 @@ help:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 full-html: html rust-html
+	true  # need a non-empty rule to prevent matching the %: rule.
 
 rust-html:
 	cargo doc --no-deps --workspace --all-features --target-dir $(BUILDDIR)/html/rust


### PR DESCRIPTION
Without the rule `x: y` just specifies a new dependency and Make matches `x` with the `%` rule above. By providing a rule it takes prcedence over matching the `%` rule.