### PR TITLE
refactor: move Array enum out of public interface

### DIFF
--- a/vortex-array/src/data.rs
+++ b/vortex-array/src/data.rs
@@ -116,27 +116,6 @@ impl ArrayData {
     }
 }
 
-impl ToArray for ArrayData {
-    fn to_array(&self) -> Array {
-        Array::Data(self.clone())
-    }
-}
-
-impl From<Array> for ArrayData {
-    fn from(value: Array) -> ArrayData {
-        match value {
-            Array::Data(d) => d,
-            Array::View(_) => value.with_dyn(|v| v.to_array_data()),
-        }
-    }
-}
-
-impl From<ArrayData> for Array {
-    fn from(value: ArrayData) -> Array {
-        Array::Data(value)
-    }
-}
-
 impl Statistics for ArrayData {
     fn get(&self, stat: Stat) -> Option<Scalar> {
         self.stats_map

--- a/vortex-array/src/typed.rs
+++ b/vortex-array/src/typed.rs
@@ -5,7 +5,7 @@ use vortex_dtype::DType;
 use vortex_error::{vortex_bail, vortex_panic, VortexError, VortexResult};
 
 use crate::stats::StatsSet;
-use crate::{Array, ArrayData, ArrayDef, IntoArray, ToArray, TryDeserializeArrayMetadata};
+use crate::{Array, ArrayData, ArrayDef, Inner, IntoArray, ToArray, TryDeserializeArrayMetadata};
 
 /// Container for an array with all the associated implementation type information (encoding reference and ID, actual array type, metadata type).
 #[derive(Debug, Clone)]
@@ -23,7 +23,7 @@ impl<D: ArrayDef> TypedArray<D> {
         children: Arc<[Array]>,
         stats: StatsSet,
     ) -> VortexResult<Self> {
-        let array = Array::Data(ArrayData::try_new(
+        let array = ArrayData::try_new(
             D::ENCODING,
             dtype,
             len,
@@ -31,7 +31,8 @@ impl<D: ArrayDef> TypedArray<D> {
             buffer,
             children,
             stats,
-        )?);
+        )?
+        .into();
         Ok(Self {
             array,
             lazy_metadata: OnceLock::new(),
@@ -39,8 +40,8 @@ impl<D: ArrayDef> TypedArray<D> {
     }
 
     pub fn metadata(&self) -> &D::Metadata {
-        match &self.array {
-            Array::Data(d) => d
+        match &self.array.0 {
+            Inner::Data(d) => d
                 .metadata()
                 .as_any()
                 .downcast_ref::<D::Metadata>()
@@ -52,12 +53,12 @@ impl<D: ArrayDef> TypedArray<D> {
                         D::ENCODING.id().as_ref(),
                     )
                 }),
-            Array::View(v) => self
+            Inner::View(v) => self
                 .lazy_metadata
                 .get_or_init(|| {
                     D::Metadata::try_deserialize_metadata(v.metadata()).unwrap_or_else(|err| {
                         vortex_panic!(
-                            "Failed to deserialize ArrayView metadata for typed array with ID {} and encoding {}: {}", 
+                            "Failed to deserialize ArrayView metadata for typed array with ID {} and encoding {}: {}",
                             D::ID.as_ref(),
                             D::ENCODING.id().as_ref(),
                             err

--- a/vortex-array/src/view.rs
+++ b/vortex-array/src/view.rs
@@ -149,7 +149,8 @@ impl ArrayView {
 
     pub fn children(&self) -> Vec<Array> {
         let mut collector = ChildrenCollector::default();
-        Array::View(self.clone())
+        self.clone()
+            .into_array()
             .with_dyn(|a| a.accept(&mut collector))
             .vortex_expect("Failed to get children");
         collector.children
@@ -260,17 +261,5 @@ impl Statistics for ArrayView {
             .ok()?
             .get(stat)
             .cloned()
-    }
-}
-
-impl ToArray for ArrayView {
-    fn to_array(&self) -> Array {
-        Array::View(self.clone())
-    }
-}
-
-impl IntoArray for ArrayView {
-    fn into_array(self) -> Array {
-        Array::View(self)
     }
 }

--- a/vortex-serde/src/messages.rs
+++ b/vortex-serde/src/messages.rs
@@ -111,22 +111,10 @@ impl WriteFlatBuffer for IPCArray<'_> {
         let column_data = self.0;
 
         let encoding = column_data.encoding().id().code();
-        let metadata = match column_data {
-            Array::Data(d) => {
-                let metadata = d
-                    .metadata()
-                    .try_serialize_metadata()
-                    // TODO(ngates): should we serialize externally to here?
-                    .vortex_expect("ArrayData is missing metadata during serialization");
-                Some(fbb.create_vector(metadata.as_ref()))
-            }
-            Array::View(v) => Some(
-                fbb.create_vector(
-                    v.metadata()
-                        .vortex_expect("ArrayView is missing metadata during serialization"),
-                ),
-            ),
-        };
+        let metadata = column_data
+            .metadata()
+            .vortex_expect("IPCArray is missing metadata during serialization");
+        let metadata = Some(fbb.create_vector(metadata.as_ref()));
 
         // Assign buffer indices for all child arrays.
         // The second tuple element holds the buffer_index for this Array subtree. If this array


### PR DESCRIPTION
Makes `Array` an opaque struct, containing a (private) inner enum with our two current variants.

In the future we can make changes to the inner enum without a breaking API change.

The other place this would be useful is for `Buffer`. If folks like this change can make that one as a follow up