### PR TITLE
feat: teach LayoutBatchStream to filter by indices

### DIFF
--- a/pyvortex/python/vortex/dataset.py
+++ b/pyvortex/python/vortex/dataset.py
@@ -230,7 +230,9 @@ class VortexDataset(pyarrow.dataset.Dataset):
         table : :class:`.pyarrow.Table`
 
         """
-        return self._dataset.to_array(columns=columns, row_filter=filter).take(encoding.array(indices)).to_arrow_table()
+        return self._dataset.to_array(
+            columns=columns, row_filter=filter, indices=encoding.array(indices)
+        ).to_arrow_table()
 
     def to_record_batch_reader(
         self,

--- a/pyvortex/src/io.rs
+++ b/pyvortex/src/io.rs
@@ -125,14 +125,15 @@ use crate::{PyArray, TOKIO_RUNTIME};
 /// >>> # b.to_arrow_array()
 ///
 #[pyfunction]
-#[pyo3(signature = (path, *, projection = None, row_filter = None))]
+#[pyo3(signature = (path, *, projection = None, row_filter = None, indices = None))]
 pub fn read_path(
     path: Bound<PyString>,
     projection: Option<Vec<Bound<PyAny>>>,
     row_filter: Option<&Bound<PyExpr>>,
+    indices: Option<&PyArray>,
 ) -> PyResult<PyArray> {
     let dataset = TOKIO_RUNTIME.block_on(TokioFileDataset::try_new(path.extract()?))?;
-    dataset.to_array(projection, row_filter)
+    dataset.to_array(projection, row_filter, indices)
 }
 
 /// Read a vortex struct array from a URL.
@@ -177,14 +178,15 @@ pub fn read_path(
 /// >>> a = vortex.io.read_url("file:/path/to/dataset.vortex")  # doctest: +SKIP
 ///
 #[pyfunction]
-#[pyo3(signature = (url, *, projection = None, row_filter = None))]
+#[pyo3(signature = (url, *, projection = None, row_filter = None, indices = None))]
 pub fn read_url(
     url: Bound<PyString>,
     projection: Option<Vec<Bound<PyAny>>>,
     row_filter: Option<&Bound<PyExpr>>,
+    indices: Option<&PyArray>,
 ) -> PyResult<PyArray> {
     let dataset = TOKIO_RUNTIME.block_on(ObjectStoreUrlDataset::try_new(url.extract()?))?;
-    dataset.to_array(projection, row_filter)
+    dataset.to_array(projection, row_filter, indices)
 }
 
 /// Write a vortex struct array to the local filesystem.

--- a/pyvortex/test/test_dataset.py
+++ b/pyvortex/test/test_dataset.py
@@ -24,8 +24,8 @@ def ds(tmpdir_factory) -> vortex.dataset.VortexDataset:
     if not os.path.exists(fname):
         a = pa.array([record(x) for x in range(1_000_000)])
         arr = vortex.encoding.compress(vortex.array(a))
-        vortex.io.write_path(arr, "/tmp/foo.vortex")
-    return vortex.dataset.VortexDataset.from_path("/tmp/foo.vortex")
+        vortex.io.write_path(arr, str(fname))
+    return vortex.dataset.VortexDataset.from_path(str(fname))
 
 
 def test_schema(ds):

--- a/vortex-serde/src/layouts/read/builder.rs
+++ b/vortex-serde/src/layouts/read/builder.rs
@@ -19,7 +19,7 @@ pub struct LayoutBatchStreamBuilder<R> {
     layout_serde: LayoutDeserializer,
     projection: Option<Projection>,
     size: Option<u64>,
-    indices: Option<Array>,
+    row_mask: Option<Array>,
     row_filter: Option<RowFilter>,
 }
 
@@ -29,9 +29,9 @@ impl<R: VortexReadAt> LayoutBatchStreamBuilder<R> {
             reader,
             layout_serde,
             projection: None,
-            row_filter: None,
             size: None,
-            indices: None,
+            row_mask: None,
+            row_filter: None,
         }
     }
 
@@ -46,12 +46,12 @@ impl<R: VortexReadAt> LayoutBatchStreamBuilder<R> {
     }
 
     pub fn with_indices(mut self, array: Array) -> Self {
-        // TODO(#441): Allow providing boolean masks
         assert!(
-            array.dtype().is_int(),
-            "Mask arrays have to be integer arrays"
+            !array.dtype().is_nullable() && (array.dtype().is_int() || array.dtype().is_boolean()),
+            "Mask arrays have to be non-nullable integer or boolean arrays"
         );
-        self.indices = Some(array);
+
+        self.row_mask = Some(array);
         self
     }
 
@@ -96,10 +96,16 @@ impl<R: VortexReadAt> LayoutBatchStreamBuilder<R> {
             })
             .transpose()?;
 
-        let indices_mask = self
-            .indices
+        let row_mask = self
+            .row_mask
             .as_ref()
-            .map(|indices| RowMask::from_index_array(indices, 0, row_count as usize))
+            .map(|row_mask| {
+                if row_mask.dtype().is_int() {
+                    RowMask::from_index_array(row_mask, 0, row_count as usize)
+                } else {
+                    RowMask::from_mask_array(row_mask, 0, row_count as usize)
+                }
+            })
             .transpose()?;
 
         Ok(LayoutBatchStream::new(
@@ -109,7 +115,7 @@ impl<R: VortexReadAt> LayoutBatchStreamBuilder<R> {
             message_cache,
             projected_dtype,
             row_count,
-            indices_mask,
+            row_mask,
         ))
     }
 

--- a/vortex-serde/src/layouts/read/builder.rs
+++ b/vortex-serde/src/layouts/read/builder.rs
@@ -5,6 +5,7 @@ use vortex_error::VortexResult;
 use vortex_expr::Select;
 use vortex_schema::projection::Projection;
 
+use super::RowMask;
 use crate::io::VortexReadAt;
 use crate::layouts::read::cache::{LayoutMessageCache, LazyDeserializedDType, RelativeLayoutCache};
 use crate::layouts::read::context::LayoutDeserializer;
@@ -87,13 +88,18 @@ impl<R: VortexReadAt> LayoutBatchStreamBuilder<R> {
 
         let filter_reader = self
             .row_filter
-            .as_ref()
-            .map(|filter| {
+            .map(|row_filter| {
                 footer.layout(
-                    Scan::new(Some(Arc::new(filter.clone()))),
+                    Scan::new(Some(Arc::new(row_filter))),
                     RelativeLayoutCache::new(message_cache.clone(), footer_dtype),
                 )
             })
+            .transpose()?;
+
+        let indices_mask = self
+            .indices
+            .as_ref()
+            .map(|indices| RowMask::from_index_array(indices, 0, row_count as usize))
             .transpose()?;
 
         Ok(LayoutBatchStream::new(
@@ -103,6 +109,7 @@ impl<R: VortexReadAt> LayoutBatchStreamBuilder<R> {
             message_cache,
             projected_dtype,
             row_count,
+            indices_mask,
         ))
     }
 

--- a/vortex-serde/src/layouts/read/mask.rs
+++ b/vortex-serde/src/layouts/read/mask.rs
@@ -121,6 +121,21 @@ impl RowMask {
         }
     }
 
+    /// Unset, in place, any bits that are unset in `other`.
+    pub fn and_inplace(&mut self, other: &RowMask) -> VortexResult<()> {
+        if self.begin != other.begin || self.end != other.end {
+            vortex_bail!(
+                "begin and ends must match: {}-{} {}-{}",
+                self.begin,
+                self.end,
+                other.begin,
+                other.end
+            );
+        }
+        self.values.and_inplace(&other.values);
+        Ok(())
+    }
+
     /// Filter array with this `RowMask`.
     ///
     /// This function assumes that Array is no longer than the mask length and that the mask starts on same offset as the array,

--- a/vortex-serde/src/layouts/read/stream.rs
+++ b/vortex-serde/src/layouts/read/stream.rs
@@ -36,7 +36,7 @@ pub struct LayoutBatchStream<R> {
     filter_reader: Option<Box<dyn LayoutReader>>,
     messages_cache: Arc<RwLock<LayoutMessageCache>>,
     splits: VecDeque<(usize, usize)>,
-    indices_mask: Option<RowMask>,
+    row_mask: Option<RowMask>,
     current_selector: Option<RowMask>,
     state: StreamingState<R>,
 }
@@ -49,7 +49,7 @@ impl<R: VortexReadAt> LayoutBatchStream<R> {
         messages_cache: Arc<RwLock<LayoutMessageCache>>,
         dtype: DType,
         row_count: u64,
-        indices_mask: Option<RowMask>,
+        row_mask: Option<RowMask>,
     ) -> Self {
         LayoutBatchStream {
             dtype,
@@ -59,7 +59,7 @@ impl<R: VortexReadAt> LayoutBatchStream<R> {
             filter_reader,
             messages_cache,
             splits: VecDeque::new(),
-            indices_mask,
+            row_mask,
             current_selector: None,
             state: StreamingState::AddSplits,
         }
@@ -133,8 +133,8 @@ impl<R: VortexReadAt + Unpin + 'static> Stream for LayoutBatchStream<R> {
                     };
 
                     self.state = if self.filter_reader.is_some() {
-                        if let Some(indices_mask) = &self.indices_mask {
-                            if indices_mask
+                        if let Some(row_mask) = &self.row_mask {
+                            if row_mask
                                 .slice(new_selector.begin(), new_selector.end())
                                 .is_empty()
                             {
@@ -146,9 +146,9 @@ impl<R: VortexReadAt + Unpin + 'static> Stream for LayoutBatchStream<R> {
                         self.current_selector = Some(new_selector);
                         StreamingState::Filter
                     } else {
-                        if let Some(indices_mask) = &self.indices_mask {
+                        if let Some(row_mask) = &self.row_mask {
                             new_selector.and_inplace(
-                                &indices_mask.slice(new_selector.begin(), new_selector.end()),
+                                &row_mask.slice(new_selector.begin(), new_selector.end()),
                             )?;
                         }
                         self.current_selector = Some(new_selector);
@@ -182,12 +182,10 @@ impl<R: VortexReadAt + Unpin + 'static> Stream for LayoutBatchStream<R> {
                                 });
                             }
                             BatchRead::Batch(mut batch) => {
-                                if let Some(indices_mask) = &self.indices_mask {
+                                if let Some(row_mask) = &self.row_mask {
                                     batch = and(
                                         batch,
-                                        indices_mask
-                                            .slice(sel_begin, sel_end)
-                                            .to_predicate_array()?,
+                                        row_mask.slice(sel_begin, sel_end).to_predicate_array()?,
                                     )?;
                                 }
 

--- a/vortex-serde/src/layouts/read/stream.rs
+++ b/vortex-serde/src/layouts/read/stream.rs
@@ -10,6 +10,7 @@ use futures_util::future::BoxFuture;
 use futures_util::{stream, FutureExt, StreamExt, TryStreamExt};
 use itertools::Itertools;
 use vortex_array::array::ChunkedArray;
+use vortex_array::compute::and;
 use vortex_array::stats::ArrayStatistics;
 use vortex_array::Array;
 use vortex_dtype::DType;
@@ -35,6 +36,7 @@ pub struct LayoutBatchStream<R> {
     filter_reader: Option<Box<dyn LayoutReader>>,
     messages_cache: Arc<RwLock<LayoutMessageCache>>,
     splits: VecDeque<(usize, usize)>,
+    indices_mask: Option<RowMask>,
     current_selector: Option<RowMask>,
     state: StreamingState<R>,
 }
@@ -47,6 +49,7 @@ impl<R: VortexReadAt> LayoutBatchStream<R> {
         messages_cache: Arc<RwLock<LayoutMessageCache>>,
         dtype: DType,
         row_count: u64,
+        indices_mask: Option<RowMask>,
     ) -> Self {
         LayoutBatchStream {
             dtype,
@@ -56,6 +59,7 @@ impl<R: VortexReadAt> LayoutBatchStream<R> {
             filter_reader,
             messages_cache,
             splits: VecDeque::new(),
+            indices_mask,
             current_selector: None,
             state: StreamingState::AddSplits,
         }
@@ -116,7 +120,7 @@ impl<R: VortexReadAt + Unpin + 'static> Stream for LayoutBatchStream<R> {
                     self.state = StreamingState::NextSplit;
                 }
                 StreamingState::NextSplit => {
-                    self.current_selector = self.splits.pop_front().map(|(begin, end)| unsafe {
+                    let new_selector = self.splits.pop_front().map(|(begin, end)| unsafe {
                         RowMask::new_unchecked(
                             Bitmap::from_range(0..(end - begin) as u32),
                             begin,
@@ -124,13 +128,30 @@ impl<R: VortexReadAt + Unpin + 'static> Stream for LayoutBatchStream<R> {
                         )
                     });
 
-                    if self.current_selector.is_none() {
+                    let Some(mut new_selector) = new_selector else {
                         return Poll::Ready(None);
-                    }
+                    };
 
                     self.state = if self.filter_reader.is_some() {
+                        if let Some(indices_mask) = &self.indices_mask {
+                            if indices_mask
+                                .slice(new_selector.begin(), new_selector.end())
+                                .is_empty()
+                            {
+                                self.state = StreamingState::NextSplit;
+                                continue;
+                            }
+                        }
+
+                        self.current_selector = Some(new_selector);
                         StreamingState::Filter
                     } else {
+                        if let Some(indices_mask) = &self.indices_mask {
+                            new_selector.and_inplace(
+                                &indices_mask.slice(new_selector.begin(), new_selector.end()),
+                            )?;
+                        }
+                        self.current_selector = Some(new_selector);
                         StreamingState::Read
                     };
                 }
@@ -160,7 +181,16 @@ impl<R: VortexReadAt + Unpin + 'static> Stream for LayoutBatchStream<R> {
                                     go_back_to_filter: true,
                                 });
                             }
-                            BatchRead::Batch(batch) => {
+                            BatchRead::Batch(mut batch) => {
+                                if let Some(indices_mask) = &self.indices_mask {
+                                    batch = and(
+                                        batch,
+                                        indices_mask
+                                            .slice(sel_begin, sel_end)
+                                            .to_predicate_array()?,
+                                    )?;
+                                }
+
                                 if batch.statistics().compute_true_count().vortex_expect(
                                     "must be a bool array if it's a result of a filter",
                                 ) == 0

--- a/vortex-serde/src/layouts/tests.rs
+++ b/vortex-serde/src/layouts/tests.rs
@@ -715,26 +715,26 @@ async fn test_with_indices_and_with_row_filter_simple() {
         .unwrap();
     let written = writer.finalize().await.unwrap();
 
-    // // test no indices
-    // let empty_indices = Vec::<u32>::new();
-    // let actual_kept_array =
-    //     LayoutBatchStreamBuilder::new(written.clone(), LayoutDeserializer::default())
-    //         .with_indices(Array::from(empty_indices))
-    //         .with_row_filter(RowFilter::new(Arc::new(BinaryExpr::new(
-    //             Arc::new(Column::new(Field::from("numbers"))),
-    //             Operator::Gt,
-    //             Arc::new(Literal::new(50_i16.into())),
-    //         ))))
-    //         .build()
-    //         .await
-    //         .unwrap()
-    //         .read_all()
-    //         .await
-    //         .unwrap()
-    //         .into_struct()
-    //         .unwrap();
+    // test no indices
+    let empty_indices = Vec::<u32>::new();
+    let actual_kept_array =
+        LayoutBatchStreamBuilder::new(written.clone(), LayoutDeserializer::default())
+            .with_indices(Array::from(empty_indices))
+            .with_row_filter(RowFilter::new(Arc::new(BinaryExpr::new(
+                Arc::new(Column::new(Field::from("numbers"))),
+                Operator::Gt,
+                Arc::new(Literal::new(50_i16.into())),
+            ))))
+            .build()
+            .await
+            .unwrap()
+            .read_all()
+            .await
+            .unwrap()
+            .into_struct()
+            .unwrap();
 
-    // assert_eq!(actual_kept_array.len(), 0);
+    assert_eq!(actual_kept_array.len(), 0);
 
     // test a few indices
     let kept_indices = vec![0_usize, 3, 99, 100, 101, 399, 400, 401, 499];

--- a/vortex-serde/src/layouts/tests.rs
+++ b/vortex-serde/src/layouts/tests.rs
@@ -7,7 +7,7 @@ use vortex_array::accessor::ArrayAccessor;
 use vortex_array::array::{ChunkedArray, PrimitiveArray, StructArray, VarBinArray};
 use vortex_array::validity::Validity;
 use vortex_array::variants::{PrimitiveArrayTrait, StructArrayTrait};
-use vortex_array::{ArrayDType, IntoArray, IntoArrayVariant};
+use vortex_array::{Array, ArrayDType, IntoArray, IntoArrayVariant};
 use vortex_dtype::field::Field;
 use vortex_dtype::{DType, Nullability, PType, StructDType};
 use vortex_error::vortex_panic;
@@ -549,5 +549,254 @@ async fn filter_and() {
     assert_eq!(
         ages.into_primitive().unwrap().maybe_null_slice::<i32>(),
         vec![25, 31]
+    );
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn test_with_indices_simple() {
+    let expected_numbers_split: Vec<Vec<i16>> = (0..5).map(|_| (0_i16..100).collect()).collect();
+    let expected_array = StructArray::from_fields(&[(
+        "numbers",
+        ChunkedArray::from_iter(expected_numbers_split.iter().cloned().map(Array::from))
+            .into_array(),
+    )])
+    .unwrap();
+    let expected_numbers: Vec<i16> = expected_numbers_split.into_iter().flatten().collect();
+
+    let writer = LayoutWriter::new(Vec::new())
+        .write_array_columns(expected_array.into_array())
+        .await
+        .unwrap();
+    let written = writer.finalize().await.unwrap();
+
+    // test no indices
+    let empty_indices = Vec::<u32>::new();
+    let actual_kept_array =
+        LayoutBatchStreamBuilder::new(written.clone(), LayoutDeserializer::default())
+            .with_indices(Array::from(empty_indices))
+            .build()
+            .await
+            .unwrap()
+            .read_all()
+            .await
+            .unwrap()
+            .into_struct()
+            .unwrap();
+
+    assert_eq!(actual_kept_array.len(), 0);
+
+    // test a few indices
+    let kept_indices = vec![0_usize, 3, 99, 100, 101, 399, 400, 401, 499];
+    let kept_indices_u16 = kept_indices.iter().map(|&x| x as u16).collect::<Vec<_>>();
+
+    let actual_kept_array =
+        LayoutBatchStreamBuilder::new(written.clone(), LayoutDeserializer::default())
+            .with_indices(Array::from(kept_indices_u16))
+            .build()
+            .await
+            .unwrap()
+            .read_all()
+            .await
+            .unwrap()
+            .into_struct()
+            .unwrap();
+    let actual_kept_numbers_array = actual_kept_array
+        .field(0)
+        .unwrap()
+        .into_primitive()
+        .unwrap();
+
+    let expected_kept_numbers: Vec<i16> =
+        kept_indices.iter().map(|&x| expected_numbers[x]).collect();
+    let actual_kept_numbers = actual_kept_numbers_array.maybe_null_slice::<i16>();
+
+    assert_eq!(expected_kept_numbers, actual_kept_numbers);
+
+    // test all indices
+    let actual_array =
+        LayoutBatchStreamBuilder::new(written.clone(), LayoutDeserializer::default())
+            .with_indices(Array::from((0..500).collect::<Vec<u32>>()))
+            .build()
+            .await
+            .unwrap()
+            .read_all()
+            .await
+            .unwrap()
+            .into_struct()
+            .unwrap();
+    let actual_numbers_array = actual_array.field(0).unwrap().into_primitive().unwrap();
+    let actual_numbers = actual_numbers_array.maybe_null_slice::<i16>();
+
+    assert_eq!(expected_numbers, actual_numbers);
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn test_with_indices_on_two_columns() {
+    let strings_expected = ["ab", "foo", "bar", "baz", "ab", "foo", "bar", "baz"];
+    let strings = ChunkedArray::from_iter([
+        VarBinArray::from(strings_expected[..4].to_vec()).into_array(),
+        VarBinArray::from(strings_expected[4..].to_vec()).into_array(),
+    ])
+    .into_array();
+
+    let numbers_expected = [1u32, 2, 3, 4, 5, 6, 7, 8];
+    let numbers = ChunkedArray::from_iter([
+        PrimitiveArray::from(numbers_expected[..4].to_vec()).into_array(),
+        PrimitiveArray::from(numbers_expected[4..].to_vec()).into_array(),
+    ])
+    .into_array();
+
+    let st = StructArray::from_fields(&[("strings", strings), ("numbers", numbers)]).unwrap();
+    let buf = Vec::new();
+    let mut writer = LayoutWriter::new(buf);
+    writer = writer.write_array_columns(st.into_array()).await.unwrap();
+    let written = writer.finalize().await.unwrap();
+
+    let kept_indices = vec![0_usize, 3, 7];
+    let kept_indices_u8 = kept_indices.iter().map(|&x| x as u8).collect::<Vec<_>>();
+
+    let array = LayoutBatchStreamBuilder::new(written.clone(), LayoutDeserializer::default())
+        .with_indices(Array::from(kept_indices_u8))
+        .build()
+        .await
+        .unwrap()
+        .read_all()
+        .await
+        .unwrap()
+        .into_struct()
+        .unwrap();
+
+    let strings_actual = array
+        .field(0)
+        .unwrap()
+        .into_varbinview()
+        .unwrap()
+        .with_iterator(|x| {
+            x.map(|x| unsafe { String::from_utf8_unchecked(x.unwrap().to_vec()) })
+                .collect::<Vec<_>>()
+        })
+        .unwrap();
+    assert_eq!(
+        strings_actual,
+        kept_indices
+            .iter()
+            .map(|&x| strings_expected[x])
+            .collect::<Vec<_>>()
+    );
+
+    let numbers_actual_array = array.field(1).unwrap().into_primitive().unwrap();
+    let numbers_actual = numbers_actual_array.maybe_null_slice::<u32>();
+    assert_eq!(
+        numbers_actual,
+        kept_indices
+            .iter()
+            .map(|&x| numbers_expected[x])
+            .collect::<Vec<u32>>()
+    );
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn test_with_indices_and_with_row_filter_simple() {
+    let expected_numbers_split: Vec<Vec<i16>> = (0..5).map(|_| (0_i16..100).collect()).collect();
+    let expected_array = StructArray::from_fields(&[(
+        "numbers",
+        ChunkedArray::from_iter(expected_numbers_split.iter().cloned().map(Array::from))
+            .into_array(),
+    )])
+    .unwrap();
+    let expected_numbers: Vec<i16> = expected_numbers_split.into_iter().flatten().collect();
+
+    let writer = LayoutWriter::new(Vec::new())
+        .write_array_columns(expected_array.into_array())
+        .await
+        .unwrap();
+    let written = writer.finalize().await.unwrap();
+
+    // // test no indices
+    // let empty_indices = Vec::<u32>::new();
+    // let actual_kept_array =
+    //     LayoutBatchStreamBuilder::new(written.clone(), LayoutDeserializer::default())
+    //         .with_indices(Array::from(empty_indices))
+    //         .with_row_filter(RowFilter::new(Arc::new(BinaryExpr::new(
+    //             Arc::new(Column::new(Field::from("numbers"))),
+    //             Operator::Gt,
+    //             Arc::new(Literal::new(50_i16.into())),
+    //         ))))
+    //         .build()
+    //         .await
+    //         .unwrap()
+    //         .read_all()
+    //         .await
+    //         .unwrap()
+    //         .into_struct()
+    //         .unwrap();
+
+    // assert_eq!(actual_kept_array.len(), 0);
+
+    // test a few indices
+    let kept_indices = vec![0_usize, 3, 99, 100, 101, 399, 400, 401, 499];
+    let kept_indices_u16 = kept_indices.iter().map(|&x| x as u16).collect::<Vec<_>>();
+
+    let actual_kept_array =
+        LayoutBatchStreamBuilder::new(written.clone(), LayoutDeserializer::default())
+            .with_indices(Array::from(kept_indices_u16))
+            .with_row_filter(RowFilter::new(Arc::new(BinaryExpr::new(
+                Arc::new(Column::new(Field::from("numbers"))),
+                Operator::Gt,
+                Arc::new(Literal::new(50_i16.into())),
+            ))))
+            .build()
+            .await
+            .unwrap()
+            .read_all()
+            .await
+            .unwrap()
+            .into_struct()
+            .unwrap();
+    let actual_kept_numbers_array = actual_kept_array
+        .field(0)
+        .unwrap()
+        .into_primitive()
+        .unwrap();
+
+    let expected_kept_numbers: Vec<i16> = kept_indices
+        .iter()
+        .map(|&x| expected_numbers[x])
+        .filter(|&x| x > 50)
+        .collect();
+    let actual_kept_numbers = actual_kept_numbers_array.maybe_null_slice::<i16>();
+
+    assert_eq!(expected_kept_numbers, actual_kept_numbers);
+
+    // test all indices
+    let actual_array =
+        LayoutBatchStreamBuilder::new(written.clone(), LayoutDeserializer::default())
+            .with_indices(Array::from((0..500).collect::<Vec<u32>>()))
+            .with_row_filter(RowFilter::new(Arc::new(BinaryExpr::new(
+                Arc::new(Column::new(Field::from("numbers"))),
+                Operator::Gt,
+                Arc::new(Literal::new(50_i16.into())),
+            ))))
+            .build()
+            .await
+            .unwrap()
+            .read_all()
+            .await
+            .unwrap()
+            .into_struct()
+            .unwrap();
+    let actual_numbers_array = actual_array.field(0).unwrap().into_primitive().unwrap();
+    let actual_numbers = actual_numbers_array.maybe_null_slice::<i16>();
+
+    assert_eq!(
+        expected_numbers
+            .iter()
+            .filter(|&&x| x > 50)
+            .cloned()
+            .collect::<Vec<_>>(),
+        actual_numbers
     );
 }

--- a/vortex-serde/src/layouts/tests.rs
+++ b/vortex-serde/src/layouts/tests.rs
@@ -587,7 +587,7 @@ async fn test_with_indices_simple() {
     assert_eq!(actual_kept_array.len(), 0);
 
     // test a few indices
-    let kept_indices = vec![0_usize, 3, 99, 100, 101, 399, 400, 401, 499];
+    let kept_indices = [0_usize, 3, 99, 100, 101, 399, 400, 401, 499];
     let kept_indices_u16 = kept_indices.iter().map(|&x| x as u16).collect::<Vec<_>>();
 
     let actual_kept_array =
@@ -654,7 +654,7 @@ async fn test_with_indices_on_two_columns() {
     writer = writer.write_array_columns(st.into_array()).await.unwrap();
     let written = writer.finalize().await.unwrap();
 
-    let kept_indices = vec![0_usize, 3, 7];
+    let kept_indices = [0_usize, 3, 7];
     let kept_indices_u8 = kept_indices.iter().map(|&x| x as u8).collect::<Vec<_>>();
 
     let array = LayoutBatchStreamBuilder::new(written.clone(), LayoutDeserializer::default())
@@ -737,7 +737,7 @@ async fn test_with_indices_and_with_row_filter_simple() {
     assert_eq!(actual_kept_array.len(), 0);
 
     // test a few indices
-    let kept_indices = vec![0_usize, 3, 99, 100, 101, 399, 400, 401, 499];
+    let kept_indices = [0_usize, 3, 99, 100, 101, 399, 400, 401, 499];
     let kept_indices_u16 = kept_indices.iter().map(|&x| x as u16).collect::<Vec<_>>();
 
     let actual_kept_array =


### PR DESCRIPTION
I have some thoughts on how to make the stream.rs logic easier to follow; however, this, I think, is the fewest changes to achieve indices filtering.

This change evaluates the filter on any row in a chunk containing at least one kept index. I have some thoughts on how to avoid evaluating the filter at a sub-chunk level but they require more substantial changes.