### PR TITLE
chore: port random access benchmark to layouts

### DIFF
--- a/bench-vortex/benches/compress_noci.rs
+++ b/bench-vortex/benches/compress_noci.rs
@@ -26,7 +26,7 @@ use vortex::array::{ChunkedArray, StructArray};
 use vortex::dtype::field::Field;
 use vortex::error::VortexResult;
 use vortex::sampling_compressor::compressors::fsst::FSSTCompressor;
-use vortex::sampling_compressor::{SamplingCompressor, ALL_COMPRESSORS_CONTEXT};
+use vortex::sampling_compressor::{SamplingCompressor, ALL_ENCODINGS_CONTEXT};
 use vortex::serde::layouts::{
     LayoutBatchStreamBuilder, LayoutContext, LayoutDeserializer, LayoutWriter,
 };
@@ -128,7 +128,7 @@ fn vortex_decompress_read(runtime: &Runtime, buf: Arc<Vec<u8>>) -> VortexResult<
         let builder: LayoutBatchStreamBuilder<_> = LayoutBatchStreamBuilder::new(
             buf,
             LayoutDeserializer::new(
-                ALL_COMPRESSORS_CONTEXT.clone(),
+                ALL_ENCODINGS_CONTEXT.clone(),
                 LayoutContext::default().into(),
             ),
         );

--- a/bench-vortex/benches/random_access.rs
+++ b/bench-vortex/benches/random_access.rs
@@ -33,12 +33,12 @@ fn random_access_vortex(c: &mut Criterion) {
             .iter(|| async { black_box(take_vortex_tokio(&taxi_vortex, &INDICES).await.unwrap()) })
     });
 
-    let local_fs = Arc::new(LocalFileSystem::new()) as Arc<dyn ObjectStore>;
-    let local_fs_path = object_store::path::Path::from_filesystem_path(&taxi_vortex).unwrap();
     group.bench_function("vortex-local-fs", |b| {
+        let local_fs = Arc::new(LocalFileSystem::new()) as Arc<dyn ObjectStore>;
+        let local_fs_path = object_store::path::Path::from_filesystem_path(&taxi_vortex).unwrap();
         b.to_async(Runtime::new().unwrap()).iter(|| async {
             black_box(
-                take_vortex_object_store(&local_fs, &local_fs_path, &INDICES)
+                take_vortex_object_store(local_fs.clone(), local_fs_path.clone(), &INDICES)
                     .await
                     .unwrap(),
             )
@@ -65,7 +65,7 @@ fn random_access_vortex(c: &mut Criterion) {
 
             b.to_async(Runtime::new().unwrap()).iter(|| async {
                 black_box(
-                    take_vortex_object_store(&r2_fs, &r2_path, &INDICES)
+                    take_vortex_object_store(r2_fs.clone(), r2_path.clone(), &INDICES)
                         .await
                         .unwrap(),
                 )

--- a/bench-vortex/src/public_bi_data.rs
+++ b/bench-vortex/src/public_bi_data.rs
@@ -13,7 +13,7 @@ use tokio::fs::File;
 use vortex::aliases::hash_map::HashMap;
 use vortex::array::ChunkedArray;
 use vortex::error::VortexResult;
-use vortex::{Array, ArrayDType, ArrayTrait, IntoArray};
+use vortex::{Array, ArrayDType, IntoArray};
 
 use crate::data_downloads::{decompress_bz2, download_data, BenchmarkDataset, FileType};
 use crate::public_bi_data::PBIDataset::*;

--- a/pyvortex/src/dataset.rs
+++ b/pyvortex/src/dataset.rs
@@ -12,7 +12,7 @@ use vortex::arrow::infer_schema;
 use vortex::dtype::field::Field;
 use vortex::dtype::DType;
 use vortex::error::VortexResult;
-use vortex::sampling_compressor::ALL_COMPRESSORS_CONTEXT;
+use vortex::sampling_compressor::ALL_ENCODINGS_CONTEXT;
 use vortex::serde::io::{ObjectStoreReadAt, VortexReadAt};
 use vortex::serde::layouts::{
     LayoutBatchStream, LayoutBatchStreamBuilder, LayoutContext, LayoutDescriptorReader,
@@ -33,7 +33,7 @@ pub async fn layout_stream_from_reader<T: VortexReadAt + Unpin>(
     let mut builder = LayoutBatchStreamBuilder::new(
         reader,
         LayoutDeserializer::new(
-            ALL_COMPRESSORS_CONTEXT.clone(),
+            ALL_ENCODINGS_CONTEXT.clone(),
             LayoutContext::default().into(),
         ),
     )
@@ -64,7 +64,7 @@ pub async fn read_array_from_reader<T: VortexReadAt + Unpin + 'static>(
 
 pub async fn read_dtype_from_reader<T: VortexReadAt + Unpin>(reader: T) -> VortexResult<DType> {
     LayoutDescriptorReader::new(LayoutDeserializer::new(
-        ALL_COMPRESSORS_CONTEXT.clone(),
+        ALL_ENCODINGS_CONTEXT.clone(),
         LayoutContext::default().into(),
     ))
     .read_footer(&reader, reader.size().await)

--- a/vortex-sampling-compressor/src/lib.rs
+++ b/vortex-sampling-compressor/src/lib.rs
@@ -75,7 +75,7 @@ pub static FASTEST_COMPRESSORS: LazyLock<[CompressorRef<'static>; 7]> = LazyLock
     ]
 });
 
-pub static ALL_COMPRESSORS_CONTEXT: LazyLock<Arc<Context>> = LazyLock::new(|| {
+pub static ALL_ENCODINGS_CONTEXT: LazyLock<Arc<Context>> = LazyLock::new(|| {
     Arc::new(Context::default().with_encodings([
         &ALPEncoding as EncodingRef,
         &ByteBoolEncoding,


### PR DESCRIPTION
develop was a643065102f24e1feeccb324ceeb0245a7405be6
layouts was this PR: 6dc6c53a477a67231a3bc425459c84f10dd8f0d1
```
# critcmp develop layouts
group                                     develop                                layouts
-----                                     -------                                -------
random-access/parquet-tokio-local-disk    1.01     94.0±0.44ms        ? ?/sec    1.00     93.3±0.62ms        ? ?/sec
random-access/vortex-local-fs             1.00   381.3±10.78µs        ? ?/sec    34.91    13.3±0.13ms        ? ?/sec
random-access/vortex-tokio-local-disk     1.00   349.5±12.64µs        ? ?/sec    29.46    10.3±0.14ms        ? ?/sec
```