### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,13 +452,10 @@ dependencies = [
  "bzip2",
  "clap",
  "criterion",
- "csv",
  "datafusion",
  "datafusion-common",
- "datafusion-execution",
  "datafusion-physical-plan",
  "enum-iterator",
- "flexbuffers",
  "futures",
  "homedir",
  "humansize",
@@ -3160,12 +3157,9 @@ name = "pyvortex"
 version = "0.14.0"
 dependencies = [
  "arrow",
- "flexbuffers",
- "futures",
  "itertools 0.13.0",
  "log",
  "object_store",
- "paste",
  "pyo3",
  "pyo3-log",
  "tokio",
@@ -4369,14 +4363,12 @@ dependencies = [
  "itertools 0.13.0",
  "log",
  "num-traits",
- "num_enum 0.7.3",
  "paste",
  "pin-project",
  "rand",
  "rstest",
  "serde",
  "static_assertions",
- "tokio",
  "vortex-buffer",
  "vortex-datetime-dtype",
  "vortex-dtype",
@@ -4398,10 +4390,7 @@ dependencies = [
 name = "vortex-bytebool"
 version = "0.14.0"
 dependencies = [
- "arrow-array",
  "arrow-buffer",
- "divan",
- "itertools 0.13.0",
  "num-traits",
  "serde",
  "vortex-array",
@@ -4428,7 +4417,6 @@ dependencies = [
  "datafusion-physical-plan",
  "futures",
  "itertools 0.13.0",
- "log",
  "object_store",
  "pin-project",
  "tempfile",
@@ -4439,7 +4427,6 @@ dependencies = [
  "vortex-dtype",
  "vortex-error",
  "vortex-expr",
- "vortex-scalar",
  "vortex-serde",
 ]
 
@@ -4460,7 +4447,6 @@ name = "vortex-datetime-parts"
 version = "0.14.0"
 dependencies = [
  "itertools 0.13.0",
- "log",
  "serde",
  "vortex-array",
  "vortex-datetime-dtype",
@@ -4473,15 +4459,12 @@ dependencies = [
 name = "vortex-dict"
 version = "0.14.0"
 dependencies = [
- "arrow-array",
  "arrow-buffer",
  "criterion",
  "hashbrown 0.15.1",
- "log",
  "num-traits",
  "rand",
  "serde",
- "simplelog",
  "vortex-array",
  "vortex-dtype",
  "vortex-error",
@@ -4527,8 +4510,6 @@ dependencies = [
 name = "vortex-expr"
 version = "0.14.0"
 dependencies = [
- "arrow-schema",
- "datafusion-common",
  "datafusion-expr",
  "datafusion-physical-expr",
  "prost",
@@ -4538,7 +4519,6 @@ dependencies = [
  "vortex-error",
  "vortex-proto",
  "vortex-scalar",
- "vortex-schema",
 ]
 
 [[package]]
@@ -4553,7 +4533,6 @@ dependencies = [
  "num-traits",
  "rand",
  "serde",
- "simplelog",
  "vortex-array",
  "vortex-buffer",
  "vortex-dtype",
@@ -4587,13 +4566,10 @@ dependencies = [
 name = "vortex-fuzz"
 version = "0.14.0"
 dependencies = [
- "arrow-buffer",
  "libfuzzer-sys",
- "num-traits",
  "vortex-array",
  "vortex-buffer",
  "vortex-dtype",
- "vortex-error",
  "vortex-sampling-compressor",
  "vortex-scalar",
 ]
@@ -4612,7 +4588,6 @@ version = "0.14.0"
 dependencies = [
  "arrow-buffer",
  "croaring",
- "log",
  "num-traits",
  "serde",
  "vortex-array",
@@ -4689,7 +4664,6 @@ dependencies = [
  "flexbuffers",
  "half",
  "itertools 0.13.0",
- "jiff",
  "num-traits",
  "paste",
  "prost",
@@ -4732,19 +4706,13 @@ dependencies = [
  "monoio",
  "object_store",
  "once_cell",
- "pin-project",
- "rand",
  "rstest",
- "simplelog",
  "tokio",
- "url",
- "vortex-alp",
  "vortex-array",
  "vortex-buffer",
  "vortex-dtype",
  "vortex-error",
  "vortex-expr",
- "vortex-fastlanes",
  "vortex-flatbuffers",
  "vortex-sampling-compressor",
  "vortex-scalar",
@@ -4759,7 +4727,6 @@ dependencies = [
  "vortex-array",
  "vortex-dtype",
  "vortex-error",
- "vortex-fastlanes",
  "vortex-scalar",
  "zigzag",
 ]
@@ -5293,7 +5260,6 @@ dependencies = [
  "anyhow",
  "clap",
  "prost-build",
- "walkdir",
  "xshell",
 ]
 

--- a/bench-vortex/Cargo.toml
+++ b/bench-vortex/Cargo.toml
@@ -29,16 +29,13 @@ arrow-select = { workspace = true }
 bytes = { workspace = true }
 bzip2 = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-csv = { workspace = true }
 datafusion = { workspace = true, features = [
     "parquet",
     "datetime_expressions",
 ] }
 datafusion-common = { workspace = true }
 datafusion-physical-plan = { workspace = true }
-datafusion-execution = { workspace = true }
 enum-iterator = { workspace = true }
-flexbuffers = { workspace = true }
 futures = { workspace = true, features = ["executor"] }
 homedir = { workspace = true }
 humansize = { workspace = true }

--- a/encodings/bytebool/Cargo.toml
+++ b/encodings/bytebool/Cargo.toml
@@ -17,9 +17,7 @@ readme = { workspace = true }
 workspace = true
 
 [dependencies]
-arrow-array = { workspace = true }
 arrow-buffer = { workspace = true }
-itertools = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 vortex-array = { workspace = true }
@@ -27,6 +25,3 @@ vortex-buffer = { workspace = true }
 vortex-dtype = { workspace = true }
 vortex-error = { workspace = true }
 vortex-scalar = { workspace = true }
-
-[dev-dependencies]
-divan = { workspace = true }

--- a/encodings/datetime-parts/Cargo.toml
+++ b/encodings/datetime-parts/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 
 [dependencies]
 itertools = { workspace = true }
-log = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 vortex-array = { workspace = true }
 vortex-datetime-dtype = { workspace = true }

--- a/encodings/dict/Cargo.toml
+++ b/encodings/dict/Cargo.toml
@@ -14,7 +14,6 @@ categories = { workspace = true }
 readme = { workspace = true }
 
 [dependencies]
-arrow-array = { workspace = true }
 arrow-buffer = { workspace = true }
 hashbrown = { workspace = true }
 num-traits = { workspace = true }
@@ -29,9 +28,7 @@ workspace = true
 
 [dev-dependencies]
 criterion = { workspace = true }
-log = { workspace = true }
 rand = { workspace = true }
-simplelog = { workspace = true }
 
 [[bench]]
 name = "dict_compress"

--- a/encodings/fastlanes/Cargo.toml
+++ b/encodings/fastlanes/Cargo.toml
@@ -32,7 +32,6 @@ vortex-scalar = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true }
 rand = { workspace = true }
-simplelog = { workspace = true }
 
 [[bench]]
 name = "bitpacking_take"

--- a/encodings/roaring/Cargo.toml
+++ b/encodings/roaring/Cargo.toml
@@ -16,7 +16,6 @@ readme = { workspace = true }
 [dependencies]
 arrow-buffer = { workspace = true }
 croaring = { workspace = true }
-log = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }
 vortex-array = { workspace = true }

--- a/encodings/zigzag/Cargo.toml
+++ b/encodings/zigzag/Cargo.toml
@@ -21,8 +21,5 @@ vortex-error = { workspace = true }
 vortex-scalar = { workspace = true }
 zigzag = { workspace = true }
 
-[dev-dependencies]
-vortex-fastlanes = { path = "../fastlanes" }
-
 [lints]
 workspace = true

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -19,13 +19,10 @@ readme = "README.md"
 cargo-fuzz = true
 
 [dependencies]
-arrow-buffer = { workspace = true }
 libfuzzer-sys = { workspace = true }
-num-traits = { workspace = true }
 vortex-array = { workspace = true, features = ["arbitrary"] }
 vortex-buffer = { workspace = true }
 vortex-dtype = { workspace = true, features = ["arbitrary"] }
-vortex-error = { workspace = true }
 vortex-sampling-compressor = { workspace = true, features = ["arbitrary"] }
 vortex-scalar = { workspace = true, features = ["arbitrary"] }
 

--- a/pyvortex/Cargo.toml
+++ b/pyvortex/Cargo.toml
@@ -24,15 +24,11 @@ doctest = false
 
 [dependencies]
 arrow = { workspace = true, features = ["pyarrow"] }
-flexbuffers = { workspace = true }
-futures = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
-paste = { workspace = true }
+object_store = { workspace = true, features = ["aws", "gcp", "azure", "http"] }
 pyo3 = { workspace = true }
 pyo3-log = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 url = { workspace = true }
-object_store = { workspace = true, features = ["aws", "gcp", "azure", "http"] }
-
 vortex = { workspace = true, features = ["tokio", "object_store", "python"] }

--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -40,7 +40,6 @@ humansize = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 num-traits = { workspace = true }
-num_enum = { workspace = true }
 paste = { workspace = true }
 pin-project = { workspace = true }
 rand = { workspace = true }
@@ -75,7 +74,6 @@ getrandom = { workspace = true, features = ["js"] }
 [dev-dependencies]
 criterion = { workspace = true }
 rstest = { workspace = true }
-tokio = { workspace = true }
 
 [[bench]]
 name = "search_sorted"

--- a/vortex-datafusion/Cargo.toml
+++ b/vortex-datafusion/Cargo.toml
@@ -30,7 +30,6 @@ datafusion-physical-expr = { workspace = true }
 datafusion-physical-plan = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
-log = { workspace = true }
 object_store = { workspace = true }
 pin-project = { workspace = true }
 vortex-array = { workspace = true }
@@ -38,7 +37,6 @@ vortex-datetime-dtype = { workspace = true }
 vortex-dtype = { workspace = true }
 vortex-error = { workspace = true, features = ["datafusion"] }
 vortex-expr = { workspace = true, features = ["datafusion"] }
-vortex-scalar = { workspace = true, features = ["datafusion"] }
 vortex-serde = { workspace = true, features = ["object_store", "tokio"] }
 
 [dev-dependencies]

--- a/vortex-expr/Cargo.toml
+++ b/vortex-expr/Cargo.toml
@@ -22,8 +22,6 @@ bench = false
 workspace = true
 
 [dependencies]
-arrow-schema = { workspace = true, optional = true }
-datafusion-common = { workspace = true, optional = true }
 datafusion-expr = { workspace = true, optional = true }
 datafusion-physical-expr = { workspace = true, optional = true }
 prost = { workspace = true, optional = true }
@@ -33,11 +31,9 @@ vortex-dtype = { workspace = true }
 vortex-error = { workspace = true }
 vortex-proto = { workspace = true, optional = true }
 vortex-scalar = { workspace = true }
-vortex-schema = { workspace = true }
 
 [features]
 datafusion = [
-    "dep:datafusion-common",
     "dep:datafusion-expr",
     "dep:datafusion-physical-expr",
     "vortex-scalar/datafusion",

--- a/vortex-scalar/Cargo.toml
+++ b/vortex-scalar/Cargo.toml
@@ -22,7 +22,6 @@ flatbuffers = { workspace = true, optional = true }
 flexbuffers = { workspace = true, optional = true }
 half = { workspace = true }
 itertools = { workspace = true }
-jiff = { workspace = true }
 num-traits = { workspace = true }
 paste = { workspace = true }
 prost = { workspace = true, optional = true }

--- a/vortex-serde/Cargo.toml
+++ b/vortex-serde/Cargo.toml
@@ -27,9 +27,7 @@ itertools = { workspace = true }
 monoio = { workspace = true, optional = true, features = ["bytes"] }
 object_store = { workspace = true, optional = true }
 once_cell = { workspace = true }
-pin-project = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "fs", "rt-multi-thread"], optional = true }
-url = { workspace = true }
 vortex-array = { workspace = true }
 vortex-buffer = { workspace = true }
 vortex-dtype = { workspace = true, features = ["flatbuffers"] }
@@ -46,12 +44,8 @@ arrow-ipc = { workspace = true, features = ["lz4"] }
 arrow-schema = { workspace = true }
 arrow-select = { workspace = true }
 criterion = { workspace = true, features = ["async_futures"] }
-rand = { workspace = true }
 rstest = { workspace = true }
-simplelog = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-vortex-alp = { path = "../encodings/alp" }
-vortex-fastlanes = { path = "../encodings/fastlanes" }
 vortex-sampling-compressor = { path = "../vortex-sampling-compressor" }
 
 [lints]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -19,7 +19,6 @@ readme = "README.md"
 anyhow = { workspace = true }
 clap = { workspace = true }
 prost-build = { workspace = true }
-walkdir = { workspace = true }
 xshell = { workspace = true }
 
 [lints]


### PR DESCRIPTION
As we move code around we didn't always remove dependencies that are no longer needed. There's still some leftover proto/prost dependencies that have to come back since we want proto serialization of dtypes and exprs