### PR TITLE
chore: release v0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## `vortex-datafusion` - [0.15.1](https://github.com/spiraldb/vortex/compare/vortex-datafusion-v0.14.0...vortex-datafusion-v0.15.1) - 2024-11-13
+## `vortex-datafusion` - [0.15.2](https://github.com/spiraldb/vortex/compare/vortex-datafusion-v0.14.0...vortex-datafusion-v0.15.2) - 2024-11-13
 
 ### Added
 - [**breaking**] standardize file format names & stop wrapping Footer contents in messages ([#1275](https://github.com/spiraldb/vortex/pull/1275))
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - some documentation of the layout reading system ([#1225](https://github.com/spiraldb/vortex/pull/1225))
 - Replace usages of lazy_static with LazyLock ([#1214](https://github.com/spiraldb/vortex/pull/1214))
 
-## `vortex-serde` - [0.15.1](https://github.com/spiraldb/vortex/compare/vortex-serde-v0.14.0...vortex-serde-v0.15.1) - 2024-11-13
+## `vortex-serde` - [0.15.2](https://github.com/spiraldb/vortex/compare/vortex-serde-v0.14.0...vortex-serde-v0.15.2) - 2024-11-13
 
 ### Added
 - [**breaking**] standardize file format names & stop wrapping Footer contents in messages ([#1275](https://github.com/spiraldb/vortex/pull/1275))
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - move Array enum out of public interface ([#1212](https://github.com/spiraldb/vortex/pull/1212))
 - Replace usages of lazy_static with LazyLock ([#1214](https://github.com/spiraldb/vortex/pull/1214))
 
-## `vortex-zigzag` - [0.15.1](https://github.com/spiraldb/vortex/compare/vortex-zigzag-v0.14.0...vortex-zigzag-v0.15.1) - 2024-11-13
+## `vortex-zigzag` - [0.15.2](https://github.com/spiraldb/vortex/compare/vortex-zigzag-v0.14.0...vortex-zigzag-v0.15.2) - 2024-11-13
 
 ### Added
 - teach PrimitiveArrayTrait iterate_primitive_array! and RowMask from_index_array ([#1241](https://github.com/spiraldb/vortex/pull/1241))
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - Remove unused dependencies ([#1256](https://github.com/spiraldb/vortex/pull/1256))
 
-## `vortex-sampling-compressor` - [0.15.1](https://github.com/spiraldb/vortex/compare/vortex-sampling-compressor-v0.14.0...vortex-sampling-compressor-v0.15.1) - 2024-11-13
+## `vortex-sampling-compressor` - [0.15.2](https://github.com/spiraldb/vortex/compare/vortex-sampling-compressor-v0.14.0...vortex-sampling-compressor-v0.15.2) - 2024-11-13
 
 ### Added
 - eagerly compute pruning stats during compression ([#1252](https://github.com/spiraldb/vortex/pull/1252))
@@ -62,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable more lints about unused lifetimes and unnecessary prefixes ([#1233](https://github.com/spiraldb/vortex/pull/1233))
 - Replace usages of lazy_static with LazyLock ([#1214](https://github.com/spiraldb/vortex/pull/1214))
 
-## `vortex-runend-bool` - [0.15.1](https://github.com/spiraldb/vortex/compare/vortex-runend-bool-v0.14.0...vortex-runend-bool-v0.15.1) - 2024-11-13
+## `vortex-runend-bool` - [0.15.2](https://github.com/spiraldb/vortex/compare/vortex-runend-bool-v0.14.0...vortex-runend-bool-v0.15.2) - 2024-11-13
 
 ### Added
 - teach PrimitiveArrayTrait iterate_primitive_array! and RowMask from_index_array ([#1241](https://github.com/spiraldb/vortex/pull/1241))
@@ -70,12 +70,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - Add Not vortex expr and use it in pruning expression conversion ([#1213](https://github.com/spiraldb/vortex/pull/1213))
 
-## `vortex-runend` - [0.15.1](https://github.com/spiraldb/vortex/compare/vortex-runend-v0.14.0...vortex-runend-v0.15.1) - 2024-11-13
+## `vortex-runend` - [0.15.2](https://github.com/spiraldb/vortex/compare/vortex-runend-v0.14.0...vortex-runend-v0.15.2) - 2024-11-13
 
 ### Added
 - teach PrimitiveArrayTrait iterate_primitive_array! and RowMask from_index_array ([#1241](https://github.com/spiraldb/vortex/pull/1241))
 
-## `vortex-roaring` - [0.15.1](https://github.com/spiraldb/vortex/compare/vortex-roaring-v0.14.0...vortex-roaring-v0.15.1) - 2024-11-13
+## `vortex-roaring` - [0.15.2](https://github.com/spiraldb/vortex/compare/vortex-roaring-v0.14.0...vortex-roaring-v0.15.2) - 2024-11-13
 
 ### Added
 - teach PrimitiveArrayTrait iterate_primitive_array! and RowMask from_index_array ([#1241](https://github.com/spiraldb/vortex/pull/1241))
@@ -84,13 +84,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove unused dependencies ([#1256](https://github.com/spiraldb/vortex/pull/1256))
 - Add Not vortex expr and use it in pruning expression conversion ([#1213](https://github.com/spiraldb/vortex/pull/1213))
 
-## `vortex-expr` - [0.15.1](https://github.com/spiraldb/vortex/compare/vortex-expr-v0.14.0...vortex-expr-v0.15.1) - 2024-11-13
+## `vortex-expr` - [0.15.2](https://github.com/spiraldb/vortex/compare/vortex-expr-v0.14.0...vortex-expr-v0.15.2) - 2024-11-13
 
 ### Other
 - Remove unused dependencies ([#1256](https://github.com/spiraldb/vortex/pull/1256))
 - Add Not vortex expr and use it in pruning expression conversion ([#1213](https://github.com/spiraldb/vortex/pull/1213))
 
-## `vortex-dict` - [0.15.1](https://github.com/spiraldb/vortex/compare/vortex-dict-v0.14.0...vortex-dict-v0.15.1) - 2024-11-13
+## `vortex-dict` - [0.15.2](https://github.com/spiraldb/vortex/compare/vortex-dict-v0.14.0...vortex-dict-v0.15.2) - 2024-11-13
 
 ### Added
 - teach PrimitiveArrayTrait iterate_primitive_array! and RowMask from_index_array ([#1241](https://github.com/spiraldb/vortex/pull/1241))
@@ -100,12 +100,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cleanup dict encoding logic ([#1231](https://github.com/spiraldb/vortex/pull/1231))
 - Enable more lints about unused lifetimes and unnecessary prefixes ([#1233](https://github.com/spiraldb/vortex/pull/1233))
 
-## `vortex-datetime-parts` - [0.15.1](https://github.com/spiraldb/vortex/compare/vortex-datetime-parts-v0.14.0...vortex-datetime-parts-v0.15.1) - 2024-11-13
+## `vortex-datetime-parts` - [0.15.2](https://github.com/spiraldb/vortex/compare/vortex-datetime-parts-v0.14.0...vortex-datetime-parts-v0.15.2) - 2024-11-13
 
 ### Other
 - Remove unused dependencies ([#1256](https://github.com/spiraldb/vortex/pull/1256))
 
-## `vortex-bytebool` - [0.15.1](https://github.com/spiraldb/vortex/compare/vortex-bytebool-v0.14.0...vortex-bytebool-v0.15.1) - 2024-11-13
+## `vortex-bytebool` - [0.15.2](https://github.com/spiraldb/vortex/compare/vortex-bytebool-v0.14.0...vortex-bytebool-v0.15.2) - 2024-11-13
 
 ### Added
 - teach PrimitiveArrayTrait iterate_primitive_array! and RowMask from_index_array ([#1241](https://github.com/spiraldb/vortex/pull/1241))
@@ -115,7 +115,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Not vortex expr and use it in pruning expression conversion ([#1213](https://github.com/spiraldb/vortex/pull/1213))
 - Enable more lints about unused lifetimes and unnecessary prefixes ([#1233](https://github.com/spiraldb/vortex/pull/1233))
 
-## `vortex-fastlanes` - [0.15.1](https://github.com/spiraldb/vortex/compare/vortex-fastlanes-v0.14.0...vortex-fastlanes-v0.15.1) - 2024-11-13
+## `vortex-fastlanes` - [0.15.2](https://github.com/spiraldb/vortex/compare/vortex-fastlanes-v0.14.0...vortex-fastlanes-v0.15.2) - 2024-11-13
 
 ### Added
 - propagate statistics through compression ([#1236](https://github.com/spiraldb/vortex/pull/1236))
@@ -125,7 +125,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - Remove unused dependencies ([#1256](https://github.com/spiraldb/vortex/pull/1256))
 
-## `vortex-scalar` - [0.15.1](https://github.com/spiraldb/vortex/compare/vortex-scalar-v0.14.0...vortex-scalar-v0.15.1) - 2024-11-13
+## `vortex-scalar` - [0.15.2](https://github.com/spiraldb/vortex/compare/vortex-scalar-v0.14.0...vortex-scalar-v0.15.2) - 2024-11-13
 
 ### Added
 - propagate statistics through compression ([#1236](https://github.com/spiraldb/vortex/pull/1236))
@@ -133,7 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - Remove unused dependencies ([#1256](https://github.com/spiraldb/vortex/pull/1256))
 
-## `vortex-flatbuffers` - [0.15.1](https://github.com/spiraldb/vortex/compare/vortex-flatbuffers-v0.14.0...vortex-flatbuffers-v0.15.1) - 2024-11-13
+## `vortex-flatbuffers` - [0.15.2](https://github.com/spiraldb/vortex/compare/vortex-flatbuffers-v0.14.0...vortex-flatbuffers-v0.15.2) - 2024-11-13
 
 ### Added
 - [**breaking**] standardize file format names & stop wrapping Footer contents in messages ([#1275](https://github.com/spiraldb/vortex/pull/1275))
@@ -142,23 +142,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable more lints about unused lifetimes and unnecessary prefixes ([#1233](https://github.com/spiraldb/vortex/pull/1233))
 - some documentation of the layout reading system ([#1225](https://github.com/spiraldb/vortex/pull/1225))
 
-## `vortex-error` - [0.15.1](https://github.com/spiraldb/vortex/compare/vortex-error-v0.14.0...vortex-error-v0.15.1) - 2024-11-13
+## `vortex-error` - [0.15.2](https://github.com/spiraldb/vortex/compare/vortex-error-v0.14.0...vortex-error-v0.15.2) - 2024-11-13
 
 ### Other
 - Annotate wrapped error in Context error type as #[source] ([#1265](https://github.com/spiraldb/vortex/pull/1265))
 - Enable more lints about unused lifetimes and unnecessary prefixes ([#1233](https://github.com/spiraldb/vortex/pull/1233))
 
-## `vortex-datetime-dtype` - [0.15.1](https://github.com/spiraldb/vortex/compare/vortex-datetime-dtype-v0.14.0...vortex-datetime-dtype-v0.15.1) - 2024-11-13
+## `vortex-datetime-dtype` - [0.15.2](https://github.com/spiraldb/vortex/compare/vortex-datetime-dtype-v0.14.0...vortex-datetime-dtype-v0.15.2) - 2024-11-13
 
 ### Other
 - Replace usages of lazy_static with LazyLock ([#1214](https://github.com/spiraldb/vortex/pull/1214))
 
-## `vortex-buffer` - [0.15.1](https://github.com/spiraldb/vortex/compare/vortex-buffer-v0.14.0...vortex-buffer-v0.15.1) - 2024-11-13
+## `vortex-buffer` - [0.15.2](https://github.com/spiraldb/vortex/compare/vortex-buffer-v0.14.0...vortex-buffer-v0.15.2) - 2024-11-13
 
 ### Other
 - move Buffer enum to private inner struct ([#1216](https://github.com/spiraldb/vortex/pull/1216))
 
-## `vortex-array` - [0.15.1](https://github.com/spiraldb/vortex/compare/0.14.0...0.15.1) - 2024-11-13
+## `vortex-array` - [0.15.2](https://github.com/spiraldb/vortex/compare/0.14.0...0.15.2) - 2024-11-13
 
 ### Added
 - propagate statistics through compression ([#1236](https://github.com/spiraldb/vortex/pull/1236))
@@ -177,7 +177,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - move Array enum out of public interface ([#1212](https://github.com/spiraldb/vortex/pull/1212))
 - Replace usages of lazy_static with LazyLock ([#1214](https://github.com/spiraldb/vortex/pull/1214))
 
-## `vortex-alp` - [0.15.1](https://github.com/spiraldb/vortex/compare/vortex-alp-v0.14.0...vortex-alp-v0.15.1) - 2024-11-13
+## `vortex-alp` - [0.15.2](https://github.com/spiraldb/vortex/compare/vortex-alp-v0.14.0...vortex-alp-v0.15.2) - 2024-11-13
 
 ### Added
 - Support patching bool arrays, patch primitive array validity and use patching when canonicalizing sparse arrays ([#1218](https://github.com/spiraldb/vortex/pull/1218))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bench-vortex"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -3170,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "pyvortex"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arrow",
  "itertools 0.13.0",
@@ -4338,7 +4338,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vortex"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "vortex-alp",
  "vortex-array",
@@ -4366,7 +4366,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-alp"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arrow-array",
  "divan",
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-array"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arbitrary",
  "arrow-arith",
@@ -4421,7 +4421,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-buffer"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arrow-buffer",
  "bytes",
@@ -4430,7 +4430,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-bytebool"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arrow-buffer",
  "num-traits",
@@ -4444,7 +4444,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-datafusion"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4474,7 +4474,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-datetime-dtype"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arrow-schema",
  "jiff",
@@ -4486,7 +4486,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-datetime-parts"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "itertools 0.13.0",
  "serde",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-dict"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arrow-buffer",
  "criterion",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-dtype"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arbitrary",
  "flatbuffers",
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-error"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arrow-schema",
  "datafusion-common",
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-expr"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "datafusion-expr",
  "datafusion-physical-expr",
@@ -4565,7 +4565,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-fastlanes"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arrayref",
  "arrow-buffer",
@@ -4584,14 +4584,14 @@ dependencies = [
 
 [[package]]
 name = "vortex-flatbuffers"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "flatbuffers",
 ]
 
 [[package]]
 name = "vortex-fsst"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4606,7 +4606,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-fuzz"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "libfuzzer-sys",
  "vortex-array",
@@ -4618,7 +4618,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-proto"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "prost",
  "prost-types",
@@ -4626,7 +4626,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-roaring"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arrow-buffer",
  "croaring",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-runend"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "itertools 0.13.0",
  "num-traits",
@@ -4654,7 +4654,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-runend-bool"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arrow-buffer",
  "criterion",
@@ -4670,7 +4670,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-sampling-compressor"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -4696,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-scalar"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arbitrary",
  "arrow-array",
@@ -4721,7 +4721,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-schema"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "vortex-dtype",
  "vortex-error",
@@ -4729,7 +4729,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-serde"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4762,7 +4762,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-zigzag"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "serde",
  "vortex-array",
@@ -5306,7 +5306,7 @@ checksum = "9d422e8e38ec76e2f06ee439ccc765e9c6a9638b9e7c9f2e8255e4d41e8bd852"
 
 [[package]]
 name = "xtask"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.1"
+version = "0.15.2"
 homepage = "https://github.com/spiraldb/vortex"
 repository = "https://github.com/spiraldb/vortex"
 authors = ["Vortex Authors <hello@vortex.dev>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,30 +133,30 @@ url = "2"
 uuid = "1.8.0"
 
 # BEGIN crates published by this project
-vortex = { version = "0.15.1", path = "./vortex" }
-vortex-alp = { version = "0.15.1", path = "./encodings/alp" }
-vortex-array = { version = "0.15.1", path = "./vortex-array" }
-vortex-buffer = { version = "0.15.1", path = "./vortex-buffer" }
-vortex-bytebool = { version = "0.15.1", path = "./encodings/bytebool" }
-vortex-datafusion = { version = "0.15.1", path = "./vortex-datafusion" }
-vortex-datetime-dtype = { version = "0.15.1", path = "./vortex-datetime-dtype" }
-vortex-datetime-parts = { version = "0.15.1", path = "./encodings/datetime-parts" }
-vortex-dict = { version = "0.15.1", path = "./encodings/dict" }
-vortex-dtype = { version = "0.15.1", path = "./vortex-dtype", default-features = false }
-vortex-error = { version = "0.15.1", path = "./vortex-error" }
-vortex-expr = { version = "0.15.1", path = "./vortex-expr" }
-vortex-fastlanes = { version = "0.15.1", path = "./encodings/fastlanes" }
-vortex-flatbuffers = { version = "0.15.1", path = "./vortex-flatbuffers" }
-vortex-fsst = { version = "0.15.1", path = "./encodings/fsst" }
-vortex-proto = { version = "0.15.1", path = "./vortex-proto" }
-vortex-roaring = { version = "0.15.1", path = "./encodings/roaring" }
-vortex-runend = { version = "0.15.1", path = "./encodings/runend" }
-vortex-runend-bool = { version = "0.15.1", path = "./encodings/runend-bool" }
-vortex-scalar = { version = "0.15.1", path = "./vortex-scalar", default-features = false }
-vortex-schema = { version = "0.15.1", path = "./vortex-schema" }
-vortex-serde = { version = "0.15.1", path = "./vortex-serde", default-features = false }
-vortex-sampling-compressor = { version = "0.15.1", path = "./vortex-sampling-compressor" }
-vortex-zigzag = { version = "0.15.1", path = "./encodings/zigzag" }
+vortex = { version = "0.15.2", path = "./vortex" }
+vortex-alp = { version = "0.15.2", path = "./encodings/alp" }
+vortex-array = { version = "0.15.2", path = "./vortex-array" }
+vortex-buffer = { version = "0.15.2", path = "./vortex-buffer" }
+vortex-bytebool = { version = "0.15.2", path = "./encodings/bytebool" }
+vortex-datafusion = { version = "0.15.2", path = "./vortex-datafusion" }
+vortex-datetime-dtype = { version = "0.15.2", path = "./vortex-datetime-dtype" }
+vortex-datetime-parts = { version = "0.15.2", path = "./encodings/datetime-parts" }
+vortex-dict = { version = "0.15.2", path = "./encodings/dict" }
+vortex-dtype = { version = "0.15.2", path = "./vortex-dtype", default-features = false }
+vortex-error = { version = "0.15.2", path = "./vortex-error" }
+vortex-expr = { version = "0.15.2", path = "./vortex-expr" }
+vortex-fastlanes = { version = "0.15.2", path = "./encodings/fastlanes" }
+vortex-flatbuffers = { version = "0.15.2", path = "./vortex-flatbuffers" }
+vortex-fsst = { version = "0.15.2", path = "./encodings/fsst" }
+vortex-proto = { version = "0.15.2", path = "./vortex-proto" }
+vortex-roaring = { version = "0.15.2", path = "./encodings/roaring" }
+vortex-runend = { version = "0.15.2", path = "./encodings/runend" }
+vortex-runend-bool = { version = "0.15.2", path = "./encodings/runend-bool" }
+vortex-scalar = { version = "0.15.2", path = "./vortex-scalar", default-features = false }
+vortex-schema = { version = "0.15.2", path = "./vortex-schema" }
+vortex-serde = { version = "0.15.2", path = "./vortex-serde", default-features = false }
+vortex-sampling-compressor = { version = "0.15.2", path = "./vortex-sampling-compressor" }
+vortex-zigzag = { version = "0.15.2", path = "./encodings/zigzag" }
 # END crates published by this project
 
 walkdir = "2.5.0"


### PR DESCRIPTION
* `vortex`: 0.14.0 -> 0.15.2
* `vortex-alp`: 0.14.0 -> 0.15.2 (⚠️ API breaking changes)
* `vortex-array`: 0.14.0 -> 0.15.2 (⚠️ API breaking changes)
* `vortex-buffer`: 0.14.0 -> 0.15.2 (⚠️ API breaking changes)
* `vortex-datetime-dtype`: 0.14.0 -> 0.15.2 (⚠️ API breaking changes)
* `vortex-dtype`: 0.14.0 -> 0.15.2
* `vortex-error`: 0.14.0 -> 0.15.2 (✓ API compatible changes)
* `vortex-flatbuffers`: 0.14.0 -> 0.15.2 (⚠️ API breaking changes)
* `vortex-proto`: 0.14.0 -> 0.15.2
* `vortex-scalar`: 0.14.0 -> 0.15.2 (✓ API compatible changes)
* `vortex-fastlanes`: 0.14.0 -> 0.15.2 (⚠️ API breaking changes)
* `vortex-bytebool`: 0.14.0 -> 0.15.2 (✓ API compatible changes)
* `vortex-datetime-parts`: 0.14.0 -> 0.15.2 (✓ API compatible changes)
* `vortex-dict`: 0.14.0 -> 0.15.2 (✓ API compatible changes)
* `vortex-expr`: 0.14.0 -> 0.15.2 (✓ API compatible changes)
* `vortex-fsst`: 0.14.0 -> 0.15.2
* `vortex-roaring`: 0.14.0 -> 0.15.2 (⚠️ API breaking changes)
* `vortex-runend`: 0.14.0 -> 0.15.2 (✓ API compatible changes)
* `vortex-runend-bool`: 0.14.0 -> 0.15.2 (✓ API compatible changes)
* `vortex-sampling-compressor`: 0.14.0 -> 0.15.2 (⚠️ API breaking changes)
* `vortex-zigzag`: 0.14.0 -> 0.15.2 (⚠️ API breaking changes)
* `vortex-schema`: 0.14.0 -> 0.15.2
* `vortex-serde`: 0.14.0 -> 0.15.2 (⚠️ API breaking changes)
* `vortex-datafusion`: 0.14.0 -> 0.15.2 (✓ API compatible changes)

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/inherent_method_missing.ron

Failed in:
  ALPArray::ptype, previously in file /tmp/.tmpRakPHw/vortex-alp/src/alp/array.rs:109
```

```
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum Stat in /tmp/.tmpW47nDN/vortex/vortex-array/src/stats/mod.rs:24

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_missing.ron

Failed in:
  enum vortex_array::Array, previously in file /tmp/.tmpRakPHw/vortex-array/src/lib.rs:68

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/inherent_method_missing.ron

Failed in:
  StatsSet::merge, previously in file /tmp/.tmpRakPHw/vortex-array/src/stats/statsset.rs:88

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/method_parameter_count_changed.ron

Failed in:
  vortex_array::array::PrimitiveArray::patch now takes 4 parameters instead of 3, in /tmp/.tmpW47nDN/vortex/vortex-array/src/array/primitive/mod.rs:161

--- failure trait_method_default_impl_removed: pub trait default method impl removed ---

Description:
A method's default impl in an unsealed trait has been removed, breaking trait implementations that relied on that default
        ref: https://doc.rust-lang.org/book/ch10-02-traits.html#default-implementations
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/trait_method_default_impl_removed.ron

Failed in:
  trait method vortex_array::variants::BoolArrayTrait::invert in file /tmp/.tmpW47nDN/vortex/vortex-array/src/variants.rs:91
```

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_missing.ron

Failed in:
  enum vortex_buffer::Buffer, previously in file /tmp/.tmpRakPHw/vortex-buffer/src/lib.rs:26
```

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_missing.ron

Failed in:
  struct vortex_datetime_dtype::TIMESTAMP_ID, previously in file /tmp/.tmpRakPHw/vortex-datetime-dtype/src/temporal.rs:11
  struct vortex_datetime_dtype::DATE_ID, previously in file /tmp/.tmpRakPHw/vortex-datetime-dtype/src/temporal.rs:11
  struct vortex_datetime_dtype::TIME_ID, previously in file /tmp/.tmpRakPHw/vortex-datetime-dtype/src/temporal.rs:11
```

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field PostscriptArgs.layout_offset in /tmp/.tmpW47nDN/vortex/vortex-flatbuffers/src/./generated/footer.rs:395
  field LayoutArgs.row_count in /tmp/.tmpW47nDN/vortex/vortex-flatbuffers/src/./generated/footer.rs:250

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_missing.ron

Failed in:
  enum vortex_flatbuffers::footer::FooterOffset, previously in file /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:301

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/function_missing.ron

Failed in:
  function vortex_flatbuffers::footer::size_prefixed_root_as_footer, previously in file /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:546
  function vortex_flatbuffers::footer::root_as_footer_unchecked, previously in file /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:579
  function vortex_flatbuffers::footer::root_as_footer_with_opts, previously in file /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:556
  function vortex_flatbuffers::footer::finish_footer_buffer, previously in file /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:590
  function vortex_flatbuffers::footer::size_prefixed_root_as_footer_unchecked, previously in file /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:586
  function vortex_flatbuffers::footer::size_prefixed_root_as_footer_with_opts, previously in file /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:569
  function vortex_flatbuffers::footer::finish_size_prefixed_footer_buffer, previously in file /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:597
  function vortex_flatbuffers::footer::root_as_footer, previously in file /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:536

--- failure inherent_associated_pub_const_missing: inherent impl's associated pub const removed ---

Description:
An inherent impl's associated public constant is removed or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/inherent_associated_pub_const_missing.ron

Failed in:
  Layout::VT_LENGTH, previously at /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:155
  Postscript::VT_FOOTER_OFFSET, previously at /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:432

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/inherent_method_missing.ron

Failed in:
  PostscriptBuilder::add_footer_offset, previously in file /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:503
  Layout::length, previously in file /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:199
  Postscript::footer_offset, previously in file /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:458
  LayoutBuilder::add_length, previously in file /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:268

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_missing.ron

Failed in:
  struct vortex_flatbuffers::footer::FooterArgs, previously in file /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:365
  struct vortex_flatbuffers::footer::Footer, previously in file /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:304
  struct vortex_flatbuffers::footer::FooterBuilder, previously in file /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:379

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field footer_offset of struct PostscriptArgs, previously in file /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:481
  field length of struct LayoutArgs, previously in file /tmp/.tmpRakPHw/vortex-flatbuffers/src/./generated/footer.rs:234
```

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/inherent_method_missing.ron

Failed in:
  BitPackedArray::ptype, previously in file /tmp/.tmpRakPHw/vortex-fastlanes/src/bitpacking/mod.rs:201
  FoRArray::ptype, previously in file /tmp/.tmpRakPHw/vortex-fastlanes/src/for/mod.rs:84
```

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/inherent_method_missing.ron

Failed in:
  RoaringIntArray::ptype, previously in file /tmp/.tmpRakPHw/vortex-roaring/src/integer/mod.rs:86
```

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/inherent_method_missing.ron

Failed in:
  CompressedArray::new, previously in file /tmp/.tmpRakPHw/vortex-sampling-compressor/src/compressors/mod.rs:191

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_missing.ron

Failed in:
  struct vortex_sampling_compressor::FASTEST_COMPRESSORS, previously in file /tmp/.tmpRakPHw/vortex-sampling-compressor/src/lib.rs:50
  struct vortex_sampling_compressor::DEFAULT_COMPRESSORS, previously in file /tmp/.tmpRakPHw/vortex-sampling-compressor/src/lib.rs:50
  struct vortex_sampling_compressor::ALL_COMPRESSORS_CONTEXT, previously in file /tmp/.tmpRakPHw/vortex-sampling-compressor/src/lib.rs:50
```

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/inherent_method_missing.ron

Failed in:
  ZigZagArray::ptype, previously in file /tmp/.tmpRakPHw/vortex-zigzag/src/array.rs:66
```

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_missing.ron

Failed in:
  enum vortex_serde::layouts::BatchRead, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/read/mod.rs:58

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/module_missing.ron

Failed in:
  mod vortex_serde::layouts, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/mod.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  INITIAL_READ_SIZE in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/read/mod.rs:36
  EOF_SIZE in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/mod.rs:12
  CHUNKED_LAYOUT_ID in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/mod.rs:14
  FOOTER_POSTSCRIPT_SIZE in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/mod.rs:11
  MAGIC_BYTES in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/mod.rs:9
  COLUMN_LAYOUT_ID in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/mod.rs:15
  VERSION in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/mod.rs:8
  INLINE_SCHEMA_LAYOUT_ID in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/mod.rs:16
  FLAT_LAYOUT_ID in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/mod.rs:13

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_missing.ron

Failed in:
  struct vortex_serde::layouts::LayoutDescriptorReader, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/read/footer.rs:140
  struct vortex_serde::layouts::LayoutContext, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/read/context.rs:41
  struct vortex_serde::layouts::LazyDeserializedDType, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/read/cache.rs:48
  struct vortex_serde::layouts::LayoutBatchStream, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/read/stream.rs:26
  struct vortex_serde::layouts::RelativeLayoutCache, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/read/cache.rs:141
  struct vortex_serde::layouts::LayoutMessageCache, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/read/cache.rs:17
  struct vortex_serde::layouts::RowFilter, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/read/filtering.rs:19
  struct vortex_serde::layouts::Layout, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/write/layouts.rs:11
  struct vortex_serde::layouts::LayoutWriter, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/write/writer.rs:21
  struct vortex_serde::layouts::VortexRecordBatchReader, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/read/recordbatchreader.rs:28
  struct vortex_serde::layouts::Scan, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/read/mod.rs:40
  struct vortex_serde::layouts::LayoutDeserializer, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/read/context.rs:72
  struct vortex_serde::layouts::LayoutId, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/read/context.rs:17
  struct vortex_serde::layouts::LayoutReaderBuilder, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/read/builder.rs:16

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/trait_missing.ron

Failed in:
  trait vortex_serde::layouts::LayoutSpec, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/read/context.rs:25
  trait vortex_serde::layouts::LayoutReader, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/read/mod.rs:63
  trait vortex_serde::layouts::AsyncRuntime, previously in file /tmp/.tmpRakPHw/vortex-serde/src/layouts/read/recordbatchreader.rs:24
```

<details><summary><i><b>Changelog</b></i></summary><p>

</p></details>