### PR TITLE
fix: release-plz-pr "needs" release-plz-release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -37,6 +37,7 @@ jobs:
 
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:
+    needs: [ release-plz-release ]
     name: Release-plz PR
     runs-on: ubuntu-latest
     concurrency:


### PR DESCRIPTION
If release-plz-pr sees that the local version is greater than the version in the crates.io registry, it does not create a new PR. We need to wait for the release to complete so that this step can trigger a new release PR.