### PR TITLE
feat: kleene_or, kleene_and, and restore SQL semantics

### DIFF
--- a/pyvortex/src/expr.rs
+++ b/pyvortex/src/expr.rs
@@ -99,8 +99,8 @@ use crate::dtype::PyDType;
 ///   ]
 ///
 /// Read rows whose name is `Angela` or whose age is between 20 and 30, inclusive. Notice that the
-/// Angela row is excluded because its age is null. The entire row filtering expression therefore
-/// evaluates to null which is interpreted as false:
+/// Angela row is included even though its age is null. Under SQL / Kleene semantics, `true or
+/// null` is `true`.
 ///
 /// >>> name = vortex.expr.column("name")
 /// >>> e = vortex.io.read_path("a.vortex", row_filter = (name == "Angela") | ((age >= 20) & (age <= 30)))

--- a/pyvortex/src/expr.rs
+++ b/pyvortex/src/expr.rs
@@ -109,11 +109,13 @@ use crate::dtype::PyDType;
 /// -- is_valid: all not null
 /// -- child 0 type: int64
 ///   [
-///     25
+///     25,
+///     null
 ///   ]
 /// -- child 1 type: string_view
 ///   [
-///     "Joseph"
+///     "Joseph",
+///     "Angela"
 ///   ]
 #[pyclass(name = "Expr", module = "vortex")]
 pub struct PyExpr {

--- a/vortex-array/src/array/bool/compute/boolean.rs
+++ b/vortex-array/src/array/bool/compute/boolean.rs
@@ -1,5 +1,7 @@
 use arrow_arith::boolean;
 use arrow_array::cast::AsArray as _;
+use arrow_array::{Array as _, BooleanArray};
+use arrow_schema::ArrowError;
 use vortex_error::VortexResult;
 
 use crate::array::BoolArray;
@@ -7,30 +9,40 @@ use crate::arrow::FromArrowArray as _;
 use crate::compute::{AndFn, OrFn};
 use crate::{Array, IntoCanonical};
 
-impl OrFn for BoolArray {
-    fn or(&self, array: &Array) -> VortexResult<Array> {
+impl BoolArray {
+    /// Lift an Arrow binary boolean kernel function to Vortex arrays.
+    fn lift_arrow<F>(&self, arrow_fun: F, other: &Array) -> VortexResult<Array>
+    where
+        F: FnOnce(&BooleanArray, &BooleanArray) -> Result<BooleanArray, ArrowError>,
+    {
         let lhs = self.clone().into_canonical()?.into_arrow()?;
         let lhs = lhs.as_boolean();
 
-        let rhs = array.clone().into_canonical()?.into_arrow()?;
+        let rhs = other.clone().into_canonical()?.into_arrow()?;
         let rhs = rhs.as_boolean();
 
-        let array = boolean::or(lhs, rhs)?;
+        let array = arrow_fun(lhs, rhs)?;
 
-        Ok(Array::from_arrow(&array, true))
+        Ok(Array::from_arrow(&array, array.is_nullable()))
+    }
+}
+
+impl OrFn for BoolArray {
+    fn or(&self, array: &Array) -> VortexResult<Array> {
+        self.lift_arrow(boolean::or, array)
+    }
+
+    fn or_kleene(&self, array: &Array) -> VortexResult<Array> {
+        self.lift_arrow(boolean::or_kleene, array)
     }
 }
 
 impl AndFn for BoolArray {
     fn and(&self, array: &Array) -> VortexResult<Array> {
-        let lhs = self.clone().into_canonical()?.into_arrow()?;
-        let lhs = lhs.as_boolean();
+        self.lift_arrow(boolean::and, array)
+    }
 
-        let rhs = array.clone().into_canonical()?.into_arrow()?;
-        let rhs = rhs.as_boolean();
-
-        let array = boolean::and(lhs, rhs)?;
-
-        Ok(Array::from_arrow(&array, true))
+    fn and_kleene(&self, array: &Array) -> VortexResult<Array> {
+        self.lift_arrow(boolean::and_kleene, array)
     }
 }

--- a/vortex-array/src/array/constant/compute.rs
+++ b/vortex-array/src/array/constant/compute.rs
@@ -119,7 +119,7 @@ impl MaybeCompareFn for ConstantArray {
     }
 }
 
-fn arrow_and(left: Option<bool>, right: Option<bool>) -> Option<bool> {
+fn and(left: Option<bool>, right: Option<bool>) -> Option<bool> {
     left.zip(right).map(|(l, r)| l & r)
 }
 
@@ -133,7 +133,7 @@ fn kleene_and(left: Option<bool>, right: Option<bool>) -> Option<bool> {
     }
 }
 
-fn arrow_or(left: Option<bool>, right: Option<bool>) -> Option<bool> {
+fn or(left: Option<bool>, right: Option<bool>) -> Option<bool> {
     left.zip(right).map(|(l, r)| l | r)
 }
 
@@ -149,7 +149,7 @@ fn kleene_or(left: Option<bool>, right: Option<bool>) -> Option<bool> {
 
 impl AndFn for ConstantArray {
     fn and(&self, array: &Array) -> VortexResult<Array> {
-        constant_array_bool_impl(self, array, arrow_and, |other, this| {
+        constant_array_bool_impl(self, array, and, |other, this| {
             other.with_dyn(|other| other.and().map(|other| other.and(this)))
         })
     }
@@ -163,7 +163,7 @@ impl AndFn for ConstantArray {
 
 impl OrFn for ConstantArray {
     fn or(&self, array: &Array) -> VortexResult<Array> {
-        constant_array_bool_impl(self, array, arrow_or, |other, this| {
+        constant_array_bool_impl(self, array, or, |other, this| {
             other.with_dyn(|other| other.or().map(|other| other.or(this)))
         })
     }

--- a/vortex-array/src/array/constant/compute.rs
+++ b/vortex-array/src/array/constant/compute.rs
@@ -119,32 +119,66 @@ impl MaybeCompareFn for ConstantArray {
     }
 }
 
+fn arrow_and(left: Option<bool>, right: Option<bool>) -> Option<bool> {
+    left.zip(right).map(|(l, r)| l & r)
+}
+
+fn kleene_and(left: Option<bool>, right: Option<bool>) -> Option<bool> {
+    match (left, right) {
+        (Some(false), _) => Some(false),
+        (_, Some(false)) => Some(false),
+        (None, _) => None,
+        (_, None) => None,
+        (Some(l), Some(r)) => Some(l & r),
+    }
+}
+
+fn arrow_or(left: Option<bool>, right: Option<bool>) -> Option<bool> {
+    left.zip(right).map(|(l, r)| l | r)
+}
+
+fn kleene_or(left: Option<bool>, right: Option<bool>) -> Option<bool> {
+    match (left, right) {
+        (Some(true), _) => Some(true),
+        (_, Some(true)) => Some(true),
+        (None, _) => None,
+        (_, None) => None,
+        (Some(l), Some(r)) => Some(l | r),
+    }
+}
+
 impl AndFn for ConstantArray {
     fn and(&self, array: &Array) -> VortexResult<Array> {
-        constant_array_bool_impl(
-            self,
-            array,
-            |(l, r)| l & r,
-            |other, this| other.with_dyn(|other| other.and().map(|other| other.and(this))),
-        )
+        constant_array_bool_impl(self, array, arrow_and, |other, this| {
+            other.with_dyn(|other| other.and().map(|other| other.and(this)))
+        })
+    }
+
+    fn and_kleene(&self, array: &Array) -> VortexResult<Array> {
+        constant_array_bool_impl(self, array, kleene_and, |other, this| {
+            other.with_dyn(|other| other.and_kleene().map(|other| other.and_kleene(this)))
+        })
     }
 }
 
 impl OrFn for ConstantArray {
     fn or(&self, array: &Array) -> VortexResult<Array> {
-        constant_array_bool_impl(
-            self,
-            array,
-            |(l, r)| l | r,
-            |other, this| other.with_dyn(|other| other.or().map(|other| other.or(this))),
-        )
+        constant_array_bool_impl(self, array, arrow_or, |other, this| {
+            other.with_dyn(|other| other.or().map(|other| other.or(this)))
+        })
+    }
+
+    fn or_kleene(&self, array: &Array) -> VortexResult<Array> {
+        constant_array_bool_impl(self, array, kleene_or, |other, this| {
+            other.with_dyn(|other| other.or_kleene().map(|other| other.or_kleene(this)))
+        })
     }
 }
 
 fn constant_array_bool_impl(
     constant_array: &ConstantArray,
     other: &Array,
-    bool_op: impl Fn((bool, bool)) -> bool,
+    bool_op: impl Fn(Option<bool>, Option<bool>) -> Option<bool>,
     fallback_fn: impl Fn(&Array, &Array) -> Option<VortexResult<Array>>,
 ) -> VortexResult<Array> {
     // If the right side is constant
@@ -152,7 +186,7 @@ fn constant_array_bool_impl(
         let lhs = constant_array.scalar_value().as_bool()?;
         let rhs = scalar_at(other, 0)?.value().as_bool()?;
 
-        let scalar = match lhs.zip(rhs).map(bool_op) {
+        let scalar = match bool_op(lhs, rhs) {
             Some(b) => Scalar::bool(b, Nullability::Nullable),
             None => Scalar::null(constant_array.dtype().as_nullable()),
         };

--- a/vortex-array/src/compute/mod.rs
+++ b/vortex-array/src/compute/mod.rs
@@ -7,7 +7,7 @@
 //! implementations of these operators, else we will decode, and perform the equivalent operator
 //! from Arrow.
 
-pub use boolean::{and, or, AndFn, OrFn};
+pub use boolean::{and, and_kleene, or, or_kleene, AndFn, OrFn};
 pub use compare::{compare, scalar_cmp, CompareFn, MaybeCompareFn, Operator};
 pub use filter::{filter, FilterFn};
 pub use search_sorted::*;
@@ -93,17 +93,31 @@ pub trait ArrayCompute {
         None
     }
 
-    /// Perform a boolean AND operation over two arrays
+    /// Perform an Arrow-style boolean AND operation over two arrays
     ///
     /// See: [AndFn].
     fn and(&self) -> Option<&dyn AndFn> {
         None
     }
 
-    /// Perform a boolean OR operation over two arrays
+    /// Perform a Kleene-style boolean AND operation over two arrays
+    ///
+    /// See: [AndFn].
+    fn and_kleene(&self) -> Option<&dyn AndFn> {
+        None
+    }
+
+    /// Perform an Arrow-style boolean OR operation over two arrays
     ///
     /// See: [OrFn].
     fn or(&self) -> Option<&dyn OrFn> {
+        None
+    }
+
+    /// Perform a Kleene-style boolean OR operation over two arrays
+    ///
+    /// See: [OrFn].
+    fn or_kleene(&self) -> Option<&dyn OrFn> {
         None
     }
 }

--- a/vortex-array/src/variants.rs
+++ b/vortex-array/src/variants.rs
@@ -98,10 +98,20 @@ pub trait BoolArrayTrait: ArrayTrait {
 
     /// An iterator over the sorted indices of set values in the underlying boolean array
     /// good to array with low number of set values.
+    ///
+    /// # Warning
+    ///
+    /// The set-ness of invalid positions is undefined and not necessarily consistent within a given
+    /// iterator.
     fn maybe_null_indices_iter<'a>(&'a self) -> Box<dyn Iterator<Item = usize> + 'a>;
 
-    /// An iterator over the sorted disjoint contiguous range set values in the underlying boolean
+    /// An iterator over the sorted disjoint contiguous range of set values in the underlying boolean
     /// array good for arrays with only long runs of set values.
+    ///
+    /// # Warning
+    ///
+    /// The set-ness of invalid positions is undefined and not necessarily consistent within a given
+    /// iterator.
     fn maybe_null_slices_iter<'a>(&'a self) -> Box<dyn Iterator<Item = (usize, usize)> + 'a>;
 
     // Other possible iterators include:

--- a/vortex-expr/src/binary.rs
+++ b/vortex-expr/src/binary.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::sync::Arc;
 
 use vortex_array::aliases::hash_set::HashSet;
-use vortex_array::compute::{and, compare, or, Operator as ArrayOperator};
+use vortex_array::compute::{and_kleene, compare, or_kleene, Operator as ArrayOperator};
 use vortex_array::Array;
 use vortex_dtype::field::Field;
 use vortex_error::VortexResult;
@@ -50,8 +50,8 @@ impl VortexExpr for BinaryExpr {
             Operator::Lte => compare(lhs, rhs, ArrayOperator::Lte),
             Operator::Gt => compare(lhs, rhs, ArrayOperator::Gt),
             Operator::Gte => compare(lhs, rhs, ArrayOperator::Gte),
-            Operator::And => and(lhs, rhs),
-            Operator::Or => or(lhs, rhs),
+            Operator::And => and_kleene(lhs, rhs),
+            Operator::Or => or_kleene(lhs, rhs),
         }
     }
 

--- a/vortex-serde/src/file/tests.rs
+++ b/vortex-serde/src/file/tests.rs
@@ -465,14 +465,17 @@ async fn filter_or() {
                 .map(|s| unsafe { String::from_utf8_unchecked(s.to_vec()) })
                 .collect::<Vec<_>>())
             .unwrap(),
-        vec!["Joseph".to_string()]
+        vec!["Joseph".to_string(), "Angela".to_string()]
     );
     let ages = result[0]
         .with_dyn(|a| a.as_struct_array_unchecked().field(1))
         .unwrap();
     assert_eq!(
-        ages.into_primitive().unwrap().maybe_null_slice::<i32>(),
-        vec![25]
+        ages.into_primitive()
+            .unwrap()
+            .with_iterator(|iter| iter.map(|x| x.cloned()).collect::<Vec<_>>())
+            .unwrap(),
+        vec![Some(25), None]
     );
 }
 


### PR DESCRIPTION
I noticed that our row filters disagreed with DuckDB's semantics which is SQL semantics, in particular `where true or null` _keeps_ the row (we filtered it).

cc: @robert3005 we'll probably conflict on #1272