### PR TITLE
fix: use macos-13, which maturin tests against

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -60,7 +60,7 @@ jobs:
   macos:
     needs: release-plz-release
     if: ${{ needs.release-plz-release.outputs.releases_created == 'true' }}
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cleanup


### PR DESCRIPTION
https://github.com/PyO3/maturin-action/blob/main/.github/workflows/test.yml#L38

Fixes the 0.14.2 and 0.13.0 macOS Python packaging failures. Notice that all these jobs use macOS 14.7.
- 0.14.2: https://github.com/spiraldb/vortex/actions/runs/11821278964/job/32936900282
- 0.13.0: https://github.com/spiraldb/vortex/actions/runs/11630848959/job/32391375552

Neither 0.14.0 nor 0.14.1 failed before macOS build.

0.12.0 was the last passing one. It used macOS 14.6:
- 0.12.0 https://github.com/spiraldb/vortex/actions/runs/11166071447/job/31039891955


See also:
- https://github.com/PyO3/maturin/issues/284
- https://github.com/PyO3/maturin-action/issues/291