### PR TITLE
Faster boolean stats

### DIFF
--- a/vortex-array/src/array/bool/stats.rs
+++ b/vortex-array/src/array/bool/stats.rs
@@ -3,11 +3,12 @@ use std::ops::BitAnd;
 use arrow_buffer::BooleanBuffer;
 use itertools::Itertools;
 use vortex_dtype::{DType, Nullability};
-use vortex_error::{vortex_err, VortexResult};
+use vortex_error::VortexResult;
+use vortex_scalar::Scalar;
 
 use crate::aliases::hash_map::HashMap;
 use crate::array::BoolArray;
-use crate::stats::{ArrayStatistics, ArrayStatisticsCompute, Stat, StatsSet};
+use crate::stats::{ArrayStatisticsCompute, Stat, StatsSet};
 use crate::validity::{ArrayValidity, LogicalValidity};
 use crate::{ArrayDType, IntoArrayVariant};
 
@@ -15,23 +16,6 @@ impl ArrayStatisticsCompute for BoolArray {
     fn compute_statistics(&self, stat: Stat) -> VortexResult<StatsSet> {
         if self.is_empty() {
             return Ok(StatsSet::new());
-        }
-
-        // Short-circuit a few stats that all delegate to true_count
-        let true_count = || {
-            self.as_ref()
-                .statistics()
-                .compute_true_count()
-                .ok_or_else(|| vortex_err!("BoolArray doesn't implement true_count stat"))
-        };
-        match stat {
-            Stat::Min => return Ok(StatsSet::of(stat, true_count()? == 0)),
-            Stat::Max => return Ok(StatsSet::of(stat, true_count()? > 0)),
-            Stat::IsConstant => {
-                let count = true_count()?;
-                return Ok(StatsSet::of(stat, count == 0 || count == self.len()));
-            }
-            _ => {}
         }
 
         match self.logical_validity() {
@@ -50,9 +34,15 @@ struct NullableBools<'a>(&'a BooleanBuffer, &'a BooleanBuffer);
 
 impl ArrayStatisticsCompute for NullableBools<'_> {
     fn compute_statistics(&self, stat: Stat) -> VortexResult<StatsSet> {
-        if stat == Stat::TrueCount {
-            // Fast-path if we just want the true-count
-            return Ok(StatsSet::of(stat, self.0.bitand(self.1).count_set_bits()));
+        // Fast-path if we just want the true-count
+        if matches!(
+            stat,
+            Stat::TrueCount | Stat::Min | Stat::Max | Stat::IsConstant
+        ) {
+            return Ok(true_count_stats(
+                self.0.bitand(self.1).count_set_bits(),
+                self.0.len(),
+            ));
         }
 
         let first_non_null_idx = self
@@ -84,19 +74,30 @@ impl ArrayStatisticsCompute for NullableBools<'_> {
 
 impl ArrayStatisticsCompute for BooleanBuffer {
     fn compute_statistics(&self, stat: Stat) -> VortexResult<StatsSet> {
-        if self.is_empty() {
-            return Ok(StatsSet::new());
-        }
-
-        if stat == Stat::TrueCount {
-            // Fast-path if we just want the true-count
-            return Ok(StatsSet::of(stat, self.count_set_bits()));
+        // Fast-path if we just want the true-count
+        if matches!(
+            stat,
+            Stat::TrueCount | Stat::Min | Stat::Max | Stat::IsConstant
+        ) {
+            return Ok(true_count_stats(self.count_set_bits(), self.len()));
         }
 
         let mut stats = BoolStatsAccumulator::new(self.value(0));
         self.iter().skip(1).for_each(|next| stats.next(next));
         Ok(stats.finish())
     }
+}
+
+fn true_count_stats(true_count: usize, len: usize) -> StatsSet {
+    StatsSet::from(HashMap::<Stat, Scalar>::from([
+        (Stat::TrueCount, true_count.into()),
+        (Stat::Min, (true_count > 0).into()),
+        (Stat::Max, (true_count < len).into()),
+        (
+            Stat::IsConstant,
+            (true_count == 0 || true_count == len).into(),
+        ),
+    ]))
 }
 
 struct BoolStatsAccumulator {

--- a/vortex-array/src/array/bool/stats.rs
+++ b/vortex-array/src/array/bool/stats.rs
@@ -1,3 +1,5 @@
+use std::ops::BitAnd;
+
 use arrow_buffer::BooleanBuffer;
 use itertools::Itertools;
 use vortex_dtype::{DType, Nullability};
@@ -47,7 +49,12 @@ impl ArrayStatisticsCompute for BoolArray {
 pub(super) struct NullableBools<'a>(&'a BooleanBuffer, &'a BooleanBuffer);
 
 impl ArrayStatisticsCompute for NullableBools<'_> {
-    fn compute_statistics(&self, _stat: Stat) -> VortexResult<StatsSet> {
+    fn compute_statistics(&self, stat: Stat) -> VortexResult<StatsSet> {
+        if stat == Stat::TrueCount {
+            // Fast-path if we just want the true-count
+            return Ok(StatsSet::of(stat, self.0.bitand(self.1).count_set_bits()));
+        }
+
         let first_non_null_idx = self
             .1
             .iter()
@@ -82,6 +89,7 @@ impl ArrayStatisticsCompute for BooleanBuffer {
         }
 
         if stat == Stat::TrueCount {
+            // Fast-path if we just want the true-count
             return Ok(StatsSet::of(stat, self.count_set_bits()));
         }
 

--- a/vortex-array/src/array/bool/stats.rs
+++ b/vortex-array/src/array/bool/stats.rs
@@ -46,7 +46,7 @@ impl ArrayStatisticsCompute for BoolArray {
     }
 }
 
-pub(super) struct NullableBools<'a>(&'a BooleanBuffer, &'a BooleanBuffer);
+struct NullableBools<'a>(&'a BooleanBuffer, &'a BooleanBuffer);
 
 impl ArrayStatisticsCompute for NullableBools<'_> {
     fn compute_statistics(&self, stat: Stat) -> VortexResult<StatsSet> {

--- a/vortex-array/src/array/bool/stats.rs
+++ b/vortex-array/src/array/bool/stats.rs
@@ -1,11 +1,11 @@
 use arrow_buffer::BooleanBuffer;
 use itertools::Itertools;
 use vortex_dtype::{DType, Nullability};
-use vortex_error::VortexResult;
+use vortex_error::{vortex_err, VortexResult};
 
 use crate::aliases::hash_map::HashMap;
 use crate::array::BoolArray;
-use crate::stats::{ArrayStatisticsCompute, Stat, StatsSet};
+use crate::stats::{ArrayStatistics, ArrayStatisticsCompute, Stat, StatsSet};
 use crate::validity::{ArrayValidity, LogicalValidity};
 use crate::{ArrayDType, IntoArrayVariant};
 
@@ -13,6 +13,23 @@ impl ArrayStatisticsCompute for BoolArray {
     fn compute_statistics(&self, stat: Stat) -> VortexResult<StatsSet> {
         if self.is_empty() {
             return Ok(StatsSet::new());
+        }
+
+        // Short-circuit a few stats that all delegate to true_count
+        let true_count = || {
+            self.as_ref()
+                .statistics()
+                .compute_true_count()
+                .ok_or_else(|| vortex_err!("BoolArray doesn't implement true_count stat"))
+        };
+        match stat {
+            Stat::Min => return Ok(StatsSet::of(stat, true_count()? == 0)),
+            Stat::Max => return Ok(StatsSet::of(stat, true_count()? > 0)),
+            Stat::IsConstant => {
+                let count = true_count()?;
+                return Ok(StatsSet::of(stat, count == 0 || count == self.len()));
+            }
+            _ => {}
         }
 
         match self.logical_validity() {
@@ -27,7 +44,7 @@ impl ArrayStatisticsCompute for BoolArray {
     }
 }
 
-struct NullableBools<'a>(&'a BooleanBuffer, &'a BooleanBuffer);
+pub(super) struct NullableBools<'a>(&'a BooleanBuffer, &'a BooleanBuffer);
 
 impl ArrayStatisticsCompute for NullableBools<'_> {
     fn compute_statistics(&self, _stat: Stat) -> VortexResult<StatsSet> {
@@ -59,9 +76,13 @@ impl ArrayStatisticsCompute for NullableBools<'_> {
 }
 
 impl ArrayStatisticsCompute for BooleanBuffer {
-    fn compute_statistics(&self, _stat: Stat) -> VortexResult<StatsSet> {
+    fn compute_statistics(&self, stat: Stat) -> VortexResult<StatsSet> {
         if self.is_empty() {
             return Ok(StatsSet::new());
+        }
+
+        if stat == Stat::TrueCount {
+            return Ok(StatsSet::of(stat, self.count_set_bits()));
         }
 
         let mut stats = BoolStatsAccumulator::new(self.value(0));
@@ -123,15 +144,7 @@ impl BoolStatsAccumulator {
 
     pub fn finish(self) -> StatsSet {
         StatsSet::from(HashMap::from([
-            (Stat::Min, (self.true_count == self.len).into()),
-            (Stat::Max, (self.true_count > 0).into()),
             (Stat::NullCount, self.null_count.into()),
-            (
-                Stat::IsConstant,
-                (self.null_count == 0 && (self.true_count == self.len || self.true_count == 0)
-                    || self.null_count == self.len)
-                    .into(),
-            ),
             (Stat::IsSorted, self.is_sorted.into()),
             (
                 Stat::IsStrictSorted,
@@ -139,7 +152,6 @@ impl BoolStatsAccumulator {
                     .into(),
             ),
             (Stat::RunCount, self.run_count.into()),
-            (Stat::TrueCount, self.true_count.into()),
         ]))
     }
 }

--- a/vortex-array/src/array/bool/stats.rs
+++ b/vortex-array/src/array/bool/stats.rs
@@ -91,8 +91,8 @@ impl ArrayStatisticsCompute for BooleanBuffer {
 fn true_count_stats(true_count: usize, len: usize) -> StatsSet {
     StatsSet::from(HashMap::<Stat, Scalar>::from([
         (Stat::TrueCount, true_count.into()),
-        (Stat::Min, (true_count > 0).into()),
-        (Stat::Max, (true_count < len).into()),
+        (Stat::Min, (true_count == len).into()),
+        (Stat::Max, (true_count > 0).into()),
         (
             Stat::IsConstant,
             (true_count == 0 || true_count == len).into(),

--- a/vortex-array/src/stats/statsset.rs
+++ b/vortex-array/src/stats/statsset.rs
@@ -87,8 +87,8 @@ impl StatsSet {
         stats
     }
 
-    pub fn of(stat: Stat, value: Scalar) -> Self {
-        Self::from(HashMap::from([(stat, value)]))
+    pub fn of<S: Into<Scalar>>(stat: Stat, value: S) -> Self {
+        Self::from(HashMap::from([(stat, value.into())]))
     }
 
     pub fn get(&self, stat: Stat) -> Option<&Scalar> {

--- a/vortex-array/src/stats/statsset.rs
+++ b/vortex-array/src/stats/statsset.rs
@@ -317,7 +317,7 @@ mod test {
 
     #[test]
     fn merge_into_min() {
-        let mut first = StatsSet::of(Stat::Min, 42.into());
+        let mut first = StatsSet::of(Stat::Min, 42);
         first.merge_ordered(&StatsSet::new());
         assert_eq!(first.get(Stat::Min), None);
     }
@@ -325,20 +325,20 @@ mod test {
     #[test]
     fn merge_from_min() {
         let mut first = StatsSet::new();
-        first.merge_ordered(&StatsSet::of(Stat::Min, 42.into()));
+        first.merge_ordered(&StatsSet::of(Stat::Min, 42));
         assert_eq!(first.get(Stat::Min), None);
     }
 
     #[test]
     fn merge_mins() {
-        let mut first = StatsSet::of(Stat::Min, 37.into());
-        first.merge_ordered(&StatsSet::of(Stat::Min, 42.into()));
+        let mut first = StatsSet::of(Stat::Min, 37);
+        first.merge_ordered(&StatsSet::of(Stat::Min, 42));
         assert_eq!(first.get(Stat::Min).cloned(), Some(37.into()));
     }
 
     #[test]
     fn merge_into_max() {
-        let mut first = StatsSet::of(Stat::Max, 42.into());
+        let mut first = StatsSet::of(Stat::Max, 42);
         first.merge_ordered(&StatsSet::new());
         assert_eq!(first.get(Stat::Max), None);
     }
@@ -346,20 +346,20 @@ mod test {
     #[test]
     fn merge_from_max() {
         let mut first = StatsSet::new();
-        first.merge_ordered(&StatsSet::of(Stat::Max, 42.into()));
+        first.merge_ordered(&StatsSet::of(Stat::Max, 42));
         assert_eq!(first.get(Stat::Max), None);
     }
 
     #[test]
     fn merge_maxes() {
-        let mut first = StatsSet::of(Stat::Max, 37.into());
-        first.merge_ordered(&StatsSet::of(Stat::Max, 42.into()));
+        let mut first = StatsSet::of(Stat::Max, 37);
+        first.merge_ordered(&StatsSet::of(Stat::Max, 42));
         assert_eq!(first.get(Stat::Max).cloned(), Some(42.into()));
     }
 
     #[test]
     fn merge_into_scalar() {
-        let mut first = StatsSet::of(Stat::TrueCount, 42.into());
+        let mut first = StatsSet::of(Stat::TrueCount, 42);
         first.merge_ordered(&StatsSet::new());
         assert_eq!(first.get(Stat::TrueCount), None);
     }
@@ -367,21 +367,21 @@ mod test {
     #[test]
     fn merge_from_scalar() {
         let mut first = StatsSet::new();
-        first.merge_ordered(&StatsSet::of(Stat::TrueCount, 42.into()));
+        first.merge_ordered(&StatsSet::of(Stat::TrueCount, 42));
         assert_eq!(first.get(Stat::TrueCount), None);
     }
 
     #[test]
     fn merge_scalars() {
-        let mut first = StatsSet::of(Stat::TrueCount, 37.into());
-        first.merge_ordered(&StatsSet::of(Stat::TrueCount, 42.into()));
+        let mut first = StatsSet::of(Stat::TrueCount, 37);
+        first.merge_ordered(&StatsSet::of(Stat::TrueCount, 42));
         assert_eq!(first.get(Stat::TrueCount).cloned(), Some(79u64.into()));
     }
 
     #[test]
     fn merge_into_freq() {
         let vec = (0..255).collect_vec();
-        let mut first = StatsSet::of(Stat::BitWidthFreq, vec.into());
+        let mut first = StatsSet::of(Stat::BitWidthFreq, vec);
         first.merge_ordered(&StatsSet::new());
         assert_eq!(first.get(Stat::BitWidthFreq), None);
     }
@@ -390,7 +390,7 @@ mod test {
     fn merge_from_freq() {
         let vec = (0..255).collect_vec();
         let mut first = StatsSet::new();
-        first.merge_ordered(&StatsSet::of(Stat::BitWidthFreq, vec.into()));
+        first.merge_ordered(&StatsSet::of(Stat::BitWidthFreq, vec));
         assert_eq!(first.get(Stat::BitWidthFreq), None);
     }
 
@@ -398,14 +398,14 @@ mod test {
     fn merge_freqs() {
         let vec_in = vec![5u64; 256];
         let vec_out = vec![10u64; 256];
-        let mut first = StatsSet::of(Stat::BitWidthFreq, vec_in.clone().into());
-        first.merge_ordered(&StatsSet::of(Stat::BitWidthFreq, vec_in.into()));
+        let mut first = StatsSet::of(Stat::BitWidthFreq, vec_in.clone());
+        first.merge_ordered(&StatsSet::of(Stat::BitWidthFreq, vec_in));
         assert_eq!(first.get(Stat::BitWidthFreq).cloned(), Some(vec_out.into()));
     }
 
     #[test]
     fn merge_into_sortedness() {
-        let mut first = StatsSet::of(Stat::IsStrictSorted, true.into());
+        let mut first = StatsSet::of(Stat::IsStrictSorted, true);
         first.merge_ordered(&StatsSet::new());
         assert_eq!(first.get(Stat::IsStrictSorted), None);
     }
@@ -413,15 +413,15 @@ mod test {
     #[test]
     fn merge_from_sortedness() {
         let mut first = StatsSet::new();
-        first.merge_ordered(&StatsSet::of(Stat::IsStrictSorted, true.into()));
+        first.merge_ordered(&StatsSet::of(Stat::IsStrictSorted, true));
         assert_eq!(first.get(Stat::IsStrictSorted), None);
     }
 
     #[test]
     fn merge_sortedness() {
-        let mut first = StatsSet::of(Stat::IsStrictSorted, true.into());
+        let mut first = StatsSet::of(Stat::IsStrictSorted, true);
         first.set(Stat::Max, 1.into());
-        let mut second = StatsSet::of(Stat::IsStrictSorted, true.into());
+        let mut second = StatsSet::of(Stat::IsStrictSorted, true);
         second.set(Stat::Min, 2.into());
         first.merge_ordered(&second);
         assert_eq!(first.get(Stat::IsStrictSorted).cloned(), Some(true.into()));
@@ -429,9 +429,9 @@ mod test {
 
     #[test]
     fn merge_sortedness_out_of_order() {
-        let mut first = StatsSet::of(Stat::IsStrictSorted, true.into());
+        let mut first = StatsSet::of(Stat::IsStrictSorted, true);
         first.set(Stat::Min, 1.into());
-        let mut second = StatsSet::of(Stat::IsStrictSorted, true.into());
+        let mut second = StatsSet::of(Stat::IsStrictSorted, true);
         second.set(Stat::Max, 2.into());
         second.merge_ordered(&first);
         assert_eq!(
@@ -442,9 +442,9 @@ mod test {
 
     #[test]
     fn merge_sortedness_only_one_sorted() {
-        let mut first = StatsSet::of(Stat::IsStrictSorted, true.into());
+        let mut first = StatsSet::of(Stat::IsStrictSorted, true);
         first.set(Stat::Max, 1.into());
-        let mut second = StatsSet::of(Stat::IsStrictSorted, false.into());
+        let mut second = StatsSet::of(Stat::IsStrictSorted, false);
         second.set(Stat::Min, 2.into());
         first.merge_ordered(&second);
         assert_eq!(
@@ -455,9 +455,9 @@ mod test {
 
     #[test]
     fn merge_sortedness_missing_min() {
-        let mut first = StatsSet::of(Stat::IsStrictSorted, true.into());
+        let mut first = StatsSet::of(Stat::IsStrictSorted, true);
         first.set(Stat::Max, 1.into());
-        let second = StatsSet::of(Stat::IsStrictSorted, true.into());
+        let second = StatsSet::of(Stat::IsStrictSorted, true);
         first.merge_ordered(&second);
         assert_eq!(first.get(Stat::IsStrictSorted).cloned(), None);
     }


### PR DESCRIPTION
For true count, we just need to count_ones in the u64. This delegates to Arrow for true counts which does the right thing.

There's overall 15% reduction in time for TPCH Q15, didn't run on any others.