### PR TITLE
fix: just skip the universal2 wheel entirely

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -83,13 +83,6 @@ jobs:
           working-directory: pyvortex
           target: aarch64  # NB: aarch64 becomes arm64 in the wheel's platform tag.
           args: --release --interpreter python3.10
-      - name: Build wheels - universal2
-        uses: PyO3/maturin-action@v1
-        with:
-          rust-toolchain: ${{ steps.rust-toolchain.version }}
-          working-directory: pyvortex
-          target: universal2-apple-darwin
-          args: --release --interpreter python3.10
       - name: test wheel
         run: |
           set -ex


### PR DESCRIPTION
> You need to just stop.
> Like can you just not

We already produce a wheel for macOS arm64 and macOS x86_64. Pip will pick the correct wheel. The only real benefit of a universal2 wheel is that, in theory, if there was a lot of shared resources between the amr64 and x86_64 builds, we would only need to upload that to PyPI once. In our case, most of the bulk seems to come from the binary anyway (75MiB before compression).

I suppose another benefit is for folks not using pip: they need not determine which wheel applies. :shrug:.