### PR TITLE
fix: use paths for dev-dependencies within the workspace

### DIFF
--- a/vortex-ipc/Cargo.toml
+++ b/vortex-ipc/Cargo.toml
@@ -33,8 +33,8 @@ arrow-select = { workspace = true }
 criterion = { workspace = true, features = ["async_futures"] }
 futures-executor = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-vortex-sampling-compressor = { workspace = true }
-vortex-io = { workspace = true, features = ["futures"] }
+vortex-sampling-compressor = { path = "../vortex-sampling-compressor" }
+vortex-io = { path = "../vortex-io", features = ["futures"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
release-plz doesn't look at dev-dependencies to figure out release ordering, so we need to use path dependencies. We were doing this already but I forgot to do this when I broke the vortex-ipc crate out