### PR TITLE
feat: return Bytes from readers

### DIFF
--- a/vortex-file/Cargo.toml
+++ b/vortex-file/Cargo.toml
@@ -57,7 +57,7 @@ vortex-sampling-compressor = { path = "../vortex-sampling-compressor" }
 workspace = true
 
 [features]
-default = []
+default = ["tokio"]
 futures = ["futures-util/io", "vortex-io/futures"]
 compio = ["dep:compio", "vortex-io/compio"]
 tokio = ["dep:tokio", "vortex-io/tokio"]

--- a/vortex-file/src/dispatcher/tokio.rs
+++ b/vortex-file/src/dispatcher/tokio.rs
@@ -117,7 +117,6 @@ impl Dispatch for TokioDispatcher {
 mod tests {
     use std::io::Write;
 
-    use bytes::BytesMut;
     use tempfile::NamedTempFile;
     use vortex_io::{TokioFile, VortexReadAt};
 
@@ -133,8 +132,8 @@ mod tests {
         let rx = dispatcher
             .dispatch(|| async move {
                 let file = TokioFile::open(tmpfile.path()).unwrap();
-                let bytes = BytesMut::zeroed(4);
-                file.read_at_into(0, bytes).await.unwrap()
+
+                file.read_byte_range(0, 4).await.unwrap()
             })
             .unwrap();
 

--- a/vortex-io/src/futures.rs
+++ b/vortex-io/src/futures.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use futures_util::{AsyncRead, AsyncReadExt};
 
 use crate::VortexRead;
@@ -8,8 +8,12 @@ use crate::VortexRead;
 pub struct FuturesAdapter<IO>(pub IO);
 
 impl<R: AsyncRead + Unpin> VortexRead for FuturesAdapter<R> {
-    async fn read_into(&mut self, mut buffer: BytesMut) -> io::Result<BytesMut> {
+    async fn read_bytes(&mut self, len: u64) -> io::Result<Bytes> {
+        let mut buffer = BytesMut::with_capacity(len as usize);
+        unsafe {
+            buffer.set_len(len as usize);
+        }
         self.0.read_exact(buffer.as_mut()).await?;
-        Ok(buffer)
+        Ok(buffer.freeze())
     }
 }

--- a/vortex-io/src/offset.rs
+++ b/vortex-io/src/offset.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-use bytes::BytesMut;
+use bytes::Bytes;
 use futures::FutureExt;
 
 use crate::VortexReadAt;
@@ -30,12 +30,12 @@ impl<R: VortexReadAt> OffsetReadAt<R> {
 }
 
 impl<R: VortexReadAt> VortexReadAt for OffsetReadAt<R> {
-    fn read_at_into(
+    fn read_byte_range(
         &self,
         pos: u64,
-        buffer: BytesMut,
-    ) -> impl Future<Output = std::io::Result<BytesMut>> + 'static {
-        self.read.read_at_into(pos + self.offset, buffer)
+        len: u64,
+    ) -> impl Future<Output = std::io::Result<Bytes>> + 'static {
+        self.read.read_byte_range(pos + self.offset, len)
     }
 
     fn performance_hint(&self) -> usize {

--- a/vortex-ipc/src/messages/reader.rs
+++ b/vortex-ipc/src/messages/reader.rs
@@ -202,7 +202,7 @@ impl<R: VortexRead> MessageReader<R> {
         let total_len = buffer_len + (page_msg.padding() as u64);
 
         let buffer = self.read.read_bytes(total_len).await?;
-        let page_buffer = Ok(Some(Buffer::from(buffer)));
+        let page_buffer = Ok(Some(Buffer::from(buffer.slice(..buffer_len as usize))));
         let _ = self.next().await?;
         page_buffer
     }

--- a/vortex-ipc/src/messages/reader.rs
+++ b/vortex-ipc/src/messages/reader.rs
@@ -1,14 +1,14 @@
 use std::io;
 use std::sync::Arc;
 
-use bytes::{Buf, Bytes, BytesMut};
+use bytes::{Buf, Bytes};
 use flatbuffers::{root, root_unchecked};
 use futures_util::stream::try_unfold;
 use vortex_array::stream::{ArrayStream, ArrayStreamAdapter};
 use vortex_array::{ArrayData, Context, IntoArrayData, ViewedArrayData};
 use vortex_buffer::Buffer;
 use vortex_dtype::DType;
-use vortex_error::{vortex_bail, vortex_err, VortexResult};
+use vortex_error::{vortex_bail, vortex_err, VortexExpect, VortexResult};
 use vortex_flatbuffers::message as fb;
 use vortex_io::VortexRead;
 
@@ -17,8 +17,8 @@ pub const MESSAGE_PREFIX_LENGTH: usize = 4;
 /// A stateful reader of [`Message`s][fb::Message] from a stream.
 pub struct MessageReader<R> {
     read: R,
-    message: BytesMut,
-    prev_message: BytesMut,
+    message: Option<Bytes>,
+    prev_message: Option<Bytes>,
     finished: bool,
 }
 
@@ -26,8 +26,8 @@ impl<R: VortexRead> MessageReader<R> {
     pub async fn try_new(read: R) -> VortexResult<Self> {
         let mut reader = Self {
             read,
-            message: BytesMut::new(),
-            prev_message: BytesMut::new(),
+            message: None,
+            prev_message: None,
             finished: false,
         };
         reader.load_next_message().await?;
@@ -35,9 +35,7 @@ impl<R: VortexRead> MessageReader<R> {
     }
 
     async fn load_next_message(&mut self) -> VortexResult<bool> {
-        let mut buffer = std::mem::take(&mut self.message);
-        buffer.resize(MESSAGE_PREFIX_LENGTH, 0);
-        let mut buffer = match self.read.read_into(buffer).await {
+        let mut buffer = match self.read.read_bytes(MESSAGE_PREFIX_LENGTH as u64).await {
             Ok(b) => b,
             Err(e) => {
                 return match e.kind() {
@@ -55,14 +53,14 @@ impl<R: VortexRead> MessageReader<R> {
             vortex_bail!(InvalidSerde: "Invalid IPC stream")
         }
 
-        buffer.reserve(len as usize);
-        unsafe { buffer.set_len(len as usize) };
-        self.message = self.read.read_into(buffer).await?;
+        let next_msg = self.read.read_bytes(len as u64).await?;
 
         // Validate that the message is valid a flatbuffer.
-        root::<fb::Message>(&self.message).map_err(
+        root::<fb::Message>(&next_msg).map_err(
             |e| vortex_err!(InvalidSerde: "Failed to parse flatbuffer message: {:?}", e),
         )?;
+
+        self.message = Some(next_msg);
 
         Ok(true)
     }
@@ -72,18 +70,28 @@ impl<R: VortexRead> MessageReader<R> {
             return None;
         }
         // The message has been validated by the next() call.
-        Some(unsafe { root_unchecked::<fb::Message>(&self.message) })
+        Some(unsafe {
+            root_unchecked::<fb::Message>(
+                self.message
+                    .as_ref()
+                    .vortex_expect("MessageReader: message"),
+            )
+        })
     }
 
     async fn next(&mut self) -> VortexResult<Buffer> {
         if self.finished {
             vortex_bail!("Reader is finished, should've peeked!")
         }
-        self.prev_message = self.message.split();
+        self.prev_message = self.message.take();
         if !self.load_next_message().await? {
             self.finished = true;
         }
-        Ok(Buffer::from(self.prev_message.clone().freeze()))
+        Ok(Buffer::from(
+            self.prev_message
+                .clone()
+                .vortex_expect("MessageReader prev_message"),
+        ))
     }
 
     pub async fn read_dtype(&mut self) -> VortexResult<DType> {
@@ -114,15 +122,14 @@ impl<R: VortexRead> MessageReader<R> {
             Some(chunk) => chunk.buffer_size() as usize,
         };
 
-        let mut array_reader =
-            ArrayMessageReader::from_fb_bytes(Buffer::from(self.message.clone().freeze()));
+        let mut array_reader = ArrayMessageReader::from_fb_bytes(Buffer::from(
+            self.message.clone().vortex_expect("MessageReader: message"),
+        ));
 
         // Issue a single read to grab all buffers
-        let mut all_buffers = BytesMut::with_capacity(all_buffers_size);
-        unsafe { all_buffers.set_len(all_buffers_size) };
-        let all_buffers = self.read.read_into(all_buffers).await?;
+        let all_buffers = self.read.read_bytes(all_buffers_size as u64).await?;
 
-        if array_reader.read(all_buffers.freeze())?.is_some() {
+        if array_reader.read(all_buffers)?.is_some() {
             unreachable!("This is an implementation bug")
         };
 
@@ -191,14 +198,11 @@ impl<R: VortexRead> MessageReader<R> {
             return Ok(None);
         };
 
-        let buffer_len = page_msg.buffer_size() as usize;
-        let total_len = buffer_len + (page_msg.padding() as usize);
+        let buffer_len = page_msg.buffer_size() as u64;
+        let total_len = buffer_len + (page_msg.padding() as u64);
 
-        let mut buffer = BytesMut::with_capacity(total_len);
-        unsafe { buffer.set_len(total_len) }
-        buffer = self.read.read_into(buffer).await?;
-        buffer.truncate(buffer_len);
-        let page_buffer = Ok(Some(Buffer::from(buffer.freeze())));
+        let buffer = self.read.read_bytes(total_len).await?;
+        let page_buffer = Ok(Some(Buffer::from(buffer)));
         let _ = self.next().await?;
         page_buffer
     }

--- a/vortex-ipc/src/stream_writer/mod.rs
+++ b/vortex-ipc/src/stream_writer/mod.rs
@@ -116,8 +116,8 @@ impl ByteRange {
         Self { begin, end }
     }
 
-    pub fn len(&self) -> usize {
-        (self.end - self.begin) as usize
+    pub fn len(&self) -> u64 {
+        self.end - self.begin
     }
 
     pub fn is_empty(&self) -> bool {


### PR DESCRIPTION
No pooling right now. I had implemented a naive buffer pool on a separate branch and it drastically hurt performance, so just getting this up as a first step