### PR TITLE
Remove BoolArray::from_vec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4835,6 +4835,7 @@ dependencies = [
  "vortex-array",
  "vortex-buffer",
  "vortex-dtype",
+ "vortex-error",
  "vortex-sampling-compressor",
  "vortex-scalar",
 ]

--- a/bench-vortex/src/bin/notimplemented.rs
+++ b/bench-vortex/src/bin/notimplemented.rs
@@ -80,12 +80,12 @@ fn enc_impls() -> Vec<ArrayData> {
         BitPackedArray::encode(&PrimitiveArray::from(vec![100u32]).into_array(), 8)
             .unwrap()
             .into_array(),
-        BoolArray::from(vec![false]).into_array(),
+        BoolArray::from_iter([false]).into_array(),
         ByteBoolArray::from(vec![false]).into_array(),
         ChunkedArray::try_new(
             vec![
-                BoolArray::from(vec![false]).into_array(),
-                BoolArray::from(vec![true]).into_array(),
+                BoolArray::from_iter([false]).into_array(),
+                BoolArray::from_iter([true]).into_array(),
             ],
             DType::Bool(Nullability::NonNullable),
         )

--- a/bench-vortex/src/reader.rs
+++ b/bench-vortex/src/reader.rs
@@ -125,7 +125,7 @@ async fn take_vortex<T: VortexReadAt + Unpin + 'static>(
             LayoutContext::default().into(),
         ),
     )
-    .with_indices(ArrayData::from(indices.to_vec()))
+    .with_indices(ArrayData::from_iter(indices.iter().copied()))
     .build()
     .await?
     .read_all()

--- a/bench-vortex/src/reader.rs
+++ b/bench-vortex/src/reader.rs
@@ -125,7 +125,7 @@ async fn take_vortex<T: VortexReadAt + Unpin + 'static>(
             LayoutContext::default().into(),
         ),
     )
-    .with_indices(ArrayData::from_iter(indices.iter().copied()))
+    .with_indices(ArrayData::from(indices.to_vec()))
     .build()
     .await?
     .read_all()

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -66,7 +66,7 @@ pub fn decompress(array: ALPArray) -> VortexResult<PrimitiveArray> {
     let ptype = array.dtype().try_into()?;
     let decoded = match_each_alp_float_ptype!(ptype, |$T| {
         PrimitiveArray::from_vec(
-            decompress_primitive::<$T>(encoded.into_maybe_null_slice(), array.exponents()),
+            decompress_primitive::<$T>(encoded.maybe_null_slice(), array.exponents()),
             validity,
         )
     });
@@ -99,12 +99,12 @@ fn patch_decoded(array: PrimitiveArray, patches: &ArrayData) -> VortexResult<Pri
 }
 
 fn decompress_primitive<T: NativePType + ALPFloat>(
-    values: Vec<T::ALPInt>,
+    values: &[T::ALPInt],
     exponents: Exponents,
 ) -> Vec<T> {
     values
-        .into_iter()
-        .map(|v| T::decode_single(v, exponents))
+        .iter()
+        .map(|v| T::decode_single(*v, exponents))
         .collect()
 }
 

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -66,7 +66,7 @@ pub fn decompress(array: ALPArray) -> VortexResult<PrimitiveArray> {
     let ptype = array.dtype().try_into()?;
     let decoded = match_each_alp_float_ptype!(ptype, |$T| {
         PrimitiveArray::from_vec(
-            decompress_primitive::<$T>(encoded.maybe_null_slice(), array.exponents()),
+            decompress_primitive::<$T>(encoded.into_maybe_null_slice(), array.exponents()),
             validity,
         )
     });
@@ -99,12 +99,14 @@ fn patch_decoded(array: PrimitiveArray, patches: &ArrayData) -> VortexResult<Pri
 }
 
 fn decompress_primitive<T: NativePType + ALPFloat>(
-    values: &[T::ALPInt],
+    values: Vec<T::ALPInt>,
     exponents: Exponents,
 ) -> Vec<T> {
     values
-        .iter()
-        .map(|v| T::decode_single(*v, exponents))
+        // NOTE(ngates): Rust should optimise this into_iter.map to re-use the memory
+        //  of the Vec rather than allocating a new one.
+        .into_iter()
+        .map(|v| T::decode_single(v, exponents))
         .collect()
 }
 

--- a/encodings/alp/src/alp/compute.rs
+++ b/encodings/alp/src/alp/compute.rs
@@ -1,12 +1,12 @@
-use vortex_array::array::{BoolArray, BooleanBuffer, ConstantArray};
+use vortex_array::array::ConstantArray;
 use vortex_array::compute::unary::{scalar_at, scalar_at_unchecked, ScalarAtFn};
 use vortex_array::compute::{
     compare, filter, slice, take, ArrayCompute, FilterFn, MaybeCompareFn, Operator, SliceFn, TakeFn,
 };
 use vortex_array::stats::{ArrayStatistics, Stat};
-use vortex_array::validity::Validity;
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData};
+use vortex_dtype::Nullability;
 use vortex_error::{VortexExpect, VortexResult};
 use vortex_scalar::{PValue, Scalar};
 
@@ -114,9 +114,9 @@ impl MaybeCompareFn for ALPArray {
             match pvalue {
                 Some(PValue::F32(f)) => Some(alp_scalar_compare(self, f, operator)),
                 Some(PValue::F64(f)) => Some(alp_scalar_compare(self, f, operator)),
-                Some(_) | None => Some(Ok(BoolArray::new(
-                    BooleanBuffer::new_unset(self.len()),
-                    Validity::AllValid,
+                Some(_) | None => Some(Ok(ConstantArray::new(
+                    Scalar::bool(false, Nullability::Nullable),
+                    self.len(),
                 )
                 .into_array())),
             }
@@ -145,7 +145,10 @@ where
                 let s = ConstantArray::new(exception, alp.len());
                 compare(patches, s.as_ref(), operator)
             } else {
-                Ok(ConstantArray::new(false, alp.len()).into_array())
+                Ok(
+                    ConstantArray::new(Scalar::bool(false, Nullability::Nullable), alp.len())
+                        .into_array(),
+                )
             }
         }
     }

--- a/encodings/alp/src/alp/compute.rs
+++ b/encodings/alp/src/alp/compute.rs
@@ -114,10 +114,11 @@ impl MaybeCompareFn for ALPArray {
             match pvalue {
                 Some(PValue::F32(f)) => Some(alp_scalar_compare(self, f, operator)),
                 Some(PValue::F64(f)) => Some(alp_scalar_compare(self, f, operator)),
-                Some(_) | None => Some(Ok(BoolArray::from_vec(
-                    vec![false; self.len()],
+                Some(_) | None => Some(Ok(BoolArray::all_false_with_validity(
+                    self.len(),
                     Validity::AllValid,
                 )
+                .vortex_expect("Failed to create bool array")
                 .into_array())),
             }
         } else {
@@ -145,7 +146,7 @@ where
                 let s = ConstantArray::new(exception, alp.len());
                 compare(patches, s.as_ref(), operator)
             } else {
-                Ok(BoolArray::from_vec(vec![false; alp.len()], Validity::AllValid).into_array())
+                Ok(ConstantArray::new(false, alp.len()).into_array())
             }
         }
     }

--- a/encodings/alp/src/alp/compute.rs
+++ b/encodings/alp/src/alp/compute.rs
@@ -1,4 +1,4 @@
-use vortex_array::array::{BoolArray, ConstantArray};
+use vortex_array::array::{BoolArray, BooleanBuffer, ConstantArray};
 use vortex_array::compute::unary::{scalar_at, scalar_at_unchecked, ScalarAtFn};
 use vortex_array::compute::{
     compare, filter, slice, take, ArrayCompute, FilterFn, MaybeCompareFn, Operator, SliceFn, TakeFn,
@@ -114,11 +114,10 @@ impl MaybeCompareFn for ALPArray {
             match pvalue {
                 Some(PValue::F32(f)) => Some(alp_scalar_compare(self, f, operator)),
                 Some(PValue::F64(f)) => Some(alp_scalar_compare(self, f, operator)),
-                Some(_) | None => Some(Ok(BoolArray::all_false_with_validity(
-                    self.len(),
+                Some(_) | None => Some(Ok(BoolArray::new(
+                    BooleanBuffer::new_unset(self.len()),
                     Validity::AllValid,
                 )
-                .vortex_expect("Failed to create bool array")
                 .into_array())),
             }
         } else {

--- a/encodings/alp/src/alp_rd/compute/filter.rs
+++ b/encodings/alp/src/alp_rd/compute/filter.rs
@@ -43,7 +43,7 @@ mod test {
         assert!(encoded.left_parts_exceptions().is_some());
 
         // The first two values need no patching
-        let filtered = filter(encoded.as_ref(), BoolArray::from(vec![true, false, true]))
+        let filtered = filter(encoded.as_ref(), BoolArray::from_iter([true, false, true]))
             .unwrap()
             .into_primitive()
             .unwrap();

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -118,7 +118,7 @@ impl From<Vec<bool>> for ByteBoolArray {
 
 impl From<Vec<Option<bool>>> for ByteBoolArray {
     fn from(value: Vec<Option<bool>>) -> Self {
-        let validity = Validity::from_iter(value.iter().cloned());
+        let validity = Validity::from_iter(value.iter().map(|v| v.is_some()));
 
         // This doesn't reallocate, and the compiler even vectorizes it
         let data = value.into_iter().map(Option::unwrap_or_default).collect();
@@ -133,7 +133,10 @@ impl IntoCanonical for ByteBoolArray {
         let boolean_buffer = BooleanBuffer::from(self.maybe_null_slice());
         let validity = self.validity();
 
-        Ok(Canonical::Bool(BoolArray::new(boolean_buffer, validity)))
+        Ok(Canonical::Bool(BoolArray::try_new(
+            boolean_buffer,
+            validity,
+        )?))
     }
 }
 

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -118,7 +118,7 @@ impl From<Vec<bool>> for ByteBoolArray {
 
 impl From<Vec<Option<bool>>> for ByteBoolArray {
     fn from(value: Vec<Option<bool>>) -> Self {
-        let validity = Validity::from_iter(value.iter());
+        let validity = Validity::from_iter(value.iter().cloned());
 
         // This doesn't reallocate, and the compiler even vectorizes it
         let data = value.into_iter().map(Option::unwrap_or_default).collect();

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -133,7 +133,7 @@ impl IntoCanonical for ByteBoolArray {
         let boolean_buffer = BooleanBuffer::from(self.maybe_null_slice());
         let validity = self.validity();
 
-        BoolArray::try_new(boolean_buffer, validity).map(Canonical::Bool)
+        Ok(Canonical::Bool(BoolArray::new(boolean_buffer, validity)))
     }
 }
 

--- a/encodings/datetime-parts/src/compute.rs
+++ b/encodings/datetime-parts/src/compute.rs
@@ -150,7 +150,7 @@ mod test {
         do_roundtrip_test(&raw_values, Validity::NonNullable);
         do_roundtrip_test(&raw_values, Validity::AllValid);
         do_roundtrip_test(&raw_values, Validity::AllInvalid);
-        do_roundtrip_test(&raw_values, Validity::from(vec![true, false, true]));
+        do_roundtrip_test(&raw_values, Validity::from_iter([true, false, true]));
     }
 
     fn do_roundtrip_test(raw_values: &[i64], validity: Validity) {

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -397,8 +397,10 @@ mod test {
     #[test]
     fn null_patches() {
         let valid_values = (0..24).map(|v| v < 1 << 4).collect::<Vec<_>>();
-        let values =
-            PrimitiveArray::from_vec((0u32..24).collect::<Vec<_>>(), Validity::from(valid_values));
+        let values = PrimitiveArray::from_vec(
+            (0u32..24).collect::<Vec<_>>(),
+            Validity::from_iter(valid_values),
+        );
         assert!(values.ptype().is_unsigned_int());
         let compressed = BitPackedArray::encode(values.as_ref(), 4).unwrap();
         assert!(compressed.patches().is_none());

--- a/encodings/fsst/tests/fsst_tests.rs
+++ b/encodings/fsst/tests/fsst_tests.rs
@@ -85,8 +85,7 @@ fn test_fsst_array_ops() {
     );
 
     // test filter
-    let predicate =
-        BoolArray::from_vec(vec![false, true, false], Validity::NonNullable).into_array();
+    let predicate = BoolArray::from_iter([false, true, false]).into_array();
 
     let fsst_filtered = filter(&fsst_array, &predicate).unwrap();
     assert_eq!(fsst_filtered.encoding().id(), FSST::ENCODING.id());

--- a/encodings/roaring/src/boolean/compute.rs
+++ b/encodings/roaring/src/boolean/compute.rs
@@ -49,7 +49,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     pub fn test_scalar_at() {
-        let bool = BoolArray::from(vec![true, false, true, true]);
+        let bool = BoolArray::from_iter([true, false, true, true]);
         let array = RoaringBoolArray::encode(bool.into_array()).unwrap();
 
         let truthy: Scalar = true.into();
@@ -64,7 +64,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     pub fn test_slice() {
-        let bool = BoolArray::from(vec![true, false, true, true]);
+        let bool = BoolArray::from_iter([true, false, true, true]);
         let array = RoaringBoolArray::encode(bool.into_array()).unwrap();
         let sliced = slice(&array, 1, 3).unwrap();
 

--- a/encodings/roaring/src/boolean/mod.rs
+++ b/encodings/roaring/src/boolean/mod.rs
@@ -157,7 +157,7 @@ mod test {
     #[test]
     #[cfg_attr(miri, ignore)]
     pub fn iter() {
-        let bool: BoolArray = BoolArray::from(vec![true, false, true, true]);
+        let bool: BoolArray = BoolArray::from_iter([true, false, true, true]);
         let array = RoaringBoolArray::encode(bool.into_array()).unwrap();
         let round_trip = RoaringBoolArray::try_from(array).unwrap();
         let values = round_trip.bitmap().to_vec();
@@ -167,11 +167,10 @@ mod test {
     #[test]
     #[cfg_attr(miri, ignore)]
     pub fn trailing_false() {
-        let bool: BoolArray = BoolArray::from(
-            vec![true, true]
+        let bool: BoolArray = BoolArray::from_iter(
+            [true, true]
                 .into_iter()
-                .chain(iter::repeat(false).take(100))
-                .collect::<Vec<_>>(),
+                .chain(iter::repeat(false).take(100)),
         );
         let array = RoaringBoolArray::encode(bool.into_array()).unwrap();
         let round_trip = RoaringBoolArray::try_from(array).unwrap();

--- a/encodings/roaring/src/boolean/mod.rs
+++ b/encodings/roaring/src/boolean/mod.rs
@@ -9,14 +9,13 @@ use vortex_array::array::visitor::{AcceptArrayVisitor, ArrayVisitor};
 use vortex_array::array::BoolArray;
 use vortex_array::encoding::ids;
 use vortex_array::stats::StatsSet;
-use vortex_array::validity::{ArrayValidity, LogicalValidity, Validity};
+use vortex_array::validity::{ArrayValidity, LogicalValidity};
 use vortex_array::variants::{ArrayVariants, BoolArrayTrait};
 use vortex_array::{
     impl_encoding, ArrayData, ArrayTrait, Canonical, IntoArrayData, IntoCanonical, TypedArray,
 };
 use vortex_buffer::Buffer;
-use vortex_dtype::DType;
-use vortex_dtype::Nullability::NonNullable;
+use vortex_dtype::{DType, Nullability};
 use vortex_error::{vortex_bail, vortex_err, VortexExpect as _, VortexResult};
 
 mod compress;
@@ -49,7 +48,7 @@ impl RoaringBoolArray {
 
         Ok(Self {
             typed: TypedArray::try_from_parts(
-                DType::Bool(NonNullable),
+                DType::Bool(Nullability::NonNullable),
                 length,
                 RoaringBoolMetadata,
                 Some(Buffer::from(bitmap.serialize::<Native>())),
@@ -139,7 +138,7 @@ impl IntoCanonical for RoaringBoolArray {
         }
         Ok(Canonical::Bool(BoolArray::new(
             BooleanBuffer::new(buffer.into(), 0, self.len()),
-            Validity::NonNullable,
+            Nullability::NonNullable,
         )))
     }
 }

--- a/encodings/roaring/src/boolean/mod.rs
+++ b/encodings/roaring/src/boolean/mod.rs
@@ -137,11 +137,10 @@ impl IntoCanonical for RoaringBoolArray {
         if byte_length > bitset.size_in_bytes() {
             buffer.extend_zeros(byte_length - bitset.size_in_bytes());
         }
-        BoolArray::try_new(
+        Ok(Canonical::Bool(BoolArray::new(
             BooleanBuffer::new(buffer.into(), 0, self.len()),
             Validity::NonNullable,
-        )
-        .map(Canonical::Bool)
+        )))
     }
 }
 

--- a/encodings/roaring/src/boolean/stats.rs
+++ b/encodings/roaring/src/boolean/stats.rs
@@ -56,7 +56,7 @@ mod test {
     #[cfg_attr(miri, ignore)]
     fn bool_stats() {
         let bool_arr = RoaringBoolArray::encode(
-            BoolArray::from(vec![false, false, true, true, false, true, true, false]).into_array(),
+            BoolArray::from_iter([false, false, true, true, false, true, true, false]).into_array(),
         )
         .unwrap();
         assert!(!bool_arr.statistics().compute_is_strict_sorted().unwrap());
@@ -71,27 +71,27 @@ mod test {
     #[cfg_attr(miri, ignore)]
     fn strict_sorted() {
         let bool_arr_1 =
-            RoaringBoolArray::encode(BoolArray::from(vec![false, true]).into_array()).unwrap();
+            RoaringBoolArray::encode(BoolArray::from_iter([false, true]).into_array()).unwrap();
         assert!(bool_arr_1.statistics().compute_is_strict_sorted().unwrap());
         assert!(bool_arr_1.statistics().compute_is_sorted().unwrap());
 
         let bool_arr_2 =
-            RoaringBoolArray::encode(BoolArray::from(vec![true]).into_array()).unwrap();
+            RoaringBoolArray::encode(BoolArray::from_iter([true]).into_array()).unwrap();
         assert!(bool_arr_2.statistics().compute_is_strict_sorted().unwrap());
         assert!(bool_arr_2.statistics().compute_is_sorted().unwrap());
 
         let bool_arr_3 =
-            RoaringBoolArray::encode(BoolArray::from(vec![false]).into_array()).unwrap();
+            RoaringBoolArray::encode(BoolArray::from_iter([false]).into_array()).unwrap();
         assert!(bool_arr_3.statistics().compute_is_strict_sorted().unwrap());
         assert!(bool_arr_3.statistics().compute_is_sorted().unwrap());
 
         let bool_arr_4 =
-            RoaringBoolArray::encode(BoolArray::from(vec![true, false]).into_array()).unwrap();
+            RoaringBoolArray::encode(BoolArray::from_iter([true, false]).into_array()).unwrap();
         assert!(!bool_arr_4.statistics().compute_is_strict_sorted().unwrap());
         assert!(!bool_arr_4.statistics().compute_is_sorted().unwrap());
 
         let bool_arr_5 =
-            RoaringBoolArray::encode(BoolArray::from(vec![false, true, true]).into_array())
+            RoaringBoolArray::encode(BoolArray::from_iter([false, true, true]).into_array())
                 .unwrap();
         assert!(!bool_arr_5.statistics().compute_is_strict_sorted().unwrap());
         assert!(bool_arr_5.statistics().compute_is_sorted().unwrap());

--- a/encodings/runend-bool/src/array.rs
+++ b/encodings/runend-bool/src/array.rs
@@ -286,7 +286,7 @@ mod test {
 
     #[test]
     fn slice_slice_array() {
-        let raw = BoolArray::from(vec![
+        let raw = BoolArray::from_iter([
             true, true, false, false, false, true, false, true, true, true,
         ])
         .to_array();

--- a/encodings/runend-bool/src/compress.rs
+++ b/encodings/runend-bool/src/compress.rs
@@ -173,7 +173,7 @@ mod test {
     fn encode_decode_offset_array() {
         let mut rng = StdRng::seed_from_u64(39451);
         let input = (0..1024 * 8 - 61).map(|_x| rng.gen::<bool>()).collect_vec();
-        let b = BoolArray::from(input.clone());
+        let b = BoolArray::from_iter(input.clone());
         let b = b.slice(3, 1024 * 8 - 66).unwrap().into_bool().unwrap();
         let (ends, start) = runend_bool_encode(&b);
 

--- a/encodings/runend-bool/src/compress.rs
+++ b/encodings/runend-bool/src/compress.rs
@@ -50,7 +50,7 @@ pub fn runend_bool_decode(
 ) -> VortexResult<BoolArray> {
     match_each_integer_ptype!(run_ends.ptype(), |$E| {
         let bools = runend_bool_decode_slice::<$E>(run_ends.maybe_null_slice(), start, offset, length);
-        BoolArray::try_new(bools, validity)
+        Ok(BoolArray::new(bools, validity))
     })
 }
 

--- a/encodings/runend-bool/src/compress.rs
+++ b/encodings/runend-bool/src/compress.rs
@@ -50,7 +50,7 @@ pub fn runend_bool_decode(
 ) -> VortexResult<BoolArray> {
     match_each_integer_ptype!(run_ends.ptype(), |$E| {
         let bools = runend_bool_decode_slice::<$E>(run_ends.maybe_null_slice(), start, offset, length);
-        Ok(BoolArray::new(bools, validity))
+        Ok(BoolArray::try_new(bools, validity)?)
     })
 }
 

--- a/encodings/runend-bool/src/compute.rs
+++ b/encodings/runend-bool/src/compute.rs
@@ -60,13 +60,10 @@ impl TakeFn for RunEndBoolArray {
                 .collect::<VortexResult<Vec<_>>>()?
         });
         let start = self.start();
-        Ok(BoolArray::from(
-            physical_indices
-                .iter()
-                .map(|&it| value_at_index(it, start))
-                .collect::<Vec<_>>(),
+        Ok(
+            BoolArray::from_iter(physical_indices.iter().map(|&it| value_at_index(it, start)))
+                .to_array(),
         )
-        .to_array())
     }
 }
 

--- a/encodings/runend/src/compress.rs
+++ b/encodings/runend/src/compress.rs
@@ -140,7 +140,7 @@ mod test {
             let mut validity = vec![true; 10];
             validity[2] = false;
             validity[7] = false;
-            Validity::from(validity)
+            Validity::from_iter(validity)
         };
         let arr = RunEndArray::try_new(
             vec![2u32, 5, 10].into_array(),
@@ -164,9 +164,7 @@ mod test {
         );
         assert_eq!(
             decoded.logical_validity().into_validity(),
-            Validity::from(vec![
-                true, true, false, true, true, true, true, false, true, true,
-            ])
+            Validity::from_iter([true, true, false, true, true, true, true, false, true, true,])
         );
     }
 }

--- a/encodings/runend/src/compute.rs
+++ b/encodings/runend/src/compute.rs
@@ -190,7 +190,7 @@ mod test {
         let array = RunEndArray::try_new(
             PrimitiveArray::from(vec![3u32, 6, 8, 12]).into_array(),
             PrimitiveArray::from_vec(vec![1, 4, 2, 5], Validity::AllValid).into_array(),
-            Validity::from(vec![
+            Validity::from_iter([
                 false, false, false, false, true, true, false, false, false, false, true, true,
             ]),
         )
@@ -311,12 +311,9 @@ mod test {
     #[test]
     fn take_with_nulls() {
         let uncompressed = PrimitiveArray::from_vec(vec![1i32, 0, 3], Validity::AllValid);
-        let validity = BoolArray::from_vec(
-            vec![
-                true, true, false, false, false, true, true, true, true, true,
-            ],
-            Validity::NonNullable,
-        );
+        let validity = BoolArray::from_iter([
+            true, true, false, false, false, true, true, true, true, true,
+        ]);
         let arr = RunEndArray::try_new(
             vec![2u32, 5, 10].into_array(),
             uncompressed.into(),

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -23,6 +23,7 @@ libfuzzer-sys = { workspace = true }
 vortex-array = { workspace = true, features = ["arbitrary"] }
 vortex-buffer = { workspace = true }
 vortex-dtype = { workspace = true, features = ["arbitrary"] }
+vortex-error = { workspace = true }
 vortex-sampling-compressor = { workspace = true, features = ["arbitrary"] }
 vortex-scalar = { workspace = true, features = ["arbitrary"] }
 

--- a/fuzz/src/filter.rs
+++ b/fuzz/src/filter.rs
@@ -4,7 +4,6 @@ use vortex_array::validity::{ArrayValidity, Validity};
 use vortex_array::variants::StructArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::{match_each_native_ptype, DType};
-use vortex_error::VortexExpect;
 
 pub fn filter_canonical_array(array: &ArrayData, filter: &[bool]) -> ArrayData {
     match array.dtype() {
@@ -16,7 +15,7 @@ pub fn filter_canonical_array(array: &ArrayData, filter: &[bool]) -> ArrayData {
                 .into_bool()
                 .unwrap()
                 .boolean_buffer();
-            BoolArray::try_new(
+            BoolArray::new(
                 BooleanBuffer::from_iter(
                     filter
                         .iter()
@@ -32,7 +31,6 @@ pub fn filter_canonical_array(array: &ArrayData, filter: &[bool]) -> ArrayData {
                         .map(|(_, v)| v),
                 ),
             )
-            .vortex_expect("Failed to create BoolArray")
             .into_array()
         }
         DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {

--- a/fuzz/src/filter.rs
+++ b/fuzz/src/filter.rs
@@ -4,6 +4,7 @@ use vortex_array::validity::{ArrayValidity, Validity};
 use vortex_array::variants::StructArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::{match_each_native_ptype, DType};
+use vortex_error::VortexExpect;
 
 pub fn filter_canonical_array(array: &ArrayData, filter: &[bool]) -> ArrayData {
     match array.dtype() {
@@ -15,7 +16,7 @@ pub fn filter_canonical_array(array: &ArrayData, filter: &[bool]) -> ArrayData {
                 .into_bool()
                 .unwrap()
                 .boolean_buffer();
-            BoolArray::new(
+            BoolArray::try_new(
                 BooleanBuffer::from_iter(
                     filter
                         .iter()
@@ -31,6 +32,7 @@ pub fn filter_canonical_array(array: &ArrayData, filter: &[bool]) -> ArrayData {
                         .map(|(_, v)| v),
                 ),
             )
+            .vortex_expect("Validity length cannot mismatch")
             .into_array()
         }
         DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {

--- a/fuzz/src/filter.rs
+++ b/fuzz/src/filter.rs
@@ -1,9 +1,10 @@
 use vortex_array::accessor::ArrayAccessor;
-use vortex_array::array::{BoolArray, PrimitiveArray, StructArray, VarBinViewArray};
+use vortex_array::array::{BoolArray, BooleanBuffer, PrimitiveArray, StructArray, VarBinViewArray};
 use vortex_array::validity::{ArrayValidity, Validity};
 use vortex_array::variants::StructArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::{match_each_native_ptype, DType};
+use vortex_error::VortexExpect;
 
 pub fn filter_canonical_array(array: &ArrayData, filter: &[bool]) -> ArrayData {
     match array.dtype() {
@@ -15,22 +16,23 @@ pub fn filter_canonical_array(array: &ArrayData, filter: &[bool]) -> ArrayData {
                 .into_bool()
                 .unwrap()
                 .boolean_buffer();
-            BoolArray::from_vec(
-                filter
-                    .iter()
-                    .zip(bool_array.boolean_buffer().iter())
-                    .filter(|(f, _)| **f)
-                    .map(|(_, v)| v)
-                    .collect::<Vec<_>>(),
-                Validity::from(
+            BoolArray::try_new(
+                BooleanBuffer::from_iter(
+                    filter
+                        .iter()
+                        .zip(bool_array.boolean_buffer().iter())
+                        .filter(|(f, _)| **f)
+                        .map(|(_, v)| v),
+                ),
+                Validity::from_iter(
                     filter
                         .iter()
                         .zip(vec_validity.iter())
                         .filter(|(f, _)| **f)
-                        .map(|(_, v)| v)
-                        .collect::<Vec<_>>(),
+                        .map(|(_, v)| v),
                 ),
             )
+            .vortex_expect("Failed to create BoolArray")
             .into_array()
         }
         DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {
@@ -48,13 +50,12 @@ pub fn filter_canonical_array(array: &ArrayData, filter: &[bool]) -> ArrayData {
                     .filter(|(f, _)| **f)
                     .map(|(_, v)| v)
                     .collect::<Vec<_>>(),
-                Validity::from(
+                Validity::from_iter(
                     filter
                         .iter()
                         .zip(vec_validity.iter())
                         .filter(|(f, _)| **f)
                         .map(|(_, v)| v)
-                        .collect::<Vec<_>>(),
                 ),
             )
             .into_array()
@@ -88,13 +89,12 @@ pub fn filter_canonical_array(array: &ArrayData, filter: &[bool]) -> ArrayData {
                 struct_array.names().clone(),
                 filtered_children,
                 filter.iter().filter(|b| **b).map(|b| *b as usize).sum(),
-                Validity::from(
+                Validity::from_iter(
                     filter
                         .iter()
                         .zip(vec_validity.iter())
                         .filter(|(f, _)| **f)
-                        .map(|(_, v)| v)
-                        .collect::<Vec<_>>(),
+                        .map(|(_, v)| v),
                 ),
             )
             .unwrap()

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -141,7 +141,7 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                         .collect::<Result<Vec<_>>>()?;
                     current_array = filter_canonical_array(&current_array, &mask);
                     (
-                        Action::Filter(BoolArray::from(mask).into_array()),
+                        Action::Filter(BoolArray::from_iter(mask).into_array()),
                         ExpectedValue::Array(current_array.clone()),
                     )
                 }

--- a/fuzz/src/slice.rs
+++ b/fuzz/src/slice.rs
@@ -4,6 +4,7 @@ use vortex_array::validity::{ArrayValidity, Validity};
 use vortex_array::variants::StructArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::{match_each_native_ptype, DType};
+use vortex_error::VortexExpect;
 
 pub fn slice_canonical_array(array: &ArrayData, start: usize, stop: usize) -> ArrayData {
     match array.dtype() {
@@ -18,10 +19,11 @@ pub fn slice_canonical_array(array: &ArrayData, start: usize, stop: usize) -> Ar
                 .boolean_buffer()
                 .iter()
                 .collect::<Vec<_>>();
-            BoolArray::new(
+            BoolArray::try_new(
                 BooleanBuffer::from(&vec_values[start..stop]),
-                Validity::from_iter(vec_validity[start..stop].iter().cloned()),
+                Validity::from_iter(vec_validity[start..stop].iter().copied()),
             )
+            .vortex_expect("Validity length cannot mismatch")
             .into_array()
         }
         DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {

--- a/fuzz/src/slice.rs
+++ b/fuzz/src/slice.rs
@@ -1,9 +1,10 @@
 use vortex_array::accessor::ArrayAccessor;
-use vortex_array::array::{BoolArray, PrimitiveArray, StructArray, VarBinViewArray};
+use vortex_array::array::{BoolArray, BooleanBuffer, PrimitiveArray, StructArray, VarBinViewArray};
 use vortex_array::validity::{ArrayValidity, Validity};
 use vortex_array::variants::StructArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::{match_each_native_ptype, DType};
+use vortex_error::VortexExpect;
 
 pub fn slice_canonical_array(array: &ArrayData, start: usize, stop: usize) -> ArrayData {
     match array.dtype() {
@@ -18,10 +19,11 @@ pub fn slice_canonical_array(array: &ArrayData, start: usize, stop: usize) -> Ar
                 .boolean_buffer()
                 .iter()
                 .collect::<Vec<_>>();
-            BoolArray::from_vec(
-                Vec::from(&vec_values[start..stop]),
-                Validity::from(Vec::from(&vec_validity[start..stop])),
+            BoolArray::try_new(
+                BooleanBuffer::from(&vec_values[start..stop]),
+                Validity::from_iter(vec_validity[start..stop].iter().cloned()),
             )
+            .vortex_expect("Failed to create BoolArray")
             .into_array()
         }
         DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {
@@ -41,7 +43,7 @@ pub fn slice_canonical_array(array: &ArrayData, start: usize, stop: usize) -> Ar
                 .collect::<Vec<_>>();
             PrimitiveArray::from_vec(
                 Vec::from(&vec_values[start..stop]),
-                Validity::from(Vec::from(&vec_validity[start..stop])),
+                Validity::from_iter(vec_validity[start..stop].iter().cloned()),
             )
             .into_array()
         }),
@@ -72,7 +74,7 @@ pub fn slice_canonical_array(array: &ArrayData, start: usize, stop: usize) -> Ar
                 struct_array.names().clone(),
                 sliced_children,
                 stop - start,
-                Validity::from(Vec::from(&vec_validity[start..stop])),
+                Validity::from_iter(vec_validity[start..stop].iter().cloned()),
             )
             .unwrap()
             .into_array()

--- a/fuzz/src/slice.rs
+++ b/fuzz/src/slice.rs
@@ -4,7 +4,6 @@ use vortex_array::validity::{ArrayValidity, Validity};
 use vortex_array::variants::StructArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::{match_each_native_ptype, DType};
-use vortex_error::VortexExpect;
 
 pub fn slice_canonical_array(array: &ArrayData, start: usize, stop: usize) -> ArrayData {
     match array.dtype() {
@@ -19,11 +18,10 @@ pub fn slice_canonical_array(array: &ArrayData, start: usize, stop: usize) -> Ar
                 .boolean_buffer()
                 .iter()
                 .collect::<Vec<_>>();
-            BoolArray::try_new(
+            BoolArray::new(
                 BooleanBuffer::from(&vec_values[start..stop]),
                 Validity::from_iter(vec_validity[start..stop].iter().cloned()),
             )
-            .vortex_expect("Failed to create BoolArray")
             .into_array()
         }
         DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {

--- a/fuzz/src/take.rs
+++ b/fuzz/src/take.rs
@@ -18,10 +18,11 @@ pub fn take_canonical_array(array: &ArrayData, indices: &[usize]) -> ArrayData {
                 .boolean_buffer()
                 .iter()
                 .collect::<Vec<_>>();
-            BoolArray::from_vec(
+            BoolArray::try_new(
                 indices.iter().map(|i| vec_values[*i]).collect(),
-                Validity::from(indices.iter().map(|i| vec_validity[*i]).collect::<Vec<_>>()),
+                Validity::from_iter(indices.iter().map(|i| vec_validity[*i])),
             )
+            .unwrap()
             .into_array()
         }
         DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {
@@ -41,7 +42,7 @@ pub fn take_canonical_array(array: &ArrayData, indices: &[usize]) -> ArrayData {
                 .collect::<Vec<_>>();
             PrimitiveArray::from_vec(
                 indices.iter().map(|i| vec_values[*i]).collect(),
-                Validity::from(indices.iter().map(|i| vec_validity[*i]).collect::<Vec<_>>())
+                Validity::from_iter(indices.iter().map(|i| vec_validity[*i]))
             )
             .into_array()
         }),
@@ -75,7 +76,7 @@ pub fn take_canonical_array(array: &ArrayData, indices: &[usize]) -> ArrayData {
                 struct_array.names().clone(),
                 taken_children,
                 indices.len(),
-                Validity::from(indices.iter().map(|i| vec_validity[*i]).collect::<Vec<_>>()),
+                Validity::from_iter(indices.iter().map(|i| vec_validity[*i])),
             )
             .unwrap()
             .into_array()

--- a/fuzz/src/take.rs
+++ b/fuzz/src/take.rs
@@ -4,6 +4,7 @@ use vortex_array::validity::{ArrayValidity, Validity};
 use vortex_array::variants::StructArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::{match_each_native_ptype, DType};
+use vortex_error::VortexExpect;
 
 pub fn take_canonical_array(array: &ArrayData, indices: &[usize]) -> ArrayData {
     match array.dtype() {
@@ -18,10 +19,11 @@ pub fn take_canonical_array(array: &ArrayData, indices: &[usize]) -> ArrayData {
                 .boolean_buffer()
                 .iter()
                 .collect::<Vec<_>>();
-            BoolArray::new(
+            BoolArray::try_new(
                 indices.iter().map(|i| vec_values[*i]).collect(),
                 Validity::from_iter(indices.iter().map(|i| vec_validity[*i])),
             )
+            .vortex_expect("Validity length cannot mismatch")
             .into_array()
         }
         DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {

--- a/fuzz/src/take.rs
+++ b/fuzz/src/take.rs
@@ -18,11 +18,10 @@ pub fn take_canonical_array(array: &ArrayData, indices: &[usize]) -> ArrayData {
                 .boolean_buffer()
                 .iter()
                 .collect::<Vec<_>>();
-            BoolArray::try_new(
+            BoolArray::new(
                 indices.iter().map(|i| vec_values[*i]).collect(),
                 Validity::from_iter(indices.iter().map(|i| vec_validity[*i])),
             )
-            .unwrap()
             .into_array()
         }
         DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {

--- a/vortex-array/benches/compare.rs
+++ b/vortex-array/benches/compare.rs
@@ -14,18 +14,8 @@ fn compare_bool(c: &mut Criterion) {
 
     let mut rng = thread_rng();
     let range = Uniform::new(0u8, 1);
-    let arr = BoolArray::from(
-        (0..10_000_000)
-            .map(|_| rng.sample(range) == 0)
-            .collect_vec(),
-    )
-    .into_array();
-    let arr2 = BoolArray::from(
-        (0..10_000_000)
-            .map(|_| rng.sample(range) == 0)
-            .collect_vec(),
-    )
-    .into_array();
+    let arr = BoolArray::from_iter((0..10_000_000).map(|_| rng.sample(range) == 0)).into_array();
+    let arr2 = BoolArray::from_iter((0..10_000_000).map(|_| rng.sample(range) == 0)).into_array();
 
     group.bench_function("compare_bool", |b| {
         b.iter(|| {

--- a/vortex-array/src/array/arbitrary.rs
+++ b/vortex-array/src/array/arbitrary.rs
@@ -3,7 +3,7 @@ use std::iter;
 use arbitrary::{Arbitrary, Result, Unstructured};
 use arrow_buffer::BooleanBuffer;
 use vortex_dtype::{DType, NativePType, Nullability, PType};
-use vortex_error::{VortexExpect, VortexUnwrap};
+use vortex_error::VortexUnwrap;
 
 use super::{BoolArray, ChunkedArray, NullArray, PrimitiveArray, StructArray};
 use crate::array::{VarBinArray, VarBinViewArray};
@@ -177,9 +177,7 @@ fn random_bool(
 ) -> Result<ArrayData> {
     let v = arbitrary_vec_of_len(u, len)?;
     let validity = random_validity(u, nullability, v.len())?;
-    Ok(BoolArray::try_new(BooleanBuffer::from(v), validity)
-        .vortex_expect("failed to create bools")
-        .into_array())
+    Ok(BoolArray::new(BooleanBuffer::from(v), validity).into_array())
 }
 
 fn random_validity(u: &mut Unstructured, nullability: Nullability, len: usize) -> Result<Validity> {

--- a/vortex-array/src/array/arbitrary.rs
+++ b/vortex-array/src/array/arbitrary.rs
@@ -1,8 +1,9 @@
 use std::iter;
 
 use arbitrary::{Arbitrary, Result, Unstructured};
+use arrow_buffer::BooleanBuffer;
 use vortex_dtype::{DType, NativePType, Nullability, PType};
-use vortex_error::VortexUnwrap;
+use vortex_error::{VortexExpect, VortexUnwrap};
 
 use super::{BoolArray, ChunkedArray, NullArray, PrimitiveArray, StructArray};
 use crate::array::{VarBinArray, VarBinViewArray};
@@ -176,7 +177,9 @@ fn random_bool(
 ) -> Result<ArrayData> {
     let v = arbitrary_vec_of_len(u, len)?;
     let validity = random_validity(u, nullability, v.len())?;
-    Ok(BoolArray::from_vec(v, validity).into_array())
+    Ok(BoolArray::try_new(BooleanBuffer::from(v), validity)
+        .vortex_expect("failed to create bools")
+        .into_array())
 }
 
 fn random_validity(u: &mut Unstructured, nullability: Nullability, len: usize) -> Result<Validity> {
@@ -185,7 +188,7 @@ fn random_validity(u: &mut Unstructured, nullability: Nullability, len: usize) -
         Nullability::Nullable => Ok(match u.int_in_range(0..=2)? {
             0 => Validity::AllValid,
             1 => Validity::AllInvalid,
-            2 => Validity::from(arbitrary_vec_of_len(u, Some(len))?),
+            2 => Validity::from_iter(arbitrary_vec_of_len::<bool>(u, Some(len))?.into_iter()),
             _ => unreachable!(),
         }),
     }

--- a/vortex-array/src/array/arbitrary.rs
+++ b/vortex-array/src/array/arbitrary.rs
@@ -3,7 +3,7 @@ use std::iter;
 use arbitrary::{Arbitrary, Result, Unstructured};
 use arrow_buffer::BooleanBuffer;
 use vortex_dtype::{DType, NativePType, Nullability, PType};
-use vortex_error::VortexUnwrap;
+use vortex_error::{VortexExpect, VortexUnwrap};
 
 use super::{BoolArray, ChunkedArray, NullArray, PrimitiveArray, StructArray};
 use crate::array::{VarBinArray, VarBinViewArray};
@@ -177,7 +177,9 @@ fn random_bool(
 ) -> Result<ArrayData> {
     let v = arbitrary_vec_of_len(u, len)?;
     let validity = random_validity(u, nullability, v.len())?;
-    Ok(BoolArray::new(BooleanBuffer::from(v), validity).into_array())
+    Ok(BoolArray::try_new(BooleanBuffer::from(v), validity)
+        .vortex_expect("Validity length cannot mismatch")
+        .into_array())
 }
 
 fn random_validity(u: &mut Unstructured, nullability: Nullability, len: usize) -> Result<Validity> {

--- a/vortex-array/src/array/arbitrary.rs
+++ b/vortex-array/src/array/arbitrary.rs
@@ -186,7 +186,7 @@ fn random_validity(u: &mut Unstructured, nullability: Nullability, len: usize) -
         Nullability::Nullable => Ok(match u.int_in_range(0..=2)? {
             0 => Validity::AllValid,
             1 => Validity::AllInvalid,
-            2 => Validity::from_iter(arbitrary_vec_of_len::<bool>(u, Some(len))?.into_iter()),
+            2 => Validity::from_iter(arbitrary_vec_of_len::<bool>(u, Some(len))?),
             _ => unreachable!(),
         }),
     }

--- a/vortex-array/src/array/bool/compute/fill.rs
+++ b/vortex-array/src/array/bool/compute/fill.rs
@@ -16,15 +16,12 @@ impl FillForwardFn for BoolArray {
         }
         // all valid, but we need to convert to non-nullable
         if validity.all_valid() {
-            return Ok(
-                Self::try_new(self.boolean_buffer().clone(), Validity::AllValid)?.into_array(),
-            );
+            return Ok(Self::new(self.boolean_buffer().clone(), Validity::AllValid).into_array());
         }
         // all invalid => fill with default value (false)
         if validity.all_invalid() {
             return Ok(
-                Self::try_new(BooleanBuffer::new_unset(self.len()), Validity::AllValid)?
-                    .into_array(),
+                Self::new(BooleanBuffer::new_unset(self.len()), Validity::AllValid).into_array(),
             );
         }
 
@@ -42,7 +39,7 @@ impl FillForwardFn for BoolArray {
                 last_value
             },
         ));
-        Ok(Self::try_new(buffer, Validity::AllValid)?.into_array())
+        Ok(Self::new(buffer, Validity::AllValid).into_array())
     }
 }
 

--- a/vortex-array/src/array/bool/compute/fill.rs
+++ b/vortex-array/src/array/bool/compute/fill.rs
@@ -16,12 +16,15 @@ impl FillForwardFn for BoolArray {
         }
         // all valid, but we need to convert to non-nullable
         if validity.all_valid() {
-            return Ok(Self::new(self.boolean_buffer().clone(), Validity::AllValid).into_array());
+            return Ok(
+                Self::new(self.boolean_buffer().clone(), Nullability::Nullable).into_array(),
+            );
         }
         // all invalid => fill with default value (false)
         if validity.all_invalid() {
             return Ok(
-                Self::new(BooleanBuffer::new_unset(self.len()), Validity::AllValid).into_array(),
+                Self::try_new(BooleanBuffer::new_unset(self.len()), Validity::AllValid)?
+                    .into_array(),
             );
         }
 
@@ -39,7 +42,7 @@ impl FillForwardFn for BoolArray {
                 last_value
             },
         ));
-        Ok(Self::new(buffer, Validity::AllValid).into_array())
+        Ok(Self::try_new(buffer, Validity::AllValid)?.into_array())
     }
 }
 

--- a/vortex-array/src/array/bool/compute/fill.rs
+++ b/vortex-array/src/array/bool/compute/fill.rs
@@ -31,19 +31,18 @@ impl FillForwardFn for BoolArray {
         let validity = validity
             .to_null_buffer()?
             .ok_or_else(|| vortex_err!("Failed to convert array validity to null buffer"))?;
+
         let bools = self.boolean_buffer();
         let mut last_value = false;
-        let filled = bools
-            .iter()
-            .zip(validity.inner().iter())
-            .map(|(v, valid)| {
+        let buffer = BooleanBuffer::from_iter(bools.iter().zip(validity.inner().iter()).map(
+            |(v, valid)| {
                 if valid {
                     last_value = v;
                 }
                 last_value
-            })
-            .collect::<Vec<_>>();
-        Ok(Self::from_vec(filled, Validity::AllValid).into_array())
+            },
+        ));
+        Ok(Self::try_new(buffer, Validity::AllValid)?.into_array())
     }
 }
 

--- a/vortex-array/src/array/bool/compute/filter.rs
+++ b/vortex-array/src/array/bool/compute/filter.rs
@@ -25,7 +25,7 @@ fn filter_select_bool(arr: &BoolArray, predicate: &ArrayData) -> VortexResult<Bo
         } else {
             filter_select_bool_by_index(&arr.boolean_buffer(), predicate, selection_count)
         };
-        Ok(BoolArray::new(out, validity))
+        BoolArray::try_new(out, validity)
     })
 }
 
@@ -65,8 +65,8 @@ mod test {
 
     #[test]
     fn filter_bool_test() {
-        let arr = BoolArray::from(vec![true, true, false]);
-        let filter = BoolArray::from(vec![true, false, true]);
+        let arr = BoolArray::from_iter([true, true, false]);
+        let filter = BoolArray::from_iter([true, false, true]);
 
         let filtered = filter_select_bool(&arr, &filter.to_array()).unwrap();
         assert_eq!(2, filtered.len());
@@ -79,8 +79,8 @@ mod test {
 
     #[test]
     fn filter_bool_by_slice_test() {
-        let arr = BoolArray::from(vec![true, true, false]);
-        let filter = BoolArray::from(vec![true, false, true]);
+        let arr = BoolArray::from_iter([true, true, false]);
+        let filter = BoolArray::from_iter([true, false, true]);
 
         let filtered = filter_select_bool_by_slice(&arr.boolean_buffer(), &filter, 2);
         assert_eq!(2, filtered.len());
@@ -90,8 +90,8 @@ mod test {
 
     #[test]
     fn filter_bool_by_index_test() {
-        let arr = BoolArray::from(vec![true, true, false]);
-        let filter = BoolArray::from(vec![true, false, true]);
+        let arr = BoolArray::from_iter([true, true, false]);
+        let filter = BoolArray::from_iter([true, false, true]);
 
         let filtered = filter_select_bool_by_index(&arr.boolean_buffer(), &filter, 2);
         assert_eq!(2, filtered.len());

--- a/vortex-array/src/array/bool/compute/filter.rs
+++ b/vortex-array/src/array/bool/compute/filter.rs
@@ -25,7 +25,7 @@ fn filter_select_bool(arr: &BoolArray, predicate: &ArrayData) -> VortexResult<Bo
         } else {
             filter_select_bool_by_index(&arr.boolean_buffer(), predicate, selection_count)
         };
-        BoolArray::try_new(out, validity)
+        Ok(BoolArray::new(out, validity))
     })
 }
 

--- a/vortex-array/src/array/bool/compute/slice.rs
+++ b/vortex-array/src/array/bool/compute/slice.rs
@@ -6,11 +6,11 @@ use crate::{ArrayData, IntoArrayData};
 
 impl SliceFn for BoolArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<ArrayData> {
-        Self::try_new(
+        Ok(Self::new(
             self.boolean_buffer().slice(start, stop - start),
             self.validity().slice(start, stop)?,
         )
-        .map(|a| a.into_array())
+        .into_array())
     }
 }
 

--- a/vortex-array/src/array/bool/compute/slice.rs
+++ b/vortex-array/src/array/bool/compute/slice.rs
@@ -6,10 +6,10 @@ use crate::{ArrayData, IntoArrayData};
 
 impl SliceFn for BoolArray {
     fn slice(&self, start: usize, stop: usize) -> VortexResult<ArrayData> {
-        Ok(Self::new(
+        Ok(Self::try_new(
             self.boolean_buffer().slice(start, stop - start),
             self.validity().slice(start, stop)?,
-        )
+        )?
         .into_array())
     }
 }

--- a/vortex-array/src/array/bool/compute/take.rs
+++ b/vortex-array/src/array/bool/compute/take.rs
@@ -13,10 +13,10 @@ impl TakeFn for BoolArray {
         let validity = self.validity();
         let indices = indices.clone().into_primitive()?;
         match_each_integer_ptype!(indices.ptype(), |$I| {
-            Ok(BoolArray::try_new(
+            Ok(BoolArray::new(
                 take_bool(&self.boolean_buffer(), indices.maybe_null_slice::<$I>()),
                 validity.take(indices.as_ref())?,
-            )?.into_array())
+            ).into_array())
         })
     }
 }

--- a/vortex-array/src/array/bool/compute/take.rs
+++ b/vortex-array/src/array/bool/compute/take.rs
@@ -13,10 +13,10 @@ impl TakeFn for BoolArray {
         let validity = self.validity();
         let indices = indices.clone().into_primitive()?;
         match_each_integer_ptype!(indices.ptype(), |$I| {
-            Ok(BoolArray::new(
+            Ok(BoolArray::try_new(
                 take_bool(&self.boolean_buffer(), indices.maybe_null_slice::<$I>()),
                 validity.take(indices.as_ref())?,
-            ).into_array())
+            )?.into_array())
         })
     }
 }

--- a/vortex-array/src/array/bool/mod.rs
+++ b/vortex-array/src/array/bool/mod.rs
@@ -41,22 +41,6 @@ impl Display for BoolMetadata {
 }
 
 impl BoolArray {
-    pub fn all_true(len: usize) -> Self {
-        Self::from(BooleanBuffer::new_set(len))
-    }
-
-    pub fn all_true_with_validity(len: usize, validity: Validity) -> VortexResult<Self> {
-        Self::try_new(BooleanBuffer::new_set(len), validity)
-    }
-
-    pub fn all_false(len: usize) -> Self {
-        Self::from(BooleanBuffer::new_unset(len))
-    }
-
-    pub fn all_false_with_validity(len: usize, validity: Validity) -> VortexResult<Self> {
-        Self::try_new(BooleanBuffer::new_unset(len), validity)
-    }
-
     /// Access internal array buffer
     pub fn buffer(&self) -> &Buffer {
         self.as_ref()
@@ -115,8 +99,7 @@ impl BoolArray {
         })
     }
 
-    // TODO(ngates): this should probably just panic on mismatched lengths?
-    pub fn try_new(buffer: BooleanBuffer, validity: Validity) -> VortexResult<Self> {
+    pub fn new(buffer: BooleanBuffer, validity: Validity) -> Self {
         let buffer_len = buffer.len();
         let buffer_offset = buffer.offset();
         let first_byte_bit_offset = (buffer_offset % 8) as u8;
@@ -126,19 +109,22 @@ impl BoolArray {
             .into_inner()
             .bit_slice(buffer_byte_offset, buffer_len);
 
-        Ok(Self {
+        Self {
             typed: TypedArray::try_from_parts(
                 DType::Bool(validity.nullability()),
                 buffer_len,
                 BoolMetadata {
-                    validity: validity.to_metadata(buffer_len)?,
+                    validity: validity
+                        .to_metadata(buffer_len)
+                        .vortex_expect("Validity array has different length"),
                     first_byte_bit_offset,
                 },
                 Some(Buffer::from(inner)),
                 validity.into_array().into_iter().collect_vec().into(),
                 StatsSet::new(),
-            )?,
-        })
+            )
+            .vortex_expect("Metadata is known to be good"),
+        }
     }
 
     pub fn patch<P: AsPrimitive<usize>>(
@@ -166,7 +152,10 @@ impl BoolArray {
             own_values.set_bit(idx.as_() + bit_offset, value);
         }
 
-        Self::try_new(own_values.finish().slice(bit_offset, len), result_validity)
+        Ok(Self::new(
+            own_values.finish().slice(bit_offset, len),
+            result_validity,
+        ))
     }
 }
 
@@ -180,7 +169,7 @@ impl ArrayVariants for BoolArray {
 
 impl BoolArrayTrait for BoolArray {
     fn invert(&self) -> VortexResult<ArrayData> {
-        BoolArray::try_new(!&self.boolean_buffer(), self.validity()).map(|a| a.into_array())
+        Ok(BoolArray::new(!&self.boolean_buffer(), self.validity()).into_array())
     }
 
     fn maybe_null_indices_iter<'a>(&'a self) -> Box<dyn Iterator<Item = usize> + 'a> {
@@ -194,8 +183,7 @@ impl BoolArrayTrait for BoolArray {
 
 impl From<BooleanBuffer> for BoolArray {
     fn from(value: BooleanBuffer) -> Self {
-        Self::try_new(value, Validity::NonNullable)
-            .vortex_expect("Failed to create BoolArray from BooleanBuffer")
+        Self::new(value, Validity::NonNullable)
     }
 }
 
@@ -215,11 +203,10 @@ impl FromIterator<bool> for BoolArray {
 impl FromIterator<Option<bool>> for BoolArray {
     fn from_iter<I: IntoIterator<Item = Option<bool>>>(iter: I) -> Self {
         let (buffer, nulls) = BooleanArray::from_iter(iter).into_parts();
-        Self::try_new(
+        Self::new(
             buffer,
             nulls.map(Validity::from).unwrap_or(Validity::AllValid),
         )
-        .vortex_expect("Failed to create BoolArray")
     }
 }
 

--- a/vortex-array/src/array/bool/mod.rs
+++ b/vortex-array/src/array/bool/mod.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Debug, Display};
 
+use arrow_array::BooleanArray;
 use arrow_buffer::bit_iterator::{BitIndexIterator, BitSliceIterator};
 use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder, MutableBuffer};
 use itertools::Itertools;
@@ -37,6 +38,22 @@ impl Display for BoolMetadata {
 }
 
 impl BoolArray {
+    pub fn all_true(len: usize) -> Self {
+        Self::from(BooleanBuffer::new_set(len))
+    }
+
+    pub fn all_true_with_validity(len: usize, validity: Validity) -> VortexResult<Self> {
+        Self::try_new(BooleanBuffer::new_set(len), validity)
+    }
+
+    pub fn all_false(len: usize) -> Self {
+        Self::from(BooleanBuffer::new_unset(len))
+    }
+
+    pub fn all_false_with_validity(len: usize, validity: Validity) -> VortexResult<Self> {
+        Self::try_new(BooleanBuffer::new_unset(len), validity)
+    }
+
     /// Access internal array buffer
     pub fn buffer(&self) -> &Buffer {
         self.as_ref()
@@ -95,6 +112,7 @@ impl BoolArray {
         })
     }
 
+    // TODO(ngates): this should probably just panic on mismatched lengths?
     pub fn try_new(buffer: BooleanBuffer, validity: Validity) -> VortexResult<Self> {
         let buffer_len = buffer.len();
         let buffer_offset = buffer.offset();
@@ -118,11 +136,6 @@ impl BoolArray {
                 StatsSet::new(),
             )?,
         })
-    }
-
-    pub fn from_vec(bools: Vec<bool>, validity: Validity) -> Self {
-        let buffer = BooleanBuffer::from(bools);
-        Self::try_new(buffer, validity).vortex_expect("Failed to create BoolArray from vec")
     }
 
     pub fn patch<P: AsPrimitive<usize>>(
@@ -183,27 +196,27 @@ impl From<BooleanBuffer> for BoolArray {
     }
 }
 
+#[cfg(test)]
 impl From<Vec<bool>> for BoolArray {
     fn from(value: Vec<bool>) -> Self {
-        Self::from_vec(value, Validity::NonNullable)
+        Self::from(BooleanBuffer::from(value))
+    }
+}
+
+impl FromIterator<bool> for BoolArray {
+    fn from_iter<T: IntoIterator<Item = bool>>(iter: T) -> Self {
+        Self::from_iter(iter.into_iter().map(Some))
     }
 }
 
 impl FromIterator<Option<bool>> for BoolArray {
     fn from_iter<I: IntoIterator<Item = Option<bool>>>(iter: I) -> Self {
-        let iter = iter.into_iter();
-        let (lower, _) = iter.size_hint();
-
-        let mut validity: Vec<bool> = Vec::with_capacity(lower);
-        let values: Vec<bool> = iter
-            .map(|i| {
-                validity.push(i.is_some());
-                i.unwrap_or_default()
-            })
-            .collect::<Vec<_>>();
-
-        Self::try_new(BooleanBuffer::from(values), Validity::from(validity))
-            .vortex_expect("Failed to create BoolArray from iterator of Option<bool>")
+        let (buffer, nulls) = BooleanArray::from_iter(iter).into_parts();
+        Self::try_new(
+            buffer,
+            nulls.map(Validity::from).unwrap_or(Validity::AllValid),
+        )
+        .vortex_expect("Failed to create BoolArray")
     }
 }
 

--- a/vortex-array/src/array/bool/mod.rs
+++ b/vortex-array/src/array/bool/mod.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use num_traits::AsPrimitive;
 use serde::{Deserialize, Serialize};
 use vortex_buffer::Buffer;
-use vortex_dtype::DType;
+use vortex_dtype::{DType, Nullability};
 use vortex_error::{vortex_bail, VortexExpect as _, VortexResult};
 
 use crate::array::visitor::{AcceptArrayVisitor, ArrayVisitor};
@@ -99,7 +99,18 @@ impl BoolArray {
         })
     }
 
-    pub fn new(buffer: BooleanBuffer, validity: Validity) -> Self {
+    /// Create a new BoolArray from a buffer and nullability.
+    pub fn new(buffer: BooleanBuffer, nullability: Nullability) -> Self {
+        let validity = match nullability {
+            Nullability::Nullable => Validity::AllValid,
+            Nullability::NonNullable => Validity::NonNullable,
+        };
+        Self::try_new(buffer, validity).vortex_expect("Validity length cannot be mismatched")
+    }
+
+    /// Create a new BoolArray from a buffer and validity metadata.
+    /// Returns an error if the validity length does not match the buffer length.
+    pub fn try_new(buffer: BooleanBuffer, validity: Validity) -> VortexResult<Self> {
         let buffer_len = buffer.len();
         let buffer_offset = buffer.offset();
         let first_byte_bit_offset = (buffer_offset % 8) as u8;
@@ -109,14 +120,12 @@ impl BoolArray {
             .into_inner()
             .bit_slice(buffer_byte_offset, buffer_len);
 
-        Self {
+        Ok(Self {
             typed: TypedArray::try_from_parts(
                 DType::Bool(validity.nullability()),
                 buffer_len,
                 BoolMetadata {
-                    validity: validity
-                        .to_metadata(buffer_len)
-                        .vortex_expect("Validity array has different length"),
+                    validity: validity.to_metadata(buffer_len)?,
                     first_byte_bit_offset,
                 },
                 Some(Buffer::from(inner)),
@@ -124,7 +133,7 @@ impl BoolArray {
                 StatsSet::new(),
             )
             .vortex_expect("Metadata is known to be good"),
-        }
+        })
     }
 
     pub fn patch<P: AsPrimitive<usize>>(
@@ -152,10 +161,7 @@ impl BoolArray {
             own_values.set_bit(idx.as_() + bit_offset, value);
         }
 
-        Ok(Self::new(
-            own_values.finish().slice(bit_offset, len),
-            result_validity,
-        ))
+        Self::try_new(own_values.finish().slice(bit_offset, len), result_validity)
     }
 }
 
@@ -169,7 +175,7 @@ impl ArrayVariants for BoolArray {
 
 impl BoolArrayTrait for BoolArray {
     fn invert(&self) -> VortexResult<ArrayData> {
-        Ok(BoolArray::new(!&self.boolean_buffer(), self.validity()).into_array())
+        Ok(BoolArray::try_new(!&self.boolean_buffer(), self.validity())?.into_array())
     }
 
     fn maybe_null_indices_iter<'a>(&'a self) -> Box<dyn Iterator<Item = usize> + 'a> {
@@ -183,30 +189,24 @@ impl BoolArrayTrait for BoolArray {
 
 impl From<BooleanBuffer> for BoolArray {
     fn from(value: BooleanBuffer) -> Self {
-        Self::new(value, Validity::NonNullable)
-    }
-}
-
-#[cfg(test)]
-impl From<Vec<bool>> for BoolArray {
-    fn from(value: Vec<bool>) -> Self {
-        Self::from(BooleanBuffer::from(value))
+        Self::new(value, Nullability::NonNullable)
     }
 }
 
 impl FromIterator<bool> for BoolArray {
     fn from_iter<T: IntoIterator<Item = bool>>(iter: T) -> Self {
-        Self::new(BooleanBuffer::from_iter(iter), Validity::NonNullable)
+        Self::new(BooleanBuffer::from_iter(iter), Nullability::NonNullable)
     }
 }
 
 impl FromIterator<Option<bool>> for BoolArray {
     fn from_iter<I: IntoIterator<Item = Option<bool>>>(iter: I) -> Self {
         let (buffer, nulls) = BooleanArray::from_iter(iter).into_parts();
-        Self::new(
+        Self::try_new(
             buffer,
             nulls.map(Validity::from).unwrap_or(Validity::AllValid),
         )
+        .vortex_expect("Validity length cannot be mismatched")
     }
 }
 
@@ -247,7 +247,7 @@ mod tests {
 
     #[test]
     fn bool_array() {
-        let arr = BoolArray::from(vec![true, false, true]).into_array();
+        let arr = BoolArray::from_iter([true, false, true]).into_array();
         let scalar = bool::try_from(&scalar_at(&arr, 0).unwrap()).unwrap();
         assert!(scalar);
     }
@@ -289,14 +289,14 @@ mod tests {
 
     #[test]
     fn constant_iter_true_test() {
-        let arr = BoolArray::from(vec![true, true, true]);
+        let arr = BoolArray::from_iter([true, true, true]);
         assert_eq!(vec![0, 1, 2], arr.maybe_null_indices_iter().collect_vec());
         assert_eq!(vec![(0, 3)], arr.maybe_null_slices_iter().collect_vec());
     }
 
     #[test]
     fn constant_iter_true_false_test() {
-        let arr = BoolArray::from(vec![true, false, true]);
+        let arr = BoolArray::from_iter([true, false, true]);
         assert_eq!(vec![0, 2], arr.maybe_null_indices_iter().collect_vec());
         assert_eq!(
             vec![(0, 1), (2, 3)],
@@ -306,7 +306,7 @@ mod tests {
 
     #[test]
     fn constant_iter_false_test() {
-        let arr = BoolArray::from(vec![false, false, false]);
+        let arr = BoolArray::from_iter([false, false, false]);
         assert_eq!(0, arr.maybe_null_indices_iter().collect_vec().len());
         assert_eq!(0, arr.maybe_null_slices_iter().collect_vec().len());
     }

--- a/vortex-array/src/array/bool/mod.rs
+++ b/vortex-array/src/array/bool/mod.rs
@@ -196,7 +196,7 @@ impl From<Vec<bool>> for BoolArray {
 
 impl FromIterator<bool> for BoolArray {
     fn from_iter<T: IntoIterator<Item = bool>>(iter: T) -> Self {
-        Self::from_iter(iter.into_iter().map(Some))
+        Self::new(BooleanBuffer::from_iter(iter), Validity::NonNullable)
     }
 }
 

--- a/vortex-array/src/array/bool/mod.rs
+++ b/vortex-array/src/array/bool/mod.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Display};
 
 use arrow_array::BooleanArray;
 use arrow_buffer::bit_iterator::{BitIndexIterator, BitSliceIterator};
-use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder, MutableBuffer};
+use arrow_buffer::{BooleanBufferBuilder, MutableBuffer};
 use itertools::Itertools;
 use num_traits::AsPrimitive;
 use serde::{Deserialize, Serialize};
@@ -22,6 +22,9 @@ use crate::{
 mod accessors;
 mod compute;
 mod stats;
+
+// Re-export the BooleanBuffer type on our API surface.
+pub use arrow_buffer::BooleanBuffer;
 
 impl_encoding!("vortex.bool", ids::BOOL, Bool);
 

--- a/vortex-array/src/array/bool/stats.rs
+++ b/vortex-array/src/array/bool/stats.rs
@@ -166,7 +166,7 @@ mod test {
 
     #[test]
     fn bool_stats() {
-        let bool_arr = BoolArray::from(vec![false, false, true, true, false, true, true, false]);
+        let bool_arr = BoolArray::from_iter([false, false, true, true, false, true, true, false]);
         assert!(!bool_arr.statistics().compute_is_strict_sorted().unwrap());
         assert!(!bool_arr.statistics().compute_is_sorted().unwrap());
         assert!(!bool_arr.statistics().compute_is_constant().unwrap());
@@ -179,23 +179,23 @@ mod test {
 
     #[test]
     fn strict_sorted() {
-        let bool_arr_1 = BoolArray::from(vec![false, true]);
+        let bool_arr_1 = BoolArray::from_iter([false, true]);
         assert!(bool_arr_1.statistics().compute_is_strict_sorted().unwrap());
         assert!(bool_arr_1.statistics().compute_is_sorted().unwrap());
 
-        let bool_arr_2 = BoolArray::from(vec![true]);
+        let bool_arr_2 = BoolArray::from_iter([true]);
         assert!(bool_arr_2.statistics().compute_is_strict_sorted().unwrap());
         assert!(bool_arr_2.statistics().compute_is_sorted().unwrap());
 
-        let bool_arr_3 = BoolArray::from(vec![false]);
+        let bool_arr_3 = BoolArray::from_iter([false]);
         assert!(bool_arr_3.statistics().compute_is_strict_sorted().unwrap());
         assert!(bool_arr_3.statistics().compute_is_sorted().unwrap());
 
-        let bool_arr_4 = BoolArray::from(vec![true, false]);
+        let bool_arr_4 = BoolArray::from_iter([true, false]);
         assert!(!bool_arr_4.statistics().compute_is_strict_sorted().unwrap());
         assert!(!bool_arr_4.statistics().compute_is_sorted().unwrap());
 
-        let bool_arr_5 = BoolArray::from(vec![false, true, true]);
+        let bool_arr_5 = BoolArray::from_iter([false, true, true]);
         assert!(!bool_arr_5.statistics().compute_is_strict_sorted().unwrap());
         assert!(bool_arr_5.statistics().compute_is_sorted().unwrap());
     }

--- a/vortex-array/src/array/chunked/canonical.rs
+++ b/vortex-array/src/array/chunked/canonical.rs
@@ -155,7 +155,7 @@ fn pack_bools(chunks: &[ArrayData], validity: Validity) -> VortexResult<BoolArra
         buffer.append_buffer(&chunk.boolean_buffer());
     }
 
-    Ok(BoolArray::new(buffer.finish(), validity))
+    BoolArray::try_new(buffer.finish(), validity)
 }
 
 /// Builds a new [PrimitiveArray] by repacking the values from the chunks into a single

--- a/vortex-array/src/array/chunked/canonical.rs
+++ b/vortex-array/src/array/chunked/canonical.rs
@@ -155,7 +155,7 @@ fn pack_bools(chunks: &[ArrayData], validity: Validity) -> VortexResult<BoolArra
         buffer.append_buffer(&chunk.boolean_buffer());
     }
 
-    BoolArray::try_new(buffer.finish(), validity)
+    Ok(BoolArray::new(buffer.finish(), validity))
 }
 
 /// Builds a new [PrimitiveArray] by repacking the values from the chunks into a single

--- a/vortex-array/src/array/chunked/compute/filter.rs
+++ b/vortex-array/src/array/chunked/compute/filter.rs
@@ -267,7 +267,7 @@ mod test {
         )
         .unwrap()
         .into_array();
-        let mask = BoolArray::from(vec![
+        let mask = BoolArray::from_iter([
             true, false, false, true, true, true, true, true, true, true, true,
         ])
         .into_array();

--- a/vortex-array/src/array/constant/canonical.rs
+++ b/vortex-array/src/array/constant/canonical.rs
@@ -24,14 +24,14 @@ impl IntoCanonical for ConstantArray {
         };
 
         if let Ok(b) = BoolScalar::try_from(scalar) {
-            return Ok(Canonical::Bool(BoolArray::new(
+            return Ok(Canonical::Bool(BoolArray::try_new(
                 if b.value().unwrap_or_default() {
                     BooleanBuffer::new_set(self.len())
                 } else {
                     BooleanBuffer::new_unset(self.len())
                 },
                 validity,
-            )));
+            )?));
         }
 
         if let Ok(s) = Utf8Scalar::try_from(scalar) {

--- a/vortex-array/src/array/constant/canonical.rs
+++ b/vortex-array/src/array/constant/canonical.rs
@@ -24,14 +24,14 @@ impl IntoCanonical for ConstantArray {
         };
 
         if let Ok(b) = BoolScalar::try_from(scalar) {
-            return Ok(Canonical::Bool(BoolArray::try_new(
+            return Ok(Canonical::Bool(BoolArray::new(
                 if b.value().unwrap_or_default() {
                     BooleanBuffer::new_set(self.len())
                 } else {
                     BooleanBuffer::new_unset(self.len())
                 },
                 validity,
-            )?));
+            )));
         }
 
         if let Ok(s) = Utf8Scalar::try_from(scalar) {

--- a/vortex-array/src/array/from.rs
+++ b/vortex-array/src/array/from.rs
@@ -14,10 +14,11 @@ impl FromIterator<Option<bool>> for ArrayData {
 
 macro_rules! impl_from_primitive_for_array {
     ($P:ty) => {
-        impl FromIterator<$P> for ArrayData {
-            fn from_iter<T: IntoIterator<Item = $P>>(iter: T) -> Self {
-                PrimitiveArray::from_vec(iter.into_iter().collect(), Validity::NonNullable)
-                    .into_array()
+        // For primitives, it's more efficient to use from_vec, instead of from_iter since
+        // the values are already correctly laid out in-memory.
+        impl From<Vec<$P>> for ArrayData {
+            fn from(value: Vec<$P>) -> Self {
+                PrimitiveArray::from_vec(value, Validity::NonNullable).into_array()
             }
         }
 

--- a/vortex-array/src/array/from.rs
+++ b/vortex-array/src/array/from.rs
@@ -2,21 +2,28 @@ use vortex_buffer::{Buffer, BufferString};
 use vortex_dtype::half::f16;
 use vortex_dtype::{DType, Nullability};
 
-use super::{PrimitiveArray, VarBinViewArray};
+use super::{BoolArray, PrimitiveArray, VarBinViewArray};
 use crate::validity::Validity;
 use crate::{ArrayData, IntoArrayData as _};
 
+impl FromIterator<Option<bool>> for ArrayData {
+    fn from_iter<T: IntoIterator<Item = Option<bool>>>(iter: T) -> Self {
+        BoolArray::from_iter(iter).into_array()
+    }
+}
+
 macro_rules! impl_from_primitive_for_array {
     ($P:ty) => {
-        impl From<Vec<$P>> for ArrayData {
-            fn from(value: Vec<$P>) -> Self {
-                PrimitiveArray::from_vec(value, Validity::NonNullable).into_array()
+        impl FromIterator<$P> for ArrayData {
+            fn from_iter<T: IntoIterator<Item = $P>>(iter: T) -> Self {
+                PrimitiveArray::from_vec(iter.into_iter().collect(), Validity::NonNullable)
+                    .into_array()
             }
         }
 
-        impl From<Vec<Option<$P>>> for ArrayData {
-            fn from(value: Vec<Option<$P>>) -> Self {
-                PrimitiveArray::from_nullable_vec(value).into_array()
+        impl FromIterator<Option<$P>> for ArrayData {
+            fn from_iter<T: IntoIterator<Item = Option<$P>>>(iter: T) -> Self {
+                PrimitiveArray::from_nullable_vec(iter.into_iter().collect()).into_array()
             }
         }
     };
@@ -34,14 +41,14 @@ impl_from_primitive_for_array!(f16);
 impl_from_primitive_for_array!(f32);
 impl_from_primitive_for_array!(f64);
 
-impl From<Vec<Option<BufferString>>> for ArrayData {
-    fn from(value: Vec<Option<BufferString>>) -> Self {
-        VarBinViewArray::from_iter(value, DType::Utf8(Nullability::Nullable)).into_array()
+impl FromIterator<Option<BufferString>> for ArrayData {
+    fn from_iter<T: IntoIterator<Item = Option<BufferString>>>(iter: T) -> Self {
+        VarBinViewArray::from_iter(iter, DType::Utf8(Nullability::Nullable)).into_array()
     }
 }
 
-impl From<Vec<Option<Buffer>>> for ArrayData {
-    fn from(value: Vec<Option<Buffer>>) -> Self {
-        VarBinViewArray::from_iter(value, DType::Binary(Nullability::Nullable)).into_array()
+impl FromIterator<Option<Buffer>> for ArrayData {
+    fn from_iter<T: IntoIterator<Item = Option<Buffer>>>(iter: T) -> Self {
+        VarBinViewArray::from_iter(iter, DType::Binary(Nullability::Nullable)).into_array()
     }
 }

--- a/vortex-array/src/array/from.rs
+++ b/vortex-array/src/array/from.rs
@@ -2,17 +2,9 @@ use vortex_buffer::{Buffer, BufferString};
 use vortex_dtype::half::f16;
 use vortex_dtype::{DType, Nullability};
 
-use super::{BoolArray, PrimitiveArray, VarBinViewArray};
+use super::{PrimitiveArray, VarBinViewArray};
 use crate::validity::Validity;
 use crate::{ArrayData, IntoArrayData as _};
-
-// `From<Vec<Option<!>>> for Array` requries the experimental uninhabited type: !.
-
-impl From<Vec<Option<bool>>> for ArrayData {
-    fn from(value: Vec<Option<bool>>) -> Self {
-        BoolArray::from_iter(value).into_array()
-    }
-}
 
 macro_rules! impl_from_primitive_for_array {
     ($P:ty) => {

--- a/vortex-array/src/array/primitive/compute/compare.rs
+++ b/vortex-array/src/array/primitive/compute/compare.rs
@@ -32,7 +32,7 @@ impl MaybeCompareFn for PrimitiveArray {
 
             return Some(
                 validity
-                    .and_then(|v| BoolArray::try_new(match_mask, v))
+                    .map(|v| BoolArray::new(match_mask, v))
                     .map(|a| a.into_array()),
             );
         }
@@ -55,7 +55,7 @@ fn primitive_const_compare(
         primitive_value_compare::<$T>(this, typed_value, operator)
     });
 
-    Ok(BoolArray::try_new(buffer, this.validity().into_nullable())?.into_array())
+    Ok(BoolArray::new(buffer, this.validity().into_nullable()).into_array())
 }
 
 fn primitive_value_compare<T: NativePType>(

--- a/vortex-array/src/array/primitive/compute/compare.rs
+++ b/vortex-array/src/array/primitive/compute/compare.rs
@@ -32,7 +32,7 @@ impl MaybeCompareFn for PrimitiveArray {
 
             return Some(
                 validity
-                    .map(|v| BoolArray::new(match_mask, v))
+                    .and_then(|v| BoolArray::try_new(match_mask, v))
                     .map(|a| a.into_array()),
             );
         }
@@ -55,7 +55,7 @@ fn primitive_const_compare(
         primitive_value_compare::<$T>(this, typed_value, operator)
     });
 
-    Ok(BoolArray::new(buffer, this.validity().into_nullable()).into_array())
+    Ok(BoolArray::try_new(buffer, this.validity().into_nullable())?.into_array())
 }
 
 fn primitive_value_compare<T: NativePType>(

--- a/vortex-array/src/array/primitive/compute/fill.rs
+++ b/vortex-array/src/array/primitive/compute/fill.rs
@@ -78,7 +78,7 @@ mod test {
     fn nullable_non_null() {
         let arr = PrimitiveArray::from_vec(
             vec![8u8, 10u8, 12u8, 14u8, 16u8],
-            Validity::Array(BoolArray::from(vec![true, true, true, true, true]).into_array()),
+            Validity::Array(BoolArray::from_iter([true, true, true, true, true]).into_array()),
         )
         .into_array();
         let p = fill_forward(&arr).unwrap().as_primitive();

--- a/vortex-array/src/array/primitive/compute/filter.rs
+++ b/vortex-array/src/array/primitive/compute/filter.rs
@@ -56,11 +56,12 @@ mod test {
 
     #[test]
     fn filter_run_variant_mixed_test() {
-        let filter = vec![true, true, false, true, true, true, false, true];
+        let filter = [true, true, false, true, true, true, false, true];
         let arr = PrimitiveArray::from(vec![1u32, 24, 54, 2, 3, 2, 3, 2]);
 
         let filtered =
-            filter_select_primitive(&arr, BoolArray::from(filter.clone()).as_ref()).unwrap();
+            filter_select_primitive(&arr, BoolArray::from_iter(filter.iter().copied()).as_ref())
+                .unwrap();
         assert_eq!(
             filtered.len(),
             filter.iter().filter(|x| **x).collect_vec().len()

--- a/vortex-array/src/array/primitive/mod.rs
+++ b/vortex-array/src/array/primitive/mod.rs
@@ -82,7 +82,7 @@ impl PrimitiveArray {
 
     pub fn from_nullable_vec<T: NativePType>(values: Vec<Option<T>>) -> Self {
         let elems: Vec<T> = values.iter().map(|v| v.unwrap_or_default()).collect();
-        let validity = Validity::from(values.iter().map(|v| v.is_some()).collect::<Vec<_>>());
+        let validity = Validity::from_iter(values.iter().map(|v| v.is_some()));
         Self::from_vec(elems, validity)
     }
 

--- a/vortex-array/src/array/sparse/canonical.rs
+++ b/vortex-array/src/array/sparse/canonical.rs
@@ -51,14 +51,14 @@ fn canonicalize_sparse_bools(
         )
     };
 
-    let bools = BoolArray::try_new(
+    let bools = BoolArray::new(
         if fill_bool {
             BooleanBuffer::new_set(len)
         } else {
             BooleanBuffer::new_unset(len)
         },
         validity,
-    )?;
+    );
     let patched = bools.patch(indices, values)?;
     Ok(Canonical::Bool(patched))
 }

--- a/vortex-array/src/array/sparse/canonical.rs
+++ b/vortex-array/src/array/sparse/canonical.rs
@@ -51,14 +51,14 @@ fn canonicalize_sparse_bools(
         )
     };
 
-    let bools = BoolArray::new(
+    let bools = BoolArray::try_new(
         if fill_bool {
             BooleanBuffer::new_set(len)
         } else {
             BooleanBuffer::new_unset(len)
         },
         validity,
-    );
+    )?;
     let patched = bools.patch(indices, values)?;
     Ok(Canonical::Bool(patched))
 }
@@ -95,6 +95,7 @@ mod test {
     use arrow_buffer::BooleanBufferBuilder;
     use rstest::rstest;
     use vortex_dtype::{DType, Nullability, PType};
+    use vortex_error::VortexExpect;
     use vortex_scalar::ScalarValue;
 
     use crate::array::sparse::SparseArray;
@@ -156,7 +157,8 @@ mod test {
             buffer.append(maybe_bool.unwrap_or_else(|| fill_value.unwrap_or_default()));
             validity.append(maybe_bool.is_some());
         }
-        BoolArray::new(buffer.finish(), Validity::from(validity.finish()))
+        BoolArray::try_new(buffer.finish(), Validity::from(validity.finish()))
+            .vortex_expect("Validity length cannot mismatch")
     }
 
     #[rstest]

--- a/vortex-array/src/array/sparse/canonical.rs
+++ b/vortex-array/src/array/sparse/canonical.rs
@@ -95,7 +95,6 @@ mod test {
     use arrow_buffer::BooleanBufferBuilder;
     use rstest::rstest;
     use vortex_dtype::{DType, Nullability, PType};
-    use vortex_error::VortexExpect as _;
     use vortex_scalar::ScalarValue;
 
     use crate::array::sparse::SparseArray;
@@ -157,8 +156,7 @@ mod test {
             buffer.append(maybe_bool.unwrap_or_else(|| fill_value.unwrap_or_default()));
             validity.append(maybe_bool.is_some());
         }
-        BoolArray::try_new(buffer.finish(), Validity::from(validity.finish()))
-            .vortex_expect("Failed to create BoolArray from nullable vec")
+        BoolArray::new(buffer.finish(), Validity::from(validity.finish()))
     }
 
     #[rstest]

--- a/vortex-array/src/array/sparse/compute/mod.rs
+++ b/vortex-array/src/array/sparse/compute/mod.rs
@@ -193,7 +193,7 @@ mod test {
     fn test_filter(array: ArrayData) {
         let mut predicate = vec![false, false, true];
         predicate.extend_from_slice(&[false; 17]);
-        let predicate = BoolArray::from(predicate).into_array();
+        let predicate = BoolArray::from_iter(predicate).into_array();
 
         let filtered_array = filter(&array, &predicate).unwrap();
         let filtered_array = SparseArray::try_from(filtered_array).unwrap();
@@ -206,7 +206,7 @@ mod test {
     #[test]
     fn true_fill_value() {
         let predicate =
-            BoolArray::from(vec![false, true, false, true, false, true, true]).into_array();
+            BoolArray::from_iter([false, true, false, true, false, true, true]).into_array();
         let array = SparseArray::try_new(
             PrimitiveArray::from(vec![0_u64, 3, 6]).into_array(),
             PrimitiveArray::from_vec(vec![33_i32, 44, 55], Validity::AllValid).into_array(),

--- a/vortex-array/src/array/sparse/compute/mod.rs
+++ b/vortex-array/src/array/sparse/compute/mod.rs
@@ -193,7 +193,7 @@ mod test {
     fn test_filter(array: ArrayData) {
         let mut predicate = vec![false, false, true];
         predicate.extend_from_slice(&[false; 17]);
-        let predicate = BoolArray::from_vec(predicate, Validity::NonNullable).into_array();
+        let predicate = BoolArray::from(predicate).into_array();
 
         let filtered_array = filter(&array, &predicate).unwrap();
         let filtered_array = SparseArray::try_from(filtered_array).unwrap();
@@ -205,11 +205,8 @@ mod test {
 
     #[test]
     fn true_fill_value() {
-        let predicate = BoolArray::from_vec(
-            vec![false, true, false, true, false, true, true],
-            Validity::NonNullable,
-        )
-        .into_array();
+        let predicate =
+            BoolArray::from(vec![false, true, false, true, false, true, true]).into_array();
         let array = SparseArray::try_new(
             PrimitiveArray::from(vec![0_u64, 3, 6]).into_array(),
             PrimitiveArray::from_vec(vec![33_i32, 44, 55], Validity::AllValid).into_array(),

--- a/vortex-array/src/array/sparse/variants.rs
+++ b/vortex-array/src/array/sparse/variants.rs
@@ -146,7 +146,7 @@ mod tests {
     fn invert_bools_non_null_fill() {
         let sparse_bools = SparseArray::try_new(
             PrimitiveArray::from(vec![0u64]).into_array(),
-            BoolArray::from(vec![false]).into_array(),
+            BoolArray::from_iter([false]).into_array(),
             2,
             true.into(),
         )

--- a/vortex-array/src/array/struct_/compute.rs
+++ b/vortex-array/src/array/struct_/compute.rs
@@ -112,7 +112,7 @@ mod tests {
         let mask = vec![
             false, true, false, true, false, true, false, true, false, true,
         ];
-        let filtered = filter(struct_arr.as_ref(), BoolArray::from(mask)).unwrap();
+        let filtered = filter(struct_arr.as_ref(), BoolArray::from_iter(mask)).unwrap();
         assert_eq!(filtered.len(), 5);
     }
 
@@ -120,7 +120,7 @@ mod tests {
     fn filter_empty_struct_with_empty_filter() {
         let struct_arr =
             StructArray::try_new(vec![].into(), vec![], 0, Validity::NonNullable).unwrap();
-        let filtered = filter(struct_arr.as_ref(), BoolArray::from(vec![])).unwrap();
+        let filtered = filter(struct_arr.as_ref(), BoolArray::from_iter::<[bool; 0]>([])).unwrap();
         assert_eq!(filtered.len(), 0);
     }
 }

--- a/vortex-array/src/array/struct_/mod.rs
+++ b/vortex-array/src/array/struct_/mod.rs
@@ -213,7 +213,7 @@ mod test {
             vec!["a", "b", "c", "d", "e"],
             DType::Utf8(Nullability::NonNullable),
         );
-        let zs = BoolArray::from(vec![true, true, true, false, false]);
+        let zs = BoolArray::from_iter([true, true, true, false, false]);
 
         let struct_a = StructArray::try_new(
             FieldNames::from(["xs".into(), "ys".into(), "zs".into()]),

--- a/vortex-array/src/array/struct_/mod.rs
+++ b/vortex-array/src/array/struct_/mod.rs
@@ -213,7 +213,7 @@ mod test {
             vec!["a", "b", "c", "d", "e"],
             DType::Utf8(Nullability::NonNullable),
         );
-        let zs = BoolArray::from_vec(vec![true, true, true, false, false], Validity::NonNullable);
+        let zs = BoolArray::from(vec![true, true, true, false, false]);
 
         let struct_a = StructArray::try_new(
             FieldNames::from(["xs".into(), "ys".into(), "zs".into()]),

--- a/vortex-array/src/array/varbin/compute/filter.rs
+++ b/vortex-array/src/array/varbin/compute/filter.rs
@@ -208,7 +208,7 @@ mod test {
             ],
             DType::Utf8(NonNullable),
         );
-        let filter = BoolArray::from(vec![true, false, true]);
+        let filter = BoolArray::from_iter([true, false, true]);
 
         let buf = filter_select_var_bin_by_index(&arr, &filter, 2)
             .unwrap()
@@ -231,7 +231,7 @@ mod test {
             ],
             DType::Utf8(NonNullable),
         );
-        let filter = BoolArray::from(vec![true, false, true, false, true]);
+        let filter = BoolArray::from_iter([true, false, true, false, true]);
 
         let buf = filter_select_var_bin_by_slice(&arr, &filter, 3)
             .unwrap()
@@ -261,9 +261,9 @@ mod test {
 
         let offsets = PrimitiveArray::from(vec![0, 3, 6, 11, 15, 19, 22]).to_array();
         let validity =
-            Validity::Array(BoolArray::from(vec![true, false, true, true, true, true]).to_array());
+            Validity::Array(BoolArray::from_iter([true, false, true, true, true, true]).to_array());
         let arr = VarBinArray::try_new(offsets, bytes, DType::Utf8(Nullable), validity).unwrap();
-        let filter = BoolArray::from(vec![true, true, true, false, true, true]);
+        let filter = BoolArray::from_iter([true, true, true, false, true, true]);
 
         let buf = filter_select_var_bin_by_slice(&arr, &filter, 5)
             .unwrap()

--- a/vortex-array/src/arrow/array.rs
+++ b/vortex-array/src/arrow/array.rs
@@ -14,11 +14,11 @@ use arrow_array::types::{
 };
 use arrow_array::{BinaryViewArray, GenericByteViewArray, StringViewArray};
 use arrow_buffer::buffer::{NullBuffer, OffsetBuffer};
-use arrow_buffer::{ArrowNativeType, Buffer, ScalarBuffer};
+use arrow_buffer::{ArrowNativeType, BooleanBuffer, Buffer, ScalarBuffer};
 use arrow_schema::{DataType, TimeUnit as ArrowTimeUnit};
 use itertools::Itertools;
 use vortex_datetime_dtype::TimeUnit;
-use vortex_dtype::{DType, NativePType, PType};
+use vortex_dtype::{DType, NativePType, Nullability, PType};
 use vortex_error::{vortex_panic, VortexExpect as _};
 
 use crate::array::{
@@ -35,9 +35,9 @@ impl From<Buffer> for ArrayData {
     }
 }
 
-impl From<NullBuffer> for ArrayData {
-    fn from(value: NullBuffer) -> Self {
-        BoolArray::new(value.into_inner(), Validity::NonNullable).into_array()
+impl From<BooleanBuffer> for ArrayData {
+    fn from(value: BooleanBuffer) -> Self {
+        BoolArray::new(value, Nullability::NonNullable).into_array()
     }
 }
 
@@ -148,7 +148,9 @@ impl<T: ByteViewType> FromArrowArray<&GenericByteViewArray<T>> for ArrayData {
 
 impl FromArrowArray<&ArrowBooleanArray> for ArrayData {
     fn from_arrow(value: &ArrowBooleanArray, nullable: bool) -> Self {
-        BoolArray::new(value.values().clone(), nulls(value.nulls(), nullable)).into()
+        BoolArray::try_new(value.values().clone(), nulls(value.nulls(), nullable))
+            .vortex_expect("Validity length cannot mismatch")
+            .into()
     }
 }
 

--- a/vortex-array/src/arrow/array.rs
+++ b/vortex-array/src/arrow/array.rs
@@ -37,9 +37,7 @@ impl From<Buffer> for ArrayData {
 
 impl From<NullBuffer> for ArrayData {
     fn from(value: NullBuffer) -> Self {
-        BoolArray::try_new(value.into_inner(), Validity::NonNullable)
-            .vortex_expect("Failed to convert null buffer to BoolArray")
-            .into_array()
+        BoolArray::new(value.into_inner(), Validity::NonNullable).into_array()
     }
 }
 
@@ -150,9 +148,7 @@ impl<T: ByteViewType> FromArrowArray<&GenericByteViewArray<T>> for ArrayData {
 
 impl FromArrowArray<&ArrowBooleanArray> for ArrayData {
     fn from_arrow(value: &ArrowBooleanArray, nullable: bool) -> Self {
-        BoolArray::try_new(value.values().clone(), nulls(value.nulls(), nullable))
-            .vortex_expect("Failed to convert Arrow BooleanArray to Vortex BoolArray")
-            .into()
+        BoolArray::new(value.values().clone(), nulls(value.nulls(), nullable)).into()
     }
 }
 

--- a/vortex-array/src/compute/boolean.rs
+++ b/vortex-array/src/compute/boolean.rs
@@ -14,8 +14,8 @@ pub trait AndFn {
     /// use vortex_array::compute::and;
     /// use vortex_array::IntoCanonical;
     /// use vortex_array::accessor::ArrayAccessor;
-    /// let a = ArrayData::from(vec![Some(true), Some(true), Some(true), None, None, None, Some(false), Some(false), Some(false)]);
-    /// let b = ArrayData::from(vec![Some(true), None, Some(false), Some(true), None, Some(false), Some(true), None, Some(false)]);
+    /// let a = ArrayData::from_iter([Some(true), Some(true), Some(true), None, None, None, Some(false), Some(false), Some(false)]);
+    /// let b = ArrayData::from_iter([Some(true), None, Some(false), Some(true), None, Some(false), Some(true), None, Some(false)]);
     /// let result = and(a, b)?.into_canonical()?.into_bool()?;
     /// let result_vec = result.with_iterator(|it| it.map(|x| x.cloned()).collect::<Vec<_>>())?;
     /// assert_eq!(result_vec, vec![Some(true), None, Some(false), None, None, None, Some(false), None, Some(false)]);
@@ -33,8 +33,8 @@ pub trait AndFn {
     /// use vortex_array::compute::and_kleene;
     /// use vortex_array::IntoCanonical;
     /// use vortex_array::accessor::ArrayAccessor;
-    /// let a = ArrayData::from(vec![Some(true), Some(true), Some(true), None, None, None, Some(false), Some(false), Some(false)]);
-    /// let b = ArrayData::from(vec![Some(true), None, Some(false), Some(true), None, Some(false), Some(true), None, Some(false)]);
+    /// let a = ArrayData::from_iter([Some(true), Some(true), Some(true), None, None, None, Some(false), Some(false), Some(false)]);
+    /// let b = ArrayData::from_iter([Some(true), None, Some(false), Some(true), None, Some(false), Some(true), None, Some(false)]);
     /// let result = and_kleene(a, b)?.into_canonical()?.into_bool()?;
     /// let result_vec = result.with_iterator(|it| it.map(|x| x.cloned()).collect::<Vec<_>>())?;
     /// assert_eq!(result_vec, vec![Some(true), None, Some(false), None, None, Some(false), Some(false), Some(false), Some(false)]);
@@ -56,8 +56,8 @@ pub trait OrFn {
     /// use vortex_array::compute::or;
     /// use vortex_array::IntoCanonical;
     /// use vortex_array::accessor::ArrayAccessor;
-    /// let a = ArrayData::from(vec![Some(true), Some(true), Some(true), None, None, None, Some(false), Some(false), Some(false)]);
-    /// let b = ArrayData::from(vec![Some(true), None, Some(false), Some(true), None, Some(false), Some(true), None, Some(false)]);
+    /// let a = ArrayData::from_iter([Some(true), Some(true), Some(true), None, None, None, Some(false), Some(false), Some(false)]);
+    /// let b = ArrayData::from_iter([Some(true), None, Some(false), Some(true), None, Some(false), Some(true), None, Some(false)]);
     /// let result = or(a, b)?.into_canonical()?.into_bool()?;
     /// let result_vec = result.with_iterator(|it| it.map(|x| x.cloned()).collect::<Vec<_>>())?;
     /// assert_eq!(result_vec, vec![Some(true), None, Some(true), None, None, None, Some(true), None, Some(false)]);
@@ -75,8 +75,8 @@ pub trait OrFn {
     /// use vortex_array::compute::or_kleene;
     /// use vortex_array::IntoCanonical;
     /// use vortex_array::accessor::ArrayAccessor;
-    /// let a = ArrayData::from(vec![Some(true), Some(true), Some(true), None, None, None, Some(false), Some(false), Some(false)]);
-    /// let b = ArrayData::from(vec![Some(true), None, Some(false), Some(true), None, Some(false), Some(true), None, Some(false)]);
+    /// let a = ArrayData::from_iter([Some(true), Some(true), Some(true), None, None, None, Some(false), Some(false), Some(false)]);
+    /// let b = ArrayData::from_iter([Some(true), None, Some(false), Some(true), None, Some(false), Some(true), None, Some(false)]);
     /// let result = or_kleene(a, b)?.into_canonical()?.into_bool()?;
     /// let result_vec = result.with_iterator(|it| it.map(|x| x.cloned()).collect::<Vec<_>>())?;
     /// assert_eq!(result_vec, vec![Some(true), Some(true), Some(true), Some(true), None, None, Some(true), None, Some(false)]);

--- a/vortex-array/src/compute/compare.rs
+++ b/vortex-array/src/compute/compare.rs
@@ -176,11 +176,10 @@ mod tests {
 
     #[test]
     fn test_bool_basic_comparisons() {
-        let arr = BoolArray::try_new(
+        let arr = BoolArray::new(
             BooleanBuffer::from_iter([true, true, false, true, false]),
             Validity::Array(BoolArray::from(vec![false, true, true, true, true]).into_array()),
         )
-        .unwrap()
         .into_array();
 
         let matches = compare(&arr, &arr, Operator::Eq)
@@ -197,11 +196,10 @@ mod tests {
         let empty: [u64; 0] = [];
         assert_eq!(to_int_indices(matches), empty);
 
-        let other = BoolArray::try_new(
+        let other = BoolArray::new(
             BooleanBuffer::from_iter([false, false, false, true, true]),
             Validity::Array(BoolArray::from(vec![false, true, true, true, true]).into_array()),
         )
-        .unwrap()
         .into_array();
 
         let matches = compare(&arr, &other, Operator::Lte)

--- a/vortex-array/src/compute/compare.rs
+++ b/vortex-array/src/compute/compare.rs
@@ -146,6 +146,7 @@ pub fn scalar_cmp(lhs: &Scalar, rhs: &Scalar, operator: Operator) -> Scalar {
 
 #[cfg(test)]
 mod tests {
+    use arrow_buffer::BooleanBuffer;
     use itertools::Itertools;
     use vortex_scalar::ScalarValue;
 
@@ -175,10 +176,11 @@ mod tests {
 
     #[test]
     fn test_bool_basic_comparisons() {
-        let arr = BoolArray::from_vec(
-            vec![true, true, false, true, false],
+        let arr = BoolArray::try_new(
+            BooleanBuffer::from_iter([true, true, false, true, false]),
             Validity::Array(BoolArray::from(vec![false, true, true, true, true]).into_array()),
         )
+        .unwrap()
         .into_array();
 
         let matches = compare(&arr, &arr, Operator::Eq)
@@ -195,10 +197,11 @@ mod tests {
         let empty: [u64; 0] = [];
         assert_eq!(to_int_indices(matches), empty);
 
-        let other = BoolArray::from_vec(
-            vec![false, false, false, true, true],
+        let other = BoolArray::try_new(
+            BooleanBuffer::from_iter([false, false, false, true, true]),
             Validity::Array(BoolArray::from(vec![false, true, true, true, true]).into_array()),
         )
+        .unwrap()
         .into_array();
 
         let matches = compare(&arr, &other, Operator::Lte)

--- a/vortex-array/src/compute/compare.rs
+++ b/vortex-array/src/compute/compare.rs
@@ -176,10 +176,11 @@ mod tests {
 
     #[test]
     fn test_bool_basic_comparisons() {
-        let arr = BoolArray::new(
+        let arr = BoolArray::try_new(
             BooleanBuffer::from_iter([true, true, false, true, false]),
-            Validity::Array(BoolArray::from(vec![false, true, true, true, true]).into_array()),
+            Validity::from_iter([false, true, true, true, true]),
         )
+        .unwrap()
         .into_array();
 
         let matches = compare(&arr, &arr, Operator::Eq)
@@ -196,10 +197,11 @@ mod tests {
         let empty: [u64; 0] = [];
         assert_eq!(to_int_indices(matches), empty);
 
-        let other = BoolArray::new(
+        let other = BoolArray::try_new(
             BooleanBuffer::from_iter([false, false, false, true, true]),
-            Validity::Array(BoolArray::from(vec![false, true, true, true, true]).into_array()),
+            Validity::from_iter([false, true, true, true, true]),
         )
+        .unwrap()
         .into_array();
 
         let matches = compare(&arr, &other, Operator::Lte)

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -67,7 +67,7 @@ mod test {
         let items =
             PrimitiveArray::from_nullable_vec(vec![Some(0i32), None, Some(1i32), None, Some(2i32)])
                 .into_array();
-        let predicate = BoolArray::from(vec![true, false, true, false, true]).into_array();
+        let predicate = BoolArray::from_iter([true, false, true, false, true]).into_array();
 
         let filtered = filter(&items, &predicate).unwrap();
         assert_eq!(

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -60,7 +60,6 @@ pub fn filter(
 mod test {
     use crate::array::{BoolArray, PrimitiveArray};
     use crate::compute::filter::filter;
-    use crate::validity::Validity;
     use crate::{IntoArrayData, IntoCanonical};
 
     #[test]
@@ -68,9 +67,7 @@ mod test {
         let items =
             PrimitiveArray::from_nullable_vec(vec![Some(0i32), None, Some(1i32), None, Some(2i32)])
                 .into_array();
-        let predicate =
-            BoolArray::from_vec(vec![true, false, true, false, true], Validity::NonNullable)
-                .into_array();
+        let predicate = BoolArray::from(vec![true, false, true, false, true]).into_array();
 
         let filtered = filter(&items, &predicate).unwrap();
         assert_eq!(

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -302,6 +302,8 @@ impl PartialEq for Validity {
     }
 }
 
+// Too inefficient, only use in tests
+#[cfg(test)]
 impl From<Vec<bool>> for Validity {
     fn from(bools: Vec<bool>) -> Self {
         if bools.iter().all(|b| *b) {
@@ -373,10 +375,15 @@ impl FromIterator<LogicalValidity> for Validity {
     }
 }
 
-impl<'a, E> FromIterator<&'a Option<E>> for Validity {
-    fn from_iter<T: IntoIterator<Item = &'a Option<E>>>(iter: T) -> Self {
-        let bools: Vec<bool> = iter.into_iter().map(|option| option.is_some()).collect();
-        Self::from(bools)
+impl FromIterator<Option<bool>> for Validity {
+    fn from_iter<T: IntoIterator<Item = Option<bool>>>(iter: T) -> Self {
+        Self::Array(BoolArray::from_iter(iter).into_array())
+    }
+}
+
+impl FromIterator<bool> for Validity {
+    fn from_iter<T: IntoIterator<Item = bool>>(iter: T) -> Self {
+        Self::Array(BoolArray::from_iter(iter).into_array())
     }
 }
 
@@ -460,8 +467,8 @@ impl TryFrom<ArrayData> for LogicalValidity {
 impl IntoArrayData for LogicalValidity {
     fn into_array(self) -> ArrayData {
         match self {
-            Self::AllValid(len) => BoolArray::from(vec![true; len]).into_array(),
-            Self::AllInvalid(len) => BoolArray::from(vec![false; len]).into_array(),
+            Self::AllValid(len) => BoolArray::all_true(len).into_array(),
+            Self::AllInvalid(len) => BoolArray::all_false(len).into_array(),
             Self::Array(a) => a,
         }
     }

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -302,20 +302,6 @@ impl PartialEq for Validity {
     }
 }
 
-// Too inefficient, only use in tests
-#[cfg(test)]
-impl From<Vec<bool>> for Validity {
-    fn from(bools: Vec<bool>) -> Self {
-        if bools.iter().all(|b| *b) {
-            Self::AllValid
-        } else if !bools.iter().any(|b| *b) {
-            Self::AllInvalid
-        } else {
-            Self::Array(BoolArray::from(bools).into_array())
-        }
-    }
-}
-
 impl From<BooleanBuffer> for Validity {
     fn from(value: BooleanBuffer) -> Self {
         if value.count_set_bits() == value.len() {
@@ -372,19 +358,6 @@ impl FromIterator<LogicalValidity> for Validity {
         }
         let bool_array = BoolArray::from(buffer.finish());
         Self::Array(bool_array.into_array())
-    }
-}
-
-/// Convert an iterator of any optional into a validity.
-impl<'a, E> FromIterator<&'a Option<E>> for Validity {
-    fn from_iter<T: IntoIterator<Item = &'a Option<E>>>(iter: T) -> Self {
-        Self::from_iter(iter.into_iter().map(|option| option.is_some()))
-    }
-}
-
-impl FromIterator<Option<bool>> for Validity {
-    fn from_iter<T: IntoIterator<Item = Option<bool>>>(iter: T) -> Self {
-        Self::Array(BoolArray::from_iter(iter).into_array())
     }
 }
 
@@ -492,20 +465,20 @@ mod tests {
     #[rstest]
     #[case(Validity::NonNullable, 5, &[2, 4], Validity::NonNullable, Validity::NonNullable)]
     #[case(Validity::NonNullable, 5, &[2, 4], Validity::AllValid, Validity::NonNullable)]
-    #[case(Validity::NonNullable, 5, &[2, 4], Validity::AllInvalid, Validity::Array(BoolArray::from(vec![true, true, false, true, false]).into_array()))]
-    #[case(Validity::NonNullable, 5, &[2, 4], Validity::Array(BoolArray::from(vec![true, false]).into_array()), Validity::Array(BoolArray::from(vec![true, true, true, true, false]).into_array()))]
+    #[case(Validity::NonNullable, 5, &[2, 4], Validity::AllInvalid, Validity::Array(BoolArray::from_iter([true, true, false, true, false]).into_array()))]
+    #[case(Validity::NonNullable, 5, &[2, 4], Validity::Array(BoolArray::from_iter([true, false]).into_array()), Validity::Array(BoolArray::from_iter([true, true, true, true, false]).into_array()))]
     #[case(Validity::AllValid, 5, &[2, 4], Validity::NonNullable, Validity::AllValid)]
     #[case(Validity::AllValid, 5, &[2, 4], Validity::AllValid, Validity::AllValid)]
-    #[case(Validity::AllValid, 5, &[2, 4], Validity::AllInvalid, Validity::Array(BoolArray::from(vec![true, true, false, true, false]).into_array()))]
-    #[case(Validity::AllValid, 5, &[2, 4], Validity::Array(BoolArray::from(vec![true, false]).into_array()), Validity::Array(BoolArray::from(vec![true, true, true, true, false]).into_array()))]
-    #[case(Validity::AllInvalid, 5, &[2, 4], Validity::NonNullable, Validity::Array(BoolArray::from(vec![false, false, true, false, true]).into_array()))]
-    #[case(Validity::AllInvalid, 5, &[2, 4], Validity::AllValid, Validity::Array(BoolArray::from(vec![false, false, true, false, true]).into_array()))]
+    #[case(Validity::AllValid, 5, &[2, 4], Validity::AllInvalid, Validity::Array(BoolArray::from_iter([true, true, false, true, false]).into_array()))]
+    #[case(Validity::AllValid, 5, &[2, 4], Validity::Array(BoolArray::from_iter([true, false]).into_array()), Validity::Array(BoolArray::from_iter([true, true, true, true, false]).into_array()))]
+    #[case(Validity::AllInvalid, 5, &[2, 4], Validity::NonNullable, Validity::Array(BoolArray::from_iter([false, false, true, false, true]).into_array()))]
+    #[case(Validity::AllInvalid, 5, &[2, 4], Validity::AllValid, Validity::Array(BoolArray::from_iter([false, false, true, false, true]).into_array()))]
     #[case(Validity::AllInvalid, 5, &[2, 4], Validity::AllInvalid, Validity::AllInvalid)]
-    #[case(Validity::AllInvalid, 5, &[2, 4], Validity::Array(BoolArray::from(vec![true, false]).into_array()), Validity::Array(BoolArray::from(vec![false, false, true, false, false]).into_array()))]
-    #[case(Validity::Array(BoolArray::from(vec![false, true, false, true, false]).into_array()), 5, &[2, 4], Validity::NonNullable, Validity::Array(BoolArray::from(vec![false, true, true, true, true]).into_array()))]
-    #[case(Validity::Array(BoolArray::from(vec![false, true, false, true, false]).into_array()), 5, &[2, 4], Validity::AllValid, Validity::Array(BoolArray::from(vec![false, true, true, true, true]).into_array()))]
-    #[case(Validity::Array(BoolArray::from(vec![false, true, false, true, false]).into_array()), 5, &[2, 4], Validity::AllInvalid, Validity::Array(BoolArray::from(vec![false, true, false, true, false]).into_array()))]
-    #[case(Validity::Array(BoolArray::from(vec![false, true, false, true, false]).into_array()), 5, &[2, 4], Validity::Array(BoolArray::from(vec![true, false]).into_array()), Validity::Array(BoolArray::from(vec![false, true, true, true, false]).into_array()))]
+    #[case(Validity::AllInvalid, 5, &[2, 4], Validity::Array(BoolArray::from_iter([true, false]).into_array()), Validity::Array(BoolArray::from_iter([false, false, true, false, false]).into_array()))]
+    #[case(Validity::Array(BoolArray::from_iter([false, true, false, true, false]).into_array()), 5, &[2, 4], Validity::NonNullable, Validity::Array(BoolArray::from_iter([false, true, true, true, true]).into_array()))]
+    #[case(Validity::Array(BoolArray::from_iter([false, true, false, true, false]).into_array()), 5, &[2, 4], Validity::AllValid, Validity::Array(BoolArray::from_iter([false, true, true, true, true]).into_array()))]
+    #[case(Validity::Array(BoolArray::from_iter([false, true, false, true, false]).into_array()), 5, &[2, 4], Validity::AllInvalid, Validity::Array(BoolArray::from_iter([false, true, false, true, false]).into_array()))]
+    #[case(Validity::Array(BoolArray::from_iter([false, true, false, true, false]).into_array()), 5, &[2, 4], Validity::Array(BoolArray::from_iter([true, false]).into_array()), Validity::Array(BoolArray::from_iter([false, true, true, true, false]).into_array()))]
     fn patch_validity(
         #[case] validity: Validity,
         #[case] len: usize,

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -11,7 +11,7 @@ use vortex_error::{
     vortex_bail, vortex_err, vortex_panic, VortexError, VortexExpect as _, VortexResult,
 };
 
-use crate::array::BoolArray;
+use crate::array::{BoolArray, ConstantArray};
 use crate::compute::unary::scalar_at_unchecked;
 use crate::compute::{filter, slice, take};
 use crate::stats::ArrayStatistics;
@@ -375,6 +375,13 @@ impl FromIterator<LogicalValidity> for Validity {
     }
 }
 
+/// Convert an iterator of any optional into a validity.
+impl<'a, E> FromIterator<&'a Option<E>> for Validity {
+    fn from_iter<T: IntoIterator<Item = &'a Option<E>>>(iter: T) -> Self {
+        Self::from_iter(iter.into_iter().map(|option| option.is_some()))
+    }
+}
+
 impl FromIterator<Option<bool>> for Validity {
     fn from_iter<T: IntoIterator<Item = Option<bool>>>(iter: T) -> Self {
         Self::Array(BoolArray::from_iter(iter).into_array())
@@ -467,8 +474,8 @@ impl TryFrom<ArrayData> for LogicalValidity {
 impl IntoArrayData for LogicalValidity {
     fn into_array(self) -> ArrayData {
         match self {
-            Self::AllValid(len) => BoolArray::all_true(len).into_array(),
-            Self::AllInvalid(len) => BoolArray::all_false(len).into_array(),
+            Self::AllValid(len) => ConstantArray::new(true, len).into_array(),
+            Self::AllInvalid(len) => ConstantArray::new(false, len).into_array(),
             Self::Array(a) => a,
         }
     }

--- a/vortex-datafusion/src/memory/plans.rs
+++ b/vortex-datafusion/src/memory/plans.rs
@@ -397,7 +397,7 @@ mod test {
             Arc::new([FieldName::from("a"), FieldName::from("b")]),
             vec![
                 PrimitiveArray::from(vec![0u64, 1, 2]).into_array(),
-                BoolArray::from(vec![false, false, true]).into_array(),
+                BoolArray::from_iter([false, false, true]).into_array(),
             ],
             3,
             Validity::NonNullable,

--- a/vortex-expr/src/not.rs
+++ b/vortex-expr/src/not.rs
@@ -71,7 +71,7 @@ mod tests {
     #[test]
     fn invert_booleans() {
         let not_expr = Not::new_expr(Arc::new(Identity));
-        let bools = BoolArray::from(vec![false, true, false, false, true, true]);
+        let bools = BoolArray::from_iter([false, true, false, false, true, true]);
         assert_eq!(
             not_expr
                 .evaluate(bools.as_ref())

--- a/vortex-file/Cargo.toml
+++ b/vortex-file/Cargo.toml
@@ -57,7 +57,7 @@ vortex-sampling-compressor = { path = "../vortex-sampling-compressor" }
 workspace = true
 
 [features]
-default = []
+default = ["tokio"]
 futures = ["futures-util/io", "vortex-io/futures"]
 compio = ["dep:compio", "vortex-io/compio"]
 tokio = ["dep:tokio", "vortex-io/tokio"]

--- a/vortex-file/src/read/filtering.rs
+++ b/vortex-file/src/read/filtering.rs
@@ -133,10 +133,11 @@ mod tests {
 
     #[test]
     fn coerces_nulls() {
-        let bool_array = BoolArray::from_vec(
-            vec![true, true, false, false],
-            Validity::Array(BoolArray::from(vec![true, false, true, false]).into()),
-        );
+        let bool_array = BoolArray::try_new(
+            BooleanBuffer::from_iter([true, true, false, false]),
+            Validity::Array(BoolArray::from_iter([true, false, true, false]).into()),
+        )
+        .unwrap();
         let non_null_array = null_as_false(bool_array).unwrap().into_bool().unwrap();
         assert_eq!(
             non_null_array.boolean_buffer().iter().collect::<Vec<_>>(),

--- a/vortex-file/src/read/filtering.rs
+++ b/vortex-file/src/read/filtering.rs
@@ -112,9 +112,7 @@ impl PartialEq<dyn Any> for RowFilter {
 pub fn null_as_false(array: BoolArray) -> VortexResult<ArrayData> {
     Ok(match array.validity() {
         Validity::NonNullable => array.into_array(),
-        Validity::AllValid => {
-            BoolArray::try_new(array.boolean_buffer(), Validity::NonNullable)?.into_array()
-        }
+        Validity::AllValid => BoolArray::from(array.boolean_buffer()).into_array(),
         Validity::AllInvalid => BoolArray::from(BooleanBuffer::new_unset(array.len())).into_array(),
         Validity::Array(v) => {
             let bool_buffer = &array.boolean_buffer() & &v.into_bool()?.boolean_buffer();
@@ -133,11 +131,10 @@ mod tests {
 
     #[test]
     fn coerces_nulls() {
-        let bool_array = BoolArray::try_new(
+        let bool_array = BoolArray::new(
             BooleanBuffer::from_iter([true, true, false, false]),
             Validity::Array(BoolArray::from_iter([true, false, true, false]).into()),
-        )
-        .unwrap();
+        );
         let non_null_array = null_as_false(bool_array).unwrap().into_bool().unwrap();
         assert_eq!(
             non_null_array.boolean_buffer().iter().collect::<Vec<_>>(),

--- a/vortex-file/src/read/filtering.rs
+++ b/vortex-file/src/read/filtering.rs
@@ -131,10 +131,11 @@ mod tests {
 
     #[test]
     fn coerces_nulls() {
-        let bool_array = BoolArray::new(
+        let bool_array = BoolArray::try_new(
             BooleanBuffer::from_iter([true, true, false, false]),
-            Validity::Array(BoolArray::from_iter([true, false, true, false]).into()),
-        );
+            Validity::from_iter([true, false, true, false]),
+        )
+        .unwrap();
         let non_null_array = null_as_false(bool_array).unwrap().into_bool().unwrap();
         assert_eq!(
             non_null_array.boolean_buffer().iter().collect::<Vec<_>>(),

--- a/vortex-file/src/read/mask.rs
+++ b/vortex-file/src/read/mask.rs
@@ -236,11 +236,7 @@ impl RowMask {
         if byte_length > bitset.size_in_bytes() {
             buffer.extend_zeros(byte_length - bitset.size_in_bytes());
         }
-        BoolArray::try_new(
-            BooleanBuffer::new(buffer.into(), 0, self.len()),
-            Validity::NonNullable,
-        )
-        .map(IntoArrayData::into_array)
+        Ok(BoolArray::from(BooleanBuffer::new(buffer.into(), 0, self.len())).into_array())
     }
 
     pub fn shift(self, offset: usize) -> VortexResult<RowMask> {

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -3,6 +3,7 @@ use std::iter;
 use std::sync::{Arc, RwLock};
 
 use futures::StreamExt;
+use itertools::Itertools;
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::array::{ChunkedArray, PrimitiveArray, StructArray, VarBinArray};
 use vortex_array::validity::Validity;
@@ -552,13 +553,8 @@ async fn test_with_indices_simple() {
     let expected_numbers_split: Vec<Vec<i16>> = (0..5).map(|_| (0_i16..100).collect()).collect();
     let expected_array = StructArray::from_fields(&[(
         "numbers",
-        ChunkedArray::from_iter(
-            expected_numbers_split
-                .iter()
-                .cloned()
-                .map(ArrayData::from_iter),
-        )
-        .into_array(),
+        ChunkedArray::from_iter(expected_numbers_split.iter().cloned().map(ArrayData::from))
+            .into_array(),
     )])
     .unwrap();
     let expected_numbers: Vec<i16> = expected_numbers_split.into_iter().flatten().collect();
@@ -572,7 +568,7 @@ async fn test_with_indices_simple() {
     // test no indices
     let empty_indices = Vec::<u32>::new();
     let actual_kept_array = VortexReadBuilder::new(written.clone(), LayoutDeserializer::default())
-        .with_indices(ArrayData::from_iter(empty_indices))
+        .with_indices(ArrayData::from(empty_indices))
         .build()
         .await
         .unwrap()
@@ -589,7 +585,7 @@ async fn test_with_indices_simple() {
     let kept_indices_u16 = kept_indices.iter().map(|&x| x as u16).collect::<Vec<_>>();
 
     let actual_kept_array = VortexReadBuilder::new(written.clone(), LayoutDeserializer::default())
-        .with_indices(ArrayData::from_iter(kept_indices_u16))
+        .with_indices(ArrayData::from(kept_indices_u16))
         .build()
         .await
         .unwrap()
@@ -612,7 +608,7 @@ async fn test_with_indices_simple() {
 
     // test all indices
     let actual_array = VortexReadBuilder::new(written.clone(), LayoutDeserializer::default())
-        .with_indices(ArrayData::from_iter(0u32..500))
+        .with_indices(ArrayData::from((0u32..500).collect_vec()))
         .build()
         .await
         .unwrap()
@@ -654,7 +650,7 @@ async fn test_with_indices_on_two_columns() {
     let kept_indices_u8 = kept_indices.iter().map(|&x| x as u8).collect::<Vec<_>>();
 
     let array = VortexReadBuilder::new(written.clone(), LayoutDeserializer::default())
-        .with_indices(ArrayData::from_iter(kept_indices_u8))
+        .with_indices(ArrayData::from(kept_indices_u8))
         .build()
         .await
         .unwrap()
@@ -699,13 +695,8 @@ async fn test_with_indices_and_with_row_filter_simple() {
     let expected_numbers_split: Vec<Vec<i16>> = (0..5).map(|_| (0_i16..100).collect()).collect();
     let expected_array = StructArray::from_fields(&[(
         "numbers",
-        ChunkedArray::from_iter(
-            expected_numbers_split
-                .iter()
-                .cloned()
-                .map(ArrayData::from_iter),
-        )
-        .into_array(),
+        ChunkedArray::from_iter(expected_numbers_split.iter().cloned().map(ArrayData::from))
+            .into_array(),
     )])
     .unwrap();
     let expected_numbers: Vec<i16> = expected_numbers_split.into_iter().flatten().collect();
@@ -719,7 +710,7 @@ async fn test_with_indices_and_with_row_filter_simple() {
     // test no indices
     let empty_indices = Vec::<u32>::new();
     let actual_kept_array = VortexReadBuilder::new(written.clone(), LayoutDeserializer::default())
-        .with_indices(ArrayData::from_iter(empty_indices))
+        .with_indices(ArrayData::from(empty_indices))
         .with_row_filter(RowFilter::new(BinaryExpr::new_expr(
             Column::new_expr(Field::from("numbers")),
             Operator::Gt,
@@ -741,7 +732,7 @@ async fn test_with_indices_and_with_row_filter_simple() {
     let kept_indices_u16 = kept_indices.iter().map(|&x| x as u16).collect::<Vec<_>>();
 
     let actual_kept_array = VortexReadBuilder::new(written.clone(), LayoutDeserializer::default())
-        .with_indices(ArrayData::from_iter(kept_indices_u16))
+        .with_indices(ArrayData::from(kept_indices_u16))
         .with_row_filter(RowFilter::new(BinaryExpr::new_expr(
             Column::new_expr(Field::from("numbers")),
             Operator::Gt,
@@ -772,7 +763,7 @@ async fn test_with_indices_and_with_row_filter_simple() {
 
     // test all indices
     let actual_array = VortexReadBuilder::new(written.clone(), LayoutDeserializer::default())
-        .with_indices(ArrayData::from_iter(0..500))
+        .with_indices(ArrayData::from((0..500).collect_vec()))
         .with_row_filter(RowFilter::new(BinaryExpr::new_expr(
             Column::new_expr(Field::from("numbers")),
             Operator::Gt,

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -552,8 +552,13 @@ async fn test_with_indices_simple() {
     let expected_numbers_split: Vec<Vec<i16>> = (0..5).map(|_| (0_i16..100).collect()).collect();
     let expected_array = StructArray::from_fields(&[(
         "numbers",
-        ChunkedArray::from_iter(expected_numbers_split.iter().cloned().map(ArrayData::from))
-            .into_array(),
+        ChunkedArray::from_iter(
+            expected_numbers_split
+                .iter()
+                .cloned()
+                .map(ArrayData::from_iter),
+        )
+        .into_array(),
     )])
     .unwrap();
     let expected_numbers: Vec<i16> = expected_numbers_split.into_iter().flatten().collect();
@@ -567,7 +572,7 @@ async fn test_with_indices_simple() {
     // test no indices
     let empty_indices = Vec::<u32>::new();
     let actual_kept_array = VortexReadBuilder::new(written.clone(), LayoutDeserializer::default())
-        .with_indices(ArrayData::from(empty_indices))
+        .with_indices(ArrayData::from_iter(empty_indices))
         .build()
         .await
         .unwrap()
@@ -584,7 +589,7 @@ async fn test_with_indices_simple() {
     let kept_indices_u16 = kept_indices.iter().map(|&x| x as u16).collect::<Vec<_>>();
 
     let actual_kept_array = VortexReadBuilder::new(written.clone(), LayoutDeserializer::default())
-        .with_indices(ArrayData::from(kept_indices_u16))
+        .with_indices(ArrayData::from_iter(kept_indices_u16))
         .build()
         .await
         .unwrap()
@@ -607,7 +612,7 @@ async fn test_with_indices_simple() {
 
     // test all indices
     let actual_array = VortexReadBuilder::new(written.clone(), LayoutDeserializer::default())
-        .with_indices(ArrayData::from((0..500).collect::<Vec<u32>>()))
+        .with_indices(ArrayData::from_iter(0u32..500))
         .build()
         .await
         .unwrap()
@@ -649,7 +654,7 @@ async fn test_with_indices_on_two_columns() {
     let kept_indices_u8 = kept_indices.iter().map(|&x| x as u8).collect::<Vec<_>>();
 
     let array = VortexReadBuilder::new(written.clone(), LayoutDeserializer::default())
-        .with_indices(ArrayData::from(kept_indices_u8))
+        .with_indices(ArrayData::from_iter(kept_indices_u8))
         .build()
         .await
         .unwrap()
@@ -694,8 +699,13 @@ async fn test_with_indices_and_with_row_filter_simple() {
     let expected_numbers_split: Vec<Vec<i16>> = (0..5).map(|_| (0_i16..100).collect()).collect();
     let expected_array = StructArray::from_fields(&[(
         "numbers",
-        ChunkedArray::from_iter(expected_numbers_split.iter().cloned().map(ArrayData::from))
-            .into_array(),
+        ChunkedArray::from_iter(
+            expected_numbers_split
+                .iter()
+                .cloned()
+                .map(ArrayData::from_iter),
+        )
+        .into_array(),
     )])
     .unwrap();
     let expected_numbers: Vec<i16> = expected_numbers_split.into_iter().flatten().collect();
@@ -709,7 +719,7 @@ async fn test_with_indices_and_with_row_filter_simple() {
     // test no indices
     let empty_indices = Vec::<u32>::new();
     let actual_kept_array = VortexReadBuilder::new(written.clone(), LayoutDeserializer::default())
-        .with_indices(ArrayData::from(empty_indices))
+        .with_indices(ArrayData::from_iter(empty_indices))
         .with_row_filter(RowFilter::new(BinaryExpr::new_expr(
             Column::new_expr(Field::from("numbers")),
             Operator::Gt,
@@ -731,7 +741,7 @@ async fn test_with_indices_and_with_row_filter_simple() {
     let kept_indices_u16 = kept_indices.iter().map(|&x| x as u16).collect::<Vec<_>>();
 
     let actual_kept_array = VortexReadBuilder::new(written.clone(), LayoutDeserializer::default())
-        .with_indices(ArrayData::from(kept_indices_u16))
+        .with_indices(ArrayData::from_iter(kept_indices_u16))
         .with_row_filter(RowFilter::new(BinaryExpr::new_expr(
             Column::new_expr(Field::from("numbers")),
             Operator::Gt,
@@ -762,7 +772,7 @@ async fn test_with_indices_and_with_row_filter_simple() {
 
     // test all indices
     let actual_array = VortexReadBuilder::new(written.clone(), LayoutDeserializer::default())
-        .with_indices(ArrayData::from((0..500).collect::<Vec<u32>>()))
+        .with_indices(ArrayData::from_iter(0..500))
         .with_row_filter(RowFilter::new(BinaryExpr::new_expr(
             Column::new_expr(Field::from("numbers")),
             Operator::Gt,

--- a/vortex-file/src/write/metadata_accumulators.rs
+++ b/vortex-file/src/write/metadata_accumulators.rs
@@ -209,7 +209,7 @@ where
 
     fn into_column(self) -> Option<(FieldName, ArrayData)> {
         if self.values.iter().any(Option::is_some) {
-            return Some((self.name, ArrayData::from_iter(self.values.into_iter())));
+            return Some((self.name, ArrayData::from_iter(self.values)));
         }
         None
     }

--- a/vortex-file/src/write/metadata_accumulators.rs
+++ b/vortex-file/src/write/metadata_accumulators.rs
@@ -105,7 +105,7 @@ impl<T> StandardAccumulator<T> {
 impl<T> MetadataAccumulator for StandardAccumulator<T>
 where
     Option<T>: TryFrom<ScalarValue, Error = VortexError>,
-    ArrayData: From<Vec<Option<T>>>,
+    ArrayData: FromIterator<Option<T>>,
 {
     fn push_chunk(&mut self, array: &ArrayData) {
         self.maxima.push_chunk(array);
@@ -195,7 +195,7 @@ impl<T> UnwrappedStatAccumulator<T> {
 impl<T> SingularAccumulator for UnwrappedStatAccumulator<T>
 where
     Option<T>: TryFrom<ScalarValue, Error = VortexError>,
-    ArrayData: From<Vec<Option<T>>>,
+    ArrayData: FromIterator<Option<T>>,
 {
     fn push_chunk(&mut self, array: &ArrayData) {
         self.values.push(
@@ -209,7 +209,7 @@ where
 
     fn into_column(self) -> Option<(FieldName, ArrayData)> {
         if self.values.iter().any(Option::is_some) {
-            return Some((self.name, ArrayData::from(self.values)));
+            return Some((self.name, ArrayData::from_iter(self.values.into_iter())));
         }
         None
     }
@@ -238,7 +238,7 @@ mod tests {
     #[test]
     fn test_bool_metadata_schema() {
         let mut bool_accumulator = BoolAccumulator::new();
-        let chunk = BoolArray::from_vec(vec![true], Validity::AllValid).into_array();
+        let chunk = BoolArray::from_iter([true]).into_array();
         bool_accumulator.push_chunk(&chunk);
 
         let struct_array =

--- a/vortex-sampling-compressor/tests/smoketest.rs
+++ b/vortex-sampling-compressor/tests/smoketest.rs
@@ -21,12 +21,13 @@ use vortex_sampling_compressor::{CompressConfig, SamplingCompressor};
 
 #[cfg(test)]
 mod tests {
-    use vortex_array::array::{Bool, ChunkedArray, VarBin};
+    use vortex_array::array::{Bool, BooleanBuffer, ChunkedArray, VarBin};
     use vortex_array::variants::{ArrayVariants, StructArrayTrait};
     use vortex_array::ArrayDef;
     use vortex_datetime_dtype::TimeUnit;
     use vortex_datetime_parts::DateTimeParts;
     use vortex_dict::Dict;
+    use vortex_error::VortexExpect;
     use vortex_fastlanes::FoR;
     use vortex_fsst::FSST;
     use vortex_sampling_compressor::compressors::alp_rd::ALPRDCompressor;
@@ -196,8 +197,12 @@ mod tests {
     }
 
     fn make_bool_column(count: usize) -> ArrayData {
-        let bools: Vec<bool> = (0..count).map(|_| rand::random::<bool>()).collect();
-        BoolArray::from_vec(bools, Validity::NonNullable).into_array()
+        BoolArray::try_new(
+            BooleanBuffer::from_iter((0..count).map(|_| rand::random::<bool>())),
+            Validity::NonNullable,
+        )
+        .vortex_expect("failed to create array")
+        .into_array()
     }
 
     fn make_string_column(count: usize) -> ArrayData {

--- a/vortex-sampling-compressor/tests/smoketest.rs
+++ b/vortex-sampling-compressor/tests/smoketest.rs
@@ -27,7 +27,6 @@ mod tests {
     use vortex_datetime_dtype::TimeUnit;
     use vortex_datetime_parts::DateTimeParts;
     use vortex_dict::Dict;
-    use vortex_error::VortexExpect;
     use vortex_fastlanes::FoR;
     use vortex_fsst::FSST;
     use vortex_sampling_compressor::compressors::alp_rd::ALPRDCompressor;
@@ -197,11 +196,10 @@ mod tests {
     }
 
     fn make_bool_column(count: usize) -> ArrayData {
-        BoolArray::try_new(
+        BoolArray::new(
             BooleanBuffer::from_iter((0..count).map(|_| rand::random::<bool>())),
             Validity::NonNullable,
         )
-        .vortex_expect("failed to create array")
         .into_array()
     }
 

--- a/vortex-sampling-compressor/tests/smoketest.rs
+++ b/vortex-sampling-compressor/tests/smoketest.rs
@@ -198,7 +198,7 @@ mod tests {
     fn make_bool_column(count: usize) -> ArrayData {
         BoolArray::new(
             BooleanBuffer::from_iter((0..count).map(|_| rand::random::<bool>())),
-            Validity::NonNullable,
+            Nullability::NonNullable,
         )
         .into_array()
     }


### PR DESCRIPTION
In general, we should only implement from_vec for arrays that can zero-copy from vec, i.e. Primitive.
All other arrays should implement from_iter.

This seems to bump some TPCH queries ~30% even
