### PR TITLE
Use arrow scalars for cmp where possible

### DIFF
--- a/bench-vortex/Cargo.toml
+++ b/bench-vortex/Cargo.toml
@@ -41,7 +41,7 @@ homedir = { workspace = true }
 humansize = { workspace = true }
 indicatif = { workspace = true }
 itertools = { workspace = true }
-log = { workspace = true }
+log = { workspace = true, features = ["max_level_debug"] }
 mimalloc = { workspace = true }
 object_store = { workspace = true, features = ["aws"] }
 parquet = { workspace = true, features = ["async"] }

--- a/vortex-array/src/arrow/datum.rs
+++ b/vortex-array/src/arrow/datum.rs
@@ -1,0 +1,40 @@
+use arrow_array::{Array, ArrayRef, Datum as ArrowDatum};
+use vortex_error::VortexError;
+
+use crate::compute::slice;
+use crate::stats::{ArrayStatistics, Stat};
+use crate::{ArrayData, IntoCanonical};
+
+/// A wrapper around a generic Arrow array that can be used as a Datum in Arrow compute.
+pub struct Datum {
+    array: ArrayRef,
+    is_scalar: bool,
+}
+
+impl TryFrom<ArrayData> for Datum {
+    type Error = VortexError;
+
+    fn try_from(array: ArrayData) -> Result<Self, Self::Error> {
+        if array
+            .statistics()
+            .get_as::<bool>(Stat::IsConstant)
+            .unwrap_or_default()
+        {
+            Ok(Self {
+                array: slice(array, 0, 1)?.into_canonical()?.into_arrow()?,
+                is_scalar: true,
+            })
+        } else {
+            Ok(Self {
+                array: array.into_canonical()?.into_arrow()?,
+                is_scalar: false,
+            })
+        }
+    }
+}
+
+impl ArrowDatum for Datum {
+    fn get(&self) -> (&dyn Array, bool) {
+        (&self.array, self.is_scalar)
+    }
+}

--- a/vortex-array/src/arrow/mod.rs
+++ b/vortex-array/src/arrow/mod.rs
@@ -5,9 +5,11 @@ use vortex_error::VortexResult;
 pub use crate::arrow::dtype::{infer_data_type, infer_schema};
 
 mod array;
+mod datum;
 mod dtype;
 mod recordbatch;
 pub mod wrappers;
+pub use datum::*;
 
 pub trait FromArrowArray<A> {
     fn from_arrow(array: A, nullable: bool) -> Self;

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -356,6 +356,7 @@ where
 /// the array's internal codec.
 impl IntoCanonical for ArrayData {
     fn into_canonical(self) -> VortexResult<Canonical> {
+        log::debug!("Canonicalizing array with encoding {:?}", self.encoding());
         ArrayEncoding::canonicalize(self.encoding(), self)
     }
 }

--- a/vortex-array/src/view.rs
+++ b/vortex-array/src/view.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use enum_iterator::all;
 use itertools::Itertools;
-use log::warn;
 use vortex_buffer::Buffer;
 use vortex_dtype::{DType, Nullability};
 use vortex_error::{vortex_err, VortexError, VortexExpect as _, VortexResult};
@@ -248,7 +247,7 @@ impl Statistics for ViewedArrayData {
     /// We want to avoid any sort of allocation on instantiation of the ArrayView, so we
     /// do not allocate a stats_set to cache values.
     fn set(&self, _stat: Stat, _value: Scalar) {
-        warn!("Cannot write stats to a view")
+        // We cannot set stats on a view
     }
 
     fn compute(&self, stat: Stat) -> Option<Scalar> {


### PR DESCRIPTION
When we delegate to Arrow compute, we should keep constant arrays as length-1 scalars where possible.

This PR also adds a bunch of stuff to making observations over TPCH easier.