### PR TITLE
Add TakeOptions to skip bounds checking

### DIFF
--- a/encodings/alp/src/alp/compute.rs
+++ b/encodings/alp/src/alp/compute.rs
@@ -1,7 +1,8 @@
 use vortex_array::array::ConstantArray;
 use vortex_array::compute::unary::{scalar_at, scalar_at_unchecked, ScalarAtFn};
 use vortex_array::compute::{
-    compare, filter, slice, take, ArrayCompute, FilterFn, MaybeCompareFn, Operator, SliceFn, TakeFn,
+    compare, filter, slice, take, ArrayCompute, FilterFn, MaybeCompareFn, Operator, SliceFn,
+    TakeFn, TakeOptions,
 };
 use vortex_array::stats::{ArrayStatistics, Stat};
 use vortex_array::variants::PrimitiveArrayTrait;
@@ -60,12 +61,14 @@ impl ScalarAtFn for ALPArray {
 }
 
 impl TakeFn for ALPArray {
-    fn take(&self, indices: &ArrayData) -> VortexResult<ArrayData> {
+    fn take(&self, indices: &ArrayData, options: TakeOptions) -> VortexResult<ArrayData> {
         // TODO(ngates): wrap up indices in an array that caches decompression?
         Ok(Self::try_new(
-            take(self.encoded(), indices)?,
+            take(self.encoded(), indices, options)?,
             self.exponents(),
-            self.patches().map(|p| take(&p, indices)).transpose()?,
+            self.patches()
+                .map(|p| take(&p, indices, options))
+                .transpose()?,
         )?
         .into_array())
     }

--- a/encodings/alp/src/alp_rd/compute/take.rs
+++ b/encodings/alp/src/alp_rd/compute/take.rs
@@ -1,21 +1,21 @@
-use vortex_array::compute::{take, TakeFn};
+use vortex_array::compute::{take, TakeFn, TakeOptions};
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData};
 use vortex_error::VortexResult;
 
 use crate::ALPRDArray;
 
 impl TakeFn for ALPRDArray {
-    fn take(&self, indices: &ArrayData) -> VortexResult<ArrayData> {
+    fn take(&self, indices: &ArrayData, options: TakeOptions) -> VortexResult<ArrayData> {
         let left_parts_exceptions = self
             .left_parts_exceptions()
-            .map(|array| take(&array, indices))
+            .map(|array| take(&array, indices, options))
             .transpose()?;
 
         Ok(ALPRDArray::try_new(
             self.dtype().clone(),
-            take(self.left_parts(), indices)?,
+            take(self.left_parts(), indices, options)?,
             self.left_parts_dict(),
-            take(self.right_parts(), indices)?,
+            take(self.right_parts(), indices, options)?,
             self.right_bit_width(),
             left_parts_exceptions,
         )?
@@ -27,7 +27,7 @@ impl TakeFn for ALPRDArray {
 mod test {
     use rstest::rstest;
     use vortex_array::array::PrimitiveArray;
-    use vortex_array::compute::take;
+    use vortex_array::compute::{take, TakeOptions};
     use vortex_array::IntoArrayVariant;
 
     use crate::{ALPRDFloat, RDEncoder};
@@ -41,10 +41,14 @@ mod test {
 
         assert!(encoded.left_parts_exceptions().is_some());
 
-        let taken = take(encoded.as_ref(), PrimitiveArray::from(vec![0, 2]).as_ref())
-            .unwrap()
-            .into_primitive()
-            .unwrap();
+        let taken = take(
+            encoded.as_ref(),
+            PrimitiveArray::from(vec![0, 2]).as_ref(),
+            TakeOptions::default(),
+        )
+        .unwrap()
+        .into_primitive()
+        .unwrap();
 
         assert_eq!(taken.maybe_null_slice::<T>(), &[a, outlier]);
     }

--- a/encodings/bytebool/src/compute.rs
+++ b/encodings/bytebool/src/compute.rs
@@ -1,6 +1,6 @@
 use num_traits::AsPrimitive;
 use vortex_array::compute::unary::{FillForwardFn, ScalarAtFn};
-use vortex_array::compute::{ArrayCompute, SliceFn, TakeFn};
+use vortex_array::compute::{ArrayCompute, SliceFn, TakeFn, TakeOptions};
 use vortex_array::validity::{ArrayValidity, Validity};
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData};
@@ -49,7 +49,7 @@ impl SliceFn for ByteBoolArray {
 }
 
 impl TakeFn for ByteBoolArray {
-    fn take(&self, indices: &ArrayData) -> VortexResult<ArrayData> {
+    fn take(&self, indices: &ArrayData, _options: TakeOptions) -> VortexResult<ArrayData> {
         let validity = self.validity();
         let indices = indices.clone().as_primitive();
         let bools = self.maybe_null_slice();

--- a/encodings/datetime-parts/src/compute.rs
+++ b/encodings/datetime-parts/src/compute.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools as _;
 use vortex_array::array::{PrimitiveArray, TemporalArray};
 use vortex_array::compute::unary::{scalar_at, ScalarAtFn};
-use vortex_array::compute::{slice, take, ArrayCompute, SliceFn, TakeFn};
+use vortex_array::compute::{slice, take, ArrayCompute, SliceFn, TakeFn, TakeOptions};
 use vortex_array::validity::ArrayValidity;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_datetime_dtype::{TemporalMetadata, TimeUnit};
@@ -26,12 +26,12 @@ impl ArrayCompute for DateTimePartsArray {
 }
 
 impl TakeFn for DateTimePartsArray {
-    fn take(&self, indices: &ArrayData) -> VortexResult<ArrayData> {
+    fn take(&self, indices: &ArrayData, options: TakeOptions) -> VortexResult<ArrayData> {
         Ok(Self::try_new(
             self.dtype().clone(),
-            take(self.days(), indices)?,
-            take(self.seconds(), indices)?,
-            take(self.subsecond(), indices)?,
+            take(self.days(), indices, options)?,
+            take(self.seconds(), indices, options)?,
+            take(self.subsecond(), indices, options)?,
         )?
         .into_array())
     }

--- a/encodings/dict/src/array.rs
+++ b/encodings/dict/src/array.rs
@@ -4,8 +4,8 @@ use arrow_buffer::BooleanBuffer;
 use serde::{Deserialize, Serialize};
 use vortex_array::array::visitor::{AcceptArrayVisitor, ArrayVisitor};
 use vortex_array::array::BoolArray;
-use vortex_array::compute::take;
 use vortex_array::compute::unary::scalar_at;
+use vortex_array::compute::{take, TakeOptions};
 use vortex_array::encoding::ids;
 use vortex_array::stats::StatsSet;
 use vortex_array::validity::{ArrayValidity, LogicalValidity};
@@ -75,10 +75,10 @@ impl IntoCanonical for DictArray {
             // copies of the view pointers.
             DType::Utf8(_) | DType::Binary(_) => {
                 let canonical_values: ArrayData = self.values().into_canonical()?.into();
-                take(canonical_values, self.codes())?.into_canonical()
+                take(canonical_values, self.codes(), TakeOptions::default())?.into_canonical()
             }
             // Non-string case: take and then canonicalize
-            _ => take(self.values(), self.codes())?.into_canonical(),
+            _ => take(self.values(), self.codes(), TakeOptions::default())?.into_canonical(),
         }
     }
 }

--- a/encodings/dict/src/compute.rs
+++ b/encodings/dict/src/compute.rs
@@ -1,6 +1,7 @@
 use vortex_array::compute::unary::{scalar_at, scalar_at_unchecked, ScalarAtFn};
 use vortex_array::compute::{
-    compare, filter, slice, take, ArrayCompute, FilterFn, MaybeCompareFn, Operator, SliceFn, TakeFn,
+    compare, filter, slice, take, ArrayCompute, FilterFn, MaybeCompareFn, Operator, SliceFn,
+    TakeFn, TakeOptions,
 };
 use vortex_array::stats::{ArrayStatistics, Stat};
 use vortex_array::{ArrayData, IntoArrayData};
@@ -75,11 +76,11 @@ impl ScalarAtFn for DictArray {
 }
 
 impl TakeFn for DictArray {
-    fn take(&self, indices: &ArrayData) -> VortexResult<ArrayData> {
+    fn take(&self, indices: &ArrayData, options: TakeOptions) -> VortexResult<ArrayData> {
         // Dict
         //   codes: 0 0 1
         //   dict: a b c d e f g h
-        let codes = take(self.codes(), indices)?;
+        let codes = take(self.codes(), indices, options)?;
         Self::try_new(codes, self.values()).map(|a| a.into_array())
     }
 }

--- a/encodings/dict/src/variants.rs
+++ b/encodings/dict/src/variants.rs
@@ -1,12 +1,17 @@
 use vortex_array::variants::{
-    ArrayVariants, BinaryArrayTrait, PrimitiveArrayTrait, Utf8ArrayTrait,
+    ArrayVariants, BinaryArrayTrait, BoolArrayTrait, PrimitiveArrayTrait, Utf8ArrayTrait,
 };
-use vortex_array::ArrayDType;
+use vortex_array::{ArrayDType, ArrayData};
 use vortex_dtype::DType;
+use vortex_error::VortexResult;
 
 use crate::DictArray;
 
 impl ArrayVariants for DictArray {
+    fn as_bool_array(&self) -> Option<&dyn BoolArrayTrait> {
+        matches!(self.dtype(), DType::Bool(..)).then_some(self)
+    }
+
     fn as_primitive_array(&self) -> Option<&dyn PrimitiveArrayTrait> {
         matches!(self.dtype(), DType::Primitive(..)).then_some(self)
     }
@@ -17,6 +22,20 @@ impl ArrayVariants for DictArray {
 
     fn as_binary_array(&self) -> Option<&dyn BinaryArrayTrait> {
         matches!(self.dtype(), DType::Binary(..)).then_some(self)
+    }
+}
+
+impl BoolArrayTrait for DictArray {
+    fn invert(&self) -> VortexResult<ArrayData> {
+        todo!()
+    }
+
+    fn maybe_null_indices_iter<'a>(&'a self) -> Box<dyn Iterator<Item = usize> + 'a> {
+        todo!()
+    }
+
+    fn maybe_null_slices_iter<'a>(&'a self) -> Box<dyn Iterator<Item = (usize, usize)> + 'a> {
+        todo!()
     }
 }
 

--- a/encodings/fastlanes/benches/bitpacking_take.rs
+++ b/encodings/fastlanes/benches/bitpacking_take.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use rand::distributions::Uniform;
 use rand::{thread_rng, Rng};
 use vortex_array::array::{PrimitiveArray, SparseArray};
-use vortex_array::compute::take;
+use vortex_array::compute::{take, TakeOptions};
 use vortex_fastlanes::{find_best_bit_width, BitPackedArray};
 
 fn values(len: usize, bits: usize) -> Vec<u32> {
@@ -26,12 +26,30 @@ fn bench_take(c: &mut Criterion) {
 
     let stratified_indices: PrimitiveArray = (0..10).map(|i| i * 10_000).collect::<Vec<_>>().into();
     c.bench_function("take_10_stratified", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), stratified_indices.as_ref()).unwrap()));
+        b.iter(|| {
+            black_box(
+                take(
+                    packed.as_ref(),
+                    stratified_indices.as_ref(),
+                    TakeOptions::default(),
+                )
+                .unwrap(),
+            )
+        });
     });
 
     let contiguous_indices: PrimitiveArray = (0..10).collect::<Vec<_>>().into();
     c.bench_function("take_10_contiguous", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), contiguous_indices.as_ref()).unwrap()));
+        b.iter(|| {
+            black_box(
+                take(
+                    packed.as_ref(),
+                    contiguous_indices.as_ref(),
+                    TakeOptions::default(),
+                )
+                .unwrap(),
+            )
+        });
     });
 
     let rng = thread_rng();
@@ -43,12 +61,30 @@ fn bench_take(c: &mut Criterion) {
         .collect_vec()
         .into();
     c.bench_function("take_10K_random", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), random_indices.as_ref()).unwrap()));
+        b.iter(|| {
+            black_box(
+                take(
+                    packed.as_ref(),
+                    random_indices.as_ref(),
+                    TakeOptions::default(),
+                )
+                .unwrap(),
+            )
+        });
     });
 
     let contiguous_indices: PrimitiveArray = (0..10_000).collect::<Vec<_>>().into();
     c.bench_function("take_10K_contiguous", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), contiguous_indices.as_ref()).unwrap()));
+        b.iter(|| {
+            black_box(
+                take(
+                    packed.as_ref(),
+                    contiguous_indices.as_ref(),
+                    TakeOptions::default(),
+                )
+                .unwrap(),
+            )
+        });
     });
 
     let lots_of_indices: PrimitiveArray = (0..200_000)
@@ -56,7 +92,16 @@ fn bench_take(c: &mut Criterion) {
         .collect::<Vec<_>>()
         .into();
     c.bench_function("take_200K_dispersed", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), lots_of_indices.as_ref()).unwrap()));
+        b.iter(|| {
+            black_box(
+                take(
+                    packed.as_ref(),
+                    lots_of_indices.as_ref(),
+                    TakeOptions::default(),
+                )
+                .unwrap(),
+            )
+        });
     });
 
     let lots_of_indices: PrimitiveArray = (0..200_000)
@@ -64,7 +109,16 @@ fn bench_take(c: &mut Criterion) {
         .collect::<Vec<_>>()
         .into();
     c.bench_function("take_200K_first_chunk_only", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), lots_of_indices.as_ref()).unwrap()));
+        b.iter(|| {
+            black_box(
+                take(
+                    packed.as_ref(),
+                    lots_of_indices.as_ref(),
+                    TakeOptions::default(),
+                )
+                .unwrap(),
+            )
+        });
     });
 }
 
@@ -90,12 +144,30 @@ fn bench_patched_take(c: &mut Criterion) {
 
     let stratified_indices: PrimitiveArray = (0..10).map(|i| i * 10_000).collect::<Vec<_>>().into();
     c.bench_function("patched_take_10_stratified", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), stratified_indices.as_ref()).unwrap()));
+        b.iter(|| {
+            black_box(
+                take(
+                    packed.as_ref(),
+                    stratified_indices.as_ref(),
+                    TakeOptions::default(),
+                )
+                .unwrap(),
+            )
+        });
     });
 
     let contiguous_indices: PrimitiveArray = (0..10).collect::<Vec<_>>().into();
     c.bench_function("patched_take_10_contiguous", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), contiguous_indices.as_ref()).unwrap()));
+        b.iter(|| {
+            black_box(
+                take(
+                    packed.as_ref(),
+                    contiguous_indices.as_ref(),
+                    TakeOptions::default(),
+                )
+                .unwrap(),
+            )
+        });
     });
 
     let rng = thread_rng();
@@ -107,7 +179,16 @@ fn bench_patched_take(c: &mut Criterion) {
         .collect_vec()
         .into();
     c.bench_function("patched_take_10K_random", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), random_indices.as_ref()).unwrap()));
+        b.iter(|| {
+            black_box(
+                take(
+                    packed.as_ref(),
+                    random_indices.as_ref(),
+                    TakeOptions::default(),
+                )
+                .unwrap(),
+            )
+        });
     });
 
     let not_patch_indices: PrimitiveArray = (0u32..num_exceptions)
@@ -116,7 +197,16 @@ fn bench_patched_take(c: &mut Criterion) {
         .collect_vec()
         .into();
     c.bench_function("patched_take_10K_contiguous_not_patches", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), not_patch_indices.as_ref()).unwrap()));
+        b.iter(|| {
+            black_box(
+                take(
+                    packed.as_ref(),
+                    not_patch_indices.as_ref(),
+                    TakeOptions::default(),
+                )
+                .unwrap(),
+            )
+        });
     });
 
     let patch_indices: PrimitiveArray = (big_base2..big_base2 + num_exceptions)
@@ -125,7 +215,16 @@ fn bench_patched_take(c: &mut Criterion) {
         .collect_vec()
         .into();
     c.bench_function("patched_take_10K_contiguous_patches", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), patch_indices.as_ref()).unwrap()));
+        b.iter(|| {
+            black_box(
+                take(
+                    packed.as_ref(),
+                    patch_indices.as_ref(),
+                    TakeOptions::default(),
+                )
+                .unwrap(),
+            )
+        });
     });
 
     let lots_of_indices: PrimitiveArray = (0..200_000)
@@ -133,7 +232,16 @@ fn bench_patched_take(c: &mut Criterion) {
         .collect::<Vec<_>>()
         .into();
     c.bench_function("patched_take_200K_dispersed", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), lots_of_indices.as_ref()).unwrap()));
+        b.iter(|| {
+            black_box(
+                take(
+                    packed.as_ref(),
+                    lots_of_indices.as_ref(),
+                    TakeOptions::default(),
+                )
+                .unwrap(),
+            )
+        });
     });
 
     let lots_of_indices: PrimitiveArray = (0..200_000)
@@ -141,7 +249,16 @@ fn bench_patched_take(c: &mut Criterion) {
         .collect::<Vec<_>>()
         .into();
     c.bench_function("patched_take_200K_first_chunk_only", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), lots_of_indices.as_ref()).unwrap()));
+        b.iter(|| {
+            black_box(
+                take(
+                    packed.as_ref(),
+                    lots_of_indices.as_ref(),
+                    TakeOptions::default(),
+                )
+                .unwrap(),
+            )
+        });
     });
 
     // There are currently 2 magic parameters of note:
@@ -165,7 +282,16 @@ fn bench_patched_take(c: &mut Criterion) {
         .collect_vec()
         .into();
     c.bench_function("patched_take_10K_adversarial", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), adversarial_indices.as_ref()).unwrap()));
+        b.iter(|| {
+            black_box(
+                take(
+                    packed.as_ref(),
+                    adversarial_indices.as_ref(),
+                    TakeOptions::default(),
+                )
+                .unwrap(),
+            )
+        });
     });
 }
 

--- a/encodings/fastlanes/src/bitpacking/compute/slice.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/slice.rs
@@ -47,7 +47,7 @@ mod test {
     use itertools::Itertools;
     use vortex_array::array::{PrimitiveArray, SparseArray};
     use vortex_array::compute::unary::scalar_at;
-    use vortex_array::compute::{slice, take};
+    use vortex_array::compute::{slice, take, TakeOptions};
     use vortex_array::IntoArrayData;
 
     use crate::BitPackedArray;
@@ -201,6 +201,7 @@ mod test {
         let taken = take(
             &sliced,
             PrimitiveArray::from(vec![101i64, 1125i64, 1138i64]).as_ref(),
+            TakeOptions::default(),
         )
         .unwrap();
         assert_eq!(taken.len(), 3);

--- a/encodings/fastlanes/src/for/compute.rs
+++ b/encodings/fastlanes/src/for/compute.rs
@@ -4,7 +4,7 @@ use num_traits::{WrappingAdd, WrappingSub};
 use vortex_array::compute::unary::{scalar_at_unchecked, ScalarAtFn};
 use vortex_array::compute::{
     filter, search_sorted, slice, take, ArrayCompute, FilterFn, SearchResult, SearchSortedFn,
-    SearchSortedSide, SliceFn, TakeFn,
+    SearchSortedSide, SliceFn, TakeFn, TakeOptions,
 };
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData};
@@ -37,9 +37,9 @@ impl ArrayCompute for FoRArray {
 }
 
 impl TakeFn for FoRArray {
-    fn take(&self, indices: &ArrayData) -> VortexResult<ArrayData> {
+    fn take(&self, indices: &ArrayData, options: TakeOptions) -> VortexResult<ArrayData> {
         Self::try_new(
-            take(self.encoded(), indices)?,
+            take(self.encoded(), indices, options)?,
             self.owned_reference_scalar(),
             self.shift(),
         )

--- a/encodings/fsst/src/compute.rs
+++ b/encodings/fsst/src/compute.rs
@@ -2,7 +2,8 @@ use fsst::Symbol;
 use vortex_array::array::{varbin_scalar, ConstantArray};
 use vortex_array::compute::unary::{scalar_at_unchecked, ScalarAtFn};
 use vortex_array::compute::{
-    compare, filter, slice, take, ArrayCompute, FilterFn, MaybeCompareFn, Operator, SliceFn, TakeFn,
+    compare, filter, slice, take, ArrayCompute, FilterFn, MaybeCompareFn, Operator, SliceFn,
+    TakeFn, TakeOptions,
 };
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_buffer::Buffer;
@@ -117,13 +118,13 @@ impl SliceFn for FSSTArray {
 
 impl TakeFn for FSSTArray {
     // Take on an FSSTArray is a simple take on the codes array.
-    fn take(&self, indices: &ArrayData) -> VortexResult<ArrayData> {
+    fn take(&self, indices: &ArrayData, options: TakeOptions) -> VortexResult<ArrayData> {
         Ok(Self::try_new(
             self.dtype().clone(),
             self.symbols(),
             self.symbol_lengths(),
-            take(self.codes(), indices)?,
-            take(self.uncompressed_lengths(), indices)?,
+            take(self.codes(), indices, options)?,
+            take(self.uncompressed_lengths(), indices, options)?,
         )?
         .into_array())
     }

--- a/encodings/fsst/tests/fsst_tests.rs
+++ b/encodings/fsst/tests/fsst_tests.rs
@@ -3,7 +3,7 @@
 use vortex_array::array::builder::VarBinBuilder;
 use vortex_array::array::{BoolArray, PrimitiveArray};
 use vortex_array::compute::unary::scalar_at;
-use vortex_array::compute::{filter, slice, take};
+use vortex_array::compute::{filter, slice, take, TakeOptions};
 use vortex_array::validity::Validity;
 use vortex_array::{ArrayData, ArrayDef, IntoArrayData, IntoCanonical};
 use vortex_dtype::{DType, Nullability};
@@ -71,7 +71,7 @@ fn test_fsst_array_ops() {
 
     // test take
     let indices = PrimitiveArray::from_vec(vec![0, 2], Validity::NonNullable).into_array();
-    let fsst_taken = take(&fsst_array, &indices).unwrap();
+    let fsst_taken = take(&fsst_array, &indices, TakeOptions::default()).unwrap();
     assert_eq!(fsst_taken.len(), 2);
     assert_nth_scalar!(
         fsst_taken,

--- a/encodings/runend-bool/src/array.rs
+++ b/encodings/runend-bool/src/array.rs
@@ -238,7 +238,7 @@ mod test {
     use rstest::rstest;
     use vortex_array::array::BoolArray;
     use vortex_array::compute::unary::scalar_at;
-    use vortex_array::compute::{slice, take};
+    use vortex_array::compute::{slice, take, TakeOptions};
     use vortex_array::stats::{ArrayStatistics as _, ArrayStatisticsCompute};
     use vortex_array::validity::Validity;
     use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoCanonical, ToArrayData};
@@ -326,6 +326,7 @@ mod test {
             )
             .unwrap(),
             vec![0, 0, 6, 4].into_array(),
+            TakeOptions::default(),
         )
         .unwrap();
 

--- a/encodings/runend-bool/src/compute.rs
+++ b/encodings/runend-bool/src/compute.rs
@@ -1,6 +1,6 @@
 use vortex_array::array::BoolArray;
 use vortex_array::compute::unary::ScalarAtFn;
-use vortex_array::compute::{slice, ArrayCompute, SliceFn, TakeFn};
+use vortex_array::compute::{slice, ArrayCompute, SliceFn, TakeFn, TakeOptions};
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayData, IntoArrayData, IntoArrayVariant, ToArrayData};
 use vortex_dtype::match_each_integer_ptype;
@@ -44,7 +44,7 @@ impl ScalarAtFn for RunEndBoolArray {
 }
 
 impl TakeFn for RunEndBoolArray {
-    fn take(&self, indices: &ArrayData) -> VortexResult<ArrayData> {
+    fn take(&self, indices: &ArrayData, _options: TakeOptions) -> VortexResult<ArrayData> {
         let primitive_indices = indices.clone().into_primitive()?;
         let physical_indices = match_each_integer_ptype!(primitive_indices.ptype(), |$P| {
             primitive_indices

--- a/encodings/runend/src/compute.rs
+++ b/encodings/runend/src/compute.rs
@@ -2,6 +2,7 @@ use vortex_array::array::{ConstantArray, PrimitiveArray, SparseArray};
 use vortex_array::compute::unary::{scalar_at, scalar_at_unchecked, ScalarAtFn};
 use vortex_array::compute::{
     compare, filter, slice, take, ArrayCompute, MaybeCompareFn, Operator, SliceFn, TakeFn,
+    TakeOptions,
 };
 use vortex_array::stats::{ArrayStatistics, Stat};
 use vortex_array::validity::Validity;
@@ -69,7 +70,7 @@ impl ScalarAtFn for RunEndArray {
 }
 
 impl TakeFn for RunEndArray {
-    fn take(&self, indices: &ArrayData) -> VortexResult<ArrayData> {
+    fn take(&self, indices: &ArrayData, options: TakeOptions) -> VortexResult<ArrayData> {
         let primitive_indices = indices.clone().into_primitive()?;
         let u64_indices = match_each_integer_ptype!(primitive_indices.ptype(), |$P| {
             primitive_indices
@@ -92,7 +93,7 @@ impl TakeFn for RunEndArray {
             .map(|idx| *idx as u64)
             .collect();
         let physical_indices_array = PrimitiveArray::from(physical_indices).into_array();
-        let dense_values = take(self.values(), &physical_indices_array)?;
+        let dense_values = take(self.values(), &physical_indices_array, options)?;
 
         Ok(match self.validity() {
             Validity::NonNullable => dense_values,
@@ -101,7 +102,7 @@ impl TakeFn for RunEndArray {
                 ConstantArray::new(Scalar::null(self.dtype().clone()), indices.len()).into_array()
             }
             Validity::Array(original_validity) => {
-                let dense_validity = take(&original_validity, indices)?;
+                let dense_validity = take(&original_validity, indices, options)?;
                 let filtered_values = filter(&dense_values, &dense_validity)?;
                 let length = dense_validity.len();
                 let dense_nonnull_indices = PrimitiveArray::from(
@@ -146,7 +147,7 @@ impl SliceFn for RunEndArray {
 mod test {
     use vortex_array::array::{BoolArray, PrimitiveArray};
     use vortex_array::compute::unary::{scalar_at, try_cast};
-    use vortex_array::compute::{slice, take};
+    use vortex_array::compute::{slice, take, TakeOptions};
     use vortex_array::validity::{ArrayValidity, Validity};
     use vortex_array::{ArrayDType, IntoArrayData, IntoArrayVariant, ToArrayData};
     use vortex_dtype::{DType, Nullability, PType};
@@ -166,6 +167,7 @@ mod test {
         let taken = take(
             ree_array().as_ref(),
             PrimitiveArray::from(vec![9, 8, 1, 3]).as_ref(),
+            TakeOptions::default(),
         )
         .unwrap();
         assert_eq!(
@@ -179,6 +181,7 @@ mod test {
         let taken = take(
             ree_array().as_ref(),
             PrimitiveArray::from(vec![11]).as_ref(),
+            TakeOptions::default(),
         )
         .unwrap();
         assert_eq!(
@@ -193,6 +196,7 @@ mod test {
         take(
             ree_array().as_ref(),
             PrimitiveArray::from(vec![12]).as_ref(),
+            TakeOptions::default(),
         )
         .unwrap();
     }
@@ -353,7 +357,7 @@ mod test {
         .unwrap();
 
         let test_indices = PrimitiveArray::from_vec(vec![0, 2, 4, 6], Validity::NonNullable);
-        let taken = take(arr.as_ref(), test_indices.as_ref()).unwrap();
+        let taken = take(arr.as_ref(), test_indices.as_ref(), TakeOptions::default()).unwrap();
 
         assert_eq!(taken.len(), test_indices.len());
 
@@ -372,6 +376,7 @@ mod test {
         let taken = take(
             sliced.as_ref(),
             PrimitiveArray::from(vec![1, 3, 4]).as_ref(),
+            TakeOptions::default(),
         )
         .unwrap();
 

--- a/fuzz/fuzz_targets/array_ops.rs
+++ b/fuzz/fuzz_targets/array_ops.rs
@@ -6,7 +6,9 @@ use vortex_array::array::{
     BoolEncoding, PrimitiveEncoding, StructEncoding, VarBinEncoding, VarBinViewEncoding,
 };
 use vortex_array::compute::unary::scalar_at;
-use vortex_array::compute::{filter, search_sorted, slice, take, SearchResult, SearchSortedSide};
+use vortex_array::compute::{
+    filter, search_sorted, slice, take, SearchResult, SearchSortedSide, TakeOptions,
+};
 use vortex_array::encoding::EncodingRef;
 use vortex_array::{ArrayData, IntoCanonical};
 use vortex_fuzz::{sort_canonical_array, Action, FuzzArrayAction};
@@ -35,7 +37,7 @@ fuzz_target!(|fuzz_action: FuzzArrayAction| -> Corpus {
                 if indices.is_empty() {
                     return Corpus::Reject;
                 }
-                current_array = take(&current_array, &indices).unwrap();
+                current_array = take(&current_array, &indices, TakeOptions::default()).unwrap();
                 assert_array_eq(&expected.array(), &current_array, i);
             }
             Action::SearchSorted(s, side) => {

--- a/pyvortex/src/array.rs
+++ b/pyvortex/src/array.rs
@@ -5,7 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyInt, PyList};
 use vortex::array::ChunkedArray;
 use vortex::compute::unary::{fill_forward, scalar_at};
-use vortex::compute::{compare, slice, take, Operator};
+use vortex::compute::{compare, slice, take, Operator, TakeOptions};
 use vortex::{ArrayDType, ArrayData, IntoCanonical};
 
 use crate::dtype::PyDType;
@@ -441,7 +441,7 @@ impl PyArray {
             )));
         }
 
-        let inner = take(&self.inner, indices)?;
+        let inner = take(&self.inner, indices, TakeOptions::default())?;
         Ok(PyArray { inner })
     }
 

--- a/vortex-array/benches/take_strings.rs
+++ b/vortex-array/benches/take_strings.rs
@@ -2,7 +2,7 @@
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use vortex_array::array::{PrimitiveArray, VarBinArray};
-use vortex_array::compute::take;
+use vortex_array::compute::{take, TakeOptions};
 use vortex_array::validity::Validity;
 use vortex_array::{ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::{DType, Nullability};
@@ -33,7 +33,9 @@ fn bench_varbin(c: &mut Criterion) {
     let array = fixture(65_535);
     let indices = indices(1024);
 
-    c.bench_function("varbin", |b| b.iter(|| take(&array, &indices).unwrap()));
+    c.bench_function("varbin", |b| {
+        b.iter(|| take(&array, &indices, TakeOptions::default()).unwrap())
+    });
 }
 
 fn bench_varbinview(c: &mut Criterion) {
@@ -41,7 +43,7 @@ fn bench_varbinview(c: &mut Criterion) {
     let indices = indices(1024);
 
     c.bench_function("varbinview", |b| {
-        b.iter(|| take(array.as_ref(), &indices).unwrap())
+        b.iter(|| take(array.as_ref(), &indices, TakeOptions::default()).unwrap())
     });
 }
 

--- a/vortex-array/src/array/bool/compute/take.rs
+++ b/vortex-array/src/array/bool/compute/take.rs
@@ -1,35 +1,81 @@
 use arrow_buffer::BooleanBuffer;
+use itertools::Itertools;
 use num_traits::AsPrimitive;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexResult;
 
 use crate::array::BoolArray;
-use crate::compute::TakeFn;
+use crate::compute::{TakeFn, TakeOptions};
 use crate::variants::PrimitiveArrayTrait;
 use crate::{ArrayData, IntoArrayData, IntoArrayVariant};
 
 impl TakeFn for BoolArray {
-    fn take(&self, indices: &ArrayData) -> VortexResult<ArrayData> {
+    fn take(&self, indices: &ArrayData, options: TakeOptions) -> VortexResult<ArrayData> {
         let validity = self.validity();
         let indices = indices.clone().into_primitive()?;
-        match_each_integer_ptype!(indices.ptype(), |$I| {
-            Ok(BoolArray::try_new(
-                take_bool(&self.boolean_buffer(), indices.maybe_null_slice::<$I>()),
-                validity.take(indices.as_ref())?,
-            )?.into_array())
-        })
+
+        // For boolean arrays that roughly fit into a single page (at least, on Linux), it's worth
+        // the overhead to convert to a Vec<bool>.
+        let buffer = if self.len() <= 4096 {
+            let bools = self.boolean_buffer().into_iter().collect_vec();
+            match_each_integer_ptype!(indices.ptype(), |$I| {
+                if options.skip_bounds_check {
+                    take_byte_bool_unchecked(bools, indices.maybe_null_slice::<$I>())
+                } else {
+                    take_byte_bool(bools, indices.maybe_null_slice::<$I>())
+                }
+            })
+        } else {
+            match_each_integer_ptype!(indices.ptype(), |$I| {
+                if options.skip_bounds_check {
+                    take_bool_unchecked(&self.boolean_buffer(), indices.maybe_null_slice::<$I>())
+                } else {
+                    take_bool(&self.boolean_buffer(), indices.maybe_null_slice::<$I>())
+                }
+            })
+        };
+
+        Ok(BoolArray::try_new(buffer, validity.take(indices.as_ref(), options)?)?.into_array())
     }
 }
 
+fn take_byte_bool<I: AsPrimitive<usize>>(bools: Vec<bool>, indices: &[I]) -> BooleanBuffer {
+    BooleanBuffer::collect_bool(indices.len(), |idx| {
+        bools[unsafe { (*indices.get_unchecked(idx)).as_() }]
+    })
+}
+
+fn take_byte_bool_unchecked<I: AsPrimitive<usize>>(
+    bools: Vec<bool>,
+    indices: &[I],
+) -> BooleanBuffer {
+    BooleanBuffer::collect_bool(indices.len(), |idx| unsafe {
+        *bools.get_unchecked((*indices.get_unchecked(idx)).as_())
+    })
+}
+
 fn take_bool<I: AsPrimitive<usize>>(bools: &BooleanBuffer, indices: &[I]) -> BooleanBuffer {
-    BooleanBuffer::collect_bool(indices.len(), |idx| bools.value(indices[idx].as_()))
+    BooleanBuffer::collect_bool(indices.len(), |idx| {
+        // We can always take from the indices unchecked since collect_bool just iterates len.
+        bools.value(unsafe { (*indices.get_unchecked(idx)).as_() })
+    })
+}
+
+fn take_bool_unchecked<I: AsPrimitive<usize>>(
+    bools: &BooleanBuffer,
+    indices: &[I],
+) -> BooleanBuffer {
+    BooleanBuffer::collect_bool(indices.len(), |idx| unsafe {
+        // We can always take from the indices unchecked since collect_bool just iterates len.
+        bools.value_unchecked((*indices.get_unchecked(idx)).as_())
+    })
 }
 
 #[cfg(test)]
 mod test {
     use crate::array::primitive::PrimitiveArray;
     use crate::array::BoolArray;
-    use crate::compute::take;
+    use crate::compute::{take, TakeOptions};
 
     #[test]
     fn take_nullable() {
@@ -41,8 +87,15 @@ mod test {
             Some(false),
         ]);
 
-        let b = BoolArray::try_from(take(&reference, PrimitiveArray::from(vec![0, 3, 4])).unwrap())
-            .unwrap();
+        let b = BoolArray::try_from(
+            take(
+                &reference,
+                PrimitiveArray::from(vec![0, 3, 4]),
+                TakeOptions::default(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             b.boolean_buffer(),
             BoolArray::from_iter(vec![Some(false), None, Some(false)]).boolean_buffer()

--- a/vortex-array/src/array/chunked/compute/filter.rs
+++ b/vortex-array/src/array/chunked/compute/filter.rs
@@ -2,7 +2,7 @@ use arrow_buffer::BooleanBufferBuilder;
 use vortex_error::{VortexExpect, VortexResult};
 
 use crate::array::{BoolArray, ChunkedArray, PrimitiveArray};
-use crate::compute::{filter, take, FilterFn, SearchSorted, SearchSortedSide};
+use crate::compute::{filter, take, FilterFn, SearchSorted, SearchSortedSide, TakeOptions};
 use crate::{ArrayDType, ArrayData, IntoArrayData, IntoCanonical};
 
 // This is modeled after the constant with the equivalent name in arrow-rs.
@@ -174,6 +174,7 @@ fn filter_indices<'a>(
                 let filtered_chunk = take(
                     chunk,
                     PrimitiveArray::from(chunk_indices.clone()).into_array(),
+                    TakeOptions::default(),
                 )?;
                 result.push(filtered_chunk);
             }
@@ -193,6 +194,7 @@ fn filter_indices<'a>(
         let filtered_chunk = take(
             &chunk,
             PrimitiveArray::from(chunk_indices.clone()).into_array(),
+            TakeOptions::default(),
         )?;
         result.push(filtered_chunk);
     }

--- a/vortex-array/src/array/constant/compute.rs
+++ b/vortex-array/src/array/constant/compute.rs
@@ -8,7 +8,7 @@ use crate::array::constant::ConstantArray;
 use crate::compute::unary::{scalar_at, ScalarAtFn};
 use crate::compute::{
     scalar_cmp, AndFn, ArrayCompute, FilterFn, MaybeCompareFn, Operator, OrFn, SearchResult,
-    SearchSortedFn, SearchSortedSide, SliceFn, TakeFn,
+    SearchSortedFn, SearchSortedSide, SliceFn, TakeFn, TakeOptions,
 };
 use crate::stats::{ArrayStatistics, Stat};
 use crate::{ArrayDType, ArrayData, IntoArrayData};
@@ -58,7 +58,7 @@ impl ScalarAtFn for ConstantArray {
 }
 
 impl TakeFn for ConstantArray {
-    fn take(&self, indices: &ArrayData) -> VortexResult<ArrayData> {
+    fn take(&self, indices: &ArrayData, _options: TakeOptions) -> VortexResult<ArrayData> {
         Ok(Self::new(self.owned_scalar(), indices.len()).into_array())
     }
 }
@@ -242,8 +242,10 @@ mod test {
     }
 
     #[rstest]
-    #[case(ConstantArray::new(true, 4).into_array(), BoolArray::from_iter([Some(true), Some(false), Some(true), Some(false)].into_iter()).into_array())]
-    #[case(BoolArray::from_iter([Some(true), Some(false), Some(true), Some(false)].into_iter()).into_array(), ConstantArray::new(true, 4).into_array())]
+    #[case(ConstantArray::new(true, 4).into_array(), BoolArray::from_iter([Some(true), Some(false), Some(true), Some(false)].into_iter()).into_array()
+    )]
+    #[case(BoolArray::from_iter([Some(true), Some(false), Some(true), Some(false)].into_iter()).into_array(), ConstantArray::new(true, 4).into_array()
+    )]
     fn test_or(#[case] lhs: ArrayData, #[case] rhs: ArrayData) {
         let r = or(&lhs, &rhs).unwrap().into_bool().unwrap().into_array();
 
@@ -259,7 +261,8 @@ mod test {
     }
 
     #[rstest]
-    #[case(ConstantArray::new(true, 4).into_array(), BoolArray::from_iter([Some(true), Some(false), Some(true), Some(false)].into_iter()).into_array())]
+    #[case(ConstantArray::new(true, 4).into_array(), BoolArray::from_iter([Some(true), Some(false), Some(true), Some(false)].into_iter()).into_array()
+    )]
     #[case(BoolArray::from_iter([Some(true), Some(false), Some(true), Some(false)].into_iter()).into_array(),
         ConstantArray::new(true, 4).into_array())]
     fn test_and(#[case] lhs: ArrayData, #[case] rhs: ArrayData) {

--- a/vortex-array/src/array/extension/compute.rs
+++ b/vortex-array/src/array/extension/compute.rs
@@ -5,7 +5,7 @@ use crate::array::extension::ExtensionArray;
 use crate::array::ConstantArray;
 use crate::compute::unary::{scalar_at, scalar_at_unchecked, CastFn, ScalarAtFn};
 use crate::compute::{
-    compare, slice, take, ArrayCompute, MaybeCompareFn, Operator, SliceFn, TakeFn,
+    compare, slice, take, ArrayCompute, MaybeCompareFn, Operator, SliceFn, TakeFn, TakeOptions,
 };
 use crate::variants::ExtensionArrayTrait;
 use crate::{ArrayDType, ArrayData, IntoArrayData};
@@ -87,7 +87,11 @@ impl SliceFn for ExtensionArray {
 }
 
 impl TakeFn for ExtensionArray {
-    fn take(&self, indices: &ArrayData) -> VortexResult<ArrayData> {
-        Ok(Self::new(self.ext_dtype().clone(), take(self.storage(), indices)?).into_array())
+    fn take(&self, indices: &ArrayData, options: TakeOptions) -> VortexResult<ArrayData> {
+        Ok(Self::new(
+            self.ext_dtype().clone(),
+            take(self.storage(), indices, options)?,
+        )
+        .into_array())
     }
 }

--- a/vortex-array/src/array/primitive/compute/take.rs
+++ b/vortex-array/src/array/primitive/compute/take.rs
@@ -1,35 +1,48 @@
-use num_traits::PrimInt;
-use vortex_dtype::{match_each_integer_ptype, match_each_native_ptype, NativePType};
-use vortex_error::{vortex_panic, VortexResult};
+use num_traits::AsPrimitive;
+use vortex_dtype::{match_each_native_ptype, match_each_unsigned_integer_ptype, NativePType};
+use vortex_error::VortexResult;
 
 use crate::array::primitive::PrimitiveArray;
-use crate::compute::TakeFn;
+use crate::compute::{TakeFn, TakeOptions};
 use crate::variants::PrimitiveArrayTrait;
 use crate::{ArrayData, IntoArrayData, IntoArrayVariant};
 
 impl TakeFn for PrimitiveArray {
-    fn take(&self, indices: &ArrayData) -> VortexResult<ArrayData> {
-        let validity = self.validity();
+    fn take(&self, indices: &ArrayData, options: TakeOptions) -> VortexResult<ArrayData> {
         let indices = indices.clone().into_primitive()?;
-        match_each_native_ptype!(self.ptype(), |$T| {
-            match_each_integer_ptype!(indices.ptype(), |$I| {
-                Ok(PrimitiveArray::from_vec(
-                    take_primitive(self.maybe_null_slice::<$T>(), indices.maybe_null_slice::<$I>()),
-                    validity.take(indices.as_ref())?,
-                ).into_array())
+        let validity = self.validity().take(indices.as_ref(), options)?;
+
+        match_each_unsigned_integer_ptype!(indices.ptype(), |$I| {
+            match_each_native_ptype!(self.ptype(), |$T| {
+                let values = if options.skip_bounds_check {
+                    take_primitive_unchecked(self.maybe_null_slice::<$T>(), indices.into_maybe_null_slice::<$I>())
+                } else {
+                    take_primitive(self.maybe_null_slice::<$T>(), indices.into_maybe_null_slice::<$I>())
+                };
+                Ok(PrimitiveArray::from_vec(values,validity).into_array())
             })
         })
     }
 }
 
-fn take_primitive<T: NativePType, I: NativePType + PrimInt>(array: &[T], indices: &[I]) -> Vec<T> {
+// We pass a Vec<I> in case we're T == u64.
+// In which case, Rust should reuse the same Vec<u64> the result.
+fn take_primitive<T: NativePType, I: NativePType + AsPrimitive<usize>>(
+    array: &[T],
+    indices: Vec<I>,
+) -> Vec<T> {
+    indices.into_iter().map(|idx| array[idx.as_()]).collect()
+}
+
+// We pass a Vec<I> in case we're T == u64.
+// In which case, Rust should reuse the same Vec<u64> the result.
+fn take_primitive_unchecked<T: NativePType, I: NativePType + AsPrimitive<usize>>(
+    array: &[T],
+    indices: Vec<I>,
+) -> Vec<T> {
     indices
-        .iter()
-        .map(|&idx| {
-            array[idx.to_usize().unwrap_or_else(|| {
-                vortex_panic!("Failed to convert index to usize: {}", idx);
-            })]
-        })
+        .into_iter()
+        .map(|idx| unsafe { *array.get_unchecked(idx.as_()) })
         .collect()
 }
 
@@ -40,7 +53,7 @@ mod test {
     #[test]
     fn test_take() {
         let a = vec![1i32, 2, 3, 4, 5];
-        let result = take_primitive(&a, &[0, 0, 4, 2]);
+        let result = take_primitive(&a, vec![0, 0, 4, 2]);
         assert_eq!(result, vec![1i32, 1, 5, 3]);
     }
 }

--- a/vortex-array/src/array/primitive/compute/take.rs
+++ b/vortex-array/src/array/primitive/compute/take.rs
@@ -1,5 +1,5 @@
 use num_traits::AsPrimitive;
-use vortex_dtype::{match_each_native_ptype, match_each_unsigned_integer_ptype, NativePType};
+use vortex_dtype::{match_each_integer_ptype, match_each_native_ptype, NativePType};
 use vortex_error::VortexResult;
 
 use crate::array::primitive::PrimitiveArray;
@@ -14,7 +14,7 @@ impl TakeFn for PrimitiveArray {
         let validity = self.validity().take(indices.as_ref(), options)?;
 
         match_each_native_ptype!(self.ptype(), |$T| {
-            match_each_unsigned_integer_ptype!(indices.ptype(), |$I| {
+            match_each_integer_ptype!(indices.ptype(), |$I| {
                 let values = if options.skip_bounds_check {
                     take_primitive_unchecked(self.maybe_null_slice::<$T>(), indices.into_maybe_null_slice::<$I>())
                 } else {

--- a/vortex-array/src/array/primitive/compute/take.rs
+++ b/vortex-array/src/array/primitive/compute/take.rs
@@ -8,12 +8,13 @@ use crate::variants::PrimitiveArrayTrait;
 use crate::{ArrayData, IntoArrayData, IntoArrayVariant};
 
 impl TakeFn for PrimitiveArray {
+    #[allow(clippy::cognitive_complexity)]
     fn take(&self, indices: &ArrayData, options: TakeOptions) -> VortexResult<ArrayData> {
         let indices = indices.clone().into_primitive()?;
         let validity = self.validity().take(indices.as_ref(), options)?;
 
-        match_each_unsigned_integer_ptype!(indices.ptype(), |$I| {
-            match_each_native_ptype!(self.ptype(), |$T| {
+        match_each_native_ptype!(self.ptype(), |$T| {
+            match_each_unsigned_integer_ptype!(indices.ptype(), |$I| {
                 let values = if options.skip_bounds_check {
                     take_primitive_unchecked(self.maybe_null_slice::<$T>(), indices.into_maybe_null_slice::<$I>())
                 } else {

--- a/vortex-array/src/array/sparse/compute/mod.rs
+++ b/vortex-array/src/array/sparse/compute/mod.rs
@@ -7,7 +7,7 @@ use crate::array::PrimitiveArray;
 use crate::compute::unary::{scalar_at, scalar_at_unchecked, ScalarAtFn};
 use crate::compute::{
     search_sorted, take, ArrayCompute, FilterFn, SearchResult, SearchSortedFn, SearchSortedSide,
-    SliceFn, TakeFn,
+    SliceFn, TakeFn, TakeOptions,
 };
 use crate::variants::PrimitiveArrayTrait;
 use crate::{ArrayData, IntoArrayData, IntoArrayVariant};
@@ -103,7 +103,11 @@ impl FilterFn for SparseArray {
 
         Ok(SparseArray::try_new(
             PrimitiveArray::from(coordinate_indices).into_array(),
-            take(self.values(), PrimitiveArray::from(value_indices))?,
+            take(
+                self.values(),
+                PrimitiveArray::from(value_indices),
+                TakeOptions::default(),
+            )?,
             buffer.count_set_bits(),
             self.fill_value().clone(),
         )?

--- a/vortex-array/src/array/struct_/compute.rs
+++ b/vortex-array/src/array/struct_/compute.rs
@@ -4,7 +4,7 @@ use vortex_scalar::Scalar;
 
 use crate::array::struct_::StructArray;
 use crate::compute::unary::{scalar_at, scalar_at_unchecked, ScalarAtFn};
-use crate::compute::{filter, slice, take, ArrayCompute, FilterFn, SliceFn, TakeFn};
+use crate::compute::{filter, slice, take, ArrayCompute, FilterFn, SliceFn, TakeFn, TakeOptions};
 use crate::stats::ArrayStatistics;
 use crate::variants::StructArrayTrait;
 use crate::{ArrayDType, ArrayData, IntoArrayData};
@@ -48,14 +48,14 @@ impl ScalarAtFn for StructArray {
 }
 
 impl TakeFn for StructArray {
-    fn take(&self, indices: &ArrayData) -> VortexResult<ArrayData> {
+    fn take(&self, indices: &ArrayData, options: TakeOptions) -> VortexResult<ArrayData> {
         Self::try_new(
             self.names().clone(),
             self.children()
-                .map(|field| take(&field, indices))
+                .map(|field| take(&field, indices, options))
                 .try_collect()?,
             indices.len(),
-            self.validity().take(indices)?,
+            self.validity().take(indices, options)?,
         )
         .map(|a| a.into_array())
     }

--- a/vortex-array/src/array/varbin/compute/take.rs
+++ b/vortex-array/src/array/varbin/compute/take.rs
@@ -4,13 +4,13 @@ use vortex_error::{vortex_err, vortex_panic, VortexResult};
 
 use crate::array::varbin::builder::VarBinBuilder;
 use crate::array::varbin::VarBinArray;
-use crate::compute::TakeFn;
+use crate::compute::{TakeFn, TakeOptions};
 use crate::validity::Validity;
 use crate::variants::PrimitiveArrayTrait;
 use crate::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
 
 impl TakeFn for VarBinArray {
-    fn take(&self, indices: &ArrayData) -> VortexResult<ArrayData> {
+    fn take(&self, indices: &ArrayData, _options: TakeOptions) -> VortexResult<ArrayData> {
         let offsets = self.offsets().into_primitive()?;
         let data = self.bytes().into_primitive()?;
         let indices = indices.clone().into_primitive()?;

--- a/vortex-array/src/compute/mod.rs
+++ b/vortex-array/src/compute/mod.rs
@@ -13,7 +13,7 @@ pub use compare::{compare, scalar_cmp, CompareFn, MaybeCompareFn, Operator};
 pub use filter::{filter, FilterFn};
 pub use search_sorted::*;
 pub use slice::{slice, SliceFn};
-pub use take::{take, TakeFn};
+pub use take::*;
 use unary::{CastFn, FillForwardFn, ScalarAtFn, SubtractScalarFn};
 use vortex_error::VortexResult;
 

--- a/vortex-array/src/compute/take.rs
+++ b/vortex-array/src/compute/take.rs
@@ -1,15 +1,22 @@
 use log::info;
 use vortex_error::{vortex_bail, vortex_err, VortexResult};
 
+use crate::stats::{ArrayStatistics, Stat};
 use crate::{ArrayDType as _, ArrayData, IntoCanonical as _};
 
+#[derive(Default, Debug, Clone, Copy)]
+pub struct TakeOptions {
+    pub skip_bounds_check: bool,
+}
+
 pub trait TakeFn {
-    fn take(&self, indices: &ArrayData) -> VortexResult<ArrayData>;
+    fn take(&self, indices: &ArrayData, options: TakeOptions) -> VortexResult<ArrayData>;
 }
 
 pub fn take(
     array: impl AsRef<ArrayData>,
     indices: impl AsRef<ArrayData>,
+    mut options: TakeOptions,
 ) -> VortexResult<ArrayData> {
     let array = array.as_ref();
     let indices = indices.as_ref();
@@ -21,16 +28,26 @@ pub fn take(
         );
     }
 
+    // If the indices are all within bounds, we can skip bounds checking.
+    if indices
+        .statistics()
+        .get_as::<usize>(Stat::Max)
+        .map(|max| max < array.len())
+        .unwrap_or_default()
+    {
+        options.skip_bounds_check = true;
+    }
+
     array.with_dyn(|a| {
         if let Some(take) = a.take() {
-            return take.take(indices);
+            return take.take(indices, options);
         }
 
         // Otherwise, flatten and try again.
         info!("TakeFn not implemented for {}, flattening", array);
         ArrayData::from(array.clone().into_canonical()?).with_dyn(|a| {
             a.take()
-                .map(|t| t.take(indices))
+                .map(|t| t.take(indices, options))
                 .unwrap_or_else(|| Err(vortex_err!(NotImplemented: "take", array.encoding().id())))
         })
     })

--- a/vortex-array/src/compute/take.rs
+++ b/vortex-array/src/compute/take.rs
@@ -37,6 +37,9 @@ pub fn take(
         options.skip_bounds_check = true;
     }
 
+    // TODO(ngates): if indices min is quite high, we could slice self and offset the indices
+    //  such that canonicalize does less work.
+
     array.with_dyn(|a| {
         if let Some(take) = a.take() {
             return take.take(indices, options);

--- a/vortex-array/src/compute/take.rs
+++ b/vortex-array/src/compute/take.rs
@@ -32,8 +32,7 @@ pub fn take(
     if indices
         .statistics()
         .get_as::<usize>(Stat::Max)
-        .map(|max| max < array.len())
-        .unwrap_or_default()
+        .is_some_and(|max| max < array.len())
     {
         options.skip_bounds_check = true;
     }

--- a/vortex-array/src/stream/take_rows.rs
+++ b/vortex-array/src/stream/take_rows.rs
@@ -8,7 +8,7 @@ use vortex_error::{vortex_bail, VortexResult};
 use vortex_scalar::Scalar;
 
 use crate::compute::unary::subtract_scalar;
-use crate::compute::{search_sorted, slice, take, SearchSortedSide};
+use crate::compute::{search_sorted, slice, take, SearchSortedSide, TakeOptions};
 use crate::stats::{ArrayStatistics, Stat};
 use crate::stream::ArrayStream;
 use crate::variants::PrimitiveArrayTrait;
@@ -93,7 +93,11 @@ impl<R: ArrayStream> Stream for TakeRows<R> {
             let shifted_arr = match_each_integer_ptype!(indices_for_batch.ptype(), |$T| {
                 subtract_scalar(&indices_for_batch.into_array(), &Scalar::from(curr_offset as $T))?
             });
-            return Poll::Ready(take(&batch, &shifted_arr).map(Some).transpose());
+            return Poll::Ready(
+                take(&batch, &shifted_arr, TakeOptions::default())
+                    .map(Some)
+                    .transpose(),
+            );
         }
 
         Poll::Ready(None)

--- a/vortex-datafusion/src/memory/plans.rs
+++ b/vortex-datafusion/src/memory/plans.rs
@@ -20,7 +20,7 @@ use futures::{ready, Stream};
 use pin_project::pin_project;
 use vortex_array::array::ChunkedArray;
 use vortex_array::arrow::FromArrowArray;
-use vortex_array::compute::take;
+use vortex_array::compute::{take, TakeOptions};
 use vortex_array::{ArrayData, IntoArrayVariant, IntoCanonical};
 use vortex_dtype::field::Field;
 use vortex_error::{vortex_err, vortex_panic, VortexError};
@@ -350,7 +350,7 @@ where
         //  We should find a way to avoid decoding the filter columns and only decode the other
         //  columns, then stitch the StructArray back together from those.
         let projected_for_output = chunk.project(this.output_projection)?;
-        let decoded = take(projected_for_output, &row_indices)?
+        let decoded = take(projected_for_output, &row_indices, TakeOptions::default())?
             .into_canonical()?
             .into_arrow()?;
 

--- a/vortex-file/src/chunked_reader/take_rows.rs
+++ b/vortex-file/src/chunked_reader/take_rows.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use vortex_array::aliases::hash_map::HashMap;
 use vortex_array::array::{ChunkedArray, PrimitiveArray};
 use vortex_array::compute::unary::{subtract_scalar, try_cast};
-use vortex_array::compute::{search_sorted, slice, take, SearchSortedSide};
+use vortex_array::compute::{search_sorted, slice, take, SearchSortedSide, TakeOptions};
 use vortex_array::stats::ArrayStatistics;
 use vortex_array::stream::{ArrayStream, ArrayStreamExt};
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
@@ -74,12 +74,16 @@ impl<R: VortexReadAt> ChunkedArrayReader<R> {
 
         // Grab the row and byte offsets for each chunk range.
         let start_chunks = PrimitiveArray::from(start_chunks).into_array();
-        let start_rows = take(&self.row_offsets, &start_chunks)?.into_primitive()?;
-        let start_bytes = take(&self.byte_offsets, &start_chunks)?.into_primitive()?;
+        let start_rows =
+            take(&self.row_offsets, &start_chunks, TakeOptions::default())?.into_primitive()?;
+        let start_bytes =
+            take(&self.byte_offsets, &start_chunks, TakeOptions::default())?.into_primitive()?;
 
         let stop_chunks = PrimitiveArray::from(stop_chunks).into_array();
-        let stop_rows = take(&self.row_offsets, &stop_chunks)?.into_primitive()?;
-        let stop_bytes = take(&self.byte_offsets, &stop_chunks)?.into_primitive()?;
+        let stop_rows =
+            take(&self.row_offsets, &stop_chunks, TakeOptions::default())?.into_primitive()?;
+        let stop_bytes =
+            take(&self.byte_offsets, &stop_chunks, TakeOptions::default())?.into_primitive()?;
 
         // For each chunk-range, read the data as an ArrayStream and call take on it.
         let chunks = stream::iter(0..coalesced_chunks.len())

--- a/vortex-file/src/read/mask.rs
+++ b/vortex-file/src/read/mask.rs
@@ -4,7 +4,7 @@ use std::fmt::{Display, Formatter};
 use arrow_buffer::{BooleanBuffer, MutableBuffer};
 use croaring::Bitmap;
 use vortex_array::array::{BoolArray, PrimitiveArray, SparseArray};
-use vortex_array::compute::{filter, slice, take};
+use vortex_array::compute::{filter, slice, take, TakeOptions};
 use vortex_array::validity::{LogicalValidity, Validity};
 use vortex_array::{iterate_integer_array, ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::PType;
@@ -213,7 +213,7 @@ impl RowMask {
 
         if (true_count as f64 / sliced.len() as f64) < PREFER_TAKE_TO_FILTER_DENSITY {
             let indices = self.to_indices_array()?;
-            take(sliced, indices).map(Some)
+            take(sliced, indices, TakeOptions::default()).map(Some)
         } else {
             let mask = self.to_mask_array()?;
             filter(sliced, mask).map(Some)

--- a/vortex-ipc/benches/ipc_take.rs
+++ b/vortex-ipc/benches/ipc_take.rs
@@ -15,7 +15,7 @@ use futures_util::{pin_mut, TryStreamExt};
 use itertools::Itertools;
 use vortex_array::array::PrimitiveArray;
 use vortex_array::compress::CompressionStrategy;
-use vortex_array::compute::take;
+use vortex_array::compute::{take, TakeOptions};
 use vortex_array::{Context, IntoArrayData};
 use vortex_io::FuturesAdapter;
 use vortex_ipc::stream_reader::StreamArrayReader;
@@ -81,7 +81,7 @@ fn ipc_take(c: &mut Criterion) {
             let reader = stream_reader.into_array_stream();
             pin_mut!(reader);
             let array_view = reader.try_next().await?.unwrap();
-            black_box(take(&array_view, indices_ref))
+            black_box(take(&array_view, indices_ref, TakeOptions::default()))
         });
     });
 }


### PR DESCRIPTION
For Q6 and Q19 this seems to help by ~15%. For the others, it's reported as an increase, but I'm not convinced this isn't just a slow benchmark run since there _shouldn't_ be any reason for an increase.