### PR TITLE
Always zero-copy from VortexBuffer to ArrowBuffer

### DIFF
--- a/vortex-buffer/src/lib.rs
+++ b/vortex-buffer/src/lib.rs
@@ -114,16 +114,10 @@ impl Buffer {
     pub fn into_arrow(self) -> ArrowBuffer {
         match self.0 {
             Inner::Arrow(a) => a,
-            Inner::Bytes(b) => {
-                unsafe {
-                    // SAFETY: Arrow's bytes are internally immutable, it's not clear why they
-                    // require a NonNull mutable pointer to construct this...
-                    let ptr = NonNull::new_unchecked(b.as_ptr() as *mut u8);
-                    let len = b.len();
-                    let dealloc = Arc::new(b);
-                    ArrowBuffer::from_custom_allocation(ptr, len, dealloc)
-                }
-            }
+            // This is cheeky. But it uses From<bytes::Bytes> for arrow_buffer::Bytes, even though
+            // arrow_buffer::Bytes is only pub(crate). Seems weird...
+            // See: https://github.com/apache/arrow-rs/issues/6033
+            Inner::Bytes(b) => ArrowBuffer::from(b.into()),
         }
     }
 }

--- a/vortex-buffer/src/lib.rs
+++ b/vortex-buffer/src/lib.rs
@@ -11,8 +11,6 @@
 
 use core::cmp::Ordering;
 use core::ops::{Deref, Range};
-use std::ptr::NonNull;
-use std::sync::Arc;
 
 use arrow_buffer::{ArrowNativeType, Buffer as ArrowBuffer, MutableBuffer as ArrowMutableBuffer};
 pub use string::*;

--- a/vortex-buffer/src/lib.rs
+++ b/vortex-buffer/src/lib.rs
@@ -11,6 +11,8 @@
 
 use core::cmp::Ordering;
 use core::ops::{Deref, Range};
+use std::ptr::NonNull;
+use std::sync::Arc;
 
 use arrow_buffer::{ArrowNativeType, Buffer as ArrowBuffer, MutableBuffer as ArrowMutableBuffer};
 pub use string::*;
@@ -112,7 +114,16 @@ impl Buffer {
     pub fn into_arrow(self) -> ArrowBuffer {
         match self.0 {
             Inner::Arrow(a) => a,
-            Inner::Bytes(b) => ArrowBuffer::from_vec(Vec::<u8>::from(b)),
+            Inner::Bytes(b) => {
+                unsafe {
+                    // SAFETY: Arrow's bytes are internally immutable, it's not clear why they
+                    // require a NonNull mutable pointer to construct this...
+                    let ptr = NonNull::new_unchecked(b.as_ptr() as *mut u8);
+                    let len = b.len();
+                    let dealloc = Arc::new(b);
+                    ArrowBuffer::from_custom_allocation(ptr, len, dealloc)
+                }
+            }
         }
     }
 }

--- a/vortex-buffer/src/lib.rs
+++ b/vortex-buffer/src/lib.rs
@@ -115,7 +115,7 @@ impl Buffer {
             // This is cheeky. But it uses From<bytes::Bytes> for arrow_buffer::Bytes, even though
             // arrow_buffer::Bytes is only pub(crate). Seems weird...
             // See: https://github.com/apache/arrow-rs/issues/6033
-            Inner::Bytes(b) => ArrowBuffer::from(b.into()),
+            Inner::Bytes(b) => ArrowBuffer::from_bytes(b.into()),
         }
     }
 }


### PR DESCRIPTION
Previously we converted to ArrowBuffer via a Vec<u8>, which was only zero-copy if we had exclusive ownership of the underlying bytes.

This uses a hard-to-find conversion from `bytes::Bytes` to `arrow_buffer::Bytes` which guarantees zero-copy.