### PR TITLE
Support RunEnd array with bool values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4926,6 +4926,7 @@ dependencies = [
 name = "vortex-runend"
 version = "0.19.0"
 dependencies = [
+ "arrow-buffer",
  "itertools 0.13.0",
  "num-traits",
  "serde",

--- a/encodings/runend/Cargo.toml
+++ b/encodings/runend/Cargo.toml
@@ -14,6 +14,7 @@ categories = { workspace = true }
 readme = { workspace = true }
 
 [dependencies]
+arrow-buffer = { workspace = true }
 itertools = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }

--- a/vortex-array/src/array/primitive/compute/compare.rs
+++ b/vortex-array/src/array/primitive/compute/compare.rs
@@ -1,7 +1,6 @@
 use vortex_error::VortexResult;
 
 use crate::array::primitive::PrimitiveArray;
-use crate::array::ConstantArray;
 use crate::compute::{arrow_compare, MaybeCompareFn, Operator};
 use crate::stats::{ArrayStatistics, Stat};
 use crate::ArrayData;
@@ -12,14 +11,11 @@ impl MaybeCompareFn for PrimitiveArray {
         other: &ArrayData,
         operator: Operator,
     ) -> Option<VortexResult<ArrayData>> {
-        // If the RHS is constant, then delegate to Arrow since.
-        // TODO(ngates): remove these dual checks once we make stats not a hashmap
-        //   https://github.com/spiraldb/vortex/issues/1309
-        if ConstantArray::try_from(other).is_ok()
-            || other
-                .statistics()
-                .get_as::<bool>(Stat::IsConstant)
-                .unwrap_or(false)
+        // If the RHS is constant, then delegate to Arrow.
+        if other
+            .statistics()
+            .get_as::<bool>(Stat::IsConstant)
+            .unwrap_or(false)
         {
             return Some(arrow_compare(self.as_ref(), other, operator));
         }

--- a/vortex-sampling-compressor/src/compressors/dict.rs
+++ b/vortex-sampling-compressor/src/compressors/dict.rs
@@ -27,9 +27,9 @@ impl EncodingCompressor for DictCompressor {
     }
 
     fn can_compress(&self, array: &ArrayData) -> Option<&dyn EncodingCompressor> {
-        if array.encoding().id() != Primitive::ID
-            && array.encoding().id() != VarBin::ID
-            && array.encoding().id() != VarBinView::ID
+        if !array.is_encoding(Primitive::ID)
+            && !array.is_encoding(VarBin::ID)
+            && !array.is_encoding(VarBinView::ID)
         {
             return None;
         };

--- a/vortex-sampling-compressor/src/compressors/runend.rs
+++ b/vortex-sampling-compressor/src/compressors/runend.rs
@@ -27,7 +27,7 @@ impl EncodingCompressor for RunEndCompressor {
     }
 
     fn can_compress(&self, array: &ArrayData) -> Option<&dyn EncodingCompressor> {
-        if array.encoding().id() != Primitive::ID {
+        if !array.is_encoding(Primitive::ID) {
             return None;
         }
 


### PR DESCRIPTION
This is necessary if we want to support compute pushdown as we will create
boolean values, otherwise we have to immediately canonicalize
