### PR TITLE
IntoCanonical as VTable

### DIFF
--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -17,7 +17,7 @@ use arrow_buffer::ScalarBuffer;
 use arrow_schema::{Field, Fields};
 use vortex_datetime_dtype::{is_temporal_ext_type, TemporalMetadata, TimeUnit};
 use vortex_dtype::{DType, NativePType, PType};
-use vortex_error::{vortex_bail, VortexResult};
+use vortex_error::{vortex_bail, VortexError, VortexResult};
 
 use crate::array::{
     varbinview_as_arrow, BoolArray, ExtensionArray, NullArray, PrimitiveArray, StructArray,
@@ -25,7 +25,7 @@ use crate::array::{
 };
 use crate::arrow::{infer_data_type, FromArrowArray};
 use crate::compute::unary::try_cast;
-use crate::encoding::ArrayEncoding;
+use crate::encoding::Encoding;
 use crate::validity::ArrayValidity;
 use crate::variants::{PrimitiveArrayTrait, StructArrayTrait};
 use crate::{ArrayDType, ArrayData, IntoArrayData};
@@ -307,6 +307,23 @@ pub trait IntoCanonical {
     fn into_canonical(self) -> VortexResult<Canonical>;
 }
 
+/// Encoding VTable for canonicalizing an array.
+#[allow(clippy::wrong_self_convention)]
+pub trait IntoCanonicalVTable {
+    fn into_canonical(&self, array: ArrayData) -> VortexResult<Canonical>;
+}
+
+/// Implement the [IntoCanonicalVTable] for all encodings with arrays implementing [IntoCanonical].
+impl<E: Encoding> IntoCanonicalVTable for E
+where
+    E::Array: IntoCanonical,
+    E::Array: TryFrom<ArrayData, Error = VortexError>,
+{
+    fn into_canonical(&self, data: ArrayData) -> VortexResult<Canonical> {
+        E::Array::try_from(data)?.into_canonical()
+    }
+}
+
 /// Trait for types that can be converted from an owned type into an owned array variant.
 ///
 /// # Canonicalization
@@ -362,7 +379,7 @@ where
 impl IntoCanonical for ArrayData {
     fn into_canonical(self) -> VortexResult<Canonical> {
         log::debug!("Canonicalizing array with encoding {:?}", self.encoding());
-        ArrayEncoding::canonicalize(self.encoding(), self)
+        self.encoding().into_canonical(self)
     }
 }
 

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -26,9 +26,10 @@ use crate::array::{
 use crate::arrow::{infer_data_type, FromArrowArray};
 use crate::compute::unary::try_cast;
 use crate::encoding::Encoding;
+use crate::stats::ArrayStatistics;
 use crate::validity::ArrayValidity;
 use crate::variants::{PrimitiveArrayTrait, StructArrayTrait};
-use crate::{ArrayDType, ArrayData, IntoArrayData};
+use crate::{canonical, ArrayDType, ArrayData, IntoArrayData};
 
 /// The set of canonical array encodings, also the set of encodings that can be transferred to
 /// Arrow with zero-copy.
@@ -320,7 +321,9 @@ where
     E::Array: TryFrom<ArrayData, Error = VortexError>,
 {
     fn into_canonical(&self, data: ArrayData) -> VortexResult<Canonical> {
-        E::Array::try_from(data)?.into_canonical()
+        let canonical = E::Array::try_from(data.clone())?.into_canonical()?;
+        canonical.inherit_statistics(data.statistics());
+        Ok(canonical)
     }
 }
 

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -29,7 +29,7 @@ use crate::encoding::Encoding;
 use crate::stats::ArrayStatistics;
 use crate::validity::ArrayValidity;
 use crate::variants::{PrimitiveArrayTrait, StructArrayTrait};
-use crate::{canonical, ArrayDType, ArrayData, IntoArrayData};
+use crate::{ArrayDType, ArrayData, IntoArrayData};
 
 /// The set of canonical array encodings, also the set of encodings that can be transferred to
 /// Arrow with zero-copy.

--- a/vortex-array/src/encoding/mod.rs
+++ b/vortex-array/src/encoding/mod.rs
@@ -7,7 +7,7 @@ use vortex_error::{vortex_panic, VortexResult};
 
 use crate::canonical::{Canonical, IntoCanonical};
 use crate::stats::ArrayStatistics as _;
-use crate::{ArrayData, ArrayDef, ArrayTrait};
+use crate::{ArrayData, ArrayDef, ArrayTrait, IntoCanonicalVTable};
 
 pub mod opaque;
 
@@ -44,14 +44,17 @@ impl AsRef<str> for EncodingId {
     }
 }
 
+/// Marker trait for array encodings with their associated Array type.
+pub trait Encoding {
+    type Array;
+}
+
 pub type EncodingRef = &'static dyn ArrayEncoding;
 
 /// Object-safe encoding trait for an array.
-pub trait ArrayEncoding: 'static + Sync + Send + Debug {
+/// TOOD(ngates): rename this EncodingVTable.
+pub trait ArrayEncoding: 'static + Sync + Send + Debug + IntoCanonicalVTable {
     fn id(&self) -> EncodingId;
-
-    /// Flatten the given array.
-    fn canonicalize(&self, array: ArrayData) -> VortexResult<Canonical>;
 
     /// Unwrap the provided array into an implementation of ArrayTrait
     fn with_dyn(

--- a/vortex-array/src/encoding/opaque.rs
+++ b/vortex-array/src/encoding/opaque.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use vortex_error::{vortex_bail, VortexResult};
 
 use crate::encoding::{ArrayEncoding, EncodingId};
-use crate::{ArrayData, ArrayTrait, Canonical};
+use crate::{ArrayData, ArrayTrait, Canonical, IntoCanonicalVTable};
 
 /// An encoding of an array that we cannot interpret.
 ///
@@ -23,13 +23,6 @@ impl ArrayEncoding for OpaqueEncoding {
         EncodingId::new("vortex.opaque", self.0)
     }
 
-    fn canonicalize(&self, _array: ArrayData) -> VortexResult<Canonical> {
-        vortex_bail!(
-            "OpaqueArray: canonicalize cannot be called for opaque array ({})",
-            self.0
-        );
-    }
-
     fn with_dyn(
         &self,
         _array: &ArrayData,
@@ -37,6 +30,15 @@ impl ArrayEncoding for OpaqueEncoding {
     ) -> VortexResult<()> {
         vortex_bail!(
             "OpaqueEncoding: with_dyn cannot be called for opaque array ({})",
+            self.0
+        )
+    }
+}
+
+impl IntoCanonicalVTable for OpaqueEncoding {
+    fn into_canonical(&self, _array: ArrayData) -> VortexResult<Canonical> {
+        vortex_bail!(
+            "OpaqueEncoding: into_canonical cannot be called for opaque array ({})",
             self.0
         )
     }

--- a/vortex-array/src/macros.rs
+++ b/vortex-array/src/macros.rs
@@ -41,6 +41,10 @@ macro_rules! impl_encoding {
                 type Encoding = [<$Name Encoding>];
             }
 
+            impl $crate::encoding::Encoding for [<$Name Encoding>] {
+                type Array = [<$Name Array>];
+            }
+
             #[derive(std::fmt::Debug, Clone)]
             pub struct [<$Name Array>] {
                 data: $crate::ArrayData,
@@ -117,11 +121,6 @@ macro_rules! impl_encoding {
                 #[inline]
                 fn id(&self) -> $crate::encoding::EncodingId {
                     <$Name as $crate::ArrayDef>::ID
-                }
-
-                #[inline]
-                fn canonicalize(&self, array: $crate::ArrayData) -> vortex_error::VortexResult<$crate::Canonical> {
-                    <Self as $crate::encoding::ArrayEncodingExt>::into_canonical(array)
                 }
 
                 #[inline]


### PR DESCRIPTION
The idea for the VTables change is that it is _encodings_ who implement the behavior of arrays taking and returning type-erased ArrayDatas.

This was already the case for canonicalize, this PR just formalizes it as a separate behavior.
It is also a useful function to call directly on arrays, hence why the non-vtable trait IntoCanonical still exists and is used to derive the IntoCanonicalVTable impls.

I still need to play around with non-owned vtable functions, the restriction being `E::Array: TryFrom<ArrayData>` would need to become `for<'a> &'a E::Array: TryFrom<&'a ArrayData>`, which is obviously impossible.... unless we only implement it for arrays that are `#[repr(transparent]` to an ArrayData. In other words, the macro'd `BoolArray` struct would need to lose its metadata field and become a unit struct that only holds ArrayData.

The implication here is that either:
* Metadata needs to be parsed on every access, and OwnedArrayData simply holds a Buffer for metadata.
* We keep ArrayData holding an `Arc<dyn ArrayMetadata>` and downcast it on access, but we still need to parse metadata for ViewedArrayData. Although I suppose we could also parse that on construction into `Arc<dyn ArrayMetadata>`....

FLUPS:
 - [x] Experiment with whether the heap allocation to parse metadata for ViewedArrayData is too costly. If so, we should make all metadata constant time access from `&[u8]`, i.e. move to flat buffers or C-repr metadata. If not, we can hold `Arc<dyn ArrayMetadata>` on both Owned and Viewed ArrayData, meaning we can remove it from the SomeArray struct and therefore permit the transmute from `&ArrayData` to `&SomeArray`.
    - It seems to make not much difference: https://github.com/spiraldb/vortex/pull/1383
    - Therefore for now I suggest we deserialize metadata on construction of ArrayData, even for ViewedArrayData. This caches the deserialized metadata for the lifetime of the ArrayData, instead of deserializing on every access.
    - In the future, we could make this `Option<Arc<dyn ArrayMetadata>>` to allow an array to decide whether to eagerly load metadata or do it lazily. 