### PR TITLE
Load metadata in ViewedArrayData

### DIFF
--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -17,7 +17,7 @@ use arrow_buffer::ScalarBuffer;
 use arrow_schema::{Field, Fields};
 use vortex_datetime_dtype::{is_temporal_ext_type, TemporalMetadata, TimeUnit};
 use vortex_dtype::{DType, NativePType, PType};
-use vortex_error::{vortex_bail, VortexResult};
+use vortex_error::{vortex_bail, VortexError, VortexResult};
 
 use crate::array::{
     varbinview_as_arrow, BoolArray, ExtensionArray, NullArray, PrimitiveArray, StructArray,
@@ -25,7 +25,7 @@ use crate::array::{
 };
 use crate::arrow::{infer_data_type, FromArrowArray};
 use crate::compute::unary::try_cast;
-use crate::encoding::ArrayEncoding;
+use crate::encoding::Encoding;
 use crate::validity::ArrayValidity;
 use crate::variants::{PrimitiveArrayTrait, StructArrayTrait};
 use crate::{ArrayDType, ArrayData, IntoArrayData};
@@ -307,6 +307,23 @@ pub trait IntoCanonical {
     fn into_canonical(self) -> VortexResult<Canonical>;
 }
 
+/// Encoding VTable for canonicalizing an array.
+#[allow(clippy::wrong_self_convention)]
+pub trait IntoCanonicalVTable {
+    fn into_canonical(&self, array: ArrayData) -> VortexResult<Canonical>;
+}
+
+/// Implement the [IntoCanonicalVTable] for all encodings with arrays implementing [IntoCanonical].
+impl<E: Encoding> IntoCanonicalVTable for E
+where
+    E::Array: IntoCanonical,
+    E::Array: TryFrom<ArrayData, Error = VortexError>,
+{
+    fn into_canonical(&self, data: ArrayData) -> VortexResult<Canonical> {
+        E::Array::try_from(data)?.into_canonical()
+    }
+}
+
 /// Trait for types that can be converted from an owned type into an owned array variant.
 ///
 /// # Canonicalization
@@ -362,7 +379,7 @@ where
 impl IntoCanonical for ArrayData {
     fn into_canonical(self) -> VortexResult<Canonical> {
         log::debug!("Canonicalizing array with encoding {:?}", self.encoding());
-        ArrayEncoding::canonicalize(self.encoding(), self)
+        self.encoding().into_canonical(self)
     }
 }
 

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -26,9 +26,10 @@ use crate::array::{
 use crate::arrow::{infer_data_type, FromArrowArray};
 use crate::compute::unary::try_cast;
 use crate::encoding::Encoding;
+use crate::stats::ArrayStatistics;
 use crate::validity::ArrayValidity;
 use crate::variants::{PrimitiveArrayTrait, StructArrayTrait};
-use crate::{ArrayDType, ArrayData, IntoArrayData};
+use crate::{canonical, ArrayDType, ArrayData, IntoArrayData};
 
 /// The set of canonical array encodings, also the set of encodings that can be transferred to
 /// Arrow with zero-copy.
@@ -320,7 +321,9 @@ where
     E::Array: TryFrom<ArrayData, Error = VortexError>,
 {
     fn into_canonical(&self, data: ArrayData) -> VortexResult<Canonical> {
-        E::Array::try_from(data)?.into_canonical()
+        let canonical = E::Array::try_from(data.clone())?.into_canonical()?;
+        canonical.inherit_statistics(data.statistics());
+        Ok(canonical)
     }
 }
 

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -29,7 +29,7 @@ use crate::encoding::Encoding;
 use crate::stats::ArrayStatistics;
 use crate::validity::ArrayValidity;
 use crate::variants::{PrimitiveArrayTrait, StructArrayTrait};
-use crate::{canonical, ArrayDType, ArrayData, IntoArrayData};
+use crate::{ArrayDType, ArrayData, IntoArrayData};
 
 /// The set of canonical array encodings, also the set of encodings that can be transferred to
 /// Arrow with zero-copy.

--- a/vortex-array/src/data/mod.rs
+++ b/vortex-array/src/data/mod.rs
@@ -218,22 +218,19 @@ impl ArrayData {
 
     pub fn metadata<M: ArrayMetadata + Clone + for<'m> TryDeserializeArrayMetadata<'m>>(
         &self,
-    ) -> VortexResult<M> {
-        let arc_metadata = match &self.0 {
+    ) -> VortexResult<&M> {
+        match &self.0 {
             InnerArrayData::Owned(d) => &d.metadata,
             InnerArrayData::Viewed(v) => &v.metadata,
-        };
-
-        arc_metadata
-            .as_any()
-            .downcast_ref::<M>()
-            .ok_or_else(|| {
-                vortex_err!(
-                    "Failed to downcast metadata to {}",
-                    std::any::type_name::<M>()
-                )
-            })
-            .cloned()
+        }
+        .as_any()
+        .downcast_ref::<M>()
+        .ok_or_else(|| {
+            vortex_err!(
+                "Failed to downcast metadata to {}",
+                std::any::type_name::<M>()
+            )
+        })
     }
 
     /// Get back the (possibly owned) metadata for the array.

--- a/vortex-array/src/data/mod.rs
+++ b/vortex-array/src/data/mod.rs
@@ -100,10 +100,13 @@ impl ArrayData {
             },
         )?;
 
+        let metadata = encoding.load_metadata(array.metadata().map(|v| v.bytes()))?;
+
         let view = ViewedArrayData {
             encoding,
             dtype,
             len,
+            metadata,
             flatbuffer,
             flatbuffer_loc,
             buffers: buffers.into(),
@@ -216,20 +219,21 @@ impl ArrayData {
     pub fn metadata<M: ArrayMetadata + Clone + for<'m> TryDeserializeArrayMetadata<'m>>(
         &self,
     ) -> VortexResult<M> {
-        match &self.0 {
-            InnerArrayData::Owned(d) => d
-                .metadata()
-                .as_any()
-                .downcast_ref::<M>()
-                .ok_or_else(|| {
-                    vortex_err!(
-                        "Failed to downcast metadata to {}",
-                        std::any::type_name::<M>()
-                    )
-                })
-                .cloned(),
-            InnerArrayData::Viewed(v) => M::try_deserialize_metadata(v.metadata()),
-        }
+        let arc_metadata = match &self.0 {
+            InnerArrayData::Owned(d) => &d.metadata,
+            InnerArrayData::Viewed(v) => &v.metadata,
+        };
+
+        arc_metadata
+            .as_any()
+            .downcast_ref::<M>()
+            .ok_or_else(|| {
+                vortex_err!(
+                    "Failed to downcast metadata to {}",
+                    std::any::type_name::<M>()
+                )
+            })
+            .cloned()
     }
 
     /// Get back the (possibly owned) metadata for the array.
@@ -251,7 +255,7 @@ impl ArrayData {
             InnerArrayData::Viewed(array_view) => {
                 // View arrays have direct access to metadata bytes.
                 array_view
-                    .metadata()
+                    .metadata_bytes()
                     .ok_or_else(|| vortex_err!("things"))
                     .map(Cow::Borrowed)
             }

--- a/vortex-array/src/data/viewed.rs
+++ b/vortex-array/src/data/viewed.rs
@@ -12,7 +12,7 @@ use crate::array::visitor::ArrayVisitor;
 use crate::encoding::opaque::OpaqueEncoding;
 use crate::encoding::EncodingRef;
 use crate::stats::{Stat, Statistics, StatsSet};
-use crate::{flatbuffers as fb, ArrayData, Context};
+use crate::{flatbuffers as fb, ArrayData, ArrayMetadata, Context};
 
 /// Zero-copy view over flatbuffer-encoded array data, created without eager serialization.
 #[derive(Clone)]
@@ -20,6 +20,7 @@ pub(super) struct ViewedArrayData {
     pub(super) encoding: EncodingRef,
     pub(super) dtype: DType,
     pub(super) len: usize,
+    pub(super) metadata: Arc<dyn ArrayMetadata>,
     pub(super) flatbuffer: Buffer,
     pub(super) flatbuffer_loc: usize,
     pub(super) buffers: Arc<[Buffer]>,
@@ -64,7 +65,7 @@ impl ViewedArrayData {
         self.len == 0
     }
 
-    pub fn metadata(&self) -> Option<&[u8]> {
+    pub fn metadata_bytes(&self) -> Option<&[u8]> {
         self.flatbuffer().metadata().map(|m| m.bytes())
     }
 
@@ -86,10 +87,13 @@ impl ViewedArrayData {
                 Box::leak(Box::new(OpaqueEncoding(child.encoding())))
             });
 
+        let metadata = encoding.load_metadata(child.metadata().map(|m| m.bytes()))?;
+
         Ok(Self {
             encoding,
             dtype: dtype.clone(),
             len,
+            metadata,
             flatbuffer: self.flatbuffer.clone(),
             flatbuffer_loc,
             buffers: self.buffers.clone(),

--- a/vortex-array/src/data/viewed.rs
+++ b/vortex-array/src/data/viewed.rs
@@ -25,9 +25,6 @@ pub(super) struct ViewedArrayData {
     pub(super) flatbuffer_loc: usize,
     pub(super) buffers: Arc<[Buffer]>,
     pub(super) ctx: Arc<Context>,
-    // TODO(ngates): a store a Projection. A projected ArrayView contains the full fb::Array
-    //  metadata, but only the buffers from the selected columns. Therefore we need to know
-    //  which fb:Array children to skip when calculating how to slice into buffers.
 }
 
 impl Debug for ViewedArrayData {

--- a/vortex-array/src/encoding/mod.rs
+++ b/vortex-array/src/encoding/mod.rs
@@ -7,7 +7,7 @@ use vortex_error::{vortex_panic, VortexResult};
 
 use crate::canonical::{Canonical, IntoCanonical};
 use crate::stats::ArrayStatistics as _;
-use crate::{ArrayData, ArrayDef, ArrayTrait, IntoCanonicalVTable};
+use crate::{ArrayData, ArrayDef, ArrayMetadata, ArrayTrait, IntoCanonicalVTable, MetadataVTable};
 
 pub mod opaque;
 
@@ -47,13 +47,16 @@ impl AsRef<str> for EncodingId {
 /// Marker trait for array encodings with their associated Array type.
 pub trait Encoding {
     type Array;
+    type Metadata: ArrayMetadata;
 }
 
 pub type EncodingRef = &'static dyn ArrayEncoding;
 
 /// Object-safe encoding trait for an array.
 /// TOOD(ngates): rename this EncodingVTable.
-pub trait ArrayEncoding: 'static + Sync + Send + Debug + IntoCanonicalVTable {
+pub trait ArrayEncoding:
+    'static + Sync + Send + Debug + IntoCanonicalVTable + MetadataVTable
+{
     fn id(&self) -> EncodingId;
 
     /// Unwrap the provided array into an implementation of ArrayTrait

--- a/vortex-array/src/encoding/mod.rs
+++ b/vortex-array/src/encoding/mod.rs
@@ -7,7 +7,7 @@ use vortex_error::{vortex_panic, VortexResult};
 
 use crate::canonical::{Canonical, IntoCanonical};
 use crate::stats::ArrayStatistics as _;
-use crate::{ArrayData, ArrayDef, ArrayTrait};
+use crate::{ArrayData, ArrayDef, ArrayTrait, IntoCanonicalVTable};
 
 pub mod opaque;
 
@@ -44,14 +44,17 @@ impl AsRef<str> for EncodingId {
     }
 }
 
+/// Marker trait for array encodings with their associated Array type.
+pub trait Encoding {
+    type Array;
+}
+
 pub type EncodingRef = &'static dyn ArrayEncoding;
 
 /// Object-safe encoding trait for an array.
-pub trait ArrayEncoding: 'static + Sync + Send + Debug {
+/// TOOD(ngates): rename this EncodingVTable.
+pub trait ArrayEncoding: 'static + Sync + Send + Debug + IntoCanonicalVTable {
     fn id(&self) -> EncodingId;
-
-    /// Flatten the given array.
-    fn canonicalize(&self, array: ArrayData) -> VortexResult<Canonical>;
 
     /// Unwrap the provided array into an implementation of ArrayTrait
     fn with_dyn(

--- a/vortex-array/src/encoding/opaque.rs
+++ b/vortex-array/src/encoding/opaque.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use vortex_error::{vortex_bail, VortexResult};
 
 use crate::encoding::{ArrayEncoding, EncodingId};
-use crate::{ArrayData, ArrayTrait, Canonical};
+use crate::{ArrayData, ArrayTrait, Canonical, IntoCanonicalVTable};
 
 /// An encoding of an array that we cannot interpret.
 ///
@@ -23,13 +23,6 @@ impl ArrayEncoding for OpaqueEncoding {
         EncodingId::new("vortex.opaque", self.0)
     }
 
-    fn canonicalize(&self, _array: ArrayData) -> VortexResult<Canonical> {
-        vortex_bail!(
-            "OpaqueArray: canonicalize cannot be called for opaque array ({})",
-            self.0
-        );
-    }
-
     fn with_dyn(
         &self,
         _array: &ArrayData,
@@ -37,6 +30,15 @@ impl ArrayEncoding for OpaqueEncoding {
     ) -> VortexResult<()> {
         vortex_bail!(
             "OpaqueEncoding: with_dyn cannot be called for opaque array ({})",
+            self.0
+        )
+    }
+}
+
+impl IntoCanonicalVTable for OpaqueEncoding {
+    fn into_canonical(&self, _array: ArrayData) -> VortexResult<Canonical> {
+        vortex_bail!(
+            "OpaqueEncoding: into_canonical cannot be called for opaque array ({})",
             self.0
         )
     }

--- a/vortex-array/src/encoding/opaque.rs
+++ b/vortex-array/src/encoding/opaque.rs
@@ -1,9 +1,14 @@
-use std::fmt::Debug;
+use std::any::Any;
+use std::fmt::{Debug, Display, Formatter};
+use std::sync::Arc;
 
 use vortex_error::{vortex_bail, VortexResult};
 
 use crate::encoding::{ArrayEncoding, EncodingId};
-use crate::{ArrayData, ArrayTrait, Canonical, IntoCanonicalVTable};
+use crate::{
+    ArrayData, ArrayMetadata, ArrayTrait, Canonical, IntoCanonicalVTable, MetadataVTable,
+    TrySerializeArrayMetadata,
+};
 
 /// An encoding of an array that we cannot interpret.
 ///
@@ -41,5 +46,36 @@ impl IntoCanonicalVTable for OpaqueEncoding {
             "OpaqueEncoding: into_canonical cannot be called for opaque array ({})",
             self.0
         )
+    }
+}
+
+impl MetadataVTable for OpaqueEncoding {
+    fn load_metadata(&self, _metadata: Option<&[u8]>) -> VortexResult<Arc<dyn ArrayMetadata>> {
+        Ok(Arc::new(OpaqueMetadata))
+    }
+}
+
+#[derive(Debug)]
+pub struct OpaqueMetadata;
+
+impl TrySerializeArrayMetadata for OpaqueMetadata {
+    fn try_serialize_metadata(&self) -> VortexResult<Arc<[u8]>> {
+        vortex_bail!("OpaqueMetadata cannot be serialized")
+    }
+}
+
+impl Display for OpaqueMetadata {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "OpaqueMetadata")
+    }
+}
+
+impl ArrayMetadata for OpaqueMetadata {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self
     }
 }

--- a/vortex-array/src/macros.rs
+++ b/vortex-array/src/macros.rs
@@ -43,6 +43,7 @@ macro_rules! impl_encoding {
 
             impl $crate::encoding::Encoding for [<$Name Encoding>] {
                 type Array = [<$Name Array>];
+                type Metadata = [<$Name Metadata>];
             }
 
             #[derive(std::fmt::Debug, Clone)]

--- a/vortex-array/src/macros.rs
+++ b/vortex-array/src/macros.rs
@@ -47,26 +47,26 @@ macro_rules! impl_encoding {
             }
 
             #[derive(std::fmt::Debug, Clone)]
-            pub struct [<$Name Array>] {
-                data: $crate::ArrayData,
-                metadata: [<$Name Metadata>],
-            }
+            #[repr(transparent)]
+            pub struct [<$Name Array>]($crate::ArrayData);
 
             impl $crate::IntoArrayData for [<$Name Array>] {
                 fn into_array(self) -> $crate::ArrayData {
-                    self.data
+                    self.0
                 }
             }
             impl AsRef<$crate::ArrayData> for [<$Name Array>] {
                 fn as_ref(&self) -> &$crate::ArrayData {
-                    &self.data
+                    &self.0
                 }
             }
 
             impl [<$Name Array>] {
                 #[allow(dead_code)]
                 fn metadata(&self) -> &[<$Name Metadata>] {
-                    &self.metadata
+                    use vortex_error::VortexExpect;
+                    self.0.metadata::<[<$Name Metadata>]>()
+                        .vortex_expect("Metadata should be tied to the encoding")
                 }
 
                 pub fn len(&self) -> usize {
@@ -108,10 +108,7 @@ macro_rules! impl_encoding {
                             <$Name as $crate::ArrayDef>::ID,
                         );
                     }
-
-                    let metadata = data.metadata::<[<$Name Metadata>]>()?;
-
-                    Ok(Self { data, metadata })
+                    Ok(Self(data))
                 }
             }
 

--- a/vortex-array/src/macros.rs
+++ b/vortex-array/src/macros.rs
@@ -41,6 +41,10 @@ macro_rules! impl_encoding {
                 type Encoding = [<$Name Encoding>];
             }
 
+            impl $crate::encoding::Encoding for [<$Name Encoding>] {
+                type Array = [<$Name Array>];
+            }
+
             #[derive(std::fmt::Debug, Clone)]
             pub struct [<$Name Array>] {
                 data: $crate::ArrayData,
@@ -117,11 +121,6 @@ macro_rules! impl_encoding {
                 #[inline]
                 fn id(&self) -> $crate::encoding::EncodingId {
                     <$Name as $crate::ArrayDef>::ID
-                }
-
-                #[inline]
-                fn canonicalize(&self, array: $crate::ArrayData) -> vortex_error::VortexResult<$crate::Canonical> {
-                    <Self as $crate::encoding::ArrayEncodingExt>::into_canonical(array)
                 }
 
                 #[inline]


### PR DESCRIPTION
It does trigger a heap allocation every time we construct a ViewedArrayMetadata (and actually, every time we visit one of its children... although I suppose we could cache those in ArrayData).

This assumes that parsing array metadata is actually somewhat expensive, which doesn't need to be true for most of our own encodings since we can use flat buffers or raw bytes. But this may not hold true forever.

TODO: add back metadata to TreeDisplay