### PR TITLE
fix: Remove redundant len/is_empty implementations on typed array structs

### DIFF
--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -10,7 +10,8 @@ use vortex_array::stats::ArrayStatisticsCompute;
 use vortex_array::validity::{ArrayValidity, LogicalValidity, Validity};
 use vortex_array::variants::{ArrayVariants, PrimitiveArrayTrait};
 use vortex_array::{
-    impl_encoding, ArrayDType, ArrayData, ArrayTrait, Canonical, IntoArrayData, IntoCanonical,
+    impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, Canonical, IntoArrayData,
+    IntoCanonical,
 };
 use vortex_dtype::{DType, PType};
 use vortex_error::{vortex_bail, vortex_panic, VortexExpect as _, VortexResult};

--- a/encodings/alp/src/alp/compute.rs
+++ b/encodings/alp/src/alp/compute.rs
@@ -5,7 +5,7 @@ use vortex_array::compute::{
     SliceFn, TakeFn, TakeOptions,
 };
 use vortex_array::variants::PrimitiveArrayTrait;
-use vortex_array::{ArrayDType, ArrayData, IntoArrayData};
+use vortex_array::{ArrayDType, ArrayData, ArrayLen, IntoArrayData};
 use vortex_dtype::Nullability;
 use vortex_error::{VortexExpect, VortexResult};
 use vortex_scalar::{PValue, Scalar};

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -6,7 +6,9 @@ use vortex_array::array::{PrimitiveArray, SparseArray};
 use vortex_array::encoding::ids;
 use vortex_array::stats::{ArrayStatisticsCompute, StatsSet};
 use vortex_array::validity::{ArrayValidity, LogicalValidity};
-use vortex_array::{impl_encoding, ArrayDType, ArrayData, ArrayTrait, Canonical, IntoCanonical};
+use vortex_array::{
+    impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, Canonical, IntoCanonical,
+};
 use vortex_dtype::{DType, Nullability, PType};
 use vortex_error::{vortex_bail, VortexExpect, VortexResult};
 

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -10,7 +10,9 @@ use vortex_array::encoding::ids;
 use vortex_array::stats::StatsSet;
 use vortex_array::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use vortex_array::variants::{ArrayVariants, BoolArrayTrait};
-use vortex_array::{impl_encoding, ArrayData, ArrayTrait, Canonical, IntoArrayData, IntoCanonical};
+use vortex_array::{
+    impl_encoding, ArrayData, ArrayLen, ArrayTrait, Canonical, IntoArrayData, IntoCanonical,
+};
 use vortex_buffer::Buffer;
 use vortex_dtype::DType;
 use vortex_error::{VortexExpect as _, VortexResult};

--- a/encodings/bytebool/src/compute.rs
+++ b/encodings/bytebool/src/compute.rs
@@ -3,7 +3,7 @@ use vortex_array::compute::unary::{FillForwardFn, ScalarAtFn};
 use vortex_array::compute::{ArrayCompute, SliceFn, TakeFn, TakeOptions};
 use vortex_array::validity::{ArrayValidity, Validity};
 use vortex_array::variants::PrimitiveArrayTrait;
-use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant, ToArrayData};
+use vortex_array::{ArrayDType, ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant, ToArrayData};
 use vortex_dtype::{match_each_integer_ptype, Nullability};
 use vortex_error::{vortex_err, VortexResult};
 use vortex_scalar::Scalar;

--- a/encodings/bytebool/src/stats.rs
+++ b/encodings/bytebool/src/stats.rs
@@ -1,5 +1,5 @@
 use vortex_array::stats::{ArrayStatisticsCompute, Stat, StatsSet};
-use vortex_array::IntoArrayVariant;
+use vortex_array::{ArrayLen, IntoArrayVariant};
 use vortex_error::VortexResult;
 
 use super::ByteBoolArray;

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -9,7 +9,8 @@ use vortex_array::stats::{ArrayStatisticsCompute, Stat, StatsSet};
 use vortex_array::validity::{ArrayValidity, LogicalValidity, Validity};
 use vortex_array::variants::{ArrayVariants, ExtensionArrayTrait};
 use vortex_array::{
-    impl_encoding, ArrayDType, ArrayData, ArrayTrait, Canonical, IntoArrayData, IntoCanonical,
+    impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, Canonical, IntoArrayData,
+    IntoCanonical,
 };
 use vortex_dtype::{DType, PType};
 use vortex_error::{vortex_bail, VortexExpect as _, VortexResult, VortexUnwrap};

--- a/encodings/datetime-parts/src/compress.rs
+++ b/encodings/datetime-parts/src/compress.rs
@@ -1,6 +1,6 @@
 use vortex_array::array::{PrimitiveArray, TemporalArray};
 use vortex_array::compute::unary::try_cast;
-use vortex_array::{ArrayDType as _, ArrayData, IntoArrayData, IntoArrayVariant};
+use vortex_array::{ArrayDType as _, ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
 use vortex_datetime_dtype::TimeUnit;
 use vortex_dtype::{DType, PType};
 use vortex_error::{vortex_bail, VortexResult};

--- a/encodings/dict/src/array.rs
+++ b/encodings/dict/src/array.rs
@@ -11,8 +11,8 @@ use vortex_array::stats::StatsSet;
 use vortex_array::validity::{ArrayValidity, LogicalValidity};
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{
-    impl_encoding, ArrayDType, ArrayData, ArrayTrait, Canonical, IntoArrayData, IntoArrayVariant,
-    IntoCanonical,
+    impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, Canonical, IntoArrayData,
+    IntoArrayVariant, IntoCanonical,
 };
 use vortex_dtype::{match_each_integer_ptype, DType, PType};
 use vortex_error::{vortex_bail, vortex_panic, VortexExpect as _, VortexResult};

--- a/encodings/dict/src/compute.rs
+++ b/encodings/dict/src/compute.rs
@@ -104,7 +104,7 @@ mod test {
     use vortex_array::array::{ConstantArray, PrimitiveArray, VarBinViewArray};
     use vortex_array::compute::unary::scalar_at;
     use vortex_array::compute::{compare, slice, Operator};
-    use vortex_array::{IntoArrayData, IntoArrayVariant, ToArrayData};
+    use vortex_array::{ArrayLen, IntoArrayData, IntoArrayVariant, ToArrayData};
     use vortex_dtype::{DType, Nullability};
     use vortex_scalar::Scalar;
 

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -4,7 +4,7 @@ use vortex_array::array::{PrimitiveArray, Sparse, SparseArray};
 use vortex_array::stats::ArrayStatistics;
 use vortex_array::validity::{ArrayValidity, Validity};
 use vortex_array::variants::PrimitiveArrayTrait;
-use vortex_array::{ArrayDType, ArrayData, ArrayDef, IntoArrayData, IntoArrayVariant};
+use vortex_array::{ArrayDType, ArrayData, ArrayDef, ArrayLen, IntoArrayData, IntoArrayVariant};
 use vortex_buffer::Buffer;
 use vortex_dtype::{
     match_each_integer_ptype, match_each_unsigned_integer_ptype, NativePType, PType,

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -128,7 +128,7 @@ fn filter_slices<T: NativePType + BitPacking + ArrowNativeType>(
 mod test {
     use vortex_array::array::PrimitiveArray;
     use vortex_array::compute::{filter, slice, FilterMask};
-    use vortex_array::IntoArrayVariant;
+    use vortex_array::{ArrayLen, IntoArrayVariant};
 
     use crate::BitPackedArray;
 

--- a/encodings/fastlanes/src/bitpacking/compute/search_sorted.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/search_sorted.rs
@@ -11,7 +11,7 @@ use vortex_array::compute::{
 };
 use vortex_array::validity::Validity;
 use vortex_array::variants::PrimitiveArrayTrait;
-use vortex_array::ArrayDType;
+use vortex_array::{ArrayDType, ArrayLen};
 use vortex_dtype::{match_each_unsigned_integer_ptype, NativePType};
 use vortex_error::{VortexError, VortexExpect as _, VortexResult};
 use vortex_scalar::Scalar;

--- a/encodings/fastlanes/src/bitpacking/compute/slice.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/slice.rs
@@ -48,7 +48,7 @@ mod test {
     use vortex_array::array::{PrimitiveArray, SparseArray};
     use vortex_array::compute::unary::scalar_at;
     use vortex_array::compute::{slice, take, TakeOptions};
-    use vortex_array::IntoArrayData;
+    use vortex_array::{ArrayLen, IntoArrayData};
 
     use crate::BitPackedArray;
 

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -5,7 +5,9 @@ use itertools::Itertools;
 use vortex_array::array::{PrimitiveArray, SparseArray};
 use vortex_array::compute::{slice, take, TakeFn, TakeOptions};
 use vortex_array::variants::PrimitiveArrayTrait;
-use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant, IntoCanonical};
+use vortex_array::{
+    ArrayDType, ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant, IntoCanonical,
+};
 use vortex_dtype::{
     match_each_integer_ptype, match_each_unsigned_integer_ptype, NativePType, PType,
 };

--- a/encodings/fastlanes/src/bitpacking/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/mod.rs
@@ -10,7 +10,9 @@ use vortex_array::encoding::ids;
 use vortex_array::stats::{ArrayStatisticsCompute, StatsSet};
 use vortex_array::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use vortex_array::variants::{ArrayVariants, PrimitiveArrayTrait};
-use vortex_array::{impl_encoding, ArrayDType, ArrayData, ArrayTrait, Canonical, IntoCanonical};
+use vortex_array::{
+    impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, Canonical, IntoCanonical,
+};
 use vortex_buffer::Buffer;
 use vortex_dtype::{DType, NativePType, Nullability, PType};
 use vortex_error::{vortex_bail, vortex_err, VortexExpect as _, VortexResult};

--- a/encodings/fastlanes/src/delta/compress.rs
+++ b/encodings/fastlanes/src/delta/compress.rs
@@ -6,7 +6,7 @@ use vortex_array::compute::unary::fill_forward;
 use vortex_array::compute::SliceFn;
 use vortex_array::validity::Validity;
 use vortex_array::variants::PrimitiveArrayTrait;
-use vortex_array::IntoArrayVariant;
+use vortex_array::{ArrayLen, IntoArrayVariant};
 use vortex_dtype::{match_each_unsigned_integer_ptype, NativePType, Nullability};
 use vortex_error::VortexResult;
 
@@ -168,6 +168,8 @@ where
 
 #[cfg(test)]
 mod test {
+    use vortex_array::ArrayLen;
+
     use super::*;
 
     #[test]

--- a/encodings/fastlanes/src/delta/mod.rs
+++ b/encodings/fastlanes/src/delta/mod.rs
@@ -9,7 +9,8 @@ use vortex_array::stats::{ArrayStatisticsCompute, StatsSet};
 use vortex_array::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use vortex_array::variants::{ArrayVariants, PrimitiveArrayTrait};
 use vortex_array::{
-    impl_encoding, ArrayDType, ArrayData, ArrayTrait, Canonical, IntoArrayData, IntoCanonical,
+    impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, Canonical, IntoArrayData,
+    IntoCanonical,
 };
 use vortex_dtype::{match_each_unsigned_integer_ptype, NativePType};
 use vortex_error::{vortex_bail, vortex_panic, VortexExpect as _, VortexResult};

--- a/encodings/fastlanes/src/for/compress.rs
+++ b/encodings/fastlanes/src/for/compress.rs
@@ -4,7 +4,7 @@ use vortex_array::array::{ConstantArray, PrimitiveArray, SparseArray};
 use vortex_array::stats::{trailing_zeros, ArrayStatistics, Stat};
 use vortex_array::validity::LogicalValidity;
 use vortex_array::variants::PrimitiveArrayTrait;
-use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
+use vortex_array::{ArrayDType, ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::{match_each_integer_ptype, NativePType};
 use vortex_error::{vortex_err, VortexResult};
 use vortex_scalar::{Scalar, ScalarValue};

--- a/encodings/fastlanes/src/for/mod.rs
+++ b/encodings/fastlanes/src/for/mod.rs
@@ -7,7 +7,9 @@ use vortex_array::encoding::ids;
 use vortex_array::stats::{ArrayStatisticsCompute, StatsSet};
 use vortex_array::validity::{ArrayValidity, LogicalValidity};
 use vortex_array::variants::{ArrayVariants, PrimitiveArrayTrait};
-use vortex_array::{impl_encoding, ArrayDType, ArrayData, ArrayTrait, Canonical, IntoCanonical};
+use vortex_array::{
+    impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, Canonical, IntoCanonical,
+};
 use vortex_dtype::DType;
 use vortex_error::{vortex_bail, VortexExpect as _, VortexResult};
 use vortex_scalar::{Scalar, ScalarValue};

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -9,7 +9,9 @@ use vortex_array::encoding::ids;
 use vortex_array::stats::{ArrayStatisticsCompute, StatsSet};
 use vortex_array::validity::{ArrayValidity, LogicalValidity, Validity};
 use vortex_array::variants::{ArrayVariants, BinaryArrayTrait, Utf8ArrayTrait};
-use vortex_array::{impl_encoding, ArrayDType, ArrayData, ArrayDef, ArrayTrait, IntoCanonical};
+use vortex_array::{
+    impl_encoding, ArrayDType, ArrayData, ArrayDef, ArrayLen, ArrayTrait, IntoCanonical,
+};
 use vortex_dtype::{DType, Nullability, PType};
 use vortex_error::{vortex_bail, VortexExpect, VortexResult};
 

--- a/encodings/fsst/src/compute.rs
+++ b/encodings/fsst/src/compute.rs
@@ -5,7 +5,7 @@ use vortex_array::compute::{
     compare, filter, slice, take, ArrayCompute, FilterFn, FilterMask, MaybeCompareFn, Operator,
     SliceFn, TakeFn, TakeOptions,
 };
-use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant, ToArrayData};
+use vortex_array::{ArrayDType, ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant, ToArrayData};
 use vortex_buffer::Buffer;
 use vortex_dtype::DType;
 use vortex_error::{vortex_err, VortexResult, VortexUnwrap};
@@ -168,7 +168,7 @@ mod tests {
     use vortex_array::array::{ConstantArray, VarBinArray};
     use vortex_array::compute::unary::scalar_at_unchecked;
     use vortex_array::compute::{MaybeCompareFn, Operator};
-    use vortex_array::{IntoArrayData, IntoArrayVariant};
+    use vortex_array::{ArrayLen, IntoArrayData, IntoArrayVariant};
     use vortex_dtype::{DType, Nullability};
     use vortex_scalar::Scalar;
 

--- a/encodings/roaring/src/boolean/compress.rs
+++ b/encodings/roaring/src/boolean/compress.rs
@@ -1,5 +1,6 @@
 use croaring::Bitmap;
 use vortex_array::array::BoolArray;
+use vortex_array::ArrayLen;
 use vortex_error::VortexResult;
 
 use crate::RoaringBoolArray;

--- a/encodings/roaring/src/boolean/mod.rs
+++ b/encodings/roaring/src/boolean/mod.rs
@@ -12,7 +12,9 @@ use vortex_array::encoding::ids;
 use vortex_array::stats::StatsSet;
 use vortex_array::validity::{ArrayValidity, LogicalValidity};
 use vortex_array::variants::{ArrayVariants, BoolArrayTrait};
-use vortex_array::{impl_encoding, ArrayData, ArrayTrait, Canonical, IntoArrayData, IntoCanonical};
+use vortex_array::{
+    impl_encoding, ArrayData, ArrayLen, ArrayTrait, Canonical, IntoArrayData, IntoCanonical,
+};
 use vortex_buffer::Buffer;
 use vortex_dtype::{DType, Nullability};
 use vortex_error::{vortex_bail, vortex_err, VortexExpect as _, VortexResult};
@@ -142,7 +144,7 @@ mod test {
     use std::iter;
 
     use vortex_array::array::BoolArray;
-    use vortex_array::{IntoArrayData, IntoArrayVariant};
+    use vortex_array::{ArrayLen, IntoArrayData, IntoArrayVariant};
 
     use crate::RoaringBoolArray;
 

--- a/encodings/roaring/src/boolean/stats.rs
+++ b/encodings/roaring/src/boolean/stats.rs
@@ -1,4 +1,5 @@
 use vortex_array::stats::{ArrayStatisticsCompute, Stat, StatsSet};
+use vortex_array::ArrayLen;
 use vortex_error::{vortex_err, VortexResult};
 
 use crate::RoaringBoolArray;

--- a/encodings/roaring/src/integer/compute.rs
+++ b/encodings/roaring/src/integer/compute.rs
@@ -1,7 +1,7 @@
 use croaring::Bitmap;
 use vortex_array::compute::unary::ScalarAtFn;
 use vortex_array::compute::{ArrayCompute, SliceFn};
-use vortex_array::{ArrayData, IntoArrayData};
+use vortex_array::{ArrayData, ArrayLen, IntoArrayData};
 use vortex_dtype::PType;
 use vortex_error::{vortex_err, VortexResult, VortexUnwrap as _};
 use vortex_scalar::Scalar;

--- a/encodings/roaring/src/integer/mod.rs
+++ b/encodings/roaring/src/integer/mod.rs
@@ -12,7 +12,8 @@ use vortex_array::stats::{ArrayStatistics, ArrayStatisticsCompute, Stat, StatsSe
 use vortex_array::validity::{ArrayValidity, LogicalValidity, Validity};
 use vortex_array::variants::{ArrayVariants, PrimitiveArrayTrait};
 use vortex_array::{
-    impl_encoding, ArrayDType as _, ArrayData, ArrayTrait, Canonical, IntoArrayData, IntoCanonical,
+    impl_encoding, ArrayDType as _, ArrayData, ArrayLen, ArrayTrait, Canonical, IntoArrayData,
+    IntoCanonical,
 };
 use vortex_buffer::Buffer;
 use vortex_dtype::Nullability::NonNullable;

--- a/encodings/runend-bool/src/array.rs
+++ b/encodings/runend-bool/src/array.rs
@@ -10,8 +10,8 @@ use vortex_array::stats::{ArrayStatistics, ArrayStatisticsCompute, Stat, StatsSe
 use vortex_array::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use vortex_array::variants::{ArrayVariants, BoolArrayTrait, PrimitiveArrayTrait};
 use vortex_array::{
-    impl_encoding, ArrayDType, ArrayData, ArrayTrait, Canonical, IntoArrayData, IntoArrayVariant,
-    IntoCanonical,
+    impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, Canonical, IntoArrayData,
+    IntoArrayVariant, IntoCanonical,
 };
 use vortex_dtype::{match_each_integer_ptype, match_each_unsigned_integer_ptype, DType, PType};
 use vortex_error::{vortex_bail, VortexExpect as _, VortexResult};
@@ -264,7 +264,9 @@ mod test {
     use vortex_array::compute::{slice, take, TakeOptions};
     use vortex_array::stats::{ArrayStatistics as _, ArrayStatisticsCompute};
     use vortex_array::validity::Validity;
-    use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoCanonical, ToArrayData};
+    use vortex_array::{
+        ArrayDType, ArrayData, ArrayLen, IntoArrayData, IntoCanonical, ToArrayData,
+    };
     use vortex_dtype::{DType, Nullability};
 
     use crate::RunEndBoolArray;

--- a/encodings/runend-bool/src/compute.rs
+++ b/encodings/runend-bool/src/compute.rs
@@ -2,7 +2,7 @@ use vortex_array::array::BoolArray;
 use vortex_array::compute::unary::ScalarAtFn;
 use vortex_array::compute::{slice, ArrayCompute, SliceFn, TakeFn, TakeOptions};
 use vortex_array::variants::PrimitiveArrayTrait;
-use vortex_array::{ArrayData, IntoArrayData, IntoArrayVariant, ToArrayData};
+use vortex_array::{ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant, ToArrayData};
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::{vortex_bail, VortexExpect as _, VortexResult};
 use vortex_scalar::Scalar;

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -10,8 +10,8 @@ use vortex_array::stats::{ArrayStatistics, ArrayStatisticsCompute, Stat, StatsSe
 use vortex_array::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use vortex_array::variants::{ArrayVariants, BoolArrayTrait, PrimitiveArrayTrait};
 use vortex_array::{
-    impl_encoding, ArrayDType, ArrayData, ArrayTrait, Canonical, IntoArrayData, IntoArrayVariant,
-    IntoCanonical,
+    impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, Canonical, IntoArrayData,
+    IntoArrayVariant, IntoCanonical,
 };
 use vortex_dtype::{DType, PType};
 use vortex_error::{vortex_bail, vortex_err, VortexExpect as _, VortexResult};
@@ -280,7 +280,7 @@ impl ArrayStatisticsCompute for RunEndArray {
 mod tests {
     use vortex_array::compute::unary::scalar_at;
     use vortex_array::validity::Validity;
-    use vortex_array::{ArrayDType, IntoArrayData};
+    use vortex_array::{ArrayDType, ArrayLen, IntoArrayData};
     use vortex_dtype::{DType, Nullability, PType};
 
     use crate::RunEndArray;

--- a/encodings/runend/src/compress.rs
+++ b/encodings/runend/src/compress.rs
@@ -112,7 +112,7 @@ pub fn runend_decode_typed_bool(
 mod test {
     use vortex_array::array::PrimitiveArray;
     use vortex_array::validity::{ArrayValidity, Validity};
-    use vortex_array::{IntoArrayData, IntoArrayVariant};
+    use vortex_array::{ArrayLen, IntoArrayData, IntoArrayVariant};
 
     use crate::compress::{runend_decode_primitive, runend_encode};
     use crate::RunEndArray;

--- a/encodings/runend/src/compute.rs
+++ b/encodings/runend/src/compute.rs
@@ -10,7 +10,7 @@ use vortex_array::compute::{
 };
 use vortex_array::validity::Validity;
 use vortex_array::variants::PrimitiveArrayTrait;
-use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
+use vortex_array::{ArrayDType, ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::{match_each_integer_ptype, match_each_unsigned_integer_ptype, NativePType};
 use vortex_error::{VortexExpect as _, VortexResult};
 use vortex_scalar::{Scalar, ScalarValue};
@@ -199,7 +199,7 @@ mod test {
     use vortex_array::compute::unary::{scalar_at, try_cast};
     use vortex_array::compute::{compare, filter, slice, take, FilterMask, Operator, TakeOptions};
     use vortex_array::validity::{ArrayValidity, Validity};
-    use vortex_array::{ArrayDType, IntoArrayData, IntoArrayVariant, ToArrayData};
+    use vortex_array::{ArrayDType, ArrayLen, IntoArrayData, IntoArrayVariant, ToArrayData};
     use vortex_dtype::{DType, Nullability, PType};
     use vortex_scalar::Scalar;
 

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -8,7 +8,8 @@ use vortex_array::stats::{ArrayStatistics, ArrayStatisticsCompute, Stat, StatsSe
 use vortex_array::validity::{ArrayValidity, LogicalValidity};
 use vortex_array::variants::{ArrayVariants, PrimitiveArrayTrait};
 use vortex_array::{
-    impl_encoding, ArrayDType, ArrayData, ArrayTrait, Canonical, IntoArrayVariant, IntoCanonical,
+    impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, Canonical, IntoArrayVariant,
+    IntoCanonical,
 };
 use vortex_dtype::{DType, PType};
 use vortex_error::{vortex_bail, vortex_err, vortex_panic, VortexExpect as _, VortexResult};

--- a/vortex-array/src/array/bool/accessors.rs
+++ b/vortex-array/src/array/bool/accessors.rs
@@ -3,7 +3,7 @@ use vortex_error::VortexResult;
 use crate::accessor::ArrayAccessor;
 use crate::array::BoolArray;
 use crate::validity::Validity;
-use crate::IntoArrayVariant;
+use crate::{ArrayLen, IntoArrayVariant};
 
 static TRUE: bool = true;
 static FALSE: bool = false;

--- a/vortex-array/src/array/bool/compute/fill.rs
+++ b/vortex-array/src/array/bool/compute/fill.rs
@@ -5,7 +5,7 @@ use vortex_error::{vortex_err, VortexResult};
 use crate::array::BoolArray;
 use crate::compute::unary::FillForwardFn;
 use crate::validity::{ArrayValidity, Validity};
-use crate::{ArrayDType, ArrayData, IntoArrayData, ToArrayData};
+use crate::{ArrayDType, ArrayData, ArrayLen, IntoArrayData, ToArrayData};
 
 impl FillForwardFn for BoolArray {
     fn fill_forward(&self) -> VortexResult<ArrayData> {

--- a/vortex-array/src/array/bool/compute/filter.rs
+++ b/vortex-array/src/array/bool/compute/filter.rs
@@ -77,7 +77,7 @@ mod test {
     use crate::array::bool::compute::filter::{filter_indices, filter_slices};
     use crate::array::BoolArray;
     use crate::compute::{filter, FilterMask};
-    use crate::{IntoArrayData, IntoArrayVariant};
+    use crate::{ArrayLen, IntoArrayData, IntoArrayVariant};
 
     #[test]
     fn filter_bool_test() {

--- a/vortex-array/src/array/bool/compute/slice.rs
+++ b/vortex-array/src/array/bool/compute/slice.rs
@@ -16,11 +16,11 @@ impl SliceFn for BoolArray {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
     use crate::compute::slice;
     use crate::compute::unary::scalar_at;
     use crate::validity::ArrayValidity;
+    use crate::ArrayLen;
 
     #[test]
     fn test_slice() {

--- a/vortex-array/src/array/bool/compute/take.rs
+++ b/vortex-array/src/array/bool/compute/take.rs
@@ -7,7 +7,7 @@ use vortex_error::VortexResult;
 use crate::array::BoolArray;
 use crate::compute::{TakeFn, TakeOptions};
 use crate::variants::PrimitiveArrayTrait;
-use crate::{ArrayData, IntoArrayData, IntoArrayVariant};
+use crate::{ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
 
 impl TakeFn for BoolArray {
     fn take(&self, indices: &ArrayData, options: TakeOptions) -> VortexResult<ArrayData> {

--- a/vortex-array/src/array/bool/mod.rs
+++ b/vortex-array/src/array/bool/mod.rs
@@ -15,7 +15,9 @@ use crate::encoding::ids;
 use crate::stats::StatsSet;
 use crate::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use crate::variants::{ArrayVariants, BoolArrayTrait};
-use crate::{impl_encoding, ArrayData, ArrayTrait, Canonical, IntoArrayData, IntoCanonical};
+use crate::{
+    impl_encoding, ArrayData, ArrayLen, ArrayTrait, Canonical, IntoArrayData, IntoCanonical,
+};
 
 mod accessors;
 pub mod compute;

--- a/vortex-array/src/array/bool/stats.rs
+++ b/vortex-array/src/array/bool/stats.rs
@@ -8,7 +8,7 @@ use vortex_error::VortexResult;
 use crate::array::BoolArray;
 use crate::stats::{ArrayStatisticsCompute, Stat, StatsSet};
 use crate::validity::{ArrayValidity, LogicalValidity};
-use crate::{ArrayDType, ArrayTrait as _, IntoArrayVariant};
+use crate::{ArrayDType, ArrayLen, ArrayTrait as _, IntoArrayVariant};
 
 impl ArrayStatisticsCompute for BoolArray {
     fn compute_statistics(&self, stat: Stat) -> VortexResult<StatsSet> {

--- a/vortex-array/src/array/chunked/canonical.rs
+++ b/vortex-array/src/array/chunked/canonical.rs
@@ -246,7 +246,7 @@ mod tests {
     use crate::compute::slice;
     use crate::validity::Validity;
     use crate::variants::StructArrayTrait;
-    use crate::{ArrayDType, IntoArrayData, IntoArrayVariant, ToArrayData};
+    use crate::{ArrayDType, ArrayLen, IntoArrayData, IntoArrayVariant, ToArrayData};
 
     fn stringview_array() -> VarBinViewArray {
         VarBinViewArray::from_iter_str(["foo", "bar", "baz", "quak"])

--- a/vortex-array/src/array/chunked/compute/filter.rs
+++ b/vortex-array/src/array/chunked/compute/filter.rs
@@ -5,7 +5,7 @@ use crate::array::{ChunkedArray, PrimitiveArray};
 use crate::compute::{
     filter, take, FilterFn, FilterMask, SearchSorted, SearchSortedSide, TakeOptions,
 };
-use crate::{ArrayDType, ArrayData, IntoArrayData, IntoCanonical};
+use crate::{ArrayDType, ArrayData, ArrayLen, IntoArrayData, IntoCanonical};
 
 // This is modeled after the constant with the equivalent name in arrow-rs.
 const FILTER_SLICES_SELECTIVITY_THRESHOLD: f64 = 0.8;

--- a/vortex-array/src/array/chunked/compute/take.rs
+++ b/vortex-array/src/array/chunked/compute/take.rs
@@ -7,7 +7,7 @@ use crate::array::chunked::ChunkedArray;
 use crate::compute::unary::{scalar_at, subtract_scalar, try_cast};
 use crate::compute::{search_sorted, slice, take, SearchSortedSide, TakeFn, TakeOptions};
 use crate::stats::ArrayStatistics;
-use crate::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant, ToArrayData};
+use crate::{ArrayDType, ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant, ToArrayData};
 
 impl TakeFn for ChunkedArray {
     fn take(&self, indices: &ArrayData, options: TakeOptions) -> VortexResult<ArrayData> {
@@ -122,7 +122,7 @@ fn take_strict_sorted(
 mod test {
     use crate::array::chunked::ChunkedArray;
     use crate::compute::{take, TakeOptions};
-    use crate::{ArrayDType, IntoArrayData, IntoArrayVariant};
+    use crate::{ArrayDType, ArrayLen, IntoArrayData, IntoArrayVariant};
 
     #[test]
     fn test_take() {

--- a/vortex-array/src/array/chunked/mod.rs
+++ b/vortex-array/src/array/chunked/mod.rs
@@ -21,7 +21,9 @@ use crate::stats::ArrayStatistics;
 use crate::stream::{ArrayStream, ArrayStreamAdapter};
 use crate::validity::Validity::NonNullable;
 use crate::validity::{ArrayValidity, LogicalValidity, Validity};
-use crate::{impl_encoding, ArrayDType, ArrayData, ArrayTrait, IntoArrayData, IntoCanonical};
+use crate::{
+    impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, IntoArrayData, IntoCanonical,
+};
 
 mod canonical;
 mod compute;

--- a/vortex-array/src/array/constant/canonical.rs
+++ b/vortex-array/src/array/constant/canonical.rs
@@ -11,7 +11,7 @@ use crate::array::{
     BinaryView, BoolArray, ExtensionArray, NullArray, VarBinViewArray, VIEW_SIZE_BYTES,
 };
 use crate::validity::Validity;
-use crate::{ArrayDType, Canonical, IntoArrayData, IntoCanonical};
+use crate::{ArrayDType, ArrayLen, Canonical, IntoArrayData, IntoCanonical};
 
 impl IntoCanonical for ConstantArray {
     fn into_canonical(self) -> VortexResult<Canonical> {
@@ -127,7 +127,7 @@ mod tests {
     use crate::array::ConstantArray;
     use crate::compute::unary::scalar_at;
     use crate::stats::{ArrayStatistics as _, StatsSet};
-    use crate::{IntoArrayData as _, IntoCanonical};
+    use crate::{ArrayLen, IntoArrayData as _, IntoCanonical};
 
     #[test]
     fn test_canonicalize_null() {

--- a/vortex-array/src/array/constant/compute.rs
+++ b/vortex-array/src/array/constant/compute.rs
@@ -11,7 +11,7 @@ use crate::compute::{
     SearchResult, SearchSortedFn, SearchSortedSide, SliceFn, TakeFn, TakeOptions,
 };
 use crate::stats::{ArrayStatistics, Stat};
-use crate::{ArrayDType, ArrayData, IntoArrayData};
+use crate::{ArrayDType, ArrayData, ArrayLen, IntoArrayData};
 
 impl ArrayCompute for ConstantArray {
     fn compare(&self, other: &ArrayData, operator: Operator) -> Option<VortexResult<ArrayData>> {

--- a/vortex-array/src/array/constant/mod.rs
+++ b/vortex-array/src/array/constant/mod.rs
@@ -8,7 +8,7 @@ use crate::array::visitor::{AcceptArrayVisitor, ArrayVisitor};
 use crate::encoding::ids;
 use crate::stats::{ArrayStatisticsCompute, Stat, StatsSet};
 use crate::validity::{ArrayValidity, LogicalValidity};
-use crate::{impl_encoding, ArrayDType, ArrayTrait};
+use crate::{impl_encoding, ArrayDType, ArrayLen, ArrayTrait};
 
 mod canonical;
 mod compute;

--- a/vortex-array/src/array/constant/variants.rs
+++ b/vortex-array/src/array/constant/variants.rs
@@ -12,7 +12,7 @@ use crate::variants::{
     ArrayVariants, BinaryArrayTrait, BoolArrayTrait, ExtensionArrayTrait, ListArrayTrait,
     NullArrayTrait, PrimitiveArrayTrait, StructArrayTrait, Utf8ArrayTrait,
 };
-use crate::{ArrayDType, ArrayData, IntoArrayData, ToArrayData};
+use crate::{ArrayDType, ArrayData, ArrayLen, IntoArrayData, ToArrayData};
 
 /// Constant arrays support all DTypes
 impl ArrayVariants for ConstantArray {

--- a/vortex-array/src/array/extension/compute.rs
+++ b/vortex-array/src/array/extension/compute.rs
@@ -8,7 +8,7 @@ use crate::compute::{
     compare, slice, take, ArrayCompute, MaybeCompareFn, Operator, SliceFn, TakeFn, TakeOptions,
 };
 use crate::variants::ExtensionArrayTrait;
-use crate::{ArrayDType, ArrayData, IntoArrayData};
+use crate::{ArrayDType, ArrayData, ArrayLen, IntoArrayData};
 
 impl ArrayCompute for ExtensionArray {
     fn cast(&self) -> Option<&dyn CastFn> {

--- a/vortex-array/src/array/extension/mod.rs
+++ b/vortex-array/src/array/extension/mod.rs
@@ -11,7 +11,7 @@ use crate::encoding::ids;
 use crate::stats::{ArrayStatistics as _, ArrayStatisticsCompute, Stat, StatsSet};
 use crate::validity::{ArrayValidity, LogicalValidity};
 use crate::variants::{ArrayVariants, ExtensionArrayTrait};
-use crate::{impl_encoding, ArrayDType, ArrayData, ArrayTrait, Canonical, IntoCanonical};
+use crate::{impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, Canonical, IntoCanonical};
 
 mod compute;
 

--- a/vortex-array/src/array/null/compute.rs
+++ b/vortex-array/src/array/null/compute.rs
@@ -6,7 +6,7 @@ use crate::array::null::NullArray;
 use crate::compute::unary::ScalarAtFn;
 use crate::compute::{ArrayCompute, SliceFn, TakeFn, TakeOptions};
 use crate::variants::PrimitiveArrayTrait;
-use crate::{ArrayData, IntoArrayData, IntoArrayVariant};
+use crate::{ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
 
 impl ArrayCompute for NullArray {
     fn scalar_at(&self) -> Option<&dyn ScalarAtFn> {
@@ -65,7 +65,7 @@ mod test {
     use crate::compute::unary::scalar_at;
     use crate::compute::{SliceFn, TakeFn, TakeOptions};
     use crate::validity::{ArrayValidity, LogicalValidity};
-    use crate::IntoArrayData;
+    use crate::{ArrayLen, IntoArrayData};
 
     #[test]
     fn test_slice_nulls() {

--- a/vortex-array/src/array/null/mod.rs
+++ b/vortex-array/src/array/null/mod.rs
@@ -9,7 +9,7 @@ use crate::encoding::ids;
 use crate::stats::{ArrayStatisticsCompute, Stat, StatsSet};
 use crate::validity::{ArrayValidity, LogicalValidity, Validity};
 use crate::variants::{ArrayVariants, NullArrayTrait};
-use crate::{impl_encoding, ArrayTrait, Canonical, IntoCanonical};
+use crate::{impl_encoding, ArrayLen, ArrayTrait, Canonical, IntoCanonical};
 
 mod compute;
 

--- a/vortex-array/src/array/primitive/compute/cast.rs
+++ b/vortex-array/src/array/primitive/compute/cast.rs
@@ -5,7 +5,7 @@ use crate::array::primitive::PrimitiveArray;
 use crate::compute::unary::CastFn;
 use crate::validity::Validity;
 use crate::variants::PrimitiveArrayTrait;
-use crate::{ArrayDType, ArrayData, IntoArrayData};
+use crate::{ArrayDType, ArrayData, ArrayLen, IntoArrayData};
 
 impl CastFn for PrimitiveArray {
     fn cast(&self, dtype: &DType) -> VortexResult<ArrayData> {

--- a/vortex-array/src/array/primitive/compute/fill.rs
+++ b/vortex-array/src/array/primitive/compute/fill.rs
@@ -5,7 +5,7 @@ use crate::array::primitive::PrimitiveArray;
 use crate::compute::unary::FillForwardFn;
 use crate::validity::{ArrayValidity, Validity};
 use crate::variants::PrimitiveArrayTrait;
-use crate::{ArrayDType, ArrayData, IntoArrayData, ToArrayData};
+use crate::{ArrayDType, ArrayData, ArrayLen, IntoArrayData, ToArrayData};
 
 impl FillForwardFn for PrimitiveArray {
     fn fill_forward(&self) -> VortexResult<ArrayData> {

--- a/vortex-array/src/array/primitive/compute/filter.rs
+++ b/vortex-array/src/array/primitive/compute/filter.rs
@@ -45,7 +45,7 @@ mod test {
 
     use crate::array::primitive::PrimitiveArray;
     use crate::compute::{FilterFn, FilterMask};
-    use crate::IntoArrayVariant;
+    use crate::{ArrayLen, IntoArrayVariant};
 
     #[test]
     fn filter_run_variant_mixed_test() {

--- a/vortex-array/src/array/primitive/compute/search_sorted.rs
+++ b/vortex-array/src/array/primitive/compute/search_sorted.rs
@@ -9,7 +9,7 @@ use crate::array::primitive::PrimitiveArray;
 use crate::compute::{IndexOrd, Len, SearchResult, SearchSorted, SearchSortedFn, SearchSortedSide};
 use crate::validity::Validity;
 use crate::variants::PrimitiveArrayTrait;
-use crate::ArrayDType;
+use crate::{ArrayDType, ArrayLen};
 
 impl SearchSortedFn for PrimitiveArray {
     fn search_sorted(&self, value: &Scalar, side: SearchSortedSide) -> VortexResult<SearchResult> {

--- a/vortex-array/src/array/primitive/compute/subtract_scalar.rs
+++ b/vortex-array/src/array/primitive/compute/subtract_scalar.rs
@@ -9,7 +9,7 @@ use crate::array::primitive::PrimitiveArray;
 use crate::compute::unary::SubtractScalarFn;
 use crate::validity::ArrayValidity;
 use crate::variants::PrimitiveArrayTrait;
-use crate::{ArrayDType, ArrayData, IntoArrayData};
+use crate::{ArrayDType, ArrayData, ArrayLen, IntoArrayData};
 
 impl SubtractScalarFn for PrimitiveArray {
     fn subtract_scalar(&self, to_subtract: &Scalar) -> VortexResult<ArrayData> {
@@ -81,7 +81,7 @@ mod test {
 
     use crate::array::primitive::PrimitiveArray;
     use crate::compute::unary::subtract_scalar;
-    use crate::{IntoArrayData, IntoArrayVariant};
+    use crate::{ArrayLen, IntoArrayData, IntoArrayVariant};
 
     #[test]
     fn test_scalar_subtract_unsigned() {

--- a/vortex-array/src/array/primitive/mod.rs
+++ b/vortex-array/src/array/primitive/mod.rs
@@ -20,7 +20,8 @@ use crate::stats::StatsSet;
 use crate::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use crate::variants::{ArrayVariants, PrimitiveArrayTrait};
 use crate::{
-    impl_encoding, ArrayDType, ArrayData, ArrayTrait, Canonical, IntoArrayData, IntoCanonical,
+    impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, Canonical, IntoArrayData,
+    IntoCanonical,
 };
 
 mod accessor;

--- a/vortex-array/src/array/sparse/canonical.rs
+++ b/vortex-array/src/array/sparse/canonical.rs
@@ -8,7 +8,7 @@ use crate::array::sparse::SparseArray;
 use crate::array::BoolArray;
 use crate::validity::Validity;
 use crate::variants::PrimitiveArrayTrait;
-use crate::{ArrayDType, Canonical, IntoArrayVariant, IntoCanonical};
+use crate::{ArrayDType, ArrayLen, Canonical, IntoArrayVariant, IntoCanonical};
 
 impl IntoCanonical for SparseArray {
     fn into_canonical(self) -> VortexResult<Canonical> {

--- a/vortex-array/src/array/sparse/compute/mod.rs
+++ b/vortex-array/src/array/sparse/compute/mod.rs
@@ -126,7 +126,7 @@ mod test {
         filter, search_sorted, slice, FilterMask, SearchResult, SearchSortedSide,
     };
     use crate::validity::Validity;
-    use crate::{ArrayData, IntoArrayData, IntoArrayVariant};
+    use crate::{ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
 
     #[fixture]
     fn array() -> ArrayData {

--- a/vortex-array/src/array/sparse/compute/take.rs
+++ b/vortex-array/src/array/sparse/compute/take.rs
@@ -98,7 +98,7 @@ mod test {
     use crate::array::sparse::SparseArray;
     use crate::compute::{take, TakeOptions};
     use crate::validity::Validity;
-    use crate::{ArrayData, IntoArrayData, IntoArrayVariant};
+    use crate::{ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
 
     fn sparse_array() -> ArrayData {
         SparseArray::try_new(

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -13,7 +13,9 @@ use crate::encoding::ids;
 use crate::stats::{ArrayStatistics, ArrayStatisticsCompute, Stat, StatsSet};
 use crate::validity::{ArrayValidity, LogicalValidity};
 use crate::variants::PrimitiveArrayTrait;
-use crate::{impl_encoding, ArrayDType, ArrayData, ArrayTrait, IntoArrayData, IntoArrayVariant};
+use crate::{
+    impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, IntoArrayData, IntoArrayVariant,
+};
 
 mod canonical;
 mod compute;

--- a/vortex-array/src/array/sparse/variants.rs
+++ b/vortex-array/src/array/sparse/variants.rs
@@ -8,7 +8,7 @@ use crate::variants::{
     ArrayVariants, BinaryArrayTrait, BoolArrayTrait, ExtensionArrayTrait, ListArrayTrait,
     NullArrayTrait, PrimitiveArrayTrait, StructArrayTrait, Utf8ArrayTrait,
 };
-use crate::{ArrayDType, ArrayData, IntoArrayData};
+use crate::{ArrayDType, ArrayData, ArrayLen, IntoArrayData};
 
 /// Sparse arrays support all DTypes
 impl ArrayVariants for SparseArray {

--- a/vortex-array/src/array/struct_/mod.rs
+++ b/vortex-array/src/array/struct_/mod.rs
@@ -11,7 +11,8 @@ use crate::stats::{ArrayStatistics, ArrayStatisticsCompute, Stat, StatsSet};
 use crate::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use crate::variants::{ArrayVariants, StructArrayTrait};
 use crate::{
-    impl_encoding, ArrayDType, ArrayData, ArrayTrait, Canonical, IntoArrayData, IntoCanonical,
+    impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, Canonical, IntoArrayData,
+    IntoCanonical,
 };
 
 mod compute;
@@ -218,7 +219,7 @@ mod test {
     use crate::array::BoolArray;
     use crate::validity::Validity;
     use crate::variants::StructArrayTrait;
-    use crate::IntoArrayData;
+    use crate::{ArrayLen, IntoArrayData};
 
     #[test]
     fn test_project() {

--- a/vortex-array/src/array/varbin/array.rs
+++ b/vortex-array/src/array/varbin/array.rs
@@ -3,6 +3,7 @@ use vortex_error::VortexResult;
 use crate::array::varbin::VarBinArray;
 use crate::array::visitor::{AcceptArrayVisitor, ArrayVisitor};
 use crate::validity::{ArrayValidity, LogicalValidity};
+use crate::ArrayLen;
 
 impl ArrayValidity for VarBinArray {
     fn is_valid(&self, index: usize) -> bool {

--- a/vortex-array/src/array/varbin/compute/compare.rs
+++ b/vortex-array/src/array/varbin/compute/compare.rs
@@ -11,7 +11,7 @@ use crate::array::varbin::arrow::{varbin_datum, varbin_to_arrow};
 use crate::array::{ConstantArray, VarBinArray};
 use crate::arrow::FromArrowArray;
 use crate::compute::{MaybeCompareFn, Operator};
-use crate::ArrayData;
+use crate::{ArrayData, ArrayLen};
 
 impl MaybeCompareFn for VarBinArray {
     fn maybe_compare(

--- a/vortex-array/src/array/varbin/mod.rs
+++ b/vortex-array/src/array/varbin/mod.rs
@@ -19,7 +19,7 @@ use crate::encoding::ids;
 use crate::stats::StatsSet;
 use crate::validity::{Validity, ValidityMetadata};
 use crate::variants::PrimitiveArrayTrait;
-use crate::{impl_encoding, ArrayDType, ArrayData, ArrayTrait, IntoArrayVariant};
+use crate::{impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, IntoArrayVariant};
 
 mod accessor;
 mod array;

--- a/vortex-array/src/array/varbin/stats.rs
+++ b/vortex-array/src/array/varbin/stats.rs
@@ -7,7 +7,7 @@ use vortex_error::VortexResult;
 use crate::accessor::ArrayAccessor;
 use crate::array::varbin::{varbin_scalar, VarBinArray};
 use crate::stats::{ArrayStatisticsCompute, Stat, StatsSet};
-use crate::{ArrayDType, ArrayTrait as _};
+use crate::{ArrayDType, ArrayLen, ArrayTrait as _};
 
 impl ArrayStatisticsCompute for VarBinArray {
     fn compute_statistics(&self, stat: Stat) -> VortexResult<StatsSet> {

--- a/vortex-array/src/array/varbinview/compute.rs
+++ b/vortex-array/src/array/varbinview/compute.rs
@@ -21,7 +21,7 @@ use crate::compute::unary::ScalarAtFn;
 use crate::compute::{slice, ArrayCompute, MaybeCompareFn, Operator, SliceFn, TakeFn, TakeOptions};
 use crate::validity::Validity;
 use crate::variants::PrimitiveArrayTrait;
-use crate::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant, IntoCanonical};
+use crate::{ArrayDType, ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant, IntoCanonical};
 
 impl ArrayCompute for VarBinViewArray {
     fn compare(&self, other: &ArrayData, operator: Operator) -> Option<VortexResult<ArrayData>> {
@@ -184,7 +184,7 @@ mod tests {
     use crate::array::varbinview::compute::compare_constant;
     use crate::array::{ConstantArray, PrimitiveArray, VarBinViewArray};
     use crate::compute::{take, Operator, TakeOptions};
-    use crate::{ArrayDType, IntoArrayData, IntoArrayVariant};
+    use crate::{ArrayDType, ArrayLen, IntoArrayData, IntoArrayVariant};
 
     #[test]
     fn basic_test() {

--- a/vortex-array/src/array/varbinview/mod.rs
+++ b/vortex-array/src/array/varbinview/mod.rs
@@ -21,7 +21,8 @@ use crate::stats::StatsSet;
 use crate::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
 use crate::variants::PrimitiveArrayTrait;
 use crate::{
-    impl_encoding, ArrayDType, ArrayData, ArrayTrait, Canonical, IntoArrayVariant, IntoCanonical,
+    impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, Canonical, IntoArrayVariant,
+    IntoCanonical,
 };
 
 mod accessor;
@@ -637,7 +638,7 @@ mod test {
     use crate::array::varbinview::{BinaryView, VarBinViewArray, VIEW_SIZE_BYTES};
     use crate::compute::slice;
     use crate::compute::unary::scalar_at;
-    use crate::{Canonical, IntoArrayData, IntoCanonical};
+    use crate::{ArrayLen, Canonical, IntoArrayData, IntoCanonical};
 
     #[test]
     pub fn varbin_view() {

--- a/vortex-array/src/array/varbinview/stats.rs
+++ b/vortex-array/src/array/varbinview/stats.rs
@@ -4,7 +4,7 @@ use crate::accessor::ArrayAccessor;
 use crate::array::varbin::compute_stats;
 use crate::array::varbinview::VarBinViewArray;
 use crate::stats::{ArrayStatisticsCompute, Stat, StatsSet};
-use crate::{ArrayDType, ArrayTrait as _};
+use crate::{ArrayDType, ArrayLen, ArrayTrait as _};
 
 impl ArrayStatisticsCompute for VarBinViewArray {
     fn compute_statistics(&self, stat: Stat) -> VortexResult<StatsSet> {

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -28,7 +28,7 @@ use crate::compute::unary::try_cast;
 use crate::encoding::ArrayEncoding;
 use crate::validity::ArrayValidity;
 use crate::variants::{PrimitiveArrayTrait, StructArrayTrait};
-use crate::{ArrayDType, ArrayData, IntoArrayData};
+use crate::{ArrayDType, ArrayData, ArrayLen, IntoArrayData};
 
 /// The set of canonical array encodings, also the set of encodings that can be transferred to
 /// Arrow with zero-copy.

--- a/vortex-array/src/compute/compare.rs
+++ b/vortex-array/src/compute/compare.rs
@@ -177,7 +177,7 @@ mod tests {
     use super::*;
     use crate::array::{BoolArray, ConstantArray};
     use crate::validity::Validity;
-    use crate::{IntoArrayData, IntoArrayVariant};
+    use crate::{ArrayLen, IntoArrayData, IntoArrayVariant};
 
     fn to_int_indices(indices_bits: BoolArray) -> Vec<u64> {
         let buffer = indices_bits.boolean_buffer();

--- a/vortex-array/src/macros.rs
+++ b/vortex-array/src/macros.rs
@@ -64,14 +64,6 @@ macro_rules! impl_encoding {
                     &self.metadata
                 }
 
-                pub fn len(&self) -> usize {
-                    self.as_ref().len()
-                }
-
-                pub fn is_empty(&self) -> bool {
-                    self.as_ref().is_empty()
-                }
-
                 #[allow(dead_code)]
                 fn try_from_parts(
                     dtype: vortex_dtype::DType,

--- a/vortex-datafusion/src/memory/exec.rs
+++ b/vortex-datafusion/src/memory/exec.rs
@@ -6,7 +6,7 @@ use datafusion_common::{Result as DFResult, Statistics};
 use datafusion_execution::{SendableRecordBatchStream, TaskContext};
 use datafusion_physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use vortex_array::array::ChunkedArray;
-use vortex_array::ArrayDType;
+use vortex_array::{ArrayDType, ArrayLen};
 use vortex_dtype::field::Field;
 use vortex_error::VortexResult;
 

--- a/vortex-datafusion/src/memory/statistics.rs
+++ b/vortex-datafusion/src/memory/statistics.rs
@@ -3,6 +3,7 @@ use datafusion_common::{ColumnStatistics, Result as DFResult, ScalarValue, Stati
 use itertools::Itertools;
 use vortex_array::array::ChunkedArray;
 use vortex_array::stats::{ArrayStatistics, Stat};
+use vortex_array::ArrayLen;
 use vortex_error::{vortex_err, VortexExpect, VortexResult};
 
 pub fn chunked_array_df_stats(array: &ChunkedArray, projection: &[usize]) -> DFResult<Statistics> {

--- a/vortex-file/src/chunked_reader/take_rows.rs
+++ b/vortex-file/src/chunked_reader/take_rows.rs
@@ -8,7 +8,7 @@ use vortex_array::compute::unary::{subtract_scalar, try_cast};
 use vortex_array::compute::{search_sorted, slice, take, SearchSortedSide, TakeOptions};
 use vortex_array::stats::ArrayStatistics;
 use vortex_array::stream::{ArrayStream, ArrayStreamExt};
-use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
+use vortex_array::{ArrayDType, ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::PType;
 use vortex_error::{vortex_bail, vortex_err, VortexResult};
 use vortex_io::{VortexBufReader, VortexReadAt};
@@ -217,7 +217,7 @@ mod test {
     use futures_executor::block_on;
     use itertools::Itertools;
     use vortex_array::array::{ChunkedArray, PrimitiveArray};
-    use vortex_array::{Context, IntoArrayData, IntoArrayVariant};
+    use vortex_array::{ArrayLen, Context, IntoArrayData, IntoArrayVariant};
     use vortex_buffer::Buffer;
     use vortex_dtype::PType;
     use vortex_error::VortexResult;

--- a/vortex-file/src/read/filtering.rs
+++ b/vortex-file/src/read/filtering.rs
@@ -9,7 +9,7 @@ use vortex_array::array::{BoolArray, ConstantArray};
 use vortex_array::compute::and_kleene;
 use vortex_array::stats::ArrayStatistics;
 use vortex_array::validity::Validity;
-use vortex_array::{ArrayData, IntoArrayData, IntoArrayVariant};
+use vortex_array::{ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::field::Field;
 use vortex_error::{VortexExpect, VortexResult};
 use vortex_expr::{split_conjunction, unbox_any, ExprRef, VortexExpr};

--- a/vortex-file/src/read/layouts/chunked.rs
+++ b/vortex-file/src/read/layouts/chunked.rs
@@ -155,7 +155,7 @@ mod tests {
     use flatbuffers::{root_unchecked, FlatBufferBuilder};
     use futures_util::TryStreamExt;
     use vortex_array::array::{BoolArray, ChunkedArray, PrimitiveArray};
-    use vortex_array::{ArrayDType, IntoArrayData, IntoArrayVariant};
+    use vortex_array::{ArrayDType, ArrayLen, IntoArrayData, IntoArrayVariant};
     use vortex_dtype::{Nullability, PType};
     use vortex_expr::{BinaryExpr, Identity, Literal, Operator};
     use vortex_flatbuffers::{footer, WriteFlatBuffer};

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -8,7 +8,7 @@ use vortex_array::accessor::ArrayAccessor;
 use vortex_array::array::{ChunkedArray, PrimitiveArray, StructArray, VarBinArray};
 use vortex_array::validity::Validity;
 use vortex_array::variants::{PrimitiveArrayTrait, StructArrayTrait};
-use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant, ToArrayData};
+use vortex_array::{ArrayDType, ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant, ToArrayData};
 use vortex_buffer::Buffer;
 use vortex_dtype::field::Field;
 use vortex_dtype::{DType, Nullability, PType, StructDType};

--- a/vortex-file/src/write/metadata_accumulators.rs
+++ b/vortex-file/src/write/metadata_accumulators.rs
@@ -219,6 +219,7 @@ where
 mod tests {
     use vortex_array::array::{BoolArray, ConstantArray, PrimitiveArray};
     use vortex_array::variants::StructArrayTrait;
+    use vortex_array::ArrayLen;
     use vortex_dtype::{Nullability, PType};
     use vortex_scalar::Scalar;
 

--- a/vortex-file/src/write/writer.rs
+++ b/vortex-file/src/write/writer.rs
@@ -5,7 +5,7 @@ use futures::TryStreamExt;
 use vortex_array::array::{ChunkedArray, StructArray};
 use vortex_array::stats::{ArrayStatistics, Stat};
 use vortex_array::stream::ArrayStream;
-use vortex_array::{ArrayDType as _, ArrayData};
+use vortex_array::{ArrayDType as _, ArrayData, ArrayLen};
 use vortex_buffer::io_buf::IoBuf;
 use vortex_dtype::DType;
 use vortex_error::{vortex_bail, vortex_err, VortexExpect as _, VortexResult};

--- a/vortex-sampling-compressor/src/compressors/bitpacked.rs
+++ b/vortex-sampling-compressor/src/compressors/bitpacked.rs
@@ -3,7 +3,7 @@ use vortex_array::array::PrimitiveArray;
 use vortex_array::encoding::EncodingRef;
 use vortex_array::stats::ArrayStatistics;
 use vortex_array::variants::PrimitiveArrayTrait;
-use vortex_array::{ArrayData, IntoArrayData, IntoArrayVariant};
+use vortex_array::{ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
 use vortex_error::{vortex_err, vortex_panic, VortexResult};
 use vortex_fastlanes::{
     bitpack, count_exceptions, find_best_bit_width, find_min_patchless_bit_width, gather_patches,

--- a/vortex-sampling-compressor/src/compressors/sparse.rs
+++ b/vortex-sampling-compressor/src/compressors/sparse.rs
@@ -2,7 +2,7 @@ use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::array::{Sparse, SparseArray, SparseEncoding};
 use vortex_array::encoding::EncodingRef;
 use vortex_array::stats::ArrayStatistics as _;
-use vortex_array::{ArrayData, ArrayDef, IntoArrayData};
+use vortex_array::{ArrayData, ArrayDef, ArrayLen, IntoArrayData};
 use vortex_error::VortexResult;
 
 use crate::compressors::{CompressedArray, CompressionTree, EncodingCompressor};

--- a/vortex-sampling-compressor/src/compressors/struct_.rs
+++ b/vortex-sampling-compressor/src/compressors/struct_.rs
@@ -5,7 +5,7 @@ use vortex_array::compress::compute_precompression_stats;
 use vortex_array::encoding::EncodingRef;
 use vortex_array::stats::ArrayStatistics as _;
 use vortex_array::variants::StructArrayTrait;
-use vortex_array::{ArrayDType, ArrayData, ArrayDef, IntoArrayData};
+use vortex_array::{ArrayDType, ArrayData, ArrayDef, ArrayLen, IntoArrayData};
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 


### PR DESCRIPTION
fix #1381 