### PR TITLE
Search sorted usize

### DIFF
--- a/encodings/fastlanes/src/bitpacking/compute/search_sorted.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/search_sorted.rs
@@ -7,7 +7,8 @@ use itertools::Itertools;
 use num_traits::AsPrimitive;
 use vortex_array::array::SparseArray;
 use vortex_array::compute::{
-    search_sorted_u64, IndexOrd, Len, SearchResult, SearchSorted, SearchSortedFn, SearchSortedSide,
+    search_sorted_usize, IndexOrd, Len, SearchResult, SearchSorted, SearchSortedFn,
+    SearchSortedSide,
 };
 use vortex_array::validity::Validity;
 use vortex_array::variants::PrimitiveArrayTrait;
@@ -25,10 +26,14 @@ impl SearchSortedFn for BitPackedArray {
         })
     }
 
-    fn search_sorted_u64(&self, value: u64, side: SearchSortedSide) -> VortexResult<SearchResult> {
+    fn search_sorted_usize(
+        &self,
+        value: usize,
+        side: SearchSortedSide,
+    ) -> VortexResult<SearchResult> {
         match_each_unsigned_integer_ptype!(self.ptype(), |$P| {
             // NOTE: conversion may truncate silently.
-            if let Some(pvalue) = num_traits::cast::<u64, $P>(value) {
+            if let Some(pvalue) = num_traits::cast::<usize, $P>(value) {
                 search_sorted_native(self, pvalue, side)
             } else {
                 // provided u64 is too large to fit in the provided PType, value must be off
@@ -59,9 +64,9 @@ impl SearchSortedFn for BitPackedArray {
         })
     }
 
-    fn search_sorted_u64_many(
+    fn search_sorted_usize_many(
         &self,
-        values: &[u64],
+        values: &[usize],
         sides: &[SearchSortedSide],
     ) -> VortexResult<Vec<SearchResult>> {
         match_each_unsigned_integer_ptype!(self.ptype(), |$P| {
@@ -111,7 +116,7 @@ where
         // max packed value just search the patches
         let usize_value: usize = value.as_();
         if usize_value > array.max_packed_value() {
-            search_sorted_u64(&patches_array, value.as_(), side)
+            search_sorted_usize(&patches_array, value.as_(), side)
         } else {
             Ok(BitPackedSearch::<'_, T>::new(array).search_sorted(&value, side))
         }

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use vortex_array::array::visitor::{AcceptArrayVisitor, ArrayVisitor};
 use vortex_array::array::PrimitiveArray;
 use vortex_array::compute::unary::scalar_at;
-use vortex_array::compute::{search_sorted, search_sorted_u64_many, SearchSortedSide};
+use vortex_array::compute::{search_sorted, search_sorted_usize_many, SearchSortedSide};
 use vortex_array::encoding::ids;
 use vortex_array::stats::{ArrayStatistics, ArrayStatisticsCompute, Stat, StatsSet};
 use vortex_array::validity::{ArrayValidity, LogicalValidity, Validity, ValidityMetadata};
@@ -122,8 +122,8 @@ impl RunEndArray {
     /// [Self::find_physical_index]
     ///
     /// See: [find_physical_index][Self::find_physical_index].
-    pub fn find_physical_indices(&self, indices: &[u64]) -> VortexResult<Vec<usize>> {
-        search_sorted_u64_many(
+    pub fn find_physical_indices(&self, indices: &[usize]) -> VortexResult<Vec<usize>> {
+        search_sorted_usize_many(
             &self.ends(),
             indices,
             &vec![SearchSortedSide::Right; indices.len()],

--- a/encodings/runend/src/compute.rs
+++ b/encodings/runend/src/compute.rs
@@ -83,7 +83,7 @@ impl TakeFn<RunEndArray> for RunEndEncoding {
         options: TakeOptions,
     ) -> VortexResult<ArrayData> {
         let primitive_indices = indices.clone().into_primitive()?;
-        let u64_indices = match_each_integer_ptype!(primitive_indices.ptype(), |$P| {
+        let usize_indices = match_each_integer_ptype!(primitive_indices.ptype(), |$P| {
             primitive_indices
                 .into_maybe_null_slice::<$P>()
                 .into_iter()
@@ -93,12 +93,12 @@ impl TakeFn<RunEndArray> for RunEndEncoding {
                         vortex_error::vortex_bail!(OutOfBounds: usize_idx, 0, array.len());
                     }
 
-                    Ok((usize_idx + array.offset()) as u64)
+                    Ok(usize_idx + array.offset())
                 })
-                .collect::<VortexResult<Vec<u64>>>()?
+                .collect::<VortexResult<Vec<usize>>>()?
         });
         let physical_indices = array
-            .find_physical_indices(&u64_indices)?
+            .find_physical_indices(&usize_indices)?
             .into_iter()
             .map(|idx| idx as u64)
             .collect::<Vec<_>>();

--- a/vortex-array/src/array/primitive/compute/search_sorted.rs
+++ b/vortex-array/src/array/primitive/compute/search_sorted.rs
@@ -29,9 +29,13 @@ impl SearchSortedFn for PrimitiveArray {
     }
 
     #[allow(clippy::cognitive_complexity)]
-    fn search_sorted_u64(&self, value: u64, side: SearchSortedSide) -> VortexResult<SearchResult> {
+    fn search_sorted_usize(
+        &self,
+        value: usize,
+        side: SearchSortedSide,
+    ) -> VortexResult<SearchResult> {
         match_each_native_ptype!(self.ptype(), |$T| {
-            if let Some(pvalue) = num_traits::cast::<u64, $T>(value) {
+            if let Some(pvalue) = num_traits::cast::<usize, $T>(value) {
                 match self.validity() {
                     Validity::NonNullable | Validity::AllValid => {
                         // null-free search


### PR DESCRIPTION
It's a small difference, but we tend to use u64 to refer specifically to meaningful u64 data, whereas usize is for generic unsigned integers outside the data domain.