### PR TITLE
chore: introduce not_prunable

### DIFF
--- a/vortex-file/src/pruning.rs
+++ b/vortex-file/src/pruning.rs
@@ -312,9 +312,7 @@ mod tests {
     use vortex_array::aliases::hash_set::HashSet;
     use vortex_array::stats::Stat;
     use vortex_dtype::field::Field;
-    use vortex_dtype::Nullability;
     use vortex_expr::{BinaryExpr, Column, Literal, Not, Operator};
-    use vortex_scalar::Scalar;
 
     use crate::pruning::{convert_to_pruning_expression, stat_column_name, PruningPredicate};
 
@@ -539,22 +537,6 @@ mod tests {
             Column::new_expr(Field::from("b")),
         ));
         assert!(PruningPredicate::try_new(&or_expr).is_none());
-    }
-
-    #[test]
-    fn self_refernece_is_not_prunable_and_has_no_references() {
-        // If we had arithmetic this would be less contrived
-        let expr = Not::new_expr(BinaryExpr::new_expr(
-            Column::new_expr(Field::from("a")),
-            Operator::Lte,
-            Column::new_expr(Field::from("a")),
-        ));
-        let predicate = PruningPredicate::try_new(&expr).unwrap();
-        assert!(predicate.required_stats().is_empty());
-
-        let actual = predicate.expr();
-        let expected = Literal::new_expr(Scalar::bool(false, Nullability::NonNullable));
-        assert_eq!(*actual.clone(), *expected.as_any());
     }
 
     #[test]

--- a/vortex-file/src/pruning.rs
+++ b/vortex-file/src/pruning.rs
@@ -106,6 +106,13 @@ impl PruningPredicate {
     }
 }
 
+fn not_prunable() -> PruningPredicateStats {
+    (
+        Literal::new_expr(Scalar::bool(false, Nullability::NonNullable)),
+        Relation::new(),
+    )
+}
+
 // Anything that can't be translated has to be represented as
 // boolean true expression, i.e. the value might be in that chunk
 fn convert_to_pruning_expression(expr: &ExprRef) -> PruningPredicateStats {
@@ -133,12 +140,7 @@ fn convert_to_pruning_expression(expr: &ExprRef) -> PruningPredicateStats {
         if let Some(col) = bexp.lhs().as_any().downcast_ref::<Column>() {
             return PruningPredicateRewriter::try_new(col.field().clone(), bexp.op(), bexp.rhs())
                 .and_then(PruningPredicateRewriter::rewrite)
-                .unwrap_or_else(|| {
-                    (
-                        Literal::new_expr(Scalar::bool(false, Nullability::NonNullable)),
-                        Relation::new(),
-                    )
-                });
+                .unwrap_or_else(not_prunable);
         };
 
         if let Some(col) = bexp.rhs().as_any().downcast_ref::<Column>() {
@@ -148,38 +150,29 @@ fn convert_to_pruning_expression(expr: &ExprRef) -> PruningPredicateStats {
                 bexp.lhs(),
             )
             .and_then(PruningPredicateRewriter::rewrite)
-            .unwrap_or_else(|| {
-                (
-                    Literal::new_expr(Scalar::bool(false, Nullability::NonNullable)),
-                    Relation::new(),
-                )
-            });
-        };
+            .unwrap_or_else(not_prunable);
+        }
     }
 
-    (
-        Literal::new_expr(Scalar::bool(false, Nullability::NonNullable)),
-        Relation::new(),
-    )
+    not_prunable()
 }
 
 fn convert_column_reference(expr: &ExprRef, invert: bool) -> PruningPredicateStats {
     let mut refs = Relation::new();
-    let min_expr = replace_column_with_stat(expr, Stat::Min, &mut refs);
-    let max_expr = replace_column_with_stat(expr, Stat::Max, &mut refs);
-    (
-        min_expr
-            .zip(max_expr)
-            .map(|(min_exp, max_exp)| {
-                if invert {
-                    BinaryExpr::new_expr(min_exp, Operator::And, max_exp)
-                } else {
-                    Not::new_expr(BinaryExpr::new_expr(min_exp, Operator::Or, max_exp))
-                }
-            })
-            .unwrap_or_else(|| Literal::new_expr(Scalar::bool(false, Nullability::NonNullable))),
-        refs,
-    )
+    let Some(min_expr) = replace_column_with_stat(expr, Stat::Min, &mut refs) else {
+        return not_prunable();
+    };
+    let Some(max_expr) = replace_column_with_stat(expr, Stat::Max, &mut refs) else {
+        return not_prunable();
+    };
+
+    let expr = if invert {
+        BinaryExpr::new_expr(min_expr, Operator::And, max_expr)
+    } else {
+        Not::new_expr(BinaryExpr::new_expr(min_expr, Operator::Or, max_expr))
+    };
+
+    (expr, refs)
 }
 
 struct PruningPredicateRewriter<'a> {
@@ -319,7 +312,9 @@ mod tests {
     use vortex_array::aliases::hash_set::HashSet;
     use vortex_array::stats::Stat;
     use vortex_dtype::field::Field;
+    use vortex_dtype::Nullability;
     use vortex_expr::{BinaryExpr, Column, Literal, Not, Operator};
+    use vortex_scalar::Scalar;
 
     use crate::pruning::{convert_to_pruning_expression, stat_column_name, PruningPredicate};
 
@@ -544,6 +539,22 @@ mod tests {
             Column::new_expr(Field::from("b")),
         ));
         assert!(PruningPredicate::try_new(&or_expr).is_none());
+    }
+
+    #[test]
+    fn self_refernece_is_not_prunable_and_has_no_references() {
+        // If we had arithmetic this would be less contrived
+        let expr = Not::new_expr(BinaryExpr::new_expr(
+            Column::new_expr(Field::from("a")),
+            Operator::Lte,
+            Column::new_expr(Field::from("a")),
+        ));
+        let predicate = PruningPredicate::try_new(&expr).unwrap();
+        assert!(predicate.required_stats().is_empty());
+
+        let actual = predicate.expr();
+        let expected = Literal::new_expr(Scalar::bool(false, Nullability::NonNullable));
+        assert_eq!(*actual.clone(), *expected.as_any());
     }
 
     #[test]


### PR DESCRIPTION
The test actually passes on develop. I am not sure if I can trigger the bad behavior on develop but it seems wrong to use the possibly mutated refs.