### PR TITLE
feat: RowFilter is a valid pruning predicate

### DIFF
--- a/vortex-file/src/pruning.rs
+++ b/vortex-file/src/pruning.rs
@@ -13,6 +13,8 @@ use vortex_dtype::Nullability;
 use vortex_expr::{BinaryExpr, Column, ExprRef, Literal, Not, Operator};
 use vortex_scalar::Scalar;
 
+use crate::RowFilter;
+
 #[derive(Debug, Clone)]
 pub struct Relation<K, V> {
     map: HashMap<K, HashSet<V>>,
@@ -34,6 +36,17 @@ impl<K: Hash + Eq, V: Hash + Eq> Relation<K, V> {
     pub fn new() -> Self {
         Relation {
             map: HashMap::new(),
+        }
+    }
+
+    pub fn union(mut iter: impl Iterator<Item = Relation<K, V>>) -> Relation<K, V> {
+        if let Some(mut x) = iter.next() {
+            for y in iter {
+                x.extend(y)
+            }
+            x
+        } else {
+            Relation::new()
         }
     }
 
@@ -155,6 +168,21 @@ fn convert_to_pruning_expression(expr: &ExprRef) -> PruningPredicateStats {
                 )
             });
         };
+    }
+
+    if let Some(RowFilter { conjunction }) = expr.as_any().downcast_ref::<RowFilter>() {
+        let (rewritten_conjunction, refses): (Vec<ExprRef>, Vec<Relation<Field, Stat>>) =
+            conjunction
+                .iter()
+                .map(convert_to_pruning_expression)
+                .unzip();
+
+        let refs = Relation::union(refses.into_iter());
+
+        return (
+            RowFilter::from_conjunction_expr(rewritten_conjunction),
+            refs,
+        );
     }
 
     (

--- a/vortex-file/src/read/filtering.rs
+++ b/vortex-file/src/read/filtering.rs
@@ -18,7 +18,7 @@ use crate::read::expr_project::expr_project;
 
 #[derive(Debug, Clone)]
 pub struct RowFilter {
-    conjunction: Vec<ExprRef>,
+    pub(crate) conjunction: Vec<ExprRef>,
 }
 
 impl RowFilter {
@@ -35,6 +35,11 @@ impl RowFilter {
     pub fn from_conjunction(conjunction: Vec<ExprRef>) -> Self {
         assert!(!conjunction.is_empty());
         Self { conjunction }
+    }
+
+    /// Create a new row filter from a conjunction. The conjunction **must** have length > 0.
+    pub fn from_conjunction_expr(conjunction: Vec<ExprRef>) -> Arc<Self> {
+        Arc::new(Self::from_conjunction(conjunction))
     }
 
     pub fn only_fields(&self, fields: &[Field]) -> Option<Self> {


### PR DESCRIPTION
The appearance of `union` makes me think this whole file needs to be cleaned up. These functions should probably all live on the rewriter who can accumulate all the references. I figure we can clean this up at some later point.