### PR TITLE
fix: allocate aligned buffers for VortexReadAt impls

### DIFF
--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -140,8 +140,6 @@ mod dtype_reader;
 
 pub use dtype_reader::*;
 
-pub const ALIGNMENT: usize = 64;
-
 mod read;
 mod write;
 

--- a/vortex-io/Cargo.toml
+++ b/vortex-io/Cargo.toml
@@ -16,7 +16,7 @@ categories.workspace = true
 [dependencies]
 bytes = { workspace = true }
 compio = { workspace = true, features = ["bytes", "macros"], optional = true }
-tokio = { workspace = true, features = ["fs"], optional = true }
+tokio = { workspace = true, features = ["fs", "io-util", "rt"], optional = true }
 tracing = { workspace = true, optional = true }
 futures = { workspace = true, features = ["std"] }
 futures-util = { workspace = true }

--- a/vortex-io/src/aligned.rs
+++ b/vortex-io/src/aligned.rs
@@ -73,6 +73,12 @@ where
     ///
     /// Failure to do so could cause uninitialized memory to be readable.
     pub unsafe fn set_len(&mut self, len: usize) {
+        assert!(
+            len <= self.capacity,
+            "set_len call out of bounds: {} > {}",
+            len,
+            self.capacity
+        );
         unsafe { self.buf.set_len(len + self.padding) }
     }
 

--- a/vortex-io/src/aligned.rs
+++ b/vortex-io/src/aligned.rs
@@ -1,0 +1,161 @@
+#![allow(dead_code)]
+use std::ops::{Deref, DerefMut};
+
+use bytes::Bytes;
+
+pub trait PowerOfTwo<const N: usize> {}
+impl<const N: usize> PowerOfTwo<N> for usize where usize: sealed::Sealed<N> {}
+
+mod sealed {
+    pub trait Sealed<const N: usize> {}
+
+    impl Sealed<1> for usize {}
+    impl Sealed<2> for usize {}
+    impl Sealed<4> for usize {}
+    impl Sealed<8> for usize {}
+    impl Sealed<16> for usize {}
+    impl Sealed<32> for usize {}
+    impl Sealed<64> for usize {}
+    impl Sealed<128> for usize {}
+    impl Sealed<256> for usize {}
+    impl Sealed<512> for usize {}
+}
+
+/// A variant of [`BytesMut`][bytes::BytesMut] that freezes into a [`Bytes`] that is guaranteed
+/// to begin at a multiple of a target byte-alignment.
+///
+/// Internally, it accomplishes this by over-allocating by up to the alignment size, padding the
+/// front as necessary. Reads and writes will only be able to access the region after the padding.
+///
+/// It is required for the alignment to be a valid power of 2 <= 512, any other value will be
+/// a compile-time failure.
+pub(crate) struct AlignedBytesMut<const ALIGN: usize> {
+    buf: Vec<u8>,
+    padding: usize,
+    capacity: usize,
+}
+
+impl<const ALIGN: usize> AlignedBytesMut<ALIGN>
+where
+    usize: PowerOfTwo<ALIGN>,
+{
+    /// Allocate a new mutable buffer with capacity to hold at least `capacity` bytes.
+    ///
+    /// The mutable buffer may allocate more than  the requested amount to pad the memory for
+    /// alignment.
+    pub fn with_capacity(capacity: usize) -> Self {
+        // Allocate up to `ALIGN` extra bytes, in case we need to pad the returned pointer.
+        let allocation_size = (capacity + ALIGN - 1).next_multiple_of(ALIGN);
+        let mut buf = Vec::<u8>::with_capacity(allocation_size);
+        let padding = buf.as_ptr().align_offset(ALIGN);
+        unsafe {
+            buf.set_len(padding);
+        }
+
+        Self {
+            buf,
+            padding,
+            capacity,
+        }
+    }
+
+    /// Usable capacity of this buffer.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Set the length of the mutable buffer directly.
+    ///
+    /// # Safety
+    ///
+    /// The caller is responsible for ensuring that the provided length fits within the original
+    /// capacity request.
+    ///
+    /// Failure to do so could cause uninitialized memory to be readable.
+    pub unsafe fn set_len(&mut self, len: usize) {
+        unsafe { self.buf.set_len(len + self.padding) }
+    }
+
+    /// Extend this mutable buffer with the contents of the provided slice.
+    pub fn extend_from_slice(&mut self, slice: &[u8]) {
+        // The internal `buf` is padded, so appends will land after the padded region.
+        self.buf.extend_from_slice(slice)
+    }
+
+    /// Freeze the existing allocation into a readonly [`Bytes`], guaranteed to be aligned to
+    /// the target [`ALIGN`] size.
+    pub fn freeze(self) -> Bytes {
+        // bytes_unaligned will contain the entire allocation, so that on Drop the entire buf
+        // is freed.
+        //
+        // bytes_aligned is a sliced view on top of bytes_unaligned.
+        //
+        // bytes_aligned
+        //     | parent    \  *ptr
+        //     v            |
+        // bytes_unaligned  |
+        //     |            |
+        //     | *ptr       |
+        //     v            v
+        //     +------------+------------------+----------------+
+        //     | padding    |   content        | spare capacity |
+        //     +------------+------------------+----------------+
+        let bytes_unaligned = Bytes::from(self.buf);
+        let bytes_aligned = bytes_unaligned.slice(self.padding..);
+
+        assert_eq!(
+            bytes_aligned.as_ptr().align_offset(ALIGN),
+            0,
+            "bytes_aligned must be aligned to {}",
+            ALIGN
+        );
+
+        bytes_aligned
+    }
+}
+
+impl<const ALIGN: usize> Deref for AlignedBytesMut<ALIGN>
+where
+    usize: PowerOfTwo<ALIGN>,
+{
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.buf[self.padding..]
+    }
+}
+
+impl<const ALIGN: usize> DerefMut for AlignedBytesMut<ALIGN>
+where
+    usize: PowerOfTwo<ALIGN>,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.buf[self.padding..]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::aligned::AlignedBytesMut;
+
+    #[test]
+    fn test_align() {
+        let mut buf = AlignedBytesMut::<128>::with_capacity(1);
+        buf.extend_from_slice(b"a");
+
+        let data = buf.freeze();
+
+        assert_eq!(data.as_ref(), b"a");
+        assert_eq!(data.as_ptr().align_offset(128), 0);
+    }
+
+    #[test]
+    fn test_extend() {
+        let mut buf = AlignedBytesMut::<128>::with_capacity(256);
+        buf.extend_from_slice(b"a");
+        buf.extend_from_slice(b"bcdefgh");
+
+        let data = buf.freeze();
+        assert_eq!(data.as_ref(), b"abcdefgh");
+    }
+}

--- a/vortex-io/src/compio.rs
+++ b/vortex-io/src/compio.rs
@@ -1,13 +1,56 @@
 use std::future::Future;
 use std::io;
 
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
+use compio::buf::{IoBuf, IoBufMut, SetBufInit};
 use compio::fs::File;
 use compio::io::AsyncReadAtExt;
 use compio::BufResult;
 use vortex_error::vortex_panic;
 
-use super::VortexReadAt;
+use crate::aligned::{AlignedBytesMut, PowerOfTwo};
+use crate::{VortexReadAt, ALIGNMENT};
+
+unsafe impl<const ALIGN: usize> IoBuf for AlignedBytesMut<ALIGN>
+where
+    usize: PowerOfTwo<ALIGN>,
+{
+    fn as_buf_ptr(&self) -> *const u8 {
+        self.as_ptr()
+    }
+
+    fn buf_len(&self) -> usize {
+        self.len()
+    }
+
+    fn buf_capacity(&self) -> usize {
+        self.capacity()
+    }
+}
+
+impl<const ALIGN: usize> SetBufInit for AlignedBytesMut<ALIGN>
+where
+    usize: PowerOfTwo<ALIGN>,
+{
+    unsafe fn set_buf_init(&mut self, len: usize) {
+        // The contract of this trait specifies that providing a `len` <= the current len should
+        // do nothing. AlignedBytesMut by default will set the len directly without checking this.
+        if self.len() < len {
+            unsafe {
+                self.set_len(len);
+            }
+        }
+    }
+}
+
+unsafe impl<const ALIGN: usize> IoBufMut for AlignedBytesMut<ALIGN>
+where
+    usize: PowerOfTwo<ALIGN>,
+{
+    fn as_buf_mut_ptr(&mut self) -> *mut u8 {
+        self.as_mut_ptr()
+    }
+}
 
 impl VortexReadAt for File {
     fn read_byte_range(
@@ -16,10 +59,7 @@ impl VortexReadAt for File {
         len: u64,
     ) -> impl Future<Output = io::Result<Bytes>> + 'static {
         let this = self.clone();
-        let mut buffer = BytesMut::with_capacity(len as usize);
-        unsafe {
-            buffer.set_len(len as usize);
-        }
+        let buffer = AlignedBytesMut::<ALIGNMENT>::with_capacity(len as usize);
         async move {
             // Turn the buffer into a static slice.
             let BufResult(res, buffer) = this.read_exact_at(buffer, pos).await;

--- a/vortex-io/src/dispatcher/mod.rs
+++ b/vortex-io/src/dispatcher/mod.rs
@@ -67,17 +67,18 @@ enum Inner {
 }
 
 impl Dispatch for IoDispatcher {
+    #[allow(unused_variables)]
     fn dispatch<F, Fut, R>(&self, task: F) -> VortexResult<oneshot::Receiver<R>>
     where
         F: (FnOnce() -> Fut) + Send + 'static,
         Fut: Future<Output = R> + 'static,
         R: Send + 'static,
     {
-        match &self.0 {
+        match self.0 {
             #[cfg(feature = "tokio")]
-            Inner::Tokio(tokio_dispatch) => tokio_dispatch.dispatch(task),
+            Inner::Tokio(ref tokio_dispatch) => tokio_dispatch.dispatch(task),
             #[cfg(feature = "compio")]
-            Inner::Compio(compio_dispatch) => compio_dispatch.dispatch(task),
+            Inner::Compio(ref compio_dispatch) => compio_dispatch.dispatch(task),
         }
     }
 

--- a/vortex-io/src/lib.rs
+++ b/vortex-io/src/lib.rs
@@ -27,3 +27,6 @@ mod read;
 #[cfg(feature = "tokio")]
 mod tokio;
 mod write;
+
+/// Required alignment for all custom buffer allocations.
+pub const BUFFER_ALIGNMENT: usize = 64;

--- a/vortex-io/src/lib.rs
+++ b/vortex-io/src/lib.rs
@@ -16,6 +16,7 @@ pub use read::*;
 pub use tokio::*;
 pub use write::*;
 
+mod aligned;
 mod buf;
 #[cfg(feature = "compio")]
 mod compio;
@@ -29,4 +30,4 @@ mod tokio;
 mod write;
 
 /// Required alignment for all custom buffer allocations.
-pub const BUFFER_ALIGNMENT: usize = 64;
+pub const ALIGNMENT: usize = 64;

--- a/vortex-io/src/object_store.rs
+++ b/vortex-io/src/object_store.rs
@@ -11,7 +11,8 @@ use vortex_buffer::io_buf::IoBuf;
 use vortex_buffer::Buffer;
 use vortex_error::{vortex_panic, VortexError, VortexResult};
 
-use crate::{VortexBufReader, VortexReadAt, VortexWrite, BUFFER_ALIGNMENT};
+use crate::aligned::AlignedBytesMut;
+use crate::{VortexBufReader, VortexReadAt, VortexWrite, ALIGNMENT};
 
 pub trait ObjectStoreExt {
     fn vortex_read(
@@ -78,17 +79,9 @@ impl VortexReadAt for ObjectStoreReadAt {
         Box::pin(async move {
             let start_range = pos as usize;
 
-            // Allocate a Vec<u8> that has at least BUFFER_ALIGNMENT-1 bytes of extra capacity.
-            // This is important as it allows us to return a properly aligned Bytes to the caller,
-            // without needing to write a custom Allocator.
-            let alloc_size =
-                ((len as usize) + (BUFFER_ALIGNMENT - 1)).next_multiple_of(BUFFER_ALIGNMENT);
-            let mut buf = Vec::<u8>::with_capacity(alloc_size as _);
-            let padding = buf.as_ptr().align_offset(BUFFER_ALIGNMENT);
-            unsafe { buf.set_len(padding) };
+            let mut buf = AlignedBytesMut::<ALIGNMENT>::with_capacity(len as _);
 
             let get_range = start_range..(start_range + len as usize);
-
             let response = object_store
                 .get_opts(
                     &location,
@@ -105,31 +98,7 @@ impl VortexReadAt for ObjectStoreReadAt {
                 buf.extend_from_slice(&bytes);
             }
 
-            // bytes_unaligned will contain the entire allocation, so that on Drop the entire buf
-            // is freed.
-            //
-            // bytes_aligned is a sliced view on top of bytes_unaligned.
-            //
-            // bytes_aligned
-            //     | parent    \  *ptr
-            //     v            |
-            // bytes_unaligned  |
-            //     |            |
-            //     | *ptr       |
-            //     v            v
-            //     +------------+------------------+----------------+
-            //     | padding    |   content        | spare capacity |
-            //     +------------+------------------+----------------+
-            //
-            let bytes_unaligned = Bytes::from(buf);
-            let bytes_aligned = bytes_unaligned.slice(padding..);
-
-            assert_eq!(
-                bytes_aligned.as_ptr().align_offset(BUFFER_ALIGNMENT),
-                0,
-                "buffer must be 64-byte aligned"
-            );
-            Ok(bytes_aligned)
+            Ok(buf.freeze())
         })
     }
 

--- a/vortex-io/src/object_store.rs
+++ b/vortex-io/src/object_store.rs
@@ -4,13 +4,14 @@ use std::sync::Arc;
 use std::{io, mem};
 
 use bytes::Bytes;
+use futures_util::StreamExt;
 use object_store::path::Path;
-use object_store::{ObjectStore, WriteMultipart};
+use object_store::{GetOptions, GetRange, ObjectStore, WriteMultipart};
 use vortex_buffer::io_buf::IoBuf;
 use vortex_buffer::Buffer;
 use vortex_error::{vortex_panic, VortexError, VortexResult};
 
-use crate::{VortexBufReader, VortexReadAt, VortexWrite};
+use crate::{VortexBufReader, VortexReadAt, VortexWrite, BUFFER_ALIGNMENT};
 
 pub trait ObjectStoreExt {
     fn vortex_read(
@@ -76,10 +77,59 @@ impl VortexReadAt for ObjectStoreReadAt {
 
         Box::pin(async move {
             let start_range = pos as usize;
-            let bytes = object_store
-                .get_range(&location, start_range..(start_range + len as usize))
+
+            // Allocate a Vec<u8> that has at least BUFFER_ALIGNMENT-1 bytes of extra capacity.
+            // This is important as it allows us to return a properly aligned Bytes to the caller,
+            // without needing to write a custom Allocator.
+            let alloc_size =
+                ((len as usize) + (BUFFER_ALIGNMENT - 1)).next_multiple_of(BUFFER_ALIGNMENT);
+            let mut buf = Vec::<u8>::with_capacity(alloc_size as _);
+            let padding = buf.as_ptr().align_offset(BUFFER_ALIGNMENT);
+            unsafe { buf.set_len(padding) };
+
+            let get_range = start_range..(start_range + len as usize);
+
+            let response = object_store
+                .get_opts(
+                    &location,
+                    GetOptions {
+                        range: Some(GetRange::Bounded(get_range)),
+                        ..Default::default()
+                    },
+                )
                 .await?;
-            Ok(bytes)
+
+            let mut byte_stream = response.into_stream();
+            while let Some(bytes) = byte_stream.next().await {
+                let bytes = bytes?;
+                buf.extend_from_slice(&bytes);
+            }
+
+            // bytes_unaligned will contain the entire allocation, so that on Drop the entire buf
+            // is freed.
+            //
+            // bytes_aligned is a sliced view on top of bytes_unaligned.
+            //
+            // bytes_aligned
+            //     | parent    \  *ptr
+            //     v            |
+            // bytes_unaligned  |
+            //     |            |
+            //     | *ptr       |
+            //     v            v
+            //     +------------+------------------+----------------+
+            //     | padding    |   content        | spare capacity |
+            //     +------------+------------------+----------------+
+            //
+            let bytes_unaligned = Bytes::from(buf);
+            let bytes_aligned = bytes_unaligned.slice(padding..);
+
+            assert_eq!(
+                bytes_aligned.as_ptr().align_offset(BUFFER_ALIGNMENT),
+                0,
+                "buffer must be 64-byte aligned"
+            );
+            Ok(bytes_aligned)
         })
     }
 

--- a/vortex-io/src/tokio.rs
+++ b/vortex-io/src/tokio.rs
@@ -6,13 +6,13 @@ use std::os::unix::fs::FileExt;
 use std::path::Path;
 use std::sync::Arc;
 
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use vortex_buffer::io_buf::IoBuf;
 use vortex_error::vortex_panic;
 
-use super::VortexReadAt;
-use crate::VortexWrite;
+use crate::aligned::AlignedBytesMut;
+use crate::{VortexReadAt, VortexWrite, ALIGNMENT};
 
 pub struct TokioAdapter<IO>(pub IO);
 
@@ -70,7 +70,7 @@ impl VortexReadAt for TokioFile {
     ) -> impl Future<Output = io::Result<Bytes>> + 'static {
         let this = self.clone();
 
-        let mut buffer = BytesMut::with_capacity(len as usize);
+        let mut buffer = AlignedBytesMut::<ALIGNMENT>::with_capacity(len as usize);
         unsafe {
             buffer.set_len(len as usize);
         }


### PR DESCRIPTION
Before this change, we did not enforce alignment on memory we allocate with `Bytes`, so for example, you could get this:

<img width="1506" alt="image" src="https://github.com/user-attachments/assets/403d04d3-c0d6-4cd1-93fd-37f2468e6a2a">

The solution this PR chooses is to round our allocation up to the alignment size, and then apply padding manually.

Then you get happy output like

<img width="1335" alt="image" src="https://github.com/user-attachments/assets/7621549c-28e7-46ae-8a83-1f8098810704">
