### PR TITLE
feature: split computations of stats for VarBin & VarBinView

### DIFF
--- a/vortex-array/src/array/varbin/mod.rs
+++ b/vortex-array/src/array/varbin/mod.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Display};
 
 use num_traits::AsPrimitive;
 use serde::{Deserialize, Serialize};
-pub use stats::compute_stats;
+pub use stats::compute_varbin_statistics;
 use vortex_buffer::Buffer;
 use vortex_dtype::{match_each_native_ptype, DType, NativePType, Nullability, PType};
 use vortex_error::{

--- a/vortex-array/src/array/varbin/stats.rs
+++ b/vortex-array/src/array/varbin/stats.rs
@@ -1,8 +1,10 @@
 use std::cmp::Ordering;
 
 use itertools::{Itertools, MinMaxResult};
+use vortex_buffer::Buffer;
 use vortex_error::{vortex_panic, VortexResult};
 
+use super::varbin_scalar;
 use crate::accessor::ArrayAccessor;
 use crate::array::varbin::VarBinArray;
 use crate::array::VarBinEncoding;
@@ -104,48 +106,38 @@ fn compute_is_constant(iter: &mut dyn Iterator<Item = Option<&[u8]>>) -> bool {
 fn compute_min_max<T: ArrayTrait + ArrayAccessor<[u8]>>(array: &T) -> VortexResult<StatsSet> {
     let mut stats = StatsSet::default();
 
-    let minmaxpos = array.with_iterator(|iter| iter.flatten().position_minmax())?;
-    let (min_idx, min_scalar, max_idx, max_scalar) = match minmaxpos {
+    let (min, max) = array.with_iterator(|iter| match iter.flatten().minmax() {
         MinMaxResult::NoElements => {
             vortex_panic!(
                 "Unreachable: already checked that array has at least one non-null element"
             );
         }
-        MinMaxResult::OneElement(idx) => {
-            let scalar = scalar_at(array, idx)?;
-            (idx, scalar.clone(), idx, scalar)
+        MinMaxResult::OneElement(value) => {
+            let scalar = varbin_scalar(Buffer::from(value), array.dtype());
+            (scalar.clone(), scalar)
         }
-        MinMaxResult::MinMax(min_idx, max_idx) => (
-            min_idx,
-            scalar_at(array, min_idx)?,
-            max_idx,
-            scalar_at(array, max_idx)?,
+        MinMaxResult::MinMax(min, max) => (
+            varbin_scalar(Buffer::from(min), array.dtype()),
+            varbin_scalar(Buffer::from(max), array.dtype()),
         ),
-    };
+    })?;
 
-    // get (don't compute) null count if `min == max` to determine if it's constant
-    let min_eq_max = min_scalar == max_scalar;
-    if min_eq_max
-        && array
+    if min == max {
+        // get (don't compute) null count if `min == max` to determine if it's constant
+        if array
             .statistics()
             .get_as::<u64>(Stat::NullCount)
             .map_or(false, |null_count| null_count == 0)
-    {
-        // if there are no nulls, then the array is constant
-        return Ok(StatsSet::constant(min_scalar, array.len()));
-    }
-    if !min_eq_max {
+        {
+            // if there are no nulls, then the array is constant
+            return Ok(StatsSet::constant(min, array.len()));
+        }
+    } else {
         stats.set(Stat::IsConstant, false);
     }
 
-    stats.set(Stat::Min, min_scalar);
-    stats.set(Stat::Max, max_scalar);
-
-    // if max comes before min, then it's not sorted
-    if max_idx < min_idx {
-        stats.set(Stat::IsSorted, false);
-        stats.set(Stat::IsStrictSorted, false);
-    }
+    stats.set(Stat::Min, min);
+    stats.set(Stat::Max, max);
 
     Ok(stats)
 }

--- a/vortex-array/src/array/varbin/stats.rs
+++ b/vortex-array/src/array/varbin/stats.rs
@@ -34,32 +34,27 @@ pub fn compute_varbin_statistics<T: ArrayTrait + ArrayAccessor<[u8]>>(
     }
 
     Ok(match stat {
-        Stat::IsConstant | Stat::NullCount => {
+        Stat::NullCount => {
             let null_count = array.logical_validity().null_count(array.len())?;
             if null_count == array.len() {
                 return Ok(StatsSet::nulls(array.len(), array.dtype()));
             }
 
             let mut stats = StatsSet::of(Stat::NullCount, null_count);
-            if stat == Stat::NullCount {
-                return Ok(stats);
-            }
-
-            let is_constant = if null_count > 0 {
+            if null_count > 0 {
                 // we know that there is at least one null, but not all nulls, so it's not constant
-                false
-            } else {
-                array.with_iterator(|iter| compute_is_constant(&mut iter.flatten()))?
-            };
-
-            if is_constant {
-                // this array is all-valid and not empty
-                let value = scalar_at(array, 0)?;
-                stats.extend(StatsSet::constant(value, array.len()));
-            } else {
-                stats.set(Stat::IsConstant, is_constant);
+                stats.set(Stat::IsConstant, false);
             }
             stats
+        }
+        Stat::IsConstant => {
+            let is_constant = array.with_iterator(compute_is_constant)?;
+            if is_constant {
+                // we know that the array is not empty
+                StatsSet::constant(scalar_at(array, 0)?, array.len())
+            } else {
+                StatsSet::of(Stat::IsConstant, is_constant)
+            }
         }
         Stat::Min | Stat::Max => compute_min_max(array)?,
         Stat::IsSorted => {
@@ -94,9 +89,9 @@ pub fn compute_varbin_statistics<T: ArrayTrait + ArrayAccessor<[u8]>>(
     })
 }
 
-fn compute_is_constant(iter: &mut dyn Iterator<Item = &[u8]>) -> bool {
+fn compute_is_constant(iter: &mut dyn Iterator<Item = Option<&[u8]>>) -> bool {
     let Some(first_value) = iter.next() else {
-        return true;
+        return true; // empty array is constant
     };
     for v in iter {
         if v != first_value {

--- a/vortex-array/src/array/varbin/stats.rs
+++ b/vortex-array/src/array/varbin/stats.rs
@@ -1,14 +1,12 @@
 use std::cmp::Ordering;
 
 use itertools::{Itertools, MinMaxResult};
-use vortex_buffer::Buffer;
-use vortex_dtype::DType;
 use vortex_error::{vortex_panic, VortexResult};
-use vortex_scalar::Scalar;
 
 use crate::accessor::ArrayAccessor;
-use crate::array::varbin::{varbin_scalar, VarBinArray};
+use crate::array::varbin::VarBinArray;
 use crate::array::VarBinEncoding;
+use crate::compute::unary::scalar_at;
 use crate::stats::{Stat, StatisticsVTable, StatsSet};
 use crate::ArrayTrait;
 
@@ -53,20 +51,17 @@ pub fn compute_varbin_statistics<T: ArrayTrait + ArrayAccessor<[u8]>>(
             } else {
                 array.with_iterator(|iter| compute_is_constant(&mut iter.flatten()))?
             };
-            stats.set(Stat::IsConstant, is_constant);
+
+            if is_constant {
+                // this array is all-valid and not empty
+                let value = scalar_at(array, 0)?;
+                stats.extend(StatsSet::constant(value, array.len()));
+            } else {
+                stats.set(Stat::IsConstant, is_constant);
+            }
             stats
         }
-        Stat::Min | Stat::Max => {
-            // handle min and max in the same loop
-            let Some((min, max)) =
-                array.with_iterator(|iter| compute_min_max(&mut iter.flatten(), array.dtype()))?
-            else {
-                vortex_panic!(
-                    "Unreachable: already checked that array has at least one non-null element"
-                );
-            };
-            StatsSet::from_iter([(Stat::Min, min), (Stat::Max, max)])
-        }
+        Stat::Min | Stat::Max => compute_min_max(array)?,
         Stat::IsSorted => {
             let is_sorted = array.with_iterator(|iter| iter.flatten().is_sorted())?;
             let mut stats = StatsSet::of(Stat::IsSorted, is_sorted);
@@ -111,21 +106,53 @@ fn compute_is_constant(iter: &mut dyn Iterator<Item = &[u8]>) -> bool {
     true
 }
 
-fn compute_min_max(
-    iter: &mut dyn Iterator<Item = &[u8]>,
-    dtype: &DType,
-) -> Option<(Scalar, Scalar)> {
-    Some(match iter.minmax() {
-        MinMaxResult::NoElements => return None,
-        MinMaxResult::OneElement(v) => {
-            let scalar = varbin_scalar(Buffer::from(v), dtype);
-            (scalar.clone(), scalar)
+fn compute_min_max<T: ArrayTrait + ArrayAccessor<[u8]>>(array: &T) -> VortexResult<StatsSet> {
+    let mut stats = StatsSet::default();
+
+    let minmaxpos = array.with_iterator(|iter| iter.flatten().position_minmax())?;
+    let (min_idx, min_scalar, max_idx, max_scalar) = match minmaxpos {
+        MinMaxResult::NoElements => {
+            vortex_panic!(
+                "Unreachable: already checked that array has at least one non-null element"
+            );
         }
-        MinMaxResult::MinMax(min, max) => (
-            varbin_scalar(Buffer::from(min), dtype),
-            varbin_scalar(Buffer::from(max), dtype),
+        MinMaxResult::OneElement(idx) => {
+            let scalar = scalar_at(array, idx)?;
+            (idx, scalar.clone(), idx, scalar)
+        }
+        MinMaxResult::MinMax(min_idx, max_idx) => (
+            min_idx,
+            scalar_at(array, min_idx)?,
+            max_idx,
+            scalar_at(array, max_idx)?,
         ),
-    })
+    };
+
+    // get (don't compute) null count if `min == max` to determine if it's constant
+    let min_eq_max = min_scalar == max_scalar;
+    if min_eq_max
+        && array
+            .statistics()
+            .get_as::<u64>(Stat::NullCount)
+            .map_or(false, |null_count| null_count == 0)
+    {
+        // if there are no nulls, then the array is constant
+        return Ok(StatsSet::constant(min_scalar, array.len()));
+    }
+    if !min_eq_max {
+        stats.set(Stat::IsConstant, false);
+    }
+
+    stats.set(Stat::Min, min_scalar);
+    stats.set(Stat::Max, max_scalar);
+
+    // if max comes before min, then it's not sorted
+    if max_idx < min_idx {
+        stats.set(Stat::IsSorted, false);
+        stats.set(Stat::IsStrictSorted, false);
+    }
+
+    Ok(stats)
 }
 
 #[cfg(test)]

--- a/vortex-array/src/array/varbin/stats.rs
+++ b/vortex-array/src/array/varbin/stats.rs
@@ -1,8 +1,10 @@
 use std::cmp::Ordering;
 
+use itertools::{Itertools, MinMaxResult};
 use vortex_buffer::Buffer;
 use vortex_dtype::DType;
-use vortex_error::VortexResult;
+use vortex_error::{vortex_panic, VortexExpect, VortexResult};
+use vortex_scalar::Scalar;
 
 use crate::accessor::ArrayAccessor;
 use crate::array::varbin::{varbin_scalar, VarBinArray};
@@ -17,11 +19,107 @@ impl StatisticsVTable<VarBinArray> for VarBinEncoding {
             return Ok(StatsSet::of(stat, array.nbytes()));
         }
 
-        if array.is_empty() {
+        if array.is_empty()
+            || stat == Stat::TrueCount
+            || stat == Stat::BitWidthFreq
+            || stat == Stat::TrailingZeroFreq
+        {
             return Ok(StatsSet::default());
         }
-        array.with_iterator(|iter| compute_stats(iter, array.dtype()))
+
+        let null_count = array.validity().null_count(array.len())?;
+        if null_count == array.len() {
+            return Ok(StatsSet::nulls(array.len(), array.dtype()));
+        } else if stat == Stat::NullCount {
+            return Ok(StatsSet::of(Stat::NullCount, null_count));
+        }
+
+        let mut stats = StatsSet::of(Stat::NullCount, null_count);
+        match stat {
+            Stat::IsConstant => {
+                let is_constant = if null_count > 0 {
+                    // we know that there is at least one null, but not all nulls, so it's not constant
+                    false
+                } else {
+                    array.with_iterator(|iter| compute_is_constant(&mut iter.flatten()))?
+                };
+                stats.set(Stat::IsConstant, is_constant);
+            }
+            Stat::Min | Stat::Max => {
+                // handle min and max in the same loop
+                let Some((min, max)) = array
+                    .with_iterator(|iter| compute_min_max(&mut iter.flatten(), array.dtype()))?
+                else {
+                    vortex_panic!(
+                        "Unreachable: already checked that array has at least one non-null element"
+                    );
+                };
+                stats.set(Stat::Min, min);
+                stats.set(Stat::Max, max);
+            }
+            Stat::IsSorted => {
+                let is_sorted = array.with_iterator(|iter| iter.flatten().is_sorted())?;
+                stats.set(Stat::IsSorted, is_sorted);
+                if !is_sorted {
+                    stats.set(Stat::IsStrictSorted, false);
+                }
+            }
+            Stat::IsStrictSorted => {
+                let is_strict_sorted = array.with_iterator(|iter| {
+                    iter.flatten()
+                        .is_sorted_by(|a, b| matches!(a.cmp(b), Ordering::Less))
+                })?;
+                stats.set(Stat::IsStrictSorted, is_strict_sorted);
+                if is_strict_sorted {
+                    stats.set(Stat::IsSorted, true);
+                }
+            }
+            Stat::RunCount => {
+                // needs its own full pass
+            }
+            Stat::UncompressedSizeInBytes
+            | Stat::TrueCount
+            | Stat::NullCount
+            | Stat::BitWidthFreq
+            | Stat::TrailingZeroFreq => {
+                vortex_panic!(
+                    "Unreachable, stat {} should have already been handled",
+                    stat
+                )
+            }
+        }
+        Ok(stats)
     }
+}
+
+fn compute_is_constant(iter: &mut dyn Iterator<Item = &[u8]>) -> bool {
+    let Some(first_value) = iter.next() else {
+        return true;
+    };
+    let first_value = first_value;
+    for v in iter {
+        if v != first_value {
+            return false;
+        }
+    }
+    true
+}
+
+fn compute_min_max(
+    iter: &mut dyn Iterator<Item = &[u8]>,
+    dtype: &DType,
+) -> Option<(Scalar, Scalar)> {
+    Some(match iter.minmax() {
+        MinMaxResult::NoElements => return None,
+        MinMaxResult::OneElement(v) => {
+            let scalar = varbin_scalar(Buffer::from(v), dtype);
+            (scalar.clone(), scalar)
+        }
+        MinMaxResult::MinMax(min, max) => (
+            varbin_scalar(Buffer::from(min), dtype),
+            varbin_scalar(Buffer::from(max), dtype),
+        ),
+    })
 }
 
 pub fn compute_stats(iter: &mut dyn Iterator<Item = Option<&[u8]>>, dtype: &DType) -> StatsSet {

--- a/vortex-array/src/array/varbin/stats.rs
+++ b/vortex-array/src/array/varbin/stats.rs
@@ -156,7 +156,6 @@ mod test {
             arr.statistics().compute_max::<BufferString>().unwrap(),
             BufferString::from("hello world this is a long string".to_string())
         );
-        assert_eq!(arr.statistics().compute_run_count().unwrap(), 2);
         assert!(!arr.statistics().compute_is_constant().unwrap());
         assert!(arr.statistics().compute_is_sorted().unwrap());
     }
@@ -172,7 +171,6 @@ mod test {
             arr.statistics().compute_max::<Buffer>().unwrap().deref(),
             "hello world this is a long string".as_bytes()
         );
-        assert_eq!(arr.statistics().compute_run_count().unwrap(), 2);
         assert!(!arr.statistics().compute_is_constant().unwrap());
         assert!(arr.statistics().compute_is_sorted().unwrap());
     }

--- a/vortex-array/src/array/varbin/stats.rs
+++ b/vortex-array/src/array/varbin/stats.rs
@@ -105,22 +105,25 @@ fn compute_is_constant(iter: &mut dyn Iterator<Item = Option<&[u8]>>) -> bool {
 
 fn compute_min_max<T: ArrayTrait + ArrayAccessor<[u8]>>(array: &T) -> VortexResult<StatsSet> {
     let mut stats = StatsSet::default();
+    if array.is_empty() {
+        return Ok(stats);
+    }
 
-    let (min, max) = array.with_iterator(|iter| match iter.flatten().minmax() {
-        MinMaxResult::NoElements => {
-            vortex_panic!(
-                "Unreachable: already checked that array has at least one non-null element"
-            );
-        }
+    let minmax = array.with_iterator(|iter| match iter.flatten().minmax() {
+        MinMaxResult::NoElements => None,
         MinMaxResult::OneElement(value) => {
             let scalar = varbin_scalar(Buffer::from(value), array.dtype());
-            (scalar.clone(), scalar)
+            Some((scalar.clone(), scalar))
         }
-        MinMaxResult::MinMax(min, max) => (
+        MinMaxResult::MinMax(min, max) => Some((
             varbin_scalar(Buffer::from(min), array.dtype()),
             varbin_scalar(Buffer::from(max), array.dtype()),
-        ),
+        )),
     })?;
+    let Some((min, max)) = minmax else {
+        // we know that the array is not empty, so it must be all nulls
+        return Ok(StatsSet::nulls(array.len(), array.dtype()));
+    };
 
     if min == max {
         // get (don't compute) null count if `min == max` to determine if it's constant

--- a/vortex-array/src/array/varbin/stats.rs
+++ b/vortex-array/src/array/varbin/stats.rs
@@ -9,88 +9,94 @@ use vortex_scalar::Scalar;
 use crate::accessor::ArrayAccessor;
 use crate::array::varbin::{varbin_scalar, VarBinArray};
 use crate::array::VarBinEncoding;
-use crate::nbytes::ArrayNBytes;
 use crate::stats::{Stat, StatisticsVTable, StatsSet};
-use crate::{ArrayDType, ArrayLen};
+use crate::ArrayTrait;
 
 impl StatisticsVTable<VarBinArray> for VarBinEncoding {
     fn compute_statistics(&self, array: &VarBinArray, stat: Stat) -> VortexResult<StatsSet> {
-        if stat == Stat::UncompressedSizeInBytes {
-            return Ok(StatsSet::of(stat, array.nbytes()));
-        }
-
-        if array.is_empty()
-            || stat == Stat::TrueCount
-            || stat == Stat::RunCount
-            || stat == Stat::BitWidthFreq
-            || stat == Stat::TrailingZeroFreq
-        {
-            return Ok(StatsSet::default());
-        }
-
-        Ok(match stat {
-            Stat::IsConstant | Stat::NullCount => {
-                let null_count = array.validity().null_count(array.len())?;
-                if null_count == array.len() {
-                    return Ok(StatsSet::nulls(array.len(), array.dtype()));
-                }
-
-                let mut stats = StatsSet::of(Stat::NullCount, null_count);
-                if stat == Stat::NullCount {
-                    return Ok(stats);
-                }
-
-                let is_constant = if null_count > 0 {
-                    // we know that there is at least one null, but not all nulls, so it's not constant
-                    false
-                } else {
-                    array.with_iterator(|iter| compute_is_constant(&mut iter.flatten()))?
-                };
-                stats.set(Stat::IsConstant, is_constant);
-                stats
-            }
-            Stat::Min | Stat::Max => {
-                // handle min and max in the same loop
-                let Some((min, max)) = array
-                    .with_iterator(|iter| compute_min_max(&mut iter.flatten(), array.dtype()))?
-                else {
-                    vortex_panic!(
-                        "Unreachable: already checked that array has at least one non-null element"
-                    );
-                };
-                StatsSet::from_iter([(Stat::Min, min), (Stat::Max, max)])
-            }
-            Stat::IsSorted => {
-                let is_sorted = array.with_iterator(|iter| iter.flatten().is_sorted())?;
-                let mut stats = StatsSet::of(Stat::IsSorted, is_sorted);
-                if !is_sorted {
-                    stats.set(Stat::IsStrictSorted, false);
-                }
-                stats
-            }
-            Stat::IsStrictSorted => {
-                let is_strict_sorted = array.with_iterator(|iter| {
-                    iter.flatten()
-                        .is_sorted_by(|a, b| matches!(a.cmp(b), Ordering::Less))
-                })?;
-                let mut stats = StatsSet::of(Stat::IsStrictSorted, is_strict_sorted);
-                if is_strict_sorted {
-                    stats.set(Stat::IsSorted, true);
-                }
-                stats
-            }
-            Stat::UncompressedSizeInBytes
-            | Stat::TrueCount
-            | Stat::RunCount
-            | Stat::BitWidthFreq
-            | Stat::TrailingZeroFreq => {
-                vortex_panic!(
-                    "Unreachable, stat {} should have already been handled",
-                    stat
-                )
-            }
-        })
+        compute_varbin_statistics(array, stat)
     }
+}
+
+pub fn compute_varbin_statistics<T: ArrayTrait + ArrayAccessor<[u8]>>(
+    array: &T,
+    stat: Stat,
+) -> VortexResult<StatsSet> {
+    if stat == Stat::UncompressedSizeInBytes {
+        return Ok(StatsSet::of(stat, array.nbytes()));
+    }
+
+    if array.is_empty()
+        || stat == Stat::TrueCount
+        || stat == Stat::RunCount
+        || stat == Stat::BitWidthFreq
+        || stat == Stat::TrailingZeroFreq
+    {
+        return Ok(StatsSet::default());
+    }
+
+    Ok(match stat {
+        Stat::IsConstant | Stat::NullCount => {
+            let null_count = array.logical_validity().null_count(array.len())?;
+            if null_count == array.len() {
+                return Ok(StatsSet::nulls(array.len(), array.dtype()));
+            }
+
+            let mut stats = StatsSet::of(Stat::NullCount, null_count);
+            if stat == Stat::NullCount {
+                return Ok(stats);
+            }
+
+            let is_constant = if null_count > 0 {
+                // we know that there is at least one null, but not all nulls, so it's not constant
+                false
+            } else {
+                array.with_iterator(|iter| compute_is_constant(&mut iter.flatten()))?
+            };
+            stats.set(Stat::IsConstant, is_constant);
+            stats
+        }
+        Stat::Min | Stat::Max => {
+            // handle min and max in the same loop
+            let Some((min, max)) =
+                array.with_iterator(|iter| compute_min_max(&mut iter.flatten(), array.dtype()))?
+            else {
+                vortex_panic!(
+                    "Unreachable: already checked that array has at least one non-null element"
+                );
+            };
+            StatsSet::from_iter([(Stat::Min, min), (Stat::Max, max)])
+        }
+        Stat::IsSorted => {
+            let is_sorted = array.with_iterator(|iter| iter.flatten().is_sorted())?;
+            let mut stats = StatsSet::of(Stat::IsSorted, is_sorted);
+            if !is_sorted {
+                stats.set(Stat::IsStrictSorted, false);
+            }
+            stats
+        }
+        Stat::IsStrictSorted => {
+            let is_strict_sorted = array.with_iterator(|iter| {
+                iter.flatten()
+                    .is_sorted_by(|a, b| matches!(a.cmp(b), Ordering::Less))
+            })?;
+            let mut stats = StatsSet::of(Stat::IsStrictSorted, is_strict_sorted);
+            if is_strict_sorted {
+                stats.set(Stat::IsSorted, true);
+            }
+            stats
+        }
+        Stat::UncompressedSizeInBytes
+        | Stat::TrueCount
+        | Stat::RunCount
+        | Stat::BitWidthFreq
+        | Stat::TrailingZeroFreq => {
+            vortex_panic!(
+                "Unreachable, stat {} should have already been handled",
+                stat
+            )
+        }
+    })
 }
 
 fn compute_is_constant(iter: &mut dyn Iterator<Item = &[u8]>) -> bool {
@@ -120,108 +126,6 @@ fn compute_min_max(
             varbin_scalar(Buffer::from(max), dtype),
         ),
     })
-}
-
-pub fn compute_stats(iter: &mut dyn Iterator<Item = Option<&[u8]>>, dtype: &DType) -> StatsSet {
-    let mut leading_nulls: usize = 0;
-    let mut first_value: Option<&[u8]> = None;
-    for v in &mut *iter {
-        if v.is_none() {
-            leading_nulls += 1;
-        } else {
-            first_value = v;
-            break;
-        }
-    }
-
-    if let Some(first_non_null) = first_value {
-        let mut acc = VarBinAccumulator::new(first_non_null);
-        acc.n_nulls(leading_nulls);
-        iter.for_each(|n| acc.nullable_next(n));
-        acc.finish(dtype)
-    } else {
-        StatsSet::nulls(leading_nulls, dtype)
-    }
-}
-
-pub struct VarBinAccumulator<'a> {
-    min: &'a [u8],
-    max: &'a [u8],
-    is_sorted: bool,
-    is_strict_sorted: bool,
-    last_value: &'a [u8],
-    null_count: usize,
-    runs: usize,
-    len: usize,
-}
-
-impl<'a> VarBinAccumulator<'a> {
-    pub fn new(value: &'a [u8]) -> Self {
-        Self {
-            min: value,
-            max: value,
-            is_sorted: true,
-            is_strict_sorted: true,
-            last_value: value,
-            runs: 1,
-            null_count: 0,
-            len: 1,
-        }
-    }
-
-    pub fn nullable_next(&mut self, val: Option<&'a [u8]>) {
-        match val {
-            None => {
-                self.null_count += 1;
-                self.len += 1;
-            }
-            Some(v) => self.next(v),
-        }
-    }
-
-    pub fn n_nulls(&mut self, null_count: usize) {
-        self.len += null_count;
-        self.null_count += null_count;
-    }
-
-    pub fn next(&mut self, val: &'a [u8]) {
-        self.len += 1;
-
-        if val < self.min {
-            self.min.clone_from(&val);
-        } else if val > self.max {
-            self.max.clone_from(&val);
-        }
-
-        match val.cmp(self.last_value) {
-            Ordering::Less => {
-                self.is_sorted = false;
-                self.is_strict_sorted = false;
-            }
-            Ordering::Equal => {
-                self.is_strict_sorted = false;
-                return;
-            }
-            Ordering::Greater => {}
-        }
-        self.last_value = val;
-        self.runs += 1;
-    }
-
-    pub fn finish(&self, dtype: &DType) -> StatsSet {
-        let is_constant =
-            (self.min == self.max && self.null_count == 0) || self.null_count == self.len;
-
-        StatsSet::from_iter([
-            (Stat::Min, varbin_scalar(Buffer::from(self.min), dtype)),
-            (Stat::Max, varbin_scalar(Buffer::from(self.max), dtype)),
-            (Stat::RunCount, self.runs.into()),
-            (Stat::IsSorted, self.is_sorted.into()),
-            (Stat::IsStrictSorted, self.is_strict_sorted.into()),
-            (Stat::IsConstant, is_constant.into()),
-            (Stat::NullCount, self.null_count.into()),
-        ])
-    }
 }
 
 #[cfg(test)]

--- a/vortex-array/src/array/varbin/stats.rs
+++ b/vortex-array/src/array/varbin/stats.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 use itertools::{Itertools, MinMaxResult};
 use vortex_buffer::Buffer;
 use vortex_dtype::DType;
-use vortex_error::{vortex_panic, VortexExpect, VortexResult};
+use vortex_error::{vortex_panic, VortexResult};
 use vortex_scalar::Scalar;
 
 use crate::accessor::ArrayAccessor;
@@ -21,22 +21,25 @@ impl StatisticsVTable<VarBinArray> for VarBinEncoding {
 
         if array.is_empty()
             || stat == Stat::TrueCount
+            || stat == Stat::RunCount
             || stat == Stat::BitWidthFreq
             || stat == Stat::TrailingZeroFreq
         {
             return Ok(StatsSet::default());
         }
 
-        let null_count = array.validity().null_count(array.len())?;
-        if null_count == array.len() {
-            return Ok(StatsSet::nulls(array.len(), array.dtype()));
-        } else if stat == Stat::NullCount {
-            return Ok(StatsSet::of(Stat::NullCount, null_count));
-        }
+        Ok(match stat {
+            Stat::IsConstant | Stat::NullCount => {
+                let null_count = array.validity().null_count(array.len())?;
+                if null_count == array.len() {
+                    return Ok(StatsSet::nulls(array.len(), array.dtype()));
+                }
 
-        let mut stats = StatsSet::of(Stat::NullCount, null_count);
-        match stat {
-            Stat::IsConstant => {
+                let mut stats = StatsSet::of(Stat::NullCount, null_count);
+                if stat == Stat::NullCount {
+                    return Ok(stats);
+                }
+
                 let is_constant = if null_count > 0 {
                     // we know that there is at least one null, but not all nulls, so it's not constant
                     false
@@ -44,6 +47,7 @@ impl StatisticsVTable<VarBinArray> for VarBinEncoding {
                     array.with_iterator(|iter| compute_is_constant(&mut iter.flatten()))?
                 };
                 stats.set(Stat::IsConstant, is_constant);
+                stats
             }
             Stat::Min | Stat::Max => {
                 // handle min and max in the same loop
@@ -54,32 +58,30 @@ impl StatisticsVTable<VarBinArray> for VarBinEncoding {
                         "Unreachable: already checked that array has at least one non-null element"
                     );
                 };
-                stats.set(Stat::Min, min);
-                stats.set(Stat::Max, max);
+                StatsSet::from_iter([(Stat::Min, min), (Stat::Max, max)])
             }
             Stat::IsSorted => {
                 let is_sorted = array.with_iterator(|iter| iter.flatten().is_sorted())?;
-                stats.set(Stat::IsSorted, is_sorted);
+                let mut stats = StatsSet::of(Stat::IsSorted, is_sorted);
                 if !is_sorted {
                     stats.set(Stat::IsStrictSorted, false);
                 }
+                stats
             }
             Stat::IsStrictSorted => {
                 let is_strict_sorted = array.with_iterator(|iter| {
                     iter.flatten()
                         .is_sorted_by(|a, b| matches!(a.cmp(b), Ordering::Less))
                 })?;
-                stats.set(Stat::IsStrictSorted, is_strict_sorted);
+                let mut stats = StatsSet::of(Stat::IsStrictSorted, is_strict_sorted);
                 if is_strict_sorted {
                     stats.set(Stat::IsSorted, true);
                 }
-            }
-            Stat::RunCount => {
-                // needs its own full pass
+                stats
             }
             Stat::UncompressedSizeInBytes
             | Stat::TrueCount
-            | Stat::NullCount
+            | Stat::RunCount
             | Stat::BitWidthFreq
             | Stat::TrailingZeroFreq => {
                 vortex_panic!(
@@ -87,8 +89,7 @@ impl StatisticsVTable<VarBinArray> for VarBinEncoding {
                     stat
                 )
             }
-        }
-        Ok(stats)
+        })
     }
 }
 
@@ -96,7 +97,6 @@ fn compute_is_constant(iter: &mut dyn Iterator<Item = &[u8]>) -> bool {
     let Some(first_value) = iter.next() else {
         return true;
     };
-    let first_value = first_value;
     for v in iter {
         if v != first_value {
             return false;

--- a/vortex-array/src/array/varbinview/stats.rs
+++ b/vortex-array/src/array/varbinview/stats.rs
@@ -1,23 +1,12 @@
 use vortex_error::VortexResult;
 
-use crate::accessor::ArrayAccessor;
-use crate::array::varbin::compute_stats;
+use crate::array::varbin::compute_varbin_statistics;
 use crate::array::varbinview::VarBinViewArray;
 use crate::array::VarBinViewEncoding;
-use crate::nbytes::ArrayNBytes;
 use crate::stats::{Stat, StatisticsVTable, StatsSet};
-use crate::{ArrayDType, ArrayLen};
 
 impl StatisticsVTable<VarBinViewArray> for VarBinViewEncoding {
     fn compute_statistics(&self, array: &VarBinViewArray, stat: Stat) -> VortexResult<StatsSet> {
-        if stat == Stat::UncompressedSizeInBytes {
-            return Ok(StatsSet::of(stat, array.nbytes()));
-        }
-
-        if array.is_empty() {
-            return Ok(StatsSet::default());
-        }
-
-        array.with_iterator(|iter| compute_stats(iter, array.dtype()))
+        compute_varbin_statistics(array, stat)
     }
 }

--- a/vortex-array/src/stats/mod.rs
+++ b/vortex-array/src/stats/mod.rs
@@ -31,9 +31,9 @@ pub enum Stat {
     /// Whether all values are the same (nulls are not equal to other non-null values,
     /// so this is true iff all values are null or all values are the same non-null value)
     IsConstant,
-    /// Whether the array is sorted
+    /// Whether the non-null values in the array are sorted (i.e., we skip nulls)
     IsSorted,
-    /// Whether the array is strictly sorted (i.e., sorted with no duplicates)
+    /// Whether the non-null values in the array are strictly sorted (i.e., sorted with no duplicates)
     IsStrictSorted,
     /// The maximum value in the array (ignoring nulls, unless all values are null)
     Max,

--- a/vortex-array/src/stats/statsset.rs
+++ b/vortex-array/src/stats/statsset.rs
@@ -339,8 +339,7 @@ impl FromIterator<(Stat, Scalar)> for StatsSet {
 impl Extend<(Stat, Scalar)> for StatsSet {
     #[inline]
     fn extend<T: IntoIterator<Item = (Stat, Scalar)>>(&mut self, iter: T) {
-        let stats = iter.into_iter().collect_vec();
-        stats.into_iter().for_each(|(stat, scalar)| {
+        iter.into_iter().for_each(|(stat, scalar)| {
             self.set(stat, scalar);
         });
     }

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -438,6 +438,27 @@ impl LogicalValidity {
             Self::Array(a) => Validity::Array(a),
         }
     }
+
+    pub fn null_count(&self, length: usize) -> VortexResult<usize> {
+        match self {
+            Self::AllValid(_) => Ok(0),
+            Self::AllInvalid(_) => Ok(length),
+            Self::Array(a) => {
+                let validity_len = a.len();
+                if validity_len != length {
+                    vortex_bail!(
+                        "Validity array length {} doesn't match array length {}",
+                        validity_len,
+                        length
+                    )
+                }
+                let true_count = a.statistics().compute_true_count().ok_or_else(|| {
+                    vortex_err!("Failed to compute true count from validity array")
+                })?;
+                Ok(length - true_count)
+            }
+        }
+    }
 }
 
 impl TryFrom<ArrayData> for LogicalValidity {

--- a/vortex-sampling-compressor/src/compressors/fsst.rs
+++ b/vortex-sampling-compressor/src/compressors/fsst.rs
@@ -102,7 +102,7 @@ impl EncodingCompressor for FSSTCompressor {
 
         let codes = fsst_array.codes();
         let compressed_codes = ctx
-            .named("fsst_codes")
+            .auxiliary("fsst_codes")
             .excluding(self)
             .including_only(&[
                 &VarBinCompressor,


### PR DESCRIPTION
fixes #1308 

Compute only the asked-for stat (and any that are free, e.g., it's not strict sorted if it's not sorted) instead of computing all stats always