### PR TITLE
feat: make ScalarValue opaque

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5078,7 +5078,6 @@ dependencies = [
  "datafusion-common",
  "flatbuffers",
  "flexbuffers",
- "half",
  "itertools 0.13.0",
  "num-traits",
  "paste",

--- a/bench-vortex/src/bin/notimplemented.rs
+++ b/bench-vortex/src/bin/notimplemented.rs
@@ -137,7 +137,7 @@ fn enc_impls() -> Vec<ArrayData> {
             PrimitiveArray::from(vec![5u64, 8]).into_array(),
             PrimitiveArray::from_vec(vec![3u32, 6], Validity::AllValid).into_array(),
             10,
-            Scalar::null(DType::Primitive(PType::U32, Nullability::Nullable)),
+            Scalar::null_typed::<u32>(),
         )
         .unwrap()
         .into_array(),

--- a/bench-vortex/src/bin/notimplemented.rs
+++ b/bench-vortex/src/bin/notimplemented.rs
@@ -20,7 +20,7 @@ use vortex::fsst::{fsst_compress, fsst_train_compressor};
 use vortex::roaring::{Bitmap, RoaringBoolArray, RoaringIntArray};
 use vortex::runend::RunEndArray;
 use vortex::runend_bool::RunEndBoolArray;
-use vortex::scalar::ScalarValue;
+use vortex::scalar::Scalar;
 use vortex::validity::Validity;
 use vortex::zigzag::ZigZagArray;
 use vortex::{ArrayData, IntoArrayData};
@@ -137,7 +137,7 @@ fn enc_impls() -> Vec<ArrayData> {
             PrimitiveArray::from(vec![5u64, 8]).into_array(),
             PrimitiveArray::from_vec(vec![3u32, 6], Validity::AllValid).into_array(),
             10,
-            ScalarValue::Null,
+            Scalar::null(DType::Primitive(PType::U32, Nullability::Nullable)),
         )
         .unwrap()
         .into_array(),

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -2,9 +2,9 @@ use vortex_array::array::{PrimitiveArray, SparseArray};
 use vortex_array::validity::Validity;
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
-use vortex_dtype::{DType, NativePType, Nullability, PType};
+use vortex_dtype::{NativePType, PType};
 use vortex_error::{vortex_bail, VortexExpect as _, VortexResult};
-use vortex_scalar::Scalar;
+use vortex_scalar::{Scalar, ScalarType};
 
 use crate::alp::{ALPArray, ALPFloat};
 use crate::Exponents;
@@ -31,6 +31,7 @@ pub fn alp_encode_components<T>(
 where
     T: ALPFloat + NativePType,
     T::ALPInt: NativePType,
+    T: ScalarType,
 {
     let (exponents, encoded, exc_pos, exc) = T::encode(values.maybe_null_slice::<T>(), exponents);
     let len = encoded.len();
@@ -42,7 +43,7 @@ where
                 PrimitiveArray::from(exc_pos).into_array(),
                 PrimitiveArray::from_vec(exc, Validity::AllValid).into_array(),
                 len,
-                Scalar::null(DType::Primitive(T::PTYPE, Nullability::Nullable)),
+                Scalar::null_typed::<T>(),
             )
             .vortex_expect("Failed to create SparseArray for ALP patches")
             .into_array()

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -2,9 +2,9 @@ use vortex_array::array::{PrimitiveArray, SparseArray};
 use vortex_array::validity::Validity;
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
-use vortex_dtype::{NativePType, PType};
+use vortex_dtype::{DType, NativePType, Nullability, PType};
 use vortex_error::{vortex_bail, VortexExpect as _, VortexResult};
-use vortex_scalar::ScalarValue;
+use vortex_scalar::Scalar;
 
 use crate::alp::{ALPArray, ALPFloat};
 use crate::Exponents;
@@ -42,7 +42,7 @@ where
                 PrimitiveArray::from(exc_pos).into_array(),
                 PrimitiveArray::from_vec(exc, Validity::AllValid).into_array(),
                 len,
-                ScalarValue::Null,
+                Scalar::null(DType::Primitive(T::PTYPE, Nullability::Nullable)),
             )
             .vortex_expect("Failed to create SparseArray for ALP patches")
             .into_array()

--- a/encodings/alp/src/alp/compute/compare.rs
+++ b/encodings/alp/src/alp/compute/compare.rs
@@ -2,7 +2,7 @@ use vortex_array::array::ConstantArray;
 use vortex_array::compute::{compare, CompareFn, Operator};
 use vortex_array::{ArrayData, ArrayLen, IntoArrayData};
 use vortex_dtype::Nullability;
-use vortex_error::{VortexExpect as _, VortexResult};
+use vortex_error::VortexResult;
 use vortex_scalar::{PrimitiveScalar, Scalar};
 
 use crate::{match_each_alp_float_ptype, ALPArray, ALPEncoding, ALPFloat};
@@ -18,8 +18,12 @@ impl CompareFn<ALPArray> for ALPEncoding {
             let pscalar = PrimitiveScalar::try_from(&const_scalar)?;
 
             match_each_alp_float_ptype!(pscalar.ptype(), |$T| {
-                let value: $T = pscalar.typed_value().vortex_expect("must be non null");
-                return alp_scalar_compare(lhs, value, operator).map(Some);
+                match pscalar.typed_value::<$T>() {
+                    Some(value) => return alp_scalar_compare(lhs, value, operator).map(Some),
+                    None => return Ok(Some(ConstantArray::new(
+                        Scalar::bool(false, Nullability::Nullable), lhs.len()
+                    ).into_array())),
+                }
             });
         }
 

--- a/encodings/alp/src/alp/compute/compare.rs
+++ b/encodings/alp/src/alp/compute/compare.rs
@@ -3,9 +3,9 @@ use vortex_array::compute::{compare, CompareFn, Operator};
 use vortex_array::{ArrayData, ArrayLen, IntoArrayData};
 use vortex_dtype::Nullability;
 use vortex_error::VortexResult;
-use vortex_scalar::{PValue, Scalar};
+use vortex_scalar::{PValue, PrimitiveScalar, Scalar};
 
-use crate::{ALPArray, ALPEncoding, ALPFloat};
+use crate::{match_each_alp_float_ptype, ALPArray, ALPEncoding, ALPFloat};
 
 impl CompareFn<ALPArray> for ALPEncoding {
     fn compare(
@@ -15,16 +15,12 @@ impl CompareFn<ALPArray> for ALPEncoding {
         operator: Operator,
     ) -> VortexResult<Option<ArrayData>> {
         if let Some(const_scalar) = rhs.as_constant() {
-            let pvalue = const_scalar.value().as_pvalue()?;
+            let pscalar = PrimitiveScalar::try_from(&const_scalar)?;
 
-            return match pvalue {
-                Some(PValue::F32(f)) => alp_scalar_compare(lhs, f, operator).map(Some),
-                Some(PValue::F64(f)) => alp_scalar_compare(lhs, f, operator).map(Some),
-                Some(_) | None => Ok(Some(
-                    ConstantArray::new(Scalar::bool(false, Nullability::Nullable), lhs.len())
-                        .into_array(),
-                )),
-            };
+            match_each_alp_float_ptype!(pscalar.ptype(), |$T| {
+                let value = $T::try_from(pscalar.pvalue().as_ref().unwrap())?;
+                return alp_scalar_compare(lhs, value, operator).map(Some);
+            });
         }
 
         Ok(None)

--- a/encodings/alp/src/alp/compute/compare.rs
+++ b/encodings/alp/src/alp/compute/compare.rs
@@ -2,8 +2,8 @@ use vortex_array::array::ConstantArray;
 use vortex_array::compute::{compare, CompareFn, Operator};
 use vortex_array::{ArrayData, ArrayLen, IntoArrayData};
 use vortex_dtype::Nullability;
-use vortex_error::VortexResult;
-use vortex_scalar::{PValue, PrimitiveScalar, Scalar};
+use vortex_error::{VortexExpect as _, VortexResult};
+use vortex_scalar::{PrimitiveScalar, Scalar};
 
 use crate::{match_each_alp_float_ptype, ALPArray, ALPEncoding, ALPFloat};
 
@@ -18,7 +18,7 @@ impl CompareFn<ALPArray> for ALPEncoding {
             let pscalar = PrimitiveScalar::try_from(&const_scalar)?;
 
             match_each_alp_float_ptype!(pscalar.ptype(), |$T| {
-                let value = $T::try_from(pscalar.pvalue().as_ref().unwrap())?;
+                let value: $T = pscalar.typed_value().vortex_expect("must be non null");
                 return alp_scalar_compare(lhs, value, operator).map(Some);
             });
         }

--- a/encodings/alp/src/alp_rd/mod.rs
+++ b/encodings/alp/src/alp_rd/mod.rs
@@ -16,7 +16,7 @@ use vortex_array::{ArrayDType, IntoArrayData};
 use vortex_dtype::{DType, NativePType};
 use vortex_error::{VortexExpect, VortexUnwrap};
 use vortex_fastlanes::bitpack_encode_unchecked;
-use vortex_scalar::ScalarValue;
+use vortex_scalar::Scalar;
 
 use crate::match_each_alp_float_ptype;
 
@@ -234,9 +234,15 @@ impl RDEncoder {
             };
 
             let exc_array = PrimitiveArray::from_vec(exceptions, Validity::AllValid).into_array();
-            SparseArray::try_new(packed_pos, exc_array, doubles.len(), ScalarValue::Null)
-                .vortex_expect("ALP-RD: construction of exceptions SparseArray")
-                .into_array()
+            let nullable_dtype = exc_array.dtype().as_nullable();
+            SparseArray::try_new(
+                packed_pos,
+                exc_array,
+                doubles.len(),
+                Scalar::null(nullable_dtype),
+            )
+            .vortex_expect("ALP-RD: construction of exceptions SparseArray")
+            .into_array()
         });
 
         ALPRDArray::try_new(

--- a/encodings/bytebool/src/compute.rs
+++ b/encodings/bytebool/src/compute.rs
@@ -144,7 +144,6 @@ impl FillForwardFn<ByteBoolArray> for ByteBoolEncoding {
 mod tests {
     use vortex_array::compute::unary::scalar_at;
     use vortex_array::compute::{compare, slice, Operator};
-    use vortex_scalar::ScalarValue;
 
     use super::*;
 
@@ -157,15 +156,15 @@ mod tests {
         let sliced_arr = ByteBoolArray::try_from(sliced_arr).unwrap();
 
         let s = scalar_at(sliced_arr.as_ref(), 0).unwrap();
-        assert_eq!(s.into_value().as_bool().unwrap(), Some(true));
+        assert_eq!(s.as_bool().value(), Some(true));
 
         let s = scalar_at(sliced_arr.as_ref(), 1).unwrap();
         assert!(!sliced_arr.is_valid(1));
         assert!(s.is_null());
-        assert_eq!(s.into_value().as_bool().unwrap(), None);
+        assert_eq!(s.as_bool().value(), None);
 
         let s = scalar_at(sliced_arr.as_ref(), 2).unwrap();
-        assert_eq!(s.into_value().as_bool().unwrap(), Some(false));
+        assert_eq!(s.as_bool().value(), Some(false));
     }
 
     #[test]
@@ -178,7 +177,7 @@ mod tests {
         for i in 0..arr.len() {
             let s = scalar_at(arr.as_ref(), i).unwrap();
             assert!(s.is_valid());
-            assert_eq!(s.value(), &ScalarValue::Bool(true));
+            assert_eq!(s.as_bool().value(), Some(true));
         }
     }
 
@@ -192,7 +191,7 @@ mod tests {
         for i in 0..arr.len() {
             let s = scalar_at(&arr, i).unwrap();
             assert!(s.is_valid());
-            assert_eq!(s.value(), &ScalarValue::Bool(false));
+            assert_eq!(s.as_bool().value(), Some(false));
         }
     }
 
@@ -206,12 +205,12 @@ mod tests {
         for i in 0..3 {
             let s = scalar_at(&arr, i).unwrap();
             assert!(s.is_valid());
-            assert_eq!(s.value(), &ScalarValue::Bool(true));
+            assert_eq!(s.as_bool().value(), Some(true));
         }
 
         let s = scalar_at(&arr, 3).unwrap();
         assert!(s.is_valid());
-        assert_eq!(s.value(), &ScalarValue::Bool(false));
+        assert_eq!(s.as_bool().value(), Some(false));
 
         let s = scalar_at(&arr, 4).unwrap();
         assert!(s.is_null());

--- a/encodings/datetime-parts/src/compute.rs
+++ b/encodings/datetime-parts/src/compute.rs
@@ -7,7 +7,7 @@ use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_datetime_dtype::{TemporalMetadata, TimeUnit};
 use vortex_dtype::DType;
 use vortex_error::{vortex_bail, VortexResult};
-use vortex_scalar::{PValue, Scalar, ScalarValue};
+use vortex_scalar::Scalar;
 
 use crate::{DateTimePartsArray, DateTimePartsEncoding};
 
@@ -74,7 +74,7 @@ impl ScalarAtFn<DateTimePartsArray> for DateTimePartsEncoding {
         };
 
         if !array.is_valid(index) {
-            return Ok(Scalar::extension(ext, ScalarValue::Null));
+            return Ok(Scalar::null(DType::Extension(ext)));
         }
 
         let divisor = match time_unit {
@@ -91,10 +91,7 @@ impl ScalarAtFn<DateTimePartsArray> for DateTimePartsEncoding {
 
         let scalar = days * 86_400 * divisor + seconds * divisor + subseconds;
 
-        Ok(Scalar::extension(
-            ext,
-            ScalarValue::Primitive(PValue::I64(scalar)),
-        ))
+        Ok(Scalar::extension(ext, Scalar::from(scalar)))
     }
 }
 

--- a/encodings/datetime-parts/src/compute.rs
+++ b/encodings/datetime-parts/src/compute.rs
@@ -7,7 +7,7 @@ use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_datetime_dtype::{TemporalMetadata, TimeUnit};
 use vortex_dtype::DType;
 use vortex_error::{vortex_bail, VortexResult};
-use vortex_scalar::{Scalar, ScalarValue};
+use vortex_scalar::{PValue, Scalar, ScalarValue};
 
 use crate::{DateTimePartsArray, DateTimePartsEncoding};
 
@@ -91,7 +91,10 @@ impl ScalarAtFn<DateTimePartsArray> for DateTimePartsEncoding {
 
         let scalar = days * 86_400 * divisor + seconds * divisor + subseconds;
 
-        Ok(Scalar::extension(ext, scalar.into()))
+        Ok(Scalar::extension(
+            ext,
+            ScalarValue::Primitive(PValue::I64(scalar)),
+        ))
     }
 }
 

--- a/encodings/dict/src/compress.rs
+++ b/encodings/dict/src/compress.rs
@@ -11,9 +11,9 @@ use vortex_array::array::{
 use vortex_array::validity::Validity;
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayDType, IntoArrayData, IntoCanonical};
-use vortex_dtype::{match_each_native_ptype, DType, NativePType, ToBytes};
+use vortex_dtype::{match_each_native_ptype, DType, NativePType, Nullability, ToBytes};
 use vortex_error::{VortexExpect as _, VortexUnwrap};
-use vortex_scalar::ScalarValue;
+use vortex_scalar::{Scalar, ScalarValue};
 
 /// Statically assigned code for a null value.
 pub const NULL_CODE: u64 = 0;
@@ -169,7 +169,10 @@ fn dict_values_validity(nullable: bool, len: usize) -> Validity {
                 ConstantArray::new(0u64, 1).into_array(),
                 ConstantArray::new(false, 1).into_array(),
                 len,
-                ScalarValue::Bool(true),
+                Scalar::new(
+                    DType::Bool(Nullability::NonNullable),
+                    ScalarValue::Bool(true),
+                ),
             )
             .vortex_unwrap()
             .into_array(),

--- a/encodings/dict/src/compress.rs
+++ b/encodings/dict/src/compress.rs
@@ -11,9 +11,9 @@ use vortex_array::array::{
 use vortex_array::validity::Validity;
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayDType, IntoArrayData, IntoCanonical};
-use vortex_dtype::{match_each_native_ptype, DType, NativePType, Nullability, ToBytes};
+use vortex_dtype::{match_each_native_ptype, DType, NativePType, ToBytes};
 use vortex_error::{VortexExpect as _, VortexUnwrap};
-use vortex_scalar::{Scalar, ScalarValue};
+use vortex_scalar::Scalar;
 
 /// Statically assigned code for a null value.
 pub const NULL_CODE: u64 = 0;
@@ -169,10 +169,7 @@ fn dict_values_validity(nullable: bool, len: usize) -> Validity {
                 ConstantArray::new(0u64, 1).into_array(),
                 ConstantArray::new(false, 1).into_array(),
                 len,
-                Scalar::new(
-                    DType::Bool(Nullability::NonNullable),
-                    ScalarValue::Bool(true),
-                ),
+                Scalar::from(true),
             )
             .vortex_unwrap()
             .into_array(),

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -10,7 +10,7 @@ use vortex_dtype::{
     match_each_integer_ptype, match_each_unsigned_integer_ptype, NativePType, PType,
 };
 use vortex_error::{vortex_bail, vortex_err, VortexResult, VortexUnwrap};
-use vortex_scalar::{Scalar, ScalarValue};
+use vortex_scalar::Scalar;
 
 use crate::BitPackedArray;
 
@@ -157,7 +157,7 @@ pub fn gather_patches(
                 indices.into_array(),
                 PrimitiveArray::from_vec(values, Validity::AllValid).into_array(),
                 parray.len(),
-                Scalar::new(parray.dtype().clone(), ScalarValue::Null),
+                Scalar::null(parray.dtype().clone()),
             )
             .vortex_unwrap()
             .into_array()

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -157,7 +157,7 @@ pub fn gather_patches(
                 indices.into_array(),
                 PrimitiveArray::from_vec(values, Validity::AllValid).into_array(),
                 parray.len(),
-                ScalarValue::Null,
+                Scalar::new(parray.dtype().clone(), ScalarValue::Null),
             )
             .vortex_unwrap()
             .into_array()

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -157,7 +157,7 @@ pub fn gather_patches(
                 indices.into_array(),
                 PrimitiveArray::from_vec(values, Validity::AllValid).into_array(),
                 parray.len(),
-                Scalar::null(parray.dtype().clone()),
+                Scalar::null(parray.dtype().as_nullable()),
             )
             .vortex_unwrap()
             .into_array()

--- a/encodings/fastlanes/src/bitpacking/compute/scalar_at.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/scalar_at.rs
@@ -26,7 +26,7 @@ mod test {
     use vortex_array::IntoArrayData;
     use vortex_buffer::Buffer;
     use vortex_dtype::{DType, Nullability, PType};
-    use vortex_scalar::{Scalar, ScalarValue};
+    use vortex_scalar::Scalar;
 
     use crate::BitPackedArray;
 
@@ -41,7 +41,7 @@ mod test {
                     PrimitiveArray::from(vec![1u64]).into_array(),
                     PrimitiveArray::from_vec(vec![999u32], Validity::AllValid).into_array(),
                     8,
-                    ScalarValue::Null,
+                    Scalar::null_typed::<u32>(),
                 )
                 .unwrap()
                 .into_array(),

--- a/encodings/fastlanes/src/for/compress.rs
+++ b/encodings/fastlanes/src/for/compress.rs
@@ -9,7 +9,7 @@ use vortex_dtype::{
     match_each_integer_ptype, match_each_unsigned_integer_ptype, DType, NativePType, Nullability,
 };
 use vortex_error::{vortex_bail, vortex_err, VortexExpect, VortexResult};
-use vortex_scalar::{PrimitiveScalar, Scalar, ScalarValue};
+use vortex_scalar::{PrimitiveScalar, Scalar};
 
 use crate::FoRArray;
 
@@ -71,10 +71,7 @@ fn encoded_zero<T: NativePType>(
                 valid_indices,
                 ConstantArray::new(zero, valid_len).into_array(),
                 len,
-                Scalar::new(
-                    DType::Primitive(encoded_ptype, Nullability::Nullable),
-                    ScalarValue::Null,
-                ),
+                Scalar::null(DType::Primitive(encoded_ptype, Nullability::Nullable)),
             )?
             .into_array()
         }

--- a/encodings/fastlanes/src/for/compress.rs
+++ b/encodings/fastlanes/src/for/compress.rs
@@ -154,7 +154,10 @@ mod test {
         // Create a range offset by a million
         let array = PrimitiveArray::from((0u32..10_000).map(|v| v + 1_000_000).collect_vec());
         let compressed = for_compress(&array).unwrap();
-        assert_eq!(u32::try_from(compressed.reference()).unwrap(), 1_000_000u32);
+        assert_eq!(
+            u32::try_from(compressed.owned_reference_scalar()).unwrap(),
+            1_000_000u32
+        );
     }
 
     #[test]
@@ -168,7 +171,7 @@ mod test {
         assert!(compressed.encoded().dtype().is_unsigned_int());
 
         let constant = compressed.encoded().as_constant().unwrap();
-        assert_eq!(constant.value(), &ScalarValue::from(0u32));
+        assert_eq!(constant, Scalar::from(0u32));
     }
 
     #[test]
@@ -197,7 +200,7 @@ mod test {
         let sparse = SparseArray::try_from(compressed.encoded()).unwrap();
         assert!(sparse.dtype().is_unsigned_int());
         assert!(sparse.statistics().to_set().into_iter().next().is_none());
-        assert_eq!(sparse.fill_value(), &ScalarValue::Null);
+        assert_eq!(sparse.fill_scalar(), Scalar::null(sparse.dtype().clone()));
         assert_eq!(
             scalar_at(&sparse, 0).unwrap(),
             Scalar::primitive(0u32, Nullability::Nullable)
@@ -230,7 +233,14 @@ mod test {
     fn test_overflow() {
         let array = PrimitiveArray::from((i8::MIN..=i8::MAX).collect_vec());
         let compressed = for_compress(&array).unwrap();
-        assert_eq!(i8::MIN, i8::try_from(compressed.reference()).unwrap());
+        assert_eq!(
+            i8::MIN,
+            compressed
+                .owned_reference_scalar()
+                .as_primitive()
+                .typed_value::<i8>()
+                .unwrap()
+        );
 
         let encoded = compressed.encoded().into_primitive().unwrap();
         let encoded_bytes: &[u8] = encoded.maybe_null_slice::<u8>();

--- a/encodings/fastlanes/src/for/compress.rs
+++ b/encodings/fastlanes/src/for/compress.rs
@@ -9,7 +9,7 @@ use vortex_dtype::{
     match_each_integer_ptype, match_each_unsigned_integer_ptype, DType, NativePType, Nullability,
 };
 use vortex_error::{vortex_bail, vortex_err, VortexExpect, VortexResult};
-use vortex_scalar::{Scalar, ScalarValue};
+use vortex_scalar::{PrimitiveScalar, Scalar, ScalarValue};
 
 use crate::FoRArray;
 
@@ -71,7 +71,10 @@ fn encoded_zero<T: NativePType>(
                 valid_indices,
                 ConstantArray::new(zero, valid_len).into_array(),
                 len,
-                ScalarValue::Null,
+                Scalar::new(
+                    DType::Primitive(encoded_ptype, Nullability::Nullable),
+                    ScalarValue::Null,
+                ),
             )?
             .into_array()
         }
@@ -111,7 +114,9 @@ pub fn decompress(array: FoRArray) -> VortexResult<PrimitiveArray> {
         if shift == <$T>::PTYPE.bit_width() {
             encoded
         } else {
-            let min: $T = array.reference().try_into()?;
+            let min: $T = PrimitiveScalar::try_from(&array.owned_reference_scalar())?
+                .typed_value::<$T>()
+                .ok_or_else(|| vortex_err!("expected reference to be non-null"))?;
             PrimitiveArray::from_vec(
                 decompress_primitive(encoded.into_maybe_null_slice::<$T>(), min, shift),
                 validity,

--- a/encodings/fastlanes/src/for/compress.rs
+++ b/encodings/fastlanes/src/for/compress.rs
@@ -9,7 +9,7 @@ use vortex_dtype::{
     match_each_integer_ptype, match_each_unsigned_integer_ptype, DType, NativePType, Nullability,
 };
 use vortex_error::{vortex_bail, vortex_err, VortexExpect, VortexResult};
-use vortex_scalar::{PrimitiveScalar, Scalar};
+use vortex_scalar::Scalar;
 
 use crate::FoRArray;
 
@@ -111,7 +111,8 @@ pub fn decompress(array: FoRArray) -> VortexResult<PrimitiveArray> {
         if shift == <$T>::PTYPE.bit_width() {
             encoded
         } else {
-            let min: $T = PrimitiveScalar::try_from(&array.owned_reference_scalar())?
+            let min = array.reference_scalar()
+                .as_primitive()
                 .typed_value::<$T>()
                 .ok_or_else(|| vortex_err!("expected reference to be non-null"))?;
             PrimitiveArray::from_vec(
@@ -155,7 +156,7 @@ mod test {
         let array = PrimitiveArray::from((0u32..10_000).map(|v| v + 1_000_000).collect_vec());
         let compressed = for_compress(&array).unwrap();
         assert_eq!(
-            u32::try_from(compressed.owned_reference_scalar()).unwrap(),
+            u32::try_from(compressed.reference_scalar()).unwrap(),
             1_000_000u32
         );
     }
@@ -236,7 +237,7 @@ mod test {
         assert_eq!(
             i8::MIN,
             compressed
-                .owned_reference_scalar()
+                .reference_scalar()
                 .as_primitive()
                 .typed_value::<i8>()
                 .unwrap()

--- a/encodings/fastlanes/src/for/compute.rs
+++ b/encodings/fastlanes/src/for/compute.rs
@@ -45,7 +45,7 @@ impl TakeFn<FoRArray> for FoREncoding {
     ) -> VortexResult<ArrayData> {
         FoRArray::try_new(
             take(array.encoded(), indices, options)?,
-            array.owned_reference_scalar(),
+            array.reference_scalar(),
             array.shift(),
         )
         .map(|a| a.into_array())
@@ -56,7 +56,7 @@ impl FilterFn<FoRArray> for FoREncoding {
     fn filter(&self, array: &FoRArray, mask: FilterMask) -> VortexResult<ArrayData> {
         FoRArray::try_new(
             filter(&array.encoded(), mask)?,
-            array.owned_reference_scalar(),
+            array.reference_scalar(),
             array.shift(),
         )
         .map(|a| a.into_array())
@@ -67,13 +67,19 @@ impl ScalarAtFn<FoRArray> for FoREncoding {
     fn scalar_at(&self, array: &FoRArray, index: usize) -> VortexResult<Scalar> {
         let encoded_pvalue = scalar_at(array.encoded(), index)?.reinterpret_cast(array.ptype());
         let encoded_pvalue = encoded_pvalue.as_primitive();
-        let reference = array.owned_reference_scalar();
+        let reference = array.reference_scalar();
         let reference = reference.as_primitive();
 
         Ok(match_each_integer_ptype!(array.ptype(), |$P| {
             encoded_pvalue
                 .typed_value::<$P>()
-                .map(|v| v.checked_shl(array.shift() as u32).unwrap_or_default().wrapping_add(reference.typed_value::<$P>().vortex_expect("reference must be non-null")))
+                .map(|v|
+                     v.checked_shl(array.shift() as u32)
+                     .unwrap_or_default()
+                     .wrapping_add(
+                         reference
+                             .typed_value::<$P>()
+                             .vortex_expect("FoRArray Reference value cannot be null")))
                 .map(|v| Scalar::primitive::<$P>(v, array.dtype().nullability()))
                 .unwrap_or_else(|| Scalar::null(array.dtype().clone()))
         }))
@@ -84,7 +90,7 @@ impl SliceFn<FoRArray> for FoREncoding {
     fn slice(&self, array: &FoRArray, start: usize, stop: usize) -> VortexResult<ArrayData> {
         FoRArray::try_new(
             slice(array.encoded(), start, stop)?,
-            array.owned_reference_scalar(),
+            array.reference_scalar(),
             array.shift(),
         )
         .map(|a| a.into_array())
@@ -121,7 +127,7 @@ where
         + Into<PValue>,
 {
     let min: T = array
-        .owned_reference_scalar()
+        .reference_scalar()
         .as_primitive()
         .typed_value::<T>()
         .vortex_expect("Reference value cannot be null");
@@ -237,7 +243,7 @@ mod test {
         let for_array = FoRArray::try_from(arr.clone()).unwrap();
 
         let min: i32 = for_array
-            .owned_reference_scalar()
+            .reference_scalar()
             .as_primitive()
             .typed_value::<i32>()
             .unwrap();

--- a/encodings/fastlanes/src/for/compute.rs
+++ b/encodings/fastlanes/src/for/compute.rs
@@ -9,7 +9,7 @@ use vortex_array::compute::{
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData};
 use vortex_dtype::{match_each_integer_ptype, NativePType};
-use vortex_error::{VortexError, VortexExpect as _, VortexResult, VortexUnwrap as _};
+use vortex_error::{VortexError, VortexExpect as _, VortexResult};
 use vortex_scalar::{PValue, Scalar};
 
 use crate::{FoRArray, FoREncoding};
@@ -65,21 +65,15 @@ impl FilterFn<FoRArray> for FoREncoding {
 
 impl ScalarAtFn<FoRArray> for FoREncoding {
     fn scalar_at(&self, array: &FoRArray, index: usize) -> VortexResult<Scalar> {
-        let encoded_pvalue = scalar_at(array.encoded(), index)?
-            .into_value()
-            .as_pvalue()
-            .vortex_expect("Encoded scalar must be primitive")
-            .map(|p| p.reinterpret_cast(array.ptype()));
-        let reference = array
-            .reference()
-            .as_pvalue()
-            .vortex_expect("Reference scalar must be primitive")
-            .vortex_expect("Reference scalar cannot be null");
+        let encoded_pvalue = scalar_at(array.encoded(), index)?.reinterpret_cast(array.ptype());
+        let encoded_pvalue = encoded_pvalue.as_primitive();
+        let reference = array.owned_reference_scalar();
+        let reference = reference.as_primitive();
 
         Ok(match_each_integer_ptype!(array.ptype(), |$P| {
             encoded_pvalue
-                .map(|v| v.as_primitive::<$P>().vortex_unwrap())
-                .map(|v| v.checked_shl(array.shift() as u32).unwrap_or_default().wrapping_add(reference.as_primitive::<$P>().vortex_unwrap()))
+                .typed_value::<$P>()
+                .map(|v| v.checked_shl(array.shift() as u32).unwrap_or_default().wrapping_add(reference.typed_value::<$P>().vortex_expect("reference must be non-null")))
                 .map(|v| Scalar::primitive::<$P>(v, array.dtype().nullability()))
                 .unwrap_or_else(|| Scalar::null(array.dtype().clone()))
         }))
@@ -127,10 +121,10 @@ where
         + Into<PValue>,
 {
     let min: T = array
-        .reference()
-        .as_pvalue()?
-        .vortex_expect("Reference value cannot be null")
-        .as_primitive::<T>()?;
+        .owned_reference_scalar()
+        .as_primitive()
+        .typed_value::<T>()
+        .vortex_expect("Reference value cannot be null");
     let primitive_value: T = value.cast(array.dtype())?.as_ref().try_into()?;
     // Make sure that smaller values are still smaller and not larger than (which they would be after wrapping_sub)
     if primitive_value < min {

--- a/encodings/fastlanes/src/for/compute.rs
+++ b/encodings/fastlanes/src/for/compute.rs
@@ -236,7 +236,11 @@ mod test {
             .into_array();
         let for_array = FoRArray::try_from(arr.clone()).unwrap();
 
-        let min: i32 = for_array.reference().try_into().unwrap();
+        let min: i32 = for_array
+            .owned_reference_scalar()
+            .as_primitive()
+            .typed_value::<i32>()
+            .unwrap();
         assert_eq!(min, 62);
         assert_eq!(for_array.shift(), 1);
 

--- a/encodings/fastlanes/src/for/mod.rs
+++ b/encodings/fastlanes/src/for/mod.rs
@@ -68,13 +68,14 @@ impl FoRArray {
     }
 
     #[inline]
+    #[deprecated]
     pub fn reference(&self) -> &ScalarValue {
         &self.metadata().reference
     }
 
     #[inline]
     pub fn owned_reference_scalar(&self) -> Scalar {
-        Scalar::new(self.dtype().clone(), self.reference().clone())
+        Scalar::new(self.dtype().clone(), self.metadata().reference.clone())
     }
 
     #[inline]

--- a/encodings/fastlanes/src/for/mod.rs
+++ b/encodings/fastlanes/src/for/mod.rs
@@ -68,13 +68,7 @@ impl FoRArray {
     }
 
     #[inline]
-    #[deprecated]
-    pub fn reference(&self) -> &ScalarValue {
-        &self.metadata().reference
-    }
-
-    #[inline]
-    pub fn owned_reference_scalar(&self) -> Scalar {
+    pub fn reference_scalar(&self) -> Scalar {
         Scalar::new(self.dtype().clone(), self.metadata().reference.clone())
     }
 

--- a/encodings/fsst/src/compute/compare.rs
+++ b/encodings/fsst/src/compute/compare.rs
@@ -50,14 +50,15 @@ fn compare_fsst_constant(
 
     let encoded_scalar = match left.dtype() {
         DType::Utf8(_) => right
-            .scalar_value()
-            .as_buffer_string()?
+            .scalar()
+            .as_utf8()
+            .value()
             .map(|scalar| Buffer::from(compressor.compress(scalar.as_bytes()))),
         DType::Binary(_) => right
-            .scalar_value()
-            .as_buffer()?
+            .scalar()
+            .as_binary()
+            .value()
             .map(|scalar| Buffer::from(compressor.compress(scalar.as_slice()))),
-
         _ => unreachable!("FSSTArray can only have string or binary data type"),
     };
 

--- a/encodings/fsst/src/compute/mod.rs
+++ b/encodings/fsst/src/compute/mod.rs
@@ -9,7 +9,7 @@ use vortex_array::compute::{
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData};
 use vortex_buffer::Buffer;
 use vortex_error::{vortex_err, VortexResult};
-use vortex_scalar::Scalar;
+use vortex_scalar::{BinaryScalar, Scalar};
 
 use crate::{FSSTArray, FSSTEncoding};
 
@@ -72,10 +72,9 @@ impl TakeFn<FSSTArray> for FSSTEncoding {
 impl ScalarAtFn<FSSTArray> for FSSTEncoding {
     fn scalar_at(&self, array: &FSSTArray, index: usize) -> VortexResult<Scalar> {
         let compressed = scalar_at(array.codes(), index)?;
-        let binary_datum = compressed
+        let binary_datum = BinaryScalar::try_from(&compressed)?
             .value()
-            .as_buffer()?
-            .ok_or_else(|| vortex_err!("Expected a binary scalar, found {}", compressed.dtype()))?;
+            .ok_or_else(|| vortex_err!("expected null to already be handled"))?;
 
         array.with_decompressor(|decompressor| {
             let decoded_buffer: Buffer = decompressor.decompress(binary_datum.as_slice()).into();

--- a/encodings/fsst/src/compute/mod.rs
+++ b/encodings/fsst/src/compute/mod.rs
@@ -9,7 +9,7 @@ use vortex_array::compute::{
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData};
 use vortex_buffer::Buffer;
 use vortex_error::{vortex_err, VortexResult};
-use vortex_scalar::{BinaryScalar, Scalar};
+use vortex_scalar::Scalar;
 
 use crate::{FSSTArray, FSSTEncoding};
 
@@ -72,7 +72,8 @@ impl TakeFn<FSSTArray> for FSSTEncoding {
 impl ScalarAtFn<FSSTArray> for FSSTEncoding {
     fn scalar_at(&self, array: &FSSTArray, index: usize) -> VortexResult<Scalar> {
         let compressed = scalar_at(array.codes(), index)?;
-        let binary_datum = BinaryScalar::try_from(&compressed)?
+        let binary_datum = compressed
+            .as_binary()
             .value()
             .ok_or_else(|| vortex_err!("expected null to already be handled"))?;
 

--- a/encodings/runend/src/compute/mod.rs
+++ b/encodings/runend/src/compute/mod.rs
@@ -15,7 +15,7 @@ use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::{match_each_integer_ptype, match_each_unsigned_integer_ptype, NativePType};
 use vortex_error::VortexResult;
-use vortex_scalar::{Scalar, ScalarValue};
+use vortex_scalar::Scalar;
 
 use crate::{RunEndArray, RunEndEncoding};
 
@@ -102,7 +102,7 @@ impl TakeFn<RunEndArray> for RunEndEncoding {
                     dense_nonnull_indices,
                     filtered_values,
                     length,
-                    Scalar::new(dtype, ScalarValue::Null),
+                    Scalar::null(dtype),
                 )?
                 .into_array()
             }

--- a/encodings/runend/src/compute/mod.rs
+++ b/encodings/runend/src/compute/mod.rs
@@ -96,12 +96,13 @@ impl TakeFn<RunEndArray> for RunEndEncoding {
                 )
                 .into_array();
                 let filtered_values = filter(&dense_values, dense_validity)?;
+                let dtype = filtered_values.dtype().clone();
 
                 SparseArray::try_new(
                     dense_nonnull_indices,
                     filtered_values,
                     length,
-                    ScalarValue::Null,
+                    Scalar::new(dtype, ScalarValue::Null),
                 )?
                 .into_array()
             }

--- a/pyvortex/src/scalar.rs
+++ b/pyvortex/src/scalar.rs
@@ -4,72 +4,75 @@
 //! :meth:`.Array.scalar_at`. They represent shared-memory views into individual values of a Vortex
 //! array.
 
-use std::sync::Arc;
-
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use vortex::buffer::{Buffer, BufferString};
-use vortex::dtype::{DType, StructDType};
-use vortex::error::vortex_panic;
-use vortex::scalar::{PValue, Scalar, ScalarValue};
+use vortex::dtype::half::f16;
+use vortex::dtype::PType;
+use vortex::error::VortexExpect as _;
+use vortex::scalar::{ListScalar, Scalar, StructScalar};
 
 pub fn scalar_into_py(py: Python, x: Scalar, copy_into_python: bool) -> PyResult<PyObject> {
-    let (dtype, value) = x.into_parts();
-    scalar_value_into_py(py, value, &dtype, copy_into_python)
-}
-
-pub fn scalar_value_into_py(
-    py: Python,
-    x: ScalarValue,
-    dtype: &DType,
-    copy_into_python: bool,
-) -> PyResult<PyObject> {
-    match x {
-        ScalarValue::Bool(x) => Ok(x.into_py(py)),
-        ScalarValue::Primitive(PValue::U8(x)) => Ok(x.into_py(py)),
-        ScalarValue::Primitive(PValue::U16(x)) => Ok(x.into_py(py)),
-        ScalarValue::Primitive(PValue::U32(x)) => Ok(x.into_py(py)),
-        ScalarValue::Primitive(PValue::U64(x)) => Ok(x.into_py(py)),
-        ScalarValue::Primitive(PValue::I8(x)) => Ok(x.into_py(py)),
-        ScalarValue::Primitive(PValue::I16(x)) => Ok(x.into_py(py)),
-        ScalarValue::Primitive(PValue::I32(x)) => Ok(x.into_py(py)),
-        ScalarValue::Primitive(PValue::I64(x)) => Ok(x.into_py(py)),
-        ScalarValue::Primitive(PValue::F16(x)) => Ok(x.to_f32().into_py(py)),
-        ScalarValue::Primitive(PValue::F32(x)) => Ok(x.into_py(py)),
-        ScalarValue::Primitive(PValue::F64(x)) => Ok(x.into_py(py)),
-        ScalarValue::Buffer(x) => {
-            if copy_into_python {
-                Ok(x.into_py(py))
-            } else {
-                PyBuffer::new_pyobject(py, x)
-            }
-        }
-        ScalarValue::BufferString(x) => {
-            if copy_into_python {
-                Ok(x.into_py(py))
-            } else {
-                PyBufferString::new_pyobject(py, x)
-            }
-        }
-        ScalarValue::List(x) => match dtype {
-            DType::List(dtype, ..) => {
-                if copy_into_python {
-                    to_python_list(py, &x, dtype, true)
-                } else {
-                    PyVortexList::new_pyobject(py, x, dtype.clone())
-                }
-            }
-            DType::Struct(dtype, ..) => {
-                if copy_into_python {
-                    to_python_dict(py, &x, dtype, true)
-                } else {
-                    PyVortexStruct::new_pyobject(py, x, dtype.clone())
-                }
-            }
-            _ => vortex_panic!("impossible"),
-        },
-        ScalarValue::Null => Ok(py.None()),
+    if x.is_null() {
+        return Ok(py.None());
     }
+
+    if let Some(b) = x.as_bool_opt() {
+        return Ok(b.value().into_py(py));
+    }
+
+    if let Some(p) = x.as_primitive_opt() {
+        return Ok(match p.ptype() {
+            PType::U8 => p.typed_value::<u8>().into_py(py),
+            PType::U16 => p.typed_value::<u16>().into_py(py),
+            PType::U32 => p.typed_value::<u32>().into_py(py),
+            PType::U64 => p.typed_value::<u64>().into_py(py),
+            PType::I8 => p.typed_value::<i8>().into_py(py),
+            PType::I16 => p.typed_value::<i16>().into_py(py),
+            PType::I32 => p.typed_value::<i32>().into_py(py),
+            PType::I64 => p.typed_value::<i64>().into_py(py),
+            PType::F16 => p.typed_value::<f16>().map(f16::to_f32).into_py(py),
+            PType::F32 => p.typed_value::<f32>().into_py(py),
+            PType::F64 => p.typed_value::<f64>().into_py(py),
+        });
+    }
+
+    if let Some(x) = x.as_binary_opt() {
+        let x = x.value().vortex_expect("already handled null");
+        if copy_into_python {
+            return Ok(x.as_slice().into_py(py));
+        } else {
+            return PyBuffer::new_pyobject(py, x);
+        }
+    }
+
+    if let Some(x) = x.as_utf8_opt() {
+        let x = x.value().vortex_expect("already handled null");
+        if copy_into_python {
+            return Ok(x.as_str().into_py(py));
+        } else {
+            return PyBufferString::new_pyobject(py, x);
+        }
+    }
+
+    if let Some(struct_scalar) = x.as_struct_opt() {
+        if copy_into_python {
+            return to_python_dict(py, struct_scalar, true);
+        } else {
+            return PyVortexStruct::new_pyobject(py, x);
+        }
+    }
+
+    if let Some(list_scalar) = x.as_list_opt() {
+        if copy_into_python {
+            return to_python_list(py, list_scalar, true);
+        } else {
+            return PyVortexList::new_pyobject(py, x);
+        }
+    }
+
+    Err(PyValueError::new_err(format!("unknown scalar: {}", x)))
 }
 
 #[pyclass(name = "Buffer", module = "vortex", sequence, subclass)]
@@ -145,33 +148,24 @@ impl PyBufferString {
 #[pyclass(name = "VortexList", module = "vortex", sequence, subclass)]
 /// A view of a variable-length list of data from a Vortex array.
 pub struct PyVortexList {
-    inner: Arc<[ScalarValue]>,
-    dtype: Arc<DType>,
+    inner: Scalar,
 }
 
 impl PyVortexList {
-    pub fn new(inner: Arc<[ScalarValue]>, dtype: Arc<DType>) -> PyVortexList {
-        PyVortexList { inner, dtype }
+    pub fn new(inner: Scalar) -> PyVortexList {
+        PyVortexList { inner }
     }
 
-    pub fn new_bound(
-        py: Python,
-        inner: Arc<[ScalarValue]>,
-        dtype: Arc<DType>,
-    ) -> PyResult<Bound<PyVortexList>> {
-        Bound::new(py, Self::new(inner, dtype))
+    pub fn new_bound(py: Python, inner: Scalar) -> PyResult<Bound<PyVortexList>> {
+        Bound::new(py, Self::new(inner))
     }
 
-    pub fn new_pyobject(
-        py: Python,
-        inner: Arc<[ScalarValue]>,
-        dtype: Arc<DType>,
-    ) -> PyResult<PyObject> {
-        let bound = Bound::new(py, Self::new(inner, dtype))?;
+    pub fn new_pyobject(py: Python, inner: Scalar) -> PyResult<PyObject> {
+        let bound = Bound::new(py, Self::new(inner))?;
         Ok(bound.into_py(py))
     }
 
-    pub fn unwrap(&self) -> &Arc<[ScalarValue]> {
+    pub fn unwrap(&self) -> &Scalar {
         &self.inner
     }
 }
@@ -181,54 +175,39 @@ impl PyVortexList {
     /// Copy the elements of this list from array memory into a :class:`list`.
     #[pyo3(signature = (*, recursive = false))]
     pub fn into_python(self_: PyRef<Self>, recursive: bool) -> PyResult<PyObject> {
-        to_python_list(self_.py(), &self_.inner, &self_.dtype, recursive)
+        to_python_list(self_.py(), self_.inner.as_list(), recursive)
     }
 }
 
-fn to_python_list(
-    py: Python,
-    values: &[ScalarValue],
-    dtype: &DType,
-    recursive: bool,
-) -> PyResult<PyObject> {
-    Ok(values
-        .iter()
-        .cloned()
-        .map(|x| scalar_value_into_py(py, x, dtype, recursive))
-        .collect::<Result<Vec<_>, _>>()?
+fn to_python_list(py: Python, scalar: ListScalar<'_>, recursive: bool) -> PyResult<PyObject> {
+    Ok(scalar
+        .elements()
+        .map(|x| scalar_into_py(py, x, recursive))
+        .collect::<PyResult<Vec<_>>>()?
         .into_py(py))
 }
 
 #[pyclass(name = "VortexStruct", module = "vortex", sequence, subclass)]
 /// A view of structured data from a Vortex array.
 pub struct PyVortexStruct {
-    inner: Arc<[ScalarValue]>,
-    dtype: StructDType,
+    inner: Scalar,
 }
 
 impl PyVortexStruct {
-    pub fn new(inner: Arc<[ScalarValue]>, dtype: StructDType) -> PyVortexStruct {
-        PyVortexStruct { inner, dtype }
+    pub fn new(inner: Scalar) -> PyVortexStruct {
+        PyVortexStruct { inner }
     }
 
-    pub fn new_bound(
-        py: Python,
-        inner: Arc<[ScalarValue]>,
-        dtype: StructDType,
-    ) -> PyResult<Bound<PyVortexStruct>> {
-        Bound::new(py, Self::new(inner, dtype))
+    pub fn new_bound(py: Python, inner: Scalar) -> PyResult<Bound<PyVortexStruct>> {
+        Bound::new(py, Self::new(inner))
     }
 
-    pub fn new_pyobject(
-        py: Python,
-        inner: Arc<[ScalarValue]>,
-        dtype: StructDType,
-    ) -> PyResult<PyObject> {
-        let bound = Bound::new(py, Self::new(inner, dtype))?;
+    pub fn new_pyobject(py: Python, inner: Scalar) -> PyResult<PyObject> {
+        let bound = Bound::new(py, Self::new(inner))?;
         Ok(bound.into_py(py))
     }
 
-    pub fn unwrap(&self) -> &Arc<[ScalarValue]> {
+    pub fn unwrap(&self) -> &Scalar {
         &self.inner
     }
 }
@@ -238,26 +217,26 @@ impl PyVortexStruct {
     #[pyo3(signature = (*, recursive = false))]
     /// Copy the elements of this list from array memory into a :class:`dict`.
     pub fn into_python(self_: PyRef<Self>, recursive: bool) -> PyResult<PyObject> {
-        to_python_dict(self_.py(), &self_.inner, &self_.dtype, recursive)
+        to_python_dict(self_.py(), self_.inner.as_struct(), recursive)
     }
 }
 
 fn to_python_dict(
     py: Python,
-    values: &[ScalarValue],
-    dtype: &StructDType,
+    struct_scalar: StructScalar<'_>,
     recursive: bool,
 ) -> PyResult<PyObject> {
+    let Some(fields) = struct_scalar.fields() else {
+        return Ok(py.None());
+    };
+
+    let dtype = struct_scalar.struct_dtype();
+
     let dict = PyDict::new_bound(py);
-    for ((child, name), dtype) in values
-        .iter()
-        .cloned()
-        .zip(dtype.names().iter())
-        .zip(dtype.dtypes().iter())
-    {
+    for (child, name) in fields.iter().zip(dtype.names().iter()) {
         dict.set_item(
             name.to_string(),
-            scalar_value_into_py(py, child, dtype, recursive)?,
+            scalar_into_py(py, child.clone(), recursive)?,
         )?
     }
     Ok(dict.into_py(py))

--- a/pyvortex/src/scalar.rs
+++ b/pyvortex/src/scalar.rs
@@ -37,7 +37,7 @@ pub fn scalar_into_py(py: Python, x: Scalar, copy_into_python: bool) -> PyResult
                 None => py.None(),
                 Some(x) => {
                     if copy_into_python {
-                        return Ok(x.as_str().into_py(py));
+                        x.as_str().into_py(py)
                     } else {
                         return PyBufferString::new_pyobject(py, x);
                     }
@@ -50,9 +50,9 @@ pub fn scalar_into_py(py: Python, x: Scalar, copy_into_python: bool) -> PyResult
                 None => py.None(),
                 Some(x) => {
                     if copy_into_python {
-                        return Ok(x.as_slice().into_py(py));
+                        x.as_slice().into_py(py)
                     } else {
-                        return PyBuffer::new_pyobject(py, x);
+                        PyBuffer::new_pyobject(py, x)?
                     }
                 }
             }
@@ -60,17 +60,17 @@ pub fn scalar_into_py(py: Python, x: Scalar, copy_into_python: bool) -> PyResult
         DType::Struct(..) => {
             let struct_scalar = x.as_struct();
             if copy_into_python {
-                return to_python_dict(py, struct_scalar, true);
+                to_python_dict(py, struct_scalar, true)?
             } else {
-                return PyVortexStruct::new_pyobject(py, x);
+                PyVortexStruct::new_pyobject(py, x)?
             }
         }
         DType::List(..) => {
             let list_scalar = x.as_list();
             if copy_into_python {
-                return to_python_list(py, list_scalar, true);
+                to_python_list(py, list_scalar, true)?
             } else {
-                return PyVortexList::new_pyobject(py, x);
+                PyVortexList::new_pyobject(py, x)?
             }
         }
         DType::Extension(_) => {

--- a/pyvortex/src/scalar.rs
+++ b/pyvortex/src/scalar.rs
@@ -4,75 +4,79 @@
 //! :meth:`.Array.scalar_at`. They represent shared-memory views into individual values of a Vortex
 //! array.
 
-use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use vortex::buffer::{Buffer, BufferString};
 use vortex::dtype::half::f16;
-use vortex::dtype::PType;
-use vortex::error::VortexExpect as _;
+use vortex::dtype::{DType, PType};
 use vortex::scalar::{ListScalar, Scalar, StructScalar};
 
 pub fn scalar_into_py(py: Python, x: Scalar, copy_into_python: bool) -> PyResult<PyObject> {
-    if x.is_null() {
-        return Ok(py.None());
-    }
-
-    if let Some(b) = x.as_bool_opt() {
-        return Ok(b.value().into_py(py));
-    }
-
-    if let Some(p) = x.as_primitive_opt() {
-        return Ok(match p.ptype() {
-            PType::U8 => p.typed_value::<u8>().into_py(py),
-            PType::U16 => p.typed_value::<u16>().into_py(py),
-            PType::U32 => p.typed_value::<u32>().into_py(py),
-            PType::U64 => p.typed_value::<u64>().into_py(py),
-            PType::I8 => p.typed_value::<i8>().into_py(py),
-            PType::I16 => p.typed_value::<i16>().into_py(py),
-            PType::I32 => p.typed_value::<i32>().into_py(py),
-            PType::I64 => p.typed_value::<i64>().into_py(py),
-            PType::F16 => p.typed_value::<f16>().map(f16::to_f32).into_py(py),
-            PType::F32 => p.typed_value::<f32>().into_py(py),
-            PType::F64 => p.typed_value::<f64>().into_py(py),
-        });
-    }
-
-    if let Some(x) = x.as_binary_opt() {
-        let x = x.value().vortex_expect("already handled null");
-        if copy_into_python {
-            return Ok(x.as_slice().into_py(py));
-        } else {
-            return PyBuffer::new_pyobject(py, x);
+    Ok(match x.dtype() {
+        DType::Null => py.None(),
+        DType::Bool(_) => x.as_bool().value().into_py(py),
+        DType::Primitive(ptype, ..) => {
+            let p = x.as_primitive();
+            match ptype {
+                PType::U8 => p.typed_value::<u8>().into_py(py),
+                PType::U16 => p.typed_value::<u16>().into_py(py),
+                PType::U32 => p.typed_value::<u32>().into_py(py),
+                PType::U64 => p.typed_value::<u64>().into_py(py),
+                PType::I8 => p.typed_value::<i8>().into_py(py),
+                PType::I16 => p.typed_value::<i16>().into_py(py),
+                PType::I32 => p.typed_value::<i32>().into_py(py),
+                PType::I64 => p.typed_value::<i64>().into_py(py),
+                PType::F16 => p.typed_value::<f16>().map(f16::to_f32).into_py(py),
+                PType::F32 => p.typed_value::<f32>().into_py(py),
+                PType::F64 => p.typed_value::<f64>().into_py(py),
+            }
         }
-    }
-
-    if let Some(x) = x.as_utf8_opt() {
-        let x = x.value().vortex_expect("already handled null");
-        if copy_into_python {
-            return Ok(x.as_str().into_py(py));
-        } else {
-            return PyBufferString::new_pyobject(py, x);
+        DType::Utf8(_) => {
+            let x = x.as_utf8().value();
+            match x {
+                None => py.None(),
+                Some(x) => {
+                    if copy_into_python {
+                        return Ok(x.as_str().into_py(py));
+                    } else {
+                        return PyBufferString::new_pyobject(py, x);
+                    }
+                }
+            }
         }
-    }
-
-    if let Some(struct_scalar) = x.as_struct_opt() {
-        if copy_into_python {
-            return to_python_dict(py, struct_scalar, true);
-        } else {
-            return PyVortexStruct::new_pyobject(py, x);
+        DType::Binary(_) => {
+            let x = x.as_binary().value();
+            match x {
+                None => py.None(),
+                Some(x) => {
+                    if copy_into_python {
+                        return Ok(x.as_slice().into_py(py));
+                    } else {
+                        return PyBuffer::new_pyobject(py, x);
+                    }
+                }
+            }
         }
-    }
-
-    if let Some(list_scalar) = x.as_list_opt() {
-        if copy_into_python {
-            return to_python_list(py, list_scalar, true);
-        } else {
-            return PyVortexList::new_pyobject(py, x);
+        DType::Struct(..) => {
+            let struct_scalar = x.as_struct();
+            if copy_into_python {
+                return to_python_dict(py, struct_scalar, true);
+            } else {
+                return PyVortexStruct::new_pyobject(py, x);
+            }
         }
-    }
-
-    Err(PyValueError::new_err(format!("unknown scalar: {}", x)))
+        DType::List(..) => {
+            let list_scalar = x.as_list();
+            if copy_into_python {
+                return to_python_list(py, list_scalar, true);
+            } else {
+                return PyVortexList::new_pyobject(py, x);
+            }
+        }
+        DType::Extension(_) => {
+            todo!()
+        }
+    })
 }
 
 #[pyclass(name = "Buffer", module = "vortex", sequence, subclass)]

--- a/pyvortex/src/scalar.rs
+++ b/pyvortex/src/scalar.rs
@@ -59,7 +59,9 @@ pub fn scalar_into_py(py: Python, x: Scalar, copy_into_python: bool) -> PyResult
         }
         DType::Struct(..) => {
             let struct_scalar = x.as_struct();
-            if copy_into_python {
+            if struct_scalar.is_null() {
+                py.None()
+            } else if copy_into_python {
                 to_python_dict(py, struct_scalar, true)?
             } else {
                 PyVortexStruct::new_pyobject(py, x)?
@@ -67,7 +69,9 @@ pub fn scalar_into_py(py: Python, x: Scalar, copy_into_python: bool) -> PyResult
         }
         DType::List(..) => {
             let list_scalar = x.as_list();
-            if copy_into_python {
+            if list_scalar.is_null() {
+                py.None()
+            } else if copy_into_python {
                 to_python_list(py, list_scalar, true)?
             } else {
                 PyVortexList::new_pyobject(py, x)?

--- a/vortex-array/src/array/assertions.rs
+++ b/vortex-array/src/array/assertions.rs
@@ -6,11 +6,11 @@ macro_rules! assert_arrays_eq {
         assert_eq!(expected.dtype(), actual.dtype());
 
         let expected_contents = (0..expected.len())
-            .map(|idx| scalar_at(&expected, idx).map(|x| x.into_value()))
+            .map(|idx| scalar_at(&expected, idx))
             .collect::<VortexResult<Vec<_>>>()
             .unwrap();
         let actual_contents = (0..actual.len())
-            .map(|idx| scalar_at(&expected, idx).map(|x| x.into_value()))
+            .map(|idx| scalar_at(&expected, idx))
             .collect::<VortexResult<Vec<_>>>()
             .unwrap();
 

--- a/vortex-array/src/array/bool/compute/slice.rs
+++ b/vortex-array/src/array/bool/compute/slice.rs
@@ -31,13 +31,13 @@ mod tests {
         assert_eq!(sliced_arr.len(), 3);
 
         let s = scalar_at(sliced_arr.as_ref(), 0).unwrap();
-        assert_eq!(s.into_value().as_bool().unwrap(), Some(true));
+        assert_eq!(s.as_bool().value(), Some(true));
 
         let s = scalar_at(sliced_arr.as_ref(), 1).unwrap();
         assert!(!sliced_arr.is_valid(1));
         assert!(s.is_null());
 
         let s = scalar_at(sliced_arr.as_ref(), 2).unwrap();
-        assert_eq!(s.into_value().as_bool().unwrap(), Some(false));
+        assert_eq!(s.as_bool().value(), Some(false));
     }
 }

--- a/vortex-array/src/array/constant/canonical.rs
+++ b/vortex-array/src/array/constant/canonical.rs
@@ -163,7 +163,7 @@ mod tests {
         let canonical = const_array.into_canonical().unwrap();
         let canonical_stats = canonical.statistics().to_set();
 
-        assert_eq!(canonical_stats, StatsSet::constant(scalar, 4));
+        assert_eq!(canonical_stats, StatsSet::constant(&scalar, 4));
         assert_eq!(canonical_stats, stats);
     }
 }

--- a/vortex-array/src/array/constant/canonical.rs
+++ b/vortex-array/src/array/constant/canonical.rs
@@ -15,7 +15,7 @@ use crate::{ArrayDType, ArrayLen, Canonical, IntoArrayData, IntoCanonical};
 
 impl IntoCanonical for ConstantArray {
     fn into_canonical(self) -> VortexResult<Canonical> {
-        let scalar = &self.owned_scalar();
+        let scalar = &self.scalar();
 
         let validity = match self.dtype().nullability() {
             Nullability::NonNullable => Validity::NonNullable,

--- a/vortex-array/src/array/constant/canonical.rs
+++ b/vortex-array/src/array/constant/canonical.rs
@@ -3,7 +3,7 @@ use arrow_buffer::{BooleanBuffer, BufferBuilder};
 use vortex_buffer::Buffer;
 use vortex_dtype::{match_each_native_ptype, DType, Nullability, PType};
 use vortex_error::{vortex_bail, VortexResult};
-use vortex_scalar::{BinaryScalar, BoolScalar, ExtScalar, Scalar, Utf8Scalar};
+use vortex_scalar::{BinaryScalar, BoolScalar, ExtScalar, Utf8Scalar};
 
 use crate::array::constant::ConstantArray;
 use crate::array::primitive::PrimitiveArray;
@@ -58,8 +58,7 @@ impl IntoCanonical for ConstantArray {
             DType::Extension(ext_dtype) => {
                 let s = ExtScalar::try_from(scalar)?;
 
-                let storage_dtype = ext_dtype.storage_dtype();
-                let storage_scalar = Scalar::new(storage_dtype.clone(), s.value().clone());
+                let storage_scalar = s.storage();
                 let storage_array = ConstantArray::new(storage_scalar, self.len()).into_array();
                 ExtensionArray::new(ext_dtype.clone(), storage_array).into_canonical()?
             }

--- a/vortex-array/src/array/constant/compute/boolean.rs
+++ b/vortex-array/src/array/constant/compute/boolean.rs
@@ -1,6 +1,6 @@
 use vortex_dtype::DType;
 use vortex_error::{vortex_bail, VortexResult};
-use vortex_scalar::Scalar;
+use vortex_scalar::{BoolScalar, Scalar};
 
 use crate::array::{ConstantArray, ConstantEncoding};
 use crate::compute::{BinaryBooleanFn, BinaryOperator};
@@ -15,11 +15,11 @@ impl BinaryBooleanFn<ConstantArray> for ConstantEncoding {
     ) -> VortexResult<ArrayData> {
         let length = lhs.len();
         let nullable = lhs.dtype().is_nullable() || rhs.dtype().is_nullable();
-        let lhs = <Option<bool>>::try_from(lhs.scalar_value())?;
+        let lhs = lhs.scalar().as_bool().value();
         let Some(rhs) = rhs.as_constant() else {
             vortex_bail!("Binary boolean operation requires both sides to be constant");
         };
-        let rhs = <Option<bool>>::try_from(rhs.value())?;
+        let rhs = BoolScalar::try_from(&rhs)?.value();
 
         let result = match op {
             BinaryOperator::And => and(lhs, rhs),
@@ -82,10 +82,10 @@ mod test {
     fn test_or(#[case] lhs: ArrayData, #[case] rhs: ArrayData) {
         let r = or(&lhs, &rhs).unwrap().into_bool().unwrap().into_array();
 
-        let v0 = scalar_at(&r, 0).unwrap().value().as_bool().unwrap();
-        let v1 = scalar_at(&r, 1).unwrap().value().as_bool().unwrap();
-        let v2 = scalar_at(&r, 2).unwrap().value().as_bool().unwrap();
-        let v3 = scalar_at(&r, 3).unwrap().value().as_bool().unwrap();
+        let v0 = scalar_at(&r, 0).unwrap().as_bool().value();
+        let v1 = scalar_at(&r, 1).unwrap().as_bool().value();
+        let v2 = scalar_at(&r, 2).unwrap().as_bool().value();
+        let v3 = scalar_at(&r, 3).unwrap().as_bool().value();
 
         assert!(v0.unwrap());
         assert!(v1.unwrap());

--- a/vortex-array/src/array/constant/compute/boolean.rs
+++ b/vortex-array/src/array/constant/compute/boolean.rs
@@ -1,6 +1,6 @@
 use vortex_dtype::DType;
-use vortex_error::{vortex_bail, VortexResult};
-use vortex_scalar::{BoolScalar, Scalar};
+use vortex_error::{vortex_bail, vortex_err, VortexResult};
+use vortex_scalar::Scalar;
 
 use crate::array::{ConstantArray, ConstantEncoding};
 use crate::compute::{BinaryBooleanFn, BinaryOperator};
@@ -19,7 +19,10 @@ impl BinaryBooleanFn<ConstantArray> for ConstantEncoding {
         let Some(rhs) = rhs.as_constant() else {
             vortex_bail!("Binary boolean operation requires both sides to be constant");
         };
-        let rhs = BoolScalar::try_from(&rhs)?.value();
+        let rhs = rhs
+            .as_bool_opt()
+            .ok_or_else(|| vortex_err!("expected rhs to be boolean"))?
+            .value();
 
         let result = match op {
             BinaryOperator::And => and(lhs, rhs),

--- a/vortex-array/src/array/constant/compute/boolean.rs
+++ b/vortex-array/src/array/constant/compute/boolean.rs
@@ -101,10 +101,10 @@ mod test {
     fn test_and(#[case] lhs: ArrayData, #[case] rhs: ArrayData) {
         let r = and(&lhs, &rhs).unwrap().into_bool().unwrap().into_array();
 
-        let v0 = scalar_at(&r, 0).unwrap().value().as_bool().unwrap();
-        let v1 = scalar_at(&r, 1).unwrap().value().as_bool().unwrap();
-        let v2 = scalar_at(&r, 2).unwrap().value().as_bool().unwrap();
-        let v3 = scalar_at(&r, 3).unwrap().value().as_bool().unwrap();
+        let v0 = scalar_at(&r, 0).unwrap().as_bool().value();
+        let v1 = scalar_at(&r, 1).unwrap().as_bool().value();
+        let v2 = scalar_at(&r, 2).unwrap().as_bool().value();
+        let v3 = scalar_at(&r, 3).unwrap().as_bool().value();
 
         assert!(v0.unwrap());
         assert!(!v1.unwrap());

--- a/vortex-array/src/array/constant/compute/compare.rs
+++ b/vortex-array/src/array/constant/compute/compare.rs
@@ -14,7 +14,7 @@ impl CompareFn<ConstantArray> for ConstantEncoding {
         // We only support comparing a constant array to another constant array.
         // For all other encodings, we assume the constant is on the RHS.
         if let Some(const_scalar) = rhs.as_constant() {
-            let lhs_scalar = lhs.owned_scalar();
+            let lhs_scalar = lhs.scalar();
             let scalar = scalar_cmp(&lhs_scalar, &const_scalar, operator);
             return Ok(Some(ConstantArray::new(scalar, lhs.len()).into_array()));
         }

--- a/vortex-array/src/array/constant/compute/mod.rs
+++ b/vortex-array/src/array/constant/compute/mod.rs
@@ -52,7 +52,7 @@ impl ComputeVTable for ConstantEncoding {
 
 impl ScalarAtFn<ConstantArray> for ConstantEncoding {
     fn scalar_at(&self, array: &ConstantArray, _index: usize) -> VortexResult<Scalar> {
-        Ok(array.owned_scalar())
+        Ok(array.scalar())
     }
 }
 
@@ -63,18 +63,18 @@ impl TakeFn<ConstantArray> for ConstantEncoding {
         indices: &ArrayData,
         _options: TakeOptions,
     ) -> VortexResult<ArrayData> {
-        Ok(ConstantArray::new(array.owned_scalar(), indices.len()).into_array())
+        Ok(ConstantArray::new(array.scalar(), indices.len()).into_array())
     }
 }
 
 impl SliceFn<ConstantArray> for ConstantEncoding {
     fn slice(&self, array: &ConstantArray, start: usize, stop: usize) -> VortexResult<ArrayData> {
-        Ok(ConstantArray::new(array.owned_scalar(), stop - start).into_array())
+        Ok(ConstantArray::new(array.scalar(), stop - start).into_array())
     }
 }
 
 impl FilterFn<ConstantArray> for ConstantEncoding {
     fn filter(&self, array: &ConstantArray, mask: FilterMask) -> VortexResult<ArrayData> {
-        Ok(ConstantArray::new(array.owned_scalar(), mask.true_count()).into_array())
+        Ok(ConstantArray::new(array.scalar(), mask.true_count()).into_array())
     }
 }

--- a/vortex-array/src/array/constant/compute/search_sorted.rs
+++ b/vortex-array/src/array/constant/compute/search_sorted.rs
@@ -14,11 +14,7 @@ impl SearchSortedFn<ConstantArray> for ConstantEncoding {
         value: &Scalar,
         side: SearchSortedSide,
     ) -> VortexResult<SearchResult> {
-        match array
-            .scalar_value()
-            .partial_cmp(value.value())
-            .unwrap_or(Ordering::Less)
-        {
+        match array.scalar().partial_cmp(value).unwrap_or(Ordering::Less) {
             Ordering::Greater => Ok(SearchResult::NotFound(0)),
             Ordering::Less => Ok(SearchResult::NotFound(array.len())),
             Ordering::Equal => match side {

--- a/vortex-array/src/array/constant/mod.rs
+++ b/vortex-array/src/array/constant/mod.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
-use vortex_error::{vortex_panic, VortexResult};
+use vortex_error::{VortexExpect, VortexResult};
 use vortex_scalar::{Scalar, ScalarValue};
 
 use crate::encoding::ids;
@@ -37,31 +37,26 @@ impl ConstantArray {
         S: Into<Scalar>,
     {
         let scalar = scalar.into();
+        let stats = StatsSet::constant(&scalar, length);
+        let (dtype, scalar_value) = scalar.into_parts();
         Self::try_from_parts(
-            scalar.dtype().clone(),
+            dtype,
             length,
-            ConstantMetadata {
-                scalar_value: scalar.value().clone(),
-            },
+            ConstantMetadata { scalar_value },
             [].into(),
-            StatsSet::constant(scalar.clone(), length),
+            stats,
         )
-        .unwrap_or_else(|err| {
-            vortex_panic!(
-                err,
-                "Failed to create Constant array of length {} from scalar {}",
-                length,
-                scalar
-            )
-        })
+        .vortex_expect("Failed to create Constant array")
     }
 
+    /// Returns the [`ScalarValue`] of this constant array.
     pub fn scalar_value(&self) -> &ScalarValue {
         &self.metadata().scalar_value
     }
 
-    /// Construct an owned [`vortex_scalar::Scalar`] with a value equal to [`Self::scalar_value()`].
-    pub fn owned_scalar(&self) -> Scalar {
+    /// Returns the [`Scalar`] value of this constant array.
+    pub fn scalar(&self) -> Scalar {
+        // NOTE(ngates): these clones are pretty cheap.
         Scalar::new(self.dtype().clone(), self.scalar_value().clone())
     }
 }
@@ -83,7 +78,7 @@ impl ValidityVTable<ConstantArray> for ConstantEncoding {
 
 impl StatisticsVTable<ConstantArray> for ConstantEncoding {
     fn compute_statistics(&self, array: &ConstantArray, _stat: Stat) -> VortexResult<StatsSet> {
-        Ok(StatsSet::constant(array.owned_scalar(), array.len()))
+        Ok(StatsSet::constant(&array.scalar(), array.len()))
     }
 }
 

--- a/vortex-array/src/array/constant/mod.rs
+++ b/vortex-array/src/array/constant/mod.rs
@@ -49,15 +49,10 @@ impl ConstantArray {
         .vortex_expect("Failed to create Constant array")
     }
 
-    /// Returns the [`ScalarValue`] of this constant array.
-    pub fn scalar_value(&self) -> &ScalarValue {
-        &self.metadata().scalar_value
-    }
-
     /// Returns the [`Scalar`] value of this constant array.
     pub fn scalar(&self) -> Scalar {
         // NOTE(ngates): these clones are pretty cheap.
-        Scalar::new(self.dtype().clone(), self.scalar_value().clone())
+        Scalar::new(self.dtype().clone(), self.metadata().scalar_value.clone())
     }
 }
 
@@ -65,11 +60,11 @@ impl ArrayTrait for ConstantArray {}
 
 impl ValidityVTable<ConstantArray> for ConstantEncoding {
     fn is_valid(&self, array: &ConstantArray, _index: usize) -> bool {
-        !array.scalar_value().is_null()
+        !array.scalar().is_null()
     }
 
     fn logical_validity(&self, array: &ConstantArray) -> LogicalValidity {
-        match array.scalar_value().is_null() {
+        match array.scalar().is_null() {
             true => LogicalValidity::AllInvalid(array.len()),
             false => LogicalValidity::AllValid(array.len()),
         }

--- a/vortex-array/src/array/constant/variants.rs
+++ b/vortex-array/src/array/constant/variants.rs
@@ -1,7 +1,7 @@
 use vortex_dtype::field::Field;
 use vortex_dtype::DType;
 use vortex_error::{VortexError, VortexExpect as _, VortexResult};
-use vortex_scalar::{Scalar, ScalarValue, StructScalar};
+use vortex_scalar::Scalar;
 
 use crate::array::constant::ConstantArray;
 use crate::iter::Accessor;
@@ -51,8 +51,7 @@ impl NullArrayTrait for ConstantArray {}
 
 impl BoolArrayTrait for ConstantArray {
     fn invert(&self) -> VortexResult<ArrayData> {
-        let value = self.scalar_value().as_bool()?;
-        match value {
+        match self.scalar().as_bool().value() {
             None => Ok(self.to_array()),
             Some(b) => Ok(ConstantArray::new(!b, self.len()).into_array()),
         }
@@ -62,7 +61,7 @@ impl BoolArrayTrait for ConstantArray {
 impl<T> Accessor<T> for ConstantArray
 where
     T: Clone,
-    T: TryFrom<ScalarValue, Error = VortexError>,
+    T: TryFrom<Scalar, Error = VortexError>,
 {
     fn array_len(&self) -> usize {
         self.len()
@@ -73,11 +72,11 @@ where
     }
 
     fn value_unchecked(&self, _index: usize) -> T {
-        T::try_from(self.scalar_value().clone()).vortex_expect("Failed to convert scalar to value")
+        T::try_from(self.scalar()).vortex_expect("Failed to convert scalar to value")
     }
 
     fn array_validity(&self) -> Validity {
-        if self.scalar_value().is_null() {
+        if self.metadata().scalar_value.is_null() {
             Validity::AllInvalid
         } else {
             Validity::AllValid
@@ -93,18 +92,17 @@ impl BinaryArrayTrait for ConstantArray {}
 
 impl StructArrayTrait for ConstantArray {
     fn field(&self, idx: usize) -> Option<ArrayData> {
-        StructScalar::try_new(self.dtype(), self.scalar_value())
-            .ok()?
+        self.scalar()
+            .as_struct()
             .field_by_idx(idx)
             .map(|scalar| ConstantArray::new(scalar, self.len()).into_array())
     }
 
     fn project(&self, projection: &[Field]) -> VortexResult<ArrayData> {
-        Ok(ConstantArray::new(
-            StructScalar::try_new(self.dtype(), self.scalar_value())?.project(projection)?,
-            self.len(),
+        Ok(
+            ConstantArray::new(self.scalar().as_struct().project(projection)?, self.len())
+                .into_array(),
         )
-        .into_array())
     }
 }
 

--- a/vortex-array/src/array/constant/variants.rs
+++ b/vortex-array/src/array/constant/variants.rs
@@ -1,7 +1,7 @@
 use vortex_dtype::field::Field;
 use vortex_dtype::DType;
 use vortex_error::{VortexError, VortexExpect as _, VortexResult};
-use vortex_scalar::{ExtScalar, Scalar};
+use vortex_scalar::Scalar;
 
 use crate::array::constant::ConstantArray;
 use crate::iter::Accessor;
@@ -110,12 +110,6 @@ impl ListArrayTrait for ConstantArray {}
 
 impl ExtensionArrayTrait for ConstantArray {
     fn storage_data(&self) -> ArrayData {
-        ConstantArray::new(
-            ExtScalar::try_from(&self.scalar())
-                .vortex_expect("extension typed constant array must have an extension scalar")
-                .storage(),
-            self.len(),
-        )
-        .into_array()
+        ConstantArray::new(self.scalar().as_extension().storage(), self.len()).into_array()
     }
 }

--- a/vortex-array/src/array/constant/variants.rs
+++ b/vortex-array/src/array/constant/variants.rs
@@ -1,7 +1,7 @@
 use vortex_dtype::field::Field;
 use vortex_dtype::DType;
 use vortex_error::{VortexError, VortexExpect as _, VortexResult};
-use vortex_scalar::Scalar;
+use vortex_scalar::{ExtScalar, Scalar};
 
 use crate::array::constant::ConstantArray;
 use crate::iter::Accessor;
@@ -76,7 +76,7 @@ where
     }
 
     fn array_validity(&self) -> Validity {
-        if self.metadata().scalar_value.is_null() {
+        if self.scalar().is_null() {
             Validity::AllInvalid
         } else {
             Validity::AllValid
@@ -110,9 +110,10 @@ impl ListArrayTrait for ConstantArray {}
 
 impl ExtensionArrayTrait for ConstantArray {
     fn storage_data(&self) -> ArrayData {
-        let storage_dtype = self.ext_dtype().storage_dtype().clone();
         ConstantArray::new(
-            Scalar::new(storage_dtype, self.scalar_value().clone()),
+            ExtScalar::try_from(&self.scalar())
+                .vortex_expect("extension typed constant array must have an extension scalar")
+                .storage(),
             self.len(),
         )
         .into_array()

--- a/vortex-array/src/array/extension/compute/compare.rs
+++ b/vortex-array/src/array/extension/compute/compare.rs
@@ -15,13 +15,16 @@ impl CompareFn<ExtensionArray> for ExtensionEncoding {
     ) -> VortexResult<Option<ArrayData>> {
         // If the RHS is a constant, we can extract the storage scalar.
         if let Some(const_ext) = rhs.as_constant() {
-            let scalar_ext = ExtScalar::try_new(const_ext.dtype(), const_ext.value())?;
-            let storage_scalar = ConstantArray::new(
-                Scalar::new(lhs.storage().dtype().clone(), scalar_ext.value().clone()),
-                lhs.len(),
-            );
+            let scalar_ext = ExtScalar::try_from(&const_ext)?;
+            let storage_scalar =
+                Scalar::new(lhs.storage().dtype().clone(), scalar_ext.value().clone());
 
-            return compare(lhs.storage(), storage_scalar, operator).map(Some);
+            return compare(
+                lhs.storage(),
+                ConstantArray::new(storage_scalar, lhs.len()),
+                operator,
+            )
+            .map(Some);
         }
 
         // If the RHS is an extension array matching ours, we can extract the storage.

--- a/vortex-array/src/array/extension/compute/compare.rs
+++ b/vortex-array/src/array/extension/compute/compare.rs
@@ -1,5 +1,4 @@
 use vortex_error::VortexResult;
-use vortex_scalar::ExtScalar;
 
 use crate::array::{ConstantArray, ExtensionArray, ExtensionEncoding};
 use crate::compute::{compare, CompareFn, Operator};
@@ -15,7 +14,7 @@ impl CompareFn<ExtensionArray> for ExtensionEncoding {
     ) -> VortexResult<Option<ArrayData>> {
         // If the RHS is a constant, we can extract the storage scalar.
         if let Some(const_ext) = rhs.as_constant() {
-            let storage_scalar = ExtScalar::try_from(&const_ext)?.storage();
+            let storage_scalar = const_ext.as_extension().storage();
             return compare(
                 lhs.storage(),
                 ConstantArray::new(storage_scalar, lhs.len()),

--- a/vortex-array/src/array/extension/compute/compare.rs
+++ b/vortex-array/src/array/extension/compute/compare.rs
@@ -1,10 +1,10 @@
 use vortex_error::VortexResult;
-use vortex_scalar::{ExtScalar, Scalar};
+use vortex_scalar::ExtScalar;
 
 use crate::array::{ConstantArray, ExtensionArray, ExtensionEncoding};
 use crate::compute::{compare, CompareFn, Operator};
 use crate::encoding::EncodingVTable;
-use crate::{ArrayDType, ArrayData, ArrayLen};
+use crate::{ArrayData, ArrayLen};
 
 impl CompareFn<ExtensionArray> for ExtensionEncoding {
     fn compare(
@@ -15,10 +15,7 @@ impl CompareFn<ExtensionArray> for ExtensionEncoding {
     ) -> VortexResult<Option<ArrayData>> {
         // If the RHS is a constant, we can extract the storage scalar.
         if let Some(const_ext) = rhs.as_constant() {
-            let scalar_ext = ExtScalar::try_from(&const_ext)?;
-            let storage_scalar =
-                Scalar::new(lhs.storage().dtype().clone(), scalar_ext.value().clone());
-
+            let storage_scalar = ExtScalar::try_from(&const_ext)?.storage();
             return compare(
                 lhs.storage(),
                 ConstantArray::new(storage_scalar, lhs.len()),

--- a/vortex-array/src/array/extension/compute/mod.rs
+++ b/vortex-array/src/array/extension/compute/mod.rs
@@ -39,7 +39,7 @@ impl ScalarAtFn<ExtensionArray> for ExtensionEncoding {
     fn scalar_at(&self, array: &ExtensionArray, index: usize) -> VortexResult<Scalar> {
         Ok(Scalar::extension(
             array.ext_dtype().clone(),
-            scalar_at(array.storage(), index)?.into_value(),
+            scalar_at(array.storage(), index)?,
         ))
     }
 }

--- a/vortex-array/src/array/extension/mod.rs
+++ b/vortex-array/src/array/extension/mod.rs
@@ -112,7 +112,7 @@ impl StatisticsVTable<ExtensionArray> for ExtensionEncoding {
 #[cfg(test)]
 mod tests {
     use vortex_dtype::PType;
-    use vortex_scalar::{PValue, Scalar, ScalarValue};
+    use vortex_scalar::Scalar;
 
     use super::*;
     use crate::array::PrimitiveArray;
@@ -144,17 +144,11 @@ mod tests {
 
         assert_eq!(
             stats.get(Stat::Min),
-            Some(&Scalar::extension(
-                ext_dtype.clone(),
-                ScalarValue::Primitive(PValue::I64(1))
-            ))
+            Some(&Scalar::extension(ext_dtype.clone(), Scalar::from(1_i64)))
         );
         assert_eq!(
             stats.get(Stat::Max),
-            Some(&Scalar::extension(
-                ext_dtype,
-                ScalarValue::Primitive(PValue::I64(5))
-            ))
+            Some(&Scalar::extension(ext_dtype, Scalar::from(5_i64)))
         );
         assert_eq!(stats.get(Stat::NullCount), Some(&0u64.into()));
     }

--- a/vortex-array/src/array/sparse/canonical.rs
+++ b/vortex-array/src/array/sparse/canonical.rs
@@ -96,7 +96,7 @@ mod test {
     use rstest::rstest;
     use vortex_dtype::{DType, Nullability, PType};
     use vortex_error::VortexExpect;
-    use vortex_scalar::ScalarValue;
+    use vortex_scalar::Scalar;
 
     use crate::array::sparse::SparseArray;
     use crate::array::{BoolArray, PrimitiveArray};
@@ -112,7 +112,7 @@ mod test {
         let values = bool_array_from_nullable_vec(vec![Some(true), None, Some(false)], fill_value)
             .into_array();
         let sparse_bools =
-            SparseArray::try_new(indices, values, 10, ScalarValue::from(fill_value)).unwrap();
+            SparseArray::try_new(indices, values, 10, Scalar::from(fill_value)).unwrap();
         assert_eq!(*sparse_bools.dtype(), DType::Bool(Nullability::Nullable));
 
         let flat_bools = sparse_bools.into_canonical().unwrap().into_bool().unwrap();
@@ -166,11 +166,13 @@ mod test {
     #[case(Some(-1i32))]
     #[case(None)]
     fn test_sparse_primitive(#[case] fill_value: Option<i32>) {
+        use vortex_scalar::Scalar;
+
         let indices = vec![0u64, 1, 7].into_array();
         let values =
             PrimitiveArray::from_nullable_vec(vec![Some(0i32), None, Some(1)]).into_array();
         let sparse_ints =
-            SparseArray::try_new(indices, values, 10, ScalarValue::from(fill_value)).unwrap();
+            SparseArray::try_new(indices, values, 10, Scalar::from(fill_value)).unwrap();
         assert_eq!(
             *sparse_ints.dtype(),
             DType::Primitive(PType::I32, Nullability::Nullable)

--- a/vortex-array/src/array/sparse/canonical.rs
+++ b/vortex-array/src/array/sparse/canonical.rs
@@ -1,7 +1,7 @@
 use arrow_buffer::{ArrowNativeType, BooleanBuffer};
 use vortex_dtype::{match_each_native_ptype, DType, NativePType, Nullability};
 use vortex_error::{VortexError, VortexResult};
-use vortex_scalar::ScalarValue;
+use vortex_scalar::Scalar;
 
 use crate::array::primitive::PrimitiveArray;
 use crate::array::sparse::SparseArray;
@@ -17,7 +17,7 @@ impl IntoCanonical for SparseArray {
 
         if matches!(self.dtype(), DType::Bool(_)) {
             let values = self.values().into_bool()?;
-            canonicalize_sparse_bools(values, &indices, self.len(), self.fill_value())
+            canonicalize_sparse_bools(values, &indices, self.len(), &self.fill_scalar())
         } else {
             let values = self.values().into_primitive()?;
             match_each_native_ptype!(values.ptype(), |$P| {
@@ -25,7 +25,7 @@ impl IntoCanonical for SparseArray {
                     values,
                     &indices,
                     self.len(),
-                    self.fill_value(),
+                    &self.fill_scalar(),
                 )
             })
         }
@@ -36,7 +36,7 @@ fn canonicalize_sparse_bools(
     values: BoolArray,
     indices: &[usize],
     len: usize,
-    fill_value: &ScalarValue,
+    fill_value: &Scalar,
 ) -> VortexResult<Canonical> {
     let (fill_bool, validity) = if fill_value.is_null() {
         (false, Validity::AllInvalid)
@@ -64,12 +64,12 @@ fn canonicalize_sparse_bools(
 }
 
 fn canonicalize_sparse_primitives<
-    T: NativePType + for<'a> TryFrom<&'a ScalarValue, Error = VortexError> + ArrowNativeType,
+    T: NativePType + for<'a> TryFrom<&'a Scalar, Error = VortexError> + ArrowNativeType,
 >(
     values: PrimitiveArray,
     indices: &[usize],
     len: usize,
-    fill_value: &ScalarValue,
+    fill_value: &Scalar,
 ) -> VortexResult<Canonical> {
     let values_validity = values.validity();
     let (primitive_fill, validity) = if fill_value.is_null() {

--- a/vortex-array/src/array/sparse/compute/mod.rs
+++ b/vortex-array/src/array/sparse/compute/mod.rs
@@ -116,7 +116,7 @@ impl FilterFn<SparseArray> for SparseEncoding {
 #[cfg(test)]
 mod test {
     use rstest::{fixture, rstest};
-    use vortex_scalar::ScalarValue;
+    use vortex_scalar::Scalar;
 
     use crate::array::primitive::PrimitiveArray;
     use crate::array::sparse::SparseArray;
@@ -132,7 +132,7 @@ mod test {
             PrimitiveArray::from(vec![2u64, 9, 15]).into_array(),
             PrimitiveArray::from_vec(vec![33_i32, 44, 55], Validity::AllValid).into_array(),
             20,
-            ScalarValue::Null,
+            Scalar::null_typed::<i32>(),
         )
         .unwrap()
         .into_array()
@@ -177,7 +177,7 @@ mod test {
             PrimitiveArray::from(vec![0u64]).into_array(),
             PrimitiveArray::from_vec(vec![0u8], Validity::AllValid).into_array(),
             2,
-            ScalarValue::Null,
+            Scalar::null_typed::<u8>(),
         )
         .unwrap()
         .into_array();
@@ -213,7 +213,7 @@ mod test {
             PrimitiveArray::from(vec![0_u64, 3, 6]).into_array(),
             PrimitiveArray::from_vec(vec![33_i32, 44, 55], Validity::AllValid).into_array(),
             7,
-            ScalarValue::Null,
+            Scalar::null_typed::<i32>(),
         )
         .unwrap()
         .into_array();

--- a/vortex-array/src/array/sparse/compute/mod.rs
+++ b/vortex-array/src/array/sparse/compute/mod.rs
@@ -107,7 +107,7 @@ impl FilterFn<SparseArray> for SparseEncoding {
                 TakeOptions::default(),
             )?,
             buffer.count_set_bits(),
-            array.fill_value().clone(),
+            array.fill_scalar(),
         )?
         .into_array())
     }

--- a/vortex-array/src/array/sparse/compute/slice.rs
+++ b/vortex-array/src/array/sparse/compute/slice.rs
@@ -16,7 +16,7 @@ impl SliceFn<SparseArray> for SparseEncoding {
             slice(array.values(), index_start_index, index_end_index)?,
             stop - start,
             array.indices_offset() + start,
-            array.fill_value().clone(),
+            array.fill_scalar(),
         )?
         .into_array())
     }

--- a/vortex-array/src/array/sparse/compute/take.rs
+++ b/vortex-array/src/array/sparse/compute/take.rs
@@ -97,7 +97,7 @@ fn take_search_sorted(
 #[cfg(test)]
 mod test {
     use itertools::Itertools;
-    use vortex_scalar::ScalarValue;
+    use vortex_scalar::Scalar;
 
     use crate::array::primitive::PrimitiveArray;
     use crate::array::sparse::compute::take::take_map;
@@ -112,7 +112,7 @@ mod test {
             PrimitiveArray::from_vec(vec![1.23f64, 0.47, 9.99, 3.5], Validity::AllValid)
                 .into_array(),
             100,
-            ScalarValue::Null,
+            Scalar::null_typed::<f64>(),
         )
         .unwrap()
         .into_array()

--- a/vortex-array/src/array/sparse/compute/take.rs
+++ b/vortex-array/src/array/sparse/compute/take.rs
@@ -33,7 +33,7 @@ impl TakeFn<SparseArray> for SparseEncoding {
             positions.into_array(),
             taken_values,
             indices.len(),
-            array.fill_value().clone(),
+            array.fill_scalar(),
         )?
         .into_array())
     }

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -43,7 +43,7 @@ impl SparseArray {
         indices: ArrayData,
         values: ArrayData,
         len: usize,
-        fill_value: ScalarValue,
+        fill_value: Scalar,
     ) -> VortexResult<Self> {
         Self::try_new_with_offset(indices, values, len, 0, fill_value)
     }
@@ -53,12 +53,12 @@ impl SparseArray {
         values: ArrayData,
         len: usize,
         indices_offset: usize,
-        fill_value: ScalarValue,
+        fill_value: Scalar,
     ) -> VortexResult<Self> {
         if !matches!(indices.dtype(), &DType::IDX | &DType::IDX_32) {
             vortex_bail!("Cannot use {} as indices", indices.dtype());
         }
-        if !fill_value.is_instance_of(values.dtype()) {
+        if fill_value.dtype() != values.dtype() {
             vortex_bail!(
                 "fill value, {:?}, should be instance of values dtype, {}",
                 fill_value,
@@ -87,7 +87,7 @@ impl SparseArray {
             SparseMetadata {
                 indices_offset,
                 indices_len: indices.len(),
-                fill_value,
+                fill_value: fill_value.into_value(),
                 u64_indices: matches!(indices.dtype(), &DType::IDX),
             },
             [indices, values].into(),
@@ -123,13 +123,8 @@ impl SparseArray {
     }
 
     #[inline]
-    pub fn fill_value(&self) -> &ScalarValue {
-        &self.metadata().fill_value
-    }
-
-    #[inline]
     pub fn fill_scalar(&self) -> Scalar {
-        Scalar::new(self.dtype().clone(), self.fill_value().clone())
+        Scalar::new(self.dtype().clone(), self.metadata().fill_value.clone())
     }
 
     /// Returns the position or the insertion point of a given index in the indices array.
@@ -200,7 +195,7 @@ impl StatisticsVTable<SparseArray> for SparseEncoding {
         }
 
         let fill_len = array.len() - array.values().len();
-        let fill_stats = if array.fill_value().is_null() {
+        let fill_stats = if array.fill_scalar().is_null() {
             StatsSet::nulls(fill_len, array.dtype())
         } else {
             StatsSet::constant(&array.fill_scalar(), fill_len)
@@ -218,14 +213,14 @@ impl StatisticsVTable<SparseArray> for SparseEncoding {
 impl ValidityVTable<SparseArray> for SparseEncoding {
     fn is_valid(&self, array: &SparseArray, index: usize) -> bool {
         match array.search_index(index).map(SearchResult::to_found) {
-            Ok(None) => !array.fill_value().is_null(),
+            Ok(None) => !array.fill_scalar().is_null(),
             Ok(Some(idx)) => array.values().with_dyn(|a| a.is_valid(idx)),
             Err(e) => vortex_panic!(e, "Error while finding index {} in sparse array", index),
         }
     }
 
     fn logical_validity(&self, array: &SparseArray) -> LogicalValidity {
-        let validity = if array.fill_value().is_null() {
+        let validity = if array.fill_scalar().is_null() {
             // If we have a null fill value, then the result is a Sparse array with a fill_value
             // of true, and patch values of false.
             SparseArray::try_new_with_offset(
@@ -279,14 +274,9 @@ mod test {
         let mut values = vec![100i32, 200, 300].into_array();
         values = try_cast(&values, fill_value.dtype()).unwrap();
 
-        SparseArray::try_new(
-            vec![2u64, 5, 8].into_array(),
-            values,
-            10,
-            fill_value.value().clone(),
-        )
-        .unwrap()
-        .into_array()
+        SparseArray::try_new(vec![2u64, 5, 8].into_array(), values, 10, fill_value)
+            .unwrap()
+            .into_array()
     }
 
     #[test]

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -203,7 +203,7 @@ impl StatisticsVTable<SparseArray> for SparseEncoding {
         let fill_stats = if array.fill_value().is_null() {
             StatsSet::nulls(fill_len, array.dtype())
         } else {
-            StatsSet::constant(array.fill_scalar(), fill_len)
+            StatsSet::constant(&array.fill_scalar(), fill_len)
         };
 
         if array.values().is_empty() {

--- a/vortex-array/src/array/sparse/variants.rs
+++ b/vortex-array/src/array/sparse/variants.rs
@@ -1,7 +1,7 @@
 use vortex_dtype::field::Field;
 use vortex_dtype::DType;
 use vortex_error::{vortex_err, VortexExpect, VortexResult};
-use vortex_scalar::StructScalar;
+use vortex_scalar::{BoolScalar, Scalar, StructScalar};
 
 use crate::array::sparse::SparseArray;
 use crate::variants::{
@@ -49,7 +49,9 @@ impl NullArrayTrait for SparseArray {}
 
 impl BoolArrayTrait for SparseArray {
     fn invert(&self) -> VortexResult<ArrayData> {
-        let inverted_fill = self.fill_value().as_bool()?.map(|v| !v);
+        let inverted_fill = BoolScalar::try_from(&self.fill_scalar())?
+            .value()
+            .map(|v| !v);
         SparseArray::try_new(
             self.indices(),
             self.values().with_dyn(|a| {
@@ -58,7 +60,7 @@ impl BoolArrayTrait for SparseArray {
                     .and_then(|b| b.invert())
             })?,
             self.len(),
-            inverted_fill.into(),
+            Scalar::from(inverted_fill),
         )
         .map(|a| a.into_array())
     }
@@ -75,7 +77,7 @@ impl StructArrayTrait for SparseArray {
         let values = self
             .values()
             .with_dyn(|s| s.as_struct_array().and_then(|s| s.field(idx)))?;
-        let scalar = StructScalar::try_new(self.dtype(), self.fill_value())
+        let scalar = StructScalar::try_from(&self.fill_scalar())
             .ok()?
             .field_by_idx(idx)?;
 
@@ -85,7 +87,7 @@ impl StructArrayTrait for SparseArray {
                 values,
                 self.len(),
                 self.indices_offset(),
-                scalar.into_value(),
+                scalar,
             )
             .ok()?
             .into_array(),
@@ -98,14 +100,14 @@ impl StructArrayTrait for SparseArray {
                 .ok_or_else(|| vortex_err!("Chunk was not a StructArray"))?
                 .project(projection)
         })?;
-        let scalar = StructScalar::try_new(self.dtype(), self.fill_value())?.project(projection)?;
+        let scalar = StructScalar::try_from(&self.fill_scalar())?.project(projection)?;
 
         SparseArray::try_new_with_offset(
             self.indices(),
             values,
             self.len(),
             self.indices_offset(),
-            scalar.into_value(),
+            scalar,
         )
         .map(|a| a.into_array())
     }
@@ -121,7 +123,7 @@ impl ExtensionArrayTrait for SparseArray {
                 .with_dyn(|a| a.as_extension_array_unchecked().storage_data()),
             self.len(),
             self.indices_offset(),
-            self.fill_value().clone(),
+            self.fill_scalar(),
         )
         .vortex_expect("Failed to create new sparse array")
         .into_array()

--- a/vortex-array/src/array/sparse/variants.rs
+++ b/vortex-array/src/array/sparse/variants.rs
@@ -1,7 +1,7 @@
 use vortex_dtype::field::Field;
 use vortex_dtype::DType;
 use vortex_error::{vortex_err, VortexExpect, VortexResult};
-use vortex_scalar::{BoolScalar, Scalar, StructScalar};
+use vortex_scalar::StructScalar;
 
 use crate::array::sparse::SparseArray;
 use crate::variants::{
@@ -49,9 +49,7 @@ impl NullArrayTrait for SparseArray {}
 
 impl BoolArrayTrait for SparseArray {
     fn invert(&self) -> VortexResult<ArrayData> {
-        let inverted_fill = BoolScalar::try_from(&self.fill_scalar())?
-            .value()
-            .map(|v| !v);
+        let inverted_fill = self.fill_scalar().as_bool().invert().into_scalar();
         SparseArray::try_new(
             self.indices(),
             self.values().with_dyn(|a| {
@@ -60,7 +58,7 @@ impl BoolArrayTrait for SparseArray {
                     .and_then(|b| b.invert())
             })?,
             self.len(),
-            Scalar::from(inverted_fill),
+            inverted_fill,
         )
         .map(|a| a.into_array())
     }
@@ -132,6 +130,8 @@ impl ExtensionArrayTrait for SparseArray {
 
 #[cfg(test)]
 mod tests {
+    use vortex_scalar::Scalar;
+
     use crate::array::{BoolArray, PrimitiveArray, SparseArray};
     use crate::{IntoArrayData, IntoArrayVariant};
 
@@ -141,7 +141,7 @@ mod tests {
             PrimitiveArray::from(vec![0u64]).into_array(),
             BoolArray::from_iter([false]).into_array(),
             2,
-            true.into(),
+            Scalar::from(true),
         )
         .unwrap()
         .into_array();

--- a/vortex-array/src/array/sparse/variants.rs
+++ b/vortex-array/src/array/sparse/variants.rs
@@ -85,7 +85,7 @@ impl StructArrayTrait for SparseArray {
                 values,
                 self.len(),
                 self.indices_offset(),
-                scalar.value().clone(),
+                scalar.into_value(),
             )
             .ok()?
             .into_array(),
@@ -105,7 +105,7 @@ impl StructArrayTrait for SparseArray {
             values,
             self.len(),
             self.indices_offset(),
-            scalar.value().clone(),
+            scalar.into_value(),
         )
         .map(|a| a.into_array())
     }

--- a/vortex-array/src/array/struct_/compute.rs
+++ b/vortex-array/src/array/struct_/compute.rs
@@ -35,7 +35,7 @@ impl ScalarAtFn<StructArray> for StructEncoding {
             array.dtype().clone(),
             array
                 .children()
-                .map(|field| scalar_at(&field, index).map(|s| s.into_value()))
+                .map(|field| scalar_at(&field, index))
                 .try_collect()?,
         ))
     }

--- a/vortex-array/src/array/struct_/compute.rs
+++ b/vortex-array/src/array/struct_/compute.rs
@@ -31,7 +31,7 @@ impl ComputeVTable for StructEncoding {
 
 impl ScalarAtFn<StructArray> for StructEncoding {
     fn scalar_at(&self, array: &StructArray, index: usize) -> VortexResult<Scalar> {
-        Ok(Scalar::r#struct(
+        Ok(Scalar::struct_(
             array.dtype().clone(),
             array
                 .children()

--- a/vortex-array/src/array/varbin/stats.rs
+++ b/vortex-array/src/array/varbin/stats.rs
@@ -53,7 +53,7 @@ pub fn compute_varbin_statistics<T: ArrayTrait + ArrayAccessor<[u8]>>(
             let is_constant = array.with_iterator(compute_is_constant)?;
             if is_constant {
                 // we know that the array is not empty
-                StatsSet::constant(scalar_at(array, 0)?, array.len())
+                StatsSet::constant(&scalar_at(array, 0)?, array.len())
             } else {
                 StatsSet::of(Stat::IsConstant, is_constant)
             }
@@ -133,7 +133,7 @@ fn compute_min_max<T: ArrayTrait + ArrayAccessor<[u8]>>(array: &T) -> VortexResu
             .map_or(false, |null_count| null_count == 0)
         {
             // if there are no nulls, then the array is constant
-            return Ok(StatsSet::constant(min, array.len()));
+            return Ok(StatsSet::constant(&min, array.len()));
         }
     } else {
         stats.set(Stat::IsConstant, false);

--- a/vortex-array/src/compute/boolean.rs
+++ b/vortex-array/src/compute/boolean.rs
@@ -168,10 +168,10 @@ mod tests {
 
         let r = r.into_bool().unwrap().into_array();
 
-        let v0 = scalar_at(&r, 0).unwrap().value().as_bool().unwrap();
-        let v1 = scalar_at(&r, 1).unwrap().value().as_bool().unwrap();
-        let v2 = scalar_at(&r, 2).unwrap().value().as_bool().unwrap();
-        let v3 = scalar_at(&r, 3).unwrap().value().as_bool().unwrap();
+        let v0 = scalar_at(&r, 0).unwrap().as_bool().value();
+        let v1 = scalar_at(&r, 1).unwrap().as_bool().value();
+        let v2 = scalar_at(&r, 2).unwrap().as_bool().value();
+        let v3 = scalar_at(&r, 3).unwrap().as_bool().value();
 
         assert!(v0.unwrap());
         assert!(v1.unwrap());
@@ -188,10 +188,10 @@ mod tests {
     fn test_and(#[case] lhs: ArrayData, #[case] rhs: ArrayData) {
         let r = and(&lhs, &rhs).unwrap().into_bool().unwrap().into_array();
 
-        let v0 = scalar_at(&r, 0).unwrap().value().as_bool().unwrap();
-        let v1 = scalar_at(&r, 1).unwrap().value().as_bool().unwrap();
-        let v2 = scalar_at(&r, 2).unwrap().value().as_bool().unwrap();
-        let v3 = scalar_at(&r, 3).unwrap().value().as_bool().unwrap();
+        let v0 = scalar_at(&r, 0).unwrap().as_bool().value();
+        let v1 = scalar_at(&r, 1).unwrap().as_bool().value();
+        let v2 = scalar_at(&r, 2).unwrap().as_bool().value();
+        let v3 = scalar_at(&r, 3).unwrap().as_bool().value();
 
         assert!(v0.unwrap());
         assert!(!v1.unwrap());

--- a/vortex-array/src/compute/compare.rs
+++ b/vortex-array/src/compute/compare.rs
@@ -205,7 +205,6 @@ pub fn scalar_cmp(lhs: &Scalar, rhs: &Scalar, operator: Operator) -> Scalar {
 mod tests {
     use arrow_buffer::BooleanBuffer;
     use itertools::Itertools;
-    use vortex_scalar::ScalarValue;
 
     use super::*;
     use crate::array::{BoolArray, ConstantArray};
@@ -293,7 +292,7 @@ mod tests {
 
         let compare = compare(left, right, Operator::Gt).unwrap();
         let res = compare.as_constant().unwrap();
-        assert_eq!(res.value(), &ScalarValue::Bool(false));
+        assert_eq!(res.as_bool().value(), Some(false));
         assert_eq!(compare.len(), 10);
     }
 }

--- a/vortex-array/src/stats/flatbuffers.rs
+++ b/vortex-array/src/stats/flatbuffers.rs
@@ -23,11 +23,11 @@ impl WriteFlatBuffer for &dyn Statistics {
 
         let min = self
             .get(Stat::Min)
-            .map(|min| min.value().write_flatbuffer(fbb));
+            .map(|min| min.into_value().write_flatbuffer(fbb));
 
         let max = self
             .get(Stat::Max)
-            .map(|max| max.value().write_flatbuffer(fbb));
+            .map(|max| max.into_value().write_flatbuffer(fbb));
 
         let stat_args = &crate::flatbuffers::ArrayStatsArgs {
             min,

--- a/vortex-array/src/stats/statsset.rs
+++ b/vortex-array/src/stats/statsset.rs
@@ -5,7 +5,7 @@ use enum_map::EnumMap;
 use itertools::{EitherOrBoth, Itertools};
 use vortex_dtype::DType;
 use vortex_error::{vortex_panic, VortexError};
-use vortex_scalar::{Scalar, ScalarValue};
+use vortex_scalar::Scalar;
 
 use crate::stats::Stat;
 
@@ -58,7 +58,7 @@ impl StatsSet {
         stats
     }
 
-    pub fn constant(scalar: Scalar, length: usize) -> Self {
+    pub fn constant(scalar: &Scalar, length: usize) -> Self {
         let mut stats = Self::default();
         if length > 0 {
             stats.set(Stat::IsConstant, true);
@@ -69,20 +69,19 @@ impl StatsSet {
         let run_count = if length == 0 { 0u64 } else { 1 };
         stats.set(Stat::RunCount, run_count);
 
-        let null_count = if scalar.value().is_null() {
-            length as u64
-        } else {
-            0
-        };
+        let null_count = if scalar.is_null() { length as u64 } else { 0 };
         stats.set(Stat::NullCount, null_count);
 
-        if let ScalarValue::Bool(b) = scalar.value() {
-            let true_count = if *b { length as u64 } else { 0 };
+        if let Some(bool_scalar) = scalar.as_bool_opt() {
+            let true_count = bool_scalar
+                .value()
+                .map(|b| if b { length as u64 } else { 0 })
+                .unwrap_or(0);
             stats.set(Stat::TrueCount, true_count);
         }
 
         stats.set(Stat::Min, scalar.clone());
-        stats.set(Stat::Max, scalar);
+        stats.set(Stat::Max, scalar.clone());
 
         stats
     }

--- a/vortex-array/src/stats/statsset.rs
+++ b/vortex-array/src/stats/statsset.rs
@@ -581,20 +581,14 @@ mod test {
             merged
                 .get(Stat::NullCount)
                 .unwrap()
-                .value()
-                .as_pvalue()
-                .unwrap()
-                .unwrap()
-                .as_u64()
+                .as_primitive()
+                .typed_value::<u64>()
                 .unwrap(),
             2 * stats
                 .get(Stat::NullCount)
                 .unwrap()
-                .value()
-                .as_pvalue()
-                .unwrap()
-                .unwrap()
-                .as_u64()
+                .as_primitive()
+                .typed_value::<u64>()
                 .unwrap()
         );
     }

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -33,6 +33,7 @@ pub enum DType {
     /// Binary data
     Binary(Nullability),
     /// A struct is composed of an ordered list of fields, each with a corresponding name and DType
+    /// TODO(ngates): we may want StructDType to be Arc<[Field]> instead so it's only a single Arc.
     Struct(StructDType, Nullability),
     /// A variable-length list type, parameterized by a single element DType
     List(Arc<DType>, Nullability),

--- a/vortex-dtype/src/ptype.rs
+++ b/vortex-dtype/src/ptype.rs
@@ -64,6 +64,9 @@ pub trait NativePType:
     /// The PType that corresponds to this native type
     const PTYPE: PType;
 
+    // /// The NonNullable DType that corresponds to this native type
+    // const DTYPE: DType;
+
     /// Whether this instance (`self`) is NaN
     /// For integer types, this is always `false`
     fn is_nan(self) -> bool;
@@ -79,6 +82,7 @@ macro_rules! native_ptype {
     ($T:ty, $ptype:tt) => {
         impl NativePType for $T {
             const PTYPE: PType = PType::$ptype;
+            // const DTYPE: DType = DType::Primitive(Self::PTYPE, Nullability::NonNullable);
 
             fn is_nan(self) -> bool {
                 false
@@ -99,6 +103,7 @@ macro_rules! native_float_ptype {
     ($T:ty, $ptype:tt) => {
         impl NativePType for $T {
             const PTYPE: PType = PType::$ptype;
+            // const DTYPE: DType = DType::Primitive(Self::PTYPE, Nullability::NonNullable);
 
             fn is_nan(self) -> bool {
                 <$T>::is_nan(self)

--- a/vortex-dtype/src/ptype.rs
+++ b/vortex-dtype/src/ptype.rs
@@ -64,9 +64,6 @@ pub trait NativePType:
     /// The PType that corresponds to this native type
     const PTYPE: PType;
 
-    // /// The NonNullable DType that corresponds to this native type
-    // const DTYPE: DType;
-
     /// Whether this instance (`self`) is NaN
     /// For integer types, this is always `false`
     fn is_nan(self) -> bool;
@@ -82,7 +79,6 @@ macro_rules! native_ptype {
     ($T:ty, $ptype:tt) => {
         impl NativePType for $T {
             const PTYPE: PType = PType::$ptype;
-            // const DTYPE: DType = DType::Primitive(Self::PTYPE, Nullability::NonNullable);
 
             fn is_nan(self) -> bool {
                 false
@@ -103,7 +99,6 @@ macro_rules! native_float_ptype {
     ($T:ty, $ptype:tt) => {
         impl NativePType for $T {
             const PTYPE: PType = PType::$ptype;
-            // const DTYPE: DType = DType::Primitive(Self::PTYPE, Nullability::NonNullable);
 
             fn is_nan(self) -> bool {
                 <$T>::is_nan(self)

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -200,7 +200,7 @@ mod tests {
         );
 
         assert_eq!(
-            Literal::new_expr(Scalar::r#struct(
+            Literal::new_expr(Scalar::struct_(
                 DType::Struct(
                     StructDType::new(
                         Arc::from([Arc::from("dog"), Arc::from("cat")]),

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -83,7 +83,7 @@ pub fn unbox_any(any: &dyn Any) -> &dyn Any {
 mod tests {
     use vortex_dtype::field::Field;
     use vortex_dtype::{DType, Nullability, PType, StructDType};
-    use vortex_scalar::{Scalar, ScalarValue};
+    use vortex_scalar::Scalar;
 
     use super::*;
 
@@ -200,7 +200,7 @@ mod tests {
         );
 
         assert_eq!(
-            Literal::new_expr(Scalar::new(
+            Literal::new_expr(Scalar::r#struct(
                 DType::Struct(
                     StructDType::new(
                         Arc::from([Arc::from("dog"), Arc::from("cat")]),
@@ -211,10 +211,7 @@ mod tests {
                     ),
                     Nullability::NonNullable
                 ),
-                ScalarValue::List(Arc::from([
-                    ScalarValue::from(32_u32),
-                    ScalarValue::from("rufus".to_string())
-                ]))
+                vec![Scalar::from(32_u32), Scalar::from("rufus".to_string())]
             ))
             .to_string(),
             "{dog:32_u32,cat:rufus}"

--- a/vortex-file/src/pruning.rs
+++ b/vortex-file/src/pruning.rs
@@ -90,10 +90,8 @@ impl PruningPredicate {
             // Is the expression constant false, i.e. prune nothing
             if lexp
                 .value()
-                .value()
-                .as_bool()
-                .ok()
-                .flatten()
+                .as_bool_opt()
+                .and_then(|b| b.value())
                 .map(|b| !b)
                 .unwrap_or(false)
             {

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -977,10 +977,8 @@ async fn test_pruning_with_or() {
             .map(|index| -> Option<i32> {
                 scalar_at(&numbers, index)
                     .unwrap()
-                    .into_value()
-                    .as_pvalue()
-                    .unwrap()
-                    .map(|x| i32::try_from(x).unwrap())
+                    .as_primitive()
+                    .typed_value::<i32>()
             })
             .collect::<Vec<_>>(),
         vec![

--- a/vortex-file/src/write/metadata_accumulators.rs
+++ b/vortex-file/src/write/metadata_accumulators.rs
@@ -220,7 +220,7 @@ mod tests {
     use vortex_array::array::{BoolArray, ConstantArray, PrimitiveArray};
     use vortex_array::variants::StructArrayTrait;
     use vortex_array::ArrayLen;
-    use vortex_dtype::{Nullability, PType};
+    use vortex_dtype::Nullability;
     use vortex_scalar::Scalar;
 
     use super::*;
@@ -287,11 +287,7 @@ mod tests {
     #[test]
     fn test_standard_metadata_all_null() {
         let mut standard_accumulator = StandardAccumulator::<u64>::new();
-        let chunk = ConstantArray::new(
-            Scalar::null(DType::Primitive(PType::U64, Nullability::Nullable)),
-            10,
-        )
-        .into_array();
+        let chunk = ConstantArray::new(Scalar::null_typed::<u64>(), 10).into_array();
         standard_accumulator.push_chunk(&chunk);
 
         let metadata_array = StructArray::try_from(
@@ -308,11 +304,7 @@ mod tests {
     #[test]
     fn test_standard_metadata_empty() {
         let mut standard_accumulator = StandardAccumulator::<u64>::new();
-        let chunk = ConstantArray::new(
-            Scalar::null(DType::Primitive(PType::U64, Nullability::Nullable)),
-            0,
-        )
-        .into_array();
+        let chunk = ConstantArray::new(Scalar::null_typed::<u64>(), 0).into_array();
         standard_accumulator.push_chunk(&chunk);
 
         let metadata_array = StructArray::try_from(

--- a/vortex-file/src/write/metadata_accumulators.rs
+++ b/vortex-file/src/write/metadata_accumulators.rs
@@ -9,7 +9,7 @@ use vortex_array::{ArrayData, IntoArrayData};
 use vortex_buffer::{Buffer, BufferString};
 use vortex_dtype::{match_each_native_ptype, DType, FieldName};
 use vortex_error::{VortexError, VortexResult};
-use vortex_scalar::ScalarValue;
+use vortex_scalar::Scalar;
 
 pub fn new_metadata_accumulator(dtype: &DType) -> Box<dyn MetadataAccumulator> {
     match dtype {
@@ -104,7 +104,7 @@ impl<T> StandardAccumulator<T> {
 
 impl<T> MetadataAccumulator for StandardAccumulator<T>
 where
-    Option<T>: TryFrom<ScalarValue, Error = VortexError>,
+    Option<T>: TryFrom<Scalar, Error = VortexError>,
     ArrayData: FromIterator<Option<T>>,
 {
     fn push_chunk(&mut self, array: &ArrayData) {
@@ -194,7 +194,7 @@ impl<T> UnwrappedStatAccumulator<T> {
 
 impl<T> SingularAccumulator for UnwrappedStatAccumulator<T>
 where
-    Option<T>: TryFrom<ScalarValue, Error = VortexError>,
+    Option<T>: TryFrom<Scalar, Error = VortexError>,
     ArrayData: FromIterator<Option<T>>,
 {
     fn push_chunk(&mut self, array: &ArrayData) {
@@ -202,7 +202,7 @@ where
             array
                 .statistics()
                 .compute(self.stat)
-                .and_then(|s| Option::<T>::try_from(s.into_value()).ok())
+                .and_then(|s| Option::<T>::try_from(s).ok())
                 .flatten(),
         )
     }

--- a/vortex-sampling-compressor/src/compressors/for.rs
+++ b/vortex-sampling-compressor/src/compressors/for.rs
@@ -65,7 +65,7 @@ impl EncodingCompressor for FoRCompressor {
         Ok(CompressedArray::compressed(
             FoRArray::try_new(
                 compressed_child.array,
-                compressed.owned_reference_scalar(),
+                compressed.reference_scalar(),
                 compressed.shift(),
             )
             .map(|a| a.into_array())?,

--- a/vortex-sampling-compressor/src/compressors/sparse.rs
+++ b/vortex-sampling-compressor/src/compressors/sparse.rs
@@ -44,7 +44,7 @@ impl EncodingCompressor for SparseCompressor {
                 indices.array,
                 values.array,
                 sparse_array.len(),
-                sparse_array.fill_value().clone(),
+                sparse_array.fill_scalar(),
             )?
             .into_array(),
             Some(CompressionTree::new(self, vec![indices.path, values.path])),

--- a/vortex-scalar/Cargo.toml
+++ b/vortex-scalar/Cargo.toml
@@ -20,7 +20,6 @@ bytes = { workspace = true }
 datafusion-common = { workspace = true, optional = true }
 flatbuffers = { workspace = true, optional = true }
 flexbuffers = { workspace = true, optional = true }
-half = { workspace = true }
 itertools = { workspace = true }
 num-traits = { workspace = true }
 paste = { workspace = true }

--- a/vortex-scalar/src/arbitrary.rs
+++ b/vortex-scalar/src/arbitrary.rs
@@ -5,7 +5,7 @@ use vortex_buffer::{Buffer, BufferString};
 use vortex_dtype::half::f16;
 use vortex_dtype::{DType, PType};
 
-use crate::{Inner, PValue, Scalar, ScalarValue};
+use crate::{InnerScalarValue, PValue, Scalar, ScalarValue};
 
 pub fn random_scalar(u: &mut Unstructured, dtype: &DType) -> Result<Scalar> {
     Ok(Scalar::new(dtype.clone(), random_scalar_value(u, dtype)?))
@@ -13,23 +13,25 @@ pub fn random_scalar(u: &mut Unstructured, dtype: &DType) -> Result<Scalar> {
 
 fn random_scalar_value(u: &mut Unstructured, dtype: &DType) -> Result<ScalarValue> {
     match dtype {
-        DType::Null => Ok(ScalarValue(Inner::Null)),
-        DType::Bool(_) => Ok(ScalarValue(Inner::Bool(u.arbitrary()?))),
-        DType::Primitive(p, _) => Ok(ScalarValue(Inner::Primitive(random_pvalue(u, p)?))),
-        DType::Utf8(_) => Ok(ScalarValue(Inner::BufferString(BufferString::from(
-            u.arbitrary::<String>()?,
-        )))),
-        DType::Binary(_) => Ok(ScalarValue(Inner::Buffer(Buffer::from(
+        DType::Null => Ok(ScalarValue(InnerScalarValue::Null)),
+        DType::Bool(_) => Ok(ScalarValue(InnerScalarValue::Bool(u.arbitrary()?))),
+        DType::Primitive(p, _) => Ok(ScalarValue(InnerScalarValue::Primitive(random_pvalue(
+            u, p,
+        )?))),
+        DType::Utf8(_) => Ok(ScalarValue(InnerScalarValue::BufferString(
+            BufferString::from(u.arbitrary::<String>()?),
+        ))),
+        DType::Binary(_) => Ok(ScalarValue(InnerScalarValue::Buffer(Buffer::from(
             u.arbitrary::<Vec<u8>>()?,
         )))),
-        DType::Struct(sdt, _) => Ok(ScalarValue(Inner::List(
+        DType::Struct(sdt, _) => Ok(ScalarValue(InnerScalarValue::List(
             sdt.dtypes()
                 .iter()
                 .map(|d| random_scalar_value(u, d))
                 .collect::<Result<Vec<_>>>()?
                 .into(),
         ))),
-        DType::List(edt, _) => Ok(ScalarValue(Inner::List(
+        DType::List(edt, _) => Ok(ScalarValue(InnerScalarValue::List(
             iter::from_fn(|| {
                 u.arbitrary()
                     .unwrap_or(false)

--- a/vortex-scalar/src/arbitrary.rs
+++ b/vortex-scalar/src/arbitrary.rs
@@ -27,7 +27,7 @@ fn random_scalar_value(u: &mut Unstructured, dtype: &DType) -> Result<ScalarValu
         DType::Struct(sdt, _) => Ok(ScalarValue(InnerScalarValue::List(
             sdt.dtypes()
                 .iter()
-                .map(|d| random_scalar_value(u, d))
+                .map(|d| random_scalar_value(u, d).map(|x| x.0))
                 .collect::<Result<Vec<_>>>()?
                 .into(),
         ))),
@@ -35,9 +35,9 @@ fn random_scalar_value(u: &mut Unstructured, dtype: &DType) -> Result<ScalarValu
             iter::from_fn(|| {
                 u.arbitrary()
                     .unwrap_or(false)
-                    .then(|| random_scalar_value(u, edt))
+                    .then(|| random_scalar_value(u, edt).map(|x| x.0))
             })
-            .collect::<Result<Vec<ScalarValue>>>()?
+            .collect::<Result<Vec<_>>>()?
             .into(),
         ))),
         DType::Extension(..) => {

--- a/vortex-scalar/src/arbitrary.rs
+++ b/vortex-scalar/src/arbitrary.rs
@@ -5,7 +5,7 @@ use vortex_buffer::{Buffer, BufferString};
 use vortex_dtype::half::f16;
 use vortex_dtype::{DType, PType};
 
-use crate::{PValue, Scalar, ScalarValue};
+use crate::{Inner, PValue, Scalar, ScalarValue};
 
 pub fn random_scalar(u: &mut Unstructured, dtype: &DType) -> Result<Scalar> {
     Ok(Scalar::new(dtype.clone(), random_scalar_value(u, dtype)?))
@@ -13,21 +13,23 @@ pub fn random_scalar(u: &mut Unstructured, dtype: &DType) -> Result<Scalar> {
 
 fn random_scalar_value(u: &mut Unstructured, dtype: &DType) -> Result<ScalarValue> {
     match dtype {
-        DType::Null => Ok(ScalarValue::Null),
-        DType::Bool(_) => Ok(ScalarValue::Bool(u.arbitrary()?)),
-        DType::Primitive(p, _) => Ok(ScalarValue::Primitive(random_pvalue(u, p)?)),
-        DType::Utf8(_) => Ok(ScalarValue::BufferString(BufferString::from(
+        DType::Null => Ok(ScalarValue(Inner::Null)),
+        DType::Bool(_) => Ok(ScalarValue(Inner::Bool(u.arbitrary()?))),
+        DType::Primitive(p, _) => Ok(ScalarValue(Inner::Primitive(random_pvalue(u, p)?))),
+        DType::Utf8(_) => Ok(ScalarValue(Inner::BufferString(BufferString::from(
             u.arbitrary::<String>()?,
-        ))),
-        DType::Binary(_) => Ok(ScalarValue::Buffer(Buffer::from(u.arbitrary::<Vec<u8>>()?))),
-        DType::Struct(sdt, _) => Ok(ScalarValue::List(
+        )))),
+        DType::Binary(_) => Ok(ScalarValue(Inner::Buffer(Buffer::from(
+            u.arbitrary::<Vec<u8>>()?,
+        )))),
+        DType::Struct(sdt, _) => Ok(ScalarValue(Inner::List(
             sdt.dtypes()
                 .iter()
                 .map(|d| random_scalar_value(u, d))
                 .collect::<Result<Vec<_>>>()?
                 .into(),
-        )),
-        DType::List(edt, _) => Ok(ScalarValue::List(
+        ))),
+        DType::List(edt, _) => Ok(ScalarValue(Inner::List(
             iter::from_fn(|| {
                 u.arbitrary()
                     .unwrap_or(false)
@@ -35,7 +37,7 @@ fn random_scalar_value(u: &mut Unstructured, dtype: &DType) -> Result<ScalarValu
             })
             .collect::<Result<Vec<ScalarValue>>>()?
             .into(),
-        )),
+        ))),
         DType::Extension(..) => {
             unreachable!("Can't yet generate arbitrary scalars for ext dtype")
         }

--- a/vortex-scalar/src/arrow.rs
+++ b/vortex-scalar/src/arrow.rs
@@ -76,7 +76,7 @@ impl TryFrom<&Scalar> for Arc<dyn Datum> {
                 value_to_arrow_scalar!(value.as_utf8().value(), StringViewArray)
             }
             DType::Binary(_) => {
-                value_to_arrow_scalar!(value.value.as_buffer()?, BinaryViewArray)
+                value_to_arrow_scalar!(value.as_binary().value(), BinaryViewArray)
             }
             DType::Struct(..) => {
                 todo!("struct scalar conversion")

--- a/vortex-scalar/src/arrow.rs
+++ b/vortex-scalar/src/arrow.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use arrow_array::*;
 use vortex_datetime_dtype::{is_temporal_ext_type, TemporalMetadata, TimeUnit};
 use vortex_dtype::{DType, PType};
-use vortex_error::{vortex_bail, VortexError};
+use vortex_error::{vortex_bail, vortex_err, VortexError};
 
-use crate::{PValue, Scalar};
+use crate::Scalar;
 
 macro_rules! value_to_arrow_scalar {
     ($V:expr, $AR:ty) => {
@@ -22,40 +22,58 @@ impl TryFrom<&Scalar> for Arc<dyn Datum> {
     fn try_from(value: &Scalar) -> Result<Arc<dyn Datum>, Self::Error> {
         match value.dtype() {
             DType::Null => Ok(Arc::new(NullArray::new(1))),
-            DType::Bool(_) => value_to_arrow_scalar!(value.value.as_bool()?, BooleanArray),
-            DType::Primitive(ptype, _) => {
-                let pvalue = value.value.as_pvalue()?;
-                Ok(match pvalue {
-                    None => match ptype {
-                        PType::U8 => Arc::new(UInt8Array::new_null(1)),
-                        PType::U16 => Arc::new(UInt16Array::new_null(1)),
-                        PType::U32 => Arc::new(UInt32Array::new_null(1)),
-                        PType::U64 => Arc::new(UInt64Array::new_null(1)),
-                        PType::I8 => Arc::new(Int8Array::new_null(1)),
-                        PType::I16 => Arc::new(Int16Array::new_null(1)),
-                        PType::I32 => Arc::new(Int32Array::new_null(1)),
-                        PType::I64 => Arc::new(Int64Array::new_null(1)),
-                        PType::F16 => Arc::new(Float16Array::new_null(1)),
-                        PType::F32 => Arc::new(Float32Array::new_null(1)),
-                        PType::F64 => Arc::new(Float64Array::new_null(1)),
-                    },
-                    Some(pvalue) => match pvalue {
-                        PValue::U8(v) => Arc::new(UInt8Array::new_scalar(v)),
-                        PValue::U16(v) => Arc::new(UInt16Array::new_scalar(v)),
-                        PValue::U32(v) => Arc::new(UInt32Array::new_scalar(v)),
-                        PValue::U64(v) => Arc::new(UInt64Array::new_scalar(v)),
-                        PValue::I8(v) => Arc::new(Int8Array::new_scalar(v)),
-                        PValue::I16(v) => Arc::new(Int16Array::new_scalar(v)),
-                        PValue::I32(v) => Arc::new(Int32Array::new_scalar(v)),
-                        PValue::I64(v) => Arc::new(Int64Array::new_scalar(v)),
-                        PValue::F16(v) => Arc::new(Float16Array::new_scalar(v)),
-                        PValue::F32(v) => Arc::new(Float32Array::new_scalar(v)),
-                        PValue::F64(v) => Arc::new(Float64Array::new_scalar(v)),
-                    },
+            DType::Bool(_) => value_to_arrow_scalar!(value.as_bool().value(), BooleanArray),
+            DType::Primitive(ptype, ..) => {
+                let scalar = value.as_primitive();
+                Ok(match ptype {
+                    PType::U8 => scalar
+                        .typed_value()
+                        .map(|i| Arc::new(UInt8Array::new_scalar(i)) as Arc<dyn Datum>)
+                        .unwrap_or_else(|| Arc::new(UInt8Array::new_null(1))),
+                    PType::U16 => scalar
+                        .typed_value()
+                        .map(|i| Arc::new(UInt16Array::new_scalar(i)) as Arc<dyn Datum>)
+                        .unwrap_or_else(|| Arc::new(UInt16Array::new_null(1))),
+                    PType::U32 => scalar
+                        .typed_value()
+                        .map(|i| Arc::new(UInt32Array::new_scalar(i)) as Arc<dyn Datum>)
+                        .unwrap_or_else(|| Arc::new(UInt32Array::new_null(1))),
+                    PType::U64 => scalar
+                        .typed_value()
+                        .map(|i| Arc::new(UInt64Array::new_scalar(i)) as Arc<dyn Datum>)
+                        .unwrap_or_else(|| Arc::new(UInt64Array::new_null(1))),
+                    PType::I8 => scalar
+                        .typed_value()
+                        .map(|i| Arc::new(Int8Array::new_scalar(i)) as Arc<dyn Datum>)
+                        .unwrap_or_else(|| Arc::new(Int8Array::new_null(1))),
+                    PType::I16 => scalar
+                        .typed_value()
+                        .map(|i| Arc::new(Int16Array::new_scalar(i)) as Arc<dyn Datum>)
+                        .unwrap_or_else(|| Arc::new(Int16Array::new_null(1))),
+                    PType::I32 => scalar
+                        .typed_value()
+                        .map(|i| Arc::new(Int32Array::new_scalar(i)) as Arc<dyn Datum>)
+                        .unwrap_or_else(|| Arc::new(Int32Array::new_null(1))),
+                    PType::I64 => scalar
+                        .typed_value()
+                        .map(|i| Arc::new(Int64Array::new_scalar(i)) as Arc<dyn Datum>)
+                        .unwrap_or_else(|| Arc::new(Int64Array::new_null(1))),
+                    PType::F16 => scalar
+                        .typed_value()
+                        .map(|i| Arc::new(Float16Array::new_scalar(i)) as Arc<dyn Datum>)
+                        .unwrap_or_else(|| Arc::new(Float16Array::new_null(1))),
+                    PType::F32 => scalar
+                        .typed_value()
+                        .map(|i| Arc::new(Float32Array::new_scalar(i)) as Arc<dyn Datum>)
+                        .unwrap_or_else(|| Arc::new(Float32Array::new_null(1))),
+                    PType::F64 => scalar
+                        .typed_value()
+                        .map(|i| Arc::new(Float64Array::new_scalar(i)) as Arc<dyn Datum>)
+                        .unwrap_or_else(|| Arc::new(Float64Array::new_null(1))),
                 })
             }
             DType::Utf8(_) => {
-                value_to_arrow_scalar!(value.value.as_buffer_string()?, StringViewArray)
+                value_to_arrow_scalar!(value.as_utf8().value(), StringViewArray)
             }
             DType::Binary(_) => {
                 value_to_arrow_scalar!(value.value.as_buffer()?, BinaryViewArray)
@@ -69,53 +87,56 @@ impl TryFrom<&Scalar> for Arc<dyn Datum> {
             DType::Extension(ext) => {
                 if is_temporal_ext_type(ext.id()) {
                     let metadata = TemporalMetadata::try_from(ext.as_ref())?;
-                    let pv = value.value.as_pvalue()?;
+                    let storage_scalar = value.as_extension().storage();
+                    let primitive = storage_scalar
+                        .as_primitive_opt()
+                        .ok_or_else(|| vortex_err!("Expected primitive scalar"))?;
+
                     return match metadata {
                         TemporalMetadata::Time(u) => match u {
                             TimeUnit::Ns => value_to_arrow_scalar!(
-                                pv.and_then(|p| p.as_i64()),
+                                primitive.as_::<i64>()?,
                                 Time64NanosecondArray
                             ),
                             TimeUnit::Us => value_to_arrow_scalar!(
-                                pv.and_then(|p| p.as_i64()),
+                                primitive.as_::<i64>()?,
                                 Time64MicrosecondArray
                             ),
                             TimeUnit::Ms => value_to_arrow_scalar!(
-                                pv.and_then(|p| p.as_i32()),
+                                primitive.as_::<i32>()?,
                                 Time32MillisecondArray
                             ),
-                            TimeUnit::S => value_to_arrow_scalar!(
-                                pv.and_then(|p| p.as_i32()),
-                                Time32SecondArray
-                            ),
+                            TimeUnit::S => {
+                                value_to_arrow_scalar!(primitive.as_::<i32>()?, Time32SecondArray)
+                            }
                             TimeUnit::D => {
                                 vortex_bail!("Unsupported TimeUnit {u} for {}", ext.id())
                             }
                         },
                         TemporalMetadata::Date(u) => match u {
                             TimeUnit::Ms => {
-                                value_to_arrow_scalar!(pv.and_then(|p| p.as_i64()), Date64Array)
+                                value_to_arrow_scalar!(primitive.as_::<i64>()?, Date64Array)
                             }
                             TimeUnit::D => {
-                                value_to_arrow_scalar!(pv.and_then(|p| p.as_i32()), Date32Array)
+                                value_to_arrow_scalar!(primitive.as_::<i32>()?, Date32Array)
                             }
                             _ => vortex_bail!("Unsupported TimeUnit {u} for {}", ext.id()),
                         },
                         TemporalMetadata::Timestamp(u, _) => match u {
                             TimeUnit::Ns => value_to_arrow_scalar!(
-                                pv.and_then(|p| p.as_i64()),
+                                primitive.as_::<i64>()?,
                                 TimestampNanosecondArray
                             ),
                             TimeUnit::Us => value_to_arrow_scalar!(
-                                pv.and_then(|p| p.as_i64()),
+                                primitive.as_::<i64>()?,
                                 TimestampMicrosecondArray
                             ),
                             TimeUnit::Ms => value_to_arrow_scalar!(
-                                pv.and_then(|p| p.as_i64()),
+                                primitive.as_::<i64>()?,
                                 TimestampMillisecondArray
                             ),
                             TimeUnit::S => value_to_arrow_scalar!(
-                                pv.and_then(|p| p.as_i64()),
+                                primitive.as_::<i64>()?,
                                 TimestampSecondArray
                             ),
                             TimeUnit::D => {

--- a/vortex-scalar/src/binary.rs
+++ b/vortex-scalar/src/binary.rs
@@ -58,7 +58,7 @@ impl<'a> TryFrom<&'a Scalar> for Buffer {
 
         binary
             .value()
-            .ok_or_else(|| vortex_err!("Can't extract present value from null scalar"))
+            .ok_or_else(|| vortex_err!("Cannot extract present value from null scalar"))
     }
 }
 
@@ -68,7 +68,7 @@ impl<'a> TryFrom<&'a Scalar> for Option<Buffer> {
     fn try_from(scalar: &'a Scalar) -> VortexResult<Self> {
         Ok(scalar
             .as_binary_opt()
-            .ok_or_else(|| vortex_err!("cannot convert non-binary scalar to buffer"))?
+            .ok_or_else(|| vortex_err!("Cannot extract buffer from non-buffer scalar"))?
             .value())
     }
 }

--- a/vortex-scalar/src/binary.rs
+++ b/vortex-scalar/src/binary.rs
@@ -66,7 +66,10 @@ impl<'a> TryFrom<&'a Scalar> for Option<Buffer> {
     type Error = VortexError;
 
     fn try_from(scalar: &'a Scalar) -> VortexResult<Self> {
-        Ok(BinaryScalar::try_from(scalar)?.value())
+        Ok(scalar
+            .as_binary_opt()
+            .ok_or_else(|| vortex_err!("cannot convert non-binary scalar to buffer"))?
+            .value())
     }
 }
 

--- a/vortex-scalar/src/binary.rs
+++ b/vortex-scalar/src/binary.rs
@@ -52,7 +52,16 @@ impl<'a> TryFrom<&'a Scalar> for Buffer {
     type Error = VortexError;
 
     fn try_from(scalar: &'a Scalar) -> VortexResult<Self> {
-        Buffer::try_from(scalar.value())
+        <Option<Buffer>>::try_from(scalar)?
+            .ok_or_else(|| vortex_err!("Can't extract present value from null scalar"))
+    }
+}
+
+impl<'a> TryFrom<&'a Scalar> for Option<Buffer> {
+    type Error = VortexError;
+
+    fn try_from(scalar: &'a Scalar) -> VortexResult<Self> {
+        Ok(BinaryScalar::try_from(scalar)?.value())
     }
 }
 
@@ -60,39 +69,32 @@ impl TryFrom<Scalar> for Buffer {
     type Error = VortexError;
 
     fn try_from(scalar: Scalar) -> VortexResult<Self> {
-        Buffer::try_from(&scalar)
+        Self::try_from(&scalar)
     }
 }
 
-impl TryFrom<&ScalarValue> for Buffer {
+impl TryFrom<Scalar> for Option<Buffer> {
     type Error = VortexError;
 
-    fn try_from(value: &ScalarValue) -> Result<Self, Self::Error> {
-        Option::<Buffer>::try_from(value)?
-            .ok_or_else(|| vortex_err!("Can't extract present value from null scalar"))
+    fn try_from(scalar: Scalar) -> VortexResult<Self> {
+        Self::try_from(&scalar)
     }
 }
 
-impl TryFrom<ScalarValue> for Buffer {
-    type Error = VortexError;
-
-    fn try_from(value: ScalarValue) -> Result<Self, Self::Error> {
-        Buffer::try_from(&value)
+impl From<bytes::Bytes> for Scalar {
+    fn from(value: bytes::Bytes) -> Self {
+        Self {
+            dtype: DType::Binary(Nullability::NonNullable),
+            value: ScalarValue::Buffer(value.into()),
+        }
     }
 }
 
-impl TryFrom<&ScalarValue> for Option<Buffer> {
-    type Error = VortexError;
-
-    fn try_from(value: &ScalarValue) -> Result<Self, Self::Error> {
-        value.as_buffer()
-    }
-}
-
-impl TryFrom<ScalarValue> for Option<Buffer> {
-    type Error = VortexError;
-
-    fn try_from(value: ScalarValue) -> Result<Self, Self::Error> {
-        Option::<Buffer>::try_from(&value)
+impl From<Buffer> for Scalar {
+    fn from(value: Buffer) -> Self {
+        Self {
+            dtype: DType::Binary(Nullability::NonNullable),
+            value: ScalarValue::Buffer(value),
+        }
     }
 }

--- a/vortex-scalar/src/binary.rs
+++ b/vortex-scalar/src/binary.rs
@@ -52,7 +52,12 @@ impl<'a> TryFrom<&'a Scalar> for Buffer {
     type Error = VortexError;
 
     fn try_from(scalar: &'a Scalar) -> VortexResult<Self> {
-        <Option<Buffer>>::try_from(scalar)?
+        let binary = scalar
+            .as_binary_opt()
+            .ok_or_else(|| vortex_err!("Cannot extract buffer from non-buffer scalar"))?;
+
+        binary
+            .value()
             .ok_or_else(|| vortex_err!("Can't extract present value from null scalar"))
     }
 }

--- a/vortex-scalar/src/binary.rs
+++ b/vortex-scalar/src/binary.rs
@@ -88,19 +88,13 @@ impl TryFrom<Scalar> for Option<Buffer> {
 
 impl From<&[u8]> for Scalar {
     fn from(value: &[u8]) -> Self {
-        Self {
-            dtype: DType::Binary(Nullability::NonNullable),
-            value: ScalarValue(InnerScalarValue::Buffer(value.into())),
-        }
+        Scalar::from(Buffer::from(value))
     }
 }
 
 impl From<bytes::Bytes> for Scalar {
     fn from(value: bytes::Bytes) -> Self {
-        Self {
-            dtype: DType::Binary(Nullability::NonNullable),
-            value: ScalarValue(InnerScalarValue::Buffer(value.into())),
-        }
+        Scalar::from(Buffer::from(value))
     }
 }
 

--- a/vortex-scalar/src/binary.rs
+++ b/vortex-scalar/src/binary.rs
@@ -2,7 +2,7 @@ use vortex_buffer::Buffer;
 use vortex_dtype::{DType, Nullability};
 use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
 
-use crate::value::{Inner, ScalarValue};
+use crate::value::{InnerScalarValue, ScalarValue};
 use crate::Scalar;
 
 pub struct BinaryScalar<'a> {
@@ -29,7 +29,7 @@ impl Scalar {
     pub fn binary(buffer: Buffer, nullability: Nullability) -> Self {
         Self {
             dtype: DType::Binary(nullability),
-            value: ScalarValue(Inner::Buffer(buffer)),
+            value: ScalarValue(InnerScalarValue::Buffer(buffer)),
         }
     }
 }
@@ -85,7 +85,7 @@ impl From<&[u8]> for Scalar {
     fn from(value: &[u8]) -> Self {
         Self {
             dtype: DType::Binary(Nullability::NonNullable),
-            value: ScalarValue(Inner::Buffer(value.into())),
+            value: ScalarValue(InnerScalarValue::Buffer(value.into())),
         }
     }
 }
@@ -94,7 +94,7 @@ impl From<bytes::Bytes> for Scalar {
     fn from(value: bytes::Bytes) -> Self {
         Self {
             dtype: DType::Binary(Nullability::NonNullable),
-            value: ScalarValue(Inner::Buffer(value.into())),
+            value: ScalarValue(InnerScalarValue::Buffer(value.into())),
         }
     }
 }
@@ -103,7 +103,7 @@ impl From<Buffer> for Scalar {
     fn from(value: Buffer) -> Self {
         Self {
             dtype: DType::Binary(Nullability::NonNullable),
-            value: ScalarValue(Inner::Buffer(value)),
+            value: ScalarValue(InnerScalarValue::Buffer(value)),
         }
     }
 }

--- a/vortex-scalar/src/binary.rs
+++ b/vortex-scalar/src/binary.rs
@@ -2,7 +2,7 @@ use vortex_buffer::Buffer;
 use vortex_dtype::{DType, Nullability};
 use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
 
-use crate::value::ScalarValue;
+use crate::value::{Inner, ScalarValue};
 use crate::Scalar;
 
 pub struct BinaryScalar<'a> {
@@ -29,7 +29,7 @@ impl Scalar {
     pub fn binary(buffer: Buffer, nullability: Nullability) -> Self {
         Self {
             dtype: DType::Binary(nullability),
-            value: ScalarValue::Buffer(buffer),
+            value: ScalarValue(Inner::Buffer(buffer)),
         }
     }
 }
@@ -81,11 +81,20 @@ impl TryFrom<Scalar> for Option<Buffer> {
     }
 }
 
+impl From<&[u8]> for Scalar {
+    fn from(value: &[u8]) -> Self {
+        Self {
+            dtype: DType::Binary(Nullability::NonNullable),
+            value: ScalarValue(Inner::Buffer(value.into())),
+        }
+    }
+}
+
 impl From<bytes::Bytes> for Scalar {
     fn from(value: bytes::Bytes) -> Self {
         Self {
             dtype: DType::Binary(Nullability::NonNullable),
-            value: ScalarValue::Buffer(value.into()),
+            value: ScalarValue(Inner::Buffer(value.into())),
         }
     }
 }
@@ -94,7 +103,7 @@ impl From<Buffer> for Scalar {
     fn from(value: Buffer) -> Self {
         Self {
             dtype: DType::Binary(Nullability::NonNullable),
-            value: ScalarValue::Buffer(value),
+            value: ScalarValue(Inner::Buffer(value)),
         }
     }
 }

--- a/vortex-scalar/src/bool.rs
+++ b/vortex-scalar/src/bool.rs
@@ -29,6 +29,23 @@ impl<'a> BoolScalar<'a> {
             _ => vortex_bail!("Can't cast {} to bool", dtype),
         }
     }
+
+    pub fn invert(self) -> BoolScalar<'a> {
+        BoolScalar {
+            dtype: self.dtype,
+            value: self.value.map(|v| !v),
+        }
+    }
+
+    pub fn into_scalar(self) -> Scalar {
+        Scalar {
+            dtype: self.dtype.clone(),
+            value: self
+                .value
+                .map(|x| ScalarValue(InnerScalarValue::Bool(x)))
+                .unwrap_or_else(|| ScalarValue(InnerScalarValue::Null)),
+        }
+    }
 }
 
 impl Scalar {

--- a/vortex-scalar/src/bool.rs
+++ b/vortex-scalar/src/bool.rs
@@ -3,7 +3,7 @@ use vortex_dtype::{DType, Nullability};
 use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
 
 use crate::value::ScalarValue;
-use crate::{Inner, Scalar};
+use crate::{InnerScalarValue, Scalar};
 
 pub struct BoolScalar<'a> {
     dtype: &'a DType,
@@ -35,7 +35,7 @@ impl Scalar {
     pub fn bool(value: bool, nullability: Nullability) -> Self {
         Self {
             dtype: DType::Bool(nullability),
-            value: ScalarValue(Inner::Bool(value)),
+            value: ScalarValue(InnerScalarValue::Bool(value)),
         }
     }
 }
@@ -98,7 +98,7 @@ impl From<bool> for Scalar {
 
 impl From<bool> for ScalarValue {
     fn from(value: bool) -> Self {
-        ScalarValue(Inner::Bool(value))
+        ScalarValue(InnerScalarValue::Bool(value))
     }
 }
 

--- a/vortex-scalar/src/bool.rs
+++ b/vortex-scalar/src/bool.rs
@@ -3,7 +3,7 @@ use vortex_dtype::{DType, Nullability};
 use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
 
 use crate::value::ScalarValue;
-use crate::Scalar;
+use crate::{Inner, Scalar};
 
 pub struct BoolScalar<'a> {
     dtype: &'a DType,
@@ -35,7 +35,7 @@ impl Scalar {
     pub fn bool(value: bool, nullability: Nullability) -> Self {
         Self {
             dtype: DType::Bool(nullability),
-            value: ScalarValue::Bool(value),
+            value: ScalarValue(Inner::Bool(value)),
         }
     }
 }
@@ -98,7 +98,7 @@ impl From<bool> for Scalar {
 
 impl From<bool> for ScalarValue {
     fn from(value: bool) -> Self {
-        ScalarValue::Bool(value)
+        ScalarValue(Inner::Bool(value))
     }
 }
 

--- a/vortex-scalar/src/bool.rs
+++ b/vortex-scalar/src/bool.rs
@@ -58,9 +58,16 @@ impl TryFrom<&Scalar> for bool {
     type Error = VortexError;
 
     fn try_from(value: &Scalar) -> VortexResult<Self> {
-        BoolScalar::try_from(value)?
-            .value()
+        <Option<bool>>::try_from(value)?
             .ok_or_else(|| vortex_err!("Can't extract present value from null scalar"))
+    }
+}
+
+impl TryFrom<&Scalar> for Option<bool> {
+    type Error = VortexError;
+
+    fn try_from(value: &Scalar) -> VortexResult<Self> {
+        Ok(BoolScalar::try_from(value)?.value())
     }
 }
 
@@ -68,7 +75,15 @@ impl TryFrom<Scalar> for bool {
     type Error = VortexError;
 
     fn try_from(value: Scalar) -> VortexResult<Self> {
-        bool::try_from(&value)
+        Self::try_from(&value)
+    }
+}
+
+impl TryFrom<Scalar> for Option<bool> {
+    type Error = VortexError;
+
+    fn try_from(value: Scalar) -> VortexResult<Self> {
+        Self::try_from(&value)
     }
 }
 
@@ -84,39 +99,6 @@ impl From<bool> for Scalar {
 impl From<bool> for ScalarValue {
     fn from(value: bool) -> Self {
         ScalarValue::Bool(value)
-    }
-}
-
-impl TryFrom<&ScalarValue> for Option<bool> {
-    type Error = VortexError;
-
-    fn try_from(value: &ScalarValue) -> VortexResult<Self> {
-        value.as_bool()
-    }
-}
-
-impl TryFrom<ScalarValue> for Option<bool> {
-    type Error = VortexError;
-
-    fn try_from(value: ScalarValue) -> VortexResult<Self> {
-        Option::<bool>::try_from(&value)
-    }
-}
-
-impl TryFrom<&ScalarValue> for bool {
-    type Error = VortexError;
-
-    fn try_from(value: &ScalarValue) -> VortexResult<Self> {
-        Option::<bool>::try_from(value)?
-            .ok_or_else(|| vortex_err!("Can't extract present value from null scalar"))
-    }
-}
-
-impl TryFrom<ScalarValue> for bool {
-    type Error = VortexError;
-
-    fn try_from(value: ScalarValue) -> VortexResult<Self> {
-        bool::try_from(&value)
     }
 }
 

--- a/vortex-scalar/src/datafusion.rs
+++ b/vortex-scalar/src/datafusion.rs
@@ -5,6 +5,7 @@ use datafusion_common::ScalarValue;
 use vortex_buffer::Buffer;
 use vortex_datetime_dtype::arrow::make_temporal_ext_dtype;
 use vortex_datetime_dtype::{is_temporal_ext_type, TemporalMetadata, TimeUnit};
+use vortex_dtype::half::f16;
 use vortex_dtype::{DType, Nullability, PType};
 use vortex_error::VortexError;
 
@@ -13,48 +14,33 @@ use crate::{PValue, Scalar};
 impl TryFrom<Scalar> for ScalarValue {
     type Error = VortexError;
 
-    fn try_from(value: Scalar) -> Result<Self, Self::Error> {
-        let (dtype, value) = value.into_parts();
-        Ok(match dtype {
+    fn try_from(scalar: Scalar) -> Result<Self, Self::Error> {
+        Ok(match scalar.dtype() {
             DType::Null => ScalarValue::Null,
-            DType::Bool(_) => ScalarValue::Boolean(value.as_bool()?),
+            DType::Bool(_) => ScalarValue::Boolean(scalar.as_bool().value()),
             DType::Primitive(ptype, _) => {
-                let pvalue = value.as_pvalue()?;
-                match pvalue {
-                    None => match ptype {
-                        PType::U8 => ScalarValue::UInt8(None),
-                        PType::U16 => ScalarValue::UInt16(None),
-                        PType::U32 => ScalarValue::UInt32(None),
-                        PType::U64 => ScalarValue::UInt64(None),
-                        PType::I8 => ScalarValue::Int8(None),
-                        PType::I16 => ScalarValue::Int16(None),
-                        PType::I32 => ScalarValue::Int32(None),
-                        PType::I64 => ScalarValue::Int64(None),
-                        PType::F16 => ScalarValue::Float16(None),
-                        PType::F32 => ScalarValue::Float32(None),
-                        PType::F64 => ScalarValue::Float64(None),
-                    },
-                    Some(pvalue) => match pvalue {
-                        PValue::U8(v) => ScalarValue::UInt8(Some(v)),
-                        PValue::U16(v) => ScalarValue::UInt16(Some(v)),
-                        PValue::U32(v) => ScalarValue::UInt32(Some(v)),
-                        PValue::U64(v) => ScalarValue::UInt64(Some(v)),
-                        PValue::I8(v) => ScalarValue::Int8(Some(v)),
-                        PValue::I16(v) => ScalarValue::Int16(Some(v)),
-                        PValue::I32(v) => ScalarValue::Int32(Some(v)),
-                        PValue::I64(v) => ScalarValue::Int64(Some(v)),
-                        PValue::F16(v) => ScalarValue::Float16(Some(v)),
-                        PValue::F32(v) => ScalarValue::Float32(Some(v)),
-                        PValue::F64(v) => ScalarValue::Float64(Some(v)),
-                    },
+                let pscalar = scalar.as_primitive();
+                match ptype {
+                    PType::U8 => ScalarValue::UInt8(pscalar.typed_value::<u8>()),
+                    PType::U16 => ScalarValue::UInt16(pscalar.typed_value::<u16>()),
+                    PType::U32 => ScalarValue::UInt32(pscalar.typed_value::<u32>()),
+                    PType::U64 => ScalarValue::UInt64(pscalar.typed_value::<u64>()),
+                    PType::I8 => ScalarValue::Int8(pscalar.typed_value::<i8>()),
+                    PType::I16 => ScalarValue::Int16(pscalar.typed_value::<i16>()),
+                    PType::I32 => ScalarValue::Int32(pscalar.typed_value::<i32>()),
+                    PType::I64 => ScalarValue::Int64(pscalar.typed_value::<i64>()),
+                    PType::F16 => ScalarValue::Float16(pscalar.typed_value::<f16>()),
+                    PType::F32 => ScalarValue::Float32(pscalar.typed_value::<f32>()),
+                    PType::F64 => ScalarValue::Float64(pscalar.typed_value::<f64>()),
                 }
             }
             DType::Utf8(_) => {
-                ScalarValue::Utf8(value.as_buffer_string()?.map(|b| b.as_str().to_string()))
+                ScalarValue::Utf8(scalar.as_utf8().value().map(|s| s.as_str().to_string()))
             }
             DType::Binary(_) => ScalarValue::Binary(
-                value
-                    .as_buffer()?
+                scalar
+                    .as_binary()
+                    .value()
                     .map(|b| b.into_vec().unwrap_or_else(|buf| buf.as_slice().to_vec())),
             ),
             DType::Struct(..) => {
@@ -64,49 +50,44 @@ impl TryFrom<Scalar> for ScalarValue {
                 todo!("list scalar conversion")
             }
             DType::Extension(ext) => {
+                let storage_scalar = scalar.as_extension().storage();
+
                 // Special handling: temporal extension types in Vortex correspond to Arrow's
                 // temporal physical types.
                 if is_temporal_ext_type(ext.id()) {
                     let metadata = TemporalMetadata::try_from(ext.as_ref())?;
-                    let pv = value.as_pvalue()?;
+                    let pv = storage_scalar.as_primitive();
                     return Ok(match metadata {
                         TemporalMetadata::Time(u) => match u {
-                            TimeUnit::Ns => {
-                                ScalarValue::Time64Nanosecond(pv.and_then(|p| p.as_i64()))
-                            }
-                            TimeUnit::Us => {
-                                ScalarValue::Time64Microsecond(pv.and_then(|p| p.as_i64()))
-                            }
-                            TimeUnit::Ms => {
-                                ScalarValue::Time32Millisecond(pv.and_then(|p| p.as_i32()))
-                            }
-                            TimeUnit::S => ScalarValue::Time32Second(pv.and_then(|p| p.as_i32())),
+                            TimeUnit::Ns => ScalarValue::Time64Nanosecond(pv.as_::<i64>()?),
+                            TimeUnit::Us => ScalarValue::Time64Microsecond(pv.as_::<i64>()?),
+                            TimeUnit::Ms => ScalarValue::Time32Millisecond(pv.as_::<i32>()?),
+                            TimeUnit::S => ScalarValue::Time32Second(pv.as_::<i32>()?),
                             TimeUnit::D => {
                                 unreachable!("Unsupported TimeUnit {u} for {}", ext.id())
                             }
                         },
                         TemporalMetadata::Date(u) => match u {
-                            TimeUnit::Ms => ScalarValue::Date64(pv.and_then(|p| p.as_i64())),
-                            TimeUnit::D => ScalarValue::Date32(pv.and_then(|p| p.as_i32())),
+                            TimeUnit::Ms => ScalarValue::Date64(pv.as_::<i64>()?),
+                            TimeUnit::D => ScalarValue::Date32(pv.as_::<i32>()?),
                             _ => unreachable!("Unsupported TimeUnit {u} for {}", ext.id()),
                         },
                         TemporalMetadata::Timestamp(u, tz) => match u {
                             TimeUnit::Ns => ScalarValue::TimestampNanosecond(
-                                pv.and_then(|p| p.as_i64()),
+                                pv.as_::<i64>()?,
                                 tz.map(|t| t.into()),
                             ),
                             TimeUnit::Us => ScalarValue::TimestampMicrosecond(
-                                pv.and_then(|p| p.as_i64()),
+                                pv.as_::<i64>()?,
                                 tz.map(|t| t.into()),
                             ),
                             TimeUnit::Ms => ScalarValue::TimestampMillisecond(
-                                pv.and_then(|p| p.as_i64()),
+                                pv.as_::<i64>()?,
                                 tz.map(|t| t.into()),
                             ),
-                            TimeUnit::S => ScalarValue::TimestampSecond(
-                                pv.and_then(|p| p.as_i64()),
-                                tz.map(|t| t.into()),
-                            ),
+                            TimeUnit::S => {
+                                ScalarValue::TimestampSecond(pv.as_::<i64>()?, tz.map(|t| t.into()))
+                            }
                             TimeUnit::D => {
                                 unreachable!("Unsupported TimeUnit {u} for {}", ext.id())
                             }
@@ -115,7 +96,7 @@ impl TryFrom<Scalar> for ScalarValue {
                 } else {
                     // Unknown extension type: perform scalar conversion using the canonical
                     // scalar DType.
-                    ScalarValue::try_from(Scalar::new(ext.storage_dtype().clone(), value))?
+                    ScalarValue::try_from(storage_scalar)?
                 }
             }
         })

--- a/vortex-scalar/src/datafusion.rs
+++ b/vortex-scalar/src/datafusion.rs
@@ -9,7 +9,7 @@ use vortex_dtype::half::f16;
 use vortex_dtype::{DType, Nullability, PType};
 use vortex_error::VortexError;
 
-use crate::{PValue, Scalar};
+use crate::{Inner, PValue, Scalar};
 
 impl TryFrom<Scalar> for ScalarValue {
     type Error = VortexError;
@@ -135,7 +135,7 @@ impl From<ScalarValue> for Scalar {
                     .with_nullability(Nullability::Nullable);
                 Scalar::new(
                     DType::Extension(Arc::new(ext_dtype)),
-                    crate::ScalarValue::Primitive(PValue::I32(i)),
+                    crate::ScalarValue(Inner::Primitive(PValue::I32(i))),
                 )
             }),
             ScalarValue::Date64(v)
@@ -148,7 +148,7 @@ impl From<ScalarValue> for Scalar {
                 let ext_dtype = make_temporal_ext_dtype(&value.data_type());
                 Scalar::new(
                     DType::Extension(Arc::new(ext_dtype.with_nullability(Nullability::Nullable))),
-                    crate::ScalarValue::Primitive(PValue::I64(i)),
+                    crate::ScalarValue(Inner::Primitive(PValue::I64(i))),
                 )
             }),
             _ => unimplemented!("Can't convert {value:?} value to a Vortex scalar"),

--- a/vortex-scalar/src/datafusion.rs
+++ b/vortex-scalar/src/datafusion.rs
@@ -9,7 +9,7 @@ use vortex_dtype::half::f16;
 use vortex_dtype::{DType, Nullability, PType};
 use vortex_error::VortexError;
 
-use crate::{Inner, PValue, Scalar};
+use crate::{InnerScalarValue, PValue, Scalar};
 
 impl TryFrom<Scalar> for ScalarValue {
     type Error = VortexError;
@@ -135,7 +135,7 @@ impl From<ScalarValue> for Scalar {
                     .with_nullability(Nullability::Nullable);
                 Scalar::new(
                     DType::Extension(Arc::new(ext_dtype)),
-                    crate::ScalarValue(Inner::Primitive(PValue::I32(i))),
+                    crate::ScalarValue(InnerScalarValue::Primitive(PValue::I32(i))),
                 )
             }),
             ScalarValue::Date64(v)
@@ -148,7 +148,7 @@ impl From<ScalarValue> for Scalar {
                 let ext_dtype = make_temporal_ext_dtype(&value.data_type());
                 Scalar::new(
                     DType::Extension(Arc::new(ext_dtype.with_nullability(Nullability::Nullable))),
-                    crate::ScalarValue(Inner::Primitive(PValue::I64(i))),
+                    crate::ScalarValue(InnerScalarValue::Primitive(PValue::I64(i))),
                 )
             }),
             _ => unimplemented!("Can't convert {value:?} value to a Vortex scalar"),

--- a/vortex-scalar/src/display.rs
+++ b/vortex-scalar/src/display.rs
@@ -109,7 +109,7 @@ mod tests {
     use vortex_dtype::Nullability::{NonNullable, Nullable};
     use vortex_dtype::{DType, ExtDType, ExtMetadata, PType, StructDType};
 
-    use crate::{PValue, Scalar, ScalarValue};
+    use crate::{InnerScalarValue, PValue, Scalar, ScalarValue};
 
     const MINUTES: i32 = 60;
     const HOURS: i32 = 60 * MINUTES;
@@ -191,19 +191,13 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Scalar::r#struct(dtype(), vec![ScalarValue(InnerScalarValue::Null)])
+                Scalar::r#struct(dtype(), vec![Scalar::null_typed::<u32>()])
             ),
             "{foo:null}"
         );
 
         assert_eq!(
-            format!(
-                "{}",
-                Scalar::r#struct(
-                    dtype(),
-                    vec![ScalarValue(InnerScalarValue::Primitive(PValue::U32(32)))]
-                )
-            ),
+            format!("{}", Scalar::r#struct(dtype(), vec![Scalar::from(32_u32)])),
             "{foo:32_u32}"
         );
     }
@@ -231,23 +225,14 @@ mod tests {
         );
 
         assert_eq!(
-            format!(
-                "{}",
-                Scalar::r#struct(dtype(), vec![ScalarValue(InnerScalarValue::Bool(true))])
-            ),
+            format!("{}", Scalar::r#struct(dtype(), vec![Scalar::from(true)])),
             "{foo:true,bar:null}"
         );
 
         assert_eq!(
             format!(
                 "{}",
-                Scalar::r#struct(
-                    dtype(),
-                    vec![
-                        ScalarValue(InnerScalarValue::Bool(true)),
-                        ScalarValue(InnerScalarValue::Primitive(PValue::U32(32)))
-                    ]
-                )
+                Scalar::r#struct(dtype(), vec![Scalar::from(true), Scalar::from(32_u32)])
             ),
             "{foo:true,bar:32_u32}"
         );

--- a/vortex-scalar/src/display.rs
+++ b/vortex-scalar/src/display.rs
@@ -189,14 +189,20 @@ mod tests {
         assert_eq!(format!("{}", Scalar::null(dtype())), "null");
 
         assert_eq!(
-            format!("{}", Scalar::r#struct(dtype(), vec![ScalarValue::Null])),
+            format!(
+                "{}",
+                Scalar::r#struct(dtype(), vec![ScalarValue(Inner::Null)])
+            ),
             "{foo:null}"
         );
 
         assert_eq!(
             format!(
                 "{}",
-                Scalar::r#struct(dtype(), vec![ScalarValue::Primitive(PValue::U32(32))])
+                Scalar::r#struct(
+                    dtype(),
+                    vec![ScalarValue(Inner::Primitive(PValue::U32(32)))]
+                )
             ),
             "{foo:32_u32}"
         );
@@ -227,7 +233,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Scalar::r#struct(dtype(), vec![ScalarValue::Bool(true)])
+                Scalar::r#struct(dtype(), vec![ScalarValue(Inner::Bool(true))])
             ),
             "{foo:true,bar:null}"
         );
@@ -238,8 +244,8 @@ mod tests {
                 Scalar::r#struct(
                     dtype(),
                     vec![
-                        ScalarValue::Bool(true),
-                        ScalarValue::Primitive(PValue::U32(32))
+                        ScalarValue(Inner::Bool(true)),
+                        ScalarValue(Inner::Primitive(PValue::U32(32)))
                     ]
                 )
             ),
@@ -264,7 +270,7 @@ mod tests {
                 "{}",
                 Scalar::new(
                     dtype(),
-                    ScalarValue::Primitive(PValue::I32(3 * MINUTES + 25))
+                    ScalarValue(Inner::Primitive(PValue::I32(3 * MINUTES + 25)))
                 )
             ),
             "00:03:25"
@@ -286,7 +292,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Scalar::new(dtype(), ScalarValue::Primitive(PValue::I32(25)))
+                Scalar::new(dtype(), ScalarValue(Inner::Primitive(PValue::I32(25))))
             ),
             "1970-01-26"
         );
@@ -294,7 +300,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Scalar::new(dtype(), ScalarValue::Primitive(PValue::I32(365)))
+                Scalar::new(dtype(), ScalarValue(Inner::Primitive(PValue::I32(365))))
             ),
             "1971-01-01"
         );
@@ -302,7 +308,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Scalar::new(dtype(), ScalarValue::Primitive(PValue::I32(365 * 4)))
+                Scalar::new(dtype(), ScalarValue(Inner::Primitive(PValue::I32(365 * 4))))
             ),
             "1973-12-31"
         );
@@ -328,7 +334,9 @@ mod tests {
                 "{}",
                 Scalar::new(
                     dtype(),
-                    ScalarValue::Primitive(PValue::I32(3 * DAYS + 2 * HOURS + 5 * MINUTES + 10))
+                    ScalarValue(Inner::Primitive(PValue::I32(
+                        3 * DAYS + 2 * HOURS + 5 * MINUTES + 10
+                    )))
                 )
             ),
             "1970-01-04T02:05:10Z"
@@ -354,7 +362,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Scalar::new(dtype(), ScalarValue::Primitive(PValue::I32(0)))
+                Scalar::new(dtype(), ScalarValue(Inner::Primitive(PValue::I32(0))))
             ),
             "1970-01-01T10:00:00+10:00[Pacific/Guam]"
         );
@@ -364,7 +372,9 @@ mod tests {
                 "{}",
                 Scalar::new(
                     dtype(),
-                    ScalarValue::Primitive(PValue::I32(3 * DAYS + 2 * HOURS + 5 * MINUTES + 10))
+                    ScalarValue(Inner::Primitive(PValue::I32(
+                        3 * DAYS + 2 * HOURS + 5 * MINUTES + 10
+                    )))
                 )
             ),
             "1970-01-04T12:05:10+10:00[Pacific/Guam]"

--- a/vortex-scalar/src/display.rs
+++ b/vortex-scalar/src/display.rs
@@ -3,12 +3,13 @@ use std::fmt::{Display, Formatter};
 use itertools::Itertools;
 use vortex_datetime_dtype::{is_temporal_ext_type, TemporalMetadata};
 use vortex_dtype::DType;
+use vortex_error::vortex_panic;
 
 use crate::binary::BinaryScalar;
 use crate::extension::ExtScalar;
 use crate::struct_::StructScalar;
 use crate::utf8::Utf8Scalar;
-use crate::{PValue, Scalar, ScalarValue};
+use crate::Scalar;
 
 impl Display for Scalar {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -66,47 +67,34 @@ impl Display for Scalar {
                 let storage_scalar = self.as_extension().storage();
 
                 match storage_scalar.dtype() {
+                    DType::Null => {
+                        write!(f, "null")
+                    }
                     DType::Primitive(..) => {
-                        let pv = storage_scalar.as_primitive();
-                        write!(
-                            f,
-                            "{}",
-                            pv.as_::<i64>()
-                                .and_then(|v| v.map(|v| metadata.to_jiff(v)))
-                                .map_err(|_| std::fmt::Error)?
-                        )
+                        let maybe_timestamp = storage_scalar
+                            .as_primitive()
+                            .as_::<i64>()
+                            .and_then(|maybe_timestamp| {
+                                maybe_timestamp.map(|v| metadata.to_jiff(v)).transpose()
+                            })
+                            .map_err(|_| std::fmt::Error)?;
+                        match maybe_timestamp {
+                            None => write!(f, "null"),
+                            Some(v) => write!(f, "{}", v),
+                        }
                     }
-                }
-
-                match ExtScalar::try_from(self)
-                    .map_err(|_| std::fmt::Error)?
-                    .value()
-                {
-                    ScalarValue::Null => write!(f, "null"),
-                    ScalarValue::Primitive(PValue::I32(v)) => {
-                        write!(
-                            f,
-                            "{}",
-                            metadata.to_jiff(*v as i64).map_err(|_| std::fmt::Error)?
-                        )
+                    _ => {
+                        vortex_panic!("Expected temporal extension data type to have Primitive or Null storage type")
                     }
-                    ScalarValue::Primitive(PValue::I64(v)) => {
-                        write!(f, "{}", metadata.to_jiff(*v).map_err(|_| std::fmt::Error)?)
-                    }
-                    _ => Err(std::fmt::Error),
                 }
             }
             // Generic handling of unknown extension types.
             // TODO(aduffy): Allow extension authors plugin their own Scalar display.
             DType::Extension(..) => {
-                let scalar_value = ExtScalar::try_from(self)
+                let storage_value = ExtScalar::try_from(self)
                     .map_err(|_| std::fmt::Error)?
-                    .value();
-                if scalar_value.is_null() {
-                    write!(f, "null")
-                } else {
-                    write!(f, "{}", scalar_value)
-                }
+                    .storage();
+                write!(f, "{}", storage_value)
             }
         }
     }

--- a/vortex-scalar/src/display.rs
+++ b/vortex-scalar/src/display.rs
@@ -171,7 +171,7 @@ mod tests {
 
         assert_eq!(format!("{}", Scalar::null(dtype())), "null");
 
-        assert_eq!(format!("{}", Scalar::r#struct(dtype(), vec![])), "{}");
+        assert_eq!(format!("{}", Scalar::struct_(dtype(), vec![])), "{}");
     }
 
     #[test]
@@ -191,13 +191,13 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Scalar::r#struct(dtype(), vec![Scalar::null_typed::<u32>()])
+                Scalar::struct_(dtype(), vec![Scalar::null_typed::<u32>()])
             ),
             "{foo:null}"
         );
 
         assert_eq!(
-            format!("{}", Scalar::r#struct(dtype(), vec![Scalar::from(32_u32)])),
+            format!("{}", Scalar::struct_(dtype(), vec![Scalar::from(32_u32)])),
             "{foo:32_u32}"
         );
     }
@@ -220,19 +220,19 @@ mod tests {
         assert_eq!(format!("{}", Scalar::null(dtype())), "null");
 
         assert_eq!(
-            format!("{}", Scalar::r#struct(dtype(), vec![])),
+            format!("{}", Scalar::struct_(dtype(), vec![])),
             "{foo:null,bar:null}"
         );
 
         assert_eq!(
-            format!("{}", Scalar::r#struct(dtype(), vec![Scalar::from(true)])),
+            format!("{}", Scalar::struct_(dtype(), vec![Scalar::from(true)])),
             "{foo:true,bar:null}"
         );
 
         assert_eq!(
             format!(
                 "{}",
-                Scalar::r#struct(dtype(), vec![Scalar::from(true), Scalar::from(32_u32)])
+                Scalar::struct_(dtype(), vec![Scalar::from(true), Scalar::from(32_u32)])
             ),
             "{foo:true,bar:32_u32}"
         );

--- a/vortex-scalar/src/display.rs
+++ b/vortex-scalar/src/display.rs
@@ -63,6 +63,21 @@ impl Display for Scalar {
             DType::Extension(dtype) if is_temporal_ext_type(dtype.id()) => {
                 let metadata =
                     TemporalMetadata::try_from(dtype.as_ref()).map_err(|_| std::fmt::Error)?;
+                let storage_scalar = self.as_extension().storage();
+
+                match storage_scalar.dtype() {
+                    DType::Primitive(..) => {
+                        let pv = storage_scalar.as_primitive();
+                        write!(
+                            f,
+                            "{}",
+                            pv.as_::<i64>()
+                                .and_then(|v| v.map(|v| metadata.to_jiff(v)))
+                                .map_err(|_| std::fmt::Error)?
+                        )
+                    }
+                }
+
                 match ExtScalar::try_from(self)
                     .map_err(|_| std::fmt::Error)?
                     .value()

--- a/vortex-scalar/src/display.rs
+++ b/vortex-scalar/src/display.rs
@@ -191,7 +191,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Scalar::r#struct(dtype(), vec![ScalarValue(Inner::Null)])
+                Scalar::r#struct(dtype(), vec![ScalarValue(InnerScalarValue::Null)])
             ),
             "{foo:null}"
         );
@@ -201,7 +201,7 @@ mod tests {
                 "{}",
                 Scalar::r#struct(
                     dtype(),
-                    vec![ScalarValue(Inner::Primitive(PValue::U32(32)))]
+                    vec![ScalarValue(InnerScalarValue::Primitive(PValue::U32(32)))]
                 )
             ),
             "{foo:32_u32}"
@@ -233,7 +233,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Scalar::r#struct(dtype(), vec![ScalarValue(Inner::Bool(true))])
+                Scalar::r#struct(dtype(), vec![ScalarValue(InnerScalarValue::Bool(true))])
             ),
             "{foo:true,bar:null}"
         );
@@ -244,8 +244,8 @@ mod tests {
                 Scalar::r#struct(
                     dtype(),
                     vec![
-                        ScalarValue(Inner::Bool(true)),
-                        ScalarValue(Inner::Primitive(PValue::U32(32)))
+                        ScalarValue(InnerScalarValue::Bool(true)),
+                        ScalarValue(InnerScalarValue::Primitive(PValue::U32(32)))
                     ]
                 )
             ),
@@ -270,7 +270,7 @@ mod tests {
                 "{}",
                 Scalar::new(
                     dtype(),
-                    ScalarValue(Inner::Primitive(PValue::I32(3 * MINUTES + 25)))
+                    ScalarValue(InnerScalarValue::Primitive(PValue::I32(3 * MINUTES + 25)))
                 )
             ),
             "00:03:25"
@@ -292,7 +292,10 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Scalar::new(dtype(), ScalarValue(Inner::Primitive(PValue::I32(25))))
+                Scalar::new(
+                    dtype(),
+                    ScalarValue(InnerScalarValue::Primitive(PValue::I32(25)))
+                )
             ),
             "1970-01-26"
         );
@@ -300,7 +303,10 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Scalar::new(dtype(), ScalarValue(Inner::Primitive(PValue::I32(365))))
+                Scalar::new(
+                    dtype(),
+                    ScalarValue(InnerScalarValue::Primitive(PValue::I32(365)))
+                )
             ),
             "1971-01-01"
         );
@@ -308,7 +314,10 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Scalar::new(dtype(), ScalarValue(Inner::Primitive(PValue::I32(365 * 4))))
+                Scalar::new(
+                    dtype(),
+                    ScalarValue(InnerScalarValue::Primitive(PValue::I32(365 * 4)))
+                )
             ),
             "1973-12-31"
         );
@@ -334,7 +343,7 @@ mod tests {
                 "{}",
                 Scalar::new(
                     dtype(),
-                    ScalarValue(Inner::Primitive(PValue::I32(
+                    ScalarValue(InnerScalarValue::Primitive(PValue::I32(
                         3 * DAYS + 2 * HOURS + 5 * MINUTES + 10
                     )))
                 )
@@ -362,7 +371,10 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Scalar::new(dtype(), ScalarValue(Inner::Primitive(PValue::I32(0))))
+                Scalar::new(
+                    dtype(),
+                    ScalarValue(InnerScalarValue::Primitive(PValue::I32(0)))
+                )
             ),
             "1970-01-01T10:00:00+10:00[Pacific/Guam]"
         );
@@ -372,7 +384,7 @@ mod tests {
                 "{}",
                 Scalar::new(
                     dtype(),
-                    ScalarValue(Inner::Primitive(PValue::I32(
+                    ScalarValue(InnerScalarValue::Primitive(PValue::I32(
                         3 * DAYS + 2 * HOURS + 5 * MINUTES + 10
                     )))
                 )

--- a/vortex-scalar/src/extension.rs
+++ b/vortex-scalar/src/extension.rs
@@ -27,7 +27,18 @@ impl<'a> ExtScalar<'a> {
         self.dtype
     }
 
+    /// Returns the storage scalar of the extension scalar.
+    pub fn storage(&self) -> Scalar {
+        let storage_dtype = if let DType::Extension(ext_dtype) = self.dtype() {
+            ext_dtype.storage_dtype().clone()
+        } else {
+            unreachable!("Expected extension DType");
+        };
+        Scalar::new(storage_dtype, self.value.clone())
+    }
+
     /// Returns the stored value of the extension scalar.
+    #[deprecated(since = "0.1.0", note = "Use `storage` instead")]
     pub fn value(&self) -> &'a ScalarValue {
         self.value
     }

--- a/vortex-scalar/src/extension.rs
+++ b/vortex-scalar/src/extension.rs
@@ -37,12 +37,6 @@ impl<'a> ExtScalar<'a> {
         Scalar::new(storage_dtype, self.value.clone())
     }
 
-    /// Returns the stored value of the extension scalar.
-    #[deprecated(since = "0.1.0", note = "Use `storage` instead")]
-    pub fn value(&self) -> &'a ScalarValue {
-        self.value
-    }
-
     pub fn cast(&self, _dtype: &DType) -> VortexResult<Scalar> {
         todo!()
     }

--- a/vortex-scalar/src/extension.rs
+++ b/vortex-scalar/src/extension.rs
@@ -57,10 +57,10 @@ impl<'a> TryFrom<&'a Scalar> for ExtScalar<'a> {
 }
 
 impl Scalar {
-    pub fn extension(ext_dtype: Arc<ExtDType>, value: ScalarValue) -> Self {
+    pub fn extension(ext_dtype: Arc<ExtDType>, value: Scalar) -> Self {
         Self {
             dtype: DType::Extension(ext_dtype),
-            value,
+            value: value.value().clone(),
         }
     }
 }

--- a/vortex-scalar/src/extension.rs
+++ b/vortex-scalar/src/extension.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use vortex_dtype::{DType, ExtDType};
-use vortex_error::{vortex_bail, VortexError, VortexResult};
+use vortex_error::{vortex_bail, vortex_panic, VortexError, VortexResult};
 
 use crate::value::ScalarValue;
 use crate::Scalar;
@@ -32,7 +32,7 @@ impl<'a> ExtScalar<'a> {
         let storage_dtype = if let DType::Extension(ext_dtype) = self.dtype() {
             ext_dtype.storage_dtype().clone()
         } else {
-            unreachable!("Expected extension DType");
+            vortex_panic!("Expected extension DType: {}", self.dtype());
         };
         Scalar::new(storage_dtype, self.value.clone())
     }

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -1,8 +1,10 @@
 use std::cmp::Ordering;
+use std::sync::Arc;
 
 use scalar_type::ScalarType;
-use vortex_dtype::DType;
-
+use vortex_buffer::{Buffer, BufferString};
+use vortex_dtype::half::f16;
+use vortex_dtype::{DType, Nullability};
 #[cfg(feature = "arbitrary")]
 pub mod arbitrary;
 mod arrow;
@@ -208,25 +210,119 @@ impl AsRef<Self> for Scalar {
     }
 }
 
-impl<T> From<T> for Scalar
-where
-    T: ScalarType,
-    ScalarValue: From<T>,
-{
-    fn from(value: T) -> Self {
-        Scalar::new(T::dtype(), ScalarValue::from(value))
-    }
-}
+// macro_rules! from_scalar_for_primitive {
+//     ($T:ty) => {
+//         impl TryFrom<Scalar> for $T {
+//             type Error = VortexError;
+
+//             fn try_from(value: Scalar) -> Result<Self, Self::Error> {
+//                 value
+//                     .as_primitive_opt()
+//                     .vortex_expect("expeced primitive value")
+//                     .typed_value::<$T>()
+//                     .ok_or_else(|| vortex_err!("cannot convert null"))
+//             }
+//         }
+//     };
+// }
+
+// from_scalar_for_primitive!(u8);
+// from_scalar_for_primitive!(u16);
+// from_scalar_for_primitive!(u32);
+// from_scalar_for_primitive!(u64);
+// from_scalar_for_primitive!(i8);
+// from_scalar_for_primitive!(i16);
+// from_scalar_for_primitive!(i32);
+// from_scalar_for_primitive!(i64);
+// from_scalar_for_primitive!(f16);
+// from_scalar_for_primitive!(f32);
+// from_scalar_for_primitive!(f64);
 
 impl<T> From<Option<T>> for Scalar
 where
     T: ScalarType,
-    ScalarValue: From<Option<T>>,
+    Scalar: From<T>,
 {
     fn from(value: Option<T>) -> Self {
-        Scalar {
+        value.map(Scalar::from).unwrap_or_else(|| Scalar {
             dtype: T::dtype().as_nullable(),
-            value: value.into(),
-        }
+            value: ScalarValue::Null,
+        })
     }
 }
+
+macro_rules! from_vec_for_scalar {
+    ($T:ty) => {
+        impl From<Vec<$T>> for Scalar {
+            fn from(value: Vec<$T>) -> Self {
+                Scalar {
+                    dtype: DType::List(Arc::from(<$T>::dtype()), Nullability::NonNullable),
+                    value: ScalarValue::List(
+                        value
+                            .into_iter()
+                            .map(Scalar::from)
+                            .map(|x| x.value)
+                            .collect::<Vec<_>>()
+                            .into(),
+                    ),
+                }
+            }
+        }
+    };
+}
+
+// no From<Vec<u8>> because it could either be a List or a Buffer
+from_vec_for_scalar!(u16);
+from_vec_for_scalar!(u32);
+from_vec_for_scalar!(u64);
+from_vec_for_scalar!(usize);
+from_vec_for_scalar!(i8);
+from_vec_for_scalar!(i16);
+from_vec_for_scalar!(i32);
+from_vec_for_scalar!(i64);
+from_vec_for_scalar!(f16);
+from_vec_for_scalar!(f32);
+from_vec_for_scalar!(f64);
+from_vec_for_scalar!(String);
+from_vec_for_scalar!(BufferString);
+from_vec_for_scalar!(bytes::Bytes);
+from_vec_for_scalar!(Buffer);
+
+// impl From<Vec<usize>> for Scalar {
+//     fn from(value: Vec<usize>) -> Self {
+//         Scalar {
+//             dtype: DType::List(Arc::from(u64::DTYPE), Nullability::NonNullable),
+//             value: ScalarValue::List(
+//                 value
+//                     .into_iter()
+//                     .map(Scalar::from)
+//                     .map(|x| x.value)
+//                     .collect::<Vec<_>>()
+//                     .into(),
+//             ),
+//         }
+//     }
+// }
+
+// impl<T> From<T> for Scalar
+// where
+//     T: ScalarType,
+//     ScalarValue: From<T>,
+// {
+//     fn from(value: T) -> Self {
+//         Scalar::new(T::dtype(), ScalarValue::from(value))
+//     }
+// }
+
+// impl<T> From<Option<T>> for Scalar
+// where
+//     T: ScalarType,
+//     ScalarValue: From<Option<T>>,
+// {
+//     fn from(value: Option<T>) -> Self {
+//         Scalar {
+//             dtype: T::dtype().as_nullable(),
+//             value: value.into(),
+//         }
+//     }
+// }

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -61,7 +61,7 @@ impl Scalar {
 
     /// Only the scalar crate should access the ScalarValue directly.
     #[inline]
-    pub fn value(&self) -> &ScalarValue {
+    pub(crate) fn value(&self) -> &ScalarValue {
         &self.value
     }
 
@@ -87,6 +87,13 @@ impl Scalar {
         assert!(dtype.is_nullable());
         Self {
             dtype,
+            value: ScalarValue(InnerScalarValue::Null),
+        }
+    }
+
+    pub fn null_typed<T: ScalarType>() -> Self {
+        Self {
+            dtype: T::dtype().as_nullable(),
             value: ScalarValue(InnerScalarValue::Null),
         }
     }
@@ -124,6 +131,13 @@ impl Scalar {
                     self.cast(ext_dtype.storage_dtype())?,
                 ))
             }
+        }
+    }
+
+    pub fn into_nullable(self) -> Self {
+        Self {
+            dtype: self.dtype.as_nullable(),
+            value: self.value,
         }
     }
 }
@@ -187,17 +201,15 @@ impl Scalar {
 }
 
 impl PartialEq for Scalar {
-    fn eq(&self, _other: &Self) -> bool {
-        todo!("How do we implement this when ScalarValue doesn't implement Eq?")
-        // self.dtype == other.dtype && self.value == other.value
+    fn eq(&self, other: &Self) -> bool {
+        self.dtype == other.dtype && self.value.0 == other.value.0
     }
 }
 
 impl PartialOrd for Scalar {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         if self.dtype().eq_ignore_nullability(other.dtype()) {
-            todo!("How do we implement this when ScalarValue doesn't implement PartialOrd?")
-            // self.value.partial_cmp(&other.value)
+            self.value.0.partial_cmp(&other.value.0)
         } else {
             None
         }
@@ -216,10 +228,13 @@ where
     Scalar: From<T>,
 {
     fn from(value: Option<T>) -> Self {
-        value.map(Scalar::from).unwrap_or_else(|| Scalar {
-            dtype: T::dtype().as_nullable(),
-            value: ScalarValue(InnerScalarValue::Null),
-        })
+        value
+            .map(Scalar::from)
+            .map(|x| x.into_nullable())
+            .unwrap_or_else(|| Scalar {
+                dtype: T::dtype().as_nullable(),
+                value: ScalarValue(InnerScalarValue::Null),
+            })
     }
 }
 
@@ -233,9 +248,8 @@ macro_rules! from_vec_for_scalar {
                         value
                             .into_iter()
                             .map(Scalar::from)
-                            .map(|x| x.value)
-                            .collect::<Vec<_>>()
-                            .into(),
+                            .map(|x| x.value.0)
+                            .collect::<Arc<[_]>>(),
                     )),
                 }
             }

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -87,7 +87,7 @@ impl Scalar {
         assert!(dtype.is_nullable());
         Self {
             dtype,
-            value: ScalarValue(Inner::Null),
+            value: ScalarValue(InnerScalarValue::Null),
         }
     }
 
@@ -210,34 +210,6 @@ impl AsRef<Self> for Scalar {
     }
 }
 
-// macro_rules! from_scalar_for_primitive {
-//     ($T:ty) => {
-//         impl TryFrom<Scalar> for $T {
-//             type Error = VortexError;
-
-//             fn try_from(value: Scalar) -> Result<Self, Self::Error> {
-//                 value
-//                     .as_primitive_opt()
-//                     .vortex_expect("expeced primitive value")
-//                     .typed_value::<$T>()
-//                     .ok_or_else(|| vortex_err!("cannot convert null"))
-//             }
-//         }
-//     };
-// }
-
-// from_scalar_for_primitive!(u8);
-// from_scalar_for_primitive!(u16);
-// from_scalar_for_primitive!(u32);
-// from_scalar_for_primitive!(u64);
-// from_scalar_for_primitive!(i8);
-// from_scalar_for_primitive!(i16);
-// from_scalar_for_primitive!(i32);
-// from_scalar_for_primitive!(i64);
-// from_scalar_for_primitive!(f16);
-// from_scalar_for_primitive!(f32);
-// from_scalar_for_primitive!(f64);
-
 impl<T> From<Option<T>> for Scalar
 where
     T: ScalarType,
@@ -246,7 +218,7 @@ where
     fn from(value: Option<T>) -> Self {
         value.map(Scalar::from).unwrap_or_else(|| Scalar {
             dtype: T::dtype().as_nullable(),
-            value: ScalarValue(Inner::Null),
+            value: ScalarValue(InnerScalarValue::Null),
         })
     }
 }
@@ -257,7 +229,7 @@ macro_rules! from_vec_for_scalar {
             fn from(value: Vec<$T>) -> Self {
                 Scalar {
                     dtype: DType::List(Arc::from(<$T>::dtype()), Nullability::NonNullable),
-                    value: ScalarValue(Inner::List(
+                    value: ScalarValue(InnerScalarValue::List(
                         value
                             .into_iter()
                             .map(Scalar::from)
@@ -275,7 +247,7 @@ macro_rules! from_vec_for_scalar {
 from_vec_for_scalar!(u16);
 from_vec_for_scalar!(u32);
 from_vec_for_scalar!(u64);
-from_vec_for_scalar!(usize);
+from_vec_for_scalar!(usize); // For usize only, we implicitly cast for better ergonomics.
 from_vec_for_scalar!(i8);
 from_vec_for_scalar!(i16);
 from_vec_for_scalar!(i32);
@@ -287,42 +259,3 @@ from_vec_for_scalar!(String);
 from_vec_for_scalar!(BufferString);
 from_vec_for_scalar!(bytes::Bytes);
 from_vec_for_scalar!(Buffer);
-
-// impl From<Vec<usize>> for Scalar {
-//     fn from(value: Vec<usize>) -> Self {
-//         Scalar {
-//             dtype: DType::List(Arc::from(u64::DTYPE), Nullability::NonNullable),
-//             value: ScalarValue::List(
-//                 value
-//                     .into_iter()
-//                     .map(Scalar::from)
-//                     .map(|x| x.value)
-//                     .collect::<Vec<_>>()
-//                     .into(),
-//             ),
-//         }
-//     }
-// }
-
-// impl<T> From<T> for Scalar
-// where
-//     T: ScalarType,
-//     ScalarValue: From<T>,
-// {
-//     fn from(value: T) -> Self {
-//         Scalar::new(T::dtype(), ScalarValue::from(value))
-//     }
-// }
-
-// impl<T> From<Option<T>> for Scalar
-// where
-//     T: ScalarType,
-//     ScalarValue: From<Option<T>>,
-// {
-//     fn from(value: Option<T>) -> Self {
-//         Scalar {
-//             dtype: T::dtype().as_nullable(),
-//             value: value.into(),
-//         }
-//     }
-// }

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use std::sync::Arc;
 
-use scalar_type::ScalarType;
+pub use scalar_type::ScalarType;
 use vortex_buffer::{Buffer, BufferString};
 use vortex_dtype::half::f16;
 use vortex_dtype::{DType, Nullability};

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -31,14 +31,20 @@ pub use pvalue::*;
 pub use struct_::*;
 pub use utf8::*;
 pub use value::*;
-use vortex_error::{vortex_bail, VortexResult};
+use vortex_error::{vortex_bail, VortexExpect, VortexResult};
 
 /// A single logical item, composed of both a [`ScalarValue`] and a logical [`DType`].
+///
+/// A [`ScalarValue`] is opaque, and should be accessed via one of the type-specific scalar wrappers
+/// for example [`BoolScalar`], [`PrimitiveScalar`], etc.
+///
+/// Note: [`PartialEq`] and [`PartialOrd`] are implemented only for an exact match of the scalar's
+/// dtype, including nullability.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct Scalar {
-    pub(crate) dtype: DType,
-    pub(crate) value: ScalarValue,
+    dtype: DType,
+    value: ScalarValue,
 }
 
 impl Scalar {
@@ -51,6 +57,7 @@ impl Scalar {
         &self.dtype
     }
 
+    /// Only the scalar crate should access the ScalarValue directly.
     #[inline]
     pub fn value(&self) -> &ScalarValue {
         &self.value
@@ -119,16 +126,76 @@ impl Scalar {
     }
 }
 
+impl Scalar {
+    pub fn as_bool(&self) -> BoolScalar {
+        BoolScalar::try_from(self).vortex_expect("Failed to convert scalar to bool")
+    }
+
+    pub fn as_bool_opt(&self) -> Option<BoolScalar> {
+        matches!(self.dtype, DType::Bool(..)).then(|| self.as_bool())
+    }
+
+    pub fn as_primitive(&self) -> PrimitiveScalar {
+        PrimitiveScalar::try_from(self).vortex_expect("Failed to convert scalar to primitive")
+    }
+
+    pub fn as_primitive_opt(&self) -> Option<PrimitiveScalar> {
+        matches!(self.dtype, DType::Primitive(..)).then(|| self.as_primitive())
+    }
+
+    pub fn as_utf8(&self) -> Utf8Scalar {
+        Utf8Scalar::try_from(self).vortex_expect("Failed to convert scalar to utf8")
+    }
+
+    pub fn as_utf8_opt(&self) -> Option<Utf8Scalar> {
+        matches!(self.dtype, DType::Utf8(..)).then(|| self.as_utf8())
+    }
+
+    pub fn as_binary(&self) -> BinaryScalar {
+        BinaryScalar::try_from(self).vortex_expect("Failed to convert scalar to binary")
+    }
+
+    pub fn as_binary_opt(&self) -> Option<BinaryScalar> {
+        matches!(self.dtype, DType::Binary(..)).then(|| self.as_binary())
+    }
+
+    pub fn as_struct(&self) -> StructScalar {
+        StructScalar::try_from(self).vortex_expect("Failed to convert scalar to struct")
+    }
+
+    pub fn as_struct_opt(&self) -> Option<StructScalar> {
+        matches!(self.dtype, DType::Struct(..)).then(|| self.as_struct())
+    }
+
+    pub fn as_list(&self) -> ListScalar {
+        ListScalar::try_from(self).vortex_expect("Failed to convert scalar to list")
+    }
+
+    pub fn as_list_opt(&self) -> Option<ListScalar> {
+        matches!(self.dtype, DType::List(..)).then(|| self.as_list())
+    }
+
+    pub fn as_extension(&self) -> ExtScalar {
+        ExtScalar::try_from(self).vortex_expect("Failed to convert scalar to extension")
+    }
+
+    pub fn as_extension_opt(&self) -> Option<ExtScalar> {
+        matches!(self.dtype, DType::Extension(..)).then(|| self.as_extension())
+    }
+}
+
 impl PartialEq for Scalar {
-    fn eq(&self, other: &Self) -> bool {
-        self.dtype == other.dtype && self.value == other.value
+    fn eq(&self, _other: &Self) -> bool {
+        todo!("How do we implement this when ScalarValue doesn't implement Eq?")
+        // self.dtype == other.dtype && self.value == other.value
     }
 }
 
 impl PartialOrd for Scalar {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         if self.dtype().eq_ignore_nullability(other.dtype()) {
-            self.value.partial_cmp(&other.value)
+            todo!("How do we implement this when ScalarValue doesn't implement PartialOrd?")
+            // self.value.partial_cmp(&other.value)
         } else {
             None
         }

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -87,7 +87,7 @@ impl Scalar {
         assert!(dtype.is_nullable());
         Self {
             dtype,
-            value: ScalarValue::Null,
+            value: ScalarValue(Inner::Null),
         }
     }
 
@@ -121,7 +121,7 @@ impl Scalar {
                 }
                 Ok(Scalar::extension(
                     ext_dtype.clone(),
-                    self.cast(ext_dtype.storage_dtype())?.value,
+                    self.cast(ext_dtype.storage_dtype())?,
                 ))
             }
         }
@@ -246,7 +246,7 @@ where
     fn from(value: Option<T>) -> Self {
         value.map(Scalar::from).unwrap_or_else(|| Scalar {
             dtype: T::dtype().as_nullable(),
-            value: ScalarValue::Null,
+            value: ScalarValue(Inner::Null),
         })
     }
 }
@@ -257,14 +257,14 @@ macro_rules! from_vec_for_scalar {
             fn from(value: Vec<$T>) -> Self {
                 Scalar {
                     dtype: DType::List(Arc::from(<$T>::dtype()), Nullability::NonNullable),
-                    value: ScalarValue::List(
+                    value: ScalarValue(Inner::List(
                         value
                             .into_iter()
                             .map(Scalar::from)
                             .map(|x| x.value)
                             .collect::<Vec<_>>()
                             .into(),
-                    ),
+                    )),
                 }
             }
         }

--- a/vortex-scalar/src/list.rs
+++ b/vortex-scalar/src/list.rs
@@ -10,7 +10,7 @@ use crate::{InnerScalarValue, Scalar};
 
 pub struct ListScalar<'a> {
     dtype: &'a DType,
-    elements: Option<Arc<[ScalarValue]>>,
+    elements: Option<Arc<[InnerScalarValue]>>,
 }
 
 impl<'a> ListScalar<'a> {
@@ -45,7 +45,7 @@ impl<'a> ListScalar<'a> {
             .and_then(|l| l.get(idx))
             .map(|value| Scalar {
                 dtype: self.element_dtype(),
-                value: value.clone(),
+                value: ScalarValue(value.clone()),
             })
     }
 
@@ -53,11 +53,11 @@ impl<'a> ListScalar<'a> {
         self.elements
             .as_ref()
             .map(AsRef::as_ref)
-            .unwrap_or_else(|| &[] as &[ScalarValue])
+            .unwrap_or_else(|| &[] as &[InnerScalarValue])
             .iter()
             .map(|e| Scalar {
                 dtype: self.element_dtype(),
-                value: e.clone(),
+                value: ScalarValue(e.clone()),
             })
     }
 
@@ -80,7 +80,10 @@ impl Scalar {
         Self {
             dtype: DType::List(element_dtype, NonNullable),
             value: ScalarValue(InnerScalarValue::List(
-                children.into_iter().map(|x| x.value).collect::<Arc<[_]>>(),
+                children
+                    .into_iter()
+                    .map(|x| x.value.0)
+                    .collect::<Arc<[_]>>(),
             )),
         }
     }

--- a/vortex-scalar/src/list.rs
+++ b/vortex-scalar/src/list.rs
@@ -32,6 +32,11 @@ impl<'a> ListScalar<'a> {
         }
     }
 
+    #[inline]
+    pub fn is_null(&self) -> bool {
+        self.elements.is_none()
+    }
+
     pub fn element_dtype(&self) -> DType {
         let DType::List(element_type, _) = self.dtype() else {
             unreachable!();

--- a/vortex-scalar/src/list.rs
+++ b/vortex-scalar/src/list.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 
 use vortex_dtype::DType;
 use vortex_dtype::Nullability::NonNullable;
-use vortex_error::{vortex_bail, VortexError, VortexResult};
+use vortex_error::{vortex_bail, vortex_panic, VortexError, VortexResult};
 
 use crate::value::ScalarValue;
-use crate::Scalar;
+use crate::{Inner, Scalar};
 
 pub struct ListScalar<'a> {
     dtype: &'a DType,
@@ -67,10 +67,21 @@ impl<'a> ListScalar<'a> {
 }
 
 impl Scalar {
-    pub fn list(element_dtype: DType, children: Vec<ScalarValue>) -> Self {
+    pub fn list(element_dtype: Arc<DType>, children: Vec<Scalar>) -> Self {
+        for child in &children {
+            if child.dtype() != &*element_dtype {
+                vortex_panic!(
+                    "tried to create list of {} with values of type {}",
+                    element_dtype,
+                    child.dtype()
+                );
+            }
+        }
         Self {
-            dtype: DType::List(Arc::new(element_dtype), NonNullable),
-            value: ScalarValue::List(children.into()),
+            dtype: DType::List(element_dtype, NonNullable),
+            value: ScalarValue(Inner::List(
+                children.into_iter().map(|x| x.value).collect::<Arc<[_]>>(),
+            )),
         }
     }
 }

--- a/vortex-scalar/src/list.rs
+++ b/vortex-scalar/src/list.rs
@@ -6,7 +6,7 @@ use vortex_dtype::Nullability::NonNullable;
 use vortex_error::{vortex_bail, vortex_panic, VortexError, VortexResult};
 
 use crate::value::ScalarValue;
-use crate::{Inner, Scalar};
+use crate::{InnerScalarValue, Scalar};
 
 pub struct ListScalar<'a> {
     dtype: &'a DType,
@@ -79,7 +79,7 @@ impl Scalar {
         }
         Self {
             dtype: DType::List(element_dtype, NonNullable),
-            value: ScalarValue(Inner::List(
+            value: ScalarValue(InnerScalarValue::List(
                 children.into_iter().map(|x| x.value).collect::<Arc<[_]>>(),
             )),
         }

--- a/vortex-scalar/src/null.rs
+++ b/vortex-scalar/src/null.rs
@@ -1,6 +1,6 @@
 use vortex_error::VortexError;
 
-use crate::{Scalar, ScalarValue};
+use crate::Scalar;
 
 impl TryFrom<&Scalar> for () {
     type Error = VortexError;
@@ -15,21 +15,5 @@ impl TryFrom<Scalar> for () {
 
     fn try_from(scalar: Scalar) -> Result<Self, Self::Error> {
         <()>::try_from(&scalar)
-    }
-}
-
-impl TryFrom<&ScalarValue> for () {
-    type Error = VortexError;
-
-    fn try_from(value: &ScalarValue) -> Result<Self, Self::Error> {
-        value.as_null()
-    }
-}
-
-impl TryFrom<ScalarValue> for () {
-    type Error = VortexError;
-
-    fn try_from(value: ScalarValue) -> Result<Self, Self::Error> {
-        <()>::try_from(&value)
     }
 }

--- a/vortex-scalar/src/primitive.rs
+++ b/vortex-scalar/src/primitive.rs
@@ -1,4 +1,6 @@
-use num_traits::NumCast;
+use std::any::type_name;
+
+use num_traits::{FromPrimitive, NumCast};
 use vortex_dtype::half::f16;
 use vortex_dtype::{match_each_native_ptype, DType, NativePType, Nullability, PType};
 use vortex_error::{
@@ -74,6 +76,37 @@ impl<'a> PrimitiveScalar<'a> {
                 ))
             })
         })
+    }
+
+    /// Attempt to extract the primitive value as the given type.
+    /// Fails on a bad cast.
+    pub fn as_<T: FromPrimitive>(&self) -> VortexResult<Option<T>> {
+        match self.pvalue {
+            None => Ok(None),
+            Some(pv) => match pv {
+                PValue::U8(v) => T::from_u8(v)
+                    .ok_or_else(|| vortex_err!("Failed to cast u8 to {}", type_name::<T>())),
+                PValue::U16(v) => T::from_u16(v)
+                    .ok_or_else(|| vortex_err!("Failed to cast u16 to {}", type_name::<T>())),
+                PValue::U32(v) => T::from_u32(v)
+                    .ok_or_else(|| vortex_err!("Failed to cast u32 to {}", type_name::<T>())),
+                PValue::U64(v) => T::from_u64(v)
+                    .ok_or_else(|| vortex_err!("Failed to cast u64 to {}", type_name::<T>())),
+                PValue::I8(v) => T::from_i8(v)
+                    .ok_or_else(|| vortex_err!("Failed to cast i8 to {}", type_name::<T>())),
+                PValue::I16(v) => T::from_i16(v)
+                    .ok_or_else(|| vortex_err!("Failed to cast i16 to {}", type_name::<T>())),
+                PValue::I32(v) => T::from_i32(v)
+                    .ok_or_else(|| vortex_err!("Failed to cast i32 to {}", type_name::<T>())),
+                PValue::I64(v) => T::from_i64(v)
+                    .ok_or_else(|| vortex_err!("Failed to cast i64 to {}", type_name::<T>())),
+                PValue::F16(v) => vortex_bail!("Cannot access values as f16"),
+                PValue::F32(v) => T::from_f32(v)
+                    .ok_or_else(|| vortex_err!("Failed to cast f32 to {}", type_name::<T>())),
+                PValue::F64(v) => T::from_f64(v)
+                    .ok_or_else(|| vortex_err!("Failed to cast f64 to {}", type_name::<T>())),
+            },
+        }
     }
 }
 

--- a/vortex-scalar/src/primitive.rs
+++ b/vortex-scalar/src/primitive.rs
@@ -80,10 +80,10 @@ impl<'a> PrimitiveScalar<'a> {
 
     /// Attempt to extract the primitive value as the given type.
     /// Fails on a bad cast.
-    pub fn as_<T: FromPrimitive>(&self) -> VortexResult<Option<T>> {
+    pub fn as_<T: FromPrimitiveOrF16>(&self) -> VortexResult<Option<T>> {
         match self.pvalue {
             None => Ok(None),
-            Some(pv) => match pv {
+            Some(pv) => Ok(Some(match pv {
                 PValue::U8(v) => T::from_u8(v)
                     .ok_or_else(|| vortex_err!("Failed to cast u8 to {}", type_name::<T>())),
                 PValue::U16(v) => T::from_u16(v)
@@ -100,13 +100,55 @@ impl<'a> PrimitiveScalar<'a> {
                     .ok_or_else(|| vortex_err!("Failed to cast i32 to {}", type_name::<T>())),
                 PValue::I64(v) => T::from_i64(v)
                     .ok_or_else(|| vortex_err!("Failed to cast i64 to {}", type_name::<T>())),
-                PValue::F16(v) => vortex_bail!("Cannot access values as f16"),
+                PValue::F16(v) => T::from_f16(v)
+                    .ok_or_else(|| vortex_err!("Failed to cast f16 to {}", type_name::<T>())),
                 PValue::F32(v) => T::from_f32(v)
                     .ok_or_else(|| vortex_err!("Failed to cast f32 to {}", type_name::<T>())),
                 PValue::F64(v) => T::from_f64(v)
                     .ok_or_else(|| vortex_err!("Failed to cast f64 to {}", type_name::<T>())),
-            },
+            }?)),
         }
+    }
+}
+
+pub trait FromPrimitiveOrF16: FromPrimitive {
+    fn from_f16(v: f16) -> Option<Self>;
+}
+
+macro_rules! from_primitive_or_f16_for_non_floating_point {
+    ($T:ty) => {
+        impl FromPrimitiveOrF16 for $T {
+            fn from_f16(_: f16) -> Option<Self> {
+                None
+            }
+        }
+    };
+}
+
+from_primitive_or_f16_for_non_floating_point!(u8);
+from_primitive_or_f16_for_non_floating_point!(u16);
+from_primitive_or_f16_for_non_floating_point!(u32);
+from_primitive_or_f16_for_non_floating_point!(u64);
+from_primitive_or_f16_for_non_floating_point!(i8);
+from_primitive_or_f16_for_non_floating_point!(i16);
+from_primitive_or_f16_for_non_floating_point!(i32);
+from_primitive_or_f16_for_non_floating_point!(i64);
+
+impl FromPrimitiveOrF16 for f16 {
+    fn from_f16(v: f16) -> Option<Self> {
+        Some(v)
+    }
+}
+
+impl FromPrimitiveOrF16 for f32 {
+    fn from_f16(v: f16) -> Option<Self> {
+        Some(v.to_f32())
+    }
+}
+
+impl FromPrimitiveOrF16 for f64 {
+    fn from_f16(v: f16) -> Option<Self> {
+        Some(v.to_f64())
     }
 }
 
@@ -164,8 +206,7 @@ macro_rules! primitive_scalar {
             type Error = VortexError;
 
             fn try_from(value: &Scalar) -> Result<Self, Self::Error> {
-                PrimitiveScalar::try_from(value)?
-                    .typed_value::<$T>()
+                <Option<$T>>::try_from(value)?
                     .ok_or_else(|| vortex_err!("Can't extract present value from null scalar"))
             }
         }
@@ -178,48 +219,67 @@ macro_rules! primitive_scalar {
             }
         }
 
-        impl From<$T> for ScalarValue {
+        impl TryFrom<&Scalar> for Option<$T> {
+            type Error = VortexError;
+
+            fn try_from(value: &Scalar) -> Result<Self, Self::Error> {
+                Ok(PrimitiveScalar::try_from(value)?.typed_value::<$T>())
+            }
+        }
+
+        impl TryFrom<Scalar> for Option<$T> {
+            type Error = VortexError;
+
+            fn try_from(value: Scalar) -> Result<Self, Self::Error> {
+                <Option<$T>>::try_from(&value)
+            }
+        }
+
+        impl From<$T> for Scalar {
             fn from(value: $T) -> Self {
-                ScalarValue::Primitive(value.into())
-            }
-        }
-
-        impl TryFrom<&ScalarValue> for $T {
-            type Error = VortexError;
-
-            fn try_from(value: &ScalarValue) -> Result<Self, Self::Error> {
-                Option::<$T>::try_from(value)?
-                    .ok_or_else(|| vortex_err!("Can't extract present value from null scalar"))
-            }
-        }
-
-        impl TryFrom<ScalarValue> for $T {
-            type Error = VortexError;
-
-            fn try_from(value: ScalarValue) -> Result<Self, Self::Error> {
-                <$T>::try_from(&value)
-            }
-        }
-
-        impl TryFrom<&ScalarValue> for Option<$T> {
-            type Error = VortexError;
-
-            fn try_from(value: &ScalarValue) -> Result<Self, Self::Error> {
-                match value {
-                    ScalarValue::Null => Ok(None),
-                    ScalarValue::Primitive(pvalue) => Ok(Some(<$T>::try_from(*pvalue)?)),
-                    _ => vortex_bail!("expected primitive"),
+                Scalar {
+                    dtype: DType::Primitive(<$T>::PTYPE, Nullability::NonNullable),
+                    value: ScalarValue::Primitive(value.into()),
                 }
             }
         }
 
-        impl TryFrom<ScalarValue> for Option<$T> {
-            type Error = VortexError;
+        //     impl TryFrom<&ScalarValue> for $T {
+        //         type Error = VortexError;
 
-            fn try_from(value: ScalarValue) -> Result<Self, Self::Error> {
-                Option::<$T>::try_from(&value)
-            }
-        }
+        //         fn try_from(value: &ScalarValue) -> Result<Self, Self::Error> {
+        //             Option::<$T>::try_from(value)?
+        //                 .ok_or_else(|| vortex_err!("Can't extract present value from null scalar"))
+        //         }
+        //     }
+
+        //     impl TryFrom<ScalarValue> for $T {
+        //         type Error = VortexError;
+
+        //         fn try_from(value: ScalarValue) -> Result<Self, Self::Error> {
+        //             <$T>::try_from(&value)
+        //         }
+        //     }
+
+        //     impl TryFrom<&ScalarValue> for Option<$T> {
+        //         type Error = VortexError;
+
+        //         fn try_from(value: &ScalarValue) -> Result<Self, Self::Error> {
+        //             match value {
+        //                 ScalarValue::Null => Ok(None),
+        //                 ScalarValue::Primitive(pvalue) => Ok(Some(<$T>::try_from(*pvalue)?)),
+        //                 _ => vortex_bail!("expected primitive"),
+        //             }
+        //         }
+        //     }
+
+        //     impl TryFrom<ScalarValue> for Option<$T> {
+        //         type Error = VortexError;
+
+        //         fn try_from(value: ScalarValue) -> Result<Self, Self::Error> {
+        //             Option::<$T>::try_from(&value)
+        //         }
+        //     }
     };
 }
 
@@ -240,15 +300,25 @@ impl TryFrom<&Scalar> for usize {
     type Error = VortexError;
 
     fn try_from(value: &Scalar) -> Result<Self, Self::Error> {
-        value.value().try_into()
+        PrimitiveScalar::try_from(value)?
+            .as_::<u64>()?
+            .map(|v| v as Self)
+            .ok_or_else(|| vortex_err!("cannot convert Null to usize"))
     }
 }
 
 /// Read a scalar as usize. For usize only, we implicitly cast for better ergonomics.
-impl TryFrom<&ScalarValue> for usize {
-    type Error = VortexError;
-
-    fn try_from(value: &ScalarValue) -> Result<Self, Self::Error> {
-        u64::try_from(value).map(|v| v as Self)
+impl From<usize> for Scalar {
+    fn from(value: usize) -> Self {
+        Scalar::primitive(value as u64, Nullability::NonNullable)
     }
 }
+
+// /// Read a scalar as usize. For usize only, we implicitly cast for better ergonomics.
+// impl TryFrom<&ScalarValue> for usize {
+//     type Error = VortexError;
+
+//     fn try_from(value: &ScalarValue) -> Result<Self, Self::Error> {
+//         u64::try_from(value).map(|v| v as Self)
+//     }
+// }

--- a/vortex-scalar/src/primitive.rs
+++ b/vortex-scalar/src/primitive.rs
@@ -9,7 +9,7 @@ use vortex_error::{
 
 use crate::pvalue::PValue;
 use crate::value::ScalarValue;
-use crate::Scalar;
+use crate::{Inner, Scalar};
 
 #[derive(Debug, Clone)]
 pub struct PrimitiveScalar<'a> {
@@ -164,7 +164,7 @@ impl Scalar {
     pub fn primitive<T: NativePType + Into<PValue>>(value: T, nullability: Nullability) -> Self {
         Self {
             dtype: DType::Primitive(T::PTYPE, nullability),
-            value: ScalarValue::Primitive(value.into()),
+            value: ScalarValue(Inner::Primitive(value.into())),
         }
     }
 
@@ -187,15 +187,15 @@ impl Scalar {
             primitive
                 .pvalue
                 .map(|p| p.reinterpret_cast(ptype))
-                .map(ScalarValue::Primitive)
-                .unwrap_or_else(|| ScalarValue::Null),
+                .map(|x| ScalarValue(Inner::Primitive(x)))
+                .unwrap_or_else(|| ScalarValue(Inner::Null)),
         )
     }
 
     pub fn zero<T: NativePType + Into<PValue>>(nullability: Nullability) -> Self {
         Self {
             dtype: DType::Primitive(T::PTYPE, nullability),
-            value: ScalarValue::Primitive(T::zero().into()),
+            value: ScalarValue(Inner::Primitive(T::zero().into())),
         }
     }
 }
@@ -239,7 +239,7 @@ macro_rules! primitive_scalar {
             fn from(value: $T) -> Self {
                 Scalar {
                     dtype: DType::Primitive(<$T>::PTYPE, Nullability::NonNullable),
-                    value: ScalarValue::Primitive(value.into()),
+                    value: ScalarValue(Inner::Primitive(value.into())),
                 }
             }
         }
@@ -266,7 +266,7 @@ macro_rules! primitive_scalar {
 
         //         fn try_from(value: &ScalarValue) -> Result<Self, Self::Error> {
         //             match value {
-        //                 ScalarValue::Null => Ok(None),
+        //                 ScalarValue(Inner::Null) => Ok(None),
         //                 ScalarValue::Primitive(pvalue) => Ok(Some(<$T>::try_from(*pvalue)?)),
         //                 _ => vortex_bail!("expected primitive"),
         //             }

--- a/vortex-scalar/src/primitive.rs
+++ b/vortex-scalar/src/primitive.rs
@@ -9,7 +9,7 @@ use vortex_error::{
 
 use crate::pvalue::PValue;
 use crate::value::ScalarValue;
-use crate::{Inner, Scalar};
+use crate::{InnerScalarValue, Scalar};
 
 #[derive(Debug, Clone)]
 pub struct PrimitiveScalar<'a> {
@@ -164,7 +164,7 @@ impl Scalar {
     pub fn primitive<T: NativePType + Into<PValue>>(value: T, nullability: Nullability) -> Self {
         Self {
             dtype: DType::Primitive(T::PTYPE, nullability),
-            value: ScalarValue(Inner::Primitive(value.into())),
+            value: ScalarValue(InnerScalarValue::Primitive(value.into())),
         }
     }
 
@@ -187,15 +187,15 @@ impl Scalar {
             primitive
                 .pvalue
                 .map(|p| p.reinterpret_cast(ptype))
-                .map(|x| ScalarValue(Inner::Primitive(x)))
-                .unwrap_or_else(|| ScalarValue(Inner::Null)),
+                .map(|x| ScalarValue(InnerScalarValue::Primitive(x)))
+                .unwrap_or_else(|| ScalarValue(InnerScalarValue::Null)),
         )
     }
 
     pub fn zero<T: NativePType + Into<PValue>>(nullability: Nullability) -> Self {
         Self {
             dtype: DType::Primitive(T::PTYPE, nullability),
-            value: ScalarValue(Inner::Primitive(T::zero().into())),
+            value: ScalarValue(InnerScalarValue::Primitive(T::zero().into())),
         }
     }
 }
@@ -239,47 +239,10 @@ macro_rules! primitive_scalar {
             fn from(value: $T) -> Self {
                 Scalar {
                     dtype: DType::Primitive(<$T>::PTYPE, Nullability::NonNullable),
-                    value: ScalarValue(Inner::Primitive(value.into())),
+                    value: ScalarValue(InnerScalarValue::Primitive(value.into())),
                 }
             }
         }
-
-        //     impl TryFrom<&ScalarValue> for $T {
-        //         type Error = VortexError;
-
-        //         fn try_from(value: &ScalarValue) -> Result<Self, Self::Error> {
-        //             Option::<$T>::try_from(value)?
-        //                 .ok_or_else(|| vortex_err!("Can't extract present value from null scalar"))
-        //         }
-        //     }
-
-        //     impl TryFrom<ScalarValue> for $T {
-        //         type Error = VortexError;
-
-        //         fn try_from(value: ScalarValue) -> Result<Self, Self::Error> {
-        //             <$T>::try_from(&value)
-        //         }
-        //     }
-
-        //     impl TryFrom<&ScalarValue> for Option<$T> {
-        //         type Error = VortexError;
-
-        //         fn try_from(value: &ScalarValue) -> Result<Self, Self::Error> {
-        //             match value {
-        //                 ScalarValue(Inner::Null) => Ok(None),
-        //                 ScalarValue::Primitive(pvalue) => Ok(Some(<$T>::try_from(*pvalue)?)),
-        //                 _ => vortex_bail!("expected primitive"),
-        //             }
-        //         }
-        //     }
-
-        //     impl TryFrom<ScalarValue> for Option<$T> {
-        //         type Error = VortexError;
-
-        //         fn try_from(value: ScalarValue) -> Result<Self, Self::Error> {
-        //             Option::<$T>::try_from(&value)
-        //         }
-        //     }
     };
 }
 
@@ -313,12 +276,3 @@ impl From<usize> for Scalar {
         Scalar::primitive(value as u64, Nullability::NonNullable)
     }
 }
-
-// /// Read a scalar as usize. For usize only, we implicitly cast for better ergonomics.
-// impl TryFrom<&ScalarValue> for usize {
-//     type Error = VortexError;
-
-//     fn try_from(value: &ScalarValue) -> Result<Self, Self::Error> {
-//         u64::try_from(value).map(|v| v as Self)
-//     }
-// }

--- a/vortex-scalar/src/scalar_type.rs
+++ b/vortex-scalar/src/scalar_type.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use half::f16;
 use vortex_buffer::{Buffer, BufferString};
+use vortex_dtype::half::f16;
 use vortex_dtype::{DType, NativePType, Nullability, PType};
 
 pub trait ScalarType {

--- a/vortex-scalar/src/scalar_type.rs
+++ b/vortex-scalar/src/scalar_type.rs
@@ -8,6 +8,12 @@ pub trait ScalarType {
     fn dtype() -> DType;
 }
 
+impl ScalarType for bool {
+    fn dtype() -> DType {
+        DType::Bool(Nullability::NonNullable)
+    }
+}
+
 macro_rules! scalar_type_for_vec {
     ($T:ty) => {
         impl ScalarType for Vec<$T> {

--- a/vortex-scalar/src/serde/proto.rs
+++ b/vortex-scalar/src/serde/proto.rs
@@ -37,7 +37,8 @@ impl From<&ScalarValue> for pb::ScalarValue {
             ScalarValue(InnerScalarValue::List(v)) => {
                 let mut values = Vec::with_capacity(v.len());
                 for elem in v.iter() {
-                    values.push(pb::ScalarValue::from(elem));
+                    // FIXME(DK): protobufs should probably also have inner vs non-inner?
+                    values.push(pb::ScalarValue::from(&ScalarValue(elem.clone())));
                 }
                 pb::ScalarValue {
                     kind: Some(Kind::ListValue(ListValue { values })),
@@ -163,7 +164,9 @@ fn deserialize_scalar_value(dtype: &DType, value: &pb::ScalarValue) -> VortexRes
                 }
                 _ => vortex_bail!("invalid dtype for list value {}", dtype),
             }
-            Ok(ScalarValue(InnerScalarValue::List(values.into())))
+            Ok(ScalarValue(InnerScalarValue::List(
+                values.iter().map(|x| x.0.clone()).collect(),
+            )))
         }
     }
 }
@@ -178,7 +181,7 @@ mod test {
     use vortex_dtype::{DType, Nullability};
     use vortex_proto::scalar as pb;
 
-    use crate::{PValue, Scalar, ScalarValue};
+    use crate::{InnerScalarValue, PValue, Scalar, ScalarValue};
 
     fn round_trip(scalar: Scalar) {
         assert_eq!(
@@ -196,7 +199,7 @@ mod test {
     fn test_bool() {
         round_trip(Scalar::new(
             DType::Bool(Nullability::Nullable),
-            ScalarValue::Bool(true),
+            ScalarValue(InnerScalarValue::Bool(true)),
         ));
     }
 
@@ -204,7 +207,7 @@ mod test {
     fn test_primitive() {
         round_trip(Scalar::new(
             DType::Primitive(I32, Nullability::Nullable),
-            ScalarValue::Primitive(42i32.into()),
+            ScalarValue(InnerScalarValue::Primitive(42i32.into())),
         ));
     }
 
@@ -212,7 +215,7 @@ mod test {
     fn test_buffer() {
         round_trip(Scalar::new(
             DType::Binary(Nullability::Nullable),
-            ScalarValue::Buffer(vec![1, 2, 3].into()),
+            ScalarValue(InnerScalarValue::Buffer(vec![1, 2, 3].into())),
         ));
     }
 
@@ -220,7 +223,9 @@ mod test {
     fn test_buffer_string() {
         round_trip(Scalar::new(
             DType::Utf8(Nullability::Nullable),
-            ScalarValue::BufferString(BufferString::from("hello".to_string())),
+            ScalarValue(InnerScalarValue::BufferString(BufferString::from(
+                "hello".to_string(),
+            ))),
         ));
     }
 
@@ -231,13 +236,13 @@ mod test {
                 Arc::new(DType::Primitive(I32, Nullability::Nullable)),
                 Nullability::Nullable,
             ),
-            ScalarValue::List(
+            ScalarValue(InnerScalarValue::List(
                 vec![
-                    ScalarValue::Primitive(42i32.into()),
-                    ScalarValue::Primitive(43i32.into()),
+                    InnerScalarValue::Primitive(42i32.into()),
+                    InnerScalarValue::Primitive(43i32.into()),
                 ]
                 .into(),
-            ),
+            )),
         ));
     }
 
@@ -245,7 +250,9 @@ mod test {
     fn test_f16() {
         round_trip(Scalar::new(
             DType::Primitive(PType::F16, Nullability::Nullable),
-            ScalarValue::Primitive(PValue::F16(f16::from_f32(0.42))),
+            ScalarValue(InnerScalarValue::Primitive(PValue::F16(f16::from_f32(
+                0.42,
+            )))),
         ));
     }
 }

--- a/vortex-scalar/src/serde/proto.rs
+++ b/vortex-scalar/src/serde/proto.rs
@@ -1,5 +1,5 @@
-use half::f16;
 use vortex_buffer::{Buffer, BufferString};
+use vortex_dtype::half::f16;
 use vortex_dtype::{DType, PType};
 use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
 use vortex_proto::scalar as pb;
@@ -164,8 +164,8 @@ fn deserialize_scalar_value(dtype: &DType, value: &pb::ScalarValue) -> VortexRes
 mod test {
     use std::sync::Arc;
 
-    use half::f16;
     use vortex_buffer::BufferString;
+    use vortex_dtype::half::f16;
     use vortex_dtype::PType::{self, I32};
     use vortex_dtype::{DType, Nullability};
     use vortex_proto::scalar as pb;

--- a/vortex-scalar/src/serde/proto.rs
+++ b/vortex-scalar/src/serde/proto.rs
@@ -7,7 +7,7 @@ use vortex_proto::scalar::scalar_value::Kind;
 use vortex_proto::scalar::ListValue;
 
 use crate::pvalue::PValue;
-use crate::{Scalar, ScalarValue};
+use crate::{Inner, Scalar, ScalarValue};
 
 impl From<&Scalar> for pb::Scalar {
     fn from(value: &Scalar) -> Self {
@@ -21,20 +21,20 @@ impl From<&Scalar> for pb::Scalar {
 impl From<&ScalarValue> for pb::ScalarValue {
     fn from(value: &ScalarValue) -> Self {
         match value {
-            ScalarValue::Null => pb::ScalarValue {
+            ScalarValue(Inner::Null) => pb::ScalarValue {
                 kind: Some(Kind::NullValue(0)),
             },
-            ScalarValue::Bool(v) => pb::ScalarValue {
+            ScalarValue(Inner::Bool(v)) => pb::ScalarValue {
                 kind: Some(Kind::BoolValue(*v)),
             },
-            ScalarValue::Primitive(v) => v.into(),
-            ScalarValue::Buffer(v) => pb::ScalarValue {
+            ScalarValue(Inner::Primitive(v)) => v.into(),
+            ScalarValue(Inner::Buffer(v)) => pb::ScalarValue {
                 kind: Some(Kind::BytesValue(v.as_slice().to_vec())),
             },
-            ScalarValue::BufferString(v) => pb::ScalarValue {
+            ScalarValue(Inner::BufferString(v)) => pb::ScalarValue {
                 kind: Some(Kind::StringValue(v.as_str().to_string())),
             },
-            ScalarValue::List(v) => {
+            ScalarValue(Inner::List(v)) => {
                 let mut values = Vec::with_capacity(v.len());
                 for elem in v.iter() {
                     values.push(pb::ScalarValue::from(elem));
@@ -117,10 +117,10 @@ fn deserialize_scalar_value(dtype: &DType, value: &pb::ScalarValue) -> VortexRes
         .ok_or_else(|| vortex_err!(InvalidSerde: "ScalarValue missing kind"))?;
 
     match kind {
-        Kind::NullValue(_) => Ok(ScalarValue::Null),
-        Kind::BoolValue(v) => Ok(ScalarValue::Bool(*v)),
-        Kind::Int32Value(v) => Ok(ScalarValue::Primitive(PValue::I32(*v))),
-        Kind::Int64Value(v) => Ok(ScalarValue::Primitive(PValue::I64(*v))),
+        Kind::NullValue(_) => Ok(ScalarValue(Inner::Null)),
+        Kind::BoolValue(v) => Ok(ScalarValue(Inner::Bool(*v))),
+        Kind::Int32Value(v) => Ok(ScalarValue(Inner::Primitive(PValue::I32(*v)))),
+        Kind::Int64Value(v) => Ok(ScalarValue(Inner::Primitive(PValue::I64(*v)))),
         Kind::Uint32Value(v) => match dtype {
             DType::Primitive(PType::F16, _) => {
                 let f16_value = f16::from_bits(u16::try_from(*v).map_err(|_| {
@@ -130,16 +130,18 @@ fn deserialize_scalar_value(dtype: &DType, value: &pb::ScalarValue) -> VortexRes
                     )
                 })?);
 
-                Ok(ScalarValue::Primitive(PValue::F16(f16_value)))
+                Ok(ScalarValue(Inner::Primitive(PValue::F16(f16_value))))
             }
-            DType::Primitive(PType::U32, _) => Ok(ScalarValue::Primitive(PValue::U32(*v))),
+            DType::Primitive(PType::U32, _) => Ok(ScalarValue(Inner::Primitive(PValue::U32(*v)))),
             _ => vortex_bail!("invalid dtype for f32 value {}", dtype),
         },
-        Kind::Uint64Value(v) => Ok(ScalarValue::Primitive(PValue::U64(*v))),
-        Kind::FloatValue(v) => Ok(ScalarValue::Primitive(PValue::F32(*v))),
-        Kind::DoubleValue(v) => Ok(ScalarValue::Primitive(PValue::F64(*v))),
-        Kind::StringValue(v) => Ok(ScalarValue::BufferString(BufferString::from(v.clone()))),
-        Kind::BytesValue(v) => Ok(ScalarValue::Buffer(Buffer::from(v.as_slice()))),
+        Kind::Uint64Value(v) => Ok(ScalarValue(Inner::Primitive(PValue::U64(*v)))),
+        Kind::FloatValue(v) => Ok(ScalarValue(Inner::Primitive(PValue::F32(*v)))),
+        Kind::DoubleValue(v) => Ok(ScalarValue(Inner::Primitive(PValue::F64(*v)))),
+        Kind::StringValue(v) => Ok(ScalarValue(Inner::BufferString(BufferString::from(
+            v.clone(),
+        )))),
+        Kind::BytesValue(v) => Ok(ScalarValue(Inner::Buffer(Buffer::from(v.as_slice())))),
         Kind::ListValue(v) => {
             let mut values = Vec::with_capacity(v.values.len());
             match dtype {
@@ -155,7 +157,7 @@ fn deserialize_scalar_value(dtype: &DType, value: &pb::ScalarValue) -> VortexRes
                 }
                 _ => vortex_bail!("invalid dtype for list value {}", dtype),
             }
-            Ok(ScalarValue::List(values.into()))
+            Ok(ScalarValue(Inner::List(values.into())))
         }
     }
 }

--- a/vortex-scalar/src/serde/proto.rs
+++ b/vortex-scalar/src/serde/proto.rs
@@ -7,7 +7,7 @@ use vortex_proto::scalar::scalar_value::Kind;
 use vortex_proto::scalar::ListValue;
 
 use crate::pvalue::PValue;
-use crate::{Inner, Scalar, ScalarValue};
+use crate::{InnerScalarValue, Scalar, ScalarValue};
 
 impl From<&Scalar> for pb::Scalar {
     fn from(value: &Scalar) -> Self {
@@ -21,20 +21,20 @@ impl From<&Scalar> for pb::Scalar {
 impl From<&ScalarValue> for pb::ScalarValue {
     fn from(value: &ScalarValue) -> Self {
         match value {
-            ScalarValue(Inner::Null) => pb::ScalarValue {
+            ScalarValue(InnerScalarValue::Null) => pb::ScalarValue {
                 kind: Some(Kind::NullValue(0)),
             },
-            ScalarValue(Inner::Bool(v)) => pb::ScalarValue {
+            ScalarValue(InnerScalarValue::Bool(v)) => pb::ScalarValue {
                 kind: Some(Kind::BoolValue(*v)),
             },
-            ScalarValue(Inner::Primitive(v)) => v.into(),
-            ScalarValue(Inner::Buffer(v)) => pb::ScalarValue {
+            ScalarValue(InnerScalarValue::Primitive(v)) => v.into(),
+            ScalarValue(InnerScalarValue::Buffer(v)) => pb::ScalarValue {
                 kind: Some(Kind::BytesValue(v.as_slice().to_vec())),
             },
-            ScalarValue(Inner::BufferString(v)) => pb::ScalarValue {
+            ScalarValue(InnerScalarValue::BufferString(v)) => pb::ScalarValue {
                 kind: Some(Kind::StringValue(v.as_str().to_string())),
             },
-            ScalarValue(Inner::List(v)) => {
+            ScalarValue(InnerScalarValue::List(v)) => {
                 let mut values = Vec::with_capacity(v.len());
                 for elem in v.iter() {
                     values.push(pb::ScalarValue::from(elem));
@@ -117,10 +117,10 @@ fn deserialize_scalar_value(dtype: &DType, value: &pb::ScalarValue) -> VortexRes
         .ok_or_else(|| vortex_err!(InvalidSerde: "ScalarValue missing kind"))?;
 
     match kind {
-        Kind::NullValue(_) => Ok(ScalarValue(Inner::Null)),
-        Kind::BoolValue(v) => Ok(ScalarValue(Inner::Bool(*v))),
-        Kind::Int32Value(v) => Ok(ScalarValue(Inner::Primitive(PValue::I32(*v)))),
-        Kind::Int64Value(v) => Ok(ScalarValue(Inner::Primitive(PValue::I64(*v)))),
+        Kind::NullValue(_) => Ok(ScalarValue(InnerScalarValue::Null)),
+        Kind::BoolValue(v) => Ok(ScalarValue(InnerScalarValue::Bool(*v))),
+        Kind::Int32Value(v) => Ok(ScalarValue(InnerScalarValue::Primitive(PValue::I32(*v)))),
+        Kind::Int64Value(v) => Ok(ScalarValue(InnerScalarValue::Primitive(PValue::I64(*v)))),
         Kind::Uint32Value(v) => match dtype {
             DType::Primitive(PType::F16, _) => {
                 let f16_value = f16::from_bits(u16::try_from(*v).map_err(|_| {
@@ -130,18 +130,24 @@ fn deserialize_scalar_value(dtype: &DType, value: &pb::ScalarValue) -> VortexRes
                     )
                 })?);
 
-                Ok(ScalarValue(Inner::Primitive(PValue::F16(f16_value))))
+                Ok(ScalarValue(InnerScalarValue::Primitive(PValue::F16(
+                    f16_value,
+                ))))
             }
-            DType::Primitive(PType::U32, _) => Ok(ScalarValue(Inner::Primitive(PValue::U32(*v)))),
+            DType::Primitive(PType::U32, _) => {
+                Ok(ScalarValue(InnerScalarValue::Primitive(PValue::U32(*v))))
+            }
             _ => vortex_bail!("invalid dtype for f32 value {}", dtype),
         },
-        Kind::Uint64Value(v) => Ok(ScalarValue(Inner::Primitive(PValue::U64(*v)))),
-        Kind::FloatValue(v) => Ok(ScalarValue(Inner::Primitive(PValue::F32(*v)))),
-        Kind::DoubleValue(v) => Ok(ScalarValue(Inner::Primitive(PValue::F64(*v)))),
-        Kind::StringValue(v) => Ok(ScalarValue(Inner::BufferString(BufferString::from(
-            v.clone(),
+        Kind::Uint64Value(v) => Ok(ScalarValue(InnerScalarValue::Primitive(PValue::U64(*v)))),
+        Kind::FloatValue(v) => Ok(ScalarValue(InnerScalarValue::Primitive(PValue::F32(*v)))),
+        Kind::DoubleValue(v) => Ok(ScalarValue(InnerScalarValue::Primitive(PValue::F64(*v)))),
+        Kind::StringValue(v) => Ok(ScalarValue(InnerScalarValue::BufferString(
+            BufferString::from(v.clone()),
+        ))),
+        Kind::BytesValue(v) => Ok(ScalarValue(InnerScalarValue::Buffer(Buffer::from(
+            v.as_slice(),
         )))),
-        Kind::BytesValue(v) => Ok(ScalarValue(Inner::Buffer(Buffer::from(v.as_slice())))),
         Kind::ListValue(v) => {
             let mut values = Vec::with_capacity(v.values.len());
             match dtype {
@@ -157,7 +163,7 @@ fn deserialize_scalar_value(dtype: &DType, value: &pb::ScalarValue) -> VortexRes
                 }
                 _ => vortex_bail!("invalid dtype for list value {}", dtype),
             }
-            Ok(ScalarValue(Inner::List(values.into())))
+            Ok(ScalarValue(InnerScalarValue::List(values.into())))
         }
     }
 }

--- a/vortex-scalar/src/serde/serde.rs
+++ b/vortex-scalar/src/serde/serde.rs
@@ -153,7 +153,9 @@ impl<'de> Deserialize<'de> for ScalarValue {
                 while let Some(e) = seq.next_element::<ScalarValue>()? {
                     elems.push(e);
                 }
-                Ok(ScalarValue(InnerScalarValue::List(elems.into())))
+                Ok(ScalarValue(InnerScalarValue::List(
+                    elems.iter().map(|x| x.0.clone()).collect(),
+                )))
             }
         }
 

--- a/vortex-scalar/src/serde/serde.rs
+++ b/vortex-scalar/src/serde/serde.rs
@@ -5,9 +5,18 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use vortex_buffer::BufferString;
 
 use crate::pvalue::PValue;
-use crate::value::ScalarValue;
+use crate::value::{Inner, ScalarValue};
 
 impl Serialize for ScalarValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl Serialize for Inner {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -40,98 +49,100 @@ impl<'de> Deserialize<'de> for ScalarValue {
             where
                 E: Error,
             {
-                Ok(ScalarValue::Bool(v))
+                Ok(ScalarValue(Inner::Bool(v)))
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue::Primitive(PValue::I8(v)))
+                Ok(ScalarValue(Inner::Primitive(PValue::I8(v))))
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue::Primitive(PValue::I16(v)))
+                Ok(ScalarValue(Inner::Primitive(PValue::I16(v))))
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue::Primitive(PValue::I32(v)))
+                Ok(ScalarValue(Inner::Primitive(PValue::I32(v))))
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue::Primitive(PValue::I64(v)))
+                Ok(ScalarValue(Inner::Primitive(PValue::I64(v))))
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue::Primitive(PValue::U8(v)))
+                Ok(ScalarValue(Inner::Primitive(PValue::U8(v))))
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue::Primitive(PValue::U16(v)))
+                Ok(ScalarValue(Inner::Primitive(PValue::U16(v))))
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue::Primitive(PValue::U32(v)))
+                Ok(ScalarValue(Inner::Primitive(PValue::U32(v))))
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue::Primitive(PValue::U64(v)))
+                Ok(ScalarValue(Inner::Primitive(PValue::U64(v))))
             }
 
             fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue::Primitive(PValue::F32(v)))
+                Ok(ScalarValue(Inner::Primitive(PValue::F32(v))))
             }
 
             fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue::Primitive(PValue::F64(v)))
+                Ok(ScalarValue(Inner::Primitive(PValue::F64(v))))
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue::BufferString(BufferString::from(v.to_string())))
+                Ok(ScalarValue(Inner::BufferString(BufferString::from(
+                    v.to_string(),
+                ))))
             }
 
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue::Buffer(v.to_vec().into()))
+                Ok(ScalarValue(Inner::Buffer(v.to_vec().into())))
             }
 
             fn visit_unit<E>(self) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue::Null)
+                Ok(ScalarValue(Inner::Null))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
@@ -142,7 +153,7 @@ impl<'de> Deserialize<'de> for ScalarValue {
                 while let Some(e) = seq.next_element::<ScalarValue>()? {
                     elems.push(e);
                 }
-                Ok(ScalarValue::List(elems.into()))
+                Ok(ScalarValue(Inner::List(elems.into())))
             }
         }
 

--- a/vortex-scalar/src/serde/serde.rs
+++ b/vortex-scalar/src/serde/serde.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use vortex_buffer::BufferString;
 
 use crate::pvalue::PValue;
-use crate::value::{Inner, ScalarValue};
+use crate::value::{InnerScalarValue, ScalarValue};
 
 impl Serialize for ScalarValue {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -16,7 +16,7 @@ impl Serialize for ScalarValue {
     }
 }
 
-impl Serialize for Inner {
+impl Serialize for InnerScalarValue {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -49,100 +49,100 @@ impl<'de> Deserialize<'de> for ScalarValue {
             where
                 E: Error,
             {
-                Ok(ScalarValue(Inner::Bool(v)))
+                Ok(ScalarValue(InnerScalarValue::Bool(v)))
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue(Inner::Primitive(PValue::I8(v))))
+                Ok(ScalarValue(InnerScalarValue::Primitive(PValue::I8(v))))
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue(Inner::Primitive(PValue::I16(v))))
+                Ok(ScalarValue(InnerScalarValue::Primitive(PValue::I16(v))))
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue(Inner::Primitive(PValue::I32(v))))
+                Ok(ScalarValue(InnerScalarValue::Primitive(PValue::I32(v))))
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue(Inner::Primitive(PValue::I64(v))))
+                Ok(ScalarValue(InnerScalarValue::Primitive(PValue::I64(v))))
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue(Inner::Primitive(PValue::U8(v))))
+                Ok(ScalarValue(InnerScalarValue::Primitive(PValue::U8(v))))
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue(Inner::Primitive(PValue::U16(v))))
+                Ok(ScalarValue(InnerScalarValue::Primitive(PValue::U16(v))))
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue(Inner::Primitive(PValue::U32(v))))
+                Ok(ScalarValue(InnerScalarValue::Primitive(PValue::U32(v))))
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue(Inner::Primitive(PValue::U64(v))))
+                Ok(ScalarValue(InnerScalarValue::Primitive(PValue::U64(v))))
             }
 
             fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue(Inner::Primitive(PValue::F32(v))))
+                Ok(ScalarValue(InnerScalarValue::Primitive(PValue::F32(v))))
             }
 
             fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue(Inner::Primitive(PValue::F64(v))))
+                Ok(ScalarValue(InnerScalarValue::Primitive(PValue::F64(v))))
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue(Inner::BufferString(BufferString::from(
-                    v.to_string(),
-                ))))
+                Ok(ScalarValue(InnerScalarValue::BufferString(
+                    BufferString::from(v.to_string()),
+                )))
             }
 
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue(Inner::Buffer(v.to_vec().into())))
+                Ok(ScalarValue(InnerScalarValue::Buffer(v.to_vec().into())))
             }
 
             fn visit_unit<E>(self) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue(Inner::Null))
+                Ok(ScalarValue(InnerScalarValue::Null))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
@@ -153,7 +153,7 @@ impl<'de> Deserialize<'de> for ScalarValue {
                 while let Some(e) = seq.next_element::<ScalarValue>()? {
                     elems.push(e);
                 }
-                Ok(ScalarValue(Inner::List(elems.into())))
+                Ok(ScalarValue(InnerScalarValue::List(elems.into())))
             }
         }
 

--- a/vortex-scalar/src/struct_.rs
+++ b/vortex-scalar/src/struct_.rs
@@ -2,11 +2,13 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use vortex_dtype::field::Field;
-use vortex_dtype::DType;
-use vortex_error::{vortex_bail, vortex_err, VortexError, VortexExpect, VortexResult};
+use vortex_dtype::{DType, StructDType};
+use vortex_error::{
+    vortex_bail, vortex_err, vortex_panic, VortexError, VortexExpect, VortexResult,
+};
 
 use crate::value::ScalarValue;
-use crate::Scalar;
+use crate::{Inner, Scalar};
 
 pub struct StructScalar<'a> {
     dtype: &'a DType,
@@ -14,7 +16,7 @@ pub struct StructScalar<'a> {
 }
 
 impl<'a> StructScalar<'a> {
-    pub fn try_new(dtype: &'a DType, value: &'a ScalarValue) -> VortexResult<Self> {
+    pub(crate) fn try_new(dtype: &'a DType, value: &'a ScalarValue) -> VortexResult<Self> {
         if !matches!(dtype, DType::Struct(..)) {
             vortex_bail!("Expected struct scalar, found {}", dtype)
         }
@@ -27,6 +29,14 @@ impl<'a> StructScalar<'a> {
     #[inline]
     pub fn dtype(&self) -> &'a DType {
         self.dtype
+    }
+
+    #[inline]
+    pub fn struct_dtype(&self) -> &'a StructDType {
+        let DType::Struct(sdtype, ..) = self.dtype else {
+            vortex_panic!("StructScalar always has struct dtype");
+        };
+        sdtype
     }
 
     pub fn is_null(&self) -> bool {
@@ -54,7 +64,17 @@ impl<'a> StructScalar<'a> {
         st.find_name(name).and_then(|idx| self.field_by_idx(idx))
     }
 
-    pub fn fields(&self) -> Option<&[ScalarValue]> {
+    pub fn fields(&self) -> Option<Vec<Scalar>> {
+        let fields = self.fields?;
+
+        Some(
+            (0..fields.len())
+                .map(|index| self.field_by_idx(index).vortex_expect("struct is non-null"))
+                .collect(),
+        )
+    }
+
+    pub(crate) fn field_values(&self) -> Option<&[ScalarValue]> {
         self.fields.map(Arc::deref)
     }
 
@@ -74,7 +94,7 @@ impl<'a> StructScalar<'a> {
             );
         }
 
-        if let Some(fs) = self.fields() {
+        if let Some(fs) = self.field_values() {
             let fields = fs
                 .iter()
                 .enumerate()
@@ -89,7 +109,7 @@ impl<'a> StructScalar<'a> {
                 .collect::<VortexResult<Vec<_>>>()?;
             Ok(Scalar {
                 dtype: dtype.clone(),
-                value: ScalarValue::List(fields.into()),
+                value: ScalarValue(Inner::List(fields.into())),
             })
         } else {
             Ok(Scalar::null(dtype.clone()))
@@ -102,8 +122,8 @@ impl<'a> StructScalar<'a> {
             .as_struct()
             .ok_or_else(|| vortex_err!("Not a struct dtype"))?;
         let projected_dtype = struct_dtype.project(projection)?;
-        let new_fields = if let Some(fs) = self.fields() {
-            ScalarValue::List(
+        let new_fields = if let Some(fs) = self.field_values() {
+            ScalarValue(Inner::List(
                 projection
                     .iter()
                     .map(|p| match p {
@@ -114,9 +134,9 @@ impl<'a> StructScalar<'a> {
                     })
                     .map(|i| fs[i].clone())
                     .collect(),
-            )
+            ))
         } else {
-            ScalarValue::Null
+            ScalarValue(Inner::Null)
         };
         Ok(Scalar::new(
             DType::Struct(projected_dtype, self.dtype().nullability()),
@@ -129,7 +149,7 @@ impl Scalar {
     pub fn r#struct(dtype: DType, children: Vec<ScalarValue>) -> Self {
         Self {
             dtype,
-            value: ScalarValue::List(children.into()),
+            value: ScalarValue(Inner::List(children.into())),
         }
     }
 }

--- a/vortex-scalar/src/struct_.rs
+++ b/vortex-scalar/src/struct_.rs
@@ -8,7 +8,7 @@ use vortex_error::{
 };
 
 use crate::value::ScalarValue;
-use crate::{Inner, Scalar};
+use crate::{InnerScalarValue, Scalar};
 
 pub struct StructScalar<'a> {
     dtype: &'a DType,
@@ -109,7 +109,7 @@ impl<'a> StructScalar<'a> {
                 .collect::<VortexResult<Vec<_>>>()?;
             Ok(Scalar {
                 dtype: dtype.clone(),
-                value: ScalarValue(Inner::List(fields.into())),
+                value: ScalarValue(InnerScalarValue::List(fields.into())),
             })
         } else {
             Ok(Scalar::null(dtype.clone()))
@@ -123,7 +123,7 @@ impl<'a> StructScalar<'a> {
             .ok_or_else(|| vortex_err!("Not a struct dtype"))?;
         let projected_dtype = struct_dtype.project(projection)?;
         let new_fields = if let Some(fs) = self.field_values() {
-            ScalarValue(Inner::List(
+            ScalarValue(InnerScalarValue::List(
                 projection
                     .iter()
                     .map(|p| match p {
@@ -136,7 +136,7 @@ impl<'a> StructScalar<'a> {
                     .collect(),
             ))
         } else {
-            ScalarValue(Inner::Null)
+            ScalarValue(InnerScalarValue::Null)
         };
         Ok(Scalar::new(
             DType::Struct(projected_dtype, self.dtype().nullability()),
@@ -149,7 +149,7 @@ impl Scalar {
     pub fn r#struct(dtype: DType, children: Vec<ScalarValue>) -> Self {
         Self {
             dtype,
-            value: ScalarValue(Inner::List(children.into())),
+            value: ScalarValue(InnerScalarValue::List(children.into())),
         }
     }
 }

--- a/vortex-scalar/src/struct_.rs
+++ b/vortex-scalar/src/struct_.rs
@@ -12,7 +12,7 @@ use crate::{InnerScalarValue, Scalar};
 
 pub struct StructScalar<'a> {
     dtype: &'a DType,
-    fields: Option<&'a Arc<[ScalarValue]>>,
+    fields: Option<&'a Arc<[InnerScalarValue]>>,
 }
 
 impl<'a> StructScalar<'a> {
@@ -53,7 +53,7 @@ impl<'a> StructScalar<'a> {
             .and_then(|fields| fields.get(idx))
             .map(|field| Scalar {
                 dtype: st.dtypes()[idx].clone(),
-                value: field.clone(),
+                value: ScalarValue(field.clone()),
             })
     }
 
@@ -74,7 +74,7 @@ impl<'a> StructScalar<'a> {
         )
     }
 
-    pub(crate) fn field_values(&self) -> Option<&[ScalarValue]> {
+    pub(crate) fn field_values(&self) -> Option<&[InnerScalarValue]> {
         self.fields.map(Arc::deref)
     }
 
@@ -101,7 +101,7 @@ impl<'a> StructScalar<'a> {
                 .map(|(i, f)| {
                     Scalar {
                         dtype: own_st.dtypes()[i].clone(),
-                        value: f.clone(),
+                        value: ScalarValue(f.clone()),
                     }
                     .cast(&st.dtypes()[i])
                     .map(|s| s.value)
@@ -109,7 +109,9 @@ impl<'a> StructScalar<'a> {
                 .collect::<VortexResult<Vec<_>>>()?;
             Ok(Scalar {
                 dtype: dtype.clone(),
-                value: ScalarValue(InnerScalarValue::List(fields.into())),
+                value: ScalarValue(InnerScalarValue::List(
+                    fields.iter().cloned().map(|x| x.0).collect(),
+                )),
             })
         } else {
             Ok(Scalar::null(dtype.clone()))
@@ -146,10 +148,12 @@ impl<'a> StructScalar<'a> {
 }
 
 impl Scalar {
-    pub fn r#struct(dtype: DType, children: Vec<ScalarValue>) -> Self {
+    pub fn r#struct(dtype: DType, children: Vec<Scalar>) -> Self {
         Self {
             dtype,
-            value: ScalarValue(InnerScalarValue::List(children.into())),
+            value: ScalarValue(InnerScalarValue::List(
+                children.into_iter().map(|x| x.into_value().0).collect(),
+            )),
         }
     }
 }

--- a/vortex-scalar/src/struct_.rs
+++ b/vortex-scalar/src/struct_.rs
@@ -148,7 +148,7 @@ impl<'a> StructScalar<'a> {
 }
 
 impl Scalar {
-    pub fn r#struct(dtype: DType, children: Vec<Scalar>) -> Self {
+    pub fn struct_(dtype: DType, children: Vec<Scalar>) -> Self {
         Self {
             dtype,
             value: ScalarValue(InnerScalarValue::List(

--- a/vortex-scalar/src/utf8.rs
+++ b/vortex-scalar/src/utf8.rs
@@ -79,11 +79,30 @@ impl From<&str> for Scalar {
     }
 }
 
+impl From<String> for Scalar {
+    fn from(value: String) -> Self {
+        Self {
+            dtype: DType::Utf8(NonNullable),
+            value: ScalarValue::BufferString(value.into()),
+        }
+    }
+}
+
+impl From<BufferString> for Scalar {
+    fn from(value: BufferString) -> Self {
+        Self {
+            dtype: DType::Utf8(NonNullable),
+            value: ScalarValue::BufferString(value),
+        }
+    }
+}
+
 impl<'a> TryFrom<&'a Scalar> for BufferString {
     type Error = VortexError;
 
     fn try_from(scalar: &'a Scalar) -> VortexResult<Self> {
-        BufferString::try_from(scalar.value())
+        <Option<BufferString>>::try_from(scalar)?
+            .ok_or_else(|| vortex_err!("Can't extract present value from null scalar"))
     }
 }
 
@@ -91,39 +110,22 @@ impl TryFrom<Scalar> for BufferString {
     type Error = VortexError;
 
     fn try_from(scalar: Scalar) -> Result<Self, Self::Error> {
-        BufferString::try_from(&scalar)
+        Self::try_from(&scalar)
     }
 }
 
-impl TryFrom<&ScalarValue> for BufferString {
+impl<'a> TryFrom<&'a Scalar> for Option<BufferString> {
     type Error = VortexError;
 
-    fn try_from(value: &ScalarValue) -> Result<Self, Self::Error> {
-        Option::<BufferString>::try_from(value)?
-            .ok_or_else(|| vortex_err!("Can't extract present value from null scalar"))
+    fn try_from(scalar: &'a Scalar) -> Result<Self, Self::Error> {
+        Ok(Utf8Scalar::try_from(scalar)?.value())
     }
 }
 
-impl TryFrom<ScalarValue> for BufferString {
+impl TryFrom<Scalar> for Option<BufferString> {
     type Error = VortexError;
 
-    fn try_from(value: ScalarValue) -> Result<Self, Self::Error> {
-        BufferString::try_from(&value)
-    }
-}
-
-impl TryFrom<&ScalarValue> for Option<BufferString> {
-    type Error = VortexError;
-
-    fn try_from(value: &ScalarValue) -> Result<Self, Self::Error> {
-        value.as_buffer_string()
-    }
-}
-
-impl TryFrom<ScalarValue> for Option<BufferString> {
-    type Error = VortexError;
-
-    fn try_from(value: ScalarValue) -> Result<Self, Self::Error> {
-        Option::<BufferString>::try_from(&value)
+    fn try_from(scalar: Scalar) -> Result<Self, Self::Error> {
+        Self::try_from(&scalar)
     }
 }

--- a/vortex-scalar/src/utf8.rs
+++ b/vortex-scalar/src/utf8.rs
@@ -4,7 +4,7 @@ use vortex_dtype::{DType, Nullability};
 use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
 
 use crate::value::ScalarValue;
-use crate::Scalar;
+use crate::{Inner, Scalar};
 
 pub struct Utf8Scalar<'a> {
     dtype: &'a DType,
@@ -43,7 +43,7 @@ impl Scalar {
     {
         Ok(Self {
             dtype: DType::Utf8(nullability),
-            value: ScalarValue::BufferString(str.try_into()?),
+            value: ScalarValue(Inner::BufferString(str.try_into()?)),
         })
     }
 }
@@ -74,7 +74,7 @@ impl From<&str> for Scalar {
     fn from(value: &str) -> Self {
         Self {
             dtype: DType::Utf8(NonNullable),
-            value: ScalarValue::BufferString(value.to_string().into()),
+            value: ScalarValue(Inner::BufferString(value.to_string().into())),
         }
     }
 }
@@ -83,7 +83,7 @@ impl From<String> for Scalar {
     fn from(value: String) -> Self {
         Self {
             dtype: DType::Utf8(NonNullable),
-            value: ScalarValue::BufferString(value.into()),
+            value: ScalarValue(Inner::BufferString(value.into())),
         }
     }
 }
@@ -92,7 +92,7 @@ impl From<BufferString> for Scalar {
     fn from(value: BufferString) -> Self {
         Self {
             dtype: DType::Utf8(NonNullable),
-            value: ScalarValue::BufferString(value),
+            value: ScalarValue(Inner::BufferString(value)),
         }
     }
 }

--- a/vortex-scalar/src/utf8.rs
+++ b/vortex-scalar/src/utf8.rs
@@ -4,7 +4,7 @@ use vortex_dtype::{DType, Nullability};
 use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
 
 use crate::value::ScalarValue;
-use crate::{Inner, Scalar};
+use crate::{InnerScalarValue, Scalar};
 
 pub struct Utf8Scalar<'a> {
     dtype: &'a DType,
@@ -43,7 +43,7 @@ impl Scalar {
     {
         Ok(Self {
             dtype: DType::Utf8(nullability),
-            value: ScalarValue(Inner::BufferString(str.try_into()?)),
+            value: ScalarValue(InnerScalarValue::BufferString(str.try_into()?)),
         })
     }
 }
@@ -74,7 +74,7 @@ impl From<&str> for Scalar {
     fn from(value: &str) -> Self {
         Self {
             dtype: DType::Utf8(NonNullable),
-            value: ScalarValue(Inner::BufferString(value.to_string().into())),
+            value: ScalarValue(InnerScalarValue::BufferString(value.to_string().into())),
         }
     }
 }
@@ -83,7 +83,7 @@ impl From<String> for Scalar {
     fn from(value: String) -> Self {
         Self {
             dtype: DType::Utf8(NonNullable),
-            value: ScalarValue(Inner::BufferString(value.into())),
+            value: ScalarValue(InnerScalarValue::BufferString(value.into())),
         }
     }
 }
@@ -92,7 +92,7 @@ impl From<BufferString> for Scalar {
     fn from(value: BufferString) -> Self {
         Self {
             dtype: DType::Utf8(NonNullable),
-            value: ScalarValue(Inner::BufferString(value)),
+            value: ScalarValue(InnerScalarValue::BufferString(value)),
         }
     }
 }

--- a/vortex-scalar/src/value.rs
+++ b/vortex-scalar/src/value.rs
@@ -19,7 +19,10 @@ use crate::pvalue::PValue;
 ///
 /// FIXME(ngates): make this opaque with an InnerScalarValue
 #[derive(Debug, Clone)]
-pub enum ScalarValue {
+pub struct ScalarValue(pub(crate) Inner);
+
+#[derive(Debug, Clone)]
+pub enum Inner {
     Bool(bool),
     Primitive(PValue),
     Buffer(Buffer),
@@ -39,6 +42,12 @@ fn to_hex(slice: &[u8]) -> Result<String, std::fmt::Error> {
 }
 
 impl Display for ScalarValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Display for Inner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Bool(b) => write!(f, "{}", b),
@@ -75,40 +84,40 @@ impl Display for ScalarValue {
 
 impl ScalarValue {
     pub(crate) fn is_null(&self) -> bool {
-        matches!(self, Self::Null)
+        matches!(self.0, Inner::Null)
     }
 
     pub fn is_instance_of(&self, dtype: &DType) -> bool {
-        match (self, dtype) {
-            (Self::Bool(_), DType::Bool(_)) => true,
-            (Self::Primitive(pvalue), DType::Primitive(ptype, _)) => pvalue.is_instance_of(ptype),
-            (Self::Buffer(_), DType::Binary(_)) => true,
-            (Self::BufferString(_), DType::Utf8(_)) => true,
-            (Self::List(values), DType::List(dtype, _)) => {
+        match (&self.0, dtype) {
+            (Inner::Bool(_), DType::Bool(_)) => true,
+            (Inner::Primitive(pvalue), DType::Primitive(ptype, _)) => pvalue.is_instance_of(ptype),
+            (Inner::Buffer(_), DType::Binary(_)) => true,
+            (Inner::BufferString(_), DType::Utf8(_)) => true,
+            (Inner::List(values), DType::List(dtype, _)) => {
                 values.iter().all(|v| v.is_instance_of(dtype))
             }
-            (Self::List(values), DType::Struct(structdt, _)) => values
+            (Inner::List(values), DType::Struct(structdt, _)) => values
                 .iter()
                 .zip(structdt.dtypes().to_vec())
                 .all(|(v, dt)| v.is_instance_of(&dt)),
-            (Self::Null, dtype) => dtype.is_nullable(),
+            (Inner::Null, dtype) => dtype.is_nullable(),
             (_, DType::Extension(ext_dtype)) => self.is_instance_of(ext_dtype.storage_dtype()),
             _ => false,
         }
     }
 
     pub(crate) fn as_null(&self) -> VortexResult<()> {
-        match self {
-            Self::Null => Ok(()),
-            _ => Err(vortex_err!("Expected a Null scalar, found {:?}", self)),
+        match self.0 {
+            Inner::Null => Ok(()),
+            _ => Err(vortex_err!("Expected a Null scalar, found {:?}", self.0)),
         }
     }
 
     pub(crate) fn as_bool(&self) -> VortexResult<Option<bool>> {
-        match self {
-            Self::Null => Ok(None),
-            Self::Bool(b) => Ok(Some(*b)),
-            _ => Err(vortex_err!("Expected a bool scalar, found {:?}", self)),
+        match &self.0 {
+            Inner::Null => Ok(None),
+            Inner::Bool(b) => Ok(Some(*b)),
+            _ => Err(vortex_err!("Expected a bool scalar, found {:?}", self.0)),
         }
     }
 
@@ -116,35 +125,38 @@ impl ScalarValue {
     ///  But the other accessors can sometimes be useful? e.g. as_buffer. But maybe we just force
     ///  the user to switch over Utf8 and Binary and use the correct Scalar wrapper?
     pub(crate) fn as_pvalue(&self) -> VortexResult<Option<PValue>> {
-        match self {
-            Self::Null => Ok(None),
-            Self::Primitive(p) => Ok(Some(*p)),
-            _ => Err(vortex_err!("Expected a primitive scalar, found {:?}", self)),
+        match &self.0 {
+            Inner::Null => Ok(None),
+            Inner::Primitive(p) => Ok(Some(*p)),
+            _ => Err(vortex_err!(
+                "Expected a primitive scalar, found {:?}",
+                self.0
+            )),
         }
     }
 
     pub(crate) fn as_buffer(&self) -> VortexResult<Option<Buffer>> {
-        match self {
-            Self::Null => Ok(None),
-            Self::Buffer(b) => Ok(Some(b.clone())),
-            _ => Err(vortex_err!("Expected a binary scalar, found {:?}", self)),
+        match &self.0 {
+            Inner::Null => Ok(None),
+            Inner::Buffer(b) => Ok(Some(b.clone())),
+            _ => Err(vortex_err!("Expected a binary scalar, found {:?}", self.0)),
         }
     }
 
     pub(crate) fn as_buffer_string(&self) -> VortexResult<Option<BufferString>> {
-        match self {
-            Self::Null => Ok(None),
-            Self::Buffer(b) => Ok(Some(BufferString::try_from(b.clone())?)),
-            Self::BufferString(b) => Ok(Some(b.clone())),
-            _ => Err(vortex_err!("Expected a string scalar, found {:?}", self)),
+        match &self.0 {
+            Inner::Null => Ok(None),
+            Inner::Buffer(b) => Ok(Some(BufferString::try_from(b.clone())?)),
+            Inner::BufferString(b) => Ok(Some(b.clone())),
+            _ => Err(vortex_err!("Expected a string scalar, found {:?}", self.0)),
         }
     }
 
     pub(crate) fn as_list(&self) -> VortexResult<Option<&Arc<[Self]>>> {
-        match self {
-            Self::Null => Ok(None),
-            Self::List(l) => Ok(Some(l)),
-            _ => Err(vortex_err!("Expected a list scalar, found {:?}", self)),
+        match &self.0 {
+            Inner::Null => Ok(None),
+            Inner::List(l) => Ok(Some(l)),
+            _ => Err(vortex_err!("Expected a list scalar, found {:?}", self.0)),
         }
     }
 }
@@ -185,7 +197,7 @@ impl ScalarValue {
 // {
 //     fn from(value: Option<T>) -> Self {
 //         match value {
-//             None => ScalarValue::Null,
+//             None => ScalarValue(Inner::Null),
 //             Some(value) => ScalarValue::from(value),
 //         }
 //     }
@@ -228,7 +240,7 @@ impl ScalarValue {
 mod test {
     use vortex_dtype::{DType, Nullability, PType, StructDType};
 
-    use crate::{PValue, ScalarValue};
+    use crate::{Inner, PValue, ScalarValue};
 
     #[test]
     pub fn test_is_instance_of_bool() {
@@ -250,7 +262,8 @@ mod test {
         let tboolnull = DType::Bool(Nullability::Nullable);
         let tnull = DType::Null;
 
-        let bool_null = ScalarValue::List(vec![ScalarValue::Bool(true), ScalarValue::Null].into());
+        let bool_null =
+            ScalarValue::List(vec![ScalarValue::Bool(true), ScalarValue(Inner::Null)].into());
         let bool_bool =
             ScalarValue::List(vec![ScalarValue::Bool(true), ScalarValue::Bool(false)].into());
 
@@ -292,22 +305,21 @@ mod test {
 
     #[test]
     pub fn test_is_instance_of_null() {
-        assert!(ScalarValue::Null.is_instance_of(&DType::Bool(Nullability::Nullable)));
-        assert!(!ScalarValue::Null.is_instance_of(&DType::Bool(Nullability::NonNullable)));
+        assert!(ScalarValue(Inner::Null).is_instance_of(&DType::Bool(Nullability::Nullable)));
+        assert!(!ScalarValue(Inner::Null).is_instance_of(&DType::Bool(Nullability::NonNullable)));
 
-        assert!(
-            ScalarValue::Null.is_instance_of(&DType::Primitive(PType::U8, Nullability::Nullable))
-        );
-        assert!(ScalarValue::Null.is_instance_of(&DType::Utf8(Nullability::Nullable)));
-        assert!(ScalarValue::Null.is_instance_of(&DType::Binary(Nullability::Nullable)));
-        assert!(ScalarValue::Null.is_instance_of(&DType::Struct(
+        assert!(ScalarValue(Inner::Null)
+            .is_instance_of(&DType::Primitive(PType::U8, Nullability::Nullable)));
+        assert!(ScalarValue(Inner::Null).is_instance_of(&DType::Utf8(Nullability::Nullable)));
+        assert!(ScalarValue(Inner::Null).is_instance_of(&DType::Binary(Nullability::Nullable)));
+        assert!(ScalarValue(Inner::Null).is_instance_of(&DType::Struct(
             StructDType::new([].into(), [].into()),
             Nullability::Nullable,
         )));
-        assert!(ScalarValue::Null.is_instance_of(&DType::List(
+        assert!(ScalarValue(Inner::Null).is_instance_of(&DType::List(
             DType::Utf8(Nullability::NonNullable).into(),
             Nullability::Nullable
         )));
-        assert!(ScalarValue::Null.is_instance_of(&DType::Null));
+        assert!(ScalarValue(Inner::Null).is_instance_of(&DType::Null));
     }
 }

--- a/vortex-scalar/src/value.rs
+++ b/vortex-scalar/src/value.rs
@@ -19,13 +19,13 @@ use crate::pvalue::PValue;
 #[derive(Debug, Clone)]
 pub struct ScalarValue(pub(crate) InnerScalarValue);
 
-#[derive(Debug, Clone)]
-pub enum InnerScalarValue {
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+pub(crate) enum InnerScalarValue {
     Bool(bool),
     Primitive(PValue),
     Buffer(Buffer),
     BufferString(BufferString),
-    List(Arc<[ScalarValue]>),
+    List(Arc<[InnerScalarValue]>),
     // It's significant that Null is last in this list. As a result generated PartialOrd sorts Scalar
     // values such that Nulls are last (greatest)
     Null,
@@ -82,11 +82,48 @@ impl Display for InnerScalarValue {
 
 impl ScalarValue {
     pub(crate) fn is_null(&self) -> bool {
-        matches!(self.0, InnerScalarValue::Null)
+        self.0.is_null()
     }
 
     pub fn is_instance_of(&self, dtype: &DType) -> bool {
-        match (&self.0, dtype) {
+        self.0.is_instance_of(dtype)
+    }
+
+    pub(crate) fn as_null(&self) -> VortexResult<()> {
+        self.0.as_null()
+    }
+
+    pub(crate) fn as_bool(&self) -> VortexResult<Option<bool>> {
+        self.0.as_bool()
+    }
+
+    /// FIXME(ngates): PValues are such a footgun... we should probably remove this.
+    ///  But the other accessors can sometimes be useful? e.g. as_buffer. But maybe we just force
+    ///  the user to switch over Utf8 and Binary and use the correct Scalar wrapper?
+    pub(crate) fn as_pvalue(&self) -> VortexResult<Option<PValue>> {
+        self.0.as_pvalue()
+    }
+
+    pub(crate) fn as_buffer(&self) -> VortexResult<Option<Buffer>> {
+        self.0.as_buffer()
+    }
+
+    pub(crate) fn as_buffer_string(&self) -> VortexResult<Option<BufferString>> {
+        self.0.as_buffer_string()
+    }
+
+    pub(crate) fn as_list(&self) -> VortexResult<Option<&Arc<[InnerScalarValue]>>> {
+        self.0.as_list()
+    }
+}
+
+impl InnerScalarValue {
+    pub(crate) fn is_null(&self) -> bool {
+        matches!(self, InnerScalarValue::Null)
+    }
+
+    pub fn is_instance_of(&self, dtype: &DType) -> bool {
+        match (&self, dtype) {
             (InnerScalarValue::Bool(_), DType::Bool(_)) => true,
             (InnerScalarValue::Primitive(pvalue), DType::Primitive(ptype, _)) => {
                 pvalue.is_instance_of(ptype)
@@ -107,17 +144,17 @@ impl ScalarValue {
     }
 
     pub(crate) fn as_null(&self) -> VortexResult<()> {
-        match self.0 {
+        match self {
             InnerScalarValue::Null => Ok(()),
-            _ => Err(vortex_err!("Expected a Null scalar, found {:?}", self.0)),
+            _ => Err(vortex_err!("Expected a Null scalar, found {:?}", self)),
         }
     }
 
     pub(crate) fn as_bool(&self) -> VortexResult<Option<bool>> {
-        match &self.0 {
+        match &self {
             InnerScalarValue::Null => Ok(None),
             InnerScalarValue::Bool(b) => Ok(Some(*b)),
-            _ => Err(vortex_err!("Expected a bool scalar, found {:?}", self.0)),
+            _ => Err(vortex_err!("Expected a bool scalar, found {:?}", self)),
         }
     }
 
@@ -125,38 +162,35 @@ impl ScalarValue {
     ///  But the other accessors can sometimes be useful? e.g. as_buffer. But maybe we just force
     ///  the user to switch over Utf8 and Binary and use the correct Scalar wrapper?
     pub(crate) fn as_pvalue(&self) -> VortexResult<Option<PValue>> {
-        match &self.0 {
+        match &self {
             InnerScalarValue::Null => Ok(None),
             InnerScalarValue::Primitive(p) => Ok(Some(*p)),
-            _ => Err(vortex_err!(
-                "Expected a primitive scalar, found {:?}",
-                self.0
-            )),
+            _ => Err(vortex_err!("Expected a primitive scalar, found {:?}", self)),
         }
     }
 
     pub(crate) fn as_buffer(&self) -> VortexResult<Option<Buffer>> {
-        match &self.0 {
+        match &self {
             InnerScalarValue::Null => Ok(None),
             InnerScalarValue::Buffer(b) => Ok(Some(b.clone())),
-            _ => Err(vortex_err!("Expected a binary scalar, found {:?}", self.0)),
+            _ => Err(vortex_err!("Expected a binary scalar, found {:?}", self)),
         }
     }
 
     pub(crate) fn as_buffer_string(&self) -> VortexResult<Option<BufferString>> {
-        match &self.0 {
+        match &self {
             InnerScalarValue::Null => Ok(None),
             InnerScalarValue::Buffer(b) => Ok(Some(BufferString::try_from(b.clone())?)),
             InnerScalarValue::BufferString(b) => Ok(Some(b.clone())),
-            _ => Err(vortex_err!("Expected a string scalar, found {:?}", self.0)),
+            _ => Err(vortex_err!("Expected a string scalar, found {:?}", self)),
         }
     }
 
     pub(crate) fn as_list(&self) -> VortexResult<Option<&Arc<[Self]>>> {
-        match &self.0 {
+        match &self {
             InnerScalarValue::Null => Ok(None),
             InnerScalarValue::List(l) => Ok(Some(l)),
-            _ => Err(vortex_err!("Expected a list scalar, found {:?}", self.0)),
+            _ => Err(vortex_err!("Expected a list scalar, found {:?}", self)),
         }
     }
 }
@@ -169,15 +203,19 @@ mod test {
 
     #[test]
     pub fn test_is_instance_of_bool() {
-        assert!(ScalarValue::Bool(true).is_instance_of(&DType::Bool(Nullability::Nullable)));
-        assert!(ScalarValue::Bool(true).is_instance_of(&DType::Bool(Nullability::NonNullable)));
-        assert!(ScalarValue::Bool(false).is_instance_of(&DType::Bool(Nullability::Nullable)));
-        assert!(ScalarValue::Bool(false).is_instance_of(&DType::Bool(Nullability::NonNullable)));
+        assert!(ScalarValue(InnerScalarValue::Bool(true))
+            .is_instance_of(&DType::Bool(Nullability::Nullable)));
+        assert!(ScalarValue(InnerScalarValue::Bool(true))
+            .is_instance_of(&DType::Bool(Nullability::NonNullable)));
+        assert!(ScalarValue(InnerScalarValue::Bool(false))
+            .is_instance_of(&DType::Bool(Nullability::Nullable)));
+        assert!(ScalarValue(InnerScalarValue::Bool(false))
+            .is_instance_of(&DType::Bool(Nullability::NonNullable)));
     }
 
     #[test]
     pub fn test_is_instance_of_primitive() {
-        assert!(ScalarValue::Primitive(PValue::F64(0.0))
+        assert!(ScalarValue(InnerScalarValue::Primitive(PValue::F64(0.0)))
             .is_instance_of(&DType::Primitive(PType::F64, Nullability::NonNullable)));
     }
 
@@ -187,11 +225,12 @@ mod test {
         let tboolnull = DType::Bool(Nullability::Nullable);
         let tnull = DType::Null;
 
-        let bool_null = ScalarValue::List(
-            vec![ScalarValue::Bool(true), ScalarValue(InnerScalarValue::Null)].into(),
-        );
-        let bool_bool =
-            ScalarValue::List(vec![ScalarValue::Bool(true), ScalarValue::Bool(false)].into());
+        let bool_null = ScalarValue(InnerScalarValue::List(
+            vec![InnerScalarValue::Bool(true), InnerScalarValue::Null].into(),
+        ));
+        let bool_bool = ScalarValue(InnerScalarValue::List(
+            vec![InnerScalarValue::Bool(true), InnerScalarValue::Bool(false)].into(),
+        ));
 
         fn tlist(element: &DType) -> DType {
             DType::List(element.clone().into(), Nullability::NonNullable)

--- a/vortex-scalar/src/value.rs
+++ b/vortex-scalar/src/value.rs
@@ -16,13 +16,11 @@ use crate::pvalue::PValue;
 ///
 /// For this reason, [`PartialEq`] and [`PartialOrd`] are only defined over [`Scalar`] and not
 /// [`ScalarValue`].
-///
-/// FIXME(ngates): make this opaque with an InnerScalarValue
 #[derive(Debug, Clone)]
-pub struct ScalarValue(pub(crate) Inner);
+pub struct ScalarValue(pub(crate) InnerScalarValue);
 
 #[derive(Debug, Clone)]
-pub enum Inner {
+pub enum InnerScalarValue {
     Bool(bool),
     Primitive(PValue),
     Buffer(Buffer),
@@ -47,7 +45,7 @@ impl Display for ScalarValue {
     }
 }
 
-impl Display for Inner {
+impl Display for InnerScalarValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Bool(b) => write!(f, "{}", b),
@@ -84,23 +82,25 @@ impl Display for Inner {
 
 impl ScalarValue {
     pub(crate) fn is_null(&self) -> bool {
-        matches!(self.0, Inner::Null)
+        matches!(self.0, InnerScalarValue::Null)
     }
 
     pub fn is_instance_of(&self, dtype: &DType) -> bool {
         match (&self.0, dtype) {
-            (Inner::Bool(_), DType::Bool(_)) => true,
-            (Inner::Primitive(pvalue), DType::Primitive(ptype, _)) => pvalue.is_instance_of(ptype),
-            (Inner::Buffer(_), DType::Binary(_)) => true,
-            (Inner::BufferString(_), DType::Utf8(_)) => true,
-            (Inner::List(values), DType::List(dtype, _)) => {
+            (InnerScalarValue::Bool(_), DType::Bool(_)) => true,
+            (InnerScalarValue::Primitive(pvalue), DType::Primitive(ptype, _)) => {
+                pvalue.is_instance_of(ptype)
+            }
+            (InnerScalarValue::Buffer(_), DType::Binary(_)) => true,
+            (InnerScalarValue::BufferString(_), DType::Utf8(_)) => true,
+            (InnerScalarValue::List(values), DType::List(dtype, _)) => {
                 values.iter().all(|v| v.is_instance_of(dtype))
             }
-            (Inner::List(values), DType::Struct(structdt, _)) => values
+            (InnerScalarValue::List(values), DType::Struct(structdt, _)) => values
                 .iter()
                 .zip(structdt.dtypes().to_vec())
                 .all(|(v, dt)| v.is_instance_of(&dt)),
-            (Inner::Null, dtype) => dtype.is_nullable(),
+            (InnerScalarValue::Null, dtype) => dtype.is_nullable(),
             (_, DType::Extension(ext_dtype)) => self.is_instance_of(ext_dtype.storage_dtype()),
             _ => false,
         }
@@ -108,15 +108,15 @@ impl ScalarValue {
 
     pub(crate) fn as_null(&self) -> VortexResult<()> {
         match self.0 {
-            Inner::Null => Ok(()),
+            InnerScalarValue::Null => Ok(()),
             _ => Err(vortex_err!("Expected a Null scalar, found {:?}", self.0)),
         }
     }
 
     pub(crate) fn as_bool(&self) -> VortexResult<Option<bool>> {
         match &self.0 {
-            Inner::Null => Ok(None),
-            Inner::Bool(b) => Ok(Some(*b)),
+            InnerScalarValue::Null => Ok(None),
+            InnerScalarValue::Bool(b) => Ok(Some(*b)),
             _ => Err(vortex_err!("Expected a bool scalar, found {:?}", self.0)),
         }
     }
@@ -126,8 +126,8 @@ impl ScalarValue {
     ///  the user to switch over Utf8 and Binary and use the correct Scalar wrapper?
     pub(crate) fn as_pvalue(&self) -> VortexResult<Option<PValue>> {
         match &self.0 {
-            Inner::Null => Ok(None),
-            Inner::Primitive(p) => Ok(Some(*p)),
+            InnerScalarValue::Null => Ok(None),
+            InnerScalarValue::Primitive(p) => Ok(Some(*p)),
             _ => Err(vortex_err!(
                 "Expected a primitive scalar, found {:?}",
                 self.0
@@ -137,110 +137,35 @@ impl ScalarValue {
 
     pub(crate) fn as_buffer(&self) -> VortexResult<Option<Buffer>> {
         match &self.0 {
-            Inner::Null => Ok(None),
-            Inner::Buffer(b) => Ok(Some(b.clone())),
+            InnerScalarValue::Null => Ok(None),
+            InnerScalarValue::Buffer(b) => Ok(Some(b.clone())),
             _ => Err(vortex_err!("Expected a binary scalar, found {:?}", self.0)),
         }
     }
 
     pub(crate) fn as_buffer_string(&self) -> VortexResult<Option<BufferString>> {
         match &self.0 {
-            Inner::Null => Ok(None),
-            Inner::Buffer(b) => Ok(Some(BufferString::try_from(b.clone())?)),
-            Inner::BufferString(b) => Ok(Some(b.clone())),
+            InnerScalarValue::Null => Ok(None),
+            InnerScalarValue::Buffer(b) => Ok(Some(BufferString::try_from(b.clone())?)),
+            InnerScalarValue::BufferString(b) => Ok(Some(b.clone())),
             _ => Err(vortex_err!("Expected a string scalar, found {:?}", self.0)),
         }
     }
 
     pub(crate) fn as_list(&self) -> VortexResult<Option<&Arc<[Self]>>> {
         match &self.0 {
-            Inner::Null => Ok(None),
-            Inner::List(l) => Ok(Some(l)),
+            InnerScalarValue::Null => Ok(None),
+            InnerScalarValue::List(l) => Ok(Some(l)),
             _ => Err(vortex_err!("Expected a list scalar, found {:?}", self.0)),
         }
     }
 }
 
-// impl From<usize> for ScalarValue {
-//     fn from(value: usize) -> Self {
-//         ScalarValue::Primitive(PValue::from(value))
-//     }
-// }
-
-// impl From<String> for ScalarValue {
-//     fn from(value: String) -> Self {
-//         ScalarValue::BufferString(BufferString::from(value))
-//     }
-// }
-
-// impl From<BufferString> for ScalarValue {
-//     fn from(value: BufferString) -> Self {
-//         ScalarValue::BufferString(value)
-//     }
-// }
-
-// impl From<bytes::Bytes> for ScalarValue {
-//     fn from(value: bytes::Bytes) -> Self {
-//         ScalarValue::Buffer(Buffer::from(value))
-//     }
-// }
-
-// impl From<Buffer> for ScalarValue {
-//     fn from(value: Buffer) -> Self {
-//         ScalarValue::Buffer(value)
-//     }
-// }
-
-// impl<T> From<Option<T>> for ScalarValue
-// where
-//     ScalarValue: From<T>,
-// {
-//     fn from(value: Option<T>) -> Self {
-//         match value {
-//             None => ScalarValue(Inner::Null),
-//             Some(value) => ScalarValue::from(value),
-//         }
-//     }
-// }
-
-// macro_rules! from_vec_for_scalar_value {
-//     ($T:ty) => {
-//         impl From<Vec<$T>> for ScalarValue {
-//             fn from(value: Vec<$T>) -> Self {
-//                 ScalarValue::List(
-//                     value
-//                         .into_iter()
-//                         .map(ScalarValue::from)
-//                         .collect::<Vec<_>>()
-//                         .into(),
-//                 )
-//             }
-//         }
-//     };
-// }
-
-// // no From<Vec<u8>> because it could either be a List or a Buffer
-// from_vec_for_scalar_value!(u16);
-// from_vec_for_scalar_value!(u32);
-// from_vec_for_scalar_value!(u64);
-// from_vec_for_scalar_value!(usize);
-// from_vec_for_scalar_value!(i8);
-// from_vec_for_scalar_value!(i16);
-// from_vec_for_scalar_value!(i32);
-// from_vec_for_scalar_value!(i64);
-// from_vec_for_scalar_value!(f16);
-// from_vec_for_scalar_value!(f32);
-// from_vec_for_scalar_value!(f64);
-// from_vec_for_scalar_value!(String);
-// from_vec_for_scalar_value!(BufferString);
-// from_vec_for_scalar_value!(bytes::Bytes);
-// from_vec_for_scalar_value!(Buffer);
-
 #[cfg(test)]
 mod test {
     use vortex_dtype::{DType, Nullability, PType, StructDType};
 
-    use crate::{Inner, PValue, ScalarValue};
+    use crate::{InnerScalarValue, PValue, ScalarValue};
 
     #[test]
     pub fn test_is_instance_of_bool() {
@@ -262,8 +187,9 @@ mod test {
         let tboolnull = DType::Bool(Nullability::Nullable);
         let tnull = DType::Null;
 
-        let bool_null =
-            ScalarValue::List(vec![ScalarValue::Bool(true), ScalarValue(Inner::Null)].into());
+        let bool_null = ScalarValue::List(
+            vec![ScalarValue::Bool(true), ScalarValue(InnerScalarValue::Null)].into(),
+        );
         let bool_bool =
             ScalarValue::List(vec![ScalarValue::Bool(true), ScalarValue::Bool(false)].into());
 
@@ -305,21 +231,31 @@ mod test {
 
     #[test]
     pub fn test_is_instance_of_null() {
-        assert!(ScalarValue(Inner::Null).is_instance_of(&DType::Bool(Nullability::Nullable)));
-        assert!(!ScalarValue(Inner::Null).is_instance_of(&DType::Bool(Nullability::NonNullable)));
+        assert!(
+            ScalarValue(InnerScalarValue::Null).is_instance_of(&DType::Bool(Nullability::Nullable))
+        );
+        assert!(!ScalarValue(InnerScalarValue::Null)
+            .is_instance_of(&DType::Bool(Nullability::NonNullable)));
 
-        assert!(ScalarValue(Inner::Null)
+        assert!(ScalarValue(InnerScalarValue::Null)
             .is_instance_of(&DType::Primitive(PType::U8, Nullability::Nullable)));
-        assert!(ScalarValue(Inner::Null).is_instance_of(&DType::Utf8(Nullability::Nullable)));
-        assert!(ScalarValue(Inner::Null).is_instance_of(&DType::Binary(Nullability::Nullable)));
-        assert!(ScalarValue(Inner::Null).is_instance_of(&DType::Struct(
-            StructDType::new([].into(), [].into()),
-            Nullability::Nullable,
-        )));
-        assert!(ScalarValue(Inner::Null).is_instance_of(&DType::List(
-            DType::Utf8(Nullability::NonNullable).into(),
-            Nullability::Nullable
-        )));
-        assert!(ScalarValue(Inner::Null).is_instance_of(&DType::Null));
+        assert!(
+            ScalarValue(InnerScalarValue::Null).is_instance_of(&DType::Utf8(Nullability::Nullable))
+        );
+        assert!(ScalarValue(InnerScalarValue::Null)
+            .is_instance_of(&DType::Binary(Nullability::Nullable)));
+        assert!(
+            ScalarValue(InnerScalarValue::Null).is_instance_of(&DType::Struct(
+                StructDType::new([].into(), [].into()),
+                Nullability::Nullable,
+            ))
+        );
+        assert!(
+            ScalarValue(InnerScalarValue::Null).is_instance_of(&DType::List(
+                DType::Utf8(Nullability::NonNullable).into(),
+                Nullability::Nullable
+            ))
+        );
+        assert!(ScalarValue(InnerScalarValue::Null).is_instance_of(&DType::Null));
     }
 }

--- a/vortex-scalar/src/value.rs
+++ b/vortex-scalar/src/value.rs
@@ -2,7 +2,6 @@ use std::fmt::{Display, Write};
 use std::sync::Arc;
 
 use vortex_buffer::{Buffer, BufferString};
-use vortex_dtype::half::f16;
 use vortex_dtype::DType;
 use vortex_error::{vortex_err, VortexResult};
 
@@ -98,16 +97,14 @@ impl ScalarValue {
         }
     }
 
-    #[deprecated(note = "Downcast Scalar to access values, rather than via ScalarValue")]
-    pub fn as_null(&self) -> VortexResult<()> {
+    pub(crate) fn as_null(&self) -> VortexResult<()> {
         match self {
             Self::Null => Ok(()),
             _ => Err(vortex_err!("Expected a Null scalar, found {:?}", self)),
         }
     }
 
-    #[deprecated(note = "Downcast Scalar to access values, rather than via ScalarValue")]
-    pub fn as_bool(&self) -> VortexResult<Option<bool>> {
+    pub(crate) fn as_bool(&self) -> VortexResult<Option<bool>> {
         match self {
             Self::Null => Ok(None),
             Self::Bool(b) => Ok(Some(*b)),
@@ -118,8 +115,7 @@ impl ScalarValue {
     /// FIXME(ngates): PValues are such a footgun... we should probably remove this.
     ///  But the other accessors can sometimes be useful? e.g. as_buffer. But maybe we just force
     ///  the user to switch over Utf8 and Binary and use the correct Scalar wrapper?
-    #[deprecated(note = "Downcast Scalar to access values, rather than via ScalarValue")]
-    pub fn as_pvalue(&self) -> VortexResult<Option<PValue>> {
+    pub(crate) fn as_pvalue(&self) -> VortexResult<Option<PValue>> {
         match self {
             Self::Null => Ok(None),
             Self::Primitive(p) => Ok(Some(*p)),
@@ -127,8 +123,7 @@ impl ScalarValue {
         }
     }
 
-    #[deprecated(note = "Downcast Scalar to access values, rather than via ScalarValue")]
-    pub fn as_buffer(&self) -> VortexResult<Option<Buffer>> {
+    pub(crate) fn as_buffer(&self) -> VortexResult<Option<Buffer>> {
         match self {
             Self::Null => Ok(None),
             Self::Buffer(b) => Ok(Some(b.clone())),
@@ -136,8 +131,7 @@ impl ScalarValue {
         }
     }
 
-    #[deprecated(note = "Downcast Scalar to access values, rather than via ScalarValue")]
-    pub fn as_buffer_string(&self) -> VortexResult<Option<BufferString>> {
+    pub(crate) fn as_buffer_string(&self) -> VortexResult<Option<BufferString>> {
         match self {
             Self::Null => Ok(None),
             Self::Buffer(b) => Ok(Some(BufferString::try_from(b.clone())?)),
@@ -146,8 +140,7 @@ impl ScalarValue {
         }
     }
 
-    #[deprecated(note = "Downcast Scalar to access values, rather than via ScalarValue")]
-    pub fn as_list(&self) -> VortexResult<Option<&Arc<[Self]>>> {
+    pub(crate) fn as_list(&self) -> VortexResult<Option<&Arc<[Self]>>> {
         match self {
             Self::Null => Ok(None),
             Self::List(l) => Ok(Some(l)),
@@ -156,80 +149,80 @@ impl ScalarValue {
     }
 }
 
-impl From<usize> for ScalarValue {
-    fn from(value: usize) -> Self {
-        ScalarValue::Primitive(PValue::from(value))
-    }
-}
+// impl From<usize> for ScalarValue {
+//     fn from(value: usize) -> Self {
+//         ScalarValue::Primitive(PValue::from(value))
+//     }
+// }
 
-impl From<String> for ScalarValue {
-    fn from(value: String) -> Self {
-        ScalarValue::BufferString(BufferString::from(value))
-    }
-}
+// impl From<String> for ScalarValue {
+//     fn from(value: String) -> Self {
+//         ScalarValue::BufferString(BufferString::from(value))
+//     }
+// }
 
-impl From<BufferString> for ScalarValue {
-    fn from(value: BufferString) -> Self {
-        ScalarValue::BufferString(value)
-    }
-}
+// impl From<BufferString> for ScalarValue {
+//     fn from(value: BufferString) -> Self {
+//         ScalarValue::BufferString(value)
+//     }
+// }
 
-impl From<bytes::Bytes> for ScalarValue {
-    fn from(value: bytes::Bytes) -> Self {
-        ScalarValue::Buffer(Buffer::from(value))
-    }
-}
+// impl From<bytes::Bytes> for ScalarValue {
+//     fn from(value: bytes::Bytes) -> Self {
+//         ScalarValue::Buffer(Buffer::from(value))
+//     }
+// }
 
-impl From<Buffer> for ScalarValue {
-    fn from(value: Buffer) -> Self {
-        ScalarValue::Buffer(value)
-    }
-}
+// impl From<Buffer> for ScalarValue {
+//     fn from(value: Buffer) -> Self {
+//         ScalarValue::Buffer(value)
+//     }
+// }
 
-impl<T> From<Option<T>> for ScalarValue
-where
-    ScalarValue: From<T>,
-{
-    fn from(value: Option<T>) -> Self {
-        match value {
-            None => ScalarValue::Null,
-            Some(value) => ScalarValue::from(value),
-        }
-    }
-}
+// impl<T> From<Option<T>> for ScalarValue
+// where
+//     ScalarValue: From<T>,
+// {
+//     fn from(value: Option<T>) -> Self {
+//         match value {
+//             None => ScalarValue::Null,
+//             Some(value) => ScalarValue::from(value),
+//         }
+//     }
+// }
 
-macro_rules! from_vec_for_scalar_value {
-    ($T:ty) => {
-        impl From<Vec<$T>> for ScalarValue {
-            fn from(value: Vec<$T>) -> Self {
-                ScalarValue::List(
-                    value
-                        .into_iter()
-                        .map(ScalarValue::from)
-                        .collect::<Vec<_>>()
-                        .into(),
-                )
-            }
-        }
-    };
-}
+// macro_rules! from_vec_for_scalar_value {
+//     ($T:ty) => {
+//         impl From<Vec<$T>> for ScalarValue {
+//             fn from(value: Vec<$T>) -> Self {
+//                 ScalarValue::List(
+//                     value
+//                         .into_iter()
+//                         .map(ScalarValue::from)
+//                         .collect::<Vec<_>>()
+//                         .into(),
+//                 )
+//             }
+//         }
+//     };
+// }
 
-// no From<Vec<u8>> because it could either be a List or a Buffer
-from_vec_for_scalar_value!(u16);
-from_vec_for_scalar_value!(u32);
-from_vec_for_scalar_value!(u64);
-from_vec_for_scalar_value!(usize);
-from_vec_for_scalar_value!(i8);
-from_vec_for_scalar_value!(i16);
-from_vec_for_scalar_value!(i32);
-from_vec_for_scalar_value!(i64);
-from_vec_for_scalar_value!(f16);
-from_vec_for_scalar_value!(f32);
-from_vec_for_scalar_value!(f64);
-from_vec_for_scalar_value!(String);
-from_vec_for_scalar_value!(BufferString);
-from_vec_for_scalar_value!(bytes::Bytes);
-from_vec_for_scalar_value!(Buffer);
+// // no From<Vec<u8>> because it could either be a List or a Buffer
+// from_vec_for_scalar_value!(u16);
+// from_vec_for_scalar_value!(u32);
+// from_vec_for_scalar_value!(u64);
+// from_vec_for_scalar_value!(usize);
+// from_vec_for_scalar_value!(i8);
+// from_vec_for_scalar_value!(i16);
+// from_vec_for_scalar_value!(i32);
+// from_vec_for_scalar_value!(i64);
+// from_vec_for_scalar_value!(f16);
+// from_vec_for_scalar_value!(f32);
+// from_vec_for_scalar_value!(f64);
+// from_vec_for_scalar_value!(String);
+// from_vec_for_scalar_value!(BufferString);
+// from_vec_for_scalar_value!(bytes::Bytes);
+// from_vec_for_scalar_value!(Buffer);
 
 #[cfg(test)]
 mod test {

--- a/vortex-scalar/src/value.rs
+++ b/vortex-scalar/src/value.rs
@@ -1,8 +1,8 @@
 use std::fmt::{Display, Write};
 use std::sync::Arc;
 
-use half::f16;
 use vortex_buffer::{Buffer, BufferString};
+use vortex_dtype::half::f16;
 use vortex_dtype::DType;
 use vortex_error::{vortex_err, VortexResult};
 
@@ -75,7 +75,7 @@ impl Display for ScalarValue {
 }
 
 impl ScalarValue {
-    pub fn is_null(&self) -> bool {
+    pub(crate) fn is_null(&self) -> bool {
         matches!(self, Self::Null)
     }
 
@@ -98,6 +98,7 @@ impl ScalarValue {
         }
     }
 
+    #[deprecated(note = "Downcast Scalar to access values, rather than via ScalarValue")]
     pub fn as_null(&self) -> VortexResult<()> {
         match self {
             Self::Null => Ok(()),
@@ -105,6 +106,7 @@ impl ScalarValue {
         }
     }
 
+    #[deprecated(note = "Downcast Scalar to access values, rather than via ScalarValue")]
     pub fn as_bool(&self) -> VortexResult<Option<bool>> {
         match self {
             Self::Null => Ok(None),
@@ -113,6 +115,10 @@ impl ScalarValue {
         }
     }
 
+    /// FIXME(ngates): PValues are such a footgun... we should probably remove this.
+    ///  But the other accessors can sometimes be useful? e.g. as_buffer. But maybe we just force
+    ///  the user to switch over Utf8 and Binary and use the correct Scalar wrapper?
+    #[deprecated(note = "Downcast Scalar to access values, rather than via ScalarValue")]
     pub fn as_pvalue(&self) -> VortexResult<Option<PValue>> {
         match self {
             Self::Null => Ok(None),
@@ -121,6 +127,7 @@ impl ScalarValue {
         }
     }
 
+    #[deprecated(note = "Downcast Scalar to access values, rather than via ScalarValue")]
     pub fn as_buffer(&self) -> VortexResult<Option<Buffer>> {
         match self {
             Self::Null => Ok(None),
@@ -129,6 +136,7 @@ impl ScalarValue {
         }
     }
 
+    #[deprecated(note = "Downcast Scalar to access values, rather than via ScalarValue")]
     pub fn as_buffer_string(&self) -> VortexResult<Option<BufferString>> {
         match self {
             Self::Null => Ok(None),
@@ -138,6 +146,7 @@ impl ScalarValue {
         }
     }
 
+    #[deprecated(note = "Downcast Scalar to access values, rather than via ScalarValue")]
     pub fn as_list(&self) -> VortexResult<Option<&Arc<[Self]>>> {
         match self {
             Self::Null => Ok(None),

--- a/vortex-scalar/src/value.rs
+++ b/vortex-scalar/src/value.rs
@@ -12,9 +12,14 @@ use crate::pvalue::PValue;
 /// up with a DType to make a Scalar.
 ///
 /// Note that these values can be deserialized from JSON or other formats. So a PValue may not
-/// have the correct width for what the DType expects. This means primitive values must be
-/// cast on-read.
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+/// have the correct width for what the DType expects. Primitive values should therefore be
+/// read using [PrimitiveScalar] which will handle the conversion.
+///
+/// For this reason, [`PartialEq`] and [`PartialOrd`] are only defined over [`Scalar`] and not
+/// [`ScalarValue`].
+///
+/// FIXME(ngates): make this opaque with an InnerScalarValue
+#[derive(Debug, Clone)]
 pub enum ScalarValue {
     Bool(bool),
     Primitive(PValue),
@@ -37,9 +42,9 @@ fn to_hex(slice: &[u8]) -> Result<String, std::fmt::Error> {
 impl Display for ScalarValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ScalarValue::Bool(b) => write!(f, "{}", b),
-            ScalarValue::Primitive(pvalue) => write!(f, "{}", pvalue),
-            ScalarValue::Buffer(buf) => {
+            Self::Bool(b) => write!(f, "{}", b),
+            Self::Primitive(pvalue) => write!(f, "{}", pvalue),
+            Self::Buffer(buf) => {
                 if buf.len() > 10 {
                     write!(
                         f,
@@ -51,7 +56,7 @@ impl Display for ScalarValue {
                     write!(f, "{}", to_hex(buf.as_slice())?)
                 }
             }
-            ScalarValue::BufferString(bufstr) => {
+            Self::BufferString(bufstr) => {
                 if bufstr.len() > 10 {
                     write!(
                         f,
@@ -63,8 +68,8 @@ impl Display for ScalarValue {
                     write!(f, "{}", bufstr.as_str())
                 }
             }
-            ScalarValue::List(_) => todo!(),
-            ScalarValue::Null => write!(f, "null"),
+            Self::List(_) => todo!(),
+            Self::Null => write!(f, "null"),
         }
     }
 }
@@ -76,20 +81,18 @@ impl ScalarValue {
 
     pub fn is_instance_of(&self, dtype: &DType) -> bool {
         match (self, dtype) {
-            (ScalarValue::Bool(_), DType::Bool(_)) => true,
-            (ScalarValue::Primitive(pvalue), DType::Primitive(ptype, _)) => {
-                pvalue.is_instance_of(ptype)
-            }
-            (ScalarValue::Buffer(_), DType::Binary(_)) => true,
-            (ScalarValue::BufferString(_), DType::Utf8(_)) => true,
-            (ScalarValue::List(values), DType::List(dtype, _)) => {
+            (Self::Bool(_), DType::Bool(_)) => true,
+            (Self::Primitive(pvalue), DType::Primitive(ptype, _)) => pvalue.is_instance_of(ptype),
+            (Self::Buffer(_), DType::Binary(_)) => true,
+            (Self::BufferString(_), DType::Utf8(_)) => true,
+            (Self::List(values), DType::List(dtype, _)) => {
                 values.iter().all(|v| v.is_instance_of(dtype))
             }
-            (ScalarValue::List(values), DType::Struct(structdt, _)) => values
+            (Self::List(values), DType::Struct(structdt, _)) => values
                 .iter()
                 .zip(structdt.dtypes().to_vec())
                 .all(|(v, dt)| v.is_instance_of(&dt)),
-            (ScalarValue::Null, dtype) => dtype.is_nullable(),
+            (Self::Null, dtype) => dtype.is_nullable(),
             (_, DType::Extension(ext_dtype)) => self.is_instance_of(ext_dtype.storage_dtype()),
             _ => false,
         }

--- a/vortex-scalar/src/value.rs
+++ b/vortex-scalar/src/value.rs
@@ -12,9 +12,9 @@ use crate::pvalue::PValue;
 ///
 /// Note that these values can be deserialized from JSON or other formats. So a PValue may not
 /// have the correct width for what the DType expects. Primitive values should therefore be
-/// read using [PrimitiveScalar] which will handle the conversion.
+/// read using [crate::PrimitiveScalar] which will handle the conversion.
 ///
-/// For this reason, [`PartialEq`] and [`PartialOrd`] are only defined over [`Scalar`] and not
+/// For this reason, [`PartialEq`] and [`PartialOrd`] are only defined over [`crate::Scalar`] and not
 /// [`ScalarValue`].
 #[derive(Debug, Clone)]
 pub struct ScalarValue(pub(crate) InnerScalarValue);


### PR DESCRIPTION
@danking I started throwing this together, seems like it removes most of the foot guns.

Roughly:
* ScalarValue is opaque (deprecated the accessor methods, burning them down)
* Callers who used to use ScalarValue, should instead downcast a Scalar with `Scalar::as_primitive(_opt)` etc. and then extract the value using `PrimitiveScalar::value` etc.
* PrimitiveScalar has a new `as_<T>()` accessor that performs a cast, this can sometimes be useful. Maybe it's unnecessary, and we should just cast the scalar? Not sure yet.
* We can make an InnerScalarValue and turn ScalarValue into a unit struct to make it truly opaque.