### PR TITLE
feat: implement SizeLimitedStream for backpressure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4978,6 +4978,7 @@ dependencies = [
  "futures",
  "futures-util",
  "object_store",
+ "pin-project",
  "tempfile",
  "tokio",
  "tracing",

--- a/vortex-io/Cargo.toml
+++ b/vortex-io/Cargo.toml
@@ -16,7 +16,8 @@ categories.workspace = true
 [dependencies]
 bytes = { workspace = true }
 compio = { workspace = true, features = ["bytes", "macros"], optional = true }
-tokio = { workspace = true, features = ["fs", "io-util", "rt"], optional = true }
+pin-project = { workspace = true }
+tokio = { workspace = true, features = ["fs", "io-util", "rt", "sync"], optional = true }
 tracing = { workspace = true, optional = true }
 futures = { workspace = true, features = ["std"] }
 futures-util = { workspace = true }

--- a/vortex-io/src/lib.rs
+++ b/vortex-io/src/lib.rs
@@ -9,6 +9,8 @@
 
 pub use buf::*;
 pub use dispatcher::*;
+#[cfg(feature = "tokio")]
+pub use limit::*;
 #[cfg(feature = "object_store")]
 pub use object_store::*;
 pub use read::*;
@@ -21,6 +23,8 @@ mod buf;
 #[cfg(feature = "compio")]
 mod compio;
 mod dispatcher;
+#[cfg(feature = "tokio")]
+mod limit;
 #[cfg(feature = "object_store")]
 mod object_store;
 pub mod offset;

--- a/vortex-io/src/limit.rs
+++ b/vortex-io/src/limit.rs
@@ -1,0 +1,190 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{ready, Context, Poll};
+
+use futures::Stream;
+use futures_util::stream::FuturesUnordered;
+use pin_project::pin_project;
+use tokio::sync::{Semaphore, TryAcquireError};
+
+/// [`Future`] that carries the amount of memory it will require to hold the completed value.
+#[pin_project]
+struct SizedFut<Fut> {
+    #[pin]
+    inner: Fut,
+    size_in_bytes: usize,
+}
+
+impl<Fut: Future> Future for SizedFut<Fut> {
+    // We tag the size in bytes alongside the original output
+    type Output = (Fut::Output, usize);
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let size_in_bytes = self.size_in_bytes;
+        let inner = ready!(self.project().inner.poll(cx));
+
+        Poll::Ready((inner, size_in_bytes))
+    }
+}
+
+/// A [`Stream`] that can work on several simultaneous requests, capping the amount of memory it
+/// uses at any given point.
+///
+/// It is meant to serve as a buffer between a producer and consumer of IO requests, with built-in
+/// backpressure that prevents the producer from materializing more than a specified maximum
+/// amount of memory.
+///
+/// This crate internally makes use of tokio's [Semaphore], and thus is only available with
+/// the `tokio` feature enabled.
+#[pin_project]
+#[cfg(feature = "tokio")]
+pub struct SizeLimitedStream<Fut> {
+    #[pin]
+    inflight: FuturesUnordered<SizedFut<Fut>>,
+    bytes_available: Semaphore,
+}
+
+#[cfg(feature = "tokio")]
+impl<Fut> SizeLimitedStream<Fut> {
+    pub fn new(max_bytes: usize) -> Self {
+        Self {
+            inflight: FuturesUnordered::new(),
+            bytes_available: Semaphore::new(max_bytes),
+        }
+    }
+
+    pub fn bytes_available(&self) -> usize {
+        self.bytes_available.available_permits()
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<Fut> SizeLimitedStream<Fut>
+where
+    Fut: Future,
+{
+    /// Push a future into the queue after reserving `bytes` of capacity.
+    ///
+    /// This call may need to wait until there is sufficient capacity available in the stream to
+    /// begin work on this future.
+    pub async fn push(&self, fut: Fut, bytes: usize) {
+        // Attempt to acquire enough permits to begin working on a request that will occupy
+        // `bytes` amount of memory when it completes.
+        // Acquiring the permits is what creates backpressure for the producer.
+        self.bytes_available
+            .acquire_many(bytes as u32)
+            .await
+            .unwrap_or_else(|_| unreachable!("pushing to closed semaphore"))
+            .forget();
+
+        let sized_fut = SizedFut {
+            inner: fut,
+            size_in_bytes: bytes,
+        };
+
+        // push into the pending queue
+        self.inflight.push(sized_fut);
+    }
+
+    /// Synchronous push method. This method will attempt to push if there is enough capacity
+    /// to begin work on the future immediately.
+    ///
+    /// If there is not enough capacity, the original future is returned to the caller.
+    pub fn try_push(&self, fut: Fut, bytes: usize) -> Result<(), Fut> {
+        match self.bytes_available.try_acquire_many(bytes as u32) {
+            Ok(permits) => {
+                permits.forget();
+                let sized_fut = SizedFut {
+                    inner: fut,
+                    size_in_bytes: bytes,
+                };
+
+                self.inflight.push(sized_fut);
+                Ok(())
+            }
+            Err(acquire_err) => match acquire_err {
+                TryAcquireError::Closed => {
+                    unreachable!("try_pushing to closed semaphore");
+                }
+
+                // No permits available, return the future back to the client so they can
+                // try again.
+                TryAcquireError::NoPermits => Err(fut),
+            },
+        }
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<Fut> Stream for SizeLimitedStream<Fut>
+where
+    Fut: Future,
+{
+    type Item = Fut::Output;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        match ready!(this.inflight.poll_next(cx)) {
+            None => Poll::Ready(None),
+            Some((result, bytes_read)) => {
+                this.bytes_available.add_permits(bytes_read);
+
+                Poll::Ready(Some(result))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{future, io};
+
+    use bytes::Bytes;
+    use futures_util::future::BoxFuture;
+    use futures_util::{FutureExt, StreamExt};
+
+    use crate::limit::SizeLimitedStream;
+
+    async fn make_future(len: usize) -> Bytes {
+        "a".as_bytes().iter().copied().cycle().take(len).collect()
+    }
+
+    #[tokio::test]
+    async fn test_size_limit() {
+        let mut size_limited = SizeLimitedStream::new(10);
+        size_limited.push(make_future(5), 5).await;
+        size_limited.push(make_future(5), 5).await;
+
+        // Pushing last request should fail, because we have 10 bytes outstanding.
+        assert!(size_limited.try_push(make_future(1), 1).is_err());
+
+        // but, we can pop off a finished work item, and then enqueue.
+        assert!(size_limited.next().await.is_some());
+        assert!(size_limited.try_push(make_future(1), 1).is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_does_not_leak_permits() {
+        let bad_fut: BoxFuture<'static, io::Result<Bytes>> =
+            future::ready(Err(io::Error::new(io::ErrorKind::Other, "badness"))).boxed();
+
+        let good_fut: BoxFuture<'static, io::Result<Bytes>> =
+            future::ready(Ok(Bytes::from_static("aaaaa".as_bytes()))).boxed();
+
+        let mut size_limited = SizeLimitedStream::new(10);
+        size_limited.push(bad_fut, 10).await;
+
+        // attempt to push should fail, as all 10 bytes of capacity is occupied by bad_fut.
+        let good_fut = size_limited
+            .try_push(good_fut, 5)
+            .expect_err("try_push should fail");
+
+        // Even though the result was an error, the 10 bytes of capacity should be returned back to
+        // the stream, allowing us to push the next request.
+        let next = size_limited.next().await.unwrap();
+        assert!(next.is_err());
+
+        assert_eq!(size_limited.bytes_available(), 10);
+        assert!(size_limited.try_push(good_fut, 5).is_ok());
+    }
+}

--- a/vortex-io/src/limit.rs
+++ b/vortex-io/src/limit.rs
@@ -37,14 +37,12 @@ impl<Fut: Future> Future for SizedFut<Fut> {
 /// This crate internally makes use of tokio's [Semaphore], and thus is only available with
 /// the `tokio` feature enabled.
 #[pin_project]
-#[cfg(feature = "tokio")]
 pub struct SizeLimitedStream<Fut> {
     #[pin]
     inflight: FuturesUnordered<SizedFut<Fut>>,
     bytes_available: Semaphore,
 }
 
-#[cfg(feature = "tokio")]
 impl<Fut> SizeLimitedStream<Fut> {
     pub fn new(max_bytes: usize) -> Self {
         Self {
@@ -58,7 +56,6 @@ impl<Fut> SizeLimitedStream<Fut> {
     }
 }
 
-#[cfg(feature = "tokio")]
 impl<Fut> SizeLimitedStream<Fut>
 where
     Fut: Future,
@@ -115,7 +112,6 @@ where
     }
 }
 
-#[cfg(feature = "tokio")]
 impl<Fut> Stream for SizeLimitedStream<Fut>
 where
     Fut: Future,


### PR DESCRIPTION
Implement a simple size-limited queue. Similar to `FuturesUnordered`, except it caps the total amount bytes that outstanding tasks will materialize into memory.

The goal is to use this in #1466 to give us a backpressure mechanism that relies on memory rather than an arbitrary # of requests.

There are explanatory doc comments on the `SizeLimitedStream` and `SizedFut` types.