### PR TITLE
chore: make the LayoutReader more poll-y

### DIFF
--- a/vortex-file/src/read/layouts/chunked.rs
+++ b/vortex-file/src/read/layouts/chunked.rs
@@ -13,8 +13,8 @@ use crate::layouts::RangedLayoutReader;
 use crate::read::cache::RelativeLayoutCache;
 use crate::read::mask::RowMask;
 use crate::{
-    BatchRead, Layout, LayoutDeserializer, LayoutId, LayoutPartId, LayoutReader, MessageLocator,
-    MetadataRead, Scan, CHUNKED_LAYOUT_ID,
+    Layout, LayoutDeserializer, LayoutId, LayoutPartId, LayoutReader, MessageLocator, PollRead,
+    Scan, CHUNKED_LAYOUT_ID,
 };
 
 #[derive(Default, Debug)]
@@ -164,6 +164,15 @@ impl ChildRead {
 
 type InProgressLayoutRanges = RwLock<HashMap<(usize, usize), (Vec<usize>, Vec<ChildRead>)>>;
 
+/// Reader for chunked arrays.
+///
+/// `ChunkedLayoutReader` is a nested layout that provides a reader for each chunk, as well as an
+/// optional "metadata layout".
+///
+/// ## Metadata Layout
+///
+/// The metadata layout provides a way to read a [table][ArrayData] of statistics. These statistics
+/// can be examined to make pruning decisions at scan time.
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct ChunkedLayoutReader {
@@ -214,17 +223,14 @@ impl ChunkedLayoutReader {
             .filter(|(_, cr)| !cr.finished())
         {
             let layout_selection = mask.slice(*begin, *end).shift(*begin)?;
-            if let Some(rr) = layout.read_selection(&layout_selection)? {
-                match rr {
-                    BatchRead::ReadMore(m) => {
-                        messages_to_fetch.extend(m);
-                    }
-                    BatchRead::Batch(a) => {
-                        *array_slot = ChildRead::Finished(Some(a));
-                    }
+            match layout.poll_read(&layout_selection)? {
+                PollRead::ReadMore(m) => {
+                    messages_to_fetch.extend(m);
                 }
-            } else {
-                *array_slot = ChildRead::Finished(None);
+                PollRead::Ready(Some(a)) => {
+                    *array_slot = ChildRead::Finished(Some(a));
+                }
+                PollRead::Ready(None) => *array_slot = ChildRead::Finished(None),
             }
         }
 
@@ -249,10 +255,10 @@ impl LayoutReader for ChunkedLayoutReader {
         Ok(())
     }
 
-    fn read_selection(&self, selector: &RowMask) -> VortexResult<Option<BatchRead>> {
+    fn poll_read(&self, selector: &RowMask) -> VortexResult<PollRead<Option<ArrayData>>> {
         let messages_to_fetch = self.buffer_read(selector)?;
         if !messages_to_fetch.is_empty() {
-            return Ok(Some(BatchRead::ReadMore(messages_to_fetch)));
+            return Ok(PollRead::ReadMore(messages_to_fetch));
         }
 
         if let Some((_, arrays_in_range)) = self
@@ -265,38 +271,39 @@ impl LayoutReader for ChunkedLayoutReader {
                 .into_iter()
                 .filter_map(ChildRead::into_value)
                 .collect::<Vec<_>>();
+
             match child_arrays.len() {
-                0 | 1 => Ok(child_arrays.pop().map(BatchRead::Batch)),
+                0 | 1 => Ok(PollRead::Ready(child_arrays.pop())),
                 _ => {
                     let dtype = child_arrays[0].dtype().clone();
-                    Ok(Some(BatchRead::Batch(
+                    Ok(PollRead::Ready(Some(
                         ChunkedArray::try_new(child_arrays, dtype)?.into_array(),
                     )))
                 }
             }
         } else {
-            Ok(None)
+            Ok(PollRead::Ready(None))
         }
     }
 
-    fn read_metadata(&self) -> VortexResult<MetadataRead> {
+    fn poll_metadata(&self) -> VortexResult<PollRead<Option<Vec<Option<ArrayData>>>>> {
         match self.metadata_layout() {
-            None => Ok(MetadataRead::None),
+            // No metadata layout means no metadata
+            None => Ok(PollRead::Ready(None)),
             Some(metadata_layout) => {
                 if let Some(md) = self.cached_metadata.get() {
-                    return Ok(MetadataRead::Batches(vec![Some(md.clone())]));
+                    return Ok(PollRead::Ready(Some(vec![Some(md.clone())])));
                 }
 
-                match metadata_layout
-                    .read_selection(&RowMask::new_valid_between(0, self.n_chunks()))?
-                {
-                    Some(BatchRead::Batch(array)) => {
+                match metadata_layout.poll_read(&RowMask::new_valid_between(0, self.n_chunks()))? {
+                    PollRead::Ready(Some(array)) => {
                         // We don't care if the write failed
-                        _ = self.cached_metadata.set(array.clone());
-                        Ok(MetadataRead::Batches(vec![Some(array)]))
+                        self.cached_metadata.set(array.clone()).ok();
+
+                        Ok(PollRead::Ready(Some(vec![Some(array)])))
                     }
-                    Some(BatchRead::ReadMore(messages)) => Ok(MetadataRead::ReadMore(messages)),
-                    None => Ok(MetadataRead::None),
+                    PollRead::Ready(None) => Ok(PollRead::Ready(None)),
+                    PollRead::ReadMore(messages) => Ok(PollRead::ReadMore(messages)),
                 }
             }
         }

--- a/vortex-file/src/read/layouts/columnar.rs
+++ b/vortex-file/src/read/layouts/columnar.rs
@@ -18,7 +18,7 @@ use crate::read::cache::{LazyDType, RelativeLayoutCache};
 use crate::read::expr_project::expr_project;
 use crate::read::mask::RowMask;
 use crate::{
-    BatchRead, Layout, LayoutDeserializer, LayoutId, LayoutReader, MetadataRead, RowFilter, Scan,
+    Layout, LayoutDeserializer, LayoutId, LayoutReader, PollRead, RowFilter, Scan,
     COLUMNAR_LAYOUT_ID,
 };
 
@@ -237,7 +237,7 @@ impl LayoutReader for ColumnarLayoutReader {
         Ok(())
     }
 
-    fn read_selection(&self, selection: &RowMask) -> VortexResult<Option<BatchRead>> {
+    fn poll_read(&self, selection: &RowMask) -> VortexResult<PollRead<Option<ArrayData>>> {
         let mut in_progress_guard = self
             .in_progress_ranges
             .write()
@@ -252,30 +252,29 @@ impl LayoutReader for ColumnarLayoutReader {
             .enumerate()
             .filter(|(_, a)| a.is_none())
         {
-            match self.children[i].read_selection(selection)? {
-                Some(rr) => match rr {
-                    BatchRead::ReadMore(message) => {
-                        messages.extend(message);
+            match self.children[i].poll_read(selection)? {
+                PollRead::ReadMore(message) => {
+                    messages.extend(message);
+                }
+                PollRead::Ready(Some(arr)) => {
+                    if self.shortcircuit_siblings
+                        && arr.statistics().compute_true_count().vortex_expect(
+                            "must be a bool array if shortcircuit_siblings is set to true",
+                        ) == 0
+                    {
+                        in_progress_guard.remove(&selection_range);
+                        return Ok(PollRead::Ready(None));
                     }
-                    BatchRead::Batch(arr) => {
-                        if self.shortcircuit_siblings
-                            && arr.statistics().compute_true_count().vortex_expect(
-                                "must be a bool array if shortcircuit_siblings is set to true",
-                            ) == 0
-                        {
-                            in_progress_guard.remove(&selection_range);
-                            return Ok(None);
-                        }
-                        *child_array = Some(arr)
-                    }
-                },
-                None => {
+
+                    *child_array = Some(arr)
+                }
+                PollRead::Ready(None) => {
                     debug_assert!(
                         in_progress_selection.iter().all(Option::is_none),
                         "Expected layout {}({i}) to produce an array but it was empty",
                         self.names[i]
                     );
-                    return Ok(None);
+                    return Ok(PollRead::Ready(None));
                 }
             }
         }
@@ -299,14 +298,14 @@ impl LayoutReader for ColumnarLayoutReader {
                 .as_ref()
                 .map(|e| e.evaluate(&array))
                 .unwrap_or_else(|| Ok(array))
-                .map(BatchRead::Batch)
                 .map(Some)
+                .map(PollRead::Ready)
         } else {
-            Ok(Some(BatchRead::ReadMore(messages)))
+            Ok(PollRead::ReadMore(messages))
         }
     }
 
-    fn read_metadata(&self) -> VortexResult<MetadataRead> {
+    fn poll_metadata(&self) -> VortexResult<PollRead<Option<Vec<Option<ArrayData>>>>> {
         let mut in_progress_metadata = self
             .in_progress_metadata
             .write()
@@ -314,18 +313,19 @@ impl LayoutReader for ColumnarLayoutReader {
         let mut messages = Vec::default();
 
         for (name, child_reader) in self.names.iter().zip(self.children.iter()) {
-            match child_reader.read_metadata()? {
-                MetadataRead::Batches(data) => {
+            match child_reader.poll_metadata()? {
+                PollRead::Ready(Some(data)) => {
                     if data.len() != 1 {
                         vortex_bail!("expected exactly one metadata array per-child");
                     }
                     in_progress_metadata.insert(name.clone(), data[0].clone());
                 }
-                MetadataRead::ReadMore(rm) => {
-                    messages.extend(rm);
-                }
-                MetadataRead::None => {
+                PollRead::Ready(None) => {
+                    // There is no metadata for whatever the child array is.
                     in_progress_metadata.insert(name.clone(), None);
+                }
+                PollRead::ReadMore(rm) => {
+                    messages.extend(rm);
                 }
             }
         }
@@ -338,9 +338,9 @@ impl LayoutReader for ColumnarLayoutReader {
                 .map(|name| in_progress_metadata[name].clone()) // TODO(Adam): Some columns might not have statistics
                 .collect::<Vec<_>>();
 
-            Ok(MetadataRead::Batches(child_arrays))
+            Ok(PollRead::Ready(Some(child_arrays)))
         } else {
-            Ok(MetadataRead::ReadMore(messages))
+            Ok(PollRead::ReadMore(messages))
         }
     }
 }

--- a/vortex-file/src/read/layouts/flat.rs
+++ b/vortex-file/src/read/layouts/flat.rs
@@ -11,8 +11,8 @@ use vortex_ipc::stream_writer::ByteRange;
 use crate::read::cache::RelativeLayoutCache;
 use crate::read::mask::RowMask;
 use crate::{
-    BatchRead, Layout, LayoutDeserializer, LayoutId, LayoutReader, MessageLocator, MetadataRead,
-    Scan, FLAT_LAYOUT_ID,
+    Layout, LayoutDeserializer, LayoutId, LayoutReader, MessageLocator, PollRead, Scan,
+    FLAT_LAYOUT_ID,
 };
 
 #[derive(Debug)]
@@ -50,6 +50,11 @@ impl Layout for FlatLayout {
     }
 }
 
+/// [`LayoutReader`] for "flat" layouts, i.e. a layout of an array that does not contain any
+/// nesting.
+///
+/// Any [array][ArrayData] can be written with a flat layout, which is simply a set of IPC messages
+/// packed into a single buffer.
 #[derive(Debug)]
 pub struct FlatLayoutReader {
     range: ByteRange,
@@ -96,29 +101,30 @@ impl LayoutReader for FlatLayoutReader {
         Ok(())
     }
 
-    fn read_selection(&self, selection: &RowMask) -> VortexResult<Option<BatchRead>> {
+    fn poll_read(&self, selection: &RowMask) -> VortexResult<PollRead<Option<ArrayData>>> {
         if let Some(buf) = self.message_cache.get(&[]) {
             let array = self.array_from_bytes(buf)?;
-            selection
-                .filter_array(array)?
-                .map(|s| {
-                    Ok(BatchRead::Batch(
-                        self.scan
-                            .expr
-                            .as_ref()
-                            .map(|e| e.evaluate(&s))
-                            .transpose()?
-                            .unwrap_or(s),
-                    ))
-                })
-                .transpose()
+
+            if let Some(selected) = selection.filter_array(array)? {
+                let filtered = self
+                    .scan
+                    .expr
+                    .as_ref()
+                    .map(|e| e.evaluate(&selected))
+                    .transpose()?
+                    .unwrap_or(selected);
+                Ok(PollRead::Ready(Some(filtered)))
+            } else {
+                Ok(PollRead::Ready(None))
+            }
         } else {
-            Ok(Some(BatchRead::ReadMore(vec![self.own_message()])))
+            Ok(PollRead::ReadMore(vec![self.own_message()]))
         }
     }
 
-    fn read_metadata(&self) -> VortexResult<MetadataRead> {
-        Ok(MetadataRead::None)
+    fn poll_metadata(&self) -> VortexResult<PollRead<Option<Vec<Option<ArrayData>>>>> {
+        // Flat layouts do not have metadata
+        Ok(PollRead::Ready(None))
     }
 }
 

--- a/vortex-file/src/read/layouts/inline_dtype.rs
+++ b/vortex-file/src/read/layouts/inline_dtype.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use flatbuffers::root;
 use once_cell::sync::OnceCell;
+use vortex_array::ArrayData;
 use vortex_error::{vortex_bail, VortexResult};
 use vortex_flatbuffers::{footer, message};
 use vortex_ipc::stream_writer::ByteRange;
@@ -11,8 +12,8 @@ use vortex_ipc::stream_writer::ByteRange;
 use crate::read::cache::{LazyDType, RelativeLayoutCache};
 use crate::read::mask::RowMask;
 use crate::{
-    BatchRead, Layout, LayoutDeserializer, LayoutId, LayoutPartId, LayoutReader, MessageLocator,
-    MetadataRead, Scan, INLINE_SCHEMA_LAYOUT_ID,
+    Layout, LayoutDeserializer, LayoutId, LayoutPartId, LayoutReader, MessageLocator, PollRead,
+    Scan, INLINE_SCHEMA_LAYOUT_ID,
 };
 
 #[derive(Debug)]
@@ -125,19 +126,19 @@ impl LayoutReader for InlineDTypeLayoutReader {
         self.child_reader()?.add_splits(row_offset, splits)
     }
 
-    fn read_selection(&self, selector: &RowMask) -> VortexResult<Option<BatchRead>> {
+    fn poll_read(&self, selector: &RowMask) -> VortexResult<PollRead<Option<ArrayData>>> {
         if let Some(cr) = self.child_layout.get() {
-            cr.read_selection(selector)
+            cr.poll_read(selector)
         } else {
             if self.message_cache.get(&[INLINE_DTYPE_BUFFER_IDX]).is_some() {
                 self.child_layout.get_or_try_init(|| self.child_reader())?;
-                return self.read_selection(selector);
+                return self.poll_read(selector);
             }
-            Ok(Some(BatchRead::ReadMore(vec![self.dtype_message()?])))
+            Ok(PollRead::ReadMore(vec![self.dtype_message()?]))
         }
     }
 
-    fn read_metadata(&self) -> VortexResult<MetadataRead> {
-        Ok(MetadataRead::None)
+    fn poll_metadata(&self) -> VortexResult<PollRead<Option<Vec<Option<ArrayData>>>>> {
+        Ok(PollRead::Ready(None))
     }
 }

--- a/vortex-file/src/read/layouts/test_read.rs
+++ b/vortex-file/src/read/layouts/test_read.rs
@@ -7,7 +7,7 @@ use vortex_error::{vortex_panic, VortexUnwrap};
 
 use crate::read::mask::RowMask;
 use crate::read::splits::{FixedSplitIterator, MaskIterator, SplitMask};
-use crate::{BatchRead, LayoutMessageCache, LayoutReader, MessageLocator};
+use crate::{LayoutMessageCache, LayoutReader, MessageLocator, PollRead};
 
 fn layout_splits(
     layouts: &[&mut dyn LayoutReader],
@@ -31,18 +31,17 @@ pub fn read_layout_data(
     buf: &Bytes,
     selector: &RowMask,
 ) -> Option<ArrayData> {
-    while let Some(rr) = layout.read_selection(selector).unwrap() {
-        match rr {
-            BatchRead::ReadMore(m) => {
+    loop {
+        match layout.poll_read(selector).unwrap() {
+            PollRead::ReadMore(m) => {
                 let mut write_cache_guard = cache.write().unwrap();
                 for MessageLocator(id, range) in m {
                     write_cache_guard.set(id, buf.slice(range.to_range()));
                 }
             }
-            BatchRead::Batch(a) => return Some(a),
+            PollRead::Ready(maybe_array) => return maybe_array,
         }
     }
-    None
 }
 
 pub fn read_filters(
@@ -51,23 +50,22 @@ pub fn read_filters(
     buf: &Bytes,
     selector: &RowMask,
 ) -> Option<RowMask> {
-    while let Some(rr) = layout.read_selection(selector).unwrap() {
-        match rr {
-            BatchRead::ReadMore(m) => {
+    loop {
+        match layout.poll_read(selector).unwrap() {
+            PollRead::ReadMore(m) => {
                 let mut write_cache_guard = cache.write().unwrap();
                 for MessageLocator(id, range) in m {
                     write_cache_guard.set(id, buf.slice(range.to_range()));
                 }
             }
-            BatchRead::Batch(a) => {
+            PollRead::Ready(Some(a)) => {
                 return Some(
                     RowMask::from_mask_array(&a, selector.begin(), selector.end()).unwrap(),
                 );
             }
+            PollRead::Ready(None) => return None,
         }
     }
-
-    None
 }
 
 pub fn filter_read_layout(

--- a/vortex-file/src/read/metadata.rs
+++ b/vortex-file/src/read/metadata.rs
@@ -10,8 +10,9 @@ use vortex_error::{vortex_bail, vortex_panic, VortexExpect as _, VortexResult};
 use vortex_io::{Dispatch as _, IoDispatcher, VortexReadAt};
 
 use super::stream::{read_ranges, StreamMessages};
-use super::{LayoutMessageCache, LayoutReader, MessageLocator, MetadataRead};
+use super::{LayoutMessageCache, LayoutReader, MessageLocator};
 use crate::read::stream::Message;
+use crate::PollRead;
 
 pub struct MetadataFetcher<R: VortexReadAt> {
     input: R,
@@ -71,15 +72,15 @@ impl<R: VortexReadAt + Unpin> Future for MetadataFetcher<R> {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         loop {
             match &mut self.state {
-                State::Initial => match self.root_layout.read_metadata()? {
-                    MetadataRead::ReadMore(messages) => {
+                State::Initial => match self.root_layout.poll_metadata()? {
+                    PollRead::ReadMore(messages) => {
                         let read_future = self.read_ranges(messages);
                         self.state = State::Reading(read_future);
                     }
-                    MetadataRead::Batches(array_data) => {
+                    PollRead::Ready(Some(array_data)) => {
                         return Poll::Ready(Ok(Some(array_data)));
                     }
-                    MetadataRead::None => {
+                    PollRead::Ready(None) => {
                         return Poll::Ready(Ok(None));
                     }
                 },

--- a/vortex-file/src/read/mod.rs
+++ b/vortex-file/src/read/mod.rs
@@ -59,28 +59,19 @@ pub type MessageId = Vec<LayoutPartId>;
 pub struct MessageLocator(pub MessageId, pub ByteRange);
 
 #[derive(Debug)]
-pub enum BatchRead {
+pub enum PollRead<T> {
     ReadMore(Vec<MessageLocator>),
-    Batch(ArrayData),
-}
-
-#[derive(Debug)]
-pub enum MetadataRead {
-    /// Layout has no metadata
-    None,
-    /// Additional IO is required
-    ReadMore(Vec<MessageLocator>),
-    Batches(Vec<Option<ArrayData>>),
+    Ready(T),
 }
 
 /// A reader for a layout, a serialized sequence of Vortex arrays.
 ///
-/// Some layouts are _horizontally divisble_: they can read a sub-sequence of rows independently of
-/// other sub-sequences. A layout advertises its sub-divisions in its [add_splits][Self::add_splits]
-/// method. Any layout which is or contains a chunked layout is horizontally divisble.
+/// Some layouts are _horizontally divisible_: they can read a sub-sequence of rows independently of
+/// other sub-sequences. A layout advertises its subdivisions in its [add_splits][Self::add_splits]
+/// method. Any layout which is or contains a chunked layout is horizontally divisible.
 ///
-/// The [read_selection][Self::read_selection] method accepts and applies a [RowMask], reading only
-/// the sub-divisions which contain the selected (i.e. masked) rows.
+/// The [poll_read][Self::poll_read] method accepts and applies a [RowMask], reading only
+/// the subdivisions which contain the selected (i.e. masked) rows.
 pub trait LayoutReader: Debug + Send {
     /// Register all horizontal row boundaries of this layout.
     ///
@@ -96,8 +87,12 @@ pub trait LayoutReader: Debug + Send {
     /// creating the invoked instance of this trait and then call back into this function.
     ///
     /// The layout is finished producing data for selection when it returns None
-    fn read_selection(&self, selector: &RowMask) -> VortexResult<Option<BatchRead>>;
+    fn poll_read(&self, selector: &RowMask) -> VortexResult<PollRead<Option<ArrayData>>>;
 
     /// Reads the metadata of the layout, if it exists.
-    fn read_metadata(&self) -> VortexResult<MetadataRead>;
+    ///
+    /// Layouts can return a [metadata table][ArrayData], which is simply a `StructArray` that
+    /// contains information potentially useful for scan pruning. The interpretation of metadata is
+    /// specific to each `LayoutReader` variant.
+    fn poll_metadata(&self) -> VortexResult<PollRead<Option<Vec<Option<ArrayData>>>>>;
 }

--- a/vortex-file/src/read/splits.rs
+++ b/vortex-file/src/read/splits.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use vortex_array::stats::ArrayStatistics;
 use vortex_error::{vortex_bail, VortexExpect, VortexResult};
 
-use crate::{BatchRead, LayoutReader, MessageLocator, RowMask};
+use crate::{LayoutReader, MessageLocator, PollRead, RowMask};
 
 pub enum SplitMask {
     ReadMore(Vec<MessageLocator>),
@@ -47,29 +47,27 @@ impl FilteringRowSplitIterator {
 
     /// Read given mask out of the reader
     fn read_mask(&mut self, mask: RowMask) -> VortexResult<Option<SplitMask>> {
-        if let Some(rs) = self.reader.read_selection(&mask)? {
-            return match rs {
-                BatchRead::ReadMore(rm) => {
-                    // If the reader needs more data we put the mask back into queue for to come back to it later
-                    self.in_progress_masks.push_back(mask);
-                    Ok(Some(SplitMask::ReadMore(rm)))
+        match self.reader.poll_read(&mask)? {
+            PollRead::ReadMore(rm) => {
+                // If the reader needs more data we put the mask back into queue for to come back to it later
+                self.in_progress_masks.push_back(mask);
+                Ok(Some(SplitMask::ReadMore(rm)))
+            }
+            PollRead::Ready(Some(batch)) => {
+                // If the mask is all FALSE we can safely discard it
+                if batch
+                    .statistics()
+                    .compute_true_count()
+                    .vortex_expect("must be a bool array if it's a result of a filter")
+                    == 0
+                {
+                    return Ok(None);
                 }
-                BatchRead::Batch(batch) => {
-                    // If the mask is all FALSE we can safely discard it
-                    if batch
-                        .statistics()
-                        .compute_true_count()
-                        .vortex_expect("must be a bool array if it's a result of a filter")
-                        == 0
-                    {
-                        return Ok(None);
-                    }
-                    // Combine requested mask with the result of filter read
-                    Ok(Some(SplitMask::Mask(mask.and_bitmask(batch)?)))
-                }
-            };
+                // Combine requested mask with the result of filter read
+                Ok(Some(SplitMask::Mask(mask.and_bitmask(batch)?)))
+            }
+            PollRead::Ready(None) => Ok(None),
         }
-        Ok(None)
     }
 
     /// Return next not all false mask or request to read more data.

--- a/vortex-file/src/read/stream.rs
+++ b/vortex-file/src/read/stream.rs
@@ -19,7 +19,7 @@ use vortex_io::{Dispatch, IoDispatcher, VortexReadAt};
 use crate::read::cache::LayoutMessageCache;
 use crate::read::mask::RowMask;
 use crate::read::splits::{FilteringRowSplitIterator, FixedSplitIterator, MaskIterator, SplitMask};
-use crate::read::{BatchRead, LayoutReader, MessageId, MessageLocator};
+use crate::read::{LayoutReader, MessageId, MessageLocator, PollRead};
 use crate::LazyDType;
 
 /// An asynchronous Vortex file that returns a [`Stream`] of [`ArrayData`]s.
@@ -195,8 +195,8 @@ impl<R: VortexReadAt + Unpin> VortexFileArrayStream<R> {
                 }
             }
             StreamingState::Read(selector, filter_reader) => {
-                match self.layout_reader.read_selection(&selector)? {
-                    Some(BatchRead::ReadMore(message_ranges)) => {
+                match self.layout_reader.poll_read(&selector)? {
+                    PollRead::ReadMore(message_ranges) => {
                         let read_future = self.read_ranges(message_ranges);
                         goto(StreamingState::Reading(ReadingFor::Read(
                             read_future,
@@ -204,10 +204,10 @@ impl<R: VortexReadAt + Unpin> VortexFileArrayStream<R> {
                             filter_reader,
                         )))
                     }
-                    Some(BatchRead::Batch(array)) => {
+                    PollRead::Ready(Some(array)) => {
                         produce(StreamingState::NextSplit(filter_reader), array)
                     }
-                    None => goto(StreamingState::NextSplit(filter_reader)),
+                    PollRead::Ready(None) => goto(StreamingState::NextSplit(filter_reader)),
                 }
             }
             StreamingState::Reading(reading_state) => match reading_state.poll_unpin(cx)? {


### PR DESCRIPTION
I'm trying to sort out the reader, there's a funky mix right now of poll-y logic and internal state manipulation. 

* Rename some types and methods to be more in-line with the `poll` types that are more typical in Rusty interfaces
* IN PROGRESS: extract the mutable state out of the polling LayoutReaders to instead have it injected as arguments to poll methods


The proximal inspiration is the Future, Stream, etc. traits but also some inspiration from GlareDB: 

* [ExecutableOperator](https://github.com/GlareDB/glaredb/blob/main/crates/rayexec_execution/src/execution/operators/mod.rs#L268)
* [ExecutionPipeline](https://github.com/GlareDB/glaredb/blob/main/crates/rayexec_execution/src/execution/executable/pipeline.rs#L327)