### PR TITLE
Make BinaryBooleanFn consistent with CompareFn

### DIFF
--- a/vortex-array/src/array/bool/compute/mod.rs
+++ b/vortex-array/src/array/bool/compute/mod.rs
@@ -11,11 +11,7 @@ mod slice;
 mod take;
 
 impl ComputeVTable for BoolEncoding {
-    fn binary_boolean_fn(
-        &self,
-        _lhs: &ArrayData,
-        _rhs: &ArrayData,
-    ) -> Option<&dyn BinaryBooleanFn<ArrayData>> {
+    fn binary_boolean_fn(&self) -> Option<&dyn BinaryBooleanFn<ArrayData>> {
         // We only implement this when other is a constant value, otherwise we fall back to the
         // default implementation that canonicalizes to Arrow.
         // TODO(ngates): implement this for constants.

--- a/vortex-array/src/array/constant/compute/boolean.rs
+++ b/vortex-array/src/array/constant/compute/boolean.rs
@@ -12,7 +12,13 @@ impl BinaryBooleanFn<ConstantArray> for ConstantEncoding {
         lhs: &ConstantArray,
         rhs: &ArrayData,
         op: BinaryOperator,
-    ) -> VortexResult<ArrayData> {
+    ) -> VortexResult<Option<ArrayData>> {
+        // We only implement this for constant <-> constant arrays, otherwise we allow fall back
+        // to the Arrow implementation.
+        if !rhs.is_constant() {
+            return Ok(None);
+        }
+
         let length = lhs.len();
         let nullable = lhs.dtype().is_nullable() || rhs.dtype().is_nullable();
         let lhs = lhs.scalar().as_bool().value();
@@ -35,7 +41,7 @@ impl BinaryBooleanFn<ConstantArray> for ConstantEncoding {
             .map(|b| Scalar::bool(b, nullable.into()))
             .unwrap_or_else(|| Scalar::null(DType::Bool(nullable.into())));
 
-        Ok(ConstantArray::new(scalar, length).into_array())
+        Ok(Some(ConstantArray::new(scalar, length).into_array()))
     }
 }
 

--- a/vortex-array/src/array/constant/compute/mod.rs
+++ b/vortex-array/src/array/constant/compute/mod.rs
@@ -15,14 +15,8 @@ use crate::compute::{
 use crate::{ArrayData, IntoArrayData};
 
 impl ComputeVTable for ConstantEncoding {
-    fn binary_boolean_fn(
-        &self,
-        lhs: &ArrayData,
-        rhs: &ArrayData,
-    ) -> Option<&dyn BinaryBooleanFn<ArrayData>> {
-        // We only need to deal with this if both sides are constant, otherwise other arrays
-        // will have handled the RHS being constant.
-        (lhs.is_constant() && rhs.is_constant()).then_some(self)
+    fn binary_boolean_fn(&self) -> Option<&dyn BinaryBooleanFn<ArrayData>> {
+        Some(self)
     }
 
     fn compare_fn(&self) -> Option<&dyn CompareFn<ArrayData>> {

--- a/vortex-array/src/compute/compare.rs
+++ b/vortex-array/src/compute/compare.rs
@@ -113,8 +113,6 @@ pub fn compare(
     if left.len() != right.len() {
         vortex_bail!("Compare operations only support arrays of the same length");
     }
-
-    // TODO(adamg): This is a placeholder until we figure out type coercion and casting
     if !left.dtype().eq_ignore_nullability(right.dtype()) {
         vortex_bail!("Compare operations only support arrays of the same type");
     }

--- a/vortex-array/src/compute/mod.rs
+++ b/vortex-array/src/compute/mod.rs
@@ -31,11 +31,7 @@ pub trait ComputeVTable {
     /// Implementation of binary boolean logic operations.
     ///
     /// See: [BinaryBooleanFn].
-    fn binary_boolean_fn(
-        &self,
-        _lhs: &ArrayData,
-        _rhs: &ArrayData,
-    ) -> Option<&dyn BinaryBooleanFn<ArrayData>> {
+    fn binary_boolean_fn(&self) -> Option<&dyn BinaryBooleanFn<ArrayData>> {
         None
     }
 


### PR DESCRIPTION
So now the implementation returns `Result<Option<ArrayData>>` and the dispatch logic is almost identical.