### PR TITLE
fix: properly gate things by features & test for that

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,20 @@ jobs:
       - uses: ./.github/actions/setup-rust
       - name: Rust Lint - Format
         run: cargo fmt --all --check
-      - name: Rust Lint - Clippy
+      - name: Rust Lint - Clippy All Features
         run: cargo clippy --all-features --all-targets
+      - name: Rust Lint - Clippy Default Features
+        run: cargo clippy --all-targets
+      - name: Rust Lint - Clippy No Default Features
+        run: |
+          set -ex
+
+          # https://spiraldb.slack.com/archives/C07BV3GKAJ2/p1732736281946729
+          for package in $(cargo check -p  2>&1 | grep '^    ')
+          do
+              echo ---- $package ----
+              cargo clippy --package $package --no-default-features
+          done
       - name: Rust Test
         run: cargo test --workspace --all-features
 

--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -33,8 +33,8 @@ arrow-select = { workspace = true }
 bytes = { workspace = true }
 enum-iterator = { workspace = true }
 enum-map = { workspace = true }
-flatbuffers = { workspace = true, optional = true }
-flexbuffers = { workspace = true, optional = true }
+flatbuffers = { workspace = true }
+flexbuffers = { workspace = true }
 futures-util = { workspace = true }
 hashbrown = { workspace = true }
 humansize = { workspace = true }
@@ -48,25 +48,13 @@ serde = { workspace = true, features = ["derive"] }
 static_assertions = { workspace = true }
 vortex-buffer = { workspace = true }
 vortex-datetime-dtype = { workspace = true }
-vortex-dtype = { workspace = true }
-vortex-error = { workspace = true }
-vortex-flatbuffers = { workspace = true, optional = true }
-vortex-scalar = { workspace = true }
+vortex-dtype = { workspace = true, features = ["flatbuffers", "serde"] }
+vortex-error = { workspace = true, features = ["flatbuffers", "flexbuffers"] }
+vortex-flatbuffers = { workspace = true, features = ["array"] }
+vortex-scalar = { workspace = true, features = ["flatbuffers", "serde"] }
 
 [features]
-default = ["flatbuffers", "serde"]
 arbitrary = ["dep:arbitrary", "vortex-dtype/arbitrary"]
-flatbuffers = [
-    "dep:flatbuffers",
-    "dep:flexbuffers",
-    "dep:vortex-flatbuffers",
-    "vortex-flatbuffers/array",
-    "vortex-dtype/flatbuffers",
-    "vortex-error/flatbuffers",
-    "vortex-error/flexbuffers",
-    "vortex-scalar/flatbuffers",
-]
-serde = ["vortex-dtype/serde", "vortex-scalar/serde"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # Enable the JS feature of getrandom (via rand) to supprt wasm32 target

--- a/vortex-io/src/dispatcher/mod.rs
+++ b/vortex-io/src/dispatcher/mod.rs
@@ -5,6 +5,8 @@ mod tokio;
 use std::future::Future;
 
 use futures::channel::oneshot;
+#[cfg(not(any(feature = "compio", feature = "tokio")))]
+use vortex_error::vortex_panic;
 use vortex_error::VortexResult;
 
 #[cfg(feature = "compio")]
@@ -73,7 +75,7 @@ impl Default for IoDispatcher {
         #[cfg(all(feature = "compio", not(feature = "tokio")))]
         return Self(Inner::Compio(CompioDispatcher::new(1)));
         #[cfg(not(any(feature = "compio", feature = "tokio")))]
-        return Self(Inner {});
+        vortex_panic!("must enable one of compio or tokio to use IoDispatcher");
     }
 }
 


### PR DESCRIPTION
Ideally we would test every combination of features, but at the very least, we should verify that no features, default features, and all features pass clippy.

The two main changes:

1. In vortex-io, we need a syntactically valid expressoin when neither compio nor tokio are available.
2. In vortex-array, we need both flatbuffers and flexbuffers for views to work. I removed the optional dependencies on these libraries. In theory, someone could go through our code base and properly feature flag array views, but that began to feel onerous as I did it.