### PR TITLE
Short-circuit BoolArray null count

### DIFF
--- a/vortex-array/src/array/bool/stats.rs
+++ b/vortex-array/src/array/bool/stats.rs
@@ -43,7 +43,7 @@ impl StatisticsVTable<NullableBools<'_>> for BoolEncoding {
         // Fast-path if we just want the true-count
         if matches!(
             stat,
-            Stat::TrueCount | Stat::Min | Stat::Max | Stat::IsConstant
+            Stat::TrueCount | Stat::Min | Stat::Max | Stat::IsConstant | Stat::NullCount
         ) {
             return Ok(StatsSet::bools_with_true_and_null_count(
                 array.0.bitand(array.1).count_set_bits(),
@@ -85,7 +85,7 @@ impl StatisticsVTable<BooleanBuffer> for BoolEncoding {
         // Fast-path if we just want the true-count
         if matches!(
             stat,
-            Stat::TrueCount | Stat::Min | Stat::Max | Stat::IsConstant
+            Stat::TrueCount | Stat::Min | Stat::Max | Stat::IsConstant | Stat::NullCount
         ) {
             return Ok(StatsSet::bools_with_true_and_null_count(
                 buffer.count_set_bits(),

--- a/vortex-array/src/array/bool/stats.rs
+++ b/vortex-array/src/array/bool/stats.rs
@@ -45,9 +45,10 @@ impl StatisticsVTable<NullableBools<'_>> for BoolEncoding {
             stat,
             Stat::TrueCount | Stat::Min | Stat::Max | Stat::IsConstant | Stat::NullCount
         ) {
+            let _null_count = array.1.count_set_bits();
             return Ok(StatsSet::bools_with_true_and_null_count(
                 array.0.bitand(array.1).count_set_bits(),
-                array.1.count_set_bits(),
+                array.1.len() - array.1.count_set_bits(),
                 array.0.len(),
             ));
         }

--- a/vortex-array/src/stats/statsset.rs
+++ b/vortex-array/src/stats/statsset.rs
@@ -90,9 +90,10 @@ impl StatsSet {
         true_count: usize,
         null_count: usize,
         len: usize,
-    ) -> StatsSet {
+    ) -> Self {
         StatsSet::from_iter([
             (Stat::TrueCount, true_count.into()),
+            (Stat::NullCount, null_count.into()),
             (Stat::Min, (true_count == len).into()),
             (Stat::Max, (true_count > 0).into()),
             (


### PR DESCRIPTION
I believe this is performance the regression from https://github.com/spiraldb/vortex/commit/10a1f2172fd70a77c66b6d81d7bb0c8d912dedae

It checks both true_count and null_count, but the null count was triggering a full stats compute.