### PR TITLE
Add ArrowPrimitiveType

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4828,6 +4828,7 @@ name = "vortex-dtype"
 version = "0.21.0"
 dependencies = [
  "arbitrary",
+ "arrow-array",
  "flatbuffers",
  "half",
  "itertools 0.13.0",

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -2,12 +2,8 @@
 
 use std::sync::Arc;
 
-use arrow_array::types::{
-    Float16Type, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type,
-    UInt32Type, UInt64Type, UInt8Type,
-};
 use arrow_array::{
-    ArrayRef, ArrowPrimitiveType, BooleanArray as ArrowBoolArray, Date32Array, Date64Array,
+    ArrayRef, BooleanArray as ArrowBoolArray, Date32Array, Date64Array,
     NullArray as ArrowNullArray, PrimitiveArray as ArrowPrimitiveArray,
     StructArray as ArrowStructArray, Time32MillisecondArray, Time32SecondArray,
     Time64MicrosecondArray, Time64NanosecondArray, TimestampMicrosecondArray,
@@ -16,7 +12,7 @@ use arrow_array::{
 use arrow_buffer::ScalarBuffer;
 use arrow_schema::{Field, FieldRef, Fields};
 use vortex_datetime_dtype::{is_temporal_ext_type, TemporalMetadata, TimeUnit};
-use vortex_dtype::{DType, NativePType, PType};
+use vortex_dtype::{match_each_native_ptype, DType, NativePType, PType};
 use vortex_error::{vortex_bail, VortexError, VortexResult};
 
 use crate::array::{
@@ -170,28 +166,12 @@ fn bool_to_arrow(bool_array: BoolArray) -> VortexResult<ArrayRef> {
     )))
 }
 
-fn primitive_to_arrow(primitive_array: PrimitiveArray) -> VortexResult<ArrayRef> {
-    fn as_arrow_array_primitive<T: ArrowPrimitiveType>(
-        array: &PrimitiveArray,
-    ) -> VortexResult<Arc<ArrowPrimitiveArray<T>>> {
-        Ok(Arc::new(ArrowPrimitiveArray::new(
-            ScalarBuffer::<T::Native>::new(array.buffer().clone().into_arrow(), 0, array.len()),
+fn primitive_to_arrow(array: PrimitiveArray) -> VortexResult<ArrayRef> {
+    match_each_native_ptype!(array.ptype(), |$P| {
+        Ok(Arc::new(ArrowPrimitiveArray::<<$P as NativePType>::ArrowPrimitiveType>::new(
+            ScalarBuffer::<$P>::new(array.buffer().clone().into_arrow(), 0, array.len()),
             array.logical_validity().to_null_buffer()?,
         )))
-    }
-
-    Ok(match primitive_array.ptype() {
-        PType::U8 => as_arrow_array_primitive::<UInt8Type>(&primitive_array)?,
-        PType::U16 => as_arrow_array_primitive::<UInt16Type>(&primitive_array)?,
-        PType::U32 => as_arrow_array_primitive::<UInt32Type>(&primitive_array)?,
-        PType::U64 => as_arrow_array_primitive::<UInt64Type>(&primitive_array)?,
-        PType::I8 => as_arrow_array_primitive::<Int8Type>(&primitive_array)?,
-        PType::I16 => as_arrow_array_primitive::<Int16Type>(&primitive_array)?,
-        PType::I32 => as_arrow_array_primitive::<Int32Type>(&primitive_array)?,
-        PType::I64 => as_arrow_array_primitive::<Int64Type>(&primitive_array)?,
-        PType::F16 => as_arrow_array_primitive::<Float16Type>(&primitive_array)?,
-        PType::F32 => as_arrow_array_primitive::<Float32Type>(&primitive_array)?,
-        PType::F64 => as_arrow_array_primitive::<Float64Type>(&primitive_array)?,
     })
 }
 

--- a/vortex-dtype/Cargo.toml
+++ b/vortex-dtype/Cargo.toml
@@ -20,6 +20,7 @@ bench = false
 
 [dependencies]
 arbitrary = { workspace = true, optional = true }
+arrow-array = { workspace = true }
 flatbuffers = { workspace = true, optional = true }
 half = { workspace = true, features = ["num-traits"] }
 itertools = { workspace = true }


### PR DESCRIPTION
Tie vortex <-> arrow primitive types together

We initially didn't want this so we could remain separate from Arrow, but we're now using Arrow as an integral part of Vortex