### PR TITLE
Fix BitPacked child validity

### DIFF
--- a/vortex-sampling-compressor/src/compressors/bitpacked.rs
+++ b/vortex-sampling-compressor/src/compressors/bitpacked.rs
@@ -124,7 +124,7 @@ impl EncodingCompressor for BitPackedCompressor {
             .into_array(),
             Some(CompressionTree::new(
                 self,
-                vec![patches.and_then(|p| p.path)],
+                vec![patches.and_then(|p| p.path), None],
             )),
             Some(array.statistics()),
         ))


### PR DESCRIPTION
```
local array: root: fastlanes.bitpacked(0x15)(u16?, len=1024) nbytes=1.81 kB (100.00%)
  metadata: BitPackedMetadata { validity: Array, bit_width: 14, offset: 0, has_patches: false }
  buffer: 1.79 kB
  validity: vortex.runendbool(0x1c)(bool, len=1024) nbytes=16 B (0.88%)
    metadata: RunEndBoolMetadata { start: false, validity: NonNullable, ends_ptype: U64, num_runs: 2, offset: 0 }
    ends: vortex.primitive(0x03)(u64, len=2) nbytes=16 B (0.88%)
      metadata: PrimitiveMetadata { validity: NonNullable }
      buffer: 16 B

problematic child_tree:   root: vortex.runendbool
    root.0: uncompressed
    root.1: uncompressed
```