### PR TITLE
fix: SparseArray scalar_at was broken due to strict PValue PartialOrd

### DIFF
--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -247,9 +247,10 @@ mod test {
     use vortex_dtype::Nullability::Nullable;
     use vortex_dtype::{DType, PType};
     use vortex_error::VortexError;
-    use vortex_scalar::Scalar;
+    use vortex_scalar::{PrimitiveScalar, Scalar};
 
     use crate::array::sparse::SparseArray;
+    use crate::array::ConstantArray;
     use crate::compute::{scalar_at, slice, try_cast};
     use crate::validity::ArrayValidity;
     use crate::{ArrayData, IntoArrayData, IntoArrayVariant};
@@ -293,6 +294,26 @@ mod test {
         assert_eq!(i, 10);
         assert_eq!(start, 0);
         assert_eq!(stop, 10);
+    }
+
+    #[test]
+    pub fn test_scalar_at_again() {
+        let arr = SparseArray::try_new(
+            ConstantArray::new(10u32, 1).into_array(),
+            ConstantArray::new(Scalar::primitive(1234u32, Nullable), 1).into_array(),
+            100,
+            Scalar::null(DType::Primitive(PType::U32, Nullable)),
+        )
+        .unwrap();
+
+        assert_eq!(
+            PrimitiveScalar::try_from(&scalar_at(&arr, 10).unwrap())
+                .unwrap()
+                .typed_value::<u32>(),
+            Some(1234)
+        );
+        assert!(scalar_at(&arr, 0).unwrap().is_null());
+        assert!(scalar_at(&arr, 99).unwrap().is_null());
     }
 
     #[test]

--- a/vortex-sampling-compressor/src/compressors/alp.rs
+++ b/vortex-sampling-compressor/src/compressors/alp.rs
@@ -2,7 +2,6 @@ use vortex_alp::{alp_encode_components, match_each_alp_float_ptype, ALPArray, AL
 use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::array::PrimitiveArray;
 use vortex_array::encoding::{Encoding, EncodingRef};
-use vortex_array::stats::ArrayStatistics;
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::PType;
@@ -78,7 +77,7 @@ impl EncodingCompressor for ALPCompressor {
                     compressed_patches.and_then(|p| p.path),
                 ],
             )),
-            Some(array.statistics()),
+            array,
         ))
     }
 

--- a/vortex-sampling-compressor/src/compressors/alp_rd.rs
+++ b/vortex-sampling-compressor/src/compressors/alp_rd.rs
@@ -5,7 +5,6 @@ use vortex_alp::{match_each_alp_float_ptype, ALPRDEncoding, RDEncoder as ALPRDEn
 use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::array::PrimitiveArray;
 use vortex_array::encoding::{Encoding, EncodingRef};
-use vortex_array::stats::ArrayStatistics;
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::PType;
@@ -68,7 +67,7 @@ impl EncodingCompressor for ALPRDCompressor {
         Ok(CompressedArray::compressed(
             encoded,
             Some(CompressionTree::new_with_metadata(self, vec![], encoder)),
-            Some(array.statistics()),
+            array,
         ))
     }
 

--- a/vortex-sampling-compressor/src/compressors/bitpacked.rs
+++ b/vortex-sampling-compressor/src/compressors/bitpacked.rs
@@ -127,7 +127,7 @@ impl EncodingCompressor for BitPackedCompressor {
                 self,
                 vec![patches.and_then(|p| p.path)],
             )),
-            Some(array.statistics()),
+            array,
         ))
     }
 

--- a/vortex-sampling-compressor/src/compressors/chunked.rs
+++ b/vortex-sampling-compressor/src/compressors/chunked.rs
@@ -5,7 +5,6 @@ use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::array::{ChunkedArray, ChunkedEncoding};
 use vortex_array::compress::compute_precompression_stats;
 use vortex_array::encoding::{Encoding, EncodingRef};
-use vortex_array::stats::ArrayStatistics;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData};
 use vortex_error::{vortex_bail, VortexExpect, VortexResult};
 
@@ -130,7 +129,7 @@ impl ChunkedCompressor {
                 compressed_trees,
                 Arc::new(ChunkedCompressorMetadata(ratio)),
             )),
-            Some(array.statistics()),
+            array,
         ))
     }
 }

--- a/vortex-sampling-compressor/src/compressors/constant.rs
+++ b/vortex-sampling-compressor/src/compressors/constant.rs
@@ -42,7 +42,7 @@ impl EncodingCompressor for ConstantCompressor {
             )
             .into_array(),
             Some(CompressionTree::flat(self)),
-            Some(array.statistics()),
+            array,
         ))
     }
 

--- a/vortex-sampling-compressor/src/compressors/date_time_parts.rs
+++ b/vortex-sampling-compressor/src/compressors/date_time_parts.rs
@@ -1,7 +1,6 @@
 use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::array::TemporalArray;
 use vortex_array::encoding::{Encoding, EncodingRef};
-use vortex_array::stats::ArrayStatistics;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData};
 use vortex_datetime_dtype::TemporalMetadata;
 use vortex_datetime_parts::{
@@ -73,7 +72,7 @@ impl EncodingCompressor for DateTimePartsCompressor {
                 self,
                 vec![days.path, seconds.path, subsecond.path],
             )),
-            Some(array.statistics()),
+            array,
         ))
     }
 

--- a/vortex-sampling-compressor/src/compressors/delta.rs
+++ b/vortex-sampling-compressor/src/compressors/delta.rs
@@ -1,7 +1,6 @@
 use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::array::PrimitiveArray;
 use vortex_array::encoding::{Encoding, EncodingRef};
-use vortex_array::stats::ArrayStatistics;
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayData, IntoArrayData};
 use vortex_error::VortexResult;
@@ -58,7 +57,7 @@ impl EncodingCompressor for DeltaCompressor {
             DeltaArray::try_from_delta_compress_parts(bases.array, deltas.array, validity)?
                 .into_array(),
             Some(CompressionTree::new(self, vec![bases.path, deltas.path])),
-            Some(array.statistics()),
+            array,
         ))
     }
 

--- a/vortex-sampling-compressor/src/compressors/dict.rs
+++ b/vortex-sampling-compressor/src/compressors/dict.rs
@@ -80,7 +80,7 @@ impl EncodingCompressor for DictCompressor {
         Ok(CompressedArray::compressed(
             DictArray::try_new(codes.array, values.array)?.into_array(),
             Some(CompressionTree::new(self, vec![codes.path, values.path])),
-            Some(array.statistics()),
+            array,
         ))
     }
 

--- a/vortex-sampling-compressor/src/compressors/for.rs
+++ b/vortex-sampling-compressor/src/compressors/for.rs
@@ -70,7 +70,7 @@ impl EncodingCompressor for FoRCompressor {
             )
             .map(|a| a.into_array())?,
             Some(CompressionTree::new(self, vec![compressed_child.path])),
-            Some(array.statistics()),
+            array,
         ))
     }
 

--- a/vortex-sampling-compressor/src/compressors/fsst.rs
+++ b/vortex-sampling-compressor/src/compressors/fsst.rs
@@ -6,7 +6,6 @@ use fsst::Compressor;
 use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::array::{VarBinEncoding, VarBinViewEncoding};
 use vortex_array::encoding::{Encoding, EncodingRef};
-use vortex_array::stats::ArrayStatistics;
 use vortex_array::{ArrayDType, IntoArrayData};
 use vortex_dtype::DType;
 use vortex_error::{vortex_bail, VortexResult};
@@ -128,7 +127,7 @@ impl EncodingCompressor for FSSTCompressor {
                 vec![None, None, compressed_codes.path, uncompressed_lengths.path],
                 compressor,
             )),
-            Some(array.statistics()),
+            array,
         ))
     }
 

--- a/vortex-sampling-compressor/src/compressors/list.rs
+++ b/vortex-sampling-compressor/src/compressors/list.rs
@@ -1,7 +1,6 @@
 use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::array::{ListArray, ListEncoding};
 use vortex_array::encoding::{Encoding, EncodingRef};
-use vortex_array::stats::ArrayStatistics;
 use vortex_array::{ArrayData, IntoArrayData};
 use vortex_error::VortexResult;
 
@@ -51,7 +50,7 @@ impl EncodingCompressor for ListCompressor {
                 self,
                 vec![compressed_elements.path, compressed_offsets.path, None],
             )),
-            Some(array.statistics()),
+            array,
         ))
     }
 

--- a/vortex-sampling-compressor/src/compressors/roaring_bool.rs
+++ b/vortex-sampling-compressor/src/compressors/roaring_bool.rs
@@ -1,7 +1,6 @@
 use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::array::BoolEncoding;
 use vortex_array::encoding::{Encoding, EncodingRef};
-use vortex_array::stats::ArrayStatistics;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::DType;
 use vortex_dtype::Nullability::NonNullable;
@@ -50,7 +49,7 @@ impl EncodingCompressor for RoaringBoolCompressor {
         Ok(CompressedArray::compressed(
             roaring_bool_encode(array.clone().into_bool()?)?.into_array(),
             Some(CompressionTree::flat(self)),
-            Some(array.statistics()),
+            array,
         ))
     }
 

--- a/vortex-sampling-compressor/src/compressors/roaring_int.rs
+++ b/vortex-sampling-compressor/src/compressors/roaring_int.rs
@@ -51,7 +51,7 @@ impl EncodingCompressor for RoaringIntCompressor {
         Ok(CompressedArray::compressed(
             roaring_int_encode(array.clone().into_primitive()?)?.into_array(),
             Some(CompressionTree::flat(self)),
-            Some(array.statistics()),
+            array,
         ))
     }
 

--- a/vortex-sampling-compressor/src/compressors/runend.rs
+++ b/vortex-sampling-compressor/src/compressors/runend.rs
@@ -73,7 +73,7 @@ impl EncodingCompressor for RunEndCompressor {
                 self,
                 vec![compressed_ends.path, compressed_values.path],
             )),
-            Some(array.statistics()),
+            array,
         ))
     }
 

--- a/vortex-sampling-compressor/src/compressors/runend.rs
+++ b/vortex-sampling-compressor/src/compressors/runend.rs
@@ -51,12 +51,12 @@ impl EncodingCompressor for RunEndCompressor {
         ctx: SamplingCompressor<'a>,
     ) -> VortexResult<CompressedArray<'a>> {
         let primitive_array = array.clone().into_primitive()?;
-
         let (ends, values) = runend_encode(&primitive_array);
-        let compressed_ends = ctx.auxiliary("ends").compress(
-            &downscale_integer_array(ends.into_array())?,
-            like.as_ref().and_then(|l| l.child(0)),
-        )?;
+        let ends = downscale_integer_array(ends.into_array())?.into_primitive()?;
+
+        let compressed_ends = ctx
+            .auxiliary("ends")
+            .compress(&ends.into_array(), like.as_ref().and_then(|l| l.child(0)))?;
         let compressed_values = ctx
             .named("values")
             .excluding(self)

--- a/vortex-sampling-compressor/src/compressors/runend_bool.rs
+++ b/vortex-sampling-compressor/src/compressors/runend_bool.rs
@@ -1,7 +1,6 @@
 use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::array::{BoolEncoding, PrimitiveArray};
 use vortex_array::encoding::{Encoding, EncodingRef};
-use vortex_array::stats::ArrayStatistics as _;
 use vortex_array::{ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_error::VortexResult;
 use vortex_runend_bool::compress::runend_bool_encode_slice;
@@ -50,7 +49,7 @@ impl EncodingCompressor for RunEndBoolCompressor {
             RunEndBoolArray::try_new(compressed_ends.array, start, bool_array.validity())?
                 .into_array(),
             Some(CompressionTree::new(self, vec![compressed_ends.path])),
-            Some(array.statistics()),
+            array,
         ))
     }
 

--- a/vortex-sampling-compressor/src/compressors/sparse.rs
+++ b/vortex-sampling-compressor/src/compressors/sparse.rs
@@ -1,7 +1,6 @@
 use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::array::{SparseArray, SparseEncoding};
 use vortex_array::encoding::{Encoding, EncodingRef};
-use vortex_array::stats::ArrayStatistics;
 use vortex_array::{ArrayData, ArrayLen, IntoArrayData};
 use vortex_error::VortexResult;
 
@@ -49,7 +48,7 @@ impl EncodingCompressor for SparseCompressor {
             )?
             .into_array(),
             Some(CompressionTree::new(self, vec![indices.path, values.path])),
-            Some(array.statistics()),
+            array,
         ))
     }
 

--- a/vortex-sampling-compressor/src/compressors/struct_.rs
+++ b/vortex-sampling-compressor/src/compressors/struct_.rs
@@ -3,7 +3,6 @@ use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::array::{StructArray, StructEncoding};
 use vortex_array::compress::compute_precompression_stats;
 use vortex_array::encoding::{Encoding, EncodingRef};
-use vortex_array::stats::ArrayStatistics;
 use vortex_array::variants::StructArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, ArrayLen, IntoArrayData};
 use vortex_dtype::DType;
@@ -66,7 +65,7 @@ impl EncodingCompressor for StructCompressor {
             )?
             .into_array(),
             Some(CompressionTree::new(self, trees)),
-            Some(array.statistics()),
+            array,
         ))
     }
 

--- a/vortex-sampling-compressor/src/compressors/varbin.rs
+++ b/vortex-sampling-compressor/src/compressors/varbin.rs
@@ -1,7 +1,6 @@
 use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::array::{VarBinArray, VarBinEncoding};
 use vortex_array::encoding::{Encoding, EncodingRef};
-use vortex_array::stats::ArrayStatistics;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData};
 use vortex_error::VortexResult;
 
@@ -45,7 +44,7 @@ impl EncodingCompressor for VarBinCompressor {
             )?
             .into_array(),
             Some(CompressionTree::new(self, vec![offsets.path, None, None])),
-            Some(array.statistics()),
+            array,
         ))
     }
 

--- a/vortex-sampling-compressor/src/compressors/zigzag.rs
+++ b/vortex-sampling-compressor/src/compressors/zigzag.rs
@@ -52,7 +52,7 @@ impl EncodingCompressor for ZigZagCompressor {
         Ok(CompressedArray::compressed(
             ZigZagArray::try_new(compressed.array)?.into_array(),
             Some(CompressionTree::new(self, vec![compressed.path])),
-            Some(array.statistics()),
+            array,
         ))
     }
 

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use std::mem::discriminant;
 use std::sync::Arc;
 
 pub use scalar_type::ScalarType;
@@ -208,7 +209,9 @@ impl PartialEq for Scalar {
 
 impl PartialOrd for Scalar {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        if self.dtype().eq_ignore_nullability(other.dtype()) {
+        // We check for DType equality, ignoring nullability, and allowing us to compare all
+        // primitive types to all other primitive types.
+        if discriminant(self.dtype()) == discriminant(other.dtype()) {
             self.value.0.partial_cmp(&other.value.0)
         } else {
             None


### PR DESCRIPTION
We made a change to use `search_sorted_usize`, which delegates to `search_sorted` with a u64 scalar. But this scalar did not support partial_cmp with e.g. a u8 array, and instead of failing we just returned `Ordering::Less` 🤦 