### PR TITLE
ci: build vortex crate with wasm32-unknown-unknown

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,5 +1,11 @@
 name: "Setup Rust"
 description: "Toolchain setup and Initial compilation"
+
+inputs:
+  targets:
+    description: "optional targets override (e.g. wasm32-unknown-unknown)"
+    required: false
+
 runs:
   using: "composite"
   steps:
@@ -14,6 +20,7 @@ runs:
       if: steps.rustup-cache.outputs.cache-hit != 'true'
       with:
         toolchain: "${{ steps.rust-version.outputs.version }}"
+        targets: "${{inputs.targets || ''}}"
         components: clippy, rustfmt, miri
 
     - name: Rust Dependency Cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,20 @@ jobs:
       - name: Rust Build (Default features)
         run: cargo build --all-targets
 
+  build-wasm32:
+    name: "Build (wasm32-unknown-unknown)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cleanup
+      - uses: rui314/setup-mold@v1
+      - uses: ./.github/actions/setup-rust
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Rust Build vortex
+        run: cargo build -p vortex
+
+
   build-all:
     name: "Build (all-features)"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ensure that `vortex` crate always builds for the `wasm32-unknown-unknown` target with default features.

In the future if we add new functionality that is part of the `default-features` that is not safe for WASM, we'll just need to mark it as `#[cfg(not(target_family = "wasm"))]`