### PR TITLE
chore: add an unsafe take_unchecked to TakeFn for bounds check ellision

### DIFF
--- a/encodings/alp/src/alp/compute/mod.rs
+++ b/encodings/alp/src/alp/compute/mod.rs
@@ -1,6 +1,6 @@
 use vortex_array::compute::{
     filter, scalar_at, slice, take, ComputeVTable, FilterFn, FilterMask, ScalarAtFn, SliceFn,
-    TakeFn, TakeOptions,
+    TakeFn,
 };
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData};
@@ -48,15 +48,10 @@ impl ScalarAtFn<ALPArray> for ALPEncoding {
 }
 
 impl TakeFn<ALPArray> for ALPEncoding {
-    fn take(
-        &self,
-        array: &ALPArray,
-        indices: &ArrayData,
-        options: TakeOptions,
-    ) -> VortexResult<ArrayData> {
+    fn take(&self, array: &ALPArray, indices: &ArrayData) -> VortexResult<ArrayData> {
         // TODO(ngates): wrap up indices in an array that caches decompression?
         Ok(ALPArray::try_new(
-            take(array.encoded(), indices, options)?,
+            take(array.encoded(), indices)?,
             array.exponents(),
             array
                 .patches()

--- a/encodings/alp/src/alp_rd/compute/take.rs
+++ b/encodings/alp/src/alp_rd/compute/take.rs
@@ -1,26 +1,21 @@
-use vortex_array::compute::{take, TakeFn, TakeOptions};
+use vortex_array::compute::{take, TakeFn};
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData};
 use vortex_error::VortexResult;
 
 use crate::{ALPRDArray, ALPRDEncoding};
 
 impl TakeFn<ALPRDArray> for ALPRDEncoding {
-    fn take(
-        &self,
-        array: &ALPRDArray,
-        indices: &ArrayData,
-        options: TakeOptions,
-    ) -> VortexResult<ArrayData> {
+    fn take(&self, array: &ALPRDArray, indices: &ArrayData) -> VortexResult<ArrayData> {
         let left_parts_exceptions = array
             .left_parts_exceptions()
-            .map(|array| take(&array, indices, options))
+            .map(|array| take(&array, indices))
             .transpose()?;
 
         Ok(ALPRDArray::try_new(
             array.dtype().clone(),
-            take(array.left_parts(), indices, options)?,
+            take(array.left_parts(), indices)?,
             array.left_parts_dict(),
-            take(array.right_parts(), indices, options)?,
+            take(array.right_parts(), indices)?,
             array.right_bit_width(),
             left_parts_exceptions,
         )?
@@ -32,7 +27,7 @@ impl TakeFn<ALPRDArray> for ALPRDEncoding {
 mod test {
     use rstest::rstest;
     use vortex_array::array::PrimitiveArray;
-    use vortex_array::compute::{take, TakeOptions};
+    use vortex_array::compute::take;
     use vortex_array::IntoArrayVariant;
 
     use crate::{ALPRDFloat, RDEncoder};
@@ -46,14 +41,10 @@ mod test {
 
         assert!(encoded.left_parts_exceptions().is_some());
 
-        let taken = take(
-            encoded.as_ref(),
-            PrimitiveArray::from(vec![0, 2]).as_ref(),
-            TakeOptions::default(),
-        )
-        .unwrap()
-        .into_primitive()
-        .unwrap();
+        let taken = take(encoded.as_ref(), PrimitiveArray::from(vec![0, 2]).as_ref())
+            .unwrap()
+            .into_primitive()
+            .unwrap();
 
         assert_eq!(taken.maybe_null_slice::<T>(), &[a, outlier]);
     }

--- a/encodings/bytebool/src/compute.rs
+++ b/encodings/bytebool/src/compute.rs
@@ -1,7 +1,5 @@
 use num_traits::AsPrimitive;
-use vortex_array::compute::{
-    ComputeVTable, FillForwardFn, ScalarAtFn, SliceFn, TakeFn, TakeOptions,
-};
+use vortex_array::compute::{ComputeVTable, FillForwardFn, ScalarAtFn, SliceFn, TakeFn};
 use vortex_array::validity::{ArrayValidity, Validity};
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant, ToArrayData};
@@ -49,12 +47,7 @@ impl SliceFn<ByteBoolArray> for ByteBoolEncoding {
 }
 
 impl TakeFn<ByteBoolArray> for ByteBoolEncoding {
-    fn take(
-        &self,
-        array: &ByteBoolArray,
-        indices: &ArrayData,
-        _options: TakeOptions,
-    ) -> VortexResult<ArrayData> {
+    fn take(&self, array: &ByteBoolArray, indices: &ArrayData) -> VortexResult<ArrayData> {
         let validity = array.validity();
         let indices = indices.clone().into_primitive()?;
         let bools = array.maybe_null_slice();

--- a/encodings/datetime-parts/src/compute/take.rs
+++ b/encodings/datetime-parts/src/compute/take.rs
@@ -1,21 +1,16 @@
-use vortex_array::compute::{take, TakeFn, TakeOptions};
+use vortex_array::compute::{take, TakeFn};
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData};
 use vortex_error::VortexResult;
 
 use crate::{DateTimePartsArray, DateTimePartsEncoding};
 
 impl TakeFn<DateTimePartsArray> for DateTimePartsEncoding {
-    fn take(
-        &self,
-        array: &DateTimePartsArray,
-        indices: &ArrayData,
-        options: TakeOptions,
-    ) -> VortexResult<ArrayData> {
+    fn take(&self, array: &DateTimePartsArray, indices: &ArrayData) -> VortexResult<ArrayData> {
         Ok(DateTimePartsArray::try_new(
             array.dtype().clone(),
-            take(array.days(), indices, options)?,
-            take(array.seconds(), indices, options)?,
-            take(array.subsecond(), indices, options)?,
+            take(array.days(), indices)?,
+            take(array.seconds(), indices)?,
+            take(array.subsecond(), indices)?,
         )?
         .into_array())
     }

--- a/encodings/dict/src/array.rs
+++ b/encodings/dict/src/array.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Display};
 use arrow_buffer::BooleanBuffer;
 use serde::{Deserialize, Serialize};
 use vortex_array::array::BoolArray;
-use vortex_array::compute::{scalar_at, take, TakeOptions};
+use vortex_array::compute::{scalar_at, take};
 use vortex_array::encoding::ids;
 use vortex_array::stats::StatsSet;
 use vortex_array::validity::{ArrayValidity, LogicalValidity, ValidityVTable};
@@ -74,10 +74,10 @@ impl IntoCanonical for DictArray {
             // copies of the view pointers.
             DType::Utf8(_) | DType::Binary(_) => {
                 let canonical_values: ArrayData = self.values().into_canonical()?.into();
-                take(canonical_values, self.codes(), TakeOptions::default())?.into_canonical()
+                take(canonical_values, self.codes())?.into_canonical()
             }
             // Non-string case: take and then canonicalize
-            _ => take(self.values(), self.codes(), TakeOptions::default())?.into_canonical(),
+            _ => take(self.values(), self.codes())?.into_canonical(),
         }
     }
 }

--- a/encodings/dict/src/compute/compare.rs
+++ b/encodings/dict/src/compute/compare.rs
@@ -1,5 +1,5 @@
 use vortex_array::array::ConstantArray;
-use vortex_array::compute::{compare, take, CompareFn, Operator, TakeOptions};
+use vortex_array::compute::{compare, take, CompareFn, Operator};
 use vortex_array::ArrayData;
 use vortex_error::VortexResult;
 
@@ -20,7 +20,7 @@ impl CompareFn<DictArray> for DictEncoding {
                 ConstantArray::new(const_scalar, lhs.values().len()),
                 operator,
             )?;
-            return take(compare_result, lhs.codes(), TakeOptions::default()).map(Some);
+            return take(compare_result, lhs.codes()).map(Some);
         }
 
         // It's a little more complex, but we could perform a comparison against the dictionary

--- a/encodings/dict/src/compute/mod.rs
+++ b/encodings/dict/src/compute/mod.rs
@@ -3,7 +3,7 @@ mod like;
 
 use vortex_array::compute::{
     filter, scalar_at, slice, take, CompareFn, ComputeVTable, FilterFn, FilterMask, LikeFn,
-    ScalarAtFn, SliceFn, TakeFn, TakeOptions,
+    ScalarAtFn, SliceFn, TakeFn,
 };
 use vortex_array::{ArrayData, IntoArrayData};
 use vortex_error::VortexResult;
@@ -45,16 +45,11 @@ impl ScalarAtFn<DictArray> for DictEncoding {
 }
 
 impl TakeFn<DictArray> for DictEncoding {
-    fn take(
-        &self,
-        array: &DictArray,
-        indices: &ArrayData,
-        options: TakeOptions,
-    ) -> VortexResult<ArrayData> {
+    fn take(&self, array: &DictArray, indices: &ArrayData) -> VortexResult<ArrayData> {
         // Dict
         //   codes: 0 0 1
         //   dict: a b c d e f g h
-        let codes = take(array.codes(), indices, options)?;
+        let codes = take(array.codes(), indices)?;
         DictArray::try_new(codes, array.values()).map(|a| a.into_array())
     }
 }

--- a/encodings/fastlanes/benches/bitpacking_take.rs
+++ b/encodings/fastlanes/benches/bitpacking_take.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use rand::distributions::Uniform;
 use rand::{thread_rng, Rng};
 use vortex_array::array::PrimitiveArray;
-use vortex_array::compute::{take, TakeOptions};
+use vortex_array::compute::take;
 use vortex_fastlanes::{find_best_bit_width, BitPackedArray};
 
 fn values(len: usize, bits: usize) -> Vec<u32> {
@@ -27,30 +27,12 @@ fn bench_take(c: &mut Criterion) {
 
     let stratified_indices: PrimitiveArray = (0..10).map(|i| i * 10_000).collect::<Vec<_>>().into();
     c.bench_function("take_10_stratified", |b| {
-        b.iter(|| {
-            black_box(
-                take(
-                    packed.as_ref(),
-                    stratified_indices.as_ref(),
-                    TakeOptions::default(),
-                )
-                .unwrap(),
-            )
-        });
+        b.iter(|| black_box(take(packed.as_ref(), stratified_indices.as_ref()).unwrap()));
     });
 
     let contiguous_indices: PrimitiveArray = (0..10).collect::<Vec<_>>().into();
     c.bench_function("take_10_contiguous", |b| {
-        b.iter(|| {
-            black_box(
-                take(
-                    packed.as_ref(),
-                    contiguous_indices.as_ref(),
-                    TakeOptions::default(),
-                )
-                .unwrap(),
-            )
-        });
+        b.iter(|| black_box(take(packed.as_ref(), contiguous_indices.as_ref()).unwrap()));
     });
 
     let rng = thread_rng();
@@ -62,30 +44,12 @@ fn bench_take(c: &mut Criterion) {
         .collect_vec()
         .into();
     c.bench_function("take_10K_random", |b| {
-        b.iter(|| {
-            black_box(
-                take(
-                    packed.as_ref(),
-                    random_indices.as_ref(),
-                    TakeOptions::default(),
-                )
-                .unwrap(),
-            )
-        });
+        b.iter(|| black_box(take(packed.as_ref(), random_indices.as_ref()).unwrap()));
     });
 
     let contiguous_indices: PrimitiveArray = (0..10_000).collect::<Vec<_>>().into();
     c.bench_function("take_10K_contiguous", |b| {
-        b.iter(|| {
-            black_box(
-                take(
-                    packed.as_ref(),
-                    contiguous_indices.as_ref(),
-                    TakeOptions::default(),
-                )
-                .unwrap(),
-            )
-        });
+        b.iter(|| black_box(take(packed.as_ref(), contiguous_indices.as_ref()).unwrap()));
     });
 
     let lots_of_indices: PrimitiveArray = (0..200_000)
@@ -93,16 +57,7 @@ fn bench_take(c: &mut Criterion) {
         .collect::<Vec<_>>()
         .into();
     c.bench_function("take_200K_dispersed", |b| {
-        b.iter(|| {
-            black_box(
-                take(
-                    packed.as_ref(),
-                    lots_of_indices.as_ref(),
-                    TakeOptions::default(),
-                )
-                .unwrap(),
-            )
-        });
+        b.iter(|| black_box(take(packed.as_ref(), lots_of_indices.as_ref()).unwrap()));
     });
 
     let lots_of_indices: PrimitiveArray = (0..200_000)
@@ -110,16 +65,7 @@ fn bench_take(c: &mut Criterion) {
         .collect::<Vec<_>>()
         .into();
     c.bench_function("take_200K_first_chunk_only", |b| {
-        b.iter(|| {
-            black_box(
-                take(
-                    packed.as_ref(),
-                    lots_of_indices.as_ref(),
-                    TakeOptions::default(),
-                )
-                .unwrap(),
-            )
-        });
+        b.iter(|| black_box(take(packed.as_ref(), lots_of_indices.as_ref()).unwrap()));
     });
 }
 
@@ -142,30 +88,12 @@ fn bench_patched_take(c: &mut Criterion) {
 
     let stratified_indices: PrimitiveArray = (0..10).map(|i| i * 10_000).collect::<Vec<_>>().into();
     c.bench_function("patched_take_10_stratified", |b| {
-        b.iter(|| {
-            black_box(
-                take(
-                    packed.as_ref(),
-                    stratified_indices.as_ref(),
-                    TakeOptions::default(),
-                )
-                .unwrap(),
-            )
-        });
+        b.iter(|| black_box(take(packed.as_ref(), stratified_indices.as_ref()).unwrap()));
     });
 
     let contiguous_indices: PrimitiveArray = (0..10).collect::<Vec<_>>().into();
     c.bench_function("patched_take_10_contiguous", |b| {
-        b.iter(|| {
-            black_box(
-                take(
-                    packed.as_ref(),
-                    contiguous_indices.as_ref(),
-                    TakeOptions::default(),
-                )
-                .unwrap(),
-            )
-        });
+        b.iter(|| black_box(take(packed.as_ref(), contiguous_indices.as_ref()).unwrap()));
     });
 
     let rng = thread_rng();
@@ -177,16 +105,7 @@ fn bench_patched_take(c: &mut Criterion) {
         .collect_vec()
         .into();
     c.bench_function("patched_take_10K_random", |b| {
-        b.iter(|| {
-            black_box(
-                take(
-                    packed.as_ref(),
-                    random_indices.as_ref(),
-                    TakeOptions::default(),
-                )
-                .unwrap(),
-            )
-        });
+        b.iter(|| black_box(take(packed.as_ref(), random_indices.as_ref()).unwrap()));
     });
 
     let not_patch_indices: PrimitiveArray = (0u32..num_exceptions)
@@ -195,16 +114,7 @@ fn bench_patched_take(c: &mut Criterion) {
         .collect_vec()
         .into();
     c.bench_function("patched_take_10K_contiguous_not_patches", |b| {
-        b.iter(|| {
-            black_box(
-                take(
-                    packed.as_ref(),
-                    not_patch_indices.as_ref(),
-                    TakeOptions::default(),
-                )
-                .unwrap(),
-            )
-        });
+        b.iter(|| black_box(take(packed.as_ref(), not_patch_indices.as_ref()).unwrap()));
     });
 
     let patch_indices: PrimitiveArray = (big_base2..big_base2 + num_exceptions)
@@ -213,16 +123,7 @@ fn bench_patched_take(c: &mut Criterion) {
         .collect_vec()
         .into();
     c.bench_function("patched_take_10K_contiguous_patches", |b| {
-        b.iter(|| {
-            black_box(
-                take(
-                    packed.as_ref(),
-                    patch_indices.as_ref(),
-                    TakeOptions::default(),
-                )
-                .unwrap(),
-            )
-        });
+        b.iter(|| black_box(take(packed.as_ref(), patch_indices.as_ref()).unwrap()));
     });
 
     let lots_of_indices: PrimitiveArray = (0..200_000)
@@ -230,16 +131,7 @@ fn bench_patched_take(c: &mut Criterion) {
         .collect::<Vec<_>>()
         .into();
     c.bench_function("patched_take_200K_dispersed", |b| {
-        b.iter(|| {
-            black_box(
-                take(
-                    packed.as_ref(),
-                    lots_of_indices.as_ref(),
-                    TakeOptions::default(),
-                )
-                .unwrap(),
-            )
-        });
+        b.iter(|| black_box(take(packed.as_ref(), lots_of_indices.as_ref()).unwrap()));
     });
 
     let lots_of_indices: PrimitiveArray = (0..200_000)
@@ -247,16 +139,7 @@ fn bench_patched_take(c: &mut Criterion) {
         .collect::<Vec<_>>()
         .into();
     c.bench_function("patched_take_200K_first_chunk_only", |b| {
-        b.iter(|| {
-            black_box(
-                take(
-                    packed.as_ref(),
-                    lots_of_indices.as_ref(),
-                    TakeOptions::default(),
-                )
-                .unwrap(),
-            )
-        });
+        b.iter(|| black_box(take(packed.as_ref(), lots_of_indices.as_ref()).unwrap()));
     });
 
     // There are currently 2 magic parameters of note:
@@ -280,16 +163,7 @@ fn bench_patched_take(c: &mut Criterion) {
         .collect_vec()
         .into();
     c.bench_function("patched_take_10K_adversarial", |b| {
-        b.iter(|| {
-            black_box(
-                take(
-                    packed.as_ref(),
-                    adversarial_indices.as_ref(),
-                    TakeOptions::default(),
-                )
-                .unwrap(),
-            )
-        });
+        b.iter(|| black_box(take(packed.as_ref(), adversarial_indices.as_ref()).unwrap()));
     });
 }
 

--- a/encodings/fastlanes/src/bitpacking/compute/slice.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/slice.rs
@@ -39,7 +39,7 @@ impl SliceFn<BitPackedArray> for BitPackedEncoding {
 mod test {
     use itertools::Itertools;
     use vortex_array::array::PrimitiveArray;
-    use vortex_array::compute::{scalar_at, slice, take, TakeOptions};
+    use vortex_array::compute::{scalar_at, slice, take};
     use vortex_array::{ArrayLen, IntoArrayData};
 
     use crate::BitPackedArray;
@@ -191,7 +191,6 @@ mod test {
         let taken = take(
             &sliced,
             PrimitiveArray::from(vec![101i64, 1125i64, 1138i64]).as_ref(),
-            TakeOptions::default(),
         )
         .unwrap();
         assert_eq!(taken.len(), 3);

--- a/encodings/fastlanes/src/for/compute.rs
+++ b/encodings/fastlanes/src/for/compute.rs
@@ -3,7 +3,7 @@ use std::ops::AddAssign;
 use num_traits::{CheckedShl, CheckedShr, WrappingAdd, WrappingSub};
 use vortex_array::compute::{
     filter, scalar_at, search_sorted, slice, take, ComputeVTable, FilterFn, FilterMask, ScalarAtFn,
-    SearchResult, SearchSortedFn, SearchSortedSide, SliceFn, TakeFn, TakeOptions,
+    SearchResult, SearchSortedFn, SearchSortedSide, SliceFn, TakeFn,
 };
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData};
@@ -36,14 +36,9 @@ impl ComputeVTable for FoREncoding {
 }
 
 impl TakeFn<FoRArray> for FoREncoding {
-    fn take(
-        &self,
-        array: &FoRArray,
-        indices: &ArrayData,
-        options: TakeOptions,
-    ) -> VortexResult<ArrayData> {
+    fn take(&self, array: &FoRArray, indices: &ArrayData) -> VortexResult<ArrayData> {
         FoRArray::try_new(
-            take(array.encoded(), indices, options)?,
+            take(array.encoded(), indices)?,
             array.reference_scalar(),
             array.shift(),
         )

--- a/encodings/fsst/src/compute/mod.rs
+++ b/encodings/fsst/src/compute/mod.rs
@@ -3,7 +3,7 @@ mod compare;
 use vortex_array::array::varbin_scalar;
 use vortex_array::compute::{
     filter, scalar_at, slice, take, CompareFn, ComputeVTable, FilterFn, FilterMask, ScalarAtFn,
-    SliceFn, TakeFn, TakeOptions,
+    SliceFn, TakeFn,
 };
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData};
 use vortex_buffer::Buffer;
@@ -51,18 +51,13 @@ impl SliceFn<FSSTArray> for FSSTEncoding {
 
 impl TakeFn<FSSTArray> for FSSTEncoding {
     // Take on an FSSTArray is a simple take on the codes array.
-    fn take(
-        &self,
-        array: &FSSTArray,
-        indices: &ArrayData,
-        options: TakeOptions,
-    ) -> VortexResult<ArrayData> {
+    fn take(&self, array: &FSSTArray, indices: &ArrayData) -> VortexResult<ArrayData> {
         Ok(FSSTArray::try_new(
             array.dtype().clone(),
             array.symbols(),
             array.symbol_lengths(),
-            take(array.codes(), indices, options)?,
-            take(array.uncompressed_lengths(), indices, options)?,
+            take(array.codes(), indices)?,
+            take(array.uncompressed_lengths(), indices)?,
         )?
         .into_array())
     }

--- a/encodings/fsst/tests/fsst_tests.rs
+++ b/encodings/fsst/tests/fsst_tests.rs
@@ -2,7 +2,7 @@
 
 use vortex_array::array::builder::VarBinBuilder;
 use vortex_array::array::PrimitiveArray;
-use vortex_array::compute::{filter, scalar_at, slice, take, FilterMask, TakeOptions};
+use vortex_array::compute::{filter, scalar_at, slice, take, FilterMask};
 use vortex_array::encoding::Encoding;
 use vortex_array::validity::Validity;
 use vortex_array::{ArrayData, IntoArrayData, IntoCanonical};
@@ -71,7 +71,7 @@ fn test_fsst_array_ops() {
 
     // test take
     let indices = PrimitiveArray::from_vec(vec![0, 2], Validity::NonNullable).into_array();
-    let fsst_taken = take(&fsst_array, &indices, TakeOptions::default()).unwrap();
+    let fsst_taken = take(&fsst_array, &indices).unwrap();
     assert_eq!(fsst_taken.len(), 2);
     assert_nth_scalar!(
         fsst_taken,

--- a/encodings/runend-bool/src/array.rs
+++ b/encodings/runend-bool/src/array.rs
@@ -255,7 +255,7 @@ mod test {
     use itertools::Itertools as _;
     use rstest::rstest;
     use vortex_array::array::{BoolArray, PrimitiveArray};
-    use vortex_array::compute::{scalar_at, slice, take, TakeOptions};
+    use vortex_array::compute::{scalar_at, slice, take};
     use vortex_array::stats::ArrayStatistics;
     use vortex_array::validity::Validity;
     use vortex_array::{
@@ -345,7 +345,6 @@ mod test {
             )
             .unwrap(),
             vec![0, 0, 6, 4].into_array(),
-            TakeOptions::default(),
         )
         .unwrap();
 

--- a/encodings/runend-bool/src/compute/mod.rs
+++ b/encodings/runend-bool/src/compute/mod.rs
@@ -1,9 +1,7 @@
 mod invert;
 
 use vortex_array::array::BoolArray;
-use vortex_array::compute::{
-    slice, ComputeVTable, InvertFn, ScalarAtFn, SliceFn, TakeFn, TakeOptions,
-};
+use vortex_array::compute::{slice, ComputeVTable, InvertFn, ScalarAtFn, SliceFn, TakeFn};
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant, ToArrayData};
 use vortex_dtype::match_each_integer_ptype;
@@ -39,12 +37,7 @@ impl ScalarAtFn<RunEndBoolArray> for RunEndBoolEncoding {
 }
 
 impl TakeFn<RunEndBoolArray> for RunEndBoolEncoding {
-    fn take(
-        &self,
-        array: &RunEndBoolArray,
-        indices: &ArrayData,
-        _options: TakeOptions,
-    ) -> VortexResult<ArrayData> {
+    fn take(&self, array: &RunEndBoolArray, indices: &ArrayData) -> VortexResult<ArrayData> {
         let primitive_indices = indices.clone().into_primitive()?;
         let physical_indices = match_each_integer_ptype!(primitive_indices.ptype(), |$P| {
             primitive_indices

--- a/fuzz/fuzz_targets/array_ops.rs
+++ b/fuzz/fuzz_targets/array_ops.rs
@@ -6,7 +6,7 @@ use vortex_array::array::{
     BoolEncoding, PrimitiveEncoding, StructEncoding, VarBinEncoding, VarBinViewEncoding,
 };
 use vortex_array::compute::{
-    filter, scalar_at, search_sorted, slice, take, SearchResult, SearchSortedSide, TakeOptions,
+    filter, scalar_at, search_sorted, slice, take, SearchResult, SearchSortedSide,
 };
 use vortex_array::encoding::EncodingRef;
 use vortex_array::{ArrayData, IntoCanonical};
@@ -36,7 +36,7 @@ fuzz_target!(|fuzz_action: FuzzArrayAction| -> Corpus {
                 if indices.is_empty() {
                     return Corpus::Reject;
                 }
-                current_array = take(&current_array, &indices, TakeOptions::default()).unwrap();
+                current_array = take(&current_array, &indices).unwrap();
                 assert_array_eq(&expected.array(), &current_array, i);
             }
             Action::SearchSorted(s, side) => {

--- a/pyvortex/src/array.rs
+++ b/pyvortex/src/array.rs
@@ -4,9 +4,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyInt, PyList};
 use vortex::array::ChunkedArray;
-use vortex::compute::{
-    compare, fill_forward, scalar_at, slice, take, FilterMask, Operator, TakeOptions,
-};
+use vortex::compute::{compare, fill_forward, scalar_at, slice, take, FilterMask, Operator};
 use vortex::{ArrayDType, ArrayData, IntoCanonical};
 
 use crate::dtype::PyDType;
@@ -439,7 +437,7 @@ impl PyArray {
             )));
         }
 
-        let inner = take(&self.inner, indices, TakeOptions::default())?;
+        let inner = take(&self.inner, indices)?;
         Ok(PyArray { inner })
     }
 

--- a/vortex-array/benches/take_strings.rs
+++ b/vortex-array/benches/take_strings.rs
@@ -2,7 +2,7 @@
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use vortex_array::array::{PrimitiveArray, VarBinArray};
-use vortex_array::compute::{take, TakeOptions};
+use vortex_array::compute::take;
 use vortex_array::validity::Validity;
 use vortex_array::{ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::{DType, Nullability};
@@ -33,9 +33,7 @@ fn bench_varbin(c: &mut Criterion) {
     let array = fixture(65_535);
     let indices = indices(1024);
 
-    c.bench_function("varbin", |b| {
-        b.iter(|| take(&array, &indices, TakeOptions::default()).unwrap())
-    });
+    c.bench_function("varbin", |b| b.iter(|| take(&array, &indices).unwrap()));
 }
 
 fn bench_varbinview(c: &mut Criterion) {
@@ -43,7 +41,7 @@ fn bench_varbinview(c: &mut Criterion) {
     let indices = indices(1024);
 
     c.bench_function("varbinview", |b| {
-        b.iter(|| take(array.as_ref(), &indices, TakeOptions::default()).unwrap())
+        b.iter(|| take(array.as_ref(), &indices).unwrap())
     });
 }
 

--- a/vortex-array/src/array/chunked/compute/filter.rs
+++ b/vortex-array/src/array/chunked/compute/filter.rs
@@ -2,9 +2,7 @@ use arrow_buffer::BooleanBufferBuilder;
 use vortex_error::{VortexExpect, VortexResult, VortexUnwrap};
 
 use crate::array::{ChunkedArray, ChunkedEncoding, PrimitiveArray};
-use crate::compute::{
-    filter, take, FilterFn, FilterMask, SearchSorted, SearchSortedSide, TakeOptions,
-};
+use crate::compute::{filter, take, FilterFn, FilterMask, SearchSorted, SearchSortedSide};
 use crate::{ArrayDType, ArrayData, ArrayLen, IntoArrayData, IntoCanonical};
 
 // This is modeled after the constant with the equivalent name in arrow-rs.
@@ -159,7 +157,6 @@ fn filter_indices(array: &ChunkedArray, mask: FilterMask) -> VortexResult<Vec<Ar
                 let filtered_chunk = take(
                     chunk,
                     PrimitiveArray::from(chunk_indices.clone()).into_array(),
-                    TakeOptions::default(),
                 )?;
                 result.push(filtered_chunk);
             }
@@ -179,7 +176,6 @@ fn filter_indices(array: &ChunkedArray, mask: FilterMask) -> VortexResult<Vec<Ar
         let filtered_chunk = take(
             &chunk,
             PrimitiveArray::from(chunk_indices.clone()).into_array(),
-            TakeOptions::default(),
         )?;
         result.push(filtered_chunk);
     }

--- a/vortex-array/src/array/constant/compute/mod.rs
+++ b/vortex-array/src/array/constant/compute/mod.rs
@@ -10,7 +10,7 @@ use crate::array::constant::ConstantArray;
 use crate::array::ConstantEncoding;
 use crate::compute::{
     BinaryBooleanFn, CompareFn, ComputeVTable, FilterFn, FilterMask, InvertFn, ScalarAtFn,
-    SearchSortedFn, SliceFn, TakeFn, TakeOptions,
+    SearchSortedFn, SliceFn, TakeFn,
 };
 use crate::{ArrayData, IntoArrayData};
 
@@ -55,12 +55,7 @@ impl ScalarAtFn<ConstantArray> for ConstantEncoding {
 }
 
 impl TakeFn<ConstantArray> for ConstantEncoding {
-    fn take(
-        &self,
-        array: &ConstantArray,
-        indices: &ArrayData,
-        _options: TakeOptions,
-    ) -> VortexResult<ArrayData> {
+    fn take(&self, array: &ConstantArray, indices: &ArrayData) -> VortexResult<ArrayData> {
         Ok(ConstantArray::new(array.scalar(), indices.len()).into_array())
     }
 }

--- a/vortex-array/src/array/extension/compute/mod.rs
+++ b/vortex-array/src/array/extension/compute/mod.rs
@@ -7,7 +7,6 @@ use crate::array::extension::ExtensionArray;
 use crate::array::ExtensionEncoding;
 use crate::compute::{
     scalar_at, slice, take, CastFn, CompareFn, ComputeVTable, ScalarAtFn, SliceFn, TakeFn,
-    TakeOptions,
 };
 use crate::variants::ExtensionArrayTrait;
 use crate::{ArrayData, IntoArrayData};
@@ -57,16 +56,10 @@ impl SliceFn<ExtensionArray> for ExtensionEncoding {
 }
 
 impl TakeFn<ExtensionArray> for ExtensionEncoding {
-    fn take(
-        &self,
-        array: &ExtensionArray,
-        indices: &ArrayData,
-        options: TakeOptions,
-    ) -> VortexResult<ArrayData> {
-        Ok(ExtensionArray::new(
-            array.ext_dtype().clone(),
-            take(array.storage(), indices, options)?,
+    fn take(&self, array: &ExtensionArray, indices: &ArrayData) -> VortexResult<ArrayData> {
+        Ok(
+            ExtensionArray::new(array.ext_dtype().clone(), take(array.storage(), indices)?)
+                .into_array(),
         )
-        .into_array())
     }
 }

--- a/vortex-array/src/array/primitive/compute/take.rs
+++ b/vortex-array/src/array/primitive/compute/take.rs
@@ -4,29 +4,36 @@ use vortex_error::VortexResult;
 
 use crate::array::primitive::PrimitiveArray;
 use crate::array::PrimitiveEncoding;
-use crate::compute::{TakeFn, TakeOptions};
+use crate::compute::TakeFn;
 use crate::variants::PrimitiveArrayTrait;
 use crate::{ArrayData, IntoArrayData, IntoArrayVariant};
 
 impl TakeFn<PrimitiveArray> for PrimitiveEncoding {
     #[allow(clippy::cognitive_complexity)]
-    fn take(
-        &self,
-        array: &PrimitiveArray,
-        indices: &ArrayData,
-        options: TakeOptions,
-    ) -> VortexResult<ArrayData> {
+    fn take(&self, array: &PrimitiveArray, indices: &ArrayData) -> VortexResult<ArrayData> {
         let indices = indices.clone().into_primitive()?;
-        let validity = array.validity().take(indices.as_ref(), options)?;
+        let validity = array.validity().take(indices.as_ref())?;
 
         match_each_native_ptype!(array.ptype(), |$T| {
             match_each_integer_ptype!(indices.ptype(), |$I| {
-                let values = if options.skip_bounds_check {
-                    take_primitive_unchecked(array.maybe_null_slice::<$T>(), indices.into_maybe_null_slice::<$I>())
-                } else {
-                    take_primitive(array.maybe_null_slice::<$T>(), indices.into_maybe_null_slice::<$I>())
-                };
-                Ok(PrimitiveArray::from_vec(values,validity).into_array())
+                let values = take_primitive(array.maybe_null_slice::<$T>(), indices.into_maybe_null_slice::<$I>());
+                Ok(PrimitiveArray::from_vec(values, validity).into_array())
+            })
+        })
+    }
+
+    unsafe fn take_unchecked(
+        &self,
+        array: &PrimitiveArray,
+        indices: &ArrayData,
+    ) -> VortexResult<ArrayData> {
+        let indices = indices.clone().into_primitive()?;
+        let validity = unsafe { array.validity().take_unchecked(indices.as_ref())? };
+
+        match_each_native_ptype!(array.ptype(), |$T| {
+            match_each_integer_ptype!(indices.ptype(), |$I| {
+                let values = take_primitive_unchecked(array.maybe_null_slice::<$T>(), indices.into_maybe_null_slice::<$I>());
+                Ok(PrimitiveArray::from_vec(values, validity).into_array())
             })
         })
     }
@@ -43,7 +50,7 @@ fn take_primitive<T: NativePType, I: NativePType + AsPrimitive<usize>>(
 
 // We pass a Vec<I> in case we're T == u64.
 // In which case, Rust should reuse the same Vec<u64> the result.
-fn take_primitive_unchecked<T: NativePType, I: NativePType + AsPrimitive<usize>>(
+unsafe fn take_primitive_unchecked<T: NativePType, I: NativePType + AsPrimitive<usize>>(
     array: &[T],
     indices: Vec<I>,
 ) -> Vec<T> {

--- a/vortex-array/src/array/sparse/compute/mod.rs
+++ b/vortex-array/src/array/sparse/compute/mod.rs
@@ -7,7 +7,6 @@ use crate::array::{PrimitiveArray, SparseEncoding};
 use crate::compute::{
     scalar_at, search_sorted, take, ComputeVTable, FilterFn, FilterMask, InvertFn, ScalarAtFn,
     SearchResult, SearchSortedFn, SearchSortedSide, SearchSortedUsizeFn, SliceFn, TakeFn,
-    TakeOptions,
 };
 use crate::variants::PrimitiveArrayTrait;
 use crate::{ArrayDType, ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
@@ -127,11 +126,7 @@ impl FilterFn<SparseArray> for SparseEncoding {
 
         Ok(SparseArray::try_new(
             PrimitiveArray::from(coordinate_indices).into_array(),
-            take(
-                array.values(),
-                PrimitiveArray::from(value_indices),
-                TakeOptions::default(),
-            )?,
+            take(array.values(), PrimitiveArray::from(value_indices))?,
             buffer.count_set_bits(),
             array.fill_scalar(),
         )?

--- a/vortex-array/src/array/struct_/compute.rs
+++ b/vortex-array/src/array/struct_/compute.rs
@@ -6,7 +6,7 @@ use crate::array::struct_::StructArray;
 use crate::array::StructEncoding;
 use crate::compute::{
     filter, scalar_at, slice, take, ComputeVTable, FilterFn, FilterMask, ScalarAtFn, SliceFn,
-    TakeFn, TakeOptions,
+    TakeFn,
 };
 use crate::variants::StructArrayTrait;
 use crate::{ArrayDType, ArrayData, IntoArrayData};
@@ -42,20 +42,15 @@ impl ScalarAtFn<StructArray> for StructEncoding {
 }
 
 impl TakeFn<StructArray> for StructEncoding {
-    fn take(
-        &self,
-        array: &StructArray,
-        indices: &ArrayData,
-        options: TakeOptions,
-    ) -> VortexResult<ArrayData> {
+    fn take(&self, array: &StructArray, indices: &ArrayData) -> VortexResult<ArrayData> {
         StructArray::try_new(
             array.names().clone(),
             array
                 .children()
-                .map(|field| take(&field, indices, options))
+                .map(|field| take(&field, indices))
                 .try_collect()?,
             indices.len(),
-            array.validity().take(indices, options)?,
+            array.validity().take(indices)?,
         )
         .map(|a| a.into_array())
     }

--- a/vortex-array/src/array/varbin/compute/take.rs
+++ b/vortex-array/src/array/varbin/compute/take.rs
@@ -5,18 +5,13 @@ use vortex_error::{vortex_err, vortex_panic, VortexResult};
 use crate::array::varbin::builder::VarBinBuilder;
 use crate::array::varbin::VarBinArray;
 use crate::array::VarBinEncoding;
-use crate::compute::{TakeFn, TakeOptions};
+use crate::compute::TakeFn;
 use crate::validity::Validity;
 use crate::variants::PrimitiveArrayTrait;
 use crate::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
 
 impl TakeFn<VarBinArray> for VarBinEncoding {
-    fn take(
-        &self,
-        array: &VarBinArray,
-        indices: &ArrayData,
-        _options: TakeOptions,
-    ) -> VortexResult<ArrayData> {
+    fn take(&self, array: &VarBinArray, indices: &ArrayData) -> VortexResult<ArrayData> {
         let offsets = array.offsets().into_primitive()?;
         let data = array.bytes().into_primitive()?;
         let indices = indices.clone().into_primitive()?;

--- a/vortex-array/src/compute/mod.rs
+++ b/vortex-array/src/compute/mod.rs
@@ -21,7 +21,7 @@ pub use scalar_at::{scalar_at, ScalarAtFn};
 pub use scalar_subtract::{subtract_scalar, SubtractScalarFn};
 pub use search_sorted::*;
 pub use slice::{slice, SliceFn};
-pub use take::{take, TakeFn, TakeOptions};
+pub use take::{take, TakeFn};
 
 use crate::ArrayData;
 

--- a/vortex-array/src/compute/take.rs
+++ b/vortex-array/src/compute/take.rs
@@ -5,18 +5,26 @@ use crate::encoding::Encoding;
 use crate::stats::{ArrayStatistics, Stat};
 use crate::{ArrayDType, ArrayData, IntoArrayData, IntoCanonical};
 
-#[derive(Default, Debug, Clone, Copy)]
-pub struct TakeOptions {
-    pub skip_bounds_check: bool,
-}
-
 pub trait TakeFn<Array> {
-    fn take(
-        &self,
-        array: &Array,
-        indices: &ArrayData,
-        options: TakeOptions,
-    ) -> VortexResult<ArrayData>;
+    /// Create a new array by taking the values from the `array` at the
+    /// given `indices`.
+    ///
+    /// # Panics
+    ///
+    /// Using `indices` that are invalid for the given `array` will cause a panic.
+    fn take(&self, array: &Array, indices: &ArrayData) -> VortexResult<ArrayData>;
+
+    /// Create a new array by taking the values from the `array` at the
+    /// given `indices`.
+    ///
+    /// # Safety
+    ///
+    /// This take variant will not perform bounds checking on indices, so it is the caller's
+    /// responsibility to ensure that the `indices` are all valid for the provided `array`.
+    /// Failure to do so could result in out of bounds memory access or UB.
+    unsafe fn take_unchecked(&self, array: &Array, indices: &ArrayData) -> VortexResult<ArrayData> {
+        self.take(array, indices)
+    }
 }
 
 impl<E: Encoding> TakeFn<ArrayData> for E
@@ -24,26 +32,20 @@ where
     E: TakeFn<E::Array>,
     for<'a> &'a E::Array: TryFrom<&'a ArrayData, Error = VortexError>,
 {
-    fn take(
-        &self,
-        array: &ArrayData,
-        indices: &ArrayData,
-        options: TakeOptions,
-    ) -> VortexResult<ArrayData> {
+    fn take(&self, array: &ArrayData, indices: &ArrayData) -> VortexResult<ArrayData> {
         let array_ref = <&E::Array>::try_from(array)?;
         let encoding = array
             .encoding()
             .as_any()
             .downcast_ref::<E>()
             .ok_or_else(|| vortex_err!("Mismatched encoding"))?;
-        TakeFn::take(encoding, array_ref, indices, options)
+        TakeFn::take(encoding, array_ref, indices)
     }
 }
 
 pub fn take(
     array: impl AsRef<ArrayData>,
     indices: impl AsRef<ArrayData>,
-    mut options: TakeOptions,
 ) -> VortexResult<ArrayData> {
     let array = array.as_ref();
     let indices = indices.as_ref();
@@ -59,27 +61,38 @@ pub fn take(
     //  the filter function since they're typically optimised for this case.
 
     // If the indices are all within bounds, we can skip bounds checking.
-    if indices
+    let checked_indices = indices
         .statistics()
         .get_as::<usize>(Stat::Max)
-        .is_some_and(|max| max < array.len())
-    {
-        options.skip_bounds_check = true;
-    }
+        .is_some_and(|max| max < array.len());
 
     // TODO(ngates): if indices min is quite high, we could slice self and offset the indices
     //  such that canonicalize does less work.
 
+    // If TakeFn defined for the encoding, delegate to TakeFn.
+    // If we know from stats that indices are all valid, we can avoid all bounds checks.
     if let Some(take_fn) = array.encoding().take_fn() {
-        return take_fn.take(array, indices, options);
+        return if checked_indices {
+            // SAFETY: indices are all inbounds per stats.
+            // TODO(aduffy): this means stats must be trusted, can still trigger UB if stats are bad.
+            unsafe { take_fn.take_unchecked(array, indices) }
+        } else {
+            take_fn.take(array, indices)
+        };
     }
 
     // Otherwise, flatten and try again.
     info!("TakeFn not implemented for {}, flattening", array);
     let canonical = array.clone().into_canonical()?.into_array();
-    canonical
+    let canonical_take_fn = canonical
         .encoding()
         .take_fn()
-        .ok_or_else(|| vortex_err!(NotImplemented: "take", canonical.encoding().id()))?
-        .take(&canonical, indices, options)
+        .ok_or_else(|| vortex_err!(NotImplemented: "take", canonical.encoding().id()))?;
+
+    if checked_indices {
+        // SAFETY: indices are known to be in-bound from stats
+        unsafe { canonical_take_fn.take_unchecked(&canonical, indices) }
+    } else {
+        canonical_take_fn.take(&canonical, indices)
+    }
 }

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -9,7 +9,7 @@ use vortex_scalar::Scalar;
 use crate::array::PrimitiveArray;
 use crate::compute::{
     scalar_at, search_sorted, search_sorted_many, search_sorted_usize, slice, subtract_scalar,
-    take, try_cast, FilterMask, SearchResult, SearchSortedSide, TakeOptions,
+    take, try_cast, FilterMask, SearchResult, SearchSortedSide,
 };
 use crate::stats::{ArrayStatistics, Stat};
 use crate::validity::Validity;
@@ -190,11 +190,7 @@ impl Patches {
         }
 
         let indices = PrimitiveArray::from(coordinate_indices).into_array();
-        let values = take(
-            self.values(),
-            PrimitiveArray::from(value_indices),
-            TakeOptions::default(),
-        )?;
+        let values = take(self.values(), PrimitiveArray::from(value_indices))?;
 
         Ok(Some(Self::new(mask.len(), indices, values)))
     }
@@ -252,7 +248,7 @@ impl Patches {
 
         let values_indices =
             PrimitiveArray::from_vec(values_indices, Validity::NonNullable).into_array();
-        let new_values = take(self.values(), values_indices, TakeOptions::default())?;
+        let new_values = take(self.values(), values_indices)?;
 
         Ok(Some(Self::new(indices.len(), new_indices, new_values)))
     }

--- a/vortex-array/src/stream/take_rows.rs
+++ b/vortex-array/src/stream/take_rows.rs
@@ -7,9 +7,7 @@ use vortex_dtype::match_each_integer_ptype;
 use vortex_error::{vortex_bail, VortexResult};
 use vortex_scalar::Scalar;
 
-use crate::compute::{
-    search_sorted_usize, slice, subtract_scalar, take, SearchSortedSide, TakeOptions,
-};
+use crate::compute::{search_sorted_usize, slice, subtract_scalar, take, SearchSortedSide};
 use crate::stats::{ArrayStatistics, Stat};
 use crate::stream::ArrayStream;
 use crate::variants::PrimitiveArrayTrait;
@@ -95,11 +93,7 @@ impl<R: ArrayStream> Stream for TakeRows<R> {
             let shifted_arr = match_each_integer_ptype!(indices_for_batch.ptype(), |$T| {
                 subtract_scalar(&indices_for_batch.into_array(), &Scalar::from(curr_offset as $T))?
             });
-            return Poll::Ready(
-                take(&batch, &shifted_arr, TakeOptions::default())
-                    .map(Some)
-                    .transpose(),
-            );
+            return Poll::Ready(take(&batch, &shifted_arr).map(Some).transpose());
         }
 
         Poll::Ready(None)

--- a/vortex-datafusion/src/memory/plans.rs
+++ b/vortex-datafusion/src/memory/plans.rs
@@ -20,7 +20,7 @@ use futures::{ready, Stream};
 use pin_project::pin_project;
 use vortex_array::array::ChunkedArray;
 use vortex_array::arrow::FromArrowArray;
-use vortex_array::compute::{take, TakeOptions};
+use vortex_array::compute::take;
 use vortex_array::{ArrayData, IntoArrayVariant, IntoCanonical};
 use vortex_dtype::field::Field;
 use vortex_error::{vortex_err, vortex_panic, VortexError};
@@ -348,8 +348,7 @@ where
         //  We should find a way to avoid decoding the filter columns and only decode the other
         //  columns, then stitch the StructArray back together from those.
         let projected_for_output = chunk.project(this.output_projection)?;
-        let decoded =
-            take(projected_for_output, &row_indices, TakeOptions::default())?.into_arrow()?;
+        let decoded = take(projected_for_output, &row_indices)?.into_arrow()?;
 
         // Send back a single record batch of the decoded data.
         let output_batch = RecordBatch::from(decoded.as_struct());

--- a/vortex-file/src/read/layouts/chunked.rs
+++ b/vortex-file/src/read/layouts/chunked.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, OnceLock, RwLock};
 use itertools::Itertools;
 use vortex_array::aliases::hash_map::HashMap;
 use vortex_array::array::ChunkedArray;
-use vortex_array::compute::{scalar_at, take, TakeOptions};
+use vortex_array::compute::{scalar_at, take};
 use vortex_array::stats::{stats_from_bitset_bytes, ArrayStatistics as _, Stat};
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData};
 use vortex_dtype::{DType, Nullability, StructDType};
@@ -266,13 +266,7 @@ impl ChunkedLayoutReader {
             .iter()
             .map(|x| *x as u64)
             .collect::<Vec<_>>();
-        let chunks_prunable = take(
-            chunk_prunability,
-            ArrayData::from(layouts),
-            TakeOptions {
-                skip_bounds_check: false,
-            },
-        )?;
+        let chunks_prunable = take(chunk_prunability, ArrayData::from(layouts))?;
 
         if !chunks_prunable
             .statistics()

--- a/vortex-ipc/benches/ipc_take.rs
+++ b/vortex-ipc/benches/ipc_take.rs
@@ -15,7 +15,7 @@ use futures_util::{pin_mut, TryStreamExt};
 use itertools::Itertools;
 use vortex_array::array::PrimitiveArray;
 use vortex_array::compress::CompressionStrategy;
-use vortex_array::compute::{take, TakeOptions};
+use vortex_array::compute::take;
 use vortex_array::{Context, IntoArrayData};
 use vortex_io::VortexBufReader;
 use vortex_ipc::stream_reader::StreamArrayReader;
@@ -83,7 +83,7 @@ fn ipc_take(c: &mut Criterion) {
             let reader = stream_reader.into_array_stream();
             pin_mut!(reader);
             let array_view = reader.try_next().await?.unwrap();
-            black_box(take(&array_view, indices_ref, TakeOptions::default()))
+            black_box(take(&array_view, indices_ref))
         });
     });
 }


### PR DESCRIPTION
The current implementation makes it possible to trigger UB solely from calling the safe public API for `take()`.

This PR moves the unsafe variants of Take that assume bounds checking has been done into a separate `unsafe fn take_unchecked`. This creates a clean separation between safe and unsafe (possible UB) codepaths.