### PR TITLE
Speed up ALP decompress

### DIFF
--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -67,7 +67,7 @@ pub fn decompress(array: ALPArray) -> VortexResult<PrimitiveArray> {
     let ptype = array.dtype().try_into()?;
     let decoded = match_each_alp_float_ptype!(ptype, |$T| {
         PrimitiveArray::from_vec(
-            decompress_primitive::<$T>(encoded.into_maybe_null_slice(), array.exponents()),
+            <$T>::decode_vec(encoded.into_maybe_null_slice(), array.exponents()),
             validity,
         )
     });
@@ -89,18 +89,6 @@ fn patch_decoded(array: PrimitiveArray, patches: &ArrayData) -> VortexResult<Pri
             primitive_values.maybe_null_slice::<$T>(),
             primitive_values.validity())
     })
-}
-
-fn decompress_primitive<T: NativePType + ALPFloat>(
-    values: Vec<T::ALPInt>,
-    exponents: Exponents,
-) -> Vec<T> {
-    values
-        // NOTE(ngates): Rust should optimise this into_iter.map to re-use the memory
-        //  of the Vec rather than allocating a new one.
-        .into_iter()
-        .map(|v| T::decode_single(v, exponents))
-        .collect()
 }
 
 #[cfg(test)]

--- a/encodings/alp/src/alp/mod.rs
+++ b/encodings/alp/src/alp/mod.rs
@@ -160,11 +160,7 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
     fn decode_vec(encoded: Vec<Self::ALPInt>, exponents: Exponents) -> Vec<Self> {
         encoded
             .into_iter()
-            .map(move |encoded| {
-                Self::from_int(encoded)
-                    * Self::F10[exponents.f as usize]
-                    * Self::IF10[exponents.e as usize]
-            })
+            .map(move |encoded| Self::decode_single(encoded, exponents))
             .collect_vec()
     }
 

--- a/encodings/alp/src/alp/mod.rs
+++ b/encodings/alp/src/alp/mod.rs
@@ -157,6 +157,17 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
         values
     }
 
+    fn decode_vec(encoded: Vec<Self::ALPInt>, exponents: Exponents) -> Vec<Self> {
+        encoded
+            .into_iter()
+            .map(move |encoded| {
+                Self::from_int(encoded)
+                    * Self::F10[exponents.f as usize]
+                    * Self::IF10[exponents.e as usize]
+            })
+            .collect_vec()
+    }
+
     #[inline]
     fn decode_single(encoded: Self::ALPInt, exponents: Exponents) -> Self {
         Self::from_int(encoded) * Self::F10[exponents.f as usize] * Self::IF10[exponents.e as usize]


### PR DESCRIPTION
I saw something interesting when fiddling with this code on TPCH Q6

Initially the profile looked like this:
<img width="1425" alt="Screenshot 2024-12-08 at 10 04 12" src="https://github.com/user-attachments/assets/298c0c18-df88-469d-8d08-5d2cedf422f8">

Then I managed to get it to look like this (note the different function calls inside the Vec collect_in_place implementation)
<img width="1434" alt="Screenshot 2024-12-08 at 10 04 05" src="https://github.com/user-attachments/assets/46755074-d8ee-47d7-b50a-bc08b7b3f7f8">

