### PR TITLE
feat: faster Patches::take & use patches in alp-rd & sparse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4771,6 +4771,7 @@ name = "vortex-alp"
 version = "0.21.0"
 dependencies = [
  "arrow-array",
+ "arrow-buffer",
  "divan",
  "itertools 0.13.0",
  "num-traits",

--- a/encodings/alp/Cargo.toml
+++ b/encodings/alp/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 itertools = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+arrow-buffer = { workspace = true }
 vortex-array = { workspace = true }
 vortex-dtype = { workspace = true }
 vortex-error = { workspace = true }

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -1,8 +1,9 @@
 use std::fmt::{Debug, Display};
 
 use serde::{Deserialize, Serialize};
-use vortex_array::array::{PrimitiveArray, SparseArray};
+use vortex_array::array::PrimitiveArray;
 use vortex_array::encoding::ids;
+use vortex_array::patches::{Patches, PatchesMetadata};
 use vortex_array::stats::{StatisticsVTable, StatsSet};
 use vortex_array::validity::{ArrayValidity, LogicalValidity, ValidityVTable};
 use vortex_array::visitor::{ArrayVisitor, VisitorVTable};
@@ -22,7 +23,7 @@ pub struct ALPRDMetadata {
     dict_len: u8,
     dict: [u16; 8],
     left_parts_ptype: PType,
-    has_exceptions: bool,
+    patches: Option<PatchesMetadata>,
 }
 
 impl Display for ALPRDMetadata {
@@ -38,7 +39,7 @@ impl ALPRDArray {
         left_parts_dict: impl AsRef<[u16]>,
         right_parts: ArrayData,
         right_bit_width: u8,
-        left_parts_exceptions: Option<ArrayData>,
+        left_parts_patches: Option<Patches>,
     ) -> VortexResult<Self> {
         if !dtype.is_float() {
             vortex_bail!("ALPRDArray given invalid DType ({dtype})");
@@ -75,16 +76,24 @@ impl ALPRDArray {
             vortex_bail!(MismatchedTypes: "non-nullable uint", right_parts.dtype());
         }
 
-        let mut children = vec![left_parts, right_parts];
-        let has_exceptions = left_parts_exceptions.is_some();
+        let mut children = vec![left_parts.clone(), right_parts];
 
-        if let Some(exceptions) = left_parts_exceptions {
-            // Enforce that the exceptions are SparseArray so that we have access to indices and values.
-            if exceptions.encoding().id().code() != ids::SPARSE {
-                vortex_bail!("left_parts_exceptions must be SparseArray encoded");
+        if let Some(patches) = left_parts_patches.as_ref() {
+            if patches.values().dtype().is_nullable() {
+                vortex_bail!("bad: {}", patches.values());
             }
-            children.push(exceptions);
         }
+
+        let patches = left_parts_patches
+            .map(|patches| -> VortexResult<_> {
+                let metadata =
+                    patches.to_metadata(left_parts.len(), &left_parts.dtype().as_nonnullable());
+                let (_, indices, values) = patches.into_parts();
+                children.push(indices);
+                children.push(values);
+                metadata
+            })
+            .transpose()?;
 
         let mut dict = [0u16; 8];
         for (idx, v) in left_parts_dict.as_ref().iter().enumerate() {
@@ -99,7 +108,7 @@ impl ALPRDArray {
                 dict_len: left_parts_dict.as_ref().len() as u8,
                 dict,
                 left_parts_ptype,
-                has_exceptions,
+                patches,
             },
             children.into(),
             StatsSet::default(),
@@ -121,6 +130,12 @@ impl ALPRDArray {
         DType::Primitive(self.metadata().left_parts_ptype, self.dtype().nullability())
     }
 
+    /// The dtype of the exceptions of the left parts of the array.
+    #[inline]
+    fn left_parts_exceptions_dtype(&self) -> DType {
+        DType::Primitive(self.metadata().left_parts_ptype, Nullability::NonNullable)
+    }
+
     /// The dtype of the right parts of the array.
     #[inline]
     fn right_parts_dtype(&self) -> DType {
@@ -132,12 +147,6 @@ impl ALPRDArray {
             },
             Nullability::NonNullable,
         )
-    }
-
-    /// The dtype of the exceptions of the left parts of the array.
-    #[inline]
-    fn left_parts_exceptions_dtype(&self) -> DType {
-        DType::Primitive(self.metadata().left_parts_ptype, Nullability::Nullable)
     }
 
     /// The leftmost (most significant) bits of the floating point values stored in the array.
@@ -158,11 +167,17 @@ impl ALPRDArray {
     }
 
     /// Patches of left-most bits.
-    pub fn left_parts_exceptions(&self) -> Option<ArrayData> {
-        self.metadata().has_exceptions.then(|| {
-            self.as_ref()
-                .child(2, &self.left_parts_exceptions_dtype(), self.len())
-                .vortex_expect("ALPRDArray: left_parts_exceptions child")
+    pub fn left_parts_patches(&self) -> Option<Patches> {
+        self.metadata().patches.as_ref().map(|metadata| {
+            Patches::new(
+                self.len(),
+                self.as_ref()
+                    .child(2, &metadata.indices_dtype(), metadata.len())
+                    .vortex_expect("ALPRDArray: patch indices"),
+                self.as_ref()
+                    .child(3, &self.left_parts_exceptions_dtype(), metadata.len())
+                    .vortex_expect("ALPRDArray: patch values"),
+            )
         })
     }
 
@@ -186,26 +201,6 @@ impl IntoCanonical for ALPRDArray {
         // Decode the left_parts using our builtin dictionary.
         let left_parts_dict = &self.metadata().dict[0..self.metadata().dict_len as usize];
 
-        let exc_pos: Vec<u64>;
-        let exc_u16: PrimitiveArray;
-
-        if let Some(left_parts_exceptions) = self.left_parts_exceptions() {
-            let left_parts_exceptions = SparseArray::try_from(left_parts_exceptions)
-                .vortex_expect("ALPRDArray: exceptions must be SparseArray encoded");
-            exc_pos = left_parts_exceptions
-                .resolved_indices_usize()
-                .into_iter()
-                .map(|v| v as _)
-                .collect();
-            exc_u16 = left_parts_exceptions
-                .values()
-                .into_canonical()?
-                .into_primitive()?;
-        } else {
-            exc_pos = Vec::new();
-            exc_u16 = PrimitiveArray::from(Vec::<u16>::new());
-        }
-
         let decoded_array = if self.is_f32() {
             PrimitiveArray::from_vec(
                 alp_rd_decode::<f32>(
@@ -213,9 +208,8 @@ impl IntoCanonical for ALPRDArray {
                     left_parts_dict,
                     self.metadata().right_bit_width,
                     right_parts.maybe_null_slice::<u32>(),
-                    &exc_pos,
-                    exc_u16.maybe_null_slice::<u16>(),
-                ),
+                    self.left_parts_patches(),
+                )?,
                 self.logical_validity().into_validity(),
             )
         } else {
@@ -225,9 +219,8 @@ impl IntoCanonical for ALPRDArray {
                     left_parts_dict,
                     self.metadata().right_bit_width,
                     right_parts.maybe_null_slice::<u64>(),
-                    &exc_pos,
-                    exc_u16.maybe_null_slice::<u16>(),
-                ),
+                    self.left_parts_patches(),
+                )?,
                 self.logical_validity().into_validity(),
             )
         };
@@ -252,8 +245,8 @@ impl VisitorVTable<ALPRDArray> for ALPRDEncoding {
     fn accept(&self, array: &ALPRDArray, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         visitor.visit_child("left_parts", &array.left_parts())?;
         visitor.visit_child("right_parts", &array.right_parts())?;
-        if let Some(left_parts_exceptions) = array.left_parts_exceptions() {
-            visitor.visit_child("left_parts_exceptions", &left_parts_exceptions)
+        if let Some(patches) = array.left_parts_patches() {
+            visitor.visit_patches(&patches)
         } else {
             Ok(())
         }
@@ -275,7 +268,7 @@ mod test {
     #[rstest]
     #[case(vec![0.1f32.next_up(); 1024], 1.123_848_f32)]
     #[case(vec![0.1f64.next_up(); 1024], 1.123_848_591_110_992_f64)]
-    fn test_array_encode_with_nulls_and_exceptions<T: ALPRDFloat>(
+    fn test_array_encode_with_nulls_and_patches<T: ALPRDFloat>(
         #[case] reals: Vec<T>,
         #[case] seed: T,
     ) {
@@ -289,7 +282,7 @@ mod test {
         // Create a new array from this.
         let real_array = PrimitiveArray::from_nullable_vec(reals.clone());
 
-        // Pick a seed that we know will trigger lots of exceptions.
+        // Pick a seed that we know will trigger lots of patches.
         let encoder: alp_rd::RDEncoder = alp_rd::RDEncoder::new(&[seed.powi(-2)]);
 
         let rd_array = encoder.encode(&real_array);

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -79,7 +79,7 @@ impl ALPRDArray {
         let mut children = vec![left_parts.clone(), right_parts];
 
         let patches = left_parts_patches
-            .map(|patches| -> VortexResult<_> {
+            .map(|patches| {
                 if patches.values().dtype().is_nullable() {
                     vortex_bail!("patches must be non-nullable: {}", patches.values());
                 }

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -78,14 +78,11 @@ impl ALPRDArray {
 
         let mut children = vec![left_parts.clone(), right_parts];
 
-        if let Some(patches) = left_parts_patches.as_ref() {
-            if patches.values().dtype().is_nullable() {
-                vortex_bail!("patches must be non-nullable: {}", patches.values());
-            }
-        }
-
         let patches = left_parts_patches
             .map(|patches| -> VortexResult<_> {
+                if patches.values().dtype().is_nullable() {
+                    vortex_bail!("patches must be non-nullable: {}", patches.values());
+                }
                 let metadata =
                     patches.to_metadata(left_parts.len(), &left_parts.dtype().as_nonnullable());
                 let (_, indices, values) = patches.into_parts();

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -127,12 +127,6 @@ impl ALPRDArray {
         DType::Primitive(self.metadata().left_parts_ptype, self.dtype().nullability())
     }
 
-    /// The dtype of the exceptions of the left parts of the array.
-    #[inline]
-    fn left_parts_exceptions_dtype(&self) -> DType {
-        DType::Primitive(self.metadata().left_parts_ptype, Nullability::NonNullable)
-    }
-
     /// The dtype of the right parts of the array.
     #[inline]
     fn right_parts_dtype(&self) -> DType {
@@ -144,6 +138,12 @@ impl ALPRDArray {
             },
             Nullability::NonNullable,
         )
+    }
+
+    /// The dtype of the patches of the left parts of the array.
+    #[inline]
+    fn left_parts_patches_dtype(&self) -> DType {
+        DType::Primitive(self.metadata().left_parts_ptype, Nullability::NonNullable)
     }
 
     /// The leftmost (most significant) bits of the floating point values stored in the array.
@@ -172,7 +172,7 @@ impl ALPRDArray {
                     .child(2, &metadata.indices_dtype(), metadata.len())
                     .vortex_expect("ALPRDArray: patch indices"),
                 self.as_ref()
-                    .child(3, &self.left_parts_exceptions_dtype(), metadata.len())
+                    .child(3, &self.left_parts_patches_dtype(), metadata.len())
                     .vortex_expect("ALPRDArray: patch values"),
             )
         })

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -80,7 +80,7 @@ impl ALPRDArray {
 
         if let Some(patches) = left_parts_patches.as_ref() {
             if patches.values().dtype().is_nullable() {
-                vortex_bail!("bad: {}", patches.values());
+                vortex_bail!("patches must be non-nullable: {}", patches.values());
             }
         }
 

--- a/encodings/alp/src/alp_rd/compute/filter.rs
+++ b/encodings/alp/src/alp_rd/compute/filter.rs
@@ -7,9 +7,10 @@ use crate::{ALPRDArray, ALPRDEncoding};
 impl FilterFn<ALPRDArray> for ALPRDEncoding {
     fn filter(&self, array: &ALPRDArray, mask: FilterMask) -> VortexResult<ArrayData> {
         let left_parts_exceptions = array
-            .left_parts_exceptions()
-            .map(|array| filter(&array, mask.clone()))
-            .transpose()?;
+            .left_parts_patches()
+            .map(|patches| patches.filter(mask.clone()))
+            .transpose()?
+            .flatten();
 
         Ok(ALPRDArray::try_new(
             array.dtype().clone(),
@@ -40,7 +41,7 @@ mod test {
         let encoded = RDEncoder::new(&[a, b]).encode(&array);
 
         // Make sure that we're testing the exception pathway.
-        assert!(encoded.left_parts_exceptions().is_some());
+        assert!(encoded.left_parts_patches().is_some());
 
         // The first two values need no patching
         let filtered = filter(encoded.as_ref(), FilterMask::from_iter([true, false, true]))

--- a/encodings/alp/src/alp_rd/compute/slice.rs
+++ b/encodings/alp/src/alp_rd/compute/slice.rs
@@ -7,9 +7,10 @@ use crate::{ALPRDArray, ALPRDEncoding};
 impl SliceFn<ALPRDArray> for ALPRDEncoding {
     fn slice(&self, array: &ALPRDArray, start: usize, stop: usize) -> VortexResult<ArrayData> {
         let left_parts_exceptions = array
-            .left_parts_exceptions()
-            .map(|array| slice(&array, start, stop))
-            .transpose()?;
+            .left_parts_patches()
+            .map(|patches| patches.slice(start, stop))
+            .transpose()?
+            .flatten();
 
         Ok(ALPRDArray::try_new(
             array.dtype().clone(),
@@ -39,7 +40,7 @@ mod test {
         let array = PrimitiveArray::from(vec![a, b, outlier]);
         let encoded = RDEncoder::new(&[a, b]).encode(&array);
 
-        assert!(encoded.left_parts_exceptions().is_some());
+        assert!(encoded.left_parts_patches().is_some());
 
         let decoded = slice(encoded.as_ref(), 1, 3)
             .unwrap()

--- a/encodings/alp/src/alp_rd/mod.rs
+++ b/encodings/alp/src/alp_rd/mod.rs
@@ -262,8 +262,6 @@ impl RDEncoder {
 /// # Panics
 ///
 /// The function panics if the provided `left_parts` and `right_parts` differ in length.
-///
-/// The function panics if the provided `exc_pos` and `exceptions` differ in length.
 pub fn alp_rd_decode<T: ALPRDFloat>(
     left_parts: &[u16],
     left_parts_dict: &[u16],

--- a/encodings/alp/src/alp_rd/mod.rs
+++ b/encodings/alp/src/alp_rd/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::cast_possible_truncation)]
 
 pub use array::*;
+use vortex_array::patches::Patches;
 use vortex_array::validity::Validity;
 use vortex_array::variants::PrimitiveArrayTrait;
 
@@ -13,12 +14,11 @@ use std::ops::{Shl, Shr};
 use itertools::Itertools;
 use num_traits::{Float, One, PrimInt};
 use vortex_array::aliases::hash_map::HashMap;
-use vortex_array::array::{PrimitiveArray, SparseArray};
+use vortex_array::array::PrimitiveArray;
 use vortex_array::{ArrayDType, IntoArrayData};
 use vortex_dtype::{DType, NativePType};
-use vortex_error::{VortexExpect, VortexUnwrap};
+use vortex_error::{vortex_bail, VortexExpect, VortexResult, VortexUnwrap};
 use vortex_fastlanes::bitpack_encode_unchecked;
-use vortex_scalar::Scalar;
 
 use crate::match_each_alp_float_ptype;
 
@@ -222,7 +222,7 @@ impl RDEncoder {
 
         // Bit-pack the dict-encoded left-parts
         // Bit-pack the right-parts
-        // SparseArray for exceptions.
+        // Patches for exceptions.
         let exceptions = (!exceptions_pos.is_empty()).then(|| {
             let max_exc_pos = exceptions_pos.last().copied().unwrap_or_default();
             let bw = bit_width!(max_exc_pos) as u8;
@@ -235,16 +235,14 @@ impl RDEncoder {
                     .into_array()
             };
 
-            let exc_array = PrimitiveArray::from_vec(exceptions, Validity::AllValid).into_array();
-            let nullable_dtype = exc_array.dtype().as_nullable();
-            SparseArray::try_new(
-                packed_pos,
-                exc_array,
-                doubles.len(),
-                Scalar::null(nullable_dtype),
-            )
-            .vortex_expect("ALP-RD: construction of exceptions SparseArray")
-            .into_array()
+            let exception_validity = Validity::NonNullable;
+            // if array.dtype().is_nullable() {
+            //     Validity::AllValid
+            // } else {
+            //     Validity::NonNullable
+            // };
+            let exc_array = PrimitiveArray::from_vec(exceptions, exception_validity).into_array();
+            Patches::new(doubles.len(), packed_pos, exc_array)
         });
 
         ALPRDArray::try_new(
@@ -271,42 +269,38 @@ pub fn alp_rd_decode<T: ALPRDFloat>(
     left_parts_dict: &[u16],
     right_bit_width: u8,
     right_parts: &[T::UINT],
-    exc_pos: &[u64],
-    exceptions: &[u16],
-) -> Vec<T> {
-    assert_eq!(
-        left_parts.len(),
-        right_parts.len(),
-        "alp_rd_decode: left_parts.len != right_parts.len"
-    );
-
-    assert_eq!(
-        exc_pos.len(),
-        exceptions.len(),
-        "alp_rd_decode: exc_pos.len != exceptions.len"
-    );
+    left_parts_patches: Option<Patches>,
+) -> VortexResult<Vec<T>> {
+    if left_parts.len() != right_parts.len() {
+        vortex_bail!("alp_rd_decode: left_parts.len != right_parts.len");
+    }
 
     let mut dict = Vec::with_capacity(left_parts_dict.len());
     dict.extend_from_slice(left_parts_dict);
 
-    let mut left_parts_decoded: Vec<T::UINT> = Vec::with_capacity(left_parts.len());
+    let mut left_parts_decoded: Vec<u16> = Vec::with_capacity(left_parts.len());
 
     // Decode with bit-packing and dict unpacking.
     for code in left_parts {
-        left_parts_decoded.push(<T as ALPRDFloat>::from_u16(dict[*code as usize]));
+        left_parts_decoded.push(dict[*code as usize]);
     }
 
-    // Apply the exception patches to left_parts
-    for (pos, val) in exc_pos.iter().zip(exceptions.iter()) {
-        left_parts_decoded[*pos as usize] = <T as ALPRDFloat>::from_u16(*val);
-    }
+    let patched_left_parts = match left_parts_patches {
+        Some(patches) => PrimitiveArray::from(left_parts_decoded)
+            .patch(patches)?
+            .into_maybe_null_slice::<u16>(),
+        None => left_parts_decoded,
+    };
 
     // recombine the left-and-right parts, adjusting by the right_bit_width.
-    left_parts_decoded
+    Ok(patched_left_parts
         .into_iter()
         .zip(right_parts.iter().copied())
-        .map(|(left, right)| T::from_bits((left << (right_bit_width as usize)) | right))
-        .collect()
+        .map(|(left, right)| {
+            let left = <T as ALPRDFloat>::from_u16(left);
+            T::from_bits((left << (right_bit_width as usize)) | right)
+        })
+        .collect())
 }
 
 /// Find the best "cut point" for a set of floating point values such that we can

--- a/encodings/alp/src/alp_rd/mod.rs
+++ b/encodings/alp/src/alp_rd/mod.rs
@@ -235,13 +235,8 @@ impl RDEncoder {
                     .into_array()
             };
 
-            let exception_validity = Validity::NonNullable;
-            // if array.dtype().is_nullable() {
-            //     Validity::AllValid
-            // } else {
-            //     Validity::NonNullable
-            // };
-            let exc_array = PrimitiveArray::from_vec(exceptions, exception_validity).into_array();
+            let exc_array =
+                PrimitiveArray::from_vec(exceptions, Validity::NonNullable).into_array();
             Patches::new(doubles.len(), packed_pos, exc_array)
         });
 

--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -83,3 +83,7 @@ harness = false
 [[bench]]
 name = "take_strings"
 harness = false
+
+[[bench]]
+name = "take_patches"
+harness = false

--- a/vortex-array/benches/take_patches.rs
+++ b/vortex-array/benches/take_patches.rs
@@ -1,0 +1,71 @@
+#![allow(clippy::unwrap_used)]
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng as _};
+use vortex_array::patches::Patches;
+use vortex_array::ArrayData;
+
+fn fixture(len: usize, sparsity: f64, rng: &mut StdRng) -> Patches {
+    // NB: indices are always ordered
+    let indices = (0..len)
+        .filter(|_| rng.gen_bool(sparsity))
+        .map(|x| x as u64)
+        .collect::<Vec<u64>>();
+    let sparse_len = indices.len();
+    let values = ArrayData::from((0..sparse_len).map(|x| x as u64).collect::<Vec<_>>());
+    Patches::new(len, ArrayData::from(indices), values)
+}
+
+fn indices(array_len: usize, n_indices: usize, rng: &mut StdRng) -> ArrayData {
+    ArrayData::from(
+        (0..n_indices)
+            .map(|_| rng.gen_range(0..(array_len as u64)))
+            .collect::<Vec<u64>>(),
+    )
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn bench_take(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bench_take");
+    let mut rng = StdRng::seed_from_u64(0);
+
+    for patches_sparsity in [0.1, 0.05, 0.01, 0.005, 0.001, 0.0005, 0.0001] {
+        let patches = fixture(65_535, patches_sparsity, &mut rng);
+        for index_multiple in [1.0, 0.5, 0.1, 0.05, 0.01, 0.005, 0.001, 0.0005, 0.0001] {
+            let indices = indices(
+                patches.array_len(),
+                (patches.array_len() as f64 * index_multiple) as usize,
+                &mut rng,
+            );
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!(
+                    "take_search: array_len={}, n_patches={} (~{}%), n_indices={} ({}%)",
+                    patches.array_len(),
+                    patches.num_patches(),
+                    patches_sparsity,
+                    indices.len(),
+                    index_multiple * 100.0
+                )),
+                &(&patches, &indices),
+                |b, (patches, indices)| b.iter(|| patches.take_search(indices)),
+            );
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!(
+                    "take_map: array_len={}, n_patches={} (~{}%), n_indices={} ({}%)",
+                    patches.array_len(),
+                    patches.num_patches(),
+                    patches_sparsity,
+                    indices.len(),
+                    index_multiple * 100.0
+                )),
+                &(&patches, &indices),
+                |b, (patches, indices)| b.iter(|| patches.take_map(indices)),
+            );
+        }
+    }
+    group.finish()
+}
+
+criterion_group!(benches, bench_take);
+criterion_main!(benches);

--- a/vortex-array/benches/take_patches.rs
+++ b/vortex-array/benches/take_patches.rs
@@ -4,7 +4,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng as _};
 use vortex_array::patches::Patches;
-use vortex_array::ArrayData;
+use vortex_array::{ArrayData, IntoCanonical as _};
 
 fn fixture(len: usize, sparsity: f64, rng: &mut StdRng) -> Patches {
     // NB: indices are always ordered
@@ -48,7 +48,18 @@ fn bench_take(c: &mut Criterion) {
                     index_multiple * 100.0
                 )),
                 &(&patches, &indices),
-                |b, (patches, indices)| b.iter(|| patches.take_search(indices)),
+                |b, (patches, indices)| {
+                    b.iter(|| {
+                        patches.take_search(
+                            <&ArrayData>::clone(indices)
+                                .clone()
+                                .into_canonical()
+                                .unwrap()
+                                .into_primitive()
+                                .unwrap(),
+                        )
+                    })
+                },
             );
             group.bench_with_input(
                 BenchmarkId::from_parameter(format!(
@@ -60,7 +71,18 @@ fn bench_take(c: &mut Criterion) {
                     index_multiple * 100.0
                 )),
                 &(&patches, &indices),
-                |b, (patches, indices)| b.iter(|| patches.take_map(indices)),
+                |b, (patches, indices)| {
+                    b.iter(|| {
+                        patches.take_map(
+                            <&ArrayData>::clone(indices)
+                                .clone()
+                                .into_canonical()
+                                .unwrap()
+                                .into_primitive()
+                                .unwrap(),
+                        )
+                    })
+                },
             );
         }
     }

--- a/vortex-array/benches/take_strings.rs
+++ b/vortex-array/benches/take_strings.rs
@@ -45,5 +45,5 @@ fn bench_varbinview(c: &mut Criterion) {
     });
 }
 
-criterion_group!(bench_take, bench_varbin, bench_varbinview);
-criterion_main!(bench_take);
+criterion_group!(bench_take_strings, bench_varbin, bench_varbinview);
+criterion_main!(bench_take_strings);

--- a/vortex-array/src/array/sparse/compute/invert.rs
+++ b/vortex-array/src/array/sparse/compute/invert.rs
@@ -7,10 +7,11 @@ use crate::{ArrayData, ArrayLen, IntoArrayData};
 impl InvertFn<SparseArray> for SparseEncoding {
     fn invert(&self, array: &SparseArray) -> VortexResult<ArrayData> {
         let inverted_fill = array.fill_scalar().as_bool().invert().into_scalar();
-        SparseArray::try_new(
-            array.indices(),
-            invert(&array.values())?,
+        let inverted_patches = array.patches().map_values(|values| invert(&values))?;
+        SparseArray::try_new_from_patches(
+            inverted_patches,
             array.len(),
+            array.indices_offset(),
             inverted_fill,
         )
         .map(|a| a.into_array())

--- a/vortex-array/src/array/sparse/compute/mod.rs
+++ b/vortex-array/src/array/sparse/compute/mod.rs
@@ -1,15 +1,13 @@
-use vortex_dtype::match_each_integer_ptype;
-use vortex_error::{VortexExpect, VortexResult};
+use vortex_error::VortexResult;
 use vortex_scalar::Scalar;
 
 use crate::array::sparse::SparseArray;
-use crate::array::{PrimitiveArray, SparseEncoding};
+use crate::array::{ConstantArray, SparseEncoding};
 use crate::compute::{
-    scalar_at, search_sorted, take, ComputeVTable, FilterFn, FilterMask, InvertFn, ScalarAtFn,
+    ComputeVTable, FilterFn, FilterMask, InvertFn, ScalarAtFn,
     SearchResult, SearchSortedFn, SearchSortedSide, SearchSortedUsizeFn, SliceFn, TakeFn,
 };
-use crate::variants::PrimitiveArrayTrait;
-use crate::{ArrayDType, ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
+use crate::{ArrayDType, ArrayData, ArrayLen, IntoArrayData};
 
 mod invert;
 mod slice;
@@ -47,10 +45,10 @@ impl ComputeVTable for SparseEncoding {
 
 impl ScalarAtFn<SparseArray> for SparseEncoding {
     fn scalar_at(&self, array: &SparseArray, index: usize) -> VortexResult<Scalar> {
-        Ok(match array.search_index(index)?.to_found() {
-            None => array.fill_scalar(),
-            Some(idx) => scalar_at(array.values(), idx)?,
-        })
+        Ok(array
+            .patches()
+            .get_patched(array.indices_offset() + index)?
+            .unwrap_or_else(|| array.fill_scalar()))
     }
 }
 
@@ -62,22 +60,10 @@ impl SearchSortedFn<SparseArray> for SparseEncoding {
         value: &Scalar,
         side: SearchSortedSide,
     ) -> VortexResult<SearchResult> {
-        search_sorted(&array.values(), value.clone(), side).and_then(|sr| {
-            let sidx = sr.to_offsets_index(array.metadata().indices_len);
-            let index: usize = scalar_at(array.indices(), sidx)?.as_ref().try_into()?;
-            Ok(match sr {
-                SearchResult::Found(i) => SearchResult::Found(
-                    if i == array.metadata().indices_len {
-                        index + 1
-                    } else {
-                        index
-                    } - array.indices_offset(),
-                ),
-                SearchResult::NotFound(i) => SearchResult::NotFound(
-                    if i == 0 { index } else { index + 1 } - array.indices_offset(),
-                ),
-            })
-        })
+        Ok(array
+            .patches()
+            .search_sorted(value.clone(), side)?
+            .map(|i| i - array.indices_offset()))
     }
 }
 
@@ -99,38 +85,14 @@ impl SearchSortedUsizeFn<SparseArray> for SparseEncoding {
 
 impl FilterFn<SparseArray> for SparseEncoding {
     fn filter(&self, array: &SparseArray, mask: FilterMask) -> VortexResult<ArrayData> {
-        let buffer = mask.to_boolean_buffer()?;
-        let mut coordinate_indices: Vec<u64> = Vec::new();
-        let mut value_indices = Vec::new();
-        let mut last_inserted_index = 0;
+        let new_length = mask.to_boolean_buffer()?.count_set_bits();
 
-        let flat_indices = array
-            .indices()
-            .into_primitive()
-            .vortex_expect("Failed to convert SparseArray indices to primitive array");
-        match_each_integer_ptype!(flat_indices.ptype(), |$P| {
-            let indices = flat_indices
-                .maybe_null_slice::<$P>()
-                .iter()
-                .map(|v| (*v as usize) - array.indices_offset());
-            for (value_idx, coordinate) in indices.enumerate() {
-                if buffer.value(coordinate) {
-                    // We count the number of truthy values between this coordinate and the previous truthy one
-                    let adjusted_coordinate = buffer.slice(last_inserted_index, coordinate - last_inserted_index).count_set_bits() as u64;
-                    coordinate_indices.push(adjusted_coordinate + coordinate_indices.last().copied().unwrap_or_default());
-                    last_inserted_index = coordinate;
-                    value_indices.push(value_idx as u64);
-                }
-            }
-        });
+        let Some(new_patches) = array.resolved_patches()?.filter(mask)? else {
+            return Ok(ConstantArray::new(array.fill_scalar(), new_length).into_array());
+        };
 
-        Ok(SparseArray::try_new(
-            PrimitiveArray::from(coordinate_indices).into_array(),
-            take(array.values(), PrimitiveArray::from(value_indices))?,
-            buffer.count_set_bits(),
-            array.fill_scalar(),
-        )?
-        .into_array())
+        SparseArray::try_new_from_patches(new_patches, new_length, 0, array.fill_scalar())
+            .map(IntoArrayData::into_array)
     }
 }
 
@@ -223,8 +185,8 @@ mod test {
         let filtered_array = SparseArray::try_from(filtered_array).unwrap();
 
         assert_eq!(filtered_array.len(), 1);
-        assert_eq!(filtered_array.values().len(), 1);
-        assert_eq!(filtered_array.indices().len(), 1);
+        assert_eq!(filtered_array.patches().values().len(), 1);
+        assert_eq!(filtered_array.patches().indices().len(), 1);
     }
 
     #[test]
@@ -243,7 +205,11 @@ mod test {
         let filtered_array = SparseArray::try_from(filtered_array).unwrap();
 
         assert_eq!(filtered_array.len(), 4);
-        let primitive = filtered_array.indices().into_primitive().unwrap();
+        let primitive = filtered_array
+            .patches()
+            .into_indices()
+            .into_primitive()
+            .unwrap();
 
         assert_eq!(primitive.maybe_null_slice::<u64>(), &[1, 3]);
     }

--- a/vortex-array/src/array/sparse/compute/mod.rs
+++ b/vortex-array/src/array/sparse/compute/mod.rs
@@ -4,8 +4,8 @@ use vortex_scalar::Scalar;
 use crate::array::sparse::SparseArray;
 use crate::array::{ConstantArray, SparseEncoding};
 use crate::compute::{
-    ComputeVTable, FilterFn, FilterMask, InvertFn, ScalarAtFn,
-    SearchResult, SearchSortedFn, SearchSortedSide, SearchSortedUsizeFn, SliceFn, TakeFn,
+    ComputeVTable, FilterFn, FilterMask, InvertFn, ScalarAtFn, SearchResult, SearchSortedFn,
+    SearchSortedSide, SearchSortedUsizeFn, SliceFn, TakeFn,
 };
 use crate::{ArrayDType, ArrayData, ArrayLen, IntoArrayData};
 

--- a/vortex-array/src/array/sparse/compute/take.rs
+++ b/vortex-array/src/array/sparse/compute/take.rs
@@ -1,110 +1,38 @@
-use std::convert::identity;
-
-use itertools::Itertools;
-use vortex_dtype::{match_each_integer_ptype, DType, Nullability, PType};
 use vortex_error::VortexResult;
 
-use crate::aliases::hash_map::HashMap;
-use crate::array::primitive::PrimitiveArray;
 use crate::array::sparse::SparseArray;
-use crate::array::SparseEncoding;
-use crate::compute::{take, try_cast, TakeFn};
-use crate::variants::PrimitiveArrayTrait;
-use crate::{ArrayData, IntoArrayData, IntoArrayVariant};
+use crate::array::{ConstantArray, SparseEncoding};
+use crate::compute::TakeFn;
+use crate::{ArrayData, IntoArrayData};
 
 impl TakeFn<SparseArray> for SparseEncoding {
-    fn take(&self, array: &SparseArray, indices: &ArrayData) -> VortexResult<ArrayData> {
-        let flat_indices = indices.clone().into_primitive()?;
-        // if we are taking a lot of values we should build a hashmap
-        let (positions, physical_take_indices) = if indices.len() > 128 {
-            take_map(array, &flat_indices)?
-        } else {
-            take_search_sorted(array, &flat_indices)?
+    fn take(&self, array: &SparseArray, take_indices: &ArrayData) -> VortexResult<ArrayData> {
+        // FIXME(DK): add_scalar to the take_indices if they are shorter
+        let resolved_patches = array.resolved_patches()?;
+
+        let Some(new_patches) = resolved_patches.take(take_indices)? else {
+            return Ok(ConstantArray::new(array.fill_scalar(), take_indices.len()).into_array());
         };
 
-        let taken_values = take(array.values(), physical_take_indices)?;
-
-        Ok(SparseArray::try_new(
-            positions.into_array(),
-            taken_values,
-            indices.len(),
-            array.fill_scalar(),
-        )?
-        .into_array())
+        SparseArray::try_new_from_patches(new_patches, take_indices.len(), 0, array.fill_scalar())
+            .map(IntoArrayData::into_array)
     }
-}
-
-fn take_map(
-    array: &SparseArray,
-    indices: &PrimitiveArray,
-) -> VortexResult<(PrimitiveArray, PrimitiveArray)> {
-    let resolved_indices = try_cast(
-        array.resolved_indices()?,
-        &DType::Primitive(PType::U64, Nullability::NonNullable),
-    )?
-    .into_primitive()?;
-    let indices_map: HashMap<u64, u64> = resolved_indices
-        .maybe_null_slice::<u64>()
-        .iter()
-        .enumerate()
-        .map(|(i, r)| (*r, i as u64))
-        .collect();
-    let min_index = array.min_index().unwrap_or_default() as u64;
-    let max_index = array.max_index().unwrap_or_default() as u64;
-    let (positions, patch_indices): (Vec<u64>, Vec<u64>) = match_each_integer_ptype!(indices.ptype(), |$P| {
-        indices.maybe_null_slice::<$P>()
-            .iter()
-            .map(|pi| *pi as u64)
-            .enumerate()
-            .filter(|(_, pi)| *pi >= min_index && *pi <= max_index) // short-circuit
-            .filter_map(|(i, pi)| indices_map.get(&pi).map(|phy_idx| (i as u64, phy_idx)))
-            .unzip()
-    });
-    Ok((
-        PrimitiveArray::from(positions),
-        PrimitiveArray::from(patch_indices),
-    ))
-}
-
-fn take_search_sorted(
-    array: &SparseArray,
-    indices: &PrimitiveArray,
-) -> VortexResult<(PrimitiveArray, PrimitiveArray)> {
-    let min_index = array.min_index().unwrap_or_default() as u64;
-    let max_index = array.max_index().unwrap_or_default() as u64;
-    let resolved = match_each_integer_ptype!(indices.ptype(), |$P| {
-        indices
-            .maybe_null_slice::<$P>()
-            .iter()
-            .enumerate()
-            .filter(|(_, i)| **i as u64 >= min_index && **i as u64 <= max_index) // short-circuit
-            .map(|(pos, i)| {
-                array
-                    .search_index(*i as usize)
-                    .map(|r| r.to_found().map(|ii| (pos as u64, ii as u64)))
-            })
-            .filter_map_ok(identity)
-            .collect::<VortexResult<Vec<_>>>()?
-    });
-
-    let (positions, patch_indices): (Vec<u64>, Vec<u64>) = resolved.into_iter().unzip();
-    Ok((
-        PrimitiveArray::from(positions),
-        PrimitiveArray::from(patch_indices),
-    ))
 }
 
 #[cfg(test)]
 mod test {
-    use itertools::Itertools;
     use vortex_scalar::Scalar;
 
     use crate::array::primitive::PrimitiveArray;
-    use crate::array::sparse::compute::take::take_map;
     use crate::array::sparse::SparseArray;
-    use crate::compute::take;
+    use crate::compute::{scalar_at, slice, take};
     use crate::validity::Validity;
     use crate::{ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
+
+    fn test_array_fill_value() -> Scalar {
+        // making this const is annoying
+        Scalar::null_typed::<f64>()
+    }
 
     fn sparse_array() -> ArrayData {
         SparseArray::try_new(
@@ -112,10 +40,20 @@ mod test {
             PrimitiveArray::from_vec(vec![1.23f64, 0.47, 9.99, 3.5], Validity::AllValid)
                 .into_array(),
             100,
-            Scalar::null_typed::<f64>(),
+            test_array_fill_value(),
         )
         .unwrap()
         .into_array()
+    }
+
+    #[test]
+    fn take_with_non_zero_offset() {
+        let sparse = sparse_array();
+        let sparse = slice(sparse, 30, 40).unwrap();
+        let sparse = take(sparse, ArrayData::from(vec![6, 7, 8])).unwrap();
+        assert_eq!(scalar_at(&sparse, 0).unwrap(), test_array_fill_value());
+        assert_eq!(scalar_at(&sparse, 1).unwrap(), Scalar::from(Some(0.47)));
+        assert_eq!(scalar_at(&sparse, 2).unwrap(), test_array_fill_value());
     }
 
     #[test]
@@ -126,7 +64,8 @@ mod test {
                 .unwrap();
         assert_eq!(
             taken
-                .indices()
+                .patches()
+                .into_indices()
                 .into_primitive()
                 .unwrap()
                 .maybe_null_slice::<u64>(),
@@ -134,7 +73,8 @@ mod test {
         );
         assert_eq!(
             taken
-                .values()
+                .patches()
+                .into_values()
                 .into_primitive()
                 .unwrap()
                 .maybe_null_slice::<f64>(),
@@ -145,19 +85,9 @@ mod test {
     #[test]
     fn nonexistent_take() {
         let sparse = sparse_array();
-        let taken = SparseArray::try_from(take(sparse, vec![69].into_array()).unwrap()).unwrap();
-        assert!(taken
-            .indices()
-            .into_primitive()
-            .unwrap()
-            .maybe_null_slice::<u64>()
-            .is_empty());
-        assert!(taken
-            .values()
-            .into_primitive()
-            .unwrap()
-            .maybe_null_slice::<f64>()
-            .is_empty());
+        let taken = take(sparse, vec![69].into_array()).unwrap();
+        assert!(taken.len() == 1);
+        assert_eq!(scalar_at(taken, 0).unwrap(), test_array_fill_value());
     }
 
     #[test]
@@ -167,7 +97,8 @@ mod test {
             SparseArray::try_from(take(&sparse, vec![69, 37].into_array()).unwrap()).unwrap();
         assert_eq!(
             taken
-                .indices()
+                .patches()
+                .into_indices()
                 .into_primitive()
                 .unwrap()
                 .maybe_null_slice::<u64>(),
@@ -175,28 +106,13 @@ mod test {
         );
         assert_eq!(
             taken
-                .values()
+                .patches()
+                .into_values()
                 .into_primitive()
                 .unwrap()
                 .maybe_null_slice::<f64>(),
             [0.47f64]
         );
         assert_eq!(taken.len(), 2);
-    }
-
-    #[test]
-    fn test_take_map() {
-        let sparse = SparseArray::try_from(sparse_array()).unwrap();
-        let indices = PrimitiveArray::from((0u64..100).collect_vec());
-        let (positions, patch_indices) = take_map(&sparse, &indices).unwrap();
-        assert_eq!(
-            positions.maybe_null_slice::<u64>(),
-            sparse
-                .indices()
-                .into_primitive()
-                .unwrap()
-                .maybe_null_slice::<u64>()
-        );
-        assert_eq!(patch_indices.maybe_null_slice::<u64>(), [0u64, 1, 2, 3]);
     }
 }

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -1,23 +1,17 @@
 use std::fmt::{Debug, Display};
 
 use ::serde::{Deserialize, Serialize};
-use vortex_dtype::Nullability::NonNullable;
-use vortex_dtype::{match_each_integer_ptype, DType, PType};
 use vortex_error::{vortex_bail, vortex_panic, VortexExpect as _, VortexResult};
 use vortex_scalar::{Scalar, ScalarValue};
 
 use crate::array::constant::ConstantArray;
-use crate::compute::{
-    scalar_at, search_sorted_usize, subtract_scalar, SearchResult, SearchSortedSide,
-};
+use crate::compute::{scalar_at, subtract_scalar};
 use crate::encoding::ids;
+use crate::patches::{Patches, PatchesMetadata};
 use crate::stats::{ArrayStatistics, Stat, StatisticsVTable, StatsSet};
 use crate::validity::{ArrayValidity, LogicalValidity, ValidityVTable};
-use crate::variants::PrimitiveArrayTrait;
 use crate::visitor::{ArrayVisitor, VisitorVTable};
-use crate::{
-    impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, IntoArrayData, IntoArrayVariant,
-};
+use crate::{impl_encoding, ArrayDType, ArrayData, ArrayLen, ArrayTrait, IntoArrayData};
 
 mod canonical;
 mod compute;
@@ -29,8 +23,7 @@ impl_encoding!("vortex.sparse", ids::SPARSE, Sparse);
 pub struct SparseMetadata {
     // Offset value for patch indices as a result of slicing
     indices_offset: usize,
-    indices_len: usize,
-    indices_ptype: PType,
+    patches: PatchesMetadata,
     fill_value: ScalarValue,
 }
 
@@ -57,13 +50,6 @@ impl SparseArray {
         indices_offset: usize,
         fill_value: Scalar,
     ) -> VortexResult<Self> {
-        if fill_value.dtype() != values.dtype() {
-            vortex_bail!(
-                "fill value, {:?}, should be instance of values dtype, {}",
-                fill_value,
-                values.dtype(),
-            );
-        }
         if indices.len() != values.len() {
             vortex_bail!(
                 "Mismatched indices {} and values {} length",
@@ -80,18 +66,36 @@ impl SparseArray {
             }
         }
 
-        let indices_ptype = PType::try_from(indices.dtype())?;
+        let patches = Patches::new(len, indices, values);
+
+        Self::try_new_from_patches(patches, len, indices_offset, fill_value)
+    }
+
+    pub fn try_new_from_patches(
+        patches: Patches,
+        len: usize,
+        indices_offset: usize,
+        fill_value: Scalar,
+    ) -> VortexResult<Self> {
+        if fill_value.dtype() != patches.values().dtype() {
+            vortex_bail!(
+                "fill value, {:?}, should be instance of values dtype, {}",
+                fill_value,
+                patches.values().dtype(),
+            );
+        }
+
+        let patches_metadata = patches.to_metadata(len, patches.dtype())?;
 
         Self::try_from_parts(
-            values.dtype().clone(),
+            patches.dtype().clone(),
             len,
             SparseMetadata {
                 indices_offset,
-                indices_len: indices.len(),
-                indices_ptype,
+                patches: patches_metadata,
                 fill_value: fill_value.into_value(),
             },
-            [indices, values].into(),
+            [patches.indices().clone(), patches.values().clone()].into(),
             StatsSet::default(),
         )
     }
@@ -102,108 +106,132 @@ impl SparseArray {
     }
 
     #[inline]
-    pub fn values(&self) -> ArrayData {
-        self.as_ref()
-            .child(1, self.dtype(), self.metadata().indices_len)
-            .vortex_expect("Missing child array in SparseArray")
+    pub fn patches(&self) -> Patches {
+        let indices = self
+            .as_ref()
+            .child(
+                0,
+                &self.metadata().patches.indices_dtype(),
+                self.metadata().patches.len(),
+            )
+            .vortex_expect("Missing indices array in SparseArray");
+        let values = self
+            .as_ref()
+            .child(1, self.dtype(), self.metadata().patches.len())
+            .vortex_expect("Missing values array in SparseArray");
+        Patches::new(self.len(), indices, values)
     }
 
     #[inline]
-    pub fn indices(&self) -> ArrayData {
-        self.as_ref()
-            .child(
-                0,
-                &DType::Primitive(self.metadata().indices_ptype, NonNullable),
-                self.metadata().indices_len,
-            )
-            .vortex_expect("Missing indices array in SparseArray")
+    pub fn resolved_patches(&self) -> VortexResult<Patches> {
+        let (len, indices, values) = self.patches().into_parts();
+        let indices = subtract_scalar(indices, &Scalar::from(self.indices_offset()))?;
+        Ok(Patches::new(len, indices, values))
     }
+
+    // #[inline]
+    // pub fn values(&self) -> ArrayData {
+    //     self.as_ref()
+    //         .child(1, self.dtype(), self.metadata().patches.len())
+    //         .vortex_expect("Missing child array in SparseArray")
+    // }
+
+    // #[inline]
+    // pub fn indices(&self) -> ArrayData {
+    //     self.as_ref()
+    //         .child(
+    //             0,
+    //             &self.metadata().patches.indices_dtype(),
+    //             self.metadata().patches.len(),
+    //         )
+    //         .vortex_expect("Missing indices array in SparseArray")
+    // }
 
     #[inline]
     pub fn fill_scalar(&self) -> Scalar {
         Scalar::new(self.dtype().clone(), self.metadata().fill_value.clone())
     }
 
-    /// Returns the position or the insertion point of a given index in the indices array.
-    fn search_index(&self, index: usize) -> VortexResult<SearchResult> {
-        search_sorted_usize(
-            &self.indices(),
-            self.indices_offset() + index,
-            SearchSortedSide::Left,
-        )
-    }
+    // /// Returns the position or the insertion point of a given index in the indices array.
+    // fn search_index(&self, index: usize) -> VortexResult<SearchResult> {
+    //     search_sorted_usize(
+    //         &self.indices(),
+    //         self.indices_offset() + index,
+    //         SearchSortedSide::Left,
+    //     )
+    // }
 
-    /// Return indices with the indices_offset applied.
-    pub fn resolved_indices(&self) -> VortexResult<ArrayData> {
-        subtract_scalar(self.indices(), &Scalar::from(self.indices_offset()))
-    }
+    // /// Return indices with the indices_offset applied.
+    // pub fn resolved_indices(&self) -> VortexResult<ArrayData> {
+    //     subtract_scalar(self.indices(), &Scalar::from(self.indices_offset()))
+    // }
 
-    /// Return the resolved indices as a `Vec<usize>`.
-    pub fn resolved_indices_usize(&self) -> Vec<usize> {
-        let flat_indices = self
-            .indices()
-            .into_primitive()
-            .vortex_expect("Failed to convert SparseArray indices to primitive array");
-        match_each_integer_ptype!(flat_indices.ptype(), |$P| {
-            flat_indices
-                .maybe_null_slice::<$P>()
-                .iter()
-                .map(|v| (*v as usize) - self.indices_offset())
-                .collect::<Vec<_>>()
-        })
-    }
+    // /// Return the resolved indices as a `Vec<usize>`.
+    // pub fn resolved_indices_usize(&self) -> Vec<usize> {
+    //     let flat_indices = self
+    //         .indices()
+    //         .into_primitive()
+    //         .vortex_expect("Failed to convert SparseArray indices to primitive array");
+    //     match_each_integer_ptype!(flat_indices.ptype(), |$P| {
+    //         flat_indices
+    //             .maybe_null_slice::<$P>()
+    //             .iter()
+    //             .map(|v| (*v as usize) - self.indices_offset())
+    //             .collect::<Vec<_>>()
+    //     })
+    // }
 
-    /// Return the minimum index if indices are present.
-    ///
-    /// If this sparse array has no indices (i.e. all elements are equal to fill_value)
-    /// then it returns None.
-    pub fn min_index(&self) -> Option<usize> {
-        (!self.indices().is_empty()).then(|| {
-            let min_index: usize = scalar_at(self.indices(), 0)
-                .and_then(|s| s.as_ref().try_into())
-                .vortex_expect("SparseArray indices is non-empty");
-            min_index - self.indices_offset()
-        })
-    }
+    // /// Return the minimum index if indices are present.
+    // ///
+    // /// If this sparse array has no indices (i.e. all elements are equal to fill_value)
+    // /// then it returns None.
+    // pub fn min_index(&self) -> Option<usize> {
+    //     (!self.indices().is_empty()).then(|| {
+    //         let min_index: usize = scalar_at(self.indices(), 0)
+    //             .and_then(|s| s.as_ref().try_into())
+    //             .vortex_expect("SparseArray indices is non-empty");
+    //         min_index - self.indices_offset()
+    //     }))
+    // }
 
-    /// Return the maximum index if indices are present.
-    ///
-    /// If this sparse array has no indices (i.e. all elements are equal to fill_value)
-    /// then it returns None.
-    pub fn max_index(&self) -> Option<usize> {
-        (!self.indices().is_empty()).then(|| {
-            let max_index: usize = scalar_at(self.indices(), self.indices().len() - 1)
-                .and_then(|s| s.as_ref().try_into())
-                .vortex_expect("SparseArray indices is non-empty");
-            max_index - self.indices_offset()
-        })
-    }
+    // /// Return the maximum index if indices are present.
+    // ///
+    // /// If this sparse array has no indices (i.e. all elements are equal to fill_value)
+    // /// then it returns None.
+    // pub fn max_index(&self) -> Option<usize> {
+    //     (!self.indices().is_empty()).then(|| {
+    //         let max_index: usize = scalar_at(self.indices(), self.indices().len() - 1)
+    //             .and_then(|s| s.as_ref().try_into())
+    //             .vortex_expect("SparseArray indices is non-empty");
+    //         max_index - self.indices_offset()
+    //     })
+    // }
 }
 
 impl ArrayTrait for SparseArray {}
 
 impl VisitorVTable<SparseArray> for SparseEncoding {
     fn accept(&self, array: &SparseArray, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
-        visitor.visit_child("indices", &array.indices())?;
-        visitor.visit_child("values", &array.values())
+        visitor.visit_patches(&array.patches())
     }
 }
 
 impl StatisticsVTable<SparseArray> for SparseEncoding {
     fn compute_statistics(&self, array: &SparseArray, stat: Stat) -> VortexResult<StatsSet> {
-        let mut stats = array.values().statistics().compute_all(&[stat])?;
-        if array.len() == array.values().len() {
+        let (_, _, values) = array.patches().into_parts();
+        let mut stats = values.statistics().compute_all(&[stat])?;
+        if array.len() == values.len() {
             return Ok(stats);
         }
 
-        let fill_len = array.len() - array.values().len();
+        let fill_len = array.len() - values.len();
         let fill_stats = if array.fill_scalar().is_null() {
             StatsSet::nulls(fill_len, array.dtype())
         } else {
             StatsSet::constant(&array.fill_scalar(), fill_len)
         };
 
-        if array.values().is_empty() {
+        if values.is_empty() {
             return Ok(fill_stats);
         }
 
@@ -214,9 +242,9 @@ impl StatisticsVTable<SparseArray> for SparseEncoding {
 
 impl ValidityVTable<SparseArray> for SparseEncoding {
     fn is_valid(&self, array: &SparseArray, index: usize) -> bool {
-        match array.search_index(index).map(SearchResult::to_found) {
-            Ok(None) => !array.fill_scalar().is_null(),
-            Ok(Some(idx)) => array.values().is_valid(idx),
+        match array.patches().get_patched(index) {
+            Ok(None) => array.fill_scalar().is_valid(),
+            Ok(Some(patch_value)) => patch_value.is_valid(),
             Err(e) => vortex_panic!(e, "Error while finding index {} in sparse array", index),
         }
     }
@@ -225,9 +253,11 @@ impl ValidityVTable<SparseArray> for SparseEncoding {
         let validity = if array.fill_scalar().is_null() {
             // If we have a null fill value, then the result is a Sparse array with a fill_value
             // of true, and patch values of false.
-            SparseArray::try_new_with_offset(
-                array.indices(),
-                ConstantArray::new(true, array.indices().len()).into_array(),
+            SparseArray::try_new_from_patches(
+                array
+                    .patches()
+                    .map_values(|values| Ok(ConstantArray::new(true, values.len()).into_array()))
+                    .vortex_expect("constant array has same length as values array"),
                 array.len(),
                 array.indices_offset(),
                 false.into(),
@@ -235,9 +265,11 @@ impl ValidityVTable<SparseArray> for SparseEncoding {
         } else {
             // If the fill_value is non-null, then the validity is based on the validity of the
             // existing values.
-            SparseArray::try_new_with_offset(
-                array.indices(),
-                array.values().logical_validity().into_array(),
+            SparseArray::try_new_from_patches(
+                array
+                    .patches()
+                    .map_values(|values| Ok(values.logical_validity().into_array()))
+                    .vortex_expect("logical validity preserves length"),
                 array.len(),
                 array.indices_offset(),
                 true.into(),
@@ -281,20 +313,14 @@ mod test {
     }
 
     #[test]
-    pub fn test_find_index() {
-        let sparse = SparseArray::try_from(sparse_array(nullable_fill())).unwrap();
-        assert_eq!(sparse.search_index(0).unwrap().to_found(), None);
-        assert_eq!(sparse.search_index(2).unwrap().to_found(), Some(0));
-        assert_eq!(sparse.search_index(5).unwrap().to_found(), Some(1));
-    }
-
-    #[test]
     pub fn test_scalar_at() {
-        assert_eq!(
-            usize::try_from(&scalar_at(sparse_array(nullable_fill()), 2).unwrap()).unwrap(),
-            100
-        );
-        let error = scalar_at(sparse_array(nullable_fill()), 10).err().unwrap();
+        let array = sparse_array(nullable_fill());
+
+        assert_eq!(scalar_at(&array, 0).unwrap(), nullable_fill());
+        assert_eq!(scalar_at(&array, 2).unwrap(), Scalar::from(Some(100_i32)));
+        assert_eq!(scalar_at(&array, 5).unwrap(), Scalar::from(Some(200_i32)));
+
+        let error = scalar_at(&array, 10).err().unwrap();
         let VortexError::OutOfBounds(i, start, stop, _) = error else {
             unreachable!()
         };

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -145,7 +145,7 @@ impl VisitorVTable<SparseArray> for SparseEncoding {
 
 impl StatisticsVTable<SparseArray> for SparseEncoding {
     fn compute_statistics(&self, array: &SparseArray, stat: Stat) -> VortexResult<StatsSet> {
-        let (_, _, values) = array.patches().into_parts();
+        let values = array.patches().into_values();
         let mut stats = values.statistics().compute_all(&[stat])?;
         if array.len() == values.len() {
             return Ok(stats);

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -129,83 +129,10 @@ impl SparseArray {
         Ok(Patches::new(len, indices, values))
     }
 
-    // #[inline]
-    // pub fn values(&self) -> ArrayData {
-    //     self.as_ref()
-    //         .child(1, self.dtype(), self.metadata().patches.len())
-    //         .vortex_expect("Missing child array in SparseArray")
-    // }
-
-    // #[inline]
-    // pub fn indices(&self) -> ArrayData {
-    //     self.as_ref()
-    //         .child(
-    //             0,
-    //             &self.metadata().patches.indices_dtype(),
-    //             self.metadata().patches.len(),
-    //         )
-    //         .vortex_expect("Missing indices array in SparseArray")
-    // }
-
     #[inline]
     pub fn fill_scalar(&self) -> Scalar {
         Scalar::new(self.dtype().clone(), self.metadata().fill_value.clone())
     }
-
-    // /// Returns the position or the insertion point of a given index in the indices array.
-    // fn search_index(&self, index: usize) -> VortexResult<SearchResult> {
-    //     search_sorted_usize(
-    //         &self.indices(),
-    //         self.indices_offset() + index,
-    //         SearchSortedSide::Left,
-    //     )
-    // }
-
-    // /// Return indices with the indices_offset applied.
-    // pub fn resolved_indices(&self) -> VortexResult<ArrayData> {
-    //     subtract_scalar(self.indices(), &Scalar::from(self.indices_offset()))
-    // }
-
-    // /// Return the resolved indices as a `Vec<usize>`.
-    // pub fn resolved_indices_usize(&self) -> Vec<usize> {
-    //     let flat_indices = self
-    //         .indices()
-    //         .into_primitive()
-    //         .vortex_expect("Failed to convert SparseArray indices to primitive array");
-    //     match_each_integer_ptype!(flat_indices.ptype(), |$P| {
-    //         flat_indices
-    //             .maybe_null_slice::<$P>()
-    //             .iter()
-    //             .map(|v| (*v as usize) - self.indices_offset())
-    //             .collect::<Vec<_>>()
-    //     })
-    // }
-
-    // /// Return the minimum index if indices are present.
-    // ///
-    // /// If this sparse array has no indices (i.e. all elements are equal to fill_value)
-    // /// then it returns None.
-    // pub fn min_index(&self) -> Option<usize> {
-    //     (!self.indices().is_empty()).then(|| {
-    //         let min_index: usize = scalar_at(self.indices(), 0)
-    //             .and_then(|s| s.as_ref().try_into())
-    //             .vortex_expect("SparseArray indices is non-empty");
-    //         min_index - self.indices_offset()
-    //     }))
-    // }
-
-    // /// Return the maximum index if indices are present.
-    // ///
-    // /// If this sparse array has no indices (i.e. all elements are equal to fill_value)
-    // /// then it returns None.
-    // pub fn max_index(&self) -> Option<usize> {
-    //     (!self.indices().is_empty()).then(|| {
-    //         let max_index: usize = scalar_at(self.indices(), self.indices().len() - 1)
-    //             .and_then(|s| s.as_ref().try_into())
-    //             .vortex_expect("SparseArray indices is non-empty");
-    //         max_index - self.indices_offset()
-    //     })
-    // }
 }
 
 impl ArrayTrait for SparseArray {}

--- a/vortex-array/src/array/sparse/variants.rs
+++ b/vortex-array/src/array/sparse/variants.rs
@@ -63,15 +63,17 @@ impl BinaryArrayTrait for SparseArray {}
 
 impl StructArrayTrait for SparseArray {
     fn field(&self, idx: usize) -> Option<ArrayData> {
-        let values = self.values().as_struct_array().and_then(|s| s.field(idx))?;
+        let new_patches = self
+            .patches()
+            .map_values_opt(|values| values.as_struct_array().and_then(|s| s.field(idx)))
+            .vortex_expect("field array length should equal struct array length")?;
         let scalar = StructScalar::try_from(&self.fill_scalar())
             .ok()?
             .field_by_idx(idx)?;
 
         Some(
-            SparseArray::try_new_with_offset(
-                self.indices(),
-                values,
+            SparseArray::try_new_from_patches(
+                new_patches,
                 self.len(),
                 self.indices_offset(),
                 scalar,
@@ -82,21 +84,16 @@ impl StructArrayTrait for SparseArray {
     }
 
     fn project(&self, projection: &[Field]) -> VortexResult<ArrayData> {
-        let values = self
-            .values()
-            .as_struct_array()
-            .ok_or_else(|| vortex_err!("Chunk was not a StructArray"))?
-            .project(projection)?;
+        let new_patches = self.patches().map_values(|values| {
+            values
+                .as_struct_array()
+                .ok_or_else(|| vortex_err!("Chunk was not a StructArray"))?
+                .project(projection)
+        })?;
         let scalar = StructScalar::try_from(&self.fill_scalar())?.project(projection)?;
 
-        SparseArray::try_new_with_offset(
-            self.indices(),
-            values,
-            self.len(),
-            self.indices_offset(),
-            scalar,
-        )
-        .map(|a| a.into_array())
+        SparseArray::try_new_from_patches(new_patches, self.len(), self.indices_offset(), scalar)
+            .map(|a| a.into_array())
     }
 }
 
@@ -104,12 +101,15 @@ impl ListArrayTrait for SparseArray {}
 
 impl ExtensionArrayTrait for SparseArray {
     fn storage_data(&self) -> ArrayData {
-        SparseArray::try_new_with_offset(
-            self.indices(),
-            self.values()
-                .as_extension_array()
-                .vortex_expect("Expected extension array")
-                .storage_data(),
+        SparseArray::try_new_from_patches(
+            self.patches()
+                .map_values(|values| {
+                    Ok(values
+                        .as_extension_array()
+                        .vortex_expect("Expected extension array")
+                        .storage_data())
+                })
+                .vortex_expect("as_extension_array preserves the length"),
             self.len(),
             self.indices_offset(),
             self.fill_scalar(),

--- a/vortex-array/src/array/sparse/variants.rs
+++ b/vortex-array/src/array/sparse/variants.rs
@@ -93,7 +93,7 @@ impl StructArrayTrait for SparseArray {
         let scalar = StructScalar::try_from(&self.fill_scalar())?.project(projection)?;
 
         SparseArray::try_new_from_patches(new_patches, self.len(), self.indices_offset(), scalar)
-            .map(|a| a.into_array())
+            .map(IntoArrayData::into_array)
     }
 }
 

--- a/vortex-array/src/compute/search_sorted.rs
+++ b/vortex-array/src/compute/search_sorted.rs
@@ -84,6 +84,18 @@ impl SearchResult {
             idx
         }
     }
+
+    /// Apply a transformation to the Found or NotFound index.
+    #[inline]
+    pub fn map<F>(self, f: F) -> SearchResult
+    where
+        F: FnOnce(usize) -> usize,
+    {
+        match self {
+            SearchResult::Found(i) => SearchResult::Found(f(i)),
+            SearchResult::NotFound(i) => SearchResult::NotFound(f(i)),
+        }
+    }
 }
 
 impl Display for SearchResult {

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -348,7 +348,6 @@ impl Patches {
             .filter_map(|(new_sparse_index, take_sparse_index)| {
                 sparse_index_to_value_index
                     .get(&I::usize_as(take_sparse_index.as_usize()))
-                    // FIXME(DK): should we choose a small index width or should the compressor do that?
                     .map(|value_index| (new_sparse_index as u64, *value_index as u64))
             })
             .unzip();

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -307,11 +307,7 @@ impl Patches {
         let take_indices = try_cast(
             take_indices,
             &DType::Primitive(
-                take_indices
-                    .dtype()
-                    .as_ptype()
-                    .vortex_expect("indices must be primitive")
-                    .to_unsigned(),
+                PType::try_from(take_indices.dtype())?.to_unsigned(),
                 NonNullable,
             ),
         )?

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -1,11 +1,15 @@
 use std::fmt::Debug;
+use std::hash::Hash;
 
 use serde::{Deserialize, Serialize};
 use vortex_dtype::Nullability::NonNullable;
-use vortex_dtype::{match_each_integer_ptype, DType, PType};
+use vortex_dtype::{
+    match_each_integer_ptype, match_each_unsigned_integer_ptype, DType, NativeIndexPType, PType,
+};
 use vortex_error::{vortex_bail, VortexExpect, VortexResult};
 use vortex_scalar::Scalar;
 
+use crate::aliases::hash_map::HashMap;
 use crate::array::PrimitiveArray;
 use crate::compute::{
     scalar_at, search_sorted, search_sorted_usize, search_sorted_usize_many, slice,
@@ -35,6 +39,10 @@ impl PatchesMetadata {
 
     #[inline]
     pub fn indices_dtype(&self) -> DType {
+        assert!(
+            self.indices_ptype.is_unsigned_int(),
+            "Patch indices must be unsigned integers"
+        );
         DType::Primitive(self.indices_ptype, NonNullable)
     }
 }
@@ -54,7 +62,10 @@ impl Patches {
             values.len(),
             "Patch indices and values must have the same length"
         );
-        assert!(indices.dtype().is_int(), "Patch indices must be integers");
+        assert!(
+            indices.dtype().is_unsigned_int(),
+            "Patch indices must be unsigned integers"
+        );
         assert!(
             indices.len() <= array_len,
             "Patch indices must be shorter than the array length"
@@ -75,6 +86,10 @@ impl Patches {
         }
     }
 
+    pub fn into_parts(self) -> (usize, ArrayData, ArrayData) {
+        (self.array_len, self.indices, self.values)
+    }
+
     pub fn array_len(&self) -> usize {
         self.array_len
     }
@@ -91,8 +106,16 @@ impl Patches {
         &self.indices
     }
 
+    pub fn into_indices(self) -> ArrayData {
+        self.indices
+    }
+
     pub fn values(&self) -> &ArrayData {
         &self.values
+    }
+
+    pub fn into_values(self) -> ArrayData {
+        self.values
     }
 
     pub fn indices_ptype(&self) -> PType {
@@ -122,13 +145,16 @@ impl Patches {
 
     /// Get the patched value at a given index if it exists.
     pub fn get_patched(&self, index: usize) -> VortexResult<Option<Scalar>> {
-        if let Some(patch_idx) =
-            search_sorted_usize(self.indices(), index, SearchSortedSide::Left)?.to_found()
-        {
+        if let Some(patch_idx) = self.search_index(index)?.to_found() {
             scalar_at(self.values(), patch_idx).map(Some)
         } else {
             Ok(None)
         }
+    }
+
+    /// Return the insertion point of [index] in the [Self::indices].
+    fn search_index(&self, index: usize) -> VortexResult<SearchResult> {
+        search_sorted_usize(&self.indices, index, SearchSortedSide::Left)
     }
 
     /// Return the search_sorted result for the given target re-mapped into the original indices.
@@ -201,10 +227,8 @@ impl Patches {
 
     /// Slice the patches by a range of the patched array.
     pub fn slice(&self, start: usize, stop: usize) -> VortexResult<Option<Self>> {
-        let patch_start =
-            search_sorted_usize(self.indices(), start, SearchSortedSide::Left)?.to_index();
-        let patch_stop =
-            search_sorted_usize(self.indices(), stop, SearchSortedSide::Left)?.to_index();
+        let patch_start = self.search_index(start)?.to_index();
+        let patch_stop = self.search_index(stop)?.to_index();
 
         if patch_start == patch_stop {
             return Ok(None);
@@ -220,15 +244,33 @@ impl Patches {
         Ok(Some(Self::new(stop - start, indices, values)))
     }
 
+    // https://docs.google.com/spreadsheets/d/1D9vBZ1QJ6mwcIvV5wIL0hjGgVchcEnAyhvitqWu2ugU
+    const PREFER_MAP_WHEN_PATCHES_OVER_INDICES_LESS_THAN: f64 = 5.0;
+
+    fn is_map_faster_than_search(&self, take_indices: &ArrayData) -> bool {
+        (self.num_patches() as f64 / take_indices.len() as f64)
+            < Self::PREFER_MAP_WHEN_PATCHES_OVER_INDICES_LESS_THAN
+    }
+
     /// Take the indices from the patches.
-    pub fn take(&self, indices: &ArrayData) -> VortexResult<Option<Self>> {
-        if indices.is_empty() {
+    pub fn take(&self, take_indices: &ArrayData) -> VortexResult<Option<Self>> {
+        if self.is_map_faster_than_search(take_indices) {
+            self.take_map(take_indices)
+        } else {
+            self.take_search(take_indices)
+        }
+    }
+
+    pub fn take_search(&self, take_indices: &ArrayData) -> VortexResult<Option<Self>> {
+        let new_length = take_indices.len();
+
+        if take_indices.is_empty() {
             return Ok(None);
         }
 
         // TODO(ngates): plenty of optimisations to be made here
         let take_indices =
-            try_cast(indices, &DType::Primitive(PType::U64, NonNullable))?.into_primitive()?;
+            try_cast(take_indices, &DType::Primitive(PType::U64, NonNullable))?.into_primitive()?;
 
         let (values_indices, new_indices): (Vec<u64>, Vec<u64>) = search_sorted_usize_many(
             self.indices(),
@@ -258,7 +300,104 @@ impl Patches {
             PrimitiveArray::from_vec(values_indices, Validity::NonNullable).into_array();
         let new_values = take(self.values(), values_indices)?;
 
-        Ok(Some(Self::new(indices.len(), new_indices, new_values)))
+        Ok(Some(Self::new(new_length, new_indices, new_values)))
+    }
+
+    pub fn take_map(&self, take_indices: &ArrayData) -> VortexResult<Option<Self>> {
+        let take_indices = try_cast(
+            take_indices,
+            &DType::Primitive(
+                take_indices
+                    .dtype()
+                    .as_ptype()
+                    .vortex_expect("indices must be primitive")
+                    .to_unsigned(),
+                NonNullable,
+            ),
+        )?
+        .into_primitive()?;
+        match_each_unsigned_integer_ptype!(self.indices_ptype(), |$INDICES| {
+            let indices = self.indices
+                .clone()
+                .into_primitive()?;
+            let indices = indices
+                .maybe_null_slice::<$INDICES>();
+            match_each_unsigned_integer_ptype!(take_indices.ptype(), |$TAKE_INDICES| {
+                let take_indices = take_indices
+                    .into_primitive()?;
+                let take_indices = take_indices
+                    .maybe_null_slice::<$TAKE_INDICES>();
+                return self.take_map_helper(indices, take_indices);
+            });
+        });
+    }
+
+    fn take_map_helper<I: NativeIndexPType + Hash + Eq, TI: NativeIndexPType>(
+        &self,
+        indices: &[I],
+        take_indices: &[TI],
+    ) -> VortexResult<Option<Self>> {
+        let new_length = take_indices.len();
+        let sparse_index_to_value_index: HashMap<I, usize> = indices
+            .iter()
+            .enumerate()
+            .map(|(value_index, sparse_index)| (*sparse_index, value_index))
+            .collect();
+        let min_index = self.min_index()?;
+        let max_index = self.max_index()?;
+        let (new_sparse_indices, value_indices): (Vec<u64>, Vec<u64>) = take_indices
+            .iter()
+            .enumerate()
+            .filter(|(_, ti)| ti.as_usize() >= min_index && ti.as_usize() <= max_index)
+            .filter_map(|(new_sparse_index, take_sparse_index)| {
+                sparse_index_to_value_index
+                    .get(&I::usize_as(take_sparse_index.as_usize()))
+                    // FIXME(DK): should we choose a small index width or should the compressor do that?
+                    .map(|value_index| (new_sparse_index as u64, *value_index as u64))
+            })
+            .unzip();
+
+        if new_sparse_indices.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(Patches::new(
+            new_length,
+            ArrayData::from(new_sparse_indices),
+            take(self.values(), ArrayData::from(value_indices))?,
+        )))
+    }
+
+    pub fn map_values<F>(self, f: F) -> VortexResult<Self>
+    where
+        F: FnOnce(ArrayData) -> VortexResult<ArrayData>,
+    {
+        let values = f(self.values)?;
+        if self.indices.len() != values.len() {
+            vortex_bail!(
+                "map_values must preserve length: expected {} received {}",
+                self.indices.len(),
+                values.len()
+            )
+        }
+        Ok(Self::new(self.array_len, self.indices, values))
+    }
+
+    pub fn map_values_opt<F>(self, f: F) -> VortexResult<Option<Self>>
+    where
+        F: FnOnce(ArrayData) -> Option<ArrayData>,
+    {
+        let Some(values) = f(self.values) else {
+            return Ok(None);
+        };
+        if self.indices.len() == values.len() {
+            vortex_bail!(
+                "map_values must preserve length: expected {} received {}",
+                self.indices.len(),
+                values.len()
+            )
+        }
+        Ok(Some(Self::new(self.array_len, self.indices, values)))
     }
 }
 

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -298,15 +298,11 @@ impl Patches {
     }
 
     pub fn take_map(&self, take_indices: PrimitiveArray) -> VortexResult<Option<Self>> {
+        let indices = self.indices.clone().into_primitive()?;
         match_each_integer_ptype!(self.indices_ptype(), |$INDICES| {
-            let indices = self.indices
-                .clone()
-                .into_primitive()?;
             let indices = indices
                 .maybe_null_slice::<$INDICES>();
             match_each_integer_ptype!(take_indices.ptype(), |$TAKE_INDICES| {
-                let take_indices = take_indices
-                    .into_primitive()?;
                 let take_indices = take_indices
                     .maybe_null_slice::<$TAKE_INDICES>();
 

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -1,11 +1,9 @@
 use std::fmt::Debug;
-use std::hash::Hash;
 
+use itertools::Itertools as _;
 use serde::{Deserialize, Serialize};
 use vortex_dtype::Nullability::NonNullable;
-use vortex_dtype::{
-    match_each_integer_ptype, match_each_unsigned_integer_ptype, DType, NativeIndexPType, PType,
-};
+use vortex_dtype::{match_each_integer_ptype, DType, PType};
 use vortex_error::{vortex_bail, VortexExpect, VortexResult};
 use vortex_scalar::Scalar;
 
@@ -13,12 +11,12 @@ use crate::aliases::hash_map::HashMap;
 use crate::array::PrimitiveArray;
 use crate::compute::{
     scalar_at, search_sorted, search_sorted_usize, search_sorted_usize_many, slice,
-    subtract_scalar, take, try_cast, FilterMask, SearchResult, SearchSortedSide,
+    subtract_scalar, take, FilterMask, SearchResult, SearchSortedSide,
 };
 use crate::stats::{ArrayStatistics, Stat};
 use crate::validity::Validity;
 use crate::variants::PrimitiveArrayTrait;
-use crate::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
+use crate::{ArrayDType, ArrayData, ArrayLen as _, IntoArrayData, IntoArrayVariant};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PatchesMetadata {
@@ -247,48 +245,44 @@ impl Patches {
     // https://docs.google.com/spreadsheets/d/1D9vBZ1QJ6mwcIvV5wIL0hjGgVchcEnAyhvitqWu2ugU
     const PREFER_MAP_WHEN_PATCHES_OVER_INDICES_LESS_THAN: f64 = 5.0;
 
-    fn is_map_faster_than_search(&self, take_indices: &ArrayData) -> bool {
+    fn is_map_faster_than_search(&self, take_indices: &PrimitiveArray) -> bool {
         (self.num_patches() as f64 / take_indices.len() as f64)
             < Self::PREFER_MAP_WHEN_PATCHES_OVER_INDICES_LESS_THAN
     }
 
     /// Take the indices from the patches.
     pub fn take(&self, take_indices: &ArrayData) -> VortexResult<Option<Self>> {
-        if self.is_map_faster_than_search(take_indices) {
+        if take_indices.is_empty() {
+            return Ok(None);
+        }
+        let take_indices = take_indices.clone().into_primitive()?;
+        if self.is_map_faster_than_search(&take_indices) {
             self.take_map(take_indices)
         } else {
             self.take_search(take_indices)
         }
     }
 
-    pub fn take_search(&self, take_indices: &ArrayData) -> VortexResult<Option<Self>> {
+    pub fn take_search(&self, take_indices: PrimitiveArray) -> VortexResult<Option<Self>> {
         let new_length = take_indices.len();
-
-        if take_indices.is_empty() {
-            return Ok(None);
-        }
-
-        // TODO(ngates): plenty of optimisations to be made here
-        let take_indices =
-            try_cast(take_indices, &DType::Primitive(PType::U64, NonNullable))?.into_primitive()?;
-
-        let (values_indices, new_indices): (Vec<u64>, Vec<u64>) = search_sorted_usize_many(
-            self.indices(),
-            &take_indices
-                .into_maybe_null_slice::<u64>()
+        let take_indices = match_each_integer_ptype!(take_indices.ptype(), |$P| {
+            take_indices
+                .into_maybe_null_slice::<$P>()
                 .into_iter()
                 .map(usize::try_from)
-                .collect::<Result<Vec<_>, _>>()?,
-            SearchSortedSide::Left,
-        )?
-        .iter()
-        .enumerate()
-        .filter_map(|(idx_in_take, search_result)| {
-            search_result
-                .to_found()
-                .map(|patch_idx| (patch_idx as u64, idx_in_take as u64))
-        })
-        .unzip();
+                .collect::<Result<Vec<_>, _>>()?
+        });
+
+        let (values_indices, new_indices): (Vec<u64>, Vec<u64>) =
+            search_sorted_usize_many(self.indices(), &take_indices, SearchSortedSide::Left)?
+                .iter()
+                .enumerate()
+                .filter_map(|(idx_in_take, search_result)| {
+                    search_result
+                        .to_found()
+                        .map(|patch_idx| (patch_idx as u64, idx_in_take as u64))
+                })
+                .unzip();
 
         if new_indices.is_empty() {
             return Ok(None);
@@ -303,64 +297,56 @@ impl Patches {
         Ok(Some(Self::new(new_length, new_indices, new_values)))
     }
 
-    pub fn take_map(&self, take_indices: &ArrayData) -> VortexResult<Option<Self>> {
-        let take_indices = try_cast(
-            take_indices,
-            &DType::Primitive(
-                PType::try_from(take_indices.dtype())?.to_unsigned(),
-                NonNullable,
-            ),
-        )?
-        .into_primitive()?;
-        match_each_unsigned_integer_ptype!(self.indices_ptype(), |$INDICES| {
+    pub fn take_map(&self, take_indices: PrimitiveArray) -> VortexResult<Option<Self>> {
+        match_each_integer_ptype!(self.indices_ptype(), |$INDICES| {
             let indices = self.indices
                 .clone()
                 .into_primitive()?;
             let indices = indices
                 .maybe_null_slice::<$INDICES>();
-            match_each_unsigned_integer_ptype!(take_indices.ptype(), |$TAKE_INDICES| {
+            match_each_integer_ptype!(take_indices.ptype(), |$TAKE_INDICES| {
                 let take_indices = take_indices
                     .into_primitive()?;
                 let take_indices = take_indices
                     .maybe_null_slice::<$TAKE_INDICES>();
-                return self.take_map_helper(indices, take_indices);
-            });
-        });
-    }
 
-    fn take_map_helper<I: NativeIndexPType + Hash + Eq, TI: NativeIndexPType>(
-        &self,
-        indices: &[I],
-        take_indices: &[TI],
-    ) -> VortexResult<Option<Self>> {
-        let new_length = take_indices.len();
-        let sparse_index_to_value_index: HashMap<I, usize> = indices
-            .iter()
-            .enumerate()
-            .map(|(value_index, sparse_index)| (*sparse_index, value_index))
-            .collect();
-        let min_index = self.min_index()?;
-        let max_index = self.max_index()?;
-        let (new_sparse_indices, value_indices): (Vec<u64>, Vec<u64>) = take_indices
-            .iter()
-            .enumerate()
-            .filter(|(_, ti)| ti.as_usize() >= min_index && ti.as_usize() <= max_index)
-            .filter_map(|(new_sparse_index, take_sparse_index)| {
-                sparse_index_to_value_index
-                    .get(&I::usize_as(take_sparse_index.as_usize()))
-                    .map(|value_index| (new_sparse_index as u64, *value_index as u64))
+                let new_length = take_indices.len();
+                let sparse_index_to_value_index: HashMap<$INDICES, usize> = indices
+                    .iter()
+                    .enumerate()
+                    .map(|(value_index, sparse_index)| (*sparse_index, value_index))
+                    .collect();
+                let min_index = self.min_index()?;
+                let max_index = self.max_index()?;
+                let (new_sparse_indices, value_indices): (Vec<u64>, Vec<u64>) =
+                    take_indices
+                    .iter()
+                    .map(|x| usize::try_from(*x))
+                    .process_results(|iter| {
+                        iter
+                           .enumerate()
+                           .filter(|(_, ti)| *ti >= min_index && *ti <= max_index)
+                           .filter_map(|(new_sparse_index, take_sparse_index)| {
+                               sparse_index_to_value_index
+                                   .get(&<$INDICES>::try_from(take_sparse_index).ok().vortex_expect(
+                                       "take_sparse_index is between min and max index",
+                                   ))
+                                   .map(|value_index| (new_sparse_index as u64, *value_index as u64))
+                           })
+                           .unzip()
+                    })?;
+
+                if new_sparse_indices.is_empty() {
+                    return Ok(None);
+                }
+
+                Ok(Some(Patches::new(
+                    new_length,
+                    ArrayData::from(new_sparse_indices),
+                    take(self.values(), ArrayData::from(value_indices))?,
+                )))
             })
-            .unzip();
-
-        if new_sparse_indices.is_empty() {
-            return Ok(None);
-        }
-
-        Ok(Some(Patches::new(
-            new_length,
-            ArrayData::from(new_sparse_indices),
-            take(self.values(), ArrayData::from(value_indices))?,
-        )))
+        })
     }
 
     pub fn map_values<F>(self, f: F) -> VortexResult<Self>

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -140,14 +140,6 @@ impl DType {
             _ => None,
         }
     }
-
-    /// Get the `PType` if `self` is a `PType`, otherwise `None`
-    pub fn as_ptype(&self) -> Option<&PType> {
-        match self {
-            Primitive(p, _) => Some(p),
-            _ => None,
-        }
-    }
 }
 
 impl Display for DType {

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -140,6 +140,14 @@ impl DType {
             _ => None,
         }
     }
+
+    /// Get the `PType` if `self` is a `PType`, otherwise `None`
+    pub fn as_ptype(&self) -> Option<&PType> {
+        match self {
+            Primitive(p, _) => Some(p),
+            _ => None,
+        }
+    }
 }
 
 impl Display for DType {

--- a/vortex-dtype/src/ptype.rs
+++ b/vortex-dtype/src/ptype.rs
@@ -75,40 +75,6 @@ pub trait NativePType:
     fn is_eq(self, other: Self) -> bool;
 }
 
-/// A trait for native Rust types that correspond 1:1 to a PType used for indexing.
-///
-/// Vortex assumes that every value used as an index is representable as both a usize and a u64.
-pub trait NativeIndexPType: NativePType {
-    /// Convert this value to a usize.
-    ///
-    /// # Safety
-    ///
-    /// 1. Assumes that the value is a valid index into an array on this machine.
-    fn as_usize(self) -> usize;
-
-    /// Convert this value to a u64.
-    ///
-    /// # Safety
-    ///
-    /// 1. Assumes that the value is a valid index into an array on this machine.
-    /// 2. Assumes this machine's pointers are not larger than u64.
-    fn as_u64(self) -> u64;
-
-    /// Convert a usize to this type.
-    ///
-    /// # Safety
-    ///
-    /// 1. Assumes that the value is small enough to fit in this type.
-    fn usize_as(value: usize) -> Self;
-
-    /// Convert a u64 to this type.
-    ///
-    /// # Safety
-    ///
-    /// 1. Assumes that the value is small enough to fit in this type.
-    fn u64_as(value: u64) -> Self;
-}
-
 macro_rules! native_ptype {
     ($T:ty, $ptype:tt) => {
         impl NativePType for $T {
@@ -124,31 +90,6 @@ macro_rules! native_ptype {
 
             fn is_eq(self, other: Self) -> bool {
                 self == other
-            }
-        }
-    };
-}
-
-macro_rules! native_index_ptype {
-    ($T:ty, $ptype:tt) => {
-        native_ptype!($T, $ptype);
-
-        #[allow(clippy::cast_possible_truncation)]
-        impl NativeIndexPType for $T {
-            fn as_usize(self) -> usize {
-                self as usize
-            }
-
-            fn as_u64(self) -> u64 {
-                self as u64
-            }
-
-            fn usize_as(value: usize) -> Self {
-                value as Self
-            }
-
-            fn u64_as(value: u64) -> Self {
-                value as Self
             }
         }
     };
@@ -174,10 +115,10 @@ macro_rules! native_float_ptype {
     };
 }
 
-native_index_ptype!(u8, U8);
-native_index_ptype!(u16, U16);
-native_index_ptype!(u32, U32);
-native_index_ptype!(u64, U64);
+native_ptype!(u8, U8);
+native_ptype!(u16, U16);
+native_ptype!(u32, U32);
+native_ptype!(u64, U64);
 native_ptype!(i8, I8);
 native_ptype!(i16, I16);
 native_ptype!(i32, I32);

--- a/vortex-dtype/src/ptype.rs
+++ b/vortex-dtype/src/ptype.rs
@@ -75,6 +75,40 @@ pub trait NativePType:
     fn is_eq(self, other: Self) -> bool;
 }
 
+/// A trait for native Rust types that correspond 1:1 to a PType used for indexing.
+///
+/// Vortex assumes that every value used as an index is representable as both a usize and a u64.
+pub trait NativeIndexPType: NativePType {
+    /// Convert this value to a usize.
+    ///
+    /// # Safety
+    ///
+    /// 1. Assumes that the value is a valid index into an array on this machine.
+    fn as_usize(self) -> usize;
+
+    /// Convert this value to a u64.
+    ///
+    /// # Safety
+    ///
+    /// 1. Assumes that the value is a valid index into an array on this machine.
+    /// 2. Assumes this machine's pointers are not larger than u64.
+    fn as_u64(self) -> u64;
+
+    /// Convert a usize to this type.
+    ///
+    /// # Safety
+    ///
+    /// 1. Assumes that the value is small enough to fit in this type.
+    fn usize_as(value: usize) -> Self;
+
+    /// Convert a u64 to this type.
+    ///
+    /// # Safety
+    ///
+    /// 1. Assumes that the value is small enough to fit in this type.
+    fn u64_as(value: u64) -> Self;
+}
+
 macro_rules! native_ptype {
     ($T:ty, $ptype:tt) => {
         impl NativePType for $T {
@@ -90,6 +124,31 @@ macro_rules! native_ptype {
 
             fn is_eq(self, other: Self) -> bool {
                 self == other
+            }
+        }
+    };
+}
+
+macro_rules! native_index_ptype {
+    ($T:ty, $ptype:tt) => {
+        native_ptype!($T, $ptype);
+
+        #[allow(clippy::cast_possible_truncation)]
+        impl NativeIndexPType for $T {
+            fn as_usize(self) -> usize {
+                self as usize
+            }
+
+            fn as_u64(self) -> u64 {
+                self as u64
+            }
+
+            fn usize_as(value: usize) -> Self {
+                value as Self
+            }
+
+            fn u64_as(value: u64) -> Self {
+                value as Self
             }
         }
     };
@@ -115,10 +174,10 @@ macro_rules! native_float_ptype {
     };
 }
 
-native_ptype!(u8, U8);
-native_ptype!(u16, U16);
-native_ptype!(u32, U32);
-native_ptype!(u64, U64);
+native_index_ptype!(u8, U8);
+native_index_ptype!(u16, U16);
+native_index_ptype!(u32, U32);
+native_index_ptype!(u64, U64);
 native_ptype!(i8, I8);
 native_ptype!(i16, I16);
 native_ptype!(i32, I32);

--- a/vortex-error/src/lib.rs
+++ b/vortex-error/src/lib.rs
@@ -9,6 +9,7 @@ pub mod python;
 
 use std::backtrace::Backtrace;
 use std::borrow::Cow;
+use std::convert::Infallible;
 use std::fmt::{Debug, Display, Formatter};
 use std::num::TryFromIntError;
 use std::ops::Deref;
@@ -50,6 +51,12 @@ impl Deref for ErrString {
 impl Display for ErrString {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Display::fmt(&self.0, f)
+    }
+}
+
+impl From<Infallible> for VortexError {
+    fn from(_: Infallible) -> Self {
+        unreachable!()
     }
 }
 


### PR DESCRIPTION
A second attempt at https://github.com/spiraldb/vortex/pull/1626 with fixes from https://github.com/spiraldb/vortex/pull/1628 as well as the transition of ALPRD and SparseArray
to use Patches.

---

See [this sheet for the data from take_patches.rs] https://docs.google.com/spreadsheets/d/1D9vBZ1QJ6mwcIvV5wIL0hjGgVchcEnAyhvitqWu2ugU). I'm on an M3 Max with 96 GiB of RAM with macOS 14.4. This threshold likely depends on the ISA.

Intuitively, repeated searching is `O(N_INDICES * lg N_PATCHES)` and repeated map lookups is `O(N_INDICES + N_PATCHES)`. It seems to me that the compiler & CPU would have trouble paralleling search (via SIMD or
ILP) because of the branching, whereas map lookups are more obviously parallelized (e.g. SIMD hash computation). I'm not entirely sure why the cross over point seems to be around N_PATCHES / N_INDICES = 5. I believe the M3 Max has 128-bit registers, so if the indices are 32-bits then index arithmetic could be 4-way parallel.