### PR TITLE
Correct condition for Validity.patch

### DIFF
--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -297,7 +297,8 @@ impl Validity {
     pub fn patch(self, len: usize, indices: &ArrayData, patches: Validity) -> VortexResult<Self> {
         match (&self, &patches) {
             (Validity::NonNullable, Validity::NonNullable) => return Ok(Validity::NonNullable),
-            (Validity::NonNullable, _) => {
+            (Validity::NonNullable, Validity::AllInvalid)
+            | (Validity::NonNullable, Validity::Array(_)) => {
                 vortex_bail!("Can't patch a non-nullable validity with nullable validity")
             }
             (_, Validity::NonNullable) => {


### PR DESCRIPTION
Seems like the rhs of validity.patch can be `AllValid` when the lhs is `NonNullable`. For example, in ALP compress: https://github.com/spiraldb/vortex/blob/60b4978497361ea8b99ac1e218468a12dfd59dc8/encodings/alp/src/alp/compress.rs#L37-L40

In [the previous commit](https://github.com/spiraldb/vortex/pull/1601/files#diff-e380a33cbf872e1375394ea26f9f6b3416ef5960e9f4545bd5c215548702f3abL284-L286), this condition is set to be `patches.null_count(positions.len())? > 0`, which also excludes the `AllValid` case. I encountered this issue with a random file. 

cc @gatesn 