### PR TITLE
Compile locally with target-cpu=native

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,11 +4,13 @@
 rustflags = [
     "-C", "link-arg=-undefined",
     "-C", "link-arg=dynamic_lookup",
+    "-C", "target-cpu=native",
 ]
 [target.x86_64-apple-darwin]
 rustflags = [
     "-C", "link-arg=-undefined",
     "-C", "link-arg=dynamic_lookup",
+    "-C", "target-cpu=native",
 ]
 
 [alias]


### PR DESCRIPTION
This makes a big difference when running datafusion with parquet