### PR TITLE
ci: actually run with wasm32-unknown-unknown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
       - name: Rust Build vortex
-        run: cargo build -p vortex
+        run: cargo build -p vortex --target wasm32-unknown-unknown
 
 
   build-all:

--- a/vortex-io/src/dispatcher/mod.rs
+++ b/vortex-io/src/dispatcher/mod.rs
@@ -10,7 +10,7 @@ use std::task::Poll;
 
 use futures::channel::oneshot;
 use futures::FutureExt;
-#[cfg(not(any(feature = "compio", feature = "tokio")))]
+#[cfg(not(any(feature = "compio", feature = "tokio", target_arch = "wasm32")))]
 use vortex_error::vortex_panic;
 use vortex_error::{vortex_err, VortexResult};
 

--- a/vortex-io/src/dispatcher/wasm.rs
+++ b/vortex-io/src/dispatcher/wasm.rs
@@ -3,11 +3,10 @@
 use std::future::Future;
 
 use futures::channel::oneshot;
-use futures::channel::oneshot::Receiver;
 use vortex_error::{vortex_panic, VortexResult};
 use wasm_bindgen_futures::wasm_bindgen::__rt::Start;
 
-use crate::{Dispatch, JoinHandle as VortexJoinHandle};
+use super::{Dispatch, JoinHandle as VortexJoinHandle};
 
 /// `Dispatch`able type that is available when running Vortex in the browser or other WASM env.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
I thought setting the toolchain was enough but apparently not.

I also fixed a couple of small WASM32 compile errors that had snuck in since last week.