### PR TITLE
Cheaper `maybe_from`

### DIFF
--- a/bench-vortex/benches/compress.rs
+++ b/bench-vortex/benches/compress.rs
@@ -104,7 +104,7 @@ fn parquet_decompress_read(buf: bytes::Bytes) -> usize {
 }
 
 fn parquet_compressed_written_size(array: &ArrayData, compression: Compression) -> usize {
-    let chunked = ChunkedArray::maybe_from(array.clone()).unwrap();
+    let chunked = ChunkedArray::maybe_from(array).unwrap();
     let (batches, schema) = chunked_to_vec_record_batch(chunked);
     parquet_compress_write(batches, schema, compression, &mut Vec::new())
 }

--- a/vortex-array/src/array/extension/compute/compare.rs
+++ b/vortex-array/src/array/extension/compute/compare.rs
@@ -23,7 +23,7 @@ impl CompareFn<ExtensionArray> for ExtensionEncoding {
         }
 
         // If the RHS is an extension array matching ours, we can extract the storage.
-        if let Some(rhs_ext) = ExtensionArray::maybe_from(rhs.clone()) {
+        if let Some(rhs_ext) = ExtensionArray::maybe_from(rhs) {
             return compare(lhs.storage(), rhs_ext.storage(), operator).map(Some);
         }
 

--- a/vortex-array/src/macros.rs
+++ b/vortex-array/src/macros.rs
@@ -64,8 +64,9 @@ macro_rules! impl_encoding {
                 ///
                 /// Preferred in cases where a backtrace isn't needed, like when trying multiple encoding to go
                 /// down different code paths.
-                pub fn maybe_from(data: $crate::ArrayData) -> Option<Self> {
-                    (data.encoding().id() == <[<$Name Encoding>] as $crate::encoding::Encoding>::ID).then_some(Self(data))
+                pub fn maybe_from(data: impl AsRef<$crate::ArrayData>) -> Option<Self> {
+                    let data = data.as_ref();
+                    (data.encoding().id() == <[<$Name Encoding>] as $crate::encoding::Encoding>::ID).then_some(Self(data.clone()))
                 }
             }
 

--- a/vortex-ipc/src/stream_writer/mod.rs
+++ b/vortex-ipc/src/stream_writer/mod.rs
@@ -82,7 +82,7 @@ impl<W: VortexWrite> StreamArrayWriter<W> {
     }
 
     pub async fn write_array(self, array: ArrayData) -> VortexResult<Self> {
-        if let Some(chunked_array) = ChunkedArray::maybe_from(array.clone()) {
+        if let Some(chunked_array) = ChunkedArray::maybe_from(&array) {
             self.write_array_stream(chunked_array.array_stream()).await
         } else {
             self.write_array_stream(array.into_array_stream()).await

--- a/vortex-sampling-compressor/src/compressors/alp.rs
+++ b/vortex-sampling-compressor/src/compressors/alp.rs
@@ -28,7 +28,7 @@ impl EncodingCompressor for ALPCompressor {
 
     fn can_compress(&self, array: &ArrayData) -> Option<&dyn EncodingCompressor> {
         // Only support primitive arrays
-        let parray = PrimitiveArray::maybe_from(array.clone())?;
+        let parray = PrimitiveArray::maybe_from(array)?;
 
         // Only supports f32 and f64
         if !matches!(parray.ptype(), PType::F32 | PType::F64) {

--- a/vortex-sampling-compressor/src/compressors/alp_rd.rs
+++ b/vortex-sampling-compressor/src/compressors/alp_rd.rs
@@ -34,7 +34,7 @@ impl EncodingCompressor for ALPRDCompressor {
 
     fn can_compress(&self, array: &ArrayData) -> Option<&dyn EncodingCompressor> {
         // Only support primitive arrays
-        let parray = PrimitiveArray::maybe_from(array.clone())?;
+        let parray = PrimitiveArray::maybe_from(array)?;
 
         // Only supports f32 and f64
         if !matches!(parray.ptype(), PType::F32 | PType::F64) {

--- a/vortex-sampling-compressor/src/compressors/bitpacked.rs
+++ b/vortex-sampling-compressor/src/compressors/bitpacked.rs
@@ -55,7 +55,7 @@ impl EncodingCompressor for BitPackedCompressor {
 
     fn can_compress(&self, array: &ArrayData) -> Option<&dyn EncodingCompressor> {
         // Only support primitive arrays
-        let parray = PrimitiveArray::maybe_from(array.clone())?;
+        let parray = PrimitiveArray::maybe_from(array)?;
 
         // Only supports unsigned ints
         if !parray.ptype().is_unsigned_int() {

--- a/vortex-sampling-compressor/src/compressors/delta.rs
+++ b/vortex-sampling-compressor/src/compressors/delta.rs
@@ -23,7 +23,7 @@ impl EncodingCompressor for DeltaCompressor {
 
     fn can_compress(&self, array: &ArrayData) -> Option<&dyn EncodingCompressor> {
         // Only support primitive arrays
-        let parray = PrimitiveArray::maybe_from(array.clone())?;
+        let parray = PrimitiveArray::maybe_from(array)?;
 
         // Only supports ints
         if !parray.ptype().is_unsigned_int() {

--- a/vortex-sampling-compressor/src/compressors/dict.rs
+++ b/vortex-sampling-compressor/src/compressors/dict.rs
@@ -54,13 +54,13 @@ impl EncodingCompressor for DictCompressor {
         like: Option<CompressionTree<'a>>,
         ctx: SamplingCompressor<'a>,
     ) -> VortexResult<CompressedArray<'a>> {
-        let (codes, values) = if let Some(p) = PrimitiveArray::maybe_from(array.clone()) {
+        let (codes, values) = if let Some(p) = PrimitiveArray::maybe_from(array) {
             let (codes, values) = dict_encode_primitive(&p);
             (codes.into_array(), values.into_array())
-        } else if let Some(vb) = VarBinArray::maybe_from(array.clone()) {
+        } else if let Some(vb) = VarBinArray::maybe_from(array) {
             let (codes, values) = dict_encode_varbin(&vb);
             (codes.into_array(), values.into_array())
-        } else if let Some(vb) = VarBinViewArray::maybe_from(array.clone()) {
+        } else if let Some(vb) = VarBinViewArray::maybe_from(array) {
             let (codes, values) = dict_encode_varbinview(&vb);
             (codes.into_array(), values.into_array())
         } else {

--- a/vortex-sampling-compressor/src/compressors/for.rs
+++ b/vortex-sampling-compressor/src/compressors/for.rs
@@ -26,7 +26,7 @@ impl EncodingCompressor for FoRCompressor {
 
     fn can_compress(&self, array: &ArrayData) -> Option<&dyn EncodingCompressor> {
         // Only support primitive arrays
-        let parray = PrimitiveArray::maybe_from(array.clone())?;
+        let parray = PrimitiveArray::maybe_from(array)?;
 
         // Only supports integers
         if !parray.ptype().is_int() {

--- a/vortex-sampling-compressor/src/compressors/zigzag.rs
+++ b/vortex-sampling-compressor/src/compressors/zigzag.rs
@@ -24,7 +24,7 @@ impl EncodingCompressor for ZigZagCompressor {
 
     fn can_compress(&self, array: &ArrayData) -> Option<&dyn EncodingCompressor> {
         // Only support primitive arrays
-        let parray = PrimitiveArray::maybe_from(array.clone())?;
+        let parray = PrimitiveArray::maybe_from(array)?;
 
         // Only supports signed integers
         if !parray.ptype().is_signed_int() {


### PR DESCRIPTION
Instead of having to clone/have an owned value, only clone if the encoding IDs match. 