### PR TITLE
fix: JSON must not have trailing commas

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -23,8 +23,11 @@ jobs:
       - name: Upload Commit Metadata
         shell: bash
         run: |
+          set -Eeu -o pipefail -x
+
           sudo apt-get update && sudo apt-get install -y jq
-          bash scripts/cat-s3.sh vortex-benchmark-results-database commits.json <(bash scripts/commit-json.sh)
+          bash scripts/commit-json.sh > new-commit.json
+          bash scripts/cat-s3.sh vortex-benchmark-results-database commits.json new-commit.json
   bench:
     strategy:
       matrix:

--- a/scripts/commit-json.sh
+++ b/scripts/commit-json.sh
@@ -29,6 +29,6 @@ jq --compact-output '.' <<EOF
     "message": "$commit_title",
     "timestamp": "$commit_timestamp",
     "tree_id": "$tree_id",
-    "url": "$repo_url/commit/$commit_id",
+    "url": "$repo_url/commit/$commit_id"
 }
 EOF


### PR DESCRIPTION
The commit-metadata job also tolerated sub-shell failures.

I've already uploaded the missing commit entry (from the current tip) to S3.