### PR TITLE
chore: release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,389 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## `vortex-datafusion` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-datafusion-v0.20.0...vortex-datafusion-v0.21.0) - 2024-12-16
+
+### Added
+- Concurrent schema discovery for DataFusion (#1568)
+- add into_arrow to IntoCanonicalVTable (#1604)
+- Add uncompressed size stat for Vortex/Datafusion (#1512)
+- add clickbench benchmark (#1304)
+- Layout metadata reader and column statistics (#1455)
+
+### Fixed
+- Consistent metadata table column names for DataFusion stats (#1577)
+- Fix repartitioning regression (#1564)
+- Correct DataFusion repartitioning (#1554)
+- support stats for ExtensionArray in vortex-file (#1547)
+
+### Other
+- Cache initial reads in `VortexFormat` ([#1633](https://github.com/spiraldb/vortex/pull/1633))
+- Propagate size from datafusion to VortexReadBuilder ([#1636](https://github.com/spiraldb/vortex/pull/1636))
+- add an unsafe take_unchecked to TakeFn for bounds check ellision (#1611)
+- Fix partition count assertion  ([#1597](https://github.com/spiraldb/vortex/pull/1597))
+- Pass typed flat buffers into layout builders ([#1563](https://github.com/spiraldb/vortex/pull/1563))
+- DF repartition by file sizes instead of number of files ([#1572](https://github.com/spiraldb/vortex/pull/1572))
+- simplify MetadataFetcher to function (#1569)
+- cleanup in vortex-ipc & vortex-file (#1553)
+- cleanups to support wasm32-wasip1 target (#1528)
+- Like expression supports negated and case_sensitive arguments ([#1537](https://github.com/spiraldb/vortex/pull/1537))
+- Add file grouping-based repartitioning for DataFusion ([#1531](https://github.com/spiraldb/vortex/pull/1531))
+- Add LIKE operator ([#1525](https://github.com/spiraldb/vortex/pull/1525))
+- Variants VTable ([#1501](https://github.com/spiraldb/vortex/pull/1501))
+- Report stats to DataFusion ([#1506](https://github.com/spiraldb/vortex/pull/1506))
+
+## `vortex-roaring` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-roaring-v0.20.0...vortex-roaring-v0.21.0) - 2024-12-16
+
+### Other
+- Stats are stored as Vec of tuples instead of enummap ([#1658](https://github.com/spiraldb/vortex/pull/1658))
+- cleanups to support wasm32-wasip1 target (#1528)
+- Variants VTable ([#1501](https://github.com/spiraldb/vortex/pull/1501))
+- Move invert from BoolArrayTrait to InvertFn ([#1490](https://github.com/spiraldb/vortex/pull/1490))
+- Flatten unary compute mod ([#1489](https://github.com/spiraldb/vortex/pull/1489))
+
+## `vortex-zigzag` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-zigzag-v0.20.0...vortex-zigzag-v0.21.0) - 2024-12-16
+
+### Other
+- impl take_fn and filter_fn for ZigZag ([#1665](https://github.com/spiraldb/vortex/pull/1665))
+- Zigzag encode/decode reuses the underlying data vec ([#1638](https://github.com/spiraldb/vortex/pull/1638))
+- Variants VTable ([#1501](https://github.com/spiraldb/vortex/pull/1501))
+- Flatten unary compute mod ([#1489](https://github.com/spiraldb/vortex/pull/1489))
+
+## `vortex-runend-bool` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-runend-bool-v0.20.0...vortex-runend-bool-v0.21.0) - 2024-12-16
+
+### Fixed
+- RunEndBool array take respects validity (#1684)
+- RunEndBool scalar_at respects array's nullability (#1683)
+- use search_sorted_usize when searching for indices (#1566)
+- Support slicing RunEndBool arrays to 0 elements (#1511)
+
+### Other
+- Stats are stored as Vec of tuples instead of enummap ([#1658](https://github.com/spiraldb/vortex/pull/1658))
+- add an unsafe take_unchecked to TakeFn for bounds check ellision (#1611)
+- cleanups to support wasm32-wasip1 target (#1528)
+- Variants VTable ([#1501](https://github.com/spiraldb/vortex/pull/1501))
+- Move invert from BoolArrayTrait to InvertFn ([#1490](https://github.com/spiraldb/vortex/pull/1490))
+- Flatten unary compute mod ([#1489](https://github.com/spiraldb/vortex/pull/1489))
+
+## `vortex-runend` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-runend-v0.20.0...vortex-runend-v0.21.0) - 2024-12-16
+
+### Fixed
+- RunEnd array correctly encodes all null arrays (#1675)
+- RunEnd encoding doesn't skip first value when encoding nullable arrays (#1674)
+- use search_sorted_usize when searching for indices (#1566)
+- Support slicing RunEndBool arrays to 0 elements (#1511)
+- Fix slicing bug in RunEndArray (#1497)
+
+### Other
+- RunEnd compare produces canonical array (#1668)
+- RunEnd fill_null correctly reconstructs itself (#1666)
+- Run end fill null ([#1660](https://github.com/spiraldb/vortex/pull/1660))
+- Remove validity from run-end array ([#1630](https://github.com/spiraldb/vortex/pull/1630))
+- add an unsafe take_unchecked to TakeFn for bounds check ellision (#1611)
+- cleanups to support wasm32-wasip1 target (#1528)
+- Variants VTable ([#1501](https://github.com/spiraldb/vortex/pull/1501))
+- Move invert from BoolArrayTrait to InvertFn ([#1490](https://github.com/spiraldb/vortex/pull/1490))
+- Flatten unary compute mod ([#1489](https://github.com/spiraldb/vortex/pull/1489))
+
+## `vortex-fsst` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-fsst-v0.20.0...vortex-fsst-v0.21.0) - 2024-12-16
+
+### Other
+- add an unsafe take_unchecked to TakeFn for bounds check ellision (#1611)
+- Ensure patches don't turn arrays nullable ([#1565](https://github.com/spiraldb/vortex/pull/1565))
+- cleanups to support wasm32-wasip1 target (#1528)
+- Narrow indices types during compression  ([#1558](https://github.com/spiraldb/vortex/pull/1558))
+- Remove with_dyn and ArrayDef ([#1503](https://github.com/spiraldb/vortex/pull/1503))
+- Variants VTable ([#1501](https://github.com/spiraldb/vortex/pull/1501))
+- Flatten unary compute mod ([#1489](https://github.com/spiraldb/vortex/pull/1489))
+
+## `vortex-sampling-compressor` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-sampling-compressor-v0.20.0...vortex-sampling-compressor-v0.21.0) - 2024-12-16
+
+### Added
+- faster Patches::take & use patches in alp-rd & sparse (#1628)
+- consistently compress validity (#1544)
+
+### Fixed
+- SparseArray scalar_at was broken due to strict PValue PartialOrd (#1575)
+
+### Other
+- Cheaper `maybe_from` ([#1677](https://github.com/spiraldb/vortex/pull/1677))
+- Remove validity from run-end array ([#1630](https://github.com/spiraldb/vortex/pull/1630))
+- Fix regression in search_sorted when Patches replaced SparseArray ([#1624](https://github.com/spiraldb/vortex/pull/1624))
+- Cannot compress like logs are debug level ([#1620](https://github.com/spiraldb/vortex/pull/1620))
+- Patches Utility ([#1601](https://github.com/spiraldb/vortex/pull/1601))
+- cleanups to support wasm32-wasip1 target (#1528)
+- Add `maybe_from` function to help downcast ArrayData into a specific encoded array without potentially capturing a backtrace ([#1560](https://github.com/spiraldb/vortex/pull/1560))
+- Narrow indices types during compression  ([#1558](https://github.com/spiraldb/vortex/pull/1558))
+- ArrayNBytes includes size of arrays metadata ([#1549](https://github.com/spiraldb/vortex/pull/1549))
+- Revert "feat: consistently compress validity" ([#1551](https://github.com/spiraldb/vortex/pull/1551))
+- Added a list compressor ([#1536](https://github.com/spiraldb/vortex/pull/1536))
+- Add more click bench things ([#1530](https://github.com/spiraldb/vortex/pull/1530))
+- Remove with_dyn and ArrayDef ([#1503](https://github.com/spiraldb/vortex/pull/1503))
+
+## `vortex-ipc` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-ipc-v0.20.0...vortex-ipc-v0.21.0) - 2024-12-16
+
+### Added
+- add into_arrow to IntoCanonicalVTable (#1604)
+
+### Other
+- IPC Message clean up ([#1686](https://github.com/spiraldb/vortex/pull/1686))
+- Cheaper `maybe_from` ([#1677](https://github.com/spiraldb/vortex/pull/1677))
+- add an unsafe take_unchecked to TakeFn for bounds check ellision (#1611)
+- cleanup in vortex-ipc & vortex-file (#1553)
+- cleanups to support wasm32-wasip1 target (#1528)
+- Add `maybe_from` function to help downcast ArrayData into a specific encoded array without potentially capturing a backtrace ([#1560](https://github.com/spiraldb/vortex/pull/1560))
+
+## `vortex-io` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-io-v0.20.0...vortex-io-v0.21.0) - 2024-12-16
+
+### Added
+- coalesce multiple reads together and don't block on io if there's values available (#1466)
+- Layout metadata reader and column statistics (#1455)
+
+### Fixed
+- properly gate things by features & test for that (#1494)
+- regression for ObjectStoreReadAt (#1483)
+
+### Other
+- use cargo-hack and build all valid feature combos (#1653)
+- actually run with wasm32-unknown-unknown (#1648)
+- Hide underlying channel in the Dispatcher (#1585)
+- cleanups to support wasm32-wasip1 target (#1528)
+
+## `vortex-file` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-file-v0.20.0...vortex-file-v0.21.0) - 2024-12-16
+
+### Added
+- Add fill_null compute function (#1590)
+- coalesce multiple reads together and don't block on io if there's values available (#1466)
+- Add uncompressed size stat for Vortex/Datafusion (#1512)
+- prune layouts based on stats (#1485)
+- Layout metadata reader and column statistics (#1455)
+
+### Fixed
+- Fix length of empty struct arrays (#1673)
+- support stats for ExtensionArray in vortex-file (#1547)
+
+### Other
+- IPC Message clean up ([#1686](https://github.com/spiraldb/vortex/pull/1686))
+- random refactoring/renaming (#1669)
+- Cache initial reads in `VortexFormat` ([#1633](https://github.com/spiraldb/vortex/pull/1633))
+- Reading stats tables reuses schemas ([#1637](https://github.com/spiraldb/vortex/pull/1637))
+- some LayoutReader cleanups (#1623)
+- add an unsafe take_unchecked to TakeFn for bounds check ellision (#1611)
+- `vortex-file` crate-level docs adjustment ([#1610](https://github.com/spiraldb/vortex/pull/1610))
+- Use FilterMask in RowMask ([#1616](https://github.com/spiraldb/vortex/pull/1616))
+- Fix up InnerScalarValue ([#1613](https://github.com/spiraldb/vortex/pull/1613))
+- Pass typed flat buffers into layout builders ([#1563](https://github.com/spiraldb/vortex/pull/1563))
+- simplify MetadataFetcher to function (#1569)
+- cleanup in vortex-ipc & vortex-file (#1553)
+- cleanups to support wasm32-wasip1 target (#1528)
+- Store present stats as a bitset in metadata of chunked layout and remove inline dtype layout ([#1555](https://github.com/spiraldb/vortex/pull/1555))
+- Remove dead chunked reader ([#1552](https://github.com/spiraldb/vortex/pull/1552))
+- Like expression supports negated and case_sensitive arguments ([#1537](https://github.com/spiraldb/vortex/pull/1537))
+- Add LIKE operator ([#1525](https://github.com/spiraldb/vortex/pull/1525))
+- Use filter in RowMask::evaluate ([#1515](https://github.com/spiraldb/vortex/pull/1515))
+- Variants VTable ([#1501](https://github.com/spiraldb/vortex/pull/1501))
+- RowMask uses ConstantArray for all valid and all invalid selections and remove unsafe RowMask constructor ([#1495](https://github.com/spiraldb/vortex/pull/1495))
+- Remove uses of with_dyn for validity ([#1487](https://github.com/spiraldb/vortex/pull/1487))
+- Flatten unary compute mod ([#1489](https://github.com/spiraldb/vortex/pull/1489))
+
+## `vortex-expr` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-expr-v0.20.0...vortex-expr-v0.21.0) - 2024-12-16
+
+### Other
+- Reading stats tables reuses schemas ([#1637](https://github.com/spiraldb/vortex/pull/1637))
+- Like expression supports negated and case_sensitive arguments ([#1537](https://github.com/spiraldb/vortex/pull/1537))
+- Add LIKE operator ([#1525](https://github.com/spiraldb/vortex/pull/1525))
+- Variants VTable ([#1501](https://github.com/spiraldb/vortex/pull/1501))
+- Move invert from BoolArrayTrait to InvertFn ([#1490](https://github.com/spiraldb/vortex/pull/1490))
+
+## `vortex-dict` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-dict-v0.20.0...vortex-dict-v0.21.0) - 2024-12-16
+
+### Added
+- Add fill_null compute function (#1590)
+
+### Other
+- add an unsafe take_unchecked to TakeFn for bounds check ellision (#1611)
+- cleanups to support wasm32-wasip1 target (#1528)
+- Like expression supports negated and case_sensitive arguments ([#1537](https://github.com/spiraldb/vortex/pull/1537))
+- Add LIKE operator ([#1525](https://github.com/spiraldb/vortex/pull/1525))
+- Variants VTable ([#1501](https://github.com/spiraldb/vortex/pull/1501))
+- Move invert from BoolArrayTrait to InvertFn ([#1490](https://github.com/spiraldb/vortex/pull/1490))
+- Remove uses of with_dyn for validity ([#1487](https://github.com/spiraldb/vortex/pull/1487))
+- Flatten unary compute mod ([#1489](https://github.com/spiraldb/vortex/pull/1489))
+
+## `vortex-datetime-parts` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-datetime-parts-v0.20.0...vortex-datetime-parts-v0.21.0) - 2024-12-16
+
+### Fixed
+- support stats for ExtensionArray in vortex-file (#1547)
+
+### Other
+- add an unsafe take_unchecked to TakeFn for bounds check ellision (#1611)
+- Fix date time parts scalar_at to cast ([#1584](https://github.com/spiraldb/vortex/pull/1584))
+- Narrow indices types during compression  ([#1558](https://github.com/spiraldb/vortex/pull/1558))
+- Use filter in RowMask::evaluate ([#1515](https://github.com/spiraldb/vortex/pull/1515))
+- Variants VTable ([#1501](https://github.com/spiraldb/vortex/pull/1501))
+- Remove uses of with_dyn for validity ([#1487](https://github.com/spiraldb/vortex/pull/1487))
+- Flatten unary compute mod ([#1489](https://github.com/spiraldb/vortex/pull/1489))
+
+## `vortex-bytebool` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-bytebool-v0.20.0...vortex-bytebool-v0.21.0) - 2024-12-16
+
+### Other
+- Stats are stored as Vec of tuples instead of enummap ([#1658](https://github.com/spiraldb/vortex/pull/1658))
+- add an unsafe take_unchecked to TakeFn for bounds check ellision (#1611)
+- Variants VTable ([#1501](https://github.com/spiraldb/vortex/pull/1501))
+- Move invert from BoolArrayTrait to InvertFn ([#1490](https://github.com/spiraldb/vortex/pull/1490))
+- Flatten unary compute mod ([#1489](https://github.com/spiraldb/vortex/pull/1489))
+
+## `vortex-fastlanes` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-fastlanes-v0.20.0...vortex-fastlanes-v0.21.0) - 2024-12-16
+
+### Added
+- Faster bitpacked filter & take (#1667)
+
+### Other
+- Fix regression in search_sorted when Patches replaced SparseArray ([#1624](https://github.com/spiraldb/vortex/pull/1624))
+- Skip FoR decompression if min and scalar are 0 ([#1618](https://github.com/spiraldb/vortex/pull/1618))
+- add an unsafe take_unchecked to TakeFn for bounds check ellision (#1611)
+- Patches Utility ([#1601](https://github.com/spiraldb/vortex/pull/1601))
+- Fix search sorted casting ([#1579](https://github.com/spiraldb/vortex/pull/1579))
+- cleanups to support wasm32-wasip1 target (#1528)
+- Add `maybe_from` function to help downcast ArrayData into a specific encoded array without potentially capturing a backtrace ([#1560](https://github.com/spiraldb/vortex/pull/1560))
+- Remove with_dyn and ArrayDef ([#1503](https://github.com/spiraldb/vortex/pull/1503))
+- Variants VTable ([#1501](https://github.com/spiraldb/vortex/pull/1501))
+- Remove uses of with_dyn for validity ([#1487](https://github.com/spiraldb/vortex/pull/1487))
+- Flatten unary compute mod ([#1489](https://github.com/spiraldb/vortex/pull/1489))
+
+## `vortex-scalar` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-scalar-v0.20.0...vortex-scalar-v0.21.0) - 2024-12-16
+
+### Fixed
+- ScalarValue flatbuffer serde doesn't perform redundant copy (#1635)
+- SparseArray scalar_at was broken due to strict PValue PartialOrd (#1575)
+
+### Other
+- Some small fixes ([#1631](https://github.com/spiraldb/vortex/pull/1631))
+- Fix up InnerScalarValue ([#1613](https://github.com/spiraldb/vortex/pull/1613))
+- cleanups to support wasm32-wasip1 target (#1528)
+- Narrow indices types during compression  ([#1558](https://github.com/spiraldb/vortex/pull/1558))
+- Array Builders ([#1543](https://github.com/spiraldb/vortex/pull/1543))
+
+## `vortex-flatbuffers` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-flatbuffers-v0.20.0...vortex-flatbuffers-v0.21.0) - 2024-12-16
+
+### Other
+- IPC Message clean up ([#1686](https://github.com/spiraldb/vortex/pull/1686))
+
+## `vortex-error` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-error-v0.20.0...vortex-error-v0.21.0) - 2024-12-16
+
+### Added
+- faster Patches::take & use patches in alp-rd & sparse (#1628)
+
+### Other
+- cleanups to support wasm32-wasip1 target (#1528)
+
+## `vortex-dtype` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-dtype-v0.20.0...vortex-dtype-v0.21.0) - 2024-12-16
+
+### Added
+- patches uses a map in some cases (#1626)
+
+### Other
+- IPC Message clean up ([#1686](https://github.com/spiraldb/vortex/pull/1686))
+- Move PrimitiveBuilder constraints to where clause ([#1634](https://github.com/spiraldb/vortex/pull/1634))
+- Reading stats tables reuses schemas ([#1637](https://github.com/spiraldb/vortex/pull/1637))
+- Revert "feat: patches uses a map in some cases" ([#1629](https://github.com/spiraldb/vortex/pull/1629))
+- fuzzer reference take implementation respects generated values nullability (#1586)
+- cleanups to support wasm32-wasip1 target (#1528)
+- Narrow indices types during compression  ([#1558](https://github.com/spiraldb/vortex/pull/1558))
+- Add ArrowPrimitiveType ([#1540](https://github.com/spiraldb/vortex/pull/1540))
+- Add lists to vortex ([#1524](https://github.com/spiraldb/vortex/pull/1524))
+
+## `vortex-buffer` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-buffer-v0.20.0...vortex-buffer-v0.21.0) - 2024-12-16
+
+### Added
+- Layout metadata reader and column statistics (#1455)
+
+## `vortex-array` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-array-v0.20.0...vortex-array-v0.21.0) - 2024-12-16
+
+### Added
+- faster Patches::take & use patches in alp-rd & sparse (#1628)
+- patches uses a map in some cases (#1626)
+- add into_arrow to IntoCanonicalVTable (#1604)
+- Add fill_null compute function (#1590)
+
+### Fixed
+- RunEndBool array take respects validity (#1684)
+- Fix length of empty struct arrays (#1673)
+- Consistent metadata table column names for DataFusion stats (#1577)
+- SparseArray scalar_at was broken due to strict PValue PartialOrd (#1575)
+- use search_sorted_usize when searching for indices (#1566)
+- support stats for ExtensionArray in vortex-file (#1547)
+- properly gate things by features & test for that (#1494)
+
+### Other
+- IPC Message clean up ([#1686](https://github.com/spiraldb/vortex/pull/1686))
+- Cheaper `maybe_from` ([#1677](https://github.com/spiraldb/vortex/pull/1677))
+- simplify StatsSet (#1672)
+- ChunkedArray stats compute handles ordered stats and doesn't eagerly merge chunk stats ([#1652](https://github.com/spiraldb/vortex/pull/1652))
+- Run end fill null ([#1660](https://github.com/spiraldb/vortex/pull/1660))
+- Stats are stored as Vec of tuples instead of enummap ([#1658](https://github.com/spiraldb/vortex/pull/1658))
+- VarBin to arrow conversion uses reinterpret cast to convert offsets to I32/64 ([#1644](https://github.com/spiraldb/vortex/pull/1644))
+- Add missing overrides for into_arrow delegation for VarBinArray ([#1642](https://github.com/spiraldb/vortex/pull/1642))
+- Move PrimitiveBuilder constraints to where clause ([#1634](https://github.com/spiraldb/vortex/pull/1634))
+- Reading stats tables reuses schemas ([#1637](https://github.com/spiraldb/vortex/pull/1637))
+- Remove validity from run-end array ([#1630](https://github.com/spiraldb/vortex/pull/1630))
+- Some small fixes ([#1631](https://github.com/spiraldb/vortex/pull/1631))
+- Revert "feat: patches uses a map in some cases" ([#1629](https://github.com/spiraldb/vortex/pull/1629))
+- Fix regression in search_sorted when Patches replaced SparseArray ([#1624](https://github.com/spiraldb/vortex/pull/1624))
+- search_sorted_many handles failed downcasts and use search_sorted_usize_many in Patches::take (#1621)
+- add an unsafe take_unchecked to TakeFn for bounds check ellision (#1611)
+- Use FilterMask in RowMask ([#1616](https://github.com/spiraldb/vortex/pull/1616))
+- Patches Utility ([#1601](https://github.com/spiraldb/vortex/pull/1601))
+- Fix up InnerScalarValue ([#1613](https://github.com/spiraldb/vortex/pull/1613))
+- Count into_canonical invocations ([#1615](https://github.com/spiraldb/vortex/pull/1615))
+- Deref scalar buffer once ([#1608](https://github.com/spiraldb/vortex/pull/1608))
+- fill_null fallback will not infinitely recurse (#1607)
+- Fallback fill_null to canonical array ([#1600](https://github.com/spiraldb/vortex/pull/1600))
+- Fix search sorted casting ([#1579](https://github.com/spiraldb/vortex/pull/1579))
+- implement binary_boolean for chunked encoding ([#1532](https://github.com/spiraldb/vortex/pull/1532))
+- Fuzz filter implementation respects data validity ([#1573](https://github.com/spiraldb/vortex/pull/1573))
+- Ensure patches don't turn arrays nullable ([#1565](https://github.com/spiraldb/vortex/pull/1565))
+- cleanups to support wasm32-wasip1 target (#1528)
+- Add `maybe_from` function to help downcast ArrayData into a specific encoded array without potentially capturing a backtrace ([#1560](https://github.com/spiraldb/vortex/pull/1560))
+- Narrow indices types during compression  ([#1558](https://github.com/spiraldb/vortex/pull/1558))
+- Store present stats as a bitset in metadata of chunked layout and remove inline dtype layout ([#1555](https://github.com/spiraldb/vortex/pull/1555))
+- ArrayNBytes includes size of arrays metadata ([#1549](https://github.com/spiraldb/vortex/pull/1549))
+- Array Builders ([#1543](https://github.com/spiraldb/vortex/pull/1543))
+- Like expression supports negated and case_sensitive arguments ([#1537](https://github.com/spiraldb/vortex/pull/1537))
+- Add ArrowPrimitiveType ([#1540](https://github.com/spiraldb/vortex/pull/1540))
+- Add lists to vortex ([#1524](https://github.com/spiraldb/vortex/pull/1524))
+- Add LIKE operator ([#1525](https://github.com/spiraldb/vortex/pull/1525))
+- Use filter in RowMask::evaluate ([#1515](https://github.com/spiraldb/vortex/pull/1515))
+- Remove with_dyn and ArrayDef ([#1503](https://github.com/spiraldb/vortex/pull/1503))
+- Variants VTable ([#1501](https://github.com/spiraldb/vortex/pull/1501))
+- Short-circuit BoolArray null count ([#1509](https://github.com/spiraldb/vortex/pull/1509))
+- Move invert from BoolArrayTrait to InvertFn ([#1490](https://github.com/spiraldb/vortex/pull/1490))
+- Remove uses of with_dyn for validity ([#1487](https://github.com/spiraldb/vortex/pull/1487))
+- Make BinaryBooleanFn consistent with CompareFn ([#1488](https://github.com/spiraldb/vortex/pull/1488))
+- Flatten unary compute mod ([#1489](https://github.com/spiraldb/vortex/pull/1489))
+
+## `vortex-alp` - [0.21.0](https://github.com/spiraldb/vortex/compare/vortex-alp-v0.20.0...vortex-alp-v0.21.0) - 2024-12-16
+
+### Added
+- faster Patches::take & use patches in alp-rd & sparse (#1628)
+
+### Other
+- add an unsafe take_unchecked to TakeFn for bounds check ellision (#1611)
+- Patches Utility ([#1601](https://github.com/spiraldb/vortex/pull/1601))
+- Speed up ALP decompress ([#1614](https://github.com/spiraldb/vortex/pull/1614))
+- Remove ALP compare ([#1603](https://github.com/spiraldb/vortex/pull/1603))
+- cleanups to support wasm32-wasip1 target (#1528)
+- Add `maybe_from` function to help downcast ArrayData into a specific encoded array without potentially capturing a backtrace ([#1560](https://github.com/spiraldb/vortex/pull/1560))
+- ALP Mask clone ([#1522](https://github.com/spiraldb/vortex/pull/1522))
+- Variants VTable ([#1501](https://github.com/spiraldb/vortex/pull/1501))
+- Remove uses of with_dyn for validity ([#1487](https://github.com/spiraldb/vortex/pull/1487))
+- Flatten unary compute mod ([#1489](https://github.com/spiraldb/vortex/pull/1489))
+
+## `vortex` - [0.21.0](https://github.com/spiraldb/vortex/compare/0.20.0...0.21.0) - 2024-12-16
+
+### Other
+- cleanups to support wasm32-wasip1 target (#1528)
+
 ## `vortex-datafusion` - [0.20.0](https://github.com/spiraldb/vortex/compare/vortex-datafusion-v0.19.0...vortex-datafusion-v0.20.0) - 2024-11-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bench-vortex"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -3478,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "pyvortex"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arrow",
  "flume",
@@ -4719,7 +4719,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vortex"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "vortex-alp",
  "vortex-array",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-alp"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4766,7 +4766,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-array"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arbitrary",
  "arrow-arith",
@@ -4807,7 +4807,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-buffer"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arrow-buffer",
  "bytes",
@@ -4816,7 +4816,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-bytebool"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arrow-buffer",
  "num-traits",
@@ -4830,7 +4830,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-datafusion"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4864,7 +4864,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-datetime-dtype"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arrow-schema",
  "jiff",
@@ -4876,7 +4876,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-datetime-parts"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "itertools 0.13.0",
  "serde",
@@ -4889,7 +4889,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-dict"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arrow-buffer",
  "criterion",
@@ -4905,7 +4905,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-dtype"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arbitrary",
  "flatbuffers",
@@ -4923,7 +4923,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-error"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arrow-schema",
  "datafusion-common",
@@ -4940,7 +4940,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-expr"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "datafusion-expr",
  "datafusion-physical-expr",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-fastlanes"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arrayref",
  "arrow-buffer",
@@ -4975,7 +4975,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-file"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -5003,7 +5003,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-flatbuffers"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "flatbuffers",
  "vortex-buffer",
@@ -5011,7 +5011,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-fsst"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -5026,7 +5026,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-fuzz"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "libfuzzer-sys",
  "vortex-array",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-io"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-ipc"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -5083,7 +5083,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-proto"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "prost",
  "prost-types",
@@ -5091,7 +5091,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-roaring"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arrow-buffer",
  "croaring",
@@ -5106,7 +5106,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-runend"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arrow-buffer",
  "itertools 0.13.0",
@@ -5120,7 +5120,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-runend-bool"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arrow-buffer",
  "criterion",
@@ -5137,7 +5137,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-sampling-compressor"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -5165,7 +5165,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-scalar"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arbitrary",
  "arrow-array",
@@ -5189,7 +5189,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-zigzag"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "serde",
  "vortex-array",
@@ -5667,7 +5667,7 @@ checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
 
 [[package]]
 name = "xtask"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.20.0"
+version = "0.21.0"
 homepage = "https://github.com/spiraldb/vortex"
 repository = "https://github.com/spiraldb/vortex"
 authors = ["Vortex Authors <hello@vortex.dev>"]
@@ -130,31 +130,31 @@ uuid = "1.8.0"
 wasm-bindgen-futures = "0.4"
 
 # BEGIN crates published by this project
-vortex = { version = "0.20.0", path = "./vortex" }
-vortex-alp = { version = "0.20.0", path = "./encodings/alp" }
-vortex-array = { version = "0.20.0", path = "./vortex-array" }
-vortex-buffer = { version = "0.20.0", path = "./vortex-buffer" }
-vortex-bytebool = { version = "0.20.0", path = "./encodings/bytebool" }
-vortex-datafusion = { version = "0.20.0", path = "./vortex-datafusion" }
-vortex-datetime-dtype = { version = "0.20.0", path = "./vortex-datetime-dtype" }
-vortex-datetime-parts = { version = "0.20.0", path = "./encodings/datetime-parts" }
-vortex-dict = { version = "0.20.0", path = "./encodings/dict" }
-vortex-dtype = { version = "0.20.0", path = "./vortex-dtype", default-features = false }
-vortex-error = { version = "0.20.0", path = "./vortex-error" }
-vortex-expr = { version = "0.20.0", path = "./vortex-expr" }
-vortex-fastlanes = { version = "0.20.0", path = "./encodings/fastlanes" }
-vortex-file = { version = "0.20.0", path = "./vortex-file", default-features = false }
-vortex-flatbuffers = { version = "0.20.0", path = "./vortex-flatbuffers" }
-vortex-fsst = { version = "0.20.0", path = "./encodings/fsst" }
-vortex-io = { version = "0.20.0", path = "./vortex-io" }
-vortex-ipc = { version = "0.20.0", path = "./vortex-ipc" }
-vortex-proto = { version = "0.20.0", path = "./vortex-proto" }
-vortex-roaring = { version = "0.20.0", path = "./encodings/roaring" }
-vortex-runend = { version = "0.20.0", path = "./encodings/runend" }
-vortex-runend-bool = { version = "0.20.0", path = "./encodings/runend-bool" }
-vortex-scalar = { version = "0.20.0", path = "./vortex-scalar", default-features = false }
-vortex-sampling-compressor = { version = "0.20.0", path = "./vortex-sampling-compressor" }
-vortex-zigzag = { version = "0.20.0", path = "./encodings/zigzag" }
+vortex = { version = "0.21.0", path = "./vortex" }
+vortex-alp = { version = "0.21.0", path = "./encodings/alp" }
+vortex-array = { version = "0.21.0", path = "./vortex-array" }
+vortex-buffer = { version = "0.21.0", path = "./vortex-buffer" }
+vortex-bytebool = { version = "0.21.0", path = "./encodings/bytebool" }
+vortex-datafusion = { version = "0.21.0", path = "./vortex-datafusion" }
+vortex-datetime-dtype = { version = "0.21.0", path = "./vortex-datetime-dtype" }
+vortex-datetime-parts = { version = "0.21.0", path = "./encodings/datetime-parts" }
+vortex-dict = { version = "0.21.0", path = "./encodings/dict" }
+vortex-dtype = { version = "0.21.0", path = "./vortex-dtype", default-features = false }
+vortex-error = { version = "0.21.0", path = "./vortex-error" }
+vortex-expr = { version = "0.21.0", path = "./vortex-expr" }
+vortex-fastlanes = { version = "0.21.0", path = "./encodings/fastlanes" }
+vortex-file = { version = "0.21.0", path = "./vortex-file", default-features = false }
+vortex-flatbuffers = { version = "0.21.0", path = "./vortex-flatbuffers" }
+vortex-fsst = { version = "0.21.0", path = "./encodings/fsst" }
+vortex-io = { version = "0.21.0", path = "./vortex-io" }
+vortex-ipc = { version = "0.21.0", path = "./vortex-ipc" }
+vortex-proto = { version = "0.21.0", path = "./vortex-proto" }
+vortex-roaring = { version = "0.21.0", path = "./encodings/roaring" }
+vortex-runend = { version = "0.21.0", path = "./encodings/runend" }
+vortex-runend-bool = { version = "0.21.0", path = "./encodings/runend-bool" }
+vortex-scalar = { version = "0.21.0", path = "./vortex-scalar", default-features = false }
+vortex-sampling-compressor = { version = "0.21.0", path = "./vortex-sampling-compressor" }
+vortex-zigzag = { version = "0.21.0", path = "./encodings/zigzag" }
 # END crates published by this project
 
 worker = "0.5.0"


### PR DESCRIPTION
## 🤖 New release
* `vortex`: 0.20.0 -> 0.21.0 (✓ API compatible changes)
* `vortex-alp`: 0.20.0 -> 0.21.0 (⚠️ API breaking changes)
* `vortex-array`: 0.20.0 -> 0.21.0 (⚠️ API breaking changes)
* `vortex-buffer`: 0.20.0 -> 0.21.0 (✓ API compatible changes)
* `vortex-datetime-dtype`: 0.20.0 -> 0.21.0
* `vortex-dtype`: 0.20.0 -> 0.21.0 (⚠️ API breaking changes)
* `vortex-error`: 0.20.0 -> 0.21.0 (✓ API compatible changes)
* `vortex-flatbuffers`: 0.20.0 -> 0.21.0 (⚠️ API breaking changes)
* `vortex-proto`: 0.20.0 -> 0.21.0
* `vortex-scalar`: 0.20.0 -> 0.21.0 (✓ API compatible changes)
* `vortex-fastlanes`: 0.20.0 -> 0.21.0 (⚠️ API breaking changes)
* `vortex-bytebool`: 0.20.0 -> 0.21.0 (⚠️ API breaking changes)
* `vortex-datetime-parts`: 0.20.0 -> 0.21.0 (⚠️ API breaking changes)
* `vortex-dict`: 0.20.0 -> 0.21.0 (⚠️ API breaking changes)
* `vortex-expr`: 0.20.0 -> 0.21.0 (✓ API compatible changes)
* `vortex-file`: 0.20.0 -> 0.21.0 (⚠️ API breaking changes)
* `vortex-io`: 0.20.0 -> 0.21.0 (✓ API compatible changes)
* `vortex-ipc`: 0.20.0 -> 0.21.0 (⚠️ API breaking changes)
* `vortex-sampling-compressor`: 0.20.0 -> 0.21.0 (⚠️ API breaking changes)
* `vortex-fsst`: 0.20.0 -> 0.21.0 (⚠️ API breaking changes)
* `vortex-runend`: 0.20.0 -> 0.21.0 (⚠️ API breaking changes)
* `vortex-runend-bool`: 0.20.0 -> 0.21.0 (⚠️ API breaking changes)
* `vortex-zigzag`: 0.20.0 -> 0.21.0 (⚠️ API breaking changes)
* `vortex-roaring`: 0.20.0 -> 0.21.0 (⚠️ API breaking changes)
* `vortex-datafusion`: 0.20.0 -> 0.21.0 (⚠️ API breaking changes)

### ⚠️ `vortex-alp` breaking changes

```
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/function_parameter_count_changed.ron

Failed in:
  vortex_alp::alp_rd_decode now takes 5 parameters instead of 6, in /tmp/.tmpCdcVjR/vortex/encodings/alp/src/alp_rd/mod.rs:260

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/inherent_method_missing.ron

Failed in:
  ALPRDArray::left_parts_exceptions, previously in file /tmp/.tmpAQdU44/vortex-alp/src/alp_rd/array.rs:161

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct vortex_alp::ALPRD, previously in file /tmp/.tmpAQdU44/vortex-alp/src/alp_rd/array.rs:17
  struct vortex_alp::ALP, previously in file /tmp/.tmpAQdU44/vortex-alp/src/alp/array.rs:19
```

### ⚠️ `vortex-array` breaking changes

```
--- failure declarative_macro_missing: macro_rules declaration removed or renamed ---

Description:
A publicly-visible `macro_rules` declarative macro cannot be imported by its prior name. A `#[macro_export]` may have been removed, or the macro itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/reference/macros-by-example.html#path-based-scope
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/declarative_macro_missing.ron

Failed in:
  macro_rules! iterate_primitive_array, previously in file /tmp/.tmpAQdU44/vortex-array/src/variants.rs:95
  macro_rules! iterate_integer_array, previously in file /tmp/.tmpAQdU44/vortex-array/src/variants.rs:117

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_variant_added.ron

Failed in:
  variant Canonical:List in /tmp/.tmpCdcVjR/vortex/vortex-array/src/canonical.rs:62

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/feature_missing.ron

Failed in:
  feature serde in the package's Cargo.toml
  feature flatbuffers in the package's Cargo.toml

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/function_missing.ron

Failed in:
  function vortex_array::compute::unary::try_cast, previously in file /tmp/.tmpAQdU44/vortex-array/src/compute/unary/cast.rs:30
  function vortex_array::compute::unary::subtract_scalar, previously in file /tmp/.tmpAQdU44/vortex-array/src/compute/unary/scalar_subtract.rs:28
  function vortex_array::compute::unary::fill_forward, previously in file /tmp/.tmpAQdU44/vortex-array/src/compute/unary/fill_forward.rs:31
  function vortex_array::compute::unary::scalar_at, previously in file /tmp/.tmpAQdU44/vortex-array/src/compute/unary/scalar_at.rs:30

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/function_parameter_count_changed.ron

Failed in:
  vortex_array::compute::take now takes 2 parameters instead of 3, in /tmp/.tmpCdcVjR/vortex/vortex-array/src/compute/take.rs:45

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/inherent_method_missing.ron

Failed in:
  SparseArray::values, previously in file /tmp/.tmpAQdU44/vortex-array/src/array/sparse/mod.rs:104
  SparseArray::indices, previously in file /tmp/.tmpAQdU44/vortex-array/src/array/sparse/mod.rs:111
  SparseArray::resolved_indices, previously in file /tmp/.tmpAQdU44/vortex-array/src/array/sparse/mod.rs:140
  SparseArray::min_index, previously in file /tmp/.tmpAQdU44/vortex-array/src/array/sparse/mod.rs:158
  SparseArray::max_index, previously in file /tmp/.tmpAQdU44/vortex-array/src/array/sparse/mod.rs:171
  ArrayData::with_dyn, previously in file /tmp/.tmpAQdU44/vortex-array/src/data/mod.rs:337

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/method_parameter_count_changed.ron

Failed in:
  vortex_array::array::PrimitiveArray::patch now takes 2 parameters instead of 4, in /tmp/.tmpCdcVjR/vortex/vortex-array/src/array/primitive/patch.rs:12
  vortex_array::array::BoolArray::patch now takes 2 parameters instead of 3, in /tmp/.tmpCdcVjR/vortex/vortex-array/src/array/bool/patch.rs:11
  vortex_array::validity::LogicalValidity::null_count now takes 1 parameters instead of 2, in /tmp/.tmpCdcVjR/vortex/vortex-array/src/validity.rs:507
  vortex_array::validity::Validity::take now takes 2 parameters instead of 3, in /tmp/.tmpCdcVjR/vortex/vortex-array/src/validity.rs:198

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/module_missing.ron

Failed in:
  mod vortex_array::compute::unary, previously in file /tmp/.tmpAQdU44/vortex-array/src/compute/unary/mod.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct vortex_array::array::Bool, previously in file /tmp/.tmpAQdU44/vortex-array/src/array/bool/mod.rs:28
  struct vortex_array::array::Null, previously in file /tmp/.tmpAQdU44/vortex-array/src/array/null/mod.rs:17
  struct vortex_array::array::Primitive, previously in file /tmp/.tmpAQdU44/vortex-array/src/array/primitive/mod.rs:29
  struct vortex_array::array::Extension, previously in file /tmp/.tmpAQdU44/vortex-array/src/array/extension/mod.rs:18
  struct vortex_array::array::Constant, previously in file /tmp/.tmpAQdU44/vortex-array/src/array/constant/mod.rs:17
  struct vortex_array::array::VarBin, previously in file /tmp/.tmpAQdU44/vortex-array/src/array/varbin/mod.rs:33
  struct vortex_array::array::Sparse, previously in file /tmp/.tmpAQdU44/vortex-array/src/array/sparse/mod.rs:24
  struct vortex_array::array::Chunked, previously in file /tmp/.tmpAQdU44/vortex-array/src/array/chunked/mod.rs:33
  struct vortex_array::array::Struct, previously in file /tmp/.tmpAQdU44/vortex-array/src/array/struct_/mod.rs:20
  struct vortex_array::compute::TakeOptions, previously in file /tmp/.tmpAQdU44/vortex-array/src/compute/take.rs:9
  struct vortex_array::array::VarBinView, previously in file /tmp/.tmpAQdU44/vortex-array/src/array/varbinview/mod.rs:230
  struct vortex_array::compute::BitIndexIterator, previously in file /tmp/.tmpAQdU44/vortex-array/src/compute/filter.rs:129

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait vortex_array::encoding::EncodingVTable gained VariantsVTable in file /tmp/.tmpCdcVjR/vortex/vortex-array/src/encoding/mod.rs:73

--- failure trait_associated_const_added: non-sealed trait added associated constant without default value ---

Description:
A non-sealed trait has gained an associated constant without a default value, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_associated_const_added.ron

Failed in:
  trait constant vortex_array::encoding::Encoding::ID in file /tmp/.tmpCdcVjR/vortex/vortex-array/src/encoding/mod.rs:64

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_method_added.ron

Failed in:
  trait method vortex_array::IntoArrayVariant::into_list in file /tmp/.tmpCdcVjR/vortex/vortex-array/src/canonical.rs:417
  trait method vortex_array::IntoCanonicalVTable::into_arrow in file /tmp/.tmpCdcVjR/vortex/vortex-array/src/canonical.rs:381

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_method_missing.ron

Failed in:
  method invert of trait BoolArrayTrait, previously in file /tmp/.tmpAQdU44/vortex-array/src/variants.rs:90
  method with_dyn of trait EncodingVTable, previously in file /tmp/.tmpAQdU44/vortex-array/src/encoding/mod.rs:89
  method search_sorted_usize of trait SearchSortedFn, previously in file /tmp/.tmpAQdU44/vortex-array/src/compute/search_sorted.rs:109
  method search_sorted_usize_many of trait SearchSortedFn, previously in file /tmp/.tmpAQdU44/vortex-array/src/compute/search_sorted.rs:132

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_missing.ron

Failed in:
  trait vortex_array::encoding::ArrayEncodingExt, previously in file /tmp/.tmpAQdU44/vortex-array/src/encoding/mod.rs:109
  trait vortex_array::compute::unary::ScalarAtFn, previously in file /tmp/.tmpAQdU44/vortex-array/src/compute/unary/scalar_at.rs:10
  trait vortex_array::compute::unary::SubtractScalarFn, previously in file /tmp/.tmpAQdU44/vortex-array/src/compute/unary/scalar_subtract.rs:8
  trait vortex_array::compute::unary::CastFn, previously in file /tmp/.tmpAQdU44/vortex-array/src/compute/unary/cast.rs:7
  trait vortex_array::ArrayDef, previously in file /tmp/.tmpAQdU44/vortex-array/src/macros.rs:12
  trait vortex_array::compute::unary::FillForwardFn, previously in file /tmp/.tmpAQdU44/vortex-array/src/compute/unary/fill_forward.rs:11
  trait vortex_array::variants::ArrayVariants, previously in file /tmp/.tmpAQdU44/vortex-array/src/variants.rs:14

--- failure trait_no_longer_object_safe: trait no longer object safe ---

Description:
Trait is no longer object safe, which breaks `dyn Trait` usage.
        ref: https://doc.rust-lang.org/stable/reference/items/traits.html#object-safety
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_no_longer_object_safe.ron

Failed in:
  trait Encoding in file /tmp/.tmpCdcVjR/vortex/vortex-array/src/encoding/mod.rs:63

--- failure trait_removed_supertrait: supertrait removed or renamed ---

Description:
A supertrait was removed from a trait. Users of the trait can no longer assume it can also be used like its supertrait.
        ref: https://doc.rust-lang.org/reference/items/traits.html#supertraits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_removed_supertrait.ron

Failed in:
  supertrait vortex_array::variants::ArrayVariants of trait ArrayTrait in file /tmp/.tmpCdcVjR/vortex/vortex-array/src/lib.rs:89
```

### ⚠️ `vortex-dtype` breaking changes

```
--- failure inherent_associated_pub_const_missing: inherent impl's associated pub const removed ---

Description:
An inherent impl's associated public constant is removed or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/inherent_associated_pub_const_missing.ron

Failed in:
  DType::IDX, previously at /tmp/.tmpAQdU44/vortex-dtype/src/dtype.rs:49
  DType::IDX_32, previously at /tmp/.tmpAQdU44/vortex-dtype/src/dtype.rs:52
```

### ⚠️ `vortex-flatbuffers` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ArrayArgs.buffers in /tmp/.tmpCdcVjR/vortex/vortex-flatbuffers/src/./generated/array.rs:248

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_missing.ron

Failed in:
  enum vortex_flatbuffers::message::BatchOffset, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:525
  enum vortex_flatbuffers::message::SchemaOffset, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:428
  enum vortex_flatbuffers::message::PageOffset, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:673

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/function_missing.ron

Failed in:
  function vortex_flatbuffers::array::finish_size_prefixed_array_buffer, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:612
  function vortex_flatbuffers::array::root_as_array_with_opts, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:571
  function vortex_flatbuffers::array::finish_array_buffer, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:605
  function vortex_flatbuffers::array::size_prefixed_root_as_array_unchecked, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:601
  function vortex_flatbuffers::array::root_as_array_unchecked, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:594
  function vortex_flatbuffers::array::size_prefixed_root_as_array_with_opts, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:584
  function vortex_flatbuffers::array::root_as_array, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:551
  function vortex_flatbuffers::array::size_prefixed_root_as_array, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:561

--- failure inherent_associated_pub_const_missing: inherent impl's associated pub const removed ---

Description:
An inherent impl's associated public constant is removed or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/inherent_associated_pub_const_missing.ron

Failed in:
  MessageHeader::Schema, previously at /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:196
  MessageHeader::Batch, previously at /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:197
  MessageHeader::Page, previously at /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:198
  Array::VT_VERSION, previously at /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:111
  Array::VT_BUFFER_INDEX, previously at /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:112

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/inherent_method_missing.ron

Failed in:
  ArrayBuilder::add_version, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:227
  ArrayBuilder::add_buffer_index, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:231
  Message::header_as_schema, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:847
  Message::header_as_batch, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:862
  Message::header_as_page, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:877
  Array::version, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:139
  Array::buffer_index, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:146

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  ENUM_VALUES_VERSION in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:20
  ENUM_MIN_VERSION in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:15
  ENUM_MAX_VERSION in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:17

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct vortex_flatbuffers::message::Buffer, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:275
  struct vortex_flatbuffers::message::BatchBuilder, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:627
  struct vortex_flatbuffers::message::PageArgs, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:737
  struct vortex_flatbuffers::message::Batch, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:528
  struct vortex_flatbuffers::message::Schema, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:431
  struct vortex_flatbuffers::message::Page, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:676
  struct vortex_flatbuffers::message::SchemaBuilder, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:494
  struct vortex_flatbuffers::message::PageBuilder, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:751
  struct vortex_flatbuffers::array::Version, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:26
  struct vortex_flatbuffers::message::SchemaArgs, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:482
  struct vortex_flatbuffers::message::BatchArgs, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/message.rs:609

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field version of struct ArrayArgs, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:200
  field buffer_index of struct ArrayArgs, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/./generated/array.rs:201

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_missing.ron

Failed in:
  trait vortex_flatbuffers::FlatBufferToBytes, previously in file /tmp/.tmpAQdU44/vortex-flatbuffers/src/lib.rs:147
```

### ⚠️ `vortex-fastlanes` breaking changes

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct vortex_fastlanes::Delta, previously in file /tmp/.tmpAQdU44/vortex-fastlanes/src/delta/mod.rs:21
  struct vortex_fastlanes::BitPacked, previously in file /tmp/.tmpAQdU44/vortex-fastlanes/src/bitpacking/mod.rs:23
  struct vortex_fastlanes::FoR, previously in file /tmp/.tmpAQdU44/vortex-fastlanes/src/for/mod.rs:20
```

### ⚠️ `vortex-bytebool` breaking changes

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct vortex_bytebool::ByteBool, previously in file /tmp/.tmpAQdU44/vortex-bytebool/src/array.rs:20
```

### ⚠️ `vortex-datetime-parts` breaking changes

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct vortex_datetime_parts::DateTimeParts, previously in file /tmp/.tmpAQdU44/vortex-datetime-parts/src/array.rs:21
```

### ⚠️ `vortex-dict` breaking changes

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct vortex_dict::Dict, previously in file /tmp/.tmpAQdU44/vortex-dict/src/array.rs:20
```

### ⚠️ `vortex-file` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_missing.ron

Failed in:
  enum vortex_file::BatchRead, previously in file /tmp/.tmpAQdU44/vortex-file/src/read/mod.rs:57

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/function_missing.ron

Failed in:
  function vortex_file::read_layout_from_initial, previously in file /tmp/.tmpAQdU44/vortex-file/src/read/builder/initial_read.rs:63

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/inherent_method_missing.ron

Failed in:
  RowMask::new_unchecked, previously in file /tmp/.tmpAQdU44/vortex-file/src/read/mask.rs:102
  RowMask::to_indices_array, previously in file /tmp/.tmpAQdU44/vortex-file/src/read/mask.rs:245
  VortexReadBuilder::with_size, previously in file /tmp/.tmpAQdU44/vortex-file/src/read/builder/mod.rs:87
  VortexReadBuilder::with_size, previously in file /tmp/.tmpAQdU44/vortex-file/src/read/builder/mod.rs:87
  LayoutSpec::inlined_schema, previously in file /tmp/.tmpAQdU44/vortex-file/src/write/layout.rs:53

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/method_parameter_count_changed.ron

Failed in:
  vortex_file::LayoutDeserializer::read_layout now takes 4 parameters instead of 5, in /tmp/.tmpCdcVjR/vortex/vortex-file/src/read/context.rs:72

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/module_missing.ron

Failed in:
  mod vortex_file::chunked_reader, previously in file /tmp/.tmpAQdU44/vortex-file/src/chunked_reader/mod.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  INLINE_SCHEMA_LAYOUT_ID in file /tmp/.tmpAQdU44/vortex-file/src/lib.rs:176

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct vortex_file::chunked_reader::ChunkedArrayReader, previously in file /tmp/.tmpAQdU44/vortex-file/src/chunked_reader/mod.rs:14
  struct vortex_file::layouts::InlineDTypeLayout, previously in file /tmp/.tmpAQdU44/vortex-file/src/read/layouts/inline_dtype.rs:19

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_method_added.ron

Failed in:
  trait method vortex_file::LayoutReader::poll_read in file /tmp/.tmpCdcVjR/vortex/vortex-file/src/read/mod.rs:123

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_method_missing.ron

Failed in:
  method read_selection of trait LayoutReader, previously in file /tmp/.tmpAQdU44/vortex-file/src/read/mod.rs:85
```

### ⚠️ `vortex-ipc` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_variant_added.ron

Failed in:
  variant IPCMessage:Array in /tmp/.tmpCdcVjR/vortex/vortex-ipc/src/messages/mod.rs:16
  variant IPCMessage:Buffer in /tmp/.tmpCdcVjR/vortex/vortex-ipc/src/messages/mod.rs:17
  variant IPCMessage:DType in /tmp/.tmpCdcVjR/vortex/vortex-ipc/src/messages/mod.rs:18

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_variant_missing.ron

Failed in:
  variant IPCMessage::Schema, previously in file /tmp/.tmpAQdU44/vortex-ipc/src/messages/mod.rs:17
  variant IPCMessage::Batch, previously in file /tmp/.tmpAQdU44/vortex-ipc/src/messages/mod.rs:18
  variant IPCMessage::Page, previously in file /tmp/.tmpAQdU44/vortex-ipc/src/messages/mod.rs:19

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/inherent_method_missing.ron

Failed in:
  MessageWriter::write_batch, previously in file /tmp/.tmpAQdU44/vortex-ipc/src/messages/writer.rs:74
  MessageReader::maybe_read_page, previously in file /tmp/.tmpAQdU44/vortex-ipc/src/messages/reader.rs:196

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct vortex_ipc::messages::IPCSchema, previously in file /tmp/.tmpAQdU44/vortex-ipc/src/messages/mod.rs:22
  struct vortex_ipc::messages::IPCPage, previously in file /tmp/.tmpAQdU44/vortex-ipc/src/messages/mod.rs:25
  struct vortex_ipc::messages::IPCArray, previously in file /tmp/.tmpAQdU44/vortex-ipc/src/messages/mod.rs:24
  struct vortex_ipc::messages::IPCBatch, previously in file /tmp/.tmpAQdU44/vortex-ipc/src/messages/mod.rs:23
```

### ⚠️ `vortex-sampling-compressor` breaking changes

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/inherent_method_missing.ron

Failed in:
  CompressionTree::num_descendants, previously in file /tmp/.tmpAQdU44/vortex-sampling-compressor/src/compressors/mod.rs:185
```

### ⚠️ `vortex-fsst` breaking changes

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct vortex_fsst::FSST, previously in file /tmp/.tmpAQdU44/vortex-fsst/src/array.rs:18
```

### ⚠️ `vortex-runend` breaking changes

```
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/function_parameter_count_changed.ron

Failed in:
  vortex_runend::compress::runend_decode_typed_bool now takes 5 parameters instead of 3, in /tmp/.tmpCdcVjR/vortex/encodings/runend/src/compress.rs:224
  vortex_runend::compress::runend_decode_primitive now takes 4 parameters instead of 5, in /tmp/.tmpCdcVjR/vortex/encodings/runend/src/compress.rs:140
  vortex_runend::compress::runend_decode_typed_primitive now takes 5 parameters instead of 3, in /tmp/.tmpCdcVjR/vortex/encodings/runend/src/compress.rs:176
  vortex_runend::compress::runend_decode_bools now takes 4 parameters instead of 5, in /tmp/.tmpCdcVjR/vortex/encodings/runend/src/compress.rs:159

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/inherent_method_missing.ron

Failed in:
  RunEndArray::validity, previously in file /tmp/.tmpAQdU44/vortex-runend/src/array.rs:146

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/method_parameter_count_changed.ron

Failed in:
  vortex_runend::RunEndArray::try_new now takes 2 parameters instead of 3, in /tmp/.tmpCdcVjR/vortex/encodings/runend/src/array.rs:39

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct vortex_runend::RunEnd, previously in file /tmp/.tmpAQdU44/vortex-runend/src/array.rs:24
```

### ⚠️ `vortex-runend-bool` breaking changes

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct vortex_runend_bool::RunEndBool, previously in file /tmp/.tmpAQdU44/vortex-runend-bool/src/array.rs:22
  struct vortex_runend_bool::array::RunEndBool, previously in file /tmp/.tmpAQdU44/vortex-runend-bool/src/array.rs:22
```

### ⚠️ `vortex-zigzag` breaking changes

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct vortex_zigzag::ZigZag, previously in file /tmp/.tmpAQdU44/vortex-zigzag/src/array.rs:22
```

### ⚠️ `vortex-roaring` breaking changes

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct vortex_roaring::RoaringBool, previously in file /tmp/.tmpAQdU44/vortex-roaring/src/boolean/mod.rs:26
  struct vortex_roaring::RoaringInt, previously in file /tmp/.tmpAQdU44/vortex-roaring/src/integer/mod.rs:26
```

### ⚠️ `vortex-datafusion` breaking changes

```
--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field VortexFileOpener.initial_read_cache in /tmp/.tmpCdcVjR/vortex/vortex-datafusion/src/persistent/opener.rs:28

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/method_parameter_count_changed.ron

Failed in:
  vortex_datafusion::persistent::execution::VortexExec::try_new now takes 5 parameters instead of 4, in /tmp/.tmpCdcVjR/vortex/vortex-datafusion/src/persistent/execution.rs:32
```

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).