### PR TITLE
fix: BitPackedArray enforces can only be built over non-negative values

### DIFF
--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -46,7 +46,7 @@ pub fn bitpack_encode(array: PrimitiveArray, bit_width: u8) -> VortexResult<BitP
 
     // SAFETY: values already checked to be non-negative.
     unsafe {
-        BitPackedArray::try_new(
+        BitPackedArray::new_unchecked(
             packed,
             array.ptype(),
             array.validity(),
@@ -73,7 +73,7 @@ pub unsafe fn bitpack_encode_unchecked(
     unsafe {
         let packed = bitpack_unchecked(&array, bit_width)?;
 
-        BitPackedArray::try_new(
+        BitPackedArray::new_unchecked(
             packed,
             array.ptype(),
             array.validity(),

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -20,6 +20,13 @@ pub fn bitpack_encode(array: PrimitiveArray, bit_width: u8) -> VortexResult<BitP
         .statistics()
         .compute_bit_width_freq()
         .ok_or_else(|| vortex_err!(ComputeError: "missing bit width frequency"))?;
+    let has_negative_values = match_each_integer_ptype!(array.ptype(), |$P| {
+        array.statistics().compute_min::<$P>().unwrap_or_default() < 0
+    });
+    if has_negative_values {
+        vortex_bail!("cannot bitpack_encode array containing negative integers")
+    }
+
     let num_exceptions = count_exceptions(bit_width, &bit_width_freq);
 
     if bit_width >= array.ptype().bit_width() as u8 {
@@ -32,14 +39,17 @@ pub fn bitpack_encode(array: PrimitiveArray, bit_width: u8) -> VortexResult<BitP
         .then(|| gather_patches(&array, bit_width, num_exceptions))
         .flatten();
 
-    BitPackedArray::try_new(
-        packed,
-        array.ptype(),
-        array.validity(),
-        patches,
-        bit_width,
-        array.len(),
-    )
+    // SAFETY: values already checked to be non-negative.
+    unsafe {
+        BitPackedArray::try_new(
+            packed,
+            array.ptype(),
+            array.validity(),
+            patches,
+            bit_width,
+            array.len(),
+        )
+    }
 }
 
 /// Bitpack an array into the specified bit-width without checking statistics.
@@ -56,19 +66,23 @@ pub unsafe fn bitpack_encode_unchecked(
 ) -> VortexResult<BitPackedArray> {
     let packed = bitpack(&array, bit_width)?;
 
-    BitPackedArray::try_new(
-        packed,
-        array.ptype(),
-        array.validity(),
-        None,
-        bit_width,
-        array.len(),
-    )
+    // SAFETY: non-negativity of values is enforced by the caller.
+    unsafe {
+        BitPackedArray::try_new(
+            packed,
+            array.ptype(),
+            array.validity(),
+            None,
+            bit_width,
+            array.len(),
+        )
+    }
 }
 
 /// Bitpack a [PrimitiveArray] to the given width.
 ///
-/// On success, returns a [Buffer] containing the packed data.
+/// On success, returns a [Buffer] containing the packed data. Before packing, values are
+/// reinterpreted to unsigned. It is the caller's responsibility to make sure this is fine.
 pub fn bitpack(parray: &PrimitiveArray, bit_width: u8) -> VortexResult<Buffer> {
     let parray = parray.reinterpret_cast(parray.ptype().to_unsigned());
     let packed = match_each_unsigned_integer_ptype!(parray.ptype(), |$P| {
@@ -358,7 +372,8 @@ pub fn count_exceptions(bit_width: u8, bit_width_freq: &[usize]) -> usize {
 #[cfg(test)]
 #[allow(clippy::cast_possible_truncation)]
 mod test {
-    use vortex_array::{IntoArrayVariant, IntoCanonical, ToArrayData};
+    use vortex_array::{IntoArrayVariant, ToArrayData};
+    use vortex_error::VortexError;
 
     use super::*;
 
@@ -430,25 +445,12 @@ mod test {
     }
 
     #[test]
-    fn compress_signed_roundtrip() {
+    fn compress_signed_fails() {
         let values: Vec<i64> = (-500..500).collect();
-        let array = PrimitiveArray::from_vec(values.clone(), Validity::AllValid);
+        let array = PrimitiveArray::from_vec(values, Validity::AllValid);
         assert!(array.ptype().is_signed_int());
 
-        let bitpacked_array =
-            BitPackedArray::encode(array.as_ref(), 1024u32.ilog2() as u8).unwrap();
-        let num_patches = bitpacked_array
-            .patches()
-            .as_ref()
-            .map(Patches::num_patches)
-            .unwrap_or_default();
-        assert_eq!(num_patches, 500);
-
-        let unpacked = bitpacked_array
-            .into_canonical()
-            .unwrap()
-            .into_primitive()
-            .unwrap();
-        assert_eq!(unpacked.into_maybe_null_slice::<i64>(), values);
+        let err = BitPackedArray::encode(array.as_ref(), 1024u32.ilog2() as u8).unwrap_err();
+        assert!(matches!(err, VortexError::InvalidArgument(_, _)));
     }
 }

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -20,11 +20,15 @@ pub fn bitpack_encode(array: PrimitiveArray, bit_width: u8) -> VortexResult<BitP
         .statistics()
         .compute_bit_width_freq()
         .ok_or_else(|| vortex_err!(ComputeError: "missing bit width frequency"))?;
-    let has_negative_values = match_each_integer_ptype!(array.ptype(), |$P| {
-        array.statistics().compute_min::<$P>().unwrap_or_default() < 0
-    });
-    if has_negative_values {
-        vortex_bail!("cannot bitpack_encode array containing negative integers")
+
+    // Check array contains no negative values.
+    if array.ptype().is_signed_int() {
+        let has_negative_values = match_each_integer_ptype!(array.ptype(), |$P| {
+            array.statistics().compute_min::<$P>().unwrap_or_default() < 0
+        });
+        if has_negative_values {
+            vortex_bail!("cannot bitpack_encode array containing negative integers")
+        }
     }
 
     let num_exceptions = count_exceptions(bit_width, &bit_width_freq);
@@ -34,7 +38,8 @@ pub fn bitpack_encode(array: PrimitiveArray, bit_width: u8) -> VortexResult<BitP
         vortex_bail!("Cannot pack -- specified bit width is greater than or equal to raw bit width")
     }
 
-    let packed = bitpack(&array, bit_width)?;
+    // SAFETY: we check that array only contains non-negative values.
+    let packed = unsafe { bitpack_unchecked(&array, bit_width)? };
     let patches = (num_exceptions > 0)
         .then(|| gather_patches(&array, bit_width, num_exceptions))
         .flatten();
@@ -64,10 +69,10 @@ pub unsafe fn bitpack_encode_unchecked(
     array: PrimitiveArray,
     bit_width: u8,
 ) -> VortexResult<BitPackedArray> {
-    let packed = bitpack(&array, bit_width)?;
-
-    // SAFETY: non-negativity of values is enforced by the caller.
+    // SAFETY: non-negativity of input checked by caller.
     unsafe {
+        let packed = bitpack_unchecked(&array, bit_width)?;
+
         BitPackedArray::try_new(
             packed,
             array.ptype(),
@@ -81,9 +86,16 @@ pub unsafe fn bitpack_encode_unchecked(
 
 /// Bitpack a [PrimitiveArray] to the given width.
 ///
-/// On success, returns a [Buffer] containing the packed data. Before packing, values are
-/// reinterpreted to unsigned. It is the caller's responsibility to make sure this is fine.
-pub fn bitpack(parray: &PrimitiveArray, bit_width: u8) -> VortexResult<Buffer> {
+/// On success, returns a [Buffer] containing the packed data.
+///
+/// # Safety
+///
+/// Internally this function will promote the provided array to its unsigned equivalent. This will
+/// violate ordering guarantees if the array contains any negative values.
+///
+/// It is the caller's responsibility to ensure that `parray` is non-negative before calling
+/// this function.
+pub unsafe fn bitpack_unchecked(parray: &PrimitiveArray, bit_width: u8) -> VortexResult<Buffer> {
     let parray = parray.reinterpret_cast(parray.ptype().to_unsigned());
     let packed = match_each_unsigned_integer_ptype!(parray.ptype(), |$P| {
         bitpack_primitive(parray.maybe_null_slice::<$P>(), bit_width)

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -24,7 +24,7 @@ pub fn bitpack_encode(array: PrimitiveArray, bit_width: u8) -> VortexResult<BitP
     // Check array contains no negative values.
     if array.ptype().is_signed_int() {
         let has_negative_values = match_each_integer_ptype!(array.ptype(), |$P| {
-            array.statistics().compute_min::<$P>().unwrap_or_default() < 0
+            array.statistics().compute_min::<Option<$P>>().unwrap_or_default().unwrap_or_default() < 0
         });
         if has_negative_values {
             vortex_bail!("cannot bitpack_encode array containing negative integers")

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -181,18 +181,18 @@ mod test {
         // Elements 0..=499 are negative integers (patches)
         // Element 500 = 0 (packed)
         // Elements 501..999 are positive integers (packed)
-        let values: Vec<i64> = (-500..500).collect_vec();
+        let values: Vec<i64> = (0..500).collect_vec();
         let unpacked = PrimitiveArray::from(values.clone());
         let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 9).unwrap();
         let filtered = filter(
             bitpacked.as_ref(),
-            FilterMask::from_indices(values.len(), 250..750),
+            FilterMask::from_indices(values.len(), 0..500),
         )
         .unwrap()
         .into_primitive()
         .unwrap()
         .into_maybe_null_slice::<i64>();
 
-        assert_eq!(filtered.as_slice(), &values[250..750]);
+        assert_eq!(filtered, values);
     }
 }

--- a/encodings/fastlanes/src/bitpacking/compute/scalar_at.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/scalar_at.rs
@@ -33,18 +33,21 @@ mod test {
 
     #[test]
     fn invalid_patches() {
-        let packed_array = BitPackedArray::try_new(
-            Buffer::from(vec![0u8; 128]),
-            PType::U32,
-            Validity::AllInvalid,
-            Some(Patches::new(
+        // SAFETY: using unsigned PType
+        let packed_array = unsafe {
+            BitPackedArray::try_new(
+                Buffer::from(vec![0u8; 128]),
+                PType::U32,
+                Validity::AllInvalid,
+                Some(Patches::new(
+                    8,
+                    PrimitiveArray::from_vec(vec![1u32], NonNullable).into_array(),
+                    PrimitiveArray::from_vec(vec![999u32], Validity::AllValid).into_array(),
+                )),
+                1,
                 8,
-                PrimitiveArray::from_vec(vec![1u32], NonNullable).into_array(),
-                PrimitiveArray::from_vec(vec![999u32], Validity::AllValid).into_array(),
-            )),
-            1,
-            8,
-        )
+            )
+        }
         .unwrap()
         .into_array();
         assert_eq!(

--- a/encodings/fastlanes/src/bitpacking/compute/scalar_at.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/scalar_at.rs
@@ -35,7 +35,7 @@ mod test {
     fn invalid_patches() {
         // SAFETY: using unsigned PType
         let packed_array = unsafe {
-            BitPackedArray::try_new(
+            BitPackedArray::new_unchecked(
                 Buffer::from(vec![0u8; 128]),
                 PType::U32,
                 Validity::AllInvalid,

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -26,7 +26,9 @@ impl TakeFn<BitPackedArray> for BitPackedEncoding {
             return take(array.clone().into_canonical()?.into_primitive()?, indices);
         }
 
-        let ptype: PType = array.dtype().try_into()?;
+        // NOTE: we use the unsigned PType because all values in the BitPackedArray must
+        //  be non-negative (pre-condition of creating the BitPackedArray).
+        let ptype: PType = PType::try_from(array.dtype())?.to_unsigned();
         let validity = array.validity();
         let taken_validity = validity.take(indices)?;
 

--- a/encodings/fastlanes/src/bitpacking/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/mod.rs
@@ -1,9 +1,9 @@
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
-use ::serde::{Deserialize, Serialize};
 pub use compress::*;
 use fastlanes::BitPacking;
+use ::serde::{Deserialize, Serialize};
 use vortex_array::array::PrimitiveArray;
 use vortex_array::encoding::ids;
 use vortex_array::patches::{Patches, PatchesMetadata};
@@ -43,11 +43,23 @@ impl BitPackedArray {
     ///
     /// The packed data should be interpreted as a sequence of values with size `bit_width`.
     ///
+    /// # Errors
+    ///
+    /// This method returns errors if any of the metadata is inconsistent, for example the packed
+    /// buffer provided does not have the right size according to the supplied length and target
+    /// PType.
+    ///
     /// # Safety
     ///
-    /// If `ptype` is signed, `packed` may **not** contain any values that once unpacked would
-    /// be interpreted as negative.
-    pub unsafe fn try_new(
+    /// For signed arrays, it is the caller's responsibility to ensure that there are no values
+    /// that can be interpreted once unpacked to the provided PType.
+    ///
+    /// This invariant is upheld by the compressor, but callers must ensure this if they wish to
+    /// construct a new `BitPackedArray` from parts.
+    ///
+    /// See also the [`encode`][Self::encode] method on this type for a safe path to create a new
+    /// bit-packed array.
+    pub unsafe fn new_unchecked(
         packed: Buffer,
         ptype: PType,
         validity: Validity,
@@ -55,10 +67,16 @@ impl BitPackedArray {
         bit_width: u8,
         len: usize,
     ) -> VortexResult<Self> {
-        Self::try_new_from_offset(packed, ptype, validity, patches, bit_width, len, 0)
+        // SAFETY: checked by caller.
+        unsafe {
+            Self::new_unchecked_with_offset(packed, ptype, validity, patches, bit_width, len, 0)
+        }
     }
 
-    pub(crate) fn try_new_from_offset(
+    /// An unsafe constructor for a `BitPackedArray` that also specifies a slicing offset.
+    ///
+    /// See also [`new_unchecked`][Self::new_unchecked].
+    pub(crate) unsafe fn new_unchecked_with_offset(
         packed: Buffer,
         ptype: PType,
         validity: Validity,
@@ -187,6 +205,17 @@ impl BitPackedArray {
         })
     }
 
+    /// Bit-pack an array of primitive integers down to the target bit-width using the FastLanes
+    /// SIMD-accelerated packing kernels.
+    ///
+    /// # Errors
+    ///
+    /// If the provided array is not an integer type, an error will be returned.
+    ///
+    /// If the provided array contains negative values, an error will be returned.
+    ///
+    /// If the requested bit-width for packing is larger than the array's native width, an
+    /// error will be returned.
     pub fn encode(array: &ArrayData, bit_width: u8) -> VortexResult<Self> {
         if let Ok(parray) = PrimitiveArray::try_from(array.clone()) {
             bitpack_encode(parray, bit_width)
@@ -195,8 +224,11 @@ impl BitPackedArray {
         }
     }
 
+    /// Calculate the maximum value that **can** be contained by this array, given its bit-width.
+    ///
+    /// Note that this value need not actually be present in the array.
     #[inline]
-    pub fn max_packed_value(&self) -> usize {
+    fn max_packed_value(&self) -> usize {
         (1 << self.bit_width()) - 1
     }
 }

--- a/encodings/fastlanes/src/bitpacking/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/mod.rs
@@ -241,20 +241,6 @@ impl VariantsVTable<BitPackedArray> for BitPackedEncoding {
 }
 
 impl PrimitiveArrayTrait for BitPackedArray {}
-// impl PrimitiveArrayTrait for BitPackedArray {
-//     fn ptype(&self) -> PType {
-//         // NOTE: we use the fastlanes::BitPack provided kernels for compute with BitPackedArray,
-//         //  which is only implemented for unsigned integer types.
-//         //  As a precondition of building a new BitPackedArray, we ensure that it may only
-//         //  contain non-negative values. Thus, it is always safe to read the packed data
-//         //  reinterpreted as the unsigned variant of any integer type.
-//         if let DType::Primitive(ptype, _) = self.dtype() {
-//             ptype.to_unsigned()
-//         } else {
-//             unreachable!()
-//         }
-//     }
-// }
 
 #[cfg(test)]
 mod test {

--- a/encodings/fastlanes/src/bitpacking/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/mod.rs
@@ -1,9 +1,9 @@
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
+use ::serde::{Deserialize, Serialize};
 pub use compress::*;
 use fastlanes::BitPacking;
-use ::serde::{Deserialize, Serialize};
 use vortex_array::array::PrimitiveArray;
 use vortex_array::encoding::ids;
 use vortex_array::patches::{Patches, PatchesMetadata};

--- a/encodings/fastlanes/src/bitpacking/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/mod.rs
@@ -1,9 +1,9 @@
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
-use ::serde::{Deserialize, Serialize};
 pub use compress::*;
 use fastlanes::BitPacking;
+use ::serde::{Deserialize, Serialize};
 use vortex_array::array::PrimitiveArray;
 use vortex_array::encoding::ids;
 use vortex_array::patches::{Patches, PatchesMetadata};
@@ -42,7 +42,12 @@ impl BitPackedArray {
     /// Create a new bitpacked array using a buffer of packed data.
     ///
     /// The packed data should be interpreted as a sequence of values with size `bit_width`.
-    pub fn try_new(
+    ///
+    /// # Safety
+    ///
+    /// If `ptype` is signed, `packed` may **not** contain any values that once unpacked would
+    /// be interpreted as negative.
+    pub unsafe fn try_new(
         packed: Buffer,
         ptype: PType,
         validity: Validity,
@@ -236,6 +241,20 @@ impl VariantsVTable<BitPackedArray> for BitPackedEncoding {
 }
 
 impl PrimitiveArrayTrait for BitPackedArray {}
+// impl PrimitiveArrayTrait for BitPackedArray {
+//     fn ptype(&self) -> PType {
+//         // NOTE: we use the fastlanes::BitPack provided kernels for compute with BitPackedArray,
+//         //  which is only implemented for unsigned integer types.
+//         //  As a precondition of building a new BitPackedArray, we ensure that it may only
+//         //  contain non-negative values. Thus, it is always safe to read the packed data
+//         //  reinterpreted as the unsigned variant of any integer type.
+//         if let DType::Primitive(ptype, _) = self.dtype() {
+//             ptype.to_unsigned()
+//         } else {
+//             unreachable!()
+//         }
+//     }
+// }
 
 #[cfg(test)]
 mod test {

--- a/vortex-array/src/stats/mod.rs
+++ b/vortex-array/src/stats/mod.rs
@@ -164,7 +164,10 @@ pub trait Statistics {
     /// Clear the value of the statistic
     fn clear(&self, stat: Stat);
 
-    /// Computes the value of the stat if it's not present
+    /// Computes the value of the stat if it's not present.
+    ///
+    /// Returns the scalar if compute succeeded, or `None` if the stat is not supported
+    /// for this array.
     fn compute(&self, stat: Stat) -> Option<Scalar>;
 
     /// Compute all the requested statistics (if not already present)
@@ -244,6 +247,9 @@ impl dyn Statistics + '_ {
             })
     }
 
+    /// Get or calculate the provided stat, converting the `Scalar` into a typed value.
+    ///
+    /// This function will panic if the conversion fails.
     pub fn compute_as<U: for<'a> TryFrom<&'a Scalar, Error = VortexError>>(
         &self,
         stat: Stat,
@@ -275,10 +281,16 @@ impl dyn Statistics + '_ {
             })
     }
 
+    /// Get or calculate the minimum value in the array, returning as a typed value.
+    ///
+    /// This function will panic if the conversion fails.
     pub fn compute_min<U: for<'a> TryFrom<&'a Scalar, Error = VortexError>>(&self) -> Option<U> {
         self.compute_as(Stat::Min)
     }
 
+    /// Get or calculate the maximum value in the array, returning as a typed value.
+    ///
+    /// This function will panic if the conversion fails.
     pub fn compute_max<U: for<'a> TryFrom<&'a Scalar, Error = VortexError>>(&self) -> Option<U> {
         self.compute_as(Stat::Max)
     }

--- a/vortex-array/src/variants.rs
+++ b/vortex-array/src/variants.rs
@@ -197,6 +197,10 @@ pub trait NullArrayTrait: ArrayTrait {}
 pub trait BoolArrayTrait: ArrayTrait {}
 
 pub trait PrimitiveArrayTrait: ArrayTrait {
+    /// The logical primitive type of the array.
+    ///
+    /// This is a type that can safely be converted into a `NativePType` for use in
+    /// `maybe_null_slice` or `into_maybe_null_slice`.
     fn ptype(&self) -> PType {
         if let DType::Primitive(ptype, ..) = self.dtype() {
             *ptype

--- a/vortex-sampling-compressor/src/compressors/bitpacked.rs
+++ b/vortex-sampling-compressor/src/compressors/bitpacked.rs
@@ -66,7 +66,7 @@ impl EncodingCompressor for BitPackedCompressor {
         // Only arrays with non-negative values can be bit-packed
         if !parray.ptype().is_unsigned_int() {
             let has_negative_elements = match_each_integer_ptype!(parray.ptype(), |$P| {
-                parray.statistics().compute_min::<$P>().unwrap_or_default() < 0
+                parray.statistics().compute_min::<Option<$P>>().unwrap_or_default().unwrap_or_default() < 0
             });
 
             if has_negative_elements {
@@ -94,7 +94,7 @@ impl EncodingCompressor for BitPackedCompressor {
         // Only arrays with non-negative values can be bit-packed
         if !parray.ptype().is_unsigned_int() {
             let has_negative_elements = match_each_integer_ptype!(parray.ptype(), |$P| {
-                parray.statistics().compute_min::<$P>().unwrap_or_default() < 0
+                parray.statistics().compute_min::<Option<$P>>().unwrap_or_default().unwrap_or_default() < 0
             });
 
             if has_negative_elements {

--- a/vortex-sampling-compressor/src/compressors/bitpacked.rs
+++ b/vortex-sampling-compressor/src/compressors/bitpacked.rs
@@ -5,6 +5,7 @@ use vortex_array::encoding::EncodingRef;
 use vortex_array::stats::ArrayStatistics;
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
+use vortex_dtype::match_each_integer_ptype;
 use vortex_error::{vortex_err, vortex_panic, VortexResult};
 use vortex_fastlanes::{
     bitpack, count_exceptions, find_best_bit_width, find_min_patchless_bit_width, gather_patches,
@@ -57,7 +58,17 @@ impl EncodingCompressor for BitPackedCompressor {
         // Only support primitive arrays
         let parray = PrimitiveArray::maybe_from(array)?;
 
+        // Only integer arrays can be bit-packed
         if !parray.ptype().is_int() {
+            return None;
+        }
+
+        // Only arrays with non-negative values can be bit-packed
+        let has_negative_elements = match_each_integer_ptype!(parray.ptype(), |$P| {
+            parray.statistics().compute_min::<$P>().unwrap_or_default() < 0
+        });
+
+        if has_negative_elements {
             return None;
         }
 
@@ -82,6 +93,15 @@ impl EncodingCompressor for BitPackedCompressor {
             .statistics()
             .compute_bit_width_freq()
             .ok_or_else(|| vortex_err!(ComputeError: "missing bit width frequency"))?;
+
+        // Only arrays with non-negative values can be bit-packed. If asked to compress
+        // an array with negative values, return the original array without compressing.
+        let has_negative_elements = match_each_integer_ptype!(parray.ptype(), |$P| {
+            parray.statistics().compute_min::<$P>().unwrap_or_default() < 0
+        });
+        if has_negative_elements {
+            return Ok(CompressedArray::uncompressed(array.clone()));
+        }
 
         let bit_width = self.find_bit_width(&parray)?;
         let num_exceptions = count_exceptions(bit_width, &bit_width_freq);
@@ -113,14 +133,17 @@ impl EncodingCompressor for BitPackedCompressor {
             .transpose()?;
 
         Ok(CompressedArray::compressed(
-            BitPackedArray::try_new(
-                packed_buffer,
-                parray.ptype(),
-                validity,
-                patches,
-                bit_width,
-                parray.len(),
-            )?
+            // SAFETY: we ensure the array contains no negative values.
+            unsafe {
+                BitPackedArray::try_new(
+                    packed_buffer,
+                    parray.ptype(),
+                    validity,
+                    patches,
+                    bit_width,
+                    parray.len(),
+                )?
+            }
             .into_array(),
             Some(CompressionTree::new(self, vec![])),
             array,

--- a/vortex-sampling-compressor/src/compressors/bitpacked.rs
+++ b/vortex-sampling-compressor/src/compressors/bitpacked.rs
@@ -159,3 +159,55 @@ impl EncodingCompressor for BitPackedCompressor {
         HashSet::from([&BitPackedEncoding as EncodingRef])
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use vortex_array::array::{ConstantArray, PrimitiveArray};
+    use vortex_array::IntoArrayData;
+
+    use crate::compressors::bitpacked::{BITPACK_NO_PATCHES, BITPACK_WITH_PATCHES};
+    use crate::compressors::EncodingCompressor;
+    use crate::SamplingCompressor;
+
+    #[test]
+    fn cannot_compress() {
+        // cannot compress when array contains negative values
+        assert!(BITPACK_NO_PATCHES
+            .can_compress(&PrimitiveArray::from(vec![-1i32, 0i32, 1i32]).into_array())
+            .is_none());
+
+        // Non-integer primitive array.
+        assert!(BITPACK_NO_PATCHES
+            .can_compress(&PrimitiveArray::from(vec![0f32, 1f32]).into_array())
+            .is_none());
+
+        // non-PrimitiveArray
+        assert!(BITPACK_NO_PATCHES
+            .can_compress(&ConstantArray::new(3u32, 10).into_array())
+            .is_none());
+    }
+
+    #[test]
+    fn can_compress() {
+        // Unsigned integers
+        assert!(BITPACK_NO_PATCHES
+            .can_compress(&PrimitiveArray::from(vec![0u32, 1u32, 2u32]).into_array())
+            .is_some());
+
+        // Signed non-negative integers
+        assert!(BITPACK_WITH_PATCHES
+            .can_compress(&PrimitiveArray::from(vec![0i32, 1i32, 2i32]).into_array())
+            .is_some());
+    }
+
+    #[test]
+    fn compress_negatives_fails() {
+        assert!(BITPACK_NO_PATCHES
+            .compress(
+                &PrimitiveArray::from(vec![-1i32, 0i32]).into_array(),
+                None,
+                SamplingCompressor::default(),
+            )
+            .is_err());
+    }
+}

--- a/vortex-sampling-compressor/src/compressors/bitpacked.rs
+++ b/vortex-sampling-compressor/src/compressors/bitpacked.rs
@@ -140,7 +140,7 @@ impl EncodingCompressor for BitPackedCompressor {
         Ok(CompressedArray::compressed(
             // SAFETY: we ensure the array contains no negative values.
             unsafe {
-                BitPackedArray::try_new(
+                BitPackedArray::new_unchecked(
                     packed_buffer,
                     parray.ptype(),
                     validity,

--- a/vortex-sampling-compressor/src/compressors/bitpacked.rs
+++ b/vortex-sampling-compressor/src/compressors/bitpacked.rs
@@ -6,10 +6,10 @@ use vortex_array::stats::ArrayStatistics;
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::match_each_integer_ptype;
-use vortex_error::{vortex_err, vortex_panic, VortexResult};
+use vortex_error::{vortex_bail, vortex_err, vortex_panic, VortexResult};
 use vortex_fastlanes::{
-    bitpack, count_exceptions, find_best_bit_width, find_min_patchless_bit_width, gather_patches,
-    BitPackedArray, BitPackedEncoding,
+    bitpack_unchecked, count_exceptions, find_best_bit_width, find_min_patchless_bit_width,
+    gather_patches, BitPackedArray, BitPackedEncoding,
 };
 
 use crate::compressors::{CompressedArray, CompressionTree, EncodingCompressor};
@@ -64,12 +64,14 @@ impl EncodingCompressor for BitPackedCompressor {
         }
 
         // Only arrays with non-negative values can be bit-packed
-        let has_negative_elements = match_each_integer_ptype!(parray.ptype(), |$P| {
-            parray.statistics().compute_min::<$P>().unwrap_or_default() < 0
-        });
+        if !parray.ptype().is_unsigned_int() {
+            let has_negative_elements = match_each_integer_ptype!(parray.ptype(), |$P| {
+                parray.statistics().compute_min::<$P>().unwrap_or_default() < 0
+            });
 
-        if has_negative_elements {
-            return None;
+            if has_negative_elements {
+                return None;
+            }
         }
 
         let bit_width = self.find_bit_width(&parray).ok()?;
@@ -89,19 +91,21 @@ impl EncodingCompressor for BitPackedCompressor {
         ctx: SamplingCompressor<'a>,
     ) -> VortexResult<CompressedArray<'a>> {
         let parray = array.clone().into_primitive()?;
+        // Only arrays with non-negative values can be bit-packed
+        if !parray.ptype().is_unsigned_int() {
+            let has_negative_elements = match_each_integer_ptype!(parray.ptype(), |$P| {
+                parray.statistics().compute_min::<$P>().unwrap_or_default() < 0
+            });
+
+            if has_negative_elements {
+                vortex_bail!("Cannot BitPackCompressor::compress an array with negative values");
+            }
+        }
+
         let bit_width_freq = parray
             .statistics()
             .compute_bit_width_freq()
             .ok_or_else(|| vortex_err!(ComputeError: "missing bit width frequency"))?;
-
-        // Only arrays with non-negative values can be bit-packed. If asked to compress
-        // an array with negative values, return the original array without compressing.
-        let has_negative_elements = match_each_integer_ptype!(parray.ptype(), |$P| {
-            parray.statistics().compute_min::<$P>().unwrap_or_default() < 0
-        });
-        if has_negative_elements {
-            return Ok(CompressedArray::uncompressed(array.clone()));
-        }
 
         let bit_width = self.find_bit_width(&parray)?;
         let num_exceptions = count_exceptions(bit_width, &bit_width_freq);
@@ -119,7 +123,8 @@ impl EncodingCompressor for BitPackedCompressor {
         }
 
         let validity = ctx.compress_validity(parray.validity())?;
-        let packed_buffer = bitpack(&parray, bit_width)?;
+        // SAFETY: we check that the array only contains non-negative values.
+        let packed_buffer = unsafe { bitpack_unchecked(&parray, bit_width)? };
         let patches = (num_exceptions > 0)
             .then(|| {
                 gather_patches(&parray, bit_width, num_exceptions).map(|p| {


### PR DESCRIPTION
Following up from #1699.

In the previous PR we allowed signed arrays to be bit-packed directly. However, we did not explicitly reject arrays with negative values. We **need** to do this because it is critical for ensuring we have fast `search_sorted` over BitPacked data with patches, only when the patches sort to the right-most side of the array can we do efficient binary search.

I've added explicit preconditions that values are non-negative, and made the BitPackedArray constructor unsafe to make it clear to callers that they must explicitly check this themselves (the recommended safe way to create a BPA is via the `BPA::encode()` method, which returns an Error if there are negative values).