### PR TITLE
fix: better child names

### DIFF
--- a/vortex-array/src/array/chunked/mod.rs
+++ b/vortex-array/src/array/chunked/mod.rs
@@ -208,7 +208,7 @@ impl VisitorVTable<ChunkedArray> for ChunkedEncoding {
     fn accept(&self, array: &ChunkedArray, visitor: &mut dyn ArrayVisitor) -> VortexResult<()> {
         visitor.visit_child("chunk_ends", &array.chunk_offsets())?;
         for (idx, chunk) in array.chunks().enumerate() {
-            visitor.visit_child(format!("[{}]", idx).as_str(), &chunk)?;
+            visitor.visit_child(format!("chunks[{}]", idx).as_str(), &chunk)?;
         }
         Ok(())
     }

--- a/vortex-array/src/array/struct_/mod.rs
+++ b/vortex-array/src/array/struct_/mod.rs
@@ -186,7 +186,7 @@ impl VisitorVTable<StructArray> for StructEncoding {
             let child = array
                 .field(idx)
                 .ok_or_else(|| vortex_err!(OutOfBounds: idx, 0, array.nfields()))?;
-            visitor.visit_child(&format!("\"{}\"", name), &child)?;
+            visitor.visit_child(name.as_ref(), &child)?;
         }
         Ok(())
     }


### PR DESCRIPTION
Making the names a bit better so they look better when displayed

<img width="347" alt="image" src="https://github.com/user-attachments/assets/f9471089-ce48-4038-a3c6-f5dc0dbff0c2" />


Would rather this be `chunks[76]  >  l_orderkey`, or maybe something else. Open to other preferences, I just don't really like current thing.