### PR TITLE
fix: sampling compressor overflow with large parameters

### DIFF
--- a/vortex-sampling-compressor/src/lib.rs
+++ b/vortex-sampling-compressor/src/lib.rs
@@ -190,6 +190,18 @@ pub struct CompressConfig {
     target_block_size: usize,
 }
 
+impl CompressConfig {
+    pub fn with_sample_size(mut self, sample_size: u16) -> Self {
+        self.sample_size = sample_size;
+        self
+    }
+
+    pub fn with_sample_count(mut self, sample_count: u16) -> Self {
+        self.sample_count = sample_count;
+        self
+    }
+}
+
 impl Default for CompressConfig {
     fn default() -> Self {
         let kib = 1 << 10;

--- a/vortex-sampling-compressor/src/sampling.rs
+++ b/vortex-sampling-compressor/src/sampling.rs
@@ -7,7 +7,7 @@ pub fn stratified_slices(
     sample_count: u16,
     rng: &mut StdRng,
 ) -> Vec<(usize, usize)> {
-    let total_num_samples: usize = (sample_count * sample_size) as usize;
+    let total_num_samples: usize = (sample_count as usize) * (sample_size as usize);
     if total_num_samples >= length {
         return vec![(0usize, length)];
     }


### PR DESCRIPTION
Our sample_size and sample_count parameters should be configurable.

As I was looking into #1723 I also noticed that we will runtime panic when the total sample > u16