### PR TITLE
Remove FSST copy

### DIFF
--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -446,7 +446,6 @@ impl Buf for ByteBufferMut {
 /// As per the BufMut implementation, we must support internal resizing when
 /// asked to extend the buffer.
 /// See: <https://github.com/tokio-rs/bytes/issues/131>
-
 unsafe impl BufMut for ByteBufferMut {
     #[inline]
     fn remaining_mut(&self) -> usize {


### PR DESCRIPTION
We don't currently align our buffers to 64 bytes, so we didn't actually need the FSST change to be zero-copy.