### PR TITLE
Improve alp decode

### DIFF
--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -66,15 +66,11 @@ pub fn alp_encode(parray: &PrimitiveArray) -> VortexResult<ALPArray> {
 pub fn decompress(array: ALPArray) -> VortexResult<PrimitiveArray> {
     let encoded = array.encoded().into_primitive()?;
     let validity = encoded.validity();
-    let exponents = array.exponents();
     let ptype = array.dtype().try_into()?;
 
     let decoded = match_each_alp_float_ptype!(ptype, |$T| {
         PrimitiveArray::new::<$T>(
-            encoded
-                .into_buffer::<<$T as ALPFloat>::ALPInt>()
-                .into_mut()
-                .map_each(move |encoded| ALPFloat::decode_single(*encoded, exponents)),
+            <$T>::decode_buffer(encoded.into_buffer().into_mut(), array.exponents()),
             validity,
         )
     });

--- a/encodings/alp/src/alp/mod.rs
+++ b/encodings/alp/src/alp/mod.rs
@@ -163,6 +163,11 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
         values
     }
 
+    #[inline(never)]
+    fn decode_buffer(encoded: BufferMut<Self::ALPInt>, exponents: Exponents) -> BufferMut<Self> {
+        encoded.map_each(move |encoded| Self::decode_single(encoded, exponents))
+    }
+
     #[inline(always)]
     fn decode_single(encoded: Self::ALPInt, exponents: Exponents) -> Self {
         Self::from_int(encoded) * Self::F10[exponents.f as usize] * Self::IF10[exponents.e as usize]

--- a/encodings/alp/src/alp/mod.rs
+++ b/encodings/alp/src/alp/mod.rs
@@ -163,7 +163,6 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
         values
     }
 
-    #[inline(never)]
     fn decode_buffer(encoded: BufferMut<Self::ALPInt>, exponents: Exponents) -> BufferMut<Self> {
         encoded.map_each(move |encoded| Self::decode_single(encoded, exponents))
     }

--- a/encodings/fastlanes/src/for/compress.rs
+++ b/encodings/fastlanes/src/for/compress.rs
@@ -127,10 +127,10 @@ fn decompress_primitive<T: NativePType + WrappingAdd + PrimInt>(
 ) -> Buffer<T> {
     if shift > 0 {
         if min == T::zero() {
-            values.map_each(move |v| *v << shift).freeze()
+            values.map_each(move |v| v << shift).freeze()
         } else {
             values
-                .map_each(move |v| (*v << shift).wrapping_add(&min))
+                .map_each(move |v| (v << shift).wrapping_add(&min))
                 .freeze()
         }
     } else {

--- a/encodings/zigzag/src/compress.rs
+++ b/encodings/zigzag/src/compress.rs
@@ -32,7 +32,7 @@ where
     <T as ExternalZigZag>::UInt: NativePType,
 {
     PrimitiveArray::new(
-        values.into_mut().map_each(|v| T::encode(*v)).freeze(),
+        values.into_mut().map_each(|v| T::encode(v)).freeze(),
         validity,
     )
 }
@@ -60,7 +60,7 @@ where
     <T as ExternalZigZag>::UInt: NativePType,
 {
     PrimitiveArray::new(
-        values.into_mut().map_each(|v| T::decode(*v)).freeze(),
+        values.into_mut().map_each(|v| T::decode(v)).freeze(),
         validity,
     )
 }

--- a/vortex-array/src/array/primitive/mod.rs
+++ b/vortex-array/src/array/primitive/mod.rs
@@ -187,12 +187,12 @@ impl PrimitiveArray {
     where
         T: NativePType,
         R: NativePType,
-        F: FnMut(&T) -> R,
+        F: FnMut(T) -> R,
     {
         let validity = self.validity();
         let buffer = match self.try_into_buffer_mut() {
             Ok(buffer_mut) => buffer_mut.map_each(f),
-            Err(parray) => BufferMut::<R>::from_iter(parray.buffer::<T>().iter().map(f)),
+            Err(parray) => BufferMut::<R>::from_iter(parray.buffer::<T>().iter().copied().map(f)),
         };
         PrimitiveArray::new(buffer.freeze(), validity)
     }

--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -443,7 +443,6 @@ impl Buf for ByteBufferMut {
 /// As per the BufMut implementation, we must support internal resizing when
 /// asked to extend the buffer.
 /// See: <https://github.com/tokio-rs/bytes/issues/131>
-
 unsafe impl BufMut for ByteBufferMut {
     #[inline]
     fn remaining_mut(&self) -> usize {

--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -305,21 +305,18 @@ impl<T> BufferMut<T> {
     /// Map each element of the buffer with a closure.
     pub fn map_each<R, F>(self, mut f: F) -> BufferMut<R>
     where
-        F: FnMut(&T) -> R,
+        T: Copy,
+        F: FnMut(T) -> R,
     {
         assert_eq!(
             size_of::<T>(),
             size_of::<R>(),
             "Size of T and R do not match"
         );
-        let length = self.len();
         // SAFETY: we have checked that `size_of::<T>` == `size_of::<R>`.
         let mut buf: BufferMut<R> = unsafe { std::mem::transmute(self) };
-        for i in 0..length {
-            // We transmute _back_ the R value into the original T to invoke the closure.
-            let src: &T = unsafe { std::mem::transmute(&buf[i]) };
-            buf.as_mut_slice()[i] = f(src);
-        }
+        buf.iter_mut()
+            .for_each(|item| *item = f(unsafe { std::mem::transmute_copy(item) }));
         buf
     }
 


### PR DESCRIPTION
* Improves the performance of map_each. We make `T: Copy` so that we can pass the value while holding a mutable reference to its position in the original array and appease the borrow checker.
* Brings back the decode_vec/buffer function in ALP (was easier to verify ASM, compiler seems happier inlining into the smaller function possibly?)
