### PR TITLE
Store PValue in FoR metadata

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -46,9 +46,9 @@ Use :func:`~vortex.encoding.compress` to compress the Vortex array and check the
 
    >>> cvtx = vortex.compress(vtx)
    >>> cvtx.nbytes
-   16859
+   16606
    >>> cvtx.nbytes / vtx.nbytes
-   0.119...
+   0.117...
 
 Vortex uses nearly ten times fewer bytes than Arrow. Fewer bytes means more of your data fits in
 cache and RAM.

--- a/vortex-scalar/src/primitive.rs
+++ b/vortex-scalar/src/primitive.rs
@@ -176,9 +176,17 @@ impl std::ops::Sub for PrimitiveScalar<'_> {
 
 impl Scalar {
     pub fn primitive<T: NativePType + Into<PValue>>(value: T, nullability: Nullability) -> Self {
+        Self::primitive_value(value.into(), T::PTYPE, nullability)
+    }
+
+    /// Create a PrimitiveScalar from a PValue.
+    ///
+    /// Note that an explicit PType is passed since any compatible PValue may be used as the value
+    /// for a primitive type.
+    pub fn primitive_value(value: PValue, ptype: PType, nullability: Nullability) -> Self {
         Self {
-            dtype: DType::Primitive(T::PTYPE, nullability),
-            value: ScalarValue(InnerScalarValue::Primitive(value.into())),
+            dtype: DType::Primitive(ptype, nullability),
+            value: ScalarValue(InnerScalarValue::Primitive(value)),
         }
     }
 

--- a/vortex-scalar/src/serde/serde.rs
+++ b/vortex-scalar/src/serde/serde.rs
@@ -184,3 +184,16 @@ impl Serialize for PValue {
         }
     }
 }
+
+impl<'de> Deserialize<'de> for PValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        ScalarValue::deserialize(deserializer)
+            .and_then(|scalar| scalar.0.as_pvalue().map_err(|e| Error::custom(e)))
+            .and_then(|pvalue| {
+                pvalue.ok_or_else(|| Error::custom("Expected a non-null primitive scalar value"))
+            })
+    }
+}

--- a/vortex-scalar/src/serde/serde.rs
+++ b/vortex-scalar/src/serde/serde.rs
@@ -191,7 +191,7 @@ impl<'de> Deserialize<'de> for PValue {
         D: Deserializer<'de>,
     {
         ScalarValue::deserialize(deserializer)
-            .and_then(|scalar| scalar.0.as_pvalue().map_err(|e| Error::custom(e)))
+            .and_then(|scalar| scalar.0.as_pvalue().map_err(Error::custom))
             .and_then(|pvalue| {
                 pvalue.ok_or_else(|| Error::custom("Expected a non-null primitive scalar value"))
             })


### PR DESCRIPTION
It's quite a bit smaller than a ScalarValue

(And should mean the BI benchmarks go back to using FoR instead of Dict. I know it's not a proper fix, but it's a positive change regardless)