### PR TITLE
Pull out message cache from layout reader

### DIFF
--- a/vortex-file/src/read/handle.rs
+++ b/vortex-file/src/read/handle.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeSet;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use futures::stream;
 use itertools::Itertools;
@@ -20,7 +20,7 @@ pub struct VortexReadHandle<R> {
     splits: Vec<(usize, usize)>,
     layout_reader: Arc<dyn LayoutReader>,
     filter_reader: Option<Arc<dyn LayoutReader>>,
-    messages_cache: Arc<RwLock<LayoutMessageCache>>,
+    messages_cache: LayoutMessageCache,
     row_mask: Option<RowMask>,
     io_dispatcher: Arc<IoDispatcher>,
 }
@@ -31,7 +31,7 @@ impl<R: VortexReadAt + Unpin> VortexReadHandle<R> {
         input: R,
         layout_reader: Arc<dyn LayoutReader>,
         filter_reader: Option<Arc<dyn LayoutReader>>,
-        messages_cache: Arc<RwLock<LayoutMessageCache>>,
+        messages_cache: LayoutMessageCache,
         dtype: Arc<LazyDType>,
         row_count: u64,
         row_mask: Option<RowMask>,

--- a/vortex-file/src/read/layouts/flat.rs
+++ b/vortex-file/src/read/layouts/flat.rs
@@ -8,11 +8,10 @@ use vortex_flatbuffers::footer;
 use vortex_ipc::messages::{BufMessageReader, DecoderMessage};
 
 use crate::byte_range::ByteRange;
-use crate::read::cache::RelativeLayoutCache;
 use crate::read::mask::RowMask;
 use crate::{
-    Layout, LayoutDeserializer, LayoutId, LayoutReader, LazyDType, MessageLocator, PollRead, Scan,
-    FLAT_LAYOUT_ID,
+    Layout, LayoutDeserializer, LayoutId, LayoutPath, LayoutReader, LazyDType, MessageCache,
+    MessageLocator, PollRead, Scan, FLAT_LAYOUT_ID,
 };
 
 #[derive(Debug)]
@@ -25,11 +24,11 @@ impl Layout for FlatLayout {
 
     fn reader(
         &self,
+        path: LayoutPath,
         layout: footer::Layout,
         dtype: Arc<LazyDType>,
         scan: Scan,
         layout_serde: LayoutDeserializer,
-        message_cache: RelativeLayoutCache,
     ) -> VortexResult<Arc<dyn LayoutReader>> {
         let buffers = layout.buffers().unwrap_or_default();
         if buffers.len() != 1 {
@@ -38,27 +37,27 @@ impl Layout for FlatLayout {
         let buf = buffers.get(0);
 
         Ok(Arc::new(FlatLayoutReader {
+            path,
             range: ByteRange::new(buf.begin(), buf.end()),
             scan,
             dtype,
             ctx: layout_serde.ctx(),
-            message_cache,
         }))
     }
 }
 
 #[derive(Debug)]
 pub struct FlatLayoutReader {
+    path: LayoutPath,
     range: ByteRange,
     scan: Scan,
     dtype: Arc<LazyDType>,
     ctx: Arc<Context>,
-    message_cache: RelativeLayoutCache,
 }
 
 impl FlatLayoutReader {
     fn own_message(&self) -> MessageLocator {
-        MessageLocator(self.message_cache.absolute_id(&[]), self.range)
+        MessageLocator(self.path.clone(), self.range)
     }
 
     fn array_from_bytes(&self, buf: Bytes) -> VortexResult<ArrayData> {
@@ -79,8 +78,12 @@ impl LayoutReader for FlatLayoutReader {
         Ok(())
     }
 
-    fn poll_read(&self, selection: &RowMask) -> VortexResult<Option<PollRead<ArrayData>>> {
-        if let Some(buf) = self.message_cache.get(&[]) {
+    fn poll_read(
+        &self,
+        selection: &RowMask,
+        msgs: &dyn MessageCache,
+    ) -> VortexResult<Option<PollRead<ArrayData>>> {
+        if let Some(buf) = msgs.get(&[]) {
             let array = self.array_from_bytes(buf)?;
             selection
                 .filter_array(array)?
@@ -103,7 +106,7 @@ impl LayoutReader for FlatLayoutReader {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, RwLock};
+    use std::sync::Arc;
 
     use bytes::Bytes;
     use vortex_array::{Context, IntoArrayData, IntoArrayVariant, ToArrayData};
@@ -114,13 +117,11 @@ mod tests {
 
     use crate::byte_range::ByteRange;
     use crate::layouts::flat::FlatLayoutReader;
-    use crate::read::cache::{LazyDType, RelativeLayoutCache};
+    use crate::read::cache::LazyDType;
     use crate::read::layouts::test_read::{filter_read_layout, read_layout};
-    use crate::{LayoutMessageCache, RowFilter, Scan};
+    use crate::{LayoutMessageCache, LayoutPath, RowFilter, Scan};
 
-    async fn read_only_layout(
-        cache: Arc<RwLock<LayoutMessageCache>>,
-    ) -> (FlatLayoutReader, Bytes, usize, Arc<LazyDType>) {
+    async fn read_only_layout() -> (FlatLayoutReader, Bytes, usize, Arc<LazyDType>) {
         let array = Buffer::from_iter(0..100).into_array();
 
         let mut written = vec![];
@@ -133,11 +134,11 @@ mod tests {
 
         (
             FlatLayoutReader {
+                path: LayoutPath::default(),
                 range: ByteRange::new(0, written.len() as u64),
                 scan: projection_scan,
                 dtype: dtype.clone(),
                 ctx: Arc::new(Context::default()),
-                message_cache: RelativeLayoutCache::new(cache),
             },
             Bytes::from(written),
             array.len(),
@@ -145,19 +146,16 @@ mod tests {
         )
     }
 
-    async fn layout_and_bytes(
-        cache: Arc<RwLock<LayoutMessageCache>>,
-        scan: Scan,
-    ) -> (FlatLayoutReader, FlatLayoutReader, Bytes, usize) {
-        let (read_layout, bytes, len, dtype) = read_only_layout(cache.clone()).await;
+    async fn layout_and_bytes(scan: Scan) -> (FlatLayoutReader, FlatLayoutReader, Bytes, usize) {
+        let (read_layout, bytes, len, dtype) = read_only_layout().await;
 
         (
             FlatLayoutReader {
+                path: LayoutPath::default(),
                 range: ByteRange::new(0, bytes.len() as u64),
                 scan,
                 ctx: Arc::new(Context::default()),
                 dtype,
-                message_cache: RelativeLayoutCache::new(cache),
             },
             read_layout,
             bytes,
@@ -168,18 +166,16 @@ mod tests {
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
     async fn read_range() {
-        let cache = Arc::new(RwLock::new(LayoutMessageCache::default()));
-        let (filter_layout, projection_layout, buf, length) = layout_and_bytes(
-            cache.clone(),
-            Scan::new(RowFilter::new_expr(BinaryExpr::new_expr(
+        let msgs = LayoutMessageCache::default();
+        let (filter_layout, projection_layout, buf, length) =
+            layout_and_bytes(Scan::new(RowFilter::new_expr(BinaryExpr::new_expr(
                 Arc::new(Identity),
                 Operator::Gt,
                 Literal::new_expr(10.into()),
-            ))),
-        )
-        .await;
+            ))))
+            .await;
         let arr =
-            filter_read_layout(&filter_layout, &projection_layout, cache, &buf, length).pop_front();
+            filter_read_layout(&filter_layout, &projection_layout, &buf, length, msgs).pop_front();
 
         assert!(arr.is_some());
         let arr = arr.unwrap();
@@ -192,9 +188,9 @@ mod tests {
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
     async fn read_range_no_filter() {
-        let cache = Arc::new(RwLock::new(LayoutMessageCache::default()));
-        let (data_layout, buf, length, ..) = read_only_layout(cache.clone()).await;
-        let arr = read_layout(&data_layout, cache, &buf, length).pop_front();
+        let msgs = LayoutMessageCache::default();
+        let (data_layout, buf, length, ..) = read_only_layout().await;
+        let arr = read_layout(&data_layout, &buf, length, msgs).pop_front();
 
         assert!(arr.is_some());
         let arr = arr.unwrap();
@@ -207,18 +203,16 @@ mod tests {
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
     async fn read_empty() {
-        let cache = Arc::new(RwLock::new(LayoutMessageCache::default()));
-        let (filter_layout, projection_layout, buf, length) = layout_and_bytes(
-            cache.clone(),
-            Scan::new(RowFilter::new_expr(BinaryExpr::new_expr(
+        let msgs = LayoutMessageCache::default();
+        let (filter_layout, projection_layout, buf, length) =
+            layout_and_bytes(Scan::new(RowFilter::new_expr(BinaryExpr::new_expr(
                 Arc::new(Identity),
                 Operator::Gt,
                 Literal::new_expr(101.into()),
-            ))),
-        )
-        .await;
+            ))))
+            .await;
         let arr =
-            filter_read_layout(&filter_layout, &projection_layout, cache, &buf, length).pop_front();
+            filter_read_layout(&filter_layout, &projection_layout, &buf, length, msgs).pop_front();
 
         assert!(arr.is_none());
     }

--- a/vortex-file/src/read/layouts/flat.rs
+++ b/vortex-file/src/read/layouts/flat.rs
@@ -83,7 +83,7 @@ impl LayoutReader for FlatLayoutReader {
         selection: &RowMask,
         msgs: &dyn MessageCache,
     ) -> VortexResult<Option<PollRead<ArrayData>>> {
-        if let Some(buf) = msgs.get(&[]) {
+        if let Some(buf) = msgs.get(&self.path) {
             let array = self.array_from_bytes(buf)?;
             selection
                 .filter_array(array)?

--- a/vortex-file/src/read/layouts/test_read.rs
+++ b/vortex-file/src/read/layouts/test_read.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeSet, VecDeque};
-use std::sync::{Arc, RwLock};
 
 use bytes::Bytes;
 use itertools::Itertools;
@@ -24,17 +23,17 @@ fn layout_splits(layouts: &[&dyn LayoutReader], length: usize) -> impl Iterator<
 
 pub fn read_layout_data(
     layout: &dyn LayoutReader,
-    cache: Arc<RwLock<LayoutMessageCache>>,
     buf: &Bytes,
     selector: &RowMask,
+    mut msgs: LayoutMessageCache,
 ) -> Option<ArrayData> {
-    while let Some(rr) = layout.poll_read(selector).unwrap() {
+    while let Some(rr) = layout.poll_read(selector, &msgs).unwrap() {
         match rr {
             PollRead::ReadMore(m) => {
-                let mut write_cache_guard = cache.write().unwrap();
-                for MessageLocator(id, range) in m {
-                    write_cache_guard.set(id, buf.slice(range.as_range()));
-                }
+                msgs.set_many(
+                    m.into_iter()
+                        .map(|MessageLocator(id, range)| (id, buf.slice(range.as_range()))),
+                );
             }
             PollRead::Value(a) => return Some(a),
         }
@@ -44,17 +43,17 @@ pub fn read_layout_data(
 
 pub fn read_filters(
     layout: &dyn LayoutReader,
-    cache: Arc<RwLock<LayoutMessageCache>>,
     buf: &Bytes,
     selector: &RowMask,
+    mut msgs: LayoutMessageCache,
 ) -> Option<RowMask> {
-    while let Some(rr) = layout.poll_read(selector).unwrap() {
+    while let Some(rr) = layout.poll_read(selector, &msgs).unwrap() {
         match rr {
             PollRead::ReadMore(m) => {
-                let mut write_cache_guard = cache.write().unwrap();
-                for MessageLocator(id, range) in m {
-                    write_cache_guard.set(id, buf.slice(range.as_range()));
-                }
+                msgs.set_many(
+                    m.into_iter()
+                        .map(|MessageLocator(id, range)| (id, buf.slice(range.as_range()))),
+                );
             }
             PollRead::Value(a) => {
                 return Some(RowMask::from_array(&a, selector.begin(), selector.end()).unwrap());
@@ -68,23 +67,23 @@ pub fn read_filters(
 pub fn filter_read_layout(
     filter_layout: &dyn LayoutReader,
     layout: &dyn LayoutReader,
-    cache: Arc<RwLock<LayoutMessageCache>>,
     buf: &Bytes,
     length: usize,
+    msgs: LayoutMessageCache,
 ) -> VecDeque<ArrayData> {
     layout_splits(&[filter_layout, layout], length)
-        .flat_map(|s| read_filters(filter_layout, cache.clone(), buf, &s))
-        .flat_map(|s| read_layout_data(layout, cache.clone(), buf, &s))
+        .flat_map(|s| read_filters(filter_layout, buf, &s, msgs.clone()))
+        .flat_map(|s| read_layout_data(layout, buf, &s, msgs.clone()))
         .collect()
 }
 
 pub fn read_layout(
     layout: &dyn LayoutReader,
-    cache: Arc<RwLock<LayoutMessageCache>>,
     buf: &Bytes,
     length: usize,
+    msgs: LayoutMessageCache,
 ) -> VecDeque<ArrayData> {
     layout_splits(&[layout], length)
-        .flat_map(|s| read_layout_data(layout, cache.clone(), buf, &s))
+        .flat_map(|s| read_layout_data(layout, buf, &s, msgs.clone()))
         .collect()
 }

--- a/vortex-file/src/read/mod.rs
+++ b/vortex-file/src/read/mod.rs
@@ -63,6 +63,7 @@ impl From<Option<ExprRef>> for Scan {
 /// Unique identifier for a message within a layout
 pub type LayoutPartId = u16;
 /// Path through layout tree to given message
+pub type LayoutPath = Vec<LayoutPartId>;
 pub type MessageId = Vec<LayoutPartId>;
 /// A unique locator for a message, including its ID and byte range containing
 /// the message contents.
@@ -121,19 +122,31 @@ pub trait LayoutReader: Debug + Send + Sync {
     /// creating the invoked instance of this trait and then call back into this function.
     ///
     /// The layout is finished producing data for selection when it returns None
-    fn poll_read(&self, selector: &RowMask) -> VortexResult<Option<PollRead<ArrayData>>>;
+    fn poll_read(
+        &self,
+        selector: &RowMask,
+        msgs: &dyn MessageCache,
+    ) -> VortexResult<Option<PollRead<ArrayData>>>;
 
     /// Reads the metadata of the layout, if it exists.
     ///
     /// `LayoutReader`s can override the default behavior, which is to return no metadata.
-    fn poll_metadata(&self) -> VortexResult<Option<PollRead<Vec<Option<ArrayData>>>>> {
+    fn poll_metadata(
+        &self,
+        _msgs: &dyn MessageCache,
+    ) -> VortexResult<Option<PollRead<Vec<Option<ArrayData>>>>> {
         Ok(None)
     }
 
     /// Introspect to determine if we can prune the given [begin, end) row range.
     ///
     /// `LayoutReader`s can opt out of the default implementation, which is to not prune.
-    fn poll_prune(&self, _begin: usize, _end: usize) -> VortexResult<PollRead<Prune>> {
+    fn poll_prune(
+        &self,
+        _begin: usize,
+        _end: usize,
+        _msgs: &dyn MessageCache,
+    ) -> VortexResult<PollRead<Prune>> {
         Ok(PollRead::Value(Prune::CannotPrune))
     }
 }

--- a/vortex-file/src/read/mod.rs
+++ b/vortex-file/src/read/mod.rs
@@ -118,8 +118,8 @@ pub trait LayoutReader: Debug + Send + Sync {
     ///
     /// Layout is required to return all data for given selection in one batch.  Layout can either
     /// return a batch of data (i.e., an Array) or ask for more layout messages to be read. When
-    /// requesting messages to be read the caller should populate the message cache used when
-    /// creating the invoked instance of this trait and then call back into this function.
+    /// requesting messages to be read the caller should populate the message cache before invoking
+    /// the poll function again.
     ///
     /// The layout is finished producing data for selection when it returns None
     fn poll_read(

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::cast_possible_truncation)]
 use std::collections::BTreeSet;
 use std::iter;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use bytes::Bytes;
 use futures::StreamExt;
@@ -23,8 +23,8 @@ use vortex_io::VortexReadAt;
 use crate::builder::initial_read::read_initial_bytes;
 use crate::write::VortexFileWriter;
 use crate::{
-    LayoutDeserializer, LayoutMessageCache, Projection, RelativeLayoutCache, RowFilter, Scan,
-    VortexReadBuilder, V1_FOOTER_FBS_SIZE, VERSION,
+    LayoutDeserializer, LayoutPath, Projection, RowFilter, Scan, VortexReadBuilder,
+    V1_FOOTER_FBS_SIZE, VERSION,
 };
 
 #[test]
@@ -133,14 +133,13 @@ async fn test_splits() {
     let layout_serde = LayoutDeserializer::default();
 
     let dtype = Arc::new(initial_read.lazy_dtype());
-    let cache = Arc::new(RwLock::new(LayoutMessageCache::new()));
 
     let layout_reader = layout_serde
         .read_layout(
+            LayoutPath::default(),
             initial_read.fb_layout(),
             Scan::empty(),
             dtype,
-            RelativeLayoutCache::new(cache),
         )
         .unwrap();
 


### PR DESCRIPTION
* More closely aligns to the poll_read pattern where the thing being read is passed in.
* Working towards moving to MessageIds instead of layout paths, so this is a temporary intermediate state.