### PR TITLE
fix: InitialRead will refetch data to capture schema + layout

### DIFF
--- a/vortex-file/src/read/builder/initial_read.rs
+++ b/vortex-file/src/read/builder/initial_read.rs
@@ -1,7 +1,7 @@
 use core::ops::Range;
 
 use flatbuffers::{root, root_unchecked};
-use vortex_buffer::{ByteBuffer, ConstBuffer};
+use vortex_buffer::{ByteBuffer, ByteBufferMut, ConstBuffer};
 use vortex_error::{vortex_bail, vortex_err, VortexResult, VortexUnwrap};
 use vortex_flatbuffers::{dtype as fbd, footer};
 use vortex_io::VortexReadAt;
@@ -71,9 +71,9 @@ pub async fn read_initial_bytes<R: VortexReadAt>(
 
     let read_size = INITIAL_READ_SIZE.min(file_size as usize);
 
-    let initial_read_offset = file_size - read_size as u64;
+    let mut initial_read_offset = file_size - read_size as u64;
 
-    let buf = ByteBuffer::from(
+    let mut buf = ByteBuffer::from(
         read.read_byte_range(initial_read_offset, read_size as u64)
             .await?,
     );
@@ -94,7 +94,6 @@ pub async fn read_initial_bytes<R: VortexReadAt>(
         vortex_bail!("Malformed file, unsupported version {version}")
     }
 
-    // The footer MUST fit in the initial read.
     let ps_size =
         u16::from_le_bytes(buf[eof_loc + 2..eof_loc + 4].try_into().vortex_unwrap()) as usize;
     if ps_size > eof_loc {
@@ -107,7 +106,7 @@ pub async fn read_initial_bytes<R: VortexReadAt>(
     }
 
     let ps_loc = eof_loc - ps_size;
-    let fb_postscript_byte_range = ps_loc..eof_loc;
+    let mut fb_postscript_byte_range = ps_loc..eof_loc;
 
     // we validate the footer here
     let postscript = root::<footer::Postscript>(&buf[fb_postscript_byte_range.clone()])?;
@@ -130,13 +129,24 @@ pub async fn read_initial_bytes<R: VortexReadAt>(
         )
     }
 
+    // If the schema is not in the initial read, we need to read more bytes.
+    // Note that this will perform a copy of the initial read, since we are prepending the schema.
     if schema_offset < initial_read_offset {
-        // TODO: instead of bailing, we can just read more bytes.
-        vortex_bail!(
-            "Schema, layout, & footer must be in the initial read, got schema at {} and initial read from {}",
-            schema_offset,
-            initial_read_offset,
-        )
+        let mut buf_builder = ByteBufferMut::with_capacity((file_size - schema_offset).try_into()?);
+        let prefix_bytes = initial_read_offset - schema_offset;
+        let leftover = read.read_byte_range(schema_offset, prefix_bytes).await?;
+
+        let prefix_bytes: usize = prefix_bytes.try_into()?;
+
+        buf_builder.extend(leftover.into_iter());
+        buf_builder.extend(buf.into_iter());
+
+        buf = buf_builder.freeze();
+        // Reset the absolute offsets to account for the new data that was fetched and
+        // prepended to the buffer.
+        initial_read_offset = schema_offset;
+        fb_postscript_byte_range.start += prefix_bytes;
+        fb_postscript_byte_range.end += prefix_bytes;
     }
 
     // validate the schema and layout
@@ -154,10 +164,104 @@ pub async fn read_initial_bytes<R: VortexReadAt>(
 
 #[cfg(test)]
 mod tests {
-    use crate::{EOF_SIZE, INITIAL_READ_SIZE, MAX_FOOTER_SIZE};
+    use flatbuffers::FlatBufferBuilder;
+    use vortex_buffer::ByteBufferMut;
+    use vortex_flatbuffers::footer::PostscriptBuilder;
+
+    use crate::{
+        read_initial_bytes, EOF_SIZE, INITIAL_READ_SIZE, MAGIC_BYTES, MAX_FOOTER_SIZE, VERSION,
+    };
 
     #[test]
     fn big_enough_initial_read() {
         assert!(INITIAL_READ_SIZE > EOF_SIZE + MAX_FOOTER_SIZE as usize);
+    }
+
+    #[tokio::test]
+    async fn test_read_initial_bytes() {
+        let mut fbb = FlatBufferBuilder::new();
+        let mut postscript_builder = PostscriptBuilder::new(&mut fbb);
+        postscript_builder.add_schema_offset(0);
+        postscript_builder.add_layout_offset(1024);
+        let root_offset = postscript_builder.finish();
+        fbb.finish(root_offset, None);
+
+        let postscript = fbb.finished_data();
+        let mut buf = ByteBufferMut::with_capacity(INITIAL_READ_SIZE);
+        // write the "schema"
+        buf.extend_from_slice(&[0; 1024]);
+        // write the "layout"
+        buf.extend_from_slice(&[0; 1024]);
+
+        let postscript_start = buf.len();
+        // Write the postscript flatbuffer
+        buf.extend_from_slice(postscript);
+
+        // Write the EOF.
+        buf.extend_from_slice(&VERSION.to_le_bytes());
+        buf.extend_from_slice(&(postscript.len() as u16).to_le_bytes());
+        buf.extend_from_slice(&MAGIC_BYTES);
+
+        let buf = buf.freeze().into_inner();
+
+        assert!(buf.len() <= INITIAL_READ_SIZE);
+        let initial_read = read_initial_bytes(&buf, buf.len() as u64).await.unwrap();
+
+        assert_eq!(initial_read.initial_read_offset, 0);
+        assert_eq!(
+            initial_read.fb_postscript_byte_range,
+            postscript_start..(postscript_start + postscript.len())
+        );
+        assert_eq!(initial_read.fb_schema_byte_range(), 0..1024,);
+        assert_eq!(initial_read.fb_layout_byte_range(), 1024..2048);
+    }
+
+    #[tokio::test]
+    async fn test_read_initial_bytes_large() {
+        // We create a Postscript flatbuffer message, with a schema offset that
+        // is before the INITIAL_READ_SIZE to test that the `read_initial_bytes` will
+        // refetch as necessary.
+
+        // Write the Postscript at the very end of the buffer.
+        let mut fbb = FlatBufferBuilder::new();
+        let mut postscript_builder = PostscriptBuilder::new(&mut fbb);
+        postscript_builder.add_schema_offset(0);
+        postscript_builder.add_layout_offset(1024);
+        let root_offset = postscript_builder.finish();
+        fbb.finish(root_offset, None);
+
+        let postscript = fbb.finished_data();
+
+        // We create a virtual footer that includes a schema offset, followed by a layout offset,
+        // both before INITIAL_READ_SIZE.
+        let mut buf = ByteBufferMut::with_capacity(2 * INITIAL_READ_SIZE);
+
+        // Write a bunch of zeros to pad.
+        let postscript_start = 2 * INITIAL_READ_SIZE - EOF_SIZE - postscript.len();
+        buf.extend_from_slice(&vec![0; postscript_start]);
+        assert_eq!(buf.len(), postscript_start);
+
+        // Write the footer flatbuffer message.
+        buf.extend_from_slice(postscript);
+
+        // Write the 8-byte EOF structure which contains the version,
+        // the postscript, and the magic bytes.
+        buf.extend_from_slice(&VERSION.to_le_bytes());
+        buf.extend_from_slice(&(postscript.len() as u16).to_le_bytes());
+        buf.extend_from_slice(&MAGIC_BYTES);
+
+        let buf = buf.freeze().into_inner();
+
+        assert_eq!(buf.len(), 2 * INITIAL_READ_SIZE);
+
+        let initial_read = read_initial_bytes(&buf, buf.len() as u64).await.unwrap();
+
+        assert_eq!(initial_read.initial_read_offset, 0);
+        assert_eq!(
+            initial_read.fb_postscript_byte_range,
+            postscript_start..(postscript_start + postscript.len())
+        );
+        assert_eq!(initial_read.fb_schema_byte_range(), 0..1024,);
+        assert_eq!(initial_read.fb_layout_byte_range(), 1024..postscript_start);
     }
 }

--- a/vortex-file/src/read/builder/initial_read.rs
+++ b/vortex-file/src/read/builder/initial_read.rs
@@ -80,6 +80,7 @@ pub async fn read_initial_bytes<R: VortexReadAt>(
 
     let eof_loc = read_size - EOF_SIZE;
     let magic_bytes_loc = eof_loc + (EOF_SIZE - MAGIC_BYTES.len());
+
     let magic_number = &buf[magic_bytes_loc..];
     if magic_number != MAGIC_BYTES {
         vortex_bail!("Malformed file, invalid magic bytes, got {magic_number:?}")
@@ -96,6 +97,7 @@ pub async fn read_initial_bytes<R: VortexReadAt>(
 
     let ps_size =
         u16::from_le_bytes(buf[eof_loc + 2..eof_loc + 4].try_into().vortex_unwrap()) as usize;
+
     if ps_size > eof_loc {
         vortex_bail!(
             "Malformed file, postscript of size {} is too large to fit in initial read of size {} (file size {})",
@@ -138,8 +140,8 @@ pub async fn read_initial_bytes<R: VortexReadAt>(
 
         let prefix_bytes: usize = prefix_bytes.try_into()?;
 
-        buf_builder.extend(leftover.into_iter());
-        buf_builder.extend(buf.into_iter());
+        buf_builder.extend_from_slice(&leftover);
+        buf_builder.extend_from_slice(&buf);
 
         buf = buf_builder.freeze();
         // Reset the absolute offsets to account for the new data that was fetched and
@@ -247,7 +249,7 @@ mod tests {
             initial_read.fb_postscript_byte_range,
             postscript_start..(postscript_start + postscript.len())
         );
-        assert_eq!(initial_read.fb_schema_byte_range(), 0..1024,);
+        assert_eq!(initial_read.fb_schema_byte_range(), 0..1024);
         assert_eq!(initial_read.fb_layout_byte_range(), 1024..postscript_start);
     }
 

--- a/vortex-file/src/read/builder/initial_read.rs
+++ b/vortex-file/src/read/builder/initial_read.rs
@@ -179,14 +179,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_initial_bytes() {
-        let mut fbb = FlatBufferBuilder::new();
-        let mut postscript_builder = PostscriptBuilder::new(&mut fbb);
-        postscript_builder.add_schema_offset(0);
-        postscript_builder.add_layout_offset(1024);
-        let root_offset = postscript_builder.finish();
-        fbb.finish(root_offset, None);
-
-        let postscript = fbb.finished_data();
+        let postscript = make_postscript(0, 1024);
         let mut buf = ByteBufferMut::with_capacity(INITIAL_READ_SIZE);
         // write the "schema"
         buf.extend_from_slice(&[0; 1024]);
@@ -195,7 +188,7 @@ mod tests {
 
         let postscript_start = buf.len();
         // Write the postscript flatbuffer
-        buf.extend_from_slice(postscript);
+        buf.extend_from_slice(&postscript);
 
         // Write the EOF.
         buf.extend_from_slice(&VERSION.to_le_bytes());
@@ -223,14 +216,7 @@ mod tests {
         // refetch as necessary.
 
         // Write the Postscript at the very end of the buffer.
-        let mut fbb = FlatBufferBuilder::new();
-        let mut postscript_builder = PostscriptBuilder::new(&mut fbb);
-        postscript_builder.add_schema_offset(0);
-        postscript_builder.add_layout_offset(1024);
-        let root_offset = postscript_builder.finish();
-        fbb.finish(root_offset, None);
-
-        let postscript = fbb.finished_data();
+        let postscript = make_postscript(0, 1024);
 
         // We create a virtual footer that includes a schema offset, followed by a layout offset,
         // both before INITIAL_READ_SIZE.
@@ -242,7 +228,7 @@ mod tests {
         assert_eq!(buf.len(), postscript_start);
 
         // Write the footer flatbuffer message.
-        buf.extend_from_slice(postscript);
+        buf.extend_from_slice(&postscript);
 
         // Write the 8-byte EOF structure which contains the version,
         // the postscript, and the magic bytes.
@@ -263,5 +249,15 @@ mod tests {
         );
         assert_eq!(initial_read.fb_schema_byte_range(), 0..1024,);
         assert_eq!(initial_read.fb_layout_byte_range(), 1024..postscript_start);
+    }
+
+    fn make_postscript(schema_offset: u64, layout_offset: u64) -> Vec<u8> {
+        let mut fbb = FlatBufferBuilder::new();
+        let mut postscript_builder = PostscriptBuilder::new(&mut fbb);
+        postscript_builder.add_schema_offset(schema_offset);
+        postscript_builder.add_layout_offset(layout_offset);
+        let root_offset = postscript_builder.finish();
+        fbb.finish(root_offset, None);
+        fbb.finished_data().to_vec()
     }
 }

--- a/vortex-file/src/read/mod.rs
+++ b/vortex-file/src/read/mod.rs
@@ -33,10 +33,18 @@ use vortex_expr::ExprRef;
 
 use crate::byte_range::ByteRange;
 pub use crate::read::mask::RowMask;
+use crate::MAX_FOOTER_SIZE;
 
 // Recommended read-size according to the AWS performance guide
 // FIXME(ngates): this is dumb
 pub const INITIAL_READ_SIZE: usize = 8 * 1024 * 1024;
+
+// There are assumptions in the initial read implementation that the postscript must fit
+// in the initial read.
+const _: () = assert!(
+    INITIAL_READ_SIZE >= MAX_FOOTER_SIZE as usize,
+    "INITIAL_READ_SIZE must be larger than MAX_FOOTER_SIZE"
+);
 
 /// Operation to apply to data returned by the layout
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Part of #1749, fixes the first issue

> Cannot read from vortex file, and error msg is

>    table = vx.io.read_path("A0.vortex")
>ValueError: Schema, layout, & footer must be in the initial read, got schema at 1889911040 and initial read from 1903721816

> accroding to this [img](https://spiraldb.github.io/vortex/docs/_images/file-format-2024-10-23-1642.svg), footer is too large? the table has 14k+ columns, which is very wide.