### PR TITLE
Don't fuzz filter for list arrays

### DIFF
--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -179,8 +179,8 @@ const ALL_ACTIONS: RangeInclusive<usize> = 0..=4;
 
 fn actions_for_encoding(encoding: EncodingRef) -> HashSet<usize> {
     if ListEncoding::ID == encoding.id() {
-        // compress, slice and filter
-        vec![0, 1, 4].into_iter().collect()
+        // compress, slice
+        vec![0, 1].into_iter().collect()
     } else {
         ALL_ACTIONS.collect()
     }


### PR DESCRIPTION
Since the fuzzer can generate chunked arrays and the chunked filter uses child take we have to disable it for now from fuzzing