### PR TITLE
feat: new expression builders

### DIFF
--- a/pyvortex/src/expr.rs
+++ b/pyvortex/src/expr.rs
@@ -1,10 +1,9 @@
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::*;
-use vortex::dtype::field::Field;
 use vortex::dtype::half::f16;
 use vortex::dtype::{DType, Nullability, PType};
-use vortex::expr::{BinaryExpr, Column, ExprRef, Literal, Operator};
+use vortex::expr::{col, lit, BinaryExpr, ExprRef, Operator};
 use vortex::scalar::Scalar;
 
 use crate::dtype::PyDType;
@@ -243,12 +242,7 @@ impl PyExpr {
 pub fn column<'py>(name: &Bound<'py, PyString>) -> PyResult<Bound<'py, PyExpr>> {
     let py = name.py();
     let name: String = name.extract()?;
-    Bound::new(
-        py,
-        PyExpr {
-            inner: Column::new_expr(Field::from(name)),
-        },
-    )
+    Bound::new(py, PyExpr { inner: col(name) })
 }
 
 #[pyfunction]
@@ -264,7 +258,7 @@ pub fn scalar<'py>(dtype: DType, value: &Bound<'py, PyAny>) -> PyResult<Bound<'p
     Bound::new(
         py,
         PyExpr {
-            inner: Literal::new_expr(scalar_helper(dtype, value)?),
+            inner: lit(scalar_helper(dtype, value)?),
         },
     )
 }

--- a/vortex-expr/src/binary.rs
+++ b/vortex-expr/src/binary.rs
@@ -76,3 +76,183 @@ impl PartialEq<dyn Any> for BinaryExpr {
             .unwrap_or(false)
     }
 }
+
+/// Create a new `BinaryExpr` using the `Eq` operator.
+///
+/// ## Example usage
+///
+/// ```
+/// use vortex_array::array::{BoolArray, PrimitiveArray };
+/// use vortex_array::{IntoArrayData, IntoArrayVariant};
+/// use vortex_array::validity::Validity;
+/// use vortex_buffer::buffer;
+/// use vortex_expr::{eq, ident, lit};
+///
+/// let xs = PrimitiveArray::new(buffer![1i32, 2i32, 3i32], Validity::NonNullable).into_array();
+/// let result = eq(ident(), lit(3)).evaluate(&xs).unwrap();
+///
+/// assert_eq!(
+///     result.into_bool().unwrap().boolean_buffer(),
+///     BoolArray::from_iter(vec![false, false, true]).boolean_buffer(),
+/// );
+/// ```
+pub fn eq(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
+    BinaryExpr::new_expr(lhs, Operator::Eq, rhs)
+}
+
+/// Create a new `BinaryExpr` using the `NotEq` operator.
+///
+/// ## Example usage
+///
+/// ```
+/// use vortex_array::array::{BoolArray, PrimitiveArray };
+/// use vortex_array::{IntoArrayData, IntoArrayVariant};
+/// use vortex_array::validity::Validity;
+/// use vortex_buffer::buffer;
+/// use vortex_expr::{ident, lit, not_eq};
+///
+/// let xs = PrimitiveArray::new(buffer![1i32, 2i32, 3i32], Validity::NonNullable).into_array();
+/// let result = not_eq(ident(), lit(3)).evaluate(&xs).unwrap();
+///
+/// assert_eq!(
+///     result.into_bool().unwrap().boolean_buffer(),
+///     BoolArray::from_iter(vec![true, true, false]).boolean_buffer(),
+/// );
+/// ```
+pub fn not_eq(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
+    BinaryExpr::new_expr(lhs, Operator::NotEq, rhs)
+}
+
+/// Create a new `BinaryExpr` using the `Gte` operator.
+///
+/// ## Example usage
+///
+/// ```
+/// use vortex_array::array::{BoolArray, PrimitiveArray };
+/// use vortex_array::{IntoArrayData, IntoArrayVariant};
+/// use vortex_array::validity::Validity;
+/// use vortex_buffer::buffer;
+/// use vortex_expr::{gt_eq, ident, lit};
+///
+/// let xs = PrimitiveArray::new(buffer![1i32, 2i32, 3i32], Validity::NonNullable).into_array();
+/// let result = gt_eq(ident(), lit(3)).evaluate(&xs).unwrap();
+///
+/// assert_eq!(
+///     result.into_bool().unwrap().boolean_buffer(),
+///     BoolArray::from_iter(vec![false, false, true]).boolean_buffer(),
+/// );
+/// ```
+pub fn gt_eq(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
+    BinaryExpr::new_expr(lhs, Operator::Gte, rhs)
+}
+
+/// Create a new `BinaryExpr` using the `Gt` operator.
+///
+/// ## Example usage
+///
+/// ```
+/// use vortex_array::array::{BoolArray, PrimitiveArray };
+/// use vortex_array::{IntoArrayData, IntoArrayVariant};
+/// use vortex_array::validity::Validity;
+/// use vortex_buffer::buffer;
+/// use vortex_expr::{gt, ident, lit};
+///
+/// let xs = PrimitiveArray::new(buffer![1i32, 2i32, 3i32], Validity::NonNullable).into_array();
+/// let result = gt(ident(), lit(2)).evaluate(&xs).unwrap();
+///
+/// assert_eq!(
+///     result.into_bool().unwrap().boolean_buffer(),
+///     BoolArray::from_iter(vec![false, false, true]).boolean_buffer(),
+/// );
+/// ```
+pub fn gt(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
+    BinaryExpr::new_expr(lhs, Operator::Gt, rhs)
+}
+
+/// Create a new `BinaryExpr` using the `Lte` operator.
+///
+/// ## Example usage
+///
+/// ```
+/// use vortex_array::array::{BoolArray, PrimitiveArray };
+/// use vortex_array::{IntoArrayData, IntoArrayVariant};
+/// use vortex_array::validity::Validity;
+/// use vortex_buffer::buffer;
+/// use vortex_expr::{ident, lit, lt_eq};
+///
+/// let xs = PrimitiveArray::new(buffer![1i32, 2i32, 3i32], Validity::NonNullable).into_array();
+/// let result = lt_eq(ident(), lit(2)).evaluate(&xs).unwrap();
+///
+/// assert_eq!(
+///     result.into_bool().unwrap().boolean_buffer(),
+///     BoolArray::from_iter(vec![true, true, false]).boolean_buffer(),
+/// );
+/// ```
+pub fn lt_eq(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
+    BinaryExpr::new_expr(lhs, Operator::Lte, rhs)
+}
+
+/// Create a new `BinaryExpr` using the `Lt` operator.
+///
+/// ## Example usage
+///
+/// ```
+/// use vortex_array::array::{BoolArray, PrimitiveArray };
+/// use vortex_array::{IntoArrayData, IntoArrayVariant};
+/// use vortex_array::validity::Validity;
+/// use vortex_buffer::buffer;
+/// use vortex_expr::{ident, lit, lt};
+///
+/// let xs = PrimitiveArray::new(buffer![1i32, 2i32, 3i32], Validity::NonNullable).into_array();
+/// let result = lt(ident(), lit(3)).evaluate(&xs).unwrap();
+///
+/// assert_eq!(
+///     result.into_bool().unwrap().boolean_buffer(),
+///     BoolArray::from_iter(vec![true, true, false]).boolean_buffer(),
+/// );
+/// ```
+pub fn lt(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
+    BinaryExpr::new_expr(lhs, Operator::Lt, rhs)
+}
+
+/// Create a new `BinaryExpr` using the `Or` operator.
+///
+/// ## Example usage
+///
+/// ```
+/// use vortex_array::array::BoolArray;
+/// use vortex_array::{IntoArrayData, IntoArrayVariant};
+/// use vortex_expr::{ ident, lit, or};
+///
+/// let xs = BoolArray::from_iter(vec![true, false, true]).into_array();
+/// let result = or(ident(), lit(false)).evaluate(&xs).unwrap();
+///
+/// assert_eq!(
+///     result.into_bool().unwrap().boolean_buffer(),
+///     BoolArray::from_iter(vec![true, false, true]).boolean_buffer(),
+/// );
+/// ```
+pub fn or(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
+    BinaryExpr::new_expr(lhs, Operator::Or, rhs)
+}
+
+/// Create a new `BinaryExpr` using the `And` operator.
+///
+/// ## Example usage
+///
+/// ```
+/// use vortex_array::array::BoolArray;
+/// use vortex_array::{IntoArrayData, IntoArrayVariant};
+/// use vortex_expr::{and, ident, lit};
+///
+/// let xs = BoolArray::from_iter(vec![true, false, true]).into_array();
+/// let result = and(ident(), lit(true)).evaluate(&xs).unwrap();
+///
+/// assert_eq!(
+///     result.into_bool().unwrap().boolean_buffer(),
+///     BoolArray::from_iter(vec![true, false, true]).boolean_buffer(),
+/// );
+/// ```
+pub fn and(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
+    BinaryExpr::new_expr(lhs, Operator::And, rhs)
+}

--- a/vortex-expr/src/column.rs
+++ b/vortex-expr/src/column.rs
@@ -26,6 +26,12 @@ impl Column {
     }
 }
 
+pub fn col(field: impl Into<Field>) -> ExprRef {
+    Arc::new(Column {
+        field: field.into(),
+    })
+}
+
 impl From<String> for Column {
     fn from(value: String) -> Self {
         Column {

--- a/vortex-expr/src/datafusion.rs
+++ b/vortex-expr/src/datafusion.rs
@@ -7,7 +7,7 @@ use datafusion_physical_expr::{expressions, PhysicalExpr};
 use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
 use vortex_scalar::Scalar;
 
-use crate::{BinaryExpr, Column, ExprRef, Like, Literal, Operator};
+use crate::{lit, BinaryExpr, Column, ExprRef, Like, Operator};
 
 pub fn convert_expr_to_vortex(physical_expr: Arc<dyn PhysicalExpr>) -> VortexResult<ExprRef> {
     if let Some(binary_expr) = physical_expr
@@ -41,12 +41,12 @@ pub fn convert_expr_to_vortex(physical_expr: Arc<dyn PhysicalExpr>) -> VortexRes
         ));
     }
 
-    if let Some(lit) = physical_expr
+    if let Some(literal) = physical_expr
         .as_any()
         .downcast_ref::<expressions::Literal>()
     {
-        let value = Scalar::from(lit.value().clone());
-        return Ok(Literal::new_expr(value));
+        let value = Scalar::from(literal.value().clone());
+        return Ok(lit(value));
     }
 
     vortex_bail!(

--- a/vortex-expr/src/identity.rs
+++ b/vortex-expr/src/identity.rs
@@ -40,3 +40,8 @@ impl PartialEq<dyn Any> for Identity {
             .unwrap_or(false)
     }
 }
+
+// Return a global pointer to the identity token.
+pub fn ident() -> ExprRef {
+    Identity::new_expr()
+}

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -96,69 +96,68 @@ mod tests {
 
     #[test]
     fn basic_expr_split_test() {
-        let lhs = Column::new_expr(Field::from("a"));
-        let rhs = Literal::new_expr(1.into());
-        let expr = BinaryExpr::new_expr(lhs, Operator::Eq, rhs);
+        let lhs = col("a");
+        let rhs = lit(1);
+        let expr = eq(lhs, rhs);
         let conjunction = split_conjunction(&expr);
         assert_eq!(conjunction.len(), 1);
     }
 
     #[test]
     fn basic_conjunction_split_test() {
-        let lhs = Column::new_expr(Field::from("a"));
-        let rhs = Literal::new_expr(1.into());
-        let expr = BinaryExpr::new_expr(lhs, Operator::And, rhs);
+        let lhs = col("a");
+        let rhs = lit(1);
+        let expr = and(lhs, rhs);
         let conjunction = split_conjunction(&expr);
         assert_eq!(conjunction.len(), 2, "Conjunction is {conjunction:?}");
     }
 
     #[test]
     fn expr_display() {
-        assert_eq!(Column::new_expr(Field::from("a")).to_string(), "$a");
-        assert_eq!(Column::new_expr(Field::Index(1)).to_string(), "[1]");
+        assert_eq!(col("a").to_string(), "$a");
+        assert_eq!(col(1).to_string(), "[1]");
         assert_eq!(Identity.to_string(), "[]");
         assert_eq!(Identity.to_string(), "[]");
 
-        let col1: Arc<dyn VortexExpr> = Column::new_expr(Field::from("col1"));
-        let col2: Arc<dyn VortexExpr> = Column::new_expr(Field::from("col2"));
+        let col1: Arc<dyn VortexExpr> = col("col1");
+        let col2: Arc<dyn VortexExpr> = col("col2");
         assert_eq!(
-            BinaryExpr::new_expr(col1.clone(), Operator::And, col2.clone()).to_string(),
+            and(col1.clone(), col2.clone()).to_string(),
             "($col1 and $col2)"
         );
         assert_eq!(
-            BinaryExpr::new_expr(col1.clone(), Operator::Or, col2.clone()).to_string(),
+            or(col1.clone(), col2.clone()).to_string(),
             "($col1 or $col2)"
         );
         assert_eq!(
-            BinaryExpr::new_expr(col1.clone(), Operator::Eq, col2.clone()).to_string(),
+            eq(col1.clone(), col2.clone()).to_string(),
             "($col1 = $col2)"
         );
         assert_eq!(
-            BinaryExpr::new_expr(col1.clone(), Operator::NotEq, col2.clone()).to_string(),
+            not_eq(col1.clone(), col2.clone()).to_string(),
             "($col1 != $col2)"
         );
         assert_eq!(
-            BinaryExpr::new_expr(col1.clone(), Operator::Gt, col2.clone()).to_string(),
+            gt(col1.clone(), col2.clone()).to_string(),
             "($col1 > $col2)"
         );
         assert_eq!(
-            BinaryExpr::new_expr(col1.clone(), Operator::Gte, col2.clone()).to_string(),
+            gt_eq(col1.clone(), col2.clone()).to_string(),
             "($col1 >= $col2)"
         );
         assert_eq!(
-            BinaryExpr::new_expr(col1.clone(), Operator::Lt, col2.clone()).to_string(),
+            lt(col1.clone(), col2.clone()).to_string(),
             "($col1 < $col2)"
         );
         assert_eq!(
-            BinaryExpr::new_expr(col1.clone(), Operator::Lte, col2.clone()).to_string(),
+            lt_eq(col1.clone(), col2.clone()).to_string(),
             "($col1 <= $col2)"
         );
 
         assert_eq!(
-            BinaryExpr::new_expr(
-                BinaryExpr::new_expr(col1.clone(), Operator::Lt, col2.clone()),
-                Operator::Or,
-                BinaryExpr::new_expr(col1.clone(), Operator::NotEq, col2.clone())
+            or(
+                lt(col1.clone(), col2.clone()),
+                not_eq(col1.clone(), col2.clone()),
             )
             .to_string(),
             "(($col1 < $col2) or ($col1 != $col2))"
@@ -184,23 +183,20 @@ mod tests {
             "Exclude($col1,$col2,[1])"
         );
 
-        assert_eq!(Literal::new_expr(Scalar::from(0_u8)).to_string(), "0_u8");
+        assert_eq!(lit(Scalar::from(0_u8)).to_string(), "0_u8");
+        assert_eq!(lit(Scalar::from(0.0_f32)).to_string(), "0_f32");
         assert_eq!(
-            Literal::new_expr(Scalar::from(0.0_f32)).to_string(),
-            "0_f32"
-        );
-        assert_eq!(
-            Literal::new_expr(Scalar::from(i64::MAX)).to_string(),
+            lit(Scalar::from(i64::MAX)).to_string(),
             "9223372036854775807_i64"
         );
-        assert_eq!(Literal::new_expr(Scalar::from(true)).to_string(), "true");
+        assert_eq!(lit(Scalar::from(true)).to_string(), "true");
         assert_eq!(
-            Literal::new_expr(Scalar::null(DType::Bool(Nullability::Nullable))).to_string(),
+            lit(Scalar::null(DType::Bool(Nullability::Nullable))).to_string(),
             "null"
         );
 
         assert_eq!(
-            Literal::new_expr(Scalar::struct_(
+            lit(Scalar::struct_(
                 DType::Struct(
                     StructDType::new(
                         Arc::from([Arc::from("dog"), Arc::from("cat")]),

--- a/vortex-expr/src/literal.rs
+++ b/vortex-expr/src/literal.rs
@@ -48,3 +48,25 @@ impl PartialEq<dyn Any> for Literal {
             .unwrap_or(false)
     }
 }
+
+/// Create a new `Literal` expression from a type that coerces to `Scalar`.
+///
+///
+/// ## Example usage
+///
+/// ```
+/// use vortex_array::array::PrimitiveArray;
+/// use vortex_dtype::Nullability;
+/// use vortex_expr::{lit, Literal};
+/// use vortex_scalar::Scalar;
+///
+/// let number = lit(34i32);
+///
+/// let literal = number.as_any()
+///     .downcast_ref::<Literal>()
+///     .unwrap();
+/// assert_eq!(literal.value(), &Scalar::primitive(34i32, Nullability::NonNullable));
+/// ```
+pub fn lit(value: impl Into<Scalar>) -> ExprRef {
+    Literal::new_expr(value.into())
+}

--- a/vortex-expr/src/project.rs
+++ b/vortex-expr/src/project.rs
@@ -1,10 +1,11 @@
+#![allow(unused_imports)]
 use std::sync::Arc;
 
 use vortex_dtype::field::Field;
 
 use crate::{
-    BinaryExpr, Column, ExprRef, Identity, Like, Literal, Not, Operator, RowFilter, Select,
-    VortexExpr,
+    col, lit, BinaryExpr, Column, ExprRef, Identity, Like, Literal, Not, Operator, RowFilter,
+    Select, VortexExpr,
 };
 
 /// Restrict expression to only the fields that appear in projection
@@ -102,15 +103,11 @@ mod tests {
     use vortex_dtype::field::Field;
 
     use super::*;
-    use crate::{BinaryExpr, Column, Identity, Literal, Not, Operator, Select, VortexExpr};
+    use crate::{and, lt, or, Identity, Not, Select, VortexExpr};
 
     #[test]
     fn project_and() {
-        let band = BinaryExpr::new_expr(
-            Column::new_expr(Field::from("a")),
-            Operator::And,
-            Column::new_expr(Field::from("b")),
-        );
+        let band = and(col("a"), col("b"));
         let projection = vec![Field::from("b")];
         assert_eq!(
             *expr_project(&band, &projection).unwrap(),
@@ -120,50 +117,25 @@ mod tests {
 
     #[test]
     fn project_or() {
-        let bor = BinaryExpr::new_expr(
-            Column::new_expr(Field::from("a")),
-            Operator::Or,
-            Column::new_expr(Field::from("b")),
-        );
+        let bor = or(col("a"), col("b"));
         let projection = vec![Field::from("b")];
         assert!(expr_project(&bor, &projection).is_none());
     }
 
     #[test]
     fn project_nested() {
-        let band = BinaryExpr::new_expr(
-            BinaryExpr::new_expr(
-                Column::new_expr(Field::from("a")),
-                Operator::Lt,
-                Column::new_expr(Field::from("b")),
-            ),
-            Operator::And,
-            BinaryExpr::new_expr(
-                Literal::new_expr(5.into()),
-                Operator::Lt,
-                Column::new_expr(Field::from("b")),
-            ),
-        );
+        let band = and(lt(col("a"), col("b")), lt(lit(5), col("b")));
         let projection = vec![Field::from("b")];
         assert!(expr_project(&band, &projection).is_none());
     }
 
     #[test]
     fn project_multicolumn() {
-        let blt = BinaryExpr::new_expr(
-            Column::new_expr(Field::from("a")),
-            Operator::Lt,
-            Column::new_expr(Field::from("b")),
-        );
+        let blt = lt(col("a"), col("b"));
         let projection = vec![Field::from("a"), Field::from("b")];
         assert_eq!(
             *expr_project(&blt, &projection).unwrap(),
-            *BinaryExpr::new_expr(
-                Column::new_expr(Field::from("a")),
-                Operator::Lt,
-                Column::new_expr(Field::from("b")),
-            )
-            .as_any()
+            *lt(col("a"), col("b")).as_any()
         );
     }
 
@@ -197,7 +169,7 @@ mod tests {
 
     #[test]
     fn project_not() {
-        let not_e = Not::new_expr(Column::new_expr(Field::from("a")));
+        let not_e = Not::new_expr(col(Field::from("a")));
         let projection = vec![Field::from("a"), Field::from("b")];
         assert_eq!(*expr_project(&not_e, &projection).unwrap(), *not_e.as_any());
     }

--- a/vortex-file/src/read/layouts/chunked.rs
+++ b/vortex-file/src/read/layouts/chunked.rs
@@ -429,7 +429,7 @@ mod tests {
     use vortex_array::{ArrayDType, ArrayLen, IntoArrayData, IntoArrayVariant};
     use vortex_buffer::Buffer;
     use vortex_dtype::PType;
-    use vortex_expr::{BinaryExpr, Identity, Literal, Operator, RowFilter};
+    use vortex_expr::{gt, lit, Identity, RowFilter};
     use vortex_flatbuffers::{footer, WriteFlatBuffer};
     use vortex_ipc::messages::{AsyncMessageWriter, EncoderMessage};
 
@@ -516,13 +516,10 @@ mod tests {
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
     async fn read_range() {
-        let (filter_layout, projection_layout, buf, length) =
-            layout_and_bytes(Scan::new(RowFilter::new_expr(BinaryExpr::new_expr(
-                Arc::new(Identity),
-                Operator::Gt,
-                Literal::new_expr(10.into()),
-            ))))
-            .await;
+        let (filter_layout, projection_layout, buf, length) = layout_and_bytes(Scan::new(
+            RowFilter::new_expr(gt(Arc::new(Identity), lit(10))),
+        ))
+        .await;
 
         assert_eq!(filter_layout.n_chunks(), 5);
         assert_eq!(projection_layout.n_chunks(), 5);

--- a/vortex-file/src/read/layouts/columnar.rs
+++ b/vortex-file/src/read/layouts/columnar.rs
@@ -10,7 +10,7 @@ use vortex_array::{ArrayData, IntoArrayData};
 use vortex_dtype::field::Field;
 use vortex_dtype::{FieldName, FieldNames};
 use vortex_error::{vortex_bail, vortex_err, vortex_panic, VortexExpect, VortexResult};
-use vortex_expr::{expr_project, Column, RowFilter, Select, VortexExpr};
+use vortex_expr::{col, expr_project, RowFilter, Select, VortexExpr};
 use vortex_flatbuffers::footer;
 
 use crate::read::cache::LazyDType;
@@ -140,7 +140,7 @@ impl ColumnarLayoutBuilder<'_> {
                 RowFilter::from_conjunction_expr(
                     handled_names
                         .iter()
-                        .map(|f| Column::new_expr(Field::from(&**f)))
+                        .map(|f| col(Field::from(&**f)))
                         .collect(),
                 )
             });
@@ -425,7 +425,7 @@ mod tests {
     use vortex_buffer::Buffer;
     use vortex_dtype::field::Field;
     use vortex_dtype::{DType, Nullability};
-    use vortex_expr::{BinaryExpr, Column, Literal, Operator, RowFilter};
+    use vortex_expr::{col, lit, BinaryExpr, Operator, RowFilter};
 
     use crate::read::builder::initial_read::read_initial_bytes;
     use crate::read::layouts::test_read::{filter_read_layout, read_layout};
@@ -504,9 +504,9 @@ mod tests {
         let msgs = LayoutMessageCache::default();
         let (filter_layout, project_layout, buf, length) =
             layout_and_bytes(Scan::new(RowFilter::new_expr(BinaryExpr::new_expr(
-                Column::new_expr(Field::from("ints")),
+                col(Field::from("ints")),
                 Operator::Gt,
-                Literal::new_expr(10.into()),
+                lit(10),
             ))))
             .await;
         let arr = filter_read_layout(
@@ -593,17 +593,9 @@ mod tests {
         let msgs = LayoutMessageCache::default();
         let (filter_layout, project_layout, buf, length) =
             layout_and_bytes(Scan::new(RowFilter::new_expr(BinaryExpr::new_expr(
-                BinaryExpr::new_expr(
-                    Column::new_expr(Field::from("strs")),
-                    Operator::Eq,
-                    Literal::new_expr("it".into()),
-                ),
+                BinaryExpr::new_expr(col(Field::from("strs")), Operator::Eq, lit("it")),
                 Operator::And,
-                BinaryExpr::new_expr(
-                    Column::new_expr(Field::from("ints")),
-                    Operator::Lt,
-                    Literal::new_expr(150.into()),
-                ),
+                BinaryExpr::new_expr(col(Field::from("ints")), Operator::Lt, lit(150)),
             ))))
             .await;
         let arr = filter_read_layout(

--- a/vortex-file/src/read/layouts/flat.rs
+++ b/vortex-file/src/read/layouts/flat.rs
@@ -112,7 +112,7 @@ mod tests {
     use vortex_array::{Context, IntoArrayData, IntoArrayVariant, ToArrayData};
     use vortex_buffer::Buffer;
     use vortex_dtype::PType;
-    use vortex_expr::{BinaryExpr, Identity, Literal, Operator, RowFilter};
+    use vortex_expr::{gt, lit, BinaryExpr, Identity, Operator, RowFilter};
     use vortex_ipc::messages::{EncoderMessage, SyncMessageWriter};
 
     use crate::byte_range::ByteRange;
@@ -167,13 +167,10 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     async fn read_range() {
         let msgs = LayoutMessageCache::default();
-        let (filter_layout, projection_layout, buf, length) =
-            layout_and_bytes(Scan::new(RowFilter::new_expr(BinaryExpr::new_expr(
-                Arc::new(Identity),
-                Operator::Gt,
-                Literal::new_expr(10.into()),
-            ))))
-            .await;
+        let (filter_layout, projection_layout, buf, length) = layout_and_bytes(Scan::new(
+            RowFilter::new_expr(gt(Arc::new(Identity), lit(10))),
+        ))
+        .await;
         let arr =
             filter_read_layout(&filter_layout, &projection_layout, &buf, length, msgs).pop_front();
 
@@ -208,7 +205,7 @@ mod tests {
             layout_and_bytes(Scan::new(RowFilter::new_expr(BinaryExpr::new_expr(
                 Arc::new(Identity),
                 Operator::Gt,
-                Literal::new_expr(101.into()),
+                lit(101),
             ))))
             .await;
         let arr =

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -18,7 +18,7 @@ use vortex_dtype::field::Field;
 use vortex_dtype::PType::I32;
 use vortex_dtype::{DType, Nullability, PType, StructDType};
 use vortex_error::{vortex_panic, VortexResult};
-use vortex_expr::{BinaryExpr, Column, Literal, Operator, RowFilter};
+use vortex_expr::{col, lit, BinaryExpr, Operator, RowFilter};
 use vortex_io::VortexReadAt;
 
 use crate::builder::initial_read::read_initial_bytes;
@@ -427,9 +427,9 @@ async fn filter_string() {
     let written = Bytes::from(writer.finalize().await.unwrap());
     let stream = VortexReadBuilder::new(written, LayoutDeserializer::default())
         .with_row_filter(RowFilter::new(BinaryExpr::new_expr(
-            Column::new_expr(Field::from("name")),
+            col(Field::from("name")),
             Operator::Eq,
-            Literal::new_expr("Joseph".into()),
+            lit("Joseph"),
         )))
         .build()
         .await
@@ -475,24 +475,12 @@ async fn filter_or() {
     let written = Bytes::from(writer.finalize().await.unwrap());
     let mut reader = VortexReadBuilder::new(written, LayoutDeserializer::default())
         .with_row_filter(RowFilter::new(BinaryExpr::new_expr(
-            BinaryExpr::new_expr(
-                Column::new_expr(Field::from("name")),
-                Operator::Eq,
-                Literal::new_expr("Angela".into()),
-            ),
+            BinaryExpr::new_expr(col(Field::from("name")), Operator::Eq, lit("Angela")),
             Operator::Or,
             BinaryExpr::new_expr(
-                BinaryExpr::new_expr(
-                    Column::new_expr(Field::from("age")),
-                    Operator::Gte,
-                    Literal::new_expr(20.into()),
-                ),
+                BinaryExpr::new_expr(col(Field::from("age")), Operator::Gte, lit(20)),
                 Operator::And,
-                BinaryExpr::new_expr(
-                    Column::new_expr(Field::from("age")),
-                    Operator::Lte,
-                    Literal::new_expr(30.into()),
-                ),
+                BinaryExpr::new_expr(col(Field::from("age")), Operator::Lte, lit(30)),
             ),
         )))
         .build()
@@ -548,17 +536,9 @@ async fn filter_and() {
     let written = Bytes::from(writer.finalize().await.unwrap());
     let mut reader = VortexReadBuilder::new(written, LayoutDeserializer::default())
         .with_row_filter(RowFilter::new(BinaryExpr::new_expr(
-            BinaryExpr::new_expr(
-                Column::new_expr(Field::from("age")),
-                Operator::Gt,
-                Literal::new_expr(21.into()),
-            ),
+            BinaryExpr::new_expr(col(Field::from("age")), Operator::Gt, lit(21)),
             Operator::And,
-            BinaryExpr::new_expr(
-                Column::new_expr(Field::from("age")),
-                Operator::Lte,
-                Literal::new_expr(33.into()),
-            ),
+            BinaryExpr::new_expr(col(Field::from("age")), Operator::Lte, lit(33)),
         )))
         .build()
         .await
@@ -756,9 +736,9 @@ async fn test_with_indices_and_with_row_filter_simple() {
     let actual_kept_array = VortexReadBuilder::new(written.clone(), LayoutDeserializer::default())
         .with_indices(ArrayData::from(empty_indices))
         .with_row_filter(RowFilter::new(BinaryExpr::new_expr(
-            Column::new_expr(Field::from("numbers")),
+            col(Field::from("numbers")),
             Operator::Gt,
-            Literal::new_expr(50_i16.into()),
+            lit(50_i16),
         )))
         .build()
         .await
@@ -782,9 +762,9 @@ async fn test_with_indices_and_with_row_filter_simple() {
     let actual_kept_array = VortexReadBuilder::new(written.clone(), LayoutDeserializer::default())
         .with_indices(ArrayData::from(kept_indices_u16))
         .with_row_filter(RowFilter::new(BinaryExpr::new_expr(
-            Column::new_expr(Field::from("numbers")),
+            col(Field::from("numbers")),
             Operator::Gt,
-            Literal::new_expr(50_i16.into()),
+            lit(50_i16),
         )))
         .build()
         .await
@@ -814,9 +794,9 @@ async fn test_with_indices_and_with_row_filter_simple() {
     let actual_array = VortexReadBuilder::new(written.clone(), LayoutDeserializer::default())
         .with_indices(ArrayData::from((0..500).collect::<Buffer<_>>()))
         .with_row_filter(RowFilter::new(BinaryExpr::new_expr(
-            Column::new_expr(Field::from("numbers")),
+            col(Field::from("numbers")),
             Operator::Gt,
-            Literal::new_expr(50_i16.into()),
+            lit(50_i16),
         )))
         .build()
         .await
@@ -880,9 +860,9 @@ async fn filter_string_chunked() {
     let actual_array =
         VortexReadBuilder::new(Bytes::from(written_bytes), LayoutDeserializer::default())
             .with_row_filter(RowFilter::new(BinaryExpr::new_expr(
-                Column::new_expr(Field::from("name")),
+                col(Field::from("name")),
                 Operator::Eq,
-                Literal::new_expr("Joseph".into()),
+                lit("Joseph"),
             )))
             .build()
             .await
@@ -968,17 +948,9 @@ async fn test_pruning_with_or() {
     let actual_array =
         VortexReadBuilder::new(Bytes::from(written_bytes), LayoutDeserializer::default())
             .with_row_filter(RowFilter::new(BinaryExpr::new_expr(
-                BinaryExpr::new_expr(
-                    Column::new_expr(Field::from("letter")),
-                    Operator::Lte,
-                    Literal::new_expr("J".into()),
-                ),
+                BinaryExpr::new_expr(col(Field::from("letter")), Operator::Lte, lit("J")),
                 Operator::Or,
-                BinaryExpr::new_expr(
-                    Column::new_expr(Field::from("number")),
-                    Operator::Lt,
-                    Literal::new_expr(25.into()),
-                ),
+                BinaryExpr::new_expr(col(Field::from("number")), Operator::Lt, lit(25)),
             )))
             .build()
             .await

--- a/vortex-layout/src/layouts/chunked/scan.rs
+++ b/vortex-layout/src/layouts/chunked/scan.rs
@@ -293,7 +293,7 @@ mod test {
     use vortex_buffer::buffer;
     use vortex_dtype::Nullability::NonNullable;
     use vortex_dtype::{DType, PType};
-    use vortex_expr::{BinaryExpr, Identity, Literal, Operator};
+    use vortex_expr::{gt, lit, Identity};
 
     use crate::layouts::chunked::scan::{ChunkState, ChunkedScan, ChunkedScanner};
     use crate::layouts::chunked::writer::ChunkedLayoutWriter;
@@ -340,11 +340,7 @@ mod test {
             layout,
             Scan {
                 projection: Identity::new_expr(),
-                filter: Some(BinaryExpr::new_expr(
-                    Identity::new_expr(),
-                    Operator::Gt,
-                    Literal::new_expr(6.into()),
-                )),
+                filter: Some(gt(Identity::new_expr(), lit(6))),
             },
             Default::default(),
         )

--- a/vortex-layout/src/layouts/flat/scan.rs
+++ b/vortex-layout/src/layouts/flat/scan.rs
@@ -131,7 +131,7 @@ mod test {
     use vortex_array::{ArrayDType, IntoArrayVariant, ToArrayData};
     use vortex_buffer::buffer;
     use vortex_dtype::{DType, Nullability};
-    use vortex_expr::{BinaryExpr, Identity, Literal, Operator};
+    use vortex_expr::{lit, BinaryExpr, Identity, Operator};
 
     use crate::layouts::flat::writer::FlatLayoutWriter;
     use crate::scanner::Scan;
@@ -172,7 +172,7 @@ mod test {
             filter: Some(BinaryExpr::new_expr(
                 Arc::new(Identity),
                 Operator::Gt,
-                Literal::new_expr(3i32.into()),
+                lit(3i32),
             )),
         };
 
@@ -194,15 +194,11 @@ mod test {
 
         let scan = Scan {
             // The projection function here changes the scan's DType to boolean
-            projection: BinaryExpr::new_expr(
-                Arc::new(Identity),
-                Operator::Lt,
-                Literal::new_expr(5.into()),
-            ),
+            projection: BinaryExpr::new_expr(Arc::new(Identity), Operator::Lt, lit(5)),
             filter: Some(BinaryExpr::new_expr(
                 Arc::new(Identity),
                 Operator::Gt,
-                Literal::new_expr(3.into()),
+                lit(3),
             )),
         };
 


### PR DESCRIPTION
For binary expressions, we now have eq, not_eq, lt, lt_eq, gt, gt_eq, and, or (see vortex-expr/src/binary.rs). Add example usage doctests for all

For literals we have lit

For Identity we have ident