### PR TITLE
Converting LogicalValidity into Validity requires passing Nullability

### DIFF
--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -207,7 +207,8 @@ impl IntoCanonical for ALPRDArray {
                     right_parts.into_buffer_mut::<u32>(),
                     self.left_parts_patches(),
                 )?,
-                self.logical_validity().into_validity(),
+                self.logical_validity()
+                    .into_validity(self.dtype().nullability()),
             )
         } else {
             PrimitiveArray::new(
@@ -218,7 +219,8 @@ impl IntoCanonical for ALPRDArray {
                     right_parts.into_buffer_mut::<u64>(),
                     self.left_parts_patches(),
                 )?,
-                self.logical_validity().into_validity(),
+                self.logical_validity()
+                    .into_validity(self.dtype().nullability()),
             )
         };
 

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -103,11 +103,9 @@ impl DateTimePartsArray {
     }
 
     pub fn validity(&self) -> Validity {
-        if self.dtype().is_nullable() {
-            self.days().logical_validity().into_validity()
-        } else {
-            Validity::NonNullable
-        }
+        self.days()
+            .logical_validity()
+            .into_validity(self.dtype().nullability())
     }
 }
 

--- a/vortex-array/src/array/chunked/canonical.rs
+++ b/vortex-array/src/array/chunked/canonical.rs
@@ -18,11 +18,9 @@ use crate::{
 
 impl IntoCanonical for ChunkedArray {
     fn into_canonical(self) -> VortexResult<Canonical> {
-        let validity = if self.dtype().is_nullable() {
-            self.logical_validity().into_validity()
-        } else {
-            Validity::NonNullable
-        };
+        let validity = self
+            .logical_validity()
+            .into_validity(self.dtype().nullability());
         try_canonicalize_chunks(self.chunks().collect(), validity, self.dtype())
     }
 }

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -491,6 +491,10 @@ impl LogicalValidity {
     }
 
     pub fn into_validity(self, nullability: Nullability) -> Validity {
+        assert!(
+            nullability == Nullability::Nullable || !matches!(self, Self::AllInvalid(_)),
+            "AllInvalid validity must be nullable",
+        );
         match self {
             Self::AllValid(_) => match nullability {
                 Nullability::NonNullable => Validity::NonNullable,
@@ -537,9 +541,10 @@ impl IntoArrayData for LogicalValidity {
 mod tests {
     use rstest::rstest;
     use vortex_buffer::{buffer, Buffer};
+    use vortex_dtype::Nullability;
 
     use crate::array::{BoolArray, PrimitiveArray};
-    use crate::validity::Validity;
+    use crate::validity::{LogicalValidity, Validity};
     use crate::IntoArrayData;
 
     #[rstest]
@@ -577,5 +582,11 @@ mod tests {
         Validity::NonNullable
             .patch(2, &buffer![4].into_array(), Validity::AllInvalid)
             .unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn into_validity_nullable() {
+        LogicalValidity::AllInvalid(10).into_validity(Nullability::NonNullable);
     }
 }

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -375,7 +375,8 @@ impl TryFrom<ArrayData> for Validity {
     type Error = VortexError;
 
     fn try_from(value: ArrayData) -> Result<Self, Self::Error> {
-        LogicalValidity::try_from(value).map(|a| a.into_validity())
+        let nullability = value.dtype().nullability();
+        LogicalValidity::try_from(value).map(|a| a.into_validity(nullability))
     }
 }
 
@@ -489,9 +490,12 @@ impl LogicalValidity {
         }
     }
 
-    pub fn into_validity(self) -> Validity {
+    pub fn into_validity(self, nullability: Nullability) -> Validity {
         match self {
-            Self::AllValid(_) => Validity::AllValid,
+            Self::AllValid(_) => match nullability {
+                Nullability::NonNullable => Validity::NonNullable,
+                Nullability::Nullable => Validity::AllValid,
+            },
             Self::AllInvalid(_) => Validity::AllInvalid,
             Self::Array(a) => Validity::Array(a),
         }

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -590,4 +590,11 @@ mod tests {
     fn into_validity_nullable() {
         LogicalValidity::AllInvalid(10).into_validity(Nullability::NonNullable);
     }
+
+    #[test]
+    #[should_panic]
+    fn into_validity_nullable_array() {
+        LogicalValidity::Array(BoolArray::from_iter(vec![true, false]).into_array())
+            .into_validity(Nullability::NonNullable);
+    }
 }

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -334,6 +334,10 @@ impl Validity {
         }
     }
 
+    /// Create Validity from boolean array with given nullability of the array.
+    ///
+    /// Note: You want to pass the nullability of parent array and not the nullability of the validity array itself
+    ///     as that is always nonnullable
     pub fn from_array(value: ArrayData, nullability: Nullability) -> VortexResult<Self> {
         LogicalValidity::try_from(value).map(|a| a.into_validity(nullability))
     }

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -301,6 +301,12 @@ impl Validity {
             _ => {}
         };
 
+        let own_nullability = if self == Validity::NonNullable {
+            Nullability::NonNullable
+        } else {
+            Nullability::Nullable
+        };
+
         let source = match self {
             Validity::NonNullable => BoolArray::from(BooleanBuffer::new_set(len)),
             Validity::AllValid => BoolArray::from(BooleanBuffer::new_set(len)),
@@ -317,7 +323,7 @@ impl Validity {
 
         let patches = Patches::new(len, indices.clone(), patch_values.into_array());
 
-        Validity::try_from(source.patch(patches)?.into_array())
+        Self::from_array(source.patch(patches)?.into_array(), own_nullability)
     }
 
     /// Convert into a nullable variant
@@ -326,6 +332,10 @@ impl Validity {
             Self::NonNullable => Self::AllValid,
             _ => self,
         }
+    }
+
+    pub fn from_array(value: ArrayData, nullability: Nullability) -> VortexResult<Self> {
+        LogicalValidity::try_from(value).map(|a| a.into_validity(nullability))
     }
 }
 
@@ -368,15 +378,6 @@ impl From<BooleanBuffer> for Validity {
 impl From<NullBuffer> for Validity {
     fn from(value: NullBuffer) -> Self {
         value.into_inner().into()
-    }
-}
-
-impl TryFrom<ArrayData> for Validity {
-    type Error = VortexError;
-
-    fn try_from(value: ArrayData) -> Result<Self, Self::Error> {
-        let nullability = value.dtype().nullability();
-        LogicalValidity::try_from(value).map(|a| a.into_validity(nullability))
     }
 }
 
@@ -492,8 +493,8 @@ impl LogicalValidity {
 
     pub fn into_validity(self, nullability: Nullability) -> Validity {
         assert!(
-            nullability == Nullability::Nullable || !matches!(self, Self::AllInvalid(_)),
-            "AllInvalid validity must be nullable",
+            nullability == Nullability::Nullable || matches!(self, Self::AllValid(_)),
+            "NonNullable validity must be AllValid",
         );
         match self {
             Self::AllValid(_) => match nullability {


### PR DESCRIPTION
Without nullability we can't accurately reconstruct Validity as LogicalValidity
losses nonnullable state

fix #1740 
