### PR TITLE
feat: negative normal form

### DIFF
--- a/vortex-expr/src/forms/mod.rs
+++ b/vortex-expr/src/forms/mod.rs
@@ -1,0 +1,1 @@
+pub mod nnf;

--- a/vortex-expr/src/forms/nnf.rs
+++ b/vortex-expr/src/forms/nnf.rs
@@ -1,0 +1,185 @@
+use vortex_error::{vortex_bail, vortex_err, VortexResult};
+
+use crate::traversal::{Node as _, NodeVisitor, TraversalOrder};
+use crate::{not, BinaryExpr, Column, ExprRef, Literal, Not, Operator};
+
+/// Return an equivalent expression in Negative Normal Form (NNF).
+///
+/// In NNF, [Not] expressions may only contain terminal nodes such as [Literal] or [Column]. They
+/// *may not* contain [BinaryExpr], [Not], etc.
+///
+/// # Examples
+///
+/// Double negation is removed entirely:
+///
+/// ```
+/// use vortex_expr::{not, col};
+/// use vortex_expr::forms::nnf::nnf;
+///
+/// let double_negation = not(not(col("a")));
+/// let nnfed = nnf(double_negation).unwrap();
+/// assert_eq!(&nnfed, &col("a"));
+/// ```
+///
+/// Triple negation becomes single negation:
+///
+/// ```
+/// use vortex_expr::{not, col};
+/// use vortex_expr::forms::nnf::nnf;
+///
+/// let triple_negation = not(not(not(col("a"))));
+/// let nnfed = nnf(triple_negation).unwrap();
+/// assert_eq!(&nnfed, &not(col("a")));
+/// ```
+///
+/// Negation at a high-level is pushed to the leaves, likely increasing the total number nodes:
+///
+/// ```
+/// use vortex_expr::{not, col, and, or};
+/// use vortex_expr::forms::nnf::nnf;
+///
+/// assert_eq!(
+///     &nnf(not(and(col("a"), col("b")))).unwrap(),
+///     &or(not(col("a")), not(col("b")))
+/// );
+/// ```
+///
+/// In Vortex, NNF is extended beyond simple Boolean operators to any Boolean-valued operator:
+///
+/// ```
+/// use vortex_expr::{not, col, and, or, lt, lit, gt_eq};
+/// use vortex_expr::forms::nnf::nnf;
+///
+/// assert_eq!(
+///     &nnf(not(and(gt_eq(col("a"), lit(3)), col("b")))).unwrap(),
+///     &or(lt(col("a"), lit(3)), not(col("b")))
+/// );
+/// ```
+pub fn nnf(expr: ExprRef) -> VortexResult<ExprRef> {
+    let mut visitor = NNFVisitor::default();
+    expr.accept(&mut visitor)?;
+    visitor.finish()
+}
+
+struct NNFVisitor {
+    negating: Vec<bool>,
+    stack: Vec<Vec<ExprRef>>,
+}
+
+impl Default for NNFVisitor {
+    fn default() -> Self {
+        NNFVisitor {
+            negating: vec![false],
+            stack: vec![vec![]],
+        }
+    }
+}
+
+impl NNFVisitor {
+    fn finish(mut self) -> VortexResult<ExprRef> {
+        if self.negating.len() != 1 || self.stack.len() != 1 {
+            vortex_bail!("finish called before traversal completed");
+        }
+
+        let mut frame = self.stack.remove(0);
+
+        if frame.len() != 1 {
+            vortex_bail!("final frame contains more than one expr: {:?}", frame);
+        }
+
+        Ok(frame.remove(0))
+    }
+}
+
+impl NodeVisitor<'_> for NNFVisitor {
+    type NodeTy = ExprRef;
+
+    fn visit_down(&mut self, node: &ExprRef) -> VortexResult<TraversalOrder> {
+        let negating = self
+            .negating
+            .last()
+            .ok_or_else(|| vortex_err!("negating must be non-empty"))?;
+        self.stack.push(vec![]);
+
+        let node_any = node.as_any();
+        if node_any.downcast_ref::<Not>().is_some() {
+            self.negating.push(!negating)
+        } else if node_any.downcast_ref::<Literal>().is_some()
+            || node_any.downcast_ref::<Column>().is_some()
+        {
+            // do nothing
+        } else if let Some(binary_expr) = node_any.downcast_ref::<BinaryExpr>() {
+            match binary_expr.op() {
+                Operator::And | Operator::Or => self.negating.push(*negating),
+                Operator::Eq
+                | Operator::NotEq
+                | Operator::Gt
+                | Operator::Gte
+                | Operator::Lt
+                | Operator::Lte => self.negating.push(false),
+            }
+        } else {
+            todo!("{:?}", node)
+        }
+
+        Ok(TraversalOrder::Continue)
+    }
+
+    fn visit_up(&mut self, node: &ExprRef) -> VortexResult<TraversalOrder> {
+        let mut children = self
+            .stack
+            .pop()
+            .ok_or_else(|| vortex_err!("stack must at least have current frame"))?;
+
+        let node_any = node.as_any();
+        let new_expr = if node_any.downcast_ref::<Not>().is_some() {
+            debug_assert_eq!(children.len(), 1);
+            self.negating.pop();
+            children.remove(0)
+        } else if node_any.downcast_ref::<Literal>().is_some()
+            || node_any.downcast_ref::<Column>().is_some()
+        {
+            debug_assert_eq!(children.len(), 0);
+
+            let negating = self
+                .negating
+                .last()
+                .ok_or_else(|| vortex_err!("negating must be non-empty"))?;
+            if *negating {
+                not(node.clone())
+            } else {
+                node.clone()
+            }
+        } else if let Some(binary_expr) = node_any.downcast_ref::<BinaryExpr>() {
+            debug_assert_eq!(children.len(), 2);
+
+            self.negating
+                .pop()
+                .ok_or_else(|| vortex_err!("negating must be non-empty"))?;
+
+            let negating = self
+                .negating
+                .last()
+                .ok_or_else(|| vortex_err!("negating must be non-empty"))?;
+
+            let rhs = children.remove(1);
+            let lhs = children.remove(0);
+            let operator = if *negating {
+                binary_expr.op().inverse()
+            } else {
+                binary_expr.op()
+            };
+
+            BinaryExpr::new_expr(lhs, operator, rhs)
+        } else {
+            todo!("{:?}", node)
+        };
+
+        self.stack
+            .last_mut()
+            .ok_or_else(|| vortex_err!("stack is always non-empty"))?
+            .push(new_expr);
+
+        Ok(TraversalOrder::Continue)
+    }
+}

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 mod binary;
 mod column;
 pub mod datafusion;
+pub mod forms;
 mod identity;
 mod like;
 mod literal;
@@ -179,7 +180,7 @@ mod tests {
             "(($col1 < $col2) or ($col1 != $col2))"
         );
 
-        assert_eq!(Not::new_expr(col1.clone()).to_string(), "!$col1");
+        assert_eq!(not(col1.clone()).to_string(), "!$col1");
 
         assert_eq!(
             Select::include(vec![Field::from("col1")]).to_string(),

--- a/vortex-expr/src/like.rs
+++ b/vortex-expr/src/like.rs
@@ -100,16 +100,14 @@ impl Eq for Like {}
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use vortex_array::array::BoolArray;
     use vortex_array::IntoArrayVariant;
 
-    use crate::{Identity, Not};
+    use crate::{ident, not};
 
     #[test]
     fn invert_booleans() {
-        let not_expr = Not::new_expr(Arc::new(Identity));
+        let not_expr = not(ident());
         let bools = BoolArray::from_iter([false, true, false, false, true, true]);
         assert_eq!(
             not_expr

--- a/vortex-expr/src/not.rs
+++ b/vortex-expr/src/not.rs
@@ -58,18 +58,20 @@ impl PartialEq for Not {
 
 impl Eq for Not {}
 
+pub fn not(operand: ExprRef) -> ExprRef {
+    Not::new_expr(operand)
+}
+
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use vortex_array::array::BoolArray;
     use vortex_array::IntoArrayVariant;
 
-    use crate::{Identity, Not};
+    use crate::{ident, not};
 
     #[test]
     fn invert_booleans() {
-        let not_expr = Not::new_expr(Arc::new(Identity));
+        let not_expr = not(ident());
         let bools = BoolArray::from_iter([false, true, false, false, true, true]);
         assert_eq!(
             not_expr

--- a/vortex-expr/src/operators.rs
+++ b/vortex-expr/src/operators.rs
@@ -33,15 +33,16 @@ impl Display for Operator {
 }
 
 impl Operator {
-    pub fn inverse(self) -> Option<Self> {
+    pub fn inverse(self) -> Self {
         match self {
-            Operator::Eq => Some(Operator::NotEq),
-            Operator::NotEq => Some(Operator::Eq),
-            Operator::Gt => Some(Operator::Lte),
-            Operator::Gte => Some(Operator::Lt),
-            Operator::Lt => Some(Operator::Gte),
-            Operator::Lte => Some(Operator::Gt),
-            Operator::And | Operator::Or => None,
+            Operator::Eq => Operator::NotEq,
+            Operator::NotEq => Operator::Eq,
+            Operator::Gt => Operator::Lte,
+            Operator::Gte => Operator::Lt,
+            Operator::Lt => Operator::Gte,
+            Operator::Lte => Operator::Gt,
+            Operator::And => Operator::Or,
+            Operator::Or => Operator::And,
         }
     }
 

--- a/vortex-expr/src/project.rs
+++ b/vortex-expr/src/project.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use vortex_dtype::Field;
 
 use crate::{
-    col, lit, BinaryExpr, Column, ExprRef, Identity, Like, Literal, Not, Operator, RowFilter,
+    col, lit, not, BinaryExpr, Column, ExprRef, Identity, Like, Literal, Not, Operator, RowFilter,
     Select, VortexExpr, VortexExprExt,
 };
 
@@ -54,7 +54,7 @@ pub fn expr_project(expr: &ExprRef, projection: &[Field]) -> Option<ExprRef> {
     } else if let Some(n) = expr.as_any().downcast_ref::<Not>() {
         let own_refs = expr.references();
         if own_refs.iter().all(|p| projection.contains(p)) {
-            expr_project(n.child(), projection).map(Not::new_expr)
+            expr_project(n.child(), projection).map(not)
         } else {
             None
         }
@@ -169,7 +169,7 @@ mod tests {
 
     #[test]
     fn project_not() {
-        let not_e = Not::new_expr(col(Field::from("a")));
+        let not_e = not(col("a"));
         let projection = vec![Field::from("a"), Field::from("b")];
         assert_eq!(&expr_project(&not_e, &projection).unwrap(), &not_e);
     }

--- a/vortex-expr/src/pruning.rs
+++ b/vortex-expr/src/pruning.rs
@@ -14,8 +14,8 @@ use vortex_error::{VortexExpect as _, VortexResult};
 use vortex_scalar::Scalar;
 
 use crate::{
-    and, col, eq, gt, gt_eq, lit, lt_eq, or, BinaryExpr, Column, ExprRef, Identity, Literal, Not,
-    Operator, RowFilter, VortexExprExt,
+    and, col, eq, gt, gt_eq, lit, lt_eq, not, or, BinaryExpr, Column, ExprRef, Identity, Literal,
+    Not, Operator, RowFilter, VortexExprExt,
 };
 
 #[derive(Debug, Clone)]
@@ -248,7 +248,7 @@ fn convert_column_reference(expr: &ExprRef, invert: bool) -> PruningPredicateSta
     let expr = if invert {
         and(min_expr, max_expr)
     } else {
-        Not::new_expr(or(min_expr, max_expr))
+        not(or(min_expr, max_expr))
     };
 
     (expr, refs)
@@ -366,9 +366,9 @@ fn replace_column_with_stat(
         return Some(col(new_field));
     }
 
-    if let Some(not) = expr.as_any().downcast_ref::<Not>() {
-        let rewritten = replace_column_with_stat(not.child(), stat, stats_to_fetch)?;
-        return Some(Not::new_expr(rewritten));
+    if let Some(not_expr) = expr.as_any().downcast_ref::<Not>() {
+        let rewritten = replace_column_with_stat(not_expr.child(), stat, stats_to_fetch)?;
+        return Some(not(rewritten));
     }
 
     if let Some(bexp) = expr.as_any().downcast_ref::<BinaryExpr>() {
@@ -445,7 +445,7 @@ mod tests {
     use crate::pruning::{
         convert_to_pruning_expression, stat_column_field, FieldOrIdentity, PruningPredicate,
     };
-    use crate::{and, col, eq, gt, gt_eq, lit, lt, lt_eq, not_eq, or, Identity, Not};
+    use crate::{and, col, eq, gt, gt_eq, lit, lt, lt_eq, not, not_eq, or, Identity};
 
     #[test]
     pub fn pruning_equals() {
@@ -643,7 +643,7 @@ mod tests {
 
     #[test]
     fn unprojectable_expr() {
-        let or_expr = Not::new_expr(lt(col(Field::from("a")), col(Field::from("b"))));
+        let or_expr = not(lt(col("a"), col("b")));
         assert!(PruningPredicate::try_new(&or_expr).is_none());
     }
 


### PR DESCRIPTION
This is missing several cases, but I want some feedback on the implementation. In particular, the traversal doesn't expose to `Visitor` a stack mechanism, so I have to reconstruct that myself.

For operators that are ExprRef -> ExprRef, I think I want something like:
```
impl Visitor for ... {
    def visit_down(&mut self, node: ExprRef, state_from_parent: State) -> VortexExpr<(TraversalOrder, State)> { ... }
    def visit_up(&mut self, visited_children: Vec<ExprRef>) -> VortexExpr<(TraversalOrder, ExprRef)> { ... }
}
```

And then I can just grab `expr.accept(my_visitor)?.1` as the resulting value.