### PR TITLE
fix: FlexBuffer serialization ambiguity for binary/string/list(u8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5303,6 +5303,7 @@ dependencies = [
  "paste",
  "prost",
  "prost-types",
+ "rstest",
  "serde",
  "vortex-buffer",
  "vortex-datetime-dtype",

--- a/vortex-array/src/array/list/mod.rs
+++ b/vortex-array/src/array/list/mod.rs
@@ -19,7 +19,7 @@ use crate::array::PrimitiveArray;
 use crate::builders::{ArrayBuilder, ListBuilder};
 use crate::compute::{scalar_at, slice};
 use crate::encoding::ids;
-use crate::stats::{Stat, StatisticsVTable, StatsSet};
+use crate::stats::{StatisticsVTable, StatsSet};
 use crate::validity::{LogicalValidity, Validity, ValidityMetadata, ValidityVTable};
 use crate::variants::{ListArrayTrait, PrimitiveArrayTrait, VariantsVTable};
 use crate::visitor::{ArrayVisitor, VisitorVTable};
@@ -174,11 +174,7 @@ impl IntoCanonical for ListArray {
     }
 }
 
-impl StatisticsVTable<ListArray> for ListEncoding {
-    fn compute_statistics(&self, _array: &ListArray, _stat: Stat) -> VortexResult<StatsSet> {
-        Ok(StatsSet::default())
-    }
-}
+impl StatisticsVTable<ListArray> for ListEncoding {}
 
 impl ListArrayTrait for ListArray {}
 

--- a/vortex-sampling-compressor/src/sampling_compressor.rs
+++ b/vortex-sampling-compressor/src/sampling_compressor.rs
@@ -62,16 +62,16 @@ impl Default for SamplingCompressor<'_> {
 }
 
 impl<'a> SamplingCompressor<'a> {
-    pub fn new(compressors: HashSet<CompressorRef<'a>>) -> Self {
+    pub fn new(compressors: impl Into<HashSet<CompressorRef<'a>>>) -> Self {
         Self::new_with_options(compressors, Default::default())
     }
 
     pub fn new_with_options(
-        compressors: HashSet<CompressorRef<'a>>,
+        compressors: impl Into<HashSet<CompressorRef<'a>>>,
         options: CompressConfig,
     ) -> Self {
         Self {
-            compressors,
+            compressors: compressors.into(),
             options,
             path: Vec::new(),
             depth: 0,

--- a/vortex-scalar/Cargo.toml
+++ b/vortex-scalar/Cargo.toml
@@ -32,6 +32,10 @@ vortex-error = { workspace = true }
 vortex-flatbuffers = { workspace = true, optional = true }
 vortex-proto = { workspace = true, optional = true }
 
+[dev-dependencies]
+flexbuffers = { workspace = true }
+rstest = { workspace = true }
+
 [lints]
 workspace = true
 


### PR DESCRIPTION
After the recent switch to ByteBuffer, FlexBuffer would have am ambiguity serializing the different sequence variants. This was resulting in Binary ScalarValues written to files to be reinterpreted as List(u8) on read.
    
Instead, we explicitly handle serialization.

Part of #1749 