### PR TITLE
Fix splits to read empty struct/chunked arrays.

### DIFF
--- a/vortex-array/src/array/chunked/compute/boolean.rs
+++ b/vortex-array/src/array/chunked/compute/boolean.rs
@@ -15,7 +15,7 @@ impl BinaryBooleanFn<ChunkedArray> for ChunkedEncoding {
         let mut idx = 0;
         let mut chunks = Vec::with_capacity(lhs.nchunks());
 
-        for chunk in lhs.chunks() {
+        for chunk in lhs.chunks().filter(|c| !c.is_empty()) {
             let sliced = slice(rhs, idx, idx + chunk.len())?;
             let result = binary_boolean(&chunk, &sliced, op)?;
             chunks.push(result);

--- a/vortex-file/src/read/handle.rs
+++ b/vortex-file/src/read/handle.rs
@@ -43,6 +43,7 @@ impl<R: VortexReadAt + Unpin> VortexReadHandle<R> {
             fr.add_splits(0, &mut reader_splits)?;
         }
 
+        reader_splits.insert(0);
         reader_splits.insert(row_count as usize);
 
         let splits = reader_splits.into_iter().tuple_windows().collect();

--- a/vortex-file/src/read/layouts/chunked.rs
+++ b/vortex-file/src/read/layouts/chunked.rs
@@ -297,9 +297,11 @@ impl ChunkedLayoutReader {
 
 impl LayoutReader for ChunkedLayoutReader {
     fn add_splits(&self, row_offset: usize, splits: &mut BTreeSet<usize>) -> VortexResult<()> {
-        for RangedLayoutReader((begin, _), child) in self.layouts.iter() {
+        for RangedLayoutReader((begin, end), child) in self.layouts.iter() {
             child.add_splits(row_offset + *begin, splits)?;
+            splits.insert(row_offset + end);
         }
+
         Ok(())
     }
 

--- a/vortex-file/src/read/layouts/columnar.rs
+++ b/vortex-file/src/read/layouts/columnar.rs
@@ -138,6 +138,7 @@ impl ColumnarLayoutBuilder<'_> {
                 unhandled_children,
                 Some(prf),
                 false,
+                self.layout.row_count(),
             )));
             handled_names.push("__unhandled".into());
         }
@@ -162,6 +163,7 @@ impl ColumnarLayoutBuilder<'_> {
             handled_children,
             top_level_expr,
             shortcircuit_siblings,
+            self.layout.row_count(),
         ))
     }
 
@@ -198,6 +200,7 @@ pub struct ColumnarLayoutReader {
     in_progress_ranges: InProgressRanges,
     in_progress_metadata: RwLock<HashMap<FieldName, Option<ArrayData>>>,
     in_progress_prunes: InProgressPrunes,
+    row_count: u64,
 }
 
 impl ColumnarLayoutReader {
@@ -206,6 +209,7 @@ impl ColumnarLayoutReader {
         children: Vec<Arc<dyn LayoutReader>>,
         expr: Option<Arc<dyn VortexExpr>>,
         shortcircuit_siblings: bool,
+        row_count: u64,
     ) -> Self {
         assert_eq!(
             names.len(),
@@ -217,6 +221,7 @@ impl ColumnarLayoutReader {
             children,
             expr,
             shortcircuit_siblings,
+            row_count,
             in_progress_ranges: RwLock::new(HashMap::new()),
             in_progress_metadata: RwLock::new(HashMap::new()),
             in_progress_prunes: RwLock::new(HashMap::new()),
@@ -229,6 +234,7 @@ impl LayoutReader for ColumnarLayoutReader {
         for child in &self.children {
             child.add_splits(row_offset, splits)?;
         }
+        splits.insert(row_offset + self.row_count as usize);
         Ok(())
     }
 

--- a/vortex-file/src/read/layouts/columnar.rs
+++ b/vortex-file/src/read/layouts/columnar.rs
@@ -138,7 +138,6 @@ impl ColumnarLayoutBuilder<'_> {
                 unhandled_children,
                 Some(prf),
                 false,
-                self.layout.row_count(),
             )));
             handled_names.push("__unhandled".into());
         }
@@ -163,7 +162,6 @@ impl ColumnarLayoutBuilder<'_> {
             handled_children,
             top_level_expr,
             shortcircuit_siblings,
-            self.layout.row_count(),
         ))
     }
 
@@ -200,7 +198,6 @@ pub struct ColumnarLayoutReader {
     in_progress_ranges: InProgressRanges,
     in_progress_metadata: RwLock<HashMap<FieldName, Option<ArrayData>>>,
     in_progress_prunes: InProgressPrunes,
-    row_count: u64,
 }
 
 impl ColumnarLayoutReader {
@@ -209,7 +206,6 @@ impl ColumnarLayoutReader {
         children: Vec<Arc<dyn LayoutReader>>,
         expr: Option<Arc<dyn VortexExpr>>,
         shortcircuit_siblings: bool,
-        row_count: u64,
     ) -> Self {
         assert_eq!(
             names.len(),
@@ -221,7 +217,6 @@ impl ColumnarLayoutReader {
             children,
             expr,
             shortcircuit_siblings,
-            row_count,
             in_progress_ranges: RwLock::new(HashMap::new()),
             in_progress_metadata: RwLock::new(HashMap::new()),
             in_progress_prunes: RwLock::new(HashMap::new()),
@@ -234,7 +229,6 @@ impl LayoutReader for ColumnarLayoutReader {
         for child in &self.children {
             child.add_splits(row_offset, splits)?;
         }
-        splits.insert(row_offset + self.row_count as usize);
         Ok(())
     }
 
@@ -299,6 +293,7 @@ impl LayoutReader for ColumnarLayoutReader {
                 .first()
                 .map(|l| l.len())
                 .unwrap_or_else(|| selection.true_count());
+
             let array =
                 StructArray::try_new(self.names.clone(), child_arrays, len, Validity::NonNullable)?
                     .into_array();

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -1250,7 +1250,7 @@ async fn roundtrip_row_count() {
         .collect::<Vec<_>>()
         .await;
 
-    let read_rows = read.iter().map(|a| a.len()).sum();
+    let read_rows = read.iter().map(|a| a.len()).sum::<usize>();
 
     assert_eq!(st.len(), read_rows);
 }

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -1250,5 +1250,7 @@ async fn roundtrip_row_count() {
         .collect::<Vec<_>>()
         .await;
 
-    assert!(read.len() > 0);
+    let read_rows = read.iter().map(|a| a.len()).sum();
+
+    assert_eq!(st.len(), read_rows);
 }

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -1226,3 +1226,29 @@ async fn test_simple_range_twice() {
         assert_eq!(row_count, 7);
     }
 }
+
+#[tokio::test]
+async fn roundtrip_row_count() {
+    let st = StructArray::try_new([].into(), [].into(), 2, Validity::AllValid).unwrap();
+
+    let buf = Vec::new();
+    let mut writer = VortexFileWriter::new(buf);
+    writer = writer
+        .write_array_columns(st.clone().into_array())
+        .await
+        .unwrap();
+    let written = Bytes::from(writer.finalize().await.unwrap());
+
+    let handle = VortexReadBuilder::new(written, LayoutDeserializer::default())
+        .build()
+        .await
+        .unwrap();
+
+    let read = handle
+        .into_stream()
+        .map(|a| a.unwrap())
+        .collect::<Vec<_>>()
+        .await;
+
+    assert!(read.len() > 0);
+}

--- a/vortex-file/src/write/writer.rs
+++ b/vortex-file/src/write/writer.rs
@@ -80,6 +80,7 @@ impl<W: VortexWrite> VortexFileWriter<W> {
         while let Some(columns) = array_stream.try_next().await? {
             let st = StructArray::try_from(columns)?;
             self.row_count += st.len() as u64;
+
             for (i, field) in st.children().enumerate() {
                 if let Ok(chunked_array) = ChunkedArray::try_from(field.clone()) {
                     self.write_column_chunks(chunked_array.array_stream(), i)


### PR DESCRIPTION
closes #1874.