### PR TITLE
Segment Alignment

### DIFF
--- a/vortex-array/src/parts.rs
+++ b/vortex-array/src/parts.rs
@@ -135,9 +135,6 @@ impl WriteFlatBuffer for ArrayPartsFlatBuffer<'_> {
         let metadata = Some(fbb.create_vector(metadata.as_ref()));
 
         // Assign buffer indices for all child arrays.
-        // The second tuple element holds the buffer_index for this Array subtree. If this array
-        // has a buffer, that is its buffer index. If it does not, that buffer index belongs
-        // to one of the children.
         let nbuffers = u16::try_from(self.array.nbuffers())
             .vortex_expect("Array can have at most u16::MAX buffers");
         let child_buffer_idx = self.buffer_idx + nbuffers;

--- a/vortex-array/src/parts.rs
+++ b/vortex-array/src/parts.rs
@@ -1,11 +1,15 @@
 use std::fmt::{Debug, Formatter};
 
-use flatbuffers::Follow;
+use flatbuffers::{FlatBufferBuilder, Follow, WIPOffset};
+use itertools::Itertools;
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
-use vortex_error::{vortex_panic, VortexResult};
-use vortex_flatbuffers::{array as fba, FlatBuffer};
+use vortex_error::{vortex_panic, VortexExpect, VortexResult};
+use vortex_flatbuffers::{
+    array as fba, FlatBuffer, FlatBufferRoot, WriteFlatBuffer, WriteFlatBufferExt,
+};
 
+use crate::stats::ArrayStatistics;
 use crate::{ArrayData, ContextRef};
 
 /// [`ArrayParts`] represents the information from an [`ArrayData`] that makes up the serialized
@@ -14,6 +18,7 @@ use crate::{ArrayData, ContextRef};
 ///
 /// An [`ArrayParts`] can be fully decoded into an [`ArrayData`] using the `decode` function.
 pub struct ArrayParts {
+    // TODO(ngates): I think we should remove this. It's not required in the serialized form.
     row_count: usize,
     // Typed as fb::Array
     flatbuffer: FlatBuffer,
@@ -71,6 +76,105 @@ impl ArrayParts {
             // SAFETY: ArrayComponents guarantees the buffers are valid.
             |buf| unsafe { Ok(fba::Array::follow(buf, self.flatbuffer_loc)) },
             self.buffers,
+        )
+    }
+}
+
+/// Convert an [`ArrayData`] into [`ArrayParts`].
+impl From<ArrayData> for ArrayParts {
+    fn from(array: ArrayData) -> Self {
+        let flatbuffer = ArrayPartsFlatBuffer {
+            array: &array,
+            buffer_idx: 0,
+        }
+        .write_flatbuffer_bytes();
+        let mut buffers: Vec<ByteBuffer> = vec![];
+        for child in array.depth_first_traversal() {
+            for buffer in child.byte_buffers() {
+                buffers.push(buffer);
+            }
+        }
+        Self {
+            row_count: array.len(),
+            flatbuffer,
+            flatbuffer_loc: 0,
+            buffers,
+        }
+    }
+}
+
+/// A utility struct for creating an [`fba::Array`] flatbuffer.
+pub struct ArrayPartsFlatBuffer<'a> {
+    array: &'a ArrayData,
+    buffer_idx: u16,
+}
+
+impl<'a> ArrayPartsFlatBuffer<'a> {
+    pub fn new(array: &'a ArrayData) -> Self {
+        Self {
+            array,
+            buffer_idx: 0,
+        }
+    }
+}
+
+impl FlatBufferRoot for ArrayPartsFlatBuffer<'_> {}
+
+impl WriteFlatBuffer for ArrayPartsFlatBuffer<'_> {
+    type Target<'t> = fba::Array<'t>;
+
+    fn write_flatbuffer<'fb>(
+        &self,
+        fbb: &mut FlatBufferBuilder<'fb>,
+    ) -> WIPOffset<Self::Target<'fb>> {
+        let encoding = self.array.encoding().id().code();
+        let metadata = self
+            .array
+            .metadata_bytes()
+            .vortex_expect("IPCArray is missing metadata during serialization");
+        let metadata = Some(fbb.create_vector(metadata.as_ref()));
+
+        // Assign buffer indices for all child arrays.
+        // The second tuple element holds the buffer_index for this Array subtree. If this array
+        // has a buffer, that is its buffer index. If it does not, that buffer index belongs
+        // to one of the children.
+        let nbuffers = u16::try_from(self.array.nbuffers())
+            .vortex_expect("Array can have at most u16::MAX buffers");
+        let child_buffer_idx = self.buffer_idx + nbuffers;
+
+        let children = self
+            .array
+            .children()
+            .iter()
+            .scan(child_buffer_idx, |buffer_idx, child| {
+                // Update the number of buffers required.
+                let msg = ArrayPartsFlatBuffer {
+                    array: child,
+                    buffer_idx: *buffer_idx,
+                }
+                .write_flatbuffer(fbb);
+                *buffer_idx = u16::try_from(child.cumulative_nbuffers())
+                    .ok()
+                    .and_then(|nbuffers| nbuffers.checked_add(*buffer_idx))
+                    .vortex_expect("Too many buffers (u16) for ArrayData");
+                Some(msg)
+            })
+            .collect_vec();
+        let children = Some(fbb.create_vector(&children));
+
+        let buffers = Some(fbb.create_vector_from_iter((0..nbuffers).map(|i| i + self.buffer_idx)));
+
+        let stats = Some(self.array.statistics().write_flatbuffer(fbb));
+
+        fba::Array::create(
+            fbb,
+            &fba::ArrayArgs {
+                encoding,
+                metadata,
+                children,
+                buffers,
+                stats,
+            },
         )
     }
 }

--- a/vortex-buffer/src/alignment.rs
+++ b/vortex-buffer/src/alignment.rs
@@ -58,6 +58,22 @@ impl Alignment {
         // of trailing zeros in the binary representation of the alignment is greater or equal.
         self.0.trailing_zeros() >= other.0.trailing_zeros()
     }
+
+    /// Returns the log2 of the alignment.
+    pub fn exponent(&self) -> u8 {
+        u8::try_from(self.0.trailing_zeros())
+            .vortex_expect("alignment fits into u16, so exponent fits in u7")
+    }
+
+    /// Create from the log2 exponent of the alignment.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if `alignment` is not a power of 2, or is greater than `u16::MAX`.
+    #[inline]
+    pub const fn from_exponent(exponent: u8) -> Self {
+        Self::new(1 << exponent)
+    }
 }
 
 impl Display for Alignment {
@@ -118,6 +134,13 @@ mod test {
     #[should_panic]
     fn alignment_not_power_of_two() {
         Alignment::new(3);
+    }
+
+    #[test]
+    fn alignment_exponent() {
+        let alignment = Alignment::new(1024);
+        assert_eq!(alignment.exponent(), 10);
+        assert_eq!(Alignment::from_exponent(10), alignment);
     }
 
     #[test]

--- a/vortex-file/src/v2/footer/file_layout.rs
+++ b/vortex-file/src/v2/footer/file_layout.rs
@@ -22,11 +22,7 @@ impl WriteFlatBuffer for FileLayout {
         fbb: &mut flatbuffers::FlatBufferBuilder<'fb>,
     ) -> flatbuffers::WIPOffset<Self::Target<'fb>> {
         let root_layout = self.root_layout.write_flatbuffer(fbb);
-        let segments = fbb.create_vector_from_iter(
-            self.segments
-                .iter()
-                .map(fb::Segment::from),
-        );
+        let segments = fbb.create_vector_from_iter(self.segments.iter().map(fb::Segment::from));
         fb::FileLayout::create(
             fbb,
             &fb::FileLayoutArgs {

--- a/vortex-file/src/v2/footer/file_layout.rs
+++ b/vortex-file/src/v2/footer/file_layout.rs
@@ -22,14 +22,11 @@ impl WriteFlatBuffer for FileLayout {
         fbb: &mut flatbuffers::FlatBufferBuilder<'fb>,
     ) -> flatbuffers::WIPOffset<Self::Target<'fb>> {
         let root_layout = self.root_layout.write_flatbuffer(fbb);
-
-        let segments = self
-            .segments
-            .iter()
-            .map(|segment| segment.write_flatbuffer(fbb))
-            .collect::<Vec<_>>();
-        let segments = fbb.create_vector(&segments);
-
+        let segments = fbb.create_vector_from_iter(
+            self.segments
+                .iter()
+                .map(|segment| fb::Segment::from(segment)),
+        );
         fb::FileLayout::create(
             fbb,
             &fb::FileLayoutArgs {

--- a/vortex-file/src/v2/footer/file_layout.rs
+++ b/vortex-file/src/v2/footer/file_layout.rs
@@ -25,7 +25,7 @@ impl WriteFlatBuffer for FileLayout {
         let segments = fbb.create_vector_from_iter(
             self.segments
                 .iter()
-                .map(|segment| fb::Segment::from(segment)),
+                .map(fb::Segment::from),
         );
         fb::FileLayout::create(
             fbb,

--- a/vortex-file/src/v2/footer/postscript.rs
+++ b/vortex-file/src/v2/footer/postscript.rs
@@ -19,13 +19,13 @@ impl WriteFlatBuffer for Postscript {
         &self,
         fbb: &mut flatbuffers::FlatBufferBuilder<'fb>,
     ) -> flatbuffers::WIPOffset<Self::Target<'fb>> {
-        let dtype = self.dtype.write_flatbuffer(fbb);
-        let file_layout = self.file_layout.write_flatbuffer(fbb);
+        let dtype = fb::Segment::from(&self.dtype);
+        let file_layout = fb::Segment::from(&self.file_layout);
         fb::Postscript::create(
             fbb,
             &fb::PostscriptArgs {
-                dtype: Some(dtype),
-                file_layout: Some(file_layout),
+                dtype: Some(&dtype),
+                file_layout: Some(&file_layout),
             },
         )
     }
@@ -39,12 +39,12 @@ impl ReadFlatBuffer for Postscript {
         fb: &<Self::Source<'buf> as Follow<'buf>>::Inner,
     ) -> Result<Self, Self::Error> {
         Ok(Self {
-            dtype: Segment::read_flatbuffer(
-                &fb.dtype()
+            dtype: Segment::try_from(
+                fb.dtype()
                     .ok_or_else(|| vortex_err!("Postscript missing dtype segment"))?,
             )?,
-            file_layout: Segment::read_flatbuffer(
-                &fb.file_layout()
+            file_layout: Segment::try_from(
+                fb.file_layout()
                     .ok_or_else(|| vortex_err!("Postscript missing file_layout segment"))?,
             )?,
         })

--- a/vortex-file/src/v2/footer/segment.rs
+++ b/vortex-file/src/v2/footer/segment.rs
@@ -1,4 +1,5 @@
 use flatbuffers::{FlatBufferBuilder, Follow, WIPOffset};
+use vortex_buffer::Alignment;
 use vortex_error::{vortex_err, VortexError};
 use vortex_flatbuffers::{footer2 as fb, ReadFlatBuffer, WriteFlatBuffer};
 
@@ -7,6 +8,7 @@ use vortex_flatbuffers::{footer2 as fb, ReadFlatBuffer, WriteFlatBuffer};
 pub(crate) struct Segment {
     pub(crate) offset: u64,
     pub(crate) length: usize,
+    pub(crate) alignment: Alignment,
 }
 
 impl WriteFlatBuffer for Segment {
@@ -21,6 +23,7 @@ impl WriteFlatBuffer for Segment {
             &fb::SegmentArgs {
                 offset: self.offset,
                 length: self.length as u64,
+                alignment: self.alignment.into(),
             },
         )
     }
@@ -37,6 +40,7 @@ impl ReadFlatBuffer for Segment {
             offset: fb.offset(),
             length: usize::try_from(fb.length())
                 .map_err(|_| vortex_err!("segment length exceeds maximum usize"))?,
+            alignment: Alignment::from(fb.alignment()),
         })
     }
 }

--- a/vortex-file/src/v2/footer/segment.rs
+++ b/vortex-file/src/v2/footer/segment.rs
@@ -1,5 +1,5 @@
 use vortex_buffer::Alignment;
-use vortex_error::{vortex_err, VortexError};
+use vortex_error::VortexError;
 use vortex_flatbuffers::footer2 as fb;
 
 /// The location of a segment within a Vortex file.
@@ -22,8 +22,7 @@ impl TryFrom<&fb::Segment> for Segment {
     fn try_from(value: &fb::Segment) -> Result<Self, Self::Error> {
         Ok(Self {
             offset: value.offset(),
-            length: u32::try_from(value.length())
-                .map_err(|_| vortex_err!("segment length exceeds maximum u32"))?,
+            length: value.length(),
             alignment: Alignment::from_exponent(value.alignment_exponent()),
         })
     }

--- a/vortex-file/src/v2/footer/segment.rs
+++ b/vortex-file/src/v2/footer/segment.rs
@@ -1,46 +1,30 @@
-use flatbuffers::{FlatBufferBuilder, Follow, WIPOffset};
 use vortex_buffer::Alignment;
 use vortex_error::{vortex_err, VortexError};
-use vortex_flatbuffers::{footer2 as fb, ReadFlatBuffer, WriteFlatBuffer};
+use vortex_flatbuffers::footer2 as fb;
 
 /// The location of a segment within a Vortex file.
 #[derive(Clone, Debug)]
 pub(crate) struct Segment {
     pub(crate) offset: u64,
-    pub(crate) length: usize,
+    pub(crate) length: u32,
     pub(crate) alignment: Alignment,
 }
 
-impl WriteFlatBuffer for Segment {
-    type Target<'a> = fb::Segment<'a>;
-
-    fn write_flatbuffer<'fb>(
-        &self,
-        fbb: &mut FlatBufferBuilder<'fb>,
-    ) -> WIPOffset<Self::Target<'fb>> {
-        fb::Segment::create(
-            fbb,
-            &fb::SegmentArgs {
-                offset: self.offset,
-                length: self.length as u64,
-                alignment: self.alignment.into(),
-            },
-        )
+impl From<&Segment> for fb::Segment {
+    fn from(value: &Segment) -> Self {
+        fb::Segment::new(value.offset, value.length, value.alignment.exponent(), 0, 0)
     }
 }
 
-impl ReadFlatBuffer for Segment {
-    type Source<'a> = fb::Segment<'a>;
+impl TryFrom<&fb::Segment> for Segment {
     type Error = VortexError;
 
-    fn read_flatbuffer<'buf>(
-        fb: &<Self::Source<'buf> as Follow<'buf>>::Inner,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(value: &fb::Segment) -> Result<Self, Self::Error> {
         Ok(Self {
-            offset: fb.offset(),
-            length: usize::try_from(fb.length())
-                .map_err(|_| vortex_err!("segment length exceeds maximum usize"))?,
-            alignment: Alignment::from(fb.alignment()),
+            offset: value.offset(),
+            length: u32::try_from(value.length())
+                .map_err(|_| vortex_err!("segment length exceeds maximum u32"))?,
+            alignment: Alignment::from_exponent(value.alignment_exponent()),
         })
     }
 }

--- a/vortex-file/src/v2/open/mod.rs
+++ b/vortex-file/src/v2/open/mod.rs
@@ -228,7 +228,7 @@ impl OpenOptions {
             .ok_or_else(|| vortex_err!("FileLayout missing segments"))?;
         let segments = fb_segments
             .iter()
-            .map(|s| Segment::try_from(s))
+            .map(Segment::try_from)
             .try_collect()?;
 
         Ok(FileLayout {

--- a/vortex-file/src/v2/open/mod.rs
+++ b/vortex-file/src/v2/open/mod.rs
@@ -183,7 +183,7 @@ impl OpenOptions {
     ) -> VortexResult<DType> {
         let offset = usize::try_from(dtype.offset - initial_offset)?;
         let sliced_buffer =
-            FlatBuffer::align_from(initial_read.slice(offset..offset + dtype.length));
+            FlatBuffer::align_from(initial_read.slice(offset..offset + (dtype.length as usize)));
         let fbd_dtype = root::<fbd::DType>(&sliced_buffer)?;
 
         DType::try_from_view(fbd_dtype, sliced_buffer.clone())
@@ -198,7 +198,7 @@ impl OpenOptions {
         dtype: DType,
     ) -> VortexResult<FileLayout> {
         let offset = usize::try_from(segment.offset - initial_offset)?;
-        let bytes = initial_read.slice(offset..offset + segment.length);
+        let bytes = initial_read.slice(offset..offset + (segment.length as usize));
 
         let fb = root::<fb::FileLayout>(&bytes)?;
         let fb_root_layout = fb
@@ -228,7 +228,7 @@ impl OpenOptions {
             .ok_or_else(|| vortex_err!("FileLayout missing segments"))?;
         let segments = fb_segments
             .iter()
-            .map(|s| Segment::read_flatbuffer(&s))
+            .map(|s| Segment::try_from(s))
             .try_collect()?;
 
         Ok(FileLayout {
@@ -253,7 +253,7 @@ impl OpenOptions {
             let segment_id = SegmentId::from(u32::try_from(idx)?);
 
             let offset = usize::try_from(segment.offset - initial_offset)?;
-            let buffer = initial_read.slice(offset..offset + segment.length);
+            let buffer = initial_read.slice(offset..offset + (segment.length as usize));
 
             segments.set(segment_id, buffer)?;
         }

--- a/vortex-file/src/v2/open/mod.rs
+++ b/vortex-file/src/v2/open/mod.rs
@@ -226,10 +226,7 @@ impl OpenOptions {
         let fb_segments = fb
             .segments()
             .ok_or_else(|| vortex_err!("FileLayout missing segments"))?;
-        let segments = fb_segments
-            .iter()
-            .map(Segment::try_from)
-            .try_collect()?;
+        let segments = fb_segments.iter().map(Segment::try_from).try_collect()?;
 
         Ok(FileLayout {
             root_layout,

--- a/vortex-file/src/v2/open/mod.rs
+++ b/vortex-file/src/v2/open/mod.rs
@@ -253,9 +253,9 @@ impl OpenOptions {
             let segment_id = SegmentId::from(u32::try_from(idx)?);
 
             let offset = usize::try_from(segment.offset - initial_offset)?;
-            let bytes = initial_read.slice(offset..offset + segment.length);
+            let buffer = initial_read.slice(offset..offset + segment.length);
 
-            segments.set(segment_id, bytes.into_inner())?;
+            segments.set(segment_id, buffer)?;
         }
         Ok(())
     }

--- a/vortex-file/src/v2/segments/writer.rs
+++ b/vortex-file/src/v2/segments/writer.rs
@@ -1,4 +1,4 @@
-use bytes::Bytes;
+use vortex_buffer::ByteBuffer;
 use vortex_error::{vortex_err, VortexResult};
 use vortex_io::VortexWrite;
 use vortex_layout::segments::{SegmentId, SegmentWriter};
@@ -8,12 +8,12 @@ use crate::v2::footer::Segment;
 /// A segment writer that holds buffers in memory until they are flushed by a writer.
 #[derive(Default)]
 pub(crate) struct BufferedSegmentWriter {
-    segments: Vec<Vec<Bytes>>,
+    segments: Vec<ByteBuffer>,
     next_id: SegmentId,
 }
 
 impl SegmentWriter for BufferedSegmentWriter {
-    fn put(&mut self, data: Vec<Bytes>) -> SegmentId {
+    fn put(&mut self, data: ByteBuffer) -> SegmentId {
         self.segments.push(data);
         let id = self.next_id;
         self.next_id = SegmentId::from(*self.next_id + 1);
@@ -28,14 +28,16 @@ impl BufferedSegmentWriter {
         write: &mut futures_util::io::Cursor<W>,
         segments: &mut Vec<Segment>,
     ) -> VortexResult<()> {
-        for segment in self.segments.drain(..) {
+        for buffer in self.segments.drain(..) {
             let offset = write.position();
-            for buffer in segment {
-                write.write_all(buffer).await?;
-            }
-            let length = usize::try_from(write.position() - offset)
-                .map_err(|_| vortex_err!("segment length exceeds maximum usize"))?;
-            segments.push(Segment { offset, length });
+            let alignment = buffer.alignment();
+            write.write_all(buffer.into_inner()).await?;
+            segments.push(Segment {
+                offset,
+                length: usize::try_from(write.position() - offset)
+                    .map_err(|_| vortex_err!("segment length exceeds maximum usize"))?,
+                alignment,
+            });
         }
         Ok(())
     }

--- a/vortex-file/src/v2/segments/writer.rs
+++ b/vortex-file/src/v2/segments/writer.rs
@@ -34,8 +34,8 @@ impl BufferedSegmentWriter {
             write.write_all(buffer.into_inner()).await?;
             segments.push(Segment {
                 offset,
-                length: usize::try_from(write.position() - offset)
-                    .map_err(|_| vortex_err!("segment length exceeds maximum usize"))?,
+                length: u32::try_from(write.position() - offset)
+                    .map_err(|_| vortex_err!("segment length exceeds maximum u32"))?,
                 alignment,
             });
         }

--- a/vortex-file/src/v2/writer.rs
+++ b/vortex-file/src/v2/writer.rs
@@ -120,8 +120,8 @@ impl WriteOptions {
         write.write_all(flatbuffer.write_flatbuffer_bytes()).await?;
         Ok(Segment {
             offset: layout_offset,
-            length: usize::try_from(write.position() - layout_offset)
-                .map_err(|_| vortex_err!("segment length exceeds maximum usize"))?,
+            length: u32::try_from(write.position() - layout_offset)
+                .map_err(|_| vortex_err!("segment length exceeds maximum u32"))?,
             alignment: FlatBuffer::alignment(),
         })
     }

--- a/vortex-file/src/v2/writer.rs
+++ b/vortex-file/src/v2/writer.rs
@@ -4,7 +4,7 @@ use futures_util::StreamExt;
 use vortex_array::iter::ArrayIterator;
 use vortex_array::stream::ArrayStream;
 use vortex_error::{vortex_bail, vortex_err, VortexExpect, VortexResult};
-use vortex_flatbuffers::{FlatBufferRoot, WriteFlatBuffer, WriteFlatBufferExt};
+use vortex_flatbuffers::{FlatBuffer, FlatBufferRoot, WriteFlatBuffer, WriteFlatBufferExt};
 use vortex_io::VortexWrite;
 use vortex_layout::strategies::LayoutStrategy;
 
@@ -122,6 +122,7 @@ impl WriteOptions {
             offset: layout_offset,
             length: usize::try_from(write.position() - layout_offset)
                 .map_err(|_| vortex_err!("segment length exceeds maximum usize"))?,
+            alignment: FlatBuffer::alignment(),
         })
     }
 }

--- a/vortex-flatbuffers/flatbuffers/vortex-file/footer2.fbs
+++ b/vortex-flatbuffers/flatbuffers/vortex-file/footer2.fbs
@@ -1,13 +1,19 @@
 include "vortex-layout/layout.fbs";
 
 /// A `Segment` acts as the locator for a buffer within the file.
-/// TODO(ngates): I think this should actually be more of a German String style struct? I don't know how
-///  many tiny buffers we have though, worth looking into it.
-table Segment {
+// TODO(ngates): I think this should actually be more of a German String style struct? I don't know how
+//  many buffers we have that are <128 bits.
+struct Segment {
     offset: uint64;
-    length: uint64; // Make this 48 bits? With leading 16-bit alignment?
-    alignment: uint16;
-    // NOTE(ngates): add compression and encryption information
+    length: uint32;
+    alignment_exponent: uint8;
+    // These two fields are reserved for future use, I imagine they will be pointers
+    // into a compression scheme and encryption scheme tables that live in the FileLayout.
+    // This struct would have been padded to 128 bits anyway, so we're not losing anything.
+    // We could also restrict alignment exponent to e.g. 5 bits, and then use 3 bits to indicate a pointer into the
+    // compression scheme table.
+    _compression: uint8;
+    _encryption: uint16;
 }
 
 /// The `FileLayout` stores the root `Layout` as well as location information for each referenced segment.

--- a/vortex-flatbuffers/flatbuffers/vortex-file/footer2.fbs
+++ b/vortex-flatbuffers/flatbuffers/vortex-file/footer2.fbs
@@ -1,9 +1,12 @@
 include "vortex-layout/layout.fbs";
 
 /// A `Segment` acts as the locator for a buffer within the file.
+/// TODO(ngates): I think this should actually be more of a German String style struct? I don't know how
+///  many tiny buffers we have though, worth looking into it.
 table Segment {
     offset: uint64;
-    length: uint64;
+    length: uint64; // Make this 48 bits? With leading 16-bit alignment?
+    alignment: uint16;
     // NOTE(ngates): add compression and encryption information
 }
 

--- a/vortex-flatbuffers/src/generated/footer2.rs
+++ b/vortex-flatbuffers/src/generated/footer2.rs
@@ -14,6 +14,8 @@ pub enum SegmentOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 /// A `Segment` acts as the locator for a buffer within the file.
+/// TODO(ngates): I think this should actually be more of a German String style struct? I don't know how
+///  many tiny buffers we have though, worth looking into it.
 pub struct Segment<'a> {
   pub _tab: flatbuffers::Table<'a>,
 }
@@ -29,6 +31,7 @@ impl<'a> flatbuffers::Follow<'a> for Segment<'a> {
 impl<'a> Segment<'a> {
   pub const VT_OFFSET: flatbuffers::VOffsetT = 4;
   pub const VT_LENGTH: flatbuffers::VOffsetT = 6;
+  pub const VT_ALIGNMENT: flatbuffers::VOffsetT = 8;
 
   #[inline]
   pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -42,6 +45,7 @@ impl<'a> Segment<'a> {
     let mut builder = SegmentBuilder::new(_fbb);
     builder.add_length(args.length);
     builder.add_offset(args.offset);
+    builder.add_alignment(args.alignment);
     builder.finish()
   }
 
@@ -60,6 +64,13 @@ impl<'a> Segment<'a> {
     // which contains a valid value in this slot
     unsafe { self._tab.get::<u64>(Segment::VT_LENGTH, Some(0)).unwrap()}
   }
+  #[inline]
+  pub fn alignment(&self) -> u16 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u16>(Segment::VT_ALIGNMENT, Some(0)).unwrap()}
+  }
 }
 
 impl flatbuffers::Verifiable for Segment<'_> {
@@ -71,6 +82,7 @@ impl flatbuffers::Verifiable for Segment<'_> {
     v.visit_table(pos)?
      .visit_field::<u64>("offset", Self::VT_OFFSET, false)?
      .visit_field::<u64>("length", Self::VT_LENGTH, false)?
+     .visit_field::<u16>("alignment", Self::VT_ALIGNMENT, false)?
      .finish();
     Ok(())
   }
@@ -78,6 +90,7 @@ impl flatbuffers::Verifiable for Segment<'_> {
 pub struct SegmentArgs {
     pub offset: u64,
     pub length: u64,
+    pub alignment: u16,
 }
 impl<'a> Default for SegmentArgs {
   #[inline]
@@ -85,6 +98,7 @@ impl<'a> Default for SegmentArgs {
     SegmentArgs {
       offset: 0,
       length: 0,
+      alignment: 0,
     }
   }
 }
@@ -101,6 +115,10 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> SegmentBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_length(&mut self, length: u64) {
     self.fbb_.push_slot::<u64>(Segment::VT_LENGTH, length, 0);
+  }
+  #[inline]
+  pub fn add_alignment(&mut self, alignment: u16) {
+    self.fbb_.push_slot::<u16>(Segment::VT_ALIGNMENT, alignment, 0);
   }
   #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> SegmentBuilder<'a, 'b, A> {
@@ -122,6 +140,7 @@ impl core::fmt::Debug for Segment<'_> {
     let mut ds = f.debug_struct("Segment");
       ds.field("offset", &self.offset());
       ds.field("length", &self.length());
+      ds.field("alignment", &self.alignment());
       ds.finish()
   }
 }

--- a/vortex-flatbuffers/src/generated/footer2.rs
+++ b/vortex-flatbuffers/src/generated/footer2.rs
@@ -10,140 +10,231 @@ use core::cmp::Ordering;
 extern crate flatbuffers;
 use self::flatbuffers::{EndianScalar, Follow};
 
-pub enum SegmentOffset {}
-#[derive(Copy, Clone, PartialEq)]
-
 /// A `Segment` acts as the locator for a buffer within the file.
-/// TODO(ngates): I think this should actually be more of a German String style struct? I don't know how
-///  many tiny buffers we have though, worth looking into it.
-pub struct Segment<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+// struct Segment, aligned to 8
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq)]
+pub struct Segment(pub [u8; 16]);
+impl Default for Segment { 
+  fn default() -> Self { 
+    Self([0; 16])
+  }
+}
+impl core::fmt::Debug for Segment {
+  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    f.debug_struct("Segment")
+      .field("offset", &self.offset())
+      .field("length", &self.length())
+      .field("alignment_exponent", &self.alignment_exponent())
+      .field("_compression", &self._compression())
+      .field("_encryption", &self._encryption())
+      .finish()
+  }
 }
 
-impl<'a> flatbuffers::Follow<'a> for Segment<'a> {
-  type Inner = Segment<'a>;
+impl flatbuffers::SimpleToVerifyInSlice for Segment {}
+impl<'a> flatbuffers::Follow<'a> for Segment {
+  type Inner = &'a Segment;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    <&'a Segment>::follow(buf, loc)
   }
 }
-
-impl<'a> Segment<'a> {
-  pub const VT_OFFSET: flatbuffers::VOffsetT = 4;
-  pub const VT_LENGTH: flatbuffers::VOffsetT = 6;
-  pub const VT_ALIGNMENT: flatbuffers::VOffsetT = 8;
-
+impl<'a> flatbuffers::Follow<'a> for &'a Segment {
+  type Inner = &'a Segment;
   #[inline]
-  pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    Segment { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
-    args: &'args SegmentArgs
-  ) -> flatbuffers::WIPOffset<Segment<'bldr>> {
-    let mut builder = SegmentBuilder::new(_fbb);
-    builder.add_length(args.length);
-    builder.add_offset(args.offset);
-    builder.add_alignment(args.alignment);
-    builder.finish()
-  }
-
-
-  #[inline]
-  pub fn offset(&self) -> u64 {
-    // Safety:
-    // Created from valid Table for this object
-    // which contains a valid value in this slot
-    unsafe { self._tab.get::<u64>(Segment::VT_OFFSET, Some(0)).unwrap()}
-  }
-  #[inline]
-  pub fn length(&self) -> u64 {
-    // Safety:
-    // Created from valid Table for this object
-    // which contains a valid value in this slot
-    unsafe { self._tab.get::<u64>(Segment::VT_LENGTH, Some(0)).unwrap()}
-  }
-  #[inline]
-  pub fn alignment(&self) -> u16 {
-    // Safety:
-    // Created from valid Table for this object
-    // which contains a valid value in this slot
-    unsafe { self._tab.get::<u16>(Segment::VT_ALIGNMENT, Some(0)).unwrap()}
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    flatbuffers::follow_cast_ref::<Segment>(buf, loc)
   }
 }
+impl<'b> flatbuffers::Push for Segment {
+    type Output = Segment;
+    #[inline]
+    unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
+        let src = ::core::slice::from_raw_parts(self as *const Segment as *const u8, <Self as flatbuffers::Push>::size());
+        dst.copy_from_slice(src);
+    }
+    #[inline]
+    fn alignment() -> flatbuffers::PushAlignment {
+        flatbuffers::PushAlignment::new(8)
+    }
+}
 
-impl flatbuffers::Verifiable for Segment<'_> {
+impl<'a> flatbuffers::Verifiable for Segment {
   #[inline]
   fn run_verifier(
     v: &mut flatbuffers::Verifier, pos: usize
   ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
     use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<u64>("offset", Self::VT_OFFSET, false)?
-     .visit_field::<u64>("length", Self::VT_LENGTH, false)?
-     .visit_field::<u16>("alignment", Self::VT_ALIGNMENT, false)?
-     .finish();
-    Ok(())
-  }
-}
-pub struct SegmentArgs {
-    pub offset: u64,
-    pub length: u64,
-    pub alignment: u16,
-}
-impl<'a> Default for SegmentArgs {
-  #[inline]
-  fn default() -> Self {
-    SegmentArgs {
-      offset: 0,
-      length: 0,
-      alignment: 0,
-    }
+    v.in_buffer::<Self>(pos)
   }
 }
 
-pub struct SegmentBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
-}
-impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> SegmentBuilder<'a, 'b, A> {
-  #[inline]
-  pub fn add_offset(&mut self, offset: u64) {
-    self.fbb_.push_slot::<u64>(Segment::VT_OFFSET, offset, 0);
+impl<'a> Segment {
+  #[allow(clippy::too_many_arguments)]
+  pub fn new(
+    offset: u64,
+    length: u32,
+    alignment_exponent: u8,
+    _compression: u8,
+    _encryption: u16,
+  ) -> Self {
+    let mut s = Self([0; 16]);
+    s.set_offset(offset);
+    s.set_length(length);
+    s.set_alignment_exponent(alignment_exponent);
+    s.set__compression(_compression);
+    s.set__encryption(_encryption);
+    s
   }
-  #[inline]
-  pub fn add_length(&mut self, length: u64) {
-    self.fbb_.push_slot::<u64>(Segment::VT_LENGTH, length, 0);
+
+  pub fn offset(&self) -> u64 {
+    let mut mem = core::mem::MaybeUninit::<<u64 as EndianScalar>::Scalar>::uninit();
+    // Safety:
+    // Created from a valid Table for this object
+    // Which contains a valid value in this slot
+    EndianScalar::from_little_endian(unsafe {
+      core::ptr::copy_nonoverlapping(
+        self.0[0..].as_ptr(),
+        mem.as_mut_ptr() as *mut u8,
+        core::mem::size_of::<<u64 as EndianScalar>::Scalar>(),
+      );
+      mem.assume_init()
+    })
   }
-  #[inline]
-  pub fn add_alignment(&mut self, alignment: u16) {
-    self.fbb_.push_slot::<u16>(Segment::VT_ALIGNMENT, alignment, 0);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> SegmentBuilder<'a, 'b, A> {
-    let start = _fbb.start_table();
-    SegmentBuilder {
-      fbb_: _fbb,
-      start_: start,
+
+  pub fn set_offset(&mut self, x: u64) {
+    let x_le = x.to_little_endian();
+    // Safety:
+    // Created from a valid Table for this object
+    // Which contains a valid value in this slot
+    unsafe {
+      core::ptr::copy_nonoverlapping(
+        &x_le as *const _ as *const u8,
+        self.0[0..].as_mut_ptr(),
+        core::mem::size_of::<<u64 as EndianScalar>::Scalar>(),
+      );
     }
   }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<Segment<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
+
+  pub fn length(&self) -> u32 {
+    let mut mem = core::mem::MaybeUninit::<<u32 as EndianScalar>::Scalar>::uninit();
+    // Safety:
+    // Created from a valid Table for this object
+    // Which contains a valid value in this slot
+    EndianScalar::from_little_endian(unsafe {
+      core::ptr::copy_nonoverlapping(
+        self.0[8..].as_ptr(),
+        mem.as_mut_ptr() as *mut u8,
+        core::mem::size_of::<<u32 as EndianScalar>::Scalar>(),
+      );
+      mem.assume_init()
+    })
   }
+
+  pub fn set_length(&mut self, x: u32) {
+    let x_le = x.to_little_endian();
+    // Safety:
+    // Created from a valid Table for this object
+    // Which contains a valid value in this slot
+    unsafe {
+      core::ptr::copy_nonoverlapping(
+        &x_le as *const _ as *const u8,
+        self.0[8..].as_mut_ptr(),
+        core::mem::size_of::<<u32 as EndianScalar>::Scalar>(),
+      );
+    }
+  }
+
+  pub fn alignment_exponent(&self) -> u8 {
+    let mut mem = core::mem::MaybeUninit::<<u8 as EndianScalar>::Scalar>::uninit();
+    // Safety:
+    // Created from a valid Table for this object
+    // Which contains a valid value in this slot
+    EndianScalar::from_little_endian(unsafe {
+      core::ptr::copy_nonoverlapping(
+        self.0[12..].as_ptr(),
+        mem.as_mut_ptr() as *mut u8,
+        core::mem::size_of::<<u8 as EndianScalar>::Scalar>(),
+      );
+      mem.assume_init()
+    })
+  }
+
+  pub fn set_alignment_exponent(&mut self, x: u8) {
+    let x_le = x.to_little_endian();
+    // Safety:
+    // Created from a valid Table for this object
+    // Which contains a valid value in this slot
+    unsafe {
+      core::ptr::copy_nonoverlapping(
+        &x_le as *const _ as *const u8,
+        self.0[12..].as_mut_ptr(),
+        core::mem::size_of::<<u8 as EndianScalar>::Scalar>(),
+      );
+    }
+  }
+
+  pub fn _compression(&self) -> u8 {
+    let mut mem = core::mem::MaybeUninit::<<u8 as EndianScalar>::Scalar>::uninit();
+    // Safety:
+    // Created from a valid Table for this object
+    // Which contains a valid value in this slot
+    EndianScalar::from_little_endian(unsafe {
+      core::ptr::copy_nonoverlapping(
+        self.0[13..].as_ptr(),
+        mem.as_mut_ptr() as *mut u8,
+        core::mem::size_of::<<u8 as EndianScalar>::Scalar>(),
+      );
+      mem.assume_init()
+    })
+  }
+
+  pub fn set__compression(&mut self, x: u8) {
+    let x_le = x.to_little_endian();
+    // Safety:
+    // Created from a valid Table for this object
+    // Which contains a valid value in this slot
+    unsafe {
+      core::ptr::copy_nonoverlapping(
+        &x_le as *const _ as *const u8,
+        self.0[13..].as_mut_ptr(),
+        core::mem::size_of::<<u8 as EndianScalar>::Scalar>(),
+      );
+    }
+  }
+
+  pub fn _encryption(&self) -> u16 {
+    let mut mem = core::mem::MaybeUninit::<<u16 as EndianScalar>::Scalar>::uninit();
+    // Safety:
+    // Created from a valid Table for this object
+    // Which contains a valid value in this slot
+    EndianScalar::from_little_endian(unsafe {
+      core::ptr::copy_nonoverlapping(
+        self.0[14..].as_ptr(),
+        mem.as_mut_ptr() as *mut u8,
+        core::mem::size_of::<<u16 as EndianScalar>::Scalar>(),
+      );
+      mem.assume_init()
+    })
+  }
+
+  pub fn set__encryption(&mut self, x: u16) {
+    let x_le = x.to_little_endian();
+    // Safety:
+    // Created from a valid Table for this object
+    // Which contains a valid value in this slot
+    unsafe {
+      core::ptr::copy_nonoverlapping(
+        &x_le as *const _ as *const u8,
+        self.0[14..].as_mut_ptr(),
+        core::mem::size_of::<<u16 as EndianScalar>::Scalar>(),
+      );
+    }
+  }
+
 }
 
-impl core::fmt::Debug for Segment<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("Segment");
-      ds.field("offset", &self.offset());
-      ds.field("length", &self.length());
-      ds.field("alignment", &self.alignment());
-      ds.finish()
-  }
-}
 pub enum FileLayoutOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -188,11 +279,11 @@ impl<'a> FileLayout<'a> {
     unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<Layout>>(FileLayout::VT_ROOT_LAYOUT, None)}
   }
   #[inline]
-  pub fn segments(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Segment<'a>>>> {
+  pub fn segments(&self) -> Option<flatbuffers::Vector<'a, Segment>> {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Segment>>>>(FileLayout::VT_SEGMENTS, None)}
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, Segment>>>(FileLayout::VT_SEGMENTS, None)}
   }
 }
 
@@ -204,14 +295,14 @@ impl flatbuffers::Verifiable for FileLayout<'_> {
     use self::flatbuffers::Verifiable;
     v.visit_table(pos)?
      .visit_field::<flatbuffers::ForwardsUOffset<Layout>>("root_layout", Self::VT_ROOT_LAYOUT, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Segment>>>>("segments", Self::VT_SEGMENTS, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, Segment>>>("segments", Self::VT_SEGMENTS, false)?
      .finish();
     Ok(())
   }
 }
 pub struct FileLayoutArgs<'a> {
     pub root_layout: Option<flatbuffers::WIPOffset<Layout<'a>>>,
-    pub segments: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Segment<'a>>>>>,
+    pub segments: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, Segment>>>,
 }
 impl<'a> Default for FileLayoutArgs<'a> {
   #[inline]
@@ -233,7 +324,7 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> FileLayoutBuilder<'a, 'b, A> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Layout>>(FileLayout::VT_ROOT_LAYOUT, root_layout);
   }
   #[inline]
-  pub fn add_segments(&mut self, segments: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Segment<'b >>>>) {
+  pub fn add_segments(&mut self, segments: flatbuffers::WIPOffset<flatbuffers::Vector<'b , Segment>>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(FileLayout::VT_SEGMENTS, segments);
   }
   #[inline]
@@ -307,18 +398,18 @@ impl<'a> Postscript<'a> {
 
 
   #[inline]
-  pub fn dtype(&self) -> Option<Segment<'a>> {
+  pub fn dtype(&self) -> Option<&'a Segment> {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<Segment>>(Postscript::VT_DTYPE, None)}
+    unsafe { self._tab.get::<Segment>(Postscript::VT_DTYPE, None)}
   }
   #[inline]
-  pub fn file_layout(&self) -> Option<Segment<'a>> {
+  pub fn file_layout(&self) -> Option<&'a Segment> {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<Segment>>(Postscript::VT_FILE_LAYOUT, None)}
+    unsafe { self._tab.get::<Segment>(Postscript::VT_FILE_LAYOUT, None)}
   }
 }
 
@@ -329,15 +420,15 @@ impl flatbuffers::Verifiable for Postscript<'_> {
   ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
     use self::flatbuffers::Verifiable;
     v.visit_table(pos)?
-     .visit_field::<flatbuffers::ForwardsUOffset<Segment>>("dtype", Self::VT_DTYPE, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<Segment>>("file_layout", Self::VT_FILE_LAYOUT, false)?
+     .visit_field::<Segment>("dtype", Self::VT_DTYPE, false)?
+     .visit_field::<Segment>("file_layout", Self::VT_FILE_LAYOUT, false)?
      .finish();
     Ok(())
   }
 }
 pub struct PostscriptArgs<'a> {
-    pub dtype: Option<flatbuffers::WIPOffset<Segment<'a>>>,
-    pub file_layout: Option<flatbuffers::WIPOffset<Segment<'a>>>,
+    pub dtype: Option<&'a Segment>,
+    pub file_layout: Option<&'a Segment>,
 }
 impl<'a> Default for PostscriptArgs<'a> {
   #[inline]
@@ -355,12 +446,12 @@ pub struct PostscriptBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
 }
 impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> PostscriptBuilder<'a, 'b, A> {
   #[inline]
-  pub fn add_dtype(&mut self, dtype: flatbuffers::WIPOffset<Segment<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Segment>>(Postscript::VT_DTYPE, dtype);
+  pub fn add_dtype(&mut self, dtype: &Segment) {
+    self.fbb_.push_slot_always::<&Segment>(Postscript::VT_DTYPE, dtype);
   }
   #[inline]
-  pub fn add_file_layout(&mut self, file_layout: flatbuffers::WIPOffset<Segment<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Segment>>(Postscript::VT_FILE_LAYOUT, file_layout);
+  pub fn add_file_layout(&mut self, file_layout: &Segment) {
+    self.fbb_.push_slot_always::<&Segment>(Postscript::VT_FILE_LAYOUT, file_layout);
   }
   #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> PostscriptBuilder<'a, 'b, A> {

--- a/vortex-layout/src/data.rs
+++ b/vortex-layout/src/data.rs
@@ -217,6 +217,17 @@ impl LayoutData {
         }
     }
 
+    /// Returns the number of segments in the layout.
+    pub fn nsegments(&self) -> usize {
+        match &self.0 {
+            Inner::Owned(owned) => owned.segments.as_ref().map_or(0, |segments| segments.len()),
+            Inner::Viewed(viewed) => viewed
+                .flatbuffer()
+                .segments()
+                .map_or(0, |segments| segments.len()),
+        }
+    }
+
     /// Fetch the i'th segment id of the layout.
     pub fn segment_id(&self, i: usize) -> Option<SegmentId> {
         match &self.0 {

--- a/vortex-layout/src/data.rs
+++ b/vortex-layout/src/data.rs
@@ -243,6 +243,11 @@ impl LayoutData {
         }
     }
 
+    /// Iterate the segment IDs of the layout.
+    pub fn segments(&self) -> impl Iterator<Item = SegmentId> + '_ {
+        (0..self.nsegments()).map(move |i| self.segment_id(i).vortex_expect("segment bounds"))
+    }
+
     /// Returns the layout metadata
     pub fn metadata(&self) -> Option<Bytes> {
         match &self.0 {

--- a/vortex-layout/src/layouts/flat/evaluator.rs
+++ b/vortex-layout/src/layouts/flat/evaluator.rs
@@ -28,8 +28,7 @@ impl AsyncEvaluator for FlatReader {
         let flatbuffer = FlatBuffer::try_from(
             buffers
                 .pop()
-                .ok_or_else(|| vortex_err!("Flat message missing"))?
-                ,
+                .ok_or_else(|| vortex_err!("Flat message missing"))?,
         )?;
 
         let row_count = usize::try_from(self.layout().row_count())

--- a/vortex-layout/src/layouts/flat/evaluator.rs
+++ b/vortex-layout/src/layouts/flat/evaluator.rs
@@ -1,33 +1,55 @@
 use async_trait::async_trait;
+use flatbuffers::root;
+use futures::future::try_join_all;
 use vortex_array::compute::filter;
+use vortex_array::parts::ArrayParts;
 use vortex_array::ArrayData;
-use vortex_error::{vortex_bail, vortex_err, VortexResult};
+use vortex_error::{vortex_err, VortexExpect, VortexResult};
 use vortex_expr::ExprRef;
-use vortex_ipc::messages::{BufMessageReader, DecoderMessage};
+use vortex_flatbuffers::{array as fba, FlatBuffer};
 use vortex_scan::{AsyncEvaluator, RowMask};
 
 use crate::layouts::flat::reader::FlatReader;
 use crate::reader::LayoutScanExt;
+use crate::LayoutReader;
 
 #[async_trait(?Send)]
 impl AsyncEvaluator for FlatReader {
     async fn evaluate(self: &Self, row_mask: RowMask, expr: ExprRef) -> VortexResult<ArrayData> {
-        // Grab the byte buffer for the segment.
-        let bytes = self.segments().get(self.segment_id()).await?;
+        // Fetch all the array buffers.
+        let buffers = try_join_all(
+            (0..self.layout().nsegments())
+                .map(|idx| {
+                    self.layout()
+                        .segment_id(idx)
+                        .vortex_expect("bounds checked")
+                })
+                .map(|segment_id| self.segments().get(segment_id)),
+        )
+        .await?;
 
-        // Decode the ArrayParts from the message bytes.
-        // TODO(ngates): ArrayParts should probably live in vortex-array, and not required
-        //  IPC message framing to read or write.
-        let mut msg_reader = BufMessageReader::new(bytes);
-        let array = if let DecoderMessage::Array(parts) = msg_reader
-            .next()
-            .ok_or_else(|| vortex_err!("Flat message body missing"))??
-        {
-            parts.decode(self.ctx(), self.dtype().clone())
-        } else {
-            vortex_bail!("Flat message is not ArrayParts")
-        }?;
+        // Fetch the array flatbuffer.
+        let flatbuffer = FlatBuffer::try_from(
+            buffers
+                .last()
+                .ok_or_else(|| vortex_err!("Flat message missing"))?
+                .clone(),
+        )?;
 
+        let row_count = usize::try_from(self.layout().row_count())
+            .vortex_expect("FlatLayout row count does not fit within usize");
+
+        let array_parts = ArrayParts::new(
+            row_count,
+            root::<fba::Array>(flatbuffer.as_ref()).vortex_expect("Invalid fba::Array flatbuffer"),
+            flatbuffer.clone(),
+            buffers.iter().take(buffers.len() - 1).cloned().collect(),
+        );
+
+        // Decode into an ArrayData.
+        let array = array_parts.decode(self.ctx().clone(), self.dtype().clone())?;
+
+        // And finally apply the expression
         // TODO(ngates): what's the best order to apply the filter mask / expression?
         let array = expr.evaluate(&array)?;
         filter(&array, row_mask.into_filter_mask()?)

--- a/vortex-layout/src/layouts/flat/evaluator.rs
+++ b/vortex-layout/src/layouts/flat/evaluator.rs
@@ -17,21 +17,17 @@ use crate::LayoutReader;
 impl AsyncEvaluator for FlatReader {
     async fn evaluate(self: &Self, row_mask: RowMask, expr: ExprRef) -> VortexResult<ArrayData> {
         // Fetch all the array buffers.
-        let buffers = try_join_all(
-            (0..self.layout().nsegments())
-                .map(|idx| {
-                    self.layout()
-                        .segment_id(idx)
-                        .vortex_expect("bounds checked")
-                })
+        let mut buffers = try_join_all(
+            self.layout()
+                .segments()
                 .map(|segment_id| self.segments().get(segment_id)),
         )
         .await?;
 
-        // Fetch the array flatbuffer.
+        // Pop the array flatbuffer.
         let flatbuffer = FlatBuffer::try_from(
             buffers
-                .last()
+                .pop()
                 .ok_or_else(|| vortex_err!("Flat message missing"))?
                 .clone(),
         )?;
@@ -43,7 +39,7 @@ impl AsyncEvaluator for FlatReader {
             row_count,
             root::<fba::Array>(flatbuffer.as_ref()).vortex_expect("Invalid fba::Array flatbuffer"),
             flatbuffer.clone(),
-            buffers.iter().take(buffers.len() - 1).cloned().collect(),
+            buffers,
         );
 
         // Decode into an ArrayData.

--- a/vortex-layout/src/layouts/flat/evaluator.rs
+++ b/vortex-layout/src/layouts/flat/evaluator.rs
@@ -29,7 +29,7 @@ impl AsyncEvaluator for FlatReader {
             buffers
                 .pop()
                 .ok_or_else(|| vortex_err!("Flat message missing"))?
-                .clone(),
+                ,
         )?;
 
         let row_count = usize::try_from(self.layout().row_count())

--- a/vortex-layout/src/layouts/flat/evaluator.rs
+++ b/vortex-layout/src/layouts/flat/evaluator.rs
@@ -47,7 +47,7 @@ impl AsyncEvaluator for FlatReader {
         );
 
         // Decode into an ArrayData.
-        let array = array_parts.decode(self.ctx().clone(), self.dtype().clone())?;
+        let array = array_parts.decode(self.ctx(), self.dtype().clone())?;
 
         // And finally apply the expression
         // TODO(ngates): what's the best order to apply the filter mask / expression?

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -1,23 +1,18 @@
 use std::sync::Arc;
 
 use vortex_array::ContextRef;
-use vortex_error::{vortex_err, vortex_panic, VortexResult};
+use vortex_error::{vortex_panic, VortexResult};
 use vortex_scan::AsyncEvaluator;
 
 use crate::layouts::flat::FlatLayout;
 use crate::reader::LayoutReader;
-use crate::segments::{AsyncSegmentReader, SegmentId};
+use crate::segments::AsyncSegmentReader;
 use crate::{LayoutData, LayoutEncoding};
 
 pub struct FlatReader {
     layout: LayoutData,
     ctx: ContextRef,
     segments: Arc<dyn AsyncSegmentReader>,
-    // The segment ID of the array in this FlatLayout.
-    // NOTE(ngates): we don't cache the ArrayData here since the cache lives for as long as the
-    //  reader does, which means likely holding a strong reference to the array for much longer
-    //  than necessary, and potentially causing a memory leak.
-    segment_id: SegmentId,
 }
 
 impl FlatReader {
@@ -30,15 +25,10 @@ impl FlatReader {
             vortex_panic!("Mismatched layout ID")
         }
 
-        let segment_id = layout
-            .segment_id(0)
-            .ok_or_else(|| vortex_err!("FlatLayout missing SegmentID"))?;
-
         Ok(Self {
             layout,
             ctx,
             segments,
-            segment_id,
         })
     }
 
@@ -48,10 +38,6 @@ impl FlatReader {
 
     pub(crate) fn segments(&self) -> &dyn AsyncSegmentReader {
         self.segments.as_ref()
-    }
-
-    pub(crate) fn segment_id(&self) -> SegmentId {
-        self.segment_id
     }
 }
 

--- a/vortex-layout/src/layouts/flat/writer.rs
+++ b/vortex-layout/src/layouts/flat/writer.rs
@@ -1,6 +1,8 @@
+use vortex_array::parts::ArrayPartsFlatBuffer;
 use vortex_array::ArrayData;
 use vortex_dtype::DType;
 use vortex_error::{vortex_bail, vortex_err, VortexResult};
+use vortex_flatbuffers::WriteFlatBufferExt;
 
 use crate::layouts::flat::FlatLayout;
 use crate::segments::SegmentWriter;
@@ -32,12 +34,24 @@ impl LayoutWriter for FlatLayoutWriter {
             vortex_bail!("FlatLayoutStrategy::push_batch called after finish");
         }
         let row_count = chunk.len() as u64;
-        let segment_id = segments.put_chunk(chunk);
+
+        // We store each Array buffer in its own segment.
+        let mut segment_ids = vec![];
+        for child in chunk.depth_first_traversal() {
+            for buffer in child.byte_buffers() {
+                segment_ids.push(segments.put(buffer));
+            }
+        }
+
+        // ...followed by a FlatBuffer describing the array layout.
+        let flatbuffer = ArrayPartsFlatBuffer::new(&chunk).write_flatbuffer_bytes();
+        segment_ids.push(segments.put(flatbuffer.into_inner()));
+
         self.layout = Some(LayoutData::new_owned(
             &FlatLayout,
             self.dtype.clone(),
             row_count,
-            Some(vec![segment_id]),
+            Some(segment_ids),
             None,
             None,
         ));

--- a/vortex-layout/src/layouts/flat/writer.rs
+++ b/vortex-layout/src/layouts/flat/writer.rs
@@ -39,6 +39,9 @@ impl LayoutWriter for FlatLayoutWriter {
         let mut segment_ids = vec![];
         for child in chunk.depth_first_traversal() {
             for buffer in child.byte_buffers() {
+                // TODO(ngates): decide a way of splitting buffers if they exceed u32 size.
+                //  We could write empty segments either side of buffers to concatenate?
+                //  Or we could use Layout::metadata to store this information.
                 segment_ids.push(segments.put(buffer));
             }
         }

--- a/vortex-layout/src/lib.rs
+++ b/vortex-layout/src/lib.rs
@@ -1,7 +1,5 @@
 #![feature(once_cell_try)]
 #![feature(trait_alias)]
-extern crate core;
-
 mod data;
 pub use data::*;
 mod context;

--- a/vortex-layout/src/lib.rs
+++ b/vortex-layout/src/lib.rs
@@ -1,5 +1,7 @@
 #![feature(once_cell_try)]
 #![feature(trait_alias)]
+extern crate core;
+
 mod data;
 pub use data::*;
 mod context;


### PR DESCRIPTION
Instead of storing these in the segment map, we could store these in the Array flatbuffer, and then can pass them into `SegmentReader::get(id, alignment)`. 

The problem with this is that it would require two round trips to load a FlatLayout. One to fetch the array flatbuffer, then we know the alignment of the data buffers, and then a second RT to fetch the data buffers. Unless of course we store data buffer alignment in the FlatLayout metadata? That could work actually...

FLUP: move ArrayData flatbuffer into the IPC definition as an ArrayMessage. Move row_count out of ArrayParts.

Open Questions:
* Who should control / configure compression + encryption? I don't think this should be handled inside the segment writer, since it doesn't know what type of segment it is (data, flatbuffer, etc.). Instead, if the layouts themselves request encryption / compression, then we can configure different properties for different layouts. e.g. different encryption key for each column.