### PR TITLE
feat: vortex-tui

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,3 +7,4 @@ rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
 
 [alias]
 xtask = "run -p xtask --"
+vx = "run -p vortex-cli --"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
           - name: "wasm32 with default features"
             command: "build"
             target: wasm32-unknown-unknown
-            args: "--target wasm32-unknown-unknown --exclude vortex-datafusion"
+            args: "--target wasm32-unknown-unknown --exclude vortex-roaring --exclude vortex-datafusion --exclude vortex-cli"
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cleanup

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytecheck"
@@ -648,10 +648,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -794,7 +809,21 @@ checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
 dependencies = [
  "strum",
  "strum_macros",
- "unicode-width",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1030,7 +1059,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -1177,6 +1206,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.8.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1265,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2192,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
 
 [[package]]
 name = "humansize"
@@ -2213,9 +2302,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2426,6 +2515,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,7 +2560,7 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "web-time",
 ]
 
@@ -2474,6 +2569,19 @@ name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
+name = "instability"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
 
 [[package]]
 name = "integer-encoding"
@@ -2674,9 +2782,9 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9569d2f74e257076d8c6bfa73fb505b46b851e51ddaecc825944aa3bed17fa"
+checksum = "cf78f52d400cf2d84a3a973a78a592b4adc535739e0a5597a0da6f0c357adc75"
 dependencies = [
  "arbitrary",
  "cc",
@@ -2748,6 +2856,15 @@ dependencies = [
  "scoped-tls",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -2830,6 +2947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -3209,7 +3327,7 @@ checksum = "d2b0f8def1f117e13c895f3eda65a7b5650688da29d6ad04635f61bc7b92eebd"
 dependencies = [
  "bytecount",
  "fnv",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -3800,6 +3918,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.8.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4100,9 +4239,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 dependencies = [
  "web-time",
 ]
@@ -4126,9 +4265,9 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "same-file"
@@ -4252,9 +4391,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -4297,6 +4436,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -4465,6 +4625,9 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"
@@ -4838,7 +5001,7 @@ checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow 0.6.24",
+ "winnow 0.6.25",
 ]
 
 [[package]]
@@ -4953,15 +5116,32 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -5155,6 +5335,19 @@ dependencies = [
  "vortex-error",
  "vortex-mask",
  "vortex-scalar",
+]
+
+[[package]]
+name = "vortex-cli"
+version = "0.22.1"
+dependencies = [
+ "bytes",
+ "clap",
+ "crossterm",
+ "ratatui",
+ "tokio",
+ "vortex",
+ "vortex-layout",
 ]
 
 [[package]]
@@ -5987,9 +6180,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2782,9 +2782,9 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.9"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf78f52d400cf2d84a3a973a78a592b4adc535739e0a5597a0da6f0c357adc75"
+checksum = "9b9569d2f74e257076d8c6bfa73fb505b46b851e51ddaecc825944aa3bed17fa"
 dependencies = [
  "arbitrary",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,10 +68,11 @@ bytes = "1.6.0"
 bzip2 = "0.5.0"
 cfg-if = "1"
 chrono = "0.4.38"
-clap = "4.5.13"
+clap = "4"
 compio = "0.13"
 criterion = { version = "0.5.1", features = ["html_reports"] }
 croaring = "2.1.0"
+crossterm = "0.28"
 datafusion = { version = "44.0.0", default-features = false }
 datafusion-common = "44"
 datafusion-execution = "44"
@@ -119,11 +120,17 @@ pyo3-log = ">= 0.11"
 rancor = "0.1.0"
 rand = "0.8.5"
 rand_distr = "0.4"
+ratatui = "0.29"
 rayon = "1.10.0"
 regex = "1.11.0"
 reqwest = { version = "0.12.0", features = ["blocking"] }
 # TODO(ngates): remove the unaligned rkyv feature when we move to 8-byte metadata.
-rkyv = { version = "0.8", features = ["little_endian", "pointer_width_32", "bytecheck", "unaligned"] }
+rkyv = { version = "0.8", features = [
+    "little_endian",
+    "pointer_width_32",
+    "bytecheck",
+    "unaligned",
+] }
 rstest = "0.24"
 serde = "1.0.197"
 serde_json = "1.0.116"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "vortex",
     "vortex-array",
     "vortex-buffer",
+    "vortex-cli",
     "vortex-datafusion",
     "vortex-datetime-dtype",
     "vortex-dtype",

--- a/vortex-array/src/parts.rs
+++ b/vortex-array/src/parts.rs
@@ -21,8 +21,8 @@ pub struct ArrayParts {
     // TODO(ngates): I think we should remove this. It's not required in the serialized form.
     row_count: usize,
     // Typed as fb::Array
-    flatbuffer: FlatBuffer,
-    flatbuffer_loc: usize,
+    pub flatbuffer: FlatBuffer,
+    pub flatbuffer_loc: usize,
     buffers: Vec<ByteBuffer>,
 }
 

--- a/vortex-array/src/parts.rs
+++ b/vortex-array/src/parts.rs
@@ -21,8 +21,8 @@ pub struct ArrayParts {
     // TODO(ngates): I think we should remove this. It's not required in the serialized form.
     row_count: usize,
     // Typed as fb::Array
-    pub flatbuffer: FlatBuffer,
-    pub flatbuffer_loc: usize,
+    flatbuffer: FlatBuffer,
+    flatbuffer_loc: usize,
     buffers: Vec<ByteBuffer>,
 }
 

--- a/vortex-cli/Cargo.toml
+++ b/vortex-cli/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "vortex-cli"
+description = "a small but might tool for working with Vortex files"
+version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
+license.workspace = true
+keywords.workspace = true
+include.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+readme.workspace = true
+categories.workspace = true
+
+[dependencies]
+bytes = { workspace = true }
+clap = { version = "4", features = ["derive"] }
+crossterm = "0.28"
+ratatui = "0.29"
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+vortex = { workspace = true, features = ["tokio"] }
+vortex-layout = { workspace = true }
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "vx"
+path = "src/main.rs"

--- a/vortex-cli/Cargo.toml
+++ b/vortex-cli/Cargo.toml
@@ -15,9 +15,9 @@ categories.workspace = true
 
 [dependencies]
 bytes = { workspace = true }
-clap = { version = "4", features = ["derive"] }
-crossterm = "0.28"
-ratatui = "0.29"
+clap = { workspace = true, features = ["derive"] }
+crossterm = { workspace = true }
+ratatui = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 vortex = { workspace = true, features = ["tokio"] }
 vortex-layout = { workspace = true }

--- a/vortex-cli/README.md
+++ b/vortex-cli/README.md
@@ -1,0 +1,58 @@
+# `vx` Vortex CLI
+
+A small, helpful CLI tool for exploring and analyzing Vortex files.
+
+* `browse`: Browse the structure of your Vortex file with a rich TUI
+* `tree`: print the file contents as JSON
+
+
+## Examples
+
+Using the `tree` subcommand to print the encoding tree for a file:
+
+```
+$ vx tree ./bench-vortex/data/tpch/1/vortex_compressed/nation.vortex
+
+root: vortex.struct(0x04)({n_nationkey=i64, n_name=utf8, n_regionkey=i64, n_comment=utf8?}, len=25) nbytes=3.04 kB (100.00%)
+  metadata: StructMetadata { validity: NonNullable }
+  n_nationkey: $vortex.primitive(0x03)(i64, len=25) nbytes=201 B (6.62%)
+    metadata: PrimitiveMetadata { validity: NonNullable }
+    buffer (align=8): 200 B
+  n_name: $vortex.varbinview(0x06)(utf8, len=25) nbytes=461 B (15.18%)
+    metadata: VarBinViewMetadata { validity: NonNullable, buffer_lens: [27] }
+    views: $vortex.primitive(0x03)(u8, len=400) nbytes=401 B (13.20%)
+      metadata: PrimitiveMetadata { validity: NonNullable }
+      buffer (align=1): 400 B
+    bytes_0: $vortex.primitive(0x03)(u8, len=27) nbytes=28 B (0.92%)
+      metadata: PrimitiveMetadata { validity: NonNullable }
+      buffer (align=1): 27 B
+  n_regionkey: $vortex.dict(0x14)(i64, len=25) nbytes=83 B (2.73%)
+    metadata: DictMetadata { codes_ptype: U8, values_len: 5 }
+    values: $vortex.primitive(0x03)(i64, len=5) nbytes=41 B (1.35%)
+      metadata: PrimitiveMetadata { validity: NonNullable }
+      buffer (align=8): 40 B
+    codes: $vortex.primitive(0x03)(u8, len=25) nbytes=26 B (0.86%)
+      metadata: PrimitiveMetadata { validity: NonNullable }
+      buffer (align=1): 25 B
+  n_comment: $vortex.varbinview(0x06)(utf8?, len=25) nbytes=2.29 kB (75.44%)
+    metadata: VarBinViewMetadata { validity: AllValid, buffer_lens: [1857] }
+    views: $vortex.primitive(0x03)(u8, len=400) nbytes=401 B (13.20%)
+      metadata: PrimitiveMetadata { validity: NonNullable }
+      buffer (align=1): 400 B
+    bytes_0: $vortex.primitive(0x03)(u8, len=1857) nbytes=1.86 kB (61.18%)
+      metadata: PrimitiveMetadata { validity: NonNullable }
+      buffer (align=1): 1.86 kB
+```
+
+Opening an interactive TUI to browse the sample file:
+
+```
+vx browse ./bench-vortex/data/tpch/1/vortex_compressed/nation.vortex
+```
+
+## Development
+
+TODO:
+
+- [ ] `cat` to print a Vortex file as JSON to stdout
+- [ ] `compress` to ingest JSON/CSV/other formats that are Arrow-compatible

--- a/vortex-cli/src/browse/app.rs
+++ b/vortex-cli/src/browse/app.rs
@@ -80,7 +80,8 @@ impl LayoutCursor {
             // Find the DType of the child based on the DType of the current node.
             dtype = match layout.encoding().id() {
                 CHUNKED_LAYOUT_ID => {
-                    if component == 0 && layout.metadata().is_some() {
+                    // If metadata is present, last child is stats table
+                    if layout.metadata().is_some() && component == (layout.nchildren() - 1) {
                         let stats = stats_from_bitset_bytes(
                             layout.metadata().expect("extracting stats").as_ref(),
                         );
@@ -190,7 +191,6 @@ impl AppState {
             .read_exact_at(&mut buf, range.start)
             .expect("read_exact_at sync");
 
-        // align to 8 bytes
         buf.freeze()
     }
 }

--- a/vortex-cli/src/browse/app.rs
+++ b/vortex-cli/src/browse/app.rs
@@ -145,6 +145,13 @@ impl LayoutCursor {
         Self::new_with_path(self.file_layout.clone(), path)
     }
 
+    /// Predicate true when the cursor is currently activated over a stats table
+    pub fn is_stats_table(&self) -> bool {
+        let parent = self.parent();
+        parent.encoding().id() == CHUNKED_LAYOUT_ID
+            && self.path.last().copied().unwrap_or_default() == (parent.layout().nchildren() - 1)
+    }
+
     pub fn dtype(&self) -> &DType {
         self.layout.dtype()
     }

--- a/vortex-cli/src/browse/app.rs
+++ b/vortex-cli/src/browse/app.rs
@@ -1,0 +1,215 @@
+use std::ops::Range;
+use std::os::unix::fs::FileExt;
+use std::path::Path;
+use std::sync::Arc;
+
+use ratatui::widgets::ListState;
+use vortex::buffer::{Alignment, ByteBuffer, ByteBufferMut};
+use vortex::dtype::{DType, Field, Nullability, StructDType};
+use vortex::error::{VortexExpect, VortexResult};
+use vortex::file::{
+    ExecutionMode, FileLayout, Segment, SplitBy, VortexOpenOptions, CHUNKED_LAYOUT_ID,
+    COLUMNAR_LAYOUT_ID, FLAT_LAYOUT_ID,
+};
+use vortex::io::TokioFile;
+use vortex::sampling_compressor::ALL_ENCODINGS_CONTEXT;
+use vortex::stats::stats_from_bitset_bytes;
+use vortex_layout::segments::SegmentId;
+use vortex_layout::{LayoutData, LayoutEncodingRef};
+// Add a shared Tokio Runtime for use in the app.
+
+#[derive(Default, Copy, Clone, Eq, PartialEq)]
+pub enum Tab {
+    /// The layout tree browser.
+    #[default]
+    Layout,
+    /// The encoding tree viewer
+    Encodings,
+    // TODO(aduffy): SQL query page powered by DF
+    // Query,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Encoding {
+    Flat,
+    Chunked,
+    Columnar,
+    Unknown,
+}
+
+impl From<u16> for Encoding {
+    fn from(value: u16) -> Self {
+        if value == FLAT_LAYOUT_ID.0 {
+            Encoding::Flat
+        } else if value == CHUNKED_LAYOUT_ID.0 {
+            Encoding::Chunked
+        } else if value == COLUMNAR_LAYOUT_ID.0 {
+            Encoding::Columnar
+        } else {
+            Encoding::Unknown
+        }
+    }
+}
+
+/// A pointer into the `Layout` hierarchy that can be advanced.
+///
+/// The pointer wraps an InitialRead.
+pub struct LayoutCursor {
+    path: Vec<usize>,
+    file_layout: FileLayout,
+    layout: LayoutData,
+    #[allow(unused)]
+    segment_map: Arc<[Segment]>,
+}
+
+impl LayoutCursor {
+    pub fn new(layout: FileLayout) -> Self {
+        Self {
+            path: Vec::new(),
+            layout: layout.root_layout().clone(),
+            segment_map: Arc::clone(layout.segment_map()),
+            file_layout: layout,
+        }
+    }
+
+    pub fn new_with_path(file_layout: FileLayout, path: Vec<usize>) -> Self {
+        let mut layout = file_layout.root_layout().clone();
+        let mut dtype = file_layout.dtype().clone();
+        // Traverse the layout tree at each element of the path.
+        for component in path.iter().copied() {
+            // Find the DType of the child based on the DType of the current node.
+            dtype = match layout.encoding().id() {
+                CHUNKED_LAYOUT_ID => {
+                    if component == 0 && layout.metadata().is_some() {
+                        let stats = stats_from_bitset_bytes(
+                            layout.metadata().expect("extracting stats").as_ref(),
+                        );
+
+                        // When Chunked layout has a metadata field set, it will have a DType with
+                        // STRUCT type and one field for each of the statistics.
+                        let struct_dtype = StructDType::new(
+                            stats
+                                .iter()
+                                .map(|stat| Arc::from(stat.to_string().as_str()))
+                                .collect::<Vec<Arc<str>>>()
+                                .into(),
+                            stats
+                                .iter()
+                                .map(|stat| stat.dtype(&dtype))
+                                .collect::<Vec<DType>>(),
+                        );
+                        DType::Struct(Arc::new(struct_dtype), Nullability::NonNullable)
+                    } else {
+                        // If there is no metadata, all children
+                        dtype.clone()
+                    }
+                }
+                COLUMNAR_LAYOUT_ID => dtype
+                    .as_struct()
+                    .expect("struct dtype")
+                    .field_info(&Field::Index(component))
+                    .expect("struct dtype component access")
+                    .dtype
+                    .value()
+                    .expect("dtype value"),
+                // Flat layouts have no children
+                FLAT_LAYOUT_ID => unreachable!("flat layouts have no children"),
+                _ => todo!("unknown DType"),
+            };
+
+            layout = layout.child(component, dtype.clone()).expect("children");
+        }
+
+        Self {
+            segment_map: Arc::clone(file_layout.segment_map()),
+            path,
+            file_layout,
+            layout,
+        }
+    }
+
+    /// Create a new LayoutCursor indexing into the n-th child of the layout at the current
+    /// cursor position.
+    pub fn child(&self, n: usize) -> Self {
+        let mut path = self.path.clone();
+        path.push(n);
+
+        Self::new_with_path(self.file_layout.clone(), path)
+    }
+
+    pub fn parent(&self) -> Self {
+        let mut path = self.path.clone();
+        path.pop();
+
+        Self::new_with_path(self.file_layout.clone(), path)
+    }
+
+    pub fn dtype(&self) -> &DType {
+        self.layout.dtype()
+    }
+
+    pub fn encoding(&self) -> LayoutEncodingRef {
+        self.layout.encoding()
+    }
+
+    pub fn layout(&self) -> &LayoutData {
+        &self.layout
+    }
+
+    pub fn segment(&self, id: SegmentId) -> &Segment {
+        &self.segment_map[*id as usize]
+    }
+}
+
+/// State saved across all Tabs.
+///
+/// Holding them all allows us to switch between tabs without resetting view state.
+pub struct AppState {
+    pub reader: TokioFile,
+    pub cursor: LayoutCursor,
+    pub current_tab: Tab,
+
+    /// List state for the Layouts view
+    pub layouts_list_state: ListState,
+}
+
+impl AppState {
+    pub fn read_segment(&self, segment_id: SegmentId) -> ByteBuffer {
+        let segment = self.cursor.segment(segment_id);
+        let range = segment.offset..(segment.offset + segment.length as u64);
+        self.read_bytes_sync(range, segment.alignment)
+    }
+
+    // Read the provided byte range
+    pub fn read_bytes_sync(&self, range: Range<u64>, alignment: Alignment) -> ByteBuffer {
+        let mut buf = ByteBufferMut::zeroed_aligned(
+            (range.end - range.start).try_into().vortex_expect("range"),
+            alignment,
+        );
+        self.reader
+            .read_exact_at(&mut buf, range.start)
+            .expect("read_exact_at sync");
+
+        // align to 8 bytes
+        buf.freeze()
+    }
+}
+
+/// Create an app backed from a file path.
+pub async fn create_file_app(path: impl AsRef<Path>) -> VortexResult<AppState> {
+    let reader = TokioFile::open(path)?;
+    let file = VortexOpenOptions::new(ALL_ENCODINGS_CONTEXT.clone())
+        .with_execution_mode(ExecutionMode::Inline)
+        .with_split_by(SplitBy::Layout)
+        .open(reader.clone())
+        .await?;
+
+    let cursor = LayoutCursor::new(file.file_layout().clone());
+
+    Ok(AppState {
+        reader,
+        cursor,
+        current_tab: Tab::default(),
+        layouts_list_state: ListState::default().with_selected(Some(0)),
+    })
+}

--- a/vortex-cli/src/browse/mod.rs
+++ b/vortex-cli/src/browse/mod.rs
@@ -1,0 +1,83 @@
+use std::path::Path;
+
+use app::{create_file_app, AppState, Tab};
+use crossterm::event;
+use crossterm::event::{Event, KeyCode, KeyEventKind};
+use ratatui::widgets::ListState;
+use ratatui::DefaultTerminal;
+use ui::render_app;
+use vortex::error::VortexResult;
+
+use crate::TOKIO_RUNTIME;
+
+mod app;
+mod ui;
+
+// Use the VortexResult and potentially launch a Backtrace.
+fn run(mut terminal: DefaultTerminal, mut app: AppState) -> VortexResult<()> {
+    loop {
+        terminal.draw(|frame| render_app(&mut app, frame))?;
+
+        if let Event::Key(key) = event::read()? {
+            if key.kind == KeyEventKind::Press {
+                match key.code {
+                    KeyCode::Char('q') => break Ok(()),
+                    KeyCode::Tab => {
+                        // toggle between tabs
+                        app.current_tab = match app.current_tab {
+                            Tab::Layout => Tab::Encodings,
+                            Tab::Encodings => Tab::Layout,
+                        };
+                    }
+                    KeyCode::Up => {
+                        // We send the key-up to the list state if we're looking at
+                        // the Layouts tab.
+                        if app.current_tab == Tab::Layout {
+                            app.layouts_list_state.scroll_up_by(1);
+                        }
+                    }
+                    KeyCode::Down => {
+                        if app.current_tab == Tab::Layout {
+                            app.layouts_list_state.scroll_down_by(1);
+                        }
+                    }
+                    KeyCode::Enter => {
+                        if app.current_tab == Tab::Layout {
+                            // Descend into the layout subtree for the selected child.
+                            let selected = app.layouts_list_state.selected().unwrap_or_default();
+                            app.cursor = app.cursor.child(selected);
+
+                            // Reset the list scroll state.
+                            app.layouts_list_state = ListState::default().with_selected(Some(0));
+                        }
+                    }
+                    KeyCode::Left => {
+                        if app.current_tab == Tab::Layout {
+                            // Ascend back up to the Parent node
+                            app.cursor = app.cursor.parent();
+                            // Reset the list scroll state.
+                            app.layouts_list_state = ListState::default().with_selected(Some(0));
+                        }
+                    }
+                    // Most events not handled
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+// TODO: add tui_logger and have a logs tab so we can see the log output from
+//  doing Vortex things.¬
+
+pub fn exec_tui(file: impl AsRef<Path>) -> VortexResult<()> {
+    let app = TOKIO_RUNTIME.block_on(create_file_app(file))?;
+
+    let mut terminal = ratatui::init();
+    terminal.clear()?;
+
+    run(terminal, app)?;
+
+    ratatui::restore();
+    Ok(())
+}

--- a/vortex-cli/src/browse/ui.rs
+++ b/vortex-cli/src/browse/ui.rs
@@ -1,0 +1,62 @@
+mod encodings;
+mod layouts;
+
+use encodings::encodings_ui;
+use layouts::render_layouts;
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, BorderType, Borders, Tabs};
+
+use super::app::{AppState, Tab};
+
+pub fn render_app(app: &mut AppState, frame: &mut Frame) {
+    // Render the outer tab view, then render the inner frame view.
+    let shell = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().magenta())
+        .title_top("vx-browse")
+        .title_bottom("press q to quit |  ← to go up a level | ENTER to go down a level")
+        .title_alignment(Alignment::Center);
+
+    // The rest of the app is rendered inside the shell.
+    let inner_area = shell.inner(frame.area());
+
+    frame.render_widget(shell, frame.area());
+
+    // Split the inner area into a Tab view area and the rest of the screen.
+    let [tab_view, app_view] = Layout::vertical([
+        // Tab bar area - 1 line
+        Constraint::Length(1),
+        // Rest of the interior space for app view
+        Constraint::Min(0),
+    ])
+    .areas(inner_area);
+
+    // Display a tab indicator.
+    let selected_tab = match app.current_tab {
+        Tab::Layout => 0,
+        Tab::Encodings => 1,
+    };
+
+    let tabs = Tabs::new([
+        "File Layout",
+        "Arrays",
+        // TODO(aduffy): add SQL query interface
+        // "Query",
+    ])
+    .style(Style::default().bold().white())
+    .highlight_style(Style::default().bold().black().on_white())
+    .select(Some(selected_tab));
+
+    frame.render_widget(tabs, tab_view);
+
+    // Render the view for the current tab.
+    match app.current_tab {
+        Tab::Layout => {
+            render_layouts(app, app_view, frame.buffer_mut());
+        }
+        Tab::Encodings => {
+            frame.render_widget(encodings_ui(app), app_view);
+        }
+    }
+}

--- a/vortex-cli/src/browse/ui/encodings.rs
+++ b/vortex-cli/src/browse/ui/encodings.rs
@@ -1,0 +1,8 @@
+use ratatui::prelude::Widget;
+use ratatui::widgets::Paragraph;
+
+use crate::browse::app::AppState;
+
+pub fn encodings_ui(_app_state: &AppState) -> impl Widget {
+    Paragraph::new("TODO: Encodings View").centered()
+}

--- a/vortex-cli/src/browse/ui/layouts.rs
+++ b/vortex-cli/src/browse/ui/layouts.rs
@@ -1,0 +1,218 @@
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Style, Stylize};
+use ratatui::text::Text;
+use ratatui::widgets::{
+    Block, BorderType, Borders, List, ListState, Paragraph, StatefulWidget, Widget,
+};
+use vortex::buffer::ByteBuffer;
+use vortex::dtype::Field;
+use vortex::error::VortexExpect;
+use vortex::file::{CHUNKED_LAYOUT_ID, COLUMNAR_LAYOUT_ID, FLAT_LAYOUT_ID};
+use vortex::flatbuffers::array::root_as_array;
+use vortex::flatbuffers::FlatBuffer;
+use vortex::stats::stats_from_bitset_bytes;
+use vortex_layout::segments::SegmentId;
+
+use crate::browse::app::{AppState, LayoutCursor};
+
+/// Render the Layouts tab.
+pub fn render_layouts(app_state: &mut AppState, area: Rect, buf: &mut Buffer) {
+    let [header_area, detail_area] =
+        Layout::vertical([Constraint::Length(10), Constraint::Min(1)]).areas(area);
+
+    // Render the header area.
+    render_layout_header(&app_state.cursor, header_area, buf);
+
+    // Render the list view if the layout has children
+    if app_state.cursor.encoding().id() == FLAT_LAYOUT_ID {
+        render_array(app_state, detail_area, buf);
+    } else {
+        render_children_list(
+            &app_state.cursor,
+            detail_area,
+            buf,
+            &mut app_state.layouts_list_state,
+        );
+    }
+}
+
+fn render_layout_header(cursor: &LayoutCursor, area: Rect, buf: &mut Buffer) {
+    // We want the header to have some padding, and all elements to be horizontally aligned.
+    // let [area] = Layout::default()
+    //     .constraints([Constraint::Min(0)])
+    //     .margin(10)
+    //     .areas(area);
+
+    let layout_kind = match cursor.encoding().id() {
+        FLAT_LAYOUT_ID => "FLAT".to_string(),
+        CHUNKED_LAYOUT_ID => "CHUNKED".to_string(),
+        COLUMNAR_LAYOUT_ID => "COLUMNAR".to_string(),
+        _ => "UNKNOWN".to_string(),
+    };
+
+    // If using a FlatLayout, read the array and parse the metadata.
+
+    let row_count = cursor.layout().row_count();
+
+    let mut rows = vec![
+        Text::from(format!("Kind: {layout_kind}")).bold(),
+        Text::from(format!("Row Count: {row_count}")).bold(),
+        Text::from(format!("Schema: {}", cursor.dtype()))
+            .bold()
+            .green(),
+    ];
+
+    if cursor.encoding().id() == CHUNKED_LAYOUT_ID {
+        // Push any columnar stats.
+        if let Some(metadata) = cursor.layout().metadata() {
+            let available_stats = stats_from_bitset_bytes(&metadata);
+            let mut line = String::new();
+            line.push_str("Statistics: ");
+            for stat in available_stats {
+                line.push_str(stat.to_string().as_str());
+                line.push(' ');
+            }
+
+            rows.push(Text::from(line));
+        } else {
+            rows.push(Text::from("No chunk statistics found"));
+        }
+    }
+
+    let container = Block::new()
+        .title("Layout Info")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(Color::DarkGray));
+
+    let inner_area = container.inner(area);
+
+    container.render(area, buf);
+
+    Widget::render(List::new(rows), inner_area, buf);
+}
+
+// Render the inner Array for a FlatLayout
+fn render_array(app: &AppState, area: Rect, buf: &mut Buffer) {
+    let segment_ids: Vec<SegmentId> = app.cursor.layout().segments().collect();
+    let buffers: Vec<ByteBuffer> = segment_ids
+        .into_iter()
+        .map(|id| app.read_segment(id))
+        .collect();
+
+    let array_fmt = read_array(
+        buffers,
+        // app.cursor.layout(),
+        // ALL_ENCODINGS_CONTEXT.clone(),
+        // app.cursor.layout().dtype(),
+    );
+
+    // Show the metadata as JSON. (show count of encoded bytes as well)
+    // let metadata_size = array.metadata_bytes().unwrap_or_default().len();
+    let container = Block::new()
+        .title("Array Info")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(Color::DarkGray));
+
+    let widget_area = container.inner(area);
+
+    container.render(area, buf);
+
+    Paragraph::new(array_fmt).render(widget_area, buf);
+}
+
+fn render_children_list(
+    cursor: &LayoutCursor,
+    area: Rect,
+    buf: &mut Buffer,
+    state: &mut ListState,
+) {
+    // TODO: add selection state.
+    let layout = cursor.layout();
+
+    if layout.nchildren() > 0 {
+        let list_items: Vec<String> = (0..layout.nchildren())
+            .map(|idx| child_name(cursor, idx))
+            .collect();
+
+        let container = Block::new()
+            .title("Child Layouts")
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(Color::DarkGray));
+
+        let inner_area = container.inner(area);
+
+        container.render(area, buf);
+
+        // Render the List view.
+        // TODO: add state so we can scroll
+        StatefulWidget::render(
+            List::new(list_items).highlight_style(Style::default().black().on_white().bold()),
+            inner_area,
+            buf,
+            state,
+        );
+    }
+}
+
+fn child_name(cursor: &LayoutCursor, nth: usize) -> String {
+    match cursor.encoding().id() {
+        COLUMNAR_LAYOUT_ID => {
+            let field_info = cursor
+                .dtype()
+                .as_struct()
+                .expect("struct dtype")
+                .field_info(&Field::Index(nth))
+                .expect("struct dtype component");
+            let field_name = field_info.name;
+            let field_dtype = field_info.dtype.value().expect("dtype value");
+            format!("Column {nth} - {field_name} ({field_dtype})")
+        }
+        CHUNKED_LAYOUT_ID => {
+            // 0th child of a ChunkedLayout is the chunk stats array.
+            // The rest of the chunks are child arrays
+            if cursor.layout().metadata().is_none() {
+                format!("Chunk {nth}")
+            } else if nth == 0 {
+                "Chunk Statistics".to_string()
+            } else {
+                format!("Chunk {}", nth - 1)
+            }
+        }
+        FLAT_LAYOUT_ID => format!("Page {nth}"),
+        _ => format!("Unknown {nth}"),
+    }
+}
+
+fn read_array(
+    mut buffers: Vec<ByteBuffer>,
+    // layout: &LayoutData,
+    // ctx: Arc<Context>,
+    // dtype: &DType,
+) -> String {
+    #[allow(clippy::unwrap_used)]
+    let flatbuffer = FlatBuffer::try_from(buffers.pop().unwrap()).unwrap();
+
+    let fb_array =
+        root_as_array(flatbuffer.as_ref()).vortex_expect("Invalid fba::Array flatbuffer");
+    format!("{fb_array:?}")
+
+    // TODO(aduffy): for some reason this fails with schema unexpected error.
+    // let mut log = std::fs::File::create("fb.log").unwrap();
+    // write!(log, "flatbuffer: {fb_array:?}").unwrap();
+    // let row_count = usize::try_from(layout.row_count())
+    //     .vortex_expect("FlatLayout row count does not fit within usize");
+
+    // let array_parts = ArrayParts::new(
+    //     row_count,
+    //     root_as_array(flatbuffer.as_ref()).vortex_expect("Invalid fba::Array flatbuffer"),
+    //     flatbuffer.clone(),
+    //     buffers,
+    // );
+
+    // // Decode into an ArrayData.
+    // array_parts.decode(ctx, dtype.clone()).unwrap()
+}

--- a/vortex-cli/src/browse/ui/layouts.rs
+++ b/vortex-cli/src/browse/ui/layouts.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Style, Stylize};
@@ -6,13 +8,17 @@ use ratatui::widgets::{
     Block, BorderType, Borders, List, ListState, Paragraph, StatefulWidget, Widget,
 };
 use vortex::buffer::ByteBuffer;
-use vortex::dtype::Field;
+use vortex::dtype::{DType, Field};
 use vortex::error::VortexExpect;
 use vortex::file::{CHUNKED_LAYOUT_ID, COLUMNAR_LAYOUT_ID, FLAT_LAYOUT_ID};
 use vortex::flatbuffers::array::root_as_array;
 use vortex::flatbuffers::FlatBuffer;
+use vortex::parts::ArrayParts;
+use vortex::sampling_compressor::ALL_ENCODINGS_CONTEXT;
 use vortex::stats::stats_from_bitset_bytes;
+use vortex::{ArrayData, Context};
 use vortex_layout::segments::SegmentId;
+use vortex_layout::LayoutData;
 
 use crate::browse::app::{AppState, LayoutCursor};
 
@@ -52,7 +58,6 @@ fn render_layout_header(cursor: &LayoutCursor, area: Rect, buf: &mut Buffer) {
     };
 
     // If using a FlatLayout, read the array and parse the metadata.
-
     let row_count = cursor.layout().row_count();
 
     let mut rows = vec![
@@ -101,11 +106,11 @@ fn render_array(app: &AppState, area: Rect, buf: &mut Buffer) {
         .map(|id| app.read_segment(id))
         .collect();
 
-    let array_fmt = read_array(
+    let array = read_array(
         buffers,
-        // app.cursor.layout(),
-        // ALL_ENCODINGS_CONTEXT.clone(),
-        // app.cursor.layout().dtype(),
+        app.cursor.layout(),
+        ALL_ENCODINGS_CONTEXT.clone(),
+        app.cursor.layout().dtype(),
     );
 
     // Show the metadata as JSON. (show count of encoded bytes as well)
@@ -120,7 +125,7 @@ fn render_array(app: &AppState, area: Rect, buf: &mut Buffer) {
 
     container.render(area, buf);
 
-    Paragraph::new(array_fmt).render(widget_area, buf);
+    Paragraph::new(array.tree_display().to_string()).render(widget_area, buf);
 }
 
 fn render_children_list(
@@ -176,10 +181,10 @@ fn child_name(cursor: &LayoutCursor, nth: usize) -> String {
             // The rest of the chunks are child arrays
             if cursor.layout().metadata().is_none() {
                 format!("Chunk {nth}")
-            } else if nth == 0 {
+            } else if nth == (cursor.layout().nchildren() - 1) {
                 "Chunk Statistics".to_string()
             } else {
-                format!("Chunk {}", nth - 1)
+                format!("Chunk {}", nth)
             }
         }
         FLAT_LAYOUT_ID => format!("Page {nth}"),
@@ -189,30 +194,23 @@ fn child_name(cursor: &LayoutCursor, nth: usize) -> String {
 
 fn read_array(
     mut buffers: Vec<ByteBuffer>,
-    // layout: &LayoutData,
-    // ctx: Arc<Context>,
-    // dtype: &DType,
-) -> String {
+    layout: &LayoutData,
+    ctx: Arc<Context>,
+    dtype: &DType,
+) -> ArrayData {
     #[allow(clippy::unwrap_used)]
     let flatbuffer = FlatBuffer::try_from(buffers.pop().unwrap()).unwrap();
 
     let fb_array =
         root_as_array(flatbuffer.as_ref()).vortex_expect("Invalid fba::Array flatbuffer");
-    format!("{fb_array:?}")
 
-    // TODO(aduffy): for some reason this fails with schema unexpected error.
-    // let mut log = std::fs::File::create("fb.log").unwrap();
-    // write!(log, "flatbuffer: {fb_array:?}").unwrap();
-    // let row_count = usize::try_from(layout.row_count())
-    //     .vortex_expect("FlatLayout row count does not fit within usize");
-
-    // let array_parts = ArrayParts::new(
-    //     row_count,
-    //     root_as_array(flatbuffer.as_ref()).vortex_expect("Invalid fba::Array flatbuffer"),
-    //     flatbuffer.clone(),
-    //     buffers,
-    // );
+    let array_parts = ArrayParts::new(
+        layout.row_count().try_into().vortex_expect("row_count"),
+        fb_array,
+        flatbuffer.clone(),
+        buffers,
+    );
 
     // // Decode into an ArrayData.
-    // array_parts.decode(ctx, dtype.clone()).unwrap()
+    array_parts.decode(ctx, dtype.clone()).unwrap()
 }

--- a/vortex-cli/src/browse/ui/layouts.rs
+++ b/vortex-cli/src/browse/ui/layouts.rs
@@ -5,9 +5,11 @@ use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Style, Stylize};
 use ratatui::text::Text;
 use ratatui::widgets::{
-    Block, BorderType, Borders, List, ListState, Paragraph, StatefulWidget, Widget,
+    Block, BorderType, Borders, Cell, List, ListState, Paragraph, Row, StatefulWidget, Table,
+    Widget,
 };
 use vortex::buffer::ByteBuffer;
+use vortex::compute::scalar_at;
 use vortex::dtype::{DType, Field};
 use vortex::error::VortexExpect;
 use vortex::file::{CHUNKED_LAYOUT_ID, COLUMNAR_LAYOUT_ID, FLAT_LAYOUT_ID};
@@ -32,7 +34,12 @@ pub fn render_layouts(app_state: &mut AppState, area: Rect, buf: &mut Buffer) {
 
     // Render the list view if the layout has children
     if app_state.cursor.encoding().id() == FLAT_LAYOUT_ID {
-        render_array(app_state, detail_area, buf);
+        render_array(
+            app_state,
+            detail_area,
+            buf,
+            app_state.cursor.is_stats_table(),
+        );
     } else {
         render_children_list(
             &app_state.cursor,
@@ -44,12 +51,6 @@ pub fn render_layouts(app_state: &mut AppState, area: Rect, buf: &mut Buffer) {
 }
 
 fn render_layout_header(cursor: &LayoutCursor, area: Rect, buf: &mut Buffer) {
-    // We want the header to have some padding, and all elements to be horizontally aligned.
-    // let [area] = Layout::default()
-    //     .constraints([Constraint::Min(0)])
-    //     .margin(10)
-    //     .areas(area);
-
     let layout_kind = match cursor.encoding().id() {
         FLAT_LAYOUT_ID => "FLAT".to_string(),
         CHUNKED_LAYOUT_ID => "CHUNKED".to_string(),
@@ -57,7 +58,6 @@ fn render_layout_header(cursor: &LayoutCursor, area: Rect, buf: &mut Buffer) {
         _ => "UNKNOWN".to_string(),
     };
 
-    // If using a FlatLayout, read the array and parse the metadata.
     let row_count = cursor.layout().row_count();
 
     let mut rows = vec![
@@ -99,7 +99,7 @@ fn render_layout_header(cursor: &LayoutCursor, area: Rect, buf: &mut Buffer) {
 }
 
 // Render the inner Array for a FlatLayout
-fn render_array(app: &AppState, area: Rect, buf: &mut Buffer) {
+fn render_array(app: &AppState, area: Rect, buf: &mut Buffer, is_stats_table: bool) {
     let segment_ids: Vec<SegmentId> = app.cursor.layout().segments().collect();
     let buffers: Vec<ByteBuffer> = segment_ids
         .into_iter()
@@ -125,7 +125,47 @@ fn render_array(app: &AppState, area: Rect, buf: &mut Buffer) {
 
     container.render(area, buf);
 
-    Paragraph::new(array.tree_display().to_string()).render(widget_area, buf);
+    if is_stats_table {
+        // Render the stats table horizontally
+        let struct_array = array.as_struct_array().vortex_expect("stats table");
+        let field_count = struct_array.nfields();
+        let header = std::iter::once("chunk")
+            .chain(struct_array.names().iter().map(|x| x.as_ref()))
+            .map(Cell::from)
+            .collect::<Row>()
+            .style(Style::default().fg(Color::Green).bg(Color::DarkGray))
+            .height(1);
+
+        let field_arrays: Vec<ArrayData> = (0..struct_array.nfields())
+            .map(|x| {
+                struct_array
+                    .maybe_null_field_by_idx(x)
+                    .vortex_expect("stats table field")
+            })
+            .collect();
+
+        // TODO: trim the number of displayed rows and allow paging through column stats.
+        let rows = (0..array.len()).map(|chunk_id| {
+            std::iter::once(Cell::from(Text::from(format!("{chunk_id}"))))
+                .chain(field_arrays.iter().map(|arr| {
+                    Cell::from(Text::from(
+                        scalar_at(arr, chunk_id)
+                            .vortex_expect("stats table scalar_at")
+                            .to_string(),
+                    ))
+                }))
+                .collect::<Row>()
+        });
+
+        Widget::render(
+            Table::new(rows, (0..field_count).map(|_| Constraint::Length(6))).header(header),
+            widget_area,
+            buf,
+        );
+    } else {
+        // Tree-display the active array
+        Paragraph::new(array.tree_display().to_string()).render(widget_area, buf);
+    };
 }
 
 fn render_children_list(
@@ -198,8 +238,8 @@ fn read_array(
     ctx: Arc<Context>,
     dtype: &DType,
 ) -> ArrayData {
-    #[allow(clippy::unwrap_used)]
-    let flatbuffer = FlatBuffer::try_from(buffers.pop().unwrap()).unwrap();
+    let flatbuffer = FlatBuffer::try_from(buffers.pop().vortex_expect("buffers pop"))
+        .vortex_expect("flatbuffers");
 
     let fb_array =
         root_as_array(flatbuffer.as_ref()).vortex_expect("Invalid fba::Array flatbuffer");
@@ -212,5 +252,7 @@ fn read_array(
     );
 
     // // Decode into an ArrayData.
-    array_parts.decode(ctx, dtype.clone()).unwrap()
+    array_parts
+        .decode(ctx, dtype.clone())
+        .vortex_expect("decoding ArrayParts")
 }

--- a/vortex-cli/src/main.rs
+++ b/vortex-cli/src/main.rs
@@ -1,0 +1,34 @@
+#![allow(clippy::expect_used)]
+mod browse;
+mod tree;
+
+use std::path::PathBuf;
+use std::sync::LazyLock;
+
+use browse::exec_tui;
+use clap::Parser;
+use tokio::runtime::Runtime;
+use tree::exec_tree;
+
+static TOKIO_RUNTIME: LazyLock<Runtime> =
+    LazyLock::new(|| Runtime::new().expect("Tokio Runtime::new()"));
+
+#[derive(clap::Parser)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum Commands {
+    Tree { file: PathBuf },
+    Browse { file: PathBuf },
+}
+
+fn main() {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Tree { file } => exec_tree(file).expect("exec_tre"),
+        Commands::Browse { file } => exec_tui(file).expect("exec_tui"),
+    }
+}

--- a/vortex-cli/src/tree.rs
+++ b/vortex-cli/src/tree.rs
@@ -1,0 +1,28 @@
+use std::path::Path;
+
+use vortex::error::VortexResult;
+use vortex::file::{ExecutionMode, Scan, SplitBy, VortexOpenOptions};
+use vortex::io::TokioFile;
+use vortex::sampling_compressor::ALL_ENCODINGS_CONTEXT;
+use vortex::stream::ArrayStreamExt;
+
+use crate::TOKIO_RUNTIME;
+
+pub fn exec_tree(file: impl AsRef<Path>) -> VortexResult<()> {
+    let opened = TokioFile::open(file)?;
+
+    let full = TOKIO_RUNTIME.block_on(async move {
+        let file = VortexOpenOptions::new(ALL_ENCODINGS_CONTEXT.clone())
+            .with_execution_mode(ExecutionMode::Inline)
+            .with_split_by(SplitBy::Layout)
+            .open(opened)
+            .await?;
+
+        // TODO(aduffy): scan with paging.
+        file.scan(Scan::all())?.into_array_data().await
+    })?;
+
+    println!("{}", full.tree_display());
+
+    Ok(())
+}

--- a/vortex-file/src/footer/mod.rs
+++ b/vortex-file/src/footer/mod.rs
@@ -4,4 +4,4 @@ mod segment;
 
 pub use file_layout::*;
 pub(crate) use postscript::*;
-pub(crate) use segment::*;
+pub use segment::*;

--- a/vortex-file/src/footer/segment.rs
+++ b/vortex-file/src/footer/segment.rs
@@ -5,9 +5,9 @@ use vortex_flatbuffers::footer as fb;
 /// The location of a segment within a Vortex file.
 #[derive(Clone, Debug)]
 pub struct Segment {
-    pub(crate) offset: u64,
-    pub(crate) length: u32,
-    pub(crate) alignment: Alignment,
+    pub offset: u64,
+    pub length: u32,
+    pub alignment: Alignment,
 }
 
 impl From<&Segment> for fb::Segment {

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -103,7 +103,7 @@ mod tests;
 mod writer;
 
 pub use file::*;
-pub use footer::FileLayout;
+pub use footer::{FileLayout, Segment};
 pub use forever_constant::*;
 pub use open::*;
 pub use writer::*;


### PR DESCRIPTION
As we change/break format makes it easier to keep this tool up to date. Also helpful for debugging/exploring format.

I've also added a `vx` alias so we can immediately access it from cargo, e.g.

```
cargo vx browse bench-vortex/data/tpch/1/vortex_compressed/nation.vortex
```

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/8d17b730-1198-45a3-b3d6-ba1c64f913a5" />
