### PR TITLE
Arc InnerArrayData and add a WeakArrayData

### DIFF
--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -1,5 +1,4 @@
 use std::fmt::{Debug, Display};
-use std::sync::Arc;
 
 use fsst::{Decompressor, Symbol};
 use serde::{Deserialize, Serialize};
@@ -89,7 +88,7 @@ impl FSSTArray {
         let len = codes.len();
         let uncompressed_lengths_ptype = PType::try_from(uncompressed_lengths.dtype())?;
         let codes_nullability = codes.dtype().nullability();
-        let children = Arc::new([symbols, symbol_lengths, codes, uncompressed_lengths]);
+        let children = [symbols, symbol_lengths, codes, uncompressed_lengths].into();
 
         Self::try_from_parts(
             dtype,

--- a/vortex-array/src/data/mod.rs
+++ b/vortex-array/src/data/mod.rs
@@ -22,11 +22,12 @@ use crate::stats::{ArrayStatistics, Stat, Statistics, StatsSet};
 use crate::stream::{ArrayStream, ArrayStreamAdapter};
 use crate::validity::{ArrayValidity, LogicalValidity, ValidityVTable};
 use crate::{
-    ArrayChildrenIterator, ArrayDType, ArrayLen, ArrayMetadata, ContextRef, NamedChildrenCollector,
-    TryDeserializeArrayMetadata,
+    ArrayChildrenIterator, ArrayDType, ArrayLen, ArrayMetadata, ChildrenCollector, ContextRef,
+    NamedChildrenCollector, TryDeserializeArrayMetadata,
 };
 
 mod owned;
+mod statistics;
 mod viewed;
 
 /// A central type for all Vortex arrays, which are known length sequences of typed and possibly compressed data.
@@ -35,7 +36,7 @@ mod viewed;
 #[derive(Debug, Clone)]
 pub struct ArrayData(Arc<InnerArrayData>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 enum InnerArrayData {
     /// Owned [`ArrayData`] with serialized metadata, backed by heap-allocated memory.
     Owned(OwnedArrayData),
@@ -72,9 +73,9 @@ impl ArrayData {
             metadata,
             buffers,
             children,
-            stats_set: Arc::new(RwLock::new(statistics)),
+            stats_set: RwLock::new(statistics),
             #[cfg(feature = "canonical_counter")]
-            canonical_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            canonical_counter: std::sync::atomic::AtomicUsize::new(0),
         }))
     }
 
@@ -113,7 +114,7 @@ impl ArrayData {
             buffers: buffers.into(),
             ctx,
             #[cfg(feature = "canonical_counter")]
-            canonical_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            canonical_counter: std::sync::atomic::AtomicUsize::new(0),
         };
 
         Self::try_new(InnerArrayData::Viewed(view))
@@ -144,10 +145,6 @@ impl ArrayData {
         //  can check the number of children, number of buffers, and metadata values etc.
 
         Ok(array)
-    }
-
-    fn into_inner(self) -> InnerArrayData {
-        Arc::try_unwrap(self.0).unwrap_or_else(|this| this.as_ref().clone())
     }
 
     /// Return the array's encoding
@@ -216,10 +213,17 @@ impl ArrayData {
     }
 
     /// Returns a Vec of Arrays with all the array's child arrays.
+    // TODO(ngates): deprecate this function and return impl Iterator
     pub fn children(&self) -> Vec<ArrayData> {
         match self.0.as_ref() {
             InnerArrayData::Owned(d) => d.children().to_vec(),
-            InnerArrayData::Viewed(v) => v.children(),
+            InnerArrayData::Viewed(_) => {
+                let mut collector = ChildrenCollector::default();
+                self.encoding()
+                    .accept(self, &mut collector)
+                    .vortex_expect("Failed to get children");
+                collector.children()
+            }
         }
     }
 
@@ -344,8 +348,11 @@ impl ArrayData {
     }
 
     pub fn into_byte_buffer(self, index: usize) -> Option<ByteBuffer> {
-        match self.into_inner() {
-            InnerArrayData::Owned(d) => d.into_byte_buffer(index),
+        // NOTE(ngates): we can't really into_inner an Arc, so instead we clone the buffer out,
+        //  but we still consume self by value such that the ref-count drops at the end of this
+        //  function.
+        match self.0.as_ref() {
+            InnerArrayData::Owned(d) => d.byte_buffer(index).cloned(),
             InnerArrayData::Viewed(v) => v.buffer(index).cloned(),
         }
     }
@@ -432,15 +439,6 @@ impl<T: AsRef<ArrayData>> ArrayDType for T {
     }
 }
 
-impl ArrayData {
-    pub fn into_dtype(self) -> DType {
-        match self.into_inner() {
-            InnerArrayData::Owned(d) => d.dtype,
-            InnerArrayData::Viewed(v) => v.dtype,
-        }
-    }
-}
-
 impl<T: AsRef<ArrayData>> ArrayLen for T {
     fn len(&self) -> usize {
         self.as_ref().len()
@@ -465,10 +463,7 @@ impl<A: AsRef<ArrayData>> ArrayValidity for A {
 
 impl<T: AsRef<ArrayData>> ArrayStatistics for T {
     fn statistics(&self) -> &(dyn Statistics + '_) {
-        match self.as_ref().0.as_ref() {
-            InnerArrayData::Owned(d) => d,
-            InnerArrayData::Viewed(v) => v,
-        }
+        self.as_ref()
     }
 
     // FIXME(ngates): this is really slow...
@@ -509,7 +504,7 @@ pub struct WeakArrayData(Weak<InnerArrayData>);
 impl WeakArrayData {
     /// Attempts to upgrade the weak reference to a strong reference.
     pub fn upgrade(&self) -> Option<ArrayData> {
-        self.0.upgrade().map(|inner| ArrayData(inner))
+        self.0.upgrade().map(ArrayData)
     }
 }
 

--- a/vortex-array/src/data/mod.rs
+++ b/vortex-array/src/data/mod.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, RwLock, Weak};
 
 use itertools::Itertools;
 use owned::OwnedArrayData;
@@ -33,7 +33,7 @@ mod viewed;
 ///
 /// This is the main entrypoint for working with in-memory Vortex data, and dispatches work over the underlying encoding or memory representations.
 #[derive(Debug, Clone)]
-pub struct ArrayData(InnerArrayData);
+pub struct ArrayData(Arc<InnerArrayData>);
 
 #[derive(Debug, Clone)]
 enum InnerArrayData {
@@ -45,13 +45,13 @@ enum InnerArrayData {
 
 impl From<OwnedArrayData> for ArrayData {
     fn from(data: OwnedArrayData) -> Self {
-        ArrayData(InnerArrayData::Owned(data))
+        ArrayData(Arc::new(InnerArrayData::Owned(data)))
     }
 }
 
 impl From<ViewedArrayData> for ArrayData {
     fn from(data: ViewedArrayData) -> Self {
-        ArrayData(InnerArrayData::Viewed(data))
+        ArrayData(Arc::new(InnerArrayData::Viewed(data)))
     }
 }
 
@@ -61,8 +61,8 @@ impl ArrayData {
         dtype: DType,
         len: usize,
         metadata: Arc<dyn ArrayMetadata>,
-        buffers: Arc<[ByteBuffer]>,
-        children: Arc<[ArrayData]>,
+        buffers: Box<[ByteBuffer]>,
+        children: Box<[ArrayData]>,
         statistics: StatsSet,
     ) -> VortexResult<Self> {
         Self::try_new(InnerArrayData::Owned(OwnedArrayData {
@@ -121,7 +121,7 @@ impl ArrayData {
 
     /// Shared constructor that performs common array validation.
     fn try_new(inner: InnerArrayData) -> VortexResult<Self> {
-        let array = ArrayData(inner);
+        let array = ArrayData(Arc::new(inner));
 
         // Sanity check that the encoding implements the correct array trait
         debug_assert!(
@@ -146,9 +146,13 @@ impl ArrayData {
         Ok(array)
     }
 
+    fn into_inner(self) -> InnerArrayData {
+        Arc::try_unwrap(self.0).unwrap_or_else(|this| this.as_ref().clone())
+    }
+
     /// Return the array's encoding
     pub fn encoding(&self) -> EncodingRef {
-        match &self.0 {
+        match self.0.as_ref() {
             InnerArrayData::Owned(d) => d.encoding,
             InnerArrayData::Viewed(v) => v.encoding,
         }
@@ -157,7 +161,7 @@ impl ArrayData {
     /// Returns the number of logical elements in the array.
     #[allow(clippy::same_name_method)]
     pub fn len(&self) -> usize {
-        match &self.0 {
+        match self.0.as_ref() {
             InnerArrayData::Owned(d) => d.len,
             InnerArrayData::Viewed(v) => v.len,
         }
@@ -203,17 +207,17 @@ impl ArrayData {
     }
 
     pub fn child<'a>(&'a self, idx: usize, dtype: &'a DType, len: usize) -> VortexResult<Self> {
-        match &self.0 {
+        match self.0.as_ref() {
             InnerArrayData::Owned(d) => d.child(idx, dtype, len).cloned(),
             InnerArrayData::Viewed(v) => v
                 .child(idx, dtype, len)
-                .map(|view| ArrayData(InnerArrayData::Viewed(view))),
+                .map(|view| ArrayData(Arc::new(InnerArrayData::Viewed(view)))),
         }
     }
 
     /// Returns a Vec of Arrays with all the array's child arrays.
     pub fn children(&self) -> Vec<ArrayData> {
-        match &self.0 {
+        match self.0.as_ref() {
             InnerArrayData::Owned(d) => d.children().to_vec(),
             InnerArrayData::Viewed(v) => v.children(),
         }
@@ -230,7 +234,7 @@ impl ArrayData {
 
     /// Returns the number of child arrays
     pub fn nchildren(&self) -> usize {
-        match &self.0 {
+        match self.0.as_ref() {
             InnerArrayData::Owned(d) => d.nchildren(),
             InnerArrayData::Viewed(v) => v.nchildren(),
         }
@@ -270,7 +274,7 @@ impl ArrayData {
     }
 
     pub fn array_metadata(&self) -> &dyn ArrayMetadata {
-        match &self.0 {
+        match self.0.as_ref() {
             InnerArrayData::Owned(d) => &*d.metadata,
             InnerArrayData::Viewed(v) => &*v.metadata,
         }
@@ -279,7 +283,7 @@ impl ArrayData {
     pub fn metadata<M: ArrayMetadata + Clone + for<'m> TryDeserializeArrayMetadata<'m>>(
         &self,
     ) -> VortexResult<&M> {
-        match &self.0 {
+        match self.0.as_ref() {
             InnerArrayData::Owned(d) => &d.metadata,
             InnerArrayData::Viewed(v) => &v.metadata,
         }
@@ -298,7 +302,7 @@ impl ArrayData {
     /// View arrays will return a reference to their bytes, while heap-backed arrays
     /// must first serialize their metadata, returning an owned byte array to the caller.
     pub fn metadata_bytes(&self) -> VortexResult<Cow<[u8]>> {
-        match &self.0 {
+        match self.0.as_ref() {
             InnerArrayData::Owned(array_data) => {
                 // Heap-backed arrays must first try and serialize the metadata.
                 let owned_meta: Vec<u8> = array_data
@@ -320,14 +324,14 @@ impl ArrayData {
     }
 
     pub fn nbuffers(&self) -> usize {
-        match &self.0 {
+        match self.0.as_ref() {
             InnerArrayData::Owned(o) => o.buffers.len(),
             InnerArrayData::Viewed(v) => v.nbuffers(),
         }
     }
 
     pub fn byte_buffer(&self, index: usize) -> Option<&ByteBuffer> {
-        match &self.0 {
+        match self.0.as_ref() {
             InnerArrayData::Owned(d) => d.byte_buffer(index),
             InnerArrayData::Viewed(v) => v.buffer(index),
         }
@@ -340,7 +344,7 @@ impl ArrayData {
     }
 
     pub fn into_byte_buffer(self, index: usize) -> Option<ByteBuffer> {
-        match self.0 {
+        match self.into_inner() {
             InnerArrayData::Owned(d) => d.into_byte_buffer(index),
             InnerArrayData::Viewed(v) => v.buffer(index).cloned(),
         }
@@ -368,7 +372,7 @@ impl ArrayData {
 
     #[cfg(feature = "canonical_counter")]
     pub(crate) fn inc_canonical_counter(&self) {
-        let prev = match &self.0 {
+        let prev = match self.0.as_ref() {
             InnerArrayData::Owned(o) => o
                 .canonical_counter
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
@@ -404,7 +408,7 @@ impl ArrayData {
 
 impl Display for ArrayData {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let prefix = match &self.0 {
+        let prefix = match self.0.as_ref() {
             InnerArrayData::Owned(_) => "",
             InnerArrayData::Viewed(_) => "$",
         };
@@ -421,7 +425,7 @@ impl Display for ArrayData {
 
 impl<T: AsRef<ArrayData>> ArrayDType for T {
     fn dtype(&self) -> &DType {
-        match &self.as_ref().0 {
+        match self.as_ref().0.as_ref() {
             InnerArrayData::Owned(d) => &d.dtype,
             InnerArrayData::Viewed(v) => &v.dtype,
         }
@@ -430,7 +434,7 @@ impl<T: AsRef<ArrayData>> ArrayDType for T {
 
 impl ArrayData {
     pub fn into_dtype(self) -> DType {
-        match self.0 {
+        match self.into_inner() {
             InnerArrayData::Owned(d) => d.dtype,
             InnerArrayData::Viewed(v) => v.dtype,
         }
@@ -461,7 +465,7 @@ impl<A: AsRef<ArrayData>> ArrayValidity for A {
 
 impl<T: AsRef<ArrayData>> ArrayStatistics for T {
     fn statistics(&self) -> &(dyn Statistics + '_) {
-        match &self.as_ref().0 {
+        match self.as_ref().0.as_ref() {
             InnerArrayData::Owned(d) => d,
             InnerArrayData::Viewed(v) => v,
         }
@@ -496,5 +500,22 @@ impl Iterator for ArrayDataIterator {
                 chunk
             }),
         }
+    }
+}
+
+/// An array data that holds a weak reference to its internals.
+pub struct WeakArrayData(Weak<InnerArrayData>);
+
+impl WeakArrayData {
+    /// Attempts to upgrade the weak reference to a strong reference.
+    pub fn upgrade(&self) -> Option<ArrayData> {
+        self.0.upgrade().map(|inner| ArrayData(inner))
+    }
+}
+
+impl ArrayData {
+    /// Downgrades the array data to a weak reference.
+    pub fn downgrade(self) -> WeakArrayData {
+        WeakArrayData(Arc::downgrade(&self.0))
     }
 }

--- a/vortex-array/src/data/owned.rs
+++ b/vortex-array/src/data/owned.rs
@@ -2,15 +2,14 @@ use std::sync::{Arc, RwLock};
 
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
-use vortex_error::{vortex_bail, vortex_panic, VortexResult};
-use vortex_scalar::Scalar;
+use vortex_error::{vortex_bail, VortexResult};
 
 use crate::encoding::EncodingRef;
-use crate::stats::{Stat, Statistics, StatsSet};
+use crate::stats::StatsSet;
 use crate::{ArrayDType, ArrayData, ArrayMetadata};
 
 /// Owned [`ArrayData`] with serialized metadata, backed by heap-allocated memory.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(super) struct OwnedArrayData {
     pub(super) encoding: EncodingRef,
     pub(super) dtype: DType,
@@ -18,9 +17,9 @@ pub(super) struct OwnedArrayData {
     pub(super) metadata: Arc<dyn ArrayMetadata>,
     pub(super) buffers: Box<[ByteBuffer]>,
     pub(super) children: Box<[ArrayData]>,
-    pub(super) stats_set: Arc<RwLock<StatsSet>>,
+    pub(super) stats_set: RwLock<StatsSet>,
     #[cfg(feature = "canonical_counter")]
-    pub(super) canonical_counter: Arc<std::sync::atomic::AtomicUsize>,
+    pub(super) canonical_counter: std::sync::atomic::AtomicUsize,
 }
 
 impl OwnedArrayData {
@@ -30,12 +29,6 @@ impl OwnedArrayData {
 
     pub fn byte_buffer(&self, index: usize) -> Option<&ByteBuffer> {
         self.buffers.get(index)
-    }
-
-    pub fn into_byte_buffer(self, index: usize) -> Option<ByteBuffer> {
-        // While this does require a clone, we're still "into" because it makes sure the self
-        // reference is dropped.
-        self.buffers.get(index).cloned()
     }
 
     // We want to allow these panics because they are indicative of implementation error.
@@ -70,73 +63,5 @@ impl OwnedArrayData {
 
     pub fn children(&self) -> &[ArrayData] {
         &self.children
-    }
-}
-
-impl Statistics for OwnedArrayData {
-    fn get(&self, stat: Stat) -> Option<Scalar> {
-        self.stats_set
-            .read()
-            .unwrap_or_else(|_| {
-                vortex_panic!(
-                    "Failed to acquire read lock on stats map while getting {}",
-                    stat
-                )
-            })
-            .get(stat)
-            .cloned()
-    }
-
-    fn to_set(&self) -> StatsSet {
-        self.stats_set
-            .read()
-            .unwrap_or_else(|_| vortex_panic!("Failed to acquire read lock on stats map"))
-            .clone()
-    }
-
-    fn set(&self, stat: Stat, value: Scalar) {
-        self.stats_set
-            .write()
-            .unwrap_or_else(|_| {
-                vortex_panic!(
-                    "Failed to acquire write lock on stats map while setting {} to {}",
-                    stat,
-                    value
-                )
-            })
-            .set(stat, value);
-    }
-
-    fn clear(&self, stat: Stat) {
-        self.stats_set
-            .write()
-            .unwrap_or_else(|_| vortex_panic!("Failed to acquire write lock on stats map"))
-            .clear(stat);
-    }
-
-    fn compute(&self, stat: Stat) -> Option<Scalar> {
-        if let Some(s) = self.get(stat) {
-            return Some(s);
-        }
-
-        let computed = self
-            .encoding
-            .compute_statistics(&ArrayData::from(self.clone()), stat)
-            .ok()?;
-
-        self.stats_set
-            .write()
-            .unwrap_or_else(|_| {
-                vortex_panic!("Failed to write to stats map while computing {}", stat)
-            })
-            .extend(computed);
-        self.get(stat)
-    }
-
-    fn retain_only(&self, stats: &[Stat]) {
-        self.stats_set
-            .write()
-            .unwrap_or_else(|_| vortex_panic!("Failed to acquire write lock on stats map"))
-            .retain_only(stats);
     }
 }

--- a/vortex-array/src/data/owned.rs
+++ b/vortex-array/src/data/owned.rs
@@ -10,14 +10,14 @@ use crate::stats::{Stat, Statistics, StatsSet};
 use crate::{ArrayDType, ArrayData, ArrayMetadata};
 
 /// Owned [`ArrayData`] with serialized metadata, backed by heap-allocated memory.
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone)]
 pub(super) struct OwnedArrayData {
     pub(super) encoding: EncodingRef,
-    pub(super) dtype: DType, // FIXME(ngates): Arc?
+    pub(super) dtype: DType,
     pub(super) len: usize,
     pub(super) metadata: Arc<dyn ArrayMetadata>,
-    pub(super) buffers: Arc<[ByteBuffer]>,
-    pub(super) children: Arc<[ArrayData]>,
+    pub(super) buffers: Box<[ByteBuffer]>,
+    pub(super) children: Box<[ArrayData]>,
     pub(super) stats_set: Arc<RwLock<StatsSet>>,
     #[cfg(feature = "canonical_counter")]
     pub(super) canonical_counter: Arc<std::sync::atomic::AtomicUsize>,
@@ -68,7 +68,7 @@ impl OwnedArrayData {
         self.children.len()
     }
 
-    pub fn children(&self) -> &Arc<[ArrayData]> {
+    pub fn children(&self) -> &[ArrayData] {
         &self.children
     }
 }

--- a/vortex-array/src/data/statistics.rs
+++ b/vortex-array/src/data/statistics.rs
@@ -115,11 +115,18 @@ impl Statistics for ArrayData {
         if let Some(s) = self.get(stat) {
             return Some(s);
         }
-        self.encoding()
+        let s = self
+            .encoding()
             .compute_statistics(self, stat)
             .ok()?
             .get(stat)
-            .cloned()
+            .cloned();
+
+        if let Some(s) = &s {
+            self.set(stat, s.clone());
+        }
+
+        s
     }
 
     fn retain_only(&self, stats: &[Stat]) {

--- a/vortex-array/src/data/statistics.rs
+++ b/vortex-array/src/data/statistics.rs
@@ -1,0 +1,138 @@
+use std::sync::Arc;
+
+use enum_iterator::all;
+use itertools::Itertools;
+use vortex_dtype::{DType, Nullability, PType};
+use vortex_error::vortex_panic;
+use vortex_scalar::{Scalar, ScalarValue};
+
+use crate::data::InnerArrayData;
+use crate::stats::{Stat, Statistics, StatsSet};
+use crate::{ArrayDType, ArrayData};
+
+impl Statistics for ArrayData {
+    fn get(&self, stat: Stat) -> Option<Scalar> {
+        match self.0.as_ref() {
+            InnerArrayData::Owned(o) => o
+                .stats_set
+                .read()
+                .unwrap_or_else(|_| {
+                    vortex_panic!(
+                        "Failed to acquire read lock on stats map while getting {}",
+                        stat
+                    )
+                })
+                .get(stat)
+                .cloned(),
+            InnerArrayData::Viewed(v) => match stat {
+                Stat::Max => {
+                    let max = v.flatbuffer().stats()?.max();
+                    max.and_then(|v| ScalarValue::try_from(v).ok())
+                        .map(|v| Scalar::new(self.dtype().clone(), v))
+                }
+                Stat::Min => {
+                    let min = v.flatbuffer().stats()?.min();
+                    min.and_then(|v| ScalarValue::try_from(v).ok())
+                        .map(|v| Scalar::new(self.dtype().clone(), v))
+                }
+                Stat::IsConstant => v.flatbuffer().stats()?.is_constant().map(bool::into),
+                Stat::IsSorted => v.flatbuffer().stats()?.is_sorted().map(bool::into),
+                Stat::IsStrictSorted => v.flatbuffer().stats()?.is_strict_sorted().map(bool::into),
+                Stat::RunCount => v.flatbuffer().stats()?.run_count().map(u64::into),
+                Stat::TrueCount => v.flatbuffer().stats()?.true_count().map(u64::into),
+                Stat::NullCount => v.flatbuffer().stats()?.null_count().map(u64::into),
+                Stat::BitWidthFreq => {
+                    let element_dtype =
+                        Arc::new(DType::Primitive(PType::U64, Nullability::NonNullable));
+                    v.flatbuffer()
+                        .stats()?
+                        .bit_width_freq()
+                        .map(|v| v.iter().map(Scalar::from).collect_vec())
+                        .map(|v| Scalar::list(element_dtype, v, Nullability::NonNullable))
+                }
+                Stat::TrailingZeroFreq => v
+                    .flatbuffer()
+                    .stats()?
+                    .trailing_zero_freq()
+                    .map(|v| v.iter().collect_vec())
+                    .map(|v| v.into()),
+                Stat::UncompressedSizeInBytes => v
+                    .flatbuffer()
+                    .stats()?
+                    .uncompressed_size_in_bytes()
+                    .map(u64::into),
+            },
+        }
+    }
+
+    fn to_set(&self) -> StatsSet {
+        match self.0.as_ref() {
+            InnerArrayData::Owned(o) => o
+                .stats_set
+                .read()
+                .unwrap_or_else(|_| vortex_panic!("Failed to acquire read lock on stats map"))
+                .clone(),
+            InnerArrayData::Viewed(_) => StatsSet::from_iter(
+                all::<Stat>().filter_map(|stat| self.get(stat).map(|v| (stat, v))),
+            ),
+        }
+    }
+
+    fn set(&self, stat: Stat, value: Scalar) {
+        match self.0.as_ref() {
+            InnerArrayData::Owned(o) => o
+                .stats_set
+                .write()
+                .unwrap_or_else(|_| {
+                    vortex_panic!(
+                        "Failed to acquire write lock on stats map while setting {} to {}",
+                        stat,
+                        value
+                    )
+                })
+                .set(stat, value),
+            InnerArrayData::Viewed(_) => {
+                // We cannot modify stats on a view
+            }
+        }
+    }
+
+    fn clear(&self, stat: Stat) {
+        match self.0.as_ref() {
+            InnerArrayData::Owned(o) => {
+                o.stats_set
+                    .write()
+                    .unwrap_or_else(|_| vortex_panic!("Failed to acquire write lock on stats map"))
+                    .clear(stat);
+            }
+            InnerArrayData::Viewed(_) => {
+                // We cannot modify stats on a view
+            }
+        }
+    }
+
+    fn compute(&self, stat: Stat) -> Option<Scalar> {
+        if let Some(s) = self.get(stat) {
+            return Some(s);
+        }
+        self.encoding()
+            .compute_statistics(self, stat)
+            .ok()?
+            .get(stat)
+            .cloned()
+    }
+
+    fn retain_only(&self, stats: &[Stat]) {
+        match self.0.as_ref() {
+            InnerArrayData::Owned(o) => {
+                o.stats_set
+                    .write()
+                    .unwrap_or_else(|_| vortex_panic!("Failed to acquire write lock on stats map"))
+                    .retain_only(stats);
+            }
+            InnerArrayData::Viewed(_) => {
+                // We cannot modify stats on a view
+            }
+        }
+    }
+}

--- a/vortex-array/src/data/viewed.rs
+++ b/vortex-array/src/data/viewed.rs
@@ -24,7 +24,7 @@ pub(super) struct ViewedArrayData {
     pub(super) metadata: Arc<dyn ArrayMetadata>,
     pub(super) flatbuffer: FlatBuffer,
     pub(super) flatbuffer_loc: usize,
-    pub(super) buffers: Arc<[ByteBuffer]>,
+    pub(super) buffers: Box<[ByteBuffer]>,
     pub(super) ctx: ContextRef,
     #[cfg(feature = "canonical_counter")]
     pub(super) canonical_counter: Arc<std::sync::atomic::AtomicUsize>,
@@ -80,7 +80,7 @@ impl ViewedArrayData {
             buffers: self.buffers.clone(),
             ctx: self.ctx.clone(),
             #[cfg(feature = "canonical_counter")]
-            canonical_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            canonical_counter: std::sync::atomic::AtomicUsize::new(0),
         })
     }
 

--- a/vortex-array/src/data/viewed.rs
+++ b/vortex-array/src/data/viewed.rs
@@ -1,22 +1,17 @@
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
-use enum_iterator::all;
 use flatbuffers::Follow;
-use itertools::Itertools;
 use vortex_buffer::ByteBuffer;
-use vortex_dtype::{DType, Nullability, PType};
-use vortex_error::{vortex_err, VortexExpect as _, VortexResult};
+use vortex_dtype::DType;
+use vortex_error::{vortex_err, VortexResult};
 use vortex_flatbuffers::FlatBuffer;
-use vortex_scalar::{Scalar, ScalarValue};
 
 use crate::encoding::opaque::OpaqueEncoding;
 use crate::encoding::EncodingRef;
-use crate::stats::{Stat, Statistics, StatsSet};
-use crate::{flatbuffers as fb, ArrayData, ArrayMetadata, ChildrenCollector, ContextRef};
+use crate::{flatbuffers as fb, ArrayMetadata, ContextRef};
 
 /// Zero-copy view over flatbuffer-encoded array data, created without eager serialization.
-#[derive(Clone)]
 pub(super) struct ViewedArrayData {
     pub(super) encoding: EncodingRef,
     pub(super) dtype: DType,
@@ -27,7 +22,7 @@ pub(super) struct ViewedArrayData {
     pub(super) buffers: Box<[ByteBuffer]>,
     pub(super) ctx: ContextRef,
     #[cfg(feature = "canonical_counter")]
-    pub(super) canonical_counter: Arc<std::sync::atomic::AtomicUsize>,
+    pub(super) canonical_counter: std::sync::atomic::AtomicUsize,
 }
 
 impl Debug for ViewedArrayData {
@@ -93,14 +88,6 @@ impl ViewedArrayData {
         self.flatbuffer().children().map(|c| c.len()).unwrap_or(0)
     }
 
-    pub fn children(&self) -> Vec<ArrayData> {
-        let mut collector = ChildrenCollector::default();
-        self.encoding
-            .accept(&ArrayData::from(self.clone()), &mut collector)
-            .vortex_expect("Failed to get children");
-        collector.children()
-    }
-
     pub fn nbuffers(&self) -> usize {
         self.flatbuffer()
             .buffers()
@@ -119,92 +106,5 @@ impl ViewedArrayData {
                 buffers.get(index) as usize
             })
             .map(|idx| &self.buffers[idx])
-    }
-}
-
-impl Statistics for ViewedArrayData {
-    fn get(&self, stat: Stat) -> Option<Scalar> {
-        match stat {
-            Stat::Max => {
-                let max = self.flatbuffer().stats()?.max();
-                max.and_then(|v| ScalarValue::try_from(v).ok())
-                    .map(|v| Scalar::new(self.dtype.clone(), v))
-            }
-            Stat::Min => {
-                let min = self.flatbuffer().stats()?.min();
-                min.and_then(|v| ScalarValue::try_from(v).ok())
-                    .map(|v| Scalar::new(self.dtype.clone(), v))
-            }
-            Stat::IsConstant => self.flatbuffer().stats()?.is_constant().map(bool::into),
-            Stat::IsSorted => self.flatbuffer().stats()?.is_sorted().map(bool::into),
-            Stat::IsStrictSorted => self
-                .flatbuffer()
-                .stats()?
-                .is_strict_sorted()
-                .map(bool::into),
-            Stat::RunCount => self.flatbuffer().stats()?.run_count().map(u64::into),
-            Stat::TrueCount => self.flatbuffer().stats()?.true_count().map(u64::into),
-            Stat::NullCount => self.flatbuffer().stats()?.null_count().map(u64::into),
-            Stat::BitWidthFreq => {
-                let element_dtype =
-                    Arc::new(DType::Primitive(PType::U64, Nullability::NonNullable));
-                self.flatbuffer()
-                    .stats()?
-                    .bit_width_freq()
-                    .map(|v| v.iter().map(Scalar::from).collect_vec())
-                    .map(|v| Scalar::list(element_dtype, v, Nullability::NonNullable))
-            }
-            Stat::TrailingZeroFreq => self
-                .flatbuffer()
-                .stats()?
-                .trailing_zero_freq()
-                .map(|v| v.iter().collect_vec())
-                .map(|v| v.into()),
-            Stat::UncompressedSizeInBytes => self
-                .flatbuffer()
-                .stats()?
-                .uncompressed_size_in_bytes()
-                .map(u64::into),
-        }
-    }
-
-    /// NB: part of the contract for to_set is that it does not do any expensive computation.
-    /// In other implementations, this means returning the underlying stats map, but for the flatbuffer
-    /// implementation, we have 'precalculated' stats in the flatbuffer itself, so we need to
-    /// allocate a stats map and populate it with those fields.
-    fn to_set(&self) -> StatsSet {
-        let mut result = StatsSet::default();
-        for stat in all::<Stat>() {
-            if let Some(value) = self.get(stat) {
-                result.set(stat, value)
-            }
-        }
-        result
-    }
-
-    /// We want to avoid any sort of allocation on instantiation of the ArrayView, so we
-    /// do not allocate a stats_set to cache values.
-    fn set(&self, _stat: Stat, _value: Scalar) {
-        // We cannot modify stats on a view
-    }
-
-    fn clear(&self, _stat: Stat) {
-        // We cannot modify stats on a view
-    }
-
-    fn retain_only(&self, _stats: &[Stat]) {
-        // We cannot modify stats on a view
-    }
-
-    fn compute(&self, stat: Stat) -> Option<Scalar> {
-        if let Some(s) = self.get(stat) {
-            return Some(s);
-        }
-
-        self.encoding
-            .compute_statistics(&ArrayData::from(self.clone()), stat)
-            .ok()?
-            .get(stat)
-            .cloned()
     }
 }

--- a/vortex-array/src/macros.rs
+++ b/vortex-array/src/macros.rs
@@ -46,7 +46,7 @@ macro_rules! impl_encoding {
                     dtype: vortex_dtype::DType,
                     len: usize,
                     metadata: [<$Name Metadata>],
-                    children: std::sync::Arc<[$crate::ArrayData]>,
+                    children: Box<[$crate::ArrayData]>,
                     stats: $crate::stats::StatsSet,
                 ) -> VortexResult<Self> {
                     Self::try_from($crate::ArrayData::try_new_owned(

--- a/vortex-array/src/stats/statsset.rs
+++ b/vortex-array/src/stats/statsset.rs
@@ -188,12 +188,16 @@ impl IntoIterator for StatsSet {
     }
 }
 
+impl FromIterator<(Stat, Scalar)> for StatsSet {
+    fn from_iter<T: IntoIterator<Item = (Stat, Scalar)>>(iter: T) -> Self {
+        Self::new_unchecked(iter.into_iter().collect())
+    }
+}
+
 impl Extend<(Stat, Scalar)> for StatsSet {
     #[inline]
     fn extend<T: IntoIterator<Item = (Stat, Scalar)>>(&mut self, iter: T) {
-        iter.into_iter().for_each(|(stat, scalar)| {
-            self.set(stat, scalar);
-        });
+        self.values.extend(iter);
     }
 }
 

--- a/vortex-array/src/stats/statsset.rs
+++ b/vortex-array/src/stats/statsset.rs
@@ -190,14 +190,23 @@ impl IntoIterator for StatsSet {
 
 impl FromIterator<(Stat, Scalar)> for StatsSet {
     fn from_iter<T: IntoIterator<Item = (Stat, Scalar)>>(iter: T) -> Self {
-        Self::new_unchecked(iter.into_iter().collect())
+        let iter = iter.into_iter();
+        let (lower_bound, _) = iter.size_hint();
+        let mut this = Self {
+            values: Vec::with_capacity(lower_bound),
+        };
+        this.extend(iter);
+        this
     }
 }
 
 impl Extend<(Stat, Scalar)> for StatsSet {
     #[inline]
     fn extend<T: IntoIterator<Item = (Stat, Scalar)>>(&mut self, iter: T) {
-        self.values.extend(iter);
+        let iter = iter.into_iter();
+        let (lower_bound, _) = iter.size_hint();
+        self.values.reserve(lower_bound);
+        iter.for_each(|(stat, value)| self.set(stat, value));
     }
 }
 

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -75,7 +75,7 @@ pub trait VortexExpr: Debug + Send + Sync + DynEq + DynHash + Display {
     fn return_dtype(&self, scope_dtype: &DType) -> VortexResult<DType> {
         let empty = Canonical::empty(scope_dtype)?.into_array();
         self.unchecked_evaluate(&empty)
-            .map(|array| array.into_dtype())
+            .map(|array| array.dtype().clone())
     }
 }
 


### PR DESCRIPTION
Closes #1518

WeakArrayData will be used for weak caching during scans.

This also impls Statistics directly on ArrayData so we don't have to clone in order to compute them. It also means we can remove Clone from InnerArrayData and remove a couple more Arcs.