### PR TITLE
Fix: Only construct StructReader field_lookup when there's more than 80 fields

### DIFF
--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -1,7 +1,10 @@
 use std::hash::Hash;
 use std::sync::{Arc, OnceLock, RwLock};
 
+<<<<<<< HEAD
 use vortex_array::aliases::hash_map::{Entry, HashMap};
+=======
+>>>>>>> bb1760c0c (Fix: Remove StructReader field_lookup)
 use vortex_array::ContextRef;
 use vortex_dtype::{DType, FieldName, StructDType};
 use vortex_error::{vortex_err, vortex_panic, VortexExpect, VortexResult};
@@ -20,8 +23,7 @@ pub struct StructReader {
     segments: Arc<dyn AsyncSegmentReader>,
 
     field_readers: Arc<[OnceLock<Arc<dyn LayoutReader>>]>,
-    field_lookup: HashMap<FieldName, usize>,
-
+    field_lookup: Option<HashMap<FieldName, usize>>,
     expr_cache: Arc<RwLock<HashMap<ExactExpr, Arc<PartitionedExpr>>>>,
 }
 
@@ -40,14 +42,7 @@ impl StructReader {
             vortex_panic!("Mismatched dtype {} for struct layout", dtype);
         };
 
-        let field_readers = struct_dt.names().iter().map(|_| OnceLock::new()).collect();
-
-        let field_lookup = struct_dt
-            .names()
-            .iter()
-            .enumerate()
-            .map(|(i, name)| (name.clone(), i))
-            .collect();
+        let field_readers = (0..layout.nchildren()).map(|_| OnceLock::new()).collect();
 
         // This is where we need to do some complex things with the scan in order to split it into
         // different scans for different fields.
@@ -70,9 +65,9 @@ impl StructReader {
 
     /// Return the child reader for the chunk.
     pub(crate) fn child(&self, name: &FieldName) -> VortexResult<&Arc<dyn LayoutReader>> {
-        let idx = *self
-            .field_lookup
-            .get(name)
+        let idx = self
+            .struct_dtype()
+            .find_name(name)
             .ok_or_else(|| vortex_err!("Field {} not found in struct layout", name))?;
 
         // TODO: think about a Hashmap<FieldName, OnceLock<Arc<dyn LayoutReader>>> for large |fields|.

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -2,9 +2,13 @@ use std::hash::Hash;
 use std::sync::{Arc, OnceLock, RwLock};
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 use vortex_array::aliases::hash_map::{Entry, HashMap};
 =======
 >>>>>>> bb1760c0c (Fix: Remove StructReader field_lookup)
+=======
+use vortex_array::aliases::hash_map::HashMap;
+>>>>>>> 83bacebab (arbitrary)
 use vortex_array::ContextRef;
 use vortex_dtype::{DType, FieldName, StructDType};
 use vortex_error::{vortex_err, vortex_panic, VortexExpect, VortexResult};
@@ -44,6 +48,12 @@ impl StructReader {
 
         let field_readers = (0..layout.nchildren()).map(|_| OnceLock::new()).collect();
 
+        let field_lookup = if layout.nchildren() > 80 {
+            Some(struct_dt.names().iter().enumerate().collect())
+        } else {
+            None
+        };
+
         // This is where we need to do some complex things with the scan in order to split it into
         // different scans for different fields.
         Ok(Self {
@@ -66,8 +76,10 @@ impl StructReader {
     /// Return the child reader for the chunk.
     pub(crate) fn child(&self, name: &FieldName) -> VortexResult<&Arc<dyn LayoutReader>> {
         let idx = self
-            .struct_dtype()
-            .find_name(name)
+            .field_lookup
+            .as_ref()
+            .and_then(|lookup| lookup.get(name).copied())
+            .or_else(|| self.struct_dtype().find_name(name))
             .ok_or_else(|| vortex_err!("Field {} not found in struct layout", name))?;
 
         // TODO: think about a Hashmap<FieldName, OnceLock<Arc<dyn LayoutReader>>> for large |fields|.

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -1,14 +1,7 @@
 use std::hash::Hash;
 use std::sync::{Arc, OnceLock, RwLock};
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 use vortex_array::aliases::hash_map::{Entry, HashMap};
-=======
->>>>>>> bb1760c0c (Fix: Remove StructReader field_lookup)
-=======
-use vortex_array::aliases::hash_map::HashMap;
->>>>>>> 83bacebab (arbitrary)
 use vortex_array::ContextRef;
 use vortex_dtype::{DType, FieldName, StructDType};
 use vortex_error::{vortex_err, vortex_panic, VortexExpect, VortexResult};
@@ -48,11 +41,15 @@ impl StructReader {
 
         let field_readers = (0..layout.nchildren()).map(|_| OnceLock::new()).collect();
 
-        let field_lookup = if layout.nchildren() > 80 {
-            Some(struct_dt.names().iter().enumerate().collect())
-        } else {
-            None
-        };
+        // NOTE: This number is arbitrary and likely depends on the longest common prefix of field names
+        let field_lookup = (layout.nchildren() > 80).then(|| {
+            struct_dt
+                .names()
+                .iter()
+                .enumerate()
+                .map(|(i, n)| (n.clone(), i))
+                .collect()
+        });
 
         // This is where we need to do some complex things with the scan in order to split it into
         // different scans for different fields.


### PR DESCRIPTION
80 is an arbitrary number and we should tune it