### PR TITLE
fix: ExtDType equality

### DIFF
--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -111,11 +111,7 @@ impl DType {
             }
             (Struct(..), _) => false,
             (Extension(lhs_extdtype), Extension(rhs_extdtype)) => {
-                lhs_extdtype.id() == rhs_extdtype.id()
-                    && lhs_extdtype.metadata() == rhs_extdtype.metadata()
-                    && lhs_extdtype
-                        .storage_dtype()
-                        .eq_ignore_nullability(rhs_extdtype.storage_dtype())
+                lhs_extdtype.as_ref().eq_ignore_nullability(&rhs_extdtype)
             }
             (Extension(_), _) => false,
         }

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -110,7 +110,12 @@ impl DType {
                         .all(|(l, r)| l.eq_ignore_nullability(&r)))
             }
             (Struct(..), _) => false,
-            (Extension(lhs_extdtype), Extension(rhs_extdtype)) => lhs_extdtype == rhs_extdtype,
+            (Extension(lhs_extdtype), Extension(rhs_extdtype)) => {
+                lhs_extdtype.id() == rhs_extdtype.id()
+                    && lhs_extdtype
+                        .storage_dtype()
+                        .eq_ignore_nullability(rhs_extdtype.storage_dtype())
+            }
             (Extension(_), _) => false,
         }
     }

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -112,6 +112,7 @@ impl DType {
             (Struct(..), _) => false,
             (Extension(lhs_extdtype), Extension(rhs_extdtype)) => {
                 lhs_extdtype.id() == rhs_extdtype.id()
+                    && lhs_extdtype.metadata() == rhs_extdtype.metadata()
                     && lhs_extdtype
                         .storage_dtype()
                         .eq_ignore_nullability(rhs_extdtype.storage_dtype())

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -111,7 +111,7 @@ impl DType {
             }
             (Struct(..), _) => false,
             (Extension(lhs_extdtype), Extension(rhs_extdtype)) => {
-                lhs_extdtype.as_ref().eq_ignore_nullability(&rhs_extdtype)
+                lhs_extdtype.as_ref().eq_ignore_nullability(rhs_extdtype)
             }
             (Extension(_), _) => false,
         }

--- a/vortex-dtype/src/extension.rs
+++ b/vortex-dtype/src/extension.rs
@@ -58,25 +58,12 @@ impl From<&[u8]> for ExtMetadata {
 }
 
 /// A type descriptor for an extension type
-#[derive(Debug, Clone, PartialOrd, Eq)]
+#[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExtDType {
     id: ExtID,
     storage_dtype: Arc<DType>,
     metadata: Option<ExtMetadata>,
-}
-
-impl PartialEq for ExtDType {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id && self.storage_dtype == other.storage_dtype
-    }
-}
-
-impl std::hash::Hash for ExtDType {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.id.hash(state);
-        self.storage_dtype.hash(state);
-    }
 }
 
 impl ExtDType {

--- a/vortex-dtype/src/extension.rs
+++ b/vortex-dtype/src/extension.rs
@@ -68,13 +68,14 @@ pub struct ExtDType {
 
 impl PartialEq for ExtDType {
     fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
+        self.id == other.id && self.storage_dtype == other.storage_dtype
     }
 }
 
 impl std::hash::Hash for ExtDType {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.id.hash(state);
+        self.storage_dtype.hash(state);
     }
 }
 

--- a/vortex-dtype/src/extension.rs
+++ b/vortex-dtype/src/extension.rs
@@ -136,4 +136,13 @@ impl ExtDType {
     pub fn metadata(&self) -> Option<&ExtMetadata> {
         self.metadata.as_ref()
     }
+
+    /// Check if `self` and `other` are equal, ignoring the storage nullability
+    pub fn eq_ignore_nullability(&self, other: &Self) -> bool {
+        self.id() == other.id()
+            && self.metadata() == other.metadata()
+            && self
+                .storage_dtype()
+                .eq_ignore_nullability(other.storage_dtype())
+    }
 }


### PR DESCRIPTION
Trying to better "adhere" to the [Arrow behavior](https://arrow.apache.org/docs/python/extending_types.html#defining-extension-types-user-defined-types).