### PR TITLE
Improvement: Optimize RunEnd array filter for sparse masks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5255,6 +5255,7 @@ name = "vortex-runend"
 version = "0.21.1"
 dependencies = [
  "arrow-buffer",
+ "criterion",
  "itertools 0.14.0",
  "num-traits",
  "serde",

--- a/encodings/runend/Cargo.toml
+++ b/encodings/runend/Cargo.toml
@@ -24,8 +24,14 @@ vortex-dtype = { workspace = true }
 vortex-error = { workspace = true }
 vortex-scalar = { workspace = true }
 
-[dev-dependencies]
-vortex-array = { workspace = true, features = ["test-harness"] }
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+vortex-array = { workspace = true, features = ["test-harness"] }
+criterion = { workspace = true }
+
+[[bench]]
+name = "run_end_filter"
+harness = false

--- a/encodings/runend/benches/run_end_filter.rs
+++ b/encodings/runend/benches/run_end_filter.rs
@@ -3,6 +3,7 @@
 use std::iter::Iterator;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use num_traits::ToPrimitive;
 use vortex_array::compute::FilterMask;
 use vortex_array::{ArrayLen, IntoArrayData};
 use vortex_buffer::Buffer;
@@ -39,7 +40,12 @@ fn evenly_spaced(c: &mut Criterion) {
                     // In this case, the benchmarks don't seem to change whether we evenly spread
                     // the mask values or like here we pack them into the beginning of the mask.
                     (0..array.len())
-                        .take((filter_density * array.len() as f64).round() as usize)
+                        .take(
+                            (filter_density * array.len() as f64)
+                                .round()
+                                .to_usize()
+                                .unwrap(),
+                        )
                         .collect(),
                 );
 

--- a/encodings/runend/benches/run_end_filter.rs
+++ b/encodings/runend/benches/run_end_filter.rs
@@ -1,0 +1,86 @@
+#![allow(clippy::unwrap_used)]
+
+use std::iter::Iterator;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use vortex_array::compute::FilterMask;
+use vortex_array::{ArrayLen, IntoArrayData};
+use vortex_buffer::Buffer;
+use vortex_runend::RunEndArray;
+use vortex_runend::_benchmarking::{filter_run_end, take_indices_unchecked};
+
+const LENS: [usize; 2] = [1000, 100_000];
+
+fn run_end_filter(c: &mut Criterion) {
+    evenly_spaced(c);
+}
+
+/// Create RunEnd arrays where the runs are equal size, and the filter mask is evenly spaced.
+fn evenly_spaced(c: &mut Criterion) {
+    let mut group = c.benchmark_group("evenly_spaced");
+
+    for &n in LENS.iter().rev() {
+        for run_step in [1usize << 2, 1 << 4, 1 << 8, 1 << 16] {
+            let ends = (0..=n)
+                .step_by(run_step)
+                .map(|x| x as u64)
+                .collect::<Buffer<_>>()
+                .into_array();
+            let run_count = ends.len() - 1;
+            let values = (0..ends.len())
+                .map(|x| x as u64)
+                .collect::<Buffer<_>>()
+                .into_array();
+            let array = RunEndArray::try_new(ends, values).unwrap();
+
+            for filter_density in [0.001, 0.01, 0.015, 0.020, 0.025, 0.030] {
+                let mask = FilterMask::from_indices(
+                    array.len(),
+                    // In this case, the benchmarks don't seem to change whether we evenly spread
+                    // the mask values or like here we pack them into the beginning of the mask.
+                    (0..array.len())
+                        .take((filter_density * array.len() as f64).round() as usize)
+                        .collect(),
+                );
+
+                if mask.true_count() == 0 {
+                    // Can skip these
+                    continue;
+                }
+
+                // Compute the ratio of true_count to run_count
+                let ratio = mask.true_count() as f64 / run_count as f64;
+
+                group.bench_function(
+                    format!(
+                        "take_indices n: {}, run_count: {}, true_count: {}, ratio: {}",
+                        n,
+                        run_count,
+                        mask.true_count(),
+                        ratio
+                    ),
+                    |b| {
+                        b.iter(|| {
+                            black_box(take_indices_unchecked(&array, mask.indices()).unwrap())
+                        });
+                    },
+                );
+                group.bench_function(
+                    format!(
+                        "filter_run_end n: {}, run_count: {}, true_count: {}, ratio: {}",
+                        n,
+                        run_count,
+                        mask.true_count(),
+                        ratio
+                    ),
+                    |b| {
+                        b.iter(|| black_box(filter_run_end(&array, &mask).unwrap()));
+                    },
+                );
+            }
+        }
+    }
+}
+
+criterion_group!(benches, run_end_filter);
+criterion_main!(benches);

--- a/encodings/runend/src/compute/binary_numeric.rs
+++ b/encodings/runend/src/compute/binary_numeric.rs
@@ -29,3 +29,25 @@ impl BinaryNumericFn<RunEndArray> for RunEndEncoding {
         .map(Some)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use vortex_array::array::PrimitiveArray;
+    use vortex_array::compute::test_harness::test_binary_numeric;
+    use vortex_array::{IntoArrayData, ToArrayData};
+
+    use crate::RunEndArray;
+
+    fn ree_array() -> RunEndArray {
+        RunEndArray::encode(
+            PrimitiveArray::from_iter([1, 1, 1, 4, 4, 4, 2, 2, 5, 5, 5, 5]).to_array(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_runend_binary_numeric() {
+        let array = ree_array().into_array();
+        test_binary_numeric::<i32>(array)
+    }
+}

--- a/encodings/runend/src/compute/compare.rs
+++ b/encodings/runend/src/compute/compare.rs
@@ -38,11 +38,18 @@ impl CompareFn<RunEndArray> for RunEndEncoding {
 }
 #[cfg(test)]
 mod test {
-    use vortex_array::array::{BooleanBuffer, ConstantArray};
+    use vortex_array::array::{BooleanBuffer, ConstantArray, PrimitiveArray};
     use vortex_array::compute::{compare, Operator};
-    use vortex_array::IntoArrayVariant;
+    use vortex_array::{IntoArrayVariant, ToArrayData};
 
-    use crate::compute::test::ree_array;
+    use crate::RunEndArray;
+
+    fn ree_array() -> RunEndArray {
+        RunEndArray::encode(
+            PrimitiveArray::from_iter([1, 1, 1, 4, 4, 4, 2, 2, 5, 5, 5, 5]).to_array(),
+        )
+        .unwrap()
+    }
 
     #[test]
     fn compare_run_end() {

--- a/encodings/runend/src/compute/filter.rs
+++ b/encodings/runend/src/compute/filter.rs
@@ -15,17 +15,21 @@ use vortex_error::{VortexResult, VortexUnwrap};
 use crate::compute::take::take_indices_unchecked;
 use crate::{RunEndArray, RunEndEncoding};
 
-const FILTER_TAKE_THRESHOLD: f64 = 0.001;
+const FILTER_TAKE_THRESHOLD: f64 = 0.1;
 
 impl FilterFn<RunEndArray> for RunEndEncoding {
     fn filter(&self, array: &RunEndArray, mask: &FilterMask) -> VortexResult<ArrayData> {
-        // If we are taking less than 0.1% of values use take
-        if mask.selectivity() < FILTER_TAKE_THRESHOLD {
+        let runs_ratio = mask.true_count() as f64 / array.ends().len() as f64;
+
+        if runs_ratio < FILTER_TAKE_THRESHOLD || mask.true_count() < 25 {
+            // This strategy is directly proportional to the number of indices.
             take_indices_unchecked(array, mask.indices())
         } else {
+            // This strategy ends up being close to fixed cost based on the number of runs,
+            // rather than the number of indices.
             let primitive_run_ends = array.ends().into_primitive()?;
             let (run_ends, values_mask) = match_each_unsigned_integer_ptype!(primitive_run_ends.ptype(), |$P| {
-                filter_run_ends(primitive_run_ends.as_slice::<$P>(), array.offset() as u64, array.len() as u64, mask)?
+                filter_run_end_primitive(primitive_run_ends.as_slice::<$P>(), array.offset() as u64, array.len() as u64, mask)?
             });
             let values = filter(&array.values(), &values_mask)?;
 
@@ -34,8 +38,19 @@ impl FilterFn<RunEndArray> for RunEndEncoding {
     }
 }
 
+// We expose this function to our benchmarks.
+pub fn filter_run_end(array: &RunEndArray, mask: &FilterMask) -> VortexResult<ArrayData> {
+    let primitive_run_ends = array.ends().into_primitive()?;
+    let (run_ends, values_mask) = match_each_unsigned_integer_ptype!(primitive_run_ends.ptype(), |$P| {
+        filter_run_end_primitive(primitive_run_ends.as_slice::<$P>(), array.offset() as u64, array.len() as u64, mask)?
+    });
+    let values = filter(&array.values(), &values_mask)?;
+
+    RunEndArray::try_new(run_ends.into_array(), values).map(|a| a.into_array())
+}
+
 // Code adapted from apache arrow-rs https://github.com/apache/arrow-rs/blob/b1f5c250ebb6c1252b4e7c51d15b8e77f4c361fa/arrow-select/src/filter.rs#L425
-fn filter_run_ends<R: NativePType + AddAssign + From<bool> + AsPrimitive<u64>>(
+fn filter_run_end_primitive<R: NativePType + AddAssign + From<bool> + AsPrimitive<u64>>(
     run_ends: &[R],
     offset: u64,
     length: u64,

--- a/encodings/runend/src/compute/filter.rs
+++ b/encodings/runend/src/compute/filter.rs
@@ -1,0 +1,150 @@
+use std::cmp::min;
+use std::ops::AddAssign;
+
+use arrow_buffer::BooleanBuffer;
+use num_traits::AsPrimitive;
+use vortex_array::array::PrimitiveArray;
+use vortex_array::compute::{filter, FilterFn, FilterMask};
+use vortex_array::validity::Validity;
+use vortex_array::variants::PrimitiveArrayTrait;
+use vortex_array::{ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
+use vortex_buffer::buffer_mut;
+use vortex_dtype::{match_each_unsigned_integer_ptype, NativePType};
+use vortex_error::{VortexResult, VortexUnwrap};
+
+use crate::compute::take::take_indices_unchecked;
+use crate::{RunEndArray, RunEndEncoding};
+
+const FILTER_TAKE_THRESHOLD: f64 = 0.001;
+
+impl FilterFn<RunEndArray> for RunEndEncoding {
+    fn filter(&self, array: &RunEndArray, mask: &FilterMask) -> VortexResult<ArrayData> {
+        // If we are taking less than 0.1% of values use take
+        if mask.selectivity() < FILTER_TAKE_THRESHOLD {
+            take_indices_unchecked(array, mask.indices())
+        } else {
+            let primitive_run_ends = array.ends().into_primitive()?;
+            let (run_ends, values_mask) = match_each_unsigned_integer_ptype!(primitive_run_ends.ptype(), |$P| {
+                filter_run_ends(primitive_run_ends.as_slice::<$P>(), array.offset() as u64, array.len() as u64, mask)?
+            });
+            let values = filter(&array.values(), &values_mask)?;
+
+            RunEndArray::try_new(run_ends.into_array(), values).map(|a| a.into_array())
+        }
+    }
+}
+
+// Code adapted from apache arrow-rs https://github.com/apache/arrow-rs/blob/b1f5c250ebb6c1252b4e7c51d15b8e77f4c361fa/arrow-select/src/filter.rs#L425
+fn filter_run_ends<R: NativePType + AddAssign + From<bool> + AsPrimitive<u64>>(
+    run_ends: &[R],
+    offset: u64,
+    length: u64,
+    mask: &FilterMask,
+) -> VortexResult<(PrimitiveArray, FilterMask)> {
+    let mut new_run_ends = buffer_mut![R::zero(); run_ends.len()];
+
+    let mut start = 0u64;
+    let mut j = 0;
+    let mut count = R::zero();
+    let filter_values = mask.boolean_buffer();
+
+    let new_mask: FilterMask = BooleanBuffer::collect_bool(run_ends.len(), |i| {
+        let mut keep = false;
+        let end = min(run_ends[i].as_() - offset, length);
+
+        // Safety: predicate must be the same length as the array the ends have been taken from
+        for pred in (start..end)
+            .map(|i| unsafe { filter_values.value_unchecked(i.try_into().vortex_unwrap()) })
+        {
+            count += <R as From<bool>>::from(pred);
+            keep |= pred
+        }
+        // this is to avoid branching
+        new_run_ends[j] = count;
+        j += keep as usize;
+
+        start = end;
+        keep
+    })
+    .into();
+
+    new_run_ends.truncate(j);
+    Ok((
+        PrimitiveArray::new(new_run_ends, Validity::NonNullable),
+        new_mask,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_array::array::PrimitiveArray;
+    use vortex_array::compute::{filter, slice, FilterMask};
+    use vortex_array::{IntoArrayVariant, ToArrayData};
+
+    use crate::RunEndArray;
+
+    fn ree_array() -> RunEndArray {
+        RunEndArray::encode(
+            PrimitiveArray::from_iter([1, 1, 1, 4, 4, 4, 2, 2, 5, 5, 5, 5]).to_array(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn filter_run_end() {
+        let arr = ree_array();
+        let filtered = filter(
+            arr.as_ref(),
+            &FilterMask::from_iter([
+                true, true, false, false, false, false, false, false, false, false, true, true,
+            ]),
+        )
+        .unwrap();
+        let filtered_run_end = RunEndArray::try_from(filtered).unwrap();
+
+        assert_eq!(
+            filtered_run_end
+                .ends()
+                .into_primitive()
+                .unwrap()
+                .as_slice::<u64>(),
+            [2, 4]
+        );
+        assert_eq!(
+            filtered_run_end
+                .values()
+                .into_primitive()
+                .unwrap()
+                .as_slice::<i32>(),
+            [1, 5]
+        );
+    }
+
+    #[test]
+    fn filter_sliced_run_end() {
+        let arr = slice(ree_array(), 2, 7).unwrap();
+        let filtered = filter(
+            &arr,
+            &FilterMask::from_iter([true, false, false, true, true]),
+        )
+        .unwrap();
+        let filtered_run_end = RunEndArray::try_from(filtered).unwrap();
+
+        assert_eq!(
+            filtered_run_end
+                .ends()
+                .into_primitive()
+                .unwrap()
+                .as_slice::<u64>(),
+            [1, 2, 3]
+        );
+        assert_eq!(
+            filtered_run_end
+                .values()
+                .into_primitive()
+                .unwrap()
+                .as_slice::<i32>(),
+            [1, 4, 2]
+        );
+    }
+}

--- a/encodings/runend/src/compute/filter.rs
+++ b/encodings/runend/src/compute/filter.rs
@@ -93,9 +93,10 @@ fn filter_run_end_primitive<R: NativePType + AddAssign + From<bool> + AsPrimitiv
 #[cfg(test)]
 mod tests {
     use vortex_array::array::PrimitiveArray;
-    use vortex_array::compute::{filter, slice, FilterMask};
+    use vortex_array::compute::{slice, FilterMask};
     use vortex_array::{IntoArrayVariant, ToArrayData};
 
+    use super::filter_run_end;
     use crate::RunEndArray;
 
     fn ree_array() -> RunEndArray {
@@ -106,16 +107,16 @@ mod tests {
     }
 
     #[test]
-    fn filter_run_end() {
+    fn run_end_filter() {
         let arr = ree_array();
-        let filtered = filter(
-            arr.as_ref(),
+        let filtered = filter_run_end(
+            &arr,
             &FilterMask::from_iter([
                 true, true, false, false, false, false, false, false, false, false, true, true,
             ]),
         )
         .unwrap();
-        let filtered_run_end = RunEndArray::try_from(filtered).unwrap();
+        let filtered_run_end = RunEndArray::maybe_from(filtered).unwrap();
 
         assert_eq!(
             filtered_run_end
@@ -138,8 +139,8 @@ mod tests {
     #[test]
     fn filter_sliced_run_end() {
         let arr = slice(ree_array(), 2, 7).unwrap();
-        let filtered = filter(
-            &arr,
+        let filtered = filter_run_end(
+            &RunEndArray::maybe_from(arr).unwrap(),
             &FilterMask::from_iter([true, false, false, true, true]),
         )
         .unwrap();

--- a/encodings/runend/src/compute/mod.rs
+++ b/encodings/runend/src/compute/mod.rs
@@ -1,27 +1,19 @@
 mod binary_numeric;
 mod compare;
 mod fill_null;
+mod filter;
 mod invert;
+mod scalar_at;
+mod slice;
 mod take;
 
-use std::cmp::min;
-use std::ops::AddAssign;
-
-use num_traits::AsPrimitive;
-use vortex_array::array::{BooleanBuffer, PrimitiveArray};
 use vortex_array::compute::{
-    filter, scalar_at, slice, BinaryNumericFn, CompareFn, ComputeVTable, FillNullFn, FilterFn,
-    FilterMask, InvertFn, ScalarAtFn, SliceFn, TakeFn,
+    BinaryNumericFn, CompareFn, ComputeVTable, FillNullFn, FilterFn, InvertFn, ScalarAtFn, SliceFn,
+    TakeFn,
 };
-use vortex_array::validity::Validity;
-use vortex_array::variants::PrimitiveArrayTrait;
-use vortex_array::{ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
-use vortex_buffer::buffer_mut;
-use vortex_dtype::{match_each_unsigned_integer_ptype, NativePType};
-use vortex_error::{VortexResult, VortexUnwrap};
-use vortex_scalar::Scalar;
+use vortex_array::ArrayData;
 
-use crate::{RunEndArray, RunEndEncoding};
+use crate::RunEndEncoding;
 
 impl ComputeVTable for RunEndEncoding {
     fn binary_numeric_fn(&self) -> Option<&dyn BinaryNumericFn<ArrayData>> {
@@ -57,278 +49,19 @@ impl ComputeVTable for RunEndEncoding {
     }
 }
 
-impl ScalarAtFn<RunEndArray> for RunEndEncoding {
-    fn scalar_at(&self, array: &RunEndArray, index: usize) -> VortexResult<Scalar> {
-        scalar_at(array.values(), array.find_physical_index(index)?)
-    }
-}
-
-impl SliceFn<RunEndArray> for RunEndEncoding {
-    fn slice(&self, array: &RunEndArray, start: usize, stop: usize) -> VortexResult<ArrayData> {
-        let new_length = stop - start;
-
-        let (slice_begin, slice_end) = if new_length == 0 {
-            let values_len = array.values().len();
-            (values_len, values_len)
-        } else {
-            let physical_start = array.find_physical_index(start)?;
-            let physical_stop = array.find_physical_index(stop)?;
-
-            (physical_start, physical_stop + 1)
-        };
-
-        Ok(RunEndArray::with_offset_and_length(
-            slice(array.ends(), slice_begin, slice_end)?,
-            slice(array.values(), slice_begin, slice_end)?,
-            if new_length == 0 {
-                0
-            } else {
-                start + array.offset()
-            },
-            new_length,
-        )?
-        .into_array())
-    }
-}
-
-impl FilterFn<RunEndArray> for RunEndEncoding {
-    fn filter(&self, array: &RunEndArray, mask: &FilterMask) -> VortexResult<ArrayData> {
-        let primitive_run_ends = array.ends().into_primitive()?;
-        let (run_ends, values_mask) = match_each_unsigned_integer_ptype!(primitive_run_ends.ptype(), |$P| {
-            filter_run_ends(primitive_run_ends.as_slice::<$P>(), array.offset() as u64, array.len() as u64, mask)?
-        });
-        let values = filter(&array.values(), &values_mask)?;
-
-        RunEndArray::try_new(run_ends.into_array(), values).map(|a| a.into_array())
-    }
-}
-
-// Code adapted from apache arrow-rs https://github.com/apache/arrow-rs/blob/b1f5c250ebb6c1252b4e7c51d15b8e77f4c361fa/arrow-select/src/filter.rs#L425
-fn filter_run_ends<R: NativePType + AddAssign + From<bool> + AsPrimitive<u64>>(
-    run_ends: &[R],
-    offset: u64,
-    length: u64,
-    mask: &FilterMask,
-) -> VortexResult<(PrimitiveArray, FilterMask)> {
-    let mut new_run_ends = buffer_mut![R::zero(); run_ends.len()];
-
-    let mut start = 0u64;
-    let mut j = 0;
-    let mut count = R::zero();
-    let filter_values = mask.boolean_buffer();
-
-    let new_mask: FilterMask = BooleanBuffer::collect_bool(run_ends.len(), |i| {
-        let mut keep = false;
-        let end = min(run_ends[i].as_() - offset, length);
-
-        // Safety: predicate must be the same length as the array the ends have been taken from
-        for pred in (start..end)
-            .map(|i| unsafe { filter_values.value_unchecked(i.try_into().vortex_unwrap()) })
-        {
-            count += <R as From<bool>>::from(pred);
-            keep |= pred
-        }
-        // this is to avoid branching
-        new_run_ends[j] = count;
-        j += keep as usize;
-
-        start = end;
-        keep
-    })
-    .into();
-
-    new_run_ends.truncate(j);
-    Ok((
-        PrimitiveArray::new(new_run_ends, Validity::NonNullable),
-        new_mask,
-    ))
-}
-
 #[cfg(test)]
 mod test {
     use vortex_array::array::PrimitiveArray;
     use vortex_array::compute::test_harness::test_binary_numeric;
-    use vortex_array::compute::{filter, scalar_at, slice, FilterMask};
-    use vortex_array::{ArrayDType, ArrayLen, IntoArrayData, IntoArrayVariant, ToArrayData};
-    use vortex_buffer::buffer;
-    use vortex_dtype::{DType, Nullability, PType};
+    use vortex_array::{IntoArrayData, ToArrayData};
 
     use crate::RunEndArray;
 
-    pub(crate) fn ree_array() -> RunEndArray {
+    fn ree_array() -> RunEndArray {
         RunEndArray::encode(
             PrimitiveArray::from_iter([1, 1, 1, 4, 4, 4, 2, 2, 5, 5, 5, 5]).to_array(),
         )
         .unwrap()
-    }
-
-    #[test]
-    fn ree_scalar_at_end() {
-        let scalar = scalar_at(ree_array().as_ref(), 11).unwrap();
-        assert_eq!(scalar, 5.into());
-    }
-
-    #[test]
-    fn slice_array() {
-        let arr = slice(
-            RunEndArray::try_new(
-                buffer![2u32, 5, 10].into_array(),
-                buffer![1i32, 2, 3].into_array(),
-            )
-            .unwrap()
-            .as_ref(),
-            3,
-            8,
-        )
-        .unwrap();
-        assert_eq!(
-            arr.dtype(),
-            &DType::Primitive(PType::I32, Nullability::NonNullable)
-        );
-        assert_eq!(arr.len(), 5);
-
-        assert_eq!(
-            arr.into_primitive().unwrap().as_slice::<i32>(),
-            vec![2, 2, 3, 3, 3]
-        );
-    }
-
-    #[test]
-    fn double_slice() {
-        let arr = slice(
-            RunEndArray::try_new(
-                buffer![2u32, 5, 10].into_array(),
-                buffer![1i32, 2, 3].into_array(),
-            )
-            .unwrap()
-            .as_ref(),
-            3,
-            8,
-        )
-        .unwrap();
-        assert_eq!(arr.len(), 5);
-
-        let doubly_sliced = slice(&arr, 0, 3).unwrap();
-
-        assert_eq!(
-            doubly_sliced.into_primitive().unwrap().as_slice::<i32>(),
-            vec![2, 2, 3]
-        );
-    }
-
-    #[test]
-    fn slice_end_inclusive() {
-        let arr = slice(
-            RunEndArray::try_new(
-                buffer![2u32, 5, 10].into_array(),
-                buffer![1i32, 2, 3].into_array(),
-            )
-            .unwrap()
-            .as_ref(),
-            4,
-            10,
-        )
-        .unwrap();
-        assert_eq!(
-            arr.dtype(),
-            &DType::Primitive(PType::I32, Nullability::NonNullable)
-        );
-        assert_eq!(arr.len(), 6);
-
-        assert_eq!(
-            arr.into_primitive().unwrap().as_slice::<i32>(),
-            vec![2, 3, 3, 3, 3, 3]
-        );
-    }
-
-    #[test]
-    fn decompress() {
-        let arr = RunEndArray::try_new(
-            buffer![2u32, 5, 10].into_array(),
-            buffer![1i32, 2, 3].into_array(),
-        )
-        .unwrap();
-
-        assert_eq!(
-            arr.into_primitive().unwrap().as_slice::<i32>(),
-            vec![1, 1, 2, 2, 2, 3, 3, 3, 3, 3]
-        );
-    }
-
-    #[test]
-    fn slice_at_end() {
-        let re_array = RunEndArray::try_new(
-            buffer![7_u64, 10].into_array(),
-            buffer![2_u64, 3].into_array(),
-        )
-        .unwrap();
-
-        assert_eq!(re_array.len(), 10);
-
-        let sliced_array = slice(&re_array, re_array.len(), re_array.len()).unwrap();
-        assert!(sliced_array.is_empty());
-
-        let re_slice = RunEndArray::try_from(sliced_array).unwrap();
-        assert!(re_slice.ends().is_empty());
-        assert!(re_slice.values().is_empty())
-    }
-
-    #[test]
-    fn filter_run_end() {
-        let arr = ree_array();
-        let filtered = filter(
-            arr.as_ref(),
-            &FilterMask::from_iter([
-                true, true, false, false, false, false, false, false, false, false, true, true,
-            ]),
-        )
-        .unwrap();
-        let filtered_run_end = RunEndArray::try_from(filtered).unwrap();
-
-        assert_eq!(
-            filtered_run_end
-                .ends()
-                .into_primitive()
-                .unwrap()
-                .as_slice::<u64>(),
-            [2, 4]
-        );
-        assert_eq!(
-            filtered_run_end
-                .values()
-                .into_primitive()
-                .unwrap()
-                .as_slice::<i32>(),
-            [1, 5]
-        );
-    }
-
-    #[test]
-    fn filter_sliced_run_end() {
-        let arr = slice(ree_array(), 2, 7).unwrap();
-        let filtered = filter(
-            &arr,
-            &FilterMask::from_iter([true, false, false, true, true]),
-        )
-        .unwrap();
-        let filtered_run_end = RunEndArray::try_from(filtered).unwrap();
-
-        assert_eq!(
-            filtered_run_end
-                .ends()
-                .into_primitive()
-                .unwrap()
-                .as_slice::<u64>(),
-            [1, 2, 3]
-        );
-        assert_eq!(
-            filtered_run_end
-                .values()
-                .into_primitive()
-                .unwrap()
-                .as_slice::<i32>(),
-            [1, 4, 2]
-        );
     }
 
     #[test]

--- a/encodings/runend/src/compute/mod.rs
+++ b/encodings/runend/src/compute/mod.rs
@@ -1,11 +1,11 @@
 mod binary_numeric;
 mod compare;
 mod fill_null;
-mod filter;
+pub(crate) mod filter;
 mod invert;
 mod scalar_at;
 mod slice;
-mod take;
+pub(crate) mod take;
 
 use vortex_array::compute::{
     BinaryNumericFn, CompareFn, ComputeVTable, FillNullFn, FilterFn, InvertFn, ScalarAtFn, SliceFn,

--- a/encodings/runend/src/compute/scalar_at.rs
+++ b/encodings/runend/src/compute/scalar_at.rs
@@ -1,0 +1,34 @@
+use vortex_array::compute::{scalar_at, ScalarAtFn};
+use vortex_error::VortexResult;
+use vortex_scalar::Scalar;
+
+use crate::{RunEndArray, RunEndEncoding};
+
+impl ScalarAtFn<RunEndArray> for RunEndEncoding {
+    fn scalar_at(&self, array: &RunEndArray, index: usize) -> VortexResult<Scalar> {
+        scalar_at(array.values(), array.find_physical_index(index)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_array::array::PrimitiveArray;
+    use vortex_array::compute::scalar_at;
+    use vortex_array::ToArrayData;
+
+    use crate::RunEndArray;
+
+    #[test]
+    fn ree_scalar_at_end() {
+        let scalar = scalar_at(
+            RunEndArray::encode(
+                PrimitiveArray::from_iter([1, 1, 1, 4, 4, 4, 2, 2, 5, 5, 5, 5]).to_array(),
+            )
+            .unwrap()
+            .as_ref(),
+            11,
+        )
+        .unwrap();
+        assert_eq!(scalar, 5.into());
+    }
+}

--- a/encodings/runend/src/compute/slice.rs
+++ b/encodings/runend/src/compute/slice.rs
@@ -1,0 +1,134 @@
+use vortex_array::compute::{slice, SliceFn};
+use vortex_array::{ArrayData, IntoArrayData};
+use vortex_error::VortexResult;
+
+use crate::{RunEndArray, RunEndEncoding};
+
+impl SliceFn<RunEndArray> for RunEndEncoding {
+    fn slice(&self, array: &RunEndArray, start: usize, stop: usize) -> VortexResult<ArrayData> {
+        let new_length = stop - start;
+
+        let (slice_begin, slice_end) = if new_length == 0 {
+            let values_len = array.values().len();
+            (values_len, values_len)
+        } else {
+            let physical_start = array.find_physical_index(start)?;
+            let physical_stop = array.find_physical_index(stop)?;
+
+            (physical_start, physical_stop + 1)
+        };
+
+        Ok(RunEndArray::with_offset_and_length(
+            slice(array.ends(), slice_begin, slice_end)?,
+            slice(array.values(), slice_begin, slice_end)?,
+            if new_length == 0 {
+                0
+            } else {
+                start + array.offset()
+            },
+            new_length,
+        )?
+        .into_array())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_array::compute::slice;
+    use vortex_array::{ArrayDType, ArrayLen, IntoArrayData, IntoArrayVariant};
+    use vortex_buffer::buffer;
+    use vortex_dtype::{DType, Nullability, PType};
+
+    use crate::RunEndArray;
+
+    #[test]
+    fn slice_array() {
+        let arr = slice(
+            RunEndArray::try_new(
+                buffer![2u32, 5, 10].into_array(),
+                buffer![1i32, 2, 3].into_array(),
+            )
+            .unwrap()
+            .as_ref(),
+            3,
+            8,
+        )
+        .unwrap();
+        assert_eq!(
+            arr.dtype(),
+            &DType::Primitive(PType::I32, Nullability::NonNullable)
+        );
+        assert_eq!(arr.len(), 5);
+
+        assert_eq!(
+            arr.into_primitive().unwrap().as_slice::<i32>(),
+            vec![2, 2, 3, 3, 3]
+        );
+    }
+
+    #[test]
+    fn double_slice() {
+        let arr = slice(
+            RunEndArray::try_new(
+                buffer![2u32, 5, 10].into_array(),
+                buffer![1i32, 2, 3].into_array(),
+            )
+            .unwrap()
+            .as_ref(),
+            3,
+            8,
+        )
+        .unwrap();
+        assert_eq!(arr.len(), 5);
+
+        let doubly_sliced = slice(&arr, 0, 3).unwrap();
+
+        assert_eq!(
+            doubly_sliced.into_primitive().unwrap().as_slice::<i32>(),
+            vec![2, 2, 3]
+        );
+    }
+
+    #[test]
+    fn slice_end_inclusive() {
+        let arr = slice(
+            RunEndArray::try_new(
+                buffer![2u32, 5, 10].into_array(),
+                buffer![1i32, 2, 3].into_array(),
+            )
+            .unwrap()
+            .as_ref(),
+            4,
+            10,
+        )
+        .unwrap();
+        assert_eq!(
+            arr.dtype(),
+            &DType::Primitive(PType::I32, Nullability::NonNullable)
+        );
+        assert_eq!(arr.len(), 6);
+
+        assert_eq!(
+            arr.into_primitive().unwrap().as_slice::<i32>(),
+            vec![2, 3, 3, 3, 3, 3]
+        );
+    }
+
+    #[test]
+    fn slice_at_end() {
+        let re_array = RunEndArray::try_new(
+            buffer![7_u64, 10].into_array(),
+            buffer![2_u64, 3].into_array(),
+        )
+        .unwrap();
+
+        assert_eq!(re_array.len(), 10);
+
+        let sliced_array = slice(&re_array, re_array.len(), re_array.len()).unwrap();
+        assert!(sliced_array.is_empty());
+
+        let re_slice = RunEndArray::try_from(sliced_array).unwrap();
+        assert!(re_slice.ends().is_empty());
+        assert!(re_slice.values().is_empty())
+    }
+}

--- a/encodings/runend/src/compute/take.rs
+++ b/encodings/runend/src/compute/take.rs
@@ -1,32 +1,44 @@
+use num_traits::AsPrimitive;
 use vortex_array::compute::{take, TakeFn};
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
 use vortex_dtype::match_each_integer_ptype;
-use vortex_error::VortexResult;
+use vortex_error::{vortex_bail, VortexResult};
 
 use crate::{RunEndArray, RunEndEncoding};
 
 impl TakeFn<RunEndArray> for RunEndEncoding {
-    #[allow(deprecated)]
     fn take(&self, array: &RunEndArray, indices: &ArrayData) -> VortexResult<ArrayData> {
         let primitive_indices = indices.clone().into_primitive()?;
-        let usize_indices = match_each_integer_ptype!(primitive_indices.ptype(), |$P| {
+
+        let checked_indices = match_each_integer_ptype!(primitive_indices.ptype(), |$P| {
             primitive_indices
                 .as_slice::<$P>()
                 .iter()
+                .copied()
                 .map(|idx| {
-                    let usize_idx = *idx as usize;
+                    let usize_idx = idx as usize;
                     if usize_idx >= array.len() {
-                        vortex_error::vortex_bail!(OutOfBounds: usize_idx, 0, array.len());
+                        vortex_bail!(OutOfBounds: usize_idx, 0, array.len());
                     }
-
-                    Ok(usize_idx + array.offset())
+                    Ok(usize_idx)
                 })
-                .collect::<VortexResult<Vec<usize>>>()?
+                .collect::<VortexResult<Vec<_>>>()?
         });
-        let physical_indices = array.find_physical_indices(&usize_indices)?.into_array();
-        take(array.values(), &physical_indices)
+        take_indices_unchecked(array, &checked_indices)
     }
+}
+
+pub(crate) fn take_indices_unchecked<T: AsPrimitive<usize>>(
+    array: &RunEndArray,
+    indices: &[T],
+) -> VortexResult<ArrayData> {
+    let adjusted_indices = indices
+        .iter()
+        .map(|idx| idx.as_() + array.offset())
+        .collect::<Vec<_>>();
+    let physical_indices = array.find_physical_indices(&adjusted_indices)?.into_array();
+    take(array.values(), &physical_indices)
 }
 
 #[cfg(test)]
@@ -37,7 +49,7 @@ mod test {
 
     use crate::RunEndArray;
 
-    pub(crate) fn ree_array() -> RunEndArray {
+    fn ree_array() -> RunEndArray {
         RunEndArray::encode(
             PrimitiveArray::from_iter([1, 1, 1, 4, 4, 4, 2, 2, 5, 5, 5, 5]).to_array(),
         )

--- a/encodings/runend/src/compute/take.rs
+++ b/encodings/runend/src/compute/take.rs
@@ -29,7 +29,8 @@ impl TakeFn<RunEndArray> for RunEndEncoding {
     }
 }
 
-pub(crate) fn take_indices_unchecked<T: AsPrimitive<usize>>(
+/// Perform a take operation on a RunEndArray by binary searching for each of the indices.
+pub fn take_indices_unchecked<T: AsPrimitive<usize>>(
     array: &RunEndArray,
     indices: &[T],
 ) -> VortexResult<ArrayData> {

--- a/encodings/runend/src/lib.rs
+++ b/encodings/runend/src/lib.rs
@@ -4,3 +4,11 @@ mod array;
 pub mod compress;
 mod compute;
 mod iter;
+
+#[doc(hidden)]
+pub mod _benchmarking {
+    pub use compute::filter::filter_run_end;
+    pub use compute::take::take_indices_unchecked;
+
+    use super::*;
+}


### PR DESCRIPTION
And reorganize compute functions into their own modules.

Against develop this is a 33% improvement in a random access benchmark. Don't know if 0.1% is the right threshold but we can write a benchmark in a follow up and find the right number

```
random-access/vortex-tokio-local-disk
                        time:   [825.58 µs 826.96 µs 828.51 µs]
                        change: [-33.408% -32.989% -32.591%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
```