### PR TITLE
Combine scan and take

### DIFF
--- a/bench-vortex/src/reader.rs
+++ b/bench-vortex/src/reader.rs
@@ -111,7 +111,7 @@ async fn take_vortex<T: VortexReadAt + Unpin + 'static>(
     VortexOpenOptions::new(ALL_ENCODINGS_CONTEXT.clone())
         .open(reader)
         .await?
-        .take(indices, Scan::all())?
+        .scan(Scan::all().with_row_indices(indices))?
         .into_array_data()
         .await?
         // For equivalence.... we decompress to make sure we're not cheating too much.

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -101,7 +101,7 @@ impl FileOpener for VortexFileOpener {
                 .await?;
 
             Ok(vxf
-                .scan(Scan::new(this.projection.clone(), this.filter.clone()))?
+                .scan(Scan::new(this.projection.clone()).with_some_filter(this.filter.clone()))?
                 .map_ok(RecordBatch::try_from)
                 .map(|r| r.and_then(|inner| inner))
                 .map_err(|e| e.into())

--- a/vortex-file/src/v2/tests.rs
+++ b/vortex-file/src/v2/tests.rs
@@ -42,8 +42,11 @@ fn basic_file_roundtrip() -> VortexResult<()> {
 #[test]
 fn file_take() -> VortexResult<()> {
     let vxf = chunked_file();
-    let result =
-        block_on(vxf.take(buffer![0, 1, 8], Scan::all())?.into_array_data())?.into_primitive()?;
+    let result = block_on(
+        vxf.scan(Scan::all().with_row_indices(buffer![0, 1, 8]))?
+            .into_array_data(),
+    )?
+    .into_primitive()?;
 
     assert_eq!(result.as_slice::<i32>(), &[0, 1, 8]);
 


### PR DESCRIPTION
This is so we can return a single `impl ArrayStream` to callers who often switch over whether or not a row_indices filter exists.