### PR TITLE
Un-arc'd ViewedArrayData

### DIFF
--- a/vortex-array/src/data/mod.rs
+++ b/vortex-array/src/data/mod.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
-use std::sync::{Arc, RwLock, Weak};
+use std::sync::{Arc, RwLock};
 
 use itertools::Itertools;
 use owned::OwnedArrayData;
@@ -34,25 +34,25 @@ mod viewed;
 ///
 /// This is the main entrypoint for working with in-memory Vortex data, and dispatches work over the underlying encoding or memory representations.
 #[derive(Debug, Clone)]
-pub struct ArrayData(Arc<InnerArrayData>);
+pub struct ArrayData(InnerArrayData);
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum InnerArrayData {
     /// Owned [`ArrayData`] with serialized metadata, backed by heap-allocated memory.
-    Owned(OwnedArrayData),
+    Owned(Arc<OwnedArrayData>),
     /// Zero-copy view over flatbuffer-encoded [`ArrayData`] data, created without eager serialization.
     Viewed(ViewedArrayData),
 }
 
 impl From<OwnedArrayData> for ArrayData {
     fn from(data: OwnedArrayData) -> Self {
-        ArrayData(Arc::new(InnerArrayData::Owned(data)))
+        ArrayData(InnerArrayData::Owned(Arc::new(data)))
     }
 }
 
 impl From<ViewedArrayData> for ArrayData {
     fn from(data: ViewedArrayData) -> Self {
-        ArrayData(Arc::new(InnerArrayData::Viewed(data)))
+        ArrayData(InnerArrayData::Viewed(data))
     }
 }
 
@@ -66,7 +66,7 @@ impl ArrayData {
         children: Box<[ArrayData]>,
         statistics: StatsSet,
     ) -> VortexResult<Self> {
-        Self::try_new(InnerArrayData::Owned(OwnedArrayData {
+        Self::try_new(InnerArrayData::Owned(Arc::new(OwnedArrayData {
             encoding,
             dtype,
             len,
@@ -76,7 +76,7 @@ impl ArrayData {
             stats_set: RwLock::new(statistics),
             #[cfg(feature = "canonical_counter")]
             canonical_counter: std::sync::atomic::AtomicUsize::new(0),
-        }))
+        })))
     }
 
     pub fn try_new_viewed<F>(
@@ -114,7 +114,7 @@ impl ArrayData {
             buffers: buffers.into(),
             ctx,
             #[cfg(feature = "canonical_counter")]
-            canonical_counter: std::sync::atomic::AtomicUsize::new(0),
+            canonical_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         };
 
         Self::try_new(InnerArrayData::Viewed(view))
@@ -122,7 +122,7 @@ impl ArrayData {
 
     /// Shared constructor that performs common array validation.
     fn try_new(inner: InnerArrayData) -> VortexResult<Self> {
-        let array = ArrayData(Arc::new(inner));
+        let array = ArrayData(inner);
 
         // Sanity check that the encoding implements the correct array trait
         debug_assert!(
@@ -149,7 +149,7 @@ impl ArrayData {
 
     /// Return the array's encoding
     pub fn encoding(&self) -> EncodingRef {
-        match self.0.as_ref() {
+        match &self.0 {
             InnerArrayData::Owned(d) => d.encoding,
             InnerArrayData::Viewed(v) => v.encoding,
         }
@@ -158,7 +158,7 @@ impl ArrayData {
     /// Returns the number of logical elements in the array.
     #[allow(clippy::same_name_method)]
     pub fn len(&self) -> usize {
-        match self.0.as_ref() {
+        match &self.0 {
             InnerArrayData::Owned(d) => d.len,
             InnerArrayData::Viewed(v) => v.len,
         }
@@ -204,18 +204,18 @@ impl ArrayData {
     }
 
     pub fn child<'a>(&'a self, idx: usize, dtype: &'a DType, len: usize) -> VortexResult<Self> {
-        match self.0.as_ref() {
+        match &self.0 {
             InnerArrayData::Owned(d) => d.child(idx, dtype, len).cloned(),
             InnerArrayData::Viewed(v) => v
                 .child(idx, dtype, len)
-                .map(|view| ArrayData(Arc::new(InnerArrayData::Viewed(view)))),
+                .map(|view| ArrayData(InnerArrayData::Viewed(view))),
         }
     }
 
     /// Returns a Vec of Arrays with all the array's child arrays.
     // TODO(ngates): deprecate this function and return impl Iterator
     pub fn children(&self) -> Vec<ArrayData> {
-        match self.0.as_ref() {
+        match &self.0 {
             InnerArrayData::Owned(d) => d.children().to_vec(),
             InnerArrayData::Viewed(_) => {
                 let mut collector = ChildrenCollector::default();
@@ -238,7 +238,7 @@ impl ArrayData {
 
     /// Returns the number of child arrays
     pub fn nchildren(&self) -> usize {
-        match self.0.as_ref() {
+        match &self.0 {
             InnerArrayData::Owned(d) => d.nchildren(),
             InnerArrayData::Viewed(v) => v.nchildren(),
         }
@@ -278,7 +278,7 @@ impl ArrayData {
     }
 
     pub fn array_metadata(&self) -> &dyn ArrayMetadata {
-        match self.0.as_ref() {
+        match &self.0 {
             InnerArrayData::Owned(d) => &*d.metadata,
             InnerArrayData::Viewed(v) => &*v.metadata,
         }
@@ -287,7 +287,7 @@ impl ArrayData {
     pub fn metadata<M: ArrayMetadata + Clone + for<'m> TryDeserializeArrayMetadata<'m>>(
         &self,
     ) -> VortexResult<&M> {
-        match self.0.as_ref() {
+        match &self.0 {
             InnerArrayData::Owned(d) => &d.metadata,
             InnerArrayData::Viewed(v) => &v.metadata,
         }
@@ -306,7 +306,7 @@ impl ArrayData {
     /// View arrays will return a reference to their bytes, while heap-backed arrays
     /// must first serialize their metadata, returning an owned byte array to the caller.
     pub fn metadata_bytes(&self) -> VortexResult<Cow<[u8]>> {
-        match self.0.as_ref() {
+        match &self.0 {
             InnerArrayData::Owned(array_data) => {
                 // Heap-backed arrays must first try and serialize the metadata.
                 let owned_meta: Vec<u8> = array_data
@@ -328,14 +328,14 @@ impl ArrayData {
     }
 
     pub fn nbuffers(&self) -> usize {
-        match self.0.as_ref() {
+        match &self.0 {
             InnerArrayData::Owned(o) => o.buffers.len(),
             InnerArrayData::Viewed(v) => v.nbuffers(),
         }
     }
 
     pub fn byte_buffer(&self, index: usize) -> Option<&ByteBuffer> {
-        match self.0.as_ref() {
+        match &self.0 {
             InnerArrayData::Owned(d) => d.byte_buffer(index),
             InnerArrayData::Viewed(v) => v.buffer(index),
         }
@@ -351,7 +351,7 @@ impl ArrayData {
         // NOTE(ngates): we can't really into_inner an Arc, so instead we clone the buffer out,
         //  but we still consume self by value such that the ref-count drops at the end of this
         //  function.
-        match self.0.as_ref() {
+        match &self.0 {
             InnerArrayData::Owned(d) => d.byte_buffer(index).cloned(),
             InnerArrayData::Viewed(v) => v.buffer(index).cloned(),
         }
@@ -379,7 +379,7 @@ impl ArrayData {
 
     #[cfg(feature = "canonical_counter")]
     pub(crate) fn inc_canonical_counter(&self) {
-        let prev = match self.0.as_ref() {
+        let prev = match &self.0 {
             InnerArrayData::Owned(o) => o
                 .canonical_counter
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
@@ -415,7 +415,7 @@ impl ArrayData {
 
 impl Display for ArrayData {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let prefix = match self.0.as_ref() {
+        let prefix = match &self.0 {
             InnerArrayData::Owned(_) => "",
             InnerArrayData::Viewed(_) => "$",
         };
@@ -432,7 +432,7 @@ impl Display for ArrayData {
 
 impl<T: AsRef<ArrayData>> ArrayDType for T {
     fn dtype(&self) -> &DType {
-        match self.as_ref().0.as_ref() {
+        match &self.as_ref().0 {
             InnerArrayData::Owned(d) => &d.dtype,
             InnerArrayData::Viewed(v) => &v.dtype,
         }
@@ -495,22 +495,5 @@ impl Iterator for ArrayDataIterator {
                 chunk
             }),
         }
-    }
-}
-
-/// An array data that holds a weak reference to its internals.
-pub struct WeakArrayData(Weak<InnerArrayData>);
-
-impl WeakArrayData {
-    /// Attempts to upgrade the weak reference to a strong reference.
-    pub fn upgrade(&self) -> Option<ArrayData> {
-        self.0.upgrade().map(ArrayData)
-    }
-}
-
-impl ArrayData {
-    /// Downgrades the array data to a weak reference.
-    pub fn downgrade(self) -> WeakArrayData {
-        WeakArrayData(Arc::downgrade(&self.0))
     }
 }

--- a/vortex-array/src/data/statistics.rs
+++ b/vortex-array/src/data/statistics.rs
@@ -12,7 +12,7 @@ use crate::{ArrayDType, ArrayData};
 
 impl Statistics for ArrayData {
     fn get(&self, stat: Stat) -> Option<Scalar> {
-        match self.0.as_ref() {
+        match &self.0 {
             InnerArrayData::Owned(o) => o
                 .stats_set
                 .read()
@@ -66,7 +66,7 @@ impl Statistics for ArrayData {
     }
 
     fn to_set(&self) -> StatsSet {
-        match self.0.as_ref() {
+        match &self.0 {
             InnerArrayData::Owned(o) => o
                 .stats_set
                 .read()
@@ -79,7 +79,7 @@ impl Statistics for ArrayData {
     }
 
     fn set(&self, stat: Stat, value: Scalar) {
-        match self.0.as_ref() {
+        match &self.0 {
             InnerArrayData::Owned(o) => o
                 .stats_set
                 .write()
@@ -98,7 +98,7 @@ impl Statistics for ArrayData {
     }
 
     fn clear(&self, stat: Stat) {
-        match self.0.as_ref() {
+        match &self.0 {
             InnerArrayData::Owned(o) => {
                 o.stats_set
                     .write()
@@ -130,7 +130,7 @@ impl Statistics for ArrayData {
     }
 
     fn retain_only(&self, stats: &[Stat]) {
-        match self.0.as_ref() {
+        match &self.0 {
             InnerArrayData::Owned(o) => {
                 o.stats_set
                     .write()

--- a/vortex-array/src/data/viewed.rs
+++ b/vortex-array/src/data/viewed.rs
@@ -76,7 +76,7 @@ impl ViewedArrayData {
             buffers: self.buffers.clone(),
             ctx: self.ctx.clone(),
             #[cfg(feature = "canonical_counter")]
-            canonical_counter: std::sync::atomic::AtomicUsize::new(0),
+            canonical_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         })
     }
 

--- a/vortex-array/src/data/viewed.rs
+++ b/vortex-array/src/data/viewed.rs
@@ -12,6 +12,7 @@ use crate::encoding::EncodingRef;
 use crate::{flatbuffers as fb, ArrayMetadata, ContextRef};
 
 /// Zero-copy view over flatbuffer-encoded array data, created without eager serialization.
+#[derive(Clone)]
 pub(super) struct ViewedArrayData {
     pub(super) encoding: EncodingRef,
     pub(super) dtype: DType,
@@ -22,7 +23,7 @@ pub(super) struct ViewedArrayData {
     pub(super) buffers: Arc<[ByteBuffer]>,
     pub(super) ctx: ContextRef,
     #[cfg(feature = "canonical_counter")]
-    pub(super) canonical_counter: std::sync::atomic::AtomicUsize,
+    pub(super) canonical_counter: Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl Debug for ViewedArrayData {


### PR DESCRIPTION
I was working on auto-pilot and forgot I was only supposed to Arc OwnedArrayData.
We should be able to traverse a ViewedArrayData without any allocations (we still alloc metadata, need to get rid of this)