### PR TITLE
Simplify FoldDown return

### DIFF
--- a/vortex-expr/src/forms/nnf.rs
+++ b/vortex-expr/src/forms/nnf.rs
@@ -1,6 +1,6 @@
 use vortex_error::VortexResult;
 
-use crate::traversal::{FoldChildren, FoldDown, FoldUp, FolderMut, Node as _};
+use crate::traversal::{FoldDown, FoldUp, FolderMut, Node as _};
 use crate::{not, BinaryExpr, ExprRef, Not, Operator};
 
 /// Return an equivalent expression in Negative Normal Form (NNF).
@@ -85,28 +85,25 @@ impl FolderMut for NNFVisitor {
             }
         }
 
-        Ok(FoldDown::SkipChildren)
+        Ok(FoldDown::Abort(node.clone()))
     }
 
     fn visit_up(
         &mut self,
         node: ExprRef,
         negating: bool,
-        new_children: FoldChildren<ExprRef>,
+        mut new_children: Vec<ExprRef>,
     ) -> VortexResult<FoldUp<ExprRef>> {
         let node_any = node.as_any();
-        let new_node = if node_any.downcast_ref::<Not>().is_some() {
-            let FoldChildren::Children(mut new_children) = new_children else {
-                unreachable!();
-            };
-            debug_assert_eq!(new_children.len(), 1);
 
+        let new_node = if node_any.downcast_ref::<Not>().is_some() {
+            debug_assert_eq!(new_children.len(), 1);
             new_children.remove(0)
         } else if let Some(binary_expr) = node_any.downcast_ref::<BinaryExpr>() {
             if !negating {
                 node
             } else {
-                let new_op = match binary_expr.op() {
+                let new_op = match binary_expr.op().swap() {
                     Operator::Eq => Operator::NotEq,
                     Operator::NotEq => Operator::Eq,
                     Operator::Gt => Operator::Lte,
@@ -118,34 +115,24 @@ impl FolderMut for NNFVisitor {
                 };
                 let (lhs, rhs) = match binary_expr.op() {
                     Operator::Or | Operator::And => {
-                        let FoldChildren::Children(mut negated_children) = new_children else {
-                            unreachable!();
-                        };
+                        let mut negated_children = new_children;
                         debug_assert_eq!(negated_children.len(), 2);
                         let rhs = negated_children.remove(1);
                         let lhs = negated_children.remove(0);
                         (lhs, rhs)
                     }
-                    _ => {
-                        let FoldChildren::Skipped = new_children else {
-                            unreachable!();
-                        };
-                        (binary_expr.lhs().clone(), binary_expr.rhs().clone())
-                    }
+                    _ => (binary_expr.lhs().clone(), binary_expr.rhs().clone()),
                 };
                 BinaryExpr::new_expr(lhs, new_op, rhs)
             }
         } else {
-            let FoldChildren::Skipped = new_children else {
-                unreachable!();
-            };
-
             if negating {
                 not(node)
             } else {
                 node
             }
         };
+
         Ok(FoldUp::Continue(new_node))
     }
 }

--- a/vortex-expr/src/forms/nnf.rs
+++ b/vortex-expr/src/forms/nnf.rs
@@ -125,12 +125,10 @@ impl FolderMut for NNFVisitor {
                 };
                 BinaryExpr::new_expr(lhs, new_op, rhs)
             }
+        } else if negating {
+            not(node)
         } else {
-            if negating {
-                not(node)
-            } else {
-                node
-            }
+            node
         };
 
         Ok(FoldUp::Continue(new_node))

--- a/vortex-expr/src/forms/nnf.rs
+++ b/vortex-expr/src/forms/nnf.rs
@@ -85,7 +85,7 @@ impl FolderMut for NNFVisitor {
             }
         }
 
-        Ok(FoldDown::Abort(node.clone()))
+        Ok(FoldDown::Continue(negating))
     }
 
     fn visit_up(
@@ -103,7 +103,7 @@ impl FolderMut for NNFVisitor {
             if !negating {
                 node
             } else {
-                let new_op = match binary_expr.op().swap() {
+                let new_op = match binary_expr.op() {
                     Operator::Eq => Operator::NotEq,
                     Operator::NotEq => Operator::Eq,
                     Operator::Gt => Operator::Lte,

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -69,10 +69,6 @@ pub trait VortexExpr: Debug + Send + Sync + DynEq + DynHash + Display {
 
     fn children(&self) -> Vec<&ExprRef>;
 
-    fn nchildren(&self) -> usize {
-        self.children().len()
-    }
-
     fn replacing_children(self: Arc<Self>, children: Vec<ExprRef>) -> ExprRef;
 
     /// Compute the type of the array returned by [VortexExpr::evaluate].

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -69,6 +69,10 @@ pub trait VortexExpr: Debug + Send + Sync + DynEq + DynHash + Display {
 
     fn children(&self) -> Vec<&ExprRef>;
 
+    fn nchildren(&self) -> usize {
+        self.children().len()
+    }
+
     fn replacing_children(self: Arc<Self>, children: Vec<ExprRef>) -> ExprRef;
 
     /// Compute the type of the array returned by [VortexExpr::evaluate].

--- a/vortex-expr/src/pack.rs
+++ b/vortex-expr/src/pack.rs
@@ -76,6 +76,7 @@ impl Pack {
     }
 }
 
+// TODO(ngates): make this signature more ergonomic
 pub fn pack(names: impl Into<FieldNames>, values: Vec<ExprRef>) -> ExprRef {
     Pack::try_new_expr(names.into(), values)
         .vortex_expect("pack names and values have the same length")

--- a/vortex-expr/src/transform/partition.rs
+++ b/vortex-expr/src/transform/partition.rs
@@ -130,15 +130,13 @@ impl<'a> Folder<'a> for ImmediateIdentityAccessesAnalysis<'a> {
         let accesses = node
             .children()
             .iter()
-            .map(|c| self.sub_expressions.get(c).cloned())
+            .filter_map(|c| self.sub_expressions.get(c).cloned())
             .collect_vec();
 
-        accesses.into_iter().for_each(|c| {
-            let accesses = self.sub_expressions.entry(node).or_default();
-            if let Some(fields) = c {
-                accesses.extend(fields.iter().cloned());
-            }
-        });
+        let node_accesses = self.sub_expressions.entry(node).or_default();
+        accesses
+            .into_iter()
+            .for_each(|fields| node_accesses.extend(fields.iter().cloned()));
 
         Ok(FoldUp::Continue(()))
     }
@@ -241,47 +239,35 @@ impl FolderMut for StructFieldExpressionSplitter<'_> {
         node: &Self::NodeTy,
         _context: Self::Context,
     ) -> VortexResult<FoldDown<ExprRef, Self::Context>> {
-        if self
-            .accesses
-            .get(node)
-            .map(|a| a.len() == 1)
-            .unwrap_or(false)
-        {
-            // Found the top most sub-expression which only access a single field
-            return Ok(FoldDown::SkipChildren(node.clone()));
+        // If this expression only accesses a single field, then we can skip the children
+        let access = self.accesses.get(node);
+        if access.as_ref().map_or(false, |a| a.len() == 1) {
+            let field_name = access
+                .vortex_expect("access is non-empty")
+                .iter()
+                .next()
+                .vortex_expect("expected one field");
+
+            // TODO(joe): dedup the sub_expression, if there are two expressions that are the same
+            // only create one entry here and reuse it.
+            let sub_exprs = self.sub_expressions.entry(field_name.clone()).or_default();
+            let idx = sub_exprs.len();
+
+            // Need to replace get_item(f, ident) with ident, making the expr relative to the child.
+            let replaced = node
+                .clone()
+                .transform_with_context(&mut ScopeStepIntoFieldExpr(field_name.clone()), ())?;
+            sub_exprs.push(replaced.result());
+
+            let access = get_item(
+                Self::field_idx_name(field_name, idx),
+                get_item(field_name.clone(), ident()),
+            );
+
+            return Ok(FoldDown::SkipChildren(access));
         };
 
-        Ok(FoldDown::Continue(()))
-    }
-
-    fn visit_up(
-        &mut self,
-        node: Self::NodeTy,
-        _context: Self::Context,
-        children: Vec<ExprRef>,
-    ) -> VortexResult<FoldUp<ExprRef>> {
-        if let Some(access) = self.accesses.get(&node) {
-            if access.len() == 1 {
-                let field_name = access.iter().next().vortex_expect("access is non-empty");
-                // TODO(joe): dedup the sub_expression, if there are two expressions that are the same
-                // only create one entry here and reuse it.
-                let sub_exprs = self.sub_expressions.entry(field_name.clone()).or_default();
-                let idx = sub_exprs.len();
-
-                // Need to replace get_item(f, ident) with ident, making the expr relative to the child.
-                let replaced = node
-                    .transform_with_context(&mut ScopeStepIntoFieldExpr(field_name.clone()), ())?;
-                sub_exprs.push(replaced.result());
-
-                let access = get_item(
-                    Self::field_idx_name(field_name, idx),
-                    get_item(field_name.clone(), ident()),
-                );
-
-                return Ok(FoldUp::Continue(access));
-            }
-        };
-
+        // If the expression is an identity, then we need to partition it into the fields of the scope.
         if node.as_any().downcast_ref::<Identity>().is_some() {
             let field_names = self.scope_dtype.names();
 
@@ -306,9 +292,19 @@ impl FolderMut for StructFieldExpressionSplitter<'_> {
                 ));
             }
 
-            return Ok(FoldUp::Continue(pack(pack_fields, pack_exprs)));
+            return Ok(FoldDown::SkipChildren(pack(pack_fields, pack_exprs)));
         }
 
+        // Otherwise, continue traversing.
+        Ok(FoldDown::Continue(()))
+    }
+
+    fn visit_up(
+        &mut self,
+        node: Self::NodeTy,
+        _context: Self::Context,
+        children: Vec<Self::Out>,
+    ) -> VortexResult<FoldUp<Self::Out>> {
         Ok(FoldUp::Continue(node.replacing_children(children)))
     }
 }

--- a/vortex-expr/src/transform/partition.rs
+++ b/vortex-expr/src/transform/partition.rs
@@ -241,7 +241,7 @@ impl FolderMut for StructFieldExpressionSplitter<'_> {
     ) -> VortexResult<FoldDown<ExprRef, Self::Context>> {
         // If this expression only accesses a single field, then we can skip the children
         let access = self.accesses.get(node);
-        if access.as_ref().map_or(false, |a| a.len() == 1) {
+        if access.as_ref().is_some_and(|a| a.len() == 1) {
             let field_name = access
                 .vortex_expect("access is non-empty")
                 .iter()

--- a/vortex-expr/src/transform/partition.rs
+++ b/vortex-expr/src/transform/partition.rs
@@ -6,7 +6,7 @@ use vortex_error::{vortex_bail, VortexExpect, VortexResult};
 
 use crate::transform::simplify_typed::simplify_typed;
 use crate::traversal::{
-    FoldChildren, FoldDown, FoldUp, Folder, FolderMut, MutNodeVisitor, Node, TransformResult,
+    FoldDown, FoldUp, Folder, FolderMut, MutNodeVisitor, Node, TransformResult,
 };
 use crate::{get_item, ident, pack, ExprRef, GetItem, Identity, Select, SelectField};
 
@@ -78,6 +78,7 @@ impl<'a> ImmediateIdentityAccessesAnalysis<'a> {
 // This is a very naive, but simple analysis to find the fields that are accessed directly on an
 // identity node. This is combined to provide an over-approximation of the fields that are accessed
 // by an expression.
+// TODO(ngates): rewrite to use Visitor not Folder
 impl<'a> Folder<'a> for ImmediateIdentityAccessesAnalysis<'a> {
     type NodeTy = ExprRef;
     type Out = ();
@@ -100,7 +101,7 @@ impl<'a> Folder<'a> for ImmediateIdentityAccessesAnalysis<'a> {
                 self.sub_expressions
                     .insert(node, HashSet::from_iter(vec![get_item.field().clone()]));
 
-                return Ok(FoldDown::SkipChildren);
+                return Ok(FoldDown::SkipChildren(()));
             }
         } else if let Some(select) = node.as_any().downcast_ref::<Select>() {
             assert!(matches!(select.fields(), SelectField::Include(_)));
@@ -110,7 +111,7 @@ impl<'a> Folder<'a> for ImmediateIdentityAccessesAnalysis<'a> {
                     HashSet::from_iter(select.fields().fields().iter().cloned()),
                 );
             }
-            return Ok(FoldDown::SkipChildren);
+            return Ok(FoldDown::SkipChildren(()));
         } else if node.as_any().downcast_ref::<Identity>().is_some() {
             let st_dtype = &self.scope_dtype;
             self.sub_expressions
@@ -124,7 +125,7 @@ impl<'a> Folder<'a> for ImmediateIdentityAccessesAnalysis<'a> {
         &mut self,
         node: &'a ExprRef,
         _context: (),
-        _children: FoldChildren<()>,
+        _children: Vec<()>,
     ) -> VortexResult<FoldUp<()>> {
         let accesses = node
             .children()
@@ -247,7 +248,7 @@ impl FolderMut for StructFieldExpressionSplitter<'_> {
             .unwrap_or(false)
         {
             // Found the top most sub-expression which only access a single field
-            return Ok(FoldDown::SkipChildren);
+            return Ok(FoldDown::SkipChildren(node.clone()));
         };
 
         Ok(FoldDown::Continue(()))
@@ -257,7 +258,7 @@ impl FolderMut for StructFieldExpressionSplitter<'_> {
         &mut self,
         node: Self::NodeTy,
         _context: Self::Context,
-        children: FoldChildren<ExprRef>,
+        children: Vec<ExprRef>,
     ) -> VortexResult<FoldUp<ExprRef>> {
         if let Some(access) = self.accesses.get(&node) {
             if access.len() == 1 {
@@ -308,10 +309,7 @@ impl FolderMut for StructFieldExpressionSplitter<'_> {
             return Ok(FoldUp::Continue(pack(pack_fields, pack_exprs)));
         }
 
-        match children {
-            FoldChildren::Skipped => unreachable!("Children skipped handled above"),
-            FoldChildren::Children(c) => Ok(FoldUp::Continue(node.replacing_children(c))),
-        }
+        Ok(FoldUp::Continue(node.replacing_children(children)))
     }
 }
 
@@ -326,15 +324,12 @@ impl FolderMut for ScopeStepIntoFieldExpr {
         &mut self,
         node: Self::NodeTy,
         _context: (),
-        children: FoldChildren<Self::Out>,
+        children: Vec<Self::Out>,
     ) -> VortexResult<FoldUp<Self::Out>> {
         if node.as_any().downcast_ref::<Identity>().is_some() {
             Ok(FoldUp::Continue(pack(vec![self.0.clone()], vec![ident()])))
         } else {
-            assert!(!matches!(children, FoldChildren::Skipped));
-            Ok(FoldUp::Continue(
-                node.replacing_children(children.into_iter().collect()),
-            ))
+            Ok(FoldUp::Continue(node.replacing_children(children)))
         }
     }
 }

--- a/vortex-expr/src/transform/simplify.rs
+++ b/vortex-expr/src/transform/simplify.rs
@@ -1,6 +1,6 @@
 use vortex_error::VortexResult;
 
-use crate::traversal::{FoldChildren, FoldUp, FolderMut, Node};
+use crate::traversal::{FoldUp, FolderMut, Node};
 use crate::{get_item, ident, Column, ExprRef, GetItem, Pack};
 
 pub fn simplify(e: ExprRef) -> VortexResult<ExprRef> {
@@ -20,7 +20,7 @@ impl FolderMut for Simplify {
         &mut self,
         node: Self::NodeTy,
         _context: Self::Context,
-        children: FoldChildren<Self::Out>,
+        children: Vec<Self::Out>,
     ) -> VortexResult<FoldUp<Self::Out>> {
         if let Some(column) = node.as_any().downcast_ref::<Column>() {
             // TODO(ngates): deprecate Column, or keep at and simplify GetItem(Ident).
@@ -33,8 +33,6 @@ impl FolderMut for Simplify {
                 return Ok(FoldUp::Continue(expr));
             }
         }
-        Ok(FoldUp::Continue(
-            node.replacing_children(children.contained_children()),
-        ))
+        Ok(FoldUp::Continue(node.replacing_children(children)))
     }
 }

--- a/vortex-expr/src/traversal/mod.rs
+++ b/vortex-expr/src/traversal/mod.rs
@@ -77,59 +77,26 @@ pub trait MutNodeVisitor {
 }
 
 pub enum FoldDown<Out, Context> {
-    Stop(Out),
-    SkipChildren,
+    /// Abort the entire traversal and immediately return the result.
+    Abort(Out),
+    /// Skip visiting children of the current node and return the result to the parent's `fold_up`.
+    SkipChildren(Out),
+    /// Continue visiting the `fold_down` of the children of the current node.
     Continue(Context),
-}
-
-pub enum FoldChildren<Out> {
-    Skipped,
-    Children(Vec<Out>),
-}
-
-impl<Out> IntoIterator for FoldChildren<Out> {
-    type Item = Out;
-    type IntoIter = <Vec<Out> as IntoIterator>::IntoIter;
-
-    fn into_iter(self) -> Self::IntoIter {
-        match self {
-            FoldChildren::Skipped => {
-                vec![]
-            }
-            FoldChildren::Children(children) => children,
-        }
-        .into_iter()
-    }
-}
-
-impl<Out> FoldChildren<Out> {
-    pub fn contained_children(self) -> Vec<Out> {
-        match self {
-            FoldChildren::Skipped => vec![],
-            FoldChildren::Children(children) => children,
-        }
-    }
-}
-
-impl<Out> FoldChildren<Out> {
-    pub fn is_empty(&self) -> bool {
-        match self {
-            FoldChildren::Skipped => true,
-            FoldChildren::Children(children) => children.is_empty(),
-        }
-    }
 }
 
 #[derive(Debug)]
 pub enum FoldUp<Out> {
-    Stop(Out),
+    /// Abort the entire traversal and immediately return the result.
+    Abort(Out),
+    /// Continue visiting the `fold_up` of the parent node.
     Continue(Out),
 }
 
 impl<Out> FoldUp<Out> {
     pub fn result(self) -> Out {
         match self {
-            FoldUp::Stop(out) => out,
+            FoldUp::Abort(out) => out,
             FoldUp::Continue(out) => out,
         }
     }
@@ -152,7 +119,7 @@ pub trait Folder<'a> {
         &mut self,
         node: &'a Self::NodeTy,
         context: Self::Context,
-        children: FoldChildren<Self::Out>,
+        children: Vec<Self::Out>,
     ) -> VortexResult<FoldUp<Self::Out>>;
 }
 
@@ -173,7 +140,7 @@ pub trait FolderMut {
         &mut self,
         node: Self::NodeTy,
         context: Self::Context,
-        children: FoldChildren<Self::Out>,
+        children: Vec<Self::Out>,
     ) -> VortexResult<FoldUp<Self::Out>>;
 }
 
@@ -232,17 +199,17 @@ impl Node for ExprRef {
         context: V::Context,
     ) -> VortexResult<FoldUp<V::Out>> {
         let children = match visitor.visit_down(self, context.clone())? {
-            FoldDown::Stop(out) => return Ok(FoldUp::Stop(out)),
-            FoldDown::SkipChildren => FoldChildren::Skipped,
+            FoldDown::Abort(out) => return Ok(FoldUp::Abort(out)),
+            FoldDown::SkipChildren(out) => return Ok(FoldUp::Continue(out)),
             FoldDown::Continue(child_context) => {
-                let mut new_children = Vec::with_capacity(self.children().len());
+                let mut new_children = Vec::with_capacity(self.nchildren());
                 for child in self.children() {
                     match child.accept_with_context(visitor, child_context.clone())? {
-                        FoldUp::Stop(out) => return Ok(FoldUp::Stop(out)),
+                        FoldUp::Abort(out) => return Ok(FoldUp::Abort(out)),
                         FoldUp::Continue(out) => new_children.push(out),
                     }
                 }
-                FoldChildren::Children(new_children)
+                new_children
             }
         };
 
@@ -307,8 +274,8 @@ impl Node for ExprRef {
         context: V::Context,
     ) -> VortexResult<FoldUp<V::Out>> {
         let children = match visitor.visit_down(&self, context.clone())? {
-            FoldDown::Stop(out) => return Ok(FoldUp::Stop(out)),
-            FoldDown::SkipChildren => FoldChildren::Skipped,
+            FoldDown::Abort(out) => return Ok(FoldUp::Abort(out)),
+            FoldDown::SkipChildren(out) => return Ok(FoldUp::Continue(out)),
             FoldDown::Continue(child_context) => {
                 let mut new_children = Vec::with_capacity(self.children().len());
                 for child in self.children() {
@@ -316,11 +283,11 @@ impl Node for ExprRef {
                         .clone()
                         .transform_with_context(visitor, child_context.clone())?
                     {
-                        FoldUp::Stop(out) => return Ok(FoldUp::Stop(out)),
+                        FoldUp::Abort(out) => return Ok(FoldUp::Abort(out)),
                         FoldUp::Continue(out) => new_children.push(out),
                     }
                 }
-                FoldChildren::Children(new_children)
+                new_children
             }
         };
 

--- a/vortex-expr/src/traversal/mod.rs
+++ b/vortex-expr/src/traversal/mod.rs
@@ -202,7 +202,7 @@ impl Node for ExprRef {
             FoldDown::Abort(out) => return Ok(FoldUp::Abort(out)),
             FoldDown::SkipChildren(out) => return Ok(FoldUp::Continue(out)),
             FoldDown::Continue(child_context) => {
-                let mut new_children = Vec::with_capacity(self.nchildren());
+                let mut new_children = Vec::with_capacity(self.children().len());
                 for child in self.children() {
                     match child.accept_with_context(visitor, child_context.clone())? {
                         FoldUp::Abort(out) => return Ok(FoldUp::Abort(out)),


### PR DESCRIPTION
Instead of matching logic in fold down and fold up, this allows for returning an `Out` from FoldDown.