### PR TITLE
Collect splits only for read fields

### DIFF
--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -52,7 +52,7 @@ impl VortexFileOpener {
                     .reduce(and)
                     .unwrap_or_else(|| lit(true));
 
-                simplify_typed(expr, dtype)
+                simplify_typed(expr, &dtype)
             })
             .transpose()?;
 

--- a/vortex-dtype/src/field.rs
+++ b/vortex-dtype/src/field.rs
@@ -131,6 +131,13 @@ impl FieldPath {
         self.0.push(field.into());
     }
 
+    /// Whether the path starts with the given field name
+    pub fn starts_with_name(&self, name: &str) -> bool {
+        self.0
+            .first()
+            .map_or(false, |f| f == &Field::Name(name.into()))
+    }
+
     /// Steps into the next field in the path
     pub fn step_into(mut self) -> VortexResult<Self> {
         if self.0.is_empty() {

--- a/vortex-dtype/src/field.rs
+++ b/vortex-dtype/src/field.rs
@@ -127,15 +127,16 @@ impl FieldPath {
     }
 
     /// Pushes a new field selector to the end of this path
-    pub fn push<F: Into<Field>>(&mut self, field: F) {
+    pub fn push<F: Into<Field>>(mut self, field: F) -> Self {
         self.0.push(field.into());
+        self
     }
 
     /// Whether the path starts with the given field name
     pub fn starts_with_name(&self, name: &str) -> bool {
         self.0
             .first()
-            .map_or(false, |f| f == &Field::Name(name.into()))
+            .is_some_and(|f| f == &Field::Name(name.into()))
     }
 
     /// Steps into the next field in the path

--- a/vortex-dtype/src/struct_.rs
+++ b/vortex-dtype/src/struct_.rs
@@ -238,6 +238,14 @@ impl StructDType {
         &self.names
     }
 
+    /// Find the index of a field.
+    pub fn find(&self, field: &Field) -> Option<usize> {
+        match field {
+            Field::Name(name) => self.find_name(&name),
+            Field::Index(idx) => Some(*idx),
+        }
+    }
+
     /// Find the index of a field by name
     /// Returns `None` if the field is not found
     pub fn find_name(&self, name: &str) -> Option<usize> {

--- a/vortex-dtype/src/struct_.rs
+++ b/vortex-dtype/src/struct_.rs
@@ -241,7 +241,7 @@ impl StructDType {
     /// Find the index of a field.
     pub fn find(&self, field: &Field) -> Option<usize> {
         match field {
-            Field::Name(name) => self.find_name(&name),
+            Field::Name(name) => self.find_name(name),
             Field::Index(idx) => Some(*idx),
         }
     }

--- a/vortex-expr/src/transform/field_mask.rs
+++ b/vortex-expr/src/transform/field_mask.rs
@@ -43,10 +43,7 @@ impl<'a> Folder<'a> for FieldMaskFolder {
             let fields = children
                 .into_iter()
                 .flat_map(|field_mask| field_mask.into_iter())
-                .map(|mut field_path| {
-                    field_path.push(Field::Name(getitem.field().clone()));
-                    field_path
-                })
+                .map(|field_path| field_path.push(Field::Name(getitem.field().clone())))
                 .collect();
             return Ok(FoldUp::Continue(fields));
         }
@@ -57,5 +54,56 @@ impl<'a> Folder<'a> for FieldMaskFolder {
 
         // Otherwise, return the field paths from the children
         Ok(FoldUp::Continue(children.into_iter().flatten().collect()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::iter;
+
+    use itertools::Itertools;
+    use vortex_dtype::Nullability::NonNullable;
+    use vortex_dtype::{DType, FieldPath, PType, StructDType};
+
+    use crate::transform::field_mask::field_mask;
+    use crate::{get_item, ident};
+
+    fn dtype() -> DType {
+        DType::Struct(
+            StructDType::new(
+                ["A".into(), "B".into(), "C".into()].into(),
+                iter::repeat(DType::Primitive(PType::I32, NonNullable))
+                    .take(3)
+                    .collect(),
+            ),
+            NonNullable,
+        )
+    }
+
+    #[test]
+    fn field_mask_ident() {
+        let mask = field_mask(&ident(), &dtype())
+            .unwrap()
+            .into_iter()
+            .collect_vec();
+        assert_eq!(mask.as_slice(), &[FieldPath::root()]);
+    }
+
+    #[test]
+    fn field_mask_get_item() {
+        let mask = field_mask(&get_item("A", ident()), &dtype())
+            .unwrap()
+            .into_iter()
+            .collect_vec();
+        assert_eq!(mask.as_slice(), &[FieldPath::from_name("A")]);
+    }
+
+    #[test]
+    fn field_mask_get_item_nested() {
+        let mask = field_mask(&get_item("B", get_item("A", ident())), &dtype())
+            .unwrap()
+            .into_iter()
+            .collect_vec();
+        assert_eq!(mask.as_slice(), &[FieldPath::from_name("A").push("B")]);
     }
 }

--- a/vortex-expr/src/transform/field_mask.rs
+++ b/vortex-expr/src/transform/field_mask.rs
@@ -1,0 +1,61 @@
+use vortex_array::aliases::hash_set::HashSet;
+use vortex_dtype::{DType, Field, FieldPath};
+use vortex_error::{vortex_bail, VortexResult};
+
+use crate::traversal::{FoldUp, Folder, Node};
+use crate::{ExprRef, GetItem, Identity, Select};
+
+/// Returns the field mask for the given expression.
+///
+/// This defines a mask over the scope of the fields that are accessed by the expression.
+pub fn field_mask(expr: &ExprRef, scope_dtype: &DType) -> VortexResult<HashSet<FieldPath>> {
+    // I know it's unused now, but we will for sure need the scope DType for future expressions.
+    let DType::Struct(_scope_dtype, _) = scope_dtype else {
+        vortex_bail!("Mismatched dtype {} for struct layout", scope_dtype);
+    };
+
+    Ok(match expr.accept_with_context(&mut FieldMaskFolder, ())? {
+        FoldUp::Abort(out) => out,
+        FoldUp::Continue(out) => out,
+    })
+}
+
+struct FieldMaskFolder;
+
+impl<'a> Folder<'a> for FieldMaskFolder {
+    type NodeTy = ExprRef;
+    type Out = HashSet<FieldPath>;
+    type Context = ();
+
+    fn visit_up(
+        &mut self,
+        node: &'a Self::NodeTy,
+        _context: Self::Context,
+        children: Vec<Self::Out>,
+    ) -> VortexResult<FoldUp<Self::Out>> {
+        // The identity returns a field path covering the root.
+        if node.as_any().downcast_ref::<Identity>().is_some() {
+            return Ok(FoldUp::Continue([FieldPath::root()].into()));
+        }
+
+        // GetItem pushes an element to each field path
+        if let Some(getitem) = node.as_any().downcast_ref::<GetItem>() {
+            let fields = children
+                .into_iter()
+                .flat_map(|field_mask| field_mask.into_iter())
+                .map(|mut field_path| {
+                    field_path.push(Field::Name(getitem.field().clone()));
+                    field_path
+                })
+                .collect();
+            return Ok(FoldUp::Continue(fields));
+        }
+
+        if node.as_any().downcast_ref::<Select>().is_some() {
+            vortex_bail!("Expression must be simplified")
+        }
+
+        // Otherwise, return the field paths from the children
+        Ok(FoldUp::Continue(children.into_iter().flatten().collect()))
+    }
+}

--- a/vortex-expr/src/transform/mod.rs
+++ b/vortex-expr/src/transform/mod.rs
@@ -1,4 +1,5 @@
 //! A collection of transformations that can be applied to a [`crate::ExprRef`].
+pub mod field_mask;
 pub mod partition;
 pub(crate) mod remove_select;
 pub mod simplify;

--- a/vortex-expr/src/transform/partition.rs
+++ b/vortex-expr/src/transform/partition.rs
@@ -207,7 +207,7 @@ impl<'a> StructFieldExpressionSplitter<'a> {
                 };
                 VortexResult::Ok(Partition {
                     name,
-                    expr: simplify_typed(expr, field_dtype)?,
+                    expr: simplify_typed(expr, &field_dtype)?,
                 })
             })
             .try_collect()?;
@@ -223,7 +223,7 @@ impl<'a> StructFieldExpressionSplitter<'a> {
             .transform(&mut ReplaceAccessesWithChild(remove_accesses))?;
 
         Ok(PartitionedExpr {
-            root: simplify_typed(split.result, dtype.clone())?,
+            root: simplify_typed(split.result, dtype)?,
             partitions: partitions.into_boxed_slice(),
         })
     }
@@ -477,7 +477,7 @@ mod tests {
             get_item("b", get_item("a", ident())),
             select(vec!["a".into(), "b".into()], ident()),
         );
-        let expr = simplify_typed(expr, dtype.clone()).unwrap();
+        let expr = simplify_typed(expr, &dtype).unwrap();
         let partitioned = StructFieldExpressionSplitter::split(expr, &dtype).unwrap();
 
         // One for id.a and id.b

--- a/vortex-expr/src/transform/remove_select.rs
+++ b/vortex-expr/src/transform/remove_select.rs
@@ -24,7 +24,7 @@ impl MutNodeVisitor for RemoveSelectTransform<'_> {
     fn visit_up(&mut self, node: ExprRef) -> VortexResult<TransformResult<Self::NodeTy>> {
         if let Some(select) = node.as_any().downcast_ref::<Select>() {
             let child = select.child();
-            let child_dtype = child.return_dtype(&self.scope_dtype)?;
+            let child_dtype = child.return_dtype(self.scope_dtype)?;
             let child_dtype = child_dtype.as_struct().ok_or_else(|| {
                 vortex_err!(
                     "Select child must return a struct dtype, however it was a {}",

--- a/vortex-expr/src/transform/remove_select.rs
+++ b/vortex-expr/src/transform/remove_select.rs
@@ -7,28 +7,24 @@ use crate::{get_item, pack, ExprRef, Select};
 
 /// Select is a useful expression, however it can be defined in terms of get_item & pack,
 /// once the expression type is known, this simplifications pass removes the select expression.
-pub fn remove_select(e: ExprRef, scope_dt: DType) -> VortexResult<ExprRef> {
-    let mut transform = RemoveSelectTransform::new(scope_dt);
+pub fn remove_select(e: ExprRef, scope_dt: &DType) -> VortexResult<ExprRef> {
+    let mut transform = RemoveSelectTransform {
+        scope_dtype: scope_dt,
+    };
     e.transform(&mut transform).map(|e| e.result)
 }
 
-struct RemoveSelectTransform {
-    ident_dtype: DType,
+struct RemoveSelectTransform<'a> {
+    scope_dtype: &'a DType,
 }
 
-impl RemoveSelectTransform {
-    fn new(ident_dtype: DType) -> Self {
-        Self { ident_dtype }
-    }
-}
-
-impl MutNodeVisitor for RemoveSelectTransform {
+impl MutNodeVisitor for RemoveSelectTransform<'_> {
     type NodeTy = ExprRef;
 
     fn visit_up(&mut self, node: ExprRef) -> VortexResult<TransformResult<Self::NodeTy>> {
         if let Some(select) = node.as_any().downcast_ref::<Select>() {
             let child = select.child();
-            let child_dtype = child.return_dtype(&self.ident_dtype)?;
+            let child_dtype = child.return_dtype(&self.scope_dtype)?;
             let child_dtype = child_dtype.as_struct().ok_or_else(|| {
                 vortex_err!(
                     "Select child must return a struct dtype, however it was a {}",
@@ -77,7 +73,7 @@ mod tests {
             NonNullable,
         );
         let e = select(["a".into(), "b".into()], ident());
-        let e = remove_select(e, dtype).unwrap();
+        let e = remove_select(e, &dtype).unwrap();
 
         assert!(e.as_any().downcast_ref::<Pack>().is_some());
     }

--- a/vortex-expr/src/transform/simplify_typed.rs
+++ b/vortex-expr/src/transform/simplify_typed.rs
@@ -8,7 +8,7 @@ use crate::ExprRef;
 /// This pass simplifies an expression under the assumption that ident()/scope as a fixed DType.
 /// There is another pass `simplify` that simplifies an expression without any assumptions.
 /// This pass also applies simplify.
-pub fn simplify_typed(e: ExprRef, scope_dt: DType) -> VortexResult<ExprRef> {
+pub fn simplify_typed(e: ExprRef, scope_dt: &DType) -> VortexResult<ExprRef> {
     let e = simplify(e)?;
     remove_select(e, scope_dt)
 }

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -132,11 +132,8 @@ impl<I: IoDriver> VortexFile<I> {
             .split_by
             .splits(self.file_layout().root_layout(), &field_mask)?
             .into_iter()
-            .inspect(|r| println!("Split: {:?}", (r.end - r.start)))
             .collect_vec()
             .into();
-
-        println!("Scanning with {} splits", splits.len());
 
         let row_masks = ArcIter::new(splits).filter_map(move |row_range| {
             let Some(row_indices) = &scan.row_indices else {

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -6,6 +6,7 @@ use std::task::{Context, Poll};
 
 use futures::Stream;
 use futures_util::{stream, FutureExt, StreamExt, TryFutureExt, TryStreamExt};
+use itertools::Itertools;
 use pin_project_lite::pin_project;
 use vortex_array::compute::FilterMask;
 use vortex_array::stats::{Stat, StatsSet};
@@ -14,6 +15,7 @@ use vortex_array::ContextRef;
 use vortex_buffer::Buffer;
 use vortex_dtype::{DType, FieldPath};
 use vortex_error::{vortex_err, VortexExpect, VortexResult};
+use vortex_expr::transform::field_mask::field_mask;
 use vortex_expr::transform::simplify_typed::simplify_typed;
 use vortex_expr::{ident, ExprRef};
 use vortex_layout::{ExprEvaluator, LayoutReader};
@@ -22,7 +24,7 @@ use vortex_scan::{RowMask, Scanner};
 use crate::exec::ExecDriver;
 use crate::io::IoDriver;
 use crate::segments::channel::SegmentChannel;
-use crate::FileLayout;
+use crate::{FileLayout, SplitBy};
 
 /// A Vortex file ready for reading.
 ///
@@ -34,7 +36,7 @@ pub struct VortexFile<I> {
     pub(crate) file_layout: FileLayout,
     pub(crate) io_driver: I,
     pub(crate) exec_driver: Arc<dyn ExecDriver>,
-    pub(crate) splits: Arc<[Range<u64>]>,
+    pub(crate) split_by: SplitBy,
 }
 
 pub struct Scan {
@@ -87,6 +89,23 @@ impl Scan {
         self.row_indices = Some(row_indices);
         self
     }
+
+    /// Compute a mask of field paths referenced by this scan.
+    pub fn field_mask(&self, scope_dtype: &DType) -> VortexResult<Vec<FieldPath>> {
+        let projection = simplify_typed(self.projection.clone(), scope_dtype)?;
+        let filter = self
+            .filter
+            .clone()
+            .map(|f| simplify_typed(f, scope_dtype))
+            .transpose()?;
+
+        let projection_mask = field_mask(&projection, scope_dtype)?;
+        Ok(filter
+            .map(|f| field_mask(&f, scope_dtype))
+            .transpose()?
+            .map(|mask| projection_mask.union(&mask).cloned().collect_vec())
+            .unwrap_or_else(|| projection_mask.into_iter().collect_vec()))
+    }
 }
 
 /// Async implementation of Vortex File.
@@ -108,7 +127,18 @@ impl<I: IoDriver> VortexFile<I> {
 
     /// Performs a scan operation over the file.
     pub fn scan(&self, scan: Scan) -> VortexResult<impl ArrayStream + 'static + use<'_, I>> {
-        let row_masks = ArcIter::new(self.splits.clone()).filter_map(move |row_range| {
+        let field_mask = scan.field_mask(self.dtype())?;
+        let splits: Arc<[Range<u64>]> = self
+            .split_by
+            .splits(self.file_layout().root_layout(), &field_mask)?
+            .into_iter()
+            .inspect(|r| println!("Split: {:?}", (r.end - r.start)))
+            .collect_vec()
+            .into();
+
+        println!("Scanning with {} splits", splits.len());
+
+        let row_masks = ArcIter::new(splits.clone()).filter_map(move |row_range| {
             let Some(row_indices) = &scan.row_indices else {
                 // If there is no row indices filter, then take the whole range
                 return Some(RowMask::new_valid_between(row_range.start, row_range.end));
@@ -164,11 +194,12 @@ impl<I: IoDriver> VortexFile<I> {
     where
         R: Iterator<Item = RowMask> + Send + 'static,
     {
-        let dt = self.dtype().clone();
         let scanner = Arc::new(Scanner::new(
             self.dtype().clone(),
-            simplify_typed(projection, dt.clone())?,
-            filter.map(|f| simplify_typed(f, dt)).transpose()?,
+            simplify_typed(projection, self.dtype())?,
+            filter
+                .map(|f| simplify_typed(f, self.dtype()))
+                .transpose()?,
         )?);
         let result_dtype = scanner.result_dtype().clone();
 

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -138,7 +138,7 @@ impl<I: IoDriver> VortexFile<I> {
 
         println!("Scanning with {} splits", splits.len());
 
-        let row_masks = ArcIter::new(splits.clone()).filter_map(move |row_range| {
+        let row_masks = ArcIter::new(splits).filter_map(move |row_range| {
             let Some(row_indices) = &scan.row_indices else {
                 // If there is no row indices filter, then take the whole range
                 return Some(RowMask::new_valid_between(row_range.start, row_range.end));

--- a/vortex-file/src/open/mod.rs
+++ b/vortex-file/src/open/mod.rs
@@ -146,16 +146,13 @@ impl VortexOpenOptions {
             .unwrap_or(ExecutionMode::Inline)
             .into_driver();
 
-        // Compute the splits of the file.
-        let splits = self.split_by.splits(file_layout.root_layout())?.into();
-
         // Finally, create the VortexFile.
         Ok(VortexFile {
             ctx: self.ctx.clone(),
             file_layout,
             io_driver,
             exec_driver,
-            splits,
+            split_by: self.split_by,
         })
     }
 

--- a/vortex-file/src/open/split_by.rs
+++ b/vortex-file/src/open/split_by.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 use std::ops::Range;
 
 use itertools::Itertools;
+use vortex_dtype::FieldPath;
 use vortex_error::VortexResult;
 use vortex_layout::LayoutData;
 
@@ -19,7 +20,11 @@ pub enum SplitBy {
 
 impl SplitBy {
     /// Compute the splits for the given layout.
-    pub(crate) fn splits(&self, layout: &LayoutData) -> VortexResult<Vec<Range<u64>>> {
+    pub(crate) fn splits(
+        &self,
+        layout: &LayoutData,
+        field_mask: &[FieldPath],
+    ) -> VortexResult<Vec<Range<u64>>> {
         Ok(match *self {
             SplitBy::Layout => {
                 let mut row_splits = BTreeSet::<u64>::new();
@@ -27,7 +32,7 @@ impl SplitBy {
                 row_splits.insert(0);
                 row_splits.insert(layout.row_count());
                 // Register the splits for all the layouts.
-                layout.register_splits(0, &mut row_splits)?;
+                layout.register_splits(field_mask, 0, &mut row_splits)?;
                 row_splits
                     .into_iter()
                     .tuple_windows()
@@ -66,7 +71,9 @@ mod test {
         let layout = FlatLayoutWriter::new(DType::Bool(NonNullable), Default::default())
             .push_one(&mut segments, buffer![1; 10].into_array())
             .unwrap();
-        let splits = SplitBy::Layout.splits(&layout).unwrap();
+        let splits = SplitBy::Layout
+            .splits(&layout, &[FieldPath::root()])
+            .unwrap();
         assert_eq!(splits, vec![0..10]);
     }
 
@@ -76,7 +83,9 @@ mod test {
         let layout = FlatLayoutWriter::new(DType::Bool(NonNullable), Default::default())
             .push_one(&mut segments, buffer![1; 10].into_array())
             .unwrap();
-        let splits = SplitBy::RowCount(3).splits(&layout).unwrap();
+        let splits = SplitBy::RowCount(3)
+            .splits(&layout, &[FieldPath::root()])
+            .unwrap();
         assert_eq!(splits, vec![0..3, 3..6, 6..9, 9..10]);
     }
 }

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::cast_possible_truncation)]
 use std::iter;
-use std::ops::Deref;
 use std::pin::pin;
 use std::sync::Arc;
 
@@ -115,38 +114,6 @@ async fn test_read_simple_with_spawn() {
         .unwrap();
 
     assert!(!buf.is_empty());
-}
-
-#[tokio::test]
-#[cfg_attr(miri, ignore)]
-async fn test_splits() {
-    let strings = ChunkedArray::from_iter([
-        VarBinArray::from(vec!["ab", "foo", "baz"]).into_array(),
-        VarBinArray::from(vec!["ab", "foo"]).into_array(),
-        VarBinArray::from(vec!["ab", "foo", "bar"]).into_array(),
-    ])
-    .into_array();
-
-    let numbers = ChunkedArray::from_iter([
-        buffer![1u32, 2, 3].into_array(),
-        buffer![4u32, 5, 6].into_array(),
-        buffer![7u32, 8].into_array(),
-    ])
-    .into_array();
-
-    let st = StructArray::from_fields(&[("strings", strings), ("numbers", numbers)]).unwrap();
-
-    let buf = VortexWriteOptions::default()
-        .write(ByteBufferMut::empty(), st.into_array().into_array_stream())
-        .await
-        .unwrap();
-
-    let file = VortexOpenOptions::new(Arc::new(Context::default()))
-        .open(buf.freeze())
-        .await
-        .unwrap();
-
-    assert_eq!(file.splits.deref(), &[0u64..3, 3..5, 5..6, 6..8]);
 }
 
 #[tokio::test]

--- a/vortex-layout/src/data.rs
+++ b/vortex-layout/src/data.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use flatbuffers::{FlatBufferBuilder, Follow, Verifiable, Verifier, VerifierOptions, WIPOffset};
 use vortex_array::ContextRef;
 use vortex_buffer::ByteBuffer;
-use vortex_dtype::DType;
+use vortex_dtype::{DType, FieldPath};
 use vortex_error::{vortex_bail, vortex_err, vortex_panic, VortexExpect, VortexResult};
 use vortex_flatbuffers::{layout as fb, layout, FlatBufferRoot, WriteFlatBuffer};
 
@@ -270,8 +270,14 @@ impl LayoutData {
     }
 
     /// Register splits for this layout.
-    pub fn register_splits(&self, row_offset: u64, splits: &mut BTreeSet<u64>) -> VortexResult<()> {
-        self.encoding().register_splits(self, row_offset, splits)
+    pub fn register_splits(
+        &self,
+        field_mask: &[FieldPath],
+        row_offset: u64,
+        splits: &mut BTreeSet<u64>,
+    ) -> VortexResult<()> {
+        self.encoding()
+            .register_splits(self, field_mask, row_offset, splits)
     }
 }
 

--- a/vortex-layout/src/encoding.rs
+++ b/vortex-layout/src/encoding.rs
@@ -3,6 +3,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
 
 use vortex_array::ContextRef;
+use vortex_dtype::FieldPath;
 use vortex_error::VortexResult;
 
 use crate::segments::AsyncSegmentReader;
@@ -43,6 +44,7 @@ pub trait LayoutEncoding: Debug + Send + Sync {
     fn register_splits(
         &self,
         layout: &LayoutData,
+        field_mask: &[FieldPath],
         row_offset: u64,
         splits: &mut BTreeSet<u64>,
     ) -> VortexResult<()>;

--- a/vortex-layout/src/layouts/chunked/mod.rs
+++ b/vortex-layout/src/layouts/chunked/mod.rs
@@ -8,6 +8,7 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use vortex_array::ContextRef;
+use vortex_dtype::FieldPath;
 use vortex_error::VortexResult;
 
 use crate::data::LayoutData;
@@ -41,6 +42,7 @@ impl LayoutEncoding for ChunkedLayout {
     fn register_splits(
         &self,
         layout: &LayoutData,
+        field_mask: &[FieldPath],
         row_offset: u64,
         splits: &mut BTreeSet<u64>,
     ) -> VortexResult<()> {
@@ -48,7 +50,7 @@ impl LayoutEncoding for ChunkedLayout {
         let mut offset = row_offset;
         for i in 0..nchunks {
             let child = layout.child(i, layout.dtype().clone())?;
-            child.register_splits(offset, splits)?;
+            child.register_splits(field_mask, offset, splits)?;
             offset += child.row_count();
             splits.insert(offset);
         }

--- a/vortex-layout/src/layouts/flat/mod.rs
+++ b/vortex-layout/src/layouts/flat/mod.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use vortex_array::ContextRef;
+use vortex_dtype::FieldPath;
 use vortex_error::VortexResult;
 
 use crate::encoding::{LayoutEncoding, LayoutId};
@@ -35,10 +36,16 @@ impl LayoutEncoding for FlatLayout {
     fn register_splits(
         &self,
         layout: &LayoutData,
+        field_mask: &[FieldPath],
         row_offset: u64,
         splits: &mut BTreeSet<u64>,
     ) -> VortexResult<()> {
-        splits.insert(row_offset + layout.row_count());
+        for path in field_mask {
+            if path.is_root() {
+                splits.insert(row_offset + layout.row_count());
+                break;
+            }
+        }
         Ok(())
     }
 }

--- a/vortex-layout/src/layouts/struct_/mod.rs
+++ b/vortex-layout/src/layouts/struct_/mod.rs
@@ -8,7 +8,8 @@ use std::sync::Arc;
 
 use reader::StructReader;
 use vortex_array::ContextRef;
-use vortex_error::VortexResult;
+use vortex_dtype::{DType, FieldPath};
+use vortex_error::{vortex_bail, vortex_err, VortexResult};
 
 use crate::data::LayoutData;
 use crate::encoding::{LayoutEncoding, LayoutId};
@@ -36,16 +37,27 @@ impl LayoutEncoding for StructLayout {
     fn register_splits(
         &self,
         layout: &LayoutData,
+        field_mask: &[FieldPath],
         row_offset: u64,
         splits: &mut BTreeSet<u64>,
     ) -> VortexResult<()> {
-        // Register the splits for each field
-        for child_idx in 0..layout.nchildren() {
-            let child = layout.child(child_idx, layout.dtype().clone())?;
-            child.register_splits(row_offset, splits)?;
+        let DType::Struct(dtype, _) = layout.dtype() else {
+            vortex_bail!("Mismatched dtype {} for struct layout", layout.dtype());
+        };
+
+        // Register the splits for each field in the mask
+        for path in field_mask {
+            if path.is_root() {
+                continue;
+            }
+            let idx = dtype
+                .find(&path.path()[0])
+                .ok_or_else(|| vortex_err!("Field not found: {}", path))?;
+
+            let child = layout.child(idx, dtype.field_dtype(idx)?)?;
+            child.register_splits(&[path.clone().step_into()?], row_offset, splits)?;
         }
-        // But also... (fun bug!), register the length of the struct in case there are no fields.
-        splits.insert(row_offset + layout.row_count());
+
         Ok(())
     }
 }


### PR DESCRIPTION
We were over-splitting the file before based on all columns.
We still need to change the SplitBy to not over-split in this case, but an improvement for now is to only look at splits for the projected / filtered fields.