### PR TITLE
feat: StructDType `from_iter`

### DIFF
--- a/vortex-array/src/array/struct_/mod.rs
+++ b/vortex-array/src/array/struct_/mod.rs
@@ -90,17 +90,19 @@ impl StructArray {
     }
 
     pub fn from_fields<N: AsRef<str>>(items: &[(N, ArrayData)]) -> VortexResult<Self> {
-        let names: Vec<FieldName> = items
-            .iter()
-            .map(|(name, _)| FieldName::from(name.as_ref()))
-            .collect();
+        let names = items.iter().map(|(name, _)| FieldName::from(name.as_ref()));
         let fields: Vec<ArrayData> = items.iter().map(|(_, array)| array.clone()).collect();
         let len = fields
             .first()
             .map(|f| f.len())
             .ok_or_else(|| vortex_err!("StructArray cannot be constructed from an empty slice of arrays because the length is unspecified"))?;
 
-        Self::try_new(FieldNames::from(names), fields, len, Validity::NonNullable)
+        Self::try_new(
+            FieldNames::from_iter(names),
+            fields,
+            len,
+            Validity::NonNullable,
+        )
     }
 
     // TODO(aduffy): Add equivalent function to support field masks for nested column access.

--- a/vortex-dtype/src/serde/flatbuffers/project.rs
+++ b/vortex-dtype/src/serde/flatbuffers/project.rs
@@ -49,16 +49,14 @@ pub fn project_and_deserialize(
         .ok_or_else(|| vortex_err!("The top-level type should be a struct"))?;
     let nullability = fb_struct.nullable().into();
 
-    let (names, dtypes): (Vec<Arc<str>>, Vec<DType>) = projection
+    let struct_dtype = projection
         .iter()
         .map(|f| resolve_field(fb_struct, f))
         .map(|idx| idx.and_then(|i| read_field(fb_struct, i, buffer)))
-        .collect::<VortexResult<Vec<_>>>()?
-        .into_iter()
-        .unzip();
+        .collect::<VortexResult<Vec<_>>>()?;
 
     Ok(DType::Struct(
-        StructDType::new(names.into(), dtypes),
+        StructDType::from_iter(struct_dtype),
         nullability,
     ))
 }

--- a/vortex-expr/src/transform/partition.rs
+++ b/vortex-expr/src/transform/partition.rs
@@ -358,20 +358,17 @@ mod tests {
 
     fn dtype() -> DType {
         DType::Struct(
-            StructDType::new(
-                vec!["a".into(), "b".into(), "c".into()].into(),
-                vec![
+            StructDType::from_iter([
+                (
+                    "a",
                     DType::Struct(
-                        StructDType::new(
-                            vec!["a".into(), "b".into()].into(),
-                            vec![I32.into(), I32.into()],
-                        ),
+                        StructDType::from_iter([("a", I32.into()), ("b", DType::from(I32))]),
                         NonNullable,
                     ),
-                    I32.into(),
-                    I32.into(),
-                ],
-            ),
+                ),
+                ("b", I32.into()),
+                ("c", I32.into()),
+            ]),
             NonNullable,
         )
     }

--- a/vortex-layout/src/layouts/chunked/stats_table.rs
+++ b/vortex-layout/src/layouts/chunked/stats_table.rs
@@ -42,14 +42,11 @@ impl StatsTable {
 
     /// Returns the DType of the statistics table given a set of statistics and column [`DType`].
     pub fn dtype_for_stats_table(column_dtype: &DType, present_stats: &[Stat]) -> DType {
-        let dtypes = present_stats
-            .iter()
-            .map(|s| s.dtype(column_dtype).as_nullable())
-            .collect();
         DType::Struct(
-            StructDType::new(
-                present_stats.iter().map(|s| s.name().into()).collect(),
-                dtypes,
+            StructDType::from_iter(
+                present_stats
+                    .iter()
+                    .map(|stat| (stat.name(), stat.dtype(column_dtype).as_nullable())),
             ),
             Nullability::NonNullable,
         )


### PR DESCRIPTION
Added a `StructDType::from_iter` and used it. This should remove some interm Vecs.