### PR TITLE
feature flag ExecDriver implementations

### DIFF
--- a/vortex-datafusion/Cargo.toml
+++ b/vortex-datafusion/Cargo.toml
@@ -40,7 +40,7 @@ vortex-buffer = { workspace = true }
 vortex-dtype = { workspace = true }
 vortex-error = { workspace = true, features = ["datafusion"] }
 vortex-expr = { workspace = true, features = ["datafusion"] }
-vortex-file = { workspace = true, features = ["object_store"] }
+vortex-file = { workspace = true, features = ["object_store", "tokio"] }
 vortex-io = { workspace = true, features = ["object_store", "tokio"] }
 vortex-scan = { workspace = true }
 

--- a/vortex-file/Cargo.toml
+++ b/vortex-file/Cargo.toml
@@ -27,8 +27,8 @@ futures-util = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 pin-project-lite = { workspace = true }
-rayon = { workspace = true }
-tokio = { workspace = true, features = ["rt"] }
+rayon = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["rt"], optional = true }
 tracing = { workspace = true, optional = true }
 vortex-array = { workspace = true }
 vortex-buffer = { workspace = true }

--- a/vortex-file/src/exec/mod.rs
+++ b/vortex-file/src/exec/mod.rs
@@ -1,4 +1,6 @@
 pub mod inline;
+
+#[cfg(feature = "tokio")]
 pub mod tokio;
 
 use futures_util::future::BoxFuture;

--- a/vortex-file/src/read/record_batch_reader.rs
+++ b/vortex-file/src/read/record_batch_reader.rs
@@ -24,6 +24,7 @@ pub trait AsyncRuntime {
     fn block_on<F: Future>(&self, fut: F) -> F::Output;
 }
 
+#[cfg(feature = "tokio")]
 impl AsyncRuntime for tokio::runtime::Runtime {
     fn block_on<F: Future>(&self, fut: F) -> F::Output {
         self.block_on(fut)

--- a/vortex/Cargo.toml
+++ b/vortex/Cargo.toml
@@ -50,7 +50,7 @@ vortex-zigzag = { workspace = true }
 vortex-roaring = { workspace = true }
 
 [features]
-tokio = ["vortex-io/tokio"]
+tokio = ["vortex-io/tokio", "vortex-file/tokio"]
 object_store = ["vortex-file/object_store"]
 parquet = ["vortex-error/parquet"]
 python = ["vortex-error/python"]


### PR DESCRIPTION
1. Feature flag tokio/rayon based `ExecDriver` implementation
2. If tokio is available AND running within the context of a runtime, use it.