### PR TITLE
Make IntoArrayVariant invocations more explicit

### DIFF
--- a/bench-vortex/benches/bytes_at.rs
+++ b/bench-vortex/benches/bytes_at.rs
@@ -36,7 +36,7 @@ fn array_view_fixture() -> VarBinViewArray {
         .unwrap()
         .into_array_data()
         .unwrap()
-        .into_varbinview()
+        .into_canonical_varbinview()
         .unwrap()
 }
 

--- a/bench-vortex/src/clickbench.rs
+++ b/bench-vortex/src/clickbench.rs
@@ -175,7 +175,7 @@ pub async fn register_vortex_files(
                     let sts = record_batches
                         .into_iter()
                         .map(ArrayData::try_from)
-                        .map(|a| a.unwrap().into_struct().unwrap())
+                        .map(|a| a.unwrap().into_canonical_struct().unwrap())
                         .collect::<Vec<_>>();
 
                     let mut arrays_map: HashMap<Arc<str>, Vec<ArrayData>> = HashMap::default();

--- a/bench-vortex/src/tpch/mod.rs
+++ b/bench-vortex/src/tpch/mod.rs
@@ -222,7 +222,7 @@ async fn register_vortex_file(
         let sts = record_batches
             .into_iter()
             .map(ArrayData::try_from)
-            .map(|a| a.unwrap().into_struct().unwrap())
+            .map(|a| a.unwrap().into_canonical_struct().unwrap())
             .collect::<Vec<_>>();
 
         let mut arrays_map: HashMap<Arc<str>, Vec<ArrayData>> = HashMap::default();

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -60,7 +60,7 @@ pub fn alp_encode(parray: &PrimitiveArray) -> VortexResult<ALPArray> {
 }
 
 pub fn decompress(array: ALPArray) -> VortexResult<PrimitiveArray> {
-    let encoded = array.encoded().into_primitive()?;
+    let encoded = array.encoded().into_canonical_primitive()?;
     let validity = encoded.validity();
     let ptype = array.dtype().try_into()?;
 
@@ -96,7 +96,7 @@ mod tests {
         assert_eq!(
             encoded
                 .encoded()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<i32>(),
             vec![1234; 1025]
@@ -115,7 +115,7 @@ mod tests {
         assert_eq!(
             encoded
                 .encoded()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<i32>(),
             vec![0, 1234, 0]
@@ -137,7 +137,7 @@ mod tests {
         assert_eq!(
             encoded
                 .encoded()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<i64>(),
             vec![1234i64, 2718, 1234, 4000] // fill forward
@@ -178,7 +178,7 @@ mod tests {
     fn roundtrips_close_fractional() {
         let original = PrimitiveArray::from_iter([195.26274f32, 195.27837, -48.815685]);
         let alp_arr = alp_encode(&original).unwrap();
-        let decompressed = alp_arr.into_primitive().unwrap();
+        let decompressed = alp_arr.into_canonical_primitive().unwrap();
         assert_eq!(original.as_slice::<f32>(), decompressed.as_slice::<f32>());
     }
 
@@ -189,7 +189,7 @@ mod tests {
             Validity::AllInvalid,
         );
         let alp_arr = alp_encode(&original).unwrap();
-        let decompressed = alp_arr.into_primitive().unwrap();
+        let decompressed = alp_arr.into_canonical_primitive().unwrap();
         assert_eq!(original.as_slice::<f64>(), decompressed.as_slice::<f64>());
         assert_eq!(original.validity(), decompressed.validity());
     }

--- a/encodings/alp/src/alp_rd/compute/filter.rs
+++ b/encodings/alp/src/alp_rd/compute/filter.rs
@@ -51,7 +51,7 @@ mod test {
             &FilterMask::from_iter([true, false, true]),
         )
         .unwrap()
-        .into_primitive()
+        .into_canonical_primitive()
         .unwrap();
         assert_eq!(filtered.as_slice::<T>(), &[a, outlier]);
     }

--- a/encodings/alp/src/alp_rd/compute/slice.rs
+++ b/encodings/alp/src/alp_rd/compute/slice.rs
@@ -44,7 +44,7 @@ mod test {
 
         let decoded = slice(encoded.as_ref(), 1, 3)
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
 
         assert_eq!(decoded.as_slice::<T>(), &[b, outlier]);

--- a/encodings/alp/src/alp_rd/compute/take.rs
+++ b/encodings/alp/src/alp_rd/compute/take.rs
@@ -49,7 +49,7 @@ mod test {
 
         let taken = take(encoded.as_ref(), PrimitiveArray::from_iter([0, 2]).as_ref())
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
 
         assert_eq!(taken.as_slice::<T>(), &[a, outlier]);

--- a/encodings/alp/src/alp_rd/mod.rs
+++ b/encodings/alp/src/alp_rd/mod.rs
@@ -276,8 +276,8 @@ pub fn alp_rd_decode<T: ALPRDFloat>(
 
     // Apply any patches
     if let Some(patches) = left_parts_patches {
-        let indices = patches.indices().clone().into_primitive()?;
-        let patch_values = patches.values().clone().into_primitive()?;
+        let indices = patches.indices().clone().into_canonical_primitive()?;
+        let patch_values = patches.values().clone().into_canonical_primitive()?;
         match_each_integer_ptype!(indices.ptype(), |$T| {
             indices
                 .as_slice::<$T>()

--- a/encodings/bytebool/src/compute.rs
+++ b/encodings/bytebool/src/compute.rs
@@ -49,7 +49,7 @@ impl SliceFn<ByteBoolArray> for ByteBoolEncoding {
 impl TakeFn<ByteBoolArray> for ByteBoolEncoding {
     fn take(&self, array: &ByteBoolArray, indices: &ArrayData) -> VortexResult<ArrayData> {
         let validity = array.validity();
-        let indices = indices.clone().into_primitive()?;
+        let indices = indices.clone().into_canonical_primitive()?;
         let bools = array.as_slice();
 
         let arr = match validity {

--- a/encodings/bytebool/src/stats.rs
+++ b/encodings/bytebool/src/stats.rs
@@ -11,7 +11,7 @@ impl StatisticsVTable<ByteBoolArray> for ByteBoolEncoding {
         }
 
         // TODO(adamgs): This is slightly wasteful and could be optimized in the future
-        let bools = array.as_ref().clone().into_bool()?;
+        let bools = array.as_ref().clone().into_canonical_bool()?;
         Ok(bools
             .statistics()
             .compute(stat)

--- a/encodings/datetime-parts/src/canonical.rs
+++ b/encodings/datetime-parts/src/canonical.rs
@@ -42,7 +42,7 @@ pub fn decode_to_temporal(array: &DateTimePartsArray) -> VortexResult<TemporalAr
         array.days(),
         &DType::Primitive(PType::I64, array.dtype().nullability()),
     )?
-    .into_primitive()?;
+    .into_canonical_primitive()?;
 
     // We start with the days component, which is always present.
     // And then add the seconds and subseconds components.
@@ -63,7 +63,7 @@ pub fn decode_to_temporal(array: &DateTimePartsArray) -> VortexResult<TemporalAr
         }
     } else {
         let seconds_buf = try_cast(array.seconds(), &DType::Primitive(PType::U32, NonNullable))?
-            .into_primitive()?;
+            .into_canonical_primitive()?;
         for (v, second) in values.iter_mut().zip(seconds_buf.as_slice::<u32>()) {
             *v += (*second as i64) * divisor;
         }
@@ -83,7 +83,7 @@ pub fn decode_to_temporal(array: &DateTimePartsArray) -> VortexResult<TemporalAr
             array.subsecond(),
             &DType::Primitive(PType::I64, NonNullable),
         )?
-        .into_primitive()?;
+        .into_canonical_primitive()?;
         for (v, subsecond) in values.iter_mut().zip(subsecond_buf.as_slice::<i64>()) {
             *v += *subsecond;
         }
@@ -134,7 +134,7 @@ mod test {
         let primitive_values = decode_to_temporal(&date_times)
             .unwrap()
             .temporal_values()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
 
         assert_eq!(

--- a/encodings/datetime-parts/src/compress.rs
+++ b/encodings/datetime-parts/src/compress.rs
@@ -19,7 +19,7 @@ pub struct TemporalParts {
 /// Splitting the components by granularity creates more small values, which enables better
 /// cascading compression.
 pub fn split_temporal(array: TemporalArray) -> VortexResult<TemporalParts> {
-    let temporal_values = array.temporal_values().into_primitive()?;
+    let temporal_values = array.temporal_values().into_canonical_primitive()?;
     let validity = temporal_values.validity();
 
     // After this operation, timestamps will be non-nullable PrimitiveArray<i64>
@@ -27,7 +27,7 @@ pub fn split_temporal(array: TemporalArray) -> VortexResult<TemporalParts> {
         &temporal_values,
         &DType::Primitive(PType::I64, temporal_values.dtype().nullability()),
     )?
-    .into_primitive()?;
+    .into_canonical_primitive()?;
 
     let divisor = match array.temporal_metadata().time_unit() {
         TimeUnit::Ns => 1_000_000_000,
@@ -102,13 +102,16 @@ mod tests {
             seconds,
             subseconds,
         } = split_temporal(temporal_array).unwrap();
-        assert_eq!(days.into_primitive().unwrap().validity(), validity);
         assert_eq!(
-            seconds.into_primitive().unwrap().validity(),
+            days.into_canonical_primitive().unwrap().validity(),
+            validity
+        );
+        assert_eq!(
+            seconds.into_canonical_primitive().unwrap().validity(),
             Validity::NonNullable
         );
         assert_eq!(
-            subseconds.into_primitive().unwrap().validity(),
+            subseconds.into_canonical_primitive().unwrap().validity(),
             Validity::NonNullable
         );
     }

--- a/encodings/dict/src/array.rs
+++ b/encodings/dict/src/array.rs
@@ -100,7 +100,7 @@ impl ValidityVTable<DictArray> for DictEncoding {
         if array.dtype().is_nullable() {
             let primitive_codes = array
                 .codes()
-                .into_primitive()
+                .into_canonical_primitive()
                 .vortex_expect("Failed to convert DictArray codes to primitive array");
             match_each_integer_ptype!(primitive_codes.ptype(), |$P| {
                 let is_valid = primitive_codes

--- a/encodings/dict/src/compute/mod.rs
+++ b/encodings/dict/src/compute/mod.rs
@@ -94,7 +94,7 @@ mod test {
             PrimitiveArray::from_option_iter([Some(42), Some(-9), None, Some(42), None, Some(-9)]);
         let (codes, values) = dict_encode_typed_primitive::<i32>(&reference);
         let dict = DictArray::try_new(codes.into_array(), values.into_array()).unwrap();
-        let flattened_dict = dict.to_array().into_primitive().unwrap();
+        let flattened_dict = dict.to_array().into_canonical_primitive().unwrap();
         assert_eq!(flattened_dict.byte_buffer(), reference.byte_buffer());
     }
 
@@ -107,7 +107,7 @@ mod test {
         assert_eq!(reference.len(), 6);
         let (codes, values) = dict_encode_varbinview(&reference);
         let dict = DictArray::try_new(codes.into_array(), values.into_array()).unwrap();
-        let flattened_dict = dict.to_array().into_varbinview().unwrap();
+        let flattened_dict = dict.to_array().into_canonical_varbinview().unwrap();
         assert_eq!(
             flattened_dict
                 .with_iterator(|iter| iter

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -434,7 +434,7 @@ mod test {
     fn compression_roundtrip(n: usize) {
         let values = PrimitiveArray::from_iter((0..n).map(|i| (i % 2047) as u16));
         let compressed = BitPackedArray::encode(values.as_ref(), 11).unwrap();
-        let decompressed = compressed.to_array().into_primitive().unwrap();
+        let decompressed = compressed.to_array().into_canonical_primitive().unwrap();
         assert_eq!(decompressed.as_slice::<u16>(), values.as_slice::<u16>());
 
         values

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -43,8 +43,8 @@ fn filter_primitive<T: NativePType + BitPacking + ArrowNativeType>(
 
     // Short-circuit if the selectivity is high enough.
     if mask.selectivity() > 0.8 {
-        return filter(array.clone().into_primitive()?.as_ref(), mask)
-            .and_then(|a| a.into_primitive());
+        return filter(array.clone().into_canonical_primitive()?.as_ref(), mask)
+            .and_then(|a| a.into_canonical_primitive());
     }
 
     let values: Buffer<T> = match mask.iter() {
@@ -145,7 +145,7 @@ mod test {
 
         let primitive_result = filter(bitpacked.as_ref(), &mask)
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
         let res_bytes = primitive_result.as_slice::<u8>();
         assert_eq!(res_bytes, &[0, 62, 31, 33, 9, 18]);
@@ -160,7 +160,10 @@ mod test {
 
         let mask = FilterMask::from_indices(sliced.len(), vec![1919, 1921]);
 
-        let primitive_result = filter(&sliced, &mask).unwrap().into_primitive().unwrap();
+        let primitive_result = filter(&sliced, &mask)
+            .unwrap()
+            .into_canonical_primitive()
+            .unwrap();
         let res_bytes = primitive_result.as_slice::<u8>();
         assert_eq!(res_bytes, &[31, 33]);
     }
@@ -175,7 +178,10 @@ mod test {
         )
         .unwrap();
         assert_eq!(
-            filtered.into_primitive().unwrap().as_slice::<u8>(),
+            filtered
+                .into_canonical_primitive()
+                .unwrap()
+                .as_slice::<u8>(),
             (0..1024).map(|i| (i % 63) as u8).collect::<Vec<_>>()
         );
     }
@@ -190,7 +196,7 @@ mod test {
             &FilterMask::from_indices(values.len(), (0..250).collect()),
         )
         .unwrap()
-        .into_primitive()
+        .into_canonical_primitive()
         .unwrap();
 
         assert_eq!(filtered.as_slice::<i64>(), &values[0..250]);

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -33,7 +33,7 @@ impl TakeFn<BitPackedArray> for BitPackedEncoding {
         let validity = array.validity();
         let taken_validity = validity.take(indices)?;
 
-        let indices = indices.clone().into_primitive()?;
+        let indices = indices.clone().into_canonical_primitive()?;
         let taken = match_each_unsigned_integer_ptype!(ptype.to_unsigned(), |$T| {
             match_each_integer_ptype!(indices.ptype(), |$I| {
                 take_primitive::<$T, $I>(array, &indices, taken_validity)?
@@ -145,7 +145,7 @@ mod test {
 
         let primitive_result = take(bitpacked.as_ref(), &indices)
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
         let res_bytes = primitive_result.as_slice::<u8>();
         assert_eq!(res_bytes, &[0, 62, 31, 33, 9, 18]);
@@ -160,7 +160,7 @@ mod test {
 
         let primitive_result = take(bitpacked.as_ref(), &indices)
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
         let res_bytes = primitive_result.as_slice::<u32>();
         assert_eq!(res_bytes, &[0, 2, 4, 6]);
@@ -175,7 +175,10 @@ mod test {
         let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 6).unwrap();
         let sliced = slice(bitpacked.as_ref(), 128, 2050).unwrap();
 
-        let primitive_result = take(&sliced, &indices).unwrap().into_primitive().unwrap();
+        let primitive_result = take(&sliced, &indices)
+            .unwrap()
+            .into_canonical_primitive()
+            .unwrap();
         let res_bytes = primitive_result.as_slice::<u8>();
         assert_eq!(res_bytes, &[31, 33]);
     }

--- a/encodings/fastlanes/src/bitpacking/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/mod.rs
@@ -319,7 +319,7 @@ mod test {
         let expected = &[1, 0, 1, 0, 1, 0, u64::MAX];
         let results = packed
             .into_array()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap()
             .as_slice::<u64>()
             .to_vec();

--- a/encodings/fastlanes/src/delta/compress.rs
+++ b/encodings/fastlanes/src/delta/compress.rs
@@ -14,7 +14,7 @@ use crate::DeltaArray;
 
 pub fn delta_compress(array: &PrimitiveArray) -> VortexResult<(PrimitiveArray, PrimitiveArray)> {
     // Fill forward nulls
-    let filled = fill_forward(array.as_ref())?.into_primitive()?;
+    let filled = fill_forward(array.as_ref())?.into_canonical_primitive()?;
 
     // Compress the filled array
     let (bases, deltas) = match_each_unsigned_integer_ptype!(array.ptype(), |$T| {
@@ -99,8 +99,8 @@ where
 }
 
 pub fn delta_decompress(array: DeltaArray) -> VortexResult<PrimitiveArray> {
-    let bases = array.bases().into_primitive()?;
-    let deltas = array.deltas().into_primitive()?;
+    let bases = array.bases().into_canonical_primitive()?;
+    let deltas = array.deltas().into_canonical_primitive()?;
     let decoded = match_each_unsigned_integer_ptype!(deltas.ptype(), |$T| {
         PrimitiveArray::new(
             decompress_primitive::<$T>(bases.as_slice(), deltas.as_slice()),
@@ -108,7 +108,7 @@ pub fn delta_decompress(array: DeltaArray) -> VortexResult<PrimitiveArray> {
         )
     });
 
-    slice(decoded, array.offset(), array.offset() + array.len())?.into_primitive()
+    slice(decoded, array.offset(), array.offset() + array.len())?.into_canonical_primitive()
 }
 
 // TODO(ngates): can we re-use the deltas buffer for the result? Might be tricky given the

--- a/encodings/fastlanes/src/delta/compute.rs
+++ b/encodings/fastlanes/src/delta/compute.rs
@@ -19,7 +19,7 @@ impl ComputeVTable for DeltaEncoding {
 
 impl ScalarAtFn<DeltaArray> for DeltaEncoding {
     fn scalar_at(&self, array: &DeltaArray, index: usize) -> VortexResult<Scalar> {
-        let decompressed = slice(array, index, index + 1)?.into_primitive()?;
+        let decompressed = slice(array, index, index + 1)?.into_canonical_primitive()?;
         scalar_at(decompressed, 0)
     }
 }
@@ -130,7 +130,7 @@ mod test {
         assert_eq!(
             slice(&delta, 10, 250)
                 .unwrap()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
             (10u32..250).collect::<Vec<_>>()
@@ -144,7 +144,7 @@ mod test {
         assert_eq!(
             slice(&delta, 1024 + 10, 1024 + 250)
                 .unwrap()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
             ((1024 + 10u32)..(1024 + 250)).collect::<Vec<_>>()
@@ -158,7 +158,7 @@ mod test {
         assert_eq!(
             slice(&delta, 1000, 1048)
                 .unwrap()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
             (1000u32..1048).collect::<Vec<_>>()
@@ -172,7 +172,7 @@ mod test {
         assert_eq!(
             slice(&delta, 2040, 2050)
                 .unwrap()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
             (2040u32..2050).collect::<Vec<_>>()
@@ -186,7 +186,7 @@ mod test {
         assert_eq!(
             slice(&delta, 0, 4096)
                 .unwrap()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
             (0u32..4096).collect::<Vec<_>>()
@@ -200,7 +200,7 @@ mod test {
         assert_eq!(
             slice(&delta, 0, 0)
                 .unwrap()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
             Vec::<u32>::new(),
@@ -209,7 +209,7 @@ mod test {
         assert_eq!(
             slice(&delta, 4096, 4096)
                 .unwrap()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
             Vec::<u32>::new(),
@@ -218,7 +218,7 @@ mod test {
         assert_eq!(
             slice(&delta, 1024, 1024)
                 .unwrap()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
             Vec::<u32>::new(),
@@ -232,7 +232,7 @@ mod test {
         assert_eq!(
             slice(&delta, 1024 + 10, 1024 + 250)
                 .unwrap()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
             ((1024 + 10u32)..(1024 + 250)).collect::<Vec<_>>()
@@ -246,7 +246,7 @@ mod test {
         assert_eq!(
             slice(&delta, 0, 0)
                 .unwrap()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
             Vec::<u32>::new(),
@@ -255,7 +255,7 @@ mod test {
         assert_eq!(
             slice(&delta, 4000, 4000)
                 .unwrap()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
             Vec::<u32>::new(),
@@ -264,7 +264,7 @@ mod test {
         assert_eq!(
             slice(&delta, 1024, 1024)
                 .unwrap()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
             Vec::<u32>::new(),
@@ -279,7 +279,10 @@ mod test {
         let sliced_again = slice(sliced, 0, 2).unwrap();
 
         assert_eq!(
-            sliced_again.into_primitive().unwrap().as_slice::<u32>(),
+            sliced_again
+                .into_canonical_primitive()
+                .unwrap()
+                .as_slice::<u32>(),
             vec![10, 11]
         );
     }
@@ -292,7 +295,10 @@ mod test {
         let sliced_again = slice(sliced, 0, 2).unwrap();
 
         assert_eq!(
-            sliced_again.into_primitive().unwrap().as_slice::<u32>(),
+            sliced_again
+                .into_canonical_primitive()
+                .unwrap()
+                .as_slice::<u32>(),
             vec![10, 11]
         );
     }
@@ -305,7 +311,10 @@ mod test {
         let sliced_again = slice(sliced, 0, 2).unwrap();
 
         assert_eq!(
-            sliced_again.into_primitive().unwrap().as_slice::<u32>(),
+            sliced_again
+                .into_canonical_primitive()
+                .unwrap()
+                .as_slice::<u32>(),
             vec![1034, 1035]
         );
     }
@@ -318,7 +327,10 @@ mod test {
         let sliced_again = slice(sliced, 0, 2).unwrap();
 
         assert_eq!(
-            sliced_again.into_primitive().unwrap().as_slice::<u32>(),
+            sliced_again
+                .into_canonical_primitive()
+                .unwrap()
+                .as_slice::<u32>(),
             vec![1034, 1035]
         );
     }
@@ -331,7 +343,10 @@ mod test {
         let sliced_again = slice(sliced, 5, 20).unwrap();
 
         assert_eq!(
-            sliced_again.into_primitive().unwrap().as_slice::<u32>(),
+            sliced_again
+                .into_canonical_primitive()
+                .unwrap()
+                .as_slice::<u32>(),
             (1015..1030).collect::<Vec<_>>(),
         );
     }
@@ -344,7 +359,10 @@ mod test {
         let sliced_again = slice(sliced, 5, 20).unwrap();
 
         assert_eq!(
-            sliced_again.into_primitive().unwrap().as_slice::<u32>(),
+            sliced_again
+                .into_canonical_primitive()
+                .unwrap()
+                .as_slice::<u32>(),
             (1015..1030).collect::<Vec<_>>(),
         );
     }

--- a/encodings/fastlanes/src/for/compress.rs
+++ b/encodings/fastlanes/src/for/compress.rs
@@ -60,7 +60,7 @@ fn encoded_zero<T: NativePType>(
         LogicalValidity::Array(a) => {
             let len = a.len();
             let valid_indices = a
-                .into_bool()?
+                .into_canonical_bool()?
                 .boolean_buffer()
                 .set_indices()
                 .map(|i| i as u64)
@@ -97,7 +97,10 @@ pub fn decompress(array: FoRArray) -> VortexResult<PrimitiveArray> {
     let ptype = array.ptype();
 
     // TODO(ngates): do we need this to be into_encoded() somehow?
-    let encoded = array.encoded().into_primitive()?.reinterpret_cast(ptype);
+    let encoded = array
+        .encoded()
+        .into_canonical_primitive()?
+        .reinterpret_cast(ptype);
     let validity = encoded.validity();
 
     Ok(match_each_integer_ptype!(ptype, |$T| {
@@ -215,7 +218,7 @@ mod test {
         let array = PrimitiveArray::from_iter((0u32..100_000).step_by(1024).map(|v| v + 1_000_000));
         let compressed = for_compress(array.clone()).unwrap();
         assert!(compressed.shift() > 0);
-        let decompressed = compressed.into_primitive().unwrap();
+        let decompressed = compressed.into_canonical_primitive().unwrap();
         assert_eq!(decompressed.as_slice::<u32>(), array.as_slice::<u32>());
     }
 
@@ -232,12 +235,16 @@ mod test {
                 .unwrap()
         );
 
-        let encoded = compressed.encoded().into_primitive().unwrap();
+        let encoded = compressed.encoded().into_canonical_primitive().unwrap();
         let encoded_bytes: &[u8] = encoded.as_slice::<u8>();
         let unsigned: Vec<u8> = (0..=u8::MAX).collect_vec();
         assert_eq!(encoded_bytes, unsigned.as_slice());
 
-        let decompressed = compressed.as_ref().clone().into_primitive().unwrap();
+        let decompressed = compressed
+            .as_ref()
+            .clone()
+            .into_canonical_primitive()
+            .unwrap();
         assert_eq!(decompressed.as_slice::<i8>(), array.as_slice::<i8>());
         array
             .as_slice::<i8>()

--- a/encodings/fsst/src/compute/compare.rs
+++ b/encodings/fsst/src/compute/compare.rs
@@ -43,10 +43,10 @@ fn compare_fsst_constant(
     right: &ConstantArray,
     equal: bool,
 ) -> VortexResult<ArrayData> {
-    let symbols = left.symbols().into_primitive()?;
+    let symbols = left.symbols().into_canonical_primitive()?;
     let symbols_u64 = symbols.as_slice::<u64>();
 
-    let symbol_lens = left.symbol_lengths().into_primitive()?;
+    let symbol_lens = left.symbol_lengths().into_canonical_primitive()?;
     let symbol_lens_u8 = symbol_lens.as_slice::<u8>();
 
     let mut compressor = fsst::CompressorBuilder::new();
@@ -115,7 +115,7 @@ mod tests {
         // Ensure fastpath for Eq exists, and returns correct answer
         let equals: Vec<bool> = compare(&lhs, &rhs, Operator::Eq)
             .unwrap()
-            .into_bool()
+            .into_canonical_bool()
             .unwrap()
             .boolean_buffer()
             .into_iter()
@@ -126,7 +126,7 @@ mod tests {
         // Ensure fastpath for Eq exists, and returns correct answer
         let not_equals: Vec<bool> = compare(&lhs, &rhs, Operator::NotEq)
             .unwrap()
-            .into_bool()
+            .into_canonical_bool()
             .unwrap()
             .boolean_buffer()
             .into_iter()

--- a/encodings/roaring/src/boolean/compute.rs
+++ b/encodings/roaring/src/boolean/compute.rs
@@ -83,7 +83,7 @@ mod tests {
 
         assert_eq!(
             sliced
-                .into_bool()
+                .into_canonical_bool()
                 .unwrap()
                 .boolean_buffer()
                 .iter()

--- a/encodings/roaring/src/boolean/mod.rs
+++ b/encodings/roaring/src/boolean/mod.rs
@@ -162,7 +162,7 @@ mod test {
             BoolArray::from_iter([true, true].into_iter().chain(iter::repeat_n(false, 100)));
         let array = RoaringBoolArray::encode(bool.into_array()).unwrap();
         let round_trip = RoaringBoolArray::try_from(array).unwrap();
-        let bool_arr = round_trip.into_bool().unwrap();
+        let bool_arr = round_trip.into_canonical_bool().unwrap();
         assert_eq!(bool_arr.len(), 102);
     }
 }

--- a/encodings/runend-bool/src/array.rs
+++ b/encodings/runend-bool/src/array.rs
@@ -195,7 +195,7 @@ impl ValidityVTable<RunEndBoolArray> for RunEndBoolEncoding {
 
 impl IntoCanonical for RunEndBoolArray {
     fn into_canonical(self) -> VortexResult<Canonical> {
-        let pends = self.ends().into_primitive()?;
+        let pends = self.ends().into_canonical_primitive()?;
         decode_runend_bool(
             &pends,
             self.start(),
@@ -219,7 +219,7 @@ impl StatisticsVTable<RunEndBoolArray> for RunEndBoolEncoding {
         let maybe_scalar: Option<Scalar> = match stat {
             Stat::NullCount => Some(array.validity().null_count(array.len())?.into()),
             Stat::TrueCount => {
-                let pends = array.ends().into_primitive()?;
+                let pends = array.ends().into_canonical_primitive()?;
                 let mut true_count: usize = 0;
                 let mut prev_end: usize = 0;
                 let mut include = array.start();

--- a/encodings/runend-bool/src/compress.rs
+++ b/encodings/runend-bool/src/compress.rs
@@ -160,13 +160,16 @@ mod test {
         let mut rng = StdRng::seed_from_u64(39451);
         let input = (0..16 * 8 - 61).map(|_x| rng.gen::<bool>()).collect_vec();
         let b = BoolArray::from_iter(input.clone());
-        let b = slice(b, 3, 16 * 8 - 66).unwrap().into_bool().unwrap();
+        let b = slice(b, 3, 16 * 8 - 66)
+            .unwrap()
+            .into_canonical_bool()
+            .unwrap();
         let (ends, start) = runend_bool_encode_slice(&b.boolean_buffer());
         let ends = PrimitiveArray::new(ends, Validity::NonNullable);
 
         let decoded = decode_runend_bool(&ends, start, Validity::NonNullable, 0, 16 * 8 - 69)
             .unwrap()
-            .into_bool()
+            .into_canonical_bool()
             .unwrap()
             .boolean_buffer()
             .iter()

--- a/encodings/runend-bool/src/compute/mod.rs
+++ b/encodings/runend-bool/src/compute/mod.rs
@@ -39,7 +39,7 @@ impl ScalarAtFn<RunEndBoolArray> for RunEndBoolEncoding {
 
 impl TakeFn<RunEndBoolArray> for RunEndBoolEncoding {
     fn take(&self, array: &RunEndBoolArray, indices: &ArrayData) -> VortexResult<ArrayData> {
-        let primitive_indices = indices.clone().into_primitive()?;
+        let primitive_indices = indices.clone().into_canonical_primitive()?;
         let physical_indices = match_each_integer_ptype!(primitive_indices.ptype(), |$P| {
             primitive_indices
                 .as_slice::<$P>()
@@ -149,7 +149,7 @@ mod tests {
         .unwrap();
 
         let taken = take(&re_array, PrimitiveArray::from_iter([6, 9])).unwrap();
-        let taken_bool = taken.into_bool().unwrap();
+        let taken_bool = taken.into_canonical_bool().unwrap();
         assert_eq!(taken_bool.dtype(), re_array.dtype());
         assert_eq!(
             taken_bool.boolean_buffer(),

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -202,14 +202,14 @@ impl ValidityVTable<RunEndArray> for RunEndEncoding {
 
 impl IntoCanonical for RunEndArray {
     fn into_canonical(self) -> VortexResult<Canonical> {
-        let pends = self.ends().into_primitive()?;
+        let pends = self.ends().into_canonical_primitive()?;
         match self.dtype() {
             DType::Bool(_) => {
-                let bools = self.values().into_bool()?;
+                let bools = self.values().into_canonical_bool()?;
                 runend_decode_bools(pends, bools, self.offset(), self.len()).map(Canonical::Bool)
             }
             DType::Primitive(..) => {
-                let pvalues = self.values().into_primitive()?;
+                let pvalues = self.values().into_canonical_primitive()?;
                 runend_decode_primitive(pends, pvalues, self.offset(), self.len())
                     .map(Canonical::Primitive)
             }

--- a/encodings/runend/src/compress.rs
+++ b/encodings/runend/src/compress.rs
@@ -23,7 +23,7 @@ pub fn runend_encode(array: &PrimitiveArray) -> VortexResult<(PrimitiveArray, Ar
                 ConstantArray::new(Scalar::null(array.dtype().clone()), 1).into_array(),
             ));
         }
-        Validity::Array(a) => Some(a.into_bool()?.boolean_buffer()),
+        Validity::Array(a) => Some(a.into_canonical_bool()?.boolean_buffer()),
     };
 
     Ok(match validity {
@@ -191,7 +191,7 @@ pub fn runend_decode_typed_primitive<T: NativePType>(
             PrimitiveArray::new(buffer![T::default(); length], Validity::AllInvalid)
         }
         LogicalValidity::Array(array) => {
-            let validity = array.into_bool()?.boolean_buffer();
+            let validity = array.into_canonical_bool()?.boolean_buffer();
             let mut decoded = BufferMut::with_capacity(length);
             let mut decoded_validity = BooleanBufferBuilder::new(length);
             for (end, value) in run_ends.zip_eq(
@@ -236,7 +236,7 @@ pub fn runend_decode_typed_bool(
                 .vortex_expect("invalid array")
         }
         LogicalValidity::Array(array) => {
-            let validity = array.into_bool()?.boolean_buffer();
+            let validity = array.into_canonical_bool()?.boolean_buffer();
             let mut decoded = BooleanBufferBuilder::new(length);
             let mut decoded_validity = BooleanBufferBuilder::new(length);
             for (end, value) in run_ends.zip_eq(
@@ -275,7 +275,7 @@ mod test {
     fn encode() {
         let arr = PrimitiveArray::from_iter([1i32, 1, 2, 2, 2, 3, 3, 3, 3, 3]);
         let (ends, values) = runend_encode(&arr).unwrap();
-        let values = values.into_primitive().unwrap();
+        let values = values.into_canonical_primitive().unwrap();
 
         assert_eq!(ends.as_slice::<u64>(), vec![2, 5, 10]);
         assert_eq!(values.as_slice::<i32>(), vec![1, 2, 3]);
@@ -290,7 +290,7 @@ mod test {
             ])),
         );
         let (ends, values) = runend_encode(&arr).unwrap();
-        let values = values.into_primitive().unwrap();
+        let values = values.into_canonical_primitive().unwrap();
 
         assert_eq!(ends.as_slice::<u64>(), vec![2, 4, 5, 8, 10]);
         assert_eq!(values.as_slice::<i32>(), vec![1, 0, 2, 3, 0]);
@@ -303,7 +303,7 @@ mod test {
             Validity::from(BooleanBuffer::new_unset(5)),
         );
         let (ends, values) = runend_encode(&arr).unwrap();
-        let values = values.into_primitive().unwrap();
+        let values = values.into_canonical_primitive().unwrap();
 
         assert_eq!(ends.as_slice::<u64>(), vec![5]);
         assert_eq!(values.as_slice::<i32>(), vec![0]);

--- a/encodings/runend/src/compute/compare.rs
+++ b/encodings/runend/src/compute/compare.rs
@@ -22,8 +22,8 @@ impl CompareFn<RunEndArray> for RunEndEncoding {
             )
             .and_then(|values| {
                 runend_decode_bools(
-                    lhs.ends().into_primitive()?,
-                    values.into_bool()?,
+                    lhs.ends().into_canonical_primitive()?,
+                    values.into_canonical_bool()?,
                     lhs.offset(),
                     lhs.len(),
                 )
@@ -55,7 +55,7 @@ mod test {
     fn compare_run_end() {
         let arr = ree_array();
         let res = compare(arr, ConstantArray::new(5, 12), Operator::Eq).unwrap();
-        let res_canon = res.into_bool().unwrap();
+        let res_canon = res.into_canonical_bool().unwrap();
         assert_eq!(
             res_canon.boolean_buffer(),
             BooleanBuffer::from(vec![

--- a/encodings/runend/src/compute/filter.rs
+++ b/encodings/runend/src/compute/filter.rs
@@ -27,7 +27,7 @@ impl FilterFn<RunEndArray> for RunEndEncoding {
         } else {
             // This strategy ends up being close to fixed cost based on the number of runs,
             // rather than the number of indices.
-            let primitive_run_ends = array.ends().into_primitive()?;
+            let primitive_run_ends = array.ends().into_canonical_primitive()?;
             let (run_ends, values_mask) = match_each_unsigned_integer_ptype!(primitive_run_ends.ptype(), |$P| {
                 filter_run_end_primitive(primitive_run_ends.as_slice::<$P>(), array.offset() as u64, array.len() as u64, mask)?
             });
@@ -40,7 +40,7 @@ impl FilterFn<RunEndArray> for RunEndEncoding {
 
 // We expose this function to our benchmarks.
 pub fn filter_run_end(array: &RunEndArray, mask: &FilterMask) -> VortexResult<ArrayData> {
-    let primitive_run_ends = array.ends().into_primitive()?;
+    let primitive_run_ends = array.ends().into_canonical_primitive()?;
     let (run_ends, values_mask) = match_each_unsigned_integer_ptype!(primitive_run_ends.ptype(), |$P| {
         filter_run_end_primitive(primitive_run_ends.as_slice::<$P>(), array.offset() as u64, array.len() as u64, mask)?
     });
@@ -121,7 +121,7 @@ mod tests {
         assert_eq!(
             filtered_run_end
                 .ends()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<u64>(),
             [2, 4]
@@ -129,7 +129,7 @@ mod tests {
         assert_eq!(
             filtered_run_end
                 .values()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<i32>(),
             [1, 5]
@@ -149,7 +149,7 @@ mod tests {
         assert_eq!(
             filtered_run_end
                 .ends()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<u64>(),
             [1, 2, 3]
@@ -157,7 +157,7 @@ mod tests {
         assert_eq!(
             filtered_run_end
                 .values()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<i32>(),
             [1, 4, 2]

--- a/encodings/runend/src/compute/slice.rs
+++ b/encodings/runend/src/compute/slice.rs
@@ -61,7 +61,7 @@ mod tests {
         assert_eq!(arr.len(), 5);
 
         assert_eq!(
-            arr.into_primitive().unwrap().as_slice::<i32>(),
+            arr.into_canonical_primitive().unwrap().as_slice::<i32>(),
             vec![2, 2, 3, 3, 3]
         );
     }
@@ -84,7 +84,10 @@ mod tests {
         let doubly_sliced = slice(&arr, 0, 3).unwrap();
 
         assert_eq!(
-            doubly_sliced.into_primitive().unwrap().as_slice::<i32>(),
+            doubly_sliced
+                .into_canonical_primitive()
+                .unwrap()
+                .as_slice::<i32>(),
             vec![2, 2, 3]
         );
     }
@@ -109,7 +112,7 @@ mod tests {
         assert_eq!(arr.len(), 6);
 
         assert_eq!(
-            arr.into_primitive().unwrap().as_slice::<i32>(),
+            arr.into_canonical_primitive().unwrap().as_slice::<i32>(),
             vec![2, 3, 3, 3, 3, 3]
         );
     }

--- a/encodings/runend/src/compute/take.rs
+++ b/encodings/runend/src/compute/take.rs
@@ -9,7 +9,7 @@ use crate::{RunEndArray, RunEndEncoding};
 
 impl TakeFn<RunEndArray> for RunEndEncoding {
     fn take(&self, array: &RunEndArray, indices: &ArrayData) -> VortexResult<ArrayData> {
-        let primitive_indices = indices.clone().into_primitive()?;
+        let primitive_indices = indices.clone().into_canonical_primitive()?;
 
         let checked_indices = match_each_integer_ptype!(primitive_indices.ptype(), |$P| {
             primitive_indices
@@ -65,7 +65,7 @@ mod test {
         )
         .unwrap();
         assert_eq!(
-            taken.into_primitive().unwrap().as_slice::<i32>(),
+            taken.into_canonical_primitive().unwrap().as_slice::<i32>(),
             &[5, 5, 1, 4]
         );
     }
@@ -77,7 +77,10 @@ mod test {
             PrimitiveArray::from_iter([11]).as_ref(),
         )
         .unwrap();
-        assert_eq!(taken.into_primitive().unwrap().as_slice::<i32>(), &[5]);
+        assert_eq!(
+            taken.into_canonical_primitive().unwrap().as_slice::<i32>(),
+            &[5]
+        );
     }
 
     #[test]

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -127,7 +127,7 @@ impl StatisticsVTable<ZigZagArray> for ZigZagEncoding {
 
 impl IntoCanonical for ZigZagArray {
     fn into_canonical(self) -> VortexResult<Canonical> {
-        zigzag_decode(self.encoded().into_primitive()?).map(Canonical::Primitive)
+        zigzag_decode(self.encoded().into_canonical_primitive()?).map(Canonical::Primitive)
     }
 }
 

--- a/encodings/zigzag/src/compress.rs
+++ b/encodings/zigzag/src/compress.rs
@@ -72,7 +72,10 @@ mod test {
         let compressed = zigzag_encode(PrimitiveArray::from_iter(-100_i8..100)).unwrap();
         assert_eq!(compressed.as_ref().encoding().id(), ZigZagEncoding.id());
         assert_eq!(
-            compressed.into_primitive().unwrap().as_slice::<i8>(),
+            compressed
+                .into_canonical_primitive()
+                .unwrap()
+                .as_slice::<i8>(),
             (-100_i8..100).collect::<Vec<_>>()
         );
     }
@@ -81,7 +84,10 @@ mod test {
         let compressed = zigzag_encode(PrimitiveArray::from_iter(-100_i16..100)).unwrap();
         assert_eq!(compressed.as_ref().encoding().id(), ZigZagEncoding.id());
         assert_eq!(
-            compressed.into_primitive().unwrap().as_slice::<i16>(),
+            compressed
+                .into_canonical_primitive()
+                .unwrap()
+                .as_slice::<i16>(),
             (-100_i16..100).collect::<Vec<_>>()
         );
     }
@@ -90,7 +96,10 @@ mod test {
         let compressed = zigzag_encode(PrimitiveArray::from_iter(-100_i32..100)).unwrap();
         assert_eq!(compressed.as_ref().encoding().id(), ZigZagEncoding.id());
         assert_eq!(
-            compressed.into_primitive().unwrap().as_slice::<i32>(),
+            compressed
+                .into_canonical_primitive()
+                .unwrap()
+                .as_slice::<i32>(),
             (-100_i32..100).collect::<Vec<_>>()
         );
     }
@@ -99,7 +108,10 @@ mod test {
         let compressed = zigzag_encode(PrimitiveArray::from_iter(-100_i64..100)).unwrap();
         assert_eq!(compressed.as_ref().encoding().id(), ZigZagEncoding.id());
         assert_eq!(
-            compressed.into_primitive().unwrap().as_slice::<i64>(),
+            compressed
+                .into_canonical_primitive()
+                .unwrap()
+                .as_slice::<i64>(),
             (-100_i64..100).collect::<Vec<_>>()
         );
     }

--- a/encodings/zigzag/src/compute.rs
+++ b/encodings/zigzag/src/compute.rs
@@ -133,10 +133,13 @@ mod tests {
     fn take_zigzag() {
         let zigzag = ZigZagArray::encode(&buffer![-189, -160, 1].into_array()).unwrap();
         let indices = buffer![0, 2].into_array();
-        let actual = take(zigzag, indices).unwrap().into_primitive().unwrap();
+        let actual = take(zigzag, indices)
+            .unwrap()
+            .into_canonical_primitive()
+            .unwrap();
         let expected = ZigZagArray::encode(&buffer![-189, 1].into_array())
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
         assert_eq!(actual.into_byte_buffer(), expected.into_byte_buffer());
     }
@@ -147,11 +150,11 @@ mod tests {
         let filter_mask = BooleanBuffer::from(vec![true, false, true]).into();
         let actual = filter(&zigzag.into_array(), &filter_mask)
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
         let expected = ZigZagArray::encode(&buffer![-189, 1].into_array())
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
         assert_eq!(actual.into_byte_buffer(), expected.into_byte_buffer());
     }

--- a/fuzz/fuzz_targets/file_io.rs
+++ b/fuzz/fuzz_targets/file_io.rs
@@ -55,7 +55,11 @@ fuzz_target!(|array_data: ArrayData| -> Corpus {
             compare_struct(array_data, output);
         } else {
             let r = compare(&array_data, output, Operator::Eq).unwrap();
-            let true_count = r.into_bool().unwrap().boolean_buffer().count_set_bits();
+            let true_count = r
+                .into_canonical_bool()
+                .unwrap()
+                .boolean_buffer()
+                .count_set_bits();
             assert_eq!(true_count, array_data.len());
         }
     });

--- a/fuzz/src/filter.rs
+++ b/fuzz/src/filter.rs
@@ -14,7 +14,7 @@ pub fn filter_canonical_array(array: &ArrayData, filter: &[bool]) -> ArrayData {
         let validity_buff = array
             .logical_validity()
             .into_array()
-            .into_bool()
+            .into_canonical_bool()
             .unwrap()
             .boolean_buffer();
         Validity::from_iter(
@@ -30,7 +30,7 @@ pub fn filter_canonical_array(array: &ArrayData, filter: &[bool]) -> ArrayData {
 
     match array.dtype() {
         DType::Bool(_) => {
-            let bool_array = array.clone().into_bool().unwrap();
+            let bool_array = array.clone().into_canonical_bool().unwrap();
             BoolArray::try_new(
                 BooleanBuffer::from_iter(
                     filter
@@ -45,7 +45,7 @@ pub fn filter_canonical_array(array: &ArrayData, filter: &[bool]) -> ArrayData {
             .into_array()
         }
         DType::Primitive(p, _) => match_each_native_ptype!(p, |$P| {
-            let primitive_array = array.clone().into_primitive().unwrap();
+            let primitive_array = array.clone().into_canonical_primitive().unwrap();
             PrimitiveArray::new(
                 filter
                     .iter()
@@ -58,7 +58,7 @@ pub fn filter_canonical_array(array: &ArrayData, filter: &[bool]) -> ArrayData {
             .into_array()
         }),
         DType::Utf8(_) | DType::Binary(_) => {
-            let utf8 = array.clone().into_varbinview().unwrap();
+            let utf8 = array.clone().into_canonical_varbinview().unwrap();
             let values = utf8
                 .with_iterator(|iter| {
                     iter.zip(filter.iter())
@@ -70,7 +70,7 @@ pub fn filter_canonical_array(array: &ArrayData, filter: &[bool]) -> ArrayData {
             VarBinViewArray::from_iter(values, array.dtype().clone()).into_array()
         }
         DType::Struct(..) => {
-            let struct_array = array.clone().into_struct().unwrap();
+            let struct_array = array.clone().into_canonical_struct().unwrap();
             let filtered_children = struct_array
                 .children()
                 .map(|c| filter_canonical_array(&c, filter))

--- a/fuzz/src/search_sorted.rs
+++ b/fuzz/src/search_sorted.rs
@@ -63,11 +63,11 @@ pub fn search_sorted_canonical_array(
 ) -> SearchResult {
     match array.dtype() {
         DType::Bool(_) => {
-            let bool_array = array.clone().into_bool().unwrap();
+            let bool_array = array.clone().into_canonical_bool().unwrap();
             let validity = bool_array
                 .logical_validity()
                 .into_array()
-                .into_bool()
+                .into_canonical_bool()
                 .unwrap()
                 .boolean_buffer();
             let opt_values = bool_array
@@ -80,11 +80,11 @@ pub fn search_sorted_canonical_array(
             SearchNullableSlice(opt_values).search_sorted(&Some(to_find), side)
         }
         DType::Primitive(p, _) => {
-            let primitive_array = array.clone().into_primitive().unwrap();
+            let primitive_array = array.clone().into_canonical_primitive().unwrap();
             let validity = primitive_array
                 .logical_validity()
                 .into_array()
-                .into_bool()
+                .into_canonical_bool()
                 .unwrap()
                 .boolean_buffer();
             match_each_native_ptype!(p, |$P| {
@@ -100,7 +100,7 @@ pub fn search_sorted_canonical_array(
             })
         }
         DType::Utf8(_) | DType::Binary(_) => {
-            let utf8 = array.clone().into_varbinview().unwrap();
+            let utf8 = array.clone().into_canonical_varbinview().unwrap();
             let opt_values = utf8
                 .with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())
                 .unwrap();

--- a/fuzz/src/slice.rs
+++ b/fuzz/src/slice.rs
@@ -12,7 +12,7 @@ pub fn slice_canonical_array(array: &ArrayData, start: usize, stop: usize) -> Ar
         let bool_buff = array
             .logical_validity()
             .into_array()
-            .into_bool()
+            .into_canonical_bool()
             .unwrap()
             .boolean_buffer();
 
@@ -23,20 +23,20 @@ pub fn slice_canonical_array(array: &ArrayData, start: usize, stop: usize) -> Ar
 
     match array.dtype() {
         DType::Bool(_) => {
-            let bool_array = array.clone().into_bool().unwrap();
+            let bool_array = array.clone().into_canonical_bool().unwrap();
             let sliced_bools = bool_array.boolean_buffer().slice(start, stop - start);
             BoolArray::try_new(sliced_bools, validity)
                 .vortex_expect("Validity length cannot mismatch")
                 .into_array()
         }
         DType::Primitive(p, _) => {
-            let primitive_array = array.clone().into_primitive().unwrap();
+            let primitive_array = array.clone().into_canonical_primitive().unwrap();
             match_each_native_ptype!(p, |$P| {
                 PrimitiveArray::new(primitive_array.buffer::<$P>().slice(start..stop), validity).into_array()
             })
         }
         DType::Utf8(_) | DType::Binary(_) => {
-            let utf8 = array.clone().into_varbinview().unwrap();
+            let utf8 = array.clone().into_canonical_varbinview().unwrap();
             let values = utf8
                 .with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())
                 .unwrap();
@@ -44,7 +44,7 @@ pub fn slice_canonical_array(array: &ArrayData, start: usize, stop: usize) -> Ar
                 .into_array()
         }
         DType::Struct(..) => {
-            let struct_array = array.clone().into_struct().unwrap();
+            let struct_array = array.clone().into_canonical_struct().unwrap();
             let sliced_children = struct_array
                 .children()
                 .map(|c| slice_canonical_array(&c, start, stop))
@@ -59,9 +59,9 @@ pub fn slice_canonical_array(array: &ArrayData, start: usize, stop: usize) -> Ar
             .into_array()
         }
         DType::List(..) => {
-            let list_array = array.clone().into_list().unwrap();
+            let list_array = array.clone().into_canonical_list().unwrap();
             let offsets = slice_canonical_array(&list_array.offsets(), start, stop + 1)
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap();
 
             let elements = slice_canonical_array(

--- a/fuzz/src/sort.rs
+++ b/fuzz/src/sort.rs
@@ -12,7 +12,7 @@ use crate::take::take_canonical_array;
 pub fn sort_canonical_array(array: &ArrayData) -> ArrayData {
     match array.dtype() {
         DType::Bool(_) => {
-            let bool_array = array.clone().into_bool().unwrap();
+            let bool_array = array.clone().into_canonical_bool().unwrap();
             let mut opt_values = bool_array
                 .boolean_buffer()
                 .iter()
@@ -20,7 +20,7 @@ pub fn sort_canonical_array(array: &ArrayData) -> ArrayData {
                     bool_array
                         .logical_validity()
                         .into_array()
-                        .into_bool()
+                        .into_canonical_bool()
                         .unwrap()
                         .boolean_buffer()
                         .iter(),
@@ -31,21 +31,19 @@ pub fn sort_canonical_array(array: &ArrayData) -> ArrayData {
             BoolArray::from_iter(opt_values).into_array()
         }
         DType::Primitive(p, _) => {
-            let primitive_array = array.clone().into_primitive().unwrap();
+            let primitive_array = array.clone().into_canonical_primitive().unwrap();
+            let validity_buf = primitive_array
+                .logical_validity()
+                .into_array()
+                .into_canonical_bool()
+                .unwrap()
+                .boolean_buffer();
             match_each_native_ptype!(p, |$P| {
                 let mut opt_values = primitive_array
                     .as_slice::<$P>()
                     .iter()
                     .copied()
-                    .zip(
-                        primitive_array
-                            .logical_validity()
-                            .into_array()
-                            .into_bool()
-                            .unwrap()
-                            .boolean_buffer()
-                            .iter(),
-                    )
+                    .zip(validity_buf.iter())
                     .map(|(p, v)| v.then_some(p))
                     .collect::<Vec<_>>();
                 sort_primitive_slice(&mut opt_values);
@@ -53,7 +51,7 @@ pub fn sort_canonical_array(array: &ArrayData) -> ArrayData {
             })
         }
         DType::Utf8(_) | DType::Binary(_) => {
-            let utf8 = array.clone().into_varbinview().unwrap();
+            let utf8 = array.clone().into_canonical_varbinview().unwrap();
             let mut opt_values = utf8
                 .with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())
                 .unwrap();

--- a/fuzz/src/take.rs
+++ b/fuzz/src/take.rs
@@ -15,7 +15,7 @@ pub fn take_canonical_array(array: &ArrayData, indices: &[usize]) -> ArrayData {
         let validity_idx = array
             .logical_validity()
             .into_array()
-            .into_bool()
+            .into_canonical_bool()
             .unwrap()
             .boolean_buffer()
             .iter()
@@ -28,20 +28,20 @@ pub fn take_canonical_array(array: &ArrayData, indices: &[usize]) -> ArrayData {
 
     match array.dtype() {
         DType::Bool(_) => {
-            let bool_array = array.clone().into_bool().unwrap();
+            let bool_array = array.clone().into_canonical_bool().unwrap();
             let vec_values = bool_array.boolean_buffer().iter().collect::<Vec<_>>();
             BoolArray::try_new(indices.iter().map(|i| vec_values[*i]).collect(), validity)
                 .vortex_expect("Validity length cannot mismatch")
                 .into_array()
         }
         DType::Primitive(p, _) => {
-            let primitive_array = array.clone().into_primitive().unwrap();
+            let primitive_array = array.clone().into_canonical_primitive().unwrap();
             match_each_native_ptype!(p, |$P| {
                 take_primitive::<$P>(primitive_array, validity, indices)
             })
         }
         DType::Utf8(_) | DType::Binary(_) => {
-            let utf8 = array.clone().into_varbinview().unwrap();
+            let utf8 = array.clone().into_canonical_varbinview().unwrap();
             let values = utf8
                 .with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())
                 .unwrap();
@@ -52,7 +52,7 @@ pub fn take_canonical_array(array: &ArrayData, indices: &[usize]) -> ArrayData {
             .into_array()
         }
         DType::Struct(..) => {
-            let struct_array = array.clone().into_struct().unwrap();
+            let struct_array = array.clone().into_canonical_struct().unwrap();
             let taken_children = struct_array
                 .children()
                 .map(|c| take_canonical_array(&c, indices))

--- a/pyvortex/src/dataset.rs
+++ b/pyvortex/src/dataset.rs
@@ -37,7 +37,7 @@ pub async fn read_array_from_reader<T: VortexReadAt + Unpin + 'static>(
     }
 
     if let Some(indices) = indices {
-        let indices = indices.into_primitive()?.into_buffer();
+        let indices = indices.into_canonical_primitive()?.into_buffer();
         scan = scan.with_row_indices(indices);
     }
 
@@ -127,7 +127,7 @@ impl TokioFileDataset {
         }
 
         if let Some(indices) = indices.map(PyArray::unwrap).cloned() {
-            let indices = indices.into_primitive()?.into_buffer();
+            let indices = indices.into_canonical_primitive()?.into_buffer();
             scan = scan.with_row_indices(indices);
         }
 
@@ -216,7 +216,7 @@ impl ObjectStoreUrlDataset {
         }
 
         if let Some(indices) = indices.map(PyArray::unwrap).cloned() {
-            let indices = indices.into_primitive()?.into_buffer();
+            let indices = indices.into_canonical_primitive()?.into_buffer();
             scan = scan.with_row_indices(indices);
         }
 

--- a/vortex-array/benches/take_strings.rs
+++ b/vortex-array/benches/take_strings.rs
@@ -31,7 +31,7 @@ fn bench_varbin(c: &mut Criterion) {
 }
 
 fn bench_varbinview(c: &mut Criterion) {
-    let array = fixture(65_535).into_varbinview().unwrap();
+    let array = fixture(65_535).into_canonical_varbinview().unwrap();
     let indices = indices(1024);
 
     c.bench_function("varbinview", |b| {

--- a/vortex-array/src/array/arbitrary.rs
+++ b/vortex-array/src/array/arbitrary.rs
@@ -48,7 +48,7 @@ fn random_array(u: &mut Unstructured, dtype: &DType, len: Option<usize>) -> Resu
                     PType::I32 => random_primitive::<i32>(u, *n, chunk_len),
                     PType::I64 => random_primitive::<i64>(u, *n, chunk_len),
                     PType::F16 => Ok(random_primitive::<u16>(u, *n, chunk_len)?
-                        .into_primitive()
+                        .into_canonical_primitive()
                         .vortex_unwrap()
                         .reinterpret_cast(PType::F16)
                         .into_array()),

--- a/vortex-array/src/array/bool/compute/fill_null.rs
+++ b/vortex-array/src/array/bool/compute/fill_null.rs
@@ -19,9 +19,9 @@ impl FillNullFn<BoolArray> for BoolEncoding {
             Validity::AllInvalid => ConstantArray::new(fill, array.len()).into_array(),
             Validity::Array(v) => {
                 let bool_buffer = if fill {
-                    &array.boolean_buffer() | &!&v.into_bool()?.boolean_buffer()
+                    &array.boolean_buffer() | &!&v.into_canonical_bool()?.boolean_buffer()
                 } else {
-                    &array.boolean_buffer() & &v.into_bool()?.boolean_buffer()
+                    &array.boolean_buffer() & &v.into_canonical_bool()?.boolean_buffer()
                 };
                 BoolArray::from(bool_buffer).into_array()
             }
@@ -51,7 +51,7 @@ mod tests {
         .unwrap();
         let non_null_array = fill_null(bool_array, fill_value.into())
             .unwrap()
-            .into_bool()
+            .into_canonical_bool()
             .unwrap();
         assert_eq!(
             non_null_array.boolean_buffer().iter().collect::<Vec<_>>(),

--- a/vortex-array/src/array/bool/compute/filter.rs
+++ b/vortex-array/src/array/bool/compute/filter.rs
@@ -80,7 +80,7 @@ mod test {
 
         let filtered = filter(&arr.into_array(), &mask)
             .unwrap()
-            .into_bool()
+            .into_canonical_bool()
             .unwrap();
         assert_eq!(2, filtered.len());
 

--- a/vortex-array/src/array/bool/compute/take.rs
+++ b/vortex-array/src/array/bool/compute/take.rs
@@ -12,7 +12,7 @@ use crate::{ArrayData, ArrayLen, IntoArrayData, IntoArrayVariant};
 impl TakeFn<BoolArray> for BoolEncoding {
     fn take(&self, array: &BoolArray, indices: &ArrayData) -> VortexResult<ArrayData> {
         let validity = array.validity();
-        let indices = indices.clone().into_primitive()?;
+        let indices = indices.clone().into_canonical_primitive()?;
 
         // For boolean arrays that roughly fit into a single page (at least, on Linux), it's worth
         // the overhead to convert to a Vec<bool>.
@@ -36,7 +36,7 @@ impl TakeFn<BoolArray> for BoolEncoding {
         indices: &ArrayData,
     ) -> VortexResult<ArrayData> {
         let validity = array.validity();
-        let indices = indices.clone().into_primitive()?;
+        let indices = indices.clone().into_canonical_primitive()?;
 
         // For boolean arrays that roughly fit into a single page (at least, on Linux), it's worth
         // the overhead to convert to a Vec<bool>.

--- a/vortex-array/src/array/bool/mod.rs
+++ b/vortex-array/src/array/bool/mod.rs
@@ -273,7 +273,11 @@ mod tests {
             BoolArray::from(builder.finish())
         };
         let sliced = slice(arr.clone(), 4, 12).unwrap();
-        let (values, offset) = sliced.clone().into_bool().unwrap().into_boolean_builder();
+        let (values, offset) = sliced
+            .clone()
+            .into_canonical_bool()
+            .unwrap()
+            .into_boolean_builder();
         assert_eq!(offset, 4);
         assert_eq!(values.as_slice(), &[254, 15]);
 
@@ -284,12 +288,12 @@ mod tests {
             BoolArray::from(BooleanBuffer::new_unset(1)).into_array(),
         );
         let arr = arr.patch(patches).unwrap();
-        let (values, offset) = arr.into_bool().unwrap().into_boolean_builder();
+        let (values, offset) = arr.into_canonical_bool().unwrap().into_boolean_builder();
         assert_eq!(offset, 0);
         assert_eq!(values.as_slice(), &[238, 15]);
 
         // the slice should be unchanged
-        let (values, offset) = sliced.into_bool().unwrap().into_boolean_builder();
+        let (values, offset) = sliced.into_canonical_bool().unwrap().into_boolean_builder();
         assert_eq!(offset, 4);
         assert_eq!(values.as_slice(), &[254, 15]); // unchanged
     }
@@ -310,7 +314,7 @@ mod tests {
         let arr = arr.patch(patches).unwrap();
         assert_eq!(arr.boolean_buffer().sliced().as_ptr(), buf_ptr);
 
-        let (values, offset) = arr.into_bool().unwrap().into_boolean_builder();
+        let (values, offset) = arr.into_canonical_bool().unwrap().into_boolean_builder();
         assert_eq!(offset, 0);
         assert_eq!(values.as_slice(), &[254, 127]);
     }

--- a/vortex-array/src/array/bool/patch.rs
+++ b/vortex-array/src/array/bool/patch.rs
@@ -10,8 +10,8 @@ use crate::{ArrayLen, IntoArrayVariant, ToArrayData};
 impl BoolArray {
     pub fn patch(self, patches: Patches) -> VortexResult<Self> {
         let length = self.len();
-        let indices = patches.indices().clone().into_primitive()?;
-        let values = patches.values().clone().into_bool()?;
+        let indices = patches.indices().clone().into_canonical_primitive()?;
+        let values = patches.values().clone().into_canonical_bool()?;
 
         let patched_validity =
             self.validity()
@@ -47,7 +47,7 @@ mod tests {
     fn patch_sliced_bools() {
         let arr = BoolArray::from(BooleanBuffer::new_set(12));
         let sliced = slice(arr, 4, 12).unwrap();
-        let (values, offset) = sliced.into_bool().unwrap().into_boolean_builder();
+        let (values, offset) = sliced.into_canonical_bool().unwrap().into_boolean_builder();
         assert_eq!(offset, 4);
         assert_eq!(values.as_slice(), &[255, 15]);
     }
@@ -56,7 +56,7 @@ mod tests {
     fn patch_sliced_bools_offset() {
         let arr = BoolArray::from(BooleanBuffer::new_set(15));
         let sliced = slice(arr, 4, 15).unwrap();
-        let (values, offset) = sliced.into_bool().unwrap().into_boolean_builder();
+        let (values, offset) = sliced.into_canonical_bool().unwrap().into_boolean_builder();
         assert_eq!(offset, 4);
         assert_eq!(values.as_slice(), &[255, 127]);
     }
@@ -65,7 +65,7 @@ mod tests {
     fn patch_sliced_bools_even() {
         let arr = BoolArray::from(BooleanBuffer::new_set(31));
         let sliced = slice(arr, 8, 24).unwrap();
-        let (values, offset) = sliced.into_bool().unwrap().into_boolean_builder();
+        let (values, offset) = sliced.into_canonical_bool().unwrap().into_boolean_builder();
         assert_eq!(offset, 0);
         assert_eq!(values.as_slice(), &[255, 255]);
     }

--- a/vortex-array/src/array/bool/stats.rs
+++ b/vortex-array/src/array/bool/stats.rs
@@ -29,7 +29,10 @@ impl StatisticsVTable<BoolArray> for BoolEncoding {
             LogicalValidity::AllValid(_) => self.compute_statistics(&array.boolean_buffer(), stat),
             LogicalValidity::AllInvalid(v) => Ok(StatsSet::nulls(v, array.dtype())),
             LogicalValidity::Array(a) => self.compute_statistics(
-                &NullableBools(&array.boolean_buffer(), &a.into_bool()?.boolean_buffer()),
+                &NullableBools(
+                    &array.boolean_buffer(),
+                    &a.into_canonical_bool()?.boolean_buffer(),
+                ),
                 stat,
             ),
         }

--- a/vortex-array/src/array/chunked/canonical.rs
+++ b/vortex-array/src/array/chunked/canonical.rs
@@ -77,7 +77,12 @@ pub(crate) fn try_canonicalize_chunks(
                 .iter()
                 // Extension-typed arrays can be compressed into something that is not an
                 // ExtensionArray, so we should canonicalize each chunk into ExtensionArray first.
-                .map(|chunk| chunk.clone().into_extension().map(|ext| ext.storage()))
+                .map(|chunk| {
+                    chunk
+                        .clone()
+                        .into_canonical_extension()
+                        .map(|ext| ext.storage())
+                })
                 .collect::<VortexResult<Vec<ArrayData>>>()?;
             let storage_dtype = ext_dtype.storage_dtype().clone();
             let chunked_storage =
@@ -132,13 +137,13 @@ fn pack_lists(chunks: &[ArrayData], validity: Validity, dtype: &DType) -> Vortex
         .vortex_expect("ListArray must have List dtype");
 
     for chunk in chunks {
-        let chunk = chunk.clone().into_list()?;
+        let chunk = chunk.clone().into_canonical_list()?;
         // TODO: handle i32 offsets if they fit.
         let offsets_arr = try_cast(
             chunk.offsets(),
             &DType::Primitive(PType::I64, Nullability::NonNullable),
         )?
-        .into_primitive()?;
+        .into_canonical_primitive()?;
 
         let first_offset_value: usize = usize::try_from(&scalar_at(offsets_arr.as_ref(), 0)?)?;
         let last_offset_value: usize =
@@ -200,7 +205,7 @@ fn pack_bools(chunks: &[ArrayData], validity: Validity) -> VortexResult<BoolArra
     let len = chunks.iter().map(|chunk| chunk.len()).sum();
     let mut buffer = BooleanBufferBuilder::new(len);
     for chunk in chunks {
-        let chunk = chunk.clone().into_bool()?;
+        let chunk = chunk.clone().into_canonical_bool()?;
         buffer.append_buffer(&chunk.boolean_buffer());
     }
 
@@ -219,7 +224,7 @@ fn pack_primitives<T: NativePType>(
     let total_len = chunks.iter().map(|a| a.len()).sum();
     let mut buffer = BufferMut::with_capacity(total_len);
     for chunk in chunks {
-        let chunk = chunk.clone().into_primitive()?;
+        let chunk = chunk.clone().into_canonical_primitive()?;
         buffer.extend_from_slice(chunk.as_slice::<T>());
     }
     Ok(PrimitiveArray::new(buffer.freeze(), validity))
@@ -243,7 +248,7 @@ fn pack_views(
         // As part of the packing operation, we need to rewrite them to be referenced to the global
         // merged buffers list.
         let buffers_offset = u32::try_from(buffers.len())?;
-        let canonical_chunk = chunk.clone().into_varbinview()?;
+        let canonical_chunk = chunk.clone().into_canonical_varbinview()?;
         buffers.extend(canonical_chunk.buffers());
 
         for view in canonical_chunk.views().iter() {
@@ -328,16 +333,16 @@ mod tests {
         )
         .unwrap()
         .into_array();
-        let canonical_struct = chunked.into_struct().unwrap();
+        let canonical_struct = chunked.into_canonical_struct().unwrap();
         let canonical_varbin = canonical_struct
             .maybe_null_field_by_idx(0)
             .unwrap()
-            .into_varbinview()
+            .into_canonical_varbinview()
             .unwrap();
         let original_varbin = struct_array
             .maybe_null_field_by_idx(0)
             .unwrap()
-            .into_varbinview()
+            .into_canonical_varbinview()
             .unwrap();
         let orig_values = original_varbin
             .with_iterator(|it| it.map(|a| a.map(|v| v.to_vec())).collect::<Vec<_>>())
@@ -369,7 +374,7 @@ mod tests {
             List(Arc::new(Primitive(I32, NonNullable)), NonNullable),
         );
 
-        let canon_values = chunked_list.unwrap().into_list().unwrap();
+        let canon_values = chunked_list.unwrap().into_canonical_list().unwrap();
 
         assert_eq!(
             scalar_at(l1, 0).unwrap(),

--- a/vortex-array/src/array/chunked/compute/boolean.rs
+++ b/vortex-array/src/array/chunked/compute/boolean.rs
@@ -55,7 +55,7 @@ mod tests {
                 BinaryOperator::Or
             )
             .unwrap()
-            .into_bool()
+            .into_canonical_bool()
             .unwrap()
             .boolean_buffer(),
             vec![true, true, false, false, true].into()

--- a/vortex-array/src/array/chunked/compute/mod.rs
+++ b/vortex-array/src/array/chunked/compute/mod.rs
@@ -107,7 +107,7 @@ mod test {
                 &DType::Primitive(PType::U64, Nullability::NonNullable)
             )
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap()
             .as_slice::<u64>(),
             &[0u64, 1, 2, 3],

--- a/vortex-array/src/array/chunked/compute/slice.rs
+++ b/vortex-array/src/array/chunked/compute/slice.rs
@@ -67,7 +67,7 @@ mod tests {
         ChunkedArray::try_from(arr)
             .unwrap()
             .chunks()
-            .map(|a| a.into_primitive().unwrap())
+            .map(|a| a.into_canonical_primitive().unwrap())
             .for_each(|a| values.extend_from_slice(a.as_slice::<T>()));
         assert_eq!(values, slice);
     }

--- a/vortex-array/src/array/chunked/compute/take.rs
+++ b/vortex-array/src/array/chunked/compute/take.rs
@@ -27,7 +27,7 @@ impl TakeFn<ChunkedArray> for ChunkedEncoding {
             return take_strict_sorted(array, indices);
         }
 
-        let indices = try_cast(indices, PType::U64.into())?.into_primitive()?;
+        let indices = try_cast(indices, PType::U64.into())?.into_canonical_primitive()?;
 
         // While the chunk idx remains the same, accumulate a list of chunk indices.
         let mut chunks = Vec::new();
@@ -140,7 +140,7 @@ mod test {
         let result = &ChunkedArray::try_from(take(arr.as_ref(), &indices).unwrap())
             .unwrap()
             .into_array()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
         assert_eq!(result.as_slice::<i32>(), &[1, 1, 1, 2]);
     }

--- a/vortex-array/src/array/chunked/mod.rs
+++ b/vortex-array/src/array/chunked/mod.rs
@@ -268,7 +268,7 @@ mod test {
         let results = chunks_out
             .next()
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap()
             .as_slice::<u64>()
             .to_vec();
@@ -276,7 +276,7 @@ mod test {
         let results = chunks_out
             .next()
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap()
             .as_slice::<u64>()
             .to_vec();
@@ -284,7 +284,7 @@ mod test {
         let results = chunks_out
             .next()
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap()
             .as_slice::<u64>()
             .to_vec();

--- a/vortex-array/src/array/constant/compute/boolean.rs
+++ b/vortex-array/src/array/constant/compute/boolean.rs
@@ -88,7 +88,11 @@ mod test {
     #[case(BoolArray::from_iter([Some(true), Some(false), Some(true), Some(false)].into_iter()).into_array(), ConstantArray::new(true, 4).into_array()
     )]
     fn test_or(#[case] lhs: ArrayData, #[case] rhs: ArrayData) {
-        let r = or(&lhs, &rhs).unwrap().into_bool().unwrap().into_array();
+        let r = or(&lhs, &rhs)
+            .unwrap()
+            .into_canonical_bool()
+            .unwrap()
+            .into_array();
 
         let v0 = scalar_at(&r, 0).unwrap().as_bool().value();
         let v1 = scalar_at(&r, 1).unwrap().as_bool().value();
@@ -107,7 +111,11 @@ mod test {
     #[case(BoolArray::from_iter([Some(true), Some(false), Some(true), Some(false)].into_iter()).into_array(),
         ConstantArray::new(true, 4).into_array())]
     fn test_and(#[case] lhs: ArrayData, #[case] rhs: ArrayData) {
-        let r = and(&lhs, &rhs).unwrap().into_bool().unwrap().into_array();
+        let r = and(&lhs, &rhs)
+            .unwrap()
+            .into_canonical_bool()
+            .unwrap()
+            .into_array();
 
         let v0 = scalar_at(&r, 0).unwrap().as_bool().value();
         let v1 = scalar_at(&r, 1).unwrap().as_bool().value();

--- a/vortex-array/src/array/datetime/test.rs
+++ b/vortex-array/src/array/datetime/test.rs
@@ -10,7 +10,10 @@ macro_rules! test_temporal_roundtrip {
     ($prim:ty, $constructor:expr, $unit:expr) => {{
         let array = buffer![100 as $prim].into_array();
         let temporal: TemporalArray = $constructor(array, $unit);
-        let prims = temporal.temporal_values().into_primitive().unwrap();
+        let prims = temporal
+            .temporal_values()
+            .into_canonical_primitive()
+            .unwrap();
 
         assert_eq!(prims.as_slice::<$prim>(), vec![100 as $prim].as_slice(),);
         assert_eq!(temporal.temporal_metadata().time_unit(), $unit);
@@ -122,7 +125,10 @@ fn test_timestamp() {
         for tz in [Some("UTC".to_string()), None] {
             let temporal_array = TemporalArray::new_timestamp(ts_array.clone(), unit, tz.clone());
 
-            let values = temporal_array.temporal_values().into_primitive().unwrap();
+            let values = temporal_array
+                .temporal_values()
+                .into_canonical_primitive()
+                .unwrap();
             assert_eq!(values.as_slice::<i64>(), vec![100i64].as_slice());
             assert_eq!(
                 temporal_array.temporal_metadata(),
@@ -161,7 +167,7 @@ fn test_validity_preservation(#[case] validity: Validity) {
     assert_eq!(
         temporal_array
             .temporal_values()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap()
             .validity(),
         validity

--- a/vortex-array/src/array/null/compute.rs
+++ b/vortex-array/src/array/null/compute.rs
@@ -36,7 +36,7 @@ impl ScalarAtFn<NullArray> for NullEncoding {
 
 impl TakeFn<NullArray> for NullEncoding {
     fn take(&self, array: &NullArray, indices: &ArrayData) -> VortexResult<ArrayData> {
-        let indices = indices.clone().into_primitive()?;
+        let indices = indices.clone().into_canonical_primitive()?;
 
         // Enforce all indices are valid
         match_each_integer_ptype!(indices.ptype(), |$T| {

--- a/vortex-array/src/array/primitive/compute/cast.rs
+++ b/vortex-array/src/array/primitive/compute/cast.rs
@@ -83,7 +83,7 @@ mod test {
         // cast from u32 to u8
         let p = try_cast(&arr, PType::U8.into())
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
         assert_eq!(p.as_slice::<u8>(), vec![0u8, 10, 200]);
         assert_eq!(p.validity(), Validity::NonNullable);
@@ -91,7 +91,7 @@ mod test {
         // to nullable
         let p = try_cast(&p, &DType::Primitive(PType::U8, Nullability::Nullable))
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
         assert_eq!(p.as_slice::<u8>(), vec![0u8, 10, 200]);
         assert_eq!(p.validity(), Validity::AllValid);
@@ -99,7 +99,7 @@ mod test {
         // back to non-nullable
         let p = try_cast(&p, &DType::Primitive(PType::U8, Nullability::NonNullable))
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
         assert_eq!(p.as_slice::<u8>(), vec![0u8, 10, 200]);
         assert_eq!(p.validity(), Validity::NonNullable);
@@ -107,7 +107,7 @@ mod test {
         // to nullable u32
         let p = try_cast(&p, &DType::Primitive(PType::U32, Nullability::Nullable))
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
         assert_eq!(p.as_slice::<u32>(), vec![0u32, 10, 200]);
         assert_eq!(p.validity(), Validity::AllValid);
@@ -115,7 +115,7 @@ mod test {
         // to non-nullable u8
         let p = try_cast(&p, &DType::Primitive(PType::U8, Nullability::NonNullable))
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
         assert_eq!(p.as_slice::<u8>(), vec![0u8, 10, 200]);
         assert_eq!(p.validity(), Validity::NonNullable);
@@ -126,7 +126,7 @@ mod test {
         let arr = buffer![0u32, 10, 200].into_array();
         let u8arr = try_cast(&arr, PType::F32.into())
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
         assert_eq!(u8arr.as_slice::<f32>(), vec![0.0f32, 10., 200.]);
     }

--- a/vortex-array/src/array/primitive/compute/fill.rs
+++ b/vortex-array/src/array/primitive/compute/fill.rs
@@ -72,7 +72,10 @@ mod test {
     fn leading_none() {
         let arr =
             PrimitiveArray::from_option_iter([None, Some(8u8), None, Some(10), None]).into_array();
-        let p = fill_forward(&arr).unwrap().into_primitive().unwrap();
+        let p = fill_forward(&arr)
+            .unwrap()
+            .into_canonical_primitive()
+            .unwrap();
         assert_eq!(p.as_slice::<u8>(), vec![0, 8, 8, 10, 10]);
         assert!(p.logical_validity().all_valid());
     }
@@ -82,7 +85,10 @@ mod test {
         let arr = PrimitiveArray::from_option_iter([Option::<u8>::None, None, None, None, None])
             .into_array();
 
-        let p = fill_forward(&arr).unwrap().into_primitive().unwrap();
+        let p = fill_forward(&arr)
+            .unwrap()
+            .into_canonical_primitive()
+            .unwrap();
         assert_eq!(p.as_slice::<u8>(), vec![0, 0, 0, 0, 0]);
         assert!(p.logical_validity().all_valid());
     }
@@ -94,7 +100,10 @@ mod test {
             Validity::Array(BoolArray::from_iter([true, true, true, true, true]).into_array()),
         )
         .into_array();
-        let p = fill_forward(&arr).unwrap().into_primitive().unwrap();
+        let p = fill_forward(&arr)
+            .unwrap()
+            .into_canonical_primitive()
+            .unwrap();
         assert_eq!(p.as_slice::<u8>(), vec![8, 10, 12, 14, 16]);
         assert!(p.logical_validity().all_valid());
     }

--- a/vortex-array/src/array/primitive/compute/filter.rs
+++ b/vortex-array/src/array/primitive/compute/filter.rs
@@ -57,7 +57,7 @@ mod test {
 
         let filtered = filter(&arr.to_array(), &FilterMask::from_iter(mask))
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
         assert_eq!(
             filtered.len(),

--- a/vortex-array/src/array/primitive/compute/take.rs
+++ b/vortex-array/src/array/primitive/compute/take.rs
@@ -12,7 +12,7 @@ use crate::{ArrayData, IntoArrayData, IntoArrayVariant};
 impl TakeFn<PrimitiveArray> for PrimitiveEncoding {
     #[allow(clippy::cognitive_complexity)]
     fn take(&self, array: &PrimitiveArray, indices: &ArrayData) -> VortexResult<ArrayData> {
-        let indices = indices.clone().into_primitive()?;
+        let indices = indices.clone().into_canonical_primitive()?;
         let validity = array.validity().take(indices.as_ref())?;
 
         match_each_native_ptype!(array.ptype(), |$T| {
@@ -28,7 +28,7 @@ impl TakeFn<PrimitiveArray> for PrimitiveEncoding {
         array: &PrimitiveArray,
         indices: &ArrayData,
     ) -> VortexResult<ArrayData> {
-        let indices = indices.clone().into_primitive()?;
+        let indices = indices.clone().into_canonical_primitive()?;
         let validity = unsafe { array.validity().take_unchecked(indices.as_ref())? };
 
         match_each_native_ptype!(array.ptype(), |$T| {

--- a/vortex-array/src/array/primitive/patch.rs
+++ b/vortex-array/src/array/primitive/patch.rs
@@ -12,8 +12,8 @@ impl PrimitiveArray {
     #[allow(clippy::cognitive_complexity)]
     pub fn patch(self, patches: Patches) -> VortexResult<Self> {
         let (_, patch_indices, patch_values) = patches.into_parts();
-        let patch_indices = patch_indices.into_primitive()?;
-        let patch_values = patch_values.into_primitive()?;
+        let patch_indices = patch_indices.into_canonical_primitive()?;
+        let patch_values = patch_values.into_canonical_primitive()?;
 
         let patched_validity =
             self.validity()
@@ -61,7 +61,7 @@ mod tests {
         let input = PrimitiveArray::new(buffer![2u32; 10], Validity::AllValid);
         let sliced = slice(input, 2, 8).unwrap();
         assert_eq!(
-            sliced.into_primitive().unwrap().as_slice::<u32>(),
+            sliced.into_canonical_primitive().unwrap().as_slice::<u32>(),
             &[2u32; 6]
         );
     }

--- a/vortex-array/src/array/primitive/stats.rs
+++ b/vortex-array/src/array/primitive/stats.rs
@@ -35,7 +35,7 @@ impl StatisticsVTable<PrimitiveArray> for PrimitiveEncoding {
                 LogicalValidity::Array(a) => self.compute_statistics(
                     &NullableValues(
                         array.as_slice::<$P>(),
-                        &a.clone().into_bool()?.boolean_buffer(),
+                        &a.clone().into_canonical_bool()?.boolean_buffer(),
                     ),
                     stat
                 ),

--- a/vortex-array/src/array/sparse/compute/mod.rs
+++ b/vortex-array/src/array/sparse/compute/mod.rs
@@ -215,7 +215,7 @@ mod test {
         let primitive = filtered_array
             .patches()
             .into_indices()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
 
         assert_eq!(primitive.as_slice::<u64>(), &[1, 3]);

--- a/vortex-array/src/array/sparse/compute/slice.rs
+++ b/vortex-array/src/array/sparse/compute/slice.rs
@@ -50,7 +50,7 @@ mod tests {
             .unwrap()
             .patches()
             .into_values()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
 
         assert_eq!(primitive.as_slice::<u32>(), &[13531]);
@@ -71,7 +71,7 @@ mod tests {
             .unwrap()
             .patches()
             .into_values()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
 
         assert_eq!(primitive.as_slice::<u32>(), &[13531]);
@@ -81,7 +81,7 @@ mod tests {
             .unwrap()
             .patches()
             .into_values()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
 
         assert_eq!(primitive_doubly_sliced.as_slice::<u32>(), &[13531]);
@@ -97,7 +97,11 @@ mod tests {
         let mut expected = vec![999u64; 1000];
         expected[0] = 0;
 
-        let actual = sliced.into_primitive().unwrap().as_slice::<u64>().to_vec();
+        let actual = sliced
+            .into_canonical_primitive()
+            .unwrap()
+            .as_slice::<u64>()
+            .to_vec();
         assert_eq!(expected, actual);
     }
 }

--- a/vortex-array/src/array/sparse/compute/take.rs
+++ b/vortex-array/src/array/sparse/compute/take.rs
@@ -66,7 +66,7 @@ mod test {
             taken
                 .patches()
                 .into_indices()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<u64>(),
             [0, 1, 2, 3, 4]
@@ -75,7 +75,7 @@ mod test {
             taken
                 .patches()
                 .into_values()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<f64>(),
             [1.23f64, 9.99, 9.99, 1.23, 3.5]
@@ -99,7 +99,7 @@ mod test {
             taken
                 .patches()
                 .into_indices()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<u64>(),
             [1]
@@ -108,7 +108,7 @@ mod test {
             taken
                 .patches()
                 .into_values()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<f64>(),
             [0.47f64]

--- a/vortex-array/src/array/sparse/mod.rs
+++ b/vortex-array/src/array/sparse/mod.rs
@@ -327,7 +327,11 @@ mod test {
     #[test]
     pub fn sparse_logical_validity() {
         let array = sparse_array(nullable_fill());
-        let validity = array.logical_validity().into_array().into_bool().unwrap();
+        let validity = array
+            .logical_validity()
+            .into_array()
+            .into_canonical_bool()
+            .unwrap();
         assert_eq!(
             validity.boolean_buffer().iter().collect_vec(),
             [false, false, true, false, false, true, false, false, true, false]
@@ -342,7 +346,7 @@ mod test {
             array
                 .logical_validity()
                 .into_array()
-                .into_bool()
+                .into_canonical_bool()
                 .unwrap()
                 .boolean_buffer()
                 .iter()

--- a/vortex-array/src/array/sparse/variants.rs
+++ b/vortex-array/src/array/sparse/variants.rs
@@ -145,7 +145,7 @@ mod tests {
         let inverted = invert(&sparse_bools).unwrap();
         assert_eq!(
             inverted
-                .into_bool()
+                .into_canonical_bool()
                 .unwrap()
                 .boolean_buffer()
                 .iter()

--- a/vortex-array/src/array/varbin/accessor.rs
+++ b/vortex-array/src/array/varbin/accessor.rs
@@ -13,7 +13,7 @@ impl ArrayAccessor<[u8]> for VarBinArray {
     where
         F: for<'a> FnOnce(&mut (dyn Iterator<Item = Option<&'a [u8]>>)) -> R,
     {
-        let offsets = self.offsets().into_primitive()?;
+        let offsets = self.offsets().into_canonical_primitive()?;
         let validity = self.logical_validity().to_null_buffer()?;
 
         // TODO(ngates): what happens if bytes is much larger than sliced_bytes?

--- a/vortex-array/src/array/varbin/arrow.rs
+++ b/vortex-array/src/array/varbin/arrow.rs
@@ -14,7 +14,7 @@ use crate::{ArrayDType, IntoArrayVariant, ToArrayData};
 pub(crate) fn varbin_to_arrow(varbin_array: &VarBinArray) -> VortexResult<ArrayRef> {
     let offsets = varbin_array
         .offsets()
-        .into_primitive()
+        .into_canonical_primitive()
         .map_err(|err| err.with_context("Failed to canonicalize offsets"))?;
     let offsets = match offsets.ptype() {
         PType::I32 | PType::I64 => offsets,
@@ -23,7 +23,7 @@ pub(crate) fn varbin_to_arrow(varbin_array: &VarBinArray) -> VortexResult<ArrayR
 
         // Unless it's u64, everything else can be converted into an i32.
         _ => try_cast(offsets.to_array(), PType::I32.into())
-            .and_then(|a| a.into_primitive())
+            .and_then(|a| a.into_canonical_primitive())
             .map_err(|err| err.with_context("Failed to cast offsets to PrimitiveArray of i32"))?,
     };
     let nulls = varbin_array

--- a/vortex-array/src/array/varbin/compute/filter.rs
+++ b/vortex-array/src/array/varbin/compute/filter.rs
@@ -31,7 +31,7 @@ fn filter_select_var_bin_by_slice(
     mask: &FilterMask,
     selection_count: usize,
 ) -> VortexResult<VarBinArray> {
-    let offsets = values.offsets().into_primitive()?;
+    let offsets = values.offsets().into_canonical_primitive()?;
     match_each_integer_ptype!(offsets.ptype(), |$O| {
         filter_select_var_bin_by_slice_primitive_offset(
             values.dtype().clone(),
@@ -131,7 +131,7 @@ fn filter_select_var_bin_by_index(
     mask: &FilterMask,
     selection_count: usize,
 ) -> VortexResult<VarBinArray> {
-    let offsets = values.offsets().into_primitive()?;
+    let offsets = values.offsets().into_canonical_primitive()?;
     match_each_integer_ptype!(offsets.ptype(), |$O| {
         filter_select_var_bin_by_index_primitive_offset(
             values.dtype().clone(),

--- a/vortex-array/src/array/varbin/compute/take.rs
+++ b/vortex-array/src/array/varbin/compute/take.rs
@@ -13,9 +13,9 @@ use crate::{ArrayDType, ArrayData, IntoArrayData, IntoArrayVariant};
 
 impl TakeFn<VarBinArray> for VarBinEncoding {
     fn take(&self, array: &VarBinArray, indices: &ArrayData) -> VortexResult<ArrayData> {
-        let offsets = array.offsets().into_primitive()?;
+        let offsets = array.offsets().into_canonical_primitive()?;
         let data = array.bytes();
-        let indices = indices.clone().into_primitive()?;
+        let indices = indices.clone().into_canonical_primitive()?;
         match_each_integer_ptype!(offsets.ptype(), |$O| {
             match_each_integer_ptype!(indices.ptype(), |$I| {
                 Ok(take(

--- a/vortex-array/src/array/varbinview/compute/mod.rs
+++ b/vortex-array/src/array/varbinview/compute/mod.rs
@@ -57,7 +57,7 @@ impl TakeFn<VarBinViewArray> for VarBinViewEncoding {
     fn take(&self, array: &VarBinViewArray, indices: &ArrayData) -> VortexResult<ArrayData> {
         // Compute the new validity
         let validity = array.validity().take(indices)?;
-        let indices = indices.clone().into_primitive()?;
+        let indices = indices.clone().into_canonical_primitive()?;
 
         let views_buffer = match_each_integer_ptype!(indices.ptype(), |$I| {
             take_views(array.views(), indices.as_slice::<$I>())
@@ -79,7 +79,7 @@ impl TakeFn<VarBinViewArray> for VarBinViewEncoding {
     ) -> VortexResult<ArrayData> {
         // Compute the new validity
         let validity = array.validity().take(indices)?;
-        let indices = indices.clone().into_primitive()?;
+        let indices = indices.clone().into_canonical_primitive()?;
 
         let views_buffer = match_each_integer_ptype!(indices.ptype(), |$I| {
             take_views_unchecked(array.views(), indices.as_slice::<$I>())
@@ -142,7 +142,7 @@ mod tests {
         assert!(taken.dtype().is_nullable());
         assert_eq!(
             taken
-                .into_varbinview()
+                .into_canonical_varbinview()
                 .unwrap()
                 .with_iterator(|it| it
                     .map(|v| v.map(|b| unsafe { String::from_utf8_unchecked(b.to_vec()) }))

--- a/vortex-array/src/arrow/record_batch.rs
+++ b/vortex-array/src/arrow/record_batch.rs
@@ -36,7 +36,7 @@ impl TryFrom<ArrayData> for RecordBatch {
     type Error = VortexError;
 
     fn try_from(value: ArrayData) -> VortexResult<Self> {
-        let struct_arr = value.into_struct().map_err(|err| {
+        let struct_arr = value.into_canonical_struct().map_err(|err| {
             vortex_err!("RecordBatch can only be constructed from a Vortex StructArray: {err}")
         })?;
 

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -180,7 +180,7 @@ mod tests {
         let list = builder.finish().unwrap();
         assert_eq!(list.len(), 2);
 
-        let list_array = list.into_list().unwrap();
+        let list_array = list.into_canonical_list().unwrap();
 
         assert_eq!(list_array.elements_at(0).unwrap().len(), 3);
         assert_eq!(list_array.elements_at(1).unwrap().len(), 3);
@@ -230,7 +230,7 @@ mod tests {
         let list = builder.finish().unwrap();
         assert_eq!(list.len(), 3);
 
-        let list_array = list.into_list().unwrap();
+        let list_array = list.into_canonical_list().unwrap();
 
         assert_eq!(list_array.elements_at(0).unwrap().len(), 3);
         assert_eq!(list_array.elements_at(1).unwrap().len(), 0);

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -272,7 +272,7 @@ pub(crate) fn varbinview_to_arrow(
 fn list_to_arrow(list: ListArray, data_type: &DataType) -> VortexResult<ArrayRef> {
     let offsets = list
         .offsets()
-        .into_primitive()
+        .into_canonical_primitive()
         .map_err(|err| err.with_context("Failed to canonicalize offsets"))?;
 
     let (cast_ptype, element_dtype) = match data_type {
@@ -283,7 +283,7 @@ fn list_to_arrow(list: ListArray, data_type: &DataType) -> VortexResult<ArrayRef
 
     let arrow_offsets = try_cast(offsets, cast_ptype.into())
         .map_err(|err| err.with_context("Failed to cast offsets to PrimitiveArray"))?
-        .into_primitive()?;
+        .into_canonical_primitive()?;
 
     let values = list.elements().into_arrow_with_data_type(element_dtype)?;
 
@@ -318,7 +318,7 @@ fn temporal_to_arrow(temporal_array: TemporalArray) -> VortexResult<ArrayRef> {
                 $values,
                 &DType::Primitive(<$prim as NativePType>::PTYPE, $values.dtype().nullability()),
             )?
-            .into_primitive()?;
+            .into_canonical_primitive()?;
             let nulls = temporal_values.logical_validity().to_null_buffer()?;
             let scalars = temporal_values.into_buffer().into_arrow_scalar_buffer();
 
@@ -465,50 +465,50 @@ where
 ///
 /// This trait has a blanket implementation for all types implementing [IntoCanonical].
 pub trait IntoArrayVariant {
-    fn into_null(self) -> VortexResult<NullArray>;
+    fn into_canonical_null(self) -> VortexResult<NullArray>;
 
-    fn into_bool(self) -> VortexResult<BoolArray>;
+    fn into_canonical_bool(self) -> VortexResult<BoolArray>;
 
-    fn into_primitive(self) -> VortexResult<PrimitiveArray>;
+    fn into_canonical_primitive(self) -> VortexResult<PrimitiveArray>;
 
-    fn into_struct(self) -> VortexResult<StructArray>;
+    fn into_canonical_struct(self) -> VortexResult<StructArray>;
 
-    fn into_list(self) -> VortexResult<ListArray>;
+    fn into_canonical_list(self) -> VortexResult<ListArray>;
 
-    fn into_varbinview(self) -> VortexResult<VarBinViewArray>;
+    fn into_canonical_varbinview(self) -> VortexResult<VarBinViewArray>;
 
-    fn into_extension(self) -> VortexResult<ExtensionArray>;
+    fn into_canonical_extension(self) -> VortexResult<ExtensionArray>;
 }
 
 impl<T> IntoArrayVariant for T
 where
     T: IntoCanonical,
 {
-    fn into_null(self) -> VortexResult<NullArray> {
+    fn into_canonical_null(self) -> VortexResult<NullArray> {
         self.into_canonical()?.into_null()
     }
 
-    fn into_bool(self) -> VortexResult<BoolArray> {
+    fn into_canonical_bool(self) -> VortexResult<BoolArray> {
         self.into_canonical()?.into_bool()
     }
 
-    fn into_primitive(self) -> VortexResult<PrimitiveArray> {
+    fn into_canonical_primitive(self) -> VortexResult<PrimitiveArray> {
         self.into_canonical()?.into_primitive()
     }
 
-    fn into_struct(self) -> VortexResult<StructArray> {
+    fn into_canonical_struct(self) -> VortexResult<StructArray> {
         self.into_canonical()?.into_struct()
     }
 
-    fn into_list(self) -> VortexResult<ListArray> {
+    fn into_canonical_list(self) -> VortexResult<ListArray> {
         self.into_canonical()?.into_list()
     }
 
-    fn into_varbinview(self) -> VortexResult<VarBinViewArray> {
+    fn into_canonical_varbinview(self) -> VortexResult<VarBinViewArray> {
         self.into_canonical()?.into_varbinview()
     }
 
-    fn into_extension(self) -> VortexResult<ExtensionArray> {
+    fn into_canonical_extension(self) -> VortexResult<ExtensionArray> {
         self.into_canonical()?.into_extension()
     }
 }

--- a/vortex-array/src/compute/boolean.rs
+++ b/vortex-array/src/compute/boolean.rs
@@ -162,11 +162,11 @@ pub(crate) fn arrow_boolean(
 ) -> VortexResult<ArrayData> {
     let nullable = lhs.dtype().is_nullable() || rhs.dtype().is_nullable();
 
-    let lhs = Canonical::Bool(lhs.into_bool()?)
+    let lhs = Canonical::Bool(lhs.into_canonical_bool()?)
         .into_arrow()?
         .as_boolean()
         .clone();
-    let rhs = Canonical::Bool(rhs.into_bool()?)
+    let rhs = Canonical::Bool(rhs.into_canonical_bool()?)
         .into_arrow()?
         .as_boolean()
         .clone();
@@ -199,7 +199,7 @@ mod tests {
     fn test_or(#[case] lhs: ArrayData, #[case] rhs: ArrayData) {
         let r = or(&lhs, &rhs).unwrap();
 
-        let r = r.into_bool().unwrap().into_array();
+        let r = r.into_canonical_bool().unwrap().into_array();
 
         let v0 = scalar_at(&r, 0).unwrap().as_bool().value();
         let v1 = scalar_at(&r, 1).unwrap().as_bool().value();
@@ -219,7 +219,11 @@ mod tests {
     #[case(BoolArray::from_iter([Some(true), Some(false), Some(true), Some(false)].into_iter()).into_array(),
         BoolArray::from_iter([Some(true), Some(true), Some(false), Some(false)].into_iter()).into_array())]
     fn test_and(#[case] lhs: ArrayData, #[case] rhs: ArrayData) {
-        let r = and(&lhs, &rhs).unwrap().into_bool().unwrap().into_array();
+        let r = and(&lhs, &rhs)
+            .unwrap()
+            .into_canonical_bool()
+            .unwrap()
+            .into_array();
 
         let v0 = scalar_at(&r, 0).unwrap().as_bool().value();
         let v1 = scalar_at(&r, 1).unwrap().as_bool().value();

--- a/vortex-array/src/compute/compare.rs
+++ b/vortex-array/src/compute/compare.rs
@@ -272,14 +272,14 @@ mod tests {
 
         let matches = compare(&arr, &arr, Operator::Eq)
             .unwrap()
-            .into_bool()
+            .into_canonical_bool()
             .unwrap();
 
         assert_eq!(to_int_indices(matches), [1u64, 2, 3, 4]);
 
         let matches = compare(&arr, &arr, Operator::NotEq)
             .unwrap()
-            .into_bool()
+            .into_canonical_bool()
             .unwrap();
         let empty: [u64; 0] = [];
         assert_eq!(to_int_indices(matches), empty);
@@ -293,25 +293,25 @@ mod tests {
 
         let matches = compare(&arr, &other, Operator::Lte)
             .unwrap()
-            .into_bool()
+            .into_canonical_bool()
             .unwrap();
         assert_eq!(to_int_indices(matches), [2u64, 3, 4]);
 
         let matches = compare(&arr, &other, Operator::Lt)
             .unwrap()
-            .into_bool()
+            .into_canonical_bool()
             .unwrap();
         assert_eq!(to_int_indices(matches), [4u64]);
 
         let matches = compare(&other, &arr, Operator::Gte)
             .unwrap()
-            .into_bool()
+            .into_canonical_bool()
             .unwrap();
         assert_eq!(to_int_indices(matches), [2u64, 3, 4]);
 
         let matches = compare(&other, &arr, Operator::Gt)
             .unwrap()
-            .into_bool()
+            .into_canonical_bool()
             .unwrap();
         assert_eq!(to_int_indices(matches), [4u64]);
     }

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -581,7 +581,9 @@ impl TryFrom<ArrayData> for FilterMask {
 
         // TODO(ngates): should we have a `to_filter_mask` compute function where encodings
         //  pick the best possible conversion? E.g. SparseArray may want from_indices.
-        Ok(Self::from_buffer(array.into_bool()?.boolean_buffer()))
+        Ok(Self::from_buffer(
+            array.into_canonical_bool()?.boolean_buffer(),
+        ))
     }
 }
 

--- a/vortex-array/src/compute/invert.rs
+++ b/vortex-array/src/compute/invert.rs
@@ -50,5 +50,5 @@ pub fn invert(array: &ArrayData) -> VortexResult<ArrayData> {
         "No invert implementation found for encoding {}",
         array.encoding().id(),
     );
-    invert(&array.clone().into_bool()?.into_array())
+    invert(&array.clone().into_canonical_bool()?.into_array())
 }

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -205,7 +205,7 @@ impl Patches {
         let mut value_indices = BufferMut::<u64>::empty();
         let mut last_inserted_index: usize = 0;
 
-        let flat_indices = self.indices().clone().into_primitive()?;
+        let flat_indices = self.indices().clone().into_canonical_primitive()?;
         match_each_integer_ptype!(flat_indices.ptype(), |$I| {
             for (value_idx, coordinate) in flat_indices.as_slice::<$I>().iter().enumerate() {
                 if buffer.value(*coordinate as usize) {
@@ -260,7 +260,7 @@ impl Patches {
         if take_indices.is_empty() {
             return Ok(None);
         }
-        let take_indices = take_indices.clone().into_primitive()?;
+        let take_indices = take_indices.clone().into_canonical_primitive()?;
         if self.is_map_faster_than_search(&take_indices) {
             self.take_map(take_indices)
         } else {
@@ -303,7 +303,7 @@ impl Patches {
     }
 
     pub fn take_map(&self, take_indices: PrimitiveArray) -> VortexResult<Option<Self>> {
-        let indices = self.indices.clone().into_primitive()?;
+        let indices = self.indices.clone().into_canonical_primitive()?;
         match_each_integer_ptype!(self.indices_ptype(), |$INDICES| {
             let indices = indices
                 .as_slice::<$INDICES>();
@@ -407,8 +407,16 @@ mod test {
             .unwrap()
             .unwrap();
 
-        let indices = filtered.indices().clone().into_primitive().unwrap();
-        let values = filtered.values().clone().into_primitive().unwrap();
+        let indices = filtered
+            .indices()
+            .clone()
+            .into_canonical_primitive()
+            .unwrap();
+        let values = filtered
+            .values()
+            .clone()
+            .into_canonical_primitive()
+            .unwrap();
         assert_eq!(indices.as_slice::<u64>(), &[0, 1]);
         assert_eq!(values.as_slice::<i32>(), &[100, 200]);
     }

--- a/vortex-array/src/stream/take_rows.rs
+++ b/vortex-array/src/stream/take_rows.rs
@@ -89,7 +89,7 @@ impl<R: ArrayStream> Stream for TakeRows<R> {
 
             // TODO(ngates): this is probably too heavy to run on the event loop. We should spawn
             //  onto a worker pool.
-            let indices_for_batch = slice(this.indices, left, right)?.into_primitive()?;
+            let indices_for_batch = slice(this.indices, left, right)?.into_canonical_primitive()?;
             let shifted_arr = match_each_integer_ptype!(indices_for_batch.ptype(), |$T| {
                 sub_scalar(&indices_for_batch.into_array(), Scalar::from(curr_offset as $T))?
             });

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -311,14 +311,14 @@ impl Validity {
             Validity::NonNullable => BoolArray::from(BooleanBuffer::new_set(len)),
             Validity::AllValid => BoolArray::from(BooleanBuffer::new_set(len)),
             Validity::AllInvalid => BoolArray::from(BooleanBuffer::new_unset(len)),
-            Validity::Array(a) => a.into_bool()?,
+            Validity::Array(a) => a.into_canonical_bool()?,
         };
 
         let patch_values = match patches {
             Validity::NonNullable => BoolArray::from(BooleanBuffer::new_set(indices.len())),
             Validity::AllValid => BoolArray::from(BooleanBuffer::new_set(indices.len())),
             Validity::AllInvalid => BoolArray::from(BooleanBuffer::new_unset(indices.len())),
-            Validity::Array(a) => a.into_bool()?,
+            Validity::Array(a) => a.into_canonical_bool()?,
         };
 
         let patches = Patches::new(len, indices.clone(), patch_values.into_array());
@@ -352,12 +352,12 @@ impl PartialEq for Validity {
             (Self::Array(a), Self::Array(b)) => {
                 let a_buffer = a
                     .clone()
-                    .into_bool()
+                    .into_canonical_bool()
                     .vortex_expect("Failed to get Validity Array as BoolArray")
                     .boolean_buffer();
                 let b_buffer = b
                     .clone()
-                    .into_bool()
+                    .into_canonical_bool()
                     .vortex_expect("Failed to get Validity Array as BoolArray")
                     .boolean_buffer();
                 a_buffer == b_buffer
@@ -406,7 +406,7 @@ impl FromIterator<LogicalValidity> for Validity {
                 LogicalValidity::AllInvalid(count) => buffer.append_n(count, false),
                 LogicalValidity::Array(array) => {
                     let array_buffer = array
-                        .into_bool()
+                        .into_canonical_bool()
                         .vortex_expect("Failed to get Validity Array as BoolArray")
                         .boolean_buffer();
                     buffer.append_buffer(&array_buffer);
@@ -466,7 +466,7 @@ impl LogicalValidity {
             Self::AllValid(_) => Ok(None),
             Self::AllInvalid(l) => Ok(Some(NullBuffer::new_null(*l))),
             Self::Array(a) => Ok(Some(NullBuffer::new(
-                a.clone().into_bool()?.boolean_buffer(),
+                a.clone().into_canonical_bool()?.boolean_buffer(),
             ))),
         }
     }

--- a/vortex-datafusion/src/memory/plans.rs
+++ b/vortex-datafusion/src/memory/plans.rs
@@ -358,7 +358,10 @@ where
             .map_err(DataFusionError::from)?)));
         }
 
-        let chunk = this.vortex_array.chunk(*this.chunk_idx)?.into_struct()?;
+        let chunk = this
+            .vortex_array
+            .chunk(*this.chunk_idx)?
+            .into_canonical_struct()?;
 
         *this.chunk_idx += 1;
 

--- a/vortex-datafusion/src/memory/stream.rs
+++ b/vortex-datafusion/src/memory/stream.rs
@@ -34,7 +34,7 @@ impl Stream for VortexRecordBatchStream {
         self.idx += 1;
 
         let struct_array = chunk
-            .into_struct()
+            .into_canonical_struct()
             .map_err(|vortex_error| DataFusionError::Execution(format!("{}", vortex_error)))?;
 
         let projected_struct = struct_array

--- a/vortex-expr/src/binary.rs
+++ b/vortex-expr/src/binary.rs
@@ -93,7 +93,7 @@ impl PartialEq for BinaryExpr {
 /// let result = eq(ident(), lit(3)).evaluate(&xs).unwrap();
 ///
 /// assert_eq!(
-///     result.into_bool().unwrap().boolean_buffer(),
+///     result.into_canonical_bool().unwrap().boolean_buffer(),
 ///     BoolArray::from_iter(vec![false, false, true]).boolean_buffer(),
 /// );
 /// ```
@@ -116,7 +116,7 @@ pub fn eq(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
 /// let result = not_eq(ident(), lit(3)).evaluate(&xs).unwrap();
 ///
 /// assert_eq!(
-///     result.into_bool().unwrap().boolean_buffer(),
+///     result.into_canonical_bool().unwrap().boolean_buffer(),
 ///     BoolArray::from_iter(vec![true, true, false]).boolean_buffer(),
 /// );
 /// ```
@@ -139,7 +139,7 @@ pub fn not_eq(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
 /// let result = gt_eq(ident(), lit(3)).evaluate(&xs).unwrap();
 ///
 /// assert_eq!(
-///     result.into_bool().unwrap().boolean_buffer(),
+///     result.into_canonical_bool().unwrap().boolean_buffer(),
 ///     BoolArray::from_iter(vec![false, false, true]).boolean_buffer(),
 /// );
 /// ```
@@ -162,7 +162,7 @@ pub fn gt_eq(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
 /// let result = gt(ident(), lit(2)).evaluate(&xs).unwrap();
 ///
 /// assert_eq!(
-///     result.into_bool().unwrap().boolean_buffer(),
+///     result.into_canonical_bool().unwrap().boolean_buffer(),
 ///     BoolArray::from_iter(vec![false, false, true]).boolean_buffer(),
 /// );
 /// ```
@@ -185,7 +185,7 @@ pub fn gt(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
 /// let result = lt_eq(ident(), lit(2)).evaluate(&xs).unwrap();
 ///
 /// assert_eq!(
-///     result.into_bool().unwrap().boolean_buffer(),
+///     result.into_canonical_bool().unwrap().boolean_buffer(),
 ///     BoolArray::from_iter(vec![true, true, false]).boolean_buffer(),
 /// );
 /// ```
@@ -208,7 +208,7 @@ pub fn lt_eq(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
 /// let result = lt(ident(), lit(3)).evaluate(&xs).unwrap();
 ///
 /// assert_eq!(
-///     result.into_bool().unwrap().boolean_buffer(),
+///     result.into_canonical_bool().unwrap().boolean_buffer(),
 ///     BoolArray::from_iter(vec![true, true, false]).boolean_buffer(),
 /// );
 /// ```
@@ -229,7 +229,7 @@ pub fn lt(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
 /// let result = or(ident(), lit(false)).evaluate(&xs).unwrap();
 ///
 /// assert_eq!(
-///     result.into_bool().unwrap().boolean_buffer(),
+///     result.into_canonical_bool().unwrap().boolean_buffer(),
 ///     BoolArray::from_iter(vec![true, false, true]).boolean_buffer(),
 /// );
 /// ```
@@ -250,7 +250,7 @@ pub fn or(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
 /// let result = and(ident(), lit(true)).evaluate(&xs).unwrap();
 ///
 /// assert_eq!(
-///     result.into_bool().unwrap().boolean_buffer(),
+///     result.into_canonical_bool().unwrap().boolean_buffer(),
 ///     BoolArray::from_iter(vec![true, false, true]).boolean_buffer(),
 /// );
 /// ```

--- a/vortex-expr/src/like.rs
+++ b/vortex-expr/src/like.rs
@@ -114,7 +114,7 @@ mod tests {
             not_expr
                 .evaluate(bools.as_ref())
                 .unwrap()
-                .into_bool()
+                .into_canonical_bool()
                 .unwrap()
                 .boolean_buffer()
                 .iter()

--- a/vortex-expr/src/not.rs
+++ b/vortex-expr/src/not.rs
@@ -79,7 +79,7 @@ mod tests {
             not_expr
                 .evaluate(bools.as_ref())
                 .unwrap()
-                .into_bool()
+                .into_canonical_bool()
                 .unwrap()
                 .boolean_buffer()
                 .iter()

--- a/vortex-expr/src/pack.rs
+++ b/vortex-expr/src/pack.rs
@@ -174,7 +174,7 @@ mod tests {
                 .maybe_null_field_by_name(field)
                 .ok_or_else(|| vortex_err!("expected field to exist: {}", field))?;
         }
-        Ok(array.into_primitive().unwrap())
+        Ok(array.into_canonical_primitive().unwrap())
     }
 
     #[test]

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -195,11 +195,11 @@ async fn test_read_projection() {
     );
 
     let actual = array
-        .into_struct()
+        .into_canonical_struct()
         .unwrap()
         .maybe_null_field_by_idx(0)
         .unwrap()
-        .into_varbinview()
+        .into_canonical_varbinview()
         .unwrap()
         .with_iterator(|x| {
             x.map(|x| unsafe { String::from_utf8_unchecked(x.unwrap().to_vec()) })
@@ -224,11 +224,11 @@ async fn test_read_projection() {
     );
 
     let primitive_array = array
-        .into_struct()
+        .into_canonical_struct()
         .unwrap()
         .maybe_null_field_by_idx(0)
         .unwrap()
-        .into_primitive()
+        .into_canonical_primitive()
         .unwrap();
     let actual = primitive_array.as_slice::<u32>();
     assert_eq!(actual, numbers_expected);
@@ -276,7 +276,7 @@ async fn unequal_batches() {
             .maybe_null_field_by_name("numbers");
 
         if let Some(numbers) = numbers {
-            let numbers = numbers.into_primitive().unwrap();
+            let numbers = numbers.into_canonical_primitive().unwrap();
             assert_eq!(numbers.ptype(), PType::U32);
         } else {
             vortex_panic!("Expected column doesn't exist")
@@ -372,7 +372,7 @@ async fn filter_string() {
         .unwrap();
     assert_eq!(
         names
-            .into_varbinview()
+            .into_canonical_varbinview()
             .unwrap()
             .with_iterator(|iter| iter
                 .flatten()
@@ -386,7 +386,10 @@ async fn filter_string() {
         .unwrap()
         .maybe_null_field_by_idx(1)
         .unwrap();
-    assert_eq!(ages.into_primitive().unwrap().as_slice::<i32>(), vec![25]);
+    assert_eq!(
+        ages.into_canonical_primitive().unwrap().as_slice::<i32>(),
+        vec![25]
+    );
 }
 
 #[tokio::test]
@@ -435,7 +438,7 @@ async fn filter_or() {
         .unwrap();
     assert_eq!(
         names
-            .into_varbinview()
+            .into_canonical_varbinview()
             .unwrap()
             .with_iterator(|iter| iter
                 .flatten()
@@ -450,7 +453,7 @@ async fn filter_or() {
         .maybe_null_field_by_idx(1)
         .unwrap();
     assert_eq!(
-        ages.into_primitive()
+        ages.into_canonical_primitive()
             .unwrap()
             .with_iterator(|iter| iter.map(|x| x.cloned()).collect::<Vec<_>>())
             .unwrap(),
@@ -501,7 +504,7 @@ async fn filter_and() {
         .unwrap();
     assert_eq!(
         names
-            .into_varbinview()
+            .into_canonical_varbinview()
             .unwrap()
             .with_iterator(|iter| iter
                 .map(|s| s.map(|st| unsafe { String::from_utf8_unchecked(st.to_vec()) }))
@@ -515,7 +518,7 @@ async fn filter_and() {
         .maybe_null_field_by_idx(1)
         .unwrap();
     assert_eq!(
-        ages.into_primitive().unwrap().as_slice::<i32>(),
+        ages.into_canonical_primitive().unwrap().as_slice::<i32>(),
         vec![25, 31]
     );
 }
@@ -552,7 +555,7 @@ async fn test_with_indices_simple() {
         .into_array_data()
         .await
         .unwrap()
-        .into_struct()
+        .into_canonical_struct()
         .unwrap();
 
     assert_eq!(actual_kept_array.len(), 0);
@@ -566,12 +569,12 @@ async fn test_with_indices_simple() {
         .into_array_data()
         .await
         .unwrap()
-        .into_struct()
+        .into_canonical_struct()
         .unwrap();
     let actual_kept_numbers_array = actual_kept_array
         .maybe_null_field_by_idx(0)
         .unwrap()
-        .into_primitive()
+        .into_canonical_primitive()
         .unwrap();
 
     let expected_kept_numbers: Vec<i16> = kept_indices
@@ -589,12 +592,12 @@ async fn test_with_indices_simple() {
         .into_array_data()
         .await
         .unwrap()
-        .into_struct()
+        .into_canonical_struct()
         .unwrap();
     let actual_numbers_array = actual_array
         .maybe_null_field_by_idx(0)
         .unwrap()
-        .into_primitive()
+        .into_canonical_primitive()
         .unwrap();
     let actual_numbers = actual_numbers_array.as_slice::<i16>();
 
@@ -636,15 +639,15 @@ async fn test_with_indices_on_two_columns() {
         .into_array_data()
         .await
         .unwrap()
-        .into_struct()
+        .into_canonical_struct()
         .unwrap()
-        .into_struct()
+        .into_canonical_struct()
         .unwrap();
 
     let strings_actual = array
         .maybe_null_field_by_idx(0)
         .unwrap()
-        .into_varbinview()
+        .into_canonical_varbinview()
         .unwrap()
         .with_iterator(|x| {
             x.map(|x| unsafe { String::from_utf8_unchecked(x.unwrap().to_vec()) })
@@ -662,7 +665,7 @@ async fn test_with_indices_on_two_columns() {
     let numbers_actual_array = array
         .maybe_null_field_by_idx(1)
         .unwrap()
-        .into_primitive()
+        .into_canonical_primitive()
         .unwrap();
     let numbers_actual = numbers_actual_array.as_slice::<u32>();
     assert_eq!(
@@ -709,9 +712,9 @@ async fn test_with_indices_and_with_row_filter_simple() {
         .into_array_data()
         .await
         .unwrap()
-        .into_struct()
+        .into_canonical_struct()
         .unwrap()
-        .into_struct()
+        .into_canonical_struct()
         .unwrap();
 
     assert_eq!(actual_kept_array.len(), 0);
@@ -729,15 +732,15 @@ async fn test_with_indices_and_with_row_filter_simple() {
         .into_array_data()
         .await
         .unwrap()
-        .into_struct()
+        .into_canonical_struct()
         .unwrap()
-        .into_struct()
+        .into_canonical_struct()
         .unwrap();
 
     let actual_kept_numbers_array = actual_kept_array
         .maybe_null_field_by_idx(0)
         .unwrap()
-        .into_primitive()
+        .into_canonical_primitive()
         .unwrap();
 
     let expected_kept_numbers: Buffer<i16> = kept_indices
@@ -760,15 +763,15 @@ async fn test_with_indices_and_with_row_filter_simple() {
         .into_array_data()
         .await
         .unwrap()
-        .into_struct()
+        .into_canonical_struct()
         .unwrap()
-        .into_struct()
+        .into_canonical_struct()
         .unwrap();
 
     let actual_numbers_array = actual_array
         .maybe_null_field_by_idx(0)
         .unwrap()
-        .into_primitive()
+        .into_canonical_primitive()
         .unwrap();
     let actual_numbers = actual_numbers_array.as_slice::<i16>();
 
@@ -827,14 +830,14 @@ async fn filter_string_chunked() {
         .into_array_data()
         .await
         .unwrap()
-        .into_struct()
+        .into_canonical_struct()
         .unwrap();
 
     assert_eq!(actual_array.len(), 1);
     let names = actual_array.maybe_null_field_by_idx(0).unwrap();
     assert_eq!(
         names
-            .into_varbinview()
+            .into_canonical_varbinview()
             .unwrap()
             .with_iterator(|iter| iter
                 .flatten()
@@ -844,7 +847,10 @@ async fn filter_string_chunked() {
         vec!["Joseph".to_string()]
     );
     let ages = actual_array.maybe_null_field_by_idx(1).unwrap();
-    assert_eq!(ages.into_primitive().unwrap().as_slice::<i32>(), vec![25]);
+    assert_eq!(
+        ages.into_canonical_primitive().unwrap().as_slice::<i32>(),
+        vec![25]
+    );
 }
 
 #[tokio::test]
@@ -914,14 +920,14 @@ async fn test_pruning_with_or() {
         .into_array_data()
         .await
         .unwrap()
-        .into_struct()
+        .into_canonical_struct()
         .unwrap();
 
     assert_eq!(actual_array.len(), 10);
     let letters = actual_array.maybe_null_field_by_idx(0).unwrap();
     assert_eq!(
         letters
-            .into_varbinview()
+            .into_canonical_varbinview()
             .unwrap()
             .with_iterator(|iter| iter
                 .map(|opt| opt.map(|s| unsafe { String::from_utf8_unchecked(s.to_vec()) }))
@@ -1003,7 +1009,7 @@ async fn test_repeated_projection() {
         .into_array_data()
         .await
         .unwrap()
-        .into_struct()
+        .into_canonical_struct()
         .unwrap();
 
     assert_eq!(
@@ -1039,7 +1045,7 @@ fn chunked_file() -> VortexFile<impl IoDriver> {
 #[test]
 fn basic_file_roundtrip() -> VortexResult<()> {
     let vxf = chunked_file();
-    let result = block_on(vxf.scan(Scan::all())?.into_array_data())?.into_primitive()?;
+    let result = block_on(vxf.scan(Scan::all())?.into_array_data())?.into_canonical_primitive()?;
 
     assert_eq!(result.as_slice::<i32>(), &[0, 1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -1053,7 +1059,7 @@ fn file_take() -> VortexResult<()> {
         vxf.scan(Scan::all().with_row_indices(buffer![0, 1, 8]))?
             .into_array_data(),
     )?
-    .into_primitive()?;
+    .into_canonical_primitive()?;
 
     assert_eq!(result.as_slice::<i32>(), &[0, 1, 8]);
 

--- a/vortex-ipc/src/iterator.rs
+++ b/vortex-ipc/src/iterator.rs
@@ -171,7 +171,11 @@ mod test {
         let reader = SyncIPCReader::try_new(Cursor::new(ipc_buffer), Default::default()).unwrap();
 
         assert_eq!(reader.dtype(), array.dtype());
-        let result = reader.into_array_data().unwrap().into_primitive().unwrap();
+        let result = reader
+            .into_array_data()
+            .unwrap()
+            .into_canonical_primitive()
+            .unwrap();
         assert_eq!(array.as_slice::<i32>(), result.as_slice::<i32>());
     }
 }

--- a/vortex-ipc/src/stream.rs
+++ b/vortex-ipc/src/stream.rs
@@ -212,7 +212,7 @@ mod test {
             .into_array_data()
             .await
             .unwrap()
-            .into_primitive()
+            .into_canonical_primitive()
             .unwrap();
         assert_eq!(array.as_slice::<i32>(), result.as_slice::<i32>());
     }

--- a/vortex-layout/src/layouts/chunked/eval_expr.rs
+++ b/vortex-layout/src/layouts/chunked/eval_expr.rs
@@ -132,7 +132,7 @@ mod test {
                 )
                 .await
                 .unwrap()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap();
 
             assert_eq!(result.len(), 9);

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -117,7 +117,7 @@ impl ChunkedReader {
             if let Some(predicate) = pruning_predicate {
                 predicate
                     .evaluate(stats_table.array())?
-                    .map(|mask| mask.into_bool())
+                    .map(|mask| mask.into_canonical_bool())
                     .transpose()?
                     .map(|mask| mask.boolean_buffer())
             } else {

--- a/vortex-layout/src/layouts/chunked/stats_table.rs
+++ b/vortex-layout/src/layouts/chunked/stats_table.rs
@@ -88,7 +88,7 @@ impl StatsTable {
                     // TODO(ngates): use Stat::Sum when we add it.
                     let parray =
                         try_cast(array, &DType::Primitive(PType::U64, Nullability::Nullable))?
-                            .into_primitive()?;
+                            .into_canonical_primitive()?;
                     let sum: u64 = parray
                         .as_slice::<u64>()
                         .iter()

--- a/vortex-layout/src/layouts/flat/eval_expr.rs
+++ b/vortex-layout/src/layouts/flat/eval_expr.rs
@@ -105,7 +105,7 @@ mod test {
                 )
                 .await
                 .unwrap()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap();
 
             assert_eq!(array.as_slice::<i32>(), result.as_slice::<i32>());
@@ -128,7 +128,7 @@ mod test {
                 .evaluate_expr(RowMask::new_valid_between(0, layout.row_count()), expr)
                 .await
                 .unwrap()
-                .into_bool()
+                .into_canonical_bool()
                 .unwrap();
 
             assert_eq!(
@@ -153,7 +153,7 @@ mod test {
                 .evaluate_expr(RowMask::new_valid_between(2, 4), ident())
                 .await
                 .unwrap()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap();
 
             assert_eq!(result.as_slice::<i32>(), &[3, 4],);

--- a/vortex-layout/src/layouts/struct_/eval_expr.rs
+++ b/vortex-layout/src/layouts/struct_/eval_expr.rs
@@ -117,7 +117,7 @@ mod tests {
         assert_eq!(
             vec![true, false, false],
             result
-                .into_bool()
+                .into_canonical_bool()
                 .unwrap()
                 .boolean_buffer()
                 .iter()
@@ -143,7 +143,7 @@ mod tests {
         assert_eq!(
             vec![true, false],
             result
-                .into_bool()
+                .into_canonical_bool()
                 .unwrap()
                 .boolean_buffer()
                 .iter()
@@ -175,7 +175,7 @@ mod tests {
                 .unwrap()
                 .maybe_null_field(&Field::Name("a".into()))
                 .unwrap()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<i32>(),
             [7, 2].as_slice()
@@ -187,7 +187,7 @@ mod tests {
                 .unwrap()
                 .maybe_null_field(&Field::Name("b".into()))
                 .unwrap()
-                .into_primitive()
+                .into_canonical_primitive()
                 .unwrap()
                 .as_slice::<i32>(),
             [4, 5].as_slice()

--- a/vortex-sampling-compressor/src/compressors/alp.rs
+++ b/vortex-sampling-compressor/src/compressors/alp.rs
@@ -44,7 +44,7 @@ impl EncodingCompressor for ALPCompressor {
         like: Option<CompressionTree<'a>>,
         ctx: SamplingCompressor<'a>,
     ) -> VortexResult<CompressedArray<'a>> {
-        let parray = array.clone().into_primitive()?;
+        let parray = array.clone().into_canonical_primitive()?;
 
         let (exponents, encoded, patches) = match_each_alp_float_ptype!(
             parray.ptype(), |$T| {

--- a/vortex-sampling-compressor/src/compressors/alp_rd.rs
+++ b/vortex-sampling-compressor/src/compressors/alp_rd.rs
@@ -50,7 +50,7 @@ impl EncodingCompressor for ALPRDCompressor {
         like: Option<CompressionTree<'a>>,
         _ctx: SamplingCompressor<'a>,
     ) -> VortexResult<CompressedArray<'a>> {
-        let primitive = array.clone().into_primitive()?;
+        let primitive = array.clone().into_canonical_primitive()?;
 
         // Train a new compressor or reuse an existing compressor.
         let encoder = like

--- a/vortex-sampling-compressor/src/compressors/bitpacked.rs
+++ b/vortex-sampling-compressor/src/compressors/bitpacked.rs
@@ -90,7 +90,7 @@ impl EncodingCompressor for BitPackedCompressor {
         _like: Option<CompressionTree<'a>>,
         ctx: SamplingCompressor<'a>,
     ) -> VortexResult<CompressedArray<'a>> {
-        let parray = array.clone().into_primitive()?;
+        let parray = array.clone().into_canonical_primitive()?;
         // Only arrays with non-negative values can be bit-packed
         if !parray.ptype().is_unsigned_int() {
             let has_negative_elements = match_each_integer_ptype!(parray.ptype(), |$P| {

--- a/vortex-sampling-compressor/src/compressors/for.rs
+++ b/vortex-sampling-compressor/src/compressors/for.rs
@@ -56,7 +56,7 @@ impl EncodingCompressor for FoRCompressor {
         like: Option<CompressionTree<'a>>,
         ctx: SamplingCompressor<'a>,
     ) -> VortexResult<CompressedArray<'a>> {
-        let compressed = for_compress(array.clone().into_primitive()?)?;
+        let compressed = for_compress(array.clone().into_canonical_primitive()?)?;
 
         let compressed_child = ctx.named("for_encoded").excluding(self).compress(
             &compressed.encoded(),

--- a/vortex-sampling-compressor/src/compressors/roaring_bool.rs
+++ b/vortex-sampling-compressor/src/compressors/roaring_bool.rs
@@ -47,7 +47,7 @@ impl EncodingCompressor for RoaringBoolCompressor {
         _ctx: SamplingCompressor<'a>,
     ) -> VortexResult<CompressedArray<'a>> {
         Ok(CompressedArray::compressed(
-            roaring_bool_encode(array.clone().into_bool()?)?.into_array(),
+            roaring_bool_encode(array.clone().into_canonical_bool()?)?.into_array(),
             Some(CompressionTree::flat(self)),
             array,
         ))

--- a/vortex-sampling-compressor/src/compressors/roaring_int.rs
+++ b/vortex-sampling-compressor/src/compressors/roaring_int.rs
@@ -49,7 +49,7 @@ impl EncodingCompressor for RoaringIntCompressor {
         _ctx: SamplingCompressor<'a>,
     ) -> VortexResult<CompressedArray<'a>> {
         Ok(CompressedArray::compressed(
-            roaring_int_encode(array.clone().into_primitive()?)?.into_array(),
+            roaring_int_encode(array.clone().into_canonical_primitive()?)?.into_array(),
             Some(CompressionTree::flat(self)),
             array,
         ))

--- a/vortex-sampling-compressor/src/compressors/runend.rs
+++ b/vortex-sampling-compressor/src/compressors/runend.rs
@@ -50,9 +50,9 @@ impl EncodingCompressor for RunEndCompressor {
         like: Option<CompressionTree<'a>>,
         ctx: SamplingCompressor<'a>,
     ) -> VortexResult<CompressedArray<'a>> {
-        let primitive_array = array.clone().into_primitive()?;
+        let primitive_array = array.clone().into_canonical_primitive()?;
         let (ends, values) = runend_encode(&primitive_array)?;
-        let ends = downscale_integer_array(ends.into_array())?.into_primitive()?;
+        let ends = downscale_integer_array(ends.into_array())?.into_canonical_primitive()?;
 
         let compressed_ends = ctx
             .auxiliary("ends")

--- a/vortex-sampling-compressor/src/compressors/runend_bool.rs
+++ b/vortex-sampling-compressor/src/compressors/runend_bool.rs
@@ -37,7 +37,7 @@ impl EncodingCompressor for RunEndBoolCompressor {
         like: Option<CompressionTree<'a>>,
         ctx: SamplingCompressor<'a>,
     ) -> VortexResult<CompressedArray<'a>> {
-        let bool_array = array.clone().into_bool()?;
+        let bool_array = array.clone().into_canonical_bool()?;
         let (ends, start) = runend_bool_encode_slice(&bool_array.boolean_buffer());
         let ends = downscale_integer_array(ends.into_array())?;
 

--- a/vortex-sampling-compressor/src/downscale.rs
+++ b/vortex-sampling-compressor/src/downscale.rs
@@ -49,7 +49,7 @@ fn downscale_primitive_integer_array(
                 &array,
                 &DType::Primitive(PType::I8, array.dtype().nullability()),
             )?
-            .into_primitive();
+            .into_canonical_primitive();
         }
 
         if min >= i16::MIN as i64 && max <= i16::MAX as i64 {
@@ -57,7 +57,7 @@ fn downscale_primitive_integer_array(
                 &array,
                 &DType::Primitive(PType::I16, array.dtype().nullability()),
             )?
-            .into_primitive();
+            .into_canonical_primitive();
         }
 
         if min >= i32::MIN as i64 && max <= i32::MAX as i64 {
@@ -65,7 +65,7 @@ fn downscale_primitive_integer_array(
                 &array,
                 &DType::Primitive(PType::I32, array.dtype().nullability()),
             )?
-            .into_primitive();
+            .into_canonical_primitive();
         }
     } else {
         // Unsigned
@@ -74,7 +74,7 @@ fn downscale_primitive_integer_array(
                 &array,
                 &DType::Primitive(PType::U8, array.dtype().nullability()),
             )?
-            .into_primitive();
+            .into_canonical_primitive();
         }
 
         if max <= u16::MAX as i64 {
@@ -82,7 +82,7 @@ fn downscale_primitive_integer_array(
                 &array,
                 &DType::Primitive(PType::U16, array.dtype().nullability()),
             )?
-            .into_primitive();
+            .into_canonical_primitive();
         }
 
         if max <= u32::MAX as i64 {
@@ -90,7 +90,7 @@ fn downscale_primitive_integer_array(
                 &array,
                 &DType::Primitive(PType::U32, array.dtype().nullability()),
             )?
-            .into_primitive();
+            .into_canonical_primitive();
         }
     }
 

--- a/vortex-scan/src/range_scan.rs
+++ b/vortex-scan/src/range_scan.rs
@@ -250,10 +250,17 @@ mod tests {
             .unwrap();
 
         assert!(res.as_struct_array().is_some());
-        let field = res.into_struct().unwrap().maybe_null_field_by_name("a");
+        let field = res
+            .into_canonical_struct()
+            .unwrap()
+            .maybe_null_field_by_name("a");
 
         assert_eq!(
-            field.unwrap().into_primitive().unwrap().as_slice::<u64>(),
+            field
+                .unwrap()
+                .into_canonical_primitive()
+                .unwrap()
+                .as_slice::<u64>(),
             (0..len as u64)
                 .filter(|&i| {
                     (i <= 10 || i >= 30) && (i <= 100 || i >= 130) && (i <= 510 || i >= 530)
@@ -307,10 +314,17 @@ mod tests {
 
         assert!(res.as_struct_array().is_some());
 
-        let field = res.into_struct().unwrap().maybe_null_field_by_name("a");
+        let field = res
+            .into_canonical_struct()
+            .unwrap()
+            .maybe_null_field_by_name("a");
 
         assert_eq!(
-            field.unwrap().into_primitive().unwrap().as_slice::<u64>(),
+            field
+                .unwrap()
+                .into_canonical_primitive()
+                .unwrap()
+                .as_slice::<u64>(),
             (0..len as u64)
                 .filter(|&i| !(i > 10 && i < 990))
                 .collect::<Vec<_>>()

--- a/vortex-scan/src/row_mask.rs
+++ b/vortex-scan/src/row_mask.rs
@@ -99,8 +99,8 @@ impl RowMask {
         let length = usize::try_from(end - begin)
             .map_err(|_| vortex_err!("Range length does not fit into a usize"))?;
 
-        let indices =
-            try_cast(array, &DType::Primitive(PType::U64, NonNullable))?.into_primitive()?;
+        let indices = try_cast(array, &DType::Primitive(PType::U64, NonNullable))?
+            .into_canonical_primitive()?;
 
         let mask = FilterMask::from_indices(
             length,
@@ -157,7 +157,7 @@ impl RowMask {
             let sparse_mask =
                 SparseArray::try_new(self.to_indices_array()?, bitmask, self.len(), false.into())?
                     .into_array()
-                    .into_bool()?;
+                    .into_canonical_bool()?;
             Self::from_mask_array(sparse_mask.as_ref(), self.begin())
         }
     }
@@ -383,7 +383,10 @@ mod tests {
         let array = Buffer::from_iter(0..20).into_array();
         let filtered = mask.filter_array(array).unwrap().unwrap();
         assert_eq!(
-            filtered.into_primitive().unwrap().as_slice::<i32>(),
+            filtered
+                .into_canonical_primitive()
+                .unwrap()
+                .as_slice::<i32>(),
             (5..10).collect::<Vec<_>>()
         );
     }


### PR DESCRIPTION
Make it obvious that we are canonicalizing arrays, fix #507 
