### PR TITLE
feat: add Owned handle to flatbuffers to make passing around easier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5118,7 +5118,9 @@ name = "vortex-flatbuffers"
 version = "0.22.1"
 dependencies = [
  "flatbuffers",
+ "paste",
  "vortex-buffer",
+ "vortex-error",
 ]
 
 [[package]]

--- a/vortex-array/src/array/primitive/mod.rs
+++ b/vortex-array/src/array/primitive/mod.rs
@@ -199,6 +199,7 @@ impl PrimitiveArray {
         }
         let length = self.len();
         let raw_slice = self.byte_buffer().as_slice();
+        println!("raw_slice.len() = {} ptype = {}", raw_slice.len(), T::PTYPE);
         debug_assert_eq!(raw_slice.len() / size_of::<T>(), length);
         // SAFETY: alignment of Buffer is checked on construction
         unsafe { std::slice::from_raw_parts(raw_slice.as_ptr().cast(), length) }

--- a/vortex-array/src/array/struct_/compute.rs
+++ b/vortex-array/src/array/struct_/compute.rs
@@ -35,7 +35,9 @@ impl ScalarAtFn<StructArray> for StructEncoding {
             array.dtype().clone(),
             array
                 .children()
-                .map(|field| scalar_at(&field, index))
+                .enumerate()
+                .inspect(|(idx, _)| println!("scalar @ for field {idx}"))
+                .map(|(_, field)| scalar_at(&field, index))
                 .try_collect()?,
         ))
     }

--- a/vortex-array/src/array/varbin/mod.rs
+++ b/vortex-array/src/array/varbin/mod.rs
@@ -190,6 +190,7 @@ impl VarBinArray {
         Ok(PrimitiveArray::maybe_from(self.offsets())
             .map(|p| {
                 match_each_native_ptype!(p.ptype(), |$P| {
+                    println!("using offset ptype {}", $P::PTYPE);
                     p.as_slice::<$P>()[index].as_()
                 })
             })

--- a/vortex-array/src/data/mod.rs
+++ b/vortex-array/src/data/mod.rs
@@ -96,6 +96,7 @@ impl ArrayData {
 
         // Parse the array metadata
         let metadata = encoding.load_metadata(array.as_fb().metadata().map(|v| v.bytes()))?;
+        println!("metadata = {:?}", metadata);
 
         let view = ViewedArrayData {
             encoding,

--- a/vortex-array/src/data/mod.rs
+++ b/vortex-array/src/data/mod.rs
@@ -8,7 +8,7 @@ use viewed::ViewedArrayData;
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
 use vortex_error::{vortex_err, VortexError, VortexExpect, VortexResult};
-use vortex_flatbuffers::FlatBuffer;
+use vortex_flatbuffers::owned::array::OwnedArray;
 use vortex_scalar::Scalar;
 
 use crate::array::{
@@ -79,39 +79,31 @@ impl ArrayData {
         })))
     }
 
-    pub fn try_new_viewed<F>(
+    pub fn try_new_viewed(
         ctx: ContextRef,
         dtype: DType,
         len: usize,
-        flatbuffer: FlatBuffer,
-        flatbuffer_init: F,
+        array: OwnedArray,
         buffers: Vec<ByteBuffer>,
-    ) -> VortexResult<Self>
-    where
-        F: FnOnce(&[u8]) -> VortexResult<crate::flatbuffers::Array>,
-    {
-        let array = flatbuffer_init(flatbuffer.as_ref())?;
-        let flatbuffer_loc = array._tab.loc();
-
-        let encoding = ctx.lookup_encoding(array.encoding()).ok_or_else(
+    ) -> VortexResult<Self> {
+        let encoding = ctx.lookup_encoding(array.as_fb().encoding()).ok_or_else(
             || {
                 let pretty_known_encodings = ctx.encodings()
                     .format_with("\n", |e, f| f(&format_args!("- {}", e.id())));
-                vortex_err!(InvalidSerde: "Unknown encoding with ID {:#02x}. Known encodings:\n{pretty_known_encodings}", array.encoding())
+                vortex_err!(InvalidSerde: "Unknown encoding with ID {:#02x}. Known encodings:\n{pretty_known_encodings}", array.as_fb().encoding())
             },
         )?;
 
         // Parse the array metadata
-        let metadata = encoding.load_metadata(array.metadata().map(|v| v.bytes()))?;
+        let metadata = encoding.load_metadata(array.as_fb().metadata().map(|v| v.bytes()))?;
 
         let view = ViewedArrayData {
             encoding,
             dtype,
             len,
             metadata,
-            flatbuffer,
-            flatbuffer_loc,
             buffers: buffers.into(),
+            array,
             ctx,
             #[cfg(feature = "canonical_counter")]
             canonical_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),

--- a/vortex-array/src/data/viewed.rs
+++ b/vortex-array/src/data/viewed.rs
@@ -1,11 +1,10 @@
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
-use flatbuffers::Follow;
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
 use vortex_error::{vortex_err, VortexResult};
-use vortex_flatbuffers::FlatBuffer;
+use vortex_flatbuffers::owned::array::OwnedArray;
 
 use crate::encoding::opaque::OpaqueEncoding;
 use crate::encoding::EncodingRef;
@@ -18,8 +17,7 @@ pub(super) struct ViewedArrayData {
     pub(super) dtype: DType,
     pub(super) len: usize,
     pub(super) metadata: Arc<dyn ArrayMetadata>,
-    pub(super) flatbuffer: FlatBuffer,
-    pub(super) flatbuffer_loc: usize,
+    pub(super) array: OwnedArray,
     pub(super) buffers: Arc<[ByteBuffer]>,
     pub(super) ctx: ContextRef,
     #[cfg(feature = "canonical_counter")]
@@ -39,11 +37,11 @@ impl Debug for ViewedArrayData {
 
 impl ViewedArrayData {
     pub fn flatbuffer(&self) -> fb::Array {
-        unsafe { fb::Array::follow(self.flatbuffer.as_ref(), self.flatbuffer_loc) }
+        self.array.as_fb()
     }
 
     pub fn metadata_bytes(&self) -> Option<&[u8]> {
-        self.flatbuffer().metadata().map(|m| m.bytes())
+        self.array.as_fb().metadata().map(|m| m.bytes())
     }
 
     // TODO(ngates): should we separate self and DType lifetimes? Should DType be cloned?
@@ -51,7 +49,9 @@ impl ViewedArrayData {
         let child = self
             .array_child(idx)
             .ok_or_else(|| vortex_err!("ArrayView: array_child({idx}) not found"))?;
-        let flatbuffer_loc = child._tab.loc();
+        let owned_child = self
+            .array
+            .owned_child::<fb::Array, OwnedArray>(child._tab.buf())?;
 
         let encoding = self
             .ctx
@@ -71,8 +71,7 @@ impl ViewedArrayData {
             dtype: dtype.clone(),
             len,
             metadata,
-            flatbuffer: self.flatbuffer.clone(),
-            flatbuffer_loc,
+            array: owned_child,
             buffers: self.buffers.clone(),
             ctx: self.ctx.clone(),
             #[cfg(feature = "canonical_counter")]

--- a/vortex-array/src/parts.rs
+++ b/vortex-array/src/parts.rs
@@ -36,9 +36,9 @@ impl ArrayParts {
     /// Creates a new [`ArrayParts`] from an [`OwnedArray`] flatbuffer.
     pub fn new(row_count: usize, array: OwnedArray, buffers: Vec<ByteBuffer>) -> Self {
         println!(
-            "CREATE array: row_count = {row_count} array = {} buffers = {}",
+            "CREATE array: row_count = {row_count} array = {} buffers = {:?}",
             array.as_fb().encoding(),
-            buffers.len()
+            buffers.iter().map(|b| b.len()).collect::<Vec<_>>()
         );
         Self {
             row_count,

--- a/vortex-array/src/parts.rs
+++ b/vortex-array/src/parts.rs
@@ -36,9 +36,13 @@ impl ArrayParts {
     /// Creates a new [`ArrayParts`] from an [`OwnedArray`] flatbuffer.
     pub fn new(row_count: usize, array: OwnedArray, buffers: Vec<ByteBuffer>) -> Self {
         println!(
-            "CREATE array: row_count = {row_count} array = {} buffers = {:?}",
+            "CREATE array: row_count = {row_count} array = {} buffers = {:?} (sums = {:?})",
             array.as_fb().encoding(),
-            buffers.iter().map(|b| b.len()).collect::<Vec<_>>()
+            buffers.iter().map(|b| b.len()).collect::<Vec<_>>(),
+            buffers
+                .iter()
+                .map(|b| b.iter().map(|x| *x as u64).sum::<u64>())
+                .collect::<Vec<_>>(),
         );
         Self {
             row_count,

--- a/vortex-array/src/parts.rs
+++ b/vortex-array/src/parts.rs
@@ -1,13 +1,12 @@
 use std::fmt::{Debug, Formatter};
 
-use flatbuffers::{FlatBufferBuilder, Follow, WIPOffset};
+use flatbuffers::{FlatBufferBuilder, WIPOffset};
 use itertools::Itertools;
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
-use vortex_error::{vortex_panic, VortexExpect, VortexResult};
-use vortex_flatbuffers::{
-    array as fba, FlatBuffer, FlatBufferRoot, WriteFlatBuffer, WriteFlatBufferExt,
-};
+use vortex_error::{VortexExpect, VortexResult};
+use vortex_flatbuffers::owned::array::OwnedArray;
+use vortex_flatbuffers::{array as fba, FlatBufferRoot, WriteFlatBuffer, WriteFlatBufferExt};
 
 use crate::stats::ArrayStatistics;
 use crate::{ArrayData, ContextRef};
@@ -20,9 +19,7 @@ use crate::{ArrayData, ContextRef};
 pub struct ArrayParts {
     // TODO(ngates): I think we should remove this. It's not required in the serialized form.
     row_count: usize,
-    // Typed as fb::Array
-    flatbuffer: FlatBuffer,
-    flatbuffer_loc: usize,
+    array: OwnedArray,
     buffers: Vec<ByteBuffer>,
 }
 
@@ -30,53 +27,24 @@ impl Debug for ArrayParts {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ArrayParts")
             .field("row_count", &self.row_count)
-            .field("flatbuffer", &self.flatbuffer.len())
-            .field("flatbuffer_loc", &self.flatbuffer_loc)
             .field("buffers", &self.buffers.len())
             .finish()
     }
 }
 
 impl ArrayParts {
-    /// Creates a new [`ArrayParts`] from a flatbuffer view.
-    ///
-    /// ## Panics
-    ///
-    /// This function will panic if the flatbuffer is not contained within the given [`FlatBuffer`].
-    pub fn new(
-        row_count: usize,
-        array: fba::Array,
-        flatbuffer: FlatBuffer,
-        buffers: Vec<ByteBuffer>,
-    ) -> Self {
-        // We ensure that the flatbuffer given to us does indeed match that of the ByteBuffer
-        if flatbuffer
-            .as_ref()
-            .as_slice()
-            .subslice_range(array._tab.buf())
-            != Some(0..flatbuffer.len())
-        {
-            vortex_panic!("Array flatbuffer is not contained within the buffer");
-        }
+    /// Creates a new [`ArrayParts`] from an [`OwnedArray`] flatbuffer.
+    pub fn new(row_count: usize, array: OwnedArray, buffers: Vec<ByteBuffer>) -> Self {
         Self {
             row_count,
-            flatbuffer,
-            flatbuffer_loc: array._tab.loc(),
+            array,
             buffers,
         }
     }
 
     /// Decode an [`ArrayParts`] into an [`ArrayData`].
     pub fn decode(self, ctx: ContextRef, dtype: DType) -> VortexResult<ArrayData> {
-        ArrayData::try_new_viewed(
-            ctx,
-            dtype,
-            self.row_count,
-            self.flatbuffer,
-            // SAFETY: ArrayComponents guarantees the buffers are valid.
-            |buf| unsafe { Ok(fba::Array::follow(buf, self.flatbuffer_loc)) },
-            self.buffers,
-        )
+        ArrayData::try_new_viewed(ctx, dtype, self.row_count, self.array, self.buffers)
     }
 }
 
@@ -88,16 +56,20 @@ impl From<ArrayData> for ArrayParts {
             buffer_idx: 0,
         }
         .write_flatbuffer_bytes();
+
+        // SAFETY: creating using the output of write_flatbuffer_bytes means we should have valid data.
+        let owned_array = unsafe { OwnedArray::new_unchecked(flatbuffer) };
+
         let mut buffers: Vec<ByteBuffer> = vec![];
         for child in array.depth_first_traversal() {
             for buffer in child.byte_buffers() {
                 buffers.push(buffer);
             }
         }
+
         Self {
             row_count: array.len(),
-            flatbuffer,
-            flatbuffer_loc: 0,
+            array: owned_array,
             buffers,
         }
     }

--- a/vortex-array/src/parts.rs
+++ b/vortex-array/src/parts.rs
@@ -35,6 +35,11 @@ impl Debug for ArrayParts {
 impl ArrayParts {
     /// Creates a new [`ArrayParts`] from an [`OwnedArray`] flatbuffer.
     pub fn new(row_count: usize, array: OwnedArray, buffers: Vec<ByteBuffer>) -> Self {
+        println!(
+            "CREATE array: row_count = {row_count} array = {} buffers = {}",
+            array.as_fb().encoding(),
+            buffers.len()
+        );
         Self {
             row_count,
             array,

--- a/vortex-flatbuffers/Cargo.toml
+++ b/vortex-flatbuffers/Cargo.toml
@@ -24,6 +24,8 @@ file = ["ipc"]
 [dependencies]
 flatbuffers = { workspace = true }
 vortex-buffer = { workspace = true }
+vortex-error = { workspace = true, features = ["flatbuffers"] }
+paste = { workspace = true }
 
 [lints]
 workspace = true

--- a/vortex-flatbuffers/src/lib.rs
+++ b/vortex-flatbuffers/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(substr_range)]
+
 //! A contiguously serialized Vortex array.
 //!
 //! See [message] and [footer] for the flatbuffer specifications.
@@ -157,6 +159,8 @@ pub mod layout;
 #[doc = include_str!("../flatbuffers/vortex-serde/message.fbs")]
 /// ```
 pub mod message;
+
+pub mod owned;
 
 use flatbuffers::{root, FlatBufferBuilder, Follow, InvalidFlatbuffer, Verifiable, WIPOffset};
 use vortex_buffer::{ByteBuffer, ConstByteBuffer};

--- a/vortex-flatbuffers/src/owned.rs
+++ b/vortex-flatbuffers/src/owned.rs
@@ -1,0 +1,141 @@
+use vortex_error::VortexResult;
+
+use crate::FlatBuffer;
+
+pub trait Owned {
+    fn try_new(buffer: FlatBuffer) -> VortexResult<Self>
+    where
+        Self: Sized,
+    {
+        Self::try_new_with_loc(buffer, 0)
+    }
+
+    fn try_new_with_loc(buffer: FlatBuffer, loc: usize) -> VortexResult<Self>
+    where
+        Self: Sized;
+}
+
+#[allow(unused_macros)]
+macro_rules! make_owned {
+    ($name:ident) => {
+        paste::paste! {
+            #[derive(Clone)]
+            pub struct [<Owned $name>]($crate::FlatBuffer);
+
+            impl $crate::owned::Owned for [<Owned $name>] {
+                /// Attempt to construct a new owned type that wraps a `flatbuffers` type.
+                fn try_new_with_loc(buffer: $crate::FlatBuffer, loc: usize) -> vortex_error::VortexResult<Self> {
+                    // Perform validation when we move into the OwnedTable.
+                    let opts = flatbuffers::VerifierOptions::default();
+                    let mut verifier = flatbuffers::Verifier::new(&opts, &buffer);
+                    <flatbuffers::ForwardsUOffset<$name> as flatbuffers::Verifiable>::run_verifier(&mut verifier, loc)?;
+
+                    Ok(Self(buffer))
+                }
+            }
+
+            impl [<Owned $name>] {
+
+                /// Create a new buffer directly.
+                ///
+                /// # Safety
+                ///
+                /// It is the caller's responsibility to be absolutely certain that the provided buffer is directly
+                /// populated with a valid Flatbuffer bytes of the desired type.
+                pub unsafe fn new_unchecked(buffer: $crate::FlatBuffer) -> Self {
+                    Self(buffer)
+                }
+
+                /// Access the `flatbuffers` inner type without verification.
+                ///
+                /// This is safe because verification is run on construction.
+                pub fn as_fb(&self) -> $name {
+                    // SAFETY: we run verification on construction.
+                    unsafe { flatbuffers::root_unchecked::<$name>(&self.0) }
+                }
+
+                /// Consume the owned reference, handing back the underlying buffer.
+                pub fn into_inner(self) -> $crate::FlatBuffer {
+                    self.0
+                }
+
+                /// Create a new owned child of type `T` over the provided slice range.
+                ///
+                /// # Panics
+                ///
+                /// If the provided slice is not a valid range within the owned buffer,
+                /// the program will panic.
+                pub fn owned_child<'a, T, O>(&self, slice: &'a [u8]) -> vortex_error::VortexResult<O>
+                where
+                    T: flatbuffers::Follow<'a>,
+                    O: $crate::owned::Owned + 'static,
+                {
+                    let Some(range) = self.0.subslice_range(slice) else {
+                        vortex_error::vortex_panic!("provided slice is not valid subrange of {}", stringify!([<Owned $name>]))
+                    };
+
+                    // Create a new buffer with the provided offset.
+                    O::try_new_with_loc(self.0.clone(), range.start)
+                }
+            }
+        }
+    };
+}
+
+#[cfg(feature = "array")]
+pub mod array {
+    use crate::array::Array;
+
+    make_owned!(Array);
+}
+
+/// Owned versions of the Flatbuffer types defined in the `message` package.
+#[cfg(feature = "ipc")]
+pub mod message {
+    use crate::message::Message;
+
+    make_owned!(Message);
+}
+
+/// Owned versions of the Flatbuffer types defined in the `layout` package.
+#[cfg(feature = "layout")]
+pub mod layout {
+    use crate::layout::Layout;
+
+    make_owned!(Layout);
+}
+
+#[cfg(test)]
+mod tests {
+    use flatbuffers::FlatBufferBuilder;
+    use vortex_buffer::{Alignment, Buffer};
+
+    use super::layout::OwnedLayout;
+    use crate::layout::{Layout, LayoutArgs};
+    use crate::owned::Owned;
+    use crate::FlatBuffer;
+
+    #[test]
+    fn test_owned_buffer() {
+        let mut fbb = FlatBufferBuilder::new();
+        let offset = Layout::create(
+            &mut fbb,
+            &LayoutArgs {
+                encoding: 1,
+                row_count: 1,
+                ..Default::default()
+            },
+        );
+
+        fbb.finish_minimal(offset);
+
+        let (buffer, start) = fbb.collapse();
+        let buffer = Buffer::copy_from_aligned(&buffer[start..buffer.len()], Alignment::new(8));
+        let buffer = FlatBuffer::try_from(buffer).unwrap();
+
+        // We can't refer to an unowned type
+        let owned = OwnedLayout::try_new(buffer).unwrap();
+        assert_eq!(owned.as_fb().encoding(), 1);
+        assert_eq!(owned.as_fb().row_count(), 1);
+    }
+}

--- a/vortex-ipc/src/messages/decoder.rs
+++ b/vortex-ipc/src/messages/decoder.rs
@@ -1,14 +1,16 @@
 use std::fmt::Debug;
 
 use bytes::Buf;
-use flatbuffers::{root, root_unchecked};
 use itertools::Itertools;
 use vortex_array::parts::ArrayParts;
 use vortex_buffer::{AlignedBuf, Alignment, ByteBuffer};
 use vortex_dtype::DType;
 use vortex_error::{vortex_bail, vortex_err, VortexExpect, VortexResult};
+use vortex_flatbuffers::array::Array;
 use vortex_flatbuffers::message::{MessageHeader, MessageVersion};
-use vortex_flatbuffers::{message as fb, FlatBuffer};
+use vortex_flatbuffers::owned::array::OwnedArray;
+use vortex_flatbuffers::owned::message::OwnedMessage;
+use vortex_flatbuffers::owned::Owned;
 
 use crate::ALIGNMENT;
 
@@ -34,7 +36,7 @@ enum State {
 }
 
 struct ReadingArray {
-    header: FlatBuffer,
+    header: OwnedMessage,
     buffers_length: usize,
 }
 
@@ -81,7 +83,7 @@ impl MessageDecoder {
     /// this number of bytes otherwise it will be given the same `NeedMore` response.
     pub fn read_next<B: AlignedBuf>(&mut self, bytes: &mut B) -> VortexResult<PollRead> {
         loop {
-            match &self.state {
+            match &mut self.state {
                 State::Length => {
                     if bytes.remaining() < 4 {
                         return Ok(PollRead::NeedMore(4));
@@ -96,14 +98,16 @@ impl MessageDecoder {
                     }
 
                     let msg_bytes = bytes.copy_to_const_aligned(*msg_length);
-                    let msg = root::<fb::Message>(msg_bytes.as_ref())?;
-                    if msg.version() != MessageVersion::V0 {
-                        vortex_bail!("Unsupported message version {:?}", msg.version());
+                    let msg: OwnedMessage = OwnedMessage::try_new(msg_bytes.clone())?;
+                    let msg_fb = msg.as_fb();
+                    if msg_fb.version() != MessageVersion::V0 {
+                        vortex_bail!("Unsupported message version {:?}", msg_fb);
                     }
 
-                    match msg.header_type() {
+                    match msg_fb.header_type() {
                         MessageHeader::ArrayMessage => {
                             let array_msg = msg
+                                .as_fb()
                                 .header_as_array_message()
                                 .vortex_expect("array message header");
                             let buffers_length: u64 = array_msg
@@ -118,12 +122,12 @@ impl MessageDecoder {
                             })?;
 
                             self.state = State::Array(ReadingArray {
-                                header: msg_bytes,
+                                header: msg,
                                 buffers_length,
                             });
                         }
                         MessageHeader::Buffer => {
-                            let buffer = msg.header_as_buffer().vortex_expect("buffer header");
+                            let buffer = msg_fb.header_as_buffer().vortex_expect("buffer header");
                             let length = usize::try_from(buffer.length())
                                 .vortex_expect("Buffer length is too large for usize");
                             let length_with_padding = length + buffer.padding() as usize;
@@ -135,15 +139,18 @@ impl MessageDecoder {
                             });
                         }
                         MessageHeader::DType => {
-                            let msg_dtype = msg.header_as_dtype().vortex_expect("dtype header");
-                            let dtype = DType::try_from_view(msg_dtype, msg_bytes.clone())?;
+                            let msg_dtype = msg_fb.header_as_dtype().vortex_expect("dtype header");
+                            let dtype = DType::try_from_view(msg_dtype, msg_bytes)?;
 
                             // Nothing else to read, so we reset the state to Length
                             self.state = Default::default();
                             return Ok(PollRead::Some(DecoderMessage::DType(dtype)));
                         }
                         _ => {
-                            vortex_bail!("Unsupported message header type {:?}", msg.header_type());
+                            vortex_bail!(
+                                "Unsupported message header type {:?}",
+                                msg_fb.header_type()
+                            );
                         }
                     }
                 }
@@ -161,7 +168,7 @@ impl MessageDecoder {
 
                     // Then use the buffer-requested alignment for the result.
                     let msg = DecoderMessage::Buffer(buffer.aligned(*alignment));
-                    bytes.advance(length_with_padding - length);
+                    bytes.advance(*length_with_padding - *length);
 
                     // Nothing else to read, so we reset the state to Length
                     self.state = Default::default();
@@ -175,8 +182,7 @@ impl MessageDecoder {
                         return Ok(PollRead::NeedMore(*buffers_length));
                     }
 
-                    // SAFETY: we've already validated the header
-                    let msg = unsafe { root_unchecked::<fb::Message>(header.as_ref()) };
+                    let msg = header.as_fb();
                     let array_msg = msg
                         .header_as_array_message()
                         .vortex_expect("array message header");
@@ -205,12 +211,10 @@ impl MessageDecoder {
                     let row_count = usize::try_from(array_msg.row_count())
                         .map_err(|_| vortex_err!("row count is too large for usize"))?;
 
-                    let msg = DecoderMessage::Array(ArrayParts::new(
-                        row_count,
-                        array,
-                        header.clone(),
-                        buffers,
-                    ));
+                    let array_owned = header.owned_child::<Array, OwnedArray>(array._tab.buf())?;
+
+                    let msg =
+                        DecoderMessage::Array(ArrayParts::new(row_count, array_owned, buffers));
 
                     self.state = Default::default();
                     return Ok(PollRead::Some(msg));

--- a/vortex-layout/src/layouts/flat/eval_expr.rs
+++ b/vortex-layout/src/layouts/flat/eval_expr.rs
@@ -21,6 +21,7 @@ impl ExprEvaluator for FlatReader {
         row_mask: RowMask,
         expr: ExprRef,
     ) -> VortexResult<ArrayData> {
+        println!("evaluate_expr {expr:?}");
         assert!(row_mask.true_count() > 0);
 
         // Fetch all the array buffers.

--- a/vortex-layout/src/layouts/flat/eval_expr.rs
+++ b/vortex-layout/src/layouts/flat/eval_expr.rs
@@ -1,12 +1,13 @@
 use async_trait::async_trait;
-use flatbuffers::root;
 use futures::future::try_join_all;
 use vortex_array::compute::{filter, slice};
 use vortex_array::parts::ArrayParts;
 use vortex_array::ArrayData;
 use vortex_error::{vortex_err, VortexExpect, VortexResult};
 use vortex_expr::ExprRef;
-use vortex_flatbuffers::{array as fba, FlatBuffer};
+use vortex_flatbuffers::owned::array::OwnedArray;
+use vortex_flatbuffers::owned::Owned;
+use vortex_flatbuffers::FlatBuffer;
 use vortex_scan::RowMask;
 
 use crate::layouts::flat::reader::FlatReader;
@@ -37,15 +38,12 @@ impl ExprEvaluator for FlatReader {
                 .ok_or_else(|| vortex_err!("Flat message missing"))?,
         )?;
 
+        let array = OwnedArray::try_new(flatbuffer)?;
+
         let row_count = usize::try_from(self.layout().row_count())
             .vortex_expect("FlatLayout row count does not fit within usize");
 
-        let array_parts = ArrayParts::new(
-            row_count,
-            root::<fba::Array>(flatbuffer.as_ref()).vortex_expect("Invalid fba::Array flatbuffer"),
-            flatbuffer.clone(),
-            buffers,
-        );
+        let array_parts = ArrayParts::new(row_count, array, buffers);
 
         // Decode into an ArrayData.
         let array = array_parts.decode(self.ctx(), self.dtype().clone())?;


### PR DESCRIPTION
Due to the way flatbuffers creates all table types with attached lifetimes, we have to always pass around a buffer + loc to read a flatbuffer type.

This PR adds some infra to make it easy to pass around `Owned` variants of all of our flatbuffer types, and feeds them into the IPC decoder and ArrayView constructor