### PR TITLE
feat: teach ALPArray to store validity only in the encoded array & other minor changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5252,9 +5252,11 @@ dependencies = [
 name = "vortex-alp"
 version = "0.23.0"
 dependencies = [
+ "arrow-array",
  "divan",
  "itertools 0.14.0",
  "num-traits",
+ "rand",
  "rstest",
  "serde",
  "vortex-array",

--- a/docs/rust/quickstart.rst
+++ b/docs/rust/quickstart.rst
@@ -45,7 +45,7 @@ Use :func:`~vortex.encoding.compress` to compress the Vortex array and check the
 
    >>> cvtx = vortex.compress(vtx)
    >>> cvtx.nbytes
-   15732
+   15755
    >>> cvtx.nbytes / vtx.nbytes
    0.11...
 

--- a/docs/rust/quickstart.rst
+++ b/docs/rust/quickstart.rst
@@ -45,7 +45,7 @@ Use :func:`~vortex.encoding.compress` to compress the Vortex array and check the
 
    >>> cvtx = vortex.compress(vtx)
    >>> cvtx.nbytes
-   15755
+   15732
    >>> cvtx.nbytes / vtx.nbytes
    0.11...
 

--- a/encodings/alp/Cargo.toml
+++ b/encodings/alp/Cargo.toml
@@ -17,6 +17,7 @@ readme = { workspace = true }
 workspace = true
 
 [dependencies]
+arrow-array = { workspace = true }
 itertools = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -30,6 +31,7 @@ vortex-scalar = { workspace = true }
 
 [dev-dependencies]
 divan = { workspace = true }
+rand = { workspace = true }
 rstest = { workspace = true }
 vortex-array = { workspace = true, features = ["test-harness"] }
 

--- a/encodings/alp/benches/alp_compress.rs
+++ b/encodings/alp/benches/alp_compress.rs
@@ -15,12 +15,12 @@ fn main() {
 }
 
 #[divan::bench(types = [f32, f64], args = [
-    (100_000, 1.0),
-    (10_000_000, 1.0),
     (100_000, 0.25),
     (10_000_000, 0.25),
     (100_000, 0.95),
     (10_000_000, 0.95),
+    (100_000, 1.0),
+    (10_000_000, 1.0),
 ])]
 fn compress_alp<T: ALPFloat + NativePType>(bencher: Bencher, args: (usize, f64)) {
     let (n, fraction_valid) = args;
@@ -37,12 +37,12 @@ fn compress_alp<T: ALPFloat + NativePType>(bencher: Bencher, args: (usize, f64))
 }
 
 #[divan::bench(types = [f32, f64], args = [
-    (100_000, 1.0),
-    (10_000_000, 1.0),
     (100_000, 0.25),
     (10_000_000, 0.25),
     (100_000, 0.95),
     (10_000_000, 0.95),
+    (100_000, 1.0),
+    (10_000_000, 1.0),
 ])]
 fn decompress_alp<T: ALPFloat + NativePType>(bencher: Bencher, args: (usize, f64)) {
     let (n, fraction_valid) = args;

--- a/encodings/alp/benches/alp_compress.rs
+++ b/encodings/alp/benches/alp_compress.rs
@@ -1,27 +1,60 @@
 #![allow(clippy::unwrap_used)]
 
 use divan::Bencher;
-use vortex_alp::{ALPFloat, ALPRDFloat, Exponents, RDEncoder};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng as _};
+use vortex_alp::{alp_encode, ALPFloat, ALPRDFloat, RDEncoder};
 use vortex_array::array::PrimitiveArray;
 use vortex_array::validity::Validity;
 use vortex_array::IntoCanonical;
-use vortex_buffer::{buffer, Buffer};
+use vortex_buffer::buffer;
+use vortex_dtype::NativePType;
 
 fn main() {
     divan::main();
 }
 
-#[divan::bench(types = [f32, f64], args = [100_000, 10_000_000])]
-fn compress_alp<T: ALPFloat>(n: usize) -> (Exponents, Buffer<T::ALPInt>, Buffer<u64>, Buffer<T>) {
-    let values: Vec<T> = vec![T::from(1.234).unwrap(); n];
-    T::encode(values.as_slice(), None)
+#[divan::bench(types = [f32, f64], args = [
+    (100_000, 1.0),
+    (10_000_000, 1.0),
+    (100_000, 0.25),
+    (10_000_000, 0.25),
+    (100_000, 0.95),
+    (10_000_000, 0.95),
+])]
+fn compress_alp<T: ALPFloat + NativePType>(bencher: Bencher, args: (usize, f64)) {
+    let (n, fraction_valid) = args;
+    let mut rng = StdRng::seed_from_u64(0);
+    let values = buffer![T::from(1.234).unwrap(); n];
+    let validity = if fraction_valid < 1.0 {
+        Validity::from_iter((0..values.len()).map(|_| rng.gen_bool(fraction_valid)))
+    } else {
+        Validity::NonNullable
+    };
+    bencher.bench_local(move || {
+        alp_encode(&PrimitiveArray::new(values.clone(), validity.clone())).unwrap()
+    })
 }
 
-#[divan::bench(types = [f32, f64], args = [100_000, 10_000_000])]
-fn decompress_alp<T: ALPFloat>(bencher: Bencher, n: usize) {
-    let values: Vec<T> = vec![T::from(1.234).unwrap(); n];
-    let (exponents, encoded, ..) = T::encode(values.as_slice(), None);
-    bencher.bench_local(move || T::decode(&encoded, exponents));
+#[divan::bench(types = [f32, f64], args = [
+    (100_000, 1.0),
+    (10_000_000, 1.0),
+    (100_000, 0.25),
+    (10_000_000, 0.25),
+    (100_000, 0.95),
+    (10_000_000, 0.95),
+])]
+fn decompress_alp<T: ALPFloat + NativePType>(bencher: Bencher, args: (usize, f64)) {
+    let (n, fraction_valid) = args;
+    let mut rng = StdRng::seed_from_u64(0);
+    let values = buffer![T::from(1.234).unwrap(); n];
+    let validity = if fraction_valid < 1.0 {
+        Validity::from_iter((0..values.len()).map(|_| rng.gen_bool(fraction_valid)))
+    } else {
+        Validity::NonNullable
+    };
+    let array = alp_encode(&PrimitiveArray::new(values, validity)).unwrap();
+    bencher.bench_local(move || array.clone().into_canonical().unwrap());
 }
 
 #[divan::bench(types = [f32, f64], args = [100_000, 10_000_000])]

--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -46,6 +46,14 @@ impl ALPArray {
         let mut children = Vec::with_capacity(2);
         children.push(encoded);
         if let Some(patches) = &patches {
+            if patches.dtype() != &dtype {
+                vortex_bail!(MismatchedTypes: dtype, patches.dtype());
+            }
+
+            if patches.values().logical_validity()?.false_count() != 0 {
+                vortex_bail!("ALPArray: patches must not contain invalid entries");
+            }
+
             children.push(patches.indices().clone());
             children.push(patches.values().clone());
         }

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -68,7 +68,6 @@ where
     } else {
         exceptional_positions
             .into_iter()
-            // index is a valid usize because it is an index into values.as_slice::<T>()
             .filter(|index| validity.value(*index as usize))
             .collect()
     };

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -75,13 +75,17 @@ where
     let patches = if valid_exceptional_positions.is_empty() {
         None
     } else {
-        assert!(values.dtype().is_nullable());
+        let patches_validity = if values.dtype().is_nullable() {
+            Validity::AllValid
+        } else {
+            Validity::NonNullable
+        };
         let exceptional_values: Buffer<T> = valid_exceptional_positions
             .iter()
             .map(|index| values_slice[*index as usize])
             .collect();
         let exceptional_values =
-            PrimitiveArray::new(exceptional_values, Validity::AllValid).into_array();
+            PrimitiveArray::new(exceptional_values, patches_validity).into_array();
         Some(Patches::new(
             values_slice.len(),
             valid_exceptional_positions.into_array(),

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -160,7 +160,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::approx_constant)] // ALP doesn't like E
+    #[allow(clippy::approx_constant)] // Clippy objects to 2.718, an approximation of e, the base of the natural logarithm.
     fn test_patched_compress() {
         let values = buffer![1.234f64, 2.718, f64::consts::PI, 4.0];
         let array = PrimitiveArray::new(values.clone(), Validity::NonNullable);
@@ -181,7 +181,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::approx_constant)] // ALP doesn't like E
+    #[allow(clippy::approx_constant)] // Clippy objects to 2.718, an approximation of e, the base of the natural logarithm.
     fn test_compress_ignores_invalid_exceptional_values() {
         let values = buffer![1.234f64, 2.718, f64::consts::PI, 4.0];
         let array = PrimitiveArray::new(values, Validity::from_iter([true, true, false, true]));

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -1,9 +1,11 @@
 use vortex_array::array::PrimitiveArray;
 use vortex_array::patches::Patches;
+use vortex_array::validity::Validity;
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{Array, IntoArray, IntoArrayVariant};
+use vortex_buffer::Buffer;
 use vortex_dtype::{NativePType, PType};
-use vortex_error::{vortex_bail, VortexResult, VortexUnwrap};
+use vortex_error::{vortex_bail, VortexResult};
 use vortex_scalar::ScalarType;
 
 use crate::alp::{ALPArray, ALPFloat};
@@ -24,39 +26,74 @@ macro_rules! match_each_alp_float_ptype {
     })
 }
 
-pub fn alp_encode_components<T>(
+pub fn alp_encode(parray: &PrimitiveArray) -> VortexResult<ALPArray> {
+    let (exponents, encoded, patches) = alp_encode_components(parray)?;
+    ALPArray::try_new(encoded, exponents, patches)
+}
+
+pub fn alp_encode_components(
+    parray: &PrimitiveArray,
+) -> VortexResult<(Exponents, Array, Option<Patches>)> {
+    match parray.ptype() {
+        PType::F32 => alp_encode_components_typed::<f32>(parray),
+        PType::F64 => alp_encode_components_typed::<f64>(parray),
+        _ => vortex_bail!("ALP can only encode f32 and f64"),
+    }
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn alp_encode_components_typed<T>(
     values: &PrimitiveArray,
-    exponents: Option<Exponents>,
-) -> (Exponents, Array, Option<Patches>)
+) -> VortexResult<(Exponents, Array, Option<Patches>)>
 where
     T: ALPFloat + NativePType,
     T::ALPInt: NativePType,
     T: ScalarType,
 {
-    let (exponents, encoded, exc_pos, exc) = T::encode(values.as_slice::<T>(), exponents);
-    let len = encoded.len();
-    (
-        exponents,
-        PrimitiveArray::new(encoded, values.validity()).into_array(),
-        (!exc.is_empty()).then(|| {
-            let position_arr = exc_pos.into_array();
-            let patch_validity = values.validity().take(&position_arr).vortex_unwrap();
-            Patches::new(
-                len,
-                position_arr,
-                PrimitiveArray::new(exc, patch_validity).into_array(),
-            )
-        }),
-    )
-}
+    let values_slice = values.as_slice::<T>();
 
-pub fn alp_encode(parray: &PrimitiveArray) -> VortexResult<ALPArray> {
-    let (exponents, encoded, patches) = match parray.ptype() {
-        PType::F32 => alp_encode_components::<f32>(parray, None),
-        PType::F64 => alp_encode_components::<f64>(parray, None),
-        _ => vortex_bail!("ALP can only encode f32 and f64"),
+    let exponents = T::find_best_exponents(values_slice);
+    let (encoded, exceptional_positions) = T::encode_chunkwise(values.as_slice::<T>(), exponents);
+
+    let encoded_array = PrimitiveArray::new(encoded, values.validity()).into_array();
+
+    let validity = values.logical_validity()?;
+    let n_valid = validity.true_count();
+    // exceptional_positions may contain exceptions at invalid positions (which contain garbage
+    // data). We remove invalid exceptional positions in order to keep the Patches small.
+    let valid_exceptional_positions = if n_valid == 0 {
+        Buffer::empty()
+    } else if n_valid == values.len() {
+        exceptional_positions
+    } else {
+        exceptional_positions
+            .into_iter()
+            // index is a valid usize because it is an index into values.as_slice::<T>()
+            .filter(|index| validity.value(*index as usize))
+            .collect()
     };
-    ALPArray::try_new(encoded, exponents, patches)
+
+    let patches = if valid_exceptional_positions.is_empty() {
+        None
+    } else {
+        let patches_validity = if values.dtype().is_nullable() {
+            Validity::AllValid
+        } else {
+            Validity::NonNullable
+        };
+        let exceptional_values: Buffer<T> = valid_exceptional_positions
+            .iter()
+            .map(|index| values_slice[*index as usize])
+            .collect();
+        let exceptional_values =
+            PrimitiveArray::new(exceptional_values, patches_validity).into_array();
+        Some(Patches::new(
+            values_slice.len(),
+            valid_exceptional_positions.into_array(),
+            exceptional_values,
+        ))
+    };
+    Ok((exponents, encoded_array, patches))
 }
 
 pub fn decompress(array: ALPArray) -> VortexResult<PrimitiveArray> {
@@ -140,12 +177,45 @@ mod tests {
                 .into_primitive()
                 .unwrap()
                 .as_slice::<i64>(),
-            vec![1234i64, 2718, 1234, 4000] // fill forward
+            vec![1234i64, 2718, 3142, 4000]
         );
         assert_eq!(encoded.exponents(), Exponents { e: 16, f: 13 });
 
         let decoded = decompress(encoded).unwrap();
         assert_eq!(values.as_slice(), decoded.as_slice::<f64>());
+    }
+
+    #[test]
+    #[allow(clippy::approx_constant)] // ALP doesn't like E
+    fn test_compress_ignores_invalid_exceptional_values() {
+        let values = buffer![1.234f64, 2.718, f64::consts::PI, 4.0];
+        let array = PrimitiveArray::new(values, Validity::from_iter([true, true, false, true]));
+        let encoded = alp_encode(&array).unwrap();
+        assert!(encoded.patches().is_none());
+        assert_eq!(
+            encoded
+                .encoded()
+                .into_primitive()
+                .unwrap()
+                .as_slice::<i64>(),
+            vec![1234i64, 2718, 3142, 4000]
+        );
+        assert_eq!(encoded.exponents(), Exponents { e: 16, f: 13 });
+
+        let decoded = decompress(encoded).unwrap();
+        assert_eq!(
+            scalar_at(&decoded, 0).unwrap(),
+            scalar_at(&array, 0).unwrap()
+        );
+        assert_eq!(
+            scalar_at(&decoded, 1).unwrap(),
+            scalar_at(&array, 1).unwrap()
+        );
+        assert!(!decoded.is_valid(2).unwrap());
+        assert_eq!(
+            scalar_at(&decoded, 3).unwrap(),
+            scalar_at(&array, 3).unwrap()
+        );
     }
 
     #[test]
@@ -168,6 +238,7 @@ mod tests {
             assert!(s.is_valid());
         }
 
+        assert!(!encoded.is_valid(4).unwrap());
         let s = scalar_at(encoded.as_ref(), 4).unwrap();
         assert!(s.is_null());
 
@@ -190,7 +261,6 @@ mod tests {
         );
         let alp_arr = alp_encode(&original).unwrap();
         let decompressed = alp_arr.into_primitive().unwrap();
-        assert_eq!(original.as_slice::<f64>(), decompressed.as_slice::<f64>());
         assert_eq!(original.validity(), decompressed.validity());
     }
 }

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -75,17 +75,13 @@ where
     let patches = if valid_exceptional_positions.is_empty() {
         None
     } else {
-        let patches_validity = if values.dtype().is_nullable() {
-            Validity::AllValid
-        } else {
-            Validity::NonNullable
-        };
+        assert!(values.dtype().is_nullable());
         let exceptional_values: Buffer<T> = valid_exceptional_positions
             .iter()
             .map(|index| values_slice[*index as usize])
             .collect();
         let exceptional_values =
-            PrimitiveArray::new(exceptional_values, patches_validity).into_array();
+            PrimitiveArray::new(exceptional_values, Validity::AllValid).into_array();
         Some(Patches::new(
             values_slice.len(),
             valid_exceptional_positions.into_array(),

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -260,6 +260,7 @@ mod tests {
         );
         let alp_arr = alp_encode(&original).unwrap();
         let decompressed = alp_arr.into_primitive().unwrap();
+        assert_eq!(original.as_slice::<f64>(), decompressed.as_slice::<f64>());
         assert_eq!(original.validity(), decompressed.validity());
     }
 }

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -121,6 +121,7 @@ mod tests {
     use vortex_array::compute::scalar_at;
     use vortex_array::validity::Validity;
     use vortex_buffer::{buffer, Buffer};
+    use vortex_scalar::Scalar;
 
     use super::*;
 
@@ -260,7 +261,23 @@ mod tests {
         );
         let alp_arr = alp_encode(&original).unwrap();
         let decompressed = alp_arr.into_primitive().unwrap();
-        assert_eq!(original.as_slice::<f64>(), decompressed.as_slice::<f64>());
+        assert_eq!(
+            // The second and third values become exceptions and are replaced
+            [195.26274, 195.26274, 195.26274],
+            decompressed.as_slice::<f64>()
+        );
         assert_eq!(original.validity(), decompressed.validity());
+        assert_eq!(
+            scalar_at(&original, 0).unwrap(),
+            Scalar::null_typed::<f64>()
+        );
+        assert_eq!(
+            scalar_at(&original, 1).unwrap(),
+            Scalar::null_typed::<f64>()
+        );
+        assert_eq!(
+            scalar_at(&original, 2).unwrap(),
+            Scalar::null_typed::<f64>()
+        );
     }
 }

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -53,7 +53,7 @@ where
     let values_slice = values.as_slice::<T>();
 
     let exponents = T::find_best_exponents(values_slice);
-    let (encoded, exceptional_positions) = T::encode_chunkwise(values.as_slice::<T>(), exponents);
+    let (encoded, exceptional_positions) = T::encode_chunkwise(values_slice, exponents);
 
     let encoded_array = PrimitiveArray::new(encoded, values.validity()).into_array();
 

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -176,7 +176,7 @@ mod tests {
                 .into_primitive()
                 .unwrap()
                 .as_slice::<i64>(),
-            vec![1234i64, 2718, 3142, 4000]
+            vec![1234i64, 2718, 1234, 4000]
         );
         assert_eq!(encoded.exponents(), Exponents { e: 16, f: 13 });
 
@@ -197,7 +197,7 @@ mod tests {
                 .into_primitive()
                 .unwrap()
                 .as_slice::<i64>(),
-            vec![1234i64, 2718, 3142, 4000]
+            vec![1234i64, 2718, 1234, 4000]
         );
         assert_eq!(encoded.exponents(), Exponents { e: 16, f: 13 });
 

--- a/encodings/alp/src/alp/compute/mod.rs
+++ b/encodings/alp/src/alp/compute/mod.rs
@@ -36,9 +36,13 @@ impl ComputeVTable for ALPEncoding {
 
 impl ScalarAtFn<ALPArray> for ALPEncoding {
     fn scalar_at(&self, array: &ALPArray, index: usize) -> VortexResult<Scalar> {
+        if !array.encoded().is_valid(index)? {
+            return Ok(Scalar::null(array.dtype().clone()));
+        }
+
         if let Some(patches) = array.patches() {
             if let Some(patch) = patches.get_patched(index)? {
-                return Ok(patch);
+                return patch.cast(array.dtype());
             }
         }
 

--- a/encodings/alp/src/alp/mod.rs
+++ b/encodings/alp/src/alp/mod.rs
@@ -63,18 +63,17 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
             values
                 .iter()
                 .step_by(values.len() / SAMPLE_SIZE)
+                .take(SAMPLE_SIZE)
                 .cloned()
                 .collect_vec()
         });
 
         for e in (0..Self::MAX_EXPONENT).rev() {
             for f in 0..e {
-                let (_, encoded, _, exc_patches) = Self::encode(
-                    sample.as_deref().unwrap_or(values),
-                    Some(Exponents { e, f }),
-                );
+                let (encoded, exceptional_positions) =
+                    Self::encode(sample.as_deref().unwrap_or(values), Exponents { e, f });
 
-                let size = Self::estimate_encoded_size(&encoded, &exc_patches);
+                let size = Self::estimate_encoded_size(&encoded, exceptional_positions.len());
                 if size < best_nbytes {
                     best_nbytes = size;
                     best_exp = Exponents { e, f };
@@ -88,7 +87,7 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
     }
 
     #[inline]
-    fn estimate_encoded_size(encoded: &[Self::ALPInt], patches: &[Self]) -> usize {
+    fn estimate_encoded_size(encoded: &[Self::ALPInt], n_exceptions: usize) -> usize {
         let bits_per_encoded = encoded
             .iter()
             .minmax()
@@ -107,42 +106,57 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
         let encoded_bytes = (encoded.len() * bits_per_encoded + 7) / 8;
         // each patch is a value + a position
         // in practice, patch positions are in [0, u16::MAX] because of how we chunk
-        let patch_bytes = patches.len() * (size_of::<Self>() + size_of::<u16>());
+        let patch_bytes = n_exceptions * (size_of::<Self>() + size_of::<u16>());
 
         encoded_bytes + patch_bytes
     }
 
-    fn encode(
+    /// A quantity of [Self] expected to fit into L1 cache.
+    const ENCODE_CHUNK_SIZE: usize = (32 << 10) / size_of::<Self::ALPInt>();
+
+    /// ALP encode chunk-by-chunk.
+    ///
+    /// Unlike [Self::encode], this operation processes no more than [Self::ENCODE_CHUNK_SIZE]
+    /// elements at once which can make better use of the L1 cache because [Self::encode] makes two
+    /// passes over `values`: first to encode and second to extract the exceptional values.
+    fn encode_chunkwise(
         values: &[Self],
-        exponents: Option<Exponents>,
-    ) -> (Exponents, Buffer<Self::ALPInt>, Buffer<u64>, Buffer<Self>) {
-        let exp = exponents.unwrap_or_else(|| Self::find_best_exponents(values));
-
-        let mut encoded_output = BufferMut::<Self::ALPInt>::with_capacity(values.len());
-        let mut patch_indices = BufferMut::<u64>::with_capacity(values.len());
-        let mut patch_values = BufferMut::<Self>::with_capacity(values.len());
-        let mut fill_value: Option<Self::ALPInt> = None;
-
-        // this is intentionally branchless
-        // we batch this into 32KB of values at a time to make it more L1 cache friendly
-        let encode_chunk_size: usize = (32 << 10) / size_of::<Self::ALPInt>();
-        for chunk in values.chunks(encode_chunk_size) {
-            encode_chunk_unchecked(
-                chunk,
-                exp,
-                &mut encoded_output,
-                &mut patch_indices,
-                &mut patch_values,
-                &mut fill_value,
-            );
+        exponents: Exponents,
+    ) -> (Buffer<Self::ALPInt>, Buffer<u64>) {
+        let mut encoded = BufferMut::<Self::ALPInt>::with_capacity(values.len());
+        let mut patch_indices = BufferMut::<u64>::empty();
+        for chunk in values.chunks(Self::ENCODE_CHUNK_SIZE) {
+            let (encoded_chunk, patches_indices_chunk) = Self::encode(chunk, exponents);
+            encoded.extend(encoded_chunk);
+            patch_indices.extend(patches_indices_chunk);
         }
+        (encoded.freeze(), patch_indices.freeze())
+    }
 
-        (
-            exp,
-            encoded_output.freeze(),
-            patch_indices.freeze(),
-            patch_values.freeze(),
-        )
+    /// ALP encode the given values using the given exponents.
+    ///
+    /// The index of each value for which encode-decode is not the identity function is returned.
+    ///
+    /// See also: [Self::encode_chunkwise].
+    fn encode(values: &[Self], exponents: Exponents) -> (Vec<Self::ALPInt>, Vec<u64>) {
+        let (encoded, needs_patch): (Vec<Self::ALPInt>, Vec<bool>) = values
+            .iter()
+            .map(|value| {
+                let encoded = unsafe { Self::encode_single_unchecked(*value, exponents) };
+                let maybe_decoded = Self::decode_single(encoded, exponents);
+                let needs_patch = maybe_decoded != *value;
+                (encoded, needs_patch)
+            })
+            .unzip();
+
+        let patch_indices: Vec<u64> = needs_patch
+            .into_iter()
+            .enumerate()
+            .filter(|(_, needs_patch)| *needs_patch)
+            .map(|(index, _)| index as u64)
+            .collect();
+
+        (encoded, patch_indices)
     }
 
     #[inline]
@@ -192,79 +206,6 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
         (value * Self::F10[exponents.e as usize] * Self::IF10[exponents.f as usize])
             .fast_round()
             .as_int()
-    }
-}
-
-#[allow(clippy::cast_possible_truncation)]
-fn encode_chunk_unchecked<T: ALPFloat>(
-    chunk: &[T],
-    exp: Exponents,
-    encoded_output: &mut BufferMut<T::ALPInt>,
-    patch_indices: &mut BufferMut<u64>,
-    patch_values: &mut BufferMut<T>,
-    fill_value: &mut Option<T::ALPInt>,
-) {
-    let num_prev_encoded = encoded_output.len();
-    let num_prev_patches = patch_indices.len();
-    assert_eq!(patch_indices.len(), patch_values.len());
-    let has_filled = fill_value.is_some();
-
-    // encode the chunk, counting the number of patches
-    let mut chunk_patch_count = 0;
-    encoded_output.extend(chunk.iter().map(|v| {
-        let encoded = unsafe { T::encode_single_unchecked(*v, exp) };
-        let decoded = T::decode_single(encoded, exp);
-        let neq = (decoded != *v) as usize;
-        chunk_patch_count += neq;
-        encoded
-    }));
-    let chunk_patch_count = chunk_patch_count; // immutable hereafter
-    assert_eq!(encoded_output.len(), num_prev_encoded + chunk.len());
-
-    if chunk_patch_count > 0 {
-        // we need to gather the patches for this chunk
-        // preallocate space for the patches (plus one because our loop may attempt to write one past the end)
-        patch_indices.reserve(chunk_patch_count + 1);
-        patch_values.reserve(chunk_patch_count + 1);
-
-        // record the patches in this chunk
-        let patch_indices_mut = patch_indices.spare_capacity_mut();
-        let patch_values_mut = patch_values.spare_capacity_mut();
-        let mut chunk_patch_index = 0;
-        for i in num_prev_encoded..encoded_output.len() {
-            let decoded = T::decode_single(encoded_output[i], exp);
-            // write() is only safe to call more than once because the values are primitive (i.e., Drop is a no-op)
-            patch_indices_mut[chunk_patch_index].write(i as u64);
-            patch_values_mut[chunk_patch_index].write(chunk[i - num_prev_encoded]);
-            chunk_patch_index += (decoded != chunk[i - num_prev_encoded]) as usize;
-        }
-        assert_eq!(chunk_patch_index, chunk_patch_count);
-        unsafe {
-            patch_indices.set_len(num_prev_patches + chunk_patch_count);
-            patch_values.set_len(num_prev_patches + chunk_patch_count);
-        }
-    }
-
-    // find the first successfully encoded value (i.e., not patched)
-    // this is our fill value for missing values
-    if fill_value.is_none() && (num_prev_encoded + chunk_patch_count < encoded_output.len()) {
-        assert_eq!(num_prev_encoded, num_prev_patches);
-        for i in num_prev_encoded..encoded_output.len() {
-            if i >= patch_indices.len() || patch_indices[i] != i as u64 {
-                *fill_value = Some(encoded_output[i]);
-                break;
-            }
-        }
-    }
-
-    // replace the patched values in the encoded array with the fill value
-    // for better downstream compression
-    if let Some(fill_value) = fill_value {
-        // handle the edge case where the first N >= 1 chunks are all patches
-        let start_patch = if !has_filled { 0 } else { num_prev_patches };
-        for patch_idx in &patch_indices[start_patch..] {
-            encoded_output[*patch_idx as usize] = *fill_value;
-        }
     }
 }
 

--- a/encodings/alp/src/alp/mod.rs
+++ b/encodings/alp/src/alp/mod.rs
@@ -35,7 +35,7 @@ mod private {
 }
 
 pub trait ALPFloat: private::Sealed + Float + Display + 'static {
-    type ALPInt: PrimInt + Display + ToPrimitive + Copy;
+    type ALPInt: PrimInt + Display + ToPrimitive + Copy + Default;
 
     const FRACTIONAL_BITS: u8;
     const MAX_EXPONENT: u8;
@@ -164,13 +164,11 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
             .collect();
 
         if !patch_indices.is_empty() {
-            if let Some(fill_value) =
-                Self::first_non_patched_encoded_value(&encoded, &patch_indices)
-            {
-                for index in patch_indices.iter() {
-                    let index = *index as usize;
-                    encoded[index] = fill_value;
-                }
+            let fill_value =
+                Self::first_non_patched_encoded_value(&encoded, &patch_indices).unwrap_or_default();
+            for index in patch_indices.iter() {
+                let index = *index as usize;
+                encoded[index] = fill_value;
             }
         }
 

--- a/encodings/alp/src/alp/mod.rs
+++ b/encodings/alp/src/alp/mod.rs
@@ -138,8 +138,9 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
     /// The index of each value for which encode-decode is not the identity function is returned.
     ///
     /// See also: [Self::encode_chunkwise].
+    #[allow(clippy::cast_possible_truncation)] // The patch_indices are known to be valid indices into encoded.
     fn encode(values: &[Self], exponents: Exponents) -> (Vec<Self::ALPInt>, Vec<u64>) {
-        let (encoded, needs_patch): (Vec<Self::ALPInt>, Vec<bool>) = values
+        let (mut encoded, needs_patch): (Vec<Self::ALPInt>, Vec<bool>) = values
             .iter()
             .map(|value| {
                 let encoded = unsafe { Self::encode_single_unchecked(*value, exponents) };
@@ -149,6 +150,12 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
             })
             .unzip();
 
+        // Patched values either have tiny differences (e.g. 1.01, 1.02, 1.00000001) or big
+        // differences (e.g. 1.01, 1.02, 1000.0). In the latter case, this large value
+        // prevents bitpacking (or forces patches into bitpacking).
+        //
+        // Zero allows bitpacking but prevents frame-of-reference encoding, so we choose the first
+        // successfully encoded value.
         let patch_indices: Vec<u64> = needs_patch
             .into_iter()
             .enumerate()
@@ -156,7 +163,28 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
             .map(|(index, _)| index as u64)
             .collect();
 
+        if let Some(fill_value) =
+            Self::find_first_non_patched_encoded_value(&encoded, &patch_indices)
+        {
+            for index in patch_indices.iter() {
+                let index = *index as usize;
+                encoded[index] = fill_value;
+            }
+        }
+
         (encoded, patch_indices)
+    }
+
+    fn find_first_non_patched_encoded_value(
+        encoded: &[Self::ALPInt],
+        patch_indices: &[u64],
+    ) -> Option<Self::ALPInt> {
+        for index in 0..encoded.len() {
+            if index >= patch_indices.len() || patch_indices[index] != index as u64 {
+                return Some(encoded[index]);
+            }
+        }
+        None
     }
 
     #[inline]

--- a/encodings/alp/src/alp/mod.rs
+++ b/encodings/alp/src/alp/mod.rs
@@ -163,19 +163,21 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
             .map(|(index, _)| index as u64)
             .collect();
 
-        if let Some(fill_value) =
-            Self::find_first_non_patched_encoded_value(&encoded, &patch_indices)
-        {
-            for index in patch_indices.iter() {
-                let index = *index as usize;
-                encoded[index] = fill_value;
+        if !patch_indices.is_empty() {
+            if let Some(fill_value) =
+                Self::first_non_patched_encoded_value(&encoded, &patch_indices)
+            {
+                for index in patch_indices.iter() {
+                    let index = *index as usize;
+                    encoded[index] = fill_value;
+                }
             }
         }
 
         (encoded, patch_indices)
     }
 
-    fn find_first_non_patched_encoded_value(
+    fn first_non_patched_encoded_value(
         encoded: &[Self::ALPInt],
         patch_indices: &[u64],
     ) -> Option<Self::ALPInt> {

--- a/vortex-sampling-compressor/src/compressors/alp.rs
+++ b/vortex-sampling-compressor/src/compressors/alp.rs
@@ -1,13 +1,13 @@
-use vortex_alp::{
-    alp_encode_components, match_each_alp_float_ptype, ALPArray, ALPEncoding, ALPRDEncoding,
-};
+use vortex_alp::{alp_encode_components, ALPArray, ALPEncoding, ALPRDEncoding};
 use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::array::PrimitiveArray;
+use vortex_array::compute::fill_null;
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{Array, Encoding, EncodingId, IntoArray, IntoArrayVariant};
 use vortex_dtype::PType;
 use vortex_error::VortexResult;
 use vortex_fastlanes::BitPackedEncoding;
+use vortex_scalar::Scalar;
 
 use super::alp_rd::ALPRDCompressor;
 use crate::compressors::{CompressedArray, CompressionTree, EncodingCompressor};
@@ -43,12 +43,9 @@ impl EncodingCompressor for ALPCompressor {
         like: Option<CompressionTree<'a>>,
         ctx: SamplingCompressor<'a>,
     ) -> VortexResult<CompressedArray<'a>> {
-        let parray = array.clone().into_primitive()?;
-
-        let (exponents, encoded, patches) = match_each_alp_float_ptype!(
-            parray.ptype(), |$T| {
-            alp_encode_components::<$T>(&parray, None)
-        });
+        let nulls_zeroed =
+            fill_null(array, Scalar::from(0.0).cast(array.dtype())?)?.into_primitive()?;
+        let (exponents, encoded, patches) = alp_encode_components(&nulls_zeroed)?;
 
         let compressed_encoded = ctx
             .named("packed")

--- a/vortex-sampling-compressor/src/compressors/alp.rs
+++ b/vortex-sampling-compressor/src/compressors/alp.rs
@@ -1,13 +1,11 @@
 use vortex_alp::{alp_encode_components, ALPArray, ALPEncoding, ALPRDEncoding};
 use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::array::PrimitiveArray;
-use vortex_array::compute::fill_null;
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{Array, Encoding, EncodingId, IntoArray, IntoArrayVariant};
 use vortex_dtype::PType;
 use vortex_error::VortexResult;
 use vortex_fastlanes::BitPackedEncoding;
-use vortex_scalar::Scalar;
 
 use super::alp_rd::ALPRDCompressor;
 use crate::compressors::{CompressedArray, CompressionTree, EncodingCompressor};

--- a/vortex-sampling-compressor/src/compressors/alp.rs
+++ b/vortex-sampling-compressor/src/compressors/alp.rs
@@ -43,9 +43,8 @@ impl EncodingCompressor for ALPCompressor {
         like: Option<CompressionTree<'a>>,
         ctx: SamplingCompressor<'a>,
     ) -> VortexResult<CompressedArray<'a>> {
-        let nulls_zeroed =
-            fill_null(array, Scalar::from(0.0).cast(array.dtype())?)?.into_primitive()?;
-        let (exponents, encoded, patches) = alp_encode_components(&nulls_zeroed)?;
+        let (exponents, encoded, patches) =
+            alp_encode_components(&array.clone().into_primitive()?)?;
 
         let compressed_encoded = ctx
             .named("packed")


### PR DESCRIPTION
The original change of this PR trims invalid values from the patches and makes the patches validity either AllValid (for nullable arrays) or NonNullable.

### Benchmarks on latest commit: 

- PR: 7fb595b75
- develop: 0a18498d0

parameter is: (number of elements, fraction patched, fraction valid).

Any ratio greater than 1.1 or less than 0.9 has a `  ***`

```
alp_compress                    │ PR median     │ develop median │ ratio
├─ compress_alp                 │               │                │
│  ├─ f32                       │               │                │
│  │  ├─ (100000, 0.0, 0.25)    │ 160.4 µs      │ 159.6 µs       │ 1.0050
│  │  ├─ (100000, 0.0, 0.95)    │ 145.9 µs      │ 143.8 µs       │ 1.0146
│  │  ├─ (100000, 0.0, 1.0)     │ 137.0 µs      │ 135.5 µs       │ 1.0110
│  │  ├─ (100000, 0.01, 0.25)   │ 227.7 µs      │ 230.7 µs       │ 0.9869
│  │  ├─ (100000, 0.01, 0.95)   │ 227.9 µs      │ 227.2 µs       │ 1.0030
│  │  ├─ (100000, 0.01, 1.0)    │ 226.6 µs      │ 227.5 µs       │ 0.9960
│  │  ├─ (100000, 0.1, 0.25)    │ 238.3 µs      │ 248.9 µs       │ 0.9574
│  │  ├─ (100000, 0.1, 0.95)    │ 238.2 µs      │ 269.8 µs       │ 0.8828  ***
│  │  ├─ (100000, 0.1, 1.0)     │ 230.6 µs      │ 231.9 µs       │ 0.9943
│  │  ├─ (10000000, 0.0, 0.25)  │ 14.17 ms      │ 13.77 ms       │ 1.0290
│  │  ├─ (10000000, 0.0, 0.95)  │ 14.16 ms      │ 13.8 ms        │ 1.0260
│  │  ├─ (10000000, 0.0, 1.0)   │ 14.0 ms       │ 12.47 ms       │ 1.1226  ***
│  │  ├─ (10000000, 0.01, 0.25) │ 22.29 ms      │ 23.13 ms       │ 0.9636
│  │  ├─ (10000000, 0.01, 0.95) │ 22.26 ms      │ 23.78 ms       │ 0.9360
│  │  ├─ (10000000, 0.01, 1.0)  │ 22.19 ms      │ 21.79 ms       │ 1.0183
│  │  ├─ (10000000, 0.1, 0.25)  │ 23.31 ms      │ 27.72 ms       │ 0.8409  ***
│  │  ├─ (10000000, 0.1, 0.95)  │ 23.4 ms       │ 27.47 ms       │ 0.8518  ***
│  │  ╰─ (10000000, 0.1, 1.0)   │ 22.99 ms      │ 22.31 ms       │ 1.0304
│  ╰─ f64                       │               │                │
│     ├─ (100000, 0.0, 0.25)    │ 165.2 µs      │ 165.4 µs       │ 0.9987
│     ├─ (100000, 0.0, 0.95)    │ 166.1 µs      │ 163.4 µs       │ 1.0165
│     ├─ (100000, 0.0, 1.0)     │ 164.7 µs      │ 179.9 µs       │ 0.9155
│     ├─ (100000, 0.01, 0.25)   │ 269.7 µs      │ 259.1 µs       │ 1.0409
│     ├─ (100000, 0.01, 0.95)   │ 270.5 µs      │ 259.6 µs       │ 1.0419
│     ├─ (100000, 0.01, 1.0)    │ 268.9 µs      │ 270.6 µs       │ 0.9937
│     ├─ (100000, 0.1, 0.25)    │ 281.7 µs      │ 281.3 µs       │ 1.0014
│     ├─ (100000, 0.1, 0.95)    │ 279.1 µs      │ 315.3 µs       │ 0.8851  ***
│     ├─ (100000, 0.1, 1.0)     │ 273.0 µs      │ 275.7 µs       │ 0.9902
│     ├─ (10000000, 0.0, 0.25)  │ 16.16 ms      │ 15.86 ms       │ 1.0189
│     ├─ (10000000, 0.0, 0.95)  │ 16.19 ms      │ 15.75 ms       │ 1.0279
│     ├─ (10000000, 0.0, 1.0)   │ 16.2 ms       │ 15.83 ms       │ 1.0233
│     ├─ (10000000, 0.01, 0.25) │ 25.29 ms      │ 25.77 ms       │ 0.9813
│     ├─ (10000000, 0.01, 0.95) │ 25.74 ms      │ 25.94 ms       │ 0.9922
│     ├─ (10000000, 0.01, 1.0)  │ 25.54 ms      │ 25.32 ms       │ 1.0086
│     ├─ (10000000, 0.1, 0.25)  │ 26.89 ms      │ 30.73 ms       │ 0.8750  ***
│     ├─ (10000000, 0.1, 0.95)  │ 27.05 ms      │ 30.53 ms       │ 0.8860  ***
│     ╰─ (10000000, 0.1, 1.0)   │ 26.22 ms      │ 25.98 ms       │ 1.0092
├─ decompress_alp               │               │                │
│  ├─ f32                       │               │                │
│  │  ├─ (100000, 0.0, 0.25)    │ 12.24 µs      │ 12.33 µs       │ 0.9927
│  │  ├─ (100000, 0.0, 0.95)    │ 12.24 µs      │ 12.16 µs       │ 1.0065
│  │  ├─ (100000, 0.0, 1.0)     │ 12.2 µs       │ 12.16 µs       │ 1.0032
│  │  ├─ (100000, 0.01, 0.25)   │ 15.12 µs      │ 14.04 µs       │ 1.0769
│  │  ├─ (100000, 0.01, 0.95)   │ 14.95 µs      │ 14.81 µs       │ 1.0094
│  │  ├─ (100000, 0.01, 1.0)    │ 13.43 µs      │ 13.24 µs       │ 1.0143
│  │  ├─ (100000, 0.1, 0.25)    │ 26.08 µs      │ 17.41 µs       │ 1.4979  ***
│  │  ├─ (100000, 0.1, 0.95)    │ 25.87 µs      │ 25.04 µs       │ 1.0331
│  │  ├─ (100000, 0.1, 1.0)     │ 19.33 µs      │ 21.08 µs       │ 0.9169
│  │  ├─ (10000000, 0.0, 0.25)  │ 2.067 ms      │ 2.057 ms       │ 1.0048
│  │  ├─ (10000000, 0.0, 0.95)  │ 2.068 ms      │ 2.055 ms       │ 1.0063
│  │  ├─ (10000000, 0.0, 1.0)   │ 2.07 ms       │ 1.261 ms       │ 1.6415  ***
│  │  ├─ (10000000, 0.01, 0.25) │ 1.51 ms       │ 2.113 ms       │ 0.7146  ***
│  │  ├─ (10000000, 0.01, 0.95) │ 1.477 ms      │ 2.621 ms       │ 0.5635  ***
│  │  ├─ (10000000, 0.01, 1.0)  │ 1.35 ms       │ 1.346 ms       │ 1.0029
│  │  ├─ (10000000, 0.1, 0.25)  │ 3.765 ms      │ 2.58 ms        │ 1.4593  ***
│  │  ├─ (10000000, 0.1, 0.95)  │ 2.784 ms      │ 3.28 ms        │ 0.8487  ***
│  │  ╰─ (10000000, 0.1, 1.0)   │ 1.764 ms      │ 1.754 ms       │ 1.0057
│  ╰─ f64                       │               │                │
│     ├─ (100000, 0.0, 0.25)    │ 23.33 µs      │ 23.45 µs       │ 0.9948
│     ├─ (100000, 0.0, 0.95)    │ 23.41 µs      │ 23.33 µs       │ 1.0034
│     ├─ (100000, 0.0, 1.0)     │ 23.33 µs      │ 23.49 µs       │ 0.9931
│     ├─ (100000, 0.01, 0.25)   │ 25.58 µs      │ 24.66 µs       │ 1.0373
│     ├─ (100000, 0.01, 0.95)   │ 25.58 µs      │ 25.79 µs       │ 0.9918
│     ├─ (100000, 0.01, 1.0)    │ 24.2 µs       │ 24.62 µs       │ 0.9829
│     ├─ (100000, 0.1, 0.25)    │ 39.83 µs      │ 27.87 µs       │ 1.4291  ***
│     ├─ (100000, 0.1, 0.95)    │ 39.7 µs       │ 39.56 µs       │ 1.0035
│     ├─ (100000, 0.1, 1.0)     │ 34.43 µs      │ 31.66 µs       │ 1.0874
│     ├─ (10000000, 0.0, 0.25)  │ 4.246 ms      │ 4.239 ms       │ 1.0016
│     ├─ (10000000, 0.0, 0.95)  │ 4.227 ms      │ 4.292 ms       │ 0.9848
│     ├─ (10000000, 0.0, 1.0)   │ 4.227 ms      │ 4.246 ms       │ 0.9955
│     ├─ (10000000, 0.01, 0.25) │ 4.696 ms      │ 4.356 ms       │ 1.0780
│     ├─ (10000000, 0.01, 0.95) │ 4.933 ms      │ 4.637 ms       │ 1.0638
│     ├─ (10000000, 0.01, 1.0)  │ 4.538 ms      │ 4.545 ms       │ 0.9984
│     ├─ (10000000, 0.1, 0.25)  │ 7.23 ms       │ 5.304 ms       │ 1.3631  ***
│     ├─ (10000000, 0.1, 0.95)  │ 6.227 ms      │ 5.913 ms       │ 1.0531
│     ╰─ (10000000, 0.1, 1.0)   │ 5.207 ms      │ 5.29 ms        │ 0.9843
```

### Benchmarks before reverting to develop's chunking code
<details>

[1] Seems like this PR is about the same except for compressing really large f64 arrays. The PR that introduced chunking, #924, reported substantially larger reductions (~5ms of 29ms) in time than this increase of ~1ms (of 17ms).
```
alp_compress               │ PR median     │ PR mean   │ develop median │ develop mean │
├─ compress_alp            │               │           │                │              │
│  ├─ f32                  │               │           │                │              │
│  │  ├─ (100000, 0.25)    │ 136.4 µs      │ 137.9 µs  │ 143 µs         │ 145.9 µs     │
│  │  ├─ (100000, 0.95)    │ 136.3 µs      │ 137.1 µs  │ 133.1 µs       │ 134.3 µs     │
│  │  ├─ (100000, 1.0)     │ 136 µs        │ 137.3 µs  │ 133.6 µs       │ 134.6 µs     │
│  │  ├─ (10000000, 0.25)  │ 13.54 ms      │ 13.67 ms  │ 13.74 ms       │ 13.84 ms     │
│  │  ├─ (10000000, 0.95)  │ 13.54 ms      │ 13.64 ms  │ 13.49 ms       │ 13.59 ms     │
│  │  ╰─ (10000000, 1.0)   │ 13.47 ms      │ 13.57 ms  │ 13.58 ms       │ 13.73 ms     │
│  ╰─ f64                  │               │           │                │              │
│     ├─ (100000, 0.25)    │ 152.5 µs      │ 153.9 µs  │ 166.1 µs       │ 167.2 µs     │
│     ├─ (100000, 0.95)    │ 152.5 µs      │ 154.3 µs  │ 166.4 µs       │ 167 µs       │
│     ├─ (100000, 1.0)     │ 151.5 µs      │ 153 µs    │ 166.2 µs       │ 166.9 µs     │
│     ├─ (10000000, 0.25)  │ 16.89 ms      │ 17 ms     │ 15.87 ms       │ 15.91 ms     │
│     ├─ (10000000, 0.95)  │ 16.96 ms      │ 17.19 ms  │ 16.14 ms       │ 16.12 ms     │
│     ╰─ (10000000, 1.0)   │ 16.93 ms      │ 16.99 ms  │ 16.15 ms       │ 16.18 ms     │
╰─ decompress_alp          │               │           │                │              │
   ├─ f32                  │               │           │                │              │
   │  ├─ (100000, 0.25)    │ 12.33 µs      │ 12.4 µs   │ 12.37 µs       │ 12.55 µs     │
   │  ├─ (100000, 0.95)    │ 11.99 µs      │ 12.01 µs  │ 12.45 µs       │ 12.58 µs     │
   │  ├─ (100000, 1.0)     │ 11.95 µs      │ 11.98 µs  │ 11.91 µs       │ 11.96 µs     │
   │  ├─ (10000000, 0.25)  │ 1.233 ms      │ 1.24 ms   │ 2.064 ms       │ 2.088 ms     │
   │  ├─ (10000000, 0.95)  │ 1.232 ms      │ 1.235 ms  │ 2.063 ms       │ 2.094 ms     │
   │  ╰─ (10000000, 1.0)   │ 1.233 ms      │ 1.236 ms  │ 2.061 ms       │ 2.088 ms     │
   ╰─ f64                  │               │           │                │              │
      ├─ (100000, 0.25)    │ 23.29 µs      │ 23.46 µs  │ 23.33 µs       │ 23.4 µs      │
      ├─ (100000, 0.95)    │ 22.87 µs      │ 22.92 µs  │ 22.99 µs       │ 23.06 µs     │
      ├─ (100000, 1.0)     │ 22.87 µs      │ 23 µs     │ 22.95 µs       │ 23 µs        │
      ├─ (10000000, 0.25)  │ 4.254 ms      │ 4.393 ms  │ 4.239 ms       │ 4.28 ms      │
      ├─ (10000000, 0.95)  │ 4.703 ms      │ 4.639 ms  │ 4.27 ms        │ 4.437 ms     │
      ╰─ (10000000, 1.0)   │ 4.479 ms      │ 4.58 ms   │ 4.684 ms       │ 4.618 ms     │
```

</details>