### PR TITLE
feat: faster bitpacking filter for selectivities from 5% to 80%

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5482,6 +5482,7 @@ dependencies = [
  "arrayref",
  "arrow-buffer",
  "criterion",
+ "divan",
  "fastlanes",
  "itertools 0.14.0",
  "num-traits",

--- a/encodings/fastlanes/Cargo.toml
+++ b/encodings/fastlanes/Cargo.toml
@@ -34,9 +34,14 @@ vortex-sparse = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+divan = { workspace = true }
 rand = { workspace = true }
 vortex-array = { workspace = true, features = ["test-harness"] }
 
 [[bench]]
 name = "bitpacking_take"
+harness = false
+
+[[bench]]
+name = "bitpacking_decompress_selection"
 harness = false

--- a/encodings/fastlanes/benches/bitpacking_decompress_selection.rs
+++ b/encodings/fastlanes/benches/bitpacking_decompress_selection.rs
@@ -10,7 +10,7 @@ use rand::rngs::StdRng;
 use rand::{Rng as _, SeedableRng as _};
 use vortex_array::array::BooleanBuffer;
 use vortex_array::compute::filter;
-use vortex_array::{IntoArrayData as _, IntoArrayVariant as _, IntoCanonical};
+use vortex_array::{IntoArray as _, IntoArrayVariant as _, IntoCanonical};
 use vortex_buffer::BufferMut;
 use vortex_dtype::NativePType;
 use vortex_fastlanes::bitpack_to_best_bit_width;

--- a/encodings/fastlanes/benches/bitpacking_decompress_selection.rs
+++ b/encodings/fastlanes/benches/bitpacking_decompress_selection.rs
@@ -1,0 +1,67 @@
+//! Benchmarking filter-then-canonicalize versus canonicalize-then-filter.
+//!
+//! Before running these benchmarks, modify filter_primitive to unconditionally call
+//! filter_primitive_chunk_by_chunk. This ensures we are actually comparing early filtering to late
+//! filtering.
+#![allow(clippy::unwrap_used)]
+
+use divan::Bencher;
+use rand::rngs::StdRng;
+use rand::{Rng as _, SeedableRng as _};
+use vortex_array::array::BooleanBuffer;
+use vortex_array::compute::filter;
+use vortex_array::{IntoArrayData as _, IntoArrayVariant as _, IntoCanonical};
+use vortex_buffer::BufferMut;
+use vortex_dtype::NativePType;
+use vortex_fastlanes::bitpack_to_best_bit_width;
+use vortex_mask::Mask;
+
+fn main() {
+    divan::main();
+}
+
+// #[divan::bench(types = [i8, i16, i32, i64], args = [0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999])]
+#[divan::bench(types = [i8, i16, i32, i64], args = [0.005, 0.01, 0.0105, 0.02, 0.03, 0.04, 0.05])]
+fn decompress_bitpacking_early_filter<T: NativePType>(bencher: Bencher, fraction_kept: f64) {
+    let mut rng = StdRng::seed_from_u64(0);
+    let values = (0..10_000)
+        .map(|_| T::from(rng.gen_range(0..100)).unwrap())
+        .collect::<BufferMut<T>>()
+        .into_array()
+        .into_primitive()
+        .unwrap();
+
+    let array = bitpack_to_best_bit_width(values).unwrap();
+    let array = array.as_ref();
+
+    let mask = (0..10000)
+        .map(|_| rng.gen_bool(fraction_kept))
+        .collect::<BooleanBuffer>();
+    let mask = &Mask::from_buffer(mask);
+
+    bencher.bench_local(move || filter(array, mask).unwrap().into_canonical().unwrap());
+}
+
+// #[divan::bench(types = [i8, i16, i32, i64], args = [0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999])]
+#[divan::bench(types = [i8, i16, i32, i64], args = [0.005, 0.01, 0.0105, 0.02, 0.03, 0.04, 0.05])]
+fn decompress_bitpacking_late_filter<T: NativePType>(bencher: Bencher, fraction_kept: f64) {
+    let mut rng = StdRng::seed_from_u64(0);
+    let values = (0..10_000)
+        .map(|_| T::from(rng.gen_range(0..100)).unwrap())
+        .collect::<BufferMut<T>>()
+        .into_array()
+        .into_primitive()
+        .unwrap();
+
+    let array = bitpack_to_best_bit_width(values).unwrap();
+    let array = array.as_ref();
+
+    let mask = (0..10000)
+        .map(|_| rng.gen_bool(fraction_kept))
+        .collect::<BooleanBuffer>();
+    let mask = &Mask::from_buffer(mask);
+
+    bencher.bench_local(move || {
+        filter(array.clone().into_canonical().unwrap().as_ref(), mask).unwrap()
+    });
+}

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -14,6 +14,11 @@ use vortex_scalar::Scalar;
 
 use crate::BitPackedArray;
 
+pub fn bitpack_to_best_bit_width(array: PrimitiveArray) -> VortexResult<BitPackedArray> {
+    let best_bit_width = find_best_bit_width(&array)?;
+    bitpack_encode(array, best_bit_width)
+}
+
 pub fn bitpack_encode(array: PrimitiveArray, bit_width: u8) -> VortexResult<BitPackedArray> {
     let bit_width_freq = array
         .statistics()

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -41,7 +41,7 @@ fn filter_primitive<T: NativePType + BitPacking + ArrowNativeType>(
 ) -> VortexResult<PrimitiveArray> {
     // Short-circuit if the selectivity is high enough.
     let full_decompression_threshold = match T::get_byte_width() {
-        1 => 0.02,
+        1 => 0.03,
         2 => 0.03,
         4 => 0.075,
         _ => 0.09,

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -71,7 +71,7 @@ fn filter_primitive_chunk_by_chunk<T: NativePType + BitPacking + ArrowNativeType
         .transpose()?
         .flatten();
 
-    let values = filter_indices::<T>(
+    let values: Buffer<T> = filter_indices(
         array,
         mask.true_count(),
         mask.values()

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -52,7 +52,7 @@ fn filter_primitive<T: NativePType + BitPacking + ArrowNativeType>(
         let decompressed_array = array.clone().into_primitive()?;
         filter(decompressed_array.as_ref(), mask)?.into_primitive()
     } else {
-        filter_primitive_chunk_by_chunk::<T>(array, mask)
+        filter_primitive_no_decompression::<T>(array, mask)
     }
 }
 

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -76,7 +76,9 @@ fn filter_primitive_chunk_by_chunk<T: NativePType + BitPacking + ArrowNativeType
         mask.true_count(),
         mask.values()
             .vortex_expect("AllTrue and AllFalse handled by filter fn")
-            .indices(),
+            .indices()
+            .iter()
+            .cloned(),
     );
 
     let mut values = PrimitiveArray::new(values, validity).reinterpret_cast(array.ptype());
@@ -89,7 +91,7 @@ fn filter_primitive_chunk_by_chunk<T: NativePType + BitPacking + ArrowNativeType
 fn filter_indices<T: NativePType + BitPacking + ArrowNativeType>(
     array: &BitPackedArray,
     indices_len: usize,
-    indices: &[usize],
+    indices: impl Iterator<Item = usize>,
 ) -> Buffer<T> {
     let offset = array.offset() as usize;
     let bit_width = array.bit_width() as usize;
@@ -102,39 +104,35 @@ fn filter_indices<T: NativePType + BitPacking + ArrowNativeType>(
     // Group the indices by the FastLanes chunk they belong to.
     let chunk_size = 128 * bit_width / size_of::<T>();
 
-    chunked_indices(
-        indices.iter().cloned(),
-        offset,
-        |chunk_idx, indices_within_chunk| {
-            let packed = &packed_bytes[chunk_idx * chunk_size..][..chunk_size];
+    chunked_indices(indices, offset, |chunk_idx, indices_within_chunk| {
+        let packed = &packed_bytes[chunk_idx * chunk_size..][..chunk_size];
 
-            if indices_within_chunk.len() == 1024 {
-                // Unpack the entire chunk.
-                unsafe {
-                    let values_len = values.len();
-                    values.set_len(values_len + 1024);
-                    BitPacking::unchecked_unpack(
-                        bit_width,
-                        packed,
-                        &mut values.as_mut_slice()[values_len..],
-                    );
-                }
-            } else if indices_within_chunk.len() > UNPACK_CHUNK_THRESHOLD {
-                // Unpack into a temporary chunk and then copy the values.
-                unsafe { BitPacking::unchecked_unpack(bit_width, packed, &mut unpacked) }
-                values.extend(
-                    indices_within_chunk
-                        .iter()
-                        .map(|&idx| unsafe { *unpacked.get_unchecked(idx) }),
+        if indices_within_chunk.len() == 1024 {
+            // Unpack the entire chunk.
+            unsafe {
+                let values_len = values.len();
+                values.set_len(values_len + 1024);
+                BitPacking::unchecked_unpack(
+                    bit_width,
+                    packed,
+                    &mut values.as_mut_slice()[values_len..],
                 );
-            } else {
-                // Otherwise, unpack each element individually.
-                values.extend(indices_within_chunk.iter().map(|&idx| unsafe {
-                    BitPacking::unchecked_unpack_single(bit_width, packed, idx)
-                }));
             }
-        },
-    );
+        } else if indices_within_chunk.len() > UNPACK_CHUNK_THRESHOLD {
+            // Unpack into a temporary chunk and then copy the values.
+            unsafe { BitPacking::unchecked_unpack(bit_width, packed, &mut unpacked) }
+            values.extend(
+                indices_within_chunk
+                    .iter()
+                    .map(|&idx| unsafe { *unpacked.get_unchecked(idx) }),
+            );
+        } else {
+            // Otherwise, unpack each element individually.
+            values.extend(indices_within_chunk.iter().map(|&idx| unsafe {
+                BitPacking::unchecked_unpack_single(bit_width, packed, idx)
+            }));
+        }
+    });
 
     values.freeze()
 }

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -43,10 +43,12 @@ fn filter_primitive<T: NativePType + BitPacking + ArrowNativeType>(
     let full_decompression_threshold = match T::get_byte_width() {
         1 => 0.02,
         2 => 0.03,
-        _ => 0.04,
-        // >8 bytes may have a higher threshold.
+        4 => 0.075,
+        _ => 0.09,
+        // >8 bytes may have a higher threshold. These numbers are derived from a GCP c2-standard-4
+        // with a "Cascade Lake" CPU.
     };
-    if mask.selectivity() >= full_decompression_threshold {
+    if mask.density() >= full_decompression_threshold {
         let decompressed_array = array.clone().into_primitive()?;
         filter(decompressed_array.as_ref(), mask)?.into_primitive()
     } else {

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -30,7 +30,34 @@ impl FilterFn<BitPackedArray> for BitPackedEncoding {
 ///
 /// All bit-packing operations will use the unsigned kernels, but the logical type of `array`
 /// dictates the final `PType` of the result.
+///
+/// This function fully decompresses the array for all but the most selective masks because the
+/// FastLanes decompression is so fast and the bookkeepping necessary to decompress individual
+/// elements is relatively slow. If you prefer to never fully decompress, use
+/// [filter_primitive_chunk_by_chunk].
 fn filter_primitive<T: NativePType + BitPacking + ArrowNativeType>(
+    array: &BitPackedArray,
+    mask: &Mask,
+) -> VortexResult<PrimitiveArray> {
+    // Short-circuit if the selectivity is high enough.
+    let full_decompression_threshold = match T::get_byte_width() {
+        1 => 0.02,
+        2 => 0.03,
+        _ => 0.04,
+        // >8 bytes may have a higher threshold.
+    };
+    if mask.selectivity() >= full_decompression_threshold {
+        let decompressed_array = array.clone().into_primitive()?;
+        filter(decompressed_array.as_ref(), mask)?.into_primitive()
+    } else {
+        filter_primitive_chunk_by_chunk::<T>(array, mask)
+    }
+}
+
+/// Filter a bit-packed array, without using full decompression.
+///
+/// You should probably use [filter_primitive].
+fn filter_primitive_chunk_by_chunk<T: NativePType + BitPacking + ArrowNativeType>(
     array: &BitPackedArray,
     mask: &Mask,
 ) -> VortexResult<PrimitiveArray> {
@@ -42,20 +69,12 @@ fn filter_primitive<T: NativePType + BitPacking + ArrowNativeType>(
         .transpose()?
         .flatten();
 
-    // Short-circuit if the selectivity is high enough.
-    if mask.density() > 0.8 {
-        return filter(array.clone().into_primitive()?.as_ref(), mask)
-            .and_then(|a| a.into_primitive());
-    }
-
-    let values: Buffer<T> = filter_indices(
+    let values = filter_indices::<T>(
         array,
         mask.true_count(),
         mask.values()
             .vortex_expect("AllTrue and AllFalse handled by filter fn")
-            .indices()
-            .iter()
-            .copied(),
+            .indices(),
     );
 
     let mut values = PrimitiveArray::new(values, validity).reinterpret_cast(array.ptype());
@@ -68,7 +87,7 @@ fn filter_primitive<T: NativePType + BitPacking + ArrowNativeType>(
 fn filter_indices<T: NativePType + BitPacking + ArrowNativeType>(
     array: &BitPackedArray,
     indices_len: usize,
-    indices: impl Iterator<Item = usize>,
+    indices: &[usize],
 ) -> Buffer<T> {
     let offset = array.offset() as usize;
     let bit_width = array.bit_width() as usize;
@@ -81,35 +100,39 @@ fn filter_indices<T: NativePType + BitPacking + ArrowNativeType>(
     // Group the indices by the FastLanes chunk they belong to.
     let chunk_size = 128 * bit_width / size_of::<T>();
 
-    chunked_indices(indices, offset, |chunk_idx, indices_within_chunk| {
-        let packed = &packed_bytes[chunk_idx * chunk_size..][..chunk_size];
+    chunked_indices(
+        indices.iter().cloned(),
+        offset,
+        |chunk_idx, indices_within_chunk| {
+            let packed = &packed_bytes[chunk_idx * chunk_size..][..chunk_size];
 
-        if indices_within_chunk.len() == 1024 {
-            // Unpack the entire chunk.
-            unsafe {
-                let values_len = values.len();
-                values.set_len(values_len + 1024);
-                BitPacking::unchecked_unpack(
-                    bit_width,
-                    packed,
-                    &mut values.as_mut_slice()[values_len..],
+            if indices_within_chunk.len() == 1024 {
+                // Unpack the entire chunk.
+                unsafe {
+                    let values_len = values.len();
+                    values.set_len(values_len + 1024);
+                    BitPacking::unchecked_unpack(
+                        bit_width,
+                        packed,
+                        &mut values.as_mut_slice()[values_len..],
+                    );
+                }
+            } else if indices_within_chunk.len() > UNPACK_CHUNK_THRESHOLD {
+                // Unpack into a temporary chunk and then copy the values.
+                unsafe { BitPacking::unchecked_unpack(bit_width, packed, &mut unpacked) }
+                values.extend(
+                    indices_within_chunk
+                        .iter()
+                        .map(|&idx| unsafe { *unpacked.get_unchecked(idx) }),
                 );
+            } else {
+                // Otherwise, unpack each element individually.
+                values.extend(indices_within_chunk.iter().map(|&idx| unsafe {
+                    BitPacking::unchecked_unpack_single(bit_width, packed, idx)
+                }));
             }
-        } else if indices_within_chunk.len() > UNPACK_CHUNK_THRESHOLD {
-            // Unpack into a temporary chunk and then copy the values.
-            unsafe { BitPacking::unchecked_unpack(bit_width, packed, &mut unpacked) }
-            values.extend(
-                indices_within_chunk
-                    .iter()
-                    .map(|&idx| unsafe { *unpacked.get_unchecked(idx) }),
-            );
-        } else {
-            // Otherwise, unpack each element individually.
-            values.extend(indices_within_chunk.iter().map(|&idx| unsafe {
-                BitPacking::unchecked_unpack_single(bit_width, packed, idx)
-            }));
-        }
-    });
+        },
+    );
 
     values.freeze()
 }

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -78,7 +78,7 @@ fn filter_primitive_chunk_by_chunk<T: NativePType + BitPacking + ArrowNativeType
             .vortex_expect("AllTrue and AllFalse handled by filter fn")
             .indices()
             .iter()
-            .cloned(),
+            .copied(),
     );
 
     let mut values = PrimitiveArray::new(values, validity).reinterpret_cast(array.ptype());

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -34,7 +34,7 @@ impl FilterFn<BitPackedArray> for BitPackedEncoding {
 /// This function fully decompresses the array for all but the most selective masks because the
 /// FastLanes decompression is so fast and the bookkeepping necessary to decompress individual
 /// elements is relatively slow. If you prefer to never fully decompress, use
-/// [filter_primitive_chunk_by_chunk].
+/// [filter_primitive_no_decompression].
 fn filter_primitive<T: NativePType + BitPacking + ArrowNativeType>(
     array: &BitPackedArray,
     mask: &Mask,
@@ -59,7 +59,7 @@ fn filter_primitive<T: NativePType + BitPacking + ArrowNativeType>(
 /// Filter a bit-packed array, without using full decompression.
 ///
 /// You should probably use [filter_primitive].
-fn filter_primitive_chunk_by_chunk<T: NativePType + BitPacking + ArrowNativeType>(
+fn filter_primitive_no_decompression<T: NativePType + BitPacking + ArrowNativeType>(
     array: &BitPackedArray,
     mask: &Mask,
 ) -> VortexResult<PrimitiveArray> {


### PR DESCRIPTION
On an Apple M3 Max, the new benchmark in this PR demonstrates that the switchpoint is in [0.02, 0.04]. 8-bit, 16-bit, 32-bit, and 64-bit arrays switch at 0.02, 0.03, 0.04, and 0.04, respectively. I later ran the benchmarks on a Cascade Lake cloud machine and found that the 8-bit, 16-bit, 32-bit, and 64-bit arrays switch at 0.03, 0.03, 0.075 and 0.09, respectively. In this PR, I use the Cascade Lake values, but I don't have a great answer for how to pick these. Regardless, it is clear that 0.8 is not the correct choice.

[Google Sheet with one run on my Apple M3 Max](https://docs.google.com/spreadsheets/d/1T4JeSLnpFegA_pRS70iNu4ve9YMjEu-j1vRL7spazoA/edit?gid=624487667#gid=624487667). [A sheet with a run on a c2-standard-4 "Cascade Lake"](https://docs.google.com/spreadsheets/d/1T4JeSLnpFegA_pRS70iNu4ve9YMjEu-j1vRL7spazoA/edit?gid=990742426#gid=990742426)

There does not appear to be a significant effect on the TPC-H or Clickbench macro benchmarks.