### PR TITLE
feat: alp compare v2

### DIFF
--- a/encodings/alp/src/alp/compute/compare.rs
+++ b/encodings/alp/src/alp/compute/compare.rs
@@ -1,0 +1,249 @@
+use std::fmt::Debug;
+
+use vortex_array::array::ConstantArray;
+use vortex_array::compute::{compare, CompareFn, Operator};
+use vortex_array::{ArrayDType, ArrayData, ArrayLen, IntoArrayData};
+use vortex_error::{vortex_bail, VortexResult};
+use vortex_scalar::{PrimitiveScalar, Scalar};
+
+use crate::{match_each_alp_float_ptype, ALPArray, ALPEncoding, ALPFloat};
+
+impl CompareFn<ALPArray> for ALPEncoding {
+    fn compare(
+        &self,
+        lhs: &ALPArray,
+        rhs: &ArrayData,
+        operator: Operator,
+    ) -> VortexResult<Option<ArrayData>> {
+        if lhs.patches().is_some() {
+            // TODO(joe): support patches
+            return Ok(None);
+        }
+        //
+        if lhs.dtype().is_nullable() {
+            // TODO(joe): support nullability
+            return Ok(None);
+        }
+
+        if operator != Operator::Eq && operator != Operator::NotEq {
+            // TODO(joe): support other operators
+            return Ok(None);
+        }
+        if let Some(const_scalar) = rhs.as_constant() {
+            let pscalar = PrimitiveScalar::try_from(&const_scalar)?;
+
+            match_each_alp_float_ptype!(pscalar.ptype(), |$T| {
+                match pscalar.typed_value::<$T>() {
+                    Some(value) => return alp_scalar_compare(lhs, value, operator),
+                    None => vortex_bail!("Failed to convert scalar {:?} to ALP type {:?}", pscalar, pscalar.ptype()),
+                }
+            });
+        }
+
+        Ok(None)
+    }
+}
+
+fn alp_scalar_compare<F: ALPFloat + Into<Scalar>>(
+    alp: &ALPArray,
+    value: F,
+    operator: Operator,
+) -> VortexResult<Option<ArrayData>>
+where
+    F::ALPInt: Into<Scalar>,
+    <F as ALPFloat>::ALPInt: Debug,
+{
+    // TODO: support patches, this is checked above.
+    assert!(alp.patches().is_none());
+
+    let exponents = alp.exponents();
+    // If the scalar doesn't fit into the ALP domain,
+    // it cannot be equal to any values in the encoded array.
+    let encoded = F::encode_single(value, alp.exponents());
+    match encoded {
+        Some(encoded) => {
+            let s = ConstantArray::new(encoded, alp.len());
+            Ok(Some(compare(alp.encoded(), s.as_ref(), operator)?))
+        }
+        None => match operator {
+            Operator::Eq => Ok(Some(ConstantArray::new(false, alp.len()).into_array())),
+            Operator::NotEq => Ok(Some(ConstantArray::new(true, alp.len()).into_array())),
+            Operator::Gt | Operator::Gte => Ok(Some(compare(
+                alp.encoded(),
+                ConstantArray::new(F::encode_above(value, exponents), alp.len()),
+                // Since the encoded value is unencodable gte is equivalent to gt.
+                // Consider a value v, between two encodable values v_l (just less) and
+                // v_a (just above), then for all encodable values (u), v > u <=> v_g >= u
+                Operator::Gte,
+            )?)),
+            Operator::Lt | Operator::Lte => Ok(Some(compare(
+                alp.encoded(),
+                ConstantArray::new(F::encode_below(value, exponents), alp.len()),
+                // Since the encoded values unencodable lt is equivalent to lte
+                Operator::Lte,
+            )?)),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_array::array::{ConstantArray, PrimitiveArray};
+    use vortex_array::compute::{compare, Operator};
+    use vortex_array::{ArrayLen, IntoArrayVariant};
+    use vortex_dtype::{DType, Nullability, PType};
+    use vortex_scalar::Scalar;
+
+    use super::*;
+    use crate::alp_encode;
+
+    #[test]
+    fn basic_comparison_test() {
+        let array = PrimitiveArray::from_iter([1.234f32; 1025]);
+        let encoded = alp_encode(&array).unwrap();
+        assert!(encoded.patches().is_none());
+        assert_eq!(
+            encoded
+                .encoded()
+                .into_primitive()
+                .unwrap()
+                .as_slice::<i32>(),
+            vec![1234; 1025]
+        );
+
+        let r = alp_scalar_compare(&encoded, 1.3_f32, Operator::Eq)
+            .unwrap()
+            .unwrap()
+            .into_bool()
+            .unwrap();
+
+        for v in r.boolean_buffer().iter() {
+            assert!(!v);
+        }
+
+        let r = alp_scalar_compare(&encoded, 1.234f32, Operator::Eq)
+            .unwrap()
+            .unwrap()
+            .into_bool()
+            .unwrap();
+
+        for v in r.boolean_buffer().iter() {
+            assert!(v);
+        }
+    }
+
+    #[test]
+    fn comparison_with_unencodable_value() {
+        let array = PrimitiveArray::from_iter([1.234f32; 1025]);
+        let encoded = alp_encode(&array).unwrap();
+        assert!(encoded.patches().is_none());
+        assert_eq!(
+            encoded
+                .encoded()
+                .into_primitive()
+                .unwrap()
+                .as_slice::<i32>(),
+            vec![1234; 1025]
+        );
+
+        let r_eq = alp_scalar_compare(&encoded, 1.23444444_f32, Operator::Eq)
+            .unwrap()
+            .unwrap()
+            .into_bool()
+            .unwrap();
+
+        assert!(r_eq.boolean_buffer().iter().all(|v| !v));
+
+        let r_neq = alp_scalar_compare(&encoded, 1.23444444f32, Operator::NotEq)
+            .unwrap()
+            .unwrap()
+            .into_bool()
+            .unwrap();
+
+        assert!(r_neq.boolean_buffer().iter().all(|v| v));
+    }
+
+    #[test]
+    fn comparison_range() {
+        let array = PrimitiveArray::from_iter([0.0605_f32; 10]);
+        let encoded = alp_encode(&array).unwrap();
+        assert!(encoded.patches().is_none());
+        assert_eq!(
+            encoded
+                .encoded()
+                .into_primitive()
+                .unwrap()
+                .as_slice::<i32>(),
+            vec![605; 10]
+        );
+
+        let r_gte = alp_scalar_compare(&encoded, 0.06051_f32, Operator::Gte)
+            .unwrap()
+            .unwrap()
+            .into_bool()
+            .unwrap();
+
+        assert!(r_gte.boolean_buffer().iter().all(|v| !v));
+        assert!(!(0.0605_f32 >= 0.06051_f32));
+
+        let r_gt = alp_scalar_compare(&encoded, 0.06051_f32, Operator::Gt)
+            .unwrap()
+            .unwrap()
+            .into_bool()
+            .unwrap();
+
+        assert!(r_gt.boolean_buffer().iter().all(|v| !v));
+        assert!(!(0.0605_f32 > 0.06051_f32));
+
+        let r_lte = alp_scalar_compare(&encoded, 0.06051_f32, Operator::Lte)
+            .unwrap()
+            .unwrap()
+            .into_bool()
+            .unwrap();
+
+        assert!(r_lte.boolean_buffer().iter().all(|v| v));
+        assert!(0.0605_f32 <= 0.06051_f32);
+
+        let r_lt = alp_scalar_compare(&encoded, 0.06051_f32, Operator::Lt)
+            .unwrap()
+            .unwrap()
+            .into_bool()
+            .unwrap();
+
+        assert!(r_lt.boolean_buffer().iter().all(|v| v));
+        assert!(0.0605_f32 < 0.06051_f32);
+    }
+
+    #[test]
+    fn compare_with_patches() {
+        let array =
+            PrimitiveArray::from_iter([1.234f32, 1.5, 19.0, std::f32::consts::E, 1_000_000.9]);
+        let encoded = alp_encode(&array).unwrap();
+        assert!(encoded.patches().is_some());
+
+        // Not supported!
+        assert!(alp_scalar_compare(&encoded, 1_000_000.9_f32, Operator::Eq)
+            .unwrap()
+            .is_none())
+    }
+
+    #[test]
+    fn compare_to_null() {
+        let array = PrimitiveArray::from_iter([1.234f32; 1025]);
+        let encoded = alp_encode(&array).unwrap();
+
+        let other = ConstantArray::new(
+            Scalar::null(DType::Primitive(PType::F32, Nullability::Nullable)),
+            array.len(),
+        );
+
+        let r = compare(encoded, other.as_ref(), Operator::Eq)
+            .unwrap()
+            .into_bool()
+            .unwrap();
+
+        for v in r.boolean_buffer().iter() {
+            assert!(!v);
+        }
+    }
+}

--- a/encodings/alp/src/alp/compute/compare.rs
+++ b/encodings/alp/src/alp/compute/compare.rs
@@ -99,6 +99,20 @@ mod tests {
     use super::*;
     use crate::alp_encode;
 
+    fn test_alp_compare<F: ALPFloat + Into<Scalar>>(
+        alp: &ALPArray,
+        value: F,
+        operator: Operator,
+    ) -> Option<Vec<bool>>
+    where
+        F::ALPInt: Into<Scalar>,
+        <F as ALPFloat>::ALPInt: Debug,
+    {
+        alp_scalar_compare(alp, value, operator)
+            .unwrap()
+            .map(|a| a.into_bool().unwrap().boolean_buffer().iter().collect())
+    }
+
     #[test]
     fn basic_comparison_test() {
         let array = PrimitiveArray::from_iter([1.234f32; 1025]);
@@ -216,6 +230,42 @@ mod tests {
 
         //0.0605_f32 < 0.06051_f32;
         assert!(r_lt.boolean_buffer().iter().all(|v| v));
+    }
+
+    #[test]
+    fn comparison_zeroes() {
+        let array = PrimitiveArray::from_iter([0.0_f32; 10]);
+        let encoded = alp_encode(&array).unwrap();
+        assert!(encoded.patches().is_none());
+        assert_eq!(
+            encoded
+                .encoded()
+                .into_primitive()
+                .unwrap()
+                .as_slice::<i32>(),
+            vec![0; 10]
+        );
+
+        let r_gte = test_alp_compare(&encoded, -0.00000001_f32, Operator::Gte).unwrap();
+        assert_eq!(r_gte, vec![true; 10]);
+
+        let r_gte = test_alp_compare(&encoded, -0.0_f32, Operator::Gte).unwrap();
+        assert_eq!(r_gte, vec![true; 10]);
+
+        let r_gt = test_alp_compare(&encoded, -0.0000000001f32, Operator::Gt).unwrap();
+        assert_eq!(r_gt, vec![true; 10]);
+
+        let r_gte = test_alp_compare(&encoded, -0.0_f32, Operator::Gt).unwrap();
+        assert_eq!(r_gte, vec![false; 10]);
+
+        let r_lte = test_alp_compare(&encoded, 0.06051_f32, Operator::Lte).unwrap();
+        assert_eq!(r_lte, vec![true; 10]);
+
+        let r_lt = test_alp_compare(&encoded, 0.06051_f32, Operator::Lt).unwrap();
+        assert_eq!(r_lt, vec![true; 10]);
+
+        let r_lt = test_alp_compare(&encoded, -0.00001_f32, Operator::Lt).unwrap();
+        assert_eq!(r_lt, vec![false; 10]);
     }
 
     #[test]

--- a/encodings/alp/src/alp/compute/compare.rs
+++ b/encodings/alp/src/alp/compute/compare.rs
@@ -187,8 +187,8 @@ mod tests {
             .into_bool()
             .unwrap();
 
+        // !(0.0605_f32 >= 0.06051_f32);
         assert!(r_gte.boolean_buffer().iter().all(|v| !v));
-        assert!(!(0.0605_f32 >= 0.06051_f32));
 
         let r_gt = alp_scalar_compare(&encoded, 0.06051_f32, Operator::Gt)
             .unwrap()
@@ -196,8 +196,8 @@ mod tests {
             .into_bool()
             .unwrap();
 
+        // (0.0605_f32 > 0.06051_f32);
         assert!(r_gt.boolean_buffer().iter().all(|v| !v));
-        assert!(!(0.0605_f32 > 0.06051_f32));
 
         let r_lte = alp_scalar_compare(&encoded, 0.06051_f32, Operator::Lte)
             .unwrap()
@@ -205,8 +205,8 @@ mod tests {
             .into_bool()
             .unwrap();
 
+        // 0.0605_f32 <= 0.06051_f32;
         assert!(r_lte.boolean_buffer().iter().all(|v| v));
-        assert!(0.0605_f32 <= 0.06051_f32);
 
         let r_lt = alp_scalar_compare(&encoded, 0.06051_f32, Operator::Lt)
             .unwrap()
@@ -214,8 +214,8 @@ mod tests {
             .into_bool()
             .unwrap();
 
+        //0.0605_f32 < 0.06051_f32;
         assert!(r_lt.boolean_buffer().iter().all(|v| v));
-        assert!(0.0605_f32 < 0.06051_f32);
     }
 
     #[test]

--- a/encodings/alp/src/alp/compute/compare.rs
+++ b/encodings/alp/src/alp/compute/compare.rs
@@ -25,10 +25,6 @@ impl CompareFn<ALPArray> for ALPEncoding {
             return Ok(None);
         }
 
-        if operator != Operator::Eq && operator != Operator::NotEq {
-            // TODO(joe): support other operators
-            return Ok(None);
-        }
         if let Some(const_scalar) = rhs.as_constant() {
             let pscalar = PrimitiveScalar::try_from(&const_scalar)?;
 
@@ -56,7 +52,7 @@ where
     F::ALPInt: Into<Scalar>,
     <F as ALPFloat>::ALPInt: Debug,
 {
-    // TODO: support patches, this is checked above.
+    // TODO(joe): support patches, this is checked above.
     if alp.patches().is_some() {
         return Ok(None);
     }

--- a/encodings/alp/src/alp/compute/compare.rs
+++ b/encodings/alp/src/alp/compute/compare.rs
@@ -8,6 +8,8 @@ use vortex_scalar::{PrimitiveScalar, Scalar};
 
 use crate::{match_each_alp_float_ptype, ALPArray, ALPEncoding, ALPFloat};
 
+// TODO(joe): add fuzzing.
+
 impl CompareFn<ALPArray> for ALPEncoding {
     fn compare(
         &self,

--- a/encodings/alp/src/alp/compute/compare.rs
+++ b/encodings/alp/src/alp/compute/compare.rs
@@ -19,8 +19,7 @@ impl CompareFn<ALPArray> for ALPEncoding {
             // TODO(joe): support patches
             return Ok(None);
         }
-        //
-        if lhs.dtype().is_nullable() {
+        if lhs.dtype().is_nullable() || rhs.dtype().is_nullable() {
             // TODO(joe): support nullability
             return Ok(None);
         }

--- a/encodings/alp/src/alp/compute/compare.rs
+++ b/encodings/alp/src/alp/compute/compare.rs
@@ -68,7 +68,11 @@ where
             Ok(Some(compare(alp.encoded(), s.as_ref(), operator)?))
         }
         None => match operator {
+            // Since this value is not encodable it cannot be equal to any value in the encoded
+            // array.
             Operator::Eq => Ok(Some(ConstantArray::new(false, alp.len()).into_array())),
+            // Since this value is not encodable it cannot be equal to any value in the encoded
+            // array, hence != to all values in the encoded array.
             Operator::NotEq => Ok(Some(ConstantArray::new(true, alp.len()).into_array())),
             Operator::Gt | Operator::Gte => Ok(Some(compare(
                 alp.encoded(),

--- a/encodings/alp/src/alp/compute/compare.rs
+++ b/encodings/alp/src/alp/compute/compare.rs
@@ -44,6 +44,9 @@ impl CompareFn<ALPArray> for ALPEncoding {
     }
 }
 
+// We can compare a scalar to an ALPArray by encoding the scalar into the ALP domain and comparing
+// the encoded value to the encoded values in the ALPArray. There are fixups when the value doesn't
+// encode into the ALP domain.
 fn alp_scalar_compare<F: ALPFloat + Into<Scalar>>(
     alp: &ALPArray,
     value: F,
@@ -79,7 +82,8 @@ where
             Operator::Lt | Operator::Lte => Ok(Some(compare(
                 alp.encoded(),
                 ConstantArray::new(F::encode_below(value, exponents), alp.len()),
-                // Since the encoded values unencodable lt is equivalent to lte
+                // Since the encoded values unencodable lt is equivalent to lte.
+                // See Gt | Gte for further explanation.
                 Operator::Lte,
             )?)),
         },

--- a/encodings/alp/src/alp/compute/compare.rs
+++ b/encodings/alp/src/alp/compute/compare.rs
@@ -57,7 +57,9 @@ where
     <F as ALPFloat>::ALPInt: Debug,
 {
     // TODO: support patches, this is checked above.
-    assert!(alp.patches().is_none());
+    if alp.patches().is_some() {
+        return Ok(None);
+    }
 
     let exponents = alp.exponents();
     // If the scalar doesn't fit into the ALP domain,
@@ -150,7 +152,8 @@ mod tests {
             vec![1234; 1025]
         );
 
-        let r_eq = alp_scalar_compare(&encoded, 1.23444444_f32, Operator::Eq)
+        #[allow(clippy::excessive_precision)]
+        let r_eq = alp_scalar_compare(&encoded, 1.234444_f32, Operator::Eq)
             .unwrap()
             .unwrap()
             .into_bool()
@@ -158,7 +161,8 @@ mod tests {
 
         assert!(r_eq.boolean_buffer().iter().all(|v| !v));
 
-        let r_neq = alp_scalar_compare(&encoded, 1.23444444f32, Operator::NotEq)
+        #[allow(clippy::excessive_precision)]
+        let r_neq = alp_scalar_compare(&encoded, 1.234444f32, Operator::NotEq)
             .unwrap()
             .unwrap()
             .into_bool()

--- a/encodings/alp/src/alp/compute/mod.rs
+++ b/encodings/alp/src/alp/compute/mod.rs
@@ -1,7 +1,7 @@
 mod compare;
 
 use vortex_array::compute::{
-    filter, scalar_at, slice, take, ComputeVTable, FilterFn, ScalarAtFn, SliceFn, TakeFn,
+    filter, scalar_at, slice, take, CompareFn, ComputeVTable, FilterFn, ScalarAtFn, SliceFn, TakeFn,
 };
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayDType, ArrayData, IntoArrayData};
@@ -25,6 +25,10 @@ impl ComputeVTable for ALPEncoding {
     }
 
     fn take_fn(&self) -> Option<&dyn TakeFn<ArrayData>> {
+        Some(self)
+    }
+
+    fn compare_fn(&self) -> Option<&dyn CompareFn<ArrayData>> {
         Some(self)
     }
 }

--- a/encodings/alp/src/alp/compute/mod.rs
+++ b/encodings/alp/src/alp/compute/mod.rs
@@ -1,3 +1,5 @@
+mod compare;
+
 use vortex_array::compute::{
     filter, scalar_at, slice, take, ComputeVTable, FilterFn, ScalarAtFn, SliceFn, TakeFn,
 };

--- a/encodings/alp/src/alp/mod.rs
+++ b/encodings/alp/src/alp/mod.rs
@@ -35,7 +35,7 @@ mod private {
 }
 
 pub trait ALPFloat: private::Sealed + Float + Display + 'static {
-    type ALPInt: PrimInt + Display + ToPrimitive;
+    type ALPInt: PrimInt + Display + ToPrimitive + Copy;
 
     const FRACTIONAL_BITS: u8;
     const MAX_EXPONENT: u8;
@@ -146,13 +146,25 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
     }
 
     #[inline]
-    fn encode_single(value: Self, exponents: Exponents) -> Result<Self::ALPInt, Self> {
+    fn encode_single(value: Self, exponents: Exponents) -> Option<Self::ALPInt> {
         let encoded = unsafe { Self::encode_single_unchecked(value, exponents) };
         let decoded = Self::decode_single(encoded, exponents);
         if decoded == value {
-            return Ok(encoded);
+            return Some(encoded);
         }
-        Err(value)
+        None
+    }
+
+    fn encode_above(value: Self, exponents: Exponents) -> Self::ALPInt {
+        (value * Self::F10[exponents.e as usize] * Self::IF10[exponents.f as usize])
+            .ceil()
+            .as_int();
+    }
+
+    fn encode_below(value: Self, exponents: Exponents) -> Self::ALPInt {
+        (value * Self::F10[exponents.e as usize] * Self::IF10[exponents.f as usize])
+            .floor()
+            .as_int();
     }
 
     fn decode(encoded: &[Self::ALPInt], exponents: Exponents) -> Vec<Self> {

--- a/encodings/alp/src/alp/mod.rs
+++ b/encodings/alp/src/alp/mod.rs
@@ -158,13 +158,13 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
     fn encode_above(value: Self, exponents: Exponents) -> Self::ALPInt {
         (value * Self::F10[exponents.e as usize] * Self::IF10[exponents.f as usize])
             .ceil()
-            .as_int();
+            .as_int()
     }
 
     fn encode_below(value: Self, exponents: Exponents) -> Self::ALPInt {
         (value * Self::F10[exponents.e as usize] * Self::IF10[exponents.f as usize])
             .floor()
-            .as_int();
+            .as_int()
     }
 
     fn decode(encoded: &[Self::ALPInt], exponents: Exponents) -> Vec<Self> {


### PR DESCRIPTION
Alp compare (v2), without patches & nullability (for now). 3 tpch queries will use this code path.

Seems like the fuzzer can help with the correctness checks (TODO).

old compare https://github.com/spiraldb/vortex/pull/1603