### PR TITLE
smaller `ScalarValue` buffer variants

### DIFF
--- a/vortex-scalar/src/arbitrary.rs
+++ b/vortex-scalar/src/arbitrary.rs
@@ -1,4 +1,5 @@
 use std::iter;
+use std::sync::Arc;
 
 use arbitrary::{Result, Unstructured};
 use vortex_buffer::{BufferString, ByteBuffer};
@@ -18,11 +19,11 @@ fn random_scalar_value(u: &mut Unstructured, dtype: &DType) -> Result<ScalarValu
         DType::Primitive(p, _) => Ok(ScalarValue(InnerScalarValue::Primitive(random_pvalue(
             u, p,
         )?))),
-        DType::Utf8(_) => Ok(ScalarValue(InnerScalarValue::BufferString(
+        DType::Utf8(_) => Ok(ScalarValue(InnerScalarValue::BufferString(Arc::new(
             BufferString::from(u.arbitrary::<String>()?),
-        ))),
-        DType::Binary(_) => Ok(ScalarValue(InnerScalarValue::Buffer(ByteBuffer::from(
-            u.arbitrary::<Vec<u8>>()?,
+        )))),
+        DType::Binary(_) => Ok(ScalarValue(InnerScalarValue::Buffer(Arc::new(
+            ByteBuffer::from(u.arbitrary::<Vec<u8>>()?),
         )))),
         DType::Struct(sdt, _) => Ok(ScalarValue(InnerScalarValue::List(
             sdt.dtypes()

--- a/vortex-scalar/src/binary.rs
+++ b/vortex-scalar/src/binary.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, Nullability};
 use vortex_error::{vortex_bail, vortex_err, VortexError, VortexExpect as _, VortexResult};
@@ -26,12 +28,12 @@ impl<'a> BinaryScalar<'a> {
         }
         Ok(Scalar::new(
             dtype.clone(),
-            ScalarValue(InnerScalarValue::Buffer(
+            ScalarValue(InnerScalarValue::Buffer(Arc::new(
                 self.value
                     .as_ref()
                     .vortex_expect("nullness handled in Scalar::cast")
                     .clone(),
-            )),
+            ))),
         ))
     }
 }
@@ -40,7 +42,7 @@ impl Scalar {
     pub fn binary(buffer: ByteBuffer, nullability: Nullability) -> Self {
         Self {
             dtype: DType::Binary(nullability),
-            value: ScalarValue(InnerScalarValue::Buffer(buffer)),
+            value: ScalarValue(InnerScalarValue::Buffer(Arc::new(buffer))),
         }
     }
 }
@@ -110,7 +112,7 @@ impl From<ByteBuffer> for Scalar {
     fn from(value: ByteBuffer) -> Self {
         Self {
             dtype: DType::Binary(Nullability::NonNullable),
-            value: ScalarValue(InnerScalarValue::Buffer(value)),
+            value: ScalarValue(InnerScalarValue::Buffer(Arc::new(value))),
         }
     }
 }

--- a/vortex-scalar/src/binary.rs
+++ b/vortex-scalar/src/binary.rs
@@ -39,10 +39,10 @@ impl<'a> BinaryScalar<'a> {
 }
 
 impl Scalar {
-    pub fn binary(buffer: ByteBuffer, nullability: Nullability) -> Self {
+    pub fn binary(buffer: impl Into<Arc<ByteBuffer>>, nullability: Nullability) -> Self {
         Self {
             dtype: DType::Binary(nullability),
-            value: ScalarValue(InnerScalarValue::Buffer(Arc::new(buffer))),
+            value: ScalarValue(InnerScalarValue::Buffer(buffer.into())),
         }
     }
 }
@@ -113,6 +113,15 @@ impl From<ByteBuffer> for Scalar {
         Self {
             dtype: DType::Binary(Nullability::NonNullable),
             value: ScalarValue(InnerScalarValue::Buffer(Arc::new(value))),
+        }
+    }
+}
+
+impl From<Arc<ByteBuffer>> for Scalar {
+    fn from(value: Arc<ByteBuffer>) -> Self {
+        Self {
+            dtype: DType::Binary(Nullability::NonNullable),
+            value: ScalarValue(InnerScalarValue::Buffer(value)),
         }
     }
 }

--- a/vortex-scalar/src/serde/proto.rs
+++ b/vortex-scalar/src/serde/proto.rs
@@ -143,11 +143,11 @@ fn deserialize_scalar_value(dtype: &DType, value: &pb::ScalarValue) -> VortexRes
         Kind::FloatValue(v) => Ok(ScalarValue(InnerScalarValue::Primitive(PValue::F32(*v)))),
         Kind::DoubleValue(v) => Ok(ScalarValue(InnerScalarValue::Primitive(PValue::F64(*v)))),
         Kind::StringValue(v) => Ok(ScalarValue(InnerScalarValue::BufferString(
-            BufferString::from(v.clone()),
+            BufferString::from(v.clone()).into(),
         ))),
-        Kind::BytesValue(v) => Ok(ScalarValue(InnerScalarValue::Buffer(ByteBuffer::from(
-            v.clone(),
-        )))),
+        Kind::BytesValue(v) => Ok(ScalarValue(InnerScalarValue::Buffer(
+            ByteBuffer::from(v.clone()).into(),
+        ))),
         Kind::ListValue(v) => {
             let mut values = Vec::with_capacity(v.values.len());
             match dtype {
@@ -212,7 +212,7 @@ mod test {
     fn test_buffer() {
         round_trip(Scalar::new(
             DType::Binary(Nullability::Nullable),
-            ScalarValue(InnerScalarValue::Buffer(vec![1, 2, 3].into())),
+            ScalarValue(InnerScalarValue::Buffer(Arc::new(vec![1, 2, 3].into()))),
         ));
     }
 
@@ -220,9 +220,9 @@ mod test {
     fn test_buffer_string() {
         round_trip(Scalar::new(
             DType::Utf8(Nullability::Nullable),
-            ScalarValue(InnerScalarValue::BufferString(BufferString::from(
-                "hello".to_string(),
-            ))),
+            ScalarValue(InnerScalarValue::BufferString(
+                BufferString::from("hello".to_string()).into(),
+            )),
         ));
     }
 

--- a/vortex-scalar/src/serde/proto.rs
+++ b/vortex-scalar/src/serde/proto.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use vortex_buffer::{BufferString, ByteBuffer};
 use vortex_dtype::half::f16;
 use vortex_dtype::{DType, PType};
@@ -142,12 +144,12 @@ fn deserialize_scalar_value(dtype: &DType, value: &pb::ScalarValue) -> VortexRes
         Kind::Uint64Value(v) => Ok(ScalarValue(InnerScalarValue::Primitive(PValue::U64(*v)))),
         Kind::FloatValue(v) => Ok(ScalarValue(InnerScalarValue::Primitive(PValue::F32(*v)))),
         Kind::DoubleValue(v) => Ok(ScalarValue(InnerScalarValue::Primitive(PValue::F64(*v)))),
-        Kind::StringValue(v) => Ok(ScalarValue(InnerScalarValue::BufferString(
-            BufferString::from(v.clone()).into(),
-        ))),
-        Kind::BytesValue(v) => Ok(ScalarValue(InnerScalarValue::Buffer(
-            ByteBuffer::from(v.clone()).into(),
-        ))),
+        Kind::StringValue(v) => Ok(ScalarValue(InnerScalarValue::BufferString(Arc::new(
+            BufferString::from(v.clone()),
+        )))),
+        Kind::BytesValue(v) => Ok(ScalarValue(InnerScalarValue::Buffer(Arc::new(
+            ByteBuffer::from(v.clone()),
+        )))),
         Kind::ListValue(v) => {
             let mut values = Vec::with_capacity(v.values.len());
             match dtype {
@@ -220,9 +222,9 @@ mod test {
     fn test_buffer_string() {
         round_trip(Scalar::new(
             DType::Utf8(Nullability::Nullable),
-            ScalarValue(InnerScalarValue::BufferString(
-                BufferString::from("hello".to_string()).into(),
-            )),
+            ScalarValue(InnerScalarValue::BufferString(Arc::new(
+                BufferString::from("hello".to_string()),
+            ))),
         ));
     }
 

--- a/vortex-scalar/src/serde/serde.rs
+++ b/vortex-scalar/src/serde/serde.rs
@@ -1,4 +1,5 @@
 use std::fmt::Formatter;
+use std::sync::Arc;
 
 use serde::de::{Error, SeqAccess, Visitor};
 use serde::ser::SerializeSeq;
@@ -137,17 +138,17 @@ impl<'de> Deserialize<'de> for ScalarValue {
             where
                 E: Error,
             {
-                Ok(ScalarValue(InnerScalarValue::BufferString(
+                Ok(ScalarValue(InnerScalarValue::BufferString(Arc::new(
                     BufferString::from(v.to_string()),
-                )))
+                ))))
             }
 
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(ScalarValue(InnerScalarValue::Buffer(ByteBuffer::from(
-                    v.to_vec(),
+                Ok(ScalarValue(InnerScalarValue::Buffer(Arc::new(
+                    ByteBuffer::from(v.to_vec()),
                 ))))
             }
 

--- a/vortex-scalar/src/utf8.rs
+++ b/vortex-scalar/src/utf8.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use vortex_buffer::BufferString;
 use vortex_dtype::Nullability::NonNullable;
 use vortex_dtype::{DType, Nullability};
@@ -27,12 +29,12 @@ impl<'a> Utf8Scalar<'a> {
         }
         Ok(Scalar::new(
             dtype.clone(),
-            ScalarValue(InnerScalarValue::BufferString(
+            ScalarValue(InnerScalarValue::BufferString(Arc::new(
                 self.value
                     .as_ref()
                     .vortex_expect("nullness handled in Scalar::cast")
                     .clone(),
-            )),
+            ))),
         ))
     }
 }
@@ -54,7 +56,7 @@ impl Scalar {
     {
         Ok(Self {
             dtype: DType::Utf8(nullability),
-            value: ScalarValue(InnerScalarValue::BufferString(str.try_into()?)),
+            value: ScalarValue(InnerScalarValue::BufferString(Arc::new(str.try_into()?))),
         })
     }
 }
@@ -85,7 +87,9 @@ impl From<&str> for Scalar {
     fn from(value: &str) -> Self {
         Self {
             dtype: DType::Utf8(NonNullable),
-            value: ScalarValue(InnerScalarValue::BufferString(value.to_string().into())),
+            value: ScalarValue(InnerScalarValue::BufferString(Arc::new(
+                value.to_string().into(),
+            ))),
         }
     }
 }
@@ -94,7 +98,7 @@ impl From<String> for Scalar {
     fn from(value: String) -> Self {
         Self {
             dtype: DType::Utf8(NonNullable),
-            value: ScalarValue(InnerScalarValue::BufferString(value.into())),
+            value: ScalarValue(InnerScalarValue::BufferString(Arc::new(value.into()))),
         }
     }
 }
@@ -103,7 +107,7 @@ impl From<BufferString> for Scalar {
     fn from(value: BufferString) -> Self {
         Self {
             dtype: DType::Utf8(NonNullable),
-            value: ScalarValue(InnerScalarValue::BufferString(value)),
+            value: ScalarValue(InnerScalarValue::BufferString(Arc::new(value))),
         }
     }
 }

--- a/vortex-scalar/src/utf8.rs
+++ b/vortex-scalar/src/utf8.rs
@@ -112,6 +112,15 @@ impl From<BufferString> for Scalar {
     }
 }
 
+impl From<Arc<BufferString>> for Scalar {
+    fn from(value: Arc<BufferString>) -> Self {
+        Self {
+            dtype: DType::Utf8(NonNullable),
+            value: ScalarValue(InnerScalarValue::BufferString(value)),
+        }
+    }
+}
+
 impl<'a> TryFrom<&'a Scalar> for BufferString {
     type Error = VortexError;
 

--- a/vortex-scalar/src/value.rs
+++ b/vortex-scalar/src/value.rs
@@ -21,8 +21,8 @@ pub struct ScalarValue(pub(crate) InnerScalarValue);
 pub(crate) enum InnerScalarValue {
     Bool(bool),
     Primitive(PValue),
-    Buffer(ByteBuffer),
-    BufferString(BufferString),
+    Buffer(Arc<ByteBuffer>),
+    BufferString(Arc<BufferString>),
     List(Arc<[ScalarValue]>),
     // It's significant that Null is last in this list. As a result generated PartialOrd sorts Scalar
     // values such that Nulls are last (greatest)
@@ -194,7 +194,7 @@ impl InnerScalarValue {
     pub(crate) fn as_buffer(&self) -> VortexResult<Option<ByteBuffer>> {
         match &self {
             InnerScalarValue::Null => Ok(None),
-            InnerScalarValue::Buffer(b) => Ok(Some(b.clone())),
+            InnerScalarValue::Buffer(b) => Ok(Some(b.as_ref().clone())),
             _ => Err(vortex_err!("Expected a binary scalar, found {:?}", self)),
         }
     }
@@ -202,8 +202,8 @@ impl InnerScalarValue {
     pub(crate) fn as_buffer_string(&self) -> VortexResult<Option<BufferString>> {
         match &self {
             InnerScalarValue::Null => Ok(None),
-            InnerScalarValue::Buffer(b) => Ok(Some(BufferString::try_from(b.clone())?)),
-            InnerScalarValue::BufferString(b) => Ok(Some(b.clone())),
+            InnerScalarValue::Buffer(b) => Ok(Some(BufferString::try_from(b.as_ref().clone())?)),
+            InnerScalarValue::BufferString(b) => Ok(Some(b.as_ref().clone())),
             _ => Err(vortex_err!("Expected a string scalar, found {:?}", self)),
         }
     }


### PR DESCRIPTION
probably a better version of #2078. Takes `ScalarValue` from 56 bytes to 24.

I don't see much perf impact either way, but it should be better to move small structs around.