### PR TITLE
Fix: Correctly handle PValue comparison/equals for f16

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -42,8 +42,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_FUZZ_SECRET_ACCESS_KEY }}
           AWS_REGION: 'us-east-1'
 
-  fuzz:
-    name: 'fuzz'
+  compute_fuzz:
+    name: 'Array Compute Fuzz'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/fuzz/fuzz_targets/array_ops.rs
+++ b/fuzz/fuzz_targets/array_ops.rs
@@ -85,8 +85,8 @@ fn assert_search_sorted(
 ) {
     let search_result = search_sorted(&array, s.clone(), side).unwrap();
     assert_eq!(
-        search_result,
         expected,
+        search_result,
         "Expected to find {s}({}) at {expected} in {} from {side} but instead found it at {search_result} in step {step}",
         s.dtype(),
         array.tree_display()

--- a/vortex-array/src/array/constant/canonical.rs
+++ b/vortex-array/src/array/constant/canonical.rs
@@ -2,7 +2,7 @@ use arrow_array::builder::make_view;
 use arrow_buffer::BooleanBuffer;
 use vortex_buffer::{buffer, Buffer, BufferMut};
 use vortex_dtype::{match_each_native_ptype, DType, Nullability};
-use vortex_error::{vortex_bail, VortexResult};
+use vortex_error::{vortex_bail, VortexExpect, VortexResult};
 use vortex_scalar::{BinaryScalar, BoolScalar, ExtScalar, Utf8Scalar};
 
 use crate::array::constant::ConstantArray;
@@ -36,7 +36,15 @@ impl IntoCanonical for ConstantArray {
             DType::Primitive(ptype, ..) => {
                 match_each_native_ptype!(ptype, |$P| {
                     Canonical::Primitive(PrimitiveArray::new(
-                        Buffer::full($P::try_from(scalar).unwrap_or_else(|_| $P::default()), self.len()),
+                        Buffer::full(
+                            if scalar.is_null() {
+                                $P::default()
+                            } else {
+                                $P::try_from(scalar)
+                                    .vortex_expect("Cannot extract primitive out of scalar")
+                            },
+                            self.len(),
+                        ),
                         validity,
                     ))
                 })
@@ -105,10 +113,12 @@ fn canonical_byte_view(
 
 #[cfg(test)]
 mod tests {
-    use vortex_dtype::{DType, Nullability};
+    use vortex_dtype::half::f16;
+    use vortex_dtype::{DType, Nullability, PType};
     use vortex_scalar::Scalar;
 
     use crate::array::ConstantArray;
+    use crate::canonical::IntoArrayVariant;
     use crate::compute::scalar_at;
     use crate::stats::{ArrayStatistics as _, StatsSet};
     use crate::{ArrayLen, IntoArrayData as _, IntoCanonical};
@@ -116,7 +126,7 @@ mod tests {
     #[test]
     fn test_canonicalize_null() {
         let const_null = ConstantArray::new(Scalar::null(DType::Null), 42);
-        let actual = const_null.into_canonical().unwrap().into_null().unwrap();
+        let actual = const_null.into_null().unwrap();
         assert_eq!(actual.len(), 42);
         assert_eq!(scalar_at(actual, 33).unwrap(), Scalar::null(DType::Null));
     }
@@ -126,11 +136,7 @@ mod tests {
         let const_array = ConstantArray::new("four".to_string(), 4);
 
         // Check all values correct.
-        let canonical = const_array
-            .into_canonical()
-            .unwrap()
-            .into_varbinview()
-            .unwrap();
+        let canonical = const_array.into_varbinview().unwrap();
 
         assert_eq!(canonical.len(), 4);
 
@@ -150,5 +156,18 @@ mod tests {
 
         assert_eq!(canonical_stats, StatsSet::constant(&scalar, 4));
         assert_eq!(canonical_stats, stats);
+    }
+
+    #[test]
+    fn test_canonicalize_scalar_values() {
+        let f16_scalar = Scalar::primitive(f16::from_f32(5.722046e-6), Nullability::NonNullable);
+        let scalar = Scalar::new(
+            DType::Primitive(PType::F16, Nullability::NonNullable),
+            Scalar::primitive(96u8, Nullability::NonNullable).into_value(),
+        );
+        let const_array = ConstantArray::new(scalar.clone(), 1).into_array();
+        let canonical_const = const_array.into_primitive().unwrap();
+        assert_eq!(scalar_at(&canonical_const, 0).unwrap(), scalar);
+        assert_eq!(scalar_at(&canonical_const, 0).unwrap(), f16_scalar);
     }
 }

--- a/vortex-scalar/src/pvalue.rs
+++ b/vortex-scalar/src/pvalue.rs
@@ -4,7 +4,6 @@ use std::hash::{Hash, Hasher};
 use std::mem;
 
 use num_traits::NumCast;
-use paste::paste;
 use vortex_dtype::half::f16;
 use vortex_dtype::{NativePType, PType, ToBytes};
 use vortex_error::{vortex_err, VortexError, VortexExpect};
@@ -26,15 +25,20 @@ pub enum PValue {
 
 impl PartialEq for PValue {
     fn eq(&self, other: &Self) -> bool {
+        // f16 can be serialized as u8, u16 or f16, we need to handle comparing all of the variants
         match (self, other) {
-            (Self::U8(s), o) => o.as_u64().vortex_expect("upcast") == *s as u64,
-            (Self::U16(s), o) => o.as_u64().vortex_expect("upcast") == *s as u64,
-            (Self::U32(s), o) => o.as_u64().vortex_expect("upcast") == *s as u64,
-            (Self::U64(s), o) => o.as_u64().vortex_expect("upcast") == *s,
-            (Self::I8(s), o) => o.as_i64().vortex_expect("upcast") == *s as i64,
-            (Self::I16(s), o) => o.as_i64().vortex_expect("upcast") == *s as i64,
-            (Self::I32(s), o) => o.as_i64().vortex_expect("upcast") == *s as i64,
-            (Self::I64(s), o) => o.as_i64().vortex_expect("upcast") == *s,
+            (Self::U8(s), Self::F16(o)) => f16::from_bits(*s as u16).is_eq(*o),
+            (Self::U8(s), o) => o.as_primitive::<u64>().vortex_expect("upcast") == *s as u64,
+            (Self::U16(s), Self::F16(o)) => f16::from_bits(*s).is_eq(*o),
+            (Self::U16(s), o) => o.as_primitive::<u64>().vortex_expect("upcast") == *s as u64,
+            (Self::U32(s), o) => o.as_primitive::<u64>().vortex_expect("upcast") == *s as u64,
+            (Self::U64(s), o) => o.as_primitive::<u64>().vortex_expect("upcast") == *s,
+            (Self::I8(s), o) => o.as_primitive::<i64>().vortex_expect("upcast") == *s as i64,
+            (Self::I16(s), o) => o.as_primitive::<i64>().vortex_expect("upcast") == *s as i64,
+            (Self::I32(s), o) => o.as_primitive::<i64>().vortex_expect("upcast") == *s as i64,
+            (Self::I64(s), o) => o.as_primitive::<i64>().vortex_expect("upcast") == *s,
+            (Self::F16(s), Self::U8(o)) => s.is_eq(f16::from_bits(*o as u16)),
+            (Self::F16(s), Self::U16(o)) => s.is_eq(f16::from_bits(*o)),
             (Self::F16(s), Self::F16(o)) => s.is_eq(*o),
             (Self::F32(s), Self::F32(o)) => s.is_eq(*o),
             (Self::F64(s), Self::F64(o)) => s.is_eq(*o),
@@ -45,15 +49,32 @@ impl PartialEq for PValue {
 
 impl PartialOrd for PValue {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        // f16 can be serialized as u8, u16 or f16, we need to handle comparing all of the variants
         match (self, other) {
-            (Self::U8(s), o) => Some((*s as u64).cmp(&o.as_u64().vortex_expect("upcast"))),
-            (Self::U16(s), o) => Some((*s as u64).cmp(&o.as_u64().vortex_expect("upcast"))),
-            (Self::U32(s), o) => Some((*s as u64).cmp(&o.as_u64().vortex_expect("upcast"))),
-            (Self::U64(s), o) => Some((*s).cmp(&o.as_u64().vortex_expect("upcast"))),
-            (Self::I8(s), o) => Some((*s as i64).cmp(&o.as_i64().vortex_expect("upcast"))),
-            (Self::I16(s), o) => Some((*s as i64).cmp(&o.as_i64().vortex_expect("upcast"))),
-            (Self::I32(s), o) => Some((*s as i64).cmp(&o.as_i64().vortex_expect("upcast"))),
-            (Self::I64(s), o) => Some((*s).cmp(&o.as_i64().vortex_expect("upcast"))),
+            (Self::U8(s), Self::F16(o)) => Some(f16::from_bits(*s as u16).total_compare(*o)),
+            (Self::U8(s), o) => {
+                Some((*s as u64).cmp(&o.as_primitive::<u64>().vortex_expect("upcast")))
+            }
+            (Self::U16(s), Self::F16(o)) => Some(f16::from_bits(*s).total_compare(*o)),
+            (Self::U16(s), o) => {
+                Some((*s as u64).cmp(&o.as_primitive::<u64>().vortex_expect("upcast")))
+            }
+            (Self::U32(s), o) => {
+                Some((*s as u64).cmp(&o.as_primitive::<u64>().vortex_expect("upcast")))
+            }
+            (Self::U64(s), o) => Some((*s).cmp(&o.as_primitive::<u64>().vortex_expect("upcast"))),
+            (Self::I8(s), o) => {
+                Some((*s as i64).cmp(&o.as_primitive::<i64>().vortex_expect("upcast")))
+            }
+            (Self::I16(s), o) => {
+                Some((*s as i64).cmp(&o.as_primitive::<i64>().vortex_expect("upcast")))
+            }
+            (Self::I32(s), o) => {
+                Some((*s as i64).cmp(&o.as_primitive::<i64>().vortex_expect("upcast")))
+            }
+            (Self::I64(s), o) => Some((*s).cmp(&o.as_primitive::<i64>().vortex_expect("upcast"))),
+            (Self::F16(s), Self::U8(o)) => Some(s.total_compare(f16::from_bits(*o as u16))),
+            (Self::F16(s), Self::U16(o)) => Some(s.total_compare(f16::from_bits(*o))),
             (Self::F16(s), Self::F16(o)) => Some(s.total_compare(*o)),
             (Self::F32(s), Self::F32(o)) => Some(s.total_compare(*o)),
             (Self::F64(s), Self::F64(o)) => Some(s.total_compare(*o)),
@@ -84,29 +105,6 @@ impl ToBytes for PValue {
             PValue::F64(v) => v.to_le_bytes(),
         }
     }
-}
-
-macro_rules! as_primitive {
-    ($T:ty, $PT:tt) => {
-        paste! {
-            #[doc = "Access PValue as `" $T "`, returning `None` if conversion is unsuccessful"]
-            pub fn [<as_ $T>](self) -> Option<$T> {
-                match self {
-                    PValue::U8(v) => <$T as NumCast>::from(v),
-                    PValue::U16(v) => <$T as NumCast>::from(v),
-                    PValue::U32(v) => <$T as NumCast>::from(v),
-                    PValue::U64(v) => <$T as NumCast>::from(v),
-                    PValue::I8(v) => <$T as NumCast>::from(v),
-                    PValue::I16(v) => <$T as NumCast>::from(v),
-                    PValue::I32(v) => <$T as NumCast>::from(v),
-                    PValue::I64(v) => <$T as NumCast>::from(v),
-                    PValue::F16(v) => <$T as NumCast>::from(v),
-                    PValue::F32(v) => <$T as NumCast>::from(v),
-                    PValue::F64(v) => <$T as NumCast>::from(v),
-                }
-            }
-        }
-    };
 }
 
 impl PValue {
@@ -199,18 +197,6 @@ impl PValue {
             },
         }
     }
-
-    as_primitive!(i8, I8);
-    as_primitive!(i16, I16);
-    as_primitive!(i32, I32);
-    as_primitive!(i64, I64);
-    as_primitive!(u8, U8);
-    as_primitive!(u16, U16);
-    as_primitive!(u32, U32);
-    as_primitive!(u64, U64);
-    as_primitive!(f16, F16);
-    as_primitive!(f32, F32);
-    as_primitive!(f64, F64);
 }
 
 macro_rules! int_pvalue {
@@ -277,6 +263,7 @@ impl TryFrom<PValue> for f16 {
     fn try_from(value: PValue) -> Result<Self, Self::Error> {
         // We serialize f16 as u16.
         match value {
+            PValue::U8(u) => Some(Self::from_bits(u as u16)),
             PValue::U16(u) => Some(Self::from_bits(u)),
             PValue::F16(u) => Some(u),
             PValue::F32(f) => <Self as NumCast>::from(f),
@@ -337,6 +324,7 @@ impl Display for PValue {
 mod test {
     use std::cmp::Ordering;
 
+    use rstest::rstest;
     use vortex_dtype::half::f16;
     use vortex_dtype::PType;
 
@@ -360,15 +348,31 @@ mod test {
         assert!(!PValue::F16(f16::from_f32(10.0)).is_instance_of(&PType::I16));
     }
 
-    #[test]
-    fn test_compare_different_types() {
-        assert_eq!(
-            PValue::I8(4).partial_cmp(&PValue::I8(5)),
-            Some(Ordering::Less)
-        );
-        assert_eq!(
-            PValue::I8(4).partial_cmp(&PValue::I64(5)),
-            Some(Ordering::Less)
-        );
+    #[rstest]
+    #[case(PValue::I8(4), PValue::I8(5), Some(Ordering::Less))]
+    #[case(PValue::I8(4), PValue::I64(5), Some(Ordering::Less))]
+    #[case(
+        PValue::U8(96),
+        PValue::F16(f16::from_f32(5.722046e-6)),
+        Some(Ordering::Equal)
+    )]
+    fn test_compare_different_types(
+        #[case] left: PValue,
+        #[case] right: PValue,
+        #[case] expected: Option<Ordering>,
+    ) {
+        assert_eq!(left.partial_cmp(&right), expected);
+    }
+
+    #[rstest]
+    #[case(PValue::I8(4), PValue::I8(5), false)]
+    #[case(PValue::I8(4), PValue::I64(5), false)]
+    #[case(PValue::U8(96), PValue::F16(f16::from_f32(5.722046e-6)), true)]
+    fn is_equals_different_types(
+        #[case] left: PValue,
+        #[case] right: PValue,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(left == right, expected);
     }
 }

--- a/vortex-scalar/src/pvalue.rs
+++ b/vortex-scalar/src/pvalue.rs
@@ -356,6 +356,11 @@ mod test {
         PValue::F16(f16::from_f32(5.722046e-6)),
         Some(Ordering::Equal)
     )]
+    #[case(
+        PValue::F16(f16::from_f32(5.722046e-6)),
+        PValue::U8(96),
+        Some(Ordering::Equal)
+    )]
     fn test_compare_different_types(
         #[case] left: PValue,
         #[case] right: PValue,
@@ -368,6 +373,7 @@ mod test {
     #[case(PValue::I8(4), PValue::I8(5), false)]
     #[case(PValue::I8(4), PValue::I64(5), false)]
     #[case(PValue::U8(96), PValue::F16(f16::from_f32(5.722046e-6)), true)]
+    #[case(PValue::F16(f16::from_f32(5.722046e-6)), PValue::U8(96), true)]
     fn is_equals_different_types(
         #[case] left: PValue,
         #[case] right: PValue,


### PR DESCRIPTION
ScalarValue serialisation can narrow down the type of the value being stored.
However, ScalarValue should be agnostic of that and as long as DType of the
scalars match the ScalarValue comparison should succeed.

For f16 we serialize the value as u16 which then can be narrowed down to u8. We
never handled f16 represented as u8s and we never handled comparison across
different serialized formats of f16.

Additionally we assumed that ConstantArray canonicalization of can only ever
default for null values, however, that was masking errors being thrown by
incorrect cast and yielded wrong canonical array
