### PR TITLE
Fix scalar eq, cmp, hash, etc.

### DIFF
--- a/pyvortex/src/scalar.rs
+++ b/pyvortex/src/scalar.rs
@@ -9,6 +9,7 @@ use pyo3::types::PyDict;
 use vortex::buffer::{BufferString, ByteBuffer};
 use vortex::dtype::half::f16;
 use vortex::dtype::{DType, PType};
+use vortex::error::VortexExpect;
 use vortex::scalar::{ListScalar, Scalar, StructScalar};
 
 pub fn scalar_into_py(py: Python, x: Scalar, copy_into_python: bool) -> PyResult<PyObject> {
@@ -190,6 +191,8 @@ impl PyVortexList {
 fn to_python_list(py: Python, scalar: ListScalar<'_>, recursive: bool) -> PyResult<PyObject> {
     Ok(scalar
         .elements()
+        .vortex_expect("non-null")
+        .into_iter()
         .map(|x| scalar_into_py(py, x, recursive))
         .collect::<PyResult<Vec<_>>>()?
         .into_py(py))

--- a/vortex-array/src/array/constant/canonical.rs
+++ b/vortex-array/src/array/constant/canonical.rs
@@ -105,10 +105,12 @@ fn canonical_byte_view(
 
 #[cfg(test)]
 mod tests {
-    use vortex_dtype::{DType, Nullability};
+    use vortex_dtype::half::f16;
+    use vortex_dtype::{DType, Nullability, PType};
     use vortex_scalar::Scalar;
 
     use crate::array::ConstantArray;
+    use crate::canonical::IntoArrayVariant;
     use crate::compute::scalar_at;
     use crate::stats::{ArrayStatistics as _, StatsSet};
     use crate::{ArrayLen, IntoArrayData as _, IntoCanonical};
@@ -150,5 +152,18 @@ mod tests {
 
         assert_eq!(canonical_stats, StatsSet::constant(&scalar, 4));
         assert_eq!(canonical_stats, stats);
+    }
+
+    #[test]
+    fn test_canonicalize_scalar_values() {
+        let f16_scalar = Scalar::primitive(f16::from_f32(5.722046e-6), Nullability::NonNullable);
+        let scalar = Scalar::new(
+            DType::Primitive(PType::F16, Nullability::NonNullable),
+            Scalar::primitive(96u8, Nullability::NonNullable).into_value(),
+        );
+        let const_array = ConstantArray::new(scalar.clone(), 1).into_array();
+        let canonical_const = const_array.into_primitive().unwrap();
+        assert_eq!(scalar_at(&canonical_const, 0).unwrap(), scalar);
+        assert_eq!(scalar_at(&canonical_const, 0).unwrap(), f16_scalar);
     }
 }

--- a/vortex-scalar/src/binary.rs
+++ b/vortex-scalar/src/binary.rs
@@ -7,9 +7,25 @@ use vortex_error::{vortex_bail, vortex_err, VortexError, VortexExpect as _, Vort
 use crate::value::{InnerScalarValue, ScalarValue};
 use crate::Scalar;
 
+#[derive(Debug, Hash)]
 pub struct BinaryScalar<'a> {
     dtype: &'a DType,
     value: Option<ByteBuffer>,
+}
+
+impl PartialEq for BinaryScalar<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.dtype == other.dtype && self.value == other.value
+    }
+}
+
+impl Eq for BinaryScalar<'_> {}
+
+/// Ord is not implemented since it's undefined for different nullability
+impl PartialOrd for BinaryScalar<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.value.partial_cmp(&other.value)
+    }
 }
 
 impl<'a> BinaryScalar<'a> {

--- a/vortex-scalar/src/bool.rs
+++ b/vortex-scalar/src/bool.rs
@@ -7,7 +7,7 @@ use vortex_error::{vortex_bail, vortex_err, VortexError, VortexExpect as _, Vort
 use crate::value::ScalarValue;
 use crate::{InnerScalarValue, Scalar};
 
-#[derive(Eq, Ord)]
+#[derive(Debug, Hash)]
 pub struct BoolScalar<'a> {
     dtype: &'a DType,
     value: Option<bool>,
@@ -19,8 +19,13 @@ impl PartialEq for BoolScalar<'_> {
     }
 }
 
+impl Eq for BoolScalar<'_> {}
+
 impl PartialOrd for BoolScalar<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        if self.dtype != other.dtype {
+            return None;
+        }
         self.value.partial_cmp(&other.value)
     }
 }

--- a/vortex-scalar/src/bool.rs
+++ b/vortex-scalar/src/bool.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use vortex_dtype::Nullability::NonNullable;
 use vortex_dtype::{DType, Nullability};
 use vortex_error::{vortex_bail, vortex_err, VortexError, VortexExpect as _, VortexResult};
@@ -5,9 +7,22 @@ use vortex_error::{vortex_bail, vortex_err, VortexError, VortexExpect as _, Vort
 use crate::value::ScalarValue;
 use crate::{InnerScalarValue, Scalar};
 
+#[derive(Eq, Ord)]
 pub struct BoolScalar<'a> {
     dtype: &'a DType,
     value: Option<bool>,
+}
+
+impl PartialEq for BoolScalar<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl PartialOrd for BoolScalar<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.value.partial_cmp(&other.value)
+    }
 }
 
 impl<'a> BoolScalar<'a> {

--- a/vortex-scalar/src/display.rs
+++ b/vortex-scalar/src/display.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Formatter};
 use itertools::Itertools;
 use vortex_datetime_dtype::{is_temporal_ext_type, TemporalMetadata};
 use vortex_dtype::DType;
-use vortex_error::vortex_panic;
+use vortex_error::{vortex_panic, VortexExpect};
 
 use crate::binary::BinaryScalar;
 use crate::extension::ExtScalar;
@@ -65,7 +65,11 @@ impl Display for Scalar {
                 if v.is_null() {
                     write!(f, "null")
                 } else {
-                    write!(f, "[{}]", v.elements().format(","))
+                    write!(
+                        f,
+                        "[{}]",
+                        v.elements().vortex_expect("non-null").iter().format(",")
+                    )
                 }
             }
             // Specialized handling for date/time/timestamp builtin extension types.

--- a/vortex-scalar/src/display.rs
+++ b/vortex-scalar/src/display.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Formatter};
 use itertools::Itertools;
 use vortex_datetime_dtype::{is_temporal_ext_type, TemporalMetadata};
 use vortex_dtype::DType;
-use vortex_error::{vortex_panic, VortexExpect};
+use vortex_error::vortex_panic;
 
 use crate::binary::BinaryScalar;
 use crate::extension::ExtScalar;
@@ -61,15 +61,11 @@ impl Display for Scalar {
             }
             DType::List(..) => {
                 let v = ListScalar::try_from(self).map_err(|_| std::fmt::Error)?;
-
-                if v.is_null() {
-                    write!(f, "null")
-                } else {
-                    write!(
-                        f,
-                        "[{}]",
-                        v.elements().vortex_expect("non-null").iter().format(",")
-                    )
+                match v.elements() {
+                    None => write!(f, "null"),
+                    Some(elems) => {
+                        write!(f, "[{}]", elems.iter().format(","))
+                    }
                 }
             }
             // Specialized handling for date/time/timestamp builtin extension types.

--- a/vortex-scalar/src/extension.rs
+++ b/vortex-scalar/src/extension.rs
@@ -1,3 +1,4 @@
+use std::hash::Hash;
 use std::sync::Arc;
 
 use vortex_dtype::{DType, ExtDType};
@@ -9,6 +10,30 @@ use crate::Scalar;
 pub struct ExtScalar<'a> {
     ext_dtype: &'a ExtDType,
     value: &'a ScalarValue,
+}
+
+impl PartialEq for ExtScalar<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.ext_dtype == other.ext_dtype && self.storage() == other.storage()
+    }
+}
+
+impl Eq for ExtScalar<'_> {}
+
+impl PartialOrd for ExtScalar<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        if self.ext_dtype != other.ext_dtype {
+            return None;
+        }
+        self.storage().partial_cmp(&other.storage())
+    }
+}
+
+impl Hash for ExtScalar<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.ext_dtype.hash(state);
+        self.storage().hash(state);
+    }
 }
 
 impl<'a> ExtScalar<'a> {

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 use std::hash::Hash;
-use std::mem::discriminant;
 use std::sync::Arc;
 
 pub use scalar_type::ScalarType;
@@ -210,12 +209,12 @@ impl PartialEq for Scalar {
         match self.dtype() {
             DType::Null => true,
             DType::Bool(_) => self.as_bool() == other.as_bool(),
-            DType::Primitive(..) => {}
-            DType::Utf8(_) => {}
-            DType::Binary(_) => {}
-            DType::Struct(..) => {}
-            DType::List(..) => {}
-            DType::Extension(_) => {}
+            DType::Primitive(..) => self.as_primitive() == other.as_primitive(),
+            DType::Utf8(_) => self.as_utf8() == other.as_utf8(),
+            DType::Binary(_) => self.as_binary() == other.as_binary(),
+            DType::Struct(..) => self.as_struct() == other.as_struct(),
+            DType::List(..) => self.as_list() == other.as_list(),
+            DType::Extension(_) => self.as_extension() == other.as_extension(),
         }
     }
 }
@@ -224,20 +223,35 @@ impl Eq for Scalar {}
 
 impl PartialOrd for Scalar {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        // We check for DType equality, ignoring nullability, and allowing us to compare all
-        // primitive types to all other primitive types.
-        if discriminant(self.dtype()) == discriminant(other.dtype()) {
-            self.value.0.partial_cmp(&other.value.0)
-        } else {
-            None
+        if self.dtype() != other.dtype() {
+            return None;
+        }
+
+        match self.dtype() {
+            DType::Null => Some(Ordering::Equal),
+            DType::Bool(_) => self.as_bool().partial_cmp(&other.as_bool()),
+            DType::Primitive(..) => self.as_primitive().partial_cmp(&other.as_primitive()),
+            DType::Utf8(_) => self.as_utf8().partial_cmp(&other.as_utf8()),
+            DType::Binary(_) => self.as_binary().partial_cmp(&other.as_binary()),
+            DType::Struct(..) => self.as_struct().partial_cmp(&other.as_struct()),
+            DType::List(..) => self.as_list().partial_cmp(&other.as_list()),
+            DType::Extension(_) => self.as_extension().partial_cmp(&other.as_extension()),
         }
     }
 }
 
 impl Hash for Scalar {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        discriminant(self.dtype()).hash(state);
-        self.value.0.hash(state);
+        match self.dtype() {
+            DType::Null => self.dtype().hash(state), // Hash the dtype instead of the value
+            DType::Bool(_) => self.as_bool().hash(state),
+            DType::Primitive(..) => self.as_primitive().hash(state),
+            DType::Utf8(_) => self.as_utf8().hash(state),
+            DType::Binary(_) => self.as_binary().hash(state),
+            DType::Struct(..) => self.as_struct().hash(state),
+            DType::List(..) => self.as_list().hash(state),
+            DType::Extension(_) => self.as_extension().hash(state),
+        }
     }
 }
 

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -41,8 +41,9 @@ use vortex_error::{vortex_bail, VortexExpect, VortexResult};
 /// A [`ScalarValue`] is opaque, and should be accessed via one of the type-specific scalar wrappers
 /// for example [`BoolScalar`], [`PrimitiveScalar`], etc.
 ///
-/// Note: [`PartialEq`] and [`PartialOrd`] are implemented only for an exact match of the scalar's
-/// dtype, including nullability.
+/// Note that [`PartialOrd`] is implemented only for an exact match of the scalar's dtype,
+/// including nullability. When the DType does match, ordering is nulls first (lowest), then the
+/// natural ordering of the scalar value.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct Scalar {

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -203,7 +203,20 @@ impl Scalar {
 
 impl PartialEq for Scalar {
     fn eq(&self, other: &Self) -> bool {
-        self.dtype == other.dtype && self.value.0 == other.value.0
+        if self.dtype != other.dtype {
+            return false;
+        }
+
+        match self.dtype() {
+            DType::Null => true,
+            DType::Bool(_) => self.as_bool() == other.as_bool(),
+            DType::Primitive(..) => {}
+            DType::Utf8(_) => {}
+            DType::Binary(_) => {}
+            DType::Struct(..) => {}
+            DType::List(..) => {}
+            DType::Extension(_) => {}
+        }
     }
 }
 

--- a/vortex-scalar/src/list.rs
+++ b/vortex-scalar/src/list.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 
 use itertools::Itertools as _;
 use vortex_dtype::{DType, Nullability};
-use vortex_error::{vortex_bail, vortex_panic, VortexError, VortexExpect as _, VortexResult};
+use vortex_error::{
+    vortex_bail, vortex_err, vortex_panic, VortexError, VortexExpect as _, VortexResult,
+};
 
 use crate::value::{InnerScalarValue, ScalarValue};
 use crate::Scalar;
@@ -160,5 +162,21 @@ impl<'a> TryFrom<&'a Scalar> for ListScalar<'a> {
             element_dtype,
             elements: value.value.as_list()?.cloned(),
         })
+    }
+}
+
+impl<'a, T: for<'b> TryFrom<&'b Scalar, Error = VortexError>> TryFrom<&'a Scalar> for Vec<T> {
+    type Error = VortexError;
+
+    fn try_from(value: &'a Scalar) -> Result<Self, Self::Error> {
+        let value = ListScalar::try_from(value)?;
+        let mut elems = vec![];
+        for e in value
+            .elements()
+            .ok_or_else(|| vortex_err!("Expected non-null list"))?
+        {
+            elems.push(T::try_from(&e)?);
+        }
+        Ok(elems)
     }
 }

--- a/vortex-scalar/src/list.rs
+++ b/vortex-scalar/src/list.rs
@@ -1,3 +1,4 @@
+use std::hash::Hash;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -12,6 +13,34 @@ pub struct ListScalar<'a> {
     dtype: &'a DType,
     element_dtype: &'a Arc<DType>,
     elements: Option<Arc<[ScalarValue]>>,
+}
+
+impl PartialEq for ListScalar<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.dtype != other.dtype {
+            return false;
+        }
+        self.elements() == other.elements()
+    }
+}
+
+impl Eq for ListScalar<'_> {}
+
+/// Ord is not implemented since it's undefined for different DTypes
+impl PartialOrd for ListScalar<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        if self.dtype() != other.dtype() {
+            return None;
+        }
+        self.elements().partial_cmp(&other.elements())
+    }
+}
+
+impl Hash for ListScalar<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.dtype.hash(state);
+        self.elements().hash(state);
+    }
 }
 
 impl<'a> ListScalar<'a> {
@@ -55,16 +84,13 @@ impl<'a> ListScalar<'a> {
             })
     }
 
-    pub fn elements(&self) -> impl Iterator<Item = Scalar> + '_ {
-        self.elements
-            .as_ref()
-            .map(AsRef::as_ref)
-            .unwrap_or_else(|| &[] as &[ScalarValue])
-            .iter()
-            .map(|e| Scalar {
-                dtype: self.element_dtype(),
-                value: e.clone(),
-            })
+    pub fn elements(&self) -> Option<Vec<Scalar>> {
+        self.elements.as_ref().map(|elems| {
+            elems
+                .iter()
+                .map(|e| Scalar::new(self.element_dtype(), e.clone()))
+                .collect_vec()
+        })
     }
 
     pub(crate) fn cast(&self, dtype: &DType) -> VortexResult<Scalar> {
@@ -134,18 +160,5 @@ impl<'a> TryFrom<&'a Scalar> for ListScalar<'a> {
             element_dtype,
             elements: value.value.as_list()?.cloned(),
         })
-    }
-}
-
-impl<'a, T: for<'b> TryFrom<&'b Scalar, Error = VortexError>> TryFrom<&'a Scalar> for Vec<T> {
-    type Error = VortexError;
-
-    fn try_from(value: &'a Scalar) -> Result<Self, Self::Error> {
-        let value = ListScalar::try_from(value)?;
-        let mut elems = vec![];
-        for e in value.elements() {
-            elems.push(T::try_from(&e)?);
-        }
-        Ok(elems)
     }
 }

--- a/vortex-scalar/src/primitive.rs
+++ b/vortex-scalar/src/primitive.rs
@@ -1,4 +1,5 @@
 use std::any::type_name;
+use std::cmp::Ordering;
 use std::fmt::{Debug, Display};
 
 use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, FromPrimitive};
@@ -13,11 +14,29 @@ use crate::pvalue::PValue;
 use crate::value::ScalarValue;
 use crate::{InnerScalarValue, Scalar};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Hash)]
 pub struct PrimitiveScalar<'a> {
     dtype: &'a DType,
     ptype: PType,
     pvalue: Option<PValue>,
+}
+
+impl PartialEq for PrimitiveScalar<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.dtype() == other.dtype() && self.pvalue == other.pvalue
+    }
+}
+
+impl Eq for PrimitiveScalar<'_> {}
+
+/// Ord is not implemented since it's undefined for different nullability
+impl PartialOrd for PrimitiveScalar<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        if self.dtype() != other.dtype() {
+            return None;
+        }
+        self.pvalue.partial_cmp(&other.pvalue)
+    }
 }
 
 impl<'a> PrimitiveScalar<'a> {

--- a/vortex-scalar/src/pvalue.rs
+++ b/vortex-scalar/src/pvalue.rs
@@ -275,8 +275,9 @@ impl TryFrom<PValue> for f16 {
     type Error = VortexError;
 
     fn try_from(value: PValue) -> Result<Self, Self::Error> {
-        // We serialize f16 as u16.
+        // We serialize f16 as u16, but this can also sometimes be narrowed down to u8 if e.g. == 0
         match value {
+            PValue::U8(u) => Some(Self::from_bits(u as u16)),
             PValue::U16(u) => Some(Self::from_bits(u)),
             PValue::F16(u) => Some(u),
             PValue::F32(f) => <Self as NumCast>::from(f),

--- a/vortex-scalar/src/serde/serde.rs
+++ b/vortex-scalar/src/serde/serde.rs
@@ -212,6 +212,7 @@ impl<'de> Deserialize<'de> for PValue {
 
 #[cfg(test)]
 mod tests {
+    use std::mem::discriminant;
     use std::sync::Arc;
 
     use flexbuffers::{FlexbufferSerializer, Reader};
@@ -232,6 +233,9 @@ mod tests {
         let written = serializer.take_buffer();
         let reader = Reader::get_root(written.as_ref()).unwrap();
         let scalar_read_back = ScalarValue::deserialize(reader).unwrap();
-        assert_eq!(scalar_value, scalar_read_back);
+        assert_eq!(
+            discriminant(&scalar_value.0),
+            discriminant(&scalar_read_back.0)
+        );
     }
 }

--- a/vortex-scalar/src/struct_.rs
+++ b/vortex-scalar/src/struct_.rs
@@ -1,3 +1,4 @@
+use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -13,6 +14,34 @@ use crate::{InnerScalarValue, Scalar};
 pub struct StructScalar<'a> {
     dtype: &'a DType,
     fields: Option<&'a Arc<[ScalarValue]>>,
+}
+
+impl PartialEq for StructScalar<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.dtype != other.dtype {
+            return false;
+        }
+        self.fields() == other.fields()
+    }
+}
+
+impl Eq for StructScalar<'_> {}
+
+/// Ord is not implemented since it's undefined for different DTypes
+impl PartialOrd for StructScalar<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        if self.dtype() != other.dtype() {
+            return None;
+        }
+        self.fields().partial_cmp(&other.fields())
+    }
+}
+
+impl Hash for StructScalar<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.dtype.hash(state);
+        self.fields().hash(state);
+    }
 }
 
 impl<'a> StructScalar<'a> {

--- a/vortex-scalar/src/utf8.rs
+++ b/vortex-scalar/src/utf8.rs
@@ -8,9 +8,25 @@ use vortex_error::{vortex_bail, vortex_err, VortexError, VortexExpect as _, Vort
 use crate::value::ScalarValue;
 use crate::{InnerScalarValue, Scalar};
 
+#[derive(Debug, Hash)]
 pub struct Utf8Scalar<'a> {
     dtype: &'a DType,
     value: Option<BufferString>,
+}
+
+impl PartialEq for Utf8Scalar<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.dtype == other.dtype && self.value == other.value
+    }
+}
+
+impl Eq for Utf8Scalar<'_> {}
+
+/// Ord is not implemented since it's undefined for different nullability
+impl PartialOrd for Utf8Scalar<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.value.partial_cmp(&other.value)
+    }
 }
 
 impl<'a> Utf8Scalar<'a> {

--- a/vortex-scalar/src/value.rs
+++ b/vortex-scalar/src/value.rs
@@ -77,7 +77,7 @@ impl Display for InnerScalarValue {
                         to_hex(&buf[buf.len() - 5..buf.len()])?,
                     )
                 } else {
-                    write!(f, "{}", to_hex(&buf)?)
+                    write!(f, "{}", to_hex(buf)?)
                 }
             }
             Self::BufferString(bufstr) => {

--- a/vortex-scalar/src/value.rs
+++ b/vortex-scalar/src/value.rs
@@ -14,10 +14,10 @@ use crate::pvalue::PValue;
 /// Note that these values can be deserialized from JSON or other formats. So a PValue may not
 /// have the correct width for what the DType expects. Primitive values should therefore be
 /// read using [crate::PrimitiveScalar] which will handle the conversion.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Hash)]
+#[derive(Debug, Clone)]
 pub struct ScalarValue(pub(crate) InnerScalarValue);
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Hash)]
+#[derive(Debug, Clone)]
 pub(crate) enum InnerScalarValue {
     Bool(bool),
     Primitive(PValue),

--- a/vortex-scalar/src/value.rs
+++ b/vortex-scalar/src/value.rs
@@ -19,14 +19,12 @@ pub struct ScalarValue(pub(crate) InnerScalarValue);
 
 #[derive(Debug, Clone)]
 pub(crate) enum InnerScalarValue {
+    Null,
     Bool(bool),
     Primitive(PValue),
     Buffer(Arc<ByteBuffer>),
     BufferString(Arc<BufferString>),
     List(Arc<[ScalarValue]>),
-    // It's significant that Null is last in this list. As a result generated PartialOrd sorts Scalar
-    // values such that Nulls are last (greatest)
-    Null,
 }
 
 #[cfg(feature = "flatbuffers")]
@@ -79,7 +77,7 @@ impl Display for InnerScalarValue {
                         to_hex(&buf[buf.len() - 5..buf.len()])?,
                     )
                 } else {
-                    write!(f, "{}", to_hex(buf.as_slice())?)
+                    write!(f, "{}", to_hex(&buf)?)
                 }
             }
             Self::BufferString(bufstr) => {
@@ -87,8 +85,8 @@ impl Display for InnerScalarValue {
                     write!(
                         f,
                         "{}..{}",
-                        &bufstr.as_str()[0..5],
-                        &bufstr.as_str()[bufstr.len() - 5..bufstr.len()],
+                        &bufstr[0..5],
+                        &bufstr[bufstr.len() - 5..bufstr.len()],
                     )
                 } else {
                     write!(f, "\"{}\"", bufstr.as_str())


### PR DESCRIPTION
Previously we were being a little bit lazy and delegating to ScalarValue. We've been bitten by this in the past!

It is never safe to delegate to ScalarValue since it doesn't have enough information to know what "equals" means, i.e. it's missing the surrounding scalar's DType.

This PR removes PartialEq, PartialOrd, and Hash from ScalarValue, in favor of forcing us to wrap the value into a Scalar and then compare each dtype-specific scalar type.