### PR TITLE
Buffer::zeroed properly sets length of the resulting buffer

### DIFF
--- a/vortex-buffer/src/buffer.rs
+++ b/vortex-buffer/src/buffer.rs
@@ -311,8 +311,8 @@ impl<T> Buffer<T> {
     /// Returns the underlying aligned buffer.
     pub fn into_inner(self) -> Bytes {
         debug_assert_eq!(
-            self.length,
-            self.bytes.len() * size_of::<T>(),
+            self.length * size_of::<T>(),
+            self.bytes.len(),
             "Own length has to be the same as the underlying bytes length"
         );
         self.bytes

--- a/vortex-buffer/src/buffer.rs
+++ b/vortex-buffer/src/buffer.rs
@@ -310,6 +310,11 @@ impl<T> Buffer<T> {
 
     /// Returns the underlying aligned buffer.
     pub fn into_inner(self) -> Bytes {
+        debug_assert_eq!(
+            self.length,
+            self.bytes.len() * size_of::<T>(),
+            "Own length has to be the same as the underlying bytes length"
+        );
         self.bytes
     }
 

--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -55,6 +55,7 @@ impl<T> BufferMut<T> {
     pub fn zeroed_aligned(len: usize, alignment: Alignment) -> Self {
         let mut bytes = BytesMut::zeroed((len * size_of::<T>()) + *alignment);
         bytes.advance(bytes.as_ptr().align_offset(*alignment));
+        unsafe { bytes.set_len(len * size_of::<T>()) };
         Self {
             bytes,
             length: len,


### PR DESCRIPTION
We allocate len * size_of::<T> + alignment, then trim alignment from the beginning by advancing by offset but we never cap the total length to the lenght of the items minus the alignment.