### PR TITLE
remove arrow from Canonical::empty

### DIFF
--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -16,7 +16,7 @@ use arrow_schema::{DataType, Field, FieldRef, Fields};
 use itertools::Itertools;
 use vortex_datetime_dtype::{is_temporal_ext_type, TemporalMetadata, TimeUnit};
 use vortex_dtype::{DType, NativePType, PType};
-use vortex_error::{vortex_bail, VortexError, VortexResult};
+use vortex_error::{vortex_bail, VortexError, VortexExpect, VortexResult};
 
 use crate::array::{
     varbinview_as_arrow, BoolArray, ExtensionArray, ListArray, NullArray, PrimitiveArray,
@@ -101,7 +101,11 @@ impl Canonical {
 
 impl Canonical {
     // Create an empty canonical array of the given dtype.
-    pub fn empty(dtype: &DType) -> VortexResult<Canonical> {
+    pub fn empty(dtype: &DType) -> Canonical {
+        Self::try_empty(dtype).vortex_expect("Cannot build an empty array")
+    }
+
+    pub fn try_empty(dtype: &DType) -> VortexResult<Canonical> {
         builder_with_capacity(dtype, 0).finish()?.into_canonical()
     }
 }

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -23,6 +23,7 @@ use crate::array::{
     StructArray, TemporalArray, VarBinViewArray,
 };
 use crate::arrow::{infer_data_type, FromArrowArray};
+use crate::builders::builder_with_capacity;
 use crate::compute::try_cast;
 use crate::encoding::Encoding;
 use crate::stats::ArrayStatistics;
@@ -101,12 +102,7 @@ impl Canonical {
 impl Canonical {
     // Create an empty canonical array of the given dtype.
     pub fn empty(dtype: &DType) -> VortexResult<Canonical> {
-        let arrow_dtype = infer_data_type(dtype)?;
-        ArrayData::from_arrow(
-            arrow_array::new_empty_array(&arrow_dtype),
-            dtype.is_nullable(),
-        )
-        .into_canonical()
+        builder_with_capacity(dtype, 0).finish()?.into_canonical()
     }
 }
 

--- a/vortex-array/src/compute/compare.rs
+++ b/vortex-array/src/compute/compare.rs
@@ -124,7 +124,7 @@ pub fn compare(
         DType::Bool((left.dtype().is_nullable() || right.dtype().is_nullable()).into());
 
     if left.is_empty() {
-        return Ok(Canonical::empty(&result_dtype)?.into_array());
+        return Ok(Canonical::empty(&result_dtype).into_array());
     }
 
     // Always try to put constants on the right-hand side so encodings can optimise themselves.

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -54,7 +54,7 @@ pub fn filter(array: &ArrayData, mask: &Mask) -> VortexResult<ArrayData> {
 
     // Fast-path for empty mask.
     if true_count == 0 {
-        return Ok(Canonical::empty(array.dtype())?.into());
+        return Ok(Canonical::empty(array.dtype()).into());
     }
 
     // Fast-path for full mask

--- a/vortex-expr/src/identity.rs
+++ b/vortex-expr/src/identity.rs
@@ -50,6 +50,10 @@ pub fn ident() -> ExprRef {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use vortex_dtype::{DType, Nullability, PType};
+
     use crate::{ident, test_harness};
 
     #[test]
@@ -57,5 +61,15 @@ mod tests {
         let dtype = test_harness::struct_dtype();
         assert_eq!(ident().return_dtype(&dtype).unwrap(), dtype);
         assert_eq!(ident().return_dtype(&dtype).unwrap(), dtype);
+    }
+
+    #[test]
+    fn list_dtype() {
+        let in_dtype = DType::List(
+            Arc::new(DType::Primitive(PType::I64, Nullability::NonNullable)),
+            Nullability::Nullable,
+        );
+        let packed_dtype = ident().return_dtype(&in_dtype).unwrap();
+        assert_eq!(packed_dtype, in_dtype);
     }
 }

--- a/vortex-expr/src/identity.rs
+++ b/vortex-expr/src/identity.rs
@@ -69,7 +69,6 @@ mod tests {
             Arc::new(DType::Primitive(PType::I64, Nullability::NonNullable)),
             Nullability::Nullable,
         );
-        let packed_dtype = ident().return_dtype(&in_dtype).unwrap();
-        assert_eq!(packed_dtype, in_dtype);
+        assert_eq!(ident().return_dtype(&in_dtype).unwrap(), in_dtype);
     }
 }

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -67,7 +67,7 @@ pub trait VortexExpr: Debug + Send + Sync + DynEq + DynHash + Display {
 
     /// Compute the type of the array returned by [VortexExpr::evaluate].
     fn return_dtype(&self, scope_dtype: &DType) -> VortexResult<DType> {
-        let empty = Canonical::empty(scope_dtype)?.into_array();
+        let empty = Canonical::empty(scope_dtype).into_array();
         self.unchecked_evaluate(&empty)
             .map(|array| array.dtype().clone())
     }

--- a/vortex-expr/src/pack.rs
+++ b/vortex-expr/src/pack.rs
@@ -213,26 +213,6 @@ mod tests {
     }
 
     #[test]
-    pub fn test_dtype_correct_nullability() {
-        let expr = Pack::try_new_expr(["one".into()].into(), vec![Identity::new_expr()]).unwrap();
-        let scope_dtype = &DType::List(
-            Arc::new(DType::Primitive(PType::I64, Nullability::NonNullable)),
-            Nullability::Nullable,
-        );
-        let packed_dtype = expr.return_dtype(scope_dtype).unwrap();
-        assert_eq!(
-            packed_dtype,
-            DType::Struct(
-                Arc::new(StructDType::new(
-                    ["one".into()].into(),
-                    vec![scope_dtype.clone()]
-                )),
-                Nullability::NonNullable,
-            ),
-        );
-    }
-
-    #[test]
     pub fn test_nested_pack() {
         let expr = Pack::try_new_expr(
             ["one".into(), "two".into(), "three".into()].into(),

--- a/vortex-expr/src/pack.rs
+++ b/vortex-expr/src/pack.rs
@@ -131,10 +131,10 @@ mod tests {
     use vortex_array::array::{PrimitiveArray, StructArray};
     use vortex_array::{ArrayData, IntoArrayData, IntoArrayVariant as _};
     use vortex_buffer::buffer;
-    use vortex_dtype::FieldNames;
+    use vortex_dtype::{DType, FieldNames, Nullability, PType, StructDType};
     use vortex_error::{vortex_bail, vortex_err, VortexResult};
 
-    use crate::{col, Pack, VortexExpr};
+    use crate::{col, Identity, Pack, VortexExpr};
 
     fn test_array() -> StructArray {
         StructArray::from_fields(&[
@@ -209,6 +209,26 @@ mod tests {
                 .unwrap()
                 .as_slice::<i32>(),
             [0, 1, 2]
+        );
+    }
+
+    #[test]
+    pub fn test_dtype_correct_nullability() {
+        let expr = Pack::try_new_expr(["one".into()].into(), vec![Identity::new_expr()]).unwrap();
+        let scope_dtype = &DType::List(
+            Arc::new(DType::Primitive(PType::I64, Nullability::NonNullable)),
+            Nullability::Nullable,
+        );
+        let packed_dtype = expr.return_dtype(scope_dtype).unwrap();
+        assert_eq!(
+            packed_dtype,
+            DType::Struct(
+                Arc::new(StructDType::new(
+                    ["one".into()].into(),
+                    vec![scope_dtype.clone()]
+                )),
+                Nullability::NonNullable,
+            ),
         );
     }
 

--- a/vortex-expr/src/pack.rs
+++ b/vortex-expr/src/pack.rs
@@ -131,10 +131,10 @@ mod tests {
     use vortex_array::array::{PrimitiveArray, StructArray};
     use vortex_array::{ArrayData, IntoArrayData, IntoArrayVariant as _};
     use vortex_buffer::buffer;
-    use vortex_dtype::{DType, FieldNames, Nullability, PType, StructDType};
+    use vortex_dtype::FieldNames;
     use vortex_error::{vortex_bail, vortex_err, VortexResult};
 
-    use crate::{col, Identity, Pack, VortexExpr};
+    use crate::{col, Pack, VortexExpr};
 
     fn test_array() -> StructArray {
         StructArray::from_fields(&[


### PR DESCRIPTION
Arrow Lists are nullable but elements of those lists are not. In `Identity::return_dtype`, previous behaviour returned `list(i64?)?` when given `list(i64)?`