### PR TITLE
bench: run benchmarks with thin-lto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,7 +231,6 @@ lto = "thin"      # attempts to perform optimizations across all crates within t
 
 [profile.bench]
 codegen-units = 16 # default for "release", which "bench" inherits
-lto = false        # default
 debug = true
 
 [profile.benchtest]


### PR DESCRIPTION
Enabling thin-lto for cargo bench targets makes the benchmarking setup consistent with how we do microbenchmarks in vortex-arrow, vortex-buffer as well as TPC-H and Clickbench.