### PR TITLE
perf: speed up dictionary encoding of primitives by ~2x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5419,6 +5419,7 @@ dependencies = [
  "criterion",
  "num-traits",
  "rand",
+ "rustc-hash",
  "serde",
  "vortex-array",
  "vortex-buffer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ rkyv = { version = "0.8", features = [
     "unaligned",
 ] }
 rstest = "0.24"
+rustc-hash = "2"
 serde = "1.0.197"
 serde_json = "1.0.116"
 serde_test = "1.0.176"

--- a/encodings/dict/Cargo.toml
+++ b/encodings/dict/Cargo.toml
@@ -15,6 +15,7 @@ readme = { workspace = true }
 
 [dependencies]
 arrow-buffer = { workspace = true }
+rustc-hash = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }
 vortex-array = { workspace = true }

--- a/encodings/dict/src/compress.rs
+++ b/encodings/dict/src/compress.rs
@@ -22,10 +22,9 @@ use crate::DictArray;
 pub const NULL_CODE: u64 = 0;
 
 mod private {
-    use vortex_dtype::half;
+    use vortex_dtype::{half, NativePType};
 
-    /// Value serves as a wrapper type to allow us to implement Hash and Eq on all of our
-    /// primitive types directly.
+    /// Value serves as a wrapper type to allow us to implement Hash and Eq on all primitive types.
     ///
     /// Rust does not define Hash/Eq for any of the float types due to the presence of
     /// NaN and +/- 0. We don't care about storing multiple NaNs or zeros in our dictionaries,
@@ -33,53 +32,48 @@ mod private {
     #[derive(Debug)]
     pub struct Value<T>(pub T);
 
-    macro_rules! prim_value_hash {
+    impl<T> PartialEq<Value<T>> for Value<T>
+    where
+        T: NativePType,
+    {
+        fn eq(&self, other: &Value<T>) -> bool {
+            self.0.is_eq(other.0)
+        }
+    }
+
+    impl<T> Eq for Value<T> where T: NativePType {}
+
+    macro_rules! prim_value {
         ($typ:ty) => {
             impl core::hash::Hash for Value<$typ> {
                 fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
                     self.0.hash(state);
                 }
             }
-
-            impl PartialEq<Self> for Value<$typ> {
-                fn eq(&self, other: &Self) -> bool {
-                    self.0.eq(&other.0)
-                }
-            }
-
-            impl Eq for Value<$typ> {}
         };
     }
 
-    macro_rules! float_value_hash {
+    macro_rules! float_value {
         ($typ:ty) => {
             impl core::hash::Hash for Value<$typ> {
                 fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
                     self.0.to_bits().hash(state);
                 }
             }
-
-            impl PartialEq<Self> for Value<$typ> {
-                fn eq(&self, other: &Self) -> bool {
-                    self.0.to_bits().eq(&other.0.to_bits())
-                }
-            }
-
-            impl Eq for Value<$typ> {}
         };
     }
 
-    prim_value_hash!(u8);
-    prim_value_hash!(u16);
-    prim_value_hash!(u32);
-    prim_value_hash!(u64);
-    prim_value_hash!(i8);
-    prim_value_hash!(i16);
-    prim_value_hash!(i32);
-    prim_value_hash!(i64);
-    float_value_hash!(half::f16);
-    float_value_hash!(f32);
-    float_value_hash!(f64);
+    prim_value!(u8);
+    prim_value!(u16);
+    prim_value!(u32);
+    prim_value!(u64);
+    prim_value!(i8);
+    prim_value!(i16);
+    prim_value!(i32);
+    prim_value!(i64);
+    float_value!(half::f16);
+    float_value!(f32);
+    float_value!(f64);
 }
 
 pub fn dict_encode(array: &ArrayData) -> VortexResult<DictArray> {

--- a/encodings/dict/src/compress.rs
+++ b/encodings/dict/src/compress.rs
@@ -1,6 +1,7 @@
-use std::hash::{BuildHasher, Hash, Hasher};
+use std::hash::{BuildHasher, Hash};
 
 use num_traits::AsPrimitive;
+use rustc_hash::FxBuildHasher;
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::aliases::hash_map::{DefaultHashBuilder, Entry, HashMap, HashTable, RandomState};
 use vortex_array::array::{
@@ -10,7 +11,7 @@ use vortex_array::validity::Validity;
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{ArrayData, IntoArrayData, IntoArrayVariant};
 use vortex_buffer::{BufferMut, ByteBufferMut};
-use vortex_dtype::{match_each_native_ptype, DType, NativePType, Nullability, PType, ToBytes};
+use vortex_dtype::{match_each_native_ptype, DType, NativePType, Nullability, PType};
 use vortex_error::{vortex_bail, VortexExpect as _, VortexResult, VortexUnwrap};
 use vortex_scalar::Scalar;
 use vortex_sparse::SparseArray;
@@ -20,22 +21,66 @@ use crate::DictArray;
 /// Statically assigned code for a null value.
 pub const NULL_CODE: u64 = 0;
 
-#[derive(Debug)]
-struct Value<T>(T);
+mod private {
+    use vortex_dtype::half;
 
-impl<T: ToBytes> Hash for Value<T> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.to_le_bytes().hash(state)
+    /// Value serves as a wrapper type to allow us to implement Hash and Eq on all of our
+    /// primitive types directly.
+    ///
+    /// Rust does not define Hash/Eq for any of the float types due to the presence of
+    /// NaN and +/- 0. We don't care about storing multiple NaNs or zeros in our dictionaries,
+    /// so we define simple bit-wise Hash/Eq for the Value-wrapped versions of these types.
+    #[derive(Debug)]
+    pub struct Value<T>(pub T);
+
+    macro_rules! prim_value_hash {
+        ($typ:ty) => {
+            impl core::hash::Hash for Value<$typ> {
+                fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+                    self.0.hash(state);
+                }
+            }
+
+            impl PartialEq<Self> for Value<$typ> {
+                fn eq(&self, other: &Self) -> bool {
+                    self.0.eq(&other.0)
+                }
+            }
+
+            impl Eq for Value<$typ> {}
+        };
     }
-}
 
-impl<T: ToBytes> PartialEq<Self> for Value<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.to_le_bytes().eq(other.0.to_le_bytes())
+    macro_rules! float_value_hash {
+        ($typ:ty) => {
+            impl core::hash::Hash for Value<$typ> {
+                fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+                    self.0.to_bits().hash(state);
+                }
+            }
+
+            impl PartialEq<Self> for Value<$typ> {
+                fn eq(&self, other: &Self) -> bool {
+                    self.0.to_bits().eq(&other.0.to_bits())
+                }
+            }
+
+            impl Eq for Value<$typ> {}
+        };
     }
-}
 
-impl<T: ToBytes> Eq for Value<T> {}
+    prim_value_hash!(u8);
+    prim_value_hash!(u16);
+    prim_value_hash!(u32);
+    prim_value_hash!(u64);
+    prim_value_hash!(i8);
+    prim_value_hash!(i16);
+    prim_value_hash!(i32);
+    prim_value_hash!(i64);
+    float_value_hash!(half::f16);
+    float_value_hash!(f32);
+    float_value_hash!(f64);
+}
 
 pub fn dict_encode(array: &ArrayData) -> VortexResult<DictArray> {
     let dict_builder: &mut dyn DictEncoder = if let Some(pa) = PrimitiveArray::maybe_from(array) {
@@ -62,12 +107,15 @@ pub trait DictEncoder {
 /// Dictionary encode primitive array with given PType.
 /// Null values in the original array are encoded in the dictionary.
 pub struct PrimitiveDictBuilder<T> {
-    lookup: HashMap<Value<T>, u64>,
+    lookup: HashMap<private::Value<T>, u64, FxBuildHasher>,
     values: BufferMut<T>,
     nullability: Nullability,
 }
 
-impl<T: NativePType> PrimitiveDictBuilder<T> {
+impl<T: NativePType> PrimitiveDictBuilder<T>
+where
+    private::Value<T>: Hash + Eq,
+{
     pub fn new(nullability: Nullability) -> Self {
         let mut values = BufferMut::<T>::empty();
 
@@ -76,7 +124,7 @@ impl<T: NativePType> PrimitiveDictBuilder<T> {
         };
 
         Self {
-            lookup: HashMap::new(),
+            lookup: HashMap::with_hasher(FxBuildHasher),
             values,
             nullability,
         }
@@ -84,7 +132,7 @@ impl<T: NativePType> PrimitiveDictBuilder<T> {
 
     #[inline]
     fn encode_value(&mut self, v: T) -> u64 {
-        match self.lookup.entry(Value(v)) {
+        match self.lookup.entry(private::Value(v)) {
             Entry::Occupied(o) => *o.get(),
             Entry::Vacant(vac) => {
                 let next_code = self.values.len() as u64;
@@ -96,7 +144,10 @@ impl<T: NativePType> PrimitiveDictBuilder<T> {
     }
 }
 
-impl<T: NativePType> DictEncoder for PrimitiveDictBuilder<T> {
+impl<T: NativePType> DictEncoder for PrimitiveDictBuilder<T>
+where
+    private::Value<T>: Hash + Eq,
+{
     fn encode_array(&mut self, array: &ArrayData) -> VortexResult<ArrayData> {
         if array.dtype().is_nullable() && self.nullability == Nullability::NonNullable {
             vortex_bail!("Cannot encode nullable array into non nullable dictionary")

--- a/pyvortex/test/bench.py
+++ b/pyvortex/test/bench.py
@@ -1,0 +1,50 @@
+"""
+Simple benchmarks
+"""
+import io
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+import vortex as vx
+
+
+@pytest.fixture(params=[10, 100])
+def vortex_array(request):
+    rows = []
+    for row in range(1_000):
+        r = {}
+        for col in range(request.param):
+            # Create large arrays of length 100 for each column.
+            r[f"col{col}"] = [1, 2, None, 4] * 25
+        rows.append(r)
+    return vx.array(rows)
+
+
+@pytest.fixture(params=[10, 100])
+def arrow_array(request):
+    rows = []
+    for row in range(1_000):
+        r = {}
+        for col in range(request.param):
+            # Create large arrays of length 100 for each column.
+            r[f"col{col}"] = [1, 2, None, 4] * 25
+        rows.append(r)
+    return pa.Table.from_pylist(rows)
+
+
+def test_compress_vortex(benchmark, vortex_array):
+    def compress():
+        vx.compress(vortex_array)
+
+    benchmark(compress)
+
+
+def test_compress_parquet(benchmark, arrow_array):
+    def compress():
+        # write to bytes in memory.
+        bout = io.BytesIO()
+        pq.write_table(arrow_array, bout)
+
+    benchmark(compress)

--- a/pyvortex/test/bench.py
+++ b/pyvortex/test/bench.py
@@ -1,6 +1,7 @@
 """
 Simple benchmarks
 """
+
 import io
 
 import pyarrow as pa

--- a/uv.lock
+++ b/uv.lock
@@ -142,7 +142,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -1326,7 +1326,7 @@ wheels = [
 
 [[package]]
 name = "vortex-array"
-version = "0.21.1"
+version = "0.22.1"
 source = { editable = "pyvortex" }
 dependencies = [
     { name = "pyarrow" },

--- a/uv.lock
+++ b/uv.lock
@@ -142,7 +142,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -1326,7 +1326,7 @@ wheels = [
 
 [[package]]
 name = "vortex-array"
-version = "0.22.1"
+version = "0.21.1"
 source = { editable = "pyvortex" }
 dependencies = [
     { name = "pyarrow" },

--- a/vortex-array/src/aliases/hash_map.rs
+++ b/vortex-array/src/aliases/hash_map.rs
@@ -1,6 +1,6 @@
 pub type DefaultHashBuilder = hashbrown::DefaultHashBuilder;
 pub type RandomState = hashbrown::DefaultHashBuilder;
-pub type HashMap<K, V> = hashbrown::HashMap<K, V>;
+pub type HashMap<K, V, S = DefaultHashBuilder> = hashbrown::HashMap<K, V, S>;
 pub type Entry<'a, K, V, S> = hashbrown::hash_map::Entry<'a, K, V, S>;
 pub type IntoIter<K, V> = hashbrown::hash_map::IntoIter<K, V>;
 pub type HashTable<T> = hashbrown::HashTable<T>;

--- a/vortex-cli/src/browse/mod.rs
+++ b/vortex-cli/src/browse/mod.rs
@@ -41,6 +41,26 @@ fn run(mut terminal: DefaultTerminal, mut app: AppState) -> VortexResult<()> {
                             app.layouts_list_state.scroll_down_by(1);
                         }
                     }
+                    KeyCode::PageUp => {
+                        if app.current_tab == Tab::Layout {
+                            app.layouts_list_state.scroll_up_by(10);
+                        }
+                    }
+                    KeyCode::PageDown => {
+                        if app.current_tab == Tab::Layout {
+                            app.layouts_list_state.scroll_down_by(10);
+                        }
+                    }
+                    KeyCode::Home => {
+                        if app.current_tab == Tab::Layout {
+                            app.layouts_list_state.select_first();
+                        }
+                    }
+                    KeyCode::End => {
+                        if app.current_tab == Tab::Layout {
+                            app.layouts_list_state.select_last();
+                        }
+                    }
                     KeyCode::Enter => {
                         if app.current_tab == Tab::Layout {
                             // Descend into the layout subtree for the selected child.


### PR DESCRIPTION
I was digging into perf on some simple Python compression benchmarks (see `bench.py`) and this particular array happened to choose Dictionary encoding.

Noticed that we were using this to_le_bytes thing to unify how we hash encode all of the primitive types. After some testing, it seems like doing hashing of fixed-size types is nearly 2x faster than doing the equivalent slice hashing, and the PartialEq check is also faster than comparing slices.


## Changes

This PR:

* Avoids going through `ToBytes` for hashing primitive types. Instead we directly hash the types
* switches `PrimitiveDictBuilder` to use `FxHash`, the hashing algorithm used by the rust compiler. I did not evaluate if this one works better overall but it seems substantially better for primitives.

After both of these changes, the benchmark execution improved by just over 20%

<img width="957" alt="image" src="https://github.com/user-attachments/assets/bae2aee6-83d6-4520-8425-4ae5b6769ce3" />


<img width="939" alt="image" src="https://github.com/user-attachments/assets/ea844be4-2403-4d1c-9b88-422a5f9ce4b8" />


<img width="2699" alt="image" src="https://github.com/user-attachments/assets/183c9a01-da52-4fa4-87e7-971ed25936bb" />

<img width="2699" alt="image" src="https://github.com/user-attachments/assets/8cced63e-7cc6-4099-948e-0e2a24b8310d" />

