### PR TITLE
chore: refresh uv's lock file

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -142,7 +142,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -1326,7 +1326,6 @@ wheels = [
 
 [[package]]
 name = "vortex-array"
-version = "0.22.1"
 source = { editable = "pyvortex" }
 dependencies = [
     { name = "pyarrow" },


### PR DESCRIPTION
uv 0.5 seems to resolve our lockfile slightly differently, which breaks the release 