### PR TITLE
feat: Add VortexFormatFactory to the datafusion integration

### DIFF
--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -10,7 +10,8 @@ use datafusion::execution::SessionState;
 use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_common::stats::Precision;
 use datafusion_common::{
-    not_impl_err, ColumnStatistics, DataFusionError, Result as DFResult, ScalarValue, Statistics,
+    not_impl_err, ColumnStatistics, DataFusionError, GetExt, Result as DFResult, ScalarValue,
+    Statistics,
 };
 use datafusion_expr::Expr;
 use datafusion_physical_expr::{LexRequirement, PhysicalExpr};
@@ -58,15 +59,23 @@ impl Default for VortexFormatOptions {
 }
 
 /// Minimal factory to create [`VortexFormat`] instances.
-struct VortexFormatFactory {}
+#[derive(Debug, Default)]
+pub struct VortexFormatFactory {}
+
+impl GetExt for VortexFormatFactory {
+    fn get_ext(&self) -> String {
+        VORTEX_FILE_EXTENSION.to_string()
+    }
+}
 
 impl FileFormatFactory for VortexFormatFactory {
+    #[allow(clippy::disallowed_types)]
     fn create(
         &self,
         _state: &SessionState,
         _format_options: &std::collections::HashMap<String, String>,
     ) -> DFResult<Arc<dyn FileFormat>> {
-        Ok(Arc::new(self.default()))
+        Ok(self.default())
     }
 
     fn default(&self) -> Arc<dyn FileFormat> {

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use arrow_schema::{Schema, SchemaRef};
 use async_trait::async_trait;
 use datafusion::datasource::file_format::file_compression_type::FileCompressionType;
-use datafusion::datasource::file_format::{FileFormat, FilePushdownSupport};
+use datafusion::datasource::file_format::{FileFormat, FileFormatFactory, FilePushdownSupport};
 use datafusion::datasource::physical_plan::{FileScanConfig, FileSinkConfig};
 use datafusion::execution::SessionState;
 use datafusion_common::parsers::CompressionTypeVariant;
@@ -54,6 +54,27 @@ impl Default for VortexFormatOptions {
             concurrent_infer_schema_ops: 64,
             cache_size_mb: 256,
         }
+    }
+}
+
+/// Minimal factory to create [`VortexFormat`] instances.
+struct VortexFormatFactory {}
+
+impl FileFormatFactory for VortexFormatFactory {
+    fn create(
+        &self,
+        _state: &SessionState,
+        _format_options: &std::collections::HashMap<String, String>,
+    ) -> DFResult<Arc<dyn FileFormat>> {
+        Ok(Arc::new(self.default()))
+    }
+
+    fn default(&self) -> Arc<dyn FileFormat> {
+        Arc::new(VortexFormat::default())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 


### PR DESCRIPTION
A piece of the `FileFormat` API, used to if we want to create a DataFusion session and execute DDL statements like:
```sql
CREATE EXTERNAL TABLE tbl
STORED AS VORTEX
LOCATION '/path/to/data';"
```