### PR TITLE
fix(tui): off-by-one in table constraints for stats table

### DIFF
--- a/vortex-tui/src/browse/ui/layouts.rs
+++ b/vortex-tui/src/browse/ui/layouts.rs
@@ -128,7 +128,8 @@ fn render_array(app: &AppState, area: Rect, buf: &mut Buffer, is_stats_table: bo
     if is_stats_table {
         // Render the stats table horizontally
         let struct_array = array.as_struct_array().vortex_expect("stats table");
-        let field_count = struct_array.nfields();
+        // add 1 for the chunk column
+        let field_count = struct_array.nfields() + 1;
         let header = std::iter::once("chunk")
             .chain(struct_array.names().iter().map(|x| x.as_ref()))
             .map(Cell::from)
@@ -158,7 +159,7 @@ fn render_array(app: &AppState, area: Rect, buf: &mut Buffer, is_stats_table: bo
         });
 
         Widget::render(
-            Table::new(rows, (0..field_count).map(|_| Constraint::Length(6))).header(header),
+            Table::new(rows, (0..field_count).map(|_| Constraint::Min(6))).header(header),
             widget_area,
             buf,
         );


### PR DESCRIPTION
New look:

<img width="1486" alt="image" src="https://github.com/user-attachments/assets/6f7182df-727d-4fcf-96be-dcd26a4b850f" />


Previously, the last `null_count` field was not being displayed.

I also boosted the layout constraint to let the table occupy more horizontal space rather than clipping to 6 chars per column