### PR TITLE
fix: Relock UV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,10 +79,6 @@ jobs:
           rm -rf .venv
           uv sync --only-dev
 
-          # Make sure the lockfile isn't dirty
-          git status --porcelain
-          test -z "$(git status --porcelain)"
-
           uv run pip install target/wheels/vortex_array-*.whl || { uv run pip debug --verbose ; exit 1 ; }
           uv run pip install pytest
           cd pyvortex/test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,10 @@ jobs:
           rm -rf .venv
           uv sync --only-dev
 
+          # Make sure the lockfile isn't dirty
+          git status --porcelain
+          test -z "$(git status --porcelain)"
+
           uv run pip install target/wheels/vortex_array-*.whl || { uv run pip debug --verbose ; exit 1 ; }
           uv run pip install pytest
           cd pyvortex/test

--- a/uv.lock
+++ b/uv.lock
@@ -1407,7 +1407,6 @@ wheels = [
 
 [[package]]
 name = "vortex-array"
-version = "0.23.0"
 source = { editable = "pyvortex" }
 dependencies = [
     { name = "pyarrow" },


### PR DESCRIPTION
seems like #2179 locked UV with an old version, so now release-plz fails because the lock file is dirty.