### PR TITLE
fix: adjust return type for `arrow_to_vortex` to `vortex.expr.Expr`

### DIFF
--- a/pyvortex/python/vortex/arrow/expression.py
+++ b/pyvortex/python/vortex/arrow/expression.py
@@ -6,7 +6,7 @@ import vortex.expr
 from vortex.substrait import extended_expression
 
 
-def arrow_to_vortex(arrow_expression: pc.Expression, schema: pa.Schema) -> list[vortex.expr.Expr]:
+def arrow_to_vortex(arrow_expression: pc.Expression, schema: pa.Schema) -> vortex.expr.Expr:
     substrait_object = ExtendedExpression()
     substrait_object.ParseFromString(arrow_expression.to_substrait(schema))
 


### PR DESCRIPTION
`pyright` flags a return type mismatch for `arrow_to_vortex`.

![image](https://github.com/user-attachments/assets/8462bf81-076f-44f8-8944-5cfcc248a9aa)

Based on the error message `arrow_to_vortex: extended expression must have exactly one child`, I'm assuming the intended return type here is `vortex.expr.Expr`.