### PR TITLE
feat: impl CompareFn for DateTimePartsEncoding

### DIFF
--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -1,0 +1,158 @@
+use vortex_array::array::ConstantArray;
+use vortex_array::compute::{and, compare, try_cast, CompareFn, Operator};
+use vortex_array::{Array, IntoArray};
+use vortex_datetime_dtype::TemporalMetadata;
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+
+use crate::array::{DateTimePartsArray, DateTimePartsEncoding};
+use crate::timestamp;
+
+impl CompareFn<DateTimePartsArray> for DateTimePartsEncoding {
+    /// Compares two arrays and returns a new boolean array with the result of the comparison.
+    /// Or, returns None if comparison is not supported.
+    ///
+    /// # NOTE: Only `Operator::Eq` is currently supported.
+    fn compare(
+        &self,
+        lhs: &DateTimePartsArray,
+        rhs: &Array,
+        operator: Operator,
+    ) -> VortexResult<Option<Array>> {
+        if operator != Operator::Eq {
+            return Ok(None);
+        }
+
+        let Some(rhs_const) = rhs.as_constant() else {
+            return Ok(None);
+        };
+        let Ok(Some(timestamp)) = rhs_const
+            .as_extension()
+            .storage()
+            .as_primitive()
+            .as_::<i64>()
+        else {
+            return Ok(None);
+        };
+
+        let DType::Extension(ext_dtype) = rhs_const.dtype() else {
+            return Ok(None);
+        };
+
+        let temporal_metadata = TemporalMetadata::try_from(ext_dtype.as_ref())?;
+        let ts_parts = timestamp::split(timestamp, temporal_metadata.time_unit())?;
+
+        let compare_dtp = |lhs: &Array, rhs: i64, operator: Operator| -> VortexResult<Array> {
+            match try_cast(ConstantArray::new(rhs, lhs.len()), lhs.dtype()) {
+                Ok(casted) => compare(lhs, casted, operator),
+                Err(_) => {
+                    let constant_value = match operator {
+                        Operator::Eq | Operator::Lt | Operator::Lte => false,
+                        Operator::NotEq | Operator::Gt | Operator::Gte => true,
+                    };
+                    Ok(ConstantArray::new(constant_value, lhs.len()).into_array())
+                }
+            }
+        };
+
+        let mut comparison = compare_dtp(&lhs.days(), ts_parts.days, operator)?;
+        // Prefer `compute_max::<bool>` over `compute_true_count` as it ignores `Null`.
+        if comparison.statistics().compute_max::<bool>() == Some(false) {
+            return Ok(Some(comparison));
+        }
+
+        comparison = and(
+            compare_dtp(&lhs.seconds(), ts_parts.seconds, operator)?,
+            comparison,
+        )?;
+
+        if comparison.statistics().compute_max::<bool>() == Some(false) {
+            return Ok(Some(comparison));
+        }
+
+        comparison = and(
+            compare_dtp(&lhs.subseconds(), ts_parts.subseconds, operator)?,
+            comparison,
+        )?;
+
+        return Ok(Some(comparison));
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use vortex_array::array::{PrimitiveArray, TemporalArray};
+    use vortex_array::compute::Operator;
+    use vortex_array::validity::Validity;
+    use vortex_array::IntoArray;
+    use vortex_buffer::buffer;
+    use vortex_datetime_dtype::{TimeUnit, TIME_ID};
+    use vortex_dtype::{ExtDType, NativePType, Nullability, PType};
+
+    use super::*;
+
+    fn dtp_array() -> DateTimePartsArray {
+        DateTimePartsArray::try_new(
+            DType::Extension(Arc::new(ExtDType::new(
+                TIME_ID.clone(),
+                Arc::new(DType::Primitive(PType::I64, Nullability::NonNullable)),
+                Some(TemporalMetadata::Time(TimeUnit::S).into()),
+            ))),
+            buffer![1i64].into_array(),
+            buffer![0i64].into_array(),
+            buffer![0i64].into_array(),
+        )
+        .unwrap()
+    }
+
+    fn dtp_array_from_timestamp<T: NativePType>(value: T) -> DateTimePartsArray {
+        DateTimePartsArray::try_from(TemporalArray::new_timestamp(
+            PrimitiveArray::new(buffer![value], Validity::NonNullable).into_array(),
+            TimeUnit::S,
+            Some("UTC".to_string()),
+        ))
+        .expect("Failed to construct DateTimePartsArray from TemporalArray")
+    }
+
+    #[test]
+    fn compare_date_time_parts_equal() {
+        let lhs = dtp_array_from_timestamp(86400i64); // January 2, 1970, 00:00:00 UTC
+        let rhs = dtp_array_from_timestamp(86400i64); // January 2, 1970, 00:00:00 UTC
+        let comparison = DateTimePartsEncoding
+            .compare(&lhs, &rhs, Operator::Eq)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 1);
+
+        let rhs = dtp_array(); // January 2, 1970, 00:00:00 UTC
+        let comparison = DateTimePartsEncoding
+            .compare(&lhs, &rhs, Operator::Eq)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 1);
+    }
+
+    #[test]
+    fn compare_date_time_parts_not_equal() {
+        let lhs = dtp_array_from_timestamp(0i64); // January 1, 1970, 00:00:00 UTC
+        let rhs = dtp_array_from_timestamp(86400i64); // January 2, 1970, 00:00:00 UTC
+        let comparison = DateTimePartsEncoding
+            .compare(&lhs, &rhs, Operator::Eq)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 0);
+
+        let rhs = dtp_array(); // January 2, 1970, 00:00:00 UTC
+        let comparison = DateTimePartsEncoding
+            .compare(&lhs, &rhs, Operator::Eq)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 0);
+    }
+}

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -75,7 +75,7 @@ impl CompareFn<DateTimePartsArray> for DateTimePartsEncoding {
             comparison,
         )?;
 
-        return Ok(Some(comparison));
+        Ok(Some(comparison))
     }
 }
 

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -45,10 +45,11 @@ impl CompareFn<DateTimePartsArray> for DateTimePartsEncoding {
         let compare_dtp = |lhs: &Array, rhs: i64, operator: Operator| -> VortexResult<Array> {
             match try_cast(ConstantArray::new(rhs, lhs.len()), lhs.dtype()) {
                 Ok(casted) => compare(lhs, casted, operator),
+                // The narrowing cast failed. Therefore, attempt to derive the result from the operator.
                 Err(_) => {
                     let constant_value = match operator {
-                        Operator::Eq | Operator::Lt | Operator::Lte => false,
-                        Operator::NotEq | Operator::Gt | Operator::Gte => true,
+                        Operator::Eq => false,
+                        _ => unreachable!("operator {} not supported", operator),
                     };
                     Ok(ConstantArray::new(constant_value, lhs.len()).into_array())
                 }

--- a/encodings/datetime-parts/src/lib.rs
+++ b/encodings/datetime-parts/src/lib.rs
@@ -6,3 +6,4 @@ mod canonical;
 mod compress;
 mod compute;
 mod stats;
+mod timestamp;

--- a/encodings/datetime-parts/src/stats.rs
+++ b/encodings/datetime-parts/src/stats.rs
@@ -9,6 +9,11 @@ impl StatisticsVTable<DateTimePartsArray> for DateTimePartsEncoding {
     fn compute_statistics(&self, array: &DateTimePartsArray, stat: Stat) -> VortexResult<StatsSet> {
         let maybe_stat = match stat {
             Stat::NullCount => Some(ScalarValue::from(array.null_count()?)),
+            Stat::IsConstant => Some(ScalarValue::from(
+                array.days().is_constant()
+                    && array.seconds().is_constant()
+                    && array.subseconds().is_constant(),
+            )),
             _ => None,
         };
 

--- a/encodings/datetime-parts/src/timestamp.rs
+++ b/encodings/datetime-parts/src/timestamp.rs
@@ -1,0 +1,188 @@
+use vortex_datetime_dtype::TimeUnit;
+use vortex_error::{vortex_bail, VortexResult};
+
+pub const SECONDS_PER_DAY: i64 = 86_400; // 24 * 60 * 60
+
+/// Parts of a Unix timestamp (time since 1970-01-01 00:00:00 UTC).
+///
+/// Broken down into:
+///  * Days since epoch
+///  * Seconds within day (0-86399)
+///  * Subseconds (range depends on `TimeUnit`)
+pub struct TimestampParts {
+    pub days: i64,
+    pub seconds: i64,
+    pub subseconds: i64,
+}
+
+/// Splits a Unix timestamp into its component parts.
+///
+/// # Arguments
+///
+/// * `timestamp` - Number of time units since the Unix epoch
+/// * `time_unit` - Precision of the timestamp (ns, μs, ms, or s)
+///
+/// # Errors
+///
+/// Returns an error if `time_unit` is days, which cannot be split.
+pub fn split(timestamp: i64, time_unit: TimeUnit) -> VortexResult<TimestampParts> {
+    let divisor = match time_unit {
+        TimeUnit::Ns => 1_000_000_000,
+        TimeUnit::Us => 1_000_000,
+        TimeUnit::Ms => 1_000,
+        TimeUnit::S => 1,
+        TimeUnit::D => vortex_bail!("Cannot handle day-level data"),
+    };
+
+    let ticks_per_day = SECONDS_PER_DAY * divisor;
+    Ok(TimestampParts {
+        days: timestamp / ticks_per_day,
+        seconds: (timestamp % ticks_per_day) / divisor,
+        subseconds: (timestamp % ticks_per_day) % divisor,
+    })
+}
+
+/// Combines timestamp parts back into a Unix timestamp.
+///
+/// # Arguments
+///
+/// * `parts` - Component parts of the timestamp (days, seconds, subseconds)
+/// * `time_unit` - Precision of the timestamp (ns, μs, ms, or s)
+///
+/// # Errors
+///
+/// Returns an error if `time_unit` is days, which cannot be combined.
+pub fn combine(ts_parts: TimestampParts, time_unit: TimeUnit) -> VortexResult<i64> {
+    let divisor = match time_unit {
+        TimeUnit::Ns => 1_000_000_000,
+        TimeUnit::Us => 1_000_000,
+        TimeUnit::Ms => 1_000,
+        TimeUnit::S => 1,
+        TimeUnit::D => vortex_bail!("Cannot handle day-level data"),
+    };
+
+    Ok(
+        ts_parts.days * SECONDS_PER_DAY * divisor
+            + ts_parts.seconds * divisor
+            + ts_parts.subseconds,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_seconds() {
+        // 1970-01-02 01:02:03 UTC
+        let ts = SECONDS_PER_DAY + 3723; // 1 day + (1*3600 + 2*60 + 3) seconds
+        let parts = split(ts, TimeUnit::S).unwrap();
+        assert_eq!(parts.days, 1);
+        assert_eq!(parts.seconds, 3723);
+        assert_eq!(parts.subseconds, 0);
+    }
+
+    #[test]
+    fn test_split_milliseconds() {
+        // 1970-01-02 01:02:03.456 UTC
+        let ts = (SECONDS_PER_DAY + 3723) * 1000 + 456;
+        let parts = split(ts, TimeUnit::Ms).unwrap();
+        assert_eq!(parts.days, 1);
+        assert_eq!(parts.seconds, 3723);
+        assert_eq!(parts.subseconds, 456);
+    }
+
+    #[test]
+    fn test_split_microseconds() {
+        // 1970-01-02 01:02:03.456789 UTC
+        let ts = (SECONDS_PER_DAY + 3723) * 1_000_000 + 456789;
+        let parts = split(ts, TimeUnit::Us).unwrap();
+        assert_eq!(parts.days, 1);
+        assert_eq!(parts.seconds, 3723);
+        assert_eq!(parts.subseconds, 456789);
+    }
+
+    #[test]
+    fn test_split_nanoseconds() {
+        // 1970-01-02 01:02:03.456789123 UTC
+        let ts = (SECONDS_PER_DAY + 3723) * 1_000_000_000 + 456789123;
+        let parts = split(ts, TimeUnit::Ns).unwrap();
+        assert_eq!(parts.days, 1);
+        assert_eq!(parts.seconds, 3723);
+        assert_eq!(parts.subseconds, 456789123);
+    }
+
+    #[test]
+    fn test_split_epoch() {
+        let ts = 0;
+        for unit in [TimeUnit::S, TimeUnit::Ms, TimeUnit::Us, TimeUnit::Ns] {
+            let parts = split(ts, unit).unwrap();
+            assert_eq!(parts.days, 0);
+            assert_eq!(parts.seconds, 0);
+            assert_eq!(parts.subseconds, 0);
+        }
+    }
+
+    #[test]
+    fn test_split_days_error() {
+        assert!(split(1, TimeUnit::D).is_err());
+    }
+
+    #[test]
+    fn test_combine_seconds() {
+        // 1970-01-02 01:02:03 UTC
+        let parts = TimestampParts {
+            days: 1,
+            seconds: 3723, // 1*3600 + 2*60 + 3
+            subseconds: 0,
+        };
+        let ts = combine(parts, TimeUnit::S).unwrap();
+        assert_eq!(ts, SECONDS_PER_DAY + 3723);
+    }
+
+    #[test]
+    fn test_combine_milliseconds() {
+        // 1970-01-02 01:02:03.456 UTC
+        let parts = TimestampParts {
+            days: 1,
+            seconds: 3723,
+            subseconds: 456,
+        };
+        let ts = combine(parts, TimeUnit::Ms).unwrap();
+        assert_eq!(ts, (SECONDS_PER_DAY + 3723) * 1000 + 456);
+    }
+
+    #[test]
+    fn test_combine_microseconds() {
+        // 1970-01-02 01:02:03.456789 UTC
+        let parts = TimestampParts {
+            days: 1,
+            seconds: 3723,
+            subseconds: 456789,
+        };
+        let ts = combine(parts, TimeUnit::Us).unwrap();
+        assert_eq!(ts, (SECONDS_PER_DAY + 3723) * 1_000_000 + 456789);
+    }
+
+    #[test]
+    fn test_combine_nanoseconds() {
+        // 1970-01-02 01:02:03.456789123 UTC
+        let parts = TimestampParts {
+            days: 1,
+            seconds: 3723,
+            subseconds: 456789123,
+        };
+        let ts = combine(parts, TimeUnit::Ns).unwrap();
+        assert_eq!(ts, (SECONDS_PER_DAY + 3723) * 1_000_000_000 + 456789123);
+    }
+
+    #[test]
+    fn test_combine_days_error() {
+        let parts = TimestampParts {
+            days: 1,
+            seconds: 0,
+            subseconds: 0,
+        };
+        assert!(combine(parts, TimeUnit::D).is_err());
+    }
+}


### PR DESCRIPTION
This PR implements `CompareFn<DateTimePartsArray> for DateTimePartsEncoding`. 
As a start, only `Operator::Eq` is covered. Further operators will be implemented in follow ups.

In addition, it extracts shared timestamp logic into a separate module.