### PR TITLE
feat: `Lte`, `Gte` & `NotEq` operators for `DateTimePartsEncoding`

### DIFF
--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -89,22 +89,7 @@ fn compare_lte(
         return Ok(Some(days_lt));
     }
 
-    let days_eq = compare_dtp(&lhs.days(), ts_parts.days, Operator::Eq)?;
-    if days_lt.statistics().compute_max::<bool>() == Some(false)
-        && days_eq.statistics().compute_max::<bool>() == Some(false)
-    {
-        // All values on the lhs are larger.
-        return Ok(Some(days_lt));
-    }
-
-    let sec_lt = compare_dtp(&lhs.seconds(), ts_parts.seconds, Operator::Lt)?;
-    let sec_eq = compare_dtp(&lhs.seconds(), ts_parts.seconds, Operator::Eq)?;
-    let sub_lte = compare_dtp(&lhs.subseconds(), ts_parts.subseconds, Operator::Lte)?;
-
-    // (days_lhs, seconds_lhs, sub_lhs) <= (days_rhs, seconds_rhs, sub_rhs)
-    let result = or(days_lt, and(days_eq, or(sec_lt, and(sec_eq, sub_lte)?)?)?)?;
-
-    Ok(Some(result))
+    Ok(None)
 }
 
 fn compare_gte(
@@ -117,22 +102,7 @@ fn compare_gte(
         return Ok(Some(days_gt));
     }
 
-    let days_eq = compare_dtp(&lhs.days(), ts_parts.days, Operator::Eq)?;
-    if days_gt.statistics().compute_max::<bool>() == Some(false)
-        && days_eq.statistics().compute_max::<bool>() == Some(false)
-    {
-        // All values on the lhs are smaller.
-        return Ok(Some(days_gt));
-    }
-
-    let sec_gt = compare_dtp(&lhs.seconds(), ts_parts.seconds, Operator::Gt)?;
-    let sec_eq = compare_dtp(&lhs.seconds(), ts_parts.seconds, Operator::Eq)?;
-    let sub_gte = compare_dtp(&lhs.subseconds(), ts_parts.subseconds, Operator::Gte)?;
-
-    // (days_lhs, seconds_lhs, sub_lhs) >= (days_rhs, seconds_rhs, sub_rhs)
-    let result = or(days_gt, and(days_eq, or(sec_gt, and(sec_eq, sub_gte)?)?)?)?;
-
-    Ok(Some(result))
+    Ok(None)
 }
 
 impl CompareFn<DateTimePartsArray> for DateTimePartsEncoding {

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -140,11 +140,11 @@ fn compare_gte(
 fn compare_dtp(lhs: &Array, rhs: i64, operator: Operator) -> VortexResult<Array> {
     match try_cast(ConstantArray::new(rhs, lhs.len()), lhs.dtype()) {
         Ok(casted) => compare(lhs, casted, operator),
-        // The narrowing cast failed. Derive the result from the operator.
+        // The narrowing cast failed. Therefore, we know rhs > lhs.
         _ => {
             let constant_value = match operator {
-                Operator::Eq | Operator::Lte => false,
-                Operator::NotEq | Operator::Gte => true,
+                Operator::Eq | Operator::Gte => false,
+                Operator::NotEq | Operator::Lte => true,
                 _ => unreachable!("operator {} not supported", operator),
             };
             Ok(ConstantArray::new(constant_value, lhs.len()).into_array())

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -143,9 +143,8 @@ fn compare_dtp(lhs: &Array, rhs: i64, operator: Operator) -> VortexResult<Array>
         // The narrowing cast failed. Therefore, we know lhs < rhs.
         _ => {
             let constant_value = match operator {
-                Operator::Eq | Operator::Gte => false,
-                Operator::NotEq | Operator::Lte => true,
-                _ => unreachable!("operator {} not supported", operator),
+                Operator::Eq | Operator::Gte | Operator::Gt => false,
+                Operator::NotEq | Operator::Lte | Operator::Lt => true,
             };
             Ok(ConstantArray::new(constant_value, lhs.len()).into_array())
         }
@@ -228,6 +227,44 @@ mod test {
 
         let comparison = DateTimePartsEncoding
             .compare(&lhs, &rhs, Operator::Gte)
+            .unwrap()
+            .unwrap();
+        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 1);
+    }
+
+    #[test]
+    fn compare_date_time_parts_narrowing() {
+        let temporal_array = TemporalArray::new_timestamp(
+            PrimitiveArray::new(buffer![0i64], Validity::NonNullable).into_array(),
+            TimeUnit::S,
+            Some("UTC".to_string()),
+        );
+
+        let lhs = DateTimePartsArray::try_new(
+            DType::Extension(temporal_array.ext_dtype()),
+            PrimitiveArray::new(buffer![0i32], Validity::NonNullable).into_array(),
+            PrimitiveArray::new(buffer![0u32], Validity::NonNullable).into_array(),
+            PrimitiveArray::new(buffer![0i64], Validity::NonNullable).into_array(),
+        )
+        .unwrap();
+
+        // Timestamp with a value larger than i32::MAX.
+        let rhs = dtp_array_from_timestamp(i64::MAX);
+
+        let comparison = DateTimePartsEncoding
+            .compare(&lhs, &rhs, Operator::Eq)
+            .unwrap()
+            .unwrap();
+        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 0);
+
+        let comparison = DateTimePartsEncoding
+            .compare(&lhs, &rhs, Operator::NotEq)
+            .unwrap()
+            .unwrap();
+        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 1);
+
+        let comparison = DateTimePartsEncoding
+            .compare(&lhs, &rhs, Operator::Lte)
             .unwrap()
             .unwrap();
         assert_eq!(comparison.statistics().compute_true_count().unwrap(), 1);

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -11,7 +11,7 @@ use crate::timestamp;
 fn compare_dtp(lhs: &Array, rhs: i64, operator: Operator) -> VortexResult<Array> {
     match try_cast(ConstantArray::new(rhs, lhs.len()), lhs.dtype()) {
         Ok(casted) => compare(lhs, casted, operator),
-        // The narrowing cast failed. Therefore, attempt to derive the result from the operator.
+        // The narrowing cast failed. Derive the result from the operator.
         _ => {
             let constant_value = match operator {
                 Operator::Eq | Operator::Lte => false,

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -211,7 +211,7 @@ mod test {
 
     #[test]
     fn compare_date_time_parts_lte() {
-        let lhs = dtp_array_from_timestamp(86400i64); // January 2, 1970, 00:00:00 UTC
+        let lhs = dtp_array_from_timestamp(0i64); // January 1, 1970, 01:00:00 UTC
         let rhs = dtp_array_from_timestamp(86400i64); // January 2, 1970, 00:00:00 UTC
 
         let comparison = DateTimePartsEncoding
@@ -219,49 +219,17 @@ mod test {
             .unwrap()
             .unwrap();
         assert_eq!(comparison.statistics().compute_true_count().unwrap(), 1);
-
-        let lhs = dtp_array_from_timestamp(86400i64 + 3600i64); // January 2, 1970, 01:00:01 UTC
-        let rhs = dtp_array_from_timestamp(86400i64 + 7200i64); // January 2, 1970, 02:00:00 UTC
-
-        let comparison = DateTimePartsEncoding
-            .compare(&lhs, &rhs, Operator::Lte)
-            .unwrap()
-            .unwrap();
-        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 1);
-
-        // Swap the operands to test the reverse.
-        let comparison = DateTimePartsEncoding
-            .compare(&rhs, &lhs, Operator::Lte)
-            .unwrap()
-            .unwrap();
-        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 0);
     }
 
     #[test]
     fn compare_date_time_parts_gte() {
-        let lhs = dtp_array_from_timestamp(86400i64); // January 2, 1970, 00:00:00 UTC
-        let rhs = dtp_array_from_timestamp(86400i64); // January 2, 1970, 00:00:00 UTC
+        let lhs = dtp_array_from_timestamp(86400i64); // January 2, 1970, 02:00:00 UTC
+        let rhs = dtp_array_from_timestamp(0i64); // January 1, 1970, 01:00:00 UTC
 
         let comparison = DateTimePartsEncoding
             .compare(&lhs, &rhs, Operator::Gte)
             .unwrap()
             .unwrap();
         assert_eq!(comparison.statistics().compute_true_count().unwrap(), 1);
-
-        let lhs = dtp_array_from_timestamp(86400i64 + 7200i64); // January 2, 1970, 02:00:00 UTC
-        let rhs = dtp_array_from_timestamp(86400i64 + 3600i64); // January 2, 1970, 01:00:00 UTC
-
-        let comparison = DateTimePartsEncoding
-            .compare(&lhs, &rhs, Operator::Gte)
-            .unwrap()
-            .unwrap();
-        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 1);
-
-        // Swap the operands to test the reverse.
-        let comparison = DateTimePartsEncoding
-            .compare(&rhs, &lhs, Operator::Gte)
-            .unwrap()
-            .unwrap();
-        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 0);
     }
 }

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -140,7 +140,7 @@ fn compare_gte(
 fn compare_dtp(lhs: &Array, rhs: i64, operator: Operator) -> VortexResult<Array> {
     match try_cast(ConstantArray::new(rhs, lhs.len()), lhs.dtype()) {
         Ok(casted) => compare(lhs, casted, operator),
-        // The narrowing cast failed. Therefore, we know rhs > lhs.
+        // The narrowing cast failed. Therefore, we know lhs < rhs.
         _ => {
             let constant_value = match operator {
                 Operator::Eq | Operator::Gte => false,

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -1,5 +1,5 @@
 use vortex_array::array::ConstantArray;
-use vortex_array::compute::{and, compare, try_cast, CompareFn, Operator};
+use vortex_array::compute::{and, compare, or, try_cast, CompareFn, Operator};
 use vortex_array::{Array, IntoArray};
 use vortex_datetime_dtype::TemporalMetadata;
 use vortex_dtype::DType;
@@ -8,18 +8,148 @@ use vortex_error::VortexResult;
 use crate::array::{DateTimePartsArray, DateTimePartsEncoding};
 use crate::timestamp;
 
+fn compare_dtp(lhs: &Array, rhs: i64, operator: Operator) -> VortexResult<Array> {
+    match try_cast(ConstantArray::new(rhs, lhs.len()), lhs.dtype()) {
+        Ok(casted) => compare(lhs, casted, operator),
+        // The narrowing cast failed. Therefore, attempt to derive the result from the operator.
+        _ => {
+            let constant_value = match operator {
+                Operator::Eq | Operator::Lte => false,
+                Operator::NotEq | Operator::Gte => true,
+                _ => unreachable!("operator {} not supported", operator),
+            };
+            Ok(ConstantArray::new(constant_value, lhs.len()).into_array())
+        }
+    }
+}
+
+fn compare_eq(
+    lhs: &DateTimePartsArray,
+    ts_parts: &timestamp::TimestampParts,
+) -> VortexResult<Option<Array>> {
+    let mut comparison = compare_dtp(&lhs.days(), ts_parts.days, Operator::Eq)?;
+    if comparison.statistics().compute_max::<bool>() == Some(false) {
+        // All values are different.
+        return Ok(Some(comparison));
+    }
+
+    comparison = and(
+        compare_dtp(&lhs.seconds(), ts_parts.seconds, Operator::Eq)?,
+        comparison,
+    )?;
+
+    if comparison.statistics().compute_max::<bool>() == Some(false) {
+        // All values are different.
+        return Ok(Some(comparison));
+    }
+
+    comparison = and(
+        compare_dtp(&lhs.subseconds(), ts_parts.subseconds, Operator::Eq)?,
+        comparison,
+    )?;
+
+    Ok(Some(comparison))
+}
+
+fn compare_ne(
+    lhs: &DateTimePartsArray,
+    ts_parts: &timestamp::TimestampParts,
+) -> VortexResult<Option<Array>> {
+    let mut comparison = compare_dtp(&lhs.days(), ts_parts.days, Operator::NotEq)?;
+    if comparison.statistics().compute_min::<bool>() == Some(true) {
+        // All values are different.
+        return Ok(Some(comparison));
+    }
+
+    comparison = or(
+        compare_dtp(&lhs.seconds(), ts_parts.seconds, Operator::NotEq)?,
+        comparison,
+    )?;
+
+    if comparison.statistics().compute_min::<bool>() == Some(true) {
+        // All values are different.
+        return Ok(Some(comparison));
+    }
+
+    comparison = or(
+        compare_dtp(&lhs.subseconds(), ts_parts.subseconds, Operator::NotEq)?,
+        comparison,
+    )?;
+
+    Ok(Some(comparison))
+}
+
+fn compare_lte(
+    lhs: &DateTimePartsArray,
+    ts_parts: &timestamp::TimestampParts,
+) -> VortexResult<Option<Array>> {
+    let days_lt = compare_dtp(&lhs.days(), ts_parts.days, Operator::Lt)?;
+    if days_lt.statistics().compute_min::<bool>() == Some(true) {
+        // All values on the lhs are smaller.
+        return Ok(Some(days_lt));
+    }
+
+    let days_eq = compare_dtp(&lhs.days(), ts_parts.days, Operator::Eq)?;
+    if days_lt.statistics().compute_max::<bool>() == Some(false)
+        && days_eq.statistics().compute_max::<bool>() == Some(false)
+    {
+        // All values on the lhs are larger.
+        return Ok(Some(days_lt));
+    }
+
+    let sec_lt = compare_dtp(&lhs.seconds(), ts_parts.seconds, Operator::Lt)?;
+    let sec_eq = compare_dtp(&lhs.seconds(), ts_parts.seconds, Operator::Eq)?;
+    let sub_lte = compare_dtp(&lhs.subseconds(), ts_parts.subseconds, Operator::Lte)?;
+
+    // (days_lhs, seconds_lhs, sub_lhs) <= (days_rhs, seconds_rhs, sub_rhs)
+    let result = or(days_lt, and(days_eq, or(sec_lt, and(sec_eq, sub_lte)?)?)?)?;
+
+    Ok(Some(result))
+}
+
+fn compare_gte(
+    lhs: &DateTimePartsArray,
+    ts_parts: &timestamp::TimestampParts,
+) -> VortexResult<Option<Array>> {
+    let days_gt = compare_dtp(&lhs.days(), ts_parts.days, Operator::Gt)?;
+    if days_gt.statistics().compute_min::<bool>() == Some(true) {
+        // All values on the lhs are larger.
+        return Ok(Some(days_gt));
+    }
+
+    let days_eq = compare_dtp(&lhs.days(), ts_parts.days, Operator::Eq)?;
+    if days_gt.statistics().compute_max::<bool>() == Some(false)
+        && days_eq.statistics().compute_max::<bool>() == Some(false)
+    {
+        // All values on the lhs are smaller.
+        return Ok(Some(days_gt));
+    }
+
+    let sec_gt = compare_dtp(&lhs.seconds(), ts_parts.seconds, Operator::Gt)?;
+    let sec_eq = compare_dtp(&lhs.seconds(), ts_parts.seconds, Operator::Eq)?;
+    let sub_gte = compare_dtp(&lhs.subseconds(), ts_parts.subseconds, Operator::Gte)?;
+
+    // (days_lhs, seconds_lhs, sub_lhs) >= (days_rhs, seconds_rhs, sub_rhs)
+    let result = or(days_gt, and(days_eq, or(sec_gt, and(sec_eq, sub_gte)?)?)?)?;
+
+    Ok(Some(result))
+}
+
 impl CompareFn<DateTimePartsArray> for DateTimePartsEncoding {
     /// Compares two arrays and returns a new boolean array with the result of the comparison.
     /// Or, returns None if comparison is not supported.
     ///
-    /// # NOTE: Only `Operator::Eq` is currently supported.
+    /// # NOTE: `Operator::Lt` and `Operator::Gt` are currently not supported.
     fn compare(
         &self,
         lhs: &DateTimePartsArray,
         rhs: &Array,
         operator: Operator,
     ) -> VortexResult<Option<Array>> {
-        if operator != Operator::Eq {
+        if !matches!(
+            operator,
+            Operator::Eq | Operator::NotEq | Operator::Lte | Operator::Gte
+        ) {
             return Ok(None);
         }
 
@@ -42,71 +172,27 @@ impl CompareFn<DateTimePartsArray> for DateTimePartsEncoding {
         let temporal_metadata = TemporalMetadata::try_from(ext_dtype.as_ref())?;
         let ts_parts = timestamp::split(timestamp, temporal_metadata.time_unit())?;
 
-        let compare_dtp = |lhs: &Array, rhs: i64, operator: Operator| -> VortexResult<Array> {
-            match try_cast(ConstantArray::new(rhs, lhs.len()), lhs.dtype()) {
-                Ok(casted) => compare(lhs, casted, operator),
-                // The narrowing cast failed. Therefore, attempt to derive the result from the operator.
-                Err(_) => {
-                    let constant_value = match operator {
-                        Operator::Eq => false,
-                        _ => unreachable!("operator {} not supported", operator),
-                    };
-                    Ok(ConstantArray::new(constant_value, lhs.len()).into_array())
-                }
-            }
-        };
-
-        let mut comparison = compare_dtp(&lhs.days(), ts_parts.days, operator)?;
-        // Prefer `compute_max::<bool>` over `compute_true_count` as it ignores `Null`.
-        if comparison.statistics().compute_max::<bool>() == Some(false) {
-            return Ok(Some(comparison));
+        match operator {
+            Operator::Eq => compare_eq(lhs, &ts_parts),
+            Operator::NotEq => compare_ne(lhs, &ts_parts),
+            Operator::Lte => compare_lte(lhs, &ts_parts),
+            Operator::Gte => compare_gte(lhs, &ts_parts),
+            _ => unreachable!("operator {} not supported", operator),
         }
-
-        comparison = and(
-            compare_dtp(&lhs.seconds(), ts_parts.seconds, operator)?,
-            comparison,
-        )?;
-
-        if comparison.statistics().compute_max::<bool>() == Some(false) {
-            return Ok(Some(comparison));
-        }
-
-        comparison = and(
-            compare_dtp(&lhs.subseconds(), ts_parts.subseconds, operator)?,
-            comparison,
-        )?;
-
-        Ok(Some(comparison))
     }
 }
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
-
     use vortex_array::array::{PrimitiveArray, TemporalArray};
     use vortex_array::compute::Operator;
     use vortex_array::validity::Validity;
     use vortex_array::IntoArray;
     use vortex_buffer::buffer;
-    use vortex_datetime_dtype::{TimeUnit, TIME_ID};
-    use vortex_dtype::{ExtDType, NativePType, Nullability, PType};
+    use vortex_datetime_dtype::TimeUnit;
+    use vortex_dtype::NativePType;
 
     use super::*;
-
-    fn dtp_array() -> DateTimePartsArray {
-        DateTimePartsArray::try_new(
-            DType::Extension(Arc::new(ExtDType::new(
-                TIME_ID.clone(),
-                Arc::new(DType::Primitive(PType::I64, Nullability::NonNullable)),
-                Some(TemporalMetadata::Time(TimeUnit::S).into()),
-            ))),
-            buffer![1i64].into_array(),
-            buffer![0i64].into_array(),
-            buffer![0i64].into_array(),
-        )
-        .unwrap()
-    }
 
     fn dtp_array_from_timestamp<T: NativePType>(value: T) -> DateTimePartsArray {
         DateTimePartsArray::try_from(TemporalArray::new_timestamp(
@@ -118,42 +204,94 @@ mod test {
     }
 
     #[test]
-    fn compare_date_time_parts_equal() {
+    fn compare_date_time_parts_eq() {
         let lhs = dtp_array_from_timestamp(86400i64); // January 2, 1970, 00:00:00 UTC
         let rhs = dtp_array_from_timestamp(86400i64); // January 2, 1970, 00:00:00 UTC
         let comparison = DateTimePartsEncoding
             .compare(&lhs, &rhs, Operator::Eq)
             .unwrap()
             .unwrap();
-
         assert_eq!(comparison.statistics().compute_true_count().unwrap(), 1);
 
-        let rhs = dtp_array(); // January 2, 1970, 00:00:00 UTC
+        let rhs = dtp_array_from_timestamp(0i64); // January 1, 1970, 00:00:00 UTC
         let comparison = DateTimePartsEncoding
             .compare(&lhs, &rhs, Operator::Eq)
             .unwrap()
             .unwrap();
-
-        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 1);
+        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 0);
     }
 
     #[test]
-    fn compare_date_time_parts_not_equal() {
-        let lhs = dtp_array_from_timestamp(0i64); // January 1, 1970, 00:00:00 UTC
+    fn compare_date_time_parts_ne() {
+        let lhs = dtp_array_from_timestamp(86400i64); // January 2, 1970, 00:00:00 UTC
+        let rhs = dtp_array_from_timestamp(86401i64); // January 2, 1970, 00:00:01 UTC
+        let comparison = DateTimePartsEncoding
+            .compare(&lhs, &rhs, Operator::NotEq)
+            .unwrap()
+            .unwrap();
+        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 1);
+
         let rhs = dtp_array_from_timestamp(86400i64); // January 2, 1970, 00:00:00 UTC
         let comparison = DateTimePartsEncoding
-            .compare(&lhs, &rhs, Operator::Eq)
+            .compare(&lhs, &rhs, Operator::NotEq)
             .unwrap()
             .unwrap();
-
         assert_eq!(comparison.statistics().compute_true_count().unwrap(), 0);
+    }
 
-        let rhs = dtp_array(); // January 2, 1970, 00:00:00 UTC
+    #[test]
+    fn compare_date_time_parts_lte() {
+        let lhs = dtp_array_from_timestamp(86400i64); // January 2, 1970, 00:00:00 UTC
+        let rhs = dtp_array_from_timestamp(86400i64); // January 2, 1970, 00:00:00 UTC
+
         let comparison = DateTimePartsEncoding
-            .compare(&lhs, &rhs, Operator::Eq)
+            .compare(&lhs, &rhs, Operator::Lte)
             .unwrap()
             .unwrap();
+        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 1);
 
+        let lhs = dtp_array_from_timestamp(86400i64 + 3600i64); // January 2, 1970, 01:00:01 UTC
+        let rhs = dtp_array_from_timestamp(86400i64 + 7200i64); // January 2, 1970, 02:00:00 UTC
+
+        let comparison = DateTimePartsEncoding
+            .compare(&lhs, &rhs, Operator::Lte)
+            .unwrap()
+            .unwrap();
+        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 1);
+
+        // Swap the operands to test the reverse.
+        let comparison = DateTimePartsEncoding
+            .compare(&rhs, &lhs, Operator::Lte)
+            .unwrap()
+            .unwrap();
+        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 0);
+    }
+
+    #[test]
+    fn compare_date_time_parts_gte() {
+        let lhs = dtp_array_from_timestamp(86400i64); // January 2, 1970, 00:00:00 UTC
+        let rhs = dtp_array_from_timestamp(86400i64); // January 2, 1970, 00:00:00 UTC
+
+        let comparison = DateTimePartsEncoding
+            .compare(&lhs, &rhs, Operator::Gte)
+            .unwrap()
+            .unwrap();
+        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 1);
+
+        let lhs = dtp_array_from_timestamp(86400i64 + 7200i64); // January 2, 1970, 02:00:00 UTC
+        let rhs = dtp_array_from_timestamp(86400i64 + 3600i64); // January 2, 1970, 01:00:00 UTC
+
+        let comparison = DateTimePartsEncoding
+            .compare(&lhs, &rhs, Operator::Gte)
+            .unwrap()
+            .unwrap();
+        assert_eq!(comparison.statistics().compute_true_count().unwrap(), 1);
+
+        // Swap the operands to test the reverse.
+        let comparison = DateTimePartsEncoding
+            .compare(&rhs, &lhs, Operator::Gte)
+            .unwrap()
+            .unwrap();
         assert_eq!(comparison.statistics().compute_true_count().unwrap(), 0);
     }
 }

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -268,5 +268,8 @@ mod test {
             .unwrap()
             .unwrap();
         assert_eq!(comparison.statistics().compute_true_count().unwrap(), 1);
+
+        // `compare_gte` only covers the case of all lhs values being larger.
+        // Therefore it is not unit tested here.
     }
 }

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -8,17 +8,49 @@ use vortex_error::VortexResult;
 use crate::array::{DateTimePartsArray, DateTimePartsEncoding};
 use crate::timestamp;
 
-fn compare_dtp(lhs: &Array, rhs: i64, operator: Operator) -> VortexResult<Array> {
-    match try_cast(ConstantArray::new(rhs, lhs.len()), lhs.dtype()) {
-        Ok(casted) => compare(lhs, casted, operator),
-        // The narrowing cast failed. Derive the result from the operator.
-        _ => {
-            let constant_value = match operator {
-                Operator::Eq | Operator::Lte => false,
-                Operator::NotEq | Operator::Gte => true,
-                _ => unreachable!("operator {} not supported", operator),
-            };
-            Ok(ConstantArray::new(constant_value, lhs.len()).into_array())
+impl CompareFn<DateTimePartsArray> for DateTimePartsEncoding {
+    /// Compares two arrays and returns a new boolean array with the result of the comparison.
+    /// Or, returns None if comparison is not supported.
+    ///
+    /// # NOTE: `Operator::Lt` and `Operator::Gt` are currently not supported.
+    fn compare(
+        &self,
+        lhs: &DateTimePartsArray,
+        rhs: &Array,
+        operator: Operator,
+    ) -> VortexResult<Option<Array>> {
+        if !matches!(
+            operator,
+            Operator::Eq | Operator::NotEq | Operator::Lte | Operator::Gte
+        ) {
+            return Ok(None);
+        }
+
+        let Some(rhs_const) = rhs.as_constant() else {
+            return Ok(None);
+        };
+        let Ok(Some(timestamp)) = rhs_const
+            .as_extension()
+            .storage()
+            .as_primitive()
+            .as_::<i64>()
+        else {
+            return Ok(None);
+        };
+
+        let DType::Extension(ext_dtype) = rhs_const.dtype() else {
+            return Ok(None);
+        };
+
+        let temporal_metadata = TemporalMetadata::try_from(ext_dtype.as_ref())?;
+        let ts_parts = timestamp::split(timestamp, temporal_metadata.time_unit())?;
+
+        match operator {
+            Operator::Eq => compare_eq(lhs, &ts_parts),
+            Operator::NotEq => compare_ne(lhs, &ts_parts),
+            Operator::Lte => compare_lte(lhs, &ts_parts),
+            Operator::Gte => compare_gte(lhs, &ts_parts),
+            _ => unreachable!("operator {} not supported", operator),
         }
     }
 }
@@ -105,49 +137,17 @@ fn compare_gte(
     Ok(None)
 }
 
-impl CompareFn<DateTimePartsArray> for DateTimePartsEncoding {
-    /// Compares two arrays and returns a new boolean array with the result of the comparison.
-    /// Or, returns None if comparison is not supported.
-    ///
-    /// # NOTE: `Operator::Lt` and `Operator::Gt` are currently not supported.
-    fn compare(
-        &self,
-        lhs: &DateTimePartsArray,
-        rhs: &Array,
-        operator: Operator,
-    ) -> VortexResult<Option<Array>> {
-        if !matches!(
-            operator,
-            Operator::Eq | Operator::NotEq | Operator::Lte | Operator::Gte
-        ) {
-            return Ok(None);
-        }
-
-        let Some(rhs_const) = rhs.as_constant() else {
-            return Ok(None);
-        };
-        let Ok(Some(timestamp)) = rhs_const
-            .as_extension()
-            .storage()
-            .as_primitive()
-            .as_::<i64>()
-        else {
-            return Ok(None);
-        };
-
-        let DType::Extension(ext_dtype) = rhs_const.dtype() else {
-            return Ok(None);
-        };
-
-        let temporal_metadata = TemporalMetadata::try_from(ext_dtype.as_ref())?;
-        let ts_parts = timestamp::split(timestamp, temporal_metadata.time_unit())?;
-
-        match operator {
-            Operator::Eq => compare_eq(lhs, &ts_parts),
-            Operator::NotEq => compare_ne(lhs, &ts_parts),
-            Operator::Lte => compare_lte(lhs, &ts_parts),
-            Operator::Gte => compare_gte(lhs, &ts_parts),
-            _ => unreachable!("operator {} not supported", operator),
+fn compare_dtp(lhs: &Array, rhs: i64, operator: Operator) -> VortexResult<Array> {
+    match try_cast(ConstantArray::new(rhs, lhs.len()), lhs.dtype()) {
+        Ok(casted) => compare(lhs, casted, operator),
+        // The narrowing cast failed. Derive the result from the operator.
+        _ => {
+            let constant_value = match operator {
+                Operator::Eq | Operator::Lte => false,
+                Operator::NotEq | Operator::Gte => true,
+                _ => unreachable!("operator {} not supported", operator),
+            };
+            Ok(ConstantArray::new(constant_value, lhs.len()).into_array())
         }
     }
 }


### PR DESCRIPTION
This PR implements `Lte`, `Gte` and `NotEq` operators for `DateTimePartsEncoding`.  As part of that, it factors out each operator evaluation into a separate function.