### PR TITLE
expr.transform is actually post-order transform

### DIFF
--- a/vortex-expr/src/traversal/mod.rs
+++ b/vortex-expr/src/traversal/mod.rs
@@ -217,7 +217,7 @@ impl Node for ExprRef {
         visitor.visit_up(self, context, children)
     }
 
-    // A pre-order transform, with an option to ignore sub-tress (using visit_down).
+    // A post-order transform, with an option to ignore sub-tress (using visit_down).
     fn transform<V: MutNodeVisitor<NodeTy = Self>>(
         self,
         visitor: &mut V,


### PR DESCRIPTION
mutable node visitor mutates on visit_up and can skip on visit down