### PR TITLE
retry R2 downloads in benchmarks

### DIFF
--- a/bench-vortex/src/bin/clickbench.rs
+++ b/bench-vortex/src/bin/clickbench.rs
@@ -68,10 +68,7 @@ fn main() {
         idempotent(&output_path, |output_path| {
             eprintln!("Downloading file {idx}");
             let url = format!("https://pub-3ba949c0f0354ac18db1f0f14f0a2c52.r2.dev/clickbench/parquet_many/hits_{idx}.parquet");
-
-
             let make_req = || reqwest::blocking::get(&url);
-
             let mut output = None;
 
             for attempt in 1..4 {
@@ -81,7 +78,7 @@ fn main() {
                           break;
                     },
                     Err(e) => {
-                        eprintln!("Request timed out, retying for the {attempt} time");
+                        eprintln!("Request for file {idx} timed out, retying for the {attempt} time");
                         output = Some(Err(e));
                     }
                 }

--- a/bench-vortex/src/bin/clickbench.rs
+++ b/bench-vortex/src/bin/clickbench.rs
@@ -60,6 +60,7 @@ fn main() {
     }
     .expect("Failed building the Runtime");
     let basepath = "clickbench".to_data_path();
+    let client = reqwest::blocking::Client::default();
 
     // The clickbench-provided file is missing some higher-level type info, so we reprocess it
     // to add that info, see https://github.com/ClickHouse/ClickBench/issues/7.
@@ -68,7 +69,7 @@ fn main() {
         idempotent(&output_path, |output_path| {
             eprintln!("Downloading file {idx}");
             let url = format!("https://pub-3ba949c0f0354ac18db1f0f14f0a2c52.r2.dev/clickbench/parquet_many/hits_{idx}.parquet");
-            let client = reqwest::blocking::Client::default();
+
 
             let make_req = || client.get(&url).send();
             let mut output = None;

--- a/bench-vortex/src/bin/clickbench.rs
+++ b/bench-vortex/src/bin/clickbench.rs
@@ -68,7 +68,9 @@ fn main() {
         idempotent(&output_path, |output_path| {
             eprintln!("Downloading file {idx}");
             let url = format!("https://pub-3ba949c0f0354ac18db1f0f14f0a2c52.r2.dev/clickbench/parquet_many/hits_{idx}.parquet");
-            let make_req = || reqwest::blocking::get(&url);
+            let client = reqwest::blocking::Client::default();
+
+            let make_req = || client.get(&url).send();
             let mut output = None;
 
             for attempt in 1..4 {

--- a/bench-vortex/src/bin/clickbench.rs
+++ b/bench-vortex/src/bin/clickbench.rs
@@ -1,7 +1,6 @@
 #![feature(exit_status_error)]
 
-use std::fs::{self, OpenOptions};
-use std::io::Write;
+use std::fs::{self, File};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -18,7 +17,7 @@ use itertools::Itertools;
 use log::LevelFilter;
 use rayon::iter::{IntoParallelIterator, ParallelIterator as _};
 use tokio::runtime::Builder;
-use vortex::error::vortex_panic;
+use vortex::error::{vortex_panic, VortexExpect};
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -69,12 +68,31 @@ fn main() {
         idempotent(&output_path, |output_path| {
             eprintln!("Downloading file {idx}");
             let url = format!("https://pub-3ba949c0f0354ac18db1f0f14f0a2c52.r2.dev/clickbench/parquet_many/hits_{idx}.parquet");
-            let r = reqwest::blocking::get(url)?.error_for_status()?;
-            let body = r.bytes()?;
 
-            let mut file = OpenOptions::new().create_new(true).write(true).open(output_path)?;
-            file.write_all(body.as_ref())?;
-            file.flush()?;
+
+            let make_req = || reqwest::blocking::get(&url);
+
+            let mut output = None;
+
+            for attempt in 1..4 {
+                match make_req() {
+                    Ok(r) => {
+                          output = Some(r.error_for_status());
+                          break;
+                    },
+                    Err(e) => {
+                        eprintln!("Request timed out, retying for the {attempt} time");
+                        output = Some(Err(e));
+                    }
+                }
+
+                // Very basic backoff mechanism
+                std::thread::sleep(Duration::from_secs(attempt));
+            }
+
+            let mut response = output.vortex_expect("Must have value here")?;
+            let mut file = File::create(output_path)?;
+            response.copy_to(&mut file)?;
 
             anyhow::Ok(PathBuf::from(output_path))
         })


### PR DESCRIPTION
already saw one timeout in a `develop` run, so this is an attempt in making it slightly more robust.