### PR TITLE
feat: lift comparison to constant null to the top-level

### DIFF
--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -3,7 +3,7 @@ use vortex_array::compute::{and, compare, or, try_cast, CompareFn, Operator};
 use vortex_array::{Array, IntoArray};
 use vortex_datetime_dtype::TemporalMetadata;
 use vortex_dtype::DType;
-use vortex_error::VortexResult;
+use vortex_error::{VortexExpect as _, VortexResult};
 
 use crate::array::{DateTimePartsArray, DateTimePartsEncoding};
 use crate::timestamp;
@@ -29,11 +29,12 @@ impl CompareFn<DateTimePartsArray> for DateTimePartsEncoding {
         let Some(rhs_const) = rhs.as_constant() else {
             return Ok(None);
         };
-        let Ok(Some(timestamp)) = rhs_const
+        let Ok(timestamp) = rhs_const
             .as_extension()
             .storage()
             .as_primitive()
             .as_::<i64>()
+            .map(|maybe_value| maybe_value.vortex_expect("null scalar handled in top-level"))
         else {
             return Ok(None);
         };

--- a/encodings/fsst/src/compute/compare.rs
+++ b/encodings/fsst/src/compute/compare.rs
@@ -1,11 +1,10 @@
 use fsst::Symbol;
 use vortex_array::array::ConstantArray;
 use vortex_array::compute::{compare, CompareFn, Operator};
-use vortex_array::{Array, IntoArray, IntoArrayVariant};
+use vortex_array::{Array, IntoArrayVariant};
 use vortex_buffer::ByteBuffer;
-use vortex_dtype::{DType, Nullability};
+use vortex_dtype::DType;
 use vortex_error::{VortexExpect, VortexResult};
-use vortex_scalar::Scalar;
 
 use crate::{FSSTArray, FSSTEncoding};
 
@@ -17,13 +16,6 @@ impl CompareFn<FSSTArray> for FSSTEncoding {
         operator: Operator,
     ) -> VortexResult<Option<Array>> {
         match (rhs.as_constant(), operator) {
-            (Some(constant), _) if constant.is_null() => {
-                // All comparisons to null must return null
-                Ok(Some(
-                    ConstantArray::new(Scalar::null(DType::Bool(Nullability::Nullable)), lhs.len())
-                        .into_array(),
-                ))
-            }
             (Some(constant), Operator::Eq | Operator::NotEq) => compare_fsst_constant(
                 lhs,
                 &ConstantArray::new(constant, lhs.len()),

--- a/vortex-array/src/array/varbin/compute/compare.rs
+++ b/vortex-array/src/array/varbin/compute/compare.rs
@@ -4,7 +4,7 @@ use arrow_ord::cmp;
 use itertools::Itertools;
 use num_traits::Zero;
 use vortex_dtype::{match_each_native_ptype, DType, NativePType};
-use vortex_error::{vortex_bail, vortex_err, VortexResult};
+use vortex_error::{vortex_bail, vortex_err, VortexExpect as _, VortexResult};
 
 use crate::array::{BoolArray, PrimitiveArray, VarBinArray, VarBinEncoding};
 use crate::arrow::{from_arrow_array_with_len, Datum};
@@ -26,12 +26,18 @@ impl CompareFn<VarBinArray> for VarBinEncoding {
 
             let rhs_is_empty = match rhs_const.dtype() {
                 DType::Utf8(_) => {
-                    let v = rhs_const.as_utf8().value();
-                    v.is_some_and(|v| v.is_empty())
+                    let v = rhs_const
+                        .as_utf8()
+                        .value()
+                        .vortex_expect("null scalar handled in top-level");
+                    v.is_empty()
                 }
                 DType::Binary(_) => {
-                    let v = rhs_const.as_binary().value();
-                    v.is_some_and(|v| v.is_empty())
+                    let v = rhs_const
+                        .as_binary()
+                        .value()
+                        .vortex_expect("null scalar handled in top-level");
+                    v.is_empty()
                 }
                 _ => vortex_bail!(
                     "VarBin array RHS can only be Utf8 or Binary, given {}",

--- a/vortex-array/src/compute/compare.rs
+++ b/vortex-array/src/compute/compare.rs
@@ -6,6 +6,7 @@ use vortex_dtype::{DType, Nullability};
 use vortex_error::{vortex_bail, VortexError, VortexResult};
 use vortex_scalar::Scalar;
 
+use crate::array::ConstantArray;
 use crate::arrow::{from_arrow_array_with_len, Datum};
 use crate::encoding::Encoding;
 use crate::{Array, Canonical, IntoArray};
@@ -115,6 +116,12 @@ pub fn compare(
 
     if left.is_empty() {
         return Ok(Canonical::empty(&result_dtype).into_array());
+    }
+
+    let left_constant_null = left.as_constant().map(|l| l.is_null()).unwrap_or(false);
+    let right_constant_null = right.as_constant().map(|r| r.is_null()).unwrap_or(false);
+    if left_constant_null || right_constant_null {
+        return Ok(ConstantArray::new(Scalar::null(result_dtype), left.len()).into_array());
     }
 
     // Always try to put constants on the right-hand side so encodings can optimise themselves.


### PR DESCRIPTION
This seems to be in the spirit of handling common cases at the top-level and making assumptions in compute methods. This might avoid decompression into arrow for arrays that do not currently support comparisons. That said, I doubt this appears in the wild. I imagine all query engines can do this optimization themselves.