### PR TITLE
Per `VortexReadAt` coalescing window

### DIFF
--- a/vortex-file/src/io/file.rs
+++ b/vortex-file/src/io/file.rs
@@ -63,6 +63,7 @@ impl<R: VortexReadAt> IoDriver for FileIoDriver<R> {
         stream: impl Stream<Item = SegmentRequest> + 'static,
     ) -> impl Stream<Item = VortexResult<()>> + 'static {
         // We map the segment requests to their respective locations within the file.
+        let coalescing_window = self.read.performance_hint().coalescing_window();
         let segment_map = self.file_layout.segment_map().clone();
         let stream = stream.filter_map(move |request| {
             let segment_map = segment_map.clone();
@@ -128,7 +129,7 @@ impl<R: VortexReadAt> IoDriver for FileIoDriver<R> {
 
         // Coalesce the segment requests to minimize the number of I/O operations.
         let stream = stream
-            .map(|r| coalesce(r, R::COALESCE_WINDOW))
+            .map(move |r| coalesce(r, coalescing_window))
             .flat_map(stream::iter);
 
         // Submit the coalesced requests to the I/O.

--- a/vortex-file/src/io/file.rs
+++ b/vortex-file/src/io/file.rs
@@ -127,7 +127,9 @@ impl<R: VortexReadAt> IoDriver for FileIoDriver<R> {
             .inspect(|requests| log::debug!("Processing {} segment requests", requests.len()));
 
         // Coalesce the segment requests to minimize the number of I/O operations.
-        let stream = stream.map(coalesce).flat_map(stream::iter);
+        let stream = stream
+            .map(|r| coalesce(r, R::COALESCE_WINDOW))
+            .flat_map(stream::iter);
 
         // Submit the coalesced requests to the I/O.
         let read = self.read.clone();
@@ -221,13 +223,15 @@ async fn evaluate<R: VortexReadAt>(
 }
 
 /// TODO(ngates): outsource coalescing to a trait
-fn coalesce(requests: Vec<FileSegmentRequest>) -> Vec<CoalescedSegmentRequest> {
-    const COALESCE: u64 = 1024 * 1024; // 1MB
+fn coalesce(
+    requests: Vec<FileSegmentRequest>,
+    coalescing_window: u64,
+) -> Vec<CoalescedSegmentRequest> {
     let fetch_ranges = merge_ranges(
         requests
             .iter()
             .map(|r| r.location.offset..r.location.offset + r.location.length as u64),
-        COALESCE,
+        coalescing_window,
     );
     let mut coalesced = fetch_ranges
         .iter()
@@ -239,7 +243,7 @@ fn coalesce(requests: Vec<FileSegmentRequest>) -> Vec<CoalescedSegmentRequest> {
 
     for req in requests {
         let idx = fetch_ranges.partition_point(|v| v.start <= req.location.offset) - 1;
-        coalesced.as_mut_slice()[idx].requests.push(req);
+        coalesced[idx].requests.push(req);
     }
 
     // Ensure we sort the requests by segment ID within the coalesced request.

--- a/vortex-io/src/compio.rs
+++ b/vortex-io/src/compio.rs
@@ -10,6 +10,7 @@ use vortex_error::VortexUnwrap;
 use crate::VortexReadAt;
 
 impl VortexReadAt for File {
+    const COALESCE_WINDOW: u64 = 0;
     fn read_byte_range(
         &self,
         pos: u64,

--- a/vortex-io/src/compio.rs
+++ b/vortex-io/src/compio.rs
@@ -10,7 +10,6 @@ use vortex_error::VortexUnwrap;
 use crate::VortexReadAt;
 
 impl VortexReadAt for File {
-    const COALESCE_WINDOW: u64 = 0;
     fn read_byte_range(
         &self,
         pos: u64,

--- a/vortex-io/src/offset.rs
+++ b/vortex-io/src/offset.rs
@@ -4,7 +4,7 @@ use std::io;
 use bytes::Bytes;
 use futures::FutureExt;
 
-use crate::VortexReadAt;
+use crate::{PerformanceHint, VortexReadAt};
 
 /// An adapter that offsets all reads by a fixed amount.
 pub struct OffsetReadAt<R> {
@@ -39,7 +39,7 @@ impl<R: VortexReadAt> VortexReadAt for OffsetReadAt<R> {
         self.read.read_byte_range(pos + self.offset, len)
     }
 
-    fn performance_hint(&self) -> usize {
+    fn performance_hint(&self) -> PerformanceHint {
         self.read.performance_hint()
     }
 

--- a/vortex-io/src/read.rs
+++ b/vortex-io/src/read.rs
@@ -13,6 +13,9 @@ use vortex_error::{vortex_err, VortexUnwrap};
 ///
 /// Readers must be cheaply cloneable to allow for easy sharing across tasks or threads.
 pub trait VortexReadAt: Send + Sync + Clone + 'static {
+    /// The maximum byte distance between ranges that should be considered for coalescing into a single request.
+    /// As a general guideline, should be higher for higher latency storage backends.
+    const COALESCE_WINDOW: u64 = 2 << 20; // 1MB
     /// Request an asynchronous positional read. Results will be returned as a [`Bytes`].
     ///
     /// If the reader does not have the requested number of bytes, the returned Future will complete
@@ -42,6 +45,7 @@ pub trait VortexReadAt: Send + Sync + Clone + 'static {
 }
 
 impl<T: VortexReadAt> VortexReadAt for Arc<T> {
+    const COALESCE_WINDOW: u64 = T::COALESCE_WINDOW;
     fn read_byte_range(
         &self,
         pos: u64,
@@ -60,6 +64,7 @@ impl<T: VortexReadAt> VortexReadAt for Arc<T> {
 }
 
 impl VortexReadAt for Bytes {
+    const COALESCE_WINDOW: u64 = 0;
     fn read_byte_range(
         &self,
         pos: u64,
@@ -82,6 +87,7 @@ impl VortexReadAt for Bytes {
 }
 
 impl VortexReadAt for ByteBuffer {
+    const COALESCE_WINDOW: u64 = 0;
     fn read_byte_range(
         &self,
         pos: u64,

--- a/vortex-io/src/read.rs
+++ b/vortex-io/src/read.rs
@@ -13,9 +13,6 @@ use vortex_error::{vortex_err, VortexUnwrap};
 ///
 /// Readers must be cheaply cloneable to allow for easy sharing across tasks or threads.
 pub trait VortexReadAt: Send + Sync + Clone + 'static {
-    /// The maximum byte distance between ranges that should be considered for coalescing into a single request.
-    /// As a general guideline, should be higher for higher latency storage backends.
-    const COALESCE_WINDOW: u64 = 2 << 20; // 1MB
     /// Request an asynchronous positional read. Results will be returned as a [`Bytes`].
     ///
     /// If the reader does not have the requested number of bytes, the returned Future will complete
@@ -33,8 +30,8 @@ pub trait VortexReadAt: Send + Sync + Clone + 'static {
 
     // TODO(ngates): the read implementation should be able to hint at its latency/throughput
     //  allowing the caller to make better decisions about how to coalesce reads.
-    fn performance_hint(&self) -> usize {
-        0
+    fn performance_hint(&self) -> PerformanceHint {
+        PerformanceHint::default()
     }
 
     /// Asynchronously get the number of bytes of data readable.
@@ -44,8 +41,35 @@ pub trait VortexReadAt: Send + Sync + Clone + 'static {
     fn size(&self) -> impl Future<Output = io::Result<u64>> + 'static;
 }
 
+pub struct PerformanceHint {
+    coalescing_window: u64,
+}
+
+impl Default for PerformanceHint {
+    fn default() -> Self {
+        Self {
+            coalescing_window: 2 << 20, //1MB,
+        }
+    }
+}
+
+impl PerformanceHint {
+    pub fn new(coalescing_window: u64) -> Self {
+        Self { coalescing_window }
+    }
+
+    /// Creates a new instance with a profile appropriate for fast local storage, like memory or files on NVMe devices.
+    pub fn local() -> Self {
+        Self::new(0)
+    }
+
+    /// The maximum distance between two reads that should coalesced into a single operation.
+    pub fn coalescing_window(&self) -> u64 {
+        self.coalescing_window
+    }
+}
+
 impl<T: VortexReadAt> VortexReadAt for Arc<T> {
-    const COALESCE_WINDOW: u64 = T::COALESCE_WINDOW;
     fn read_byte_range(
         &self,
         pos: u64,
@@ -54,7 +78,7 @@ impl<T: VortexReadAt> VortexReadAt for Arc<T> {
         T::read_byte_range(self, pos, len)
     }
 
-    fn performance_hint(&self) -> usize {
+    fn performance_hint(&self) -> PerformanceHint {
         T::performance_hint(self)
     }
 
@@ -64,7 +88,6 @@ impl<T: VortexReadAt> VortexReadAt for Arc<T> {
 }
 
 impl VortexReadAt for Bytes {
-    const COALESCE_WINDOW: u64 = 0;
     fn read_byte_range(
         &self,
         pos: u64,
@@ -84,10 +107,13 @@ impl VortexReadAt for Bytes {
     fn size(&self) -> impl Future<Output = io::Result<u64>> + 'static {
         ready(Ok(self.len() as u64))
     }
+
+    fn performance_hint(&self) -> PerformanceHint {
+        PerformanceHint::local()
+    }
 }
 
 impl VortexReadAt for ByteBuffer {
-    const COALESCE_WINDOW: u64 = 0;
     fn read_byte_range(
         &self,
         pos: u64,
@@ -102,6 +128,10 @@ impl VortexReadAt for ByteBuffer {
             )));
         }
         ready(Ok(self.slice(read_start..read_end).into_inner()))
+    }
+
+    fn performance_hint(&self) -> PerformanceHint {
+        PerformanceHint::local()
     }
 
     fn size(&self) -> impl Future<Output = io::Result<u64>> + 'static {

--- a/vortex-io/src/tokio.rs
+++ b/vortex-io/src/tokio.rs
@@ -60,6 +60,7 @@ impl Deref for TokioFile {
 }
 
 impl VortexReadAt for TokioFile {
+    const COALESCE_WINDOW: u64 = 0;
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     fn read_byte_range(
         &self,

--- a/vortex-io/src/tokio.rs
+++ b/vortex-io/src/tokio.rs
@@ -10,7 +10,7 @@ use bytes::{Bytes, BytesMut};
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use vortex_error::VortexUnwrap;
 
-use crate::{IoBuf, VortexReadAt, VortexWrite};
+use crate::{IoBuf, PerformanceHint, VortexReadAt, VortexWrite};
 
 pub struct TokioAdapter<IO>(pub IO);
 
@@ -60,7 +60,6 @@ impl Deref for TokioFile {
 }
 
 impl VortexReadAt for TokioFile {
-    const COALESCE_WINDOW: u64 = 0;
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     fn read_byte_range(
         &self,
@@ -81,6 +80,10 @@ impl VortexReadAt for TokioFile {
         let this = self.clone();
 
         async move { this.metadata().map(|metadata| metadata.len()) }
+    }
+
+    fn performance_hint(&self) -> PerformanceHint {
+        PerformanceHint::local()
     }
 }
 


### PR DESCRIPTION
Introduces a new `PerformanceHint` struct that can have more knobs in the future, and configure it for each `VortexReadAt` implementation we have.