### PR TITLE
feat: Feature flag allocators for benchmarks

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -60,6 +60,7 @@ jobs:
 
           cargo criterion \
                 --bench ${{ matrix.benchmark.id }} \
+                --features mimalloc
                 --message-format=json \
             > ${{ matrix.benchmark.id }}-raw.json
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -65,6 +65,7 @@ jobs:
 
           cargo criterion \
                 --bench ${{ matrix.benchmark.id }} \
+                --features mimalloc
                 --message-format=json \
             > ${{ matrix.benchmark.id }}-raw.json
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "bzip2",
+ "cfg-if",
  "clap",
  "criterion",
  "datafusion",
@@ -505,6 +506,7 @@ dependencies = [
  "simplelog",
  "tabled",
  "tar",
+ "tikv-jemallocator",
  "tokio",
  "uuid",
  "vortex",
@@ -1818,7 +1820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2584,7 +2586,7 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2637,7 +2639,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3770,7 +3772,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4111,7 +4113,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4653,7 +4655,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4734,6 +4736,26 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "ordered-float",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -5837,7 +5859,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ static_assertions = "1.1"
 tabled = { version = "0.17.0", default-features = false }
 tar = "0.4"
 tempfile = "3"
+tikv-jemallocator = "0.6"
 thiserror = "2.0.3"
 tokio = "1.36"
 tracing = "0.1.37"

--- a/bench-vortex/Cargo.toml
+++ b/bench-vortex/Cargo.toml
@@ -29,6 +29,7 @@ arrow-select = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 bzip2 = { workspace = true }
+cfg-if = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 datafusion = { workspace = true, features = [
     "parquet",
@@ -57,6 +58,7 @@ serde_json = { workspace = true }
 simplelog = { workspace = true }
 tabled = { workspace = true, features = ["std"] }
 tar = { workspace = true }
+tikv-jemallocator = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full"] }
 uuid = { workspace = true, features = ["v4"] }
 vortex = { workspace = true, features = ["object_store", "parquet"] }
@@ -66,6 +68,10 @@ xshell = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports", "async_tokio"] }
+
+[features]
+mimalloc = []
+jemalloc = ["dep:tikv-jemallocator"]
 
 [[bench]]
 name = "compress"

--- a/bench-vortex/README.md
+++ b/bench-vortex/README.md
@@ -24,7 +24,13 @@ For profiling, you can open in Instruments using the following invocation:
 cargo instruments -p bench-vortex --bin tpch_benchmark --template Time --profile bench
 ```
 
-# Common Issues
+## Memory allocators
+
+If you don't want to use the default system allocator, there are `"jemalloc"` and `"mimalloc"` features available that configure a different allocators at compile time.
+
+As of this writing, if both are enabled `mimalloc` will be used.
+
+## Common Issues
 
 If the benchmarks fail because of this error:
 

--- a/bench-vortex/benches/bytes_at.rs
+++ b/bench-vortex/benches/bytes_at.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use bench_vortex::feature_flagged_allocator;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use parquet::data_type::AsBytes;
 use vortex::array::{VarBinArray, VarBinViewArray};
@@ -12,6 +13,8 @@ use vortex::ipc::iterator::{ArrayIteratorIPC, SyncIPCReader};
 use vortex::iter::ArrayIteratorExt;
 use vortex::validity::Validity;
 use vortex::{Context, IntoArray, IntoArrayVariant};
+
+feature_flagged_allocator!();
 
 fn array_data_fixture() -> VarBinArray {
     VarBinArray::try_new(

--- a/bench-vortex/benches/compress.rs
+++ b/bench-vortex/benches/compress.rs
@@ -16,7 +16,9 @@ use bench_vortex::public_bi_data::BenchmarkDatasets;
 use bench_vortex::public_bi_data::PBIDataset::*;
 use bench_vortex::taxi_data::taxi_data_parquet;
 use bench_vortex::tpch::dbgen::{DBGen, DBGenOptions};
-use bench_vortex::{fetch_taxi_data, generate_struct_of_list_of_ints_array, tpch};
+use bench_vortex::{
+    feature_flagged_allocator, fetch_taxi_data, generate_struct_of_list_of_ints_array, tpch,
+};
 use bytes::Bytes;
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use futures::TryStreamExt;
@@ -38,6 +40,8 @@ use vortex::sampling_compressor::{SamplingCompressor, ALL_ENCODINGS_CONTEXT};
 use vortex::{Array, IntoArray, IntoArrayVariant};
 
 use crate::tokio_runtime::TOKIO_RUNTIME;
+
+feature_flagged_allocator!();
 
 #[derive(serde::Serialize)]
 struct GenericBenchmarkResults<'a> {

--- a/bench-vortex/benches/compressor_throughput.rs
+++ b/bench-vortex/benches/compressor_throughput.rs
@@ -1,5 +1,5 @@
+use bench_vortex::feature_flagged_allocator;
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion, Throughput};
-use mimalloc::MiMalloc;
 use rand::distributions::Alphanumeric;
 use rand::seq::SliceRandom as _;
 use rand::{thread_rng, Rng, SeedableRng as _};
@@ -24,8 +24,7 @@ use vortex::sampling_compressor::compressors::CompressorRef;
 use vortex::sampling_compressor::SamplingCompressor;
 use vortex::{IntoArray, IntoCanonical};
 
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
+feature_flagged_allocator!();
 
 fn primitive(c: &mut Criterion) {
     let mut group = c.benchmark_group("primitive-decompression");

--- a/bench-vortex/benches/random_access.rs
+++ b/bench-vortex/benches/random_access.rs
@@ -1,20 +1,19 @@
 use std::env;
 use std::sync::Arc;
 
+use bench_vortex::feature_flagged_allocator;
 use bench_vortex::reader::{
     take_parquet, take_parquet_object_store, take_vortex_object_store, take_vortex_tokio,
 };
 use bench_vortex::taxi_data::{taxi_data_parquet, taxi_data_vortex};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use mimalloc::MiMalloc;
 use object_store::aws::AmazonS3Builder;
 use object_store::local::LocalFileSystem;
 use object_store::ObjectStore;
 use tokio::runtime::Runtime;
 use vortex::buffer::buffer;
 
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
+feature_flagged_allocator!();
 
 /// Benchmarks against object stores require setting
 /// * AWS_ACCESS_KEY_ID

--- a/bench-vortex/src/bin/clickbench.rs
+++ b/bench-vortex/src/bin/clickbench.rs
@@ -7,8 +7,8 @@ use std::time::{Duration, Instant};
 use bench_vortex::clickbench::{self, clickbench_queries, HITS_SCHEMA};
 use bench_vortex::display::{print_measurements_json, render_table, DisplayFormat};
 use bench_vortex::{
-    execute_query, get_session_with_cache, idempotent, physical_plan, setup_logger, Format,
-    IdempotentPath as _, Measurement,
+    execute_query, feature_flagged_allocator, get_session_with_cache, idempotent, physical_plan,
+    setup_logger, Format, IdempotentPath as _, Measurement,
 };
 use clap::Parser;
 use datafusion_physical_plan::display::DisplayableExecutionPlan;
@@ -18,6 +18,8 @@ use log::LevelFilter;
 use rayon::iter::{IntoParallelIterator, ParallelIterator as _};
 use tokio::runtime::Builder;
 use vortex::error::{vortex_panic, VortexExpect};
+
+feature_flagged_allocator!();
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]

--- a/bench-vortex/src/bin/tpch_benchmark.rs
+++ b/bench-vortex/src/bin/tpch_benchmark.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use bench_vortex::display::{print_measurements_json, render_table, DisplayFormat};
 use bench_vortex::tpch::dbgen::{DBGen, DBGenOptions};
 use bench_vortex::tpch::{load_datasets, run_tpch_query, tpch_queries, EXPECTED_ROW_COUNTS};
-use bench_vortex::{setup_logger, Format, Measurement};
+use bench_vortex::{feature_flagged_allocator, setup_logger, Format, Measurement};
 use clap::{ArgAction, Parser};
 use futures::future::try_join_all;
 use indicatif::ProgressBar;
@@ -13,6 +13,8 @@ use itertools::Itertools;
 use log::LevelFilter;
 use tokio::runtime::Builder;
 use vortex::aliases::hash_map::HashMap;
+
+feature_flagged_allocator!();
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -52,6 +52,21 @@ pub mod vortex_utils;
 const TARGET_BLOCK_BYTESIZE: usize = 16 * (1 << 20);
 const TARGET_BLOCK_SIZE: usize = 64 * (1 << 10);
 
+#[macro_export]
+macro_rules! feature_flagged_allocator {
+    () => {
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "mimalloc")] {
+                #[global_allocator]
+                static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+            } else if #[cfg(feature = "jemalloc")] {
+                #[global_allocator]
+                static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+            }
+        }
+    };
+}
+
 pub static CTX: LazyLock<ContextRef> = LazyLock::new(|| {
     Arc::new(
         (*(ALL_ENCODINGS_CONTEXT.clone()))


### PR DESCRIPTION
Allow benchmark users to change the allocator between the default system one, mimalloc and jemalloc. Mostly motivated by how annoying and slow I find it to run clickbench of my macbook (and annoying to profile around the very slow drops).