### PR TITLE
ci: run criterion benchmarks with codspeed

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,5 @@
+[target.'(target_familiy="unix")']
+rustflags = ["-C", "force-frame-pointers=yes"]
 # For pyo3 to successfully link on Macos
 # See https://stackoverflow.com/a/77382609
 [target.aarch64-apple-darwin]

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -32,12 +32,6 @@ jobs:
       - uses: ./.github/actions/cleanup
       - uses: ./.github/actions/setup-rust
 
-      # - name: Install
-      #   shell: bash
-      #   run: |
-      #     set -Eeu -o pipefail -x
-      #     base_commit_sha=${{ github.event.pull_request.base.sha }}
-
       # The compression benchmarks rely on DuckDB being installed to convert CSV to Parquet
       - name: Install DuckDB
         uses: opt-nc/setup-duckdb-action@v1.0.10
@@ -45,20 +39,22 @@ jobs:
         with:
           version: v1.0.0
 
-      - name: Setup rust toolchain, cache and cargo-codspeed binary
-        uses: moonrepo/setup-rust@v1
-        with:
-          channel: nightly
-          cache-target: release
-          bins: cargo-codspeed
+      - name: Install Codspeed
+        shell: bash
+        run: |
+          cargo install --force cargo-codspeed --locked
 
-      - name: Build the benchmark target(s)
-        run: cargo codspeed build compress
+      - name: Build benchmark targets
+        run: cargo codspeed build compare
 
       - name: Run the benchmarks
+        env:
+          BENCH_VORTEX_RATIOS: ".*"
+          RUSTFLAGS: "-C target-cpu=native"
+          HOME: /home/ci-runner
         uses: CodSpeedHQ/action@v3
         with:
-          run: cargo codspeed run compress
+          run: cargo codspeed run compare
           token: ${{ secrets.CODSPEED_TOKEN }}
 
   # bench:

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -2,9 +2,9 @@ name: PR Benchmarks
 
 on:
   pull_request:
-    types: [ labeled, synchronize ]
-    branches: [ "develop" ]
-  workflow_dispatch: { }
+    types: [labeled, synchronize]
+    branches: ["develop"]
+  workflow_dispatch: {}
 
 permissions:
   actions: write
@@ -49,24 +49,37 @@ jobs:
         run: |
           echo "TMPDIR=/work" >> $GITHUB_ENV
 
-      - name: Run benchmark
-        shell: bash
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@v3
         env:
-          BENCH_VORTEX_RATIOS: '.*'
-          RUSTFLAGS: '-C target-cpu=native'
-        run: |
-          cargo install cargo-criterion
-          sudo apt-get update && sudo apt-get install -y jq
+          BENCH_VORTEX_RATIOS: ".*"
+          RUSTFLAGS: "-C target-cpu=native"
+        with:
+          token: ${{ secrets.CODSPEED_TOKEN }}
+          shell: bash
+          run: |
+            cargo install cargo-codspeed --locked
+            cargo codspeed build ${{ matrix.benchmark.id }}
+            cargo codspeed run ${{ matrix.benchmark.id }}
 
-          cargo criterion \
-                --bench ${{ matrix.benchmark.id }} \
-                --features mimalloc \
-                --message-format=json \
-            > ${{ matrix.benchmark.id }}-raw.json
+        # - name: Run benchmark
+        #   shell: bash
+        #   env:
+        #     BENCH_VORTEX_RATIOS: '.*'
+        #     RUSTFLAGS: '-C target-cpu=native'
+        #   run: |
+        #     cargo install cargo-criterion
+        #     sudo apt-get update && sudo apt-get install -y jq
 
-          cat ${{ matrix.benchmark.id }}-raw.json \
-            | bash scripts/coerce-criterion-json.sh \
-            > ${{ matrix.benchmark.id }}.json
+        #     cargo criterion \
+        #           --bench ${{ matrix.benchmark.id }} \
+        #           --features mimalloc \
+        #           --message-format=json \
+        #       > ${{ matrix.benchmark.id }}-raw.json
+
+        #     cat ${{ matrix.benchmark.id }}-raw.json \
+        #       | bash scripts/coerce-criterion-json.sh \
+        #       > ${{ matrix.benchmark.id }}.json
 
       - name: Setup AWS CLI
         uses: aws-actions/configure-aws-credentials@v4
@@ -120,8 +133,8 @@ jobs:
       - name: Run TPC-H benchmark
         shell: bash
         env:
-          BENCH_VORTEX_RATIOS: '.*'
-          RUSTFLAGS: '-C target-cpu=native'
+          BENCH_VORTEX_RATIOS: ".*"
+          RUSTFLAGS: "-C target-cpu=native"
         run: |
           cargo run --bin tpch_benchmark --release -- -d gh-json -t 1 | tee tpch.json
       - name: Setup AWS CLI
@@ -177,8 +190,8 @@ jobs:
       - name: Run Clickbench benchmark
         shell: bash
         env:
-          BENCH_VORTEX_RATIOS: '.*'
-          RUSTFLAGS: '-C target-cpu=native'
+          BENCH_VORTEX_RATIOS: ".*"
+          RUSTFLAGS: "-C target-cpu=native"
           HOME: /home/ci-runner
         run: |
           cargo run --bin clickbench --release -- -d gh-json | tee clickbench.json

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -2,9 +2,9 @@ name: PR Benchmarks
 
 on:
   pull_request:
-    types: [labeled, synchronize]
-    branches: ["develop"]
-  workflow_dispatch: {}
+    types: [ labeled, synchronize ]
+    branches: [ "develop" ]
+  workflow_dispatch: { }
 
 permissions:
   actions: write
@@ -21,7 +21,6 @@ jobs:
       - uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: benchmark
-      - uses: actions/checkout@v4
 
   codspeed_bench:
     name: Run benchmarks
@@ -44,17 +43,9 @@ jobs:
       - uses: ./.github/actions/cleanup
       - uses: ./.github/actions/setup-rust
 
-      # The compression benchmarks rely on DuckDB being installed to convert CSV to Parquet
-      - name: Install DuckDB
-        uses: opt-nc/setup-duckdb-action@v1.0.10
-        if: runner.environment != 'self-hosted'
-        with:
-          version: v1.0.0
-
       - name: Install Codspeed
         shell: bash
-        run: |
-          cargo install --force cargo-codspeed --locked
+        run: cargo install --force cargo-codspeed --locked
 
       - name: Build benchmark targets
         env:
@@ -69,209 +60,194 @@ jobs:
           run: cargo codspeed run $BENCH_TARGETS
           token: ${{ secrets.CODSPEED_TOKEN }}
 
-  # bench:
-  #   needs: label_trigger
-  #   strategy:
-  #     matrix:
-  #       benchmark:
-  #         - id: random_access
-  #           name: Random Access
-  #         - id: compress
-  #           name: Vortex Compression
-  #   runs-on: self-hosted
-  #   if: ${{ contains(github.event.head_commit.message, '[benchmark]') || github.event.label.name == 'benchmark' && github.event_name == 'pull_request' }}
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: ./.github/actions/cleanup
-  #     - uses: ./.github/actions/setup-rust
+  bench:
+    needs: label_trigger
+    strategy:
+      matrix:
+        benchmark:
+          - id: random_access
+            name: Random Access
+          - id: compress
+            name: Vortex Compression
+    runs-on: self-hosted
+    if: ${{ contains(github.event.head_commit.message, '[benchmark]') || github.event.label.name == 'benchmark' && github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cleanup
+      - uses: ./.github/actions/setup-rust
 
-  #     # The compression benchmarks rely on DuckDB being installed to convert CSV to Parquet
-  #     - name: Install DuckDB
-  #       uses: opt-nc/setup-duckdb-action@v1.0.10
-  #       if: runner.environment != 'self-hosted'
-  #       with:
-  #         version: v1.0.0
+      # The compression benchmarks rely on DuckDB being installed to convert CSV to Parquet
+      - name: Install DuckDB
+        uses: opt-nc/setup-duckdb-action@v1.0.10
+        if: runner.environment != 'self-hosted'
+        with:
+          version: v1.0.0
 
-  #     - name: Set tempdir
-  #       if: runner.environment == 'self-hosted'
-  #       run: |
-  #         # echo "TMPDIR=/work" >> $GITHUB_ENV
+      - name: Set tempdir
+        if: runner.environment == 'self-hosted'
+        run: |
+          echo "TMPDIR=/work" >> $GITHUB_ENV
 
-  #     - name: Run benchmarks
-  #       uses: CodSpeedHQ/action@v3
-  #       env:
-  #         BENCH_VORTEX_RATIOS: ".*"
-  #         RUSTFLAGS: "-C target-cpu=native"
-  #         HOME: /home/ci-runner
-  #       with:
-  #         token: ${{ secrets.CODSPEED_TOKEN }}
-  #         shell: bash
-  #         run: |
-  #           rustup default nightly
-  #           cargo install --force cargo-codspeed --locked
-  #           cargo codspeed build ${{ matrix.benchmark.id }}
-  #           cargo codspeed run ${{ matrix.benchmark.id }}
+      - name: Run benchmark
+        shell: bash
+        env:
+          BENCH_VORTEX_RATIOS: '.*'
+          RUSTFLAGS: '-C target-cpu=native'
+        run: |
+          cargo install cargo-criterion
+          sudo apt-get update && sudo apt-get install -y jq
 
-  # - name: Run benchmark
-  #   shell: bash
-  #   env:
-  #     BENCH_VORTEX_RATIOS: '.*'
-  #     RUSTFLAGS: '-C target-cpu=native'
-  #   run: |
-  #     cargo install cargo-criterion
-  #     sudo apt-get update && sudo apt-get install -y jq
+          cargo criterion \
+                --bench ${{ matrix.benchmark.id }} \
+                --features mimalloc \
+                --message-format=json \
+            > ${{ matrix.benchmark.id }}-raw.json
 
-  #     cargo criterion \
-  #           --bench ${{ matrix.benchmark.id }} \
-  #           --features mimalloc \
-  #           --message-format=json \
-  #       > ${{ matrix.benchmark.id }}-raw.json
+          cat ${{ matrix.benchmark.id }}-raw.json \
+            | bash scripts/coerce-criterion-json.sh \
+            > ${{ matrix.benchmark.id }}.json
 
-  #     cat ${{ matrix.benchmark.id }}-raw.json \
-  #       | bash scripts/coerce-criterion-json.sh \
-  #       > ${{ matrix.benchmark.id }}.json
+      - name: Setup AWS CLI
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::375504701696:role/GitHubBenchmarkRole
+          aws-region: us-east-1
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Compare results
+        shell: bash
+        run: |
+          set -Eeu -o pipefail -x
 
-  # - name: Setup AWS CLI
-  #   uses: aws-actions/configure-aws-credentials@v4
-  #   with:
-  #     role-to-assume: arn:aws:iam::375504701696:role/GitHubBenchmarkRole
-  #     aws-region: us-east-1
-  # - name: Install uv
-  #   uses: astral-sh/setup-uv@v5
-  # - name: Compare results
-  #   shell: bash
-  #   run: |
-  #     set -Eeu -o pipefail -x
+          base_commit_sha=${{ github.event.pull_request.base.sha }}
 
-  #     base_commit_sha=${{ github.event.pull_request.base.sha }}
+          aws s3 cp s3://vortex-benchmark-results-database/data.json - \
+            | grep $base_commit_sha \
+            > base.json
 
-  #     aws s3 cp s3://vortex-benchmark-results-database/data.json - \
-  #       | grep $base_commit_sha \
-  #       > base.json
+          echo '# Benchmarks: ${{ matrix.benchmark.id }}' > comment.md
+          echo '<details>' >> comment.md
+          echo '<summary>Table of Results</summary>' >> comment.md
+          echo '' >> comment.md
+          uv run scripts/compare-benchmark-jsons.py base.json ${{ matrix.benchmark.id }}.json \
+            >> comment.md
+          echo '</details>' >> comment.md
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          file-path: comment.md
+          comment-tag: bench-pr-comment-${{ matrix.benchmark.id }}
+  tpch:
+    needs: label_trigger
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cleanup
+      - uses: ./.github/actions/setup-rust
+      # The compression benchmarks rely on DuckDB being installed to convert CSV to Parquet
+      - name: Install DuckDB
+        uses: opt-nc/setup-duckdb-action@v1.0.10
+        if: runner.environment != 'self-hosted'
+        with:
+          version: v1.0.0
 
-  #     echo '# Benchmarks: ${{ matrix.benchmark.id }}' > comment.md
-  #     echo '<details>' >> comment.md
-  #     echo '<summary>Table of Results</summary>' >> comment.md
-  #     echo '' >> comment.md
-  #     uv run scripts/compare-benchmark-jsons.py base.json ${{ matrix.benchmark.id }}.json \
-  #       >> comment.md
-  #     echo '</details>' >> comment.md
-  # - name: Comment PR
-  #   uses: thollander/actions-comment-pull-request@v3
-  #   with:
-  #     file-path: comment.md
-  #     comment-tag: bench-pr-comment-${{ matrix.benchmark.id }}
-  # tpch:
-  #   needs: label_trigger
-  #   runs-on: self-hosted
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: ./.github/actions/cleanup
-  #     - uses: ./.github/actions/setup-rust
-  #     # The compression benchmarks rely on DuckDB being installed to convert CSV to Parquet
-  #     - name: Install DuckDB
-  #       uses: opt-nc/setup-duckdb-action@v1.0.10
-  #       if: runner.environment != 'self-hosted'
-  #       with:
-  #         version: v1.0.0
+      - name: Set tempdir
+        if: runner.environment == 'self-hosted'
+        run: |
+          echo "TMPDIR=/work" >> $GITHUB_ENV
 
-  #     - name: Set tempdir
-  #       if: runner.environment == 'self-hosted'
-  #       run: |
-  #         echo "TMPDIR=/work" >> $GITHUB_ENV
+      - name: Run TPC-H benchmark
+        shell: bash
+        env:
+          BENCH_VORTEX_RATIOS: '.*'
+          RUSTFLAGS: '-C target-cpu=native'
+        run: |
+          cargo run --bin tpch_benchmark --release -- -d gh-json -t 1 | tee tpch.json
+      - name: Setup AWS CLI
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::375504701696:role/GitHubBenchmarkRole
+          aws-region: us-east-1
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Compare results
+        shell: bash
+        run: |
+          set -Eeu -o pipefail -x
 
-  #     - name: Run TPC-H benchmark
-  #       shell: bash
-  #       env:
-  #         BENCH_VORTEX_RATIOS: ".*"
-  #         RUSTFLAGS: "-C target-cpu=native"
-  #       run: |
-  #         cargo run --bin tpch_benchmark --release -- -d gh-json -t 1 | tee tpch.json
-  #     - name: Setup AWS CLI
-  #       uses: aws-actions/configure-aws-credentials@v4
-  #       with:
-  #         role-to-assume: arn:aws:iam::375504701696:role/GitHubBenchmarkRole
-  #         aws-region: us-east-1
-  #     - name: Install uv
-  #       uses: astral-sh/setup-uv@v5
-  #     - name: Compare results
-  #       shell: bash
-  #       run: |
-  #         set -Eeu -o pipefail -x
+          base_commit_sha=${{ github.event.pull_request.base.sha }}
 
-  #         base_commit_sha=${{ github.event.pull_request.base.sha }}
+          aws s3 cp s3://vortex-benchmark-results-database/data.json - \
+            | grep $base_commit_sha \
+            > base.json
 
-  #         aws s3 cp s3://vortex-benchmark-results-database/data.json - \
-  #           | grep $base_commit_sha \
-  #           > base.json
+          echo '# Benchmarks: TPC-H' > comment.md
+          echo '<details>' >> comment.md
+          echo '<summary>Table of Results</summary>' >> comment.md
+          echo '' >> comment.md
+          uv run python3 scripts/compare-benchmark-jsons.py base.json tpch.json \
+            >> comment.md
+          echo '</details>' >> comment.md
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          file-path: comment.md
+          comment-tag: bench-pr-comment-tpch
+  clickbench:
+    needs: label_trigger
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cleanup
+      - uses: ./.github/actions/setup-rust
 
-  #         echo '# Benchmarks: TPC-H' > comment.md
-  #         echo '<details>' >> comment.md
-  #         echo '<summary>Table of Results</summary>' >> comment.md
-  #         echo '' >> comment.md
-  #         uv run python3 scripts/compare-benchmark-jsons.py base.json tpch.json \
-  #           >> comment.md
-  #         echo '</details>' >> comment.md
-  #     - name: Comment PR
-  #       uses: thollander/actions-comment-pull-request@v3
-  #       with:
-  #         file-path: comment.md
-  #         comment-tag: bench-pr-comment-tpch
-  # clickbench:
-  #   needs: label_trigger
-  #   runs-on: self-hosted
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: ./.github/actions/cleanup
-  #     - uses: ./.github/actions/setup-rust
+      # The compression benchmarks rely on DuckDB being installed to convert CSV to Parquet
+      - name: Install DuckDB
+        uses: opt-nc/setup-duckdb-action@v1.0.10
+        if: runner.environment != 'self-hosted'
+        with:
+          version: v1.0.0
 
-  #     # The compression benchmarks rely on DuckDB being installed to convert CSV to Parquet
-  #     - name: Install DuckDB
-  #       uses: opt-nc/setup-duckdb-action@v1.0.10
-  #       if: runner.environment != 'self-hosted'
-  #       with:
-  #         version: v1.0.0
+      - name: Set tempdir
+        if: runner.environment == 'self-hosted'
+        run: |
+          echo "TMPDIR=/work" >> $GITHUB_ENV
 
-  #     - name: Set tempdir
-  #       if: runner.environment == 'self-hosted'
-  #       run: |
-  #         echo "TMPDIR=/work" >> $GITHUB_ENV
+      - name: Run Clickbench benchmark
+        shell: bash
+        env:
+          BENCH_VORTEX_RATIOS: '.*'
+          RUSTFLAGS: '-C target-cpu=native'
+          HOME: /home/ci-runner
+        run: |
+          cargo run --bin clickbench --release -- -d gh-json | tee clickbench.json
+      - name: Setup AWS CLI
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::375504701696:role/GitHubBenchmarkRole
+          aws-region: us-east-1
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Compare results
+        shell: bash
+        run: |
+          set -Eeu -o pipefail -x
 
-  #     - name: Run Clickbench benchmark
-  #       shell: bash
-  #       env:
-  #         BENCH_VORTEX_RATIOS: ".*"
-  #         RUSTFLAGS: "-C target-cpu=native"
-  #         HOME: /home/ci-runner
-  #       run: |
-  #         cargo run --bin clickbench --release -- -d gh-json | tee clickbench.json
-  #     - name: Setup AWS CLI
-  #       uses: aws-actions/configure-aws-credentials@v4
-  #       with:
-  #         role-to-assume: arn:aws:iam::375504701696:role/GitHubBenchmarkRole
-  #         aws-region: us-east-1
-  #     - name: Install uv
-  #       uses: astral-sh/setup-uv@v5
-  #     - name: Compare results
-  #       shell: bash
-  #       run: |
-  #         set -Eeu -o pipefail -x
+          base_commit_sha=${{ github.event.pull_request.base.sha }}
 
-  #         base_commit_sha=${{ github.event.pull_request.base.sha }}
+          aws s3 cp s3://vortex-benchmark-results-database/data.json - \
+            | grep $base_commit_sha \
+            > base.json
 
-  #         aws s3 cp s3://vortex-benchmark-results-database/data.json - \
-  #           | grep $base_commit_sha \
-  #           > base.json
-
-  #         echo '# Benchmarks: Clickbench' > comment.md
-  #         echo '<details>' >> comment.md
-  #         echo '<summary>Table of Results</summary>' >> comment.md
-  #         echo '' >> comment.md
-  #         uv run scripts/compare-benchmark-jsons.py base.json clickbench.json \
-  #           >> comment.md
-  #         echo '</details>' >> comment.md
-  #     - name: Comment PR
-  #       uses: thollander/actions-comment-pull-request@v3
-  #       with:
-  #         file-path: comment.md
-  #         comment-tag: bench-pr-comment-clickbench
+          echo '# Benchmarks: Clickbench' > comment.md
+          echo '<details>' >> comment.md
+          echo '<summary>Table of Results</summary>' >> comment.md
+          echo '' >> comment.md
+          uv run scripts/compare-benchmark-jsons.py base.json clickbench.json \
+            >> comment.md
+          echo '</details>' >> comment.md
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          file-path: comment.md
+          comment-tag: bench-pr-comment-clickbench

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v4
 
   codspeed_bench:
+    name: Run benchmarks
     needs: label_trigger
     env:
       BENCH_TARGETS: >
@@ -37,7 +38,6 @@ jobs:
         compare
         take_strings
         take_patches
-    name: Run benchmarks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +59,9 @@ jobs:
       - name: Build benchmark targets
         env:
           RUSTFLAGS: "-C target-cpu=native"
-        run: cargo codspeed build $BENCH_TARGETS
+        # The profile needs to be set explicitly to bench
+        # as codspeed by default compiles with the release profile.
+        run: cargo codspeed build --profile bench $BENCH_TARGETS
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v3

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -59,6 +59,7 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
           shell: bash
           run: |
+            rustup default nightly
             cargo install --force cargo-codspeed --locked
             cargo codspeed build ${{ matrix.benchmark.id }}
             cargo codspeed run ${{ matrix.benchmark.id }}

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -21,21 +21,22 @@ jobs:
       - uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: benchmark
-  bench:
+      - uses: actions/checkout@v4
+
+  codspeed_bench:
     needs: label_trigger
-    strategy:
-      matrix:
-        benchmark:
-          - id: random_access
-            name: Random Access
-          - id: compress
-            name: Vortex Compression
-    runs-on: self-hosted
-    if: ${{ contains(github.event.head_commit.message, '[benchmark]') || github.event.label.name == 'benchmark' && github.event_name == 'pull_request' }}
+    name: Run benchmarks
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cleanup
       - uses: ./.github/actions/setup-rust
+
+      # - name: Install
+      #   shell: bash
+      #   run: |
+      #     set -Eeu -o pipefail -x
+      #     base_commit_sha=${{ github.event.pull_request.base.sha }}
 
       # The compression benchmarks rely on DuckDB being installed to convert CSV to Parquet
       - name: Install DuckDB
@@ -44,186 +45,225 @@ jobs:
         with:
           version: v1.0.0
 
-      - name: Set tempdir
-        if: runner.environment == 'self-hosted'
-        run: |
-          echo "TMPDIR=/work" >> $GITHUB_ENV
+      - name: Setup rust toolchain, cache and cargo-codspeed binary
+        uses: moonrepo/setup-rust@v1
+        with:
+          channel: nightly
+          cache-target: release
+          bins: cargo-codspeed
 
-      - name: Run benchmarks
+      - name: Build the benchmark target(s)
+        run: cargo codspeed build compress
+
+      - name: Run the benchmarks
         uses: CodSpeedHQ/action@v3
-        env:
-          BENCH_VORTEX_RATIOS: ".*"
-          RUSTFLAGS: "-C target-cpu=native"
-          HOME: /home/ci-runner
         with:
+          run: cargo codspeed run compress
           token: ${{ secrets.CODSPEED_TOKEN }}
-          shell: bash
-          run: |
-            rustup default nightly
-            cargo install --force cargo-codspeed --locked
-            cargo codspeed build ${{ matrix.benchmark.id }}
-            cargo codspeed run ${{ matrix.benchmark.id }}
 
-        # - name: Run benchmark
-        #   shell: bash
-        #   env:
-        #     BENCH_VORTEX_RATIOS: '.*'
-        #     RUSTFLAGS: '-C target-cpu=native'
-        #   run: |
-        #     cargo install cargo-criterion
-        #     sudo apt-get update && sudo apt-get install -y jq
+  # bench:
+  #   needs: label_trigger
+  #   strategy:
+  #     matrix:
+  #       benchmark:
+  #         - id: random_access
+  #           name: Random Access
+  #         - id: compress
+  #           name: Vortex Compression
+  #   runs-on: self-hosted
+  #   if: ${{ contains(github.event.head_commit.message, '[benchmark]') || github.event.label.name == 'benchmark' && github.event_name == 'pull_request' }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: ./.github/actions/cleanup
+  #     - uses: ./.github/actions/setup-rust
 
-        #     cargo criterion \
-        #           --bench ${{ matrix.benchmark.id }} \
-        #           --features mimalloc \
-        #           --message-format=json \
-        #       > ${{ matrix.benchmark.id }}-raw.json
+  #     # The compression benchmarks rely on DuckDB being installed to convert CSV to Parquet
+  #     - name: Install DuckDB
+  #       uses: opt-nc/setup-duckdb-action@v1.0.10
+  #       if: runner.environment != 'self-hosted'
+  #       with:
+  #         version: v1.0.0
 
-        #     cat ${{ matrix.benchmark.id }}-raw.json \
-        #       | bash scripts/coerce-criterion-json.sh \
-        #       > ${{ matrix.benchmark.id }}.json
+  #     - name: Set tempdir
+  #       if: runner.environment == 'self-hosted'
+  #       run: |
+  #         # echo "TMPDIR=/work" >> $GITHUB_ENV
 
-      - name: Setup AWS CLI
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::375504701696:role/GitHubBenchmarkRole
-          aws-region: us-east-1
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-      - name: Compare results
-        shell: bash
-        run: |
-          set -Eeu -o pipefail -x
+  #     - name: Run benchmarks
+  #       uses: CodSpeedHQ/action@v3
+  #       env:
+  #         BENCH_VORTEX_RATIOS: ".*"
+  #         RUSTFLAGS: "-C target-cpu=native"
+  #         HOME: /home/ci-runner
+  #       with:
+  #         token: ${{ secrets.CODSPEED_TOKEN }}
+  #         shell: bash
+  #         run: |
+  #           rustup default nightly
+  #           cargo install --force cargo-codspeed --locked
+  #           cargo codspeed build ${{ matrix.benchmark.id }}
+  #           cargo codspeed run ${{ matrix.benchmark.id }}
 
-          base_commit_sha=${{ github.event.pull_request.base.sha }}
+  # - name: Run benchmark
+  #   shell: bash
+  #   env:
+  #     BENCH_VORTEX_RATIOS: '.*'
+  #     RUSTFLAGS: '-C target-cpu=native'
+  #   run: |
+  #     cargo install cargo-criterion
+  #     sudo apt-get update && sudo apt-get install -y jq
 
-          aws s3 cp s3://vortex-benchmark-results-database/data.json - \
-            | grep $base_commit_sha \
-            > base.json
+  #     cargo criterion \
+  #           --bench ${{ matrix.benchmark.id }} \
+  #           --features mimalloc \
+  #           --message-format=json \
+  #       > ${{ matrix.benchmark.id }}-raw.json
 
-          echo '# Benchmarks: ${{ matrix.benchmark.id }}' > comment.md
-          echo '<details>' >> comment.md
-          echo '<summary>Table of Results</summary>' >> comment.md
-          echo '' >> comment.md
-          uv run scripts/compare-benchmark-jsons.py base.json ${{ matrix.benchmark.id }}.json \
-            >> comment.md
-          echo '</details>' >> comment.md
-      - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v3
-        with:
-          file-path: comment.md
-          comment-tag: bench-pr-comment-${{ matrix.benchmark.id }}
-  tpch:
-    needs: label_trigger
-    runs-on: self-hosted
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/cleanup
-      - uses: ./.github/actions/setup-rust
-      # The compression benchmarks rely on DuckDB being installed to convert CSV to Parquet
-      - name: Install DuckDB
-        uses: opt-nc/setup-duckdb-action@v1.0.10
-        if: runner.environment != 'self-hosted'
-        with:
-          version: v1.0.0
+  #     cat ${{ matrix.benchmark.id }}-raw.json \
+  #       | bash scripts/coerce-criterion-json.sh \
+  #       > ${{ matrix.benchmark.id }}.json
 
-      - name: Set tempdir
-        if: runner.environment == 'self-hosted'
-        run: |
-          echo "TMPDIR=/work" >> $GITHUB_ENV
+  # - name: Setup AWS CLI
+  #   uses: aws-actions/configure-aws-credentials@v4
+  #   with:
+  #     role-to-assume: arn:aws:iam::375504701696:role/GitHubBenchmarkRole
+  #     aws-region: us-east-1
+  # - name: Install uv
+  #   uses: astral-sh/setup-uv@v5
+  # - name: Compare results
+  #   shell: bash
+  #   run: |
+  #     set -Eeu -o pipefail -x
 
-      - name: Run TPC-H benchmark
-        shell: bash
-        env:
-          BENCH_VORTEX_RATIOS: ".*"
-          RUSTFLAGS: "-C target-cpu=native"
-        run: |
-          cargo run --bin tpch_benchmark --release -- -d gh-json -t 1 | tee tpch.json
-      - name: Setup AWS CLI
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::375504701696:role/GitHubBenchmarkRole
-          aws-region: us-east-1
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-      - name: Compare results
-        shell: bash
-        run: |
-          set -Eeu -o pipefail -x
+  #     base_commit_sha=${{ github.event.pull_request.base.sha }}
 
-          base_commit_sha=${{ github.event.pull_request.base.sha }}
+  #     aws s3 cp s3://vortex-benchmark-results-database/data.json - \
+  #       | grep $base_commit_sha \
+  #       > base.json
 
-          aws s3 cp s3://vortex-benchmark-results-database/data.json - \
-            | grep $base_commit_sha \
-            > base.json
+  #     echo '# Benchmarks: ${{ matrix.benchmark.id }}' > comment.md
+  #     echo '<details>' >> comment.md
+  #     echo '<summary>Table of Results</summary>' >> comment.md
+  #     echo '' >> comment.md
+  #     uv run scripts/compare-benchmark-jsons.py base.json ${{ matrix.benchmark.id }}.json \
+  #       >> comment.md
+  #     echo '</details>' >> comment.md
+  # - name: Comment PR
+  #   uses: thollander/actions-comment-pull-request@v3
+  #   with:
+  #     file-path: comment.md
+  #     comment-tag: bench-pr-comment-${{ matrix.benchmark.id }}
+  # tpch:
+  #   needs: label_trigger
+  #   runs-on: self-hosted
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: ./.github/actions/cleanup
+  #     - uses: ./.github/actions/setup-rust
+  #     # The compression benchmarks rely on DuckDB being installed to convert CSV to Parquet
+  #     - name: Install DuckDB
+  #       uses: opt-nc/setup-duckdb-action@v1.0.10
+  #       if: runner.environment != 'self-hosted'
+  #       with:
+  #         version: v1.0.0
 
-          echo '# Benchmarks: TPC-H' > comment.md
-          echo '<details>' >> comment.md
-          echo '<summary>Table of Results</summary>' >> comment.md
-          echo '' >> comment.md
-          uv run python3 scripts/compare-benchmark-jsons.py base.json tpch.json \
-            >> comment.md
-          echo '</details>' >> comment.md
-      - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v3
-        with:
-          file-path: comment.md
-          comment-tag: bench-pr-comment-tpch
-  clickbench:
-    needs: label_trigger
-    runs-on: self-hosted
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/cleanup
-      - uses: ./.github/actions/setup-rust
+  #     - name: Set tempdir
+  #       if: runner.environment == 'self-hosted'
+  #       run: |
+  #         echo "TMPDIR=/work" >> $GITHUB_ENV
 
-      # The compression benchmarks rely on DuckDB being installed to convert CSV to Parquet
-      - name: Install DuckDB
-        uses: opt-nc/setup-duckdb-action@v1.0.10
-        if: runner.environment != 'self-hosted'
-        with:
-          version: v1.0.0
+  #     - name: Run TPC-H benchmark
+  #       shell: bash
+  #       env:
+  #         BENCH_VORTEX_RATIOS: ".*"
+  #         RUSTFLAGS: "-C target-cpu=native"
+  #       run: |
+  #         cargo run --bin tpch_benchmark --release -- -d gh-json -t 1 | tee tpch.json
+  #     - name: Setup AWS CLI
+  #       uses: aws-actions/configure-aws-credentials@v4
+  #       with:
+  #         role-to-assume: arn:aws:iam::375504701696:role/GitHubBenchmarkRole
+  #         aws-region: us-east-1
+  #     - name: Install uv
+  #       uses: astral-sh/setup-uv@v5
+  #     - name: Compare results
+  #       shell: bash
+  #       run: |
+  #         set -Eeu -o pipefail -x
 
-      - name: Set tempdir
-        if: runner.environment == 'self-hosted'
-        run: |
-          echo "TMPDIR=/work" >> $GITHUB_ENV
+  #         base_commit_sha=${{ github.event.pull_request.base.sha }}
 
-      - name: Run Clickbench benchmark
-        shell: bash
-        env:
-          BENCH_VORTEX_RATIOS: ".*"
-          RUSTFLAGS: "-C target-cpu=native"
-          HOME: /home/ci-runner
-        run: |
-          cargo run --bin clickbench --release -- -d gh-json | tee clickbench.json
-      - name: Setup AWS CLI
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::375504701696:role/GitHubBenchmarkRole
-          aws-region: us-east-1
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-      - name: Compare results
-        shell: bash
-        run: |
-          set -Eeu -o pipefail -x
+  #         aws s3 cp s3://vortex-benchmark-results-database/data.json - \
+  #           | grep $base_commit_sha \
+  #           > base.json
 
-          base_commit_sha=${{ github.event.pull_request.base.sha }}
+  #         echo '# Benchmarks: TPC-H' > comment.md
+  #         echo '<details>' >> comment.md
+  #         echo '<summary>Table of Results</summary>' >> comment.md
+  #         echo '' >> comment.md
+  #         uv run python3 scripts/compare-benchmark-jsons.py base.json tpch.json \
+  #           >> comment.md
+  #         echo '</details>' >> comment.md
+  #     - name: Comment PR
+  #       uses: thollander/actions-comment-pull-request@v3
+  #       with:
+  #         file-path: comment.md
+  #         comment-tag: bench-pr-comment-tpch
+  # clickbench:
+  #   needs: label_trigger
+  #   runs-on: self-hosted
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: ./.github/actions/cleanup
+  #     - uses: ./.github/actions/setup-rust
 
-          aws s3 cp s3://vortex-benchmark-results-database/data.json - \
-            | grep $base_commit_sha \
-            > base.json
+  #     # The compression benchmarks rely on DuckDB being installed to convert CSV to Parquet
+  #     - name: Install DuckDB
+  #       uses: opt-nc/setup-duckdb-action@v1.0.10
+  #       if: runner.environment != 'self-hosted'
+  #       with:
+  #         version: v1.0.0
 
-          echo '# Benchmarks: Clickbench' > comment.md
-          echo '<details>' >> comment.md
-          echo '<summary>Table of Results</summary>' >> comment.md
-          echo '' >> comment.md
-          uv run scripts/compare-benchmark-jsons.py base.json clickbench.json \
-            >> comment.md
-          echo '</details>' >> comment.md
-      - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v3
-        with:
-          file-path: comment.md
-          comment-tag: bench-pr-comment-clickbench
+  #     - name: Set tempdir
+  #       if: runner.environment == 'self-hosted'
+  #       run: |
+  #         echo "TMPDIR=/work" >> $GITHUB_ENV
+
+  #     - name: Run Clickbench benchmark
+  #       shell: bash
+  #       env:
+  #         BENCH_VORTEX_RATIOS: ".*"
+  #         RUSTFLAGS: "-C target-cpu=native"
+  #         HOME: /home/ci-runner
+  #       run: |
+  #         cargo run --bin clickbench --release -- -d gh-json | tee clickbench.json
+  #     - name: Setup AWS CLI
+  #       uses: aws-actions/configure-aws-credentials@v4
+  #       with:
+  #         role-to-assume: arn:aws:iam::375504701696:role/GitHubBenchmarkRole
+  #         aws-region: us-east-1
+  #     - name: Install uv
+  #       uses: astral-sh/setup-uv@v5
+  #     - name: Compare results
+  #       shell: bash
+  #       run: |
+  #         set -Eeu -o pipefail -x
+
+  #         base_commit_sha=${{ github.event.pull_request.base.sha }}
+
+  #         aws s3 cp s3://vortex-benchmark-results-database/data.json - \
+  #           | grep $base_commit_sha \
+  #           > base.json
+
+  #         echo '# Benchmarks: Clickbench' > comment.md
+  #         echo '<details>' >> comment.md
+  #         echo '<summary>Table of Results</summary>' >> comment.md
+  #         echo '' >> comment.md
+  #         uv run scripts/compare-benchmark-jsons.py base.json clickbench.json \
+  #           >> comment.md
+  #         echo '</details>' >> comment.md
+  #     - name: Comment PR
+  #       uses: thollander/actions-comment-pull-request@v3
+  #       with:
+  #         file-path: comment.md
+  #         comment-tag: bench-pr-comment-clickbench

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -54,6 +54,7 @@ jobs:
         env:
           BENCH_VORTEX_RATIOS: ".*"
           RUSTFLAGS: "-C target-cpu=native"
+          HOME: /home/ci-runner
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           shell: bash

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -25,29 +25,18 @@ jobs:
 
   codspeed_bench:
     needs: label_trigger
-    strategy:
-      matrix:
-        benchmark:
-          - id: dict_compare
-            name: dict compare
-          - id: dict_compress
-            name: dict compress
-          - id: bitpacking_take
-            name: fastlanes bitpacking take
-          - id: run_end_filter
-            name: runend filter
-          - id: run_end_null_count
-            name: runend null count
-          - id: search_sorted
-            name: vortex-array search sorted
-          - id: scalar_subtract
-            name: vortex-array scalar subtract
-          - id: compare
-            name: vortex-array compare
-          - id: take_strings
-            name: vortex-array take strings
-          - id: take_patches
-            name: vortex-array take patches
+    env:
+      BENCH_TARGETS: >
+        dict_compare
+        dict_compress
+        bitpacking_take
+        run_end_filter
+        run_end_null_count
+        search_sorted
+        scalar_subtract
+        compare
+        take_strings
+        take_patches
     name: Run benchmarks
     runs-on: ubuntu-latest
     steps:
@@ -68,14 +57,14 @@ jobs:
           cargo install --force cargo-codspeed --locked
 
       - name: Build benchmark targets
-        run: cargo codspeed build compare
-
-      - name: Run the benchmarks
         env:
           RUSTFLAGS: "-C target-cpu=native"
+        run: cargo codspeed build $BENCH_TARGETS
+
+      - name: Run the benchmarks
         uses: CodSpeedHQ/action@v3
         with:
-          run: cargo codspeed run compare
+          run: cargo codspeed run $BENCH_TARGETS
           token: ${{ secrets.CODSPEED_TOKEN }}
 
   # bench:

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -59,7 +59,7 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
           shell: bash
           run: |
-            cargo install cargo-codspeed --locked
+            cargo install --force cargo-codspeed --locked
             cargo codspeed build ${{ matrix.benchmark.id }}
             cargo codspeed run ${{ matrix.benchmark.id }}
 

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -25,6 +25,13 @@ jobs:
 
   codspeed_bench:
     needs: label_trigger
+    strategy:
+      matrix:
+        benchmark:
+          - id: compare
+            name: vortex-array compare
+          - id: alp_compress
+            name: alp compress
     name: Run benchmarks
     runs-on: ubuntu-latest
     steps:
@@ -49,9 +56,7 @@ jobs:
 
       - name: Run the benchmarks
         env:
-          BENCH_VORTEX_RATIOS: ".*"
           RUSTFLAGS: "-C target-cpu=native"
-          HOME: /home/ci-runner
         uses: CodSpeedHQ/action@v3
         with:
           run: cargo codspeed run compare

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -23,7 +23,7 @@ jobs:
           labels: benchmark
 
   codspeed_bench:
-    name: Run benchmarks
+    name: Run Criterion benchmarks with Codspeed
     needs: label_trigger
     env:
       BENCH_TARGETS: >

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -28,10 +28,26 @@ jobs:
     strategy:
       matrix:
         benchmark:
+          - id: dict_compare
+            name: dict compare
+          - id: dict_compress
+            name: dict compress
+          - id: bitpacking_take
+            name: fastlanes bitpacking take
+          - id: run_end_filter
+            name: runend filter
+          - id: run_end_null_count
+            name: runend null count
+          - id: search_sorted
+            name: vortex-array search sorted
+          - id: scalar_subtract
+            name: vortex-array scalar subtract
           - id: compare
             name: vortex-array compare
-          - id: alp_compress
-            name: alp compress
+          - id: take_strings
+            name: vortex-array take strings
+          - id: take_patches
+            name: vortex-array take patches
     name: Run benchmarks
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,6 +28,45 @@ jobs:
           sudo apt-get update && sudo apt-get install -y jq
           bash scripts/commit-json.sh > new-commit.json
           bash scripts/cat-s3.sh vortex-benchmark-results-database commits.json new-commit.json
+
+
+  codspeed_bench:
+    name: Run benchmarks
+    env:
+      BENCH_TARGETS: >
+        dict_compare
+        dict_compress
+        bitpacking_take
+        run_end_filter
+        run_end_null_count
+        search_sorted
+        scalar_subtract
+        compare
+        take_strings
+        take_patches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cleanup
+      - uses: ./.github/actions/setup-rust
+
+      - name: Install Codspeed
+        shell: bash
+        run: cargo install --force cargo-codspeed --locked
+
+      - name: Build benchmark targets
+        env:
+          RUSTFLAGS: "-C target-cpu=native"
+        # The profile needs to be set explicitly to bench
+        # as codspeed by default compiles with the release profile.
+        run: cargo codspeed build --profile bench $BENCH_TARGETS
+
+      - name: Run the benchmarks
+        uses: CodSpeedHQ/action@v3
+        with:
+          run: cargo codspeed run $BENCH_TARGETS
+          token: ${{ secrets.CODSPEED_TOKEN }}
+
   bench:
     strategy:
       matrix:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,7 +31,7 @@ jobs:
 
 
   codspeed_bench:
-    name: Run benchmarks
+    name: Run Criterion benchmarks with Codspeed
     env:
       BENCH_TARGETS: >
         dict_compare

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,7 +481,7 @@ dependencies = [
  "bzip2",
  "cfg-if",
  "clap",
- "criterion",
+ "codspeed-criterion-compat",
  "datafusion",
  "datafusion-common",
  "datafusion-physical-plan",
@@ -798,10 +798,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "codspeed"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "450a0e9df9df1c154156f4344f99d8f6f6e69d0fc4de96ef6e2e68b2ec3bce97"
+dependencies = [
+ "colored",
+ "libc",
+ "serde_json",
+]
+
+[[package]]
+name = "codspeed-criterion-compat"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb1a6cb9c20e177fde58cdef97c1c7c9264eb1424fe45c4fccedc2fb078a569"
+dependencies = [
+ "codspeed",
+ "colored",
+ "criterion",
+ "futures",
+ "tokio",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "comfy-table"
@@ -5187,7 +5221,7 @@ dependencies = [
  "arrow-select",
  "arrow-string",
  "backtrace",
- "criterion",
+ "codspeed-criterion-compat",
  "enum-iterator",
  "flatbuffers 25.1.24",
  "flexbuffers",
@@ -5312,7 +5346,7 @@ name = "vortex-dict"
 version = "0.24.0"
 dependencies = [
  "arrow-buffer",
- "criterion",
+ "codspeed-criterion-compat",
  "divan",
  "num-traits",
  "rand",
@@ -5391,7 +5425,7 @@ version = "0.24.0"
 dependencies = [
  "arrayref",
  "arrow-buffer",
- "criterion",
+ "codspeed-criterion-compat",
  "divan",
  "fastlanes",
  "itertools 0.14.0",
@@ -5568,7 +5602,7 @@ name = "vortex-runend"
 version = "0.24.0"
 dependencies = [
  "arrow-buffer",
- "criterion",
+ "codspeed-criterion-compat",
  "itertools 0.14.0",
  "num-traits",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,9 @@ cfg-if = "1"
 chrono = "0.4.38"
 clap = "4"
 compio = { version = "0.13", features = ["io-uring"], default-features = false }
-criterion = { package = "codspeed-criterion-compat", features = ["html_reports"], version = "2.7.2" }
+criterion = { package = "codspeed-criterion-compat", features = [
+    "html_reports",
+], version = "2.7.2" }
 croaring = "2.1.0"
 crossterm = "0.28"
 datafusion = { version = "44.0.0", default-features = false }
@@ -239,14 +241,10 @@ codegen-units = 1
 lto = "thin"      # attempts to perform optimizations across all crates within the dependency graph
 
 [profile.bench]
-codegen-units = 16 # default for "release", which "bench" inherits
-debug = true
+codegen-units = 16
+debug = "full"
+lto = false
 
-[profile.benchtest]
+[profile.bench_assert]
 inherits = "bench"
 debug-assertions = true
-lto = false # bench without lto (so it builds faster)
-
-[profile.samply]
-inherits = "release"
-debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ cfg-if = "1"
 chrono = "0.4.38"
 clap = "4"
 compio = { version = "0.13", features = ["io-uring"], default-features = false }
-criterion = { version = "0.5.1", features = ["html_reports"] }
+criterion = { package = "codspeed-criterion-compat", features = ["html_reports"], version = "2.7.2" }
 croaring = "2.1.0"
 crossterm = "0.28"
 datafusion = { version = "44.0.0", default-features = false }


### PR DESCRIPTION
Run criterion benchmarks with [Codspeed](https://codspeed.io).

Further, this PR introduces 
```
[target.'(target_familiy="unix")']
rustflags = ["-C", "force-frame-pointers=yes"]
```

and cleans up the bench profile section in the top-level cargo.toml:

```
[profile.release]
codegen-units = 1
lto = "thin"      # attempts to perform optimizations across all crates within the dependency graph

[profile.bench]
codegen-units = 16
debug = "full"
lto = false

[profile.bench_assert]
inherits = "bench"
debug-assertions = true
```

In particular, thin-lto is turned off for benchmarking targets to improve compile times. The samply profile is dropped as it is redundant to `profile.bench`.