### PR TITLE
Move all arrow/datafusion -> Vortex translation efforts to `VortexExec`

### DIFF
--- a/vortex-array/src/arrow/dtype.rs
+++ b/vortex-array/src/arrow/dtype.rs
@@ -52,7 +52,7 @@ impl FromArrowType<&Schema> for DType {
     fn from_arrow(value: &Schema) -> Self {
         Self::Struct(
             Arc::new(StructDType::from_arrow(value.fields())),
-            Nullability::NonNullable, // Must match From<RecordBatch> for Array)
+            Nullability::NonNullable, // Must match From<RecordBatch> for Array
         )
     }
 }

--- a/vortex-array/src/arrow/dtype.rs
+++ b/vortex-array/src/arrow/dtype.rs
@@ -44,9 +44,15 @@ impl TryFromArrowType<&DataType> for PType {
 
 impl FromArrowType<SchemaRef> for DType {
     fn from_arrow(value: SchemaRef) -> Self {
+        Self::from_arrow(value.as_ref())
+    }
+}
+
+impl FromArrowType<&Schema> for DType {
+    fn from_arrow(value: &Schema) -> Self {
         Self::Struct(
-            Arc::new(StructDType::from_arrow(value.fields())),
-            Nullability::NonNullable, // Must match From<RecordBatch> for Array
+            Arc::new(StructDType::from_arrow(&value.fields)),
+            Nullability::NonNullable, // Must match From<RecordBatch> for Array)
         )
     }
 }

--- a/vortex-array/src/arrow/dtype.rs
+++ b/vortex-array/src/arrow/dtype.rs
@@ -51,7 +51,7 @@ impl FromArrowType<SchemaRef> for DType {
 impl FromArrowType<&Schema> for DType {
     fn from_arrow(value: &Schema) -> Self {
         Self::Struct(
-            Arc::new(StructDType::from_arrow(&value.fields)),
+            Arc::new(StructDType::from_arrow(value.fields())),
             Nullability::NonNullable, // Must match From<RecordBatch> for Array)
         )
     }

--- a/vortex-datafusion/src/persistent/config.rs
+++ b/vortex-datafusion/src/persistent/config.rs
@@ -4,8 +4,7 @@ use arrow_schema::SchemaRef;
 use datafusion::datasource::physical_plan::FileScanConfig;
 use datafusion_common::Statistics;
 use datafusion_physical_expr::LexOrdering;
-use vortex_array::arrow::FromArrowType as _;
-use vortex_dtype::{DType, FieldName};
+use vortex_dtype::FieldName;
 use vortex_expr::{ident, select, VortexExpr};
 
 /// Vortex specific methods for [`FileScanConfig`]
@@ -14,10 +13,9 @@ pub trait FileScanConfigExt {
 }
 
 impl FileScanConfigExt for FileScanConfig {
-    /// Apply the projection to the [`DType`] in addition to the original schema and statistics, and create a [`VortexExpr`] to represent it.
+    /// Apply the projection to the original schema and statistics, and create a [`VortexExpr`] to represent it.
     fn project_for_vortex(&self) -> ConfigProjection {
         let (arrow_schema, statistics, orderings) = self.project();
-        let dtype = DType::from_arrow(arrow_schema.as_ref());
         let projection_expr = match self.projection {
             None => ident(),
             Some(_) => projection_expr(&arrow_schema),
@@ -28,7 +26,6 @@ impl FileScanConfigExt for FileScanConfig {
             statistics,
             orderings,
             projection_expr,
-            dtype,
         }
     }
 }
@@ -38,7 +35,6 @@ pub struct ConfigProjection {
     pub statistics: Statistics,
     pub orderings: Vec<LexOrdering>,
     pub projection_expr: Arc<dyn VortexExpr>,
-    pub dtype: DType,
 }
 
 fn projection_expr(projected_arrow_schema: &SchemaRef) -> Arc<dyn VortexExpr> {

--- a/vortex-datafusion/src/persistent/config.rs
+++ b/vortex-datafusion/src/persistent/config.rs
@@ -1,13 +1,52 @@
-use datafusion::datasource::listing::PartitionedFile;
-use object_store::ObjectMeta;
+use std::sync::Arc;
 
-#[derive(Debug, Clone)]
-pub(crate) struct VortexFile {
-    pub(crate) object_meta: ObjectMeta,
+use arrow_schema::SchemaRef;
+use datafusion::datasource::physical_plan::FileScanConfig;
+use datafusion_common::Statistics;
+use datafusion_physical_expr::LexOrdering;
+use vortex_array::arrow::FromArrowType as _;
+use vortex_dtype::{DType, FieldName};
+use vortex_expr::{ident, select, VortexExpr};
+
+/// Vortex specific methods for [`FileScanConfig`]
+pub trait FileScanConfigExt {
+    fn project_for_vortex(&self) -> ConfigProjection;
 }
 
-impl From<VortexFile> for PartitionedFile {
-    fn from(value: VortexFile) -> Self {
-        PartitionedFile::new(value.object_meta.location, value.object_meta.size as u64)
+impl FileScanConfigExt for FileScanConfig {
+    /// Apply the projection to the [`DType`] in addition to the original schema and statistics, and create a [`VortexExpr`] to represent it.
+    fn project_for_vortex(&self) -> ConfigProjection {
+        let (arrow_schema, statistics, orderings) = self.project();
+        let dtype = DType::from_arrow(arrow_schema.as_ref());
+        let projection_expr = match self.projection {
+            None => ident(),
+            Some(_) => projection_expr(&arrow_schema),
+        };
+
+        ConfigProjection {
+            arrow_schema,
+            statistics,
+            orderings,
+            projection_expr,
+            dtype,
+        }
     }
+}
+
+pub struct ConfigProjection {
+    pub arrow_schema: SchemaRef,
+    pub statistics: Statistics,
+    pub orderings: Vec<LexOrdering>,
+    pub projection_expr: Arc<dyn VortexExpr>,
+    pub dtype: DType,
+}
+
+fn projection_expr(projected_arrow_schema: &SchemaRef) -> Arc<dyn VortexExpr> {
+    let fields = projected_arrow_schema
+        .fields()
+        .iter()
+        .map(|field| FieldName::from(field.name().clone()))
+        .collect::<Vec<_>>();
+
+    select(fields, ident())
 }

--- a/vortex-datafusion/src/persistent/execution.rs
+++ b/vortex-datafusion/src/persistent/execution.rs
@@ -13,21 +13,27 @@ use datafusion_physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion_physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use itertools::Itertools;
 use vortex_array::ContextRef;
-use vortex_dtype::FieldName;
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+use vortex_expr::datafusion::convert_expr_to_vortex;
+use vortex_expr::transform::simplify_typed::simplify_typed;
+use vortex_expr::{and, VortexExpr};
 
 use super::cache::FileLayoutCache;
+use super::config::{ConfigProjection, FileScanConfigExt};
 use crate::persistent::opener::VortexFileOpener;
 
 #[derive(Debug, Clone)]
 pub(crate) struct VortexExec {
     file_scan_config: FileScanConfig,
     metrics: ExecutionPlanMetricsSet,
-    predicate: Option<Arc<dyn PhysicalExpr>>,
+    predicate: Option<Arc<dyn VortexExpr>>,
     plan_properties: PlanProperties,
     projected_statistics: Statistics,
     ctx: ContextRef,
     initial_read_cache: FileLayoutCache,
     projected_arrow_schema: SchemaRef,
+    projection: Arc<dyn VortexExpr>,
 }
 
 impl VortexExec {
@@ -38,18 +44,25 @@ impl VortexExec {
         ctx: ContextRef,
         initial_read_cache: FileLayoutCache,
     ) -> DFResult<Self> {
-        let (projected_arrow_schema, mut projected_statistics, orderings) =
-            file_scan_config.project();
+        let ConfigProjection {
+            arrow_schema,
+            mut statistics,
+            orderings,
+            projection_expr,
+            dtype,
+        } = file_scan_config.project_for_vortex();
+
+        let predicate = make_vortex_predicate(predicate, dtype)?;
 
         // We project our statistics to only the selected columns
         // We must also take care to report in-exact statistics if we have any form of filter
         // push-down.
         if predicate.is_some() {
-            projected_statistics = projected_statistics.to_inexact();
+            statistics = statistics.to_inexact();
         }
 
         let plan_properties = PlanProperties::new(
-            EquivalenceProperties::new_with_orderings(projected_arrow_schema.clone(), &orderings),
+            EquivalenceProperties::new_with_orderings(arrow_schema.clone(), &orderings),
             Partitioning::UnknownPartitioning(file_scan_config.file_groups.len()),
             EmissionType::Incremental,
             Boundedness::Bounded,
@@ -60,10 +73,11 @@ impl VortexExec {
             metrics,
             predicate,
             plan_properties,
-            projected_statistics,
             ctx,
             initial_read_cache,
-            projected_arrow_schema,
+            projected_statistics: statistics,
+            projected_arrow_schema: arrow_schema,
+            projection: projection_expr,
         })
     }
 
@@ -114,22 +128,13 @@ impl ExecutionPlan for VortexExec {
         let object_store = context
             .runtime_env()
             .object_store(&self.file_scan_config.object_store_url)?;
-        let file_schema = self.file_scan_config.file_schema.clone();
-        let projection = self.file_scan_config.projection.as_ref().map(|projection| {
-            projection
-                .iter()
-                .map(|i| FieldName::from(file_schema.fields[*i].name().clone()))
-                .collect()
-        });
 
-        // TODO(joe): apply the predicate/filter mapping to vortex-expr once.
         let opener = VortexFileOpener::new(
             self.ctx.clone(),
             object_store,
-            projection,
+            self.projection.clone(),
             self.predicate.clone(),
             self.initial_read_cache.clone(),
-            file_schema,
             self.projected_arrow_schema.clone(),
         )?;
         let stream = FileStream::new(&self.file_scan_config, partition, opener, &self.metrics)?;
@@ -160,6 +165,26 @@ impl ExecutionPlan for VortexExec {
 
         Ok(Some(Arc::new(new_plan)))
     }
+}
+
+fn make_vortex_predicate(
+    predicate: Option<Arc<dyn PhysicalExpr>>,
+    dtype: DType,
+) -> VortexResult<Option<Arc<dyn VortexExpr>>> {
+    predicate
+        .as_ref()
+        // If we cannot convert an expr to a vortex expr, we run no filter, since datafusion
+        // will rerun the filter expression anyway.
+        .and_then(|expr| {
+            // This splits expressions into conjunctions and converts them to vortex expressions.
+            // Any inconvertible expressions are dropped since true /\ a == a.
+            datafusion_physical_expr::split_conjunction(expr)
+                .into_iter()
+                .filter_map(|e| convert_expr_to_vortex(e.clone()).ok())
+                .reduce(and)
+                .map(|expr| simplify_typed(expr, &dtype))
+        })
+        .transpose()
 }
 
 fn repartition_by_size(

--- a/vortex-datafusion/src/persistent/execution.rs
+++ b/vortex-datafusion/src/persistent/execution.rs
@@ -54,8 +54,7 @@ impl VortexExec {
 
         let predicate = make_vortex_predicate(predicate, dtype)?;
 
-        // We project our statistics to only the selected columns
-        // We must also take care to report in-exact statistics if we have any form of filter
+        // We must take care to report in-exact statistics if we have any form of filter
         // push-down.
         if predicate.is_some() {
             statistics = statistics.to_inexact();

--- a/vortex-datafusion/src/persistent/execution.rs
+++ b/vortex-datafusion/src/persistent/execution.rs
@@ -13,10 +13,7 @@ use datafusion_physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion_physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use itertools::Itertools;
 use vortex_array::ContextRef;
-use vortex_dtype::DType;
-use vortex_error::VortexResult;
 use vortex_expr::datafusion::convert_expr_to_vortex;
-use vortex_expr::transform::simplify_typed::simplify_typed;
 use vortex_expr::{and, VortexExpr};
 
 use super::cache::FileLayoutCache;
@@ -49,10 +46,9 @@ impl VortexExec {
             mut statistics,
             orderings,
             projection_expr,
-            dtype,
         } = file_scan_config.project_for_vortex();
 
-        let predicate = make_vortex_predicate(predicate, dtype)?;
+        let predicate = make_vortex_predicate(predicate);
 
         // We must take care to report in-exact statistics if we have any form of filter
         // push-down.
@@ -166,10 +162,7 @@ impl ExecutionPlan for VortexExec {
     }
 }
 
-fn make_vortex_predicate(
-    predicate: Option<Arc<dyn PhysicalExpr>>,
-    dtype: DType,
-) -> VortexResult<Option<Arc<dyn VortexExpr>>> {
+fn make_vortex_predicate(predicate: Option<Arc<dyn PhysicalExpr>>) -> Option<Arc<dyn VortexExpr>> {
     predicate
         .as_ref()
         // If we cannot convert an expr to a vortex expr, we run no filter, since datafusion
@@ -181,9 +174,7 @@ fn make_vortex_predicate(
                 .into_iter()
                 .filter_map(|e| convert_expr_to_vortex(e.clone()).ok())
                 .reduce(and)
-                .map(|expr| simplify_typed(expr, &dtype))
         })
-        .transpose()
 }
 
 fn repartition_by_size(


### PR DESCRIPTION
1. Saves on clones
2. Everything happens in a single place without any intermediate state between stages.