### PR TITLE
Improve expression performance

### DIFF
--- a/bench-vortex/src/clickbench.rs
+++ b/bench-vortex/src/clickbench.rs
@@ -184,7 +184,7 @@ pub async fn register_vortex_files(
                     for st in sts.into_iter() {
                         let struct_dtype = st.dtype().as_struct().unwrap();
                         let names = struct_dtype.names().iter();
-                        let types = struct_dtype.dtypes();
+                        let types = struct_dtype.fields();
 
                         for (field_name, field_type) in names.zip(types) {
                             let val = arrays_map.entry(field_name.clone()).or_default();

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -241,7 +241,7 @@ impl CompressionRunStats {
 
         self.compressed_sizes
             .iter()
-            .zip_eq(st.names().iter().zip_eq(st.dtypes()))
+            .zip_eq(st.names().iter().zip_eq(st.fields()))
             .map(
                 |(&size, (column_name, column_type))| CompressionRunResults {
                     dataset_name: dataset_name.clone(),

--- a/bench-vortex/src/tpch/mod.rs
+++ b/bench-vortex/src/tpch/mod.rs
@@ -224,7 +224,7 @@ async fn register_vortex_file(
         for st in sts.into_iter() {
             let struct_dtype = st.dtype().as_struct().unwrap();
             let names = struct_dtype.names().iter();
-            let types = struct_dtype.dtypes();
+            let types = struct_dtype.fields();
 
             for (field_name, field_type) in names.zip(types) {
                 let val = arrays_map.entry(field_name.clone()).or_default();

--- a/fuzz/fuzz_targets/file_io.rs
+++ b/fuzz/fuzz_targets/file_io.rs
@@ -116,6 +116,6 @@ fn has_nullable_struct(dtype: &DType) -> bool {
     dtype.is_nullable()
         || dtype
             .as_struct()
-            .map(|sdt| sdt.dtypes().any(|dtype| has_nullable_struct(&dtype)))
+            .map(|sdt| sdt.fields().any(|dtype| has_nullable_struct(&dtype)))
             .unwrap_or(false)
 }

--- a/pyvortex/src/dtype/struct_.rs
+++ b/pyvortex/src/dtype/struct_.rs
@@ -28,7 +28,7 @@ impl PyStructDType {
         };
 
         let mut fields = Vec::with_capacity(dtype.names().len());
-        for dtype in dtype.dtypes() {
+        for dtype in dtype.fields() {
             fields.push(PyDType::init(self_.py(), dtype)?);
         }
         Ok(fields)

--- a/pyvortex/src/encoding/builtins/struct_.rs
+++ b/pyvortex/src/encoding/builtins/struct_.rs
@@ -1,4 +1,3 @@
-use pyo3::exceptions::PyKeyError;
 use pyo3::{pyclass, pymethods, Bound, PyRef, PyResult};
 use vortex::array::StructEncoding;
 use vortex::variants::StructArrayTrait;
@@ -22,10 +21,7 @@ impl PyStructEncoding {
 
     /// Returns the given field of the struct array.
     pub fn field<'py>(self_: PyRef<'py, Self>, name: &str) -> PyResult<Bound<'py, PyArray>> {
-        let field = self_
-            .as_array_ref()
-            .maybe_null_field_by_name(name)
-            .ok_or_else(|| PyKeyError::new_err(format!("Field name not found: {}", name)))?;
+        let field = self_.as_array_ref().maybe_null_field_by_name(name)?;
         PyArray::init(self_.py(), field)
     }
 }

--- a/pyvortex/src/python_repr.rs
+++ b/pyvortex/src/python_repr.rs
@@ -55,7 +55,7 @@ impl Display for DTypePythonRepr<'_> {
                 "struct({{{}}}, nullable={})",
                 st.names()
                     .iter()
-                    .zip(st.dtypes())
+                    .zip(st.fields())
                     .map(|(n, dt)| format!("\"{}\": {}", n, dt.python_repr()))
                     .join(", "),
                 n.python_repr()

--- a/pyvortex/src/scalar/struct_.rs
+++ b/pyvortex/src/scalar/struct_.rs
@@ -1,4 +1,3 @@
-use pyo3::exceptions::PyKeyError;
 use pyo3::{pyclass, pymethods, IntoPy, PyObject, PyRef, PyResult};
 use vortex::scalar::StructScalar;
 
@@ -18,9 +17,7 @@ impl PyStructScalar {
     /// Return the child scalar with the given field name.
     pub fn field(self_: PyRef<'_, Self>, name: &str) -> PyResult<PyObject> {
         let scalar = self_.as_scalar_ref();
-        let child = scalar
-            .field_by_name(name)
-            .ok_or_else(|| PyKeyError::new_err(format!("Field not found {}", name)))?;
+        let child = scalar.field(name)?;
         Ok(PyVortex(&child).into_py(self_.py()))
     }
 }

--- a/vortex-array/src/array/arbitrary.rs
+++ b/vortex-array/src/array/arbitrary.rs
@@ -59,7 +59,7 @@ fn random_array(u: &mut Unstructured, dtype: &DType, len: Option<usize>) -> Resu
                 DType::Binary(n) => random_bytes(u, *n, chunk_len),
                 DType::Struct(sdt, n) => {
                     let first_array = sdt
-                        .dtypes()
+                        .fields()
                         .next()
                         .map(|d| random_array(u, &d, chunk_len))
                         .transpose()?;
@@ -73,7 +73,7 @@ fn random_array(u: &mut Unstructured, dtype: &DType, len: Option<usize>) -> Resu
                         .into_iter()
                         .map(Ok)
                         .chain(
-                            sdt.dtypes()
+                            sdt.fields()
                                 .skip(1)
                                 .map(|d| random_array(u, &d, Some(resolved_len))),
                         )

--- a/vortex-array/src/array/constant/variants.rs
+++ b/vortex-array/src/array/constant/variants.rs
@@ -74,7 +74,7 @@ impl Utf8ArrayTrait for ConstantArray {}
 impl BinaryArrayTrait for ConstantArray {}
 
 impl StructArrayTrait for ConstantArray {
-    fn maybe_null_field_by_idx(&self, idx: usize) -> Option<Array> {
+    fn maybe_null_field_by_idx(&self, idx: usize) -> VortexResult<Array> {
         self.scalar()
             .as_struct()
             .field_by_idx(idx)

--- a/vortex-array/src/arrow/dtype.rs
+++ b/vortex-array/src/arrow/dtype.rs
@@ -114,7 +114,7 @@ pub fn infer_schema(dtype: &DType) -> VortexResult<Schema> {
     }
 
     let mut builder = SchemaBuilder::with_capacity(struct_dtype.names().len());
-    for (field_name, field_dtype) in struct_dtype.names().iter().zip(struct_dtype.dtypes()) {
+    for (field_name, field_dtype) in struct_dtype.names().iter().zip(struct_dtype.fields()) {
         builder.push(FieldRef::from(Field::new(
             field_name.to_string(),
             infer_data_type(&field_dtype)?,
@@ -149,7 +149,7 @@ pub fn infer_data_type(dtype: &DType) -> VortexResult<DataType> {
         DType::Binary(_) => DataType::BinaryView,
         DType::Struct(struct_dtype, _) => {
             let mut fields = Vec::with_capacity(struct_dtype.names().len());
-            for (field_name, field_dt) in struct_dtype.names().iter().zip(struct_dtype.dtypes()) {
+            for (field_name, field_dt) in struct_dtype.names().iter().zip(struct_dtype.fields()) {
                 fields.push(FieldRef::from(Field::new(
                     field_name.to_string(),
                     infer_data_type(&field_dt)?,

--- a/vortex-array/src/builders/struct_.rs
+++ b/vortex-array/src/builders/struct_.rs
@@ -26,7 +26,7 @@ impl StructBuilder {
         capacity: usize,
     ) -> Self {
         let builders = struct_dtype
-            .dtypes()
+            .fields()
             .map(|dt| builder_with_capacity(&dt, capacity))
             .collect();
 

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -362,23 +362,6 @@ impl Patches {
         }
         Ok(Self::new(self.array_len, self.indices, values))
     }
-
-    pub fn map_values_opt<F>(self, f: F) -> VortexResult<Option<Self>>
-    where
-        F: FnOnce(Array) -> Option<Array>,
-    {
-        let Some(values) = f(self.values) else {
-            return Ok(None);
-        };
-        if self.indices.len() == values.len() {
-            vortex_bail!(
-                "map_values must preserve length: expected {} received {}",
-                self.indices.len(),
-                values.len()
-            )
-        }
-        Ok(Some(Self::new(self.array_len, self.indices, values)))
-    }
 }
 
 /// Filter patches with the provided mask (in flattened space).

--- a/vortex-datafusion/src/memory/statistics.rs
+++ b/vortex-datafusion/src/memory/statistics.rs
@@ -5,7 +5,7 @@ use vortex_array::array::ChunkedArray;
 use vortex_array::stats::{Stat, Statistics as _};
 use vortex_array::variants::StructArrayTrait;
 use vortex_dtype::FieldNames;
-use vortex_error::{vortex_err, VortexExpect, VortexResult};
+use vortex_error::{VortexExpect, VortexResult};
 
 use crate::converter::directional_bound_to_df_precision;
 
@@ -16,11 +16,7 @@ pub(crate) fn chunked_array_df_stats(
     let mut nbytes: usize = 0;
     let column_statistics = projection
         .iter()
-        .map(|name| {
-            array
-                .maybe_null_field_by_name(name)
-                .ok_or_else(|| vortex_err!("Projection references unknown field {name}"))
-        })
+        .map(|name| array.maybe_null_field_by_name(name))
         .map_ok(|arr| {
             nbytes += arr.nbytes();
             ColumnStatistics {

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -112,8 +112,8 @@ impl DType {
             (Struct(lhs_dtype, _), Struct(rhs_dtype, _)) => {
                 (lhs_dtype.names() == rhs_dtype.names())
                     && (lhs_dtype
-                        .dtypes()
-                        .zip_eq(rhs_dtype.dtypes())
+                        .fields()
+                        .zip_eq(rhs_dtype.fields())
                         .all(|(l, r)| l.eq_ignore_nullability(&r)))
             }
             (Struct(..), _) => false,
@@ -184,7 +184,7 @@ impl Display for DType {
                 "{{{}}}{}",
                 sdt.names()
                     .iter()
-                    .zip(sdt.dtypes())
+                    .zip(sdt.fields())
                     .map(|(n, dt)| format!("{}={}", n, dt))
                     .join(", "),
                 n

--- a/vortex-dtype/src/field.rs
+++ b/vortex-dtype/src/field.rs
@@ -8,18 +8,15 @@ use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
 use itertools::Itertools;
-use vortex_error::{vortex_err, VortexResult};
-
-use crate::FieldNames;
 
 /// A selector for a field in a struct
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Field {
-    /// A field selector by name
+    /// Address a field of a [`crate::DType::Struct`].
     Name(Arc<str>),
-    /// A field selector by index (position)
-    Index(usize),
+    /// Address the element type of a [`crate::DType::List`].
+    ElementType,
 }
 
 impl From<&str> for Field {
@@ -34,17 +31,12 @@ impl From<String> for Field {
     }
 }
 
-impl From<usize> for Field {
-    fn from(value: usize) -> Self {
-        Field::Index(value)
-    }
-}
-
 impl Display for Field {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Field::Name(name) => write!(f, "${name}"),
-            Field::Index(idx) => write!(f, "[{idx}]"),
+            Field::ElementType => write!(f, "[]"),
+            Field::StorageType => write!(f, "ext"),
         }
     }
 }
@@ -53,47 +45,6 @@ impl Field {
     /// Returns true if the field is defined by Name
     pub fn is_named(&self) -> bool {
         matches!(self, Field::Name(_))
-    }
-
-    /// Returns true if the field is defined by Index
-    pub fn is_indexed(&self) -> bool {
-        matches!(self, Field::Index(_))
-    }
-
-    /// Convert a field to a named field
-    pub fn into_named_field(self, field_names: &FieldNames) -> VortexResult<Self> {
-        match self {
-            Field::Index(idx) => field_names
-                .get(idx)
-                .ok_or_else(|| {
-                    vortex_err!(
-                        "Field index {} out of bounds, it has names {:?}",
-                        idx,
-                        field_names
-                    )
-                })
-                .cloned()
-                .map(Field::Name),
-            Field::Name(_) => Ok(self),
-        }
-    }
-
-    /// Convert a field to an indexed field
-    pub fn into_index_field(self, field_names: &FieldNames) -> VortexResult<Self> {
-        match self {
-            Field::Name(name) => field_names
-                .iter()
-                .position(|n| *n == name)
-                .ok_or_else(|| {
-                    vortex_err!(
-                        "Field name {} not found, it has names {:?}",
-                        name,
-                        field_names
-                    )
-                })
-                .map(Field::Index),
-            Field::Index(_) => Ok(self),
-        }
     }
 }
 

--- a/vortex-dtype/src/field.rs
+++ b/vortex-dtype/src/field.rs
@@ -36,7 +36,6 @@ impl Display for Field {
         match self {
             Field::Name(name) => write!(f, "${name}"),
             Field::ElementType => write!(f, "[]"),
-            Field::StorageType => write!(f, "ext"),
         }
     }
 }

--- a/vortex-dtype/src/serde/flatbuffers/mod.rs
+++ b/vortex-dtype/src/serde/flatbuffers/mod.rs
@@ -210,7 +210,7 @@ impl WriteFlatBuffer for DType {
                 let names = Some(fbb.create_vector(&names));
 
                 let dtypes = st
-                    .dtypes()
+                    .fields()
                     .map(|dtype| dtype.write_flatbuffer(fbb))
                     .collect_vec();
                 let dtypes = Some(fbb.create_vector(&dtypes));

--- a/vortex-dtype/src/serde/flatbuffers/project.rs
+++ b/vortex-dtype/src/serde/flatbuffers/project.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use vortex_error::{vortex_err, VortexResult};
+use vortex_error::{vortex_bail, vortex_err, VortexResult};
 use vortex_flatbuffers::FlatBuffer;
 
 use crate::field::Field;
@@ -20,7 +20,7 @@ pub fn resolve_field<'a, 'b: 'a>(fb: fb::Struct_<'b>, field: &'a Field) -> Vorte
                 .position(|name| name == &**n)
                 .ok_or_else(|| vortex_err!("Unknown field name {n}"))
         }
-        Field::Index(i) => Ok(*i),
+        _ => vortex_bail!("Only field names are supported for now"),
     }
 }
 

--- a/vortex-dtype/src/serde/proto.rs
+++ b/vortex-dtype/src/serde/proto.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use vortex_error::{vortex_err, VortexError, VortexResult, VortexUnwrap};
+use vortex_error::{vortex_err, VortexError, VortexResult};
 
 use crate::field::{Field, FieldPath};
 use crate::proto::dtype as pb;
@@ -146,9 +146,6 @@ impl TryFrom<&pb::FieldPath> for FieldPath {
                 .ok_or_else(|| vortex_err!(InvalidSerde: "FieldPath part missing type"))?
             {
                 FieldType::Name(name) => path.push(Field::from(name.as_str())),
-                FieldType::Index(idx) => {
-                    path.push(Field::from(usize::try_from(*idx).vortex_unwrap()))
-                }
             }
         }
         Ok(FieldPath::from(path))

--- a/vortex-dtype/src/serde/proto.rs
+++ b/vortex-dtype/src/serde/proto.rs
@@ -79,7 +79,7 @@ impl From<&DType> for pb::DType {
                 }),
                 DType::Struct(s, n) => DtypeType::Struct(pb::Struct {
                     names: s.names().iter().map(|s| s.as_ref().to_string()).collect(),
-                    dtypes: s.dtypes().map(|d| Self::from(&d)).collect(),
+                    dtypes: s.fields().map(|d| Self::from(&d)).collect(),
                     nullable: (*n).into(),
                 }),
                 DType::List(l, n) => DtypeType::List(Box::new(pb::List {

--- a/vortex-expr/src/binary.rs
+++ b/vortex-expr/src/binary.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use vortex_array::compute::{and_kleene, compare, or_kleene, Operator as ArrayOperator};
 use vortex_array::Array;
+use vortex_dtype::DType;
 use vortex_error::VortexResult;
 
 use crate::{ExprRef, Operator, VortexExpr};
@@ -69,6 +70,12 @@ impl VortexExpr for BinaryExpr {
     fn replacing_children(self: Arc<Self>, children: Vec<ExprRef>) -> ExprRef {
         assert_eq!(children.len(), 2);
         BinaryExpr::new_expr(children[0].clone(), self.operator, children[1].clone())
+    }
+
+    fn return_dtype(&self, scope_dtype: &DType) -> VortexResult<DType> {
+        let lhs = self.lhs.return_dtype(scope_dtype)?;
+        let rhs = self.rhs.return_dtype(scope_dtype)?;
+        Ok(DType::Bool((lhs.is_nullable() || rhs.is_nullable()).into()))
     }
 }
 

--- a/vortex-expr/src/identity.rs
+++ b/vortex-expr/src/identity.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 use std::sync::{Arc, LazyLock};
 
 use vortex_array::Array;
+use vortex_dtype::DType;
 use vortex_error::VortexResult;
 
 use crate::{ExprRef, VortexExpr};
@@ -40,6 +41,10 @@ impl VortexExpr for Identity {
     fn replacing_children(self: Arc<Self>, children: Vec<ExprRef>) -> ExprRef {
         assert_eq!(children.len(), 0);
         self
+    }
+
+    fn return_dtype(&self, scope_dtype: &DType) -> VortexResult<DType> {
+        Ok(scope_dtype.clone())
     }
 }
 

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -35,7 +35,7 @@ pub use operators::*;
 pub use pack::*;
 pub use select::*;
 use vortex_array::aliases::hash_set::HashSet;
-use vortex_array::{Array, Canonical, IntoArray as _};
+use vortex_array::Array;
 use vortex_dtype::{DType, FieldName};
 use vortex_error::{VortexResult, VortexUnwrap};
 
@@ -68,11 +68,7 @@ pub trait VortexExpr: Debug + Send + Sync + DynEq + DynHash + Display {
     fn replacing_children(self: Arc<Self>, children: Vec<ExprRef>) -> ExprRef;
 
     /// Compute the type of the array returned by [VortexExpr::evaluate].
-    fn return_dtype(&self, scope_dtype: &DType) -> VortexResult<DType> {
-        let empty = Canonical::empty(scope_dtype).into_array();
-        self.unchecked_evaluate(&empty)
-            .map(|array| array.dtype().clone())
-    }
+    fn return_dtype(&self, scope_dtype: &DType) -> VortexResult<DType>;
 }
 
 pub trait VortexExprExt {

--- a/vortex-expr/src/like.rs
+++ b/vortex-expr/src/like.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use vortex_array::compute::{like, LikeOptions};
 use vortex_array::Array;
+use vortex_dtype::DType;
 use vortex_error::VortexResult;
 
 use crate::{ExprRef, VortexExpr};
@@ -86,6 +87,14 @@ impl VortexExpr for Like {
             self.negated,
             self.case_insensitive,
         )
+    }
+
+    fn return_dtype(&self, scope_dtype: &DType) -> VortexResult<DType> {
+        let input = self.child().return_dtype(scope_dtype)?;
+        let pattern = self.pattern().return_dtype(scope_dtype)?;
+        Ok(DType::Bool(
+            (input.is_nullable() || pattern.is_nullable()).into(),
+        ))
     }
 }
 

--- a/vortex-expr/src/literal.rs
+++ b/vortex-expr/src/literal.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use vortex_array::array::ConstantArray;
 use vortex_array::{Array, IntoArray};
+use vortex_dtype::DType;
 use vortex_error::VortexResult;
 use vortex_scalar::Scalar;
 
@@ -48,6 +49,10 @@ impl VortexExpr for Literal {
     fn replacing_children(self: Arc<Self>, children: Vec<ExprRef>) -> ExprRef {
         assert_eq!(children.len(), 0);
         self
+    }
+
+    fn return_dtype(&self, _scope_dtype: &DType) -> VortexResult<DType> {
+        Ok(self.value.dtype().clone())
     }
 }
 

--- a/vortex-expr/src/merge.rs
+++ b/vortex-expr/src/merge.rs
@@ -125,10 +125,10 @@ impl VortexExpr for Merge {
                 let field_name = struct_dtype.field_name(i).vortex_expect("never OOB");
                 let field_dtype = struct_dtype.field_by_index(i).vortex_expect("never OOB");
                 if let Some(idx) = field_names.iter().position(|name| name == field_name) {
-                    arrays[idx] = field_dtype.into();
+                    arrays[idx] = field_dtype;
                 } else {
                     field_names.push(field_name.clone());
-                    arrays.push(field_dtype.into());
+                    arrays.push(field_dtype);
                 }
             }
         }

--- a/vortex-expr/src/merge.rs
+++ b/vortex-expr/src/merge.rs
@@ -7,7 +7,7 @@ use itertools::Itertools as _;
 use vortex_array::array::StructArray;
 use vortex_array::validity::Validity;
 use vortex_array::{Array, IntoArray};
-use vortex_dtype::FieldNames;
+use vortex_dtype::{DType, FieldNames, Nullability, StructDType};
 use vortex_error::{vortex_bail, VortexExpect as _, VortexResult};
 
 use crate::{ExprRef, VortexExpr};
@@ -106,6 +106,38 @@ impl VortexExpr for Merge {
     fn replacing_children(self: Arc<Self>, children: Vec<ExprRef>) -> ExprRef {
         Self::new_expr(children)
     }
+
+    fn return_dtype(&self, scope_dtype: &DType) -> VortexResult<DType> {
+        let mut field_names = Vec::new();
+        let mut arrays = Vec::new();
+
+        for value in self.values.iter() {
+            let dtype = value.return_dtype(scope_dtype)?;
+            if !dtype.is_struct() {
+                vortex_bail!("merge expects non-nullable struct input");
+            }
+
+            let struct_dtype = dtype
+                .as_struct()
+                .vortex_expect("merge expects struct input");
+
+            for i in 0..struct_dtype.nfields() {
+                let field_name = struct_dtype.field_name(i).vortex_expect("never OOB");
+                let field_dtype = struct_dtype.field_by_index(i).vortex_expect("never OOB");
+                if let Some(idx) = field_names.iter().position(|name| name == field_name) {
+                    arrays[idx] = field_dtype.into();
+                } else {
+                    field_names.push(field_name.clone());
+                    arrays.push(field_dtype.into());
+                }
+            }
+        }
+
+        Ok(DType::Struct(
+            Arc::new(StructDType::new(FieldNames::from(field_names), arrays)),
+            Nullability::NonNullable,
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -127,15 +159,13 @@ mod tests {
         let mut array = array
             .as_struct_array()
             .ok_or_else(|| vortex_err!("expected a struct"))?
-            .maybe_null_field_by_name(field)
-            .ok_or_else(|| vortex_err!("expected field to exist: {}", field))?;
+            .maybe_null_field_by_name(field)?;
 
         for field in field_path {
             array = array
                 .as_struct_array()
                 .ok_or_else(|| vortex_err!("expected a struct"))?
-                .maybe_null_field_by_name(field)
-                .ok_or_else(|| vortex_err!("expected field to exist: {}", field))?;
+                .maybe_null_field_by_name(field)?;
         }
         Ok(array.into_primitive().unwrap())
     }

--- a/vortex-expr/src/not.rs
+++ b/vortex-expr/src/not.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use vortex_array::compute::invert;
 use vortex_array::Array;
+use vortex_dtype::DType;
 use vortex_error::VortexResult;
 
 use crate::{ExprRef, VortexExpr};
@@ -50,6 +51,10 @@ impl VortexExpr for Not {
     fn replacing_children(self: Arc<Self>, mut children: Vec<ExprRef>) -> ExprRef {
         assert_eq!(children.len(), 0);
         Self::new_expr(children.remove(0))
+    }
+
+    fn return_dtype(&self, scope_dtype: &DType) -> VortexResult<DType> {
+        self.child.return_dtype(scope_dtype)
     }
 }
 

--- a/vortex-expr/src/transform/partition.rs
+++ b/vortex-expr/src/transform/partition.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use vortex_array::aliases::hash_map::HashMap;
-use vortex_dtype::{DType, Field, FieldName, StructDType};
+use vortex_dtype::{DType, FieldName, StructDType};
 use vortex_error::{vortex_bail, VortexExpect, VortexResult};
 
 use crate::transform::immediate_access::{immediate_scope_accesses, FieldAccesses};
@@ -95,10 +95,7 @@ impl<'a> StructFieldExpressionSplitter<'a> {
             .sub_expressions
             .into_iter()
             .map(|(name, exprs)| {
-                let field_dtype = scope_dtype
-                    .field_info(&Field::Name(name.clone()))?
-                    .dtype
-                    .value()?;
+                let field_dtype = scope_dtype.field(&name)?;
                 // If there is a single expr then we don't need to `pack` this, and we must update
                 // the root expr removing this access.
                 let expr = if exprs.len() == 1 {

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -247,7 +247,7 @@ async fn unequal_batches() {
             .unwrap()
             .maybe_null_field_by_name("numbers");
 
-        if let Some(numbers) = numbers {
+        if let Ok(numbers) = numbers {
             let numbers = numbers.into_primitive().unwrap();
             assert_eq!(numbers.ptype(), PType::U32);
         } else {

--- a/vortex-layout/src/layouts/chunked/stats_table.rs
+++ b/vortex-layout/src/layouts/chunked/stats_table.rs
@@ -117,7 +117,8 @@ impl StatsTable {
             .array
             .as_struct_array()
             .vortex_expect("Stats table must be a struct array")
-            .maybe_null_field_by_name(stat.name()))
+            .maybe_null_field_by_name(stat.name())
+            .ok())
     }
 }
 

--- a/vortex-layout/src/layouts/struct_/eval_expr.rs
+++ b/vortex-layout/src/layouts/struct_/eval_expr.rs
@@ -61,7 +61,7 @@ mod tests {
     use vortex_array::{IntoArray, IntoArrayVariant};
     use vortex_buffer::buffer;
     use vortex_dtype::PType::I32;
-    use vortex_dtype::{DType, Field, Nullability, StructDType};
+    use vortex_dtype::{DType, Nullability, StructDType};
     use vortex_expr::{get_item, gt, ident, pack};
     use vortex_mask::Mask;
     use vortex_scan::RowMask;
@@ -170,7 +170,7 @@ mod tests {
             result
                 .as_struct_array()
                 .unwrap()
-                .maybe_null_field(&Field::Name("a".into()))
+                .maybe_null_field_by_name("a")
                 .unwrap()
                 .into_primitive()
                 .unwrap()
@@ -182,7 +182,7 @@ mod tests {
             result
                 .as_struct_array()
                 .unwrap()
-                .maybe_null_field(&Field::Name("b".into()))
+                .maybe_null_field_by_name("b")
                 .unwrap()
                 .into_primitive()
                 .unwrap()

--- a/vortex-layout/src/layouts/struct_/eval_stats.rs
+++ b/vortex-layout/src/layouts/struct_/eval_stats.rs
@@ -24,11 +24,8 @@ impl StatsEvaluator for StructReader {
                 futures.push(ready(Ok(vec![StatsSet::default()])).boxed());
             } else {
                 // Otherwise, strip off the first path element and delegate to the child layout
-                let Field::Name(field) = path.path()[0]
-                    .clone()
-                    .into_named_field(self.struct_dtype().names())?
-                else {
-                    vortex_bail!("Field not found: {}", path);
+                let Field::Name(field) = path.path()[0].clone() else {
+                    vortex_bail!("Expected Field::Name")
                 };
                 let child_path = path
                     .clone()

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -76,14 +76,14 @@ impl StructReader {
             .field_lookup
             .as_ref()
             .and_then(|lookup| lookup.get(name).copied())
-            .or_else(|| self.struct_dtype().find_name(name))
+            .or_else(|| self.struct_dtype().find(name).ok())
             .ok_or_else(|| vortex_err!("Field {} not found in struct layout", name))?;
 
         // TODO: think about a Hashmap<FieldName, OnceLock<Arc<dyn LayoutReader>>> for large |fields|.
         self.field_readers[idx].get_or_try_init(|| {
             let child_layout = self
                 .layout
-                .child(idx, self.struct_dtype().field_dtype(idx)?)?;
+                .child(idx, self.struct_dtype().field_by_index(idx)?)?;
             child_layout.reader(self.segments.clone(), self.ctx.clone())
         })
     }

--- a/vortex-layout/src/layouts/struct_/writer.rs
+++ b/vortex-layout/src/layouts/struct_/writer.rs
@@ -19,7 +19,7 @@ pub struct StructLayoutWriter {
 impl StructLayoutWriter {
     pub fn new(dtype: DType, column_layout_writers: Vec<Box<dyn LayoutWriter>>) -> Self {
         let struct_dtype = dtype.as_struct().vortex_expect("dtype is not a struct");
-        if struct_dtype.dtypes().len() != column_layout_writers.len() {
+        if struct_dtype.fields().len() != column_layout_writers.len() {
             vortex_panic!(
                 "number of fields in struct dtype does not match number of column layout writers"
             );
@@ -39,7 +39,7 @@ impl StructLayoutWriter {
         Ok(Self::new(
             dtype.clone(),
             struct_dtype
-                .dtypes()
+                .fields()
                 .map(|dtype| factory.new_writer(&dtype))
                 .try_collect()?,
         ))

--- a/vortex-layout/src/scan/mod.rs
+++ b/vortex-layout/src/scan/mod.rs
@@ -107,39 +107,18 @@ impl<D: ScanDriver> ScanBuilder<D> {
         self.driver_options = Some(options);
         self
     }
-
-    /// Compute a mask of field paths referenced by this scan.
-    fn field_mask(&self, scope_dtype: &DType) -> VortexResult<Vec<FieldMask>> {
-        // TODO(joe): simplify this expr once
-        let projection = simplify_typed(self.projection.clone(), scope_dtype)?;
-        let filter = self
-            .filter
-            .clone()
-            .map(|f| simplify_typed(f, scope_dtype))
-            .transpose()?;
-
-        let Some(struct_dtype) = scope_dtype.as_struct() else {
-            return Ok(vec![FieldMask::All]);
-        };
-
-        let projection_mask = immediate_scope_access(&projection, struct_dtype)?;
-        let filter_mask = filter
-            .map(|f| immediate_scope_access(&f, struct_dtype))
-            .transpose()?
-            .unwrap_or_default();
-
-        Ok(projection_mask
-            .union(&filter_mask)
-            .cloned()
-            .map(|c| FieldMask::Prefix(FieldPath::from(Field::Name(c))))
-            .collect_vec())
-    }
 }
 
 impl<D: ScanDriver> ScanBuilder<D> {
     /// Perform the scan operation and return a stream of arrays.
     pub fn into_array_stream(self) -> VortexResult<impl ArrayStream + 'static> {
-        let field_mask = self.field_mask(self.layout.dtype())?;
+        let projection = simplify_typed(self.projection, self.layout.dtype())?;
+        let filter = self
+            .filter
+            .map(|f| simplify_typed(f, self.layout.dtype()))
+            .transpose()?;
+
+        let field_mask = field_mask(&projection, filter.as_ref(), self.layout.dtype())?;
 
         let splits = self.split_by.splits(&self.layout, &field_mask)?;
         let row_indices = self.row_indices.clone();
@@ -192,17 +171,10 @@ impl<D: ScanDriver> ScanBuilder<D> {
             })
             .collect_vec();
 
-        self.into_stream_with_masks(row_masks)
-    }
-
-    fn into_stream_with_masks(
-        self,
-        row_masks: Vec<RowMask>,
-    ) -> VortexResult<impl ArrayStream + 'static + use<D>> {
         let scanner = Arc::new(Scanner::new(
             self.layout.dtype().clone(),
-            self.projection,
-            self.filter,
+            projection,
+            filter,
         )?);
 
         let result_dtype = scanner.result_dtype().clone();
@@ -255,4 +227,29 @@ impl<D: ScanDriver> ScanBuilder<D> {
     pub async fn into_array(self) -> VortexResult<Array> {
         self.into_array_stream()?.into_array().await
     }
+}
+
+/// Compute a mask of field paths referenced by this scan.
+///
+/// Projection and filter must be pre-simplified.
+fn field_mask(
+    projection: &ExprRef,
+    filter: Option<&ExprRef>,
+    scope_dtype: &DType,
+) -> VortexResult<Vec<FieldMask>> {
+    let Some(struct_dtype) = scope_dtype.as_struct() else {
+        return Ok(vec![FieldMask::All]);
+    };
+
+    let projection_mask = immediate_scope_access(&projection, struct_dtype)?;
+    let filter_mask = filter
+        .map(|f| immediate_scope_access(&f, struct_dtype))
+        .transpose()?
+        .unwrap_or_default();
+
+    Ok(projection_mask
+        .union(&filter_mask)
+        .cloned()
+        .map(|c| FieldMask::Prefix(FieldPath::from(Field::Name(c))))
+        .collect_vec())
 }

--- a/vortex-layout/src/scan/mod.rs
+++ b/vortex-layout/src/scan/mod.rs
@@ -241,9 +241,9 @@ fn field_mask(
         return Ok(vec![FieldMask::All]);
     };
 
-    let projection_mask = immediate_scope_access(&projection, struct_dtype)?;
+    let projection_mask = immediate_scope_access(projection, struct_dtype)?;
     let filter_mask = filter
-        .map(|f| immediate_scope_access(&f, struct_dtype))
+        .map(|f| immediate_scope_access(f, struct_dtype))
         .transpose()?
         .unwrap_or_default();
 

--- a/vortex-proto/proto/dtype.proto
+++ b/vortex-proto/proto/dtype.proto
@@ -70,7 +70,6 @@ message DType {
 message Field {
   oneof field_type {
     string name = 1;
-    uint64 index = 2;
   }
 }
 

--- a/vortex-proto/src/generated/vortex.dtype.rs
+++ b/vortex-proto/src/generated/vortex.dtype.rs
@@ -79,7 +79,7 @@ pub mod d_type {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Field {
-    #[prost(oneof = "field::FieldType", tags = "1, 2")]
+    #[prost(oneof = "field::FieldType", tags = "1")]
     pub field_type: ::core::option::Option<field::FieldType>,
 }
 /// Nested message and enum types in `Field`.
@@ -88,8 +88,6 @@ pub mod field {
     pub enum FieldType {
         #[prost(string, tag = "1")]
         Name(::prost::alloc::string::String),
-        #[prost(uint64, tag = "2")]
-        Index(u64),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/vortex-scalar/src/arbitrary.rs
+++ b/vortex-scalar/src/arbitrary.rs
@@ -26,7 +26,7 @@ fn random_scalar_value(u: &mut Unstructured, dtype: &DType) -> Result<ScalarValu
             ByteBuffer::from(u.arbitrary::<Vec<u8>>()?),
         )))),
         DType::Struct(sdt, _) => Ok(ScalarValue(InnerScalarValue::List(
-            sdt.dtypes()
+            sdt.fields()
                 .map(|d| random_scalar_value(u, &d))
                 .collect::<Result<Vec<_>>>()?
                 .into(),

--- a/vortex-scalar/src/display.rs
+++ b/vortex-scalar/src/display.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Formatter};
 use itertools::Itertools;
 use vortex_datetime_dtype::{is_temporal_ext_type, TemporalMetadata};
 use vortex_dtype::DType;
-use vortex_error::vortex_panic;
+use vortex_error::{vortex_panic, VortexExpect};
 
 use crate::binary::BinaryScalar;
 use crate::extension::ExtScalar;
@@ -50,9 +50,9 @@ impl Display for Scalar {
                         .names()
                         .iter()
                         .enumerate()
-                        .map(|(idx, name)| match v.field_by_idx(idx) {
-                            None => format!("{name}:null"),
-                            Some(val) => format!("{name}:{val}"),
+                        .map(|(idx, name)| {
+                            let val = v.field_by_idx(idx).vortex_expect("not out of bounds");
+                            format!("{name}:{val}")
                         })
                         .format(",");
                     write!(f, "{}", formatted_fields)?;

--- a/vortex-scalar/src/scalarvalue/mod.rs
+++ b/vortex-scalar/src/scalarvalue/mod.rs
@@ -162,7 +162,7 @@ impl InnerScalarValue {
             }
             (InnerScalarValue::List(values), DType::Struct(structdt, _)) => values
                 .iter()
-                .zip(structdt.dtypes())
+                .zip(structdt.fields())
                 .all(|(v, dt)| v.is_instance_of(&dt)),
             (InnerScalarValue::Null, dtype) => dtype.is_nullable(),
             (_, DType::Extension(ext_dtype)) => self.is_instance_of(ext_dtype.storage_dtype()),

--- a/vortex-scalar/src/serde/proto.rs
+++ b/vortex-scalar/src/serde/proto.rs
@@ -154,7 +154,7 @@ fn deserialize_scalar_value(dtype: &DType, value: &pb::ScalarValue) -> VortexRes
             let mut values = Vec::with_capacity(v.values.len());
             match dtype {
                 DType::Struct(structdt, _) => {
-                    for (elem, dtype) in v.values.iter().zip(structdt.dtypes()) {
+                    for (elem, dtype) in v.values.iter().zip(structdt.fields()) {
                         values.push(deserialize_scalar_value(&dtype, elem)?);
                     }
                 }

--- a/vortex-tui/src/browse/app.rs
+++ b/vortex-tui/src/browse/app.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use ratatui::widgets::ListState;
 use vortex::buffer::{Alignment, ByteBuffer, ByteBufferMut};
-use vortex::dtype::{DType, Field};
+use vortex::dtype::DType;
 use vortex::error::{VortexExpect, VortexResult};
 use vortex::file::{
     FileLayout, Segment, VortexOpenOptions, CHUNKED_LAYOUT_ID, COLUMNAR_LAYOUT_ID, FLAT_LAYOUT_ID,
@@ -93,11 +93,8 @@ impl LayoutCursor {
                 COLUMNAR_LAYOUT_ID => dtype
                     .as_struct()
                     .expect("struct dtype")
-                    .field_info(&Field::Index(component))
-                    .expect("struct dtype component access")
-                    .dtype
-                    .value()
-                    .expect("dtype value"),
+                    .field_by_index(component)
+                    .expect("struct dtype component access"),
                 // Flat layouts have no children
                 FLAT_LAYOUT_ID => unreachable!("flat layouts have no children"),
                 _ => todo!("unknown DType"),

--- a/vortex-tui/src/browse/ui/layouts.rs
+++ b/vortex-tui/src/browse/ui/layouts.rs
@@ -6,7 +6,6 @@ use ratatui::widgets::{
     Block, BorderType, Borders, Cell, List, Paragraph, Row, StatefulWidget, Table, Widget,
 };
 use vortex::compute::scalar_at;
-use vortex::dtype::Field;
 use vortex::error::VortexExpect;
 use vortex::file::{CHUNKED_LAYOUT_ID, COLUMNAR_LAYOUT_ID, FLAT_LAYOUT_ID};
 use vortex::sampling_compressor::ALL_ENCODINGS_CONTEXT;
@@ -226,14 +225,9 @@ fn render_children_list(app: &mut AppState, area: Rect, buf: &mut Buffer) {
 fn child_name(cursor: &LayoutCursor, nth: usize) -> String {
     match cursor.encoding().id() {
         COLUMNAR_LAYOUT_ID => {
-            let field_info = cursor
-                .dtype()
-                .as_struct()
-                .expect("struct dtype")
-                .field_info(&Field::Index(nth))
-                .expect("struct dtype component");
-            let field_name = field_info.name;
-            let field_dtype = field_info.dtype.value().expect("dtype value");
+            let struct_dtype = cursor.dtype().as_struct().expect("struct dtype");
+            let field_name = struct_dtype.field_name(nth).expect("field name");
+            let field_dtype = struct_dtype.field_by_index(nth).expect("dtype value");
             format!("Column {nth} - {field_name} ({field_dtype})")
         }
         CHUNKED_LAYOUT_ID => {


### PR DESCRIPTION
* Only simplify once in the scanner
* Manually implement return_dtype instead of expensive Canonical::Empty (FLUP: we should add `return_nullability()` expr too)
* Remove `Field::Index` weirdness.
* More consistent APIs for Struct{Scalar,Array,DType}