### PR TITLE
Cache pruning predicate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5566,6 +5566,7 @@ dependencies = [
  "flatbuffers 25.1.24",
  "futures",
  "itertools 0.14.0",
+ "log",
  "oneshot",
  "pin-project-lite",
  "vortex-array",

--- a/vortex-layout/Cargo.toml
+++ b/vortex-layout/Cargo.toml
@@ -21,6 +21,7 @@ bytes = { workspace = true }
 flatbuffers = { workspace = true }
 futures = { workspace = true, features = ["alloc"] }
 itertools = { workspace = true }
+log = { workspace = true }
 oneshot = { workspace = true, features = ["async"] }
 pin-project-lite = { workspace = true }
 vortex-array = { workspace = true }

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -108,7 +108,7 @@ impl ChunkedReader {
             .write()
             .map_err(|_| vortex_err!("poisoned lock"))?
             .entry(expr.clone())
-            .or_insert(Arc::new(OnceCell::new()))
+            .or_insert_with(|| Arc::new(OnceCell::new()))
             .clone();
 
         cell.get_or_try_init(async {

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -16,13 +16,15 @@ use crate::reader::LayoutReader;
 use crate::segments::AsyncSegmentReader;
 use crate::{ExprEvaluator, Layout, LayoutVTable};
 
+type PruningCache = Arc<OnceCell<Option<BooleanBuffer>>>;
+
 #[derive(Clone)]
 pub struct ChunkedReader {
     layout: Layout,
     ctx: ContextRef,
     segments: Arc<dyn AsyncSegmentReader>,
     /// A cache of expr -> optional pruning result (applying the pruning expr to the stats table)
-    pruning_result: Arc<RwLock<HashMap<ExprRef, Arc<OnceCell<Option<BooleanBuffer>>>>>>,
+    pruning_result: Arc<RwLock<HashMap<ExprRef, PruningCache>>>,
     /// Shared stats table
     stats_table: Arc<OnceCell<Option<StatsTable>>>,
     /// Shared lazy chunk scanners

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -22,7 +22,7 @@ pub struct ChunkedReader {
     ctx: ContextRef,
     segments: Arc<dyn AsyncSegmentReader>,
     /// A cache of expr -> optional pruning result (applying the pruning expr to the stats table)
-    pruning_result: Arc<RwLock<HashMap<ExprRef, Option<BooleanBuffer>>>>,
+    pruning_result: Arc<RwLock<HashMap<ExprRef, Arc<OnceCell<Option<BooleanBuffer>>>>>>,
     /// Shared stats table
     stats_table: Arc<OnceCell<Option<StatsTable>>>,
     /// Shared lazy chunk scanners
@@ -101,35 +101,32 @@ impl ChunkedReader {
     }
 
     pub(crate) async fn pruning_mask(&self, expr: &ExprRef) -> VortexResult<Option<BooleanBuffer>> {
-        if let Some(mask) = self
+        let cell = self
             .pruning_result
-            .read()
-            .map_err(|_| vortex_err!("poisoned lock"))?
-            .get(expr)
-        {
-            return Ok(mask.clone());
-        }
-        let pruning_predicate = PruningPredicate::try_new(expr);
-        let res = if let Some(stats_table) = self.stats_table().await? {
-            if let Some(predicate) = pruning_predicate {
-                predicate
-                    .evaluate(stats_table.array())?
-                    .map(|mask| mask.into_bool())
-                    .transpose()?
-                    .map(|mask| mask.boolean_buffer())
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        self.pruning_result
             .write()
             .map_err(|_| vortex_err!("poisoned lock"))?
-            .insert(expr.clone(), res.clone());
+            .entry(expr.clone())
+            .or_insert(Arc::new(OnceCell::new()))
+            .clone();
 
-        Ok(res)
+        cell.get_or_try_init(async {
+            let pruning_predicate = PruningPredicate::try_new(expr);
+            Ok(if let Some(stats_table) = self.stats_table().await? {
+                if let Some(predicate) = pruning_predicate {
+                    predicate
+                        .evaluate(stats_table.array())?
+                        .map(|mask| mask.into_bool())
+                        .transpose()?
+                        .map(|mask| mask.boolean_buffer())
+                } else {
+                    None
+                }
+            } else {
+                None
+            })
+        })
+        .await
+        .cloned()
     }
 
     /// Return the number of chunks

--- a/vortex-layout/src/layouts/struct_/eval_stats.rs
+++ b/vortex-layout/src/layouts/struct_/eval_stats.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::future::{ready, try_join_all};
-use futures::FutureExt;
+use futures::future::ready;
+use futures::stream::FuturesOrdered;
+use futures::{FutureExt, TryStreamExt};
 use vortex_array::stats::{Stat, StatsSet};
 use vortex_dtype::{Field, FieldPath};
 use vortex_error::{vortex_bail, vortex_err, VortexResult};
@@ -17,11 +18,11 @@ impl StatsEvaluator for StructReader {
         field_paths: Arc<[FieldPath]>,
         stats: Arc<[Stat]>,
     ) -> VortexResult<Vec<StatsSet>> {
-        let mut futures = Vec::with_capacity(field_paths.len());
+        let mut futures = FuturesOrdered::new();
         for path in field_paths.iter() {
             if path.is_root() {
                 // We don't have any stats for a struct layout
-                futures.push(ready(Ok(vec![StatsSet::default()])).boxed());
+                futures.push_back(ready(Ok(vec![StatsSet::default()])).boxed());
             } else {
                 // Otherwise, strip off the first path element and delegate to the child layout
                 let Field::Name(field) = path.path()[0].clone() else {
@@ -31,14 +32,15 @@ impl StatsEvaluator for StructReader {
                     .clone()
                     .step_into()
                     .ok_or_else(|| vortex_err!("cannot step into path"))?;
-                futures.push(
+                futures.push_back(
                     self.child(&field)?
                         .evaluate_stats([child_path].into(), stats.clone()),
                 );
             }
         }
 
-        let results = try_join_all(futures)
+        let results = futures
+            .try_collect::<Vec<_>>()
             .await?
             .into_iter()
             .flat_map(|r| r.into_iter())


### PR DESCRIPTION
We were sort of caching pruning predicates... but not really. This now avoids race conditions and all concurrent jobs poll the same async OnceCell