### PR TITLE
Scan builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5494,10 +5494,7 @@ dependencies = [
  "vortex-flatbuffers",
  "vortex-io",
  "vortex-layout",
- "vortex-mask",
  "vortex-sampling-compressor",
- "vortex-scalar",
- "vortex-scan",
 ]
 
 [[package]]

--- a/vortex-file/Cargo.toml
+++ b/vortex-file/Cargo.toml
@@ -37,10 +37,7 @@ vortex-expr = { workspace = true }
 vortex-flatbuffers = { workspace = true, features = ["file"] }
 vortex-io = { workspace = true }
 vortex-layout = { workspace = true }
-vortex-mask = { workspace = true }
 vortex-sampling-compressor = { workspace = true }
-vortex-scalar = { workspace = true, features = ["flatbuffers"] }
-vortex-scan = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }


### PR DESCRIPTION
Pull a Scan struct out of the ScanBuilder, allows us to more easily implement alternate scanning strategies