### PR TITLE
bench: drop superfluous `black_box` calls

### DIFF
--- a/bench-vortex/benches/compress.rs
+++ b/bench-vortex/benches/compress.rs
@@ -20,7 +20,7 @@ use bench_vortex::{
     feature_flagged_allocator, fetch_taxi_data, generate_struct_of_list_of_ints_array, tpch,
 };
 use bytes::Bytes;
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use futures::TryStreamExt;
 use log::LevelFilter;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
@@ -187,10 +187,9 @@ fn benchmark_compress<F, U>(
         measurement_time.map(|t| group.measurement_time(t));
         group.bench_function(bench_name, |b| {
             b.iter_with_large_drop(|| {
-                compressed_size = black_box(
+                compressed_size =
                     vortex_compressed_written_size(runtime, compressor, uncompressed.as_ref())
-                        .unwrap(),
-                );
+                        .unwrap();
             });
         });
         group.finish();
@@ -209,12 +208,12 @@ fn benchmark_compress<F, U>(
             let (batches, schema) = chunked_to_vec_record_batch(chunked);
 
             b.iter_with_large_drop(|| {
-                parquet_compressed_size = black_box(parquet_compress_write(
+                parquet_compressed_size = parquet_compress_write(
                     batches.clone(),
                     schema.clone(),
                     Compression::ZSTD(ZstdLevel::default()),
                     &mut Vec::new(),
-                ));
+                );
             });
         });
         group.finish();
@@ -234,7 +233,7 @@ fn benchmark_compress<F, U>(
 
         group.bench_function(bench_name, |b| {
             b.iter_with_large_drop(|| {
-                black_box(vortex_decompress_read(runtime, buffer.clone()).unwrap());
+                vortex_decompress_read(runtime, buffer.clone()).unwrap();
             });
         });
         group.finish();
@@ -261,7 +260,7 @@ fn benchmark_compress<F, U>(
 
         group.bench_function(bench_name, |b| {
             b.iter_with_large_drop(|| {
-                black_box(parquet_decompress_read(buffer.clone()));
+                parquet_decompress_read(buffer.clone());
             });
         });
         group.finish();

--- a/bench-vortex/benches/compressor_throughput.rs
+++ b/bench-vortex/benches/compressor_throughput.rs
@@ -1,5 +1,5 @@
 use bench_vortex::feature_flagged_allocator;
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
 use rand::distributions::Alphanumeric;
 use rand::seq::SliceRandom as _;
 use rand::{thread_rng, Rng, SeedableRng as _};
@@ -58,11 +58,9 @@ fn primitive(c: &mut Criterion) {
     for (compressor, name, array) in compressors_names_and_arrays {
         group.bench_function(format!("{} compress", name), |b| {
             b.iter(|| {
-                black_box(
-                    compressor
-                        .compress(array, None, ctx.including(compressor))
-                        .unwrap(),
-                );
+                compressor
+                    .compress(array, None, ctx.including(compressor))
+                    .unwrap()
             })
         });
 
@@ -70,12 +68,11 @@ fn primitive(c: &mut Criterion) {
             .compress(array, None, ctx.including(compressor))
             .unwrap()
             .into_array();
+
         group.bench_function(format!("{} decompress", name), |b| {
             b.iter_batched(
                 || compressed.clone(),
-                |compressed| {
-                    black_box(compressed.into_canonical().unwrap());
-                },
+                |compressed| compressed.into_canonical().unwrap(),
                 BatchSize::SmallInput,
             )
         });
@@ -93,13 +90,13 @@ fn strings(c: &mut Criterion) {
         varbinview_arr.clone().into_array().nbytes() as u64,
     ));
     group.bench_function("dict_decode_varbinview", |b| {
-        b.iter(|| black_box(dict.clone().into_canonical().unwrap()));
+        b.iter(|| dict.clone().into_canonical().unwrap());
     });
 
     let fsst_compressor = fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
     let fsst_array = fsst_compress(&varbinview_arr.clone().into_array(), &fsst_compressor).unwrap();
     group.bench_function("fsst_decompress_varbinview", |b| {
-        b.iter(|| black_box(fsst_array.clone().into_canonical().unwrap()));
+        b.iter(|| fsst_array.clone().into_canonical().unwrap());
     });
 }
 

--- a/bench-vortex/benches/random_access.rs
+++ b/bench-vortex/benches/random_access.rs
@@ -6,7 +6,7 @@ use bench_vortex::reader::{
     take_parquet, take_parquet_object_store, take_vortex_object_store, take_vortex_tokio,
 };
 use bench_vortex::taxi_data::{taxi_data_parquet, taxi_data_vortex};
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use object_store::aws::AmazonS3Builder;
 use object_store::local::LocalFileSystem;
 use object_store::ObjectStore;
@@ -30,11 +30,9 @@ fn random_access_vortex(c: &mut Criterion) {
     let taxi_vortex = taxi_data_vortex();
     group.bench_function("vortex-tokio-local-disk", |b| {
         b.to_async(Runtime::new().unwrap()).iter(|| async {
-            black_box(
-                take_vortex_tokio(&taxi_vortex, indices.clone())
-                    .await
-                    .unwrap(),
-            )
+            take_vortex_tokio(&taxi_vortex, indices.clone())
+                .await
+                .unwrap()
         })
     });
 
@@ -42,11 +40,9 @@ fn random_access_vortex(c: &mut Criterion) {
         let local_fs = Arc::new(LocalFileSystem::new()) as Arc<dyn ObjectStore>;
         let local_fs_path = object_store::path::Path::from_filesystem_path(&taxi_vortex).unwrap();
         b.to_async(Runtime::new().unwrap()).iter(|| async {
-            black_box(
-                take_vortex_object_store(local_fs.clone(), local_fs_path.clone(), indices.clone())
-                    .await
-                    .unwrap(),
-            )
+            take_vortex_object_store(local_fs.clone(), local_fs_path.clone(), indices.clone())
+                .await
+                .unwrap()
         })
     });
 
@@ -55,9 +51,8 @@ fn random_access_vortex(c: &mut Criterion) {
 
     let taxi_parquet = taxi_data_parquet();
     group.bench_function("parquet-tokio-local-disk", |b| {
-        b.to_async(Runtime::new().unwrap()).iter(|| async {
-            black_box(take_parquet(&taxi_parquet, indices.clone()).await.unwrap())
-        })
+        b.to_async(Runtime::new().unwrap())
+            .iter(|| async { take_parquet(&taxi_parquet, indices.clone()).await.unwrap() })
     });
 
     if env::var("AWS_ACCESS_KEY_ID").is_ok() {
@@ -70,11 +65,9 @@ fn random_access_vortex(c: &mut Criterion) {
             .unwrap();
 
             b.to_async(Runtime::new().unwrap()).iter(|| async {
-                black_box(
-                    take_vortex_object_store(r2_fs.clone(), r2_path.clone(), indices.clone())
-                        .await
-                        .unwrap(),
-                )
+                take_vortex_object_store(r2_fs.clone(), r2_path.clone(), indices.clone())
+                    .await
+                    .unwrap()
             })
         });
 
@@ -86,11 +79,9 @@ fn random_access_vortex(c: &mut Criterion) {
             .unwrap();
 
             b.to_async(Runtime::new().unwrap()).iter(|| async {
-                black_box(
-                    take_parquet_object_store(r2_fs.clone(), &r2_parquet_path, indices.clone())
-                        .await
-                        .unwrap(),
-                )
+                take_parquet_object_store(r2_fs.clone(), &r2_parquet_path, indices.clone())
+                    .await
+                    .unwrap()
             })
         });
     }

--- a/encodings/dict/benches/dict_compress.rs
+++ b/encodings/dict/benches/dict_compress.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::cast_possible_truncation)]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use rand::distributions::{Alphanumeric, Uniform};
 use rand::prelude::SliceRandom;
 use rand::{thread_rng, Rng};
@@ -42,19 +42,19 @@ fn encode(c: &mut Criterion) {
     let primitive_arr = gen_primitive_dict(1_000_000, 0.00005);
     group.throughput(Throughput::Bytes(primitive_arr.nbytes() as u64));
     group.bench_function("dict_encode_primitives", |b| {
-        b.iter(|| black_box(dict_encode(primitive_arr.as_ref())));
+        b.iter(|| dict_encode(primitive_arr.as_ref()));
     });
 
     let varbin_arr = VarBinArray::from(gen_varbin_words(1_000_000, 0.00005));
     group.throughput(Throughput::Bytes(varbin_arr.nbytes() as u64));
     group.bench_function("dict_encode_varbin", |b| {
-        b.iter(|| black_box(dict_encode(varbin_arr.as_ref())));
+        b.iter(|| dict_encode(varbin_arr.as_ref()));
     });
 
     let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
     group.throughput(Throughput::Bytes(varbinview_arr.nbytes() as u64));
     group.bench_function("dict_encode_view", |b| {
-        b.iter(|| black_box(dict_encode(varbinview_arr.as_ref())));
+        b.iter(|| dict_encode(varbinview_arr.as_ref()));
     });
 }
 
@@ -65,21 +65,21 @@ fn decode(c: &mut Criterion) {
     let dict = dict_encode(primitive_arr.as_ref()).unwrap();
     group.throughput(Throughput::Bytes(primitive_arr.nbytes() as u64));
     group.bench_function("dict_decode_primitives", |b| {
-        b.iter(|| black_box(dict.clone().into_canonical().unwrap()));
+        b.iter(|| dict.clone().into_canonical().unwrap());
     });
 
     let varbin_arr = VarBinArray::from(gen_varbin_words(1_000_000, 0.00005));
     let dict = dict_encode(varbin_arr.as_ref()).unwrap();
     group.throughput(Throughput::Bytes(varbin_arr.nbytes() as u64));
     group.bench_function("dict_decode_varbin", |b| {
-        b.iter(|| black_box(dict.clone().into_canonical().unwrap()));
+        b.iter(|| dict.clone().into_canonical().unwrap());
     });
 
     let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
     let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
     group.throughput(Throughput::Bytes(varbin_arr.nbytes() as u64));
     group.bench_function("dict_decode_view", |b| {
-        b.iter(|| black_box(dict.clone().into_canonical().unwrap()));
+        b.iter(|| dict.clone().into_canonical().unwrap());
     });
 }
 

--- a/encodings/fastlanes/benches/bitpacking_take.rs
+++ b/encodings/fastlanes/benches/bitpacking_take.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::cast_possible_truncation)]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use rand::distributions::Uniform;
 use rand::{thread_rng, Rng};
 use vortex_array::array::PrimitiveArray;
@@ -28,12 +28,12 @@ fn bench_take(c: &mut Criterion) {
 
     let stratified_indices = PrimitiveArray::from_iter((0..10).map(|i| i * 10_000));
     c.bench_function("take_10_stratified", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), stratified_indices.as_ref()).unwrap()));
+        b.iter(|| take(packed.as_ref(), stratified_indices.as_ref()).unwrap());
     });
 
     let contiguous_indices = PrimitiveArray::from_iter(0..10);
     c.bench_function("take_10_contiguous", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), contiguous_indices.as_ref()).unwrap()));
+        b.iter(|| take(packed.as_ref(), contiguous_indices.as_ref()).unwrap());
     });
 
     let rng = thread_rng();
@@ -41,23 +41,23 @@ fn bench_take(c: &mut Criterion) {
     let random_indices =
         PrimitiveArray::from_iter(rng.sample_iter(range).take(10_000).map(|i| i as u32));
     c.bench_function("take_10K_random", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), random_indices.as_ref()).unwrap()));
+        b.iter(|| take(packed.as_ref(), random_indices.as_ref()).unwrap());
     });
 
     let contiguous_indices = PrimitiveArray::from_iter(0..10_000);
     c.bench_function("take_10K_contiguous", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), contiguous_indices.as_ref()).unwrap()));
+        b.iter(|| take(packed.as_ref(), contiguous_indices.as_ref()).unwrap());
     });
 
     let lots_of_indices =
         PrimitiveArray::from_iter((0..200_000).map(|i| (i * 42) % values.len() as u64));
     c.bench_function("take_200K_dispersed", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), lots_of_indices.as_ref()).unwrap()));
+        b.iter(|| take(packed.as_ref(), lots_of_indices.as_ref()).unwrap());
     });
 
     let lots_of_indices = PrimitiveArray::from_iter((0..200_000).map(|i| ((i * 42) % 1024) as u64));
     c.bench_function("take_200K_first_chunk_only", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), lots_of_indices.as_ref()).unwrap()));
+        b.iter(|| take(packed.as_ref(), lots_of_indices.as_ref()).unwrap());
     });
 }
 
@@ -80,12 +80,12 @@ fn bench_patched_take(c: &mut Criterion) {
 
     let stratified_indices = PrimitiveArray::from_iter((0..10).map(|i| i * 10_000));
     c.bench_function("patched_take_10_stratified", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), stratified_indices.as_ref()).unwrap()));
+        b.iter(|| take(packed.as_ref(), stratified_indices.as_ref()).unwrap());
     });
 
     let contiguous_indices = PrimitiveArray::from_iter(0..10);
     c.bench_function("patched_take_10_contiguous", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), contiguous_indices.as_ref()).unwrap()));
+        b.iter(|| take(packed.as_ref(), contiguous_indices.as_ref()).unwrap());
     });
 
     let rng = thread_rng();
@@ -93,29 +93,29 @@ fn bench_patched_take(c: &mut Criterion) {
     let random_indices =
         PrimitiveArray::from_iter(rng.sample_iter(range).take(10_000).map(|i| i as u32));
     c.bench_function("patched_take_10K_random", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), random_indices.as_ref()).unwrap()));
+        b.iter(|| take(packed.as_ref(), random_indices.as_ref()).unwrap());
     });
 
     let not_patch_indices = PrimitiveArray::from_iter((0u32..num_exceptions).cycle().take(10000));
     c.bench_function("patched_take_10K_contiguous_not_patches", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), not_patch_indices.as_ref()).unwrap()));
+        b.iter(|| take(packed.as_ref(), not_patch_indices.as_ref()).unwrap());
     });
 
     let patch_indices =
         PrimitiveArray::from_iter((big_base2..big_base2 + num_exceptions).cycle().take(10000));
     c.bench_function("patched_take_10K_contiguous_patches", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), patch_indices.as_ref()).unwrap()));
+        b.iter(|| take(packed.as_ref(), patch_indices.as_ref()).unwrap());
     });
 
     let lots_of_indices =
         PrimitiveArray::from_iter((0..200_000).map(|i| (i * 42) % values.len() as u64));
     c.bench_function("patched_take_200K_dispersed", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), lots_of_indices.as_ref()).unwrap()));
+        b.iter(|| take(packed.as_ref(), lots_of_indices.as_ref()).unwrap());
     });
 
     let lots_of_indices = PrimitiveArray::from_iter((0..200_000).map(|i| ((i * 42) % 1024) as u64));
     c.bench_function("patched_take_200K_first_chunk_only", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), lots_of_indices.as_ref()).unwrap()));
+        b.iter(|| take(packed.as_ref(), lots_of_indices.as_ref()).unwrap());
     });
 
     // There are currently 2 magic parameters of note:
@@ -139,7 +139,7 @@ fn bench_patched_take(c: &mut Criterion) {
             .take(10000),
     );
     c.bench_function("patched_take_10K_adversarial", |b| {
-        b.iter(|| black_box(take(packed.as_ref(), adversarial_indices.as_ref()).unwrap()));
+        b.iter(|| take(packed.as_ref(), adversarial_indices.as_ref()).unwrap());
     });
 }
 

--- a/encodings/runend/benches/run_end_filter.rs
+++ b/encodings/runend/benches/run_end_filter.rs
@@ -2,7 +2,7 @@
 
 use std::iter::Iterator;
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use num_traits::ToPrimitive;
 use vortex_array::IntoArray;
 use vortex_buffer::Buffer;
@@ -67,10 +67,8 @@ fn evenly_spaced(c: &mut Criterion) {
                     ),
                     |b| {
                         b.iter(|| {
-                            black_box(
-                                take_indices_unchecked(&array, mask.values().unwrap().indices())
-                                    .unwrap(),
-                            )
+                            take_indices_unchecked(&array, mask.values().unwrap().indices())
+                                .unwrap()
                         });
                     },
                 );
@@ -83,7 +81,7 @@ fn evenly_spaced(c: &mut Criterion) {
                         ratio
                     ),
                     |b| {
-                        b.iter(|| black_box(filter_run_end(&array, &mask).unwrap()));
+                        b.iter(|| filter_run_end(&array, &mask).unwrap());
                     },
                 );
             }

--- a/encodings/runend/benches/run_end_null_count.rs
+++ b/encodings/runend/benches/run_end_null_count.rs
@@ -2,7 +2,7 @@
 
 use std::iter::Iterator;
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng as _};
 use vortex_array::array::PrimitiveArray;
@@ -42,12 +42,10 @@ fn run_end_null_count(c: &mut Criterion) {
                     ),
                     |b| {
                         b.iter(|| {
-                            black_box(
-                                array
-                                    .vtable()
-                                    .compute_statistics(&array, Stat::NullCount)
-                                    .unwrap(),
-                            )
+                            array
+                                .vtable()
+                                .compute_statistics(&array, Stat::NullCount)
+                                .unwrap()
                         });
                     },
                 );

--- a/vortex-array/benches/compare.rs
+++ b/vortex-array/benches/compare.rs
@@ -1,13 +1,12 @@
 #![allow(clippy::unwrap_used)]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use rand::distributions::Uniform;
 use rand::{thread_rng, Rng};
 use vortex_array::array::BoolArray;
 use vortex_array::compute::Operator;
 use vortex_array::IntoArray;
 use vortex_buffer::Buffer;
-use vortex_error::VortexError;
 
 fn compare_bool(c: &mut Criterion) {
     let mut group = c.benchmark_group("compare");
@@ -18,11 +17,7 @@ fn compare_bool(c: &mut Criterion) {
     let arr2 = BoolArray::from_iter((0..10_000_000).map(|_| rng.sample(range) == 0)).into_array();
 
     group.bench_function("compare_bool", |b| {
-        b.iter(|| {
-            let indices = vortex_array::compute::compare(&arr, &arr2, Operator::Gte).unwrap();
-            black_box(indices);
-            Ok::<(), VortexError>(())
-        });
+        b.iter(|| vortex_array::compute::compare(&arr, &arr2, Operator::Gte).unwrap());
     });
 }
 
@@ -42,11 +37,7 @@ fn compare_primitive(c: &mut Criterion) {
         .into_array();
 
     group.bench_function("compare_int", |b| {
-        b.iter(|| {
-            let indices = vortex_array::compute::compare(&arr, &arr2, Operator::Gte).unwrap();
-            black_box(indices);
-            Ok::<(), VortexError>(())
-        });
+        b.iter(|| vortex_array::compute::compare(&arr, &arr2, Operator::Gte).unwrap());
     });
 }
 

--- a/vortex-array/benches/scalar_subtract.rs
+++ b/vortex-array/benches/scalar_subtract.rs
@@ -1,12 +1,11 @@
 #![allow(clippy::unwrap_used)]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use rand::distributions::Uniform;
 use rand::{thread_rng, Rng};
 use vortex_array::array::ChunkedArray;
 use vortex_array::IntoArray;
 use vortex_buffer::Buffer;
-use vortex_error::VortexError;
 
 fn scalar_subtract(c: &mut Criterion) {
     let mut group = c.benchmark_group("scalar_subtract");
@@ -29,10 +28,7 @@ fn scalar_subtract(c: &mut Criterion) {
     group.bench_function("vortex", |b| {
         b.iter(|| {
             let array = vortex_array::compute::sub_scalar(&chunked, to_subtract.into()).unwrap();
-
-            let chunked = ChunkedArray::try_from(array).unwrap();
-            black_box(chunked);
-            Ok::<(), VortexError>(())
+            ChunkedArray::try_from(array).unwrap()
         });
     });
 }

--- a/vortex-array/benches/search_sorted.rs
+++ b/vortex-array/benches/search_sorted.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use rand::distributions::Uniform;
 use rand::{thread_rng, Rng};
 use vortex_array::compute::{SearchSorted, SearchSortedSide};
@@ -12,10 +12,9 @@ fn search_sorted(c: &mut Criterion) {
     data.sort();
     let needle = rng.sample(range);
 
-    group.bench_function("std", |b| b.iter(|| black_box(data.binary_search(&needle))));
-
+    group.bench_function("std", |b| b.iter(|| data.binary_search(&needle)));
     group.bench_function("vortex", |b| {
-        b.iter(|| black_box(data.search_sorted(&needle, SearchSortedSide::Left)))
+        b.iter(|| data.search_sorted(&needle, SearchSortedSide::Left))
     });
 }
 

--- a/vortex-buffer/benches/vortex_buffer.rs
+++ b/vortex-buffer/benches/vortex_buffer.rs
@@ -4,7 +4,7 @@ use std::iter;
 use std::iter::Iterator;
 
 use arrow_buffer::{ArrowNativeType, MutableBuffer, ScalarBuffer, ToByteSlice};
-use divan::{black_box, Bencher};
+use divan::Bencher;
 use vortex_buffer::{Buffer, BufferMut};
 use vortex_error::{vortex_err, VortexExpect};
 
@@ -81,7 +81,7 @@ impl<T: Copy, R> MapEach<T, R> for BufferMut<T> {
 fn map_each<B: MapEach<i32, u32> + FromIterator<i32>>(bencher: Bencher, n: i32) {
     bencher
         .with_inputs(|| B::from_iter((0..n).map(|i| i % i32::MAX)))
-        .bench_local_values(|buffer| black_box(B::map_each(buffer, |i| (i as u32) + 1)));
+        .bench_local_values(|buffer| B::map_each(buffer, |i| (i as u32) + 1));
 }
 
 trait Push<T> {


### PR DESCRIPTION
Divan as well as Criterion black box input parameters automatically. Further, benchmarked closures do not get optimized away, saying no explicit wrapping in a black box is required by default. 

Additional `black_box` calls might only be used to provide additional black-boxing, e.g. for a constant that is defined within a benchmarking closure the compiler is not supposed to see through.

Unnecessary `black_box` calls are removed by this PR. I double checked that the durations for changed benchmarks are unchanged.