### PR TITLE
perf: compute and propagate is_constant more carefully

### DIFF
--- a/vortex-array/src/array/chunked/stats.rs
+++ b/vortex-array/src/array/chunked/stats.rs
@@ -9,22 +9,31 @@ impl StatisticsVTable<ChunkedArray> for ChunkedEncoding {
     fn compute_statistics(&self, array: &ChunkedArray, stat: Stat) -> VortexResult<StatsSet> {
         // for UncompressedSizeInBytes, we end up with sum of chunk uncompressed sizes
         // this ignores the `chunk_offsets` array child, so it won't exactly match self.nbytes()
-        Ok(array
-            .chunks()
-            .map(|c| {
-                let s = c.statistics();
-                match stat {
-                    // We need to know min and max to merge_ordered these stats.
-                    Stat::IsConstant | Stat::IsSorted | Stat::IsStrictSorted => {
-                        s.compute_all(&[stat, Stat::Min, Stat::Max]).ok()
+
+        let mut stats: Option<StatsSet> = None;
+
+        for chunk in array.chunks() {
+            let s = chunk.statistics();
+            let chunk_stat = match stat {
+                // We need to know min and max to merge_ordered these stats.
+                Stat::IsConstant | Stat::IsSorted | Stat::IsStrictSorted => {
+                    let chunk_stats = s.compute_all(&[stat, Stat::Min, Stat::Max])?;
+                    if chunk_stats.get_as::<bool>(stat) == Some(Precision::Exact(false)) {
+                        // exit early
+                        return Ok(StatsSet::of(stat, Precision::exact(false)));
+                    } else {
+                        Some(chunk_stats)
                     }
-                    _ => s
-                        .compute_stat(stat)
-                        .map(|s| StatsSet::of(stat, Precision::exact(s))),
                 }
-                .unwrap_or_default()
-            })
-            .reduce(|acc, x| acc.merge_ordered(&x, array.dtype()))
-            .unwrap_or_default())
+                _ => s
+                    .compute_stat(stat)
+                    .map(|s| StatsSet::of(stat, Precision::exact(s))),
+            }
+            .unwrap_or_default();
+
+            stats = stats.map(|s| s.merge_ordered(&chunk_stat, array.dtype()));
+        }
+
+        Ok(stats.unwrap_or_default())
     }
 }

--- a/vortex-array/src/compute/slice.rs
+++ b/vortex-array/src/compute/slice.rs
@@ -2,7 +2,7 @@ use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
 
 use crate::array::ConstantArray;
 use crate::encoding::Encoding;
-use crate::stats::{Stat, Statistics, StatsSet};
+use crate::stats::{Precision, Stat, Statistics, StatsSet};
 use crate::{Array, Canonical, IntoArray};
 
 /// Limit array to start...stop range
@@ -91,8 +91,11 @@ pub fn slice(array: impl AsRef<Array>, start: usize, stop: usize) -> VortexResul
 fn derive_sliced_stats(arr: &Array) -> StatsSet {
     let stats = arr.stats_set();
 
-    stats.keep_exact_inexact_stats(
-        &[Stat::IsConstant, Stat::IsSorted, Stat::IsStrictSorted],
+    // an array that is not constant can become constant after slicing
+    let is_constant = stats.get_as::<bool>(Stat::IsConstant);
+
+    let mut stats = stats.keep_exact_inexact_stats(
+        &[Stat::IsSorted, Stat::IsStrictSorted],
         &[
             Stat::Max,
             Stat::Min,
@@ -101,7 +104,16 @@ fn derive_sliced_stats(arr: &Array) -> StatsSet {
             Stat::NullCount,
             Stat::UncompressedSizeInBytes,
         ],
-    )
+    );
+
+    if is_constant
+        .as_ref()
+        .is_some_and(|is_constant| is_constant == &Precision::exact(true))
+    {
+        stats.set(Stat::IsConstant, Precision::exact(true));
+    };
+
+    stats
 }
 
 fn check_slice_bounds(array: &Array, start: usize, stop: usize) -> VortexResult<()> {

--- a/vortex-array/src/compute/slice.rs
+++ b/vortex-array/src/compute/slice.rs
@@ -1,5 +1,6 @@
 use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
 
+use crate::array::ConstantArray;
 use crate::encoding::Encoding;
 use crate::stats::{Stat, Statistics, StatsSet};
 use crate::{Array, Canonical, IntoArray};
@@ -45,7 +46,12 @@ pub fn slice(array: impl AsRef<Array>, start: usize, stop: usize) -> VortexResul
 
     check_slice_bounds(array, start, stop)?;
 
-    let derived_stats = derive_sliced_stats(array);
+    // We know that constant array don't need stats propagation, so we can avoid the overhead of
+    let derived_stats = if ConstantArray::maybe_from(array).is_some() {
+        None
+    } else {
+        Some(derive_sliced_stats(array))
+    };
 
     let sliced = array
         .vtable()
@@ -58,10 +64,12 @@ pub fn slice(array: impl AsRef<Array>, start: usize, stop: usize) -> VortexResul
             ))
         })?;
 
-    let mut stats = sliced.stats_set();
-    stats.combine_sets(&derived_stats, array.dtype())?;
-    for (stat, val) in stats.into_iter() {
-        sliced.set_stat(stat, val)
+    if let Some(derived_stats) = derived_stats {
+        let mut stats = sliced.stats_set();
+        stats.combine_sets(&derived_stats, array.dtype())?;
+        for (stat, val) in stats.into_iter() {
+            sliced.set_stat(stat, val)
+        }
     }
 
     debug_assert_eq!(

--- a/vortex-array/src/compute/slice.rs
+++ b/vortex-array/src/compute/slice.rs
@@ -60,13 +60,13 @@ pub fn slice(array: impl AsRef<Array>, start: usize, stop: usize) -> VortexResul
             ))
         })?;
 
-    derived_stats.inspect(|derived_stats| {
+    if let Some(derived_stats) = derived_stats {
         let mut stats = sliced.stats_set();
         stats.combine_sets(&derived_stats, array.dtype())?;
         for (stat, val) in stats.into_iter() {
             sliced.set_stat(stat, val)
         }
-    });
+    }
 
     debug_assert_eq!(
         sliced.len(),

--- a/vortex-array/src/compute/slice.rs
+++ b/vortex-array/src/compute/slice.rs
@@ -93,25 +93,27 @@ fn derive_sliced_stats(arr: &Array) -> StatsSet {
 
     // an array that is not constant can become constant after slicing
     let is_constant = stats.get_as::<bool>(Stat::IsConstant);
+    let is_sorted = stats.get_as::<bool>(Stat::IsConstant);
+    let is_strict_sorted = stats.get_as::<bool>(Stat::IsConstant);
 
-    let mut stats = stats.keep_exact_inexact_stats(
-        &[Stat::IsSorted, Stat::IsStrictSorted],
-        &[
-            Stat::Max,
-            Stat::Min,
-            Stat::RunCount,
-            Stat::TrueCount,
-            Stat::NullCount,
-            Stat::UncompressedSizeInBytes,
-        ],
-    );
+    let mut stats = stats.keep_inexact_stats(&[
+        Stat::Max,
+        Stat::Min,
+        Stat::RunCount,
+        Stat::TrueCount,
+        Stat::NullCount,
+        Stat::UncompressedSizeInBytes,
+    ]);
 
-    if is_constant
-        .as_ref()
-        .is_some_and(|is_constant| is_constant == &Precision::exact(true))
-    {
+    if is_constant == Some(Precision::Exact(true)) {
         stats.set(Stat::IsConstant, Precision::exact(true));
-    };
+    }
+    if is_sorted == Some(Precision::Exact(true)) {
+        stats.set(Stat::IsSorted, Precision::exact(true));
+    }
+    if is_strict_sorted == Some(Precision::Exact(true)) {
+        stats.set(Stat::IsStrictSorted, Precision::exact(true));
+    }
 
     stats
 }

--- a/vortex-array/src/compute/slice.rs
+++ b/vortex-array/src/compute/slice.rs
@@ -1,6 +1,6 @@
 use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
 
-use crate::array::ConstantArray;
+use crate::array::{ConstantArray, ConstantEncoding};
 use crate::encoding::Encoding;
 use crate::stats::{Precision, Stat, Statistics, StatsSet};
 use crate::{Array, Canonical, IntoArray};
@@ -47,7 +47,8 @@ pub fn slice(array: impl AsRef<Array>, start: usize, stop: usize) -> VortexResul
     check_slice_bounds(array, start, stop)?;
 
     // We know that constant array don't need stats propagation, so we can avoid the overhead of
-    let derived_stats = if ConstantArray::maybe_from(array).is_some() {
+    // computing derived stats and merging them in.
+    let derived_stats = if array.must_be_constant() {
         None
     } else {
         Some(derive_sliced_stats(array))

--- a/vortex-array/src/compute/slice.rs
+++ b/vortex-array/src/compute/slice.rs
@@ -1,6 +1,5 @@
 use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
 
-use crate::array::{ConstantArray, ConstantEncoding};
 use crate::encoding::Encoding;
 use crate::stats::{Precision, Stat, Statistics, StatsSet};
 use crate::{Array, Canonical, IntoArray};
@@ -48,11 +47,7 @@ pub fn slice(array: impl AsRef<Array>, start: usize, stop: usize) -> VortexResul
 
     // We know that constant array don't need stats propagation, so we can avoid the overhead of
     // computing derived stats and merging them in.
-    let derived_stats = if array.must_be_constant() {
-        None
-    } else {
-        Some(derive_sliced_stats(array))
-    };
+    let derived_stats = (!array.must_be_constant()).then(|| derive_sliced_stats(array));
 
     let sliced = array
         .vtable()
@@ -65,13 +60,13 @@ pub fn slice(array: impl AsRef<Array>, start: usize, stop: usize) -> VortexResul
             ))
         })?;
 
-    if let Some(derived_stats) = derived_stats {
+    derived_stats.inspect(|derived_stats| {
         let mut stats = sliced.stats_set();
         stats.combine_sets(&derived_stats, array.dtype())?;
         for (stat, val) in stats.into_iter() {
             sliced.set_stat(stat, val)
         }
-    }
+    });
 
     debug_assert_eq!(
         sliced.len(),

--- a/vortex-array/src/compute/take.rs
+++ b/vortex-array/src/compute/take.rs
@@ -61,14 +61,22 @@ pub fn take(array: impl AsRef<Array>, indices: impl AsRef<Array>) -> VortexResul
 
     let derived_stats = derive_take_stats(array);
 
+    // We know that constant array don't need stats propagation, so we can avoid the overhead of
+    // computing derived stats and merging them in.
+    let derived_stats = if array.must_be_constant() {
+        None
+    } else {
+        Some(derive_take_stats(array))
+    };
+
     let taken = take_impl(array, indices, checked_indices)?;
 
-    let mut stats = taken.stats_set();
-    stats.combine_sets(&derived_stats, array.dtype())?;
-    // TODO(joe): add
-    // taken.inherit_statistics(&stats)?;
-    for (stat, val) in stats.into_iter() {
-        taken.set_stat(stat, val)
+    if let Some(derived_stats) = derived_stats {
+        let mut stats = taken.stats_set();
+        stats.combine_sets(&derived_stats, array.dtype())?;
+        for (stat, val) in stats.into_iter() {
+            taken.set_stat(stat, val)
+        }
     }
 
     debug_assert_eq!(

--- a/vortex-array/src/compute/take.rs
+++ b/vortex-array/src/compute/take.rs
@@ -1,7 +1,7 @@
 use vortex_error::{vortex_bail, vortex_err, VortexError, VortexResult};
 
 use crate::encoding::Encoding;
-use crate::stats::{Max, Stat, Statistics, StatsSet};
+use crate::stats::{Max, Precision, Stat, Statistics, StatsSet};
 use crate::{Array, IntoArray, IntoCanonical};
 
 pub trait TakeFn<A> {
@@ -90,15 +90,20 @@ pub fn take(array: impl AsRef<Array>, indices: impl AsRef<Array>) -> VortexResul
 fn derive_take_stats(arr: &Array) -> StatsSet {
     let stats = arr.stats_set();
 
-    stats.keep_exact_inexact_stats(
+    let is_constant = stats.get_as::<bool>(Stat::IsConstant);
+
+    let mut stats = stats.keep_inexact_stats(&[
+        // Cannot create values smaller than min or larger than max
+        Stat::Min,
+        Stat::Max,
+    ]);
+
+    if is_constant == Some(Precision::Exact(true)) {
         // Any combination of elements from a constant array is still const
-        &[Stat::IsConstant],
-        &[
-            // Cannot create values smaller than min or larger than max
-            Stat::Min,
-            Stat::Max,
-        ],
-    )
+        stats.set(Stat::IsConstant, Precision::exact(true));
+    }
+
+    stats
 }
 
 fn take_impl(array: &Array, indices: &Array, checked_indices: bool) -> VortexResult<Array> {

--- a/vortex-array/src/compute/take.rs
+++ b/vortex-array/src/compute/take.rs
@@ -59,25 +59,19 @@ pub fn take(array: impl AsRef<Array>, indices: impl AsRef<Array>) -> VortexResul
         .get_as_bound::<Max, usize>()
         .is_some_and(|max| max < array.len());
 
-    let derived_stats = derive_take_stats(array);
-
     // We know that constant array don't need stats propagation, so we can avoid the overhead of
     // computing derived stats and merging them in.
-    let derived_stats = if array.must_be_constant() {
-        None
-    } else {
-        Some(derive_take_stats(array))
-    };
+    let derived_stats = (!array.must_be_constant()).then(|| derive_take_stats(array));
 
     let taken = take_impl(array, indices, checked_indices)?;
 
-    if let Some(derived_stats) = derived_stats {
+    derived_stats.inspect(|derived_stats| {
         let mut stats = taken.stats_set();
         stats.combine_sets(&derived_stats, array.dtype())?;
         for (stat, val) in stats.into_iter() {
             taken.set_stat(stat, val)
         }
-    }
+    });
 
     debug_assert_eq!(
         taken.len(),

--- a/vortex-array/src/compute/take.rs
+++ b/vortex-array/src/compute/take.rs
@@ -65,13 +65,13 @@ pub fn take(array: impl AsRef<Array>, indices: impl AsRef<Array>) -> VortexResul
 
     let taken = take_impl(array, indices, checked_indices)?;
 
-    derived_stats.inspect(|derived_stats| {
+    if let Some(derived_stats) = derived_stats {
         let mut stats = taken.stats_set();
         stats.combine_sets(&derived_stats, array.dtype())?;
         for (stat, val) in stats.into_iter() {
             taken.set_stat(stat, val)
         }
-    });
+    }
 
     debug_assert_eq!(
         taken.len(),

--- a/vortex-array/src/data/mod.rs
+++ b/vortex-array/src/data/mod.rs
@@ -241,8 +241,8 @@ impl Array {
         self.is_encoding(BoolEncoding.id())
             || self
                 .statistics()
-                .get_as(Stat::IsConstant)
-                .is_some_and(|p| p == Precision::exact(true))
+                .get_as::<bool>(Stat::IsConstant)
+                .is_some_and(|p| p == Precision::Exact(true))
     }
 
     /// Return whether the array is constant.

--- a/vortex-array/src/data/mod.rs
+++ b/vortex-array/src/data/mod.rs
@@ -16,7 +16,7 @@ use crate::array::{
 use crate::compute::scalar_at;
 use crate::encoding::{Encoding, EncodingId};
 use crate::iter::{ArrayIterator, ArrayIteratorAdapter};
-use crate::stats::{Stat, StatsSet};
+use crate::stats::{Precision, Stat, StatsSet};
 use crate::stream::{ArrayStream, ArrayStreamAdapter};
 use crate::vtable::{EncodingVTable, VTableRef};
 use crate::{ArrayChildrenIterator, ChildrenCollector, ContextRef, NamedChildrenCollector};
@@ -233,6 +233,16 @@ impl Array {
             || self.is_encoding(PrimitiveEncoding.id())
             || self.is_encoding(VarBinEncoding.id())
             || self.is_encoding(VarBinViewEncoding.id())
+    }
+
+    /// A method that *cheaply* checks if the array is constant, might may return false when
+    /// the array is in-fact constant.
+    pub fn must_be_constant(&self) -> bool {
+        self.is_encoding(BoolEncoding.id())
+            || self
+                .statistics()
+                .get_as(Stat::IsConstant)
+                .is_some_and(|p| p == Precision::exact(true))
     }
 
     /// Return whether the array is constant.

--- a/vortex-array/src/stats/stat_bound.rs
+++ b/vortex-array/src/stats/stat_bound.rs
@@ -67,9 +67,13 @@ impl<T: PartialOrd + Clone> StatBound<T> for Precision<T> {
                     IntersectionResult::None
                 }
             }
-            (Precision::Exact(exact), Precision::Inexact(_))
-            | (Precision::Inexact(_), Precision::Exact(exact)) => {
-                IntersectionResult::Value(Precision::Inexact(exact.clone()))
+            (Precision::Exact(exact), Precision::Inexact(inexact))
+            | (Precision::Inexact(inexact), Precision::Exact(exact)) => {
+                if exact.partial_cmp(inexact)? == Ordering::Less {
+                    IntersectionResult::Value(Precision::Inexact(exact.clone()))
+                } else {
+                    IntersectionResult::Value(Precision::Exact(exact.clone()))
+                }
             }
             (Precision::Inexact(lhs), Precision::Inexact(rhs)) => {
                 IntersectionResult::Value(Precision::Inexact(partial_min(lhs, rhs)?.clone()))

--- a/vortex-array/src/stats/stats_set.rs
+++ b/vortex-array/src/stats/stats_set.rs
@@ -213,13 +213,7 @@ impl StatsSet {
     pub fn keep_inexact_stats(self, inexact_keep: &[Stat]) -> Self {
         if let Some(v) = self.values {
             v.into_iter()
-                .filter_map(|(s, v)| {
-                    if inexact_keep.contains(&s) {
-                        Some((s, v.into_inexact()))
-                    } else {
-                        None
-                    }
-                })
+                .filter_map(|(s, v)| inexact_keep.contains(&s).then(|| (s, v.into_inexact())))
                 .collect()
         } else {
             self
@@ -923,7 +917,7 @@ mod test {
             (Stat::TrueCount, Precision::inexact(10)),
         ]);
 
-        let set = set.keep_exact_inexact_stats(&[Stat::Min, Stat::Max]);
+        let set = set.keep_inexact_stats(&[Stat::Min, Stat::Max]);
 
         assert_eq!(set.len(), 2);
         assert_eq!(set.get_as::<i32>(Stat::Max), Some(Precision::inexact(100)));

--- a/vortex-array/src/stats/stats_set.rs
+++ b/vortex-array/src/stats/stats_set.rs
@@ -4,7 +4,7 @@ use vortex_dtype::DType;
 use vortex_error::{vortex_err, vortex_panic, VortexError, VortexExpect, VortexResult};
 use vortex_scalar::{Scalar, ScalarValue};
 
-use crate::stats::{Max, Min, Precision, Stat, StatBound, StatType};
+use crate::stats::{IsConstant, Max, Min, Precision, Stat, StatBound, StatType};
 
 #[derive(Default, Debug, Clone)]
 pub struct StatsSet {
@@ -176,6 +176,14 @@ impl StatsSet {
         })
     }
 
+    pub fn get_as_bound<S, U>(&self) -> Option<S::Bound>
+    where
+        S: StatType<U>,
+        U: for<'a> TryFrom<&'a ScalarValue, Error = VortexError>,
+    {
+        self.get_as::<U>(S::STAT).map(|v| v.bound::<S>())
+    }
+
     /// Set the stat `stat` to `value`.
     pub fn set(&mut self, stat: Stat, value: Precision<ScalarValue>) {
         if self.values.is_none() {
@@ -204,8 +212,6 @@ impl StatsSet {
 
     pub fn keep_exact_inexact_stats(self, exact_keep: &[Stat], inexact_keep: &[Stat]) -> Self {
         if let Some(v) = self.values {
-            // v.retain(|(s, _)| exact_keep.contains(s) || inexact_keep.contains(s));
-
             v.into_iter()
                 .filter_map(|(s, v)| {
                     if exact_keep.contains(&s) {
@@ -330,7 +336,8 @@ impl StatsSet {
     // given two sets of stats (of differing precision) for the same array, combine them
     pub fn combine_sets(&mut self, other: &Self, dtype: &DType) -> VortexResult<()> {
         self.combine_max(other, dtype)?;
-        self.combine_min(other, dtype)
+        self.combine_min(other, dtype)?;
+        self.combine_is_constant(other)
     }
 
     fn combine_min(&mut self, other: &Self, dtype: &DType) -> VortexResult<()> {
@@ -375,6 +382,29 @@ impl StatsSet {
         Ok(())
     }
 
+    fn combine_is_constant(&mut self, other: &Self) -> VortexResult<()> {
+        match (
+            self.get_as_bound::<IsConstant, bool>(),
+            other.get_as_bound::<IsConstant, bool>(),
+        ) {
+            (Some(m1), Some(m2)) => {
+                let intersection = m1
+                    .intersection(&m2)
+                    .vortex_expect("can always compare scalar")
+                    .ok_or_else(|| {
+                        vortex_err!("IsConstant bounds ({m1:?}, {m2:?}) do not overlap")
+                    })?;
+                if intersection != m1 {
+                    self.set(Stat::IsConstant, intersection.map(ScalarValue::from));
+                }
+            }
+            (None, Some(m)) => self.set(Stat::IsConstant, m.map(ScalarValue::from)),
+            (Some(_), None) => (),
+            (None, None) => self.clear(Stat::IsConstant),
+        }
+        Ok(())
+    }
+
     fn merge_min(&mut self, other: &Self, dtype: &DType) {
         match (
             self.get_scalar_bound::<Min>(dtype.clone()),
@@ -406,21 +436,25 @@ impl StatsSet {
     }
 
     fn merge_is_constant(&mut self, other: &Self, dtype: &DType) {
-        if self
-            .get_as(Stat::IsConstant)
-            .is_some_and(|v| v.some_exact() == Some(true))
-            && other
-                .get_as(Stat::IsConstant)
-                .is_some_and(|v| v.some_exact() == Some(true))
-            && self
-                .get_scalar(Stat::Min, dtype.clone())
-                .is_some_and(|min| {
-                    min.is_exact() && Some(min) == other.get_scalar(Stat::Min, dtype.clone())
-                })
+        let self_const = self.get_as(Stat::IsConstant);
+        let other_const = other.get_as(Stat::IsConstant);
+        let self_min = self.get_scalar(Stat::Min, dtype.clone());
+        let other_min = other.get_scalar(Stat::Min, dtype.clone());
+
+        if let (
+            Some(Precision::Exact(self_const)),
+            Some(Precision::Exact(other_const)),
+            Some(Precision::Exact(self_min)),
+            Some(Precision::Exact(other_min)),
+        ) = (self_const, other_const, self_min, other_min)
         {
-            return;
+            if self_const && other_const && self_min == other_min {
+                self.set(Stat::IsConstant, Precision::exact(true));
+            } else {
+                self.set(Stat::IsConstant, Precision::inexact(false));
+            }
         }
-        self.set(Stat::IsConstant, Precision::inexact(false));
+        self.set(Stat::IsConstant, Precision::exact(false));
     }
 
     fn merge_is_sorted(&mut self, other: &Self, dtype: &DType) {
@@ -595,7 +629,7 @@ mod test {
         );
         assert_eq!(
             first.get_as::<bool>(Stat::IsConstant),
-            Some(Precision::inexact(false))
+            Some(Precision::exact(false))
         );
         assert_eq!(first.get_as::<i32>(Stat::Min), Some(Precision::exact(42)));
     }
@@ -897,5 +931,38 @@ mod test {
         assert_eq!(set.get_as::<i32>(Stat::Max), Some(Precision::inexact(100)));
         assert_eq!(set.get_as::<i32>(Stat::Min), Some(Precision::exact(50)));
         assert_eq!(set.get_as::<i32>(Stat::TrueCount), None);
+    }
+
+    #[test]
+    fn test_combine_is_constant() {
+        {
+            let mut stats = StatsSet::of(Stat::IsConstant, Precision::exact(true));
+            let stats2 = StatsSet::of(Stat::IsConstant, Precision::exact(true));
+            stats.combine_is_constant(&stats2).unwrap();
+            assert_eq!(
+                stats.get_as::<bool>(Stat::IsConstant),
+                Some(Precision::exact(true))
+            );
+        }
+
+        {
+            let mut stats = StatsSet::of(Stat::IsConstant, Precision::exact(true));
+            let stats2 = StatsSet::of(Stat::IsConstant, Precision::inexact(false));
+            stats.combine_is_constant(&stats2).unwrap();
+            assert_eq!(
+                stats.get_as::<bool>(Stat::IsConstant),
+                Some(Precision::exact(true))
+            );
+        }
+
+        {
+            let mut stats = StatsSet::of(Stat::IsConstant, Precision::exact(false));
+            let stats2 = StatsSet::of(Stat::IsConstant, Precision::inexact(false));
+            stats.combine_is_constant(&stats2).unwrap();
+            assert_eq!(
+                stats.get_as::<bool>(Stat::IsConstant),
+                Some(Precision::exact(false))
+            );
+        }
     }
 }

--- a/vortex-array/src/stats/stats_set.rs
+++ b/vortex-array/src/stats/stats_set.rs
@@ -210,13 +210,11 @@ impl StatsSet {
         }
     }
 
-    pub fn keep_exact_inexact_stats(self, exact_keep: &[Stat], inexact_keep: &[Stat]) -> Self {
+    pub fn keep_inexact_stats(self, inexact_keep: &[Stat]) -> Self {
         if let Some(v) = self.values {
             v.into_iter()
                 .filter_map(|(s, v)| {
-                    if exact_keep.contains(&s) {
-                        Some((s, v))
-                    } else if inexact_keep.contains(&s) {
+                    if inexact_keep.contains(&s) {
                         Some((s, v.into_inexact()))
                     } else {
                         None
@@ -925,11 +923,11 @@ mod test {
             (Stat::TrueCount, Precision::inexact(10)),
         ]);
 
-        let set = set.keep_exact_inexact_stats(&[Stat::Min], &[Stat::Max]);
+        let set = set.keep_exact_inexact_stats(&[Stat::Min, Stat::Max]);
 
         assert_eq!(set.len(), 2);
         assert_eq!(set.get_as::<i32>(Stat::Max), Some(Precision::inexact(100)));
-        assert_eq!(set.get_as::<i32>(Stat::Min), Some(Precision::exact(50)));
+        assert_eq!(set.get_as::<i32>(Stat::Min), Some(Precision::inexact(50)));
         assert_eq!(set.get_as::<i32>(Stat::TrueCount), None);
     }
 


### PR DESCRIPTION
 - Early bail on is_constant for chunked array 
 - Don't compute stats in compute fns for const array
 - Fixup inference of is_constant inference in compute fns