### PR TITLE
restore uncompressed by default behaviour in VortexLayoutStrategy

### DIFF
--- a/bench-vortex/src/clickbench.rs
+++ b/bench-vortex/src/clickbench.rs
@@ -12,6 +12,7 @@ use tokio::fs::{create_dir_all, OpenOptions};
 use vortex::arrow::FromArrowType;
 use vortex::dtype::DType;
 use vortex::error::{vortex_err, VortexError};
+use vortex::file::strategy::VortexLayoutStrategy;
 use vortex::file::{VortexWriteOptions, VORTEX_FILE_EXTENSION};
 use vortex::stream::ArrayStreamAdapter;
 use vortex::Array;
@@ -184,7 +185,10 @@ pub async fn register_vortex_files(
                         .open(&vtx_file)
                         .await?;
 
-                    VortexWriteOptions::default().write(f, array_stream).await?;
+                    VortexWriteOptions::default()
+                        .with_strategy(VortexLayoutStrategy::default().with_compress(true))
+                        .write(f, array_stream)
+                        .await?;
 
                     anyhow::Ok(())
                 })

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -93,7 +93,7 @@ mod generic;
 mod memory;
 mod open;
 pub mod segments;
-mod strategy;
+pub mod strategy;
 #[cfg(test)]
 mod tests;
 mod writer;

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -41,6 +41,13 @@ impl Default for VortexLayoutStrategy {
     }
 }
 
+impl VortexLayoutStrategy {
+    pub fn with_compress(mut self, compress: bool) -> Self {
+        self.compress = compress;
+        self
+    }
+}
+
 impl LayoutStrategy for VortexLayoutStrategy {
     fn new_writer(&self, dtype: &DType) -> VortexResult<Box<dyn LayoutWriter>> {
         // First, we unwrap struct arrays into their components.

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -28,6 +28,7 @@ pub struct VortexLayoutStrategy {
     pub minimum_block_size: usize,
     /// The divisor for the number of rows in a block.
     pub block_len_multiple: usize,
+    pub compress: bool,
 }
 
 impl Default for VortexLayoutStrategy {
@@ -35,6 +36,7 @@ impl Default for VortexLayoutStrategy {
         Self {
             minimum_block_size: 8 * (1 << 20), // 8MB
             block_len_multiple: 8 * 1024,      // 8192 rows
+            compress: false,
         }
     }
 }
@@ -47,27 +49,30 @@ impl LayoutStrategy for VortexLayoutStrategy {
                 .map(|w| w.boxed());
         }
 
-        // Then we re-chunk each column per our strategy...
-        Ok(ColumnChunker::new(
-            dtype.clone(),
-            // ...compress each chunk using a sampling compressor...
+        let chunked_writer = ChunkedLayoutWriter::new(
+            dtype,
+            ChunkedLayoutOptions {
+                chunk_strategy: Arc::new(FlatLayoutOptions::default()),
+                ..Default::default()
+            },
+        )
+        .boxed();
+
+        let writer = if self.compress {
             SamplingCompressorWriter {
                 compressor: COMPRESSOR.clone(),
                 compress_like: None,
-                child: ChunkedLayoutWriter::new(
-                    dtype,
-                    ChunkedLayoutOptions {
-                        // ...and write each chunk as a flat layout.
-                        chunk_strategy: Arc::new(FlatLayoutOptions::default()),
-                        ..Default::default()
-                    },
-                )
-                .boxed(),
+                child: chunked_writer,
             }
-            .boxed(),
-            self.clone(),
-        )
-        .boxed())
+            .boxed()
+        } else {
+            chunked_writer
+        };
+
+        // Then we re-chunk each column per our strategy, optionally
+        // compressing each chunk using a sampling compressor, and writing
+        // each chunk as a flat layout.
+        Ok(ColumnChunker::new(dtype.clone(), writer, self.clone()).boxed())
     }
 }
 

--- a/vortex-layout/src/layouts/flat/writer.rs
+++ b/vortex-layout/src/layouts/flat/writer.rs
@@ -59,7 +59,7 @@ fn retain_only_stats(array: &Array, stats: &[Stat]) {
 impl LayoutWriter for FlatLayoutWriter {
     fn push_chunk(&mut self, segments: &mut dyn SegmentWriter, chunk: Array) -> VortexResult<()> {
         if self.layout.is_some() {
-            vortex_bail!("FlatLayoutStrategy::push_batch called after finish");
+            vortex_bail!("FlatLayoutStrategy::push_chunk called after finish");
         }
         let row_count = chunk.len() as u64;
         retain_only_stats(&chunk, &self.options.array_stats);
@@ -84,7 +84,7 @@ impl LayoutWriter for FlatLayoutWriter {
     fn finish(&mut self, _segments: &mut dyn SegmentWriter) -> VortexResult<Layout> {
         self.layout
             .take()
-            .ok_or_else(|| vortex_err!("FlatLayoutStrategy::finish called without push_batch"))
+            .ok_or_else(|| vortex_err!("FlatLayoutStrategy::finish called without push_chunk"))
     }
 }
 


### PR DESCRIPTION
`VortexWriteOptions::default` to compress by default ends up double compressing at some call sites, example: https://github.com/spiraldb/vortex/blob/1ca79f4cd0edb03c5e24c0575eea0db671690e22/bench-vortex/benches/compress.rs#L118-L124

This PR restores the behaviour of the previous `VortexLayoutStrategy` and adding a new flag to enable compression