### PR TITLE
unbreak release-plz again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,4 +210,3 @@ benchmarks/.out
 profile.json.gz
 *.trace.json
 *.folded
-*.svg


### PR DESCRIPTION
I added `*.svg` in #2276 because some flamegraphs are svgs, but we actually want some svg files for docs.