### PR TITLE
Configurable IoDispatcher for datafusion

### DIFF
--- a/vortex-datafusion/src/persistent/execution.rs
+++ b/vortex-datafusion/src/persistent/execution.rs
@@ -15,6 +15,7 @@ use itertools::Itertools;
 use vortex_array::ContextRef;
 use vortex_expr::datafusion::convert_expr_to_vortex;
 use vortex_expr::{and, VortexExpr};
+use vortex_io::IoDispatcher;
 
 use super::cache::FileLayoutCache;
 use super::config::{ConfigProjection, FileScanConfigExt};
@@ -31,6 +32,7 @@ pub(crate) struct VortexExec {
     initial_read_cache: FileLayoutCache,
     projected_arrow_schema: SchemaRef,
     projection: Arc<dyn VortexExpr>,
+    io_dispatcher: IoDispatcher,
 }
 
 impl VortexExec {
@@ -40,6 +42,7 @@ impl VortexExec {
         predicate: Option<Arc<dyn PhysicalExpr>>,
         ctx: ContextRef,
         initial_read_cache: FileLayoutCache,
+        io_dispatcher: IoDispatcher,
     ) -> DFResult<Self> {
         let ConfigProjection {
             arrow_schema,
@@ -74,6 +77,7 @@ impl VortexExec {
             projected_statistics: statistics,
             projected_arrow_schema: arrow_schema,
             projection: projection_expr,
+            io_dispatcher,
         })
     }
 
@@ -133,6 +137,7 @@ impl ExecutionPlan for VortexExec {
             self.initial_read_cache.clone(),
             self.projected_arrow_schema.clone(),
             context.session_config().batch_size(),
+            self.io_dispatcher.clone(),
         )?;
         let stream = FileStream::new(&self.file_scan_config, partition, opener, &self.metrics)?;
 

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -28,7 +28,7 @@ use vortex_array::{stats, ContextRef};
 use vortex_dtype::DType;
 use vortex_error::{vortex_err, VortexExpect, VortexResult};
 use vortex_file::{VortexOpenOptions, VORTEX_FILE_EXTENSION};
-use vortex_io::ObjectStoreReadAt;
+use vortex_io::{IoDispatcher, ObjectStoreReadAt};
 
 use super::cache::FileLayoutCache;
 use super::execution::VortexExec;
@@ -42,6 +42,7 @@ pub struct VortexFormat {
     context: ContextRef,
     file_layout_cache: FileLayoutCache,
     opts: VortexFormatOptions,
+    io_dispatcher: IoDispatcher,
 }
 
 /// Options to configure the [`VortexFormat`].
@@ -49,11 +50,16 @@ pub struct VortexFormat {
 pub struct VortexFormatOptions {
     /// The size of the in-memory [`vortex_file::FileLayout`] cache.
     pub cache_size_mb: usize,
+    /// Number of threads to dispatch the scan over
+    pub dispatch_threads: usize,
 }
 
 impl Default for VortexFormatOptions {
     fn default() -> Self {
-        Self { cache_size_mb: 256 }
+        Self {
+            cache_size_mb: 256,
+            dispatch_threads: 1,
+        }
     }
 }
 
@@ -117,10 +123,12 @@ impl VortexFormat {
     /// Create a new instance of the [`VortexFormat`].
     pub fn new(context: ContextRef) -> Self {
         let opts = VortexFormatOptions::default();
+        let io_dispatcher = IoDispatcher::new_tokio(opts.dispatch_threads);
         Self {
             file_layout_cache: FileLayoutCache::new(opts.cache_size_mb, context.clone()),
             context,
             opts,
+            io_dispatcher,
         }
     }
 
@@ -302,6 +310,7 @@ impl FileFormat for VortexFormat {
             filters.cloned(),
             self.context.clone(),
             self.file_layout_cache.clone(),
+            self.io_dispatcher.clone(),
         )?
         .into_arc();
 

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -24,9 +24,11 @@ pub(crate) struct VortexFileOpener {
     pub(crate) file_layout_cache: FileLayoutCache,
     pub projected_arrow_schema: SchemaRef,
     pub batch_size: usize,
+    pub io_dispatcher: IoDispatcher,
 }
 
 impl VortexFileOpener {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         ctx: ContextRef,
         object_store: Arc<dyn ObjectStore>,
@@ -35,6 +37,7 @@ impl VortexFileOpener {
         file_layout_cache: FileLayoutCache,
         projected_arrow_schema: SchemaRef,
         batch_size: usize,
+        io_dispatcher: IoDispatcher,
     ) -> VortexResult<Self> {
         Ok(Self {
             ctx,
@@ -44,6 +47,7 @@ impl VortexFileOpener {
             file_layout_cache,
             projected_arrow_schema,
             batch_size,
+            io_dispatcher,
         })
     }
 }
@@ -60,6 +64,7 @@ impl FileOpener for VortexFileOpener {
         let object_store = self.object_store.clone();
         let projected_arrow_schema = self.projected_arrow_schema.clone();
         let batch_size = self.batch_size;
+        let io_dispatcher = self.io_dispatcher.clone();
 
         Ok(async move {
             let vxf = VortexOpenOptions::file(read_at)
@@ -85,7 +90,7 @@ impl FileOpener for VortexFileOpener {
 
             // TODO(ngates): we may want to do something to also poll this handle and propagate
             //  any errors back into DataFusion.
-            IoDispatcher::default().dispatch(move || {
+            io_dispatcher.dispatch(move || {
                 let mut send = send.clone();
                 async move {
                     let stream = vxf


### PR DESCRIPTION
instead of using a static shared dispatcher, allow the user to control the number of threads