### PR TITLE
Use vortex-scan to orchestrate conjuncts

### DIFF
--- a/bench-vortex/src/bin/clickbench.rs
+++ b/bench-vortex/src/bin/clickbench.rs
@@ -64,7 +64,6 @@ fn main() {
 
         let fmt_layer = tracing_subscriber::fmt::layer()
             .with_writer(std::io::stderr)
-            .with_file(true)
             .with_level(true)
             .with_line_number(true);
 

--- a/vortex-array/src/vtable/canonical.rs
+++ b/vortex-array/src/vtable/canonical.rs
@@ -12,10 +12,7 @@ pub trait CanonicalVTable<Array> {
 
     fn canonicalize_into(&self, array: Array, builder: &mut dyn ArrayBuilder) -> VortexResult<()> {
         let canonical = self.into_canonical(array)?;
-        debug!(
-            "default impl canonicalize_into {}",
-            canonical.tree_display()
-        );
+        debug!("default impl canonicalize_into {}", canonical.encoding());
         builder.extend_from_array(canonical.into_array())
     }
 }

--- a/vortex-layout/src/layouts/chunked/eval_expr.rs
+++ b/vortex-layout/src/layouts/chunked/eval_expr.rs
@@ -20,6 +20,13 @@ impl ExprEvaluator for ChunkedReader {
 
         // First we need to compute the pruning mask
         let pruning_mask = self.pruning_mask(&expr).await?;
+        log::debug!(
+            "Pruning mask for {}..{} expr {}: {:?}",
+            row_mask.begin(),
+            row_mask.end(),
+            expr,
+            pruning_mask
+        );
 
         // Figure out which chunks intersect the RowMask
         let chunk_range = self.chunk_range(row_mask.begin()..row_mask.end());

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -144,7 +144,7 @@ impl ChunkedReader {
                 if let Some(predicate) = pruning_predicate {
                     predicate
                         .evaluate(stats_table.array())?
-                        .map(|mask| Mask::try_from(mask))
+                        .map(Mask::try_from)
                         .transpose()?
                 } else {
                     None

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -2,14 +2,14 @@ use std::iter;
 use std::ops::Range;
 use std::sync::{Arc, OnceLock, RwLock};
 
-use arrow_buffer::BooleanBuffer;
 use async_once_cell::OnceCell;
 use vortex_array::aliases::hash_map::HashMap;
 use vortex_array::stats::stats_from_bitset_bytes;
-use vortex_array::{ContextRef, IntoArrayVariant};
+use vortex_array::ContextRef;
 use vortex_error::{vortex_bail, vortex_err, vortex_panic, VortexResult};
 use vortex_expr::pruning::PruningPredicate;
 use vortex_expr::{ExprRef, Identity};
+use vortex_mask::Mask;
 use vortex_scan::RowMask;
 
 use crate::layouts::chunked::stats_table::StatsTable;
@@ -18,7 +18,7 @@ use crate::reader::LayoutReader;
 use crate::scan::ScanExecutor;
 use crate::{ExprEvaluator, Layout, LayoutVTable};
 
-type PruningCache = Arc<OnceCell<Option<BooleanBuffer>>>;
+type PruningCache = Arc<OnceCell<Option<Mask>>>;
 
 #[derive(Clone)]
 pub struct ChunkedReader {
@@ -125,7 +125,8 @@ impl ChunkedReader {
             .map(|opt| opt.as_ref())
     }
 
-    pub(crate) async fn pruning_mask(&self, expr: &ExprRef) -> VortexResult<Option<BooleanBuffer>> {
+    /// Returns a pruning mask where `true` means the chunk _can be pruned_.
+    pub(crate) async fn pruning_mask(&self, expr: &ExprRef) -> VortexResult<Option<Mask>> {
         let cell = self
             .pruning_result
             .write()
@@ -135,15 +136,16 @@ impl ChunkedReader {
             .clone();
 
         cell.get_or_try_init(async {
-            log::debug!("Constructing pruning mask for expr: {:?}", expr);
             let pruning_predicate = PruningPredicate::try_new(expr);
+            if let Some(p) = &pruning_predicate {
+                log::debug!("Constructed pruning mask for expr: {}: {}", expr, p);
+            }
             Ok(if let Some(stats_table) = self.stats_table().await? {
                 if let Some(predicate) = pruning_predicate {
                     predicate
                         .evaluate(stats_table.array())?
-                        .map(|mask| mask.into_bool())
+                        .map(|mask| Mask::try_from(mask))
                         .transpose()?
-                        .map(|mask| mask.boolean_buffer())
                 } else {
                     None
                 }

--- a/vortex-layout/src/reader.rs
+++ b/vortex-layout/src/reader.rs
@@ -26,6 +26,9 @@ impl LayoutReader for Arc<dyn LayoutReader + 'static> {
 }
 
 /// A trait for evaluating expressions against a [`LayoutReader`].
+///
+/// FIXME(ngates): what if this was evaluating_predicate(mask, expr) -> mask,
+///  evaluate_filter(mask, scan) -> Array, and evaluate_projection(mask, expr) -> Array?
 #[async_trait]
 pub trait ExprEvaluator {
     async fn evaluate_expr(&self, row_mask: RowMask, expr: ExprRef) -> VortexResult<Array>;

--- a/vortex-layout/src/scan/mod.rs
+++ b/vortex-layout/src/scan/mod.rs
@@ -1,4 +1,3 @@
-use std::ops::BitAnd;
 use std::sync::Arc;
 
 use futures::stream::BoxStream;
@@ -8,7 +7,6 @@ use vortex_array::stream::{ArrayStream, ArrayStreamAdapter, ArrayStreamExt};
 use vortex_buffer::{Buffer, ByteBuffer};
 use vortex_expr::{ExprRef, Identity};
 mod split_by;
-use futures::FutureExt;
 mod task;
 pub mod unified;
 
@@ -21,7 +19,7 @@ use vortex_error::{VortexExpect, VortexResult};
 use vortex_expr::transform::immediate_access::immediate_scope_access;
 use vortex_expr::transform::simplify_typed::simplify_typed;
 use vortex_mask::Mask;
-use vortex_scan::RowMask;
+use vortex_scan::{RowMask, Scanner};
 
 use crate::scan::unified::UnifiedDriverStream;
 use crate::segments::{AsyncSegmentReader, SegmentId};
@@ -263,6 +261,8 @@ impl<D: ScanDriver> Scan<D> {
         let reader: Arc<dyn LayoutReader> =
             self.layout.reader(executor.clone(), self.ctx.clone())?;
 
+        let scanner = Arc::new(Scanner::new(self.filter.clone())?);
+
         // Setup a filter stream
         let row_masks = stream::iter(self.row_masks);
         let row_masks: BoxStream<'static, VortexResult<RowMask>> =
@@ -272,31 +272,34 @@ impl<D: ScanDriver> Scan<D> {
                     .map(move |row_mask| {
                         let reader = reader.clone();
                         let filter = filter.clone();
+
+                        log::debug!(
+                            "Evaluating filter {} for row mask {}..{} {}",
+                            &filter,
+                            row_mask.begin(),
+                            row_mask.end(),
+                            row_mask.filter_mask().density()
+                        );
+
+                        let row_offset = row_mask.begin();
+                        let range_scanner = scanner.clone().range_scanner(row_mask);
+
                         async move {
-                            log::debug!(
-                                "Evaluating filter {} for row mask {}..{} {}",
-                                &filter,
-                                row_mask.begin(),
-                                row_mask.end(),
-                                row_mask.filter_mask().density()
-                            );
-                            let array = reader
-                                .evaluate_expr(
-                                    RowMask::new_valid_between(row_mask.begin(), row_mask.end()),
-                                    filter.clone(),
-                                )
+                            let mask = range_scanner
+                                .evaluate_async(move |mask, expr| {
+                                    let reader = reader.clone();
+                                    async move { reader.evaluate_expr(mask, expr).await }
+                                })
                                 .await?;
-                            let mask = Mask::try_from(array)?.bitand(row_mask.filter_mask());
                             if mask.all_false() {
                                 Ok(None)
                             } else {
-                                Ok(Some(RowMask::new(mask, row_mask.begin())))
+                                Ok(Some(RowMask::new(mask, row_offset)))
                             }
                         }
-                        .map(|r| r.transpose())
                     })
                     .buffered(self.concurrency)
-                    .filter_map(|r| async move { r })
+                    .filter_map(|r| async move { r.transpose() })
                     .boxed()
             } else {
                 row_masks.map(Ok).boxed()

--- a/vortex-scan/src/lib.rs
+++ b/vortex-scan/src/lib.rs
@@ -11,10 +11,8 @@ use std::sync::Arc;
 
 pub use range_scan::*;
 pub use row_mask::*;
-use vortex_dtype::DType;
 use vortex_error::VortexResult;
 use vortex_expr::forms::cnf::cnf;
-use vortex_expr::transform::simplify_typed::simplify_typed;
 use vortex_expr::{lit, or, ExprRef};
 
 /// Represents a scan operation to read data from a set of rows, with an optional filter expression,
@@ -30,9 +28,7 @@ use vortex_expr::{lit, or, ExprRef};
 /// the second filter over the reduced set of rows.
 #[derive(Debug, Clone)]
 pub struct Scanner {
-    projection: ExprRef,
     rev_filter: Box<[ExprRef]>,
-    projection_dtype: DType,
     // A sorted list of row indices to include in the scan. We store row indices since they may
     // produce a very sparse RowMask.
     // take_indices: Vec<u64>,
@@ -41,14 +37,8 @@ pub struct Scanner {
 
 impl Scanner {
     /// Create a new scan with the given projection and optional filter.
-    pub fn new(dtype: DType, projection: ExprRef, filter: Option<ExprRef>) -> VortexResult<Self> {
-        let projection = simplify_typed(projection, &dtype)?;
-        let filter = filter.map(|f| simplify_typed(f, &dtype)).transpose()?;
-
-        // TODO(ngates): compute and cache a FieldMask based on the referenced fields.
-        //  Where FieldMask ~= Vec<FieldPath>
-        let result_dtype = projection.return_dtype(&dtype)?;
-
+    /// Expressions must be simplified and typed before being passed to this function.
+    pub fn new(filter: Option<ExprRef>) -> VortexResult<Self> {
         let conjuncts: Box<[ExprRef]> = if let Some(filter) = filter {
             let conjuncts = cnf(filter)?;
             conjuncts
@@ -67,29 +57,13 @@ impl Scanner {
         };
 
         Ok(Self {
-            projection,
             rev_filter: conjuncts,
-            projection_dtype: result_dtype,
         })
-    }
-
-    /// Returns the projection expression.
-    pub fn projection(&self) -> &ExprRef {
-        &self.projection
-    }
-
-    /// Compute the result dtype of the scan given the input dtype.
-    pub fn result_dtype(&self) -> &DType {
-        &self.projection_dtype
     }
 
     /// Instantiate a new scan for a specific range. The range scan will share statistics with this
     /// parent scan in order to optimize future range scans.
-    pub fn range_scanner(self: Arc<Self>, row_mask: RowMask) -> VortexResult<RangeScanner> {
-        Ok(RangeScanner::new(
-            self,
-            row_mask.begin(),
-            row_mask.filter_mask().clone(),
-        ))
+    pub fn range_scanner(self: Arc<Self>, row_mask: RowMask) -> RangeScanner {
+        RangeScanner::new(self, row_mask.begin(), row_mask.filter_mask().clone())
     }
 }

--- a/vortex-scan/src/range_scan.rs
+++ b/vortex-scan/src/range_scan.rs
@@ -3,7 +3,7 @@ use std::ops::{BitAnd, Range};
 use std::sync::Arc;
 
 use vortex_array::Array;
-use vortex_error::{VortexExpect, VortexResult};
+use vortex_error::{vortex_bail, VortexExpect, VortexResult};
 use vortex_expr::ExprRef;
 use vortex_mask::Mask;
 
@@ -11,26 +11,23 @@ use crate::{RowMask, Scanner};
 
 /// A scan operation defined for a single row-range of the columnar data.
 pub struct RangeScanner {
-    scan: Arc<Scanner>,
     row_range: Range<u64>,
     mask: Mask,
     state: State,
 }
 
 enum State {
-    // First we run the filter expression over the full row range.
+    // We run the filters.
     FilterEval((Mask, Vec<ExprRef>)),
-    // Then we project the selected rows.
-    Project((Mask, ExprRef)),
-    // And then we're done.
-    Ready(Option<Array>),
+    // And then we return the projection mask.
+    Ready(Mask),
 }
 
 /// The next operation that should be performed. Either an expression to run, or the result
 /// of the [`RangeScanner`].
 pub enum NextOp {
-    /// The finished result of the scan.
-    Ready(Option<Array>),
+    /// The finished result of the scan is the projection mask.
+    Ready(Mask),
     /// The next expression to evaluate.
     /// The caller **must** first apply the mask before evaluating the expression.
     Eval((Range<u64>, Mask, ExprRef)),
@@ -69,12 +66,10 @@ impl RangeScanner {
             //  aligned and intersected with the given mask.
             State::FilterEval((Mask::new_true(mask.len()), scan.rev_filter.to_vec()))
         } else {
-            // If there is no filter expression, then we immediately perform a mask + project.
-            State::Project((mask.clone(), scan.projection().clone()))
+            State::Ready(mask.clone())
         };
 
         Self {
-            scan,
             row_range: row_offset..row_offset + mask.len() as u64,
             mask,
             state,
@@ -96,10 +91,7 @@ impl RangeScanner {
                     .vortex_expect("conjuncts is always non-empty")
                     .clone(),
             )),
-            State::Project((mask, expr)) => {
-                NextOp::Eval((self.row_range.clone(), mask.clone(), expr.clone()))
-            }
-            State::Ready(array) => NextOp::Ready(array.clone()),
+            State::Ready(mask) => NextOp::Ready(mask.clone()),
         }
     }
 
@@ -122,11 +114,7 @@ impl RangeScanner {
                     self.mask.intersect_by_rank(&mask)
                 };
 
-                // Then move onto the projection
-                if mask.true_count() == 0 {
-                    // If the mask is empty, then we're done.
-                    self.state = State::Ready(None);
-                } else if !conjuncts_rev.is_empty() {
+                if mask.true_count() > 0 && !conjuncts_rev.is_empty() {
                     self.mask = mask;
                     let mask = if self.mask.density() < APPLY_FILTER_SELECTIVITY_THRESHOLD {
                         self.mask.clone()
@@ -136,27 +124,25 @@ impl RangeScanner {
                     // conjuncts_rev is again non-empty, so we can put it into FilterEval
                     self.state = State::FilterEval((mask, conjuncts_rev))
                 } else {
-                    self.state = State::Project((mask, self.scan.projection().clone()))
+                    // Otherwise, we're done
+                    self.state = State::Ready(mask);
                 }
             }
-            State::Project(_) => {
-                // We're done.
-                assert!(!result.is_empty(), "projected array cannot be empty");
-                self.state = State::Ready(Some(result));
+            State::Ready(_) => {
+                vortex_bail!("unexpected state transition")
             }
-            State::Ready(_) => {}
         }
         Ok(self)
     }
 
     /// Evaluate the [`RangeScanner`] operation using a synchronous expression evaluator.
-    pub fn evaluate<E>(mut self, evaluator: E) -> VortexResult<Option<Array>>
+    pub fn evaluate<E>(mut self, evaluator: E) -> VortexResult<Mask>
     where
         E: Fn(RowMask, ExprRef) -> VortexResult<Array>,
     {
         loop {
             match self.next() {
-                NextOp::Ready(array) => return Ok(array),
+                NextOp::Ready(mask) => return Ok(mask),
                 NextOp::Eval((row_range, mask, expr)) => {
                     self =
                         self.transition(evaluator(RowMask::new(mask, row_range.start), expr)?)?;
@@ -166,14 +152,14 @@ impl RangeScanner {
     }
 
     /// Evaluate the [`RangeScanner`] operation using an async expression evaluator.
-    pub async fn evaluate_async<E, F>(mut self, evaluator: E) -> VortexResult<Option<Array>>
+    pub async fn evaluate_async<E, F>(mut self, evaluator: E) -> VortexResult<Mask>
     where
         E: Fn(RowMask, ExprRef) -> F,
         F: Future<Output = VortexResult<Array>>,
     {
         loop {
             match self.next() {
-                NextOp::Ready(array) => return Ok(array),
+                NextOp::Ready(mask) => return Ok(mask),
                 NextOp::Eval((row_range, mask, expr)) => {
                     log::debug!("RangeScan {:?} evaluating expr {}", row_range, expr);
                     self = self
@@ -190,25 +176,11 @@ mod tests {
 
     use vortex_array::array::{BoolArray, PrimitiveArray, StructArray};
     use vortex_array::compute::filter;
-    use vortex_array::variants::StructArrayTrait;
-    use vortex_array::{IntoArray, IntoArrayVariant};
-    use vortex_dtype::Nullability::NonNullable;
-    use vortex_dtype::PType::U64;
-    use vortex_dtype::{DType, StructDType};
+    use vortex_array::IntoArray;
     use vortex_expr::{and, get_item, gt, ident, lit};
     use vortex_mask::Mask;
 
     use crate::{RangeScanner, Scanner};
-
-    fn dtype() -> DType {
-        DType::Struct(
-            Arc::new(StructDType::new(
-                vec!["a".into(), "b".into(), "c".into()].into(),
-                vec![U64.into(), U64.into(), U64.into()],
-            )),
-            NonNullable,
-        )
-    }
 
     #[test]
     fn range_scan_few_conj_filter_low_selectivity() {
@@ -216,17 +188,16 @@ mod tests {
         let expr_b = gt(get_item("b", ident()), lit(2));
         let expr_c = gt(get_item("c", ident()), lit(3));
         let scan = Arc::new(
-            Scanner::new(
-                dtype(),
-                ident(),
-                Some(and(expr_a.clone(), and(expr_b.clone(), expr_c.clone()))),
-            )
+            Scanner::new(Some(and(
+                expr_a.clone(),
+                and(expr_b.clone(), expr_c.clone()),
+            )))
             .unwrap(),
         );
         let len = 1000;
         let range = RangeScanner::new(scan, 0, Mask::new_true(len));
 
-        let res = range
+        let mask = range
             .evaluate(|mask, expr| {
                 let arr = if expr == expr_a.clone() {
                     BoolArray::from_iter((0..mask.len()).map(|i| !(i > 10 && i < 30))).into_array()
@@ -249,16 +220,15 @@ mod tests {
 
                 filter(&arr, mask.filter_mask())
             })
-            .unwrap()
             .unwrap();
 
-        assert!(res.as_struct_array().is_some());
-        let field = res.into_struct().unwrap().maybe_null_field_by_name("a");
-
         assert_eq!(
-            field.unwrap().into_primitive().unwrap().as_slice::<u64>(),
+            mask.to_boolean_buffer()
+                .iter()
+                .collect::<Vec<_>>()
+                .as_slice(),
             (0..len as u64)
-                .filter(|&i| {
+                .map(|i| {
                     (i <= 10 || i >= 30) && (i <= 100 || i >= 130) && (i <= 510 || i >= 530)
                 })
                 .collect::<Vec<_>>()
@@ -272,17 +242,16 @@ mod tests {
         let expr_b = gt(get_item("b", ident()), lit(2));
         let expr_c = gt(get_item("c", ident()), lit(3));
         let scan = Arc::new(
-            Scanner::new(
-                dtype(),
-                ident(),
-                Some(and(expr_a.clone(), and(expr_b.clone(), expr_c.clone()))),
-            )
+            Scanner::new(Some(and(
+                expr_a.clone(),
+                and(expr_b.clone(), expr_c.clone()),
+            )))
             .unwrap(),
         );
         let len = 1000;
         let range = RangeScanner::new(scan, 0, Mask::new_true(len));
 
-        let res = range
+        let mask = range
             .evaluate(|mask, expr| {
                 let arr = if expr == expr_a.clone() {
                     BoolArray::from_iter((0..mask.len()).map(|i| !(i > 10 && i < 900))).into_array()
@@ -305,17 +274,15 @@ mod tests {
 
                 filter(&arr, mask.filter_mask())
             })
-            .unwrap()
             .unwrap();
 
-        assert!(res.as_struct_array().is_some());
-
-        let field = res.into_struct().unwrap().maybe_null_field_by_name("a");
-
         assert_eq!(
-            field.unwrap().into_primitive().unwrap().as_slice::<u64>(),
+            mask.to_boolean_buffer()
+                .iter()
+                .collect::<Vec<_>>()
+                .as_slice(),
             (0..len as u64)
-                .filter(|&i| !(i > 10 && i < 990))
+                .map(|i| !(i > 10 && i < 990))
                 .collect::<Vec<_>>()
                 .as_slice()
         );


### PR DESCRIPTION
The downside here is that we only spawn I/O for one conjunction at a time. It would be good to work towards an API where we can spawn all the I/O up-front, but then still benefit from re-ordering of expressions.

This would help even more because currently the conjunct ordering is fixed at the time the range scanner is created (for each row mask). In practice, we buffer enough row masks that almost all splits are constructed with the default conjunct ordering, before we have had a chance to reorder it.

So ideally, we kick off I/O, and then when the fields are in, we choose at that point which order to evaluate the conjuncts. If a conjunct is occasionally 100% selective, then we could split out the I/O and run it first, before even fetching the remainder.