### PR TITLE
Fix take with nullable indices on arrays with patches

### DIFF
--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -71,9 +71,6 @@ impl ALPRDArray {
             PType::try_from(left_parts.dtype()).vortex_expect("left_parts dtype must be uint");
 
         // we enforce right_parts to be non-nullable uint
-        if right_parts.dtype().is_nullable() {
-            vortex_bail!("right_parts dtype must be non-nullable");
-        }
         if !right_parts.dtype().is_unsigned_int() || right_parts.dtype().is_nullable() {
             vortex_bail!(MismatchedTypes: "non-nullable uint", right_parts.dtype());
         }
@@ -150,7 +147,7 @@ impl ALPRDArray {
     /// The dtype of the patches of the left parts of the array.
     #[inline]
     fn left_parts_patches_dtype(&self) -> DType {
-        DType::Primitive(self.metadata().left_parts_ptype, Nullability::NonNullable)
+        DType::Primitive(self.metadata().left_parts_ptype, self.dtype().nullability())
     }
 
     /// The leftmost (most significant) bits of the floating point values stored in the array.

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -82,12 +82,8 @@ impl ALPRDArray {
                 if !patches.values().all_valid()? {
                     vortex_bail!("patches must be all valid: {}", patches.values());
                 }
-                let metadata = patches.to_metadata(
-                    left_parts.len(),
-                    &left_parts
-                        .dtype()
-                        .with_nullability(patches.values().dtype().nullability()),
-                );
+                let patches = patches.cast_values(left_parts.dtype())?;
+                let metadata = patches.to_metadata(left_parts.len(), left_parts.dtype());
                 let (_, _, indices, values) = patches.into_parts();
                 children.push(indices);
                 children.push(values);

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -85,7 +85,12 @@ impl ALPRDArray {
                 if !patches.values().all_valid()? {
                     vortex_bail!("patches must be all valid: {}", patches.values());
                 }
-                let metadata = patches.to_metadata(left_parts.len(), left_parts.dtype());
+                let metadata = patches.to_metadata(
+                    left_parts.len(),
+                    &left_parts
+                        .dtype()
+                        .with_nullability(patches.values().dtype().nullability()),
+                );
                 let (_, _, indices, values) = patches.into_parts();
                 children.push(indices);
                 children.push(values);

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -82,11 +82,10 @@ impl ALPRDArray {
 
         let patches = left_parts_patches
             .map(|patches| {
-                if patches.values().dtype().is_nullable() {
-                    vortex_bail!("patches must be non-nullable: {}", patches.values());
+                if !patches.values().all_valid()? {
+                    vortex_bail!("patches must be all valid: {}", patches.values());
                 }
-                let metadata =
-                    patches.to_metadata(left_parts.len(), &left_parts.dtype().as_nonnullable());
+                let metadata = patches.to_metadata(left_parts.len(), left_parts.dtype());
                 let (_, _, indices, values) = patches.into_parts();
                 children.push(indices);
                 children.push(values);

--- a/encodings/alp/src/alp_rd/compute/take.rs
+++ b/encodings/alp/src/alp_rd/compute/take.rs
@@ -1,6 +1,7 @@
-use vortex_array::compute::{take, TakeFn};
+use vortex_array::compute::{fill_null, take, TakeFn};
 use vortex_array::{Array, IntoArray};
 use vortex_error::VortexResult;
+use vortex_scalar::{Scalar, ScalarValue};
 
 use crate::{ALPRDArray, ALPRDEncoding};
 
@@ -21,6 +22,10 @@ impl TakeFn<ALPRDArray> for ALPRDEncoding {
             })
             .transpose()?;
 
+        let right_parts = fill_null(
+            take(array.right_parts(), indices)?,
+            Scalar::new(array.right_parts().dtype().clone(), ScalarValue::from(0)),
+        )?;
         Ok(ALPRDArray::try_new(
             if taken_left_parts.dtype().is_nullable() {
                 array.dtype().as_nullable()
@@ -29,7 +34,7 @@ impl TakeFn<ALPRDArray> for ALPRDEncoding {
             },
             taken_left_parts,
             array.left_parts_dict(),
-            take(array.right_parts(), indices)?,
+            right_parts,
             array.right_bit_width(),
             left_parts_exceptions,
         )?
@@ -66,5 +71,32 @@ mod test {
             .unwrap();
 
         assert_eq!(taken.as_slice::<T>(), &[a, outlier]);
+    }
+
+    #[rstest]
+    #[case(0.1f32, 0.2f32, 3e25f32)]
+    #[case(0.1f64, 0.2f64, 3e100f64)]
+    fn take_with_nulls<T: ALPRDFloat>(#[case] a: T, #[case] b: T, #[case] outlier: T) {
+        let array = PrimitiveArray::from_iter([a, b, outlier]);
+        let encoded = RDEncoder::new(&[a, b]).encode(&array);
+
+        assert!(encoded.left_parts_patches().is_some());
+        assert!(encoded
+            .left_parts_patches()
+            .unwrap()
+            .dtype()
+            .is_unsigned_int());
+
+        let taken = take(
+            encoded.as_ref(),
+            PrimitiveArray::from_option_iter([Some(0), Some(2), None]).as_ref(),
+        )
+        .unwrap()
+        .into_primitive()
+        .unwrap();
+
+        assert_eq!(taken.as_slice::<T>()[0], a);
+        assert_eq!(taken.as_slice::<T>()[1], outlier);
+        assert_eq!(taken.validity_mask().unwrap().value(2), false);
     }
 }

--- a/encodings/alp/src/alp_rd/compute/take.rs
+++ b/encodings/alp/src/alp_rd/compute/take.rs
@@ -6,13 +6,13 @@ use crate::{ALPRDArray, ALPRDEncoding};
 
 impl TakeFn<ALPRDArray> for ALPRDEncoding {
     fn take(&self, array: &ALPRDArray, indices: &Array) -> VortexResult<Array> {
+        let taken_left_parts = take(array.left_parts(), indices)?;
         let left_parts_exceptions = array
             .left_parts_patches()
             .map(|patches| patches.take(indices))
             .transpose()?
             .flatten();
 
-        let taken_left_parts = take(array.left_parts(), indices)?;
         Ok(ALPRDArray::try_new(
             if taken_left_parts.dtype().is_nullable() {
                 array.dtype().as_nullable()

--- a/encodings/alp/src/alp_rd/compute/take.rs
+++ b/encodings/alp/src/alp_rd/compute/take.rs
@@ -97,6 +97,6 @@ mod test {
 
         assert_eq!(taken.as_slice::<T>()[0], a);
         assert_eq!(taken.as_slice::<T>()[1], outlier);
-        assert_eq!(taken.validity_mask().unwrap().value(2), false);
+        assert!(!taken.validity_mask().unwrap().value(2));
     }
 }

--- a/encodings/alp/src/alp_rd/compute/take.rs
+++ b/encodings/alp/src/alp_rd/compute/take.rs
@@ -11,7 +11,15 @@ impl TakeFn<ALPRDArray> for ALPRDEncoding {
             .left_parts_patches()
             .map(|patches| patches.take(indices))
             .transpose()?
-            .flatten();
+            .flatten()
+            .map(|p| {
+                let values_dtype = p
+                    .values()
+                    .dtype()
+                    .with_nullability(taken_left_parts.dtype().nullability());
+                p.cast_values(&values_dtype)
+            })
+            .transpose()?;
 
         Ok(ALPRDArray::try_new(
             if taken_left_parts.dtype().is_nullable() {

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -235,7 +235,7 @@ mod test {
 
         let taken_primitive = take(
             &start,
-            &PrimitiveArray::from_option_iter([Some(0u64), Some(1), None, Some(3)]),
+            PrimitiveArray::from_option_iter([Some(0u64), Some(1), None, Some(3)]),
         )
         .unwrap()
         .into_primitive()

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -229,7 +229,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn take_nullable_with_nullables() {
         let start =
             BitPackedArray::encode(&buffer![1i32, 2i32, 3i32, 4i32].into_array(), 1).unwrap();

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -113,7 +113,8 @@ fn take_primitive<T: NativePType + BitPacking, I: NativePType>(
     }
     if let Some(patches) = array.patches() {
         if let Some(patches) = patches.take(indices)? {
-            return unpatched_taken.patch(patches);
+            let cast_patches = patches.cast_values(unpatched_taken.dtype())?;
+            return unpatched_taken.patch(cast_patches);
         }
     }
 

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -132,6 +132,7 @@ mod test {
     use vortex_array::{IntoArray, IntoArrayVariant};
     use vortex_buffer::{buffer, Buffer};
 
+    use crate::bitpacking::compute::take::take_primitive;
     use crate::BitPackedArray;
 
     #[test]
@@ -218,12 +219,29 @@ mod test {
         let start =
             BitPackedArray::encode(&buffer![1i32, 2i32, 3i32, 4i32].into_array(), 1).unwrap();
 
-        let taken_primitive = super::take_primitive::<u32, u64>(
+        let taken_primitive = take_primitive::<u32, u64>(
             &start,
             &PrimitiveArray::from_iter([0u64, 1, 2, 3]),
             Validity::NonNullable,
         )
         .unwrap();
         assert_eq!(taken_primitive.as_slice::<i32>(), &[1i32, 2, 3, 4]);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn take_nullable_with_nullables() {
+        let start =
+            BitPackedArray::encode(&buffer![1i32, 2i32, 3i32, 4i32].into_array(), 1).unwrap();
+
+        let taken_primitive = take(
+            &start,
+            &PrimitiveArray::from_option_iter([Some(0u64), Some(1), None, Some(3)]),
+        )
+        .unwrap()
+        .into_primitive()
+        .unwrap();
+        assert_eq!(taken_primitive.as_slice::<i32>(), &[1i32, 2, 1, 4]);
+        assert_eq!(taken_primitive.invalid_count().unwrap(), 1);
     }
 }


### PR DESCRIPTION
If the array is nonnullable after a take it might end up being nullable,
however, same take might not affect the values of patches thus resulting in
nonullable patches. Need to ensure that after take the patches values have same
nullability as the target array
