### PR TITLE
add ext trait and function to flatten nested VortexResult

### DIFF
--- a/vortex-error/src/ext.rs
+++ b/vortex-error/src/ext.rs
@@ -2,7 +2,7 @@ use crate::VortexResult;
 
 /// Extension trait for VortexResult
 pub trait ResultExt<T>: private::Sealed {
-    /// Flatten a nested [`VortexResult`]. Helper function until https://github.com/rust-lang/rust/issues/70142 is stabilized.
+    /// Flatten a nested [`VortexResult`]. Helper function until <https://github.com/rust-lang/rust/issues/70142> is stabilized.
     fn flatten(self) -> VortexResult<T>;
 }
 

--- a/vortex-error/src/ext.rs
+++ b/vortex-error/src/ext.rs
@@ -1,0 +1,24 @@
+use crate::VortexResult;
+
+/// Extension trait for VortexResult
+pub trait ResultExt<T>: private::Sealed {
+    /// Flatten a nested [`VortexResult`]. Helper function until https://github.com/rust-lang/rust/issues/70142 is stabilized.
+    fn flatten(self) -> VortexResult<T>;
+}
+
+mod private {
+    use crate::VortexResult;
+
+    pub trait Sealed {}
+
+    impl<T> Sealed for VortexResult<VortexResult<T>> {}
+}
+
+impl<T> ResultExt<T> for VortexResult<VortexResult<T>> {
+    fn flatten(self) -> VortexResult<T> {
+        match self {
+            Ok(Ok(v)) => Ok(v),
+            Ok(Err(e)) | Err(e) => Err(e),
+        }
+    }
+}

--- a/vortex-error/src/lib.rs
+++ b/vortex-error/src/lib.rs
@@ -7,6 +7,8 @@
 #[cfg(feature = "python")]
 pub mod python;
 
+mod ext;
+
 use std::backtrace::Backtrace;
 use std::borrow::Cow;
 use std::convert::Infallible;
@@ -15,6 +17,8 @@ use std::fmt::{Debug, Display, Formatter};
 use std::num::TryFromIntError;
 use std::ops::Deref;
 use std::{env, fmt, io};
+
+pub use ext::*;
 
 /// A string that can be used as an error message.
 #[derive(Debug)]


### PR DESCRIPTION
just a temporary measure until the [language API](https://github.com/rust-lang/rust/issues/70142) is stabilized. I have a couple of these cases in #2348 so I figured its worth pulling into a separate PR.