### PR TITLE
VortexResult::flatten -> unnest

### DIFF
--- a/vortex-error/src/ext.rs
+++ b/vortex-error/src/ext.rs
@@ -2,8 +2,8 @@ use crate::VortexResult;
 
 /// Extension trait for VortexResult
 pub trait ResultExt<T>: private::Sealed {
-    /// Flatten a nested [`VortexResult`]. Helper function until <https://github.com/rust-lang/rust/issues/70142> is stabilized.
-    fn flatten(self) -> VortexResult<T>;
+    /// Unnest a nested [`VortexResult`]. Helper function until <https://github.com/rust-lang/rust/issues/70142> is stabilized.
+    fn unnest(self) -> VortexResult<T>;
 }
 
 mod private {
@@ -15,10 +15,23 @@ mod private {
 }
 
 impl<T> ResultExt<T> for VortexResult<VortexResult<T>> {
-    fn flatten(self) -> VortexResult<T> {
+    fn unnest(self) -> VortexResult<T> {
         match self {
             Ok(Ok(v)) => Ok(v),
             Ok(Err(e)) | Err(e) => Err(e),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_example() {
+        let r: VortexResult<VortexResult<usize>> = Ok(Ok(5_usize));
+
+        // Only need to unwrap once!
+        assert_eq!(5, r.unnest().unwrap());
     }
 }


### PR DESCRIPTION
Didn't actually check that in #2360, apparently the compiler doesn't like `flatten` becuase it exists in an unstable feature.

This PR is dedicated to @danking as the chief [haskeller](https://en.wiktionary.org/wiki/Haskeller).