### PR TITLE
Disable fail-fast on SQL benchmark matrix

### DIFF
--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -11,6 +11,7 @@ jobs:
   bench:
     runs-on: [ self-hosted, gcp ]
     strategy:
+      fail-fast: false
       matrix:
         benchmark:
           - id: tpch


### PR DESCRIPTION
Seems like tpch q15 has become even less reliable which makes the clickbench job to get cancelled often. This change decouples their success.

IMO we should also consider disabling q15 or put more resources into debugging the issue, but that's a different conversation.