### PR TITLE
bench: pass input by ref if possible

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -23,7 +23,7 @@ jobs:
           labels: benchmark
 
   codspeed_bench:
-    name: Run Criterion benchmarks with Codspeed
+    name: Benchmark with Codspeed
     needs: label_trigger
     runs-on: ubuntu-latest
     steps:
@@ -35,14 +35,13 @@ jobs:
         shell: bash
         run: cargo install --force cargo-codspeed --locked
 
-      - name: Build benchmark targets
+      - name: Build benchmarks
         env:
           RUSTFLAGS: "-C target-cpu=native"
-        # We want to run micro-benchmarks with release profile.
-        # We run with all features since we feature gate bench utils.
+        # Run micro-benchmarks with release profile to match the production environment.
         run: cargo codspeed build --features test-harness --exclude bench-vortex --workspace --profile release
 
-      - name: Run the benchmarks
+      - name: Run benchmarks
         uses: CodSpeedHQ/action@v3
         with:
           run: cargo codspeed run

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,7 +31,7 @@ jobs:
 
 
   codspeed_bench:
-    name: Run Criterion benchmarks with Codspeed
+    name: Benchmark with Codspeed
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -42,14 +42,13 @@ jobs:
         shell: bash
         run: cargo install --force cargo-codspeed --locked
 
-      - name: Build benchmark targets
+      - name: Build benchmarks
         env:
           RUSTFLAGS: "-C target-cpu=native"
-        # We want to run micro-benchmarks with release profile.
-        # We run with all features since we feature gate bench utils.
+        # Run micro-benchmarks with release profile to match the production environment.
         run: cargo codspeed build --features test-harness --exclude bench-vortex --workspace --profile release
 
-      - name: Run the benchmarks
+      - name: Run benchmarks
         uses: CodSpeedHQ/action@v3
         with:
           run: cargo codspeed run

--- a/encodings/alp/benches/alp_compress.rs
+++ b/encodings/alp/benches/alp_compress.rs
@@ -31,7 +31,7 @@ fn compress_alp<T: ALPFloat + NativePType>(bencher: Bencher, args: (usize, f64, 
 
     bencher
         .with_inputs(|| (values.clone(), validity.clone()))
-        .bench_refs(|(values, validity)| {
+        .bench_values(|(values, validity)| {
             alp_encode(&PrimitiveArray::new(values, validity)).unwrap()
         })
 }

--- a/encodings/alp/benches/alp_compress.rs
+++ b/encodings/alp/benches/alp_compress.rs
@@ -31,7 +31,7 @@ fn compress_alp<T: ALPFloat + NativePType>(bencher: Bencher, args: (usize, f64, 
 
     bencher
         .with_inputs(|| (values.clone(), validity.clone()))
-        .bench_values(|(values, validity)| {
+        .bench_refs(|(values, validity)| {
             alp_encode(&PrimitiveArray::new(values, validity)).unwrap()
         })
 }

--- a/encodings/dict/benches/dict_compare.rs
+++ b/encodings/dict/benches/dict_compare.rs
@@ -30,7 +30,7 @@ fn bench_compare_primitive(bencher: divan::Bencher, (len, uniqueness): (usize, u
 
     bencher
         .with_inputs(|| dict.clone())
-        .bench_local_values(|dict| {
+        .bench_local_refs(|dict| {
             compare(dict, ConstantArray::new(value, len), Operator::Eq).unwrap()
         })
 }
@@ -46,7 +46,7 @@ fn bench_compare_varbin(bencher: divan::Bencher, (len, uniqueness): (usize, usiz
 
     bencher
         .with_inputs(|| dict.clone())
-        .bench_local_values(|dict| {
+        .bench_local_refs(|dict| {
             compare(dict, ConstantArray::new(value, len), Operator::Eq).unwrap()
         })
 }
@@ -61,7 +61,7 @@ fn bench_compare_varbinview(bencher: divan::Bencher, (len, uniqueness): (usize, 
     let value = from_utf8(bytes.as_slice()).unwrap();
     bencher
         .with_inputs(|| dict.clone())
-        .bench_local_values(|dict| {
+        .bench_local_refs(|dict| {
             compare(dict, ConstantArray::new(value, len), Operator::Eq).unwrap()
         })
 }

--- a/encodings/dict/benches/dict_compress.rs
+++ b/encodings/dict/benches/dict_compress.rs
@@ -41,7 +41,7 @@ where
 
     bencher
         .with_inputs(|| primitive_arr.clone())
-        .bench_values(|arr| dict_encode(arr.as_ref()));
+        .bench_refs(|arr| dict_encode(arr.as_ref()));
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -50,7 +50,7 @@ fn encode_varbin(bencher: Bencher, (len, unique_values): (usize, usize)) {
 
     bencher
         .with_inputs(|| varbin_arr.clone())
-        .bench_values(|arr| dict_encode(arr.as_ref()));
+        .bench_refs(|arr| dict_encode(arr.as_ref()));
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -59,7 +59,7 @@ fn encode_varbinview(bencher: Bencher, (len, unique_values): (usize, usize)) {
 
     bencher
         .with_inputs(|| varbinview_arr.clone())
-        .bench_values(|arr| dict_encode(arr.as_ref()));
+        .bench_refs(|arr| dict_encode(arr.as_ref()));
 }
 
 #[divan::bench(types = [u8, f32, i64], args = BENCH_ARGS)]

--- a/vortex-buffer/benches/vortex_buffer.rs
+++ b/vortex-buffer/benches/vortex_buffer.rs
@@ -107,9 +107,9 @@ impl<T> Push<T> for BufferMut<T> {
 fn push<B: Push<i32> + FromIterator<i32>>(bencher: Bencher, n: i32) {
     bencher
         .with_inputs(|| B::from_iter(iter::empty()))
-        .bench_local_refs(|mut buffer| {
+        .bench_local_refs(|buffer| {
             for _ in 0..n {
-                Push::push(&mut buffer, 0)
+                Push::push(buffer, 0)
             }
         });
 }

--- a/vortex-buffer/benches/vortex_buffer.rs
+++ b/vortex-buffer/benches/vortex_buffer.rs
@@ -107,7 +107,7 @@ impl<T> Push<T> for BufferMut<T> {
 fn push<B: Push<i32> + FromIterator<i32>>(bencher: Bencher, n: i32) {
     bencher
         .with_inputs(|| B::from_iter(iter::empty()))
-        .bench_local_values(|mut buffer| {
+        .bench_local_refs(|mut buffer| {
             for _ in 0..n {
                 Push::push(&mut buffer, 0)
             }


### PR DESCRIPTION
This is to exclude benchmarking `drop` as part of the micro-benchmarks.