### PR TITLE
ci: change bench profile back to "bench"

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -48,7 +48,7 @@ jobs:
             --exclude pyvortex \
             --exclude xtask \
             --workspace \
-            --profile release
+            --profile bench
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v3

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -54,7 +54,8 @@ jobs:
             --exclude vortex-fuzz \
             --exclude pyvortex \
             --exclude xtask \
-            --workspace --profile release
+            --workspace \
+            --profile bench
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v3


### PR DESCRIPTION
Besides much faster build times, we ultimately can't rely on clients compiling Vortex with LTO.