### PR TITLE
chore: remove Option because a Box of ZST does not allocate

### DIFF
--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -67,8 +67,8 @@ impl ALPArray {
             dtype,
             length,
             SerdeMetadata(ALPMetadata { exponents, patches }),
-            None,
-            Some(children.into()),
+            vec![].into(),
+            children.into(),
             Default::default(),
         )
     }

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -106,8 +106,8 @@ impl ALPRDArray {
                 left_parts_ptype,
                 patches,
             }),
-            None,
-            Some(children.into()),
+            vec![].into(),
+            children.into(),
             StatsSet::default(),
         )
     }

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -46,8 +46,11 @@ impl ByteBoolArray {
             SerdeMetadata(ByteBoolMetadata {
                 validity: validity.to_metadata(length)?,
             }),
-            Some([buffer.into_byte_buffer()].into()),
-            validity.into_array().map(|v| [v].into()),
+            [buffer.into_byte_buffer()].into(),
+            validity
+                .into_array()
+                .map(|v| [v].into())
+                .unwrap_or_default(),
             StatsSet::default(),
         )
     }

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -70,8 +70,8 @@ impl DateTimePartsArray {
             dtype,
             length,
             SerdeMetadata(metadata),
-            None,
-            Some([days, seconds, subseconds].into()),
+            vec![].into(),
+            [days, seconds, subseconds].into(),
             StatsSet::default(),
         )
     }

--- a/encodings/dict/src/array.rs
+++ b/encodings/dict/src/array.rs
@@ -64,8 +64,8 @@ impl DictArray {
                     .vortex_expect("codes dtype must be uint"),
                 values_len: values.len(),
             }),
-            None,
-            Some([codes, values].into()),
+            vec![].into(),
+            [codes, values].into(),
             StatsSet::default(),
         )
     }

--- a/encodings/fastlanes/src/bitpacking/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/mod.rs
@@ -156,8 +156,8 @@ impl BitPackedArray {
             dtype,
             length,
             RkyvMetadata(metadata),
-            Some([packed].into()),
-            Some(children.into()),
+            [packed].into(),
+            children.into(),
             StatsSet::default(),
         )
     }

--- a/encodings/fastlanes/src/delta/mod.rs
+++ b/encodings/fastlanes/src/delta/mod.rs
@@ -142,8 +142,8 @@ impl DeltaArray {
             dtype,
             logical_len,
             RkyvMetadata(metadata),
-            None,
-            Some(children.into()),
+            vec![].into(),
+            children.into(),
             StatsSet::default(),
         )?;
 

--- a/encodings/fastlanes/src/for/mod.rs
+++ b/encodings/fastlanes/src/for/mod.rs
@@ -55,8 +55,8 @@ impl FoRArray {
             dtype,
             encoded.len(),
             SerdeMetadata(FoRMetadata { reference }),
-            None,
-            Some([encoded].into()),
+            vec![].into(),
+            [encoded].into(),
             StatsSet::default(),
         )
     }

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -98,8 +98,8 @@ impl FSSTArray {
                 codes_nullability,
                 uncompressed_lengths_ptype,
             }),
-            None,
-            Some(children),
+            vec![].into(),
+            children,
             StatsSet::default(),
         )
     }

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -83,8 +83,8 @@ impl RunEndArray {
             dtype,
             length,
             SerdeMetadata(metadata),
-            None,
-            Some(vec![ends, values].into()),
+            vec![].into(),
+            vec![ends, values].into(),
             StatsSet::default(),
         )
     }

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -105,8 +105,8 @@ impl SparseArray {
             RkyvMetadata(SparseMetadata {
                 patches: patches_metadata,
             }),
-            Some([fill_value_buffer.into_inner()].into()),
-            Some([patches.indices().clone(), patches.values().clone()].into()),
+            [fill_value_buffer.into_inner()].into(),
+            [patches.indices().clone(), patches.values().clone()].into(),
             StatsSet::default(),
         )
     }

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -36,8 +36,8 @@ impl ZigZagArray {
             dtype,
             len,
             EmptyMetadata,
-            None,
-            Some(children.into()),
+            vec![].into(),
+            children.into(),
             StatsSet::default(),
         )
     }

--- a/vortex-array/src/array/bool/mod.rs
+++ b/vortex-array/src/array/bool/mod.rs
@@ -148,8 +148,11 @@ impl BoolArray {
                 validity: validity.to_metadata(buffer_len)?,
                 first_byte_bit_offset: first_byte_bit_offset as u8,
             }),
-            Some(vec![ByteBuffer::from_arrow_buffer(inner, Alignment::of::<u8>())].into()),
-            validity.into_array().map(|v| [v].into()),
+            vec![ByteBuffer::from_arrow_buffer(inner, Alignment::of::<u8>())].into(),
+            validity
+                .into_array()
+                .map(|v| [v].into())
+                .unwrap_or_default(),
             StatsSet::default(),
         )
     }

--- a/vortex-array/src/array/chunked/mod.rs
+++ b/vortex-array/src/array/chunked/mod.rs
@@ -81,8 +81,8 @@ impl ChunkedArray {
             dtype,
             curr_offset.try_into().vortex_unwrap(),
             RkyvMetadata(ChunkedMetadata { nchunks }),
-            None,
-            Some(children.into()),
+            vec![].into(),
+            children.into(),
             StatsSet::default(),
         )
         .vortex_expect("Constructing chunked array")

--- a/vortex-array/src/array/constant/mod.rs
+++ b/vortex-array/src/array/constant/mod.rs
@@ -35,8 +35,8 @@ impl ConstantArray {
             dtype,
             length,
             EmptyMetadata,
-            Some([value_buffer.into_inner()].into()),
-            None,
+            [value_buffer.into_inner()].into(),
+            vec![].into(),
             stats,
         )
         .vortex_expect("Failed to create Constant array")

--- a/vortex-array/src/array/extension/mod.rs
+++ b/vortex-array/src/array/extension/mod.rs
@@ -35,8 +35,8 @@ impl ExtensionArray {
             DType::Extension(ext_dtype),
             storage.len(),
             EmptyMetadata,
-            None,
-            Some([storage].into()),
+            vec![].into(),
+            [storage].into(),
             StatsSet::default(),
         )
         .vortex_expect("Invalid ExtensionArray")

--- a/vortex-array/src/array/list/mod.rs
+++ b/vortex-array/src/array/list/mod.rs
@@ -99,8 +99,8 @@ impl ListArray {
                 elements_len: element_len,
                 offset_ptype,
             }),
-            None,
-            Some(children.into()),
+            vec![].into(),
+            children.into(),
             StatsSet::default(),
         )
     }

--- a/vortex-array/src/array/null/mod.rs
+++ b/vortex-array/src/array/null/mod.rs
@@ -23,8 +23,8 @@ impl NullArray {
             DType::Null,
             len,
             EmptyMetadata,
-            None,
-            None,
+            vec![].into(),
+            vec![].into(),
             StatsSet::nulls(len, &DType::Null),
         )
         .vortex_expect("NullArray::new should never fail!")

--- a/vortex-array/src/array/primitive/mod.rs
+++ b/vortex-array/src/array/primitive/mod.rs
@@ -57,8 +57,11 @@ impl PrimitiveArray {
             RkyvMetadata(PrimitiveMetadata {
                 validity: validity.to_metadata(len).vortex_expect("Invalid validity"),
             }),
-            Some([buffer.into_byte_buffer()].into()),
-            validity.into_array().map(|v| [v].into()),
+            [buffer.into_byte_buffer()].into(),
+            validity
+                .into_array()
+                .map(|v| [v].into())
+                .unwrap_or_default(),
             StatsSet::default(),
         )
         .vortex_expect("Should not fail to create PrimitiveArray")

--- a/vortex-array/src/array/struct_/mod.rs
+++ b/vortex-array/src/array/struct_/mod.rs
@@ -91,8 +91,8 @@ impl StructArray {
             RkyvMetadata(StructMetadata {
                 validity: validity_metadata,
             }),
-            None,
-            Some(fields.into()),
+            vec![].into(),
+            fields.into(),
             StatsSet::default(),
         )
     }

--- a/vortex-array/src/array/varbin/mod.rs
+++ b/vortex-array/src/array/varbin/mod.rs
@@ -91,8 +91,8 @@ impl VarBinArray {
             dtype,
             length,
             RkyvMetadata(metadata),
-            Some([bytes].into()),
-            Some(children.into()),
+            [bytes].into(),
+            children.into(),
             StatsSet::default(),
         )
     }

--- a/vortex-array/src/array/varbinview/mod.rs
+++ b/vortex-array/src/array/varbinview/mod.rs
@@ -261,8 +261,11 @@ impl VarBinViewArray {
             dtype,
             array_len,
             RkyvMetadata(metadata),
-            Some(array_buffers.into()),
-            validity.into_array().map(|v| [v].into()),
+            array_buffers.into(),
+            validity
+                .into_array()
+                .map(|v| [v].into())
+                .unwrap_or_default(),
             StatsSet::default(),
         )
     }

--- a/vortex-array/src/data/mod.rs
+++ b/vortex-array/src/data/mod.rs
@@ -57,8 +57,8 @@ impl Array {
         dtype: DType,
         len: usize,
         metadata: Option<ByteBuffer>,
-        buffers: Option<Box<[ByteBuffer]>>,
-        children: Option<Box<[Array]>>,
+        buffers: Box<[ByteBuffer]>,
+        children: Box<[Array]>,
         statistics: StatsSet,
     ) -> VortexResult<Self> {
         Self::try_new(InnerArray::Owned(Arc::new(OwnedArray {
@@ -272,7 +272,7 @@ impl Array {
     // TODO(ngates): deprecate this function and return impl Iterator
     pub fn children(&self) -> Vec<Array> {
         match &self.0 {
-            InnerArray::Owned(d) => d.children.as_ref().map(|c| c.to_vec()).unwrap_or_default(),
+            InnerArray::Owned(d) => d.children.to_vec(),
             InnerArray::Viewed(_) => {
                 let mut collector = ChildrenCollector::default();
                 self.vtable()
@@ -342,7 +342,7 @@ impl Array {
 
     pub fn nbuffers(&self) -> usize {
         match &self.0 {
-            InnerArray::Owned(o) => o.buffers.as_ref().map_or(0, |b| b.len()),
+            InnerArray::Owned(o) => o.buffers.len(),
             InnerArray::Viewed(v) => v.nbuffers(),
         }
     }

--- a/vortex-array/src/data/owned.rs
+++ b/vortex-array/src/data/owned.rs
@@ -15,8 +15,8 @@ pub(super) struct OwnedArray {
     pub(super) dtype: DType,
     pub(super) len: usize,
     pub(super) metadata: Option<ByteBuffer>,
-    pub(super) buffers: Option<Box<[ByteBuffer]>>,
-    pub(super) children: Option<Box<[Array]>>,
+    pub(super) buffers: Box<[ByteBuffer]>,
+    pub(super) children: Box<[Array]>,
     pub(super) stats_set: RwLock<StatsSet>,
     #[cfg(feature = "canonical_counter")]
     pub(super) canonical_counter: std::sync::atomic::AtomicUsize,
@@ -24,13 +24,13 @@ pub(super) struct OwnedArray {
 
 impl OwnedArray {
     pub fn byte_buffer(&self, index: usize) -> Option<&ByteBuffer> {
-        self.buffers.as_ref().and_then(|b| b.get(index))
+        self.buffers.get(index)
     }
 
     // We want to allow these panics because they are indicative of implementation error.
     #[allow(clippy::panic_in_result_fn)]
     pub fn child(&self, index: usize, dtype: &DType, len: usize) -> VortexResult<&Array> {
-        match self.children.as_ref().and_then(|c| c.get(index)) {
+        match self.children.get(index) {
             None => vortex_bail!(
                 "Array::child({}): child {index} not found",
                 self.encoding.id().as_ref()
@@ -54,6 +54,6 @@ impl OwnedArray {
     }
 
     pub fn nchildren(&self) -> usize {
-        self.children.as_ref().map_or(0, |c| c.len())
+        self.children.len()
     }
 }

--- a/vortex-array/src/macros.rs
+++ b/vortex-array/src/macros.rs
@@ -31,8 +31,8 @@ macro_rules! impl_encoding {
                     dtype: vortex_dtype::DType,
                     len: usize,
                     metadata: $Metadata,
-                    buffers: Option<Box<[vortex_buffer::ByteBuffer]>>,
-                    children: Option<Box<[$crate::Array]>>,
+                    buffers: Box<[vortex_buffer::ByteBuffer]>,
+                    children: Box<[$crate::Array]>,
                     stats: $crate::stats::StatsSet,
                 ) -> VortexResult<Self> {
                     use $crate::SerializeMetadata;


### PR DESCRIPTION
From [Box::new](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.new):

> Allocates memory on the heap and then places x into it.
>
> This doesn’t actually allocate if T is zero-sized.