### PR TITLE
feat: impl canonicalize_into for SparseArray

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5596,7 +5596,9 @@ dependencies = [
 name = "vortex-sparse"
 version = "0.24.0"
 dependencies = [
+ "codspeed-divan-compat",
  "itertools 0.14.0",
+ "rand",
  "rkyv",
  "rstest",
  "serde",

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -4,7 +4,7 @@ use arrow_buffer::ArrowNativeType;
 use fastlanes::BitPacking;
 use num_traits::AsPrimitive;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::builders::{ArrayBuilder as _, PrimitiveBuilder, UninitRange};
+use vortex_array::builders::{ArrayBuilder as _, PrimitiveBuilder, UninitPrimitive};
 use vortex_array::patches::Patches;
 use vortex_array::validity::Validity;
 use vortex_array::variants::PrimitiveArrayTrait;
@@ -269,7 +269,10 @@ where
     Ok(())
 }
 
-fn apply_patches<T: NativePType>(dst: &mut UninitRange<T>, patches: Patches) -> VortexResult<()> {
+fn apply_patches<T: NativePType>(
+    dst: &mut UninitPrimitive<T>,
+    patches: Patches,
+) -> VortexResult<()> {
     let (array_len, indices_offset, indices, values) = patches.into_parts();
     assert_eq!(array_len, dst.len());
 
@@ -292,7 +295,7 @@ fn insert_values_and_validity_at_indices<
     T: NativePType,
     IndexT: NativePType + AsPrimitive<usize>,
 >(
-    dst: &mut UninitRange<T>,
+    dst: &mut UninitPrimitive<T>,
     indices: PrimitiveArray,
     values: &[T],
     validity: Validity,
@@ -315,7 +318,7 @@ fn insert_values_and_validity_at_indices<
                 let out_index = decompressed_index.as_() - indices_offset;
                 dst[decompressed_index.as_() - indices_offset] =
                     MaybeUninit::new(values[compressed_index]);
-                dst.set_bit(out_index, validity.value(out_index));
+                dst.set_valid_bit(out_index, validity.value(out_index));
             }
         }
     }
@@ -328,7 +331,7 @@ fn unpack_values_into<T: NativePType, UnsignedT: NativePType + BitPacking, F, G>
     bit_width: usize,
     offset: usize,
     // TODO(ngates): do we want to use fastlanes alignment for this buffer?
-    uninit: &mut UninitRange<T>,
+    uninit: &mut UninitPrimitive<T>,
     transmute: F,
     transmute_mut: G,
 ) -> VortexResult<()>

--- a/encodings/sparse/Cargo.toml
+++ b/encodings/sparse/Cargo.toml
@@ -28,5 +28,11 @@ vortex-mask = { workspace = true }
 vortex-scalar = { workspace = true }
 
 [dev-dependencies]
+divan = { workspace = true }
+rand = { workspace = true }
 rstest = { workspace = true }
 vortex-array = { workspace = true, features = ["test-harness"] }
+
+[[bench]]
+name = "canonical"
+harness = false

--- a/encodings/sparse/benches/canonical.rs
+++ b/encodings/sparse/benches/canonical.rs
@@ -1,0 +1,49 @@
+#![allow(clippy::unwrap_used)]
+
+use divan::Bencher;
+use vortex_array::builders::{ArrayBuilder, PrimitiveBuilder};
+use vortex_array::{IntoArray, IntoCanonical};
+use vortex_buffer::BufferMut;
+use vortex_dtype::Nullability;
+use vortex_scalar::Scalar;
+use vortex_sparse::SparseArray;
+
+fn generate_sparse_array(len: usize, sparsity: f64) -> SparseArray {
+    // Choose a small number of indices from the full len to hold values.
+    let indices: BufferMut<u64> = (0..len as u64)
+        .filter(|_| rand::random::<f64>() < sparsity)
+        .collect();
+
+    let values = indices.clone();
+
+    SparseArray::try_new(
+        indices.into_array(),
+        values.into_array(),
+        len,
+        Scalar::primitive(u64::MAX, Nullability::NonNullable),
+    )
+    .unwrap()
+}
+
+#[divan::bench(args = [0.001, 0.01, 0.05, 0.1], sample_count = 1000)]
+fn into_canonical(bencher: Bencher, sparsity: f64) {
+    bencher
+        .with_inputs(|| generate_sparse_array(64_000, sparsity))
+        .bench_values(|sparse_array| sparse_array.into_canonical().unwrap())
+}
+
+#[divan::bench(args = [0.001, 0.01, 0.05, 0.1], sample_count = 1000)]
+fn canonicalize_into(bencher: Bencher, sparsity: f64) {
+    bencher
+        .with_inputs(|| generate_sparse_array(64_000, sparsity))
+        .bench_values(|sparse_array| {
+            let mut output: PrimitiveBuilder<u64> =
+                PrimitiveBuilder::with_capacity(Nullability::NonNullable, 64_000);
+            sparse_array.canonicalize_into(&mut output).unwrap();
+            output.finish()
+        })
+}
+
+fn main() {
+    divan::main()
+}

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -1,6 +1,6 @@
 mod builder;
 
-use vortex_array::array::{BoolArray, BooleanBuffer, ConstantArray, PrimitiveArray};
+use vortex_array::arrays::{BoolArray, BooleanBuffer, ConstantArray, NullArray, PrimitiveArray};
 use vortex_array::builders::{ArrayBuilder, BoolBuilder, NullBuilder, PrimitiveBuilder};
 use vortex_array::patches::Patches;
 use vortex_array::validity::Validity;
@@ -8,8 +8,8 @@ use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::vtable::CanonicalVTable;
 use vortex_array::{Canonical, IntoCanonical};
 use vortex_buffer::buffer;
-use vortex_dtype::{match_each_native_ptype, DType, NativePType, Nullability, PType};
-use vortex_error::{VortexError, VortexExpect, VortexResult};
+use vortex_dtype::{match_each_native_ptype, DType, NativePType, Nullability};
+use vortex_error::{vortex_bail, VortexError, VortexExpect, VortexResult};
 use vortex_scalar::Scalar;
 
 use crate::canonical::builder::{canonicalize_bool_into, canonicalize_primitive_into};
@@ -22,16 +22,18 @@ impl CanonicalVTable<SparseArray> for SparseEncoding {
             return ConstantArray::new(array.fill_scalar(), array.len()).into_canonical();
         }
 
-        if matches!(array.dtype(), DType::Bool(_)) {
-            canonicalize_sparse_bools(resolved_patches, &array.fill_scalar())
-        } else {
-            let ptype = PType::try_from(resolved_patches.values().dtype())?;
-            match_each_native_ptype!(ptype, |$P| {
-                canonicalize_sparse_primitives::<$P>(
-                    resolved_patches,
-                    &array.fill_scalar(),
-                )
-            })
+        match array.dtype() {
+            DType::Null => Ok(Canonical::Null(NullArray::new(array.len()))),
+            DType::Bool(_) => canonicalize_sparse_bools(resolved_patches, &array.fill_scalar()),
+            DType::Primitive(ptype, _) => {
+                match_each_native_ptype!(ptype, |$P| {
+                        canonicalize_sparse_primitives::<$P>(
+                        resolved_patches,
+                        &array.fill_scalar(),
+                    )
+                })
+            }
+            dtype => vortex_bail!("unsupported DType for SparseArray: {dtype}"),
         }
     }
 
@@ -59,7 +61,7 @@ impl CanonicalVTable<SparseArray> for SparseEncoding {
                     canonicalize_primitive_into(&array, builder)?;
                 });
             }
-            _ => unreachable!("unsupported SparseArray dtype {}", array.dtype()),
+            dtype => vortex_bail!("unsupported DType for SparseArray: {dtype}"),
         }
         Ok(())
     }

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -1,13 +1,18 @@
-use vortex_array::arrays::{BoolArray, BooleanBuffer, ConstantArray, PrimitiveArray};
+mod builder;
+
+use vortex_array::array::{BoolArray, BooleanBuffer, ConstantArray, PrimitiveArray};
+use vortex_array::builders::{ArrayBuilder, BoolBuilder, NullBuilder, PrimitiveBuilder};
 use vortex_array::patches::Patches;
 use vortex_array::validity::Validity;
+use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::vtable::CanonicalVTable;
 use vortex_array::{Canonical, IntoCanonical};
 use vortex_buffer::buffer;
 use vortex_dtype::{match_each_native_ptype, DType, NativePType, Nullability, PType};
-use vortex_error::{VortexError, VortexResult};
+use vortex_error::{VortexError, VortexExpect, VortexResult};
 use vortex_scalar::Scalar;
 
+use crate::canonical::builder::{canonicalize_bool_into, canonicalize_primitive_into};
 use crate::{SparseArray, SparseEncoding};
 
 impl CanonicalVTable<SparseArray> for SparseEncoding {
@@ -28,6 +33,35 @@ impl CanonicalVTable<SparseArray> for SparseEncoding {
                 )
             })
         }
+    }
+
+    fn canonicalize_into(
+        &self,
+        array: SparseArray,
+        builder: &mut dyn ArrayBuilder,
+    ) -> VortexResult<()> {
+        match array.dtype() {
+            DType::Null => {
+                if let Some(builder) = builder.as_any_mut().downcast_mut::<NullBuilder>() {
+                    builder.append_nulls(array.len());
+                }
+            }
+            DType::Bool(_) => {
+                let builder = builder
+                    .as_any_mut()
+                    .downcast_mut::<BoolBuilder>()
+                    .vortex_expect("BoolBuilder");
+                canonicalize_bool_into(&array, builder)?;
+            }
+            DType::Primitive(..) => {
+                match_each_native_ptype!(array.ptype(), |$P| {
+                    let builder = builder.as_any_mut().downcast_mut::<PrimitiveBuilder<$P>>().vortex_expect("PrimitiveBuilder");
+                    canonicalize_primitive_into(&array, builder)?;
+                });
+            }
+            _ => unreachable!("unsupported SparseArray dtype {}", array.dtype()),
+        }
+        Ok(())
     }
 }
 

--- a/encodings/sparse/src/canonical/builder.rs
+++ b/encodings/sparse/src/canonical/builder.rs
@@ -1,0 +1,69 @@
+use vortex_array::builders::{BoolBuilder, PrimitiveBuilder};
+use vortex_array::variants::PrimitiveArrayTrait;
+use vortex_array::IntoArrayVariant;
+use vortex_dtype::{match_each_integer_ptype, NativePType};
+use vortex_error::{VortexError, VortexExpect, VortexResult};
+use vortex_scalar::PValue;
+
+use crate::SparseArray;
+
+#[allow(clippy::cast_possible_truncation)]
+pub(super) fn canonicalize_primitive_into<T: NativePType + TryFrom<PValue, Error = VortexError>>(
+    sparse: &SparseArray,
+    builder: &mut PrimitiveBuilder<T>,
+) -> VortexResult<()> {
+    // Fill the output buffer with the fill value.
+    builder.values.fill(
+        sparse
+            .fill_scalar()
+            .as_primitive()
+            .typed_value()
+            .vortex_expect("fill value"),
+    );
+
+    let patches = sparse.resolved_patches()?;
+    let indices = patches.indices().clone().into_primitive()?;
+    let values = patches.values().clone().into_primitive()?;
+
+    // Scatter the values into the output buffer
+    match_each_integer_ptype!(indices.ptype(), |$I| {
+        let indices = indices.as_slice::<$I>();
+        for (&index, &value) in indices.iter().zip(values.as_slice::<T>()) {
+            builder.values[index as usize] = value;
+        }
+    });
+
+    // Set the validity from the sparse array.
+    builder.nulls.append_validity_mask(sparse.validity_mask()?);
+
+    Ok(())
+}
+
+// bool
+pub(super) fn canonicalize_bool_into(
+    sparse: &SparseArray,
+    builder: &mut BoolBuilder,
+) -> VortexResult<()> {
+    // Populate the buffer with the fill value
+    builder.inner.append_n(
+        sparse.len(),
+        sparse.fill_scalar().as_bool().value().unwrap_or_default(),
+    );
+
+    let patches = sparse.resolved_patches()?;
+    let indices = patches.indices().clone().into_primitive()?;
+    let values = patches.values().clone().into_bool()?;
+
+    // Scatter the values into the output buffer
+    let indices = indices.as_slice::<u32>();
+    for (&index, value) in indices.iter().zip(values.boolean_buffer().into_iter()) {
+        builder.inner.set_bit(index as usize, value);
+    }
+
+    // Set the validity from the sparse array.
+    builder.nulls.append_validity_mask(sparse.validity_mask()?);
+
+    Ok(())
+}
+
+// TODO(aduffy): support for string, binary, float, struct, list

--- a/encodings/sparse/src/canonical/builder.rs
+++ b/encodings/sparse/src/canonical/builder.rs
@@ -1,10 +1,13 @@
 use std::mem::MaybeUninit;
 
-use vortex_array::builders::{BoolBuilder, PrimitiveBuilder};
+use vortex_array::arrays::{BoolArray, PrimitiveArray};
+use vortex_array::builders::{BoolBuilder, PrimitiveBuilder, UninitBool, UninitPrimitive};
+use vortex_array::validity::Validity;
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::IntoArrayVariant;
 use vortex_dtype::{match_each_integer_ptype, NativePType};
-use vortex_error::{VortexError, VortexResult};
+use vortex_error::{VortexError, VortexExpect, VortexResult};
+use vortex_mask::Mask;
 use vortex_scalar::PValue;
 
 use crate::SparseArray;
@@ -14,51 +17,70 @@ pub(super) fn canonicalize_primitive_into<T: NativePType + TryFrom<PValue, Error
     sparse: &SparseArray,
     builder: &mut PrimitiveBuilder<T>,
 ) -> VortexResult<()> {
-    // Scatter the fill value into the output buffer
-    let mut values_uninit = builder.uninit_values(sparse.len());
-    if let Some(fill_value) = sparse.fill_scalar().as_primitive().typed_value() {
-        values_uninit.fill(MaybeUninit::new(fill_value));
-    } else {
-        // fill value is NULL, leave the slots with uninitialized values.
+    let fill_value: Option<T> = sparse.fill_scalar().as_primitive().typed_value();
+
+    // Prepare the null buffer so we can set ranges of it.
+    // If the fill value is NULL, we initialize the null buffer with false.
+    //
+    // If the fill value is non-NULL but the array is nullable, we initialize the null buffer with
+    //  true, and will patch in the false bits as we write nulls.
+    if fill_value.is_none() {
+        builder.append_mask(Mask::AllFalse(sparse.len()));
+    } else if sparse.dtype().is_nullable() {
+        builder.append_mask(Mask::AllTrue(sparse.len()));
+    }
+
+    let mut values_uninit = builder.uninit_range(sparse.len());
+
+    // If fill value is non-null, fill the buffer with it. If it is NULL, we leave the slots
+    // uninitialized, as their values are not semantically meaningful.
+    if let Some(value) = fill_value {
+        values_uninit.fill(MaybeUninit::new(value));
     }
 
     let patches = sparse.resolved_patches()?;
     let indices = patches.indices().clone().into_primitive()?;
     let values = patches.values().clone().into_primitive()?;
 
-    fn scatter_values<T>(index: usize, value: T, values_uninit: &mut [MaybeUninit<T>]) {
-        values_uninit[index] = MaybeUninit::new(value);
-    };
-
-    let scatter_values_with_nulls =
-        |index: usize, value: T, values_uninit: &mut [MaybeUninit<T>]| {
+    fn write_value<T, const VALUE: bool, const NULLS: bool>(
+        index: usize,
+        sparse_index: usize,
+        value: T,
+        values_uninit: &mut UninitPrimitive<T>,
+        values: &PrimitiveArray,
+    ) {
+        if VALUE {
             values_uninit[index] = MaybeUninit::new(value);
-            // Offset the index using our builtin buffer.
-            builder.nulls.set_bit()
-        };
+        }
 
-    // Get access to the validity function of the patch values instead.
-    let scatter_values = |index: usize, value: T, values_uninit: &mut [MaybeUninit<T>]| {
-        values_uninit[index] = MaybeUninit::new(value);
+        if NULLS {
+            // We use our final value bit instead.
+            values_uninit.set_valid_bit(
+                index,
+                values
+                    .is_valid(sparse_index)
+                    .vortex_expect("values.is_valid"),
+            );
+        }
+    }
+
+    let writer = match values.validity() {
+        // Just write values. We don't need to write false bits
+        Validity::NonNullable | Validity::AllValid => write_value::<T, true, false>,
+        // Write nulls, do not write values
+        Validity::AllInvalid => write_value::<T, false, true>,
+        // Write nulls and values.
+        Validity::Array(_) => write_value::<T, true, true>,
     };
 
     match_each_integer_ptype!(indices.ptype(), |$I| {
         let indices = indices.as_slice::<$I>();
-        for (&index, &value) in indices.iter().zip(values.as_slice::<T>()) {
-            builder.values[index as usize] = value;
+        for (sparse_index, (&index, &value)) in indices.iter().zip(values.as_slice::<T>()).enumerate() {
+            writer(index as usize, sparse_index, value, &mut values_uninit, &values);
         }
     });
 
-    builder.patch(sparse.resolved_patches()?, 0)?;
-
-    // If the array is nullable, and we have some sparse NULLs spread throughout the code,
-    // we can create a new null buffer and set it directly.
-    if sparse.dtype().is_nullable() {
-        sparse.patches().values()
-    }
-
-    // Set the validity from the sparse array.
-    builder.nulls.append_validity_mask(sparse.validity_mask()?);
+    values_uninit.finish();
 
     Ok(())
 }
@@ -70,25 +92,64 @@ pub(super) fn canonicalize_bool_into(
     sparse: &SparseArray,
     builder: &mut BoolBuilder,
 ) -> VortexResult<()> {
-    builder.inner.append_n(
-        sparse.len(),
-        sparse.fill_scalar().as_bool().value().unwrap_or_default(),
-    );
+    let fill_value = sparse.fill_scalar().as_bool().value();
+
+    if fill_value.is_none() {
+        builder.append_mask(Mask::AllFalse(sparse.len()));
+    } else if sparse.dtype().is_nullable() {
+        builder.append_mask(Mask::AllTrue(sparse.len()));
+    }
+
+    let mut values_uninit = builder.uninit_range(sparse.len());
+
+    // If the fill value is non-NULL.
+    if let Some(value) = fill_value {
+        values_uninit.set_all(value);
+    }
+
+    fn write_bool<const VALUE: bool, const NULLS: bool>(
+        index: usize,
+        sparse_index: usize,
+        value: bool,
+        uninit: &mut UninitBool,
+        values: &BoolArray,
+    ) {
+        if VALUE {
+            uninit.set_bit(index, value);
+        }
+
+        if NULLS {
+            uninit.set_valid_bit(
+                index,
+                values
+                    .is_valid(sparse_index)
+                    .vortex_expect("values.is_valid"),
+            );
+        }
+    }
 
     let patches = sparse.resolved_patches()?;
     let indices = patches.indices().clone().into_primitive()?;
     let values = patches.values().clone().into_bool()?;
 
-    // Scatter the values into the output buffer
+    let writer = match values.validity() {
+        // No nulls present, just write values
+        Validity::NonNullable | Validity::AllValid => write_bool::<true, false>,
+        // Write nulls, do not write values
+        Validity::AllInvalid => write_bool::<false, true>,
+        // Write nulls and values.
+        Validity::Array(_) => write_bool::<true, true>,
+    };
+
+    // Scatter the patch values into the output buffer.
     match_each_integer_ptype!(indices.ptype(), |$I| {
         let indices = indices.as_slice::<$I>();
-        for (&index, value) in indices.iter().zip(values.boolean_buffer().into_iter()) {
-            builder.inner.set_bit(index as usize, value);
+        for (sparse_index, (&index, value)) in indices.iter().zip(values.boolean_buffer().into_iter()).enumerate() {
+            writer(index as usize, sparse_index, value, &mut values_uninit, &values);
         }
     });
 
-    // Set the validity from the sparse array.
-    builder.nulls.append_validity_mask(sparse.validity_mask()?);
+    values_uninit.finish();
 
     Ok(())
 }

--- a/encodings/sparse/src/canonical/builder.rs
+++ b/encodings/sparse/src/canonical/builder.rs
@@ -1,8 +1,10 @@
+use std::mem::MaybeUninit;
+
 use vortex_array::builders::{BoolBuilder, PrimitiveBuilder};
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::IntoArrayVariant;
 use vortex_dtype::{match_each_integer_ptype, NativePType};
-use vortex_error::{VortexError, VortexExpect, VortexResult};
+use vortex_error::{VortexError, VortexResult};
 use vortex_scalar::PValue;
 
 use crate::SparseArray;
@@ -12,20 +14,34 @@ pub(super) fn canonicalize_primitive_into<T: NativePType + TryFrom<PValue, Error
     sparse: &SparseArray,
     builder: &mut PrimitiveBuilder<T>,
 ) -> VortexResult<()> {
-    // Fill the output buffer with the fill value.
-    builder.values.fill(
-        sparse
-            .fill_scalar()
-            .as_primitive()
-            .typed_value()
-            .vortex_expect("fill value"),
-    );
+    // Scatter the fill value into the output buffer
+    let mut values_uninit = builder.uninit_values(sparse.len());
+    if let Some(fill_value) = sparse.fill_scalar().as_primitive().typed_value() {
+        values_uninit.fill(MaybeUninit::new(fill_value));
+    } else {
+        // fill value is NULL, leave the slots with uninitialized values.
+    }
 
     let patches = sparse.resolved_patches()?;
     let indices = patches.indices().clone().into_primitive()?;
     let values = patches.values().clone().into_primitive()?;
 
-    // Scatter the values into the output buffer
+    fn scatter_values<T>(index: usize, value: T, values_uninit: &mut [MaybeUninit<T>]) {
+        values_uninit[index] = MaybeUninit::new(value);
+    };
+
+    let scatter_values_with_nulls =
+        |index: usize, value: T, values_uninit: &mut [MaybeUninit<T>]| {
+            values_uninit[index] = MaybeUninit::new(value);
+            // Offset the index using our builtin buffer.
+            builder.nulls.set_bit()
+        };
+
+    // Get access to the validity function of the patch values instead.
+    let scatter_values = |index: usize, value: T, values_uninit: &mut [MaybeUninit<T>]| {
+        values_uninit[index] = MaybeUninit::new(value);
+    };
+
     match_each_integer_ptype!(indices.ptype(), |$I| {
         let indices = indices.as_slice::<$I>();
         for (&index, &value) in indices.iter().zip(values.as_slice::<T>()) {
@@ -33,18 +49,27 @@ pub(super) fn canonicalize_primitive_into<T: NativePType + TryFrom<PValue, Error
         }
     });
 
+    builder.patch(sparse.resolved_patches()?, 0)?;
+
+    // If the array is nullable, and we have some sparse NULLs spread throughout the code,
+    // we can create a new null buffer and set it directly.
+    if sparse.dtype().is_nullable() {
+        sparse.patches().values()
+    }
+
     // Set the validity from the sparse array.
     builder.nulls.append_validity_mask(sparse.validity_mask()?);
 
     Ok(())
 }
 
-// bool
+/// Canonicalize a set of bools into a builder.
+///
+/// The builder must be properly sized before being used.
 pub(super) fn canonicalize_bool_into(
     sparse: &SparseArray,
     builder: &mut BoolBuilder,
 ) -> VortexResult<()> {
-    // Populate the buffer with the fill value
     builder.inner.append_n(
         sparse.len(),
         sparse.fill_scalar().as_bool().value().unwrap_or_default(),
@@ -55,10 +80,12 @@ pub(super) fn canonicalize_bool_into(
     let values = patches.values().clone().into_bool()?;
 
     // Scatter the values into the output buffer
-    let indices = indices.as_slice::<u32>();
-    for (&index, value) in indices.iter().zip(values.boolean_buffer().into_iter()) {
-        builder.inner.set_bit(index as usize, value);
-    }
+    match_each_integer_ptype!(indices.ptype(), |$I| {
+        let indices = indices.as_slice::<$I>();
+        for (&index, value) in indices.iter().zip(values.boolean_buffer().into_iter()) {
+            builder.inner.set_bit(index as usize, value);
+        }
+    });
 
     // Set the validity from the sparse array.
     builder.nulls.append_validity_mask(sparse.validity_mask()?);
@@ -67,3 +94,78 @@ pub(super) fn canonicalize_bool_into(
 }
 
 // TODO(aduffy): support for string, binary, float, struct, list
+
+#[cfg(test)]
+mod tests {
+    use itertools::Itertools;
+    use vortex_array::arrays::BoolArray;
+    use vortex_array::builders::{ArrayBuilder, BoolBuilder, PrimitiveBuilder};
+    use vortex_array::{IntoArray, IntoCanonical};
+    use vortex_buffer::{buffer, buffer_mut, Buffer};
+    use vortex_dtype::Nullability;
+    use vortex_scalar::Scalar;
+
+    use crate::SparseArray;
+
+    #[test]
+    fn test_primitive() {
+        let len = 10;
+        let indices: Buffer<u64> = buffer![0u64, 2, 4, 6, 8];
+
+        let values = buffer_mut![18u64, 19, 20, 21, 22];
+
+        let sparse = SparseArray::try_new(
+            indices.into_array(),
+            values.into_array(),
+            len,
+            Scalar::primitive(u64::MAX, Nullability::NonNullable),
+        )
+        .unwrap();
+
+        let mut result = PrimitiveBuilder::<u64>::with_capacity(Nullability::NonNullable, len);
+        sparse.canonicalize_into(&mut result).unwrap();
+
+        assert_eq!(
+            result.finish_into_primitive().as_slice::<u64>(),
+            &[
+                18,
+                u64::MAX,
+                19,
+                u64::MAX,
+                20,
+                u64::MAX,
+                21,
+                u64::MAX,
+                22,
+                u64::MAX,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_bool() {
+        let len = 10;
+        let indices: Buffer<u64> = buffer![0u64, 2, 4, 6, 8];
+
+        let values = BoolArray::from_iter(vec![true, true, true, true, true]);
+
+        let sparse = SparseArray::try_new(
+            indices.into_array(),
+            values.into_array(),
+            len,
+            Scalar::bool(false, Nullability::NonNullable),
+        )
+        .unwrap();
+
+        let mut result = BoolBuilder::with_capacity(Nullability::NonNullable, len);
+        sparse.canonicalize_into(&mut result).unwrap();
+
+        let bools = BoolArray::try_from(result.finish())
+            .unwrap()
+            .boolean_buffer();
+        assert_eq!(
+            bools.into_iter().collect_vec(),
+            vec![true, false, true, false, true, false, true, false, true, false]
+        );
+    }
+}

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -4,6 +4,7 @@ use vortex_array::arrays::BooleanBufferBuilder;
 use vortex_array::compute::{scalar_at, sub_scalar};
 use vortex_array::patches::{Patches, PatchesMetadata};
 use vortex_array::stats::{Stat, Statistics, StatsSet};
+use vortex_array::validity::ValidityMetadata;
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::visitor::ArrayVisitor;
 use vortex_array::vtable::{StatisticsVTable, ValidateVTable, ValidityVTable, VisitorVTable};
@@ -96,7 +97,6 @@ impl SparseArray {
         }
 
         let patches_metadata = patches.to_metadata(len, patches.dtype())?;
-
         let fill_value_buffer = fill_value.into_value().to_flexbytes();
 
         Self::try_from_parts(

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -4,7 +4,6 @@ use vortex_array::arrays::BooleanBufferBuilder;
 use vortex_array::compute::{scalar_at, sub_scalar};
 use vortex_array::patches::{Patches, PatchesMetadata};
 use vortex_array::stats::{Stat, Statistics, StatsSet};
-use vortex_array::validity::ValidityMetadata;
 use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::visitor::ArrayVisitor;
 use vortex_array::vtable::{StatisticsVTable, ValidateVTable, ValidityVTable, VisitorVTable};

--- a/vortex-array/src/builders/bool.rs
+++ b/vortex-array/src/builders/bool.rs
@@ -3,6 +3,7 @@ use std::any::Any;
 use arrow_buffer::BooleanBufferBuilder;
 use vortex_dtype::{DType, Nullability};
 use vortex_error::{vortex_bail, VortexExpect as _, VortexResult};
+use vortex_mask::Mask;
 
 use crate::arrays::BoolArray;
 use crate::builders::lazy_validity_builder::LazyNullBufferBuilder;
@@ -10,8 +11,8 @@ use crate::builders::ArrayBuilder;
 use crate::{Array, Canonical, IntoArray, IntoCanonical};
 
 pub struct BoolBuilder {
-    pub inner: BooleanBufferBuilder,
-    pub nulls: LazyNullBufferBuilder,
+    inner: BooleanBufferBuilder,
+    nulls: LazyNullBufferBuilder,
     nullability: Nullability,
     dtype: DType,
 }
@@ -30,6 +31,11 @@ impl BoolBuilder {
         }
     }
 
+    /// Append a `Mask` to the null buffer.
+    pub fn append_mask(&mut self, mask: Mask) {
+        self.nulls.append_validity_mask(mask);
+    }
+
     pub fn append_value(&mut self, value: bool) {
         self.append_values(value, 1)
     }
@@ -43,6 +49,78 @@ impl BoolBuilder {
         match value {
             Some(value) => self.append_value(value),
             None => self.append_null(),
+        }
+    }
+
+    pub fn uninit_range(&mut self, len: usize) -> UninitBool {
+        let begin = self.inner.len();
+
+        assert!(
+            begin + len <= self.inner.capacity(),
+            "uninit_range of len {len} exceeds capacity"
+        );
+
+        // NOTE(aduffy): we advance the builder so that the uninitialized bits are now addressable
+        //  by `set_bit()`. In the Drop impl for UninitBool we truncate the length back to `begin`
+        //  in the case an error is thrown that causes the UninitBool to be dropped before `finish()`.
+        self.inner.advance(len);
+
+        UninitBool {
+            builder: self,
+            begin,
+            len,
+            finished: false,
+        }
+    }
+}
+
+pub struct UninitBool<'a> {
+    builder: &'a mut BoolBuilder,
+    begin: usize,
+    len: usize,
+    finished: bool,
+}
+
+impl UninitBool<'_> {
+    /// Randomly set a bit in the range.
+    pub fn set_bit(&mut self, index: usize, value: bool) {
+        self.builder.inner.set_bit(index, value);
+    }
+
+    /// Set the entire range to a given value.
+    pub fn set_all(&mut self, value: bool) {
+        // Truncate down to the original length, then overwrite with many packed bytes of `value`.
+        self.builder.inner.truncate(self.begin);
+        self.builder.inner.append_n(self.len, value);
+    }
+
+    /// Set a validity bit at the given index. The index is relative to the start of this range
+    /// of the builder.
+    pub fn set_valid_bit(&mut self, index: usize, v: bool) {
+        self.builder.nulls.set_bit(self.begin + index, v);
+    }
+
+    /// Complete initialization of this bit range.
+    ///
+    /// After calling this method, the entire range of values covered by this UninitBool will be
+    /// considered initialized.
+    pub fn finish(mut self) {
+        self.finished = true;
+    }
+}
+
+impl Drop for UninitBool<'_> {
+    fn drop(&mut self) {
+        // NOTE: this is a cleanup function. The only way we can perform random access into a
+        //  BooleanBuffer is by `advance()`ing the pointer. However, this presents an issue in
+        //  the face of an Error. The Drop handler will be called before some of those values were
+        //  properly initialized. To prevent exposing the possibly uninitialized values to the user
+        //  of the BoolBuilder, we do a check on Drop that it is happening after a clean `finish()`.
+        //  If we detect that the caller didn't `finish()` the UninitBool before dropping it, we
+        //  truncate the user-visible length of the BooleanBuffer to its initial length before
+        //  the UninitBool was created.
+        if !self.finished {
+            self.builder.inner.truncate(self.begin);
         }
     }
 }
@@ -104,11 +182,14 @@ impl ArrayBuilder for BoolBuilder {
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error;
+
     use rand::prelude::StdRng;
     use rand::{Rng, SeedableRng};
+    use vortex_dtype::Nullability;
 
     use crate::arrays::{BoolArray, ChunkedArray};
-    use crate::builders::builder_with_capacity;
+    use crate::builders::{builder_with_capacity, ArrayBuilder, BoolBuilder};
     use crate::{Array, IntoArray, IntoCanonical};
 
     fn make_opt_bool_chunks(len: usize, chunk_count: usize) -> Array {
@@ -147,5 +228,29 @@ mod tests {
 
         assert_eq!(canon_into.validity(), into_canon.validity());
         assert_eq!(canon_into.boolean_buffer(), into_canon.boolean_buffer());
+    }
+
+    #[test]
+    fn test_uninit_drop() {
+        fn do_partial_work(builder: &mut BoolBuilder) -> Result<(), Box<dyn Error + Send + Sync>> {
+            let mut uninit = builder.uninit_range(5);
+            uninit.set_bit(0, true);
+            uninit.set_bit(1, false);
+            Err("oh no an error!".into())
+        }
+
+        let mut builder = BoolBuilder::with_capacity(Nullability::NonNullable, 10);
+        // Push 5 values into the array.
+        let mut range = builder.uninit_range(5);
+        range.set_bit(0, true);
+        range.set_bit(4, true);
+        range.finish();
+
+        // The builder has 5 values before we call this function, which will complete
+        // with error.
+        assert!(do_partial_work(&mut builder).ok().is_none());
+
+        // After the error, the builder still has 5 initialized values.
+        assert_eq!(builder.len(), 5);
     }
 }

--- a/vortex-array/src/builders/bool.rs
+++ b/vortex-array/src/builders/bool.rs
@@ -10,8 +10,8 @@ use crate::builders::ArrayBuilder;
 use crate::{Array, Canonical, IntoArray, IntoCanonical};
 
 pub struct BoolBuilder {
-    inner: BooleanBufferBuilder,
-    nulls: LazyNullBufferBuilder,
+    pub inner: BooleanBufferBuilder,
+    pub nulls: LazyNullBufferBuilder,
     nullability: Nullability,
     dtype: DType,
 }

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -126,10 +126,10 @@ impl<T: NativePType> PrimitiveBuilder<T> {
 
     pub fn extend_with_iterator(&mut self, iter: impl IntoIterator<Item = T>, mask: Mask) {
         self.values.extend(iter);
-        self.extend_validity(mask)
+        self.extend_with_validity_mask(mask)
     }
 
-    fn extend_validity(&mut self, validity_mask: Mask) {
+    fn extend_with_validity_mask(&mut self, validity_mask: Mask) {
         self.nulls.append_validity_mask(validity_mask);
     }
 }
@@ -169,7 +169,7 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
 
         self.values.extend_from_slice(array.as_slice::<T>());
 
-        self.extend_validity(array.validity_mask()?);
+        self.extend_with_validity_mask(array.validity_mask()?);
 
         Ok(())
     }

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -81,14 +81,14 @@ impl<T: NativePType> PrimitiveBuilder<T> {
     ///
     /// assert_eq!(built.as_slice::<i32>(), &[0i32, 1, 2, 3, 4]);
     /// ```
-    pub fn uninit_range(&mut self, len: usize) -> UninitRange<T> {
+    pub fn uninit_range(&mut self, len: usize) -> UninitPrimitive<T> {
         let offset = self.values.len();
         assert!(
             offset + len <= self.values.capacity(),
             "uninit_range of len {len} exceeds builder capacity"
         );
 
-        UninitRange {
+        UninitPrimitive {
             offset,
             len,
             builder: self,
@@ -179,13 +179,13 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
     }
 }
 
-pub struct UninitRange<'a, T> {
+pub struct UninitPrimitive<'a, T> {
     offset: usize,
     len: usize,
     builder: &'a mut PrimitiveBuilder<T>,
 }
 
-impl<T> Deref for UninitRange<'_, T> {
+impl<T> Deref for UninitPrimitive<'_, T> {
     type Target = [MaybeUninit<T>];
 
     fn deref(&self) -> &[MaybeUninit<T>] {
@@ -202,16 +202,16 @@ impl<T> Deref for UninitRange<'_, T> {
     }
 }
 
-impl<T> DerefMut for UninitRange<'_, T> {
+impl<T> DerefMut for UninitPrimitive<'_, T> {
     fn deref_mut(&mut self) -> &mut [MaybeUninit<T>] {
         &mut self.builder.values.spare_capacity_mut()[..self.len]
     }
 }
 
-impl<T> UninitRange<'_, T> {
+impl<T> UninitPrimitive<'_, T> {
     /// Set a validity bit at the given index. The index is relative to the start of this range
     /// of the builder.
-    pub fn set_bit(&mut self, index: usize, v: bool) {
+    pub fn set_valid_bit(&mut self, index: usize, v: bool) {
         self.builder.nulls.set_bit(self.offset + index, v);
     }
 

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -126,10 +126,10 @@ impl<T: NativePType> PrimitiveBuilder<T> {
 
     pub fn extend_with_iterator(&mut self, iter: impl IntoIterator<Item = T>, mask: Mask) {
         self.values.extend(iter);
-        self.extend_with_validity_mask(mask)
+        self.extend_validity(mask)
     }
 
-    fn extend_with_validity_mask(&mut self, validity_mask: Mask) {
+    fn extend_validity(&mut self, validity_mask: Mask) {
         self.nulls.append_validity_mask(validity_mask);
     }
 }
@@ -169,7 +169,7 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
 
         self.values.extend_from_slice(array.as_slice::<T>());
 
-        self.extend_with_validity_mask(array.validity_mask()?);
+        self.extend_validity(array.validity_mask()?);
 
         Ok(())
     }

--- a/vortex-btrblocks/src/float.rs
+++ b/vortex-btrblocks/src/float.rs
@@ -34,13 +34,7 @@ impl Compressor for FloatCompressor {
     type StatsType = FloatStats;
 
     fn schemes() -> &'static [&'static Self::SchemeType] {
-        &[
-            &UncompressedScheme,
-            &ConstantScheme,
-            &ALPScheme,
-            &ALPRDScheme,
-            &DictScheme,
-        ]
+        &[&ConstantScheme, &ALPScheme, &ALPRDScheme, &DictScheme]
     }
 
     fn default_scheme() -> &'static Self::SchemeType {


### PR DESCRIPTION
```
Timer precision: 41 ns
canonical             fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ canonicalize_into                │               │               │               │         │
│  ├─ 0.001           8.207 µs      │ 553 µs        │ 11.77 µs      │ 12.59 µs      │ 1000    │ 1000
│  ├─ 0.01            12.04 µs      │ 121.5 µs      │ 13.2 µs       │ 13.42 µs      │ 1000    │ 1000
│  ├─ 0.05            15.99 µs      │ 38.08 µs      │ 18.41 µs      │ 18.43 µs      │ 1000    │ 1000
│  ╰─ 0.1             20.41 µs      │ 140.4 µs      │ 23.29 µs      │ 23.35 µs      │ 1000    │ 1000
╰─ into_canonical                   │               │               │               │         │
   ├─ 0.001           8.874 µs      │ 154.9 µs      │ 12.24 µs      │ 12.88 µs      │ 1000    │ 1000
   ├─ 0.01            11.91 µs      │ 129.2 µs      │ 13.12 µs      │ 13.38 µs      │ 1000    │ 1000
   ├─ 0.05            13.74 µs      │ 117.8 µs      │ 18.24 µs      │ 17.31 µs      │ 1000    │ 1000
   ╰─ 0.1             17.08 µs      │ 118.9 µs      │ 20.22 µs      │ 20.3 µs       │ 1000    │ 1000
```