### PR TITLE
fix: codspeed build

### DIFF
--- a/vortex-btrblocks/benches/compress.rs
+++ b/vortex-btrblocks/benches/compress.rs
@@ -1,5 +1,8 @@
 #![allow(clippy::unwrap_used)]
+#![allow(unexpected_cfgs)]
+#![allow(unused_imports)]
 
+#[cfg(not(codspeed))]
 use divan::counter::{BytesCount, ItemsCount};
 use divan::Bencher;
 use rand::prelude::StdRng;
@@ -11,6 +14,7 @@ use vortex_btrblocks::Compressor;
 use vortex_buffer::buffer_mut;
 use vortex_sampling_compressor::SamplingCompressor;
 
+#[cfg(not(codspeed))]
 fn make_clickbench_window_name() -> Array {
     // A test that's meant to mirror the WindowName column from ClickBench.
     let mut values = buffer_mut![-1i32; 1_000_000];
@@ -30,6 +34,7 @@ fn make_clickbench_window_name() -> Array {
     values.freeze().into_array()
 }
 
+#[cfg(not(codspeed))]
 #[divan::bench]
 fn btrblocks(bencher: Bencher) {
     bencher
@@ -39,6 +44,7 @@ fn btrblocks(bencher: Bencher) {
         .bench_local_values(|array| IntCompressor::compress(&array, false, 3, &[]).unwrap());
 }
 
+#[cfg(not(codspeed))]
 #[divan::bench]
 fn sampling_compressor(bencher: Bencher) {
     let compressor = SamplingCompressor::default();

--- a/vortex-btrblocks/benches/stats_calc.rs
+++ b/vortex-btrblocks/benches/stats_calc.rs
@@ -1,7 +1,10 @@
 #![allow(clippy::cast_possible_truncation, clippy::use_debug)]
+#![allow(unexpected_cfgs)]
 
+#[cfg(not(codspeed))]
 use vortex_buffer::{Buffer, BufferMut};
 
+#[cfg(not(codspeed))]
 fn generate_dataset(max_run: u32, distinct: u32) -> Buffer<u32> {
     let mut output = BufferMut::with_capacity(64_000);
     let mut run = 0;
@@ -18,6 +21,7 @@ fn generate_dataset(max_run: u32, distinct: u32) -> Buffer<u32> {
     output.freeze()
 }
 
+#[cfg(not(codspeed))]
 #[derive(Debug, Copy, Clone)]
 enum Distribution {
     LowCardinality,
@@ -25,6 +29,7 @@ enum Distribution {
     LongRuns,
 }
 
+#[cfg(not(codspeed))]
 #[divan::bench_group(items_count = 64_000u32, bytes_count = 256_000u32)]
 mod stats {
     use divan::Bencher;
@@ -77,6 +82,7 @@ mod stats {
         });
     }
 }
+
 fn main() {
     divan::main();
 }


### PR DESCRIPTION
Codspeed's Divan compatibility layer does not provide the full feature set of Divan. Therefore, we need to conditionally compile some of the benchmarks.