### PR TITLE
clean: clean up cfg codspeed handling

### DIFF
--- a/vortex-btrblocks/benches/compress.rs
+++ b/vortex-btrblocks/benches/compress.rs
@@ -1,58 +1,56 @@
 #![allow(clippy::unwrap_used)]
 #![allow(unexpected_cfgs)]
-#![allow(unused_imports)]
 
 #[cfg(not(codspeed))]
-use divan::counter::{BytesCount, ItemsCount};
-use divan::Bencher;
-use rand::prelude::StdRng;
-use rand::{RngCore, SeedableRng};
-use vortex_array::aliases::hash_set::HashSet;
-use vortex_array::{Array, IntoArray, IntoArrayVariant};
-use vortex_btrblocks::integer::IntCompressor;
-use vortex_btrblocks::Compressor;
-use vortex_buffer::buffer_mut;
-use vortex_sampling_compressor::SamplingCompressor;
+mod benchmarks {
+    use divan::counter::{BytesCount, ItemsCount};
+    use divan::Bencher;
+    use rand::prelude::StdRng;
+    use rand::{RngCore, SeedableRng};
+    use vortex_array::aliases::hash_set::HashSet;
+    use vortex_array::{Array, IntoArray, IntoArrayVariant};
+    use vortex_btrblocks::integer::IntCompressor;
+    use vortex_btrblocks::Compressor;
+    use vortex_buffer::buffer_mut;
+    use vortex_sampling_compressor::SamplingCompressor;
 
-#[cfg(not(codspeed))]
-fn make_clickbench_window_name() -> Array {
-    // A test that's meant to mirror the WindowName column from ClickBench.
-    let mut values = buffer_mut![-1i32; 1_000_000];
-    let mut visited = HashSet::new();
-    let mut rng = StdRng::seed_from_u64(1u64);
-    while visited.len() < 223 {
-        let random = (rng.next_u32() as usize) % 1_000_000;
-        if visited.contains(&random) {
-            continue;
+    fn make_clickbench_window_name() -> Array {
+        // A test that's meant to mirror the WindowName column from ClickBench.
+        let mut values = buffer_mut![-1i32; 1_000_000];
+        let mut visited = HashSet::new();
+        let mut rng = StdRng::seed_from_u64(1u64);
+        while visited.len() < 223 {
+            let random = (rng.next_u32() as usize) % 1_000_000;
+            if visited.contains(&random) {
+                continue;
+            }
+            visited.insert(random);
+            // Pick 100 random values to insert.
+            values[random] = 5 * (rng.next_u64() % 100) as i32;
         }
-        visited.insert(random);
-        // Pick 100 random values to insert.
-        values[random] = 5 * (rng.next_u64() % 100) as i32;
+
+        // Ok, now let's compress
+        values.freeze().into_array()
     }
 
-    // Ok, now let's compress
-    values.freeze().into_array()
-}
+    #[divan::bench]
+    fn btrblocks(bencher: Bencher) {
+        bencher
+            .with_inputs(|| make_clickbench_window_name().into_primitive().unwrap())
+            .input_counter(|array| ItemsCount::new(array.len()))
+            .input_counter(|array| BytesCount::of_many::<i32>(array.len()))
+            .bench_local_values(|array| IntCompressor::compress(&array, false, 3, &[]).unwrap());
+    }
 
-#[cfg(not(codspeed))]
-#[divan::bench]
-fn btrblocks(bencher: Bencher) {
-    bencher
-        .with_inputs(|| make_clickbench_window_name().into_primitive().unwrap())
-        .input_counter(|array| ItemsCount::new(array.len()))
-        .input_counter(|array| BytesCount::of_many::<i32>(array.len()))
-        .bench_local_values(|array| IntCompressor::compress(&array, false, 3, &[]).unwrap());
-}
-
-#[cfg(not(codspeed))]
-#[divan::bench]
-fn sampling_compressor(bencher: Bencher) {
-    let compressor = SamplingCompressor::default();
-    bencher
-        .with_inputs(make_clickbench_window_name)
-        .input_counter(|array| ItemsCount::new(array.len()))
-        .input_counter(|array| BytesCount::of_many::<i32>(array.len()))
-        .bench_local_values(|array| compressor.compress(&array, None).unwrap());
+    #[divan::bench]
+    fn sampling_compressor(bencher: Bencher) {
+        let compressor = SamplingCompressor::default();
+        bencher
+            .with_inputs(make_clickbench_window_name)
+            .input_counter(|array| ItemsCount::new(array.len()))
+            .input_counter(|array| BytesCount::of_many::<i32>(array.len()))
+            .bench_local_values(|array| compressor.compress(&array, None).unwrap());
+    }
 }
 
 fn main() {

--- a/vortex-btrblocks/benches/stats_calc.rs
+++ b/vortex-btrblocks/benches/stats_calc.rs
@@ -2,44 +2,37 @@
 #![allow(unexpected_cfgs)]
 
 #[cfg(not(codspeed))]
-use vortex_buffer::{Buffer, BufferMut};
-
-#[cfg(not(codspeed))]
-fn generate_dataset(max_run: u32, distinct: u32) -> Buffer<u32> {
-    let mut output = BufferMut::with_capacity(64_000);
-    let mut run = 0;
-    let mut value = 0;
-    for _ in 0..64_000 {
-        if run == 0 {
-            value = rand::random::<u32>() % distinct;
-            run = std::cmp::max(rand::random::<u32>() % max_run, 1);
-        }
-        output.push(value);
-        run -= 1;
-    }
-
-    output.freeze()
-}
-
-#[cfg(not(codspeed))]
-#[derive(Debug, Copy, Clone)]
-enum Distribution {
-    LowCardinality,
-    ShortRuns,
-    LongRuns,
-}
-
-#[cfg(not(codspeed))]
 #[divan::bench_group(items_count = 64_000u32, bytes_count = 256_000u32)]
-mod stats {
+mod benchmarks {
     use divan::Bencher;
     use vortex_array::array::PrimitiveArray;
     use vortex_array::validity::Validity;
     use vortex_btrblocks::integer::IntegerStats;
     use vortex_btrblocks::{CompressorStats, GenerateStatsOptions};
-    use vortex_buffer::Buffer;
+    use vortex_buffer::{Buffer, BufferMut};
 
-    use crate::{generate_dataset, Distribution};
+    fn generate_dataset(max_run: u32, distinct: u32) -> Buffer<u32> {
+        let mut output = BufferMut::with_capacity(64_000);
+        let mut run = 0;
+        let mut value = 0;
+        for _ in 0..64_000 {
+            if run == 0 {
+                value = rand::random::<u32>() % distinct;
+                run = std::cmp::max(rand::random::<u32>() % max_run, 1);
+            }
+            output.push(value);
+            run -= 1;
+        }
+
+        output.freeze()
+    }
+
+    #[derive(Debug, Copy, Clone)]
+    enum Distribution {
+        LowCardinality,
+        ShortRuns,
+        LongRuns,
+    }
 
     fn generate_low_cardinality() -> PrimitiveArray {
         let values: Buffer<u32> = (0..1024).cycle().take(64_000).collect();


### PR DESCRIPTION
Set `#[cfg(not(codspeed))]` once per benchmark target on `mod benchmarks`.