### PR TITLE
Don't allow scanning tables with defined output ordering

### DIFF
--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -296,6 +296,10 @@ impl FileFormat for VortexFormat {
             return not_impl_err!("Hive style partitioning isn't implemented yet for Vortex");
         }
 
+        if !file_scan_config.output_ordering.is_empty() {
+            return not_impl_err!("Vortex doesn't respect output ordering");
+        }
+
         let exec = VortexExec::try_new(
             file_scan_config,
             metrics,

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -297,7 +297,7 @@ impl FileFormat for VortexFormat {
         }
 
         if !file_scan_config.output_ordering.is_empty() {
-            return not_impl_err!("Vortex doesn't respect output ordering");
+            return not_impl_err!("Vortex doesn't support output ordering");
         }
 
         let exec = VortexExec::try_new(


### PR DESCRIPTION
Error when trying to query tables defined with a `WITH ORDER` clause, e.g.:
```sql
CREATE EXTERNAL TABLE tbl (
    c1  VARCHAR NOT NULL,
    c2  INT NOT NULL,
)
STORED AS VORTEX
WITH ORDER (c1 ASC)
```
Until now we effectively just ignored these options, but that might have some correctness issues so I figured its just best to error out right now.