### PR TITLE
chore: minor datafusion improvement and make all eprintln use proper logging

### DIFF
--- a/bench-vortex/benches/compress.rs
+++ b/bench-vortex/benches/compress.rs
@@ -1,5 +1,4 @@
 use core::cell::LazyCell;
-use core::str::FromStr;
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::io::Cursor;
 use std::path::Path;
@@ -26,7 +25,6 @@ use parquet::basic::{Compression, ZstdLevel};
 use parquet::file::properties::WriterProperties;
 use regex::Regex;
 use tokio::runtime::{Builder, Runtime};
-use tracing::info;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
 use vortex::arrays::{ChunkedArray, StructArray};
@@ -154,13 +152,12 @@ fn benchmark_compress<F, U>(
 {
     // if no logging is enabled, enable it
     if !LOG_INITIALIZED.swap(true, Ordering::SeqCst) {
-        let level_filter = match EnvFilter::try_from_default_env() {
-            Ok(filter) => LevelFilter::from(filter),
-            Err(_e) => LevelFilter::OFF,
-        };
+        let filter = EnvFilter::builder()
+            .with_default_directive(LevelFilter::OFF.into())
+            .from_env_lossy();
 
         tracing_subscriber::fmt()
-            .with_max_level(level_filter)
+            .with_env_filter(filter)
             .with_writer(std::io::stderr)
             .init();
     }

--- a/bench-vortex/benches/compress.rs
+++ b/bench-vortex/benches/compress.rs
@@ -26,7 +26,9 @@ use parquet::basic::{Compression, ZstdLevel};
 use parquet::file::properties::WriterProperties;
 use regex::Regex;
 use tokio::runtime::{Builder, Runtime};
+use tracing::info;
 use tracing::level_filters::LevelFilter;
+use tracing_subscriber::EnvFilter;
 use vortex::arrays::{ChunkedArray, StructArray};
 use vortex::arrow::IntoArrowArray;
 use vortex::dtype::FieldName;
@@ -152,13 +154,13 @@ fn benchmark_compress<F, U>(
 {
     // if no logging is enabled, enable it
     if !LOG_INITIALIZED.swap(true, Ordering::SeqCst) {
-        let level = env::var("RUST_LOG")
-            .ok()
-            .and_then(|s| LevelFilter::from_str(&s).ok())
-            .unwrap_or(LevelFilter::OFF);
+        let level_filter = match EnvFilter::try_from_default_env() {
+            Ok(filter) => LevelFilter::from(filter),
+            Err(_e) => LevelFilter::OFF,
+        };
 
         tracing_subscriber::fmt()
-            .with_max_level(level)
+            .with_max_level(level_filter)
             .with_writer(std::io::stderr)
             .init();
     }
@@ -259,7 +261,7 @@ fn benchmark_compress<F, U>(
         .map(|x| Regex::new(&x).unwrap().is_match(bench_name))
         .unwrap_or(false)
     {
-        eprintln!(
+        info!(
             "{}",
             serde_json::to_string(&GenericBenchmarkResults {
                 name: &format!("vortex:parquet-zstd size/{}", bench_name),
@@ -270,7 +272,7 @@ fn benchmark_compress<F, U>(
             .unwrap()
         );
 
-        eprintln!(
+        info!(
             "{}",
             serde_json::to_string(&GenericBenchmarkResults {
                 name: &format!("vortex:raw size/{}", bench_name),
@@ -281,7 +283,7 @@ fn benchmark_compress<F, U>(
             .unwrap()
         );
 
-        eprintln!(
+        info!(
             "{}",
             serde_json::to_string(&GenericBenchmarkResults {
                 name: &format!("vortex size/{}", bench_name),

--- a/bench-vortex/benches/compress.rs
+++ b/bench-vortex/benches/compress.rs
@@ -261,7 +261,7 @@ fn benchmark_compress<F, U>(
         .map(|x| Regex::new(&x).unwrap().is_match(bench_name))
         .unwrap_or(false)
     {
-        info!(
+        println!(
             "{}",
             serde_json::to_string(&GenericBenchmarkResults {
                 name: &format!("vortex:parquet-zstd size/{}", bench_name),
@@ -272,7 +272,7 @@ fn benchmark_compress<F, U>(
             .unwrap()
         );
 
-        info!(
+        println!(
             "{}",
             serde_json::to_string(&GenericBenchmarkResults {
                 name: &format!("vortex:raw size/{}", bench_name),
@@ -283,7 +283,7 @@ fn benchmark_compress<F, U>(
             .unwrap()
         );
 
-        info!(
+        println!(
             "{}",
             serde_json::to_string(&GenericBenchmarkResults {
                 name: &format!("vortex size/{}", bench_name),

--- a/bench-vortex/src/bin/clickbench.rs
+++ b/bench-vortex/src/bin/clickbench.rs
@@ -13,6 +13,7 @@ use clap::Parser;
 use datafusion_physical_plan::display::DisplayableExecutionPlan;
 use indicatif::ProgressBar;
 use itertools::Itertools;
+use log::{info, warn};
 use rayon::iter::{IntoParallelIterator, ParallelIterator as _};
 use tokio::runtime::Builder;
 use tracing::info_span;
@@ -98,7 +99,7 @@ fn main() {
     (0_u32..100).into_par_iter().for_each(|idx| {
         let output_path = basepath.join("parquet").join(format!("hits_{idx}.parquet"));
         idempotent(&output_path, |output_path| {
-            eprintln!("Downloading file {idx}");
+            info!("Downloading file {idx}");
             let url = format!("https://pub-3ba949c0f0354ac18db1f0f14f0a2c52.r2.dev/clickbench/parquet_many/hits_{idx}.parquet");
 
 
@@ -112,7 +113,7 @@ fn main() {
                           break;
                     },
                     Err(e) => {
-                        eprintln!("Request for file {idx} timed out, retying for the {attempt} time");
+                        warn!("Request for file {idx} timed out, retying for the {attempt} time");
                         output = Some(Err(e));
                     }
                 }

--- a/bench-vortex/src/bin/tpch.rs
+++ b/bench-vortex/src/bin/tpch.rs
@@ -13,6 +13,7 @@ use bench_vortex::{default_env_filter, feature_flagged_allocator, setup_logger, 
 use clap::{Parser, ValueEnum};
 use indicatif::ProgressBar;
 use itertools::Itertools;
+use log::{info, warn};
 use tokio::runtime::Builder;
 use url::Url;
 use vortex::aliases::hash_map::HashMap;
@@ -91,7 +92,7 @@ fn main() -> ExitCode {
                 }
             };
 
-            eprintln!(
+            info!(
                 "Using existing or generating new files located at {}.",
                 data_dir.display()
             );
@@ -108,9 +109,9 @@ fn main() -> ExitCode {
             //
             // The folder must already be populated with data!
             if !tpch_benchmark_remote_data_dir.ends_with("/") {
-                eprintln!("Supply a --use-remote-data-dir argument which ends in a slash e.g. s3://vortex-bench-dev/parquet/");
+                warn!("Supply a --use-remote-data-dir argument which ends in a slash e.g. s3://vortex-bench-dev/parquet/");
             }
-            eprintln!(
+            info!(
                 concat!(
                 "Assuming data already exists at this remote (e.g. S3, GCS) URL: {}.\n",
                 "If it does not, you should kill this command, locally generate the files (by running without\n",
@@ -156,7 +157,7 @@ async fn bench_main(
         );
     };
 
-    eprintln!(
+    info!(
         "Benchmarking against these formats: {}.",
         formats.iter().join(", ")
     );
@@ -210,7 +211,7 @@ async fn bench_main(
                 "gcs" => "gcs",
                 "file" => "nvme",
                 otherwise => {
-                    println!("unknown URL scheme: {}", otherwise);
+                    warn!("unknown URL scheme: {}", otherwise);
                     return ExitCode::FAILURE;
                 }
             }
@@ -248,14 +249,14 @@ async fn bench_main(
                 let expected_row_count = expected_row_counts[idx];
                 if actual_row_count != expected_row_count {
                     if idx == 15 && actual_row_count == 0 {
-                        eprintln!(
+                        warn!(
                             "*IGNORING* mismatched row count {} instead of {} for format {:?} because Query 15 is flaky. See: https://github.com/spiraldb/vortex/issues/2395",
                             actual_row_count,
                             expected_row_count,
                             format,
                         );
                     } else  {
-                        eprintln!(
+                        warn!(
                             "Mismatched row count {} instead of {} in query {} for format {:?}",
                             actual_row_count,
                             expected_row_count,

--- a/bench-vortex/src/clickbench.rs
+++ b/bench-vortex/src/clickbench.rs
@@ -9,6 +9,7 @@ use datafusion::datasource::listing::{
 use datafusion::prelude::{ParquetReadOptions, SessionContext};
 use futures::{stream, StreamExt, TryStreamExt};
 use tokio::fs::{create_dir_all, OpenOptions};
+use tracing::info;
 use vortex::arrow::FromArrowType;
 use vortex::dtype::DType;
 use vortex::error::{vortex_err, VortexError};
@@ -158,7 +159,7 @@ pub async fn register_vortex_files(
             tokio::spawn(async move {
                 let output_path = output_path.clone();
                 idempotent_async(&output_path, move |vtx_file| async move {
-                    eprintln!("Processing file {idx}");
+                    info!("Processing file {idx}");
                     let record_batches = session
                         .read_parquet(
                             parquet_file_path.to_str().unwrap(),

--- a/bench-vortex/src/display.rs
+++ b/bench-vortex/src/display.rs
@@ -75,6 +75,7 @@ pub fn render_table<T: ToGeneric>(
 
 pub fn print_measurements_json<T: ToJson>(all_measurements: Vec<T>) -> anyhow::Result<()> {
     for measurement in all_measurements {
+        // This has to be `println!` and go to stdout, because we capture it from there.
         println!("{}", serde_json::to_string(&measurement.to_json())?)
     }
 

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -186,14 +186,13 @@ impl IdempotentPath for PathBuf {
     }
 }
 
-pub fn setup_logger(_filter: EnvFilter) {
-    // #[cfg(not(feature = "tracing"))]
+pub fn setup_logger(filter: EnvFilter) {
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_file(true)
         .with_level(true)
         .with_line_number(true)
-        .with_env_filter(_filter)
+        .with_env_filter(filter)
         .init();
 }
 

--- a/vortex-btrblocks/src/lib.rs
+++ b/vortex-btrblocks/src/lib.rs
@@ -235,7 +235,6 @@ pub struct BtrBlocksCompressor;
 impl BtrBlocksCompressor {
     #[allow(clippy::only_used_in_recursion)]
     pub fn compress(&self, array: Array) -> VortexResult<Array> {
-        // println!("compressing array of len {}", array.len());
         match array.into_canonical()? {
             Canonical::Null(null_array) => Ok(null_array.into_array()),
             // TODO(aduffy): Sparse, other bool compressors.

--- a/vortex-datafusion/src/persistent/execution.rs
+++ b/vortex-datafusion/src/persistent/execution.rs
@@ -161,6 +161,9 @@ impl ExecutionPlan for VortexExec {
             .iter()
             .flatten()
             .collect::<Vec<_>>();
+
+        dbg!(&all_files[0].statistics);
+
         let total_size = all_files.iter().map(|f| f.object_meta.size).sum::<usize>();
 
         // If there's one file or less total files in the scan, we can't repartition it
@@ -257,12 +260,15 @@ mod tests {
             PartitionedFile::new("e", 50),
         ]];
 
-        repartition_by_size(file_groups.iter().flatten().collect(), 2);
+        let groups = repartition_by_size(file_groups.iter().flatten().collect(), 2);
+
+        assert_eq!(groups.len(), 2);
 
         let file_groups = (0..100)
             .map(|idx| PartitionedFile::new(format!("{idx}"), idx))
             .collect::<Vec<_>>();
 
-        repartition_by_size(file_groups.iter().collect(), 16);
+        let groups = repartition_by_size(file_groups.iter().collect(), 16);
+        assert_eq!(groups.len(), 16);
     }
 }

--- a/vortex-datafusion/src/persistent/execution.rs
+++ b/vortex-datafusion/src/persistent/execution.rs
@@ -156,12 +156,21 @@ impl ExecutionPlan for VortexExec {
         target_partitions: usize,
         _config: &ConfigOptions,
     ) -> DFResult<Option<Arc<dyn ExecutionPlan>>> {
+        // If there's only one total file in the scan, we can't repartition it
+        if self
+            .file_scan_config
+            .file_groups
+            .iter()
+            .map(|group| group.len())
+            .sum::<usize>()
+            == 1
+        {
+            return Ok(None);
+        }
+
         let file_groups = self.file_scan_config.file_groups.clone();
-
         let repartitioned_file_groups = repartition_by_size(file_groups, target_partitions);
-
         let mut new_plan = self.clone();
-
         let num_partitions = repartitioned_file_groups.len();
 
         log::debug!("VortexExec repartitioned to {num_partitions} partitions");

--- a/vortex-datafusion/src/persistent/execution.rs
+++ b/vortex-datafusion/src/persistent/execution.rs
@@ -252,15 +252,15 @@ mod tests {
 
     #[test]
     fn basic_repartition_test() {
-        let file_groups = vec![vec![
+        let file_groups = vec![
             PartitionedFile::new("a", 100),
             PartitionedFile::new("b", 25),
             PartitionedFile::new("c", 25),
             PartitionedFile::new("d", 25),
             PartitionedFile::new("e", 50),
-        ]];
+        ];
 
-        let groups = repartition_by_size(file_groups.iter().flatten().collect(), 2);
+        let groups = repartition_by_size(file_groups.iter().collect(), 2);
 
         assert_eq!(groups.len(), 2);
 

--- a/vortex-datafusion/src/persistent/execution.rs
+++ b/vortex-datafusion/src/persistent/execution.rs
@@ -156,14 +156,14 @@ impl ExecutionPlan for VortexExec {
         target_partitions: usize,
         _config: &ConfigOptions,
     ) -> DFResult<Option<Arc<dyn ExecutionPlan>>> {
-        // If there's only one total file in the scan, we can't repartition it
+        // If there's one file or less total files in the scan, we can't repartition it
         if self
             .file_scan_config
             .file_groups
             .iter()
             .map(|group| group.len())
             .sum::<usize>()
-            == 1
+            <= 1
         {
             return Ok(None);
         }

--- a/vortex-datafusion/src/persistent/execution.rs
+++ b/vortex-datafusion/src/persistent/execution.rs
@@ -11,7 +11,6 @@ use datafusion_physical_expr::{EquivalenceProperties, Partitioning, PhysicalExpr
 use datafusion_physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion_physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
 use datafusion_physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
-use itertools::Itertools;
 use object_store::ObjectStoreScheme;
 use vortex_array::ContextRef;
 use vortex_expr::datafusion::convert_expr_to_vortex;
@@ -154,22 +153,26 @@ impl ExecutionPlan for VortexExec {
     fn repartitioned(
         &self,
         target_partitions: usize,
-        _config: &ConfigOptions,
+        config: &ConfigOptions,
     ) -> DFResult<Option<Arc<dyn ExecutionPlan>>> {
-        // If there's one file or less total files in the scan, we can't repartition it
-        if self
+        let all_files = self
             .file_scan_config
             .file_groups
             .iter()
-            .map(|group| group.len())
-            .sum::<usize>()
-            <= 1
-        {
+            .flatten()
+            .collect::<Vec<_>>();
+        let total_size = all_files.iter().map(|f| f.object_meta.size).sum::<usize>();
+
+        // If there's one file or less total files in the scan, we can't repartition it
+        if all_files.len() <= 1 {
             return Ok(None);
         }
 
-        let file_groups = self.file_scan_config.file_groups.clone();
-        let repartitioned_file_groups = repartition_by_size(file_groups, target_partitions);
+        if total_size < config.optimizer.repartition_file_min_size {
+            return Ok(None);
+        }
+
+        let repartitioned_file_groups = repartition_by_size(all_files, target_partitions);
         let mut new_plan = self.clone();
         let num_partitions = repartitioned_file_groups.len();
 
@@ -197,10 +200,9 @@ fn make_vortex_predicate(predicate: Option<Arc<dyn PhysicalExpr>>) -> Option<Arc
 }
 
 fn repartition_by_size(
-    file_groups: Vec<Vec<PartitionedFile>>,
+    all_files: Vec<&PartitionedFile>,
     desired_partitions: usize,
 ) -> Vec<Vec<PartitionedFile>> {
-    let all_files = file_groups.into_iter().concat();
     let total_file_count = all_files.len();
     let total_size = all_files.iter().map(|f| f.object_meta.size).sum::<usize>();
     let target_partition_size = total_size / (desired_partitions + 1);
@@ -212,7 +214,7 @@ fn repartition_by_size(
 
     for file in all_files.into_iter() {
         curr_partition_size += file.object_meta.size;
-        curr_partition.push(file);
+        curr_partition.push(file.clone());
 
         if curr_partition_size >= target_partition_size {
             curr_partition_size = 0;
@@ -227,7 +229,7 @@ fn repartition_by_size(
     } else if !curr_partition.is_empty() {
         for (idx, file) in curr_partition.into_iter().enumerate() {
             let new_part_idx = idx % partitions.len();
-            partitions[new_part_idx].push(file);
+            partitions[new_part_idx].push(file.clone());
         }
     }
 
@@ -255,12 +257,12 @@ mod tests {
             PartitionedFile::new("e", 50),
         ]];
 
-        repartition_by_size(file_groups, 2);
+        repartition_by_size(file_groups.iter().flatten().collect(), 2);
 
-        let file_groups = vec![(0..100)
+        let file_groups = (0..100)
             .map(|idx| PartitionedFile::new(format!("{idx}"), idx))
-            .collect()];
+            .collect::<Vec<_>>();
 
-        repartition_by_size(file_groups, 16);
+        repartition_by_size(file_groups.iter().collect(), 16);
     }
 }


### PR DESCRIPTION
1. Short circuit repartitioning if there's only one file in the scan (like in our current TPC-H setup)
2. Make all `eprintln!` in the benchmarks use proper logging frameworks