### PR TITLE
Deny dbg macro in code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,6 +213,7 @@ cargo = { level = "deny", priority = -1 }
 cast_possible_truncation = "deny"
 collection_is_never_read = "deny"
 cognitive_complexity = "deny"
+dbg_macro = "deny"
 debug_assert_with_mut_call = "deny"
 derive_partial_eq_without_eq = "deny"
 exit = "deny"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,5 @@
+allow-dbg-in-tests = true
 allow-expect-in-tests = true
 allow-unwrap-in-tests = true
 single-char-binding-names-threshold = 2
-disallowed-types = [
-    "std::collections::HashMap",
-    "std::collections::HashSet",
-]
+disallowed-types = ["std::collections::HashMap", "std::collections::HashSet"]

--- a/vortex-datafusion/src/persistent/execution.rs
+++ b/vortex-datafusion/src/persistent/execution.rs
@@ -162,8 +162,6 @@ impl ExecutionPlan for VortexExec {
             .flatten()
             .collect::<Vec<_>>();
 
-        dbg!(&all_files[0].statistics);
-
         let total_size = all_files.iter().map(|f| f.object_meta.size).sum::<usize>();
 
         // If there's one file or less total files in the scan, we can't repartition it


### PR DESCRIPTION
clippy will now forbid `dbg!` usage outside of tests (but `cargo run`/`cargo test` will work nicely as far as I can tell).