### PR TITLE
feat: add new `uninit_range` API for PrimitiveBuilder

### DIFF
--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -1,13 +1,14 @@
-use std::ops::DerefMut as _;
+use std::mem::MaybeUninit;
 
 use arrow_buffer::ArrowNativeType;
 use fastlanes::BitPacking;
+use num_traits::AsPrimitive;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::builders::{ArrayBuilder as _, PrimitiveBuilder};
+use vortex_array::builders::{ArrayBuilder as _, PrimitiveBuilder, UninitRange};
 use vortex_array::patches::Patches;
 use vortex_array::validity::Validity;
 use vortex_array::variants::PrimitiveArrayTrait;
-use vortex_array::IntoArray;
+use vortex_array::{IntoArray, IntoArrayVariant};
 use vortex_buffer::{Buffer, BufferMut, ByteBuffer};
 use vortex_dtype::{
     match_each_integer_ptype, match_each_integer_ptype_with_unsigned_type,
@@ -239,8 +240,6 @@ where
     F: Fn(&[UnsignedT]) -> &[T],
     G: Fn(&mut [T]) -> &mut [UnsignedT],
 {
-    let my_offset_in_builder = builder.len();
-
     builder
         .nulls
         .append_validity(array.validity(), array.len())?;
@@ -250,19 +249,79 @@ where
     let length = array.len();
     let offset = array.offset() as usize;
 
+    let mut uninit = builder.uninit_range(length);
+
     unpack_values_into(
         packed,
         bit_width,
-        length,
         offset,
-        builder,
+        // Ask the builder for the next `length` values in the buffer as a [MaybeUninit<T>]
+        &mut uninit,
         transmute,
         transmute_mut,
     )?;
 
+    // uninit.finish();
+
     if let Some(patches) = array.patches() {
-        builder.patch(patches, my_offset_in_builder)?;
+        apply_patches(&mut uninit, patches)?;
     };
+
+    uninit.finish();
+
+    Ok(())
+}
+
+fn apply_patches<T: NativePType>(dst: &mut UninitRange<T>, patches: Patches) -> VortexResult<()> {
+    let (array_len, indices_offset, indices, values) = patches.into_parts();
+    assert_eq!(array_len, dst.len());
+
+    let indices = indices.into_primitive()?;
+    let values = values.into_primitive()?;
+    let validity = values.validity();
+    let values = values.as_slice::<T>();
+    match_each_unsigned_integer_ptype!(indices.ptype(), |$P| {
+        insert_values_and_validity_at_indices::<T, $P>(
+            dst,
+            indices,
+            values,
+            validity,
+            indices_offset,
+        )
+    })
+}
+
+fn insert_values_and_validity_at_indices<
+    T: NativePType,
+    IndexT: NativePType + AsPrimitive<usize>,
+>(
+    dst: &mut UninitRange<T>,
+    indices: PrimitiveArray,
+    values: &[T],
+    validity: Validity,
+    indices_offset: usize,
+) -> VortexResult<()> {
+    match validity {
+        Validity::NonNullable => {
+            for (compressed_index, decompressed_index) in
+                indices.as_slice::<IndexT>().iter().enumerate()
+            {
+                dst[decompressed_index.as_() - indices_offset] =
+                    MaybeUninit::new(values[compressed_index]);
+            }
+        }
+        _ => {
+            let validity = validity.to_logical(indices.len())?;
+            for (compressed_index, decompressed_index) in
+                indices.as_slice::<IndexT>().iter().enumerate()
+            {
+                let out_index = decompressed_index.as_() - indices_offset;
+                dst[decompressed_index.as_() - indices_offset] =
+                    MaybeUninit::new(values[compressed_index]);
+                dst.set_bit(out_index, validity.value(out_index));
+            }
+        }
+    }
 
     Ok(())
 }
@@ -270,10 +329,9 @@ where
 fn unpack_values_into<T: NativePType, UnsignedT: NativePType + BitPacking, F, G>(
     packed: &[UnsignedT],
     bit_width: usize,
-    length: usize,
     offset: usize,
     // TODO(ngates): do we want to use fastlanes alignment for this buffer?
-    builder: &mut PrimitiveBuilder<T>,
+    uninit: &mut UninitRange<T>,
     transmute: F,
     transmute_mut: G,
 ) -> VortexResult<()>
@@ -281,22 +339,20 @@ where
     F: Fn(&[UnsignedT]) -> &[T],
     G: Fn(&mut [T]) -> &mut [UnsignedT],
 {
-    let my_offset_in_builder = builder.len();
-    let last_chunk_length = match (offset + length) % 1024 {
-        0 => 1024,
-        last_chunk_length => last_chunk_length,
+    let last_chunk_length = if (offset + uninit.len()) % 1024 == 0 {
+        1024
+    } else {
+        (offset + uninit.len()) % 1024
     };
 
     if bit_width == 0 {
-        builder.values.push_n(T::zero(), length);
+        uninit.fill(MaybeUninit::new(T::zero()));
         return Ok(());
     }
 
-    builder.values.reserve(length);
-
     // How many fastlanes vectors we will process.
     // Packed array might not start at 0 when the array is sliced. Offset is guaranteed to be < 1024.
-    let num_chunks = (offset + length).div_ceil(1024);
+    let num_chunks = (offset + uninit.len()).div_ceil(1024);
     let elems_per_chunk = 128 * bit_width / size_of::<T>();
     assert_eq!(
         packed.len(),
@@ -313,9 +369,12 @@ where
         // 1. chunk is elems_per_chunk.
         // 2. decoded is exactly 1024.
         unsafe { BitPacking::unchecked_unpack(bit_width, chunk, &mut decoded) };
-        builder
-            .values
-            .extend_from_slice(transmute(&decoded[offset..][..length]));
+        uninit.copy_from_init(
+            0,
+            uninit.len(),
+            transmute(&decoded[offset..][..uninit.len()]),
+        );
+
         return Ok(());
     }
 
@@ -324,6 +383,8 @@ where
     let full_chunks_range =
         (first_chunk_is_sliced as usize)..(num_chunks - last_chunk_is_sliced as usize);
 
+    // Index into the builder's uninit values buffer.
+    let mut out_idx = 0;
     if first_chunk_is_sliced {
         let chunk = &packed[..elems_per_chunk];
         let mut decoded = [UnsignedT::zero(); 1024];
@@ -331,28 +392,19 @@ where
         // 1. chunk is elems_per_chunk.
         // 2. decoded is exactly 1024.
         unsafe { BitPacking::unchecked_unpack(bit_width, chunk, &mut decoded) };
-        builder
-            .values
-            .extend_from_slice(transmute(&decoded[offset..]));
+        uninit.copy_from_init(out_idx, 1024 - offset, transmute(&decoded[offset..]));
+        out_idx += 1024 - offset;
     }
     for i in full_chunks_range {
         let chunk = &packed[i * elems_per_chunk..][..elems_per_chunk];
 
-        // SAFETY:
-        //
-        // 1. unchecked_unpack only writes into the output and when it is finished, all the outputs
-        // have been written to.
-        //
-        // 2. The output buffer is exactly size 1024.
         unsafe {
-            builder.values.set_len(builder.values.len() + 1024);
-            BitPacking::unchecked_unpack(
-                bit_width,
-                chunk,
-                &mut transmute_mut(builder.values.deref_mut())
-                    [my_offset_in_builder + i * 1024 - offset..][..1024],
-            );
+            // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout
+            let dst: &mut [T] = std::mem::transmute(&mut uninit[out_idx..][..1024]);
+            let dst: &mut [UnsignedT] = transmute_mut(dst);
+            BitPacking::unchecked_unpack(bit_width, chunk, dst);
         }
+        out_idx += 1024;
     }
     if last_chunk_is_sliced {
         let chunk = &packed[(num_chunks - 1) * elems_per_chunk..][..elems_per_chunk];
@@ -361,9 +413,11 @@ where
         // 1. chunk is elems_per_chunk.
         // 2. decoded is exactly 1024.
         unsafe { BitPacking::unchecked_unpack(bit_width, chunk, &mut decoded) };
-        builder
-            .values
-            .extend_from_slice(transmute(&decoded[..last_chunk_length]));
+        uninit.copy_from_init(
+            out_idx,
+            last_chunk_length,
+            transmute(&decoded[..last_chunk_length]),
+        );
     }
 
     Ok(())
@@ -717,7 +771,7 @@ mod test {
         let mut rng = StdRng::seed_from_u64(0);
 
         let chunks = (0..10)
-            .map(|_| make_array(&mut rng, 100, 0.0, 0.0).unwrap())
+            .map(|_| make_array(&mut rng, 100, 0.25, 0.25).unwrap())
             .collect::<Vec<_>>();
         let chunked = ChunkedArray::from_iter(chunks).into_array();
 

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -261,8 +261,6 @@ where
         transmute_mut,
     )?;
 
-    // uninit.finish();
-
     if let Some(patches) = array.patches() {
         apply_patches(&mut uninit, patches)?;
     };

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -381,16 +381,17 @@ where
         (first_chunk_is_sliced as usize)..(num_chunks - last_chunk_is_sliced as usize);
 
     // Index into the builder's uninit values buffer.
+    const CHUNK_SIZE: usize = 1024;
     let mut out_idx = 0;
     if first_chunk_is_sliced {
         let chunk = &packed[..elems_per_chunk];
-        let mut decoded = [UnsignedT::zero(); 1024];
+        let mut decoded = [UnsignedT::zero(); CHUNK_SIZE];
         // SAFETY:
         // 1. chunk is elems_per_chunk.
         // 2. decoded is exactly 1024.
         unsafe { BitPacking::unchecked_unpack(bit_width, chunk, &mut decoded) };
-        uninit.copy_from_init(out_idx, 1024 - offset, transmute(&decoded[offset..]));
-        out_idx += 1024 - offset;
+        uninit.copy_from_init(out_idx, CHUNK_SIZE - offset, transmute(&decoded[offset..]));
+        out_idx += CHUNK_SIZE - offset;
     }
     for i in full_chunks_range {
         let chunk = &packed[i * elems_per_chunk..][..elems_per_chunk];
@@ -401,11 +402,11 @@ where
             let dst: &mut [UnsignedT] = transmute_mut(dst);
             BitPacking::unchecked_unpack(bit_width, chunk, dst);
         }
-        out_idx += 1024;
+        out_idx += CHUNK_SIZE;
     }
     if last_chunk_is_sliced {
         let chunk = &packed[(num_chunks - 1) * elems_per_chunk..][..elems_per_chunk];
-        let mut decoded = [UnsignedT::zero(); 1024];
+        let mut decoded = [UnsignedT::zero(); CHUNK_SIZE];
         // SAFETY:
         // 1. chunk is elems_per_chunk.
         // 2. decoded is exactly 1024.

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -240,9 +240,8 @@ where
     F: Fn(&[UnsignedT]) -> &[T],
     G: Fn(&mut [T]) -> &mut [UnsignedT],
 {
-    builder
-        .nulls
-        .append_validity(array.validity(), array.len())?;
+    // Append a dense null Mask.
+    builder.append_mask(array.validity_mask()?);
 
     let packed = array.packed_slice::<UnsignedT>();
     let bit_width = array.bit_width() as usize;

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -52,6 +52,29 @@ impl<T: NativePType> PrimitiveBuilder<T> {
     ///
     /// All reads/writes through the handle to the values buffer or the validity buffer will operate
     /// on indices relative to the start of the range.
+    ///
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use std::mem::MaybeUninit;
+    /// use vortex_array::builders::{ArrayBuilder, PrimitiveBuilder};
+    /// use vortex_dtype::Nullability;
+    ///
+    /// // Create a new builder.
+    /// let mut builder: PrimitiveBuilder<i32> = PrimitiveBuilder::with_capacity(Nullability::NonNullable, 5);
+    ///
+    /// // Populate the values in reverse order.
+    /// let mut range = builder.uninit_range(5);
+    /// for i in [4, 3, 2, 1, 0] {
+    ///     range[i] = MaybeUninit::new(i as i32);
+    /// }
+    /// range.finish();
+    ///
+    /// let built = builder.finish_into_primitive();
+    ///
+    /// assert_eq!(built.as_slice::<i32>(), &[0i32, 1, 2, 3, 4]);
+    /// ```
     pub fn uninit_range(&mut self, len: usize) -> UninitRange<T> {
         let offset = self.values.len();
         assert!(
@@ -67,13 +90,17 @@ impl<T: NativePType> PrimitiveBuilder<T> {
     }
 
     pub fn finish_into_primitive(&mut self) -> PrimitiveArray {
-        assert_eq!(
-            self.nulls.len(),
-            self.values.len(),
-            "null count must equal value count"
-        );
+        let nulls = self.nulls.finish();
 
-        let validity = match (self.nulls.finish(), self.dtype().nullability()) {
+        if let Some(null_buf) = nulls.as_ref() {
+            assert_eq!(
+                null_buf.len(),
+                self.values.len(),
+                "null buffer length must equal value buffer length"
+            );
+        }
+
+        let validity = match (nulls, self.dtype().nullability()) {
             (None, Nullability::NonNullable) => Validity::NonNullable,
             (Some(_), Nullability::NonNullable) => {
                 vortex_panic!("Non-nullable builder has null values")
@@ -149,7 +176,6 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
 pub struct UninitRange<'a, T> {
     offset: usize,
     len: usize,
-    // uninit: &'a mut [MaybeUninit<T>],
     builder: &'a mut PrimitiveBuilder<T>,
 }
 

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -14,9 +14,10 @@ use crate::validity::Validity;
 use crate::variants::PrimitiveArrayTrait;
 use crate::{Array, IntoArray, IntoCanonical};
 
+/// Builder for [`PrimitiveArray`].
 pub struct PrimitiveBuilder<T> {
-    pub values: BufferMut<T>,
-    pub nulls: LazyNullBufferBuilder,
+    values: BufferMut<T>,
+    nulls: LazyNullBufferBuilder,
     dtype: DType,
 }
 
@@ -31,6 +32,11 @@ impl<T: NativePType> PrimitiveBuilder<T> {
             nulls: LazyNullBufferBuilder::new(capacity),
             dtype: DType::Primitive(T::PTYPE, nullability),
         }
+    }
+
+    /// Append a `Mask` to the null buffer.
+    pub fn append_mask(&mut self, mask: Mask) {
+        self.nulls.append_validity_mask(mask);
     }
 
     pub fn append_value(&mut self, value: T) {

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -1,20 +1,20 @@
 use std::any::Any;
+use std::mem::MaybeUninit;
+use std::ops::{Deref, DerefMut};
 
-use num_traits::AsPrimitive;
 use vortex_buffer::BufferMut;
-use vortex_dtype::{match_each_unsigned_integer_ptype, DType, NativePType, Nullability};
+use vortex_dtype::{DType, NativePType, Nullability};
 use vortex_error::{vortex_bail, vortex_panic, VortexResult};
 use vortex_mask::Mask;
 
 use crate::arrays::{BoolArray, PrimitiveArray};
 use crate::builders::lazy_validity_builder::LazyNullBufferBuilder;
 use crate::builders::ArrayBuilder;
-use crate::patches::Patches;
 use crate::validity::Validity;
 use crate::variants::PrimitiveArrayTrait;
-use crate::{Array, IntoArray, IntoArrayVariant as _, IntoCanonical};
+use crate::{Array, IntoArray, IntoCanonical};
 
-pub struct PrimitiveBuilder<T: NativePType> {
+pub struct PrimitiveBuilder<T> {
     pub values: BufferMut<T>,
     pub nulls: LazyNullBufferBuilder,
     dtype: DType,
@@ -48,50 +48,22 @@ impl<T: NativePType> PrimitiveBuilder<T> {
         }
     }
 
-    pub fn patch(&mut self, patches: Patches, starting_at: usize) -> VortexResult<()> {
-        let (array_len, indices_offset, indices, values) = patches.into_parts();
-        assert!(starting_at + array_len == self.len());
-        let indices = indices.into_primitive()?;
-        let values = values.into_primitive()?;
-        let validity = values.validity();
-        let values = values.as_slice::<T>();
-        match_each_unsigned_integer_ptype!(indices.ptype(), |$P| {
-            self.insert_values_and_validity_at_indices::<$P>(indices, values, validity, starting_at, indices_offset)
-        })
-    }
+    /// Create a new handle to the next `len` uninitialized values in the builder.
+    ///
+    /// All reads/writes through the handle to the values buffer or the validity buffer will operate
+    /// on indices relative to the start of the range.
+    pub fn uninit_range(&mut self, len: usize) -> UninitRange<T> {
+        let offset = self.values.len();
+        assert!(
+            offset + len <= self.values.capacity(),
+            "uninit_range of len {len} exceeds builder capacity"
+        );
 
-    fn insert_values_and_validity_at_indices<IndexT: NativePType + AsPrimitive<usize>>(
-        &mut self,
-        indices: PrimitiveArray,
-        values: &[T],
-        validity: Validity,
-        starting_at: usize,
-        indices_offset: usize,
-    ) -> VortexResult<()> {
-        match validity {
-            Validity::NonNullable => {
-                for (compressed_index, decompressed_index) in
-                    indices.as_slice::<IndexT>().iter().enumerate()
-                {
-                    let decompressed_index = decompressed_index.as_();
-                    let out_index = starting_at + decompressed_index - indices_offset;
-                    self.values[out_index] = values[compressed_index];
-                }
-            }
-            _ => {
-                let validity = validity.to_logical(indices.len())?;
-                for (compressed_index, decompressed_index) in
-                    indices.as_slice::<IndexT>().iter().enumerate()
-                {
-                    let decompressed_index = decompressed_index.as_();
-                    let out_index = starting_at + decompressed_index - indices_offset;
-                    self.values[out_index] = values[compressed_index];
-                    self.nulls.set_bit(out_index, validity.value(out_index));
-                }
-            }
+        UninitRange {
+            offset,
+            len,
+            builder: self,
         }
-
-        Ok(())
     }
 
     pub fn finish_into_primitive(&mut self) -> PrimitiveArray {
@@ -171,5 +143,62 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
 
     fn finish(&mut self) -> Array {
         self.finish_into_primitive().into_array()
+    }
+}
+
+pub struct UninitRange<'a, T> {
+    offset: usize,
+    len: usize,
+    // uninit: &'a mut [MaybeUninit<T>],
+    builder: &'a mut PrimitiveBuilder<T>,
+}
+
+impl<T> Deref for UninitRange<'_, T> {
+    type Target = [MaybeUninit<T>];
+
+    fn deref(&self) -> &[MaybeUninit<T>] {
+        let start = self.builder.values.as_ptr();
+        unsafe {
+            // SAFETY: start + len is checked on construction to be in range.
+            let dst = std::slice::from_raw_parts(start, self.len);
+
+            // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout
+            let dst: &[MaybeUninit<T>] = std::mem::transmute(dst);
+
+            dst
+        }
+    }
+}
+
+impl<T> DerefMut for UninitRange<'_, T> {
+    fn deref_mut(&mut self) -> &mut [MaybeUninit<T>] {
+        &mut self.builder.values.spare_capacity_mut()[..self.len]
+    }
+}
+
+impl<T> UninitRange<'_, T> {
+    /// Set a validity bit at the given index. The index is relative to the start of this range
+    /// of the builder.
+    pub fn set_bit(&mut self, index: usize, v: bool) {
+        self.builder.nulls.set_bit(self.offset + index, v);
+    }
+
+    /// Set values from an initialized range.
+    pub fn copy_from_init(&mut self, offset: usize, len: usize, src: &[T])
+    where
+        T: Copy,
+    {
+        // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout
+        let uninit_src: &[MaybeUninit<T>] = unsafe { std::mem::transmute(src) };
+
+        let dst = &mut self[offset..][..len];
+        dst.copy_from_slice(uninit_src);
+    }
+
+    /// Finish building this range, marking it as initialized and advancing the length of the
+    /// underlying values buffer.
+    pub fn finish(self) {
+        // SAFETY: constructor enforces that offset + len does not exceed the capacity of the array.
+        unsafe { self.builder.values.set_len(self.offset + self.len) };
     }
 }


### PR DESCRIPTION
The PrimitiveBuilder currently exposes its internal components as `pub`. This puts the onus of handling the state of the null buffer and values buffers on the client.

The PrimitiveBuilder is built around append-only access to values and buffers. But for several array variants, random access is better suited. For example, unpacking FastLanes vectors, or scattering the patches of a SpareArray.

This PR removes `values` and `nulls` from the public API for the PrimitiveBuilder, and replaces it with an `uninit_range(len: usize)` method. This returns a mutable handle that provides scoped access to the nulls and the values. For simplicity, it impls Deref/DerefMut to `&[MaybeUninit<T>]` to make random access of values easy and also gives direct access to nice std::slice methods like `fill` or `copy_from_slice`.

The returned handle has a `finish(self)` method which should be called after value initialization, and will advance the internal buffer length to finish a chunk.

As an example of usage:

```
    let mut builder: PrimitiveBuilder<i32> = PrimitiveBuilder::with_capacity(Nullability::NonNullable, 5);
    
	// Get a range. In this case it's the full range but it can be a partial range.
    let mut range = builder.uninit_range(5);

	// Populate the uninitialized range in reverse order.
    // Even indices will store values, odd indices will be NULLs.
    for i in [4, 3, 2, 1, 0] {
        range[i] = MaybeUninit::new(i as i32);
    }
    range.finish();
```

You can also copy into the output from an already initialized set of values:

```
range.copy_from_init(0, 3, &[1,2,3]);
```