### PR TITLE
Safer tokio task executor

### DIFF
--- a/vortex-layout/Cargo.toml
+++ b/vortex-layout/Cargo.toml
@@ -29,16 +29,19 @@ pin-project-lite = { workspace = true }
 vortex-array = { workspace = true }
 vortex-buffer = { workspace = true }
 vortex-dtype = { workspace = true }
-vortex-error = { workspace = true, features = ["tokio"] }
+vortex-error = { workspace = true }
 vortex-expr = { workspace = true }
 vortex-flatbuffers = { workspace = true, features = ["layout"] }
 vortex-mask = { workspace = true }
 vortex-scalar = { workspace = true }
-tokio = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["sync"], optional = true }
 
 [dev-dependencies]
 futures = { workspace = true, features = ["executor"] }
 rstest = { workspace = true }
+
+[features]
+tokio = ["dep:tokio", "vortex-error/tokio"]
 
 [lints]
 workspace = true

--- a/vortex-layout/src/scan/executor/threads.rs
+++ b/vortex-layout/src/scan/executor/threads.rs
@@ -10,10 +10,6 @@ use vortex_error::{vortex_err, VortexResult, VortexUnwrap};
 
 use super::Executor;
 
-trait Task {
-    fn run(self: Box<Self>);
-}
-
 struct ExecutorTask<F, R> {
     task: F,
     result: oneshot::Sender<R>,
@@ -59,6 +55,10 @@ impl Default for Inner {
         // 1 isn't 0
         Self::new(unsafe { NonZeroUsize::new_unchecked(1) })
     }
+}
+
+trait Task {
+    fn run(self: Box<Self>);
 }
 
 impl Inner {

--- a/vortex-layout/src/scan/executor/threads.rs
+++ b/vortex-layout/src/scan/executor/threads.rs
@@ -10,6 +10,10 @@ use vortex_error::{vortex_err, VortexResult, VortexUnwrap};
 
 use super::Executor;
 
+trait Task {
+    fn run(self: Box<Self>);
+}
+
 struct ExecutorTask<F, R> {
     task: F,
     result: oneshot::Sender<R>,
@@ -55,10 +59,6 @@ impl Default for Inner {
         // 1 isn't 0
         Self::new(unsafe { NonZeroUsize::new_unchecked(1) })
     }
-}
-
-trait Task {
-    fn run(self: Box<Self>);
 }
 
 impl Inner {

--- a/vortex-layout/src/scan/executor/tokio.rs
+++ b/vortex-layout/src/scan/executor/tokio.rs
@@ -1,19 +1,37 @@
 use std::future::Future;
+use std::sync::{Arc, Mutex};
 
 use futures::future::BoxFuture;
 use futures::{FutureExt, TryFutureExt};
 use tokio::runtime::Handle;
-use vortex_error::{VortexError, VortexResult};
+use tokio::sync::oneshot;
+use tokio::task::JoinSet;
+use vortex_error::{vortex_err, VortexExpect, VortexResult};
 
 use super::Executor;
 
 /// Tokio-based async task executor, runs task on the provided runtime.
 #[derive(Clone)]
-pub struct TokioExecutor(Handle);
+pub struct TokioExecutor {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    handle: Handle,
+    // We use a joinset here so when the executor is dropped, it'll abort all running tasks
+    join_set: Mutex<JoinSet<()>>,
+}
 
 impl TokioExecutor {
     pub fn new(handle: Handle) -> Self {
-        Self(handle)
+        let inner = Inner {
+            handle,
+            join_set: Mutex::new(JoinSet::new()),
+        };
+
+        Self {
+            inner: Arc::new(inner),
+        }
     }
 }
 
@@ -24,6 +42,19 @@ impl Executor for TokioExecutor {
         F: Future + Send + 'static,
         <F as Future>::Output: Send + 'static,
     {
-        self.0.spawn(f).map_err(VortexError::from).boxed()
+        let (tx, rx) = oneshot::channel();
+        let f = async move {
+            let r = f.await;
+            _ = tx.send(r);
+        };
+
+        self.inner
+            .join_set
+            .lock()
+            .vortex_expect("poisoned lock")
+            .spawn_on(f, &self.inner.handle);
+
+        rx.map_err(|e| vortex_err!("Task sender dropped: {e}"))
+            .boxed()
     }
 }


### PR DESCRIPTION
Just making sure all tasks are aborted when the executor is dropped (like in the case of an aborted stream).