### PR TITLE
bench: drop flaky buffer push benchmark parameter

### DIFF
--- a/vortex-buffer/benches/vortex_buffer.rs
+++ b/vortex-buffer/benches/vortex_buffer.rs
@@ -83,7 +83,7 @@ fn map_each<B: MapEach<i32, u32> + FromIterator<i32>>(bencher: Bencher, n: i32) 
         .bench_local_values(|buffer| B::map_each(buffer, |i| (i as u32) + 1));
 }
 
-#[divan::bench(args = [1, 100, 1_000, 10_000, 100_000, 1_000_000])]
+#[divan::bench(args = [100, 1_000, 10_000, 100_000, 1_000_000])]
 fn push_vortex_buffer(bencher: Bencher, length: i32) {
     bencher
         .with_inputs(|| BufferMut::<i32>::with_capacity(length as usize))
@@ -94,7 +94,7 @@ fn push_vortex_buffer(bencher: Bencher, length: i32) {
         });
 }
 
-#[divan::bench(args = [1, 100, 1_000, 10_000, 100_000, 1_000_000])]
+#[divan::bench(args = [100, 1_000, 10_000, 100_000, 1_000_000])]
 fn push_arrow_buffer(bencher: Bencher, length: i32) {
     bencher
         .with_inputs(|| {


### PR DESCRIPTION
Benchmarking a single `push` on buffers yields flaky performance benchmarks which adds noise to Codspeed reports.