### PR TITLE
bench: divan runs single threaded by default

### DIFF
--- a/encodings/alp/benches/alp_compress.rs
+++ b/encodings/alp/benches/alp_compress.rs
@@ -83,14 +83,14 @@ fn decompress_alp<T: ALPFloat + NativePType>(bencher: Bencher, args: (usize, f64
     let array = alp_encode(&PrimitiveArray::new(values, validity)).unwrap();
     bencher
         .with_inputs(|| array.clone())
-        .bench_local_values(|array| array.into_canonical().unwrap());
+        .bench_values(|array| array.into_canonical().unwrap());
 }
 
 #[divan::bench(types = [f32, f64], args = [10_000, 100_000])]
 fn compress_rd<T: ALPRDFloat>(bencher: Bencher, n: usize) {
     let primitive = PrimitiveArray::new(buffer![T::from(1.23).unwrap(); n], Validity::NonNullable);
     let encoder = RDEncoder::new(&[T::from(1.23).unwrap()]);
-    bencher.bench_local(|| encoder.encode(&primitive));
+    bencher.bench(|| encoder.encode(&primitive));
 }
 
 #[divan::bench(types = [f32, f64], args = [10_000, 100_000])]
@@ -101,5 +101,5 @@ fn decompress_rd<T: ALPRDFloat>(bencher: Bencher, n: usize) {
 
     bencher
         .with_inputs(move || encoded.clone())
-        .bench_local_values(|encoded| encoded.into_canonical().unwrap());
+        .bench_values(|encoded| encoded.into_canonical().unwrap());
 }

--- a/encodings/dict/benches/chunked_dict_array_builder.rs
+++ b/encodings/dict/benches/chunked_dict_array_builder.rs
@@ -29,13 +29,11 @@ fn chunked_dict_primitive_canonical_into<T: NativePType>(
 {
     let chunk = gen_dict_primitive_chunks::<T, u16>(len, unique_values, chunk_count);
 
-    bencher
-        .with_inputs(|| chunk.clone())
-        .bench_local_values(|chunk| {
-            let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
-            chunk.canonicalize_into(builder.as_mut()).vortex_unwrap();
-            builder.finish()
-        })
+    bencher.with_inputs(|| chunk.clone()).bench_values(|chunk| {
+        let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
+        chunk.canonicalize_into(builder.as_mut()).vortex_unwrap();
+        builder.finish()
+    })
 }
 
 #[divan::bench(types = [u32, u64, f32, f64], args = BENCH_ARGS)]
@@ -49,7 +47,7 @@ fn chunked_dict_primitive_into_canonical<T: NativePType>(
 
     bencher
         .with_inputs(|| chunk.clone())
-        .bench_local_values(|chunk| chunk.into_canonical().vortex_unwrap())
+        .bench_values(|chunk| chunk.into_canonical().vortex_unwrap())
 }
 
 fn make_dict_fsst_chunks<T: NativePType>(
@@ -70,13 +68,11 @@ fn chunked_dict_fsst_canonical_into(
 ) {
     let chunk = make_dict_fsst_chunks::<u16>(len, unique_values, chunk_count);
 
-    bencher
-        .with_inputs(|| chunk.clone())
-        .bench_local_values(|chunk| {
-            let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
-            chunk.canonicalize_into(builder.as_mut()).vortex_unwrap();
-            builder.finish()
-        })
+    bencher.with_inputs(|| chunk.clone()).bench_values(|chunk| {
+        let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
+        chunk.canonicalize_into(builder.as_mut()).vortex_unwrap();
+        builder.finish()
+    })
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -88,5 +84,5 @@ fn chunked_dict_fsst_into_canonical(
 
     bencher
         .with_inputs(|| chunk.clone())
-        .bench_local_values(|chunk| chunk.into_canonical().vortex_unwrap())
+        .bench_values(|chunk| chunk.into_canonical().vortex_unwrap())
 }

--- a/encodings/dict/benches/dict_compare.rs
+++ b/encodings/dict/benches/dict_compare.rs
@@ -38,9 +38,7 @@ fn bench_compare_primitive(bencher: divan::Bencher, (len, uniqueness): (usize, u
 
     bencher
         .with_inputs(|| dict.clone())
-        .bench_local_refs(|dict| {
-            compare(dict, ConstantArray::new(value, len), Operator::Eq).unwrap()
-        })
+        .bench_refs(|dict| compare(dict, ConstantArray::new(value, len), Operator::Eq).unwrap())
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -54,9 +52,7 @@ fn bench_compare_varbin(bencher: divan::Bencher, (len, uniqueness): (usize, usiz
 
     bencher
         .with_inputs(|| dict.clone())
-        .bench_local_refs(|dict| {
-            compare(dict, ConstantArray::new(value, len), Operator::Eq).unwrap()
-        })
+        .bench_refs(|dict| compare(dict, ConstantArray::new(value, len), Operator::Eq).unwrap())
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -69,7 +65,5 @@ fn bench_compare_varbinview(bencher: divan::Bencher, (len, uniqueness): (usize, 
     let value = from_utf8(bytes.as_slice()).unwrap();
     bencher
         .with_inputs(|| dict.clone())
-        .bench_local_refs(|dict| {
-            compare(dict, ConstantArray::new(value, len), Operator::Eq).unwrap()
-        })
+        .bench_refs(|dict| compare(dict, ConstantArray::new(value, len), Operator::Eq).unwrap())
 }

--- a/encodings/fastlanes/benches/bitpacking_decompress_selection.rs
+++ b/encodings/fastlanes/benches/bitpacking_decompress_selection.rs
@@ -39,7 +39,7 @@ fn decompress_bitpacking_early_filter<T: NativePType>(bencher: Bencher, fraction
         .collect::<BooleanBuffer>();
     let mask = &Mask::from_buffer(mask);
 
-    bencher.bench_local(|| filter(array, mask).unwrap().into_canonical().unwrap());
+    bencher.bench(|| filter(array, mask).unwrap().into_canonical().unwrap());
 }
 
 // #[divan::bench(types = [i8, i16, i32, i64], args = [0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999])]
@@ -63,7 +63,5 @@ fn decompress_bitpacking_late_filter<T: NativePType>(bencher: Bencher, fraction_
 
     bencher
         .with_inputs(|| array.clone())
-        .bench_local_values(|array| {
-            filter(array.into_canonical().unwrap().as_ref(), mask).unwrap()
-        });
+        .bench_values(|array| filter(array.into_canonical().unwrap().as_ref(), mask).unwrap());
 }

--- a/encodings/fastlanes/benches/compute_between.rs
+++ b/encodings/fastlanes/benches/compute_between.rs
@@ -73,16 +73,14 @@ where
     let mut rng = StdRng::seed_from_u64(0);
     let arr = generate_primitive_array::<T>(&mut rng, len);
 
-    bencher
-        .with_inputs(|| arr.clone())
-        .bench_local_values(|arr| {
-            binary_boolean(
-                &compare(&arr, ConstantArray::new(min, arr.len()), Operator::Gte).vortex_expect(""),
-                &compare(&arr, ConstantArray::new(max, arr.len()), Operator::Lt).vortex_expect(""),
-                BinaryOperator::And,
-            )
-            .vortex_expect("")
-        })
+    bencher.with_inputs(|| arr.clone()).bench_values(|arr| {
+        binary_boolean(
+            &compare(&arr, ConstantArray::new(min, arr.len()), Operator::Gte).vortex_expect(""),
+            &compare(&arr, ConstantArray::new(max, arr.len()), Operator::Lt).vortex_expect(""),
+            BinaryOperator::And,
+        )
+        .vortex_expect("")
+    })
 }
 
 #[divan::bench(
@@ -99,20 +97,18 @@ where
     let mut rng = StdRng::seed_from_u64(0);
     let arr = generate_primitive_array::<T>(&mut rng, len);
 
-    bencher
-        .with_inputs(|| arr.clone())
-        .bench_local_values(|arr| {
-            between(
-                &arr,
-                ConstantArray::new(min, arr.len()),
-                ConstantArray::new(max, arr.len()),
-                &BetweenOptions {
-                    lower_strict: NonStrict,
-                    upper_strict: NonStrict,
-                },
-            )
-            .vortex_expect("")
-        })
+    bencher.with_inputs(|| arr.clone()).bench_values(|arr| {
+        between(
+            &arr,
+            ConstantArray::new(min, arr.len()),
+            ConstantArray::new(max, arr.len()),
+            &BetweenOptions {
+                lower_strict: NonStrict,
+                upper_strict: NonStrict,
+            },
+        )
+        .vortex_expect("")
+    })
 }
 
 #[divan::bench(
@@ -129,15 +125,13 @@ where
     let mut rng = StdRng::seed_from_u64(0);
     let arr = generate_bit_pack_primitive_array::<T>(&mut rng, len);
 
-    bencher
-        .with_inputs(|| arr.clone())
-        .bench_local_values(|arr| {
-            binary_boolean(
-                &compare(&arr, ConstantArray::new(min, arr.len()), Operator::Gte).vortex_expect(""),
-                &compare(&arr, ConstantArray::new(max, arr.len()), Operator::Lt).vortex_expect(""),
-                BinaryOperator::And,
-            )
-        })
+    bencher.with_inputs(|| arr.clone()).bench_values(|arr| {
+        binary_boolean(
+            &compare(&arr, ConstantArray::new(min, arr.len()), Operator::Gte).vortex_expect(""),
+            &compare(&arr, ConstantArray::new(max, arr.len()), Operator::Lt).vortex_expect(""),
+            BinaryOperator::And,
+        )
+    })
 }
 
 #[divan::bench(
@@ -154,19 +148,17 @@ where
     let mut rng = StdRng::seed_from_u64(0);
     let arr = generate_bit_pack_primitive_array::<T>(&mut rng, len);
 
-    bencher
-        .with_inputs(|| arr.clone())
-        .bench_local_values(|arr| {
-            between(
-                &arr,
-                ConstantArray::new(min, arr.len()),
-                ConstantArray::new(max, arr.len()),
-                &BetweenOptions {
-                    lower_strict: NonStrict,
-                    upper_strict: NonStrict,
-                },
-            )
-        })
+    bencher.with_inputs(|| arr.clone()).bench_values(|arr| {
+        between(
+            &arr,
+            ConstantArray::new(min, arr.len()),
+            ConstantArray::new(max, arr.len()),
+            &BetweenOptions {
+                lower_strict: NonStrict,
+                upper_strict: NonStrict,
+            },
+        )
+    })
 }
 
 #[divan::bench(
@@ -183,15 +175,13 @@ where
     let mut rng = StdRng::seed_from_u64(0);
     let arr = generate_alp_bit_pack_primitive_array::<T>(&mut rng, len);
 
-    bencher
-        .with_inputs(|| arr.clone())
-        .bench_local_values(|arr| {
-            binary_boolean(
-                &compare(&arr, ConstantArray::new(min, arr.len()), Operator::Gte).vortex_expect(""),
-                &compare(&arr, ConstantArray::new(max, arr.len()), Operator::Lt).vortex_expect(""),
-                BinaryOperator::And,
-            )
-        })
+    bencher.with_inputs(|| arr.clone()).bench_values(|arr| {
+        binary_boolean(
+            &compare(&arr, ConstantArray::new(min, arr.len()), Operator::Gte).vortex_expect(""),
+            &compare(&arr, ConstantArray::new(max, arr.len()), Operator::Lt).vortex_expect(""),
+            BinaryOperator::And,
+        )
+    })
 }
 
 #[divan::bench(
@@ -208,17 +198,15 @@ where
     let mut rng = StdRng::seed_from_u64(0);
     let arr = generate_alp_bit_pack_primitive_array::<T>(&mut rng, len);
 
-    bencher
-        .with_inputs(|| arr.clone())
-        .bench_local_values(|arr| {
-            between(
-                &arr,
-                ConstantArray::new(min, arr.len()),
-                ConstantArray::new(max, arr.len()),
-                &BetweenOptions {
-                    lower_strict: NonStrict,
-                    upper_strict: NonStrict,
-                },
-            )
-        })
+    bencher.with_inputs(|| arr.clone()).bench_values(|arr| {
+        between(
+            &arr,
+            ConstantArray::new(min, arr.len()),
+            ConstantArray::new(max, arr.len()),
+            &BetweenOptions {
+                lower_strict: NonStrict,
+                upper_strict: NonStrict,
+            },
+        )
+    })
 }

--- a/vortex-array/benches/chunk_array_builder.rs
+++ b/vortex-array/benches/chunk_array_builder.rs
@@ -22,29 +22,25 @@ const BENCH_ARGS: &[(usize, usize)] = &[
 fn chunked_bool_canonical_into(bencher: Bencher, (len, chunk_count): (usize, usize)) {
     let chunk = make_bool_chunks(len, chunk_count);
 
-    bencher
-        .with_inputs(|| chunk.clone())
-        .bench_local_values(|chunk| {
-            let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
-            chunk.canonicalize_into(builder.as_mut()).vortex_unwrap();
-            builder.finish()
-        })
+    bencher.with_inputs(|| chunk.clone()).bench_values(|chunk| {
+        let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
+        chunk.canonicalize_into(builder.as_mut()).vortex_unwrap();
+        builder.finish()
+    })
 }
 
 #[divan::bench(args = BENCH_ARGS)]
 fn chunked_opt_bool_canonical_into(bencher: Bencher, (len, chunk_count): (usize, usize)) {
     let chunk = make_opt_bool_chunks(len, chunk_count);
 
-    bencher
-        .with_inputs(|| chunk.clone())
-        .bench_local_values(|chunk| {
-            let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
-            chunk
-                .clone()
-                .canonicalize_into(builder.as_mut())
-                .vortex_unwrap();
-            builder.finish()
-        })
+    bencher.with_inputs(|| chunk.clone()).bench_values(|chunk| {
+        let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
+        chunk
+            .clone()
+            .canonicalize_into(builder.as_mut())
+            .vortex_unwrap();
+        builder.finish()
+    })
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -53,7 +49,7 @@ fn chunked_bool_into_canonical(bencher: Bencher, (len, chunk_count): (usize, usi
 
     bencher
         .with_inputs(|| chunk.clone())
-        .bench_local_values(|chunk| chunk.into_canonical())
+        .bench_values(|chunk| chunk.into_canonical())
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -62,7 +58,7 @@ fn chunked_opt_bool_into_canonical(bencher: Bencher, (len, chunk_count): (usize,
 
     bencher
         .with_inputs(|| chunk.clone())
-        .bench_local_values(|chunk| chunk.into_canonical())
+        .bench_values(|chunk| chunk.into_canonical())
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -71,7 +67,7 @@ fn chunked_varbinview_canonical_into(bencher: Bencher, (len, chunk_count): (usiz
 
     bencher
         .with_inputs(|| chunks.clone())
-        .bench_local_values(|chunk| {
+        .bench_values(|chunk| {
             let mut builder = VarBinViewBuilder::with_capacity(
                 DType::Utf8(chunk.dtype().nullability()),
                 len * chunk_count,
@@ -87,7 +83,7 @@ fn chunked_varbinview_into_canonical(bencher: Bencher, (len, chunk_count): (usiz
 
     bencher
         .with_inputs(|| chunks.clone())
-        .bench_local_values(|chunk| chunk.into_canonical())
+        .bench_values(|chunk| chunk.into_canonical())
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -96,7 +92,7 @@ fn chunked_varbinview_opt_canonical_into(bencher: Bencher, (len, chunk_count): (
 
     bencher
         .with_inputs(|| chunks.clone())
-        .bench_local_values(|chunk| {
+        .bench_values(|chunk| {
             let mut builder = VarBinViewBuilder::with_capacity(
                 DType::Utf8(chunk.dtype().nullability()),
                 len * chunk_count,
@@ -112,7 +108,7 @@ fn chunked_varbinview_opt_into_canonical(bencher: Bencher, (len, chunk_count): (
 
     bencher
         .with_inputs(|| chunks.clone())
-        .bench_local_values(|chunk| chunk.into_canonical())
+        .bench_values(|chunk| chunk.into_canonical())
 }
 
 fn make_opt_bool_chunks(len: usize, chunk_count: usize) -> Array {

--- a/vortex-btrblocks/benches/compress.rs
+++ b/vortex-btrblocks/benches/compress.rs
@@ -39,7 +39,7 @@ mod benchmarks {
             .with_inputs(|| make_clickbench_window_name().into_primitive().unwrap())
             .input_counter(|array| ItemsCount::new(array.len()))
             .input_counter(|array| BytesCount::of_many::<i32>(array.len()))
-            .bench_local_values(|array| IntCompressor::compress(&array, false, 3, &[]).unwrap());
+            .bench_values(|array| IntCompressor::compress(&array, false, 3, &[]).unwrap());
     }
 
     #[divan::bench]
@@ -49,7 +49,7 @@ mod benchmarks {
             .with_inputs(make_clickbench_window_name)
             .input_counter(|array| ItemsCount::new(array.len()))
             .input_counter(|array| BytesCount::of_many::<i32>(array.len()))
-            .bench_local_values(|array| compressor.compress(&array, None).unwrap());
+            .bench_values(|array| compressor.compress(&array, None).unwrap());
     }
 }
 

--- a/vortex-btrblocks/benches/dict_encode.rs
+++ b/vortex-btrblocks/benches/dict_encode.rs
@@ -28,14 +28,14 @@ fn make_array() -> PrimitiveArray {
 fn encode_generic(bencher: Bencher) {
     bencher
         .with_inputs(|| make_array().into_array())
-        .bench_local_values(|array| dict_encode(&array).unwrap());
+        .bench_values(|array| dict_encode(&array).unwrap());
 }
 
 #[divan::bench]
 fn encode_specialized(bencher: Bencher) {
     bencher
         .with_inputs(|| IntegerStats::generate(&make_array()))
-        .bench_local_values(|stats| dictionary_encode(&stats).unwrap());
+        .bench_values(|stats| dictionary_encode(&stats).unwrap());
 }
 
 fn main() {

--- a/vortex-buffer/benches/vortex_buffer.rs
+++ b/vortex-buffer/benches/vortex_buffer.rs
@@ -80,14 +80,14 @@ impl<T: Copy, R> MapEach<T, R> for BufferMut<T> {
 fn map_each<B: MapEach<i32, u32> + FromIterator<i32>>(bencher: Bencher, n: i32) {
     bencher
         .with_inputs(|| B::from_iter((0..n).map(|i| i % i32::MAX)))
-        .bench_local_values(|buffer| B::map_each(buffer, |i| (i as u32) + 1));
+        .bench_values(|buffer| B::map_each(buffer, |i| (i as u32) + 1));
 }
 
 #[divan::bench(args = [100, 1_000, 10_000, 100_000, 1_000_000])]
 fn push_vortex_buffer(bencher: Bencher, length: i32) {
     bencher
         .with_inputs(|| BufferMut::<i32>::with_capacity(length as usize))
-        .bench_local_refs(|buffer| {
+        .bench_refs(|buffer| {
             for idx in 0..length {
                 buffer.push(divan::black_box(idx));
             }
@@ -102,7 +102,7 @@ fn push_arrow_buffer(bencher: Bencher, length: i32) {
                 length as usize * size_of::<i32>(),
             ))
         })
-        .bench_local_refs(|buffer| {
+        .bench_refs(|buffer| {
             for idx in 0..length {
                 buffer.0.push(divan::black_box(idx));
             }


### PR DESCRIPTION
Therefore, we don't need to explicitly use the `_local` variants. 

Multithreaded benchmark runs can be enabled via:
- attribute: `#[divan::bench(threads = 4)]`
- command line: `--threads 4`
- environment variable: `DIVAN_THREADS=4`

Default init for Divan is set here: https://github.com/nvzqz/divan/blob/main/src/divan.rs#L274 where `NonZeroUsize::MIN` = 1.