### PR TITLE
ci: ignore ring advisory in cargo-deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,7 +11,8 @@ feature-depth = 1
 
 
 [advisories]
-ignore = []
+# ring is unmaintained: https://github.com/briansmith/ring/discussions/2414
+ignore = ["RUSTSEC-2025-0007"]
 
 [licenses]
 # List of explicitly allowed licenses


### PR DESCRIPTION
ring is brought in via reqwest as its rustls cipher provider, the maintainer is walking away (see https://github.com/briansmith/ring/discussions/2414)