### PR TITLE
chore: remove b16 from list of supported dtypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The Vortex type-system is still in flux. The current set of logical types is:
 * Null
 * Bool
 * Integer(8, 16, 32, 64)
-* Float(16, b16, 32, 64)
+* Float(16, 32, 64)
 * Binary
 * UTF8
 * Struct


### PR DESCRIPTION
AFAIK, we do not have support for bfloat16, but we do support IEEE754 binary16.