### PR TITLE
Do not include sum in empty stats

### DIFF
--- a/vortex-array/src/stats/stats_set.rs
+++ b/vortex-array/src/stats/stats_set.rs
@@ -66,7 +66,6 @@ impl StatsSet {
     // A convenience method for creating a stats set which will represent an empty array.
     pub fn empty_array() -> StatsSet {
         StatsSet::new_unchecked(vec![
-            (Stat::Sum, Precision::exact(0)),
             (Stat::RunCount, Precision::exact(0)),
             (Stat::NullCount, Precision::exact(0)),
         ])


### PR DESCRIPTION
This doesn't make sense for arrays that don't support sum, and also breaks for float arrays since we store an integer value.