### PR TITLE
chore: fix release-plz by updating uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1408,7 +1408,7 @@ wheels = [
 
 [[package]]
 name = "vortex-array"
-version = "0.23.0"
+version = "0.24.0"
 source = { editable = "pyvortex" }
 dependencies = [
     { name = "pyarrow" },


### PR DESCRIPTION
I ran `# uv sync --all-extras --dev -v`.

It seems sensible that the uv.lock file would need to have the same version of vortex-array as our python package's version, but I'm not sure why it started failing after #2459 merged. That PR didn't change the version of the Python library.

https://github.com/spiraldb/vortex/actions/workflows/release-plz.yml