### PR TITLE
Fix release-plz and lock uv version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ packages = ["dummy"] # Required for workspace project
 
 [tool.uv]
 managed = true
-required-version = ">=0.5.25"
+required-version = ">=0.5.0"
 # Currently, all dev dependencies live in the root since uv doesn't have transitive dev dependencies.
 #  See: https://github.com/astral-sh/uv/issues/7541
 dev-dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,7 @@ version = "0.1.0"
 description = "Add your description here"
 authors = [{ name = "Nicholas Gates", email = "nick@nickgates.com" }]
 requires-python = ">= 3.10"
-dependencies = [
-    "vortex-array",
-    "docs",
-]
+dependencies = ["vortex-array", "docs"]
 
 [build-system]
 requires = ["hatchling"]
@@ -18,6 +15,7 @@ packages = ["dummy"] # Required for workspace project
 
 [tool.uv]
 managed = true
+required-version = ">=0.5.25"
 # Currently, all dev dependencies live in the root since uv doesn't have transitive dev dependencies.
 #  See: https://github.com/astral-sh/uv/issues/7541
 dev-dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1408,7 +1408,6 @@ wheels = [
 
 [[package]]
 name = "vortex-array"
-version = "0.24.0"
 source = { editable = "pyvortex" }
 dependencies = [
     { name = "pyarrow" },


### PR DESCRIPTION
This is the same issue as #2188. We use uv 0.5 in CI, and now it shouldn't be possible to use older version locally.