### PR TITLE
Write for reference to metadata

### DIFF
--- a/encodings/fastlanes/src/for/mod.rs
+++ b/encodings/fastlanes/src/for/mod.rs
@@ -7,12 +7,14 @@ use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::vtable::{StatisticsVTable, VTableRef};
 use vortex_array::{
     Array, ArrayCanonicalImpl, ArrayImpl, ArrayRef, ArrayStatisticsImpl, ArrayValidityImpl,
-    ArrayVariantsImpl, Canonical, EmptyMetadata, Encoding, EncodingId, encoding_ids,
+    ArrayVariantsImpl, Canonical, Encoding, EncodingId, encoding_ids,
 };
 use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_bail};
 use vortex_mask::Mask;
 use vortex_scalar::Scalar;
+
+use crate::r#for::serde::ScalarValueMetadata;
 
 mod compress;
 mod compute;
@@ -29,7 +31,7 @@ pub struct FoREncoding;
 impl Encoding for FoREncoding {
     const ID: EncodingId = EncodingId::new("fastlanes.for", encoding_ids::FL_FOR);
     type Array = FoRArray;
-    type Metadata = EmptyMetadata;
+    type Metadata = ScalarValueMetadata;
 }
 
 impl FoRArray {

--- a/encodings/fastlanes/src/for/serde.rs
+++ b/encodings/fastlanes/src/for/serde.rs
@@ -1,27 +1,24 @@
+use std::fmt::Formatter;
+
 use vortex_array::serde::ArrayParts;
 use vortex_array::vtable::SerdeVTable;
 use vortex_array::{
-    Array, ArrayBufferVisitor, ArrayChildVisitor, ArrayRef, ArrayVisitorImpl, ContextRef,
-    EmptyMetadata,
+    Array, ArrayChildVisitor, ArrayRef, ArrayVisitorImpl, ContextRef, DeserializeMetadata,
+    SerializeMetadata,
 };
 use vortex_dtype::{DType, PType};
-use vortex_error::{VortexResult, vortex_bail};
+use vortex_error::{VortexResult, vortex_bail, vortex_err};
 use vortex_scalar::{Scalar, ScalarValue};
 
 use crate::{FoRArray, FoREncoding};
 
-impl ArrayVisitorImpl for FoRArray {
-    fn _buffers(&self, visitor: &mut dyn ArrayBufferVisitor) {
-        let pvalue = self.reference_scalar().value().to_flexbytes();
-        visitor.visit_buffer(pvalue.as_ref());
-    }
-
+impl ArrayVisitorImpl<ScalarValueMetadata> for FoRArray {
     fn _children(&self, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("encoded", self.encoded())
     }
 
-    fn _metadata(&self) -> EmptyMetadata {
-        EmptyMetadata
+    fn _metadata(&self) -> ScalarValueMetadata {
+        ScalarValueMetadata(self.reference_scalar().value().clone())
     }
 }
 
@@ -44,11 +41,38 @@ impl SerdeVTable<&FoRArray> for FoREncoding {
         let encoded_dtype = DType::Primitive(ptype.to_unsigned(), dtype.nullability());
         let encoded = parts.child(0).decode(ctx, encoded_dtype, len)?;
 
-        if parts.nbuffers() != 1 {
-            vortex_bail!("Expected 1 buffers, got {}", parts.nbuffers());
-        }
-        let reference = Scalar::new(dtype, ScalarValue::from_flexbytes(&parts.buffer(0)?)?);
+        let reference = ScalarValue::from_flexbytes(
+            parts
+                .metadata()
+                .ok_or_else(|| vortex_err!("Missing FoR metadata"))?,
+        )?;
+        let reference = Scalar::new(dtype, reference);
 
         Ok(FoRArray::try_new(encoded, reference)?.into_array())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ScalarValueMetadata(ScalarValue);
+
+impl SerializeMetadata for ScalarValueMetadata {
+    fn serialize(&self) -> Option<Vec<u8>> {
+        Some(self.0.to_flexbytes())
+    }
+}
+
+impl DeserializeMetadata for ScalarValueMetadata {
+    type Output = ScalarValue;
+
+    fn deserialize(metadata: Option<&[u8]>) -> VortexResult<Self::Output> {
+        ScalarValue::from_flexbytes(
+            metadata.ok_or_else(|| vortex_err!("Missing ScalarValue metadata"))?,
+        )
+    }
+
+    fn format(metadata: Option<&[u8]>, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Self::deserialize(metadata)
+            .map(|value| write!(f, "{:?}", value))
+            .unwrap_or_else(|_| write!(f, "<unknown>"))
     }
 }

--- a/encodings/fastlanes/src/for/serde.rs
+++ b/encodings/fastlanes/src/for/serde.rs
@@ -72,7 +72,7 @@ impl DeserializeMetadata for ScalarValueMetadata {
 
     fn format(metadata: Option<&[u8]>, f: &mut Formatter<'_>) -> std::fmt::Result {
         Self::deserialize(metadata)
-            .map(|value| write!(f, "{:?}", value))
+            .map(|value| write!(f, "{}", value))
             .unwrap_or_else(|_| write!(f, "<unknown>"))
     }
 }

--- a/encodings/sparse/src/serde.rs
+++ b/encodings/sparse/src/serde.rs
@@ -5,6 +5,7 @@ use vortex_array::{
     Array, ArrayBufferVisitor, ArrayChildVisitor, ArrayRef, ArrayVisitorImpl, ContextRef,
     DeserializeMetadata, RkyvMetadata,
 };
+use vortex_buffer::ByteBufferMut;
 use vortex_dtype::DType;
 use vortex_error::{VortexExpect, VortexResult, vortex_bail};
 use vortex_scalar::{Scalar, ScalarValue};
@@ -19,7 +20,11 @@ pub struct SparseMetadata {
 
 impl ArrayVisitorImpl<RkyvMetadata<SparseMetadata>> for SparseArray {
     fn _buffers(&self, visitor: &mut dyn ArrayBufferVisitor) {
-        let fill_value_buffer = self.fill_value.value().to_flexbytes().into_inner();
+        let fill_value_buffer = self
+            .fill_value
+            .value()
+            .to_flexbytes::<ByteBufferMut>()
+            .freeze();
         visitor.visit_buffer(&fill_value_buffer);
     }
 

--- a/vortex-array/src/arrays/constant/serde.rs
+++ b/vortex-array/src/arrays/constant/serde.rs
@@ -1,3 +1,4 @@
+use vortex_buffer::ByteBufferMut;
 use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_bail};
 use vortex_scalar::{Scalar, ScalarValue};
@@ -9,7 +10,7 @@ use crate::{Array, ArrayBufferVisitor, ArrayRef, ArrayVisitorImpl, ContextRef, E
 
 impl ArrayVisitorImpl for ConstantArray {
     fn _buffers(&self, visitor: &mut dyn ArrayBufferVisitor) {
-        let buffer = self.scalar.value().to_flexbytes().into_inner();
+        let buffer = self.scalar.value().to_flexbytes::<ByteBufferMut>().freeze();
         visitor.visit_buffer(&buffer);
     }
 

--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -420,6 +420,16 @@ impl<T> Extend<T> for BufferMut<T> {
     }
 }
 
+impl<'a, T> Extend<&'a T> for BufferMut<T>
+where
+    T: Copy + 'a,
+{
+    #[inline]
+    fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
+        self.spec_extend(iter.into_iter())
+    }
+}
+
 impl<T> FromIterator<T> for BufferMut<T> {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         // We don't infer the capacity here and just let the first call to `extend` do it for us.

--- a/vortex-buffer/src/spec_extend.rs
+++ b/vortex-buffer/src/spec_extend.rs
@@ -85,6 +85,17 @@ where
     }
 }
 
+impl<'a, T: 'a, I> SpecExtend<&'a T, I> for BufferMut<T>
+where
+    I: Iterator<Item = &'a T>,
+    T: Clone,
+{
+    #[track_caller]
+    default fn spec_extend(&mut self, iterator: I) {
+        self.spec_extend(iterator.cloned())
+    }
+}
+
 impl<'a, T: 'a> SpecExtend<&'a T, slice::Iter<'a, T>> for BufferMut<T>
 where
     T: Copy,

--- a/vortex-scalar/src/scalarvalue/mod.rs
+++ b/vortex-scalar/src/scalarvalue/mod.rs
@@ -36,7 +36,7 @@ pub(crate) enum InnerScalarValue {
 
 #[cfg(feature = "flatbuffers")]
 impl ScalarValue {
-    pub fn to_flexbytes(&self) -> vortex_flatbuffers::FlatBuffer {
+    pub fn to_flexbytes<B: Default + for<'a> Extend<&'a u8>>(&self) -> B {
         use serde::Serialize;
         use vortex_error::VortexExpect;
 
@@ -44,7 +44,11 @@ impl ScalarValue {
         self.0
             .serialize(&mut ser)
             .vortex_expect("Failed to serialize ScalarValue");
-        vortex_flatbuffers::FlatBuffer::copy_from(ser.view())
+        let view = ser.view();
+
+        let mut buf = B::default();
+        buf.extend(view);
+        buf
     }
 
     pub fn from_flexbytes(buf: &[u8]) -> VortexResult<Self> {


### PR DESCRIPTION
I don't think we want to make metadata 8 bytes anymore, so we may as well put the reference value in metadata so we get a pretty-printed value in tree-display.

Since we need a Vec<u8> instead of ByteBuffer, I also fixed the SpecExtend for an iter::Slice