### PR TITLE
fix: StructLayoutWriter requires unique field names

### DIFF
--- a/vortex-dtype/src/struct_.rs
+++ b/vortex-dtype/src/struct_.rs
@@ -271,7 +271,7 @@ where
             .into_iter()
             .map(|(name, dtype)| (name.into(), dtype.into()))
             .unzip();
-        StructDType::from_fields(names.into(), dtypes.into_iter().collect())
+        StructDType::from_fields(names.into(), dtypes)
     }
 }
 

--- a/vortex-layout/src/layouts/struct_/eval_expr.rs
+++ b/vortex-layout/src/layouts/struct_/eval_expr.rs
@@ -85,6 +85,7 @@ mod tests {
     use vortex_buffer::buffer;
     use vortex_dtype::PType::I32;
     use vortex_dtype::{DType, Nullability, StructDType};
+    use vortex_error::VortexUnwrap;
     use vortex_expr::{get_item, gt, ident, pack};
     use vortex_mask::Mask;
 
@@ -101,7 +102,7 @@ mod tests {
         let ctx = ArrayContext::empty();
         let mut segments = TestSegments::default();
 
-        let layout = StructLayoutWriter::new(
+        let layout = StructLayoutWriter::try_new(
             DType::Struct(
                 Arc::new(StructDType::new(
                     vec!["a".into(), "b".into(), "c".into()].into(),
@@ -127,6 +128,7 @@ mod tests {
                 )),
             ],
         )
+        .vortex_unwrap()
         .push_all(
             &mut segments,
             [Ok(StructArray::from_fields(


### PR DESCRIPTION
We assume throughout scanning that the column names in expression can be unique identifiers but we never enforce it. This fixes the issue by rejecting such schemas and also avoids running into them in the fuzzer