### PR TITLE
use the same rate limiter across partitions in slow object store

### DIFF
--- a/bench-vortex/src/blob.rs
+++ b/bench-vortex/src/blob.rs
@@ -41,12 +41,12 @@ impl ObjectStoreRegistry for SlowObjectStoreRegistry {
         url: &Url,
         store: Arc<dyn ObjectStore>,
     ) -> Option<Arc<dyn ObjectStore>> {
-        self.inner.register_store(url, store)
+        self.inner
+            .register_store(url, Arc::new(SlowObjectStore::new(store)))
     }
 
     fn get_store(&self, url: &Url) -> datafusion_common::Result<Arc<dyn ObjectStore>> {
-        let store = self.inner.get_store(url)?;
-        Ok(Arc::new(SlowObjectStore::new(store)))
+        self.inner.get_store(url)
     }
 }
 


### PR DESCRIPTION
we should return the same slow object store in a `get_store` call for the same url, so multiple partitions reading the same url can share the underlying rate limiter.