### PR TITLE
Feature flag available encodings in `vortex-file`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5530,7 +5530,6 @@ dependencies = [
  "vortex-btrblocks",
  "vortex-buffer",
  "vortex-bytebool",
- "vortex-datetime-dtype",
  "vortex-datetime-parts",
  "vortex-dict",
  "vortex-dtype",

--- a/bench-vortex/src/clickbench.rs
+++ b/bench-vortex/src/clickbench.rs
@@ -14,7 +14,7 @@ use vortex::TryIntoArray;
 use vortex::arrow::FromArrowType;
 use vortex::dtype::DType;
 use vortex::error::{VortexError, vortex_err};
-use vortex::file::{DEFAULT_REGISTRY, VORTEX_FILE_EXTENSION, VortexWriteOptions};
+use vortex::file::{FULL_REGISTRY, VORTEX_FILE_EXTENSION, VortexWriteOptions};
 use vortex::layout::{LayoutRegistry, LayoutRegistryExt};
 use vortex::stream::ArrayStreamAdapter;
 use vortex_datafusion::persistent::VortexFormat;
@@ -201,7 +201,7 @@ pub async fn register_vortex_files(
         .await?;
 
     let format = Arc::new(VortexFormat::new(
-        DEFAULT_REGISTRY.clone(),
+        FULL_REGISTRY.clone(),
         Arc::new(LayoutRegistry::default()),
     ));
     let table_path = vortex_dir

--- a/bench-vortex/src/tpch/mod.rs
+++ b/bench-vortex/src/tpch/mod.rs
@@ -24,7 +24,7 @@ use vortex::arrays::ChunkedArray;
 use vortex::arrow::{FromArrowArray, FromArrowType};
 use vortex::dtype::DType;
 use vortex::error::VortexExpect as _;
-use vortex::file::{DEFAULT_REGISTRY, VORTEX_FILE_EXTENSION, VortexWriteOptions};
+use vortex::file::{FULL_REGISTRY, VORTEX_FILE_EXTENSION, VortexWriteOptions};
 use vortex::layout::{LayoutRegistry, LayoutRegistryExt};
 use vortex::{Array, ArrayRef, TryIntoArray};
 use vortex_datafusion::SessionContextExt;
@@ -351,7 +351,7 @@ async fn register_vortex_file(
     }
 
     let format = Arc::new(VortexFormat::new(
-        DEFAULT_REGISTRY.clone(),
+        FULL_REGISTRY.clone(),
         Arc::new(LayoutRegistry::default()),
     ));
     let table_url = ListingTableUrl::parse(vtx_file.as_str())?;

--- a/vortex-array/src/context.rs
+++ b/vortex-array/src/context.rs
@@ -12,12 +12,12 @@ use crate::arrays::{
 use crate::encoding::Encoding;
 use crate::vtable::VTableRef;
 
-/// A collection of array encodings.
 // TODO(ngates): it feels weird that this has interior mutability. I think maybe it shouldn't.
 pub type ArrayContext = VTableContext<VTableRef>;
 pub type ArrayRegistry = VTableRegistry<VTableRef>;
 
 impl Default for ArrayRegistry {
+    /// Create a new [`ArrayRegistry`] with all the canonical encodings and the main utility ones
     fn default() -> Self {
         let mut this = Self::empty();
 

--- a/vortex-array/src/context.rs
+++ b/vortex-array/src/context.rs
@@ -17,7 +17,7 @@ pub type ArrayContext = VTableContext<VTableRef>;
 pub type ArrayRegistry = VTableRegistry<VTableRef>;
 
 impl Default for ArrayRegistry {
-    /// Create a new [`ArrayRegistry`] with all the canonical encodings and the main utility ones
+    /// Create a new [`ArrayRegistry`] with all the canonical encodings, and the main utility ones
     fn default() -> Self {
         let mut this = Self::empty();
 

--- a/vortex-file/Cargo.toml
+++ b/vortex-file/Cargo.toml
@@ -29,26 +29,25 @@ tokio = { workspace = true, features = ["rt"], optional = true }
 tracing = { workspace = true, optional = true }
 # Needed to pickup the "js" feature for wasm targets from the workspace configuration
 uuid = { workspace = true }
-vortex-alp = { workspace = true }
+vortex-alp = { workspace = true, optional = true }
 vortex-array = { workspace = true }
 vortex-btrblocks = { workspace = true }
 vortex-buffer = { workspace = true }
-vortex-bytebool = { workspace = true }
-vortex-datetime-dtype = { workspace = true }
-vortex-datetime-parts = { workspace = true }
-vortex-dict = { workspace = true }
+vortex-bytebool = { workspace = true, optional = true }
+vortex-datetime-parts = { workspace = true, optional = true }
+vortex-dict = { workspace = true, optional = true }
 vortex-dtype = { workspace = true }
 vortex-error = { workspace = true }
 vortex-expr = { workspace = true }
-vortex-fastlanes = { workspace = true }
+vortex-fastlanes = { workspace = true, optional = true }
 vortex-flatbuffers = { workspace = true, features = ["file"] }
-vortex-fsst = { workspace = true }
+vortex-fsst = { workspace = true, optional = true }
 vortex-io = { workspace = true }
 vortex-layout = { workspace = true }
 vortex-metrics = { workspace = true }
-vortex-runend = { workspace = true }
-vortex-sparse = { workspace = true }
-vortex-zigzag = { workspace = true }
+vortex-runend = { workspace = true, optional = true }
+vortex-sparse = { workspace = true, optional = true }
+vortex-zigzag = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
@@ -59,5 +58,25 @@ vortex-io = { path = "../vortex-io", features = ["tokio"] }
 workspace = true
 
 [features]
+default = [
+    "alp",
+    "fastlanes",
+    "fsst",
+    "zigzag",
+    "sparse",
+    "runend",
+    "bytebool",
+    "dict",
+    "datetime_parts",
+]
 object_store = ["vortex-error/object_store", "vortex-io/object_store"]
 tracing = ["dep:tracing", "vortex-io/tracing"]
+alp = ["dep:vortex-alp"]
+fastlanes = ["dep:vortex-fastlanes"]
+fsst = ["dep:vortex-fsst"]
+zigzag = ["dep:vortex-zigzag"]
+runend = ["dep:vortex-runend"]
+bytebool = ["dep:vortex-bytebool"]
+sparse = ["dep:vortex-sparse"]
+dict = ["dep:vortex-dict"]
+datetime_parts = ["dep:vortex-datetime-parts"]

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -156,21 +156,35 @@ mod forever_constant {
     }
 }
 
-/// A registry containing all available encodings in the core Vortex repo.
+/// A registry containing all available encodings from the core repo.
+///
+/// The exact available encodings can be controlled by feature flags.
 pub static FULL_REGISTRY: LazyLock<Arc<ArrayRegistry>> = LazyLock::new(|| {
     // Register the compressed encodings that Vortex ships with.
     let registry = ArrayRegistry::default().register_many([
+        #[cfg(feature = "alp")]
         ALPEncoding.vtable(),
+        #[cfg(feature = "alp")]
         ALPRDEncoding.vtable(),
+        #[cfg(feature = "fastlanes")]
         BitPackedEncoding.vtable(),
+        #[cfg(feature = "bytebool")]
         ByteBoolEncoding.vtable(),
+        #[cfg(feature = "datetime_parts")]
         DateTimePartsEncoding.vtable(),
+        #[cfg(feature = "fastlanes")]
         DeltaEncoding.vtable(),
+        #[cfg(feature = "dict")]
         DictEncoding.vtable(),
+        #[cfg(feature = "fastlanes")]
         FoREncoding.vtable(),
+        #[cfg(feature = "fsst")]
         FSSTEncoding.vtable(),
+        #[cfg(feature = "runend")]
         RunEndEncoding.vtable(),
+        #[cfg(feature = "sparse")]
         SparseEncoding.vtable(),
+        #[cfg(feature = "zigzag")]
         ZigZagEncoding.vtable(),
     ]);
     Arc::new(registry)

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -111,17 +111,8 @@ pub use generic::*;
 pub use memory::*;
 pub use open::*;
 pub use strategy::*;
-use vortex_alp::{ALPEncoding, ALPRDEncoding};
-use vortex_array::{ArrayRegistry, Encoding};
-use vortex_bytebool::ByteBoolEncoding;
-use vortex_datetime_parts::DateTimePartsEncoding;
-use vortex_dict::DictEncoding;
-use vortex_fastlanes::{BitPackedEncoding, DeltaEncoding, FoREncoding};
-use vortex_fsst::FSSTEncoding;
+use vortex_array::ArrayRegistry;
 pub use vortex_layout::scan::*;
-use vortex_runend::RunEndEncoding;
-use vortex_sparse::SparseEncoding;
-use vortex_zigzag::ZigZagEncoding;
 pub use writer::*;
 
 /// The current version of the Vortex file format
@@ -163,29 +154,29 @@ pub static FULL_REGISTRY: LazyLock<Arc<ArrayRegistry>> = LazyLock::new(|| {
     // Register the compressed encodings that Vortex ships with.
     let registry = ArrayRegistry::default().register_many([
         #[cfg(feature = "alp")]
-        ALPEncoding.vtable(),
+        vortex_array::Encoding::vtable(&vortex_alp::ALPEncoding),
         #[cfg(feature = "alp")]
-        ALPRDEncoding.vtable(),
+        vortex_array::Encoding::vtable(&vortex_alp::ALPRDEncoding),
         #[cfg(feature = "fastlanes")]
-        BitPackedEncoding.vtable(),
+        vortex_array::Encoding::vtable(&vortex_fastlanes::BitPackedEncoding),
         #[cfg(feature = "bytebool")]
-        ByteBoolEncoding.vtable(),
+        vortex_array::Encoding::vtable(&vortex_bytebool::ByteBoolEncoding),
         #[cfg(feature = "datetime_parts")]
-        DateTimePartsEncoding.vtable(),
+        vortex_array::Encoding::vtable(&vortex_datetime_parts::DateTimePartsEncoding),
         #[cfg(feature = "fastlanes")]
-        DeltaEncoding.vtable(),
+        vortex_array::Encoding::vtable(&vortex_fastlanes::DeltaEncoding),
         #[cfg(feature = "dict")]
-        DictEncoding.vtable(),
+        vortex_array::Encoding::vtable(&vortex_dict::DictEncoding),
         #[cfg(feature = "fastlanes")]
-        FoREncoding.vtable(),
+        vortex_array::Encoding::vtable(&vortex_fastlanes::FoREncoding),
         #[cfg(feature = "fsst")]
-        FSSTEncoding.vtable(),
+        vortex_array::Encoding::vtable(&vortex_fsst::FSSTEncoding),
         #[cfg(feature = "runend")]
-        RunEndEncoding.vtable(),
+        vortex_array::Encoding::vtable(&vortex_runend::RunEndEncoding),
         #[cfg(feature = "sparse")]
-        SparseEncoding.vtable(),
+        vortex_array::Encoding::vtable(&vortex_sparse::SparseEncoding),
         #[cfg(feature = "zigzag")]
-        ZigZagEncoding.vtable(),
+        vortex_array::Encoding::vtable(&vortex_zigzag::ZigZagEncoding),
     ]);
     Arc::new(registry)
 });

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -156,8 +156,8 @@ mod forever_constant {
     }
 }
 
-/// A default registry containing the built-in Vortex encodings and layouts.
-pub static DEFAULT_REGISTRY: LazyLock<Arc<ArrayRegistry>> = LazyLock::new(|| {
+/// A registry containing all available encodings in the core Vortex repo.
+pub static FULL_REGISTRY: LazyLock<Arc<ArrayRegistry>> = LazyLock::new(|| {
     // Register the compressed encodings that Vortex ships with.
     let registry = ArrayRegistry::default().register_many([
         ALPEncoding.vtable(),

--- a/vortex-file/src/open.rs
+++ b/vortex-file/src/open.rs
@@ -17,7 +17,7 @@ use vortex_metrics::VortexMetrics;
 
 use crate::footer::{Footer, Postscript, Segment};
 use crate::segments::{NoOpSegmentCache, SegmentCache};
-use crate::{DEFAULT_REGISTRY, EOF_SIZE, MAGIC_BYTES, MAX_FOOTER_SIZE, VERSION, VortexFile};
+use crate::{EOF_SIZE, FULL_REGISTRY, MAGIC_BYTES, MAX_FOOTER_SIZE, VERSION, VortexFile};
 
 pub trait FileType: Sized {
     type Options: Clone;
@@ -60,7 +60,7 @@ impl<F: FileType> VortexOpenOptions<F> {
         Self {
             read,
             options,
-            registry: DEFAULT_REGISTRY.clone(),
+            registry: FULL_REGISTRY.clone(),
             layout_registry: Arc::new(LayoutRegistry::default()),
             file_size: None,
             dtype: None,


### PR DESCRIPTION
vortex-file currently pulls all encodings, not allowing users to opt out.
It also exports a confusingly names `DEFAULT_REGISTRY`, which is renamed here.

Another issue not addressed here is that its currently possible to write files you can't read, because the btrblocks compressor has its own "encoding registry" mechanism and it never integrates with the outside world.