### PR TITLE
Recover from failed/yanked released

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bench-vortex"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -3716,7 +3716,7 @@ dependencies = [
 
 [[package]]
 name = "pyvortex"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arrow",
  "futures",
@@ -5188,7 +5188,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vortex"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "vortex-alp",
  "vortex-array",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-alp"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "codspeed-divan-compat",
  "itertools 0.14.0",
@@ -5237,7 +5237,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-array"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arbitrary",
  "arrow-arith",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-btrblocks"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arrow-buffer",
  "codspeed-divan-compat",
@@ -5311,7 +5311,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-buffer"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arrow-buffer",
  "bytes",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-bytebool"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arrow-buffer",
  "num-traits",
@@ -5340,7 +5340,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-datafusion"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-datetime-dtype"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arrow-schema",
  "jiff",
@@ -5390,7 +5390,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-datetime-parts"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "getrandom 0.2.15",
  "rkyv",
@@ -5407,7 +5407,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-dict"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arrow-buffer",
  "codspeed-divan-compat",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-dtype"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arbitrary",
  "flatbuffers 25.2.10",
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-error"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arrow-schema",
  "datafusion-common",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-expr"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "datafusion-expr",
  "datafusion-physical-expr",
@@ -5485,7 +5485,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-fastlanes"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arrayref",
  "arrow-buffer",
@@ -5508,7 +5508,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-file"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-flatbuffers"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "flatbuffers 25.2.10",
  "vortex-buffer",
@@ -5555,7 +5555,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-fsst"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arrow-array",
  "codspeed-divan-compat",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-fuzz"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arrow-buffer",
  "arrow-ord",
@@ -5592,7 +5592,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-io"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-ipc"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "bytes",
  "flatbuffers 25.2.10",
@@ -5631,7 +5631,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-layout"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arrow-buffer",
  "async-once-cell",
@@ -5660,7 +5660,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-mask"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arrow-buffer",
  "itertools 0.14.0",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-metrics"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "getrandom 0.3.1",
  "vortex-error",
@@ -5678,7 +5678,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-proto"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "prost",
  "prost-types",
@@ -5686,7 +5686,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-runend"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arrow-buffer",
  "codspeed-divan-compat",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-scalar"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arbitrary",
  "arrow-array",
@@ -5729,7 +5729,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-sparse"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "itertools 0.14.0",
  "rkyv",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-tui"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -5758,7 +5758,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-zigzag"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "vortex-array",
  "vortex-buffer",
@@ -6326,7 +6326,7 @@ checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
 
 [[package]]
 name = "xtask"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = ["wasm-test"]
 resolver = "2"
 
 [workspace.package]
-version = "0.25.0"
+version = "0.25.1"
 homepage = "https://github.com/spiraldb/vortex"
 repository = "https://github.com/spiraldb/vortex"
 authors = ["Vortex Authors <hello@vortex.dev>"]
@@ -164,33 +164,33 @@ wasm-bindgen-futures = "0.4.39"
 witchcraft-metrics = "1.0.1"
 
 # BEGIN crates published by this project
-vortex = { version = "0.25.0", path = "./vortex" }
-vortex-alp = { version = "0.25.0", path = "./encodings/alp" }
-vortex-array = { version = "0.25.0", path = "./vortex-array" }
-vortex-btrblocks = { version = "0.25.0", path = "./vortex-btrblocks" }
-vortex-buffer = { version = "0.25.0", path = "./vortex-buffer" }
-vortex-bytebool = { version = "0.25.0", path = "./encodings/bytebool" }
-vortex-datafusion = { version = "0.25.0", path = "./vortex-datafusion" }
-vortex-datetime-dtype = { version = "0.25.0", path = "./vortex-datetime-dtype" }
-vortex-datetime-parts = { version = "0.25.0", path = "./encodings/datetime-parts" }
-vortex-dict = { version = "0.25.0", path = "./encodings/dict" }
-vortex-dtype = { version = "0.25.0", path = "./vortex-dtype", default-features = false }
-vortex-error = { version = "0.25.0", path = "./vortex-error" }
-vortex-expr = { version = "0.25.0", path = "./vortex-expr" }
-vortex-fastlanes = { version = "0.25.0", path = "./encodings/fastlanes" }
-vortex-file = { version = "0.25.0", path = "./vortex-file", default-features = false }
-vortex-flatbuffers = { version = "0.25.0", path = "./vortex-flatbuffers" }
-vortex-fsst = { version = "0.25.0", path = "./encodings/fsst" }
-vortex-io = { version = "0.25.0", path = "./vortex-io" }
-vortex-ipc = { version = "0.25.0", path = "./vortex-ipc" }
-vortex-layout = { version = "0.25.0", path = "./vortex-layout" }
-vortex-mask = { version = "0.25.0", path = "./vortex-mask" }
-vortex-metrics = { version = "0.25.0", path = "./vortex-metrics" }
-vortex-proto = { version = "0.25.0", path = "./vortex-proto" }
-vortex-runend = { version = "0.25.0", path = "./encodings/runend" }
-vortex-scalar = { version = "0.25.0", path = "./vortex-scalar", default-features = false }
-vortex-sparse = { version = "0.25.0", path = "./encodings/sparse" }
-vortex-zigzag = { version = "0.25.0", path = "./encodings/zigzag" }
+vortex = { version = "0.25.1", path = "./vortex" }
+vortex-alp = { version = "0.25.1", path = "./encodings/alp" }
+vortex-array = { version = "0.25.1", path = "./vortex-array" }
+vortex-btrblocks = { version = "0.25.1", path = "./vortex-btrblocks" }
+vortex-buffer = { version = "0.25.1", path = "./vortex-buffer" }
+vortex-bytebool = { version = "0.25.1", path = "./encodings/bytebool" }
+vortex-datafusion = { version = "0.25.1", path = "./vortex-datafusion" }
+vortex-datetime-dtype = { version = "0.25.1", path = "./vortex-datetime-dtype" }
+vortex-datetime-parts = { version = "0.25.1", path = "./encodings/datetime-parts" }
+vortex-dict = { version = "0.25.1", path = "./encodings/dict" }
+vortex-dtype = { version = "0.25.1", path = "./vortex-dtype", default-features = false }
+vortex-error = { version = "0.25.1", path = "./vortex-error" }
+vortex-expr = { version = "0.25.1", path = "./vortex-expr" }
+vortex-fastlanes = { version = "0.25.1", path = "./encodings/fastlanes" }
+vortex-file = { version = "0.25.1", path = "./vortex-file", default-features = false }
+vortex-flatbuffers = { version = "0.25.1", path = "./vortex-flatbuffers" }
+vortex-fsst = { version = "0.25.1", path = "./encodings/fsst" }
+vortex-io = { version = "0.25.1", path = "./vortex-io" }
+vortex-ipc = { version = "0.25.1", path = "./vortex-ipc" }
+vortex-layout = { version = "0.25.1", path = "./vortex-layout" }
+vortex-mask = { version = "0.25.1", path = "./vortex-mask" }
+vortex-metrics = { version = "0.25.1", path = "./vortex-metrics" }
+vortex-proto = { version = "0.25.1", path = "./vortex-proto" }
+vortex-runend = { version = "0.25.1", path = "./encodings/runend" }
+vortex-scalar = { version = "0.25.1", path = "./vortex-scalar", default-features = false }
+vortex-sparse = { version = "0.25.1", path = "./encodings/sparse" }
+vortex-zigzag = { version = "0.25.1", path = "./encodings/zigzag" }
 # END crates published by this project
 
 worker = "0.5.0"


### PR DESCRIPTION
In order to get release-plz back on track, we need to manually bump the version. This is a [known issue](https://release-plz.dev/docs/extra/yanked-packages) in how it deals with yanked version