### PR TITLE
Fix README location for `vortex` rustdoc

### DIFF
--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -1,4 +1,5 @@
-#![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../README.md"))]
+// https://github.com/rust-lang/cargo/pull/11645#issuecomment-1536905941
+#![doc = include_str!(concat!("../", env!("CARGO_PKG_README")))]
 
 pub use vortex_array::*;
 #[cfg(feature = "files")]


### PR DESCRIPTION
Verified locally by running:
```
cargo publish --workspace --dry-run --exclude bench-vortex --exclude vortex-fuzz --exclude xtask --exclude pyvortex --allow-dirty -Z package-workspace
```