### PR TITLE
fix: SparseArray#search_sorted handles non null fill value that is between patch values

### DIFF
--- a/encodings/sparse/src/compute/search_sorted.rs
+++ b/encodings/sparse/src/compute/search_sorted.rs
@@ -17,34 +17,21 @@ impl SearchSortedFn<&SparseArray> for SparseEncoding {
         // first search result in patches
         let patches_result = array.patches().search_sorted(value.clone(), side)?;
         match patches_result {
-            SearchResult::Found(i) => Ok(SearchResult::Found(i)),
-            SearchResult::NotFound(i) => {
-                // In not found case we need to find the relative position of fill value to the patches
-                let fill_result = if array.fill_scalar().is_null() {
-                    // For null fill the patches can only ever be after the fill
-                    SearchResult::NotFound(array.patches().min_index()?)
-                } else {
-                    array
-                        .patches()
-                        .search_sorted(array.fill_scalar().clone(), side)?
-                };
-                let fill_result_index = fill_result.to_index();
-                // Find the relevant position of the fill value in the patches
-                let fill_index = if fill_result_index <= array.patches().min_index()? {
-                    // [fill, ..., patch]
-                    0
-                } else if fill_result_index > array.patches().max_index()? {
-                    // [patch, ..., fill]
-                    array.len()
-                } else {
-                    // [patch, fill, ..., fill, patch]
+            SearchResult::Found(i) => {
+                if value == array.fill_scalar() {
+                    // Find the relevant position of the fill value in the patches
+                    let fill_index = fill_position(array, side)?;
                     match side {
-                        SearchSortedSide::Left => fill_result_index,
-                        SearchSortedSide::Right => {
-                            array.len() - array.patches().num_patches() + fill_result_index
-                        }
+                        SearchSortedSide::Left => Ok(SearchResult::Found(i.min(fill_index))),
+                        SearchSortedSide::Right => Ok(SearchResult::Found(i.max(fill_index))),
                     }
-                };
+                } else {
+                    Ok(SearchResult::Found(i))
+                }
+            }
+            SearchResult::NotFound(i) => {
+                // Find the relevant position of the fill value in the patches
+                let fill_index = fill_position(array, side)?;
 
                 // Adjust the position of the search value relative to the position of the fill value
                 match value
@@ -61,6 +48,38 @@ impl SearchSortedFn<&SparseArray> for SparseEncoding {
             }
         }
     }
+}
+
+fn fill_position(array: &SparseArray, side: SearchSortedSide) -> VortexResult<usize> {
+    // In not found case we need to find the relative position of fill value to the patches
+    let fill_result = if array.fill_scalar().is_null() {
+        // For null fill the patches can only ever be after the fill
+        SearchResult::NotFound(array.patches().min_index()?)
+    } else {
+        array
+            .patches()
+            .search_sorted(array.fill_scalar().clone(), side)?
+    };
+    let fill_result_index = fill_result.to_index();
+    // Find the relevant position of the fill value in the patches
+    Ok(if fill_result_index <= array.patches().min_index()? {
+        // [fill, ..., patch]
+        0
+    } else if fill_result_index > array.patches().max_index()? {
+        // [patch, ..., fill]
+        array.len()
+    } else {
+        // [patch, fill, ..., fill, patch]
+        match side {
+            SearchSortedSide::Left => fill_result_index,
+            SearchSortedSide::Right => match fill_result {
+                SearchResult::Found(i) => i,
+                SearchResult::NotFound(_) => {
+                    array.len() - array.patches().num_patches() + fill_result_index
+                }
+            },
+        }
+    })
 }
 
 impl SearchSortedUsizeFn<&SparseArray> for SparseEncoding {
@@ -130,6 +149,50 @@ mod tests {
             buffer![11i32, 22, 33, 44, 55].into_array(),
             20,
             Scalar::primitive(30, Nullability::NonNullable),
+        )
+        .unwrap()
+        .into_array()
+    }
+
+    fn sparse_high_fill_in_patches() -> ArrayRef {
+        SparseArray::try_new(
+            buffer![17u64, 18, 19].into_array(),
+            buffer![33_i32, 44, 55].into_array(),
+            20,
+            Scalar::primitive(33, Nullability::NonNullable),
+        )
+        .unwrap()
+        .into_array()
+    }
+
+    fn sparse_low_fill_in_patches() -> ArrayRef {
+        SparseArray::try_new(
+            buffer![0u64, 1, 2].into_array(),
+            buffer![33_i32, 44, 55].into_array(),
+            20,
+            Scalar::primitive(55, Nullability::NonNullable),
+        )
+        .unwrap()
+        .into_array()
+    }
+
+    fn sparse_low_high_fill_in_patches_low() -> ArrayRef {
+        SparseArray::try_new(
+            buffer![0u64, 1, 17, 18, 19].into_array(),
+            buffer![11i32, 22, 33, 44, 55].into_array(),
+            20,
+            Scalar::primitive(22, Nullability::NonNullable),
+        )
+        .unwrap()
+        .into_array()
+    }
+
+    fn sparse_low_high_fill_in_patches_high() -> ArrayRef {
+        SparseArray::try_new(
+            buffer![0u64, 1, 17, 18, 19].into_array(),
+            buffer![11i32, 22, 33, 44, 55].into_array(),
+            20,
+            Scalar::primitive(33, Nullability::NonNullable),
         )
         .unwrap()
         .into_array()
@@ -233,6 +296,26 @@ mod tests {
         Scalar::primitive(30, Nullability::NonNullable),
         SearchResult::Found(2)
     )]
+    #[case(
+        sparse_high_fill_in_patches(),
+        Scalar::primitive(33, Nullability::NonNullable),
+        SearchResult::Found(0)
+    )]
+    #[case(
+        sparse_low_fill_in_patches(),
+        Scalar::primitive(55, Nullability::NonNullable),
+        SearchResult::Found(2)
+    )]
+    #[case(
+        sparse_low_high_fill_in_patches_low(),
+        Scalar::primitive(22, Nullability::NonNullable),
+        SearchResult::Found(1)
+    )]
+    #[case(
+        sparse_low_high_fill_in_patches_high(),
+        Scalar::primitive(33, Nullability::NonNullable),
+        SearchResult::Found(17)
+    )]
     fn search_fill_left(
         #[case] array: ArrayRef,
         #[case] search: Scalar,
@@ -259,6 +342,26 @@ mod tests {
         sparse_low_high(),
         Scalar::primitive(30, Nullability::NonNullable),
         SearchResult::Found(17)
+    )]
+    #[case(
+        sparse_high_fill_in_patches(),
+        Scalar::primitive(33, Nullability::NonNullable),
+        SearchResult::Found(18)
+    )]
+    #[case(
+        sparse_low_fill_in_patches(),
+        Scalar::primitive(55, Nullability::NonNullable),
+        SearchResult::Found(20)
+    )]
+    #[case(
+        sparse_low_high_fill_in_patches_low(),
+        Scalar::primitive(22, Nullability::NonNullable),
+        SearchResult::Found(17)
+    )]
+    #[case(
+        sparse_low_high_fill_in_patches_high(),
+        Scalar::primitive(33, Nullability::NonNullable),
+        SearchResult::Found(18)
     )]
     fn search_fill_right(
         #[case] array: ArrayRef,

--- a/encodings/sparse/src/compute/search_sorted.rs
+++ b/encodings/sparse/src/compute/search_sorted.rs
@@ -74,28 +74,25 @@ fn fill_position(array: &SparseArray, side: SearchSortedSide) -> VortexResult<us
         // [patch, fill, ..., fill, patch]
         match side {
             SearchSortedSide::Left => fill_result_index,
-            SearchSortedSide::Right => match fill_result {
-                SearchResult::Found(i) => {
-                    let fill_index = array.patches().search_index(i)?.to_index();
-                    if fill_index < array.patches().num_patches() {
-                        // Since we are searching from right the fill_index is the index one after the found one
-                        let next_index =
-                            usize::try_from(&scalar_at(array.patches().indices(), fill_index)?)?;
-                        // fill value is dense with a next patch value we want to return the original fill_index,
-                        // i.e. the fill value cannot exist between fill_index and next_index
-                        if fill_index + 1 == next_index {
-                            fill_index
-                        } else {
-                            next_index
-                        }
-                    } else {
+            SearchSortedSide::Right => {
+                // When searching from right we need to find the right most occurrence of our fill value. If fill value
+                // is present in patches this would be the index of the next value after the fill value
+                let fill_index = array.patches().search_index(fill_result_index)?.to_index();
+                if fill_index < array.patches().num_patches() {
+                    // Since we are searching from right the fill_index is the index one after the found one
+                    let next_index =
+                        usize::try_from(&scalar_at(array.patches().indices(), fill_index)?)?;
+                    // fill value is dense with a next patch value we want to return the original fill_index,
+                    // i.e. the fill value cannot exist between fill_index and next_index
+                    if fill_index + 1 == next_index {
                         fill_index
+                    } else {
+                        next_index
                     }
+                } else {
+                    fill_index
                 }
-                SearchResult::NotFound(_) => {
-                    array.len() - array.patches().num_patches() + fill_result_index
-                }
-            },
+            }
         }
     })
 }

--- a/encodings/sparse/src/compute/search_sorted.rs
+++ b/encodings/sparse/src/compute/search_sorted.rs
@@ -1,7 +1,9 @@
 use std::cmp::Ordering;
 
 use vortex_array::Array;
-use vortex_array::compute::{SearchResult, SearchSortedFn, SearchSortedSide, SearchSortedUsizeFn};
+use vortex_array::compute::{
+    SearchResult, SearchSortedFn, SearchSortedSide, SearchSortedUsizeFn, scalar_at,
+};
 use vortex_error::{VortexExpect, VortexResult};
 use vortex_scalar::Scalar;
 
@@ -73,7 +75,23 @@ fn fill_position(array: &SparseArray, side: SearchSortedSide) -> VortexResult<us
         match side {
             SearchSortedSide::Left => fill_result_index,
             SearchSortedSide::Right => match fill_result {
-                SearchResult::Found(i) => i,
+                SearchResult::Found(i) => {
+                    let fill_index = array.patches().search_index(i)?.to_index();
+                    if fill_index < array.patches().num_patches() {
+                        // Since we are searching from right the fill_index is the index one after the found one
+                        let next_index =
+                            usize::try_from(&scalar_at(array.patches().indices(), fill_index)?)?;
+                        // fill value is dense with a next patch value we want to return the original fill_index,
+                        // i.e. the fill value cannot exist between fill_index and next_index
+                        if fill_index + 1 == next_index {
+                            fill_index
+                        } else {
+                            next_index
+                        }
+                    } else {
+                        fill_index
+                    }
+                }
                 SearchResult::NotFound(_) => {
                     array.len() - array.patches().num_patches() + fill_result_index
                 }

--- a/encodings/sparse/src/compute/search_sorted.rs
+++ b/encodings/sparse/src/compute/search_sorted.rs
@@ -14,35 +14,52 @@ impl SearchSortedFn<&SparseArray> for SparseEncoding {
         value: &Scalar,
         side: SearchSortedSide,
     ) -> VortexResult<SearchResult> {
-        let min_index = array.patches().min_index()?;
-        // For a sorted array the patches can be either at the beginning or at the end of the array
-        if min_index == 0 {
-            match value
-                .partial_cmp(array.fill_scalar())
-                .vortex_expect("value and fill scalar must have same dtype")
-            {
-                Ordering::Less => array.patches().search_sorted(value.clone(), side),
-                Ordering::Equal => Ok(SearchResult::Found(if side == SearchSortedSide::Left {
-                    // In case of patches being at the beginning we want the first index after the end of patches
-                    array.patches().indices().len()
+        // first search result in patches
+        let patches_result = array.patches().search_sorted(value.clone(), side)?;
+        match patches_result {
+            SearchResult::Found(i) => Ok(SearchResult::Found(i)),
+            SearchResult::NotFound(i) => {
+                let fill_result = if array.fill_scalar().is_null() {
+                    SearchResult::NotFound(array.patches().min_index()?)
                 } else {
-                    array.len()
-                })),
-                Ordering::Greater => Ok(SearchResult::NotFound(array.len())),
-            }
-        } else {
-            match value
-                .partial_cmp(array.fill_scalar())
-                .vortex_expect("value and fill scalar must have same dtype")
-            {
-                Ordering::Less => Ok(SearchResult::NotFound(0)),
-                Ordering::Equal => Ok(SearchResult::Found(if side == SearchSortedSide::Left {
-                    0
-                } else {
-                    // Searching from right the min_index is one value after the last fill value
-                    min_index
-                })),
-                Ordering::Greater => array.patches().search_sorted(value.clone(), side),
+                    array
+                        .patches()
+                        .search_sorted(array.fill_scalar().clone(), side)?
+                };
+                let fill_index = fill_result.to_index();
+                let min_index = array.patches().min_index()?;
+                let max_index = array.patches().max_index()?;
+                let value_index = match side {
+                    SearchSortedSide::Left => {
+                        if fill_index <= min_index {
+                            0
+                        } else if fill_index > max_index {
+                            array.len()
+                        } else {
+                            fill_index
+                        }
+                    }
+                    SearchSortedSide::Right => {
+                        if fill_index <= min_index {
+                            0
+                        } else if fill_index > min_index {
+                            array.len() - array.patches().num_patches() + fill_index
+                        } else {
+                            fill_index
+                        }
+                    }
+                };
+                match value
+                    .partial_cmp(array.fill_scalar())
+                    .vortex_expect("value and fill scalar must have same dtype")
+                {
+                    Ordering::Less => Ok(SearchResult::NotFound(i.min(value_index))),
+                    Ordering::Equal => match side {
+                        SearchSortedSide::Left => Ok(SearchResult::Found(i.min(value_index))),
+                        SearchSortedSide::Right => Ok(SearchResult::Found(i.max(value_index))),
+                    },
+                    Ordering::Greater => Ok(SearchResult::NotFound(i.max(value_index))),
+                }
             }
         }
     }
@@ -109,10 +126,22 @@ mod tests {
         .into_array()
     }
 
+    fn sparse_low_high() -> ArrayRef {
+        SparseArray::try_new(
+            buffer![0u64, 1, 17, 18, 19].into_array(),
+            buffer![11i32, 22, 33, 44, 55].into_array(),
+            20,
+            Scalar::primitive(30, Nullability::NonNullable),
+        )
+        .unwrap()
+        .into_array()
+    }
+
     #[rstest]
     #[case(sparse_high_null_fill(), SearchResult::NotFound(20))]
     #[case(sparse_high_non_null_fill(), SearchResult::NotFound(20))]
     #[case(sparse_low(), SearchResult::NotFound(20))]
+    #[case(sparse_low_high(), SearchResult::NotFound(20))]
     fn search_larger_than_left(#[case] array: ArrayRef, #[case] expected: SearchResult) {
         let res = search_sorted(&array, 66, SearchSortedSide::Left).unwrap();
         assert_eq!(res, expected);
@@ -122,6 +151,7 @@ mod tests {
     #[case(sparse_high_null_fill(), SearchResult::NotFound(20))]
     #[case(sparse_high_non_null_fill(), SearchResult::NotFound(20))]
     #[case(sparse_low(), SearchResult::NotFound(20))]
+    #[case(sparse_low_high(), SearchResult::NotFound(20))]
     fn search_larger_than_right(#[case] array: ArrayRef, #[case] expected: SearchResult) {
         let res = search_sorted(&array, 66, SearchSortedSide::Right).unwrap();
         assert_eq!(res, expected);
@@ -131,6 +161,7 @@ mod tests {
     #[case(sparse_high_null_fill(), SearchResult::NotFound(17))]
     #[case(sparse_high_non_null_fill(), SearchResult::NotFound(0))]
     #[case(sparse_low(), SearchResult::NotFound(0))]
+    #[case(sparse_low_high(), SearchResult::NotFound(1))]
     fn search_less_than_left(#[case] array: ArrayRef, #[case] expected: SearchResult) {
         let res = search_sorted(&array, 21, SearchSortedSide::Left).unwrap();
         assert_eq!(res, expected);
@@ -140,6 +171,7 @@ mod tests {
     #[case(sparse_high_null_fill(), SearchResult::NotFound(17))]
     #[case(sparse_high_non_null_fill(), SearchResult::NotFound(0))]
     #[case(sparse_low(), SearchResult::NotFound(0))]
+    #[case(sparse_low_high(), SearchResult::NotFound(1))]
     fn search_less_than_right(#[case] array: ArrayRef, #[case] expected: SearchResult) {
         let res = search_sorted(&array, 21, SearchSortedSide::Right).unwrap();
         assert_eq!(res, expected);
@@ -149,6 +181,7 @@ mod tests {
     #[case(sparse_high_null_fill(), SearchResult::Found(18))]
     #[case(sparse_high_non_null_fill(), SearchResult::Found(18))]
     #[case(sparse_low(), SearchResult::Found(1))]
+    #[case(sparse_low_high(), SearchResult::Found(18))]
     fn search_patches_found_left(#[case] array: ArrayRef, #[case] expected: SearchResult) {
         let res = search_sorted(&array, 44, SearchSortedSide::Left).unwrap();
         assert_eq!(res, expected);
@@ -158,8 +191,29 @@ mod tests {
     #[case(sparse_high_null_fill(), SearchResult::Found(19))]
     #[case(sparse_high_non_null_fill(), SearchResult::Found(19))]
     #[case(sparse_low(), SearchResult::Found(2))]
+    #[case(sparse_low_high(), SearchResult::Found(19))]
     fn search_patches_found_right(#[case] array: ArrayRef, #[case] expected: SearchResult) {
         let res = search_sorted(&array, 44, SearchSortedSide::Right).unwrap();
+        assert_eq!(res, expected);
+    }
+
+    #[rstest]
+    #[case(sparse_high_null_fill(), SearchResult::NotFound(19))]
+    #[case(sparse_high_non_null_fill(), SearchResult::NotFound(19))]
+    #[case(sparse_low(), SearchResult::NotFound(2))]
+    #[case(sparse_low_high(), SearchResult::NotFound(19))]
+    fn search_mid_patches_not_found_left(#[case] array: ArrayRef, #[case] expected: SearchResult) {
+        let res = search_sorted(&array, 45, SearchSortedSide::Left).unwrap();
+        assert_eq!(res, expected);
+    }
+
+    #[rstest]
+    #[case(sparse_high_null_fill(), SearchResult::NotFound(19))]
+    #[case(sparse_high_non_null_fill(), SearchResult::NotFound(19))]
+    #[case(sparse_low(), SearchResult::NotFound(2))]
+    #[case(sparse_low_high(), SearchResult::NotFound(19))]
+    fn search_mid_patches_not_found_right(#[case] array: ArrayRef, #[case] expected: SearchResult) {
+        let res = search_sorted(&array, 45, SearchSortedSide::Right).unwrap();
         assert_eq!(res, expected);
     }
 
@@ -175,6 +229,11 @@ mod tests {
         sparse_low(),
         Scalar::primitive(60, Nullability::NonNullable),
         SearchResult::Found(3)
+    )]
+    #[case(
+        sparse_low_high(),
+        Scalar::primitive(30, Nullability::NonNullable),
+        SearchResult::Found(2)
     )]
     fn search_fill_left(
         #[case] array: ArrayRef,
@@ -197,6 +256,11 @@ mod tests {
         sparse_low(),
         Scalar::primitive(60, Nullability::NonNullable),
         SearchResult::Found(20)
+    )]
+    #[case(
+        sparse_low_high(),
+        Scalar::primitive(30, Nullability::NonNullable),
+        SearchResult::Found(17)
     )]
     fn search_fill_right(
         #[case] array: ArrayRef,

--- a/encodings/sparse/src/compute/search_sorted.rs
+++ b/encodings/sparse/src/compute/search_sorted.rs
@@ -19,46 +19,44 @@ impl SearchSortedFn<&SparseArray> for SparseEncoding {
         match patches_result {
             SearchResult::Found(i) => Ok(SearchResult::Found(i)),
             SearchResult::NotFound(i) => {
+                // In not found case we need to find the relative position of fill value to the patches
                 let fill_result = if array.fill_scalar().is_null() {
+                    // For null fill the patches can only ever be after the fill
                     SearchResult::NotFound(array.patches().min_index()?)
                 } else {
                     array
                         .patches()
                         .search_sorted(array.fill_scalar().clone(), side)?
                 };
-                let fill_index = fill_result.to_index();
-                let min_index = array.patches().min_index()?;
-                let max_index = array.patches().max_index()?;
-                let value_index = match side {
-                    SearchSortedSide::Left => {
-                        if fill_index <= min_index {
-                            0
-                        } else if fill_index > max_index {
-                            array.len()
-                        } else {
-                            fill_index
-                        }
-                    }
-                    SearchSortedSide::Right => {
-                        if fill_index <= min_index {
-                            0
-                        } else if fill_index > min_index {
-                            array.len() - array.patches().num_patches() + fill_index
-                        } else {
-                            fill_index
+                let fill_result_index = fill_result.to_index();
+                // Find the relevant position of the fill value in the patches
+                let fill_index = if fill_result_index <= array.patches().min_index()? {
+                    // [fill, ..., patch]
+                    0
+                } else if fill_result_index > array.patches().max_index()? {
+                    // [patch, ..., fill]
+                    array.len()
+                } else {
+                    // [patch, fill, ..., fill, patch]
+                    match side {
+                        SearchSortedSide::Left => fill_result_index,
+                        SearchSortedSide::Right => {
+                            array.len() - array.patches().num_patches() + fill_result_index
                         }
                     }
                 };
+
+                // Adjust the position of the search value relative to the position of the fill value
                 match value
                     .partial_cmp(array.fill_scalar())
                     .vortex_expect("value and fill scalar must have same dtype")
                 {
-                    Ordering::Less => Ok(SearchResult::NotFound(i.min(value_index))),
+                    Ordering::Less => Ok(SearchResult::NotFound(i.min(fill_index))),
                     Ordering::Equal => match side {
-                        SearchSortedSide::Left => Ok(SearchResult::Found(i.min(value_index))),
-                        SearchSortedSide::Right => Ok(SearchResult::Found(i.max(value_index))),
+                        SearchSortedSide::Left => Ok(SearchResult::Found(i.min(fill_index))),
+                        SearchSortedSide::Right => Ok(SearchResult::Found(i.max(fill_index))),
                     },
-                    Ordering::Greater => Ok(SearchResult::NotFound(i.max(value_index))),
+                    Ordering::Greater => Ok(SearchResult::NotFound(i.max(fill_index))),
                 }
             }
         }

--- a/fuzz/fuzz_targets/array_ops.rs
+++ b/fuzz/fuzz_targets/array_ops.rs
@@ -21,8 +21,9 @@ fuzz_target!(|fuzz_action: FuzzArrayAction| -> Corpus {
     for (i, (action, expected)) in actions.into_iter().enumerate() {
         match action {
             Action::Compress(c) => {
-                let compressed_array =
-                    fuzz_compress(current_array.to_canonical().unwrap().as_ref(), &c);
+                let compressed_array = c
+                    .compress(current_array.to_canonical().unwrap().as_ref())
+                    .unwrap();
                 assert_array_eq(&expected.array(), &compressed_array, i);
                 current_array = compressed_array;
             }
@@ -50,8 +51,9 @@ fuzz_target!(|fuzz_action: FuzzArrayAction| -> Corpus {
                 ])
                 .contains(&current_array.encoding())
                 {
-                    sorted = fuzz_compress(&sorted, &BtrBlocksCompressor);
+                    sorted = BtrBlocksCompressor.compress(&sorted).unwrap();
                 }
+
                 assert_search_sorted(sorted, s, side, expected.search(), i)
             }
             Action::Filter(mask) => {

--- a/fuzz/fuzz_targets/array_ops.rs
+++ b/fuzz/fuzz_targets/array_ops.rs
@@ -53,7 +53,6 @@ fuzz_target!(|fuzz_action: FuzzArrayAction| -> Corpus {
                 {
                     sorted = BtrBlocksCompressor.compress(&sorted).unwrap();
                 }
-
                 assert_search_sorted(sorted, s, side, expected.search(), i)
             }
             Action::Filter(mask) => {

--- a/fuzz/fuzz_targets/array_ops.rs
+++ b/fuzz/fuzz_targets/array_ops.rs
@@ -65,10 +65,6 @@ fuzz_target!(|fuzz_action: FuzzArrayAction| -> Corpus {
     Corpus::Keep
 });
 
-fn fuzz_compress(array: &dyn Array, compressor: &BtrBlocksCompressor) -> ArrayRef {
-    compressor.compress(array).unwrap()
-}
-
 fn assert_search_sorted(
     array: ArrayRef,
     s: Scalar,

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -217,7 +217,7 @@ impl Patches {
         }
     }
 
-    /// Return the insertion point of [index] in the [Self::indices].
+    /// Return the insertion point of `index` in the [Self::indices].
     pub fn search_index(&self, index: usize) -> VortexResult<SearchResult> {
         search_sorted_usize(&self.indices, index + self.offset, SearchSortedSide::Left)
     }

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -218,7 +218,7 @@ impl Patches {
     }
 
     /// Return the insertion point of [index] in the [Self::indices].
-    fn search_index(&self, index: usize) -> VortexResult<SearchResult> {
+    pub fn search_index(&self, index: usize) -> VortexResult<SearchResult> {
         search_sorted_usize(&self.indices, index + self.offset, SearchSortedSide::Left)
     }
 
@@ -678,6 +678,34 @@ mod test {
             patches.search_sorted(54, SearchSortedSide::Left).unwrap(),
             SearchResult::NotFound(19)
         );
+    }
+
+    #[test]
+    fn search_left_end() {
+        let patches = Patches::new(
+            32,
+            0,
+            buffer![0u8, 1, 2, 31].into_array(),
+            PrimitiveArray::new(
+                buffer![0u8, 0, 32, 127],
+                Validity::from_iter([false, false, true, true]),
+            )
+            .into_array(),
+        );
+        let res = patches.search_sorted(85, SearchSortedSide::Left).unwrap();
+        assert_eq!(res, SearchResult::NotFound(3));
+    }
+
+    #[test]
+    fn search_left() {
+        let patches = Patches::new(
+            20,
+            0,
+            buffer![0u64, 1, 17, 18, 19].into_array(),
+            buffer![11i32, 22, 33, 44, 55].into_array(),
+        );
+        let res = patches.search_sorted(30, SearchSortedSide::Left).unwrap();
+        assert_eq!(res, SearchResult::NotFound(2));
     }
 
     #[rstest]

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -680,34 +680,6 @@ mod test {
         );
     }
 
-    #[test]
-    fn search_left_end() {
-        let patches = Patches::new(
-            32,
-            0,
-            buffer![0u8, 1, 2, 31].into_array(),
-            PrimitiveArray::new(
-                buffer![0u8, 0, 32, 127],
-                Validity::from_iter([false, false, true, true]),
-            )
-            .into_array(),
-        );
-        let res = patches.search_sorted(85, SearchSortedSide::Left).unwrap();
-        assert_eq!(res, SearchResult::NotFound(3));
-    }
-
-    #[test]
-    fn search_left() {
-        let patches = Patches::new(
-            20,
-            0,
-            buffer![0u64, 1, 17, 18, 19].into_array(),
-            buffer![11i32, 22, 33, 44, 55].into_array(),
-        );
-        let res = patches.search_sorted(30, SearchSortedSide::Left).unwrap();
-        assert_eq!(res, SearchResult::NotFound(2));
-    }
-
     #[rstest]
     fn take_wit_nulls(patches: Patches) {
         let taken = patches


### PR DESCRIPTION
Need to add some comments to the code since it took me a while to figure out this flow. The code before was naive and didn't acocunt for fill value that falls in between patch values which could still constitute a sorted sparse array, i.e `[A, fill, fill, fill, B]`