### PR TITLE
Fix TPC-H file regeneration

### DIFF
--- a/.github/workflows/generate-tpch-s3.yml
+++ b/.github/workflows/generate-tpch-s3.yml
@@ -17,8 +17,9 @@ jobs:
   generate_files:
     name: Generate S3 TPCH files
     runs-on:
-      - self-hosted
-      - aws
+      - runs-on=${{ github.run_id }}
+      - family=m7i.2xlarge
+      - image=ubuntu24-full-x64
     env:
       REMOTE_PATH: s3://vortex-bench-dev-eu/tpch-sf1/
       TMPDIR: /work


### PR DESCRIPTION
The job was configured to run on servers we no longer run. Chose a general purpose AWS machine which should be relatively cheap because we don't really care about performance here.