### PR TITLE
chore: Rename `Segment` to `SegmentSpec`

### DIFF
--- a/vortex-datafusion/src/persistent/cache.rs
+++ b/vortex-datafusion/src/persistent/cache.rs
@@ -10,7 +10,7 @@ use vortex_array::aliases::DefaultHashBuilder;
 use vortex_array::stats::{Precision, Stat};
 use vortex_dtype::DType;
 use vortex_error::{VortexError, VortexResult, vortex_err};
-use vortex_file::{Footer, SegmentDescription, VortexOpenOptions};
+use vortex_file::{Footer, SegmentSpec, VortexOpenOptions};
 use vortex_io::ObjectStoreReadAt;
 use vortex_layout::LayoutRegistry;
 use vortex_layout::segments::SegmentId;
@@ -39,7 +39,7 @@ impl From<&ObjectMeta> for Key {
 
 /// Approximate the in-memory size of a layout
 fn estimate_layout_size(footer: &Footer) -> usize {
-    let segments_size = footer.segment_map().len() * size_of::<SegmentDescription>();
+    let segments_size = footer.segment_map().len() * size_of::<SegmentSpec>();
     let stats_size = footer
         .statistics()
         .iter()

--- a/vortex-datafusion/src/persistent/cache.rs
+++ b/vortex-datafusion/src/persistent/cache.rs
@@ -10,7 +10,7 @@ use vortex_array::aliases::DefaultHashBuilder;
 use vortex_array::stats::{Precision, Stat};
 use vortex_dtype::DType;
 use vortex_error::{VortexError, VortexResult, vortex_err};
-use vortex_file::{Footer, Segment, VortexOpenOptions};
+use vortex_file::{Footer, SegmentDescription, VortexOpenOptions};
 use vortex_io::ObjectStoreReadAt;
 use vortex_layout::LayoutRegistry;
 use vortex_layout::segments::SegmentId;
@@ -39,7 +39,7 @@ impl From<&ObjectMeta> for Key {
 
 /// Approximate the in-memory size of a layout
 fn estimate_layout_size(footer: &Footer) -> usize {
-    let segments_size = footer.segment_map().len() * size_of::<Segment>();
+    let segments_size = footer.segment_map().len() * size_of::<SegmentDescription>();
     let stats_size = footer
         .statistics()
         .iter()

--- a/vortex-file/src/footer/mod.rs
+++ b/vortex-file/src/footer/mod.rs
@@ -203,8 +203,7 @@ impl WriteFlatBuffer for FooterFlatBufferWriter {
         let layout_ctx = LayoutContext::empty();
         let layout = self.layout.write_flatbuffer(fbb, &layout_ctx);
 
-        let segments =
-            fbb.create_vector_from_iter(self.segments.iter().map(fb::SegmentSpec::from));
+        let segments = fbb.create_vector_from_iter(self.segments.iter().map(fb::SegmentSpec::from));
         let statistics = self
             .statistics
             .as_ref()

--- a/vortex-file/src/footer/mod.rs
+++ b/vortex-file/src/footer/mod.rs
@@ -22,7 +22,7 @@ pub struct Footer {
     ctx: ArrayContext,
     layout_ctx: LayoutContext,
     layout: Layout,
-    segments: Arc<[Segment]>,
+    segments: Arc<[SegmentDescription]>,
     statistics: Option<Arc<[StatsSet]>>,
 }
 
@@ -36,7 +36,7 @@ impl Footer {
         ctx: ArrayContext,
         layout_ctx: LayoutContext,
         root_layout: Layout,
-        segments: Arc<[Segment]>,
+        segments: Arc<[SegmentDescription]>,
         statistics: Option<Arc<[StatsSet]>>,
     ) -> Self {
         // Note this assertion is `<=` since we allow zero-length segments
@@ -108,7 +108,10 @@ impl Footer {
         let fb_segments = fb
             .segments()
             .ok_or_else(|| vortex_err!("Footer missing segments"))?;
-        let segments = fb_segments.iter().map(Segment::try_from).try_collect()?;
+        let segments = fb_segments
+            .iter()
+            .map(SegmentDescription::try_from)
+            .try_collect()?;
 
         let statistics = fb
             .statistics()
@@ -144,7 +147,7 @@ impl Footer {
     }
 
     /// Returns the segment map of the file.
-    pub fn segment_map(&self) -> &Arc<[Segment]> {
+    pub fn segment_map(&self) -> &Arc<[SegmentDescription]> {
         &self.segments
     }
 
@@ -168,7 +171,7 @@ impl Footer {
     pub(crate) fn flatbuffer_writer<'a>(
         ctx: ArrayContext,
         layout: Layout,
-        segments: Arc<[Segment]>,
+        segments: Arc<[SegmentDescription]>,
         statistics: Option<Arc<[StatsSet]>>,
     ) -> impl WriteFlatBuffer<Target<'a> = fb::Footer<'a>> + FlatBufferRoot {
         FooterFlatBufferWriter {
@@ -183,7 +186,7 @@ impl Footer {
 pub(crate) struct FooterFlatBufferWriter {
     ctx: ArrayContext,
     layout: Layout,
-    segments: Arc<[Segment]>,
+    segments: Arc<[SegmentDescription]>,
     statistics: Option<Arc<[StatsSet]>>,
 }
 
@@ -200,7 +203,8 @@ impl WriteFlatBuffer for FooterFlatBufferWriter {
         let layout_ctx = LayoutContext::empty();
         let layout = self.layout.write_flatbuffer(fbb, &layout_ctx);
 
-        let segments = fbb.create_vector_from_iter(self.segments.iter().map(fb::Segment::from));
+        let segments =
+            fbb.create_vector_from_iter(self.segments.iter().map(fb::SegmentDescription::from));
         let statistics = self
             .statistics
             .as_ref()

--- a/vortex-file/src/footer/mod.rs
+++ b/vortex-file/src/footer/mod.rs
@@ -22,7 +22,7 @@ pub struct Footer {
     ctx: ArrayContext,
     layout_ctx: LayoutContext,
     layout: Layout,
-    segments: Arc<[SegmentDescription]>,
+    segments: Arc<[SegmentSpec]>,
     statistics: Option<Arc<[StatsSet]>>,
 }
 
@@ -36,7 +36,7 @@ impl Footer {
         ctx: ArrayContext,
         layout_ctx: LayoutContext,
         root_layout: Layout,
-        segments: Arc<[SegmentDescription]>,
+        segments: Arc<[SegmentSpec]>,
         statistics: Option<Arc<[StatsSet]>>,
     ) -> Self {
         // Note this assertion is `<=` since we allow zero-length segments
@@ -110,7 +110,7 @@ impl Footer {
             .ok_or_else(|| vortex_err!("Footer missing segments"))?;
         let segments = fb_segments
             .iter()
-            .map(SegmentDescription::try_from)
+            .map(SegmentSpec::try_from)
             .try_collect()?;
 
         let statistics = fb
@@ -147,7 +147,7 @@ impl Footer {
     }
 
     /// Returns the segment map of the file.
-    pub fn segment_map(&self) -> &Arc<[SegmentDescription]> {
+    pub fn segment_map(&self) -> &Arc<[SegmentSpec]> {
         &self.segments
     }
 
@@ -171,7 +171,7 @@ impl Footer {
     pub(crate) fn flatbuffer_writer<'a>(
         ctx: ArrayContext,
         layout: Layout,
-        segments: Arc<[SegmentDescription]>,
+        segments: Arc<[SegmentSpec]>,
         statistics: Option<Arc<[StatsSet]>>,
     ) -> impl WriteFlatBuffer<Target<'a> = fb::Footer<'a>> + FlatBufferRoot {
         FooterFlatBufferWriter {
@@ -186,7 +186,7 @@ impl Footer {
 pub(crate) struct FooterFlatBufferWriter {
     ctx: ArrayContext,
     layout: Layout,
-    segments: Arc<[SegmentDescription]>,
+    segments: Arc<[SegmentSpec]>,
     statistics: Option<Arc<[StatsSet]>>,
 }
 
@@ -204,7 +204,7 @@ impl WriteFlatBuffer for FooterFlatBufferWriter {
         let layout = self.layout.write_flatbuffer(fbb, &layout_ctx);
 
         let segments =
-            fbb.create_vector_from_iter(self.segments.iter().map(fb::SegmentDescription::from));
+            fbb.create_vector_from_iter(self.segments.iter().map(fb::SegmentSpec::from));
         let statistics = self
             .statistics
             .as_ref()

--- a/vortex-file/src/footer/postscript.rs
+++ b/vortex-file/src/footer/postscript.rs
@@ -2,12 +2,12 @@ use flatbuffers::Follow;
 use vortex_error::{VortexError, vortex_err};
 use vortex_flatbuffers::{FlatBufferRoot, ReadFlatBuffer, WriteFlatBuffer, footer as fb};
 
-use crate::footer::segment::Segment;
+use crate::footer::segment::SegmentDescription;
 
 /// Captures the layout information of a Vortex file.
 pub(crate) struct Postscript {
-    pub(crate) dtype: Option<Segment>,
-    pub(crate) footer: Segment,
+    pub(crate) dtype: Option<SegmentDescription>,
+    pub(crate) footer: SegmentDescription,
 }
 
 impl FlatBufferRoot for Postscript {}
@@ -19,8 +19,8 @@ impl WriteFlatBuffer for Postscript {
         &self,
         fbb: &mut flatbuffers::FlatBufferBuilder<'fb>,
     ) -> flatbuffers::WIPOffset<Self::Target<'fb>> {
-        let dtype = self.dtype.as_ref().map(fb::Segment::from);
-        let footer = fb::Segment::from(&self.footer);
+        let dtype = self.dtype.as_ref().map(fb::SegmentDescription::from);
+        let footer = fb::SegmentDescription::from(&self.footer);
         fb::Postscript::create(
             fbb,
             &fb::PostscriptArgs {
@@ -39,8 +39,8 @@ impl ReadFlatBuffer for Postscript {
         fb: &<Self::Source<'buf> as Follow<'buf>>::Inner,
     ) -> Result<Self, Self::Error> {
         Ok(Self {
-            dtype: fb.dtype().map(Segment::try_from).transpose()?,
-            footer: Segment::try_from(
+            dtype: fb.dtype().map(SegmentDescription::try_from).transpose()?,
+            footer: SegmentDescription::try_from(
                 fb.footer()
                     .ok_or_else(|| vortex_err!("Postscript missing footer segment"))?,
             )?,

--- a/vortex-file/src/footer/postscript.rs
+++ b/vortex-file/src/footer/postscript.rs
@@ -2,12 +2,12 @@ use flatbuffers::Follow;
 use vortex_error::{VortexError, vortex_err};
 use vortex_flatbuffers::{FlatBufferRoot, ReadFlatBuffer, WriteFlatBuffer, footer as fb};
 
-use crate::footer::segment::SegmentDescription;
+use crate::footer::segment::SegmentSpec;
 
 /// Captures the layout information of a Vortex file.
 pub(crate) struct Postscript {
-    pub(crate) dtype: Option<SegmentDescription>,
-    pub(crate) footer: SegmentDescription,
+    pub(crate) dtype: Option<SegmentSpec>,
+    pub(crate) footer: SegmentSpec,
 }
 
 impl FlatBufferRoot for Postscript {}
@@ -19,8 +19,8 @@ impl WriteFlatBuffer for Postscript {
         &self,
         fbb: &mut flatbuffers::FlatBufferBuilder<'fb>,
     ) -> flatbuffers::WIPOffset<Self::Target<'fb>> {
-        let dtype = self.dtype.as_ref().map(fb::SegmentDescription::from);
-        let footer = fb::SegmentDescription::from(&self.footer);
+        let dtype = self.dtype.as_ref().map(fb::SegmentSpec::from);
+        let footer = fb::SegmentSpec::from(&self.footer);
         fb::Postscript::create(
             fbb,
             &fb::PostscriptArgs {
@@ -39,8 +39,8 @@ impl ReadFlatBuffer for Postscript {
         fb: &<Self::Source<'buf> as Follow<'buf>>::Inner,
     ) -> Result<Self, Self::Error> {
         Ok(Self {
-            dtype: fb.dtype().map(SegmentDescription::try_from).transpose()?,
-            footer: SegmentDescription::try_from(
+            dtype: fb.dtype().map(SegmentSpec::try_from).transpose()?,
+            footer: SegmentSpec::try_from(
                 fb.footer()
                     .ok_or_else(|| vortex_err!("Postscript missing footer segment"))?,
             )?,

--- a/vortex-file/src/footer/segment.rs
+++ b/vortex-file/src/footer/segment.rs
@@ -4,22 +4,22 @@ use vortex_flatbuffers::footer as fb;
 
 /// The location of a segment within a Vortex file.
 #[derive(Clone, Debug)]
-pub struct Segment {
+pub struct SegmentDescription {
     pub offset: u64,
     pub length: u32,
     pub alignment: Alignment,
 }
 
-impl From<&Segment> for fb::Segment {
-    fn from(value: &Segment) -> Self {
-        fb::Segment::new(value.offset, value.length, value.alignment.exponent(), 0, 0)
+impl From<&SegmentDescription> for fb::SegmentDescription {
+    fn from(value: &SegmentDescription) -> Self {
+        fb::SegmentDescription::new(value.offset, value.length, value.alignment.exponent(), 0, 0)
     }
 }
 
-impl TryFrom<&fb::Segment> for Segment {
+impl TryFrom<&fb::SegmentDescription> for SegmentDescription {
     type Error = VortexError;
 
-    fn try_from(value: &fb::Segment) -> Result<Self, Self::Error> {
+    fn try_from(value: &fb::SegmentDescription) -> Result<Self, Self::Error> {
         Ok(Self {
             offset: value.offset(),
             length: value.length(),

--- a/vortex-file/src/footer/segment.rs
+++ b/vortex-file/src/footer/segment.rs
@@ -4,22 +4,22 @@ use vortex_flatbuffers::footer as fb;
 
 /// The location of a segment within a Vortex file.
 #[derive(Clone, Debug)]
-pub struct SegmentDescription {
+pub struct SegmentSpec {
     pub offset: u64,
     pub length: u32,
     pub alignment: Alignment,
 }
 
-impl From<&SegmentDescription> for fb::SegmentDescription {
-    fn from(value: &SegmentDescription) -> Self {
-        fb::SegmentDescription::new(value.offset, value.length, value.alignment.exponent(), 0, 0)
+impl From<&SegmentSpec> for fb::SegmentSpec {
+    fn from(value: &SegmentSpec) -> Self {
+        fb::SegmentSpec::new(value.offset, value.length, value.alignment.exponent(), 0, 0)
     }
 }
 
-impl TryFrom<&fb::SegmentDescription> for SegmentDescription {
+impl TryFrom<&fb::SegmentSpec> for SegmentSpec {
     type Error = VortexError;
 
-    fn try_from(value: &fb::SegmentDescription) -> Result<Self, Self::Error> {
+    fn try_from(value: &fb::SegmentSpec) -> Result<Self, Self::Error> {
         Ok(Self {
             offset: value.offset(),
             length: value.length(),

--- a/vortex-file/src/generic.rs
+++ b/vortex-file/src/generic.rs
@@ -19,7 +19,7 @@ use vortex_layout::scan::ScanDriver;
 use vortex_layout::segments::{AsyncSegmentReader, SegmentEvent, SegmentId, SegmentStream};
 use vortex_metrics::{Counter, VortexMetrics};
 
-use crate::footer::{Footer, SegmentDescription};
+use crate::footer::{Footer, SegmentSpec};
 use crate::segments::channel::SegmentChannel;
 use crate::segments::{InMemorySegmentCache, SegmentCache};
 use crate::{FileType, VortexOpenOptions};
@@ -344,24 +344,20 @@ where
 #[derive(Debug)]
 struct SegmentRequest {
     id: SegmentId,
-    location: SegmentDescription,
+    spec: SegmentSpec,
     cancel_handle: oneshot::Receiver<()>,
 }
 
 impl SegmentRequest {
-    fn new(
-        id: SegmentId,
-        location: SegmentDescription,
-        cancel_handle: oneshot::Receiver<()>,
-    ) -> Self {
+    fn new(id: SegmentId, spec: SegmentSpec, cancel_handle: oneshot::Receiver<()>) -> Self {
         Self {
             id,
-            location,
+            spec,
             cancel_handle,
         }
     }
     fn range(&self) -> Range<u64> {
-        self.location.offset..self.location.offset + self.location.length as u64
+        self.spec.offset..self.spec.offset + self.spec.length as u64
     }
 }
 
@@ -370,7 +366,7 @@ async fn filter_with_cache(
     cache: Arc<dyn SegmentCache>,
     inflight_segments: InflightSegments,
 ) -> Option<SegmentRequest> {
-    match cache.get(request.id, request.location.alignment).await {
+    match cache.get(request.id, request.spec.alignment).await {
         Ok(None) => {}
         Ok(Some(buffer)) => {
             inflight_segments.complete(request.id, Ok(buffer));
@@ -393,7 +389,7 @@ struct CoalescedSegmentRequest {
     /// The range of the file to read.
     pub(crate) byte_range: Range<u64>,
     /// The original segment requests, ordered by segment ID.
-    pub(crate) requests: Vec<(SegmentId, SegmentDescription)>,
+    pub(crate) requests: Vec<(SegmentId, SegmentSpec)>,
 }
 
 #[derive(Default)]
@@ -434,7 +430,7 @@ impl CoalescedCancellationHandle {
 async fn evaluate<R: VortexReadAt>(
     read: R,
     request: CoalescedSegmentRequest,
-    segment_map: Arc<[SegmentDescription]>,
+    segment_map: Arc<[SegmentSpec]>,
     segment_cache: Arc<dyn SegmentCache>,
     inflight_segments: InflightSegments,
 ) -> VortexResult<()> {
@@ -520,7 +516,7 @@ fn coalesce(
                     //  to ensure correct alignment for all coalesced buffers.
                     alignment: requests
                         .first()
-                        .map(|r| r.location.alignment)
+                        .map(|r| r.spec.alignment)
                         .unwrap_or(Alignment::none()),
                     byte_range: range.clone(),
                     requests: vec![],
@@ -535,9 +531,9 @@ fn coalesce(
         .collect::<Vec<_>>();
 
     for req in requests {
-        let idx = fetch_ranges.partition_point(|v| v.start <= req.location.offset) - 1;
+        let idx = fetch_ranges.partition_point(|v| v.start <= req.spec.offset) - 1;
         let (ref mut request, ref mut cancellation) = coalesced[idx];
-        request.requests.push((req.id, req.location));
+        request.requests.push((req.id, req.spec));
         cancellation.push(req.cancel_handle);
     }
 

--- a/vortex-file/src/generic.rs
+++ b/vortex-file/src/generic.rs
@@ -19,7 +19,7 @@ use vortex_layout::scan::ScanDriver;
 use vortex_layout::segments::{AsyncSegmentReader, SegmentEvent, SegmentId, SegmentStream};
 use vortex_metrics::{Counter, VortexMetrics};
 
-use crate::footer::{Footer, Segment};
+use crate::footer::{Footer, SegmentDescription};
 use crate::segments::channel::SegmentChannel;
 use crate::segments::{InMemorySegmentCache, SegmentCache};
 use crate::{FileType, VortexOpenOptions};
@@ -332,12 +332,16 @@ where
 #[derive(Debug)]
 struct SegmentRequest {
     id: SegmentId,
-    location: Segment,
+    location: SegmentDescription,
     cancel_handle: oneshot::Receiver<()>,
 }
 
 impl SegmentRequest {
-    fn new(id: SegmentId, location: Segment, cancel_handle: oneshot::Receiver<()>) -> Self {
+    fn new(
+        id: SegmentId,
+        location: SegmentDescription,
+        cancel_handle: oneshot::Receiver<()>,
+    ) -> Self {
         Self {
             id,
             location,
@@ -349,8 +353,8 @@ impl SegmentRequest {
     }
 }
 
-impl From<(SegmentId, Segment, oneshot::Receiver<()>)> for SegmentRequest {
-    fn from(value: (SegmentId, Segment, oneshot::Receiver<()>)) -> Self {
+impl From<(SegmentId, SegmentDescription, oneshot::Receiver<()>)> for SegmentRequest {
+    fn from(value: (SegmentId, SegmentDescription, oneshot::Receiver<()>)) -> Self {
         let (id, location, cancel_handle) = value;
         SegmentRequest {
             id,
@@ -388,7 +392,7 @@ struct CoalescedSegmentRequest {
     /// The range of the file to read.
     pub(crate) byte_range: Range<u64>,
     /// The original segment requests, ordered by segment ID.
-    pub(crate) requests: Vec<(SegmentId, Segment)>,
+    pub(crate) requests: Vec<(SegmentId, SegmentDescription)>,
 }
 
 #[derive(Default)]
@@ -411,7 +415,7 @@ impl CoalescedCancellationHandle {
 async fn evaluate<R: VortexReadAt>(
     read: R,
     request: CoalescedSegmentRequest,
-    segment_map: Arc<[Segment]>,
+    segment_map: Arc<[SegmentDescription]>,
     segment_cache: Arc<dyn SegmentCache>,
     inflight_segments: InflightSegments,
 ) -> VortexResult<()> {

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -105,7 +105,7 @@ mod writer;
 use std::sync::{Arc, LazyLock};
 
 pub use file::*;
-pub use footer::{Footer, Segment};
+pub use footer::{Footer, SegmentDescription};
 pub use forever_constant::*;
 pub use generic::*;
 pub use memory::*;

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -105,7 +105,7 @@ mod writer;
 use std::sync::{Arc, LazyLock};
 
 pub use file::*;
-pub use footer::{Footer, SegmentDescription};
+pub use footer::{Footer, SegmentSpec};
 pub use forever_constant::*;
 pub use generic::*;
 pub use memory::*;

--- a/vortex-file/src/memory.rs
+++ b/vortex-file/src/memory.rs
@@ -9,7 +9,7 @@ use vortex_layout::segments::{AsyncSegmentReader, SegmentId, SegmentStream};
 use vortex_metrics::VortexMetrics;
 
 use crate::segments::SegmentCache;
-use crate::{FileType, Footer, SegmentDescription, VortexOpenOptions};
+use crate::{FileType, Footer, SegmentSpec, VortexOpenOptions};
 
 /// A Vortex file that is backed by an in-memory buffer.
 ///
@@ -60,7 +60,7 @@ impl ScanDriver for InMemoryVortexFile {
 #[async_trait]
 impl AsyncSegmentReader for InMemoryVortexFile {
     async fn get(&self, id: SegmentId) -> VortexResult<ByteBuffer> {
-        let segment: &SegmentDescription = self
+        let segment: &SegmentSpec = self
             .footer
             .segment_map()
             .get(*id as usize)

--- a/vortex-file/src/memory.rs
+++ b/vortex-file/src/memory.rs
@@ -9,7 +9,7 @@ use vortex_layout::segments::{AsyncSegmentReader, SegmentId, SegmentStream};
 use vortex_metrics::VortexMetrics;
 
 use crate::segments::SegmentCache;
-use crate::{FileType, Footer, Segment, VortexOpenOptions};
+use crate::{FileType, Footer, SegmentDescription, VortexOpenOptions};
 
 /// A Vortex file that is backed by an in-memory buffer.
 ///
@@ -60,7 +60,7 @@ impl ScanDriver for InMemoryVortexFile {
 #[async_trait]
 impl AsyncSegmentReader for InMemoryVortexFile {
     async fn get(&self, id: SegmentId) -> VortexResult<ByteBuffer> {
-        let segment: &Segment = self
+        let segment: &SegmentDescription = self
             .footer
             .segment_map()
             .get(*id as usize)

--- a/vortex-file/src/open.rs
+++ b/vortex-file/src/open.rs
@@ -15,7 +15,7 @@ use vortex_layout::segments::SegmentId;
 use vortex_layout::{LayoutRegistry, LayoutRegistryExt};
 use vortex_metrics::VortexMetrics;
 
-use crate::footer::{Footer, Postscript, SegmentDescription};
+use crate::footer::{Footer, Postscript, SegmentSpec};
 use crate::segments::{NoOpSegmentCache, SegmentCache};
 use crate::{DEFAULT_REGISTRY, EOF_SIZE, MAGIC_BYTES, MAX_FOOTER_SIZE, VERSION, VortexFile};
 
@@ -272,7 +272,7 @@ impl<F: FileType> VortexOpenOptions<F> {
         &self,
         initial_offset: u64,
         initial_read: &ByteBuffer,
-        dtype: SegmentDescription,
+        dtype: SegmentSpec,
     ) -> VortexResult<DType> {
         let offset = usize::try_from(dtype.offset - initial_offset)?;
         let sliced_buffer =
@@ -287,7 +287,7 @@ impl<F: FileType> VortexOpenOptions<F> {
         &self,
         initial_offset: u64,
         initial_read: &ByteBuffer,
-        segment: SegmentDescription,
+        segment: SegmentSpec,
         dtype: DType,
     ) -> VortexResult<Footer> {
         let offset = usize::try_from(segment.offset - initial_offset)?;

--- a/vortex-file/src/open.rs
+++ b/vortex-file/src/open.rs
@@ -15,7 +15,7 @@ use vortex_layout::segments::SegmentId;
 use vortex_layout::{LayoutRegistry, LayoutRegistryExt};
 use vortex_metrics::VortexMetrics;
 
-use crate::footer::{Footer, Postscript, Segment};
+use crate::footer::{Footer, Postscript, SegmentDescription};
 use crate::segments::{NoOpSegmentCache, SegmentCache};
 use crate::{DEFAULT_REGISTRY, EOF_SIZE, MAGIC_BYTES, MAX_FOOTER_SIZE, VERSION, VortexFile};
 
@@ -272,7 +272,7 @@ impl<F: FileType> VortexOpenOptions<F> {
         &self,
         initial_offset: u64,
         initial_read: &ByteBuffer,
-        dtype: Segment,
+        dtype: SegmentDescription,
     ) -> VortexResult<DType> {
         let offset = usize::try_from(dtype.offset - initial_offset)?;
         let sliced_buffer =
@@ -287,7 +287,7 @@ impl<F: FileType> VortexOpenOptions<F> {
         &self,
         initial_offset: u64,
         initial_read: &ByteBuffer,
-        segment: Segment,
+        segment: SegmentDescription,
         dtype: DType,
     ) -> VortexResult<Footer> {
         let offset = usize::try_from(segment.offset - initial_offset)?;

--- a/vortex-file/src/segments/writer.rs
+++ b/vortex-file/src/segments/writer.rs
@@ -3,7 +3,7 @@ use vortex_error::{VortexResult, vortex_err};
 use vortex_io::VortexWrite;
 use vortex_layout::segments::{SegmentId, SegmentWriter};
 
-use crate::footer::SegmentDescription;
+use crate::footer::SegmentSpec;
 
 /// A segment writer that holds buffers in memory until they are flushed by a writer.
 #[derive(Default)]
@@ -27,7 +27,7 @@ impl BufferedSegmentWriter {
     pub async fn flush_async<W: VortexWrite>(
         &mut self,
         writer: &mut futures::io::Cursor<W>,
-        segment_descriptions: &mut Vec<SegmentDescription>,
+        segment_descriptions: &mut Vec<SegmentSpec>,
     ) -> VortexResult<()> {
         for buffers in self.segments_buffers.drain(..) {
             // The API requires us to write these buffers contiguously. Therefore, we can only
@@ -53,7 +53,7 @@ impl BufferedSegmentWriter {
                 writer.write_all(buffer).await?;
             }
 
-            segment_descriptions.push(SegmentDescription {
+            segment_descriptions.push(SegmentSpec {
                 offset,
                 length: u32::try_from(writer.position() - offset)
                     .map_err(|_| vortex_err!("segment length exceeds maximum u32"))?,

--- a/vortex-file/src/segments/writer.rs
+++ b/vortex-file/src/segments/writer.rs
@@ -3,18 +3,19 @@ use vortex_error::{VortexResult, vortex_err};
 use vortex_io::VortexWrite;
 use vortex_layout::segments::{SegmentId, SegmentWriter};
 
-use crate::footer::Segment;
+use crate::footer::SegmentDescription;
 
 /// A segment writer that holds buffers in memory until they are flushed by a writer.
 #[derive(Default)]
 pub(crate) struct BufferedSegmentWriter {
-    segments: Vec<Vec<ByteBuffer>>,
+    /// A Vec byte buffers for segments
+    segments_buffers: Vec<Vec<ByteBuffer>>,
     next_id: SegmentId,
 }
 
 impl SegmentWriter for BufferedSegmentWriter {
     fn put(&mut self, data: &[ByteBuffer]) -> SegmentId {
-        self.segments.push(data.to_vec());
+        self.segments_buffers.push(data.to_vec());
         let id = self.next_id;
         self.next_id = SegmentId::from(*self.next_id + 1);
         id
@@ -25,10 +26,10 @@ impl BufferedSegmentWriter {
     /// Flush the segments to the provided async writer.
     pub async fn flush_async<W: VortexWrite>(
         &mut self,
-        write: &mut futures::io::Cursor<W>,
-        segments: &mut Vec<Segment>,
+        writer: &mut futures::io::Cursor<W>,
+        segment_descriptions: &mut Vec<SegmentDescription>,
     ) -> VortexResult<()> {
-        for buffers in self.segments.drain(..) {
+        for buffers in self.segments_buffers.drain(..) {
             // The API requires us to write these buffers contiguously. Therefore, we can only
             // respect the alignment of the first one.
             // Don't worry, in most cases the caller knows what they're doing and will align the
@@ -39,22 +40,22 @@ impl BufferedSegmentWriter {
                 .unwrap_or_else(Alignment::none);
 
             // Add any padding required to align the segment.
-            let offset = write.position();
+            let offset = writer.position();
             let padding = offset.next_multiple_of(*alignment as u64) - offset;
             if padding > 0 {
-                write
+                writer
                     .write_all(ByteBuffer::zeroed(padding as usize))
                     .await?;
             }
-            let offset = write.position();
+            let offset = writer.position();
 
             for buffer in buffers {
-                write.write_all(buffer).await?;
+                writer.write_all(buffer).await?;
             }
 
-            segments.push(Segment {
+            segment_descriptions.push(SegmentDescription {
                 offset,
-                length: u32::try_from(write.position() - offset)
+                length: u32::try_from(writer.position() - offset)
                     .map_err(|_| vortex_err!("segment length exceeds maximum u32"))?,
                 alignment,
             });

--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -8,7 +8,7 @@ use vortex_io::VortexWrite;
 use vortex_layout::stats::FileStatsLayoutWriter;
 use vortex_layout::{LayoutStrategy, LayoutWriter};
 
-use crate::footer::{Footer, Postscript, SegmentDescription};
+use crate::footer::{Footer, Postscript, SegmentSpec};
 use crate::segments::writer::BufferedSegmentWriter;
 use crate::strategy::VortexLayoutStrategy;
 use crate::{EOF_SIZE, MAGIC_BYTES, MAX_FOOTER_SIZE, VERSION};
@@ -148,10 +148,10 @@ impl VortexWriteOptions {
         &self,
         write: &mut futures::io::Cursor<W>,
         flatbuffer: &F,
-    ) -> VortexResult<SegmentDescription> {
+    ) -> VortexResult<SegmentSpec> {
         let layout_offset = write.position();
         write.write_all(flatbuffer.write_flatbuffer_bytes()).await?;
-        Ok(SegmentDescription {
+        Ok(SegmentSpec {
             offset: layout_offset,
             length: u32::try_from(write.position() - layout_offset)
                 .map_err(|_| vortex_err!("segment length exceeds maximum u32"))?,

--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -8,7 +8,7 @@ use vortex_io::VortexWrite;
 use vortex_layout::stats::FileStatsLayoutWriter;
 use vortex_layout::{LayoutStrategy, LayoutWriter};
 
-use crate::footer::{Footer, Postscript, Segment};
+use crate::footer::{Footer, Postscript, SegmentDescription};
 use crate::segments::writer::BufferedSegmentWriter;
 use crate::strategy::VortexLayoutStrategy;
 use crate::{EOF_SIZE, MAGIC_BYTES, MAX_FOOTER_SIZE, VERSION};
@@ -55,7 +55,7 @@ impl VortexWriteOptions {
     /// Perform an async write of the provided stream of `Array`.
     pub async fn write<W: VortexWrite, S: ArrayStream + Unpin>(
         self,
-        write: W,
+        writer: W,
         mut stream: S,
     ) -> VortexResult<W> {
         // Set up a Context to capture the encodings used in the file.
@@ -69,27 +69,28 @@ impl VortexWriteOptions {
         )?;
 
         // First we write the magic number
-        let mut write = futures::io::Cursor::new(write);
-        write.write_all(MAGIC_BYTES).await?;
+        let mut writer = futures::io::Cursor::new(writer);
+        writer.write_all(MAGIC_BYTES).await?;
 
         // Our buffered message writer accumulates messages for each batch so we can flush them
         // into the file.
         let mut segment_writer = BufferedSegmentWriter::default();
-        let mut segments = vec![];
+        let mut segment_descriptions = vec![];
 
         // Then write the stream via the root layout
         while let Some(chunk) = stream.next().await {
-            layout_writer.push_chunk(&mut segment_writer, chunk?)?;
+            let chunk = chunk?;
+            layout_writer.push_chunk(&mut segment_writer, chunk)?;
             // NOTE(ngates): we could spawn this task and continue to compress the next chunk.
             segment_writer
-                .flush_async(&mut write, &mut segments)
+                .flush_async(&mut writer, &mut segment_descriptions)
                 .await?;
         }
 
         // Flush the final layout messages into the file
         let layout = layout_writer.finish(&mut segment_writer)?;
         segment_writer
-            .flush_async(&mut write, &mut segments)
+            .flush_async(&mut writer, &mut segment_descriptions)
             .await?;
 
         // Write the DType, followed by the Footer. We choose this order because in many cases
@@ -99,16 +100,16 @@ impl VortexWriteOptions {
         let dtype_segment = if self.exclude_dtype {
             None
         } else {
-            Some(self.write_flatbuffer(&mut write, stream.dtype()).await?)
+            Some(self.write_flatbuffer(&mut writer, stream.dtype()).await?)
         };
 
         let footer_segment = self
             .write_flatbuffer(
-                &mut write,
+                &mut writer,
                 &Footer::flatbuffer_writer(
                     ctx,
                     layout,
-                    segments.into(),
+                    segment_descriptions.into(),
                     self.file_statistics
                         .is_some()
                         .then(|| layout_writer.into_stats_sets().into()),
@@ -131,26 +132,26 @@ impl VortexWriteOptions {
         }
         let postscript_len = u16::try_from(postscript_buffer.len())
             .vortex_expect("Postscript already verified to fit into u16");
-        write.write_all(postscript_buffer).await?;
+        writer.write_all(postscript_buffer).await?;
 
         // And finally, the EOF 8-byte footer.
         let mut eof = [0u8; EOF_SIZE];
         eof[0..2].copy_from_slice(&VERSION.to_le_bytes());
         eof[2..4].copy_from_slice(&postscript_len.to_le_bytes());
         eof[4..8].copy_from_slice(&MAGIC_BYTES);
-        write.write_all(eof).await?;
+        writer.write_all(eof).await?;
 
-        Ok(write.into_inner())
+        Ok(writer.into_inner())
     }
 
     async fn write_flatbuffer<W: VortexWrite, F: FlatBufferRoot + WriteFlatBuffer>(
         &self,
         write: &mut futures::io::Cursor<W>,
         flatbuffer: &F,
-    ) -> VortexResult<Segment> {
+    ) -> VortexResult<SegmentDescription> {
         let layout_offset = write.position();
         write.write_all(flatbuffer.write_flatbuffer_bytes()).await?;
-        Ok(Segment {
+        Ok(SegmentDescription {
             offset: layout_offset,
             length: u32::try_from(write.position() - layout_offset)
                 .map_err(|_| vortex_err!("segment length exceeds maximum u32"))?,

--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -55,7 +55,7 @@ impl VortexWriteOptions {
     /// Perform an async write of the provided stream of `Array`.
     pub async fn write<W: VortexWrite, S: ArrayStream + Unpin>(
         self,
-        writer: W,
+        write: W,
         mut stream: S,
     ) -> VortexResult<W> {
         // Set up a Context to capture the encodings used in the file.
@@ -69,13 +69,13 @@ impl VortexWriteOptions {
         )?;
 
         // First we write the magic number
-        let mut writer = futures::io::Cursor::new(writer);
-        writer.write_all(MAGIC_BYTES).await?;
+        let mut write = futures::io::Cursor::new(write);
+        write.write_all(MAGIC_BYTES).await?;
 
         // Our buffered message writer accumulates messages for each batch so we can flush them
         // into the file.
         let mut segment_writer = BufferedSegmentWriter::default();
-        let mut segment_descriptions = vec![];
+        let mut segment_map = vec![];
 
         // Then write the stream via the root layout
         while let Some(chunk) = stream.next().await {
@@ -83,14 +83,14 @@ impl VortexWriteOptions {
             layout_writer.push_chunk(&mut segment_writer, chunk)?;
             // NOTE(ngates): we could spawn this task and continue to compress the next chunk.
             segment_writer
-                .flush_async(&mut writer, &mut segment_descriptions)
+                .flush_async(&mut write, &mut segment_map)
                 .await?;
         }
 
         // Flush the final layout messages into the file
         let layout = layout_writer.finish(&mut segment_writer)?;
         segment_writer
-            .flush_async(&mut writer, &mut segment_descriptions)
+            .flush_async(&mut write, &mut segment_map)
             .await?;
 
         // Write the DType, followed by the Footer. We choose this order because in many cases
@@ -100,16 +100,16 @@ impl VortexWriteOptions {
         let dtype_segment = if self.exclude_dtype {
             None
         } else {
-            Some(self.write_flatbuffer(&mut writer, stream.dtype()).await?)
+            Some(self.write_flatbuffer(&mut write, stream.dtype()).await?)
         };
 
         let footer_segment = self
             .write_flatbuffer(
-                &mut writer,
+                &mut write,
                 &Footer::flatbuffer_writer(
                     ctx,
                     layout,
-                    segment_descriptions.into(),
+                    segment_map.into(),
                     self.file_statistics
                         .is_some()
                         .then(|| layout_writer.into_stats_sets().into()),
@@ -132,16 +132,16 @@ impl VortexWriteOptions {
         }
         let postscript_len = u16::try_from(postscript_buffer.len())
             .vortex_expect("Postscript already verified to fit into u16");
-        writer.write_all(postscript_buffer).await?;
+        write.write_all(postscript_buffer).await?;
 
         // And finally, the EOF 8-byte footer.
         let mut eof = [0u8; EOF_SIZE];
         eof[0..2].copy_from_slice(&VERSION.to_le_bytes());
         eof[2..4].copy_from_slice(&postscript_len.to_le_bytes());
         eof[4..8].copy_from_slice(&MAGIC_BYTES);
-        writer.write_all(eof).await?;
+        write.write_all(eof).await?;
 
-        Ok(writer.into_inner())
+        Ok(write.into_inner())
     }
 
     async fn write_flatbuffer<W: VortexWrite, F: FlatBufferRoot + WriteFlatBuffer>(

--- a/vortex-flatbuffers/flatbuffers/vortex-file/footer.fbs
+++ b/vortex-flatbuffers/flatbuffers/vortex-file/footer.fbs
@@ -5,14 +5,14 @@ include "vortex-layout/layout.fbs";
 /// The `Footer` stores the root `Layout` as well as location information for each referenced segment.
 table Footer {
     layout: Layout;
-    segments: [SegmentDescription];
+    segments: [SegmentSpec];
     statistics: [ArrayStats];
     array_encodings: [ArrayEncoding];
     layout_encodings: [LayoutEncoding];
 }
 
-/// A `SegmentDescription` acts as the locator for a buffer within the file.
-struct SegmentDescription {
+/// A `SegmentSpec` acts as the locator for a buffer within the file.
+struct SegmentSpec {
     offset: uint64;
     length: uint32;
     alignment_exponent: uint8;
@@ -48,8 +48,8 @@ table LayoutEncoding {
 /// The initial read of a Vortex file is always at least 64KB (u16::MAX bytes) and therefore
 /// is guaranteed to cover at least the Postscript.
 table Postscript {
-    dtype: SegmentDescription;
-    footer: SegmentDescription;
+    dtype: SegmentSpec;
+    footer: SegmentSpec;
 }
 // [postscript]
 

--- a/vortex-flatbuffers/flatbuffers/vortex-file/footer.fbs
+++ b/vortex-flatbuffers/flatbuffers/vortex-file/footer.fbs
@@ -5,14 +5,14 @@ include "vortex-layout/layout.fbs";
 /// The `Footer` stores the root `Layout` as well as location information for each referenced segment.
 table Footer {
     layout: Layout;
-    segments: [Segment];
+    segments: [SegmentDescription];
     statistics: [ArrayStats];
     array_encodings: [ArrayEncoding];
     layout_encodings: [LayoutEncoding];
 }
 
-/// A `Segment` acts as the locator for a buffer within the file.
-struct Segment {
+/// A `SegmentDescription` acts as the locator for a buffer within the file.
+struct SegmentDescription {
     offset: uint64;
     length: uint32;
     alignment_exponent: uint8;
@@ -48,8 +48,8 @@ table LayoutEncoding {
 /// The initial read of a Vortex file is always at least 64KB (u16::MAX bytes) and therefore
 /// is guaranteed to cover at least the Postscript.
 table Postscript {
-    dtype: Segment;
-    footer: Segment;
+    dtype: SegmentDescription;
+    footer: SegmentDescription;
 }
 // [postscript]
 

--- a/vortex-flatbuffers/flatbuffers/vortex-layout/layout.fbs
+++ b/vortex-flatbuffers/flatbuffers/vortex-layout/layout.fbs
@@ -22,7 +22,7 @@ table Layout {
     metadata: [ubyte];
     /// The children of this Layout.
     children: [Layout];
-    /// Identifiers for each `Segment` of data required by this layout.
+    /// Identifiers for each `SegmentDescription` of data required by this layout.
     segments: [uint32];
 }
 

--- a/vortex-flatbuffers/flatbuffers/vortex-layout/layout.fbs
+++ b/vortex-flatbuffers/flatbuffers/vortex-layout/layout.fbs
@@ -22,7 +22,7 @@ table Layout {
     metadata: [ubyte];
     /// The children of this Layout.
     children: [Layout];
-    /// Identifiers for each `SegmentDescription` of data required by this layout.
+    /// Identifiers for each `SegmentSpec` of data required by this layout.
     segments: [uint32];
 }
 

--- a/vortex-flatbuffers/src/generated/footer.rs
+++ b/vortex-flatbuffers/src/generated/footer.rs
@@ -3,8 +3,8 @@
 
 // @generated
 
-use crate::layout::*;
 use crate::scalar::*;
+use crate::layout::*;
 use crate::array::*;
 use crate::dtype::*;
 use core::mem;
@@ -13,19 +13,19 @@ use core::cmp::Ordering;
 extern crate flatbuffers;
 use self::flatbuffers::{EndianScalar, Follow};
 
-/// A `Segment` acts as the locator for a buffer within the file.
-// struct Segment, aligned to 8
+/// A `SegmentDescription` acts as the locator for a buffer within the file.
+// struct SegmentDescription, aligned to 8
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
-pub struct Segment(pub [u8; 16]);
-impl Default for Segment { 
+pub struct SegmentDescription(pub [u8; 16]);
+impl Default for SegmentDescription { 
   fn default() -> Self { 
     Self([0; 16])
   }
 }
-impl core::fmt::Debug for Segment {
+impl core::fmt::Debug for SegmentDescription {
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-    f.debug_struct("Segment")
+    f.debug_struct("SegmentDescription")
       .field("offset", &self.offset())
       .field("length", &self.length())
       .field("alignment_exponent", &self.alignment_exponent())
@@ -35,26 +35,26 @@ impl core::fmt::Debug for Segment {
   }
 }
 
-impl flatbuffers::SimpleToVerifyInSlice for Segment {}
-impl<'a> flatbuffers::Follow<'a> for Segment {
-  type Inner = &'a Segment;
+impl flatbuffers::SimpleToVerifyInSlice for SegmentDescription {}
+impl<'a> flatbuffers::Follow<'a> for SegmentDescription {
+  type Inner = &'a SegmentDescription;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    <&'a Segment>::follow(buf, loc)
+    <&'a SegmentDescription>::follow(buf, loc)
   }
 }
-impl<'a> flatbuffers::Follow<'a> for &'a Segment {
-  type Inner = &'a Segment;
+impl<'a> flatbuffers::Follow<'a> for &'a SegmentDescription {
+  type Inner = &'a SegmentDescription;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    flatbuffers::follow_cast_ref::<Segment>(buf, loc)
+    flatbuffers::follow_cast_ref::<SegmentDescription>(buf, loc)
   }
 }
-impl<'b> flatbuffers::Push for Segment {
-    type Output = Segment;
+impl<'b> flatbuffers::Push for SegmentDescription {
+    type Output = SegmentDescription;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        let src = ::core::slice::from_raw_parts(self as *const Segment as *const u8, <Self as flatbuffers::Push>::size());
+        let src = ::core::slice::from_raw_parts(self as *const SegmentDescription as *const u8, <Self as flatbuffers::Push>::size());
         dst.copy_from_slice(src);
     }
     #[inline]
@@ -63,7 +63,7 @@ impl<'b> flatbuffers::Push for Segment {
     }
 }
 
-impl<'a> flatbuffers::Verifiable for Segment {
+impl<'a> flatbuffers::Verifiable for SegmentDescription {
   #[inline]
   fn run_verifier(
     v: &mut flatbuffers::Verifier, pos: usize
@@ -73,7 +73,7 @@ impl<'a> flatbuffers::Verifiable for Segment {
   }
 }
 
-impl<'a> Segment {
+impl<'a> SegmentDescription {
   #[allow(clippy::too_many_arguments)]
   pub fn new(
     offset: u64,
@@ -288,11 +288,11 @@ impl<'a> Footer<'a> {
     unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<Layout>>(Footer::VT_LAYOUT, None)}
   }
   #[inline]
-  pub fn segments(&self) -> Option<flatbuffers::Vector<'a, Segment>> {
+  pub fn segments(&self) -> Option<flatbuffers::Vector<'a, SegmentDescription>> {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, Segment>>>(Footer::VT_SEGMENTS, None)}
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, SegmentDescription>>>(Footer::VT_SEGMENTS, None)}
   }
   #[inline]
   pub fn statistics(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ArrayStats<'a>>>> {
@@ -325,7 +325,7 @@ impl flatbuffers::Verifiable for Footer<'_> {
     use self::flatbuffers::Verifiable;
     v.visit_table(pos)?
      .visit_field::<flatbuffers::ForwardsUOffset<Layout>>("layout", Self::VT_LAYOUT, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, Segment>>>("segments", Self::VT_SEGMENTS, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, SegmentDescription>>>("segments", Self::VT_SEGMENTS, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<ArrayStats>>>>("statistics", Self::VT_STATISTICS, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<ArrayEncoding>>>>("array_encodings", Self::VT_ARRAY_ENCODINGS, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<LayoutEncoding>>>>("layout_encodings", Self::VT_LAYOUT_ENCODINGS, false)?
@@ -335,7 +335,7 @@ impl flatbuffers::Verifiable for Footer<'_> {
 }
 pub struct FooterArgs<'a> {
     pub layout: Option<flatbuffers::WIPOffset<Layout<'a>>>,
-    pub segments: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, Segment>>>,
+    pub segments: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, SegmentDescription>>>,
     pub statistics: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ArrayStats<'a>>>>>,
     pub array_encodings: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ArrayEncoding<'a>>>>>,
     pub layout_encodings: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<LayoutEncoding<'a>>>>>,
@@ -363,7 +363,7 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> FooterBuilder<'a, 'b, A> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Layout>>(Footer::VT_LAYOUT, layout);
   }
   #[inline]
-  pub fn add_segments(&mut self, segments: flatbuffers::WIPOffset<flatbuffers::Vector<'b , Segment>>) {
+  pub fn add_segments(&mut self, segments: flatbuffers::WIPOffset<flatbuffers::Vector<'b , SegmentDescription>>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Footer::VT_SEGMENTS, segments);
   }
   #[inline]
@@ -649,18 +649,18 @@ impl<'a> Postscript<'a> {
 
 
   #[inline]
-  pub fn dtype(&self) -> Option<&'a Segment> {
+  pub fn dtype(&self) -> Option<&'a SegmentDescription> {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<Segment>(Postscript::VT_DTYPE, None)}
+    unsafe { self._tab.get::<SegmentDescription>(Postscript::VT_DTYPE, None)}
   }
   #[inline]
-  pub fn footer(&self) -> Option<&'a Segment> {
+  pub fn footer(&self) -> Option<&'a SegmentDescription> {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<Segment>(Postscript::VT_FOOTER, None)}
+    unsafe { self._tab.get::<SegmentDescription>(Postscript::VT_FOOTER, None)}
   }
 }
 
@@ -671,15 +671,15 @@ impl flatbuffers::Verifiable for Postscript<'_> {
   ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
     use self::flatbuffers::Verifiable;
     v.visit_table(pos)?
-     .visit_field::<Segment>("dtype", Self::VT_DTYPE, false)?
-     .visit_field::<Segment>("footer", Self::VT_FOOTER, false)?
+     .visit_field::<SegmentDescription>("dtype", Self::VT_DTYPE, false)?
+     .visit_field::<SegmentDescription>("footer", Self::VT_FOOTER, false)?
      .finish();
     Ok(())
   }
 }
 pub struct PostscriptArgs<'a> {
-    pub dtype: Option<&'a Segment>,
-    pub footer: Option<&'a Segment>,
+    pub dtype: Option<&'a SegmentDescription>,
+    pub footer: Option<&'a SegmentDescription>,
 }
 impl<'a> Default for PostscriptArgs<'a> {
   #[inline]
@@ -697,12 +697,12 @@ pub struct PostscriptBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
 }
 impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> PostscriptBuilder<'a, 'b, A> {
   #[inline]
-  pub fn add_dtype(&mut self, dtype: &Segment) {
-    self.fbb_.push_slot_always::<&Segment>(Postscript::VT_DTYPE, dtype);
+  pub fn add_dtype(&mut self, dtype: &SegmentDescription) {
+    self.fbb_.push_slot_always::<&SegmentDescription>(Postscript::VT_DTYPE, dtype);
   }
   #[inline]
-  pub fn add_footer(&mut self, footer: &Segment) {
-    self.fbb_.push_slot_always::<&Segment>(Postscript::VT_FOOTER, footer);
+  pub fn add_footer(&mut self, footer: &SegmentDescription) {
+    self.fbb_.push_slot_always::<&SegmentDescription>(Postscript::VT_FOOTER, footer);
   }
   #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> PostscriptBuilder<'a, 'b, A> {

--- a/vortex-flatbuffers/src/generated/footer.rs
+++ b/vortex-flatbuffers/src/generated/footer.rs
@@ -4,28 +4,28 @@
 // @generated
 
 use crate::scalar::*;
-use crate::layout::*;
 use crate::array::*;
 use crate::dtype::*;
+use crate::layout::*;
 use core::mem;
 use core::cmp::Ordering;
 
 extern crate flatbuffers;
 use self::flatbuffers::{EndianScalar, Follow};
 
-/// A `SegmentDescription` acts as the locator for a buffer within the file.
-// struct SegmentDescription, aligned to 8
+/// A `SegmentSpec` acts as the locator for a buffer within the file.
+// struct SegmentSpec, aligned to 8
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
-pub struct SegmentDescription(pub [u8; 16]);
-impl Default for SegmentDescription { 
+pub struct SegmentSpec(pub [u8; 16]);
+impl Default for SegmentSpec { 
   fn default() -> Self { 
     Self([0; 16])
   }
 }
-impl core::fmt::Debug for SegmentDescription {
+impl core::fmt::Debug for SegmentSpec {
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-    f.debug_struct("SegmentDescription")
+    f.debug_struct("SegmentSpec")
       .field("offset", &self.offset())
       .field("length", &self.length())
       .field("alignment_exponent", &self.alignment_exponent())
@@ -35,26 +35,26 @@ impl core::fmt::Debug for SegmentDescription {
   }
 }
 
-impl flatbuffers::SimpleToVerifyInSlice for SegmentDescription {}
-impl<'a> flatbuffers::Follow<'a> for SegmentDescription {
-  type Inner = &'a SegmentDescription;
+impl flatbuffers::SimpleToVerifyInSlice for SegmentSpec {}
+impl<'a> flatbuffers::Follow<'a> for SegmentSpec {
+  type Inner = &'a SegmentSpec;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    <&'a SegmentDescription>::follow(buf, loc)
+    <&'a SegmentSpec>::follow(buf, loc)
   }
 }
-impl<'a> flatbuffers::Follow<'a> for &'a SegmentDescription {
-  type Inner = &'a SegmentDescription;
+impl<'a> flatbuffers::Follow<'a> for &'a SegmentSpec {
+  type Inner = &'a SegmentSpec;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    flatbuffers::follow_cast_ref::<SegmentDescription>(buf, loc)
+    flatbuffers::follow_cast_ref::<SegmentSpec>(buf, loc)
   }
 }
-impl<'b> flatbuffers::Push for SegmentDescription {
-    type Output = SegmentDescription;
+impl<'b> flatbuffers::Push for SegmentSpec {
+    type Output = SegmentSpec;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        let src = ::core::slice::from_raw_parts(self as *const SegmentDescription as *const u8, <Self as flatbuffers::Push>::size());
+        let src = ::core::slice::from_raw_parts(self as *const SegmentSpec as *const u8, <Self as flatbuffers::Push>::size());
         dst.copy_from_slice(src);
     }
     #[inline]
@@ -63,7 +63,7 @@ impl<'b> flatbuffers::Push for SegmentDescription {
     }
 }
 
-impl<'a> flatbuffers::Verifiable for SegmentDescription {
+impl<'a> flatbuffers::Verifiable for SegmentSpec {
   #[inline]
   fn run_verifier(
     v: &mut flatbuffers::Verifier, pos: usize
@@ -73,7 +73,7 @@ impl<'a> flatbuffers::Verifiable for SegmentDescription {
   }
 }
 
-impl<'a> SegmentDescription {
+impl<'a> SegmentSpec {
   #[allow(clippy::too_many_arguments)]
   pub fn new(
     offset: u64,
@@ -288,11 +288,11 @@ impl<'a> Footer<'a> {
     unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<Layout>>(Footer::VT_LAYOUT, None)}
   }
   #[inline]
-  pub fn segments(&self) -> Option<flatbuffers::Vector<'a, SegmentDescription>> {
+  pub fn segments(&self) -> Option<flatbuffers::Vector<'a, SegmentSpec>> {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, SegmentDescription>>>(Footer::VT_SEGMENTS, None)}
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, SegmentSpec>>>(Footer::VT_SEGMENTS, None)}
   }
   #[inline]
   pub fn statistics(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ArrayStats<'a>>>> {
@@ -325,7 +325,7 @@ impl flatbuffers::Verifiable for Footer<'_> {
     use self::flatbuffers::Verifiable;
     v.visit_table(pos)?
      .visit_field::<flatbuffers::ForwardsUOffset<Layout>>("layout", Self::VT_LAYOUT, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, SegmentDescription>>>("segments", Self::VT_SEGMENTS, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, SegmentSpec>>>("segments", Self::VT_SEGMENTS, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<ArrayStats>>>>("statistics", Self::VT_STATISTICS, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<ArrayEncoding>>>>("array_encodings", Self::VT_ARRAY_ENCODINGS, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<LayoutEncoding>>>>("layout_encodings", Self::VT_LAYOUT_ENCODINGS, false)?
@@ -335,7 +335,7 @@ impl flatbuffers::Verifiable for Footer<'_> {
 }
 pub struct FooterArgs<'a> {
     pub layout: Option<flatbuffers::WIPOffset<Layout<'a>>>,
-    pub segments: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, SegmentDescription>>>,
+    pub segments: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, SegmentSpec>>>,
     pub statistics: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ArrayStats<'a>>>>>,
     pub array_encodings: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ArrayEncoding<'a>>>>>,
     pub layout_encodings: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<LayoutEncoding<'a>>>>>,
@@ -363,7 +363,7 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> FooterBuilder<'a, 'b, A> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Layout>>(Footer::VT_LAYOUT, layout);
   }
   #[inline]
-  pub fn add_segments(&mut self, segments: flatbuffers::WIPOffset<flatbuffers::Vector<'b , SegmentDescription>>) {
+  pub fn add_segments(&mut self, segments: flatbuffers::WIPOffset<flatbuffers::Vector<'b , SegmentSpec>>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Footer::VT_SEGMENTS, segments);
   }
   #[inline]
@@ -649,18 +649,18 @@ impl<'a> Postscript<'a> {
 
 
   #[inline]
-  pub fn dtype(&self) -> Option<&'a SegmentDescription> {
+  pub fn dtype(&self) -> Option<&'a SegmentSpec> {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<SegmentDescription>(Postscript::VT_DTYPE, None)}
+    unsafe { self._tab.get::<SegmentSpec>(Postscript::VT_DTYPE, None)}
   }
   #[inline]
-  pub fn footer(&self) -> Option<&'a SegmentDescription> {
+  pub fn footer(&self) -> Option<&'a SegmentSpec> {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<SegmentDescription>(Postscript::VT_FOOTER, None)}
+    unsafe { self._tab.get::<SegmentSpec>(Postscript::VT_FOOTER, None)}
   }
 }
 
@@ -671,15 +671,15 @@ impl flatbuffers::Verifiable for Postscript<'_> {
   ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
     use self::flatbuffers::Verifiable;
     v.visit_table(pos)?
-     .visit_field::<SegmentDescription>("dtype", Self::VT_DTYPE, false)?
-     .visit_field::<SegmentDescription>("footer", Self::VT_FOOTER, false)?
+     .visit_field::<SegmentSpec>("dtype", Self::VT_DTYPE, false)?
+     .visit_field::<SegmentSpec>("footer", Self::VT_FOOTER, false)?
      .finish();
     Ok(())
   }
 }
 pub struct PostscriptArgs<'a> {
-    pub dtype: Option<&'a SegmentDescription>,
-    pub footer: Option<&'a SegmentDescription>,
+    pub dtype: Option<&'a SegmentSpec>,
+    pub footer: Option<&'a SegmentSpec>,
 }
 impl<'a> Default for PostscriptArgs<'a> {
   #[inline]
@@ -697,12 +697,12 @@ pub struct PostscriptBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
 }
 impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> PostscriptBuilder<'a, 'b, A> {
   #[inline]
-  pub fn add_dtype(&mut self, dtype: &SegmentDescription) {
-    self.fbb_.push_slot_always::<&SegmentDescription>(Postscript::VT_DTYPE, dtype);
+  pub fn add_dtype(&mut self, dtype: &SegmentSpec) {
+    self.fbb_.push_slot_always::<&SegmentSpec>(Postscript::VT_DTYPE, dtype);
   }
   #[inline]
-  pub fn add_footer(&mut self, footer: &SegmentDescription) {
-    self.fbb_.push_slot_always::<&SegmentDescription>(Postscript::VT_FOOTER, footer);
+  pub fn add_footer(&mut self, footer: &SegmentSpec) {
+    self.fbb_.push_slot_always::<&SegmentSpec>(Postscript::VT_FOOTER, footer);
   }
   #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> PostscriptBuilder<'a, 'b, A> {

--- a/vortex-flatbuffers/src/generated/layout.rs
+++ b/vortex-flatbuffers/src/generated/layout.rs
@@ -97,7 +97,7 @@ impl<'a> Layout<'a> {
     // which contains a valid value in this slot
     unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Layout>>>>(Layout::VT_CHILDREN, None)}
   }
-  /// Identifiers for each `Segment` of data required by this layout.
+  /// Identifiers for each `SegmentDescription` of data required by this layout.
   #[inline]
   pub fn segments(&self) -> Option<flatbuffers::Vector<'a, u32>> {
     // Safety:

--- a/vortex-flatbuffers/src/generated/layout.rs
+++ b/vortex-flatbuffers/src/generated/layout.rs
@@ -97,7 +97,7 @@ impl<'a> Layout<'a> {
     // which contains a valid value in this slot
     unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Layout>>>>(Layout::VT_CHILDREN, None)}
   }
-  /// Identifiers for each `SegmentDescription` of data required by this layout.
+  /// Identifiers for each `SegmentSpec` of data required by this layout.
   #[inline]
   pub fn segments(&self) -> Option<flatbuffers::Vector<'a, u32>> {
     // Safety:

--- a/vortex-layout/src/layouts/flat/writer.rs
+++ b/vortex-layout/src/layouts/flat/writer.rs
@@ -64,7 +64,7 @@ fn update_stats(array: &dyn Array, stats: &[Stat]) -> VortexResult<()> {
 impl LayoutWriter for FlatLayoutWriter {
     fn push_chunk(
         &mut self,
-        segments: &mut dyn SegmentWriter,
+        segment_writer: &mut dyn SegmentWriter,
         chunk: ArrayRef,
     ) -> VortexResult<()> {
         if self.layout.is_some() {
@@ -80,7 +80,7 @@ impl LayoutWriter for FlatLayoutWriter {
                 include_padding: self.options.include_padding,
             },
         );
-        let segment_id = segments.put(&buffers);
+        let segment_id = segment_writer.put(&buffers);
 
         self.layout = Some(Layout::new_owned(
             "flat".into(),
@@ -94,7 +94,7 @@ impl LayoutWriter for FlatLayoutWriter {
         Ok(())
     }
 
-    fn finish(&mut self, _segments: &mut dyn SegmentWriter) -> VortexResult<Layout> {
+    fn finish(&mut self, _segment_writer: &mut dyn SegmentWriter) -> VortexResult<Layout> {
         self.layout
             .take()
             .ok_or_else(|| vortex_err!("FlatLayoutStrategy::finish called without push_batch"))

--- a/vortex-layout/src/layouts/stats/writer.rs
+++ b/vortex-layout/src/layouts/stats/writer.rs
@@ -74,7 +74,7 @@ impl StatsLayoutWriter {
 impl LayoutWriter for StatsLayoutWriter {
     fn push_chunk(
         &mut self,
-        segments: &mut dyn SegmentWriter,
+        segment_writer: &mut dyn SegmentWriter,
         chunk: ArrayRef,
     ) -> VortexResult<()> {
         if chunk.len() > self.options.block_size {
@@ -93,11 +93,11 @@ impl LayoutWriter for StatsLayoutWriter {
 
         self.nblocks += 1;
         self.stats_accumulator.push_chunk(&chunk)?;
-        self.child_writer.push_chunk(segments, chunk)
+        self.child_writer.push_chunk(segment_writer, chunk)
     }
 
-    fn finish(&mut self, segments: &mut dyn SegmentWriter) -> VortexResult<Layout> {
-        let child = self.child_writer.finish(segments)?;
+    fn finish(&mut self, segment_writer: &mut dyn SegmentWriter) -> VortexResult<Layout> {
+        let child = self.child_writer.finish(segment_writer)?;
 
         // Collect together the statistics
         let Some(stats_table) = self.stats_accumulator.as_stats_table() else {
@@ -112,7 +112,7 @@ impl LayoutWriter for StatsLayoutWriter {
         let mut stats_writer = self
             .stats_strategy
             .new_writer(&self.ctx, stats_array.dtype())?;
-        let stats_layout = stats_writer.push_one(segments, stats_table.array().clone())?;
+        let stats_layout = stats_writer.push_one(segment_writer, stats_table.array().clone())?;
 
         let mut metadata = ByteBufferMut::empty();
 

--- a/vortex-layout/src/stats.rs
+++ b/vortex-layout/src/stats.rs
@@ -60,7 +60,7 @@ impl FileStatsLayoutWriter {
 impl LayoutWriter for FileStatsLayoutWriter {
     fn push_chunk(
         &mut self,
-        segments: &mut dyn SegmentWriter,
+        segment_writer: &mut dyn SegmentWriter,
         chunk: ArrayRef,
     ) -> VortexResult<()> {
         match chunk.as_struct_typed() {
@@ -73,10 +73,10 @@ impl LayoutWriter for FileStatsLayoutWriter {
                 }
             }
         }
-        self.inner.push_chunk(segments, chunk)
+        self.inner.push_chunk(segment_writer, chunk)
     }
 
-    fn finish(&mut self, segments: &mut dyn SegmentWriter) -> VortexResult<Layout> {
-        self.inner.finish(segments)
+    fn finish(&mut self, segment_writer: &mut dyn SegmentWriter) -> VortexResult<Layout> {
+        self.inner.finish(segment_writer)
     }
 }

--- a/vortex-layout/src/strategy.rs
+++ b/vortex-layout/src/strategy.rs
@@ -32,7 +32,7 @@ pub struct StructStrategy;
 impl LayoutStrategy for StructStrategy {
     fn new_writer(&self, ctx: &ArrayContext, dtype: &DType) -> VortexResult<Box<dyn LayoutWriter>> {
         if let DType::Struct(..) = dtype {
-            StructLayoutWriter::try_new_with_factory(ctx, dtype, StructStrategy).map(|w| w.boxed())
+            StructLayoutWriter::try_new_with_strategy(ctx, dtype, StructStrategy).map(|w| w.boxed())
         } else {
             Ok(FlatLayoutWriter::new(ctx.clone(), dtype.clone(), Default::default()).boxed())
         }

--- a/vortex-layout/src/writer.rs
+++ b/vortex-layout/src/writer.rs
@@ -7,10 +7,13 @@ use crate::segments::SegmentWriter;
 /// A strategy for writing chunks of an array into a layout.
 // [layout writer]
 pub trait LayoutWriter: Send {
-    fn push_chunk(&mut self, segments: &mut dyn SegmentWriter, chunk: ArrayRef)
-    -> VortexResult<()>;
+    fn push_chunk(
+        &mut self,
+        segment_writer: &mut dyn SegmentWriter,
+        chunk: ArrayRef,
+    ) -> VortexResult<()>;
 
-    fn finish(&mut self, segments: &mut dyn SegmentWriter) -> VortexResult<Layout>;
+    fn finish(&mut self, segment_writer: &mut dyn SegmentWriter) -> VortexResult<Layout>;
 }
 // [layout writer]
 
@@ -26,24 +29,24 @@ pub trait LayoutWriterExt: LayoutWriter {
     /// Push a single chunk into the layout writer and return the finished [`Layout`].
     fn push_one(
         &mut self,
-        segments: &mut dyn SegmentWriter,
+        segment_writer: &mut dyn SegmentWriter,
         chunk: ArrayRef,
     ) -> VortexResult<Layout> {
-        self.push_chunk(segments, chunk)?;
-        self.finish(segments)
+        self.push_chunk(segment_writer, chunk)?;
+        self.finish(segment_writer)
     }
 
     /// Push all chunks of the iterator into the layout writer and return the finished
     /// [`Layout`].
     fn push_all<I: IntoIterator<Item = VortexResult<ArrayRef>>>(
         &mut self,
-        segments: &mut dyn SegmentWriter,
+        segment_writer: &mut dyn SegmentWriter,
         iter: I,
     ) -> VortexResult<Layout> {
         for chunk in iter.into_iter() {
-            self.push_chunk(segments, chunk?)?
+            self.push_chunk(segment_writer, chunk?)?
         }
-        self.finish(segments)
+        self.finish(segment_writer)
     }
 }
 

--- a/vortex-layout/src/writers/repartition.rs
+++ b/vortex-layout/src/writers/repartition.rs
@@ -96,7 +96,7 @@ impl RepartitionWriter {
 impl LayoutWriter for RepartitionWriter {
     fn push_chunk(
         &mut self,
-        segments: &mut dyn SegmentWriter,
+        segment_writer: &mut dyn SegmentWriter,
         chunk: ArrayRef,
     ) -> VortexResult<()> {
         // We make sure the chunks are canonical so our nbytes measurement is accurate.
@@ -112,18 +112,18 @@ impl LayoutWriter for RepartitionWriter {
             self.chunks.push_back(c);
             offset = end;
 
-            self.flush(segments)?;
+            self.flush(segment_writer)?;
         }
 
         Ok(())
     }
 
-    fn finish(&mut self, segments: &mut dyn SegmentWriter) -> VortexResult<Layout> {
+    fn finish(&mut self, segment_writer: &mut dyn SegmentWriter) -> VortexResult<Layout> {
         let chunk =
             ChunkedArray::new_unchecked(self.chunks.drain(..).collect(), self.dtype.clone())
                 .to_canonical()?
                 .into_array();
-        self.writer.push_chunk(segments, chunk)?;
-        self.writer.finish(segments)
+        self.writer.push_chunk(segment_writer, chunk)?;
+        self.writer.finish(segment_writer)
     }
 }

--- a/vortex-tui/src/browse/app.rs
+++ b/vortex-tui/src/browse/app.rs
@@ -8,7 +8,7 @@ use ratatui::widgets::ListState;
 use vortex::buffer::{Alignment, ByteBuffer, ByteBufferMut};
 use vortex::dtype::DType;
 use vortex::error::{VortexExpect, VortexResult};
-use vortex::file::{Footer, SegmentDescription, VortexOpenOptions};
+use vortex::file::{Footer, SegmentSpec, VortexOpenOptions};
 use vortex::io::TokioFile;
 use vortex::stats::stats_from_bitset_bytes;
 use vortex_layout::layouts::stats::stats_table::StatsTable;
@@ -36,7 +36,7 @@ pub struct LayoutCursor {
     footer: Footer,
     layout: Layout,
     #[allow(unused)]
-    segment_map: Arc<[SegmentDescription]>,
+    segment_map: Arc<[SegmentSpec]>,
 }
 
 impl LayoutCursor {
@@ -165,7 +165,7 @@ impl LayoutCursor {
         &self.layout
     }
 
-    pub fn segment_description(&self, id: SegmentId) -> &SegmentDescription {
+    pub fn segment_description(&self, id: SegmentId) -> &SegmentSpec {
         &self.segment_map[*id as usize]
     }
 }

--- a/vortex-tui/src/browse/app.rs
+++ b/vortex-tui/src/browse/app.rs
@@ -134,14 +134,14 @@ impl LayoutCursor {
         self.layout
             .segments()
             .last()
-            .map(|id| self.segment_description(id).length as usize)
+            .map(|id| self.segment_spec(id).length as usize)
             .unwrap_or_default()
     }
 
     pub fn segment_size(&self) -> usize {
         self.layout()
             .segments()
-            .map(|id| self.segment_description(id).length as usize)
+            .map(|id| self.segment_spec(id).length as usize)
             .sum()
     }
 
@@ -165,7 +165,7 @@ impl LayoutCursor {
         &self.layout
     }
 
-    pub fn segment_description(&self, id: SegmentId) -> &SegmentSpec {
+    pub fn segment_spec(&self, id: SegmentId) -> &SegmentSpec {
         &self.segment_map[*id as usize]
     }
 }

--- a/vortex-tui/src/browse/app.rs
+++ b/vortex-tui/src/browse/app.rs
@@ -8,7 +8,7 @@ use ratatui::widgets::ListState;
 use vortex::buffer::{Alignment, ByteBuffer, ByteBufferMut};
 use vortex::dtype::DType;
 use vortex::error::{VortexExpect, VortexResult};
-use vortex::file::{Footer, Segment, VortexOpenOptions};
+use vortex::file::{Footer, SegmentDescription, VortexOpenOptions};
 use vortex::io::TokioFile;
 use vortex::stats::stats_from_bitset_bytes;
 use vortex_layout::layouts::stats::stats_table::StatsTable;
@@ -36,7 +36,7 @@ pub struct LayoutCursor {
     footer: Footer,
     layout: Layout,
     #[allow(unused)]
-    segment_map: Arc<[Segment]>,
+    segment_map: Arc<[SegmentDescription]>,
 }
 
 impl LayoutCursor {
@@ -134,14 +134,14 @@ impl LayoutCursor {
         self.layout
             .segments()
             .last()
-            .map(|id| self.segment(id).length as usize)
+            .map(|id| self.segment_description(id).length as usize)
             .unwrap_or_default()
     }
 
     pub fn segment_size(&self) -> usize {
         self.layout()
             .segments()
-            .map(|id| self.segment(id).length as usize)
+            .map(|id| self.segment_description(id).length as usize)
             .sum()
     }
 
@@ -165,7 +165,7 @@ impl LayoutCursor {
         &self.layout
     }
 
-    pub fn segment(&self, id: SegmentId) -> &Segment {
+    pub fn segment_description(&self, id: SegmentId) -> &SegmentDescription {
         &self.segment_map[*id as usize]
     }
 }


### PR DESCRIPTION
I was reading through the writing code and I think these names are clearer, we use `segments/segment` a bunch for different things, so this is an attempt to make things more distinct.