### PR TITLE
remove extra unsafe in view coercion

### DIFF
--- a/vortex-btrblocks/src/string.rs
+++ b/vortex-btrblocks/src/string.rs
@@ -29,15 +29,13 @@ fn estimate_distinct_count(strings: &VarBinViewArray) -> u32 {
     // Iterate the views. Two strings which are equal must have the same first 8-bytes.
     // NOTE: there are cases where this performs pessimally, e.g. when we have strings that all
     // share a 4-byte prefix and have the same length.
-    let mut disinct = HashSet::with_capacity(views.len() / 2);
+    let mut distinct = HashSet::with_capacity(views.len() / 2);
     views.iter().for_each(|&view| {
-        // SAFETY: we're doing bitwise manipulations. Did you expect that to be safe??
-        let view_u128: u128 = unsafe { std::mem::transmute(view) };
-        let len_and_prefix = view_u128 as u64;
-        disinct.insert(len_and_prefix);
+        let len_and_prefix = view.as_u128() as u64;
+        distinct.insert(len_and_prefix);
     });
 
-    disinct
+    distinct
         .len()
         .try_into()
         .vortex_expect("distinct count must fit in u32")


### PR DESCRIPTION
also make it work on native big endian (not that we are planning to run on mainframes anytime soon)