### PR TITLE
Use a bigger disk for benchmark data generation

### DIFF
--- a/.github/workflows/generate-benchmarks-s3.yml
+++ b/.github/workflows/generate-benchmarks-s3.yml
@@ -46,5 +46,5 @@ jobs:
           # We run each query once to make sure we don't upload a file if there's a bug that causes a panic.
           cargo run --release --bin clickbench -- --formats parquet,vortex -i1
           aws s3 rm --recursive s3://vortex-bench-dev-eu/clickbench/
-          aws s3 cp --recursive bench-vortex/data/clickbench s3://vortex-bench-dev-eu/clickbench/
+          aws s3 cp --recursive bench-vortex/data/clickbench_partitioned s3://vortex-bench-dev-eu/clickbench/
           rm -rf bench-vortex/data/clickbench_partitioned/

--- a/.github/workflows/generate-benchmarks-s3.yml
+++ b/.github/workflows/generate-benchmarks-s3.yml
@@ -21,6 +21,7 @@ jobs:
       - family=m7i.2xlarge
       - image=ubuntu24-full-x64
       - spot=false
+      - disk=large
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,13 +31,14 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::375504701696:role/GitHubBenchmarkRole
           aws-region: us-east-1
-      - name: Generate tpch locally
+      - name: Generate TPC-H locally
         shell: bash
         run: |
           # We run each query once to make sure we don't upload a file if there's a bug that causes a panic.
           cargo run --release --bin tpch -- --formats parquet,vortex -i1
           aws s3 rm --recursive s3://vortex-bench-dev-eu/tpch-sf1/
           aws s3 cp --recursive bench-vortex/data/tpch/1 s3://vortex-bench-dev-eu/tpch-sf1/
+          rm -rf bench-vortex/data/tpch/
 
       - name: Generate clickbench locally
         shell: bash
@@ -45,3 +47,4 @@ jobs:
           cargo run --release --bin clickbench -- --formats parquet,vortex -i1
           aws s3 rm --recursive s3://vortex-bench-dev-eu/clickbench/
           aws s3 cp --recursive bench-vortex/data/clickbench s3://vortex-bench-dev-eu/clickbench/
+          rm -rf bench-vortex/data/clickbench_partitioned/


### PR DESCRIPTION
seems like #2704 fills up the disk. This should give us twice as much storage + clean generated data after its uploaded to S3.