### PR TITLE
feat(java): support serializing time/date/timestamp types over FFI

### DIFF
--- a/java/vortex-jni/build.gradle.kts
+++ b/java/vortex-jni/build.gradle.kts
@@ -1,9 +1,13 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
     `java-library`
     `jvm-test-suite`
     `maven-publish`
     id("com.google.protobuf")
+    id("com.gradleup.shadow") version "8.3.6"
 }
+
 
 dependencies {
     api("net.java.dev.jna:jna-platform")
@@ -32,6 +36,17 @@ protobuf {
     protoc {
         artifact = "com.google.protobuf:protoc:4.30.1"
     }
+}
+
+// shade guava and protobuf dependencies
+tasks.withType<ShadowJar>() {
+    archiveClassifier.set("")
+    relocate("com.google.protobuf", "dev.vortex.relocated.com.google.protobuf")
+    relocate("com.google.common", "dev.vortex.relocated.com.google.common")
+}
+
+tasks.build {
+    dependsOn("shadowJar")
 }
 
 publishing {

--- a/java/vortex-jni/build.gradle.kts
+++ b/java/vortex-jni/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
     id("com.gradleup.shadow") version "8.3.6"
 }
 
-
 dependencies {
     api("net.java.dev.jna:jna-platform")
     api("com.google.protobuf:protobuf-java")
@@ -39,7 +38,7 @@ protobuf {
 }
 
 // shade guava and protobuf dependencies
-tasks.withType<ShadowJar>() {
+tasks.withType<ShadowJar> {
     archiveClassifier.set("")
     relocate("com.google.protobuf", "dev.vortex.relocated.com.google.protobuf")
     relocate("com.google.common", "dev.vortex.relocated.com.google.common")

--- a/java/vortex-jni/src/main/java/dev/vortex/DateTimeUtil.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/DateTimeUtil.java
@@ -1,0 +1,37 @@
+/**
+ * (c) Copyright 2025 SpiralDB Inc. All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.vortex;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+
+// Helpful functions borrowed from Iceberg class with same name.
+public final class DateTimeUtil {
+    public static final OffsetDateTime EPOCH = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC);
+
+    // Just assume timestamp is already at UTC for conversion purposes.
+    // When decoded back to LocalDateTime
+    public static long nanosFromTimestamp(LocalDateTime dateTime) {
+        return ChronoUnit.NANOS.between(EPOCH, dateTime.atOffset(ZoneOffset.UTC));
+    }
+
+    public static long nanosFromTimestamptz(OffsetDateTime dateTime) {
+        return ChronoUnit.NANOS.between(EPOCH, dateTime);
+    }
+}

--- a/java/vortex-jni/src/main/java/dev/vortex/api/expressions/Literal.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/api/expressions/Literal.java
@@ -17,6 +17,7 @@ package dev.vortex.api.expressions;
 
 import com.google.common.base.Objects;
 import dev.vortex.api.Expression;
+import java.util.Optional;
 
 public abstract class Literal<T> implements Expression {
     private final T value;
@@ -86,6 +87,42 @@ public abstract class Literal<T> implements Expression {
         return new BytesLiteral(value);
     }
 
+    public static Literal<Integer> timeSeconds(Integer value) {
+        return new TimeSeconds(value);
+    }
+
+    public static Literal<Integer> timeMillis(Integer value) {
+        return new TimeMillis(value);
+    }
+
+    public static Literal<Long> timeMicros(Long value) {
+        return new TimeMicros(value);
+    }
+
+    public static Literal<Long> timeNanos(Long value) {
+        return new TimeNanos(value);
+    }
+
+    public static Literal<Integer> dateDays(Integer value) {
+        return new DateDays(value);
+    }
+
+    public static Literal<Long> dateMillis(Long value) {
+        return new DateMillis(value);
+    }
+
+    public static Literal<Long> timestampMillis(Long value, Optional<String> timeZone) {
+        return new TimestampMillis(value, timeZone);
+    }
+
+    public static Literal<Long> timestampMicros(Long value, Optional<String> timeZone) {
+        return new TimestampMicros(value, timeZone);
+    }
+
+    public static Literal<Long> timestampNanos(Long value, Optional<String> timeZone) {
+        return new TimestampNanos(value, timeZone);
+    }
+
     @Override
     public <R> R accept(Expression.Visitor<R> visitor) {
         return visitor.visitLiteral(this);
@@ -105,6 +142,24 @@ public abstract class Literal<T> implements Expression {
         U visitInt32(Integer literal);
 
         U visitInt64(Long literal);
+
+        U visitDateDays(Integer days);
+
+        U visitDateMillis(Long millis);
+
+        U visitTimeSeconds(Integer seconds);
+
+        U visitTimeMillis(Integer seconds);
+
+        U visitTimeMicros(Long seconds);
+
+        U visitTimeNanos(Long seconds);
+
+        U visitTimestampMillis(Long epochMillis, Optional<String> timeZone);
+
+        U visitTimestampMicros(Long epochMicros, Optional<String> timeZone);
+
+        U visitTimestampNanos(Long epochNanos, Optional<String> timeZone);
 
         U visitFloat32(Float literal);
 
@@ -224,6 +279,114 @@ public abstract class Literal<T> implements Expression {
         @Override
         public <U> U acceptLiteralVisitor(LiteralVisitor<U> visitor) {
             return visitor.visitBytes(getValue());
+        }
+    }
+
+    static final class TimeSeconds extends Literal<Integer> {
+        TimeSeconds(Integer value) {
+            super(value);
+        }
+
+        @Override
+        public <U> U acceptLiteralVisitor(LiteralVisitor<U> visitor) {
+            return visitor.visitTimeSeconds(getValue());
+        }
+    }
+
+    static final class TimeMillis extends Literal<Integer> {
+        TimeMillis(Integer value) {
+            super(value);
+        }
+
+        @Override
+        public <U> U acceptLiteralVisitor(LiteralVisitor<U> visitor) {
+            return visitor.visitTimeMillis(getValue());
+        }
+    }
+
+    static final class TimeMicros extends Literal<Long> {
+        TimeMicros(Long value) {
+            super(value);
+        }
+
+        @Override
+        public <U> U acceptLiteralVisitor(LiteralVisitor<U> visitor) {
+            return visitor.visitTimeMicros(getValue());
+        }
+    }
+
+    static final class TimeNanos extends Literal<Long> {
+        TimeNanos(Long value) {
+            super(value);
+        }
+
+        @Override
+        public <U> U acceptLiteralVisitor(LiteralVisitor<U> visitor) {
+            return visitor.visitTimeNanos(getValue());
+        }
+    }
+
+    static final class DateDays extends Literal<Integer> {
+        DateDays(Integer value) {
+            super(value);
+        }
+
+        @Override
+        public <U> U acceptLiteralVisitor(LiteralVisitor<U> visitor) {
+            return visitor.visitDateDays(getValue());
+        }
+    }
+
+    static final class DateMillis extends Literal<Long> {
+        DateMillis(Long value) {
+            super(value);
+        }
+
+        @Override
+        public <U> U acceptLiteralVisitor(LiteralVisitor<U> visitor) {
+            return visitor.visitDateMillis(getValue());
+        }
+    }
+
+    static final class TimestampMillis extends Literal<Long> {
+        private final Optional<String> timeZone;
+
+        TimestampMillis(Long value, Optional<String> timeZone) {
+            super(value);
+            this.timeZone = timeZone;
+        }
+
+        @Override
+        public <U> U acceptLiteralVisitor(LiteralVisitor<U> visitor) {
+            return visitor.visitTimestampMillis(getValue(), timeZone);
+        }
+    }
+
+    static final class TimestampMicros extends Literal<Long> {
+        private final Optional<String> timeZone;
+
+        TimestampMicros(Long value, Optional<String> timeZone) {
+            super(value);
+            this.timeZone = timeZone;
+        }
+
+        @Override
+        public <U> U acceptLiteralVisitor(LiteralVisitor<U> visitor) {
+            return visitor.visitTimestampMicros(getValue(), timeZone);
+        }
+    }
+
+    static final class TimestampNanos extends Literal<Long> {
+        private final Optional<String> timeZone;
+
+        TimestampNanos(Long value, Optional<String> timeZone) {
+            super(value);
+            this.timeZone = timeZone;
+        }
+
+        @Override
+        public <U> U acceptLiteralVisitor(LiteralVisitor<U> visitor) {
+            return visitor.visitTimestampNanos(getValue(), timeZone);
         }
     }
 }

--- a/java/vortex-jni/src/main/java/dev/vortex/api/expressions/proto/DTypes.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/api/expressions/proto/DTypes.java
@@ -108,7 +108,7 @@ final class DTypes {
                 .setExtension(DTypeProtos.Extension.newBuilder()
                         .setId("vortex.date")
                         .setStorageDtype(DTypes.int32(nullable))
-                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.DATE_DAYS))
+                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.DATE_DAYS.get()))
                         .build())
                 .build();
     }
@@ -118,7 +118,7 @@ final class DTypes {
                 .setExtension(DTypeProtos.Extension.newBuilder()
                         .setId("vortex.date")
                         .setStorageDtype(DTypes.int64(nullable))
-                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.DATE_MILLIS))
+                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.DATE_MILLIS.get()))
                         .build())
                 .build();
     }
@@ -128,7 +128,7 @@ final class DTypes {
                 .setExtension(DTypeProtos.Extension.newBuilder()
                         .setId("vortex.time")
                         .setStorageDtype(DTypes.int32(nullable))
-                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.TIME_SECONDS))
+                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.TIME_SECONDS.get()))
                         .build())
                 .build();
     }
@@ -138,7 +138,7 @@ final class DTypes {
                 .setExtension(DTypeProtos.Extension.newBuilder()
                         .setId("vortex.time")
                         .setStorageDtype(DTypes.int32(nullable))
-                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.TIME_MILLIS))
+                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.TIME_MILLIS.get()))
                         .build())
                 .build();
     }
@@ -148,7 +148,7 @@ final class DTypes {
                 .setExtension(DTypeProtos.Extension.newBuilder()
                         .setId("vortex.time")
                         .setStorageDtype(DTypes.int64(nullable))
-                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.TIME_MICROS))
+                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.TIME_MICROS.get()))
                         .build())
                 .build();
     }
@@ -158,7 +158,7 @@ final class DTypes {
                 .setExtension(DTypeProtos.Extension.newBuilder()
                         .setId("vortex.time")
                         .setStorageDtype(DTypes.int64(nullable))
-                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.TIME_NANOS))
+                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.TIME_NANOS.get()))
                         .build())
                 .build();
     }

--- a/java/vortex-jni/src/main/java/dev/vortex/api/expressions/proto/DTypes.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/api/expressions/proto/DTypes.java
@@ -15,7 +15,12 @@
  */
 package dev.vortex.api.expressions.proto;
 
+import static dev.vortex.api.expressions.proto.TemporalMetadatas.TIME_UNIT_MICROS;
+import static dev.vortex.api.expressions.proto.TemporalMetadatas.TIME_UNIT_NANOS;
+
+import com.google.protobuf.ByteString;
 import dev.vortex.proto.DTypeProtos;
+import java.util.Optional;
 
 final class DTypes {
     private DTypes() {}
@@ -95,6 +100,88 @@ final class DTypes {
     static DTypeProtos.DType binary(boolean nullable) {
         return DTypeProtos.DType.newBuilder()
                 .setBinary(DTypeProtos.Binary.newBuilder().setNullable(nullable).build())
+                .build();
+    }
+
+    static DTypeProtos.DType dateDays(boolean nullable) {
+        return DTypeProtos.DType.newBuilder()
+                .setExtension(DTypeProtos.Extension.newBuilder()
+                        .setId("vortex.date")
+                        .setStorageDtype(DTypes.int32(nullable))
+                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.DATE_DAYS))
+                        .build())
+                .build();
+    }
+
+    static DTypeProtos.DType dateMillis(boolean nullable) {
+        return DTypeProtos.DType.newBuilder()
+                .setExtension(DTypeProtos.Extension.newBuilder()
+                        .setId("vortex.date")
+                        .setStorageDtype(DTypes.int64(nullable))
+                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.DATE_MILLIS))
+                        .build())
+                .build();
+    }
+
+    static DTypeProtos.DType timeSeconds(boolean nullable) {
+        return DTypeProtos.DType.newBuilder()
+                .setExtension(DTypeProtos.Extension.newBuilder()
+                        .setId("vortex.time")
+                        .setStorageDtype(DTypes.int32(nullable))
+                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.TIME_SECONDS))
+                        .build())
+                .build();
+    }
+
+    static DTypeProtos.DType timeMillis(boolean nullable) {
+        return DTypeProtos.DType.newBuilder()
+                .setExtension(DTypeProtos.Extension.newBuilder()
+                        .setId("vortex.time")
+                        .setStorageDtype(DTypes.int32(nullable))
+                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.TIME_MILLIS))
+                        .build())
+                .build();
+    }
+
+    static DTypeProtos.DType timeMicros(boolean nullable) {
+        return DTypeProtos.DType.newBuilder()
+                .setExtension(DTypeProtos.Extension.newBuilder()
+                        .setId("vortex.time")
+                        .setStorageDtype(DTypes.int64(nullable))
+                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.TIME_MICROS))
+                        .build())
+                .build();
+    }
+
+    static DTypeProtos.DType timeNanos(boolean nullable) {
+        return DTypeProtos.DType.newBuilder()
+                .setExtension(DTypeProtos.Extension.newBuilder()
+                        .setId("vortex.time")
+                        .setStorageDtype(DTypes.int64(nullable))
+                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.TIME_NANOS))
+                        .build())
+                .build();
+    }
+
+    static DTypeProtos.DType timestampMillis(Optional<String> timeZone, boolean nullable) {
+        return timestamp(TemporalMetadatas.TIME_UNIT_MILLIS, timeZone, nullable);
+    }
+
+    static DTypeProtos.DType timestampMicros(Optional<String> timeZone, boolean nullable) {
+        return timestamp(TIME_UNIT_MICROS, timeZone, nullable);
+    }
+
+    static DTypeProtos.DType timestampNanos(Optional<String> timeZone, boolean nullable) {
+        return timestamp(TIME_UNIT_NANOS, timeZone, nullable);
+    }
+
+    private static DTypeProtos.DType timestamp(byte timeUnit, Optional<String> timeZone, boolean nullable) {
+        return DTypeProtos.DType.newBuilder()
+                .setExtension(DTypeProtos.Extension.newBuilder()
+                        .setId("vortex.timestamp")
+                        .setStorageDtype(DTypes.int64(nullable))
+                        .setMetadata(ByteString.copyFrom(TemporalMetadatas.timestamp(timeUnit, timeZone)))
+                        .build())
                 .build();
     }
 }

--- a/java/vortex-jni/src/main/java/dev/vortex/api/expressions/proto/LiteralToScalar.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/api/expressions/proto/LiteralToScalar.java
@@ -18,6 +18,7 @@ package dev.vortex.api.expressions.proto;
 import dev.vortex.api.expressions.Literal;
 import dev.vortex.proto.ScalarProtos;
 import java.util.Objects;
+import java.util.Optional;
 
 final class LiteralToScalar implements Literal.LiteralVisitor<ScalarProtos.Scalar> {
     static final LiteralToScalar INSTANCE = new LiteralToScalar();
@@ -71,6 +72,87 @@ final class LiteralToScalar implements Literal.LiteralVisitor<ScalarProtos.Scala
             return Scalars.nullInt64();
         } else {
             return Scalars.int64(literal);
+        }
+    }
+
+    @Override
+    public ScalarProtos.Scalar visitDateDays(Integer days) {
+        if (Objects.isNull(days)) {
+            return Scalars.nullDateDays();
+        } else {
+            return Scalars.dateDays(days);
+        }
+    }
+
+    @Override
+    public ScalarProtos.Scalar visitDateMillis(Long millis) {
+        if (Objects.isNull(millis)) {
+            return Scalars.nullDateMillis();
+        } else {
+            return Scalars.dateMillis(millis);
+        }
+    }
+
+    @Override
+    public ScalarProtos.Scalar visitTimeSeconds(Integer seconds) {
+        if (Objects.isNull(seconds)) {
+            return Scalars.nullTimeSeconds();
+        } else {
+            return Scalars.timeSeconds(seconds);
+        }
+    }
+
+    @Override
+    public ScalarProtos.Scalar visitTimeMillis(Integer seconds) {
+        if (Objects.isNull(seconds)) {
+            return Scalars.nullTimeMillis();
+        } else {
+            return Scalars.timeMillis(seconds);
+        }
+    }
+
+    @Override
+    public ScalarProtos.Scalar visitTimeMicros(Long seconds) {
+        if (Objects.isNull(seconds)) {
+            return Scalars.nullTimeMicros();
+        } else {
+            return Scalars.timeMicros(seconds);
+        }
+    }
+
+    @Override
+    public ScalarProtos.Scalar visitTimeNanos(Long seconds) {
+        if (Objects.isNull(seconds)) {
+            return Scalars.nullTimeNanos();
+        } else {
+            return Scalars.timeNanos(seconds);
+        }
+    }
+
+    @Override
+    public ScalarProtos.Scalar visitTimestampMillis(Long epochMillis, Optional<String> timeZone) {
+        if (Objects.isNull(epochMillis)) {
+            return Scalars.nullTimestampMillis(timeZone);
+        } else {
+            return Scalars.timestampMillis(epochMillis, timeZone);
+        }
+    }
+
+    @Override
+    public ScalarProtos.Scalar visitTimestampMicros(Long epochMicros, Optional<String> timeZone) {
+        if (Objects.isNull(epochMicros)) {
+            return Scalars.nullTimestampMicros(timeZone);
+        } else {
+            return Scalars.timestampMicros(epochMicros, timeZone);
+        }
+    }
+
+    @Override
+    public ScalarProtos.Scalar visitTimestampNanos(Long epochNanos, Optional<String> timeZone) {
+        if (Objects.isNull(epochNanos)) {
+            return Scalars.nullTimestampNanos(timeZone);
+        } else {
+            return Scalars.timestampNanos(epochNanos, timeZone);
         }
     }
 

--- a/java/vortex-jni/src/main/java/dev/vortex/api/expressions/proto/Scalars.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/api/expressions/proto/Scalars.java
@@ -18,6 +18,7 @@ package dev.vortex.api.expressions.proto;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.NullValue;
 import dev.vortex.proto.ScalarProtos;
+import java.util.Optional;
 
 final class Scalars {
     private Scalars() {}
@@ -188,6 +189,168 @@ final class Scalars {
                         .setNullValue(NullValue.NULL_VALUE)
                         .build())
                 .setDtype(DTypes.binary(true))
+                .build();
+    }
+
+    static ScalarProtos.Scalar dateDays(int value) {
+        return ScalarProtos.Scalar.newBuilder()
+                .setValue(ScalarProtos.ScalarValue.newBuilder()
+                        .setInt32Value(value)
+                        .build())
+                .setDtype(DTypes.dateDays(false))
+                .build();
+    }
+
+    static ScalarProtos.Scalar nullDateDays() {
+        return ScalarProtos.Scalar.newBuilder()
+                .setValue(ScalarProtos.ScalarValue.newBuilder()
+                        .setNullValue(NullValue.NULL_VALUE)
+                        .build())
+                .setDtype(DTypes.dateDays(true))
+                .build();
+    }
+
+    static ScalarProtos.Scalar dateMillis(long value) {
+        return ScalarProtos.Scalar.newBuilder()
+                .setValue(ScalarProtos.ScalarValue.newBuilder()
+                        .setInt64Value(value)
+                        .build())
+                .setDtype(DTypes.dateMillis(false))
+                .build();
+    }
+
+    static ScalarProtos.Scalar nullDateMillis() {
+        return ScalarProtos.Scalar.newBuilder()
+                .setValue(ScalarProtos.ScalarValue.newBuilder()
+                        .setNullValue(NullValue.NULL_VALUE)
+                        .build())
+                .setDtype(DTypes.dateMillis(true))
+                .build();
+    }
+
+    static ScalarProtos.Scalar timeSeconds(int value) {
+        return ScalarProtos.Scalar.newBuilder()
+                .setValue(ScalarProtos.ScalarValue.newBuilder()
+                        .setInt32Value(value)
+                        .build())
+                .setDtype(DTypes.timeSeconds(false))
+                .build();
+    }
+
+    static ScalarProtos.Scalar nullTimeSeconds() {
+        return ScalarProtos.Scalar.newBuilder()
+                .setValue(ScalarProtos.ScalarValue.newBuilder()
+                        .setNullValue(NullValue.NULL_VALUE)
+                        .build())
+                .setDtype(DTypes.timeSeconds(true))
+                .build();
+    }
+
+    static ScalarProtos.Scalar timeMillis(int value) {
+        return ScalarProtos.Scalar.newBuilder()
+                .setValue(ScalarProtos.ScalarValue.newBuilder()
+                        .setInt32Value(value)
+                        .build())
+                .setDtype(DTypes.timeMillis(false))
+                .build();
+    }
+
+    static ScalarProtos.Scalar nullTimeMillis() {
+        return ScalarProtos.Scalar.newBuilder()
+                .setValue(ScalarProtos.ScalarValue.newBuilder()
+                        .setNullValue(NullValue.NULL_VALUE)
+                        .build())
+                .setDtype(DTypes.timeMillis(true))
+                .build();
+    }
+
+    static ScalarProtos.Scalar timeMicros(long value) {
+        return ScalarProtos.Scalar.newBuilder()
+                .setValue(ScalarProtos.ScalarValue.newBuilder()
+                        .setInt64Value(value)
+                        .build())
+                .setDtype(DTypes.timeMicros(false))
+                .build();
+    }
+
+    static ScalarProtos.Scalar nullTimeMicros() {
+        return ScalarProtos.Scalar.newBuilder()
+                .setValue(ScalarProtos.ScalarValue.newBuilder()
+                        .setNullValue(NullValue.NULL_VALUE)
+                        .build())
+                .setDtype(DTypes.timeMicros(true))
+                .build();
+    }
+
+    static ScalarProtos.Scalar timeNanos(long value) {
+        return ScalarProtos.Scalar.newBuilder()
+                .setValue(ScalarProtos.ScalarValue.newBuilder()
+                        .setInt64Value(value)
+                        .build())
+                .setDtype(DTypes.timeNanos(false))
+                .build();
+    }
+
+    static ScalarProtos.Scalar nullTimeNanos() {
+        return ScalarProtos.Scalar.newBuilder()
+                .setValue(ScalarProtos.ScalarValue.newBuilder()
+                        .setNullValue(NullValue.NULL_VALUE)
+                        .build())
+                .setDtype(DTypes.timeNanos(true))
+                .build();
+    }
+
+    static ScalarProtos.Scalar timestampMillis(long value, Optional<String> timeZone) {
+        return ScalarProtos.Scalar.newBuilder()
+                .setValue(ScalarProtos.ScalarValue.newBuilder()
+                        .setInt64Value(value)
+                        .build())
+                .setDtype(DTypes.timestampMillis(timeZone, false))
+                .build();
+    }
+
+    static ScalarProtos.Scalar nullTimestampMillis(Optional<String> timeZone) {
+        return ScalarProtos.Scalar.newBuilder()
+                .setValue(ScalarProtos.ScalarValue.newBuilder()
+                        .setNullValue(NullValue.NULL_VALUE)
+                        .build())
+                .setDtype(DTypes.timestampMillis(timeZone, true))
+                .build();
+    }
+
+    static ScalarProtos.Scalar timestampMicros(long value, Optional<String> timeZone) {
+        return ScalarProtos.Scalar.newBuilder()
+                .setValue(ScalarProtos.ScalarValue.newBuilder()
+                        .setInt64Value(value)
+                        .build())
+                .setDtype(DTypes.timestampMicros(timeZone, false))
+                .build();
+    }
+
+    static ScalarProtos.Scalar nullTimestampMicros(Optional<String> timeZone) {
+        return ScalarProtos.Scalar.newBuilder()
+                .setValue(ScalarProtos.ScalarValue.newBuilder()
+                        .setNullValue(NullValue.NULL_VALUE)
+                        .build())
+                .setDtype(DTypes.timestampMicros(timeZone, true))
+                .build();
+    }
+
+    static ScalarProtos.Scalar timestampNanos(long value, Optional<String> timeZone) {
+        return ScalarProtos.Scalar.newBuilder()
+                .setValue(ScalarProtos.ScalarValue.newBuilder()
+                        .setInt64Value(value)
+                        .build())
+                .setDtype(DTypes.timestampNanos(timeZone, false))
+                .build();
+    }
+
+    static ScalarProtos.Scalar nullTimestampNanos(Optional<String> timeZone) {
+        return ScalarProtos.Scalar.newBuilder()
+                .setValue(ScalarProtos.ScalarValue.newBuilder()
+                        .setNullValue(NullValue.NULL_VALUE)
+                        .build())
+                .setDtype(DTypes.timestampNanos(timeZone, true))
                 .build();
     }
 }

--- a/java/vortex-jni/src/main/java/dev/vortex/api/expressions/proto/TemporalMetadatas.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/api/expressions/proto/TemporalMetadatas.java
@@ -17,8 +17,10 @@ package dev.vortex.api.expressions.proto;
 
 import com.google.common.base.Preconditions;
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
+@SuppressWarnings("MutablePublicArray")
 public final class TemporalMetadatas {
     private TemporalMetadatas() {}
 
@@ -42,7 +44,7 @@ public final class TemporalMetadatas {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         baos.write(timeUnit);
         if (timeZone.isPresent()) {
-            byte[] timeZoneBytes = timeZone.get().getBytes();
+            byte[] timeZoneBytes = timeZone.get().getBytes(StandardCharsets.UTF_8);
             // Write length as little-endian uint16.
             int lenLow = timeZoneBytes.length & 0xFF;
             int lenHigh = (timeZoneBytes.length >> 8) & 0xFF;
@@ -81,7 +83,7 @@ public final class TemporalMetadatas {
         } else {
             byte[] timeZoneBytes = new byte[len];
             System.arraycopy(serializedMetadata, 3, timeZoneBytes, 0, len);
-            return Optional.of(new String(timeZoneBytes));
+            return Optional.of(new String(timeZoneBytes, StandardCharsets.UTF_8));
         }
     }
 }

--- a/java/vortex-jni/src/main/java/dev/vortex/api/expressions/proto/TemporalMetadatas.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/api/expressions/proto/TemporalMetadatas.java
@@ -1,0 +1,87 @@
+/**
+ * (c) Copyright 2025 SpiralDB Inc. All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.vortex.api.expressions.proto;
+
+import com.google.common.base.Preconditions;
+import java.io.ByteArrayOutputStream;
+import java.util.Optional;
+
+public final class TemporalMetadatas {
+    private TemporalMetadatas() {}
+
+    public static byte TIME_UNIT_NANOS = 0;
+    public static byte TIME_UNIT_MICROS = 1;
+    public static byte TIME_UNIT_MILLIS = 2;
+    public static byte TIME_UNIT_SECONDS = 3;
+    public static byte TIME_UNIT_DAYS = 4;
+
+    public static final byte[] DATE_DAYS = new byte[] {TIME_UNIT_DAYS};
+    public static final byte[] DATE_MILLIS = new byte[] {TIME_UNIT_MILLIS};
+    public static final byte[] TIME_SECONDS = new byte[] {TIME_UNIT_SECONDS};
+    public static final byte[] TIME_MILLIS = new byte[] {TIME_UNIT_MILLIS};
+    public static final byte[] TIME_MICROS = new byte[] {TIME_UNIT_MICROS};
+    public static final byte[] TIME_NANOS = new byte[] {TIME_UNIT_NANOS};
+
+    public static byte[] timestamp(byte timeUnit, Optional<String> timeZone) {
+        Preconditions.checkArgument(
+                timeUnit >= TIME_UNIT_NANOS && timeUnit < TIME_UNIT_DAYS, "invalid timeUnit for Timestamp:" + timeUnit);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write(timeUnit);
+        if (timeZone.isPresent()) {
+            byte[] timeZoneBytes = timeZone.get().getBytes();
+            // Write length as little-endian uint16.
+            int lenLow = timeZoneBytes.length & 0xFF;
+            int lenHigh = (timeZoneBytes.length >> 8) & 0xFF;
+            baos.write(lenLow);
+            baos.write(lenHigh);
+            baos.writeBytes(timeZoneBytes);
+        } else {
+            // write uint16 zero value
+            baos.write(0);
+            baos.write(0);
+        }
+        return baos.toByteArray();
+    }
+
+    /**
+     * Extract the time unit byte from the serialized metadata.
+     */
+    public static byte getTimeUnit(byte[] serializedMetadata) {
+        byte timeUnit = serializedMetadata[0];
+        Preconditions.checkArgument(
+                timeUnit >= TIME_UNIT_NANOS && timeUnit <= TIME_UNIT_DAYS, "invalid timeUnit byte: " + timeUnit);
+
+        return timeUnit;
+    }
+
+    /**
+     * Read from a serialized metadata representation into a time zone string.
+     */
+    public static Optional<String> getTimeZone(byte[] serializedMetadata) {
+        byte _timeUnit = serializedMetadata[0];
+        byte lenLow = serializedMetadata[1];
+        byte lenHigh = serializedMetadata[2];
+        int len = ((lenHigh & 0xFF) << 8) | (lenLow & 0xFF);
+        if (len == 0) {
+            return Optional.empty();
+        } else {
+            byte[] timeZoneBytes = new byte[len];
+            System.arraycopy(serializedMetadata, 3, timeZoneBytes, 0, len);
+            return Optional.of(new String(timeZoneBytes));
+        }
+    }
+}

--- a/java/vortex-jni/src/main/java/dev/vortex/api/expressions/proto/TemporalMetadatas.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/api/expressions/proto/TemporalMetadatas.java
@@ -16,28 +16,29 @@
 package dev.vortex.api.expressions.proto;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
-@SuppressWarnings("MutablePublicArray")
-public final class TemporalMetadatas {
+final class TemporalMetadatas {
     private TemporalMetadatas() {}
 
-    public static byte TIME_UNIT_NANOS = 0;
-    public static byte TIME_UNIT_MICROS = 1;
-    public static byte TIME_UNIT_MILLIS = 2;
-    public static byte TIME_UNIT_SECONDS = 3;
-    public static byte TIME_UNIT_DAYS = 4;
+    static byte TIME_UNIT_NANOS = 0;
+    static byte TIME_UNIT_MICROS = 1;
+    static byte TIME_UNIT_MILLIS = 2;
+    static byte TIME_UNIT_SECONDS = 3;
+    static byte TIME_UNIT_DAYS = 4;
 
-    public static final byte[] DATE_DAYS = new byte[] {TIME_UNIT_DAYS};
-    public static final byte[] DATE_MILLIS = new byte[] {TIME_UNIT_MILLIS};
-    public static final byte[] TIME_SECONDS = new byte[] {TIME_UNIT_SECONDS};
-    public static final byte[] TIME_MILLIS = new byte[] {TIME_UNIT_MILLIS};
-    public static final byte[] TIME_MICROS = new byte[] {TIME_UNIT_MICROS};
-    public static final byte[] TIME_NANOS = new byte[] {TIME_UNIT_NANOS};
+    static final Supplier<byte[]> DATE_DAYS = Suppliers.memoize(() -> new byte[] {TIME_UNIT_DAYS});
+    static final Supplier<byte[]> DATE_MILLIS = Suppliers.memoize(() -> new byte[] {TIME_UNIT_MILLIS});
+    static final Supplier<byte[]> TIME_SECONDS = Suppliers.memoize(() -> new byte[] {TIME_UNIT_SECONDS});
+    static final Supplier<byte[]> TIME_MILLIS = Suppliers.memoize(() -> new byte[] {TIME_UNIT_MILLIS});
+    static final Supplier<byte[]> TIME_MICROS = Suppliers.memoize(() -> new byte[] {TIME_UNIT_MICROS});
+    static final Supplier<byte[]> TIME_NANOS = Suppliers.memoize(() -> new byte[] {TIME_UNIT_NANOS});
 
-    public static byte[] timestamp(byte timeUnit, Optional<String> timeZone) {
+    static byte[] timestamp(byte timeUnit, Optional<String> timeZone) {
         Preconditions.checkArgument(
                 timeUnit >= TIME_UNIT_NANOS && timeUnit < TIME_UNIT_DAYS, "invalid timeUnit for Timestamp:" + timeUnit);
 
@@ -62,7 +63,7 @@ public final class TemporalMetadatas {
     /**
      * Extract the time unit byte from the serialized metadata.
      */
-    public static byte getTimeUnit(byte[] serializedMetadata) {
+    static byte getTimeUnit(byte[] serializedMetadata) {
         byte timeUnit = serializedMetadata[0];
         Preconditions.checkArgument(
                 timeUnit >= TIME_UNIT_NANOS && timeUnit <= TIME_UNIT_DAYS, "invalid timeUnit byte: " + timeUnit);
@@ -73,7 +74,7 @@ public final class TemporalMetadatas {
     /**
      * Read from a serialized metadata representation into a time zone string.
      */
-    public static Optional<String> getTimeZone(byte[] serializedMetadata) {
+    static Optional<String> getTimeZone(byte[] serializedMetadata) {
         byte _timeUnit = serializedMetadata[0];
         byte lenLow = serializedMetadata[1];
         byte lenHigh = serializedMetadata[2];

--- a/vortex-expr/src/get_item.rs
+++ b/vortex-expr/src/get_item.rs
@@ -56,14 +56,14 @@ impl Display for GetItem {
 }
 
 #[cfg(feature = "proto")]
-mod proto {
+pub(crate) mod proto {
     use vortex_error::{VortexResult, vortex_bail};
     use vortex_proto::expr::kind;
     use vortex_proto::expr::kind::Kind;
 
     use crate::{ExprDeserialize, ExprRef, ExprSerializable, GetItem, Id};
 
-    struct GetItemSerde;
+    pub(crate) struct GetItemSerde;
 
     impl Id for GetItemSerde {
         fn id(&self) -> &'static str {

--- a/vortex-expr/src/registry.rs
+++ b/vortex-expr/src/registry.rs
@@ -6,6 +6,7 @@ use vortex_error::{VortexResult, vortex_err};
 use vortex_proto::expr;
 
 use crate::binary::proto::BinarySerde;
+use crate::get_item::proto::GetItemSerde;
 use crate::identity::proto::IdentitySerde;
 use crate::literal::proto::LiteralSerde;
 use crate::merge::proto::MergeSerde;
@@ -17,6 +18,7 @@ use crate::{ExprDeserialize, ExprRef};
 const EXPRESSIONS: &[&'static dyn ExprDeserialize] = &[
     &BinarySerde,
     &LiteralSerde,
+    &GetItemSerde,
     &IdentitySerde,
     &NotSerde,
     &SelectSerde,


### PR DESCRIPTION
Additionally

- shade Guava/Protobuf deps (causing runtime conflict with Spark)
- Expose `GetItem` properly