### PR TITLE
perf: pass pointers to utf8 over the FFI

### DIFF
--- a/java/vortex-jni/src/main/java/dev/vortex/api/Array.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/api/Array.java
@@ -44,6 +44,8 @@ public interface Array extends AutoCloseable {
 
     String getUTF8(int index);
 
+    void getUTF8_ptr_len(int index, long[] ptr, int[] len);
+
     byte[] getBinary(int index);
 
     @Override

--- a/java/vortex-jni/src/main/java/dev/vortex/jni/JNIArray.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/jni/JNIArray.java
@@ -107,6 +107,11 @@ public class JNIArray implements Array {
     }
 
     @Override
+    public void getUTF8_ptr_len(int index, long[] ptr, int[] len) {
+        NativeArrayMethods.getUTF8_ptr_len(pointer.getAsLong(), index, ptr, len);
+    }
+
+    @Override
     public byte[] getBinary(int index) {
         return NativeArrayMethods.getBinary(pointer.getAsLong(), index);
     }

--- a/java/vortex-jni/src/main/java/dev/vortex/jni/NativeArrayMethods.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/jni/NativeArrayMethods.java
@@ -52,5 +52,14 @@ public final class NativeArrayMethods {
 
     public static native String getUTF8(long pointer, int index);
 
+    /**
+     * Raw-pointer variant of {@link #getUTF8(long, int)} that accepts an array to hold
+     * a pointer and an output length.
+     * <p>
+     * For Java query engines that use Unsafe to manipulate native memory, this allows working with the string
+     * inside of the JVM without copying it into Java heap memory.
+     */
+    public static native void getUTF8_ptr_len(long pointer, int index, long[] outPtr, int[] outLen);
+
     public static native byte[] getBinary(long pointer, int index);
 }

--- a/java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexColumnVector.java
+++ b/java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexColumnVector.java
@@ -24,6 +24,9 @@ import org.apache.spark.sql.vectorized.ColumnarMap;
 import org.apache.spark.unsafe.types.UTF8String;
 
 public final class VortexColumnVector extends ColumnVector {
+    private final long[] outPtr = new long[1];
+    private final int[] outLen = new int[1];
+
     private final Array array;
 
     public VortexColumnVector(Array array) {
@@ -113,7 +116,12 @@ public final class VortexColumnVector extends ColumnVector {
 
     @Override
     public UTF8String getUTF8String(int rowId) {
-        return UTF8String.fromString(array.getUTF8(rowId));
+        array.getUTF8_ptr_len(rowId, outPtr, outLen);
+        long addr = outPtr[0];
+        int len = outLen[0];
+        outPtr[0] = 0;
+        outLen[0] = 0;
+        return UTF8String.fromAddress(null, addr, len);
     }
 
     @Override

--- a/vortex-jni/src/array.rs
+++ b/vortex-jni/src/array.rs
@@ -1,10 +1,11 @@
 use jni::JNIEnv;
-use jni::objects::{JByteArray, JClass, JObject, JString};
+use jni::objects::{JByteArray, JClass, JIntArray, JLongArray, JObject, JString};
 use jni::sys::{JNI_FALSE, JNI_TRUE, jboolean, jbyte, jdouble, jfloat, jint, jlong, jshort};
+use vortex::arrays::{VarBinArray, VarBinViewArray};
 use vortex::compute::{scalar_at, slice};
 use vortex::dtype::DType;
-use vortex::error::vortex_err;
-use vortex::{Array, ArrayRef};
+use vortex::error::{VortexExpect, VortexResult, vortex_err};
+use vortex::{Array, ArrayRef, ArrayVariants};
 
 use crate::errors::Throwable;
 
@@ -341,6 +342,45 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getUTF8<'local>(
 }
 
 #[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getUTF8_1ptr_1len<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    array_ptr: jlong,
+    index: jint,
+    out_ptr: JLongArray<'local>,
+    out_len: JIntArray<'local>,
+) {
+    let array_ref = unsafe { NativeArray::from_ptr(array_ptr) };
+    if array_ref.inner.as_utf8_typed().is_none() {
+        vortex_err!("getUTF8_ptr_len expected UTF8 array").throw_illegal_argument(&mut env);
+        return;
+    }
+
+    if let Some(varbin) = array_ref.inner.as_any().downcast_ref::<VarBinArray>() {
+        match get_ptr_len_varbin(index, varbin) {
+            Ok((ptr, len)) => {
+                env.set_long_array_region(&out_ptr, 0, &[ptr as jlong])
+                    .expect("set_long_array_region");
+                env.set_int_array_region(&out_len, 0, &[len as jint])
+                    .expect("set_int_array_region");
+            }
+            Err(err) => {
+                err.throw_runtime(&mut env, "get_ptr_len_varbin");
+            }
+        }
+    } else if let Some(varbinview) = array_ref.inner.as_any().downcast_ref::<VarBinViewArray>() {
+        let (ptr, len) = get_ptr_len_view(index, varbinview);
+        env.set_long_array_region(&out_ptr, 0, &[ptr as jlong])
+            .expect("set_long_array_region");
+        env.set_int_array_region(&out_len, 0, &[len as jint])
+            .expect("set_int_array_region");
+    } else {
+        vortex_err!("getUTF8_ptr_len expected VarBin or VarBinView")
+            .throw_illegal_argument(&mut env);
+    }
+}
+
+#[unsafe(no_mangle)]
 pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getBinary<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
@@ -360,4 +400,22 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getBinary<'local>(
             JObject::null().into()
         }
     }
+}
+
+/// Get a raw pointer + len to pass back to Java to avoid copying across the boundary.
+fn get_ptr_len_varbin(index: jint, array: &VarBinArray) -> VortexResult<(*const u8, u32)> {
+    let bytes = array.bytes_at(usize::try_from(index).vortex_expect("index must fit in usize"))?;
+    Ok((
+        bytes.as_ptr(),
+        u32::try_from(bytes.len()).vortex_expect("string length must fit in u32"),
+    ))
+}
+
+/// Get a raw pointer + len to pass back to Java to avoid copying across the boundary.
+fn get_ptr_len_view(index: jint, array: &VarBinViewArray) -> (*const u8, u32) {
+    let bytes = array.bytes_at(usize::try_from(index).expect("index must fit in usize"));
+    (
+        bytes.as_ptr(),
+        u32::try_from(bytes.len()).vortex_expect("string length must fit in u32"),
+    )
 }

--- a/vortex-jni/src/file.rs
+++ b/vortex-jni/src/file.rs
@@ -191,6 +191,10 @@ pub extern "system" fn Java_dev_vortex_jni_NativeFileMethods_scan(
         }
     }
 
+    // Canonicalize first, to avoid needing to pay decoding cost for every access.
+    // This is preferable when we are expecting to have a lot of Arrow overhead.
+    scan_builder = scan_builder.with_canonicalize(true);
+
     // build and wrap scan with native object
     match scan_builder.build() {
         Ok(scan) => NativeArrayStream::new(

--- a/vortex-jni/src/file.rs
+++ b/vortex-jni/src/file.rs
@@ -192,7 +192,6 @@ pub extern "system" fn Java_dev_vortex_jni_NativeFileMethods_scan(
     }
 
     // Canonicalize first, to avoid needing to pay decoding cost for every access.
-    // This is preferable when we are expecting to have a lot of Arrow overhead.
     scan_builder = scan_builder.with_canonicalize(true);
 
     // build and wrap scan with native object


### PR DESCRIPTION
Spark column vectors return `UTF8String`s, which can wrap one of

- JVM heap-allocated `String`
- JVM heap-allocated `byte[]`
- A native pointer + len to native off-heap memory

Previously we've been using the String pathway, this PR changes our Java scans to canonicalize on read (`.with_canonicalize(true)`), and sends back to Java a ptr + len pair.

This patch when ferried down into Iceberg gives us another 2x speedup on Citibike scan