### PR TITLE
Improve write strategy

### DIFF
--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -88,6 +88,12 @@ impl VortexWriteOptions {
         }
 
         // Flush the final layout messages into the file
+        layout_writer.flush(&mut segment_writer)?;
+        segment_writer
+            .flush_async(&mut write, &mut segment_map)
+            .await?;
+
+        // Finish the layouts and flush the finishing messages into the file
         let layout = layout_writer.finish(&mut segment_writer)?;
         segment_writer
             .flush_async(&mut write, &mut segment_map)

--- a/vortex-layout/src/layouts/chunked/writer.rs
+++ b/vortex-layout/src/layouts/chunked/writer.rs
@@ -62,8 +62,13 @@ impl LayoutWriter for ChunkedLayoutWriter {
             .chunk_strategy
             .new_writer(&self.ctx, chunk.dtype())?;
         chunk_writer.push_chunk(segment_writer, chunk)?;
+        chunk_writer.flush(segment_writer)?;
         self.chunks.push(chunk_writer);
 
+        Ok(())
+    }
+
+    fn flush(&mut self, _segment_writer: &mut dyn SegmentWriter) -> VortexResult<()> {
         Ok(())
     }
 

--- a/vortex-layout/src/layouts/flat/writer.rs
+++ b/vortex-layout/src/layouts/flat/writer.rs
@@ -94,6 +94,10 @@ impl LayoutWriter for FlatLayoutWriter {
         Ok(())
     }
 
+    fn flush(&mut self, _segment_writer: &mut dyn SegmentWriter) -> VortexResult<()> {
+        Ok(())
+    }
+
     fn finish(&mut self, _segment_writer: &mut dyn SegmentWriter) -> VortexResult<Layout> {
         self.layout
             .take()

--- a/vortex-layout/src/layouts/stats/writer.rs
+++ b/vortex-layout/src/layouts/stats/writer.rs
@@ -96,6 +96,10 @@ impl LayoutWriter for StatsLayoutWriter {
         self.child_writer.push_chunk(segment_writer, chunk)
     }
 
+    fn flush(&mut self, segment_writer: &mut dyn SegmentWriter) -> VortexResult<()> {
+        self.child_writer.flush(segment_writer)
+    }
+
     fn finish(&mut self, segment_writer: &mut dyn SegmentWriter) -> VortexResult<Layout> {
         let child = self.child_writer.finish(segment_writer)?;
 

--- a/vortex-layout/src/layouts/struct_/writer.rs
+++ b/vortex-layout/src/layouts/struct_/writer.rs
@@ -93,6 +93,13 @@ impl LayoutWriter for StructLayoutWriter {
         Ok(())
     }
 
+    fn flush(&mut self, segment_writer: &mut dyn SegmentWriter) -> VortexResult<()> {
+        for writer in self.column_strategies.iter_mut() {
+            writer.flush(segment_writer)?;
+        }
+        Ok(())
+    }
+
     fn finish(&mut self, segment_writer: &mut dyn SegmentWriter) -> VortexResult<Layout> {
         let mut column_layouts = vec![];
         for writer in self.column_strategies.iter_mut() {

--- a/vortex-layout/src/stats.rs
+++ b/vortex-layout/src/stats.rs
@@ -76,6 +76,10 @@ impl LayoutWriter for FileStatsLayoutWriter {
         self.inner.push_chunk(segment_writer, chunk)
     }
 
+    fn flush(&mut self, segment_writer: &mut dyn SegmentWriter) -> VortexResult<()> {
+        self.inner.flush(segment_writer)
+    }
+
     fn finish(&mut self, segment_writer: &mut dyn SegmentWriter) -> VortexResult<Layout> {
         self.inner.finish(segment_writer)
     }

--- a/vortex-layout/src/writers/repartition.rs
+++ b/vortex-layout/src/writers/repartition.rs
@@ -46,7 +46,7 @@ impl RepartitionWriter {
         }
     }
 
-    fn flush(&mut self, segments: &mut dyn SegmentWriter) -> VortexResult<()> {
+    fn maybe_flush_chunk(&mut self, segments: &mut dyn SegmentWriter) -> VortexResult<()> {
         if self.nbytes >= self.options.block_size_minimum {
             let nblocks = self.row_count / self.options.block_len_multiple;
 
@@ -112,7 +112,7 @@ impl LayoutWriter for RepartitionWriter {
             self.chunks.push_back(c);
             offset = end;
 
-            self.flush(segment_writer)?;
+            self.maybe_flush_chunk(segment_writer)?;
         }
 
         Ok(())

--- a/vortex-layout/src/writers/repartition.rs
+++ b/vortex-layout/src/writers/repartition.rs
@@ -118,12 +118,16 @@ impl LayoutWriter for RepartitionWriter {
         Ok(())
     }
 
-    fn finish(&mut self, segment_writer: &mut dyn SegmentWriter) -> VortexResult<Layout> {
+    fn flush(&mut self, segment_writer: &mut dyn SegmentWriter) -> VortexResult<()> {
         let chunk =
             ChunkedArray::new_unchecked(self.chunks.drain(..).collect(), self.dtype.clone())
                 .to_canonical()?
                 .into_array();
         self.writer.push_chunk(segment_writer, chunk)?;
+        self.writer.flush(segment_writer)
+    }
+
+    fn finish(&mut self, segment_writer: &mut dyn SegmentWriter) -> VortexResult<Layout> {
         self.writer.finish(segment_writer)
     }
 }


### PR DESCRIPTION
* Introducing a separate flush stage allows us to ensure stats tables are written at the end of the file.
* We buffer each column to help keep chunks from the same column next to each other, within some memory budget. Currently this is naive per-column memory, not amortized over the size of the schema.

Note: this isn't a break, but we should re-generate S3 files