### PR TITLE
In PR benchmarks, pull the PRs HEAD commit instead of a merge commit

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: runs-on/action@v1
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           submodules: "recursive"
       # rustup is pre-installed on the ubuntu24-full-x64 image.
 

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -36,9 +36,15 @@ jobs:
     steps:
       - uses: runs-on/action@v1
       - uses: actions/checkout@v4
+        if: inputs.mode == 'pr'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          submodules: "recursive"
+
+      - uses: actions/checkout@v4
+        if: inputs.mode != 'pr'
         with:
           submodules: "recursive"
-      # rustup is pre-installed on the ubuntu24-full-x64 image.
 
       - name: Run ${{ matrix.name }} benchmark
         if: matrix.remote_storage == null


### PR DESCRIPTION
Should reduce some noise and make the runs more reliable/indicative of performance issues in the PR. Currently the benchmarks run with a merge commit that might introduce unexpected interactions/behaviors.