### PR TITLE
fix: ignore `duckdb-vortex/duckdb` for release-plz

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,6 @@
 [workspace]
 # set the path of all the crates to the changelog to the root of the repository
+publish_allow_dirty = ["duckdb-vortex/duckdb"]
 changelog_path = "./CHANGELOG.md"
 git_release_enable = false
 git_tag_enable = false


### PR DESCRIPTION
This is to ignore the following error message: 

```
Caused by:
    0: failed to determine next versions
    1: the working directory of this project has uncommitted changes. If these files are both committed and in .gitignore, either delete them or remove them from .gitignore. Otherwise, please commit or stash these changes:
       ["duckdb-vortex/duckdb"]
```