### PR TITLE
Replace `exponential-decay-histogram` with `ddsketch` in `FilterExpr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4957,6 +4957,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6257,16 +6263,17 @@ dependencies = [
  "async-trait",
  "bit-vec",
  "bytes",
- "exponential-decay-histogram",
  "flatbuffers 25.2.10",
  "flume",
  "futures",
  "getrandom 0.3.2",
  "itertools 0.14.0",
  "log",
+ "parking_lot",
  "pin-project-lite",
  "range_union_find",
  "rstest",
+ "sketches-ddsketch",
  "tokio",
  "tracing",
  "tracing-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ datafusion-execution = { version = "46" }
 datafusion-expr = { version = "46" }
 datafusion-physical-expr = { version = "46" }
 datafusion-physical-plan = { version = "46" }
+sketches-ddsketch = "0.3.0"
 divan = { package = "codspeed-divan-compat", version = "2.8.0" }
 duckdb = { path = "duckdb-vortex/duckdb-rs/crates/duckdb", features = [
     "vtab-full",
@@ -89,7 +90,6 @@ duckdb = { path = "duckdb-vortex/duckdb-rs/crates/duckdb", features = [
 ] }
 dyn-hash = "0.2.0"
 enum-iterator = "2.0.0"
-exponential-decay-histogram = "=0.1.13"
 fastlanes = "0.1.8"
 flatbuffers = "25"
 flexbuffers = "25"

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -110,46 +110,10 @@ impl LayoutStrategy for BtrBlocksCompressedStrategy {
 
 struct PreviousCompression {
     chunk: ArrayRef,
-    past_ratios: Vec<f64>,
+    ratio: f64,
 }
 
-impl PreviousCompression {
-    fn new(chunk: ArrayRef, first_measurement: f64) -> Self {
-        Self {
-            chunk,
-            past_ratios: vec![first_measurement],
-        }
-    }
-    fn mean(&self) -> f64 {
-        self.past_ratios.iter().sum::<f64>() / self.past_ratios.len() as f64
-    }
-
-    fn std_deviation(&self) -> f64 {
-        let mean = self.mean();
-        let count = self.past_ratios.len() as f64;
-        let variance = self
-            .past_ratios
-            .iter()
-            .map(|v| (mean - *v).powi(2))
-            .sum::<f64>()
-            / count;
-
-        variance.sqrt()
-    }
-
-    fn z_score(&self, measurement: f64) -> f64 {
-        let mean = self.mean();
-        let std_deviation = self.std_deviation();
-
-        (measurement - mean) / std_deviation
-    }
-
-    fn add_measurement(&mut self, measurement: f64) {
-        self.past_ratios.push(measurement);
-    }
-}
-
-const STD_DEV_THRESHOLD: f64 = 2.0;
+const COMPRESSION_DRIFT_THRESHOLD: f64 = 1.2;
 
 /// A layout writer that compresses chunks using a sampling compressor, and re-uses the previous
 /// compressed chunk as a hint for the next.
@@ -172,7 +136,7 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
             Some(ConstantArray::new(constant, chunk.len()).into_array())
         }
         // If we have information about the data from the previous chunk
-        else if let Some(prev_compression) = self.previous_chunk.as_mut() {
+        else if let Some(prev_compression) = self.previous_chunk.as_ref() {
             let prev_chunk = prev_compression.chunk.clone();
             let canonical_chunk = chunk.to_canonical()?;
 
@@ -184,14 +148,12 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
 
                 // not sure this condition is right, but the idea is to make sure the ratio is within the expected drift.
                 // If it isn't we  fall back to the compressor.
-                if prev_compression.z_score(ratio) < STD_DEV_THRESHOLD {
-                    prev_compression.add_measurement(ratio);
+                if ratio < prev_compression.ratio * COMPRESSION_DRIFT_THRESHOLD {
                     Some(encoded_chunk)
                 } else {
                     log::trace!(
                         "Compressed to a ratio of {ratio}, which is above the threshold of {}",
-                        prev_compression.mean()
-                            + (prev_compression.std_deviation() * STD_DEV_THRESHOLD)
+                        prev_compression.ratio * COMPRESSION_DRIFT_THRESHOLD
                     );
                     None
                 }
@@ -209,10 +171,10 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
             None => {
                 let canonical_chunk = chunk.to_canonical()?;
                 let compressed = BtrBlocksCompressor.compress(canonical_chunk.as_ref())?;
-                self.previous_chunk = Some(PreviousCompression::new(
-                    compressed.clone(),
-                    compressed.nbytes() as f64 / canonical_chunk.as_ref().nbytes() as f64,
-                ));
+                self.previous_chunk = Some(PreviousCompression {
+                    chunk: compressed.clone(),
+                    ratio: compressed.nbytes() as f64 / canonical_chunk.as_ref().nbytes() as f64,
+                });
                 compressed
             }
         };

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -110,10 +110,46 @@ impl LayoutStrategy for BtrBlocksCompressedStrategy {
 
 struct PreviousCompression {
     chunk: ArrayRef,
-    ratio: f64,
+    past_ratios: Vec<f64>,
 }
 
-const COMPRESSION_DRIFT_THRESHOLD: f64 = 1.2;
+impl PreviousCompression {
+    fn new(chunk: ArrayRef, first_measurement: f64) -> Self {
+        Self {
+            chunk,
+            past_ratios: vec![first_measurement],
+        }
+    }
+    fn mean(&self) -> f64 {
+        self.past_ratios.iter().sum::<f64>() / self.past_ratios.len() as f64
+    }
+
+    fn std_deviation(&self) -> f64 {
+        let mean = self.mean();
+        let count = self.past_ratios.len() as f64;
+        let variance = self
+            .past_ratios
+            .iter()
+            .map(|v| (mean - *v).powi(2))
+            .sum::<f64>()
+            / count;
+
+        variance.sqrt()
+    }
+
+    fn z_score(&self, measurement: f64) -> f64 {
+        let mean = self.mean();
+        let std_deviation = self.std_deviation();
+
+        (measurement - mean) / std_deviation
+    }
+
+    fn add_measurement(&mut self, measurement: f64) {
+        self.past_ratios.push(measurement);
+    }
+}
+
+const STD_DEV_THRESHOLD: f64 = 2.0;
 
 /// A layout writer that compresses chunks using a sampling compressor, and re-uses the previous
 /// compressed chunk as a hint for the next.
@@ -136,7 +172,7 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
             Some(ConstantArray::new(constant, chunk.len()).into_array())
         }
         // If we have information about the data from the previous chunk
-        else if let Some(prev_compression) = self.previous_chunk.as_ref() {
+        else if let Some(prev_compression) = self.previous_chunk.as_mut() {
             let prev_chunk = prev_compression.chunk.clone();
             let canonical_chunk = chunk.to_canonical()?;
 
@@ -148,12 +184,14 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
 
                 // not sure this condition is right, but the idea is to make sure the ratio is within the expected drift.
                 // If it isn't we  fall back to the compressor.
-                if ratio < prev_compression.ratio * COMPRESSION_DRIFT_THRESHOLD {
+                if prev_compression.z_score(ratio) < STD_DEV_THRESHOLD {
+                    prev_compression.add_measurement(ratio);
                     Some(encoded_chunk)
                 } else {
                     log::trace!(
                         "Compressed to a ratio of {ratio}, which is above the threshold of {}",
-                        prev_compression.ratio * COMPRESSION_DRIFT_THRESHOLD
+                        prev_compression.mean()
+                            + (prev_compression.std_deviation() * STD_DEV_THRESHOLD)
                     );
                     None
                 }
@@ -171,10 +209,10 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
             None => {
                 let canonical_chunk = chunk.to_canonical()?;
                 let compressed = BtrBlocksCompressor.compress(canonical_chunk.as_ref())?;
-                self.previous_chunk = Some(PreviousCompression {
-                    chunk: compressed.clone(),
-                    ratio: compressed.nbytes() as f64 / canonical_chunk.as_ref().nbytes() as f64,
-                });
+                self.previous_chunk = Some(PreviousCompression::new(
+                    compressed.clone(),
+                    compressed.nbytes() as f64 / canonical_chunk.as_ref().nbytes() as f64,
+                ));
                 compressed
             }
         };

--- a/vortex-layout/Cargo.toml
+++ b/vortex-layout/Cargo.toml
@@ -19,13 +19,14 @@ async-once-cell = { workspace = true }
 async-trait = { workspace = true }
 bit-vec = { workspace = true }
 bytes = { workspace = true }
-exponential-decay-histogram = { workspace = true }
+sketches-ddsketch = { workspace = true }
 flatbuffers = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true, features = ["alloc", "executor"] }
 getrandom_v03 = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
+parking_lot = { workspace = true }
 pin-project-lite = { workspace = true }
 range_union_find = { workspace = true }
 tokio = { workspace = true, features = ["sync"], optional = true }

--- a/vortex-layout/Cargo.toml
+++ b/vortex-layout/Cargo.toml
@@ -19,7 +19,6 @@ async-once-cell = { workspace = true }
 async-trait = { workspace = true }
 bit-vec = { workspace = true }
 bytes = { workspace = true }
-sketches-ddsketch = { workspace = true }
 flatbuffers = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true, features = ["alloc", "executor"] }
@@ -29,6 +28,7 @@ log = { workspace = true }
 parking_lot = { workspace = true }
 pin-project-lite = { workspace = true }
 range_union_find = { workspace = true }
+sketches-ddsketch = { workspace = true }
 tokio = { workspace = true, features = ["sync"], optional = true }
 tracing = { workspace = true, optional = true }
 tracing-futures = { workspace = true, features = [

--- a/vortex-layout/src/scan/filter.rs
+++ b/vortex-layout/src/scan/filter.rs
@@ -158,7 +158,8 @@ impl FilterExpr {
                 histogram
                     .read()
                     .quantile(self.selectivity_quantile)
-                    .expect("Quantile should always be in (0, 1)")
+                    .ok() // Placeholder fo a second
+                    .vortex_expect("Quantile should always be in (0, 1)")
                     // If the sketch is empty, its selectivity is 0.
                     .unwrap_or_default()
             })

--- a/vortex-layout/src/scan/filter.rs
+++ b/vortex-layout/src/scan/filter.rs
@@ -9,7 +9,7 @@ use parking_lot::RwLock;
 use sketches_ddsketch::DDSketch;
 use vortex_array::ArrayRef;
 use vortex_dtype::{FieldName, StructDType};
-use vortex_error::{VortexExpect, VortexResult, vortex_panic};
+use vortex_error::{VortexExpect, VortexResult, VortexUnwrap, vortex_err, vortex_panic};
 use vortex_expr::forms::cnf::cnf;
 use vortex_expr::transform::immediate_access::immediate_scope_access;
 use vortex_expr::{ExprRef, get_item, ident};
@@ -158,8 +158,8 @@ impl FilterExpr {
                 histogram
                     .read()
                     .quantile(self.selectivity_quantile)
-                    .ok() // Placeholder fo a second
-                    .vortex_expect("Quantile should always be in (0, 1)")
+                    .map_err(|e| vortex_err!("{e}")) // Only errors when the quantile is out of range
+                    .vortex_unwrap()
                     // If the sketch is empty, its selectivity is 0.
                     .unwrap_or_default()
             })

--- a/vortex-layout/src/scan/filter.rs
+++ b/vortex-layout/src/scan/filter.rs
@@ -1,11 +1,12 @@
 use std::iter;
 use std::ops::BitAnd;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use bit_vec::BitVec;
-use exponential_decay_histogram::ExponentialDecayHistogram;
 use futures::future::try_join_all;
 use itertools::Itertools;
+use parking_lot::RwLock;
+use sketches_ddsketch::DDSketch;
 use vortex_array::ArrayRef;
 use vortex_dtype::{FieldName, StructDType};
 use vortex_error::{VortexExpect, VortexResult, vortex_panic};
@@ -20,8 +21,6 @@ use crate::{ExprEvaluator, RowMask};
 const DEFAULT_SELECTIVITY_THRESHOLD: f64 = 0.05;
 /// The selectivity histogram quantile to use for reordering conjuncts. Where 0 == no rows match.
 const DEFAULT_SELECTIVITY_QUANTILE: f64 = 0.1;
-/// The multiplier to used to convert selectivity to i64 for the histogram.
-const SELECTIVITY_MULTIPLIER: f64 = 1_000_000.0;
 
 /// A [`FilterExpr`] performs smart stateful evaluation of a filter expression across multiple
 /// row splits.
@@ -38,7 +37,7 @@ pub struct FilterExpr {
     /// The fields involved in each conjunct.
     conjunct_fields: Vec<Vec<usize>>,
     /// A histogram of the selectivity of each conjunct.
-    conjunct_selectivity: Vec<RwLock<ExponentialDecayHistogram>>,
+    conjunct_selectivity: Vec<RwLock<DDSketch>>,
     /// The preferred ordering of conjuncts.
     ordering: RwLock<Vec<usize>>,
     /// The threshold of selectivity below which the filter is pushed down.
@@ -86,11 +85,9 @@ impl FilterExpr {
             fields,
             conjuncts,
             conjunct_fields,
-            conjunct_selectivity: iter::repeat_with(|| {
-                RwLock::new(ExponentialDecayHistogram::new())
-            })
-            .take(nconjuncts)
-            .collect(),
+            conjunct_selectivity: iter::repeat_with(|| RwLock::new(DDSketch::default()))
+                .take(nconjuncts)
+                .collect(),
             prefetch_conjuncts,
             // The initial ordering is naive, we could order this by how well we expect each
             // comparison operator to perform. e.g. == might be more selective than <=? Not obvious.
@@ -122,19 +119,23 @@ impl FilterExpr {
         remaining: &BitVec,
         fetched_fields: &[Option<ArrayRef>],
     ) -> Option<usize> {
-        let read = self.ordering.read().vortex_expect("poisoned lock");
+        let read_guard = self.ordering.read();
 
         // First try to find a conjunct that we've already fetched fields for.
-        if let Some(next) = read.iter().filter(|&idx| remaining[*idx]).find(|&idx| {
-            self.conjunct_fields[*idx]
-                .iter()
-                .all(|&field_idx| fetched_fields[field_idx].is_some())
-        }) {
+        if let Some(next) = read_guard
+            .iter()
+            .filter(|&idx| remaining[*idx])
+            .find(|&idx| {
+                self.conjunct_fields[*idx]
+                    .iter()
+                    .all(|&field_idx| fetched_fields[field_idx].is_some())
+            })
+        {
             return Some(*next);
         }
 
         // Otherwise, just take the first conjunct that we prefer.
-        read.iter().find(|&idx| remaining[*idx]).copied()
+        read_guard.iter().find(|&idx| remaining[*idx]).copied()
     }
 
     /// Report the selectivity of a conjunct, i.e. 0 means no rows matched the predicate.
@@ -145,13 +146,9 @@ impl FilterExpr {
         }
 
         {
-            let mut histogram = self.conjunct_selectivity[conjunct_idx]
-                .write()
-                .vortex_expect("poisoned lock");
+            let mut histogram = self.conjunct_selectivity[conjunct_idx].write();
 
-            // Since our histogram only supports i64, we map our f64 into a 0-1m range.
-            let selectivity = (selectivity * SELECTIVITY_MULTIPLIER).round() as i64;
-            histogram.update(selectivity);
+            histogram.add(selectivity);
         }
 
         let all_selectivity = self
@@ -160,32 +157,33 @@ impl FilterExpr {
             .map(|histogram| {
                 histogram
                     .read()
-                    .vortex_expect("poisoned lock")
-                    .snapshot()
-                    .value(self.selectivity_quantile)
+                    .quantile(self.selectivity_quantile)
+                    .expect("Quantile should always be in (0, 1)")
+                    // If the sketch is empty, its selectivity is 0.
+                    .unwrap_or_default()
             })
             .collect::<Vec<_>>();
 
         {
-            let ordering = self.ordering.read().vortex_expect("lock poisoned");
+            let ordering = self.ordering.read();
             if ordering.is_sorted_by_key(|&idx| all_selectivity[idx]) {
                 return;
             }
         }
 
         // Re-sort our conjuncts based on the new statistics.
-        let mut ordering = self.ordering.write().vortex_expect("lock poisoned");
-        ordering.sort_unstable_by_key(|&idx| all_selectivity[idx]);
+        let mut ordering = self.ordering.write();
+        ordering.sort_unstable_by(|&l_idx, &r_idx| {
+            all_selectivity[l_idx]
+                .partial_cmp(&all_selectivity[r_idx])
+                .vortex_expect("Can't compare selectivity values")
+        });
 
         log::debug!(
             "Reordered conjuncts based on new selectivity {:?}",
             ordering
                 .iter()
-                .map(|&idx| format!(
-                    "({}) => {}",
-                    self.conjuncts[idx],
-                    all_selectivity[idx] as f64 / SELECTIVITY_MULTIPLIER
-                ))
+                .map(|&idx| format!("({}) => {}", self.conjuncts[idx], all_selectivity[idx]))
                 .join(", ")
         );
     }


### PR DESCRIPTION
`exponential-decay-histogram` takes timing into account, which means results are dependent not only on order of results but also on the CPU speed and overall systems load.
DDSketch is a pretty proven sketch for these cases and is used in some pretty proven systems in the ecosystem.