### PR TITLE
General benchmark improvements

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -12,10 +12,6 @@ permissions:
   pull-requests: write
   id-token: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
-  cancel-in-progress: false
-
 jobs:
   label_trigger:
     runs-on: ubuntu-latest

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -12,6 +12,10 @@ permissions:
   pull-requests: write
   id-token: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   label_trigger:
     runs-on: ubuntu-latest
@@ -58,7 +62,7 @@ jobs:
         env:
           RUSTFLAGS: '-C target-cpu=native'
         run: |
-          cargo run --bin ${{ matrix.benchmark.id }} --release -- -d gh-json | tee ${{ matrix.benchmark.id }}.json
+          cargo run --bin ${{ matrix.benchmark.id }} --package bench-vortex --release -- -d gh-json | tee ${{ matrix.benchmark.id }}.json
 
       - name: Setup AWS CLI
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           RUSTFLAGS: '-C target-cpu=native'
         run: |
-          cargo run --bin ${{ matrix.benchmark.id }} --release -- -d gh-json | tee ${{ matrix.benchmark.id }}.json
+          cargo run --bin ${{ matrix.benchmark.id }} --package bench-vortex --release -- -d gh-json | tee ${{ matrix.benchmark.id }}.json
 
       - name: Setup AWS CLI
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,8 +170,6 @@ jobs:
         with:
           submodules: "recursive"
       - uses: rui314/setup-mold@v1
-        with:
-          targets: ${{matrix.config.target || ''}}
       - uses: ./.github/actions/setup-c++
       - name: Install wasm32 target
         if: ${{ matrix.config.target == 'wasm32-unknown-unknown' }}

--- a/.github/workflows/generate-benchmarks-s3.yml
+++ b/.github/workflows/generate-benchmarks-s3.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
         run: |
           # We run each query once to make sure we don't upload a file if there's a bug that causes a panic.
-          cargo run --release --bin clickbench -p bench-vortex -- --formats vortex -i1
+          cargo run --release --bin clickbench --package bench-vortex -- --formats vortex -i1
           aws s3 rm --recursive s3://vortex-bench-dev-eu/develop/clickbench/
           aws s3 cp --recursive bench-vortex/data/clickbench_partitioned s3://vortex-bench-dev-eu/develop/clickbench/
           rm -rf bench-vortex/data/clickbench_partitioned/

--- a/.github/workflows/generate-benchmarks-s3.yml
+++ b/.github/workflows/generate-benchmarks-s3.yml
@@ -31,15 +31,6 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::375504701696:role/GitHubBenchmarkRole
           aws-region: us-east-1
-      - name: Generate TPC-H locally
-        shell: bash
-        run: |
-          # We run each query once to make sure we don't upload a file if there's a bug that causes a panic.
-          cargo run --release --bin tpch --package bench-vortex -- --formats vortex -i1
-          aws s3 rm --recursive s3://vortex-bench-dev-eu/develop/tpch-sf1/
-          aws s3 cp --recursive bench-vortex/data/tpch/1 s3://vortex-bench-dev-eu/develop/tpch-sf1/
-          rm -rf bench-vortex/data/tpch/
-
       - name: Generate clickbench locally
         shell: bash
         run: |

--- a/.github/workflows/generate-benchmarks-s3.yml
+++ b/.github/workflows/generate-benchmarks-s3.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
         run: |
           # We run each query once to make sure we don't upload a file if there's a bug that causes a panic.
-          cargo run --release --bin clickbench --package bench-vortex -- --formats vortex -i1
+          cargo run --release --bin clickbench --package bench-vortex -- --formats parquet,vortex -i1
           aws s3 rm --recursive s3://vortex-bench-dev-eu/develop/clickbench/
           aws s3 cp --recursive bench-vortex/data/clickbench_partitioned s3://vortex-bench-dev-eu/develop/clickbench/
           rm -rf bench-vortex/data/clickbench_partitioned/

--- a/.github/workflows/generate-benchmarks-s3.yml
+++ b/.github/workflows/generate-benchmarks-s3.yml
@@ -35,16 +35,16 @@ jobs:
         shell: bash
         run: |
           # We run each query once to make sure we don't upload a file if there's a bug that causes a panic.
-          cargo run --release --bin tpch -- --formats parquet,vortex -i1
-          aws s3 rm --recursive s3://vortex-bench-dev-eu/tpch-sf1/
-          aws s3 cp --recursive bench-vortex/data/tpch/1 s3://vortex-bench-dev-eu/tpch-sf1/
+          cargo run --release --bin tpch --package bench-vortex -- --formats vortex -i1
+          aws s3 rm --recursive s3://vortex-bench-dev-eu/develop/tpch-sf1/
+          aws s3 cp --recursive bench-vortex/data/tpch/1 s3://vortex-bench-dev-eu/develop/tpch-sf1/
           rm -rf bench-vortex/data/tpch/
 
       - name: Generate clickbench locally
         shell: bash
         run: |
           # We run each query once to make sure we don't upload a file if there's a bug that causes a panic.
-          cargo run --release --bin clickbench -- --formats parquet,vortex -i1
-          aws s3 rm --recursive s3://vortex-bench-dev-eu/clickbench/
-          aws s3 cp --recursive bench-vortex/data/clickbench_partitioned s3://vortex-bench-dev-eu/clickbench/
+          cargo run --release --bin clickbench -p bench-vortex -- --formats vortex -i1
+          aws s3 rm --recursive s3://vortex-bench-dev-eu/develop/clickbench/
+          aws s3 cp --recursive bench-vortex/data/clickbench_partitioned s3://vortex-bench-dev-eu/develop/clickbench/
           rm -rf bench-vortex/data/clickbench_partitioned/

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -92,7 +92,7 @@ jobs:
           OTEL_RESOURCE_ATTRIBUTES: 'bench-name=${{ matrix.id }}'
         run: |
           # Generate data, running each query once to make sure they don't panic.
-          cargo run --release --bin ${{ matrix.binary_name }} --package bench-vortex -- --formats vortex -i1
+          cargo run --release --bin ${{ matrix.binary_name }} --package bench-vortex -- --formats parquet,vortex -i1
           aws s3 rm --recursive ${{ matrix.remote_storage }}
           aws s3 cp --recursive ${{matrix.local_dir}} ${{ matrix.remote_storage }}
 
@@ -102,7 +102,7 @@ jobs:
               --release \
               -- \
               --use-remote-data-dir ${{ matrix.remote_storage }} \
-              --formats 'parquet,vortex' \
+              --formats parquet,vortex \
               --export-spans \
               -d gh-json \
             | tee results.json

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -9,6 +9,10 @@ on:
 
 jobs:
   bench:
+    # S3 is shared state here, and we want to make sure only one of each job runs at a time
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref_name }}-${{matrix.id}}
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -87,8 +87,8 @@ jobs:
           OTEL_EXPORTER_OTLP_HEADERS: '${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}'
           OTEL_RESOURCE_ATTRIBUTES: 'bench-name=${{ matrix.id }}'
         run: |
-          # Generate date
-          cargo run --release --bin tpch --package bench-vortex -- --formats vortex -i1
+          # Generate data, running each query once to make sure they don't panic.
+          cargo run --release --bin ${{ matrix.binary_name }} --package bench-vortex -- --formats vortex -i1
           aws s3 rm --recursive ${{ matrix.remote_storage }}
           aws s3 cp --recursive ${{matrix.local_dir}} ${{ matrix.remote_storage }}
 

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -8,30 +8,7 @@ on:
         type: string
 
 jobs:
-  generate_tpch_s3:
-    runs-on:
-      - runs-on=${{ github.run_id }}
-      - family=m7i.2xlarge
-      - image=ubuntu24-full-x64
-      - spot=false
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
-      - name: Setup AWS CLI
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::375504701696:role/GitHubBenchmarkRole
-          aws-region: us-east-1
-      - name: Generate TPC-H locally
-        shell: bash
-        run: |
-          cargo run --release --bin tpch --package bench-vortex -- --formats vortex -i1
-          aws s3 rm --recursive s3://vortex-bench-dev-eu/${{github.ref_name}}/tpch-sf1/
-          aws s3 cp --recursive bench-vortex/data/tpch/1 s3://vortex-bench-dev-eu/${{github.ref_name}}/tpch-sf1/
-
   bench:
-    needs: generate_tpch_s3
     strategy:
       fail-fast: false
       matrix:
@@ -41,12 +18,15 @@ jobs:
           - id: tpch-nvme
             binary_name: tpch
             name: TPC-H on NVME
+            local_dir: bench-vortex/data/tpch/1
           - id: clickbench-nvme
             binary_name: clickbench
             name: Clickbench on NVME
+            local_dir: bench-vortex/data/clickbench_partitioned
           - id: tpch-s3
             binary_name: tpch
             name: TPC-H on S3
+            local_dir: bench-vortex/data/tpch/1
             remote_storage: s3://vortex-bench-dev-eu/${{github.ref_name}}/tpch-sf1/
     runs-on:
       - runs-on=${{ github.run_id }}
@@ -68,6 +48,12 @@ jobs:
         if: inputs.mode != 'pr'
         with:
           submodules: "recursive"
+
+      - name: Setup AWS CLI
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::375504701696:role/GitHubBenchmarkRole
+          aws-region: us-east-1
 
       - name: Run ${{ matrix.name }} benchmark
         if: matrix.remote_storage == null
@@ -101,6 +87,11 @@ jobs:
           OTEL_EXPORTER_OTLP_HEADERS: '${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}'
           OTEL_RESOURCE_ATTRIBUTES: 'bench-name=${{ matrix.id }}'
         run: |
+          # Generate date
+          cargo run --release --bin tpch --package bench-vortex -- --formats vortex -i1
+          aws s3 rm --recursive ${{ matrix.remote_storage }}
+          aws s3 cp --recursive ${{matrix.local_dir}} ${{ matrix.remote_storage }}
+
           cargo run \
               --package bench-vortex \
               --bin ${{ matrix.binary_name }} \
@@ -111,12 +102,6 @@ jobs:
               --export-spans \
               -d gh-json \
             | tee results.json
-
-      - name: Setup AWS CLI
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::375504701696:role/GitHubBenchmarkRole
-          aws-region: us-east-1
 
       - name: Install uv
         if: inputs.mode == 'pr'

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -8,7 +8,30 @@ on:
         type: string
 
 jobs:
+  generate_tpch_s3:
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - family=m7i.2xlarge
+      - image=ubuntu24-full-x64
+      - spot=false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Setup AWS CLI
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::375504701696:role/GitHubBenchmarkRole
+          aws-region: us-east-1
+      - name: Generate TPC-H locally
+        shell: bash
+        run: |
+          cargo run --release --bin tpch --package bench-vortex -- --formats vortex -i1
+          aws s3 rm --recursive s3://vortex-bench-dev-eu/${{github.ref_name}}/tpch-sf1/
+          aws s3 cp --recursive bench-vortex/data/tpch/1 s3://vortex-bench-dev-eu/${{github.ref_name}}/tpch-sf1/
+
   bench:
+    needs: generate_tpch_s3
     strategy:
       fail-fast: false
       matrix:
@@ -24,7 +47,7 @@ jobs:
           - id: tpch-s3
             binary_name: tpch
             name: TPC-H on S3
-            remote_storage: s3://vortex-bench-dev-eu/tpch-sf1/
+            remote_storage: s3://vortex-bench-dev-eu/${{github.ref_name}}/tpch-sf1/
     runs-on:
       - runs-on=${{ github.run_id }}
       - family=c7i.8xlarge
@@ -59,6 +82,7 @@ jobs:
         run: |
           cargo run \
               --bin ${{ matrix.binary_name }} \
+              --package bench-vortex \
               --release \
               -- \
               -d gh-json \
@@ -78,6 +102,7 @@ jobs:
           OTEL_RESOURCE_ATTRIBUTES: 'bench-name=${{ matrix.id }}'
         run: |
           cargo run \
+              --package bench-vortex \
               --bin ${{ matrix.binary_name }} \
               --release \
               -- \


### PR DESCRIPTION
1. Generate TPC-H files in S3 whenever we run SQL benchmarks. Its fast enough IMO and I'll set an aggressive lifecycle configuration on the bucket to make sure old branches get cleaned up.
2. Whenever we run a benchmarks binary, use `--package bench-vortex` which seems to actually save on some dependencies because it doesn't compile the whole workspace.