### PR TITLE
min_max for dict

### DIFF
--- a/encodings/dict/src/compute/min_max.rs
+++ b/encodings/dict/src/compute/min_max.rs
@@ -1,0 +1,10 @@
+use vortex_array::compute::{MinMaxFn, MinMaxResult, min_max, take};
+use vortex_error::VortexResult;
+
+use crate::{DictArray, DictEncoding};
+
+impl MinMaxFn<&DictArray> for DictEncoding {
+    fn min_max(&self, array: &DictArray) -> VortexResult<Option<MinMaxResult>> {
+        min_max(&take(array.values(), array.codes())?)
+    }
+}

--- a/encodings/dict/src/compute/mod.rs
+++ b/encodings/dict/src/compute/mod.rs
@@ -3,10 +3,11 @@ mod compare;
 mod is_constant;
 mod is_sorted;
 mod like;
+mod min_max;
 
 use vortex_array::compute::{
     BinaryNumericFn, CompareFn, FilterKernel, FilterKernelAdapter, IsConstantFn, IsSortedFn,
-    KernelRef, LikeFn, ScalarAtFn, SliceFn, TakeFn, filter, scalar_at, slice, take,
+    KernelRef, LikeFn, MinMaxFn, ScalarAtFn, SliceFn, TakeFn, filter, scalar_at, slice, take,
 };
 use vortex_array::vtable::ComputeVTable;
 use vortex_array::{Array, ArrayComputeImpl, ArrayRef};
@@ -50,6 +51,10 @@ impl ComputeVTable for DictEncoding {
     }
 
     fn take_fn(&self) -> Option<&dyn TakeFn<&dyn Array>> {
+        Some(self)
+    }
+
+    fn min_max_fn(&self) -> Option<&dyn MinMaxFn<&dyn Array>> {
         Some(self)
     }
 }


### PR DESCRIPTION
Not the smartest thing we could do but still useful to have to prevent `to_canonical` calls for deeply nested dict encoded arrays. We do not need to canonicalise the entire array to calculate min_max