### PR TITLE
fix instrument macro to support multiple attributes

### DIFF
--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -45,7 +45,7 @@ impl FlatReader {
         self.array
             .get_or_try_init(instrument!(
                 "flat_read",
-                { name = self.layout().name() },
+                [name = self.layout().name()],
                 async move {
                     let segment_id = self
                         .layout()

--- a/vortex-layout/src/macros.rs
+++ b/vortex-layout/src/macros.rs
@@ -2,9 +2,9 @@
 #[macro_export]
 macro_rules! instrument {
     ($span_name:expr, $expr:expr) => {
-        instrument!($span_name, {}, $expr)
+        instrument!($span_name, [], $expr)
     };
-    ($span_name:expr, { $($key:ident = $value:expr),* $(,)? }, $expr:expr) => {
+    ($span_name:expr, [ $($key:ident = $value:expr),* $(,)? ], $expr:expr) => {
         {
             let task = $expr;
             #[cfg(feature = "tracing")]


### PR DESCRIPTION
For some reason rustc doesn't like `{` and fails to parse invocations of this macro with multiple arguments like `instrument!(name, { a = "a", b = "b" }, f)`. My macro-fu is not enough to fix it so using `[]` now