### PR TITLE
Reuse the struct array dtype between compute functions

### DIFF
--- a/fuzz/src/filter.rs
+++ b/fuzz/src/filter.rs
@@ -3,7 +3,6 @@ use vortex_array::arrays::{
     BoolArray, BooleanBuffer, PrimitiveArray, StructArray, VarBinViewArray,
 };
 use vortex_array::validity::Validity;
-use vortex_array::variants::StructArrayTrait;
 use vortex_array::{Array, ArrayRef, ToCanonical};
 use vortex_buffer::Buffer;
 use vortex_dtype::{DType, match_each_native_ptype};

--- a/fuzz/src/filter.rs
+++ b/fuzz/src/filter.rs
@@ -71,9 +71,9 @@ pub fn filter_canonical_array(array: &dyn Array, filter: &[bool]) -> VortexResul
                 .map(|c| filter_canonical_array(c, filter))
                 .collect::<VortexResult<Vec<_>>>()?;
 
-            StructArray::try_new(
-                struct_array.names().clone(),
+            StructArray::try_new_with_dtype(
                 filtered_children,
+                struct_array.struct_dtype().clone(),
                 filter.iter().filter(|b| **b).map(|b| *b as usize).sum(),
                 validity,
             )

--- a/fuzz/src/slice.rs
+++ b/fuzz/src/slice.rs
@@ -49,9 +49,9 @@ pub fn slice_canonical_array(
                 .iter()
                 .map(|c| slice_canonical_array(c, start, stop))
                 .collect::<VortexResult<Vec<_>>>()?;
-            StructArray::try_new(
-                struct_array.names().clone(),
+            StructArray::try_new_with_dtype(
                 sliced_children,
+                struct_array.struct_dtype().clone(),
                 stop - start,
                 validity,
             )

--- a/fuzz/src/slice.rs
+++ b/fuzz/src/slice.rs
@@ -1,7 +1,7 @@
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::{BoolArray, ListArray, PrimitiveArray, StructArray, VarBinViewArray};
 use vortex_array::validity::Validity;
-use vortex_array::variants::{PrimitiveArrayTrait, StructArrayTrait};
+use vortex_array::variants::PrimitiveArrayTrait;
 use vortex_array::{Array, ArrayRef, ToCanonical};
 use vortex_dtype::{
     DType, NativePType, Nullability, match_each_integer_ptype, match_each_native_ptype,

--- a/vortex-array/src/arrays/chunked/canonical.rs
+++ b/vortex-array/src/arrays/chunked/canonical.rs
@@ -67,12 +67,7 @@ fn swizzle_struct_chunks(
         field_arrays.push(field_array.into_array());
     }
 
-    StructArray::try_new_with_dtype(
-        field_arrays,
-        DType::Struct(struct_dtype.clone(), validity.nullability()),
-        len,
-        validity,
-    )
+    StructArray::try_new_with_dtype(field_arrays, struct_dtype.clone(), len, validity)
 }
 
 fn pack_lists(

--- a/vortex-array/src/arrays/chunked/canonical.rs
+++ b/vortex-array/src/arrays/chunked/canonical.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use vortex_buffer::BufferMut;
 use vortex_dtype::{DType, Nullability, PType, StructDType};
 use vortex_error::{VortexExpect, VortexResult, vortex_err};
@@ -46,7 +48,7 @@ impl ArrayCanonicalImpl for ChunkedArray {
 fn swizzle_struct_chunks(
     chunks: &[ArrayRef],
     validity: Validity,
-    struct_dtype: &StructDType,
+    struct_dtype: &Arc<StructDType>,
 ) -> VortexResult<StructArray> {
     let len = chunks.iter().map(|chunk| chunk.len()).sum();
     let mut field_arrays = Vec::new();
@@ -65,7 +67,12 @@ fn swizzle_struct_chunks(
         field_arrays.push(field_array.into_array());
     }
 
-    StructArray::try_new(struct_dtype.names().clone(), field_arrays, len, validity)
+    StructArray::try_new_with_dtype(
+        field_arrays,
+        DType::Struct(struct_dtype.clone(), validity.nullability()),
+        len,
+        validity,
+    )
 }
 
 fn pack_lists(

--- a/vortex-array/src/arrays/constant/canonical.rs
+++ b/vortex-array/src/arrays/constant/canonical.rs
@@ -72,12 +72,9 @@ impl ArrayCanonicalImpl for ConstantArray {
                         .map(|s| ConstantArray::new(s, self.len()).into_array())
                         .collect::<Vec<_>>()
                 });
-                let Some(struct_dtype) = value.dtype().as_struct() else {
-                    unreachable!()
-                };
                 Canonical::Struct(StructArray::try_new_with_dtype(
                     fields.unwrap_or_default(),
-                    struct_dtype.clone(),
+                    value.struct_dtype().clone(),
                     self.len(),
                     validity,
                 )?)

--- a/vortex-array/src/arrays/constant/canonical.rs
+++ b/vortex-array/src/arrays/constant/canonical.rs
@@ -72,12 +72,12 @@ impl ArrayCanonicalImpl for ConstantArray {
                         .map(|s| ConstantArray::new(s, self.len()).into_array())
                         .collect::<Vec<_>>()
                 });
-                let DType::Struct(struct_dt, _) = value.dtype() else {
+                let Some(struct_dtype) = value.dtype().as_struct() else {
                     unreachable!()
                 };
                 Canonical::Struct(StructArray::try_new_with_dtype(
                     fields.unwrap_or_default(),
-                    struct_dt.clone(),
+                    struct_dtype.clone(),
                     self.len(),
                     validity,
                 )?)

--- a/vortex-array/src/arrays/constant/canonical.rs
+++ b/vortex-array/src/arrays/constant/canonical.rs
@@ -64,7 +64,7 @@ impl ArrayCanonicalImpl for ConstantArray {
                 let const_value = value.as_ref().map(|v| v.as_slice());
                 Canonical::VarBinView(canonical_byte_view(const_value, self.dtype(), self.len())?)
             }
-            DType::Struct(..) => {
+            DType::Struct(struct_dtype, _) => {
                 let value = StructScalar::try_from(scalar)?;
                 let fields = value.fields().map(|fields| {
                     fields
@@ -74,7 +74,7 @@ impl ArrayCanonicalImpl for ConstantArray {
                 });
                 Canonical::Struct(StructArray::try_new_with_dtype(
                     fields.unwrap_or_default(),
-                    value.struct_dtype().clone(),
+                    struct_dtype.clone(),
                     self.len(),
                     validity,
                 )?)

--- a/vortex-array/src/arrays/constant/canonical.rs
+++ b/vortex-array/src/arrays/constant/canonical.rs
@@ -72,9 +72,12 @@ impl ArrayCanonicalImpl for ConstantArray {
                         .map(|s| ConstantArray::new(s, self.len()).into_array())
                         .collect::<Vec<_>>()
                 });
+                let DType::Struct(struct_dt, _) = value.dtype() else {
+                    unreachable!()
+                };
                 Canonical::Struct(StructArray::try_new_with_dtype(
                     fields.unwrap_or_default(),
-                    value.struct_dtype().clone(),
+                    struct_dt.clone(),
                     self.len(),
                     validity,
                 )?)

--- a/vortex-array/src/arrays/constant/canonical.rs
+++ b/vortex-array/src/arrays/constant/canonical.rs
@@ -72,9 +72,9 @@ impl ArrayCanonicalImpl for ConstantArray {
                         .map(|s| ConstantArray::new(s, self.len()).into_array())
                         .collect::<Vec<_>>()
                 });
-                Canonical::Struct(StructArray::try_new(
-                    value.struct_dtype().names().clone(),
+                Canonical::Struct(StructArray::try_new_with_dtype(
                     fields.unwrap_or_default(),
+                    value.struct_dtype().clone(),
                     self.len(),
                     validity,
                 )?)

--- a/vortex-array/src/arrays/struct_/compute/mod.rs
+++ b/vortex-array/src/arrays/struct_/compute/mod.rs
@@ -78,14 +78,14 @@ impl CastFn<&StructArray> for StructEncoding {
             .clone()
             .cast_nullability(dtype.nullability())?;
 
-        StructArray::try_new_with_dtype(
+        StructArray::try_new(
+            target_sdtype.names().clone(),
             array
                 .fields()
                 .iter()
                 .zip_eq(target_sdtype.fields())
                 .map(|(field, dtype)| try_cast(field, &dtype))
                 .try_collect()?,
-            array.struct_dtype().clone(),
             array.len(),
             validity,
         )

--- a/vortex-array/src/arrays/struct_/compute/mod.rs
+++ b/vortex-array/src/arrays/struct_/compute/mod.rs
@@ -86,7 +86,7 @@ impl CastFn<&StructArray> for StructEncoding {
                 .zip_eq(target_sdtype.fields())
                 .map(|(field, dtype)| try_cast(field, &dtype))
                 .try_collect()?,
-            array.struct_dtype(),
+            array.struct_dtype().clone(),
             array.len(),
             validity,
         )
@@ -115,7 +115,7 @@ impl TakeFn<&StructArray> for StructEncoding {
                 .iter()
                 .map(|field| take(field, indices))
                 .try_collect()?,
-            array.dtype().clone(),
+            array.struct_dtype().clone(),
             indices.len(),
             array.validity().take(indices)?,
         )
@@ -132,7 +132,7 @@ impl SliceFn<&StructArray> for StructEncoding {
             .try_collect()?;
         StructArray::try_new_with_dtype(
             fields,
-            array.dtype().clone(),
+            array.struct_dtype().clone(),
             stop - start,
             array.validity().slice(start, stop)?,
         )
@@ -154,7 +154,7 @@ impl FilterKernel for StructEncoding {
             .map(|a| a.len())
             .unwrap_or_else(|| mask.true_count());
 
-        StructArray::try_new_with_dtype(fields, array.dtype().clone(), length, validity)
+        StructArray::try_new_with_dtype(fields, array.struct_dtype().clone(), length, validity)
             .map(|a| a.into_array())
     }
 }
@@ -163,9 +163,9 @@ impl MaskFn<&StructArray> for StructEncoding {
     fn mask(&self, array: &StructArray, filter_mask: Mask) -> VortexResult<ArrayRef> {
         let validity = array.validity().mask(&filter_mask)?;
 
-        StructArray::try_new(
-            array.names().clone(),
+        StructArray::try_new_with_dtype(
             array.fields().to_vec(),
+            array.struct_dtype().clone(),
             array.len(),
             validity,
         )

--- a/vortex-array/src/arrays/struct_/compute/mod.rs
+++ b/vortex-array/src/arrays/struct_/compute/mod.rs
@@ -79,14 +79,14 @@ impl CastFn<&StructArray> for StructEncoding {
             .clone()
             .cast_nullability(dtype.nullability())?;
 
-        StructArray::try_new(
-            target_sdtype.names().clone(),
+        StructArray::try_new_with_dtype(
             array
                 .fields()
                 .iter()
                 .zip_eq(target_sdtype.fields())
                 .map(|(field, dtype)| try_cast(field, &dtype))
                 .try_collect()?,
+            array.struct_dtype(),
             array.len(),
             validity,
         )
@@ -109,13 +109,13 @@ impl ScalarAtFn<&StructArray> for StructEncoding {
 
 impl TakeFn<&StructArray> for StructEncoding {
     fn take(&self, array: &StructArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
-        StructArray::try_new(
-            array.names().clone(),
+        StructArray::try_new_with_dtype(
             array
                 .fields()
                 .iter()
                 .map(|field| take(field, indices))
                 .try_collect()?,
+            array.dtype().clone(),
             indices.len(),
             array.validity().take(indices)?,
         )
@@ -130,9 +130,9 @@ impl SliceFn<&StructArray> for StructEncoding {
             .iter()
             .map(|field| slice(field, start, stop))
             .try_collect()?;
-        StructArray::try_new(
-            array.names().clone(),
+        StructArray::try_new_with_dtype(
             fields,
+            array.dtype().clone(),
             stop - start,
             array.validity().slice(start, stop)?,
         )
@@ -154,7 +154,7 @@ impl FilterKernel for StructEncoding {
             .map(|a| a.len())
             .unwrap_or_else(|| mask.true_count());
 
-        StructArray::try_new(array.names().clone(), fields, length, validity)
+        StructArray::try_new_with_dtype(fields, array.dtype().clone(), length, validity)
             .map(|a| a.into_array())
     }
 }

--- a/vortex-array/src/arrays/struct_/compute/mod.rs
+++ b/vortex-array/src/arrays/struct_/compute/mod.rs
@@ -13,7 +13,6 @@ use crate::compute::{
     MinMaxFn, MinMaxResult, ScalarAtFn, SliceFn, TakeFn, ToArrowFn, UncompressedSizeFn, filter,
     is_constant_opts, scalar_at, slice, take, try_cast, uncompressed_size,
 };
-use crate::variants::StructArrayTrait;
 use crate::vtable::ComputeVTable;
 use crate::{Array, ArrayComputeImpl, ArrayRef, ArrayVisitor};
 

--- a/vortex-array/src/arrays/struct_/mod.rs
+++ b/vortex-array/src/arrays/struct_/mod.rs
@@ -192,7 +192,7 @@ impl ArrayImpl for StructArray {
         let fields_idx = if validity.is_array() { 1_usize } else { 0 };
         let fields = children[fields_idx..].to_vec();
 
-        Self::try_new(self.names().clone(), fields, self.len(), validity)
+        Self::try_new_with_dtype(fields, self.struct_dtype().clone(), self.len(), validity)
     }
 }
 

--- a/vortex-array/src/arrays/struct_/mod.rs
+++ b/vortex-array/src/arrays/struct_/mod.rs
@@ -116,8 +116,6 @@ impl StructArray {
         })
     }
 
-    // TODO(joe): add a new struct ctor that doesn't create a dtype
-
     pub fn from_fields<N: AsRef<str>>(items: &[(N, ArrayRef)]) -> VortexResult<Self> {
         let names = items.iter().map(|(name, _)| FieldName::from(name.as_ref()));
         let fields: Vec<ArrayRef> = items.iter().map(|(_, array)| array.to_array()).collect();

--- a/vortex-array/src/arrays/struct_/mod.rs
+++ b/vortex-array/src/arrays/struct_/mod.rs
@@ -43,12 +43,12 @@ impl StructArray {
     }
 
     pub fn struct_dtype(&self) -> &Arc<StructDType> {
-        let DType::Struct(str, _) = &self.dtype else {
+        let Some(struct_dtype) = &self.dtype.as_struct() else {
             unreachable!(
                 "struct arrays must have be a DType::Struct, this is likely an internal bug."
             )
         };
-        str
+        struct_dtype
     }
 
     pub fn try_new(

--- a/vortex-array/src/arrays/struct_/mod.rs
+++ b/vortex-array/src/arrays/struct_/mod.rs
@@ -42,6 +42,13 @@ impl StructArray {
         &self.fields
     }
 
+    pub fn struct_dtype(&self) -> &Arc<StructDType> {
+        let DType::Struct(str, _) = &self.dtype else {
+            unreachable!()
+        };
+        str
+    }
+
     pub fn try_new(
         names: FieldNames,
         fields: Vec<ArrayRef>,
@@ -74,6 +81,40 @@ impl StructArray {
             stats_set: Default::default(),
         })
     }
+
+    pub fn try_new_with_dtype(
+        fields: Vec<ArrayRef>,
+        dtype: Arc<StructDType>,
+        length: usize,
+        validity: Validity,
+    ) -> VortexResult<Self> {
+        for (field, struct_dt) in fields.iter().zip(dtype.fields()) {
+            if field.len() != length {
+                vortex_bail!(
+                    "Expected all struct fields to have length {length}, found {}",
+                    field.len()
+                );
+            }
+
+            if &struct_dt != field.dtype() {
+                vortex_bail!(
+                    "Expected all struct fields to have dtype {}, found {}",
+                    struct_dt,
+                    field.dtype()
+                );
+            }
+        }
+
+        Ok(Self {
+            len: length,
+            dtype: DType::Struct(dtype, validity.nullability()),
+            fields,
+            validity,
+            stats_set: Default::default(),
+        })
+    }
+
+    // TODO(joe): add a new struct ctor that doesn't create a dtype
 
     pub fn from_fields<N: AsRef<str>>(items: &[(N, ArrayRef)]) -> VortexResult<Self> {
         let names = items.iter().map(|(name, _)| FieldName::from(name.as_ref()));

--- a/vortex-array/src/arrays/struct_/mod.rs
+++ b/vortex-array/src/arrays/struct_/mod.rs
@@ -44,7 +44,9 @@ impl StructArray {
 
     pub fn struct_dtype(&self) -> &Arc<StructDType> {
         let DType::Struct(str, _) = &self.dtype else {
-            unreachable!()
+            unreachable!(
+                "struct arrays must have be a DType::Struct, this is likely an internal bug."
+            )
         };
         str
     }

--- a/vortex-array/src/arrays/struct_/serde.rs
+++ b/vortex-array/src/arrays/struct_/serde.rs
@@ -53,10 +53,11 @@ impl EncodingVTable for StructEncoding {
             })
             .try_collect()?;
 
-        Ok(
-            StructArray::try_new(struct_dtype.names().clone(), children, len, validity)?
-                .into_array(),
-        )
+        let DType::Struct(struct_dtype, _) = dtype else {
+            unreachable!()
+        };
+
+        Ok(StructArray::try_new_with_dtype(children, struct_dtype, len, validity)?.into_array())
     }
 }
 

--- a/vortex-array/src/arrays/struct_/serde.rs
+++ b/vortex-array/src/arrays/struct_/serde.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use vortex_dtype::DType;
-use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
+use vortex_error::{VortexExpect, VortexResult, vortex_bail};
 
 use super::StructEncoding;
 use crate::arrays::StructArray;
@@ -24,12 +24,12 @@ impl EncodingVTable for StructEncoding {
         dtype: DType,
         len: usize,
     ) -> VortexResult<ArrayRef> {
-        let struct_dtype = dtype
-            .as_struct()
-            .ok_or_else(|| vortex_err!("Expected struct dtype, found {:?}", dtype))?;
+        let DType::Struct(struct_dtype, nullability) = dtype else {
+            vortex_bail!("Expected struct dtype, found {:?}", dtype)
+        };
 
         let validity = if parts.nchildren() == struct_dtype.nfields() {
-            Validity::from(dtype.nullability())
+            Validity::from(nullability)
         } else if parts.nchildren() == struct_dtype.nfields() + 1 {
             // Validity is the first child if it exists.
             let validity = parts.child(0).decode(ctx, Validity::DTYPE, len)?;
@@ -52,10 +52,6 @@ impl EncodingVTable for StructEncoding {
                 child_parts.decode(ctx, child_dtype, len)
             })
             .try_collect()?;
-
-        let DType::Struct(struct_dtype, _) = dtype else {
-            unreachable!()
-        };
 
         Ok(StructArray::try_new_with_dtype(children, struct_dtype, len, validity)?.into_array())
     }

--- a/vortex-array/src/builders/struct_.rs
+++ b/vortex-array/src/builders/struct_.rs
@@ -157,7 +157,7 @@ impl ArrayBuilder for StructBuilder {
 
         let validity = self.validity.finish_with_nullability(self.nullability);
 
-        StructArray::try_new(self.struct_dtype.names().clone(), fields, len, validity)
+        StructArray::try_new_with_dtype(fields, self.struct_dtype.clone(), len, validity)
             .vortex_expect("Fields must all have same length.")
             .into_array()
     }

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -160,7 +160,7 @@ impl DType {
     }
 
     /// Get the `StructDType` if `self` is a `StructDType`, otherwise `None`
-    pub fn as_struct(&self) -> Option<&StructDType> {
+    pub fn as_struct(&self) -> Option<&Arc<StructDType>> {
         match self {
             Struct(s, _) => Some(s),
             _ => None,

--- a/vortex-layout/src/scan/filter.rs
+++ b/vortex-layout/src/scan/filter.rs
@@ -51,12 +51,12 @@ pub struct FilterExpr {
 
 impl FilterExpr {
     pub fn try_new(
-        scope_dtype: StructDType,
+        scope_dtype: &StructDType,
         expr: ExprRef,
         prefetch_conjuncts: bool,
     ) -> VortexResult<Self> {
         // Find all the fields involved in the expression.
-        let fields: Arc<[FieldName]> = immediate_scope_access(&expr, &scope_dtype)?
+        let fields: Arc<[FieldName]> = immediate_scope_access(&expr, scope_dtype)?
             .into_iter()
             .collect();
 
@@ -66,7 +66,7 @@ impl FilterExpr {
         // Find which fields are referenced by each conjunct.
         let conjunct_fields = conjuncts
             .iter()
-            .map(|expr| immediate_scope_access(expr, &scope_dtype))
+            .map(|expr| immediate_scope_access(expr, scope_dtype))
             .map_ok(|conjunct_fields| {
                 conjunct_fields
                     .iter()

--- a/vortex-layout/src/scan/mod.rs
+++ b/vortex-layout/src/scan/mod.rs
@@ -291,13 +291,9 @@ impl<D: ScanDriver> Scan<D> {
             .as_ref()
             .map(|filter| {
                 let pruning = Arc::new(FilterExpr::try_new(
-                    reader
-                        .dtype()
-                        .as_struct()
-                        .ok_or_else(|| {
-                            vortex_err!("Vortex scan currently only works for struct arrays")
-                        })?
-                        .clone(),
+                    reader.dtype().as_struct().ok_or_else(|| {
+                        vortex_err!("Vortex scan currently only works for struct arrays")
+                    })?,
                     filter.clone(),
                     self.prefetch_conjuncts,
                 )?);

--- a/vortex-scalar/src/struct_.rs
+++ b/vortex-scalar/src/struct_.rs
@@ -60,7 +60,7 @@ impl<'a> StructScalar<'a> {
     }
 
     #[inline]
-    pub fn struct_dtype(&self) -> &'a StructDType {
+    pub fn struct_dtype(&self) -> &Arc<StructDType> {
         let DType::Struct(sdtype, ..) = self.dtype else {
             vortex_panic!("StructScalar always has struct dtype");
         };


### PR DESCRIPTION
There is a bit of overhead if create large struct dtypes in compute functions when we don't need to recreate, so dont