### PR TITLE
fsst take to work with nullable indices

### DIFF
--- a/encodings/fsst/src/compute/mod.rs
+++ b/encodings/fsst/src/compute/mod.rs
@@ -61,7 +61,10 @@ impl TakeFn<&FSSTArray> for FSSTEncoding {
             take(array.codes(), indices)?,
             fill_null(
                 &take(array.uncompressed_lengths(), indices)?,
-                Scalar::new(indices.dtype().clone(), ScalarValue::from(0)),
+                Scalar::new(
+                    array.uncompressed_lengths_dtype().clone(),
+                    ScalarValue::from(0),
+                ),
             )?,
         )?
         .into_array())

--- a/encodings/fsst/src/compute/mod.rs
+++ b/encodings/fsst/src/compute/mod.rs
@@ -3,8 +3,8 @@ mod compare;
 use vortex_array::arrays::varbin_scalar;
 use vortex_array::builders::ArrayBuilder;
 use vortex_array::compute::{
-    CompareFn, FilterKernel, FilterKernelAdapter, KernelRef, ScalarAtFn, SliceFn, TakeFn, filter,
-    scalar_at, slice, take,
+    CompareFn, FilterKernel, FilterKernelAdapter, KernelRef, ScalarAtFn, SliceFn, TakeFn,
+    fill_null, filter, scalar_at, slice, take,
 };
 use vortex_array::vtable::ComputeVTable;
 use vortex_array::{Array, ArrayComputeImpl, ArrayRef};
@@ -59,7 +59,10 @@ impl TakeFn<&FSSTArray> for FSSTEncoding {
             array.symbols().clone(),
             array.symbol_lengths().clone(),
             take(array.codes(), indices)?,
-            take(array.uncompressed_lengths(), indices)?,
+            fill_null(
+                &take(array.uncompressed_lengths(), indices)?,
+                Scalar::from(0).cast(indices.dtype())?,
+            )?,
         )?
         .into_array())
     }

--- a/encodings/fsst/src/compute/mod.rs
+++ b/encodings/fsst/src/compute/mod.rs
@@ -11,7 +11,7 @@ use vortex_array::{Array, ArrayComputeImpl, ArrayRef};
 use vortex_buffer::ByteBuffer;
 use vortex_error::{VortexResult, vortex_err};
 use vortex_mask::Mask;
-use vortex_scalar::Scalar;
+use vortex_scalar::{Scalar, ScalarValue};
 
 use crate::{FSSTArray, FSSTEncoding};
 
@@ -61,7 +61,7 @@ impl TakeFn<&FSSTArray> for FSSTEncoding {
             take(array.codes(), indices)?,
             fill_null(
                 &take(array.uncompressed_lengths(), indices)?,
-                Scalar::from(0).cast(indices.dtype())?,
+                Scalar::new(indices.dtype().clone(), ScalarValue::from(0)),
             )?,
         )?
         .into_array())


### PR DESCRIPTION
Investigating the doctest failure at https://github.com/spiraldb/vortex/pull/2811 led me to this. 

If we have a dict array with fsst values, currently we won't be able to canonicalise the array if the dict has any nulls:
- dict array on construction switches codes nullability to match values.
- calling `take` on this dict would call take on its values, which is fsst.
- fsst::take takes on the passed indices (codes of the parent dict array), to contruct the uncompressed lengths array of the new fsst array to return
- take on the primitive uncompressed lengths array with nullable codes as indices would result in a nullable primitive array
- fsst construction rejects if uncompressed lengths are nullable