### PR TITLE
ci: re-enable aws spot instances

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -29,7 +29,6 @@ jobs:
       - family=c7i.8xlarge
       - image=ubuntu24-full-x64
       - disk=large
-      - spot=false
       - tag=${{ matrix.benchmark.id }}
     strategy:
       matrix:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -37,7 +37,6 @@ jobs:
       - family=c7i.8xlarge
       - image=ubuntu24-full-x64
       - disk=large
-      - spot=false
       - tag=${{ matrix.benchmark.id }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,6 @@ jobs:
       - cpu=8
       - image=ubuntu24-full-x64
       - disk=large
-      - spot=false
       - tag=rust-docs
     steps:
       - uses: actions/checkout@v4
@@ -133,7 +132,6 @@ jobs:
       - cpu=8
       - image=ubuntu24-full-x64
       - disk=large
-      - spot=false
       - tag=${{ matrix.config.name }}
 
     env:
@@ -189,7 +187,6 @@ jobs:
       - cpu=8
       - image=ubuntu24-full-x64
       - disk=large
-      - spot=false
       - tag=rust-min-deps
     steps:
       - uses: runs-on/action@v1
@@ -210,7 +207,6 @@ jobs:
       - cpu=8
       - image=ubuntu24-full-x64
       - disk=large
-      - spot=false
       - tag=rust-lint
     steps:
       - uses: runs-on/action@v1
@@ -283,7 +279,6 @@ jobs:
       - runs-on=${{ github.run_id }}
       - family=c7i.8xlarge
       - image=ubuntu24-full-x64
-      - spot=false
 
     steps:
       - uses: runs-on/action@v1

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -14,7 +14,6 @@ jobs:
       - image=ubuntu24-full-x64
       - disk=large
       - tag=io-fuzz
-      - spot=false
     steps:
       - uses: runs-on/action@v1
       - uses: actions/checkout@v4
@@ -59,7 +58,6 @@ jobs:
       - image=ubuntu24-full-x64
       - disk=large
       - tag=ops-fuzz
-      - spot=false
     steps:
       - uses: runs-on/action@v1
       - uses: actions/checkout@v4

--- a/.github/workflows/generate-benchmarks-s3.yml
+++ b/.github/workflows/generate-benchmarks-s3.yml
@@ -20,7 +20,6 @@ jobs:
       - runs-on=${{ github.run_id }}
       - family=m7i.2xlarge
       - image=ubuntu24-full-x64
-      - spot=false
       - disk=large
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -30,7 +30,6 @@ jobs:
       - family=c7i.8xlarge
       - image=ubuntu24-full-x64
       - disk=large
-      - spot=false
       - tag=${{ matrix.include.id }}
 
     steps:


### PR DESCRIPTION
Fixed in the latest runs-on version: https://github.com/runs-on/runs-on/issues/251