### PR TITLE
Keep array stats when writing arrays through the btrblocks layout

### DIFF
--- a/vortex-btrblocks/src/lib.rs
+++ b/vortex-btrblocks/src/lib.rs
@@ -245,9 +245,12 @@ pub trait Compressor {
 pub struct BtrBlocksCompressor;
 
 impl BtrBlocksCompressor {
-    #[allow(clippy::only_used_in_recursion)]
     pub fn compress(&self, array: &dyn Array) -> VortexResult<ArrayRef> {
-        match array.to_canonical()? {
+        self.compress_canonical(array.to_canonical()?)
+    }
+
+    pub fn compress_canonical(&self, array: Canonical) -> VortexResult<ArrayRef> {
+        match array {
             Canonical::Null(null_array) => Ok(null_array.into_array()),
             // TODO(aduffy): Sparse, other bool compressors.
             Canonical::Bool(bool_array) => Ok(bool_array.into_array()),

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -130,6 +130,7 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
     ) -> VortexResult<()> {
         // Compute the stats for the chunk prior to compression
         chunk.statistics().compute_all(STATS_TO_WRITE)?;
+        let chunk_statistics = chunk.statistics().to_owned();
 
         // Short circuit the decision if the chunk is constant
         let compressed_chunk = if let Some(constant) = chunk.as_constant() {
@@ -167,7 +168,10 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
         };
 
         let compressed_chunk = match compressed_chunk {
-            Some(array) => array,
+            Some(array) => {
+                array.statistics().inherit(chunk.statistics());
+                array
+            }
             None => {
                 let canonical_chunk = chunk.to_canonical()?;
                 let compressed = BtrBlocksCompressor.compress(canonical_chunk.as_ref())?;
@@ -178,6 +182,8 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
                 compressed
             }
         };
+
+        let stats = compressed_chunk.statistics().to_owned();
 
         self.child.push_chunk(segment_writer, compressed_chunk)
     }

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -170,10 +170,11 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
             Some(array) => array,
             None => {
                 let canonical_chunk = chunk.to_canonical()?;
-                let compressed = BtrBlocksCompressor.compress(canonical_chunk.as_ref())?;
+                let canonical_size = canonical_chunk.as_ref().nbytes() as f64;
+                let compressed = BtrBlocksCompressor.compress_canonical(canonical_chunk)?;
                 self.previous_chunk = Some(PreviousCompression {
                     chunk: compressed.clone(),
-                    ratio: compressed.nbytes() as f64 / canonical_chunk.as_ref().nbytes() as f64,
+                    ratio: compressed.nbytes() as f64 / canonical_size,
                 });
                 compressed
             }

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -167,10 +167,7 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
         };
 
         let compressed_chunk = match compressed_chunk {
-            Some(array) => {
-                array.statistics().inherit(chunk.statistics());
-                array
-            }
+            Some(array) => array,
             None => {
                 let canonical_chunk = chunk.to_canonical()?;
                 let compressed = BtrBlocksCompressor.compress(canonical_chunk.as_ref())?;
@@ -181,6 +178,8 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
                 compressed
             }
         };
+
+        compressed_chunk.statistics().inherit(chunk.statistics());
 
         self.child.push_chunk(segment_writer, compressed_chunk)
     }

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -130,7 +130,6 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
     ) -> VortexResult<()> {
         // Compute the stats for the chunk prior to compression
         chunk.statistics().compute_all(STATS_TO_WRITE)?;
-        let chunk_statistics = chunk.statistics().to_owned();
 
         // Short circuit the decision if the chunk is constant
         let compressed_chunk = if let Some(constant) = chunk.as_constant() {
@@ -182,8 +181,6 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
                 compressed
             }
         };
-
-        let stats = compressed_chunk.statistics().to_owned();
 
         self.child.push_chunk(segment_writer, compressed_chunk)
     }


### PR DESCRIPTION
~I introduced a nice bug in #2724. This is not a real fix just a patch to guesstimate the impact.~ This was actually the behavior even before, seems like a waste to throw it away?