### PR TITLE
fix: unblock release-plz flow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
       - name: Run release-plz
         id: run-release-plz
-        uses: MarcoIeni/release-plz-action@v0.5
+        uses: MarcoIeni/release-plz-action@5280151
         with:
           command: release
         env:
@@ -51,7 +51,7 @@ jobs:
       - uses: ./.github/actions/cleanup
       - uses: ./.github/actions/setup-rust
       - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@v0.5
+        uses: MarcoIeni/release-plz-action@5280151
         with:
           command: release-pr
         env:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,6 @@
 [workspace]
 # set the path of all the crates to the changelog to the root of the repository
-publish_allow_dirty = ["duckdb-vortex/duckdb"]
+publish_allow_dirty = true
 changelog_path = "./CHANGELOG.md"
 git_release_enable = false
 git_tag_enable = false


### PR DESCRIPTION
This should be sufficient to unblock our release-plz flow. The full release-plz fix is currently worked on in context of https://github.com/release-plz/release-plz/pull/2153.