### PR TITLE
Btrblock compress string to constant

### DIFF
--- a/vortex-btrblocks/src/string.rs
+++ b/vortex-btrblocks/src/string.rs
@@ -68,7 +68,7 @@ impl CompressorStats for StringStats {
             value_count: value_count.try_into().vortex_expect("value_count"),
             null_count: null_count.try_into().vortex_expect("null_count"),
             estimated_distinct_count: estimated_distinct,
-            exact_distinct_count: is_exact.then(|| estimated_distinct),
+            exact_distinct_count: is_exact.then_some(estimated_distinct),
         }
     }
 

--- a/vortex-btrblocks/src/string.rs
+++ b/vortex-btrblocks/src/string.rs
@@ -1,7 +1,7 @@
 use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::arrays::{ConstantArray, VarBinViewArray};
+use vortex_array::stats::Precision;
 use vortex_array::stats::Stat::IsConstant;
-use vortex_array::stats::{Precision, StatsProvider};
 use vortex_array::{Array, ArrayRef, ArrayStatistics, ToCanonical};
 use vortex_dict::DictArray;
 use vortex_dict::builders::dict_encode;

--- a/vortex-btrblocks/src/string.rs
+++ b/vortex-btrblocks/src/string.rs
@@ -1,5 +1,7 @@
 use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::arrays::{ConstantArray, VarBinViewArray};
+use vortex_array::stats::Precision;
+use vortex_array::stats::Stat::IsConstant;
 use vortex_array::{Array, ArrayRef, ArrayStatistics, ToCanonical};
 use vortex_dict::DictArray;
 use vortex_dict::builders::dict_encode;
@@ -62,6 +64,10 @@ impl CompressorStats for StringStats {
         } else {
             (u32::MAX, false)
         };
+
+        if is_exact && estimated_distinct == 1 && null_count == 0 {
+            input.statistics().set(IsConstant, Precision::exact(true));
+        }
 
         Self {
             src: input.clone(),

--- a/vortex-btrblocks/src/string.rs
+++ b/vortex-btrblocks/src/string.rs
@@ -1,5 +1,3 @@
-use std::error::Error;
-
 use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::arrays::{ConstantArray, VarBinViewArray};
 use vortex_array::{Array, ArrayRef, ArrayStatistics, ToCanonical};
@@ -19,28 +17,35 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct StringStats {
     src: VarBinViewArray,
+    exact_distinct_count: Option<u32>,
     estimated_distinct_count: u32,
     value_count: u32,
-    // null_count: u32,
+    null_count: u32,
 }
 
 /// Estimate the number of distinct strings in the var bin view array.
+/// If all are inlined then is count is exact and true is returned.
 #[allow(clippy::cast_possible_truncation)]
-fn estimate_distinct_count(strings: &VarBinViewArray) -> u32 {
+fn estimate_distinct_count(strings: &VarBinViewArray) -> (u32, bool) {
     let views = strings.views();
     // Iterate the views. Two strings which are equal must have the same first 8-bytes.
     // NOTE: there are cases where this performs pessimally, e.g. when we have strings that all
     // share a 4-byte prefix and have the same length.
     let mut distinct = HashSet::with_capacity(views.len() / 2);
+    let mut all_inlined = true;
     views.iter().for_each(|&view| {
         let len_and_prefix = view.as_u128() as u64;
         distinct.insert(len_and_prefix);
+        all_inlined &= view.is_inlined();
     });
 
-    distinct
-        .len()
-        .try_into()
-        .vortex_expect("distinct count must fit in u32")
+    (
+        distinct
+            .len()
+            .try_into()
+            .vortex_expect("distinct count must fit in u32"),
+        all_inlined,
+    )
 }
 
 impl CompressorStats for StringStats {
@@ -52,17 +57,18 @@ impl CompressorStats for StringStats {
             .compute_null_count()
             .vortex_expect("null count");
         let value_count = input.len() - null_count;
-        let estimated_distinct = if opts.count_distinct_values {
+        let (estimated_distinct, is_exact) = if opts.count_distinct_values {
             estimate_distinct_count(input)
         } else {
-            u32::MAX
+            (u32::MAX, false)
         };
 
         Self {
             src: input.clone(),
             value_count: value_count.try_into().vortex_expect("value_count"),
-            // null_count: null_count.try_into().vortex_expect("null_count"),
+            null_count: null_count.try_into().vortex_expect("null_count"),
             estimated_distinct_count: estimated_distinct,
+            exact_distinct_count: is_exact.then(|| estimated_distinct),
         }
     }
 
@@ -165,9 +171,13 @@ impl Scheme for ConstantScheme {
         CONSTANT_SCHEME
     }
 
+    fn is_constant(&self) -> bool {
+        true
+    }
+
     fn expected_compression_ratio(
         &self,
-        stats: &Self::StatsType,
+        stats: &StringStats,
         is_sample: bool,
         _allowed_cascading: usize,
         _excludes: &[Self::CodeType],
@@ -178,7 +188,7 @@ impl Scheme for ConstantScheme {
         }
 
         // Only arrays with one distinct values can be constant compressed.
-        if stats.estimated_distinct_count != 1 {
+        if stats.exact_distinct_count.unwrap_or(stats.value_count) != 1 {
             return Ok(0.0);
         }
 

--- a/vortex-btrblocks/src/string.rs
+++ b/vortex-btrblocks/src/string.rs
@@ -1,6 +1,8 @@
+use std::error::Error;
+
 use vortex_array::aliases::hash_set::HashSet;
-use vortex_array::arrays::VarBinViewArray;
-use vortex_array::{Array, ArrayRef, ToCanonical};
+use vortex_array::arrays::{ConstantArray, VarBinViewArray};
+use vortex_array::{Array, ArrayRef, ArrayStatistics, ToCanonical};
 use vortex_dict::DictArray;
 use vortex_dict::builders::dict_encode;
 use vortex_error::{VortexExpect, VortexResult};
@@ -85,7 +87,12 @@ impl Compressor for StringCompressor {
     type StatsType = StringStats;
 
     fn schemes() -> &'static [&'static Self::SchemeType] {
-        &[&UncompressedScheme, &DictScheme, &FSSTScheme]
+        &[
+            &UncompressedScheme,
+            &ConstantScheme,
+            &DictScheme,
+            &FSSTScheme,
+        ]
     }
 
     fn default_scheme() -> &'static Self::SchemeType {
@@ -105,6 +112,9 @@ impl<T> StringScheme for T where T: Scheme<StatsType = StringStats, CodeType = S
 pub struct UncompressedScheme;
 
 #[derive(Debug, Copy, Clone)]
+pub struct ConstantScheme;
+
+#[derive(Debug, Copy, Clone)]
 pub struct DictScheme;
 
 #[derive(Debug, Copy, Clone)]
@@ -116,6 +126,7 @@ pub struct StringCode(u8);
 const UNCOMPRESSED_SCHEME: StringCode = StringCode(0);
 const DICT_SCHEME: StringCode = StringCode(1);
 const FSST_SCHEME: StringCode = StringCode(2);
+const CONSTANT_SCHEME: StringCode = StringCode(3);
 
 impl Scheme for UncompressedScheme {
     type StatsType = StringStats;
@@ -143,6 +154,55 @@ impl Scheme for UncompressedScheme {
         _excludes: &[StringCode],
     ) -> VortexResult<ArrayRef> {
         Ok(stats.source().clone().into_array())
+    }
+}
+
+impl Scheme for ConstantScheme {
+    type StatsType = StringStats;
+    type CodeType = StringCode;
+
+    fn code(&self) -> Self::CodeType {
+        CONSTANT_SCHEME
+    }
+
+    fn expected_compression_ratio(
+        &self,
+        stats: &Self::StatsType,
+        is_sample: bool,
+        _allowed_cascading: usize,
+        _excludes: &[Self::CodeType],
+    ) -> VortexResult<f64> {
+        // Never yield ConstantScheme for a sample, it could be a false-positive.
+        if is_sample {
+            return Ok(0.0);
+        }
+
+        // Only arrays with one distinct values can be constant compressed.
+        if stats.estimated_distinct_count != 1 {
+            return Ok(0.0);
+        }
+
+        // Cannot have mix of nulls and non-nulls
+        if stats.null_count > 0 && stats.value_count > 0 {
+            return Ok(0.0);
+        }
+
+        Ok(stats.value_count as f64)
+    }
+
+    fn compress(
+        &self,
+        stats: &Self::StatsType,
+        _is_sample: bool,
+        _allowed_cascading: usize,
+        _excludes: &[Self::CodeType],
+    ) -> VortexResult<ArrayRef> {
+        let scalar = stats
+            .source()
+            .as_constant()
+            .vortex_expect("constant array expected");
+
+        Ok(ConstantArray::new(scalar, stats.src.len()).into_array())
     }
 }
 

--- a/vortex-btrblocks/src/string.rs
+++ b/vortex-btrblocks/src/string.rs
@@ -1,11 +1,11 @@
 use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::arrays::{ConstantArray, VarBinViewArray};
-use vortex_array::stats::Precision;
 use vortex_array::stats::Stat::IsConstant;
+use vortex_array::stats::{Precision, StatsProvider};
 use vortex_array::{Array, ArrayRef, ArrayStatistics, ToCanonical};
 use vortex_dict::DictArray;
 use vortex_dict::builders::dict_encode;
-use vortex_error::{VortexExpect, VortexResult};
+use vortex_error::{VortexExpect, VortexResult, vortex_bail};
 use vortex_fsst::{fsst_compress, fsst_train_compressor};
 
 use crate::downscale::downscale_integer_array;
@@ -213,6 +213,9 @@ impl Scheme for ConstantScheme {
         _allowed_cascading: usize,
         _excludes: &[Self::CodeType],
     ) -> VortexResult<ArrayRef> {
+        if stats.source().statistics().get_as::<bool>(IsConstant) != Some(Precision::exact(true)) {
+            vortex_bail!("array was thought to be constant, but it is not");
+        }
         let scalar = stats
             .source()
             .as_constant()


### PR DESCRIPTION
While the compress does return small dicts with 0-width bitpacked codes, I think we should instead return a constant array here