### PR TITLE
feat(java): prefetch thread

### DIFF
--- a/java/vortex-jni/src/main/java/dev/vortex/api/Array.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/api/Array.java
@@ -21,6 +21,8 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 public interface Array extends AutoCloseable {
     long getLen();
 
+    long nbytes();
+
     /**
      * Export to an ArrowVector. The data will now be owned by the VectorSchemaRoot after this operation.
      */

--- a/java/vortex-jni/src/main/java/dev/vortex/jni/JNIArray.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/jni/JNIArray.java
@@ -47,6 +47,11 @@ public final class JNIArray implements Array {
     }
 
     @Override
+    public long nbytes() {
+        return NativeArrayMethods.nbytes(pointer.getAsLong());
+    }
+
+    @Override
     public VectorSchemaRoot exportToArrow(BufferAllocator allocator, VectorSchemaRoot reuse) {
         // Export the dataset to Arrow over C Data Interface.
         NativeArrayMethods.exportToArrow(pointer.getAsLong(), schemaPtr.get(), arrayPtr.get());

--- a/java/vortex-jni/src/main/java/dev/vortex/jni/NativeArrayMethods.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/jni/NativeArrayMethods.java
@@ -22,6 +22,8 @@ public final class NativeArrayMethods {
 
     private NativeArrayMethods() {}
 
+    public static native long nbytes(long pointer);
+
     public static native void exportToArrow(long pointer, long[] schemaPointer, long[] arrayPointer);
 
     public static native void dropArrowSchema(long arrowSchemaPtr);

--- a/java/vortex-spark/src/main/java/dev/vortex/spark/read/PrefetchingIterator.java
+++ b/java/vortex-spark/src/main/java/dev/vortex/spark/read/PrefetchingIterator.java
@@ -1,0 +1,106 @@
+/**
+ * (c) Copyright 2025 SpiralDB Inc. All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.vortex.spark.read;
+
+import java.util.Iterator;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.ToLongFunction;
+
+final class PrefetchingIterator<T> implements Iterator<T>, AutoCloseable {
+    // Global condition variable shared between the prefetcher and consumer threads,
+    // to coordinate wake ups for when the buffer may no longer be full.
+    private static final Object CONDITION = new Object();
+
+    private final BlockingQueue<T> fetched = new LinkedBlockingQueue<>();
+    private final Thread producerThread;
+    private final Iterator<T> delegate;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+    private final AtomicLong bufferBytes = new AtomicLong(0);
+    private final long maxBufferSize;
+    private final ToLongFunction<T> sizeFunc;
+
+    PrefetchingIterator(Iterator<T> delegate, long maxBufferSize, ToLongFunction<T> sizeFunc) {
+        this.delegate = delegate;
+        this.maxBufferSize = maxBufferSize;
+        this.sizeFunc = sizeFunc;
+        this.producerThread = new Thread(this::prefetchLoop, "vortex-prefetch-thread");
+        producerThread.setDaemon(true);
+        producerThread.start();
+    }
+
+    private void prefetchLoop() {
+        try {
+            while (!closed.get() && delegate.hasNext()) {
+                while (bufferBytes.get() > maxBufferSize) {
+                    synchronized (CONDITION) {
+                        CONDITION.wait();
+                    }
+                }
+                T nextElem = delegate.next();
+                long elemSize = sizeFunc.applyAsLong(nextElem);
+                bufferBytes.addAndGet(elemSize);
+                fetched.put(nextElem);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Prefetching interrupted", e);
+        } catch (Exception e) {
+            throw new RuntimeException("Prefetching failed", e);
+        } finally {
+            closed.set(true);
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        // If the prefetcher is not finished, then we could be waiting for
+        // a fetched item.
+        while (!closed.get()) {
+            if (!fetched.isEmpty()) {
+                return true;
+            }
+        }
+        // If the prefetcher is finished, then we can examine fetched and immediately return a result.
+        return !fetched.isEmpty();
+    }
+
+    @Override
+    public T next() {
+        // We assume that this has been called after hasNext() returned true, so it is
+        // safe to call take() without checking if the queue maybe be empty.
+        try {
+            T nextElem = this.fetched.take();
+            long elemSize = sizeFunc.applyAsLong(nextElem);
+            bufferBytes.addAndGet(-elemSize);
+            // Notify the producer that it may now be able to add more items to the queue.
+            synchronized (CONDITION) {
+                CONDITION.notify();
+            }
+            return nextElem;
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Prefetch queue take interrupted", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        closed.set(true);
+        producerThread.interrupt();
+    }
+}

--- a/java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexColumnarBatchIterator.java
+++ b/java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexColumnarBatchIterator.java
@@ -24,13 +24,16 @@ import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
 public final class VortexColumnarBatchIterator implements Iterator<ColumnarBatch>, AutoCloseable {
+    public static final long MAX_BUFFER_BYTES = 16 * 1024 * 1024; // 16MB
     private final ArrayStream backing;
+    private final PrefetchingIterator<Array> prefetching;
 
     // Reusable root
     private VectorSchemaRoot root = null;
 
     public VortexColumnarBatchIterator(ArrayStream backing) {
         this.backing = backing;
+        this.prefetching = new PrefetchingIterator<>(backing, MAX_BUFFER_BYTES, Array::nbytes);
     }
 
     @Override
@@ -40,7 +43,7 @@ public final class VortexColumnarBatchIterator implements Iterator<ColumnarBatch
 
     @Override
     public ColumnarBatch next() {
-        Array next = backing.next();
+        Array next = prefetching.next();
 
         root = next.exportToArrow(ArrowAllocation.rootAllocator(), root);
 
@@ -54,6 +57,7 @@ public final class VortexColumnarBatchIterator implements Iterator<ColumnarBatch
 
     @Override
     public void close() {
+        this.prefetching.close();
         this.backing.close();
         if (root != null) {
             root.close();

--- a/java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexColumnarBatchIterator.java
+++ b/java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexColumnarBatchIterator.java
@@ -38,7 +38,7 @@ public final class VortexColumnarBatchIterator implements Iterator<ColumnarBatch
 
     @Override
     public boolean hasNext() {
-        return backing.hasNext();
+        return prefetching.hasNext();
     }
 
     @Override

--- a/java/vortex-spark/src/test/java/dev/vortex/spark/VortexScanTest.java
+++ b/java/vortex-spark/src/test/java/dev/vortex/spark/VortexScanTest.java
@@ -28,7 +28,7 @@ final class VortexScanTest {
     private static final Path TPCH_PARQUET = Paths.get("/Volumes/Code/vortex/bench-vortex/data/tpch/1/parquet");
 
     static {
-        NativeLogging.initLogging(NativeLogging.DEBUG);
+        NativeLogging.initLogging(NativeLogging.ERROR);
     }
 
     private void registerTables(SparkSession spark, Path root, String format) {
@@ -88,7 +88,7 @@ final class VortexScanTest {
         long start = System.nanoTime();
         var results = plan.collectAsList();
         long duration = System.nanoTime() - start;
-        plan.queryExecution().debug().codegen();
+        // plan.queryExecution().debug().codegen();
         System.out.println("Q1 (" + duration + " nanos) results: " + results);
     }
 

--- a/vortex-jni/src/array.rs
+++ b/vortex-jni/src/array.rs
@@ -10,6 +10,7 @@ use vortex::arrow::IntoArrowArray;
 use vortex::compute::{preferred_arrow_data_type, scalar_at, slice};
 use vortex::dtype::DType;
 use vortex::error::{VortexError, VortexExpect, VortexResult};
+use vortex::nbytes::NBytes;
 use vortex::{Array, ArrayRef, ArrayVariants};
 
 use crate::errors::try_or_throw;
@@ -54,6 +55,16 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_free(
     array_ptr: jlong,
 ) {
     drop(unsafe { NativeArray::from_raw(array_ptr) });
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_nbytes(
+    _env: JNIEnv,
+    _class: JClass,
+    array_ptr: jlong,
+) -> jlong {
+    let array_ref = unsafe { NativeArray::from_ptr(array_ptr) };
+    array_ref.inner.nbytes() as jlong
 }
 
 #[unsafe(no_mangle)]


### PR DESCRIPTION
Add a background prefetching thread in our Spark connector. This thread has its lifetime tied to the `VortexColumnarBatchIterator` that we poll inside of the tasks.