### PR TITLE
Invert compression ratio in `BtrBlocksCompressedWriter`

### DIFF
--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -173,7 +173,7 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
                 let compressed = BtrBlocksCompressor.compress_canonical(canonical_chunk)?;
                 self.previous_chunk = Some(PreviousCompression {
                     chunk: compressed.clone(),
-                    ratio: compressed.nbytes() as f64 / canonical_size,
+                    ratio: canonical_size / compressed.nbytes() as f64,
                 });
                 compressed
             }

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -144,15 +144,14 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
                 encode_children_like(canonical_chunk.clone().into_array(), prev_chunk)?
             {
                 let ratio =
-                    encoded_chunk.nbytes() as f64 / canonical_chunk.as_ref().nbytes() as f64;
+                    canonical_chunk.as_ref().nbytes() as f64 / encoded_chunk.nbytes() as f64;
 
-                // not sure this condition is right, but the idea is to make sure the ratio is within the expected drift.
-                // If it isn't we  fall back to the compressor.
-                if ratio < prev_compression.ratio * COMPRESSION_DRIFT_THRESHOLD {
+                // Make sure the ratio is within the expected drift, if it isn't we  fall back to the compressor.
+                if ratio > prev_compression.ratio / COMPRESSION_DRIFT_THRESHOLD {
                     Some(encoded_chunk)
                 } else {
                     log::trace!(
-                        "Compressed to a ratio of {ratio}, which is above the threshold of {}",
+                        "Compressed to a ratio of {ratio}, which is below the threshold of {}",
                         prev_compression.ratio * COMPRESSION_DRIFT_THRESHOLD
                     );
                     None


### PR DESCRIPTION
compression ratio is often [defined](https://en.wikipedia.org/wiki/Data_compression_ratio#Definition) as `before / after` ("higher is better"), that's also what we do in the BtrBlocks compressor, so it seems like making it consistent across the codebase makes sense. ~I thought there's another place we use the term, but I couldn't find it.~ I think it was when we store the previous chunk's compression ratio, got it before merging.