### PR TITLE
Increase default TPC-H benchmark iterations

### DIFF
--- a/bench-vortex/src/bin/clickbench.rs
+++ b/bench-vortex/src/bin/clickbench.rs
@@ -26,7 +26,7 @@ feature_flagged_allocator!();
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    #[arg(short, long, default_value = "5")]
+    #[arg(short, long, default_value_t = 5)]
     iterations: usize,
     #[arg(short, long)]
     threads: Option<usize>,
@@ -40,9 +40,9 @@ struct Args {
     display_format: DisplayFormat,
     #[arg(short, long, value_delimiter = ',')]
     queries: Option<Vec<usize>>,
-    #[arg(long, default_value = "false")]
+    #[arg(long, default_value_t = false)]
     emit_plan: bool,
-    #[arg(long, default_value = "false")]
+    #[arg(long, default_value_t = false)]
     emulate_object_store: bool,
     #[arg(long)]
     export_spans: bool,
@@ -50,7 +50,7 @@ struct Args {
     flavor: Flavor,
     #[arg(long)]
     use_remote_data_dir: Option<String>,
-    #[arg(long, default_value = "false")]
+    #[arg(long, default_value_t = false)]
     single_file: bool,
 }
 

--- a/bench-vortex/src/bin/compress.rs
+++ b/bench-vortex/src/bin/compress.rs
@@ -21,7 +21,7 @@ feature_flagged_allocator!();
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    #[arg(short, long, default_value = "5")]
+    #[arg(short, long, default_value_t = 5)]
     iterations: usize,
     #[arg(short, long)]
     threads: Option<usize>,

--- a/bench-vortex/src/bin/random_access.rs
+++ b/bench-vortex/src/bin/random_access.rs
@@ -16,7 +16,7 @@ feature_flagged_allocator!();
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    #[arg(short, long, default_value = "10")]
+    #[arg(short, long, default_value_t = 10)]
     iterations: usize,
     #[arg(short, long)]
     threads: Option<usize>,

--- a/bench-vortex/src/bin/tpch.rs
+++ b/bench-vortex/src/bin/tpch.rs
@@ -35,7 +35,7 @@ struct Args {
     threads: Option<usize>,
     #[arg(long)]
     use_remote_data_dir: Option<String>,
-    #[arg(short, long, default_value = "5")]
+    #[arg(short, long, default_value = "10")]
     iterations: usize,
     #[arg(long, value_delimiter = ',', value_enum, default_values_t = vec![Format::Arrow, Format::Parquet, Format::OnDiskVortex])]
     formats: Vec<Format>,

--- a/bench-vortex/src/bin/tpch.rs
+++ b/bench-vortex/src/bin/tpch.rs
@@ -35,7 +35,7 @@ struct Args {
     threads: Option<usize>,
     #[arg(long)]
     use_remote_data_dir: Option<String>,
-    #[arg(short, long, default_value = "10")]
+    #[arg(short, long, default_value_t = 10)]
     iterations: usize,
     #[arg(long, value_delimiter = ',', value_enum, default_values_t = vec![Format::Arrow, Format::Parquet, Format::OnDiskVortex])]
     formats: Vec<Format>,
@@ -47,7 +47,7 @@ struct Args {
     verbose: bool,
     #[arg(short, long, default_value_t, value_enum)]
     display_format: DisplayFormat,
-    #[arg(long, default_value = "false")]
+    #[arg(long, default_value_t = false)]
     emulate_object_store: bool,
     #[arg(long, default_value_t, value_enum)]
     data_generator: DataGenerator,


### PR DESCRIPTION
Seems like TPC-H is quite noisy, even on disk. Doubling the iterations will hopefully help a bit with the noise while not making a huge difference in overall benchmark runtime (When running on disk - it might even still be slower than building the binary).
Also changed a bunch of string-based `default_value` to `default_value_t` which takes on the post-parsing value.