### PR TITLE
Sample more aggressively 

### DIFF
--- a/vortex-btrblocks/src/lib.rs
+++ b/vortex-btrblocks/src/lib.rs
@@ -127,7 +127,7 @@ pub fn estimate_compression_ratio_with_sampling<T: Scheme + ?Sized>(
     let sample = if is_sample {
         stats.clone()
     } else {
-        stats.sample(64, 10)
+        stats.sample(640, 20)
     };
 
     let after = compressor


### PR DESCRIPTION
These new arbitrary values make the file ~3GB smaller (~13%), I'm mostly curious to see the impact elsewhere. Long term this should probably be some knob the user can control.