### PR TITLE
Every level of indentation in tree display should add up to 100%

### DIFF
--- a/pyvortex/src/arrays/mod.rs
+++ b/pyvortex/src/arrays/mod.rs
@@ -620,10 +620,10 @@ impl PyArray {
     ///     >>> print(arr.tree_display())
     ///     root: vortex.primitive(i64?, len=4) nbytes=33 B (100.00%)
     ///       metadata: EmptyMetadata
-    ///       buffer (align=8): 32 B
+    ///       buffer (align=8): 32 B (96.97%)
     ///       validity: vortex.bool(bool, len=4) nbytes=1 B (3.03%)
     ///         metadata: BoolMetadata { offset: 0 }
-    ///         buffer (align=1): 1 B
+    ///         buffer (align=1): 1 B (100.00%)
     ///     <BLANKLINE>
     ///
     /// Compressed arrays often have more complex, deeply nested encoding trees.

--- a/vortex-array/src/tree.rs
+++ b/vortex-array/src/tree.rs
@@ -42,7 +42,7 @@ impl<'a, 'b: 'a> TreeFormatter<'a, 'b> {
             name,
             array,
             format_size(nbytes, DECIMAL),
-            100f64 * nbytes as f64 / total_size as f64
+            100_f64 * nbytes as f64 / total_size as f64
         )?;
 
         self.indent(|i| {
@@ -53,9 +53,10 @@ impl<'a, 'b: 'a> TreeFormatter<'a, 'b> {
             for buffer in array.buffers() {
                 writeln!(
                     i,
-                    "buffer (align={}): {}",
+                    "buffer (align={}): {} ({:.2}%)",
                     buffer.alignment(),
-                    format_size(buffer.len(), DECIMAL)
+                    format_size(buffer.len(), DECIMAL),
+                    100_f64 * buffer.len() as f64 / nbytes as f64
                 )?;
             }
 
@@ -67,7 +68,7 @@ impl<'a, 'b: 'a> TreeFormatter<'a, 'b> {
             // Clear the total size so each chunk is treated as a new root.
             self.total_size = None
         } else {
-            self.total_size = Some(total_size);
+            self.total_size = Some(nbytes);
         }
 
         self.indent(|i| {


### PR DESCRIPTION
I think this is the behavior we wanted here, IMO its also more intuitive.
![Screenshot 2025-04-01 at 13 45 13](https://github.com/user-attachments/assets/22e7f46b-0540-450e-bad4-0151e54665e1)
```
root = 100%
codes + values = 100%
values.buffers[*] + values.codes + values.uncompressed.lengths = 100%
...
```
The same chunk on develop currently looks like:
![Screenshot 2025-04-01 at 13 46 59](https://github.com/user-attachments/assets/59708a43-5022-46f3-9931-1c9feaf0bdb1)
values + codes add up to 100%, but their children show a percentage out of the top-level root, which seems inconsistent. 

