### PR TITLE
Change instance type to c6id

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -26,9 +26,8 @@ jobs:
     needs: label_trigger
     runs-on:
       - runs-on=${{ github.run_id }}
-      - family=c7i.8xlarge
+      - family=c6id.8xlarge
       - image=ubuntu24-full-x64
-      - disk=large
       - tag=${{ matrix.benchmark.id }}
     strategy:
       matrix:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -36,7 +36,6 @@ jobs:
       - runs-on=${{ github.run_id }}
       - family=c6id.8xlarge
       - image=ubuntu24-full-x64
-      - disk=large
       - tag=${{ matrix.benchmark.id }}
     strategy:
       matrix:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -34,7 +34,7 @@ jobs:
   bench:
     runs-on:
       - runs-on=${{ github.run_id }}
-      - family=c7i.8xlarge
+      - family=c6id.8xlarge
       - image=ubuntu24-full-x64
       - disk=large
       - tag=${{ matrix.benchmark.id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
     name: Benchmark with Codspeed
     runs-on:
       - runs-on=${{ github.run_id }}
-      - family=c7i.8xlarge
+      - family=c6id.8xlarge
       - image=ubuntu24-full-x64
 
     steps:

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -34,7 +34,7 @@ jobs:
             remote_storage: s3://vortex-bench-dev-eu/${{github.ref_name}}/tpch-sf1/
     runs-on:
       - runs-on=${{ github.run_id }}
-      - family=c7i.8xlarge
+      - family=c6id.8xlarge
       - image=ubuntu24-full-x64
       - disk=large
       - tag=${{ matrix.id }}

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -36,7 +36,6 @@ jobs:
       - runs-on=${{ github.run_id }}
       - family=c6id.8xlarge
       - image=ubuntu24-full-x64
-      - disk=large
       - tag=${{ matrix.id }}
 
     steps:


### PR DESCRIPTION
1. NVMe instead of EBS, also removed references to disk sizes as c6id comes with a dedicated drive.
2. 4th Gen -> 3rd Gen (Sapphire Rapids to Ice Lake), which is perfectly fine IMO given the availability of newer architectures in public clouds.