### PR TITLE
Explicitly write parquet formatted files with duckdb

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -28,6 +28,7 @@ jobs:
       - runs-on=${{ github.run_id }}
       - family=c6id.8xlarge
       - image=ubuntu24-full-x64
+      - spot=false
       - tag=${{ matrix.benchmark.id }}
     strategy:
       matrix:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -36,6 +36,7 @@ jobs:
       - runs-on=${{ github.run_id }}
       - family=c6id.8xlarge
       - image=ubuntu24-full-x64
+      - spot=false
       - tag=${{ matrix.benchmark.id }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,7 @@ jobs:
     runs-on:
       - runs-on=${{ github.run_id }}
       - family=c6id.8xlarge
+      - spot=false
       - image=ubuntu24-full-x64
 
     steps:

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -36,6 +36,7 @@ jobs:
       - runs-on=${{ github.run_id }}
       - family=c6id.8xlarge
       - image=ubuntu24-full-x64
+      - spot=false
       - tag=${{ matrix.id }}
 
     steps:

--- a/bench-vortex/src/datasets/public_bi_data.rs
+++ b/bench-vortex/src/datasets/public_bi_data.rs
@@ -649,7 +649,7 @@ fn write_csv_as_parquet(csv_path: PathBuf, output_path: &Path) -> VortexResult<(
     Command::new("duckdb")
         .arg("-c")
         .arg(format!(
-            "COPY (SELECT * FROM read_csv('{}', delim = '|', header = false, nullstr = 'null')) TO '{}' (COMPRESSION ZSTD);",
+            "COPY (SELECT * FROM read_csv('{}', delim = '|', header = false, nullstr = 'null')) TO '{}' (FORMAT parquet, COMPRESSION zstd);",
             csv_path.to_str().unwrap(),
             output_path.to_str().unwrap()
         ))

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -98,7 +98,7 @@ pub fn idempotent<T, E, P: IdempotentPath + ?Sized>(
     f: impl FnOnce(&Path) -> Result<T, E>,
 ) -> Result<PathBuf, E> {
     let data_path = path.to_data_path();
-    let temp_path = temp_download_dir();
+    let temp_path = temp_download_filepath();
     if !data_path.exists() {
         f(temp_path.as_path())?;
         std::fs::rename(temp_path, &data_path).unwrap();
@@ -115,7 +115,7 @@ where
     P: IdempotentPath + ?Sized,
 {
     let data_path = path.to_data_path();
-    let temp_path = temp_download_dir();
+    let temp_path = temp_download_filepath();
     if !data_path.exists() {
         f(temp_path.clone()).await?;
         std::fs::rename(temp_path, &data_path).unwrap();
@@ -131,7 +131,7 @@ pub fn data_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("data")
 }
 
-pub fn temp_download_dir() -> PathBuf {
+pub fn temp_download_filepath() -> PathBuf {
     data_dir().join(format!("download_{}.file", uuid::Uuid::new_v4()))
 }
 


### PR DESCRIPTION
In a classic case of [Hyrum's law](https://www.hyrumslaw.com/), the path's extension was a load bearing piece, so it broke when I changed the tempfile path in #2878.