### PR TITLE
Store only VortexMetrics until we emit them from DF

### DIFF
--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -31,9 +31,9 @@ use vortex_expr::{VortexExpr, and};
 use vortex_file::{DEFAULT_REGISTRY, VORTEX_FILE_EXTENSION, VortexOpenOptions};
 use vortex_io::ObjectStoreReadAt;
 use vortex_layout::{LayoutRegistry, LayoutRegistryExt};
+use vortex_metrics::VortexMetrics;
 
 use super::cache::FooterCache;
-use super::metrics::VortexSourceMetrics;
 use super::sink::VortexSink;
 use super::source::VortexSource;
 use crate::{PrecisionExt as _, can_be_pushed_down};
@@ -165,7 +165,7 @@ impl FileFormat for VortexFormat {
     fn file_source(&self) -> Arc<dyn FileSource> {
         Arc::new(VortexSource::new(
             self.footer_cache.clone(),
-            VortexSourceMetrics::default(),
+            VortexMetrics::default(),
         ))
     }
 
@@ -329,8 +329,7 @@ impl FileFormat for VortexFormat {
             return not_impl_err!("Vortex doesn't support output ordering");
         }
 
-        let mut source =
-            VortexSource::new(self.footer_cache.clone(), VortexSourceMetrics::default());
+        let mut source = VortexSource::new(self.footer_cache.clone(), VortexMetrics::default());
 
         if let Some(predicate) = make_vortex_predicate(filters) {
             source = source.with_predicate(predicate);

--- a/vortex-datafusion/src/persistent/source.rs
+++ b/vortex-datafusion/src/persistent/source.rs
@@ -12,10 +12,11 @@ use object_store::{ObjectStore, ObjectStoreScheme};
 use vortex_error::VortexExpect as _;
 use vortex_expr::{Identity, VortexExpr};
 use vortex_file::VORTEX_FILE_EXTENSION;
+use vortex_metrics::VortexMetrics;
 
 use super::cache::FooterCache;
 use super::config::{ConfigProjection, FileScanConfigExt};
-use super::metrics::{PARTITION_LABEL, VortexSourceMetrics};
+use super::metrics::PARTITION_LABEL;
 use super::opener::VortexFileOpener;
 
 /// A config for [`VortexFileOpener`]. Used to create [`DataSourceExec`] based physical plans.
@@ -29,11 +30,12 @@ pub struct VortexSource {
     pub(crate) batch_size: Option<usize>,
     pub(crate) projected_statistics: Option<Statistics>,
     pub(crate) arrow_schema: Option<SchemaRef>,
-    pub(crate) metrics: VortexSourceMetrics,
+    pub(crate) metrics: VortexMetrics,
+    _unused_df_metrics: ExecutionPlanMetricsSet,
 }
 
 impl VortexSource {
-    pub(crate) fn new(footer_cache: FooterCache, metrics: VortexSourceMetrics) -> Self {
+    pub(crate) fn new(footer_cache: FooterCache, metrics: VortexMetrics) -> Self {
         Self {
             footer_cache,
             metrics,
@@ -42,6 +44,7 @@ impl VortexSource {
             projected_statistics: None,
             arrow_schema: None,
             predicate: None,
+            _unused_df_metrics: Default::default(),
         }
     }
 
@@ -135,7 +138,7 @@ impl FileSource for VortexSource {
     }
 
     fn metrics(&self) -> &ExecutionPlanMetricsSet {
-        self.metrics.report_to_datafusion()
+        &self._unused_df_metrics
     }
 
     fn statistics(&self) -> DFResult<Statistics> {


### PR DESCRIPTION
This is a bit of a temporary hack. Basically, it's hard for us to keep our metrics registry in sync with the DataFusion one, so instead of trying to do this (we were duplicating lots of metrics into an every growing registry), we only combine them when printing them out at the end.