### PR TITLE
fix: yet another python pipeline issue

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -96,7 +96,7 @@ jobs:
           echo removing linux_x86_64 if it exists because PyPI will reject the package if it is present
           rm -f target/wheels/*linux_x86_64.whl
 
-          uv run pip install --force-reinstall vortex-array --no-index --find-links target/wheels
+          uv run pip install --no-deps --force-reinstall vortex-array --no-index --find-links target/wheels
 
           cd pyvortex/test
           uv run pytest


### PR DESCRIPTION
This change somehow sneaked in #2580, I don't recall if I had a reason or if I tested it at a time. I'm still not sure why this fails but `uv run pip install target/wheels/vortex_array-*.whl` which we run in CI seems to work :/.