### PR TITLE
Use blocking ArrayIterator in JNI

### DIFF
--- a/java/vortex-jni/src/main/java/dev/vortex/api/ArrayIterator.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/api/ArrayIterator.java
@@ -17,7 +17,7 @@ package dev.vortex.api;
 
 import java.util.Iterator;
 
-public interface ArrayStream extends AutoCloseable, Iterator<Array> {
+public interface ArrayIterator extends AutoCloseable, Iterator<Array> {
     DType getDataType();
 
     @Override

--- a/java/vortex-jni/src/main/java/dev/vortex/api/File.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/api/File.java
@@ -18,7 +18,7 @@ package dev.vortex.api;
 public interface File extends AutoCloseable {
     DType getDType();
 
-    ArrayStream newScan(ScanOptions options);
+    ArrayIterator newScan(ScanOptions options);
 
     @Override
     void close();

--- a/java/vortex-jni/src/main/java/dev/vortex/jni/JNIArrayIterator.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/jni/JNIArrayIterator.java
@@ -17,16 +17,17 @@ package dev.vortex.jni;
 
 import com.google.common.base.Preconditions;
 import dev.vortex.api.Array;
-import dev.vortex.api.ArrayStream;
+import dev.vortex.api.ArrayIterator;
 import dev.vortex.api.DType;
+
 import java.util.Optional;
 import java.util.OptionalLong;
 
-public final class JNIArrayStream implements ArrayStream {
+public final class JNIArrayIterator implements ArrayIterator {
     private OptionalLong pointer;
     private Optional<Array> next;
 
-    public JNIArrayStream(long pointer) {
+    public JNIArrayIterator(long pointer) {
         Preconditions.checkArgument(pointer > 0, "Invalid pointer address: " + pointer);
         this.pointer = OptionalLong.of(pointer);
         advance();
@@ -46,18 +47,18 @@ public final class JNIArrayStream implements ArrayStream {
 
     @Override
     public DType getDataType() {
-        return new JNIDType(NativeArrayStreamMethods.getDType(pointer.getAsLong()), false);
+        return new JNIDType(NativeArrayIteratorMethods.getDType(pointer.getAsLong()), false);
     }
 
     @Override
     public void close() {
-        NativeArrayStreamMethods.free(pointer.getAsLong());
+        NativeArrayIteratorMethods.free(pointer.getAsLong());
         pointer = OptionalLong.empty();
         next = Optional.empty();
     }
 
     private void advance() {
-        long next = NativeArrayStreamMethods.take(pointer.getAsLong());
+        long next = NativeArrayIteratorMethods.take(pointer.getAsLong());
         if (next <= 0) {
             this.next = Optional.empty();
         } else {

--- a/java/vortex-jni/src/main/java/dev/vortex/jni/JNIArrayIterator.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/jni/JNIArrayIterator.java
@@ -19,7 +19,6 @@ import com.google.common.base.Preconditions;
 import dev.vortex.api.Array;
 import dev.vortex.api.ArrayIterator;
 import dev.vortex.api.DType;
-
 import java.util.Optional;
 import java.util.OptionalLong;
 

--- a/java/vortex-jni/src/main/java/dev/vortex/jni/JNIFile.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/jni/JNIFile.java
@@ -21,7 +21,6 @@ import dev.vortex.api.DType;
 import dev.vortex.api.File;
 import dev.vortex.api.ScanOptions;
 import dev.vortex.api.expressions.proto.ExpressionProtoSerializer;
-
 import java.util.OptionalLong;
 
 public final class JNIFile implements File {

--- a/java/vortex-jni/src/main/java/dev/vortex/jni/JNIFile.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/jni/JNIFile.java
@@ -16,11 +16,12 @@
 package dev.vortex.jni;
 
 import com.google.common.base.Preconditions;
-import dev.vortex.api.ArrayStream;
+import dev.vortex.api.ArrayIterator;
 import dev.vortex.api.DType;
 import dev.vortex.api.File;
 import dev.vortex.api.ScanOptions;
 import dev.vortex.api.expressions.proto.ExpressionProtoSerializer;
+
 import java.util.OptionalLong;
 
 public final class JNIFile implements File {
@@ -37,7 +38,7 @@ public final class JNIFile implements File {
     }
 
     @Override
-    public ArrayStream newScan(ScanOptions options) {
+    public ArrayIterator newScan(ScanOptions options) {
         byte[] predicateProto = null;
 
         if (options.predicate().isPresent()) {
@@ -48,7 +49,7 @@ public final class JNIFile implements File {
 
         long[] rowIndices = options.rowIndices().orElse(null);
 
-        return new JNIArrayStream(
+        return new JNIArrayIterator(
                 NativeFileMethods.scan(pointer.getAsLong(), options.columns(), predicateProto, rowIndices));
     }
 

--- a/java/vortex-jni/src/main/java/dev/vortex/jni/NativeArrayIteratorMethods.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/jni/NativeArrayIteratorMethods.java
@@ -20,8 +20,7 @@ public final class NativeArrayIteratorMethods {
         NativeLoader.loadJni();
     }
 
-    private NativeArrayIteratorMethods() {
-    }
+    private NativeArrayIteratorMethods() {}
 
     /**
      * Free all resources associated with the stream behind the pointer.

--- a/java/vortex-jni/src/main/java/dev/vortex/jni/NativeArrayIteratorMethods.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/jni/NativeArrayIteratorMethods.java
@@ -15,12 +15,13 @@
  */
 package dev.vortex.jni;
 
-public final class NativeArrayStreamMethods {
+public final class NativeArrayIteratorMethods {
     static {
         NativeLoader.loadJni();
     }
 
-    private NativeArrayStreamMethods() {}
+    private NativeArrayIteratorMethods() {
+    }
 
     /**
      * Free all resources associated with the stream behind the pointer.

--- a/java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexColumnarBatchIterator.java
+++ b/java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexColumnarBatchIterator.java
@@ -16,22 +16,24 @@
 package dev.vortex.spark.read;
 
 import dev.vortex.api.Array;
-import dev.vortex.api.ArrayStream;
+import dev.vortex.api.ArrayIterator;
 import dev.vortex.arrow.ArrowAllocation;
 import dev.vortex.relocated.org.apache.arrow.vector.VectorSchemaRoot;
+
 import java.util.Iterator;
+
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
 public final class VortexColumnarBatchIterator implements Iterator<ColumnarBatch>, AutoCloseable {
     public static final long MAX_BUFFER_BYTES = 16 * 1024 * 1024; // 16MB
-    private final ArrayStream backing;
+    private final ArrayIterator backing;
     private final PrefetchingIterator<Array> prefetching;
 
     // Reusable root
     private VectorSchemaRoot root = null;
 
-    public VortexColumnarBatchIterator(ArrayStream backing) {
+    public VortexColumnarBatchIterator(ArrayIterator backing) {
         this.backing = backing;
         this.prefetching = new PrefetchingIterator<>(backing, MAX_BUFFER_BYTES, Array::nbytes);
     }

--- a/java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexColumnarBatchIterator.java
+++ b/java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexColumnarBatchIterator.java
@@ -19,9 +19,7 @@ import dev.vortex.api.Array;
 import dev.vortex.api.ArrayIterator;
 import dev.vortex.arrow.ArrowAllocation;
 import dev.vortex.relocated.org.apache.arrow.vector.VectorSchemaRoot;
-
 import java.util.Iterator;
-
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 

--- a/vortex-jni/src/file.rs
+++ b/vortex-jni/src/file.rs
@@ -19,11 +19,10 @@ use vortex::error::{VortexError, VortexExpect, VortexResult, vortex_bail, vortex
 use vortex::expr::{Identity, deserialize_expr, select};
 use vortex::file::{VortexFile, VortexOpenOptions};
 use vortex::proto::expr::Expr;
-use vortex::stream::ArrayStreamExt;
 
-use crate::array_stream::NativeArrayStream;
+use crate::array_iter::NativeArrayIterator;
+use crate::block_on;
 use crate::errors::try_or_throw;
-use crate::{TOKIO_RUNTIME, block_on};
 
 pub struct NativeFile {
     inner: VortexFile,
@@ -167,10 +166,9 @@ pub extern "system" fn Java_dev_vortex_jni_NativeFileMethods_scan(
         }
 
         // Canonicalize first, to avoid needing to pay decoding cost for every access.
-        let scan = scan_builder
-            .with_canonicalize(true)
-            .spawn_tokio(TOKIO_RUNTIME.handle().clone())?;
-        Ok(NativeArrayStream::new(scan.boxed()).into_raw())
+        let scan = scan_builder.with_canonicalize(true);
+
+        Ok(NativeArrayIterator::new(Box::new(scan.into_array_iter()?)).into_raw())
     })
 }
 

--- a/vortex-jni/src/lib.rs
+++ b/vortex-jni/src/lib.rs
@@ -10,7 +10,7 @@ macro_rules! throw_runtime {
 }
 
 mod array;
-mod array_stream;
+mod array_iter;
 mod dtype;
 mod errors;
 mod file;


### PR DESCRIPTION
We prefer to use Stream for async APIs, and Iterator for blocking APIs.

This also uses `ScanBuilder::into_iter` to run CPU work on the current thread, rather than contending on the central tokio runtime.