### PR TITLE
Revert "Use fixed sized array instead of vector for bitpacked take/filter index grouping"

### DIFF
--- a/encodings/fastlanes/src/bitpacking/compute/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/mod.rs
@@ -1,6 +1,3 @@
-use std::mem;
-use std::mem::MaybeUninit;
-
 use vortex_array::compute::{
     BetweenFn, BetweenOptions, FilterKernelAdapter, KernelRef, ScalarAtFn, SearchSortedFn, SliceFn,
     TakeFn, between,
@@ -48,37 +45,28 @@ fn chunked_indices<F: FnMut(usize, &[usize])>(
     offset: usize,
     mut chunk_fn: F,
 ) {
-    let mut indices_within_chunk = [const { MaybeUninit::<usize>::uninit() }; 1024];
-    let mut indices_len = 0;
+    let mut indices_within_chunk: Vec<usize> = Vec::with_capacity(1024);
 
     let Some(first_idx) = indices.next() else {
         return;
     };
 
     let mut current_chunk_idx = (first_idx + offset) / 1024;
-    indices_within_chunk[indices_len] = MaybeUninit::new((first_idx + offset) % 1024);
-    indices_len += 1;
+    indices_within_chunk.push((first_idx + offset) % 1024);
     for idx in indices {
         let new_chunk_idx = (idx + offset) / 1024;
 
         if new_chunk_idx != current_chunk_idx {
-            chunk_fn(current_chunk_idx, unsafe {
-                mem::transmute::<&[MaybeUninit<usize>], &[usize]>(
-                    &indices_within_chunk[..indices_len],
-                )
-            });
-            indices_len = 0;
+            chunk_fn(current_chunk_idx, &indices_within_chunk);
+            indices_within_chunk.clear();
         }
 
         current_chunk_idx = new_chunk_idx;
-        indices_within_chunk[indices_len] = MaybeUninit::new((idx + offset) % 1024);
-        indices_len += 1;
+        indices_within_chunk.push((idx + offset) % 1024);
     }
 
-    if indices_len > 0 {
-        chunk_fn(current_chunk_idx, unsafe {
-            mem::transmute::<&[MaybeUninit<usize>], &[usize]>(&indices_within_chunk[..indices_len])
-        });
+    if !indices_within_chunk.is_empty() {
+        chunk_fn(current_chunk_idx, &indices_within_chunk);
     }
 }
 


### PR DESCRIPTION
Reverts spiraldb/vortex#2915, Indices aren't necessarily unique meaning there can be more of them than 1024 per 1024 chunk