### PR TITLE
Fix: float serde handles non 0 values getting widened

### DIFF
--- a/vortex-scalar/src/pvalue.rs
+++ b/vortex-scalar/src/pvalue.rs
@@ -272,6 +272,7 @@ impl TryFrom<PValue> for f64 {
 impl TryFrom<PValue> for f32 {
     type Error = VortexError;
 
+    #[allow(clippy::cast_possible_truncation)]
     fn try_from(value: PValue) -> Result<Self, Self::Error> {
         // We serialize f32 as u32, but this can also sometimes be narrowed down to u8 if e.g. == 0
         match value {
@@ -292,6 +293,7 @@ impl TryFrom<PValue> for f32 {
 impl TryFrom<PValue> for f16 {
     type Error = VortexError;
 
+    #[allow(clippy::cast_possible_truncation)]
     fn try_from(value: PValue) -> Result<Self, Self::Error> {
         // We serialize f16 as u16, but this can also sometimes be narrowed down to u8 if e.g. == 0
         match value {

--- a/vortex-scalar/src/pvalue.rs
+++ b/vortex-scalar/src/pvalue.rs
@@ -278,7 +278,8 @@ impl TryFrom<PValue> for f32 {
             PValue::U8(u) => Some(Self::from_bits(u as u32)),
             PValue::U16(u) => Some(Self::from_bits(u as u32)),
             PValue::U32(u) => Some(Self::from_bits(u)),
-            PValue::U64(u) => <Self as NumCast>::from(f64::from_bits(u)),
+            // We assume that the value was created from a valid f16 and only changed in serialization
+            PValue::U64(u) => <Self as NumCast>::from(Self::from_bits(u as u32)),
             PValue::F16(f) => <Self as NumCast>::from(f),
             PValue::F32(f) => <Self as NumCast>::from(f),
             PValue::F64(f) => <Self as NumCast>::from(f),
@@ -296,8 +297,9 @@ impl TryFrom<PValue> for f16 {
         match value {
             PValue::U8(u) => Some(Self::from_bits(u as u16)),
             PValue::U16(u) => Some(Self::from_bits(u)),
-            PValue::U32(u) => <Self as NumCast>::from(f32::from_bits(u)),
-            PValue::U64(u) => <Self as NumCast>::from(f64::from_bits(u)),
+            // We assume that the value was created from a valid f16 and only changed in serialization
+            PValue::U32(u) => Some(Self::from_bits(u as u16)),
+            PValue::U64(u) => Some(Self::from_bits(u as u16)),
             PValue::F16(u) => Some(u),
             PValue::F32(f) => <Self as NumCast>::from(f),
             PValue::F64(f) => <Self as NumCast>::from(f),

--- a/vortex-scalar/src/serde/serde.rs
+++ b/vortex-scalar/src/serde/serde.rs
@@ -223,7 +223,7 @@ mod tests {
         Nullability::NonNullable),
         vec![
             Scalar::primitive(23592960, Nullability::NonNullable),
-            Scalar::primitive(f16::from_bits(0), Nullability::NonNullable),
+            Scalar::primitive(f16::from_f32(2.6584664e36f32), Nullability::NonNullable),
         ],
     ))]
     #[case(Scalar::struct_(DType::Struct(
@@ -235,8 +235,8 @@ mod tests {
         Nullability::NonNullable),
         vec![
             Scalar::primitive(415118687234i64, Nullability::NonNullable),
-            Scalar::primitive(0.0f32, Nullability::NonNullable),
-            Scalar::primitive(f16::from_bits(0), Nullability::NonNullable),
+            Scalar::primitive(2.6584664e36f32, Nullability::NonNullable),
+            Scalar::primitive(f16::from_f32(2.6584664e36f32), Nullability::NonNullable),
         ],
     ))]
     fn test_scalar_value_serde_roundtrip(#[case] scalar: Scalar) {


### PR DESCRIPTION
When f32/f16 gets serialized as an integer that then gets widened it's invalid to interpret the value as the widened type (f32 -> u32 -> u64 -> f32) since the value doesn't contain necessary padding. If we get unsinged integer value for a float value we assume that it has the bit width of the bits of the float value and interpret it as such. 