### PR TITLE
chore: Bump tokio version to include soundness fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5431,9 +5431,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,7 @@ tar = "0.4"
 tempfile = "3"
 thiserror = "2.0.3"
 tikv-jemallocator = "0.6"
-tokio = "1.43"
+tokio = "1.44.2"
 tokio-stream = "0.1.17"
 tracing = { version = "0.1.41" }
 tracing-chrome = "0.7.2"


### PR DESCRIPTION
Tokio had a soundness bug that was just fixed, see https://github.com/tokio-rs/tokio/pull/7232 for more details.