### PR TITLE
chore: rename IoDispatcher::default() -> IoDispatcher::shared

### DIFF
--- a/vortex-file/src/generic.rs
+++ b/vortex-file/src/generic.rs
@@ -152,7 +152,7 @@ impl Default for GenericFileOptions {
     fn default() -> Self {
         Self {
             io_concurrency: 8,
-            io_dispatcher: IoDispatcher::default(),
+            io_dispatcher: IoDispatcher::shared(),
         }
     }
 }

--- a/vortex-io/src/dispatcher/mod.rs
+++ b/vortex-io/src/dispatcher/mod.rs
@@ -14,7 +14,7 @@ use futures::FutureExt;
 use futures::channel::oneshot;
 use vortex_error::{VortexResult, vortex_err};
 
-static DEFAULT: LazyLock<IoDispatcher> = LazyLock::new(IoDispatcher::new);
+static SHARED: LazyLock<IoDispatcher> = LazyLock::new(IoDispatcher::new);
 
 #[cfg(feature = "compio")]
 use self::compio::*;
@@ -106,10 +106,10 @@ impl IoDispatcher {
     }
 }
 
-impl Default for IoDispatcher {
-    fn default() -> Self {
-        // By default, we return a shared handle
-        DEFAULT.clone()
+impl IoDispatcher {
+    /// Returns a handle to the current process's shared Dispatcher.
+    pub fn shared() -> Self {
+        SHARED.clone()
     }
 }
 

--- a/vortex-io/src/dispatcher/mod.rs
+++ b/vortex-io/src/dispatcher/mod.rs
@@ -106,6 +106,12 @@ impl IoDispatcher {
     }
 }
 
+impl Default for IoDispatcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl IoDispatcher {
     /// Returns a handle to the current process's shared Dispatcher.
     pub fn shared() -> Self {


### PR DESCRIPTION
I think it's clearer for consumers that the default is spawning onto a shared async runtime