### PR TITLE
Make `FlatLayout` be more consistent with other layouts

### DIFF
--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -13,7 +13,7 @@ use vortex_btrblocks::BtrBlocksCompressor;
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 use vortex_layout::layouts::chunked::writer::ChunkedLayoutStrategy;
-use vortex_layout::layouts::flat::FlatLayout;
+use vortex_layout::layouts::flat::writer::FlatLayoutStrategy;
 use vortex_layout::layouts::repartition::{RepartitionWriter, RepartitionWriterOptions};
 use vortex_layout::layouts::stats::writer::{StatsLayoutOptions, StatsLayoutWriter};
 use vortex_layout::layouts::struct_::writer::StructLayoutWriter;
@@ -68,7 +68,7 @@ impl LayoutStrategy for VortexLayoutStrategy {
             dtype,
             writer,
             ArcRef::new_arc(Arc::new(BtrBlocksCompressedStrategy {
-                child: ArcRef::new_ref(&FlatLayout),
+                child: ArcRef::new_arc(Arc::new(FlatLayoutStrategy::default())),
             })),
             StatsLayoutOptions {
                 block_size: ROW_BLOCK_SIZE,

--- a/vortex-layout/src/layouts/chunked/writer.rs
+++ b/vortex-layout/src/layouts/chunked/writer.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use vortex_array::arcref::ArcRef;
 use vortex_array::{ArrayContext, ArrayRef};
 use vortex_dtype::DType;
@@ -5,7 +7,7 @@ use vortex_error::{VortexExpect, VortexResult};
 
 use crate::data::Layout;
 use crate::layouts::chunked::ChunkedLayout;
-use crate::layouts::flat::FlatLayout;
+use crate::layouts::flat::writer::FlatLayoutStrategy;
 use crate::segments::SegmentWriter;
 use crate::strategy::LayoutStrategy;
 use crate::writer::LayoutWriter;
@@ -20,7 +22,7 @@ pub struct ChunkedLayoutStrategy {
 impl Default for ChunkedLayoutStrategy {
     fn default() -> Self {
         Self {
-            chunk_strategy: ArcRef::new_ref(&FlatLayout),
+            chunk_strategy: ArcRef::new_arc(Arc::new(FlatLayoutStrategy::default())),
         }
     }
 }

--- a/vortex-layout/src/layouts/flat/writer.rs
+++ b/vortex-layout/src/layouts/flat/writer.rs
@@ -10,14 +10,14 @@ use crate::writer::LayoutWriter;
 use crate::{Layout, LayoutStrategy, LayoutVTableRef, LayoutWriterExt};
 
 #[derive(Clone)]
-pub struct FlatLayoutOptions {
+pub struct FlatLayoutStrategy {
     /// Stats to preserve when writing arrays
     pub array_stats: Vec<Stat>,
     /// Whether to include padding for memory-mapped reads.
     pub include_padding: bool,
 }
 
-impl Default for FlatLayoutOptions {
+impl Default for FlatLayoutStrategy {
     fn default() -> Self {
         Self {
             array_stats: STATS_TO_WRITE.to_vec(),
@@ -26,7 +26,7 @@ impl Default for FlatLayoutOptions {
     }
 }
 
-impl LayoutStrategy for FlatLayoutOptions {
+impl LayoutStrategy for FlatLayoutStrategy {
     fn new_writer(&self, ctx: &ArrayContext, dtype: &DType) -> VortexResult<Box<dyn LayoutWriter>> {
         Ok(FlatLayoutWriter::new(ctx.clone(), dtype.clone(), self.clone()).boxed())
     }
@@ -36,12 +36,12 @@ impl LayoutStrategy for FlatLayoutOptions {
 pub struct FlatLayoutWriter {
     ctx: ArrayContext,
     dtype: DType,
-    options: FlatLayoutOptions,
+    options: FlatLayoutStrategy,
     layout: Option<Layout>,
 }
 
 impl FlatLayoutWriter {
-    pub fn new(ctx: ArrayContext, dtype: DType, options: FlatLayoutOptions) -> Self {
+    pub fn new(ctx: ArrayContext, dtype: DType, options: FlatLayoutStrategy) -> Self {
         Self {
             ctx,
             dtype,

--- a/vortex-layout/src/layouts/stats/eval_expr.rs
+++ b/vortex-layout/src/layouts/stats/eval_expr.rs
@@ -144,7 +144,7 @@ mod test {
     use vortex_mask::Mask;
 
     use crate::layouts::chunked::writer::ChunkedLayoutWriter;
-    use crate::layouts::flat::FlatLayout;
+    use crate::layouts::flat::writer::FlatLayoutStrategy;
     use crate::layouts::stats::writer::{StatsLayoutOptions, StatsLayoutWriter};
     use crate::segments::{SegmentSource, TestSegments};
     use crate::writer::LayoutWriterExt;
@@ -164,7 +164,7 @@ mod test {
                 Default::default(),
             )
             .boxed(),
-            ArcRef::new_ref(&FlatLayout),
+            ArcRef::new_arc(Arc::new(FlatLayoutStrategy::default())),
             StatsLayoutOptions {
                 block_size: 3,
                 ..Default::default()

--- a/vortex-layout/src/layouts/struct_/writer.rs
+++ b/vortex-layout/src/layouts/struct_/writer.rs
@@ -125,7 +125,7 @@ mod tests {
     use vortex_dtype::{DType, Nullability, PType};
 
     use crate::LayoutWriterExt;
-    use crate::layouts::flat::writer::{FlatLayoutOptions, FlatLayoutWriter};
+    use crate::layouts::flat::writer::{FlatLayoutStrategy, FlatLayoutWriter};
     use crate::layouts::struct_::writer::StructLayoutWriter;
 
     #[test]
@@ -147,13 +147,13 @@ mod tests {
                 FlatLayoutWriter::new(
                     ArrayContext::empty(),
                     DType::Primitive(PType::I32, Nullability::NonNullable),
-                    FlatLayoutOptions::default(),
+                    FlatLayoutStrategy::default(),
                 )
                 .boxed(),
                 FlatLayoutWriter::new(
                     ArrayContext::empty(),
                     DType::Primitive(PType::I32, Nullability::NonNullable),
-                    FlatLayoutOptions::default(),
+                    FlatLayoutStrategy::default(),
                 )
                 .boxed(),
             ],

--- a/vortex-layout/src/strategy.rs
+++ b/vortex-layout/src/strategy.rs
@@ -7,7 +7,6 @@ use vortex_array::ArrayContext;
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 
-use crate::layouts::flat::FlatLayout;
 use crate::layouts::flat::writer::FlatLayoutWriter;
 use crate::layouts::struct_::writer::StructLayoutWriter;
 use crate::writer::{LayoutWriter, LayoutWriterExt};
@@ -15,13 +14,6 @@ use crate::writer::{LayoutWriter, LayoutWriterExt};
 /// A trait for creating new layout writers given a DType.
 pub trait LayoutStrategy: 'static + Send + Sync {
     fn new_writer(&self, ctx: &ArrayContext, dtype: &DType) -> VortexResult<Box<dyn LayoutWriter>>;
-}
-
-/// Implement the [`LayoutStrategy`] trait for the [`FlatLayout`] for easy use.
-impl LayoutStrategy for FlatLayout {
-    fn new_writer(&self, ctx: &ArrayContext, dtype: &DType) -> VortexResult<Box<dyn LayoutWriter>> {
-        Ok(FlatLayoutWriter::new(ctx.clone(), dtype.clone(), Default::default()).boxed())
-    }
 }
 
 /// A layout strategy that preserves struct arrays and writes everything else as flat.


### PR DESCRIPTION
Removes the `LayoutStrategy` implementation for `FlatLayout` that was basically the same as `FlatLayoutStrategy` (previously `FlatLayoutOptions`).