### PR TITLE
Fill null in chunked array to propagate the right dtype

### DIFF
--- a/vortex-array/src/arrays/chunked/compute/fill_null.rs
+++ b/vortex-array/src/arrays/chunked/compute/fill_null.rs
@@ -13,7 +13,7 @@ impl FillNullFn<&ChunkedArray> for ChunkedEncoding {
                 .iter()
                 .map(|c| fill_null(c, fill_value.clone()))
                 .collect::<VortexResult<Vec<_>>>()?,
-            array.dtype().as_nonnullable(),
+            fill_value.dtype().clone(),
         )
         .into_array())
     }

--- a/vortex-array/src/compute/fill_null.rs
+++ b/vortex-array/src/compute/fill_null.rs
@@ -47,9 +47,9 @@ pub fn fill_null(array: &dyn Array, fill_value: Scalar) -> VortexResult<ArrayRef
         array.encoding()
     );
     assert_eq!(
-        filled.dtype(),
-        &array.dtype().with_nullability(fill_value_nullability),
-        "FillNull dtype mismatch {}",
+        filled.dtype().nullability(),
+        fill_value_nullability,
+        "FillNull nullability mismatch {}",
         array.encoding()
     );
 


### PR DESCRIPTION
top level `fill_null` enforces the return value nullability to match the fill value nullability. This fixes chunked array fill_null to work with nullable fill values