### PR TITLE
chore: add docs in vortex-file

### DIFF
--- a/pyvortex/src/lib.rs
+++ b/pyvortex/src/lib.rs
@@ -29,7 +29,7 @@ use vortex::error::{VortexError, VortexExpect as _};
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-pub static TOKIO_RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
+static TOKIO_RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
     Runtime::new()
         .map_err(VortexError::IOError)
         .vortex_expect("tokio runtime must not fail to start")

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -1,3 +1,31 @@
+//! Builders for Vortex arrays.
+//!
+//! Every logical type in Vortex has a canonical (uncompressed) in-memory encoding. This module
+//! provides pre-allocated builders to construct new canonical arrays.
+//!
+//! ## Example:
+//!
+//! ```
+//! use vortex_array::builders::{builder_with_capacity, ArrayBuilderExt};
+//! use vortex_array::compute::scalar_at;
+//! use vortex_dtype::{DType, Nullability};
+//!
+//! // Create a new builder for string data.
+//! let mut builder = builder_with_capacity(&DType::Utf8(Nullability::NonNullable), 4);
+//!
+//! builder.append_scalar(&"a".into()).unwrap();
+//! builder.append_scalar(&"b".into()).unwrap();
+//! builder.append_scalar(&"c".into()).unwrap();
+//! builder.append_scalar(&"d".into()).unwrap();
+//!
+//! let strings = builder.finish();
+//!
+//! assert_eq!(scalar_at(&strings, 0).unwrap(), "a".into());
+//! assert_eq!(scalar_at(&strings, 1).unwrap(), "b".into());
+//! assert_eq!(scalar_at(&strings, 2).unwrap(), "c".into());
+//! assert_eq!(scalar_at(&strings, 3).unwrap(), "d".into());
+//! ```
+
 mod bool;
 mod extension;
 mod lazy_validity_builder;
@@ -76,6 +104,31 @@ pub trait ArrayBuilder: Send {
     fn finish(&mut self) -> ArrayRef;
 }
 
+/// Construct a new canonical builder for the given [`DType`].
+///
+///
+/// # Example
+///
+/// ```
+/// use vortex_array::builders::{builder_with_capacity, ArrayBuilderExt};
+/// use vortex_array::compute::scalar_at;
+/// use vortex_dtype::{DType, Nullability};
+///
+/// // Create a new builder for string data.
+/// let mut builder = builder_with_capacity(&DType::Utf8(Nullability::NonNullable), 4);
+///
+/// builder.append_scalar(&"a".into()).unwrap();
+/// builder.append_scalar(&"b".into()).unwrap();
+/// builder.append_scalar(&"c".into()).unwrap();
+/// builder.append_scalar(&"d".into()).unwrap();
+///
+/// let strings = builder.finish();
+///
+/// assert_eq!(scalar_at(&strings, 0).unwrap(), "a".into());
+/// assert_eq!(scalar_at(&strings, 1).unwrap(), "b".into());
+/// assert_eq!(scalar_at(&strings, 2).unwrap(), "c".into());
+/// assert_eq!(scalar_at(&strings, 3).unwrap(), "d".into());
+/// ```
 pub fn builder_with_capacity(dtype: &DType, capacity: usize) -> Box<dyn ArrayBuilder> {
     match dtype {
         DType::Null => Box::new(NullBuilder::new()),

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -1,3 +1,7 @@
+/// This module defines the `VortexFile` struct, which represents a Vortex file on disk or in memory.
+///
+/// The `VortexFile` provides methods for accessing file metadata, creating segment sources for reading
+/// data from the file, and initiating scans to read the file's contents into memory as Vortex arrays.
 use std::sync::Arc;
 
 use vortex_array::stats::StatsSet;
@@ -10,33 +14,45 @@ use vortex_metrics::VortexMetrics;
 
 use crate::footer::Footer;
 
+/// Represents a Vortex file, providing access to its metadata and content.
+///
+/// A `VortexFile` is created by opening a Vortex file using [`VortexOpenOptions`](crate::VortexOpenOptions).
+/// It provides methods for accessing file metadata (such as row count, data type, and statistics)
+/// and for initiating scans to read the file's contents.
 #[derive(Clone)]
 pub struct VortexFile {
-    /// The footer of the Vortex file.
+    /// The footer of the Vortex file, containing metadata and layout information.
     pub(crate) footer: Footer,
-    /// A for reading segments from the file.
+    /// A factory for creating segment sources that read data from the file.
     pub(crate) segment_source_factory: Arc<dyn SegmentSourceFactory>,
-    /// Metrics tied to the file.
+    /// Metrics tied to the file for performance monitoring.
     pub(crate) metrics: VortexMetrics,
 }
 
 impl VortexFile {
+    /// Returns a reference to the file's footer, which contains metadata and layout information.
     pub fn footer(&self) -> &Footer {
         &self.footer
     }
 
+    /// Returns the number of rows in the file.
     pub fn row_count(&self) -> u64 {
         self.footer.row_count()
     }
 
+    /// Returns the data type of the file's contents.
     pub fn dtype(&self) -> &DType {
         self.footer.dtype()
     }
 
+    /// Returns the file's statistics, if available.
+    ///
+    /// Statistics can be used for query optimization and data exploration.
     pub fn file_stats(&self) -> Option<&Arc<[StatsSet]>> {
         self.footer.statistics()
     }
 
+    /// Returns a reference to the file's metrics for performance monitoring.
     pub fn metrics(&self) -> &VortexMetrics {
         &self.metrics
     }
@@ -64,7 +80,20 @@ impl VortexFile {
     }
 }
 
+/// A factory for creating segment sources that read data from a Vortex file.
+///
+/// This trait abstracts over different implementations of segment sources, allowing
+/// for different I/O strategies (e.g., synchronous, asynchronous, memory-mapped)
+/// to be used with the same file interface.
 pub trait SegmentSourceFactory: 'static + Send + Sync {
     /// Create a segment source for reading segments from the file.
+    ///
+    /// # Arguments
+    ///
+    /// * `metrics` - Metrics for monitoring the performance of the segment source.
+    ///
+    /// # Returns
+    ///
+    /// A new segment source that can be used to read data from the file.
     fn segment_source(&self, metrics: VortexMetrics) -> Arc<dyn SegmentSource>;
 }

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -1,7 +1,7 @@
-/// This module defines the `VortexFile` struct, which represents a Vortex file on disk or in memory.
-///
-/// The `VortexFile` provides methods for accessing file metadata, creating segment sources for reading
-/// data from the file, and initiating scans to read the file's contents into memory as Vortex arrays.
+//! This module defines the [`VortexFile`] struct, which represents a Vortex file on disk or in memory.
+//!
+//! The `VortexFile` provides methods for accessing file metadata, creating segment sources for reading
+//! data from the file, and initiating scans to read the file's contents into memory as Vortex arrays.
 use std::sync::Arc;
 
 use vortex_array::stats::StatsSet;
@@ -25,7 +25,7 @@ pub struct VortexFile {
     pub(crate) footer: Footer,
     /// A factory for creating segment sources that read data from the file.
     pub(crate) segment_source_factory: Arc<dyn SegmentSourceFactory>,
-    /// Metrics tied to the file for performance monitoring.
+    /// Metrics tied to the file.
     pub(crate) metrics: VortexMetrics,
 }
 
@@ -52,7 +52,7 @@ impl VortexFile {
         self.footer.statistics()
     }
 
-    /// Returns a reference to the file's metrics for performance monitoring.
+    /// Returns a reference to the file's metrics.
     pub fn metrics(&self) -> &VortexMetrics {
         &self.metrics
     }

--- a/vortex-file/src/footer/file_layout.rs
+++ b/vortex-file/src/footer/file_layout.rs
@@ -1,3 +1,9 @@
+/// This module defines the file layout component of the Vortex file footer.
+///
+/// The file layout describes the structure of the data in the file, including:
+/// - The root layout of the file
+/// - Specifications for all segments in the file
+/// - Specifications for array and layout encodings used in the file
 use std::sync::Arc;
 
 use flatbuffers::{FlatBufferBuilder, WIPOffset};
@@ -7,9 +13,16 @@ use vortex_layout::{Layout, LayoutContext};
 
 use crate::footer::segment::SegmentSpec;
 
+/// A writer for serializing a file layout to a FlatBuffer.
+///
+/// This struct is used to write the layout component of a Vortex file footer,
+/// which describes the structure of the data in the file.
 pub(crate) struct FileLayoutFlatBufferWriter {
+    /// The array context containing encodings used in the file.
     pub(crate) ctx: ArrayContext,
+    /// The root layout of the file.
     pub(crate) layout: Layout,
+    /// Specifications for all segments in the file.
     pub(crate) segment_specs: Arc<[SegmentSpec]>,
 }
 

--- a/vortex-file/src/footer/file_layout.rs
+++ b/vortex-file/src/footer/file_layout.rs
@@ -1,9 +1,9 @@
-/// This module defines the file layout component of the Vortex file footer.
-///
-/// The file layout describes the structure of the data in the file, including:
-/// - The root layout of the file
-/// - Specifications for all segments in the file
-/// - Specifications for array and layout encodings used in the file
+//! This module defines the file layout component of the Vortex file footer.
+//!
+//! The file layout describes the structure of the data in the file, including:
+//! - The root layout of the file
+//! - Specifications for all segments in the file
+//! - Specifications for array and layout encodings used in the file
 use std::sync::Arc;
 
 use flatbuffers::{FlatBufferBuilder, WIPOffset};

--- a/vortex-file/src/footer/file_statistics.rs
+++ b/vortex-file/src/footer/file_statistics.rs
@@ -1,8 +1,8 @@
-/// This module defines the file statistics component of the Vortex file footer.
-///
-/// File statistics provide metadata about the data in the file, such as min/max values,
-/// null counts, and other statistical information that can be used for query optimization
-/// and data exploration.
+//! This module defines the file statistics component of the Vortex file footer.
+//!
+//! File statistics provide metadata about the data in the file, such as min/max values,
+//! null counts, and other statistical information that can be used for query optimization
+//! and data exploration.
 use std::sync::Arc;
 
 use flatbuffers::{FlatBufferBuilder, Follow, WIPOffset};
@@ -19,7 +19,7 @@ use vortex_flatbuffers::{FlatBufferRoot, ReadFlatBuffer, WriteFlatBuffer, footer
 #[derive(Clone, Debug)]
 pub(crate) struct FileStatistics(
     /// An array of statistics sets, one for each field or column in the file.
-    pub(crate) Arc<[StatsSet]>
+    pub(crate) Arc<[StatsSet]>,
 );
 
 impl FlatBufferRoot for FileStatistics {}

--- a/vortex-file/src/footer/file_statistics.rs
+++ b/vortex-file/src/footer/file_statistics.rs
@@ -1,3 +1,8 @@
+/// This module defines the file statistics component of the Vortex file footer.
+///
+/// File statistics provide metadata about the data in the file, such as min/max values,
+/// null counts, and other statistical information that can be used for query optimization
+/// and data exploration.
 use std::sync::Arc;
 
 use flatbuffers::{FlatBufferBuilder, Follow, WIPOffset};
@@ -6,8 +11,16 @@ use vortex_array::stats::StatsSet;
 use vortex_error::VortexError;
 use vortex_flatbuffers::{FlatBufferRoot, ReadFlatBuffer, WriteFlatBuffer, footer as fb};
 
+/// Contains statistical information about the data in a Vortex file.
+///
+/// This struct wraps an array of `StatsSet` objects, each containing statistics
+/// for a field or column in the file. These statistics can be used for query
+/// optimization and data exploration.
 #[derive(Clone, Debug)]
-pub(crate) struct FileStatistics(pub(crate) Arc<[StatsSet]>);
+pub(crate) struct FileStatistics(
+    /// An array of statistics sets, one for each field or column in the file.
+    pub(crate) Arc<[StatsSet]>
+);
 
 impl FlatBufferRoot for FileStatistics {}
 

--- a/vortex-file/src/footer/mod.rs
+++ b/vortex-file/src/footer/mod.rs
@@ -1,3 +1,11 @@
+//! This module defines the footer of a Vortex file, which contains metadata about the file's contents.
+//!
+//! The footer includes:
+//! - The file's layout, which describes how the data is organized
+//! - Statistics about the data, which can be used for query optimization
+//! - Segment map, which describe the physical location of data in the file
+//!
+//! The footer is located at the end of the file and is used to interpret the file's contents.
 mod file_layout;
 mod file_statistics;
 mod postscript;

--- a/vortex-file/src/footer/segment.rs
+++ b/vortex-file/src/footer/segment.rs
@@ -5,14 +5,23 @@ use vortex_error::VortexError;
 use vortex_flatbuffers::footer as fb;
 
 /// The location of a segment within a Vortex file.
+///
+/// A segment is a contiguous block of bytes in a file that contains a part of the file's data.
+/// The `SegmentSpec` struct specifies the location and properties of a segment.
 #[derive(Clone, Debug)]
 pub struct SegmentSpec {
+    /// The byte offset of the segment from the start of the file.
     pub offset: u64,
+    /// The length of the segment in bytes.
     pub length: u32,
+    /// The memory alignment requirement of the segment.
     pub alignment: Alignment,
 }
 
 impl SegmentSpec {
+    /// Returns the byte range of the segment within the file.
+    ///
+    /// The range starts at the segment's offset and extends for its length.
     pub fn byte_range(&self) -> Range<u64> {
         self.offset..self.offset + u64::from(self.length)
     }


### PR DESCRIPTION
Was just playing around with Jetbrains Junie (their newly GA agent model). Prompt was "add missing docs to vortex-file". I had to clean it up by hand but it did a decent job