### PR TITLE
Publish to maven on release-plz merge

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -7,7 +7,6 @@ concurrency:
 on:
   push:
     branches: [ "develop" ]
-    tags: [ "*" ]
   pull_request: {}
   workflow_dispatch: {}
 
@@ -103,5 +102,5 @@ jobs:
       - name: Build Java
         run: ./gradlew shadowJar
       - name: Publish to Maven Central
-        if: startsWith(github.ref, 'refs/tags/')
+        if: "startsWith(github.event.head_commit.message, 'chore: release')"
         run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache


### PR DESCRIPTION
Seems like release-plz [didn't](https://github.com/spiraldb/vortex/actions/runs/14513316181/job/40716962653) trigger the publish step because the ref is `refs/heads/develop`, I think this might be the behavior we want?