### PR TITLE
ci: fetch version for Java publication from Cargo.toml

### DIFF
--- a/java/buildSrc/build.gradle.kts
+++ b/java/buildSrc/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.moandjiezana.toml:toml4j:0.7.2")
+}

--- a/java/buildSrc/src/main/kotlin/Cargo.kt
+++ b/java/buildSrc/src/main/kotlin/Cargo.kt
@@ -1,0 +1,9 @@
+import com.moandjiezana.toml.Toml
+import org.gradle.api.Project
+
+fun Project.cargoVersion(): String {
+    val manifestFile = rootDir.parentFile.resolve("Cargo.toml")
+    val manifest = Toml().read(manifestFile)
+
+    return manifest.getString("workspace.package.version")
+}

--- a/java/vortex-jni/build.gradle.kts
+++ b/java/vortex-jni/build.gradle.kts
@@ -34,7 +34,7 @@ testing {
 }
 
 mavenPublishing {
-    coordinates(groupId = "dev.vortex", artifactId = "vortex-jni", version = version.toString())
+    coordinates(groupId = "dev.vortex", artifactId = "vortex-jni", version = cargoVersion())
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
 
     signAllPublications()

--- a/java/vortex-spark/build.gradle.kts
+++ b/java/vortex-spark/build.gradle.kts
@@ -27,7 +27,7 @@ testing {
 }
 
 mavenPublishing {
-    coordinates(groupId = "dev.vortex", artifactId = "vortex-spark", version = version.toString())
+    coordinates(groupId = "dev.vortex", artifactId = "vortex-spark", version = cargoVersion())
 
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
 

--- a/vortex-jni/README.md
+++ b/vortex-jni/README.md
@@ -1,0 +1,3 @@
+## Vortex JNI bindings
+
+Java Native Interface bindings to Vortex


### PR DESCRIPTION
This adds an extension function on the gradle project to fetch the `Cargo.toml` manifest version.

I've verified it has the right output by hooking it up to a dummy `printCargoVersion` task