### PR TITLE
Make df cache configurable in benchmarks

### DIFF
--- a/bench-vortex/src/bin/clickbench.rs
+++ b/bench-vortex/src/bin/clickbench.rs
@@ -55,6 +55,8 @@ struct Args {
     queries_file: Option<PathBuf>,
     #[arg(long, default_value_t = false)]
     emulate_object_store: bool,
+    #[arg(long, default_value_t = false)]
+    disable_datafusion_cache: bool,
     #[arg(long)]
     export_spans: bool,
     #[arg(long, value_enum, default_value_t = Flavor::Partitioned)]
@@ -175,7 +177,8 @@ fn main() -> anyhow::Result<()> {
 
     for engine in &args.engines {
         for file_format in &args.formats {
-            let session_ctx = df::get_session_with_cache(args.emulate_object_store);
+            let session_ctx =
+                df::get_session_context(args.emulate_object_store, args.disable_datafusion_cache);
 
             // Register object store to the session.
             df::make_object_store(&session_ctx, &base_url).expect("Failed to make object store");

--- a/bench-vortex/src/bin/public_bi.rs
+++ b/bench-vortex/src/bin/public_bi.rs
@@ -34,6 +34,8 @@ struct Args {
     display_format: DisplayFormat,
     #[arg(long, default_value_t = false)]
     emulate_object_store: bool,
+    #[arg(long, default_value_t = false)]
+    disable_datafusion_cache: bool,
     #[arg(short, long, value_delimiter = ',')]
     dataset: PBIDataset,
     #[arg(short, long, value_delimiter = ',')]
@@ -98,7 +100,8 @@ fn main() -> anyhow::Result<()> {
     runtime.block_on(dataset.write_as_vortex());
 
     for format in &args.formats {
-        let session = df::get_session_with_cache(args.emulate_object_store);
+        let session =
+            df::get_session_context(args.emulate_object_store, args.disable_datafusion_cache);
         let file_type = match format {
             Format::Csv => FileType::Csv,
             Format::Parquet => FileType::Parquet,

--- a/bench-vortex/src/bin/tpch.rs
+++ b/bench-vortex/src/bin/tpch.rs
@@ -54,6 +54,8 @@ struct Args {
     display_format: DisplayFormat,
     #[arg(long, default_value_t = false)]
     emulate_object_store: bool,
+    #[arg(long, default_value_t = false)]
+    disable_datafusion_cache: bool,
     #[arg(long, default_value_t, value_enum)]
     data_generator: DataGenerator,
     #[arg(long)]
@@ -166,6 +168,7 @@ fn main() -> ExitCode {
         args.formats,
         args.display_format,
         args.emulate_object_store,
+        args.disable_datafusion_cache,
         args.scale_factor,
         url,
         args.all_metrics,
@@ -286,6 +289,7 @@ async fn bench_main(
     formats: Vec<Format>,
     display_format: DisplayFormat,
     emulate_object_store: bool,
+    disable_datafusion_cache: bool,
     scale_factor: u8,
     url: Url,
     display_all_metrics: bool,
@@ -332,9 +336,10 @@ async fn bench_main(
         for format in formats.iter().copied() {
             match engine {
                 Engine::DataFusion => {
-                    let ctx = load_datasets(&url, format, emulate_object_store)
-                        .await
-                        .unwrap();
+                    let ctx =
+                        load_datasets(&url, format, emulate_object_store, disable_datafusion_cache)
+                            .await
+                            .unwrap();
 
                     let mut plans = Vec::new();
 

--- a/bench-vortex/src/engines/df/mod.rs
+++ b/bench-vortex/src/engines/df/mod.rs
@@ -47,7 +47,7 @@ pub fn get_session_context(
         Arc::new(DefaultObjectStoreRegistry::new()) as _
     };
 
-    let mut rt_builder = RuntimeEnvBuilder::new();
+    let mut rt_builder = RuntimeEnvBuilder::new().with_object_store_registry(registry);
 
     if !disable_datafusion_cache {
         let file_static_cache = Arc::new(DefaultFileStatisticsCache::default());
@@ -55,9 +55,7 @@ pub fn get_session_context(
         let cache_config = CacheManagerConfig::default()
             .with_files_statistics_cache(Some(file_static_cache))
             .with_list_files_cache(Some(list_file_cache));
-        rt_builder = rt_builder
-            .with_cache_manager(cache_config)
-            .with_object_store_registry(registry);
+        rt_builder = rt_builder.with_cache_manager(cache_config);
     }
 
     let rt = rt_builder

--- a/bench-vortex/src/engines/df/mod.rs
+++ b/bench-vortex/src/engines/df/mod.rs
@@ -3,18 +3,24 @@ use std::process::Command;
 use std::sync::{Arc, LazyLock};
 
 use arrow_array::RecordBatch;
+use datafusion::datasource::provider::DefaultTableFactory;
+use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::cache::cache_manager::CacheManagerConfig;
 use datafusion::execution::cache::cache_unit::{DefaultFileStatisticsCache, DefaultListFilesCache};
 use datafusion::execution::object_store::DefaultObjectStoreRegistry;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
-use datafusion::physical_plan::{ExecutionPlan, collect};
+use datafusion::physical_plan::collect;
+use datafusion::physical_plan::execution_plan::ExecutionPlan;
 use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion_common::GetExt;
+use datafusion_physical_plan::display::DisplayableExecutionPlan;
 use object_store::ObjectStore;
 use object_store::aws::AmazonS3Builder;
 use object_store::gcp::GoogleCloudStorageBuilder;
 use object_store::local::LocalFileSystem;
 use url::Url;
 use vortex::error::VortexResult;
+use vortex_datafusion::persistent::VortexFormatFactory;
 
 use crate::blob::SlowObjectStoreRegistry;
 
@@ -31,27 +37,52 @@ pub static GIT_COMMIT_ID: LazyLock<String> = LazyLock::new(|| {
     .to_string()
 });
 
-pub fn get_session_with_cache(emulate_object_store: bool) -> SessionContext {
+pub fn get_session_context(
+    emulate_object_store: bool,
+    disable_datafusion_cache: bool,
+) -> SessionContext {
     let registry = if emulate_object_store {
         Arc::new(SlowObjectStoreRegistry::default()) as _
     } else {
         Arc::new(DefaultObjectStoreRegistry::new()) as _
     };
 
-    let file_static_cache = Arc::new(DefaultFileStatisticsCache::default());
-    let list_file_cache = Arc::new(DefaultListFilesCache::default());
+    let mut rt_builder = RuntimeEnvBuilder::new();
 
-    let cache_config = CacheManagerConfig::default()
-        .with_files_statistics_cache(Some(file_static_cache))
-        .with_list_files_cache(Some(list_file_cache));
+    if !disable_datafusion_cache {
+        let file_static_cache = Arc::new(DefaultFileStatisticsCache::default());
+        let list_file_cache = Arc::new(DefaultListFilesCache::default());
+        let cache_config = CacheManagerConfig::default()
+            .with_files_statistics_cache(Some(file_static_cache))
+            .with_list_files_cache(Some(list_file_cache));
+        rt_builder = rt_builder
+            .with_cache_manager(cache_config)
+            .with_object_store_registry(registry);
+    }
 
-    let rt = RuntimeEnvBuilder::new()
-        .with_cache_manager(cache_config)
-        .with_object_store_registry(registry)
+    let rt = rt_builder
         .build_arc()
         .expect("could not build runtime environment");
 
-    SessionContext::new_with_config_rt(SessionConfig::default(), rt)
+    let factory = VortexFormatFactory::default_config();
+
+    let mut session_state_builder = SessionStateBuilder::new()
+        .with_config(SessionConfig::default())
+        .with_runtime_env(rt)
+        .with_default_features();
+
+    if let Some(table_factories) = session_state_builder.table_factories() {
+        table_factories.insert(
+            GetExt::get_ext(&factory).to_uppercase(), // Has to be uppercase
+            Arc::new(DefaultTableFactory::new()),
+        );
+    }
+
+    if let Some(file_formats) = session_state_builder.file_formats() {
+        file_formats.push(Arc::new(factory));
+    }
+
+    SessionContext::new_with_state(session_state_builder.build())
 }
 
 pub fn make_object_store(
@@ -109,10 +140,8 @@ pub fn write_execution_plan(
     query_idx: usize,
     format: crate::Format,
     dataset_name: &str,
-    execution_plan: &std::sync::Arc<dyn datafusion::physical_plan::execution_plan::ExecutionPlan>,
+    execution_plan: &Arc<dyn ExecutionPlan>,
 ) {
-    use datafusion::physical_plan::display::DisplayableExecutionPlan;
-
     fs::write(
         format!("{dataset_name}_{format}_q{query_idx:02}.plan"),
         format!("{:#?}", execution_plan),

--- a/bench-vortex/src/tpch/mod.rs
+++ b/bench-vortex/src/tpch/mod.rs
@@ -14,7 +14,7 @@ use vortex::{Array, ArrayRef, TryIntoArray};
 use vortex_datafusion::SessionContextExt;
 
 use crate::Format;
-use crate::engines::df::{get_session_with_cache, make_object_store};
+use crate::engines::df::{get_session_context, make_object_store};
 
 pub mod dbgen;
 pub mod duckdb;
@@ -41,8 +41,9 @@ pub async fn load_datasets(
     base_dir: &Url,
     format: Format,
     emulate_object_store: bool,
+    disable_datafusion_cache: bool,
 ) -> anyhow::Result<SessionContext> {
-    let context = get_session_with_cache(emulate_object_store);
+    let context = get_session_context(emulate_object_store, disable_datafusion_cache);
 
     let object_store = make_object_store(&context, base_dir)?;
 


### PR DESCRIPTION
default is still the same, I just want to disable it in ClickBench.