### PR TITLE
Leaky Cauldron

### DIFF
--- a/vortex-ffi/src/array.rs
+++ b/vortex-ffi/src/array.rs
@@ -11,7 +11,7 @@ use vortex::dtype::half::f16;
 use vortex::error::{VortexExpect, VortexUnwrap, vortex_err};
 use vortex::{Array, ArrayRef, ArrayVariants};
 
-use crate::error::{try_or, vx_error};
+use crate::error::{try_or, try_or_else, vx_error};
 
 /// The FFI interface for an [`Array`].
 ///
@@ -44,7 +44,7 @@ pub unsafe extern "C-unwind" fn vx_array_get_field(
     index: u32,
     error: *mut *mut vx_error,
 ) -> *const vx_array {
-    try_or(error, ptr::null, || {
+    try_or_else(error, ptr::null, || {
         let array = array.as_ref().vortex_expect("array null");
 
         let field_array = array
@@ -77,7 +77,7 @@ pub unsafe extern "C-unwind" fn vx_array_slice(
     error: *mut *mut vx_error,
 ) -> *const vx_array {
     let array = array.as_ref().vortex_expect("array null");
-    try_or(error, ptr::null_mut, || {
+    try_or_else(error, ptr::null_mut, || {
         let sliced = slice(array.inner.as_ref(), start as usize, stop as usize)?;
         Ok(Box::into_raw(Box::new(vx_array { inner: sliced })))
     })
@@ -90,7 +90,7 @@ pub unsafe extern "C-unwind" fn vx_array_is_null(
     error: *mut *mut vx_error,
 ) -> bool {
     let array = array.as_ref().vortex_expect("array null");
-    try_or(error, || false, || array.inner.is_invalid(index as usize))
+    try_or(error, false, || array.inner.is_invalid(index as usize))
 }
 
 #[unsafe(no_mangle)]
@@ -99,11 +99,9 @@ pub unsafe extern "C-unwind" fn vx_array_null_count(
     error: *mut *mut vx_error,
 ) -> u32 {
     let array = array.as_ref().vortex_expect("array null");
-    try_or(
-        error,
-        || 0,
-        || Ok(array.inner.as_ref().invalid_count()?.try_into()?),
-    )
+    try_or(error, 0, || {
+        Ok(array.inner.as_ref().invalid_count()?.try_into()?)
+    })
 }
 
 macro_rules! ffiarray_get_ptype {

--- a/vortex-ffi/src/array.rs
+++ b/vortex-ffi/src/array.rs
@@ -44,7 +44,7 @@ pub unsafe extern "C-unwind" fn vx_array_get_field(
     index: u32,
     error: *mut *mut vx_error,
 ) -> *const vx_array {
-    try_or(error, ptr::null(), || {
+    try_or(error, ptr::null, || {
         let array = array.as_ref().vortex_expect("array null");
 
         let field_array = array
@@ -77,7 +77,7 @@ pub unsafe extern "C-unwind" fn vx_array_slice(
     error: *mut *mut vx_error,
 ) -> *const vx_array {
     let array = array.as_ref().vortex_expect("array null");
-    try_or(error, ptr::null_mut(), || {
+    try_or(error, ptr::null_mut, || {
         let sliced = slice(array.inner.as_ref(), start as usize, stop as usize)?;
         Ok(Box::into_raw(Box::new(vx_array { inner: sliced })))
     })
@@ -90,7 +90,7 @@ pub unsafe extern "C-unwind" fn vx_array_is_null(
     error: *mut *mut vx_error,
 ) -> bool {
     let array = array.as_ref().vortex_expect("array null");
-    try_or(error, false, || array.inner.is_invalid(index as usize))
+    try_or(error, || false, || array.inner.is_invalid(index as usize))
 }
 
 #[unsafe(no_mangle)]
@@ -99,9 +99,11 @@ pub unsafe extern "C-unwind" fn vx_array_null_count(
     error: *mut *mut vx_error,
 ) -> u32 {
     let array = array.as_ref().vortex_expect("array null");
-    try_or(error, 0, || {
-        Ok(array.inner.as_ref().invalid_count()?.try_into()?)
-    })
+    try_or(
+        error,
+        || 0,
+        || Ok(array.inner.as_ref().invalid_count()?.try_into()?),
+    )
 }
 
 macro_rules! ffiarray_get_ptype {

--- a/vortex-ffi/src/dtype.rs
+++ b/vortex-ffi/src/dtype.rs
@@ -1,12 +1,12 @@
 use std::ffi::{CStr, c_char, c_int, c_void};
-use std::ptr::null;
+use std::ptr;
 use std::sync::Arc;
 
 use vortex::dtype::datetime::{DATE_ID, TIME_ID, TIMESTAMP_ID, TemporalMetadata};
 use vortex::dtype::{DType, FieldNames, PType, StructDType};
 use vortex::error::{VortexExpect, VortexUnwrap, vortex_bail};
 
-use crate::error::{try_or, vx_error};
+use crate::error::{try_or_else, vx_error};
 
 /// Pointer to a `DType` value that has been heap-allocated.
 /// Create a new simple dtype.
@@ -199,7 +199,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_element_type(
 ) -> *const DType {
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
 
-    try_or(error, null, || {
+    try_or_else(error, ptr::null, || {
         let DType::List(element_dtype, _) = dtype else {
             vortex_bail!("vx_dtype_element_type: not a list dtype")
         };

--- a/vortex-ffi/src/dtype.rs
+++ b/vortex-ffi/src/dtype.rs
@@ -199,7 +199,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_element_type(
 ) -> *const DType {
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
 
-    try_or(error, null(), || {
+    try_or(error, null, || {
         let DType::List(element_dtype, _) = dtype else {
             vortex_bail!("vx_dtype_element_type: not a list dtype")
         };

--- a/vortex-ffi/src/duckdb/mod.rs
+++ b/vortex-ffi/src/duckdb/mod.rs
@@ -33,7 +33,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_to_duckdb_logical_type(
 
     try_or(
         error,
-        LogicalTypeHandle::from(LogicalTypeId::Invalid).into_owning_ptr(),
+        || LogicalTypeHandle::from(LogicalTypeId::Invalid).into_owning_ptr(),
         || Ok(dtype.to_duckdb_type()?.into_owning_ptr()),
     )
 }
@@ -87,7 +87,7 @@ pub unsafe extern "C-unwind" fn vx_array_create_empty_from_duckdb_table(
     len: c_int,
     error: *mut *mut vx_error,
 ) -> *mut vx_array {
-    try_or(error, ptr::null_mut(), || {
+    try_or(error, ptr::null_mut, || {
         let field_names: Vec<Arc<str>> = (0..len)
             .map(|i| to_string(*names.offset(i as isize)))
             .map(Arc::from)

--- a/vortex-ffi/src/duckdb/mod.rs
+++ b/vortex-ffi/src/duckdb/mod.rs
@@ -50,34 +50,38 @@ pub unsafe extern "C-unwind" fn vx_array_to_duckdb_chunk(
     cache: *mut vx_conversion_cache,
     error: *mut *mut vx_error,
 ) -> c_uint {
-    try_or(error, 0, || {
-        let offset = offset as usize;
+    try_or(
+        error,
+        || 0,
+        || {
+            let offset = offset as usize;
 
-        let array = &unsafe { stream.as_ref() }
-            .vortex_expect("null stream")
-            .inner;
+            let array = &unsafe { stream.as_ref() }
+                .vortex_expect("null stream")
+                .inner;
 
-        assert!(array.len() > offset, "offset out of bounds");
+            assert!(array.len() > offset, "offset out of bounds");
 
-        let end = min(offset + DUCKDB_STANDARD_VECTOR_SIZE, array.len());
-        let is_end = end == array.len();
+            let end = min(offset + DUCKDB_STANDARD_VECTOR_SIZE, array.len());
+            let is_end = end == array.len();
 
-        let slice = slice(array, offset, end)?;
-        let mut data_chunk_handle = unsafe { DataChunkHandle::new_unowned(data_chunk_ptr) };
-        let cache: &mut ConversionCache = unsafe { into_conversion_cache(cache) };
+            let slice = slice(array, offset, end)?;
+            let mut data_chunk_handle = unsafe { DataChunkHandle::new_unowned(data_chunk_ptr) };
+            let cache: &mut ConversionCache = unsafe { into_conversion_cache(cache) };
 
-        to_duckdb_chunk(
-            &slice.to_struct().vortex_expect("must be a struct"),
-            &mut data_chunk_handle,
-            cache,
-        )?;
+            to_duckdb_chunk(
+                &slice.to_struct().vortex_expect("must be a struct"),
+                &mut data_chunk_handle,
+                cache,
+            )?;
 
-        if is_end {
-            Ok(0)
-        } else {
-            Ok(u32::try_from(end)?)
-        }
-    })
+            if is_end {
+                Ok(0)
+            } else {
+                Ok(u32::try_from(end)?)
+            }
+        },
+    )
 }
 
 #[unsafe(no_mangle)]

--- a/vortex-ffi/src/duckdb/mod.rs
+++ b/vortex-ffi/src/duckdb/mod.rs
@@ -20,7 +20,7 @@ use vortex_duckdb::{
 
 use crate::array::vx_array;
 use crate::duckdb::cache::{into_conversion_cache, vx_conversion_cache};
-use crate::error::{try_or, vx_error};
+use crate::error::{try_or, try_or_else, vx_error};
 use crate::to_string;
 
 /// Converts a DType into a duckdb
@@ -31,7 +31,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_to_duckdb_logical_type(
 ) -> duckdb_logical_type {
     let dtype = unsafe { dtype.as_ref().vortex_expect("null dtype") };
 
-    try_or(
+    try_or_else(
         error,
         || LogicalTypeHandle::from(LogicalTypeId::Invalid).into_owning_ptr(),
         || Ok(dtype.to_duckdb_type()?.into_owning_ptr()),
@@ -50,38 +50,34 @@ pub unsafe extern "C-unwind" fn vx_array_to_duckdb_chunk(
     cache: *mut vx_conversion_cache,
     error: *mut *mut vx_error,
 ) -> c_uint {
-    try_or(
-        error,
-        || 0,
-        || {
-            let offset = offset as usize;
+    try_or(error, 0, || {
+        let offset = offset as usize;
 
-            let array = &unsafe { stream.as_ref() }
-                .vortex_expect("null stream")
-                .inner;
+        let array = &unsafe { stream.as_ref() }
+            .vortex_expect("null stream")
+            .inner;
 
-            assert!(array.len() > offset, "offset out of bounds");
+        assert!(array.len() > offset, "offset out of bounds");
 
-            let end = min(offset + DUCKDB_STANDARD_VECTOR_SIZE, array.len());
-            let is_end = end == array.len();
+        let end = min(offset + DUCKDB_STANDARD_VECTOR_SIZE, array.len());
+        let is_end = end == array.len();
 
-            let slice = slice(array, offset, end)?;
-            let mut data_chunk_handle = unsafe { DataChunkHandle::new_unowned(data_chunk_ptr) };
-            let cache: &mut ConversionCache = unsafe { into_conversion_cache(cache) };
+        let slice = slice(array, offset, end)?;
+        let mut data_chunk_handle = unsafe { DataChunkHandle::new_unowned(data_chunk_ptr) };
+        let cache: &mut ConversionCache = unsafe { into_conversion_cache(cache) };
 
-            to_duckdb_chunk(
-                &slice.to_struct().vortex_expect("must be a struct"),
-                &mut data_chunk_handle,
-                cache,
-            )?;
+        to_duckdb_chunk(
+            &slice.to_struct().vortex_expect("must be a struct"),
+            &mut data_chunk_handle,
+            cache,
+        )?;
 
-            if is_end {
-                Ok(0)
-            } else {
-                Ok(u32::try_from(end)?)
-            }
-        },
-    )
+        if is_end {
+            Ok(0)
+        } else {
+            Ok(u32::try_from(end)?)
+        }
+    })
 }
 
 #[unsafe(no_mangle)]
@@ -91,7 +87,7 @@ pub unsafe extern "C-unwind" fn vx_array_create_empty_from_duckdb_table(
     len: c_int,
     error: *mut *mut vx_error,
 ) -> *mut vx_array {
-    try_or(error, ptr::null_mut, || {
+    try_or_else(error, ptr::null_mut, || {
         let field_names: Vec<Arc<str>> = (0..len)
             .map(|i| to_string(*names.offset(i as isize)))
             .map(Arc::from)

--- a/vortex-ffi/src/error.rs
+++ b/vortex-ffi/src/error.rs
@@ -13,6 +13,35 @@ pub struct vx_error {
 #[inline]
 pub fn try_or<T>(
     error: *mut *mut vx_error,
+    default_value: T,
+    function: impl FnOnce() -> VortexResult<T>,
+) -> T {
+    match function() {
+        Ok(value) => {
+            unsafe { error.write(ptr::null_mut()) };
+            value
+        }
+        Err(err) => {
+            #[allow(clippy::expect_used)]
+            let c_string =
+                std::ffi::CString::new(err.to_string()).expect("Failed to create CString");
+            unsafe {
+                error.write(
+                    Box::into_raw(Box::new(vx_error {
+                        code: -1,
+                        message: c_string.into_raw(),
+                    }))
+                    .cast(),
+                )
+            };
+            default_value
+        }
+    }
+}
+
+#[inline]
+pub fn try_or_else<T>(
+    error: *mut *mut vx_error,
     default_value: impl FnOnce() -> T,
     function: impl FnOnce() -> VortexResult<T>,
 ) -> T {

--- a/vortex-ffi/src/error.rs
+++ b/vortex-ffi/src/error.rs
@@ -12,8 +12,8 @@ pub struct vx_error {
 
 pub fn try_or<T>(
     error: *mut *mut vx_error,
-    default_value: T,
-    mut function: impl FnMut() -> VortexResult<T>,
+    default_value: impl FnOnce() -> T,
+    function: impl FnOnce() -> VortexResult<T>,
 ) -> T {
     match function() {
         Ok(value) => {

--- a/vortex-ffi/src/error.rs
+++ b/vortex-ffi/src/error.rs
@@ -10,6 +10,7 @@ pub struct vx_error {
     pub message: *const c_char,
 }
 
+#[inline]
 pub fn try_or<T>(
     error: *mut *mut vx_error,
     default_value: impl FnOnce() -> T,

--- a/vortex-ffi/src/error.rs
+++ b/vortex-ffi/src/error.rs
@@ -33,7 +33,7 @@ pub fn try_or<T>(
                     .cast(),
                 )
             };
-            default_value
+            default_value()
         }
     }
 }

--- a/vortex-ffi/src/file.rs
+++ b/vortex-ffi/src/file.rs
@@ -83,7 +83,7 @@ pub unsafe extern "C-unwind" fn vx_file_open_reader(
     options: *const vx_file_open_options,
     error: *mut *mut vx_error,
 ) -> *mut vx_file_reader {
-    try_or(error, null_mut(), || {
+    try_or(error, null_mut, || {
         {
             let options = unsafe {
                 options
@@ -121,7 +121,7 @@ pub unsafe extern "C-unwind" fn vx_file_create(
     options: *const vx_file_create_options,
     error: *mut *mut vx_error,
 ) -> *mut vx_file_writer {
-    try_or(error, null_mut(), || {
+    try_or(error, null_mut, || {
         let options = options.as_ref().vortex_expect("null options");
         assert!(!options.path.is_null(), "null path");
 
@@ -139,21 +139,25 @@ pub unsafe extern "C-unwind" fn vx_file_write_array(
     ffi_array: *mut vx_array,
     error: *mut *mut vx_error,
 ) {
-    try_or(error, (), || {
-        let array = unsafe { ffi_array.as_ref().vortex_expect("null array") };
-        let file = unsafe { file.as_mut().vortex_expect("null file") };
+    try_or(
+        error,
+        || (),
+        || {
+            let array = unsafe { ffi_array.as_ref().vortex_expect("null array") };
+            let file = unsafe { file.as_mut().vortex_expect("null file") };
 
-        RUNTIME.with(|r| {
-            r.block_on(async move {
-                let file = VortexWriteOptions::default()
-                    .write(&mut file.inner, array.inner.to_array_stream())
-                    .await?;
+            RUNTIME.with(|r| {
+                r.block_on(async move {
+                    let file = VortexWriteOptions::default()
+                        .write(&mut file.inner, array.inner.to_array_stream())
+                        .await?;
 
-                file.flush().await?;
-                Ok(())
+                    file.flush().await?;
+                    Ok(())
+                })
             })
-        })
-    });
+        },
+    );
 }
 
 /// Whole file statistics.
@@ -198,7 +202,7 @@ pub unsafe extern "C-unwind" fn vx_file_scan(
     opts: *const vx_file_scan_options,
     error: *mut *mut vx_error,
 ) -> *mut vx_array_stream {
-    try_or(error, null_mut(), || {
+    try_or(error, null_mut, || {
         let file = unsafe { file.as_ref().vortex_expect("null file") };
         let mut stream = file.inner.scan().vortex_expect("create scan");
 

--- a/vortex-ffi/src/file.rs
+++ b/vortex-ffi/src/file.rs
@@ -1,10 +1,9 @@
 //! FFI interface for Vortex File I/O.
 
 use std::ffi::{CStr, c_char, c_int};
-use std::ptr::null_mut;
-use std::slice;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::{ptr, slice};
 
 use object_store::aws::{AmazonS3Builder, AmazonS3ConfigKey};
 use object_store::azure::{AzureConfigKey, MicrosoftAzureBuilder};
@@ -24,7 +23,7 @@ use vortex::proto::expr::Expr;
 use vortex::stream::ArrayStreamArrayExt;
 
 use crate::array::vx_array;
-use crate::error::{try_or, vx_error};
+use crate::error::{try_or, try_or_else, vx_error};
 use crate::stream::{ArrayStreamInner, vx_array_stream};
 use crate::{RUNTIME, to_string, to_string_vec};
 
@@ -83,7 +82,7 @@ pub unsafe extern "C-unwind" fn vx_file_open_reader(
     options: *const vx_file_open_options,
     error: *mut *mut vx_error,
 ) -> *mut vx_file_reader {
-    try_or(error, null_mut, || {
+    try_or_else(error, ptr::null_mut, || {
         {
             let options = unsafe {
                 options
@@ -121,7 +120,7 @@ pub unsafe extern "C-unwind" fn vx_file_create(
     options: *const vx_file_create_options,
     error: *mut *mut vx_error,
 ) -> *mut vx_file_writer {
-    try_or(error, null_mut, || {
+    try_or_else(error, ptr::null_mut, || {
         let options = options.as_ref().vortex_expect("null options");
         assert!(!options.path.is_null(), "null path");
 
@@ -139,25 +138,21 @@ pub unsafe extern "C-unwind" fn vx_file_write_array(
     ffi_array: *mut vx_array,
     error: *mut *mut vx_error,
 ) {
-    try_or(
-        error,
-        || (),
-        || {
-            let array = unsafe { ffi_array.as_ref().vortex_expect("null array") };
-            let file = unsafe { file.as_mut().vortex_expect("null file") };
+    try_or(error, (), || {
+        let array = unsafe { ffi_array.as_ref().vortex_expect("null array") };
+        let file = unsafe { file.as_mut().vortex_expect("null file") };
 
-            RUNTIME.with(|r| {
-                r.block_on(async move {
-                    let file = VortexWriteOptions::default()
-                        .write(&mut file.inner, array.inner.to_array_stream())
-                        .await?;
+        RUNTIME.with(|r| {
+            r.block_on(async move {
+                let file = VortexWriteOptions::default()
+                    .write(&mut file.inner, array.inner.to_array_stream())
+                    .await?;
 
-                    file.flush().await?;
-                    Ok(())
-                })
+                file.flush().await?;
+                Ok(())
             })
-        },
-    );
+        })
+    });
 }
 
 /// Whole file statistics.
@@ -202,7 +197,7 @@ pub unsafe extern "C-unwind" fn vx_file_scan(
     opts: *const vx_file_scan_options,
     error: *mut *mut vx_error,
 ) -> *mut vx_array_stream {
-    try_or(error, null_mut, || {
+    try_or_else(error, ptr::null_mut, || {
         let file = unsafe { file.as_ref().vortex_expect("null file") };
         let mut stream = file.inner.scan().vortex_expect("create scan");
 

--- a/vortex-ffi/src/stream.rs
+++ b/vortex-ffi/src/stream.rs
@@ -1,6 +1,5 @@
 use std::pin::Pin;
 use std::ptr;
-use std::ptr::null_mut;
 
 use futures::StreamExt;
 use vortex::dtype::DType;
@@ -8,7 +7,7 @@ use vortex::error::{VortexExpect, vortex_bail};
 use vortex::stream::ArrayStream;
 
 use crate::array::vx_array;
-use crate::error::{try_or, vx_error};
+use crate::error::{try_or_else, vx_error};
 
 /// FFI-exposed stream interface.
 #[allow(non_camel_case_types)]
@@ -48,7 +47,7 @@ pub unsafe extern "C-unwind" fn vx_array_stream_next(
     stream: *mut vx_array_stream,
     error: *mut *mut vx_error,
 ) -> *mut vx_array {
-    try_or(error, null_mut, || {
+    try_or_else(error, ptr::null_mut, || {
         let stream = unsafe { stream.as_mut() }.vortex_expect("stream null");
         let Some(inner) = stream.inner.as_mut() else {
             vortex_bail!("vx_array_stream_next called after finish")
@@ -62,7 +61,7 @@ pub unsafe extern "C-unwind" fn vx_array_stream_next(
             // Drop the stream pointers.
             stream.inner.take();
 
-            Ok(null_mut())
+            Ok(ptr::null_mut())
         }
     })
 }

--- a/vortex-ffi/src/stream.rs
+++ b/vortex-ffi/src/stream.rs
@@ -48,7 +48,7 @@ pub unsafe extern "C-unwind" fn vx_array_stream_next(
     stream: *mut vx_array_stream,
     error: *mut *mut vx_error,
 ) -> *mut vx_array {
-    try_or(error, null_mut(), || {
+    try_or(error, null_mut, || {
         let stream = unsafe { stream.as_mut() }.vortex_expect("stream null");
         let Some(inner) = stream.inner.as_mut() else {
             vortex_bail!("vx_array_stream_next called after finish")


### PR DESCRIPTION
I think the leak was us allocating the invalid logical type even when no error was raised. This makes the default value in error handling lazy. Since `try_or` is generic, there is no added cost when the default value is constant.