### PR TITLE
Refactor scan API to make it easier to correctly spawn tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6386,7 +6386,9 @@ dependencies = [
 name = "vortex-layout"
 version = "0.31.0"
 dependencies = [
+ "arrow-array",
  "arrow-buffer",
+ "arrow-schema",
  "async-trait",
  "bit-vec",
  "bytes",

--- a/bench-vortex/Cargo.toml
+++ b/bench-vortex/Cargo.toml
@@ -71,7 +71,7 @@ tracing-subscriber = { workspace = true, features = [
 ] }
 url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
-vortex = { workspace = true, features = ["object_store", "parquet"] }
+vortex = { workspace = true, features = ["object_store", "parquet", "files"] }
 vortex-datafusion = { workspace = true }
 vortex-metrics = { workspace = true }
 xshell = { workspace = true }

--- a/bench-vortex/src/compress/vortex.rs
+++ b/bench-vortex/src/compress/vortex.rs
@@ -3,7 +3,6 @@ use std::io::Cursor;
 use arrow_array::ArrayRef;
 use bytes::Bytes;
 use futures::TryStreamExt;
-use tokio::runtime::Handle;
 use vortex::Array;
 use vortex::arrow::IntoArrowArray;
 use vortex::error::VortexResult;
@@ -23,9 +22,8 @@ pub async fn vortex_decompress_read(buf: Bytes) -> VortexResult<Vec<ArrayRef>> {
     VortexOpenOptions::in_memory()
         .open(buf)
         .await?
-        .scan()
-        .unwrap()
-        .spawn_tokio(Handle::current())?
+        .scan()?
+        .into_array_stream()?
         .try_collect::<Vec<_>>()
         .await?
         .into_iter()

--- a/bench-vortex/src/datasets/taxi_data.rs
+++ b/bench-vortex/src/datasets/taxi_data.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
-use tokio::runtime::Handle;
 use vortex::ArrayRef;
 use vortex::error::VortexError;
 use vortex::file::{VortexOpenOptions, VortexWriteOptions};
@@ -43,7 +42,7 @@ pub async fn fetch_taxi_data() -> ArrayRef {
         .unwrap()
         .scan()
         .unwrap()
-        .spawn_tokio(Handle::current())
+        .into_array_stream()
         .unwrap()
         .read_all()
         .await

--- a/bench-vortex/src/public_bi.rs
+++ b/bench-vortex/src/public_bi.rs
@@ -28,7 +28,7 @@ use vortex::arrays::ChunkedArray;
 use vortex::error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
 use vortex::file::{VortexOpenOptions, VortexWriteOptions};
 use vortex::io::TokioFile;
-use vortex::stream::{ArrayStreamAdapter, ArrayStreamExt};
+use vortex::stream::ArrayStreamExt;
 use vortex::{Array, ArrayRef};
 use vortex_datafusion::persistent::VortexFormat;
 
@@ -405,12 +405,13 @@ impl Dataset for PBIBenchmark {
 
         let arrays = stream::iter(dataset.list_files(FileType::Vortex))
             .map(|f| async move {
-                let scan = VortexOpenOptions::file()
+                VortexOpenOptions::file()
                     .open(TokioFile::open(f)?)
                     .await?
-                    .scan()?;
-                let dtype = scan.dtype()?;
-                ArrayStreamAdapter::new(dtype, scan.spawn_tokio(Handle::current()).unwrap())
+                    .scan()?
+                    // TODO(ngates): why do we spawn this on the tokio executor?
+                    .with_tokio_executor(Handle::current())
+                    .into_array_stream()?
                     .read_all()
                     .await
             })

--- a/bench-vortex/src/public_bi.rs
+++ b/bench-vortex/src/public_bi.rs
@@ -28,7 +28,7 @@ use vortex::arrays::ChunkedArray;
 use vortex::error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
 use vortex::file::{VortexOpenOptions, VortexWriteOptions};
 use vortex::io::TokioFile;
-use vortex::stream::ArrayStreamExt;
+use vortex::stream::{ArrayStreamAdapter, ArrayStreamExt};
 use vortex::{Array, ArrayRef};
 use vortex_datafusion::persistent::VortexFormat;
 
@@ -405,12 +405,12 @@ impl Dataset for PBIBenchmark {
 
         let arrays = stream::iter(dataset.list_files(FileType::Vortex))
             .map(|f| async move {
-                VortexOpenOptions::file()
+                let scan = VortexOpenOptions::file()
                     .open(TokioFile::open(f)?)
                     .await?
-                    .scan()?
-                    .spawn_tokio(Handle::current())
-                    .unwrap()
+                    .scan()?;
+                let dtype = scan.dtype()?;
+                ArrayStreamAdapter::new(dtype, scan.spawn_tokio(Handle::current()).unwrap())
                     .read_all()
                     .await
             })

--- a/bench-vortex/src/random_access/take.rs
+++ b/bench-vortex/src/random_access/take.rs
@@ -12,7 +12,6 @@ use parquet::arrow::arrow_reader::ArrowReaderOptions;
 use parquet::arrow::async_reader::AsyncFileReader;
 use parquet::file::metadata::RowGroupMetaData;
 use stream::StreamExt;
-use tokio::runtime::Handle;
 use vortex::aliases::hash_map::HashMap;
 use vortex::buffer::Buffer;
 use vortex::error::VortexResult;
@@ -39,7 +38,7 @@ async fn take_vortex<T: VortexReadAt + Send + Sync>(
         .await?
         .scan()?
         .with_row_indices(indices)
-        .spawn_tokio(Handle::current())?
+        .into_array_stream()?
         .read_all()
         .await?
         // For equivalence.... we decompress to make sure we're not cheating too much.

--- a/pyvortex/src/file.rs
+++ b/pyvortex/src/file.rs
@@ -154,6 +154,7 @@ impl PyVortexFile {
             .get()
             .vxf
             .scan()?
+            .with_tokio_executor(TOKIO_RUNTIME.handle().clone())
             .with_some_filter(expr.map(|e| e.into_inner()))
             .with_projection(projection.map(|p| p.0).unwrap_or_else(ident));
 
@@ -168,9 +169,7 @@ impl PyVortexFile {
             builder = builder.with_split_by(SplitBy::RowCount(batch_size));
         }
 
-        let iter = ArrayStreamToIterator::new(ArrayStreamExt::boxed(
-            builder.spawn_tokio(TOKIO_RUNTIME.handle().clone())?,
-        ));
+        let iter = ArrayStreamToIterator::new(ArrayStreamExt::boxed(builder.into_array_stream()?));
         Ok(PyArrayIterator::new(Box::new(iter)))
     }
 
@@ -188,6 +187,7 @@ impl PyVortexFile {
         let stream = slf.py().allow_threads(|| {
             let mut builder = vxf
                 .scan()?
+                .with_tokio_executor(TOKIO_RUNTIME.handle().clone())
                 .with_canonicalize(true)
                 .with_some_filter(expr.map(|e| e.into_inner()))
                 .with_projection(projection.map(|p| p.0).unwrap_or_else(ident));
@@ -196,9 +196,7 @@ impl PyVortexFile {
                 builder = builder.with_split_by(SplitBy::RowCount(batch_size));
             }
 
-            Ok::<_, VortexError>(ArrayStreamExt::boxed(
-                builder.spawn_tokio(TOKIO_RUNTIME.handle().clone())?,
-            ))
+            Ok::<_, VortexError>(ArrayStreamExt::boxed(builder.into_array_stream()?))
         })?;
 
         let iter = ArrayStreamToIterator::new(stream);

--- a/pyvortex/src/file.rs
+++ b/pyvortex/src/file.rs
@@ -188,7 +188,6 @@ impl PyVortexFile {
             let mut builder = vxf
                 .scan()?
                 .with_tokio_executor(TOKIO_RUNTIME.handle().clone())
-                .with_canonicalize(true)
                 .with_some_filter(expr.map(|e| e.into_inner()))
                 .with_projection(projection.map(|p| p.0).unwrap_or_else(ident));
 
@@ -196,6 +195,7 @@ impl PyVortexFile {
                 builder = builder.with_split_by(SplitBy::RowCount(batch_size));
             }
 
+            // TODO(ngates): use ScanBuilder::map_to_record_batch
             Ok::<_, VortexError>(ArrayStreamExt::boxed(builder.into_array_stream()?))
         })?;
 

--- a/vortex-array/src/compute/to_arrow.rs
+++ b/vortex-array/src/compute/to_arrow.rs
@@ -2,9 +2,8 @@ use arrow_array::{Array as ArrowArray, ArrayRef as ArrowArrayRef};
 use arrow_schema::DataType;
 use vortex_error::{VortexExpect, VortexResult, vortex_err};
 
-use crate::Array;
-use crate::builders::builder_with_capacity;
 use crate::encoding::Encoding;
+use crate::{Array, IntoArray};
 
 /// Trait for Arrow conversion compute function.
 pub trait ToArrowFn<A> {
@@ -83,9 +82,7 @@ pub fn to_arrow(array: &dyn Array, data_type: &DataType) -> VortexResult<ArrowAr
     }
 
     // Fall back to canonicalizing and then converting.
-    let mut builder = builder_with_capacity(array.dtype(), array.len());
-    array.append_to_builder(builder.as_mut())?;
-    let canonical_array = builder.finish();
+    let canonical_array = array.to_canonical()?.into_array();
     let arrow_array = canonical_array
         .vtable()
         .to_arrow_fn()

--- a/vortex-datafusion/Cargo.toml
+++ b/vortex-datafusion/Cargo.toml
@@ -44,7 +44,7 @@ vortex-error = { workspace = true, features = ["datafusion"] }
 vortex-expr = { workspace = true, features = ["datafusion"] }
 vortex-file = { workspace = true, features = ["object_store", "tokio"] }
 vortex-io = { workspace = true, features = ["object_store", "tokio"] }
-vortex-layout = { workspace = true }
+vortex-layout = { workspace = true, features = ["tokio"] }
 vortex-metrics = { workspace = true }
 
 [features]

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -6,7 +6,6 @@ use datafusion_common::Result as DFResult;
 use futures::{FutureExt as _, StreamExt, TryStreamExt};
 use object_store::ObjectStore;
 use tokio::runtime::Handle;
-use vortex_array::ToCanonical;
 use vortex_error::VortexError;
 use vortex_expr::{ExprRef, VortexExpr};
 use vortex_layout::scan::SplitBy;
@@ -59,12 +58,11 @@ impl FileOpener for VortexFileOpener {
         let batch_size = self.batch_size;
 
         Ok(async move {
-            let projected_arrow_schema = projected_arrow_schema.clone();
-
             Ok(file_cache
                 .try_get(&file_meta.object_meta, object_store)
                 .await?
                 .scan()?
+                .with_tokio_executor(Handle::current())
                 .with_metrics(metrics)
                 .with_projection(projection)
                 .with_some_filter(filter)
@@ -72,11 +70,8 @@ impl FileOpener for VortexFileOpener {
                 // but at the moment our scanner has too much overhead to process small
                 // batches efficiently.
                 .with_split_by(SplitBy::RowCount(8 * batch_size))
-                .map(move |array| {
-                    let st = array.to_struct()?;
-                    st.into_record_batch_with_schema(projected_arrow_schema.as_ref())
-                })
-                .spawn_tokio(Handle::current())?
+                .map_to_record_batch(projected_arrow_schema.clone())
+                .into_stream()?
                 .map_err(|e: VortexError| ArrowError::from(e))
                 .boxed())
         }

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
-use arrow_schema::SchemaRef;
+use arrow_schema::{ArrowError, SchemaRef};
 use datafusion::datasource::physical_plan::{FileMeta, FileOpenFuture, FileOpener};
 use datafusion_common::Result as DFResult;
-use futures::{FutureExt as _, StreamExt};
+use futures::{FutureExt as _, StreamExt, TryStreamExt};
 use object_store::ObjectStore;
 use tokio::runtime::Handle;
 use vortex_array::ToCanonical;
+use vortex_error::VortexError;
 use vortex_expr::{ExprRef, VortexExpr};
 use vortex_layout::scan::SplitBy;
 use vortex_metrics::VortexMetrics;
@@ -58,6 +59,8 @@ impl FileOpener for VortexFileOpener {
         let batch_size = self.batch_size;
 
         Ok(async move {
+            let projected_arrow_schema = projected_arrow_schema.clone();
+
             Ok(file_cache
                 .try_get(&file_meta.object_meta, object_store)
                 .await?
@@ -65,16 +68,16 @@ impl FileOpener for VortexFileOpener {
                 .with_metrics(metrics)
                 .with_projection(projection)
                 .with_some_filter(filter)
-                .with_canonicalize(true)
                 // DataFusion likes ~8k row batches. Ideally we would respect the config,
                 // but at the moment our scanner has too much overhead to process small
                 // batches efficiently.
                 .with_split_by(SplitBy::RowCount(8 * batch_size))
-                .spawn_tokio(Handle::current())?
                 .map(move |array| {
-                    let st = array?.to_struct()?;
-                    Ok(st.into_record_batch_with_schema(projected_arrow_schema.as_ref())?)
+                    let st = array.to_struct()?;
+                    st.into_record_batch_with_schema(projected_arrow_schema.as_ref())
                 })
+                .spawn_tokio(Handle::current())?
+                .map_err(|e: VortexError| ArrowError::from(e))
                 .boxed())
         }
         .boxed())

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -4,6 +4,7 @@
 //! data from the file, and initiating scans to read the file's contents into memory as Vortex arrays.
 use std::sync::Arc;
 
+use vortex_array::ArrayRef;
 use vortex_array::stats::StatsSet;
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
@@ -75,7 +76,7 @@ impl VortexFile {
     }
 
     /// Initiate a scan of the file, returning a builder for configuring the scan.
-    pub fn scan(&self) -> VortexResult<ScanBuilder> {
+    pub fn scan(&self) -> VortexResult<ScanBuilder<ArrayRef>> {
         Ok(ScanBuilder::new(self.layout_reader()?).with_metrics(self.metrics.clone()))
     }
 }

--- a/vortex-jni/src/file.rs
+++ b/vortex-jni/src/file.rs
@@ -165,10 +165,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeFileMethods_scan(
             scan_builder = scan_builder.with_row_indices(indices_buffer);
         }
 
-        // Canonicalize first, to avoid needing to pay decoding cost for every access.
-        let scan = scan_builder.with_canonicalize(true);
-
-        Ok(NativeArrayIterator::new(Box::new(scan.into_array_iter()?)).into_raw())
+        Ok(NativeArrayIterator::new(Box::new(scan_builder.into_array_iter()?)).into_raw())
     })
 }
 

--- a/vortex-layout/Cargo.toml
+++ b/vortex-layout/Cargo.toml
@@ -14,7 +14,9 @@ rust-version = { workspace = true }
 version = { workspace = true }
 
 [dependencies]
+arrow-array = { workspace = true }
 arrow-buffer = { workspace = true }
+arrow-schema = { workspace = true }
 async-trait = { workspace = true }
 bit-vec = { workspace = true }
 bytes = { workspace = true }

--- a/vortex-layout/src/scan/executor.rs
+++ b/vortex-layout/src/scan/executor.rs
@@ -1,0 +1,78 @@
+use std::sync::Arc;
+
+use futures::channel::oneshot;
+use futures::future::BoxFuture;
+use futures::{FutureExt, TryFutureExt};
+use vortex_error::{ResultExt, VortexError, VortexResult, vortex_err};
+
+pub trait TaskExecutor: 'static + Send + Sync {
+    fn do_spawn(
+        &self,
+        fut: BoxFuture<'static, VortexResult<()>>,
+    ) -> BoxFuture<'static, VortexResult<()>>;
+}
+
+impl<T: TaskExecutor> TaskExecutor for Arc<T> {
+    fn do_spawn(
+        &self,
+        fut: BoxFuture<'static, VortexResult<()>>,
+    ) -> BoxFuture<'static, VortexResult<()>> {
+        self.as_ref().do_spawn(fut)
+    }
+}
+
+pub trait TaskExecutorExt: TaskExecutor {
+    fn spawn<T: 'static + Send>(
+        &self,
+        fut: BoxFuture<'static, VortexResult<T>>,
+    ) -> BoxFuture<'static, VortexResult<T>>;
+}
+
+impl<E: TaskExecutor + ?Sized> TaskExecutorExt for E {
+    fn spawn<T: 'static + Send>(
+        &self,
+        fut: BoxFuture<'static, VortexResult<T>>,
+    ) -> BoxFuture<'static, VortexResult<T>> {
+        let (send, recv) = oneshot::channel::<VortexResult<T>>();
+        let fut = self.do_spawn(
+            async move {
+                let result = fut.await;
+                send.send(result)
+                    .map_err(|_| vortex_err!("Failed to send result"))
+            }
+            .boxed(),
+        );
+
+        Box::pin(async move {
+            fut.await?;
+            recv.await
+                .map_err(|canceled| vortex_err!("Spawned task canceled {}", canceled))
+                .unnest()
+        })
+    }
+}
+
+/// A task executor that runs tasks on the polling thread.
+pub struct BlockingTaskExecutor;
+
+impl TaskExecutor for BlockingTaskExecutor {
+    fn do_spawn(
+        &self,
+        fut: BoxFuture<'static, VortexResult<()>>,
+    ) -> BoxFuture<'static, VortexResult<()>> {
+        fut
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl TaskExecutor for tokio::runtime::Handle {
+    fn do_spawn(
+        &self,
+        f: BoxFuture<'static, VortexResult<()>>,
+    ) -> BoxFuture<'static, VortexResult<()>> {
+        tokio::runtime::Handle::spawn(self, f)
+            .map_err(VortexError::from)
+            .map(|result| result.unnest())
+            .boxed()
+    }
+}

--- a/vortex-layout/src/scan/executor.rs
+++ b/vortex-layout/src/scan/executor.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
+use futures::FutureExt;
 use futures::channel::oneshot;
 use futures::future::BoxFuture;
-use futures::{FutureExt, TryFutureExt};
-use vortex_error::{ResultExt, VortexError, VortexResult, vortex_err};
+use vortex_error::{ResultExt, VortexResult, vortex_err};
 
 pub trait TaskExecutor: 'static + Send + Sync {
     fn do_spawn(
@@ -70,8 +70,10 @@ impl TaskExecutor for tokio::runtime::Handle {
         &self,
         f: BoxFuture<'static, VortexResult<()>>,
     ) -> BoxFuture<'static, VortexResult<()>> {
+        use futures::TryFutureExt;
+
         tokio::runtime::Handle::spawn(self, f)
-            .map_err(VortexError::from)
+            .map_err(vortex_error::VortexError::from)
             .map(|result| result.unnest())
             .boxed()
     }

--- a/vortex-layout/src/scan/executor.rs
+++ b/vortex-layout/src/scan/executor.rs
@@ -52,18 +52,6 @@ impl<E: TaskExecutor + ?Sized> TaskExecutorExt for E {
     }
 }
 
-/// A task executor that runs tasks on the polling thread.
-pub struct BlockingTaskExecutor;
-
-impl TaskExecutor for BlockingTaskExecutor {
-    fn do_spawn(
-        &self,
-        fut: BoxFuture<'static, VortexResult<()>>,
-    ) -> BoxFuture<'static, VortexResult<()>> {
-        fut
-    }
-}
-
 #[cfg(feature = "tokio")]
 impl TaskExecutor for tokio::runtime::Handle {
     fn do_spawn(

--- a/vortex-layout/src/scan/mod.rs
+++ b/vortex-layout/src/scan/mod.rs
@@ -2,16 +2,18 @@ use std::iter;
 use std::ops::Range;
 use std::sync::Arc;
 
+use arrow_array::RecordBatch;
+use arrow_schema::SchemaRef;
+pub use executor::*;
 use futures::executor::LocalPool;
-use futures::future::BoxFuture;
 use futures::task::LocalSpawnExt;
-use futures::{FutureExt, Stream, StreamExt, stream};
+use futures::{Stream, StreamExt, stream};
 use itertools::Itertools;
 pub use selection::*;
 pub use split_by::*;
-use vortex_array::ArrayRef;
 use vortex_array::iter::{ArrayIterator, ArrayIteratorAdapter};
 use vortex_array::stream::{ArrayStream, ArrayStreamAdapter};
+use vortex_array::{ArrayRef, ToCanonical};
 use vortex_buffer::Buffer;
 use vortex_dtype::{DType, Field, FieldMask, FieldName, FieldPath};
 use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_err};
@@ -22,7 +24,7 @@ use vortex_metrics::{VortexMetrics, instrument};
 
 use crate::layouts::filter::FilterLayoutReader;
 use crate::{ExprEvaluator, LayoutReader};
-
+mod executor;
 pub mod row_mask;
 mod selection;
 mod split_by;
@@ -44,10 +46,12 @@ pub struct ScanBuilder<A> {
     concurrency: usize,
     /// Function to apply to each [`ArrayRef`] within the spawned split tasks.
     map_fn: Arc<dyn Fn(ArrayRef) -> VortexResult<A> + Send + Sync>,
+    /// The executor used to spawn each split task.
+    executor: Option<Arc<dyn TaskExecutor>>,
     metrics: VortexMetrics,
 }
 
-impl<A: 'static> ScanBuilder<A> {
+impl<A: 'static + Send> ScanBuilder<A> {
     pub fn with_filter(mut self, filter: ExprRef) -> Self {
         self.filter = Some(filter);
         self
@@ -101,9 +105,40 @@ impl<A: 'static> ScanBuilder<A> {
         self
     }
 
+    /// Spawn each CPU task onto the given Tokio runtime.
+    ///
+    /// Note that this is an odd use of the Tokio runtime. Typically, it is used predominantly
+    /// for I/O bound tasks.
+    #[cfg(feature = "tokio")]
+    pub fn with_tokio_executor(mut self, handle: tokio::runtime::Handle) -> Self {
+        self.executor = Some(Arc::new(handle));
+        self
+    }
+
     pub fn with_metrics(mut self, metrics: VortexMetrics) -> Self {
         self.metrics = metrics;
         self
+    }
+
+    /// Map each split of the scan. The function will be run on the spawned task.
+    pub fn map<B: 'static>(
+        self,
+        map_fn: impl Fn(A) -> VortexResult<B> + 'static + Send + Sync,
+    ) -> ScanBuilder<B> {
+        let old_map_fn = self.map_fn;
+        ScanBuilder {
+            layout_reader: self.layout_reader,
+            projection: self.projection,
+            filter: self.filter,
+            row_range: self.row_range,
+            selection: self.selection,
+            split_by: self.split_by,
+            canonicalize: self.canonicalize,
+            concurrency: self.concurrency,
+            map_fn: Arc::new(move |a| map_fn(old_map_fn(a)?)),
+            executor: self.executor,
+            metrics: self.metrics,
+        }
     }
 
     /// Returns the output [`DType`] of the scan.
@@ -210,47 +245,19 @@ impl<A: 'static> ScanBuilder<A> {
                     Ok(Some(array))
                 }))
             })
+            .map_ok(|task| match &self.executor {
+                None => Box::pin(task),
+                Some(executor) => executor.spawn(Box::pin(task)),
+            })
             .try_collect()
     }
 
-    /// Returns a stream over the scan with each CPU task spawned using the given spawn function.
-    fn spawn_on<F, S>(
-        self,
-        mut spawner: S,
-    ) -> VortexResult<impl Stream<Item = VortexResult<A>> + 'static>
-    where
-        F: Future<Output = VortexResult<Option<A>>>,
-        S: FnMut(BoxFuture<'static, VortexResult<Option<A>>>) -> F + 'static,
-    {
+    /// Returns a stream over the scan objects.
+    pub fn into_stream(self) -> VortexResult<impl Stream<Item = VortexResult<A>> + 'static> {
         let concurrency = self.concurrency;
-        let tasks = self.build()?;
-
-        Ok(stream::iter(tasks)
-            .map(move |task| spawner(task.boxed()))
+        Ok(stream::iter(self.build()?)
             .buffered(concurrency)
-            .filter_map(|v| async move { v.transpose() }))
-    }
-}
-
-impl<A: 'static + Send> ScanBuilder<A> {
-    /// Returns a stream over the scan with each CPU task spawned onto the given Tokio runtime
-    /// using [`tokio::runtime::Handle::spawn`].
-    ///
-    /// Note that this should only be used if the Tokio runtime is dedicated to CPU-bound tasks.
-    #[cfg(feature = "tokio")]
-    pub fn spawn_tokio(
-        self,
-        handle: tokio::runtime::Handle,
-    ) -> VortexResult<impl Stream<Item = VortexResult<A>> + 'static> {
-        self.spawn_on(move |task| {
-            let handle = handle.clone();
-            async move {
-                handle
-                    .spawn(task)
-                    .await
-                    .vortex_expect("Failed to join task")
-            }
-        })
+            .filter_map(|r| async move { r.transpose() }))
     }
 }
 
@@ -268,57 +275,52 @@ impl ScanBuilder<ArrayRef> {
             // that is decided by the TaskExecutor).
             concurrency: 16,
             map_fn: Arc::new(Ok),
+            executor: None,
             metrics: Default::default(),
         }
     }
 
-    /// Map each split of the scan. The function will be run on the spawned task.
-    pub fn map<A: 'static>(
-        self,
-        map_fn: impl Fn(ArrayRef) -> VortexResult<A> + 'static + Send + Sync,
-    ) -> ScanBuilder<A> {
-        ScanBuilder {
-            layout_reader: self.layout_reader,
-            projection: self.projection,
-            filter: self.filter,
-            row_range: self.row_range,
-            selection: self.selection,
-            split_by: self.split_by,
-            canonicalize: self.canonicalize,
-            concurrency: self.concurrency,
-            map_fn: Arc::new(map_fn),
-            metrics: self.metrics,
-        }
+    /// Map the scan into a stream of Arrow [`RecordBatch`].
+    pub fn map_to_record_batch(self, schema: SchemaRef) -> ScanBuilder<RecordBatch> {
+        self.map(move |array| {
+            let st = array.to_struct()?;
+            st.into_record_batch_with_schema(schema.as_ref())
+        })
     }
 
     /// Returns a stream over the scan with each CPU task polled on the current thread as per
     /// the behaviour of [`futures::stream::Buffered`].
     pub fn into_array_stream(self) -> VortexResult<impl ArrayStream + 'static> {
         let dtype = self.dtype()?;
-        let stream = self.spawn_on(|task| task)?;
+        let stream = self.into_stream()?;
         Ok(ArrayStreamAdapter::new(dtype, stream))
     }
 
     /// Returns a blocking iterator over the scan.
     ///
     /// All work will be performed on the current thread, with tasks interleaved per the
-    /// configured concurrency.
+    /// configured concurrency. Any configured executor will be ignored.
     pub fn into_array_iter(self) -> VortexResult<impl ArrayIterator + 'static> {
         let dtype = self.dtype()?;
+        let concurrency = self.concurrency;
 
         let mut local_pool = LocalPool::new();
         let spawner = local_pool.spawner();
-        let array_stream = self.spawn_on(move |task| {
-            spawner
-                .spawn_local_with_handle(task)
-                .map_err(|e| vortex_err!("Failed to spawn task: {e}"))
-                .vortex_expect("Failed to spawn task")
-        })?;
 
-        let mut array_stream = Box::pin(array_stream);
+        let mut stream = stream::iter(self.build()?)
+            .map(move |task| {
+                spawner
+                    .spawn_local_with_handle(task)
+                    .map_err(|e| vortex_err!("Failed to spawn task: {e}"))
+                    .vortex_expect("Failed to spawn task")
+            })
+            .buffered(concurrency)
+            .filter_map(|a| async move { a.transpose() })
+            .boxed_local();
+
         Ok(ArrayIteratorAdapter::new(
             dtype,
-            iter::from_fn(move || local_pool.run_until(array_stream.next())),
+            iter::from_fn(move || local_pool.run_until(stream.next())),
         ))
     }
 }

--- a/vortex-layout/src/scan/mod.rs
+++ b/vortex-layout/src/scan/mod.rs
@@ -5,14 +5,13 @@ use std::sync::Arc;
 use futures::executor::LocalPool;
 use futures::future::BoxFuture;
 use futures::task::LocalSpawnExt;
-use futures::{FutureExt, StreamExt, stream};
+use futures::{FutureExt, Stream, StreamExt, stream};
 use itertools::Itertools;
 pub use selection::*;
 pub use split_by::*;
-use vortex_array::builders::builder_with_capacity;
+use vortex_array::ArrayRef;
 use vortex_array::iter::{ArrayIterator, ArrayIteratorAdapter};
 use vortex_array::stream::{ArrayStream, ArrayStreamAdapter};
-use vortex_array::{Array, ArrayRef};
 use vortex_buffer::Buffer;
 use vortex_dtype::{DType, Field, FieldMask, FieldName, FieldPath};
 use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_err};
@@ -29,7 +28,7 @@ mod selection;
 mod split_by;
 
 /// A struct for building a scan operation.
-pub struct ScanBuilder {
+pub struct ScanBuilder<A> {
     layout_reader: Arc<dyn LayoutReader>,
     projection: ExprRef,
     filter: Option<ExprRef>,
@@ -43,26 +42,12 @@ pub struct ScanBuilder {
     canonicalize: bool,
     /// The number of splits to make progress on concurrently.
     concurrency: usize,
+    /// Function to apply to each [`ArrayRef`] within the spawned split tasks.
+    map_fn: Arc<dyn Fn(ArrayRef) -> VortexResult<A> + Send + Sync>,
     metrics: VortexMetrics,
 }
 
-impl ScanBuilder {
-    pub fn new(layout_reader: Arc<dyn LayoutReader>) -> Self {
-        Self {
-            layout_reader,
-            projection: Identity::new_expr(),
-            filter: None,
-            row_range: None,
-            selection: Default::default(),
-            split_by: SplitBy::Layout,
-            canonicalize: false,
-            // How many row splits to make progress on concurrently (not necessarily in parallel,
-            // that is decided by the TaskExecutor).
-            concurrency: 16,
-            metrics: Default::default(),
-        }
-    }
-
+impl<A: 'static> ScanBuilder<A> {
     pub fn with_filter(mut self, filter: ExprRef) -> Self {
         self.filter = Some(filter);
         self
@@ -121,10 +106,14 @@ impl ScanBuilder {
         self
     }
 
+    /// Returns the output [`DType`] of the scan.
+    pub fn dtype(&self) -> VortexResult<DType> {
+        self.projection.return_dtype(self.layout_reader.dtype())
+    }
+
+    /// Constructs a task per row split of the scan, returned as a vector of futures.
     #[allow(clippy::unused_enumerate_index)]
-    fn build_tasks(
-        self,
-    ) -> VortexResult<Vec<impl Future<Output = VortexResult<Option<ArrayRef>>>>> {
+    pub fn build(self) -> VortexResult<Vec<impl Future<Output = VortexResult<Option<A>>>>> {
         // Spin up the root layout reader, and wrap it in a FilterLayoutReader to perform
         // conjunction splitting if a filter is provided.
         let mut layout_reader = self.layout_reader;
@@ -186,6 +175,7 @@ impl ScanBuilder {
                     .map(|expr| layout_reader.filter_evaluation(&row_range, expr))
                     .transpose()?;
                 let project_eval = layout_reader.projection_evaluation(&row_range, &projection)?;
+                let map_fn = self.map_fn.clone();
 
                 Ok::<_, VortexError>(instrument!("split", [split = _i], async move {
                     let mut mask = row_mask.mask().clone();
@@ -212,13 +202,10 @@ impl ScanBuilder {
                     }
 
                     log::debug!("Projecting row range {:?}", row_range);
-                    let mut array = project_eval.invoke(mask).await?;
-                    if self.canonicalize {
-                        log::debug!("Canonicalizing row range {:?}", row_range);
-                        let mut builder = builder_with_capacity(array.dtype(), array.len());
-                        array.append_to_builder(builder.as_mut())?;
-                        array = builder.finish();
-                    }
+                    let array = project_eval.invoke(mask).await?;
+
+                    log::debug!("Mapping row range {:?}", row_range);
+                    let array = (map_fn)(array.clone())?;
 
                     Ok(Some(array))
                 }))
@@ -227,26 +214,25 @@ impl ScanBuilder {
     }
 
     /// Returns a stream over the scan with each CPU task spawned using the given spawn function.
-    pub fn spawn_on<F, S>(self, mut spawner: S) -> VortexResult<impl ArrayStream + 'static>
+    fn spawn_on<F, S>(
+        self,
+        mut spawner: S,
+    ) -> VortexResult<impl Stream<Item = VortexResult<A>> + 'static>
     where
-        F: Future<Output = VortexResult<Option<ArrayRef>>>,
-        S: FnMut(BoxFuture<'static, VortexResult<Option<ArrayRef>>>) -> F + 'static,
+        F: Future<Output = VortexResult<Option<A>>>,
+        S: FnMut(BoxFuture<'static, VortexResult<Option<A>>>) -> F + 'static,
     {
         let concurrency = self.concurrency;
-        let dtype = self.projection.return_dtype(self.layout_reader.dtype())?;
-        let tasks = self.build_tasks()?;
+        let tasks = self.build()?;
 
-        let array_stream = stream::iter(tasks)
+        Ok(stream::iter(tasks)
             .map(move |task| spawner(task.boxed()))
             .buffered(concurrency)
-            .filter_map(|v| async move { v.transpose() });
-
-        Ok(ArrayStreamAdapter::new(
-            dtype,
-            instrument!("array_stream", array_stream),
-        ))
+            .filter_map(|v| async move { v.transpose() }))
     }
+}
 
+impl<A: 'static + Send> ScanBuilder<A> {
     /// Returns a stream over the scan with each CPU task spawned onto the given Tokio runtime
     /// using [`tokio::runtime::Handle::spawn`].
     ///
@@ -255,7 +241,7 @@ impl ScanBuilder {
     pub fn spawn_tokio(
         self,
         handle: tokio::runtime::Handle,
-    ) -> VortexResult<impl ArrayStream + 'static> {
+    ) -> VortexResult<impl Stream<Item = VortexResult<A>> + 'static> {
         self.spawn_on(move |task| {
             let handle = handle.clone();
             async move {
@@ -266,29 +252,51 @@ impl ScanBuilder {
             }
         })
     }
+}
 
-    /// Returns a stream over the scan with each CPU task spawned onto a Tokio worker thread
-    /// using [`tokio::runtime::Handle::spawn_blocking`].
-    #[cfg(feature = "tokio")]
-    pub fn spawn_tokio_blocking(
+impl ScanBuilder<ArrayRef> {
+    pub fn new(layout_reader: Arc<dyn LayoutReader>) -> Self {
+        Self {
+            layout_reader,
+            projection: Identity::new_expr(),
+            filter: None,
+            row_range: None,
+            selection: Default::default(),
+            split_by: SplitBy::Layout,
+            canonicalize: false,
+            // How many row splits to make progress on concurrently (not necessarily in parallel,
+            // that is decided by the TaskExecutor).
+            concurrency: 16,
+            map_fn: Arc::new(Ok),
+            metrics: Default::default(),
+        }
+    }
+
+    /// Map each split of the scan. The function will be run on the spawned task.
+    pub fn map<A: 'static>(
         self,
-        handle: tokio::runtime::Handle,
-    ) -> VortexResult<impl ArrayStream + 'static> {
-        self.spawn_on(move |task| {
-            let handle = handle.clone();
-            async move {
-                handle
-                    .spawn_blocking(|| futures::executor::block_on(task))
-                    .await
-                    .vortex_expect("Failed to join task")
-            }
-        })
+        map_fn: impl Fn(ArrayRef) -> VortexResult<A> + 'static + Send + Sync,
+    ) -> ScanBuilder<A> {
+        ScanBuilder {
+            layout_reader: self.layout_reader,
+            projection: self.projection,
+            filter: self.filter,
+            row_range: self.row_range,
+            selection: self.selection,
+            split_by: self.split_by,
+            canonicalize: self.canonicalize,
+            concurrency: self.concurrency,
+            map_fn: Arc::new(map_fn),
+            metrics: self.metrics,
+        }
     }
 
     /// Returns a stream over the scan with each CPU task polled on the current thread as per
     /// the behaviour of [`futures::stream::Buffered`].
     pub fn into_array_stream(self) -> VortexResult<impl ArrayStream + 'static> {
-        self.spawn_on(|task| task)
+        let dtype = self.dtype()?;
+        let stream = self.spawn_on(|task| task)?;
+        Ok(ArrayStreamAdapter::new(dtype, stream))
     }
 
     /// Returns a blocking iterator over the scan.
@@ -296,6 +304,8 @@ impl ScanBuilder {
     /// All work will be performed on the current thread, with tasks interleaved per the
     /// configured concurrency.
     pub fn into_array_iter(self) -> VortexResult<impl ArrayIterator + 'static> {
+        let dtype = self.dtype()?;
+
         let mut local_pool = LocalPool::new();
         let spawner = local_pool.spawner();
         let array_stream = self.spawn_on(move |task| {
@@ -307,7 +317,7 @@ impl ScanBuilder {
 
         let mut array_stream = Box::pin(array_stream);
         Ok(ArrayIteratorAdapter::new(
-            array_stream.dtype().clone(),
+            dtype,
             iter::from_fn(move || local_pool.run_until(array_stream.next())),
         ))
     }

--- a/vortex-layout/src/scan/mod.rs
+++ b/vortex-layout/src/scan/mod.rs
@@ -40,8 +40,6 @@ pub struct ScanBuilder<A> {
     selection: Selection,
     /// How to split the file for concurrent processing.
     split_by: SplitBy,
-    /// Whether the arrays returned by the scan should be in canonical form.
-    canonicalize: bool,
     /// The number of splits to make progress on concurrently.
     concurrency: usize,
     /// Function to apply to each [`ArrayRef`] within the spawned split tasks.
@@ -92,12 +90,6 @@ impl<A: 'static + Send> ScanBuilder<A> {
         self
     }
 
-    /// Set whether the scan should canonicalize the output.
-    pub fn with_canonicalize(mut self, canonicalize: bool) -> Self {
-        self.canonicalize = canonicalize;
-        self
-    }
-
     /// The number of row splits to make progress on concurrently, must be greater than 0.
     pub fn with_concurrency(mut self, concurrency: usize) -> Self {
         assert!(concurrency > 0);
@@ -133,7 +125,6 @@ impl<A: 'static + Send> ScanBuilder<A> {
             row_range: self.row_range,
             selection: self.selection,
             split_by: self.split_by,
-            canonicalize: self.canonicalize,
             concurrency: self.concurrency,
             map_fn: Arc::new(move |a| map_fn(old_map_fn(a)?)),
             executor: self.executor,
@@ -270,7 +261,6 @@ impl ScanBuilder<ArrayRef> {
             row_range: None,
             selection: Default::default(),
             split_by: SplitBy::Layout,
-            canonicalize: false,
             // How many row splits to make progress on concurrently (not necessarily in parallel,
             // that is decided by the TaskExecutor).
             concurrency: 16,

--- a/vortex-tui/src/tree.rs
+++ b/vortex-tui/src/tree.rs
@@ -14,7 +14,8 @@ pub async fn exec_tree(file: impl AsRef<Path>) -> VortexResult<()> {
         .open(opened)
         .await?
         .scan()?
-        .spawn_tokio(TOKIO_RUNTIME.handle().clone())?
+        .with_tokio_executor(TOKIO_RUNTIME.handle().clone())
+        .into_array_stream()?
         .read_all()
         .await?;
 


### PR DESCRIPTION
* Task executor is wrapped up inside the ScanBuilder
* It's possible to map elements of the scan _within_ the spawned tasks (instead of the user having to re-spawn, which is easy to forget to do, as we did!)

FLUP: add a stream ext to buffer_with_ordered(bool), so e.g. datafusion can support out-of-order reads