### PR TITLE
Prevent compression from converging into low-quality compressions

### DIFF
--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -173,7 +173,7 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
                 let compressed = BtrBlocksCompressor.compress_canonical(canonical_chunk)?;
 
                 if compressed.is_canonical()
-                    || ((canonical_size / compressed.nbytes() as f64) < 1.2)
+                    || ((canonical_size / compressed.nbytes() as f64) < COMPRESSION_DRIFT_THRESHOLD)
                 {
                     self.previous_chunk = None;
                 } else {

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -147,12 +147,12 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
                 let ratio = canonical_nbytes as f64 / encoded_chunk.nbytes() as f64;
 
                 // Make sure the ratio is within the expected drift, if it isn't we  fall back to the compressor.
-                if ratio > prev_compression.ratio / COMPRESSION_DRIFT_THRESHOLD {
+                if ratio > (prev_compression.ratio / COMPRESSION_DRIFT_THRESHOLD) {
                     Some(encoded_chunk)
                 } else {
                     log::trace!(
                         "Compressed to a ratio of {ratio}, which is below the threshold of {}",
-                        prev_compression.ratio * COMPRESSION_DRIFT_THRESHOLD
+                        prev_compression.ratio / COMPRESSION_DRIFT_THRESHOLD
                     );
                     None
                 }
@@ -171,10 +171,18 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
                 let canonical_chunk = chunk.to_canonical()?;
                 let canonical_size = canonical_chunk.as_ref().nbytes() as f64;
                 let compressed = BtrBlocksCompressor.compress_canonical(canonical_chunk)?;
-                self.previous_chunk = Some(PreviousCompression {
-                    chunk: compressed.clone(),
-                    ratio: canonical_size / compressed.nbytes() as f64,
-                });
+
+                if compressed.is_canonical()
+                    || (canonical_size / compressed.nbytes() as f64 > COMPRESSION_DRIFT_THRESHOLD)
+                {
+                    self.previous_chunk = None;
+                } else {
+                    self.previous_chunk = Some(PreviousCompression {
+                        chunk: compressed.clone(),
+                        ratio: canonical_size / compressed.nbytes() as f64,
+                    });
+                }
+
                 compressed
             }
         };

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -173,7 +173,7 @@ impl LayoutWriter for BtrBlocksCompressedWriter {
                 let compressed = BtrBlocksCompressor.compress_canonical(canonical_chunk)?;
 
                 if compressed.is_canonical()
-                    || (canonical_size / compressed.nbytes() as f64 > COMPRESSION_DRIFT_THRESHOLD)
+                    || ((canonical_size / compressed.nbytes() as f64) < 1.2)
                 {
                     self.previous_chunk = None;
                 } else {


### PR DESCRIPTION
File size before this change is about 21.18GB, after this change its 19.23GB.

The issue we found is that for large files, we tend to converge into not-compressing, or settling for mediocre compressions. With this change we don't keep  if the encoding is canonical or otherwise non satisfactory, we don't keep that state and try again on the next chunk.
