### PR TITLE
NaN cannot be a min/max value of a primitive array

### DIFF
--- a/encodings/alp/src/alp/compute/compare.rs
+++ b/encodings/alp/src/alp/compute/compare.rs
@@ -78,7 +78,7 @@ where
             Operator::Gt | Operator::Gte => {
                 // Per IEEE 754 totalOrder semantics the ordering is -Nan < -Inf < Inf < Nan.
                 // All values in the encoded array are definitely finite
-                let is_not_finite = value.is_infinite() || NativePType::is_nan(value);
+                let is_not_finite = NativePType::is_infinite(value) || NativePType::is_nan(value);
                 if is_not_finite {
                     Ok(Some(
                         ConstantArray::new(value.is_sign_negative(), alp.len()).into_array(),
@@ -97,7 +97,7 @@ where
             Operator::Lt | Operator::Lte => {
                 // Per IEEE 754 totalOrder semantics the ordering is -Nan < -Inf < Inf < Nan.
                 // All values in the encoded array are definitely finite
-                let is_not_finite = value.is_infinite() || NativePType::is_nan(value);
+                let is_not_finite = NativePType::is_infinite(value) || NativePType::is_nan(value);
                 if is_not_finite {
                     Ok(Some(
                         ConstantArray::new(value.is_sign_positive(), alp.len()).into_array(),

--- a/vortex-array/src/arrays/primitive/compute/min_max.rs
+++ b/vortex-array/src/arrays/primitive/compute/min_max.rs
@@ -72,7 +72,7 @@ mod tests {
     #[test]
     fn min_max_nan() {
         let array = PrimitiveArray::new(
-            buffer![f32::NAN, -1.0 / 0.0, -1.0, 1.0],
+            buffer![f32::NAN, -f32::NAN, -1.0, 1.0],
             Validity::NonNullable,
         );
         let min_max = min_max(&array).unwrap().unwrap();
@@ -87,7 +87,7 @@ mod tests {
             Validity::NonNullable,
         );
         let min_max = min_max(&array).unwrap().unwrap();
-        assert_eq!(f32::try_from(min_max.min).unwrap(), -1.0);
-        assert_eq!(f32::try_from(min_max.max).unwrap(), 1.0);
+        assert_eq!(f32::try_from(min_max.min).unwrap(), f32::NEG_INFINITY);
+        assert_eq!(f32::try_from(min_max.max).unwrap(), f32::INFINITY);
     }
 }

--- a/vortex-array/src/arrays/primitive/compute/min_max.rs
+++ b/vortex-array/src/arrays/primitive/compute/min_max.rs
@@ -38,10 +38,13 @@ where
 
 fn compute_min_max<'a, T>(iter: impl Iterator<Item = &'a T>, dtype: &DType) -> Option<MinMaxResult>
 where
-    T: Into<ScalarValue> + NativePType + Copy,
+    T: Into<ScalarValue> + NativePType,
 {
     // this `compare` function provides a total ordering (even for NaN values)
-    match iter.minmax_by(|a, b| a.total_compare(**b)) {
+    match iter
+        .filter(|v| !v.is_nan() && !v.is_infinite())
+        .minmax_by(|a, b| a.total_compare(**b))
+    {
         itertools::MinMaxResult::NoElements => None,
         itertools::MinMaxResult::OneElement(&x) => {
             let scalar = Scalar::new(dtype.clone(), x.into());
@@ -54,5 +57,36 @@ where
             min: Scalar::new(dtype.clone(), min.into()),
             max: Scalar::new(dtype.clone(), max.into()),
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_buffer::buffer;
+
+    use crate::arrays::PrimitiveArray;
+    use crate::compute::min_max;
+    use crate::validity::Validity;
+
+    #[test]
+    fn min_max_nan() {
+        let array = PrimitiveArray::new(
+            buffer![f32::NAN, -1.0 / 0.0, -1.0, 1.0],
+            Validity::NonNullable,
+        );
+        let min_max = min_max(&array).unwrap().unwrap();
+        assert_eq!(f32::try_from(min_max.min).unwrap(), -1.0);
+        assert_eq!(f32::try_from(min_max.max).unwrap(), 1.0);
+    }
+
+    #[test]
+    fn min_max_inf() {
+        let array = PrimitiveArray::new(
+            buffer![f32::INFINITY, f32::NEG_INFINITY, -1.0, 1.0],
+            Validity::NonNullable,
+        );
+        let min_max = min_max(&array).unwrap().unwrap();
+        assert_eq!(f32::try_from(min_max.min).unwrap(), -1.0);
+        assert_eq!(f32::try_from(min_max.max).unwrap(), 1.0);
     }
 }

--- a/vortex-array/src/arrays/primitive/compute/min_max.rs
+++ b/vortex-array/src/arrays/primitive/compute/min_max.rs
@@ -40,9 +40,10 @@ fn compute_min_max<'a, T>(iter: impl Iterator<Item = &'a T>, dtype: &DType) -> O
 where
     T: Into<ScalarValue> + NativePType,
 {
-    // this `compare` function provides a total ordering (even for NaN values)
+    // `total_compare` function provides a total ordering (even for NaN values).
+    // However, we exclude NaNs from min max as they're not useful for any purpose where min/max would be used
     match iter
-        .filter(|v| !v.is_nan() && !v.is_infinite())
+        .filter(|v| !v.is_nan())
         .minmax_by(|a, b| a.total_compare(**b))
     {
         itertools::MinMaxResult::NoElements => None,

--- a/vortex-dtype/src/ptype.rs
+++ b/vortex-dtype/src/ptype.rs
@@ -80,6 +80,10 @@ pub trait NativePType:
     /// For integer types, this is always `false`
     fn is_nan(self) -> bool;
 
+    /// Whether this instance (`self`) is Infinite
+    /// For integer types, this is always `false`
+    fn is_infinite(self) -> bool;
+
     /// Compare another instance of this type to `self`, providing a total ordering
     fn total_compare(self, other: Self) -> Ordering;
 
@@ -122,6 +126,11 @@ macro_rules! native_ptype {
             }
 
             #[inline]
+            fn is_infinite(self) -> bool {
+                false
+            }
+
+            #[inline]
             fn total_compare(self, other: Self) -> Ordering {
                 self.cmp(&other)
             }
@@ -142,6 +151,11 @@ macro_rules! native_float_ptype {
             #[inline]
             fn is_nan(self) -> bool {
                 <$T>::is_nan(self)
+            }
+
+            #[inline]
+            fn is_infinite(self) -> bool {
+                <$T>::is_infinite(self)
             }
 
             #[inline]


### PR DESCRIPTION
In a followup we will add a stat for nan_count of the array

fixes #1375 
