### PR TITLE
feat: Implement all of the compute fns for DecimalArray

### DIFF
--- a/vortex-array/src/arrays/decimal/compute/between.rs
+++ b/vortex-array/src/arrays/decimal/compute/between.rs
@@ -5,8 +5,8 @@ use vortex_scalar::{DecimalValue, i256};
 
 use crate::arrays::decimal::serde::DecimalValueType;
 use crate::arrays::{BoolArray, DecimalArray, DecimalEncoding, NativeDecimalType};
-use crate::compute::{BetweenKernel, BetweenOptions, StrictComparison};
-use crate::{Array, ArrayRef};
+use crate::compute::{BetweenKernel, BetweenKernelAdapter, BetweenOptions, StrictComparison};
+use crate::{Array, ArrayRef, register_kernel};
 
 impl BetweenKernel for DecimalEncoding {
     // Determine if the values are between the lower and upper bounds
@@ -90,6 +90,8 @@ impl BetweenKernel for DecimalEncoding {
         }
     }
 }
+
+register_kernel!(BetweenKernelAdapter(DecimalEncoding).lift());
 
 fn between_impl<T: NativeDecimalType>(
     arr: &DecimalArray,

--- a/vortex-array/src/arrays/decimal/compute/between.rs
+++ b/vortex-array/src/arrays/decimal/compute/between.rs
@@ -1,0 +1,204 @@
+use arrow_buffer::BooleanBuffer;
+use vortex_dtype::Nullability;
+use vortex_error::{VortexResult, vortex_bail};
+use vortex_scalar::{DecimalValue, i256};
+
+use crate::arrays::decimal::serde::DecimalValueType;
+use crate::arrays::{BoolArray, DecimalArray, DecimalEncoding, NativeDecimalType};
+use crate::compute::{BetweenKernel, BetweenOptions, StrictComparison};
+use crate::{Array, ArrayRef};
+
+impl BetweenKernel for DecimalEncoding {
+    // Determine if the values are between the lower and upper bounds
+    fn between(
+        &self,
+        arr: &DecimalArray,
+        lower: &dyn Array,
+        upper: &dyn Array,
+        options: &BetweenOptions,
+    ) -> VortexResult<Option<ArrayRef>> {
+        // NOTE: We know that the precision and scale were already checked to be equal by the main
+        // `between` entrypoint function.
+
+        let (Some(lower), Some(upper)) = (lower.as_constant(), upper.as_constant()) else {
+            return Ok(None);
+        };
+
+        // NOTE: we know that have checked before that the lower and upper bounds are not all null.
+        let nullability =
+            arr.dtype.nullability() | lower.dtype().nullability() | upper.dtype().nullability();
+
+        match arr.values_type {
+            DecimalValueType::I128 => {
+                let Some(DecimalValue::I128(lower_128)) = *lower.as_decimal().decimal_value()
+                else {
+                    vortex_bail!("invalid lower bound Scalar: {lower}");
+                };
+                let Some(DecimalValue::I128(upper_128)) = *upper.as_decimal().decimal_value()
+                else {
+                    vortex_bail!("invalid upper bound Scalar: {upper}");
+                };
+
+                let lower_op = match options.lower_strict {
+                    StrictComparison::Strict => i128_lt_i128,
+                    StrictComparison::NonStrict => i128_lte_i128,
+                };
+
+                let upper_op = match options.upper_strict {
+                    StrictComparison::Strict => i128_lt_i128,
+                    StrictComparison::NonStrict => i128_lte_i128,
+                };
+
+                Ok(Some(between_impl::<i128>(
+                    arr,
+                    lower_128,
+                    upper_128,
+                    nullability,
+                    lower_op,
+                    upper_op,
+                )))
+            }
+            DecimalValueType::I256 => {
+                let Some(DecimalValue::I256(lower_256)) = *lower.as_decimal().decimal_value()
+                else {
+                    vortex_bail!("invalid lower bound Scalar: {lower}");
+                };
+                let Some(DecimalValue::I256(upper_256)) = *upper.as_decimal().decimal_value()
+                else {
+                    vortex_bail!("invalid upper bound Scalar: {upper}");
+                };
+
+                let lower_op = match options.lower_strict {
+                    StrictComparison::Strict => i256_lt_i256,
+                    StrictComparison::NonStrict => i256_lte_i256,
+                };
+
+                let upper_op = match options.upper_strict {
+                    StrictComparison::Strict => i256_lt_i256,
+                    StrictComparison::NonStrict => i256_lte_i256,
+                };
+
+                Ok(Some(between_impl::<i256>(
+                    arr,
+                    lower_256,
+                    upper_256,
+                    nullability,
+                    lower_op,
+                    upper_op,
+                )))
+            }
+        }
+    }
+}
+
+fn between_impl<T: NativeDecimalType>(
+    arr: &DecimalArray,
+    lower: T,
+    upper: T,
+    nullability: Nullability,
+    lower_op: fn(T, T) -> bool,
+    upper_op: fn(T, T) -> bool,
+) -> ArrayRef {
+    let buffer = arr.buffer::<T>();
+    BoolArray::new(
+        BooleanBuffer::collect_bool(buffer.len(), |idx| {
+            let value = buffer[idx];
+            lower_op(lower, value) & upper_op(value, upper)
+        }),
+        arr.validity().clone().union_nullability(nullability),
+    )
+    .into_array()
+}
+
+#[inline]
+const fn i128_lt_i128(a: i128, b: i128) -> bool {
+    a < b
+}
+
+#[inline]
+const fn i128_lte_i128(a: i128, b: i128) -> bool {
+    a <= b
+}
+
+#[inline]
+fn i256_lt_i256(a: i256, b: i256) -> bool {
+    a < b
+}
+
+#[inline]
+fn i256_lte_i256(a: i256, b: i256) -> bool {
+    a <= b
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_buffer::buffer;
+    use vortex_dtype::{DecimalDType, Nullability};
+    use vortex_scalar::{DecimalValue, Scalar};
+
+    use crate::Array;
+    use crate::arrays::{ConstantArray, DecimalArray};
+    use crate::compute::{BetweenOptions, StrictComparison, between};
+    use crate::validity::Validity;
+
+    #[test]
+    fn test_between() {
+        let values = buffer![100i128, 200i128, 300i128, 400i128];
+        let decimal_type = DecimalDType::new(3, 2);
+        let array = DecimalArray::new(values, decimal_type, Validity::NonNullable);
+
+        let lower = ConstantArray::new(
+            Scalar::decimal(
+                DecimalValue::I128(100i128),
+                decimal_type,
+                Nullability::NonNullable,
+            ),
+            array.len(),
+        );
+        let upper = ConstantArray::new(
+            Scalar::decimal(
+                DecimalValue::I128(400i128),
+                decimal_type,
+                Nullability::NonNullable,
+            ),
+            array.len(),
+        );
+
+        // Strict lower bound, non-strict upper bound
+        let between_strict = between(
+            &array,
+            &lower,
+            &upper,
+            &BetweenOptions {
+                lower_strict: StrictComparison::Strict,
+                upper_strict: StrictComparison::NonStrict,
+            },
+        )
+        .unwrap();
+        assert_eq!(bool_to_vec(&between_strict), vec![false, true, true, true]);
+
+        // Non-strict lower bound, strict upper bound
+        let between_strict = between(
+            &array,
+            &lower,
+            &upper,
+            &BetweenOptions {
+                lower_strict: StrictComparison::NonStrict,
+                upper_strict: StrictComparison::Strict,
+            },
+        )
+        .unwrap();
+        assert_eq!(bool_to_vec(&between_strict), vec![true, true, true, false]);
+    }
+
+    fn bool_to_vec(array: &dyn Array) -> Vec<bool> {
+        array
+            .to_canonical()
+            .unwrap()
+            .into_bool()
+            .unwrap()
+            .boolean_buffer()
+            .iter()
+            .collect()
+    }
+}

--- a/vortex-array/src/arrays/decimal/compute/is_constant.rs
+++ b/vortex-array/src/arrays/decimal/compute/is_constant.rs
@@ -1,0 +1,61 @@
+use vortex_error::VortexResult;
+use vortex_scalar::i256;
+
+use crate::arrays::decimal::serde::DecimalValueType;
+use crate::arrays::{DecimalArray, DecimalEncoding, NativeDecimalType};
+use crate::compute::{IsConstantFn, IsConstantOpts};
+
+impl IsConstantFn<&DecimalArray> for DecimalEncoding {
+    fn is_constant(
+        &self,
+        array: &DecimalArray,
+        _opts: &IsConstantOpts,
+    ) -> VortexResult<Option<bool>> {
+        match array.values_type {
+            DecimalValueType::I128 => Ok(Some(compute_is_constant(&array.buffer::<i128>()))),
+            DecimalValueType::I256 => Ok(Some(compute_is_constant(&array.buffer::<i256>()))),
+        }
+    }
+}
+
+fn compute_is_constant<T: NativeDecimalType>(values: &[T]) -> bool {
+    // We know that the top-level `is_constant` ensures that the array is all_valid or non-null.
+    let first_value = values[0];
+
+    for &value in &values[1..] {
+        if value != first_value {
+            return false;
+        }
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_buffer::buffer;
+    use vortex_dtype::DecimalDType;
+
+    use crate::arrays::DecimalArray;
+    use crate::compute::is_constant;
+    use crate::validity::Validity;
+
+    #[test]
+    fn test_is_constant() {
+        let array = DecimalArray::new(
+            buffer![0i128, 1i128, 2i128],
+            DecimalDType::new(19, 0),
+            Validity::NonNullable,
+        );
+
+        assert!(!is_constant(&array).unwrap());
+
+        let array = DecimalArray::new(
+            buffer![100i128, 100i128, 100i128],
+            DecimalDType::new(19, 0),
+            Validity::NonNullable,
+        );
+
+        assert!(is_constant(&array).unwrap());
+    }
+}

--- a/vortex-array/src/arrays/decimal/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/decimal/compute/is_sorted.rs
@@ -1,0 +1,95 @@
+use vortex_error::VortexResult;
+use vortex_mask::Mask;
+use vortex_scalar::i256;
+
+use crate::Array;
+use crate::arrays::decimal::serde::DecimalValueType;
+use crate::arrays::{DecimalArray, DecimalEncoding, NativeDecimalType};
+use crate::compute::{IsSortedFn, IsSortedIteratorExt};
+
+impl IsSortedFn<&DecimalArray> for DecimalEncoding {
+    fn is_sorted(&self, array: &DecimalArray) -> VortexResult<bool> {
+        match array.values_type {
+            DecimalValueType::I128 => compute_is_sorted::<i128>(array, false),
+            DecimalValueType::I256 => compute_is_sorted::<i256>(array, false),
+        }
+    }
+
+    fn is_strict_sorted(&self, array: &DecimalArray) -> VortexResult<bool> {
+        match array.values_type {
+            DecimalValueType::I128 => compute_is_sorted::<i128>(array, true),
+            DecimalValueType::I256 => compute_is_sorted::<i256>(array, true),
+        }
+    }
+}
+
+fn compute_is_sorted<T: NativeDecimalType>(array: &DecimalArray, strict: bool) -> VortexResult<bool>
+where
+    dyn Iterator<Item = T>: IsSortedIteratorExt,
+{
+    match array.validity_mask()? {
+        Mask::AllFalse(_) => Ok(!strict),
+        Mask::AllTrue(_) => {
+            let buf = array.buffer::<T>();
+            let iter = buf.iter().copied();
+
+            Ok(if strict {
+                IsSortedIteratorExt::is_strict_sorted(iter)
+            } else {
+                iter.is_sorted()
+            })
+        }
+        Mask::Values(mask_values) => {
+            let buf = array.buffer::<T>();
+
+            let iter = mask_values
+                .boolean_buffer()
+                .set_indices()
+                .map(|idx| buf[idx]);
+
+            Ok(if strict {
+                IsSortedIteratorExt::is_strict_sorted(iter)
+            } else {
+                iter.is_sorted()
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_buffer::buffer;
+    use vortex_dtype::DecimalDType;
+
+    use crate::arrays::DecimalArray;
+    use crate::compute::{is_sorted, is_strict_sorted};
+    use crate::validity::Validity;
+
+    #[test]
+    fn test_is_sorted() {
+        let sorted = buffer![100i128, 200i128, 200i128];
+        let unsorted = buffer![200i128, 100i128, 200i128];
+
+        let dtype = DecimalDType::new(19, 2);
+
+        let sorted_array = DecimalArray::new(sorted, dtype, Validity::NonNullable);
+        let unsorted_array = DecimalArray::new(unsorted, dtype, Validity::NonNullable);
+
+        assert!(is_sorted(&sorted_array).unwrap());
+        assert!(!is_sorted(&unsorted_array).unwrap());
+    }
+
+    #[test]
+    fn test_is_strict_sorted() {
+        let strict_sorted = buffer![100i128, 200i128, 300i128];
+        let sorted = buffer![100i128, 200i128, 200i128];
+
+        let dtype = DecimalDType::new(19, 2);
+
+        let strict_sorted_array = DecimalArray::new(strict_sorted, dtype, Validity::NonNullable);
+        let sorted_array = DecimalArray::new(sorted, dtype, Validity::NonNullable);
+
+        assert!(is_strict_sorted(&strict_sorted_array).unwrap());
+        assert!(!is_strict_sorted(&sorted_array).unwrap());
+    }
+}

--- a/vortex-array/src/arrays/decimal/compute/mod.rs
+++ b/vortex-array/src/arrays/decimal/compute/mod.rs
@@ -10,7 +10,7 @@ mod to_arrow;
 
 use crate::Array;
 use crate::arrays::DecimalEncoding;
-use crate::compute::{IsConstantFn, IsSortedFn, ScalarAtFn, SliceFn, SumFn, TakeFn, ToArrowFn};
+use crate::compute::{IsConstantFn, IsSortedFn, ScalarAtFn, SliceFn, TakeFn, ToArrowFn};
 use crate::vtable::ComputeVTable;
 
 impl ComputeVTable for DecimalEncoding {

--- a/vortex-array/src/arrays/decimal/compute/mod.rs
+++ b/vortex-array/src/arrays/decimal/compute/mod.rs
@@ -5,10 +5,12 @@ mod is_sorted;
 mod scalar_at;
 mod slice;
 mod sum;
+mod take;
 
 use crate::arrays::{DecimalArray, DecimalEncoding};
 use crate::compute::{
-    BetweenFn, FilterKernelAdapter, IsConstantFn, IsSortedFn, KernelRef, ScalarAtFn, SliceFn, SumFn,
+    BetweenFn, FilterKernelAdapter, IsConstantFn, IsSortedFn, KernelRef, ScalarAtFn, SliceFn,
+    SumFn, TakeFn,
 };
 use crate::vtable::ComputeVTable;
 use crate::{Array, ArrayComputeImpl};
@@ -42,6 +44,7 @@ impl ComputeVTable for DecimalEncoding {
         Some(self)
     }
 
-    // TODO(aduffy): BinaryNumericFn
-    // TODO(aduffy): TakeFn
+    fn take_fn(&self) -> Option<&dyn TakeFn<&dyn Array>> {
+        Some(self)
+    }
 }

--- a/vortex-array/src/arrays/decimal/compute/mod.rs
+++ b/vortex-array/src/arrays/decimal/compute/mod.rs
@@ -1,10 +1,11 @@
+mod between;
 mod filter;
 mod scalar_at;
 mod slice;
 mod sum;
 
 use crate::arrays::{DecimalArray, DecimalEncoding};
-use crate::compute::{FilterKernelAdapter, KernelRef, ScalarAtFn, SliceFn, SumFn};
+use crate::compute::{BetweenFn, FilterKernelAdapter, KernelRef, ScalarAtFn, SliceFn, SumFn};
 use crate::vtable::ComputeVTable;
 use crate::{Array, ArrayComputeImpl};
 
@@ -25,7 +26,10 @@ impl ComputeVTable for DecimalEncoding {
         Some(self)
     }
 
-    // TODO(aduffy): BetweenFn
+    fn between_fn(&self) -> Option<&dyn BetweenFn<&dyn Array>> {
+        Some(self)
+    }
+
     // TODO(aduffy): IsSortedFn
     // TODO(aduffy): SearchSortedFn
     // TODO(aduffy): CompareFn

--- a/vortex-array/src/arrays/decimal/compute/mod.rs
+++ b/vortex-array/src/arrays/decimal/compute/mod.rs
@@ -6,11 +6,12 @@ mod scalar_at;
 mod slice;
 mod sum;
 mod take;
+mod to_arrow;
 
 use crate::arrays::{DecimalArray, DecimalEncoding};
 use crate::compute::{
     BetweenFn, FilterKernelAdapter, IsConstantFn, IsSortedFn, KernelRef, ScalarAtFn, SliceFn,
-    SumFn, TakeFn,
+    SumFn, TakeFn, ToArrowFn,
 };
 use crate::vtable::ComputeVTable;
 use crate::{Array, ArrayComputeImpl};
@@ -45,6 +46,10 @@ impl ComputeVTable for DecimalEncoding {
     }
 
     fn take_fn(&self) -> Option<&dyn TakeFn<&dyn Array>> {
+        Some(self)
+    }
+
+    fn to_arrow_fn(&self) -> Option<&dyn ToArrowFn<&dyn Array>> {
         Some(self)
     }
 }

--- a/vortex-array/src/arrays/decimal/compute/mod.rs
+++ b/vortex-array/src/arrays/decimal/compute/mod.rs
@@ -30,10 +30,6 @@ impl ComputeVTable for DecimalEncoding {
         Some(self)
     }
 
-    fn sum_fn(&self) -> Option<&dyn SumFn<&dyn Array>> {
-        Some(self)
-    }
-
     fn take_fn(&self) -> Option<&dyn TakeFn<&dyn Array>> {
         Some(self)
     }

--- a/vortex-array/src/arrays/decimal/compute/mod.rs
+++ b/vortex-array/src/arrays/decimal/compute/mod.rs
@@ -1,3 +1,36 @@
 mod filter;
 mod scalar_at;
 mod slice;
+mod sum;
+
+use crate::arrays::{DecimalArray, DecimalEncoding};
+use crate::compute::{FilterKernelAdapter, KernelRef, ScalarAtFn, SliceFn, SumFn};
+use crate::vtable::ComputeVTable;
+use crate::{Array, ArrayComputeImpl};
+
+impl ArrayComputeImpl for DecimalArray {
+    const FILTER: Option<KernelRef> = FilterKernelAdapter(DecimalEncoding).some();
+}
+
+impl ComputeVTable for DecimalEncoding {
+    fn scalar_at_fn(&self) -> Option<&dyn ScalarAtFn<&dyn Array>> {
+        Some(self)
+    }
+
+    fn slice_fn(&self) -> Option<&dyn SliceFn<&dyn Array>> {
+        Some(self)
+    }
+
+    fn sum_fn(&self) -> Option<&dyn SumFn<&dyn Array>> {
+        Some(self)
+    }
+
+    // TODO(aduffy): BetweenFn
+    // TODO(aduffy): IsSortedFn
+    // TODO(aduffy): SearchSortedFn
+    // TODO(aduffy): CompareFn
+    // TODO(aduffy): IsConstant
+    // TODO(aduffy): BetweenFn
+    // TODO(aduffy): BinaryNumericFn
+    // TODO(aduffy): TakeFn
+}

--- a/vortex-array/src/arrays/decimal/compute/mod.rs
+++ b/vortex-array/src/arrays/decimal/compute/mod.rs
@@ -8,17 +8,12 @@ mod sum;
 mod take;
 mod to_arrow;
 
-use crate::arrays::{DecimalArray, DecimalEncoding};
+use crate::Array;
+use crate::arrays::DecimalEncoding;
 use crate::compute::{
-    BetweenFn, FilterKernelAdapter, IsConstantFn, IsSortedFn, KernelRef, ScalarAtFn, SliceFn,
-    SumFn, TakeFn, ToArrowFn,
+    BetweenFn, IsConstantFn, IsSortedFn, ScalarAtFn, SliceFn, SumFn, TakeFn, ToArrowFn,
 };
 use crate::vtable::ComputeVTable;
-use crate::{Array, ArrayComputeImpl};
-
-impl ArrayComputeImpl for DecimalArray {
-    const FILTER: Option<KernelRef> = FilterKernelAdapter(DecimalEncoding).some();
-}
 
 impl ComputeVTable for DecimalEncoding {
     fn between_fn(&self) -> Option<&dyn BetweenFn<&dyn Array>> {

--- a/vortex-array/src/arrays/decimal/compute/mod.rs
+++ b/vortex-array/src/arrays/decimal/compute/mod.rs
@@ -10,16 +10,10 @@ mod to_arrow;
 
 use crate::Array;
 use crate::arrays::DecimalEncoding;
-use crate::compute::{
-    BetweenFn, IsConstantFn, IsSortedFn, ScalarAtFn, SliceFn, SumFn, TakeFn, ToArrowFn,
-};
+use crate::compute::{IsConstantFn, IsSortedFn, ScalarAtFn, SliceFn, SumFn, TakeFn, ToArrowFn};
 use crate::vtable::ComputeVTable;
 
 impl ComputeVTable for DecimalEncoding {
-    fn between_fn(&self) -> Option<&dyn BetweenFn<&dyn Array>> {
-        Some(self)
-    }
-
     fn is_constant_fn(&self) -> Option<&dyn IsConstantFn<&dyn Array>> {
         Some(self)
     }

--- a/vortex-array/src/arrays/decimal/compute/mod.rs
+++ b/vortex-array/src/arrays/decimal/compute/mod.rs
@@ -1,5 +1,6 @@
 mod between;
 mod filter;
+mod is_constant;
 mod is_sorted;
 mod scalar_at;
 mod slice;
@@ -7,7 +8,7 @@ mod sum;
 
 use crate::arrays::{DecimalArray, DecimalEncoding};
 use crate::compute::{
-    BetweenFn, FilterKernelAdapter, IsSortedFn, KernelRef, ScalarAtFn, SliceFn, SumFn,
+    BetweenFn, FilterKernelAdapter, IsConstantFn, IsSortedFn, KernelRef, ScalarAtFn, SliceFn, SumFn,
 };
 use crate::vtable::ComputeVTable;
 use crate::{Array, ArrayComputeImpl};
@@ -17,6 +18,18 @@ impl ArrayComputeImpl for DecimalArray {
 }
 
 impl ComputeVTable for DecimalEncoding {
+    fn between_fn(&self) -> Option<&dyn BetweenFn<&dyn Array>> {
+        Some(self)
+    }
+
+    fn is_constant_fn(&self) -> Option<&dyn IsConstantFn<&dyn Array>> {
+        Some(self)
+    }
+
+    fn is_sorted_fn(&self) -> Option<&dyn IsSortedFn<&dyn Array>> {
+        Some(self)
+    }
+
     fn scalar_at_fn(&self) -> Option<&dyn ScalarAtFn<&dyn Array>> {
         Some(self)
     }
@@ -29,16 +42,6 @@ impl ComputeVTable for DecimalEncoding {
         Some(self)
     }
 
-    fn between_fn(&self) -> Option<&dyn BetweenFn<&dyn Array>> {
-        Some(self)
-    }
-
-    fn is_sorted_fn(&self) -> Option<&dyn IsSortedFn<&dyn Array>> {
-        Some(self)
-    }
-
-    // TODO(aduffy): IsConstant
-    // TODO(aduffy): BetweenFn
     // TODO(aduffy): BinaryNumericFn
     // TODO(aduffy): TakeFn
 }

--- a/vortex-array/src/arrays/decimal/compute/mod.rs
+++ b/vortex-array/src/arrays/decimal/compute/mod.rs
@@ -1,11 +1,14 @@
 mod between;
 mod filter;
+mod is_sorted;
 mod scalar_at;
 mod slice;
 mod sum;
 
 use crate::arrays::{DecimalArray, DecimalEncoding};
-use crate::compute::{BetweenFn, FilterKernelAdapter, KernelRef, ScalarAtFn, SliceFn, SumFn};
+use crate::compute::{
+    BetweenFn, FilterKernelAdapter, IsSortedFn, KernelRef, ScalarAtFn, SliceFn, SumFn,
+};
 use crate::vtable::ComputeVTable;
 use crate::{Array, ArrayComputeImpl};
 
@@ -27,6 +30,10 @@ impl ComputeVTable for DecimalEncoding {
     }
 
     fn between_fn(&self) -> Option<&dyn BetweenFn<&dyn Array>> {
+        Some(self)
+    }
+
+    fn is_sorted_fn(&self) -> Option<&dyn IsSortedFn<&dyn Array>> {
         Some(self)
     }
 

--- a/vortex-array/src/arrays/decimal/compute/mod.rs
+++ b/vortex-array/src/arrays/decimal/compute/mod.rs
@@ -37,9 +37,6 @@ impl ComputeVTable for DecimalEncoding {
         Some(self)
     }
 
-    // TODO(aduffy): IsSortedFn
-    // TODO(aduffy): SearchSortedFn
-    // TODO(aduffy): CompareFn
     // TODO(aduffy): IsConstant
     // TODO(aduffy): BetweenFn
     // TODO(aduffy): BinaryNumericFn

--- a/vortex-array/src/arrays/decimal/compute/sum.rs
+++ b/vortex-array/src/arrays/decimal/compute/sum.rs
@@ -3,10 +3,10 @@ use vortex_error::{VortexResult, vortex_bail};
 use vortex_mask::Mask;
 use vortex_scalar::{DecimalValue, Scalar, i256};
 
-use crate::Array;
 use crate::arrays::decimal::serde::DecimalValueType;
 use crate::arrays::{DecimalArray, DecimalEncoding};
-use crate::compute::SumFn;
+use crate::compute::{SumKernel, SumKernelAdapter};
+use crate::{Array, register_kernel};
 
 macro_rules! sum_decimal {
     ($ty:ty, $values:expr) => {{
@@ -27,7 +27,7 @@ macro_rules! sum_decimal {
     }};
 }
 
-impl SumFn<&DecimalArray> for DecimalEncoding {
+impl SumKernel for DecimalEncoding {
     fn sum(&self, array: &DecimalArray) -> VortexResult<Scalar> {
         let decimal_dtype = array.decimal_dtype();
         let nullability = array.dtype.nullability();
@@ -70,3 +70,5 @@ impl SumFn<&DecimalArray> for DecimalEncoding {
         }
     }
 }
+
+register_kernel!(SumKernelAdapter(DecimalEncoding).lift());

--- a/vortex-array/src/arrays/decimal/compute/sum.rs
+++ b/vortex-array/src/arrays/decimal/compute/sum.rs
@@ -1,0 +1,72 @@
+use itertools::Itertools;
+use vortex_error::{VortexResult, vortex_bail};
+use vortex_mask::Mask;
+use vortex_scalar::{DecimalValue, Scalar, i256};
+
+use crate::Array;
+use crate::arrays::decimal::serde::DecimalValueType;
+use crate::arrays::{DecimalArray, DecimalEncoding};
+use crate::compute::SumFn;
+
+macro_rules! sum_decimal {
+    ($ty:ty, $values:expr) => {{
+        let mut sum: $ty = <$ty>::default();
+        for v in $values {
+            sum = num_traits::CheckedAdd::checked_add(&sum, &v).expect("overflow");
+        }
+        sum
+    }};
+    ($ty:ty, $values:expr, $validity:expr) => {{
+        let mut sum: $ty = <$ty>::default();
+        for (v, valid) in $values.iter().zip_eq($validity.iter()) {
+            if valid {
+                sum = num_traits::CheckedAdd::checked_add(&sum, &v).expect("overflow");
+            }
+        }
+        sum
+    }};
+}
+
+impl SumFn<&DecimalArray> for DecimalEncoding {
+    fn sum(&self, array: &DecimalArray) -> VortexResult<Scalar> {
+        let decimal_dtype = array.decimal_dtype();
+        let nullability = array.dtype.nullability();
+
+        match (array.values_type, array.validity_mask()?) {
+            (_, Mask::AllFalse(_)) => {
+                vortex_bail!("invalid state, all-null array should be checked by top-level sum fn")
+            }
+
+            // fast paths: no validity checks needed
+            (DecimalValueType::I128, Mask::AllTrue(_)) => Ok(Scalar::decimal(
+                DecimalValue::I128(sum_decimal!(i128, array.buffer::<i128>())),
+                decimal_dtype,
+                nullability,
+            )),
+            (DecimalValueType::I256, Mask::AllTrue(_)) => Ok(Scalar::decimal(
+                DecimalValue::I256(sum_decimal!(i256, array.buffer::<i256>())),
+                decimal_dtype,
+                nullability,
+            )),
+            // Variant that requires validity checks
+            (DecimalValueType::I128, Mask::Values(mask_values)) => Ok(Scalar::decimal(
+                DecimalValue::I128(sum_decimal!(
+                    i128,
+                    array.buffer::<i128>(),
+                    mask_values.boolean_buffer()
+                )),
+                decimal_dtype,
+                nullability,
+            )),
+            (DecimalValueType::I256, Mask::Values(mask_values)) => Ok(Scalar::decimal(
+                DecimalValue::I256(sum_decimal!(
+                    i256,
+                    array.buffer::<i256>(),
+                    mask_values.boolean_buffer()
+                )),
+                decimal_dtype,
+                nullability,
+            )),
+        }
+    }
+}

--- a/vortex-array/src/arrays/decimal/compute/take.rs
+++ b/vortex-array/src/arrays/decimal/compute/take.rs
@@ -34,7 +34,6 @@ impl TakeFn<&DecimalArray> for DecimalEncoding {
     }
 }
 
-/// Convert the BufferMut<T> into a Buffer<T>.
 #[inline]
 fn take_to_buffer<I: NativePType + AsPrimitive<usize>, T: NativeDecimalType>(
     indices: &[I],

--- a/vortex-array/src/arrays/decimal/compute/take.rs
+++ b/vortex-array/src/arrays/decimal/compute/take.rs
@@ -1,0 +1,73 @@
+use num_traits::AsPrimitive;
+use vortex_buffer::Buffer;
+use vortex_dtype::{NativePType, match_each_integer_ptype};
+use vortex_error::{VortexResult, vortex_err};
+use vortex_scalar::i256;
+
+use crate::arrays::decimal::serde::DecimalValueType;
+use crate::arrays::{DecimalArray, DecimalEncoding, NativeDecimalType, PrimitiveArray};
+use crate::compute::TakeFn;
+use crate::variants::PrimitiveArrayTrait;
+use crate::{Array, ArrayRef};
+
+impl TakeFn<&DecimalArray> for DecimalEncoding {
+    fn take(&self, array: &DecimalArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
+        let indices = indices
+            .as_any()
+            .downcast_ref::<PrimitiveArray>()
+            .ok_or_else(|| vortex_err!("indices must be a PrimitiveArray"))?;
+
+        match array.values_type() {
+            DecimalValueType::I128 => {
+                match_each_integer_ptype!(indices.ptype(), |$I| {
+                    let buffer = take_to_buffer::<$I, i128>(indices.as_slice::<$I>(), array.buffer::<i128>().as_slice());
+                    Ok(DecimalArray::new(buffer, array.decimal_dtype(), array.validity().clone()).into_array())
+                })
+            }
+            DecimalValueType::I256 => {
+                match_each_integer_ptype!(indices.ptype(), |$I| {
+                    let buffer = take_to_buffer::<$I, i256>(indices.as_slice::<$I>(), array.buffer::<i256>().as_slice());
+                    Ok(DecimalArray::new(buffer, array.decimal_dtype(), array.validity().clone()).into_array())
+                })
+            }
+        }
+    }
+}
+
+/// Convert the BufferMut<T> into a Buffer<T>.
+#[inline]
+fn take_to_buffer<I: NativePType + AsPrimitive<usize>, T: NativeDecimalType>(
+    indices: &[I],
+    values: &[T],
+) -> Buffer<T> {
+    indices.iter().map(|idx| values[idx.as_()]).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_buffer::buffer;
+    use vortex_dtype::DecimalDType;
+
+    use crate::arrays::DecimalArray;
+    use crate::compute::take;
+    use crate::validity::Validity;
+    use crate::{Array, IntoArray};
+
+    #[test]
+    fn test_take() {
+        let array = DecimalArray::new(
+            buffer![10i128, 11i128, 12i128, 13i128],
+            DecimalDType::new(19, 1),
+            Validity::NonNullable,
+        );
+
+        let indices = buffer![0, 2, 3].into_array();
+        let taken = take(&array, indices.as_ref()).unwrap();
+        let taken_decimals = taken.as_any().downcast_ref::<DecimalArray>().unwrap();
+        assert_eq!(
+            taken_decimals.buffer::<i128>(),
+            buffer![10i128, 12i128, 13i128]
+        );
+        assert_eq!(taken_decimals.decimal_dtype(), DecimalDType::new(19, 1));
+    }
+}

--- a/vortex-array/src/arrays/decimal/compute/to_arrow.rs
+++ b/vortex-array/src/arrays/decimal/compute/to_arrow.rs
@@ -1,0 +1,108 @@
+use std::mem;
+use std::sync::Arc;
+
+use arrow_array::{ArrayRef as ArrowArrayRef, Decimal128Array, Decimal256Array};
+use arrow_schema::DataType;
+use vortex_buffer::Buffer;
+use vortex_error::{VortexResult, vortex_bail};
+use vortex_scalar::i256;
+
+use crate::Array;
+use crate::arrays::decimal::serde::DecimalValueType;
+use crate::arrays::{DecimalArray, DecimalEncoding};
+use crate::compute::ToArrowFn;
+
+impl ToArrowFn<&DecimalArray> for DecimalEncoding {
+    fn to_arrow(
+        &self,
+        array: &DecimalArray,
+        data_type: &DataType,
+    ) -> VortexResult<Option<ArrowArrayRef>> {
+        let precision = array.decimal_dtype().precision();
+        let scale = array.decimal_dtype().scale();
+        let nulls = array.validity_mask()?.to_null_buffer();
+
+        match array.values_type {
+            DecimalValueType::I128 => {
+                let DataType::Decimal128(p, s) = data_type else {
+                    vortex_bail!(
+                        "Target Arrow type does not match Decimal source: {:?} ≠ {:?}",
+                        data_type,
+                        array.decimal_dtype()
+                    );
+                };
+                if *p != precision || *s != scale {
+                    vortex_bail!(
+                        "Decimal128: precision {} and scale {} do not match expected ({}, {})",
+                        precision,
+                        scale,
+                        p,
+                        s
+                    );
+                }
+
+                Ok(Some(Arc::new(
+                    Decimal128Array::new(array.buffer::<i128>().into_arrow_scalar_buffer(), nulls)
+                        .with_precision_and_scale(precision, scale)?,
+                )))
+            }
+            DecimalValueType::I256 => {
+                let DataType::Decimal256(p, s) = data_type else {
+                    vortex_bail!(
+                        "Target Arrow type does not match Decimal source: {:?} ≠ {:?}",
+                        data_type,
+                        array.decimal_dtype()
+                    );
+                };
+                if *p != precision || *s != scale {
+                    vortex_bail!(
+                        "Decimal128: precision {} and scale {} do not match expected ({}, {})",
+                        precision,
+                        scale,
+                        p,
+                        s
+                    );
+                }
+
+                let buffer_i256 = array.buffer::<i256>();
+                // SAFETY: vortex_scalar::i256 and arrow_buffer::i256 have same bits
+                let buffer_i256: Buffer<arrow_buffer::i256> =
+                    unsafe { mem::transmute(buffer_i256) };
+
+                Ok(Some(Arc::new(
+                    Decimal256Array::new(buffer_i256.into_arrow_scalar_buffer(), nulls)
+                        .with_precision_and_scale(precision, scale)?,
+                )))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow_array::{Array, Decimal128Array};
+    use arrow_schema::DataType;
+    use vortex_buffer::buffer;
+    use vortex_dtype::DecimalDType;
+
+    use crate::arrays::DecimalArray;
+    use crate::compute::to_arrow;
+    use crate::validity::Validity;
+
+    #[test]
+    fn test_to_arrow() {
+        // Make a very simple i128 and i256 array.
+        let decimal_vortex = DecimalArray::new(
+            buffer![1i128, 2i128, 3i128, 4i128, 5i128],
+            DecimalDType::new(19, 2),
+            Validity::NonNullable,
+        );
+        let arrow = to_arrow(&decimal_vortex, &DataType::Decimal128(19, 2)).unwrap();
+        assert_eq!(arrow.data_type(), &DataType::Decimal128(19, 2));
+        let decimal_array = arrow.as_any().downcast_ref::<Decimal128Array>().unwrap();
+        assert_eq!(
+            decimal_array.values().as_ref(),
+            &[1i128, 2i128, 3i128, 4i128, 5i128]
+        );
+    }
+}

--- a/vortex-array/src/arrays/decimal/mod.rs
+++ b/vortex-array/src/arrays/decimal/mod.rs
@@ -28,7 +28,7 @@ impl Encoding for DecimalEncoding {
 }
 
 /// Type of decimal scalar values.
-pub trait NativeDecimalType {
+pub trait NativeDecimalType: Copy + Eq + Ord {
     const VALUES_TYPE: DecimalValueType;
 }
 

--- a/vortex-array/src/arrays/decimal/mod.rs
+++ b/vortex-array/src/arrays/decimal/mod.rs
@@ -108,6 +108,10 @@ impl DecimalArray {
         }
     }
 
+    pub fn values_type(&self) -> DecimalValueType {
+        self.values_type
+    }
+
     pub fn precision(&self) -> u8 {
         self.decimal_dtype().precision()
     }

--- a/vortex-array/src/arrays/decimal/mod.rs
+++ b/vortex-array/src/arrays/decimal/mod.rs
@@ -10,11 +10,10 @@ use vortex_scalar::i256;
 use crate::array::{Array, ArrayCanonicalImpl, ArrayValidityImpl, ArrayVariantsImpl};
 use crate::arrays::decimal::serde::{DecimalMetadata, DecimalValueType};
 use crate::builders::ArrayBuilder;
-use crate::compute::{ScalarAtFn, SliceFn};
 use crate::stats::{ArrayStats, StatsSetRef};
 use crate::validity::Validity;
 use crate::variants::DecimalArrayTrait;
-use crate::vtable::{ComputeVTable, VTableRef};
+use crate::vtable::VTableRef;
 use crate::{
     ArrayBufferVisitor, ArrayChildVisitor, ArrayImpl, ArrayRef, ArrayStatisticsImpl,
     ArrayVisitorImpl, Canonical, Encoding, ProstMetadata, try_from_array_ref,
@@ -22,26 +21,6 @@ use crate::{
 
 #[derive(Debug)]
 pub struct DecimalEncoding;
-
-impl ComputeVTable for DecimalEncoding {
-    fn scalar_at_fn(&self) -> Option<&dyn ScalarAtFn<&dyn Array>> {
-        Some(self)
-    }
-
-    fn slice_fn(&self) -> Option<&dyn SliceFn<&dyn Array>> {
-        Some(self)
-    }
-
-    // TODO(aduffy): SumFn
-    // TODO(aduffy): BetweenFn
-    // TODO(aduffy): IsSortedFn
-    // TODO(aduffy): SearchSortedFn
-    // TODO(aduffy): CompareFn
-    // TODO(aduffy): IsConstant
-    // TODO(aduffy): BetweenFn
-    // TODO(aduffy): BinaryNumericFn
-    // TODO(aduffy): TakeFn
-}
 
 impl Encoding for DecimalEncoding {
     type Array = DecimalArray;

--- a/vortex-array/src/builders/decimal.rs
+++ b/vortex-array/src/builders/decimal.rs
@@ -1,0 +1,174 @@
+use std::any::Any;
+
+use vortex_buffer::BufferMut;
+use vortex_dtype::{DType, DecimalDType, Nullability};
+use vortex_error::{VortexResult, vortex_bail, vortex_panic};
+use vortex_mask::Mask;
+
+use crate::arrays::{BoolArray, DecimalArray, NativeDecimalType};
+use crate::builders::ArrayBuilder;
+use crate::builders::lazy_validity_builder::LazyNullBufferBuilder;
+use crate::validity::Validity;
+use crate::{Array, ArrayRef, ToCanonical};
+
+pub struct DecimalBuilder<T> {
+    values: BufferMut<T>,
+    nulls: LazyNullBufferBuilder,
+    dtype: DType,
+}
+
+const DEFAULT_BUILDER_CAPACITY: usize = 1024;
+
+impl<T: NativeDecimalType> DecimalBuilder<T> {
+    pub fn new(precision: u8, scale: i8, nullability: Nullability) -> Self {
+        Self::with_capacity(DEFAULT_BUILDER_CAPACITY, precision, scale, nullability)
+    }
+
+    pub fn with_capacity(
+        capacity: usize,
+        precision: u8,
+        scale: i8,
+        nullability: Nullability,
+    ) -> Self {
+        Self {
+            values: BufferMut::with_capacity(capacity),
+            nulls: LazyNullBufferBuilder::new(capacity),
+            dtype: DType::Decimal(DecimalDType::new(precision, scale), nullability),
+        }
+    }
+
+    /// Append a `Mask` to the null buffer.
+    pub fn append_mask(&mut self, mask: Mask) {
+        self.nulls.append_validity_mask(mask);
+    }
+
+    fn extend_with_validity_mask(&mut self, validity_mask: Mask) {
+        self.nulls.append_validity_mask(validity_mask);
+    }
+
+    pub fn append_value(&mut self, value: T) {
+        self.values.push(value);
+        self.nulls.append(true);
+    }
+
+    pub fn append_option(&mut self, value: Option<T>)
+    where
+        Self: Send,
+        T: Default + Send + 'static,
+    {
+        match value {
+            Some(value) => {
+                self.values.push(value);
+                self.nulls.append(true);
+            }
+            None => self.append_null(),
+        }
+    }
+
+    pub fn values(&self) -> &[T] {
+        self.values.as_ref()
+    }
+
+    pub fn finish_into_decimal(&mut self) -> DecimalArray {
+        let nulls = self.nulls.finish();
+
+        if let Some(null_buf) = nulls.as_ref() {
+            assert_eq!(
+                null_buf.len(),
+                self.values.len(),
+                "null buffer length must equal value buffer length"
+            );
+        }
+
+        let validity = match (nulls, self.dtype.nullability()) {
+            (None, Nullability::NonNullable) => Validity::NonNullable,
+            (Some(_), Nullability::NonNullable) => {
+                vortex_panic!("Non-nullable builder has null values")
+            }
+            (None, Nullability::Nullable) => Validity::AllValid,
+            (Some(nulls), Nullability::Nullable) => {
+                if nulls.null_count() == nulls.len() {
+                    Validity::AllInvalid
+                } else {
+                    Validity::Array(BoolArray::from(nulls.into_inner()).into_array())
+                }
+            }
+        };
+
+        let DType::Decimal(decimal_dtype, _) = self.dtype else {
+            vortex_panic!("DecimalBuilder must have Decimal DType");
+        };
+
+        DecimalArray::new(
+            std::mem::take(&mut self.values).freeze(),
+            decimal_dtype,
+            validity,
+        )
+    }
+}
+
+impl<T: NativeDecimalType + Default + Send + 'static> ArrayBuilder for DecimalBuilder<T> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn dtype(&self) -> &DType {
+        &self.dtype
+    }
+
+    fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    fn append_zeros(&mut self, n: usize) {
+        self.values.push_n(T::default(), n);
+        self.nulls.append_n_non_nulls(n);
+    }
+
+    fn append_nulls(&mut self, n: usize) {
+        self.values.push_n(T::default(), n);
+        self.nulls.append_n_nulls(n);
+    }
+
+    fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
+        let array = array.to_decimal()?;
+
+        let DType::Decimal(decimal_dtype, _) = self.dtype else {
+            vortex_panic!("DecimalBuilder must have Decimal DType");
+        };
+
+        if array.decimal_dtype() != decimal_dtype {
+            vortex_bail!(
+                "Cannot extend from array with different decimal type: {:?} != {:?}",
+                array.decimal_dtype(),
+                decimal_dtype
+            );
+        }
+
+        self.values
+            .extend_from_slice(array.buffer::<T>().as_slice());
+        self.extend_with_validity_mask(array.validity_mask()?);
+
+        Ok(())
+    }
+
+    fn ensure_capacity(&mut self, capacity: usize) {
+        if capacity > self.values.capacity() {
+            self.values.reserve(capacity - self.values.len());
+            self.nulls.ensure_capacity(capacity);
+        }
+    }
+
+    fn set_validity(&mut self, validity: Mask) {
+        self.nulls = LazyNullBufferBuilder::new(validity.len());
+        self.nulls.append_validity_mask(validity);
+    }
+
+    fn finish(&mut self) -> ArrayRef {
+        self.finish_into_decimal().into_array()
+    }
+}

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -27,6 +27,7 @@
 //! ```
 
 mod bool;
+mod decimal;
 mod extension;
 mod lazy_validity_builder;
 mod list;
@@ -38,6 +39,7 @@ mod varbinview;
 use std::any::Any;
 
 pub use bool::*;
+pub use decimal::*;
 pub use extension::*;
 pub use list::*;
 pub use null::*;

--- a/vortex-array/src/compute/numeric.rs
+++ b/vortex-array/src/compute/numeric.rs
@@ -158,9 +158,10 @@ impl ComputeFnVTable for Numeric {
 
     fn return_type<'a>(&self, args: &'a InvocationArgs<'a>) -> VortexResult<DType> {
         let NumericArgs { lhs, rhs, .. } = NumericArgs::try_from(args)?;
-        if !matches!(lhs.dtype(), DType::Primitive(_, _))
-            || !matches!(rhs.dtype(), DType::Primitive(_, _))
-            || !lhs.dtype().eq_ignore_nullability(rhs.dtype())
+        if !matches!(
+            (lhs.dtype(), rhs.dtype()),
+            (DType::Primitive(..), DType::Primitive(..)) | (DType::Decimal(..), DType::Decimal(..))
+        ) || !lhs.dtype().eq_ignore_nullability(rhs.dtype())
         {
             vortex_bail!(
                 "Numeric operations are only supported on two arrays sharing the same primitive-type: {} {}",

--- a/vortex-array/src/compute/numeric.rs
+++ b/vortex-array/src/compute/numeric.rs
@@ -164,7 +164,7 @@ impl ComputeFnVTable for Numeric {
         ) || !lhs.dtype().eq_ignore_nullability(rhs.dtype())
         {
             vortex_bail!(
-                "Numeric operations are only supported on two arrays sharing the same primitive-type: {} {}",
+                "Numeric operations are only supported on two arrays sharing the same numeric type: {} {}",
                 lhs.dtype(),
                 rhs.dtype()
             )


### PR DESCRIPTION
Follow on to #3058 

In the previous PR, several compute functions were left unimplemented. This closes out and implements the remainder needed for full support of DecimalArray and Decimal types.

All compute functions have some associated unit tests