### PR TITLE
Pin benchmark colors

### DIFF
--- a/benchmarks-website/code.js
+++ b/benchmarks-website/code.js
@@ -7,9 +7,9 @@ window.initAndRender = (function () {
             "datafusion:parquet": '#ef7f1d',
             "datafusion:vortex": '#19a508',
 
-            "duckdb:parquet": '#ef7f1d',
-            "duckdb:vortex": '#19a508',
-            "duckdb:duckdb": '#fada58',
+            "duckdb:parquet": '#985113',
+            "duckdb:vortex": '#0e5e04',
+            "duckdb:duckdb": '#87752e',
         };
 
         if (MAP[str]) {

--- a/benchmarks-website/code.js
+++ b/benchmarks-website/code.js
@@ -5,12 +5,11 @@ window.initAndRender = (function () {
         const MAP = {
             "datafusion:arrow": '#7a27b1',
             "datafusion:parquet": '#ef7f1d',
-            "datafusionvortex": '#23d100',
+            "datafusion:vortex": '#19a508',
 
-            "duckdb:parquet": '#ef1d24',
-            "duckdb:vortex": '#0062d1',
-            "duckdb:duckdb": '#000000',
-
+            "duckdb:parquet": '#ef7f1d',
+            "duckdb:vortex": '#19a508',
+            "duckdb:duckdb": '#fada58',
         };
 
         if (MAP[str]) {


### PR DESCRIPTION
I'd argue it's more important to easily see which lines are vortex vs parquet vs other, than it is to distinguish between engines which can be done on-hover. And 6 different colours is hard to mentally track.