### PR TITLE
Cleanup mimalloc usage in benchmarks

### DIFF
--- a/bench-vortex/Cargo.toml
+++ b/bench-vortex/Cargo.toml
@@ -70,5 +70,4 @@ vortex-io = { workspace = true, features = ["tokio"] }
 xshell = { workspace = true }
 
 [features]
-mimalloc = []
 tracing = ["vortex-datafusion/tracing"]

--- a/bench-vortex/src/bin/clickbench.rs
+++ b/bench-vortex/src/bin/clickbench.rs
@@ -28,9 +28,6 @@ use url::Url;
 use vortex::error::{VortexExpect, vortex_panic};
 use vortex_datafusion::persistent::metrics::VortexMetricsFinder;
 
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {

--- a/bench-vortex/src/bin/compress.rs
+++ b/bench-vortex/src/bin/compress.rs
@@ -18,9 +18,6 @@ use vortex::builders::builder_with_capacity;
 use vortex::error::VortexUnwrap;
 use vortex::{Array, ArrayExt};
 
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {

--- a/bench-vortex/src/bin/public_bi.rs
+++ b/bench-vortex/src/bin/public_bi.rs
@@ -15,9 +15,6 @@ use tracing_futures::Instrument;
 use vortex::error::{VortexExpect, vortex_panic};
 use vortex_datafusion::persistent::metrics::VortexMetricsFinder;
 
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {

--- a/bench-vortex/src/bin/random_access.rs
+++ b/bench-vortex/src/bin/random_access.rs
@@ -13,9 +13,6 @@ use tokio::runtime::Runtime;
 use vortex::buffer::{Buffer, buffer};
 use vortex::error::VortexUnwrap;
 
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {

--- a/bench-vortex/src/bin/tpch.rs
+++ b/bench-vortex/src/bin/tpch.rs
@@ -32,9 +32,6 @@ use vortex::aliases::hash_map::HashMap;
 use vortex::error::VortexExpect;
 use vortex_datafusion::persistent::metrics::VortexMetricsFinder;
 
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -29,6 +29,10 @@ pub use datasets::{BenchmarkDataset, file};
 pub use engines::{ddb, df};
 pub use vortex::error::vortex_panic;
 
+// All benchmarks run with mimalloc for consistency.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize)]
 pub struct Target {
     engine: Engine,

--- a/vortex-ffi/Cargo.toml
+++ b/vortex-ffi/Cargo.toml
@@ -21,7 +21,7 @@ duckdb = { workspace = true, optional = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
-mimalloc = { workspace = true }
+mimalloc = { workspace = true, optional = true }
 object_store = { workspace = true, features = ["aws", "azure", "gcp"] }
 paste = { workspace = true }
 prost = { workspace = true }
@@ -32,6 +32,8 @@ vortex = { workspace = true, features = ["object_store", "proto"] }
 vortex-duckdb = { workspace = true, optional = true }
 
 [features]
+default = ["mimalloc"]
+mimalloc = ["dep:mimalloc"]
 duckdb = ["dep:vortex-duckdb", "dep:duckdb"]
 
 [lib]

--- a/vortex-ffi/src/lib.rs
+++ b/vortex-ffi/src/lib.rs
@@ -18,7 +18,7 @@ pub use log::vx_log_level;
 use tokio::runtime::{Builder, Runtime};
 use vortex::error::VortexExpect;
 
-#[cfg(not(miri))]
+#[cfg(all(feature = "mimalloc", not(miri)))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 


### PR DESCRIPTION
1. Only configure in one place (lib.rs) so all future benchmarks will also pull it automatically.
2. Allow opting out of it in `vortex-ffi`
3. Remove meaningless `mimalloc` feature that was left in `bench-vortex`.