### PR TITLE
Slight improvement for `VTableRegistry::register_many`

### DIFF
--- a/vortex-array/src/context.rs
+++ b/vortex-array/src/context.rs
@@ -137,8 +137,7 @@ impl<T: Clone + Display + Eq> VTableRegistry<T> {
 
     /// Register a new encoding, replacing any existing encoding with the same ID.
     pub fn register_many<I: IntoIterator<Item = T>>(&mut self, encodings: I) {
-        encodings.into_iter().for_each(|encoding| {
-            self.0.insert(encoding.to_string(), encoding);
-        });
+        self.0
+            .extend(encodings.into_iter().map(|e| (e.to_string(), e)));
     }
 }


### PR DESCRIPTION
just delegate to the inner `extend` function that also deals with reserving enough space. Saw it in a profile of a very fast query as part of clickbench, spent like 2ms just resizing this tiny map.