### PR TITLE
Weak shared futures

### DIFF
--- a/vortex-layout/src/layouts/dict/eval_expr.rs
+++ b/vortex-layout/src/layouts/dict/eval_expr.rs
@@ -10,7 +10,8 @@ use vortex_error::{VortexResult, vortex_err};
 use vortex_expr::{ExprRef, Identity};
 use vortex_mask::Mask;
 
-use super::reader::{DictReader, SharedArrayFuture};
+use super::reader::DictReader;
+use crate::layouts::SharedArrayFuture;
 use crate::{
     ArrayEvaluation, ExprEvaluator, MaskEvaluation, NoOpPruningEvaluation, PruningEvaluation,
 };

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -1,27 +1,26 @@
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::Arc;
 
 use futures::FutureExt;
-use futures::future::{BoxFuture, Shared};
-use vortex_array::aliases::hash_map::HashMap;
-use vortex_array::{ArrayContext, ArrayRef, DeserializeMetadata, IntoArray, ProstMetadata};
+use parking_lot::{Mutex, RwLock};
+use vortex_array::aliases::hash_map::{Entry, HashMap};
+use vortex_array::{ArrayContext, DeserializeMetadata, ProstMetadata};
 use vortex_dtype::{DType, PType};
-use vortex_error::{SharedVortexResult, VortexExpect, VortexResult, vortex_panic};
+use vortex_error::{VortexExpect, VortexResult, vortex_panic};
 use vortex_expr::{ExprRef, Identity};
 use vortex_mask::Mask;
 
 use super::DictLayout;
 use super::writer::DictLayoutMetadata;
+use crate::layouts::{SharedArrayFuture, WeakSharedArrayFuture};
 use crate::segments::SegmentSource;
 use crate::{Layout, LayoutReader, LayoutVTable};
-
-pub(crate) type SharedArrayFuture = Shared<BoxFuture<'static, SharedVortexResult<ArrayRef>>>;
 
 pub struct DictReader {
     layout: Layout,
     /// Cached dict values array
-    values_array: OnceLock<SharedArrayFuture>,
+    values_array: Mutex<Option<WeakSharedArrayFuture>>,
     /// Cache of expression evaluation results on the values array by expression
-    values_evals: RwLock<HashMap<ExprRef, SharedArrayFuture>>,
+    values_evals: RwLock<HashMap<ExprRef, Option<WeakSharedArrayFuture>>>,
     pub(crate) values: Arc<dyn LayoutReader>,
     pub(crate) codes: Arc<dyn LayoutReader>,
 }
@@ -59,46 +58,77 @@ impl DictReader {
     }
 
     pub(crate) fn values_array(&self) -> SharedArrayFuture {
-        self.values_array
-            .get_or_init(move || {
-                let values_len = self.values.row_count();
-                let eval = self
-                    .values
-                    .projection_evaluation(&(0..values_len), &Identity::new_expr())
-                    .vortex_expect("must construct dict values array evaluation");
+        let mut guard = self.values_array.lock();
 
-                async move {
-                    eval.invoke(Mask::new_true(
-                        usize::try_from(values_len)
-                            .vortex_expect("dict values length must fit in u32"),
-                    ))
-                    .await
-                    .map_err(Arc::new)
-                }
-                .boxed()
-                .shared()
-            })
-            .clone()
+        if let Some(shared_array) = guard.as_ref().and_then(|v| v.upgrade()) {
+            shared_array
+        } else {
+            let values_len = self.values.row_count();
+            let eval = self
+                .values
+                .projection_evaluation(&(0..values_len), &Identity::new_expr())
+                .vortex_expect("must construct dict values array evaluation");
+
+            let shared_array_future = async move {
+                eval.invoke(Mask::new_true(
+                    usize::try_from(values_len).vortex_expect("dict values length must fit in u32"),
+                ))
+                .await
+                .map_err(Arc::new)
+            }
+            .boxed()
+            .shared();
+
+            *guard = Some(
+                shared_array_future
+                    .downgrade()
+                    .vortex_expect("Future was never polled"),
+            );
+            shared_array_future
+        }
     }
 
     pub(crate) fn values_eval(&self, expr: ExprRef) -> SharedArrayFuture {
-        self.values_evals
-            .write()
-            .vortex_expect("poisoned lock")
-            .entry(expr.clone())
-            .or_insert_with(|| {
-                self.values_array()
+        let mut guard = self.values_evals.write();
+
+        match guard.entry(expr.clone()) {
+            Entry::Occupied(mut occupied) => {
+                if let Some(f) = occupied.get().clone().and_then(|v| v.upgrade()) {
+                    f
+                } else {
+                    let f = self
+                        .values_array()
+                        .map(move |array| {
+                            expr.evaluate(&array?)
+                                // .and_then(|result| result.to_canonical())
+                                // TODO(os): not all expressions would benefit from a canonical array
+                                // .map(|canonical| canonical.into_array())
+                                .map_err(Arc::new)
+                        })
+                        .boxed()
+                        .shared();
+
+                    occupied.insert(f.downgrade());
+                    f
+                }
+            }
+            Entry::Vacant(vacant) => {
+                let f = self
+                    .values_array()
                     .map(move |array| {
-                        expr.evaluate(&array?)
-                            .and_then(|result| result.to_canonical())
+                        expr.evaluate(array?.as_ref())
+                            // .and_then(|result| result.to_canonical())
                             // TODO(os): not all expressions would benefit from a canonical array
-                            .map(|canonical| canonical.into_array())
+                            // .map(|canonical| canonical.into_array())
                             .map_err(Arc::new)
                     })
                     .boxed()
-                    .shared()
-            })
-            .clone()
+                    .shared();
+
+                vacant.insert(f.downgrade());
+                f
+            }
+        }
     }
 }
 

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -32,7 +32,7 @@ impl DictReader {
         ctx: &ArrayContext,
     ) -> VortexResult<Self> {
         if layout.vtable().id() != DictLayout.id() {
-            vortex_panic!("Mitmatched layout ID")
+            vortex_panic!("Mismatched layout ID")
         }
         let metadata = ProstMetadata::<DictLayoutMetadata>::deserialize(
             layout.metadata().as_ref().map(|b| b.as_ref()),
@@ -98,13 +98,7 @@ impl DictReader {
                 } else {
                     let f = self
                         .values_array()
-                        .map(move |array| {
-                            expr.evaluate(&array?)
-                                // .and_then(|result| result.to_canonical())
-                                // TODO(os): not all expressions would benefit from a canonical array
-                                // .map(|canonical| canonical.into_array())
-                                .map_err(Arc::new)
-                        })
+                        .map(move |array| expr.evaluate(&array?).map_err(Arc::new))
                         .boxed()
                         .shared();
 
@@ -115,13 +109,7 @@ impl DictReader {
             Entry::Vacant(vacant) => {
                 let f = self
                     .values_array()
-                    .map(move |array| {
-                        expr.evaluate(array?.as_ref())
-                            // .and_then(|result| result.to_canonical())
-                            // TODO(os): not all expressions would benefit from a canonical array
-                            // .map(|canonical| canonical.into_array())
-                            .map_err(Arc::new)
-                    })
+                    .map(move |array| expr.evaluate(&array?).map_err(Arc::new))
                     .boxed()
                     .shared();
 

--- a/vortex-layout/src/layouts/flat/eval_expr.rs
+++ b/vortex-layout/src/layouts/flat/eval_expr.rs
@@ -7,7 +7,8 @@ use vortex_error::{VortexExpect, VortexResult};
 use vortex_expr::{ExprRef, Identity};
 use vortex_mask::Mask;
 
-use crate::layouts::flat::reader::{FlatReader, SharedArray};
+use crate::layouts::SharedArrayFuture;
+use crate::layouts::flat::reader::FlatReader;
 use crate::{
     ArrayEvaluation, ExprEvaluator, Layout, LayoutReader, MaskEvaluation, NoOpPruningEvaluation,
     PruningEvaluation,
@@ -67,7 +68,7 @@ impl ExprEvaluator for FlatReader {
 
 struct FlatEvaluation {
     layout: Layout,
-    array: SharedArray,
+    array: SharedArrayFuture,
     row_range: Range<usize>,
     expr: ExprRef,
 }

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -1,23 +1,22 @@
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use futures::FutureExt;
-use futures::future::{BoxFuture, Shared};
+use parking_lot::Mutex;
+use vortex_array::ArrayContext;
 use vortex_array::serde::ArrayParts;
-use vortex_array::{ArrayContext, ArrayRef};
-use vortex_error::{SharedVortexResult, VortexResult, vortex_err, vortex_panic};
+use vortex_error::{VortexExpect, VortexResult, vortex_err, vortex_panic};
 
 use crate::layouts::flat::FlatLayout;
+use crate::layouts::{SharedArrayFuture, WeakSharedArrayFuture};
 use crate::reader::LayoutReader;
 use crate::segments::SegmentSource;
 use crate::{Layout, LayoutVTable};
-
-pub(crate) type SharedArray = Shared<BoxFuture<'static, SharedVortexResult<ArrayRef>>>;
 
 pub struct FlatReader {
     pub(crate) layout: Layout,
     pub(crate) segment_source: Arc<dyn SegmentSource>,
     pub(crate) ctx: ArrayContext,
-    pub(crate) array: OnceLock<SharedArray>,
+    pub(crate) array: Mutex<Option<WeakSharedArrayFuture>>,
 }
 
 impl FlatReader {
@@ -45,7 +44,7 @@ impl FlatReader {
     // TODO(ngates): caching this and ignoring SegmentReaders may be a terrible idea... we may
     //  instead want to store all segment futures and race them, so if a layout requests a
     //  projection future before a pruning future, the pruning isn't blocked.
-    pub(crate) fn array_future(&self) -> VortexResult<SharedArray> {
+    pub(crate) fn array_future(&self) -> VortexResult<SharedArrayFuture> {
         let segment_id = self
             .layout
             .segment_id(0)
@@ -57,21 +56,29 @@ impl FlatReader {
         // This is gross... see the function's TODO for a maybe better solution?
         let segment_fut = self.segment_source.request(segment_id, self.layout.name());
 
-        Ok(self
-            .array
-            .get_or_init(|| {
-                let ctx = self.ctx.clone();
-                let dtype = self.layout.dtype().clone();
-                async move {
-                    let segment = segment_fut.await?;
-                    ArrayParts::try_from(segment)?
-                        .decode(&ctx, dtype.clone(), row_count)
-                        .map_err(Arc::new)
-                }
-                .boxed()
-                .shared()
-            })
-            .clone())
+        let mut guard = self.array.lock();
+
+        if let Some(shared_array) = guard.as_ref().and_then(|v| v.upgrade()) {
+            Ok(shared_array)
+        } else {
+            let ctx = self.ctx.clone();
+            let dtype = self.layout.dtype().clone();
+            let shared_array = async move {
+                let segment = segment_fut.await?;
+                ArrayParts::try_from(segment)?
+                    .decode(&ctx, dtype.clone(), row_count)
+                    .map_err(Arc::new)
+            }
+            .boxed()
+            .shared();
+
+            *guard = Some(
+                shared_array
+                    .downgrade()
+                    .vortex_expect("Future was never polled"),
+            );
+            Ok(shared_array)
+        }
     }
 }
 

--- a/vortex-layout/src/layouts/mod.rs
+++ b/vortex-layout/src/layouts/mod.rs
@@ -1,4 +1,9 @@
 //! A collection of built-in layouts for Vortex
+
+use futures::future::{BoxFuture, Shared, WeakShared};
+use vortex_array::ArrayRef;
+use vortex_error::SharedVortexResult;
+
 pub mod chunked;
 pub mod dict;
 pub mod file_stats;
@@ -7,3 +12,6 @@ pub mod flat;
 pub mod repartition;
 pub mod stats;
 pub mod struct_;
+
+type WeakSharedArrayFuture = WeakShared<BoxFuture<'static, SharedVortexResult<ArrayRef>>>;
+type SharedArrayFuture = Shared<BoxFuture<'static, SharedVortexResult<ArrayRef>>>;


### PR DESCRIPTION
Use `WeakShared` futures in the layout caches, so once all work is dropped the underlying result is dropped.