### PR TITLE
Remove thread local from FFI, use multi-threaded runtime for now

### DIFF
--- a/vortex-ffi/src/file.rs
+++ b/vortex-ffi/src/file.rs
@@ -25,7 +25,7 @@ use vortex::stream::ArrayStreamArrayExt;
 use crate::array::vx_array;
 use crate::error::{try_or, vx_error};
 use crate::stream::{ArrayStreamInner, vx_array_stream};
-use crate::{to_string, to_string_vec};
+use crate::{RUNTIME, to_string, to_string_vec};
 
 /// A file reader that can be used to read from a file.
 #[allow(non_camel_case_types)]
@@ -88,7 +88,7 @@ pub unsafe extern "C-unwind" fn vx_file_open_reader(
 
         let object_store = make_object_store(&uri, &prop_keys, &prop_vals)?;
 
-        let inner = futures::executor::block_on(async move {
+        let inner = RUNTIME.block_on(async move {
             VortexOpenOptions::file()
                 .open_object_store(&object_store, uri.path())
                 .await
@@ -107,7 +107,7 @@ pub unsafe extern "C-unwind" fn vx_file_write_array(
         let array = unsafe { ffi_array.as_ref().vortex_expect("null array") };
         let path = CStr::from_ptr(path).to_str()?;
 
-        futures::executor::block_on(async {
+        RUNTIME.block_on(async {
             VortexWriteOptions::default()
                 .write(
                     &mut File::create(path).await?,

--- a/vortex-ffi/src/file.rs
+++ b/vortex-ffi/src/file.rs
@@ -91,12 +91,10 @@ pub unsafe extern "C-unwind" fn vx_file_open_reader(
 
             // TODO(joe): replace with futures::executor::block_on, currently vortex-file has a hidden
             // tokio dep
-            let inner = RUNTIME.with(|r| {
-                r.block_on(async move {
-                    VortexOpenOptions::file()
-                        .open_object_store(&object_store, uri.path())
-                        .await
-                })
+            let inner = futures::executor::block_on(async move {
+                VortexOpenOptions::file()
+                    .open_object_store(&object_store, uri.path())
+                    .await
             })?;
             Ok(Box::into_raw(Box::new(vx_file_reader { inner })))
         }
@@ -113,16 +111,14 @@ pub unsafe extern "C-unwind" fn vx_file_write_array(
         let array = unsafe { ffi_array.as_ref().vortex_expect("null array") };
         let path = CStr::from_ptr(path).to_str()?;
 
-        RUNTIME.with(|r| {
-            r.block_on(async move {
-                VortexWriteOptions::default()
-                    .write(
-                        &mut File::create(path).await?,
-                        array.inner.to_array_stream(),
-                    )
-                    .await?;
-                Ok(())
-            })
+        futures::executor::block_on(async {
+            VortexWriteOptions::default()
+                .write(
+                    &mut File::create(path).await?,
+                    array.inner.to_array_stream(),
+                )
+                .await?;
+            Ok(())
         })
     });
 }

--- a/vortex-ffi/src/file.rs
+++ b/vortex-ffi/src/file.rs
@@ -71,33 +71,29 @@ pub unsafe extern "C-unwind" fn vx_file_open_reader(
     error: *mut *mut vx_error,
 ) -> *mut vx_file_reader {
     try_or(error, ptr::null_mut(), || {
-        {
-            let options = unsafe {
-                options
-                    .as_ref()
-                    .ok_or_else(|| vortex_err!("null options"))?
-            };
+        let options = unsafe {
+            options
+                .as_ref()
+                .ok_or_else(|| vortex_err!("null options"))?
+        };
 
-            if options.uri.is_null() {
-                vortex_bail!("null uri")
-            }
-            let uri = CStr::from_ptr(options.uri).to_string_lossy();
-            let uri: Url = uri.parse().vortex_expect("File_open: parse uri");
-
-            let prop_keys = to_string_vec(options.property_keys, options.property_len);
-            let prop_vals = to_string_vec(options.property_vals, options.property_len);
-
-            let object_store = make_object_store(&uri, &prop_keys, &prop_vals)?;
-
-            // TODO(joe): replace with futures::executor::block_on, currently vortex-file has a hidden
-            // tokio dep
-            let inner = futures::executor::block_on(async move {
-                VortexOpenOptions::file()
-                    .open_object_store(&object_store, uri.path())
-                    .await
-            })?;
-            Ok(Box::into_raw(Box::new(vx_file_reader { inner })))
+        if options.uri.is_null() {
+            vortex_bail!("null uri")
         }
+        let uri = CStr::from_ptr(options.uri).to_string_lossy();
+        let uri: Url = uri.parse().vortex_expect("File_open: parse uri");
+
+        let prop_keys = to_string_vec(options.property_keys, options.property_len);
+        let prop_vals = to_string_vec(options.property_vals, options.property_len);
+
+        let object_store = make_object_store(&uri, &prop_keys, &prop_vals)?;
+
+        let inner = futures::executor::block_on(async move {
+            VortexOpenOptions::file()
+                .open_object_store(&object_store, uri.path())
+                .await
+        })?;
+        Ok(Box::into_raw(Box::new(vx_file_reader { inner })))
     })
 }
 

--- a/vortex-ffi/src/file.rs
+++ b/vortex-ffi/src/file.rs
@@ -25,7 +25,7 @@ use vortex::stream::ArrayStreamArrayExt;
 use crate::array::vx_array;
 use crate::error::{try_or, vx_error};
 use crate::stream::{ArrayStreamInner, vx_array_stream};
-use crate::{RUNTIME, to_string, to_string_vec};
+use crate::{to_string, to_string_vec};
 
 /// A file reader that can be used to read from a file.
 #[allow(non_camel_case_types)]

--- a/vortex-ffi/src/lib.rs
+++ b/vortex-ffi/src/lib.rs
@@ -13,7 +13,6 @@ mod stream;
 
 use std::ffi::{CStr, c_char, c_int};
 use std::sync::LazyLock;
-use std::thread::Builder;
 
 pub use log::vx_log_level;
 use tokio::runtime;

--- a/vortex-ffi/src/lib.rs
+++ b/vortex-ffi/src/lib.rs
@@ -12,10 +12,8 @@ mod log;
 mod stream;
 
 use std::ffi::{CStr, c_char, c_int};
-use std::sync::LazyLock;
 
 pub use log::vx_log_level;
-use tokio::runtime::{Builder, Runtime};
 use vortex::error::VortexExpect;
 
 #[cfg(all(feature = "mimalloc", not(miri)))]

--- a/vortex-ffi/src/lib.rs
+++ b/vortex-ffi/src/lib.rs
@@ -12,12 +12,23 @@ mod log;
 mod stream;
 
 use std::ffi::{CStr, c_char, c_int};
+use std::sync::LazyLock;
+use std::thread::Builder;
 
 pub use log::vx_log_level;
+use tokio::runtime;
+use tokio::runtime::Runtime;
 
 #[cfg(all(feature = "mimalloc", not(miri)))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
+    runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Cannot start runtime")
+});
 
 pub(crate) unsafe fn to_string(ptr: *const c_char) -> String {
     let c_str = CStr::from_ptr(ptr);

--- a/vortex-ffi/src/lib.rs
+++ b/vortex-ffi/src/lib.rs
@@ -18,6 +18,7 @@ use std::thread::Builder;
 pub use log::vx_log_level;
 use tokio::runtime;
 use tokio::runtime::Runtime;
+use vortex::error::VortexExpect;
 
 #[cfg(all(feature = "mimalloc", not(miri)))]
 #[global_allocator]
@@ -27,7 +28,7 @@ static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
     runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
-        .expect("Cannot start runtime")
+        .vortex_expect("Cannot start runtime")
 });
 
 pub(crate) unsafe fn to_string(ptr: *const c_char) -> String {

--- a/vortex-ffi/src/lib.rs
+++ b/vortex-ffi/src/lib.rs
@@ -22,16 +22,6 @@ use vortex::error::VortexExpect;
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-thread_local! {
-    static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
-        // Using a new_multi_thread runtime since a current local runtime has a deadlock.
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .vortex_expect("building runtime")
-    });
-}
-
 pub(crate) unsafe fn to_string(ptr: *const c_char) -> String {
     let c_str = CStr::from_ptr(ptr);
     c_str.to_string_lossy().into_owned()

--- a/vortex-ffi/src/lib.rs
+++ b/vortex-ffi/src/lib.rs
@@ -14,7 +14,6 @@ mod stream;
 use std::ffi::{CStr, c_char, c_int};
 
 pub use log::vx_log_level;
-use vortex::error::VortexExpect;
 
 #[cfg(all(feature = "mimalloc", not(miri)))]
 #[global_allocator]


### PR DESCRIPTION
We should add a non-tokio file option