### PR TITLE
fix rustfmt

### DIFF
--- a/vortex-file/src/generic.rs
+++ b/vortex-file/src/generic.rs
@@ -142,7 +142,17 @@ impl VortexOpenOptions<GenericVortexFile> {
         let postscript = self.parse_postscript(&initial_read)?;
 
         // If we haven't been provided a DType, we must read one from the file.
-        let dtype_segment = self.dtype.is_none().then(|| postscript.dtype.ok_or_else(|| vortex_err!("Vortex file doesn't embed a DType and one has not been provided to VortexOpenOptions"))).transpose()?;
+        let dtype_segment = self
+            .dtype
+            .is_none()
+            .then(|| {
+                postscript.dtype.ok_or_else(|| {
+                    vortex_err!(
+                        "Vortex file doesn't embed a DType and none provided to VortexOpenOptions"
+                    )
+                })
+            })
+            .transpose()?;
 
         // The other postscript segments are required, so now we figure out our the offset that
         // contains all the required segments.


### PR DESCRIPTION
TIL rustfmt gives up on the entire block if it includes a string long enough to not fit on a single line: https://github.com/rust-lang/rustfmt/issues/3863

This PR makes the error message a bit shorter so rustfmt works