### PR TITLE
Expose `vortex-io` through the ubercrate

### DIFF
--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -6,7 +6,7 @@ pub use vortex_array::*;
 pub use vortex_file as file;
 pub use {
     vortex_btrblocks as compressor, vortex_buffer as buffer, vortex_dtype as dtype,
-    vortex_error as error, vortex_expr as expr, vortex_flatbuffers as flatbuffers,
+    vortex_error as error, vortex_expr as expr, vortex_flatbuffers as flatbuffers, vortex_io as io,
     vortex_ipc as ipc, vortex_layout as layout, vortex_mask as mask, vortex_proto as proto,
     vortex_scalar as scalar,
 };

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -4,9 +4,11 @@
 pub use vortex_array::*;
 #[cfg(feature = "files")]
 pub use vortex_file as file;
+#[cfg(feature = "files")]
+pub use vortex_io as io;
 pub use {
     vortex_btrblocks as compressor, vortex_buffer as buffer, vortex_dtype as dtype,
-    vortex_error as error, vortex_expr as expr, vortex_flatbuffers as flatbuffers, vortex_io as io,
+    vortex_error as error, vortex_expr as expr, vortex_flatbuffers as flatbuffers,
     vortex_ipc as ipc, vortex_layout as layout, vortex_mask as mask, vortex_proto as proto,
     vortex_scalar as scalar,
 };


### PR DESCRIPTION
Needed to allow users of `Vortex` to implement external readers.