### PR TITLE
DictLayout uses regular PType for metadata

### DIFF
--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, OnceLock, RwLock};
 use futures::FutureExt;
 use vortex_array::aliases::hash_map::HashMap;
 use vortex_array::{ArrayContext, DeserializeMetadata, ProstMetadata};
-use vortex_dtype::{DType, PType};
+use vortex_dtype::DType;
 use vortex_error::{VortexExpect, VortexResult, vortex_panic};
 use vortex_expr::{ExprRef, Identity};
 use vortex_mask::Mask;
@@ -41,8 +41,8 @@ impl DictReader {
             .child(0, layout.dtype().clone(), "values")?
             .reader(segment_source, ctx)?;
 
-        let codes_dtype = DType::from(PType::from(metadata.codes_ptype()))
-            .with_nullability(values.dtype().nullability());
+        let codes_dtype =
+            DType::from(metadata.codes_ptype()).with_nullability(values.dtype().nullability());
 
         let codes = layout
             .child(1, codes_dtype, "codes")?

--- a/vortex-layout/src/layouts/dict/writer/mod.rs
+++ b/vortex-layout/src/layouts/dict/writer/mod.rs
@@ -6,7 +6,6 @@ use vortex_array::{Array, ArrayContext, ArrayRef, ProstMetadata, SerializeMetada
 use vortex_btrblocks::BtrBlocksCompressor;
 use vortex_dict::DictEncoding;
 use vortex_dict::builders::{DictConstraints, DictEncoder, dict_encoder};
-use vortex_dtype::proto::dtype as pb;
 use vortex_dtype::{DType, PType};
 use vortex_error::{VortexResult, vortex_bail, vortex_err};
 
@@ -123,7 +122,7 @@ impl LayoutWriter for DelegatingDictLayoutWriter {
 
 #[derive(prost::Message)]
 pub struct DictLayoutMetadata {
-    #[prost(enumeration = "pb::PType", tag = "1")]
+    #[prost(enumeration = "PType", tag = "1")]
     // i32 is required for proto, use the generated getter to read this field.
     codes_ptype: i32,
 }
@@ -131,14 +130,14 @@ pub struct DictLayoutMetadata {
 impl DictLayoutMetadata {
     pub fn new(codes_ptype: PType) -> Self {
         let mut metadata = Self::default();
-        metadata.set_codes_ptype(codes_ptype.into());
+        metadata.set_codes_ptype(codes_ptype);
         metadata
     }
 }
 
 fn dict_layout(values: Layout, codes: Layout) -> VortexResult<Layout> {
-    let metadata = Bytes::copy_from_slice(
-        &ProstMetadata(DictLayoutMetadata::new(codes.dtype().try_into()?))
+    let metadata = Bytes::from(
+        ProstMetadata(DictLayoutMetadata::new(codes.dtype().try_into()?))
             .serialize()
             .ok_or_else(|| vortex_err!("could not serialize dict layout metadata"))?,
     );

--- a/vortex-tui/src/browse/app.rs
+++ b/vortex-tui/src/browse/app.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use ratatui::widgets::ListState;
-use vortex::dtype::{DType, PType};
+use vortex::dtype::DType;
 use vortex::error::{VortexExpect, VortexResult, VortexUnwrap, vortex_panic};
 use vortex::file::{Footer, SegmentSpec, VortexFile, VortexOpenOptions};
 use vortex::stats::stats_from_bitset_bytes;
@@ -99,8 +99,7 @@ impl LayoutCursor {
                             layout.metadata().as_ref().map(|b| b.as_ref()),
                         )
                         .expect("dict metadata");
-                        DType::from(PType::from(metadata.codes_ptype()))
-                            .with_nullability(dtype.nullability())
+                        DType::from(metadata.codes_ptype()).with_nullability(dtype.nullability())
                     }
                     _ => vortex_panic!("can't have more than 2 children for dict layout"),
                 }


### PR DESCRIPTION
Since regular PType now has prost annotations we don't have to use the generated one. We do have a bit of a redundancy now where DType generated proto definition and other objects are manually tagged leading to a duplicate PType proto definition 