### PR TITLE
Truncate stats on write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6522,7 +6522,6 @@ dependencies = [
  "bytes",
  "dashmap",
  "flatbuffers",
- "flume",
  "futures",
  "getrandom 0.3.2",
  "itertools 0.14.0",
@@ -6546,6 +6545,7 @@ dependencies = [
  "vortex-flatbuffers",
  "vortex-mask",
  "vortex-metrics",
+ "vortex-scalar",
 ]
 
 [[package]]

--- a/duckdb-vortex/src/include/vortex_common.hpp
+++ b/duckdb-vortex/src/include/vortex_common.hpp
@@ -139,7 +139,9 @@ struct ArrayStreamSink {
 
 	~ArrayStreamSink() {
 		// "should dctor a sink, before closing it
-		D_ASSERT(sink == nullptr);
+		// If you throw during writes then the stack will be unwound and the destructor is going to be called before the
+		// close method is invoked thus triggering following assertion failure and will clobber the exception printing
+		// D_ASSERT(sink == nullptr);
 	}
 
 	vx_array_sink *sink;

--- a/vortex-array/src/builders/decimal.rs
+++ b/vortex-array/src/builders/decimal.rs
@@ -107,7 +107,7 @@ impl<T: NativeDecimalType> DecimalBuilder<T> {
     }
 }
 
-impl<T: NativeDecimalType + Default + Send + 'static> ArrayBuilder for DecimalBuilder<T> {
+impl<T: NativeDecimalType> ArrayBuilder for DecimalBuilder<T> {
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -43,6 +43,7 @@ pub use extension::*;
 pub use list::*;
 pub use null::*;
 pub use primitive::*;
+pub use struct_::*;
 pub use varbinview::*;
 use vortex_dtype::{DType, match_each_native_ptype};
 use vortex_error::{VortexResult, vortex_bail, vortex_err};
@@ -53,7 +54,6 @@ use vortex_scalar::{
 };
 
 use crate::arrays::precision_to_storage_size;
-use crate::builders::struct_::StructBuilder;
 use crate::{Array, ArrayRef};
 
 pub trait ArrayBuilder: Send {

--- a/vortex-array/src/stats/array.rs
+++ b/vortex-array/src/stats/array.rs
@@ -156,9 +156,9 @@ impl StatsSetRef<'_> {
 
     pub fn compute_all(&self, stats: &[Stat]) -> VortexResult<StatsSet> {
         let mut stats_set = StatsSet::default();
-        for stat in stats {
-            if let Some(s) = self.compute_stat(*stat)? {
-                stats_set.set(*stat, Precision::exact(s))
+        for &stat in stats {
+            if let Some(s) = self.compute_stat(stat)? {
+                stats_set.set(stat, Precision::exact(s))
             }
         }
         Ok(stats_set)

--- a/vortex-array/src/stats/mod.rs
+++ b/vortex-array/src/stats/mod.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 
 use arrow_buffer::bit_iterator::BitIterator;
 use arrow_buffer::{BooleanBufferBuilder, MutableBuffer};
-use enum_iterator::{Sequence, last};
+use enum_iterator::{Sequence, all, last};
 use log::debug;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 pub use stats_set::*;
@@ -35,19 +35,6 @@ pub const PRUNING_STATS: &[Stat] = &[
     Stat::Sum,
     Stat::NullCount,
     Stat::NaNCount,
-];
-
-/// Stats to keep when serializing arrays to layouts
-pub const STATS_TO_WRITE: &[Stat] = &[
-    Stat::Min,
-    Stat::Max,
-    Stat::NullCount,
-    Stat::NaNCount,
-    Stat::Sum,
-    Stat::IsConstant,
-    Stat::IsSorted,
-    Stat::IsStrictSorted,
-    Stat::UncompressedSizeInBytes,
 ];
 
 #[derive(
@@ -235,6 +222,10 @@ impl Stat {
             Self::Sum => "sum",
             Self::NaNCount => "nan_count",
         }
+    }
+
+    pub fn all() -> impl Iterator<Item = Stat> {
+        all::<Self>()
     }
 }
 

--- a/vortex-array/src/stats/precision.rs
+++ b/vortex-array/src/stats/precision.rs
@@ -25,8 +25,8 @@ where
 {
     fn clone(&self) -> Self {
         match self {
-            Self::Exact(e) => Self::Exact(e.clone()),
-            Self::Inexact(ie) => Self::Inexact(ie.clone()),
+            Exact(e) => Exact(e.clone()),
+            Inexact(ie) => Inexact(ie.clone()),
         }
     }
 }
@@ -129,7 +129,8 @@ impl<T> Precision<T> {
         Ok(precision)
     }
 
-    pub(crate) fn into_inner(self) -> T {
+    /// Unwrap the underlying value
+    pub fn into_inner(self) -> T {
         match self {
             Exact(val) | Inexact(val) => val,
         }

--- a/vortex-buffer/src/string.rs
+++ b/vortex-buffer/src/string.rs
@@ -27,6 +27,11 @@ impl BufferString {
     pub fn into_inner(self) -> ByteBuffer {
         self.0
     }
+
+    /// Returns reference to the inner [`ByteBuffer`].
+    pub fn inner(&self) -> &ByteBuffer {
+        &self.0
+    }
 }
 
 impl Debug for BufferString {

--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -20,6 +20,7 @@ use crate::{EOF_SIZE, MAGIC_BYTES, MAX_FOOTER_SIZE, VERSION};
 pub struct VortexWriteOptions {
     strategy: Box<dyn LayoutStrategy>,
     exclude_dtype: bool,
+    max_variable_length_statistics_size: usize,
     file_statistics: Vec<Stat>,
 }
 
@@ -29,6 +30,7 @@ impl Default for VortexWriteOptions {
             strategy: Box::new(VortexLayoutStrategy),
             exclude_dtype: false,
             file_statistics: PRUNING_STATS.to_vec(),
+            max_variable_length_statistics_size: 64,
         }
     }
 }
@@ -70,6 +72,7 @@ impl VortexWriteOptions {
             self.strategy.new_writer(&ctx, stream.dtype())?,
             stream.dtype(),
             self.file_statistics.clone().into(),
+            self.max_variable_length_statistics_size,
         )?;
 
         // First we write the magic number

--- a/vortex-flatbuffers/flatbuffers/vortex-array/array.fbs
+++ b/vortex-flatbuffers/flatbuffers/vortex-array/array.fbs
@@ -34,10 +34,17 @@ table ArrayNode {
     stats: ArrayStats;
 }
 
+enum Precision: uint8 {
+    Inexact = 0,
+    Exact = 1,
+}
+
 table ArrayStats {
     /// Protobuf serialized ScalarValue
     min: [ubyte];
+    min_precision: Precision;
     max: [ubyte];
+    max_precision: Precision;
     sum: [ubyte];
     is_sorted: bool = null;
     is_strict_sorted: bool = null;

--- a/vortex-flatbuffers/src/generated/array.rs
+++ b/vortex-flatbuffers/src/generated/array.rs
@@ -95,6 +95,91 @@ impl<'a> flatbuffers::Verifiable for Compression {
 }
 
 impl flatbuffers::SimpleToVerifyInSlice for Compression {}
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+pub const ENUM_MIN_PRECISION: u8 = 0;
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+pub const ENUM_MAX_PRECISION: u8 = 1;
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[allow(non_camel_case_types)]
+pub const ENUM_VALUES_PRECISION: [Precision; 2] = [
+  Precision::Inexact,
+  Precision::Exact,
+];
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+pub struct Precision(pub u8);
+#[allow(non_upper_case_globals)]
+impl Precision {
+  pub const Inexact: Self = Self(0);
+  pub const Exact: Self = Self(1);
+
+  pub const ENUM_MIN: u8 = 0;
+  pub const ENUM_MAX: u8 = 1;
+  pub const ENUM_VALUES: &'static [Self] = &[
+    Self::Inexact,
+    Self::Exact,
+  ];
+  /// Returns the variant's name or "" if unknown.
+  pub fn variant_name(self) -> Option<&'static str> {
+    match self {
+      Self::Inexact => Some("Inexact"),
+      Self::Exact => Some("Exact"),
+      _ => None,
+    }
+  }
+}
+impl core::fmt::Debug for Precision {
+  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    if let Some(name) = self.variant_name() {
+      f.write_str(name)
+    } else {
+      f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
+    }
+  }
+}
+impl<'a> flatbuffers::Follow<'a> for Precision {
+  type Inner = Self;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+    Self(b)
+  }
+}
+
+impl flatbuffers::Push for Precision {
+    type Output = Precision;
+    #[inline]
+    unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
+        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+    }
+}
+
+impl flatbuffers::EndianScalar for Precision {
+  type Scalar = u8;
+  #[inline]
+  fn to_little_endian(self) -> u8 {
+    self.0.to_le()
+  }
+  #[inline]
+  #[allow(clippy::wrong_self_convention)]
+  fn from_little_endian(v: u8) -> Self {
+    let b = u8::from_le(v);
+    Self(b)
+  }
+}
+
+impl<'a> flatbuffers::Verifiable for Precision {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    u8::run_verifier(v, pos)
+  }
+}
+
+impl flatbuffers::SimpleToVerifyInSlice for Precision {}
 /// A Buffer describes the location of a data buffer in the byte stream as a packed 64-bit struct.
 // struct Buffer, aligned to 4
 #[repr(transparent)]
@@ -592,14 +677,16 @@ impl<'a> flatbuffers::Follow<'a> for ArrayStats<'a> {
 
 impl<'a> ArrayStats<'a> {
   pub const VT_MIN: flatbuffers::VOffsetT = 4;
-  pub const VT_MAX: flatbuffers::VOffsetT = 6;
-  pub const VT_SUM: flatbuffers::VOffsetT = 8;
-  pub const VT_IS_SORTED: flatbuffers::VOffsetT = 10;
-  pub const VT_IS_STRICT_SORTED: flatbuffers::VOffsetT = 12;
-  pub const VT_IS_CONSTANT: flatbuffers::VOffsetT = 14;
-  pub const VT_NULL_COUNT: flatbuffers::VOffsetT = 16;
-  pub const VT_UNCOMPRESSED_SIZE_IN_BYTES: flatbuffers::VOffsetT = 18;
-  pub const VT_NAN_COUNT: flatbuffers::VOffsetT = 20;
+  pub const VT_MIN_PRECISION: flatbuffers::VOffsetT = 6;
+  pub const VT_MAX: flatbuffers::VOffsetT = 8;
+  pub const VT_MAX_PRECISION: flatbuffers::VOffsetT = 10;
+  pub const VT_SUM: flatbuffers::VOffsetT = 12;
+  pub const VT_IS_SORTED: flatbuffers::VOffsetT = 14;
+  pub const VT_IS_STRICT_SORTED: flatbuffers::VOffsetT = 16;
+  pub const VT_IS_CONSTANT: flatbuffers::VOffsetT = 18;
+  pub const VT_NULL_COUNT: flatbuffers::VOffsetT = 20;
+  pub const VT_UNCOMPRESSED_SIZE_IN_BYTES: flatbuffers::VOffsetT = 22;
+  pub const VT_NAN_COUNT: flatbuffers::VOffsetT = 24;
 
   #[inline]
   pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -620,6 +707,8 @@ impl<'a> ArrayStats<'a> {
     if let Some(x) = args.is_constant { builder.add_is_constant(x); }
     if let Some(x) = args.is_strict_sorted { builder.add_is_strict_sorted(x); }
     if let Some(x) = args.is_sorted { builder.add_is_sorted(x); }
+    builder.add_max_precision(args.max_precision);
+    builder.add_min_precision(args.min_precision);
     builder.finish()
   }
 
@@ -633,11 +722,25 @@ impl<'a> ArrayStats<'a> {
     unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(ArrayStats::VT_MIN, None)}
   }
   #[inline]
+  pub fn min_precision(&self) -> Precision {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<Precision>(ArrayStats::VT_MIN_PRECISION, Some(Precision::Inexact)).unwrap()}
+  }
+  #[inline]
   pub fn max(&self) -> Option<flatbuffers::Vector<'a, u8>> {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
     unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(ArrayStats::VT_MAX, None)}
+  }
+  #[inline]
+  pub fn max_precision(&self) -> Precision {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<Precision>(ArrayStats::VT_MAX_PRECISION, Some(Precision::Inexact)).unwrap()}
   }
   #[inline]
   pub fn sum(&self) -> Option<flatbuffers::Vector<'a, u8>> {
@@ -698,7 +801,9 @@ impl flatbuffers::Verifiable for ArrayStats<'_> {
     use self::flatbuffers::Verifiable;
     v.visit_table(pos)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>("min", Self::VT_MIN, false)?
+     .visit_field::<Precision>("min_precision", Self::VT_MIN_PRECISION, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>("max", Self::VT_MAX, false)?
+     .visit_field::<Precision>("max_precision", Self::VT_MAX_PRECISION, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>("sum", Self::VT_SUM, false)?
      .visit_field::<bool>("is_sorted", Self::VT_IS_SORTED, false)?
      .visit_field::<bool>("is_strict_sorted", Self::VT_IS_STRICT_SORTED, false)?
@@ -712,7 +817,9 @@ impl flatbuffers::Verifiable for ArrayStats<'_> {
 }
 pub struct ArrayStatsArgs<'a> {
     pub min: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
+    pub min_precision: Precision,
     pub max: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
+    pub max_precision: Precision,
     pub sum: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
     pub is_sorted: Option<bool>,
     pub is_strict_sorted: Option<bool>,
@@ -726,7 +833,9 @@ impl<'a> Default for ArrayStatsArgs<'a> {
   fn default() -> Self {
     ArrayStatsArgs {
       min: None,
+      min_precision: Precision::Inexact,
       max: None,
+      max_precision: Precision::Inexact,
       sum: None,
       is_sorted: None,
       is_strict_sorted: None,
@@ -748,8 +857,16 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ArrayStatsBuilder<'a, 'b, A> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ArrayStats::VT_MIN, min);
   }
   #[inline]
+  pub fn add_min_precision(&mut self, min_precision: Precision) {
+    self.fbb_.push_slot::<Precision>(ArrayStats::VT_MIN_PRECISION, min_precision, Precision::Inexact);
+  }
+  #[inline]
   pub fn add_max(&mut self, max: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u8>>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ArrayStats::VT_MAX, max);
+  }
+  #[inline]
+  pub fn add_max_precision(&mut self, max_precision: Precision) {
+    self.fbb_.push_slot::<Precision>(ArrayStats::VT_MAX_PRECISION, max_precision, Precision::Inexact);
   }
   #[inline]
   pub fn add_sum(&mut self, sum: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u8>>) {
@@ -798,7 +915,9 @@ impl core::fmt::Debug for ArrayStats<'_> {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
     let mut ds = f.debug_struct("ArrayStats");
       ds.field("min", &self.min());
+      ds.field("min_precision", &self.min_precision());
       ds.field("max", &self.max());
+      ds.field("max_precision", &self.max_precision());
       ds.field("sum", &self.sum());
       ds.field("is_sorted", &self.is_sorted());
       ds.field("is_strict_sorted", &self.is_strict_sorted());

--- a/vortex-flatbuffers/src/generated/message.rs
+++ b/vortex-flatbuffers/src/generated/message.rs
@@ -3,8 +3,8 @@
 
 // @generated
 
-use crate::array::*;
 use crate::dtype::*;
+use crate::array::*;
 use core::mem;
 use core::cmp::Ordering;
 

--- a/vortex-layout/Cargo.toml
+++ b/vortex-layout/Cargo.toml
@@ -23,7 +23,6 @@ bit-vec = { workspace = true }
 bytes = { workspace = true }
 dashmap = { workspace = true }
 flatbuffers = { workspace = true }
-flume = { workspace = true }
 futures = { workspace = true, features = ["alloc", "async-await", "executor"] }
 getrandom_v03 = { workspace = true }
 itertools = { workspace = true }
@@ -48,6 +47,7 @@ vortex-expr = { workspace = true }
 vortex-flatbuffers = { workspace = true, features = ["layout"] }
 vortex-mask = { workspace = true }
 vortex-metrics = { workspace = true }
+vortex-scalar = { workspace = true }
 
 [dev-dependencies]
 futures = { workspace = true, features = ["executor"] }

--- a/vortex-layout/src/layouts/file_stats.rs
+++ b/vortex-layout/src/layouts/file_stats.rs
@@ -24,13 +24,21 @@ impl FileStatsLayoutWriter {
         inner: Box<dyn LayoutWriter>,
         dtype: &DType,
         stats: Arc<[Stat]>,
+        max_variable_length_statistics_size: usize,
     ) -> VortexResult<Self> {
         let stats_accumulators = match dtype.as_struct() {
             Some(dtype) => dtype
                 .fields()
-                .map(|field_dtype| StatsAccumulator::new(field_dtype, &stats))
+                .map(|field_dtype| {
+                    StatsAccumulator::new(&field_dtype, &stats, max_variable_length_statistics_size)
+                })
                 .collect(),
-            None => [StatsAccumulator::new(dtype.clone(), &stats)].into(),
+            None => [StatsAccumulator::new(
+                dtype,
+                &stats,
+                max_variable_length_statistics_size,
+            )]
+            .into(),
         };
 
         Ok(Self {

--- a/vortex-layout/src/layouts/stats/mod.rs
+++ b/vortex-layout/src/layouts/stats/mod.rs
@@ -1,0 +1,50 @@
+mod builder;
+mod eval_expr;
+mod reader;
+pub mod stats_table;
+pub mod writer;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+pub use builder::{lower_bound, upper_bound};
+use vortex_array::ArrayContext;
+use vortex_dtype::FieldMask;
+use vortex_error::VortexResult;
+
+use crate::data::Layout;
+use crate::layouts::stats::reader::StatsReader;
+use crate::reader::{LayoutReader, LayoutReaderExt};
+use crate::segments::SegmentSource;
+use crate::vtable::LayoutVTable;
+use crate::{LayoutId, STATS_LAYOUT_ID};
+
+#[derive(Default, Debug)]
+pub struct StatsLayout;
+
+/// First child contains the data, second child contains the statistics table.
+impl LayoutVTable for StatsLayout {
+    fn id(&self) -> LayoutId {
+        STATS_LAYOUT_ID
+    }
+
+    fn reader(
+        &self,
+        layout: Layout,
+        segment_source: &Arc<dyn SegmentSource>,
+        ctx: &ArrayContext,
+    ) -> VortexResult<Arc<dyn LayoutReader>> {
+        Ok(StatsReader::try_new(layout, segment_source, ctx)?.into_arc())
+    }
+
+    fn register_splits(
+        &self,
+        layout: &Layout,
+        field_mask: &[FieldMask],
+        row_offset: u64,
+        splits: &mut BTreeSet<u64>,
+    ) -> VortexResult<()> {
+        layout
+            .child(0, layout.dtype().clone(), "data")?
+            .register_splits(field_mask, row_offset, splits)
+    }
+}

--- a/vortex-layout/src/layouts/struct_/writer.rs
+++ b/vortex-layout/src/layouts/struct_/writer.rs
@@ -43,7 +43,7 @@ impl StructLayoutWriter {
     pub fn try_new_with_strategy<S: LayoutStrategy>(
         ctx: &ArrayContext,
         dtype: &DType,
-        factory: S,
+        factory: &S,
     ) -> VortexResult<Self> {
         let struct_dtype = dtype
             .as_struct()

--- a/vortex-layout/src/layouts/zoned/builder.rs
+++ b/vortex-layout/src/layouts/zoned/builder.rs
@@ -1,0 +1,307 @@
+use std::marker::PhantomData;
+
+use vortex_array::arrays::ConstantArray;
+use vortex_array::builders::{ArrayBuilder, ArrayBuilderExt, BoolBuilder, builder_with_capacity};
+use vortex_array::stats::Stat;
+use vortex_array::{Array, ArrayRef, IntoArray};
+use vortex_dtype::{DType, FieldName, Nullability};
+use vortex_error::VortexResult;
+use vortex_scalar::{BinaryScalar, ScalarValue, Utf8Scalar};
+
+pub const MAX_IS_TRUNCATED: &str = "max_is_truncated";
+pub const MIN_IS_TRUNCATED: &str = "min_is_truncated";
+
+pub fn stats_builder_with_capacity(
+    stat: Stat,
+    dtype: &DType,
+    capacity: usize,
+    max_length: usize,
+) -> Box<dyn StatsArrayBuilder> {
+    let values_builder = builder_with_capacity(dtype, capacity);
+    match stat {
+        Stat::Max => match dtype {
+            DType::Utf8(_) => Box::new(TruncatedMaxBinaryStatsBuilder::<Utf8Scalar>::new(
+                values_builder,
+                BoolBuilder::with_capacity(Nullability::NonNullable, capacity),
+                max_length,
+            )),
+            DType::Binary(_) => Box::new(TruncatedMaxBinaryStatsBuilder::<BinaryScalar>::new(
+                values_builder,
+                BoolBuilder::with_capacity(Nullability::NonNullable, capacity),
+                max_length,
+            )),
+            _ => Box::new(StatNameArrayBuilder::new(stat, values_builder)),
+        },
+        Stat::Min => match dtype {
+            DType::Utf8(_) => Box::new(TruncatedMinBinaryStatsBuilder::<Utf8Scalar>::new(
+                values_builder,
+                BoolBuilder::with_capacity(Nullability::NonNullable, capacity),
+                max_length,
+            )),
+            DType::Binary(_) => Box::new(TruncatedMinBinaryStatsBuilder::<BinaryScalar>::new(
+                values_builder,
+                BoolBuilder::with_capacity(Nullability::NonNullable, capacity),
+                max_length,
+            )),
+            _ => Box::new(StatNameArrayBuilder::new(stat, values_builder)),
+        },
+        _ => Box::new(StatNameArrayBuilder::new(stat, values_builder)),
+    }
+}
+
+/// Arrays with their associated names, reduced version of a StructArray
+pub struct NamedArrays {
+    pub names: Vec<FieldName>,
+    pub arrays: Vec<ArrayRef>,
+}
+
+impl NamedArrays {
+    pub fn all_invalid(&self) -> VortexResult<bool> {
+        // by convention we assume that the first array is the one we care about for logical validity
+        self.arrays[0].all_invalid()
+    }
+}
+
+/// Minimal array builder interface for use by StatsTable for building stats arrays
+pub trait StatsArrayBuilder: Send {
+    fn stat(&self) -> Stat;
+
+    fn append_scalar_value(&mut self, value: ScalarValue) -> VortexResult<()>;
+
+    fn append_null(&mut self);
+
+    fn finish(&mut self) -> NamedArrays;
+}
+
+pub struct StatNameArrayBuilder {
+    stat: Stat,
+    builder: Box<dyn ArrayBuilder>,
+}
+
+impl StatNameArrayBuilder {
+    pub fn new(stat: Stat, builder: Box<dyn ArrayBuilder>) -> Self {
+        Self { stat, builder }
+    }
+}
+
+impl StatsArrayBuilder for StatNameArrayBuilder {
+    fn stat(&self) -> Stat {
+        self.stat
+    }
+
+    fn append_scalar_value(&mut self, value: ScalarValue) -> VortexResult<()> {
+        self.builder.append_scalar_value(value)
+    }
+
+    fn append_null(&mut self) {
+        self.builder.append_null()
+    }
+
+    fn finish(&mut self) -> NamedArrays {
+        let array = self.builder.finish();
+        let len = array.len();
+        match self.stat {
+            Stat::Max => NamedArrays {
+                names: vec![self.stat.name().into(), MAX_IS_TRUNCATED.into()],
+                arrays: vec![array, ConstantArray::new(false, len).into_array()],
+            },
+            Stat::Min => NamedArrays {
+                names: vec![self.stat.name().into(), MIN_IS_TRUNCATED.into()],
+                arrays: vec![array, ConstantArray::new(false, len).into_array()],
+            },
+            _ => NamedArrays {
+                names: vec![self.stat.name().into()],
+                arrays: vec![array],
+            },
+        }
+    }
+}
+
+struct TruncatedMaxBinaryStatsBuilder<T: ScalarTruncation> {
+    values: Box<dyn ArrayBuilder>,
+    is_truncated: BoolBuilder,
+    max_value_length: usize,
+    _marker: PhantomData<T>,
+}
+
+impl<T: ScalarTruncation> TruncatedMaxBinaryStatsBuilder<T> {
+    pub fn new(
+        values: Box<dyn ArrayBuilder>,
+        is_truncated: BoolBuilder,
+        max_value_length: usize,
+    ) -> Self {
+        Self {
+            values,
+            is_truncated,
+            max_value_length,
+            _marker: PhantomData,
+        }
+    }
+}
+
+struct TruncatedMinBinaryStatsBuilder<T: ScalarTruncation> {
+    values: Box<dyn ArrayBuilder>,
+    is_truncated: BoolBuilder,
+    max_value_length: usize,
+    _marker: PhantomData<T>,
+}
+
+impl<T: ScalarTruncation> TruncatedMinBinaryStatsBuilder<T> {
+    pub fn new(
+        values: Box<dyn ArrayBuilder>,
+        is_truncated: BoolBuilder,
+        max_value_length: usize,
+    ) -> Self {
+        Self {
+            values,
+            is_truncated,
+            max_value_length,
+            _marker: PhantomData,
+        }
+    }
+}
+
+pub trait ScalarTruncation: Send + Sized {
+    fn from_scalar_value(dtype: &DType, value: ScalarValue) -> VortexResult<impl ScalarTruncation>;
+
+    fn len(&self) -> Option<usize>;
+
+    fn into_value(self) -> ScalarValue;
+
+    fn upper_bound(self, max_length: usize) -> Option<Self>;
+
+    fn lower_bound(self, max_length: usize) -> Self;
+}
+
+impl ScalarTruncation for BinaryScalar<'_> {
+    fn from_scalar_value(dtype: &DType, value: ScalarValue) -> VortexResult<impl ScalarTruncation> {
+        BinaryScalar::from_scalar_value(dtype, value)
+    }
+
+    fn len(&self) -> Option<usize> {
+        self.len()
+    }
+
+    fn into_value(self) -> ScalarValue {
+        self.into_value()
+    }
+
+    fn upper_bound(self, max_length: usize) -> Option<Self> {
+        self.upper_bound(max_length)
+    }
+
+    fn lower_bound(self, max_length: usize) -> Self {
+        self.lower_bound(max_length)
+    }
+}
+
+impl ScalarTruncation for Utf8Scalar<'_> {
+    fn from_scalar_value(dtype: &DType, value: ScalarValue) -> VortexResult<impl ScalarTruncation> {
+        Utf8Scalar::from_scalar_value(dtype, value)
+    }
+
+    fn len(&self) -> Option<usize> {
+        self.len()
+    }
+
+    fn into_value(self) -> ScalarValue {
+        self.into_value()
+    }
+
+    fn upper_bound(self, max_length: usize) -> Option<Self> {
+        self.upper_bound(max_length)
+    }
+
+    fn lower_bound(self, max_length: usize) -> Self {
+        self.lower_bound(max_length)
+    }
+}
+
+impl<T: ScalarTruncation> StatsArrayBuilder for TruncatedMaxBinaryStatsBuilder<T> {
+    fn stat(&self) -> Stat {
+        Stat::Max
+    }
+
+    fn append_scalar_value(&mut self, value: ScalarValue) -> VortexResult<()> {
+        let (value, truncated) =
+            upper_bound::<T>(self.values.dtype(), value, self.max_value_length)?;
+
+        if let Some(upper_bound) = value {
+            ArrayBuilderExt::append_scalar_value(self.values.as_mut(), upper_bound)?;
+            self.is_truncated.append_value(truncated);
+        } else {
+            self.append_null()
+        }
+        Ok(())
+    }
+
+    fn append_null(&mut self) {
+        ArrayBuilder::append_null(self.values.as_mut());
+        self.is_truncated.append_value(false);
+    }
+
+    fn finish(&mut self) -> NamedArrays {
+        NamedArrays {
+            names: vec![Stat::Max.name().into(), MAX_IS_TRUNCATED.into()],
+            arrays: vec![
+                ArrayBuilder::finish(self.values.as_mut()),
+                ArrayBuilder::finish(&mut self.is_truncated),
+            ],
+        }
+    }
+}
+
+impl<T: ScalarTruncation> StatsArrayBuilder for TruncatedMinBinaryStatsBuilder<T> {
+    fn stat(&self) -> Stat {
+        Stat::Min
+    }
+
+    fn append_scalar_value(&mut self, value: ScalarValue) -> VortexResult<()> {
+        let (value, truncated) =
+            lower_bound::<T>(self.values.dtype(), value, self.max_value_length)?;
+        ArrayBuilderExt::append_scalar_value(self.values.as_mut(), value)?;
+        self.is_truncated.append_value(truncated);
+        Ok(())
+    }
+
+    fn append_null(&mut self) {
+        ArrayBuilder::append_null(self.values.as_mut());
+        self.is_truncated.append_value(false);
+    }
+
+    fn finish(&mut self) -> NamedArrays {
+        NamedArrays {
+            names: vec![Stat::Min.name().into(), MIN_IS_TRUNCATED.into()],
+            arrays: vec![
+                ArrayBuilder::finish(self.values.as_mut()),
+                ArrayBuilder::finish(&mut self.is_truncated),
+            ],
+        }
+    }
+}
+
+pub fn lower_bound<T: ScalarTruncation>(
+    dtype: &DType,
+    value: ScalarValue,
+    max_length: usize,
+) -> VortexResult<(ScalarValue, bool)> {
+    let trunc = T::from_scalar_value(dtype, value)?;
+    if trunc.len().unwrap_or(0) > max_length {
+        Ok((trunc.lower_bound(max_length).into_value(), true))
+    } else {
+        Ok((trunc.into_value(), false))
+    }
+}
+
+pub fn upper_bound<T: ScalarTruncation>(
+    dtype: &DType,
+    value: ScalarValue,
+    max_length: usize,
+) -> VortexResult<(Option<ScalarValue>, bool)> {
+    let trunc = T::from_scalar_value(dtype, value)?;
+    if trunc.len().unwrap_or(0) > max_length {
+        Ok((trunc.upper_bound(max_length).map(|v| v.into_value()), true))
+    } else {
+        Ok((Some(trunc.into_value()), false))
+    }
+}

--- a/vortex-layout/src/layouts/zoned/mod.rs
+++ b/vortex-layout/src/layouts/zoned/mod.rs
@@ -1,3 +1,4 @@
+mod builder;
 mod reader;
 pub mod writer;
 pub mod zone_map;
@@ -5,6 +6,7 @@ pub mod zone_map;
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
+pub use builder::{MAX_IS_TRUNCATED, MIN_IS_TRUNCATED, lower_bound, upper_bound};
 use vortex_array::stats::{Stat, as_stat_bitset_bytes, stats_from_bitset_bytes};
 use vortex_array::{ArrayContext, DeserializeMetadata, SerializeMetadata};
 use vortex_dtype::{DType, FieldMask, TryFromBytes};

--- a/vortex-layout/src/layouts/zoned/writer.rs
+++ b/vortex-layout/src/layouts/zoned/writer.rs
@@ -18,6 +18,8 @@ pub struct ZonedLayoutOptions {
     pub block_size: usize,
     /// The statistics to collect for each block.
     pub stats: Arc<[Stat]>,
+    /// Maximum length of a variable length statistics
+    pub max_variable_length_statistics_size: usize,
 }
 
 impl Default for ZonedLayoutOptions {
@@ -25,6 +27,7 @@ impl Default for ZonedLayoutOptions {
         Self {
             block_size: 8192,
             stats: PRUNING_STATS.into(),
+            max_variable_length_statistics_size: 64,
         }
     }
 }
@@ -54,7 +57,11 @@ impl ZonedLayoutWriter {
         options: ZonedLayoutOptions,
     ) -> Self {
         let present_stats: Arc<[Stat]> = options.stats.iter().sorted().copied().collect();
-        let stats_accumulator = StatsAccumulator::new(dtype.clone(), &present_stats);
+        let stats_accumulator = StatsAccumulator::new(
+            dtype,
+            &present_stats,
+            options.max_variable_length_statistics_size,
+        );
 
         Self {
             ctx,

--- a/vortex-layout/src/strategy.rs
+++ b/vortex-layout/src/strategy.rs
@@ -22,7 +22,8 @@ pub struct StructStrategy;
 impl LayoutStrategy for StructStrategy {
     fn new_writer(&self, ctx: &ArrayContext, dtype: &DType) -> VortexResult<Box<dyn LayoutWriter>> {
         if let DType::Struct(..) = dtype {
-            StructLayoutWriter::try_new_with_strategy(ctx, dtype, StructStrategy).map(|w| w.boxed())
+            StructLayoutWriter::try_new_with_strategy(ctx, dtype, &StructStrategy)
+                .map(|w| w.boxed())
         } else {
             Ok(FlatLayoutWriter::new(ctx.clone(), dtype.clone(), Default::default()).boxed())
         }

--- a/vortex-scalar/src/datafusion.rs
+++ b/vortex-scalar/src/datafusion.rs
@@ -64,12 +64,16 @@ impl TryFrom<Scalar> for ScalarValue {
                     }
                 }
             }
-            DType::Utf8(_) => {
-                ScalarValue::Utf8(scalar.as_utf8().value().map(|s| s.as_str().to_string()))
-            }
-            DType::Binary(_) => {
-                ScalarValue::Binary(scalar.as_binary().value().map(|b| b.as_slice().to_vec()))
-            }
+            // SAFETY: By construction Utf8 scalar values are utf8
+            DType::Utf8(_) => ScalarValue::Utf8(scalar.as_utf8().value().map(|s| unsafe {
+                String::from_utf8_unchecked(Vec::<u8>::from(s.into_inner().into_inner()))
+            })),
+            DType::Binary(_) => ScalarValue::Binary(
+                scalar
+                    .as_binary()
+                    .value()
+                    .map(|b| Vec::<u8>::from(b.into_inner())),
+            ),
             DType::Struct(..) => {
                 todo!("struct scalar conversion")
             }

--- a/vortex-scalar/src/decimal.rs
+++ b/vortex-scalar/src/decimal.rs
@@ -32,7 +32,7 @@ pub enum DecimalValue {
 }
 
 /// Type of decimal scalar values.
-pub trait NativeDecimalType: Copy + Eq + Ord {
+pub trait NativeDecimalType: Copy + Eq + Ord + Default + Send + Sync + 'static {
     const VALUES_TYPE: DecimalValueType;
 }
 

--- a/vortex-scalar/src/scalar_value/binary.rs
+++ b/vortex-scalar/src/scalar_value/binary.rs
@@ -12,7 +12,9 @@ impl<'a> TryFrom<&'a ScalarValue> for ByteBuffer {
     fn try_from(scalar: &'a ScalarValue) -> VortexResult<Self> {
         Ok(scalar
             .as_buffer()?
-            .vortex_expect("Can't convert null scalar into a byte buffer"))
+            .vortex_expect("Can't convert null scalar into a byte buffer")
+            .as_ref()
+            .clone())
     }
 }
 
@@ -20,7 +22,7 @@ impl<'a> TryFrom<&'a ScalarValue> for Option<ByteBuffer> {
     type Error = VortexError;
 
     fn try_from(scalar: &'a ScalarValue) -> VortexResult<Self> {
-        scalar.as_buffer()
+        Ok(scalar.as_buffer()?.as_ref().map(|b| b.as_ref().clone()))
     }
 }
 

--- a/vortex-scalar/src/scalar_value/utf8.rs
+++ b/vortex-scalar/src/scalar_value/utf8.rs
@@ -50,6 +50,6 @@ impl<'a> TryFrom<&'a ScalarValue> for Option<BufferString> {
     type Error = VortexError;
 
     fn try_from(scalar: &'a ScalarValue) -> Result<Self, Self::Error> {
-        scalar.as_buffer_string()
+        Ok(scalar.as_buffer_string()?.map(|s| s.as_ref().clone()))
     }
 }


### PR DESCRIPTION
When truncating min we take the prefix and for max we increment the value until it doesn't overflow. Needs some tests