### PR TITLE
duckdb: switch to https://github.com/cameron314/concurrentqueue

### DIFF
--- a/duckdb-vortex/vcpkg.json
+++ b/duckdb-vortex/vcpkg.json
@@ -1,7 +1,3 @@
 {
-  "dependencies": [
-    { "name": "atomic-queue" },
-    { "name": "catch2" },
-    { "name": "protobuf" }
-  ]
+  "dependencies": [{ "name": "catch2" }, { "name": "protobuf" }]
 }


### PR DESCRIPTION
This PR switches to the lock-free queue used in the DuckDB Vortex extension to https://github.com/cameron314/concurrentqueue. Besides removing an additional vcpkg managed dependency (DuckDB repo includes this 3rd party lock-free queue), we need to use a queue which allocates on push instead of throwing an error in case the capacity is exhausted.