### PR TITLE
Compute between on empty array should not error

### DIFF
--- a/vortex-array/src/compute/between.rs
+++ b/vortex-array/src/compute/between.rs
@@ -114,7 +114,13 @@ impl ComputeFnVTable for Between {
 
         let return_dtype = self.return_dtype(args)?;
 
+        // Bail early if the array is empty.
+        if array.is_empty() {
+            return Ok(Canonical::empty(&return_dtype).into_array().into());
+        }
+
         // A quick check to see if either array might is a null constant array.
+        // Note: Depends on returning early if array is empty for is_invalid check.
         if lower.is_invalid(0)? || upper.is_invalid(0)? {
             if let (Some(c_lower), Some(c_upper)) = (lower.as_constant(), upper.as_constant()) {
                 if c_lower.is_null() || c_upper.is_null() {


### PR DESCRIPTION
The following expression can't be evaluated on an empty array
```
expr: Between { 
arr: GetItem { field: "y", child: Identity }, 
lower: Literal { value: Scalar { dtype: Primitive(I64, Nullable), value: ScalarValue(Primitive(I64(65552))) } }, 
upper: Literal { value: Scalar { dtype: Primitive(I64, Nullable), value: ScalarValue(Primitive(I64(196624))) } }, 
options: BetweenOptions { lower_strict: NonStrict, upper_strict: Strict } }
```

The reason is that evaluating literal returns an empty constant array https://github.com/vortex-data/vortex/blob/develop/vortex-expr/src/literal.rs#L90 and therefore `if lower.is_invalid(0)? || upper.is_invalid(0)? {` condition fails because all arrays are empty.

I'm not sure, but I doubt between can assume lower / upper non-empty so this adds a check to bail early and not hit that condition.
