### PR TITLE
Abstract access to ArrayChildren during decode

### DIFF
--- a/encodings/bytebool/src/serde.rs
+++ b/encodings/bytebool/src/serde.rs
@@ -1,9 +1,8 @@
-use vortex_array::serde::ArrayParts;
+use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
 use vortex_array::vtable::{SerdeVTable, ValidityHelper, VisitorVTable};
 use vortex_array::{
-    ArrayBufferVisitor, ArrayChildVisitor, ArrayContext, ArrayRef, DeserializeMetadata,
-    EmptyMetadata,
+    ArrayBufferVisitor, ArrayChildVisitor, ArrayRef, DeserializeMetadata, EmptyMetadata,
 };
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
@@ -20,17 +19,16 @@ impl SerdeVTable<ByteBoolVTable> for ByteBoolVTable {
 
     fn build(
         _encoding: &ByteBoolEncoding,
-        dtype: DType,
+        dtype: &DType,
         len: usize,
         _metadata: &<Self::Metadata as DeserializeMetadata>::Output,
         buffers: &[ByteBuffer],
-        children: &[ArrayParts],
-        ctx: &ArrayContext,
+        children: &dyn ArrayChildren,
     ) -> VortexResult<ByteBoolArray> {
         let validity = if children.is_empty() {
             Validity::from(dtype.nullability())
         } else if children.len() == 1 {
-            let validity = children[0].decode(ctx, Validity::DTYPE, len)?;
+            let validity = children.get(0, &Validity::DTYPE, len)?;
             Validity::Array(validity)
         } else {
             vortex_bail!("Expected 0 or 1 child, got {}", children.len());

--- a/pyvortex/src/arrays/py/vtable.rs
+++ b/pyvortex/src/arrays/py/vtable.rs
@@ -7,15 +7,15 @@ use vortex::dtype::DType;
 use vortex::error::{VortexResult, vortex_err};
 use vortex::mask::Mask;
 use vortex::scalar::Scalar;
-use vortex::serde::ArrayParts;
+use vortex::serde::ArrayChildren;
 use vortex::stats::StatsSetRef;
 use vortex::vtable::{
     ArrayVTable, CanonicalVTable, ComputeVTable, EncodeVTable, OperationsVTable, SerdeVTable,
     VTable, ValidityVTable, VisitorVTable,
 };
 use vortex::{
-    Array, ArrayBufferVisitor, ArrayChildVisitor, ArrayContext, ArrayRef, Canonical,
-    DeserializeMetadata, EncodingId, EncodingRef, RawMetadata, vtable,
+    Array, ArrayBufferVisitor, ArrayChildVisitor, ArrayRef, Canonical, DeserializeMetadata,
+    EncodingId, EncodingRef, RawMetadata, vtable,
 };
 
 use crate::arrays::py::{PythonArray, PythonEncoding};
@@ -150,12 +150,11 @@ impl SerdeVTable<PythonVTable> for PythonVTable {
 
     fn build(
         _encoding: &PythonEncoding,
-        _dtype: DType,
+        _dtype: &DType,
         _len: usize,
         _metadata: &<Self::Metadata as DeserializeMetadata>::Output,
         _buffers: &[ByteBuffer],
-        _children: &[ArrayParts],
-        _ctx: &ArrayContext,
+        _children: &dyn ArrayChildren,
     ) -> VortexResult<PythonArray> {
         todo!()
     }

--- a/pyvortex/src/serde/parts.rs
+++ b/pyvortex/src/serde/parts.rs
@@ -45,11 +45,7 @@ impl PyArrayParts {
     ///
     /// The decoded array.
     fn decode(&self, ctx: &PyArrayContext, dtype: PyDType, len: usize) -> PyResult<PyArrayRef> {
-        Ok(PyArrayRef::from(self.0.decode(
-            ctx,
-            dtype.into_inner(),
-            len,
-        )?))
+        Ok(PyArrayRef::from(self.0.decode(ctx, dtype.inner(), len)?))
     }
 
     /// Fetch the serialized metadata of the array.

--- a/vortex-array/src/arrays/constant/serde.rs
+++ b/vortex-array/src/arrays/constant/serde.rs
@@ -3,10 +3,10 @@ use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_bail};
 use vortex_scalar::{Scalar, ScalarValue};
 
+use crate::EmptyMetadata;
 use crate::arrays::{ConstantArray, ConstantEncoding, ConstantVTable};
-use crate::serde::ArrayParts;
+use crate::serde::ArrayChildren;
 use crate::vtable::SerdeVTable;
-use crate::{ArrayContext, EmptyMetadata};
 
 impl SerdeVTable<ConstantVTable> for ConstantVTable {
     type Metadata = EmptyMetadata;
@@ -17,18 +17,17 @@ impl SerdeVTable<ConstantVTable> for ConstantVTable {
 
     fn build(
         _encoding: &ConstantEncoding,
-        dtype: DType,
+        dtype: &DType,
         len: usize,
         _metadata: &Self::Metadata,
         buffers: &[ByteBuffer],
-        _children: &[ArrayParts],
-        _ctx: &ArrayContext,
+        _children: &dyn ArrayChildren,
     ) -> VortexResult<ConstantArray> {
         if buffers.len() != 1 {
             vortex_bail!("Expected 1 buffer, got {}", buffers.len());
         }
         let sv = ScalarValue::from_protobytes(&buffers[0])?;
-        let scalar = Scalar::new(dtype, sv);
+        let scalar = Scalar::new(dtype.clone(), sv);
         Ok(ConstantArray::new(scalar, len))
     }
 }

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -4,15 +4,15 @@ use vortex_error::VortexResult;
 use vortex_mask::Mask;
 use vortex_scalar::Scalar;
 
-use crate::serde::ArrayParts;
+use crate::serde::ArrayChildren;
 use crate::stats::{ArrayStats, StatsSetRef};
 use crate::vtable::{
     ArrayVTable, CanonicalVTable, NotSupported, OperationsVTable, SerdeVTable, VTable,
     ValidityVTable, VisitorVTable,
 };
 use crate::{
-    ArrayBufferVisitor, ArrayChildVisitor, ArrayContext, ArrayRef, Canonical, EmptyMetadata,
-    EncodingId, EncodingRef, IntoArray, vtable,
+    ArrayBufferVisitor, ArrayChildVisitor, ArrayRef, Canonical, EmptyMetadata, EncodingId,
+    EncodingRef, IntoArray, vtable,
 };
 
 mod compute;
@@ -82,12 +82,11 @@ impl SerdeVTable<NullVTable> for NullVTable {
 
     fn build(
         _encoding: &NullEncoding,
-        _dtype: DType,
+        _dtype: &DType,
         len: usize,
         _metadata: &Self::Metadata,
         _buffers: &[ByteBuffer],
-        _children: &[ArrayParts],
-        _ctx: &ArrayContext,
+        _children: &dyn ArrayChildren,
     ) -> VortexResult<NullArray> {
         Ok(NullArray::new(len))
     }

--- a/vortex-array/src/data.rs
+++ b/vortex-array/src/data.rs
@@ -1,0 +1,79 @@
+use vortex_buffer::ByteBuffer;
+use vortex_dtype::DType;
+use vortex_error::{VortexError, VortexResult, vortex_bail, vortex_err};
+
+use crate::serde::ArrayChildren;
+use crate::{Array, ArrayRef, EncodingRef};
+
+#[derive(Clone, Debug)]
+pub struct ArrayData {
+    encoding: EncodingRef,
+    len: usize,
+    dtype: DType,
+    metadata: Vec<u8>,
+    buffers: Vec<ByteBuffer>,
+    children: Vec<ArrayData>,
+}
+
+impl ArrayChildren for ArrayData {
+    fn get(&self, index: usize, dtype: &DType, len: usize) -> VortexResult<ArrayRef> {
+        if index >= self.children.len() {
+            vortex_bail!("Index out of bounds");
+        }
+        let child = &self.children[index];
+        if child.len != len {
+            vortex_bail!(
+                "Child length mismatch. Provided {}, but actually {}",
+                len,
+                child.len
+            );
+        }
+        if child.dtype != *dtype {
+            vortex_bail!(
+                "Child dtype mismatch. Provided {:?}, but actually {:?}",
+                dtype,
+                child.dtype
+            );
+        }
+        ArrayRef::try_from(child)
+    }
+
+    fn len(&self) -> usize {
+        self.children.len()
+    }
+}
+
+impl TryFrom<&dyn Array> for ArrayData {
+    type Error = VortexError;
+
+    fn try_from(value: &dyn Array) -> Result<Self, Self::Error> {
+        Ok(ArrayData {
+            encoding: value.encoding(),
+            len: value.len(),
+            dtype: value.dtype().clone(),
+            metadata: value
+                .metadata()?
+                .ok_or_else(|| vortex_err!("Array does not support serialization"))?,
+            buffers: value.buffers().to_vec(),
+            children: value
+                .children()
+                .iter()
+                .map(|child| child.as_ref().try_into())
+                .try_collect()?,
+        })
+    }
+}
+
+impl TryFrom<&ArrayData> for ArrayRef {
+    type Error = VortexError;
+
+    fn try_from(value: &ArrayData) -> Result<Self, Self::Error> {
+        value.encoding.build(
+            &value.dtype,
+            value.len,
+            &value.metadata,
+            &value.buffers,
+            value,
+        )
+    }
+}

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -30,6 +30,7 @@ mod canonical;
 pub mod compress;
 pub mod compute;
 mod context;
+pub mod data;
 mod encoding;
 pub mod iter;
 mod metadata;

--- a/vortex-array/src/vtable/serde.rs
+++ b/vortex-array/src/vtable/serde.rs
@@ -4,9 +4,9 @@ use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_bail};
 
-use crate::serde::ArrayParts;
+use crate::serde::ArrayChildren;
 use crate::vtable::{NotSupported, VTable};
-use crate::{ArrayContext, DeserializeMetadata, EmptyMetadata, SerializeMetadata};
+use crate::{DeserializeMetadata, EmptyMetadata, SerializeMetadata};
 
 /// VTable for assisting with the serialization and deserialiation of arrays.
 ///
@@ -28,12 +28,11 @@ pub trait SerdeVTable<V: VTable> {
     /// Build an array from its given parts.
     fn build(
         encoding: &V::Encoding,
-        dtype: DType,
+        dtype: &DType,
         len: usize,
         metadata: &<Self::Metadata as DeserializeMetadata>::Output,
         buffers: &[ByteBuffer],
-        children: &[ArrayParts],
-        ctx: &ArrayContext,
+        children: &dyn ArrayChildren,
     ) -> VortexResult<V::Array>;
 }
 
@@ -46,12 +45,11 @@ impl<V: VTable> SerdeVTable<V> for NotSupported {
 
     fn build(
         encoding: &V::Encoding,
-        _dtype: DType,
+        _dtype: &DType,
         _len: usize,
         _metadata: &Self::Metadata,
         _buffers: &[ByteBuffer],
-        _children: &[ArrayParts],
-        _ctx: &ArrayContext,
+        _children: &dyn ArrayChildren,
     ) -> VortexResult<V::Array> {
         vortex_bail!("Serde not supported by {} encoding", V::id(encoding));
     }

--- a/vortex-ipc/src/iterator.rs
+++ b/vortex-ipc/src/iterator.rs
@@ -44,7 +44,7 @@ impl<R: Read> Iterator for SyncIPCReader<R> {
             Ok(msg) => match msg {
                 DecoderMessage::Array((array_parts, ctx, row_count)) => Some(
                     array_parts
-                        .decode(&ctx, self.dtype.clone(), row_count)
+                        .decode(&ctx, &self.dtype, row_count)
                         .and_then(|array| {
                             if array.dtype() != self.dtype() {
                                 Err(vortex_err!(

--- a/vortex-ipc/src/messages/decoder.rs
+++ b/vortex-ipc/src/messages/decoder.rs
@@ -179,7 +179,7 @@ mod test {
 
         // Decode the array parts with the context
         let actual = array_parts
-            .decode(&ctx, expected.dtype().clone(), row_count)
+            .decode(&ctx, expected.dtype(), row_count)
             .unwrap();
 
         assert_eq!(expected.len(), actual.len());

--- a/vortex-ipc/src/stream.rs
+++ b/vortex-ipc/src/stream.rs
@@ -59,7 +59,7 @@ impl<R: AsyncRead> Stream for AsyncIPCReader<R> {
             Some(msg) => match msg {
                 Ok(DecoderMessage::Array((array_parts, ctx, row_count))) => Poll::Ready(Some(
                     array_parts
-                        .decode(&ctx, this.dtype.clone(), row_count)
+                        .decode(&ctx, this.dtype, row_count)
                         .and_then(|array| {
                             if array.dtype() != this.dtype {
                                 Err(vortex_err!(

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -63,7 +63,7 @@ impl FlatReader {
                 async move {
                     let segment = segment_fut.await?;
                     ArrayParts::try_from(segment)?
-                        .decode(&ctx, dtype.clone(), row_count)
+                        .decode(&ctx, &dtype, row_count)
                         .map_err(Arc::new)
                 }
                 .boxed()


### PR DESCRIPTION
Instead of exposing ArrayParts (which requires a flatbuffer array representation), this PR changes the VTable to accept a `&dyn ArrayChildren` that provides an abstract accessor to decode children. 

This will allow us to use the same build function to remove replace_children from the vtable, that way sharing the same validation logic as the decode.