### PR TITLE
feat: extension pluggability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6237,11 +6237,13 @@ name = "vortex-dtype"
 version = "0.33.0"
 dependencies = [
  "arbitrary",
+ "arcref",
  "arrow-schema",
  "flatbuffers",
  "half",
  "itertools 0.14.0",
  "jiff",
+ "log",
  "num-traits",
  "num_enum 0.7.3",
  "prost",

--- a/encodings/datetime-parts/src/canonical.rs
+++ b/encodings/datetime-parts/src/canonical.rs
@@ -31,11 +31,11 @@ pub fn decode_to_temporal(array: &DateTimePartsArray) -> VortexResult<TemporalAr
     };
 
     let divisor = match temporal_metadata.time_unit() {
-        TimeUnit::Ns => 1_000_000_000,
-        TimeUnit::Us => 1_000_000,
-        TimeUnit::Ms => 1_000,
-        TimeUnit::S => 1,
-        TimeUnit::D => vortex_bail!(InvalidArgument: "cannot decode into TimeUnit::D"),
+        TimeUnit::Nano => 1_000_000_000,
+        TimeUnit::Micro => 1_000_000,
+        TimeUnit::Milli => 1_000,
+        TimeUnit::Second => 1,
+        TimeUnit::Day => vortex_bail!(InvalidArgument: "cannot decode into TimeUnit::D"),
     };
 
     let days_buf = cast(
@@ -127,7 +127,7 @@ mod test {
         );
         let date_times = DateTimePartsArray::try_from(TemporalArray::new_timestamp(
             milliseconds.clone().into_array(),
-            TimeUnit::Ms,
+            TimeUnit::Milli,
             Some("UTC".to_string()),
         ))
         .unwrap();

--- a/encodings/datetime-parts/src/compress.rs
+++ b/encodings/datetime-parts/src/compress.rs
@@ -90,7 +90,7 @@ mod tests {
         )
         .into_array();
         let temporal_array =
-            TemporalArray::new_timestamp(milliseconds, TimeUnit::Ms, Some("UTC".to_string()));
+            TemporalArray::new_timestamp(milliseconds, TimeUnit::Milli, Some("UTC".to_string()));
         let TemporalParts {
             days,
             seconds,

--- a/encodings/datetime-parts/src/compute/cast.rs
+++ b/encodings/datetime-parts/src/compute/cast.rs
@@ -50,7 +50,7 @@ mod tests {
                 validity,
             )
             .into_array(),
-            TimeUnit::Ms,
+            TimeUnit::Milli,
             Some("UTC".to_string()),
         ))
         .unwrap()

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -168,7 +168,7 @@ mod test {
     fn dtp_array_from_timestamp<T: NativePType>(value: T) -> DateTimePartsArray {
         DateTimePartsArray::try_from(TemporalArray::new_timestamp(
             PrimitiveArray::new(buffer![value], Validity::NonNullable).into_array(),
-            TimeUnit::S,
+            TimeUnit::Second,
             Some("UTC".to_string()),
         ))
         .expect("Failed to construct DateTimePartsArray from TemporalArray")
@@ -220,7 +220,7 @@ mod test {
     fn compare_date_time_parts_narrowing() {
         let temporal_array = TemporalArray::new_timestamp(
             PrimitiveArray::new(buffer![0i64], Validity::NonNullable).into_array(),
-            TimeUnit::S,
+            TimeUnit::Second,
             Some("UTC".to_string()),
         );
 

--- a/encodings/datetime-parts/src/timestamp.rs
+++ b/encodings/datetime-parts/src/timestamp.rs
@@ -27,11 +27,11 @@ pub struct TimestampParts {
 /// Returns an error if `time_unit` is days, which cannot be split.
 pub fn split(timestamp: i64, time_unit: TimeUnit) -> VortexResult<TimestampParts> {
     let divisor = match time_unit {
-        TimeUnit::Ns => 1_000_000_000,
-        TimeUnit::Us => 1_000_000,
-        TimeUnit::Ms => 1_000,
-        TimeUnit::S => 1,
-        TimeUnit::D => vortex_bail!("Cannot handle day-level data"),
+        TimeUnit::Nano => 1_000_000_000,
+        TimeUnit::Micro => 1_000_000,
+        TimeUnit::Milli => 1_000,
+        TimeUnit::Second => 1,
+        TimeUnit::Day => vortex_bail!("Cannot handle day-level data"),
     };
 
     let ticks_per_day = SECONDS_PER_DAY * divisor;
@@ -54,11 +54,11 @@ pub fn split(timestamp: i64, time_unit: TimeUnit) -> VortexResult<TimestampParts
 /// Returns an error if `time_unit` is days, which cannot be combined.
 pub fn combine(ts_parts: TimestampParts, time_unit: TimeUnit) -> VortexResult<i64> {
     let divisor = match time_unit {
-        TimeUnit::Ns => 1_000_000_000,
-        TimeUnit::Us => 1_000_000,
-        TimeUnit::Ms => 1_000,
-        TimeUnit::S => 1,
-        TimeUnit::D => vortex_bail!("Cannot handle day-level data"),
+        TimeUnit::Nano => 1_000_000_000,
+        TimeUnit::Micro => 1_000_000,
+        TimeUnit::Milli => 1_000,
+        TimeUnit::Second => 1,
+        TimeUnit::Day => vortex_bail!("Cannot handle day-level data"),
     };
 
     Ok(
@@ -76,7 +76,7 @@ mod tests {
     fn test_split_seconds() {
         // 1970-01-02 01:02:03 UTC
         let ts = SECONDS_PER_DAY + 3723; // 1 day + (1*3600 + 2*60 + 3) seconds
-        let parts = split(ts, TimeUnit::S).unwrap();
+        let parts = split(ts, TimeUnit::Second).unwrap();
         assert_eq!(parts.days, 1);
         assert_eq!(parts.seconds, 3723);
         assert_eq!(parts.subseconds, 0);
@@ -86,7 +86,7 @@ mod tests {
     fn test_split_milliseconds() {
         // 1970-01-02 01:02:03.456 UTC
         let ts = (SECONDS_PER_DAY + 3723) * 1000 + 456;
-        let parts = split(ts, TimeUnit::Ms).unwrap();
+        let parts = split(ts, TimeUnit::Milli).unwrap();
         assert_eq!(parts.days, 1);
         assert_eq!(parts.seconds, 3723);
         assert_eq!(parts.subseconds, 456);
@@ -96,7 +96,7 @@ mod tests {
     fn test_split_microseconds() {
         // 1970-01-02 01:02:03.456789 UTC
         let ts = (SECONDS_PER_DAY + 3723) * 1_000_000 + 456789;
-        let parts = split(ts, TimeUnit::Us).unwrap();
+        let parts = split(ts, TimeUnit::Micro).unwrap();
         assert_eq!(parts.days, 1);
         assert_eq!(parts.seconds, 3723);
         assert_eq!(parts.subseconds, 456789);
@@ -106,7 +106,7 @@ mod tests {
     fn test_split_nanoseconds() {
         // 1970-01-02 01:02:03.456789123 UTC
         let ts = (SECONDS_PER_DAY + 3723) * 1_000_000_000 + 456789123;
-        let parts = split(ts, TimeUnit::Ns).unwrap();
+        let parts = split(ts, TimeUnit::Nano).unwrap();
         assert_eq!(parts.days, 1);
         assert_eq!(parts.seconds, 3723);
         assert_eq!(parts.subseconds, 456789123);
@@ -115,7 +115,12 @@ mod tests {
     #[test]
     fn test_split_epoch() {
         let ts = 0;
-        for unit in [TimeUnit::S, TimeUnit::Ms, TimeUnit::Us, TimeUnit::Ns] {
+        for unit in [
+            TimeUnit::Second,
+            TimeUnit::Milli,
+            TimeUnit::Micro,
+            TimeUnit::Nano,
+        ] {
             let parts = split(ts, unit).unwrap();
             assert_eq!(parts.days, 0);
             assert_eq!(parts.seconds, 0);
@@ -125,7 +130,7 @@ mod tests {
 
     #[test]
     fn test_split_days_error() {
-        assert!(split(1, TimeUnit::D).is_err());
+        assert!(split(1, TimeUnit::Day).is_err());
     }
 
     #[test]
@@ -136,7 +141,7 @@ mod tests {
             seconds: 3723, // 1*3600 + 2*60 + 3
             subseconds: 0,
         };
-        let ts = combine(parts, TimeUnit::S).unwrap();
+        let ts = combine(parts, TimeUnit::Second).unwrap();
         assert_eq!(ts, SECONDS_PER_DAY + 3723);
     }
 
@@ -148,7 +153,7 @@ mod tests {
             seconds: 3723,
             subseconds: 456,
         };
-        let ts = combine(parts, TimeUnit::Ms).unwrap();
+        let ts = combine(parts, TimeUnit::Milli).unwrap();
         assert_eq!(ts, (SECONDS_PER_DAY + 3723) * 1000 + 456);
     }
 
@@ -160,7 +165,7 @@ mod tests {
             seconds: 3723,
             subseconds: 456789,
         };
-        let ts = combine(parts, TimeUnit::Us).unwrap();
+        let ts = combine(parts, TimeUnit::Micro).unwrap();
         assert_eq!(ts, (SECONDS_PER_DAY + 3723) * 1_000_000 + 456789);
     }
 
@@ -172,7 +177,7 @@ mod tests {
             seconds: 3723,
             subseconds: 456789123,
         };
-        let ts = combine(parts, TimeUnit::Ns).unwrap();
+        let ts = combine(parts, TimeUnit::Nano).unwrap();
         assert_eq!(ts, (SECONDS_PER_DAY + 3723) * 1_000_000_000 + 456789123);
     }
 
@@ -183,6 +188,6 @@ mod tests {
             seconds: 0,
             subseconds: 0,
         };
-        assert!(combine(parts, TimeUnit::D).is_err());
+        assert!(combine(parts, TimeUnit::Day).is_err());
     }
 }

--- a/pyvortex/src/arrays/mod.rs
+++ b/pyvortex/src/arrays/mod.rs
@@ -218,7 +218,7 @@ impl PyArray {
         if let Some(chunked_array) = array.as_opt::<ChunkedVTable>() {
             // We figure out a single Arrow Data Type to convert all chunks into, otherwise
             // the preferred type of each chunk may be different.
-            let arrow_dtype = chunked_array.dtype().to_arrow_dtype()?;
+            let arrow_dtype = chunked_array.dtype().to_arrow()?;
 
             let chunks = chunked_array
                 .chunks()

--- a/pyvortex/src/dtype/mod.rs
+++ b/pyvortex/src/dtype/mod.rs
@@ -137,7 +137,7 @@ impl PyDType {
 #[pymethods]
 impl PyDType {
     fn to_arrow_type(&self, py: Python) -> PyResult<PyObject> {
-        self.0.to_arrow_dtype()?.into_pyarrow(py)
+        self.0.to_arrow()?.into_pyarrow(py)
     }
 
     fn to_arrow_schema(&self, py: Python) -> PyResult<PyObject> {

--- a/vortex-array/src/arrays/datetime/mod.rs
+++ b/vortex-array/src/arrays/datetime/mod.rs
@@ -70,10 +70,10 @@ impl TemporalArray {
     /// If any other time unit is provided, it panics.
     pub fn new_date(array: ArrayRef, time_unit: TimeUnit) -> Self {
         match time_unit {
-            TimeUnit::D => {
+            TimeUnit::Day => {
                 assert_width!(i32, array);
             }
-            TimeUnit::Ms => {
+            TimeUnit::Milli => {
                 assert_width!(i64, array);
             }
             _ => vortex_panic!("invalid TimeUnit {time_unit} for vortex.date"),
@@ -112,9 +112,9 @@ impl TemporalArray {
     /// If the time unit is nanoseconds, and the array is not of primitive I64 type, it panics.
     pub fn new_time(array: ArrayRef, time_unit: TimeUnit) -> Self {
         match time_unit {
-            TimeUnit::S | TimeUnit::Ms => assert_width!(i32, array),
-            TimeUnit::Us | TimeUnit::Ns => assert_width!(i64, array),
-            TimeUnit::D => vortex_panic!("invalid unit D for vortex.time data"),
+            TimeUnit::Second | TimeUnit::Milli => assert_width!(i32, array),
+            TimeUnit::Micro | TimeUnit::Nano => assert_width!(i64, array),
+            TimeUnit::Day => vortex_panic!("invalid unit D for vortex.time data"),
         }
 
         let temporal_metadata = TemporalMetadata::Time(time_unit);

--- a/vortex-array/src/arrays/datetime/test.rs
+++ b/vortex-array/src/arrays/datetime/test.rs
@@ -43,25 +43,25 @@ test_success_case!(
     test_roundtrip_time32_second,
     i32,
     TemporalArray::new_time,
-    TimeUnit::S
+    TimeUnit::Second
 );
 test_success_case!(
     test_roundtrip_time32_millisecond,
     i32,
     TemporalArray::new_time,
-    TimeUnit::Ms
+    TimeUnit::Milli
 );
 test_fail_case!(
     test_fail_time32_micro,
     i32,
     TemporalArray::new_time,
-    TimeUnit::Us
+    TimeUnit::Micro
 );
 test_fail_case!(
     test_fail_time32_nano,
     i32,
     TemporalArray::new_time,
-    TimeUnit::Ns
+    TimeUnit::Nano
 );
 
 // Time64 conformance tests
@@ -69,31 +69,31 @@ test_success_case!(
     test_roundtrip_time64_us,
     i64,
     TemporalArray::new_time,
-    TimeUnit::Us
+    TimeUnit::Micro
 );
 test_success_case!(
     test_roundtrip_time64_ns,
     i64,
     TemporalArray::new_time,
-    TimeUnit::Ns
+    TimeUnit::Nano
 );
 test_fail_case!(
     test_fail_time64_ms,
     i64,
     TemporalArray::new_time,
-    TimeUnit::Ms
+    TimeUnit::Milli
 );
 test_fail_case!(
     test_fail_time64_s,
     i64,
     TemporalArray::new_time,
-    TimeUnit::S
+    TimeUnit::Second
 );
 test_fail_case!(
     test_fail_time64_i32,
     i32,
     TemporalArray::new_time,
-    TimeUnit::Ns
+    TimeUnit::Nano
 );
 
 // Date32 conformance tests
@@ -101,18 +101,28 @@ test_success_case!(
     test_roundtrip_date32,
     i32,
     TemporalArray::new_date,
-    TimeUnit::D
+    TimeUnit::Day
 );
-test_fail_case!(test_fail_date32, i64, TemporalArray::new_date, TimeUnit::D);
+test_fail_case!(
+    test_fail_date32,
+    i64,
+    TemporalArray::new_date,
+    TimeUnit::Day
+);
 
 // Date64 conformance tests
 test_success_case!(
     test_roundtrip_date64,
     i64,
     TemporalArray::new_date,
-    TimeUnit::Ms
+    TimeUnit::Milli
 );
-test_fail_case!(test_fail_date64, i32, TemporalArray::new_date, TimeUnit::Ms);
+test_fail_case!(
+    test_fail_date64,
+    i32,
+    TemporalArray::new_date,
+    TimeUnit::Milli
+);
 
 // We test Timestamp explicitly to avoid the macro getting too complex.
 #[test]
@@ -120,7 +130,12 @@ fn test_timestamp() {
     let ts = PrimitiveArray::from_iter([100i64]);
     let ts_array = ts.into_array();
 
-    for unit in [TimeUnit::S, TimeUnit::Ms, TimeUnit::Us, TimeUnit::Ns] {
+    for unit in [
+        TimeUnit::Second,
+        TimeUnit::Milli,
+        TimeUnit::Micro,
+        TimeUnit::Nano,
+    ] {
         for tz in [Some("UTC".to_string()), None] {
             let temporal_array =
                 TemporalArray::new_timestamp(ts_array.to_array(), unit, tz.clone());
@@ -141,7 +156,7 @@ fn test_timestamp_fails_i32() {
     let ts = PrimitiveArray::from_iter([100i32]);
     let ts_array = ts.into_array();
 
-    let _ = TemporalArray::new_timestamp(ts_array, TimeUnit::S, None);
+    let _ = TemporalArray::new_timestamp(ts_array, TimeUnit::Second, None);
 }
 
 #[rstest]
@@ -160,7 +175,7 @@ fn test_validity_preservation(#[case] validity: Validity) {
     )
     .into_array();
     let temporal_array =
-        TemporalArray::new_timestamp(milliseconds, TimeUnit::Ms, Some("UTC".to_string()));
+        TemporalArray::new_timestamp(milliseconds, TimeUnit::Milli, Some("UTC".to_string()));
     assert_eq!(
         temporal_array
             .temporal_values()

--- a/vortex-array/src/arrow/compute/to_arrow/canonical.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/canonical.rs
@@ -46,7 +46,7 @@ impl Kernel for ToArrowCanonical {
         let arrow_type = arrow_type
             .cloned()
             .map(Ok)
-            .unwrap_or_else(|| array.dtype().to_arrow_dtype())?;
+            .unwrap_or_else(|| array.dtype().to_arrow())?;
 
         let arrow_array = match (array.to_canonical()?, &arrow_type) {
             (Canonical::Null(array), DataType::Null) => to_arrow_null(array),

--- a/vortex-array/src/arrow/compute/to_arrow/mod.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/mod.rs
@@ -258,7 +258,7 @@ mod tests {
         );
 
         assert_eq!(
-            &to_arrow(array.as_ref(), &array.dtype().to_arrow_dtype().unwrap()).unwrap(),
+            &to_arrow(array.as_ref(), &array.dtype().to_arrow().unwrap()).unwrap(),
             &arrow_array
         );
     }

--- a/vortex-array/src/arrow/compute/to_arrow/temporal.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/temporal.rs
@@ -44,41 +44,42 @@ impl Kernel for ToArrowTemporal {
             .unwrap_or_else(|| array.dtype().to_arrow())?;
 
         let arrow_array: ArrowArrayRef = match (array.temporal_metadata(), &arrow_type) {
-            (TemporalMetadata::Date(TimeUnit::D), DataType::Date32) => {
+            (TemporalMetadata::Date(TimeUnit::Day), DataType::Date32) => {
                 to_arrow_temporal::<Date32Type>(&array)
             }
-            (TemporalMetadata::Date(TimeUnit::Ms), DataType::Date64) => {
+            (TemporalMetadata::Date(TimeUnit::Milli), DataType::Date64) => {
                 to_arrow_temporal::<Date64Type>(&array)
             }
-            (TemporalMetadata::Time(TimeUnit::S), DataType::Time32(ArrowTimeUnit::Second)) => {
+            (TemporalMetadata::Time(TimeUnit::Second), DataType::Time32(ArrowTimeUnit::Second)) => {
                 to_arrow_temporal::<Time32SecondType>(&array)
             }
             (
-                TemporalMetadata::Time(TimeUnit::Ms),
+                TemporalMetadata::Time(TimeUnit::Milli),
                 DataType::Time32(ArrowTimeUnit::Millisecond),
             ) => to_arrow_temporal::<Time32MillisecondType>(&array),
             (
-                TemporalMetadata::Time(TimeUnit::Us),
+                TemporalMetadata::Time(TimeUnit::Micro),
                 DataType::Time64(ArrowTimeUnit::Microsecond),
             ) => to_arrow_temporal::<Time64MicrosecondType>(&array),
 
-            (TemporalMetadata::Time(TimeUnit::Ns), DataType::Time64(ArrowTimeUnit::Nanosecond)) => {
-                to_arrow_temporal::<Time64NanosecondType>(&array)
-            }
             (
-                TemporalMetadata::Timestamp(TimeUnit::S, _),
+                TemporalMetadata::Time(TimeUnit::Nano),
+                DataType::Time64(ArrowTimeUnit::Nanosecond),
+            ) => to_arrow_temporal::<Time64NanosecondType>(&array),
+            (
+                TemporalMetadata::Timestamp(TimeUnit::Second, _),
                 DataType::Timestamp(ArrowTimeUnit::Second, None),
             ) => to_arrow_temporal::<TimestampSecondType>(&array),
             (
-                TemporalMetadata::Timestamp(TimeUnit::Ms, _),
+                TemporalMetadata::Timestamp(TimeUnit::Milli, _),
                 DataType::Timestamp(ArrowTimeUnit::Millisecond, None),
             ) => to_arrow_temporal::<TimestampMillisecondType>(&array),
             (
-                TemporalMetadata::Timestamp(TimeUnit::Us, _),
+                TemporalMetadata::Timestamp(TimeUnit::Micro, _),
                 DataType::Timestamp(ArrowTimeUnit::Microsecond, None),
             ) => to_arrow_temporal::<TimestampMicrosecondType>(&array),
             (
-                TemporalMetadata::Timestamp(TimeUnit::Ns, _),
+                TemporalMetadata::Timestamp(TimeUnit::Nano, _),
                 DataType::Timestamp(ArrowTimeUnit::Nanosecond, None),
             ) => to_arrow_temporal::<TimestampNanosecondType>(&array),
             _ => vortex_bail!(

--- a/vortex-array/src/arrow/compute/to_arrow/temporal.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/temporal.rs
@@ -41,7 +41,7 @@ impl Kernel for ToArrowTemporal {
         let arrow_type = arrow_type
             .cloned()
             .map(Ok)
-            .unwrap_or_else(|| array.dtype().to_arrow_dtype())?;
+            .unwrap_or_else(|| array.dtype().to_arrow())?;
 
         let arrow_array: ArrowArrayRef = match (array.temporal_metadata(), &arrow_type) {
             (TemporalMetadata::Date(TimeUnit::D), DataType::Date32) => {

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -234,18 +234,14 @@ impl FromArrowArray<&ArrowStructArray> for ArrayRef {
         let mut field_arrays = Vec::with_capacity(value.fields().len());
 
         for (field, column) in value.fields().iter().zip(value.columns()) {
-            let array = match field.extension_type_name() {
-                Some(_) => {
-                    match arrow_field_to_dtype(field).vortex_expect("arrow_field_to_dtype") {
-                        Some(DType::Extension(ext_dtype)) => {
-                            let storage = Self::from_arrow(column.clone(), field.is_nullable());
-                            ExtensionArray::new(ext_dtype, storage).into_array()
-                        }
-                        _ => Self::from_arrow(column.clone(), field.is_nullable()),
-                    }
+            let mut array = Self::from_arrow(column.clone(), field.is_nullable());
+            if field.extension_type_name().is_some() {
+                if let Some(DType::Extension(ext_dtype)) =
+                    arrow_field_to_dtype(field).vortex_expect("arrow_field_to_dtype")
+                {
+                    array = ExtensionArray::new(ext_dtype, array).into_array()
                 }
-                None => Self::from_arrow(column.clone(), field.is_nullable()),
-            };
+            }
             field_names.push(field.name().to_string().into());
             field_arrays.push(array);
         }

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -166,8 +166,8 @@ where
         }
         DataType::Time32(time_unit) => TemporalArray::new_time(arr, time_unit.into()).into(),
         DataType::Time64(time_unit) => TemporalArray::new_time(arr, time_unit.into()).into(),
-        DataType::Date32 => TemporalArray::new_date(arr, TimeUnit::D).into(),
-        DataType::Date64 => TemporalArray::new_date(arr, TimeUnit::Ms).into(),
+        DataType::Date32 => TemporalArray::new_date(arr, TimeUnit::Day).into(),
+        DataType::Date64 => TemporalArray::new_date(arr, TimeUnit::Milli).into(),
         DataType::Duration(_) => unimplemented!(),
         DataType::Interval(_) => unimplemented!(),
         _ => vortex_panic!("Invalid temporal type: {}", T::DATA_TYPE),

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow_array::array::{
     Array as ArrowArray, ArrayRef as ArrowArrayRef, ArrowPrimitiveType,
     BooleanArray as ArrowBooleanArray, GenericByteArray, NullArray as ArrowNullArray,
@@ -16,14 +18,15 @@ use arrow_buffer::buffer::{NullBuffer, OffsetBuffer};
 use arrow_buffer::{ArrowNativeType, BooleanBuffer, Buffer as ArrowBuffer, ScalarBuffer};
 use arrow_schema::{DataType, TimeUnit as ArrowTimeUnit};
 use vortex_buffer::{Alignment, Buffer, ByteBuffer};
+use vortex_dtype::arrow::arrow_field_to_dtype;
 use vortex_dtype::datetime::TimeUnit;
-use vortex_dtype::{DType, DecimalDType, NativePType, PType};
+use vortex_dtype::{DType, DecimalDType, FieldNames, NativePType, PType};
 use vortex_error::{VortexExpect as _, vortex_panic};
 use vortex_scalar::i256;
 
 use crate::arrays::{
-    BoolArray, DecimalArray, ListArray, NullArray, PrimitiveArray, StructArray, TemporalArray,
-    VarBinArray, VarBinViewArray,
+    BoolArray, DecimalArray, ExtensionArray, ListArray, NullArray, PrimitiveArray, StructArray,
+    TemporalArray, VarBinArray, VarBinViewArray,
 };
 use crate::arrow::FromArrowArray;
 use crate::validity::Validity;
@@ -227,14 +230,29 @@ impl FromArrowArray<&ArrowBooleanArray> for ArrayRef {
 
 impl FromArrowArray<&ArrowStructArray> for ArrayRef {
     fn from_arrow(value: &ArrowStructArray, nullable: bool) -> Self {
+        let mut field_names: Vec<Arc<str>> = Vec::with_capacity(value.fields().len());
+        let mut field_arrays = Vec::with_capacity(value.fields().len());
+
+        for (field, column) in value.fields().iter().zip(value.columns()) {
+            let array = match field.extension_type_name() {
+                Some(_) => {
+                    match arrow_field_to_dtype(field).vortex_expect("arrow_field_to_dtype") {
+                        Some(DType::Extension(ext_dtype)) => {
+                            let storage = Self::from_arrow(column.clone(), field.is_nullable());
+                            ExtensionArray::new(ext_dtype, storage).into_array()
+                        }
+                        _ => Self::from_arrow(column.clone(), field.is_nullable()),
+                    }
+                }
+                None => Self::from_arrow(column.clone(), field.is_nullable()),
+            };
+            field_names.push(field.name().to_string().into());
+            field_arrays.push(array);
+        }
+
         StructArray::try_new(
-            value.column_names().iter().map(|s| (*s).into()).collect(),
-            value
-                .columns()
-                .iter()
-                .zip(value.fields())
-                .map(|(c, field)| Self::from_arrow(c.clone(), field.is_nullable()))
-                .collect(),
+            FieldNames::from_iter(field_names),
+            field_arrays,
             value.len(),
             nulls(value.nulls(), nullable),
         )

--- a/vortex-array/src/arrow/record_batch.rs
+++ b/vortex-array/src/arrow/record_batch.rs
@@ -1,31 +1,20 @@
-use arrow_array::RecordBatch;
 use arrow_array::cast::AsArray;
+use arrow_array::{Array as _, RecordBatch};
 use arrow_schema::{DataType, Schema};
 use vortex_error::{VortexError, VortexResult, vortex_err};
 
 use crate::arrays::StructArray;
 use crate::arrow::FromArrowArray;
 use crate::arrow::compute::{to_arrow, to_arrow_preferred};
-use crate::validity::Validity;
-use crate::{Array, ArrayRef, IntoArray, ToCanonical, TryIntoArray};
+use crate::{Array, ArrayRef, ToCanonical, TryIntoArray};
 
 impl TryIntoArray for RecordBatch {
     fn try_into_array(self) -> VortexResult<ArrayRef> {
-        Ok(StructArray::try_new(
-            self.schema()
-                .fields()
-                .iter()
-                .map(|f| f.name().as_str().into())
-                .collect(),
-            self.columns()
-                .iter()
-                .zip(self.schema().fields())
-                .map(|(array, field)| ArrayRef::from_arrow(array.clone(), field.is_nullable()))
-                .collect(),
-            self.num_rows(),
-            Validity::NonNullable, // Must match FromArrowType<SchemaRef> for DType
-        )?
-        .into_array())
+        let struct_array = arrow_array::StructArray::from(self);
+        Ok(ArrayRef::from_arrow(
+            &struct_array,
+            struct_array.is_nullable(),
+        ))
     }
 }
 

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -96,7 +96,7 @@ impl Canonical {
     pub fn into_list(self) -> VortexResult<ListArray> {
         match self {
             Canonical::List(a) => Ok(a),
-            _ => vortex_bail!("Cannot unwrap StructArray from {:?}", &self),
+            _ => vortex_bail!("Cannot unwrap ListArray from {:?}", &self),
         }
     }
 

--- a/vortex-dtype/Cargo.toml
+++ b/vortex-dtype/Cargo.toml
@@ -15,11 +15,13 @@ version = { workspace = true }
 
 [dependencies]
 arbitrary = { workspace = true, optional = true }
+arcref = { workspace = true }
 arrow-schema = { workspace = true, optional = true }
 flatbuffers = { workspace = true }
 half = { workspace = true, features = ["num-traits"] }
 itertools = { workspace = true }
 jiff = { workspace = true }
+log = { workspace = true }
 num-traits = { workspace = true }
 num_enum = { workspace = true }
 prost = { workspace = true }

--- a/vortex-dtype/src/arrow.rs
+++ b/vortex-dtype/src/arrow.rs
@@ -148,7 +148,7 @@ use vortex_error::{VortexExpect, VortexResult, vortex_assert, vortex_bail, vorte
 
 use crate::datetime::arrow::{make_arrow_temporal_dtype, make_temporal_ext_dtype};
 use crate::datetime::is_temporal_ext_type;
-use crate::{DType, DecimalDType, ExtDType, FieldName, Nullability, PType, StructDType};
+use crate::{DType, DecimalDType, ExtDType, ExtensionRegistry, FieldName, Nullability, PType, StructDType};
 
 /// Trait for converting Arrow types to Vortex types.
 pub trait FromArrowType<T>: Sized {
@@ -351,7 +351,12 @@ impl DType {
                 {
                     // Special handling for extension types in case they should serialize
                     // to an Arrow extension type.
+                    // If the type is one of the ones that has a special arrow serialization, we use
+                    // it directly.
                     let field = if let DType::Extension(ext_type) = &field_dt {
+                        // If the field converts into Arrow in some way, convert it instead.
+                        ExtensionRegistry::shared()
+
                         if let Some(f) = extension_type_to_arrow(ext_type.as_ref())? {
                             f.with_name(field_name.to_string())
                         } else {

--- a/vortex-dtype/src/arrow.rs
+++ b/vortex-dtype/src/arrow.rs
@@ -1,25 +1,154 @@
-//! Convert between Vortex [`crate::DType`] and Apache Arrow [`arrow_schema::DataType`].
+//! Convert between Vortex [`DType`] and Apache Arrow [`DataType`].
 //!
-//! Apache Arrow's type system includes physical information, which could lead to ambiguities as
-//! Vortex treats encodings as separate from logical types.
+//! ## Arrow -> Vortex
 //!
-//! [`DType::to_arrow_schema`] and its sibling [`DType::to_arrow_dtype`] use a simple algorithm,
-//! where every logical type is encoded in its simplest corresponding Arrow type. This reflects the
-//! reality that most compute engines don't make use of the entire type range arrow-rs supports.
+//! Each Arrow `DataType` has a defined mapping onto its nearest Vortex data type, via
+//! implementation of the `FromArrowType` trait.
 //!
-//! For this reason, it's recommended to do as much computation as possible within Vortex, and then
-//! materialize an Arrow ArrayRef at the very end of the processing chain.
+//! All of the Arrow primitive types map onto the equivalent Vortex primitives:
+//!
+//! ```rust
+//! use arrow_schema::DataType;
+//! use vortex_dtype::{DType, Nullability, PType, arrow::FromArrowType};
+//!
+//! let arrow_i32 = DataType::Int32;
+//! let vortex_i32 = DType::from_arrow((&arrow_i32, false.into()));
+//! assert_eq!(vortex_i32, DType::Primitive(PType::I32, false.into()));
+//! ```
+//!
+//! However, some types in Arrow do not map 1:1 onto Vortex. This is because
+//! Arrow uses _physical_ type information, whereas Vortex is a pure logical
+//! type system.For example, Arrow distinguishes between `String` and `LargeString`
+//! layouts based on the size of the offset elements, whereas in Vortex they are
+//! both just `Utf8`.
+//!
+//!
+//! ```rust
+//! use arrow_schema::DataType;
+//! use vortex_dtype::{DType, Nullability, PType, arrow::FromArrowType};
+//!
+//! // This type has no exact representation in Vortex
+//! let arrow_large_string = DataType::LargeUtf8;
+//! let vortex_string = DType::from_arrow((&arrow_large_string, false.into()));
+//! // The "Large" is lost in the conversion.
+//! assert_eq!(vortex_string, DType::Utf8(false.into()));
+//! ```
+//!
+//! There are many such cases where extra Arrow type information is lost. Users that
+//! want to be able to round-trip back to Arrow later should save the original
+//! `DataType`.
+//!
+//! ## Vortex -> Arrow
+//!
+//! `DType` has defined conversions into both [`Schema`] and [`DataType`], where the former
+//! is only supported for struct types.
+//!
+//! [`DType::to_arrow_schema`] and its sibling [`DType::to_arrow`] follow a simple algorithm
+//! for selecting the nearest Arrow type:
+//!
+//! * Vortex `Utf8` maps to Arrow `Utf8View` and Vortex `Binary` maps to `BinaryView`
+//! * The non-`Large` variant of a type is always selected by default
+//! * Extension types provide a mapping to
+//!
+//! ```rust
+//! use std::sync::Arc;
+//! use arrow_schema::DataType;
+//! use vortex_dtype::{DType, Nullability, PType};
+//!
+//! // Utf8 will be selected over LargeUtf8
+//! assert_eq!(
+//!     DType::Utf8(false.into()).to_arrow().unwrap(),
+//!     DataType::Utf8View,
+//! );
+//!
+//! // List will be selected over LargeList
+//! assert_eq!(
+//!     DType::List(Arc::new(PType::I32.into()), false.into()).to_arrow().unwrap(),
+//!     DataType::new_list(DataType::Int32, false),
+//! );
+//! ```
+//!
+//! ## Extension type support
+//!
+//! Arrow provides an extension type mechanism, effectively a type alias to another `DataType` with
+//! some additional key-value string metadata that is carried on the field schema.
+//!
+//! Vortex supports canonicalizing its types into Arrow extension types, by implementing
+//! the [`ArrowTypeConversion`] trait.
+//!
+//! ```rust
+//! use std::collections::HashMap;
+//! use std::sync::Arc;
+//!
+//! use arcref::ArcRef;
+//! use arrow_schema::extension::{EXTENSION_TYPE_METADATA_KEY, EXTENSION_TYPE_NAME_KEY};
+//! use arrow_schema::{DataType, Field};
+//! use vortex_dtype::{DType, ExtDType, ExtID, PType, StructDType};
+//! use vortex_dtype::arrow::{ArrowTypeConversion, ArrowTypeConversionRef};
+//! use vortex_error::VortexResult;
+//!
+//! #[derive(Debug)]
+//! pub struct TemperatureConversion;
+//!
+//! impl ArrowTypeConversion for TemperatureConversion {
+//!     fn to_arrow(&self, dtype: &ExtDType) -> VortexResult<Option<Field>> {
+//!         if dtype.id().as_ref() != "vortex.temperature" {
+//!             return Ok(None);
+//!         }
+//!
+//!         let mut metadata = HashMap::new();
+//!         metadata.insert(EXTENSION_TYPE_NAME_KEY.to_string(), "vortex.temperature".to_string());
+//!         metadata.insert(EXTENSION_TYPE_METADATA_KEY.to_string(), r#"{"unit": "F"}"#.to_string());
+//!
+//!         let field = Field::new("value", DataType::Float32, dtype.storage_dtype().is_nullable());
+//!         Ok(Some(field.with_metadata(metadata)))
+//!     }
+//! }
+//!
+//! // Register the extension type so `DType` methods are aware of it at runtime.
+//! DType::register_extension_type(ArrowTypeConversionRef(ArcRef::new_ref(&TemperatureConversion)));
+//!
+//! // Attempt to use the extension type
+//! let ext_type = ExtDType::new(
+//!     ExtID::new("vortex.temperature".into()),
+//!     Arc::new(DType::Primitive(PType::F32, false.into())),
+//!     None,
+//! );
+//!
+//! // Extension types only carry their metadata in a schema, so we
+//! // use a struct type
+//! let ext_type = DType::Extension(Arc::new(ext_type));
+//! let schema = StructDType::from_fields(
+//!     ["values".into()].into(),
+//!     vec![ext_type.into()],
+//! );
+//!
+//! let schema_type = DType::Struct(Arc::new(schema), false.into());
+//!
+//! let arrow_schema = schema_type.to_arrow_schema().unwrap();
+//! let ext_field = arrow_schema.field(0);
+//! assert_eq!(
+//!     ext_field.extension_type_name(),
+//!     Some("vortex.temperature"),
+//! );
+//!
+//! assert_eq!(
+//!     ext_field.extension_type_metadata(),
+//!     Some(r#"{"unit": "F"}"#),
+//! );
+//! ```
 
-use std::sync::Arc;
+use std::fmt::Debug;
+use std::ops::Deref;
+use std::sync::{Arc, LazyLock, RwLock};
 
-use arrow_schema::{
-    DECIMAL128_MAX_SCALE, DataType, Field, FieldRef, Fields, Schema, SchemaBuilder, SchemaRef,
-};
-use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
+use arcref::ArcRef;
+use arrow_schema::{DECIMAL128_MAX_SCALE, DataType, Field, FieldRef, Fields, Schema, SchemaRef};
+use vortex_error::{VortexExpect, VortexResult, vortex_assert, vortex_bail, vortex_err};
 
 use crate::datetime::arrow::{make_arrow_temporal_dtype, make_temporal_ext_dtype};
 use crate::datetime::is_temporal_ext_type;
-use crate::{DType, DecimalDType, FieldName, Nullability, PType, StructDType};
+use crate::{DType, DecimalDType, ExtDType, FieldName, Nullability, PType, StructDType};
 
 /// Trait for converting Arrow types to Vortex types.
 pub trait FromArrowType<T>: Sized {
@@ -131,35 +260,66 @@ impl FromArrowType<(&DataType, Nullability)> for DType {
 
 impl FromArrowType<&Field> for DType {
     fn from_arrow(field: &Field) -> Self {
+        if let Some(ext_type) = field.extension_type_name() {
+            // Check the registry for any Vortex extension types that represent the Arrow
+            // extension type named here.
+            if let Some(converted) =
+                arrow_field_to_dtype(field).vortex_expect("conversion cannot error")
+            {
+                return converted;
+            }
+
+            log::debug!(
+                "failed to resolve ArrowTypeConversion for unrecognized extension type \"{}\"",
+                ext_type
+            );
+        }
+
         Self::from_arrow((field.data_type(), field.is_nullable().into()))
+    }
+}
+
+/// Registry of Arrow extension type conversions.
+static EXTENSION_TYPES: LazyLock<RwLock<Vec<ArrowTypeConversionRef>>> =
+    LazyLock::new(|| RwLock::new(Vec::new()));
+
+impl DType {
+    /// Register a new Arrow extension type conversion function dynamically.
+    ///
+    /// This associated function should be called early in the program before any data is processed, to ensure that
+    /// subsequent calls to [`DType::to_arrow`] or [`DType::from_arrow`] are aware of it.
+    pub fn register_extension_type(extension: ArrowTypeConversionRef) {
+        EXTENSION_TYPES
+            .write()
+            .vortex_expect("poisoned")
+            .push(extension);
     }
 }
 
 impl DType {
     /// Convert a Vortex [`DType`] into an Arrow [`Schema`].
     pub fn to_arrow_schema(&self) -> VortexResult<Schema> {
-        let DType::Struct(struct_dtype, nullable) = self else {
-            vortex_bail!("only DType::Struct can be converted to arrow schema");
+        vortex_assert!(
+            self.is_struct(),
+            "to_arrow_schema expected struct type, was {}",
+            self,
+        );
+        vortex_assert!(
+            !self.is_nullable(),
+            "nullable Struct cannot be converted to Arrow Schema"
+        );
+
+        let DataType::Struct(fields) = self.to_arrow()? else {
+            vortex_bail!(
+                "Cannot convert non-struct dtype to Arrow schema: {:?}",
+                self
+            )
         };
-
-        if *nullable != Nullability::NonNullable {
-            vortex_bail!("top-level struct in Schema must be NonNullable");
-        }
-
-        let mut builder = SchemaBuilder::with_capacity(struct_dtype.names().len());
-        for (field_name, field_dtype) in struct_dtype.names().iter().zip(struct_dtype.fields()) {
-            builder.push(FieldRef::from(Field::new(
-                field_name.to_string(),
-                field_dtype.to_arrow_dtype()?,
-                field_dtype.is_nullable(),
-            )));
-        }
-
-        Ok(builder.finish())
+        Ok(Schema::new(fields))
     }
 
-    /// Returns the Arrow [`DataType`] that best corresponds to this Vortex [`DType`].
-    pub fn to_arrow_dtype(&self) -> VortexResult<DataType> {
+    /// Returns the Arrow [`Field`] that best represents the Vortex type.
+    pub fn to_arrow(&self) -> VortexResult<DataType> {
         Ok(match self {
             DType::Null => DataType::Null,
             DType::Bool(_) => DataType::Boolean,
@@ -189,11 +349,27 @@ impl DType {
                 let mut fields = Vec::with_capacity(struct_dtype.names().len());
                 for (field_name, field_dt) in struct_dtype.names().iter().zip(struct_dtype.fields())
                 {
-                    fields.push(FieldRef::from(Field::new(
-                        field_name.to_string(),
-                        field_dt.to_arrow_dtype()?,
-                        field_dt.is_nullable(),
-                    )));
+                    // Special handling for extension types in case they should serialize
+                    // to an Arrow extension type.
+                    let field = if let DType::Extension(ext_type) = &field_dt {
+                        if let Some(f) = extension_type_to_arrow(ext_type.as_ref())? {
+                            f.with_name(field_name.to_string())
+                        } else {
+                            Field::new(
+                                field_name.to_string(),
+                                field_dt.to_arrow()?,
+                                field_dt.is_nullable(),
+                            )
+                        }
+                    } else {
+                        Field::new(
+                            field_name.to_string(),
+                            field_dt.to_arrow()?,
+                            field_dt.is_nullable(),
+                        )
+                    };
+
+                    fields.push(field);
                 }
 
                 DataType::Struct(Fields::from(fields))
@@ -201,19 +377,90 @@ impl DType {
             // There are four kinds of lists: List (32-bit offsets), Large List (64-bit), List View
             // (32-bit), Large List View (64-bit). We cannot both guarantee zero-copy and commit to an
             // Arrow dtype because we do not how large our offsets are.
-            DType::List(l, _) => DataType::List(FieldRef::new(Field::new_list_field(
-                l.to_arrow_dtype()?,
-                l.nullability().into(),
+            DType::List(elem_type, _) => DataType::List(FieldRef::new(Field::new_list_field(
+                elem_type.to_arrow()?,
+                elem_type.nullability().into(),
             ))),
             DType::Extension(ext_dtype) => {
                 // Try and match against the known extension DTypes.
                 if is_temporal_ext_type(ext_dtype.id()) {
                     make_arrow_temporal_dtype(ext_dtype)
                 } else {
-                    vortex_bail!("Unsupported extension type \"{}\"", ext_dtype.id())
+                    ext_dtype.storage_dtype().to_arrow()?
                 }
             }
         })
+    }
+}
+
+/// If a suitable [conversion is registered][DType::register_extension_type], returns the Arrow `Field`
+/// representing that this extension type converts into. Otherwise, `None` is returned.
+///
+/// Any errors from the conversion function are propagated here via
+/// the outer `VortexResult` wrapper.
+pub fn extension_type_to_arrow(ext_type: &ExtDType) -> VortexResult<Option<Field>> {
+    for kernel in EXTENSION_TYPES.read().vortex_expect("poisoned").iter() {
+        if let Some(metadata) = kernel.0.to_arrow(ext_type)? {
+            return Ok(Some(metadata));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Convert an Arrow [`Field`] to a `DType` using a [registered extension][ArrowTypeConversion].
+///
+/// If no suitable conversion has been registered, `Ok(None)` is returned.
+pub fn arrow_field_to_dtype(field: &Field) -> VortexResult<Option<DType>> {
+    for converter in EXTENSION_TYPES.read().vortex_expect("poisoned").iter() {
+        if let Some(converted) = converter.to_vortex(field)? {
+            return Ok(Some(converted));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Conversions between Arrow [`Field`] type and Vortex logical `DType`.
+///
+/// This crate provides infra for registering and discovering extension types.
+/// Once you implement this trait, you need to register it using [`DType::register_extension_type`]
+/// to have it get discovered.
+///
+/// See also: [`DType::register_extension_type`]
+pub trait ArrowTypeConversion: 'static + Send + Sync + Debug {
+    /// Convert the given Arrow [`Field`] to a Vortex [`DType`].
+    fn to_vortex(&self, _field: &Field) -> VortexResult<Option<DType>> {
+        Ok(None)
+    }
+
+    /// Map a type into an Arrow [`Field`] type.
+    ///
+    /// This method should be implemented if you want to add support for a Vortex
+    /// [extension type][ExtDType] that also has a corresponding canonical Arrow
+    /// extension type, to preserve round-trip between the two.
+    #[allow(clippy::disallowed_types)]
+    fn to_arrow(&self, _dtype: &ExtDType) -> VortexResult<Option<Field>> {
+        Ok(None)
+    }
+}
+
+/// Conversion token
+#[derive(Debug)]
+pub struct ArrowTypeConversionRef(pub ArcRef<dyn ArrowTypeConversion>);
+
+impl Deref for ArrowTypeConversionRef {
+    type Target = dyn ArrowTypeConversion;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl ArrowTypeConversionRef {
+    /// Create a new `TypeConversionRef` from a pointer to an implementation.
+    pub const fn new(conversion: ArcRef<dyn ArrowTypeConversion>) -> Self {
+        Self(conversion)
     }
 }
 
@@ -226,33 +473,27 @@ mod test {
 
     #[test]
     fn test_dtype_conversion_success() {
-        assert_eq!(DType::Null.to_arrow_dtype().unwrap(), DataType::Null);
+        assert_eq!(DType::Null.to_arrow().unwrap(), DataType::Null);
 
         assert_eq!(
-            DType::Bool(Nullability::NonNullable)
-                .to_arrow_dtype()
-                .unwrap(),
+            DType::Bool(Nullability::NonNullable).to_arrow().unwrap(),
             DataType::Boolean
         );
 
         assert_eq!(
             DType::Primitive(PType::U64, Nullability::NonNullable)
-                .to_arrow_dtype()
+                .to_arrow()
                 .unwrap(),
             DataType::UInt64
         );
 
         assert_eq!(
-            DType::Utf8(Nullability::NonNullable)
-                .to_arrow_dtype()
-                .unwrap(),
+            DType::Utf8(Nullability::NonNullable).to_arrow().unwrap(),
             DataType::Utf8View
         );
 
         assert_eq!(
-            DType::Binary(Nullability::NonNullable)
-                .to_arrow_dtype()
-                .unwrap(),
+            DType::Binary(Nullability::NonNullable).to_arrow().unwrap(),
             DataType::BinaryView
         );
 
@@ -264,7 +505,7 @@ mod test {
                 ])),
                 Nullability::NonNullable,
             )
-            .to_arrow_dtype()
+            .to_arrow()
             .unwrap(),
             DataType::Struct(Fields::from(vec![
                 FieldRef::from(Field::new("field_a", DataType::Boolean, false)),
@@ -280,15 +521,14 @@ mod test {
             Nullability::Nullable,
         );
 
-        let arrow_list_non_nullable = list_non_nullable.to_arrow_dtype().unwrap();
+        let arrow_list_non_nullable = list_non_nullable.to_arrow().unwrap();
 
         let list_nullable = DType::List(
             Arc::new(DType::Primitive(PType::I64, Nullability::Nullable)),
             Nullability::Nullable,
         );
-        let arrow_list_nullable = list_nullable.to_arrow_dtype().unwrap();
+        let arrow_list_nullable = list_nullable.to_arrow().unwrap();
 
-        assert_ne!(arrow_list_non_nullable, arrow_list_nullable);
         assert_eq!(
             arrow_list_nullable,
             DataType::new_list(DataType::Int64, true)
@@ -300,15 +540,15 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_dtype_conversion_panics() {
-        let _ = DType::Extension(Arc::new(ExtDType::new(
+    fn test_unregistered_extension_conversion() {
+        let arrow = DType::Extension(Arc::new(ExtDType::new(
             ExtID::from("my-fake-ext-dtype"),
             Arc::new(DType::Utf8(Nullability::NonNullable)),
             None,
         )))
-        .to_arrow_dtype()
+        .to_arrow()
         .unwrap();
+        assert_eq!(arrow, DataType::Utf8View);
     }
 
     #[test]

--- a/vortex-dtype/src/datetime/arrow.rs
+++ b/vortex-dtype/src/datetime/arrow.rs
@@ -44,12 +44,12 @@ pub fn make_temporal_ext_dtype(data_type: &DataType) -> ExtDType {
         DataType::Date32 => ExtDType::new(
             DATE_ID.clone(),
             Arc::new(PType::I32.into()),
-            Some(TemporalMetadata::Date(TimeUnit::D).into()),
+            Some(TemporalMetadata::Date(TimeUnit::Day).into()),
         ),
         DataType::Date64 => ExtDType::new(
             DATE_ID.clone(),
             Arc::new(PType::I64.into()),
-            Some(TemporalMetadata::Date(TimeUnit::Ms).into()),
+            Some(TemporalMetadata::Date(TimeUnit::Milli).into()),
         ),
         _ => unimplemented!("{data_type} conversion"),
     }
@@ -63,26 +63,30 @@ pub fn make_arrow_temporal_dtype(ext_dtype: &ExtDType) -> DataType {
         .vortex_expect("make_arrow_temporal_dtype must be called with a temporal ExtDType")
     {
         TemporalMetadata::Date(time_unit) => match time_unit {
-            TimeUnit::D => DataType::Date32,
-            TimeUnit::Ms => DataType::Date64,
+            TimeUnit::Day => DataType::Date32,
+            TimeUnit::Milli => DataType::Date64,
             _ => {
                 vortex_panic!(InvalidArgument: "Invalid TimeUnit {} for {}", time_unit, ext_dtype.id())
             }
         },
         TemporalMetadata::Time(time_unit) => match time_unit {
-            TimeUnit::S => DataType::Time32(ArrowTimeUnit::Second),
-            TimeUnit::Ms => DataType::Time32(ArrowTimeUnit::Millisecond),
-            TimeUnit::Us => DataType::Time64(ArrowTimeUnit::Microsecond),
-            TimeUnit::Ns => DataType::Time64(ArrowTimeUnit::Nanosecond),
+            TimeUnit::Second => DataType::Time32(ArrowTimeUnit::Second),
+            TimeUnit::Milli => DataType::Time32(ArrowTimeUnit::Millisecond),
+            TimeUnit::Micro => DataType::Time64(ArrowTimeUnit::Microsecond),
+            TimeUnit::Nano => DataType::Time64(ArrowTimeUnit::Nanosecond),
             _ => {
                 vortex_panic!(InvalidArgument: "Invalid TimeUnit {} for {}", time_unit, ext_dtype.id())
             }
         },
         TemporalMetadata::Timestamp(time_unit, tz) => match time_unit {
-            TimeUnit::Ns => DataType::Timestamp(ArrowTimeUnit::Nanosecond, tz.map(|t| t.into())),
-            TimeUnit::Us => DataType::Timestamp(ArrowTimeUnit::Microsecond, tz.map(|t| t.into())),
-            TimeUnit::Ms => DataType::Timestamp(ArrowTimeUnit::Millisecond, tz.map(|t| t.into())),
-            TimeUnit::S => DataType::Timestamp(ArrowTimeUnit::Second, tz.map(|t| t.into())),
+            TimeUnit::Nano => DataType::Timestamp(ArrowTimeUnit::Nanosecond, tz.map(|t| t.into())),
+            TimeUnit::Micro => {
+                DataType::Timestamp(ArrowTimeUnit::Microsecond, tz.map(|t| t.into()))
+            }
+            TimeUnit::Milli => {
+                DataType::Timestamp(ArrowTimeUnit::Millisecond, tz.map(|t| t.into()))
+            }
+            TimeUnit::Second => DataType::Timestamp(ArrowTimeUnit::Second, tz.map(|t| t.into())),
             _ => {
                 vortex_panic!(InvalidArgument: "Invalid TimeUnit {} for {}", time_unit, ext_dtype.id())
             }
@@ -99,10 +103,10 @@ impl From<&ArrowTimeUnit> for TimeUnit {
 impl From<ArrowTimeUnit> for TimeUnit {
     fn from(value: ArrowTimeUnit) -> Self {
         match value {
-            ArrowTimeUnit::Second => Self::S,
-            ArrowTimeUnit::Millisecond => Self::Ms,
-            ArrowTimeUnit::Microsecond => Self::Us,
-            ArrowTimeUnit::Nanosecond => Self::Ns,
+            ArrowTimeUnit::Second => Self::Second,
+            ArrowTimeUnit::Millisecond => Self::Milli,
+            ArrowTimeUnit::Microsecond => Self::Micro,
+            ArrowTimeUnit::Nanosecond => Self::Nano,
         }
     }
 }
@@ -112,10 +116,10 @@ impl TryFrom<TimeUnit> for ArrowTimeUnit {
 
     fn try_from(value: TimeUnit) -> VortexResult<Self> {
         Ok(match value {
-            TimeUnit::S => Self::Second,
-            TimeUnit::Ms => Self::Millisecond,
-            TimeUnit::Us => Self::Microsecond,
-            TimeUnit::Ns => Self::Nanosecond,
+            TimeUnit::Second => Self::Second,
+            TimeUnit::Milli => Self::Millisecond,
+            TimeUnit::Micro => Self::Microsecond,
+            TimeUnit::Nano => Self::Nanosecond,
             _ => vortex_bail!("Cannot convert {value} to Arrow TimeUnit"),
         })
     }
@@ -130,7 +134,7 @@ mod tests {
         let ext_dtype = ExtDType::new(
             TIMESTAMP_ID.clone(),
             Arc::new(PType::I64.into()),
-            Some(TemporalMetadata::Timestamp(TimeUnit::Ms, None).into()),
+            Some(TemporalMetadata::Timestamp(TimeUnit::Milli, None).into()),
         );
         let expected_arrow_type = DataType::Timestamp(ArrowTimeUnit::Millisecond, None);
 
@@ -146,7 +150,7 @@ mod tests {
         let ext_dtype = ExtDType::new(
             TIME_ID.clone(),
             Arc::new(PType::I32.into()),
-            Some(TemporalMetadata::Time(TimeUnit::Ms).into()),
+            Some(TemporalMetadata::Time(TimeUnit::Milli).into()),
         );
         let expected_arrow_type = DataType::Time32(ArrowTimeUnit::Millisecond);
         let arrow_dtype = make_arrow_temporal_dtype(&ext_dtype);
@@ -161,7 +165,7 @@ mod tests {
         let ext_dtype = ExtDType::new(
             TIME_ID.clone(),
             Arc::new(PType::I64.into()),
-            Some(TemporalMetadata::Time(TimeUnit::Us).into()),
+            Some(TemporalMetadata::Time(TimeUnit::Micro).into()),
         );
         let expected_arrow_type = DataType::Time64(ArrowTimeUnit::Microsecond);
         let arrow_dtype = make_arrow_temporal_dtype(&ext_dtype);
@@ -176,7 +180,7 @@ mod tests {
         let ext_dtype = ExtDType::new(
             DATE_ID.clone(),
             Arc::new(PType::I32.into()),
-            Some(TemporalMetadata::Date(TimeUnit::D).into()),
+            Some(TemporalMetadata::Date(TimeUnit::Day).into()),
         );
         let expected_arrow_type = DataType::Date32;
         let arrow_dtype = make_arrow_temporal_dtype(&ext_dtype);
@@ -191,7 +195,7 @@ mod tests {
         let ext_dtype = ExtDType::new(
             DATE_ID.clone(),
             Arc::new(PType::I64.into()),
-            Some(TemporalMetadata::Date(TimeUnit::Ms).into()),
+            Some(TemporalMetadata::Date(TimeUnit::Milli).into()),
         );
         let expected_arrow_type = DataType::Date64;
         let arrow_dtype = make_arrow_temporal_dtype(&ext_dtype);

--- a/vortex-dtype/src/datetime/temporal.rs
+++ b/vortex-dtype/src/datetime/temporal.rs
@@ -3,10 +3,12 @@ use std::sync::{Arc, LazyLock};
 
 use jiff::civil::{Date, Time};
 use jiff::{Timestamp, Zoned};
-use vortex_error::{VortexError, VortexResult, vortex_bail, vortex_err, vortex_panic};
+use vortex_error::{
+    VortexError, VortexExpect, VortexResult, vortex_assert, vortex_bail, vortex_err, vortex_panic,
+};
 
 use crate::datetime::unit::TimeUnit;
-use crate::{ExtDType, ExtID, ExtMetadata};
+use crate::{DType, ExtDType, ExtID, ExtMetadata, ExtensionType, PType};
 
 /// ID for the Vortex time type.
 pub static TIME_ID: LazyLock<ExtID> = LazyLock::new(|| ExtID::from("vortex.time"));
@@ -18,6 +20,254 @@ pub static TIMESTAMP_ID: LazyLock<ExtID> = LazyLock::new(|| ExtID::from("vortex.
 /// Check if an `ExtID` is one of the temporal types.
 pub fn is_temporal_ext_type(id: &ExtID) -> bool {
     [&DATE_ID as &ExtID, &TIME_ID, &TIMESTAMP_ID].contains(&id)
+}
+
+/// An [`ExtensionType`] for time of day.
+///
+/// All values of this type are referenced to midnight being the start of a day.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TimeType {
+    /// The storage type for the time values.
+    pub storage_type: DType,
+
+    /// The metadata dictating the interpretation of the time scalars.
+    pub metadata: TimeMetadata,
+}
+
+/// Metadata for [`TimeType`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TimeMetadata {
+    /// The time unit for all values of this type.
+    ///
+    /// Valid values are `Second`, `Milli`, `Micro`, and `Nano`.
+    pub unit: TimeUnit,
+}
+
+// Extension type metadata involved here instead...I think we want to make a new creator
+// of this extension type? The metadata is really all that matters.
+
+impl ExtensionType for TimeType {
+    type Metadata = TimeMetadata;
+
+    fn type_id() -> ExtID {
+        TIME_ID.clone()
+    }
+
+    fn metadata(&self) -> &Self::Metadata {
+        &self.metadata
+    }
+
+    fn serialize(&self) -> Option<ExtMetadata> {
+        Some(ExtMetadata::new(vec![self.metadata.unit as u8].into()))
+    }
+
+    fn try_deserialize(serialized: &ExtMetadata) -> VortexResult<Self::Metadata>
+    where
+        Self: Sized,
+    {
+        vortex_assert!(
+            serialized.as_ref().len() == 1,
+            "TimeMetadata must be 1 byte: {:x?}",
+            serialized.as_ref()
+        );
+
+        let unit = TimeUnit::try_from(serialized.as_ref()[0])
+            .map_err(|e| vortex_err!(ComputeError: "invalid TimeUnit byte: {e}"))?;
+        Ok(TimeMetadata { unit })
+    }
+
+    fn try_new(storage_type: DType, metadata: Self::Metadata) -> VortexResult<Self> {
+        fn is_valid(dtype: &DType, unit: &TimeUnit) -> bool {
+            match (dtype, unit) {
+                (DType::Primitive(PType::I32, _), TimeUnit::Second | TimeUnit::Milli) => true,
+                (DType::Primitive(PType::I64, _), TimeUnit::Micro | TimeUnit::Nano) => true,
+                _ => false,
+            }
+        }
+
+        vortex_assert!(
+            is_valid(&storage_type, &metadata.unit),
+            "Invalid storage type for TimeType: {:?} with unit {:?}",
+            storage_type,
+            metadata.unit
+        );
+
+        Ok(Self {
+            storage_type,
+            metadata,
+        })
+    }
+}
+
+/// Extension type for date values.
+///
+/// Date values are number of days since January 1, 1970 in multiple units.
+#[derive(Debug, Clone)]
+pub struct DateType {
+    /// The storage type for the date values.
+    pub storage_type: DType,
+
+    /// Metadata used to interpret the values of this type.
+    pub metadata: DateMetadata,
+}
+
+/// Metadata for interpreting values of a `DateType` array.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DateMetadata {
+    /// The time unit for all values of this type.
+    ///
+    /// Valid values are `Day` and `Milli`.
+    pub unit: TimeUnit,
+}
+
+impl ExtensionType for DateType {
+    type Metadata = DateMetadata;
+
+    fn type_id() -> ExtID {
+        DATE_ID.clone()
+    }
+
+    fn metadata(&self) -> &Self::Metadata {
+        &self.metadata
+    }
+
+    fn serialize(&self) -> Option<ExtMetadata> {
+        Some(ExtMetadata::new(vec![self.metadata.unit as u8].into()))
+    }
+
+    fn try_deserialize(serialized: &ExtMetadata) -> VortexResult<Self::Metadata>
+    where
+        Self: Sized,
+    {
+        vortex_assert!(
+            serialized.as_ref().len() == 1,
+            "DateMetadata must be 1 byte: {:x?}",
+            serialized.as_ref()
+        );
+
+        let unit = TimeUnit::try_from(serialized.as_ref()[0])
+            .map_err(|e| vortex_err!(ComputeError: "invalid TimeUnit byte: {e}"))?;
+        Ok(DateMetadata { unit })
+    }
+
+    fn try_new(storage_type: DType, metadata: Self::Metadata) -> VortexResult<Self> {
+        fn is_valid(dtype: &DType, unit: &TimeUnit) -> bool {
+            match (dtype, unit) {
+                (DType::Primitive(PType::I32, _), TimeUnit::Day) => true,
+                (DType::Primitive(PType::I64, _), TimeUnit::Milli) => true,
+                _ => false,
+            }
+        }
+
+        vortex_assert!(
+            is_valid(&storage_type, &metadata.unit),
+            "Invalid storage type for DateType: {:?} with unit {:?}",
+            storage_type,
+            metadata.unit
+        );
+
+        Ok(Self {
+            storage_type,
+            metadata,
+        })
+    }
+}
+
+/// Timestamp extension type.
+#[derive(Debug, Clone)]
+pub struct TimestampType {
+    /// Storage type for timestamp values.
+    pub storage_type: DType,
+
+    /// Metadata used to interpret the values of this type.
+    pub metadata: TimestampMetadata,
+}
+
+/// Metadata for interpreting values of a `TimestampType`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TimestampMetadata {
+    /// Unit for timestamp values. Valid options are `Second`, `Milli`, `Micro`, and `Nano`.
+    pub unit: TimeUnit,
+
+    /// An optional time zone string.
+    ///
+    /// The timezone can be any of the formats supported by Arrow:
+    ///
+    /// * IANA tzdata zone names (e.g. "America/New_York")
+    /// * An absolute zone offset in the form "+XX:XX" or "-XX:XX", e.g. "+07:30"
+    pub tz: Option<String>,
+}
+
+impl ExtensionType for TimestampType {
+    type Metadata = TimestampMetadata;
+
+    fn type_id() -> ExtID {
+        TIMESTAMP_ID.clone()
+    }
+
+    fn metadata(&self) -> &Self::Metadata {
+        &self.metadata
+    }
+
+    fn serialize(&self) -> Option<ExtMetadata> {
+        let mut serialized = Vec::new();
+        serialized.push(self.metadata.unit as u8);
+
+        if let Some(tz) = self.metadata.tz.as_ref() {
+            serialized.push(tz.len().try_into().vortex_expect("tz len overflow"));
+            serialized.extend_from_slice(tz.as_bytes());
+        }
+
+        Some(ExtMetadata::new(serialized.into()))
+    }
+
+    fn try_deserialize(serialized: &ExtMetadata) -> VortexResult<Self::Metadata>
+    where
+        Self: Sized,
+    {
+        vortex_assert!(
+            !serialized.as_ref().is_empty(),
+            "TimestampType must have at least 1 byte: {:x?}",
+            serialized.as_ref()
+        );
+        let unit = TimeUnit::try_from(serialized.as_ref()[0])
+            .map_err(|e| vortex_err!(ComputeError: "invalid TimeUnit byte: {e}"))?;
+
+        let tz = (serialized.as_ref().len() > 1).then(|| {
+            let tz_len = serialized.as_ref()[1];
+            let tz_bytes = &serialized.as_ref()[2..(2 + (tz_len as usize))];
+            String::from_utf8_lossy(tz_bytes).to_string()
+        });
+
+        Ok(TimestampMetadata { unit, tz })
+    }
+
+    fn try_new(storage_type: DType, metadata: Self::Metadata) -> VortexResult<Self>
+    where
+        Self: Sized,
+    {
+        fn is_valid(dtype: &DType, unit: &TimeUnit) -> bool {
+            match (dtype, unit) {
+                (DType::Primitive(PType::I32, _), TimeUnit::Second | TimeUnit::Milli) => true,
+                (DType::Primitive(PType::I64, _), TimeUnit::Micro | TimeUnit::Nano) => true,
+                _ => false,
+            }
+        }
+
+        vortex_assert!(
+            is_valid(&storage_type, &metadata.unit),
+            "Invalid storage type for TimestampType: {:?} with unit {:?}",
+            storage_type,
+            metadata.unit
+        );
+
+        // TODO(aduffy): check that timezone is valid using jiff TimeZoneDatabase?
+
+        Ok(Self {
+            storage_type,
+            metadata,
+        })
+    }
 }
 
 /// Metadata for TemporalArray.
@@ -80,21 +330,21 @@ impl TemporalMetadata {
     /// Convert a timestamp value to a Jiff value.
     pub fn to_jiff(&self, v: i64) -> VortexResult<TemporalJiff> {
         match self {
-            TemporalMetadata::Time(TimeUnit::D) => {
+            TemporalMetadata::Time(TimeUnit::Day) => {
                 vortex_bail!("Invalid TimeUnit TimeUnit::D for TemporalMetadata::Time")
             }
             TemporalMetadata::Time(unit) => Ok(TemporalJiff::Time(
                 Time::MIN.checked_add(unit.to_jiff_span(v)?)?,
             )),
             TemporalMetadata::Date(unit) => match unit {
-                TimeUnit::D | TimeUnit::Ms => Ok(TemporalJiff::Date(
+                TimeUnit::Day | TimeUnit::Milli => Ok(TemporalJiff::Date(
                     Date::new(1970, 1, 1)?.checked_add(unit.to_jiff_span(v)?)?,
                 )),
                 _ => {
                     vortex_bail!("Invalid TimeUnit {} for TemporalMetadata::Time", unit)
                 }
             },
-            TemporalMetadata::Timestamp(TimeUnit::D, _) => {
+            TemporalMetadata::Timestamp(TimeUnit::Day, _) => {
                 vortex_bail!("Invalid TimeUnit TimeUnit::D for TemporalMetadata::Timestamp")
             }
             TemporalMetadata::Timestamp(unit, None) => Ok(TemporalJiff::Timestamp(
@@ -216,7 +466,7 @@ mod tests {
     #[test]
     fn test_roundtrip_metadata() {
         let meta: ExtMetadata =
-            TemporalMetadata::Timestamp(TimeUnit::Ms, Some("UTC".to_string())).into();
+            TemporalMetadata::Timestamp(TimeUnit::Milli, Some("UTC".to_string())).into();
 
         assert_eq!(
             meta.as_ref(),
@@ -237,7 +487,7 @@ mod tests {
 
         assert_eq!(
             temporal_metadata,
-            TemporalMetadata::Timestamp(TimeUnit::Ms, Some("UTC".to_string()))
+            TemporalMetadata::Timestamp(TimeUnit::Milli, Some("UTC".to_string()))
         );
     }
 }

--- a/vortex-dtype/src/datetime/unit.rs
+++ b/vortex-dtype/src/datetime/unit.rs
@@ -12,26 +12,26 @@ use vortex_error::VortexResult;
 #[repr(u8)]
 pub enum TimeUnit {
     /// Nanoseconds
-    Ns = 0,
+    Nano = 0,
     /// Microseconds
-    Us = 1,
+    Micro = 1,
     /// Milliseconds
-    Ms = 2,
+    Milli = 2,
     /// Seconds
-    S = 3,
+    Second = 3,
     /// Days
-    D = 4,
+    Day = 4,
 }
 
 impl TimeUnit {
     /// Convert to a Jiff span.
     pub fn to_jiff_span(&self, v: i64) -> VortexResult<Span> {
         Ok(match self {
-            TimeUnit::Ns => Span::new().try_nanoseconds(v)?,
-            TimeUnit::Us => Span::new().try_microseconds(v)?,
-            TimeUnit::Ms => Span::new().try_milliseconds(v)?,
-            TimeUnit::S => Span::new().try_seconds(v)?,
-            TimeUnit::D => Span::new().try_days(v)?,
+            TimeUnit::Nano => Span::new().try_nanoseconds(v)?,
+            TimeUnit::Micro => Span::new().try_microseconds(v)?,
+            TimeUnit::Milli => Span::new().try_milliseconds(v)?,
+            TimeUnit::Second => Span::new().try_seconds(v)?,
+            TimeUnit::Day => Span::new().try_days(v)?,
         })
     }
 }
@@ -39,11 +39,11 @@ impl TimeUnit {
 impl Display for TimeUnit {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Ns => write!(f, "ns"),
-            Self::Us => write!(f, "µs"),
-            Self::Ms => write!(f, "ms"),
-            Self::S => write!(f, "s"),
-            Self::D => write!(f, "days"),
+            Self::Nano => write!(f, "ns"),
+            Self::Micro => write!(f, "µs"),
+            Self::Milli => write!(f, "ms"),
+            Self::Second => write!(f, "s"),
+            Self::Day => write!(f, "days"),
         }
     }
 }

--- a/vortex-dtype/src/extension.rs
+++ b/vortex-dtype/src/extension.rs
@@ -1,6 +1,8 @@
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
+use vortex_error::VortexResult;
+
 use crate::{DType, Nullability};
 
 /// A unique identifier for an extension type
@@ -57,7 +59,10 @@ impl From<&[u8]> for ExtMetadata {
     }
 }
 
-/// A type descriptor for an extension type
+/// A type descriptor for an extension type.
+///
+/// Stores the type ID, the logical type of the stored values, and an optional
+/// piece of metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExtDType {
@@ -144,6 +149,96 @@ impl ExtDType {
             && self
                 .storage_dtype()
                 .eq_ignore_nullability(other.storage_dtype())
+    }
+}
+
+/// A trait covering pluggable extension types.
+///
+/// Any user of this crate can create their own extension types and plug them into Vortex by defining
+/// an implementation of this trait for their type. The trait defines an interface for types to
+/// be in serialized/deserialized form, as well as some of the other metadata types here.
+pub trait ExtensionType {
+    /// Type of the metadata attached to this type.
+    ///
+    /// If the type has not metadata `()` can be used.
+    type Metadata;
+
+    /// Globally unique type identifier for the extension.
+    fn type_id() -> ExtID;
+
+    /// Get a reference to the metadata for an instance of the extension type.
+    fn metadata(&self) -> &Self::Metadata;
+
+    /// Serialize the owned metadata into an `ExtMetadata` serialized format.
+    fn serialize(&self) -> Option<ExtMetadata>;
+
+    /// Deserialize a piece of owned metadata from the serialized `ExtMetadata`, propagating
+    /// any errors in the deserialization process.
+    fn try_deserialize(serialized: &ExtMetadata) -> VortexResult<Self::Metadata>
+    where
+        Self: Sized;
+
+    /// Create a new extension type instance from the storage type and metadata.
+    fn try_new(storage_type: DType, metadata: Self::Metadata) -> VortexResult<Self>
+    where
+        Self: Sized;
+}
+
+impl ExtDType {
+    /// Downcast the ref.
+    pub fn downcast_ref<T: ExtensionType>(&self) -> Option<&T> {
+        if self.id() == &T::type_id() {
+            // Attempt to deserialize the metadata down.
+            // We could promote this with a `TryFrom` impl, but that would require
+            // `T` to be `Sized`.
+            let metadata = T::try_deserialize(self.metadata()?).ok();
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature = "arrow")]
+mod arrow_impl {
+    use arrow_schema::extension::ExtensionType as ArrowExtensionType;
+    use vortex_error::{VortexResult, vortex_err};
+
+    use crate::{DType, ExtID, ExtMetadata, ExtensionType};
+
+    // Arrow uses std HashMap which we disallow.
+    #[allow(clippy::disallowed_types)]
+    impl<T: ArrowExtensionType> ExtensionType for T {
+        type Metadata = <T as ArrowExtensionType>::Metadata;
+
+        fn type_id() -> ExtID {
+            ExtID::from(T::NAME)
+        }
+
+        fn metadata(&self) -> &Self::Metadata {
+            <T as ArrowExtensionType>::metadata(self)
+        }
+
+        fn serialize(&self) -> Option<ExtMetadata> {
+            Some(ExtMetadata::from(T::serialize_metadata(self)?.as_bytes()))
+        }
+
+        fn try_deserialize(metadata: &ExtMetadata) -> VortexResult<Self::Metadata> {
+            let bytes = metadata.as_ref();
+            let json = std::str::from_utf8(bytes)
+                .map_err(|e| vortex_err!("failed to parse metadata as UTF-8 string: {}", e))?;
+            // Figure out how to deserialize the metadata as-is here.
+            Ok(T::deserialize_metadata(Some(json))?)
+        }
+
+        fn try_new(storage_type: DType, metadata: Self::Metadata) -> VortexResult<Self>
+        where
+            Self: Sized,
+        {
+            Ok(<T as ArrowExtensionType>::try_new(
+                &storage_type.to_arrow()?,
+                metadata,
+            )?)
+        }
     }
 }
 

--- a/vortex-dtype/src/extension.rs
+++ b/vortex-dtype/src/extension.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock, RwLock};
 
-use vortex_error::VortexResult;
+use vortex_error::{VortexExpect, VortexResult};
 
 use crate::{DType, Nullability};
 
@@ -36,7 +37,7 @@ impl From<&str> for ExtID {
 }
 
 /// Opaque metadata for an extension type
-#[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, PartialOrd, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExtMetadata(Arc<[u8]>);
 
@@ -150,6 +151,14 @@ impl ExtDType {
                 .storage_dtype()
                 .eq_ignore_nullability(other.storage_dtype())
     }
+
+    pub fn try_extension_type<T: ExtensionType>(&self) -> Option<T> {
+        if !ExtensionRegistry::shared().is_valid(self) {
+            None
+        } else {
+            ExtensionRegistry::shared().is_valid()
+        }
+    }
 }
 
 /// A trait covering pluggable extension types.
@@ -182,30 +191,35 @@ pub trait ExtensionType {
     fn try_new(storage_type: DType, metadata: Self::Metadata) -> VortexResult<Self>
     where
         Self: Sized;
-}
 
-impl ExtDType {
-    /// Downcast the ref.
-    pub fn downcast_ref<T: ExtensionType>(&self) -> Option<&T> {
-        if self.id() == &T::type_id() {
-            // Attempt to deserialize the metadata down.
-            // We could promote this with a `TryFrom` impl, but that would require
-            // `T` to be `Sized`.
-            let metadata = T::try_deserialize(self.metadata()?).ok();
-        } else {
-            None
-        }
+    #[cfg(feature = "arrow")]
+    /// Convert to an Arrow [`Field`] containing the data type and any Arrow extension metadata
+    /// that should be attached for Arrow clients.
+    ///
+    /// By default nothing is returned.
+    fn to_field(&self) -> Option<arrow_schema::Field> {
+        None
     }
 }
 
 #[cfg(feature = "arrow")]
 mod arrow_impl {
     use arrow_schema::extension::ExtensionType as ArrowExtensionType;
+    use arrow_schema::{DataType, Field};
     use vortex_error::{VortexResult, vortex_err};
 
     use crate::{DType, ExtID, ExtMetadata, ExtensionType};
 
-    // Arrow uses std HashMap which we disallow.
+    pub struct GenericArrowExtensionType<T: ArrowExtensionType> {
+        data_type: DataType,
+        extension_type: T,
+    }
+
+    // If it works, we can capture one from somewhere and deploy it here instead.
+    // If we're getting some sort of type here we can capture the extension type so
+    // that we get access to the type values here instead...I think?
+
+    // Arrow uses std HashMap which we otherwise disallow.
     #[allow(clippy::disallowed_types)]
     impl<T: ArrowExtensionType> ExtensionType for T {
         type Metadata = <T as ArrowExtensionType>::Metadata;
@@ -238,6 +252,98 @@ mod arrow_impl {
                 &storage_type.to_arrow()?,
                 metadata,
             )?)
+        }
+
+        /// Convert self into a field type.
+        /// If we have an Arrow extension type wrapping another type, then that works as expected.
+        fn to_field(&self) -> Option<Field> {
+            todo!()
+        }
+    }
+}
+
+/// Validation function, constructed from a T to validate that the metadata and storage
+/// type conform to the requirements of the type.
+type ValidateFn = Box<dyn Fn(&ExtDType) -> VortexResult<()> + Send + Sync + 'static>;
+
+#[cfg(feature = "arrow")]
+/// Convert the a storage type + metadata into some inner T and then convert it to a field.
+type ToFieldFn =
+    Box<dyn Fn(&DType, &ExtMetadata) -> Option<arrow_schema::Field> + Send + Sync + 'static>;
+
+// Entry in the extensions table
+struct Entry {
+    validate_fn: ValidateFn,
+    #[cfg(feature = "arrow")]
+    to_field_fn: ToFieldFn,
+}
+
+static REGISTRY: LazyLock<ExtensionRegistry> = LazyLock::new(|| ExtensionRegistry {
+    extensions: Arc::new(RwLock::new(HashMap::new())),
+});
+
+pub struct ExtensionRegistry {
+    extensions: Arc<RwLock<HashMap<ExtID, Entry>>>,
+}
+
+impl ExtensionRegistry {
+    /// Get access to the shared registry.
+    pub fn shared() -> &'static Self {
+        &REGISTRY
+    }
+
+    /// Register the extension type `T` so that it can be recognized by several intrinsic Vortex
+    /// functions that operate over extensions.
+    pub fn register<T: ExtensionType>(&self) {
+        let validate_fn = Box::new(|ext_dtype: &ExtDType| {
+            let m = T::try_deserialize(&ext_dtype.metadata().cloned().unwrap_or_default())?;
+            let _ = T::try_new(ext_dtype.storage_dtype().clone(), m)?;
+            Ok(())
+        });
+
+        #[cfg(feature = "arrow")]
+        let to_field_fn = Box::new(|storage_type: &DType, metadata: &ExtMetadata| {
+            let m = T::try_deserialize(&metadata)?;
+            let ext = T::try_new(storage_type.clone(), m)
+                .vortex_expect("validation should have succeeded previously");
+            ext.to_field()
+        });
+
+        self.extensions.write().unwrap().insert(
+            T::type_id(),
+            Entry {
+                validate_fn,
+                #[cfg(feature = "arrow")]
+                to_field_fn,
+            },
+        );
+    }
+
+    /// Validate that the metadata is valid according to our validation logic.
+    pub fn is_valid(&self, extension_type: &ExtDType) -> bool {
+        let map_guard = self.extensions.read().vortex_expect("poisoned");
+        if let Some(entry) = map_guard.get(extension_type.id()) {
+            (entry.validate_fn)(
+                extension_type.storage_dtype(),
+                &extension_type.metadata().cloned().unwrap_or_default(),
+            )
+            .is_ok()
+        } else {
+            false
+        }
+    }
+
+    #[cfg(feature = "arrow")]
+    pub fn try_to_arrow(&self, ext_dtype: &ExtDType) -> Option<arrow_schema::Field> {
+        if let Some(entry) = self
+            .extensions
+            .read()
+            .vortex_expect("poisoned")
+            .get(ext_dtype.id())
+        {
+            (entry.to_field_fn)()
+        } else {
+            None
         }
     }
 }

--- a/vortex-duckdb/src/convert/scalar/mod.rs
+++ b/vortex-duckdb/src/convert/scalar/mod.rs
@@ -116,15 +116,15 @@ impl ToDuckDBScalar for ExtScalar<'_> {
         };
         match time {
             TemporalMetadata::Time(unit) => match unit {
-                TimeUnit::Us => Ok(Value::time_from_us(value()?)),
-                TimeUnit::Ms => Ok(Value::time_from_us(value()? * 1000)),
-                TimeUnit::S => Ok(Value::time_from_us(value()? * 1000 * 1000)),
-                TimeUnit::Ns | TimeUnit::D => {
+                TimeUnit::Micro => Ok(Value::time_from_us(value()?)),
+                TimeUnit::Milli => Ok(Value::time_from_us(value()? * 1000)),
+                TimeUnit::Second => Ok(Value::time_from_us(value()? * 1000 * 1000)),
+                TimeUnit::Nano | TimeUnit::Day => {
                     vortex_bail!("cannot convert timeunit {unit} to a duckdb MS time")
                 }
             },
             TemporalMetadata::Date(unit) => match unit {
-                TimeUnit::D => Ok(self
+                TimeUnit::Day => Ok(self
                     .storage()
                     .as_primitive_opt()
                     .ok_or_else(|| {
@@ -140,11 +140,11 @@ impl ToDuckDBScalar for ExtScalar<'_> {
                     todo!("timezones to duckdb scalar")
                 }
                 match unit {
-                    TimeUnit::Ns => Ok(Value::timestamp_ns(value()?)),
-                    TimeUnit::Us => Ok(Value::timestamp_us(value()?)),
-                    TimeUnit::Ms => Ok(Value::timestamp_ms(value()?)),
-                    TimeUnit::S => Ok(Value::timestamp_s(value()?)),
-                    TimeUnit::D => {
+                    TimeUnit::Nano => Ok(Value::timestamp_ns(value()?)),
+                    TimeUnit::Micro => Ok(Value::timestamp_us(value()?)),
+                    TimeUnit::Milli => Ok(Value::timestamp_ms(value()?)),
+                    TimeUnit::Second => Ok(Value::timestamp_s(value()?)),
+                    TimeUnit::Day => {
                         vortex_bail!("timestamp(d) is cannot be converted to duckdb scalar")
                     }
                 }

--- a/vortex-duckdb/src/convert/types/from.rs
+++ b/vortex-duckdb/src/convert/types/from.rs
@@ -39,12 +39,12 @@ impl FromDuckDBType<LogicalTypeHandle> for DType {
             LogicalTypeId::Date => Ok(DType::Extension(Arc::new(ExtDType::new(
                 DATE_ID.clone(),
                 Arc::new(DType::Primitive(PType::I32, nullable)),
-                Some(TemporalMetadata::Date(TimeUnit::D).into()),
+                Some(TemporalMetadata::Date(TimeUnit::Day).into()),
             )))),
             LogicalTypeId::Time => Ok(DType::Extension(Arc::new(ExtDType::new(
                 TIME_ID.clone(),
                 Arc::new(DType::Primitive(PType::I64, nullable)),
-                Some(TemporalMetadata::Time(TimeUnit::Us).into()),
+                Some(TemporalMetadata::Time(TimeUnit::Micro).into()),
             )))),
             LogicalTypeId::Timestamp
             | LogicalTypeId::TimestampS
@@ -72,10 +72,10 @@ impl FromDuckDBType<LogicalTypeHandle> for DType {
 
 fn timestamp_time_unit(type_id: LogicalTypeId) -> VortexResult<TimeUnit> {
     match type_id {
-        LogicalTypeId::TimestampS => Ok(TimeUnit::S),
-        LogicalTypeId::TimestampMs => Ok(TimeUnit::Ms),
-        LogicalTypeId::Timestamp => Ok(TimeUnit::Us),
-        LogicalTypeId::TimestampNs => Ok(TimeUnit::Ns),
+        LogicalTypeId::TimestampS => Ok(TimeUnit::Second),
+        LogicalTypeId::TimestampMs => Ok(TimeUnit::Milli),
+        LogicalTypeId::Timestamp => Ok(TimeUnit::Micro),
+        LogicalTypeId::TimestampNs => Ok(TimeUnit::Nano),
         _ => vortex_bail!("invalid type_id for function"),
     }
 }

--- a/vortex-duckdb/src/convert/types/to.rs
+++ b/vortex-duckdb/src/convert/types/to.rs
@@ -64,13 +64,13 @@ pub fn ext_to_duckdb(ext_dtype: &ExtDType) -> LogicalTypeHandle {
         .vortex_expect("make_arrow_temporal_dtype must be called with a temporal ExtDType")
     {
         TemporalMetadata::Date(time_unit) => match time_unit {
-            TimeUnit::D => LogicalTypeHandle::from(LogicalTypeId::Date),
+            TimeUnit::Day => LogicalTypeHandle::from(LogicalTypeId::Date),
             _ => {
                 vortex_panic!(InvalidArgument: "Invalid TimeUnit {} for {}", time_unit, ext_dtype.id())
             }
         },
         TemporalMetadata::Time(time_unit) => match time_unit {
-            TimeUnit::Us => LogicalTypeHandle::from(LogicalTypeId::Time),
+            TimeUnit::Micro => LogicalTypeHandle::from(LogicalTypeId::Time),
             _ => {
                 vortex_panic!(InvalidArgument: "Invalid TimeUnit {} for {}", time_unit, ext_dtype.id())
             }
@@ -80,10 +80,10 @@ pub fn ext_to_duckdb(ext_dtype: &ExtDType) -> LogicalTypeHandle {
                 vortex_panic!(InvalidArgument: "Timestamp with timezone is not yet supported")
             }
             match time_unit {
-                TimeUnit::Ns => LogicalTypeHandle::from(LogicalTypeId::TimestampNs),
-                TimeUnit::Us => LogicalTypeHandle::from(LogicalTypeId::Timestamp),
-                TimeUnit::Ms => LogicalTypeHandle::from(LogicalTypeId::TimestampMs),
-                TimeUnit::S => LogicalTypeHandle::from(LogicalTypeId::TimestampS),
+                TimeUnit::Nano => LogicalTypeHandle::from(LogicalTypeId::TimestampNs),
+                TimeUnit::Micro => LogicalTypeHandle::from(LogicalTypeId::Timestamp),
+                TimeUnit::Milli => LogicalTypeHandle::from(LogicalTypeId::TimestampMs),
+                TimeUnit::Second => LogicalTypeHandle::from(LogicalTypeId::TimestampS),
                 _ => {
                     vortex_panic!(InvalidArgument: "Invalid TimeUnit {} for {}", time_unit, ext_dtype.id())
                 }

--- a/vortex-error/src/lib.rs
+++ b/vortex-error/src/lib.rs
@@ -418,6 +418,21 @@ macro_rules! vortex_bail {
     };
 }
 
+/// Convenience macro that bails if an assertion fails.
+#[macro_export]
+macro_rules! vortex_assert {
+    ($condition:expr) => {{
+        if !$condition {
+            $crate::vortex_bail!("Assertion failed: {}", stringify!{ $condition })
+        }
+    }};
+    ($condition:expr, $($tt:tt)+) => {{
+        if !$condition {
+            $crate::vortex_bail!($($tt)*)
+        }
+    }};
+}
+
 /// A convenient macro for panicking with a VortexError in the presence of a programmer error
 /// (e.g., an invariant has been violated).
 #[macro_export]

--- a/vortex-jni/src/array.rs
+++ b/vortex-jni/src/array.rs
@@ -76,7 +76,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_exportToArrow<'loc
     let array_ref = unsafe { NativeArray::from_ptr(array_ptr) };
 
     try_or_throw(&mut env, |env| {
-        let preferred_arrow_type = array_ref.inner.dtype().to_arrow_dtype()?;
+        let preferred_arrow_type = array_ref.inner.dtype().to_arrow()?;
         let viewless_arrow_type = data_type_no_views(preferred_arrow_type);
 
         let arrow_array = array_ref.inner.clone().into_arrow(&viewless_arrow_type)?;

--- a/vortex-jni/src/dtype.rs
+++ b/vortex-jni/src/dtype.rs
@@ -237,11 +237,11 @@ pub extern "system" fn Java_dev_vortex_jni_NativeDTypeMethods_getTimeUnit(
 
         let temporal = TemporalMetadata::try_from(ext_dtype)?;
         Ok(match temporal.time_unit() {
-            TimeUnit::Ns => 0,
-            TimeUnit::Us => 1,
-            TimeUnit::Ms => 2,
-            TimeUnit::S => 3,
-            TimeUnit::D => 4,
+            TimeUnit::Nano => 0,
+            TimeUnit::Micro => 1,
+            TimeUnit::Milli => 2,
+            TimeUnit::Second => 3,
+            TimeUnit::Day => 4,
         })
     })
 }

--- a/vortex-scalar/src/arrow.rs
+++ b/vortex-scalar/src/arrow.rs
@@ -109,52 +109,52 @@ impl TryFrom<&Scalar> for Arc<dyn Datum> {
 
                     return match metadata {
                         TemporalMetadata::Time(u) => match u {
-                            TimeUnit::Ns => value_to_arrow_scalar!(
+                            TimeUnit::Nano => value_to_arrow_scalar!(
                                 primitive.as_::<i64>()?,
                                 Time64NanosecondArray
                             ),
-                            TimeUnit::Us => value_to_arrow_scalar!(
+                            TimeUnit::Micro => value_to_arrow_scalar!(
                                 primitive.as_::<i64>()?,
                                 Time64MicrosecondArray
                             ),
-                            TimeUnit::Ms => value_to_arrow_scalar!(
+                            TimeUnit::Milli => value_to_arrow_scalar!(
                                 primitive.as_::<i32>()?,
                                 Time32MillisecondArray
                             ),
-                            TimeUnit::S => {
+                            TimeUnit::Second => {
                                 value_to_arrow_scalar!(primitive.as_::<i32>()?, Time32SecondArray)
                             }
-                            TimeUnit::D => {
+                            TimeUnit::Day => {
                                 vortex_bail!("Unsupported TimeUnit {u} for {}", ext.id())
                             }
                         },
                         TemporalMetadata::Date(u) => match u {
-                            TimeUnit::Ms => {
+                            TimeUnit::Milli => {
                                 value_to_arrow_scalar!(primitive.as_::<i64>()?, Date64Array)
                             }
-                            TimeUnit::D => {
+                            TimeUnit::Day => {
                                 value_to_arrow_scalar!(primitive.as_::<i32>()?, Date32Array)
                             }
                             _ => vortex_bail!("Unsupported TimeUnit {u} for {}", ext.id()),
                         },
                         TemporalMetadata::Timestamp(u, _) => match u {
-                            TimeUnit::Ns => value_to_arrow_scalar!(
+                            TimeUnit::Nano => value_to_arrow_scalar!(
                                 primitive.as_::<i64>()?,
                                 TimestampNanosecondArray
                             ),
-                            TimeUnit::Us => value_to_arrow_scalar!(
+                            TimeUnit::Micro => value_to_arrow_scalar!(
                                 primitive.as_::<i64>()?,
                                 TimestampMicrosecondArray
                             ),
-                            TimeUnit::Ms => value_to_arrow_scalar!(
+                            TimeUnit::Milli => value_to_arrow_scalar!(
                                 primitive.as_::<i64>()?,
                                 TimestampMillisecondArray
                             ),
-                            TimeUnit::S => value_to_arrow_scalar!(
+                            TimeUnit::Second => value_to_arrow_scalar!(
                                 primitive.as_::<i64>()?,
                                 TimestampSecondArray
                             ),
-                            TimeUnit::D => {
+                            TimeUnit::Day => {
                                 vortex_bail!("Unsupported TimeUnit {u} for {}", ext.id())
                             }
                         },

--- a/vortex-scalar/src/datafusion.rs
+++ b/vortex-scalar/src/datafusion.rs
@@ -86,36 +86,36 @@ impl TryFrom<Scalar> for ScalarValue {
                     let pv = storage_scalar.as_primitive();
                     return Ok(match metadata {
                         TemporalMetadata::Time(u) => match u {
-                            TimeUnit::Ns => ScalarValue::Time64Nanosecond(pv.as_::<i64>()?),
-                            TimeUnit::Us => ScalarValue::Time64Microsecond(pv.as_::<i64>()?),
-                            TimeUnit::Ms => ScalarValue::Time32Millisecond(pv.as_::<i32>()?),
-                            TimeUnit::S => ScalarValue::Time32Second(pv.as_::<i32>()?),
-                            TimeUnit::D => {
+                            TimeUnit::Nano => ScalarValue::Time64Nanosecond(pv.as_::<i64>()?),
+                            TimeUnit::Micro => ScalarValue::Time64Microsecond(pv.as_::<i64>()?),
+                            TimeUnit::Milli => ScalarValue::Time32Millisecond(pv.as_::<i32>()?),
+                            TimeUnit::Second => ScalarValue::Time32Second(pv.as_::<i32>()?),
+                            TimeUnit::Day => {
                                 unreachable!("Unsupported TimeUnit {u} for {}", ext.id())
                             }
                         },
                         TemporalMetadata::Date(u) => match u {
-                            TimeUnit::Ms => ScalarValue::Date64(pv.as_::<i64>()?),
-                            TimeUnit::D => ScalarValue::Date32(pv.as_::<i32>()?),
+                            TimeUnit::Milli => ScalarValue::Date64(pv.as_::<i64>()?),
+                            TimeUnit::Day => ScalarValue::Date32(pv.as_::<i32>()?),
                             _ => unreachable!("Unsupported TimeUnit {u} for {}", ext.id()),
                         },
                         TemporalMetadata::Timestamp(u, tz) => match u {
-                            TimeUnit::Ns => ScalarValue::TimestampNanosecond(
+                            TimeUnit::Nano => ScalarValue::TimestampNanosecond(
                                 pv.as_::<i64>()?,
                                 tz.map(|t| t.into()),
                             ),
-                            TimeUnit::Us => ScalarValue::TimestampMicrosecond(
+                            TimeUnit::Micro => ScalarValue::TimestampMicrosecond(
                                 pv.as_::<i64>()?,
                                 tz.map(|t| t.into()),
                             ),
-                            TimeUnit::Ms => ScalarValue::TimestampMillisecond(
+                            TimeUnit::Milli => ScalarValue::TimestampMillisecond(
                                 pv.as_::<i64>()?,
                                 tz.map(|t| t.into()),
                             ),
-                            TimeUnit::S => {
+                            TimeUnit::Second => {
                                 ScalarValue::TimestampSecond(pv.as_::<i64>()?, tz.map(|t| t.into()))
                             }
-                            TimeUnit::D => {
+                            TimeUnit::Day => {
                                 unreachable!("Unsupported TimeUnit {u} for {}", ext.id())
                             }
                         },

--- a/vortex-scalar/src/display.rs
+++ b/vortex-scalar/src/display.rs
@@ -178,7 +178,7 @@ mod tests {
             DType::Extension(Arc::new(ExtDType::new(
                 TIME_ID.clone(),
                 Arc::new(DType::Primitive(PType::I32, Nullable)),
-                Some(ExtMetadata::from(TemporalMetadata::Time(TimeUnit::S))),
+                Some(ExtMetadata::from(TemporalMetadata::Time(TimeUnit::Second))),
             )))
         }
 
@@ -202,7 +202,7 @@ mod tests {
             DType::Extension(Arc::new(ExtDType::new(
                 DATE_ID.clone(),
                 Arc::new(DType::Primitive(PType::I32, Nullable)),
-                Some(ExtMetadata::from(TemporalMetadata::Date(TimeUnit::D))),
+                Some(ExtMetadata::from(TemporalMetadata::Date(TimeUnit::Day))),
             )))
         }
 
@@ -249,7 +249,7 @@ mod tests {
                 TIMESTAMP_ID.clone(),
                 Arc::new(DType::Primitive(PType::I32, Nullable)),
                 Some(ExtMetadata::from(TemporalMetadata::Timestamp(
-                    TimeUnit::S,
+                    TimeUnit::Second,
                     None,
                 ))),
             )))
@@ -279,7 +279,7 @@ mod tests {
                 TIMESTAMP_ID.clone(),
                 Arc::new(DType::Primitive(PType::I64, Nullable)),
                 Some(ExtMetadata::from(TemporalMetadata::Timestamp(
-                    TimeUnit::S,
+                    TimeUnit::Second,
                     Some(String::from("Pacific/Guam")),
                 ))),
             )))


### PR DESCRIPTION
Extracting this out of #3213.

This adds a new `ArrowTypeConversion` trait, which provides a way to support externally pluggable extension types for Vortex. Downstream crates can register these implementations using the `DType::register_extension_type` associated function. I originally went with `inventory` crate but there are a whole slew of issues with using it, that I tried to document in [this repo](https://github.com/a10y/testinv/blob/main/plugin_use/src/main.rs).

ArrowTypeConversion provides optional conversion in both directions between Vortex extension types and Arrow types. It also fixes up a few code paths to ensure that any struct conversions will attach the Arrow extension type/metadata