### PR TITLE
fix: duckdb tls on linux machine as default

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Run ${{ matrix.benchmark.name }} benchmark
         shell: bash
         run: |
-          target/release_debug/${{ matrix.benchmark.id }} -d gh-json --skip-duckdb-build | tee ${{ matrix.benchmark.id }}.json
+          target/release_debug/${{ matrix.benchmark.id }} -d gh-json | tee ${{ matrix.benchmark.id }}.json
 
       - name: Setup AWS CLI
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -131,7 +131,6 @@ jobs:
           # The `NATIVE_ARCH` environment variable is picked up by `duckdb/Makefile`.
           NATIVE_ARCH: 1
           DUCKDB_PLATFORM: linux_amd64
-          CFLAGS: -ftls-model=global-dynamic
         run: GEN=ninja make release
         working-directory: ${{ github.workspace }}/duckdb-vortex
 

--- a/duckdb-vortex/Makefile
+++ b/duckdb-vortex/Makefile
@@ -20,7 +20,7 @@ export VCPKG_TOOLCHAIN_PATH := ${PROJ_DIR}vcpkg/scripts/buildsystems/vcpkg.cmake
 export BUILD_MAIN_DUCKDB_LIBRARY=0
 export DISABLE_BUILTIN_EXTENSIONS=1
 
-# This is not needed on macOS, we don't see a tls there.
+# This is not needed on macOS, we don't see a tls error on load there.
 ifeq ($(shell uname), Linux)
     export CFLAGS=-ftls-model=global-dynamic
 endif

--- a/duckdb-vortex/Makefile
+++ b/duckdb-vortex/Makefile
@@ -20,7 +20,7 @@ export VCPKG_TOOLCHAIN_PATH := ${PROJ_DIR}vcpkg/scripts/buildsystems/vcpkg.cmake
 export BUILD_MAIN_DUCKDB_LIBRARY=0
 export DISABLE_BUILTIN_EXTENSIONS=1
 
-# TODO(joe): fix me on windows
+# This is not needed on macOS, we don't see a tls there.
 ifeq ($(shell uname), Linux)
     export CFLAGS=-ftls-model=global-dynamic
 endif

--- a/duckdb-vortex/Makefile
+++ b/duckdb-vortex/Makefile
@@ -20,4 +20,9 @@ export VCPKG_TOOLCHAIN_PATH := ${PROJ_DIR}vcpkg/scripts/buildsystems/vcpkg.cmake
 export BUILD_MAIN_DUCKDB_LIBRARY=0
 export DISABLE_BUILTIN_EXTENSIONS=1
 
+# TODO(joe): fix me on windows
+ifeq ($(shell uname), Linux)
+    export CFLAGS=-ftls-model=global-dynamic
+endif
+
 include extension-ci-tools/makefiles/duckdb_extension.Makefile


### PR DESCRIPTION
Use the makefile to ensure `-ftls-model=global-dynamic` 