### PR TITLE
Fix Array Debug

### DIFF
--- a/vortex-array/src/vtable/mod.rs
+++ b/vortex-array/src/vtable/mod.rs
@@ -39,7 +39,7 @@ use crate::{Array, Encoding, EncodingId, EncodingRef, IntoArray};
 /// out of bounds). Post-conditions are validated after invocation of the vtable function and will
 /// panic if violated.
 pub trait VTable: 'static + Sized + Send + Sync + Debug {
-    type Array: 'static + Send + Sync + Clone + Deref<Target = dyn Array> + IntoArray;
+    type Array: 'static + Send + Sync + Clone + Debug + Deref<Target = dyn Array> + IntoArray;
     type Encoding: 'static + Send + Sync + Clone + Deref<Target = dyn Encoding>;
 
     type ArrayVTable: ArrayVTable<Self>;


### PR DESCRIPTION
On dev now: 

```rust
    let mut b = PrimitiveBuilder::<i32>::new(
        Nullability::NonNullable
    );

    b.extend_with_iterator(
        vec![1, 2, 3, 4, 5],
        Mask::AllTrue(5)
    );

    let arr = b.finish_into_primitive();
    let array = arr.to_array();

    println!("array: {:?}", array);
```

```
thread 'main' has overflowed its stack
fatal runtime error: stack overflow
```


After this change: 

```
array: PrimitiveArray { dtype: Primitive(I32, NonNullable), buffer: Buffer<u8> { length: 20, alignment: Alignment(4), as_slice: [1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, ...] }, validity: NonNullable, stats_set: ArrayStats { inner: RwLock { data: StatsSet { values: [] } } } }
```

