### PR TITLE
Return null-d array in `between`

### DIFF
--- a/vortex-array/src/compute/between.rs
+++ b/vortex-array/src/compute/between.rs
@@ -312,7 +312,7 @@ mod tests {
         .to_bool()
         .unwrap();
 
-        let indices = to_int_indices(matches);
+        let indices = to_int_indices(matches).unwrap();
         assert_eq!(indices, expected);
     }
 
@@ -340,8 +340,8 @@ mod tests {
         .to_bool()
         .unwrap();
 
-        let indices = to_int_indices(matches);
-        assert_eq!(indices, vec![]);
+        let indices = to_int_indices(matches).unwrap();
+        assert!(indices.is_empty());
 
         // upper is a fixed constant
         let upper = ConstantArray::new(Scalar::from(2), 5);
@@ -357,7 +357,7 @@ mod tests {
         .unwrap()
         .to_bool()
         .unwrap();
-        let indices = to_int_indices(matches);
+        let indices = to_int_indices(matches).unwrap();
         assert_eq!(indices, vec![0, 1, 3]);
 
         // lower is also a constant
@@ -375,7 +375,7 @@ mod tests {
         .unwrap()
         .to_bool()
         .unwrap();
-        let indices = to_int_indices(matches);
+        let indices = to_int_indices(matches).unwrap();
         assert_eq!(indices, vec![0, 1, 2, 3, 4]);
     }
 }

--- a/vortex-array/src/compute/between.rs
+++ b/vortex-array/src/compute/between.rs
@@ -134,7 +134,9 @@ impl ComputeFnVTable for Between {
         if lower.as_constant().is_some_and(|v| v.is_null())
             || upper.as_constant().is_some_and(|v| v.is_null())
         {
-            return Ok(Canonical::empty(&return_dtype).into_array().into());
+            return Ok(ConstantArray::new(Scalar::null(return_dtype), array.len())
+                .into_array()
+                .into());
         }
 
         // Try each kernel
@@ -270,5 +272,110 @@ impl StrictComparison {
             StrictComparison::Strict => Operator::Lt,
             StrictComparison::NonStrict => Operator::Lte,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_dtype::{Nullability, PType};
+
+    use super::*;
+    use crate::ToCanonical;
+    use crate::arrays::PrimitiveArray;
+    use crate::compute::conformance::search_sorted::rstest;
+    use crate::test_harness::to_int_indices;
+
+    #[rstest]
+    #[case(StrictComparison::NonStrict, StrictComparison::NonStrict, vec![0, 1, 2, 3])]
+    #[case(StrictComparison::NonStrict, StrictComparison::Strict, vec![0, 1])]
+    #[case(StrictComparison::Strict, StrictComparison::NonStrict, vec![0, 2])]
+    #[case(StrictComparison::Strict, StrictComparison::Strict, vec![0])]
+    fn test_bounds(
+        #[case] lower_strict: StrictComparison,
+        #[case] upper_strict: StrictComparison,
+        #[case] expected: Vec<u64>,
+    ) {
+        let lower = PrimitiveArray::from_iter([0, 0, 0, 0, 2]);
+        let array = PrimitiveArray::from_iter([1, 0, 1, 0, 1]);
+        let upper = PrimitiveArray::from_iter([2, 1, 1, 0, 0]);
+
+        let matches = between(
+            array.as_ref(),
+            lower.as_ref(),
+            upper.as_ref(),
+            &BetweenOptions {
+                lower_strict,
+                upper_strict,
+            },
+        )
+        .unwrap()
+        .to_bool()
+        .unwrap();
+
+        let indices = to_int_indices(matches);
+        assert_eq!(indices, expected);
+    }
+
+    #[test]
+    fn test_constants() {
+        let lower = PrimitiveArray::from_iter([0, 0, 2, 0, 2]);
+        let array = PrimitiveArray::from_iter([1, 0, 1, 0, 1]);
+
+        // upper is null
+        let upper = ConstantArray::new(
+            Scalar::null(DType::Primitive(PType::I32, Nullability::Nullable)),
+            5,
+        );
+
+        let matches = between(
+            array.as_ref(),
+            lower.as_ref(),
+            upper.as_ref(),
+            &BetweenOptions {
+                lower_strict: StrictComparison::NonStrict,
+                upper_strict: StrictComparison::NonStrict,
+            },
+        )
+        .unwrap()
+        .to_bool()
+        .unwrap();
+
+        let indices = to_int_indices(matches);
+        assert_eq!(indices, vec![]);
+
+        // upper is a fixed constant
+        let upper = ConstantArray::new(Scalar::from(2), 5);
+        let matches = between(
+            array.as_ref(),
+            lower.as_ref(),
+            upper.as_ref(),
+            &BetweenOptions {
+                lower_strict: StrictComparison::NonStrict,
+                upper_strict: StrictComparison::NonStrict,
+            },
+        )
+        .unwrap()
+        .to_bool()
+        .unwrap();
+        let indices = to_int_indices(matches);
+        assert_eq!(indices, vec![0, 1, 3]);
+
+        // lower is also a constant
+        let lower = ConstantArray::new(Scalar::from(0), 5);
+
+        let matches = between(
+            array.as_ref(),
+            lower.as_ref(),
+            upper.as_ref(),
+            &BetweenOptions {
+                lower_strict: StrictComparison::NonStrict,
+                upper_strict: StrictComparison::NonStrict,
+            },
+        )
+        .unwrap()
+        .to_bool()
+        .unwrap();
+        let indices = to_int_indices(matches);
+        assert_eq!(indices, vec![0, 1, 2, 3, 4]);
     }
 }

--- a/vortex-array/src/compute/compare.rs
+++ b/vortex-array/src/compute/compare.rs
@@ -324,23 +324,13 @@ pub fn scalar_cmp(lhs: &Scalar, rhs: &Scalar, operator: Operator) -> Scalar {
 #[cfg(test)]
 mod tests {
     use arrow_buffer::BooleanBuffer;
-    use itertools::Itertools;
     use rstest::rstest;
 
     use super::*;
     use crate::ToCanonical;
     use crate::arrays::{BoolArray, ConstantArray, VarBinArray, VarBinViewArray};
+    use crate::test_harness::to_int_indices;
     use crate::validity::Validity;
-
-    fn to_int_indices(indices_bits: BoolArray) -> Vec<u64> {
-        let buffer = indices_bits.boolean_buffer();
-        let mask = indices_bits.validity_mask().unwrap();
-        buffer
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, v)| (v && mask.value(idx)).then_some(idx as u64))
-            .collect_vec()
-    }
 
     #[test]
     fn test_bool_basic_comparisons() {

--- a/vortex-array/src/compute/compare.rs
+++ b/vortex-array/src/compute/compare.rs
@@ -344,14 +344,14 @@ mod tests {
             .to_bool()
             .unwrap();
 
-        assert_eq!(to_int_indices(matches), [1u64, 2, 3, 4]);
+        assert_eq!(to_int_indices(matches).unwrap(), [1u64, 2, 3, 4]);
 
         let matches = compare(arr.as_ref(), arr.as_ref(), Operator::NotEq)
             .unwrap()
             .to_bool()
             .unwrap();
         let empty: [u64; 0] = [];
-        assert_eq!(to_int_indices(matches), empty);
+        assert_eq!(to_int_indices(matches).unwrap(), empty);
 
         let other = BoolArray::new(
             BooleanBuffer::from_iter([false, false, false, true, true]),
@@ -362,25 +362,25 @@ mod tests {
             .unwrap()
             .to_bool()
             .unwrap();
-        assert_eq!(to_int_indices(matches), [2u64, 3, 4]);
+        assert_eq!(to_int_indices(matches).unwrap(), [2u64, 3, 4]);
 
         let matches = compare(arr.as_ref(), other.as_ref(), Operator::Lt)
             .unwrap()
             .to_bool()
             .unwrap();
-        assert_eq!(to_int_indices(matches), [4u64]);
+        assert_eq!(to_int_indices(matches).unwrap(), [4u64]);
 
         let matches = compare(other.as_ref(), arr.as_ref(), Operator::Gte)
             .unwrap()
             .to_bool()
             .unwrap();
-        assert_eq!(to_int_indices(matches), [2u64, 3, 4]);
+        assert_eq!(to_int_indices(matches).unwrap(), [2u64, 3, 4]);
 
         let matches = compare(other.as_ref(), arr.as_ref(), Operator::Gt)
             .unwrap()
             .to_bool()
             .unwrap();
-        assert_eq!(to_int_indices(matches), [4u64]);
+        assert_eq!(to_int_indices(matches).unwrap(), [4u64]);
     }
 
     #[test]

--- a/vortex-array/src/test_harness.rs
+++ b/vortex-array/src/test_harness.rs
@@ -2,7 +2,9 @@ use std::io::Write;
 
 use goldenfile::Mint;
 use goldenfile::differs::binary_diff;
+use itertools::Itertools;
 
+use crate::arrays::BoolArray;
 use crate::{DeserializeMetadata, SerializeMetadata};
 
 /// Check that a named metadata matches its previous versioning.
@@ -20,4 +22,15 @@ where
         .new_goldenfile_with_differ(name, Box::new(binary_diff))
         .unwrap();
     f.write_all(&meta).unwrap();
+}
+
+/// Outputs the indices of the true values in a BoolArray
+pub fn to_int_indices(indices_bits: BoolArray) -> Vec<u64> {
+    let buffer = indices_bits.boolean_buffer();
+    let mask = indices_bits.validity_mask().unwrap();
+    buffer
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, v)| (v && mask.value(idx)).then_some(idx as u64))
+        .collect_vec()
 }

--- a/vortex-array/src/test_harness.rs
+++ b/vortex-array/src/test_harness.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use goldenfile::Mint;
 use goldenfile::differs::binary_diff;
 use itertools::Itertools;
+use vortex_error::VortexResult;
 
 use crate::arrays::BoolArray;
 use crate::{DeserializeMetadata, SerializeMetadata};
@@ -25,12 +26,12 @@ where
 }
 
 /// Outputs the indices of the true values in a BoolArray
-pub fn to_int_indices(indices_bits: BoolArray) -> Vec<u64> {
+pub fn to_int_indices(indices_bits: BoolArray) -> VortexResult<Vec<u64>> {
     let buffer = indices_bits.boolean_buffer();
-    let mask = indices_bits.validity_mask().unwrap();
-    buffer
+    let mask = indices_bits.validity_mask()?;
+    Ok(buffer
         .iter()
         .enumerate()
         .filter_map(|(idx, v)| (v && mask.value(idx)).then_some(idx as u64))
-        .collect_vec()
+        .collect_vec())
 }


### PR DESCRIPTION
Now on dev: 

```rust

    let a = vortex::arrays::PrimitiveArray::from_iter([0, 0, 2, 0, 2]);
    let b = vortex::arrays::PrimitiveArray::from_iter([0, 0, 2, 0, 2]);
    let c = ConstantArray::new(Scalar::null(DType::Primitive(PType::I32, Nullability::Nullable)), 5);

    let opts = BetweenOptions {
        lower_strict: StrictComparison::NonStrict,
        upper_strict: StrictComparison::NonStrict,
    };

    let t = vortex::compute::between(
        &b.to_array(),
        &a.to_array(),
        &c.to_array(),
        &opts
    ).unwrap().to_bool().unwrap();
```
```
thread 'main' panicked at src/main.rs:44:7:
called `Result::unwrap()` on an `Err` value: Internal error: compute function between returned a result of length 0 but expected 5
```