### PR TITLE
Use dashmap for layout reader expression caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6368,6 +6368,7 @@ dependencies = [
  "arcref",
  "async-trait",
  "bytes",
+ "dashmap",
  "flatbuffers",
  "futures",
  "getrandom 0.3.2",

--- a/vortex-file/Cargo.toml
+++ b/vortex-file/Cargo.toml
@@ -17,6 +17,7 @@ version = { workspace = true }
 arcref = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
+dashmap = { workspace = true }
 flatbuffers = { workspace = true }
 futures = { workspace = true, features = ["std", "async-await"] }
 # Needed to pickup the "wasm_js" feature for wasm targets from the workspace configuration

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -2,9 +2,8 @@ use std::ops::{BitAnd, Deref, Range};
 use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
+use dashmap::DashMap;
 use futures::{FutureExt, join};
-use parking_lot::RwLock;
-use vortex_array::aliases::hash_map::HashMap;
 use vortex_array::arrays::StructArray;
 use vortex_array::compute::{MinMaxResult, filter, min_max};
 use vortex_array::{Array, ArrayContext, ArrayRef, ToCanonical};
@@ -29,7 +28,7 @@ pub struct DictReader {
     /// Cached dict values array
     values_array: OnceLock<SharedArrayFuture>,
     /// Cache of expression evaluation results on the values array by expression
-    values_evals: RwLock<HashMap<ExprRef, SharedArrayFuture>>,
+    values_evals: DashMap<ExprRef, SharedArrayFuture>,
 
     values: LayoutReaderRef,
     codes: LayoutReaderRef,
@@ -96,7 +95,6 @@ impl DictReader {
 
     fn values_eval(&self, expr: ExprRef) -> SharedArrayFuture {
         self.values_evals
-            .write()
             .entry(expr.clone())
             .or_insert_with(|| {
                 self.values_array()

--- a/vortex-layout/src/layouts/filter.rs
+++ b/vortex-layout/src/layouts/filter.rs
@@ -4,10 +4,10 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bit_vec::BitVec;
+use dashmap::DashMap;
 use itertools::Itertools;
 use parking_lot::RwLock;
 use sketches_ddsketch::DDSketch;
-use vortex_array::aliases::hash_map::HashMap;
 use vortex_error::{VortexExpect, VortexResult, vortex_err, vortex_panic};
 use vortex_expr::ExprRef;
 use vortex_expr::forms::cnf::cnf;
@@ -28,7 +28,7 @@ const DEFAULT_SELECTIVITY_QUANTILE: f64 = 0.1;
 /// expression rewrite logic at read-time.
 pub struct FilterLayoutReader {
     child: LayoutReaderRef,
-    cache: RwLock<HashMap<ExprRef, Arc<FilterExpr>>>,
+    cache: DashMap<ExprRef, Arc<FilterExpr>>,
 }
 
 impl FilterLayoutReader {
@@ -60,7 +60,6 @@ impl LayoutReader for FilterLayoutReader {
     ) -> VortexResult<Box<dyn PruningEvaluation>> {
         let filter_expr = self
             .cache
-            .write()
             .entry(expr.clone())
             .or_insert_with(|| Arc::new(FilterExpr::new(expr.clone())))
             .clone();
@@ -83,7 +82,6 @@ impl LayoutReader for FilterLayoutReader {
     ) -> VortexResult<Box<dyn MaskEvaluation>> {
         let filter_expr = self
             .cache
-            .write()
             .entry(expr.clone())
             .or_insert_with(|| Arc::new(FilterExpr::new(expr.clone())))
             .clone();

--- a/vortex-layout/src/lib.rs
+++ b/vortex-layout/src/lib.rs
@@ -1,5 +1,7 @@
 #![feature(once_cell_try)]
 #![feature(trait_alias)]
+#![feature(mpmc_channel)]
+
 mod context;
 pub use context::*;
 pub mod layouts;

--- a/vortex-layout/src/lib.rs
+++ b/vortex-layout/src/lib.rs
@@ -1,7 +1,5 @@
 #![feature(once_cell_try)]
 #![feature(trait_alias)]
-#![feature(mpmc_channel)]
-
 mod context;
 pub use context::*;
 pub mod layouts;

--- a/vortex-layout/src/scan/mod.rs
+++ b/vortex-layout/src/scan/mod.rs
@@ -108,6 +108,11 @@ impl<A: 'static + Send> ScanBuilder<A> {
         self
     }
 
+    pub fn with_executor(mut self, executor: Arc<dyn TaskExecutor>) -> Self {
+        self.executor = Some(executor);
+        self
+    }
+
     pub fn with_metrics(mut self, metrics: VortexMetrics) -> Self {
         self.metrics = metrics;
         self
@@ -236,7 +241,7 @@ impl<A: 'static + Send> ScanBuilder<A> {
             row_masks
         };
 
-        // Finally, map the row masks through the projection evaluation
+        // Finally, map the row masks through the projection evaluation and spawn.
         row_masks
             .into_iter()
             .map(|(row_range, mask_fut)| {


### PR DESCRIPTION
And for good measure, everywhere else we had a `RwLock<HashMap<..>>`