### PR TITLE
Fix style issues caught by newer rust and clippy

### DIFF
--- a/bench-vortex/src/bin/clickbench.rs
+++ b/bench-vortex/src/bin/clickbench.rs
@@ -329,7 +329,7 @@ fn print_results(
 fn data_source_base_url(remote_data_dir: &Option<String>, flavor: Flavor) -> anyhow::Result<Url> {
     match remote_data_dir {
         None => {
-            let basepath = format!("clickbench_{}", flavor).to_data_path();
+            let basepath = format!("clickbench_{flavor}").to_data_path();
             let client = reqwest::blocking::Client::default();
 
             flavor.download(&client, basepath.as_path())?;

--- a/bench-vortex/src/bin/public_bi.rs
+++ b/bench-vortex/src/bin/public_bi.rs
@@ -176,7 +176,7 @@ fn main() -> anyhow::Result<()> {
                             .sorted_for_display()
                             .iter()
                         {
-                            println!("{}", m);
+                            println!("{m}");
                         }
                     }
                 }

--- a/bench-vortex/src/bin/tpch.rs
+++ b/bench-vortex/src/bin/tpch.rs
@@ -434,7 +434,7 @@ async fn bench_main(
                 }
             }
             _ => {
-                warn!("Engine {:?} not supported for TPC-H benchmarks", engine);
+                warn!("Engine {engine:?} not supported for TPC-H benchmarks");
             }
         }
     }
@@ -447,7 +447,7 @@ async fn bench_main(
                 metrics = metrics.aggregate();
             }
             for m in metrics.timestamps_removed().sorted_for_display().iter() {
-                println!("{}", m);
+                println!("{m}");
             }
             render_table(measurements, &targets)?;
         }

--- a/bench-vortex/src/compress/bench.rs
+++ b/bench-vortex/src/compress/bench.rs
@@ -91,7 +91,7 @@ pub fn benchmark_compress(
         });
         vortex_compress_time = Some(time);
         timings.push(CompressionTimingMeasurement {
-            name: format!("compress time/{}", bench_name),
+            name: format!("compress time/{bench_name}"),
             time,
             format: Format::OnDiskVortex,
         });
@@ -99,7 +99,7 @@ pub fn benchmark_compress(
 
         let compressed_size_f64 = compressed_size.load(Ordering::SeqCst) as f64;
         ratios.push(CustomUnitMeasurement {
-            name: format!("vortex size/{}", bench_name),
+            name: format!("vortex size/{bench_name}"),
             format: Format::OnDiskVortex,
             unit: Cow::from("bytes"),
             value: compressed_size_f64,
@@ -123,7 +123,7 @@ pub fn benchmark_compress(
         });
         parquet_compress_time = Some(time);
         timings.push(CompressionTimingMeasurement {
-            name: format!("compress time/{}", bench_name),
+            name: format!("compress time/{bench_name}"),
             time,
             format: Format::Parquet,
         });
@@ -131,14 +131,14 @@ pub fn benchmark_compress(
         progress.inc(1);
         let parquet_compressed_size = parquet_compressed_size.into_inner();
         ratios.push(CustomUnitMeasurement {
-            name: format!("parquet-zstd size/{}", bench_name),
+            name: format!("parquet-zstd size/{bench_name}"),
             // unlike timings, ratios have a single column vortex
             format: Format::OnDiskVortex,
             unit: Cow::from("bytes"),
             value: parquet_compressed_size as f64,
         });
         ratios.push(CustomUnitMeasurement {
-            name: format!("vortex:parquet-zstd size/{}", bench_name),
+            name: format!("vortex:parquet-zstd size/{bench_name}"),
             format: Format::OnDiskVortex,
             unit: Cow::from("ratio"),
             value: compressed_size.load(Ordering::SeqCst) as f64 / parquet_compressed_size as f64,
@@ -161,7 +161,7 @@ pub fn benchmark_compress(
         });
         vortex_decompress_time = Some(time);
         timings.push(CompressionTimingMeasurement {
-            name: format!("decompress time/{}", bench_name),
+            name: format!("decompress time/{bench_name}"),
             time,
             format: Format::OnDiskVortex,
         });
@@ -188,7 +188,7 @@ pub fn benchmark_compress(
         });
         parquet_decompress_time = Some(time);
         timings.push(CompressionTimingMeasurement {
-            name: format!("decompress time/{}", bench_name),
+            name: format!("decompress time/{bench_name}"),
             time,
             format: Format::Parquet,
         });
@@ -197,7 +197,7 @@ pub fn benchmark_compress(
 
     if let Some((vortex, parquet)) = vortex_compress_time.zip(parquet_compress_time) {
         ratios.push(CustomUnitMeasurement {
-            name: format!("vortex:parquet-zstd ratio compress time/{}", bench_name),
+            name: format!("vortex:parquet-zstd ratio compress time/{bench_name}"),
             format: Format::OnDiskVortex,
             unit: Cow::from("ratio"),
             value: vortex.as_nanos() as f64 / parquet.as_nanos() as f64,
@@ -206,7 +206,7 @@ pub fn benchmark_compress(
 
     if let Some((vortex, parquet)) = vortex_decompress_time.zip(parquet_decompress_time) {
         ratios.push(CustomUnitMeasurement {
-            name: format!("vortex:parquet-zstd ratio decompress time/{}", bench_name),
+            name: format!("vortex:parquet-zstd ratio decompress time/{bench_name}"),
             format: Format::OnDiskVortex,
             unit: Cow::from("ratio"),
             value: vortex.as_nanos() as f64 / parquet.as_nanos() as f64,

--- a/bench-vortex/src/engines/ddb/mod.rs
+++ b/bench-vortex/src/engines/ddb/mod.rs
@@ -271,7 +271,7 @@ pub fn register_tables(
         object,
     ));
 
-    trace!("register duckdb tables with command: {:?}", command);
+    trace!("register duckdb tables with command: {command:?}");
 
     // Pass along OS env vars (for aws creds)
     // Don't trace env vars.
@@ -318,7 +318,7 @@ pub fn execute_query(
         .arg("-c")
         .arg(query);
 
-    trace!("execute duckdb query with command: {:?}", command);
+    trace!("execute duckdb query with command: {command:?}");
 
     let time_instant = Instant::now();
     let output = command.output()?;

--- a/bench-vortex/src/engines/df/mod.rs
+++ b/bench-vortex/src/engines/df/mod.rs
@@ -84,7 +84,7 @@ pub fn make_object_store(
                     .build()
                     .unwrap(),
             );
-            df.register_object_store(&Url::parse(&format!("s3://{}/", bucket_name))?, s3.clone());
+            df.register_object_store(&Url::parse(&format!("s3://{bucket_name}/"))?, s3.clone());
             Ok(s3)
         }
         "gs" => {
@@ -95,7 +95,7 @@ pub fn make_object_store(
                     .build()
                     .unwrap(),
             );
-            df.register_object_store(&Url::parse(&format!("gs://{}/", bucket_name))?, gcs.clone());
+            df.register_object_store(&Url::parse(&format!("gs://{bucket_name}/"))?, gcs.clone());
             Ok(gcs)
         }
         _ => {
@@ -130,7 +130,7 @@ pub fn write_execution_plan(
 ) {
     fs::write(
         format!("{dataset_name}_{format}_q{query_idx:02}.plan"),
-        format!("{:#?}", execution_plan),
+        format!("{execution_plan:#?}"),
     )
     .expect("Unable to write file");
 

--- a/bench-vortex/src/measurements.rs
+++ b/bench-vortex/src/measurements.rs
@@ -27,10 +27,10 @@ pub enum MeasurementValue {
 impl Display for MeasurementValue {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            MeasurementValue::Int(i) => write!(f, "{}", i),
+            MeasurementValue::Int(i) => write!(f, "{i}"),
             MeasurementValue::Float(fl) => match f.precision() {
-                None => write!(f, "{}", fl),
-                Some(p) => write!(f, "{1:.*}", p, fl),
+                None => write!(f, "{fl}"),
+                Some(p) => write!(f, "{fl:.p$}"),
             },
         }
     }

--- a/bench-vortex/src/tpcds/mod.rs
+++ b/bench-vortex/src/tpcds/mod.rs
@@ -24,7 +24,7 @@ pub fn tpcds_queries() -> impl Iterator<Item = (usize, String)> {
 fn tpch_query(query_idx: usize) -> String {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tpcds")
-        .join(format!("{:02}", query_idx))
+        .join(format!("{query_idx:02}"))
         .with_extension("sql");
     fs::read_to_string(manifest_dir).unwrap()
 }

--- a/bench-vortex/src/tpch/dbgen.rs
+++ b/bench-vortex/src/tpch/dbgen.rs
@@ -153,7 +153,7 @@ impl Display for Platform {
             Platform::MacOS => "macos",
             Platform::Linux => "linux",
         };
-        write!(f, "{}", str)
+        write!(f, "{str}")
     }
 }
 

--- a/bench-vortex/src/tpch/mod.rs
+++ b/bench-vortex/src/tpch/mod.rs
@@ -289,7 +289,7 @@ pub fn tpch_queries() -> impl Iterator<Item = (usize, Vec<String>)> {
 fn tpch_query(query_idx: usize) -> Vec<String> {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tpch")
-        .join(format!("q{}", query_idx))
+        .join(format!("q{query_idx}"))
         .with_extension("sql");
     fs::read_to_string(manifest_dir)
         .unwrap()

--- a/encodings/datetime-parts/src/compute/cast.rs
+++ b/encodings/datetime-parts/src/compute/cast.rs
@@ -72,7 +72,7 @@ mod tests {
         let array = date_time_array(validity);
         let new_dtype = array.dtype().with_nullability(cast_to_nullability);
         let result = cast(&array, &new_dtype);
-        assert!(result.is_ok(), "{:?}", result);
+        assert!(result.is_ok(), "{result:?}");
         assert_eq!(result.unwrap().dtype(), &new_dtype);
     }
 
@@ -86,8 +86,7 @@ mod tests {
             result
                 .as_ref()
                 .is_err_and(|err| err.to_string().contains("cannot cast from")),
-            "{:?}",
-            result
+            "{result:?}"
         );
 
         let result = cast(
@@ -98,8 +97,7 @@ mod tests {
             result.as_ref().is_err_and(|err| err
                 .to_string()
                 .contains("invalid cast from nullable to non-nullable")),
-            "{:?}",
-            result
+            "{result:?}"
         );
     }
 }

--- a/encodings/dict/src/array.rs
+++ b/encodings/dict/src/array.rs
@@ -118,10 +118,7 @@ impl CanonicalVTable<DictVTable> for DictVTable {
 impl ValidityVTable<DictVTable> for DictVTable {
     fn is_valid(array: &DictArray, index: usize) -> VortexResult<bool> {
         let scalar = array.codes().scalar_at(index).map_err(|err| {
-            err.with_context(format!(
-                "Failed to get index {} from DictArray codes",
-                index
-            ))
+            err.with_context(format!("Failed to get index {index} from DictArray codes"))
         })?;
 
         if scalar.is_null() {

--- a/pyvortex/src/arrays/py/encoding.rs
+++ b/pyvortex/src/arrays/py/encoding.rs
@@ -23,8 +23,7 @@ impl<'py> FromPyObject<'py> for PythonEncoding {
             cls.getattr("id")
                 .map_err(|_| {
                     PyValueError::new_err(format!(
-                        "PyEncoding subclass {} must have an 'id' attribute",
-                        ob
+                        "PyEncoding subclass {ob} must have an 'id' attribute"
                     ))
                 })?
                 .extract::<String>()

--- a/pyvortex/src/dataset.rs
+++ b/pyvortex/src/dataset.rs
@@ -59,8 +59,7 @@ fn projection_from_python(columns: Option<Vec<Bound<PyAny>>>) -> PyResult<ExprRe
             Ok(FieldName::from(field.downcast::<PyString>()?.to_str()?))
         } else {
             Err(PyTypeError::new_err(format!(
-                "projection: expected list of strings or None, but found: {}.",
-                field,
+                "projection: expected list of strings or None, but found: {field}.",
             )))
         }
     }

--- a/pyvortex/src/expr/mod.rs
+++ b/pyvortex/src/expr/mod.rs
@@ -87,8 +87,7 @@ fn coerce_expr<'py>(value: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyExpr>> {
         scalar(DType::Binary(nonnull), value)
     } else {
         Err(PyValueError::new_err(format!(
-            "expected None, int, float, str, or bytes but found: {}",
-            value
+            "expected None, int, float, str, or bytes but found: {value}"
         )))
     }
 }

--- a/pyvortex/src/lib.rs
+++ b/pyvortex/src/lib.rs
@@ -44,7 +44,7 @@ fn _lib(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
             .filter_target("my_module::verbose_submodule".to_owned(), LevelFilter::Warn)
             .install()
             .map(|_| ())
-            .map_err(|err| PyRuntimeError::new_err(format!("could not initialize logger {}", err)))
+            .map_err(|err| PyRuntimeError::new_err(format!("could not initialize logger {err}")))
     })?;
 
     // Initialize our submodules, living under vortex._lib

--- a/pyvortex/src/scalar/list.rs
+++ b/pyvortex/src/scalar/list.rs
@@ -20,7 +20,7 @@ impl PyListScalar {
         let scalar = self_.as_scalar_ref();
         let child = scalar
             .element(idx)
-            .ok_or_else(|| PyIndexError::new_err(format!("Index out of bounds {}", idx)))?;
+            .ok_or_else(|| PyIndexError::new_err(format!("Index out of bounds {idx}")))?;
         PyVortex(&child).into_pyobject(self_.py()).map(|v| v.into())
     }
 }

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -672,7 +672,7 @@ impl<V: VTable> ArrayVisitor for ArrayAdapter<V> {
 
     fn metadata_fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match <V::SerdeVTable as SerdeVTable<V>>::metadata(&self.0) {
-            Err(e) => write!(f, "<serde error: {}>", e),
+            Err(e) => write!(f, "<serde error: {e}>"),
             Ok(None) => write!(f, "<serde not supported>"),
             Ok(Some(metadata)) => Debug::fmt(&metadata, f),
         }

--- a/vortex-array/src/arrays/bool/serde.rs
+++ b/vortex-array/src/arrays/bool/serde.rs
@@ -22,7 +22,7 @@ impl SerdeVTable<BoolVTable> for BoolVTable {
 
     fn metadata(array: &BoolArray) -> VortexResult<Option<Self::Metadata>> {
         let bit_offset = array.boolean_buffer().offset();
-        assert!(bit_offset < 8, "Offset must be <8, got {}", bit_offset);
+        assert!(bit_offset < 8, "Offset must be <8, got {bit_offset}");
         Ok(Some(ProstMetadata(BoolMetadata {
             offset: u32::try_from(bit_offset).vortex_expect("checked"),
         })))

--- a/vortex-array/src/arrays/chunked/serde.rs
+++ b/vortex-array/src/arrays/chunked/serde.rs
@@ -68,7 +68,7 @@ impl VisitorVTable<ChunkedVTable> for ChunkedVTable {
         visitor.visit_child("chunk_offsets", chunk_offsets.as_ref());
 
         for (idx, chunk) in array.chunks().iter().enumerate() {
-            visitor.visit_child(format!("chunks[{}]", idx).as_str(), chunk);
+            visitor.visit_child(format!("chunks[{idx}]").as_str(), chunk);
         }
     }
 }

--- a/vortex-array/src/arrays/struct_/compute/mod.rs
+++ b/vortex-array/src/arrays/struct_/compute/mod.rs
@@ -194,8 +194,7 @@ mod tests {
                 err.to_string()
                     .contains("cannot cast {xs=u8, ys=u8, zs=u8} to {ys=u8, xs=u8, zs=u8}")
             }),
-            "{:?}",
-            result
+            "{result:?}"
         );
     }
 

--- a/vortex-array/src/arrow/compute/to_arrow/canonical.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/canonical.rs
@@ -240,7 +240,7 @@ fn to_arrow_struct(array: StructArray, fields: &[FieldRef]) -> VortexResult<Arro
 
             arr.clone()
                 .into_arrow(field.data_type())
-                .map_err(|err| err.with_context(format!("Failed to canonicalize field {}", field)))
+                .map_err(|err| err.with_context(format!("Failed to canonicalize field {field}")))
         })
         .collect::<VortexResult<Vec<_>>>()?;
 
@@ -282,7 +282,7 @@ fn to_arrow_list<O: NativePType + OffsetSizeTrait>(
     // First we cast the offsets into the correct width.
     let offsets_dtype = DType::Primitive(O::PTYPE, array.dtype().nullability());
     let arrow_offsets = cast(array.offsets(), &offsets_dtype)
-        .map_err(|err| err.with_context(format!("Failed to cast offsets to {}", offsets_dtype)))?
+        .map_err(|err| err.with_context(format!("Failed to cast offsets to {offsets_dtype}")))?
         .to_primitive()?;
 
     let values = array.elements().clone().into_arrow(element.data_type())?;

--- a/vortex-array/src/builders/struct_.rs
+++ b/vortex-array/src/builders/struct_.rs
@@ -143,9 +143,7 @@ impl ArrayBuilder for StructBuilder {
                 assert_eq!(
                     field.len(),
                     expected_length,
-                    "Field {} does not have expected length {}",
-                    index,
-                    expected_length
+                    "Field {index} does not have expected length {expected_length}"
                 );
             }
         }

--- a/vortex-array/src/compute/conformance/binary_numeric.rs
+++ b/vortex-array/src/compute/conformance/binary_numeric.rs
@@ -55,10 +55,7 @@ where
                     .vortex_expect("numeric operator overflow"))
                 .map(<Scalar as From<PrimitiveScalar<'_>>>::from)
                 .collect::<Vec<Scalar>>(),
-            "({:?}) {} (Constant array of {}) did not produce expected results",
-            array,
-            operator,
-            scalar_one,
+            "({array:?}) {operator} (Constant array of {scalar_one}) did not produce expected results",
         );
 
         assert_eq!(
@@ -78,10 +75,7 @@ where
                     .vortex_expect("numeric operator overflow"))
                 .map(<Scalar as From<PrimitiveScalar<'_>>>::from)
                 .collect::<Vec<_>>(),
-            "(Constant array of {}) {} ({:?}) did not produce expected results",
-            scalar_one,
-            operator,
-            array,
+            "(Constant array of {scalar_one}) {operator} ({array:?}) did not produce expected results",
         );
     }
 }

--- a/vortex-array/src/compute/is_constant.rs
+++ b/vortex-array/src/compute/is_constant.rs
@@ -77,8 +77,7 @@ impl ComputeFnVTable for IsConstant {
             // When we run linear canonicalize, there we must always return an exact answer.
             assert!(
                 value.is_some(),
-                "is constant in array {} canonicalize returned None",
-                array
+                "is constant in array {array} canonicalize returned None"
             );
         }
 

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -96,10 +96,7 @@ impl Patches {
         .vortex_expect("indices must be a number");
         assert!(
             max - offset < array_len,
-            "Patch indices {:?}, offset {} are longer than the array length {}",
-            max,
-            offset,
-            array_len
+            "Patch indices {max:?}, offset {offset} are longer than the array length {array_len}"
         );
         Self::new_unchecked(array_len, offset, indices, values)
     }

--- a/vortex-array/src/stats/array.rs
+++ b/vortex-array/src/stats/array.rs
@@ -186,7 +186,7 @@ impl StatsSetRef<'_> {
         stat: Stat,
     ) -> Option<U> {
         self.compute_stat(stat)
-            .inspect_err(|e| log::warn!("Failed to compute stat {}: {}", stat, e))
+            .inspect_err(|e| log::warn!("Failed to compute stat {stat}: {e}"))
             .ok()
             .flatten()
             .map(|s| U::try_from(&s))

--- a/vortex-array/src/stats/precision.rs
+++ b/vortex-array/src/stats/precision.rs
@@ -141,10 +141,10 @@ impl<T: Display> Display for Precision<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Exact(v) => {
-                write!(f, "{}", v)
+                write!(f, "{v}")
             }
             Inexact(v) => {
-                write!(f, "~{}", v)
+                write!(f, "~{v}")
             }
         }
     }

--- a/vortex-array/src/stats/stats_set.rs
+++ b/vortex-array/src/stats/stats_set.rs
@@ -732,7 +732,7 @@ mod test {
 
         let stats = array.statistics().to_owned();
         for stat in &all_stats {
-            assert!(stats.get(*stat).is_some(), "Stat {} is missing", stat);
+            assert!(stats.get(*stat).is_some(), "Stat {stat} is missing");
         }
 
         let merged = stats.clone().merge_unordered(
@@ -743,8 +743,7 @@ mod test {
             assert_eq!(
                 merged.get(*stat).is_some(),
                 stat.is_commutative(),
-                "Stat {} remains after merge_unordered despite not being commutative, or was removed despite being commutative",
-                stat
+                "Stat {stat} remains after merge_unordered despite not being commutative, or was removed despite being commutative"
             )
         }
 

--- a/vortex-buffer/src/buffer.rs
+++ b/vortex-buffer/src/buffer.rs
@@ -377,9 +377,7 @@ impl<T> Buffer<T> {
             {
                 let bt = std::backtrace::Backtrace::capture();
                 log::warn!(
-                    "Buffer is not aligned to requested alignment {}, copying: {}",
-                    alignment,
-                    bt
+                    "Buffer is not aligned to requested alignment {alignment}, copying: {bt}"
                 )
             }
             Self::copy_from_aligned(self, alignment)

--- a/vortex-datafusion/src/lib.rs
+++ b/vortex-datafusion/src/lib.rs
@@ -48,7 +48,7 @@ fn supported_data_types(dt: DataType) -> bool {
         );
 
     if !is_supported {
-        log::debug!("DataFusion data type {:?} is not supported", dt);
+        log::debug!("DataFusion data type {dt:?} is not supported");
     }
 
     is_supported
@@ -110,7 +110,7 @@ fn can_be_pushed_down(expr: &Expr, schema: &Schema) -> bool {
         }
         Expr::Literal(lit) => supported_data_types(lit.data_type()),
         _ => {
-            log::debug!("DataFusion expression can't be pushed down: {:?}", expr);
+            log::debug!("DataFusion expression can't be pushed down: {expr:?}");
             false
         }
     }

--- a/vortex-datafusion/src/memory/stream.rs
+++ b/vortex-datafusion/src/memory/stream.rs
@@ -35,7 +35,7 @@ impl Stream for VortexRecordBatchStream {
 
         let struct_array = chunk
             .to_struct()
-            .map_err(|vortex_error| DataFusionError::Execution(format!("{}", vortex_error)))?;
+            .map_err(|vortex_error| DataFusionError::Execution(format!("{vortex_error}")))?;
 
         let projected_struct = struct_array
             .project(&self.projection)

--- a/vortex-datafusion/src/persistent/cache.rs
+++ b/vortex-datafusion/src/persistent/cache.rs
@@ -61,7 +61,7 @@ impl VortexFileCache {
         let file_cache = Cache::builder()
             .max_capacity(size_mb as u64 * (1 << 20))
             .eviction_listener(|k: Arc<FileKey>, _v: VortexFile, cause| {
-                log::trace!("Removed {:?} due to {:?}", k, cause);
+                log::trace!("Removed {k:?} due to {cause:?}");
             })
             .weigher(|_k, vxf| {
                 u32::try_from(estimate_layout_size(vxf.footer())).unwrap_or(u32::MAX)
@@ -71,7 +71,7 @@ impl VortexFileCache {
         let segment_cache = Cache::builder()
             .max_capacity(segment_size_mb as u64 * (1 << 20))
             .eviction_listener(|k: Arc<SegmentKey>, _v: ByteBuffer, cause| {
-                log::trace!("Removed {:?} due to {:?}", k, cause);
+                log::trace!("Removed {k:?} due to {cause:?}");
             })
             .weigher(|_k, v| u32::try_from(v.len()).unwrap_or(u32::MAX))
             .build_with_hasher(DefaultHashBuilder::default());

--- a/vortex-dtype/src/datetime/temporal.rs
+++ b/vortex-dtype/src/datetime/temporal.rs
@@ -48,10 +48,10 @@ pub enum TemporalJiff {
 impl Display for TemporalJiff {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TemporalJiff::Time(t) => write!(f, "{}", t),
-            TemporalJiff::Date(d) => write!(f, "{}", d),
-            TemporalJiff::Timestamp(ts) => write!(f, "{}", ts),
-            TemporalJiff::Zoned(z) => write!(f, "{}", z),
+            TemporalJiff::Time(t) => write!(f, "{t}"),
+            TemporalJiff::Date(d) => write!(f, "{d}"),
+            TemporalJiff::Timestamp(ts) => write!(f, "{ts}"),
+            TemporalJiff::Zoned(z) => write!(f, "{z}"),
         }
     }
 }

--- a/vortex-dtype/src/decimal.rs
+++ b/vortex-dtype/src/decimal.rs
@@ -39,14 +39,12 @@ impl DecimalDType {
     pub fn new(precision: u8, scale: i8) -> Self {
         assert!(
             precision <= MAX_PRECISION,
-            "decimal precision {} exceeds MAX_PRECISION",
-            precision
+            "decimal precision {precision} exceeds MAX_PRECISION"
         );
 
         assert!(
             scale <= MAX_SCALE,
-            "decimal scale {} exceeds MAX_SCALE",
-            scale
+            "decimal scale {scale} exceeds MAX_SCALE"
         );
 
         Self { precision, scale }

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -234,22 +234,22 @@ impl Display for DType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Null => write!(f, "null"),
-            Bool(n) => write!(f, "bool{}", n),
-            Primitive(pt, n) => write!(f, "{}{}", pt, n),
-            Decimal(dt, n) => write!(f, "{}{}", dt, n),
-            Utf8(n) => write!(f, "utf8{}", n),
-            Binary(n) => write!(f, "binary{}", n),
+            Bool(n) => write!(f, "bool{n}"),
+            Primitive(pt, n) => write!(f, "{pt}{n}"),
+            Decimal(dt, n) => write!(f, "{dt}{n}"),
+            Utf8(n) => write!(f, "utf8{n}"),
+            Binary(n) => write!(f, "binary{n}"),
             Struct(sdt, n) => write!(
                 f,
                 "{{{}}}{}",
                 sdt.names()
                     .iter()
                     .zip(sdt.fields())
-                    .map(|(n, dt)| format!("{}={}", n, dt))
+                    .map(|(n, dt)| format!("{n}={dt}"))
                     .join(", "),
                 n
             ),
-            List(edt, n) => write!(f, "list({}){}", edt, n),
+            List(edt, n) => write!(f, "list({edt}){n}"),
             Extension(ext) => write!(
                 f,
                 "ext({}, {}{}){}",
@@ -257,7 +257,7 @@ impl Display for DType {
                 ext.storage_dtype()
                     .with_nullability(Nullability::NonNullable),
                 ext.metadata()
-                    .map(|m| format!(", {:?}", m))
+                    .map(|m| format!(", {m:?}"))
                     .unwrap_or_else(|| "".to_string()),
                 ext.storage_dtype().nullability(),
             ),

--- a/vortex-duckdb/src/convert/array/chunked.rs
+++ b/vortex-duckdb/src/convert/array/chunked.rs
@@ -78,7 +78,7 @@ mod tests {
         to_duckdb_chunk(&struct_, &mut data_chunk, &mut cache).unwrap();
 
         assert_eq!(
-            format!("{:?}", data_chunk),
+            format!("{data_chunk:?}"),
             r#"Chunk - [1 Columns]
 - FLAT INTEGER: 5 = [ 2, 2, 0, 1, 2]
 "#

--- a/vortex-duckdb/src/convert/array/decimal.rs
+++ b/vortex-duckdb/src/convert/array/decimal.rs
@@ -205,7 +205,7 @@ mod tests {
         to_duckdb_chunk(&str, &mut chunk, &mut ConversionCache::default()).unwrap();
 
         assert_eq!(
-            format!("{:?}", chunk),
+            format!("{chunk:?}"),
             r#"Chunk - [1 Columns]
 - FLAT DECIMAL(3,2): 3 = [ 1.00, 2.00, 2.55]
 "#
@@ -223,7 +223,7 @@ mod tests {
         let mut chunk = DataChunkHandle::new(&[array.dtype().to_duckdb_type().unwrap()]);
         to_duckdb_chunk(&str, &mut chunk, &mut ConversionCache::default()).unwrap();
         assert_eq!(
-            format!("{:?}", chunk),
+            format!("{chunk:?}"),
             r#"Chunk - [1 Columns]
 - FLAT DECIMAL(5,2): 3 = [ 1.00, 2.00, 3.00]
 "#
@@ -241,7 +241,7 @@ mod tests {
         let mut chunk = DataChunkHandle::new(&[array.dtype().to_duckdb_type().unwrap()]);
         to_duckdb_chunk(&str, &mut chunk, &mut ConversionCache::default()).unwrap();
         assert_eq!(
-            format!("{:?}", chunk),
+            format!("{chunk:?}"),
             r#"Chunk - [1 Columns]
 - FLAT DECIMAL(5,2): 3 = [ 1.00, 1.02, 1.09]
 "#
@@ -259,7 +259,7 @@ mod tests {
         let mut chunk = DataChunkHandle::new(&[array.dtype().to_duckdb_type().unwrap()]);
         to_duckdb_chunk(&str, &mut chunk, &mut ConversionCache::default()).unwrap();
         assert_eq!(
-            format!("{:?}", chunk),
+            format!("{chunk:?}"),
             r#"Chunk - [1 Columns]
 - FLAT DECIMAL(20,2): 3 = [ 1.00, 2.00, 3.00]
 "#

--- a/vortex-duckdb/src/convert/array/mod.rs
+++ b/vortex-duckdb/src/convert/array/mod.rs
@@ -116,7 +116,7 @@ mod tests {
         to_duckdb_chunk(&st, &mut output_chunk, &mut ConversionCache::default()).unwrap();
 
         assert_eq!(
-            format!("{:?}", output_chunk),
+            format!("{output_chunk:?}"),
             "Chunk - [2 Columns]\n- CONSTANT BIGINT: 100 = [ 23444233]\n- CONSTANT INTEGER: 100 = [ 234]\n"
         )
     }
@@ -161,7 +161,7 @@ mod tests {
 
         chunk.verify();
         assert_eq!(
-            format!("{:?}", chunk),
+            format!("{chunk:?}"),
             r#"Chunk - [5 Columns]
 - FLAT INTEGER: 5 = [ 0, 1, 2, 3, 4]
 - FLAT VARCHAR: 5 = [ a, ab, abc, abcd, abcde]
@@ -192,7 +192,7 @@ mod tests {
 
         chunk.verify();
         assert_eq!(
-            format!("{:?}", chunk),
+            format!("{chunk:?}"),
             r#"Chunk - [1 Columns]
 - DICTIONARY INTEGER: 5 = [ 0, 3, 4, 2, 1]
 "#

--- a/vortex-duckdb/src/convert/array/run_end.rs
+++ b/vortex-duckdb/src/convert/array/run_end.rs
@@ -120,7 +120,7 @@ mod tests {
 
         chunk.verify();
         assert_eq!(
-            format!("{:?}", chunk),
+            format!("{chunk:?}"),
             r#"Chunk - [1 Columns]
 - DICTIONARY INTEGER: 4 = [ 1, 2, 2, 2]
 "#
@@ -144,7 +144,7 @@ mod tests {
 
         chunk.verify();
         assert_eq!(
-            format!("{:?}", chunk),
+            format!("{chunk:?}"),
             format!(
                 r#"Chunk - [1 Columns]
 - DICTIONARY INTEGER: 2048 = [ {}, {}, {}]

--- a/vortex-duckdb/src/convert/array/varbinview.rs
+++ b/vortex-duckdb/src/convert/array/varbinview.rs
@@ -152,7 +152,7 @@ mod tests {
         chunk.set_len(len);
         chunk.verify();
         assert_eq!(
-            format!("{:?}", chunk),
+            format!("{chunk:?}"),
             r#"Chunk - [1 Columns]
 - CONSTANT VARCHAR: 100 = [ ]
 "#
@@ -177,7 +177,7 @@ mod tests {
         chunk.set_len(len);
         chunk.verify();
         assert_eq!(
-            format!("{:?}", chunk),
+            format!("{chunk:?}"),
             r#"Chunk - [1 Columns]
 - CONSTANT VARCHAR: 100 = [ long string 100000000000000000000000000000000000000000000000000000000000]
 "#
@@ -202,7 +202,7 @@ mod tests {
 
             chunk.verify();
             assert_eq!(
-                format!("{:?}", chunk),
+                format!("{chunk:?}"),
                 r#"Chunk - [1 Columns]
 - FLAT VARCHAR: 2 = [ a, ab]
 "#
@@ -225,7 +225,7 @@ mod tests {
 
             chunk.verify();
             assert_eq!(
-                format!("{:?}", chunk),
+                format!("{chunk:?}"),
                 r#"Chunk - [1 Columns]
 - FLAT VARCHAR: 3 = [ abc, abcd, abcde]
 "#

--- a/vortex-expr/src/pruning.rs
+++ b/vortex-expr/src/pruning.rs
@@ -421,7 +421,7 @@ impl FieldOrIdentity {
 impl Display for FieldOrIdentity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FieldOrIdentity::Field(field) => write!(f, "{}", field),
+            FieldOrIdentity::Field(field) => write!(f, "{field}"),
             FieldOrIdentity::Identity => write!(f, "$[]"),
         }
     }

--- a/vortex-expr/src/transform/match_between.rs
+++ b/vortex-expr/src/transform/match_between.rs
@@ -233,7 +233,7 @@ mod tests {
         );
         let find = find_between(expr);
 
-        println!("{}", find);
+        println!("{find}");
 
         // $.y >= 10 /\ 2 < $.x <= 5
         assert_eq!(
@@ -261,7 +261,7 @@ mod tests {
         );
         let find = find_between(expr);
 
-        println!("{}", find);
+        println!("{find}");
 
         // $.y >= 10 /\ 2 < $.x <= 5
         assert_eq!(

--- a/vortex-expr/src/transform/partition.rs
+++ b/vortex-expr/src/transform/partition.rs
@@ -59,7 +59,7 @@ impl Display for PartitionedExpr {
             self.partition_names
                 .iter()
                 .zip(self.partitions.iter())
-                .map(|(name, partition)| format!("{}: {}", name, partition))
+                .map(|(name, partition)| format!("{name}: {partition}"))
                 .join(", ")
         )
     }

--- a/vortex-ffi/src/array.rs
+++ b/vortex-ffi/src/array.rs
@@ -256,14 +256,14 @@ mod tests {
                 inner: primitive.to_array(),
             });
 
-            assert_eq!(vx_array_len(&*vx_array), 3);
+            assert_eq!(vx_array_len(&raw const *vx_array), 3);
 
-            let array_dtype = vx_array_dtype(&*vx_array);
+            let array_dtype = vx_array_dtype(&raw const *vx_array);
             assert_eq!(vx_dtype_get(array_dtype), DTYPE_PRIMITIVE_I32);
 
-            assert_eq!(vx_array_get_i32(&*vx_array, 0), 1);
-            assert_eq!(vx_array_get_i32(&*vx_array, 1), 2);
-            assert_eq!(vx_array_get_i32(&*vx_array, 2), 3);
+            assert_eq!(vx_array_get_i32(&raw const *vx_array, 0), 1);
+            assert_eq!(vx_array_get_i32(&raw const *vx_array, 1), 2);
+            assert_eq!(vx_array_get_i32(&raw const *vx_array, 2), 3);
 
             vx_array_free(Box::into_raw(vx_array));
         }

--- a/vortex-ffi/src/dtype.rs
+++ b/vortex-ffi/src/dtype.rs
@@ -250,9 +250,8 @@ pub unsafe extern "C-unwind" fn vx_dtype_time_unit(dtype: *const DType) -> u8 {
     };
 
     let metadata = ext_dtype.metadata().vortex_expect("time unit metadata");
-    let time_unit = metadata.as_ref()[0];
 
-    time_unit
+    metadata.as_ref()[0]
 }
 
 #[unsafe(no_mangle)]
@@ -279,7 +278,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_time_zone(
                 unsafe { *len = 0 };
             }
         }
-        _ => panic!("DType_time_zone: not a timestamp metadata: {:?}", ext_dtype),
+        _ => panic!("DType_time_zone: not a timestamp metadata: {ext_dtype:?}"),
     }
 }
 
@@ -353,7 +352,7 @@ mod tests {
                 person,
                 0,
                 name_bytes.as_mut_ptr() as *mut c_void,
-                &mut name_len,
+                &raw mut name_len,
             );
             // Check name_bytes
             let field_name = std::str::from_utf8_unchecked(&name_bytes[..name_len as usize]);
@@ -363,7 +362,7 @@ mod tests {
                 person,
                 1,
                 name_bytes.as_mut_ptr() as *mut c_void,
-                &mut name_len,
+                &raw mut name_len,
             );
             // Check name_bytes
             let field_name = std::str::from_utf8_unchecked(&name_bytes[..name_len as usize]);

--- a/vortex-ffi/src/duckdb/mod.rs
+++ b/vortex-ffi/src/duckdb/mod.rs
@@ -166,14 +166,15 @@ mod tests {
         let mut error: *mut vx_error = null_mut();
 
         let handle = DataChunkHandle::new(&[LogicalTypeHandle::from(LogicalTypeId::Integer)]);
-        let offset =
-            unsafe { vx_array_to_duckdb_chunk(ffi_array, 0, handle.get_ptr(), cache, &mut error) };
+        let offset = unsafe {
+            vx_array_to_duckdb_chunk(ffi_array, 0, handle.get_ptr(), cache, &raw mut error)
+        };
         assert!(error.is_null());
         assert_eq!(offset, 2048);
         assert_eq!(handle.len(), 2048);
 
         let offset = unsafe {
-            vx_array_to_duckdb_chunk(ffi_array, offset, handle.get_ptr(), cache, &mut error)
+            vx_array_to_duckdb_chunk(ffi_array, offset, handle.get_ptr(), cache, &raw mut error)
         };
         assert!(error.is_null());
         assert_eq!(offset, 0);

--- a/vortex-ffi/src/file.rs
+++ b/vortex-ffi/src/file.rs
@@ -337,7 +337,7 @@ fn make_object_store(
                 if let Ok(config_key) = AmazonS3ConfigKey::from_str(key.as_str()) {
                     builder = builder.with_config(config_key, val);
                 } else {
-                    log::warn!("Skipping unknown Amazon S3 config key: {}", key);
+                    log::warn!("Skipping unknown Amazon S3 config key: {key}");
                 }
             }
 
@@ -359,7 +359,7 @@ fn make_object_store(
                 if let Ok(config_key) = AzureConfigKey::from_str(key.as_str()) {
                     builder = builder.with_config(config_key, val);
                 } else {
-                    log::warn!("Skipping unknown Azure config key: {}", key);
+                    log::warn!("Skipping unknown Azure config key: {key}");
                 }
             }
 
@@ -374,7 +374,7 @@ fn make_object_store(
                 if let Ok(config_key) = GoogleConfigKey::from_str(key.as_str()) {
                     builder = builder.with_config(config_key, val);
                 } else {
-                    log::warn!("Skipping unknown Google Cloud Storage config key: {}", key);
+                    log::warn!("Skipping unknown Google Cloud Storage config key: {key}");
                 }
             }
 

--- a/vortex-ffi/src/session.rs
+++ b/vortex-ffi/src/session.rs
@@ -45,7 +45,7 @@ impl VortexSession {
         let file_cache = Cache::builder()
             .max_capacity(64u64 * (1 << 20))
             .eviction_listener(|k: Arc<FileKey>, _v: Footer, cause| {
-                log::trace!("Removed {:?} due to {:?}", k, cause);
+                log::trace!("Removed {k:?} due to {cause:?}");
             })
             .weigher(|_k, footer| u32::try_from(estimate_layout_size(footer)).unwrap_or(u32::MAX))
             .build_with_hasher(DefaultHashBuilder::default());

--- a/vortex-file/src/driver.rs
+++ b/vortex-file/src/driver.rs
@@ -256,7 +256,7 @@ impl CoalescedDriver {
             self.mark_as_prefetched(request.id());
         }
 
-        log::debug!("Coalesced request: {:?}", coalesced);
+        log::debug!("Coalesced request: {coalesced:?}");
         self.coalesced_counter.inc();
         self.coalesced_bytes_counter
             .add(coalesced.size_bytes().try_into().vortex_expect("isize"));
@@ -278,7 +278,7 @@ impl Stream for CoalescedDriver {
             };
 
             // Process the event.
-            log::debug!("Processing: {:?}", event);
+            log::debug!("Processing: {event:?}");
             match event {
                 SegmentEvent::Requested(req) => this.on_requested(req),
                 SegmentEvent::Polled(id) => this.on_polled(id),
@@ -322,7 +322,7 @@ impl Stream for CoalescedDriver {
                 {
                     let coalesced =
                         this.coalesce_request(request, Some(this.inflight_prefetch_lease.clone()));
-                    log::debug!("Prefetching: {:?}", coalesced);
+                    log::debug!("Prefetching: {coalesced:?}");
                     return Poll::Ready(Some(coalesced));
                 }
             }

--- a/vortex-file/src/generic.rs
+++ b/vortex-file/src/generic.rs
@@ -169,9 +169,7 @@ impl VortexOpenOptions<GenericVortexFile> {
         // Read more bytes if necessary.
         if read_more_offset < initial_offset {
             log::info!(
-                "Initial read from {} did not cover all footer segments, reading from {}",
-                initial_offset,
-                read_more_offset
+                "Initial read from {initial_offset} did not cover all footer segments, reading from {read_more_offset}"
             );
 
             let mut new_initial_read =

--- a/vortex-io/src/limit.rs
+++ b/vortex-io/src/limit.rs
@@ -166,7 +166,7 @@ mod tests {
     #[tokio::test]
     async fn test_does_not_leak_permits() {
         let bad_fut: BoxFuture<'static, io::Result<Bytes>> =
-            future::ready(Err(io::Error::new(io::ErrorKind::Other, "badness"))).boxed();
+            future::ready(Err(io::Error::other("badness"))).boxed();
 
         let good_fut: BoxFuture<'static, io::Result<Bytes>> =
             future::ready(Ok(Bytes::from("aaaaa"))).boxed();

--- a/vortex-io/src/object_store.rs
+++ b/vortex-io/src/object_store.rs
@@ -73,7 +73,7 @@ impl VortexReadAt for ObjectStoreReadAt {
                         Ok::<_, io::Error>(buffer)
                     })
                     .await
-                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))??
+                    .map_err(io::Error::other)??
                 }
                 #[cfg(not(feature = "tokio"))]
                 {
@@ -81,7 +81,7 @@ impl VortexReadAt for ObjectStoreReadAt {
                         file.read_exact_at(&mut buffer, range.start)?;
                         Ok::<_, io::Error>(buffer)
                     }
-                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
+                    .map_err(io::Error::other)?
                 }
             }
             GetResultPayload::Stream(mut byte_stream) => {

--- a/vortex-jni/src/file.rs
+++ b/vortex-jni/src/file.rs
@@ -202,7 +202,7 @@ fn make_object_store(
                 if let Ok(config_key) = AmazonS3ConfigKey::from_str(key.as_str()) {
                     builder = builder.with_config(config_key, val);
                 } else {
-                    log::warn!("Skipping unknown Amazon S3 config key: {}", key);
+                    log::warn!("Skipping unknown Amazon S3 config key: {key}");
                 }
             }
 
@@ -222,7 +222,7 @@ fn make_object_store(
                     log::warn!("setting azure config {key:?} = {val}");
                     builder = builder.with_config(config_key, val);
                 } else {
-                    log::warn!("Skipping unknown Azure config key: {}", key);
+                    log::warn!("Skipping unknown Azure config key: {key}");
                 }
             }
 
@@ -236,7 +236,7 @@ fn make_object_store(
                 if let Ok(config_key) = GoogleConfigKey::from_str(key.as_str()) {
                     builder = builder.with_config(config_key, val);
                 } else {
-                    log::warn!("Skipping unknown Google Cloud Storage config key: {}", key);
+                    log::warn!("Skipping unknown Google Cloud Storage config key: {key}");
                 }
             }
 

--- a/vortex-layout/src/layout.rs
+++ b/vortex-layout/src/layout.rs
@@ -93,7 +93,7 @@ impl LayoutChildType {
     /// Returns the name of this child.
     pub fn name(&self) -> Arc<str> {
         match self {
-            LayoutChildType::Chunk((idx, _offset)) => format!("[{}]", idx).into(),
+            LayoutChildType::Chunk((idx, _offset)) => format!("[{idx}]").into(),
             LayoutChildType::Auxiliary(name) => name.clone(),
             LayoutChildType::Transparent(name) => name.clone(),
             LayoutChildType::Field(name) => name.clone(),

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -52,11 +52,11 @@ impl DictReader {
         let values =
             layout
                 .values
-                .new_reader(&format!("{}.values", name).into(), segment_source, ctx)?;
+                .new_reader(&format!("{name}.values").into(), segment_source, ctx)?;
         let codes =
             layout
                 .codes
-                .new_reader(&format!("{}.codes", name).into(), segment_source, ctx)?;
+                .new_reader(&format!("{name}.codes").into(), segment_source, ctx)?;
 
         Ok(Self {
             layout,

--- a/vortex-layout/src/layouts/zoned/reader.rs
+++ b/vortex-layout/src/layouts/zoned/reader.rs
@@ -60,7 +60,7 @@ impl ZonedReader {
         let zones_child =
             layout
                 .zones
-                .new_reader(&format!("{}.zones", name).into(), &segment_source, &ctx)?;
+                .new_reader(&format!("{name}.zones").into(), &segment_source, &ctx)?;
 
         Ok(Self {
             layout,
@@ -118,11 +118,11 @@ impl ZonedReader {
             .entry(expr.clone())
             .or_insert_with(|| match self.pruning_predicate(expr.clone()) {
                 None => {
-                    log::debug!("No pruning predicate for expr: {}", expr);
+                    log::debug!("No pruning predicate for expr: {expr}");
                     None
                 }
                 Some(pred) => {
-                    log::debug!("Constructed pruning predicate for expr: {}: {}", expr, pred);
+                    log::debug!("Constructed pruning predicate for expr: {expr}: {pred}");
                     Some(
                         self.stats_table()
                             .map(move |stats_table| {
@@ -170,7 +170,7 @@ impl LayoutReader for ZonedReader {
         let data_eval = self.data_child.pruning_evaluation(row_range, expr)?;
 
         let Some(pruning_mask_future) = self.pruning_mask_future(expr.clone()) else {
-            log::debug!("Stats pruning evaluation: not prune-able {}", expr);
+            log::debug!("Stats pruning evaluation: not prune-able {expr}");
             return Ok(data_eval);
         };
 

--- a/vortex-layout/src/segments/events.rs
+++ b/vortex-layout/src/segments/events.rs
@@ -56,9 +56,9 @@ impl Debug for SegmentEvent {
                 "SegmentEvent::Registered({:?}, {})",
                 req.id, req.for_whom
             ),
-            SegmentEvent::Polled(id) => write!(f, "SegmentEvent::Polled({:?})", id),
-            SegmentEvent::Dropped(id) => write!(f, "SegmentEvent::Dropped({:?})", id),
-            SegmentEvent::Resolved(id) => write!(f, "SegmentEvent::Resolved({:?})", id),
+            SegmentEvent::Polled(id) => write!(f, "SegmentEvent::Polled({id:?})"),
+            SegmentEvent::Dropped(id) => write!(f, "SegmentEvent::Dropped({id:?})"),
+            SegmentEvent::Resolved(id) => write!(f, "SegmentEvent::Resolved({id:?})"),
         }
     }
 }
@@ -105,7 +105,7 @@ impl SegmentEvents {
                     if let Some(fut) = e.get().future() {
                         return fut;
                     } else {
-                        log::debug!("Re-requesting dropped segment from segment reader {}", id);
+                        log::debug!("Re-requesting dropped segment from segment reader {id}");
                         e.remove();
                     }
                 }

--- a/vortex-mask/src/lib.rs
+++ b/vortex-mask/src/lib.rs
@@ -313,15 +313,11 @@ impl Mask {
         for (first, second) in vec.iter().tuple_windows() {
             assert!(
                 first.0 < second.0,
-                "Slices must be sorted, got {:?} and {:?}",
-                first,
-                second
+                "Slices must be sorted, got {first:?} and {second:?}"
             );
             assert!(
                 first.1 <= second.0,
-                "Slices must be non-overlapping, got {:?} and {:?}",
-                first,
-                second
+                "Slices must be non-overlapping, got {first:?} and {second:?}"
             );
         }
     }

--- a/vortex-scalar/src/bool.rs
+++ b/vortex-scalar/src/bool.rs
@@ -17,7 +17,7 @@ impl Display for BoolScalar<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self.value {
             None => write!(f, "null"),
-            Some(v) => write!(f, "{}", v),
+            Some(v) => write!(f, "{v}"),
         }
     }
 }

--- a/vortex-scalar/src/decimal.rs
+++ b/vortex-scalar/src/decimal.rs
@@ -63,12 +63,12 @@ impl NativeDecimalType for i256 {
 impl Display for DecimalValue {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            DecimalValue::I8(v8) => write!(f, "decimal8({})", v8),
-            DecimalValue::I16(v16) => write!(f, "decimal16({})", v16),
-            DecimalValue::I32(v32) => write!(f, "decimal32({})", v32),
-            DecimalValue::I64(v32) => write!(f, "decimal64({})", v32),
-            DecimalValue::I128(v128) => write!(f, "decimal128({})", v128),
-            DecimalValue::I256(v256) => write!(f, "decimal256({})", v256),
+            DecimalValue::I8(v8) => write!(f, "decimal8({v8})"),
+            DecimalValue::I16(v16) => write!(f, "decimal16({v16})"),
+            DecimalValue::I32(v32) => write!(f, "decimal32({v32})"),
+            DecimalValue::I64(v32) => write!(f, "decimal64({v32})"),
+            DecimalValue::I128(v128) => write!(f, "decimal128({v128})"),
+            DecimalValue::I256(v256) => write!(f, "decimal256({v256})"),
         }
     }
 }

--- a/vortex-scalar/src/extension.rs
+++ b/vortex-scalar/src/extension.rs
@@ -31,7 +31,7 @@ impl Display for ExtScalar<'_> {
 
             match maybe_timestamp {
                 None => write!(f, "null"),
-                Some(v) => write!(f, "{}", v),
+                Some(v) => write!(f, "{v}"),
             }
         } else {
             write!(f, "{}({})", self.ext_dtype().id(), self.storage())

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -89,8 +89,7 @@ impl Scalar {
     pub fn null(dtype: DType) -> Self {
         assert!(
             dtype.is_nullable(),
-            "Creating null scalar for non-nullable DType {}",
-            dtype
+            "Creating null scalar for non-nullable DType {dtype}"
         );
         Self {
             dtype,
@@ -566,8 +565,7 @@ mod test {
                     .to_string()
                     .contains("Can't cast u16 scalar 1000u16 to u8 (cause: Cannot read primitive value U16(1000) as u8")
             }),
-            "{:?}",
-            result
+            "{result:?}"
         );
     }
 }

--- a/vortex-scalar/src/primitive.rs
+++ b/vortex-scalar/src/primitive.rs
@@ -24,7 +24,7 @@ impl Display for PrimitiveScalar<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self.pvalue {
             None => write!(f, "null"),
-            Some(pv) => write!(f, "{}", pv),
+            Some(pv) => write!(f, "{pv}"),
         }
     }
 }

--- a/vortex-scalar/src/scalar_value/mod.rs
+++ b/vortex-scalar/src/scalar_value/mod.rs
@@ -63,7 +63,7 @@ impl ScalarValue {
 fn to_hex(slice: &[u8]) -> String {
     slice
         .iter()
-        .format_with("", |f, b| b(&format_args!("{:02x}", f)))
+        .format_with("", |f, b| b(&format_args!("{f:02x}")))
         .to_string()
 }
 
@@ -76,9 +76,9 @@ impl Display for ScalarValue {
 impl Display for InnerScalarValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Bool(b) => write!(f, "{}", b),
-            Self::Primitive(pvalue) => write!(f, "{}", pvalue),
-            Self::Decimal(value) => write!(f, "{}", value),
+            Self::Bool(b) => write!(f, "{b}"),
+            Self::Primitive(pvalue) => write!(f, "{pvalue}"),
+            Self::Decimal(value) => write!(f, "{value}"),
             Self::Buffer(buf) => {
                 if buf.len() > 10 {
                     write!(
@@ -101,7 +101,7 @@ impl Display for InnerScalarValue {
 
                     write!(f, "\"{prefix}..{suffix}\"")
                 } else {
-                    write!(f, "\"{}\"", bufstr)
+                    write!(f, "\"{bufstr}\"")
                 }
             }
             Self::List(elems) => {

--- a/vortex-scalar/src/struct_.rs
+++ b/vortex-scalar/src/struct_.rs
@@ -32,7 +32,7 @@ impl Display for StructScalar<'_> {
                         format!("{name}: {val}")
                     })
                     .format(", ");
-                write!(f, "{}", formatted_fields)?;
+                write!(f, "{formatted_fields}")?;
                 write!(f, "}}")
             }
         }

--- a/vortex-tui/src/browse/ui/layouts.rs
+++ b/vortex-tui/src/browse/ui/layouts.rs
@@ -50,7 +50,7 @@ fn render_layout_header(cursor: &LayoutCursor, area: Rect, buf: &mut Buffer) {
             .bold()
             .green(),
         Text::from(format!("Children: {}", cursor.layout().nchildren())).bold(),
-        Text::from(format!("Segment data size: {}", size)).bold(),
+        Text::from(format!("Segment data size: {size}")).bold(),
     ];
 
     if cursor.layout().is::<FlatVTable>() {


### PR DESCRIPTION
While I was debugging an unrelated issue I tried compiling our repo
with latest nightly and it found some new style issues that should be addressed.

I quite like that it calls out unnecessary transmute if safe versions exist

Signed-off-by: Robert Kruszewski <github@robertk.io>
