### PR TITLE
Change concurrency group

### DIFF
--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 120
     # S3 is shared state here, and we want to make sure only one of each job runs at a time
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref_name }}-${{matrix.id}}
+      group: ${{ github.workflow }}-${{ github.ref_name }}-${{ matrix.id }}-${{ inputs.mode }}
       cancel-in-progress: false
     strategy:
       fail-fast: false


### PR DESCRIPTION
I think this will fix our hanging benchmarks. Any change would be sufficient, but adding mode seems sensible.