### PR TITLE
feat: add a evaluation context to expression and an aux expression that uses it

### DIFF
--- a/vortex-datafusion/src/memory/plans.rs
+++ b/vortex-datafusion/src/memory/plans.rs
@@ -25,7 +25,7 @@ use vortex_array::compute::take;
 use vortex_array::{Array, ArrayRef, ToCanonical};
 use vortex_dtype::{FieldName, FieldNames};
 use vortex_error::{VortexError, vortex_err, vortex_panic};
-use vortex_expr::{EvalCtx, ExprRef, VortexExprExt};
+use vortex_expr::{EvaluationContext, ExprRef, VortexExprExt};
 
 /// Physical plan operator that applies a set of [filters][Expr] against the input, producing a
 /// row mask that can be used downstream to force a take against the corresponding struct array
@@ -158,7 +158,7 @@ impl Stream for RowIndicesStream {
         let selection = to_arrow(
             &this
                 .conjunction_expr
-                .evaluate(&EvalCtx::new_ident(vortex_struct.to_array()))
+                .evaluate(&EvaluationContext::new_ident(vortex_struct.to_array()))
                 .map_err(|e| DataFusionError::External(e.into()))?,
             &DataType::Boolean,
         )?;

--- a/vortex-datafusion/src/memory/plans.rs
+++ b/vortex-datafusion/src/memory/plans.rs
@@ -25,7 +25,7 @@ use vortex_array::compute::take;
 use vortex_array::{Array, ArrayRef, ToCanonical};
 use vortex_dtype::{FieldName, FieldNames};
 use vortex_error::{VortexError, vortex_err, vortex_panic};
-use vortex_expr::{EvaluationContext, ExprRef, VortexExprExt};
+use vortex_expr::{ExprRef, VortexExprExt};
 
 /// Physical plan operator that applies a set of [filters][Expr] against the input, producing a
 /// row mask that can be used downstream to force a take against the corresponding struct array
@@ -158,7 +158,7 @@ impl Stream for RowIndicesStream {
         let selection = to_arrow(
             &this
                 .conjunction_expr
-                .evaluate(&EvaluationContext::new_ident(vortex_struct.to_array()))
+                .evaluate_array(vortex_struct.as_ref())
                 .map_err(|e| DataFusionError::External(e.into()))?,
             &DataType::Boolean,
         )?;

--- a/vortex-datafusion/src/memory/plans.rs
+++ b/vortex-datafusion/src/memory/plans.rs
@@ -25,7 +25,7 @@ use vortex_array::compute::take;
 use vortex_array::{Array, ArrayRef, ToCanonical};
 use vortex_dtype::{FieldName, FieldNames};
 use vortex_error::{VortexError, vortex_err, vortex_panic};
-use vortex_expr::{ExprRef, VortexExprExt};
+use vortex_expr::{EvalCtx, ExprRef, VortexExprExt};
 
 /// Physical plan operator that applies a set of [filters][Expr] against the input, producing a
 /// row mask that can be used downstream to force a take against the corresponding struct array
@@ -158,7 +158,7 @@ impl Stream for RowIndicesStream {
         let selection = to_arrow(
             &this
                 .conjunction_expr
-                .evaluate(vortex_struct.as_ref())
+                .evaluate(&EvalCtx::new_ident(vortex_struct.to_array()))
                 .map_err(|e| DataFusionError::External(e.into()))?,
             &DataType::Boolean,
         )?;

--- a/vortex-expr/src/aux.rs
+++ b/vortex-expr/src/aux.rs
@@ -93,14 +93,14 @@ mod tests {
     use vortex_array::ToCanonical;
     use vortex_array::arrays::PrimitiveArray;
 
-    use crate::{EvalCtx, aux, ident};
+    use crate::{EvaluationContext, aux, ident};
 
     #[test]
     fn test_aux_and_arr() {
         let aux_array = PrimitiveArray::from_iter(0i32..10).to_array();
         let arr = PrimitiveArray::from_iter(10i32..20).to_array();
 
-        let ctx = EvalCtx::new(arr, aux_array).unwrap();
+        let ctx = EvaluationContext::new(arr, aux_array).unwrap();
 
         let value = ident().evaluate(&ctx).unwrap();
         let value = value.to_primitive().unwrap();

--- a/vortex-expr/src/aux.rs
+++ b/vortex-expr/src/aux.rs
@@ -9,7 +9,7 @@ use vortex_error::VortexResult;
 use crate::{ExprRef, VortexExpr};
 
 static AUX: LazyLock<ExprRef> = LazyLock::new(|| Arc::new(Aux));
-static AUX_ID: &'static str = "aux";
+pub static AUX_ID: &'static str = "aux";
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Aux;
@@ -85,4 +85,29 @@ impl VortexExpr for Aux {
 
 pub fn aux() -> ExprRef {
     Aux::new_expr()
+}
+
+#[cfg(test)]
+mod tests {
+    use itertools::Itertools;
+    use vortex_array::ToCanonical;
+    use vortex_array::arrays::PrimitiveArray;
+
+    use crate::{EvalCtx, aux, ident};
+
+    #[test]
+    fn test_aux_and_arr() {
+        let aux_array = PrimitiveArray::from_iter(0i32..10).to_array();
+        let arr = PrimitiveArray::from_iter(10i32..20).to_array();
+
+        let ctx = EvalCtx::new(arr, aux_array).unwrap();
+
+        let value = ident().evaluate(&ctx).unwrap();
+        let value = value.to_primitive().unwrap();
+        assert_eq!(value.as_slice::<i32>(), (10..20).collect_vec().as_slice());
+
+        let row_id = aux().evaluate(&ctx).unwrap();
+        let row_id = row_id.to_primitive().unwrap();
+        assert_eq!(row_id.as_slice::<i32>(), (0..10).collect_vec().as_slice());
+    }
 }

--- a/vortex-expr/src/aux.rs
+++ b/vortex-expr/src/aux.rs
@@ -2,14 +2,14 @@ use std::any::Any;
 use std::fmt::Display;
 use std::sync::{Arc, LazyLock};
 
-use vortex_array::{Array, ArrayRef, ToCanonical};
+use vortex_array::{Array, ArrayRef};
 use vortex_dtype::DType;
-use vortex_error::VortexResult;
+use vortex_error::{VortexResult, vortex_err};
 
-use crate::{ExprRef, VortexExpr};
+use crate::{EvaluationContext, ExprRef, VortexExpr};
 
 static AUX: LazyLock<ExprRef> = LazyLock::new(|| Arc::new(Aux));
-pub static AUX_ID: &'static str = "aux";
+pub static AUX_ID: &'static str = "#aux";
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Aux;
@@ -65,8 +65,17 @@ impl VortexExpr for Aux {
         self
     }
 
-    fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        batch.to_struct()?.field_by_name("#").cloned()
+    fn unchecked_evaluate(
+        &self,
+        _array: &dyn Array,
+        ctx: &EvaluationContext,
+    ) -> VortexResult<ArrayRef> {
+        ctx.ctx
+            .get(AUX_ID)
+            .ok_or_else(|| vortex_err!("missing aux"))?
+            .downcast_ref::<ArrayRef>()
+            .ok_or_else(|| vortex_err!("aux not array"))
+            .cloned()
     }
 
     fn children(&self) -> Vec<&ExprRef> {
@@ -89,24 +98,31 @@ pub fn aux() -> ExprRef {
 
 #[cfg(test)]
 mod tests {
-    use itertools::Itertools;
-    use vortex_array::ToCanonical;
-    use vortex_array::arrays::PrimitiveArray;
+    use std::any::Any;
+    use std::sync::Arc;
 
-    use crate::{EvaluationContext, aux, ident};
+    use itertools::Itertools;
+    use vortex_array::aliases::hash_map::HashMap;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::{IntoArray, ToCanonical};
+
+    use crate::{AUX_ID, EvaluationContext, aux, ident};
 
     #[test]
     fn test_aux_and_arr() {
-        let aux_array = PrimitiveArray::from_iter(0i32..10).to_array();
+        let aux_array = PrimitiveArray::from_iter(0i32..10).into_array();
         let arr = PrimitiveArray::from_iter(10i32..20).to_array();
 
-        let ctx = EvaluationContext::new(arr, aux_array).unwrap();
+        let ctx = EvaluationContext::new(HashMap::from_iter([(
+            Arc::from(AUX_ID),
+            Arc::new(aux_array) as Arc<dyn Any>,
+        )]));
 
-        let value = ident().evaluate(&ctx).unwrap();
+        let value = ident().evaluate(&arr, &ctx).unwrap();
         let value = value.to_primitive().unwrap();
         assert_eq!(value.as_slice::<i32>(), (10..20).collect_vec().as_slice());
 
-        let row_id = aux().evaluate(&ctx).unwrap();
+        let row_id = aux().evaluate(&arr, &ctx).unwrap();
         let row_id = row_id.to_primitive().unwrap();
         assert_eq!(row_id.as_slice::<i32>(), (0..10).collect_vec().as_slice());
     }

--- a/vortex-expr/src/aux.rs
+++ b/vortex-expr/src/aux.rs
@@ -9,7 +9,7 @@ use vortex_error::{VortexResult, vortex_err};
 use crate::{EvaluationContext, ExprRef, VortexExpr};
 
 static AUX: LazyLock<ExprRef> = LazyLock::new(|| Arc::new(Aux));
-pub static AUX_ID: &'static str = "#aux";
+pub static AUX_ID: &str = "#aux";
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Aux;

--- a/vortex-expr/src/aux.rs
+++ b/vortex-expr/src/aux.rs
@@ -1,0 +1,88 @@
+use std::any::Any;
+use std::fmt::Display;
+use std::sync::{Arc, LazyLock};
+
+use vortex_array::{Array, ArrayRef, ToCanonical};
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+
+use crate::{ExprRef, VortexExpr};
+
+static AUX: LazyLock<ExprRef> = LazyLock::new(|| Arc::new(Aux));
+static AUX_ID: &'static str = "aux";
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct Aux;
+
+impl Aux {
+    pub fn new_expr() -> ExprRef {
+        AUX.clone()
+    }
+}
+
+#[cfg(feature = "proto")]
+pub(crate) mod proto {
+    use vortex_error::VortexResult;
+    use vortex_proto::expr::kind;
+    use vortex_proto::expr::kind::Kind;
+
+    use crate::aux::{AUX, AUX_ID, Aux};
+    use crate::{ExprDeserialize, ExprRef, ExprSerializable, Id};
+
+    pub(crate) struct AuxSerde;
+
+    impl Id for AuxSerde {
+        fn id(&self) -> &'static str {
+            AUX_ID
+        }
+    }
+
+    impl ExprDeserialize for AuxSerde {
+        fn deserialize(&self, _expr: &Kind, _children: Vec<ExprRef>) -> VortexResult<ExprRef> {
+            Ok(AUX.clone())
+        }
+    }
+
+    impl ExprSerializable for Aux {
+        fn id(&self) -> &'static str {
+            AuxSerde.id()
+        }
+
+        fn serialize_kind(&self) -> VortexResult<Kind> {
+            Ok(Kind::Identity(kind::Identity {}))
+        }
+    }
+}
+
+impl Display for Aux {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "_$")
+    }
+}
+
+impl VortexExpr for Aux {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
+        batch.to_struct()?.field_by_name("#").cloned()
+    }
+
+    fn children(&self) -> Vec<&ExprRef> {
+        vec![]
+    }
+
+    fn replacing_children(self: Arc<Self>, children: Vec<ExprRef>) -> ExprRef {
+        assert_eq!(children.len(), 0);
+        self
+    }
+
+    fn return_dtype(&self, scope_dtype: &DType) -> VortexResult<DType> {
+        Ok(scope_dtype.clone())
+    }
+}
+
+pub fn aux() -> ExprRef {
+    Aux::new_expr()
+}

--- a/vortex-expr/src/between.rs
+++ b/vortex-expr/src/between.rs
@@ -8,7 +8,7 @@ use vortex_dtype::DType;
 use vortex_dtype::DType::Bool;
 use vortex_error::VortexResult;
 
-use crate::{BinaryExpr, ExprRef, VortexExpr};
+use crate::{BinaryExpr, EvaluationContext, ExprRef, VortexExpr};
 
 #[derive(Debug, Eq, Hash)]
 #[allow(clippy::derived_hash_with_manual_eq)]
@@ -135,10 +135,14 @@ impl VortexExpr for Between {
         self
     }
 
-    fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let arr_val = self.arr.unchecked_evaluate(batch)?;
-        let lower_arr_val = self.lower.unchecked_evaluate(batch)?;
-        let upper_arr_val = self.upper.unchecked_evaluate(batch)?;
+    fn unchecked_evaluate(
+        &self,
+        batch: &dyn Array,
+        ctx: &EvaluationContext,
+    ) -> VortexResult<ArrayRef> {
+        let arr_val = self.arr.unchecked_evaluate(batch, ctx)?;
+        let lower_arr_val = self.lower.unchecked_evaluate(batch, ctx)?;
+        let upper_arr_val = self.upper.unchecked_evaluate(batch, ctx)?;
 
         between(&arr_val, &lower_arr_val, &upper_arr_val, &self.options)
     }

--- a/vortex-expr/src/between.rs
+++ b/vortex-expr/src/between.rs
@@ -136,9 +136,9 @@ impl VortexExpr for Between {
     }
 
     fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let arr_val = self.arr.evaluate(batch)?;
-        let lower_arr_val = self.lower.evaluate(batch)?;
-        let upper_arr_val = self.upper.evaluate(batch)?;
+        let arr_val = self.arr.unchecked_evaluate(batch)?;
+        let lower_arr_val = self.lower.unchecked_evaluate(batch)?;
+        let upper_arr_val = self.upper.unchecked_evaluate(batch)?;
 
         between(&arr_val, &lower_arr_val, &upper_arr_val, &self.options)
     }

--- a/vortex-expr/src/binary.rs
+++ b/vortex-expr/src/binary.rs
@@ -141,7 +141,7 @@ impl PartialEq for BinaryExpr {
 /// use vortex_expr::{eq, ident, lit};
 ///
 /// let xs = PrimitiveArray::new(buffer![1i32, 2i32, 3i32], Validity::NonNullable);
-/// let result = eq(ident(), lit(3)).evaluate(xs.as_ref()).unwrap();
+/// let result = eq(ident(), lit(3)).evaluate_array(xs.as_ref()).unwrap();
 ///
 /// assert_eq!(
 ///     result.to_bool().unwrap().boolean_buffer(),
@@ -298,7 +298,7 @@ pub fn or(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
 /// use vortex_expr::{and, ident, lit, EvaluationContext};
 ///
 /// let xs = BoolArray::from_iter(vec![true, false, true]);
-/// let result = and(ident(), lit(true)).evaluate_array(&xs).unwrap();
+/// let result = and(ident(), lit(true)).evaluate_array(xs.as_ref()).unwrap();
 ///
 /// assert_eq!(
 ///     result.to_bool().unwrap().boolean_buffer(),

--- a/vortex-expr/src/binary.rs
+++ b/vortex-expr/src/binary.rs
@@ -164,7 +164,7 @@ pub fn eq(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
 /// use vortex_expr::{ident, lit, not_eq};
 ///
 /// let xs = PrimitiveArray::new(buffer![1i32, 2i32, 3i32], Validity::NonNullable);
-/// let result = not_eq(ident(), lit(3)).evaluate(xs.as_ref()).unwrap();
+/// let result = not_eq(ident(), lit(3)).evaluate_array(xs.as_ref()).unwrap();
 ///
 /// assert_eq!(
 ///     result.to_bool().unwrap().boolean_buffer(),
@@ -187,7 +187,7 @@ pub fn not_eq(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
 /// use vortex_expr::{gt_eq, ident, lit};
 ///
 /// let xs = PrimitiveArray::new(buffer![1i32, 2i32, 3i32], Validity::NonNullable);
-/// let result = gt_eq(ident(), lit(3)).evaluate(xs.as_ref()).unwrap();
+/// let result = gt_eq(ident(), lit(3)).evaluate_array(xs.as_ref()).unwrap();
 ///
 /// assert_eq!(
 ///     result.to_bool().unwrap().boolean_buffer(),
@@ -210,7 +210,7 @@ pub fn gt_eq(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
 /// use vortex_expr::{gt, ident, lit};
 ///
 /// let xs = PrimitiveArray::new(buffer![1i32, 2i32, 3i32], Validity::NonNullable);
-/// let result = gt(ident(), lit(2)).evaluate(xs.as_ref()).unwrap();
+/// let result = gt(ident(), lit(2)).evaluate_array(xs.as_ref()).unwrap();
 ///
 /// assert_eq!(
 ///     result.to_bool().unwrap().boolean_buffer(),
@@ -233,7 +233,7 @@ pub fn gt(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
 /// use vortex_expr::{ident, lit, lt_eq};
 ///
 /// let xs = PrimitiveArray::new(buffer![1i32, 2i32, 3i32], Validity::NonNullable);
-/// let result = lt_eq(ident(), lit(2)).evaluate(xs.as_ref()).unwrap();
+/// let result = lt_eq(ident(), lit(2)).evaluate_array(xs.as_ref()).unwrap();
 ///
 /// assert_eq!(
 ///     result.to_bool().unwrap().boolean_buffer(),
@@ -256,7 +256,7 @@ pub fn lt_eq(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
 /// use vortex_expr::{ident, lit, lt};
 ///
 /// let xs = PrimitiveArray::new(buffer![1i32, 2i32, 3i32], Validity::NonNullable);
-/// let result = lt(ident(), lit(3)).evaluate(xs.as_ref()).unwrap();
+/// let result = lt(ident(), lit(3)).evaluate_array(xs.as_ref()).unwrap();
 ///
 /// assert_eq!(
 ///     result.to_bool().unwrap().boolean_buffer(),
@@ -277,7 +277,7 @@ pub fn lt(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
 /// use vortex_expr::{ ident, lit, or};
 ///
 /// let xs = BoolArray::from_iter(vec![true, false, true]);
-/// let result = or(ident(), lit(false)).evaluate(xs.as_ref()).unwrap();
+/// let result = or(ident(), lit(false)).evaluate_array(xs.as_ref()).unwrap();
 ///
 /// assert_eq!(
 ///     result.to_bool().unwrap().boolean_buffer(),
@@ -298,7 +298,7 @@ pub fn or(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
 /// use vortex_expr::{and, ident, lit, EvaluationContext};
 ///
 /// let xs = BoolArray::from_iter(vec![true, false, true]);
-/// let result = and(ident(), lit(true)).evaluate(&EvaluationContext::new_ident(xs.to_array())).unwrap();
+/// let result = and(ident(), lit(true)).evaluate_array(&xs).unwrap();
 ///
 /// assert_eq!(
 ///     result.to_bool().unwrap().boolean_buffer(),

--- a/vortex-expr/src/binary.rs
+++ b/vortex-expr/src/binary.rs
@@ -88,8 +88,8 @@ impl VortexExpr for BinaryExpr {
     }
 
     fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let lhs = self.lhs.evaluate(batch)?;
-        let rhs = self.rhs.evaluate(batch)?;
+        let lhs = self.lhs.unchecked_evaluate(batch)?;
+        let rhs = self.rhs.unchecked_evaluate(batch)?;
 
         match self.operator {
             Operator::Eq => compare(&lhs, &rhs, ArrayOperator::Eq),
@@ -291,10 +291,10 @@ pub fn or(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
 /// ```
 /// use vortex_array::arrays::BoolArray;
 /// use vortex_array::{IntoArray, ToCanonical};
-/// use vortex_expr::{and, ident, lit};
+/// use vortex_expr::{and, ident, lit, EvalCtx};
 ///
 /// let xs = BoolArray::from_iter(vec![true, false, true]);
-/// let result = and(ident(), lit(true)).evaluate(xs.as_ref()).unwrap();
+/// let result = and(ident(), lit(true)).evaluate(&EvalCtx::new_ident(xs.to_array())).unwrap();
 ///
 /// assert_eq!(
 ///     result.to_bool().unwrap().boolean_buffer(),

--- a/vortex-expr/src/binary.rs
+++ b/vortex-expr/src/binary.rs
@@ -8,7 +8,7 @@ use vortex_array::{Array, ArrayRef};
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 
-use crate::{ExprRef, Operator, VortexExpr};
+use crate::{EvaluationContext, ExprRef, Operator, VortexExpr};
 
 #[derive(Debug, Clone, Eq, Hash)]
 #[allow(clippy::derived_hash_with_manual_eq)]
@@ -87,9 +87,13 @@ impl VortexExpr for BinaryExpr {
         self
     }
 
-    fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let lhs = self.lhs.unchecked_evaluate(batch)?;
-        let rhs = self.rhs.unchecked_evaluate(batch)?;
+    fn unchecked_evaluate(
+        &self,
+        batch: &dyn Array,
+        ctx: &EvaluationContext,
+    ) -> VortexResult<ArrayRef> {
+        let lhs = self.lhs.unchecked_evaluate(batch, ctx)?;
+        let rhs = self.rhs.unchecked_evaluate(batch, ctx)?;
 
         match self.operator {
             Operator::Eq => compare(&lhs, &rhs, ArrayOperator::Eq),

--- a/vortex-expr/src/binary.rs
+++ b/vortex-expr/src/binary.rs
@@ -291,10 +291,10 @@ pub fn or(lhs: ExprRef, rhs: ExprRef) -> ExprRef {
 /// ```
 /// use vortex_array::arrays::BoolArray;
 /// use vortex_array::{IntoArray, ToCanonical};
-/// use vortex_expr::{and, ident, lit, EvalCtx};
+/// use vortex_expr::{and, ident, lit, EvaluationContext};
 ///
 /// let xs = BoolArray::from_iter(vec![true, false, true]);
-/// let result = and(ident(), lit(true)).evaluate(&EvalCtx::new_ident(xs.to_array())).unwrap();
+/// let result = and(ident(), lit(true)).evaluate(&EvaluationContext::new_ident(xs.to_array())).unwrap();
 ///
 /// assert_eq!(
 ///     result.to_bool().unwrap().boolean_buffer(),

--- a/vortex-expr/src/get_item.rs
+++ b/vortex-expr/src/get_item.rs
@@ -7,7 +7,7 @@ use vortex_array::{Array, ArrayRef, ToCanonical};
 use vortex_dtype::{DType, FieldName};
 use vortex_error::{VortexResult, vortex_err};
 
-use crate::{ExprRef, VortexExpr, ident};
+use crate::{EvaluationContext, ExprRef, VortexExpr, ident};
 
 #[derive(Debug, Clone, Eq, Hash)]
 #[allow(clippy::derived_hash_with_manual_eq)]
@@ -99,9 +99,13 @@ impl VortexExpr for GetItem {
         self
     }
 
-    fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
+    fn unchecked_evaluate(
+        &self,
+        batch: &dyn Array,
+        ctx: &EvaluationContext,
+    ) -> VortexResult<ArrayRef> {
         self.child
-            .unchecked_evaluate(batch)?
+            .unchecked_evaluate(batch, ctx)?
             .to_struct()?
             .field_by_name(self.field())
             .cloned()
@@ -140,7 +144,7 @@ mod tests {
     use vortex_dtype::PType::I32;
 
     use crate::get_item::get_item;
-    use crate::{EvaluationContext, ident};
+    use crate::ident;
 
     fn test_array() -> StructArray {
         StructArray::from_fields(&[
@@ -154,9 +158,7 @@ mod tests {
     pub fn get_item_by_name() {
         let st = test_array();
         let get_item = get_item("a", ident());
-        let item = get_item
-            .evaluate(&EvaluationContext::new_ident(st.to_array()))
-            .unwrap();
+        let item = get_item.evaluate_array(st.as_ref()).unwrap();
         assert_eq!(item.dtype(), &DType::from(I32))
     }
 
@@ -164,10 +166,6 @@ mod tests {
     pub fn get_item_by_name_none() {
         let st = test_array();
         let get_item = get_item("c", ident());
-        assert!(
-            get_item
-                .evaluate(&EvaluationContext::new_ident(st.to_array()))
-                .is_err()
-        );
+        assert!(get_item.evaluate_array(st.as_ref()).is_err());
     }
 }

--- a/vortex-expr/src/get_item.rs
+++ b/vortex-expr/src/get_item.rs
@@ -140,7 +140,7 @@ mod tests {
     use vortex_dtype::PType::I32;
 
     use crate::get_item::get_item;
-    use crate::{EvalCtx, ident};
+    use crate::{EvaluationContext, ident};
 
     fn test_array() -> StructArray {
         StructArray::from_fields(&[
@@ -155,7 +155,7 @@ mod tests {
         let st = test_array();
         let get_item = get_item("a", ident());
         let item = get_item
-            .evaluate(&EvalCtx::new_ident(st.to_array()))
+            .evaluate(&EvaluationContext::new_ident(st.to_array()))
             .unwrap();
         assert_eq!(item.dtype(), &DType::from(I32))
     }
@@ -166,7 +166,7 @@ mod tests {
         let get_item = get_item("c", ident());
         assert!(
             get_item
-                .evaluate(&EvalCtx::new_ident(st.to_array()))
+                .evaluate(&EvaluationContext::new_ident(st.to_array()))
                 .is_err()
         );
     }

--- a/vortex-expr/src/get_item.rs
+++ b/vortex-expr/src/get_item.rs
@@ -101,7 +101,7 @@ impl VortexExpr for GetItem {
 
     fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
         self.child
-            .evaluate(batch)?
+            .unchecked_evaluate(batch)?
             .to_struct()?
             .field_by_name(self.field())
             .cloned()
@@ -140,7 +140,7 @@ mod tests {
     use vortex_dtype::PType::I32;
 
     use crate::get_item::get_item;
-    use crate::ident;
+    use crate::{EvalCtx, ident};
 
     fn test_array() -> StructArray {
         StructArray::from_fields(&[
@@ -154,7 +154,9 @@ mod tests {
     pub fn get_item_by_name() {
         let st = test_array();
         let get_item = get_item("a", ident());
-        let item = get_item.evaluate(st.as_ref()).unwrap();
+        let item = get_item
+            .evaluate(&EvalCtx::new_ident(st.to_array()))
+            .unwrap();
         assert_eq!(item.dtype(), &DType::from(I32))
     }
 
@@ -162,6 +164,10 @@ mod tests {
     pub fn get_item_by_name_none() {
         let st = test_array();
         let get_item = get_item("c", ident());
-        assert!(get_item.evaluate(st.as_ref()).is_err());
+        assert!(
+            get_item
+                .evaluate(&EvalCtx::new_ident(st.to_array()))
+                .is_err()
+        );
     }
 }

--- a/vortex-expr/src/identity.rs
+++ b/vortex-expr/src/identity.rs
@@ -2,11 +2,11 @@ use std::any::Any;
 use std::fmt::Display;
 use std::sync::{Arc, LazyLock};
 
-use vortex_array::{Array, ArrayRef, ToCanonical};
+use vortex_array::{Array, ArrayRef};
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 
-use crate::{ExprRef, VortexExpr};
+use crate::{EvaluationContext, ExprRef, VortexExpr};
 
 static IDENTITY: LazyLock<ExprRef> = LazyLock::new(|| Arc::new(Identity));
 
@@ -64,8 +64,12 @@ impl VortexExpr for Identity {
         self
     }
 
-    fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        batch.to_struct()?.field_by_name("$").cloned()
+    fn unchecked_evaluate(
+        &self,
+        batch: &dyn Array,
+        _ctx: &EvaluationContext,
+    ) -> VortexResult<ArrayRef> {
+        Ok(batch.to_array())
     }
 
     fn children(&self) -> Vec<&ExprRef> {

--- a/vortex-expr/src/identity.rs
+++ b/vortex-expr/src/identity.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::fmt::Display;
 use std::sync::{Arc, LazyLock};
 
-use vortex_array::{Array, ArrayRef};
+use vortex_array::{Array, ArrayRef, ToCanonical};
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 
@@ -65,7 +65,7 @@ impl VortexExpr for Identity {
     }
 
     fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        Ok(batch.to_array())
+        batch.to_struct()?.field_by_name("$").cloned()
     }
 
     fn children(&self) -> Vec<&ExprRef> {

--- a/vortex-expr/src/is_null.rs
+++ b/vortex-expr/src/is_null.rs
@@ -9,7 +9,7 @@ use vortex_dtype::{DType, Nullability};
 use vortex_error::{VortexExpect, VortexResult};
 use vortex_mask::Mask;
 
-use crate::{ExprRef, VortexExpr};
+use crate::{EvaluationContext, ExprRef, VortexExpr};
 
 #[derive(Debug, Eq, Hash)]
 #[allow(clippy::derived_hash_with_manual_eq)]
@@ -78,8 +78,12 @@ impl VortexExpr for IsNull {
         self
     }
 
-    fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let array = self.child.unchecked_evaluate(batch)?;
+    fn unchecked_evaluate(
+        &self,
+        batch: &dyn Array,
+        ctx: &EvaluationContext,
+    ) -> VortexResult<ArrayRef> {
+        let array = self.child.unchecked_evaluate(batch, ctx)?;
         match array.validity_mask()? {
             Mask::AllTrue(len) => Ok(ConstantArray::new(false, len).into_array()),
             Mask::AllFalse(len) => Ok(ConstantArray::new(true, len).into_array()),
@@ -116,7 +120,7 @@ mod tests {
     use vortex_scalar::Scalar;
 
     use crate::is_null::is_null;
-    use crate::{EvaluationContext, get_item, ident, test_harness};
+    use crate::{get_item, ident, test_harness};
 
     #[test]
     fn dtype() {
@@ -140,9 +144,7 @@ mod tests {
                 .into_array();
         let expected = [false, true, false, true, false];
 
-        let result = is_null(ident())
-            .evaluate(&EvaluationContext::new_ident(test_array.clone()))
-            .unwrap();
+        let result = is_null(ident()).evaluate_array(&test_array).unwrap();
 
         assert_eq!(result.len(), test_array.len());
         assert_eq!(result.dtype(), &DType::Bool(Nullability::NonNullable));
@@ -159,9 +161,7 @@ mod tests {
     fn evaluate_all_false() {
         let test_array = PrimitiveArray::from_iter(vec![1, 2, 3, 4, 5]).into_array();
 
-        let result = is_null(ident())
-            .evaluate(&EvaluationContext::new_ident(test_array.clone()))
-            .unwrap();
+        let result = is_null(ident()).evaluate_array(&test_array).unwrap();
 
         assert_eq!(result.len(), test_array.len());
         assert_eq!(
@@ -176,9 +176,7 @@ mod tests {
             PrimitiveArray::from_option_iter(vec![None::<i32>, None, None, None, None])
                 .into_array();
 
-        let result = is_null(ident())
-            .evaluate(&EvaluationContext::new_ident(test_array.clone()))
-            .unwrap();
+        let result = is_null(ident()).evaluate_array(&test_array).unwrap();
 
         assert_eq!(result.len(), test_array.len());
         assert_eq!(
@@ -199,7 +197,7 @@ mod tests {
         let expected = [false, true, false, true, false];
 
         let result = is_null(get_item("a", ident()))
-            .evaluate(&EvaluationContext::new_ident(test_array.clone()))
+            .evaluate_array(&test_array)
             .unwrap();
 
         assert_eq!(result.len(), test_array.len());

--- a/vortex-expr/src/is_null.rs
+++ b/vortex-expr/src/is_null.rs
@@ -116,7 +116,7 @@ mod tests {
     use vortex_scalar::Scalar;
 
     use crate::is_null::is_null;
-    use crate::{EvalCtx, get_item, ident, test_harness};
+    use crate::{EvaluationContext, get_item, ident, test_harness};
 
     #[test]
     fn dtype() {
@@ -141,7 +141,7 @@ mod tests {
         let expected = [false, true, false, true, false];
 
         let result = is_null(ident())
-            .evaluate(&EvalCtx::new_ident(test_array.clone()))
+            .evaluate(&EvaluationContext::new_ident(test_array.clone()))
             .unwrap();
 
         assert_eq!(result.len(), test_array.len());
@@ -160,7 +160,7 @@ mod tests {
         let test_array = PrimitiveArray::from_iter(vec![1, 2, 3, 4, 5]).into_array();
 
         let result = is_null(ident())
-            .evaluate(&EvalCtx::new_ident(test_array.clone()))
+            .evaluate(&EvaluationContext::new_ident(test_array.clone()))
             .unwrap();
 
         assert_eq!(result.len(), test_array.len());
@@ -177,7 +177,7 @@ mod tests {
                 .into_array();
 
         let result = is_null(ident())
-            .evaluate(&EvalCtx::new_ident(test_array.clone()))
+            .evaluate(&EvaluationContext::new_ident(test_array.clone()))
             .unwrap();
 
         assert_eq!(result.len(), test_array.len());
@@ -199,7 +199,7 @@ mod tests {
         let expected = [false, true, false, true, false];
 
         let result = is_null(get_item("a", ident()))
-            .evaluate(&EvalCtx::new_ident(test_array.clone()))
+            .evaluate(&EvaluationContext::new_ident(test_array.clone()))
             .unwrap();
 
         assert_eq!(result.len(), test_array.len());

--- a/vortex-expr/src/is_null.rs
+++ b/vortex-expr/src/is_null.rs
@@ -79,7 +79,7 @@ impl VortexExpr for IsNull {
     }
 
     fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let array = self.child.evaluate(batch)?;
+        let array = self.child.unchecked_evaluate(batch)?;
         match array.validity_mask()? {
             Mask::AllTrue(len) => Ok(ConstantArray::new(false, len).into_array()),
             Mask::AllFalse(len) => Ok(ConstantArray::new(true, len).into_array()),
@@ -116,7 +116,7 @@ mod tests {
     use vortex_scalar::Scalar;
 
     use crate::is_null::is_null;
-    use crate::{get_item, ident, test_harness};
+    use crate::{EvalCtx, get_item, ident, test_harness};
 
     #[test]
     fn dtype() {
@@ -140,7 +140,9 @@ mod tests {
                 .into_array();
         let expected = [false, true, false, true, false];
 
-        let result = is_null(ident()).unchecked_evaluate(&test_array).unwrap();
+        let result = is_null(ident())
+            .evaluate(&EvalCtx::new_ident(test_array.clone()))
+            .unwrap();
 
         assert_eq!(result.len(), test_array.len());
         assert_eq!(result.dtype(), &DType::Bool(Nullability::NonNullable));
@@ -157,7 +159,9 @@ mod tests {
     fn evaluate_all_false() {
         let test_array = PrimitiveArray::from_iter(vec![1, 2, 3, 4, 5]).into_array();
 
-        let result = is_null(ident()).unchecked_evaluate(&test_array).unwrap();
+        let result = is_null(ident())
+            .evaluate(&EvalCtx::new_ident(test_array.clone()))
+            .unwrap();
 
         assert_eq!(result.len(), test_array.len());
         assert_eq!(
@@ -172,7 +176,9 @@ mod tests {
             PrimitiveArray::from_option_iter(vec![None::<i32>, None, None, None, None])
                 .into_array();
 
-        let result = is_null(ident()).unchecked_evaluate(&test_array).unwrap();
+        let result = is_null(ident())
+            .evaluate(&EvalCtx::new_ident(test_array.clone()))
+            .unwrap();
 
         assert_eq!(result.len(), test_array.len());
         assert_eq!(
@@ -193,7 +199,7 @@ mod tests {
         let expected = [false, true, false, true, false];
 
         let result = is_null(get_item("a", ident()))
-            .unchecked_evaluate(&test_array)
+            .evaluate(&EvalCtx::new_ident(test_array.clone()))
             .unwrap();
 
         assert_eq!(result.len(), test_array.len());

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -97,17 +97,15 @@ pub trait VortexExpr: Debug + Send + Sync + DynEq + DynHash + Display + ExprSeri
     /// Compute result of expression on given batch producing a new batch
     ///
     fn evaluate(&self, array: &dyn Array, ctx: &EvaluationContext) -> VortexResult<ArrayRef> {
-        // let batch =
         let result = self.unchecked_evaluate(array, ctx)?;
-        // TODO(joe): enable
-        // debug_assert_eq!(
-        //     result.dtype(),
-        //     &self.return_dtype(batch.dtype())?,
-        //     "Expression {} returned dtype {} but declared return_dtype of {}",
-        //     self,
-        //     result.dtype(),
-        //     self.return_dtype(batch.dtype())?,
-        // );
+        assert_eq!(
+            result.dtype(),
+            &self.return_dtype(array.dtype())?,
+            "Expression {} returned dtype {} but declared return_dtype of {}",
+            self,
+            result.dtype(),
+            self.return_dtype(array.dtype())?,
+        );
         Ok(result)
     }
 

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -6,6 +6,7 @@ use dyn_hash::DynHash;
 
 mod binary;
 
+mod aux;
 mod between;
 pub mod datafusion;
 mod field;
@@ -26,6 +27,7 @@ mod select;
 pub mod transform;
 pub mod traversal;
 
+pub use aux::*;
 pub use between::*;
 pub use binary::*;
 pub use get_item::*;

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -78,19 +78,19 @@ pub trait ExprSerializable {}
 #[cfg(not(feature = "proto"))]
 impl<T> ExprSerializable for T {}
 
-pub struct EvalCtx {
+pub struct EvaluationContext {
     struct_array: StructArray,
 }
 
-impl EvalCtx {
-    pub fn new(ident: ArrayRef, aux: ArrayRef) -> VortexResult<EvalCtx> {
-        Ok(EvalCtx {
+impl EvaluationContext {
+    pub fn new(ident: ArrayRef, aux: ArrayRef) -> VortexResult<EvaluationContext> {
+        Ok(EvaluationContext {
             struct_array: StructArray::from_fields(&[("$", ident), ("#", aux)])?,
         })
     }
 
-    pub fn new_ident(ident: ArrayRef) -> EvalCtx {
-        EvalCtx {
+    pub fn new_ident(ident: ArrayRef) -> EvaluationContext {
+        EvaluationContext {
             struct_array: StructArray::from_fields(&[("$", ident)]).unwrap(),
         }
     }
@@ -107,7 +107,7 @@ pub trait VortexExpr: Debug + Send + Sync + DynEq + DynHash + Display + ExprSeri
 
     /// Compute result of expression on given batch producing a new batch
     ///
-    fn evaluate(&self, eval_ctx: &EvalCtx) -> VortexResult<ArrayRef> {
+    fn evaluate(&self, eval_ctx: &EvaluationContext) -> VortexResult<ArrayRef> {
         // let batch =
         let result = self.unchecked_evaluate(eval_ctx.struct_array.as_ref())?;
         // TODO(joe): enable

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -43,6 +43,7 @@ pub use pack::*;
 pub use registry::deserialize_expr;
 pub use select::*;
 use vortex_array::aliases::hash_set::HashSet;
+use vortex_array::arrays::StructArray;
 use vortex_array::{Array, ArrayRef};
 use vortex_dtype::{DType, FieldName};
 use vortex_error::{VortexResult, VortexUnwrap};
@@ -77,6 +78,28 @@ pub trait ExprSerializable {}
 #[cfg(not(feature = "proto"))]
 impl<T> ExprSerializable for T {}
 
+pub struct EvalCtx {
+    struct_array: StructArray,
+}
+
+impl EvalCtx {
+    pub fn new(ident: ArrayRef, aux: ArrayRef) -> VortexResult<EvalCtx> {
+        Ok(EvalCtx {
+            struct_array: StructArray::from_fields(&[("$", ident), ("#", aux)])?,
+        })
+    }
+
+    pub fn new_ident(ident: ArrayRef) -> EvalCtx {
+        EvalCtx {
+            struct_array: StructArray::from_fields(&[("$", ident)]).unwrap(),
+        }
+    }
+
+    pub fn ident(&self) -> ArrayRef {
+        self.struct_array.field_by_name("$").unwrap().clone()
+    }
+}
+
 /// Represents logical operation on [`ArrayRef`]s
 pub trait VortexExpr: Debug + Send + Sync + DynEq + DynHash + Display + ExprSerializable {
     /// Convert expression reference to reference of [`Any`] type
@@ -84,16 +107,18 @@ pub trait VortexExpr: Debug + Send + Sync + DynEq + DynHash + Display + ExprSeri
 
     /// Compute result of expression on given batch producing a new batch
     ///
-    fn evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let result = self.unchecked_evaluate(batch)?;
-        assert_eq!(
-            result.dtype(),
-            &self.return_dtype(batch.dtype())?,
-            "Expression {} returned dtype {} but declared return_dtype of {}",
-            self,
-            result.dtype(),
-            self.return_dtype(batch.dtype())?,
-        );
+    fn evaluate(&self, eval_ctx: &EvalCtx) -> VortexResult<ArrayRef> {
+        // let batch =
+        let result = self.unchecked_evaluate(eval_ctx.struct_array.as_ref())?;
+        // TODO(joe): enable
+        // debug_assert_eq!(
+        //     result.dtype(),
+        //     &self.return_dtype(batch.dtype())?,
+        //     "Expression {} returned dtype {} but declared return_dtype of {}",
+        //     self,
+        //     result.dtype(),
+        //     self.return_dtype(batch.dtype())?,
+        // );
         Ok(result)
     }
 

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -42,8 +42,8 @@ pub use pack::*;
 #[cfg(feature = "proto")]
 pub use registry::deserialize_expr;
 pub use select::*;
+use vortex_array::aliases::hash_map::HashMap;
 use vortex_array::aliases::hash_set::HashSet;
-use vortex_array::arrays::StructArray;
 use vortex_array::{Array, ArrayRef};
 use vortex_dtype::{DType, FieldName};
 use vortex_error::{VortexResult, VortexUnwrap};
@@ -78,25 +78,14 @@ pub trait ExprSerializable {}
 #[cfg(not(feature = "proto"))]
 impl<T> ExprSerializable for T {}
 
+#[derive(Clone, Default)]
 pub struct EvaluationContext {
-    struct_array: StructArray,
+    ctx: HashMap<Arc<str>, Arc<dyn Any>>,
 }
 
 impl EvaluationContext {
-    pub fn new(ident: ArrayRef, aux: ArrayRef) -> VortexResult<EvaluationContext> {
-        Ok(EvaluationContext {
-            struct_array: StructArray::from_fields(&[("$", ident), ("#", aux)])?,
-        })
-    }
-
-    pub fn new_ident(ident: ArrayRef) -> EvaluationContext {
-        EvaluationContext {
-            struct_array: StructArray::from_fields(&[("$", ident)]).unwrap(),
-        }
-    }
-
-    pub fn ident(&self) -> ArrayRef {
-        self.struct_array.field_by_name("$").unwrap().clone()
+    pub fn new(ctx: HashMap<Arc<str>, Arc<dyn Any>>) -> Self {
+        Self { ctx }
     }
 }
 
@@ -107,9 +96,9 @@ pub trait VortexExpr: Debug + Send + Sync + DynEq + DynHash + Display + ExprSeri
 
     /// Compute result of expression on given batch producing a new batch
     ///
-    fn evaluate(&self, eval_ctx: &EvaluationContext) -> VortexResult<ArrayRef> {
+    fn evaluate(&self, array: &dyn Array, ctx: &EvaluationContext) -> VortexResult<ArrayRef> {
         // let batch =
-        let result = self.unchecked_evaluate(eval_ctx.struct_array.as_ref())?;
+        let result = self.unchecked_evaluate(array, ctx)?;
         // TODO(joe): enable
         // debug_assert_eq!(
         //     result.dtype(),
@@ -122,12 +111,20 @@ pub trait VortexExpr: Debug + Send + Sync + DynEq + DynHash + Display + ExprSeri
         Ok(result)
     }
 
+    fn evaluate_array(&self, array: &dyn Array) -> VortexResult<ArrayRef> {
+        self.evaluate(array, &EvaluationContext::default())
+    }
+
     /// Compute result of expression on given batch producing a new batch
     ///
     /// "Unchecked" means that this function lacks a debug assertion that the returned array matches
     /// the [VortexExpr::return_dtype] method. Use instead the [VortexExpr::evaluate] function which
     /// includes such an assertion.
-    fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef>;
+    fn unchecked_evaluate(
+        &self,
+        array: &dyn Array,
+        ctx: &EvaluationContext,
+    ) -> VortexResult<ArrayRef>;
 
     fn children(&self) -> Vec<&ExprRef>;
 

--- a/vortex-expr/src/like.rs
+++ b/vortex-expr/src/like.rs
@@ -8,7 +8,7 @@ use vortex_array::{Array, ArrayRef};
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 
-use crate::{ExprRef, VortexExpr};
+use crate::{EvaluationContext, ExprRef, VortexExpr};
 
 #[derive(Debug, Eq, Hash)]
 #[allow(clippy::derived_hash_with_manual_eq)]
@@ -107,9 +107,13 @@ impl VortexExpr for Like {
         self
     }
 
-    fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let child = self.child().unchecked_evaluate(batch)?;
-        let pattern = self.pattern().unchecked_evaluate(&child)?;
+    fn unchecked_evaluate(
+        &self,
+        batch: &dyn Array,
+        ctx: &EvaluationContext,
+    ) -> VortexResult<ArrayRef> {
+        let child = self.child().unchecked_evaluate(batch, ctx)?;
+        let pattern = self.pattern().unchecked_evaluate(&child, ctx)?;
         like(
             &child,
             &pattern,
@@ -158,7 +162,7 @@ mod tests {
     use vortex_array::arrays::BoolArray;
     use vortex_dtype::{DType, Nullability};
 
-    use crate::{EvaluationContext, Like, ident, lit, not};
+    use crate::{Like, ident, lit, not};
 
     #[test]
     fn invert_booleans() {
@@ -166,7 +170,7 @@ mod tests {
         let bools = BoolArray::from_iter([false, true, false, false, true, true]);
         assert_eq!(
             not_expr
-                .evaluate(&EvaluationContext::new_ident(bools.to_array()))
+                .evaluate_array(bools.as_ref())
                 .unwrap()
                 .to_bool()
                 .unwrap()

--- a/vortex-expr/src/like.rs
+++ b/vortex-expr/src/like.rs
@@ -108,8 +108,8 @@ impl VortexExpr for Like {
     }
 
     fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let child = self.child().evaluate(batch)?;
-        let pattern = self.pattern().evaluate(&child)?;
+        let child = self.child().unchecked_evaluate(batch)?;
+        let pattern = self.pattern().unchecked_evaluate(&child)?;
         like(
             &child,
             &pattern,
@@ -158,7 +158,7 @@ mod tests {
     use vortex_array::arrays::BoolArray;
     use vortex_dtype::{DType, Nullability};
 
-    use crate::{Like, ident, lit, not};
+    use crate::{EvalCtx, Like, ident, lit, not};
 
     #[test]
     fn invert_booleans() {
@@ -166,7 +166,7 @@ mod tests {
         let bools = BoolArray::from_iter([false, true, false, false, true, true]);
         assert_eq!(
             not_expr
-                .evaluate(bools.as_ref())
+                .evaluate(&EvalCtx::new_ident(bools.to_array()))
                 .unwrap()
                 .to_bool()
                 .unwrap()

--- a/vortex-expr/src/like.rs
+++ b/vortex-expr/src/like.rs
@@ -158,7 +158,7 @@ mod tests {
     use vortex_array::arrays::BoolArray;
     use vortex_dtype::{DType, Nullability};
 
-    use crate::{EvalCtx, Like, ident, lit, not};
+    use crate::{EvaluationContext, Like, ident, lit, not};
 
     #[test]
     fn invert_booleans() {
@@ -166,7 +166,7 @@ mod tests {
         let bools = BoolArray::from_iter([false, true, false, false, true, true]);
         assert_eq!(
             not_expr
-                .evaluate(&EvalCtx::new_ident(bools.to_array()))
+                .evaluate(&EvaluationContext::new_ident(bools.to_array()))
                 .unwrap()
                 .to_bool()
                 .unwrap()

--- a/vortex-expr/src/literal.rs
+++ b/vortex-expr/src/literal.rs
@@ -8,7 +8,7 @@ use vortex_dtype::DType;
 use vortex_error::VortexResult;
 use vortex_scalar::Scalar;
 
-use crate::{ExprRef, VortexExpr};
+use crate::{EvaluationContext, ExprRef, VortexExpr};
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Literal {
@@ -86,7 +86,11 @@ impl VortexExpr for Literal {
         self
     }
 
-    fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
+    fn unchecked_evaluate(
+        &self,
+        batch: &dyn Array,
+        _ctx: &EvaluationContext,
+    ) -> VortexResult<ArrayRef> {
         Ok(ConstantArray::new(self.value.clone(), batch.len()).into_array())
     }
 

--- a/vortex-expr/src/merge.rs
+++ b/vortex-expr/src/merge.rs
@@ -188,7 +188,7 @@ mod tests {
     use vortex_dtype::Nullability;
     use vortex_error::{VortexResult, vortex_bail};
 
-    use crate::{EvalCtx, GetItem, Identity, Merge, VortexExpr};
+    use crate::{EvaluationContext, GetItem, Identity, Merge, VortexExpr};
 
     fn primitive_field(array: &dyn Array, field_path: &[&str]) -> VortexResult<PrimitiveArray> {
         let mut field_path = field_path.iter();
@@ -246,7 +246,9 @@ mod tests {
         ])
         .unwrap()
         .into_array();
-        let actual_array = expr.evaluate(&EvalCtx::new_ident(test_array)).unwrap();
+        let actual_array = expr
+            .evaluate(&EvaluationContext::new_ident(test_array))
+            .unwrap();
 
         assert_eq!(
             actual_array.as_struct_typed().names(),
@@ -293,7 +295,7 @@ mod tests {
             .unwrap()
             .into_array();
         let actual_array = expr
-            .evaluate(&EvalCtx::new_ident(test_array.clone()))
+            .evaluate(&EvaluationContext::new_ident(test_array.clone()))
             .unwrap();
         assert_eq!(actual_array.len(), test_array.len());
         assert_eq!(actual_array.as_struct_typed().nfields(), 0);
@@ -341,7 +343,7 @@ mod tests {
         .unwrap()
         .into_array();
         let actual_array = expr
-            .evaluate(&EvalCtx::new_ident(test_array))
+            .evaluate(&EvaluationContext::new_ident(test_array))
             .unwrap()
             .to_struct()
             .unwrap();
@@ -393,7 +395,7 @@ mod tests {
         .unwrap()
         .into_array();
         let actual_array = expr
-            .evaluate(&EvalCtx::new_ident(test_array))
+            .evaluate(&EvaluationContext::new_ident(test_array))
             .unwrap()
             .to_struct()
             .unwrap();
@@ -422,7 +424,9 @@ mod tests {
         )])
         .unwrap()
         .into_array();
-        let actual_array = expr.evaluate(&EvalCtx::new_ident(test_array)).unwrap();
+        let actual_array = expr
+            .evaluate(&EvaluationContext::new_ident(test_array))
+            .unwrap();
         assert!(actual_array.dtype().is_nullable());
     }
 }

--- a/vortex-expr/src/merge.rs
+++ b/vortex-expr/src/merge.rs
@@ -10,7 +10,7 @@ use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
 use vortex_dtype::{DType, FieldNames, Nullability, StructDType};
 use vortex_error::{VortexExpect as _, VortexResult, vortex_bail};
 
-use crate::{ExprRef, VortexExpr};
+use crate::{EvaluationContext, ExprRef, VortexExpr};
 
 /// Merge zero or more expressions that ALL return structs.
 ///
@@ -93,12 +93,16 @@ impl VortexExpr for Merge {
         self
     }
 
-    fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
+    fn unchecked_evaluate(
+        &self,
+        batch: &dyn Array,
+        ctx: &EvaluationContext,
+    ) -> VortexResult<ArrayRef> {
         let len = batch.len();
         let value_arrays = self
             .values
             .iter()
-            .map(|value_expr| value_expr.unchecked_evaluate(batch))
+            .map(|value_expr| value_expr.unchecked_evaluate(batch, ctx))
             .process_results(|it| it.collect::<Vec<_>>())?;
 
         // Collect fields in order of appearance. Later fields overwrite earlier fields.
@@ -188,7 +192,7 @@ mod tests {
     use vortex_dtype::Nullability;
     use vortex_error::{VortexResult, vortex_bail};
 
-    use crate::{EvaluationContext, GetItem, Identity, Merge, VortexExpr};
+    use crate::{GetItem, Identity, Merge, VortexExpr};
 
     fn primitive_field(array: &dyn Array, field_path: &[&str]) -> VortexResult<PrimitiveArray> {
         let mut field_path = field_path.iter();
@@ -246,9 +250,7 @@ mod tests {
         ])
         .unwrap()
         .into_array();
-        let actual_array = expr
-            .evaluate(&EvaluationContext::new_ident(test_array))
-            .unwrap();
+        let actual_array = expr.evaluate_array(&test_array).unwrap();
 
         assert_eq!(
             actual_array.as_struct_typed().names(),
@@ -294,9 +296,7 @@ mod tests {
         let test_array = StructArray::from_fields(&[("a", buffer![0, 1, 2].into_array())])
             .unwrap()
             .into_array();
-        let actual_array = expr
-            .evaluate(&EvaluationContext::new_ident(test_array.clone()))
-            .unwrap();
+        let actual_array = expr.evaluate_array(&test_array).unwrap();
         assert_eq!(actual_array.len(), test_array.len());
         assert_eq!(actual_array.as_struct_typed().nfields(), 0);
     }
@@ -343,7 +343,7 @@ mod tests {
         .unwrap()
         .into_array();
         let actual_array = expr
-            .evaluate(&EvaluationContext::new_ident(test_array))
+            .evaluate_array(&test_array)
             .unwrap()
             .to_struct()
             .unwrap();
@@ -395,7 +395,7 @@ mod tests {
         .unwrap()
         .into_array();
         let actual_array = expr
-            .evaluate(&EvaluationContext::new_ident(test_array))
+            .evaluate_array(&test_array)
             .unwrap()
             .to_struct()
             .unwrap();
@@ -424,9 +424,7 @@ mod tests {
         )])
         .unwrap()
         .into_array();
-        let actual_array = expr
-            .evaluate(&EvaluationContext::new_ident(test_array))
-            .unwrap();
+        let actual_array = expr.evaluate_array(&test_array).unwrap();
         assert!(actual_array.dtype().is_nullable());
     }
 }

--- a/vortex-expr/src/merge.rs
+++ b/vortex-expr/src/merge.rs
@@ -98,7 +98,7 @@ impl VortexExpr for Merge {
         let value_arrays = self
             .values
             .iter()
-            .map(|value_expr| value_expr.evaluate(batch))
+            .map(|value_expr| value_expr.unchecked_evaluate(batch))
             .process_results(|it| it.collect::<Vec<_>>())?;
 
         // Collect fields in order of appearance. Later fields overwrite earlier fields.
@@ -188,7 +188,7 @@ mod tests {
     use vortex_dtype::Nullability;
     use vortex_error::{VortexResult, vortex_bail};
 
-    use crate::{GetItem, Identity, Merge, VortexExpr};
+    use crate::{EvalCtx, GetItem, Identity, Merge, VortexExpr};
 
     fn primitive_field(array: &dyn Array, field_path: &[&str]) -> VortexResult<PrimitiveArray> {
         let mut field_path = field_path.iter();
@@ -246,7 +246,7 @@ mod tests {
         ])
         .unwrap()
         .into_array();
-        let actual_array = expr.evaluate(test_array.as_ref()).unwrap();
+        let actual_array = expr.evaluate(&EvalCtx::new_ident(test_array)).unwrap();
 
         assert_eq!(
             actual_array.as_struct_typed().names(),
@@ -292,7 +292,9 @@ mod tests {
         let test_array = StructArray::from_fields(&[("a", buffer![0, 1, 2].into_array())])
             .unwrap()
             .into_array();
-        let actual_array = expr.evaluate(&test_array).unwrap();
+        let actual_array = expr
+            .evaluate(&EvalCtx::new_ident(test_array.clone()))
+            .unwrap();
         assert_eq!(actual_array.len(), test_array.len());
         assert_eq!(actual_array.as_struct_typed().nfields(), 0);
     }
@@ -339,7 +341,7 @@ mod tests {
         .unwrap()
         .into_array();
         let actual_array = expr
-            .evaluate(test_array.as_ref())
+            .evaluate(&EvalCtx::new_ident(test_array))
             .unwrap()
             .to_struct()
             .unwrap();
@@ -391,7 +393,7 @@ mod tests {
         .unwrap()
         .into_array();
         let actual_array = expr
-            .evaluate(test_array.as_ref())
+            .evaluate(&EvalCtx::new_ident(test_array))
             .unwrap()
             .to_struct()
             .unwrap();
@@ -420,7 +422,7 @@ mod tests {
         )])
         .unwrap()
         .into_array();
-        let actual_array = expr.evaluate(test_array.as_ref()).unwrap();
+        let actual_array = expr.evaluate(&EvalCtx::new_ident(test_array)).unwrap();
         assert!(actual_array.dtype().is_nullable());
     }
 }

--- a/vortex-expr/src/not.rs
+++ b/vortex-expr/src/not.rs
@@ -108,7 +108,7 @@ mod tests {
     use vortex_array::arrays::BoolArray;
     use vortex_dtype::{DType, Nullability};
 
-    use crate::{EvalCtx, col, ident, not, test_harness};
+    use crate::{EvaluationContext, col, ident, not, test_harness};
 
     #[test]
     fn invert_booleans() {
@@ -116,7 +116,7 @@ mod tests {
         let bools = BoolArray::from_iter([false, true, false, false, true, true]);
         assert_eq!(
             not_expr
-                .evaluate(&EvalCtx::new_ident(bools.to_array()))
+                .evaluate(&EvaluationContext::new_ident(bools.to_array()))
                 .unwrap()
                 .to_bool()
                 .unwrap()

--- a/vortex-expr/src/not.rs
+++ b/vortex-expr/src/not.rs
@@ -74,7 +74,7 @@ impl VortexExpr for Not {
     }
 
     fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let child_result = self.child.evaluate(batch)?;
+        let child_result = self.child.unchecked_evaluate(batch)?;
         invert(&child_result)
     }
 
@@ -108,7 +108,7 @@ mod tests {
     use vortex_array::arrays::BoolArray;
     use vortex_dtype::{DType, Nullability};
 
-    use crate::{col, ident, not, test_harness};
+    use crate::{EvalCtx, col, ident, not, test_harness};
 
     #[test]
     fn invert_booleans() {
@@ -116,7 +116,7 @@ mod tests {
         let bools = BoolArray::from_iter([false, true, false, false, true, true]);
         assert_eq!(
             not_expr
-                .evaluate(bools.as_ref())
+                .evaluate(&EvalCtx::new_ident(bools.to_array()))
                 .unwrap()
                 .to_bool()
                 .unwrap()

--- a/vortex-expr/src/not.rs
+++ b/vortex-expr/src/not.rs
@@ -8,7 +8,7 @@ use vortex_array::{Array, ArrayRef};
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 
-use crate::{ExprRef, VortexExpr};
+use crate::{EvaluationContext, ExprRef, VortexExpr};
 
 #[derive(Debug, Eq, Hash)]
 // We cannot auto derive PartialEq because ExprRef, since its a Arc<..> and derive doesn't work
@@ -73,8 +73,12 @@ impl VortexExpr for Not {
         self
     }
 
-    fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let child_result = self.child.unchecked_evaluate(batch)?;
+    fn unchecked_evaluate(
+        &self,
+        batch: &dyn Array,
+        ctx: &EvaluationContext,
+    ) -> VortexResult<ArrayRef> {
+        let child_result = self.child.unchecked_evaluate(batch, ctx)?;
         invert(&child_result)
     }
 
@@ -108,7 +112,7 @@ mod tests {
     use vortex_array::arrays::BoolArray;
     use vortex_dtype::{DType, Nullability};
 
-    use crate::{EvaluationContext, col, ident, not, test_harness};
+    use crate::{col, ident, not, test_harness};
 
     #[test]
     fn invert_booleans() {
@@ -116,7 +120,7 @@ mod tests {
         let bools = BoolArray::from_iter([false, true, false, false, true, true]);
         assert_eq!(
             not_expr
-                .evaluate(&EvaluationContext::new_ident(bools.to_array()))
+                .evaluate_array(bools.as_ref())
                 .unwrap()
                 .to_bool()
                 .unwrap()

--- a/vortex-expr/src/pack.rs
+++ b/vortex-expr/src/pack.rs
@@ -10,7 +10,7 @@ use vortex_array::{Array, ArrayRef, IntoArray};
 use vortex_dtype::{DType, FieldName, FieldNames, Nullability, StructDType};
 use vortex_error::{VortexExpect as _, VortexResult, vortex_bail, vortex_err};
 
-use crate::{ExprRef, VortexExpr};
+use crate::{EvaluationContext, ExprRef, VortexExpr};
 
 /// Pack zero or more expressions into a structure with named fields.
 ///
@@ -148,12 +148,16 @@ impl VortexExpr for Pack {
         self
     }
 
-    fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
+    fn unchecked_evaluate(
+        &self,
+        batch: &dyn Array,
+        ctx: &EvaluationContext,
+    ) -> VortexResult<ArrayRef> {
         let len = batch.len();
         let value_arrays = self
             .values
             .iter()
-            .map(|value_expr| value_expr.unchecked_evaluate(batch))
+            .map(|value_expr| value_expr.unchecked_evaluate(batch, ctx))
             .process_results(|it| it.collect::<Vec<_>>())?;
         let validity = match self.nullability {
             Nullability::NonNullable => Validity::NonNullable,
@@ -197,7 +201,7 @@ mod tests {
     use vortex_dtype::{FieldNames, Nullability};
     use vortex_error::{VortexResult, vortex_bail};
 
-    use crate::{EvaluationContext, Pack, VortexExpr, col};
+    use crate::{Pack, VortexExpr, col};
 
     fn test_array() -> ArrayRef {
         StructArray::from_fields(&[
@@ -227,9 +231,7 @@ mod tests {
         let expr = Pack::try_new_expr(Arc::new([]), Vec::new(), Nullability::NonNullable).unwrap();
 
         let test_array = test_array();
-        let actual_array = expr
-            .evaluate(&EvaluationContext::new_ident(test_array.clone()))
-            .unwrap();
+        let actual_array = expr.evaluate_array(&test_array).unwrap();
         assert_eq!(actual_array.len(), test_array.len());
         assert_eq!(
             actual_array.to_struct().unwrap().struct_dtype().nfields(),
@@ -247,7 +249,7 @@ mod tests {
         .unwrap();
 
         let actual_array = expr
-            .evaluate(&EvaluationContext::new_ident(test_array()))
+            .evaluate_array(test_array().as_ref())
             .unwrap()
             .to_struct()
             .unwrap();
@@ -294,7 +296,7 @@ mod tests {
         .unwrap();
 
         let actual_array = expr
-            .evaluate(&EvaluationContext::new_ident(test_array()))
+            .evaluate_array(&test_array())
             .unwrap()
             .to_struct()
             .unwrap();
@@ -337,7 +339,7 @@ mod tests {
         .unwrap();
 
         let actual_array = expr
-            .evaluate(&EvaluationContext::new_ident(test_array()))
+            .evaluate_array(&test_array())
             .unwrap()
             .to_struct()
             .unwrap();

--- a/vortex-expr/src/pack.rs
+++ b/vortex-expr/src/pack.rs
@@ -28,7 +28,7 @@ use crate::{EvaluationContext, ExprRef, VortexExpr};
 ///     vec![Identity::new_expr(), Identity::new_expr(), Identity::new_expr()],
 ///     Nullability::NonNullable,
 /// ).unwrap();
-/// let packed = example.evaluate(&EvalCtx::new_ident(buffer![100, 110, 200].into_array())).unwrap();
+/// let packed = example.evaluate_array(&buffer![100, 110, 200].into_array()).unwrap();
 /// let x_copy = packed
 ///     .to_struct()
 ///     .unwrap()

--- a/vortex-expr/src/pack.rs
+++ b/vortex-expr/src/pack.rs
@@ -28,7 +28,7 @@ use crate::{ExprRef, VortexExpr};
 ///     vec![Identity::new_expr(), Identity::new_expr(), Identity::new_expr()],
 ///     Nullability::NonNullable,
 /// ).unwrap();
-/// let packed = example.evaluate(&buffer![100, 110, 200].into_array()).unwrap();
+/// let packed = example.evaluate(&EvalCtx::new_ident(buffer![100, 110, 200].into_array())).unwrap();
 /// let x_copy = packed
 ///     .to_struct()
 ///     .unwrap()
@@ -153,7 +153,7 @@ impl VortexExpr for Pack {
         let value_arrays = self
             .values
             .iter()
-            .map(|value_expr| value_expr.evaluate(batch))
+            .map(|value_expr| value_expr.unchecked_evaluate(batch))
             .process_results(|it| it.collect::<Vec<_>>())?;
         let validity = match self.nullability {
             Nullability::NonNullable => Validity::NonNullable,
@@ -192,19 +192,20 @@ mod tests {
     use vortex_array::arrays::{PrimitiveArray, StructArray};
     use vortex_array::validity::Validity;
     use vortex_array::vtable::ValidityHelper;
-    use vortex_array::{Array, IntoArray, ToCanonical};
+    use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
     use vortex_buffer::buffer;
     use vortex_dtype::{FieldNames, Nullability};
     use vortex_error::{VortexResult, vortex_bail};
 
-    use crate::{Pack, VortexExpr, col};
+    use crate::{EvalCtx, Pack, VortexExpr, col};
 
-    fn test_array() -> StructArray {
+    fn test_array() -> ArrayRef {
         StructArray::from_fields(&[
             ("a", buffer![0, 1, 2].into_array()),
             ("b", buffer![4, 5, 6].into_array()),
         ])
         .unwrap()
+        .into_array()
     }
 
     fn primitive_field(array: &dyn Array, field_path: &[&str]) -> VortexResult<PrimitiveArray> {
@@ -225,8 +226,10 @@ mod tests {
     pub fn test_empty_pack() {
         let expr = Pack::try_new_expr(Arc::new([]), Vec::new(), Nullability::NonNullable).unwrap();
 
-        let test_array = test_array().into_array();
-        let actual_array = expr.evaluate(&test_array).unwrap();
+        let test_array = test_array();
+        let actual_array = expr
+            .evaluate(&EvalCtx::new_ident(test_array.clone()))
+            .unwrap();
         assert_eq!(actual_array.len(), test_array.len());
         assert_eq!(
             actual_array.to_struct().unwrap().struct_dtype().nfields(),
@@ -244,7 +247,7 @@ mod tests {
         .unwrap();
 
         let actual_array = expr
-            .evaluate(test_array().as_ref())
+            .evaluate(&EvalCtx::new_ident(test_array()))
             .unwrap()
             .to_struct()
             .unwrap();
@@ -291,7 +294,7 @@ mod tests {
         .unwrap();
 
         let actual_array = expr
-            .evaluate(test_array().as_ref())
+            .evaluate(&EvalCtx::new_ident(test_array()))
             .unwrap()
             .to_struct()
             .unwrap();
@@ -334,7 +337,7 @@ mod tests {
         .unwrap();
 
         let actual_array = expr
-            .evaluate(test_array().as_ref())
+            .evaluate(&EvalCtx::new_ident(test_array()))
             .unwrap()
             .to_struct()
             .unwrap();

--- a/vortex-expr/src/pack.rs
+++ b/vortex-expr/src/pack.rs
@@ -197,7 +197,7 @@ mod tests {
     use vortex_dtype::{FieldNames, Nullability};
     use vortex_error::{VortexResult, vortex_bail};
 
-    use crate::{EvalCtx, Pack, VortexExpr, col};
+    use crate::{EvaluationContext, Pack, VortexExpr, col};
 
     fn test_array() -> ArrayRef {
         StructArray::from_fields(&[
@@ -228,7 +228,7 @@ mod tests {
 
         let test_array = test_array();
         let actual_array = expr
-            .evaluate(&EvalCtx::new_ident(test_array.clone()))
+            .evaluate(&EvaluationContext::new_ident(test_array.clone()))
             .unwrap();
         assert_eq!(actual_array.len(), test_array.len());
         assert_eq!(
@@ -247,7 +247,7 @@ mod tests {
         .unwrap();
 
         let actual_array = expr
-            .evaluate(&EvalCtx::new_ident(test_array()))
+            .evaluate(&EvaluationContext::new_ident(test_array()))
             .unwrap()
             .to_struct()
             .unwrap();
@@ -294,7 +294,7 @@ mod tests {
         .unwrap();
 
         let actual_array = expr
-            .evaluate(&EvalCtx::new_ident(test_array()))
+            .evaluate(&EvaluationContext::new_ident(test_array()))
             .unwrap()
             .to_struct()
             .unwrap();
@@ -337,7 +337,7 @@ mod tests {
         .unwrap();
 
         let actual_array = expr
-            .evaluate(&EvalCtx::new_ident(test_array()))
+            .evaluate(&EvaluationContext::new_ident(test_array()))
             .unwrap()
             .to_struct()
             .unwrap();

--- a/vortex-expr/src/pruning.rs
+++ b/vortex-expr/src/pruning.rs
@@ -15,8 +15,8 @@ use vortex_scalar::Scalar;
 
 use crate::between::Between;
 use crate::{
-    BinaryExpr, ExprRef, GetItem, Identity, Literal, Not, Operator, VortexExprExt, and, eq,
-    get_item, gt, ident, lit, not, or,
+    BinaryExpr, EvalCtx, ExprRef, GetItem, Identity, Literal, Not, Operator, VortexExprExt, and,
+    eq, get_item, gt, ident, lit, not, or,
 };
 
 #[derive(Debug, Clone)]
@@ -152,7 +152,10 @@ impl PruningPredicate {
             return Ok(None);
         }
 
-        Ok(Some(self.expr.evaluate(metadata)?))
+        Ok(Some(
+            self.expr
+                .evaluate(&EvalCtx::new_ident(metadata.to_array()))?,
+        ))
     }
 }
 

--- a/vortex-expr/src/pruning.rs
+++ b/vortex-expr/src/pruning.rs
@@ -15,8 +15,8 @@ use vortex_scalar::Scalar;
 
 use crate::between::Between;
 use crate::{
-    BinaryExpr, EvalCtx, ExprRef, GetItem, Identity, Literal, Not, Operator, VortexExprExt, and,
-    eq, get_item, gt, ident, lit, not, or,
+    BinaryExpr, EvaluationContext, ExprRef, GetItem, Identity, Literal, Not, Operator,
+    VortexExprExt, and, eq, get_item, gt, ident, lit, not, or,
 };
 
 #[derive(Debug, Clone)]
@@ -152,10 +152,9 @@ impl PruningPredicate {
             return Ok(None);
         }
 
-        Ok(Some(
-            self.expr
-                .evaluate(&EvalCtx::new_ident(metadata.to_array()))?,
-        ))
+        Ok(Some(self.expr.evaluate(&EvaluationContext::new_ident(
+            metadata.to_array(),
+        ))?))
     }
 }
 

--- a/vortex-expr/src/pruning.rs
+++ b/vortex-expr/src/pruning.rs
@@ -131,7 +131,11 @@ impl PruningPredicate {
     /// Returns Ok(None) if any of the required statistics are not present in metadata.
     /// If it returns Ok(Some(array)), the array is a boolean array with the same length as the
     /// metadata, and a true value means the chunk _can_ be pruned.
-    pub fn evaluate(&self, metadata: &dyn Array) -> VortexResult<Option<ArrayRef>> {
+    pub fn evaluate(
+        &self,
+        metadata: &dyn Array,
+        ctx: &EvaluationContext,
+    ) -> VortexResult<Option<ArrayRef>> {
         let known_stats = HashSet::from_iter(
             metadata
                 .dtype()
@@ -152,9 +156,7 @@ impl PruningPredicate {
             return Ok(None);
         }
 
-        Ok(Some(self.expr.evaluate(&EvaluationContext::new_ident(
-            metadata.to_array(),
-        ))?))
+        Ok(Some(self.expr.evaluate(metadata, ctx)?))
     }
 }
 

--- a/vortex-expr/src/registry.rs
+++ b/vortex-expr/src/registry.rs
@@ -5,6 +5,7 @@ use vortex_array::aliases::hash_map::HashMap;
 use vortex_error::{VortexResult, vortex_err};
 use vortex_proto::expr;
 
+use crate::aux::proto::AuxSerde;
 use crate::between::proto::BetweenSerde;
 use crate::binary::proto::BinarySerde;
 use crate::get_item::proto::GetItemSerde;
@@ -18,6 +19,7 @@ use crate::select::proto::SelectSerde;
 use crate::{ExprDeserialize, ExprRef};
 
 const EXPRESSIONS: &[&'static dyn ExprDeserialize] = &[
+    &AuxSerde,
     &BetweenSerde,
     &BinarySerde,
     &GetItemSerde,

--- a/vortex-expr/src/select.rs
+++ b/vortex-expr/src/select.rs
@@ -158,7 +158,7 @@ impl VortexExpr for Select {
     }
 
     fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let batch = self.child.evaluate(batch)?.to_struct()?;
+        let batch = self.child.unchecked_evaluate(batch)?.to_struct()?;
         Ok(match &self.fields {
             SelectField::Include(f) => batch.project(f),
             SelectField::Exclude(names) => {
@@ -218,25 +218,30 @@ mod tests {
     use std::sync::Arc;
 
     use vortex_array::arrays::StructArray;
-    use vortex_array::{IntoArray, ToCanonical};
+    use vortex_array::{ArrayRef, IntoArray, ToCanonical};
     use vortex_buffer::buffer;
     use vortex_dtype::{DType, FieldName, Nullability};
 
-    use crate::{ident, select, select_exclude, test_harness};
+    use crate::{EvalCtx, ident, select, select_exclude, test_harness};
 
-    fn test_array() -> StructArray {
+    fn test_array() -> ArrayRef {
         StructArray::from_fields(&[
             ("a", buffer![0, 1, 2].into_array()),
             ("b", buffer![4, 5, 6].into_array()),
         ])
         .unwrap()
+        .into_array()
     }
 
     #[test]
     pub fn include_columns() {
         let st = test_array();
         let select = select(vec![FieldName::from("a")], ident());
-        let selected = select.evaluate(st.as_ref()).unwrap().to_struct().unwrap();
+        let selected = select
+            .evaluate(&EvalCtx::new_ident(st))
+            .unwrap()
+            .to_struct()
+            .unwrap();
         let selected_names = selected.names().clone();
         assert_eq!(selected_names.as_ref(), &["a".into()]);
     }
@@ -245,7 +250,11 @@ mod tests {
     pub fn exclude_columns() {
         let st = test_array();
         let select = select_exclude(vec![FieldName::from("a")], ident());
-        let selected = select.evaluate(st.as_ref()).unwrap().to_struct().unwrap();
+        let selected = select
+            .evaluate(&EvalCtx::new_ident(st))
+            .unwrap()
+            .to_struct()
+            .unwrap();
         let selected_names = selected.names().clone();
         assert_eq!(selected_names.as_ref(), &["b".into()]);
     }

--- a/vortex-expr/src/select.rs
+++ b/vortex-expr/src/select.rs
@@ -222,7 +222,7 @@ mod tests {
     use vortex_buffer::buffer;
     use vortex_dtype::{DType, FieldName, Nullability};
 
-    use crate::{EvalCtx, ident, select, select_exclude, test_harness};
+    use crate::{EvaluationContext, ident, select, select_exclude, test_harness};
 
     fn test_array() -> ArrayRef {
         StructArray::from_fields(&[
@@ -238,7 +238,7 @@ mod tests {
         let st = test_array();
         let select = select(vec![FieldName::from("a")], ident());
         let selected = select
-            .evaluate(&EvalCtx::new_ident(st))
+            .evaluate(&EvaluationContext::new_ident(st))
             .unwrap()
             .to_struct()
             .unwrap();
@@ -251,7 +251,7 @@ mod tests {
         let st = test_array();
         let select = select_exclude(vec![FieldName::from("a")], ident());
         let selected = select
-            .evaluate(&EvalCtx::new_ident(st))
+            .evaluate(&EvaluationContext::new_ident(st))
             .unwrap()
             .to_struct()
             .unwrap();

--- a/vortex-expr/src/select.rs
+++ b/vortex-expr/src/select.rs
@@ -8,7 +8,7 @@ use vortex_dtype::{DType, FieldNames};
 use vortex_error::{VortexResult, vortex_bail, vortex_err};
 
 use crate::field::DisplayFieldNames;
-use crate::{ExprRef, VortexExpr};
+use crate::{EvaluationContext, ExprRef, VortexExpr};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SelectField {
@@ -157,8 +157,12 @@ impl VortexExpr for Select {
         self
     }
 
-    fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let batch = self.child.unchecked_evaluate(batch)?.to_struct()?;
+    fn unchecked_evaluate(
+        &self,
+        batch: &dyn Array,
+        ctx: &EvaluationContext,
+    ) -> VortexResult<ArrayRef> {
+        let batch = self.child.unchecked_evaluate(batch, ctx)?.to_struct()?;
         Ok(match &self.fields {
             SelectField::Include(f) => batch.project(f),
             SelectField::Exclude(names) => {
@@ -218,19 +222,18 @@ mod tests {
     use std::sync::Arc;
 
     use vortex_array::arrays::StructArray;
-    use vortex_array::{ArrayRef, IntoArray, ToCanonical};
+    use vortex_array::{IntoArray, ToCanonical};
     use vortex_buffer::buffer;
     use vortex_dtype::{DType, FieldName, Nullability};
 
-    use crate::{EvaluationContext, ident, select, select_exclude, test_harness};
+    use crate::{ident, select, select_exclude, test_harness};
 
-    fn test_array() -> ArrayRef {
+    fn test_array() -> StructArray {
         StructArray::from_fields(&[
             ("a", buffer![0, 1, 2].into_array()),
             ("b", buffer![4, 5, 6].into_array()),
         ])
         .unwrap()
-        .into_array()
     }
 
     #[test]
@@ -238,7 +241,7 @@ mod tests {
         let st = test_array();
         let select = select(vec![FieldName::from("a")], ident());
         let selected = select
-            .evaluate(&EvaluationContext::new_ident(st))
+            .evaluate_array(st.as_ref())
             .unwrap()
             .to_struct()
             .unwrap();
@@ -251,7 +254,7 @@ mod tests {
         let st = test_array();
         let select = select_exclude(vec![FieldName::from("a")], ident());
         let selected = select
-            .evaluate(&EvaluationContext::new_ident(st))
+            .evaluate_array(st.as_ref())
             .unwrap()
             .to_struct()
             .unwrap();

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -8,8 +8,8 @@ use vortex_array::ArrayRef;
 use vortex_array::stats::StatsSet;
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
-use vortex_expr::ExprRef;
 use vortex_expr::pruning::PruningPredicate;
+use vortex_expr::{EvaluationContext, ExprRef};
 use vortex_layout::LayoutReader;
 use vortex_layout::scan::ScanBuilder;
 use vortex_layout::segments::SegmentSource;
@@ -105,7 +105,7 @@ impl VortexFile {
         };
 
         Ok(predicate
-            .evaluate(&struct_row)?
+            .evaluate(&struct_row, &EvaluationContext::default())?
             .and_then(|p| p.as_constant())
             .is_some_and(|result| result.as_bool().value() == Some(true)))
     }

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -12,7 +12,7 @@ use vortex_array::{Array, ArrayContext, ArrayRef, ToCanonical};
 use vortex_dict::DictArray;
 use vortex_dtype::{DType, FieldMask};
 use vortex_error::{VortexExpect, VortexResult};
-use vortex_expr::{EvalCtx, ExprRef, Identity};
+use vortex_expr::{EvaluationContext, ExprRef, Identity};
 use vortex_mask::Mask;
 
 use super::DictLayout;
@@ -94,7 +94,10 @@ impl DictReader {
             .entry(expr.clone())
             .or_insert_with(|| {
                 self.values_array()
-                    .map(move |array| expr.evaluate(&EvalCtx::new_ident(array?)).map_err(Arc::new))
+                    .map(move |array| {
+                        expr.evaluate(&EvaluationContext::new_ident(array?))
+                            .map_err(Arc::new)
+                    })
                     .boxed()
                     .shared()
             })

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -12,7 +12,7 @@ use vortex_array::{Array, ArrayContext, ArrayRef, ToCanonical};
 use vortex_dict::DictArray;
 use vortex_dtype::{DType, FieldMask};
 use vortex_error::{VortexExpect, VortexResult};
-use vortex_expr::{ExprRef, Identity};
+use vortex_expr::{EvalCtx, ExprRef, Identity};
 use vortex_mask::Mask;
 
 use super::DictLayout;
@@ -94,7 +94,7 @@ impl DictReader {
             .entry(expr.clone())
             .or_insert_with(|| {
                 self.values_array()
-                    .map(move |array| expr.evaluate(&array?).map_err(Arc::new))
+                    .map(move |array| expr.evaluate(&EvalCtx::new_ident(array?)).map_err(Arc::new))
                     .boxed()
                     .shared()
             })

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -12,7 +12,7 @@ use vortex_array::{Array, ArrayContext, ArrayRef, ToCanonical};
 use vortex_dict::DictArray;
 use vortex_dtype::{DType, FieldMask};
 use vortex_error::{VortexExpect, VortexResult};
-use vortex_expr::{EvaluationContext, ExprRef, Identity};
+use vortex_expr::{ExprRef, Identity};
 use vortex_mask::Mask;
 
 use super::DictLayout;
@@ -94,10 +94,7 @@ impl DictReader {
             .entry(expr.clone())
             .or_insert_with(|| {
                 self.values_array()
-                    .map(move |array| {
-                        expr.evaluate(&EvaluationContext::new_ident(array?))
-                            .map_err(Arc::new)
-                    })
+                    .map(move |array| expr.evaluate_array(&array?).map_err(Arc::new))
                     .boxed()
                     .shared()
             })

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -10,7 +10,7 @@ use vortex_array::stats::Precision;
 use vortex_array::{Array, ArrayContext, ArrayRef};
 use vortex_dtype::{DType, FieldMask};
 use vortex_error::{VortexExpect, VortexResult, VortexUnwrap as _};
-use vortex_expr::{ExprRef, Identity};
+use vortex_expr::{EvalCtx, ExprRef, Identity};
 use vortex_mask::Mask;
 
 use crate::layouts::SharedArrayFuture;
@@ -183,11 +183,12 @@ impl MaskEvaluation for FlatEvaluation {
         let array_mask = if mask.density() < EXPR_EVAL_THRESHOLD {
             // Evaluate only the selected rows of the mask.
             array = filter(&array, &mask)?;
-            let array_mask = Mask::try_from(self.expr.evaluate(&array)?.as_ref())?;
+            let array_mask =
+                Mask::try_from(self.expr.evaluate(&EvalCtx::new_ident(array))?.as_ref())?;
             mask.intersect_by_rank(&array_mask)
         } else {
             // Evaluate all rows, avoiding the more expensive rank intersection.
-            array = self.expr.evaluate(&array)?;
+            array = self.expr.evaluate(&EvalCtx::new_ident(array))?;
             let array_mask = Mask::try_from(array.as_ref())?;
             mask.bitand(&array_mask)
         };
@@ -229,7 +230,7 @@ impl ArrayEvaluation for FlatEvaluation {
 
         // Evaluate the projection expression.
         if !self.expr.as_any().is::<Identity>() {
-            array = self.expr.evaluate(&array)?;
+            array = self.expr.evaluate(&EvalCtx::new_ident(array))?;
         }
 
         Ok(array)

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -10,7 +10,7 @@ use vortex_array::stats::Precision;
 use vortex_array::{Array, ArrayContext, ArrayRef};
 use vortex_dtype::{DType, FieldMask};
 use vortex_error::{VortexExpect, VortexResult, VortexUnwrap as _};
-use vortex_expr::{EvalCtx, ExprRef, Identity};
+use vortex_expr::{EvaluationContext, ExprRef, Identity};
 use vortex_mask::Mask;
 
 use crate::layouts::SharedArrayFuture;
@@ -183,12 +183,15 @@ impl MaskEvaluation for FlatEvaluation {
         let array_mask = if mask.density() < EXPR_EVAL_THRESHOLD {
             // Evaluate only the selected rows of the mask.
             array = filter(&array, &mask)?;
-            let array_mask =
-                Mask::try_from(self.expr.evaluate(&EvalCtx::new_ident(array))?.as_ref())?;
+            let array_mask = Mask::try_from(
+                self.expr
+                    .evaluate(&EvaluationContext::new_ident(array))?
+                    .as_ref(),
+            )?;
             mask.intersect_by_rank(&array_mask)
         } else {
             // Evaluate all rows, avoiding the more expensive rank intersection.
-            array = self.expr.evaluate(&EvalCtx::new_ident(array))?;
+            array = self.expr.evaluate(&EvaluationContext::new_ident(array))?;
             let array_mask = Mask::try_from(array.as_ref())?;
             mask.bitand(&array_mask)
         };
@@ -230,7 +233,7 @@ impl ArrayEvaluation for FlatEvaluation {
 
         // Evaluate the projection expression.
         if !self.expr.as_any().is::<Identity>() {
-            array = self.expr.evaluate(&EvalCtx::new_ident(array))?;
+            array = self.expr.evaluate(&EvaluationContext::new_ident(array))?;
         }
 
         Ok(array)

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -10,7 +10,7 @@ use vortex_array::stats::Precision;
 use vortex_array::{Array, ArrayContext, ArrayRef};
 use vortex_dtype::{DType, FieldMask};
 use vortex_error::{VortexExpect, VortexResult, VortexUnwrap as _};
-use vortex_expr::{EvaluationContext, ExprRef, Identity};
+use vortex_expr::{ExprRef, Identity};
 use vortex_mask::Mask;
 
 use crate::layouts::SharedArrayFuture;
@@ -183,15 +183,11 @@ impl MaskEvaluation for FlatEvaluation {
         let array_mask = if mask.density() < EXPR_EVAL_THRESHOLD {
             // Evaluate only the selected rows of the mask.
             array = filter(&array, &mask)?;
-            let array_mask = Mask::try_from(
-                self.expr
-                    .evaluate(&EvaluationContext::new_ident(array))?
-                    .as_ref(),
-            )?;
+            let array_mask = Mask::try_from(self.expr.evaluate_array(&array)?.as_ref())?;
             mask.intersect_by_rank(&array_mask)
         } else {
             // Evaluate all rows, avoiding the more expensive rank intersection.
-            array = self.expr.evaluate(&EvaluationContext::new_ident(array))?;
+            array = self.expr.evaluate_array(&array)?;
             let array_mask = Mask::try_from(array.as_ref())?;
             mask.bitand(&array_mask)
         };
@@ -233,7 +229,7 @@ impl ArrayEvaluation for FlatEvaluation {
 
         // Evaluate the projection expression.
         if !self.expr.as_any().is::<Identity>() {
-            array = self.expr.evaluate(&EvaluationContext::new_ident(array))?;
+            array = self.expr.evaluate_array(&array)?;
         }
 
         Ok(array)

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -12,11 +12,11 @@ use vortex_array::aliases::hash_map::HashMap;
 use vortex_array::arrays::StructArray;
 use vortex_array::stats::Precision;
 use vortex_array::validity::Validity;
-use vortex_array::{ArrayContext, ArrayRef, IntoArray};
+use vortex_array::{Array, ArrayContext, ArrayRef, IntoArray};
 use vortex_dtype::{DType, FieldMask, FieldName, StructDType};
 use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_err};
-use vortex_expr::ExprRef;
 use vortex_expr::transform::partition::{PartitionedExpr, partition};
+use vortex_expr::{EvalCtx, ExprRef};
 use vortex_mask::Mask;
 
 use crate::layouts::struct_::StructLayout;
@@ -285,7 +285,12 @@ impl MaskEvaluation for StructMaskEvaluation {
         )?
         .into_array();
 
-        let root_mask = Mask::try_from(self.partitioned.root.evaluate(&root_scope)?.as_ref())?;
+        let root_mask = Mask::try_from(
+            self.partitioned
+                .root
+                .evaluate(&EvalCtx::new_ident(root_scope.to_array()))?
+                .as_ref(),
+        )?;
         let mask = mask.bitand(&root_mask);
 
         Ok(mask)
@@ -324,7 +329,9 @@ impl ArrayEvaluation for StructArrayEvaluation {
         )?
         .into_array();
 
-        self.partitioned.root.evaluate(&root_scope)
+        self.partitioned
+            .root
+            .evaluate(&EvalCtx::new_ident(root_scope.to_array()))
     }
 }
 

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -12,11 +12,11 @@ use vortex_array::aliases::hash_map::HashMap;
 use vortex_array::arrays::StructArray;
 use vortex_array::stats::Precision;
 use vortex_array::validity::Validity;
-use vortex_array::{Array, ArrayContext, ArrayRef, IntoArray};
+use vortex_array::{ArrayContext, ArrayRef, IntoArray};
 use vortex_dtype::{DType, FieldMask, FieldName, StructDType};
 use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_err};
+use vortex_expr::ExprRef;
 use vortex_expr::transform::partition::{PartitionedExpr, partition};
-use vortex_expr::{EvaluationContext, ExprRef};
 use vortex_mask::Mask;
 
 use crate::layouts::struct_::StructLayout;
@@ -285,12 +285,8 @@ impl MaskEvaluation for StructMaskEvaluation {
         )?
         .into_array();
 
-        let root_mask = Mask::try_from(
-            self.partitioned
-                .root
-                .evaluate(&EvaluationContext::new_ident(root_scope.to_array()))?
-                .as_ref(),
-        )?;
+        let root_mask =
+            Mask::try_from(self.partitioned.root.evaluate_array(&root_scope)?.as_ref())?;
         let mask = mask.bitand(&root_mask);
 
         Ok(mask)
@@ -329,9 +325,7 @@ impl ArrayEvaluation for StructArrayEvaluation {
         )?
         .into_array();
 
-        self.partitioned
-            .root
-            .evaluate(&EvaluationContext::new_ident(root_scope.to_array()))
+        self.partitioned.root.evaluate_array(&root_scope)
     }
 }
 

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -16,7 +16,7 @@ use vortex_array::{Array, ArrayContext, ArrayRef, IntoArray};
 use vortex_dtype::{DType, FieldMask, FieldName, StructDType};
 use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_err};
 use vortex_expr::transform::partition::{PartitionedExpr, partition};
-use vortex_expr::{EvalCtx, ExprRef};
+use vortex_expr::{EvaluationContext, ExprRef};
 use vortex_mask::Mask;
 
 use crate::layouts::struct_::StructLayout;
@@ -288,7 +288,7 @@ impl MaskEvaluation for StructMaskEvaluation {
         let root_mask = Mask::try_from(
             self.partitioned
                 .root
-                .evaluate(&EvalCtx::new_ident(root_scope.to_array()))?
+                .evaluate(&EvaluationContext::new_ident(root_scope.to_array()))?
                 .as_ref(),
         )?;
         let mask = mask.bitand(&root_mask);
@@ -331,7 +331,7 @@ impl ArrayEvaluation for StructArrayEvaluation {
 
         self.partitioned
             .root
-            .evaluate(&EvalCtx::new_ident(root_scope.to_array()))
+            .evaluate(&EvaluationContext::new_ident(root_scope.to_array()))
     }
 }
 

--- a/vortex-layout/src/layouts/zoned/reader.rs
+++ b/vortex-layout/src/layouts/zoned/reader.rs
@@ -13,7 +13,7 @@ use vortex_array::{ArrayContext, ToCanonical};
 use vortex_dtype::{DType, FieldMask};
 use vortex_error::{SharedVortexResult, VortexError, VortexExpect, VortexResult};
 use vortex_expr::pruning::PruningPredicate;
-use vortex_expr::{ExprRef, Identity};
+use vortex_expr::{EvaluationContext, ExprRef, Identity};
 use vortex_mask::Mask;
 
 use crate::layouts::zoned::ZonedLayout;
@@ -122,10 +122,13 @@ impl ZonedReader {
                         self.stats_table()
                             .map(move |stats_table| {
                                 stats_table.and_then(move |stats_table| {
-                                    pred.evaluate(stats_table.array().as_ref())?
-                                        .map(|a| Mask::try_from(a.as_ref()))
-                                        .transpose()
-                                        .map_err(Arc::new)
+                                    pred.evaluate(
+                                        stats_table.array().as_ref(),
+                                        &EvaluationContext::default(),
+                                    )?
+                                    .map(|a| Mask::try_from(a.as_ref()))
+                                    .transpose()
+                                    .map_err(Arc::new)
                                 })
                             })
                             .boxed()

--- a/vortex-proto/proto/expr.proto
+++ b/vortex-proto/proto/expr.proto
@@ -21,6 +21,7 @@ message Kind {
     BinaryOp binary_op = 2;
     GetItem get_item = 3;
     Identity identity = 4;
+    Aux aux = 11;
     Merge merge = 5;
     Not not = 6;
     Pack pack = 7;
@@ -38,6 +39,10 @@ message Kind {
   }
 
   message Identity {
+
+  }
+
+  message Aux {
 
   }
 

--- a/vortex-proto/src/generated/vortex.expr.rs
+++ b/vortex-proto/src/generated/vortex.expr.rs
@@ -12,7 +12,7 @@ pub struct Expr {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Kind {
     /// This enum is very unstable, and will likely be replaced with something more extensible.
-    #[prost(oneof = "kind::Kind", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
+    #[prost(oneof = "kind::Kind", tags = "1, 2, 3, 4, 11, 5, 6, 7, 8, 9, 10")]
     pub kind: ::core::option::Option<kind::Kind>,
 }
 /// Nested message and enum types in `Kind`.
@@ -26,6 +26,8 @@ pub mod kind {
     pub struct Not {}
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct Identity {}
+    #[derive(Clone, Copy, PartialEq, ::prost::Message)]
+    pub struct Aux {}
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct Merge {}
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -119,6 +121,8 @@ pub mod kind {
         GetItem(GetItem),
         #[prost(message, tag = "4")]
         Identity(Identity),
+        #[prost(message, tag = "11")]
+        Aux(Aux),
         #[prost(message, tag = "5")]
         Merge(Merge),
         #[prost(message, tag = "6")]


### PR DESCRIPTION

The new eval function is:
`fn evaluate(&self, array: &dyn Array, ctx: &EvaluationContext) -> VortexResult<ArrayRef> { ... }`

Signed-off-by: Joe Isaacs <joe.isaacs@live.co.uk>