### PR TITLE
perf: use evaluate_unchecked recursive expr calls

### DIFF
--- a/vortex-expr/src/between.rs
+++ b/vortex-expr/src/between.rs
@@ -136,9 +136,9 @@ impl VortexExpr for Between {
     }
 
     fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let arr_val = self.arr.evaluate(batch)?;
-        let lower_arr_val = self.lower.evaluate(batch)?;
-        let upper_arr_val = self.upper.evaluate(batch)?;
+        let arr_val = self.arr.unchecked_evaluate(batch)?;
+        let lower_arr_val = self.lower.unchecked_evaluate(batch)?;
+        let upper_arr_val = self.upper.unchecked_evaluate(batch)?;
 
         between(&arr_val, &lower_arr_val, &upper_arr_val, &self.options)
     }

--- a/vortex-expr/src/binary.rs
+++ b/vortex-expr/src/binary.rs
@@ -88,8 +88,8 @@ impl VortexExpr for BinaryExpr {
     }
 
     fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let lhs = self.lhs.evaluate(batch)?;
-        let rhs = self.rhs.evaluate(batch)?;
+        let lhs = self.lhs.unchecked_evaluate(batch)?;
+        let rhs = self.rhs.unchecked_evaluate(batch)?;
 
         match self.operator {
             Operator::Eq => compare(&lhs, &rhs, ArrayOperator::Eq),

--- a/vortex-expr/src/get_item.rs
+++ b/vortex-expr/src/get_item.rs
@@ -101,7 +101,7 @@ impl VortexExpr for GetItem {
 
     fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
         self.child
-            .evaluate(batch)?
+            .unchecked_evaluate(batch)?
             .to_struct()?
             .field_by_name(self.field())
             .cloned()

--- a/vortex-expr/src/is_null.rs
+++ b/vortex-expr/src/is_null.rs
@@ -79,7 +79,7 @@ impl VortexExpr for IsNull {
     }
 
     fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let array = self.child.evaluate(batch)?;
+        let array = self.child.unchecked_evaluate(batch)?;
         match array.validity_mask()? {
             Mask::AllTrue(len) => Ok(ConstantArray::new(false, len).into_array()),
             Mask::AllFalse(len) => Ok(ConstantArray::new(true, len).into_array()),

--- a/vortex-expr/src/like.rs
+++ b/vortex-expr/src/like.rs
@@ -108,8 +108,8 @@ impl VortexExpr for Like {
     }
 
     fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let child = self.child().evaluate(batch)?;
-        let pattern = self.pattern().evaluate(&child)?;
+        let child = self.child().unchecked_evaluate(batch)?;
+        let pattern = self.pattern().unchecked_evaluate(&child)?;
         like(
             &child,
             &pattern,

--- a/vortex-expr/src/merge.rs
+++ b/vortex-expr/src/merge.rs
@@ -98,7 +98,7 @@ impl VortexExpr for Merge {
         let value_arrays = self
             .values
             .iter()
-            .map(|value_expr| value_expr.evaluate(batch))
+            .map(|value_expr| value_expr.unchecked_evaluate(batch))
             .process_results(|it| it.collect::<Vec<_>>())?;
 
         // Collect fields in order of appearance. Later fields overwrite earlier fields.

--- a/vortex-expr/src/not.rs
+++ b/vortex-expr/src/not.rs
@@ -74,7 +74,7 @@ impl VortexExpr for Not {
     }
 
     fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let child_result = self.child.evaluate(batch)?;
+        let child_result = self.child.unchecked_evaluate(batch)?;
         invert(&child_result)
     }
 

--- a/vortex-expr/src/pack.rs
+++ b/vortex-expr/src/pack.rs
@@ -153,7 +153,7 @@ impl VortexExpr for Pack {
         let value_arrays = self
             .values
             .iter()
-            .map(|value_expr| value_expr.evaluate(batch))
+            .map(|value_expr| value_expr.unchecked_evaluate(batch))
             .process_results(|it| it.collect::<Vec<_>>())?;
         let validity = match self.nullability {
             Nullability::NonNullable => Validity::NonNullable,

--- a/vortex-expr/src/pruning.rs
+++ b/vortex-expr/src/pruning.rs
@@ -152,7 +152,7 @@ impl PruningPredicate {
             return Ok(None);
         }
 
-        Ok(Some(self.expr.evaluate(metadata)?))
+        Ok(Some(self.expr.unchecked_evaluate(metadata)?))
     }
 }
 

--- a/vortex-expr/src/select.rs
+++ b/vortex-expr/src/select.rs
@@ -158,7 +158,7 @@ impl VortexExpr for Select {
     }
 
     fn unchecked_evaluate(&self, batch: &dyn Array) -> VortexResult<ArrayRef> {
-        let batch = self.child.evaluate(batch)?.to_struct()?;
+        let batch = self.child.unchecked_evaluate(batch)?.to_struct()?;
         Ok(match &self.fields {
             SelectField::Include(f) => batch.project(f),
             SelectField::Exclude(names) => {


### PR DESCRIPTION
expr eval is much ore expensive than eval_unchecked

Maybe we should make the return type check debug, but then it never run in practise.