### PR TITLE
feat & fix: Scalar::zero & from_arrow handles nullable struct fields

### DIFF
--- a/vortex-array/src/arrays/constant/canonical.rs
+++ b/vortex-array/src/arrays/constant/canonical.rs
@@ -3,15 +3,15 @@ use vortex_buffer::{Buffer, BufferMut, buffer};
 use vortex_dtype::{DType, Nullability, PType, match_each_native_ptype};
 use vortex_error::{VortexExpect, VortexResult};
 use vortex_scalar::{
-    BinaryScalar, BoolScalar, DecimalValue, ExtScalar, ListScalar, Scalar, ScalarValue,
-    StructScalar, Utf8Scalar, match_each_decimal_value, match_each_decimal_value_type,
+    BinaryScalar, BoolScalar, DecimalValue, DecimalValueType, ExtScalar, ListScalar, Scalar,
+    ScalarValue, StructScalar, Utf8Scalar, match_each_decimal_value, match_each_decimal_value_type,
 };
 
 use crate::arrays::constant::ConstantArray;
 use crate::arrays::primitive::PrimitiveArray;
 use crate::arrays::{
     BinaryView, BoolArray, ConstantVTable, DecimalArray, ExtensionArray, ListArray, NullArray,
-    StructArray, VarBinViewArray, smallest_storage_type,
+    StructArray, VarBinViewArray,
 };
 use crate::builders::{ArrayBuilderExt, builder_with_capacity};
 use crate::validity::Validity;
@@ -57,7 +57,7 @@ impl CanonicalVTable<ConstantVTable> for ConstantVTable {
                 })
             }
             DType::Decimal(decimal_type, ..) => {
-                let size = smallest_storage_type(decimal_type);
+                let size = DecimalValueType::smallest_storage_type(decimal_type);
                 let decimal = scalar.as_decimal();
                 let Some(value) = decimal.decimal_value() else {
                     let all_null = match_each_decimal_value_type!(size, |D| {

--- a/vortex-array/src/arrays/decimal/mod.rs
+++ b/vortex-array/src/arrays/decimal/mod.rs
@@ -44,20 +44,6 @@ impl VTable for DecimalVTable {
 #[derive(Clone, Debug)]
 pub struct DecimalEncoding;
 
-/// Maps a decimal precision into the smallest type that can represent it.
-pub fn smallest_storage_type(decimal_dtype: &DecimalDType) -> DecimalValueType {
-    match decimal_dtype.precision() {
-        1..=2 => DecimalValueType::I8,
-        3..=4 => DecimalValueType::I16,
-        5..=9 => DecimalValueType::I32,
-        10..=18 => DecimalValueType::I64,
-        19..=38 => DecimalValueType::I128,
-        39..=76 => DecimalValueType::I256,
-        0 => unreachable!("precision must be greater than 0"),
-        p => unreachable!("precision larger than 76 is invalid found precision {p}"),
-    }
-}
-
 /// Array for decimal-typed real numbers
 #[derive(Clone, Debug)]
 pub struct DecimalArray {

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -19,13 +19,14 @@ use vortex_buffer::{Alignment, Buffer, ByteBuffer};
 use vortex_dtype::datetime::TimeUnit;
 use vortex_dtype::{DType, DecimalDType, NativePType, PType};
 use vortex_error::{VortexExpect as _, vortex_panic};
-use vortex_scalar::i256;
+use vortex_scalar::{Scalar, i256};
 
 use crate::arrays::{
     BoolArray, DecimalArray, ListArray, NullArray, PrimitiveArray, StructArray, TemporalArray,
     VarBinArray, VarBinViewArray,
 };
 use crate::arrow::FromArrowArray;
+use crate::compute::fill_null;
 use crate::validity::Validity;
 use crate::{ArrayRef, IntoArray};
 
@@ -226,17 +227,31 @@ impl FromArrowArray<&ArrowBooleanArray> for ArrayRef {
 }
 
 impl FromArrowArray<&ArrowStructArray> for ArrayRef {
-    fn from_arrow(value: &ArrowStructArray, nullable: bool) -> Self {
+    fn from_arrow(struct_array: &ArrowStructArray, nullable: bool) -> Self {
         StructArray::try_new(
-            value.column_names().iter().map(|s| (*s).into()).collect(),
-            value
+            struct_array
+                .column_names()
+                .iter()
+                .map(|s| (*s).into())
+                .collect(),
+            struct_array
                 .columns()
                 .iter()
-                .zip(value.fields())
-                .map(|(c, field)| Self::from_arrow(c.as_ref(), field.is_nullable()))
+                .zip(struct_array.fields())
+                .map(|(c, field)| {
+                    let vtx = Self::from_arrow(c.as_ref(), true);
+                    if field.is_nullable() {
+                        vtx
+                    } else {
+                        // ASSUMPTION: Non-nullable fields of an Arrow struct array only have nulls
+                        // at positions at which the struct (or some higher-level struct) is null.
+                        fill_null(vtx.as_ref(), &Scalar::zero(vtx.dtype()))
+                            .vortex_expect("fill_null is always implemented")
+                    }
+                })
                 .collect(),
-            value.len(),
-            nulls(value.nulls(), nullable),
+            struct_array.len(),
+            nulls(struct_array.nulls(), nullable),
         )
         .vortex_expect("Failed to convert Arrow StructArray to Vortex StructArray")
         .into_array()
@@ -368,5 +383,38 @@ impl FromArrowArray<&dyn ArrowArray> for ArrayRef {
                 array.data_type().clone()
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::{ArrayRef as ArrowArrayRef, StructArray as ArrowStructArray, new_null_array};
+    use arrow_buffer::NullBufferBuilder;
+    use arrow_schema::{DataType, Field, Fields};
+
+    use crate::ArrayRef;
+    use crate::arrow::FromArrowArray as _;
+
+    #[test]
+    pub fn nullable_may_contain_non_nullable() {
+        let fields = Fields::from(vec![Field::new(
+            "non_nullable_inner",
+            DataType::Int32,
+            false,
+        )]);
+        let nulls = {
+            let mut builder = NullBufferBuilder::new(1);
+            builder.append_null();
+            builder.finish()
+        };
+        let array: ArrowArrayRef = Arc::from(
+            ArrowStructArray::try_new(fields, vec![new_null_array(&DataType::Int32, 1)], nulls)
+                .unwrap(),
+        );
+        println!("{:?}", array);
+
+        ArrayRef::from_arrow(array.as_ref(), true);
     }
 }

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -413,7 +413,6 @@ mod tests {
             ArrowStructArray::try_new(fields, vec![new_null_array(&DataType::Int32, 1)], nulls)
                 .unwrap(),
         );
-        println!("{:?}", array);
 
         ArrayRef::from_arrow(array.as_ref(), true);
     }

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -53,7 +53,6 @@ use vortex_scalar::{
     ScalarValue, StructScalar, Utf8Scalar, match_each_decimal_value, match_each_decimal_value_type,
 };
 
-use crate::arrays::smallest_storage_type;
 use crate::{Array, ArrayRef};
 
 pub trait ArrayBuilder: Send {
@@ -140,13 +139,16 @@ pub fn builder_with_capacity(dtype: &DType, capacity: usize) -> Box<dyn ArrayBui
             })
         }
         DType::Decimal(decimal_type, n) => {
-            match_each_decimal_value_type!(smallest_storage_type(decimal_type), |D| {
-                Box::new(DecimalBuilder::with_capacity::<D>(
-                    capacity,
-                    *decimal_type,
-                    *n,
-                ))
-            })
+            match_each_decimal_value_type!(
+                DecimalValueType::smallest_storage_type(decimal_type),
+                |D| {
+                    Box::new(DecimalBuilder::with_capacity::<D>(
+                        capacity,
+                        *decimal_type,
+                        *n,
+                    ))
+                }
+            )
         }
         DType::Utf8(n) => Box::new(VarBinViewBuilder::with_capacity(DType::Utf8(*n), capacity)),
         DType::Binary(n) => Box::new(VarBinViewBuilder::with_capacity(

--- a/vortex-scalar/src/decimal.rs
+++ b/vortex-scalar/src/decimal.rs
@@ -89,6 +89,22 @@ pub enum DecimalValueType {
     I256 = 5,
 }
 
+impl DecimalValueType {
+    /// Maps a decimal precision into the smallest type that can represent it.
+    pub fn smallest_storage_type(decimal_dtype: &DecimalDType) -> Self {
+        match decimal_dtype.precision() {
+            1..=2 => Self::I8,
+            3..=4 => Self::I16,
+            5..=9 => Self::I32,
+            10..=18 => Self::I64,
+            19..=38 => Self::I128,
+            39..=76 => Self::I256,
+            0 => unreachable!("precision must be greater than 0"),
+            p => unreachable!("precision larger than 76 is invalid found precision {p}"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum DecimalValue {
     I8(i8),
@@ -97,6 +113,19 @@ pub enum DecimalValue {
     I64(i64),
     I128(i128),
     I256(i256),
+}
+
+impl DecimalValue {
+    pub fn zero(decimal_dtype: DecimalValueType) -> Self {
+        match decimal_dtype {
+            DecimalValueType::I8 => Self::I8(0),
+            DecimalValueType::I16 => Self::I16(0),
+            DecimalValueType::I32 => Self::I32(0),
+            DecimalValueType::I64 => Self::I64(0),
+            DecimalValueType::I128 => Self::I128(0),
+            DecimalValueType::I256 => Self::I256(i256::from_i128(0)),
+        }
+    }
 }
 
 // Comparisons between DecimalValue types should upcast to i256 and operate in the upcast space.

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -179,6 +179,17 @@ impl Scalar {
             DType::Extension(_ext_dtype) => self.as_extension().storage().nbytes(),
         }
     }
+
+    /// Produces a "zero" value of the given type.
+    ///
+    /// Even recursive values (i.e. structs) transitively will not contain any nulls.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if given the nullable data type.
+    pub fn zero(dtype: &DType) -> Self {
+        Scalar::new(dtype.clone(), ScalarValue::zero(dtype))
+    }
 }
 
 impl Scalar {

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -182,11 +182,38 @@ impl Scalar {
 
     /// Produces a "zero" value of the given type.
     ///
-    /// Even recursive values (i.e. structs) transitively will not contain any nulls.
+    /// For every type except the Null type, the value is guarnateed to be not null. This
+    /// transitively applies to any value contained in a recursive value (i.e. structs).
     ///
-    /// # Panics
+    /// # Examples
     ///
-    /// This function panics if given the nullable data type.
+    /// ```
+    /// use std::sync::Arc;
+    /// use vortex_scalar::{Scalar, PValue};
+    /// use vortex_dtype::{DType, PType};
+    /// use vortex_dtype::Nullability::Nullable;
+    ///
+    /// let zero = Scalar::zero(&DType::Null);
+    /// assert!(zero.is_null());
+    ///
+    /// let zero = Scalar::zero(&DType::Bool(Nullable));
+    /// assert_eq!(zero.as_bool().value(), Some(false));
+    ///
+    /// let zero = Scalar::zero(&DType::Primitive(PType::I32, Nullable));
+    /// assert_eq!(
+    ///   zero.as_primitive().pvalue(),
+    ///   Some(PValue::I32(0))
+    /// );
+    ///
+    /// let zero = Scalar::zero(&DType::Utf8(Nullable));
+    /// assert_eq!(
+    ///     zero.as_utf8().value().as_ref().map(|x| x.as_str()),
+    ///     Some("")
+    /// );
+    ///
+    /// let zero = Scalar::zero(&DType::List(Arc::from(DType::Bool(Nullable)), Nullable));
+    /// assert!(zero.as_list().is_empty());
+    /// ```
     pub fn zero(dtype: &DType) -> Self {
         Scalar::new(dtype.clone(), ScalarValue::zero(dtype))
     }

--- a/vortex-scalar/src/scalar_value/mod.rs
+++ b/vortex-scalar/src/scalar_value/mod.rs
@@ -13,12 +13,12 @@ use itertools::Itertools;
 use prost::Message;
 use vortex_buffer::{BufferString, ByteBuffer};
 use vortex_dtype::DType;
-use vortex_error::{VortexResult, VortexUnwrap, vortex_bail, vortex_err};
+use vortex_error::{VortexResult, VortexUnwrap, vortex_bail, vortex_err, vortex_panic};
 use vortex_proto::scalar as pb;
 
 use crate::decimal::DecimalValue;
 use crate::pvalue::PValue;
-use crate::{ScalarType, i256};
+use crate::{DecimalValueType, ScalarType, i256};
 
 /// Represents the internal data of a scalar value. Must be interpreted by wrapping
 /// up with a DType to make a Scalar.
@@ -155,6 +155,17 @@ impl ScalarValue {
     pub(crate) fn as_list(&self) -> VortexResult<Option<&Arc<[ScalarValue]>>> {
         self.0.as_list()
     }
+
+    /// Produces a "zero" value of the given type.
+    ///
+    /// Even recursive values (i.e. structs) transitively will not contain any nulls.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if given the nullable data type.
+    pub(crate) fn zero(dtype: &DType) -> Self {
+        Self(InnerScalarValue::zero(dtype))
+    }
 }
 
 impl InnerScalarValue {
@@ -256,6 +267,35 @@ impl InnerScalarValue {
             InnerScalarValue::Null => Ok(None),
             InnerScalarValue::List(l) => Ok(Some(l)),
             _ => Err(vortex_err!("Expected a list scalar, found {:?}", self)),
+        }
+    }
+
+    /// Produces a "zero" value of the given type.
+    ///
+    /// Even recursive values (i.e. structs) transitively will not contain any nulls.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if given the nullable data type.
+    pub(crate) fn zero(dtype: &DType) -> Self {
+        match &dtype {
+            DType::Null => vortex_panic!("the null data type has no 'zero' value"),
+            DType::Bool(_) => Self::Bool(false),
+            DType::Primitive(ptype, _) => Self::Primitive(PValue::zero(*ptype)),
+            DType::Decimal(decimal_dtype, _) => {
+                let decimal_storage_dtype = DecimalValueType::smallest_storage_type(decimal_dtype);
+                Self::Decimal(DecimalValue::zero(decimal_storage_dtype))
+            }
+            DType::Utf8(_) => Self::BufferString(Arc::from(BufferString::from(""))),
+            DType::Binary(_) => Self::Buffer(Arc::from(ByteBuffer::empty())),
+            DType::Struct(struct_dtype, _) => Self::List(Arc::from(
+                struct_dtype
+                    .fields()
+                    .map(|t| ScalarValue::zero(&t))
+                    .collect::<Vec<_>>(),
+            )),
+            DType::List(..) => Self::List(Arc::from(Vec::new())),
+            DType::Extension(ext_dtype) => Self::zero(ext_dtype.storage_dtype()),
         }
     }
 }

--- a/vortex-scalar/src/scalar_value/mod.rs
+++ b/vortex-scalar/src/scalar_value/mod.rs
@@ -13,7 +13,7 @@ use itertools::Itertools;
 use prost::Message;
 use vortex_buffer::{BufferString, ByteBuffer};
 use vortex_dtype::DType;
-use vortex_error::{VortexResult, VortexUnwrap, vortex_bail, vortex_err, vortex_panic};
+use vortex_error::{VortexResult, VortexUnwrap, vortex_bail, vortex_err};
 use vortex_proto::scalar as pb;
 
 use crate::decimal::DecimalValue;
@@ -158,11 +158,8 @@ impl ScalarValue {
 
     /// Produces a "zero" value of the given type.
     ///
-    /// Even recursive values (i.e. structs) transitively will not contain any nulls.
-    ///
-    /// # Panics
-    ///
-    /// This function panics if given the nullable data type.
+    /// For every type except the Null type, the value is guarnateed to be not null. This
+    /// transitively applies to any value contained in a recursive value (i.e. structs).
     pub(crate) fn zero(dtype: &DType) -> Self {
         Self(InnerScalarValue::zero(dtype))
     }
@@ -272,14 +269,11 @@ impl InnerScalarValue {
 
     /// Produces a "zero" value of the given type.
     ///
-    /// Even recursive values (i.e. structs) transitively will not contain any nulls.
-    ///
-    /// # Panics
-    ///
-    /// This function panics if given the nullable data type.
+    /// For every type except the Null type, the value is guarnateed to be not null. This
+    /// transitively applies to any value contained in a recursive value (i.e. structs).
     pub(crate) fn zero(dtype: &DType) -> Self {
         match &dtype {
-            DType::Null => vortex_panic!("the null data type has no 'zero' value"),
+            DType::Null => Self::Null,
             DType::Bool(_) => Self::Bool(false),
             DType::Primitive(ptype, _) => Self::Primitive(PValue::zero(*ptype)),
             DType::Decimal(decimal_dtype, _) => {


### PR DESCRIPTION
Consider this nullable struct type with a non-nullable field.

```
{
    non_nullable_inner=i32
}?
```

In Arrow, a nullable field *does not mean* the corresponding array has no nulls. Instead, it means that the array has nulls at only those positions that some containing struct array has a null.

For example, this is a valid arrow array of that type:

```
StructArray
-- validity:
[
  null,
]
[
-- child 0: "non_nullable_inner" (Int32)
PrimitiveArray<Int32>
[
  null,
]
]
```

In this PR, we use `fill_null`, with the newly implemented `Scalar::zero`, to convert a nullable Arrow field array into a valid non-nullable Vortex array. If a function like `fill_null_arbitrary` existed, some arrays could simply drop their validity mask without modifying their data.