### PR TITLE
fix: Teach from_arrow to handle non-nullable fields with nulls

### DIFF
--- a/bench-vortex/src/tpch/mod.rs
+++ b/bench-vortex/src/tpch/mod.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use object_store::ObjectStore;
 use url::Url;
 use vortex::arrays::ChunkedArray;
-use vortex::arrow::FromArrowArray;
+use vortex::arrow::{ArrowNullability, FromArrowArray};
 use vortex::{Array, ArrayRef, IntoArray, TryIntoArray};
 use vortex_datafusion::SessionContextExt;
 
@@ -244,7 +244,7 @@ async fn register_vortex(
     let chunks: Vec<ArrayRef> = record_batches
         .into_iter()
         .map(ArrowStructArray::from)
-        .map(|struct_array| ArrayRef::from_arrow(&struct_array, false))
+        .map(|struct_array| ArrayRef::from_arrow(&struct_array, ArrowNullability::NonNullable))
         .collect();
 
     let dtype = chunks[0].dtype().clone();

--- a/vortex-array/src/arrays/varbin/canonical.rs
+++ b/vortex-array/src/arrays/varbin/canonical.rs
@@ -4,14 +4,14 @@ use vortex_error::VortexResult;
 
 use crate::arrays::VarBinVTable;
 use crate::arrays::varbin::VarBinArray;
-use crate::arrow::{FromArrowArray, IntoArrowArray};
+use crate::arrow::{ArrowNullability, FromArrowArray, IntoArrowArray};
 use crate::vtable::CanonicalVTable;
 use crate::{ArrayRef, Canonical, ToCanonical};
 
 impl CanonicalVTable<VarBinVTable> for VarBinVTable {
     fn canonicalize(array: &VarBinArray) -> VortexResult<Canonical> {
         let dtype = array.dtype().clone();
-        let nullable = dtype.is_nullable();
+        let nullable = ArrowNullability::from(&dtype);
 
         let array_ref = array.to_array().into_arrow_preferred()?;
         let array = match dtype {

--- a/vortex-array/src/arrays/varbinview/mod.rs
+++ b/vortex-array/src/arrays/varbinview/mod.rs
@@ -9,7 +9,7 @@ use vortex_buffer::{Alignment, Buffer, ByteBuffer};
 use vortex_dtype::DType;
 use vortex_error::{VortexExpect, VortexResult, VortexUnwrap, vortex_bail, vortex_panic};
 
-use crate::arrow::FromArrowArray;
+use crate::arrow::{ArrowNullability, FromArrowArray};
 use crate::builders::ArrayBuilder;
 use crate::stats::{ArrayStats, StatsSetRef};
 use crate::validity::Validity;
@@ -424,7 +424,7 @@ impl VarBinViewArray {
         for s in iter {
             builder.append_value(s);
         }
-        ArrayRef::from_arrow(&builder.finish(), false)
+        ArrayRef::from_arrow(&builder.finish(), ArrowNullability::NonNullable)
             .to_varbinview()
             .vortex_expect("VarBinViewArray from StringViewBuilder")
     }
@@ -436,7 +436,7 @@ impl VarBinViewArray {
         let mut builder = StringViewBuilder::with_capacity(iter.size_hint().0);
         builder.extend(iter);
 
-        let array = ArrayRef::from_arrow(&builder.finish(), true);
+        let array = ArrayRef::from_arrow(&builder.finish(), ArrowNullability::Nullable);
         array
             .to_varbinview()
             .vortex_expect("VarBinViewArray from StringViewBuilder")
@@ -448,7 +448,7 @@ impl VarBinViewArray {
         for b in iter {
             builder.append_value(b);
         }
-        ArrayRef::from_arrow(&builder.finish(), false)
+        ArrayRef::from_arrow(&builder.finish(), ArrowNullability::NonNullable)
             .to_varbinview()
             .vortex_expect("VarBinViewArray from StringViewBuilder")
     }
@@ -459,7 +459,7 @@ impl VarBinViewArray {
         let iter = iter.into_iter();
         let mut builder = BinaryViewBuilder::with_capacity(iter.size_hint().0);
         builder.extend(iter);
-        ArrayRef::from_arrow(&builder.finish(), true)
+        ArrayRef::from_arrow(&builder.finish(), ArrowNullability::Nullable)
             .to_varbinview()
             .vortex_expect("VarBinViewArray from StringViewBuilder")
     }

--- a/vortex-array/src/arrow/array.rs
+++ b/vortex-array/src/arrow/array.rs
@@ -7,6 +7,7 @@ use vortex_error::{VortexResult, vortex_bail};
 use vortex_mask::Mask;
 use vortex_scalar::Scalar;
 
+use super::ArrowNullability;
 use crate::arrow::FromArrowArray;
 use crate::stats::{ArrayStats, StatsSetRef};
 use crate::vtable::{
@@ -84,7 +85,8 @@ impl ArrayVTable<ArrowVTable> for ArrowVTable {
 
 impl CanonicalVTable<ArrowVTable> for ArrowVTable {
     fn canonicalize(array: &ArrowArray) -> VortexResult<Canonical> {
-        ArrayRef::from_arrow(array.inner.as_ref(), array.dtype.is_nullable()).to_canonical()
+        ArrayRef::from_arrow(array.inner.as_ref(), ArrowNullability::from(&array.dtype))
+            .to_canonical()
     }
 }
 

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -12,7 +12,7 @@ use arrow_array::types::{
     TimestampSecondType, UInt8Type, UInt16Type, UInt32Type, UInt64Type,
 };
 use arrow_array::{BinaryViewArray, GenericByteViewArray, GenericListArray, StringViewArray};
-use arrow_buffer::buffer::{NullBuffer, OffsetBuffer};
+use arrow_buffer::buffer::OffsetBuffer;
 use arrow_buffer::{ArrowNativeType, BooleanBuffer, Buffer as ArrowBuffer, ScalarBuffer};
 use arrow_schema::{DataType, TimeUnit as ArrowTimeUnit};
 use vortex_buffer::{Alignment, Buffer, ByteBuffer};
@@ -25,7 +25,7 @@ use crate::arrays::{
     BoolArray, DecimalArray, ListArray, NullArray, PrimitiveArray, StructArray, TemporalArray,
     VarBinArray, VarBinViewArray,
 };
-use crate::arrow::FromArrowArray;
+use crate::arrow::{ArrowNullability, FromArrowArray};
 use crate::validity::Validity;
 use crate::{ArrayRef, IntoArray};
 
@@ -76,9 +76,9 @@ where
 macro_rules! impl_from_arrow_primitive {
     ($ty:path) => {
         impl FromArrowArray<&ArrowPrimitiveArray<$ty>> for ArrayRef {
-            fn from_arrow(value: &ArrowPrimitiveArray<$ty>, nullable: bool) -> Self {
+            fn from_arrow(value: &ArrowPrimitiveArray<$ty>, nullable: ArrowNullability) -> Self {
                 let buffer = Buffer::from_arrow_scalar_buffer(value.values().clone());
-                let validity = nulls(value.nulls(), nullable);
+                let validity = nullable.into_validity(value.nulls());
                 PrimitiveArray::new(buffer, validity).into_array()
             }
         }
@@ -98,16 +98,16 @@ impl_from_arrow_primitive!(Float32Type);
 impl_from_arrow_primitive!(Float64Type);
 
 impl FromArrowArray<&ArrowPrimitiveArray<Decimal128Type>> for ArrayRef {
-    fn from_arrow(array: &ArrowPrimitiveArray<Decimal128Type>, nullable: bool) -> Self {
+    fn from_arrow(array: &ArrowPrimitiveArray<Decimal128Type>, nullable: ArrowNullability) -> Self {
         let decimal_type = DecimalDType::new(array.precision(), array.scale());
         let buffer = Buffer::from_arrow_scalar_buffer(array.values().clone());
-        let validity = nulls(array.nulls(), nullable);
+        let validity = nullable.into_validity(array.nulls());
         DecimalArray::new(buffer, decimal_type, validity).into_array()
     }
 }
 
 impl FromArrowArray<&ArrowPrimitiveArray<Decimal256Type>> for ArrayRef {
-    fn from_arrow(array: &ArrowPrimitiveArray<Decimal256Type>, nullable: bool) -> Self {
+    fn from_arrow(array: &ArrowPrimitiveArray<Decimal256Type>, nullable: ArrowNullability) -> Self {
         let decimal_type = DecimalDType::new(array.precision(), array.scale());
         let buffer = Buffer::from_arrow_scalar_buffer(array.values().clone());
         // SAFETY: Our i256 implementation has the same bit-pattern representation of the
@@ -115,7 +115,7 @@ impl FromArrowArray<&ArrowPrimitiveArray<Decimal256Type>> for ArrayRef {
         //  of either type.
         let buffer =
             unsafe { std::mem::transmute::<Buffer<arrow_buffer::i256>, Buffer<i256>>(buffer) };
-        let validity = nulls(array.nulls(), nullable);
+        let validity = nullable.into_validity(array.nulls());
         DecimalArray::new(buffer, decimal_type, validity).into_array()
     }
 }
@@ -123,7 +123,7 @@ impl FromArrowArray<&ArrowPrimitiveArray<Decimal256Type>> for ArrayRef {
 macro_rules! impl_from_arrow_temporal {
     ($ty:path) => {
         impl FromArrowArray<&ArrowPrimitiveArray<$ty>> for ArrayRef {
-            fn from_arrow(value: &ArrowPrimitiveArray<$ty>, nullable: bool) -> Self {
+            fn from_arrow(value: &ArrowPrimitiveArray<$ty>, nullable: ArrowNullability) -> Self {
                 temporal_array(value, nullable)
             }
         }
@@ -146,13 +146,16 @@ impl_from_arrow_temporal!(Time64NanosecondType);
 impl_from_arrow_temporal!(Date32Type);
 impl_from_arrow_temporal!(Date64Type);
 
-fn temporal_array<T: ArrowPrimitiveType>(value: &ArrowPrimitiveArray<T>, nullable: bool) -> ArrayRef
+fn temporal_array<T: ArrowPrimitiveType>(
+    value: &ArrowPrimitiveArray<T>,
+    nullable: ArrowNullability,
+) -> ArrayRef
 where
     T::Native: NativePType,
 {
     let arr = PrimitiveArray::new(
         Buffer::from_arrow_scalar_buffer(value.values().clone()),
-        nulls(value.nulls(), nullable),
+        nullable.into_validity(value.nulls()),
     )
     .into_array();
 
@@ -175,7 +178,7 @@ impl<T: ByteArrayType> FromArrowArray<&GenericByteArray<T>> for ArrayRef
 where
     <T as ByteArrayType>::Offset: NativePType,
 {
-    fn from_arrow(value: &GenericByteArray<T>, nullable: bool) -> Self {
+    fn from_arrow(value: &GenericByteArray<T>, nullable: ArrowNullability) -> Self {
         let dtype = match T::DATA_TYPE {
             DataType::Binary | DataType::LargeBinary => DType::Binary(nullable.into()),
             DataType::Utf8 | DataType::LargeUtf8 => DType::Utf8(nullable.into()),
@@ -185,7 +188,7 @@ where
             value.offsets().clone().into_array(),
             ByteBuffer::from_arrow_buffer(value.values().clone(), Alignment::of::<u8>()),
             dtype,
-            nulls(value.nulls(), nullable),
+            nullable.into_validity(value.nulls()),
         )
         .vortex_expect("Failed to convert Arrow GenericByteArray to Vortex VarBinArray")
         .into_array()
@@ -193,7 +196,7 @@ where
 }
 
 impl<T: ByteViewType> FromArrowArray<&GenericByteViewArray<T>> for ArrayRef {
-    fn from_arrow(value: &GenericByteViewArray<T>, nullable: bool) -> Self {
+    fn from_arrow(value: &GenericByteViewArray<T>, nullable: ArrowNullability) -> Self {
         let dtype = match T::DATA_TYPE {
             DataType::BinaryView => DType::Binary(nullable.into()),
             DataType::Utf8View => DType::Utf8(nullable.into()),
@@ -212,7 +215,7 @@ impl<T: ByteViewType> FromArrowArray<&GenericByteViewArray<T>> for ArrayRef {
                 .map(|b| ByteBuffer::from_arrow_buffer(b.clone(), Alignment::of::<u8>()))
                 .collect::<Vec<_>>(),
             dtype,
-            nulls(value.nulls(), nullable),
+            nullable.into_validity(value.nulls()),
         )
         .vortex_expect("Failed to convert Arrow GenericByteViewArray to Vortex VarBinViewArray")
         .into_array()
@@ -220,23 +223,33 @@ impl<T: ByteViewType> FromArrowArray<&GenericByteViewArray<T>> for ArrayRef {
 }
 
 impl FromArrowArray<&ArrowBooleanArray> for ArrayRef {
-    fn from_arrow(value: &ArrowBooleanArray, nullable: bool) -> Self {
-        BoolArray::new(value.values().clone(), nulls(value.nulls(), nullable)).into_array()
+    fn from_arrow(value: &ArrowBooleanArray, nullable: ArrowNullability) -> Self {
+        BoolArray::new(
+            value.values().clone(),
+            nullable.into_validity(value.nulls()),
+        )
+        .into_array()
     }
 }
 
 impl FromArrowArray<&ArrowStructArray> for ArrayRef {
-    fn from_arrow(value: &ArrowStructArray, nullable: bool) -> Self {
+    fn from_arrow(struct_array: &ArrowStructArray, nullable: ArrowNullability) -> Self {
         StructArray::try_new(
-            value.column_names().iter().map(|s| (*s).into()).collect(),
-            value
+            struct_array
+                .column_names()
+                .iter()
+                .map(|s| (*s).into())
+                .collect(),
+            struct_array
                 .columns()
                 .iter()
-                .zip(value.fields())
-                .map(|(c, field)| Self::from_arrow(c.as_ref(), field.is_nullable()))
+                .zip(struct_array.fields())
+                .map(|(c, field)| {
+                    Self::from_arrow(c.as_ref(), ArrowNullability::from(field.as_ref()))
+                })
                 .collect(),
-            value.len(),
-            nulls(value.nulls(), nullable),
+            struct_array.len(),
+            nullable.into_validity(struct_array.nulls()),
         )
         .vortex_expect("Failed to convert Arrow StructArray to Vortex StructArray")
         .into_array()
@@ -244,18 +257,19 @@ impl FromArrowArray<&ArrowStructArray> for ArrayRef {
 }
 
 impl<O: OffsetSizeTrait + NativePType> FromArrowArray<&GenericListArray<O>> for ArrayRef {
-    fn from_arrow(value: &GenericListArray<O>, nullable: bool) -> Self {
+    fn from_arrow(value: &GenericListArray<O>, nullable: ArrowNullability) -> Self {
         // Extract the validity of the underlying element array
-        let elem_nullable = match value.data_type() {
-            DataType::List(field) => field.is_nullable(),
-            DataType::LargeList(field) => field.is_nullable(),
+        let field = match value.data_type() {
+            DataType::List(field) => field,
+            DataType::LargeList(field) => field,
             dt => vortex_panic!("Invalid data type for ListArray: {dt}"),
         };
+        let elem_nullable = ArrowNullability::from(field.as_ref());
         ListArray::try_new(
             Self::from_arrow(value.values().as_ref(), elem_nullable),
             // offsets are always non-nullable
             value.offsets().clone().into_array(),
-            nulls(value.nulls(), nullable),
+            nullable.into_validity(value.nulls()),
         )
         .vortex_expect("Failed to convert Arrow StructArray to Vortex StructArray")
         .into_array()
@@ -263,31 +277,14 @@ impl<O: OffsetSizeTrait + NativePType> FromArrowArray<&GenericListArray<O>> for 
 }
 
 impl FromArrowArray<&ArrowNullArray> for ArrayRef {
-    fn from_arrow(value: &ArrowNullArray, nullable: bool) -> Self {
-        assert!(nullable);
+    fn from_arrow(value: &ArrowNullArray, nullable: ArrowNullability) -> Self {
+        assert!(nullable.is_nullable());
         NullArray::new(value.len()).into_array()
     }
 }
 
-fn nulls(nulls: Option<&NullBuffer>, nullable: bool) -> Validity {
-    if nullable {
-        nulls
-            .map(|nulls| {
-                if nulls.null_count() == nulls.len() {
-                    Validity::AllInvalid
-                } else {
-                    Validity::from(nulls.inner().clone())
-                }
-            })
-            .unwrap_or_else(|| Validity::AllValid)
-    } else {
-        assert!(nulls.map(|x| x.null_count() == 0).unwrap_or(true));
-        Validity::NonNullable
-    }
-}
-
 impl FromArrowArray<&dyn ArrowArray> for ArrayRef {
-    fn from_arrow(array: &dyn ArrowArray, nullable: bool) -> Self {
+    fn from_arrow(array: &dyn ArrowArray, nullable: ArrowNullability) -> Self {
         match array.data_type() {
             DataType::Boolean => Self::from_arrow(array.as_boolean(), nullable),
             DataType::UInt8 => Self::from_arrow(array.as_primitive::<UInt8Type>(), nullable),
@@ -368,5 +365,30 @@ impl FromArrowArray<&dyn ArrowArray> for ArrayRef {
                 array.data_type().clone()
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow_array::new_null_array;
+    use arrow_schema::{DataType, Field, Fields};
+
+    use crate::ArrayRef;
+    use crate::arrow::{ArrowNullability, FromArrowArray as _};
+
+    #[test]
+    pub fn nullable_may_contain_non_nullable() {
+        let null_struct_array_with_non_nullable_field = new_null_array(
+            &DataType::Struct(Fields::from(vec![Field::new(
+                "non_nullable_inner",
+                DataType::Int32,
+                false,
+            )])),
+            1,
+        );
+        ArrayRef::from_arrow(
+            null_struct_array_with_non_nullable_field.as_ref(),
+            ArrowNullability::Nullable,
+        );
     }
 }

--- a/vortex-array/src/arrow/datum.rs
+++ b/vortex-array/src/arrow/datum.rs
@@ -2,6 +2,7 @@ use arrow_array::{Array as ArrowArray, ArrayRef as ArrowArrayRef, Datum as Arrow
 use arrow_schema::DataType;
 use vortex_error::{VortexResult, vortex_panic};
 
+use super::ArrowNullability;
 use crate::arrays::ConstantArray;
 use crate::arrow::{FromArrowArray, IntoArrowArray};
 use crate::{Array, ArrayRef, IntoArray};
@@ -62,7 +63,8 @@ pub fn from_arrow_array_with_len<A>(array: A, len: usize, nullable: bool) -> Vor
 where
     ArrayRef: FromArrowArray<A>,
 {
-    let array = ArrayRef::from_arrow(array, nullable);
+    let desired_nullability = ArrowNullability::from_top_level_is_nullable(nullable);
+    let array = ArrayRef::from_arrow(array, desired_nullability);
     if array.len() == len {
         return Ok(array);
     }

--- a/vortex-array/src/arrow/mod.rs
+++ b/vortex-array/src/arrow/mod.rs
@@ -1,7 +1,9 @@
 //! Utilities to work with `Arrow` data and types.
 
 use arrow_array::ArrayRef as ArrowArrayRef;
+use arrow_buffer::NullBuffer;
 use arrow_schema::DataType;
+use vortex_dtype::{DType, Nullability};
 use vortex_error::VortexResult;
 
 mod array;
@@ -13,9 +15,98 @@ mod record_batch;
 pub use datum::*;
 
 use crate::arrow::compute::ToArrowOptions;
+use crate::validity::Validity;
+
+/// Describes the desired nullability of a Vortex array created from an Arrow array.
+///
+/// In Arrow, non-nullable struct or list fields may contain nulls, if-and-only-if the nulls are
+/// "masked" by the outer array.
+#[derive(Clone, Copy, Debug)]
+pub enum ArrowNullability {
+    Nullable,
+    NonNullable,
+    NonNullableField,
+}
+
+impl From<Nullability> for ArrowNullability {
+    fn from(value: Nullability) -> Self {
+        match value {
+            Nullability::NonNullable => Self::NonNullable,
+            Nullability::Nullable => Self::Nullable,
+        }
+    }
+}
+
+impl From<ArrowNullability> for Nullability {
+    fn from(value: ArrowNullability) -> Nullability {
+        match value {
+            ArrowNullability::Nullable => Nullability::Nullable,
+            ArrowNullability::NonNullable => Nullability::NonNullable,
+            ArrowNullability::NonNullableField => Nullability::NonNullable,
+        }
+    }
+}
+
+impl From<&arrow_schema::Field> for ArrowNullability {
+    fn from(value: &arrow_schema::Field) -> Self {
+        match value.is_nullable() {
+            true => Self::Nullable,
+            false => Self::NonNullableField,
+        }
+    }
+}
+
+impl From<&DType> for ArrowNullability {
+    fn from(value: &DType) -> Self {
+        match value.is_nullable() {
+            true => Self::Nullable,
+            false => Self::NonNullable,
+        }
+    }
+}
+
+impl ArrowNullability {
+    pub fn from_top_level_is_nullable(is_nullable: bool) -> Self {
+        match is_nullable {
+            true => Self::Nullable,
+            false => Self::NonNullable,
+        }
+    }
+
+    pub fn is_nullable(self) -> bool {
+        match self {
+            ArrowNullability::Nullable => true,
+            ArrowNullability::NonNullable => false,
+            ArrowNullability::NonNullableField => false,
+        }
+    }
+
+    pub fn into_validity(self, nulls: Option<&NullBuffer>) -> Validity {
+        match self {
+            ArrowNullability::Nullable => nulls
+                .map(|nulls| {
+                    if nulls.null_count() == nulls.len() {
+                        Validity::AllInvalid
+                    } else {
+                        Validity::from(nulls.inner().clone())
+                    }
+                })
+                .unwrap_or_else(|| Validity::AllValid),
+            ArrowNullability::NonNullable => {
+                assert!(nulls.map(|x| x.null_count() == 0).unwrap_or(true));
+                Validity::NonNullable
+            }
+            ArrowNullability::NonNullableField => {
+                // Non-nullable fields may contain "masked" nulls, so we do not check the null
+                // count. We assume Arrow constructed a valid struct array.
+                Validity::NonNullable
+            }
+        }
+    }
+}
 
 pub trait FromArrowArray<A> {
-    fn from_arrow(array: A, nullable: bool) -> Self;
+    fn from_arrow(array: A, nullable: ArrowNullability) -> Self;
 }
 
 pub trait IntoArrowArray {

--- a/vortex-array/src/arrow/record_batch.rs
+++ b/vortex-array/src/arrow/record_batch.rs
@@ -3,6 +3,7 @@ use arrow_array::cast::AsArray;
 use arrow_schema::{DataType, Schema};
 use vortex_error::{VortexError, VortexResult, vortex_err};
 
+use super::ArrowNullability;
 use crate::arrays::StructArray;
 use crate::arrow::FromArrowArray;
 use crate::arrow::compute::{to_arrow, to_arrow_preferred};
@@ -20,7 +21,9 @@ impl TryIntoArray for RecordBatch {
             self.columns()
                 .iter()
                 .zip(self.schema().fields())
-                .map(|(array, field)| ArrayRef::from_arrow(array.as_ref(), field.is_nullable()))
+                .map(|(array, field)| {
+                    ArrayRef::from_arrow(array.as_ref(), ArrowNullability::from(field.as_ref()))
+                })
                 .collect(),
             self.num_rows(),
             Validity::NonNullable, // Must match FromArrowType<SchemaRef> for DType

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -222,7 +222,7 @@ mod test {
     use vortex_buffer::buffer;
 
     use crate::arrays::{ConstantArray, StructArray};
-    use crate::arrow::{FromArrowArray, IntoArrowArray};
+    use crate::arrow::{ArrowNullability, FromArrowArray, IntoArrowArray};
     use crate::{ArrayRef, IntoArray};
 
     #[test]
@@ -316,7 +316,7 @@ mod test {
             nulls.finish(),
         );
 
-        let vortex_struct = ArrayRef::from_arrow(&arrow_struct, true);
+        let vortex_struct = ArrayRef::from_arrow(&arrow_struct, ArrowNullability::Nullable);
 
         assert_eq!(
             &arrow_struct,
@@ -340,8 +340,7 @@ mod test {
         );
         let list_data_type = arrow_list.data_type();
 
-        let vortex_list = ArrayRef::from_arrow(&arrow_list, true);
-
+        let vortex_list = ArrayRef::from_arrow(&arrow_list, ArrowNullability::Nullable);
         let rt_arrow_list = vortex_list.into_arrow(list_data_type).unwrap();
 
         assert_eq!(

--- a/vortex-array/src/compute/boolean.rs
+++ b/vortex-array/src/compute/boolean.rs
@@ -7,7 +7,7 @@ use arrow_schema::DataType;
 use vortex_dtype::DType;
 use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_bail, vortex_err};
 
-use crate::arrow::{FromArrowArray, IntoArrowArray};
+use crate::arrow::{ArrowNullability, FromArrowArray, IntoArrowArray};
 use crate::compute::{ComputeFn, ComputeFnVTable, InvocationArgs, Kernel, Options, Output};
 use crate::vtable::VTable;
 use crate::{Array, ArrayRef};
@@ -252,7 +252,10 @@ pub(crate) fn arrow_boolean(
         BooleanOperator::OrKleene => arrow_arith::boolean::or_kleene(&lhs, &rhs)?,
     };
 
-    Ok(ArrayRef::from_arrow(&array, nullable))
+    Ok(ArrayRef::from_arrow(
+        &array,
+        ArrowNullability::from_top_level_is_nullable(nullable),
+    ))
 }
 
 #[cfg(test)]

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -9,7 +9,7 @@ use vortex_mask::Mask;
 use vortex_scalar::Scalar;
 
 use crate::arrays::{BoolArray, ConstantArray};
-use crate::arrow::{FromArrowArray, IntoArrowArray};
+use crate::arrow::{ArrowNullability, FromArrowArray, IntoArrowArray};
 use crate::compute::{ComputeFn, ComputeFnVTable, InvocationArgs, Kernel, Output, fill_null};
 use crate::vtable::VTable;
 use crate::{Array, ArrayRef, Canonical, IntoArray, ToCanonical};
@@ -241,7 +241,7 @@ pub fn arrow_filter_fn(array: &dyn Array, mask: &Mask) -> VortexResult<ArrayRef>
 
     Ok(ArrayRef::from_arrow(
         filtered.as_ref(),
-        array.dtype().is_nullable(),
+        ArrowNullability::from(array.dtype()),
     ))
 }
 

--- a/vortex-array/src/compute/mask.rs
+++ b/vortex-array/src/compute/mask.rs
@@ -8,7 +8,7 @@ use vortex_mask::Mask;
 use vortex_scalar::Scalar;
 
 use crate::arrays::ConstantArray;
-use crate::arrow::{FromArrowArray, IntoArrowArray};
+use crate::arrow::{ArrowNullability, FromArrowArray, IntoArrowArray};
 use crate::compute::{ComputeFn, ComputeFnVTable, InvocationArgs, Kernel, Output, cast};
 use crate::vtable::VTable;
 use crate::{Array, ArrayRef, IntoArray};
@@ -128,7 +128,7 @@ impl ComputeFnVTable for MaskFn {
 
         let masked = arrow_select::nullif::nullif(array_ref.as_ref(), &mask)?;
 
-        Ok(ArrayRef::from_arrow(masked.as_ref(), true).into())
+        Ok(ArrayRef::from_arrow(masked.as_ref(), ArrowNullability::Nullable).into())
     }
 
     fn return_dtype(&self, args: &InvocationArgs) -> VortexResult<DType> {

--- a/vortex-datafusion/src/memory/plans.rs
+++ b/vortex-datafusion/src/memory/plans.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 use pin_project::pin_project;
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::arrow::compute::to_arrow;
-use vortex_array::arrow::{FromArrowArray, IntoArrowArray};
+use vortex_array::arrow::{ArrowNullability, FromArrowArray, IntoArrowArray};
 use vortex_array::compute::take;
 use vortex_array::{Array, ArrayRef, ToCanonical};
 use vortex_dtype::{FieldName, FieldNames};
@@ -343,8 +343,10 @@ where
             "input yielded too many RecordBatches"
         );
 
-        let row_indices =
-            ArrayRef::from_arrow(record_batch.column(0).as_primitive::<UInt64Type>(), false);
+        let row_indices = ArrayRef::from_arrow(
+            record_batch.column(0).as_primitive::<UInt64Type>(),
+            ArrowNullability::NonNullable,
+        );
 
         // If no columns in the output projection, we send back a RecordBatch with empty schema.
         // This is common for COUNT queries.

--- a/vortex-duckdb/src/convert/array/array_ref.rs
+++ b/vortex-duckdb/src/convert/array/array_ref.rs
@@ -2,7 +2,7 @@ use duckdb::core::LogicalTypeId;
 use duckdb::vtab::arrow::flat_vector_to_arrow_array;
 use vortex::ArrayRef;
 use vortex::arrays::DecimalArray;
-use vortex::arrow::FromArrowArray;
+use vortex::arrow::{ArrowNullability, FromArrowArray};
 use vortex::error::{VortexResult, vortex_err};
 
 use crate::FromDuckDB;
@@ -20,7 +20,7 @@ impl FromDuckDB<SizedFlatVector> for ArrayRef {
             .map_err(|e| vortex_err!("Failed to convert duckdb array to vortex: {}", e))?;
         Ok(ArrayRef::from_arrow(
             arrow_arr.as_ref(),
-            sized_vector.nullable,
+            ArrowNullability::from_top_level_is_nullable(sized_vector.nullable),
         ))
     }
 }

--- a/vortex-python/src/arrays/from_arrow.rs
+++ b/vortex-python/src/arrays/from_arrow.rs
@@ -6,7 +6,7 @@ use arrow::record_batch::RecordBatchReader;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use vortex::arrays::ChunkedArray;
-use vortex::arrow::FromArrowArray;
+use vortex::arrow::{ArrowNullability, FromArrowArray};
 use vortex::dtype::DType;
 use vortex::dtype::arrow::FromArrowType;
 use vortex::error::{VortexError, VortexResult};
@@ -23,8 +23,10 @@ pub(super) fn from_arrow(obj: &Bound<'_, PyAny>) -> PyResult<PyArrayRef> {
 
     if obj.is_instance(&pa_array)? {
         let arrow_array = ArrowArrayData::from_pyarrow_bound(obj).map(make_array)?;
-        let is_nullable = arrow_array.is_nullable();
-        let enc_array = ArrayRef::from_arrow(arrow_array.as_ref(), is_nullable);
+        let enc_array = ArrayRef::from_arrow(
+            arrow_array.as_ref(),
+            ArrowNullability::from_top_level_is_nullable(arrow_array.is_nullable()),
+        );
         Ok(PyArrayRef::from(enc_array))
     } else if obj.is_instance(&chunked_array)? {
         let chunks: Vec<Bound<PyAny>> = obj.getattr("chunks")?.extract()?;
@@ -33,7 +35,7 @@ pub(super) fn from_arrow(obj: &Bound<'_, PyAny>) -> PyResult<PyArrayRef> {
             .map(|a| {
                 ArrowArrayData::from_pyarrow_bound(a)
                     .map(make_array)
-                    .map(|a| ArrayRef::from_arrow(a.as_ref(), false))
+                    .map(|a| ArrayRef::from_arrow(a.as_ref(), ArrowNullability::NonNullable))
             })
             .collect::<PyResult<Vec<_>>>()?;
         let dtype: DType = obj


### PR DESCRIPTION
Arrow permits non-nullable struct array fields to contain nulls if the containing struct array "masks" this null. This is explicitly checked in
[StructArray::try_new](https://github.com/apache/arrow-rs/blob/55.1.0/arrow-array/src/array/struct_array.rs#L169-L180). Lists appear to allow the same situation.

As written, Vortex panics if a null appears in any non-nullable array, even if the array is a field of a struct array. This PR fixes that. It, lamentably, introduces `ArrowNullability` an enum representing these three states: nullable, not nullable, and "not nullable, but a null might appear because this is a field array". I *do not* check that the containing struct or list masks this null because Arrow checked that on creation.

See also: https://spiraldb.slack.com/archives/C07BV3GKAJ2/p1748562330640079