### PR TITLE
ci: fix JAR packaging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,8 +138,8 @@ jobs:
       matrix:
         target:
           - { os: macos, runs-on: "macos-latest", target: aarch64-apple-darwin }
-          - { os: ubuntu, runs-on: "ubuntu-latest", target: aarch64-unknown-linux-gnu }
-          - { os: ubuntu, runs-on: "ubuntu-24.04-arm", target: x86_64-unknown-linux-gnu }
+          - { os: ubuntu, runs-on: "ubuntu-24.04-arm", target: aarch64-unknown-linux-gnu }
+          - { os: ubuntu, runs-on: "ubuntu-latest", target: x86_64-unknown-linux-gnu }
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
#3306 seems to have broken publish for JARs by swapping the architectures for the Java x86 and ARM native libs.

This PR switches them back.