### PR TITLE
Use foldhash for counting instances

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -4,3 +4,8 @@ allow-unwrap-in-tests = true
 single-char-binding-names-threshold = 2
 # We prefer using parking_lot for improved ergonomics and performance.
 disallowed-types = ["std::collections::HashMap", "std::collections::HashSet", "std::sync::Mutex", "std::sync::RwLock"]
+
+disallowed-methods = [
+    # It uses the default hasher and is very easy to just inline with a faster implementation
+    "itertools::Itertools::counts"
+    ]

--- a/encodings/alp/src/alp_rd/mod.rs
+++ b/encodings/alp/src/alp_rd/mod.rs
@@ -346,11 +346,12 @@ fn build_left_parts_dictionary<T: ALPRDFloat>(
     );
 
     // Count the number of occurrences of each left bit pattern
-    let counts = samples
+    let mut counts = HashMap::new();
+    samples
         .iter()
         .copied()
         .map(|v| <T as ALPRDFloat>::to_u16(T::to_bits(v).shr(right_bw as _)))
-        .counts();
+        .for_each(|item| *counts.entry(item).or_default() += 1);
 
     // Sorted counts: sort by negative count so that heavy hitters sort first.
     let mut sorted_bit_counts: Vec<(u16, usize)> = counts.into_iter().collect_vec();


### PR DESCRIPTION
`Itertools::counts()` uses the default std hasher which we know is worse, this just inlines it and uses foldhash from hashbrown.