### PR TITLE
feat: Make `Identifier` an enum

### DIFF
--- a/vortex-expr/src/let_.rs
+++ b/vortex-expr/src/let_.rs
@@ -47,7 +47,7 @@ pub(crate) mod proto {
             };
 
             Ok(Let::new_expr(
-                op.var.clone().into(),
+                op.var.clone().parse()?,
                 children[0].clone(),
                 children[1].clone(),
             ))
@@ -108,8 +108,8 @@ impl PartialEq for Let {
     }
 }
 
-pub fn let_(var: impl Into<Identifier>, bind: ExprRef, expr: ExprRef) -> ExprRef {
-    Let::new_expr(var.into(), bind, expr)
+pub fn let_(ident: Identifier, bind: ExprRef, expr: ExprRef) -> ExprRef {
+    Let::new_expr(ident, bind, expr)
 }
 
 #[cfg(test)]
@@ -132,9 +132,13 @@ mod tests {
             .to_array();
 
         let expr = let_(
-            "x",
+            "x".parse().unwrap(),
             get_item_scope("a1"),
-            let_("y", get_item_scope("a2"), eq(var("x"), var("y"))),
+            let_(
+                "y".parse().unwrap(),
+                get_item_scope("a2"),
+                eq(var("x".parse().unwrap()), var("y".parse().unwrap())),
+            ),
         );
         let res = expr.evaluate(&Scope::new(struct_arr)).unwrap();
         let res = res.to_bool().unwrap().boolean_buffer().iter().collect_vec();

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -93,7 +93,6 @@ pub trait VortexExpr:
     fn as_any(&self) -> &dyn Any;
 
     /// Compute result of expression on given batch producing a new batch
-    ///
     fn evaluate(&self, scope: &Scope) -> VortexResult<ArrayRef> {
         let result = self.unchecked_evaluate(scope)?;
         assert_eq!(

--- a/vortex-expr/src/pruning/pruning_predicate.rs
+++ b/vortex-expr/src/pruning/pruning_predicate.rs
@@ -132,8 +132,8 @@ mod tests {
     use crate::pruning::pruning_predicate::{HashMap, pruning_expr};
     use crate::pruning::{PruningPredicate, stat_field_name};
     use crate::{
-        HashSet, IDENTITY_IDENTIFIER, and, col, eq, get_item, get_item_scope, gt, gt_eq, lit, lt,
-        lt_eq, not_eq, or, root,
+        HashSet, Identifier, and, col, eq, get_item, get_item_scope, gt, gt_eq, lit, lt, lt_eq,
+        not_eq, or, root,
     };
 
     #[test]
@@ -169,11 +169,11 @@ mod tests {
             refs.map(),
             &HashMap::from_iter([
                 (
-                    (IDENTITY_IDENTIFIER.into(), FieldPath::from_name(&column)),
+                    (Identifier::Identity, FieldPath::from_name(&column)),
                     HashSet::from_iter([Stat::Min, Stat::Max])
                 ),
                 (
-                    (IDENTITY_IDENTIFIER.into(), FieldPath::from_name(&other_col)),
+                    (Identifier::Identity, FieldPath::from_name(&other_col)),
                     HashSet::from_iter([Stat::Max, Stat::Min])
                 )
             ])
@@ -205,11 +205,11 @@ mod tests {
             refs.map(),
             &HashMap::from_iter([
                 (
-                    (IDENTITY_IDENTIFIER.into(), FieldPath::from_name(&column)),
+                    (Identifier::Identity, FieldPath::from_name(&column)),
                     HashSet::from_iter([Stat::Min, Stat::Max])
                 ),
                 (
-                    (IDENTITY_IDENTIFIER.into(), FieldPath::from_name(&other_col)),
+                    (Identifier::Identity, FieldPath::from_name(&other_col)),
                     HashSet::from_iter([Stat::Max, Stat::Min])
                 )
             ])
@@ -240,11 +240,11 @@ mod tests {
             refs.map(),
             &HashMap::from_iter([
                 (
-                    (IDENTITY_IDENTIFIER.into(), FieldPath::from_name(&column)),
+                    (Identifier::Identity, FieldPath::from_name(&column)),
                     HashSet::from_iter([Stat::Max])
                 ),
                 (
-                    (IDENTITY_IDENTIFIER.into(), FieldPath::from_name(&other_col)),
+                    (Identifier::Identity, FieldPath::from_name(&other_col)),
                     HashSet::from_iter([Stat::Min])
                 )
             ])
@@ -266,7 +266,7 @@ mod tests {
         assert_eq!(
             refs.map(),
             &HashMap::from_iter([(
-                (IDENTITY_IDENTIFIER.into(), FieldPath::from_name(&column)),
+                (Identifier::Identity, FieldPath::from_name(&column)),
                 HashSet::from_iter([Stat::Max])
             ),])
         );
@@ -289,11 +289,11 @@ mod tests {
             refs.map(),
             &HashMap::from_iter([
                 (
-                    (IDENTITY_IDENTIFIER.into(), FieldPath::from_name(&column)),
+                    (Identifier::Identity, FieldPath::from_name(&column)),
                     HashSet::from_iter([Stat::Min])
                 ),
                 (
-                    (IDENTITY_IDENTIFIER.into(), FieldPath::from_name(&other_col)),
+                    (Identifier::Identity, FieldPath::from_name(&other_col)),
                     HashSet::from_iter([Stat::Max])
                 )
             ])
@@ -315,7 +315,7 @@ mod tests {
         assert_eq!(
             refs.map(),
             &HashMap::from_iter([(
-                (IDENTITY_IDENTIFIER.into(), FieldPath::from_name(&column)),
+                (Identifier::Identity, FieldPath::from_name(&column)),
                 HashSet::from_iter([Stat::Min])
             )])
         );

--- a/vortex-expr/src/scope.rs
+++ b/vortex-expr/src/scope.rs
@@ -6,18 +6,49 @@ use vortex_array::{Array, ArrayRef};
 use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_err};
 
-use crate::IDENTITY_IDENTIFIER;
-
-pub type Identifier = Arc<str>;
 type ExprScope<T> = HashMap<Identifier, T>;
 
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub enum Identifier {
+    Identity,
+    Other(Arc<str>),
+}
+
+impl From<String> for Identifier {
+    fn from(value: String) -> Self {
+        Self::Other(value.into())
+    }
+}
+
+impl From<&str> for Identifier {
+    fn from(value: &str) -> Self {
+        Self::Other(value.into())
+    }
+}
+
+impl Identifier {
+    pub fn is_identity(&self) -> bool {
+        matches!(self, Self::Identity)
+    }
+}
+
+impl std::fmt::Display for Identifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Identifier::Identity => write!(f, "$"),
+            Identifier::Other(v) => write!(f, "{}", v),
+        }
+    }
+}
+
+/// The evaluation scope for an expression, all variables are evaluated relatively to the data it contains.
+/// It allows for expressions to access fields and previously defined data by [`Identifier`].
 #[derive(Clone, Default)]
 pub struct Scope {
     array_len: usize,
     root_scope: Option<ArrayRef>,
     /// A map from identifiers to arrays
-    values: ExprScope<ArrayRef>,
-    #[allow(dead_code)]
+    arrays: ExprScope<ArrayRef>,
     /// A map identifiers to opaque values used by expressions, but
     /// cannot affect the result type/shape.
     vars: ExprScope<Arc<dyn Any + Send + Sync>>,
@@ -39,16 +70,12 @@ impl Scope {
         }
     }
 
-    pub fn values(&self, id: &Identifier) -> VortexResult<&ArrayRef> {
-        if id.as_ref() == IDENTITY_IDENTIFIER {
-            return self
-                .root_scope
-                .as_ref()
-                .ok_or_else(|| vortex_err!("no root scope"));
+    /// Get a value out of the scope by its [`Identifier`]
+    pub fn array(&self, id: &Identifier) -> Option<&ArrayRef> {
+        if id.is_identity() {
+            return self.root_scope.as_ref();
         }
-        self.values
-            .get(id)
-            .ok_or_else(|| vortex_err!("cannot find {} in values scope", id))
+        self.arrays.get(id)
     }
 
     pub fn vars(&self, id: Identifier) -> VortexResult<&Arc<dyn Any + Send + Sync>> {
@@ -66,17 +93,18 @@ impl Scope {
     }
 
     pub fn copy_with_value(&self, ident: Identifier, value: ArrayRef) -> Self {
-        self.clone().with_value(ident, value)
+        self.clone().with_array(ident, value)
     }
 
-    pub fn with_value(mut self, ident: impl Into<Identifier>, value: ArrayRef) -> Self {
+    /// Register an array with an identifier in the scope, overriding any existing value stored in it.
+    pub fn with_array(mut self, ident: impl Into<Identifier>, value: ArrayRef) -> Self {
         assert_eq!(value.len(), self.len());
         let ident = ident.into();
 
-        if ident.as_ref() == IDENTITY_IDENTIFIER {
+        if ident.is_identity() {
             self.root_scope = Some(value);
         } else {
-            self.values.insert(ident, value);
+            self.arrays.insert(ident, value);
         }
         self
     }
@@ -84,6 +112,12 @@ impl Scope {
     pub fn with_var(mut self, ident: Identifier, var: Arc<dyn Any + Send + Sync>) -> Self {
         self.vars.insert(ident, var);
         self
+    }
+}
+
+impl From<ArrayRef> for Scope {
+    fn from(value: ArrayRef) -> Self {
+        Self::new(value)
     }
 }
 
@@ -98,7 +132,7 @@ impl From<&Scope> for ScopeDType {
         Self {
             root: ctx.root_scope.as_ref().map(|s| s.dtype().clone()),
             types: HashMap::from_iter(
-                ctx.values
+                ctx.arrays
                     .iter()
                     .map(|(k, v)| (k.clone(), v.dtype().clone())),
             ),
@@ -114,16 +148,11 @@ impl ScopeDType {
         }
     }
 
-    pub fn dtype(&self, id: &Identifier) -> VortexResult<&DType> {
-        if id.as_ref() == IDENTITY_IDENTIFIER {
-            return self
-                .root
-                .as_ref()
-                .ok_or_else(|| vortex_err!("missing root type"));
+    pub fn dtype(&self, id: &Identifier) -> Option<&DType> {
+        if id.is_identity() {
+            return self.root.as_ref();
         }
-        self.types
-            .get(id)
-            .ok_or_else(|| vortex_err!("cannot find {} in values scope", id))
+        self.types.get(id)
     }
 
     pub fn copy_with_value(&self, ident: Identifier, dtype: DType) -> Self {
@@ -131,7 +160,7 @@ impl ScopeDType {
     }
 
     pub fn with_value(mut self, ident: Identifier, dtype: DType) -> Self {
-        if ident.as_ref() == IDENTITY_IDENTIFIER {
+        if ident.is_identity() {
             self.root = Some(dtype);
         } else {
             self.types.insert(ident, dtype);

--- a/vortex-expr/src/scope.rs
+++ b/vortex-expr/src/scope.rs
@@ -1,10 +1,11 @@
 use std::any::Any;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use vortex_array::aliases::hash_map::HashMap;
 use vortex_array::{Array, ArrayRef};
 use vortex_dtype::DType;
-use vortex_error::{VortexResult, vortex_err};
+use vortex_error::{VortexError, VortexResult, vortex_bail, vortex_err};
 
 type ExprScope<T> = HashMap<Identifier, T>;
 
@@ -14,15 +15,15 @@ pub enum Identifier {
     Other(Arc<str>),
 }
 
-impl From<String> for Identifier {
-    fn from(value: String) -> Self {
-        Self::Other(value.into())
-    }
-}
+impl FromStr for Identifier {
+    type Err = VortexError;
 
-impl From<&str> for Identifier {
-    fn from(value: &str) -> Self {
-        Self::Other(value.into())
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            vortex_bail!("Empty strings aren't allowed in identifiers")
+        } else {
+            Ok(Identifier::Other(s.into()))
+        }
     }
 }
 
@@ -35,7 +36,7 @@ impl Identifier {
 impl std::fmt::Display for Identifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Identifier::Identity => write!(f, "$"),
+            Identifier::Identity => write!(f, ""),
             Identifier::Other(v) => write!(f, "{}", v),
         }
     }
@@ -97,9 +98,8 @@ impl Scope {
     }
 
     /// Register an array with an identifier in the scope, overriding any existing value stored in it.
-    pub fn with_array(mut self, ident: impl Into<Identifier>, value: ArrayRef) -> Self {
+    pub fn with_array(mut self, ident: Identifier, value: ArrayRef) -> Self {
         assert_eq!(value.len(), self.len());
-        let ident = ident.into();
 
         if ident.is_identity() {
             self.root_scope = Some(value);

--- a/vortex-expr/src/var.rs
+++ b/vortex-expr/src/var.rs
@@ -1,11 +1,11 @@
 use std::any::Any;
 use std::fmt::Display;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use vortex_array::ArrayRef;
 use vortex_array::stats::Stat;
 use vortex_dtype::{DType, FieldPath};
-use vortex_error::VortexResult;
+use vortex_error::{VortexResult, vortex_err};
 
 use crate::{AnalysisExpr, ExprRef, Identifier, Scope, ScopeDType, StatsCatalog, VortexExpr};
 
@@ -89,7 +89,9 @@ impl VortexExpr for Var {
     }
 
     fn unchecked_evaluate(&self, ctx: &Scope) -> VortexResult<ArrayRef> {
-        ctx.values(&self.var).cloned()
+        ctx.array(&self.var)
+            .cloned()
+            .ok_or_else(|| vortex_err!("cannot find '{}' in arrays scope", self.var))
     }
 
     fn children(&self) -> Vec<&ExprRef> {
@@ -102,7 +104,10 @@ impl VortexExpr for Var {
     }
 
     fn return_dtype(&self, dt_ctx: &ScopeDType) -> VortexResult<DType> {
-        dt_ctx.dtype(&self.var).cloned()
+        dt_ctx
+            .dtype(&self.var)
+            .cloned()
+            .ok_or_else(|| vortex_err!("cannot find '{}' in dtype scope", self.var))
     }
 }
 
@@ -111,18 +116,17 @@ pub fn var(var: impl Into<Identifier>) -> ExprRef {
 }
 
 pub const IDENTITY_IDENTIFIER: &str = "";
-static IDENTITY: LazyLock<ExprRef> = LazyLock::new(|| Var::new_expr(IDENTITY_IDENTIFIER.into()));
 
 /// Return a global pointer to the identity token.
 /// This is the name of the data found in a vortex array or file.
 pub fn root() -> ExprRef {
-    IDENTITY.clone()
+    Var::new_expr(Identifier::Identity)
 }
 
 pub fn is_root(expr: &ExprRef) -> bool {
     expr.as_any()
         .downcast_ref::<Var>()
-        .is_some_and(|v| v.var().as_ref() == "")
+        .is_some_and(|v| v.var().is_identity())
 }
 
 #[cfg(test)]
@@ -142,7 +146,7 @@ mod tests {
 
         let expr = eq(var(""), var("row"));
         let res = expr
-            .evaluate(&Scope::new(a1).with_value("row", a2))
+            .evaluate(&Scope::new(a1).with_array("row", a2))
             .unwrap();
         let res = res.to_bool().unwrap().boolean_buffer().iter().collect_vec();
 

--- a/vortex-expr/src/var.rs
+++ b/vortex-expr/src/var.rs
@@ -27,8 +27,7 @@ impl Var {
 #[cfg(feature = "proto")]
 pub(crate) mod proto {
     use vortex_error::{VortexResult, vortex_bail};
-    use vortex_proto::expr::kind;
-    use vortex_proto::expr::kind::Kind;
+    use vortex_proto::expr::kind::{Kind, Var as ProtoVar};
 
     use crate::{ExprDeserialize, ExprRef, ExprSerializable, Id, Var};
 
@@ -46,7 +45,10 @@ pub(crate) mod proto {
                 vortex_bail!("wrong kind {:?}, wanted var", kind)
             };
 
-            Ok(Var::new_expr(op.var.clone().into()))
+            match op.var.as_str() {
+                "" => Ok(Var::new_expr(crate::Identifier::Identity)),
+                other => Ok(Var::new_expr(other.parse()?)),
+            }
         }
     }
 
@@ -56,7 +58,7 @@ pub(crate) mod proto {
         }
 
         fn serialize_kind(&self) -> VortexResult<Kind> {
-            Ok(Kind::Var(kind::Var {
+            Ok(Kind::Var(ProtoVar {
                 var: self.var.to_string(),
             }))
         }
@@ -111,11 +113,9 @@ impl VortexExpr for Var {
     }
 }
 
-pub fn var(var: impl Into<Identifier>) -> ExprRef {
-    Var::new_expr(var.into())
+pub fn var(ident: Identifier) -> ExprRef {
+    Var::new_expr(ident)
 }
-
-pub const IDENTITY_IDENTIFIER: &str = "";
 
 /// Return a global pointer to the identity token.
 /// This is the name of the data found in a vortex array or file.
@@ -131,25 +131,32 @@ pub fn is_root(expr: &ExprRef) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use itertools::Itertools;
     use vortex_array::ToCanonical;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
 
-    use crate::{Scope, eq, var};
+    use crate::{Identifier, Scope, eq, var};
 
     #[test]
     fn test_two_vars() {
         let a1 = PrimitiveArray::new(buffer![5, 4, 3, 2, 1, 0], Validity::AllValid).to_array();
         let a2 = PrimitiveArray::from_iter(1..=6).to_array();
 
-        let expr = eq(var(""), var("row"));
+        let expr = eq(var(Identifier::Identity), var("row".parse().unwrap()));
         let res = expr
-            .evaluate(&Scope::new(a1).with_array("row", a2))
+            .evaluate(&Scope::new(a1).with_array("row".parse().unwrap(), a2))
             .unwrap();
         let res = res.to_bool().unwrap().boolean_buffer().iter().collect_vec();
 
         assert_eq!(res, vec![false, false, true, false, false, false])
+    }
+
+    #[test]
+    fn test_empty_string_ident_not_allowed() {
+        assert!(Identifier::from_str("").is_err());
     }
 }


### PR DESCRIPTION
Using an empty string as a sentinel value for the "identity" identifier seems bug-prune, and the API isn't very ergonomic.

The naming in this PR is a bit atrocious, but I'm more than open to suggestions.

Also added some comments that made sense to me but might not be 100% correct or clear.