### PR TITLE
Use set instead of map to count distinct values in float compressor

### DIFF
--- a/fuzz/fuzz_targets/file_io.rs
+++ b/fuzz/fuzz_targets/file_io.rs
@@ -5,6 +5,7 @@ use arrow_ord::ord::make_comparator;
 use arrow_ord::sort::SortOptions;
 use futures_util::TryStreamExt;
 use libfuzzer_sys::{Corpus, fuzz_target};
+use vortex_array::aliases::DefaultHashBuilder;
 use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::arrays::arbitrary::ArbitraryArray;
@@ -131,7 +132,8 @@ fn has_duplicate_field_names(dtype: &DType) -> bool {
 }
 
 fn struct_has_duplicate_names(struct_dtype: &StructFields) -> bool {
-    HashSet::from_iter(struct_dtype.names().iter()).len() != struct_dtype.names().len()
+    HashSet::<_, DefaultHashBuilder>::from_iter(struct_dtype.names().iter()).len()
+        != struct_dtype.names().len()
         || struct_dtype
             .fields()
             .any(|dtype| has_duplicate_field_names(&dtype))

--- a/vortex-array/src/aliases/hash_set.rs
+++ b/vortex-array/src/aliases/hash_set.rs
@@ -1,3 +1,3 @@
-pub type HashSet<V> = hashbrown::HashSet<V>;
+pub type HashSet<V, S = super::DefaultHashBuilder> = hashbrown::HashSet<V, S>;
 pub type Entry<'a, V, S> = hashbrown::hash_set::Entry<'a, V, S>;
 pub type IntoIter<V> = hashbrown::hash_set::IntoIter<V>;

--- a/vortex-btrblocks/src/float/dictionary.rs
+++ b/vortex-btrblocks/src/float/dictionary.rs
@@ -13,7 +13,7 @@ use crate::float::stats::{ErasedDistinctValues, FloatStats};
 
 macro_rules! typed_encode {
     ($stats:ident, $typed:ident, $validity:ident, $typ:ty) => {{
-        let values: Buffer<$typ> = $typed.values.keys().map(|x| x.0).collect();
+        let values: Buffer<$typ> = $typed.values.iter().map(|x| x.0).collect();
 
         let max_code = values.len();
         let codes = if max_code <= u8::MAX as usize {

--- a/vortex-btrblocks/src/float/stats.rs
+++ b/vortex-btrblocks/src/float/stats.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use num_traits::Float;
 use rustc_hash::FxBuildHasher;
 use vortex_array::ToCanonical;
-use vortex_array::aliases::hash_map::HashMap;
+use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::arrays::{NativeValue, PrimitiveArray, PrimitiveVTable};
 use vortex_dtype::half::f16;
 use vortex_dtype::{NativePType, PType};
@@ -16,7 +16,7 @@ use crate::{CompressorStats, GenerateStatsOptions};
 
 #[derive(Debug, Clone)]
 pub struct DistinctValues<T> {
-    pub values: HashMap<NativeValue<T>, u32, FxBuildHasher>,
+    pub values: HashSet<NativeValue<T>, FxBuildHasher>,
 }
 
 #[derive(Debug, Clone)]
@@ -95,7 +95,7 @@ where
             average_run_length: 0,
             distinct_values_count: 0,
             distinct_values: DistinctValues {
-                values: HashMap::<NativeValue<T>, u32, FxBuildHasher>::with_hasher(FxBuildHasher),
+                values: HashSet::<NativeValue<T>, FxBuildHasher>::with_hasher(FxBuildHasher),
             }
             .into(),
         };
@@ -107,7 +107,7 @@ where
             average_run_length: 0,
             distinct_values_count: 0,
             distinct_values: DistinctValues {
-                values: HashMap::<NativeValue<T>, u32, FxBuildHasher>::with_hasher(FxBuildHasher),
+                values: HashSet::<NativeValue<T>, FxBuildHasher>::with_hasher(FxBuildHasher),
             }
             .into(),
         };
@@ -122,9 +122,9 @@ where
     // Keep a HashMap of T, then convert the keys into PValue afterward since value is
     // so much more efficient to hash and search for.
     let mut distinct_values = if count_distinct_values {
-        HashMap::with_capacity_and_hasher(array.len() / 2, FxBuildHasher)
+        HashSet::with_capacity_and_hasher(array.len() / 2, FxBuildHasher)
     } else {
-        HashMap::with_hasher(FxBuildHasher)
+        HashSet::with_hasher(FxBuildHasher)
     };
 
     let validity = array.validity_mask().vortex_expect("logical_validity");
@@ -141,7 +141,7 @@ where
         AllOr::All => {
             for value in first_valid_buff {
                 if count_distinct_values {
-                    *distinct_values.entry(NativeValue(value)).or_insert(0) += 1;
+                    distinct_values.insert(NativeValue(value));
                 }
 
                 if value != prev {
@@ -158,7 +158,7 @@ where
             {
                 if valid {
                     if count_distinct_values {
-                        *distinct_values.entry(NativeValue(value)).or_insert(0) += 1;
+                        distinct_values.insert(NativeValue(value));
                     }
 
                     if value != prev {

--- a/vortex-layout/src/layouts/struct_/writer.rs
+++ b/vortex-layout/src/layouts/struct_/writer.rs
@@ -8,6 +8,7 @@ use futures::future::try_join_all;
 use futures::{Stream, StreamExt};
 use itertools::Itertools;
 use parking_lot::Mutex;
+use vortex_array::aliases::DefaultHashBuilder;
 use vortex_array::aliases::hash_set::HashSet;
 use vortex_array::{ArrayContext, ToCanonical};
 use vortex_error::{VortexExpect as _, VortexResult, vortex_bail};
@@ -42,7 +43,9 @@ impl LayoutStrategy for StructStrategy {
             // nothing we can do if dtype is not struct
             return self.child.write_stream(ctx, sequence_writer, stream);
         };
-        if HashSet::from_iter(struct_dtype.names().iter()).len() != struct_dtype.names().len() {
+        if HashSet::<_, DefaultHashBuilder>::from_iter(struct_dtype.names().iter()).len()
+            != struct_dtype.names().len()
+        {
             return Box::pin(async { vortex_bail!("StructLayout must have unique field names") });
         }
 


### PR DESCRIPTION
Just seems like the values aren't actually used anywhere and its extra work that popped out while profiling some benchmark