### PR TITLE
chore: Fix comments that could be rustdoc

### DIFF
--- a/bench-vortex/src/tpch/dbgen.rs
+++ b/bench-vortex/src/tpch/dbgen.rs
@@ -160,7 +160,7 @@ impl Display for Platform {
 // Increment this when we release new tpch-dbgen.
 const DBGEN_VERSION: &str = "0.1.0";
 
-// Return a handle to the downloaded toolchain.
+/// Return a handle to the downloaded toolchain.
 fn get_cached_dbgen<P: AsRef<Path>>(cache_dir: P) -> anyhow::Result<PathBuf> {
     if cfg!(target_os = "macos") {
         return get_or_cache_toolchain(cache_dir.as_ref(), DBGEN_VERSION, Platform::MacOS);

--- a/bench-vortex/src/tpch/mod.rs
+++ b/bench-vortex/src/tpch/mod.rs
@@ -35,7 +35,7 @@ pub const EXPECTED_ROW_COUNTS_SF10: [usize; TPC_H_ROW_COUNT_ARRAY_LENGTH] = [
     0, 4, 100, 10, 5, 5, 1, 4, 2, 175, 20, 0, 2, 45, 1, 1, 27840, 1, 100, 1, 1804, 100, 7,
 ];
 
-// Generate table dataset.
+/// Generate table dataset.
 pub async fn load_datasets(
     base_dir: &Url,
     format: Format,

--- a/encodings/alp/src/alp/compute/compare.rs
+++ b/encodings/alp/src/alp/compute/compare.rs
@@ -48,9 +48,9 @@ impl CompareKernel for ALPVTable {
 
 register_kernel!(CompareKernelAdapter(ALPVTable).lift());
 
-// We can compare a scalar to an ALPArray by encoding the scalar into the ALP domain and comparing
-// the encoded value to the encoded values in the ALPArray. There are fixups when the value doesn't
-// encode into the ALP domain.
+/// We can compare a scalar to an ALPArray by encoding the scalar into the ALP domain and comparing
+/// the encoded value to the encoded values in the ALPArray. There are fixups when the value doesn't
+/// encode into the ALP domain.
 fn alp_scalar_compare<F: ALPFloat + Into<Scalar>>(
     alp: &ALPArray,
     value: F,

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -16,9 +16,9 @@ use vortex_error::{VortexExpect as _, VortexResult};
 use super::chunked_indices;
 use crate::{BitPackedArray, BitPackedVTable, unpack_single_primitive};
 
-// assuming the buffer is already allocated (which will happen at most once) then unpacking
-// all 1024 elements takes ~8.8x as long as unpacking a single element on an M2 Macbook Air.
-// see https://github.com/vortex-data/vortex/pull/190#issue-2223752833
+/// assuming the buffer is already allocated (which will happen at most once) then unpacking
+/// all 1024 elements takes ~8.8x as long as unpacking a single element on an M2 Macbook Air.
+/// see https://github.com/vortex-data/vortex/pull/190#issue-2223752833
 pub(super) const UNPACK_CHUNK_THRESHOLD: usize = 8;
 
 impl TakeKernel for BitPackedVTable {

--- a/encodings/fsst/benches/fsst_compress.rs
+++ b/encodings/fsst/benches/fsst_compress.rs
@@ -131,7 +131,7 @@ fn chunked_into_canonical(
         .bench_values(|array| array.to_canonical().unwrap());
 }
 
-// Helper function to generate random string data.
+/// Helper function to generate random string data.
 fn generate_test_data(string_count: usize, avg_len: usize, unique_chars: u8) -> VarBinArray {
     let mut rng = StdRng::seed_from_u64(0);
     let mut strings = Vec::with_capacity(string_count);

--- a/encodings/fsst/src/tests.rs
+++ b/encodings/fsst/src/tests.rs
@@ -13,7 +13,7 @@ macro_rules! assert_nth_scalar {
     };
 }
 
-// this function is VERY slow on miri, so we only want to run it once
+/// this function is VERY slow on miri, so we only want to run it once
 fn build_fsst_array() -> ArrayRef {
     let mut input_array = VarBinBuilder::<i32>::with_capacity(3);
     input_array.append_value(b"The Greeks never said that the limit could not be overstepped");

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -35,7 +35,7 @@ impl SequenceArray {
         Self::new(base.into(), multiplier.into(), T::PTYPE, length)
     }
 
-    // Constructs a sequence array using two integer values (with the same ptype).
+    /// Constructs a sequence array using two integer values (with the same ptype).
     pub fn new(
         base: PValue,
         multiplier: PValue,
@@ -119,7 +119,7 @@ impl SequenceArray {
         })
     }
 
-    // Return the validated final value of a sequence array
+    /// Returns the validated final value of a sequence array
     pub fn last(&self) -> PValue {
         Self::try_last(self.base, self.multiplier, self.ptype(), self.length)
             .vortex_expect("validated array")

--- a/vortex-array/src/arrays/chunked/compute/filter.rs
+++ b/vortex-array/src/arrays/chunked/compute/filter.rs
@@ -175,8 +175,8 @@ fn filter_indices(
     Ok(result)
 }
 
-// Mirrors the find_chunk_idx method on ChunkedArray, but avoids all of the overhead
-// from scalars, dtypes, and metadata cloning.
+/// Mirrors the find_chunk_idx method on ChunkedArray, but avoids all of the overhead
+/// from scalars, dtypes, and metadata cloning.
 pub(crate) fn find_chunk_idx(idx: usize, chunk_ends: &[u64]) -> (usize, usize) {
     let chunk_id = chunk_ends
         .search_sorted(&(idx as u64), SearchSortedSide::Right)

--- a/vortex-array/src/arrays/primitive/compute/is_constant.rs
+++ b/vortex-array/src/arrays/primitive/compute/is_constant.rs
@@ -36,8 +36,8 @@ impl IsConstantKernel for PrimitiveVTable {
 
 register_kernel!(IsConstantKernelAdapter(PrimitiveVTable).lift());
 
-// Assumes any floating point has been cast into its bit representation for which != and !is_eq are the same
-// Assumes there's at least 1 value in the slice, which is an invariant of the entry level function.
+/// Assumes any floating point has been cast into its bit representation for which != and !is_eq are the same
+/// Assumes there's at least 1 value in the slice, which is an invariant of the entry level function.
 pub fn compute_is_constant<T: NativePType, const WIDTH: usize>(values: &[T]) -> bool {
     let first_value = values[0];
     let first_vec = &[first_value; WIDTH];

--- a/vortex-array/src/arrays/varbinview/mod.rs
+++ b/vortex-array/src/arrays/varbinview/mod.rs
@@ -465,7 +465,7 @@ impl VarBinViewArray {
     }
 }
 
-// Generic helper to create an Arrow ByteViewBuilder of the appropriate type.
+/// Generic helper to create an Arrow ByteViewBuilder of the appropriate type.
 fn generic_byte_view_builder<B, V, F>(
     values: impl Iterator<Item = Option<V>>,
     mut append_fn: F,

--- a/vortex-array/src/builders/decimal.rs
+++ b/vortex-array/src/builders/decimal.rs
@@ -12,10 +12,11 @@ use crate::builders::lazy_validity_builder::LazyNullBufferBuilder;
 use crate::validity::Validity;
 use crate::{Array, ArrayRef, IntoArray, ToCanonical};
 
-// Wrapper around the typed builder.
-// We want to be able to downcast a Box<dyn ArrayBuilder> to a DecimalBuilder and we generally
-// don't have enough type information to get the `T` at the call site, so we instead use this
-// to hold values and can push values into the correct buffer type generically.
+/// Wrapper around the typed builder.
+///
+/// We want to be able to downcast a `Box<dyn ArrayBuilder>` to a [`DecimalBuilder`] and we generally
+/// don't have enough type information to get the `T` at the call site, so we instead use this
+/// to hold values and can push values into the correct buffer type generically.
 enum DecimalBuffer {
     I8(BufferMut<i8>),
     I16(BufferMut<i16>),

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -47,7 +47,7 @@ pub enum Canonical {
 }
 
 impl Canonical {
-    // Create an empty canonical array of the given dtype.
+    /// Create an empty canonical array of the given dtype.
     pub fn empty(dtype: &DType) -> Canonical {
         builder_with_capacity(dtype, 0)
             .finish()

--- a/vortex-array/src/compute/list.rs
+++ b/vortex-array/src/compute/list.rs
@@ -219,8 +219,8 @@ fn list_is_not_empty(list_array: &ListArray) -> VortexResult<ArrayRef> {
     Ok(BoolArray::new(buffer, list_array.validity().clone()).into_array())
 }
 
-// Reduce each boolean values into a Mask that indicates which elements in the
-// ListArray contain the matching value.
+/// Reduces each boolean values into a Mask that indicates which elements in the
+/// ListArray contain the matching value.
 fn reduce_with_ends<T: NativePType + AsPrimitive<usize>>(
     ends: &[T],
     matches: &BooleanBuffer,

--- a/vortex-array/src/stats/bound.rs
+++ b/vortex-array/src/stats/bound.rs
@@ -50,7 +50,6 @@ impl<T: PartialOrd + Clone> StatBound<T> for LowerBound<T> {
         Self(value)
     }
 
-    // The meet or tightest covering bound
     fn union(&self, other: &Self) -> Option<LowerBound<T>> {
         Some(LowerBound(match (&self.0, &other.0) {
             (Exact(lhs), Exact(rhs)) => Exact(partial_min(lhs, rhs)?.clone()),

--- a/vortex-array/src/stats/stats_set.rs
+++ b/vortex-array/src/stats/stats_set.rs
@@ -39,7 +39,7 @@ impl StatsSet {
         stats
     }
 
-    // A convenience method for creating a stats set which will represent an empty array.
+    /// A convenience method for creating a stats set which will represent an empty array.
     pub fn empty_array() -> StatsSet {
         StatsSet::new_unchecked(vec![(Stat::NullCount, Precision::exact(0))])
     }
@@ -232,7 +232,7 @@ impl StatsSet {
         self
     }
 
-    // given two sets of stats (of differing precision) for the same array, combine them
+    /// Given two sets of stats (of differing precision) for the same array, combine them
     pub fn combine_sets(&mut self, other: &Self, dtype: &DType) -> VortexResult<()> {
         let other_stats: Vec<_> = other.values.iter().map(|(stat, _)| *stat).collect();
         for s in other_stats {

--- a/vortex-btrblocks/src/lib.rs
+++ b/vortex-btrblocks/src/lib.rs
@@ -47,11 +47,12 @@ const SAMPLE_SIZE: u32 = 64;
 pub trait CompressorStats: Debug + Clone {
     type ArrayVTable: VTable;
 
-    // Generate with options.
+    /// Generate stats with default options
     fn generate(input: &<Self::ArrayVTable as VTable>::Array) -> Self {
         Self::generate_opts(input, GenerateStatsOptions::default())
     }
 
+    /// Generate stats with provided options
     fn generate_opts(
         input: &<Self::ArrayVTable as VTable>::Array,
         opts: GenerateStatsOptions,

--- a/vortex-buffer/benches/vortex_buffer.rs
+++ b/vortex-buffer/benches/vortex_buffer.rs
@@ -12,7 +12,7 @@ fn main() {
     divan::main();
 }
 
-// We wrap the Arrow Buffer so the Divan output has a nice name!!
+/// Wraps an arrow buffer so Divan can provide a nice name
 pub struct Arrow<T>(T);
 
 impl<T: ArrowNativeType> FromIterator<T> for Arrow<ScalarBuffer<T>> {

--- a/vortex-buffer/src/spec_extend.rs
+++ b/vortex-buffer/src/spec_extend.rs
@@ -59,7 +59,7 @@ impl<T> BufferMut<T> {
     }
 }
 
-// Specialization trait used for BufferMut::extend
+/// Specialization trait used for BufferMut::extend
 pub(super) trait SpecExtend<T, I> {
     #[track_caller]
     fn spec_extend(&mut self, iter: I);

--- a/vortex-duckdb/src/convert/array/cache.rs
+++ b/vortex-duckdb/src/convert/array/cache.rs
@@ -9,7 +9,7 @@ use vortex::{Array, ArrayRef, Canonical, IntoArray};
 pub struct ConversionCache {
     pub values_cache: HashMap<usize, (ArrayRef, FlatVector)>,
     pub canonical_cache: HashMap<usize, (ArrayRef, Canonical)>,
-    // A value which must be unique for a given duckdb pipeline.
+    /// A value which must be unique for a given duckdb pipeline.
     pub instance_id: u64,
 }
 

--- a/vortex-duckdb/src/convert/types/from.rs
+++ b/vortex-duckdb/src/convert/types/from.rs
@@ -14,7 +14,7 @@ pub trait FromDuckDBType<A> {
 }
 
 impl FromDuckDBType<LogicalTypeHandle> for DType {
-    // Converts a DuckDB logical type handle to a `DType` based on the logical type ID.
+    /// Converts a DuckDB logical type handle to a `DType` based on the logical type ID.
     fn from_duckdb(type_: LogicalTypeHandle, nullable: Nullability) -> VortexResult<Self> {
         match type_.id() {
             LogicalTypeId::SQLNull => Ok(DType::Null),

--- a/vortex-expr/src/analysis.rs
+++ b/vortex-expr/src/analysis.rs
@@ -4,8 +4,8 @@ use vortex_dtype::FieldPath;
 use crate::{ExprRef, Identifier};
 
 pub trait StatsCatalog {
-    // Given an id, field and stat return an expression that when evaluated will return that stat
-    // this would be a column reference or a literal value, if the value is known at planning time.
+    /// Given an id, field and stat return an expression that when evaluated will return that stat
+    /// this would be a column reference or a literal value, if the value is known at planning time.
     fn stats_ref(&mut self, _id: &Identifier, _field: &FieldPath, _stat: Stat) -> Option<ExprRef> {
         None
     }

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -84,7 +84,7 @@ impl VortexFile {
         Ok(ScanBuilder::new(self.layout_reader()?).with_metrics(self.metrics.clone()))
     }
 
-    // Returns true if the expression will never match any rows in the file.
+    /// Returns true if the expression will never match any rows in the file.
     pub fn can_prune(&self, filter: &ExprRef) -> VortexResult<bool> {
         let Some((file_stats, struct_dtype)) = self
             .footer

--- a/vortex-python/src/scalar/factory.rs
+++ b/vortex-python/src/scalar/factory.rs
@@ -37,9 +37,9 @@ pub fn scalar_helper(value: &Bound<'_, PyAny>, dtype: Option<&DType>) -> PyResul
     }
 }
 
-// This function attempts to convert the python object to a scalar, with a hint of the expected
-// dtype. It can assume that the scalar_helper function will perform a final cast to the correct
-// dtype if necessary.
+/// Attempts to convert the python object to a scalar, with a hint of the expected
+/// dtype. It can assume that the scalar_helper function will perform a final cast to the correct
+/// dtype if necessary.
 fn scalar_helper_inner(value: &Bound<'_, PyAny>, dtype: Option<&DType>) -> PyResult<Scalar> {
     // If it's already a scalar, return it
     if let Ok(value) = value.downcast::<PyScalar>() {

--- a/vortex-tui/src/browse/ui/layouts.rs
+++ b/vortex-tui/src/browse/ui/layouts.rs
@@ -85,7 +85,7 @@ fn render_layout_header(cursor: &LayoutCursor, area: Rect, buf: &mut Buffer) {
     Widget::render(List::new(rows), inner_area, buf);
 }
 
-// Render the inner Array for a FlatLayout
+/// Render the inner Array for a FlatLayout
 fn render_array(app: &AppState, area: Rect, buf: &mut Buffer, is_stats_table: bool) {
     let row_count = app.cursor.layout().row_count();
     let reader = app


### PR DESCRIPTION
I was hoping to find a regex that can find those reliably, but there are too many false positives. For the record the last ripgrep command I used was;
```bash
rg -U '^\t*// [A-Za-z].*\n\t*(fn|pub|struct|trait|enum|type)' -g '*.rs'
```