### PR TITLE
feat: Initial limit pushdown in the scan

### DIFF
--- a/bench-vortex/src/bin/clickbench.rs
+++ b/bench-vortex/src/bin/clickbench.rs
@@ -25,7 +25,7 @@ use tracing::{debug, info_span};
 use tracing_futures::Instrument;
 use url::Url;
 use vortex::error::{VortexExpect, vortex_panic};
-use vortex_datafusion::persistent::metrics::VortexMetricsFinder;
+use vortex_datafusion::metrics::VortexMetricsFinder;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]

--- a/bench-vortex/src/bin/public_bi.rs
+++ b/bench-vortex/src/bin/public_bi.rs
@@ -13,7 +13,7 @@ use itertools::Itertools;
 use tracing::info_span;
 use tracing_futures::Instrument;
 use vortex::error::{VortexExpect, vortex_panic};
-use vortex_datafusion::persistent::metrics::VortexMetricsFinder;
+use vortex_datafusion::metrics::VortexMetricsFinder;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]

--- a/bench-vortex/src/bin/tpch.rs
+++ b/bench-vortex/src/bin/tpch.rs
@@ -30,7 +30,7 @@ use similar::{ChangeTag, TextDiff};
 use url::Url;
 use vortex::error::VortexExpect;
 use vortex::utils::aliases::hash_map::HashMap;
-use vortex_datafusion::persistent::metrics::VortexMetricsFinder;
+use vortex_datafusion::metrics::VortexMetricsFinder;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]

--- a/bench-vortex/src/clickbench.rs
+++ b/bench-vortex/src/clickbench.rs
@@ -21,7 +21,7 @@ use tracing::{debug, info, warn};
 use url::Url;
 use vortex::error::VortexExpect;
 use vortex::file::{VORTEX_FILE_EXTENSION, VortexWriteOptions};
-use vortex_datafusion::persistent::VortexFormat;
+use vortex_datafusion::VortexFormat;
 
 use crate::Format;
 use crate::conversions::parquet_to_vortex;

--- a/bench-vortex/src/datasets/file.rs
+++ b/bench-vortex/src/datasets/file.rs
@@ -14,7 +14,7 @@ use tokio::fs::OpenOptions;
 use tracing::info;
 use url::Url;
 use vortex::file::VortexWriteOptions;
-use vortex_datafusion::persistent::VortexFormat;
+use vortex_datafusion::VortexFormat;
 
 use crate::conversions::parquet_to_vortex;
 use crate::datasets::BenchmarkDataset;

--- a/bench-vortex/src/engines/df/mod.rs
+++ b/bench-vortex/src/engines/df/mod.rs
@@ -18,7 +18,7 @@ use object_store::aws::AmazonS3Builder;
 use object_store::gcp::GoogleCloudStorageBuilder;
 use object_store::local::LocalFileSystem;
 use url::Url;
-use vortex_datafusion::persistent::VortexFormatFactory;
+use vortex_datafusion::VortexFormatFactory;
 
 pub static GIT_COMMIT_ID: LazyLock<String> = LazyLock::new(|| {
     String::from_utf8(

--- a/bench-vortex/src/public_bi.rs
+++ b/bench-vortex/src/public_bi.rs
@@ -31,7 +31,7 @@ use vortex::error::{VortexResult, vortex_err};
 use vortex::file::{VortexLayoutStrategy, VortexOpenOptions, VortexWriteOptions};
 use vortex::stream::ArrayStreamExt;
 use vortex::utils::aliases::hash_map::HashMap;
-use vortex_datafusion::persistent::VortexFormat;
+use vortex_datafusion::VortexFormat;
 
 use crate::conversions::parquet_to_vortex;
 use crate::datasets::Dataset;

--- a/vortex-datafusion/examples/vortex_table.rs
+++ b/vortex-datafusion/examples/vortex_table.rs
@@ -12,7 +12,7 @@ use vortex::buffer::buffer;
 use vortex::error::vortex_err;
 use vortex::file::VortexWriteOptions;
 use vortex::validity::Validity;
-use vortex_datafusion::persistent::VortexFormat;
+use vortex_datafusion::VortexFormat;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/vortex-datafusion/src/lib.rs
+++ b/vortex-datafusion/src/lib.rs
@@ -1,4 +1,4 @@
-//! Connectors to enable DataFusion to read Vortex data.
+//! Connectors to enable [DataFusion](https://docs.rs/datafusion/latest/datafusion/) to read [`Vortex`](https://docs.rs/crate/vortex/latest) data.
 #![deny(missing_docs)]
 use std::fmt::Debug;
 
@@ -8,7 +8,9 @@ use datafusion::logical_expr::{Expr, Operator};
 use vortex::stats::Precision;
 
 mod convert;
-pub mod persistent;
+mod persistent;
+
+pub use persistent::*;
 
 const SUPPORTED_BINARY_OPS: &[Operator] = &[
     Operator::Eq,

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -309,10 +309,6 @@ impl FileFormat for VortexFormat {
             return not_impl_err!("File level partitioning isn't implemented yet for Vortex");
         }
 
-        if file_scan_config.limit.is_some() {
-            return not_impl_err!("Limit isn't implemented yet for Vortex");
-        }
-
         if !file_scan_config.table_partition_cols.is_empty() {
             return not_impl_err!("Hive style partitioning isn't implemented yet for Vortex");
         }

--- a/vortex-datafusion/src/persistent/mod.rs
+++ b/vortex-datafusion/src/persistent/mod.rs
@@ -35,6 +35,7 @@ mod tests {
         ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
     };
     use datafusion::prelude::SessionContext;
+    use rstest::rstest;
     use tempfile::tempdir;
     use tokio::fs::OpenOptions;
     use vortex::IntoArray;
@@ -46,8 +47,11 @@ mod tests {
 
     use crate::persistent::VortexFormat;
 
+    #[rstest]
+    #[case(Some(1))]
+    #[case(None)]
     #[tokio::test]
-    async fn query_file() -> anyhow::Result<()> {
+    async fn query_file(#[case] limit: Option<usize>) -> anyhow::Result<()> {
         let temp_dir = tempdir()?;
         let strings = ChunkedArray::from_iter([
             VarBinArray::from(vec!["ab", "foo", "bar", "baz"]).into_array(),
@@ -99,8 +103,17 @@ mod tests {
         let listing_table = Arc::new(ListingTable::try_new(config)?);
 
         ctx.register_table("vortex_tbl", listing_table as _)?;
-        let row_count = ctx.table("vortex_tbl").await?.count().await?;
-        assert_eq!(row_count, 8);
+        let total_row_count = ctx.table("vortex_tbl").await?.count().await?;
+        assert_eq!(total_row_count, 8);
+
+        let row_count = ctx
+            .table("vortex_tbl")
+            .await?
+            .limit(0, limit)?
+            .count()
+            .await?;
+
+        assert_eq!(row_count, limit.unwrap_or(total_row_count));
 
         Ok(())
     }

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -27,6 +27,7 @@ pub(crate) struct VortexFileOpener {
     pub(crate) file_cache: VortexFileCache,
     pub projected_arrow_schema: SchemaRef,
     pub batch_size: usize,
+    pub limit: Option<usize>,
     metrics: VortexMetrics,
     layout_readers: Arc<DashMap<Path, Weak<dyn LayoutReader>>>,
 }
@@ -40,6 +41,7 @@ impl VortexFileOpener {
         file_cache: VortexFileCache,
         projected_arrow_schema: SchemaRef,
         batch_size: usize,
+        limit: Option<usize>,
         metrics: VortexMetrics,
         layout_readers: Arc<DashMap<Path, Weak<dyn LayoutReader>>>,
     ) -> Self {
@@ -50,6 +52,7 @@ impl VortexFileOpener {
             file_cache,
             projected_arrow_schema,
             batch_size,
+            limit,
             metrics,
             layout_readers,
         }
@@ -65,6 +68,7 @@ impl FileOpener for VortexFileOpener {
         let projected_arrow_schema = self.projected_arrow_schema.clone();
         let metrics = self.metrics.clone();
         let batch_size = self.batch_size;
+        let limit = self.limit;
         let layout_reader = self.layout_readers.clone();
 
         Ok(async move {
@@ -104,7 +108,11 @@ impl FileOpener for VortexFileOpener {
             };
 
             let scan_builder = ScanBuilder::new(layout_reader);
-            let scan_builder = apply_byte_range(file_meta, vxf.row_count(), scan_builder);
+            let mut scan_builder = apply_byte_range(file_meta, vxf.row_count(), scan_builder);
+
+            if let Some(limit) = limit {
+                scan_builder = scan_builder.with_limit(limit);
+            }
 
             let stream = scan_builder
                 .with_tokio_executor(Handle::current())
@@ -138,10 +146,9 @@ impl FileOpener for VortexFileOpener {
                     )
                 })
                 .map_err(|e: VortexError| ArrowError::ExternalError(Box::new(e)))
-                .try_flatten()
-                .boxed();
+                .try_flatten();
 
-            Ok(stream)
+            Ok(stream.boxed())
         }
         .boxed())
     }

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -111,7 +111,9 @@ impl FileOpener for VortexFileOpener {
             let mut scan_builder = apply_byte_range(file_meta, vxf.row_count(), scan_builder);
 
             if let Some(limit) = limit {
-                scan_builder = scan_builder.with_limit(limit);
+                if filter.is_none() {
+                    scan_builder = scan_builder.with_limit(limit);
+                }
             }
 
             let stream = scan_builder
@@ -146,9 +148,10 @@ impl FileOpener for VortexFileOpener {
                     )
                 })
                 .map_err(|e: VortexError| ArrowError::ExternalError(Box::new(e)))
-                .try_flatten();
+                .try_flatten()
+                .boxed();
 
-            Ok(stream.boxed())
+            Ok(stream)
         }
         .boxed())
     }

--- a/vortex-datafusion/src/persistent/source.rs
+++ b/vortex-datafusion/src/persistent/source.rs
@@ -65,7 +65,7 @@ impl FileSource for VortexSource {
     fn create_file_opener(
         &self,
         object_store: Arc<dyn ObjectStore>,
-        _base_config: &FileScanConfig,
+        base_config: &FileScanConfig,
         partition: usize,
     ) -> Arc<dyn FileOpener> {
         let partition_metrics = self
@@ -85,6 +85,7 @@ impl FileSource for VortexSource {
                 .clone()
                 .vortex_expect("We should have a schema here"),
             batch_size,
+            base_config.limit,
             partition_metrics,
             self.layout_readers.clone(),
         );

--- a/vortex-dtype/src/field_mask.rs
+++ b/vortex-dtype/src/field_mask.rs
@@ -5,7 +5,7 @@ use vortex_error::{VortexResult, vortex_bail};
 
 use crate::{Field, FieldPath};
 
-/// Represents a field mask, which is a projection of fields under a layout.
+/// A projection of fields under a layout.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FieldMask {
     /// Select all fields in the layout

--- a/vortex-layout/src/scan/mod.rs
+++ b/vortex-layout/src/scan/mod.rs
@@ -159,6 +159,12 @@ impl<A: 'static + Send + Sync> ScanBuilder<A> {
         if self.filter.is_some() && self.limit.is_some() {
             vortex_bail!("Vortex doesn't support scans with both a filter and a limit")
         }
+
+        // The ultimate short circuit
+        if self.limit.is_some_and(|l| l == 0) {
+            return Ok(Vec::new());
+        }
+
         // Spin up the root layout reader, and wrap it in a FilterLayoutReader to perform
         // conjunction splitting if a filter is provided.
         let layout_reader = if self.filter.is_some() {

--- a/vortex-layout/src/scan/mod.rs
+++ b/vortex-layout/src/scan/mod.rs
@@ -186,7 +186,7 @@ impl<A: 'static + Send + Sync> ScanBuilder<A> {
         // Create a task that executes the full scan pipeline for each split.
         let split_tasks = splits
             .into_iter()
-            .map(|split_range| {
+            .filter_map(|split_range| {
                 let ctx = Arc::new(TaskContext {
                     row_range: self.row_range.clone(),
                     selection: self.selection.clone(),
@@ -197,7 +197,11 @@ impl<A: 'static + Send + Sync> ScanBuilder<A> {
                     task_executor: None,
                 });
 
-                split_exec(ctx, split_range, self.limit.as_mut())
+                if self.limit.is_some_and(|l| l == 0) {
+                    None
+                } else {
+                    Some(split_exec(ctx, split_range, self.limit.as_mut()))
+                }
             })
             .try_collect()?;
 

--- a/vortex-layout/src/scan/mod.rs
+++ b/vortex-layout/src/scan/mod.rs
@@ -53,6 +53,8 @@ pub struct ScanBuilder<A> {
     metrics: VortexMetrics,
     /// Should we try to prune the file (using stats) on open.
     file_stats: Option<Arc<[StatsSet]>>,
+    /// Maximal number of rows to read (after filtering)
+    limit: Option<usize>,
 }
 
 impl<A: 'static + Send + Sync> ScanBuilder<A> {
@@ -118,6 +120,11 @@ impl<A: 'static + Send + Sync> ScanBuilder<A> {
         self
     }
 
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
     /// Map each split of the scan. The function will be run on the spawned task.
     pub fn map<B: 'static>(
         self,
@@ -136,6 +143,7 @@ impl<A: 'static + Send + Sync> ScanBuilder<A> {
             executor: self.executor,
             metrics: self.metrics,
             file_stats: self.file_stats,
+            limit: self.limit,
         }
     }
 
@@ -222,6 +230,7 @@ impl ScanBuilder<ArrayRef> {
             executor: None,
             metrics: Default::default(),
             file_stats: None,
+            limit: None,
         }
     }
 

--- a/vortex-layout/src/scan/mod.rs
+++ b/vortex-layout/src/scan/mod.rs
@@ -17,7 +17,7 @@ use vortex_array::stream::{ArrayStream, ArrayStreamAdapter};
 use vortex_array::{ArrayRef, ToCanonical};
 use vortex_buffer::Buffer;
 use vortex_dtype::{DType, Field, FieldMask, FieldName, FieldPath};
-use vortex_error::{VortexExpect, VortexResult, vortex_err};
+use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
 use vortex_expr::transform::immediate_access::immediate_scope_access;
 use vortex_expr::transform::simplify_typed::simplify_typed;
 use vortex_expr::{ExprRef, ScopeDType, root};
@@ -155,7 +155,10 @@ impl<A: 'static + Send + Sync> ScanBuilder<A> {
 
     /// Constructs a task per row split of the scan, returned as a vector of futures.
     #[allow(clippy::unused_enumerate_index)]
-    pub fn build(self) -> VortexResult<Vec<impl Future<Output = VortexResult<Option<A>>>>> {
+    pub fn build(mut self) -> VortexResult<Vec<impl Future<Output = VortexResult<Option<A>>>>> {
+        if self.filter.is_some() && self.limit.is_some() {
+            vortex_bail!("Vortex doesn't support scans with both a filter and a limit")
+        }
         // Spin up the root layout reader, and wrap it in a FilterLayoutReader to perform
         // conjunction splitting if a filter is provided.
         let layout_reader = if self.filter.is_some() {
@@ -177,17 +180,13 @@ impl<A: 'static + Send + Sync> ScanBuilder<A> {
         // Construct field masks and compute the row splits of the scan.
         let (filter_mask, projection_mask) =
             filter_and_projection_masks(&projection, filter.as_ref(), layout_reader.dtype())?;
-        let field_mask: Vec<_> = filter_mask
-            .iter()
-            .cloned()
-            .chain(projection_mask.iter().cloned())
-            .collect();
+        let field_mask: Vec<_> = [filter_mask, projection_mask].concat();
         let splits = self.split_by.splits(layout_reader.as_ref(), &field_mask)?;
 
         // Create a task that executes the full scan pipeline for each split.
         let split_tasks = splits
             .into_iter()
-            .map(move |split_range| {
+            .map(|split_range| {
                 let ctx = Arc::new(TaskContext {
                     row_range: self.row_range.clone(),
                     selection: self.selection.clone(),
@@ -198,7 +197,7 @@ impl<A: 'static + Send + Sync> ScanBuilder<A> {
                     task_executor: None,
                 });
 
-                split_exec(ctx, split_range)
+                split_exec(ctx, split_range, self.limit.as_mut())
             })
             .try_collect()?;
 

--- a/vortex-layout/src/scan/tasks.rs
+++ b/vortex-layout/src/scan/tasks.rs
@@ -8,6 +8,7 @@ use futures::future::{BoxFuture, ok};
 use vortex_array::ArrayRef;
 use vortex_error::VortexResult;
 use vortex_expr::ExprRef;
+use vortex_mask::Mask;
 
 use crate::LayoutReader;
 use crate::scan::{Selection, TaskExecutor, TaskExecutorExt};
@@ -57,13 +58,15 @@ pub(super) fn split_exec<A: 'static + Send + Sync>(
     let filter = match ctx.filter.as_ref() {
         // No filter == immediate task
         None => {
-            let row_mask = if let Some(limit) = limit.filter(|l| **l > 0_usize) {
-                let true_count = row_mask.true_count();
-                let row_mask = row_mask.limit(*limit);
-                *limit -= usize::min(*limit, true_count);
-                row_mask
-            } else {
-                row_mask
+            let row_mask = match limit {
+                Some(l) if *l == 0 => Mask::new_false(row_mask.len()),
+                Some(l) => {
+                    let true_count = row_mask.true_count();
+                    let row_mask = row_mask.limit(*l);
+                    *l -= usize::min(*l, true_count);
+                    row_mask
+                }
+                None => row_mask,
             };
 
             ok(row_mask).boxed()

--- a/vortex-layout/src/scan/tasks.rs
+++ b/vortex-layout/src/scan/tasks.rs
@@ -29,6 +29,7 @@ pub type TaskFuture<A> = BoxFuture<'static, VortexResult<A>>;
 pub(super) fn split_exec<A: 'static + Send + Sync>(
     ctx: Arc<TaskContext<A>>,
     split: Range<u64>,
+    limit: Option<&mut usize>,
 ) -> VortexResult<TaskFuture<Option<A>>> {
     // Step 1: using the caller-provided row range and selection, attempt to disregard this split.
     let read_range = match &ctx.row_range {
@@ -55,7 +56,18 @@ pub(super) fn split_exec<A: 'static + Send + Sync>(
 
     let filter = match ctx.filter.as_ref() {
         // No filter == immediate task
-        None => ok(row_mask).boxed(),
+        None => {
+            let row_mask = if let Some(limit) = limit.filter(|l| **l > 0_usize) {
+                let true_count = row_mask.true_count();
+                let row_mask = row_mask.limit(*limit);
+                *limit -= usize::min(*limit, true_count);
+                row_mask
+            } else {
+                row_mask
+            };
+
+            ok(row_mask).boxed()
+        }
         Some(filter) => {
             // Step 2: if there is a filter provided, attempt to prune this range based on the filter.
             // NOTE: it's very important that the pruning and filter evaluations are built OUTSIDE

--- a/vortex-mask/src/lib.rs
+++ b/vortex-mask/src/lib.rs
@@ -510,7 +510,7 @@ impl Mask {
         }
     }
 
-    /// Limit the mast to the first `limit` true values
+    /// Limit the mask to the first `limit` true values
     pub fn limit(self, limit: usize) -> Self {
         if self.len() <= limit {
             return self;
@@ -521,20 +521,18 @@ impl Mask {
                 Self::from_iter([Self::new_true(limit), Self::new_false(len - limit)])
             }
             Mask::AllFalse(_) => self,
-            Mask::Values(mask_values) => {
+            Mask::Values(ref mask_values) => {
+                if limit >= mask_values.true_count() {
+                    return self;
+                }
+
                 let existing_buffer = mask_values.boolean_buffer();
-                let mut limit = limit;
+
                 let mut new_buffer_builder = BooleanBufferBuilder::new(mask_values.len());
                 new_buffer_builder.append_n(existing_buffer.len(), false);
 
-                for index in existing_buffer.set_indices() {
-                    match limit {
-                        0 => break,
-                        _ => {
-                            limit -= 1;
-                            new_buffer_builder.set_bit(index, true);
-                        }
-                    }
+                for index in existing_buffer.set_indices().take(limit) {
+                    new_buffer_builder.set_bit(index, true);
                 }
 
                 Self::from(new_buffer_builder.finish())

--- a/vortex-mask/src/lib.rs
+++ b/vortex-mask/src/lib.rs
@@ -529,7 +529,7 @@ impl Mask {
                 let existing_buffer = mask_values.boolean_buffer();
 
                 let mut new_buffer_builder = BooleanBufferBuilder::new(mask_values.len());
-                new_buffer_builder.append_n(existing_buffer.len(), false);
+                new_buffer_builder.append_n(mask_values.len(), false);
 
                 for index in existing_buffer.set_indices().take(limit) {
                     new_buffer_builder.set_bit(index, true);

--- a/vortex-mask/src/lib.rs
+++ b/vortex-mask/src/lib.rs
@@ -357,7 +357,7 @@ impl Mask {
         match &self {
             Self::AllTrue(len) => *len,
             Self::AllFalse(len) => *len,
-            Self::Values(values) => values.buffer.len(),
+            Self::Values(values) => values.len(),
         }
     }
 
@@ -509,6 +509,38 @@ impl Mask {
             _ => None,
         }
     }
+
+    /// Limit the mast to the first `limit` true values
+    pub fn limit(self, limit: usize) -> Self {
+        if self.len() <= limit {
+            return self;
+        }
+
+        match self {
+            Mask::AllTrue(len) => {
+                Self::from_iter([Self::new_true(limit), Self::new_false(len - limit)])
+            }
+            Mask::AllFalse(_) => self,
+            Mask::Values(mask_values) => {
+                let existing_buffer = mask_values.boolean_buffer();
+                let mut limit = limit;
+                let mut new_buffer_builder = BooleanBufferBuilder::new(mask_values.len());
+                new_buffer_builder.append_n(existing_buffer.len(), false);
+
+                for index in existing_buffer.set_indices() {
+                    match limit {
+                        0 => break,
+                        _ => {
+                            limit -= 1;
+                            new_buffer_builder.set_bit(index, true);
+                        }
+                    }
+                }
+
+                Self::from(new_buffer_builder.finish())
+            }
+        }
+    }
 }
 
 /// Iterator over the indices or slices of a mask.
@@ -605,5 +637,49 @@ mod test {
                 AllOr::Some(&BooleanBuffer::from_iter([true, false, true, true, false]))
             );
         }
+    }
+
+    #[test]
+    fn limit_all_true_mask() {
+        let all_true = Mask::new_true(4);
+        let limited_mask = all_true.clone().limit(2);
+        assert_eq!(all_true.len(), limited_mask.len());
+        assert_eq!(limited_mask.true_count(), 2);
+        assert_eq!(
+            limited_mask.boolean_buffer(),
+            AllOr::Some(&BooleanBuffer::from_iter([true, true, false, false]))
+        );
+
+        let limited_mask = all_true.clone().limit(5);
+        assert_eq!(limited_mask, all_true);
+    }
+
+    #[test]
+    fn limit_mask_values() {
+        let original_mask = Mask::from_iter([true, true, false, true, false, true]);
+        let limited_mask = original_mask.clone().limit(2);
+
+        assert_eq!(
+            limited_mask.boolean_buffer(),
+            AllOr::Some(&BooleanBuffer::from_iter([
+                true, true, false, false, false, false
+            ]))
+        );
+        assert_eq!(limited_mask.true_count(), 2);
+
+        let limited_mask = original_mask.limit(3);
+
+        assert_eq!(
+            limited_mask.boolean_buffer(),
+            AllOr::Some(&BooleanBuffer::from_iter([
+                true, true, false, true, false, false
+            ]))
+        );
+        assert_eq!(limited_mask.true_count(), 3);
+
+        let original_mask = Mask::from_iter([true, true, false, true, false, true]);
+        let limited_mask = original_mask.clone().limit(100);
+
+        assert_eq!(original_mask, limited_mask);
     }
 }


### PR DESCRIPTION
Figured that `SELECT * FROM tbl LIMIT 10` is a pretty common use case for data exploration and is probably worth including. I think this closes #2593 and is also part of #2254.

Supporting limit with filters with our heavy use of `async move` seems much harder because the limit has to be shared in some way. Doing that for the stream (like when `into_stream`) is trivial with a `StreamExt::scan` but for the current return type of `ScanBuilder::build` that will require shared state and I'm not even sure that would be correct given the ordering isn't guaranteed.