### PR TITLE
fix(doc): fix the example file link in quick start

### DIFF
--- a/docs/quickstart/python.rst
+++ b/docs/quickstart/python.rst
@@ -14,7 +14,7 @@ Convert
 -------
 
 You can either use your own Parquet file or download the `example used here
-<https://spiraldb.github.io/vortex/docs/_static/example.parquet>`__.
+<https://github.com/vortex-data/vortex/blob/develop/docs/_static/example.parquet>`__.
 
 Use Arrow to read a Parquet file and then use :func:`~vortex.array` to construct an uncompressed
 Vortex array:

--- a/docs/quickstart/python.rst
+++ b/docs/quickstart/python.rst
@@ -14,7 +14,7 @@ Convert
 -------
 
 You can either use your own Parquet file or download the `example used here
-<https://github.com/vortex-data/vortex/blob/develop/docs/_static/example.parquet>`__.
+<https://docs.vortex.dev/_static/example.parquet>`__.
 
 Use Arrow to read a Parquet file and then use :func:`~vortex.array` to construct an uncompressed
 Vortex array:

--- a/docs/quickstart/rust.rst
+++ b/docs/quickstart/rust.rst
@@ -14,7 +14,7 @@ Convert
 -------
 
 You can either use your own Parquet file or download the `example used here
-<https://spiraldb.github.io/vortex/docs/_static/example.parquet>`__.
+<https://github.com/vortex-data/vortex/blob/develop/docs/_static/example.parquet>`__.
 
 Use Arrow to read a Parquet file and then construct an uncompressed Vortex array:
 

--- a/docs/quickstart/rust.rst
+++ b/docs/quickstart/rust.rst
@@ -14,7 +14,7 @@ Convert
 -------
 
 You can either use your own Parquet file or download the `example used here
-<https://github.com/vortex-data/vortex/blob/develop/docs/_static/example.parquet>`__.
+<https://docs.vortex.dev/_static/example.parquet>`__.
 
 Use Arrow to read a Parquet file and then construct an uncompressed Vortex array:
 


### PR DESCRIPTION
The link for the example file in the quick start can now be reached; changed it to the GitHub link.