### PR TITLE
fix[vortex-array]: list_contains compare opposed nullable list values or search values

### DIFF
--- a/vortex-array/src/compute/list.rs
+++ b/vortex-array/src/compute/list.rs
@@ -51,7 +51,7 @@ pub fn list_contains(array: &dyn Array, value: &dyn Array) -> VortexResult<Array
     let DType::List(elem_dtype, _) = array.dtype() else {
         vortex_bail!("Array must be of List type");
     };
-    if elem_dtype.as_ref() != value.dtype() {
+    if !elem_dtype.eq_ignore_nullability(value.dtype()) {
         vortex_bail!("Element type of ListArray does not match search value");
     }
 


### PR DESCRIPTION
Since compare functions will compare values of the same type with differing nullability, so should this fn