### PR TITLE
chore[vortex-layout]: use scope dtype in layouts (not dtype)

### DIFF
--- a/vortex-expr/src/scope.rs
+++ b/vortex-expr/src/scope.rs
@@ -144,7 +144,7 @@ impl From<ArrayRef> for Scope {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct ScopeDType {
     root: Option<DType>,
     types: ExprScope<DType>,

--- a/vortex-file/src/footer/mod.rs
+++ b/vortex-file/src/footer/mod.rs
@@ -22,7 +22,8 @@ pub use segment::*;
 use vortex_array::stats::StatsSet;
 use vortex_array::{ArrayContext, ArrayRegistry};
 use vortex_dtype::DType;
-use vortex_error::{VortexResult, vortex_bail, vortex_err};
+use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
+use vortex_expr::Identifier;
 use vortex_flatbuffers::{FlatBuffer, footer as fb};
 use vortex_layout::{LayoutContext, LayoutRef, LayoutRegistry, layout_from_flatbuffer};
 
@@ -114,7 +115,10 @@ impl Footer {
 
     /// Returns the [`DType`] of the file.
     pub fn dtype(&self) -> &DType {
-        self.root_layout.dtype()
+        self.root_layout
+            .scope_dtype()
+            .dtype(&Identifier::Identity)
+            .vortex_expect("required identity scope in layout for file")
     }
 
     /// Returns the number of rows in the file.

--- a/vortex-file/src/open.rs
+++ b/vortex-file/src/open.rs
@@ -87,7 +87,7 @@ impl<F: FileType> VortexOpenOptions<F> {
     /// If this is provided, then the Vortex file can be opened without performing any I/O.
     /// Once open, the [`Footer`] can be accessed via [`crate::VortexFile::footer`].
     pub fn with_footer(mut self, footer: Footer) -> Self {
-        self.dtype = Some(footer.layout().dtype().clone());
+        self.dtype = Some(footer.dtype().clone());
         self.footer = Some(footer);
         self
     }

--- a/vortex-layout/src/children.rs
+++ b/vortex-layout/src/children.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use flatbuffers::Follow;
 use itertools::Itertools;
 use vortex_dtype::DType;
-use vortex_error::{VortexResult, vortex_bail, vortex_err, vortex_panic};
+use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err, vortex_panic};
 use vortex_expr::Identifier;
 use vortex_flatbuffers::{FlatBuffer, layout as fbl};
 
@@ -76,7 +76,7 @@ impl LayoutChildren for OwnedLayoutChildren {
         let child_dtype = child
             .scope_dtype()
             .dtype(&Identifier::Identity)
-            .expect("no identity");
+            .vortex_expect("no identity");
         if child_dtype != dtype {
             vortex_panic!("Child dtype mismatch: {} != {}", child_dtype, dtype);
         }

--- a/vortex-layout/src/children.rs
+++ b/vortex-layout/src/children.rs
@@ -5,6 +5,7 @@ use flatbuffers::Follow;
 use itertools::Itertools;
 use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_bail, vortex_err, vortex_panic};
+use vortex_expr::Identifier;
 use vortex_flatbuffers::{FlatBuffer, layout as fbl};
 
 use crate::segments::SegmentId;
@@ -72,8 +73,12 @@ impl LayoutChildren for OwnedLayoutChildren {
             vortex_bail!("Child index out of bounds: {} of {}", idx, self.0.len());
         }
         let child = &self.0[idx];
-        if child.dtype() != dtype {
-            vortex_panic!("Child dtype mismatch: {} != {}", child.dtype(), dtype);
+        let child_dtype = child
+            .scope_dtype()
+            .dtype(&Identifier::Identity)
+            .expect("no identity");
+        if child_dtype != dtype {
+            vortex_panic!("Child dtype mismatch: {} != {}", child_dtype, dtype);
         }
         Ok(child.clone())
     }

--- a/vortex-layout/src/encoding.rs
+++ b/vortex-layout/src/encoding.rs
@@ -5,6 +5,7 @@ use arcref::ArcRef;
 use vortex_array::DeserializeMetadata;
 use vortex_dtype::DType;
 use vortex_error::{VortexExpect, VortexResult, vortex_panic};
+use vortex_expr::Identifier;
 
 use crate::segments::SegmentId;
 use crate::{IntoLayout, LayoutChildren, LayoutRef, VTable};
@@ -58,8 +59,14 @@ impl<V: VTable> LayoutEncoding for LayoutEncodingAdapter<V> {
                 row_count
             );
         }
-        if layout.dtype() != dtype {
-            vortex_panic!("Layout dtype mismatch: {} != {}", layout.dtype(), dtype);
+
+        let child_dtype = layout
+            .scope_dtype()
+            .dtype(&Identifier::Identity)
+            .expect("not identity child");
+
+        if child_dtype != dtype {
+            vortex_panic!("Layout dtype mismatch: {} != {}", child_dtype, dtype);
         }
 
         Ok(layout.into_layout())

--- a/vortex-layout/src/encoding.rs
+++ b/vortex-layout/src/encoding.rs
@@ -63,7 +63,7 @@ impl<V: VTable> LayoutEncoding for LayoutEncodingAdapter<V> {
         let child_dtype = layout
             .scope_dtype()
             .dtype(&Identifier::Identity)
-            .expect("not identity child");
+            .vortex_expect("not identity child");
 
         if child_dtype != dtype {
             vortex_panic!("Layout dtype mismatch: {} != {}", child_dtype, dtype);

--- a/vortex-layout/src/layout.rs
+++ b/vortex-layout/src/layout.rs
@@ -5,8 +5,9 @@ use std::sync::Arc;
 use arcref::ArcRef;
 use itertools::Itertools;
 use vortex_array::{ArrayContext, SerializeMetadata};
-use vortex_dtype::{DType, FieldName};
+use vortex_dtype::FieldName;
 use vortex_error::{VortexExpect, VortexResult, vortex_err};
+use vortex_expr::ScopeDType;
 
 use crate::segments::{SegmentId, SegmentSource};
 use crate::{LayoutEncodingId, LayoutEncodingRef, LayoutReaderRef, VTable};
@@ -29,7 +30,7 @@ pub trait Layout: 'static + Send + Sync + Debug + private::Sealed {
     fn row_count(&self) -> u64;
 
     /// The dtype of this layout.
-    fn dtype(&self) -> &DType;
+    fn scope_dtype(&self) -> &ScopeDType;
 
     /// The number of children in this layout.
     fn nchildren(&self) -> usize;
@@ -217,8 +218,8 @@ impl<V: VTable> Layout for LayoutAdapter<V> {
         V::row_count(&self.0)
     }
 
-    fn dtype(&self) -> &DType {
-        V::dtype(&self.0)
+    fn scope_dtype(&self) -> &ScopeDType {
+        V::scope_dtype(&self.0)
     }
 
     fn nchildren(&self) -> usize {

--- a/vortex-layout/src/layouts/chunked/mod.rs
+++ b/vortex-layout/src/layouts/chunked/mod.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use vortex_array::{ArrayContext, DeserializeMetadata, EmptyMetadata};
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
+use vortex_expr::ScopeDType;
 
 use crate::children::LayoutChildren;
 use crate::layouts::chunked::reader::ChunkedReader;
@@ -33,8 +34,8 @@ impl VTable for ChunkedVTable {
         layout.row_count
     }
 
-    fn dtype(layout: &Self::Layout) -> &DType {
-        &layout.dtype
+    fn scope_dtype(layout: &Self::Layout) -> &ScopeDType {
+        &layout.scope_dtype
     }
 
     fn metadata(_layout: &Self::Layout) -> Self::Metadata {
@@ -94,6 +95,7 @@ pub struct ChunkedLayoutEncoding;
 pub struct ChunkedLayout {
     row_count: u64,
     dtype: DType,
+    scope_dtype: ScopeDType,
     children: Arc<dyn LayoutChildren>,
     chunk_offsets: Vec<u64>,
 }
@@ -113,7 +115,8 @@ impl ChunkedLayout {
         );
         Self {
             row_count,
-            dtype,
+            dtype: dtype.clone(),
+            scope_dtype: ScopeDType::new(dtype),
             children,
             chunk_offsets,
         }

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -118,8 +118,8 @@ impl LayoutReader for ChunkedReader {
         &self.name
     }
 
-    fn dtype(&self) -> &DType {
-        self.layout.dtype()
+    fn scope_dtype(&self) -> &ScopeDType {
+        self.layout.scope_dtype()
     }
 
     fn row_count(&self) -> Precision<u64> {
@@ -191,7 +191,7 @@ impl LayoutReader for ChunkedReader {
         row_range: &Range<u64>,
         expr: &ExprRef,
     ) -> VortexResult<Box<dyn ArrayEvaluation>> {
-        let dtype = expr.return_dtype(&ScopeDType::new(self.dtype().clone()))?;
+        let dtype = expr.return_dtype(self.scope_dtype())?;
         let mut chunk_evals = vec![];
         let mut mask_ranges = vec![];
 

--- a/vortex-layout/src/layouts/dict/mod.rs
+++ b/vortex-layout/src/layouts/dict/mod.rs
@@ -7,6 +7,7 @@ use reader::DictReader;
 use vortex_array::{ArrayContext, DeserializeMetadata, ProstMetadata};
 use vortex_dtype::{DType, PType};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_panic};
+use vortex_expr::{Identifier, ScopeDType};
 
 use crate::children::LayoutChildren;
 use crate::segments::{SegmentId, SegmentSource};
@@ -33,13 +34,20 @@ impl VTable for DictVTable {
         layout.codes.row_count()
     }
 
-    fn dtype(layout: &Self::Layout) -> &DType {
-        layout.values.dtype()
+    fn scope_dtype(layout: &Self::Layout) -> &ScopeDType {
+        layout.values.scope_dtype()
     }
 
     fn metadata(layout: &Self::Layout) -> Self::Metadata {
         ProstMetadata(DictLayoutMetadata::new(
-            PType::try_from(layout.codes.dtype()).vortex_expect("ptype"),
+            PType::try_from(
+                layout
+                    .codes
+                    .scope_dtype()
+                    .dtype(&Identifier::Identity)
+                    .vortex_expect("must have root scope"),
+            )
+            .vortex_expect("ptype"),
         ))
     }
 

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -10,9 +10,9 @@ use vortex_array::compute::{MinMaxResult, filter, min_max};
 use vortex_array::stats::Precision;
 use vortex_array::{Array, ArrayContext, ArrayRef, ToCanonical};
 use vortex_dict::DictArray;
-use vortex_dtype::{DType, FieldMask};
+use vortex_dtype::FieldMask;
 use vortex_error::{VortexExpect, VortexResult};
-use vortex_expr::{ExprRef, Scope, root};
+use vortex_expr::{ExprRef, Scope, ScopeDType, root};
 use vortex_mask::Mask;
 
 use super::DictLayout;
@@ -107,8 +107,8 @@ impl LayoutReader for DictReader {
         &self.name
     }
 
-    fn dtype(&self) -> &DType {
-        self.layout.dtype()
+    fn scope_dtype(&self) -> &ScopeDType {
+        self.layout.scope_dtype()
     }
 
     fn row_count(&self) -> Precision<u64> {

--- a/vortex-layout/src/layouts/filter.rs
+++ b/vortex-layout/src/layouts/filter.rs
@@ -10,10 +10,10 @@ use itertools::Itertools;
 use parking_lot::RwLock;
 use sketches_ddsketch::DDSketch;
 use vortex_array::stats::Precision;
-use vortex_dtype::{DType, FieldMask};
+use vortex_dtype::FieldMask;
 use vortex_error::{VortexExpect, VortexResult, vortex_err, vortex_panic};
-use vortex_expr::ExprRef;
 use vortex_expr::forms::cnf::cnf;
+use vortex_expr::{ExprRef, ScopeDType};
 use vortex_mask::Mask;
 
 use crate::{ArrayEvaluation, LayoutReader, LayoutReaderRef, MaskEvaluation, PruningEvaluation};
@@ -46,8 +46,8 @@ impl LayoutReader for FilterLayoutReader {
         self.child.name()
     }
 
-    fn dtype(&self) -> &DType {
-        self.child.dtype()
+    fn scope_dtype(&self) -> &ScopeDType {
+        self.child.scope_dtype()
     }
 
     fn row_count(&self) -> Precision<u64> {

--- a/vortex-layout/src/layouts/flat/mod.rs
+++ b/vortex-layout/src/layouts/flat/mod.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use vortex_array::{ArrayContext, DeserializeMetadata, EmptyMetadata};
 use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_bail, vortex_panic};
+use vortex_expr::ScopeDType;
 
 use crate::children::LayoutChildren;
 use crate::layouts::flat::reader::FlatReader;
@@ -33,8 +34,8 @@ impl VTable for FlatVTable {
         layout.row_count
     }
 
-    fn dtype(layout: &Self::Layout) -> &DType {
-        &layout.dtype
+    fn scope_dtype(layout: &Self::Layout) -> &ScopeDType {
+        &layout.scope_dtype
     }
 
     fn metadata(_layout: &Self::Layout) -> Self::Metadata {
@@ -82,11 +83,7 @@ impl VTable for FlatVTable {
         if segment_ids.len() != 1 {
             vortex_bail!("Flat layout must have exactly one segment ID");
         }
-        Ok(FlatLayout {
-            row_count,
-            dtype: dtype.clone(),
-            segment_id: segment_ids[0],
-        })
+        Ok(FlatLayout::new(row_count, dtype.clone(), segment_ids[0]))
     }
 }
 
@@ -97,6 +94,7 @@ pub struct FlatLayoutEncoding;
 pub struct FlatLayout {
     row_count: u64,
     dtype: DType,
+    scope_dtype: ScopeDType,
     segment_id: SegmentId,
 }
 
@@ -104,7 +102,8 @@ impl FlatLayout {
     pub fn new(row_count: u64, dtype: DType, segment_id: SegmentId) -> Self {
         Self {
             row_count,
-            dtype,
+            dtype: dtype.clone(),
+            scope_dtype: ScopeDType::new(dtype),
             segment_id,
         }
     }

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -8,9 +8,9 @@ use vortex_array::compute::filter;
 use vortex_array::serde::ArrayParts;
 use vortex_array::stats::Precision;
 use vortex_array::{Array, ArrayContext, ArrayRef};
-use vortex_dtype::{DType, FieldMask};
+use vortex_dtype::FieldMask;
 use vortex_error::{VortexExpect, VortexResult, VortexUnwrap as _};
-use vortex_expr::{ExprRef, Scope, is_root};
+use vortex_expr::{ExprRef, Scope, ScopeDType, is_root};
 use vortex_mask::Mask;
 
 use crate::layouts::SharedArrayFuture;
@@ -72,7 +72,7 @@ impl FlatReader {
             .array
             .get_or_init(|| {
                 let ctx = self.ctx.clone();
-                let dtype = self.layout.dtype().clone();
+                let dtype = self.layout.dtype.clone();
                 async move {
                     let segment = segment_fut.await?;
                     ArrayParts::try_from(segment)?
@@ -91,8 +91,8 @@ impl LayoutReader for FlatReader {
         &self.name
     }
 
-    fn dtype(&self) -> &DType {
-        self.layout.dtype()
+    fn scope_dtype(&self) -> &ScopeDType {
+        self.layout.scope_dtype()
     }
 
     fn row_count(&self) -> Precision<u64> {
@@ -166,6 +166,8 @@ impl MaskEvaluation for FlatEvaluation {
         // TODO(ngates): if the mask density is low enough, or if the mask is dense within a range
         //  (as often happens with zone map pruning), then we could slice/filter the array prior
         //  to evaluating the expression.
+
+        // println!("expr {:?}", self.expr);
 
         // Now we await the array .
         let mut array = self.array.clone().await?;

--- a/vortex-layout/src/layouts/struct_/mod.rs
+++ b/vortex-layout/src/layouts/struct_/mod.rs
@@ -7,6 +7,7 @@ use reader::StructReader;
 use vortex_array::{ArrayContext, DeserializeMetadata, EmptyMetadata};
 use vortex_dtype::{DType, Field, FieldMask, StructFields};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err, vortex_panic};
+use vortex_expr::ScopeDType;
 
 use crate::children::{LayoutChildren, OwnedLayoutChildren};
 use crate::segments::{SegmentId, SegmentSource};
@@ -33,8 +34,8 @@ impl VTable for StructVTable {
         layout.row_count
     }
 
-    fn dtype(layout: &Self::Layout) -> &DType {
-        &layout.dtype
+    fn scope_dtype(layout: &Self::Layout) -> &ScopeDType {
+        &layout.scope_dtype
     }
 
     fn metadata(_layout: &Self::Layout) -> Self::Metadata {
@@ -99,6 +100,7 @@ impl VTable for StructVTable {
         }
         Ok(StructLayout {
             row_count,
+            scope_dtype: ScopeDType::new(dtype.clone()),
             dtype: dtype.clone(),
             children: children.to_arc(),
         })
@@ -111,6 +113,7 @@ pub struct StructLayoutEncoding;
 #[derive(Clone, Debug)]
 pub struct StructLayout {
     row_count: u64,
+    scope_dtype: ScopeDType,
     dtype: DType,
     children: Arc<dyn LayoutChildren>,
 }
@@ -119,14 +122,18 @@ impl StructLayout {
     pub fn new(row_count: u64, dtype: DType, children: Vec<LayoutRef>) -> Self {
         Self {
             row_count,
+            scope_dtype: ScopeDType::new(dtype.clone()),
             dtype,
             children: OwnedLayoutChildren::layout_children(children),
         }
     }
 
     pub fn struct_fields(&self) -> &Arc<StructFields> {
-        let DType::Struct(dtype, _) = self.dtype() else {
-            vortex_panic!("Mismatched dtype {} for struct layout", self.dtype());
+        let DType::Struct(dtype, _) = &self.dtype else {
+            vortex_panic!(
+                "Mismatched scope_dtype {:?} for struct layout",
+                self.scope_dtype()
+            );
         };
         dtype
     }

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -15,7 +15,7 @@ use vortex_array::{ArrayContext, ArrayRef, IntoArray};
 use vortex_dtype::{DType, FieldMask, FieldName, StructFields};
 use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_err};
 use vortex_expr::transform::partition::{PartitionedExpr, partition};
-use vortex_expr::{ExprRef, Scope};
+use vortex_expr::{ExprRef, Scope, ScopeDType};
 use vortex_mask::Mask;
 use vortex_utils::aliases::hash_map::HashMap;
 
@@ -71,6 +71,10 @@ impl StructReader {
     /// Return the [`StructFields`] of this layout.
     fn struct_fields(&self) -> &StructFields {
         self.layout.struct_fields()
+    }
+
+    fn dtype(&self) -> &DType {
+        &self.layout.dtype
     }
 
     /// Return the child reader for the field.
@@ -132,8 +136,8 @@ impl LayoutReader for StructReader {
         &self.name
     }
 
-    fn dtype(&self) -> &DType {
-        self.layout.dtype()
+    fn scope_dtype(&self) -> &ScopeDType {
+        self.layout.scope_dtype()
     }
 
     fn row_count(&self) -> Precision<u64> {

--- a/vortex-layout/src/layouts/zoned/mod.rs
+++ b/vortex-layout/src/layouts/zoned/mod.rs
@@ -136,13 +136,13 @@ impl ZonedLayout {
         let expected_dtype = ZoneMap::dtype_for_stats_table(
             data.scope_dtype()
                 .dtype(&Identifier::Identity)
-                .expect("no identity scope"),
+                .vortex_expect("no identity scope"),
             &present_stats,
         );
         if zones
             .scope_dtype()
             .dtype(&Identifier::Identity)
-            .expect("no identity scope")
+            .vortex_expect("no identity scope")
             != &expected_dtype
         {
             vortex_panic!("Invalid zone map layout: zones dtype does not match expected dtype");

--- a/vortex-layout/src/layouts/zoned/mod.rs
+++ b/vortex-layout/src/layouts/zoned/mod.rs
@@ -10,6 +10,7 @@ use vortex_array::stats::{Stat, as_stat_bitset_bytes, stats_from_bitset_bytes};
 use vortex_array::{ArrayContext, DeserializeMetadata, SerializeMetadata};
 use vortex_dtype::{DType, TryFromBytes};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_panic};
+use vortex_expr::{Identifier, ScopeDType};
 
 use crate::children::LayoutChildren;
 use crate::layouts::zoned::reader::ZonedReader;
@@ -38,8 +39,8 @@ impl VTable for ZonedVTable {
         layout.data.row_count()
     }
 
-    fn dtype(layout: &Self::Layout) -> &DType {
-        layout.data.dtype()
+    fn scope_dtype(layout: &Self::Layout) -> &ScopeDType {
+        layout.data.scope_dtype()
     }
 
     fn metadata(layout: &Self::Layout) -> Self::Metadata {
@@ -97,7 +98,12 @@ impl VTable for ZonedVTable {
     ) -> VortexResult<Self::Layout> {
         let data = children.child(0, dtype)?;
 
-        let zones_dtype = ZoneMap::dtype_for_stats_table(data.dtype(), &metadata.present_stats);
+        let zones_dtype = ZoneMap::dtype_for_stats_table(
+            data.scope_dtype()
+                .dtype(&Identifier::Identity)
+                .vortex_expect(""),
+            &metadata.present_stats,
+        );
         let zones = children.child(1, &zones_dtype)?;
 
         Ok(ZonedLayout::new(
@@ -127,8 +133,18 @@ impl ZonedLayout {
         zone_len: usize,
         present_stats: Arc<[Stat]>,
     ) -> Self {
-        let expected_dtype = ZoneMap::dtype_for_stats_table(data.dtype(), &present_stats);
-        if zones.dtype() != &expected_dtype {
+        let expected_dtype = ZoneMap::dtype_for_stats_table(
+            data.scope_dtype()
+                .dtype(&Identifier::Identity)
+                .expect("no identity scope"),
+            &present_stats,
+        );
+        if zones
+            .scope_dtype()
+            .dtype(&Identifier::Identity)
+            .expect("no identity scope")
+            != &expected_dtype
+        {
             vortex_panic!("Invalid zone map layout: zones dtype does not match expected dtype");
         }
         Self {

--- a/vortex-layout/src/layouts/zoned/reader.rs
+++ b/vortex-layout/src/layouts/zoned/reader.rs
@@ -10,10 +10,10 @@ use futures::{FutureExt, TryFutureExt};
 use itertools::Itertools;
 use vortex_array::stats::Precision;
 use vortex_array::{ArrayContext, ToCanonical};
-use vortex_dtype::{DType, FieldMask};
+use vortex_dtype::FieldMask;
 use vortex_error::{SharedVortexResult, VortexError, VortexExpect, VortexResult};
 use vortex_expr::pruning::PruningPredicate;
-use vortex_expr::{ExprRef, Scope, root};
+use vortex_expr::{ExprRef, Scope, ScopeDType, root};
 use vortex_mask::Mask;
 
 use crate::layouts::zoned::ZonedLayout;
@@ -157,8 +157,8 @@ impl LayoutReader for ZonedReader {
         &self.name
     }
 
-    fn dtype(&self) -> &DType {
-        self.data_child.dtype()
+    fn scope_dtype(&self) -> &ScopeDType {
+        self.data_child.scope_dtype()
     }
 
     fn row_count(&self) -> Precision<u64> {

--- a/vortex-layout/src/reader.rs
+++ b/vortex-layout/src/reader.rs
@@ -9,7 +9,7 @@ use vortex_array::stats::Precision;
 use vortex_array::{ArrayContext, ArrayRef};
 use vortex_dtype::{DType, FieldMask};
 use vortex_error::{SharedVortexResult, VortexError, VortexResult, vortex_bail};
-use vortex_expr::ExprRef;
+use vortex_expr::{ExprRef, ScopeDType};
 use vortex_mask::Mask;
 
 use crate::children::LayoutChildren;
@@ -24,7 +24,7 @@ pub trait LayoutReader: 'static + Send + Sync {
     fn name(&self) -> &Arc<str>;
 
     /// Returns the un-projected dtype of the layout reader.
-    fn dtype(&self) -> &DType;
+    fn scope_dtype(&self) -> &ScopeDType;
 
     /// Returns the number of rows in the layout reader.
     /// An inexact count may be larger or smaller than the actual row count.

--- a/vortex-layout/src/scan/mod.rs
+++ b/vortex-layout/src/scan/mod.rs
@@ -20,7 +20,7 @@ use vortex_dtype::{DType, Field, FieldMask, FieldName, FieldPath};
 use vortex_error::{VortexExpect, VortexResult, vortex_err};
 use vortex_expr::transform::immediate_access::immediate_scope_access;
 use vortex_expr::transform::simplify_typed::simplify_typed;
-use vortex_expr::{ExprRef, ScopeDType, root};
+use vortex_expr::{ExprRef, Identifier, ScopeDType, root};
 use vortex_metrics::VortexMetrics;
 
 use crate::LayoutReader;
@@ -147,7 +147,7 @@ impl<A: 'static + Send + Sync> ScanBuilder<A> {
     /// Returns the output [`DType`] of the scan.
     pub fn dtype(&self) -> VortexResult<DType> {
         self.projection
-            .return_dtype(&ScopeDType::new(self.layout_reader.dtype().clone()))
+            .return_dtype(self.layout_reader.scope_dtype())
     }
 
     /// Constructs a task per row split of the scan, returned as a vector of futures.
@@ -161,7 +161,7 @@ impl<A: 'static + Send + Sync> ScanBuilder<A> {
             self.layout_reader
         };
 
-        let ctx = ScopeDType::new(layout_reader.dtype().clone());
+        let ctx = layout_reader.scope_dtype().clone();
 
         // Normalize and simplify the expressions.
         let projection = simplify_typed(self.projection.clone(), &ctx)?;
@@ -173,7 +173,7 @@ impl<A: 'static + Send + Sync> ScanBuilder<A> {
 
         // Construct field masks and compute the row splits of the scan.
         let (filter_mask, projection_mask) =
-            filter_and_projection_masks(&projection, filter.as_ref(), layout_reader.dtype())?;
+            filter_and_projection_masks(&projection, filter.as_ref(), layout_reader.scope_dtype())?;
         let field_mask: Vec<_> = filter_mask
             .iter()
             .cloned()
@@ -281,9 +281,13 @@ impl ScanBuilder<ArrayRef> {
 fn filter_and_projection_masks(
     projection: &ExprRef,
     filter: Option<&ExprRef>,
-    dtype: &DType,
+    scope_dtype: &ScopeDType,
 ) -> VortexResult<(Vec<FieldMask>, Vec<FieldMask>)> {
-    let Some(struct_dtype) = dtype.as_struct() else {
+    let Some(struct_dtype) = scope_dtype
+        .dtype(&Identifier::Identity)
+        .expect("no ident")
+        .as_struct()
+    else {
         return Ok(match filter {
             Some(_) => (vec![FieldMask::All], vec![FieldMask::All]),
             None => (Vec::new(), vec![FieldMask::All]),

--- a/vortex-layout/src/scan/mod.rs
+++ b/vortex-layout/src/scan/mod.rs
@@ -285,7 +285,7 @@ fn filter_and_projection_masks(
 ) -> VortexResult<(Vec<FieldMask>, Vec<FieldMask>)> {
     let Some(struct_dtype) = scope_dtype
         .dtype(&Identifier::Identity)
-        .expect("no ident")
+        .vortex_expect("no ident")
         .as_struct()
     else {
         return Ok(match filter {

--- a/vortex-layout/src/scan/split_by.rs
+++ b/vortex-layout/src/scan/split_by.rs
@@ -11,7 +11,7 @@ use crate::LayoutReader;
 /// Defines how the Vortex file is split into batches for reading.
 ///
 /// Note that each split must fit into the platform's maximum usize.
-#[derive(Default, Copy, Clone)]
+#[derive(Default, Copy, Clone, Debug)]
 pub enum SplitBy {
     #[default]
     /// Splits any time there is a chunk boundary in the file.

--- a/vortex-layout/src/vtable.rs
+++ b/vortex-layout/src/vtable.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use vortex_array::{ArrayContext, DeserializeMetadata, SerializeMetadata};
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
+use vortex_expr::ScopeDType;
 
 use crate::children::LayoutChildren;
 use crate::segments::{SegmentId, SegmentSource};
@@ -28,7 +29,7 @@ pub trait VTable: 'static + Sized + Send + Sync + Debug {
     fn row_count(layout: &Self::Layout) -> u64;
 
     /// Returns the dtype for the layout reader.
-    fn dtype(layout: &Self::Layout) -> &DType;
+    fn scope_dtype(layout: &Self::Layout) -> &ScopeDType;
 
     /// Returns the metadata for the layout.
     fn metadata(layout: &Self::Layout) -> Self::Metadata;

--- a/vortex-tui/src/browse/app.rs
+++ b/vortex-tui/src/browse/app.rs
@@ -5,6 +5,7 @@ use ratatui::prelude::Size;
 use ratatui::widgets::ListState;
 use vortex::dtype::DType;
 use vortex::error::{VortexExpect, VortexResult};
+use vortex::expr::Identifier;
 use vortex::file::{Footer, SegmentSpec, VortexFile, VortexOpenOptions};
 use vortex_layout::LayoutRef;
 use vortex_layout::layouts::flat::FlatVTable;
@@ -109,7 +110,10 @@ impl LayoutCursor {
     }
 
     pub fn dtype(&self) -> &DType {
-        self.layout.dtype()
+        self.layout
+            .scope_dtype()
+            .dtype(&Identifier::Identity)
+            .vortex_expect("required scope with identity in file reader")
     }
 
     pub fn layout(&self) -> &LayoutRef {


### PR DESCRIPTION
This is a bit anyoing that you keep having to unwrap the dtype().

Maybe another function that panics if there is no value for the ident. I don't think we want to assume there is always a Identity identifier 