### PR TITLE
feat: link duckdb dynamically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,7 +331,7 @@ jobs:
       - name: Rust Tests
         # vortex-duckdb-ext currently fails linking for cargo test targets.
         run: |
-          cargo nextest run --locked --workspace --all-features --no-fail-fast --exclude vortex-duckdb-ext
+          cargo nextest run --locked --workspace --all-features --no-fail-fast
 
       - name: Generate coverage report
         if: github.ref == 'refs/heads/develop'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,9 +2145,27 @@ dependencies = [
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
- "libduckdb-sys",
+ "libduckdb-sys 1.2.2",
  "memchr",
  "num",
+ "num-integer",
+ "rust_decimal",
+ "smallvec",
+ "strum 0.25.0",
+]
+
+[[package]]
+name = "duckdb"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "379464d1fbb69d1bbda7c11d96fafde6f2bdb78c67e630e6339b048e6e45107e"
+dependencies = [
+ "arrow",
+ "cast",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libduckdb-sys 1.3.0",
  "num-integer",
  "rust_decimal",
  "smallvec",
@@ -3299,6 +3317,21 @@ version = "1.2.2"
 dependencies = [
  "autocfg",
  "cc",
+ "flate2",
+ "pkg-config",
+ "serde",
+ "serde_json",
+ "tar",
+ "vcpkg",
+]
+
+[[package]]
+name = "libduckdb-sys"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25d3f1defe457d1ac0fbaef0fe6926953cb33419dd3c8dbac53882d020bee697"
+dependencies = [
+ "autocfg",
  "flate2",
  "pkg-config",
  "serde",
@@ -6398,7 +6431,7 @@ dependencies = [
 name = "vortex-duckdb"
 version = "0.1.0"
 dependencies = [
- "duckdb",
+ "duckdb 1.2.2",
  "itertools 0.14.0",
  "num-traits",
  "vortex",
@@ -6412,6 +6445,7 @@ dependencies = [
  "bitvec",
  "cbindgen",
  "cc",
+ "duckdb 1.3.0",
  "itertools 0.14.0",
  "num-traits",
  "reqwest",
@@ -6487,7 +6521,7 @@ dependencies = [
 name = "vortex-ffi"
 version = "0.1.0"
 dependencies = [
- "duckdb",
+ "duckdb 1.2.2",
  "futures",
  "itertools 0.14.0",
  "log",

--- a/vortex-duckdb-ext/Cargo.toml
+++ b/vortex-duckdb-ext/Cargo.toml
@@ -27,7 +27,7 @@ vortex = { workspace = true, features = ["files"] }
 vortex-file = { workspace = true, features = ["tokio"] }
 
 [dev-dependencies]
-# duckdb = { version = "1.3.0" }
+duckdb = { version = "1.3.0" }
 
 [lints]
 workspace = true

--- a/vortex-duckdb-ext/build.rs
+++ b/vortex-duckdb-ext/build.rs
@@ -12,14 +12,14 @@ fn download_duckdb_archive() -> Result<PathBuf, Box<dyn std::error::Error>> {
 
     let target = env::var("TARGET")?;
     let (platform, arch) = match target.as_str() {
-        "aarch64-apple-darwin" => ("osx", "arm64"),
-        "x86_64-apple-darwin" => ("osx", "amd64"),
+        "aarch64-apple-darwin" => ("osx", "universal"),
+        "x86_64-apple-darwin" => ("osx", "universal"),
         "x86_64-unknown-linux-gnu" | "x86_64-unknown-linux-musl" => ("linux", "amd64"),
         "aarch64-unknown-linux-gnu" | "aarch64-unknown-linux-musl" => ("linux", "arm64"),
         _ => return Err(format!("Unsupported target: {target}").into()),
     };
 
-    let archive_name = format!("static-libs-{platform}-{arch}.zip");
+    let archive_name = format!("libduckdb-{platform}-{arch}.zip");
     let url = format!("{DUCKDB_BASE_URL}/{DUCKDB_VERSION}/{archive_name}");
     let archive_path = duckdb_dir.join(&archive_name);
 
@@ -45,7 +45,7 @@ fn extract_duckdb_libraries(archive_path: PathBuf) -> Result<PathBuf, Box<dyn st
         .to_path_buf();
 
     // Check if already extracted.
-    if duckdb_dir.join("libduckdb_static.a").exists() {
+    if duckdb_dir.join("libduckdb.so").exists() {
         println!("DuckDB libraries already extracted, skipping extraction");
         return Ok(duckdb_dir);
     }
@@ -99,10 +99,14 @@ fn main() {
     let zip_path = download_duckdb_archive().unwrap();
     let lib_path = extract_duckdb_libraries(zip_path).unwrap();
 
-    // Link against static DuckDB libraries.
+    // Link against DuckDB dylib.
     println!("cargo:rustc-link-search=native={}", lib_path.display());
-    println!("cargo:rustc-link-lib=static=duckdb_static");
-    println!("cargo:rustc-link-lib=static=duckdb_fmt");
+    println!("cargo:rustc-link-lib=dylib=duckdb");
+
+    // Linux requires libstdc++ to be linked explicitly.
+    if env::var("TARGET").unwrap().contains("linux") {
+        println!("cargo:rustc-link-lib=stdc++");
+    }
 
     // Compile our C++ code that exposes additional DuckDB functionality.
     cc::Build::new()

--- a/vortex-duckdb-ext/src/lib.rs
+++ b/vortex-duckdb-ext/src/lib.rs
@@ -58,24 +58,23 @@ pub extern "C" fn vortex_extension_version() -> *const c_char {
 
 #[cfg(test)]
 mod tests {
-    // TODO(alex): bring back tests
-    // use duckdb::Connection;
+    use duckdb::Connection;
 
-    // use crate::duckdb::Database;
+    use crate::duckdb::Database;
 
     #[test]
     fn test_extension() {
-        // let db = Database::open_in_memory().unwrap();
-        // let connection = db.connect().unwrap();
-        // super::init(&connection).unwrap();
+        let db = Database::open_in_memory().unwrap();
+        let connection = db.connect().unwrap();
+        super::init(&connection).unwrap();
 
-        // // Now we use DuckDB-rs to query the connection.
-        // let conn = unsafe { Connection::open_from_raw(db.as_ptr().cast()) }.unwrap();
-        // let result = conn
-        //     .prepare("SELECT * FROM hello(?) WHERE greeting = 'Hello Bob'")
-        //     .unwrap()
-        //     .query_row(["Bob"], |row| row.get::<_, String>(0))
-        //     .unwrap();
-        // assert_eq!(&result, "Hello Bob");
+        // Now we use DuckDB-rs to query the connection.
+        let conn = unsafe { Connection::open_from_raw(db.as_ptr().cast()) }.unwrap();
+        let result = conn
+            .prepare("SELECT * FROM hello(?) WHERE greeting = 'Hello Bob'")
+            .unwrap()
+            .query_row(["Bob"], |row| row.get::<_, String>(0))
+            .unwrap();
+        assert_eq!(&result, "Hello Bob");
     }
 }


### PR DESCRIPTION
When linking static libraries, the linker includes the entire object file, not just the symbols needed. The static library might not be self contained and can reference symbols that require additional libraries to be linked, as it was the case here with `libduckdb_static.a`.  

On macOS, the static linking suceeded in the previous setup already because of the linker flags we set in `.cargo/config` for which there is no identical equivalent for Linux.

```
[target.aarch64-apple-darwin]
rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
```