### PR TITLE
fix: deserialize ident proto expressions as the new Var("")

### DIFF
--- a/vortex-expr/src/registry.rs
+++ b/vortex-expr/src/registry.rs
@@ -16,13 +16,14 @@ use crate::merge::proto::MergeSerde;
 use crate::not::proto::NotSerde;
 use crate::pack::proto::PackSerde;
 use crate::select::proto::SelectSerde;
-use crate::var::proto::VarSerde;
+use crate::var::proto::{IdentitySerde, VarSerde};
 use crate::{ExprDeserialize, ExprRef};
 
 const EXPRESSIONS: &[&'static dyn ExprDeserialize] = &[
     &BetweenSerde,
     &BinarySerde,
     &GetItemSerde,
+    &IdentitySerde,
     &LetSerde,
     &LikeSerde,
     &LiteralSerde,

--- a/vortex-expr/src/var.rs
+++ b/vortex-expr/src/var.rs
@@ -33,7 +33,27 @@ pub(crate) mod proto {
     use vortex_error::{VortexResult, vortex_bail};
     use vortex_proto::expr::kind::{Kind, Var as ProtoVar};
 
-    use crate::{ExprDeserialize, ExprRef, ExprSerializable, Id, Var};
+    use crate::{ExprDeserialize, ExprRef, ExprSerializable, Id, Var, root};
+
+    // NOTE(aduffy): identity expression is deprecated for the moment, but it is still
+    // in the protobuf definition. We map it into the new Var(root()) expression.
+    pub(crate) struct IdentitySerde;
+
+    impl Id for IdentitySerde {
+        fn id(&self) -> &'static str {
+            "identity"
+        }
+    }
+
+    impl ExprDeserialize for IdentitySerde {
+        fn deserialize(&self, kind: &Kind, _children: Vec<ExprRef>) -> VortexResult<ExprRef> {
+            let Kind::Identity(..) = kind else {
+                vortex_bail!("wrong kind {:?}, wanted identity", kind)
+            };
+
+            Ok(root())
+        }
+    }
 
     pub(crate) struct VarSerde;
 


### PR DESCRIPTION
I had considered removing Ident from the proto and changing all of the Spark/Iceberg protobuf serde, but I'm honestly not convinced we aren't going to keep changing/remove Var/Let so I'd prefer to just deserialize Ident proto