### PR TITLE
feat[vortex-layout]: add a virtual layout reader node not persisted

### DIFF
--- a/vortex-layout/src/layouts/filter.rs
+++ b/vortex-layout/src/layouts/filter.rs
@@ -19,7 +19,7 @@ use crate::{ArrayEvaluation, MaskEvaluation, PruningEvaluation};
 /// The selectivity histogram quantile to use for reordering conjuncts. Where 0 == no rows match.
 const DEFAULT_SELECTIVITY_QUANTILE: f64 = 0.1;
 
-/// A [`LayoutReader`] that splits boolean expressions into individual conjunctions, tracks
+/// A [`VirtualLayoutReader`] that splits boolean expressions into individual conjunctions, tracks
 /// statistics about selectivity, and uses this information to reorder the evaluation of the
 /// conjunctions in an attempt to minimize the work done.
 ///

--- a/vortex-layout/src/layouts/filter.rs
+++ b/vortex-layout/src/layouts/filter.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeSet;
 use std::iter;
 use std::ops::{BitAnd, Range};
 use std::sync::Arc;
@@ -9,14 +8,13 @@ use dashmap::DashMap;
 use itertools::Itertools;
 use parking_lot::RwLock;
 use sketches_ddsketch::DDSketch;
-use vortex_array::stats::Precision;
-use vortex_dtype::{DType, FieldMask};
 use vortex_error::{VortexExpect, VortexResult, vortex_err, vortex_panic};
-use vortex_expr::ExprRef;
 use vortex_expr::forms::cnf::cnf;
+use vortex_expr::{ExprRef, ScopeDType};
 use vortex_mask::Mask;
 
-use crate::{ArrayEvaluation, LayoutReader, LayoutReaderRef, MaskEvaluation, PruningEvaluation};
+use crate::virtual_reader::{VirtualLayoutReader, VirtualLayoutReaderRef};
+use crate::{ArrayEvaluation, MaskEvaluation, PruningEvaluation};
 
 /// The selectivity histogram quantile to use for reordering conjuncts. Where 0 == no rows match.
 const DEFAULT_SELECTIVITY_QUANTILE: f64 = 0.1;
@@ -28,12 +26,12 @@ const DEFAULT_SELECTIVITY_QUANTILE: f64 = 0.1;
 /// This reader does not have a corresponding layout in the file, as it merely implements
 /// expression rewrite logic at read-time.
 pub struct FilterLayoutReader {
-    child: LayoutReaderRef,
+    child: VirtualLayoutReaderRef,
     cache: DashMap<ExprRef, Arc<FilterExpr>>,
 }
 
 impl FilterLayoutReader {
-    pub fn new(child: LayoutReaderRef) -> Self {
+    pub fn new(child: VirtualLayoutReaderRef) -> Self {
         Self {
             child,
             cache: Default::default(),
@@ -41,27 +39,13 @@ impl FilterLayoutReader {
     }
 }
 
-impl LayoutReader for FilterLayoutReader {
+impl VirtualLayoutReader for FilterLayoutReader {
     fn name(&self) -> &Arc<str> {
         self.child.name()
     }
 
-    fn dtype(&self) -> &DType {
-        self.child.dtype()
-    }
-
-    fn row_count(&self) -> Precision<u64> {
-        self.child.row_count()
-    }
-
-    fn register_splits(
-        &self,
-        field_mask: &[FieldMask],
-        row_offset: u64,
-        splits: &mut BTreeSet<u64>,
-    ) -> VortexResult<()> {
-        // Pass-through the splits to the child layout reader.
-        self.child.register_splits(field_mask, row_offset, splits)
+    fn scope_dtype(&self) -> &ScopeDType {
+        self.child.scope_dtype()
     }
 
     fn pruning_evaluation(

--- a/vortex-layout/src/lib.rs
+++ b/vortex-layout/src/lib.rs
@@ -22,5 +22,6 @@ pub mod scan;
 pub mod segments;
 pub mod sequence;
 mod strategy;
+mod virtual_reader;
 pub mod vtable;
 mod writer;

--- a/vortex-layout/src/scan/mod.rs
+++ b/vortex-layout/src/scan/mod.rs
@@ -26,6 +26,7 @@ use vortex_metrics::VortexMetrics;
 use crate::LayoutReader;
 use crate::layouts::filter::FilterLayoutReader;
 use crate::scan::tasks::{TaskContext, split_exec};
+use crate::virtual_reader::{PhysicalToVirtualLayoutAdaptor, VirtualLayoutReaderRef};
 
 mod executor;
 pub mod row_mask;
@@ -155,10 +156,12 @@ impl<A: 'static + Send + Sync> ScanBuilder<A> {
     pub fn build(self) -> VortexResult<Vec<impl Future<Output = VortexResult<Option<A>>>>> {
         // Spin up the root layout reader, and wrap it in a FilterLayoutReader to perform
         // conjunction splitting if a filter is provided.
-        let layout_reader = if self.filter.is_some() {
-            Arc::new(FilterLayoutReader::new(self.layout_reader))
-        } else {
-            self.layout_reader
+        let layout_reader = self.layout_reader;
+        let mut virtual_layout_reader =
+            Arc::new(PhysicalToVirtualLayoutAdaptor::new(layout_reader.clone()))
+                as VirtualLayoutReaderRef;
+        if self.filter.is_some() {
+            virtual_layout_reader = Arc::new(FilterLayoutReader::new(virtual_layout_reader));
         };
 
         let ctx = ScopeDType::new(layout_reader.dtype().clone());
@@ -189,7 +192,7 @@ impl<A: 'static + Send + Sync> ScanBuilder<A> {
                     row_range: self.row_range.clone(),
                     selection: self.selection.clone(),
                     filter: self.filter.clone(),
-                    reader: layout_reader.clone(),
+                    virtual_reader: virtual_layout_reader.clone(),
                     projection: projection.clone(),
                     mapper: self.map_fn.clone(),
                     task_executor: None,

--- a/vortex-layout/src/scan/tasks.rs
+++ b/vortex-layout/src/scan/tasks.rs
@@ -9,8 +9,8 @@ use vortex_array::ArrayRef;
 use vortex_error::VortexResult;
 use vortex_expr::ExprRef;
 
-use crate::LayoutReader;
 use crate::scan::{Selection, TaskExecutor, TaskExecutorExt};
+use crate::virtual_reader::VirtualLayoutReaderRef;
 
 pub type TaskFuture<A> = BoxFuture<'static, VortexResult<A>>;
 
@@ -61,8 +61,8 @@ pub(super) fn split_exec<A: 'static + Send + Sync>(
             // NOTE: it's very important that the pruning and filter evaluations are built OUTSIDE
             // of the future. Registering these row ranges eagerly is a hint to the IO system that
             // we want to start prefetching the IO for this split.
-            let prune = ctx.reader.pruning_evaluation(&row_range, filter)?;
-            let eval = ctx.reader.filter_evaluation(&row_range, filter)?;
+            let prune = ctx.virtual_reader.pruning_evaluation(&row_range, filter)?;
+            let eval = ctx.virtual_reader.filter_evaluation(&row_range, filter)?;
 
             async move {
                 let pruned_mask = prune.invoke(row_mask).await?;
@@ -78,7 +78,7 @@ pub(super) fn split_exec<A: 'static + Send + Sync>(
 
     // Step 4: execute the projection, only at the mask for rows which match the filter
     let exec = ctx
-        .reader
+        .virtual_reader
         .projection_evaluation(&row_range, &ctx.projection)?;
     let mapper = ctx.mapper.clone();
     let array_fut = async move {
@@ -106,8 +106,8 @@ pub(super) struct TaskContext<A> {
     /// The filter expression for the current task.
     pub(super) filter: Option<ExprRef>,
 
-    /// The layout reader.
-    pub(super) reader: Arc<dyn LayoutReader>,
+    /// The virtual layout reader.
+    pub(super) virtual_reader: VirtualLayoutReaderRef,
 
     /// The projection expression to apply to gather the scanned rows.
     pub(super) projection: ExprRef,

--- a/vortex-layout/src/virtual_reader.rs
+++ b/vortex-layout/src/virtual_reader.rs
@@ -8,7 +8,7 @@ use crate::{ArrayEvaluation, LayoutReaderRef, MaskEvaluation, PruningEvaluation}
 
 pub type VirtualLayoutReaderRef = Arc<dyn VirtualLayoutReader>;
 
-/// A [`VirtualLayoutReader`] is a used to adapt (and read) a [`crate::Layout`].
+/// A [`crate::VirtualLayoutReader`] is a used to adapt (and read) a [`crate::Layout`].
 /// virtual layouts add virtual columns or other reader functionality on top of a layout
 pub trait VirtualLayoutReader: 'static + Send + Sync {
     /// Returns the name of the layout reader for debugging.

--- a/vortex-layout/src/virtual_reader.rs
+++ b/vortex-layout/src/virtual_reader.rs
@@ -1,0 +1,89 @@
+use std::ops::Range;
+use std::sync::Arc;
+
+use vortex_error::VortexResult;
+use vortex_expr::{ExprRef, ScopeDType};
+
+use crate::{ArrayEvaluation, LayoutReaderRef, MaskEvaluation, PruningEvaluation};
+
+pub type VirtualLayoutReaderRef = Arc<dyn VirtualLayoutReader>;
+
+/// A [`VirtualLayoutReader`] is a used to read a [`crate::Layout`] in a way that can cache state across multiple
+/// evaluation operations.
+pub trait VirtualLayoutReader: 'static + Send + Sync {
+    /// Returns the name of the layout reader for debugging.
+    fn name(&self) -> &Arc<str>;
+
+    /// Returns the un-projected dtype of the layout reader.
+    fn scope_dtype(&self) -> &ScopeDType;
+
+    /// Performs an approximate evaluation of the expression against the layout reader.
+    fn pruning_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &ExprRef,
+    ) -> VortexResult<Box<dyn PruningEvaluation>>;
+
+    /// Performs an exact evaluation of the expression against the layout reader.
+    fn filter_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &ExprRef,
+    ) -> VortexResult<Box<dyn MaskEvaluation>>;
+
+    /// Evaluates the expression against the layout.
+    fn projection_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &ExprRef,
+    ) -> VortexResult<Box<dyn ArrayEvaluation>>;
+}
+
+pub struct PhysicalToVirtualLayoutAdaptor {
+    child: LayoutReaderRef,
+    scope_dtype: ScopeDType,
+}
+
+impl PhysicalToVirtualLayoutAdaptor {
+    pub fn new(child: LayoutReaderRef) -> Self {
+        let dtype = child.dtype().clone();
+        Self {
+            child,
+            scope_dtype: ScopeDType::new(dtype),
+        }
+    }
+}
+
+impl VirtualLayoutReader for PhysicalToVirtualLayoutAdaptor {
+    fn name(&self) -> &Arc<str> {
+        self.child.name()
+    }
+
+    fn scope_dtype(&self) -> &ScopeDType {
+        &self.scope_dtype
+    }
+
+    fn pruning_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &ExprRef,
+    ) -> VortexResult<Box<dyn PruningEvaluation>> {
+        self.child.pruning_evaluation(row_range, expr)
+    }
+
+    fn filter_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &ExprRef,
+    ) -> VortexResult<Box<dyn MaskEvaluation>> {
+        self.child.filter_evaluation(row_range, expr)
+    }
+
+    fn projection_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &ExprRef,
+    ) -> VortexResult<Box<dyn ArrayEvaluation>> {
+        self.child.projection_evaluation(row_range, expr)
+    }
+}

--- a/vortex-layout/src/virtual_reader.rs
+++ b/vortex-layout/src/virtual_reader.rs
@@ -8,8 +8,8 @@ use crate::{ArrayEvaluation, LayoutReaderRef, MaskEvaluation, PruningEvaluation}
 
 pub type VirtualLayoutReaderRef = Arc<dyn VirtualLayoutReader>;
 
-/// A [`VirtualLayoutReader`] is a used to read a [`crate::Layout`] in a way that can cache state across multiple
-/// evaluation operations.
+/// A [`VirtualLayoutReader`] is a used to adapt (and read) a [`crate::Layout`].
+/// virtual layouts add virtual columns or other reader functionality on top of a layout
 pub trait VirtualLayoutReader: 'static + Send + Sync {
     /// Returns the name of the layout reader for debugging.
     fn name(&self) -> &Arc<str>;


### PR DESCRIPTION
Layouts seem to be mapped directly to seconds on a file, this PR distinguishes between (physical) layout and (new) virtual layouts, these can be used to include extra reading logic or virtual columns
Signed-off-by: Joe Isaacs <joe.isaacs@live.co.uk>