### PR TITLE
feat: scope dynamic symbol resolution to `vortex-python`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,11 +1,5 @@
 [target.'(target_familiy="unix")']
 rustflags = ["-C", "force-frame-pointers=yes"]
-# For pyo3 to successfully link on Macos
-# See https://stackoverflow.com/a/77382609
-[target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
-[target.x86_64-apple-darwin]
-rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
 [target.wasm32-unknown-unknown]
 rustflags = ['--cfg', 'getrandom_backend="wasm_js"', '-C', 'target-feature=+atomics']
 

--- a/vortex-duckdb-ext/build.rs
+++ b/vortex-duckdb-ext/build.rs
@@ -103,9 +103,10 @@ fn main() {
     println!("cargo:rustc-link-search=native={}", lib_path.display());
     println!("cargo:rustc-link-lib=dylib=duckdb");
 
-    // Linux requires libstdc++ to be linked explicitly.
     if env::var("TARGET").unwrap().contains("linux") {
         println!("cargo:rustc-link-lib=stdc++");
+    } else {
+        println!("cargo:rustc-link-lib=c++");
     }
 
     // Compile our C++ code that exposes additional DuckDB functionality.

--- a/vortex-python/.cargo/config.toml
+++ b/vortex-python/.cargo/config.toml
@@ -1,0 +1,7 @@
+# For pyo3 to successfully link on Macos
+# See https://stackoverflow.com/a/77382609
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]


### PR DESCRIPTION
This PR scopes dynamic symbol resolution to `vortex-python`. When unresolved symbols lead to crashes at runtime, no context is provided why or where the code crashed, with the only error shown being: `SIGSEGV (11). Invalid memory access`.