### PR TITLE
fix: vortex-flatbuffers docs has bad links

### DIFF
--- a/vortex-flatbuffers/src/lib.rs
+++ b/vortex-flatbuffers/src/lib.rs
@@ -1,7 +1,5 @@
 //! A contiguously serialized Vortex array.
 //!
-//! See [message] and [footer] for the flatbuffer specifications.
-//!
 //! See the `vortex-file` crate for non-contiguous serialization.
 
 #[cfg(feature = "array")]


### PR DESCRIPTION
I do not know why, but these errors are caught by:

```
cargo doc --no-dep -p vortex-flatbuffers
```

but not by

```
cargo doc --no-dep
```