### PR TITLE
chore: remove most nightly features usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,3 +24,5 @@
   or cheap non-zero-cost abstractions.
 * Every new public API definition must have a doc comment. Examples are nice to have but not
   strictly required.
+* Use `vortex_err!` to create a `VortexError` with a format string and `vortex_bail!` to do the same but immediately
+  return it as a `VortexResult<T>` to the surrounding context.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ version = "55.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73a47aa0c771b5381de2b7f16998d351a6f4eb839f1e13d48353e17e873d969b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -576,7 +576,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -595,12 +595,6 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -646,7 +640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
 dependencies = [
  "once_cell",
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -987,7 +981,7 @@ checksum = "30fe872bc4214626b35d3a1706a905d0243503bb6ba3bb7be2fc59083d5d680c"
 dependencies = [
  "divan-macros",
  "itertools 0.14.0",
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -1168,7 +1162,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05ed201484967dc70de77a8f7a02b29aaa8e6c81cbea2e75492ee0c8d97766b"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -1420,7 +1414,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -2387,7 +2381,7 @@ version = "25.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1045398c1bfd89168b5fd3f1fc11f6e70b34f6f66300c87d44d3de849463abf1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "rustc_version",
 ]
 
@@ -2400,19 +2394,6 @@ dependencies = [
  "crc32fast",
  "libz-rs-sys",
  "miniz_oxide",
-]
-
-[[package]]
-name = "flexbuffers"
-version = "25.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935627e7bc8f083035d9faad09ffaed9128f73fb1f74a8798f115749c43378e8"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "num_enum 0.5.11",
- "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -3079,7 +3060,7 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ebb93303c65a11753dd0e45cd6bfa5c65ee1f0b9f8e2178b6998ddc8b284f04"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "cfg-if",
  "libc",
 ]
@@ -3426,7 +3407,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "libc",
  "redox_syscall",
 ]
@@ -3682,7 +3663,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3811,32 +3792,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive 0.5.11",
-]
-
-[[package]]
-name = "num_enum"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
- "num_enum_derive 0.7.3",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "num_enum_derive",
 ]
 
 [[package]]
@@ -4320,21 +4280,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
- "toml_edit 0.22.27",
+ "toml_edit",
 ]
 
 [[package]]
@@ -4671,7 +4621,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -4732,7 +4682,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -4921,7 +4871,7 @@ checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
 dependencies = [
  "cfg-if",
  "glob",
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "regex",
@@ -4985,7 +4935,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4998,7 +4948,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -5115,7 +5065,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5549,7 +5499,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5856,7 +5806,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.27",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5870,17 +5820,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
@@ -5890,7 +5829,7 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "toml_write",
- "winnow 0.7.10",
+ "winnow",
 ]
 
 [[package]]
@@ -5941,7 +5880,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -6264,7 +6203,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "num-traits",
- "num_enum 0.7.3",
+ "num_enum",
  "parking_lot",
  "paste",
  "pin-project",
@@ -6426,7 +6365,7 @@ dependencies = [
  "itertools 0.14.0",
  "jiff",
  "num-traits",
- "num_enum 0.7.3",
+ "num_enum",
  "prost",
  "serde",
  "serde_json",
@@ -6477,7 +6416,6 @@ version = "0.1.0"
 dependencies = [
  "arrow-schema",
  "flatbuffers",
- "flexbuffers",
  "jiff",
  "object_store",
  "parquet",
@@ -7501,15 +7439,6 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
@@ -7523,7 +7452,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3917,6 +3917,9 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "parking_lot_core",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -6713,6 +6716,7 @@ dependencies = [
  "getrandom 0.3.3",
  "itertools 0.14.0",
  "log",
+ "once_cell",
  "parking_lot",
  "paste",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ moka = { version = "0.12.10", default-features = false }
 num-traits = "0.2.19"
 num_enum = { version = "0.7.3", default-features = false }
 object_store = "0.12.1"
-once_cell = "1"
+once_cell = "1.21"
 opentelemetry = "0.29.0"
 opentelemetry-otlp = "0.29.0"
 opentelemetry_sdk = "0.29.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ moka = { version = "0.12.10", default-features = false }
 num-traits = "0.2.19"
 num_enum = { version = "0.7.3", default-features = false }
 object_store = "0.12.1"
+once_cell = "1"
 opentelemetry = "0.29.0"
 opentelemetry-otlp = "0.29.0"
 opentelemetry_sdk = "0.29.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,6 @@ dyn-hash = "0.2.0"
 enum-iterator = "2.0.0"
 fastlanes = "0.1.8"
 flatbuffers = "25.2.10"
-flexbuffers = "25.2.10"
 flume = "0.11"
 fsst-rs = "0.5.2"
 futures = { version = "0.3.31", default-features = false }

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(exit_status_error)]
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::expect_used)]
 

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -73,7 +73,6 @@ fn take_primitive<T: NativePType + BitPacking, I: NativePType>(
     chunked_indices(indices_iter, offset, |chunk_idx, indices_within_chunk| {
         let packed = &packed[chunk_idx * chunk_len..][..chunk_len];
 
-        // array_chunks produced a fixed size array, doesn't heap allocate
         let mut have_unpacked = false;
         let mut offset_chunk_iter = indices_within_chunk.chunks_exact(UNPACK_CHUNK_THRESHOLD);
 

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -75,13 +75,11 @@ fn take_primitive<T: NativePType + BitPacking, I: NativePType>(
 
         // array_chunks produced a fixed size array, doesn't heap allocate
         let mut have_unpacked = false;
-        let mut offset_chunk_iter = indices_within_chunk
-            .iter()
-            .copied()
-            .array_chunks::<UNPACK_CHUNK_THRESHOLD>();
+        let mut offset_chunk_iter = indices_within_chunk.chunks_exact(UNPACK_CHUNK_THRESHOLD);
 
         // this loop only runs if we have at least UNPACK_CHUNK_THRESHOLD offsets
         for offset_chunk in &mut offset_chunk_iter {
+            assert_eq!(offset_chunk.len(), UNPACK_CHUNK_THRESHOLD); // let compiler know slice length
             if !have_unpacked {
                 unsafe {
                     let dst: &mut [MaybeUninit<T>] = &mut unpacked;
@@ -91,22 +89,22 @@ fn take_primitive<T: NativePType + BitPacking, I: NativePType>(
                 have_unpacked = true;
             }
 
-            for index in offset_chunk {
+            for &index in offset_chunk {
                 output.push(unsafe { unpacked[index].assume_init() });
             }
         }
 
         // if we have a remainder (i.e., < UNPACK_CHUNK_THRESHOLD leftover offsets), we need to handle it
-        if let Some(remainder) = offset_chunk_iter.into_remainder() {
+        if !offset_chunk_iter.remainder().is_empty() {
             if have_unpacked {
                 // we already bulk unpacked this chunk, so we can just push the remaining elements
-                for index in remainder {
+                for &index in offset_chunk_iter.remainder() {
                     output.push(unsafe { unpacked[index].assume_init() });
                 }
             } else {
                 // we had fewer than UNPACK_CHUNK_THRESHOLD offsets in the first place,
                 // so we need to unpack each one individually
-                for index in remainder {
+                for &index in offset_chunk_iter.remainder() {
                     output.push(unsafe { unpack_single_primitive::<T>(packed, bit_width, index) });
                 }
             }

--- a/encodings/fastlanes/src/lib.rs
+++ b/encodings/fastlanes/src/lib.rs
@@ -1,8 +1,6 @@
 #![allow(incomplete_features)]
 #![allow(clippy::cast_possible_truncation)]
 #![feature(generic_const_exprs)]
-#![feature(vec_into_raw_parts)]
-#![feature(iter_array_chunks)]
 
 pub use bitpacking::*;
 pub use delta::*;

--- a/java/testfiles/Cargo.lock
+++ b/java/testfiles/Cargo.lock
@@ -296,12 +296,6 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
@@ -311,12 +305,6 @@ name = "bumpalo"
 version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -572,21 +560,8 @@ version = "25.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1045398c1bfd89168b5fd3f1fc11f6e70b34f6f66300c87d44d3de849463abf1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "rustc_version",
-]
-
-[[package]]
-name = "flexbuffers"
-version = "25.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935627e7bc8f083035d9faad09ffaed9128f73fb1f74a8798f115749c43378e8"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "num_enum 0.5.11",
- "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -924,16 +899,6 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
-dependencies = [
- "equivalent",
- "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -1356,32 +1321,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive 0.5.11",
-]
-
-[[package]]
-name = "num_enum"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
- "num_enum_derive 0.7.3",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "num_enum_derive",
 ]
 
 [[package]]
@@ -1390,7 +1334,6 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.103",
@@ -1410,6 +1353,9 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "parking_lot_core",
+]
 
 [[package]]
 name = "ordered-float"
@@ -1566,25 +1512,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
-dependencies = [
- "toml_edit 0.22.27",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,26 +1553,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.103",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,15 +1566,6 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
-
-[[package]]
-name = "rancor"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947"
-dependencies = [
- "ptr_meta",
-]
 
 [[package]]
 name = "rand"
@@ -1743,7 +1641,7 @@ version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -2069,34 +1967,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow 0.7.11",
-]
-
-[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,7 +2138,7 @@ dependencies = [
  "itertools",
  "log",
  "num-traits",
- "num_enum 0.7.3",
+ "num_enum",
  "parking_lot",
  "paste",
  "pin-project",
@@ -2394,7 +2264,7 @@ dependencies = [
  "itertools",
  "jiff",
  "num-traits",
- "num_enum 0.7.3",
+ "num_enum",
  "prost",
  "serde",
  "static_assertions",
@@ -2410,10 +2280,8 @@ version = "0.1.0"
 dependencies = [
  "arrow-schema",
  "flatbuffers",
- "flexbuffers",
  "jiff",
  "prost",
- "rancor",
  "thiserror 2.0.12",
  "url",
 ]
@@ -2567,6 +2435,7 @@ dependencies = [
  "getrandom 0.3.3",
  "itertools",
  "log",
+ "once_cell",
  "parking_lot",
  "paste",
  "pin-project-lite",
@@ -3029,30 +2898,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]

--- a/vortex-array/src/arrays/list/mod.rs
+++ b/vortex-array/src/arrays/list/mod.rs
@@ -3,7 +3,6 @@ mod serde;
 
 use std::sync::Arc;
 
-#[cfg(feature = "test-harness")]
 use itertools::Itertools;
 use num_traits::{AsPrimitive, PrimInt};
 use vortex_dtype::{DType, NativePType, match_each_native_ptype};

--- a/vortex-array/src/arrays/primitive/compute/is_constant.rs
+++ b/vortex-array/src/arrays/primitive/compute/is_constant.rs
@@ -42,8 +42,9 @@ pub fn compute_is_constant<T: NativePType, const WIDTH: usize>(values: &[T]) -> 
     let first_value = values[0];
     let first_vec = &[first_value; WIDTH];
 
-    let mut chunks = values[1..].array_chunks::<WIDTH>();
+    let mut chunks = values[1..].chunks_exact(WIDTH);
     for chunk in &mut chunks {
+        assert_eq!(chunk.len(), WIDTH); // let the compiler know each chunk is WIDTH.
         if first_vec != chunk {
             return false;
         }

--- a/vortex-array/src/arrays/struct_/compute/filter.rs
+++ b/vortex-array/src/arrays/struct_/compute/filter.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 

--- a/vortex-array/src/data.rs
+++ b/vortex-array/src/data.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
 use vortex_error::{VortexError, VortexResult, vortex_bail, vortex_err};

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -1,9 +1,4 @@
-#![feature(once_cell_try)]
 #![feature(portable_simd)]
-#![feature(substr_range)]
-#![feature(trusted_len)]
-#![feature(array_chunks)]
-#![feature(iterator_try_collect)]
 //! Vortex crate containing core logic for encoding and memory representation of [arrays](ArrayRef).
 //!
 //! At the heart of Vortex are [arrays](ArrayRef) and [encodings](EncodingRef).

--- a/vortex-array/src/serde.rs
+++ b/vortex-array/src/serde.rs
@@ -3,6 +3,7 @@ use std::iter;
 use std::sync::Arc;
 
 use flatbuffers::{FlatBufferBuilder, Follow, WIPOffset, root};
+use itertools::Itertools;
 use vortex_buffer::{Alignment, ByteBuffer};
 use vortex_dtype::{DType, TryFromBytes};
 use vortex_error::{

--- a/vortex-btrblocks/src/integer/stats.rs
+++ b/vortex-btrblocks/src/integer/stats.rs
@@ -213,11 +213,15 @@ where
     };
 
     let sliced = buffer.slice(head_idx..array.len());
-    let mut chunks = sliced.as_slice().array_chunks::<64>();
+    let mut chunks = sliced.as_slice().chunks_exact(64);
     match validity.boolean_buffer() {
         AllOr::All => {
             for chunk in &mut chunks {
-                inner_loop_nonnull(chunk, count_distinct_values, &mut loop_state)
+                inner_loop_nonnull(
+                    chunk.try_into().vortex_unwrap(),
+                    count_distinct_values,
+                    &mut loop_state,
+                )
             }
             let remainder = chunks.remainder();
             inner_loop_naive(
@@ -239,10 +243,14 @@ where
                     // All nulls -> no stats to update
                     0 => continue,
                     // Inner loop for when validity check can be elided
-                    64 => inner_loop_nonnull(chunk, count_distinct_values, &mut loop_state),
+                    64 => inner_loop_nonnull(
+                        chunk.try_into().vortex_unwrap(),
+                        count_distinct_values,
+                        &mut loop_state,
+                    ),
                     // Inner loop for when we need to check validity
                     _ => inner_loop_nullable(
-                        chunk,
+                        chunk.try_into().vortex_unwrap(),
                         count_distinct_values,
                         &validity,
                         &mut loop_state,

--- a/vortex-btrblocks/src/lib.rs
+++ b/vortex-btrblocks/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(array_chunks)]
-
 use std::fmt::Debug;
 use std::hash::Hash;
 

--- a/vortex-error/Cargo.toml
+++ b/vortex-error/Cargo.toml
@@ -21,7 +21,6 @@ serde = ["dep:serde_json"]
 [dependencies]
 arrow-schema = { workspace = true }
 flatbuffers = { workspace = true, optional = true }
-flexbuffers = { workspace = true, optional = true }
 jiff = { workspace = true }
 object_store = { workspace = true, optional = true }
 parquet = { workspace = true, optional = true }

--- a/vortex-error/src/lib.rs
+++ b/vortex-error/src/lib.rs
@@ -95,15 +95,6 @@ pub enum VortexError {
     /// A wrapper for errors from the FlatBuffers library.
     #[cfg(feature = "flatbuffers")]
     FlatBuffersError(flatbuffers::InvalidFlatbuffer, Backtrace),
-    /// A wrapper for reader errors from the FlexBuffers library.
-    #[cfg(feature = "flexbuffers")]
-    FlexBuffersReaderError(flexbuffers::ReaderError, Backtrace),
-    /// A wrapper for deserialization errors from the FlexBuffers library.
-    #[cfg(feature = "flexbuffers")]
-    FlexBuffersDeError(flexbuffers::DeserializationError, Backtrace),
-    /// A wrapper for serialization errors from the FlexBuffers library.
-    #[cfg(feature = "flexbuffers")]
-    FlexBuffersSerError(flexbuffers::SerializationError, Backtrace),
     /// A wrapper for formatting errors.
     FmtError(fmt::Error, Backtrace),
     /// A wrapper for IO errors.
@@ -204,18 +195,6 @@ impl Display for VortexError {
             VortexError::FlatBuffersError(err, backtrace) => {
                 write!(f, "{}\nBacktrace:\n{}", err, backtrace)
             }
-            #[cfg(feature = "flexbuffers")]
-            VortexError::FlexBuffersReaderError(err, backtrace) => {
-                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
-            }
-            #[cfg(feature = "flexbuffers")]
-            VortexError::FlexBuffersDeError(err, backtrace) => {
-                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
-            }
-            #[cfg(feature = "flexbuffers")]
-            VortexError::FlexBuffersSerError(err, backtrace) => {
-                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
-            }
             VortexError::FmtError(err, backtrace) => {
                 write!(f, "{}\nBacktrace:\n{}", err, backtrace)
             }
@@ -282,12 +261,6 @@ impl Error for VortexError {
             VortexError::ArrowError(err, _) => Some(err),
             #[cfg(feature = "flatbuffers")]
             VortexError::FlatBuffersError(err, _) => Some(err),
-            #[cfg(feature = "flexbuffers")]
-            VortexError::FlexBuffersReaderError(err, _) => Some(err),
-            #[cfg(feature = "flexbuffers")]
-            VortexError::FlexBuffersDeError(err, _) => Some(err),
-            #[cfg(feature = "flexbuffers")]
-            VortexError::FlexBuffersSerError(err, _) => Some(err),
             VortexError::FmtError(err, _) => Some(err),
             VortexError::IOError(err, _) => Some(err),
             VortexError::Utf8Error(err, _) => Some(err),
@@ -517,27 +490,6 @@ impl From<arrow_schema::ArrowError> for VortexError {
 impl From<flatbuffers::InvalidFlatbuffer> for VortexError {
     fn from(value: flatbuffers::InvalidFlatbuffer) -> Self {
         VortexError::FlatBuffersError(value, Backtrace::capture())
-    }
-}
-
-#[cfg(feature = "flexbuffers")]
-impl From<flexbuffers::ReaderError> for VortexError {
-    fn from(value: flexbuffers::ReaderError) -> Self {
-        VortexError::FlexBuffersReaderError(value, Backtrace::capture())
-    }
-}
-
-#[cfg(feature = "flexbuffers")]
-impl From<flexbuffers::DeserializationError> for VortexError {
-    fn from(value: flexbuffers::DeserializationError) -> Self {
-        VortexError::FlexBuffersDeError(value, Backtrace::capture())
-    }
-}
-
-#[cfg(feature = "flexbuffers")]
-impl From<flexbuffers::SerializationError> for VortexError {
-    fn from(value: flexbuffers::SerializationError) -> Self {
-        VortexError::FlexBuffersSerError(value, Backtrace::capture())
     }
 }
 

--- a/vortex-error/src/lib.rs
+++ b/vortex-error/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(error_generic_member_access)]
 #![deny(missing_docs)]
 
 //! This crate defines error & result types for Vortex.
@@ -67,196 +66,253 @@ impl From<Infallible> for VortexError {
 }
 
 /// The top-level error type for Vortex.
-#[derive(thiserror::Error)]
 #[non_exhaustive]
 pub enum VortexError {
     /// A wrapped generic error
-    #[error("{0}\nBacktrace:\n{1}")]
     Generic(Box<dyn Error + Send + Sync + 'static>, Backtrace),
     /// An index is out of bounds.
-    #[error("index {0} out of bounds from {1} to {2}\nBacktrace:\n{3}")]
     OutOfBounds(usize, usize, usize, Backtrace),
     /// An error occurred while executing a compute kernel.
-    #[error("{0}\nBacktrace:\n{1}")]
     ComputeError(ErrString, Backtrace),
     /// An invalid argument was provided.
-    #[error("{0}\nBacktrace:\n{1}")]
     InvalidArgument(ErrString, Backtrace),
     /// The system has reached an invalid state,
-    #[error("{0}\nBacktrace:\n{1}")]
     InvalidState(ErrString, Backtrace),
     /// An error occurred while serializing or deserializing.
-    #[error("{0}\nBacktrace:\n{1}")]
     InvalidSerde(ErrString, Backtrace),
     /// An unimplemented function was called.
-    #[error("function {0} not implemented for {1}\nBacktrace:\n{2}")]
     NotImplemented(ErrString, ErrString, Backtrace),
     /// A type mismatch occurred.
-    #[error("expected type: {0} but instead got {1}\nBacktrace:\n{2}")]
     MismatchedTypes(ErrString, ErrString, Backtrace),
     /// An assertion failed.
-    #[error("{0}\nBacktrace:\n{1}")]
     AssertionFailed(ErrString, Backtrace),
     /// A wrapper for other errors, carrying additional context.
-    #[error("{0}: {1}")]
-    Context(ErrString, #[source] Box<VortexError>),
+    Context(ErrString, Box<VortexError>),
     /// A wrapper for shared errors that require cloning.
-    #[error(transparent)]
     Shared(Arc<VortexError>),
     /// A wrapper for errors from the Arrow library.
-    #[error("{0}\nBacktrace:\n{1}")]
     ArrowError(arrow_schema::ArrowError, Backtrace),
     /// A wrapper for errors from the FlatBuffers library.
     #[cfg(feature = "flatbuffers")]
-    #[error(transparent)]
-    FlatBuffersError(
-        #[from]
-        #[backtrace]
-        flatbuffers::InvalidFlatbuffer,
-    ),
+    FlatBuffersError(flatbuffers::InvalidFlatbuffer, Backtrace),
     /// A wrapper for reader errors from the FlexBuffers library.
     #[cfg(feature = "flexbuffers")]
-    #[error(transparent)]
-    FlexBuffersReaderError(
-        #[from]
-        #[backtrace]
-        flexbuffers::ReaderError,
-    ),
+    FlexBuffersReaderError(flexbuffers::ReaderError, Backtrace),
     /// A wrapper for deserialization errors from the FlexBuffers library.
     #[cfg(feature = "flexbuffers")]
-    #[error(transparent)]
-    FlexBuffersDeError(
-        #[from]
-        #[backtrace]
-        flexbuffers::DeserializationError,
-    ),
+    FlexBuffersDeError(flexbuffers::DeserializationError, Backtrace),
     /// A wrapper for serialization errors from the FlexBuffers library.
     #[cfg(feature = "flexbuffers")]
-    #[error(transparent)]
-    FlexBuffersSerError(
-        #[from]
-        #[backtrace]
-        flexbuffers::SerializationError,
-    ),
+    FlexBuffersSerError(flexbuffers::SerializationError, Backtrace),
     /// A wrapper for formatting errors.
-    #[error(transparent)]
-    FmtError(
-        #[from]
-        #[backtrace]
-        fmt::Error,
-    ),
+    FmtError(fmt::Error, Backtrace),
     /// A wrapper for IO errors.
-    #[error(transparent)]
-    IOError(
-        #[from]
-        #[backtrace]
-        io::Error,
-    ),
+    IOError(io::Error, Backtrace),
     /// A wrapper for UTF-8 conversion errors.
-    #[error(transparent)]
-    Utf8Error(
-        #[from]
-        #[backtrace]
-        std::str::Utf8Error,
-    ),
+    Utf8Error(std::str::Utf8Error, Backtrace),
     /// A wrapper for errors from the Parquet library.
     #[cfg(feature = "parquet")]
-    #[error(transparent)]
-    ParquetError(
-        #[from]
-        #[backtrace]
-        parquet::errors::ParquetError,
-    ),
+    ParquetError(parquet::errors::ParquetError, Backtrace),
     /// A wrapper for errors from the standard library when converting a slice to an array.
-    #[error(transparent)]
-    TryFromSliceError(
-        #[from]
-        #[backtrace]
-        std::array::TryFromSliceError,
-    ),
+    TryFromSliceError(std::array::TryFromSliceError, Backtrace),
     /// A wrapper for errors from the Cloudflare Workers library.
     #[cfg(feature = "worker")]
-    #[error(transparent)]
-    WorkerError(
-        #[from]
-        #[backtrace]
-        worker::Error,
-    ),
+    WorkerError(worker::Error, Backtrace),
     /// A wrapper for errors from the Object Store library.
     #[cfg(feature = "object_store")]
-    #[error(transparent)]
-    ObjectStore(
-        #[from]
-        #[backtrace]
-        object_store::Error,
-    ),
+    ObjectStore(object_store::Error, Backtrace),
     /// A wrapper for errors from the Jiff library.
-    #[error(transparent)]
-    JiffError(
-        #[from]
-        #[backtrace]
-        jiff::Error,
-    ),
+    JiffError(jiff::Error, Backtrace),
     /// A wrapper for Tokio join error.
     #[cfg(feature = "tokio")]
-    #[error(transparent)]
-    JoinError(
-        #[from]
-        #[backtrace]
-        tokio::task::JoinError,
-    ),
+    JoinError(tokio::task::JoinError, Backtrace),
     /// A wrapper for URL parsing errors.
-    #[error(transparent)]
-    UrlError(
-        #[from]
-        #[backtrace]
-        url::ParseError,
-    ),
+    UrlError(url::ParseError, Backtrace),
     /// Wrap errors for fallible integer casting.
-    #[error(transparent)]
-    TryFromInt(
-        #[from]
-        #[backtrace]
-        TryFromIntError,
-    ),
+    TryFromInt(TryFromIntError, Backtrace),
     /// Wrap serde and serde json errors
     #[cfg(feature = "serde")]
-    #[error(transparent)]
-    SerdeJsonError(
-        #[from]
-        #[backtrace]
-        serde_json::Error,
-    ),
+    SerdeJsonError(serde_json::Error, Backtrace),
     /// Wrap prost encode error
     #[cfg(feature = "prost")]
-    #[error(transparent)]
-    ProstEncodeError(
-        #[from]
-        #[backtrace]
-        prost::EncodeError,
-    ),
+    ProstEncodeError(prost::EncodeError, Backtrace),
     /// Wrap prost decode error
     #[cfg(feature = "prost")]
-    #[error(transparent)]
-    ProstDecodeError(
-        #[from]
-        #[backtrace]
-        prost::DecodeError,
-    ),
+    ProstDecodeError(prost::DecodeError, Backtrace),
     /// Wrap prost unknown enum value
     #[cfg(feature = "prost")]
-    #[error(transparent)]
-    ProstUnknownEnumValue(
-        #[from]
-        #[backtrace]
-        prost::UnknownEnumValue,
-    ),
+    ProstUnknownEnumValue(prost::UnknownEnumValue, Backtrace),
 }
 
 impl VortexError {
     /// Adds additional context to an error.
     pub fn with_context<T: Into<ErrString>>(self, msg: T) -> Self {
         VortexError::Context(msg.into(), Box::new(self))
+    }
+}
+
+impl Display for VortexError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            VortexError::Generic(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            VortexError::OutOfBounds(idx, start, stop, backtrace) => {
+                write!(
+                    f,
+                    "index {} out of bounds from {} to {}\nBacktrace:\n{}",
+                    idx, start, stop, backtrace
+                )
+            }
+            VortexError::ComputeError(msg, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", msg, backtrace)
+            }
+            VortexError::InvalidArgument(msg, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", msg, backtrace)
+            }
+            VortexError::InvalidState(msg, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", msg, backtrace)
+            }
+            VortexError::InvalidSerde(msg, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", msg, backtrace)
+            }
+            VortexError::NotImplemented(func, by_whom, backtrace) => {
+                write!(
+                    f,
+                    "function {} not implemented for {}\nBacktrace:\n{}",
+                    func, by_whom, backtrace
+                )
+            }
+            VortexError::MismatchedTypes(expected, actual, backtrace) => {
+                write!(
+                    f,
+                    "expected type: {} but instead got {}\nBacktrace:\n{}",
+                    expected, actual, backtrace
+                )
+            }
+            VortexError::AssertionFailed(msg, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", msg, backtrace)
+            }
+            VortexError::Context(msg, inner) => {
+                write!(f, "{}: {}", msg, inner)
+            }
+            VortexError::Shared(inner) => Display::fmt(inner, f),
+            VortexError::ArrowError(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            #[cfg(feature = "flatbuffers")]
+            VortexError::FlatBuffersError(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            #[cfg(feature = "flexbuffers")]
+            VortexError::FlexBuffersReaderError(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            #[cfg(feature = "flexbuffers")]
+            VortexError::FlexBuffersDeError(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            #[cfg(feature = "flexbuffers")]
+            VortexError::FlexBuffersSerError(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            VortexError::FmtError(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            VortexError::IOError(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            VortexError::Utf8Error(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            #[cfg(feature = "parquet")]
+            VortexError::ParquetError(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            VortexError::TryFromSliceError(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            #[cfg(feature = "worker")]
+            VortexError::WorkerError(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            #[cfg(feature = "object_store")]
+            VortexError::ObjectStore(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            VortexError::JiffError(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            #[cfg(feature = "tokio")]
+            VortexError::JoinError(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            VortexError::UrlError(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            VortexError::TryFromInt(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            #[cfg(feature = "serde")]
+            VortexError::SerdeJsonError(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            #[cfg(feature = "prost")]
+            VortexError::ProstEncodeError(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            #[cfg(feature = "prost")]
+            VortexError::ProstDecodeError(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+            #[cfg(feature = "prost")]
+            VortexError::ProstUnknownEnumValue(err, backtrace) => {
+                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
+            }
+        }
+    }
+}
+
+impl Error for VortexError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            VortexError::Generic(err, _) => Some(err.as_ref()),
+            VortexError::Context(_, inner) => inner.source(),
+            VortexError::Shared(inner) => inner.source(),
+            VortexError::ArrowError(err, _) => Some(err),
+            #[cfg(feature = "flatbuffers")]
+            VortexError::FlatBuffersError(err, _) => Some(err),
+            #[cfg(feature = "flexbuffers")]
+            VortexError::FlexBuffersReaderError(err, _) => Some(err),
+            #[cfg(feature = "flexbuffers")]
+            VortexError::FlexBuffersDeError(err, _) => Some(err),
+            #[cfg(feature = "flexbuffers")]
+            VortexError::FlexBuffersSerError(err, _) => Some(err),
+            VortexError::FmtError(err, _) => Some(err),
+            VortexError::IOError(err, _) => Some(err),
+            VortexError::Utf8Error(err, _) => Some(err),
+            #[cfg(feature = "parquet")]
+            VortexError::ParquetError(err, _) => Some(err),
+            VortexError::TryFromSliceError(err, _) => Some(err),
+            #[cfg(feature = "worker")]
+            VortexError::WorkerError(err, _) => Some(err),
+            #[cfg(feature = "object_store")]
+            VortexError::ObjectStore(err, _) => Some(err),
+            VortexError::JiffError(err, _) => Some(err),
+            #[cfg(feature = "tokio")]
+            VortexError::JoinError(err, _) => Some(err),
+            VortexError::UrlError(err, _) => Some(err),
+            VortexError::TryFromInt(err, _) => Some(err),
+            #[cfg(feature = "serde")]
+            VortexError::SerdeJsonError(err, _) => Some(err),
+            #[cfg(feature = "prost")]
+            VortexError::ProstEncodeError(err, _) => Some(err),
+            #[cfg(feature = "prost")]
+            VortexError::ProstDecodeError(err, _) => Some(err),
+            #[cfg(feature = "prost")]
+            VortexError::ProstUnknownEnumValue(err, _) => Some(err),
+            _ => None,
+        }
     }
 }
 
@@ -357,6 +413,12 @@ macro_rules! vortex_err {
             $crate::VortexError::AssertionFailed(err_string.into(), Backtrace::capture())
         )
     }};
+    (IOError: $($tts:tt)*) => {{
+        use std::backtrace::Backtrace;
+        $crate::__private::must_use(
+            $crate::VortexError::IOError(err_string.into(), Backtrace::capture())
+        )
+    }};
     (OutOfBounds: $idx:expr, $start:expr, $stop:expr) => {{
         use std::backtrace::Backtrace;
         $crate::__private::must_use(
@@ -448,6 +510,132 @@ macro_rules! vortex_panic {
 impl From<arrow_schema::ArrowError> for VortexError {
     fn from(value: arrow_schema::ArrowError) -> Self {
         VortexError::ArrowError(value, Backtrace::capture())
+    }
+}
+
+#[cfg(feature = "flatbuffers")]
+impl From<flatbuffers::InvalidFlatbuffer> for VortexError {
+    fn from(value: flatbuffers::InvalidFlatbuffer) -> Self {
+        VortexError::FlatBuffersError(value, Backtrace::capture())
+    }
+}
+
+#[cfg(feature = "flexbuffers")]
+impl From<flexbuffers::ReaderError> for VortexError {
+    fn from(value: flexbuffers::ReaderError) -> Self {
+        VortexError::FlexBuffersReaderError(value, Backtrace::capture())
+    }
+}
+
+#[cfg(feature = "flexbuffers")]
+impl From<flexbuffers::DeserializationError> for VortexError {
+    fn from(value: flexbuffers::DeserializationError) -> Self {
+        VortexError::FlexBuffersDeError(value, Backtrace::capture())
+    }
+}
+
+#[cfg(feature = "flexbuffers")]
+impl From<flexbuffers::SerializationError> for VortexError {
+    fn from(value: flexbuffers::SerializationError) -> Self {
+        VortexError::FlexBuffersSerError(value, Backtrace::capture())
+    }
+}
+
+impl From<fmt::Error> for VortexError {
+    fn from(value: fmt::Error) -> Self {
+        VortexError::FmtError(value, Backtrace::capture())
+    }
+}
+
+impl From<io::Error> for VortexError {
+    fn from(value: io::Error) -> Self {
+        VortexError::IOError(value, Backtrace::capture())
+    }
+}
+
+impl From<std::str::Utf8Error> for VortexError {
+    fn from(value: std::str::Utf8Error) -> Self {
+        VortexError::Utf8Error(value, Backtrace::capture())
+    }
+}
+
+#[cfg(feature = "parquet")]
+impl From<parquet::errors::ParquetError> for VortexError {
+    fn from(value: parquet::errors::ParquetError) -> Self {
+        VortexError::ParquetError(value, Backtrace::capture())
+    }
+}
+
+impl From<std::array::TryFromSliceError> for VortexError {
+    fn from(value: std::array::TryFromSliceError) -> Self {
+        VortexError::TryFromSliceError(value, Backtrace::capture())
+    }
+}
+
+#[cfg(feature = "worker")]
+impl From<worker::Error> for VortexError {
+    fn from(value: worker::Error) -> Self {
+        VortexError::WorkerError(value, Backtrace::capture())
+    }
+}
+
+#[cfg(feature = "object_store")]
+impl From<object_store::Error> for VortexError {
+    fn from(value: object_store::Error) -> Self {
+        VortexError::ObjectStore(value, Backtrace::capture())
+    }
+}
+
+impl From<jiff::Error> for VortexError {
+    fn from(value: jiff::Error) -> Self {
+        VortexError::JiffError(value, Backtrace::capture())
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl From<tokio::task::JoinError> for VortexError {
+    fn from(value: tokio::task::JoinError) -> Self {
+        VortexError::JoinError(value, Backtrace::capture())
+    }
+}
+
+impl From<url::ParseError> for VortexError {
+    fn from(value: url::ParseError) -> Self {
+        VortexError::UrlError(value, Backtrace::capture())
+    }
+}
+
+impl From<TryFromIntError> for VortexError {
+    fn from(value: TryFromIntError) -> Self {
+        VortexError::TryFromInt(value, Backtrace::capture())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl From<serde_json::Error> for VortexError {
+    fn from(value: serde_json::Error) -> Self {
+        VortexError::SerdeJsonError(value, Backtrace::capture())
+    }
+}
+
+#[cfg(feature = "prost")]
+impl From<prost::EncodeError> for VortexError {
+    fn from(value: prost::EncodeError) -> Self {
+        VortexError::ProstEncodeError(value, Backtrace::capture())
+    }
+}
+
+#[cfg(feature = "prost")]
+impl From<prost::DecodeError> for VortexError {
+    fn from(value: prost::DecodeError) -> Self {
+        VortexError::ProstDecodeError(value, Backtrace::capture())
+    }
+}
+
+#[cfg(feature = "prost")]
+impl From<prost::UnknownEnumValue> for VortexError {
+    fn from(value: prost::UnknownEnumValue) -> Self {
+        VortexError::ProstUnknownEnumValue(value, Backtrace::capture())
     }
 }
 

--- a/vortex-expr/src/binary.rs
+++ b/vortex-expr/src/binary.rs
@@ -92,8 +92,8 @@ impl AnalysisExpr for BinaryExpr {
                 let min_rhs = self.rhs.min(catalog);
                 let max_rhs = self.rhs.max(catalog);
 
-                let left = min_lhs.zip_with(max_rhs, gt);
-                let right = min_rhs.zip_with(max_lhs, gt);
+                let left = min_lhs.zip(max_rhs).map(|(a, b)| gt(a, b));
+                let right = min_rhs.zip(max_lhs).map(|(a, b)| gt(a, b));
                 left.into_iter().chain(right).reduce(or)
             }
             Operator::NotEq => {

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(option_zip)]
-
 use std::any::Any;
 use std::fmt::{Debug, Display};
 use std::hash::Hash;

--- a/vortex-ffi/src/file.rs
+++ b/vortex-ffi/src/file.rs
@@ -285,8 +285,8 @@ fn make_object_store(
     property_keys: &[String],
     property_vals: &[String],
 ) -> VortexResult<Arc<dyn ObjectStore>> {
-    let (scheme, _) =
-        ObjectStoreScheme::parse(url).map_err(|error| VortexError::ObjectStore(error.into()))?;
+    let (scheme, _) = ObjectStoreScheme::parse(url)
+        .map_err(|error| VortexError::from(object_store::Error::from(error)))?;
 
     if property_vals.len() != property_keys.len() {
         vortex_bail!(

--- a/vortex-jni/src/file.rs
+++ b/vortex-jni/src/file.rs
@@ -164,8 +164,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeFileMethods_scan(
         // Apply predicate if one was provided
         if !predicate.is_null() {
             let proto_vec = env.convert_byte_array(predicate)?;
-            let expr_proto =
-                Expr::decode(proto_vec.as_slice()).map_err(VortexError::ProstDecodeError)?;
+            let expr_proto = Expr::decode(proto_vec.as_slice()).map_err(VortexError::from)?;
             let expr = deserialize_expr(&expr_proto)?;
             scan_builder = scan_builder.with_filter(expr);
         }
@@ -201,8 +200,8 @@ fn make_object_store(
     static OBJECT_STORES: LazyLock<Mutex<HashMap<String, Arc<dyn ObjectStore>>>> =
         LazyLock::new(|| Mutex::new(HashMap::new()));
 
-    let (scheme, _) =
-        ObjectStoreScheme::parse(url).map_err(|error| VortexError::ObjectStore(error.into()))?;
+    let (scheme, _) = ObjectStoreScheme::parse(url)
+        .map_err(|error| VortexError::from(object_store::Error::from(error)))?;
 
     let cache_key = url_cache_key(url);
 

--- a/vortex-layout/Cargo.toml
+++ b/vortex-layout/Cargo.toml
@@ -27,6 +27,7 @@ futures = { workspace = true, features = ["alloc", "async-await", "executor"] }
 getrandom_v03 = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
+once_cell = { workspace = true, features = ["parking_lot"] }
 parking_lot = { workspace = true }
 paste = { workspace = true }
 pin-project-lite = { workspace = true }

--- a/vortex-layout/src/lib.rs
+++ b/vortex-layout/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(once_cell_try)]
-#![feature(trait_alias)]
 mod context;
 pub use context::*;
 pub mod layouts;

--- a/vortex-layout/src/reader.rs
+++ b/vortex-layout/src/reader.rs
@@ -1,14 +1,15 @@
 use std::collections::BTreeSet;
 use std::ops::Range;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::FutureExt;
 use futures::future::{BoxFuture, Shared};
+use once_cell::sync::OnceCell;
 use vortex_array::stats::Precision;
 use vortex_array::{ArrayContext, ArrayRef};
 use vortex_dtype::{DType, FieldMask};
-use vortex_error::{SharedVortexResult, VortexError, VortexResult, vortex_bail, vortex_err};
+use vortex_error::{SharedVortexResult, VortexError, VortexResult, vortex_bail};
 use vortex_expr::ExprRef;
 use vortex_mask::Mask;
 
@@ -103,7 +104,7 @@ pub struct LazyReaderChildren {
     ctx: ArrayContext,
 
     // TODO(ngates): we may want a hash map of some sort here?
-    cache: Vec<OnceLock<LayoutReaderRef>>,
+    cache: Vec<OnceCell<LayoutReaderRef>>,
 }
 
 impl LazyReaderChildren {
@@ -113,7 +114,7 @@ impl LazyReaderChildren {
         ctx: ArrayContext,
     ) -> Self {
         let nchildren = children.nchildren();
-        let cache = (0..nchildren).map(|_| OnceLock::new()).collect::<Vec<_>>();
+        let cache = (0..nchildren).map(|_| OnceCell::new()).collect();
         Self {
             children,
             segment_source,
@@ -132,26 +133,9 @@ impl LazyReaderChildren {
             vortex_bail!("Child index out of bounds: {} of {}", idx, self.cache.len());
         }
 
-        if let Some(reader) = self.cache[idx].get() {
-            return Ok(reader);
-        }
-
-        let child = self.children.child(idx, dtype)?;
-        let reader =
-            child.new_reader(name.clone(), self.segment_source.clone(), self.ctx.clone())?;
-
-        // Try to set the value, but if another thread beat us to it, use their value instead
-        match self.cache[idx].set(reader) {
-            Ok(()) => self.cache[idx]
-                .get()
-                .ok_or_else(|| vortex_err!(InvalidState: "Failed to retrieve just-set value")),
-            Err(_) => {
-                // Another thread set the value first, use the cached value
-                // The reader we created gets dropped here
-                self.cache[idx].get().ok_or_else(
-                    || vortex_err!(InvalidState: "Expected cached value after failed set"),
-                )
-            }
-        }
+        self.cache[idx].get_or_try_init(|| {
+            let child = self.children.child(idx, dtype)?;
+            child.new_reader(name.clone(), self.segment_source.clone(), self.ctx.clone())
+        })
     }
 }

--- a/vortex-layout/src/reader.rs
+++ b/vortex-layout/src/reader.rs
@@ -8,7 +8,7 @@ use futures::future::{BoxFuture, Shared};
 use vortex_array::stats::Precision;
 use vortex_array::{ArrayContext, ArrayRef};
 use vortex_dtype::{DType, FieldMask};
-use vortex_error::{SharedVortexResult, VortexError, VortexResult, vortex_bail};
+use vortex_error::{SharedVortexResult, VortexError, VortexResult, vortex_bail, vortex_err};
 use vortex_expr::ExprRef;
 use vortex_mask::Mask;
 
@@ -131,9 +131,27 @@ impl LazyReaderChildren {
         if idx >= self.cache.len() {
             vortex_bail!("Child index out of bounds: {} of {}", idx, self.cache.len());
         }
-        self.cache[idx].get_or_try_init(|| {
-            let child = self.children.child(idx, dtype)?;
-            child.new_reader(name.clone(), self.segment_source.clone(), self.ctx.clone())
-        })
+
+        if let Some(reader) = self.cache[idx].get() {
+            return Ok(reader);
+        }
+
+        let child = self.children.child(idx, dtype)?;
+        let reader =
+            child.new_reader(name.clone(), self.segment_source.clone(), self.ctx.clone())?;
+
+        // Try to set the value, but if another thread beat us to it, use their value instead
+        match self.cache[idx].set(reader) {
+            Ok(()) => self.cache[idx]
+                .get()
+                .ok_or_else(|| vortex_err!(InvalidState: "Failed to retrieve just-set value")),
+            Err(_) => {
+                // Another thread set the value first, use the cached value
+                // The reader we created gets dropped here
+                self.cache[idx].get().ok_or_else(
+                    || vortex_err!(InvalidState: "Expected cached value after failed set"),
+                )
+            }
+        }
     }
 }

--- a/vortex-mask/src/lib.rs
+++ b/vortex-mask/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(trusted_len)]
 //! A mask is a set of sorted unique positive integers.
 #![deny(missing_docs)]
 mod bitops;

--- a/vortex-python/src/lib.rs
+++ b/vortex-python/src/lib.rs
@@ -31,7 +31,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 static TOKIO_RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
     Runtime::new()
-        .map_err(VortexError::IOError)
+        .map_err(VortexError::from)
         .vortex_expect("tokio runtime must not fail to start")
 });
 

--- a/wasm-test/Cargo.lock
+++ b/wasm-test/Cargo.lock
@@ -242,16 +242,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "better_io"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92fde17f91e7ba10b2a07f8dff29530b77144894bc6ae850fbc66e1276af0d28"
+
+[[package]]
 name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -264,12 +264,6 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -374,6 +368,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtype_dispatch"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a5ccdfd6c5e7e2fea9c5cf256f2a08216047fab19c621c3da64e9ae4a1462d"
+
+[[package]]
 name = "dyn-hash"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,21 +469,8 @@ version = "25.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1045398c1bfd89168b5fd3f1fc11f6e70b34f6f66300c87d44d3de849463abf1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "rustc_version",
-]
-
-[[package]]
-name = "flexbuffers"
-version = "25.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935627e7bc8f083035d9faad09ffaed9128f73fb1f74a8798f115749c43378e8"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "num_enum 0.5.11",
- "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -603,10 +590,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -821,16 +806,6 @@ checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
-dependencies = [
- "equivalent",
- "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -1150,32 +1125,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive 0.5.11",
-]
-
-[[package]]
-name = "num_enum"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
- "num_enum_derive 0.7.3",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "num_enum_derive",
 ]
 
 [[package]]
@@ -1184,7 +1138,6 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -1195,6 +1148,9 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "parking_lot_core",
+]
 
 [[package]]
 name = "ordered-float"
@@ -1242,6 +1198,18 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pco"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e5e35686bd1ed459b4617bdd0b9740d566cbe7b3116fee0d99c9d9237d6fe91"
+dependencies = [
+ "better_io",
+ "dtype_dispatch",
+ "half",
+ "rand_xoshiro",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1312,25 +1280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
-dependencies = [
- "toml_edit 0.22.26",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,26 +1321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,15 +1334,6 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
-
-[[package]]
-name = "rancor"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947"
-dependencies = [
- "ptr_meta",
-]
 
 [[package]]
 name = "rand"
@@ -1475,12 +1395,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1710,34 +1639,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow 0.7.9",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,11 +1695,13 @@ dependencies = [
  "vortex-layout",
  "vortex-mask",
  "vortex-metrics",
+ "vortex-pco",
  "vortex-proto",
  "vortex-runend",
  "vortex-scalar",
  "vortex-sequence",
  "vortex-sparse",
+ "vortex-utils",
  "vortex-zigzag",
 ]
 
@@ -1817,6 +1720,7 @@ dependencies = [
  "vortex-fastlanes",
  "vortex-mask",
  "vortex-scalar",
+ "vortex-utils",
 ]
 
 [[package]]
@@ -1844,7 +1748,7 @@ dependencies = [
  "itertools",
  "log",
  "num-traits",
- "num_enum 0.7.3",
+ "num_enum",
  "parking_lot",
  "paste",
  "pin-project",
@@ -1859,6 +1763,7 @@ dependencies = [
  "vortex-flatbuffers",
  "vortex-mask",
  "vortex-scalar",
+ "vortex-utils",
 ]
 
 [[package]]
@@ -1866,7 +1771,7 @@ name = "vortex-btrblocks"
 version = "0.1.0"
 dependencies = [
  "arrow-buffer",
- "getrandom 0.2.16",
+ "getrandom 0.3.2",
  "itertools",
  "log",
  "num-traits",
@@ -1886,6 +1791,7 @@ dependencies = [
  "vortex-runend",
  "vortex-scalar",
  "vortex-sparse",
+ "vortex-utils",
  "vortex-zigzag",
 ]
 
@@ -1955,6 +1861,7 @@ dependencies = [
  "vortex-error",
  "vortex-mask",
  "vortex-scalar",
+ "vortex-utils",
 ]
 
 [[package]]
@@ -1967,13 +1874,14 @@ dependencies = [
  "itertools",
  "jiff",
  "num-traits",
- "num_enum 0.7.3",
+ "num_enum",
  "prost",
  "serde",
  "static_assertions",
  "vortex-error",
  "vortex-flatbuffers",
  "vortex-proto",
+ "vortex-utils",
 ]
 
 [[package]]
@@ -1982,10 +1890,8 @@ version = "0.1.0"
 dependencies = [
  "arrow-schema",
  "flatbuffers",
- "flexbuffers",
  "jiff",
  "prost",
- "rancor",
  "thiserror",
  "url",
 ]
@@ -2003,6 +1909,7 @@ dependencies = [
  "vortex-mask",
  "vortex-proto",
  "vortex-scalar",
+ "vortex-utils",
 ]
 
 [[package]]
@@ -2079,6 +1986,7 @@ dependencies = [
  "getrandom 0.3.2",
  "itertools",
  "log",
+ "once_cell",
  "parking_lot",
  "paste",
  "pin-project-lite",
@@ -2095,6 +2003,8 @@ dependencies = [
  "vortex-mask",
  "vortex-metrics",
  "vortex-scalar",
+ "vortex-sequence",
+ "vortex-utils",
 ]
 
 [[package]]
@@ -2113,6 +2023,21 @@ dependencies = [
  "getrandom 0.3.2",
  "parking_lot",
  "witchcraft-metrics",
+]
+
+[[package]]
+name = "vortex-pco"
+version = "0.1.0"
+dependencies = [
+ "half",
+ "pco",
+ "prost",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-dtype",
+ "vortex-error",
+ "vortex-mask",
+ "vortex-scalar",
 ]
 
 [[package]]
@@ -2185,6 +2110,13 @@ dependencies = [
  "vortex-error",
  "vortex-mask",
  "vortex-scalar",
+]
+
+[[package]]
+name = "vortex-utils"
+version = "0.1.0"
+dependencies = [
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -2413,30 +2345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
 ]
 
 [[package]]


### PR DESCRIPTION
Part of addressing #3546 

Takes us from 18 nightly flags -> 5. Some were just totally unused, others were very easy to port to equivalent stable code.

This still leaves const generic exprs (for fastlanes), portable_simd for one function, and trustedlen specialization for vortex-buffer. I will deal with those in a follow up.

Signed-off-by: Andrew Duffy <andrew@a10y.dev>