### PR TITLE
chore: Cleanup some effectively unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
 dependencies = [
  "bytecheck_derive",
- "ptr_meta 0.1.4",
+ "ptr_meta",
  "simdutf8",
 ]
 
@@ -3845,7 +3845,6 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -4411,16 +4410,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
 dependencies = [
- "ptr_meta_derive 0.1.4",
-]
-
-[[package]]
-name = "ptr_meta"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90"
-dependencies = [
- "ptr_meta_derive 0.3.0",
+ "ptr_meta_derive",
 ]
 
 [[package]]
@@ -4432,17 +4422,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -4614,15 +4593,6 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "rancor"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947"
-dependencies = [
- "ptr_meta 0.3.0",
-]
 
 [[package]]
 name = "rand"
@@ -4899,7 +4869,7 @@ dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.12.3",
- "ptr_meta 0.1.4",
+ "ptr_meta",
  "rend",
  "rkyv_derive",
  "seahash",
@@ -6510,7 +6480,6 @@ dependencies = [
  "parquet",
  "prost",
  "pyo3",
- "rancor",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ memmap2 = "0.9.5"
 mimalloc = "0.1.42"
 moka = { version = "0.12.10", default-features = false }
 num-traits = "0.2.19"
-num_enum = {version = "0.7.3", default-features = false}
+num_enum = { version = "0.7.3", default-features = false }
 object_store = "0.12.1"
 opentelemetry = "0.29.0"
 opentelemetry-otlp = "0.29.0"
@@ -218,7 +218,9 @@ vortex-ffi = { path = "./vortex-ffi", default-features = false }
 worker = "0.5.0"
 xshell = "0.2.6"
 zigzag = "0.1.0"
-zstd = { version = "0.13.3", default-features = false, features = ["zdict_builder"] }
+zstd = { version = "0.13.3", default-features = false, features = [
+    "zdict_builder",
+] }
 
 [workspace.dependencies.getrandom_v03]
 features = ["wasm_js"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ memmap2 = "0.9.5"
 mimalloc = "0.1.42"
 moka = { version = "0.12.10", default-features = false }
 num-traits = "0.2.19"
-num_enum = "0.7.2"
+num_enum = {version = "0.7.3", default-features = false}
 object_store = "0.12.1"
 opentelemetry = "0.29.0"
 opentelemetry-otlp = "0.29.0"
@@ -134,7 +134,6 @@ prost-build = "0.13.4"
 prost-types = "0.13.4"
 pyo3 = { version = "0.24.1", features = ["extension-module", "abi3-py310"] }
 pyo3-log = "0.12.1"
-rancor = "0.1.0"
 rand = "0.9.0"
 parking_lot = { version = "0.12.3", features = ["nightly"] }
 rand_distr = "0.5"
@@ -219,7 +218,7 @@ vortex-ffi = { path = "./vortex-ffi", default-features = false }
 worker = "0.5.0"
 xshell = "0.2.6"
 zigzag = "0.1.0"
-zstd = "0.13"
+zstd = { version = "0.13.3", default-features = false, features = ["zdict_builder"] }
 
 [workspace.dependencies.getrandom_v03]
 features = ["wasm_js"]

--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -53,12 +53,7 @@ serde = { workspace = true, features = ["derive"] }
 static_assertions = { workspace = true }
 vortex-buffer = { workspace = true, features = ["arrow"] }
 vortex-dtype = { workspace = true, features = ["arrow", "serde"] }
-vortex-error = { workspace = true, features = [
-    "flatbuffers",
-    "flexbuffers",
-    "prost",
-    "rancor",
-] }
+vortex-error = { workspace = true, features = ["prost"] }
 vortex-flatbuffers = { workspace = true, features = ["array"] }
 vortex-mask = { workspace = true }
 vortex-scalar = { workspace = true }

--- a/vortex-error/Cargo.toml
+++ b/vortex-error/Cargo.toml
@@ -27,7 +27,6 @@ object_store = { workspace = true, optional = true }
 parquet = { workspace = true, optional = true }
 prost = { workspace = true, optional = true }
 pyo3 = { workspace = true, optional = true }
-rancor = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt"], optional = true }

--- a/vortex-error/src/lib.rs
+++ b/vortex-error/src/lib.rs
@@ -463,23 +463,6 @@ pub mod __private {
     }
 }
 
-#[cfg(feature = "rancor")]
-impl rancor::Source for VortexError {
-    fn new<T: Error + Send + Sync + 'static>(source: T) -> Self {
-        VortexError::Generic(Box::new(source), Backtrace::capture())
-    }
-}
-
-#[cfg(feature = "rancor")]
-impl rancor::Trace for VortexError {
-    fn trace<R>(self, trace: R) -> Self
-    where
-        R: Debug + Display + Send + Sync + 'static,
-    {
-        VortexError::Context(trace.to_string().into(), Box::new(self))
-    }
-}
-
 #[cfg(feature = "worker")]
 impl From<VortexError> for worker::Error {
     fn from(value: VortexError) -> Self {


### PR DESCRIPTION
Inspired by a conversation with @joseph-isaacs.

The next candidate for some dependency cleanup might be `jiff`, which is now tied with `zstd-sys` to be the biggest non arrow or vortex dependency of the core crate. 