### PR TITLE
Make sure the session config gets applied to our tables

### DIFF
--- a/bench-vortex/src/clickbench.rs
+++ b/bench-vortex/src/clickbench.rs
@@ -216,8 +216,9 @@ pub async fn register_vortex_files(
 
     let table_url = ListingTableUrl::parse(vortex_path)?;
 
-    let config =
-        ListingTableConfig::new(table_url).with_listing_options(ListingOptions::new(format));
+    let config = ListingTableConfig::new(table_url).with_listing_options(
+        ListingOptions::new(format).with_session_config_options(session.state().config()),
+    );
 
     let config = if let Some(schema) = schema {
         config.with_schema(schema.into())
@@ -248,7 +249,9 @@ pub fn register_parquet_files(
     let table_url = ListingTableUrl::parse(table_path)?;
 
     let config = ListingTableConfig::new(table_url)
-        .with_listing_options(ListingOptions::new(format))
+        .with_listing_options(
+            ListingOptions::new(format).with_session_config_options(session.state().config()),
+        )
         .with_schema(schema.clone().into());
 
     let listing_table = Arc::new(ListingTable::try_new(config)?);

--- a/bench-vortex/src/datasets/file.rs
+++ b/bench-vortex/src/datasets/file.rs
@@ -66,8 +66,9 @@ pub async fn register_parquet_files(
             info!("Registering table from {}", &parquet_path);
             let table_url = ListingTableUrl::parse(parquet_path)?;
 
-            let config = ListingTableConfig::new(table_url)
-                .with_listing_options(ListingOptions::new(format));
+            let config = ListingTableConfig::new(table_url).with_listing_options(
+                ListingOptions::new(format).with_session_config_options(session.state().config()),
+            );
 
             let config = if let Some(schema) = schema {
                 config.with_schema(schema.into())
@@ -97,8 +98,9 @@ pub async fn register_vortex_files(
             // Register the Vortex file
             let format = Arc::new(VortexFormat::default());
             let table_url = ListingTableUrl::parse(file_url.as_str())?;
-            let config = ListingTableConfig::new(table_url)
-                .with_listing_options(ListingOptions::new(format));
+            let config = ListingTableConfig::new(table_url).with_listing_options(
+                ListingOptions::new(format).with_session_config_options(session.state().config()),
+            );
 
             let config = if let Some(schema) = schema {
                 config.with_schema(schema.into())

--- a/bench-vortex/src/public_bi.rs
+++ b/bench-vortex/src/public_bi.rs
@@ -393,7 +393,10 @@ impl PBIData {
             let path = self.get_file_path(&table.name, file_type);
             let table_url = ListingTableUrl::parse(path.to_str().expect("unicode"))?;
             let config = ListingTableConfig::new(table_url)
-                .with_listing_options(ListingOptions::new(df_format))
+                .with_listing_options(
+                    ListingOptions::new(df_format)
+                        .with_session_config_options(session.state().config()),
+                )
                 .with_schema(schema.into());
 
             let listing_table = Arc::new(ListingTable::try_new(config)?);

--- a/vortex-datafusion/examples/vortex_table.rs
+++ b/vortex-datafusion/examples/vortex_table.rs
@@ -57,7 +57,9 @@ async fn main() -> anyhow::Result<()> {
             .ok_or_else(|| vortex_err!("Path is not valid UTF-8"))?,
     )?;
     let config = ListingTableConfig::new(table_url)
-        .with_listing_options(ListingOptions::new(format))
+        .with_listing_options(
+            ListingOptions::new(format).with_session_config_options(ctx.state().config()),
+        )
         .infer_schema(&ctx.state())
         .await?;
 

--- a/vortex-datafusion/src/persistent/mod.rs
+++ b/vortex-datafusion/src/persistent/mod.rs
@@ -96,7 +96,9 @@ mod tests {
         assert!(table_url.is_collection());
 
         let config = ListingTableConfig::new(table_url)
-            .with_listing_options(ListingOptions::new(format))
+            .with_listing_options(
+                ListingOptions::new(format).with_session_config_options(ctx.state().config()),
+            )
             .infer_schema(&ctx.state())
             .await?;
 


### PR DESCRIPTION
This is required for https://github.com/apache/datafusion/pull/16447 to take effect (once its merged). By default datafusion will take care of that if you use the SQL interface (and do all the session state setup).