### PR TITLE
fix: make dylib rpath available for all targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,9 @@ rustflags = [
     "-C", "force-frame-pointers=yes",
     # Add dynamic DuckDB library directory to runtime search path.
     "-C", "link-arg=-Wl,-rpath,$ORIGIN/../duckdb-v1.3.0",
-    "-C", "link-arg=-Wl,-rpath,@executable_path/../duckdb-v1.3.0"
+    "-C", "link-arg=-Wl,-rpath,$ORIGIN/../../duckdb-v1.3.0",
+    "-C", "link-arg=-Wl,-rpath,@executable_path/../duckdb-v1.3.0",
+    "-C", "link-arg=-Wl,-rpath,@executable_path/../../duckdb-v1.3.0"
 ]
 
 [target.wasm32-unknown-unknown]

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -129,6 +129,9 @@ jobs:
 
       - name: Run ${{ matrix.benchmark.name }} benchmark
         shell: bash
+        env:
+          RUST_BACKTRACE: full
+          LD_LIBRARY_PATH: target/duckdb-v1.3.0
         run: |
           target/release_debug/${{ matrix.benchmark.id }} -d gh-json | tee ${{ matrix.benchmark.id }}.json
 

--- a/vortex-duckdb-ext/build.rs
+++ b/vortex-duckdb-ext/build.rs
@@ -109,6 +109,7 @@ fn main() {
     // Link against DuckDB dylib.
     println!("cargo:rustc-link-search=native={}", lib_path.display());
     println!("cargo:rustc-link-lib=dylib=duckdb");
+    println!("cargo:rustc-link-arg=-Wl,-rpath,{}", lib_path.display());
 
     if env::var("TARGET").unwrap().contains("linux") {
         println!("cargo:rustc-link-lib=stdc++");


### PR DESCRIPTION
The dynamic library search path is defined relative to the executable location. Executables either reside under `target/<build_config>` or `target/<build_config>/deps`. 