### PR TITLE
bug[vortex-duckdb-ext]: fix the scan termination condition

### DIFF
--- a/vortex-duckdb-ext/src/duckdb/data_chunk.rs
+++ b/vortex-duckdb-ext/src/duckdb/data_chunk.rs
@@ -39,6 +39,14 @@ impl DataChunk {
     pub fn get_vector(&self, idx: usize) -> Vector {
         unsafe { Vector::borrow(cpp::duckdb_data_chunk_get_vector(self.as_ptr(), idx as _)) }
     }
+
+    pub fn len(&self) -> u64 {
+        unsafe { cpp::duckdb_data_chunk_get_size(self.ptr) }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 impl TryFrom<DataChunk> for String {
     type Error = VortexError;

--- a/vortex-duckdb-ext/src/duckdb/query_result.rs
+++ b/vortex-duckdb-ext/src/duckdb/query_result.rs
@@ -1,5 +1,6 @@
 use std::ffi::CStr;
 
+use bitvec::macros::internal::funty::Fundamental;
 use vortex::error::{VortexResult, vortex_err};
 
 use crate::{cpp, wrapper};
@@ -94,6 +95,12 @@ impl QueryResult {
         T::try_from(value)
     }
 
+    pub fn cell_as_str(&self, col_idx: usize, row_idx: usize) -> VortexResult<String> {
+        self.check_bounds(col_idx, row_idx)?;
+
+        unsafe { QueryResultCell::new(self.as_ptr(), col_idx, row_idx) }.to_string()
+    }
+
     /// Check if a value is null.
     pub fn is_null(&self, col_idx: usize, row_idx: usize) -> VortexResult<bool> {
         self.check_bounds(col_idx, row_idx)?;
@@ -134,6 +141,14 @@ impl QueryResultCell {
 
     pub fn column_type(&self) -> cpp::DUCKDB_TYPE {
         self.column_type
+    }
+
+    pub fn to_string(&self) -> VortexResult<String> {
+        let slice = unsafe {
+            let d = cpp::duckdb_value_string(self.result_ptr, self.col_idx, self.row_idx);
+            std::slice::from_raw_parts(d.data as *const u8, d.size.as_usize())
+        };
+        String::from_utf8(slice.to_vec()).map_err(|e| vortex_err!("{e}"))
     }
 }
 

--- a/vortex-duckdb-ext/src/scan.rs
+++ b/vortex-duckdb-ext/src/scan.rs
@@ -217,7 +217,7 @@ impl TableFunction for VortexTableFunction {
             Ok(ArrayIteratorExporter::new(Box::new(array_iterator)))
         };
 
-        if local_state.exporter.is_none() {
+        while local_state.exporter.is_none() {
             if !global_state
                 .is_first_file_processed
                 .swap(true, atomic::Ordering::SeqCst)
@@ -236,18 +236,18 @@ impl TableFunction for VortexTableFunction {
                 chunk.set_len(0);
                 return Ok(());
             }
-        }
 
-        let Some(ref mut exporter) = local_state.exporter else {
-            vortex_bail!("ArrayIteratorExporter is not set")
-        };
+            let Some(ref mut exporter) = local_state.exporter else {
+                vortex_bail!("ArrayIteratorExporter is not set")
+            };
 
-        let is_data_left_to_scan = !exporter
-            .export(chunk)
-            .map_err(|e| vortex_err!("Failed to export data: {}", e))?;
+            let is_data_left_to_scan = !exporter
+                .export(chunk)
+                .map_err(|e| vortex_err!("Failed to export data: {}", e))?;
 
-        if !is_data_left_to_scan {
-            local_state.exporter = None;
+            if is_data_left_to_scan {
+                local_state.exporter = None;
+            }
         }
 
         Ok(())

--- a/vortex-duckdb-ext/src/scan.rs
+++ b/vortex-duckdb-ext/src/scan.rs
@@ -217,7 +217,7 @@ impl TableFunction for VortexTableFunction {
             Ok(ArrayIteratorExporter::new(Box::new(array_iterator)))
         };
 
-        while local_state.exporter.is_none() {
+        loop {
             if !global_state
                 .is_first_file_processed
                 .swap(true, atomic::Ordering::SeqCst)
@@ -247,10 +247,11 @@ impl TableFunction for VortexTableFunction {
 
             if is_data_left_to_scan {
                 local_state.exporter = None;
+            } else {
+                assert!(!chunk.is_empty());
+                return Ok(());
             }
         }
-
-        Ok(())
     }
 
     fn init_global(init_input: &TableInitInput<Self>) -> VortexResult<Self::GlobalState> {


### PR DESCRIPTION
A whole export can be empty so need to keep looking for another chunk before returning

We cannot currently tests this, however I manually verified that a few queries where correct