### PR TITLE
fix: skip ddb vortex in clickbench

### DIFF
--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -85,9 +85,9 @@ jobs:
           RUST_BACKTRACE: full
         run: |
           # Generate data, running each query once to make sure they don't panic.
-          target/release_debug/${{ matrix.binary_name }} --targets datafusion:parquet -i1 -d gh-json --skip-duckdb-build
-          target/release_debug/${{ matrix.binary_name }} --targets datafusion:vortex -i1 -d gh-json --skip-duckdb-build
-          target/release_debug/${{ matrix.binary_name }} --targets duckdb:vortex -i1 -d gh-json --skip-duckdb-build
+          target/release_debug/${{ matrix.binary_name }} --targets datafusion:parquet -i1 -d gh-json
+          target/release_debug/${{ matrix.binary_name }} --targets datafusion:vortex -i1 -d gh-json
+          target/release_debug/${{ matrix.binary_name }} --targets duckdb:vortex -i1 -d gh-json
 
       - name: Upload data
         if: matrix.remote_storage != null
@@ -119,7 +119,6 @@ jobs:
             -d gh-json \
             --targets ${{ matrix.targets }} \
             --export-spans \
-            --skip-duckdb-build \
           | tee results.json
 
       - name: Run ${{ matrix.name }} benchmark (remote)
@@ -137,7 +136,6 @@ jobs:
               --use-remote-data-dir ${{ matrix.remote_storage }} \
               --targets ${{ matrix.targets }} \
               --export-spans \
-              --skip-duckdb-build \
               -d gh-json \
             | tee results.json
 

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -29,7 +29,7 @@ jobs:
             binary_name: clickbench
             name: Clickbench on NVME
             local_dir: bench-vortex/data/clickbench_partitioned
-            targets: "datafusion:parquet,datafusion:vortex,duckdb:parquet,duckdb:vortex,duckdb:duckdb"
+            targets: "datafusion:parquet,datafusion:vortex,duckdb:parquet,duckdb:duckdb"
           - id: tpch-s3
             binary_name: tpch
             name: TPC-H on S3


### PR DESCRIPTION
We'll resurrect ddb vortex in clickbench once it is more stable.