### PR TITLE
fix: duckdb vx ext memory leak

### DIFF
--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -20,8 +20,8 @@ struct CTableFunctionInfo final : TableFunctionInfo {
 };
 
 struct CTableBindData final : TableFunctionData {
-    CTableBindData(unique_ptr<CTableFunctionInfo> info_p, optional_ptr<vortex::CData> ffi_data_p)
-        : info(std::move(info_p)), ffi_data(ffi_data_p) {
+    CTableBindData(unique_ptr<CTableFunctionInfo> info_p, unique_ptr<vortex::CData> ffi_data_p)
+        : info(std::move(info_p)), ffi_data(std::move(ffi_data_p)) {
     }
 
     unique_ptr<FunctionData> Copy() const override {
@@ -32,19 +32,20 @@ struct CTableBindData final : TableFunctionData {
         if (error_out) {
             throw BinderException(IntoErrString(error_out));
         }
-        return make_uniq<CTableBindData>(make_uniq<CTableFunctionInfo>(info->vtab),
-                                         optional_ptr(reinterpret_cast<vortex::CData *>(copied_ffi_data)));
+        return make_uniq<CTableBindData>(
+            make_uniq<CTableFunctionInfo>(info->vtab),
+            unique_ptr<vortex::CData>(reinterpret_cast<vortex::CData *>(copied_ffi_data)));
     }
 
     unique_ptr<CTableFunctionInfo> info;
-    optional_ptr<vortex::CData> ffi_data;
+    unique_ptr<vortex::CData> ffi_data;
 };
 
 struct CTableGlobalData final : GlobalTableFunctionState {
-    explicit CTableGlobalData(optional_ptr<vortex::CData> ffi_data_p) : ffi_data(ffi_data_p) {
+    explicit CTableGlobalData(unique_ptr<vortex::CData> ffi_data_p) : ffi_data(std::move(ffi_data_p)) {
     }
 
-    optional_ptr<vortex::CData> ffi_data;
+    unique_ptr<vortex::CData> ffi_data;
 
     idx_t MaxThreads() const override {
         return GlobalTableFunctionState::MAX_THREADS;
@@ -52,10 +53,10 @@ struct CTableGlobalData final : GlobalTableFunctionState {
 };
 
 struct CTableLocalData final : LocalTableFunctionState {
-    explicit CTableLocalData(optional_ptr<vortex::CData> ffi_data_p) : ffi_data(ffi_data_p) {
+    explicit CTableLocalData(unique_ptr<vortex::CData> ffi_data_p) : ffi_data(std::move(ffi_data_p)) {
     }
 
-    optional_ptr<vortex::CData> ffi_data;
+    unique_ptr<vortex::CData> ffi_data;
 };
 
 /**
@@ -83,8 +84,9 @@ unique_ptr<FunctionData> c_bind(ClientContext &context, TableFunctionBindInput &
         throw BinderException(IntoErrString(error_out));
     }
 
-    return make_uniq<CTableBindData>(make_uniq<CTableFunctionInfo>(info.vtab),
-                                     optional_ptr(reinterpret_cast<vortex::CData *>(ffi_bind_data)));
+    return make_uniq<CTableBindData>(
+        make_uniq<CTableFunctionInfo>(info.vtab),
+        unique_ptr<vortex::CData>(reinterpret_cast<vortex::CData *>(ffi_bind_data)));
 }
 
 unique_ptr<GlobalTableFunctionState> c_init_global(ClientContext &context, TableFunctionInitInput &input) {
@@ -105,7 +107,8 @@ unique_ptr<GlobalTableFunctionState> c_init_global(ClientContext &context, Table
         throw BinderException(IntoErrString(error_out));
     }
 
-    return make_uniq<CTableGlobalData>(optional_ptr(reinterpret_cast<vortex::CData *>(ffi_global_data)));
+    return make_uniq<CTableGlobalData>(
+        unique_ptr<vortex::CData>(reinterpret_cast<vortex::CData *>(ffi_global_data)));
 }
 
 unique_ptr<LocalTableFunctionState> c_init_local(ExecutionContext &context, TableFunctionInitInput &input,
@@ -128,7 +131,8 @@ unique_ptr<LocalTableFunctionState> c_init_local(ExecutionContext &context, Tabl
         throw BinderException(IntoErrString(error_out));
     }
 
-    return make_uniq<CTableLocalData>(optional_ptr(reinterpret_cast<vortex::CData *>(ffi_local_data)));
+    return make_uniq<CTableLocalData>(
+        unique_ptr<vortex::CData>(reinterpret_cast<vortex::CData *>(ffi_local_data)));
 }
 
 void c_function(ClientContext &context, TableFunctionInput &input, DataChunk &output) {

--- a/vortex-duckdb/src/duckdb/data.rs
+++ b/vortex-duckdb/src/duckdb/data.rs
@@ -6,7 +6,7 @@ wrapper!(Data, cpp::duckdb_vx_data, |_| {});
 impl<T> From<Box<T>> for Data {
     fn from(value: Box<T>) -> Self {
         unsafe {
-            Self::borrow(cpp::duckdb_vx_data_create(
+            Self::own(cpp::duckdb_vx_data_create(
                 Box::into_raw(value).cast(),
                 Some(drop_boxed::<T>),
             ))

--- a/vortex-duckdb/src/duckdb/data.rs
+++ b/vortex-duckdb/src/duckdb/data.rs
@@ -6,7 +6,7 @@ wrapper!(Data, cpp::duckdb_vx_data, |_| {});
 impl<T> From<Box<T>> for Data {
     fn from(value: Box<T>) -> Self {
         unsafe {
-            Self::own(cpp::duckdb_vx_data_create(
+            Self::borrow(cpp::duckdb_vx_data_create(
                 Box::into_raw(value).cast(),
                 Some(drop_boxed::<T>),
             ))


### PR DESCRIPTION
Difference can be observed via: `leaks -atExit -- ./clickbench -i1 --targets duckdb:vortex`. 