### PR TITLE
fix: don't leak selection vector

### DIFF
--- a/vortex-duckdb/cpp/include/duckdb_vx/vector.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/vector.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-/// Slice to a dictionary vector, takes ownership of selection vector.
+/// Slice to a dictionary vector.
 void duckdb_vx_vector_slice_to_dictionary(duckdb_vector ffi_vector, duckdb_selection_vector selection_vector,
                                           idx_t selection_vector_length);
 

--- a/vortex-duckdb/src/duckdb/vector.rs
+++ b/vortex-duckdb/src/duckdb/vector.rs
@@ -35,7 +35,7 @@ impl Vector {
         unsafe {
             cpp::duckdb_vx_vector_slice_to_dictionary(
                 self.as_ptr(),
-                sel_vec.into_ptr(),
+                sel_vec.as_ptr(),
                 sel_vec_length as _,
             )
         }


### PR DESCRIPTION
`duckdb_vx_vector_slice_to_dictionary` does not take ownership.