### PR TITLE
fix: duckdb `varchar` leak

### DIFF
--- a/vortex-duckdb/src/convert/expr.rs
+++ b/vortex-duckdb/src/convert/expr.rs
@@ -55,7 +55,7 @@ pub fn try_from_table_filter(value: &TableFilter, col: &str) -> VortexResult<Opt
 fn like_pattern_str(value: &Expression) -> VortexResult<Option<String>> {
     match value.as_class().vortex_expect("unknown class") {
         ExpressionClass::BoundConstant(constant) => {
-            Ok(Some(format!("%{}%", constant.value.as_string().to_str()?)))
+            Ok(Some(format!("%{}%", constant.value.as_string())))
         }
         _ => Ok(None),
     }

--- a/vortex-duckdb/src/convert/scalar.rs
+++ b/vortex-duckdb/src/convert/scalar.rs
@@ -260,7 +260,7 @@ impl TryFrom<Value> for Scalar {
                 Ok(Scalar::utf8(str, Nullable))
             }
             DUCKDB_TYPE::DUCKDB_TYPE_BLOB => Ok(Scalar::binary(
-                ByteBuffer::copy_from(value.as_string().to_str()?),
+                ByteBuffer::copy_from(value.as_string()),
                 Nullable,
             )),
             DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_S => Ok(Scalar::extension(

--- a/vortex-duckdb/src/duckdb/value.rs
+++ b/vortex-duckdb/src/duckdb/value.rs
@@ -71,8 +71,14 @@ impl Value {
         unsafe { Self::own(cpp::duckdb_create_date(cpp::duckdb_date { days })) }
     }
 
-    pub fn as_string(&self) -> &CStr {
-        unsafe { CStr::from_ptr(cpp::duckdb_get_varchar(self.as_ptr())) }
+    pub fn as_string(&self) -> String {
+        unsafe {
+            let ptr = cpp::duckdb_get_varchar(self.as_ptr());
+            let cstr = CStr::from_ptr(ptr);
+            let result = cstr.to_string_lossy().into_owned();
+            cpp::duckdb_free(ptr.cast());
+            result
+        }
     }
 
     pub fn as_u8(&self) -> u8 {

--- a/vortex-duckdb/src/scan.rs
+++ b/vortex-duckdb/src/scan.rs
@@ -170,7 +170,7 @@ impl TableFunction for VortexTableFunction {
             .get_parameter(0)
             .ok_or_else(|| vortex_err!("Missing file glob parameter"))?;
 
-        let paths = match glob::glob(file_glob_string.as_string().to_str()?) {
+        let paths = match glob::glob(&file_glob_string.as_string()) {
             Ok(paths) => paths,
             Err(e) => vortex_bail!("Failed to glob files: {}", e),
         };


### PR DESCRIPTION
The caller is responsible for free-ing the memory with `duckdb_free`.