### PR TITLE
Disable auto-labeler

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -33,23 +33,6 @@ version-resolver:
       - 'wire-break'
   default: patch
 
-autolabeler:
-  - label: 'break'
-    title:
-      - '/break/i'
-  - label: 'chore'
-    title:
-      - '/chore/i'
-  - label: 'fix'
-    title:
-      - '/fix/i'
-  - label: 'feature'
-    title:
-      - '/feat/i'
-  - label: 'performance'
-    title:
-      - '/perf/i'
-
 template: |
   ## Changes
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,10 +3,6 @@ on:
   push:
     branches:
       - develop
-  # pull_request event is required only for autolabeler
-  pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [ opened, reopened, synchronize ]
 
 permissions:
   contents: read
@@ -16,12 +12,9 @@ jobs:
     permissions:
       # write permission is required to create a github release
       contents: write
-      # write permission is required for autolabeler
-      pull-requests: write
-      issues: write
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
+      # Drafts your next Release notes as Pull Requests are merged into "develop"
       - uses: release-drafter/release-drafter@v6.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since the auto-labeler adds labels using GitHub Actions token, it cannot trigger the PR Labels workflow to re-run, meaning we get stuck with a failing workflow.

This change means we have to manually label each PR