### PR TITLE
fix: `TableFunction` leak

### DIFF
--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -227,34 +227,34 @@ extern "C" duckdb_state duckdb_vx_tfunc_register(duckdb_connection ffi_conn,
     }
 
     auto conn = reinterpret_cast<Connection *>(ffi_conn);
-    auto tf = new TableFunction(vtab->name, {}, c_function, c_bind, c_init_global, c_init_local);
+    auto tf = TableFunction(vtab->name, {}, c_function, c_bind, c_init_global, c_init_local);
 
-    tf->pushdown_complex_filter = c_pushdown_complex_filter;
+    tf.pushdown_complex_filter = c_pushdown_complex_filter;
 
-    tf->projection_pushdown = vtab->projection_pushdown;
-    tf->filter_pushdown = vtab->filter_pushdown;
-    tf->filter_prune = vtab->filter_prune;
-    tf->sampling_pushdown = vtab->sampling_pushdown;
-    tf->late_materialization = vtab->late_materialization;
+    tf.projection_pushdown = vtab->projection_pushdown;
+    tf.filter_pushdown = vtab->filter_pushdown;
+    tf.filter_prune = vtab->filter_prune;
+    tf.sampling_pushdown = vtab->sampling_pushdown;
+    tf.late_materialization = vtab->late_materialization;
 
     // Set up the parameters
     for (size_t i = 0; i < vtab->parameter_count; i++) {
         auto logical_type = reinterpret_cast<LogicalType *>(vtab->parameters[i]);
-        tf->arguments.push_back(*logical_type);
+        tf.arguments.push_back(*logical_type);
     }
     // And the named parameters
     for (size_t i = 0; i < vtab->named_parameter_count; i++) {
         auto logical_type = reinterpret_cast<LogicalType *>(vtab->named_parameter_types[i]);
-        tf->named_parameters.insert({vtab->named_parameter_names[i], *logical_type});
+        tf.named_parameters.insert({vtab->named_parameter_names[i], *logical_type});
     }
 
     // Assign the VTable to the function info so we can access it later to invoke the callbacks.
-    tf->function_info = make_shared_ptr<CTableFunctionInfo>(*vtab);
+    tf.function_info = make_shared_ptr<CTableFunctionInfo>(*vtab);
 
     try {
         conn->context->RunFunctionInTransaction([&]() {
             auto &catalog = Catalog::GetSystemCatalog(*conn->context);
-            CreateTableFunctionInfo tf_info(*tf);
+            CreateTableFunctionInfo tf_info(tf);
             catalog.CreateTableFunction(*conn->context, tf_info);
         });
     } catch (...) {


### PR DESCRIPTION
`tf` is copied by value and does not need to be heap allocated.