### PR TITLE
fix: add bounds checking in take_primitive_simd

### DIFF
--- a/vortex-array/src/arrays/primitive/compute/take.rs
+++ b/vortex-array/src/arrays/primitive/compute/take.rs
@@ -7,7 +7,7 @@ use vortex_dtype::{
     NativePType, Nullability, PType, match_each_integer_ptype, match_each_native_ptype,
     match_each_native_simd_ptype, match_each_unsigned_integer_ptype,
 };
-use vortex_error::{VortexResult, vortex_panic};
+use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_panic};
 
 use crate::arrays::PrimitiveVTable;
 use crate::arrays::primitive::PrimitiveArray;
@@ -28,13 +28,30 @@ impl TakeKernel for PrimitiveVTable {
             // TODO(alex): handle nullable codes & values
             match_each_unsigned_integer_ptype!(indices.ptype(), |C| {
                 match_each_native_simd_ptype!(array.ptype(), |V| {
+                    // Check Indices in-bounds
+                    let max: usize = indices
+                        .statistics()
+                        .compute_max::<C>()
+                        .vortex_expect("all_valid indices must have max")
+                        .as_();
+                    if max >= array.len() {
+                        vortex_bail!(
+                            "take indices with max={} invalid for array of length {}",
+                            max,
+                            array.len()
+                        );
+                    }
+
                     // SIMD types larger than the SIMD register size are beneficial for
                     // performance as this leads to better instruction level parallelism.
-                    let decoded = take_primitive_simd::<C, V, 64>(
-                        indices.as_slice(),
-                        array.as_slice(),
-                        array.dtype().nullability() | indices.dtype().nullability(),
-                    );
+                    // SAFETY: we have checked all indices to be in-bounds above.
+                    let decoded = unsafe {
+                        take_primitive_simd::<C, V, 64>(
+                            indices.as_slice(),
+                            array.as_slice(),
+                            array.dtype().nullability() | indices.dtype().nullability(),
+                        )
+                    };
 
                     return Ok(decoded.into_array()) as VortexResult<ArrayRef>;
                 })
@@ -78,11 +95,11 @@ fn take_primitive<T: NativePType, I: NativePType + AsPrimitive<usize>>(
 /// A `PrimitiveArray` containing the gathered values where each index has been replaced with
 /// the corresponding value from the source array.
 ///
-/// # Panics
+/// # Safety
 ///
-/// This function does bounds checking on the indices, if any are out of bounds for `values` we
-/// will panic.
-fn take_primitive_simd<I, V, const LANE_COUNT: usize>(
+/// This function circumvents bounds checks when accessing the `values` slice, so all `indices`
+/// must be valid or it will result in out of bounds memory access.
+unsafe fn take_primitive_simd<I, V, const LANE_COUNT: usize>(
     indices: &[I],
     values: &[V],
     nullability: Nullability,

--- a/vortex-array/src/arrays/primitive/compute/take.rs
+++ b/vortex-array/src/arrays/primitive/compute/take.rs
@@ -7,7 +7,7 @@ use vortex_dtype::{
     NativePType, Nullability, PType, match_each_integer_ptype, match_each_native_ptype,
     match_each_native_simd_ptype, match_each_unsigned_integer_ptype,
 };
-use vortex_error::VortexResult;
+use vortex_error::{VortexResult, vortex_panic};
 
 use crate::arrays::PrimitiveVTable;
 use crate::arrays::primitive::PrimitiveArray;
@@ -77,6 +77,11 @@ fn take_primitive<T: NativePType, I: NativePType + AsPrimitive<usize>>(
 /// # Returns
 /// A `PrimitiveArray` containing the gathered values where each index has been replaced with
 /// the corresponding value from the source array.
+///
+/// # Panics
+///
+/// This function does bounds checking on the indices, if any are out of bounds for `values` we
+/// will panic.
 fn take_primitive_simd<I, V, const LANE_COUNT: usize>(
     indices: &[I],
     values: &[V],
@@ -89,6 +94,17 @@ where
     simd::Simd<I, LANE_COUNT>: SimdUint<Cast<usize> = simd::Simd<usize, LANE_COUNT>>,
 {
     let indices_len = indices.len();
+    // Check all indices before gathering.
+    for &idx in indices.iter() {
+        let idx: usize = idx.as_();
+        if idx >= values.len() {
+            vortex_panic!(
+                "cannot take with index {} on array of length {}",
+                idx,
+                values.len()
+            );
+        }
+    }
 
     let mut buffer = BufferMut::<V>::with_capacity_aligned(
         indices_len,
@@ -102,6 +118,8 @@ where
         let mask = simd::Mask::from_bitmask(u64::MAX);
         let codes_chunk = simd::Simd::<I, LANE_COUNT>::from_slice(&indices[offset..]);
 
+        // SAFETY: we have verified that all indices are in-bounds, so gather will not
+        // read invalid memory.
         unsafe {
             let selection = simd::Simd::gather_select_unchecked(
                 values,


### PR DESCRIPTION
Fix soundness issue with `take_primitive_simd`.

We have bounds-checking implicitly for the old scalar implementation since it goes through `std::slice` access.

Before, if we had invalid take indices we'd do invalid memory accesses 😱 