### PR TITLE
bug[encodings/sparse]: sparse array doesn't respect indicies validity on fill vector

### DIFF
--- a/encodings/sparse/src/compute/take.rs
+++ b/encodings/sparse/src/compute/take.rs
@@ -21,10 +21,15 @@ impl TakeKernel for SparseVTable {
             return Ok(new_patches.into_values());
         }
 
-        Ok(
-            SparseArray::try_new_from_patches(new_patches, array.fill_scalar().clone())?
-                .into_array(),
-        )
+        Ok(SparseArray::try_new_from_patches(
+            new_patches,
+            array.fill_scalar().cast(
+                &array
+                    .dtype()
+                    .union_nullability(take_indices.dtype().nullability()),
+            )?,
+        )?
+        .into_array())
     }
 }
 
@@ -37,6 +42,8 @@ mod test {
     use vortex_array::validity::Validity;
     use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
     use vortex_buffer::buffer;
+    use vortex_dtype::PType::I32;
+    use vortex_dtype::{DType, Nullability};
     use vortex_scalar::Scalar;
 
     use crate::{SparseArray, SparseVTable};
@@ -110,5 +117,36 @@ mod test {
             [0.47f64]
         );
         assert_eq!(taken.len(), 2);
+    }
+
+    #[test]
+    fn nullable_take() {
+        let arr = SparseArray::try_new(
+            buffer![1u32].into_array(),
+            buffer![10].into_array(),
+            10,
+            Scalar::primitive(1, Nullability::NonNullable),
+        )
+        .unwrap();
+
+        let taken = take(
+            arr.as_ref(),
+            PrimitiveArray::from_option_iter([Some(2u32), Some(1u32), Option::<u32>::None])
+                .as_ref(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            taken.scalar_at(0).unwrap(),
+            Scalar::primitive(1, Nullability::Nullable)
+        );
+        assert_eq!(
+            taken.scalar_at(1).unwrap(),
+            Scalar::primitive(10, Nullability::Nullable)
+        );
+        assert_eq!(
+            taken.scalar_at(2).unwrap(),
+            Scalar::null(DType::Primitive(I32, Nullability::Nullable))
+        );
     }
 }


### PR DESCRIPTION
Indices validity only applied to patches, this requires an expensive intersection of patches-indices with validity set bits