### PR TITLE
fix[vortex-array]: check NaN for inferring is constant with min/max

### DIFF
--- a/vortex-array/src/compute/is_constant.rs
+++ b/vortex-array/src/compute/is_constant.rs
@@ -139,17 +139,21 @@ fn is_constant_impl(
     let min = array.statistics().get_scalar(Stat::Min, array.dtype());
     let max = array.statistics().get_scalar(Stat::Max, array.dtype());
 
+    println!(
+        "min {:?}, max {:?}",
+        array.statistics().get_as::<f32>(Stat::Min),
+        array.statistics().get_as::<f32>(Stat::Max),
+    );
+
     if let Some((min, max)) = min.zip(max) {
         // min/max are equal and exact and there are no NaNs
         if min.is_exact()
             && min == max
-            && array
+            && if array
                 .dtype()
-                .is_float()
-                .then(|| {
+                .is_float() { {
                     array.statistics().get_as::<u64>(Stat::NaNCount) == Some(Precision::exact(0u64))
-                })
-                .unwrap_or(true)
+                } } else { true }
         {
             return Ok(Some(true));
         }
@@ -291,13 +295,20 @@ impl IsConstantOpts {
 #[cfg(test)]
 mod tests {
     use crate::arrays::PrimitiveArray;
+    use crate::stats::Stat;
 
     #[test]
     fn is_constant_min_max_no_nan() {
         let arr = PrimitiveArray::from_iter([0, 1]);
+        arr.statistics()
+            .compute_all(&[Stat::Min, Stat::Max])
+            .unwrap();
         assert!(!arr.is_constant());
 
         let arr = PrimitiveArray::from_iter([0, 0]);
+        arr.statistics()
+            .compute_all(&[Stat::Min, Stat::Max])
+            .unwrap();
         assert!(arr.is_constant());
 
         let arr = PrimitiveArray::from_option_iter([Some(0), Some(0)]);
@@ -306,11 +317,17 @@ mod tests {
 
     #[test]
     fn is_constant_min_max_with_nan() {
-        let arr = PrimitiveArray::from_option_iter([Some(0.0), Some(f32::NAN)]);
+        let arr = PrimitiveArray::from_iter([0.0, 0.0, f32::NAN]);
+        arr.statistics()
+            .compute_all(&[Stat::Min, Stat::Max])
+            .unwrap();
         assert!(!arr.is_constant());
 
         let arr =
             PrimitiveArray::from_option_iter([Some(f32::NEG_INFINITY), Some(f32::NEG_INFINITY)]);
+        arr.statistics()
+            .compute_all(&[Stat::Min, Stat::Max])
+            .unwrap();
         assert!(arr.is_constant());
     }
 }

--- a/vortex-array/src/compute/is_constant.rs
+++ b/vortex-array/src/compute/is_constant.rs
@@ -139,21 +139,15 @@ fn is_constant_impl(
     let min = array.statistics().get_scalar(Stat::Min, array.dtype());
     let max = array.statistics().get_scalar(Stat::Max, array.dtype());
 
-    println!(
-        "min {:?}, max {:?}",
-        array.statistics().get_as::<f32>(Stat::Min),
-        array.statistics().get_as::<f32>(Stat::Max),
-    );
-
     if let Some((min, max)) = min.zip(max) {
         // min/max are equal and exact and there are no NaNs
         if min.is_exact()
             && min == max
-            && if array
-                .dtype()
-                .is_float() { {
-                    array.statistics().get_as::<u64>(Stat::NaNCount) == Some(Precision::exact(0u64))
-                } } else { true }
+            && if array.dtype().is_float() {
+                array.statistics().get_as::<u64>(Stat::NaNCount) == Some(Precision::exact(0u64))
+            } else {
+                true
+            }
         {
             return Ok(Some(true));
         }

--- a/vortex-array/src/compute/is_constant.rs
+++ b/vortex-array/src/compute/is_constant.rs
@@ -143,7 +143,7 @@ fn is_constant_impl(
         // min/max are equal and exact and there are no NaNs
         if min.is_exact()
             && min == max
-            && (!array.dtype().is_float()
+            && (Stat::NaNCount.dtype(array.dtype()).is_none()
                 || array.statistics().get_as::<u64>(Stat::NaNCount) == Some(Precision::exact(0u64)))
         {
             return Ok(Some(true));

--- a/vortex-array/src/compute/is_constant.rs
+++ b/vortex-array/src/compute/is_constant.rs
@@ -136,17 +136,21 @@ fn is_constant_impl(
     }
 
     // We already know here that the array is all valid, so we check for min/max stats.
-    let min = array
-        .statistics()
-        .get_scalar(Stat::Min, array.dtype())
-        .and_then(|p| p.as_exact());
-    let max = array
-        .statistics()
-        .get_scalar(Stat::Max, array.dtype())
-        .and_then(|p| p.as_exact());
+    let min = array.statistics().get_scalar(Stat::Min, array.dtype());
+    let max = array.statistics().get_scalar(Stat::Max, array.dtype());
 
     if let Some((min, max)) = min.zip(max) {
-        if min == max {
+        // min/max are equal and exact and there are no NaNs
+        if min.is_exact()
+            && min == max
+            && array
+                .dtype()
+                .is_float()
+                .then(|| {
+                    array.statistics().get_as::<u64>(Stat::NaNCount) == Some(Precision::exact(0u64))
+                })
+                .unwrap_or(true)
+        {
             return Ok(Some(true));
         }
     }
@@ -281,5 +285,32 @@ impl Options for IsConstantOpts {
 impl IsConstantOpts {
     pub fn is_negligible_cost(&self) -> bool {
         self.cost == Cost::Negligible
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::arrays::PrimitiveArray;
+
+    #[test]
+    fn is_constant_min_max_no_nan() {
+        let arr = PrimitiveArray::from_iter([0, 1]);
+        assert!(!arr.is_constant());
+
+        let arr = PrimitiveArray::from_iter([0, 0]);
+        assert!(arr.is_constant());
+
+        let arr = PrimitiveArray::from_option_iter([Some(0), Some(0)]);
+        assert!(arr.is_constant());
+    }
+
+    #[test]
+    fn is_constant_min_max_with_nan() {
+        let arr = PrimitiveArray::from_option_iter([Some(0.0), Some(f32::NAN)]);
+        assert!(!arr.is_constant());
+
+        let arr =
+            PrimitiveArray::from_option_iter([Some(f32::NEG_INFINITY), Some(f32::NEG_INFINITY)]);
+        assert!(arr.is_constant());
     }
 }

--- a/vortex-array/src/compute/is_constant.rs
+++ b/vortex-array/src/compute/is_constant.rs
@@ -143,11 +143,8 @@ fn is_constant_impl(
         // min/max are equal and exact and there are no NaNs
         if min.is_exact()
             && min == max
-            && if array.dtype().is_float() {
-                array.statistics().get_as::<u64>(Stat::NaNCount) == Some(Precision::exact(0u64))
-            } else {
-                true
-            }
+            && (!array.dtype().is_float()
+                || array.statistics().get_as::<u64>(Stat::NaNCount) == Some(Precision::exact(0u64)))
         {
             return Ok(Some(true));
         }

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -11,13 +11,16 @@ use vortex_array::arrays::{
     ChunkedArray, ConstantArray, DecimalArray, ListArray, PrimitiveArray, StructArray, VarBinArray,
     VarBinViewArray,
 };
+use vortex_array::stats::Stat::IsConstant;
+use vortex_array::stats::StatsProvider;
 use vortex_array::stream::ArrayStreamExt;
 use vortex_array::validity::Validity;
 use vortex_array::{Array, IntoArray, ToCanonical};
 use vortex_buffer::{Buffer, ByteBufferMut, buffer};
 use vortex_dtype::PType::I32;
+use vortex_dtype::half::f16;
 use vortex_dtype::{DType, DecimalDType, Nullability, PType, StructFields};
-use vortex_error::VortexResult;
+use vortex_error::{VortexResult, VortexUnwrap};
 use vortex_expr::{and, eq, get_item, gt, gt_eq, lit, lt, lt_eq, or, root, select};
 use vortex_scalar::Scalar;
 

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -11,16 +11,13 @@ use vortex_array::arrays::{
     ChunkedArray, ConstantArray, DecimalArray, ListArray, PrimitiveArray, StructArray, VarBinArray,
     VarBinViewArray,
 };
-use vortex_array::stats::Stat::IsConstant;
-use vortex_array::stats::StatsProvider;
 use vortex_array::stream::ArrayStreamExt;
 use vortex_array::validity::Validity;
 use vortex_array::{Array, IntoArray, ToCanonical};
 use vortex_buffer::{Buffer, ByteBufferMut, buffer};
 use vortex_dtype::PType::I32;
-use vortex_dtype::half::f16;
 use vortex_dtype::{DType, DecimalDType, Nullability, PType, StructFields};
-use vortex_error::{VortexResult, VortexUnwrap};
+use vortex_error::VortexResult;
 use vortex_expr::{and, eq, get_item, gt, gt_eq, lit, lt, lt_eq, or, root, select};
 use vortex_scalar::Scalar;
 


### PR DESCRIPTION
I think that in the future min == max doesn't imply is constant for all types e.g. truncated str. I think we should reconsider this.

Closes https://github.com/vortex-data/vortex/issues/3660