### PR TITLE
fix[compressor]: Enable float run-end compressor scheme

### DIFF
--- a/vortex-btrblocks/src/float.rs
+++ b/vortex-btrblocks/src/float.rs
@@ -40,6 +40,7 @@ impl Compressor for FloatCompressor {
             &ALPScheme,
             &ALPRDScheme,
             &DictScheme,
+            &RunEndScheme,
         ]
     }
 


### PR DESCRIPTION
Seems like an omission? Couldn't find any reference on slack to it