### PR TITLE
feat: multiversion for primitive take

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3521,6 +3521,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "multiversion"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edb7f0ff51249dfda9ab96b5823695e15a052dc15074c9dbf3d118afaf2c201"
+dependencies = [
+ "multiversion-macros",
+ "target-features",
+]
+
+[[package]]
+name = "multiversion-macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b093064383341eb3271f42e381cb8f10a01459478446953953c75d24bd339fc0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "target-features",
+]
+
+[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5405,6 +5427,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-features"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1bbb9f3c5c463a01705937a24fdabc5047929ac764b2d5b9cf681c1f5041ed5"
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6059,6 +6087,7 @@ dependencies = [
  "inventory",
  "itertools 0.14.0",
  "log",
+ "multiversion",
  "num-traits",
  "num_enum",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ log = { version = "0.4.21" }
 memmap2 = "0.9.5"
 mimalloc = "0.1.42"
 moka = { version = "0.12.10", default-features = false }
+multiversion = "0.8.0"
 num-traits = "0.2.19"
 num_enum = { version = "0.7.3", default-features = false }
 object_store = "0.12.1"

--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -38,6 +38,7 @@ humansize = { workspace = true }
 inventory = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
+multiversion = { workspace = true }
 num-traits = { workspace = true }
 num_enum = { workspace = true }
 parking_lot = { workspace = true }

--- a/vortex-array/src/arrays/primitive/compute/take.rs
+++ b/vortex-array/src/arrays/primitive/compute/take.rs
@@ -77,7 +77,7 @@ register_kernel!(TakeKernelAdapter(PrimitiveVTable).lift());
 /// # Returns
 /// A `PrimitiveArray` containing the gathered values where each index has been replaced with
 /// the corresponding value from the source array.
-#[multiversion(targets("x86_64+avx+avx2"))]
+#[multiversion(targets("x86_64+avx2", "x86_64+avx"))]
 fn take_primitive_simd<I, V, const LANE_COUNT: usize>(indices: &[I], values: &[V]) -> Buffer<V>
 where
     I: simd::SimdElement + AsPrimitive<usize>,

--- a/vortex-array/src/arrays/primitive/compute/take.rs
+++ b/vortex-array/src/arrays/primitive/compute/take.rs
@@ -1,6 +1,7 @@
 use std::mem::{MaybeUninit, transmute};
 use std::simd;
 
+use multiversion::multiversion;
 use num_traits::AsPrimitive;
 use simd::num::SimdUint;
 use vortex_buffer::{Alignment, Buffer, BufferMut};
@@ -72,11 +73,11 @@ register_kernel!(TakeKernelAdapter(PrimitiveVTable).lift());
 /// # Parameters
 /// * `indices` - Indices to gather values from
 /// * `values` - Source values to index
-/// * `nullability` - Nullability of the resulting array
 ///
 /// # Returns
 /// A `PrimitiveArray` containing the gathered values where each index has been replaced with
 /// the corresponding value from the source array.
+#[multiversion(targets("x86_64+avx+avx2"))]
 fn take_primitive_simd<I, V, const LANE_COUNT: usize>(indices: &[I], values: &[V]) -> Buffer<V>
 where
     I: simd::SimdElement + AsPrimitive<usize>,

--- a/vortex-array/src/arrays/primitive/compute/take.rs
+++ b/vortex-array/src/arrays/primitive/compute/take.rs
@@ -77,7 +77,7 @@ register_kernel!(TakeKernelAdapter(PrimitiveVTable).lift());
 /// # Returns
 /// A `PrimitiveArray` containing the gathered values where each index has been replaced with
 /// the corresponding value from the source array.
-#[multiversion(targets("x86_64+avx2", "x86_64+avx"))]
+#[multiversion(targets("x86_64+avx2", "x86_64+avx", "aarch64+neon"))]
 fn take_primitive_simd<I, V, const LANE_COUNT: usize>(indices: &[I], values: &[V]) -> Buffer<V>
 where
     I: simd::SimdElement + AsPrimitive<usize>,


### PR DESCRIPTION
Doesn't affect the CodSpeed runs since we already run our benchmarks with `target-feature=avx2` but probably helps library clients out