### PR TITLE
chore: Set DuckDB submodule URL to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vortex-duckdb/duckdb"]
 	path = vortex-duckdb/duckdb
-	url = git@github.com:duckdb/duckdb.git
+	url = https://github.com/duckdb/duckdb.git


### PR DESCRIPTION
Seems like cargo/github actions has issues pulling `git@` based submodules.
This was also the URL before #3666.