### PR TITLE
feat: teach StructFields to Default to empty

### DIFF
--- a/vortex-dtype/src/struct_.rs
+++ b/vortex-dtype/src/struct_.rs
@@ -166,6 +166,12 @@ pub struct StructFields {
     dtypes: Arc<[FieldDType]>,
 }
 
+impl Default for StructFields {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
 impl StructFields {
     /// The fields of the empty struct.
     pub fn empty() -> Self {


### PR DESCRIPTION
I dunno what's best practice. Should (a) empty call default, (b) default call empty, or (c) should there be no empty? I kinda feel like `empty` is the semantically meaningful name and defaulting to `Self::empty()` seems semantically right? Curious for your thoughts.