### PR TITLE
feat: simplify again after removing select & merge

### DIFF
--- a/vortex-expr/src/transform/simplify_typed.rs
+++ b/vortex-expr/src/transform/simplify_typed.rs
@@ -15,6 +15,7 @@ pub fn simplify_typed(e: ExprRef, ctx: &ScopeDType) -> VortexResult<ExprRef> {
 
     let e = remove_select(e, ctx)?;
     let e = remove_merge(e, ctx)?;
+    let e = simplify(e)?;
 
     Ok(e)
 }


### PR DESCRIPTION
Spiral (after some forthcoming changes) will `merge` two fairly large structs. After `remove_merge`, these become _enormous_ packs. These huge packs are almost always the result of `get_item("field", merge(col("data"), col("aux")))`. This relatively small and readable expression explodes into a huge expression even though it really should simplify to:

    get_item("field", col("data"))

Running one more simplify returns us to a concise expression.