### PR TITLE
chore: polish benchmark row count verification

### DIFF
--- a/bench-vortex/src/bin/clickbench.rs
+++ b/bench-vortex/src/bin/clickbench.rs
@@ -343,20 +343,31 @@ fn execute_queries(
 ) -> Vec<QueryMeasurement> {
     let mut query_measurements = Vec::default();
 
+    const REFERENCE_ROW_COUNTS: [usize; 43] = [
+        1, 1, 1, 1, 1, 1, 1, 18, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 4, 1, 10, 10, 10, 10,
+        10, 10, 25, 25, 1, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+    ];
+
     for &(query_idx, ref query_string) in queries.iter() {
         match engine_ctx {
             EngineCtx::DataFusion(ctx) => {
-                let (fastest_run, execution_plan) = tokio_runtime.block_on(async {
+                let (fastest_run, (execution_plan, row_count)) = tokio_runtime.block_on(async {
                     benchmark_datafusion_query(iterations, || async {
-                        df::execute_query(&ctx.session, query_string)
+                        let (batches, plan) = df::execute_query(&ctx.session, query_string)
                             .await
                             .unwrap_or_else(|err| {
                                 vortex_panic!("query: {query_idx} failed with: {err}")
-                            })
-                            .1
+                            });
+                        let row_count: usize = batches.iter().map(|batch| batch.num_rows()).sum();
+                        (plan, row_count)
                     })
                     .await
                 });
+
+                assert_eq!(
+                    row_count, REFERENCE_ROW_COUNTS[query_idx],
+                    "Error: Row count mismatch for query idx {query_idx} - datafusion:{file_format}",
+                );
 
                 ctx.execution_plans
                     .push((query_idx, execution_plan.clone()));
@@ -385,7 +396,13 @@ fn execute_queries(
                 });
             }
             EngineCtx::DuckDB(ctx) => {
-                let fastest_run = benchmark_duckdb_query(query_idx, query_string, iterations, ctx);
+                let (fastest_run, row_count) =
+                    benchmark_duckdb_query(query_idx, query_string, iterations, ctx);
+
+                assert_eq!(
+                    row_count, REFERENCE_ROW_COUNTS[query_idx],
+                    "Error: Row count mismatch for query idx {query_idx} - duckdb:{file_format}",
+                );
 
                 query_measurements.push(QueryMeasurement {
                     query_idx,

--- a/bench-vortex/src/bin/tpcds.rs
+++ b/bench-vortex/src/bin/tpcds.rs
@@ -165,7 +165,7 @@ async fn bench_main(
                     ctx.register_tables(&url, format, BenchmarkDataset::TpcDS)?;
 
                     for (query_idx, sql_query) in &tpch_queries {
-                        let fastest_run =
+                        let (fastest_run, _row_count) =
                             benchmark_duckdb_query(*query_idx, sql_query, iterations, ctx);
 
                         let storage = bench_vortex::utils::url_scheme_to_storage(&url)?;

--- a/bench-vortex/src/bin/tpch.rs
+++ b/bench-vortex/src/bin/tpch.rs
@@ -9,8 +9,7 @@ use bench_vortex::measurements::QueryMeasurement;
 use bench_vortex::metrics::{MetricsSetExt, export_plan_spans};
 use bench_vortex::tpch::duckdb::{DuckdbTpcOptions, TpcDataset, generate_tpc};
 use bench_vortex::tpch::{
-    EXPECTED_ROW_COUNTS_SF1, EXPECTED_ROW_COUNTS_SF10, TPC_H_ROW_COUNT_ARRAY_LENGTH, load_datasets,
-    run_tpch_query, tpch_queries,
+    EXPECTED_ROW_COUNTS_SF1, EXPECTED_ROW_COUNTS_SF10, load_datasets, run_tpch_query, tpch_queries,
 };
 use bench_vortex::utils::constants::TPCH_DATASET;
 use bench_vortex::utils::new_tokio_runtime;
@@ -25,7 +24,6 @@ use log::{info, warn};
 use similar::{ChangeTag, TextDiff};
 use url::Url;
 use vortex::error::VortexExpect;
-use vortex::utils::aliases::hash_map::HashMap;
 use vortex_datafusion::metrics::VortexMetricsFinder;
 
 #[derive(Parser, Debug)]
@@ -176,63 +174,6 @@ fn main() -> anyhow::Result<()> {
     ))
 }
 
-/// Verify row counts against expected values for TPC-H queries
-///
-/// Returns true if there are any row count mismatches.
-fn verify_row_counts(
-    row_counts: &[(usize, Format, usize)],
-    expected_row_counts: [usize; TPC_H_ROW_COUNT_ARRAY_LENGTH],
-    queries: &Option<Vec<usize>>,
-    exclude_queries: &Option<Vec<usize>>,
-) -> bool {
-    let format_row_counts =
-        row_counts
-            .iter()
-            .fold(HashMap::new(), |mut acc, &(idx, format, row_count)| {
-                acc.entry(format)
-                    .or_insert_with(|| vec![0; TPC_H_ROW_COUNT_ARRAY_LENGTH])[idx] = row_count;
-                acc
-            });
-
-    let is_query_included = |idx: &usize| {
-        queries.as_ref().is_none_or(|q| q.contains(idx))
-            && exclude_queries
-                .as_ref()
-                .is_none_or(|excluded| !excluded.contains(idx))
-    };
-
-    let mut mismatched = false;
-    for (format, row_counts) in format_row_counts {
-        row_counts
-            .into_iter()
-            .enumerate()
-            .filter(|(idx, _)| is_query_included(idx))
-            .for_each(|(idx, actual_row_count)| {
-                if actual_row_count != expected_row_counts[idx] {
-                    if idx == 15 && actual_row_count == 0 {
-                        warn!(
-                            "*IGNORING* mismatched row count {} instead of {} for format {:?} because Query 15 is flaky. See: https://github.com/vortex-data/vortex/issues/2395",
-                            actual_row_count,
-                            expected_row_counts[idx],
-                            format,
-                        );
-                    } else  {
-                        warn!(
-                            "Mismatched row count {} instead of {} in query {} for format {:?}",
-                            actual_row_count,
-                            expected_row_counts[idx],
-                            idx,
-                            format,
-                        );
-                        mismatched = true;
-                    }
-                }
-            });
-    }
-
-    mismatched
-}
-
 #[allow(clippy::too_many_arguments)]
 async fn bench_main(
     queries: Option<Vec<usize>>,
@@ -265,7 +206,6 @@ async fn bench_main(
 
     let query_count = queries.as_ref().map_or(22, |c| c.len());
     let progress = ProgressBar::new((query_count * targets.len()) as u64);
-    let mut row_counts: Vec<(usize, Format, usize)> = Vec::new();
     let mut measurements = Vec::new();
     let mut metrics = MetricsSet::new();
     let tpch_queries: Vec<_> = tpch_queries()
@@ -306,7 +246,13 @@ async fn bench_main(
                         })
                         .await;
 
-                    row_counts.push((query_idx, format, row_count));
+                    // Query 15 is flaky for DataFusion: https://github.com/vortex-data/vortex/issues/2395.
+                    if query_idx != 15 {
+                        assert_eq!(
+                            row_count, expected_row_counts[query_idx],
+                            "Error: Row count mismatch for query idx {query_idx} - {engine}:{format}",
+                        );
+                    }
 
                     // Gather metrics.
                     for (idx, metrics_set) in VortexMetricsFinder::find_all(plan.as_ref())
@@ -356,11 +302,16 @@ async fn bench_main(
                     ctx.register_tables(&url, format, BenchmarkDataset::TpcH)?;
 
                     for (query_idx, sql_queries) in tpch_queries.clone() {
-                        let fastest_run = benchmark_duckdb_query(
+                        let (fastest_run, row_count) = benchmark_duckdb_query(
                             query_idx,
                             &sql_queries.join(";"),
                             iterations,
                             ctx,
+                        );
+
+                        assert_eq!(
+                            row_count, expected_row_counts[query_idx],
+                            "Error: Row count mismatch for query idx {query_idx} - {engine}:{format}",
                         );
 
                         let storage = bench_vortex::utils::url_scheme_to_storage(&url)?;
@@ -400,10 +351,6 @@ async fn bench_main(
         DisplayFormat::GhJson => {
             print_measurements_json(measurements)?;
         }
-    }
-
-    if verify_row_counts(&row_counts, expected_row_counts, &queries, &exclude_queries) {
-        return Err(anyhow!("Mismatched row counts. See logs for details."));
     }
 
     // The CI env var is defined by Github Actions.

--- a/bench-vortex/src/bin/tpch.rs
+++ b/bench-vortex/src/bin/tpch.rs
@@ -246,13 +246,10 @@ async fn bench_main(
                         })
                         .await;
 
-                    // Query 15 is flaky for DataFusion: https://github.com/vortex-data/vortex/issues/2395.
-                    if query_idx != 15 {
-                        assert_eq!(
-                            row_count, expected_row_counts[query_idx],
-                            "Error: Row count mismatch for query idx {query_idx} - {engine}:{format}",
-                        );
-                    }
+                    assert_eq!(
+                        row_count, expected_row_counts[query_idx],
+                        "Error: Row count mismatch for query idx {query_idx} - {engine}:{format}",
+                    );
 
                     // Gather metrics.
                     for (idx, metrics_set) in VortexMetricsFinder::find_all(plan.as_ref())

--- a/bench-vortex/src/engines/ddb/mod.rs
+++ b/bench-vortex/src/engines/ddb/mod.rs
@@ -39,14 +39,14 @@ impl DuckDBCtx {
     }
 
     /// Execute DuckDB queries for benchmarks using the internal connection
-    pub fn execute_query(&self, query: &str) -> Result<Duration> {
+    pub fn execute_query(&self, query: &str) -> Result<(Duration, usize)> {
         trace!("execute duckdb query: {}", query);
         let time_instant = Instant::now();
-        self.connection.query(query)?;
+        let result = self.connection.query(query)?;
         let query_time = time_instant.elapsed();
         trace!("query completed in {:.3}s", query_time.as_secs_f64());
 
-        Ok(query_time)
+        Ok((query_time, result.row_count()?))
     }
 
     /// Register tables for benchmarks using the internal connection

--- a/bench-vortex/src/engines/mod.rs
+++ b/bench-vortex/src/engines/mod.rs
@@ -42,14 +42,22 @@ pub fn benchmark_duckdb_query(
     query_string: &str,
     iterations: usize,
     duckdb_ctx: &ddb::DuckDBCtx,
-) -> Duration {
-    (0..iterations).fold(Duration::from_millis(u64::MAX), |fastest, _| {
-        let duration = duckdb_ctx
+) -> (Duration, usize) {
+    let mut fastest = Duration::from_millis(u64::MAX);
+    let mut row_count = 0;
+
+    for _ in 0..iterations {
+        let (duration, current_row_count) = duckdb_ctx
             .execute_query(query_string)
             .unwrap_or_else(|err| vortex_panic!("query: {query_idx} failed with: {err}"));
 
-        fastest.min(duration)
-    })
+        if duration < fastest {
+            fastest = duration;
+            row_count = current_row_count;
+        }
+    }
+
+    (fastest, row_count)
 }
 
 pub async fn benchmark_datafusion_query<T, F, Fut>(iterations: usize, mut f: F) -> (Duration, T)


### PR DESCRIPTION
In particular, this commit adds row count verification for the clickbench benchmark. Further, each row count gets verified on the fly rather than collected and verified at the end.