### PR TITLE
chore: remove unused `worker` dep from repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3473,12 +3473,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5049,17 +5043,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-wasm-bindgen"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6360,7 +6343,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "url",
- "worker",
 ]
 
 [[package]]
@@ -7360,80 +7342,6 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde-value",
-]
-
-[[package]]
-name = "worker"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6ac1566a3005b790b974f0621d77431e2a47e5f481276485f5ac0485775de2"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "js-sys",
- "matchit",
- "pin-project",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "worker-kv",
- "worker-macros",
- "worker-sys",
-]
-
-[[package]]
-name = "worker-kv"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d30eb90e8db0657414129624c0d12c6cb480574bc2ddd584822db196cb9a52"
-dependencies = [
- "js-sys",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "thiserror 2.0.12",
- "wasm-bindgen",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "worker-macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba7478759843ae3d56dc7ba2445e7a514a5d043eaa98cebac2789f7ab5221ee"
-dependencies = [
- "async-trait",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-macro-support",
- "worker-sys",
-]
-
-[[package]]
-name = "worker-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4d7a3273dd584b9526aec77bbcf815c51d1a0e17407b1a390cf5a39b6d4fbd"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,6 @@ vortex-zstd = { version = "0.1.0", path = "./encodings/zstd", default-features =
 vortex-duckdb = { path = "./vortex-duckdb", default-features = false }
 vortex-ffi = { path = "./vortex-ffi", default-features = false }
 
-worker = "0.6.0"
 xshell = "0.2.6"
 zigzag = "0.1.0"
 zstd = { version = "0.13.3", default-features = false, features = [

--- a/vortex-error/Cargo.toml
+++ b/vortex-error/Cargo.toml
@@ -29,7 +29,6 @@ pyo3 = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt"], optional = true }
 url = { workspace = true }
-worker = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/vortex-error/src/lib.rs
+++ b/vortex-error/src/lib.rs
@@ -106,9 +106,6 @@ pub enum VortexError {
     ParquetError(parquet::errors::ParquetError, Backtrace),
     /// A wrapper for errors from the standard library when converting a slice to an array.
     TryFromSliceError(std::array::TryFromSliceError, Backtrace),
-    /// A wrapper for errors from the Cloudflare Workers library.
-    #[cfg(feature = "worker")]
-    WorkerError(worker::Error, Backtrace),
     /// A wrapper for errors from the Object Store library.
     #[cfg(feature = "object_store")]
     ObjectStore(object_store::Error, Backtrace),
@@ -211,10 +208,6 @@ impl Display for VortexError {
             VortexError::TryFromSliceError(err, backtrace) => {
                 write!(f, "{}\nBacktrace:\n{}", err, backtrace)
             }
-            #[cfg(feature = "worker")]
-            VortexError::WorkerError(err, backtrace) => {
-                write!(f, "{}\nBacktrace:\n{}", err, backtrace)
-            }
             #[cfg(feature = "object_store")]
             VortexError::ObjectStore(err, backtrace) => {
                 write!(f, "{}\nBacktrace:\n{}", err, backtrace)
@@ -267,8 +260,6 @@ impl Error for VortexError {
             #[cfg(feature = "parquet")]
             VortexError::ParquetError(err, _) => Some(err),
             VortexError::TryFromSliceError(err, _) => Some(err),
-            #[cfg(feature = "worker")]
-            VortexError::WorkerError(err, _) => Some(err),
             #[cfg(feature = "object_store")]
             VortexError::ObjectStore(err, _) => Some(err),
             VortexError::JiffError(err, _) => Some(err),
@@ -524,13 +515,6 @@ impl From<std::array::TryFromSliceError> for VortexError {
     }
 }
 
-#[cfg(feature = "worker")]
-impl From<worker::Error> for VortexError {
-    fn from(value: worker::Error) -> Self {
-        VortexError::WorkerError(value, Backtrace::capture())
-    }
-}
-
 #[cfg(feature = "object_store")]
 impl From<object_store::Error> for VortexError {
     fn from(value: object_store::Error) -> Self {
@@ -600,13 +584,6 @@ pub mod __private {
     #[must_use]
     pub const fn must_use(error: crate::VortexError) -> crate::VortexError {
         error
-    }
-}
-
-#[cfg(feature = "worker")]
-impl From<VortexError> for worker::Error {
-    fn from(value: VortexError) -> Self {
-        Self::RustError(value.to_string())
     }
 }
 


### PR DESCRIPTION
Noticed recent renovate PR to bump `worker`, but we don't have any use for it.