### PR TITLE
chore[benchmark]: add -o option to specify where the write results

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -76,7 +76,7 @@ jobs:
         env:
           RUST_BACKTRACE: full
         run: |
-          target/release_debug/${{ matrix.benchmark.id }} -d gh-json | tee ${{ matrix.benchmark.id }}.json
+          target/release_debug/${{ matrix.benchmark.id }} -d gh-json -o ${{ matrix.benchmark.id }}.json
 
       - name: Setup AWS CLI
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           RUSTFLAGS: '-C target-cpu=native'
         run: |
-          cargo run --bin ${{ matrix.benchmark.id }} --package bench-vortex --release -- -d gh-json | tee ${{ matrix.benchmark.id }}.json
+          cargo run --bin ${{ matrix.benchmark.id }} --package bench-vortex --release -- -d gh-json -o ${{ matrix.benchmark.id }}.json
 
       - name: Setup AWS CLI
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -117,7 +117,7 @@ jobs:
             -d gh-json \
             --targets ${{ matrix.targets }} \
             --export-spans \
-          | tee results.json
+            -o results.json
 
       - name: Run ${{ matrix.name }} benchmark (remote)
         if: matrix.remote_storage != null
@@ -135,7 +135,7 @@ jobs:
               --targets ${{ matrix.targets }} \
               --export-spans \
               -d gh-json \
-            | tee results.json
+              -o results.json
 
       - name: Install uv
         if: inputs.mode == 'pr'

--- a/bench-vortex/src/bin/clickbench.rs
+++ b/bench-vortex/src/bin/clickbench.rs
@@ -101,10 +101,10 @@ fn main() -> anyhow::Result<()> {
             .build();
 
         let fmt_layer = tracing_subscriber::fmt::layer()
-            .with_writer(std::io::stderr)
+            .with_writer(io::stderr)
             .with_level(true)
             .with_line_number(true)
-            .with_ansi(std::io::stderr().is_terminal());
+            .with_ansi(io::stderr().is_terminal());
 
         tracing_subscriber::registry()
             .with(filter)

--- a/bench-vortex/src/bin/clickbench.rs
+++ b/bench-vortex/src/bin/clickbench.rs
@@ -1,3 +1,6 @@
+use std::fs::File;
+use std::io;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use bench_vortex::clickbench::{Flavor, clickbench_queries};
@@ -12,6 +15,7 @@ use bench_vortex::{
 };
 use clap::{Parser, value_parser};
 use indicatif::ProgressBar;
+use io::stdout;
 use itertools::Itertools;
 use log::warn;
 use tokio::runtime::Runtime;
@@ -61,6 +65,8 @@ struct Args {
     hide_progress_bar: bool,
     #[arg(long, default_value_t = false)]
     show_metrics: bool,
+    #[arg(short)]
+    output_path: Option<PathBuf>,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -70,12 +76,6 @@ fn main() -> anyhow::Result<()> {
         .targets
         .iter()
         .map(|t| t.engine())
-        .unique()
-        .collect_vec();
-    let formats = args
-        .targets
-        .iter()
-        .map(|t| t.format())
         .unique()
         .collect_vec();
 
@@ -133,7 +133,7 @@ fn main() -> anyhow::Result<()> {
     let progress_bar = if args.hide_progress_bar {
         ProgressBar::hidden()
     } else {
-        ProgressBar::new((queries.len() * formats.len() * engines.len()) as u64)
+        ProgressBar::new((queries.len() * args.targets.len()) as u64)
     };
 
     let mut query_measurements = Vec::new();
@@ -189,7 +189,12 @@ fn main() -> anyhow::Result<()> {
         query_measurements.extend(bench_measurements);
     }
 
-    print_results(&args.display_format, query_measurements, &args.targets)
+    print_results(
+        &args.display_format,
+        query_measurements,
+        &args.targets,
+        &args.output_path,
+    )
 }
 
 fn validate_args(engines: &[Engine], args: &Args) {
@@ -230,11 +235,18 @@ fn print_results(
     display_format: &DisplayFormat,
     query_measurements: Vec<QueryMeasurement>,
     targets: &[Target],
+    file_path: &Option<PathBuf>,
 ) -> anyhow::Result<()> {
+    let mut writer: Box<dyn Write> = if let Some(file_path) = file_path {
+        Box::new(File::create(file_path)?)
+    } else {
+        let stdout = stdout();
+        Box::new(stdout.lock())
+    };
     match display_format {
-        DisplayFormat::Table => render_table(query_measurements, targets),
+        DisplayFormat::Table => render_table(&mut writer, query_measurements, targets),
 
-        DisplayFormat::GhJson => print_measurements_json(query_measurements),
+        DisplayFormat::GhJson => print_measurements_json(&mut writer, query_measurements),
     }
 }
 

--- a/bench-vortex/src/bin/compress.rs
+++ b/bench-vortex/src/bin/compress.rs
@@ -1,3 +1,7 @@
+use std::fs::File;
+use std::io::{Write, stdout};
+use std::path::PathBuf;
+
 use bench_vortex::compress::bench::{CompressMeasurements, benchmark_compress};
 use bench_vortex::datasets::Dataset;
 use bench_vortex::datasets::struct_list_of_ints::StructListOfInts;
@@ -29,6 +33,8 @@ struct Args {
     datasets: Option<String>,
     #[arg(short, long, default_value_t, value_enum)]
     display_format: DisplayFormat,
+    #[arg(short)]
+    output_path: Option<PathBuf>,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -45,6 +51,7 @@ fn main() -> anyhow::Result<()> {
         args.datasets.map(|d| Regex::new(&d)).transpose()?,
         args.formats,
         args.display_format,
+        &args.output_path,
     )
 }
 
@@ -54,6 +61,7 @@ fn compress(
     datasets_filter: Option<Regex>,
     formats: Vec<Format>,
     display_format: DisplayFormat,
+    output_path: &Option<PathBuf>,
 ) -> anyhow::Result<()> {
     let targets = formats
         .iter()
@@ -105,10 +113,18 @@ fn compress(
 
     progress.finish();
 
+    let mut writer: Box<dyn Write> = if let Some(output_path) = output_path {
+        Box::new(File::create(output_path)?)
+    } else {
+        let stdout = stdout();
+        Box::new(stdout.lock())
+    };
+
     match display_format {
         DisplayFormat::Table => {
-            render_table(measurements.timings, &targets)?;
+            render_table(&mut writer, measurements.timings, &targets)?;
             render_table(
+                &mut writer,
                 measurements.ratios,
                 &if formats.contains(&Format::OnDiskVortex) {
                     vec![Target::new(Engine::default(), Format::OnDiskVortex)]
@@ -118,8 +134,8 @@ fn compress(
             )
         }
         DisplayFormat::GhJson => {
-            print_measurements_json(measurements.timings)?;
-            print_measurements_json(measurements.ratios)
+            print_measurements_json(&mut writer, measurements.timings)?;
+            print_measurements_json(&mut writer, measurements.ratios)
         }
     }
 }

--- a/bench-vortex/src/bin/public_bi.rs
+++ b/bench-vortex/src/bin/public_bi.rs
@@ -1,3 +1,6 @@
+use std::fs::File;
+use std::io::{Write, stdout};
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use bench_vortex::display::{DisplayFormat, print_measurements_json, render_table};
@@ -44,6 +47,8 @@ struct Args {
     dataset: PBIDataset,
     #[arg(short, long, value_delimiter = ',')]
     queries: Option<Vec<usize>>,
+    #[arg(short)]
+    output_path: Option<PathBuf>,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -163,6 +168,13 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
+    let mut writer: Box<dyn Write> = if let Some(output_path) = args.output_path {
+        Box::new(File::create(output_path)?)
+    } else {
+        let stdout = stdout();
+        Box::new(stdout.lock())
+    };
+
     match args.display_format {
         DisplayFormat::Table => {
             if args.display_metrics {
@@ -181,8 +193,8 @@ fn main() -> anyhow::Result<()> {
                     }
                 }
             }
-            render_table(all_measurements, &args.targets)
+            render_table(&mut writer, all_measurements, &args.targets)
         }
-        DisplayFormat::GhJson => print_measurements_json(all_measurements),
+        DisplayFormat::GhJson => print_measurements_json(&mut writer, all_measurements),
     }
 }

--- a/bench-vortex/src/bin/random_access.rs
+++ b/bench-vortex/src/bin/random_access.rs
@@ -1,3 +1,7 @@
+use std::fs::File;
+use std::io::{Write, stdout};
+use std::path::PathBuf;
+
 use bench_vortex::bench_run::run_with_setup;
 use bench_vortex::datasets::taxi_data::{taxi_data_parquet, taxi_data_vortex};
 use bench_vortex::display::{DisplayFormat, print_measurements_json, render_table};
@@ -25,6 +29,8 @@ struct Args {
     verbose: bool,
     #[arg(short, long, default_value_t, value_enum)]
     display_format: DisplayFormat,
+    #[arg(short)]
+    output_path: Option<PathBuf>,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -39,6 +45,7 @@ fn main() -> anyhow::Result<()> {
         args.display_format,
         args.verbose,
         indices,
+        &args.output_path,
     )
 }
 
@@ -49,6 +56,7 @@ fn random_access(
     display_format: DisplayFormat,
     verbose: bool,
     indices: Buffer<u64>,
+    output_path: &Option<PathBuf>,
 ) -> anyhow::Result<()> {
     // Capture `RUST_LOG` configuration
     let filter = default_env_filter(verbose);
@@ -94,12 +102,19 @@ fn random_access(
         progress.inc(1);
     }
 
+    let mut writer: Box<dyn Write> = if let Some(output_path) = output_path {
+        Box::new(File::create(output_path)?)
+    } else {
+        let stdout = stdout();
+        Box::new(stdout.lock())
+    };
+
     match display_format {
         DisplayFormat::Table => {
-            render_table(measurements, &targets)?;
+            render_table(&mut writer, measurements, &targets)?;
         }
         DisplayFormat::GhJson => {
-            print_measurements_json(measurements)?;
+            print_measurements_json(&mut writer, measurements)?;
         }
     }
 

--- a/bench-vortex/src/bin/tpcds.rs
+++ b/bench-vortex/src/bin/tpcds.rs
@@ -1,3 +1,7 @@
+use std::fs::File;
+use std::io::{Write, stdout};
+use std::path::PathBuf;
+
 use bench_vortex::display::{DisplayFormat, print_measurements_json, render_table};
 use bench_vortex::engines::{EngineCtx, benchmark_datafusion_query, benchmark_duckdb_query};
 use bench_vortex::measurements::QueryMeasurement;
@@ -45,6 +49,8 @@ struct Args {
     export_spans: bool,
     #[arg(long, default_value_t = false)]
     emit_plan: bool,
+    #[arg(short)]
+    output_path: Option<PathBuf>,
 }
 
 #[allow(clippy::expect_used)]
@@ -115,6 +121,7 @@ fn main() -> anyhow::Result<()> {
         args.targets,
         args.display_format,
         url,
+        &args.output_path,
     ))?;
 
     // Require trace guard lives until here
@@ -131,6 +138,7 @@ async fn bench_main(
     targets: Vec<Target>,
     display_format: DisplayFormat,
     url: Url,
+    output_path: &Option<PathBuf>,
 ) -> anyhow::Result<()> {
     info!(
         "Benchmarking against these targets: {}.",
@@ -221,12 +229,19 @@ async fn bench_main(
 
     progress.finish();
 
+    let mut writer: Box<dyn Write> = if let Some(output_path) = output_path {
+        Box::new(File::create(output_path)?)
+    } else {
+        let stdout = stdout();
+        Box::new(stdout.lock())
+    };
+
     match display_format {
         DisplayFormat::Table => {
-            render_table(measurements, &targets)?;
+            render_table(&mut writer, measurements, &targets)?;
         }
         DisplayFormat::GhJson => {
-            print_measurements_json(measurements)?;
+            print_measurements_json(&mut writer, measurements)?;
         }
     };
     Ok(())

--- a/bench-vortex/src/bin/tpch.rs
+++ b/bench-vortex/src/bin/tpch.rs
@@ -1,3 +1,5 @@
+use std::fs::File;
+use std::io::{Write, stdout};
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
@@ -66,6 +68,8 @@ struct Args {
     export_spans: bool,
     #[arg(long, default_value_t = false)]
     emit_plan: bool,
+    #[arg(short)]
+    output_path: Option<PathBuf>,
 }
 
 #[derive(ValueEnum, Default, Clone, Debug, PartialEq, Eq)]
@@ -171,6 +175,7 @@ fn main() -> anyhow::Result<()> {
         args.all_metrics,
         args.export_spans,
         args.emit_plan,
+        &args.output_path,
     ))
 }
 
@@ -187,6 +192,7 @@ async fn bench_main(
     display_all_metrics: bool,
     export_spans: bool,
     emit_plan: bool,
+    output_path: &Option<PathBuf>,
 ) -> anyhow::Result<()> {
     let expected_row_counts = if scale_factor == 1 {
         EXPECTED_ROW_COUNTS_SF1
@@ -335,6 +341,13 @@ async fn bench_main(
 
     progress.finish();
 
+    let mut writer: Box<dyn Write> = if let Some(output_path) = output_path {
+        Box::new(File::create(output_path)?)
+    } else {
+        let stdout = stdout();
+        Box::new(stdout.lock())
+    };
+
     match display_format {
         DisplayFormat::Table => {
             if !display_all_metrics {
@@ -343,10 +356,10 @@ async fn bench_main(
             for m in metrics.timestamps_removed().sorted_for_display().iter() {
                 println!("{m}");
             }
-            render_table(measurements, &targets)?;
+            render_table(&mut writer, measurements, &targets)?;
         }
         DisplayFormat::GhJson => {
-            print_measurements_json(measurements)?;
+            print_measurements_json(&mut writer, measurements)?;
         }
     }
 

--- a/bench-vortex/src/display.rs
+++ b/bench-vortex/src/display.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 use std::iter;
 
 use clap::ValueEnum;
@@ -18,6 +19,7 @@ pub enum DisplayFormat {
 }
 
 pub fn render_table<T: ToTable>(
+    writer: &mut Box<dyn Write>,
     all_measurements: Vec<T>,
     targets: &[Target],
 ) -> anyhow::Result<()> {
@@ -88,15 +90,17 @@ pub fn render_table<T: ToTable>(
         table.with(color);
     }
 
-    println!("{table}");
+    write!(writer, "{table}")?;
 
     Ok(())
 }
 
-pub fn print_measurements_json<T: ToJson>(all_measurements: Vec<T>) -> anyhow::Result<()> {
+pub fn print_measurements_json<T: ToJson>(
+    writer: &mut Box<dyn Write>,
+    all_measurements: Vec<T>,
+) -> anyhow::Result<()> {
     for measurement in all_measurements {
-        // This has to be `println!` and go to stdout, because we capture it from there.
-        println!("{}", serde_json::to_string(&measurement.to_json())?)
+        write!(writer, "{}", serde_json::to_string(&measurement.to_json())?)?
     }
 
     Ok(())

--- a/bench-vortex/src/display.rs
+++ b/bench-vortex/src/display.rs
@@ -90,7 +90,7 @@ pub fn render_table<T: ToTable>(
         table.with(color);
     }
 
-    write!(writer, "{table}")?;
+    writeln!(writer, "{table}")?;
 
     Ok(())
 }
@@ -100,7 +100,7 @@ pub fn print_measurements_json<T: ToJson>(
     all_measurements: Vec<T>,
 ) -> anyhow::Result<()> {
     for measurement in all_measurements {
-        write!(writer, "{}", serde_json::to_string(&measurement.to_json())?)?
+        writeln!(writer, "{}", serde_json::to_string(&measurement.to_json())?)?
     }
 
     Ok(())


### PR DESCRIPTION
This change allow CI to print more diagnostics and still output a result file