### PR TITLE
feat: Hide as many of FieldNames' Arcs as possible

### DIFF
--- a/bench-vortex/src/datasets/struct_list_of_ints.rs
+++ b/bench-vortex/src/datasets/struct_list_of_ints.rs
@@ -36,7 +36,7 @@ impl Dataset for StructListOfInts {
 
     async fn to_vortex_array(&self) -> ArrayRef {
         let names: FieldNames = (0..self.num_columns)
-            .map(|col_idx| (col_idx.to_string().into()))
+            .map(|col_idx| (col_idx.to_string()))
             .collect();
         let mut rng = rand::rngs::StdRng::seed_from_u64(0);
 

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -254,7 +254,7 @@ mod test {
 
     #[test]
     fn test_sparse_struct_valid_fill() {
-        let field_names = FieldNames::from_iter(["a".into(), "b".into()]);
+        let field_names = FieldNames::from_iter(["a", "b"]);
         let field_types = vec![
             DType::Primitive(PType::I32, Nullable),
             DType::Primitive(PType::I32, Nullable),
@@ -333,7 +333,7 @@ mod test {
 
     #[test]
     fn test_sparse_struct_invalid_fill() {
-        let field_names = FieldNames::from_iter(["a".into(), "b".into()]);
+        let field_names = FieldNames::from_iter(["a", "b"]);
         let field_types = vec![
             DType::Primitive(PType::I32, Nullable),
             DType::Primitive(PType::I32, Nullable),

--- a/java/testfiles/src/main.rs
+++ b/java/testfiles/src/main.rs
@@ -61,7 +61,7 @@ fn main() {
 
     // Make the struct array
     let rows = StructArray::try_new(
-        ["Name".into(), "Salary".into(), "State".into()].into(),
+        ["Name", "Salary", "State"].into(),
         vec![names, salary, states],
         10,
         Validity::NonNullable,

--- a/vortex-array/src/arrays/chunked/compute/take.rs
+++ b/vortex-array/src/arrays/chunked/compute/take.rs
@@ -73,6 +73,7 @@ register_kernel!(TakeKernelAdapter(ChunkedVTable).lift());
 #[cfg(test)]
 mod test {
     use vortex_buffer::buffer;
+    use vortex_dtype::FieldNames;
 
     use crate::IntoArray;
     use crate::array::Array;
@@ -101,7 +102,8 @@ mod test {
     #[test]
     fn test_take_nullability() {
         let struct_array =
-            StructArray::try_new([].into(), vec![], 100, Validity::NonNullable).unwrap();
+            StructArray::try_new(FieldNames::default(), vec![], 100, Validity::NonNullable)
+                .unwrap();
 
         let arr = ChunkedArray::from_iter(vec![struct_array.to_array(), struct_array.to_array()]);
 
@@ -112,7 +114,7 @@ mod test {
         .unwrap();
 
         let expect = StructArray::try_new(
-            [].into(),
+            FieldNames::default(),
             vec![],
             3,
             Validity::Array(BoolArray::from_iter(vec![true, false, true]).to_array()),

--- a/vortex-array/src/arrays/list/compute/is_constant.rs
+++ b/vortex-array/src/arrays/list/compute/is_constant.rs
@@ -76,7 +76,7 @@ mod tests {
         .unwrap();
 
         let struct_of_lists = StructArray::try_new(
-            FieldNames::from(["xs".into()]),
+            FieldNames::from(["xs"]),
             vec![xs.into_array()],
             2,
             Validity::NonNullable,

--- a/vortex-array/src/arrays/struct_/compute/mod.rs
+++ b/vortex-array/src/arrays/struct_/compute/mod.rs
@@ -123,14 +123,14 @@ mod tests {
         assert_eq!(
             taken.scalar_at(0).unwrap(),
             Scalar::struct_(
-                DType::Struct(StructFields::new([].into(), vec![]), Nullable),
+                DType::Struct(StructFields::new(FieldNames::default(), vec![]), Nullable),
                 vec![]
             )
         );
         assert_eq!(
             taken.scalar_at(1).unwrap(),
             Scalar::null(DType::Struct(
-                StructFields::new([].into(), vec![]),
+                StructFields::new(FieldNames::default(), vec![]),
                 Nullable
             ))
         );
@@ -188,10 +188,10 @@ mod tests {
 
         test_mask(
             StructArray::try_new(
-                ["xs".into(), "ys".into(), "zs".into()].into(),
+                ["xs", "ys", "zs"].into(),
                 vec![
                     StructArray::try_new(
-                        ["left".into(), "right".into()].into(),
+                        ["left", "right"].into(),
                         vec![xs.clone(), xs],
                         5,
                         Validity::NonNullable,
@@ -211,14 +211,18 @@ mod tests {
 
     #[test]
     fn test_cast_empty_struct() {
-        let array = StructArray::try_new(vec![].into(), vec![], 5, Validity::NonNullable)
+        let array = StructArray::try_new(FieldNames::default(), vec![], 5, Validity::NonNullable)
             .unwrap()
             .into_array();
-        let non_nullable_dtype = DType::Struct(StructFields::new([].into(), vec![]), NonNullable);
+        let non_nullable_dtype = DType::Struct(
+            StructFields::new(FieldNames::default(), vec![]),
+            NonNullable,
+        );
         let casted = cast(&array, &non_nullable_dtype).unwrap();
         assert_eq!(casted.dtype(), &non_nullable_dtype);
 
-        let nullable_dtype = DType::Struct(StructFields::new([].into(), vec![]), Nullable);
+        let nullable_dtype =
+            DType::Struct(StructFields::new(FieldNames::default(), vec![]), Nullable);
         let casted = cast(&array, &nullable_dtype).unwrap();
         assert_eq!(casted.dtype(), &nullable_dtype);
     }
@@ -226,7 +230,7 @@ mod tests {
     #[test]
     fn test_cast_cannot_change_name_order() {
         let array = StructArray::try_new(
-            ["xs".into(), "ys".into(), "zs".into()].into(),
+            ["xs", "ys", "zs"].into(),
             vec![
                 buffer![1u8].into_array(),
                 buffer![1u8].into_array(),
@@ -243,7 +247,7 @@ mod tests {
             array.as_ref(),
             &DType::Struct(
                 StructFields::new(
-                    FieldNames::from(["ys".into(), "xs".into(), "zs".into()]),
+                    FieldNames::from(["ys", "xs", "zs"]),
                     vec![tu8.clone(), tu8.clone(), tu8],
                 ),
                 NonNullable,
@@ -267,10 +271,10 @@ mod tests {
             Validity::AllValid,
         );
         let fully_nullable_array = StructArray::try_new(
-            ["xs".into(), "ys".into(), "zs".into()].into(),
+            ["xs", "ys", "zs"].into(),
             vec![
                 StructArray::try_new(
-                    ["left".into(), "right".into()].into(),
+                    ["left", "right"].into(),
                     vec![xs.to_array(), xs.to_array()],
                     5,
                     Validity::AllValid,
@@ -292,11 +296,11 @@ mod tests {
 
         let non_null_xs_right = DType::Struct(
             StructFields::new(
-                ["xs".into(), "ys".into(), "zs".into()].into(),
+                ["xs", "ys", "zs"].into(),
                 vec![
                     DType::Struct(
                         StructFields::new(
-                            ["left".into(), "right".into()].into(),
+                            ["left", "right"].into(),
                             vec![
                                 DType::Primitive(PType::I64, NonNullable),
                                 DType::Primitive(PType::I64, Nullable),
@@ -315,11 +319,11 @@ mod tests {
 
         let non_null_xs = DType::Struct(
             StructFields::new(
-                ["xs".into(), "ys".into(), "zs".into()].into(),
+                ["xs", "ys", "zs"].into(),
                 vec![
                     DType::Struct(
                         StructFields::new(
-                            ["left".into(), "right".into()].into(),
+                            ["left", "right"].into(),
                             vec![
                                 DType::Primitive(PType::I64, Nullable),
                                 DType::Primitive(PType::I64, Nullable),

--- a/vortex-array/src/arrays/struct_/mod.rs
+++ b/vortex-array/src/arrays/struct_/mod.rs
@@ -325,7 +325,7 @@ mod test {
         let zs = BoolArray::from_iter([true, true, true, false, false]);
 
         let struct_a = StructArray::try_new(
-            FieldNames::from(["xs".into(), "ys".into(), "zs".into()]),
+            FieldNames::from(["xs", "ys", "zs"]),
             vec![xs.into_array(), ys.into_array(), zs.into_array()],
             5,
             Validity::NonNullable,
@@ -365,7 +365,7 @@ mod test {
         let ys = PrimitiveArray::new(buffer![4u64, 5, 6, 7, 8], Validity::NonNullable);
 
         let mut struct_a = StructArray::try_new(
-            FieldNames::from(["xs".into(), "ys".into()]),
+            FieldNames::from(["xs", "ys"]),
             vec![xs.into_array(), ys.into_array()],
             5,
             Validity::NonNullable,
@@ -382,7 +382,7 @@ mod test {
             [0i64, 1, 2, 3, 4]
         );
 
-        assert_eq!(struct_a.names().as_ref(), [FieldName::from("ys")]);
+        assert_eq!(struct_a.names(), &[FieldName::from("ys")].into());
         assert_eq!(struct_a.fields.len(), 1);
         assert_eq!(struct_a.len(), 5);
         assert_eq!(
@@ -401,6 +401,6 @@ mod test {
             empty.is_none(),
             "Expected None when removing non-existent column"
         );
-        assert_eq!(struct_a.names().as_ref(), [FieldName::from("ys")]);
+        assert_eq!(struct_a.names(), &[FieldName::from("ys")].into());
     }
 }

--- a/vortex-array/src/arrow/compute/to_arrow/canonical.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/canonical.rs
@@ -414,7 +414,7 @@ mod tests {
         let xs = PrimitiveArray::new(buffer![0i64, 1, 2, 3, 4], Validity::AllValid);
 
         let struct_a = StructArray::try_new(
-            FieldNames::from(["xs".into()]),
+            FieldNames::from(["xs"]),
             vec![xs.into_array()],
             5,
             Validity::AllValid,
@@ -433,7 +433,7 @@ mod tests {
             PrimitiveArray::from_option_iter(vec![Some(0_i64), Some(1), Some(2), None, Some(3)]);
 
         let struct_a = StructArray::try_new(
-            FieldNames::from(["xs".into()]),
+            FieldNames::from(["xs"]),
             vec![xs.into_array()],
             5,
             Validity::AllValid,
@@ -451,7 +451,7 @@ mod tests {
         let xs = PrimitiveArray::new(buffer![0i64, 1, 2, 3, 4], Validity::AllValid);
 
         let struct_a = StructArray::try_new(
-            FieldNames::from(["xs".into()]),
+            FieldNames::from(["xs"]),
             vec![xs.into_array()],
             5,
             Validity::AllValid,

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -279,7 +279,7 @@ fn remove_nulls(data: arrow_data::ArrayData) -> arrow_data::ArrayData {
 impl FromArrowArray<&ArrowStructArray> for ArrayRef {
     fn from_arrow(value: &ArrowStructArray, nullable: bool) -> Self {
         StructArray::try_new(
-            value.column_names().iter().map(|s| (*s).into()).collect(),
+            value.column_names().iter().copied().collect(),
             value
                 .columns()
                 .iter()

--- a/vortex-array/src/arrow/record_batch.rs
+++ b/vortex-array/src/arrow/record_batch.rs
@@ -15,7 +15,7 @@ impl TryIntoArray for RecordBatch {
             self.schema()
                 .fields()
                 .iter()
-                .map(|f| f.name().as_str().into())
+                .map(|f| f.name().as_str())
                 .collect(),
             self.columns()
                 .iter()

--- a/vortex-array/src/compute/min_max.rs
+++ b/vortex-array/src/compute/min_max.rs
@@ -93,7 +93,7 @@ impl ComputeFnVTable for MinMax {
         // that the array is all null or empty.
         Ok(DType::Struct(
             StructFields::new(
-                ["min".into(), "max".into()].into(),
+                ["min", "max"].into(),
                 vec![array.dtype().clone(), array.dtype().clone()],
             ),
             Nullability::Nullable,
@@ -176,7 +176,7 @@ impl<V: VTable + MinMaxKernel> Kernel for MinMaxKernelAdapter<V> {
         };
         let dtype = DType::Struct(
             StructFields::new(
-                ["min".into(), "max".into()].into(),
+                ["min", "max"].into(),
                 vec![array.dtype().clone(), array.dtype().clone()],
             ),
             Nullability::Nullable,

--- a/vortex-datafusion/examples/vortex_table.rs
+++ b/vortex-datafusion/examples/vortex_table.rs
@@ -30,7 +30,7 @@ async fn main() -> anyhow::Result<()> {
     .into_array();
 
     let st = StructArray::try_new(
-        ["strings".into(), "numbers".into()].into(),
+        ["strings", "numbers"].into(),
         vec![strings, numbers],
         8,
         Validity::NonNullable,

--- a/vortex-datafusion/src/persistent/mod.rs
+++ b/vortex-datafusion/src/persistent/mod.rs
@@ -66,7 +66,7 @@ mod tests {
         .into_array();
 
         let st = StructArray::try_new(
-            ["strings".into(), "numbers".into()].into(),
+            ["strings", "numbers"].into(),
             vec![strings, numbers],
             8,
             Validity::NonNullable,

--- a/vortex-dtype/src/arbitrary.rs
+++ b/vortex-dtype/src/arbitrary.rs
@@ -91,7 +91,7 @@ fn random_struct_dtype(u: &mut Unstructured<'_>, depth: u8) -> Result<StructFiel
     let field_count = u.choose_index(3)?;
     let names: FieldNames = (0..field_count)
         .map(|_| FieldName::arbitrary(u))
-        .collect::<Result<Arc<_>>>()?;
+        .collect::<Result<FieldNames>>()?;
     let dtypes = (0..names.len())
         .map(|_| random_dtype(u, depth))
         .collect::<Result<Vec<_>>>()?;

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
+use std::ops::Index;
 use std::sync::Arc;
 
 use DType::*;
@@ -50,7 +51,7 @@ impl AsRef<[FieldName]> for FieldNames {
     }
 }
 
-impl std::ops::Index<usize> for FieldNames {
+impl Index<usize> for FieldNames {
     type Output = FieldName;
 
     fn index(&self, index: usize) -> &Self::Output {

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -13,8 +13,151 @@ use crate::{ExtDType, FieldDType, PType, StructFields};
 
 /// A name for a field in a struct
 pub type FieldName = Arc<str>;
+
 /// An ordered list of field names in a struct
-pub type FieldNames = Arc<[FieldName]>;
+#[derive(Clone, PartialEq, Eq, Debug, Default, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct FieldNames(Arc<[FieldName]>);
+
+impl FieldNames {
+    /// Returns the number of elements.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns true if the number of elements is 0.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns a borrowed iterator over the field names.
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &FieldName> {
+        FieldNamesIter {
+            inner: self,
+            idx: 0,
+        }
+    }
+
+    /// Returns a reference to a field name, or None if `index` is out of bounds.
+    pub fn get(&self, index: usize) -> Option<&FieldName> {
+        self.0.get(index)
+    }
+}
+
+impl AsRef<[FieldName]> for FieldNames {
+    fn as_ref(&self) -> &[FieldName] {
+        &self.0
+    }
+}
+
+impl std::ops::Index<usize> for FieldNames {
+    type Output = FieldName;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+/// Iterator of references to field names
+pub struct FieldNamesIter<'a> {
+    inner: &'a FieldNames,
+    idx: usize,
+}
+
+impl<'a> Iterator for FieldNamesIter<'a> {
+    type Item = &'a FieldName;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.idx >= self.inner.len() {
+            return None;
+        }
+
+        let i = &self.inner.0[self.idx];
+        self.idx += 1;
+        Some(i)
+    }
+}
+
+impl ExactSizeIterator for FieldNamesIter<'_> {
+    fn len(&self) -> usize {
+        self.inner.len() - self.idx
+    }
+}
+
+/// Owned iterator of field names.
+pub struct FieldNamesIntoIter {
+    inner: FieldNames,
+    idx: usize,
+}
+
+impl Iterator for FieldNamesIntoIter {
+    type Item = FieldName;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.idx >= self.inner.len() {
+            return None;
+        }
+
+        let i = self.inner.0[self.idx].clone();
+        self.idx += 1;
+        Some(i)
+    }
+}
+
+impl ExactSizeIterator for FieldNamesIntoIter {
+    fn len(&self) -> usize {
+        self.inner.len() - self.idx
+    }
+}
+
+impl IntoIterator for FieldNames {
+    type Item = FieldName;
+
+    type IntoIter = FieldNamesIntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        FieldNamesIntoIter {
+            inner: self,
+            idx: 0,
+        }
+    }
+}
+
+impl From<Vec<FieldName>> for FieldNames {
+    fn from(value: Vec<FieldName>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<&[&'static str]> for FieldNames {
+    fn from(value: &[&'static str]) -> Self {
+        Self(value.iter().cloned().map(Arc::from).collect())
+    }
+}
+
+impl From<&[FieldName]> for FieldNames {
+    fn from(value: &[FieldName]) -> Self {
+        Self(Arc::from(value))
+    }
+}
+
+impl<const N: usize> From<[&'static str; N]> for FieldNames {
+    fn from(value: [&'static str; N]) -> Self {
+        Self(value.into_iter().map(Arc::from).collect())
+    }
+}
+
+impl<const N: usize> From<[FieldName; N]> for FieldNames {
+    fn from(value: [FieldName; N]) -> Self {
+        Self(value.into())
+    }
+}
+
+impl<F: Into<FieldName>> FromIterator<F> for FieldNames {
+    fn from_iter<T: IntoIterator<Item = F>>(iter: T) -> Self {
+        Self(iter.into_iter().map(|v| v.into()).collect())
+    }
+}
 
 /// The logical types of elements in Vortex arrays.
 ///

--- a/vortex-dtype/src/field.rs
+++ b/vortex-dtype/src/field.rs
@@ -11,14 +11,14 @@ use std::sync::Arc;
 use itertools::Itertools;
 use vortex_utils::aliases::hash_set::HashSet;
 
-use crate::DType;
+use crate::{DType, FieldName};
 
 /// Selects a nested type within either a struct or a list.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Field {
     /// Address a field of a [`crate::DType::Struct`].
-    Name(Arc<str>),
+    Name(FieldName),
     /// Address the element type of a [`crate::DType::List`].
     ElementType,
 }

--- a/vortex-dtype/src/serde/flatbuffers/mod.rs
+++ b/vortex-dtype/src/serde/flatbuffers/mod.rs
@@ -49,7 +49,6 @@ impl StructFields {
             .names()
             .ok_or_else(|| vortex_err!("failed to parse struct names from flatbuffer"))?
             .iter()
-            .map(|n| (*n).into())
             .collect();
 
         let dtypes = fb_struct
@@ -375,7 +374,7 @@ mod test {
         ));
         roundtrip_dtype(DType::Struct(
             StructFields::new(
-                ["strings".into(), "ints".into()].into(),
+                ["strings", "ints"].into(),
                 vec![
                     DType::Utf8(Nullability::NonNullable),
                     DType::Primitive(PType::U16, Nullability::Nullable),

--- a/vortex-dtype/src/serde/proto.rs
+++ b/vortex-dtype/src/serde/proto.rs
@@ -29,7 +29,7 @@ impl TryFrom<&pb::DType> for DType {
             DtypeType::Binary(b) => Ok(Self::Binary(b.nullable.into())),
             DtypeType::Struct(s) => Ok(Self::Struct(
                 StructFields::new(
-                    s.names.iter().map(|s| s.as_str().into()).collect(),
+                    s.names.iter().map(|s| s.as_str()).collect(),
                     s.dtypes
                         .iter()
                         .map(TryInto::<Self>::try_into)

--- a/vortex-dtype/src/struct_.rs
+++ b/vortex-dtype/src/struct_.rs
@@ -189,7 +189,7 @@ impl StructFields {
     /// The fields of the empty struct.
     pub fn empty() -> Self {
         Self(Arc::new(StructFieldsInner {
-            names: Arc::from([]),
+            names: FieldNames::default(),
             dtypes: Arc::from([]),
         }))
     }
@@ -372,7 +372,7 @@ mod test {
     fn nullability() {
         assert!(
             !DType::Struct(
-                StructFields::new(vec![].into(), Vec::new()),
+                StructFields::new(FieldNames::default(), Vec::new()),
                 Nullability::NonNullable
             )
             .is_nullable()
@@ -432,10 +432,7 @@ mod test {
         let sf2 = StructFields::from_iter([("C", child_c.clone())]);
 
         let merged = StructFields::disjoint_merge(&sf1, &sf2).unwrap();
-        assert_eq!(
-            merged.names(),
-            &FieldNames::from_iter(["A".into(), "B".into(), "C".into()])
-        );
+        assert_eq!(merged.names(), &FieldNames::from_iter(["A", "B", "C"]));
         assert_eq!(
             merged.fields().collect_vec(),
             vec![child_a, child_b, child_c]

--- a/vortex-duckdb/src/convert/dtype.rs
+++ b/vortex-duckdb/src/convert/dtype.rs
@@ -433,7 +433,7 @@ mod tests {
 
     #[test]
     fn test_empty_struct() {
-        let struct_fields = StructFields::new([].into(), [].into());
+        let struct_fields = StructFields::new(FieldNames::default(), [].into());
         let dtype = DType::Struct(struct_fields, Nullability::NonNullable);
 
         let logical_type = LogicalType::try_from(&dtype).unwrap();

--- a/vortex-expr/src/arbitrary.rs
+++ b/vortex-expr/src/arbitrary.rs
@@ -15,7 +15,7 @@ pub fn projection_expr(u: &mut Unstructured<'_>, dtype: &DType) -> AResult<Optio
 
     let cols = (0..column_count)
         .map(|_| {
-            let get_item = u.choose(struct_dtype.names().iter().as_slice())?;
+            let get_item = u.choose_iter(struct_dtype.names().iter())?;
             Ok((get_item.clone(), get_item_scope(get_item.clone())))
         })
         .collect::<AResult<Vec<_>>>()?;

--- a/vortex-expr/src/exprs/list_contains.rs
+++ b/vortex-expr/src/exprs/list_contains.rs
@@ -159,7 +159,7 @@ mod tests {
     use vortex_array::validity::Validity;
     use vortex_array::{Array, ArrayRef, IntoArray};
     use vortex_dtype::PType::I32;
-    use vortex_dtype::{Field, FieldNames, FieldPath, FieldPathSet, Nullability, StructFields};
+    use vortex_dtype::{Field, FieldPath, FieldPathSet, Nullability, StructFields};
     use vortex_scalar::Scalar;
     use vortex_utils::aliases::hash_map::HashMap;
 
@@ -278,7 +278,7 @@ mod tests {
     pub fn test_return_type() {
         let scope = ScopeDType::new(DType::Struct(
             StructFields::new(
-                FieldNames::from(["array".into()]),
+                ["array"].into(),
                 vec![DType::List(
                     Arc::new(DType::Primitive(I32, Nullability::NonNullable)),
                     Nullability::Nullable,

--- a/vortex-expr/src/exprs/literal.rs
+++ b/vortex-expr/src/exprs/literal.rs
@@ -138,7 +138,6 @@ pub fn lit(value: impl Into<Scalar>) -> ExprRef {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use vortex_dtype::{DType, Nullability, PType, StructFields};
     use vortex_scalar::Scalar;
@@ -176,7 +175,7 @@ mod tests {
 
         let sdtype = DType::Struct(
             StructFields::new(
-                Arc::from([Arc::from("dog"), Arc::from("cat")]),
+                ["dog", "cat"].into(),
                 vec![
                     DType::Primitive(PType::U32, Nullability::NonNullable),
                     DType::Utf8(Nullability::NonNullable),

--- a/vortex-expr/src/exprs/merge.rs
+++ b/vortex-expr/src/exprs/merge.rs
@@ -252,7 +252,7 @@ mod tests {
 
         assert_eq!(
             actual_array.as_struct_typed().names(),
-            &["a".into(), "b".into(), "c".into(), "d".into(), "e".into()].into()
+            &["a", "b", "c", "d", "e"].into()
         );
 
         assert_eq!(
@@ -392,10 +392,7 @@ mod tests {
             .to_struct()
             .unwrap();
 
-        assert_eq!(
-            actual_array.names(),
-            &["a".into(), "c".into(), "b".into(), "d".into()].into()
-        );
+        assert_eq!(actual_array.names(), &["a", "c", "b", "d"].into());
     }
 
     #[test]

--- a/vortex-expr/src/exprs/pack.rs
+++ b/vortex-expr/src/exprs/pack.rs
@@ -24,7 +24,7 @@ use crate::{AnalysisExpr, ExprRef, Scope, ScopeDType, VortexExpr};
 /// use vortex_dtype::Nullability;
 ///
 /// let example = Pack::try_new_expr(
-///     ["x".into(), "x copy".into(), "second x copy".into()].into(),
+///     ["x", "x copy", "second x copy"].into(),
 ///     vec![root(), root(), root()],
 ///     Nullability::NonNullable,
 /// ).unwrap();

--- a/vortex-expr/src/exprs/pack.rs
+++ b/vortex-expr/src/exprs/pack.rs
@@ -140,7 +140,7 @@ pub(crate) mod proto {
             };
 
             Pack::try_new_expr(
-                op.paths.iter().cloned().map(|p| p.into()).collect(),
+                op.paths.iter().map(|p| p.as_str()).collect(),
                 children,
                 op.nullable.into(),
             )
@@ -207,7 +207,6 @@ impl VortexExpr for Pack {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use vortex_array::arrays::{PrimitiveArray, StructArray};
     use vortex_array::validity::Validity;
@@ -244,7 +243,8 @@ mod tests {
 
     #[test]
     pub fn test_empty_pack() {
-        let expr = Pack::try_new_expr(Arc::new([]), Vec::new(), Nullability::NonNullable).unwrap();
+        let expr = Pack::try_new_expr(FieldNames::default(), Vec::new(), Nullability::NonNullable)
+            .unwrap();
 
         let test_array = test_array();
         let actual_array = expr.evaluate(&Scope::new(test_array.clone())).unwrap();
@@ -258,7 +258,7 @@ mod tests {
     #[test]
     pub fn test_simple_pack() {
         let expr = Pack::try_new_expr(
-            ["one".into(), "two".into(), "three".into()].into(),
+            ["one", "two", "three"].into(),
             vec![col("a"), col("b"), col("a")],
             Nullability::NonNullable,
         )
@@ -269,7 +269,7 @@ mod tests {
             .unwrap()
             .to_struct()
             .unwrap();
-        let expected_names: FieldNames = ["one".into(), "two".into(), "three".into()].into();
+        let expected_names: FieldNames = ["one", "two", "three"].into();
         assert_eq!(actual_array.names(), &expected_names);
         assert_eq!(actual_array.validity(), &Validity::NonNullable);
 
@@ -296,11 +296,11 @@ mod tests {
     #[test]
     pub fn test_nested_pack() {
         let expr = Pack::try_new_expr(
-            ["one".into(), "two".into(), "three".into()].into(),
+            ["one", "two", "three"].into(),
             vec![
                 col("a"),
                 Pack::try_new_expr(
-                    ["two_one".into(), "two_two".into()].into(),
+                    ["two_one", "two_two"].into(),
                     vec![col("b"), col("b")],
                     Nullability::NonNullable,
                 )
@@ -316,7 +316,7 @@ mod tests {
             .unwrap()
             .to_struct()
             .unwrap();
-        let expected_names: FieldNames = ["one".into(), "two".into(), "three".into()].into();
+        let expected_names = FieldNames::from(["one", "two", "three"]);
         assert_eq!(actual_array.names(), &expected_names);
 
         assert_eq!(
@@ -348,7 +348,7 @@ mod tests {
     #[test]
     pub fn test_pack_nullable() {
         let expr = Pack::try_new_expr(
-            ["one".into(), "two".into(), "three".into()].into(),
+            ["one", "two", "three"].into(),
             vec![col("a"), col("b"), col("a")],
             Nullability::Nullable,
         )
@@ -359,7 +359,7 @@ mod tests {
             .unwrap()
             .to_struct()
             .unwrap();
-        let expected_names: FieldNames = ["one".into(), "two".into(), "three".into()].into();
+        let expected_names: FieldNames = ["one", "two", "three"].into();
         assert_eq!(actual_array.names(), &expected_names);
         assert_eq!(actual_array.validity(), &Validity::AllValid);
     }

--- a/vortex-expr/src/exprs/select.rs
+++ b/vortex-expr/src/exprs/select.rs
@@ -87,7 +87,11 @@ impl SelectField {
     }
 
     pub fn as_include_names(&self, field_names: &FieldNames) -> VortexResult<FieldNames> {
-        if self.fields().iter().any(|f| !field_names.contains(f)) {
+        if self
+            .fields()
+            .iter()
+            .any(|f| !field_names.iter().contains(f))
+        {
             vortex_bail!(
                 "Field {:?} in select not in field names {:?}",
                 self,
@@ -98,7 +102,7 @@ impl SelectField {
             SelectField::Include(fields) => Ok(fields.clone()),
             SelectField::Exclude(exc_fields) => Ok(field_names
                 .iter()
-                .filter(|f| exc_fields.contains(f))
+                .filter(|f| exc_fields.iter().contains(f))
                 .cloned()
                 .collect()),
         }
@@ -162,12 +166,12 @@ impl VortexExpr for Select {
     fn unchecked_evaluate(&self, scope: &Scope) -> VortexResult<ArrayRef> {
         let batch = self.child.unchecked_evaluate(scope)?.to_struct()?;
         Ok(match &self.fields {
-            SelectField::Include(f) => batch.project(f),
+            SelectField::Include(f) => batch.project(f.as_ref()),
             SelectField::Exclude(names) => {
                 let included_names = batch
                     .names()
                     .iter()
-                    .filter(|&f| !names.contains(f))
+                    .filter(|&f| !names.iter().contains(f))
                     .cloned()
                     .collect::<Vec<_>>();
                 batch.project(included_names.as_slice())
@@ -192,13 +196,13 @@ impl VortexExpr for Select {
             .ok_or_else(|| vortex_err!("Select child not a struct dtype"))?;
 
         let projected = match &self.fields {
-            SelectField::Include(fields) => child_struct_dtype.project(fields)?,
+            SelectField::Include(fields) => child_struct_dtype.project(fields.as_ref())?,
             SelectField::Exclude(fields) => child_struct_dtype
                 .names()
                 .iter()
                 .cloned()
                 .zip_eq(child_struct_dtype.fields())
-                .filter(|(name, _)| !fields.contains(name))
+                .filter(|(name, _)| !fields.iter().contains(name))
                 .collect(),
         };
 

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -248,14 +248,7 @@ pub mod test_harness {
     pub fn struct_dtype() -> DType {
         DType::Struct(
             StructFields::new(
-                [
-                    "a".into(),
-                    "col1".into(),
-                    "col2".into(),
-                    "bool1".into(),
-                    "bool2".into(),
-                ]
-                .into(),
+                ["a", "col1", "col2", "bool1", "bool2"].into(),
                 vec![
                     DType::Primitive(PType::I32, Nullability::NonNullable),
                     DType::Primitive(PType::U16, Nullability::Nullable),
@@ -271,7 +264,7 @@ pub mod test_harness {
 
 #[cfg(test)]
 mod tests {
-    use vortex_dtype::{DType, Nullability, PType, StructFields};
+    use vortex_dtype::{DType, FieldNames, Nullability, PType, StructFields};
     use vortex_scalar::Scalar;
 
     use super::*;
@@ -382,7 +375,7 @@ mod tests {
             lit(Scalar::struct_(
                 DType::Struct(
                     StructFields::new(
-                        Arc::from([Arc::from("dog"), Arc::from("cat")]),
+                        FieldNames::from(["dog", "cat"]),
                         vec![
                             DType::Primitive(PType::U32, Nullability::NonNullable),
                             DType::Utf8(Nullability::NonNullable)

--- a/vortex-expr/src/transform/field_mask.rs
+++ b/vortex-expr/src/transform/field_mask.rs
@@ -71,7 +71,7 @@ mod test {
     fn dtype() -> DType {
         DType::Struct(
             StructFields::new(
-                ["A".into(), "B".into(), "C".into()].into(),
+                ["A", "B", "C"].into(),
                 iter::repeat_n(DType::Primitive(PType::I32, NonNullable), 3).collect(),
             ),
             NonNullable,

--- a/vortex-expr/src/transform/remove_select.rs
+++ b/vortex-expr/src/transform/remove_select.rs
@@ -65,13 +65,10 @@ mod tests {
     #[test]
     fn test_remove_select() {
         let dtype = DType::Struct(
-            StructFields::new(
-                ["a".into(), "b".into()].into(),
-                vec![I32.into(), I32.into()],
-            ),
+            StructFields::new(["a", "b"].into(), vec![I32.into(), I32.into()]),
             Nullable,
         );
-        let e = select(["a".into(), "b".into()], root());
+        let e = select(["a", "b"], root());
         let e = remove_select(e, &ScopeDType::new(dtype.clone())).unwrap();
 
         assert!(e.as_any().is::<Pack>());

--- a/vortex-file/src/pruning.rs
+++ b/vortex-file/src/pruning.rs
@@ -4,7 +4,7 @@ use vortex_array::ArrayRef;
 use vortex_array::arrays::{ConstantArray, StructArray};
 use vortex_array::stats::{Stat, StatsProvider, StatsSet};
 use vortex_array::validity::Validity;
-use vortex_dtype::{Field, FieldName, FieldPath, StructFields};
+use vortex_dtype::{Field, FieldName, FieldNames, FieldPath, StructFields};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
 use vortex_expr::pruning::field_path_stat_field_name;
 use vortex_scalar::Scalar;
@@ -17,7 +17,7 @@ pub fn extract_relevant_file_stats_as_struct_row(
     struct_dtype: &StructFields,
 ) -> VortexResult<Option<ArrayRef>> {
     if access.is_empty() {
-        return StructArray::try_new([].into(), vec![], 1, Validity::NonNullable)
+        return StructArray::try_new(FieldNames::default(), vec![], 1, Validity::NonNullable)
             .map(|s| Some(s.to_array()));
     }
 

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -220,7 +220,7 @@ async fn test_read_projection() {
     let array = file
         .scan()
         .unwrap()
-        .with_projection(select(["strings".into()], root()))
+        .with_projection(select(["strings"], root()))
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -248,7 +248,7 @@ async fn test_read_projection() {
     let array = file
         .scan()
         .unwrap()
-        .with_projection(select(["numbers".into()], root()))
+        .with_projection(select(["numbers"], root()))
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -258,7 +258,7 @@ async fn test_read_projection() {
     assert_eq!(
         array.dtype(),
         &DType::Struct(
-            StructFields::new(vec!["numbers".into()].into(), vec![numbers_dtype.clone()]),
+            StructFields::new(["numbers"].into(), vec![numbers_dtype.clone()]),
             Nullability::NonNullable,
         )
     );
@@ -335,7 +335,7 @@ async fn write_chunked() {
             .unwrap()
             .into_array();
     let st = StructArray::try_new(
-        ["strings".into(), "numbers".into()].into(),
+        ["strings", "numbers"].into(),
         vec![strings_chunked, numbers_chunked],
         16,
         Validity::NonNullable,
@@ -407,7 +407,7 @@ async fn filter_string() {
     let ages_orig =
         PrimitiveArray::from_option_iter([Some(25), Some(31), None, Some(57), None]).into_array();
     let st = StructArray::try_new(
-        ["name".into(), "age".into()].into(),
+        ["name", "age"].into(),
         vec![names_orig, ages_orig],
         5,
         Validity::NonNullable,
@@ -458,7 +458,7 @@ async fn filter_or() {
     );
     let ages = PrimitiveArray::from_option_iter([Some(25), Some(31), None, Some(57), None]);
     let st = StructArray::try_new(
-        ["name".into(), "age".into()].into(),
+        ["name", "age"].into(),
         vec![names.into_array(), ages.into_array()],
         5,
         Validity::NonNullable,
@@ -522,7 +522,7 @@ async fn filter_and() {
     );
     let ages = PrimitiveArray::from_option_iter([Some(25), Some(31), None, Some(57), None]);
     let st = StructArray::try_new(
-        ["name".into(), "age".into()].into(),
+        ["name", "age"].into(),
         vec![names.into_array(), ages.into_array()],
         5,
         Validity::NonNullable,
@@ -1029,7 +1029,7 @@ async fn test_repeated_projection() {
     let actual = file
         .scan()
         .unwrap()
-        .with_projection(select(["strings".into(), "strings".into()], root()))
+        .with_projection(select(["strings", "strings"], root()))
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -1132,7 +1132,7 @@ async fn write_nullable_top_level_struct() {
     let ages = PrimitiveArray::from_option_iter([Some(25), Some(31), None, Some(57), None]);
 
     let array = StructArray::try_new(
-        ["age".into()].into(),
+        ["age"].into(),
         vec![ages.into_array()],
         5,
         Validity::AllValid,
@@ -1159,7 +1159,7 @@ async fn write_nullable_nested_struct() -> VortexResult<()> {
     let struct_ = ConstantArray::new(Scalar::null(nested_dtype.clone()), 3).to_array();
 
     let array = StructArray::try_new(
-        ["struct".into()].into(),
+        ["struct"].into(),
         vec![struct_.into_array()],
         3,
         Validity::NonNullable,

--- a/vortex-layout/src/layouts/struct_/writer.rs
+++ b/vortex-layout/src/layouts/struct_/writer.rs
@@ -205,7 +205,7 @@ mod tests {
     use vortex_array::validity::Validity;
     use vortex_array::{ArrayContext, IntoArray as _};
     use vortex_buffer::buffer;
-    use vortex_dtype::{DType, Nullability, PType, StructFields};
+    use vortex_dtype::{DType, FieldNames, Nullability, PType, StructFields};
 
     use crate::layouts::flat::writer::FlatLayoutStrategy;
     use crate::layouts::struct_::writer::StructStrategy;
@@ -259,7 +259,7 @@ mod tests {
                         Ok((
                             SequenceId::root().downgrade(),
                             StructArray::try_new(
-                                ["a".into()].into(),
+                                ["a"].into(),
                                 vec![buffer![1, 2, 3].into_array()],
                                 3,
                                 Validity::Array(
@@ -290,24 +290,34 @@ mod tests {
                 SequenceWriter::new(Box::new(TestSegments::default())),
                 SequentialStreamAdapter::new(
                     DType::Struct(
-                        StructFields::new([].into(), vec![]),
+                        StructFields::new(FieldNames::default(), vec![]),
                         Nullability::NonNullable,
                     ),
                     stream::iter([
                         {
                             Ok((
                                 SequenceId::root().downgrade(),
-                                StructArray::try_new([].into(), vec![], 3, Validity::NonNullable)
-                                    .unwrap()
-                                    .into_array(),
+                                StructArray::try_new(
+                                    FieldNames::default(),
+                                    vec![],
+                                    3,
+                                    Validity::NonNullable,
+                                )
+                                .unwrap()
+                                .into_array(),
                             ))
                         },
                         {
                             Ok((
                                 SequenceId::root().advance(),
-                                StructArray::try_new([].into(), vec![], 5, Validity::NonNullable)
-                                    .unwrap()
-                                    .into_array(),
+                                StructArray::try_new(
+                                    FieldNames::default(),
+                                    vec![],
+                                    5,
+                                    Validity::NonNullable,
+                                )
+                                .unwrap()
+                                .into_array(),
                             ))
                         },
                     ]),

--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -70,7 +70,7 @@ fn projection_from_python(columns: Option<Vec<Bound<PyAny>>>) -> PyResult<ExprRe
             let fields = columns
                 .iter()
                 .map(field_from_pyany)
-                .collect::<PyResult<Arc<[FieldName]>>>()?;
+                .collect::<PyResult<_>>()?;
 
             Select::include_expr(fields, root())
         }

--- a/vortex-scalar/src/display.rs
+++ b/vortex-scalar/src/display.rs
@@ -92,7 +92,7 @@ mod tests {
     #[test]
     fn display_empty_struct() {
         fn dtype() -> DType {
-            DType::Struct(StructFields::new([].into(), vec![]), Nullable)
+            DType::Struct(StructFields::new(Default::default(), vec![]), Nullable)
         }
 
         assert_eq!(format!("{}", Scalar::null(dtype())), "null");

--- a/vortex-scalar/src/scalar_value/mod.rs
+++ b/vortex-scalar/src/scalar_value/mod.rs
@@ -275,7 +275,7 @@ where
 #[cfg(test)]
 mod test {
 
-    use vortex_dtype::{DType, Nullability, PType, StructFields};
+    use vortex_dtype::{DType, FieldNames, Nullability, PType, StructFields};
 
     use crate::{InnerScalarValue, PValue, ScalarValue};
 
@@ -387,7 +387,7 @@ mod test {
         );
         assert!(
             ScalarValue(InnerScalarValue::Null).is_instance_of(&DType::Struct(
-                StructFields::new([].into(), [].into()),
+                StructFields::new(FieldNames::default(), [].into()),
                 Nullability::Nullable,
             ))
         );


### PR DESCRIPTION
The main purpose of this PR is to hide the implementation details of `FieldNames` from the public API, and pushing all the required `from/into` calls internally.

The change in API can be seen in all the test changes, which I think are nicer.