### PR TITLE
chore: java and python publish do not block on Rust publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,7 +105,7 @@ jobs:
           path: dist/
 
   publish-python:
-    needs: [ prepare-python, publish-rust ]
+    needs: [ prepare-python ]
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -158,7 +158,7 @@ jobs:
           if-no-files-found: error
 
   publish-java:
-    needs: [ prepare-java, publish-rust ]
+    needs: [ prepare-java ]
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:


### PR DESCRIPTION
It is very easy for a maintainer to manually release the Rust crates after a failure, it is very difficult to release the Java and Python modules except from CI since they need to perform cross-platform builds.
