### PR TITLE
fix: STRIDE for u8/i32 AVX2 take kernel

### DIFF
--- a/vortex-array/src/arrays/primitive/compute/take/avx2.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/avx2.rs
@@ -141,7 +141,7 @@ impl_gather!(u8,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i32gather_epi32,
         store: _mm256_storeu_si256,
-        WIDTH = 8, STRIDE = 8
+        WIDTH = 8, STRIDE = 16
     },
 
     // 64-bit values, loaded 4 at a time


### PR DESCRIPTION
Fix issue found by ASAN in fuzzing. Fuzz ran crashes with following trace:

```
Running: array_ops/crash-485c6df67fbeb2caf5cab98aeeaf26213930c6a6
=================================================================
==11223==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x79bb6b5e3dd2 at pc 0x5aacd3d7cc3b bp 0x7ffccb9264d0 sp 0x7ffccb925c90
READ of size 16 at 0x79bb6b5e3dd2 thread T0
    #0 0x5aacd3d7cc3a in __asan_memcpy /rustc/llvm/src/llvm-project/compiler-rt/lib/asan/asan_interceptors_memintrinsics.cpp:63:3
    #1 0x5aacd5042064 in copy_nonoverlapping<u8> /home/ubuntu/.rustup/toolchains/nightly-2025-02-24-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/intrinsics/mod.rs:4427:14
    #2 0x5aacd5042064 in _mm_loadu_si128 /home/ubuntu/.rustup/toolchains/nightly-2025-02-24-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/../../stdarch/crates/core_arch/src/x86/sse2.rs:1229:5
    #3 0x5aacd5042064 in gather /home/ubuntu/vortex/vortex-array/src/arrays/primitive/compute/take/avx2.rs:96:48
    #4 0x5aacd5042064 in exec_take<u8, i32, vortex_array::arrays::primitive::compute::take::avx2::AVX2Gather> /home/ubuntu/vortex/vortex-array/src/arrays/primitive/compute/take/avx2.rs:363:13
    #5 0x5aacd5042064 in vortex_array::arrays::primitive::compute::take::avx2::take_primitive_avx2::hfc291a04de95e914 /home/ubuntu/vortex/vortex-array/src/arrays/primitive/compute/take/avx2.rs:417:26
    #6 0x5aacd502c647 in _$LT$vortex_array..arrays..primitive..compute..take..avx2..TakeKernelAVX2$u20$as$u20$vortex_array..arrays..primitive..compute..take..TakeImpl$GT$::take::h37582b50fa47a0fd /home/ubuntu/vortex/vortex-array/src/arrays/primitive/compute/take/avx2.rs:46:21
    #7 0x5aacd504946e in vortex_array::arrays::primitive::compute::take::_$LT$impl$u20$vortex_array..compute..take..TakeKernel$u20$for$u20$vortex_array..arrays..primitive..PrimitiveVTable$GT$::take::hc525459d00ac5810 /home/ubuntu/vortex/vortex-array/src/arrays/primitive/compute/take/mod.rs:86:9
    #8 0x5aacd53f9f2a in _$LT$vortex_array..compute..take..TakeKernelAdapter$LT$V$GT$$u20$as$u20$vortex_array..compute..Kernel$GT$::invoke::hb4732cfed80c7c28 /home/ubuntu/vortex/vortex-array/src/compute/take.rs:207:17
    #9 0x5aacd53f2b28 in take_impl /home/ubuntu/vortex/vortex-array/src/compute/take.rs:138:31
    #10 0x5aacd53f2b28 in _$LT$vortex_array..compute..take..Take$u20$as$u20$vortex_array..compute..ComputeFnVTable$GT$::invoke::hc51045665759dafd /home/ubuntu/vortex/vortex-array/src/compute/take.rs:59:21
    #11 0x5aacd53fd09f in vortex_array::compute::ComputeFn::invoke::ha4d4cce1e985a281 /home/ubuntu/vortex/vortex-array/src/compute/mod.rs:112:22
```

Our exec_take iterates in units of STRIDE, and if there aren't STRIDE more elements available in the indices, it fallsback to scalar iteration.

We encoded the wrong STRIDE for the u8/i32 kernel, it should match u8/u32.