### PR TITLE
ci: Fuzz failures should fail whole job

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -37,6 +37,7 @@ jobs:
           AWS_REGION: 'us-east-1'
           AWS_ENDPOINT_URL: 'https://01e9655179bbec953276890b183039bc.r2.cloudflarestorage.com'
       - name: Run fuzzing target
+        id: fuzz
         run: RUST_BACKTRACE=1 cargo fuzz run file_io -j "$(nproc)" -- -max_total_time=7200
         continue-on-error: true
       - name: Archive crash artifacts
@@ -54,6 +55,9 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_FUZZ_SECRET_ACCESS_KEY }}
           AWS_REGION: 'us-east-1'
           AWS_ENDPOINT_URL: 'https://01e9655179bbec953276890b183039bc.r2.cloudflarestorage.com'
+      - name: Fail job if fuzz run found a bug
+        if: steps.fuzz.outcome == 'failure'
+        run: exit 1
 
   ops_fuzz:
     name: 'Array Operations Fuzz'
@@ -86,6 +90,7 @@ jobs:
           AWS_REGION: 'us-east-1'
           AWS_ENDPOINT_URL: 'https://01e9655179bbec953276890b183039bc.r2.cloudflarestorage.com'
       - name: Run fuzzing target
+        id: fuzz
         run: RUST_BACKTRACE=1 cargo fuzz run array_ops -j "$(nproc)" -- -max_total_time=7200
         continue-on-error: true
       - name: Archive crash artifacts
@@ -103,3 +108,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_FUZZ_SECRET_ACCESS_KEY }}
           AWS_REGION: 'us-east-1'
           AWS_ENDPOINT_URL: 'https://01e9655179bbec953276890b183039bc.r2.cloudflarestorage.com'
+      - name: Fail job if fuzz run found a bug
+        if: steps.fuzz.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
Currently due to our use of `continue-on-error: true` fuzzing failures are indistinguishable from fuzzing successes in the Github Actions listing.

This makes the whole job fail based on the fuzz failure after artifacts are uploaded.

See https://docs.github.com/en/actions/reference/contexts-reference#steps-context for more details about the `steps.ID.outcome` parameter