### PR TITLE
fix: DecimalByteParts compare with overflow and nullable elements

### DIFF
--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/compare.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/compare.rs
@@ -20,10 +20,6 @@ impl CompareKernel for DecimalBytePartsVTable {
         rhs: &dyn Array,
         operator: Operator,
     ) -> VortexResult<Option<ArrayRef>> {
-        // TODO(joe): support compare with lower parts
-        if !lhs.lower_parts.is_empty() {
-            return Ok(None);
-        }
         let Some(rhs_const) = rhs.as_constant() else {
             return Ok(None);
         };
@@ -43,12 +39,25 @@ impl CompareKernel for DecimalBytePartsVTable {
                 let encoded_const = ConstantArray::new(encoded_scalar, rhs.len());
                 compare(&lhs.msp, &encoded_const.to_array(), operator).map(Some)
             }
-            // here the scalar value is bigger than the msp type.
-            // TODO(joe): fixme, when allowing lsp values.
-            Err(sign) => Ok(Some(
-                ConstantArray::new(unconvertible_value(sign, operator, nullability), lhs.len())
-                    .to_array(),
-            )),
+
+            Err(sign) => {
+                // If the MSP and the constant are non-null, we know that failing to coerce the
+                // constant into the MSP bit-width means that it is larger/smaller
+                // (depending on the `sign`) than all values in MSP.
+                // If the LHS or the RHS contain nulls, then we must fallback to the canonicalized
+                // implementation which does null-checking instead.
+                if lhs.all_valid()? && rhs.all_valid()? {
+                    Ok(Some(
+                        ConstantArray::new(
+                            unconvertible_value(sign, operator, nullability),
+                            lhs.len(),
+                        )
+                        .to_array(),
+                    ))
+                } else {
+                    Ok(None)
+                }
+            }
         }
     }
 }
@@ -114,12 +123,13 @@ register_kernel!(CompareKernelAdapter(DecimalBytePartsVTable).lift());
 
 #[cfg(test)]
 mod tests {
-    use vortex_array::arrays::{ConstantArray, PrimitiveArray};
+    use vortex_array::arrays::{BoolArray, ConstantArray, PrimitiveArray};
     use vortex_array::compute::{Operator, compare};
     use vortex_array::validity::Validity;
-    use vortex_array::{Array, ToCanonical};
+    use vortex_array::{Array, IntoArray, ToCanonical};
     use vortex_buffer::buffer;
     use vortex_dtype::{DType, DecimalDType, Nullability};
+    use vortex_error::VortexResult;
     use vortex_scalar::{DecimalValue, Scalar};
 
     use crate::DecimalBytePartsArray;
@@ -130,7 +140,6 @@ mod tests {
         let dtype = DType::Decimal(decimal_dtype, Nullability::Nullable);
         let lhs = DecimalBytePartsArray::try_new(
             PrimitiveArray::new(buffer![100i32, 200i32, 400i32], Validity::AllValid).to_array(),
-            vec![],
             decimal_dtype,
         )
         .unwrap()
@@ -150,12 +159,42 @@ mod tests {
     }
 
     #[test]
+    fn test_byteparts_compare_nullable() -> VortexResult<()> {
+        let decimal_type = DecimalDType::new(19, -11);
+        let lhs = DecimalBytePartsArray::try_new(
+            PrimitiveArray::new(
+                buffer![1i64, 2i64, 3i64, 4i64],
+                Validity::Array(BoolArray::from_iter([false, true, true, true]).into_array()),
+            )
+            .into_array(),
+            decimal_type,
+        )?;
+
+        let rhs = ConstantArray::new(
+            Scalar::decimal(
+                DecimalValue::I128(289888198),
+                decimal_type,
+                Nullability::NonNullable,
+            ),
+            4,
+        )
+        .into_array();
+
+        let res = compare(lhs.as_ref(), rhs.as_ref(), Operator::Lte)?;
+        assert_eq!(res.scalar_at(0)?.as_bool().value(), None);
+        assert_eq!(res.scalar_at(1)?.as_bool().value(), Some(true));
+        assert_eq!(res.scalar_at(2)?.as_bool().value(), Some(true));
+        assert_eq!(res.scalar_at(3)?.as_bool().value(), Some(true));
+
+        Ok(())
+    }
+
+    #[test]
     fn compare_decimal_const_unconvertible_comparison() {
         let decimal_dtype = DecimalDType::new(40, 2);
         let dtype = DType::Decimal(decimal_dtype, Nullability::Nullable);
         let lhs = DecimalBytePartsArray::try_new(
             PrimitiveArray::new(buffer![100i32, 200i32, 400i32], Validity::AllValid).to_array(),
-            vec![],
             decimal_dtype,
         )
         .unwrap()

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/filter.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/filter.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use itertools::Itertools;
 use vortex_array::compute::{FilterKernel, FilterKernelAdapter, filter};
 use vortex_array::{ArrayRef, register_kernel};
 use vortex_error::VortexResult;
@@ -11,16 +10,8 @@ use crate::{DecimalBytePartsArray, DecimalBytePartsVTable};
 
 impl FilterKernel for DecimalBytePartsVTable {
     fn filter(&self, array: &Self::Array, mask: &Mask) -> VortexResult<ArrayRef> {
-        DecimalBytePartsArray::try_new(
-            filter(&array.msp, mask)?,
-            array
-                .lower_parts
-                .iter()
-                .map(|p| filter(p, mask))
-                .try_collect()?,
-            *array.decimal_dtype(),
-        )
-        .map(|d| d.to_array())
+        DecimalBytePartsArray::try_new(filter(&array.msp, mask)?, *array.decimal_dtype())
+            .map(|d| d.to_array())
     }
 }
 

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -4,7 +4,6 @@
 mod compute;
 mod serde;
 
-use itertools::Itertools;
 use vortex_array::arrays::DecimalArray;
 use vortex_array::stats::{ArrayStats, StatsSetRef};
 use vortex_array::vtable::{
@@ -12,8 +11,7 @@ use vortex_array::vtable::{
     ValidityHelper, ValidityVTableFromChild,
 };
 use vortex_array::{Array, ArrayRef, Canonical, EncodingId, EncodingRef, vtable};
-use vortex_dtype::Nullability::NonNullable;
-use vortex_dtype::{DType, DecimalDType, PType, match_each_signed_integer_ptype};
+use vortex_dtype::{DType, DecimalDType, match_each_signed_integer_ptype};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail};
 use vortex_scalar::{DecimalValue, Scalar};
 
@@ -49,44 +47,24 @@ impl VTable for DecimalBytePartsVTable {
 #[derive(Clone, Debug)]
 pub struct DecimalBytePartsArray {
     msp: ArrayRef,
-    lower_parts: Vec<ArrayRef>,
+    // NOTE: the lower_parts is currently unused, we reserve this field so that it is properly
+    //  read/written during serde, but provide no constructor to initialize this to anything
+    //  other than the empty Vec.
+    _lower_parts: Vec<ArrayRef>,
     dtype: DType,
     stats_set: ArrayStats,
 }
 
 impl DecimalBytePartsArray {
-    pub fn try_new(
-        msp: ArrayRef,
-        lower_parts: Vec<ArrayRef>,
-        decimal_dtype: DecimalDType,
-    ) -> VortexResult<Self> {
-        if !lower_parts.is_empty() {
-            // TODO(joe): remove this constraint.
-            vortex_bail!("DecimalBytePartsArray doesn't support lower parts arrays")
-        }
-
-        if !(0usize..=3).contains(&lower_parts.iter().len()) {
-            vortex_bail!(
-                "DecimalBytePartsArray lower_parts must have between 0..=3 children, instead given: {}",
-                lower_parts.len()
-            )
-        }
-
+    pub fn try_new(msp: ArrayRef, decimal_dtype: DecimalDType) -> VortexResult<Self> {
         if !msp.dtype().is_signed_int() {
             vortex_bail!("decimal bytes parts, first part must be a signed array")
-        }
-
-        if lower_parts
-            .iter()
-            .any(|a| a.dtype() != &DType::Primitive(PType::U64, NonNullable))
-        {
-            vortex_bail!("decimal bytes parts 2nd to 4th must be non-nullable u64 primitive typed")
         }
 
         let nullable = msp.dtype().nullability();
         Ok(Self {
             msp,
-            lower_parts,
+            _lower_parts: Vec::new(),
             dtype: DType::Decimal(decimal_dtype, nullable),
             stats_set: Default::default(),
         })
@@ -119,7 +97,6 @@ impl ArrayVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
 impl CanonicalVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
     fn canonicalize(array: &DecimalBytePartsArray) -> VortexResult<Canonical> {
         // TODO(joe): support parts len != 1
-        assert!(array.lower_parts.is_empty());
         let prim = array.msp.to_canonical()?.into_primitive()?;
         // Depending on the decimal type and the min/max of the primitive array we can choose
         // the correct buffer size
@@ -138,22 +115,13 @@ impl CanonicalVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
 
 impl OperationsVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
     fn slice(array: &DecimalBytePartsArray, start: usize, stop: usize) -> VortexResult<ArrayRef> {
-        DecimalBytePartsArray::try_new(
-            array.msp.slice(start, stop)?,
-            array
-                .lower_parts
-                .iter()
-                .map(|p| p.slice(start, stop))
-                .try_collect()?,
-            *array.decimal_dtype(),
-        )
-        .map(|d| d.to_array())
+        DecimalBytePartsArray::try_new(array.msp.slice(start, stop)?, *array.decimal_dtype())
+            .map(|d| d.to_array())
     }
 
     #[allow(clippy::useless_conversion)]
     fn scalar_at(array: &DecimalBytePartsArray, index: usize) -> VortexResult<Scalar> {
         // TODO(joe): support parts len != 1
-        assert!(array.lower_parts.is_empty());
         let scalar = array.msp.scalar_at(index)?;
 
         // Note. values in msp, can only be signed integers upto size i64.
@@ -201,7 +169,6 @@ mod tests {
                 Validity::Array(BoolArray::from_iter(vec![false, true, true]).to_array()),
             )
             .to_array(),
-            vec![],
             decimal_dtype,
         )
         .unwrap()

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/serde.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/serde.rs
@@ -7,8 +7,6 @@ use vortex_array::{
     Array, ArrayBufferVisitor, ArrayChildVisitor, DeserializeMetadata, ProstMetadata,
 };
 use vortex_buffer::ByteBuffer;
-use vortex_dtype::Nullability::NonNullable;
-use vortex_dtype::PType::U64;
 use vortex_dtype::{DType, PType};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail};
 
@@ -50,16 +48,12 @@ impl SerdeVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
 
         let msp = children.get(0, &encoded_dtype, len)?;
 
-        let mut lower_parts = Vec::with_capacity(metadata.lower_part_count as usize);
-        for idx in 0..metadata.lower_part_count {
-            lower_parts.push(children.get(
-                (idx + 1) as usize,
-                &DType::Primitive(U64, NonNullable),
-                len,
-            )?)
-        }
+        assert_eq!(
+            metadata.lower_part_count, 0,
+            "lower_part_count > 0 not currently supported"
+        );
 
-        DecimalBytePartsArray::try_new(msp, lower_parts, *decimal_dtype)
+        DecimalBytePartsArray::try_new(msp, *decimal_dtype)
     }
 }
 

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/serde.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/serde.rs
@@ -27,8 +27,7 @@ impl SerdeVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
         Ok(Some(ProstMetadata(DecimalBytesPartsMetadata {
             zeroth_child_ptype: PType::try_from(array.msp.dtype()).vortex_expect("must be a PType")
                 as i32,
-            lower_part_count: u32::try_from(array.lower_parts.len())
-                .vortex_expect("1..=3 fits in u8"),
+            lower_part_count: 0,
         })))
     }
 
@@ -57,16 +56,10 @@ impl SerdeVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
     }
 }
 
-const ENCODED_NAMES: [&str; 3] = ["lower-0", "lower-1", "lower-2"];
-
 impl VisitorVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
     fn visit_buffers(_array: &DecimalBytePartsArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(array: &DecimalBytePartsArray, visitor: &mut dyn ArrayChildVisitor) {
-        assert!(array.lower_parts.len() <= 3);
         visitor.visit_child("msp", &array.msp);
-        array.lower_parts.iter().enumerate().for_each(|(idx, arr)| {
-            visitor.visit_child(ENCODED_NAMES[idx], arr);
-        })
     }
 }

--- a/fuzz/fuzz_targets/array_ops.rs
+++ b/fuzz/fuzz_targets/array_ops.rs
@@ -134,8 +134,8 @@ fn assert_array_eq(lhs: &ArrayRef, rhs: &ArrayRef, step: usize) -> VortexFuzzRes
                 l,
                 r,
                 idx,
-                lhs.to_array(),
-                rhs.to_array(),
+                lhs.clone(),
+                rhs.clone(),
                 step,
             ));
         }

--- a/vortex-array/src/arrays/decimal/compute/take.rs
+++ b/vortex-array/src/arrays/decimal/compute/take.rs
@@ -44,10 +44,11 @@ fn take_to_buffer<I: NativePType + AsPrimitive<usize>, T: NativeDecimalType>(
 #[cfg(test)]
 mod tests {
     use vortex_buffer::buffer;
-    use vortex_dtype::DecimalDType;
+    use vortex_dtype::{DecimalDType, Nullability};
+    use vortex_scalar::{DecimalValue, Scalar};
 
     use crate::IntoArray;
-    use crate::arrays::{DecimalArray, DecimalVTable};
+    use crate::arrays::{DecimalArray, DecimalVTable, PrimitiveArray};
     use crate::compute::take;
     use crate::validity::Validity;
 
@@ -67,5 +68,36 @@ mod tests {
             buffer![10i128, 12i128, 13i128]
         );
         assert_eq!(taken_decimals.decimal_dtype(), DecimalDType::new(19, 1));
+    }
+
+    #[test]
+    fn test_take_null_indices() {
+        let array = DecimalArray::new(
+            buffer![i128::MAX, 11i128, 12i128, 13i128],
+            DecimalDType::new(19, 1),
+            Validity::NonNullable,
+        );
+
+        let indices = PrimitiveArray::from_option_iter([None, Some(2), Some(3)]).into_array();
+        let taken = take(array.as_ref(), indices.as_ref()).unwrap();
+
+        assert!(taken.scalar_at(0).unwrap().is_null());
+        assert_eq!(
+            taken.scalar_at(1).unwrap(),
+            Scalar::decimal(
+                DecimalValue::I128(12i128),
+                array.decimal_dtype(),
+                Nullability::Nullable
+            )
+        );
+
+        assert_eq!(
+            taken.scalar_at(2).unwrap(),
+            Scalar::decimal(
+                DecimalValue::I128(13i128),
+                array.decimal_dtype(),
+                Nullability::Nullable
+            )
+        );
     }
 }

--- a/vortex-btrblocks/src/decimal.rs
+++ b/vortex-btrblocks/src/decimal.rs
@@ -26,8 +26,7 @@ pub fn compress_decimal(decimal: &DecimalArray) -> VortexResult<ArrayRef> {
 
     let compressed = IntCompressor::compress(&prim, false, MAX_CASCADE, &[])?;
 
-    DecimalBytePartsArray::try_new(compressed, vec![], decimal.decimal_dtype())
-        .map(|d| d.to_array())
+    DecimalBytePartsArray::try_new(compressed, decimal.decimal_dtype()).map(|d| d.to_array())
 }
 
 macro_rules! try_downcast {


### PR DESCRIPTION
Fuzzer is [currently failing](https://github.com/vortex-data/vortex/actions/runs/16105049077/job/45439258523) on an optimization pathway in DecimalBytePartsArray, where the constant cannot be represented in the narrowed PType of DBP's narrowed PType.

So for example if you have a nullable DecimalByteParts with values `None, Some(1i32), Some(2i32)` and you do the comparison `<= ConstantArray(Some(999999999999999i128))`, we'd first try and cast `999999999999999i128` to an `i32`, and when that fails we'd assume that it is larger than all values in the original array, so immediately return `ConstantArray(true)`.

However, that disregards the validity information. I've updated the branch so that the optimized pathway is only taken if the array and the constant are non-null

Separately I removed the references to lower_parts, it was a lot of cruft and idk when we're going to implement it so just put a note that we're receiving a field for it in the struct and metadata.