### PR TITLE
fix: make Java test gradle self-contained

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,13 +345,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cleanup
       - uses: ./.github/actions/setup-rust
-      # Build vortex-jni shared library, and copy into JAR.
-      - name: Build vortex-jni
-        run: |
-          cargo build -p vortex-jni
-          mkdir -p java/vortex-jni/src/main/resources/native/linux-amd64
-          cargo xtask java-test-files
-          cp target/debug/libvortex_jni.so java/vortex-jni/src/main/resources/native/linux-amd64
       - run: ./gradlew test --parallel
         working-directory: ./java
 

--- a/java/vortex-jni/build.gradle.kts
+++ b/java/vortex-jni/build.gradle.kts
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import com.vanniktech.maven.publish.SonatypeHost
+import org.gradle.kotlin.dsl.support.serviceOf
 
 plugins {
     `java-library`
@@ -41,7 +41,7 @@ testing {
 
 mavenPublishing {
     coordinates(groupId = "dev.vortex", artifactId = "vortex-jni", version = "${rootProject.version}")
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral()
 
     signAllPublications()
 
@@ -107,6 +107,49 @@ tasks.withType<ShadowJar> {
 
 tasks.build {
     dependsOn("shadowJar")
+}
+
+tasks.register("makeTestFiles") {
+    description = "Generate files used by unit tests"
+    group = "verification"
+
+    doLast {
+        println("makeTestFiles executed")
+
+        val execOps = serviceOf<ExecOperations>()
+
+        // Build the JNI lib
+
+        execOps.exec {
+            workingDir = rootProject.projectDir.absoluteFile.parentFile
+            executable = "cargo"
+            args("build", "--package", "vortex-jni")
+        }
+
+        copy {
+            from("${rootProject.projectDir.absoluteFile.parentFile}/target/debug/libvortex_jni.so")
+            into("$projectDir/src/main/resources/native/linux-amd64")
+        }
+
+        copy {
+            from("${rootProject.projectDir.absoluteFile.parentFile}/target/debug/libvortex_jni.dylib")
+            into("$projectDir/src/main/resources/native/darwin-aarch64")
+        }
+
+        execOps.exec {
+            workingDir = rootProject.projectDir.absoluteFile.parentFile
+            executable = "cargo"
+            args("xtask", "java-test-files")
+        }
+    }
+}
+
+tasks.named("processResources").all {
+    dependsOn("makeTestFiles")
+}
+
+tasks.withType<Test>().all {
+    dependsOn("makeTestFiles")
 }
 
 tasks.register("generateJniHeaders") {

--- a/java/vortex-jni/build.gradle.kts
+++ b/java/vortex-jni/build.gradle.kts
@@ -144,7 +144,7 @@ tasks.register("makeTestFiles") {
     }
 }
 
-tasks.named("processResources").all {
+tasks.named("processResources").configure {
     dependsOn("makeTestFiles")
 }
 

--- a/java/vortex-spark/build.gradle.kts
+++ b/java/vortex-spark/build.gradle.kts
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-import com.vanniktech.maven.publish.SonatypeHost
-
 apply(plugin = "com.vanniktech.maven.publish")
 
 plugins {
@@ -32,7 +30,7 @@ testing {
 mavenPublishing {
     coordinates(groupId = "dev.vortex", artifactId = "vortex-spark", version = "${rootProject.version}")
 
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral()
 
     signAllPublications()
 


### PR DESCRIPTION
Fixes #3775 

The gradle tasks call into the `xtask` command, directly from the `test` task.