### PR TITLE
ci: run Rust tests with ASAN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,7 @@ jobs:
       - name: Rust Tests
         # vortex-duckdb-ext currently fails linking for cargo test targets.
         run: |
-          cargo nextest run --locked --workspace --all-features --no-fail-fast
+          cargo nextest run --locked --workspace --all-features --no-fail-fast --target x86_64-unknown-linux-gnu
 
       - name: Generate coverage report
         if: github.ref == 'refs/heads/develop'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,8 @@ jobs:
 
   rust-test:
     name: "Rust (tests)"
+    env:
+      RUSTFLAGS: "-Z sanitizer=address"
     timeout-minutes: 120
     runs-on:
       - runs-on=${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,8 +280,6 @@ jobs:
 
   rust-test:
     name: "Rust (tests)"
-    env:
-      RUSTFLAGS: "-Z sanitizer=address"
     timeout-minutes: 120
     runs-on:
       - runs-on=${{ github.run_id }}
@@ -296,7 +294,7 @@ jobs:
         shell: bash
         if: github.ref == 'refs/heads/develop'
         run: |
-          echo "RUSTFLAGS=-Cinstrument-coverage -A warnings">> $GITHUB_ENV
+          echo "RUSTFLAGS=-Cinstrument-coverage -A warnings -Z sanitizer=address">> $GITHUB_ENV
           # Disable incremental compilation to get accurate coverage
           echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
           echo "LLVM_PROFILE_FILE=target/coverage/vortex-%p-%m.profraw" >> $GITHUB_ENV
@@ -305,7 +303,7 @@ jobs:
         shell: bash
         if: github.ref != 'refs/heads/develop'
         run: |
-          echo "RUSTFLAGS=-A warnings" >> $GITHUB_ENV
+          echo "RUSTFLAGS=-A warnings -Z sanitizer=address" >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"

--- a/vortex-array/src/arrays/primitive/compute/take/avx2.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/avx2.rs
@@ -493,8 +493,8 @@ mod tests {
                     #[test]
                     #[allow(clippy::cast_possible_truncation)]
                     fn [<test_avx2_take_simple_ $IDX _ $VAL>]() {
-                        let values: Vec<$VAL> = (1..=128).map(|x| x as $VAL).collect();
-                        let indices: Vec<$IDX> = (0..128).collect();
+                        let values: Vec<$VAL> = (1..=127).map(|x| x as $VAL).collect();
+                        let indices: Vec<$IDX> = (0..127).collect();
 
                         let result = unsafe { take_primitive_avx2(&indices, &values, Validity::NonNullable) };
                         assert_eq!(&values, result.as_slice::<$VAL>());
@@ -506,7 +506,7 @@ mod tests {
                     #[allow(clippy::cast_possible_truncation)]
                     fn [<test_avx2_take_empty_ $IDX _ $VAL>]() {
                         let values: Vec<$VAL> = vec![];
-                        let indices: Vec<$IDX> = (0..128).collect();
+                        let indices: Vec<$IDX> = (0..127).collect();
                         let result = unsafe { take_primitive_avx2(&indices, &values, Validity::NonNullable) };
                         assert!(result.is_empty());
                     }
@@ -516,12 +516,12 @@ mod tests {
                     #[should_panic]
                     #[allow(clippy::cast_possible_truncation)]
                     fn [<test_avx2_take_invalid_ $IDX _ $VAL>]() {
-                        let values: Vec<$VAL> = (1..=128).map(|x| x as $VAL).collect();
+                        let values: Vec<$VAL> = (1..=127).map(|x| x as $VAL).collect();
                         // all out of bounds indices
-                        let indices: Vec<$IDX> = (128..=255).collect();
+                        let indices: Vec<$IDX> = (127..=254).collect();
 
                         let result = unsafe { take_primitive_avx2(&indices, &values, Validity::NonNullable) };
-                        assert_eq!(&[0 as $VAL; 128], result.as_slice::<$VAL>());
+                        assert_eq!(&[0 as $VAL; 127], result.as_slice::<$VAL>());
                     }
                 )+
             }

--- a/vortex-array/src/arrays/primitive/compute/take/avx2.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/avx2.rs
@@ -144,7 +144,7 @@ impl_gather!(u8,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i32gather_epi32,
         store: _mm256_storeu_si256,
-        WIDTH = 8, STRIDE = 8
+        WIDTH = 8, STRIDE = 16
     },
 
     // 64-bit values, loaded 4 at a time

--- a/vortex-array/src/arrays/primitive/compute/take/avx2.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/avx2.rs
@@ -144,7 +144,7 @@ impl_gather!(u8,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i32gather_epi32,
         store: _mm256_storeu_si256,
-        WIDTH = 8, STRIDE = 16
+        WIDTH = 8, STRIDE = 8
     },
 
     // 64-bit values, loaded 4 at a time

--- a/vortex-duckdb/src/duckdb/data_chunk.rs
+++ b/vortex-duckdb/src/duckdb/data_chunk.rs
@@ -18,7 +18,8 @@ wrapper!(
 
 impl DataChunk {
     /// Create a new data chunk using a list of logical dtypes
-    pub fn new(column_types: &[LogicalType]) -> DataChunk {
+    pub fn new(column_types: impl AsRef<[LogicalType]>) -> DataChunk {
+        let column_types = column_types.as_ref();
         let mut ptrs = column_types
             .iter()
             .map(|x| x.as_ptr())

--- a/vortex-duckdb/src/duckdb/data_chunk.rs
+++ b/vortex-duckdb/src/duckdb/data_chunk.rs
@@ -18,11 +18,12 @@ wrapper!(
 
 impl DataChunk {
     /// Create a new data chunk using a list of logical dtypes
-    pub fn new(column_types: impl IntoIterator<Item = LogicalType>) -> DataChunk {
+    pub fn new(column_types: &[LogicalType]) -> DataChunk {
         let mut ptrs = column_types
-            .into_iter()
-            .map(|x| x.into_ptr())
+            .iter()
+            .map(|x| x.as_ptr())
             .collect::<Vec<duckdb_logical_type>>();
+
         let ptr = unsafe { cpp::duckdb_create_data_chunk(ptrs.as_mut_ptr(), ptrs.len() as _) };
         unsafe { DataChunk::own(ptr) }
     }

--- a/vortex-duckdb/src/duckdb/data_chunk.rs
+++ b/vortex-duckdb/src/duckdb/data_chunk.rs
@@ -19,8 +19,8 @@ wrapper!(
 impl DataChunk {
     /// Create a new data chunk using a list of logical dtypes
     pub fn new(column_types: impl AsRef<[LogicalType]>) -> DataChunk {
-        let column_types = column_types.as_ref();
         let mut ptrs = column_types
+            .as_ref()
             .iter()
             .map(|x| x.as_ptr())
             .collect::<Vec<duckdb_logical_type>>();

--- a/vortex-duckdb/src/duckdb/logical_type.rs
+++ b/vortex-duckdb/src/duckdb/logical_type.rs
@@ -42,6 +42,30 @@ impl LogicalType {
             )
         }
     }
+
+    pub fn array_child_type(&self) -> Self {
+        unsafe { LogicalType::own(duckdb_array_type_child_type(self.as_ptr())) }
+    }
+
+    pub fn list_child_type(&self) -> Self {
+        unsafe { LogicalType::own(duckdb_list_type_child_type(self.as_ptr())) }
+    }
+
+    pub fn map_key_type(&self) -> Self {
+        unsafe { LogicalType::own(duckdb_map_type_key_type(self.as_ptr())) }
+    }
+
+    pub fn map_value_type(&self) -> Self {
+        unsafe { LogicalType::own(duckdb_map_type_value_type(self.as_ptr())) }
+    }
+
+    pub fn struct_child_type(&self, idx: idx_t) -> Self {
+        unsafe { LogicalType::own(duckdb_struct_type_child_type(self.as_ptr(), idx)) }
+    }
+
+    pub fn union_member_type(&self, idx: idx_t) -> Self {
+        unsafe { LogicalType::own(duckdb_union_type_member_type(self.as_ptr(), idx)) }
+    }
 }
 
 impl Debug for LogicalType {
@@ -247,11 +271,11 @@ mod tests {
         assert_eq!(list_type.as_type_id(), DUCKDB_TYPE::DUCKDB_TYPE_LIST);
 
         // Verify the child type is preserved
-        let original_child = unsafe { duckdb_list_type_child_type(list_type.as_ptr()) };
-        let cloned_child = unsafe { duckdb_list_type_child_type(cloned.as_ptr()) };
+        let original_child = list_type.list_child_type();
+        let cloned_child = cloned.list_child_type();
 
-        let original_child_type_id = unsafe { duckdb_get_type_id(original_child) };
-        let cloned_child_type_id = unsafe { duckdb_get_type_id(cloned_child) };
+        let original_child_type_id = unsafe { duckdb_get_type_id(original_child.as_ptr()) };
+        let cloned_child_type_id = unsafe { duckdb_get_type_id(cloned_child.as_ptr()) };
 
         assert_eq!(original_child_type_id, cloned_child_type_id);
         assert_eq!(original_child_type_id, DUCKDB_TYPE::DUCKDB_TYPE_INTEGER);
@@ -272,11 +296,11 @@ mod tests {
         assert_eq!(array_type.as_type_id(), DUCKDB_TYPE::DUCKDB_TYPE_ARRAY);
 
         // Verify the child type is preserved
-        let original_child = unsafe { duckdb_array_type_child_type(array_type.as_ptr()) };
-        let cloned_child = unsafe { duckdb_array_type_child_type(cloned.as_ptr()) };
+        let original_child = array_type.array_child_type();
+        let cloned_child = cloned.array_child_type();
 
-        let original_child_type_id = unsafe { duckdb_get_type_id(original_child) };
-        let cloned_child_type_id = unsafe { duckdb_get_type_id(cloned_child) };
+        let original_child_type_id = unsafe { duckdb_get_type_id(original_child.as_ptr()) };
+        let cloned_child_type_id = unsafe { duckdb_get_type_id(cloned_child.as_ptr()) };
 
         assert_eq!(original_child_type_id, cloned_child_type_id);
         assert_eq!(original_child_type_id, DUCKDB_TYPE::DUCKDB_TYPE_VARCHAR);
@@ -312,20 +336,18 @@ mod tests {
         assert_eq!(map_type.as_type_id(), DUCKDB_TYPE::DUCKDB_TYPE_MAP);
 
         // Verify the key and value types are preserved
-        let original_key = unsafe { duckdb_map_type_key_type(map_type.as_ptr()) };
-        let original_value = unsafe { duckdb_map_type_value_type(map_type.as_ptr()) };
-        let cloned_key = unsafe { duckdb_map_type_key_type(cloned.as_ptr()) };
-        let cloned_value = unsafe { duckdb_map_type_value_type(cloned.as_ptr()) };
+        let original_key = map_type.map_key_type();
+        let original_value = map_type.map_value_type();
+        let cloned_key = cloned.map_key_type();
+        let cloned_value = cloned.map_value_type();
 
-        let original_key_type_id = unsafe { duckdb_get_type_id(original_key) };
-        let original_value_type_id = unsafe { duckdb_get_type_id(original_value) };
-        let cloned_key_type_id = unsafe { duckdb_get_type_id(cloned_key) };
-        let cloned_value_type_id = unsafe { duckdb_get_type_id(cloned_value) };
-
-        assert_eq!(original_key_type_id, cloned_key_type_id);
-        assert_eq!(original_value_type_id, cloned_value_type_id);
-        assert_eq!(original_key_type_id, DUCKDB_TYPE::DUCKDB_TYPE_VARCHAR);
-        assert_eq!(original_value_type_id, DUCKDB_TYPE::DUCKDB_TYPE_INTEGER);
+        assert_eq!(original_key.as_type_id(), cloned_key.as_type_id());
+        assert_eq!(original_value.as_type_id(), cloned_value.as_type_id());
+        assert_eq!(original_key.as_type_id(), DUCKDB_TYPE::DUCKDB_TYPE_VARCHAR);
+        assert_eq!(
+            original_value.as_type_id(),
+            DUCKDB_TYPE::DUCKDB_TYPE_INTEGER
+        );
     }
 
     #[test]
@@ -365,21 +387,26 @@ mod tests {
 
         // Verify each field
         for idx in 0..original_count {
-            let original_child_type =
-                unsafe { duckdb_struct_type_child_type(struct_type.as_ptr(), idx) };
-            let cloned_child_type = unsafe { duckdb_struct_type_child_type(cloned.as_ptr(), idx) };
+            let original_child_type = struct_type.struct_child_type(idx);
+            let cloned_child_type = cloned.struct_child_type(idx);
             let original_child_name =
                 unsafe { duckdb_struct_type_child_name(struct_type.as_ptr(), idx) };
             let cloned_child_name = unsafe { duckdb_struct_type_child_name(cloned.as_ptr(), idx) };
 
-            let original_type_id = unsafe { duckdb_get_type_id(original_child_type) };
-            let cloned_type_id = unsafe { duckdb_get_type_id(cloned_child_type) };
-
-            assert_eq!(original_type_id, cloned_type_id);
+            assert_eq!(
+                original_child_type.as_type_id(),
+                cloned_child_type.as_type_id()
+            );
 
             let original_name = unsafe { std::ffi::CStr::from_ptr(original_child_name) };
             let cloned_name = unsafe { std::ffi::CStr::from_ptr(cloned_child_name) };
             assert_eq!(original_name, cloned_name);
+
+            // Free strings
+            unsafe {
+                duckdb_free(original_child_name.cast());
+                duckdb_free(cloned_child_name.cast());
+            }
         }
     }
 
@@ -420,22 +447,27 @@ mod tests {
 
         // Verify each member
         for idx in 0..original_count {
-            let original_member_type =
-                unsafe { duckdb_union_type_member_type(union_type.as_ptr(), idx) };
-            let cloned_member_type = unsafe { duckdb_union_type_member_type(cloned.as_ptr(), idx) };
+            let original_member_type = union_type.union_member_type(idx);
+            let cloned_member_type = cloned.union_member_type(idx);
             let original_member_name =
                 unsafe { duckdb_union_type_member_name(union_type.as_ptr(), idx) };
             let cloned_member_name = unsafe { duckdb_union_type_member_name(cloned.as_ptr(), idx) };
 
             assert_eq!(
-                unsafe { duckdb_get_type_id(original_member_type) },
-                unsafe { duckdb_get_type_id(cloned_member_type) }
+                original_member_type.as_type_id(),
+                cloned_member_type.as_type_id(),
             );
 
             assert_eq!(
                 unsafe { std::ffi::CStr::from_ptr(original_member_name) },
                 unsafe { std::ffi::CStr::from_ptr(cloned_member_name) }
             );
+
+            // Free strings
+            unsafe {
+                duckdb_free(original_member_name.cast());
+                duckdb_free(cloned_member_name.cast());
+            }
         }
     }
 }

--- a/vortex-duckdb/src/exporter/bool.rs
+++ b/vortex-duckdb/src/exporter/bool.rs
@@ -55,8 +55,7 @@ mod tests {
     #[test]
     fn test_bool() {
         let arr = BoolArray::from_iter([true, false, true]);
-
-        let mut chunk = DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_BOOLEAN)]);
+        let mut chunk = DataChunk::new(&[LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_BOOLEAN)]);
 
         new_exporter(&arr)
             .unwrap()
@@ -76,7 +75,7 @@ mod tests {
     fn test_bool_long() {
         let arr = BoolArray::from_iter([true; 128]);
 
-        let mut chunk = DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_BOOLEAN)]);
+        let mut chunk = DataChunk::new(&[LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_BOOLEAN)]);
 
         new_exporter(&arr)
             .unwrap()

--- a/vortex-duckdb/src/exporter/bool.rs
+++ b/vortex-duckdb/src/exporter/bool.rs
@@ -55,7 +55,7 @@ mod tests {
     #[test]
     fn test_bool() {
         let arr = BoolArray::from_iter([true, false, true]);
-        let mut chunk = DataChunk::new(&[LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_BOOLEAN)]);
+        let mut chunk = DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_BOOLEAN)]);
 
         new_exporter(&arr)
             .unwrap()
@@ -75,7 +75,7 @@ mod tests {
     fn test_bool_long() {
         let arr = BoolArray::from_iter([true; 128]);
 
-        let mut chunk = DataChunk::new(&[LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_BOOLEAN)]);
+        let mut chunk = DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_BOOLEAN)]);
 
         new_exporter(&arr)
             .unwrap()

--- a/vortex-duckdb/src/exporter/sequence.rs
+++ b/vortex-duckdb/src/exporter/sequence.rs
@@ -43,7 +43,7 @@ mod tests {
     #[test]
     fn test_sequence() {
         let arr = SequenceArray::typed_new(2, 5, 100).unwrap();
-        let mut chunk = DataChunk::new(&[LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_INTEGER)]);
+        let mut chunk = DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_INTEGER)]);
 
         new_exporter(&arr)
             .unwrap()

--- a/vortex-duckdb/src/exporter/sequence.rs
+++ b/vortex-duckdb/src/exporter/sequence.rs
@@ -43,8 +43,7 @@ mod tests {
     #[test]
     fn test_sequence() {
         let arr = SequenceArray::typed_new(2, 5, 100).unwrap();
-
-        let mut chunk = DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_INTEGER)]);
+        let mut chunk = DataChunk::new(&[LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_INTEGER)]);
 
         new_exporter(&arr)
             .unwrap()

--- a/vortex-duckdb/src/exporter/temporal.rs
+++ b/vortex-duckdb/src/exporter/temporal.rs
@@ -43,7 +43,7 @@ mod tests {
             None,
         );
         let mut chunk =
-            DataChunk::new(&[LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_TIMESTAMP_S)]);
+            DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_TIMESTAMP_S)]);
 
         new_exporter(&arr)
             .unwrap()
@@ -67,8 +67,7 @@ mod tests {
             TimeUnit::Us,
             None,
         );
-        let mut chunk =
-            DataChunk::new(&[LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_TIMESTAMP)]);
+        let mut chunk = DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_TIMESTAMP)]);
 
         new_exporter(&arr)
             .unwrap()
@@ -91,7 +90,7 @@ mod tests {
             TimeUnit::Us,
         );
 
-        let mut chunk = DataChunk::new(&[LogicalType::try_from(arr.dtype()).unwrap()]);
+        let mut chunk = DataChunk::new([LogicalType::try_from(arr.dtype()).unwrap()]);
 
         new_exporter(&arr)
             .unwrap()

--- a/vortex-duckdb/src/exporter/temporal.rs
+++ b/vortex-duckdb/src/exporter/temporal.rs
@@ -43,7 +43,7 @@ mod tests {
             None,
         );
         let mut chunk =
-            DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_TIMESTAMP_S)]);
+            DataChunk::new(&[LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_TIMESTAMP_S)]);
 
         new_exporter(&arr)
             .unwrap()
@@ -67,7 +67,8 @@ mod tests {
             TimeUnit::Us,
             None,
         );
-        let mut chunk = DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_TIMESTAMP)]);
+        let mut chunk =
+            DataChunk::new(&[LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_TIMESTAMP)]);
 
         new_exporter(&arr)
             .unwrap()
@@ -90,7 +91,7 @@ mod tests {
             TimeUnit::Us,
         );
 
-        let mut chunk = DataChunk::new([LogicalType::try_from(arr.dtype()).unwrap()]);
+        let mut chunk = DataChunk::new(&[LogicalType::try_from(arr.dtype()).unwrap()]);
 
         new_exporter(&arr)
             .unwrap()


### PR DESCRIPTION
Not sure if this works. It fails locally but might be a mac problem.

Nice for catching things like the bug introduced with AVX2 change last week (and Miri can't execute SIMD kernels so this is our only way to catch potentially safety issues)