### PR TITLE
ci: update target dir for coverage runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,39 +278,33 @@ jobs:
           # https://spiraldb.slack.com/archives/C07BV3GKAJ2/p1732736281946729
           cargo hack clippy --no-default-features
 
-  rust-test:
-    name: "Rust (tests)"
+  rust-coverage:
+    name: "Rust (coverage)"
     timeout-minutes: 120
+    if: github.ref == 'refs/heads/develop'
     runs-on:
       - runs-on=${{ github.run_id }}
       - family=m7i+m7i-flex+m7a
       - cpu=8
       - image=ubuntu24-full-x64
       - extras=s3-cache
-      - tag=rust-test
+      - tag=rust-coverage
     steps:
       # Disable lints when running tests. They will be caught by the Rust lint job.
-      - name: Setup environment (On develop)
+      - name: Setup environment
         shell: bash
-        if: github.ref == 'refs/heads/develop'
         run: |
-          echo "RUSTFLAGS=-Cinstrument-coverage -A warnings -Z sanitizer=address">> $GITHUB_ENV
+          echo "RUSTFLAGS=-Cinstrument-coverage -A warnings">> $GITHUB_ENV
           # Disable incremental compilation to get accurate coverage
           echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
           echo "LLVM_PROFILE_FILE=target/coverage/vortex-%p-%m.profraw" >> $GITHUB_ENV
           echo "GRCOV_OUTPUT_FILE=target/coverage/vortex.lcov" >> $GITHUB_ENV
-      - name: Setup environment
-        shell: bash
-        if: github.ref != 'refs/heads/develop'
-        run: |
-          echo "RUSTFLAGS=-A warnings -Z sanitizer=address" >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
       - uses: ./.github/actions/cleanup
       - uses: ./.github/actions/setup-rust
       - name: Install grcov
-        if: github.ref == 'refs/heads/develop'
         uses: taiki-e/install-action@grcov
       - name: Install nextest
         uses: taiki-e/install-action@v2
@@ -319,7 +313,7 @@ jobs:
       - name: Rust Tests
         # vortex-duckdb-ext currently fails linking for cargo test targets.
         run: |
-          cargo nextest run --locked --workspace --all-features --no-fail-fast --target x86_64-unknown-linux-gnu
+          cargo nextest run --locked --workspace --all-features --no-fail-fast
 
       - name: Generate coverage report
         if: github.ref == 'refs/heads/develop'
@@ -336,6 +330,33 @@ jobs:
         if: github.ref == 'refs/heads/develop'
         with:
           file: ${{ env.GRCOV_OUTPUT_FILE }}
+
+  rust-test:
+    name: "Rust (tests)"
+    timeout-minutes: 120
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - family=m7i+m7i-flex+m7a
+      - cpu=8
+      - image=ubuntu24-full-x64
+      - extras=s3-cache
+      - tag=rust-test
+    env:
+      RUSTFLAGS: '-A warnings -Zsanitizer=address'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - uses: ./.github/actions/cleanup
+      - uses: ./.github/actions/setup-rust
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.98
+      - name: Rust Tests
+        # vortex-duckdb-ext currently fails linking for cargo test targets.
+        run: |
+          cargo nextest run --locked --workspace --all-features --no-fail-fast --target x86_64-unknown-linux-gnu
 
   build-java:
     name: "Java"


### PR DESCRIPTION
The `-C instrument-coverage` flag doesn't play well with ASAN, because both instruments require hooking into shutdown so one ends up overriding the other.