### PR TITLE
chore: better naming for SendableLayoutFuture

### DIFF
--- a/vortex-layout/src/layouts/buffered.rs
+++ b/vortex-layout/src/layouts/buffered.rs
@@ -10,7 +10,7 @@ use vortex_array::ArrayContext;
 
 use crate::segments::SequenceWriter;
 use crate::{
-    LayoutStrategy, SendableLayoutWriter, SendableSequentialStream, SequentialStreamAdapter,
+    LayoutStrategy, SendableLayoutFuture, SendableSequentialStream, SequentialStreamAdapter,
     SequentialStreamExt as _,
 };
 
@@ -31,7 +31,7 @@ impl LayoutStrategy for BufferedStrategy {
         ctx: &ArrayContext,
         sequence_writer: SequenceWriter,
         stream: SendableSequentialStream,
-    ) -> SendableLayoutWriter {
+    ) -> SendableLayoutFuture {
         let dtype = stream.dtype().clone();
         let buffer_size = self.buffer_size;
         let buffered_stream = try_stream! {

--- a/vortex-layout/src/layouts/chunked/writer.rs
+++ b/vortex-layout/src/layouts/chunked/writer.rs
@@ -14,7 +14,7 @@ use crate::layouts::chunked::ChunkedLayout;
 use crate::layouts::flat::writer::FlatLayoutStrategy;
 use crate::segments::SequenceWriter;
 use crate::{
-    IntoLayout, LayoutStrategy, SendableLayoutWriter, SendableSequentialStream,
+    IntoLayout, LayoutStrategy, SendableLayoutFuture, SendableSequentialStream,
     SequentialStreamAdapter, SequentialStreamExt as _,
 };
 
@@ -37,7 +37,7 @@ impl LayoutStrategy for ChunkedLayoutStrategy {
         ctx: &ArrayContext,
         sequence_writer: SequenceWriter,
         mut stream: SendableSequentialStream,
-    ) -> SendableLayoutWriter {
+    ) -> SendableLayoutFuture {
         let chunk_strategy = self.chunk_strategy.clone();
         let ctx = ctx.clone();
         Box::pin(async move {

--- a/vortex-layout/src/layouts/compressed.rs
+++ b/vortex-layout/src/layouts/compressed.rs
@@ -12,7 +12,7 @@ use vortex_btrblocks::BtrBlocksCompressor;
 use crate::scan::{TaskExecutor, TaskExecutorExt as _};
 use crate::segments::SequenceWriter;
 use crate::{
-    LayoutStrategy, SendableLayoutWriter, SendableSequentialStream, SequentialStreamAdapter,
+    LayoutStrategy, SendableLayoutFuture, SendableSequentialStream, SequentialStreamAdapter,
     SequentialStreamExt as _,
 };
 
@@ -43,7 +43,7 @@ impl LayoutStrategy for BtrBlocksCompressedStrategy {
         ctx: &ArrayContext,
         sequence_writer: SequenceWriter,
         stream: SendableSequentialStream,
-    ) -> SendableLayoutWriter {
+    ) -> SendableLayoutFuture {
         let executor = self.executor.clone();
 
         let dtype = stream.dtype().clone();

--- a/vortex-layout/src/layouts/dict/writer/mod.rs
+++ b/vortex-layout/src/layouts/dict/writer/mod.rs
@@ -23,7 +23,7 @@ use crate::scan::{TaskExecutor, TaskExecutorExt as _};
 use crate::segments::SequenceWriter;
 use crate::sequence::{SequenceId, SequencePointer};
 use crate::{
-    IntoLayout, LayoutStrategy, OwnedLayoutChildren, SendableLayoutWriter,
+    IntoLayout, LayoutStrategy, OwnedLayoutChildren, SendableLayoutFuture,
     SendableSequentialStream, SequentialStreamAdapter, SequentialStreamExt,
 };
 
@@ -83,7 +83,7 @@ impl LayoutStrategy for DictStrategy {
         ctx: &ArrayContext,
         sequence_writer: SequenceWriter,
         stream: SendableSequentialStream,
-    ) -> SendableLayoutWriter {
+    ) -> SendableLayoutFuture {
         if !dict_layout_supported(stream.dtype()) {
             return self.fallback.write_stream(ctx, sequence_writer, stream);
         }

--- a/vortex-layout/src/layouts/flat/writer.rs
+++ b/vortex-layout/src/layouts/flat/writer.rs
@@ -12,7 +12,7 @@ use vortex_scalar::{BinaryScalar, Utf8Scalar};
 use crate::layouts::flat::FlatLayout;
 use crate::layouts::zoned::{lower_bound, upper_bound};
 use crate::segments::SequenceWriter;
-use crate::{IntoLayout, LayoutStrategy, SendableLayoutWriter, SendableSequentialStream};
+use crate::{IntoLayout, LayoutStrategy, SendableLayoutFuture, SendableSequentialStream};
 
 #[derive(Clone)]
 pub struct FlatLayoutStrategy {
@@ -37,7 +37,7 @@ impl LayoutStrategy for FlatLayoutStrategy {
         ctx: &ArrayContext,
         sequence_writer: SequenceWriter,
         mut stream: SendableSequentialStream,
-    ) -> SendableLayoutWriter {
+    ) -> SendableLayoutFuture {
         let ctx = ctx.clone();
         let options = self.clone();
         Box::pin(async move {

--- a/vortex-layout/src/layouts/repartition.rs
+++ b/vortex-layout/src/layouts/repartition.rs
@@ -12,7 +12,7 @@ use vortex_error::{VortexExpect, VortexResult};
 
 use crate::segments::SequenceWriter;
 use crate::{
-    LayoutStrategy, SendableLayoutWriter, SendableSequentialStream, SequentialStreamAdapter,
+    LayoutStrategy, SendableLayoutFuture, SendableSequentialStream, SequentialStreamAdapter,
     SequentialStreamExt,
 };
 
@@ -45,7 +45,7 @@ impl LayoutStrategy for RepartitionStrategy {
         ctx: &ArrayContext,
         sequence_writer: SequenceWriter,
         stream: SendableSequentialStream,
-    ) -> SendableLayoutWriter {
+    ) -> SendableLayoutFuture {
         // TODO(os): spawn stream below like:
         // canon_stream = stream.map(async {to_canonical}).map(spawn).buffered(parallelism)
         let dtype = stream.dtype().clone();

--- a/vortex-layout/src/layouts/struct_/writer.rs
+++ b/vortex-layout/src/layouts/struct_/writer.rs
@@ -19,7 +19,7 @@ use vortex_utils::aliases::hash_set::HashSet;
 use crate::layouts::struct_::StructLayout;
 use crate::segments::SequenceWriter;
 use crate::{
-    IntoLayout as _, LayoutStrategy, SendableLayoutWriter, SendableSequentialStream,
+    IntoLayout as _, LayoutStrategy, SendableLayoutFuture, SendableSequentialStream,
     SequentialStreamAdapter, SequentialStreamExt,
 };
 
@@ -40,7 +40,7 @@ impl LayoutStrategy for StructStrategy {
         ctx: &ArrayContext,
         sequence_writer: SequenceWriter,
         stream: SendableSequentialStream,
-    ) -> SendableLayoutWriter {
+    ) -> SendableLayoutFuture {
         let dtype = stream.dtype().clone();
         let Some(struct_dtype) = stream.dtype().as_struct().cloned() else {
             // nothing we can do if dtype is not struct

--- a/vortex-layout/src/layouts/zoned/writer.rs
+++ b/vortex-layout/src/layouts/zoned/writer.rs
@@ -19,7 +19,7 @@ use crate::scan::{TaskExecutor, TaskExecutorExt};
 use crate::segments::SequenceWriter;
 use crate::sequence::SequenceId;
 use crate::{
-    IntoLayout, LayoutStrategy, SendableLayoutWriter, SendableSequentialStream,
+    IntoLayout, LayoutStrategy, SendableLayoutFuture, SendableSequentialStream,
     SequentialStreamAdapter, SequentialStreamExt,
 };
 
@@ -74,7 +74,7 @@ impl LayoutStrategy for ZonedStrategy {
         ctx: &ArrayContext,
         sequence_writer: SequenceWriter,
         stream: SendableSequentialStream,
-    ) -> SendableLayoutWriter {
+    ) -> SendableLayoutFuture {
         let executor = self.executor.clone();
         let stats = self.options.stats.clone();
         let precomputed_stream = SequentialStreamAdapter::new(

--- a/vortex-layout/src/strategy.rs
+++ b/vortex-layout/src/strategy.rs
@@ -15,7 +15,7 @@ use vortex_array::{ArrayContext, ArrayRef};
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 
-use crate::SendableLayoutWriter;
+use crate::SendableLayoutFuture;
 use crate::segments::SequenceWriter;
 use crate::sequence::SequenceId;
 
@@ -37,7 +37,7 @@ pub trait LayoutStrategy: 'static + Send + Sync {
         ctx: &ArrayContext,
         sequence_writer: SequenceWriter,
         stream: SendableSequentialStream,
-    ) -> SendableLayoutWriter;
+    ) -> SendableLayoutFuture;
 }
 
 pub trait SequentialStreamExt: SequentialStream {

--- a/vortex-layout/src/writer.rs
+++ b/vortex-layout/src/writer.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::pin::Pin;
-
+use futures::future::BoxFuture;
 use vortex_error::VortexResult;
 
 use crate::LayoutRef;
@@ -11,11 +10,5 @@ use crate::LayoutRef;
 /// trait to be potentially extended with new methods.
 // Tag for Python docs:
 // [layout writer]
-pub trait LayoutWriter: Future<Output = VortexResult<LayoutRef>> {}
+pub type SendableLayoutFuture = BoxFuture<'static, VortexResult<LayoutRef>>;
 // [layout writer]
-
-// Allow async blocks to impl LayoutWriter, this would change if more methods
-// are added to LayoutWriter.
-impl<F: Future<Output = VortexResult<LayoutRef>> + ?Sized + Send> LayoutWriter for F {}
-
-pub type SendableLayoutWriter = Pin<Box<dyn LayoutWriter + Send>>;


### PR DESCRIPTION
It's not really a writer, if anything the LayoutStrategy is the LayoutWriter, the thing it returns should be a `SendableLayoutFuture`