### PR TITLE
feat[compressor]: wire up sequence array into the compressor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6226,6 +6226,7 @@ dependencies = [
  "vortex-mask",
  "vortex-runend",
  "vortex-scalar",
+ "vortex-sequence",
  "vortex-sparse",
  "vortex-utils",
  "vortex-zigzag",

--- a/bench-vortex/src/tpch/tpchgen.rs
+++ b/bench-vortex/src/tpch/tpchgen.rs
@@ -121,7 +121,10 @@ pub async fn generate_tpch_tables(options: &TpchGenOptions) -> Result<()> {
     stream::iter(all_futures.into_iter().flatten())
         .map(|future| tokio::spawn(future))
         .buffer_unordered(MAX_CONCURRENT_FILES)
-        .try_for_each(|_| async { Ok(()) })
+        .try_for_each(|f| async {
+            f.unwrap();
+            Ok(())
+        })
         .await?;
 
     Ok(())

--- a/bench-vortex/src/tpch/tpchgen.rs
+++ b/bench-vortex/src/tpch/tpchgen.rs
@@ -118,14 +118,16 @@ pub async fn generate_tpch_tables(options: &TpchGenOptions) -> Result<()> {
 
     // Process futures with bounded concurrency
     // Map each future to a spawned task, then use buffer_unordered to limit concurrency
-    stream::iter(all_futures.into_iter().flatten())
+    let results: Vec<_> = stream::iter(all_futures.into_iter().flatten())
         .map(|future| tokio::spawn(future))
         .buffer_unordered(MAX_CONCURRENT_FILES)
-        .try_for_each(|f| async {
-            f.unwrap();
-            Ok(())
-        })
+        .try_collect()
         .await?;
+
+    // Check all spawned tasks completed successfully
+    for result in results {
+        result?;
+    }
 
     Ok(())
 }
@@ -313,7 +315,7 @@ struct VortexWriter {
 
 impl VortexWriter {
     fn new(path: PathBuf, schema: SchemaRef) -> Result<Self> {
-        // limit the number of in flight rows.
+        // Increase buffer size to avoid backpressure issues
         let (sender, receiver) = mpsc::channel(2);
         let dtype = DType::from_arrow(schema);
         let file_path = path;
@@ -350,7 +352,7 @@ impl FileWriter for VortexWriter {
 
     async fn finalize(mut self: Box<Self>) -> Result<()> {
         // Close the sender to signal end of stream
-        drop(self.sender);
+        self.sender.take();
 
         // Wait for write task to complete
         if let Some(task) = self.write_task.take() {

--- a/docs/quickstart/python.rst
+++ b/docs/quickstart/python.rst
@@ -37,7 +37,7 @@ Use :func:`~vortex.compress` to compress the Vortex array and check the relative
 
    >>> cvtx = vx.compress(vtx)
    >>> cvtx.nbytes
-   14309
+   14297
    >>> cvtx.nbytes / vtx.nbytes
    0.10...
 

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -11,8 +11,10 @@ use vortex_array::vtable::{
 use vortex_array::{
     ArrayBufferVisitor, ArrayChildVisitor, ArrayRef, Canonical, EncodingId, EncodingRef, vtable,
 };
-use vortex_dtype::Nullability::NonNullable;
-use vortex_dtype::{DType, NativePType, PType, match_each_integer_ptype, match_each_native_ptype};
+use vortex_buffer::BufferMut;
+use vortex_dtype::{
+    DType, NativePType, Nullability, PType, match_each_integer_ptype, match_each_native_ptype,
+};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
 use vortex_mask::Mask;
 use vortex_scalar::{PValue, Scalar, ScalarValue};
@@ -33,9 +35,16 @@ impl SequenceArray {
     pub fn typed_new<T: NativePType + Into<PValue>>(
         base: T,
         multiplier: T,
+        nullability: Nullability,
         length: usize,
     ) -> VortexResult<Self> {
-        Self::new(base.into(), multiplier.into(), T::PTYPE, length)
+        Self::new(
+            base.into(),
+            multiplier.into(),
+            T::PTYPE,
+            nullability,
+            length,
+        )
     }
 
     /// Constructs a sequence array using two integer values (with the same ptype).
@@ -43,6 +52,7 @@ impl SequenceArray {
         base: PValue,
         multiplier: PValue,
         ptype: PType,
+        nullability: Nullability,
         length: usize,
     ) -> VortexResult<Self> {
         if !ptype.is_int() {
@@ -56,16 +66,23 @@ impl SequenceArray {
             ))
         })?;
 
-        Ok(Self::unchecked_new(base, multiplier, ptype, length))
+        Ok(Self::unchecked_new(
+            base,
+            multiplier,
+            ptype,
+            nullability,
+            length,
+        ))
     }
 
     pub(crate) fn unchecked_new(
         base: PValue,
         multiplier: PValue,
         ptype: PType,
+        nullability: Nullability,
         length: usize,
     ) -> Self {
-        let dtype = DType::Primitive(ptype, NonNullable);
+        let dtype = DType::Primitive(ptype, nullability);
         Self {
             base,
             multiplier,
@@ -170,10 +187,11 @@ impl CanonicalVTable<SequenceVTable> for SequenceVTable {
         let prim = match_each_native_ptype!(array.ptype(), |P| {
             let base = array.base().as_primitive::<P>()?;
             let multiplier = array.multiplier().as_primitive::<P>()?;
-            PrimitiveArray::from_iter(
+            let values = BufferMut::from_iter(
                 (0..array.len())
                     .map(|i| base + <P>::from_usize(i).vortex_expect("must fit") * multiplier),
-            )
+            );
+            PrimitiveArray::new(values, array.dtype.nullability().into())
         });
 
         Ok(Canonical::Primitive(prim))
@@ -186,6 +204,7 @@ impl OperationsVTable<SequenceVTable> for SequenceVTable {
             array.index_value(start)?,
             array.multiplier,
             array.ptype(),
+            array.dtype().nullability(),
             stop - start,
         )
         .to_array())
@@ -232,13 +251,14 @@ pub struct SequenceEncoding;
 #[cfg(test)]
 mod tests {
     use vortex_array::arrays::PrimitiveArray;
+    use vortex_dtype::Nullability;
     use vortex_scalar::{Scalar, ScalarValue};
 
     use crate::array::SequenceArray;
 
     #[test]
     fn test_sequence_canonical() {
-        let arr = SequenceArray::typed_new(2i64, 3, 4).unwrap();
+        let arr = SequenceArray::typed_new(2i64, 3, Nullability::NonNullable, 4).unwrap();
 
         let canon = PrimitiveArray::from_iter((0..4).map(|i| 2i64 + i * 3));
 
@@ -254,7 +274,7 @@ mod tests {
 
     #[test]
     fn test_sequence_slice_canonical() {
-        let arr = SequenceArray::typed_new(2i64, 3, 4)
+        let arr = SequenceArray::typed_new(2i64, 3, Nullability::NonNullable, 4)
             .unwrap()
             .slice(2, 3)
             .unwrap();
@@ -273,7 +293,7 @@ mod tests {
 
     #[test]
     fn test_sequence_scalar_at() {
-        let scalar = SequenceArray::typed_new(2i64, 3, 4)
+        let scalar = SequenceArray::typed_new(2i64, 3, Nullability::NonNullable, 4)
             .unwrap()
             .scalar_at(2)
             .unwrap();
@@ -286,13 +306,13 @@ mod tests {
 
     #[test]
     fn test_sequence_min_max() {
-        assert!(SequenceArray::typed_new(-127i8, -1i8, 2).is_ok());
-        assert!(SequenceArray::typed_new(126i8, -1i8, 2).is_ok());
+        assert!(SequenceArray::typed_new(-127i8, -1i8, Nullability::NonNullable, 2).is_ok());
+        assert!(SequenceArray::typed_new(126i8, -1i8, Nullability::NonNullable, 2).is_ok());
     }
 
     #[test]
     fn test_sequence_too_big() {
-        assert!(SequenceArray::typed_new(127i8, 1i8, 2).is_err());
-        assert!(SequenceArray::typed_new(-128i8, -1i8, 2).is_err());
+        assert!(SequenceArray::typed_new(127i8, 1i8, Nullability::NonNullable, 2).is_err());
+        assert!(SequenceArray::typed_new(-128i8, -1i8, Nullability::NonNullable, 2).is_err());
     }
 }

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -105,7 +105,7 @@ impl SequenceArray {
         self.multiplier
     }
 
-    fn try_last(
+    pub(crate) fn try_last(
         base: PValue,
         multiplier: PValue,
         ptype: PType,

--- a/encodings/sequence/src/compress.rs
+++ b/encodings/sequence/src/compress.rs
@@ -3,46 +3,53 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_dtype::{NativePType, match_each_integer_ptype};
+use vortex_dtype::{NativePType, Nullability, match_each_integer_ptype};
 use vortex_error::VortexResult;
 use vortex_scalar::PValue;
 
 use crate::SequenceArray;
 
 pub fn sequence_encode(primitive_array: &PrimitiveArray) -> VortexResult<Option<ArrayRef>> {
-    if primitive_array.len() == 0 {
+    if primitive_array.is_empty() {
         // we cannot encode an empty array
         return Ok(None);
     }
 
-    if primitive_array.dtype().is_nullable() {
-        // for now we don't handle nullable arrays
+    if !primitive_array.all_valid()? {
         return Ok(None);
     }
 
     if primitive_array.ptype().is_float() {
-        // for now we don't handle float arrays, due to possible precision issues
+        // for now, we don't handle float arrays, due to possible precision issues
         return Ok(None);
     }
 
     match_each_integer_ptype!(primitive_array.ptype(), |P| {
-        encode_primitive_array(primitive_array.as_slice::<P>())
+        encode_primitive_array(
+            primitive_array.as_slice::<P>(),
+            primitive_array.dtype().nullability(),
+        )
     })
 }
 
 fn encode_primitive_array<P: NativePType + Into<PValue>>(
     slice: &[P],
+    nullability: Nullability,
 ) -> VortexResult<Option<ArrayRef>> {
     if slice.len() == 1 {
         // The multiplier here can be any value, zero is chosen
-        return SequenceArray::typed_new(slice[0], P::zero(), 1).map(|a| Some(a.to_array()));
+        return SequenceArray::typed_new(slice[0], P::zero(), nullability, 1)
+            .map(|a| Some(a.to_array()));
     }
     let base = slice[0];
     let multiplier = slice[1] - slice[0];
     slice
         .windows(2)
         .all(|w| w[1] == w[0] + multiplier)
-        .then_some(SequenceArray::typed_new(base, multiplier, slice.len()).map(|a| a.to_array()))
+        .then_some(
+            SequenceArray::typed_new(base, multiplier, nullability, slice.len())
+                .map(|a| a.to_array()),
+        )
         .transpose()
 }
 

--- a/encodings/sequence/src/compress.rs
+++ b/encodings/sequence/src/compress.rs
@@ -46,6 +46,16 @@ fn encode_primitive_array<P: NativePType + Into<PValue> + CheckedAdd + CheckedSu
     let Some(multiplier) = slice[1].checked_sub(&base) else {
         return Ok(None);
     };
+
+    if multiplier == P::zero() {
+        return Ok(None);
+    }
+
+    if SequenceArray::try_last(base.into(), multiplier.into(), P::PTYPE, slice.len()).is_err() {
+        // If the last value is out of range, we cannot encode
+        return Ok(None);
+    }
+
     slice
         .windows(2)
         .all(|w| Some(w[1]) == w[0].checked_add(&multiplier))
@@ -84,6 +94,14 @@ mod tests {
     #[test]
     fn test_encode_array_fail() {
         let primitive_array = PrimitiveArray::from_iter([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
+
+        let encoded = sequence_encode(&primitive_array).unwrap();
+        assert!(encoded.is_none());
+    }
+
+    #[test]
+    fn test_encode_array_fail_oob() {
+        let primitive_array = PrimitiveArray::from_iter(vec![100i8; 1000]);
 
         let encoded = sequence_encode(&primitive_array).unwrap();
         assert!(encoded.is_none());

--- a/encodings/sequence/src/compress.rs
+++ b/encodings/sequence/src/compress.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use num_traits::{CheckedAdd, CheckedSub};
 use vortex_array::ArrayRef;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_dtype::{NativePType, Nullability, match_each_integer_ptype};
@@ -32,7 +33,7 @@ pub fn sequence_encode(primitive_array: &PrimitiveArray) -> VortexResult<Option<
     })
 }
 
-fn encode_primitive_array<P: NativePType + Into<PValue>>(
+fn encode_primitive_array<P: NativePType + Into<PValue> + CheckedAdd + CheckedSub>(
     slice: &[P],
     nullability: Nullability,
 ) -> VortexResult<Option<ArrayRef>> {
@@ -42,10 +43,12 @@ fn encode_primitive_array<P: NativePType + Into<PValue>>(
             .map(|a| Some(a.to_array()));
     }
     let base = slice[0];
-    let multiplier = slice[1] - slice[0];
+    let Some(multiplier) = slice[1].checked_sub(&base) else {
+        return Ok(None);
+    };
     slice
         .windows(2)
-        .all(|w| w[1] == w[0] + multiplier)
+        .all(|w| Some(w[1]) == w[0].checked_add(&multiplier))
         .then_some(
             SequenceArray::typed_new(base, multiplier, nullability, slice.len())
                 .map(|a| a.to_array()),

--- a/encodings/sequence/src/compress.rs
+++ b/encodings/sequence/src/compress.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
 use vortex_array::ArrayRef;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_dtype::{NativePType, match_each_integer_ptype};

--- a/encodings/sequence/src/compress.rs
+++ b/encodings/sequence/src/compress.rs
@@ -10,6 +10,12 @@ use vortex_scalar::PValue;
 
 use crate::SequenceArray;
 
+/// Encodes a primitive array into a sequence array, this is possible if:
+/// 1. The array is not empty, and contains no nulls
+/// 2. The array is not a float array. (This is due to precision issues, how it will stack well with ALP).
+/// 3. The array is representable as a sequence `A[i] = base + i * multiplier` for multiplier != 0.
+/// 4. The sequence has no deviations from the equation, this could be fixed with patches. However,
+///    we might want a different array for that since sequence provide fast access.
 pub fn sequence_encode(primitive_array: &PrimitiveArray) -> VortexResult<Option<ArrayRef>> {
     if primitive_array.is_empty() {
         // we cannot encode an empty array

--- a/encodings/sequence/src/compress.rs
+++ b/encodings/sequence/src/compress.rs
@@ -1,0 +1,78 @@
+use vortex_array::ArrayRef;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_dtype::{NativePType, match_each_integer_ptype};
+use vortex_error::VortexResult;
+use vortex_scalar::PValue;
+
+use crate::SequenceArray;
+
+pub fn sequence_encode(primitive_array: &PrimitiveArray) -> VortexResult<Option<ArrayRef>> {
+    if primitive_array.len() == 0 {
+        // we cannot encode an empty array
+        return Ok(None);
+    }
+
+    if primitive_array.dtype().is_nullable() {
+        // for now we don't handle nullable arrays
+        return Ok(None);
+    }
+
+    if primitive_array.ptype().is_float() {
+        // for now we don't handle float arrays, due to possible precision issues
+        return Ok(None);
+    }
+
+    match_each_integer_ptype!(primitive_array.ptype(), |P| {
+        encode_primitive_array(primitive_array.as_slice::<P>())
+    })
+}
+
+fn encode_primitive_array<P: NativePType + Into<PValue>>(
+    slice: &[P],
+) -> VortexResult<Option<ArrayRef>> {
+    if slice.len() == 1 {
+        // The multiplier here can be any value, zero is chosen
+        return SequenceArray::typed_new(slice[0], P::zero(), 1).map(|a| Some(a.to_array()));
+    }
+    let base = slice[0];
+    let multiplier = slice[1] - slice[0];
+    slice
+        .windows(2)
+        .all(|w| w[1] == w[0] + multiplier)
+        .then_some(SequenceArray::typed_new(base, multiplier, slice.len()).map(|a| a.to_array()))
+        .transpose()
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_array::ToCanonical;
+    use vortex_array::arrays::PrimitiveArray;
+
+    use crate::sequence_encode;
+
+    #[test]
+    fn test_encode_array_success() {
+        let primitive_array = PrimitiveArray::from_iter([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        let encoded = sequence_encode(&primitive_array).unwrap();
+        assert!(encoded.is_some());
+        let decoded = encoded.unwrap().to_primitive().unwrap();
+        assert_eq!(decoded.as_slice::<i32>(), primitive_array.as_slice::<i32>());
+    }
+
+    #[test]
+    fn test_encode_array_1_success() {
+        let primitive_array = PrimitiveArray::from_iter([0]);
+        let encoded = sequence_encode(&primitive_array).unwrap();
+        assert!(encoded.is_some());
+        let decoded = encoded.unwrap().to_primitive().unwrap();
+        assert_eq!(decoded.as_slice::<i32>(), primitive_array.as_slice::<i32>());
+    }
+
+    #[test]
+    fn test_encode_array_fail() {
+        let primitive_array = PrimitiveArray::from_iter([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
+
+        let encoded = sequence_encode(&primitive_array).unwrap();
+        assert!(encoded.is_none());
+    }
+}

--- a/encodings/sequence/src/compute/compare.rs
+++ b/encodings/sequence/src/compute/compare.rs
@@ -104,7 +104,7 @@ mod tests {
     use vortex_array::ToCanonical;
     use vortex_array::arrays::{BoolArray, ConstantArray};
     use vortex_array::compute::{Operator, compare};
-    use vortex_dtype::Nullability::NonNullable;
+    use vortex_dtype::Nullability::{NonNullable, Nullable};
 
     use crate::SequenceArray;
 
@@ -124,7 +124,7 @@ mod tests {
 
     #[test]
     fn test_compare_match_scale() {
-        let lhs = SequenceArray::typed_new(2i64, 3, nullability::Nullable, 4).unwrap();
+        let lhs = SequenceArray::typed_new(2i64, 3, Nullable, 4).unwrap();
 
         let rhs = ConstantArray::new(8i64, lhs.len());
 

--- a/encodings/sequence/src/compute/compare.rs
+++ b/encodings/sequence/src/compute/compare.rs
@@ -104,12 +104,13 @@ mod tests {
     use vortex_array::ToCanonical;
     use vortex_array::arrays::{BoolArray, ConstantArray};
     use vortex_array::compute::{Operator, compare};
+    use vortex_dtype::Nullability::NonNullable;
 
     use crate::SequenceArray;
 
     #[test]
     fn test_compare_match() {
-        let lhs = SequenceArray::typed_new(2i64, 1, 4).unwrap();
+        let lhs = SequenceArray::typed_new(2i64, 1, NonNullable, 4).unwrap();
 
         let rhs = ConstantArray::new(4i64, lhs.len());
 
@@ -123,7 +124,7 @@ mod tests {
 
     #[test]
     fn test_compare_match_scale() {
-        let lhs = SequenceArray::typed_new(2i64, 3, 4).unwrap();
+        let lhs = SequenceArray::typed_new(2i64, 3, nullability::Nullable, 4).unwrap();
 
         let rhs = ConstantArray::new(8i64, lhs.len());
 
@@ -137,7 +138,7 @@ mod tests {
 
     #[test]
     fn test_compare_no_match() {
-        let lhs = SequenceArray::typed_new(2i64, 1, 4).unwrap();
+        let lhs = SequenceArray::typed_new(2i64, 1, NonNullable, 4).unwrap();
 
         let rhs = ConstantArray::new(1i64, lhs.len());
 

--- a/encodings/sequence/src/compute/list_contains.rs
+++ b/encodings/sequence/src/compute/list_contains.rs
@@ -76,7 +76,7 @@ mod tests {
             // [1, 3] in  1
             //            2
             //            3
-            let array = SequenceArray::typed_new(1, 1, 3).unwrap();
+            let array = SequenceArray::typed_new(1, 1, Nullability::NonNullable, 3).unwrap();
 
             let res = list_contains(elements.as_ref(), array.as_ref())
                 .unwrap()
@@ -92,7 +92,7 @@ mod tests {
             // [1, 3] in  1
             //            3
             //            5
-            let array = SequenceArray::typed_new(1, 2, 3).unwrap();
+            let array = SequenceArray::typed_new(1, 2, Nullability::NonNullable, 3).unwrap();
 
             let res = list_contains(elements.as_ref(), array.as_ref())
                 .unwrap()

--- a/encodings/sequence/src/lib.rs
+++ b/encodings/sequence/src/lib.rs
@@ -2,12 +2,14 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 mod array;
+mod compress;
 mod compute;
 mod serde;
 
 /// Represents the equation A\[i\] = a * i b.
 /// This can be used for compression, fast comparisons and also for row ids.
 pub use array::{SequenceArray, SequenceEncoding, SequenceVTable};
+pub use compress::sequence_encode;
 
 // TODO(joe): hook up to the compressor
 // TODO(joe): support comparisons with other operators

--- a/encodings/sequence/src/serde.rs
+++ b/encodings/sequence/src/serde.rs
@@ -77,7 +77,13 @@ impl SerdeVTable<SequenceVTable> for SequenceVTable {
         .pvalue()
         .vortex_expect("non-nullable primitive");
 
-        Ok(SequenceArray::unchecked_new(base, multiplier, ptype, len))
+        Ok(SequenceArray::unchecked_new(
+            base,
+            multiplier,
+            ptype,
+            dtype.nullability(),
+            len,
+        ))
     }
 }
 
@@ -88,6 +94,7 @@ mod tests {
     use arcref::ArcRef;
     use vortex_array::arrays::{PrimitiveArray, StructArray};
     use vortex_array::stream::ArrayStreamExt;
+    use vortex_dtype::Nullability;
     use vortex_expr::{get_item, root};
     use vortex_file::{VortexOpenOptions, VortexWriteOptions};
     use vortex_layout::layouts::flat::writer::FlatLayoutStrategy;
@@ -96,7 +103,7 @@ mod tests {
 
     #[tokio::test]
     async fn round_trip_seq() {
-        let seq = SequenceArray::typed_new(2i8, 3, 4).unwrap();
+        let seq = SequenceArray::typed_new(2i8, 3, Nullability::NonNullable, 4).unwrap();
         let st = StructArray::from_fields(&[("a", seq.to_array())]).unwrap();
 
         let file = tokio::fs::File::create("/tmp/abc.vx").await.unwrap();

--- a/vortex-btrblocks/Cargo.toml
+++ b/vortex-btrblocks/Cargo.toml
@@ -34,6 +34,7 @@ vortex-fsst = { workspace = true }
 vortex-mask = { workspace = true }
 vortex-runend = { workspace = true }
 vortex-scalar = { workspace = true }
+vortex-sequence = { workspace = true }
 vortex-sparse = { workspace = true }
 vortex-utils = { workspace = true }
 vortex-zigzag = { workspace = true }

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -12,11 +12,12 @@ use vortex_array::arrays::{ConstantArray, PrimitiveArray, PrimitiveVTable};
 use vortex_array::compress::downscale_integer_array;
 use vortex_array::{ArrayRef, IntoArray, ToCanonical};
 use vortex_dict::DictArray;
-use vortex_error::{VortexExpect, VortexResult, VortexUnwrap};
+use vortex_error::{VortexExpect, VortexResult, VortexUnwrap, vortex_bail, vortex_err};
 use vortex_fastlanes::{FoRArray, bit_width_histogram, bitpack_encode, find_best_bit_width};
 use vortex_runend::RunEndArray;
 use vortex_runend::compress::runend_encode;
 use vortex_scalar::Scalar;
+use vortex_sequence::sequence_encode;
 use vortex_sparse::{SparseArray, SparseVTable};
 use vortex_zigzag::{ZigZagArray, zigzag_encode};
 
@@ -43,6 +44,7 @@ impl Compressor for IntCompressor {
             &SparseScheme,
             &DictScheme,
             &RunEndScheme,
+            &SequenceScheme,
         ]
     }
 
@@ -97,6 +99,7 @@ const BITPACKING_SCHEME: IntCode = IntCode(4);
 const SPARSE_SCHEME: IntCode = IntCode(5);
 const DICT_SCHEME: IntCode = IntCode(6);
 const RUNEND_SCHEME: IntCode = IntCode(7);
+const SEQUENCE_SCHEME: IntCode = IntCode(8);
 
 #[derive(Debug, Copy, Clone)]
 pub struct UncompressedScheme;
@@ -121,6 +124,9 @@ pub struct DictScheme;
 
 #[derive(Debug, Copy, Clone)]
 pub struct RunEndScheme;
+
+#[derive(Debug, Copy, Clone)]
+pub struct SequenceScheme;
 
 /// Threshold for the average run length in an array before we consider run-end encoding.
 const RUN_END_THRESHOLD: u32 = 4;
@@ -669,6 +675,45 @@ impl Scheme for RunEndScheme {
         )?;
 
         Ok(RunEndArray::try_new(compressed_ends, compressed_values)?.into_array())
+    }
+}
+
+impl Scheme for SequenceScheme {
+    type StatsType = IntegerStats;
+    type CodeType = IntCode;
+
+    fn code(&self) -> Self::CodeType {
+        SEQUENCE_SCHEME
+    }
+
+    fn expected_compression_ratio(
+        &self,
+        stats: &Self::StatsType,
+        _is_sample: bool,
+        _allowed_cascading: usize,
+        _excludes: &[Self::CodeType],
+    ) -> VortexResult<f64> {
+        if stats.null_count > 0 {
+            return Ok(0.0);
+        }
+        // Since two values are required to store base and multiplier the
+        // compression ratio is divided by 2.
+        Ok(sequence_encode(&stats.src)?
+            .map(|_| stats.src.len() as f64 / 2.0)
+            .unwrap_or(0.0))
+    }
+
+    fn compress(
+        &self,
+        stats: &Self::StatsType,
+        _is_sample: bool,
+        _allowed_cascading: usize,
+        _excludes: &[Self::CodeType],
+    ) -> VortexResult<ArrayRef> {
+        if stats.null_count > 0 {
+            vortex_bail!("sequence encoding does not support nulls");
+        }
+        sequence_encode(&stats.src)?.ok_or_else(|| vortex_err!("cannot sequence encode array"))
     }
 }
 

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -728,10 +728,11 @@ mod tests {
     use vortex_array::vtable::ValidityHelper;
     use vortex_array::{Array, IntoArray, ToCanonical};
     use vortex_buffer::{Buffer, BufferMut, buffer, buffer_mut};
+    use vortex_sequence::SequenceEncoding;
     use vortex_sparse::SparseEncoding;
     use vortex_utils::aliases::hash_set::HashSet;
 
-    use crate::integer::{IntCompressor, IntegerStats, SparseScheme};
+    use crate::integer::{IntCompressor, IntegerStats, SequenceScheme, SparseScheme};
     use crate::{Compressor, CompressorStats, Scheme};
 
     #[test]
@@ -831,5 +832,18 @@ mod tests {
         let expected = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 46];
         assert_eq!(decoded.as_slice::<u8>(), &expected);
         assert_eq!(decoded.validity(), array.validity());
+    }
+
+    #[test]
+    fn nullable_sequence() {
+        let values = (0i32..20).step_by(7).collect_vec();
+        println!("{:?}", values);
+        let array = PrimitiveArray::from_option_iter(values.clone().into_iter().map(Some));
+        let compressed = SequenceScheme
+            .compress(&IntegerStats::generate(&array), false, 3, &[])
+            .unwrap();
+        assert_eq!(compressed.encoding_id(), SequenceEncoding.id());
+        let decoded = compressed.to_primitive().unwrap();
+        assert_eq!(decoded.as_slice::<i32>(), values.as_slice());
     }
 }

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -837,7 +837,6 @@ mod tests {
     #[test]
     fn nullable_sequence() {
         let values = (0i32..20).step_by(7).collect_vec();
-        println!("{:?}", values);
         let array = PrimitiveArray::from_option_iter(values.clone().into_iter().map(Some));
         let compressed = SequenceScheme
             .compress(&IntegerStats::generate(&array), false, 3, &[])

--- a/vortex-duckdb/src/exporter/sequence.rs
+++ b/vortex-duckdb/src/exporter/sequence.rs
@@ -35,6 +35,7 @@ impl ColumnExporter for SequenceExporter {
 
 #[cfg(test)]
 mod tests {
+    use vortex::dtype::Nullability;
 
     use super::*;
     use crate::cpp;
@@ -42,7 +43,7 @@ mod tests {
 
     #[test]
     fn test_sequence() {
-        let arr = SequenceArray::typed_new(2, 5, 100).unwrap();
+        let arr = SequenceArray::typed_new(2, 5, Nullability::NonNullable, 100).unwrap();
         let mut chunk = DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_INTEGER)]);
 
         new_exporter(&arr)

--- a/vortex-layout/src/layouts/row_idx/mod.rs
+++ b/vortex-layout/src/layouts/row_idx/mod.rs
@@ -8,13 +8,14 @@ use std::fmt::{Display, Formatter};
 use std::ops::{BitAnd, Range};
 use std::sync::Arc;
 
+use Nullability::NonNullable;
 use async_trait::async_trait;
 use dashmap::DashMap;
 pub use expr::*;
 use vortex_array::compute::filter;
 use vortex_array::stats::Precision;
 use vortex_array::{ArrayRef, IntoArray};
-use vortex_dtype::{DType, FieldMask, PType};
+use vortex_dtype::{DType, FieldMask, Nullability, PType};
 use vortex_error::{VortexExpect, VortexResult};
 use vortex_expr::transform::partition::{PartitionedExpr, partition};
 use vortex_expr::transform::replace::replace;
@@ -227,6 +228,7 @@ impl RowIdxEvaluation {
             PValue::U64(row_offset + row_range.start),
             PValue::U64(1),
             PType::U64,
+            NonNullable,
             usize::try_from(row_range.end - row_range.start)
                 .vortex_expect("Row range length must fit in usize"),
         )

--- a/vortex-python/src/arrays/compressed.rs
+++ b/vortex-python/src/arrays/compressed.rs
@@ -7,6 +7,7 @@ use vortex::encodings::datetime_parts::DateTimePartsVTable;
 use vortex::encodings::dict::DictVTable;
 use vortex::encodings::fsst::FSSTVTable;
 use vortex::encodings::runend::RunEndVTable;
+use vortex::encodings::sequence::SequenceVTable;
 use vortex::encodings::sparse::SparseVTable;
 use vortex::encodings::zigzag::ZigZagVTable;
 
@@ -74,4 +75,12 @@ pub(crate) struct PyZigZagArray;
 
 impl EncodingSubclass for PyZigZagArray {
     type VTable = ZigZagVTable;
+}
+
+/// Concrete class for arrays with `vortex.sequence` encoding.
+#[pyclass(name = "SequenceArray", module = "vortex", extends=PyNativeArray, frozen)]
+pub(crate) struct PySequenceArray;
+
+impl EncodingSubclass for PySequenceArray {
+    type VTable = SequenceVTable;
 }

--- a/vortex-python/src/arrays/native.rs
+++ b/vortex-python/src/arrays/native.rs
@@ -17,6 +17,7 @@ use vortex::encodings::dict::DictVTable;
 use vortex::encodings::fastlanes::{BitPackedVTable, DeltaVTable, FoRVTable};
 use vortex::encodings::fsst::FSSTVTable;
 use vortex::encodings::runend::RunEndVTable;
+use vortex::encodings::sequence::SequenceVTable;
 use vortex::encodings::sparse::SparseVTable;
 use vortex::encodings::zigzag::ZigZagVTable;
 use vortex::error::VortexExpect;
@@ -31,7 +32,7 @@ use crate::arrays::builtins::{
 };
 use crate::arrays::compressed::{
     PyAlpArray, PyAlpRdArray, PyDateTimePartsArray, PyDictArray, PyFsstArray, PyRunEndArray,
-    PySparseArray, PyZigZagArray,
+    PySequenceArray, PySparseArray, PyZigZagArray,
 };
 use crate::arrays::fastlanes::{
     PyFastLanesBitPackedArray, PyFastLanesDeltaArray, PyFastLanesFoRArray,
@@ -143,6 +144,10 @@ impl PyNativeArray {
 
         if array.is::<DecimalVTable>() {
             return Self::with_subclass(py, array, PyDecimalArray);
+        }
+
+        if array.is::<SequenceVTable>() {
+            return Self::with_subclass(py, array, PySequenceArray);
         }
 
         Err(PyTypeError::new_err(format!(

--- a/vortex-python/src/compress.rs
+++ b/vortex-python/src/compress.rs
@@ -38,7 +38,7 @@ pub(crate) fn init(py: Python, parent: &Bound<PyModule>) -> PyResult<()> {
 ///
 ///    >>> a = vx.array(list(range(1000)))
 ///    >>> str(vx.compress(a))
-///    'fastlanes.bitpacked(i64, len=1000)'
+///    'vortex.sequence(i64, len=1000)'
 ///
 /// Compress an array of increasing floating-point numbers and a few nulls:
 ///


### PR DESCRIPTION
Add sequence array into the compressor.

We might in the future want to add patches or a validity array, but these are omitted for now, and can be added without a break