### PR TITLE
feat: Minimal support for extension array casting

### DIFF
--- a/encodings/datetime-parts/src/compute/cast.rs
+++ b/encodings/datetime-parts/src/compute/cast.rs
@@ -4,26 +4,28 @@
 use vortex_array::compute::{CastKernel, CastKernelAdapter, cast};
 use vortex_array::{Array, ArrayRef, IntoArray, register_kernel};
 use vortex_dtype::DType;
-use vortex_error::{VortexResult, vortex_bail};
+use vortex_error::VortexResult;
 
 use crate::{DateTimePartsArray, DateTimePartsVTable};
 
 impl CastKernel for DateTimePartsVTable {
-    fn cast(&self, array: &DateTimePartsArray, dtype: &DType) -> VortexResult<ArrayRef> {
+    fn cast(&self, array: &DateTimePartsArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         if !array.dtype().eq_ignore_nullability(dtype) {
-            vortex_bail!("cannot cast from {} to {}", array.dtype(), dtype);
+            return Ok(None);
         };
 
-        Ok(DateTimePartsArray::try_new(
-            dtype.clone(),
-            cast(
-                array.days().as_ref(),
-                &array.days().dtype().with_nullability(dtype.nullability()),
-            )?,
-            array.seconds().clone(),
-            array.subseconds().clone(),
-        )?
-        .into_array())
+        Ok(Some(
+            DateTimePartsArray::try_new(
+                dtype.clone(),
+                cast(
+                    array.days().as_ref(),
+                    &array.days().dtype().with_nullability(dtype.nullability()),
+                )?,
+                array.seconds().clone(),
+                array.subseconds().clone(),
+            )?
+            .into_array(),
+        ))
     }
 }
 
@@ -86,10 +88,10 @@ mod tests {
         let array = date_time_array(validity);
         let result = cast(&array, &DType::Bool(Nullability::NonNullable));
         assert!(
-            result
-                .as_ref()
-                .is_err_and(|err| err.to_string().contains("cannot cast from")),
-            "{result:?}"
+            result.as_ref().is_err_and(|err| err.to_string().contains(
+                "No compute kernel to cast array vortex.ext with dtype ext(vortex.timestamp, i64, ExtMetadata([2, 3, 0, 85, 84, 67]))? to bool"
+            )),
+            "Got error: {result:?}"
         );
 
         let result = cast(
@@ -100,7 +102,7 @@ mod tests {
             result.as_ref().is_err_and(|err| err
                 .to_string()
                 .contains("invalid cast from nullable to non-nullable")),
-            "{result:?}"
+            "Got error: {result:?}"
         );
     }
 }

--- a/vortex-array/src/arrays/bool/compute/cast.rs
+++ b/vortex-array/src/arrays/bool/compute/cast.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_dtype::DType;
-use vortex_error::{VortexResult, vortex_bail};
+use vortex_error::VortexResult;
 
 use crate::array::ArrayRef;
 use crate::arrays::{BoolArray, BoolVTable};
@@ -11,14 +11,16 @@ use crate::register_kernel;
 use crate::vtable::ValidityHelper;
 
 impl CastKernel for BoolVTable {
-    fn cast(&self, array: &BoolArray, dtype: &DType) -> VortexResult<ArrayRef> {
+    fn cast(&self, array: &BoolArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         if !matches!(dtype, DType::Bool(_)) {
-            vortex_bail!("Cannot cast {} to {}", array.dtype(), dtype);
+            return Ok(None);
         }
 
         let new_nullability = dtype.nullability();
         let new_validity = array.validity().clone().cast_nullability(new_nullability)?;
-        Ok(BoolArray::new(array.boolean_buffer().clone(), new_validity).to_array())
+        Ok(Some(
+            BoolArray::new(array.boolean_buffer().clone(), new_validity).to_array(),
+        ))
     }
 }
 

--- a/vortex-array/src/arrays/chunked/compute/cast.rs
+++ b/vortex-array/src/arrays/chunked/compute/cast.rs
@@ -9,13 +9,15 @@ use crate::compute::{CastKernel, CastKernelAdapter, cast};
 use crate::{ArrayRef, IntoArray, register_kernel};
 
 impl CastKernel for ChunkedVTable {
-    fn cast(&self, array: &ChunkedArray, dtype: &DType) -> VortexResult<ArrayRef> {
+    fn cast(&self, array: &ChunkedArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         let mut cast_chunks = Vec::new();
         for chunk in array.chunks() {
             cast_chunks.push(cast(chunk, dtype)?);
         }
 
-        Ok(ChunkedArray::new_unchecked(cast_chunks, dtype.clone()).into_array())
+        Ok(Some(
+            ChunkedArray::new_unchecked(cast_chunks, dtype.clone()).into_array(),
+        ))
     }
 }
 

--- a/vortex-array/src/arrays/constant/compute/cast.rs
+++ b/vortex-array/src/arrays/constant/compute/cast.rs
@@ -9,8 +9,11 @@ use crate::compute::{CastKernel, CastKernelAdapter};
 use crate::{ArrayRef, IntoArray, register_kernel};
 
 impl CastKernel for ConstantVTable {
-    fn cast(&self, array: &ConstantArray, dtype: &DType) -> VortexResult<ArrayRef> {
-        Ok(ConstantArray::new(array.scalar().cast(dtype)?, array.len()).into_array())
+    fn cast(&self, array: &ConstantArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
+        match array.scalar().cast(dtype) {
+            Ok(scalar) => Ok(Some(ConstantArray::new(scalar, array.len()).into_array())),
+            Err(_e) => Ok(None),
+        }
     }
 }
 

--- a/vortex-array/src/arrays/extension/compute/cast.rs
+++ b/vortex-array/src/arrays/extension/compute/cast.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::DType;
+
+use crate::arrays::{ExtensionArray, ExtensionVTable};
+use crate::compute::{CastKernel, CastKernelAdapter, cast};
+use crate::{ArrayRef, IntoArray, register_kernel};
+
+impl CastKernel for ExtensionVTable {
+    fn cast(
+        &self,
+        array: &ExtensionArray,
+        dtype: &DType,
+    ) -> vortex_error::VortexResult<Option<ArrayRef>> {
+        if !array.dtype().eq_ignore_nullability(dtype) {
+            return Ok(None);
+        }
+
+        let DType::Extension(ext_dtype) = dtype else {
+            unreachable!("Already verified we have an extension dtype");
+        };
+
+        let new_storage = match cast(array.storage(), ext_dtype.storage_dtype()) {
+            Ok(arr) => arr,
+            Err(e) => {
+                log::warn!("Failed to cast storage array: {e}");
+                return Ok(None);
+            }
+        };
+
+        Ok(Some(
+            ExtensionArray::new(ext_dtype.clone(), new_storage).into_array(),
+        ))
+    }
+}
+
+register_kernel!(CastKernelAdapter(ExtensionVTable).lift());
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use vortex_dtype::datetime::{TIMESTAMP_ID, TemporalMetadata, TimeUnit};
+    use vortex_dtype::{ExtDType, Nullability, PType};
+
+    use super::*;
+    use crate::arrays::PrimitiveArray;
+
+    #[test]
+    fn cast_same_ext_dtype() {
+        let ext_dtype = Arc::new(ExtDType::new(
+            TIMESTAMP_ID.clone(),
+            Arc::new(PType::I64.into()),
+            Some(TemporalMetadata::Timestamp(TimeUnit::Ms, None).into()),
+        ));
+        let storage = PrimitiveArray::from_iter(Vec::<i64>::new()).into_array();
+
+        let arr = ExtensionArray::new(ext_dtype.clone(), storage);
+
+        let output = cast(arr.as_ref(), &DType::Extension(ext_dtype.clone())).unwrap();
+        assert_eq!(arr.len(), output.len());
+        assert_eq!(arr.dtype(), output.dtype());
+        assert_eq!(output.dtype(), &DType::Extension(ext_dtype));
+    }
+
+    #[test]
+    fn cast_same_ext_dtype_differet_nullability() {
+        let ext_dtype = Arc::new(ExtDType::new(
+            TIMESTAMP_ID.clone(),
+            Arc::new(PType::I64.into()),
+            Some(TemporalMetadata::Timestamp(TimeUnit::Ms, None).into()),
+        ));
+        let storage = PrimitiveArray::from_iter(Vec::<i64>::new()).into_array();
+
+        let arr = ExtensionArray::new(ext_dtype.clone(), storage);
+        assert!(!arr.dtype.is_nullable());
+
+        let new_dtype = DType::Extension(ext_dtype).with_nullability(Nullability::Nullable);
+
+        let output = cast(arr.as_ref(), &new_dtype).unwrap();
+        assert_eq!(arr.len(), output.len());
+        assert!(arr.dtype().eq_ignore_nullability(output.dtype()));
+        assert_eq!(output.dtype(), &new_dtype);
+    }
+
+    #[test]
+    fn cast_different_ext_dtype() {
+        let original_dtype = Arc::new(ExtDType::new(
+            TIMESTAMP_ID.clone(),
+            Arc::new(PType::I64.into()),
+            Some(TemporalMetadata::Timestamp(TimeUnit::Ms, None).into()),
+        ));
+        let target_dtype = Arc::new(ExtDType::new(
+            TIMESTAMP_ID.clone(),
+            Arc::new(PType::I64.into()),
+            // Note NS here instead of MS
+            Some(TemporalMetadata::Timestamp(TimeUnit::Ns, None).into()),
+        ));
+
+        let storage = PrimitiveArray::from_iter(Vec::<i64>::new()).into_array();
+        let arr = ExtensionArray::new(original_dtype, storage);
+
+        assert!(cast(arr.as_ref(), &DType::Extension(target_dtype)).is_err());
+    }
+}

--- a/vortex-array/src/arrays/extension/compute/mod.rs
+++ b/vortex-array/src/arrays/extension/compute/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+mod cast;
 mod compare;
 
 use vortex_error::VortexResult;

--- a/vortex-array/src/arrays/list/compute/cast.rs
+++ b/vortex-array/src/arrays/list/compute/cast.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_dtype::DType;
-use vortex_error::{VortexResult, vortex_bail};
+use vortex_error::VortexResult;
 
 use crate::arrays::{ListArray, ListVTable};
 use crate::compute::{CastKernel, CastKernelAdapter, cast};
@@ -10,9 +10,9 @@ use crate::vtable::ValidityHelper;
 use crate::{ArrayRef, register_kernel};
 
 impl CastKernel for ListVTable {
-    fn cast(&self, array: &Self::Array, dtype: &DType) -> VortexResult<ArrayRef> {
+    fn cast(&self, array: &Self::Array, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         let Some(target_element_type) = dtype.as_list_element() else {
-            vortex_bail!("cannot cast {} to {}", array.dtype(), dtype);
+            return Ok(None);
         };
 
         let validity = array
@@ -25,7 +25,7 @@ impl CastKernel for ListVTable {
             array.offsets().clone(),
             validity,
         )
-        .map(|a| a.to_array())
+        .map(|a| Some(a.to_array()))
     }
 }
 

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -13,9 +13,9 @@ use crate::vtable::ValidityHelper;
 use crate::{ArrayRef, IntoArray, register_kernel};
 
 impl CastKernel for PrimitiveVTable {
-    fn cast(&self, array: &PrimitiveArray, dtype: &DType) -> VortexResult<ArrayRef> {
+    fn cast(&self, array: &PrimitiveArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         let DType::Primitive(new_ptype, new_nullability) = dtype else {
-            vortex_bail!(MismatchedTypes: "primitive type", dtype);
+            return Ok(None);
         };
         let (new_ptype, new_nullability) = (*new_ptype, *new_nullability);
 
@@ -36,17 +36,21 @@ impl CastKernel for PrimitiveVTable {
 
         // If the bit width is the same, we can short-circuit and simply update the validity
         if array.ptype() == new_ptype {
-            return Ok(PrimitiveArray::from_byte_buffer(
-                array.byte_buffer().clone(),
-                array.ptype(),
-                new_validity,
-            )
-            .into_array());
+            return Ok(Some(
+                PrimitiveArray::from_byte_buffer(
+                    array.byte_buffer().clone(),
+                    array.ptype(),
+                    new_validity,
+                )
+                .into_array(),
+            ));
         }
 
         // Otherwise, we need to cast the values one-by-one
         match_each_native_ptype!(new_ptype, |T| {
-            Ok(PrimitiveArray::new(cast::<T>(array)?, new_validity).into_array())
+            Ok(Some(
+                PrimitiveArray::new(cast::<T>(array)?, new_validity).into_array(),
+            ))
         })
     }
 }

--- a/vortex-array/src/arrays/struct_/compute/cast.rs
+++ b/vortex-array/src/arrays/struct_/compute/cast.rs
@@ -11,9 +11,9 @@ use crate::vtable::ValidityHelper;
 use crate::{ArrayRef, IntoArray, register_kernel};
 
 impl CastKernel for StructVTable {
-    fn cast(&self, array: &StructArray, dtype: &DType) -> VortexResult<ArrayRef> {
+    fn cast(&self, array: &StructArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         let Some(target_sdtype) = dtype.as_struct() else {
-            vortex_bail!("cannot cast {} to {}", array.dtype(), dtype);
+            return Ok(None);
         };
 
         let source_sdtype = array
@@ -41,7 +41,7 @@ impl CastKernel for StructVTable {
             array.len(),
             validity,
         )
-        .map(|a| a.into_array())
+        .map(|a| Some(a.into_array()))
     }
 }
 

--- a/vortex-array/src/arrays/varbin/compute/cast.rs
+++ b/vortex-array/src/arrays/varbin/compute/cast.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_dtype::DType;
-use vortex_error::{VortexResult, vortex_bail};
+use vortex_error::VortexResult;
 
 use crate::arrays::{VarBinArray, VarBinVTable};
 use crate::compute::{CastKernel, CastKernelAdapter};
@@ -10,21 +10,23 @@ use crate::vtable::ValidityHelper;
 use crate::{ArrayRef, IntoArray, register_kernel};
 
 impl CastKernel for VarBinVTable {
-    fn cast(&self, array: &VarBinArray, dtype: &DType) -> VortexResult<ArrayRef> {
+    fn cast(&self, array: &VarBinArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         if !array.dtype().eq_ignore_nullability(dtype) {
-            vortex_bail!("Cannot cast {} to {}", array.dtype(), dtype);
+            return Ok(None);
         }
 
         let new_nullability = dtype.nullability();
         let new_validity = array.validity().clone().cast_nullability(new_nullability)?;
         let new_dtype = array.dtype().with_nullability(new_nullability);
-        Ok(VarBinArray::try_new(
-            array.offsets().clone(),
-            array.bytes().clone(),
-            new_dtype,
-            new_validity,
-        )?
-        .into_array())
+        Ok(Some(
+            VarBinArray::try_new(
+                array.offsets().clone(),
+                array.bytes().clone(),
+                new_dtype,
+                new_validity,
+            )?
+            .into_array(),
+        ))
     }
 }
 

--- a/vortex-array/src/arrays/varbinview/compute/cast.rs
+++ b/vortex-array/src/arrays/varbinview/compute/cast.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_dtype::DType;
-use vortex_error::{VortexResult, vortex_bail};
+use vortex_error::VortexResult;
 
 use crate::arrays::{VarBinViewArray, VarBinViewVTable};
 use crate::compute::{CastKernel, CastKernelAdapter};
@@ -10,21 +10,23 @@ use crate::vtable::ValidityHelper;
 use crate::{ArrayRef, IntoArray, register_kernel};
 
 impl CastKernel for VarBinViewVTable {
-    fn cast(&self, array: &VarBinViewArray, dtype: &DType) -> VortexResult<ArrayRef> {
+    fn cast(&self, array: &VarBinViewArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         if !array.dtype().eq_ignore_nullability(dtype) {
-            vortex_bail!("Cannot cast {} to {}", array.dtype(), dtype);
+            return Ok(None);
         }
 
         let new_nullability = dtype.nullability();
         let new_validity = array.validity().clone().cast_nullability(new_nullability)?;
         let new_dtype = array.dtype().with_nullability(new_nullability);
-        Ok(VarBinViewArray::try_new(
-            array.views().clone(),
-            array.buffers().to_vec(),
-            new_dtype,
-            new_validity,
-        )?
-        .into_array())
+        Ok(Some(
+            VarBinViewArray::try_new(
+                array.views().clone(),
+                array.buffers().to_vec(),
+                new_dtype,
+                new_validity,
+            )?
+            .into_array(),
+        ))
     }
 }
 

--- a/vortex-array/src/compute/cast.rs
+++ b/vortex-array/src/compute/cast.rs
@@ -63,10 +63,12 @@ impl ComputeFnVTable for Cast {
             array.dtype(),
             dtype
         );
+
         if array.is_canonical() {
             vortex_bail!(
-                "No compute kernel to cast array {} to {}",
+                "No compute kernel to cast array {} with dtype {} to {}",
                 array.encoding_id(),
+                array.dtype(),
                 dtype
             );
         }
@@ -119,7 +121,7 @@ pub struct CastKernelRef(ArcRef<dyn Kernel>);
 inventory::collect!(CastKernelRef);
 
 pub trait CastKernel: VTable {
-    fn cast(&self, array: &Self::Array, dtype: &DType) -> VortexResult<ArrayRef>;
+    fn cast(&self, array: &Self::Array, dtype: &DType) -> VortexResult<Option<ArrayRef>>;
 }
 
 #[derive(Debug)]
@@ -137,6 +139,7 @@ impl<V: VTable + CastKernel> Kernel for CastKernelAdapter<V> {
         let Some(array) = array.as_opt::<V>() else {
             return Ok(None);
         };
-        Ok(Some(V::cast(&self.0, array, dtype)?.into()))
+
+        Ok(V::cast(&self.0, array, dtype)?.map(|o| o.into()))
     }
 }


### PR DESCRIPTION
I think this is the most minimal example of extension array casting that's easy and safe to execute? Basically just handles casting within the same extension dtype, changing nullability when appropriate. 

Actually casting the underlying storage array seems dangerous given that we don't know how its actually used.