### PR TITLE
fix: Fuzzer does not generate filter on struct

### DIFF
--- a/vortex-dtype/src/arbitrary.rs
+++ b/vortex-dtype/src/arbitrary.rs
@@ -93,8 +93,8 @@ impl<'a> Arbitrary<'a> for StructFields {
 fn random_struct_dtype(u: &mut Unstructured<'_>, depth: u8) -> Result<StructFields> {
     let field_count = u.choose_index(3)?;
     let names: FieldNames = (0..field_count)
-        .map(|_| FieldName::arbitrary(u))
-        .collect::<Result<FieldNames>>()?;
+        .map(|idx| FieldName::from(format!("field_{idx}")))
+        .collect();
     let dtypes = (0..names.len())
         .map(|_| random_dtype(u, depth))
         .collect::<Result<Vec<_>>>()?;

--- a/vortex-dtype/src/arbitrary.rs
+++ b/vortex-dtype/src/arbitrary.rs
@@ -93,8 +93,8 @@ impl<'a> Arbitrary<'a> for StructFields {
 fn random_struct_dtype(u: &mut Unstructured<'_>, depth: u8) -> Result<StructFields> {
     let field_count = u.choose_index(3)?;
     let names: FieldNames = (0..field_count)
-        .map(|idx| FieldName::from(format!("field_{idx}")))
-        .collect();
+        .map(|_| FieldName::arbitrary(u))
+        .collect::<Result<FieldNames>>()?;
     let dtypes = (0..names.len())
         .map(|_| random_dtype(u, depth))
         .collect::<Result<Vec<_>>>()?;

--- a/vortex-expr/src/arbitrary.rs
+++ b/vortex-expr/src/arbitrary.rs
@@ -34,10 +34,17 @@ pub fn filter_expr(u: &mut Unstructured<'_>, dtype: &DType) -> AResult<Option<Ex
     let filter_count = u.int_in_range::<usize>(0..=max(struct_dtype.nfields(), 10))?;
 
     let filters = (0..filter_count)
-        .map(|_| {
-            let (col, dtype) =
-                u.choose_iter(struct_dtype.names().iter().zip(struct_dtype.fields()))?;
-            random_comparison(u, col, &dtype)
+        .filter_map(|_| {
+            match u.choose_iter(struct_dtype.names().iter().zip(struct_dtype.fields())) {
+                Ok((col, dtype)) => {
+                    if dtype.is_struct() {
+                        None
+                    } else {
+                        Some(random_comparison(u, col, &dtype))
+                    }
+                }
+                Err(e) => Some(Err(e)),
+            }
         })
         .collect::<AResult<Vec<_>>>()?;
 


### PR DESCRIPTION
Fix the fuzzer to not try and generate compare ops for struct fields.
