### PR TITLE
fix: Include size of self in nbytes

### DIFF
--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -280,7 +280,7 @@ impl dyn Array + '_ {
     /// Total size of the array in bytes, including all children and buffers.
     // TODO(ngates): this should return u64
     pub fn nbytes(&self) -> usize {
-        let mut nbytes = 0;
+        let mut nbytes = size_of_val(self);
         for array in self.depth_first_traversal() {
             for buffer in array.buffers() {
                 nbytes += buffer.len();


### PR DESCRIPTION
This is definitely an overestimation but should never be an underestimation. fix #3885 

Signed-off-by: Robert Kruszewski <github@robertk.io>
