### PR TITLE
fix: drop cargo fmt unstable features

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,8 +1,2 @@
-condense_wildcard_suffixes = true
-format_macro_matchers = true
-format_macro_bodies = true
-group_imports = "StdExternalCrate"
-unstable_features = true
 use_field_init_shorthand = true
-imports_granularity = "Module"
 style_edition = "2024"


### PR DESCRIPTION
Running ` cargo fmt --all --check` currently yields the following warnings:
```
Warning: can't set `format_macro_matchers = true`, unstable features are only available in nightly channel.
Warning: can't set `format_macro_bodies = true`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Module`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `condense_wildcard_suffixes = true`, unstable features are only available in nightly channel.
Warning: can't set `unstable_features = true`, unstable features are only available in nightly channel.
```

