### PR TITLE
chore[docs]: deny missing_docs on vortex-scalar, vortex-utils, & vortex-flatbuffers

### DIFF
--- a/vortex-flatbuffers/src/lib.rs
+++ b/vortex-flatbuffers/src/lib.rs
@@ -107,7 +107,7 @@ pub mod footer;
 #[allow(missing_docs)]
 #[rustfmt::skip]
 #[path = "./generated/layout.rs"]
-/// A serialized sequence of arrays, each with its buffers.
+/// Structures describing the physical layout of Vortex arrays in random access storage.
 ///
 /// `layout.fbs`:
 /// ```flatbuffers
@@ -161,12 +161,12 @@ pub trait ReadFlatBuffer: Sized {
     /// The error type returned when reading fails.
     type Error: From<InvalidFlatbuffer>;
 
-    /// Reads this type from a FlatBuffer.
+    /// Reads this type from a FlatBuffer source.
     fn read_flatbuffer<'buf>(
         fb: &<Self::Source<'buf> as Follow<'buf>>::Inner,
     ) -> Result<Self, Self::Error>;
 
-    /// Reads this type from FlatBuffer bytes.
+    /// Reads this type from bytes representing a FlatBuffer source.
     fn read_flatbuffer_bytes<'buf>(bytes: &'buf [u8]) -> Result<Self, Self::Error>
     where
         <Self as ReadFlatBuffer>::Source<'buf>: 'buf,
@@ -181,7 +181,7 @@ pub trait WriteFlatBuffer {
     /// The FlatBuffer type that this type can be written to.
     type Target<'a>;
 
-    /// Writes this type to a FlatBuffer.
+    /// Writes this type to a FlatBuffer builder.
     fn write_flatbuffer<'fb>(
         &self,
         fbb: &mut FlatBufferBuilder<'fb>,
@@ -190,7 +190,7 @@ pub trait WriteFlatBuffer {
 
 /// Extension trait for types that can be written as FlatBuffer root objects.
 pub trait WriteFlatBufferExt: WriteFlatBuffer + FlatBufferRoot {
-    /// Write the flatbuffer into a [`FlatBuffer`].
+    /// Writes self as a FlatBuffer root object into a [`FlatBuffer`] byte buffer.
     fn write_flatbuffer_bytes(&self) -> FlatBuffer;
 }
 

--- a/vortex-flatbuffers/src/lib.rs
+++ b/vortex-flatbuffers/src/lib.rs
@@ -5,6 +5,8 @@
 //!
 //! See the `vortex-file` crate for non-contiguous serialization.
 
+#![deny(missing_docs)]
+
 #[cfg(feature = "array")]
 #[allow(clippy::all)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -21,6 +23,7 @@
 #[allow(unused_imports)]
 #[allow(unused_lifetimes)]
 #[allow(unused_qualifications)]
+#[allow(missing_docs)]
 #[rustfmt::skip]
 #[path = "./generated/array.rs"]
 /// A serialized array without its buffer (i.e. data).
@@ -47,6 +50,7 @@ pub mod array;
 #[allow(unused_imports)]
 #[allow(unused_lifetimes)]
 #[allow(unused_qualifications)]
+#[allow(missing_docs)]
 #[rustfmt::skip]
 #[path = "./generated/dtype.rs"]
 /// A serialized data type.
@@ -73,6 +77,7 @@ pub mod dtype;
 #[allow(unused_imports)]
 #[allow(unused_lifetimes)]
 #[allow(unused_qualifications)]
+#[allow(missing_docs)]
 #[rustfmt::skip]
 #[path = "./generated/footer.rs"]
 /// A file format footer containing a serialized `vortex-file` Layout.
@@ -99,6 +104,7 @@ pub mod footer;
 #[allow(unused_imports)]
 #[allow(unused_lifetimes)]
 #[allow(unused_qualifications)]
+#[allow(missing_docs)]
 #[rustfmt::skip]
 #[path = "./generated/layout.rs"]
 /// A serialized sequence of arrays, each with its buffers.
@@ -125,6 +131,7 @@ pub mod layout;
 #[allow(unused_imports)]
 #[allow(unused_lifetimes)]
 #[allow(unused_qualifications)]
+#[allow(missing_docs)]
 #[rustfmt::skip]
 #[path = "./generated/message.rs"]
 /// A serialized sequence of arrays, each with its buffers.
@@ -144,16 +151,22 @@ use vortex_buffer::{ByteBuffer, ConstByteBuffer};
 /// See: <https://groups.google.com/g/flatbuffers/c/PSgQeWeTx_g>
 pub type FlatBuffer = ConstByteBuffer<8>;
 
+/// Marker trait for types that can be the root of a FlatBuffer.
 pub trait FlatBufferRoot {}
 
+/// Trait for reading a type from a FlatBuffer.
 pub trait ReadFlatBuffer: Sized {
+    /// The FlatBuffer type that this type can be read from.
     type Source<'a>: Verifiable + Follow<'a>;
+    /// The error type returned when reading fails.
     type Error: From<InvalidFlatbuffer>;
 
+    /// Reads this type from a FlatBuffer.
     fn read_flatbuffer<'buf>(
         fb: &<Self::Source<'buf> as Follow<'buf>>::Inner,
     ) -> Result<Self, Self::Error>;
 
+    /// Reads this type from FlatBuffer bytes.
     fn read_flatbuffer_bytes<'buf>(bytes: &'buf [u8]) -> Result<Self, Self::Error>
     where
         <Self as ReadFlatBuffer>::Source<'buf>: 'buf,
@@ -163,15 +176,19 @@ pub trait ReadFlatBuffer: Sized {
     }
 }
 
+/// Trait for writing a type to a FlatBuffer.
 pub trait WriteFlatBuffer {
+    /// The FlatBuffer type that this type can be written to.
     type Target<'a>;
 
+    /// Writes this type to a FlatBuffer.
     fn write_flatbuffer<'fb>(
         &self,
         fbb: &mut FlatBufferBuilder<'fb>,
     ) -> WIPOffset<Self::Target<'fb>>;
 }
 
+/// Extension trait for types that can be written as FlatBuffer root objects.
 pub trait WriteFlatBufferExt: WriteFlatBuffer + FlatBufferRoot {
     /// Write the flatbuffer into a [`FlatBuffer`].
     fn write_flatbuffer_bytes(&self) -> FlatBuffer;

--- a/vortex-scalar/src/arbitrary/decimal.rs
+++ b/vortex-scalar/src/arbitrary/decimal.rs
@@ -11,7 +11,7 @@ use vortex_dtype::{DECIMAL128_MAX_PRECISION, DecimalDType};
 
 use crate::{DecimalValue, InnerScalarValue, ScalarValue, i256};
 
-/// Generate an arbitrary decimal scalar confined to the bounds of
+/// Generate an arbitrary decimal scalar confined to the given bounds of precision and scale.
 pub fn random_decimal(u: &mut Unstructured, decimal_type: &DecimalDType) -> Result<ScalarValue> {
     let precision = decimal_type.precision();
     if precision <= DECIMAL128_MAX_PRECISION {

--- a/vortex-scalar/src/arbitrary/mod.rs
+++ b/vortex-scalar/src/arbitrary/mod.rs
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+//! Arbitrary scalar value generation.
+//!
+//! This module provides functions to generate arbitrary scalar values of various data types.
+//! It is used by the fuzzer to test the correctness of the scalar value implementation.
+
 mod decimal;
 
 use std::iter;
@@ -14,6 +19,7 @@ use vortex_dtype::{DType, PType};
 
 use crate::{InnerScalarValue, PValue, Scalar, ScalarValue};
 
+/// Generate an arbitrary scalar value of the given data type.
 pub fn random_scalar(u: &mut Unstructured, dtype: &DType) -> Result<Scalar> {
     Ok(Scalar::new(dtype.clone(), random_scalar_value(u, dtype)?))
 }

--- a/vortex-scalar/src/bigint/bigcast.rs
+++ b/vortex-scalar/src/bigint/bigcast.rs
@@ -5,7 +5,7 @@ use crate::i256;
 
 /// Checked conversion from one primitive type to another.
 ///
-/// This is meant to mirror the `ToPrimitive` trait from `num-traits` but with awareness of `i256`.
+/// This is meant to extend the `ToPrimitive` trait from `num-traits` with awareness of `i256`.
 pub trait ToPrimitive: num_traits::ToPrimitive {
     /// Converts the value of `self` to an `i256`. If the value cannot be
     /// represented by an `i256`, then `None` is returned.

--- a/vortex-scalar/src/bigint/mod.rs
+++ b/vortex-scalar/src/bigint/mod.rs
@@ -21,9 +21,13 @@ pub struct i256(arrow_buffer::i256);
 
 #[allow(clippy::same_name_method)]
 impl i256 {
+    /// The zero value for i256.
     pub const ZERO: Self = Self(arrow_buffer::i256::ZERO);
+    /// The one value for i256.
     pub const ONE: Self = Self(arrow_buffer::i256::ONE);
+    /// The maximum value for i256.
     pub const MAX: Self = Self(arrow_buffer::i256::MAX);
+    /// The minimum value for i256.
     pub const MIN: Self = Self(arrow_buffer::i256::MIN);
 
     /// Construct a new `i256` from an unsigned `lower` bits and a signed `upper` bits.
@@ -36,6 +40,9 @@ impl i256 {
         Self(arrow_buffer::i256::from_i128(i))
     }
 
+    /// Attempts to convert this i256 to an i128.
+    ///
+    /// Returns None if the value is too large to fit in an i128.
     pub fn maybe_i128(self) -> Option<i128> {
         self.0.to_i128()
     }
@@ -57,10 +64,12 @@ impl i256 {
         self.0.to_parts()
     }
 
+    /// Raises self to the power of `exp`, wrapping around on overflow.
     pub fn wrapping_pow(&self, exp: u32) -> Self {
         Self(self.0.wrapping_pow(exp))
     }
 
+    /// Wrapping (modular) addition. Computes `self + other`, wrapping around at the boundary.
     pub fn wrapping_add(&self, other: Self) -> Self {
         Self(self.0.wrapping_add(other.0))
     }

--- a/vortex-scalar/src/bigint/mod.rs
+++ b/vortex-scalar/src/bigint/mod.rs
@@ -12,7 +12,7 @@ use vortex_error::VortexExpect;
 
 /// Signed 256-bit integer type.
 ///
-/// This one of the physical representations of `DecimalScalar` values and can be safely converted
+/// This is one of the physical representations of `DecimalScalar` values and can be safely converted
 /// back and forth with Arrow's [`i256`][arrow_buffer::i256].
 #[repr(transparent)]
 #[allow(non_camel_case_types)]
@@ -21,13 +21,13 @@ pub struct i256(arrow_buffer::i256);
 
 #[allow(clippy::same_name_method)]
 impl i256 {
-    /// The zero value for i256.
+    /// The zero value for `i256`.
     pub const ZERO: Self = Self(arrow_buffer::i256::ZERO);
-    /// The one value for i256.
+    /// The one value for `i256`.
     pub const ONE: Self = Self(arrow_buffer::i256::ONE);
-    /// The maximum value for i256.
+    /// The maximum value for `i256`.
     pub const MAX: Self = Self(arrow_buffer::i256::MAX);
-    /// The minimum value for i256.
+    /// The minimum value for `i256`.
     pub const MIN: Self = Self(arrow_buffer::i256::MIN);
 
     /// Construct a new `i256` from an unsigned `lower` bits and a signed `upper` bits.
@@ -47,14 +47,14 @@ impl i256 {
         self.0.to_i128()
     }
 
-    /// Create an integer value from its representation as a byte array in little-endian.
+    /// Create an integer value from its little-endian byte array representation.
     pub const fn from_le_bytes(bytes: [u8; 32]) -> Self {
         Self(arrow_buffer::i256::from_le_bytes(bytes))
     }
 
     /// Split the 256-bit signed integer value into an unsigned lower bits and a signed upper bits.
     ///
-    /// This versions gives us ownership of the value.
+    /// This version gives us ownership of the value.
     pub const fn into_parts(self) -> (u128, i128) {
         self.0.to_parts()
     }

--- a/vortex-scalar/src/binary.rs
+++ b/vortex-scalar/src/binary.rs
@@ -11,6 +11,10 @@ use vortex_error::{VortexError, VortexExpect as _, VortexResult, vortex_bail, vo
 
 use crate::{InnerScalarValue, Scalar, ScalarValue};
 
+/// A scalar value representing binary data.
+///
+/// This type provides a view into a binary scalar value, which can be either
+/// a valid byte buffer or null.
 #[derive(Debug, Hash)]
 pub struct BinaryScalar<'a> {
     dtype: &'a DType,
@@ -51,6 +55,11 @@ impl Ord for BinaryScalar<'_> {
 }
 
 impl<'a> BinaryScalar<'a> {
+    /// Creates a binary scalar from a data type and scalar value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the data type is not a binary type.
     pub fn from_scalar_value(dtype: &'a DType, value: ScalarValue) -> VortexResult<Self> {
         if !matches!(dtype, DType::Binary(..)) {
             vortex_bail!("Can only construct binary scalar from binary dtype, found {dtype}")
@@ -61,18 +70,20 @@ impl<'a> BinaryScalar<'a> {
         })
     }
 
+    /// Returns the data type of this binary scalar.
     #[inline]
     pub fn dtype(&self) -> &'a DType {
         self.dtype
     }
 
+    /// Returns the binary value as a byte buffer, or None if null.
     pub fn value(&self) -> Option<ByteBuffer> {
         self.value.as_ref().map(|v| v.as_ref().clone())
     }
 
-    /// Construct a value at most `max_length` in size that's greater than ourselves.
+    /// Constructs a value at most `max_length` in size that's greater than this value.
     ///
-    /// Will return None if constructing greater value overflows
+    /// Returns None if constructing a greater value would overflow.
     pub fn upper_bound(self, max_length: usize) -> Option<Self> {
         if let Some(value) = self.value {
             if value.len() > max_length {
@@ -156,6 +167,7 @@ impl<'a> BinaryScalar<'a> {
 }
 
 impl Scalar {
+    /// Creates a new binary scalar from a byte buffer.
     pub fn binary(buffer: impl Into<Arc<ByteBuffer>>, nullability: Nullability) -> Self {
         Self {
             dtype: DType::Binary(nullability),

--- a/vortex-scalar/src/bool.rs
+++ b/vortex-scalar/src/bool.rs
@@ -10,6 +10,10 @@ use vortex_error::{VortexError, VortexExpect as _, VortexResult, vortex_bail, vo
 
 use crate::{InnerScalarValue, Scalar, ScalarValue};
 
+/// A scalar value representing a boolean.
+///
+/// This type provides a view into a boolean scalar value, which can be either
+/// true, false, or null.
 #[derive(Debug, Hash)]
 pub struct BoolScalar<'a> {
     dtype: &'a DType,
@@ -46,11 +50,13 @@ impl Ord for BoolScalar<'_> {
 }
 
 impl<'a> BoolScalar<'a> {
+    /// Returns the data type of this boolean scalar.
     #[inline]
     pub fn dtype(&self) -> &'a DType {
         self.dtype
     }
 
+    /// Returns the boolean value, or None if null.
     pub fn value(&self) -> Option<bool> {
         self.value
     }
@@ -65,6 +71,9 @@ impl<'a> BoolScalar<'a> {
         ))
     }
 
+    /// Returns a new boolean scalar with the inverted value.
+    ///
+    /// Null values remain null.
     pub fn invert(self) -> BoolScalar<'a> {
         BoolScalar {
             dtype: self.dtype,
@@ -72,6 +81,7 @@ impl<'a> BoolScalar<'a> {
         }
     }
 
+    /// Converts this boolean scalar into a general scalar.
     pub fn into_scalar(self) -> Scalar {
         Scalar {
             dtype: self.dtype.clone(),
@@ -84,6 +94,7 @@ impl<'a> BoolScalar<'a> {
 }
 
 impl Scalar {
+    /// Creates a new boolean scalar with the given value and nullability.
     pub fn bool(value: bool, nullability: Nullability) -> Self {
         Self {
             dtype: DType::Bool(nullability),

--- a/vortex-scalar/src/decimal.rs
+++ b/vortex-scalar/src/decimal.rs
@@ -12,6 +12,15 @@ use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_bail};
 use crate::scalar_value::InnerScalarValue;
 use crate::{BigCast, Scalar, ScalarValue, ToPrimitive, i256};
 
+/// Matches over each decimal value variant, binding the inner value to a variable.
+///
+/// # Example
+///
+/// ```ignore
+/// match_each_decimal_value!(value, |v| {
+///     println!("Value: {}", v);
+/// });
+/// ```
 #[macro_export]
 macro_rules! match_each_decimal_value {
     ($self:expr, | $value:ident | $body:block) => {{
@@ -84,21 +93,37 @@ macro_rules! match_each_decimal_value_type {
 #[repr(u8)]
 #[non_exhaustive]
 pub enum DecimalValueType {
+    /// 8-bit decimal value type.
     I8 = 0,
+    /// 16-bit decimal value type.
     I16 = 1,
+    /// 32-bit decimal value type.
     I32 = 2,
+    /// 64-bit decimal value type.
     I64 = 3,
+    /// 128-bit decimal value type.
     I128 = 4,
+    /// 256-bit decimal value type.
     I256 = 5,
 }
 
+/// A decimal value that can be stored in various integer widths.
+///
+/// This enum represents decimal values with different storage sizes,
+/// from 8-bit to 256-bit integers.
 #[derive(Debug, Clone, Copy)]
 pub enum DecimalValue {
+    /// 8-bit signed decimal value.
     I8(i8),
+    /// 16-bit signed decimal value.
     I16(i16),
+    /// 32-bit signed decimal value.
     I32(i32),
+    /// 64-bit signed decimal value.
     I64(i64),
+    /// 128-bit signed decimal value.
     I128(i128),
+    /// 256-bit signed decimal value.
     I256(i256),
 }
 
@@ -158,11 +183,16 @@ impl Hash for DecimalValue {
 }
 
 /// Type of decimal scalar values.
+///
+/// This trait is implemented by native integer types that can be used
+/// to store decimal values.
 pub trait NativeDecimalType:
     Copy + Eq + Ord + Default + Send + Sync + BigCast + Debug + Display + 'static
 {
+    /// The decimal value type corresponding to this native type.
     const VALUES_TYPE: DecimalValueType;
 
+    /// Attempts to convert a decimal value to this native type.
     fn maybe_from(decimal_type: DecimalValue) -> Option<Self>;
 }
 
@@ -246,6 +276,7 @@ impl Display for DecimalValue {
 }
 
 impl Scalar {
+    /// Creates a new decimal scalar with the given value, precision, scale, and nullability.
     pub fn decimal(
         value: DecimalValue,
         decimal_type: DecimalDType,
@@ -258,6 +289,7 @@ impl Scalar {
     }
 }
 
+/// A scalar value representing a decimal number with fixed precision and scale.
 #[derive(Debug, Clone, Copy, Hash)]
 pub struct DecimalScalar<'a> {
     dtype: &'a DType,
@@ -266,6 +298,11 @@ pub struct DecimalScalar<'a> {
 }
 
 impl<'a> DecimalScalar<'a> {
+    /// Creates a new decimal scalar from a data type and scalar value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the data type is not a decimal type.
     pub fn try_new(dtype: &'a DType, value: &ScalarValue) -> VortexResult<Self> {
         let decimal_type = DecimalDType::try_from(dtype)?;
         let value = value.as_decimal()?;
@@ -277,11 +314,13 @@ impl<'a> DecimalScalar<'a> {
         })
     }
 
+    /// Returns the data type of this decimal scalar.
     #[inline]
     pub fn dtype(&self) -> &'a DType {
         self.dtype
     }
 
+    /// Returns the decimal value, or None if null.
     pub fn decimal_value(&self) -> &Option<DecimalValue> {
         &self.value
     }

--- a/vortex-scalar/src/extension.rs
+++ b/vortex-scalar/src/extension.rs
@@ -11,6 +11,9 @@ use vortex_error::{VortexError, VortexResult, vortex_bail};
 
 use crate::{Scalar, ScalarValue};
 
+/// A scalar value representing an extension type.
+///
+/// Extension types allow wrapping a storage type with custom semantics.
 pub struct ExtScalar<'a> {
     ext_dtype: &'a ExtDType,
     value: &'a ScalarValue,
@@ -68,6 +71,11 @@ impl Hash for ExtScalar<'_> {
 }
 
 impl<'a> ExtScalar<'a> {
+    /// Creates a new extension scalar from a data type and scalar value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the data type is not an extension type.
     pub fn try_new(dtype: &'a DType, value: &'a ScalarValue) -> VortexResult<Self> {
         let DType::Extension(ext_dtype) = dtype else {
             vortex_bail!("Expected extension scalar, found {}", dtype)
@@ -81,6 +89,7 @@ impl<'a> ExtScalar<'a> {
         Scalar::new(self.ext_dtype.storage_dtype().clone(), self.value.clone())
     }
 
+    /// Returns the extension data type.
     pub fn ext_dtype(&self) -> &'a ExtDType {
         self.ext_dtype
     }
@@ -124,6 +133,7 @@ impl<'a> TryFrom<&'a Scalar> for ExtScalar<'a> {
 }
 
 impl Scalar {
+    /// Creates a new extension scalar wrapping the given storage value.
     pub fn extension(ext_dtype: Arc<ExtDType>, value: Scalar) -> Self {
         // TODO(joe): enable once we use rust duckdb
         // assert_eq!(ext_dtype.storage_dtype(), value.dtype());

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -1,6 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+//! Scalar values and types for the Vortex system.
+//!
+//! This crate provides scalar types and values that can be used to represent individual
+//! data elements in the Vortex array system. Scalars are composed of a logical data type
+//! ([`DType`]) and a value ([`ScalarValue`]).
+
+#![deny(missing_docs)]
+
 use std::cmp::Ordering;
 use std::hash::Hash;
 use std::sync::Arc;
@@ -56,38 +64,50 @@ pub struct Scalar {
 }
 
 impl Scalar {
+    /// Creates a new scalar with the given data type and value.
     pub fn new(dtype: DType, value: ScalarValue) -> Self {
         Self { dtype, value }
     }
 
+    /// Returns a reference to the scalar's data type.
     #[inline]
     pub fn dtype(&self) -> &DType {
         &self.dtype
     }
 
+    /// Returns a reference to the scalar's underlying value.
     #[inline]
     pub fn value(&self) -> &ScalarValue {
         &self.value
     }
 
+    /// Consumes the scalar and returns its data type and value as a tuple.
     #[inline]
     pub fn into_parts(self) -> (DType, ScalarValue) {
         (self.dtype, self.value)
     }
 
+    /// Consumes the scalar and returns its underlying value.
     #[inline]
     pub fn into_value(self) -> ScalarValue {
         self.value
     }
 
+    /// Returns true if the scalar is not null.
     pub fn is_valid(&self) -> bool {
         !self.value.is_null()
     }
 
+    /// Returns true if the scalar is null.
     pub fn is_null(&self) -> bool {
         self.value.is_null()
     }
 
+    /// Creates a null scalar with the given nullable data type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the data type is not nullable.
     pub fn null(dtype: DType) -> Self {
         assert!(
             dtype.is_nullable(),
@@ -99,6 +119,9 @@ impl Scalar {
         }
     }
 
+    /// Creates a null scalar for the given scalar type.
+    ///
+    /// The resulting scalar will have a nullable version of the type's data type.
     pub fn null_typed<T: ScalarType>() -> Self {
         Self {
             dtype: T::dtype().as_nullable(),
@@ -106,6 +129,10 @@ impl Scalar {
         }
     }
 
+    /// Casts the scalar to the target data type.
+    ///
+    /// Returns an error if the cast is not supported or if the value cannot be represented
+    /// in the target type.
     pub fn cast(&self, target: &DType) -> VortexResult<Self> {
         if let DType::Extension(ext_dtype) = target {
             let storage_scalar = self.cast_to_non_extension(ext_dtype.storage_dtype())?;
@@ -142,6 +169,7 @@ impl Scalar {
         }
     }
 
+    /// Converts the scalar to have a nullable version of its data type.
     pub fn into_nullable(self) -> Self {
         Self {
             dtype: self.dtype.as_nullable(),
@@ -149,7 +177,7 @@ impl Scalar {
         }
     }
 
-    /// Size of the scalar in bytes, uncompressed.
+    /// Returns the size of the scalar in bytes, uncompressed.
     pub fn nbytes(&self) -> usize {
         match self.dtype() {
             DType::Null => 0,
@@ -182,7 +210,10 @@ impl Scalar {
         }
     }
 
-    /// Create a "default" scalar value for the given data type.
+    /// Creates a "default" scalar value for the given data type.
+    ///
+    /// For nullable types, returns null. For non-nullable types, returns
+    /// an appropriate zero/empty value.
     pub fn default_value(dtype: DType) -> Self {
         if dtype.is_nullable() {
             return Self::null(dtype);
@@ -213,66 +244,114 @@ impl Scalar {
 }
 
 impl Scalar {
+    /// Returns a view of the scalar as a boolean scalar.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the scalar is not a boolean type.
     pub fn as_bool(&self) -> BoolScalar<'_> {
         BoolScalar::try_from(self).vortex_expect("Failed to convert scalar to bool")
     }
 
+    /// Returns a view of the scalar as a boolean scalar if it has a boolean type.
     pub fn as_bool_opt(&self) -> Option<BoolScalar<'_>> {
         matches!(self.dtype, DType::Bool(..)).then(|| self.as_bool())
     }
 
+    /// Returns a view of the scalar as a primitive scalar.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the scalar is not a primitive type.
     pub fn as_primitive(&self) -> PrimitiveScalar<'_> {
         PrimitiveScalar::try_from(self).vortex_expect("Failed to convert scalar to primitive")
     }
 
+    /// Returns a view of the scalar as a primitive scalar if it has a primitive type.
     pub fn as_primitive_opt(&self) -> Option<PrimitiveScalar<'_>> {
         matches!(self.dtype, DType::Primitive(..)).then(|| self.as_primitive())
     }
 
+    /// Returns a view of the scalar as a decimal scalar.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the scalar is not a decimal type.
     pub fn as_decimal(&self) -> DecimalScalar<'_> {
         DecimalScalar::try_from(self).vortex_expect("Failed to convert scalar to decimal")
     }
 
+    /// Returns a view of the scalar as a decimal scalar if it has a decimal type.
     pub fn as_decimal_opt(&self) -> Option<DecimalScalar<'_>> {
         matches!(self.dtype, DType::Decimal(..)).then(|| self.as_decimal())
     }
 
+    /// Returns a view of the scalar as a UTF-8 string scalar.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the scalar is not a UTF-8 type.
     pub fn as_utf8(&self) -> Utf8Scalar<'_> {
         Utf8Scalar::try_from(self).vortex_expect("Failed to convert scalar to utf8")
     }
 
+    /// Returns a view of the scalar as a UTF-8 string scalar if it has a UTF-8 type.
     pub fn as_utf8_opt(&self) -> Option<Utf8Scalar<'_>> {
         matches!(self.dtype, DType::Utf8(..)).then(|| self.as_utf8())
     }
 
+    /// Returns a view of the scalar as a binary scalar.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the scalar is not a binary type.
     pub fn as_binary(&self) -> BinaryScalar<'_> {
         BinaryScalar::try_from(self).vortex_expect("Failed to convert scalar to binary")
     }
 
+    /// Returns a view of the scalar as a binary scalar if it has a binary type.
     pub fn as_binary_opt(&self) -> Option<BinaryScalar<'_>> {
         matches!(self.dtype, DType::Binary(..)).then(|| self.as_binary())
     }
 
+    /// Returns a view of the scalar as a struct scalar.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the scalar is not a struct type.
     pub fn as_struct(&self) -> StructScalar<'_> {
         StructScalar::try_from(self).vortex_expect("Failed to convert scalar to struct")
     }
 
+    /// Returns a view of the scalar as a struct scalar if it has a struct type.
     pub fn as_struct_opt(&self) -> Option<StructScalar<'_>> {
         matches!(self.dtype, DType::Struct(..)).then(|| self.as_struct())
     }
 
+    /// Returns a view of the scalar as a list scalar.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the scalar is not a list type.
     pub fn as_list(&self) -> ListScalar<'_> {
         ListScalar::try_from(self).vortex_expect("Failed to convert scalar to list")
     }
 
+    /// Returns a view of the scalar as a list scalar if it has a list type.
     pub fn as_list_opt(&self) -> Option<ListScalar<'_>> {
         matches!(self.dtype, DType::List(..)).then(|| self.as_list())
     }
 
+    /// Returns a view of the scalar as an extension scalar.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the scalar is not an extension type.
     pub fn as_extension(&self) -> ExtScalar<'_> {
         ExtScalar::try_from(self).vortex_expect("Failed to convert scalar to extension")
     }
 
+    /// Returns a view of the scalar as an extension scalar if it has an extension type.
     pub fn as_extension_opt(&self) -> Option<ExtScalar<'_>> {
         matches!(self.dtype, DType::Extension(..)).then(|| self.as_extension())
     }

--- a/vortex-scalar/src/list.rs
+++ b/vortex-scalar/src/list.rs
@@ -14,6 +14,10 @@ use vortex_error::{
 
 use crate::{InnerScalarValue, Scalar, ScalarValue};
 
+/// A scalar value representing a list (array) of elements.
+///
+/// This type provides a view into a list scalar value, which can contain
+/// zero or more elements of the same type, or be null.
 pub struct ListScalar<'a> {
     dtype: &'a DType,
     element_dtype: &'a Arc<DType>,
@@ -67,16 +71,21 @@ impl Hash for ListScalar<'_> {
 }
 
 impl<'a> ListScalar<'a> {
+    /// Returns the data type of this list scalar.
     #[inline]
     pub fn dtype(&self) -> &'a DType {
         self.dtype
     }
 
+    /// Returns the number of elements in the list.
+    ///
+    /// Returns 0 if the list is null.
     #[inline]
     pub fn len(&self) -> usize {
         self.elements.as_ref().map(|e| e.len()).unwrap_or(0)
     }
 
+    /// Returns true if the list has no elements or is null.
     #[inline]
     pub fn is_empty(&self) -> bool {
         match self.elements.as_ref() {
@@ -85,11 +94,13 @@ impl<'a> ListScalar<'a> {
         }
     }
 
+    /// Returns true if the list is null.
     #[inline]
     pub fn is_null(&self) -> bool {
         self.elements.is_none()
     }
 
+    /// Returns the data type of the list's elements.
     pub fn element_dtype(&self) -> &DType {
         let DType::List(element_type, _) = self.dtype() else {
             unreachable!();
@@ -97,6 +108,9 @@ impl<'a> ListScalar<'a> {
         (*element_type).deref()
     }
 
+    /// Returns the element at the given index as a scalar.
+    ///
+    /// Returns None if the list is null or the index is out of bounds.
     pub fn element(&self, idx: usize) -> Option<Scalar> {
         self.elements
             .as_ref()
@@ -107,6 +121,9 @@ impl<'a> ListScalar<'a> {
             })
     }
 
+    /// Returns all elements in the list as a vector of scalars.
+    ///
+    /// Returns None if the list is null.
     pub fn elements(&self) -> Option<Vec<Scalar>> {
         self.elements.as_ref().map(|elems| {
             elems
@@ -140,6 +157,11 @@ impl<'a> ListScalar<'a> {
 }
 
 impl Scalar {
+    /// Creates a new list scalar with the given element type and children.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any child scalar has a different type than the element type.
     pub fn list(
         element_dtype: Arc<DType>,
         children: Vec<Scalar>,
@@ -162,6 +184,7 @@ impl Scalar {
         }
     }
 
+    /// Creates a new empty list scalar with the given element type.
     pub fn list_empty(element_dtype: Arc<DType>, nullability: Nullability) -> Self {
         Self {
             dtype: DType::List(element_dtype, nullability),

--- a/vortex-scalar/src/primitive.rs
+++ b/vortex-scalar/src/primitive.rs
@@ -16,6 +16,10 @@ use vortex_error::{
 use crate::pvalue::PValue;
 use crate::{InnerScalarValue, Scalar, ScalarValue};
 
+/// A scalar value representing a primitive type.
+///
+/// This type provides a view into a primitive scalar value of any primitive type
+/// (integers, floats) with various bit widths.
 #[derive(Debug, Clone, Copy, Hash)]
 pub struct PrimitiveScalar<'a> {
     dtype: &'a DType,
@@ -51,6 +55,12 @@ impl PartialOrd for PrimitiveScalar<'_> {
 }
 
 impl<'a> PrimitiveScalar<'a> {
+    /// Creates a new primitive scalar from a data type and scalar value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the data type is not a primitive type or if the value
+    /// cannot be converted to the expected primitive type.
     pub fn try_new(dtype: &'a DType, value: &ScalarValue) -> VortexResult<Self> {
         let ptype = PType::try_from(dtype)?;
 
@@ -71,21 +81,29 @@ impl<'a> PrimitiveScalar<'a> {
         })
     }
 
+    /// Returns the data type of this primitive scalar.
     #[inline]
     pub fn dtype(&self) -> &'a DType {
         self.dtype
     }
 
+    /// Returns the primitive type of this scalar.
     #[inline]
     pub fn ptype(&self) -> PType {
         self.ptype
     }
 
+    /// Returns the primitive value, or None if null.
     #[inline]
     pub fn pvalue(&self) -> Option<PValue> {
         self.pvalue
     }
 
+    /// Returns the value as a specific native primitive type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the primitive type of this scalar does not match the requested type.
     pub fn typed_value<T: NativePType + TryFrom<PValue, Error = VortexError>>(&self) -> Option<T> {
         assert_eq!(
             self.ptype,
@@ -119,8 +137,11 @@ impl<'a> PrimitiveScalar<'a> {
         }))
     }
 
-    /// Attempt to extract the primitive value as the given type.
-    /// Fails on a bad cast.
+    /// Attempts to extract the primitive value as the given type.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the cast fails due to overflow or type incompatibility.
     pub fn as_<T: FromPrimitiveOrF16>(&self) -> VortexResult<Option<T>> {
         match self.pvalue {
             None => Ok(None),
@@ -152,7 +173,11 @@ impl<'a> PrimitiveScalar<'a> {
     }
 }
 
+/// A trait for types that can be created from primitive values, including f16.
+///
+/// This extends the `FromPrimitive` trait to also support conversion from f16 values.
 pub trait FromPrimitiveOrF16: FromPrimitive {
+    /// Converts an f16 value to this type, returning None if the conversion fails.
     fn from_f16(v: f16) -> Option<Self>;
 }
 
@@ -233,6 +258,7 @@ impl CheckedAdd for PrimitiveScalar<'_> {
 }
 
 impl Scalar {
+    /// Creates a new primitive scalar from a native value.
     pub fn primitive<T: NativePType + Into<PValue>>(value: T, nullability: Nullability) -> Self {
         Self::primitive_value(value.into(), T::PTYPE, nullability)
     }
@@ -248,6 +274,11 @@ impl Scalar {
         }
     }
 
+    /// Reinterprets the bytes of this scalar as a different primitive type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the scalar is not a primitive type or if the types have different byte widths.
     pub fn reinterpret_cast(&self, ptype: PType) -> Self {
         let primitive = PrimitiveScalar::try_from(self).unwrap_or_else(|e| {
             vortex_panic!(e, "Failed to reinterpret cast {} to {}", self.dtype, ptype)
@@ -391,6 +422,7 @@ impl Display for NumericOperator {
 }
 
 impl NumericOperator {
+    /// Returns the operator with swapped operands (e.g., Sub becomes RSub).
     pub fn swap(self) -> Self {
         match self {
             NumericOperator::Add => NumericOperator::Add,

--- a/vortex-scalar/src/pvalue.rs
+++ b/vortex-scalar/src/pvalue.rs
@@ -11,18 +11,33 @@ use vortex_dtype::half::f16;
 use vortex_dtype::{NativePType, PType, ToBytes};
 use vortex_error::{VortexError, VortexExpect, vortex_err};
 
+/// A primitive value that can represent any primitive type supported by Vortex.
+///
+/// `PValue` is used to store primitive scalar values in a type-erased manner,
+/// supporting all primitive types (integers, floats) with various bit widths.
 #[derive(Debug, Clone, Copy)]
 pub enum PValue {
+    /// Unsigned 8-bit integer.
     U8(u8),
+    /// Unsigned 16-bit integer.
     U16(u16),
+    /// Unsigned 32-bit integer.
     U32(u32),
+    /// Unsigned 64-bit integer.
     U64(u64),
+    /// Signed 8-bit integer.
     I8(i8),
+    /// Signed 16-bit integer.
     I16(i16),
+    /// Signed 32-bit integer.
     I32(i32),
+    /// Signed 64-bit integer.
     I64(i64),
+    /// 16-bit floating point.
     F16(f16),
+    /// 32-bit floating point.
     F32(f32),
+    /// 64-bit floating point.
     F64(f64),
 }
 
@@ -124,6 +139,7 @@ macro_rules! as_primitive {
 }
 
 impl PValue {
+    /// Creates a zero value for the given primitive type.
     pub fn zero(ptype: PType) -> PValue {
         match ptype {
             PType::U8 => PValue::U8(0),
@@ -140,6 +156,7 @@ impl PValue {
         }
     }
 
+    /// Returns the primitive type of this value.
     pub fn ptype(&self) -> PType {
         match self {
             Self::U8(_) => PType::U8,
@@ -156,10 +173,14 @@ impl PValue {
         }
     }
 
+    /// Returns true if this value is of the given primitive type.
     pub fn is_instance_of(&self, ptype: &PType) -> bool {
         &self.ptype() == ptype
     }
 
+    /// Converts this value to a specific native primitive type.
+    ///
+    /// Returns an error if the conversion is not supported or would overflow.
     #[inline]
     pub fn as_primitive<T: NativePType + TryFrom<PValue, Error = VortexError>>(
         &self,
@@ -167,6 +188,13 @@ impl PValue {
         T::try_from(*self)
     }
 
+    /// Reinterprets the bits of this value as a different primitive type.
+    ///
+    /// This performs a bitwise cast between types of the same width.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the target type has a different byte width than this value.
     pub fn reinterpret_cast(&self, ptype: PType) -> Self {
         if ptype == self.ptype() {
             return *self;

--- a/vortex-scalar/src/scalar_type.rs
+++ b/vortex-scalar/src/scalar_type.rs
@@ -7,7 +7,12 @@ use vortex_buffer::{BufferString, ByteBuffer};
 use vortex_dtype::half::f16;
 use vortex_dtype::{DType, NativePType, Nullability, PType};
 
+/// A trait for types that can be used as scalar values.
+///
+/// This trait is implemented by native Rust types that can be converted
+/// to and from Vortex scalar values.
 pub trait ScalarType {
+    /// Returns the Vortex data type for this scalar type.
     fn dtype() -> DType;
 }
 

--- a/vortex-scalar/src/scalar_value/mod.rs
+++ b/vortex-scalar/src/scalar_value/mod.rs
@@ -23,12 +23,12 @@ use crate::decimal::DecimalValue;
 use crate::pvalue::PValue;
 use crate::{ScalarType, i256};
 
-/// Represents the internal data of a scalar value. Must be interpreted by wrapping
-/// up with a DType to make a Scalar.
+/// Represents the internal data of a scalar value. Must be interpreted by wrapping up with a
+/// [`DType`] to make a [`super::Scalar`].
 ///
-/// Note that these values can be deserialized from JSON or other formats. So a PValue may not
-/// have the correct width for what the DType expects. Primitive values should therefore be
-/// read using [crate::PrimitiveScalar] which will handle the conversion.
+/// Note that these values can be deserialized from JSON or other formats. So a [`PValue`] may not
+/// have the correct width for what the [`DType`] expects. Primitive values should therefore be
+/// read using [`super::PrimitiveScalar`] which will handle the conversion.
 #[derive(Debug, Clone)]
 pub struct ScalarValue(pub(crate) InnerScalarValue);
 

--- a/vortex-scalar/src/scalar_value/mod.rs
+++ b/vortex-scalar/src/scalar_value/mod.rs
@@ -44,6 +44,7 @@ pub(crate) enum InnerScalarValue {
 }
 
 impl ScalarValue {
+    /// Serializes the scalar value to Protocol Buffers format.
     pub fn to_protobytes<B: BufMut + Default>(&self) -> B {
         let pb_scalar = pb::ScalarValue::from(self);
 
@@ -55,6 +56,7 @@ impl ScalarValue {
         buf
     }
 
+    /// Deserializes a scalar value from Protocol Buffers format.
     pub fn from_protobytes(buf: &[u8]) -> VortexResult<Self> {
         ScalarValue::try_from(
             &pb::ScalarValue::decode(buf)
@@ -116,14 +118,17 @@ impl Display for InnerScalarValue {
 }
 
 impl ScalarValue {
+    /// Creates a null scalar value.
     pub const fn null() -> Self {
         ScalarValue(InnerScalarValue::Null)
     }
 
+    /// Returns true if this is a null value.
     pub fn is_null(&self) -> bool {
         self.0.is_null()
     }
 
+    /// Returns true if this value is compatible with the given data type.
     pub fn is_instance_of(&self, dtype: &DType) -> bool {
         self.0.is_instance_of(dtype)
     }

--- a/vortex-scalar/src/struct_.rs
+++ b/vortex-scalar/src/struct_.rs
@@ -12,6 +12,10 @@ use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_bail, vortex_
 
 use crate::{InnerScalarValue, Scalar, ScalarValue};
 
+/// A scalar value representing a struct with named fields.
+///
+/// This type provides a view into a struct scalar value, which can contain
+/// named fields with different types, or be null.
 pub struct StructScalar<'a> {
     dtype: &'a DType,
     fields: Option<&'a Arc<[ScalarValue]>>,
@@ -79,11 +83,13 @@ impl<'a> StructScalar<'a> {
         })
     }
 
+    /// Returns the data type of this struct scalar.
     #[inline]
     pub fn dtype(&self) -> &'a DType {
         self.dtype
     }
 
+    /// Returns the struct field definitions.
     #[inline]
     pub fn struct_fields(&self) -> &StructFields {
         self.dtype
@@ -91,19 +97,31 @@ impl<'a> StructScalar<'a> {
             .vortex_expect("StructScalar always has struct dtype")
     }
 
+    /// Returns the field names of the struct.
     pub fn names(&self) -> &FieldNames {
         self.struct_fields().names()
     }
 
+    /// Returns true if the struct is null.
     pub fn is_null(&self) -> bool {
         self.fields.is_none()
     }
 
+    /// Returns the field with the given name as a scalar.
+    ///
+    /// Returns None if the field doesn't exist.
     pub fn field(&self, name: impl AsRef<str>) -> Option<Scalar> {
         let idx = self.struct_fields().find(name)?;
         self.field_by_idx(idx)
     }
 
+    /// Returns the field at the given index as a scalar.
+    ///
+    /// Returns None if the index is out of bounds.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the struct is null.
     pub fn field_by_idx(&self, idx: usize) -> Option<Scalar> {
         let fields = self
             .fields
@@ -131,6 +149,11 @@ impl<'a> StructScalar<'a> {
         self.fields.map(Arc::deref)
     }
 
+    /// Casts this struct scalar to another struct type.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the target type is not a struct or if the number of fields don't match.
     pub fn cast(&self, dtype: &DType) -> VortexResult<Scalar> {
         let DType::Struct(st, _) = dtype else {
             vortex_bail!("Can only cast struct to another struct")
@@ -172,6 +195,11 @@ impl<'a> StructScalar<'a> {
         }
     }
 
+    /// Projects this struct scalar to include only the specified fields.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the struct cannot be projected or if a field is not found.
     pub fn project(&self, projection: &[FieldName]) -> VortexResult<Scalar> {
         let struct_dtype = self
             .dtype
@@ -201,6 +229,7 @@ impl<'a> StructScalar<'a> {
 }
 
 impl Scalar {
+    /// Creates a new struct scalar with the given fields.
     pub fn struct_(dtype: DType, children: Vec<Scalar>) -> Self {
         Self {
             dtype,

--- a/vortex-scalar/src/utf8.rs
+++ b/vortex-scalar/src/utf8.rs
@@ -11,6 +11,10 @@ use vortex_error::{VortexError, VortexExpect as _, VortexResult, vortex_bail, vo
 
 use crate::{InnerScalarValue, Scalar, ScalarValue};
 
+/// A scalar value representing a UTF-8 encoded string.
+///
+/// This type provides a view into a UTF-8 string scalar value, which can be either
+/// a valid UTF-8 string or null.
 #[derive(Debug, Hash)]
 pub struct Utf8Scalar<'a> {
     dtype: &'a DType,
@@ -47,6 +51,11 @@ impl Ord for Utf8Scalar<'_> {
 }
 
 impl<'a> Utf8Scalar<'a> {
+    /// Creates a UTF-8 scalar from a data type and scalar value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the data type is not a UTF-8 type.
     pub fn from_scalar_value(dtype: &'a DType, value: ScalarValue) -> VortexResult<Self> {
         if !matches!(dtype, DType::Utf8(..)) {
             vortex_bail!("Can only construct utf8 scalar from utf8 dtype, found {dtype}")
@@ -57,18 +66,20 @@ impl<'a> Utf8Scalar<'a> {
         })
     }
 
+    /// Returns the data type of this UTF-8 scalar.
     #[inline]
     pub fn dtype(&self) -> &'a DType {
         self.dtype
     }
 
+    /// Returns the string value, or None if null.
     pub fn value(&self) -> Option<BufferString> {
         self.value.as_ref().map(|v| v.as_ref().clone())
     }
 
-    /// Construct a value at most `max_length` in size that's greater than ourselves.
+    /// Constructs a value at most `max_length` in size that's greater than this value.
     ///
-    /// Will return None if constructing greater value overflows
+    /// Returns None if constructing a greater value would overflow.
     pub fn upper_bound(self, max_length: usize) -> Option<Self> {
         if let Some(value) = self.value {
             if value.len() > max_length {
@@ -172,6 +183,11 @@ impl<'a> Utf8Scalar<'a> {
 }
 
 impl Scalar {
+    /// Creates a new UTF-8 scalar from a string-like value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the input cannot be converted to a valid UTF-8 string.
     pub fn utf8<B>(str: B, nullability: Nullability) -> Self
     where
         B: Into<BufferString>,
@@ -179,6 +195,11 @@ impl Scalar {
         Self::try_utf8(str, nullability).unwrap()
     }
 
+    /// Tries to create a new UTF-8 scalar from a string-like value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the input cannot be converted to a valid UTF-8 string.
     pub fn try_utf8<B>(
         str: B,
         nullability: Nullability,

--- a/vortex-utils/src/aliases/hash_map.rs
+++ b/vortex-utils/src/aliases/hash_map.rs
@@ -1,10 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+/// The default hash builder for HashMap.
 pub type DefaultHashBuilder = hashbrown::DefaultHashBuilder;
+/// Random state for HashMap (alias for DefaultHashBuilder).
 pub type RandomState = hashbrown::DefaultHashBuilder;
+/// HashMap type alias using the default hash builder.
 pub type HashMap<K, V, S = DefaultHashBuilder> = hashbrown::HashMap<K, V, S>;
+/// Entry type for HashMap.
 pub type Entry<'a, K, V, S> = hashbrown::hash_map::Entry<'a, K, V, S>;
+/// IntoIter type for HashMap.
 pub type IntoIter<K, V> = hashbrown::hash_map::IntoIter<K, V>;
+/// HashTable type alias.
 pub type HashTable<T> = hashbrown::HashTable<T>;
+/// Entry type for HashTable.
 pub type HashTableEntry<'a, T> = hashbrown::hash_table::Entry<'a, T>;

--- a/vortex-utils/src/aliases/hash_set.rs
+++ b/vortex-utils/src/aliases/hash_set.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+/// HashSet type alias using the default hash builder.
 pub type HashSet<V, S = super::DefaultHashBuilder> = hashbrown::HashSet<V, S>;
+/// Entry type for HashSet.
 pub type Entry<'a, V, S> = hashbrown::hash_set::Entry<'a, V, S>;
+/// IntoIter type for HashSet.
 pub type IntoIter<V> = hashbrown::hash_set::IntoIter<V>;

--- a/vortex-utils/src/aliases/mod.rs
+++ b/vortex-utils/src/aliases/mod.rs
@@ -6,7 +6,10 @@
 //! The HashMap/Set should be preferred over the standard library variants or other alternatives.
 //! Currently defers to the excellent [hashbrown](https://docs.rs/hashbrown/latest/hashbrown/) crate.
 
+/// HashMap type aliases and re-exports.
 pub mod hash_map;
+/// HashSet type aliases and re-exports.
 pub mod hash_set;
 
+/// The default hash builder used by HashMap and HashSet.
 pub use hashbrown::DefaultHashBuilder;

--- a/vortex-utils/src/lib.rs
+++ b/vortex-utils/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Utility types and functions for the Vortex system.
+//! Utility types and functions to be shared amongst the Vortex crates.
 
 #![deny(missing_docs)]
 

--- a/vortex-utils/src/lib.rs
+++ b/vortex-utils/src/lib.rs
@@ -1,4 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+//! Utility types and functions for the Vortex system.
+
+#![deny(missing_docs)]
+
 pub mod aliases;


### PR DESCRIPTION
I gave the following prompt to Claude Code:

> Our goal is to write high quality docstrings in idiomatic Rust style. We would like to enforce this for certain crates, by applying the `#![deny(missing_docs)]` directive to those crates. Please apply that directive and then write docstrings for all of the public methods and structs in the indicated crates. For now, let's start by working on the vortex-scalar, vortex-utils, and vortex-flatbuffers crates.

I then skimmed the changes in GH, made some minor revisions with help from Cursor. AI is taking our jobs?