### PR TITLE
feat: impl optimize for more arrays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,8 +242,10 @@ jobs:
         with:
           submodules: "recursive"
       - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: nightly
       - name: Rust Lint - Format
-        run: cargo fmt --all --check
+        run: cargo +nightly fmt --all --check
       - name: Rustc check
         run: cargo check --locked --all-features --all-targets
       - name: Rust Lint - Clippy All Features

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -79,6 +79,8 @@ jobs:
         with:
           submodules: "recursive"
       - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: nightly
       - name: Install cargo fuzz
         run: cargo install --locked cargo-fuzz
       - name: Restore corpus
@@ -93,7 +95,7 @@ jobs:
           AWS_ENDPOINT_URL: 'https://01e9655179bbec953276890b183039bc.r2.cloudflarestorage.com'
       - name: Run fuzzing target
         id: fuzz
-        run: RUST_BACKTRACE=1 cargo fuzz run array_ops -j "$(nproc)" -- -max_total_time=7200
+        run: RUST_BACKTRACE=1 cargo +nightly fuzz run array_ops -j "$(nproc)" -- -max_total_time=7200
         continue-on-error: true
       - name: Archive crash artifacts
         uses: actions/upload-artifact@v4

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -4,13 +4,14 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::expect_used)]
 
-use clap::ValueEnum;
-use itertools::Itertools;
-use serde::Serialize;
 use std::clone::Clone;
 use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
+
+use clap::ValueEnum;
+use itertools::Itertools;
+use serde::Serialize;
 
 pub mod bench_run;
 pub mod benchmark_driver;

--- a/encodings/runend/src/ops.rs
+++ b/encodings/runend/src/ops.rs
@@ -3,8 +3,10 @@
 
 use vortex_array::arrays::ConstantArray;
 use vortex_array::vtable::OperationsVTable;
-use vortex_array::{Array, ArrayRef, IntoArray};
-use vortex_error::VortexResult;
+use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
+use vortex_buffer::Buffer;
+use vortex_dtype::{NativePType, match_each_native_ptype};
+use vortex_error::{VortexExpect, VortexResult};
 use vortex_scalar::Scalar;
 
 use crate::{RunEndArray, RunEndVTable};
@@ -44,11 +46,34 @@ impl OperationsVTable<RunEndVTable> for RunEndVTable {
     fn scalar_at(array: &RunEndArray, index: usize) -> VortexResult<Scalar> {
         array.values().scalar_at(array.find_physical_index(index)?)
     }
+
+    fn optimize(array: &RunEndArray) -> VortexResult<RunEndArray> {
+        // Only optimize sliced RunEndArray
+        if array.offset() == 0 {
+            return Ok(array.clone());
+        }
+
+        // Renumber the ends to account for the offset.
+        let ends = array.ends().to_primitive()?;
+        let new_ends = match_each_native_ptype!(ends.ptype(), |P| {
+            renumber_ends(ends.as_slice::<P>(), array.offset()).into_array()
+        });
+
+        // The ends final value should be capped at the end of the array instead.
+
+        // New values, sliced properly
+        RunEndArray::with_offset_and_length(new_ends, array.values().clone(), 0, array.len())
+    }
+}
+
+/// Subtract the offset out from all of the ends.
+fn renumber_ends<I: NativePType>(ends: &[I], offset: usize) -> Buffer<I> {
+    let offset = I::from(offset).vortex_expect("offset must fit into index type");
+    ends.iter().map(|&end| end - offset).collect()
 }
 
 #[cfg(test)]
 mod tests {
-
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::{Array, IntoArray, ToCanonical};
     use vortex_buffer::buffer;
@@ -155,5 +180,19 @@ mod tests {
         .scalar_at(11)
         .unwrap();
         assert_eq!(scalar, 5.into());
+    }
+
+    #[test]
+    fn slice_and_optimize() {
+        let original = RunEndArray::encode(
+            buffer![1u32, 1u32, 1u32, 1u32, 2u32, 2u32, 2u32, 2u32].into_array(),
+        )
+        .unwrap();
+
+        let sliced = original.slice(2, 5).unwrap();
+        let optimized = sliced.optimize().unwrap();
+
+        let values = optimized.to_primitive().unwrap();
+        assert_eq!(values.as_slice::<u32>(), &[1u32, 1u32, 2u32]);
     }
 }

--- a/encodings/runend/src/ops.rs
+++ b/encodings/runend/src/ops.rs
@@ -25,6 +25,7 @@ impl OperationsVTable<RunEndVTable> for RunEndVTable {
             (physical_start, physical_stop + 1)
         };
 
+        // If the sliced range contains only a single run, opt to return a ConstantArray.
         if slice_begin + 1 == slice_end {
             let value = array.values().scalar_at(slice_begin)?;
             return Ok(ConstantArray::new(value, new_length).into_array());
@@ -78,7 +79,7 @@ mod tests {
     use vortex_buffer::buffer;
     use vortex_dtype::{DType, Nullability, PType};
 
-    use crate::RunEndArray;
+    use crate::{RunEndArray, RunEndVTable};
 
     #[test]
     fn slice_array() {
@@ -183,13 +184,25 @@ mod tests {
 
     #[test]
     fn slice_and_optimize() {
+        // Encodes as
+        //   ends:   [4, 8]
+        //   values: [1, 2]
         let original = RunEndArray::encode(
             buffer![1u32, 1u32, 1u32, 1u32, 2u32, 2u32, 2u32, 2u32].into_array(),
         )
         .unwrap();
 
+        // After slicing:
+        //   ends:   [4, 8]
+        //   values: [1, 2]
         let sliced = original.slice(2, 5).unwrap();
+
+        // After optimizing:
+        //  ends:   [0, 4]
+        //  values: [1, 2]
         let optimized = sliced.optimize().unwrap();
+
+        assert_eq!(optimized.as_::<RunEndVTable>().offset(), 0);
 
         let values = optimized.to_primitive().unwrap();
         assert_eq!(values.as_slice::<u32>(), &[1u32, 1u32, 2u32]);

--- a/encodings/runend/src/ops.rs
+++ b/encodings/runend/src/ops.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_array::arrays::ConstantArray;
-use vortex_array::vtable::OperationsVTable;
+use vortex_array::arrays::{ConstantArray, PrimitiveArray};
+use vortex_array::vtable::{OperationsVTable, ValidityHelper};
 use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
 use vortex_buffer::Buffer;
 use vortex_dtype::{NativePType, match_each_native_ptype};
@@ -56,10 +56,9 @@ impl OperationsVTable<RunEndVTable> for RunEndVTable {
         // Renumber the ends to account for the offset.
         let ends = array.ends().to_primitive()?;
         let new_ends = match_each_native_ptype!(ends.ptype(), |P| {
-            renumber_ends(ends.as_slice::<P>(), array.offset()).into_array()
+            let buffer = renumber_ends(ends.as_slice::<P>(), array.offset());
+            PrimitiveArray::new(buffer, ends.validity().clone()).into_array()
         });
-
-        // The ends final value should be capped at the end of the array instead.
 
         // New values, sliced properly
         RunEndArray::with_offset_and_length(new_ends, array.values().clone(), 0, array.len())

--- a/encodings/sparse/src/ops.rs
+++ b/encodings/sparse/src/ops.rs
@@ -35,11 +35,16 @@ impl OperationsVTable<SparseVTable> for SparseVTable {
             .get_patched(index)?
             .unwrap_or_else(|| array.fill_scalar().clone()))
     }
+
+    /// Optimize the patches inside of the SparseArray, applying the offset to the indices
+    /// and rebuilding the offset.
+    fn optimize(array: &SparseArray) -> VortexResult<SparseArray> {
+        SparseArray::try_new_from_patches(array.patches().optimize()?, array.fill_scalar().clone())
+    }
 }
 
 #[cfg(test)]
 mod tests {
-
     use vortex_array::{IntoArray, ToCanonical};
     use vortex_buffer::buffer;
 

--- a/vortex-array/src/arrays/chunked/ops.rs
+++ b/vortex-array/src/arrays/chunked/ops.rs
@@ -53,7 +53,10 @@ impl OperationsVTable<ChunkedVTable> for ChunkedVTable {
             .map(|chunk| chunk.optimize())
             .collect::<VortexResult<Vec<_>>>()?;
 
-        ChunkedArray::try_new(optimized_chunks, array.dtype().clone())
+        Ok(ChunkedArray::new_unchecked(
+            optimized_chunks,
+            array.dtype().clone(),
+        ))
     }
 }
 

--- a/vortex-array/src/arrays/chunked/ops.rs
+++ b/vortex-array/src/arrays/chunked/ops.rs
@@ -45,6 +45,16 @@ impl OperationsVTable<ChunkedVTable> for ChunkedVTable {
         let (chunk_index, chunk_offset) = array.find_chunk_idx(index);
         array.chunk(chunk_index)?.scalar_at(chunk_offset)
     }
+
+    fn optimize(array: &ChunkedArray) -> VortexResult<ChunkedArray> {
+        let optimized_chunks = array
+            .chunks()
+            .iter()
+            .map(|chunk| chunk.optimize())
+            .collect::<VortexResult<Vec<_>>>()?;
+
+        ChunkedArray::try_new(optimized_chunks, array.dtype().clone())
+    }
 }
 
 #[cfg(test)]

--- a/vortex-array/src/arrays/list/mod.rs
+++ b/vortex-array/src/arrays/list/mod.rs
@@ -47,6 +47,7 @@ impl VTable for ListVTable {
     }
 }
 
+/// The canonical array for List type data. This is modeled similarly to a ListArray.
 #[derive(Clone, Debug)]
 pub struct ListArray {
     dtype: DType,
@@ -168,6 +169,15 @@ impl OperationsVTable<ListVTable> for ListVTable {
             scalars,
             array.dtype().nullability(),
         ))
+    }
+
+    /// Implements the optimization operation by pushing it down into the children.
+    fn optimize(array: &ListArray) -> VortexResult<ListArray> {
+        ListArray::try_new(
+            array.offsets().optimize()?,
+            array.elements().optimize()?,
+            array.validity().optimize()?,
+        )
     }
 }
 

--- a/vortex-array/src/arrays/list/mod.rs
+++ b/vortex-array/src/arrays/list/mod.rs
@@ -174,8 +174,8 @@ impl OperationsVTable<ListVTable> for ListVTable {
     /// Implements the optimization operation by pushing it down into the children.
     fn optimize(array: &ListArray) -> VortexResult<ListArray> {
         ListArray::try_new(
-            array.offsets().optimize()?,
             array.elements().optimize()?,
+            array.offsets().optimize()?,
             array.validity().optimize()?,
         )
     }

--- a/vortex-array/src/arrays/struct_/mod.rs
+++ b/vortex-array/src/arrays/struct_/mod.rs
@@ -315,6 +315,20 @@ impl OperationsVTable<StructVTable> for StructVTable {
                 .try_collect()?,
         ))
     }
+
+    /// Optimize a StructArray recursively by optimizing all of its fields.
+    fn optimize(array: &StructArray) -> VortexResult<StructArray> {
+        StructArray::try_new(
+            array.names().clone(),
+            array
+                .fields
+                .iter()
+                .map(|field| field.optimize())
+                .collect::<VortexResult<Vec<ArrayRef>>>()?,
+            array.len,
+            array.validity.optimize()?,
+        )
+    }
 }
 
 #[cfg(test)]

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -8,7 +8,7 @@ use std::hash::Hash;
 use itertools::Itertools as _;
 use num_traits::{NumCast, ToPrimitive};
 use serde::{Deserialize, Serialize};
-use vortex_buffer::BufferMut;
+use vortex_buffer::{Buffer, BufferMut};
 use vortex_dtype::Nullability::NonNullable;
 use vortex_dtype::{
     DType, NativePType, PType, match_each_integer_ptype, match_each_unsigned_integer_ptype,
@@ -308,6 +308,31 @@ impl Patches {
         )))
     }
 
+    /// Optimize the Patches, shifting off any offsets and optimizing the child arrays
+    /// to create a more compact Patches representation for serialization.
+    pub fn optimize(&self) -> VortexResult<Self> {
+        if self.offset == 0 {
+            let indices = self.indices.optimize()?;
+            let values = self.values.optimize()?;
+
+            Ok(Self::new(self.array_len, self.offset, indices, values))
+        } else {
+            // Shift off the offset, renumber all of the inputs to be relative to zero.
+            let indices = self.indices.to_primitive()?;
+            let zeroed_indices = match_each_integer_ptype!(indices.ptype(), |T| {
+                let buffer = renumber_indices(indices.as_slice::<T>(), self.offset);
+                PrimitiveArray::new(buffer, indices.validity().clone()).into_array()
+            });
+
+            Ok(Self::new(
+                self.array_len,
+                0,
+                zeroed_indices,
+                self.values.clone(),
+            ))
+        }
+    }
+
     // https://docs.google.com/spreadsheets/d/1D9vBZ1QJ6mwcIvV5wIL0hjGgVchcEnAyhvitqWu2ugU
     const PREFER_MAP_WHEN_PATCHES_OVER_INDICES_LESS_THAN: f64 = 5.0;
 
@@ -426,6 +451,11 @@ impl Patches {
         }
         Ok(Self::new(self.array_len, self.offset, self.indices, values))
     }
+}
+
+fn renumber_indices<T: NativePType>(indices: &[T], offset: usize) -> Buffer<T> {
+    let offset = T::from(offset).vortex_expect("offset must fit into index type");
+    indices.iter().map(|&idx| idx - offset).collect()
 }
 
 fn take_search<I: NativePType + NumCast + PartialOrd, T: NativePType + NumCast>(
@@ -797,5 +827,28 @@ mod test {
         let primitive_doubly_sliced = doubly_sliced.values().to_primitive().unwrap();
 
         assert_eq!(primitive_doubly_sliced.as_slice::<u32>(), &[13531]);
+    }
+
+    #[test]
+    fn slice_optimize() {
+        let values = buffer![15_u32, 135, 13531, 42].into_array();
+        let indices = buffer![10_u64, 11, 50, 100].into_array();
+
+        let patches = Patches::new(101, 0, indices, values);
+        let sliced = patches.slice(15, 101).unwrap().unwrap();
+        assert_eq!(sliced.array_len(), 86);
+
+        // Before optimization: indices are still referenced to the offset.
+        assert_eq!(sliced.offset(), 15);
+        assert_eq!(
+            sliced.indices().to_primitive().unwrap().as_slice::<u64>(),
+            &[50, 100]
+        );
+
+        // After optimization: indices are shifted to zero out the offset.
+        let optimized = sliced.optimize().unwrap();
+        assert_eq!(optimized.offset(), 0);
+        let indices = optimized.indices().to_primitive().unwrap();
+        assert_eq!(indices.as_slice::<u64>(), &[35, 85]);
     }
 }

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -179,7 +179,7 @@ impl Validity {
         }
     }
 
-    /// If this validity is backed by an array, [`optimize`][crate::vtable::operations::OperationsVTable]
+    /// If this validity is backed by an array, [`optimize`][crate::vtable::OperationsVTable]
     /// the underlying array. Otherwise, returns the original validity unchanged.
     pub fn optimize(&self) -> VortexResult<Self> {
         match self {

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -179,6 +179,15 @@ impl Validity {
         }
     }
 
+    /// If this validity is backed by an array, [`optimize`][crate::vtable::operations::OperationsVTable]
+    /// the underlying array. Otherwise, returns the original validity unchanged.
+    pub fn optimize(&self) -> VortexResult<Self> {
+        match self {
+            Validity::Array(array) => array.optimize().map(Validity::Array),
+            x => Ok(x.clone()),
+        }
+    }
+
     /// Set to false any entries for which the mask is true.
     ///
     /// The result is always nullable. The result has the same length as self.

--- a/vortex-expr/src/forms/nnf.rs
+++ b/vortex-expr/src/forms/nnf.rs
@@ -136,9 +136,8 @@ impl FolderMut for NNFVisitor {
 
 #[cfg(test)]
 mod tests {
-    use crate::{and, lit, or};
-
     use super::*;
+    use crate::{and, lit, or};
 
     #[test]
     fn basic_nnf_test() {


### PR DESCRIPTION
Implements `optimize` for RunEnd, Patches and SparseArray by shifting the offset out of the indices. For ListArray and StructArray, it recursively optimizes the children.

This augments #3852 

Signed-off-by: Andrew Duffy <andrew@a10y.dev>Signed-off-by: Andrew Duffy <andrew@a10y.dev>Signed-off-by: Andrew Duffy <andrew@a10y.dev>