### PR TITLE
chore: Migrate NNF doctests to actual tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6439,6 +6439,7 @@ dependencies = [
  "itertools 0.14.0",
  "paste",
  "prost 0.14.1",
+ "rstest",
  "serde",
  "vortex-array",
  "vortex-buffer",

--- a/vortex-expr/Cargo.toml
+++ b/vortex-expr/Cargo.toml
@@ -35,6 +35,7 @@ vortex-scalar = { workspace = true }
 vortex-utils = { workspace = true }
 
 [dev-dependencies]
+rstest = { workspace = true }
 vortex-expr = { path = ".", features = ["test-harness"] }
 
 [features]

--- a/vortex-expr/src/forms/nnf.rs
+++ b/vortex-expr/src/forms/nnf.rs
@@ -3,10 +3,13 @@
 
 use vortex_error::{VortexExpect, VortexResult, vortex_bail};
 
-use crate::traversal::{FoldDown, FoldUp, FolderMut, Node as _};
-use crate::{BinaryExpr, BinaryVTable, ExprRef, IntoExpr, NotVTable, Operator, not};
+use crate::traversal::{FoldDown, FoldUp, FolderMut, Node as _, NodeVisitor, TraversalOrder};
+use crate::{
+    BinaryExpr, BinaryVTable, ExprRef, GetItemVTable, IntoExpr, LiteralVTable, NotVTable, Operator,
+    not,
+};
 
-/// Return an equivalent expression in Negative Normal Form (NNF).
+/// Return an equivalent expression in Negative Normal Form (NNF)[https://en.wikipedia.org/wiki/Negation_normal_form].
 ///
 /// In NNF, [crate::NotExpr] expressions may only contain terminal nodes such as [Literal](crate::LiteralExpr) or
 /// [GetItem](crate::GetItemExpr). They *may not* contain [crate::BinaryExpr], [crate::NotExpr], etc.
@@ -64,6 +67,15 @@ pub fn nnf(expr: ExprRef) -> ExprRef {
     expr.transform_with_context(&mut visitor, false)
         .vortex_expect("cannot fail")
         .result()
+}
+
+/// Verifies whether the expression is in Negative Normal Form (NNF)[https://en.wikipedia.org/wiki/Negation_normal_form].
+///
+/// Note that NNF isn't canonical, different expressions might be logically equivalent but different.
+pub fn is_nnf(expr: &ExprRef) -> bool {
+    let mut visitor = NNFValidationVisitor::default();
+    expr.accept(&mut visitor).expect("never fails");
+    visitor.is_nnf
 }
 
 #[derive(Default)]
@@ -134,24 +146,56 @@ impl FolderMut for NNFVisitor {
     }
 }
 
+struct NNFValidationVisitor {
+    is_nnf: bool,
+}
+
+impl Default for NNFValidationVisitor {
+    fn default() -> Self {
+        Self { is_nnf: true }
+    }
+}
+
+impl<'a> NodeVisitor<'a> for NNFValidationVisitor {
+    type NodeTy = ExprRef;
+
+    fn visit_down(&mut self, node: &'a Self::NodeTy) -> VortexResult<TraversalOrder> {
+        if let Some(not_expr) = node.as_opt::<NotVTable>() {
+            let is_var =
+                not_expr.child().is::<GetItemVTable>() || not_expr.child().is::<LiteralVTable>();
+            self.is_nnf &= is_var;
+            if !is_var {
+                return Ok(TraversalOrder::Stop);
+            }
+        }
+
+        Ok(TraversalOrder::Continue)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{and, lit, or};
+    use crate::{and, col, gt_eq, lit, lt, or};
 
-    #[test]
-    fn basic_nnf_test() {
-        let expr = and(not(and(lit(true), lit(true))), and(lit(true), lit(true)));
-        let expected = and(
-            or(not(lit(true)), not(lit(true))),
-            and(lit(true), lit(true)),
-        );
-        let mut rewriter = NNFVisitor::default();
-        let value = expr
-            .transform_with_context(&mut rewriter, false)
-            .unwrap()
-            .result();
+    use rstest::rstest;
 
-        assert_eq!(&value, &expected);
+    #[rstest]
+    #[case(
+        and(not(and(lit(true), lit(true))), and(lit(true), lit(true))),
+        and(or(not(lit(true)), not(lit(true))), and(lit(true), lit(true)),)
+    )]
+    #[case(not(not(col("a"))), col("a"))]
+    #[case(not(not(not(col("a")))), not(col("a")))]
+    #[case(not(and(col("a"), col("b"))), or(not(col("a")), not(col("b"))))]
+    #[case(
+        not(and(gt_eq(col("a"), lit(3)), col("b"))),
+        or(lt(col("a"), lit(3)), not(col("b")))
+    )]
+    fn basic_nnf_test(#[case] input: ExprRef, #[case] expected: ExprRef) {
+        let output = nnf(input);
+
+        assert_eq!(&output, &expected);
+        assert!(is_nnf(&output));
     }
 }

--- a/vortex-expr/src/forms/nnf.rs
+++ b/vortex-expr/src/forms/nnf.rs
@@ -9,7 +9,7 @@ use crate::{
     not,
 };
 
-/// Return an equivalent expression in Negative Normal Form (NNF)[https://en.wikipedia.org/wiki/Negation_normal_form].
+/// Return an equivalent expression in Negative Normal Form ([NNF](https://en.wikipedia.org/wiki/Negation_normal_form)).
 ///
 /// In NNF, [crate::NotExpr] expressions may only contain terminal nodes such as [Literal](crate::LiteralExpr) or
 /// [GetItem](crate::GetItemExpr). They *may not* contain [crate::BinaryExpr], [crate::NotExpr], etc.
@@ -69,12 +69,12 @@ pub fn nnf(expr: ExprRef) -> ExprRef {
         .result()
 }
 
-/// Verifies whether the expression is in Negative Normal Form (NNF)[https://en.wikipedia.org/wiki/Negation_normal_form].
+/// Verifies whether the expression is in Negative Normal Form ([NNF](https://en.wikipedia.org/wiki/Negation_normal_form)).
 ///
 /// Note that NNF isn't canonical, different expressions might be logically equivalent but different.
 pub fn is_nnf(expr: &ExprRef) -> bool {
     let mut visitor = NNFValidationVisitor::default();
-    expr.accept(&mut visitor).expect("never fails");
+    expr.accept(&mut visitor).vortex_expect("never fails");
     visitor.is_nnf
 }
 
@@ -175,10 +175,10 @@ impl<'a> NodeVisitor<'a> for NNFValidationVisitor {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
     use crate::{and, col, gt_eq, lit, lt, or};
-
-    use rstest::rstest;
 
     #[rstest]
     #[case(
@@ -193,9 +193,12 @@ mod tests {
         or(lt(col("a"), lit(3)), not(col("b")))
     )]
     fn basic_nnf_test(#[case] input: ExprRef, #[case] expected: ExprRef) {
-        let output = nnf(input);
+        let output = nnf(input.clone());
 
-        assert_eq!(&output, &expected);
+        assert_eq!(
+            &output, &expected,
+            "\nOriginal expr: {input}]\nRewritten expr: {output}\nexpected expr:{expected}"
+        );
         assert!(is_nnf(&output));
     }
 }


### PR DESCRIPTION
doctests just don't give the same level of feedback loop, especially when using nextest that doesn't run them.