### PR TITLE
fix: mitigate duckdb threading issue

### DIFF
--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -50,7 +50,7 @@ struct CTableGlobalData final : GlobalTableFunctionState {
     unique_ptr<vortex::CData> ffi_data;
 
     idx_t MaxThreads() const override {
-        return GlobalTableFunctionState::MAX_THREADS;
+        return 1;
     }
 };
 


### PR DESCRIPTION
Set to 1 until we figure out the DuckDB threading issue which can lead to incorrect results.