### PR TITLE
chore: fix type bound on Scalar::binary

### DIFF
--- a/vortex-python/src/scalar/factory.rs
+++ b/vortex-python/src/scalar/factory.rs
@@ -7,7 +7,6 @@ use itertools::Itertools;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PyString};
-use vortex::buffer::ByteBuffer;
 use vortex::dtype::{DType, FieldName, FieldNames, Nullability, StructFields};
 use vortex::scalar::Scalar;
 
@@ -91,7 +90,7 @@ fn scalar_helper_inner(value: &Bound<'_, PyAny>, dtype: Option<&DType>) -> PyRes
     // bytes
     if let Ok(bytes) = value.downcast::<PyBytes>() {
         return Ok(Scalar::binary(
-            Arc::new(ByteBuffer::from(bytes.extract::<Vec<u8>>()?)),
+            bytes.extract::<Vec<u8>>()?,
             Nullability::NonNullable,
         ));
     }

--- a/vortex-scalar/src/binary.rs
+++ b/vortex-scalar/src/binary.rs
@@ -168,10 +168,10 @@ impl<'a> BinaryScalar<'a> {
 
 impl Scalar {
     /// Creates a new binary scalar from a byte buffer.
-    pub fn binary(buffer: impl Into<Arc<ByteBuffer>>, nullability: Nullability) -> Self {
+    pub fn binary(buffer: impl Into<ByteBuffer>, nullability: Nullability) -> Self {
         Self {
             dtype: DType::Binary(nullability),
-            value: ScalarValue(InnerScalarValue::Buffer(buffer.into())),
+            value: ScalarValue(InnerScalarValue::Buffer(Arc::new(buffer.into()))),
         }
     }
 }


### PR DESCRIPTION
There isn't anything that impls `Into<Arc<ByteBuffer>>` except for ByteBuffer, so the bound currently is kind of pointless. I've relaxed the bound so that we get all of `Into<ByteBuffer>`, which covers a wider range of types.

The internal Arc is just there to cut down on the size of InnerScalarValue, there aren't any code paths where we actually get an `Arc<ByteBuffer>` out of something and want to turn it into a scalar directly.