### PR TITLE
Use c-unwrap ABI for duckdb extension

### DIFF
--- a/vortex-duckdb/build.rs
+++ b/vortex-duckdb/build.rs
@@ -3,9 +3,10 @@
 
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::expect_used)]
-use bindgen::Abi;
 use std::path::PathBuf;
 use std::{env, fs};
+
+use bindgen::Abi;
 
 const DUCKDB_VERSION: &str = "1.3.2";
 const DUCKDB_BASE_URL: &str = "https://github.com/duckdb/duckdb/releases/download";

--- a/vortex-duckdb/build.rs
+++ b/vortex-duckdb/build.rs
@@ -3,6 +3,7 @@
 
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::expect_used)]
+use bindgen::Abi;
 use std::path::PathBuf;
 use std::{env, fs};
 
@@ -147,6 +148,7 @@ fn main() {
     // Generate the _imported_ bindings from our C++ code.
     bindgen::Builder::default()
         .header("cpp/include/duckdb_vx.h")
+        .override_abi(Abi::CUnwind, ".*")
         // Add the #[must_use] attribute to FFI functions that return results.
         .must_use_type("duckdb_state")
         .rustified_enum("duckdb_state")

--- a/vortex-duckdb/src/duckdb/copy_function/callback.rs
+++ b/vortex-duckdb/src/duckdb/copy_function/callback.rs
@@ -14,7 +14,7 @@ use crate::cpp::{
 };
 use crate::duckdb::{CopyFunction, Data, DataChunk, LogicalType, try_or, try_or_null};
 
-pub(crate) unsafe extern "C" fn bind_callback<T: CopyFunction>(
+pub(crate) unsafe extern "C-unwind" fn bind_callback<T: CopyFunction>(
     // TODO(joe): pass this into T::bind(..)
     _input: duckdb_vx_copy_func_bind_input,
     column_names: *const *const c_char,
@@ -45,7 +45,7 @@ pub(crate) unsafe extern "C" fn bind_callback<T: CopyFunction>(
     })
 }
 
-pub(crate) unsafe extern "C" fn global_callback<T: CopyFunction>(
+pub(crate) unsafe extern "C-unwind" fn global_callback<T: CopyFunction>(
     bind_data: *const c_void,
     file_path: *const c_char,
     error_out: *mut duckdb_vx_error,
@@ -61,7 +61,7 @@ pub(crate) unsafe extern "C" fn global_callback<T: CopyFunction>(
     })
 }
 
-pub(crate) unsafe extern "C" fn local_callback<T: CopyFunction>(
+pub(crate) unsafe extern "C-unwind" fn local_callback<T: CopyFunction>(
     bind_data: *const c_void,
     error_out: *mut duckdb_vx_error,
 ) -> cpp::duckdb_vx_data {
@@ -73,7 +73,7 @@ pub(crate) unsafe extern "C" fn local_callback<T: CopyFunction>(
     })
 }
 
-pub(crate) unsafe extern "C" fn copy_to_sink_callback<T: CopyFunction>(
+pub(crate) unsafe extern "C-unwind" fn copy_to_sink_callback<T: CopyFunction>(
     bind_data: *const c_void,
     global_data: *mut c_void,
     local_data: *mut c_void,
@@ -95,7 +95,7 @@ pub(crate) unsafe extern "C" fn copy_to_sink_callback<T: CopyFunction>(
     })
 }
 
-pub(crate) unsafe extern "C" fn copy_to_finalize_callback<T: CopyFunction>(
+pub(crate) unsafe extern "C-unwind" fn copy_to_finalize_callback<T: CopyFunction>(
     bind_data: *const c_void,
     global_data: *mut c_void,
     error_out: *mut duckdb_vx_error,

--- a/vortex-duckdb/src/duckdb/mod.rs
+++ b/vortex-duckdb/src/duckdb/mod.rs
@@ -157,7 +157,7 @@ pub(crate) fn try_or<T: Default>(
 }
 
 /// Creates a function that drops a `Box<T>` when called.
-extern "C" fn drop_boxed<T>(ptr: *mut c_void) {
+extern "C-unwind" fn drop_boxed<T>(ptr: *mut c_void) {
     // Safety: We assume that the pointer is valid and points to a Box<T>.
     // The caller is responsible for ensuring that the pointer is valid.
     if !ptr.is_null() {

--- a/vortex-duckdb/src/duckdb/table_function/bind.rs
+++ b/vortex-duckdb/src/duckdb/table_function/bind.rs
@@ -10,7 +10,7 @@ use crate::duckdb::{LogicalType, TableFunction, Value, try_or_null};
 use crate::{cpp, wrapper};
 
 /// The native bind callback for a table function.
-pub(crate) unsafe extern "C" fn bind_callback<T: TableFunction>(
+pub(crate) unsafe extern "C-unwind" fn bind_callback<T: TableFunction>(
     bind_input: cpp::duckdb_vx_tfunc_bind_input,
     bind_result: cpp::duckdb_vx_tfunc_bind_result,
     error_out: *mut cpp::duckdb_vx_error,
@@ -25,7 +25,7 @@ pub(crate) unsafe extern "C" fn bind_callback<T: TableFunction>(
 }
 
 /// The native copy callback for bind data.
-pub(crate) unsafe extern "C" fn bind_data_clone_callback<T: TableFunction>(
+pub(crate) unsafe extern "C-unwind" fn bind_data_clone_callback<T: TableFunction>(
     bind_data: *const std::ffi::c_void,
     error_out: *mut cpp::duckdb_vx_error,
 ) -> cpp::duckdb_vx_data {

--- a/vortex-duckdb/src/duckdb/table_function/cardinality.rs
+++ b/vortex-duckdb/src/duckdb/table_function/cardinality.rs
@@ -9,7 +9,7 @@ use crate::cpp;
 use crate::duckdb::{Cardinality, TableFunction};
 
 /// Native callback for the cardinality estimate of a table function.
-pub(crate) unsafe extern "C" fn cardinality_callback<T: TableFunction>(
+pub(crate) unsafe extern "C-unwind" fn cardinality_callback<T: TableFunction>(
     bind_data: *mut c_void,
     node_stats_out: *mut cpp::duckdb_vx_node_statistics,
 ) {

--- a/vortex-duckdb/src/duckdb/table_function/init.rs
+++ b/vortex-duckdb/src/duckdb/table_function/init.rs
@@ -12,7 +12,7 @@ use crate::duckdb::data::Data;
 use crate::duckdb::{TableFilterSet, TableFunction};
 
 /// Native callback for the global initialization of a table function.
-pub(crate) unsafe extern "C" fn init_global_callback<T: TableFunction>(
+pub(crate) unsafe extern "C-unwind" fn init_global_callback<T: TableFunction>(
     init_input: *const cpp::duckdb_vx_tfunc_init_input,
     error_out: *mut cpp::duckdb_vx_error,
 ) -> cpp::duckdb_vx_data {
@@ -33,7 +33,7 @@ pub(crate) unsafe extern "C" fn init_global_callback<T: TableFunction>(
 
 /// Native callback for the local initialization of a table function.
 #[allow(deref_nullptr)]
-pub(crate) unsafe extern "C" fn init_local_callback<T: TableFunction>(
+pub(crate) unsafe extern "C-unwind" fn init_local_callback<T: TableFunction>(
     init_input: *const cpp::duckdb_vx_tfunc_init_input,
     global_init_data: *mut c_void,
     error_out: *mut cpp::duckdb_vx_error,

--- a/vortex-duckdb/src/duckdb/table_function/mod.rs
+++ b/vortex-duckdb/src/duckdb/table_function/mod.rs
@@ -162,7 +162,7 @@ impl Connection {
 }
 
 /// The native function callback for a table function.
-unsafe extern "C" fn function<T: TableFunction>(
+unsafe extern "C-unwind" fn function<T: TableFunction>(
     bind_data: *const c_void,
     global_init_data: *mut c_void,
     local_init_data: *mut c_void,

--- a/vortex-duckdb/src/duckdb/table_function/pushdown_complex_filter.rs
+++ b/vortex-duckdb/src/duckdb/table_function/pushdown_complex_filter.rs
@@ -10,7 +10,7 @@ use crate::duckdb::expr::Expression;
 use crate::duckdb::{TableFunction, try_or};
 
 /// Native callback for the global initialization of a table function.
-pub(crate) unsafe extern "C" fn pushdown_complex_filter_callback<T: TableFunction>(
+pub(crate) unsafe extern "C-unwind" fn pushdown_complex_filter_callback<T: TableFunction>(
     bind_data: *mut c_void,
     expr: cpp::duckdb_vx_expr,
     error_out: *mut cpp::duckdb_vx_error,


### PR DESCRIPTION
I have tested (while debugging a panic...) that backtraces now propagate from Rust -> DuckDB -> Rust callback