### PR TITLE
Fix DuckDB timestamp values

### DIFF
--- a/vortex-duckdb/src/convert/expr.rs
+++ b/vortex-duckdb/src/convert/expr.rs
@@ -21,7 +21,7 @@ const DUCKDB_FUNCTION_NAME_CONTAINS: &str = "contains";
 fn like_pattern_str(value: &Expression) -> VortexResult<Option<String>> {
     match value.as_class().vortex_expect("unknown class") {
         ExpressionClass::BoundConstant(constant) => {
-            Ok(Some(format!("%{}%", constant.value.as_string())))
+            Ok(Some(format!("%{}%", constant.value.as_string().as_str())))
         }
         _ => Ok(None),
     }

--- a/vortex-duckdb/src/convert/scalar.rs
+++ b/vortex-duckdb/src/convert/scalar.rs
@@ -19,10 +19,8 @@
 //! | `Binary` | `BLOB` |
 //! | `ExtScalar` (temporal) | `DATE`/`TIME`/`TIMESTAMP` |
 
-use std::ffi::CStr;
 use std::sync::Arc;
 
-use vortex::buffer::ByteBuffer;
 use vortex::dtype::Nullability::Nullable;
 use vortex::dtype::PType::{I32, I64};
 use vortex::dtype::datetime::{DATE_ID, TIME_ID, TIMESTAMP_ID, TemporalMetadata, TimeUnit};
@@ -35,8 +33,7 @@ use vortex::scalar::{
 };
 
 use crate::convert::dtype::FromLogicalType;
-use crate::cpp::{self, DUCKDB_TYPE, duckdb_free};
-use crate::duckdb::{Value, i128_from_parts};
+use crate::duckdb::Value;
 
 /// Trait for converting Vortex scalars to DuckDB values.
 pub trait ToDuckDBScalar {
@@ -220,125 +217,79 @@ impl TryFrom<&Value> for Scalar {
     type Error = VortexError;
 
     fn try_from(value: &Value) -> Result<Self, Self::Error> {
-        if unsafe { cpp::duckdb_is_null_value(value.as_ptr()) } {
-            let dtype = DType::from_logical_type(value.logical_type(), Nullable);
-            return Ok(Scalar::null(dtype?));
-        };
-        match value.logical_type().as_type_id() {
-            DUCKDB_TYPE::DUCKDB_TYPE_INVALID => vortex_bail!("invalid duckdb type"),
-            DUCKDB_TYPE::DUCKDB_TYPE_SQLNULL => Ok(Scalar::new(DType::Null, ScalarValue::null())),
-            DUCKDB_TYPE::DUCKDB_TYPE_BOOLEAN => {
-                let bool = unsafe { cpp::duckdb_get_bool(value.as_ptr()) };
-                Ok(Scalar::bool(bool, Nullable))
+        use crate::duckdb::Val;
+        let dtype = DType::from_logical_type(value.logical_type(), Nullable)?;
+        match value.extract() {
+            Val::Null => Ok(Scalar::null(dtype)),
+            Val::Boolean(b) => Ok(Scalar::bool(b, Nullable)),
+            Val::TinyInt(v) => Ok(Scalar::primitive(v, Nullable)),
+            Val::SmallInt(v) => Ok(Scalar::primitive(v, Nullable)),
+            Val::Integer(v) => Ok(Scalar::primitive(v, Nullable)),
+            Val::BigInt(v) => Ok(Scalar::primitive(v, Nullable)),
+            Val::HugeInt(_) => {
+                vortex_bail!("DuckDB HugeInt is not yet supported in Vortex");
             }
-            DUCKDB_TYPE::DUCKDB_TYPE_TINYINT => Ok(Scalar::primitive(
-                unsafe { cpp::duckdb_get_int8(value.as_ptr()) },
-                Nullable,
-            )),
-            DUCKDB_TYPE::DUCKDB_TYPE_SMALLINT => Ok(Scalar::primitive(
-                unsafe { cpp::duckdb_get_int16(value.as_ptr()) },
-                Nullable,
-            )),
-            DUCKDB_TYPE::DUCKDB_TYPE_INTEGER => Ok(Scalar::primitive(value.as_i32(), Nullable)),
-            DUCKDB_TYPE::DUCKDB_TYPE_BIGINT => Ok(Scalar::primitive(value.as_i64(), Nullable)),
-            DUCKDB_TYPE::DUCKDB_TYPE_UTINYINT => Ok(Scalar::primitive(value.as_u8(), Nullable)),
-            DUCKDB_TYPE::DUCKDB_TYPE_USMALLINT => Ok(Scalar::primitive(
-                unsafe { cpp::duckdb_get_uint16(value.as_ptr()) },
-                Nullable,
-            )),
-            DUCKDB_TYPE::DUCKDB_TYPE_UINTEGER => Ok(Scalar::primitive(
-                unsafe { cpp::duckdb_get_uint32(value.as_ptr()) },
-                Nullable,
-            )),
-            DUCKDB_TYPE::DUCKDB_TYPE_UBIGINT => Ok(Scalar::primitive(
-                unsafe { cpp::duckdb_get_uint64(value.as_ptr()) },
-                Nullable,
-            )),
-            DUCKDB_TYPE::DUCKDB_TYPE_FLOAT => Ok(Scalar::primitive(
-                unsafe { cpp::duckdb_get_float(value.as_ptr()) },
-                Nullable,
-            )),
-            DUCKDB_TYPE::DUCKDB_TYPE_DOUBLE => Ok(Scalar::primitive(
-                unsafe { cpp::duckdb_get_double(value.as_ptr()) },
-                Nullable,
-            )),
-            DUCKDB_TYPE::DUCKDB_TYPE_VARCHAR => {
-                let scalar = unsafe {
-                    let ptr = cpp::duckdb_get_varchar(value.as_ptr());
-                    let scalar = Scalar::utf8(CStr::from_ptr(ptr).to_str()?, Nullable);
-                    duckdb_free(ptr.cast());
-                    scalar
-                };
-
-                Ok(scalar)
-            }
-            DUCKDB_TYPE::DUCKDB_TYPE_BLOB => Ok(Scalar::binary(
-                ByteBuffer::copy_from(value.as_string()),
-                Nullable,
-            )),
-            DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_S => Ok(Scalar::extension(
-                Arc::new(ExtDType::new(
-                    TIMESTAMP_ID.clone(),
-                    Arc::new(DType::Primitive(I32, Nullable)),
-                    Some(TemporalMetadata::Timestamp(TimeUnit::S, None).into()),
-                )),
-                Scalar::new(DType::Primitive(I32, Nullable), value.as_i32().into()),
-            )),
-            DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_MS => Ok(Scalar::extension(
-                Arc::new(ExtDType::new(
-                    TIMESTAMP_ID.clone(),
-                    Arc::new(DType::Primitive(I32, Nullable)),
-                    Some(TemporalMetadata::Timestamp(TimeUnit::Ms, None).into()),
-                )),
-                Scalar::new(DType::Primitive(I32, Nullable), value.as_i32().into()),
-            )),
-            // Us
-            DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP => Ok(Scalar::extension(
-                Arc::new(ExtDType::new(
-                    TIMESTAMP_ID.clone(),
-                    Arc::new(DType::Primitive(I64, Nullable)),
-                    Some(TemporalMetadata::Timestamp(TimeUnit::Us, None).into()),
-                )),
-                Scalar::new(DType::Primitive(I64, Nullable), value.as_i64().into()),
-            )),
-            DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_NS => Ok(Scalar::extension(
-                Arc::new(ExtDType::new(
-                    TIMESTAMP_ID.clone(),
-                    Arc::new(DType::Primitive(I64, Nullable)),
-                    Some(TemporalMetadata::Timestamp(TimeUnit::Ns, None).into()),
-                )),
-                Scalar::new(DType::Primitive(I64, Nullable), value.as_i64().into()),
-            )),
-            DUCKDB_TYPE::DUCKDB_TYPE_DATE => Ok(Scalar::extension(
+            Val::UTinyInt(v) => Ok(Scalar::primitive(v, Nullable)),
+            Val::USmallInt(v) => Ok(Scalar::primitive(v, Nullable)),
+            Val::UInteger(v) => Ok(Scalar::primitive(v, Nullable)),
+            Val::UBigInt(v) => Ok(Scalar::primitive(v, Nullable)),
+            Val::Float(v) => Ok(Scalar::primitive(v, Nullable)),
+            Val::Double(v) => Ok(Scalar::primitive(v, Nullable)),
+            Val::Varchar(s) => Ok(Scalar::utf8(s, Nullable)),
+            Val::Blob(b) => Ok(Scalar::binary(b, Nullable)),
+            Val::Date(days) => Ok(Scalar::extension(
                 Arc::new(ExtDType::new(
                     DATE_ID.clone(),
                     Arc::new(DType::Primitive(I32, Nullable)),
                     Some(TemporalMetadata::Date(TimeUnit::D).into()),
                 )),
-                Scalar::new(DType::Primitive(I32, Nullable), value.as_date().into()),
+                Scalar::new(DType::Primitive(I32, Nullable), ScalarValue::from(days)),
             )),
-            DUCKDB_TYPE::DUCKDB_TYPE_TIME => Ok(Scalar::extension(
+            Val::Time(micros) => Ok(Scalar::extension(
                 Arc::new(ExtDType::new(
                     TIME_ID.clone(),
                     Arc::new(DType::Primitive(I64, Nullable)),
-                    Some(TemporalMetadata::Date(TimeUnit::Us).into()),
+                    Some(TemporalMetadata::Time(TimeUnit::Us).into()),
                 )),
-                Scalar::new(DType::Primitive(I64, Nullable), value.as_time().into()),
+                Scalar::new(DType::Primitive(I64, Nullable), ScalarValue::from(micros)),
             )),
-            DUCKDB_TYPE::DUCKDB_TYPE_DECIMAL => {
-                let cpp::duckdb_decimal {
-                    value,
-                    width,
-                    scale,
-                } = value.as_decimal();
-                Ok(Scalar::decimal(
-                    DecimalValue::I128(i128_from_parts(value.upper, value.lower)),
-                    DecimalDType::new(width, scale.try_into()?),
-                    Nullable,
-                ))
-            }
-
-            _ => todo!("cannot convert value into scalar {value:?}"),
+            Val::TimestampNs(nanos) => Ok(Scalar::extension(
+                Arc::new(ExtDType::new(
+                    TIMESTAMP_ID.clone(),
+                    Arc::new(DType::Primitive(I64, Nullable)),
+                    Some(TemporalMetadata::Timestamp(TimeUnit::Ns, None).into()),
+                )),
+                Scalar::new(DType::Primitive(I64, Nullable), ScalarValue::from(nanos)),
+            )),
+            Val::Timestamp(micros) => Ok(Scalar::extension(
+                Arc::new(ExtDType::new(
+                    TIMESTAMP_ID.clone(),
+                    Arc::new(DType::Primitive(I64, Nullable)),
+                    Some(TemporalMetadata::Timestamp(TimeUnit::Us, None).into()),
+                )),
+                Scalar::new(DType::Primitive(I64, Nullable), ScalarValue::from(micros)),
+            )),
+            Val::TimestampMs(millis) => Ok(Scalar::extension(
+                Arc::new(ExtDType::new(
+                    TIMESTAMP_ID.clone(),
+                    Arc::new(DType::Primitive(I32, Nullable)),
+                    Some(TemporalMetadata::Timestamp(TimeUnit::Ms, None).into()),
+                )),
+                Scalar::new(DType::Primitive(I32, Nullable), ScalarValue::from(millis)),
+            )),
+            Val::TimestampS(seconds) => Ok(Scalar::extension(
+                Arc::new(ExtDType::new(
+                    TIMESTAMP_ID.clone(),
+                    Arc::new(DType::Primitive(I32, Nullable)),
+                    Some(TemporalMetadata::Timestamp(TimeUnit::S, None).into()),
+                )),
+                Scalar::new(DType::Primitive(I32, Nullable), ScalarValue::from(seconds)),
+            )),
+            Val::Decimal(precision, scale, value) => Ok(Scalar::decimal(
+                DecimalValue::I128(value),
+                DecimalDType::new(precision, scale),
+                Nullable,
+            )),
         }
     }
 }

--- a/vortex-duckdb/src/duckdb/value.rs
+++ b/vortex-duckdb/src/duckdb/value.rs
@@ -4,6 +4,11 @@
 use std::ffi::CStr;
 use std::fmt::{Debug, Formatter};
 
+use arrow_buffer::ArrowNativeType;
+use vortex::buffer::{BufferString, ByteBuffer};
+use vortex::error::{VortexExpect, vortex_err, vortex_panic};
+
+use crate::cpp::DUCKDB_TYPE;
 use crate::duckdb::LogicalType;
 use crate::{cpp, wrapper};
 
@@ -74,43 +79,11 @@ impl Value {
         unsafe { Self::own(cpp::duckdb_create_date(cpp::duckdb_date { days })) }
     }
 
-    pub fn as_string(&self) -> String {
-        unsafe {
-            let ptr = cpp::duckdb_get_varchar(self.as_ptr());
-            let cstr = CStr::from_ptr(ptr);
-            let result = cstr.to_string_lossy().into_owned();
-            cpp::duckdb_free(ptr.cast());
-            result
-        }
-    }
-
-    pub fn as_u8(&self) -> u8 {
-        unsafe { cpp::duckdb_get_uint8(self.ptr) }
-    }
-
-    pub fn as_i32(&self) -> i32 {
-        unsafe { cpp::duckdb_get_int32(self.ptr) }
-    }
-
-    pub fn as_i64(&self) -> i64 {
-        unsafe { cpp::duckdb_get_int64(self.ptr) }
-    }
-
-    pub fn as_i128(&self) -> i128 {
-        let huge = unsafe { cpp::duckdb_get_hugeint(self.ptr) };
-        i128_from_parts(huge.upper, huge.lower)
-    }
-
-    pub fn as_date(&self) -> i32 {
-        unsafe { cpp::duckdb_get_date(self.ptr).days }
-    }
-
-    pub fn as_time(&self) -> i64 {
-        unsafe { cpp::duckdb_get_time(self.ptr).micros }
-    }
-
-    pub fn as_decimal(&self) -> cpp::duckdb_decimal {
-        unsafe { cpp::duckdb_get_decimal(self.ptr) }
+    pub fn as_string(&self) -> BufferString {
+        let Val::Varchar(string) = self.extract() else {
+            vortex_panic!("Value is not a string");
+        };
+        string
     }
 }
 
@@ -223,9 +196,132 @@ impl From<&[u8]> for Value {
     }
 }
 
+/// An enum for extracting the underlying typed value from a `Value`.
+pub enum Val {
+    Null,
+    TinyInt(i8),
+    SmallInt(i16),
+    Integer(i32),
+    BigInt(i64),
+    HugeInt(i128),
+    UTinyInt(u8),
+    USmallInt(u16),
+    UInteger(u32),
+    UBigInt(u64),
+    Float(f32),
+    Double(f64),
+    Boolean(bool),
+    Varchar(BufferString),
+    Blob(ByteBuffer),
+    Date(i32),
+    Time(i64),
+    TimestampNs(i64),
+    Timestamp(i64),
+    TimestampMs(i64),
+    TimestampS(i64),
+    Decimal(u8, i8, i128),
+}
+
+impl Value {
+    /// Extracts the value from the DuckDB `Value` into a `ValueRef`.
+    pub fn extract(&self) -> Val {
+        if unsafe { cpp::duckdb_is_null_value(self.as_ptr()) } {
+            return Val::Null;
+        }
+        match self.logical_type().as_type_id() {
+            DUCKDB_TYPE::DUCKDB_TYPE_INVALID => vortex_panic!("Invalid type for DuckDB value"),
+            DUCKDB_TYPE::DUCKDB_TYPE_SQLNULL => Val::Null,
+            DUCKDB_TYPE::DUCKDB_TYPE_BOOLEAN => {
+                Val::Boolean(unsafe { cpp::duckdb_get_bool(self.as_ptr()) })
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_TINYINT => {
+                Val::TinyInt(unsafe { cpp::duckdb_get_int8(self.as_ptr()) })
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_SMALLINT => {
+                Val::SmallInt(unsafe { cpp::duckdb_get_int16(self.as_ptr()) })
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_INTEGER => {
+                Val::Integer(unsafe { cpp::duckdb_get_int32(self.as_ptr()) })
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_BIGINT => {
+                Val::BigInt(unsafe { cpp::duckdb_get_int64(self.as_ptr()) })
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_UTINYINT => {
+                Val::UTinyInt(unsafe { cpp::duckdb_get_uint8(self.as_ptr()) })
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_USMALLINT => {
+                Val::USmallInt(unsafe { cpp::duckdb_get_uint16(self.as_ptr()) })
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_UINTEGER => {
+                Val::UInteger(unsafe { cpp::duckdb_get_uint32(self.as_ptr()) })
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_UBIGINT => {
+                Val::UBigInt(unsafe { cpp::duckdb_get_uint64(self.as_ptr()) })
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_FLOAT => {
+                Val::Float(unsafe { cpp::duckdb_get_float(self.as_ptr()) })
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_DOUBLE => {
+                Val::Double(unsafe { cpp::duckdb_get_double(self.as_ptr()) })
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_VARCHAR => {
+                let ptr = unsafe { cpp::duckdb_get_varchar(self.as_ptr()) };
+                let cstr = unsafe { CStr::from_ptr(ptr) };
+                let string = BufferString::from(
+                    cstr.to_str()
+                        .map_err(|e| vortex_err!("Invalid UTF-8 string from DuckDB: {e}"))
+                        .vortex_expect("Invalid UTF-8 string from DuckDB"),
+                );
+                unsafe { cpp::duckdb_free(ptr.cast()) };
+                Val::Varchar(string)
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_BLOB => {
+                // TODO(ngates): for blobs and strings, we could write our own C functions to
+                //  get the values by reference, avoiding a double copy since these C functions
+                //  also copy on the CPP side.
+                let blob = unsafe { cpp::duckdb_get_blob(self.as_ptr()) };
+                let slice = unsafe {
+                    std::slice::from_raw_parts(blob.data.cast::<u8>(), blob.size.as_usize())
+                };
+                let bytes = ByteBuffer::copy_from(slice);
+                unsafe { cpp::duckdb_free(blob.data) };
+                Val::Blob(bytes)
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_DATE => {
+                Val::Date(unsafe { cpp::duckdb_get_date(self.as_ptr()).days })
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_TIME => {
+                Val::Time(unsafe { cpp::duckdb_get_time(self.as_ptr()).micros })
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_NS => {
+                Val::TimestampNs(unsafe { cpp::duckdb_get_timestamp_ns(self.as_ptr()).nanos })
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP => {
+                Val::Timestamp(unsafe { cpp::duckdb_get_timestamp(self.as_ptr()).micros })
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_MS => {
+                Val::TimestampMs(unsafe { cpp::duckdb_get_timestamp_ms(self.as_ptr()).millis })
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_S => {
+                Val::TimestampS(unsafe { cpp::duckdb_get_timestamp_s(self.as_ptr()).seconds })
+            }
+            DUCKDB_TYPE::DUCKDB_TYPE_DECIMAL => {
+                let decimal = unsafe { cpp::duckdb_get_decimal(self.as_ptr()) };
+                let value = i128_from_parts(decimal.value.upper, decimal.value.lower);
+                Val::Decimal(
+                    decimal.width,
+                    i8::try_from(decimal.scale).vortex_expect("invalid scale"),
+                    value,
+                )
+            }
+            // ...other types remain unimplemented...
+            _ => vortex_panic!("Unsupported DuckDB value type {:?}", self),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-
     use crate::duckdb::i128_from_parts;
 
     #[test]


### PR DESCRIPTION
Adds a more typed way of accessing DuckDB values. We were actually fetching the timestamp data incorrectly, so unclear how DuckDB was able to return correct results unless it also post-filters?