### PR TITLE
Extract work queue logic

### DIFF
--- a/vortex-scan/src/lib.rs
+++ b/vortex-scan/src/lib.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::future::Future;
 use std::iter;
 use std::ops::Range;
 use std::sync::Arc;
@@ -9,6 +8,7 @@ use std::sync::Arc;
 use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef;
 use futures::executor::{LocalPool, ThreadPool};
+use futures::future::BoxFuture;
 use futures::stream::FuturesOrdered;
 use futures::task::{LocalSpawnExt, SpawnExt};
 use futures::{Stream, StreamExt, stream};
@@ -36,6 +36,7 @@ pub mod row_mask;
 mod selection;
 mod split_by;
 mod tasks;
+mod work_queue;
 
 pub use multi_scan::{MultiScan, MultiScanIterator};
 use tasks::{TaskContext, split_exec};
@@ -170,7 +171,7 @@ impl<A: 'static + Send + Sync> ScanBuilder<A> {
     }
 
     /// Constructs a task per row split of the scan, returned as a vector of futures.
-    pub fn build(mut self) -> VortexResult<Vec<impl Future<Output = VortexResult<Option<A>>>>> {
+    pub fn build(mut self) -> VortexResult<Vec<BoxFuture<'static, VortexResult<Option<A>>>>> {
         if self.filter.is_some() && self.limit.is_some() {
             vortex_bail!("Vortex doesn't support scans with both a filter and a limit")
         }

--- a/vortex-scan/src/multi_scan.rs
+++ b/vortex-scan/src/multi_scan.rs
@@ -1,108 +1,36 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::iter;
-use std::sync::Arc;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering::{Relaxed, SeqCst};
-
-use crossbeam_deque::{Steal, Stealer, Worker};
-use crossbeam_queue::SegQueue;
 use futures::executor::LocalPool;
 use futures::future::BoxFuture;
-use parking_lot::RwLock;
 use vortex_error::VortexResult;
 
 use crate::ScanBuilder;
+use crate::work_queue::{TaskFactory, WorkQueue, WorkQueueIterator};
 
 type ArrayFuture<T> = BoxFuture<'static, VortexResult<Option<T>>>;
-type ScanBuilderFactory<T> = Box<dyn FnOnce() -> ScanBuilder<T> + Send + Sync>;
 
 /// Coordinator to orchestrate multiple scan operations.
 ///
 /// `MultiScan` allows to queue multiple scan operations in order to execute
 /// them in parallel. In particular, this enables scanning multiple files.
 pub struct MultiScan<T> {
-    state: Arc<State<T>>,
+    work_queue: WorkQueue<ArrayFuture<T>>,
 }
 
-struct State<T> {
-    /// A queue of factories that lazily produce [`ScanBuilder`] instances.
-    scan_builders: SegQueue<ScanBuilderFactory<T>>,
-
-    /// The total number of scans that need to be constructed.
-    num_scans: usize,
-    /// How many scan builders have been constructed and had their tasks completely pushed
-    /// into a worker queue.
-    num_scans_constructed: AtomicUsize,
-
-    /// The vector of stealers, one for each worker.
-    stealers: RwLock<Vec<Stealer<ArrayFuture<T>>>>,
-}
-
-impl<T: 'static + Send + Sync> State<T> {
-    /// Loads a scan and pushes its tasks into the given worker queue.
-    ///
-    /// Returns `true` if any tasks were pushed into the worker. Note that these tasks may have
-    /// been stolen by the time the worker queue is checked.
-    fn load_next_scan(&self, worker: &Worker<ArrayFuture<T>>) -> bool {
-        if let Some(scan_builder_fn) = self.scan_builders.pop() {
-            match scan_builder_fn().build() {
-                Ok(tasks) => {
-                    for task in tasks {
-                        worker.push(Box::pin(task));
-                    }
-                    self.num_scans_constructed.fetch_add(1, SeqCst);
-                }
-                Err(err) => {
-                    // If the scan builder fails, we can return an error.
-                    worker.push(Box::pin(async { Err(err) }));
-                }
-            }
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Attempts to steal work from other workers, returns `true` if work was stolen.
-    fn steal_work(&self, worker: &Worker<ArrayFuture<T>>) -> Steal<()> {
-        // Repeatedly attempt to steal work from other workers until there are no retries.
-        iter::repeat_with(|| {
-            // This collect tries all stealers, exits early on the first successful steal,
-            // or else tracks whether any steal requires a retry.
-            self.stealers
-                .read()
-                .iter()
-                .map(|stealer| stealer.steal_batch(worker))
-                .collect::<Steal<()>>()
-        })
-        .find(|steal| !steal.is_retry())
-        .unwrap_or(Steal::Empty)
-    }
-}
-
-impl<T> MultiScan<T> {
+impl<T: 'static + Send + Sync> MultiScan<T> {
     /// Created with lazily constructed scan builders closures.
     pub fn new<I, F>(closures: I) -> Self
     where
         F: FnOnce() -> ScanBuilder<T> + 'static + Send + Sync,
         I: IntoIterator<Item = F>,
     {
-        let scan_builders: SegQueue<ScanBuilderFactory<T>> = SegQueue::new();
-        for closure in closures.into_iter() {
-            scan_builders.push(Box::new(closure));
-        }
-
-        let num_scans = scan_builders.len();
-
         Self {
-            state: Arc::new(State {
-                scan_builders,
-                num_scans_constructed: AtomicUsize::new(0),
-                num_scans,
-                stealers: RwLock::new(Vec::new()),
-            }),
+            work_queue: WorkQueue::new(
+                closures.into_iter().map(|closure| {
+                    Box::new(move || closure().build()) as TaskFactory<ArrayFuture<T>>
+                }),
+            ),
         }
     }
 
@@ -110,24 +38,16 @@ impl<T> MultiScan<T> {
     ///
     /// The scan progresses when calling `next` on the iterator.
     pub fn new_scan_iterator(&self) -> MultiScanIterator<T> {
-        let worker = Worker::new_fifo();
-
-        // Register the worker with the shared state.
-        self.state.stealers.write().push(worker.stealer());
-
         MultiScanIterator {
-            state: self.state.clone(),
-            worker,
-            local_pool: LocalPool::new(),
+            inner: self.work_queue.new_iterator(),
+            local_pool: Default::default(),
         }
     }
 }
 
 /// Scan iterator to participate in a `MultiScan`.
 pub struct MultiScanIterator<T> {
-    state: Arc<State<T>>,
-
-    worker: Worker<ArrayFuture<T>>,
+    inner: WorkQueueIterator<ArrayFuture<T>>,
     local_pool: LocalPool,
 }
 
@@ -135,24 +55,9 @@ impl<T: Send + Sync + 'static> Iterator for MultiScanIterator<T> {
     type Item = VortexResult<T>;
 
     fn next(&mut self) -> Option<VortexResult<T>> {
-        if self.worker.is_empty() && !self.state.load_next_scan(&self.worker) {
-            // If there are no more scans to load, then there is at least one worker
-            // constructing a scan and about to push some tasks.
-            // We sit in a loop trying to steal some of those tasks, or else bail out when
-            // all scans have been constructed, and we didn't manage to steal anything. To avoid
-            // spinning too hot, we yield the thread each time we fail to steal work.
-            while self.state.num_scans_constructed.load(Relaxed) < self.state.num_scans
-                || !self.state.steal_work(&self.worker).is_empty()
-            {
-                if self.state.steal_work(&self.worker).is_success() {
-                    break;
-                } else {
-                    std::thread::yield_now();
-                }
-            }
+        match self.inner.next()? {
+            Ok(task) => self.local_pool.run_until(task).transpose(),
+            Err(e) => Some(Err(e)),
         }
-
-        let task = self.worker.pop()?;
-        self.local_pool.run_until(task).transpose()
     }
 }

--- a/vortex-scan/src/work_queue.rs
+++ b/vortex-scan/src/work_queue.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::iter;
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::{Relaxed, SeqCst};
+
+use crossbeam_deque::{Steal, Stealer, Worker};
+use crossbeam_queue::SegQueue;
+use parking_lot::RwLock;
+use vortex_error::VortexResult;
+
+/// A factory that produces a vector of tasks.
+pub type TaskFactory<T> = Box<dyn FnOnce() -> VortexResult<Vec<T>> + Send + Sync>;
+
+/// A work-stealing queue that supports dynamically adding tasks from task factories.
+///
+/// Each task factory has affinity to a particular worker. After all factories have been
+/// constructed, workers will attempt to steal tasks from each other until all tasks are processed.
+pub struct WorkQueue<T> {
+    state: Arc<State<T>>,
+}
+
+struct State<T> {
+    /// A queue of factories that lazily produce tasks of type `T`.
+    task_factories: SegQueue<TaskFactory<T>>,
+
+    /// The total number of task factories that need to be constructed.
+    num_factories: usize,
+
+    /// How many factories have been constructed and had their tasks completely pushed into
+    /// a worker queue.
+    num_factories_constructed: AtomicUsize,
+
+    /// The vector of stealers, one for each worker.
+    stealers: RwLock<Vec<Stealer<T>>>,
+}
+
+impl<T> State<T> {
+    /// Loads a factory and pushes its tasks into the given worker queue.
+    ///
+    /// Returns `true` if any tasks were pushed into the worker. Note that these tasks may have
+    /// been stolen by the time the worker queue is checked.
+    fn load_next_factory(&self, worker: &Worker<T>) -> VortexResult<bool> {
+        if let Some(factory_fn) = self.task_factories.pop() {
+            let tasks = factory_fn()?;
+            for task in tasks {
+                worker.push(task);
+            }
+            self.num_factories_constructed.fetch_add(1, SeqCst);
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Attempts to steal work from other workers, returns `true` if work was stolen.
+    fn steal_work(&self, worker: &Worker<T>) -> Steal<()> {
+        // Repeatedly attempt to steal work from other workers until there are no retries.
+        iter::repeat_with(|| {
+            // This collect tries all stealers, exits early on the first successful steal,
+            // or else tracks whether any steal requires a retry.
+            self.stealers
+                .read()
+                .iter()
+                .map(|stealer| stealer.steal_batch(worker))
+                .collect::<Steal<()>>()
+        })
+        .find(|steal| !steal.is_retry())
+        .unwrap_or(Steal::Empty)
+    }
+}
+
+impl<T> WorkQueue<T> {
+    /// Created with lazily constructed task factories.
+    pub fn new<I>(factories: I) -> Self
+    where
+        I: IntoIterator<Item = TaskFactory<T>>,
+    {
+        let queue: SegQueue<TaskFactory<T>> = SegQueue::new();
+        for factory in factories.into_iter() {
+            queue.push(factory);
+        }
+        let num_factories = queue.len();
+
+        Self {
+            state: Arc::new(State {
+                task_factories: queue,
+                num_factories_constructed: AtomicUsize::new(0),
+                num_factories,
+                stealers: RwLock::new(Vec::new()),
+            }),
+        }
+    }
+
+    /// Creates a new worker to participate.
+    ///
+    /// The scan progresses when calling `next` on the iterator.
+    pub fn new_iterator(&self) -> WorkQueueIterator<T> {
+        let worker = Worker::new_fifo();
+
+        // Register the worker with the shared state.
+        self.state.stealers.write().push(worker.stealer());
+
+        WorkQueueIterator {
+            state: self.state.clone(),
+            worker,
+        }
+    }
+}
+
+/// Iterator yield tasks from the work-stealing queue.
+pub struct WorkQueueIterator<T> {
+    state: Arc<State<T>>,
+    worker: Worker<T>,
+}
+
+impl<T> Iterator for WorkQueueIterator<T> {
+    type Item = VortexResult<T>;
+
+    fn next(&mut self) -> Option<VortexResult<T>> {
+        if self.worker.is_empty() {
+            let next_factory_loaded = match self.state.load_next_factory(&self.worker) {
+                Ok(next_factory_loaded) => next_factory_loaded,
+                Err(e) => return Some(Err(e)),
+            };
+
+            if !next_factory_loaded {
+                // If there are no more factories to load, then there is at least one worker
+                // constructing a factory and about to push some tasks.
+                //
+                // We sit in a loop trying to steal some of those tasks, or else bail out when
+                // all scans have been constructed, and we didn't manage to steal anything. To avoid
+                // spinning too hot, we yield the thread each time we fail to steal work.
+                while self.state.num_factories_constructed.load(Relaxed) < self.state.num_factories
+                    || !self.state.steal_work(&self.worker).is_empty()
+                {
+                    if self.state.steal_work(&self.worker).is_success() {
+                        break;
+                    } else {
+                        std::thread::yield_now();
+                    }
+                }
+            }
+        }
+
+        Some(Ok(self.worker.pop()?))
+    }
+}


### PR DESCRIPTION
Pull out the work queue logic from multi-scan so we can reuse it for a single-scan, and possible for array exporting too.