### PR TITLE
fix: Prevent compressor from choosing SequenceArray for dictionary codes

### DIFF
--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -589,7 +589,7 @@ impl Scheme for DictScheme {
         let dict = dictionary_encode(stats)?;
 
         // Cascade the codes child
-        let mut new_excludes = vec![DICT_SCHEME];
+        let mut new_excludes = vec![DICT_SCHEME, SEQUENCE_SCHEME];
         new_excludes.extend_from_slice(excludes);
 
         let compressed_codes = IntCompressor::compress_no_dict(
@@ -728,6 +728,7 @@ mod tests {
     use vortex_array::vtable::ValidityHelper;
     use vortex_array::{Array, IntoArray, ToCanonical};
     use vortex_buffer::{Buffer, BufferMut, buffer, buffer_mut};
+    use vortex_dict::DictEncoding;
     use vortex_sequence::SequenceEncoding;
     use vortex_sparse::SparseEncoding;
     use vortex_utils::aliases::hash_set::HashSet;
@@ -771,7 +772,7 @@ mod tests {
 
         let primitive = codes.freeze().into_array().to_primitive().unwrap();
         let compressed = IntCompressor::compress(&primitive, false, 3, &[]).unwrap();
-        log::info!("compressed values: {}", compressed.display_tree());
+        assert_eq!(compressed.encoding_id(), DictEncoding.id());
     }
 
     #[test]

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -589,6 +589,7 @@ impl Scheme for DictScheme {
         let dict = dictionary_encode(stats)?;
 
         // Cascade the codes child
+        // Don't allow SequenceArray as the codes child as it merely adds extra indirection without actually compressing data.
         let mut new_excludes = vec![DICT_SCHEME, SEQUENCE_SCHEME];
         new_excludes.extend_from_slice(excludes);
 


### PR DESCRIPTION
fix #3976

Signed-off-by: Robert Kruszewski <github@robertk.io>
