### PR TITLE
chore: benchmark individual encoding throughputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6211,8 +6211,11 @@ name = "vortex"
 version = "0.1.0"
 dependencies = [
  "arrow-array",
+ "codspeed-divan-compat",
  "itertools 0.14.0",
+ "mimalloc",
  "parquet",
+ "rand 0.9.2",
  "tokio",
  "vortex",
  "vortex-alp",

--- a/vortex/Cargo.toml
+++ b/vortex/Cargo.toml
@@ -49,6 +49,7 @@ vortex-zstd = { workspace = true, optional = true }
 
 [dev-dependencies]
 arrow-array = { workspace = true }
+criterion = { workspace = true }
 itertools = { workspace = true }
 parquet = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
@@ -64,3 +65,8 @@ python = ["vortex-error/python"]
 tokio = ["vortex-file/tokio", "vortex-scan/tokio"]
 tracing = ["vortex-file/tracing", "vortex-layout/tracing"]
 zstd = ["dep:vortex-zstd", "vortex-file/zstd", "vortex-layout/zstd"]
+
+[[bench]]
+name = "single_encoding_throughput"
+harness = false
+test = false

--- a/vortex/Cargo.toml
+++ b/vortex/Cargo.toml
@@ -49,9 +49,11 @@ vortex-zstd = { workspace = true, optional = true }
 
 [dev-dependencies]
 arrow-array = { workspace = true }
-criterion = { workspace = true }
+divan = { workspace = true }
 itertools = { workspace = true }
+mimalloc = { workspace = true }
 parquet = { workspace = true }
+rand = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 vortex = { path = ".", features = ["parquet", "tokio"] }
 

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -1,0 +1,125 @@
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+use mimalloc::MiMalloc;
+use rand::distributions::Alphanumeric;
+use rand::seq::SliceRandom as _;
+use rand::{thread_rng, Rng, SeedableRng as _};
+use vortex::aliases::hash_set::HashSet;
+use vortex::array::VarBinViewArray;
+use vortex::buffer::Buffer;
+use vortex::compute::try_cast;
+use vortex::dtype::PType;
+use vortex::encodings::dict::dict_encode;
+use vortex::encodings::fsst::{fsst_compress, fsst_train_compressor};
+use vortex::sampling_compressor::compressors::alp::ALPCompressor;
+use vortex::sampling_compressor::compressors::alp_rd::ALPRDCompressor;
+use vortex::sampling_compressor::compressors::bitpacked::{
+    BITPACK_NO_PATCHES, BITPACK_WITH_PATCHES,
+};
+use vortex::sampling_compressor::compressors::delta::DeltaCompressor;
+use vortex::sampling_compressor::compressors::dict::DictCompressor;
+use vortex::sampling_compressor::compressors::r#for::FoRCompressor;
+use vortex::sampling_compressor::compressors::runend::DEFAULT_RUN_END_COMPRESSOR;
+use vortex::sampling_compressor::compressors::zigzag::ZigZagCompressor;
+use vortex::sampling_compressor::compressors::CompressorRef;
+use vortex::sampling_compressor::SamplingCompressor;
+use vortex::{IntoArray, IntoCanonical};
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
+fn primitive(c: &mut Criterion) {
+    let mut group = c.benchmark_group("primitive-decompression");
+    let num_values = u16::MAX as u64;
+    group.throughput(Throughput::Bytes(num_values * 4));
+
+    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+
+    let uint_array =
+        Buffer::from_iter((0..num_values).map(|_| rng.gen_range(0u32..256))).into_array();
+    let int_array = try_cast(uint_array.clone(), PType::I32.into()).unwrap();
+    let float_array = try_cast(uint_array.clone(), PType::F32.into()).unwrap();
+
+    let compressors_names_and_arrays = [
+        (
+            &BITPACK_NO_PATCHES as CompressorRef,
+            "bitpacked_no_patches",
+            &uint_array,
+        ),
+        (&BITPACK_WITH_PATCHES, "bitpacked_with_patches", &uint_array),
+        (&DEFAULT_RUN_END_COMPRESSOR, "runend", &uint_array),
+        (&DeltaCompressor, "delta", &uint_array),
+        (&DictCompressor, "dict", &uint_array),
+        (&FoRCompressor, "frame_of_reference", &int_array),
+        (&ZigZagCompressor, "zigzag", &int_array),
+        (&ALPCompressor, "alp", &float_array),
+        (&ALPRDCompressor, "alp_rd", &float_array),
+    ];
+
+    let ctx = SamplingCompressor::new(HashSet::new());
+    for (compressor, name, array) in compressors_names_and_arrays {
+        group.bench_function(format!("{} compress", name), |b| {
+            b.iter(|| {
+                black_box(
+                    compressor
+                        .compress(array, None, ctx.including(compressor))
+                        .unwrap(),
+                );
+            })
+        });
+
+        let compressed = compressor
+            .compress(array, None, ctx.including(compressor))
+            .unwrap()
+            .into_array();
+        group.bench_function(format!("{} decompress", name), |b| {
+            b.iter_batched(
+                || compressed.clone(),
+                |compressed| {
+                    black_box(compressed.into_canonical().unwrap());
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+}
+
+fn strings(c: &mut Criterion) {
+    let mut group = c.benchmark_group("string-decompression");
+    let num_values = u16::MAX as u64;
+    group.throughput(Throughput::Bytes(num_values * 8));
+
+    let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+    let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
+    group.throughput(Throughput::Bytes(
+        varbinview_arr.clone().into_array().nbytes() as u64,
+    ));
+    group.bench_function("dict_decode_varbinview", |b| {
+        b.iter(|| black_box(dict.clone().into_canonical().unwrap()));
+    });
+
+    let fsst_compressor = fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
+    let fsst_array = fsst_compress(&varbinview_arr.clone().into_array(), &fsst_compressor).unwrap();
+    group.bench_function("fsst_decompress_varbinview", |b| {
+        b.iter(|| black_box(fsst_array.clone().into_canonical().unwrap()));
+    });
+}
+
+fn gen_varbin_words(len: usize, uniqueness: f64) -> Vec<String> {
+    let mut rng = thread_rng();
+    let uniq_cnt = (len as f64 * uniqueness) as usize;
+    let dict: Vec<String> = (0..uniq_cnt)
+        .map(|_| {
+            (&mut rng)
+                .sample_iter(&Alphanumeric)
+                .take(8)
+                .map(char::from)
+                .collect()
+        })
+        .collect();
+    (0..len)
+        .map(|_| dict.choose(&mut rng).unwrap().clone())
+        .collect()
+}
+
+criterion_group!(benches, primitive, strings);
+criterion_main!(benches);

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -16,6 +16,7 @@ use vortex::encodings::fsst::{fsst_compress, fsst_train_compressor};
 use vortex::encodings::pco::PcoArray;
 use vortex::encodings::runend::RunEndArray;
 use vortex::encodings::zigzag::zigzag_encode;
+#[cfg(feature = "zstd")]
 use vortex::encodings::zstd::ZstdArray;
 use vortex::validity::Validity;
 use vortex::{IntoArray, ToCanonical};
@@ -242,6 +243,7 @@ mod primitive_decompression {
             .bench_values(|a| a.to_canonical().unwrap());
     }
 
+    #[cfg(feature = "zstd")]
     #[divan::bench(name = "zstd_compress")]
     fn bench_zstd_compress(bencher: Bencher) {
         let (uint_array, ..) = setup_arrays();
@@ -252,6 +254,7 @@ mod primitive_decompression {
             .bench_values(|a| ZstdArray::from_array(a.into_array(), 3, 8192).unwrap());
     }
 
+    #[cfg(feature = "zstd")]
     #[divan::bench(name = "zstd_decompress")]
     fn bench_zstd_decompress(bencher: Bencher) {
         let (uint_array, ..) = setup_arrays();

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -10,9 +10,7 @@ use vortex::arrays::{PrimitiveArray, VarBinViewArray};
 use vortex::compute::cast;
 use vortex::encodings::alp::{RDEncoder, alp_encode};
 use vortex::encodings::dict::builders::dict_encode;
-use vortex::encodings::fastlanes::{
-    DeltaArray, FoRArray, bitpack_to_best_bit_width, delta_compress,
-};
+use vortex::encodings::fastlanes::{DeltaArray, delta_compress};
 use vortex::encodings::fsst::{fsst_compress, fsst_train_compressor};
 use vortex::encodings::pco::PcoArray;
 use vortex::encodings::runend::RunEndArray;
@@ -52,21 +50,29 @@ mod primitive_decompression {
 
     #[divan::bench(name = "bitpacked_compress")]
     fn bench_bitpacked_compress(bencher: Bencher) {
+        use vortex::encodings::fastlanes::bitpack_encode_unchecked;
+
         let (uint_array, _, _) = setup_arrays();
+        let bit_width = 8;
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(|| bitpack_to_best_bit_width(&uint_array).unwrap());
+            .with_inputs(|| uint_array.clone())
+            .bench_values(|a| unsafe { bitpack_encode_unchecked(a, bit_width).unwrap() });
     }
 
     #[divan::bench(name = "bitpacked_decompress")]
     fn bench_bitpacked_decompress(bencher: Bencher) {
+        use vortex::encodings::fastlanes::bitpack_encode;
+
         let (uint_array, _, _) = setup_arrays();
-        let compressed = bitpack_to_best_bit_width(&uint_array).unwrap();
+        let bit_width = 8;
+        let compressed = bitpack_encode(&uint_array, bit_width, None).unwrap();
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(move || compressed.clone().to_canonical().unwrap());
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
     }
 
     #[divan::bench(name = "runend_compress")]
@@ -75,7 +81,8 @@ mod primitive_decompression {
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(|| RunEndArray::encode(uint_array.clone().into_array()).unwrap());
+            .with_inputs(|| uint_array.clone())
+            .bench_values(|a| RunEndArray::encode(a.into_array()).unwrap());
     }
 
     #[divan::bench(name = "runend_decompress")]
@@ -85,7 +92,8 @@ mod primitive_decompression {
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(move || compressed.clone().to_canonical().unwrap());
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
     }
 
     #[divan::bench(name = "delta_compress")]
@@ -94,8 +102,9 @@ mod primitive_decompression {
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(|| {
-                let (bases, deltas) = delta_compress(&uint_array).unwrap();
+            .with_inputs(|| uint_array.clone())
+            .bench_values(|a| {
+                let (bases, deltas) = delta_compress(&a).unwrap();
                 DeltaArray::try_from_delta_compress_parts(
                     bases.into_array(),
                     deltas.into_array(),
@@ -118,7 +127,8 @@ mod primitive_decompression {
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(move || compressed.clone().to_canonical().unwrap());
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
     }
 
     #[divan::bench(name = "dict_compress")]
@@ -127,7 +137,8 @@ mod primitive_decompression {
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(|| dict_encode(uint_array.as_ref()).unwrap());
+            .with_inputs(|| uint_array.clone())
+            .bench_values(|a| dict_encode(a.as_ref()).unwrap());
     }
 
     #[divan::bench(name = "dict_decompress")]
@@ -137,26 +148,8 @@ mod primitive_decompression {
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(move || compressed.clone().to_canonical().unwrap());
-    }
-
-    #[divan::bench(name = "frame_of_reference_compress")]
-    fn bench_for_compress(bencher: Bencher) {
-        let (_, int_array, _) = setup_arrays();
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(|| FoRArray::encode(int_array.clone()).unwrap());
-    }
-
-    #[divan::bench(name = "frame_of_reference_decompress")]
-    fn bench_for_decompress(bencher: Bencher) {
-        let (_, int_array, _) = setup_arrays();
-        let compressed = FoRArray::encode(int_array).unwrap();
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(move || compressed.clone().to_canonical().unwrap());
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
     }
 
     #[divan::bench(name = "zigzag_compress")]
@@ -165,7 +158,8 @@ mod primitive_decompression {
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(|| zigzag_encode(int_array.clone()).unwrap());
+            .with_inputs(|| int_array.clone())
+            .bench_values(|a| zigzag_encode(a).unwrap());
     }
 
     #[divan::bench(name = "zigzag_decompress")]
@@ -175,7 +169,8 @@ mod primitive_decompression {
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(move || compressed.clone().to_canonical().unwrap());
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
     }
 
     #[divan::bench(name = "alp_compress")]
@@ -184,7 +179,8 @@ mod primitive_decompression {
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(|| alp_encode(&float_array, None).unwrap());
+            .with_inputs(|| float_array.clone())
+            .bench_values(|a| alp_encode(&a, None).unwrap());
     }
 
     #[divan::bench(name = "alp_decompress")]
@@ -194,7 +190,8 @@ mod primitive_decompression {
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(move || compressed.clone().to_canonical().unwrap());
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
     }
 
     #[divan::bench(name = "alp_rd_compress")]
@@ -203,9 +200,10 @@ mod primitive_decompression {
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(|| {
-                let encoder = RDEncoder::new(float_array.as_slice::<f32>());
-                encoder.encode(&float_array)
+            .with_inputs(|| float_array.clone())
+            .bench_values(|a| {
+                let encoder = RDEncoder::new(a.as_slice::<f32>());
+                encoder.encode(&a)
             });
     }
 
@@ -217,7 +215,8 @@ mod primitive_decompression {
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(move || compressed.clone().to_canonical().unwrap());
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
     }
 
     #[divan::bench(name = "pcodec_compress")]
@@ -226,7 +225,8 @@ mod primitive_decompression {
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(|| PcoArray::from_primitive(&float_array, 3, 0).unwrap());
+            .with_inputs(|| float_array.clone())
+            .bench_values(|a| PcoArray::from_primitive(&a, 3, 0).unwrap());
     }
 
     #[divan::bench(name = "pcodec_decompress")]
@@ -236,7 +236,8 @@ mod primitive_decompression {
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(move || compressed.clone().to_canonical().unwrap());
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
     }
 
     #[divan::bench(name = "zstd_compress")]
@@ -245,9 +246,8 @@ mod primitive_decompression {
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(|| {
-                ZstdArray::from_array(uint_array.clone().into_array(), 3, 8192).unwrap()
-            });
+            .with_inputs(|| uint_array.clone())
+            .bench_values(|a| ZstdArray::from_array(a.into_array(), 3, 8192).unwrap());
     }
 
     #[divan::bench(name = "zstd_decompress")]
@@ -257,7 +257,8 @@ mod primitive_decompression {
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
-            .bench_local(move || compressed.clone().to_canonical().unwrap());
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
     }
 }
 
@@ -290,7 +291,8 @@ mod string_decompression {
 
         bencher
             .counter(BytesCount::new(nbytes))
-            .bench_local(move || dict.clone().to_canonical().unwrap());
+            .with_inputs(|| dict.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
     }
 
     #[divan::bench(name = "fsst_decompress_varbinview")]
@@ -303,6 +305,7 @@ mod string_decompression {
 
         bencher
             .counter(BytesCount::new(nbytes))
-            .bench_local(move || fsst_array.clone().to_canonical().unwrap());
+            .with_inputs(|| fsst_array.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
     }
 }

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -2,313 +2,320 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 #![allow(clippy::unwrap_used)]
+#![allow(unexpected_cfgs)]
 
-use divan::Bencher;
-use divan::counter::BytesCount;
-use mimalloc::MiMalloc;
-use rand::{Rng, SeedableRng};
-use vortex::arrays::{PrimitiveArray, VarBinViewArray};
-use vortex::compute::cast;
-use vortex::encodings::alp::{RDEncoder, alp_encode};
-use vortex::encodings::dict::builders::dict_encode;
-use vortex::encodings::fastlanes::{DeltaArray, delta_compress};
-use vortex::encodings::fsst::{fsst_compress, fsst_train_compressor};
-use vortex::encodings::pco::PcoArray;
-use vortex::encodings::runend::RunEndArray;
-use vortex::encodings::zigzag::zigzag_encode;
-use vortex::encodings::zstd::ZstdArray;
-use vortex::validity::Validity;
-use vortex::{IntoArray, ToCanonical};
+#[cfg(not(codspeed))]
+mod benchmarks {
+    use divan::Bencher;
+    use divan::counter::BytesCount;
+    use mimalloc::MiMalloc;
+    use rand::{Rng, SeedableRng};
+    use vortex::arrays::{PrimitiveArray, VarBinViewArray};
+    use vortex::compute::cast;
+    use vortex::encodings::alp::{RDEncoder, alp_encode};
+    use vortex::encodings::dict::builders::dict_encode;
+    use vortex::encodings::fastlanes::{DeltaArray, delta_compress};
+    use vortex::encodings::fsst::{fsst_compress, fsst_train_compressor};
+    use vortex::encodings::pco::PcoArray;
+    use vortex::encodings::runend::RunEndArray;
+    use vortex::encodings::zigzag::zigzag_encode;
+    use vortex::encodings::zstd::ZstdArray;
+    use vortex::validity::Validity;
+    use vortex::{IntoArray, ToCanonical};
 
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
+    #[global_allocator]
+    static GLOBAL: MiMalloc = MiMalloc;
+
+    const NUM_VALUES: u64 = 1_000_000;
+
+    #[divan::bench_group]
+    mod primitive_decompression {
+        use vortex::dtype::PType;
+
+        use super::*;
+
+        fn setup_arrays() -> (PrimitiveArray, PrimitiveArray, PrimitiveArray) {
+            let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+            let uint_array =
+                PrimitiveArray::from_iter((0..NUM_VALUES).map(|_| rng.random_range(0u32..256)));
+            let int_array = cast(uint_array.as_ref(), PType::I32.into())
+                .unwrap()
+                .to_primitive()
+                .unwrap();
+            let float_array = cast(uint_array.as_ref(), PType::F32.into())
+                .unwrap()
+                .to_primitive()
+                .unwrap();
+            (uint_array, int_array, float_array)
+        }
+
+        #[divan::bench(name = "bitpacked_compress")]
+        fn bench_bitpacked_compress(bencher: Bencher) {
+            use vortex::encodings::fastlanes::bitpack_encode_unchecked;
+
+            let (uint_array, ..) = setup_arrays();
+            let bit_width = 8;
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| uint_array.clone())
+                .bench_values(|a| unsafe { bitpack_encode_unchecked(a, bit_width).unwrap() });
+        }
+
+        #[divan::bench(name = "bitpacked_decompress")]
+        fn bench_bitpacked_decompress(bencher: Bencher) {
+            use vortex::encodings::fastlanes::bitpack_encode;
+
+            let (uint_array, ..) = setup_arrays();
+            let bit_width = 8;
+            let compressed = bitpack_encode(&uint_array, bit_width, None).unwrap();
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| compressed.clone())
+                .bench_values(|a| a.to_canonical().unwrap());
+        }
+
+        #[divan::bench(name = "runend_compress")]
+        fn bench_runend_compress(bencher: Bencher) {
+            let (uint_array, ..) = setup_arrays();
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| uint_array.clone())
+                .bench_values(|a| RunEndArray::encode(a.into_array()).unwrap());
+        }
+
+        #[divan::bench(name = "runend_decompress")]
+        fn bench_runend_decompress(bencher: Bencher) {
+            let (uint_array, ..) = setup_arrays();
+            let compressed = RunEndArray::encode(uint_array.into_array()).unwrap();
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| compressed.clone())
+                .bench_values(|a| a.to_canonical().unwrap());
+        }
+
+        #[divan::bench(name = "delta_compress")]
+        fn bench_delta_compress(bencher: Bencher) {
+            let (uint_array, ..) = setup_arrays();
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| uint_array.clone())
+                .bench_values(|a| {
+                    let (bases, deltas) = delta_compress(&a).unwrap();
+                    DeltaArray::try_from_delta_compress_parts(
+                        bases.into_array(),
+                        deltas.into_array(),
+                        Validity::NonNullable,
+                    )
+                    .unwrap()
+                });
+        }
+
+        #[divan::bench(name = "delta_decompress")]
+        fn bench_delta_decompress(bencher: Bencher) {
+            let (uint_array, ..) = setup_arrays();
+            let (bases, deltas) = delta_compress(&uint_array).unwrap();
+            let compressed = DeltaArray::try_from_delta_compress_parts(
+                bases.into_array(),
+                deltas.into_array(),
+                Validity::NonNullable,
+            )
+            .unwrap();
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| compressed.clone())
+                .bench_values(|a| a.to_canonical().unwrap());
+        }
+
+        #[divan::bench(name = "dict_compress")]
+        fn bench_dict_compress(bencher: Bencher) {
+            let (uint_array, ..) = setup_arrays();
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| uint_array.clone())
+                .bench_values(|a| dict_encode(a.as_ref()).unwrap());
+        }
+
+        #[divan::bench(name = "dict_decompress")]
+        fn bench_dict_decompress(bencher: Bencher) {
+            let (uint_array, ..) = setup_arrays();
+            let compressed = dict_encode(uint_array.as_ref()).unwrap();
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| compressed.clone())
+                .bench_values(|a| a.to_canonical().unwrap());
+        }
+
+        #[divan::bench(name = "zigzag_compress")]
+        fn bench_zigzag_compress(bencher: Bencher) {
+            let (_, int_array, _) = setup_arrays();
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| int_array.clone())
+                .bench_values(|a| zigzag_encode(a).unwrap());
+        }
+
+        #[divan::bench(name = "zigzag_decompress")]
+        fn bench_zigzag_decompress(bencher: Bencher) {
+            let (_, int_array, _) = setup_arrays();
+            let compressed = zigzag_encode(int_array).unwrap();
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| compressed.clone())
+                .bench_values(|a| a.to_canonical().unwrap());
+        }
+
+        #[divan::bench(name = "alp_compress")]
+        fn bench_alp_compress(bencher: Bencher) {
+            let (_, _, float_array) = setup_arrays();
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| float_array.clone())
+                .bench_values(|a| alp_encode(&a, None).unwrap());
+        }
+
+        #[divan::bench(name = "alp_decompress")]
+        fn bench_alp_decompress(bencher: Bencher) {
+            let (_, _, float_array) = setup_arrays();
+            let compressed = alp_encode(&float_array, None).unwrap();
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| compressed.clone())
+                .bench_values(|a| a.to_canonical().unwrap());
+        }
+
+        #[divan::bench(name = "alp_rd_compress")]
+        fn bench_alp_rd_compress(bencher: Bencher) {
+            let (_, _, float_array) = setup_arrays();
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| float_array.clone())
+                .bench_values(|a| {
+                    let encoder = RDEncoder::new(a.as_slice::<f32>());
+                    encoder.encode(&a)
+                });
+        }
+
+        #[divan::bench(name = "alp_rd_decompress")]
+        fn bench_alp_rd_decompress(bencher: Bencher) {
+            let (_, _, float_array) = setup_arrays();
+            let encoder = RDEncoder::new(float_array.as_slice::<f32>());
+            let compressed = encoder.encode(&float_array);
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| compressed.clone())
+                .bench_values(|a| a.to_canonical().unwrap());
+        }
+
+        #[divan::bench(name = "pcodec_compress")]
+        fn bench_pcodec_compress(bencher: Bencher) {
+            let (_, _, float_array) = setup_arrays();
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| float_array.clone())
+                .bench_values(|a| PcoArray::from_primitive(&a, 3, 0).unwrap());
+        }
+
+        #[divan::bench(name = "pcodec_decompress")]
+        fn bench_pcodec_decompress(bencher: Bencher) {
+            let (_, _, float_array) = setup_arrays();
+            let compressed = PcoArray::from_primitive(&float_array, 3, 0).unwrap();
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| compressed.clone())
+                .bench_values(|a| a.to_canonical().unwrap());
+        }
+
+        #[divan::bench(name = "zstd_compress")]
+        fn bench_zstd_compress(bencher: Bencher) {
+            let (uint_array, ..) = setup_arrays();
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| uint_array.clone())
+                .bench_values(|a| ZstdArray::from_array(a.into_array(), 3, 8192).unwrap());
+        }
+
+        #[divan::bench(name = "zstd_decompress")]
+        fn bench_zstd_decompress(bencher: Bencher) {
+            let (uint_array, ..) = setup_arrays();
+            let compressed = ZstdArray::from_array(uint_array.into_array(), 3, 8192).unwrap();
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| compressed.clone())
+                .bench_values(|a| a.to_canonical().unwrap());
+        }
+    }
+
+    #[divan::bench_group]
+    mod string_decompression {
+        use rand::prelude::IndexedRandom;
+
+        use super::*;
+
+        #[allow(clippy::cast_possible_truncation)]
+        fn gen_varbin_words(len: usize, uniqueness: f64) -> Vec<String> {
+            let mut rng = rand::rng();
+            let uniq_cnt = (len as f64 * uniqueness) as usize;
+            let dict: Vec<String> = (0..uniq_cnt)
+                .map(|_| {
+                    (0..8)
+                        .map(|_| (rng.random_range(b'a'..=b'z')) as char)
+                        .collect()
+                })
+                .collect();
+            (0..len)
+                .map(|_| dict.choose(&mut rng).unwrap().clone())
+                .collect()
+        }
+
+        #[divan::bench(name = "dict_decode_varbinview")]
+        fn bench_dict_decode_varbinview(bencher: Bencher) {
+            let varbinview_arr =
+                VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+            let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
+            let nbytes = varbinview_arr.into_array().nbytes() as u64;
+
+            bencher
+                .counter(BytesCount::new(nbytes))
+                .with_inputs(|| dict.clone())
+                .bench_values(|a| a.to_canonical().unwrap());
+        }
+
+        #[divan::bench(name = "fsst_decompress_varbinview")]
+        fn bench_fsst_decompress_varbinview(bencher: Bencher) {
+            let varbinview_arr =
+                VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+            let fsst_compressor =
+                fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
+            let fsst_array =
+                fsst_compress(&varbinview_arr.clone().into_array(), &fsst_compressor).unwrap();
+            let nbytes = varbinview_arr.into_array().nbytes() as u64;
+
+            bencher
+                .counter(BytesCount::new(nbytes))
+                .with_inputs(|| fsst_array.clone())
+                .bench_values(|a| a.to_canonical().unwrap());
+        }
+    }
+}
 
 fn main() {
-    divan::main();
-}
-
-const NUM_VALUES: u64 = 1_000_000;
-
-#[divan::bench_group]
-mod primitive_decompression {
-    use vortex::dtype::PType;
-
-    use super::*;
-
-    fn setup_arrays() -> (PrimitiveArray, PrimitiveArray, PrimitiveArray) {
-        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
-        let uint_array =
-            PrimitiveArray::from_iter((0..NUM_VALUES).map(|_| rng.random_range(0u32..256)));
-        let int_array = cast(uint_array.as_ref(), PType::I32.into())
-            .unwrap()
-            .to_primitive()
-            .unwrap();
-        let float_array = cast(uint_array.as_ref(), PType::F32.into())
-            .unwrap()
-            .to_primitive()
-            .unwrap();
-        (uint_array, int_array, float_array)
-    }
-
-    #[divan::bench(name = "bitpacked_compress")]
-    fn bench_bitpacked_compress(bencher: Bencher) {
-        use vortex::encodings::fastlanes::bitpack_encode_unchecked;
-
-        let (uint_array, ..) = setup_arrays();
-        let bit_width = 8;
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .with_inputs(|| uint_array.clone())
-            .bench_values(|a| unsafe { bitpack_encode_unchecked(a, bit_width).unwrap() });
-    }
-
-    #[divan::bench(name = "bitpacked_decompress")]
-    fn bench_bitpacked_decompress(bencher: Bencher) {
-        use vortex::encodings::fastlanes::bitpack_encode;
-
-        let (uint_array, ..) = setup_arrays();
-        let bit_width = 8;
-        let compressed = bitpack_encode(&uint_array, bit_width, None).unwrap();
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-
-    #[divan::bench(name = "runend_compress")]
-    fn bench_runend_compress(bencher: Bencher) {
-        let (uint_array, ..) = setup_arrays();
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .with_inputs(|| uint_array.clone())
-            .bench_values(|a| RunEndArray::encode(a.into_array()).unwrap());
-    }
-
-    #[divan::bench(name = "runend_decompress")]
-    fn bench_runend_decompress(bencher: Bencher) {
-        let (uint_array, ..) = setup_arrays();
-        let compressed = RunEndArray::encode(uint_array.into_array()).unwrap();
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-
-    #[divan::bench(name = "delta_compress")]
-    fn bench_delta_compress(bencher: Bencher) {
-        let (uint_array, ..) = setup_arrays();
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .with_inputs(|| uint_array.clone())
-            .bench_values(|a| {
-                let (bases, deltas) = delta_compress(&a).unwrap();
-                DeltaArray::try_from_delta_compress_parts(
-                    bases.into_array(),
-                    deltas.into_array(),
-                    Validity::NonNullable,
-                )
-                .unwrap()
-            });
-    }
-
-    #[divan::bench(name = "delta_decompress")]
-    fn bench_delta_decompress(bencher: Bencher) {
-        let (uint_array, ..) = setup_arrays();
-        let (bases, deltas) = delta_compress(&uint_array).unwrap();
-        let compressed = DeltaArray::try_from_delta_compress_parts(
-            bases.into_array(),
-            deltas.into_array(),
-            Validity::NonNullable,
-        )
-        .unwrap();
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-
-    #[divan::bench(name = "dict_compress")]
-    fn bench_dict_compress(bencher: Bencher) {
-        let (uint_array, ..) = setup_arrays();
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .with_inputs(|| uint_array.clone())
-            .bench_values(|a| dict_encode(a.as_ref()).unwrap());
-    }
-
-    #[divan::bench(name = "dict_decompress")]
-    fn bench_dict_decompress(bencher: Bencher) {
-        let (uint_array, ..) = setup_arrays();
-        let compressed = dict_encode(uint_array.as_ref()).unwrap();
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-
-    #[divan::bench(name = "zigzag_compress")]
-    fn bench_zigzag_compress(bencher: Bencher) {
-        let (_, int_array, _) = setup_arrays();
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .with_inputs(|| int_array.clone())
-            .bench_values(|a| zigzag_encode(a).unwrap());
-    }
-
-    #[divan::bench(name = "zigzag_decompress")]
-    fn bench_zigzag_decompress(bencher: Bencher) {
-        let (_, int_array, _) = setup_arrays();
-        let compressed = zigzag_encode(int_array).unwrap();
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-
-    #[divan::bench(name = "alp_compress")]
-    fn bench_alp_compress(bencher: Bencher) {
-        let (_, _, float_array) = setup_arrays();
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .with_inputs(|| float_array.clone())
-            .bench_values(|a| alp_encode(&a, None).unwrap());
-    }
-
-    #[divan::bench(name = "alp_decompress")]
-    fn bench_alp_decompress(bencher: Bencher) {
-        let (_, _, float_array) = setup_arrays();
-        let compressed = alp_encode(&float_array, None).unwrap();
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-
-    #[divan::bench(name = "alp_rd_compress")]
-    fn bench_alp_rd_compress(bencher: Bencher) {
-        let (_, _, float_array) = setup_arrays();
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .with_inputs(|| float_array.clone())
-            .bench_values(|a| {
-                let encoder = RDEncoder::new(a.as_slice::<f32>());
-                encoder.encode(&a)
-            });
-    }
-
-    #[divan::bench(name = "alp_rd_decompress")]
-    fn bench_alp_rd_decompress(bencher: Bencher) {
-        let (_, _, float_array) = setup_arrays();
-        let encoder = RDEncoder::new(float_array.as_slice::<f32>());
-        let compressed = encoder.encode(&float_array);
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-
-    #[divan::bench(name = "pcodec_compress")]
-    fn bench_pcodec_compress(bencher: Bencher) {
-        let (_, _, float_array) = setup_arrays();
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .with_inputs(|| float_array.clone())
-            .bench_values(|a| PcoArray::from_primitive(&a, 3, 0).unwrap());
-    }
-
-    #[divan::bench(name = "pcodec_decompress")]
-    fn bench_pcodec_decompress(bencher: Bencher) {
-        let (_, _, float_array) = setup_arrays();
-        let compressed = PcoArray::from_primitive(&float_array, 3, 0).unwrap();
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-
-    #[divan::bench(name = "zstd_compress")]
-    fn bench_zstd_compress(bencher: Bencher) {
-        let (uint_array, ..) = setup_arrays();
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .with_inputs(|| uint_array.clone())
-            .bench_values(|a| ZstdArray::from_array(a.into_array(), 3, 8192).unwrap());
-    }
-
-    #[divan::bench(name = "zstd_decompress")]
-    fn bench_zstd_decompress(bencher: Bencher) {
-        let (uint_array, ..) = setup_arrays();
-        let compressed = ZstdArray::from_array(uint_array.into_array(), 3, 8192).unwrap();
-
-        bencher
-            .counter(BytesCount::new(NUM_VALUES * 4))
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-}
-
-#[divan::bench_group]
-mod string_decompression {
-    use rand::prelude::IndexedRandom;
-
-    use super::*;
-
-    #[allow(clippy::cast_possible_truncation)]
-    fn gen_varbin_words(len: usize, uniqueness: f64) -> Vec<String> {
-        let mut rng = rand::rng();
-        let uniq_cnt = (len as f64 * uniqueness) as usize;
-        let dict: Vec<String> = (0..uniq_cnt)
-            .map(|_| {
-                (0..8)
-                    .map(|_| (rng.random_range(b'a'..=b'z')) as char)
-                    .collect()
-            })
-            .collect();
-        (0..len)
-            .map(|_| dict.choose(&mut rng).unwrap().clone())
-            .collect()
-    }
-
-    #[divan::bench(name = "dict_decode_varbinview")]
-    fn bench_dict_decode_varbinview(bencher: Bencher) {
-        let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-        let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
-        let nbytes = varbinview_arr.into_array().nbytes() as u64;
-
-        bencher
-            .counter(BytesCount::new(nbytes))
-            .with_inputs(|| dict.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-
-    #[divan::bench(name = "fsst_decompress_varbinview")]
-    fn bench_fsst_decompress_varbinview(bencher: Bencher) {
-        let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-        let fsst_compressor = fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
-        let fsst_array =
-            fsst_compress(&varbinview_arr.clone().into_array(), &fsst_compressor).unwrap();
-        let nbytes = varbinview_arr.into_array().nbytes() as u64;
-
-        bencher
-            .counter(BytesCount::new(nbytes))
-            .with_inputs(|| fsst_array.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
+    divan::main()
 }

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -39,7 +39,10 @@ macro_rules! with_counter {
         #[cfg(not(codspeed))]
         let bencher = $bencher.counter(BytesCount::new($bytes));
         #[cfg(codspeed)]
-        let bencher = $bencher;
+        let bencher = {
+            let _ = $bytes; // Consume the bytes value to avoid unused variable warning
+            $bencher
+        };
         bencher
     }};
 }

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -14,7 +14,7 @@ mod benchmarks {
     use vortex::compute::cast;
     use vortex::encodings::alp::{RDEncoder, alp_encode};
     use vortex::encodings::dict::builders::dict_encode;
-    use vortex::encodings::fastlanes::{DeltaArray, delta_compress};
+    use vortex::encodings::fastlanes::{DeltaArray, FoRArray, delta_compress};
     use vortex::encodings::fsst::{fsst_compress, fsst_train_compressor};
     use vortex::encodings::pco::PcoArray;
     use vortex::encodings::runend::RunEndArray;
@@ -37,7 +37,7 @@ mod benchmarks {
         fn setup_arrays() -> (PrimitiveArray, PrimitiveArray, PrimitiveArray) {
             let mut rng = rand::rngs::StdRng::seed_from_u64(0);
             let uint_array =
-                PrimitiveArray::from_iter((0..NUM_VALUES).map(|_| rng.random_range(0u32..256)));
+                PrimitiveArray::from_iter((0..NUM_VALUES).map(|_| rng.random_range(42u32..256)));
             let int_array = cast(uint_array.as_ref(), PType::I32.into())
                 .unwrap()
                 .to_primitive()
@@ -125,6 +125,27 @@ mod benchmarks {
                 Validity::NonNullable,
             )
             .unwrap();
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| compressed.clone())
+                .bench_values(|a| a.to_canonical().unwrap());
+        }
+
+        #[divan::bench(name = "for_compress")]
+        fn bench_for_compress(bencher: Bencher) {
+            let (uint_array, ..) = setup_arrays();
+
+            bencher
+                .counter(BytesCount::new(NUM_VALUES * 4))
+                .with_inputs(|| uint_array.clone())
+                .bench_values(|a| FoRArray::encode(a).unwrap());
+        }
+
+        #[divan::bench(name = "for_decompress")]
+        fn bench_for_decompress(bencher: Bencher) {
+            let (uint_array, ..) = setup_arrays();
+            let compressed = FoRArray::encode(uint_array).unwrap();
 
             bencher
                 .counter(BytesCount::new(NUM_VALUES * 4))
@@ -287,8 +308,20 @@ mod benchmarks {
                 .collect()
         }
 
-        #[divan::bench(name = "dict_decode_varbinview")]
-        fn bench_dict_decode_varbinview(bencher: Bencher) {
+        #[divan::bench(name = "dict_compress_varbinview")]
+        fn bench_dict_compress_varbinview(bencher: Bencher) {
+            let varbinview_arr =
+                VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+            let nbytes = varbinview_arr.nbytes() as u64;
+
+            bencher
+                .counter(BytesCount::new(nbytes))
+                .with_inputs(|| varbinview_arr.clone())
+                .bench_values(|a| dict_encode(a.as_ref()).unwrap());
+        }
+
+        #[divan::bench(name = "dict_decompress_varbinview")]
+        fn bench_dict_decompress_varbinview(bencher: Bencher) {
             let varbinview_arr =
                 VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
             let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
@@ -298,6 +331,20 @@ mod benchmarks {
                 .counter(BytesCount::new(nbytes))
                 .with_inputs(|| dict.clone())
                 .bench_values(|a| a.to_canonical().unwrap());
+        }
+
+        #[divan::bench(name = "fsst_compress_varbinview")]
+        fn bench_fsst_compress_varbinview(bencher: Bencher) {
+            let varbinview_arr =
+                VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+            let fsst_compressor =
+                fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
+            let nbytes = varbinview_arr.nbytes() as u64;
+
+            bencher
+                .counter(BytesCount::new(nbytes))
+                .with_inputs(|| varbinview_arr.clone())
+                .bench_values(|a| fsst_compress(&a.into_array(), &fsst_compressor).unwrap());
         }
 
         #[divan::bench(name = "fsst_decompress_varbinview")]
@@ -313,6 +360,34 @@ mod benchmarks {
             bencher
                 .counter(BytesCount::new(nbytes))
                 .with_inputs(|| fsst_array.clone())
+                .bench_values(|a| a.to_canonical().unwrap());
+        }
+
+        #[cfg(feature = "zstd")]
+        #[divan::bench(name = "zstd_compress_varbinview")]
+        fn bench_zstd_compress_varbinview(bencher: Bencher) {
+            let varbinview_arr =
+                VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+            let nbytes = varbinview_arr.nbytes() as u64;
+
+            bencher
+                .counter(BytesCount::new(nbytes))
+                .with_inputs(|| varbinview_arr.clone())
+                .bench_values(|a| ZstdArray::from_array(a.into_array(), 3, 8192).unwrap());
+        }
+
+        #[cfg(feature = "zstd")]
+        #[divan::bench(name = "zstd_decompress_varbinview")]
+        fn bench_zstd_decompress_varbinview(bencher: Bencher) {
+            let varbinview_arr =
+                VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+            let compressed =
+                ZstdArray::from_array(varbinview_arr.clone().into_array(), 3, 8192).unwrap();
+            let nbytes = varbinview_arr.into_array().nbytes() as u64;
+
+            bencher
+                .counter(BytesCount::new(nbytes))
+                .with_inputs(|| compressed.clone())
                 .bench_values(|a| a.to_canonical().unwrap());
         }
     }

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -33,15 +33,13 @@ const NUM_VALUES: u64 = 1_000_000;
 
 // Helper macro to conditionally add counter based on codspeed cfg
 macro_rules! with_counter {
-    ($bencher:expr, $bytes:expr) => {
-        {
-            #[cfg(not(codspeed))]
-            let bencher = $bencher.counter(BytesCount::new($bytes));
-            #[cfg(codspeed)]
-            let bencher = $bencher;
-            bencher
-        }
-    };
+    ($bencher:expr, $bytes:expr) => {{
+        #[cfg(not(codspeed))]
+        let bencher = $bencher.counter(BytesCount::new($bytes));
+        #[cfg(codspeed)]
+        let bencher = $bencher;
+        bencher
+    }};
 }
 
 #[divan::bench_group]
@@ -51,236 +49,236 @@ mod primitive_decompression {
     use super::*;
 
     fn setup_arrays() -> (PrimitiveArray, PrimitiveArray, PrimitiveArray) {
-            let mut rng = rand::rngs::StdRng::seed_from_u64(0);
-            let uint_array =
-                PrimitiveArray::from_iter((0..NUM_VALUES).map(|_| rng.random_range(42u32..256)));
-            let int_array = cast(uint_array.as_ref(), PType::I32.into())
-                .unwrap()
-                .to_primitive()
-                .unwrap();
-            let float_array = cast(uint_array.as_ref(), PType::F32.into())
-                .unwrap()
-                .to_primitive()
-                .unwrap();
-            (uint_array, int_array, float_array)
-        }
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+        let uint_array =
+            PrimitiveArray::from_iter((0..NUM_VALUES).map(|_| rng.random_range(42u32..256)));
+        let int_array = cast(uint_array.as_ref(), PType::I32.into())
+            .unwrap()
+            .to_primitive()
+            .unwrap();
+        let float_array = cast(uint_array.as_ref(), PType::F32.into())
+            .unwrap()
+            .to_primitive()
+            .unwrap();
+        (uint_array, int_array, float_array)
+    }
 
     #[divan::bench(name = "bitpacked_compress")]
     fn bench_bitpacked_compress(bencher: Bencher) {
-            use vortex::encodings::fastlanes::bitpack_encode_unchecked;
+        use vortex::encodings::fastlanes::bitpack_encode_unchecked;
 
-            let (uint_array, ..) = setup_arrays();
-            let bit_width = 8;
+        let (uint_array, ..) = setup_arrays();
+        let bit_width = 8;
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| uint_array.clone())
-                .bench_values(|a| unsafe { bitpack_encode_unchecked(a, bit_width).unwrap() });
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| uint_array.clone())
+            .bench_values(|a| unsafe { bitpack_encode_unchecked(a, bit_width).unwrap() });
+    }
 
     #[divan::bench(name = "bitpacked_decompress")]
     fn bench_bitpacked_decompress(bencher: Bencher) {
-            use vortex::encodings::fastlanes::bitpack_encode;
+        use vortex::encodings::fastlanes::bitpack_encode;
 
-            let (uint_array, ..) = setup_arrays();
-            let bit_width = 8;
-            let compressed = bitpack_encode(&uint_array, bit_width, None).unwrap();
+        let (uint_array, ..) = setup_arrays();
+        let bit_width = 8;
+        let compressed = bitpack_encode(&uint_array, bit_width, None).unwrap();
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| compressed.clone())
-                .bench_values(|a| a.to_canonical().unwrap());
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
+    }
 
     #[divan::bench(name = "runend_compress")]
     fn bench_runend_compress(bencher: Bencher) {
-            let (uint_array, ..) = setup_arrays();
+        let (uint_array, ..) = setup_arrays();
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| uint_array.clone())
-                .bench_values(|a| RunEndArray::encode(a.into_array()).unwrap());
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| uint_array.clone())
+            .bench_values(|a| RunEndArray::encode(a.into_array()).unwrap());
+    }
 
     #[divan::bench(name = "runend_decompress")]
     fn bench_runend_decompress(bencher: Bencher) {
-            let (uint_array, ..) = setup_arrays();
-            let compressed = RunEndArray::encode(uint_array.into_array()).unwrap();
+        let (uint_array, ..) = setup_arrays();
+        let compressed = RunEndArray::encode(uint_array.into_array()).unwrap();
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| compressed.clone())
-                .bench_values(|a| a.to_canonical().unwrap());
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
+    }
 
     #[divan::bench(name = "delta_compress")]
     fn bench_delta_compress(bencher: Bencher) {
-            let (uint_array, ..) = setup_arrays();
+        let (uint_array, ..) = setup_arrays();
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| uint_array.clone())
-                .bench_values(|a| {
-                    let (bases, deltas) = delta_compress(&a).unwrap();
-                    DeltaArray::try_from_delta_compress_parts(
-                        bases.into_array(),
-                        deltas.into_array(),
-                        Validity::NonNullable,
-                    )
-                    .unwrap()
-                });
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| uint_array.clone())
+            .bench_values(|a| {
+                let (bases, deltas) = delta_compress(&a).unwrap();
+                DeltaArray::try_from_delta_compress_parts(
+                    bases.into_array(),
+                    deltas.into_array(),
+                    Validity::NonNullable,
+                )
+                .unwrap()
+            });
+    }
 
     #[divan::bench(name = "delta_decompress")]
     fn bench_delta_decompress(bencher: Bencher) {
-            let (uint_array, ..) = setup_arrays();
-            let (bases, deltas) = delta_compress(&uint_array).unwrap();
-            let compressed = DeltaArray::try_from_delta_compress_parts(
-                bases.into_array(),
-                deltas.into_array(),
-                Validity::NonNullable,
-            )
-            .unwrap();
+        let (uint_array, ..) = setup_arrays();
+        let (bases, deltas) = delta_compress(&uint_array).unwrap();
+        let compressed = DeltaArray::try_from_delta_compress_parts(
+            bases.into_array(),
+            deltas.into_array(),
+            Validity::NonNullable,
+        )
+        .unwrap();
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| compressed.clone())
-                .bench_values(|a| a.to_canonical().unwrap());
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
+    }
 
     #[divan::bench(name = "for_compress")]
     fn bench_for_compress(bencher: Bencher) {
-            let (uint_array, ..) = setup_arrays();
+        let (uint_array, ..) = setup_arrays();
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| uint_array.clone())
-                .bench_values(|a| FoRArray::encode(a).unwrap());
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| uint_array.clone())
+            .bench_values(|a| FoRArray::encode(a).unwrap());
+    }
 
     #[divan::bench(name = "for_decompress")]
     fn bench_for_decompress(bencher: Bencher) {
-            let (uint_array, ..) = setup_arrays();
-            let compressed = FoRArray::encode(uint_array).unwrap();
+        let (uint_array, ..) = setup_arrays();
+        let compressed = FoRArray::encode(uint_array).unwrap();
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| compressed.clone())
-                .bench_values(|a| a.to_canonical().unwrap());
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
+    }
 
     #[divan::bench(name = "dict_compress")]
     fn bench_dict_compress(bencher: Bencher) {
-            let (uint_array, ..) = setup_arrays();
+        let (uint_array, ..) = setup_arrays();
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| uint_array.clone())
-                .bench_values(|a| dict_encode(a.as_ref()).unwrap());
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| uint_array.clone())
+            .bench_values(|a| dict_encode(a.as_ref()).unwrap());
+    }
 
     #[divan::bench(name = "dict_decompress")]
     fn bench_dict_decompress(bencher: Bencher) {
-            let (uint_array, ..) = setup_arrays();
-            let compressed = dict_encode(uint_array.as_ref()).unwrap();
+        let (uint_array, ..) = setup_arrays();
+        let compressed = dict_encode(uint_array.as_ref()).unwrap();
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| compressed.clone())
-                .bench_values(|a| a.to_canonical().unwrap());
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
+    }
 
     #[divan::bench(name = "zigzag_compress")]
     fn bench_zigzag_compress(bencher: Bencher) {
-            let (_, int_array, _) = setup_arrays();
+        let (_, int_array, _) = setup_arrays();
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| int_array.clone())
-                .bench_values(|a| zigzag_encode(a).unwrap());
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| int_array.clone())
+            .bench_values(|a| zigzag_encode(a).unwrap());
+    }
 
     #[divan::bench(name = "zigzag_decompress")]
     fn bench_zigzag_decompress(bencher: Bencher) {
-            let (_, int_array, _) = setup_arrays();
-            let compressed = zigzag_encode(int_array).unwrap();
+        let (_, int_array, _) = setup_arrays();
+        let compressed = zigzag_encode(int_array).unwrap();
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| compressed.clone())
-                .bench_values(|a| a.to_canonical().unwrap());
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
+    }
 
     #[divan::bench(name = "alp_compress")]
     fn bench_alp_compress(bencher: Bencher) {
-            let (_, _, float_array) = setup_arrays();
+        let (_, _, float_array) = setup_arrays();
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| float_array.clone())
-                .bench_values(|a| alp_encode(&a, None).unwrap());
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| float_array.clone())
+            .bench_values(|a| alp_encode(&a, None).unwrap());
+    }
 
     #[divan::bench(name = "alp_decompress")]
     fn bench_alp_decompress(bencher: Bencher) {
-            let (_, _, float_array) = setup_arrays();
-            let compressed = alp_encode(&float_array, None).unwrap();
+        let (_, _, float_array) = setup_arrays();
+        let compressed = alp_encode(&float_array, None).unwrap();
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| compressed.clone())
-                .bench_values(|a| a.to_canonical().unwrap());
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
+    }
 
     #[divan::bench(name = "alp_rd_compress")]
     fn bench_alp_rd_compress(bencher: Bencher) {
-            let (_, _, float_array) = setup_arrays();
+        let (_, _, float_array) = setup_arrays();
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| float_array.clone())
-                .bench_values(|a| {
-                    let encoder = RDEncoder::new(a.as_slice::<f32>());
-                    encoder.encode(&a)
-                });
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| float_array.clone())
+            .bench_values(|a| {
+                let encoder = RDEncoder::new(a.as_slice::<f32>());
+                encoder.encode(&a)
+            });
+    }
 
     #[divan::bench(name = "alp_rd_decompress")]
     fn bench_alp_rd_decompress(bencher: Bencher) {
-            let (_, _, float_array) = setup_arrays();
-            let encoder = RDEncoder::new(float_array.as_slice::<f32>());
-            let compressed = encoder.encode(&float_array);
+        let (_, _, float_array) = setup_arrays();
+        let encoder = RDEncoder::new(float_array.as_slice::<f32>());
+        let compressed = encoder.encode(&float_array);
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| compressed.clone())
-                .bench_values(|a| a.to_canonical().unwrap());
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
+    }
 
     #[divan::bench(name = "pcodec_compress")]
     fn bench_pcodec_compress(bencher: Bencher) {
-            let (_, _, float_array) = setup_arrays();
+        let (_, _, float_array) = setup_arrays();
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| float_array.clone())
-                .bench_values(|a| PcoArray::from_primitive(&a, 3, 0).unwrap());
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| float_array.clone())
+            .bench_values(|a| PcoArray::from_primitive(&a, 3, 0).unwrap());
+    }
 
     #[divan::bench(name = "pcodec_decompress")]
     fn bench_pcodec_decompress(bencher: Bencher) {
-            let (_, _, float_array) = setup_arrays();
-            let compressed = PcoArray::from_primitive(&float_array, 3, 0).unwrap();
+        let (_, _, float_array) = setup_arrays();
+        let compressed = PcoArray::from_primitive(&float_array, 3, 0).unwrap();
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| compressed.clone())
-                .bench_values(|a| a.to_canonical().unwrap());
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
+    }
 
     #[cfg(feature = "zstd")]
     #[divan::bench(name = "zstd_compress")]
     fn bench_zstd_compress(bencher: Bencher) {
-            let (uint_array, ..) = setup_arrays();
+        let (uint_array, ..) = setup_arrays();
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| uint_array.clone())
-                .bench_values(|a| ZstdArray::from_array(a.into_array(), 3, 8192).unwrap());
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| uint_array.clone())
+            .bench_values(|a| ZstdArray::from_array(a.into_array(), 3, 8192).unwrap());
+    }
 
     #[cfg(feature = "zstd")]
     #[divan::bench(name = "zstd_decompress")]
     fn bench_zstd_decompress(bencher: Bencher) {
-            let (uint_array, ..) = setup_arrays();
-            let compressed = ZstdArray::from_array(uint_array.into_array(), 3, 8192).unwrap();
+        let (uint_array, ..) = setup_arrays();
+        let compressed = ZstdArray::from_array(uint_array.into_array(), 3, 8192).unwrap();
 
-            with_counter!(bencher, NUM_VALUES * 4)
-                .with_inputs(|| compressed.clone())
-                .bench_values(|a| a.to_canonical().unwrap());
-        }
+        with_counter!(bencher, NUM_VALUES * 4)
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
     }
+}
 
 #[divan::bench_group]
 mod string_decompression {
@@ -290,94 +288,86 @@ mod string_decompression {
 
     #[allow(clippy::cast_possible_truncation)]
     fn gen_varbin_words(len: usize, uniqueness: f64) -> Vec<String> {
-            let mut rng = rand::rng();
-            let uniq_cnt = (len as f64 * uniqueness) as usize;
-            let dict: Vec<String> = (0..uniq_cnt)
-                .map(|_| {
-                    (0..8)
-                        .map(|_| (rng.random_range(b'a'..=b'z')) as char)
-                        .collect()
-                })
-                .collect();
-            (0..len)
-                .map(|_| dict.choose(&mut rng).unwrap().clone())
-                .collect()
-        }
+        let mut rng = rand::rng();
+        let uniq_cnt = (len as f64 * uniqueness) as usize;
+        let dict: Vec<String> = (0..uniq_cnt)
+            .map(|_| {
+                (0..8)
+                    .map(|_| (rng.random_range(b'a'..=b'z')) as char)
+                    .collect()
+            })
+            .collect();
+        (0..len)
+            .map(|_| dict.choose(&mut rng).unwrap().clone())
+            .collect()
+    }
 
     #[divan::bench(name = "dict_compress_varbinview")]
     fn bench_dict_compress_varbinview(bencher: Bencher) {
-            let varbinview_arr =
-                VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-            let nbytes = varbinview_arr.nbytes() as u64;
+        let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+        let nbytes = varbinview_arr.nbytes() as u64;
 
-            with_counter!(bencher, nbytes)
-                .with_inputs(|| varbinview_arr.clone())
-                .bench_values(|a| dict_encode(a.as_ref()).unwrap());
-        }
+        with_counter!(bencher, nbytes)
+            .with_inputs(|| varbinview_arr.clone())
+            .bench_values(|a| dict_encode(a.as_ref()).unwrap());
+    }
 
     #[divan::bench(name = "dict_decompress_varbinview")]
     fn bench_dict_decompress_varbinview(bencher: Bencher) {
-            let varbinview_arr =
-                VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-            let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
-            let nbytes = varbinview_arr.into_array().nbytes() as u64;
+        let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+        let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
+        let nbytes = varbinview_arr.into_array().nbytes() as u64;
 
-            with_counter!(bencher, nbytes)
-                .with_inputs(|| dict.clone())
-                .bench_values(|a| a.to_canonical().unwrap());
-        }
+        with_counter!(bencher, nbytes)
+            .with_inputs(|| dict.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
+    }
 
     #[divan::bench(name = "fsst_compress_varbinview")]
     fn bench_fsst_compress_varbinview(bencher: Bencher) {
-            let varbinview_arr =
-                VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-            let fsst_compressor =
-                fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
-            let nbytes = varbinview_arr.nbytes() as u64;
+        let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+        let fsst_compressor = fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
+        let nbytes = varbinview_arr.nbytes() as u64;
 
-            with_counter!(bencher, nbytes)
-                .with_inputs(|| varbinview_arr.clone())
-                .bench_values(|a| fsst_compress(&a.into_array(), &fsst_compressor).unwrap());
-        }
+        with_counter!(bencher, nbytes)
+            .with_inputs(|| varbinview_arr.clone())
+            .bench_values(|a| fsst_compress(&a.into_array(), &fsst_compressor).unwrap());
+    }
 
     #[divan::bench(name = "fsst_decompress_varbinview")]
     fn bench_fsst_decompress_varbinview(bencher: Bencher) {
-            let varbinview_arr =
-                VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-            let fsst_compressor =
-                fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
-            let fsst_array =
-                fsst_compress(&varbinview_arr.clone().into_array(), &fsst_compressor).unwrap();
-            let nbytes = varbinview_arr.into_array().nbytes() as u64;
+        let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+        let fsst_compressor = fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
+        let fsst_array =
+            fsst_compress(&varbinview_arr.clone().into_array(), &fsst_compressor).unwrap();
+        let nbytes = varbinview_arr.into_array().nbytes() as u64;
 
-            with_counter!(bencher, nbytes)
-                .with_inputs(|| fsst_array.clone())
-                .bench_values(|a| a.to_canonical().unwrap());
-        }
+        with_counter!(bencher, nbytes)
+            .with_inputs(|| fsst_array.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
+    }
 
     #[cfg(feature = "zstd")]
     #[divan::bench(name = "zstd_compress_varbinview")]
     fn bench_zstd_compress_varbinview(bencher: Bencher) {
-            let varbinview_arr =
-                VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-            let nbytes = varbinview_arr.nbytes() as u64;
+        let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+        let nbytes = varbinview_arr.nbytes() as u64;
 
-            with_counter!(bencher, nbytes)
-                .with_inputs(|| varbinview_arr.clone())
-                .bench_values(|a| ZstdArray::from_array(a.into_array(), 3, 8192).unwrap());
-        }
+        with_counter!(bencher, nbytes)
+            .with_inputs(|| varbinview_arr.clone())
+            .bench_values(|a| ZstdArray::from_array(a.into_array(), 3, 8192).unwrap());
+    }
 
     #[cfg(feature = "zstd")]
     #[divan::bench(name = "zstd_decompress_varbinview")]
     fn bench_zstd_decompress_varbinview(bencher: Bencher) {
-            let varbinview_arr =
-                VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-            let compressed =
-                ZstdArray::from_array(varbinview_arr.clone().into_array(), 3, 8192).unwrap();
-            let nbytes = varbinview_arr.into_array().nbytes() as u64;
+        let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+        let compressed =
+            ZstdArray::from_array(varbinview_arr.clone().into_array(), 3, 8192).unwrap();
+        let nbytes = varbinview_arr.into_array().nbytes() as u64;
 
-            with_counter!(bencher, nbytes)
-                .with_inputs(|| compressed.clone())
-                .bench_values(|a| a.to_canonical().unwrap());
+        with_counter!(bencher, nbytes)
+            .with_inputs(|| compressed.clone())
+            .bench_values(|a| a.to_canonical().unwrap());
     }
 }

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -3,20 +3,23 @@
 
 #![allow(clippy::unwrap_used)]
 
-use divan::Bencher;
+use divan::{Bencher, counter::BytesCount};
 use mimalloc::MiMalloc;
 use rand::{Rng, SeedableRng};
 use vortex::arrays::{PrimitiveArray, VarBinViewArray};
-use vortex::compressor::BtrBlocksCompressor;
 use vortex::compute::cast;
-use vortex::encodings::alp::{alp_encode, RDEncoder};
+use vortex::encodings::alp::{RDEncoder, alp_encode};
 use vortex::encodings::dict::builders::dict_encode;
-use vortex::encodings::fastlanes::{bitpack_to_best_bit_width, delta_compress, DeltaArray, FoRArray};
+use vortex::encodings::fastlanes::{
+    DeltaArray, FoRArray, bitpack_to_best_bit_width, delta_compress,
+};
 use vortex::encodings::fsst::{fsst_compress, fsst_train_compressor};
+use vortex::encodings::pco::PcoArray;
 use vortex::encodings::runend::RunEndArray;
 use vortex::encodings::zigzag::zigzag_encode;
+use vortex::encodings::zstd::ZstdArray;
 use vortex::validity::Validity;
-use vortex::{Array, IntoArray, ToCanonical};
+use vortex::{IntoArray, ToCanonical};
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
@@ -25,7 +28,7 @@ fn main() {
     divan::main();
 }
 
-const NUM_VALUES: u64 = u16::MAX as u64;
+const NUM_VALUES: u64 = 1_000_000;
 
 #[divan::bench_group]
 mod primitive_decompression {
@@ -34,7 +37,8 @@ mod primitive_decompression {
 
     fn setup_arrays() -> (PrimitiveArray, PrimitiveArray, PrimitiveArray) {
         let mut rng = rand::rngs::StdRng::seed_from_u64(0);
-        let uint_array = PrimitiveArray::from_iter((0..NUM_VALUES).map(|_| rng.random_range(0u32..256)));
+        let uint_array =
+            PrimitiveArray::from_iter((0..NUM_VALUES).map(|_| rng.random_range(0u32..256)));
         let int_array = cast(uint_array.as_ref(), PType::I32.into())
             .unwrap()
             .to_primitive()
@@ -49,62 +53,55 @@ mod primitive_decompression {
     #[divan::bench(name = "bitpacked_compress")]
     fn bench_bitpacked_compress(bencher: Bencher) {
         let (uint_array, _, _) = setup_arrays();
-        
+
         bencher
-            .counter(NUM_VALUES * 4)
-            .bench_local(|| {
-                bitpack_to_best_bit_width(&uint_array).unwrap()
-            });
+            .counter(BytesCount::new(NUM_VALUES * 4))
+            .bench_local(|| bitpack_to_best_bit_width(&uint_array).unwrap());
     }
 
     #[divan::bench(name = "bitpacked_decompress")]
     fn bench_bitpacked_decompress(bencher: Bencher) {
         let (uint_array, _, _) = setup_arrays();
         let compressed = bitpack_to_best_bit_width(&uint_array).unwrap();
-        
+
         bencher
-            .counter(NUM_VALUES * 4)
-            .bench_local(move || {
-                compressed.clone().to_canonical().unwrap()
-            });
+            .counter(BytesCount::new(NUM_VALUES * 4))
+            .bench_local(move || compressed.clone().to_canonical().unwrap());
     }
 
     #[divan::bench(name = "runend_compress")]
     fn bench_runend_compress(bencher: Bencher) {
         let (uint_array, _, _) = setup_arrays();
-        
+
         bencher
-            .counter(NUM_VALUES * 4)
-            .bench_local(|| {
-                RunEndArray::encode(uint_array.clone().into_array()).unwrap()
-            });
+            .counter(BytesCount::new(NUM_VALUES * 4))
+            .bench_local(|| RunEndArray::encode(uint_array.clone().into_array()).unwrap());
     }
 
     #[divan::bench(name = "runend_decompress")]
     fn bench_runend_decompress(bencher: Bencher) {
         let (uint_array, _, _) = setup_arrays();
-        let compressed = RunEndArray::encode(uint_array.clone().into_array()).unwrap();
-        
+        let compressed = RunEndArray::encode(uint_array.into_array()).unwrap();
+
         bencher
-            .counter(NUM_VALUES * 4)
-            .bench_local(move || {
-                compressed.clone().to_canonical().unwrap()
-            });
+            .counter(BytesCount::new(NUM_VALUES * 4))
+            .bench_local(move || compressed.clone().to_canonical().unwrap());
     }
 
     #[divan::bench(name = "delta_compress")]
     fn bench_delta_compress(bencher: Bencher) {
         let (uint_array, _, _) = setup_arrays();
-        
+
         bencher
-            .counter(NUM_VALUES * 4)
+            .counter(BytesCount::new(NUM_VALUES * 4))
             .bench_local(|| {
                 let (bases, deltas) = delta_compress(&uint_array).unwrap();
                 DeltaArray::try_from_delta_compress_parts(
                     bases.into_array(),
                     deltas.into_array(),
-                    Validity::NonNullable
-                ).unwrap()
+                    Validity::NonNullable,
+                )
+                .unwrap()
             });
     }
 
@@ -115,114 +112,97 @@ mod primitive_decompression {
         let compressed = DeltaArray::try_from_delta_compress_parts(
             bases.into_array(),
             deltas.into_array(),
-            Validity::NonNullable
-        ).unwrap();
-        
+            Validity::NonNullable,
+        )
+        .unwrap();
+
         bencher
-            .counter(NUM_VALUES * 4)
-            .bench_local(move || {
-                compressed.clone().to_canonical().unwrap()
-            });
+            .counter(BytesCount::new(NUM_VALUES * 4))
+            .bench_local(move || compressed.clone().to_canonical().unwrap());
     }
 
     #[divan::bench(name = "dict_compress")]
     fn bench_dict_compress(bencher: Bencher) {
         let (uint_array, _, _) = setup_arrays();
-        
+
         bencher
-            .counter(NUM_VALUES * 4)
-            .bench_local(|| {
-                dict_encode(uint_array.as_ref()).unwrap()
-            });
+            .counter(BytesCount::new(NUM_VALUES * 4))
+            .bench_local(|| dict_encode(uint_array.as_ref()).unwrap());
     }
 
     #[divan::bench(name = "dict_decompress")]
     fn bench_dict_decompress(bencher: Bencher) {
         let (uint_array, _, _) = setup_arrays();
         let compressed = dict_encode(uint_array.as_ref()).unwrap();
-        
+
         bencher
-            .counter(NUM_VALUES * 4)
-            .bench_local(move || {
-                compressed.clone().to_canonical().unwrap()
-            });
+            .counter(BytesCount::new(NUM_VALUES * 4))
+            .bench_local(move || compressed.clone().to_canonical().unwrap());
     }
 
     #[divan::bench(name = "frame_of_reference_compress")]
     fn bench_for_compress(bencher: Bencher) {
         let (_, int_array, _) = setup_arrays();
-        
+
         bencher
-            .counter(NUM_VALUES * 4)
-            .bench_local(|| {
-                FoRArray::encode(int_array.clone()).unwrap()
-            });
+            .counter(BytesCount::new(NUM_VALUES * 4))
+            .bench_local(|| FoRArray::encode(int_array.clone()).unwrap());
     }
 
     #[divan::bench(name = "frame_of_reference_decompress")]
     fn bench_for_decompress(bencher: Bencher) {
         let (_, int_array, _) = setup_arrays();
-        let compressed = FoRArray::encode(int_array.clone()).unwrap();
-        
+        let compressed = FoRArray::encode(int_array).unwrap();
+
         bencher
-            .counter(NUM_VALUES * 4)
-            .bench_local(move || {
-                compressed.clone().to_canonical().unwrap()
-            });
+            .counter(BytesCount::new(NUM_VALUES * 4))
+            .bench_local(move || compressed.clone().to_canonical().unwrap());
     }
 
     #[divan::bench(name = "zigzag_compress")]
     fn bench_zigzag_compress(bencher: Bencher) {
         let (_, int_array, _) = setup_arrays();
-        
+
         bencher
-            .counter(NUM_VALUES * 4)
-            .bench_local(|| {
-                zigzag_encode(int_array.clone()).unwrap()
-            });
+            .counter(BytesCount::new(NUM_VALUES * 4))
+            .bench_local(|| zigzag_encode(int_array.clone()).unwrap());
     }
 
     #[divan::bench(name = "zigzag_decompress")]
     fn bench_zigzag_decompress(bencher: Bencher) {
         let (_, int_array, _) = setup_arrays();
-        let compressed = zigzag_encode(int_array.clone()).unwrap();
-        
+        let compressed = zigzag_encode(int_array).unwrap();
+
         bencher
-            .counter(NUM_VALUES * 4)
-            .bench_local(move || {
-                compressed.clone().to_canonical().unwrap()
-            });
+            .counter(BytesCount::new(NUM_VALUES * 4))
+            .bench_local(move || compressed.clone().to_canonical().unwrap());
     }
 
     #[divan::bench(name = "alp_compress")]
     fn bench_alp_compress(bencher: Bencher) {
         let (_, _, float_array) = setup_arrays();
-        
+
         bencher
-            .counter(NUM_VALUES * 4)
-            .bench_local(|| {
-                alp_encode(&float_array, None).unwrap()
-            });
+            .counter(BytesCount::new(NUM_VALUES * 4))
+            .bench_local(|| alp_encode(&float_array, None).unwrap());
     }
 
     #[divan::bench(name = "alp_decompress")]
     fn bench_alp_decompress(bencher: Bencher) {
         let (_, _, float_array) = setup_arrays();
         let compressed = alp_encode(&float_array, None).unwrap();
-        
+
         bencher
-            .counter(NUM_VALUES * 4)
-            .bench_local(move || {
-                compressed.clone().to_canonical().unwrap()
-            });
+            .counter(BytesCount::new(NUM_VALUES * 4))
+            .bench_local(move || compressed.clone().to_canonical().unwrap());
     }
 
     #[divan::bench(name = "alp_rd_compress")]
     fn bench_alp_rd_compress(bencher: Bencher) {
         let (_, _, float_array) = setup_arrays();
-        
+
         bencher
-            .counter(NUM_VALUES * 4)
+            .counter(BytesCount::new(NUM_VALUES * 4))
             .bench_local(|| {
                 let encoder = RDEncoder::new(float_array.as_slice::<f32>());
                 encoder.encode(&float_array)
@@ -234,35 +214,50 @@ mod primitive_decompression {
         let (_, _, float_array) = setup_arrays();
         let encoder = RDEncoder::new(float_array.as_slice::<f32>());
         let compressed = encoder.encode(&float_array);
-        
+
         bencher
-            .counter(NUM_VALUES * 4)
-            .bench_local(move || {
-                compressed.clone().to_canonical().unwrap()
-            });
+            .counter(BytesCount::new(NUM_VALUES * 4))
+            .bench_local(move || compressed.clone().to_canonical().unwrap());
     }
 
-    #[divan::bench(name = "btrblocks_compress")]
-    fn bench_btrblocks_compress(bencher: Bencher) {
-        let (uint_array, _, _) = setup_arrays();
-        
+    #[divan::bench(name = "pcodec_compress")]
+    fn bench_pcodec_compress(bencher: Bencher) {
+        let (_, _, float_array) = setup_arrays();
+
         bencher
-            .counter(NUM_VALUES * 4)
+            .counter(BytesCount::new(NUM_VALUES * 4))
+            .bench_local(|| PcoArray::from_primitive(&float_array, 3, 0).unwrap());
+    }
+
+    #[divan::bench(name = "pcodec_decompress")]
+    fn bench_pcodec_decompress(bencher: Bencher) {
+        let (_, _, float_array) = setup_arrays();
+        let compressed = PcoArray::from_primitive(&float_array, 3, 0).unwrap();
+
+        bencher
+            .counter(BytesCount::new(NUM_VALUES * 4))
+            .bench_local(move || compressed.clone().to_canonical().unwrap());
+    }
+
+    #[divan::bench(name = "zstd_compress")]
+    fn bench_zstd_compress(bencher: Bencher) {
+        let (uint_array, _, _) = setup_arrays();
+
+        bencher
+            .counter(BytesCount::new(NUM_VALUES * 4))
             .bench_local(|| {
-                BtrBlocksCompressor.compress(uint_array.as_ref()).unwrap()
+                ZstdArray::from_array(uint_array.clone().into_array(), 3, 8192).unwrap()
             });
     }
 
-    #[divan::bench(name = "btrblocks_decompress")]
-    fn bench_btrblocks_decompress(bencher: Bencher) {
+    #[divan::bench(name = "zstd_decompress")]
+    fn bench_zstd_decompress(bencher: Bencher) {
         let (uint_array, _, _) = setup_arrays();
-        let compressed = BtrBlocksCompressor.compress(uint_array.as_ref()).unwrap();
-        
+        let compressed = ZstdArray::from_array(uint_array.into_array(), 3, 8192).unwrap();
+
         bencher
-            .counter(NUM_VALUES * 4)
-            .bench_local(move || {
-                compressed.clone().to_canonical().unwrap()
-            });
+            .counter(BytesCount::new(NUM_VALUES * 4))
+            .bench_local(move || compressed.clone().to_canonical().unwrap());
     }
 }
 
@@ -271,6 +266,7 @@ mod string_decompression {
     use super::*;
     use rand::prelude::IndexedRandom;
 
+    #[allow(clippy::cast_possible_truncation)]
     fn gen_varbin_words(len: usize, uniqueness: f64) -> Vec<String> {
         let mut rng = rand::rng();
         let uniq_cnt = (len as f64 * uniqueness) as usize;
@@ -290,26 +286,23 @@ mod string_decompression {
     fn bench_dict_decode_varbinview(bencher: Bencher) {
         let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
         let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
-        let nbytes = varbinview_arr.clone().into_array().nbytes() as u64;
-        
+        let nbytes = varbinview_arr.into_array().nbytes() as u64;
+
         bencher
-            .counter(nbytes)
-            .bench_local(move || {
-                dict.clone().to_canonical().unwrap()
-            });
+            .counter(BytesCount::new(nbytes))
+            .bench_local(move || dict.clone().to_canonical().unwrap());
     }
 
     #[divan::bench(name = "fsst_decompress_varbinview")]
     fn bench_fsst_decompress_varbinview(bencher: Bencher) {
         let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
         let fsst_compressor = fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
-        let fsst_array = fsst_compress(&varbinview_arr.clone().into_array(), &fsst_compressor).unwrap();
-        let nbytes = varbinview_arr.clone().into_array().nbytes() as u64;
-        
+        let fsst_array =
+            fsst_compress(&varbinview_arr.clone().into_array(), &fsst_compressor).unwrap();
+        let nbytes = varbinview_arr.into_array().nbytes() as u64;
+
         bencher
-            .counter(nbytes)
-            .bench_local(move || {
-                fsst_array.clone().to_canonical().unwrap()
-            });
+            .counter(BytesCount::new(nbytes))
+            .bench_local(move || fsst_array.clone().to_canonical().unwrap());
     }
 }

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -3,7 +3,8 @@
 
 #![allow(clippy::unwrap_used)]
 
-use divan::{Bencher, counter::BytesCount};
+use divan::Bencher;
+use divan::counter::BytesCount;
 use mimalloc::MiMalloc;
 use rand::{Rng, SeedableRng};
 use vortex::arrays::{PrimitiveArray, VarBinViewArray};
@@ -30,8 +31,9 @@ const NUM_VALUES: u64 = 1_000_000;
 
 #[divan::bench_group]
 mod primitive_decompression {
-    use super::*;
     use vortex::dtype::PType;
+
+    use super::*;
 
     fn setup_arrays() -> (PrimitiveArray, PrimitiveArray, PrimitiveArray) {
         let mut rng = rand::rngs::StdRng::seed_from_u64(0);
@@ -52,7 +54,7 @@ mod primitive_decompression {
     fn bench_bitpacked_compress(bencher: Bencher) {
         use vortex::encodings::fastlanes::bitpack_encode_unchecked;
 
-        let (uint_array, _, _) = setup_arrays();
+        let (uint_array, ..) = setup_arrays();
         let bit_width = 8;
 
         bencher
@@ -65,7 +67,7 @@ mod primitive_decompression {
     fn bench_bitpacked_decompress(bencher: Bencher) {
         use vortex::encodings::fastlanes::bitpack_encode;
 
-        let (uint_array, _, _) = setup_arrays();
+        let (uint_array, ..) = setup_arrays();
         let bit_width = 8;
         let compressed = bitpack_encode(&uint_array, bit_width, None).unwrap();
 
@@ -77,7 +79,7 @@ mod primitive_decompression {
 
     #[divan::bench(name = "runend_compress")]
     fn bench_runend_compress(bencher: Bencher) {
-        let (uint_array, _, _) = setup_arrays();
+        let (uint_array, ..) = setup_arrays();
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
@@ -87,7 +89,7 @@ mod primitive_decompression {
 
     #[divan::bench(name = "runend_decompress")]
     fn bench_runend_decompress(bencher: Bencher) {
-        let (uint_array, _, _) = setup_arrays();
+        let (uint_array, ..) = setup_arrays();
         let compressed = RunEndArray::encode(uint_array.into_array()).unwrap();
 
         bencher
@@ -98,7 +100,7 @@ mod primitive_decompression {
 
     #[divan::bench(name = "delta_compress")]
     fn bench_delta_compress(bencher: Bencher) {
-        let (uint_array, _, _) = setup_arrays();
+        let (uint_array, ..) = setup_arrays();
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
@@ -116,7 +118,7 @@ mod primitive_decompression {
 
     #[divan::bench(name = "delta_decompress")]
     fn bench_delta_decompress(bencher: Bencher) {
-        let (uint_array, _, _) = setup_arrays();
+        let (uint_array, ..) = setup_arrays();
         let (bases, deltas) = delta_compress(&uint_array).unwrap();
         let compressed = DeltaArray::try_from_delta_compress_parts(
             bases.into_array(),
@@ -133,7 +135,7 @@ mod primitive_decompression {
 
     #[divan::bench(name = "dict_compress")]
     fn bench_dict_compress(bencher: Bencher) {
-        let (uint_array, _, _) = setup_arrays();
+        let (uint_array, ..) = setup_arrays();
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
@@ -143,7 +145,7 @@ mod primitive_decompression {
 
     #[divan::bench(name = "dict_decompress")]
     fn bench_dict_decompress(bencher: Bencher) {
-        let (uint_array, _, _) = setup_arrays();
+        let (uint_array, ..) = setup_arrays();
         let compressed = dict_encode(uint_array.as_ref()).unwrap();
 
         bencher
@@ -242,7 +244,7 @@ mod primitive_decompression {
 
     #[divan::bench(name = "zstd_compress")]
     fn bench_zstd_compress(bencher: Bencher) {
-        let (uint_array, _, _) = setup_arrays();
+        let (uint_array, ..) = setup_arrays();
 
         bencher
             .counter(BytesCount::new(NUM_VALUES * 4))
@@ -252,7 +254,7 @@ mod primitive_decompression {
 
     #[divan::bench(name = "zstd_decompress")]
     fn bench_zstd_decompress(bencher: Bencher) {
-        let (uint_array, _, _) = setup_arrays();
+        let (uint_array, ..) = setup_arrays();
         let compressed = ZstdArray::from_array(uint_array.into_array(), 3, 8192).unwrap();
 
         bencher
@@ -264,8 +266,9 @@ mod primitive_decompression {
 
 #[divan::bench_group]
 mod string_decompression {
-    use super::*;
     use rand::prelude::IndexedRandom;
+
+    use super::*;
 
     #[allow(clippy::cast_possible_truncation)]
     fn gen_varbin_words(len: usize, uniqueness: f64) -> Vec<String> {

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -8,9 +8,11 @@ use divan::Bencher;
 #[cfg(not(codspeed))]
 use divan::counter::BytesCount;
 use mimalloc::MiMalloc;
+use rand::prelude::IndexedRandom;
 use rand::{Rng, SeedableRng};
 use vortex::arrays::{PrimitiveArray, VarBinViewArray};
 use vortex::compute::cast;
+use vortex::dtype::PType;
 use vortex::encodings::alp::{RDEncoder, alp_encode};
 use vortex::encodings::dict::builders::dict_encode;
 use vortex::encodings::fastlanes::{DeltaArray, FoRArray, delta_compress};
@@ -42,332 +44,319 @@ macro_rules! with_counter {
     }};
 }
 
-#[divan::bench_group]
-mod primitive_decompression {
-    use vortex::dtype::PType;
-
-    use super::*;
-
-    fn setup_arrays() -> (PrimitiveArray, PrimitiveArray, PrimitiveArray) {
-        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
-        let uint_array =
-            PrimitiveArray::from_iter((0..NUM_VALUES).map(|_| rng.random_range(42u32..256)));
-        let int_array = cast(uint_array.as_ref(), PType::I32.into())
-            .unwrap()
-            .to_primitive()
-            .unwrap();
-        let float_array = cast(uint_array.as_ref(), PType::F32.into())
-            .unwrap()
-            .to_primitive()
-            .unwrap();
-        (uint_array, int_array, float_array)
-    }
-
-    #[divan::bench(name = "bitpacked_compress")]
-    fn bench_bitpacked_compress(bencher: Bencher) {
-        use vortex::encodings::fastlanes::bitpack_encode_unchecked;
-
-        let (uint_array, ..) = setup_arrays();
-        let bit_width = 8;
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| uint_array.clone())
-            .bench_values(|a| unsafe { bitpack_encode_unchecked(a, bit_width).unwrap() });
-    }
-
-    #[divan::bench(name = "bitpacked_decompress")]
-    fn bench_bitpacked_decompress(bencher: Bencher) {
-        use vortex::encodings::fastlanes::bitpack_encode;
-
-        let (uint_array, ..) = setup_arrays();
-        let bit_width = 8;
-        let compressed = bitpack_encode(&uint_array, bit_width, None).unwrap();
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-
-    #[divan::bench(name = "runend_compress")]
-    fn bench_runend_compress(bencher: Bencher) {
-        let (uint_array, ..) = setup_arrays();
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| uint_array.clone())
-            .bench_values(|a| RunEndArray::encode(a.into_array()).unwrap());
-    }
-
-    #[divan::bench(name = "runend_decompress")]
-    fn bench_runend_decompress(bencher: Bencher) {
-        let (uint_array, ..) = setup_arrays();
-        let compressed = RunEndArray::encode(uint_array.into_array()).unwrap();
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-
-    #[divan::bench(name = "delta_compress")]
-    fn bench_delta_compress(bencher: Bencher) {
-        let (uint_array, ..) = setup_arrays();
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| uint_array.clone())
-            .bench_values(|a| {
-                let (bases, deltas) = delta_compress(&a).unwrap();
-                DeltaArray::try_from_delta_compress_parts(
-                    bases.into_array(),
-                    deltas.into_array(),
-                    Validity::NonNullable,
-                )
-                .unwrap()
-            });
-    }
-
-    #[divan::bench(name = "delta_decompress")]
-    fn bench_delta_decompress(bencher: Bencher) {
-        let (uint_array, ..) = setup_arrays();
-        let (bases, deltas) = delta_compress(&uint_array).unwrap();
-        let compressed = DeltaArray::try_from_delta_compress_parts(
-            bases.into_array(),
-            deltas.into_array(),
-            Validity::NonNullable,
-        )
+// Setup functions
+fn setup_primitive_arrays() -> (PrimitiveArray, PrimitiveArray, PrimitiveArray) {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+    let uint_array =
+        PrimitiveArray::from_iter((0..NUM_VALUES).map(|_| rng.random_range(42u32..256)));
+    let int_array = cast(uint_array.as_ref(), PType::I32.into())
+        .unwrap()
+        .to_primitive()
         .unwrap();
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-
-    #[divan::bench(name = "for_compress")]
-    fn bench_for_compress(bencher: Bencher) {
-        let (uint_array, ..) = setup_arrays();
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| uint_array.clone())
-            .bench_values(|a| FoRArray::encode(a).unwrap());
-    }
-
-    #[divan::bench(name = "for_decompress")]
-    fn bench_for_decompress(bencher: Bencher) {
-        let (uint_array, ..) = setup_arrays();
-        let compressed = FoRArray::encode(uint_array).unwrap();
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-
-    #[divan::bench(name = "dict_compress")]
-    fn bench_dict_compress(bencher: Bencher) {
-        let (uint_array, ..) = setup_arrays();
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| uint_array.clone())
-            .bench_values(|a| dict_encode(a.as_ref()).unwrap());
-    }
-
-    #[divan::bench(name = "dict_decompress")]
-    fn bench_dict_decompress(bencher: Bencher) {
-        let (uint_array, ..) = setup_arrays();
-        let compressed = dict_encode(uint_array.as_ref()).unwrap();
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-
-    #[divan::bench(name = "zigzag_compress")]
-    fn bench_zigzag_compress(bencher: Bencher) {
-        let (_, int_array, _) = setup_arrays();
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| int_array.clone())
-            .bench_values(|a| zigzag_encode(a).unwrap());
-    }
-
-    #[divan::bench(name = "zigzag_decompress")]
-    fn bench_zigzag_decompress(bencher: Bencher) {
-        let (_, int_array, _) = setup_arrays();
-        let compressed = zigzag_encode(int_array).unwrap();
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-
-    #[divan::bench(name = "alp_compress")]
-    fn bench_alp_compress(bencher: Bencher) {
-        let (_, _, float_array) = setup_arrays();
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| float_array.clone())
-            .bench_values(|a| alp_encode(&a, None).unwrap());
-    }
-
-    #[divan::bench(name = "alp_decompress")]
-    fn bench_alp_decompress(bencher: Bencher) {
-        let (_, _, float_array) = setup_arrays();
-        let compressed = alp_encode(&float_array, None).unwrap();
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-
-    #[divan::bench(name = "alp_rd_compress")]
-    fn bench_alp_rd_compress(bencher: Bencher) {
-        let (_, _, float_array) = setup_arrays();
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| float_array.clone())
-            .bench_values(|a| {
-                let encoder = RDEncoder::new(a.as_slice::<f32>());
-                encoder.encode(&a)
-            });
-    }
-
-    #[divan::bench(name = "alp_rd_decompress")]
-    fn bench_alp_rd_decompress(bencher: Bencher) {
-        let (_, _, float_array) = setup_arrays();
-        let encoder = RDEncoder::new(float_array.as_slice::<f32>());
-        let compressed = encoder.encode(&float_array);
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-
-    #[divan::bench(name = "pcodec_compress")]
-    fn bench_pcodec_compress(bencher: Bencher) {
-        let (_, _, float_array) = setup_arrays();
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| float_array.clone())
-            .bench_values(|a| PcoArray::from_primitive(&a, 3, 0).unwrap());
-    }
-
-    #[divan::bench(name = "pcodec_decompress")]
-    fn bench_pcodec_decompress(bencher: Bencher) {
-        let (_, _, float_array) = setup_arrays();
-        let compressed = PcoArray::from_primitive(&float_array, 3, 0).unwrap();
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
-
-    #[cfg(feature = "zstd")]
-    #[divan::bench(name = "zstd_compress")]
-    fn bench_zstd_compress(bencher: Bencher) {
-        let (uint_array, ..) = setup_arrays();
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| uint_array.clone())
-            .bench_values(|a| ZstdArray::from_array(a.into_array(), 3, 8192).unwrap());
-    }
-
-    #[cfg(feature = "zstd")]
-    #[divan::bench(name = "zstd_decompress")]
-    fn bench_zstd_decompress(bencher: Bencher) {
-        let (uint_array, ..) = setup_arrays();
-        let compressed = ZstdArray::from_array(uint_array.into_array(), 3, 8192).unwrap();
-
-        with_counter!(bencher, NUM_VALUES * 4)
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
+    let float_array = cast(uint_array.as_ref(), PType::F64.into())
+        .unwrap()
+        .to_primitive()
+        .unwrap();
+    (uint_array, int_array, float_array)
 }
 
-#[divan::bench_group]
-mod string_decompression {
-    use rand::prelude::IndexedRandom;
+#[allow(clippy::cast_possible_truncation)]
+fn gen_varbin_words(len: usize, uniqueness: f64) -> Vec<String> {
+    let mut rng = rand::rng();
+    let uniq_cnt = (len as f64 * uniqueness) as usize;
+    let dict: Vec<String> = (0..uniq_cnt)
+        .map(|_| {
+            (0..8)
+                .map(|_| (rng.random_range(b'a'..=b'z')) as char)
+                .collect()
+        })
+        .collect();
+    (0..len)
+        .map(|_| dict.choose(&mut rng).unwrap().clone())
+        .collect()
+}
 
-    use super::*;
+// Primitive compression benchmarks
+#[divan::bench(name = "bitpacked_compress_u32")]
+fn bench_bitpacked_compress_u32(bencher: Bencher) {
+    use vortex::encodings::fastlanes::bitpack_encode_unchecked;
 
-    #[allow(clippy::cast_possible_truncation)]
-    fn gen_varbin_words(len: usize, uniqueness: f64) -> Vec<String> {
-        let mut rng = rand::rng();
-        let uniq_cnt = (len as f64 * uniqueness) as usize;
-        let dict: Vec<String> = (0..uniq_cnt)
-            .map(|_| {
-                (0..8)
-                    .map(|_| (rng.random_range(b'a'..=b'z')) as char)
-                    .collect()
-            })
-            .collect();
-        (0..len)
-            .map(|_| dict.choose(&mut rng).unwrap().clone())
-            .collect()
-    }
+    let (uint_array, ..) = setup_primitive_arrays();
+    let bit_width = 8;
 
-    #[divan::bench(name = "dict_compress_varbinview")]
-    fn bench_dict_compress_varbinview(bencher: Bencher) {
-        let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-        let nbytes = varbinview_arr.nbytes() as u64;
+    with_counter!(bencher, NUM_VALUES * 4)
+        .with_inputs(|| uint_array.clone())
+        .bench_values(|a| unsafe { bitpack_encode_unchecked(a, bit_width).unwrap() });
+}
 
-        with_counter!(bencher, nbytes)
-            .with_inputs(|| varbinview_arr.clone())
-            .bench_values(|a| dict_encode(a.as_ref()).unwrap());
-    }
+#[divan::bench(name = "bitpacked_decompress_u32")]
+fn bench_bitpacked_decompress_u32(bencher: Bencher) {
+    use vortex::encodings::fastlanes::bitpack_encode;
 
-    #[divan::bench(name = "dict_decompress_varbinview")]
-    fn bench_dict_decompress_varbinview(bencher: Bencher) {
-        let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-        let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
-        let nbytes = varbinview_arr.into_array().nbytes() as u64;
+    let (uint_array, ..) = setup_primitive_arrays();
+    let bit_width = 8;
+    let compressed = bitpack_encode(&uint_array, bit_width, None).unwrap();
 
-        with_counter!(bencher, nbytes)
-            .with_inputs(|| dict.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
+    with_counter!(bencher, NUM_VALUES * 4)
+        .with_inputs(|| compressed.clone())
+        .bench_values(|a| a.to_canonical().unwrap());
+}
 
-    #[divan::bench(name = "fsst_compress_varbinview")]
-    fn bench_fsst_compress_varbinview(bencher: Bencher) {
-        let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-        let fsst_compressor = fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
-        let nbytes = varbinview_arr.nbytes() as u64;
+#[divan::bench(name = "runend_compress_u32")]
+fn bench_runend_compress_u32(bencher: Bencher) {
+    let (uint_array, ..) = setup_primitive_arrays();
 
-        with_counter!(bencher, nbytes)
-            .with_inputs(|| varbinview_arr.clone())
-            .bench_values(|a| fsst_compress(&a.into_array(), &fsst_compressor).unwrap());
-    }
+    with_counter!(bencher, NUM_VALUES * 4)
+        .with_inputs(|| uint_array.clone())
+        .bench_values(|a| RunEndArray::encode(a.into_array()).unwrap());
+}
 
-    #[divan::bench(name = "fsst_decompress_varbinview")]
-    fn bench_fsst_decompress_varbinview(bencher: Bencher) {
-        let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-        let fsst_compressor = fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
-        let fsst_array =
-            fsst_compress(&varbinview_arr.clone().into_array(), &fsst_compressor).unwrap();
-        let nbytes = varbinview_arr.into_array().nbytes() as u64;
+#[divan::bench(name = "runend_decompress_u32")]
+fn bench_runend_decompress_u32(bencher: Bencher) {
+    let (uint_array, ..) = setup_primitive_arrays();
+    let compressed = RunEndArray::encode(uint_array.into_array()).unwrap();
 
-        with_counter!(bencher, nbytes)
-            .with_inputs(|| fsst_array.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
+    with_counter!(bencher, NUM_VALUES * 4)
+        .with_inputs(|| compressed.clone())
+        .bench_values(|a| a.to_canonical().unwrap());
+}
 
-    #[cfg(feature = "zstd")]
-    #[divan::bench(name = "zstd_compress_varbinview")]
-    fn bench_zstd_compress_varbinview(bencher: Bencher) {
-        let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-        let nbytes = varbinview_arr.nbytes() as u64;
+#[divan::bench(name = "delta_compress_u32")]
+fn bench_delta_compress_u32(bencher: Bencher) {
+    let (uint_array, ..) = setup_primitive_arrays();
 
-        with_counter!(bencher, nbytes)
-            .with_inputs(|| varbinview_arr.clone())
-            .bench_values(|a| ZstdArray::from_array(a.into_array(), 3, 8192).unwrap());
-    }
+    with_counter!(bencher, NUM_VALUES * 4)
+        .with_inputs(|| uint_array.clone())
+        .bench_values(|a| {
+            let (bases, deltas) = delta_compress(&a).unwrap();
+            DeltaArray::try_from_delta_compress_parts(
+                bases.into_array(),
+                deltas.into_array(),
+                Validity::NonNullable,
+            )
+            .unwrap()
+        });
+}
 
-    #[cfg(feature = "zstd")]
-    #[divan::bench(name = "zstd_decompress_varbinview")]
-    fn bench_zstd_decompress_varbinview(bencher: Bencher) {
-        let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-        let compressed =
-            ZstdArray::from_array(varbinview_arr.clone().into_array(), 3, 8192).unwrap();
-        let nbytes = varbinview_arr.into_array().nbytes() as u64;
+#[divan::bench(name = "delta_decompress_u32")]
+fn bench_delta_decompress_u32(bencher: Bencher) {
+    let (uint_array, ..) = setup_primitive_arrays();
+    let (bases, deltas) = delta_compress(&uint_array).unwrap();
+    let compressed = DeltaArray::try_from_delta_compress_parts(
+        bases.into_array(),
+        deltas.into_array(),
+        Validity::NonNullable,
+    )
+    .unwrap();
 
-        with_counter!(bencher, nbytes)
-            .with_inputs(|| compressed.clone())
-            .bench_values(|a| a.to_canonical().unwrap());
-    }
+    with_counter!(bencher, NUM_VALUES * 4)
+        .with_inputs(|| compressed.clone())
+        .bench_values(|a| a.to_canonical().unwrap());
+}
+
+#[divan::bench(name = "for_compress_i32")]
+fn bench_for_compress_i32(bencher: Bencher) {
+    let (_, int_array, _) = setup_primitive_arrays();
+
+    with_counter!(bencher, NUM_VALUES * 4)
+        .with_inputs(|| int_array.clone())
+        .bench_values(|a| FoRArray::encode(a).unwrap());
+}
+
+#[divan::bench(name = "for_decompress_i32")]
+fn bench_for_decompress_i32(bencher: Bencher) {
+    let (_, int_array, _) = setup_primitive_arrays();
+    let compressed = FoRArray::encode(int_array).unwrap();
+
+    with_counter!(bencher, NUM_VALUES * 4)
+        .with_inputs(|| compressed.clone())
+        .bench_values(|a| a.to_canonical().unwrap());
+}
+
+#[divan::bench(name = "dict_compress_u32")]
+fn bench_dict_compress_u32(bencher: Bencher) {
+    let (uint_array, ..) = setup_primitive_arrays();
+
+    with_counter!(bencher, NUM_VALUES * 4)
+        .with_inputs(|| uint_array.clone())
+        .bench_values(|a| dict_encode(a.as_ref()).unwrap());
+}
+
+#[divan::bench(name = "dict_decompress_u32")]
+fn bench_dict_decompress_u32(bencher: Bencher) {
+    let (uint_array, ..) = setup_primitive_arrays();
+    let compressed = dict_encode(uint_array.as_ref()).unwrap();
+
+    with_counter!(bencher, NUM_VALUES * 4)
+        .with_inputs(|| compressed.clone())
+        .bench_values(|a| a.to_canonical().unwrap());
+}
+
+#[divan::bench(name = "zigzag_compress_i32")]
+fn bench_zigzag_compress_i32(bencher: Bencher) {
+    let (_, int_array, _) = setup_primitive_arrays();
+
+    with_counter!(bencher, NUM_VALUES * 4)
+        .with_inputs(|| int_array.clone())
+        .bench_values(|a| zigzag_encode(a).unwrap());
+}
+
+#[divan::bench(name = "zigzag_decompress_i32")]
+fn bench_zigzag_decompress_i32(bencher: Bencher) {
+    let (_, int_array, _) = setup_primitive_arrays();
+    let compressed = zigzag_encode(int_array).unwrap();
+
+    with_counter!(bencher, NUM_VALUES * 4)
+        .with_inputs(|| compressed.clone())
+        .bench_values(|a| a.to_canonical().unwrap());
+}
+
+#[divan::bench(name = "alp_compress_f64")]
+fn bench_alp_compress_f64(bencher: Bencher) {
+    let (_, _, float_array) = setup_primitive_arrays();
+
+    with_counter!(bencher, NUM_VALUES * 8)
+        .with_inputs(|| float_array.clone())
+        .bench_values(|a| alp_encode(&a, None).unwrap());
+}
+
+#[divan::bench(name = "alp_decompress_f64")]
+fn bench_alp_decompress_f64(bencher: Bencher) {
+    let (_, _, float_array) = setup_primitive_arrays();
+    let compressed = alp_encode(&float_array, None).unwrap();
+
+    with_counter!(bencher, NUM_VALUES * 8)
+        .with_inputs(|| compressed.clone())
+        .bench_values(|a| a.to_canonical().unwrap());
+}
+
+#[divan::bench(name = "alp_rd_compress_f64")]
+fn bench_alp_rd_compress_f64(bencher: Bencher) {
+    let (_, _, float_array) = setup_primitive_arrays();
+
+    with_counter!(bencher, NUM_VALUES * 8)
+        .with_inputs(|| float_array.clone())
+        .bench_values(|a| {
+            let encoder = RDEncoder::new(a.as_slice::<f64>());
+            encoder.encode(&a)
+        });
+}
+
+#[divan::bench(name = "alp_rd_decompress_f64")]
+fn bench_alp_rd_decompress_f64(bencher: Bencher) {
+    let (_, _, float_array) = setup_primitive_arrays();
+    let encoder = RDEncoder::new(float_array.as_slice::<f64>());
+    let compressed = encoder.encode(&float_array);
+
+    with_counter!(bencher, NUM_VALUES * 8)
+        .with_inputs(|| compressed.clone())
+        .bench_values(|a| a.to_canonical().unwrap());
+}
+
+#[divan::bench(name = "pcodec_compress_f64")]
+fn bench_pcodec_compress_f64(bencher: Bencher) {
+    let (_, _, float_array) = setup_primitive_arrays();
+
+    with_counter!(bencher, NUM_VALUES * 8)
+        .with_inputs(|| float_array.clone())
+        .bench_values(|a| PcoArray::from_primitive(&a, 3, 0).unwrap());
+}
+
+#[divan::bench(name = "pcodec_decompress_f64")]
+fn bench_pcodec_decompress_f64(bencher: Bencher) {
+    let (_, _, float_array) = setup_primitive_arrays();
+    let compressed = PcoArray::from_primitive(&float_array, 3, 0).unwrap();
+
+    with_counter!(bencher, NUM_VALUES * 8)
+        .with_inputs(|| compressed.clone())
+        .bench_values(|a| a.to_canonical().unwrap());
+}
+
+#[cfg(feature = "zstd")]
+#[divan::bench(name = "zstd_compress_u32")]
+fn bench_zstd_compress_u32(bencher: Bencher) {
+    let (uint_array, ..) = setup_primitive_arrays();
+
+    with_counter!(bencher, NUM_VALUES * 4)
+        .with_inputs(|| uint_array.clone())
+        .bench_values(|a| ZstdArray::from_array(a.into_array(), 3, 8192).unwrap());
+}
+
+#[cfg(feature = "zstd")]
+#[divan::bench(name = "zstd_decompress_u32")]
+fn bench_zstd_decompress_u32(bencher: Bencher) {
+    let (uint_array, ..) = setup_primitive_arrays();
+    let compressed = ZstdArray::from_array(uint_array.into_array(), 3, 8192).unwrap();
+
+    with_counter!(bencher, NUM_VALUES * 4)
+        .with_inputs(|| compressed.clone())
+        .bench_values(|a| a.to_canonical().unwrap());
+}
+
+// String compression benchmarks
+#[divan::bench(name = "dict_compress_string")]
+fn bench_dict_compress_string(bencher: Bencher) {
+    let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+    let nbytes = varbinview_arr.nbytes() as u64;
+
+    with_counter!(bencher, nbytes)
+        .with_inputs(|| varbinview_arr.clone())
+        .bench_values(|a| dict_encode(a.as_ref()).unwrap());
+}
+
+#[divan::bench(name = "dict_decompress_string")]
+fn bench_dict_decompress_string(bencher: Bencher) {
+    let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+    let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
+    let nbytes = varbinview_arr.into_array().nbytes() as u64;
+
+    with_counter!(bencher, nbytes)
+        .with_inputs(|| dict.clone())
+        .bench_values(|a| a.to_canonical().unwrap());
+}
+
+#[divan::bench(name = "fsst_compress_string")]
+fn bench_fsst_compress_string(bencher: Bencher) {
+    let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+    let fsst_compressor = fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
+    let nbytes = varbinview_arr.nbytes() as u64;
+
+    with_counter!(bencher, nbytes)
+        .with_inputs(|| varbinview_arr.clone())
+        .bench_values(|a| fsst_compress(&a.into_array(), &fsst_compressor).unwrap());
+}
+
+#[divan::bench(name = "fsst_decompress_string")]
+fn bench_fsst_decompress_string(bencher: Bencher) {
+    let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+    let fsst_compressor = fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
+    let fsst_array = fsst_compress(&varbinview_arr.clone().into_array(), &fsst_compressor).unwrap();
+    let nbytes = varbinview_arr.into_array().nbytes() as u64;
+
+    with_counter!(bencher, nbytes)
+        .with_inputs(|| fsst_array.clone())
+        .bench_values(|a| a.to_canonical().unwrap());
+}
+
+#[cfg(feature = "zstd")]
+#[divan::bench(name = "zstd_compress_string")]
+fn bench_zstd_compress_string(bencher: Bencher) {
+    let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+    let nbytes = varbinview_arr.nbytes() as u64;
+
+    with_counter!(bencher, nbytes)
+        .with_inputs(|| varbinview_arr.clone())
+        .bench_values(|a| ZstdArray::from_array(a.into_array(), 3, 8192).unwrap());
+}
+
+#[cfg(feature = "zstd")]
+#[divan::bench(name = "zstd_decompress_string")]
+fn bench_zstd_decompress_string(bencher: Bencher) {
+    let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+    let compressed = ZstdArray::from_array(varbinview_arr.clone().into_array(), 3, 8192).unwrap();
+    let nbytes = varbinview_arr.into_array().nbytes() as u64;
+
+    with_counter!(bencher, nbytes)
+        .with_inputs(|| compressed.clone())
+        .bench_values(|a| a.to_canonical().unwrap());
 }

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -1,125 +1,137 @@
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+#![allow(clippy::unwrap_used)]
+
+use divan::Bencher;
 use mimalloc::MiMalloc;
-use rand::distributions::Alphanumeric;
-use rand::seq::SliceRandom as _;
-use rand::{thread_rng, Rng, SeedableRng as _};
-use vortex::aliases::hash_set::HashSet;
-use vortex::array::VarBinViewArray;
-use vortex::buffer::Buffer;
-use vortex::compute::try_cast;
-use vortex::dtype::PType;
-use vortex::encodings::dict::dict_encode;
+use rand::{Rng, SeedableRng};
+use vortex::arrays::{PrimitiveArray, VarBinViewArray};
+use vortex::compressor::BtrBlocksCompressor;
+use vortex::compute::cast;
+use vortex::encodings::dict::builders::dict_encode;
 use vortex::encodings::fsst::{fsst_compress, fsst_train_compressor};
-use vortex::sampling_compressor::compressors::alp::ALPCompressor;
-use vortex::sampling_compressor::compressors::alp_rd::ALPRDCompressor;
-use vortex::sampling_compressor::compressors::bitpacked::{
-    BITPACK_NO_PATCHES, BITPACK_WITH_PATCHES,
-};
-use vortex::sampling_compressor::compressors::delta::DeltaCompressor;
-use vortex::sampling_compressor::compressors::dict::DictCompressor;
-use vortex::sampling_compressor::compressors::r#for::FoRCompressor;
-use vortex::sampling_compressor::compressors::runend::DEFAULT_RUN_END_COMPRESSOR;
-use vortex::sampling_compressor::compressors::zigzag::ZigZagCompressor;
-use vortex::sampling_compressor::compressors::CompressorRef;
-use vortex::sampling_compressor::SamplingCompressor;
-use vortex::{IntoArray, IntoCanonical};
+use vortex::{Array, IntoArray, ToCanonical};
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
-fn primitive(c: &mut Criterion) {
-    let mut group = c.benchmark_group("primitive-decompression");
-    let num_values = u16::MAX as u64;
-    group.throughput(Throughput::Bytes(num_values * 4));
+fn main() {
+    divan::main();
+}
 
-    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+const NUM_VALUES: u64 = u16::MAX as u64;
 
-    let uint_array =
-        Buffer::from_iter((0..num_values).map(|_| rng.gen_range(0u32..256))).into_array();
-    let int_array = try_cast(uint_array.clone(), PType::I32.into()).unwrap();
-    let float_array = try_cast(uint_array.clone(), PType::F32.into()).unwrap();
+#[divan::bench_group]
+mod primitive_decompression {
+    use super::*;
+    use vortex::dtype::PType;
 
-    let compressors_names_and_arrays = [
-        (
-            &BITPACK_NO_PATCHES as CompressorRef,
-            "bitpacked_no_patches",
-            &uint_array,
-        ),
-        (&BITPACK_WITH_PATCHES, "bitpacked_with_patches", &uint_array),
-        (&DEFAULT_RUN_END_COMPRESSOR, "runend", &uint_array),
-        (&DeltaCompressor, "delta", &uint_array),
-        (&DictCompressor, "dict", &uint_array),
-        (&FoRCompressor, "frame_of_reference", &int_array),
-        (&ZigZagCompressor, "zigzag", &int_array),
-        (&ALPCompressor, "alp", &float_array),
-        (&ALPRDCompressor, "alp_rd", &float_array),
-    ];
-
-    let ctx = SamplingCompressor::new(HashSet::new());
-    for (compressor, name, array) in compressors_names_and_arrays {
-        group.bench_function(format!("{} compress", name), |b| {
-            b.iter(|| {
-                black_box(
-                    compressor
-                        .compress(array, None, ctx.including(compressor))
-                        .unwrap(),
-                );
-            })
-        });
-
-        let compressed = compressor
-            .compress(array, None, ctx.including(compressor))
+    fn setup_arrays() -> (PrimitiveArray, PrimitiveArray, PrimitiveArray) {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+        let uint_array = PrimitiveArray::from_iter((0..NUM_VALUES).map(|_| rng.random_range(0u32..256)));
+        let int_array = cast(uint_array.as_ref(), PType::I32.into())
             .unwrap()
-            .into_array();
-        group.bench_function(format!("{} decompress", name), |b| {
-            b.iter_batched(
-                || compressed.clone(),
-                |compressed| {
-                    black_box(compressed.into_canonical().unwrap());
-                },
-                BatchSize::SmallInput,
-            )
-        });
+            .to_primitive()
+            .unwrap();
+        let float_array = cast(uint_array.as_ref(), PType::F32.into())
+            .unwrap()
+            .to_primitive()
+            .unwrap();
+        (uint_array, int_array, float_array)
+    }
+
+    #[divan::bench(name = "dict_compress")]
+    fn bench_dict_compress(bencher: Bencher) {
+        let (uint_array, _, _) = setup_arrays();
+        
+        bencher
+            .counter(NUM_VALUES * 4)
+            .bench_local(|| {
+                dict_encode(uint_array.as_ref()).unwrap()
+            });
+    }
+
+    #[divan::bench(name = "dict_decompress")]
+    fn bench_dict_decompress(bencher: Bencher) {
+        let (uint_array, _, _) = setup_arrays();
+        let compressed = dict_encode(uint_array.as_ref()).unwrap();
+        
+        bencher
+            .counter(NUM_VALUES * 4)
+            .bench_local(move || {
+                compressed.clone().to_canonical().unwrap()
+            });
+    }
+
+    #[divan::bench(name = "btrblocks_compress")]
+    fn bench_btrblocks_compress(bencher: Bencher) {
+        let (uint_array, _, _) = setup_arrays();
+        
+        bencher
+            .counter(NUM_VALUES * 4)
+            .bench_local(|| {
+                BtrBlocksCompressor.compress(uint_array.as_ref()).unwrap()
+            });
+    }
+
+    #[divan::bench(name = "btrblocks_decompress")]
+    fn bench_btrblocks_decompress(bencher: Bencher) {
+        let (uint_array, _, _) = setup_arrays();
+        let compressed = BtrBlocksCompressor.compress(uint_array.as_ref()).unwrap();
+        
+        bencher
+            .counter(NUM_VALUES * 4)
+            .bench_local(move || {
+                compressed.clone().to_canonical().unwrap()
+            });
     }
 }
 
-fn strings(c: &mut Criterion) {
-    let mut group = c.benchmark_group("string-decompression");
-    let num_values = u16::MAX as u64;
-    group.throughput(Throughput::Bytes(num_values * 8));
+#[divan::bench_group]
+mod string_decompression {
+    use super::*;
+    use rand::prelude::IndexedRandom;
 
-    let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-    let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
-    group.throughput(Throughput::Bytes(
-        varbinview_arr.clone().into_array().nbytes() as u64,
-    ));
-    group.bench_function("dict_decode_varbinview", |b| {
-        b.iter(|| black_box(dict.clone().into_canonical().unwrap()));
-    });
+    fn gen_varbin_words(len: usize, uniqueness: f64) -> Vec<String> {
+        let mut rng = rand::rng();
+        let uniq_cnt = (len as f64 * uniqueness) as usize;
+        let dict: Vec<String> = (0..uniq_cnt)
+            .map(|_| {
+                (0..8)
+                    .map(|_| (rng.random_range(b'a'..=b'z')) as char)
+                    .collect()
+            })
+            .collect();
+        (0..len)
+            .map(|_| dict.choose(&mut rng).unwrap().clone())
+            .collect()
+    }
 
-    let fsst_compressor = fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
-    let fsst_array = fsst_compress(&varbinview_arr.clone().into_array(), &fsst_compressor).unwrap();
-    group.bench_function("fsst_decompress_varbinview", |b| {
-        b.iter(|| black_box(fsst_array.clone().into_canonical().unwrap()));
-    });
+    #[divan::bench(name = "dict_decode_varbinview")]
+    fn bench_dict_decode_varbinview(bencher: Bencher) {
+        let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+        let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
+        let nbytes = varbinview_arr.clone().into_array().nbytes() as u64;
+        
+        bencher
+            .counter(nbytes)
+            .bench_local(move || {
+                dict.clone().to_canonical().unwrap()
+            });
+    }
+
+    #[divan::bench(name = "fsst_decompress_varbinview")]
+    fn bench_fsst_decompress_varbinview(bencher: Bencher) {
+        let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
+        let fsst_compressor = fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
+        let fsst_array = fsst_compress(&varbinview_arr.clone().into_array(), &fsst_compressor).unwrap();
+        let nbytes = varbinview_arr.clone().into_array().nbytes() as u64;
+        
+        bencher
+            .counter(nbytes)
+            .bench_local(move || {
+                fsst_array.clone().to_canonical().unwrap()
+            });
+    }
 }
-
-fn gen_varbin_words(len: usize, uniqueness: f64) -> Vec<String> {
-    let mut rng = thread_rng();
-    let uniq_cnt = (len as f64 * uniqueness) as usize;
-    let dict: Vec<String> = (0..uniq_cnt)
-        .map(|_| {
-            (&mut rng)
-                .sample_iter(&Alphanumeric)
-                .take(8)
-                .map(char::from)
-                .collect()
-        })
-        .collect();
-    (0..len)
-        .map(|_| dict.choose(&mut rng).unwrap().clone())
-        .collect()
-}
-
-criterion_group!(benches, primitive, strings);
-criterion_main!(benches);

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -9,8 +9,13 @@ use rand::{Rng, SeedableRng};
 use vortex::arrays::{PrimitiveArray, VarBinViewArray};
 use vortex::compressor::BtrBlocksCompressor;
 use vortex::compute::cast;
+use vortex::encodings::alp::{alp_encode, RDEncoder};
 use vortex::encodings::dict::builders::dict_encode;
+use vortex::encodings::fastlanes::{bitpack_to_best_bit_width, delta_compress, DeltaArray, FoRArray};
 use vortex::encodings::fsst::{fsst_compress, fsst_train_compressor};
+use vortex::encodings::runend::RunEndArray;
+use vortex::encodings::zigzag::zigzag_encode;
+use vortex::validity::Validity;
 use vortex::{Array, IntoArray, ToCanonical};
 
 #[global_allocator]
@@ -41,6 +46,85 @@ mod primitive_decompression {
         (uint_array, int_array, float_array)
     }
 
+    #[divan::bench(name = "bitpacked_compress")]
+    fn bench_bitpacked_compress(bencher: Bencher) {
+        let (uint_array, _, _) = setup_arrays();
+        
+        bencher
+            .counter(NUM_VALUES * 4)
+            .bench_local(|| {
+                bitpack_to_best_bit_width(&uint_array).unwrap()
+            });
+    }
+
+    #[divan::bench(name = "bitpacked_decompress")]
+    fn bench_bitpacked_decompress(bencher: Bencher) {
+        let (uint_array, _, _) = setup_arrays();
+        let compressed = bitpack_to_best_bit_width(&uint_array).unwrap();
+        
+        bencher
+            .counter(NUM_VALUES * 4)
+            .bench_local(move || {
+                compressed.clone().to_canonical().unwrap()
+            });
+    }
+
+    #[divan::bench(name = "runend_compress")]
+    fn bench_runend_compress(bencher: Bencher) {
+        let (uint_array, _, _) = setup_arrays();
+        
+        bencher
+            .counter(NUM_VALUES * 4)
+            .bench_local(|| {
+                RunEndArray::encode(uint_array.clone().into_array()).unwrap()
+            });
+    }
+
+    #[divan::bench(name = "runend_decompress")]
+    fn bench_runend_decompress(bencher: Bencher) {
+        let (uint_array, _, _) = setup_arrays();
+        let compressed = RunEndArray::encode(uint_array.clone().into_array()).unwrap();
+        
+        bencher
+            .counter(NUM_VALUES * 4)
+            .bench_local(move || {
+                compressed.clone().to_canonical().unwrap()
+            });
+    }
+
+    #[divan::bench(name = "delta_compress")]
+    fn bench_delta_compress(bencher: Bencher) {
+        let (uint_array, _, _) = setup_arrays();
+        
+        bencher
+            .counter(NUM_VALUES * 4)
+            .bench_local(|| {
+                let (bases, deltas) = delta_compress(&uint_array).unwrap();
+                DeltaArray::try_from_delta_compress_parts(
+                    bases.into_array(),
+                    deltas.into_array(),
+                    Validity::NonNullable
+                ).unwrap()
+            });
+    }
+
+    #[divan::bench(name = "delta_decompress")]
+    fn bench_delta_decompress(bencher: Bencher) {
+        let (uint_array, _, _) = setup_arrays();
+        let (bases, deltas) = delta_compress(&uint_array).unwrap();
+        let compressed = DeltaArray::try_from_delta_compress_parts(
+            bases.into_array(),
+            deltas.into_array(),
+            Validity::NonNullable
+        ).unwrap();
+        
+        bencher
+            .counter(NUM_VALUES * 4)
+            .bench_local(move || {
+                compressed.clone().to_canonical().unwrap()
+            });
+    }
+
     #[divan::bench(name = "dict_compress")]
     fn bench_dict_compress(bencher: Bencher) {
         let (uint_array, _, _) = setup_arrays();
@@ -56,6 +140,100 @@ mod primitive_decompression {
     fn bench_dict_decompress(bencher: Bencher) {
         let (uint_array, _, _) = setup_arrays();
         let compressed = dict_encode(uint_array.as_ref()).unwrap();
+        
+        bencher
+            .counter(NUM_VALUES * 4)
+            .bench_local(move || {
+                compressed.clone().to_canonical().unwrap()
+            });
+    }
+
+    #[divan::bench(name = "frame_of_reference_compress")]
+    fn bench_for_compress(bencher: Bencher) {
+        let (_, int_array, _) = setup_arrays();
+        
+        bencher
+            .counter(NUM_VALUES * 4)
+            .bench_local(|| {
+                FoRArray::encode(int_array.clone()).unwrap()
+            });
+    }
+
+    #[divan::bench(name = "frame_of_reference_decompress")]
+    fn bench_for_decompress(bencher: Bencher) {
+        let (_, int_array, _) = setup_arrays();
+        let compressed = FoRArray::encode(int_array.clone()).unwrap();
+        
+        bencher
+            .counter(NUM_VALUES * 4)
+            .bench_local(move || {
+                compressed.clone().to_canonical().unwrap()
+            });
+    }
+
+    #[divan::bench(name = "zigzag_compress")]
+    fn bench_zigzag_compress(bencher: Bencher) {
+        let (_, int_array, _) = setup_arrays();
+        
+        bencher
+            .counter(NUM_VALUES * 4)
+            .bench_local(|| {
+                zigzag_encode(int_array.clone()).unwrap()
+            });
+    }
+
+    #[divan::bench(name = "zigzag_decompress")]
+    fn bench_zigzag_decompress(bencher: Bencher) {
+        let (_, int_array, _) = setup_arrays();
+        let compressed = zigzag_encode(int_array.clone()).unwrap();
+        
+        bencher
+            .counter(NUM_VALUES * 4)
+            .bench_local(move || {
+                compressed.clone().to_canonical().unwrap()
+            });
+    }
+
+    #[divan::bench(name = "alp_compress")]
+    fn bench_alp_compress(bencher: Bencher) {
+        let (_, _, float_array) = setup_arrays();
+        
+        bencher
+            .counter(NUM_VALUES * 4)
+            .bench_local(|| {
+                alp_encode(&float_array, None).unwrap()
+            });
+    }
+
+    #[divan::bench(name = "alp_decompress")]
+    fn bench_alp_decompress(bencher: Bencher) {
+        let (_, _, float_array) = setup_arrays();
+        let compressed = alp_encode(&float_array, None).unwrap();
+        
+        bencher
+            .counter(NUM_VALUES * 4)
+            .bench_local(move || {
+                compressed.clone().to_canonical().unwrap()
+            });
+    }
+
+    #[divan::bench(name = "alp_rd_compress")]
+    fn bench_alp_rd_compress(bencher: Bencher) {
+        let (_, _, float_array) = setup_arrays();
+        
+        bencher
+            .counter(NUM_VALUES * 4)
+            .bench_local(|| {
+                let encoder = RDEncoder::new(float_array.as_slice::<f32>());
+                encoder.encode(&float_array)
+            });
+    }
+
+    #[divan::bench(name = "alp_rd_decompress")]
+    fn bench_alp_rd_decompress(bencher: Bencher) {
+        let (_, _, float_array) = setup_arrays();
+        let encoder = RDEncoder::new(float_array.as_slice::<f32>());
+        let compressed = encoder.encode(&float_array);
         
         bencher
             .counter(NUM_VALUES * 4)

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -4,37 +4,53 @@
 #![allow(clippy::unwrap_used)]
 #![allow(unexpected_cfgs)]
 
+use divan::Bencher;
 #[cfg(not(codspeed))]
-mod benchmarks {
-    use divan::Bencher;
-    use divan::counter::BytesCount;
-    use mimalloc::MiMalloc;
-    use rand::{Rng, SeedableRng};
-    use vortex::arrays::{PrimitiveArray, VarBinViewArray};
-    use vortex::compute::cast;
-    use vortex::encodings::alp::{RDEncoder, alp_encode};
-    use vortex::encodings::dict::builders::dict_encode;
-    use vortex::encodings::fastlanes::{DeltaArray, FoRArray, delta_compress};
-    use vortex::encodings::fsst::{fsst_compress, fsst_train_compressor};
-    use vortex::encodings::pco::PcoArray;
-    use vortex::encodings::runend::RunEndArray;
-    use vortex::encodings::zigzag::zigzag_encode;
-    use vortex::encodings::zstd::ZstdArray;
-    use vortex::validity::Validity;
-    use vortex::{IntoArray, ToCanonical};
+use divan::counter::BytesCount;
+use mimalloc::MiMalloc;
+use rand::{Rng, SeedableRng};
+use vortex::arrays::{PrimitiveArray, VarBinViewArray};
+use vortex::compute::cast;
+use vortex::encodings::alp::{RDEncoder, alp_encode};
+use vortex::encodings::dict::builders::dict_encode;
+use vortex::encodings::fastlanes::{DeltaArray, FoRArray, delta_compress};
+use vortex::encodings::fsst::{fsst_compress, fsst_train_compressor};
+use vortex::encodings::pco::PcoArray;
+use vortex::encodings::runend::RunEndArray;
+use vortex::encodings::zigzag::zigzag_encode;
+use vortex::encodings::zstd::ZstdArray;
+use vortex::validity::Validity;
+use vortex::{IntoArray, ToCanonical};
 
-    #[global_allocator]
-    static GLOBAL: MiMalloc = MiMalloc;
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
-    const NUM_VALUES: u64 = 1_000_000;
+fn main() {
+    divan::main();
+}
 
-    #[divan::bench_group]
-    mod primitive_decompression {
-        use vortex::dtype::PType;
+const NUM_VALUES: u64 = 1_000_000;
 
-        use super::*;
+// Helper macro to conditionally add counter based on codspeed cfg
+macro_rules! with_counter {
+    ($bencher:expr, $bytes:expr) => {
+        {
+            #[cfg(not(codspeed))]
+            let bencher = $bencher.counter(BytesCount::new($bytes));
+            #[cfg(codspeed)]
+            let bencher = $bencher;
+            bencher
+        }
+    };
+}
 
-        fn setup_arrays() -> (PrimitiveArray, PrimitiveArray, PrimitiveArray) {
+#[divan::bench_group]
+mod primitive_decompression {
+    use vortex::dtype::PType;
+
+    use super::*;
+
+    fn setup_arrays() -> (PrimitiveArray, PrimitiveArray, PrimitiveArray) {
             let mut rng = rand::rngs::StdRng::seed_from_u64(0);
             let uint_array =
                 PrimitiveArray::from_iter((0..NUM_VALUES).map(|_| rng.random_range(42u32..256)));
@@ -49,60 +65,55 @@ mod benchmarks {
             (uint_array, int_array, float_array)
         }
 
-        #[divan::bench(name = "bitpacked_compress")]
-        fn bench_bitpacked_compress(bencher: Bencher) {
+    #[divan::bench(name = "bitpacked_compress")]
+    fn bench_bitpacked_compress(bencher: Bencher) {
             use vortex::encodings::fastlanes::bitpack_encode_unchecked;
 
             let (uint_array, ..) = setup_arrays();
             let bit_width = 8;
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| uint_array.clone())
                 .bench_values(|a| unsafe { bitpack_encode_unchecked(a, bit_width).unwrap() });
         }
 
-        #[divan::bench(name = "bitpacked_decompress")]
-        fn bench_bitpacked_decompress(bencher: Bencher) {
+    #[divan::bench(name = "bitpacked_decompress")]
+    fn bench_bitpacked_decompress(bencher: Bencher) {
             use vortex::encodings::fastlanes::bitpack_encode;
 
             let (uint_array, ..) = setup_arrays();
             let bit_width = 8;
             let compressed = bitpack_encode(&uint_array, bit_width, None).unwrap();
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| compressed.clone())
                 .bench_values(|a| a.to_canonical().unwrap());
         }
 
-        #[divan::bench(name = "runend_compress")]
-        fn bench_runend_compress(bencher: Bencher) {
+    #[divan::bench(name = "runend_compress")]
+    fn bench_runend_compress(bencher: Bencher) {
             let (uint_array, ..) = setup_arrays();
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| uint_array.clone())
                 .bench_values(|a| RunEndArray::encode(a.into_array()).unwrap());
         }
 
-        #[divan::bench(name = "runend_decompress")]
-        fn bench_runend_decompress(bencher: Bencher) {
+    #[divan::bench(name = "runend_decompress")]
+    fn bench_runend_decompress(bencher: Bencher) {
             let (uint_array, ..) = setup_arrays();
             let compressed = RunEndArray::encode(uint_array.into_array()).unwrap();
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| compressed.clone())
                 .bench_values(|a| a.to_canonical().unwrap());
         }
 
-        #[divan::bench(name = "delta_compress")]
-        fn bench_delta_compress(bencher: Bencher) {
+    #[divan::bench(name = "delta_compress")]
+    fn bench_delta_compress(bencher: Bencher) {
             let (uint_array, ..) = setup_arrays();
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| uint_array.clone())
                 .bench_values(|a| {
                     let (bases, deltas) = delta_compress(&a).unwrap();
@@ -115,8 +126,8 @@ mod benchmarks {
                 });
         }
 
-        #[divan::bench(name = "delta_decompress")]
-        fn bench_delta_decompress(bencher: Bencher) {
+    #[divan::bench(name = "delta_decompress")]
+    fn bench_delta_decompress(bencher: Bencher) {
             let (uint_array, ..) = setup_arrays();
             let (bases, deltas) = delta_compress(&uint_array).unwrap();
             let compressed = DeltaArray::try_from_delta_compress_parts(
@@ -126,102 +137,92 @@ mod benchmarks {
             )
             .unwrap();
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| compressed.clone())
                 .bench_values(|a| a.to_canonical().unwrap());
         }
 
-        #[divan::bench(name = "for_compress")]
-        fn bench_for_compress(bencher: Bencher) {
+    #[divan::bench(name = "for_compress")]
+    fn bench_for_compress(bencher: Bencher) {
             let (uint_array, ..) = setup_arrays();
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| uint_array.clone())
                 .bench_values(|a| FoRArray::encode(a).unwrap());
         }
 
-        #[divan::bench(name = "for_decompress")]
-        fn bench_for_decompress(bencher: Bencher) {
+    #[divan::bench(name = "for_decompress")]
+    fn bench_for_decompress(bencher: Bencher) {
             let (uint_array, ..) = setup_arrays();
             let compressed = FoRArray::encode(uint_array).unwrap();
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| compressed.clone())
                 .bench_values(|a| a.to_canonical().unwrap());
         }
 
-        #[divan::bench(name = "dict_compress")]
-        fn bench_dict_compress(bencher: Bencher) {
+    #[divan::bench(name = "dict_compress")]
+    fn bench_dict_compress(bencher: Bencher) {
             let (uint_array, ..) = setup_arrays();
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| uint_array.clone())
                 .bench_values(|a| dict_encode(a.as_ref()).unwrap());
         }
 
-        #[divan::bench(name = "dict_decompress")]
-        fn bench_dict_decompress(bencher: Bencher) {
+    #[divan::bench(name = "dict_decompress")]
+    fn bench_dict_decompress(bencher: Bencher) {
             let (uint_array, ..) = setup_arrays();
             let compressed = dict_encode(uint_array.as_ref()).unwrap();
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| compressed.clone())
                 .bench_values(|a| a.to_canonical().unwrap());
         }
 
-        #[divan::bench(name = "zigzag_compress")]
-        fn bench_zigzag_compress(bencher: Bencher) {
+    #[divan::bench(name = "zigzag_compress")]
+    fn bench_zigzag_compress(bencher: Bencher) {
             let (_, int_array, _) = setup_arrays();
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| int_array.clone())
                 .bench_values(|a| zigzag_encode(a).unwrap());
         }
 
-        #[divan::bench(name = "zigzag_decompress")]
-        fn bench_zigzag_decompress(bencher: Bencher) {
+    #[divan::bench(name = "zigzag_decompress")]
+    fn bench_zigzag_decompress(bencher: Bencher) {
             let (_, int_array, _) = setup_arrays();
             let compressed = zigzag_encode(int_array).unwrap();
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| compressed.clone())
                 .bench_values(|a| a.to_canonical().unwrap());
         }
 
-        #[divan::bench(name = "alp_compress")]
-        fn bench_alp_compress(bencher: Bencher) {
+    #[divan::bench(name = "alp_compress")]
+    fn bench_alp_compress(bencher: Bencher) {
             let (_, _, float_array) = setup_arrays();
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| float_array.clone())
                 .bench_values(|a| alp_encode(&a, None).unwrap());
         }
 
-        #[divan::bench(name = "alp_decompress")]
-        fn bench_alp_decompress(bencher: Bencher) {
+    #[divan::bench(name = "alp_decompress")]
+    fn bench_alp_decompress(bencher: Bencher) {
             let (_, _, float_array) = setup_arrays();
             let compressed = alp_encode(&float_array, None).unwrap();
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| compressed.clone())
                 .bench_values(|a| a.to_canonical().unwrap());
         }
 
-        #[divan::bench(name = "alp_rd_compress")]
-        fn bench_alp_rd_compress(bencher: Bencher) {
+    #[divan::bench(name = "alp_rd_compress")]
+    fn bench_alp_rd_compress(bencher: Bencher) {
             let (_, _, float_array) = setup_arrays();
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| float_array.clone())
                 .bench_values(|a| {
                     let encoder = RDEncoder::new(a.as_slice::<f32>());
@@ -229,71 +230,66 @@ mod benchmarks {
                 });
         }
 
-        #[divan::bench(name = "alp_rd_decompress")]
-        fn bench_alp_rd_decompress(bencher: Bencher) {
+    #[divan::bench(name = "alp_rd_decompress")]
+    fn bench_alp_rd_decompress(bencher: Bencher) {
             let (_, _, float_array) = setup_arrays();
             let encoder = RDEncoder::new(float_array.as_slice::<f32>());
             let compressed = encoder.encode(&float_array);
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| compressed.clone())
                 .bench_values(|a| a.to_canonical().unwrap());
         }
 
-        #[divan::bench(name = "pcodec_compress")]
-        fn bench_pcodec_compress(bencher: Bencher) {
+    #[divan::bench(name = "pcodec_compress")]
+    fn bench_pcodec_compress(bencher: Bencher) {
             let (_, _, float_array) = setup_arrays();
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| float_array.clone())
                 .bench_values(|a| PcoArray::from_primitive(&a, 3, 0).unwrap());
         }
 
-        #[divan::bench(name = "pcodec_decompress")]
-        fn bench_pcodec_decompress(bencher: Bencher) {
+    #[divan::bench(name = "pcodec_decompress")]
+    fn bench_pcodec_decompress(bencher: Bencher) {
             let (_, _, float_array) = setup_arrays();
             let compressed = PcoArray::from_primitive(&float_array, 3, 0).unwrap();
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| compressed.clone())
                 .bench_values(|a| a.to_canonical().unwrap());
         }
 
-        #[cfg(feature = "zstd")]
-        #[divan::bench(name = "zstd_compress")]
-        fn bench_zstd_compress(bencher: Bencher) {
+    #[cfg(feature = "zstd")]
+    #[divan::bench(name = "zstd_compress")]
+    fn bench_zstd_compress(bencher: Bencher) {
             let (uint_array, ..) = setup_arrays();
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| uint_array.clone())
                 .bench_values(|a| ZstdArray::from_array(a.into_array(), 3, 8192).unwrap());
         }
 
-        #[cfg(feature = "zstd")]
-        #[divan::bench(name = "zstd_decompress")]
-        fn bench_zstd_decompress(bencher: Bencher) {
+    #[cfg(feature = "zstd")]
+    #[divan::bench(name = "zstd_decompress")]
+    fn bench_zstd_decompress(bencher: Bencher) {
             let (uint_array, ..) = setup_arrays();
             let compressed = ZstdArray::from_array(uint_array.into_array(), 3, 8192).unwrap();
 
-            bencher
-                .counter(BytesCount::new(NUM_VALUES * 4))
+            with_counter!(bencher, NUM_VALUES * 4)
                 .with_inputs(|| compressed.clone())
                 .bench_values(|a| a.to_canonical().unwrap());
         }
     }
 
-    #[divan::bench_group]
-    mod string_decompression {
-        use rand::prelude::IndexedRandom;
+#[divan::bench_group]
+mod string_decompression {
+    use rand::prelude::IndexedRandom;
 
-        use super::*;
+    use super::*;
 
-        #[allow(clippy::cast_possible_truncation)]
-        fn gen_varbin_words(len: usize, uniqueness: f64) -> Vec<String> {
+    #[allow(clippy::cast_possible_truncation)]
+    fn gen_varbin_words(len: usize, uniqueness: f64) -> Vec<String> {
             let mut rng = rand::rng();
             let uniq_cnt = (len as f64 * uniqueness) as usize;
             let dict: Vec<String> = (0..uniq_cnt)
@@ -308,47 +304,44 @@ mod benchmarks {
                 .collect()
         }
 
-        #[divan::bench(name = "dict_compress_varbinview")]
-        fn bench_dict_compress_varbinview(bencher: Bencher) {
+    #[divan::bench(name = "dict_compress_varbinview")]
+    fn bench_dict_compress_varbinview(bencher: Bencher) {
             let varbinview_arr =
                 VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
             let nbytes = varbinview_arr.nbytes() as u64;
 
-            bencher
-                .counter(BytesCount::new(nbytes))
+            with_counter!(bencher, nbytes)
                 .with_inputs(|| varbinview_arr.clone())
                 .bench_values(|a| dict_encode(a.as_ref()).unwrap());
         }
 
-        #[divan::bench(name = "dict_decompress_varbinview")]
-        fn bench_dict_decompress_varbinview(bencher: Bencher) {
+    #[divan::bench(name = "dict_decompress_varbinview")]
+    fn bench_dict_decompress_varbinview(bencher: Bencher) {
             let varbinview_arr =
                 VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
             let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
             let nbytes = varbinview_arr.into_array().nbytes() as u64;
 
-            bencher
-                .counter(BytesCount::new(nbytes))
+            with_counter!(bencher, nbytes)
                 .with_inputs(|| dict.clone())
                 .bench_values(|a| a.to_canonical().unwrap());
         }
 
-        #[divan::bench(name = "fsst_compress_varbinview")]
-        fn bench_fsst_compress_varbinview(bencher: Bencher) {
+    #[divan::bench(name = "fsst_compress_varbinview")]
+    fn bench_fsst_compress_varbinview(bencher: Bencher) {
             let varbinview_arr =
                 VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
             let fsst_compressor =
                 fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
             let nbytes = varbinview_arr.nbytes() as u64;
 
-            bencher
-                .counter(BytesCount::new(nbytes))
+            with_counter!(bencher, nbytes)
                 .with_inputs(|| varbinview_arr.clone())
                 .bench_values(|a| fsst_compress(&a.into_array(), &fsst_compressor).unwrap());
         }
 
-        #[divan::bench(name = "fsst_decompress_varbinview")]
-        fn bench_fsst_decompress_varbinview(bencher: Bencher) {
+    #[divan::bench(name = "fsst_decompress_varbinview")]
+    fn bench_fsst_decompress_varbinview(bencher: Bencher) {
             let varbinview_arr =
                 VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
             let fsst_compressor =
@@ -357,42 +350,34 @@ mod benchmarks {
                 fsst_compress(&varbinview_arr.clone().into_array(), &fsst_compressor).unwrap();
             let nbytes = varbinview_arr.into_array().nbytes() as u64;
 
-            bencher
-                .counter(BytesCount::new(nbytes))
+            with_counter!(bencher, nbytes)
                 .with_inputs(|| fsst_array.clone())
                 .bench_values(|a| a.to_canonical().unwrap());
         }
 
-        #[cfg(feature = "zstd")]
-        #[divan::bench(name = "zstd_compress_varbinview")]
-        fn bench_zstd_compress_varbinview(bencher: Bencher) {
+    #[cfg(feature = "zstd")]
+    #[divan::bench(name = "zstd_compress_varbinview")]
+    fn bench_zstd_compress_varbinview(bencher: Bencher) {
             let varbinview_arr =
                 VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
             let nbytes = varbinview_arr.nbytes() as u64;
 
-            bencher
-                .counter(BytesCount::new(nbytes))
+            with_counter!(bencher, nbytes)
                 .with_inputs(|| varbinview_arr.clone())
                 .bench_values(|a| ZstdArray::from_array(a.into_array(), 3, 8192).unwrap());
         }
 
-        #[cfg(feature = "zstd")]
-        #[divan::bench(name = "zstd_decompress_varbinview")]
-        fn bench_zstd_decompress_varbinview(bencher: Bencher) {
+    #[cfg(feature = "zstd")]
+    #[divan::bench(name = "zstd_decompress_varbinview")]
+    fn bench_zstd_decompress_varbinview(bencher: Bencher) {
             let varbinview_arr =
                 VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
             let compressed =
                 ZstdArray::from_array(varbinview_arr.clone().into_array(), 3, 8192).unwrap();
             let nbytes = varbinview_arr.into_array().nbytes() as u64;
 
-            bencher
-                .counter(BytesCount::new(nbytes))
+            with_counter!(bencher, nbytes)
                 .with_inputs(|| compressed.clone())
                 .bench_values(|a| a.to_canonical().unwrap());
-        }
     }
-}
-
-fn main() {
-    divan::main()
 }


### PR DESCRIPTION
Claude rewrote [this](https://github.com/vortex-data/vortex/blob/6cb597f1e3aabc6dca2202a6e4d2df0c36cb85c7/bench-vortex/benches/compressor_throughput.rs) old (removed) benchmark to use divan. 

```
~/g/vortex ❯❯❯ cargo bench -p vortex --bench single_encoding_throughput
   Compiling vortex v0.1.0 (/Users/will/git/vortex/vortex)
    Finished `bench` profile [optimized + debuginfo] target(s) in 2.25s
     Running benches/single_encoding_throughput.rs (target/release/deps/single_encoding_throughput-edb1df956e2587c9)
Timer precision: 41 ns
single_encoding_throughput   fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ alp_compress_f64          1.105 ms      │ 1.96 ms       │ 1.164 ms      │ 1.187 ms      │ 100     │ 100
│                            7.236 GB/s    │ 4.08 GB/s     │ 6.87 GB/s     │ 6.737 GB/s    │         │
├─ alp_decompress_f64        200.4 µs      │ 656.2 µs      │ 208.4 µs      │ 213.5 µs      │ 100     │ 100
│                            39.9 GB/s     │ 12.18 GB/s    │ 38.36 GB/s    │ 37.46 GB/s    │         │
├─ alp_rd_compress_f64       25.9 ms       │ 32.47 ms      │ 27.9 ms       │ 28.09 ms      │ 100     │ 100
│                            308.8 MB/s    │ 246.3 MB/s    │ 286.6 MB/s    │ 284.7 MB/s    │         │
├─ alp_rd_decompress_f64     672.2 µs      │ 829 µs        │ 736.5 µs      │ 735.9 µs      │ 100     │ 100
│                            11.9 GB/s     │ 9.649 GB/s    │ 10.86 GB/s    │ 10.87 GB/s    │         │
├─ bitpacked_compress_u32    48.33 µs      │ 77.12 µs      │ 48.93 µs      │ 51.17 µs      │ 100     │ 100
│                            82.76 GB/s    │ 51.86 GB/s    │ 81.73 GB/s    │ 78.15 GB/s    │         │
├─ bitpacked_decompress_u32  67.45 µs      │ 127.4 µs      │ 67.62 µs      │ 69.22 µs      │ 100     │ 100
│                            59.29 GB/s    │ 31.37 GB/s    │ 59.15 GB/s    │ 57.77 GB/s    │         │
├─ delta_compress_u32        205.2 µs      │ 269.3 µs      │ 219 µs        │ 219.5 µs      │ 100     │ 100
│                            19.48 GB/s    │ 14.85 GB/s    │ 18.25 GB/s    │ 18.21 GB/s    │         │
├─ delta_decompress_u32      247.3 µs      │ 307.6 µs      │ 255.8 µs      │ 258.9 µs      │ 100     │ 100
│                            16.17 GB/s    │ 13 GB/s       │ 15.63 GB/s    │ 15.44 GB/s    │         │
├─ dict_compress_string      5.794 ms      │ 9.102 ms      │ 6.992 ms      │ 7.048 ms      │ 100     │ 100
│                            2.761 GB/s    │ 1.757 GB/s    │ 2.288 GB/s    │ 2.269 GB/s    │         │
├─ dict_compress_u32         2.639 ms      │ 3.641 ms      │ 2.938 ms      │ 3.124 ms      │ 100     │ 100
│                            1.515 GB/s    │ 1.098 GB/s    │ 1.361 GB/s    │ 1.28 GB/s     │         │
├─ dict_decompress_string    357.6 µs      │ 442.6 µs      │ 371.8 µs      │ 373.2 µs      │ 100     │ 100
│                            44.73 GB/s    │ 36.14 GB/s    │ 43.03 GB/s    │ 42.86 GB/s    │         │
├─ dict_decompress_u32       364.6 µs      │ 596.2 µs      │ 373 µs        │ 379.1 µs      │ 100     │ 100
│                            10.97 GB/s    │ 6.708 GB/s    │ 10.72 GB/s    │ 10.55 GB/s    │         │
├─ for_compress_i32          498.5 µs      │ 882.8 µs      │ 506.6 µs      │ 512.3 µs      │ 100     │ 100
│                            8.022 GB/s    │ 4.53 GB/s     │ 7.894 GB/s    │ 7.807 GB/s    │         │
├─ for_decompress_i32        95.45 µs      │ 123.6 µs      │ 104.5 µs      │ 104.9 µs      │ 100     │ 100
│                            41.9 GB/s     │ 32.34 GB/s    │ 38.26 GB/s    │ 38.1 GB/s     │         │
├─ fsst_compress_string      8.229 ms      │ 10.64 ms      │ 8.751 ms      │ 8.796 ms      │ 100     │ 100
│                            1.944 GB/s    │ 1.502 GB/s    │ 1.828 GB/s    │ 1.819 GB/s    │         │
├─ fsst_decompress_string    2.3 ms        │ 2.644 ms      │ 2.383 ms      │ 2.388 ms      │ 100     │ 100
│                            6.954 GB/s    │ 6.049 GB/s    │ 6.712 GB/s    │ 6.697 GB/s    │         │
├─ pcodec_compress_f64       7.255 ms      │ 9.489 ms      │ 7.391 ms      │ 7.429 ms      │ 100     │ 100
│                            1.102 GB/s    │ 843 MB/s      │ 1.082 GB/s    │ 1.076 GB/s    │         │
├─ pcodec_decompress_f64     1.616 ms      │ 1.897 ms      │ 1.631 ms      │ 1.639 ms      │ 100     │ 100
│                            4.949 GB/s    │ 4.216 GB/s    │ 4.902 GB/s    │ 4.878 GB/s    │         │
├─ runend_compress_u32       2.987 ms      │ 3.534 ms      │ 3.094 ms      │ 3.128 ms      │ 100     │ 100
│                            1.338 GB/s    │ 1.131 GB/s    │ 1.292 GB/s    │ 1.278 GB/s    │         │
├─ runend_decompress_u32     932.3 µs      │ 1.028 ms      │ 977.1 µs      │ 979.8 µs      │ 100     │ 100
│                            4.29 GB/s     │ 3.89 GB/s     │ 4.093 GB/s    │ 4.082 GB/s    │         │
├─ zigzag_compress_i32       97.66 µs      │ 191.2 µs      │ 101.1 µs      │ 105.8 µs      │ 100     │ 100
│                            40.95 GB/s    │ 20.91 GB/s    │ 39.56 GB/s    │ 37.78 GB/s    │         │
├─ zigzag_decompress_i32     101.7 µs      │ 140.8 µs      │ 111.7 µs      │ 111.9 µs      │ 100     │ 100
│                            39.31 GB/s    │ 28.4 GB/s     │ 35.78 GB/s    │ 35.72 GB/s    │         │
├─ zstd_compress_string      147.7 ms      │ 163.1 ms      │ 149.3 ms      │ 149.7 ms      │ 100     │ 100
│                            108.3 MB/s    │ 98.07 MB/s    │ 107.1 MB/s    │ 106.8 MB/s    │         │
├─ zstd_compress_u32         122.7 ms      │ 127.8 ms      │ 124 ms        │ 124.4 ms      │ 100     │ 100
│                            32.57 MB/s    │ 31.28 MB/s    │ 32.23 MB/s    │ 32.14 MB/s    │         │
├─ zstd_decompress_string    8.135 ms      │ 10.55 ms      │ 8.255 ms      │ 8.331 ms      │ 100     │ 100
│                            1.966 GB/s    │ 1.515 GB/s    │ 1.937 GB/s    │ 1.92 GB/s     │         │
╰─ zstd_decompress_u32       3.826 ms      │ 5.474 ms      │ 4.015 ms      │ 4.06 ms       │ 100     │ 100
                             1.045 GB/s    │ 730.7 MB/s    │ 996.1 MB/s    │ 985 MB/s      │         │
```