### PR TITLE
chore: optionally delete the duckdb database on engine creation.

### DIFF
--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -86,7 +86,11 @@ jobs:
           RUST_BACKTRACE: full
         run: |
           # Generate data, running each query once to make sure they don't panic.
-          target/release_debug/query_bench ${{ matrix.subcommand }} --targets ${{ matrix.targets }} -i1 -d gh-json ${{ matrix.scale_factor }}
+          target/release_debug/query_bench \
+            ${{ matrix.subcommand }} \
+            --targets ${{ matrix.targets }} \
+            -i1 \
+            -d gh-json ${{ matrix.scale_factor }}
 
       - name: Setup AWS CLI
         uses: aws-actions/configure-aws-credentials@v4
@@ -125,6 +129,7 @@ jobs:
             --targets ${{ matrix.targets }} \
             --export-spans \
             ${{ matrix.scale_factor }} \
+            --delete_duckdb_database \
             -o results.json
 
       - name: Run ${{ matrix.name }} benchmark (remote)
@@ -144,6 +149,7 @@ jobs:
               --export-spans \
               ${{ matrix.scale_factor }} \
               -d gh-json \
+              --delete_duckdb_database \
               -o results.json
 
       - name: Install uv

--- a/bench-vortex/src/benchmark_driver.rs
+++ b/bench-vortex/src/benchmark_driver.rs
@@ -31,6 +31,7 @@ pub struct DriverConfig {
     pub verbose: bool,
     pub display_format: DisplayFormat,
     pub disable_datafusion_cache: bool,
+    pub reuse_duckdb_database: bool,
     pub queries: Option<Vec<usize>>,
     pub exclude_queries: Option<Vec<usize>>,
     pub output_path: Option<PathBuf>,
@@ -78,6 +79,7 @@ pub fn run_benchmark<B: Benchmark>(benchmark: B, config: DriverConfig) -> Result
             target,
             config.disable_datafusion_cache,
             config.emit_plan,
+            config.reuse_duckdb_database,
         )?;
 
         tokio_runtime.block_on(benchmark.register_tables(&engine_ctx, target.format()))?;

--- a/bench-vortex/src/benchmark_driver.rs
+++ b/bench-vortex/src/benchmark_driver.rs
@@ -31,7 +31,7 @@ pub struct DriverConfig {
     pub verbose: bool,
     pub display_format: DisplayFormat,
     pub disable_datafusion_cache: bool,
-    pub reuse_duckdb_database: bool,
+    pub delete_duckdb_database: bool,
     pub queries: Option<Vec<usize>>,
     pub exclude_queries: Option<Vec<usize>>,
     pub output_path: Option<PathBuf>,
@@ -79,7 +79,7 @@ pub fn run_benchmark<B: Benchmark>(benchmark: B, config: DriverConfig) -> Result
             target,
             config.disable_datafusion_cache,
             config.emit_plan,
-            config.reuse_duckdb_database,
+            config.delete_duckdb_database,
         )?;
 
         tokio_runtime.block_on(benchmark.register_tables(&engine_ctx, target.format()))?;

--- a/bench-vortex/src/benchmark_trait.rs
+++ b/bench-vortex/src/benchmark_trait.rs
@@ -19,7 +19,7 @@ pub trait Benchmark {
         target: &Target,
         disable_datafusion_cache: bool,
         emit_plan: bool,
-        reuse_duckdb_database: bool,
+        delete_duckdb_database: bool,
     ) -> Result<EngineCtx> {
         let engine = target.engine();
         let format = target.format();
@@ -36,7 +36,7 @@ pub trait Benchmark {
                 Ok(EngineCtx::new_with_duckdb(
                     self.dataset(),
                     format,
-                    reuse_duckdb_database,
+                    delete_duckdb_database,
                 )?)
             }
             _ => unreachable!("engine not supported"),

--- a/bench-vortex/src/benchmark_trait.rs
+++ b/bench-vortex/src/benchmark_trait.rs
@@ -19,6 +19,7 @@ pub trait Benchmark {
         target: &Target,
         disable_datafusion_cache: bool,
         emit_plan: bool,
+        reuse_duckdb_database: bool,
     ) -> Result<EngineCtx> {
         let engine = target.engine();
         let format = target.format();
@@ -32,7 +33,11 @@ pub trait Benchmark {
             Engine::DuckDB => {
                 // Create a generic dataset for DuckDB context creation
                 // This will be properly configured when tables are registered
-                Ok(EngineCtx::new_with_duckdb(self.dataset(), format)?)
+                Ok(EngineCtx::new_with_duckdb(
+                    self.dataset(),
+                    format,
+                    reuse_duckdb_database,
+                )?)
             }
             _ => unreachable!("engine not supported"),
         }

--- a/bench-vortex/src/bin/query_bench.rs
+++ b/bench-vortex/src/bin/query_bench.rs
@@ -55,6 +55,9 @@ struct CommonArgs {
     #[arg(long, default_value_t = false)]
     disable_datafusion_cache: bool,
 
+    #[arg(long, default_value_t = false)]
+    reuse_duckdb_database: bool,
+
     #[arg(short, long, value_delimiter = ',')]
     queries: Option<Vec<usize>>,
 
@@ -195,6 +198,7 @@ fn run_clickbench(args: ClickBenchArgs) -> anyhow::Result<()> {
         verbose: args.common.verbose,
         display_format: args.common.display_format,
         disable_datafusion_cache: args.common.disable_datafusion_cache,
+        reuse_duckdb_database: args.common.reuse_duckdb_database,
         queries: args.common.queries,
         exclude_queries: args.common.exclude_queries,
         output_path: args.common.output_path,
@@ -222,6 +226,7 @@ fn run_tpch(args: TpcHArgs) -> anyhow::Result<()> {
         verbose: args.common.verbose,
         display_format: args.common.display_format,
         disable_datafusion_cache: args.common.disable_datafusion_cache,
+        reuse_duckdb_database: args.common.reuse_duckdb_database,
         queries: args.common.queries,
         exclude_queries: args.common.exclude_queries,
         output_path: args.common.output_path,
@@ -250,6 +255,7 @@ fn run_tpcds(args: TpcDSArgs) -> anyhow::Result<()> {
         verbose: args.common.verbose,
         display_format: args.common.display_format,
         disable_datafusion_cache: args.common.disable_datafusion_cache,
+        reuse_duckdb_database: args.common.reuse_duckdb_database,
         queries: args.common.queries,
         exclude_queries: args.common.exclude_queries,
         output_path: args.common.output_path,

--- a/bench-vortex/src/bin/query_bench.rs
+++ b/bench-vortex/src/bin/query_bench.rs
@@ -56,7 +56,7 @@ struct CommonArgs {
     disable_datafusion_cache: bool,
 
     #[arg(long, default_value_t = false)]
-    reuse_duckdb_database: bool,
+    delete_duckdb_database: bool,
 
     #[arg(short, long, value_delimiter = ',')]
     queries: Option<Vec<usize>>,
@@ -198,7 +198,7 @@ fn run_clickbench(args: ClickBenchArgs) -> anyhow::Result<()> {
         verbose: args.common.verbose,
         display_format: args.common.display_format,
         disable_datafusion_cache: args.common.disable_datafusion_cache,
-        reuse_duckdb_database: args.common.reuse_duckdb_database,
+        delete_duckdb_database: args.common.delete_duckdb_database,
         queries: args.common.queries,
         exclude_queries: args.common.exclude_queries,
         output_path: args.common.output_path,
@@ -226,7 +226,7 @@ fn run_tpch(args: TpcHArgs) -> anyhow::Result<()> {
         verbose: args.common.verbose,
         display_format: args.common.display_format,
         disable_datafusion_cache: args.common.disable_datafusion_cache,
-        reuse_duckdb_database: args.common.reuse_duckdb_database,
+        delete_duckdb_database: args.common.delete_duckdb_database,
         queries: args.common.queries,
         exclude_queries: args.common.exclude_queries,
         output_path: args.common.output_path,
@@ -255,7 +255,7 @@ fn run_tpcds(args: TpcDSArgs) -> anyhow::Result<()> {
         verbose: args.common.verbose,
         display_format: args.common.display_format,
         disable_datafusion_cache: args.common.disable_datafusion_cache,
-        reuse_duckdb_database: args.common.reuse_duckdb_database,
+        delete_duckdb_database: args.common.delete_duckdb_database,
         queries: args.common.queries,
         exclude_queries: args.common.exclude_queries,
         output_path: args.common.output_path,

--- a/bench-vortex/src/engines/ddb/mod.rs
+++ b/bench-vortex/src/engines/ddb/mod.rs
@@ -33,7 +33,7 @@ pub struct DuckDBCtx {
 }
 
 impl DuckDBCtx {
-    pub fn new(dataset: BenchmarkDataset, format: Format, reuse_database: bool) -> Result<Self> {
+    pub fn new(dataset: BenchmarkDataset, format: Format, delete_database: bool) -> Result<Self> {
         let dir = match dataset {
             BenchmarkDataset::ClickBench { flavor, .. } => {
                 format!("clickbench_{}/{}", flavor, format.name()).to_data_path()
@@ -48,7 +48,7 @@ impl DuckDBCtx {
         };
         std::fs::create_dir_all(&dir)?;
         let db_path = dir.join("duckdb.db");
-        if !reuse_database {
+        if delete_database {
             std::fs::remove_file(&db_path)?;
         }
         let db = Database::open(db_path)?;

--- a/bench-vortex/src/engines/ddb/mod.rs
+++ b/bench-vortex/src/engines/ddb/mod.rs
@@ -33,7 +33,7 @@ pub struct DuckDBCtx {
 }
 
 impl DuckDBCtx {
-    pub fn new(dataset: BenchmarkDataset, format: Format) -> Result<Self> {
+    pub fn new(dataset: BenchmarkDataset, format: Format, reuse_database: bool) -> Result<Self> {
         let dir = match dataset {
             BenchmarkDataset::ClickBench { flavor, .. } => {
                 format!("clickbench_{}/{}", flavor, format.name()).to_data_path()
@@ -48,6 +48,9 @@ impl DuckDBCtx {
         };
         std::fs::create_dir_all(&dir)?;
         let db_path = dir.join("duckdb.db");
+        if !reuse_database {
+            std::fs::remove_file(&db_path)?;
+        }
         let db = Database::open(db_path)?;
         let connection = db.connect()?;
         vortex_duckdb::register_table_functions(&connection)?;

--- a/bench-vortex/src/engines/mod.rs
+++ b/bench-vortex/src/engines/mod.rs
@@ -31,12 +31,12 @@ impl EngineCtx {
     pub fn new_with_duckdb(
         dataset: BenchmarkDataset,
         format: Format,
-        reuse_duckdb_database: bool,
+        delete_duckdb_database: bool,
     ) -> anyhow::Result<Self> {
         Ok(EngineCtx::DuckDB(ddb::DuckDBCtx::new(
             dataset,
             format,
-            reuse_duckdb_database,
+            delete_duckdb_database,
         )?))
     }
 

--- a/bench-vortex/src/engines/mod.rs
+++ b/bench-vortex/src/engines/mod.rs
@@ -28,8 +28,16 @@ impl EngineCtx {
         })
     }
 
-    pub fn new_with_duckdb(dataset: BenchmarkDataset, format: Format) -> anyhow::Result<Self> {
-        Ok(EngineCtx::DuckDB(ddb::DuckDBCtx::new(dataset, format)?))
+    pub fn new_with_duckdb(
+        dataset: BenchmarkDataset,
+        format: Format,
+        reuse_duckdb_database: bool,
+    ) -> anyhow::Result<Self> {
+        Ok(EngineCtx::DuckDB(ddb::DuckDBCtx::new(
+            dataset,
+            format,
+            reuse_duckdb_database,
+        )?))
     }
 
     pub fn to_engine(&self) -> Engine {

--- a/bench-vortex/src/tpcds/tpcds_benchmark.rs
+++ b/bench-vortex/src/tpcds/tpcds_benchmark.rs
@@ -71,8 +71,8 @@ impl Benchmark for TpcDsBenchmark {
                 // Create output directory
                 fs::create_dir_all(&base_data_dir)?;
 
-                // Generate TPC-DS data using DuckDB
-                let duckdb_ctx = DuckDBCtx::new(self.dataset(), target.format())?;
+                // Generate TPC-DS data using DuckDesB
+                let duckdb_ctx = DuckDBCtx::new(self.dataset(), target.format(), false)?;
 
                 // Install and load the tpcds extension
                 let _result1 = duckdb_ctx.execute_query("INSTALL tpcds")?;


### PR DESCRIPTION
We previously deleted this file (see 45200f1). Reusing the file substantially improved TPC-H S3 SF=1 (but neither clickbench nor other scale factors).

It seems we should at least be able to choose this option.