### PR TITLE
use arc slice for buffers in varbinview

### DIFF
--- a/encodings/dict/src/builders/bytes.rs
+++ b/encodings/dict/src/builders/bytes.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::hash::BuildHasher;
+use std::sync::Arc;
 
 use arrow_buffer::NullBufferBuilder;
 use num_traits::AsPrimitive;
@@ -180,7 +181,7 @@ impl<Code: Unsigned + AsPrimitive<usize> + NativePType> DictEncoder for BytesDic
     fn values(&mut self) -> VortexResult<ArrayRef> {
         VarBinViewArray::try_new(
             self.views.clone().freeze(),
-            vec![self.values.clone().freeze()],
+            Arc::from([self.values.clone().freeze()]),
             self.dtype.clone(),
             self.dtype.nullability().into(),
         )

--- a/encodings/fsst/src/canonical.rs
+++ b/encodings/fsst/src/canonical.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::sync::Arc;
+
 use fsst::Decompressor;
 use vortex_array::arrays::{BinaryView, VarBinViewArray};
 use vortex_array::builders::{ArrayBuilder, VarBinViewBuilder};
@@ -94,7 +96,7 @@ fn fsst_into_varbin_view(
 
     VarBinViewArray::try_new(
         views,
-        vec![uncompressed_bytes_array],
+        Arc::from([uncompressed_bytes_array]),
         fsst_array.dtype().clone(),
         Validity::copy_from_array(fsst_array.as_ref())?,
     )

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::sync::Arc;
+
 use itertools::Itertools;
 use num_traits::NumCast;
 use vortex_array::arrays::{
@@ -259,7 +261,7 @@ fn canonicalize_varbin_inner<I: NativePType>(
         views[patch_index_usize] = patch;
     }
 
-    let array = VarBinViewArray::try_new(views.freeze(), buffers, dtype, validity)?;
+    let array = VarBinViewArray::try_new(views.freeze(), Arc::from(buffers), dtype, validity)?;
 
     Ok(Canonical::VarBinView(array))
 }

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::fmt::Debug;
+use std::sync::Arc;
 
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::{BinaryView, PrimitiveArray, VarBinViewArray};
@@ -468,7 +469,7 @@ impl ZstdArray {
 
                 let vbv = VarBinViewArray::try_new(
                     views,
-                    vec![decompressed],
+                    Arc::from([decompressed]),
                     self.dtype.clone(),
                     slice_validity,
                 )?;

--- a/vortex-array/src/arrays/constant/canonical.rs
+++ b/vortex-array/src/arrays/constant/canonical.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::sync::Arc;
+
 use arrow_buffer::BooleanBuffer;
 use vortex_buffer::{Buffer, BufferMut, buffer};
 use vortex_dtype::{DType, Nullability, PType, match_each_native_ptype};
@@ -146,7 +148,12 @@ fn canonical_byte_view(
         None => {
             let views = buffer![BinaryView::from(0_u128); len];
 
-            VarBinViewArray::try_new(views, Vec::new(), dtype.clone(), Validity::AllInvalid)
+            VarBinViewArray::try_new(
+                views,
+                Default::default(),
+                dtype.clone(),
+                Validity::AllInvalid,
+            )
         }
         Some(scalar_bytes) => {
             // Create a view to hold the scalar bytes.
@@ -167,7 +174,7 @@ fn canonical_byte_view(
 
             VarBinViewArray::try_new(
                 views.freeze(),
-                buffers,
+                Arc::from(buffers),
                 dtype.clone(),
                 Validity::from(dtype.nullability()),
             )

--- a/vortex-array/src/arrays/varbinview/compact.rs
+++ b/vortex-array/src/arrays/varbinview/compact.rs
@@ -29,7 +29,7 @@ pub fn compact_buffers(array: &VarBinViewArray) -> VortexResult<VarBinViewArray>
         // The array contains no values, all buffers can be dropped.
         Validity::AllInvalid => Ok(VarBinViewArray::try_new(
             array.views().clone(),
-            vec![],
+            Default::default(),
             array.dtype().clone(),
             array.validity().clone(),
         )?),

--- a/vortex-array/src/arrays/varbinview/compute/cast.rs
+++ b/vortex-array/src/arrays/varbinview/compute/cast.rs
@@ -21,7 +21,7 @@ impl CastKernel for VarBinViewVTable {
         Ok(Some(
             VarBinViewArray::try_new(
                 array.views().clone(),
-                array.buffers().to_vec(),
+                array.buffers_arc(),
                 new_dtype,
                 new_validity,
             )?

--- a/vortex-array/src/arrays/varbinview/compute/cast.rs
+++ b/vortex-array/src/arrays/varbinview/compute/cast.rs
@@ -21,7 +21,7 @@ impl CastKernel for VarBinViewVTable {
         Ok(Some(
             VarBinViewArray::try_new(
                 array.views().clone(),
-                array.buffers_arc(),
+                array.buffers().clone(),
                 new_dtype,
                 new_validity,
             )?

--- a/vortex-array/src/arrays/varbinview/compute/mask.rs
+++ b/vortex-array/src/arrays/varbinview/compute/mask.rs
@@ -13,7 +13,7 @@ impl MaskKernel for VarBinViewVTable {
     fn mask(&self, array: &VarBinViewArray, mask: &Mask) -> VortexResult<ArrayRef> {
         Ok(VarBinViewArray::try_new(
             array.views().clone(),
-            array.buffers().to_vec(),
+            array.buffers_arc(),
             array.dtype().as_nullable(),
             array.validity().mask(mask)?,
         )?

--- a/vortex-array/src/arrays/varbinview/compute/mask.rs
+++ b/vortex-array/src/arrays/varbinview/compute/mask.rs
@@ -13,7 +13,7 @@ impl MaskKernel for VarBinViewVTable {
     fn mask(&self, array: &VarBinViewArray, mask: &Mask) -> VortexResult<ArrayRef> {
         Ok(VarBinViewArray::try_new(
             array.views().clone(),
-            array.buffers_arc(),
+            array.buffers().clone(),
             array.dtype().as_nullable(),
             array.validity().mask(mask)?,
         )?

--- a/vortex-array/src/arrays/varbinview/compute/take.rs
+++ b/vortex-array/src/arrays/varbinview/compute/take.rs
@@ -30,7 +30,7 @@ impl TakeKernel for VarBinViewVTable {
 
         Ok(VarBinViewArray::try_new(
             views_buffer,
-            array.buffers().to_vec(),
+            array.buffers_arc(),
             array
                 .dtype()
                 .union_nullability(indices.dtype().nullability()),

--- a/vortex-array/src/arrays/varbinview/compute/take.rs
+++ b/vortex-array/src/arrays/varbinview/compute/take.rs
@@ -30,7 +30,7 @@ impl TakeKernel for VarBinViewVTable {
 
         Ok(VarBinViewArray::try_new(
             views_buffer,
-            array.buffers_arc(),
+            array.buffers().clone(),
             array
                 .dtype()
                 .union_nullability(indices.dtype().nullability()),

--- a/vortex-array/src/arrays/varbinview/mod.rs
+++ b/vortex-array/src/arrays/varbinview/mod.rs
@@ -379,14 +379,8 @@ impl VarBinViewArray {
 
     /// Iterate over the underlying raw data buffers, not including the views buffer.
     #[inline]
-    pub fn buffers(&self) -> &[ByteBuffer] {
+    pub fn buffers(&self) -> &Arc<[ByteBuffer]> {
         &self.buffers
-    }
-
-    /// Share ownership of the underlying raw data buffers, not including the views buffer.
-    #[inline]
-    pub(crate) fn buffers_arc(&self) -> Arc<[ByteBuffer]> {
-        self.buffers.clone()
     }
 
     /// Accumulate an iterable set of values into our type here.

--- a/vortex-array/src/arrays/varbinview/mod.rs
+++ b/vortex-array/src/arrays/varbinview/mod.rs
@@ -299,7 +299,7 @@ pub struct VarBinViewEncoding;
 impl VarBinViewArray {
     pub fn try_new(
         views: Buffer<BinaryView>,
-        buffers: Vec<ByteBuffer>,
+        buffers: Arc<[ByteBuffer]>,
         dtype: DType,
         validity: Validity,
     ) -> VortexResult<Self> {
@@ -317,7 +317,7 @@ impl VarBinViewArray {
 
         Ok(Self {
             dtype,
-            buffers: Arc::from(buffers),
+            buffers,
             views,
             validity,
             stats_set: Default::default(),
@@ -381,6 +381,12 @@ impl VarBinViewArray {
     #[inline]
     pub fn buffers(&self) -> &[ByteBuffer] {
         &self.buffers
+    }
+
+    /// Share ownership of the underlying raw data buffers, not including the views buffer.
+    #[inline]
+    pub(crate) fn buffers_arc(&self) -> Arc<[ByteBuffer]> {
+        self.buffers.clone()
     }
 
     /// Accumulate an iterable set of values into our type here.

--- a/vortex-array/src/arrays/varbinview/mod.rs
+++ b/vortex-array/src/arrays/varbinview/mod.rs
@@ -3,6 +3,7 @@
 
 use std::fmt::{Debug, Formatter};
 use std::ops::Range;
+use std::sync::Arc;
 
 use static_assertions::{assert_eq_align, assert_eq_size};
 use vortex_buffer::{Alignment, Buffer, ByteBuffer};
@@ -286,7 +287,7 @@ impl VTable for VarBinViewVTable {
 #[derive(Clone, Debug)]
 pub struct VarBinViewArray {
     dtype: DType,
-    buffers: Vec<ByteBuffer>,
+    buffers: Arc<[ByteBuffer]>,
     views: Buffer<BinaryView>,
     validity: Validity,
     stats_set: ArrayStats,
@@ -316,7 +317,7 @@ impl VarBinViewArray {
 
         Ok(Self {
             dtype,
-            buffers,
+            buffers: Arc::from(buffers),
             views,
             validity,
             stats_set: Default::default(),

--- a/vortex-array/src/arrays/varbinview/ops.rs
+++ b/vortex-array/src/arrays/varbinview/ops.rs
@@ -14,7 +14,7 @@ impl OperationsVTable<VarBinViewVTable> for VarBinViewVTable {
 
         Ok(VarBinViewArray::try_new(
             views,
-            array.buffers().to_vec(),
+            array.buffers_arc(),
             array.dtype().clone(),
             array.validity().slice(start, stop)?,
         )?

--- a/vortex-array/src/arrays/varbinview/ops.rs
+++ b/vortex-array/src/arrays/varbinview/ops.rs
@@ -14,7 +14,7 @@ impl OperationsVTable<VarBinViewVTable> for VarBinViewVTable {
 
         Ok(VarBinViewArray::try_new(
             views,
-            array.buffers_arc(),
+            array.buffers().clone(),
             array.dtype().clone(),
             array.validity().slice(start, stop)?,
         )?

--- a/vortex-array/src/arrays/varbinview/serde.rs
+++ b/vortex-array/src/arrays/varbinview/serde.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::sync::Arc;
+
 use vortex_buffer::{Buffer, ByteBuffer};
 use vortex_dtype::DType;
 use vortex_error::{VortexExpect, VortexResult, vortex_bail};
@@ -48,7 +50,7 @@ impl SerdeVTable<VarBinViewVTable> for VarBinViewVTable {
             vortex_bail!("Expected 0 or 1 children, got {}", children.len());
         };
 
-        VarBinViewArray::try_new(views, buffers, dtype.clone(), validity)
+        VarBinViewArray::try_new(views, Arc::from(buffers), dtype.clone(), validity)
     }
 }
 

--- a/vortex-array/src/arrays/varbinview/serde.rs
+++ b/vortex-array/src/arrays/varbinview/serde.rs
@@ -56,7 +56,7 @@ impl SerdeVTable<VarBinViewVTable> for VarBinViewVTable {
 
 impl VisitorVTable<VarBinViewVTable> for VarBinViewVTable {
     fn visit_buffers(array: &VarBinViewArray, visitor: &mut dyn ArrayBufferVisitor) {
-        for buffer in array.buffers() {
+        for buffer in array.buffers().as_ref() {
             visitor.visit_buffer(buffer);
         }
         visitor.visit_buffer(&array.views().clone().into_byte_buffer());

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::sync::Arc;
+
 use arrow_array::array::{
     Array as ArrowArray, ArrowPrimitiveType, BooleanArray as ArrowBooleanArray, GenericByteArray,
     NullArray as ArrowNullArray, OffsetSizeTrait, PrimitiveArray as ArrowPrimitiveArray,
@@ -210,11 +212,13 @@ impl<T: ByteViewType> FromArrowArray<&GenericByteViewArray<T>> for ArrayRef {
 
         VarBinViewArray::try_new(
             views_buffer,
-            value
-                .data_buffers()
-                .iter()
-                .map(|b| ByteBuffer::from_arrow_buffer(b.clone(), Alignment::of::<u8>()))
-                .collect::<Vec<_>>(),
+            Arc::from(
+                value
+                    .data_buffers()
+                    .iter()
+                    .map(|b| ByteBuffer::from_arrow_buffer(b.clone(), Alignment::of::<u8>()))
+                    .collect::<Vec<_>>(),
+            ),
             dtype,
             nulls(value.nulls(), nullable),
         )

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -3,6 +3,7 @@
 
 use std::any::Any;
 use std::cmp::max;
+use std::sync::Arc;
 
 use vortex_buffer::{Buffer, BufferMut, ByteBuffer, ByteBufferMut};
 use vortex_dtype::{DType, Nullability};
@@ -136,7 +137,7 @@ impl VarBinViewBuilder {
 
         VarBinViewArray::try_new(
             std::mem::take(&mut self.views_builder).freeze(),
-            buffers,
+            Arc::from(buffers),
             std::mem::replace(&mut self.dtype, DType::Null),
             validity,
         )


### PR DESCRIPTION
`varbinview.clone()` should be constant, with the Vec for buffers it was linear with the number buffers before