### PR TITLE
chore: Timeout data downloads in benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ rand_distr = "0.5"
 ratatui = "0.29"
 rayon = "1.10.0"
 regex = "1.11.0"
-reqwest = { version = "0.12.0", features = [
+reqwest = { version = "0.12.4", features = [
     "charset",
     "http2",
     "macos-system-configuration",

--- a/bench-vortex/src/datasets/data_downloads.rs
+++ b/bench-vortex/src/datasets/data_downloads.rs
@@ -4,9 +4,11 @@
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
+use std::time::Duration;
 
 use bzip2::read::BzDecoder;
 use log::info;
+use reqwest::Client;
 use tokio::fs::File as TokioFile;
 use tokio::io::AsyncWriteExt;
 use vortex::error::VortexError;
@@ -17,10 +19,15 @@ pub async fn download_data(fname: PathBuf, data_url: &str) -> PathBuf {
     idempotent_async(&fname, async |path| {
         info!("Downloading {} from {}", fname.to_str().unwrap(), data_url);
         let mut file = TokioFile::create(path).await?;
-        let mut response = reqwest::get(data_url).await?;
-        if !response.status().is_success() {
-            anyhow::bail!("Failed to download data from {}", data_url);
-        }
+        let mut response = Client::builder()
+            .read_timeout(Duration::from_secs(60))
+            .timeout(Duration::from_secs(60 * 15))
+            .build()?
+            .get(data_url)
+            .send()
+            .await?
+            .error_for_status()?;
+
         while let Some(chunk) = response.chunk().await? {
             AsyncWriteExt::write_all(&mut file, &chunk).await?;
         }


### PR DESCRIPTION
Values are arbitrary and I assume are reasonable, open to suggestions if anyone thinks they should be more or less generous