### PR TITLE
docs: Document all canonical array types

### DIFF
--- a/vortex-array/src/arrays/bool/array.rs
+++ b/vortex-array/src/arrays/bool/array.rs
@@ -13,6 +13,35 @@ use crate::stats::{ArrayStats, StatsSetRef};
 use crate::validity::Validity;
 use crate::vtable::{ArrayVTable, CanonicalVTable, ValidityHelper};
 
+/// A boolean array that stores true/false values in a compact bit-packed format.
+///
+/// This mirrors the Apache Arrow Boolean array encoding, where each boolean value
+/// is stored as a single bit rather than a full byte.
+///
+/// The data layout uses:
+/// - A bit-packed buffer where each bit represents one boolean value (0 = false, 1 = true)
+/// - An optional validity child array, which must be of type `Bool(NonNullable)`, where true values
+///   indicate valid and false indicates null. if the i-th value is null in the validity child,
+///   the i-th packed bit in the buffer may be 0 or 1, i.e. it is undefined.
+/// - Bit-level slicing is supported with minimal overhead
+///
+/// # Examples
+///
+/// ```
+/// use vortex_array::arrays::BoolArray;
+/// use vortex_array::IntoArray;
+///
+/// // Create from iterator using FromIterator impl
+/// let array: BoolArray = [true, false, true, false].into_iter().collect();
+///
+/// // Slice the array
+/// let sliced = array.slice(1, 3).unwrap();
+/// assert_eq!(sliced.len(), 2);
+///
+/// // Access individual values
+/// let value = array.scalar_at(0).unwrap();
+/// assert_eq!(value, true.into());
+/// ```
 #[derive(Clone, Debug)]
 pub struct BoolArray {
     dtype: DType,

--- a/vortex-array/src/arrays/decimal/mod.rs
+++ b/vortex-array/src/arrays/decimal/mod.rs
@@ -67,7 +67,63 @@ pub fn compatible_storage_type(value_type: DecimalValueType, dtype: DecimalDType
     value_type >= smallest_storage_type(&dtype)
 }
 
-/// Array for decimal-typed real numbers
+/// A decimal array that stores fixed-precision decimal numbers with configurable scale.
+///
+/// This mirrors the Apache Arrow Decimal encoding and provides exact arithmetic for
+/// financial and scientific computations where floating-point precision loss is unacceptable.
+///
+/// ## Storage Format
+///
+/// Decimals are stored as scaled integers in a supported scalar value type.
+///
+/// The precisions supported for each scalar type are:
+/// - **i8**: precision 1-2 digits
+/// - **i16**: precision 3-4 digits  
+/// - **i32**: precision 5-9 digits
+/// - **i64**: precision 10-18 digits
+/// - **i128**: precision 19-38 digits
+/// - **i256**: precision 39-76 digits
+///
+/// These are just the maximal ranges for each scalar type, but it is perfectly legal to store
+/// values with precision that does not match this exactly. For example, a valid DecimalArray with
+/// precision=39 may store its values in an `i8` if all of the actual values fit into it.
+///
+/// Similarly, a `DecimalArray` can be built that stores a set of precision=2 values in a
+/// `Buffer<i256>`.
+///
+/// ## Precision and Scale
+///
+/// - **Precision**: Total number of significant digits (1-76, u8 range)
+/// - **Scale**: Number of digits after the decimal point (-128 to 127, i8 range)
+/// - **Value**: `stored_integer / 10^scale`
+///
+/// For example, with precision=5 and scale=2:
+/// - Stored value 12345 represents 123.45
+/// - Range: -999.99 to 999.99
+///
+/// ## Valid Scalar Types
+///
+/// The underlying storage uses these native types based on precision:
+/// - `DecimalValueType::I8`, `I16`, `I32`, `I64`, `I128`, `I256`
+/// - Type selection is automatic based on the required precision
+///
+/// # Examples
+///
+/// ```
+/// use vortex_array::arrays::DecimalArray;
+/// use vortex_dtype::DecimalDType;
+/// use vortex_buffer::{buffer, Buffer};
+/// use vortex_array::validity::Validity;
+///
+/// // Create a decimal array with precision=5, scale=2 (e.g., 123.45)
+/// let decimal_dtype = DecimalDType::new(5, 2);
+/// let values = buffer![12345i32, 67890i32, -12300i32]; // 123.45, 678.90, -123.00
+/// let array = DecimalArray::new(values, decimal_dtype, Validity::NonNullable);
+///
+/// assert_eq!(array.precision(), 5);
+/// assert_eq!(array.scale(), 2);
+/// assert_eq!(array.len(), 3);
+/// ```
 #[derive(Clone, Debug)]
 pub struct DecimalArray {
     dtype: DType,

--- a/vortex-array/src/arrays/extension/mod.rs
+++ b/vortex-array/src/arrays/extension/mod.rs
@@ -47,6 +47,82 @@ impl VTable for ExtensionVTable {
 #[derive(Clone, Debug)]
 pub struct ExtensionEncoding;
 
+/// An extension array that wraps another array with additional type information.
+///
+/// **⚠️ Unstable API**: This is an experimental feature that may change significantly
+/// in future versions. The extension type system is still evolving.
+///
+/// Unlike Apache Arrow's extension arrays, Vortex extension arrays provide a more flexible
+/// mechanism for adding semantic meaning to existing array types without requiring
+/// changes to the core type system.
+///
+/// ## Design Philosophy
+///
+/// Extension arrays serve as a type-safe wrapper that:
+/// - Preserves the underlying storage format and operations
+/// - Adds semantic type information via `ExtDType`
+/// - Enables custom serialization and deserialization logic
+/// - Allows domain-specific interpretations of generic data
+///
+/// ## Storage and Type Relationship
+///
+/// The extension array maintains a strict contract:
+/// - **Storage array**: Contains the actual data in a standard Vortex encoding
+/// - **Extension type**: Defines how to interpret the storage data semantically
+/// - **Type safety**: The storage array's dtype must match the extension type's storage dtype
+///
+/// ## Use Cases
+///
+/// Extension arrays are ideal for:
+/// - **Custom numeric types**: Decimal types, units of measurement, currencies
+/// - **Temporal types**: Custom date/time formats, time zones, calendars
+/// - **Domain-specific types**: UUIDs, IP addresses, geographic coordinates
+/// - **Encoded types**: Base64 strings, compressed data, encrypted values
+///
+/// ## Validity and Operations
+///
+/// Extension arrays delegate validity and most operations to their storage array:
+/// - Validity is inherited from the underlying storage
+/// - Slicing preserves the extension type
+/// - Scalar access wraps storage scalars with extension metadata
+///
+/// # Examples
+///
+/// ```
+/// use std::sync::Arc;
+/// use vortex_array::arrays::{ExtensionArray, PrimitiveArray};
+/// use vortex_dtype::{ExtDType, ExtID, DType, Nullability, PType};
+/// use vortex_array::validity::Validity;
+/// use vortex_array::IntoArray;
+/// use vortex_buffer::buffer;
+///
+/// // Define a custom extension type for representing currency values
+/// let currency_id = ExtID::from("example.currency");
+/// let currency_dtype = Arc::new(ExtDType::new(
+///     currency_id,
+///     Arc::new(DType::Primitive(PType::I64, Nullability::NonNullable)), // Storage as i64 cents
+///     None, // No additional metadata needed
+/// ));
+///
+/// // Create storage array with currency values in cents
+/// let cents_storage = PrimitiveArray::new(
+///     buffer![12345i64, 67890, 99999], // $123.45, $678.90, $999.99
+///     Validity::NonNullable
+/// );
+///
+/// // Wrap with extension type
+/// let currency_array = ExtensionArray::new(
+///     currency_dtype.clone(),
+///     cents_storage.into_array()
+/// );
+///
+/// assert_eq!(currency_array.len(), 3);
+/// assert_eq!(currency_array.id().as_ref(), "example.currency");
+///
+/// // Access maintains extension type information
+/// let first_value = currency_array.scalar_at(0).unwrap();
+/// assert!(first_value.as_extension_opt().is_some());
+/// ```
 #[derive(Clone, Debug)]
 pub struct ExtensionArray {
     dtype: DType,

--- a/vortex-array/src/arrays/extension/mod.rs
+++ b/vortex-array/src/arrays/extension/mod.rs
@@ -74,7 +74,7 @@ pub struct ExtensionEncoding;
 /// ## Use Cases
 ///
 /// Extension arrays are ideal for:
-/// - **Custom numeric types**: Decimal types, units of measurement, currencies
+/// - **Custom numeric types**: Units of measurement, currencies
 /// - **Temporal types**: Custom date/time formats, time zones, calendars
 /// - **Domain-specific types**: UUIDs, IP addresses, geographic coordinates
 /// - **Encoded types**: Base64 strings, compressed data, encrypted values

--- a/vortex-array/src/arrays/list/mod.rs
+++ b/vortex-array/src/arrays/list/mod.rs
@@ -47,7 +47,57 @@ impl VTable for ListVTable {
     }
 }
 
-/// The canonical array for List type data. This is modeled similarly to a ListArray.
+/// A list array that stores variable-length lists of elements, similar to `Vec<Vec<T>>`.
+///
+/// This mirrors the Apache Arrow List array encoding and provides efficient storage
+/// for nested data where each row contains a list of elements of the same type.
+///
+/// ## Data Layout
+///
+/// The list array uses an offset-based encoding:
+/// - **Elements array**: A flat array containing all list elements concatenated together
+/// - **Offsets array**: Integer array where `offsets[i]` is an (inclusive) start index into
+///   the **elements** and `offsets[i+1]` is the (exclusive) stop index for the `i`th list.
+/// - **Validity**: Optional mask indicating which lists are null
+///
+/// This allows for excellent cascading compression of the elements and offsets, as similar values
+/// are clustered together and the offsets have a predictable pattern and small deltas between
+/// consecutive elements.
+///
+/// ## Offset Semantics
+///
+/// - Offsets must be non-nullable integers (i32, i64, etc.)
+/// - Offsets array has length `n+1` where `n` is the number of lists
+/// - List `i` contains elements from `elements[offsets[i]..offsets[i+1]]`  
+/// - Offsets must be monotonically increasing
+///
+/// # Examples
+///
+/// ```
+/// use vortex_array::arrays::{ListArray, PrimitiveArray};
+/// use vortex_array::validity::Validity;
+/// use vortex_array::IntoArray;
+/// use std::sync::Arc;
+///
+/// // Create a list array representing [[1, 2], [3, 4, 5], []]
+/// let elements = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5]);
+/// let offsets = PrimitiveArray::from_iter([0u32, 2, 5, 5]); // 3 lists
+///
+/// let list_array = ListArray::try_new(
+///     elements.into_array(),
+///     offsets.into_array(),
+///     Validity::NonNullable,
+/// ).unwrap();
+///
+/// assert_eq!(list_array.len(), 3);
+///
+/// // Access individual lists
+/// let first_list = list_array.elements_at(0).unwrap();
+/// assert_eq!(first_list.len(), 2); // [1, 2]
+///
+/// let third_list = list_array.elements_at(2).unwrap();
+/// assert!(third_list.is_empty()); // []
+/// ```
 #[derive(Clone, Debug)]
 pub struct ListArray {
     dtype: DType,

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -44,6 +44,30 @@ impl VTable for NullVTable {
     }
 }
 
+/// A array where all values are null.
+///
+/// This mirrors the Apache Arrow Null array encoding and provides an efficient representation
+/// for arrays containing only null values. No actual data is stored, only the length.
+///
+/// All operations on null arrays return null values or indicate invalid data.
+///
+/// # Examples
+///
+/// ```
+/// use vortex_array::arrays::NullArray;
+/// use vortex_array::IntoArray;
+///
+/// // Create a null array with 5 elements
+/// let array = NullArray::new(5);
+///
+/// // Slice the array - still contains nulls
+/// let sliced = array.slice(1, 3).unwrap();
+/// assert_eq!(sliced.len(), 2);
+///
+/// // All elements are null
+/// let scalar = array.scalar_at(0).unwrap();
+/// assert!(scalar.is_null());
+/// ```
 #[derive(Clone, Debug)]
 pub struct NullArray {
     len: usize,

--- a/vortex-array/src/arrays/primitive/mod.rs
+++ b/vortex-array/src/arrays/primitive/mod.rs
@@ -55,6 +55,37 @@ impl VTable for PrimitiveVTable {
     }
 }
 
+/// A primitive array that stores [native types][vortex_dtype::NativePType] in a contiguous buffer
+/// of memory, along with an optional validity child.
+///
+/// This mirrors the Apache Arrow Primitive layout and can be converted into and out of one
+/// without allocations or copies.
+///
+/// The underlying buffer must be natively aligned to the primitive type they are representing.
+///
+/// Values are stored in their native representation with proper alignment.
+/// Null values still occupy space in the buffer but are marked invalid in the validity mask.
+///
+/// # Examples
+///
+/// ```
+/// use vortex_array::arrays::PrimitiveArray;
+/// use vortex_array::compute::sum;
+/// ///
+/// // Create from iterator using FromIterator impl
+/// let array: PrimitiveArray = [1i32, 2, 3, 4, 5].into_iter().collect();
+///
+/// // Slice the array
+/// let sliced = array.slice(1, 3).unwrap();
+///
+/// // Access individual values
+/// let value = sliced.scalar_at(0).unwrap();
+/// assert_eq!(value, 2i32.into());
+///
+/// // Convert into a type-erased array that can be passed to compute functions.
+/// let summed = sum(sliced.as_ref()).unwrap().as_primitive().typed_value::<i64>().unwrap();
+/// assert_eq!(summed, 5i64);
+/// ```
 #[derive(Clone, Debug)]
 pub struct PrimitiveArray {
     dtype: DType,

--- a/vortex-array/src/arrays/struct_/mod.rs
+++ b/vortex-array/src/arrays/struct_/mod.rs
@@ -44,6 +44,124 @@ impl VTable for StructVTable {
     }
 }
 
+/// A struct array that stores multiple named fields as columns, similar to a database row.
+///
+/// This mirrors the Apache Arrow Struct array encoding and provides a columnar representation
+/// of structured data where each row contains multiple named fields of potentially different types.
+///
+/// ## Data Layout
+///
+/// The struct array uses a columnar layout where:
+/// - Each field is stored as a separate child array
+/// - All fields must have the same length (number of rows)
+/// - Field names and types are defined in the struct's dtype
+/// - An optional validity mask indicates which entire rows are null
+///
+/// ## Row-level nulls
+///
+/// The StructArray contains its own top-level nulls, which are superimposed on top of the
+/// field-level validity values. This can be the case even if the fields themselves are non-nullable,
+/// accessing a particular row can yield nulls even if all children are valid at that position.
+///
+/// ```
+/// use vortex_array::arrays::{StructArray, BoolArray};
+/// use vortex_array::validity::Validity;
+/// use vortex_array::IntoArray;
+/// use vortex_dtype::FieldNames;
+/// use vortex_buffer::buffer;
+///
+/// // Create struct with all non-null fields but struct-level nulls
+/// let struct_array = StructArray::try_new(
+///     FieldNames::from(["a", "b", "c"]),
+///     vec![
+///         buffer![1i32, 2i32].into_array(),  // non-null field a
+///         buffer![10i32, 20i32].into_array(), // non-null field b  
+///         buffer![100i32, 200i32].into_array(), // non-null field c
+///     ],
+///     2,
+///     Validity::Array(BoolArray::from_iter([true, false]).into_array()), // row 1 is null
+/// ).unwrap();
+///
+/// // Row 0 is valid - returns a struct scalar with field values
+/// let row0 = struct_array.scalar_at(0).unwrap();
+/// assert!(!row0.is_null());
+///
+/// // Row 1 is null at struct level - returns null even though fields have values
+/// let row1 = struct_array.scalar_at(1).unwrap();
+/// assert!(row1.is_null());
+/// ```
+///
+/// ## Name uniqueness
+///
+/// It is valid for a StructArray to have multiple child columns that have the same name. In this
+/// case, any accessors that use column names will find the first column in sequence with the name.
+///
+/// ```
+/// use vortex_array::arrays::StructArray;
+/// use vortex_array::validity::Validity;
+/// use vortex_array::IntoArray;
+/// use vortex_dtype::FieldNames;
+/// use vortex_buffer::buffer;
+///
+/// // Create struct with duplicate "data" field names
+/// let struct_array = StructArray::try_new(
+///     FieldNames::from(["data", "data"]),
+///     vec![
+///         buffer![1i32, 2i32].into_array(),   // first "data"
+///         buffer![3i32, 4i32].into_array(),   // second "data"
+///     ],
+///     2,
+///     Validity::NonNullable,
+/// ).unwrap();
+///
+/// // field_by_name returns the FIRST "data" field
+/// let first_data = struct_array.field_by_name("data").unwrap();
+/// assert_eq!(first_data.scalar_at(0).unwrap(), 1i32.into());
+/// ```
+///
+/// ## Field Operations
+///
+/// Struct arrays support efficient column operations:
+/// - **Projection**: Select/reorder fields without copying data
+/// - **Field access**: Get columns by name or index
+/// - **Column addition**: Add new fields to create extended structs
+/// - **Column removal**: Remove fields to create narrower structs
+///
+/// ## Validity Semantics
+///
+/// - Row-level nulls are tracked in the struct's validity child
+/// - Individual field nulls are tracked in each field's own validity
+/// - A null struct row means all fields in that row are conceptually null
+/// - Field-level nulls can exist independently of struct-level nulls
+///
+/// # Examples
+///
+/// ```
+/// use vortex_array::arrays::{StructArray, PrimitiveArray};
+/// use vortex_array::validity::Validity;
+/// use vortex_array::IntoArray;
+/// use vortex_dtype::FieldNames;
+/// use vortex_buffer::buffer;
+///
+/// // Create arrays for each field
+/// let ids = PrimitiveArray::new(buffer![1i32, 2, 3], Validity::NonNullable);
+/// let names = PrimitiveArray::new(buffer![100u64, 200, 300], Validity::NonNullable);
+///
+/// // Create struct array with named fields
+/// let struct_array = StructArray::try_new(
+///     FieldNames::from(["id", "score"]),
+///     vec![ids.into_array(), names.into_array()],
+///     3,
+///     Validity::NonNullable,
+/// ).unwrap();
+///
+/// assert_eq!(struct_array.len(), 3);
+/// assert_eq!(struct_array.names().len(), 2);
+///
+/// // Access field by name
+/// let id_field = struct_array.field_by_name("id").unwrap();
+/// assert_eq!(id_field.len(), 3);
+/// ```
 #[derive(Clone, Debug)]
 pub struct StructArray {
     len: usize,
@@ -318,14 +436,31 @@ impl OperationsVTable<StructVTable> for StructVTable {
     }
 
     fn scalar_at(array: &StructArray, index: usize) -> VortexResult<Scalar> {
-        Ok(Scalar::struct_(
-            array.dtype().clone(),
-            array
-                .fields()
-                .iter()
-                .map(|field| field.scalar_at(index))
-                .try_collect()?,
-        ))
+        match array.validity {
+            Validity::AllValid | Validity::NonNullable => Ok(Scalar::struct_(
+                array.dtype().clone(),
+                array
+                    .fields()
+                    .iter()
+                    .map(|field| field.scalar_at(index))
+                    .try_collect()?,
+            )),
+            Validity::AllInvalid => Ok(Scalar::null(array.dtype().clone())),
+            Validity::Array(_) => {
+                if array.is_valid(index)? {
+                    Ok(Scalar::struct_(
+                        array.dtype().clone(),
+                        array
+                            .fields()
+                            .iter()
+                            .map(|field| field.scalar_at(index))
+                            .try_collect()?,
+                    ))
+                } else {
+                    Ok(Scalar::null(array.dtype().clone()))
+                }
+            }
+        }
     }
 }
 
@@ -428,5 +563,43 @@ mod test {
             "Expected None when removing non-existent column"
         );
         assert_eq!(struct_a.names(), &[FieldName::from("ys")].into());
+    }
+
+    #[test]
+    fn test_duplicate_field_names() {
+        // Test that StructArray allows duplicate field names and returns the first match
+        let field1 = buffer![1i32, 2, 3].into_array();
+        let field2 = buffer![10i32, 20, 30].into_array();
+        let field3 = buffer![100i32, 200, 300].into_array();
+
+        // Create struct with duplicate field names - "value" appears twice
+        let struct_array = StructArray::try_new(
+            FieldNames::from(["value", "other", "value"]),
+            vec![field1, field2, field3],
+            3,
+            Validity::NonNullable,
+        )
+        .unwrap();
+
+        // field_by_name should return the first field with the matching name
+        let first_value_field = struct_array.field_by_name("value").unwrap();
+        assert_eq!(
+            first_value_field.as_::<PrimitiveVTable>().as_slice::<i32>(),
+            [1i32, 2, 3] // This is field1, not field3
+        );
+
+        // Verify field_by_name_opt also returns the first match
+        let opt_field = struct_array.field_by_name_opt("value").unwrap();
+        assert_eq!(
+            opt_field.as_::<PrimitiveVTable>().as_slice::<i32>(),
+            [1i32, 2, 3] // First "value" field
+        );
+
+        // Verify the third field (second "value") can be accessed by index
+        let third_field = &struct_array.fields()[2];
+        assert_eq!(
+            third_field.as_::<PrimitiveVTable>().as_slice::<i32>(),
+            [100i32, 200, 300]
+        );
     }
 }

--- a/vortex-array/src/arrays/struct_/mod.rs
+++ b/vortex-array/src/arrays/struct_/mod.rs
@@ -436,30 +436,17 @@ impl OperationsVTable<StructVTable> for StructVTable {
     }
 
     fn scalar_at(array: &StructArray, index: usize) -> VortexResult<Scalar> {
-        match array.validity {
-            Validity::AllValid | Validity::NonNullable => Ok(Scalar::struct_(
+        if array.is_valid(index)? {
+            Ok(Scalar::struct_(
                 array.dtype().clone(),
                 array
                     .fields()
                     .iter()
                     .map(|field| field.scalar_at(index))
                     .try_collect()?,
-            )),
-            Validity::AllInvalid => Ok(Scalar::null(array.dtype().clone())),
-            Validity::Array(_) => {
-                if array.is_valid(index)? {
-                    Ok(Scalar::struct_(
-                        array.dtype().clone(),
-                        array
-                            .fields()
-                            .iter()
-                            .map(|field| field.scalar_at(index))
-                            .try_collect()?,
-                    ))
-                } else {
-                    Ok(Scalar::null(array.dtype().clone()))
-                }
-            }
+            ))
+        } else {
+            Ok(Scalar::null(array.dtype().clone()))
         }
     }
 }

--- a/vortex-array/src/arrays/varbinview/mod.rs
+++ b/vortex-array/src/arrays/varbinview/mod.rs
@@ -284,6 +284,65 @@ impl VTable for VarBinViewVTable {
     }
 }
 
+/// A variable-length binary view array that stores strings and binary data efficiently.
+///
+/// This mirrors the Apache Arrow StringView/BinaryView array encoding and provides
+/// an optimized representation for variable-length data with excellent performance
+/// characteristics for both short and long strings.
+///
+/// ## Data Layout
+///
+/// The array uses a hybrid storage approach with two main components:
+/// - **Views buffer**: Array of 16-byte `BinaryView` entries (one per logical element)
+/// - **Data buffers**: Shared backing storage for strings longer than 12 bytes
+///
+/// ## View Structure
+///
+/// Commonly referred to as "German Strings", each 16-byte view entry contains either:
+/// - **Inlined data**: For strings ≤ 12 bytes, the entire string is stored directly in the view
+/// - **Reference data**: For strings > 12 bytes, contains:
+///   - String length (4 bytes)
+///   - First 4 bytes of string as prefix (4 bytes)
+///   - Buffer index and offset (8 bytes total)
+///
+/// The following ASCII graphic is reproduced verbatim from the Arrow documentation:
+///
+/// ```text
+///                         ┌──────┬────────────────────────┐
+///                         │length│      string value      │
+///    Strings (len <= 12)  │      │    (padded with 0)     │
+///                         └──────┴────────────────────────┘
+///                          0    31                      127
+///
+///                         ┌───────┬───────┬───────┬───────┐
+///                         │length │prefix │  buf  │offset │
+///    Strings (len > 12)   │       │       │ index │       │
+///                         └───────┴───────┴───────┴───────┘
+///                          0    31       63      95    127
+/// ```
+///
+/// # Examples
+///
+/// ```
+/// use vortex_array::arrays::VarBinViewArray;
+/// use vortex_dtype::{DType, Nullability};
+/// use vortex_array::IntoArray;
+///
+/// // Create from an Iterator<Item = &str>
+/// let array = VarBinViewArray::from_iter_str([
+///         "inlined",
+///         "this string is outlined"
+/// ]);
+///
+/// assert_eq!(array.len(), 2);
+///
+/// // Access individual strings
+/// let first = array.bytes_at(0);
+/// assert_eq!(first.as_slice(), b"inlined"); // "short"
+///
+/// let second = array.bytes_at(1);
+/// assert_eq!(second.as_slice(), b"this string is outlined"); // Long string
+/// ```
 #[derive(Clone, Debug)]
 pub struct VarBinViewArray {
     dtype: DType,


### PR DESCRIPTION
Also, fixed a bug in scalar_at for StructArray, which did not check validity first.
