### PR TITLE
fix: Forbid SequenceScheme for String and Float dictionary codes as well as Integer

### DIFF
--- a/vortex-btrblocks/src/float.rs
+++ b/vortex-btrblocks/src/float.rs
@@ -328,7 +328,7 @@ impl Scheme for DictScheme {
             &codes_stats,
             is_sample,
             allowed_cascading - 1,
-            &[integer::DictScheme.code()],
+            &[integer::DictScheme.code(), integer::SequenceScheme.code()],
         )?;
         let compressed_codes = codes_scheme.compress(
             &codes_stats,

--- a/vortex-btrblocks/src/string.rs
+++ b/vortex-btrblocks/src/string.rs
@@ -14,7 +14,7 @@ use crate::integer::IntCompressor;
 use crate::sample::sample;
 use crate::{
     Compressor, CompressorStats, GenerateStatsOptions, Scheme,
-    estimate_compression_ratio_with_sampling,
+    estimate_compression_ratio_with_sampling, integer,
 };
 
 #[derive(Clone, Debug)]
@@ -201,10 +201,7 @@ impl Scheme for DictScheme {
             &dict.codes().to_primitive()?,
             is_sample,
             allowed_cascading - 1,
-            &[
-                crate::integer::DictScheme.code(),
-                crate::integer::SequenceScheme.code(),
-            ],
+            &[integer::DictScheme.code(), integer::SequenceScheme.code()],
         )?;
 
         // Attempt to compress the values with non-Dict compression.

--- a/vortex-btrblocks/src/string.rs
+++ b/vortex-btrblocks/src/string.rs
@@ -201,7 +201,10 @@ impl Scheme for DictScheme {
             &dict.codes().to_primitive()?,
             is_sample,
             allowed_cascading - 1,
-            &[crate::integer::DictScheme.code()],
+            &[
+                crate::integer::DictScheme.code(),
+                crate::integer::SequenceScheme.code(),
+            ],
         )?;
 
         // Attempt to compress the values with non-Dict compression.


### PR DESCRIPTION
Signed-off-by: Robert Kruszewski <github@robertk.io>
