### PR TITLE
fix: Correctly calculate the size of FlatLayouts array flatbuffer size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6960,6 +6960,7 @@ dependencies = [
  "clap",
  "crossterm",
  "env_logger",
+ "futures-executor",
  "futures-util",
  "humansize",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ flatbuffers = "25.2.10"
 flume = "0.11"
 fsst-rs = "0.5.2"
 futures = { version = "0.3.31", default-features = false }
+futures-executor = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
 goldenfile = "1"

--- a/vortex-tui/Cargo.toml
+++ b/vortex-tui/Cargo.toml
@@ -19,6 +19,7 @@ clap = { workspace = true, features = ["derive"] }
 crossterm = { workspace = true }
 env_logger = { version = "0.11" }
 futures-util = { workspace = true }
+futures-executor = { workspace = true }
 humansize = { workspace = true }
 indicatif = { workspace = true, features = ["futures"] }
 parquet = { workspace = true, features = ["arrow", "async"] }

--- a/vortex-tui/Cargo.toml
+++ b/vortex-tui/Cargo.toml
@@ -18,8 +18,8 @@ anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 crossterm = { workspace = true }
 env_logger = { version = "0.11" }
-futures-util = { workspace = true }
 futures-executor = { workspace = true }
+futures-util = { workspace = true }
 humansize = { workspace = true }
 indicatif = { workspace = true, features = ["futures"] }
 parquet = { workspace = true, features = ["arrow", "async"] }

--- a/vortex-tui/src/browse/app.rs
+++ b/vortex-tui/src/browse/app.rs
@@ -7,13 +7,15 @@ use std::sync::Arc;
 use ratatui::prelude::Size;
 use ratatui::widgets::ListState;
 use vortex::dtype::DType;
-use vortex::error::{VortexExpect, VortexResult};
+use vortex::error::{VortexExpect, VortexResult, VortexUnwrap};
 use vortex::file::{Footer, SegmentSpec, VortexFile, VortexOpenOptions};
 use vortex::layout::LayoutRef;
 use vortex::layout::layouts::flat::FlatVTable;
 use vortex::layout::layouts::zoned::ZonedVTable;
-use vortex::layout::segments::SegmentId;
+use vortex::layout::segments::{SegmentId, SegmentSource};
+use vortex::serde::ArrayParts;
 
+use crate::TOKIO_RUNTIME;
 use crate::browse::ui::SegmentGridState;
 
 #[derive(Default, Copy, Clone, Eq, PartialEq)]
@@ -36,19 +38,25 @@ pub struct LayoutCursor {
     footer: Footer,
     layout: LayoutRef,
     segment_map: Arc<[SegmentSpec]>,
+    segment_source: Arc<dyn SegmentSource>,
 }
 
 impl LayoutCursor {
-    pub fn new(footer: Footer) -> Self {
+    pub fn new(footer: Footer, segment_source: Arc<dyn SegmentSource>) -> Self {
         Self {
             path: Vec::new(),
             layout: footer.layout().clone(),
             segment_map: Arc::clone(footer.segment_map()),
             footer,
+            segment_source,
         }
     }
 
-    pub fn new_with_path(footer: Footer, path: Vec<usize>) -> Self {
+    pub fn new_with_path(
+        footer: Footer,
+        segment_source: Arc<dyn SegmentSource>,
+        path: Vec<usize>,
+    ) -> Self {
         let mut layout = footer.layout().clone();
 
         // Traverse the layout tree at each element of the path.
@@ -63,6 +71,7 @@ impl LayoutCursor {
             path,
             footer,
             layout,
+            segment_source,
         }
     }
 
@@ -72,14 +81,14 @@ impl LayoutCursor {
         let mut path = self.path.clone();
         path.push(n);
 
-        Self::new_with_path(self.footer.clone(), path)
+        Self::new_with_path(self.footer.clone(), self.segment_source.clone(), path)
     }
 
     pub fn parent(&self) -> Self {
         let mut path = self.path.clone();
         path.pop();
 
-        Self::new_with_path(self.footer.clone(), path)
+        Self::new_with_path(self.footer.clone(), self.segment_source.clone(), path)
     }
 
     /// Get the size of the backing flatbuffer for this layout.
@@ -87,7 +96,13 @@ impl LayoutCursor {
     /// NOTE: this is only safe to run against a FLAT layout.
     pub fn flatbuffer_size(&self) -> usize {
         let segment_id = self.layout.as_::<FlatVTable>().segment_id();
-        self.segment_spec(segment_id).length as usize
+        let segment = TOKIO_RUNTIME
+            .block_on(async { self.segment_source.request(segment_id, &("".into())).await })
+            .vortex_unwrap();
+        ArrayParts::try_from(segment)
+            .vortex_unwrap()
+            .metadata()
+            .len()
     }
 
     pub fn total_size(&self) -> usize {
@@ -167,7 +182,7 @@ impl AppState<'_> {
 pub async fn create_file_app<'a>(path: impl AsRef<Path>) -> VortexResult<AppState<'a>> {
     let vxf = VortexOpenOptions::file().open(path).await?;
 
-    let cursor = LayoutCursor::new(vxf.footer().clone());
+    let cursor = LayoutCursor::new(vxf.footer().clone(), vxf.segment_source());
 
     Ok(AppState {
         vxf,

--- a/vortex-tui/src/browse/app.rs
+++ b/vortex-tui/src/browse/app.rs
@@ -4,6 +4,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use futures_executor::block_on;
 use ratatui::prelude::Size;
 use ratatui::widgets::ListState;
 use vortex::dtype::DType;
@@ -15,7 +16,6 @@ use vortex::layout::layouts::zoned::ZonedVTable;
 use vortex::layout::segments::{SegmentId, SegmentSource};
 use vortex::serde::ArrayParts;
 
-use crate::TOKIO_RUNTIME;
 use crate::browse::ui::SegmentGridState;
 
 #[derive(Default, Copy, Clone, Eq, PartialEq)]
@@ -91,14 +91,13 @@ impl LayoutCursor {
         Self::new_with_path(self.footer.clone(), self.segment_source.clone(), path)
     }
 
-    /// Get the size of the backing flatbuffer for this layout.
+    /// Get the size of the array flatbuffer for this layout.
     ///
     /// NOTE: this is only safe to run against a FLAT layout.
     pub fn flatbuffer_size(&self) -> usize {
         let segment_id = self.layout.as_::<FlatVTable>().segment_id();
-        let segment = TOKIO_RUNTIME
-            .block_on(async { self.segment_source.request(segment_id, &("".into())).await })
-            .vortex_unwrap();
+        let segment =
+            block_on(self.segment_source.request(segment_id, &("".into()))).vortex_unwrap();
         ArrayParts::try_from(segment)
             .vortex_unwrap()
             .metadata()


### PR DESCRIPTION
This was lost in some refactors, we parse the flat layouts segment to pick up
the arrays metadata bytes

fix #3977 