### PR TITLE
chore: reject warnings on clippy but not on check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,9 +236,9 @@ jobs:
       - name: Rustc check
         run: cargo check --locked --all-features --all-targets
       - name: Rust Lint - Clippy All Features
-        run: cargo clippy --locked --all-features --all-targets
+        run: cargo clippy --locked --all-features --all-targets -- -D warnings
       - name: Rust Lint - Clippy Default Features
-        run: cargo clippy --locked --all-targets
+        run: cargo clippy --locked --all-targets -- -D warnings
 
   rust-lint-no-default:
     name: "Rust (lint, no default)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,7 +247,7 @@ unexpected_cfgs = { level = "deny", check-cfg = [
     "cfg(codspeed)",
     "cfg(vortex_nightly)",
 ] }
-warnings = "deny"
+warnings = "warn"
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }


### PR DESCRIPTION
When I develop, I often tweak things - add a panic, rename a variable, comment something out. Every time I do cargo run or cargo check, I get a bunch of noise about unused variables or similar warnings, which I'm forced to fix before I can verify the actual change. But I don’t want to fix them yet - I just want to test the logic, confirm it resolves the issue, and then clean up.

In spiral it made development much easier after https://github.com/spiraldb/spiraldb/pull/2002