### PR TITLE
varbinview zip kernel

### DIFF
--- a/vortex-array/src/arrays/varbinview/compute/mod.rs
+++ b/vortex-array/src/arrays/varbinview/compute/mod.rs
@@ -8,6 +8,7 @@ mod is_sorted;
 mod mask;
 mod min_max;
 mod take;
+mod zip;
 
 #[cfg(test)]
 mod tests {

--- a/vortex-array/src/arrays/varbinview/compute/zip.rs
+++ b/vortex-array/src/arrays/varbinview/compute/zip.rs
@@ -3,26 +3,25 @@
 
 use vortex_error::VortexResult;
 
-use crate::arrays::VarBinViewArray;
+use crate::arrays::{VarBinViewArray, VarBinViewVTable};
 use crate::builders::VarBinViewBuilder;
-use crate::compute::{ZipKernelAdapter, zip_impl_with_builder, zip_return_dtype};
+use crate::compute::{ZipKernel, ZipKernelAdapter, zip_impl_with_builder, zip_return_dtype};
 use crate::{Array, ArrayRef, register_kernel};
-use crate::{arrays::VarBinViewVTable, compute::ZipKernel};
 
 impl ZipKernel for VarBinViewVTable {
     fn zip(
         &self,
-        mask: &vortex_mask::Mask,
         if_true: &VarBinViewArray,
         if_false: &dyn Array,
+        mask: &vortex_mask::Mask,
     ) -> VortexResult<Option<ArrayRef>> {
         let Some(if_false) = if_false.as_opt::<VarBinViewVTable>() else {
             return Ok(None);
         };
         Ok(Some(zip_impl_with_builder(
-            mask,
             if_true.as_ref(),
             if_false.as_ref(),
+            mask,
             Box::new(VarBinViewBuilder::with_buffer_deduplication(
                 zip_return_dtype(if_true.as_ref(), if_false.as_ref()),
                 if_true.len(),
@@ -32,3 +31,45 @@ impl ZipKernel for VarBinViewVTable {
 }
 
 register_kernel!(ZipKernelAdapter(VarBinViewVTable).lift());
+
+#[cfg(test)]
+mod tests {
+    use vortex_dtype::{DType, Nullability};
+    use vortex_mask::Mask;
+
+    use crate::{
+        arrays::VarBinViewVTable,
+        builders::{ArrayBuilder as _, VarBinViewBuilder},
+        compute::zip,
+    };
+
+    #[test]
+    fn test_varbinview_zip() {
+        let if_true = {
+            let mut builder =
+                VarBinViewBuilder::with_capacity(DType::Utf8(Nullability::NonNullable), 10);
+            for _ in 0..100 {
+                builder.append_value("Hello");
+                builder.append_value("Hello this is a long string that won't be inlined.");
+            }
+            builder.finish()
+        };
+
+        let if_false = {
+            let mut builder =
+                VarBinViewBuilder::with_capacity(DType::Utf8(Nullability::NonNullable), 10);
+            for _ in 0..100 {
+                builder.append_value("Hello2");
+                builder.append_value("Hello2 this is a long string that won't be inlined.");
+            }
+            builder.finish()
+        };
+
+        // [1,2,4,5,7,8,..]
+        let mask = Mask::from_indices(100, (0..100).filter(|i| i % 3 != 0).collect());
+
+        let zipped = zip(&if_true, &if_false, &mask).unwrap();
+        let zipped = zipped.as_opt::<VarBinViewVTable>().unwrap();
+        assert_eq!(zipped.nbuffers(), 2);
+    }
+}

--- a/vortex-array/src/arrays/varbinview/compute/zip.rs
+++ b/vortex-array/src/arrays/varbinview/compute/zip.rs
@@ -39,13 +39,11 @@ mod tests {
     use vortex_dtype::{DType, Nullability};
     use vortex_mask::Mask;
 
-    use crate::{
-        IntoArray,
-        arrays::VarBinViewVTable,
-        arrow::IntoArrowArray,
-        builders::{ArrayBuilder as _, VarBinViewBuilder},
-        compute::zip,
-    };
+    use crate::IntoArray;
+    use crate::arrays::VarBinViewVTable;
+    use crate::arrow::IntoArrowArray;
+    use crate::builders::{ArrayBuilder as _, VarBinViewBuilder};
+    use crate::compute::zip;
 
     #[test]
     fn test_varbinview_zip() {

--- a/vortex-array/src/arrays/varbinview/compute/zip.rs
+++ b/vortex-array/src/arrays/varbinview/compute/zip.rs
@@ -34,11 +34,15 @@ register_kernel!(ZipKernelAdapter(VarBinViewVTable).lift());
 
 #[cfg(test)]
 mod tests {
+    use arrow_array::cast::AsArray;
+    use arrow_select::zip::zip as arrow_zip;
     use vortex_dtype::{DType, Nullability};
     use vortex_mask::Mask;
 
     use crate::{
+        IntoArray,
         arrays::VarBinViewVTable,
+        arrow::IntoArrowArray,
         builders::{ArrayBuilder as _, VarBinViewBuilder},
         compute::zip,
     };
@@ -66,10 +70,24 @@ mod tests {
         };
 
         // [1,2,4,5,7,8,..]
-        let mask = Mask::from_indices(100, (0..100).filter(|i| i % 3 != 0).collect());
+        let mask = Mask::from_indices(200, (0..100).filter(|i| i % 3 != 0).collect());
 
         let zipped = zip(&if_true, &if_false, &mask).unwrap();
         let zipped = zipped.as_opt::<VarBinViewVTable>().unwrap();
         assert_eq!(zipped.nbuffers(), 2);
+
+        // assert the result is the same as arrow
+        let expected = arrow_zip(
+            mask.into_array()
+                .into_arrow_preferred()
+                .unwrap()
+                .as_boolean(),
+            &if_true.into_arrow_preferred().unwrap(),
+            &if_false.into_arrow_preferred().unwrap(),
+        )
+        .unwrap();
+
+        let actual = zipped.clone().into_array().into_arrow_preferred().unwrap();
+        assert_eq!(actual.as_ref(), expected.as_ref());
     }
 }

--- a/vortex-array/src/arrays/varbinview/compute/zip.rs
+++ b/vortex-array/src/arrays/varbinview/compute/zip.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
 use vortex_error::VortexResult;
 
 use crate::arrays::VarBinViewArray;

--- a/vortex-array/src/arrays/varbinview/compute/zip.rs
+++ b/vortex-array/src/arrays/varbinview/compute/zip.rs
@@ -1,0 +1,31 @@
+use vortex_error::VortexResult;
+
+use crate::arrays::VarBinViewArray;
+use crate::builders::VarBinViewBuilder;
+use crate::compute::{ZipKernelAdapter, zip_impl_with_builder, zip_return_dtype};
+use crate::{Array, ArrayRef, register_kernel};
+use crate::{arrays::VarBinViewVTable, compute::ZipKernel};
+
+impl ZipKernel for VarBinViewVTable {
+    fn zip(
+        &self,
+        mask: &vortex_mask::Mask,
+        if_true: &VarBinViewArray,
+        if_false: &dyn Array,
+    ) -> VortexResult<Option<ArrayRef>> {
+        let Some(if_false) = if_false.as_opt::<VarBinViewVTable>() else {
+            return Ok(None);
+        };
+        Ok(Some(zip_impl_with_builder(
+            mask,
+            if_true.as_ref(),
+            if_false.as_ref(),
+            Box::new(VarBinViewBuilder::with_buffer_deduplication(
+                zip_return_dtype(if_true.as_ref(), if_false.as_ref()),
+                if_true.len(),
+            )),
+        )?))
+    }
+}
+
+register_kernel!(ZipKernelAdapter(VarBinViewVTable).lift());

--- a/vortex-array/src/compute/zip.rs
+++ b/vortex-array/src/compute/zip.rs
@@ -9,7 +9,7 @@ use vortex_error::{VortexError, VortexResult, vortex_bail, vortex_err};
 use vortex_mask::{AllOr, Mask};
 
 use super::{ComputeFnVTable, InvocationArgs, Output, cast};
-use crate::builders::builder_with_capacity;
+use crate::builders::{ArrayBuilder, builder_with_capacity};
 use crate::compute::{ComputeFn, Kernel};
 use crate::vtable::VTable;
 use crate::{Array, ArrayRef};
@@ -144,7 +144,7 @@ pub trait ZipKernel: VTable {
         mask: &Mask,
         if_true: &Self::Array,
         if_false: &dyn Array,
-    ) -> VortexResult<ArrayRef>;
+    ) -> VortexResult<Option<ArrayRef>>;
 }
 
 pub struct ZipKernelRef(pub ArcRef<dyn Kernel>);
@@ -169,11 +169,11 @@ impl<V: VTable + ZipKernel> Kernel for ZipKernelAdapter<V> {
         let Some(if_true) = if_true.as_opt::<V>() else {
             return Ok(None);
         };
-        Ok(Some(V::zip(&self.0, mask, if_true, if_false)?.into()))
+        Ok(V::zip(&self.0, mask, if_true, if_false)?.map(Into::into))
     }
 }
 
-fn zip_return_dtype(if_true: &dyn Array, if_false: &dyn Array) -> DType {
+pub(crate) fn zip_return_dtype(if_true: &dyn Array, if_false: &dyn Array) -> DType {
     if_true
         .dtype()
         .union_nullability(if_false.dtype().nullability())
@@ -181,8 +181,16 @@ fn zip_return_dtype(if_true: &dyn Array, if_false: &dyn Array) -> DType {
 
 fn zip_impl(mask: &Mask, if_true: &dyn Array, if_false: &dyn Array) -> VortexResult<ArrayRef> {
     // if_true.len() == if_false.len() from ComputeFn::invoke
-    let mut builder = builder_with_capacity(&zip_return_dtype(if_true, if_false), if_true.len());
+    let builder = builder_with_capacity(&zip_return_dtype(if_true, if_false), if_true.len());
+    zip_impl_with_builder(mask, if_true, if_false, builder)
+}
 
+pub(crate) fn zip_impl_with_builder(
+    mask: &Mask,
+    if_true: &dyn Array,
+    if_false: &dyn Array,
+    mut builder: Box<dyn ArrayBuilder>,
+) -> VortexResult<ArrayRef> {
     match mask.slices() {
         AllOr::All => Ok(if_true.to_array()),
         AllOr::None => Ok(if_false.to_array()),

--- a/vortex-array/src/compute/zip.rs
+++ b/vortex-array/src/compute/zip.rs
@@ -91,8 +91,11 @@ impl ComputeFnVTable for Zip {
     }
 
     fn return_len(&self, args: &InvocationArgs) -> VortexResult<usize> {
-        let ZipArgs { if_true, .. } = ZipArgs::try_from(args)?;
+        let ZipArgs { if_true, mask, .. } = ZipArgs::try_from(args)?;
         // ComputeFn::invoke asserts if_true.len() == if_false.len(), because zip is elementwise
+        if if_true.len() != mask.len() {
+            vortex_bail!("input arrays must have the same length as the mask");
+        }
         Ok(if_true.len())
     }
 

--- a/vortex-array/src/compute/zip.rs
+++ b/vortex-array/src/compute/zip.rs
@@ -18,10 +18,10 @@ use crate::{Array, ArrayRef};
 ///
 /// Returns a new array where `result[i] = if_true[i]` when `mask[i]` is true,
 /// otherwise `result[i] = if_false[i]`.
-pub fn zip(mask: &Mask, if_true: &dyn Array, if_false: &dyn Array) -> VortexResult<ArrayRef> {
+pub fn zip(if_true: &dyn Array, if_false: &dyn Array, mask: &Mask) -> VortexResult<ArrayRef> {
     ZIP_FN
         .invoke(&InvocationArgs {
-            inputs: &[mask.into(), if_true.into(), if_false.into()],
+            inputs: &[if_true.into(), if_false.into(), mask.into()],
             options: &(),
         })?
         .unwrap_array()
@@ -44,9 +44,9 @@ impl ComputeFnVTable for Zip {
         kernels: &[ArcRef<dyn Kernel>],
     ) -> VortexResult<Output> {
         let ZipArgs {
-            mask,
             if_true,
             if_false,
+            mask,
         } = ZipArgs::try_from(args)?;
 
         if mask.all_true() {
@@ -55,11 +55,6 @@ impl ComputeFnVTable for Zip {
 
         if mask.all_false() {
             return Ok(cast(if_false, &zip_return_dtype(if_true, if_false))?.into());
-        }
-
-        if if_true.is_canonical() && if_false.is_canonical() {
-            // skip kernel lookup if both arrays are canonical
-            return Ok(zip_impl(mask, if_true, if_false)?.into());
         }
 
         // check if if_true supports zip directly
@@ -77,9 +72,9 @@ impl ComputeFnVTable for Zip {
         //           kernel.invoke(Args(if_false, if_true, mask, invert_mask = true))
 
         Ok(zip_impl(
-            mask,
             if_true.to_canonical()?.as_ref(),
             if_false.to_canonical()?.as_ref(),
+            mask,
         )?
         .into())
     }
@@ -107,9 +102,9 @@ impl ComputeFnVTable for Zip {
 }
 
 struct ZipArgs<'a> {
-    mask: &'a Mask,
     if_true: &'a dyn Array,
     if_false: &'a dyn Array,
+    mask: &'a Mask,
 }
 
 impl<'a> TryFrom<&InvocationArgs<'a>> for ZipArgs<'a> {
@@ -119,21 +114,22 @@ impl<'a> TryFrom<&InvocationArgs<'a>> for ZipArgs<'a> {
         if value.inputs.len() != 3 {
             vortex_bail!("Expected 3 inputs for zip, found {}", value.inputs.len());
         }
-        let mask = value.inputs[0]
-            .mask()
-            .ok_or_else(|| vortex_err!("Expected input 0 to be a mask"))?;
+        let if_true = value.inputs[0]
+            .array()
+            .ok_or_else(|| vortex_err!("Expected input 0 to be an array"))?;
 
-        let if_true = value.inputs[1]
+        let if_false = value.inputs[1]
             .array()
             .ok_or_else(|| vortex_err!("Expected input 1 to be an array"))?;
 
-        let if_false = value.inputs[2]
-            .array()
-            .ok_or_else(|| vortex_err!("Expected input 2 to be an array"))?;
+        let mask = value.inputs[2]
+            .mask()
+            .ok_or_else(|| vortex_err!("Expected input 2 to be a mask"))?;
+
         Ok(Self {
-            mask,
             if_true,
             if_false,
+            mask,
         })
     }
 }
@@ -141,9 +137,9 @@ impl<'a> TryFrom<&InvocationArgs<'a>> for ZipArgs<'a> {
 pub trait ZipKernel: VTable {
     fn zip(
         &self,
-        mask: &Mask,
         if_true: &Self::Array,
         if_false: &dyn Array,
+        mask: &Mask,
     ) -> VortexResult<Option<ArrayRef>>;
 }
 
@@ -162,14 +158,14 @@ impl<V: VTable + ZipKernel> ZipKernelAdapter<V> {
 impl<V: VTable + ZipKernel> Kernel for ZipKernelAdapter<V> {
     fn invoke(&self, args: &InvocationArgs) -> VortexResult<Option<Output>> {
         let ZipArgs {
-            mask,
             if_true,
             if_false,
+            mask,
         } = ZipArgs::try_from(args)?;
         let Some(if_true) = if_true.as_opt::<V>() else {
             return Ok(None);
         };
-        Ok(V::zip(&self.0, mask, if_true, if_false)?.map(Into::into))
+        Ok(V::zip(&self.0, if_true, if_false, mask)?.map(Into::into))
     }
 }
 
@@ -179,16 +175,16 @@ pub(crate) fn zip_return_dtype(if_true: &dyn Array, if_false: &dyn Array) -> DTy
         .union_nullability(if_false.dtype().nullability())
 }
 
-fn zip_impl(mask: &Mask, if_true: &dyn Array, if_false: &dyn Array) -> VortexResult<ArrayRef> {
+fn zip_impl(if_true: &dyn Array, if_false: &dyn Array, mask: &Mask) -> VortexResult<ArrayRef> {
     // if_true.len() == if_false.len() from ComputeFn::invoke
     let builder = builder_with_capacity(&zip_return_dtype(if_true, if_false), if_true.len());
-    zip_impl_with_builder(mask, if_true, if_false, builder)
+    zip_impl_with_builder(if_true, if_false, mask, builder)
 }
 
 pub(crate) fn zip_impl_with_builder(
-    mask: &Mask,
     if_true: &dyn Array,
     if_false: &dyn Array,
+    mask: &Mask,
     mut builder: Box<dyn ArrayBuilder>,
 ) -> VortexResult<ArrayRef> {
     match mask.slices() {
@@ -221,7 +217,7 @@ mod tests {
         let if_true = PrimitiveArray::from_iter([10, 20, 30, 40, 50]).into_array();
         let if_false = PrimitiveArray::from_iter([1, 2, 3, 4, 5]).into_array();
 
-        let result = zip(&mask, &if_true, &if_false).unwrap();
+        let result = zip(&if_true, &if_false, &mask).unwrap();
         let expected = PrimitiveArray::from_iter([10, 2, 3, 40, 5]);
 
         assert_eq!(
@@ -237,7 +233,7 @@ mod tests {
         let if_false =
             PrimitiveArray::from_option_iter([Some(1), Some(2), Some(3), None]).into_array();
 
-        let result = zip(&mask, &if_true, &if_false).unwrap();
+        let result = zip(&if_true, &if_false, &mask).unwrap();
 
         assert_eq!(
             result.to_primitive().unwrap().as_slice::<i32>(),
@@ -255,6 +251,6 @@ mod tests {
         let if_true = PrimitiveArray::from_iter([10, 20, 30]).into_array();
         let if_false = PrimitiveArray::from_iter([1, 2, 3, 4]).into_array();
 
-        zip(&mask, &if_true, &if_false).unwrap();
+        zip(&if_true, &if_false, &mask).unwrap();
     }
 }


### PR DESCRIPTION
Uses the buffer deduplicating builder to construct the zipped array. This guards against the pathological case where we are zipping two varbinview arrays with a mask that has lots of contiguous slices. Each `builder.extend_from_array(input.slice(..))` would duplicate the entire buffers of `input`, and each slice in the mask would add the same buffers to the result array over and over again.