### PR TITLE
[wip] Parameterized VTables

### DIFF
--- a/vortex-array/src/arrays/decimal/mod.rs
+++ b/vortex-array/src/arrays/decimal/mod.rs
@@ -7,6 +7,8 @@ mod patch;
 mod serde;
 
 use arrow_buffer::BooleanBufferBuilder;
+use std::marker::PhantomData;
+use std::sync::Arc;
 use vortex_buffer::{Buffer, BufferMut, ByteBuffer};
 use vortex_dtype::{DType, DecimalDType};
 use vortex_error::{VortexResult, vortex_panic};
@@ -20,14 +22,14 @@ use crate::vtable::{
     ValidityVTableFromValidityHelper, VisitorVTable,
 };
 use crate::{
-    ArrayBufferVisitor, ArrayChildVisitor, Canonical, EncodingId, EncodingRef, vtable, vtable_raw,
+    ArrayBufferVisitor, ArrayChildVisitor, Canonical, EncodingId, EncodingRef, vtable_raw,
 };
 
-vtable_raw!(DecimalVTable, DecimalArray, DecimalEncoding, <D: NativeDecimalType);
+vtable_raw!(DecimalVTable, DecimalArray, DecimalEncoding, <D: NativeDecimalType>);
 
 impl<D: NativeDecimalType> VTable for DecimalVTable<D> {
-    type Array = DecimalArray;
-    type Encoding = DecimalEncoding;
+    type Array = DecimalArray<D>;
+    type Encoding = DecimalEncoding<D>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;
@@ -43,12 +45,13 @@ impl<D: NativeDecimalType> VTable for DecimalVTable<D> {
     }
 
     fn encoding(_array: &Self::Array) -> EncodingRef {
-        EncodingRef::new_ref(DecimalEncoding.as_ref())
+        // TODO(ngates): ideally, we have a lazy static HashMap<TypeId, EncodingRef>
+        DecimalEncoding::<D>::default().to_encoding()
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct DecimalEncoding;
+#[derive(Clone, Debug, Default)]
+pub struct DecimalEncoding<D: NativeDecimalType>(PhantomData<D>);
 
 /// Maps a decimal precision into the smallest type that can represent it.
 pub fn smallest_storage_type(decimal_dtype: &DecimalDType) -> DecimalValueType {
@@ -127,31 +130,26 @@ pub fn compatible_storage_type(value_type: DecimalValueType, dtype: DecimalDType
 /// assert_eq!(array.len(), 3);
 /// ```
 #[derive(Clone, Debug)]
-pub struct DecimalArray {
+pub struct DecimalArray<D: NativeDecimalType> {
     dtype: DType,
-    values: ByteBuffer,
-    values_type: DecimalValueType,
+    values: Buffer<D>,
     validity: Validity,
     stats_set: ArrayStats,
 }
 
-impl DecimalArray {
+impl<D: NativeDecimalType> DecimalArray<D> {
     /// Creates a new [`DecimalArray`] from a [`Buffer`] and [`Validity`], without checking
     /// any invariants.
     ///
     /// # Panics
     ///
     /// Panics if the validity length is not compatible with the buffer length.
-    pub fn new<T: NativeDecimalType>(
-        buffer: Buffer<T>,
-        decimal_dtype: DecimalDType,
-        validity: Validity,
-    ) -> Self {
+    pub fn new(values: Buffer<D>, decimal_dtype: DecimalDType, validity: Validity) -> Self {
         if let Some(len) = validity.maybe_len() {
-            if buffer.len() != len {
+            if values.len() != len {
                 vortex_panic!(
                     "Buffer and validity length mismatch: buffer={}, validity={}",
-                    buffer.len(),
+                    values.len(),
                     len,
                 );
             }
@@ -159,8 +157,7 @@ impl DecimalArray {
 
         Self {
             dtype: DType::Decimal(decimal_dtype, validity.nullability()),
-            values: buffer.into_byte_buffer(),
-            values_type: T::VALUES_TYPE,
+            values,
             validity,
             stats_set: ArrayStats::default(),
         }

--- a/vortex-array/src/arrays/decimal/mod.rs
+++ b/vortex-array/src/arrays/decimal/mod.rs
@@ -19,11 +19,13 @@ use crate::vtable::{
     ArrayVTable, CanonicalVTable, NotSupported, VTable, ValidityHelper,
     ValidityVTableFromValidityHelper, VisitorVTable,
 };
-use crate::{ArrayBufferVisitor, ArrayChildVisitor, Canonical, EncodingId, EncodingRef, vtable};
+use crate::{
+    ArrayBufferVisitor, ArrayChildVisitor, Canonical, EncodingId, EncodingRef, vtable, vtable_raw,
+};
 
-vtable!(Decimal);
+vtable_raw!(DecimalVTable, DecimalArray, DecimalEncoding, <D: NativeDecimalType);
 
-impl VTable for DecimalVTable {
+impl<D: NativeDecimalType> VTable for DecimalVTable<D> {
     type Array = DecimalArray;
     type Encoding = DecimalEncoding;
 

--- a/vortex-array/src/vtable/mod.rs
+++ b/vortex-array/src/vtable/mod.rs
@@ -76,53 +76,62 @@ pub struct NotSupported;
 macro_rules! vtable {
     ($V:ident) => {
         $crate::aliases::paste::paste! {
-            #[derive(Debug)]
-            pub struct [<$V VTable>];
+            $crate::vtable_raw!([<$V VTable>], [<$V Array>], [<$V Encoding>]);
+        }
+    };
+}
 
-            impl AsRef<dyn $crate::Array> for [<$V Array>] {
-                fn as_ref(&self) -> &dyn $crate::Array {
-                    // We can unsafe cast ourselves to an ArrayAdapter.
-                    unsafe { &*(self as *const [<$V Array>] as *const $crate::ArrayAdapter<[<$V VTable>]>) }
-                }
+#[macro_export]
+macro_rules! vtable_raw {
+    ($V:ident, $A:ident, $E:ident$(, < $($G:ident $(: $($bound:path),+)?),+ >)?) => {
+        #[derive(Debug)]
+        pub struct $V$(< $($G $(: $($bound),+)?),+ >)?;
+
+        impl$(< $($G $(: $($bound),+)?),+ >)? AsRef<dyn $crate::Array> for $A$(< $($G),+ >)? {
+            fn as_ref(&self) -> &dyn $crate::Array {
+                // We can unsafe cast ourselves to an ArrayAdapter.
+                unsafe { &*(self as *const Self as *const $crate::ArrayAdapter<$V$(< $($G),+ >)?>) }
             }
+        }
 
-            impl std::ops::Deref for [<$V Array>] {
-                type Target = dyn $crate::Array;
+        impl$(< $($G $(: $($bound),+)?),+ >)? std::ops::Deref for $A$(< $($G),+ >)? {
+            type Target = dyn $crate::Array;
 
-                fn deref(&self) -> &Self::Target {
-                    // We can unsafe cast ourselves to an ArrayAdapter.
-                    unsafe { &*(self as *const [<$V Array>] as *const $crate::ArrayAdapter<[<$V VTable>]>) }
-                }
+            fn deref(&self) -> &Self::Target {
+                // We can unsafe cast ourselves to an ArrayAdapter.
+                unsafe { &*(self as *const Self as *const $crate::ArrayAdapter<$V$(< $($G),+ >)?>) }
             }
+        }
 
-            impl $crate::IntoArray for [<$V Array>] {
-                fn into_array(self) -> $crate::ArrayRef {
-                    // We can unsafe transmute ourselves to an ArrayAdapter.
-                    std::sync::Arc::new(unsafe { std::mem::transmute::<[<$V Array>], $crate::ArrayAdapter::<[<$V VTable>]>>(self) })
-                }
+        impl$(< $($G $(: $($bound),+)?),+ >)? $crate::IntoArray for $A$(< $($G),+ >)? {
+            fn into_array(self) -> $crate::ArrayRef {
+                // We can unsafe transmute ourselves to an ArrayAdapter.
+                std::sync::Arc::new(unsafe {
+                    std::mem::transmute::<Self, $crate::ArrayAdapter<$V$(< $($G),+ >)?>>(self)
+                })
             }
+        }
 
-            impl From<[<$V Array>]> for $crate::ArrayRef {
-                fn from(value: [<$V Array>]) -> $crate::ArrayRef {
-                    use $crate::IntoArray;
-                    value.into_array()
-                }
+        impl From<$A$(< $($G),+ >)?> for $crate::ArrayRef {
+            fn from(value: $A$(< $($G),+ >)?) -> $crate::ArrayRef {
+                use $crate::IntoArray;
+                value.into_array()
             }
+        }
 
-            impl AsRef<dyn $crate::Encoding> for [<$V Encoding>] {
-                fn as_ref(&self) -> &dyn $crate::Encoding {
-                    // We can unsafe cast ourselves to an EncodingAdapter.
-                    unsafe { &*(self as *const [<$V Encoding>] as *const $crate::EncodingAdapter<[<$V VTable>]>) }
-                }
+        impl$(< $($G $(: $($bound),+)?),+ >)? AsRef<dyn $crate::Encoding> for $E$(< $($G),+ >)? {
+            fn as_ref(&self) -> &dyn $crate::Encoding {
+                // We can unsafe cast ourselves to an EncodingAdapter.
+                unsafe { &*(self as *const Self as *const $crate::EncodingAdapter<$V$(< $($G),+ >)?>) }
             }
+        }
 
-            impl std::ops::Deref for [<$V Encoding>] {
-                type Target = dyn $crate::Encoding;
+        impl$(< $($G $(: $($bound),+)?),+ >)? std::ops::Deref for $E$(< $($G),+ >)? {
+            type Target = dyn $crate::Encoding;
 
-                fn deref(&self) -> &Self::Target {
-                    // We can unsafe cast ourselves to an EncodingAdapter.
-                    unsafe { &*(self as *const [<$V Encoding>] as *const $crate::EncodingAdapter<[<$V VTable>]>) }
-                }
+            fn deref(&self) -> &Self::Target {
+                // We can unsafe cast ourselves to an EncodingAdapter.
+                unsafe { &*(self as *const Self as *const $crate::EncodingAdapter<$V$(< $($G),+ >)?>) }
             }
         }
     };

--- a/vortex-duckdb/include/vortex.h
+++ b/vortex-duckdb/include/vortex.h
@@ -24,6 +24,7 @@ extern "C" {
  * - C++ wrappers call the corresponding Rust functions
  *
  * This ensures DuckDB can find the symbols when loading the extension.
+ *
  * The DuckDB extension ABI initialization function.
  */
 void vortex_init_rust(duckdb_database db);


### PR DESCRIPTION
Claude gave me some help with the gnarly macro... but it is now possible to have generics in array vtables. Maybe Decimal, Primitive, VarBin(View) are good candidates?

cc @AdamGS 

-- 

This doesn't quite work. Encodings are supposed to be unique by ID, therefore they cannot have the type parameter in them. But the point of the vtable trait is such that we can strongly type functions that take an encoding and return VTable::Array. If we relaxed the vtable so these can return ArrayRef, then we could have the generics only on the array type and otherwise abstract them away from the encoding.