### PR TITLE
chore: Make vortex pretty

### DIFF
--- a/vortex/Cargo.toml
+++ b/vortex/Cargo.toml
@@ -67,6 +67,7 @@ python = ["vortex-error/python"]
 tokio = ["vortex-file/tokio", "vortex-scan/tokio"]
 tracing = ["vortex-file/tracing", "vortex-layout/tracing"]
 zstd = ["dep:vortex-zstd", "vortex-file/zstd", "vortex-layout/zstd"]
+pretty = ["vortex-array/table-display"]
 
 [[bench]]
 name = "single_encoding_throughput"


### PR DESCRIPTION
Adds a top-level feature to enable pretty-printing features in the underlying crates.