### PR TITLE
feat: Make all built-in expressions Eq + replace dyn-eq with our trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,12 +2294,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a5ccdfd6c5e7e2fea9c5cf256f2a08216047fab19c621c3da64e9ae4a1462d"
 
 [[package]]
-name = "dyn-eq"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2d035d21af5cde1a6f5c7b444a5bf963520a9f142e5d06931178433d7d5388"
-
-[[package]]
 name = "dyn-hash"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6601,7 +6595,6 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "arcref",
- "dyn-eq",
  "dyn-hash",
  "itertools 0.14.0",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,6 @@ datafusion-common = { version = "49" }
 datafusion-physical-plan = { version = "49" }
 dirs = "6.0.0"
 divan = { package = "codspeed-divan-compat", version = "3.0" }
-dyn-eq = "0.1.3"
 dyn-hash = "0.2.0"
 enum-iterator = "2.0.0"
 erased-serde = "0.4"

--- a/vortex-expr/Cargo.toml
+++ b/vortex-expr/Cargo.toml
@@ -19,7 +19,6 @@ workspace = true
 [dependencies]
 arbitrary = { workspace = true, optional = true }
 arcref = { workspace = true }
-dyn-eq = { workspace = true }
 dyn-hash = { workspace = true }
 itertools = { workspace = true }
 parking_lot = { workspace = true }

--- a/vortex-expr/src/dyn_traits.rs
+++ b/vortex-expr/src/dyn_traits.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::any::Any;
+
+// TODO(adam): Look into having a similar setup as dyn-hash that will allow deriving `PartialEq` for structs
+// that have `Arc<dyn Trait>` fields.
+/// Allows comparing dyn-compatible objects, like [`ExprRef`].
+pub trait DynEq {
+    fn dyn_eq(&self, other: &dyn Any) -> bool;
+}
+
+impl<T: Eq + Any> DynEq for T {
+    fn dyn_eq(&self, other: &dyn Any) -> bool {
+        Some(self) == other.downcast_ref::<Self>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+    use std::fmt::Debug;
+
+    use super::DynEq;
+
+    trait MyTrait: DynEq + Debug + Any {}
+
+    impl MyTrait for u32 {}
+
+    impl MyTrait for u64 {}
+
+    impl PartialEq for dyn MyTrait {
+        fn eq(&self, other: &Self) -> bool {
+            self.dyn_eq(other)
+        }
+    }
+
+    #[test]
+    fn test_dyn_eq() {
+        let var_w = &2_u32 as &dyn MyTrait;
+        let var_x = &5_u32 as &dyn MyTrait;
+        let var_y = &5_u32 as &dyn MyTrait;
+        let var_z = &5_u64 as &dyn MyTrait;
+
+        // Same value, same type
+        assert_eq!(var_x, var_y);
+        // Different value, same type
+        assert_ne!(var_w, var_x);
+        // Same value, different type
+        assert_ne!(var_y, var_z);
+    }
+}

--- a/vortex-expr/src/exprs/between.rs
+++ b/vortex-expr/src/exprs/between.rs
@@ -17,7 +17,7 @@ use crate::{
 vtable!(Between);
 
 #[allow(clippy::derived_hash_with_manual_eq)]
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug, Hash, Eq)]
 pub struct BetweenExpr {
     arr: ExprRef,
     lower: ExprRef,

--- a/vortex-expr/src/exprs/binary.rs
+++ b/vortex-expr/src/exprs/binary.rs
@@ -18,7 +18,7 @@ use crate::{
 vtable!(Binary);
 
 #[allow(clippy::derived_hash_with_manual_eq)]
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, Eq)]
 pub struct BinaryExpr {
     lhs: ExprRef,
     operator: Operator,

--- a/vortex-expr/src/exprs/cast.rs
+++ b/vortex-expr/src/exprs/cast.rs
@@ -14,7 +14,7 @@ use crate::{AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTa
 vtable!(Cast);
 
 #[allow(clippy::derived_hash_with_manual_eq)]
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, Eq)]
 pub struct CastExpr {
     target: DType,
     child: ExprRef,

--- a/vortex-expr/src/exprs/get_item.rs
+++ b/vortex-expr/src/exprs/get_item.rs
@@ -18,7 +18,7 @@ use crate::{
 vtable!(GetItem);
 
 #[allow(clippy::derived_hash_with_manual_eq)]
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, Eq)]
 pub struct GetItemExpr {
     field: FieldName,
     child: ExprRef,

--- a/vortex-expr/src/exprs/is_null.rs
+++ b/vortex-expr/src/exprs/is_null.rs
@@ -15,7 +15,7 @@ use crate::{AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTa
 vtable!(IsNull);
 
 #[allow(clippy::derived_hash_with_manual_eq)]
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug, Hash, Eq)]
 pub struct IsNullExpr {
     child: ExprRef,
 }

--- a/vortex-expr/src/exprs/like.rs
+++ b/vortex-expr/src/exprs/like.rs
@@ -15,7 +15,7 @@ use crate::{AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTa
 vtable!(Like);
 
 #[allow(clippy::derived_hash_with_manual_eq)]
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug, Hash, Eq)]
 pub struct LikeExpr {
     child: ExprRef,
     pattern: ExprRef,

--- a/vortex-expr/src/exprs/list_contains.rs
+++ b/vortex-expr/src/exprs/list_contains.rs
@@ -17,7 +17,7 @@ use crate::{
 vtable!(ListContains);
 
 #[allow(clippy::derived_hash_with_manual_eq)]
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, Eq)]
 pub struct ListContainsExpr {
     list: ExprRef,
     value: ExprRef,

--- a/vortex-expr/src/exprs/not.rs
+++ b/vortex-expr/src/exprs/not.rs
@@ -14,7 +14,7 @@ use crate::{AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTa
 vtable!(Not);
 
 #[allow(clippy::derived_hash_with_manual_eq)]
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug, Hash, Eq)]
 pub struct NotExpr {
     child: ExprRef,
 }

--- a/vortex-expr/src/exprs/select.rs
+++ b/vortex-expr/src/exprs/select.rs
@@ -21,7 +21,7 @@ pub enum SelectField {
 
 vtable!(Select);
 
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, Eq)]
 #[allow(clippy::derived_hash_with_manual_eq)]
 pub struct SelectExpr {
     fields: SelectField,

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -6,13 +6,13 @@ use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
-use dyn_eq::DynEq;
 use dyn_hash::DynHash;
 pub use exprs::*;
 pub mod aliases;
 mod analysis;
 #[cfg(feature = "arbitrary")]
 pub mod arbitrary;
+pub mod dyn_traits;
 mod encoding;
 mod exprs;
 mod field;
@@ -50,6 +50,7 @@ use vortex_error::{VortexExpect, VortexResult, VortexUnwrap, vortex_bail};
 use vortex_utils::aliases::hash_set::HashSet;
 pub use vtable::*;
 
+use crate::dyn_traits::DynEq;
 use crate::traversal::{Node, ReferenceCollector};
 
 pub trait IntoExpr {
@@ -98,8 +99,15 @@ pub trait VortexExpr:
     fn return_dtype(&self, scope: &DType) -> VortexResult<DType>;
 }
 
-dyn_eq::eq_trait_object!(VortexExpr);
 dyn_hash::hash_trait_object!(VortexExpr);
+
+impl PartialEq for dyn VortexExpr {
+    fn eq(&self, other: &Self) -> bool {
+        self.dyn_eq(other.as_any())
+    }
+}
+
+impl Eq for dyn VortexExpr {}
 
 impl dyn VortexExpr + '_ {
     pub fn id(&self) -> ExprId {


### PR DESCRIPTION
Eq for trait just makes them more useful.

Replacing `dyn_eq` both removes a crate that seems to does a bunch of stuff we don't care about with a very small trait, which also saves downstream users from pulling a third party crate in some cases.  
