### PR TITLE
chore: Reapply "feat: implement Cast Kernel everywhere"

### DIFF
--- a/encodings/alp/src/alp/compute/cast.rs
+++ b/encodings/alp/src/alp/compute/cast.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_array::compute::{CastKernel, CastKernelAdapter, cast};
+use vortex_array::{ArrayRef, IntoArray, register_kernel};
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+
+use crate::alp::{ALPArray, ALPVTable};
+
+impl CastKernel for ALPVTable {
+    fn cast(&self, array: &ALPArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
+        // Check if this is just a nullability change
+        if array.dtype().eq_ignore_nullability(dtype) {
+            // For nullability-only changes, we can avoid decoding
+            // Cast the encoded array (integers) to handle nullability
+            let new_encoded = cast(
+                array.encoded(),
+                &array
+                    .encoded()
+                    .dtype()
+                    .with_nullability(dtype.nullability()),
+            )?;
+
+            Ok(Some(
+                ALPArray::try_new(new_encoded, array.exponents(), array.patches().cloned())?
+                    .into_array(),
+            ))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+register_kernel!(CastKernelAdapter(ALPVTable).lift());
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use vortex_array::IntoArray;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::compute::cast;
+    use vortex_array::compute::conformance::cast::test_cast_conformance;
+    use vortex_buffer::buffer;
+    use vortex_dtype::{DType, Nullability, PType};
+
+    use crate::ALPEncoding;
+
+    #[test]
+    fn test_cast_alp_f32_to_f64() {
+        let values = buffer![1.5f32, 2.5, 3.5, 4.5].into_array();
+        let alp = ALPEncoding
+            .encode(&values.to_canonical().unwrap(), None)
+            .unwrap()
+            .unwrap();
+
+        let casted = cast(
+            alp.as_ref(),
+            &DType::Primitive(PType::F64, Nullability::NonNullable),
+        )
+        .unwrap();
+        assert_eq!(
+            casted.dtype(),
+            &DType::Primitive(PType::F64, Nullability::NonNullable)
+        );
+
+        let decoded = casted.to_canonical().unwrap().into_primitive().unwrap();
+        let values = decoded.as_slice::<f64>();
+        assert_eq!(values.len(), 4);
+        assert!((values[0] - 1.5).abs() < f64::EPSILON);
+        assert!((values[1] - 2.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_cast_alp_to_int() {
+        let values = buffer![1.0f32, 2.0, 3.0, 4.0].into_array();
+        let alp = ALPEncoding
+            .encode(&values.to_canonical().unwrap(), None)
+            .unwrap()
+            .unwrap();
+
+        let casted = cast(
+            alp.as_ref(),
+            &DType::Primitive(PType::I32, Nullability::NonNullable),
+        )
+        .unwrap();
+        assert_eq!(
+            casted.dtype(),
+            &DType::Primitive(PType::I32, Nullability::NonNullable)
+        );
+
+        let decoded = casted.to_canonical().unwrap().into_primitive().unwrap();
+        assert_eq!(decoded.as_slice::<i32>(), &[1i32, 2, 3, 4]);
+    }
+
+    #[rstest]
+    #[case(buffer![1.23f32, 4.56, 7.89, 10.11, 12.13].into_array())]
+    #[case(buffer![100.1f64, 200.2, 300.3, 400.4, 500.5].into_array())]
+    #[case(PrimitiveArray::from_option_iter([Some(1.1f32), None, Some(2.2), Some(3.3), None]).into_array())]
+    #[case(buffer![42.42f64].into_array())]
+    #[case(buffer![0.0f32, -1.5, 2.5, -3.5, 4.5].into_array())]
+    fn test_cast_alp_conformance(#[case] array: vortex_array::ArrayRef) {
+        let alp = ALPEncoding
+            .encode(&array.to_canonical().unwrap(), None)
+            .unwrap()
+            .unwrap();
+        test_cast_conformance(alp.as_ref());
+    }
+}

--- a/encodings/alp/src/alp/compute/mod.rs
+++ b/encodings/alp/src/alp/compute/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 mod between;
+mod cast;
 mod compare;
 mod filter;
 mod mask;

--- a/encodings/datetime-parts/src/compute/cast.rs
+++ b/encodings/datetime-parts/src/compute/cast.rs
@@ -105,4 +105,37 @@ mod tests {
             "Got error: {result:?}"
         );
     }
+
+    #[rstest]
+    #[case(DateTimePartsArray::try_from(TemporalArray::new_timestamp(
+        PrimitiveArray::from_iter([
+            0i64,
+            86_400_000,  // 1 day in ms
+            172_800_000, // 2 days in ms
+            259_200_000, // 3 days in ms
+            345_600_000, // 4 days in ms
+        ]).into_array(),
+        TimeUnit::Ms,
+        Some("UTC".to_string())
+    )).unwrap())]
+    #[case(DateTimePartsArray::try_from(TemporalArray::new_timestamp(
+        PrimitiveArray::from_option_iter([
+            Some(0i64),
+            None,
+            Some(172_800_000), // 2 days in ms
+            Some(259_200_000), // 3 days in ms
+            None,
+        ]).into_array(),
+        TimeUnit::Ms,
+        Some("UTC".to_string())
+    )).unwrap())]
+    #[case(DateTimePartsArray::try_from(TemporalArray::new_timestamp(
+        PrimitiveArray::from_iter([86_400_000_000_000i64]).into_array(), // 1 day in ns
+        TimeUnit::Ns,
+        Some("UTC".to_string())
+    )).unwrap())]
+    fn test_cast_datetime_parts_conformance(#[case] array: DateTimePartsArray) {
+        use vortex_array::compute::conformance::cast::test_cast_conformance;
+        test_cast_conformance(array.as_ref());
+    }
 }

--- a/encodings/dict/src/compute/cast.rs
+++ b/encodings/dict/src/compute/cast.rs
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_array::compute::{CastKernel, CastKernelAdapter, cast};
+use vortex_array::{ArrayRef, IntoArray, register_kernel};
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+
+use crate::{DictArray, DictVTable};
+
+impl CastKernel for DictVTable {
+    fn cast(&self, array: &DictArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
+        // Cast the dictionary values to the target type
+        let casted_values = cast(array.values(), dtype)?;
+
+        let casted_codes = if dtype.nullability() != array.codes().dtype().nullability() {
+            cast(
+                array.codes(),
+                &array.codes().dtype().with_nullability(dtype.nullability()),
+            )?
+        } else {
+            array.codes().clone()
+        };
+
+        // Create a new dictionary array with the same codes but casted values
+        Ok(Some(
+            DictArray::try_new(casted_codes, casted_values)?.into_array(),
+        ))
+    }
+}
+
+register_kernel!(CastKernelAdapter(DictVTable).lift());
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use vortex_array::IntoArray;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::compute::cast;
+    use vortex_array::compute::conformance::cast::test_cast_conformance;
+    use vortex_buffer::buffer;
+    use vortex_dtype::{DType, Nullability, PType};
+
+    use crate::DictVTable;
+    use crate::builders::dict_encode;
+
+    #[test]
+    fn test_cast_dict_to_wider_type() {
+        let values = buffer![1i32, 2, 3, 2, 1].into_array();
+        let dict = dict_encode(&values).unwrap();
+
+        let casted = cast(
+            dict.as_ref(),
+            &DType::Primitive(PType::I64, Nullability::NonNullable),
+        )
+        .unwrap();
+        assert_eq!(
+            casted.dtype(),
+            &DType::Primitive(PType::I64, Nullability::NonNullable)
+        );
+
+        let decoded = casted.to_canonical().unwrap().into_primitive().unwrap();
+        assert_eq!(decoded.as_slice::<i64>(), &[1i64, 2, 3, 2, 1]);
+    }
+
+    #[test]
+    fn test_cast_dict_nullable() {
+        let values =
+            PrimitiveArray::from_option_iter([Some(10i32), None, Some(20), Some(10), None]);
+        let dict = dict_encode(values.as_ref()).unwrap();
+
+        let casted = cast(
+            dict.as_ref(),
+            &DType::Primitive(PType::I64, Nullability::Nullable),
+        )
+        .unwrap();
+        assert_eq!(
+            casted.dtype(),
+            &DType::Primitive(PType::I64, Nullability::Nullable)
+        );
+    }
+
+    #[test]
+    fn test_cast_dict_allvalid_to_nonnullable_and_back() {
+        // Create an AllValid dict array (no nulls)
+        let values = buffer![10i32, 20, 30, 40].into_array();
+        let dict = dict_encode(&values).unwrap();
+
+        // Verify initial state - codes should be NonNullable, values should be NonNullable
+        assert_eq!(dict.codes().dtype().nullability(), Nullability::NonNullable);
+        assert_eq!(
+            dict.values().dtype().nullability(),
+            Nullability::NonNullable
+        );
+
+        // Cast to NonNullable (should be identity since already NonNullable)
+        let non_nullable = cast(
+            dict.as_ref(),
+            &DType::Primitive(PType::I32, Nullability::NonNullable),
+        )
+        .unwrap();
+        assert_eq!(
+            non_nullable.dtype(),
+            &DType::Primitive(PType::I32, Nullability::NonNullable)
+        );
+
+        // Check that codes and values are still NonNullable
+        let non_nullable_dict = non_nullable.as_::<DictVTable>();
+        assert_eq!(
+            non_nullable_dict.codes().dtype().nullability(),
+            Nullability::NonNullable
+        );
+        assert_eq!(
+            non_nullable_dict.values().dtype().nullability(),
+            Nullability::NonNullable
+        );
+
+        // Cast to Nullable
+        let nullable = cast(
+            non_nullable.as_ref(),
+            &DType::Primitive(PType::I32, Nullability::Nullable),
+        )
+        .unwrap();
+        assert_eq!(
+            nullable.dtype(),
+            &DType::Primitive(PType::I32, Nullability::Nullable)
+        );
+
+        // Check that both codes and values are now Nullable
+        let nullable_dict = nullable.as_::<DictVTable>();
+        assert_eq!(
+            nullable_dict.codes().dtype().nullability(),
+            Nullability::Nullable
+        );
+        assert_eq!(
+            nullable_dict.values().dtype().nullability(),
+            Nullability::Nullable
+        );
+
+        // Cast back to NonNullable
+        let back_to_non_nullable = cast(
+            nullable.as_ref(),
+            &DType::Primitive(PType::I32, Nullability::NonNullable),
+        )
+        .unwrap();
+        assert_eq!(
+            back_to_non_nullable.dtype(),
+            &DType::Primitive(PType::I32, Nullability::NonNullable)
+        );
+
+        // Check that both codes and values are NonNullable again
+        let back_dict = back_to_non_nullable.as_::<DictVTable>();
+        assert_eq!(
+            back_dict.codes().dtype().nullability(),
+            Nullability::NonNullable
+        );
+        assert_eq!(
+            back_dict.values().dtype().nullability(),
+            Nullability::NonNullable
+        );
+
+        // Verify values are unchanged
+        let original_values = dict.to_canonical().unwrap().into_primitive().unwrap();
+        let final_values = back_dict.to_canonical().unwrap().into_primitive().unwrap();
+        assert_eq!(
+            original_values.as_slice::<i32>(),
+            final_values.as_slice::<i32>()
+        );
+    }
+
+    #[rstest]
+    #[case(dict_encode(&buffer![1i32, 2, 3, 2, 1, 3].into_array()).unwrap().into_array())]
+    #[case(dict_encode(&buffer![100u32, 200, 100, 300, 200].into_array()).unwrap().into_array())]
+    #[case(dict_encode(&PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None]).into_array()).unwrap().into_array())]
+    #[case(dict_encode(&buffer![1.5f32, 2.5, 1.5, 3.5].into_array()).unwrap().into_array())]
+    fn test_cast_dict_conformance(#[case] array: vortex_array::ArrayRef) {
+        test_cast_conformance(array.as_ref());
+    }
+}

--- a/encodings/dict/src/compute/mod.rs
+++ b/encodings/dict/src/compute/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 mod binary_numeric;
+mod cast;
 mod compare;
 mod fill_null;
 mod is_constant;

--- a/encodings/fastlanes/src/bitpacking/compute/cast.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/cast.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_array::compute::{CastKernel, CastKernelAdapter, cast};
+use vortex_array::patches::Patches;
+use vortex_array::vtable::ValidityHelper;
+use vortex_array::{ArrayRef, IntoArray, register_kernel};
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+
+use crate::bitpacking::{BitPackedArray, BitPackedVTable};
+
+impl CastKernel for BitPackedVTable {
+    fn cast(&self, array: &BitPackedArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
+        if array.dtype().eq_ignore_nullability(dtype) {
+            let new_validity = array
+                .validity()
+                .clone()
+                .cast_nullability(dtype.nullability())?;
+            return Ok(Some(
+                unsafe {
+                    BitPackedArray::new_unchecked_with_offset(
+                        array.packed().clone(),
+                        dtype.as_ptype(),
+                        new_validity,
+                        array
+                            .patches()
+                            .map(|patches| {
+                                let new_values = cast(patches.values(), dtype)?;
+                                VortexResult::Ok(Patches::new(
+                                    patches.array_len(),
+                                    patches.offset(),
+                                    patches.indices().clone(),
+                                    new_values,
+                                ))
+                            })
+                            .transpose()?,
+                        array.bit_width(),
+                        array.len(),
+                        array.offset(),
+                    )?
+                }
+                .into_array(),
+            ));
+        }
+
+        Ok(None)
+    }
+}
+
+register_kernel!(CastKernelAdapter(BitPackedVTable).lift());
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use vortex_array::IntoArray;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::compute::cast;
+    use vortex_array::compute::conformance::cast::test_cast_conformance;
+    use vortex_buffer::buffer;
+    use vortex_dtype::{DType, Nullability, PType};
+
+    use crate::BitPackedArray;
+
+    #[test]
+    fn test_cast_bitpacked_u8_to_u32() {
+        let packed =
+            BitPackedArray::encode(buffer![10u8, 20, 30, 40, 50, 60].into_array().as_ref(), 6)
+                .unwrap();
+
+        let casted = cast(
+            packed.as_ref(),
+            &DType::Primitive(PType::U32, Nullability::NonNullable),
+        )
+        .unwrap();
+        assert_eq!(
+            casted.dtype(),
+            &DType::Primitive(PType::U32, Nullability::NonNullable)
+        );
+
+        let decoded = casted.to_canonical().unwrap().into_primitive().unwrap();
+        assert_eq!(decoded.as_slice::<u32>(), &[10u32, 20, 30, 40, 50, 60]);
+    }
+
+    #[test]
+    fn test_cast_bitpacked_nullable() {
+        let values = PrimitiveArray::from_option_iter([Some(5u16), None, Some(10), Some(15), None]);
+        let packed = BitPackedArray::encode(values.as_ref(), 4).unwrap();
+
+        let casted = cast(
+            packed.as_ref(),
+            &DType::Primitive(PType::U32, Nullability::Nullable),
+        )
+        .unwrap();
+        assert_eq!(
+            casted.dtype(),
+            &DType::Primitive(PType::U32, Nullability::Nullable)
+        );
+    }
+
+    #[rstest]
+    #[case(BitPackedArray::encode(buffer![0u8, 10, 20, 30, 40, 50, 60, 63].into_array().as_ref(), 6).unwrap())]
+    #[case(BitPackedArray::encode(buffer![0u16, 100, 200, 300, 400, 500].into_array().as_ref(), 9).unwrap())]
+    #[case(BitPackedArray::encode(buffer![0u32, 1000, 2000, 3000, 4000].into_array().as_ref(), 12).unwrap())]
+    #[case(BitPackedArray::encode(PrimitiveArray::from_option_iter([Some(1u32), None, Some(7), Some(15), None]).as_ref(), 4).unwrap())]
+    fn test_cast_bitpacked_conformance(#[case] array: BitPackedArray) {
+        test_cast_conformance(array.as_ref());
+    }
+}

--- a/encodings/fastlanes/src/bitpacking/compute/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 mod between;
+mod cast;
 mod filter;
 mod is_constant;
 mod take;

--- a/encodings/fastlanes/src/for/compute/cast.rs
+++ b/encodings/fastlanes/src/for/compute/cast.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_array::compute::{CastKernel, CastKernelAdapter, cast};
+use vortex_array::{ArrayRef, IntoArray, register_kernel};
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+
+use crate::r#for::{FoRArray, FoRVTable};
+
+impl CastKernel for FoRVTable {
+    fn cast(&self, array: &FoRArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
+        // FoR only supports integer types
+        if !dtype.is_int() {
+            return Ok(None);
+        }
+
+        // For type changes between integers, cast the components
+        let casted_child = cast(array.encoded(), dtype)?;
+        let casted_reference = array.reference_scalar().cast(dtype)?;
+
+        Ok(Some(
+            FoRArray::try_new(casted_child, casted_reference)?.into_array(),
+        ))
+    }
+}
+
+register_kernel!(CastKernelAdapter(FoRVTable).lift());
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use vortex_array::IntoArray;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::compute::cast;
+    use vortex_array::compute::conformance::cast::test_cast_conformance;
+    use vortex_buffer::buffer;
+    use vortex_dtype::{DType, Nullability, PType};
+    use vortex_scalar::Scalar;
+
+    use crate::FoRArray;
+
+    #[test]
+    fn test_cast_for_i32_to_i64() {
+        let for_array = FoRArray::try_new(
+            buffer![0i32, 10, 20, 30, 40].into_array(),
+            Scalar::from(100i32),
+        )
+        .unwrap();
+
+        let casted = cast(
+            for_array.as_ref(),
+            &DType::Primitive(PType::I64, Nullability::NonNullable),
+        )
+        .unwrap();
+        assert_eq!(
+            casted.dtype(),
+            &DType::Primitive(PType::I64, Nullability::NonNullable)
+        );
+
+        // Verify the values after decoding
+        let decoded = casted.to_canonical().unwrap().into_primitive().unwrap();
+        assert_eq!(decoded.as_slice::<i64>(), &[100i64, 110, 120, 130, 140]);
+    }
+
+    #[test]
+    fn test_cast_for_nullable() {
+        let values = PrimitiveArray::from_option_iter([Some(0i32), None, Some(20), Some(30), None]);
+        let for_array = FoRArray::try_new(values.into_array(), Scalar::from(50i32)).unwrap();
+
+        let casted = cast(
+            for_array.as_ref(),
+            &DType::Primitive(PType::I64, Nullability::Nullable),
+        )
+        .unwrap();
+        assert_eq!(
+            casted.dtype(),
+            &DType::Primitive(PType::I64, Nullability::Nullable)
+        );
+    }
+
+    #[rstest]
+    #[case(FoRArray::try_new(
+        buffer![0i32, 1, 2, 3, 4].into_array(),
+        Scalar::from(100i32)
+    ).unwrap())]
+    #[case(FoRArray::try_new(
+        buffer![0u64, 10, 20, 30].into_array(),
+        Scalar::from(1000u64)
+    ).unwrap())]
+    #[case(FoRArray::try_new(
+        PrimitiveArray::from_option_iter([Some(0i16), None, Some(5), Some(10), None]).into_array(),
+        Scalar::from(50i16)
+    ).unwrap())]
+    #[case(FoRArray::try_new(
+        buffer![-10i32, -5, 0, 5, 10].into_array(),
+        Scalar::from(-100i32)
+    ).unwrap())]
+    fn test_cast_for_conformance(#[case] array: FoRArray) {
+        test_cast_conformance(array.as_ref());
+    }
+}

--- a/encodings/fastlanes/src/for/compute/mod.rs
+++ b/encodings/fastlanes/src/for/compute/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+mod cast;
 mod compare;
 mod is_constant;
 

--- a/encodings/fsst/src/compute/cast.rs
+++ b/encodings/fsst/src/compute/cast.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_array::arrays::VarBinVTable;
+use vortex_array::compute::{CastKernel, CastKernelAdapter, cast};
+use vortex_array::{ArrayRef, IntoArray, register_kernel};
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+
+use crate::{FSSTArray, FSSTVTable};
+
+impl CastKernel for FSSTVTable {
+    fn cast(&self, array: &FSSTArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
+        // FSST is a string compression encoding.
+        // For nullability changes, we can cast the codes and symbols arrays
+        if array.dtype().eq_ignore_nullability(dtype) {
+            // Cast codes array to handle nullability
+            let new_codes = cast(
+                array.codes().as_ref(),
+                &array.codes().dtype().with_nullability(dtype.nullability()),
+            )?;
+
+            Ok(Some(
+                FSSTArray::try_new(
+                    dtype.clone(),
+                    array.symbols().clone(),
+                    array.symbol_lengths().clone(),
+                    new_codes.as_::<VarBinVTable>().clone(),
+                    array.uncompressed_lengths().clone(),
+                )?
+                .into_array(),
+            ))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+register_kernel!(CastKernelAdapter(FSSTVTable).lift());
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use vortex_array::arrays::VarBinArray;
+    use vortex_array::compute::cast;
+    use vortex_array::compute::conformance::cast::test_cast_conformance;
+    use vortex_dtype::{DType, Nullability};
+
+    use crate::{fsst_compress, fsst_train_compressor};
+
+    #[test]
+    fn test_cast_fsst_nullability() {
+        let strings = VarBinArray::from_iter(
+            vec![Some("hello"), Some("world"), Some("hello world")],
+            DType::Utf8(Nullability::NonNullable),
+        );
+
+        let compressor = fsst_train_compressor(strings.as_ref()).unwrap();
+        let fsst = fsst_compress(strings.as_ref(), &compressor).unwrap();
+
+        // Cast to nullable
+        let casted = cast(fsst.as_ref(), &DType::Utf8(Nullability::Nullable)).unwrap();
+        assert_eq!(casted.dtype(), &DType::Utf8(Nullability::Nullable));
+    }
+
+    #[rstest]
+    #[case(VarBinArray::from_iter(
+        vec![Some("hello"), Some("world"), Some("hello world")],
+        DType::Utf8(Nullability::NonNullable)
+    ))]
+    #[case(VarBinArray::from_iter(
+        vec![Some("foo"), None, Some("bar"), Some("foobar")],
+        DType::Utf8(Nullability::Nullable)
+    ))]
+    #[case(VarBinArray::from_iter(
+        vec![Some("test")],
+        DType::Utf8(Nullability::NonNullable)
+    ))]
+    fn test_cast_fsst_conformance(#[case] array: VarBinArray) {
+        let compressor = fsst_train_compressor(array.as_ref()).unwrap();
+        let fsst = fsst_compress(array.as_ref(), &compressor).unwrap();
+        test_cast_conformance(fsst.as_ref());
+    }
+}

--- a/encodings/fsst/src/compute/mod.rs
+++ b/encodings/fsst/src/compute/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+mod cast;
 mod compare;
 mod filter;
 

--- a/encodings/runend/src/compute/cast.rs
+++ b/encodings/runend/src/compute/cast.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_array::compute::{CastKernel, CastKernelAdapter, cast};
+use vortex_array::{ArrayRef, IntoArray, register_kernel};
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+
+use crate::{RunEndArray, RunEndVTable};
+
+impl CastKernel for RunEndVTable {
+    fn cast(&self, array: &RunEndArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
+        // Cast the values array to the target type
+        let casted_values = cast(array.values(), dtype)?;
+
+        Ok(Some(
+            RunEndArray::try_new(array.ends().clone(), casted_values)?.into_array(),
+        ))
+    }
+}
+
+register_kernel!(CastKernelAdapter(RunEndVTable).lift());
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use vortex_array::arrays::{BoolArray, PrimitiveArray};
+    use vortex_array::compute::cast;
+    use vortex_array::compute::conformance::cast::test_cast_conformance;
+    use vortex_array::{Array, IntoArray};
+    use vortex_buffer::buffer;
+    use vortex_dtype::{DType, Nullability, PType};
+
+    use crate::RunEndArray;
+
+    #[test]
+    fn test_cast_runend_i32_to_i64() {
+        let runend = RunEndArray::try_new(
+            buffer![3u64, 5, 8, 10].into_array(),
+            buffer![100i32, 200, 100, 300].into_array(),
+        )
+        .unwrap();
+
+        let casted = cast(
+            runend.as_ref(),
+            &DType::Primitive(PType::I64, Nullability::NonNullable),
+        )
+        .unwrap();
+        assert_eq!(
+            casted.dtype(),
+            &DType::Primitive(PType::I64, Nullability::NonNullable)
+        );
+
+        // Verify by decoding to canonical form
+        let decoded = casted.to_canonical().unwrap().into_primitive().unwrap();
+        // RunEnd encoding should expand to [100, 100, 100, 200, 200, 100, 100, 100, 300, 300]
+        assert_eq!(decoded.len(), 10);
+        assert_eq!(decoded.as_slice::<i64>()[0], 100);
+        assert_eq!(decoded.as_slice::<i64>()[3], 200);
+        assert_eq!(decoded.as_slice::<i64>()[5], 100);
+        assert_eq!(decoded.as_slice::<i64>()[8], 300);
+    }
+
+    #[test]
+    fn test_cast_runend_nullable() {
+        let runend = RunEndArray::try_new(
+            buffer![2u64, 4, 7].into_array(),
+            PrimitiveArray::from_option_iter([Some(10i32), None, Some(20)]).into_array(),
+        )
+        .unwrap();
+
+        let casted = cast(
+            runend.as_ref(),
+            &DType::Primitive(PType::I64, Nullability::Nullable),
+        )
+        .unwrap();
+        assert_eq!(
+            casted.dtype(),
+            &DType::Primitive(PType::I64, Nullability::Nullable)
+        );
+    }
+
+    #[rstest]
+    #[case(RunEndArray::try_new(
+        buffer![3u64, 5, 8].into_array(),
+        buffer![100i32, 200, 300].into_array()
+    ).unwrap())]
+    #[case(RunEndArray::try_new(
+        buffer![1u64, 4, 10].into_array(),
+        buffer![1.5f32, 2.5, 3.5].into_array()
+    ).unwrap())]
+    #[case(RunEndArray::try_new(
+        buffer![2u64, 3, 5].into_array(),
+        PrimitiveArray::from_option_iter([Some(42i32), None, Some(84)]).into_array()
+    ).unwrap())]
+    #[case(RunEndArray::try_new(
+        buffer![10u64].into_array(),
+        buffer![255u8].into_array()
+    ).unwrap())]
+    #[case(RunEndArray::try_new(
+        buffer![2u64, 4, 6, 8, 10].into_array(),
+        BoolArray::from_iter(vec![true, false, true, false, true]).into_array()
+    ).unwrap())]
+    fn test_cast_runend_conformance(#[case] array: RunEndArray) {
+        test_cast_conformance(array.as_ref());
+    }
+}

--- a/encodings/runend/src/compute/cast.rs
+++ b/encodings/runend/src/compute/cast.rs
@@ -14,7 +14,13 @@ impl CastKernel for RunEndVTable {
         let casted_values = cast(array.values(), dtype)?;
 
         Ok(Some(
-            RunEndArray::try_new(array.ends().clone(), casted_values)?.into_array(),
+            RunEndArray::with_offset_and_length(
+                array.ends().clone(),
+                casted_values,
+                array.offset(),
+                array.len(),
+            )?
+            .into_array(),
         ))
     }
 }
@@ -77,6 +83,40 @@ mod tests {
         assert_eq!(
             casted.dtype(),
             &DType::Primitive(PType::I64, Nullability::Nullable)
+        );
+    }
+
+    #[test]
+    fn test_cast_runend_with_offset() {
+        // Create a RunEndArray: [100, 100, 100, 200, 200, 300, 300, 300, 300, 300]
+        let runend = RunEndArray::try_new(
+            buffer![3u64, 5, 10].into_array(),
+            buffer![100i32, 200, 300].into_array(),
+        )
+        .unwrap();
+
+        // Slice it to get offset 3, length 5: [200, 200, 300, 300, 300]
+        let sliced = runend.slice(3, 8).unwrap();
+
+        // Verify the slice is correct before casting
+        let sliced_decoded = sliced.to_canonical().unwrap().into_primitive().unwrap();
+        assert_eq!(sliced_decoded.len(), 5);
+        assert_eq!(sliced_decoded.as_slice::<i32>(), &[200, 200, 300, 300, 300]);
+
+        // Cast the sliced array
+        let casted = cast(
+            sliced.as_ref(),
+            &DType::Primitive(PType::I64, Nullability::NonNullable),
+        )
+        .unwrap();
+
+        // Verify the cast preserved the offset
+        let casted_decoded = casted.to_canonical().unwrap().into_primitive().unwrap();
+        assert_eq!(casted_decoded.len(), 5);
+        assert_eq!(
+            casted_decoded.as_slice::<i64>(),
+            &[200i64, 200, 300, 300, 300],
+            "Cast failed to preserve offset - got wrong values after cast"
         );
     }
 

--- a/encodings/runend/src/compute/mod.rs
+++ b/encodings/runend/src/compute/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 mod binary_numeric;
+mod cast;
 mod compare;
 mod fill_null;
 pub(crate) mod filter;

--- a/encodings/sparse/src/compute/cast.rs
+++ b/encodings/sparse/src/compute/cast.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_array::compute::{CastKernel, CastKernelAdapter, cast};
+use vortex_array::{ArrayRef, IntoArray, register_kernel};
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+
+use crate::{SparseArray, SparseVTable};
+
+impl CastKernel for SparseVTable {
+    fn cast(&self, array: &SparseArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
+        // Cast both the patches values and the fill value
+        let casted_fill = array.fill_scalar().cast(dtype)?;
+        let casted_patches = array
+            .patches()
+            .clone()
+            .map_values(|values| cast(&values, dtype))?;
+
+        Ok(Some(
+            SparseArray::try_new_from_patches(casted_patches, casted_fill)?.into_array(),
+        ))
+    }
+}
+
+register_kernel!(CastKernelAdapter(SparseVTable).lift());
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use vortex_array::IntoArray;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::compute::cast;
+    use vortex_array::compute::conformance::cast::test_cast_conformance;
+    use vortex_buffer::buffer;
+    use vortex_dtype::{DType, Nullability, PType};
+    use vortex_scalar::Scalar;
+
+    use crate::SparseArray;
+
+    #[test]
+    fn test_cast_sparse_i32_to_i64() {
+        let sparse = SparseArray::try_new(
+            buffer![2u64, 5, 8].into_array(),
+            buffer![100i32, 200, 300].into_array(),
+            10,
+            Scalar::from(0i32),
+        )
+        .unwrap();
+
+        let casted = cast(
+            sparse.as_ref(),
+            &DType::Primitive(PType::I64, Nullability::NonNullable),
+        )
+        .unwrap();
+        assert_eq!(
+            casted.dtype(),
+            &DType::Primitive(PType::I64, Nullability::NonNullable)
+        );
+
+        let decoded = casted.to_canonical().unwrap().into_primitive().unwrap();
+        let values = decoded.as_slice::<i64>();
+        assert_eq!(values[2], 100);
+        assert_eq!(values[5], 200);
+        assert_eq!(values[8], 300);
+        assert_eq!(values[0], 0); // fill value
+    }
+
+    #[test]
+    fn test_cast_sparse_with_null_fill() {
+        let sparse = SparseArray::try_new(
+            buffer![1u64, 3, 5].into_array(),
+            PrimitiveArray::from_option_iter([Some(42i32), Some(84), Some(126)]).into_array(),
+            8,
+            Scalar::null_typed::<i32>(),
+        )
+        .unwrap();
+
+        let casted = cast(
+            sparse.as_ref(),
+            &DType::Primitive(PType::I64, Nullability::Nullable),
+        )
+        .unwrap();
+        assert_eq!(
+            casted.dtype(),
+            &DType::Primitive(PType::I64, Nullability::Nullable)
+        );
+    }
+
+    #[rstest]
+    #[case(SparseArray::try_new(
+        buffer![2u64, 5, 8].into_array(),
+        buffer![100i32, 200, 300].into_array(),
+        10,
+        Scalar::from(0i32)
+    ).unwrap())]
+    #[case(SparseArray::try_new(
+        buffer![0u64, 4, 9].into_array(),
+        buffer![1.5f32, 2.5, 3.5].into_array(),
+        10,
+        Scalar::from(0.0f32)
+    ).unwrap())]
+    #[case(SparseArray::try_new(
+        buffer![1u64, 3, 7].into_array(),
+        PrimitiveArray::from_option_iter([Some(100i32), None, Some(300)]).into_array(),
+        10,
+        Scalar::null_typed::<i32>()
+    ).unwrap())]
+    #[case(SparseArray::try_new(
+        buffer![5u64].into_array(),
+        buffer![42u8].into_array(),
+        10,
+        Scalar::from(0u8)
+    ).unwrap())]
+    fn test_cast_sparse_conformance(#[case] array: SparseArray) {
+        test_cast_conformance(array.as_ref());
+    }
+}

--- a/encodings/sparse/src/compute/mod.rs
+++ b/encodings/sparse/src/compute/mod.rs
@@ -10,6 +10,7 @@ use vortex_mask::Mask;
 use crate::{SparseArray, SparseVTable};
 
 mod binary_numeric;
+mod cast;
 mod invert;
 mod take;
 

--- a/encodings/zigzag/src/compute/cast.rs
+++ b/encodings/zigzag/src/compute/cast.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_array::compute::{CastKernel, CastKernelAdapter, cast};
+use vortex_array::{ArrayRef, IntoArray, register_kernel};
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+
+use crate::{ZigZagArray, ZigZagVTable};
+
+impl CastKernel for ZigZagVTable {
+    fn cast(&self, array: &ZigZagArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
+        if !dtype.is_signed_int() {
+            return Ok(None);
+        }
+
+        let new_encoded_dtype =
+            DType::Primitive(dtype.as_ptype().to_unsigned(), dtype.nullability());
+        let new_encoded = cast(array.encoded(), &new_encoded_dtype)?;
+        Ok(Some(ZigZagArray::try_new(new_encoded)?.into_array()))
+    }
+}
+
+register_kernel!(CastKernelAdapter(ZigZagVTable).lift());
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use vortex_array::Array;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::compute::cast;
+    use vortex_array::compute::conformance::cast::test_cast_conformance;
+    use vortex_dtype::{DType, Nullability, PType};
+
+    use crate::{ZigZagArray, zigzag_encode};
+
+    #[test]
+    fn test_cast_zigzag_i32_to_i64() {
+        let values = PrimitiveArray::from_iter([-100i32, -1, 0, 1, 100]);
+        let zigzag = zigzag_encode(values).unwrap();
+
+        let casted = cast(
+            zigzag.as_ref(),
+            &DType::Primitive(PType::I64, Nullability::NonNullable),
+        )
+        .unwrap();
+        assert_eq!(
+            casted.dtype(),
+            &DType::Primitive(PType::I64, Nullability::NonNullable)
+        );
+
+        // Verify the result is still a ZigZagArray (not decoded)
+        // Note: The result might be wrapped, so let's check the encoding ID
+        assert_eq!(
+            casted.encoding().id().as_ref(),
+            "vortex.zigzag",
+            "Cast should preserve ZigZag encoding"
+        );
+
+        let decoded = casted.to_canonical().unwrap().into_primitive().unwrap();
+        assert_eq!(decoded.as_slice::<i64>(), &[-100i64, -1, 0, 1, 100]);
+    }
+
+    #[test]
+    fn test_cast_zigzag_width_changes() {
+        // Test i32 to i16 (narrowing)
+        let values = PrimitiveArray::from_iter([100i32, -50, 0, 25, -100]);
+        let zigzag = zigzag_encode(values).unwrap();
+
+        let casted = cast(
+            zigzag.as_ref(),
+            &DType::Primitive(PType::I16, Nullability::NonNullable),
+        )
+        .unwrap();
+        assert_eq!(
+            casted.encoding().id().as_ref(),
+            "vortex.zigzag",
+            "Should remain ZigZag encoded"
+        );
+
+        let decoded = casted.to_canonical().unwrap().into_primitive().unwrap();
+        assert_eq!(decoded.as_slice::<i16>(), &[100i16, -50, 0, 25, -100]);
+
+        // Test i16 to i64 (widening)
+        let values16 = PrimitiveArray::from_iter([1000i16, -500, 0, 250, -1000]);
+        let zigzag16 = zigzag_encode(values16).unwrap();
+
+        let casted64 = cast(
+            zigzag16.as_ref(),
+            &DType::Primitive(PType::I64, Nullability::NonNullable),
+        )
+        .unwrap();
+        assert_eq!(
+            casted64.encoding().id().as_ref(),
+            "vortex.zigzag",
+            "Should remain ZigZag encoded"
+        );
+
+        let decoded64 = casted64.to_canonical().unwrap().into_primitive().unwrap();
+        assert_eq!(decoded64.as_slice::<i64>(), &[1000i64, -500, 0, 250, -1000]);
+    }
+
+    #[test]
+    fn test_cast_zigzag_nullable() {
+        let values =
+            PrimitiveArray::from_option_iter([Some(-10i32), None, Some(0), Some(10), None]);
+        let zigzag = zigzag_encode(values).unwrap();
+
+        let casted = cast(
+            zigzag.as_ref(),
+            &DType::Primitive(PType::I64, Nullability::Nullable),
+        )
+        .unwrap();
+        assert_eq!(
+            casted.dtype(),
+            &DType::Primitive(PType::I64, Nullability::Nullable)
+        );
+    }
+
+    #[rstest]
+    #[case(zigzag_encode(PrimitiveArray::from_iter([-100i32, -50, -1, 0, 1, 50, 100])).unwrap())]
+    #[case(zigzag_encode(PrimitiveArray::from_iter([-1000i64, -1, 0, 1, 1000])).unwrap())]
+    #[case(zigzag_encode(PrimitiveArray::from_option_iter([Some(-5i16), None, Some(0), Some(5), None])).unwrap())]
+    #[case(zigzag_encode(PrimitiveArray::from_iter([i32::MIN, -1, 0, 1, i32::MAX])).unwrap())]
+    fn test_cast_zigzag_conformance(#[case] array: ZigZagArray) {
+        test_cast_conformance(array.as_ref());
+    }
+}

--- a/encodings/zigzag/src/compute/mod.rs
+++ b/encodings/zigzag/src/compute/mod.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+mod cast;
+
 use vortex_array::compute::{
     FilterKernel, FilterKernelAdapter, MaskKernel, MaskKernelAdapter, TakeKernel,
     TakeKernelAdapter, filter, mask, take,

--- a/vortex-array/src/arrays/bool/compute/cast.rs
+++ b/vortex-array/src/arrays/bool/compute/cast.rs
@@ -28,10 +28,12 @@ register_kernel!(CastKernelAdapter(BoolVTable).lift());
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
     use vortex_dtype::{DType, Nullability};
 
     use crate::arrays::BoolArray;
     use crate::compute::cast;
+    use crate::compute::conformance::cast::test_cast_conformance;
 
     #[test]
     fn try_cast_bool_success() {
@@ -47,5 +49,14 @@ mod tests {
     fn try_cast_bool_fail() {
         let bool = BoolArray::from_iter(vec![Some(true), Some(false), None]);
         cast(bool.as_ref(), &DType::Bool(Nullability::NonNullable)).unwrap();
+    }
+
+    #[rstest]
+    #[case(BoolArray::from_iter(vec![true, false, true, true, false]))]
+    #[case(BoolArray::from_iter(vec![Some(true), Some(false), None, Some(true), None]))]
+    #[case(BoolArray::from_iter(vec![true]))]
+    #[case(BoolArray::from_iter(vec![false, false]))]
+    fn test_cast_bool_conformance(#[case] array: BoolArray) {
+        test_cast_conformance(array.as_ref());
     }
 }

--- a/vortex-array/src/arrays/chunked/compute/cast.rs
+++ b/vortex-array/src/arrays/chunked/compute/cast.rs
@@ -25,13 +25,16 @@ register_kernel!(CastKernelAdapter(ChunkedVTable).lift());
 
 #[cfg(test)]
 mod test {
+    use rstest::rstest;
     use vortex_buffer::buffer;
     use vortex_dtype::{DType, Nullability, PType};
 
     use crate::IntoArray;
+    use crate::arrays::PrimitiveArray;
     use crate::arrays::chunked::ChunkedArray;
     use crate::canonical::ToCanonical;
     use crate::compute::cast;
+    use crate::compute::conformance::cast::test_cast_conformance;
 
     #[test]
     fn test_cast_chunked() {
@@ -64,5 +67,32 @@ mod test {
             .as_slice::<u64>(),
             &[0u64, 1, 2, 3],
         );
+    }
+
+    #[rstest]
+    #[case(ChunkedArray::try_new(
+        vec![buffer![0u32, 1, 2].into_array(), buffer![3u32, 4].into_array()],
+        DType::Primitive(PType::U32, Nullability::NonNullable)
+    ).unwrap().into_array())]
+    #[case(ChunkedArray::try_new(
+        vec![
+            buffer![-10i32, -5, 0].into_array(),
+            buffer![5i32, 10].into_array()
+        ],
+        DType::Primitive(PType::I32, Nullability::NonNullable)
+    ).unwrap().into_array())]
+    #[case(ChunkedArray::try_new(
+        vec![
+            PrimitiveArray::from_option_iter([Some(1.5f32), None, Some(2.5)]).into_array(),
+            PrimitiveArray::from_option_iter([Some(3.5f32), Some(4.5)]).into_array()
+        ],
+        DType::Primitive(PType::F32, Nullability::Nullable)
+    ).unwrap().into_array())]
+    #[case(ChunkedArray::try_new(
+        vec![buffer![42u8].into_array()],
+        DType::Primitive(PType::U8, Nullability::NonNullable)
+    ).unwrap().into_array())]
+    fn test_cast_chunked_conformance(#[case] array: crate::ArrayRef) {
+        test_cast_conformance(array.as_ref());
     }
 }

--- a/vortex-array/src/arrays/constant/compute/cast.rs
+++ b/vortex-array/src/arrays/constant/compute/cast.rs
@@ -18,3 +18,24 @@ impl CastKernel for ConstantVTable {
 }
 
 register_kernel!(CastKernelAdapter(ConstantVTable).lift());
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use vortex_scalar::Scalar;
+
+    use crate::IntoArray;
+    use crate::arrays::ConstantArray;
+    use crate::compute::conformance::cast::test_cast_conformance;
+
+    #[rstest]
+    #[case(ConstantArray::new(Scalar::from(42u32), 5).into_array())]
+    #[case(ConstantArray::new(Scalar::from(-100i32), 10).into_array())]
+    #[case(ConstantArray::new(Scalar::from(3.5f32), 3).into_array())]
+    #[case(ConstantArray::new(Scalar::from(true), 7).into_array())]
+    #[case(ConstantArray::new(Scalar::null_typed::<i32>(), 4).into_array())]
+    #[case(ConstantArray::new(Scalar::from(255u8), 1).into_array())]
+    fn test_cast_constant_conformance(#[case] array: crate::ArrayRef) {
+        test_cast_conformance(array.as_ref());
+    }
+}

--- a/vortex-array/src/arrays/decimal/compute/cast.rs
+++ b/vortex-array/src/arrays/decimal/compute/cast.rs
@@ -60,12 +60,14 @@ register_kernel!(CastKernelAdapter(DecimalVTable).lift());
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
     use vortex_buffer::buffer;
     use vortex_dtype::{DType, DecimalDType, Nullability};
 
     use crate::arrays::DecimalArray;
     use crate::canonical::ToCanonical;
     use crate::compute::cast;
+    use crate::compute::conformance::cast::test_cast_conformance;
     use crate::validity::Validity;
     use crate::vtable::ValidityHelper;
 
@@ -160,5 +162,14 @@ mod tests {
                 .to_string()
                 .contains("No compute kernel to cast")
         );
+    }
+
+    #[rstest]
+    #[case(DecimalArray::new(buffer![100i32, 200, 300], DecimalDType::new(10, 2), Validity::NonNullable))]
+    #[case(DecimalArray::new(buffer![10000i64, 20000, 30000], DecimalDType::new(18, 4), Validity::NonNullable))]
+    #[case(DecimalArray::from_option_iter([Some(100i32), None, Some(300)], DecimalDType::new(10, 2)))]
+    #[case(DecimalArray::new(buffer![42i32], DecimalDType::new(5, 1), Validity::NonNullable))]
+    fn test_cast_decimal_conformance(#[case] array: DecimalArray) {
+        test_cast_conformance(array.as_ref());
     }
 }

--- a/vortex-array/src/arrays/extension/compute/cast.rs
+++ b/vortex-array/src/arrays/extension/compute/cast.rs
@@ -41,11 +41,15 @@ register_kernel!(CastKernelAdapter(ExtensionVTable).lift());
 mod tests {
     use std::sync::Arc;
 
+    use rstest::rstest;
+    use vortex_buffer::buffer;
     use vortex_dtype::datetime::{TIMESTAMP_ID, TemporalMetadata, TimeUnit};
     use vortex_dtype::{ExtDType, Nullability, PType};
 
     use super::*;
+    use crate::IntoArray;
     use crate::arrays::PrimitiveArray;
+    use crate::compute::conformance::cast::test_cast_conformance;
 
     #[test]
     fn cast_same_ext_dtype() {
@@ -102,5 +106,41 @@ mod tests {
         let arr = ExtensionArray::new(original_dtype, storage);
 
         assert!(cast(arr.as_ref(), &DType::Extension(target_dtype)).is_err());
+    }
+
+    #[rstest]
+    #[case(create_timestamp_array(TimeUnit::Ms, false))]
+    #[case(create_timestamp_array(TimeUnit::Us, true))]
+    #[case(create_timestamp_array(TimeUnit::Ns, false))]
+    #[case(create_timestamp_array(TimeUnit::S, true))]
+    fn test_cast_extension_conformance(#[case] array: ExtensionArray) {
+        test_cast_conformance(array.as_ref());
+    }
+
+    fn create_timestamp_array(time_unit: TimeUnit, nullable: bool) -> ExtensionArray {
+        let ext_dtype = Arc::new(ExtDType::new(
+            TIMESTAMP_ID.clone(),
+            Arc::new(if nullable {
+                DType::Primitive(PType::I64, Nullability::Nullable)
+            } else {
+                DType::Primitive(PType::I64, Nullability::NonNullable)
+            }),
+            Some(TemporalMetadata::Timestamp(time_unit, Some("UTC".to_string())).into()),
+        ));
+
+        let storage = if nullable {
+            PrimitiveArray::from_option_iter([
+                Some(1_000_000i64), // 1 second in microseconds
+                None,
+                Some(2_000_000),
+                Some(3_000_000),
+                None,
+            ])
+            .into_array()
+        } else {
+            buffer![1_000_000i64, 2_000_000, 3_000_000, 4_000_000, 5_000_000].into_array()
+        };
+
+        ExtensionArray::new(ext_dtype, storage)
     }
 }

--- a/vortex-array/src/arrays/list/compute/cast.rs
+++ b/vortex-array/src/arrays/list/compute/cast.rs
@@ -35,10 +35,14 @@ register_kernel!(CastKernelAdapter(ListVTable).lift());
 mod tests {
     use std::sync::Arc;
 
-    use vortex_dtype::{DType, Nullability};
+    use rstest::rstest;
+    use vortex_buffer::buffer;
+    use vortex_dtype::{DType, Nullability, PType};
 
-    use crate::arrays::{BoolArray, ListArray, PrimitiveArray};
+    use crate::IntoArray;
+    use crate::arrays::{BoolArray, ListArray, PrimitiveArray, VarBinArray};
     use crate::compute::cast;
+    use crate::compute::conformance::cast::test_cast_conformance;
     use crate::validity::Validity;
 
     #[test]
@@ -51,10 +55,7 @@ mod tests {
         .unwrap();
 
         let target_dtype = DType::List(
-            Arc::new(DType::Primitive(
-                vortex_dtype::PType::U64,
-                Nullability::Nullable,
-            )),
+            Arc::new(DType::Primitive(PType::U64, Nullability::Nullable)),
             Nullability::Nullable,
         );
 
@@ -72,7 +73,7 @@ mod tests {
         )
         .unwrap();
 
-        let target_dtype = DType::Primitive(vortex_dtype::PType::U64, Nullability::NonNullable);
+        let target_dtype = DType::Primitive(PType::U64, Nullability::NonNullable);
         // can't cast list to u64
 
         let result = cast(list.to_array().as_ref(), &target_dtype);
@@ -92,10 +93,7 @@ mod tests {
         .unwrap();
 
         let target_dtype = DType::List(
-            Arc::new(DType::Primitive(
-                vortex_dtype::PType::U64,
-                Nullability::Nullable,
-            )),
+            Arc::new(DType::Primitive(PType::U64, Nullability::Nullable)),
             Nullability::NonNullable,
         );
 
@@ -111,14 +109,76 @@ mod tests {
         .unwrap();
 
         let target_dtype = DType::List(
-            Arc::new(DType::Primitive(
-                vortex_dtype::PType::U64,
-                Nullability::NonNullable,
-            )),
+            Arc::new(DType::Primitive(PType::U64, Nullability::NonNullable)),
             Nullability::NonNullable,
         );
 
         let result = cast(list.to_array().as_ref(), &target_dtype);
         assert!(result.is_err());
+    }
+
+    #[rstest]
+    #[case(create_simple_list())]
+    #[case(create_nullable_list())]
+    #[case(create_string_list())]
+    #[case(create_nested_list())]
+    #[case(create_empty_lists())]
+    fn test_cast_list_conformance(#[case] array: ListArray) {
+        test_cast_conformance(array.as_ref());
+    }
+
+    fn create_simple_list() -> ListArray {
+        let data = buffer![1i32, 2, 3, 4, 5, 6].into_array();
+        let offsets = buffer![0i64, 2, 2, 5, 6].into_array();
+
+        ListArray::try_new(data, offsets, Validity::NonNullable).unwrap()
+    }
+
+    fn create_nullable_list() -> ListArray {
+        let data = PrimitiveArray::from_option_iter([
+            Some(10i64),
+            None,
+            Some(20),
+            Some(30),
+            None,
+            Some(40),
+        ])
+        .into_array();
+        let offsets = buffer![0i64, 3, 6].into_array();
+        let validity = Validity::Array(BoolArray::from_iter(vec![true, false]).into_array());
+
+        ListArray::try_new(data, offsets, validity).unwrap()
+    }
+
+    fn create_string_list() -> ListArray {
+        let data = VarBinArray::from_iter(
+            vec![Some("hello"), Some("world"), Some("foo"), Some("bar")],
+            DType::Utf8(Nullability::NonNullable),
+        )
+        .into_array();
+        let offsets = buffer![0i64, 2, 4].into_array();
+
+        ListArray::try_new(data, offsets, Validity::NonNullable).unwrap()
+    }
+
+    fn create_nested_list() -> ListArray {
+        // Create inner lists: [[1, 2], [3], [4, 5, 6]]
+        let inner_data = buffer![1i32, 2, 3, 4, 5, 6].into_array();
+        let inner_offsets = buffer![0i64, 2, 3, 6].into_array();
+        let inner_list = ListArray::try_new(inner_data, inner_offsets, Validity::NonNullable)
+            .unwrap()
+            .into_array();
+
+        // Create outer list: [[[1, 2], [3]], [[4, 5, 6]]]
+        let outer_offsets = buffer![0i64, 2, 3].into_array();
+
+        ListArray::try_new(inner_list, outer_offsets, Validity::NonNullable).unwrap()
+    }
+
+    fn create_empty_lists() -> ListArray {
+        let data = buffer![42u8].into_array();
+        let offsets = buffer![0i64, 0, 0, 1].into_array();
+
+        ListArray::try_new(data, offsets, Validity::NonNullable).unwrap()
     }
 }

--- a/vortex-array/src/arrays/null/compute/cast.rs
+++ b/vortex-array/src/arrays/null/compute/cast.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::DType;
+use vortex_error::{VortexResult, vortex_bail};
+use vortex_scalar::{Scalar, ScalarValue};
+
+use crate::arrays::{ConstantArray, NullArray, NullVTable};
+use crate::compute::{CastKernel, CastKernelAdapter};
+use crate::{ArrayRef, IntoArray, register_kernel};
+
+impl CastKernel for NullVTable {
+    fn cast(&self, array: &NullArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
+        if !dtype.is_nullable() {
+            vortex_bail!("Cannot cast Null to {}", dtype);
+        }
+        if dtype == &DType::Null {
+            return Ok(Some(array.to_array()));
+        }
+
+        let scalar = Scalar::new(dtype.clone(), ScalarValue::null());
+        Ok(Some(ConstantArray::new(scalar, array.len()).into_array()))
+    }
+}
+
+register_kernel!(CastKernelAdapter(NullVTable).lift());
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use vortex_dtype::{DType, Nullability, PType};
+
+    use crate::arrays::NullArray;
+    use crate::compute::cast;
+    use crate::compute::conformance::cast::test_cast_conformance;
+
+    #[test]
+    fn test_cast_null_to_null() {
+        let null_array = NullArray::new(5);
+        let result = cast(null_array.as_ref(), &DType::Null).unwrap();
+        assert_eq!(result.len(), 5);
+        assert_eq!(result.dtype(), &DType::Null);
+    }
+
+    #[test]
+    fn test_cast_null_to_nullable_succeeds() {
+        let null_array = NullArray::new(5);
+        let result = cast(
+            null_array.as_ref(),
+            &DType::Primitive(PType::I32, Nullability::Nullable),
+        )
+        .unwrap();
+
+        // Should create a ConstantArray of nulls
+        assert_eq!(result.len(), 5);
+        assert_eq!(
+            result.dtype(),
+            &DType::Primitive(PType::I32, Nullability::Nullable)
+        );
+
+        // Verify all values are null
+        for i in 0..5 {
+            assert!(result.scalar_at(i).unwrap().is_null());
+        }
+    }
+
+    #[test]
+    fn test_cast_null_to_non_nullable_fails() {
+        let null_array = NullArray::new(5);
+        let result = cast(
+            null_array.as_ref(),
+            &DType::Primitive(PType::I32, Nullability::NonNullable),
+        );
+        assert!(result.is_err());
+    }
+
+    #[rstest]
+    #[case(NullArray::new(5))]
+    #[case(NullArray::new(1))]
+    #[case(NullArray::new(100))]
+    #[case(NullArray::new(0))]
+    fn test_cast_null_conformance(#[case] array: NullArray) {
+        test_cast_conformance(array.as_ref());
+    }
+}

--- a/vortex-array/src/arrays/null/compute/mod.rs
+++ b/vortex-array/src/arrays/null/compute/mod.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+mod cast;
+
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::{VortexResult, vortex_bail};
 use vortex_mask::Mask;

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -73,6 +73,7 @@ fn cast<T: NativePType>(array: &PrimitiveArray) -> VortexResult<Buffer<T>> {
 
 #[cfg(test)]
 mod test {
+    use rstest::rstest;
     use vortex_buffer::buffer;
     use vortex_dtype::{DType, Nullability, PType};
     use vortex_error::VortexError;
@@ -81,6 +82,7 @@ mod test {
     use crate::arrays::PrimitiveArray;
     use crate::canonical::ToCanonical;
     use crate::compute::cast;
+    use crate::compute::conformance::cast::test_cast_conformance;
     use crate::validity::Validity;
     use crate::vtable::ValidityHelper;
 
@@ -172,5 +174,23 @@ mod test {
             s.to_string(),
             "invalid cast from nullable to non-nullable, since source array actually contains nulls"
         );
+    }
+
+    #[rstest]
+    #[case(buffer![0u8, 1, 2, 3, 255].into_array())]
+    #[case(buffer![0u16, 100, 1000, 65535].into_array())]
+    #[case(buffer![0u32, 100, 1000, 1000000].into_array())]
+    #[case(buffer![0u64, 100, 1000, 1000000000].into_array())]
+    #[case(buffer![-128i8, -1, 0, 1, 127].into_array())]
+    #[case(buffer![-1000i16, -1, 0, 1, 1000].into_array())]
+    #[case(buffer![-1000000i32, -1, 0, 1, 1000000].into_array())]
+    #[case(buffer![-1000000000i64, -1, 0, 1, 1000000000].into_array())]
+    #[case(buffer![0.0f32, 1.5, -2.5, 100.0, 1e6].into_array())]
+    #[case(buffer![0.0f64, 1.5, -2.5, 100.0, 1e12].into_array())]
+    #[case(PrimitiveArray::from_option_iter([Some(1u8), None, Some(255), Some(0), None]).into_array())]
+    #[case(PrimitiveArray::from_option_iter([Some(1i32), None, Some(-100), Some(0), None]).into_array())]
+    #[case(buffer![42u32].into_array())]
+    fn test_cast_primitive_conformance(#[case] array: crate::ArrayRef) {
+        test_cast_conformance(array.as_ref());
     }
 }

--- a/vortex-array/src/arrays/struct_/compute/cast.rs
+++ b/vortex-array/src/arrays/struct_/compute/cast.rs
@@ -46,3 +46,91 @@ impl CastKernel for StructVTable {
 }
 
 register_kernel!(CastKernelAdapter(StructVTable).lift());
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use vortex_buffer::buffer;
+    use vortex_dtype::{DType, FieldNames, Nullability};
+
+    use crate::IntoArray;
+    use crate::arrays::{StructArray, VarBinArray};
+    use crate::compute::conformance::cast::test_cast_conformance;
+
+    #[rstest]
+    #[case(create_test_struct(false))]
+    #[case(create_test_struct(true))]
+    #[case(create_nested_struct())]
+    #[case(create_simple_struct())]
+    fn test_cast_struct_conformance(#[case] array: StructArray) {
+        test_cast_conformance(array.as_ref());
+    }
+
+    fn create_test_struct(nullable: bool) -> StructArray {
+        let names: FieldNames = vec!["a".into(), "b".into()].into();
+
+        let a = buffer![1i32, 2, 3].into_array();
+        let b = VarBinArray::from_iter(
+            vec![Some("x"), None, Some("z")],
+            DType::Utf8(Nullability::Nullable),
+        )
+        .into_array();
+
+        StructArray::try_new(
+            names,
+            vec![a, b],
+            3,
+            if nullable {
+                crate::validity::Validity::AllValid
+            } else {
+                crate::validity::Validity::NonNullable
+            },
+        )
+        .unwrap()
+    }
+
+    fn create_nested_struct() -> StructArray {
+        // Create inner struct
+        let inner_names: FieldNames = vec!["x".into(), "y".into()].into();
+
+        let x = buffer![1.0f32, 2.0, 3.0].into_array();
+        let y = buffer![4.0f32, 5.0, 6.0].into_array();
+        let inner_struct = StructArray::try_new(
+            inner_names,
+            vec![x, y],
+            3,
+            crate::validity::Validity::NonNullable,
+        )
+        .unwrap()
+        .into_array();
+
+        // Create outer struct with inner struct as a field
+        let outer_names: FieldNames = vec!["id".into(), "point".into()].into();
+        // Outer struct would have fields: id (I64) and point (inner struct)
+
+        let ids = buffer![100i64, 200, 300].into_array();
+
+        StructArray::try_new(
+            outer_names,
+            vec![ids, inner_struct],
+            3,
+            crate::validity::Validity::NonNullable,
+        )
+        .unwrap()
+    }
+
+    fn create_simple_struct() -> StructArray {
+        let names: FieldNames = vec!["value".into()].into();
+        // Simple struct with a single U8 field
+
+        let values = buffer![42u8].into_array();
+
+        StructArray::try_new(
+            names,
+            vec![values],
+            1,
+            crate::validity::Validity::NonNullable,
+        )
+        .unwrap()
+    }
+}

--- a/vortex-array/src/arrays/varbin/compute/cast.rs
+++ b/vortex-array/src/arrays/varbin/compute/cast.rs
@@ -39,6 +39,7 @@ mod tests {
 
     use crate::arrays::VarBinArray;
     use crate::compute::cast;
+    use crate::compute::conformance::cast::test_cast_conformance;
 
     #[rstest]
     #[case(
@@ -73,5 +74,15 @@ mod tests {
         let non_nullable_source = source.as_nonnullable();
         let varbin = VarBinArray::from_iter(vec![Some("a"), Some("b"), None], source);
         cast(varbin.as_ref(), &non_nullable_source).unwrap();
+    }
+
+    #[rstest]
+    #[case(VarBinArray::from_iter(vec![Some("hello"), Some("world"), Some("test")], DType::Utf8(Nullability::NonNullable)))]
+    #[case(VarBinArray::from_iter(vec![Some("hello"), None, Some("world")], DType::Utf8(Nullability::Nullable)))]
+    #[case(VarBinArray::from_iter(vec![Some(b"binary".as_slice()), Some(b"data".as_slice())], DType::Binary(Nullability::NonNullable)))]
+    #[case(VarBinArray::from_iter(vec![Some(b"test".as_slice()), None], DType::Binary(Nullability::Nullable)))]
+    #[case(VarBinArray::from_iter(vec![Some("single")], DType::Utf8(Nullability::NonNullable)))]
+    fn test_cast_varbin_conformance(#[case] array: VarBinArray) {
+        test_cast_conformance(array.as_ref());
     }
 }

--- a/vortex-array/src/arrays/varbinview/compute/cast.rs
+++ b/vortex-array/src/arrays/varbinview/compute/cast.rs
@@ -39,6 +39,7 @@ mod tests {
 
     use crate::arrays::VarBinViewArray;
     use crate::compute::cast;
+    use crate::compute::conformance::cast::test_cast_conformance;
 
     #[rstest]
     #[case(
@@ -73,5 +74,16 @@ mod tests {
         let non_nullable_source = source.as_nonnullable();
         let varbin = VarBinViewArray::from_iter(vec![Some("a"), Some("b"), None], source);
         cast(varbin.as_ref(), &non_nullable_source).unwrap();
+    }
+
+    #[rstest]
+    #[case(VarBinViewArray::from_iter(vec![Some("hello"), Some("world"), Some("test")], DType::Utf8(Nullability::NonNullable)))]
+    #[case(VarBinViewArray::from_iter(vec![Some("hello"), None, Some("world")], DType::Utf8(Nullability::Nullable)))]
+    #[case(VarBinViewArray::from_iter(vec![Some(b"binary".as_slice()), Some(b"data".as_slice())], DType::Binary(Nullability::NonNullable)))]
+    #[case(VarBinViewArray::from_iter(vec![Some(b"test".as_slice()), None], DType::Binary(Nullability::Nullable)))]
+    #[case(VarBinViewArray::from_iter(vec![Some("single")], DType::Utf8(Nullability::NonNullable)))]
+    #[case(VarBinViewArray::from_iter(vec![Some("very long string that exceeds the inline size to test view functionality with multiple buffers")], DType::Utf8(Nullability::NonNullable)))]
+    fn test_cast_varbinview_conformance(#[case] array: VarBinViewArray) {
+        test_cast_conformance(array.as_ref());
     }
 }

--- a/vortex-array/src/compute/conformance/cast.rs
+++ b/vortex-array/src/compute/conformance/cast.rs
@@ -1,0 +1,634 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::{DType, Nullability, PType};
+use vortex_error::VortexUnwrap;
+
+use crate::Array;
+use crate::compute::cast;
+
+/// Test conformance of the cast compute function for an array.
+///
+/// This function tests various casting scenarios including:
+/// - Casting between numeric types (widening and narrowing)
+/// - Casting between signed and unsigned types
+/// - Casting between integral and floating-point types
+/// - Casting with nullability changes
+/// - Casting between string types (Utf8/Binary)
+/// - Edge cases like overflow behavior
+pub fn test_cast_conformance(array: &dyn Array) {
+    let dtype = array.dtype();
+
+    // Always test identity cast and nullability changes
+    test_cast_identity(array);
+
+    // Test AllValid to NonNullable and back if applicable
+    test_cast_allvalid_to_nonnullable_and_back(array);
+
+    // Test based on the specific DType
+    match dtype {
+        DType::Null => test_cast_from_null(array),
+        DType::Bool(nullability) => test_cast_from_bool(array, *nullability),
+        DType::Primitive(ptype, nullability) => {
+            test_cast_nullability_changes_primitive(array, *ptype, *nullability);
+            match ptype {
+                PType::U8 => test_cast_from_u8(array),
+                PType::U16 => test_cast_from_u16(array),
+                PType::U32 => test_cast_from_u32(array),
+                PType::U64 => test_cast_from_u64(array),
+                PType::I8 => test_cast_from_i8(array),
+                PType::I16 => test_cast_from_i16(array),
+                PType::I32 => test_cast_from_i32(array),
+                PType::I64 => test_cast_from_i64(array),
+                PType::F16 => test_cast_from_f16(array),
+                PType::F32 => test_cast_from_f32(array),
+                PType::F64 => test_cast_from_f64(array),
+            }
+        }
+        DType::Decimal(_, nullability) => test_cast_from_decimal(array, *nullability),
+        DType::Utf8(nullability) => test_cast_from_utf8(array, *nullability),
+        DType::Binary(nullability) => test_cast_from_binary(array, *nullability),
+        DType::Struct(_, nullability) => test_cast_from_struct(array, *nullability),
+        DType::List(_, nullability) => test_cast_from_list(array, *nullability),
+        DType::Extension(_) => test_cast_from_extension(array),
+    }
+}
+
+fn test_cast_identity(array: &dyn Array) {
+    // Casting to the same type should be a no-op
+    let result = cast(array, array.dtype()).vortex_unwrap();
+    assert_eq!(result.len(), array.len());
+    assert_eq!(result.dtype(), array.dtype());
+
+    // Verify values are unchanged
+    for i in 0..array.len().min(10) {
+        assert_eq!(
+            array.scalar_at(i).vortex_unwrap(),
+            result.scalar_at(i).vortex_unwrap()
+        );
+    }
+}
+
+fn test_cast_from_null(array: &dyn Array) {
+    // Null can be cast to itself
+    let result = cast(array, &DType::Null).vortex_unwrap();
+    assert_eq!(result.len(), array.len());
+    assert_eq!(result.dtype(), &DType::Null);
+
+    // Null can also be cast to any nullable type
+    let nullable_types = vec![
+        DType::Bool(Nullability::Nullable),
+        DType::Primitive(PType::I32, Nullability::Nullable),
+        DType::Primitive(PType::F64, Nullability::Nullable),
+        DType::Utf8(Nullability::Nullable),
+        DType::Binary(Nullability::Nullable),
+    ];
+
+    for dtype in nullable_types {
+        let result = cast(array, &dtype).vortex_unwrap();
+        assert_eq!(result.len(), array.len());
+        assert_eq!(result.dtype(), &dtype);
+
+        // Verify all values are null
+        for i in 0..array.len().min(10) {
+            assert!(result.scalar_at(i).vortex_unwrap().is_null());
+        }
+    }
+
+    // Casting to non-nullable types should fail
+    let non_nullable_types = vec![
+        DType::Bool(Nullability::NonNullable),
+        DType::Primitive(PType::I32, Nullability::NonNullable),
+    ];
+
+    for dtype in non_nullable_types {
+        assert!(cast(array, &dtype).is_err());
+    }
+}
+
+fn test_cast_from_bool(array: &dyn Array, nullability: Nullability) {
+    // Test nullability changes
+    test_cast_nullability_changes(array, &DType::Bool(Nullability::Nullable));
+    if nullability == Nullability::Nullable {
+        // Try casting to non-nullable (may fail if nulls present)
+        let _ = cast(array, &DType::Bool(Nullability::NonNullable));
+    }
+
+    // Test bool to numeric casts (true -> 1, false -> 0)
+    test_cast_to_primitive(array, PType::U8);
+    test_cast_to_primitive(array, PType::I32);
+    test_cast_to_primitive(array, PType::F32);
+}
+
+fn test_cast_from_decimal(array: &dyn Array, nullability: Nullability) {
+    // Test nullability changes for the same decimal type
+    if let DType::Decimal(decimal_type, _) = array.dtype() {
+        test_cast_nullability_changes(array, &DType::Decimal(*decimal_type, Nullability::Nullable));
+        if nullability == Nullability::Nullable {
+            // Try casting to non-nullable (may fail if nulls present)
+            let _ = cast(
+                array,
+                &DType::Decimal(*decimal_type, Nullability::NonNullable),
+            );
+        }
+    }
+}
+
+fn test_cast_from_utf8(array: &dyn Array, nullability: Nullability) {
+    // Test nullability changes
+    test_cast_nullability_changes(array, &DType::Utf8(Nullability::Nullable));
+    if nullability == Nullability::Nullable {
+        // Try casting to non-nullable (may fail if nulls present)
+        let _ = cast(array, &DType::Utf8(Nullability::NonNullable));
+    }
+
+    // UTF-8 strings can potentially be cast to Binary
+    test_cast_to_type_safe(array, &DType::Binary(nullability));
+}
+
+fn test_cast_from_binary(array: &dyn Array, nullability: Nullability) {
+    // Test nullability changes
+    test_cast_nullability_changes(array, &DType::Binary(Nullability::Nullable));
+    if nullability == Nullability::Nullable {
+        // Try casting to non-nullable (may fail if nulls present)
+        let _ = cast(array, &DType::Binary(Nullability::NonNullable));
+    }
+
+    // Binary might be castable to UTF-8 if it contains valid UTF-8
+    test_cast_to_type_safe(array, &DType::Utf8(nullability));
+}
+
+fn test_cast_from_struct(array: &dyn Array, nullability: Nullability) {
+    // Test nullability changes for the same struct type
+    if let DType::Struct(fields, _) = array.dtype() {
+        test_cast_nullability_changes(array, &DType::Struct(fields.clone(), Nullability::Nullable));
+        if nullability == Nullability::Nullable {
+            // Try casting to non-nullable (may fail if nulls present)
+            let _ = cast(
+                array,
+                &DType::Struct(fields.clone(), Nullability::NonNullable),
+            );
+        }
+    }
+}
+
+fn test_cast_from_list(array: &dyn Array, nullability: Nullability) {
+    // Test nullability changes for the same list type
+    if let DType::List(element_type, _) = array.dtype() {
+        test_cast_nullability_changes(
+            array,
+            &DType::List(element_type.clone(), Nullability::Nullable),
+        );
+        if nullability == Nullability::Nullable {
+            // Try casting to non-nullable (may fail if nulls present)
+            let _ = cast(
+                array,
+                &DType::List(element_type.clone(), Nullability::NonNullable),
+            );
+        }
+    }
+}
+
+fn test_cast_from_extension(array: &dyn Array) {
+    // Extension types typically only cast to themselves
+    // The specific casting rules depend on the extension type
+    if let DType::Extension(ext_dtype) = array.dtype() {
+        let result = cast(array, &DType::Extension(ext_dtype.clone())).vortex_unwrap();
+        assert_eq!(result.len(), array.len());
+        assert_eq!(result.dtype(), array.dtype());
+    }
+}
+
+fn test_cast_allvalid_to_nonnullable_and_back(array: &dyn Array) {
+    // Skip if array is null type (special case)
+    if array.dtype() == &DType::Null {
+        return;
+    }
+
+    // Only test if array has no nulls
+    if let Ok(null_count) = array.invalid_count() {
+        if null_count == 0 {
+            // Test casting to NonNullable if currently Nullable
+            if array.dtype().nullability() == Nullability::Nullable {
+                let non_nullable_dtype = array.dtype().with_nullability(Nullability::NonNullable);
+
+                // Cast to NonNullable
+                if let Ok(non_nullable) = cast(array, &non_nullable_dtype) {
+                    assert_eq!(non_nullable.dtype(), &non_nullable_dtype);
+                    assert_eq!(non_nullable.len(), array.len());
+
+                    // Cast back to Nullable
+                    let nullable_dtype = array.dtype().with_nullability(Nullability::Nullable);
+                    let back_to_nullable = cast(&non_nullable, &nullable_dtype).vortex_unwrap();
+                    assert_eq!(back_to_nullable.dtype(), &nullable_dtype);
+                    assert_eq!(back_to_nullable.len(), array.len());
+
+                    // Verify values are unchanged
+                    for i in 0..array.len().min(10) {
+                        assert_eq!(
+                            array.scalar_at(i).vortex_unwrap(),
+                            back_to_nullable.scalar_at(i).vortex_unwrap()
+                        );
+                    }
+                }
+            }
+            // Test casting to Nullable if currently NonNullable
+            else if array.dtype().nullability() == Nullability::NonNullable {
+                let nullable_dtype = array.dtype().with_nullability(Nullability::Nullable);
+
+                // Cast to Nullable
+                let nullable = cast(array, &nullable_dtype).vortex_unwrap();
+                assert_eq!(nullable.dtype(), &nullable_dtype);
+                assert_eq!(nullable.len(), array.len());
+
+                // Cast back to NonNullable
+                let non_nullable_dtype = array.dtype().with_nullability(Nullability::NonNullable);
+                let back_to_non_nullable = cast(&nullable, &non_nullable_dtype).vortex_unwrap();
+                assert_eq!(back_to_non_nullable.dtype(), &non_nullable_dtype);
+                assert_eq!(back_to_non_nullable.len(), array.len());
+
+                // Verify values are unchanged
+                for i in 0..array.len().min(10) {
+                    assert_eq!(
+                        array.scalar_at(i).vortex_unwrap(),
+                        back_to_non_nullable.scalar_at(i).vortex_unwrap()
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn test_cast_nullability_changes(array: &dyn Array, nullable_version: &DType) {
+    // Test casting to nullable version
+    if array.dtype().nullability() == Nullability::NonNullable {
+        let result = cast(array, nullable_version).vortex_unwrap();
+        assert_eq!(result.len(), array.len());
+        assert_eq!(result.dtype(), nullable_version);
+
+        // IMPORTANT: Nullability casting should preserve the encoding
+        assert_eq!(
+            result.encoding().id(),
+            array.encoding().id(),
+            "Nullability cast should preserve encoding"
+        );
+
+        // Values should be unchanged
+        for i in 0..array.len().min(10) {
+            assert_eq!(
+                array.scalar_at(i).vortex_unwrap(),
+                result.scalar_at(i).vortex_unwrap()
+            );
+        }
+    }
+}
+
+fn test_cast_nullability_changes_primitive(
+    array: &dyn Array,
+    ptype: PType,
+    nullability: Nullability,
+) {
+    // Test casting to nullable version
+    if nullability == Nullability::NonNullable {
+        let nullable_dtype = DType::Primitive(ptype, Nullability::Nullable);
+        let result = cast(array, &nullable_dtype).vortex_unwrap();
+        assert_eq!(result.len(), array.len());
+        assert_eq!(result.dtype(), &nullable_dtype);
+
+        // IMPORTANT: Nullability casting should preserve the encoding
+        assert_eq!(
+            result.encoding().id(),
+            array.encoding().id(),
+            "Nullability cast should preserve encoding"
+        );
+
+        // Values should be unchanged
+        for i in 0..array.len().min(10) {
+            assert_eq!(
+                array.scalar_at(i).vortex_unwrap(),
+                result.scalar_at(i).vortex_unwrap()
+            );
+        }
+    }
+
+    // Test casting from nullable to non-nullable (only if no nulls present)
+    if nullability == Nullability::Nullable {
+        // Try to cast to non-nullable and see if it succeeds
+        let non_nullable_dtype = DType::Primitive(ptype, Nullability::NonNullable);
+        if let Ok(result) = cast(array, &non_nullable_dtype) {
+            assert_eq!(result.len(), array.len());
+            assert_eq!(result.dtype(), &non_nullable_dtype);
+
+            // IMPORTANT: Nullability casting should preserve the encoding
+            assert_eq!(
+                result.encoding().id(),
+                array.encoding().id(),
+                "Nullability cast should preserve encoding"
+            );
+
+            // Values should be unchanged
+            for i in 0..array.len().min(10) {
+                assert_eq!(
+                    array.scalar_at(i).vortex_unwrap(),
+                    result.scalar_at(i).vortex_unwrap()
+                );
+            }
+        }
+    }
+}
+
+fn test_cast_from_u8(array: &dyn Array) {
+    // Test widening casts
+    test_cast_to_primitive(array, PType::U16);
+    test_cast_to_primitive(array, PType::U32);
+    test_cast_to_primitive(array, PType::U64);
+    test_cast_to_primitive(array, PType::I16);
+    test_cast_to_primitive(array, PType::I32);
+    test_cast_to_primitive(array, PType::I64);
+    test_cast_to_primitive(array, PType::F32);
+    test_cast_to_primitive(array, PType::F64);
+
+    // Test same-width cast
+    test_cast_to_primitive(array, PType::I8);
+}
+
+fn test_cast_from_u16(array: &dyn Array) {
+    // Test narrowing cast
+    test_cast_to_primitive(array, PType::U8);
+
+    // Test widening casts
+    test_cast_to_primitive(array, PType::U32);
+    test_cast_to_primitive(array, PType::U64);
+    test_cast_to_primitive(array, PType::I32);
+    test_cast_to_primitive(array, PType::I64);
+    test_cast_to_primitive(array, PType::F32);
+    test_cast_to_primitive(array, PType::F64);
+
+    // Test same-width cast
+    test_cast_to_primitive(array, PType::I16);
+}
+
+fn test_cast_from_u32(array: &dyn Array) {
+    // Test narrowing casts
+    test_cast_to_primitive(array, PType::U8);
+    test_cast_to_primitive(array, PType::U16);
+    test_cast_to_primitive(array, PType::I8);
+    test_cast_to_primitive(array, PType::I16);
+
+    // Test widening casts
+    test_cast_to_primitive(array, PType::U64);
+    test_cast_to_primitive(array, PType::I64);
+    test_cast_to_primitive(array, PType::F64);
+
+    // Test same-width casts
+    test_cast_to_primitive(array, PType::I32);
+    test_cast_to_primitive(array, PType::F32);
+}
+
+fn test_cast_from_u64(array: &dyn Array) {
+    // Test narrowing casts
+    test_cast_to_primitive(array, PType::U8);
+    test_cast_to_primitive(array, PType::U16);
+    test_cast_to_primitive(array, PType::U32);
+    test_cast_to_primitive(array, PType::I8);
+    test_cast_to_primitive(array, PType::I16);
+    test_cast_to_primitive(array, PType::I32);
+    test_cast_to_primitive(array, PType::F32);
+
+    // Test same-width casts
+    test_cast_to_primitive(array, PType::I64);
+    test_cast_to_primitive(array, PType::F64);
+}
+
+fn test_cast_from_i8(array: &dyn Array) {
+    // Test widening casts
+    test_cast_to_primitive(array, PType::I16);
+    test_cast_to_primitive(array, PType::I32);
+    test_cast_to_primitive(array, PType::I64);
+    test_cast_to_primitive(array, PType::F32);
+    test_cast_to_primitive(array, PType::F64);
+
+    // Test same-width cast (may fail for negative values)
+    test_cast_to_primitive(array, PType::U8);
+}
+
+fn test_cast_from_i16(array: &dyn Array) {
+    // Test narrowing cast
+    test_cast_to_primitive(array, PType::I8);
+
+    // Test widening casts
+    test_cast_to_primitive(array, PType::I32);
+    test_cast_to_primitive(array, PType::I64);
+    test_cast_to_primitive(array, PType::F32);
+    test_cast_to_primitive(array, PType::F64);
+
+    // Test same-width cast (may fail for negative values)
+    test_cast_to_primitive(array, PType::U16);
+}
+
+fn test_cast_from_i32(array: &dyn Array) {
+    // Test narrowing casts
+    test_cast_to_primitive(array, PType::I8);
+    test_cast_to_primitive(array, PType::I16);
+
+    // Test widening casts
+    test_cast_to_primitive(array, PType::I64);
+    test_cast_to_primitive(array, PType::F64);
+
+    // Test same-width casts
+    test_cast_to_primitive(array, PType::F32);
+    test_cast_to_primitive(array, PType::U32);
+}
+
+fn test_cast_from_i64(array: &dyn Array) {
+    // Test narrowing casts
+    test_cast_to_primitive(array, PType::I8);
+    test_cast_to_primitive(array, PType::I16);
+    test_cast_to_primitive(array, PType::I32);
+    test_cast_to_primitive(array, PType::F32);
+
+    // Test same-width cast
+    test_cast_to_primitive(array, PType::F64);
+    test_cast_to_primitive(array, PType::U64);
+}
+
+fn test_cast_from_f16(array: &dyn Array) {
+    // Test casts to other float types
+    test_cast_to_primitive(array, PType::F32);
+    test_cast_to_primitive(array, PType::F64);
+}
+
+fn test_cast_from_f32(array: &dyn Array) {
+    // Test narrowing cast
+    test_cast_to_primitive(array, PType::F16);
+
+    // Test widening cast
+    test_cast_to_primitive(array, PType::F64);
+
+    // Test casts to integer types (truncation)
+    test_cast_to_integral_types(array);
+}
+
+fn test_cast_from_f64(array: &dyn Array) {
+    // Test narrowing casts
+    test_cast_to_primitive(array, PType::F16);
+    test_cast_to_primitive(array, PType::F32);
+
+    // Test casts to integer types (truncation)
+    test_cast_to_integral_types(array);
+}
+
+fn test_cast_to_integral_types(array: &dyn Array) {
+    // Test casting to all integral types
+    // Some may fail due to out-of-range values
+    test_cast_to_primitive(array, PType::I8);
+    test_cast_to_primitive(array, PType::U8);
+    test_cast_to_primitive(array, PType::I16);
+    test_cast_to_primitive(array, PType::U16);
+    test_cast_to_primitive(array, PType::I32);
+    test_cast_to_primitive(array, PType::U32);
+    test_cast_to_primitive(array, PType::I64);
+    test_cast_to_primitive(array, PType::U64);
+}
+
+fn test_cast_to_primitive(array: &dyn Array, target_ptype: PType) {
+    let target_dtype = DType::Primitive(target_ptype, array.dtype().nullability());
+    test_cast_to_type_safe(array, &target_dtype);
+}
+
+fn test_cast_to_type_safe(array: &dyn Array, target_dtype: &DType) {
+    // Attempt the cast
+    let result = match cast(array, target_dtype) {
+        Ok(r) => r,
+        Err(_) => {
+            // Some casts may fail (e.g., negative to unsigned, out-of-range values)
+            // This is expected behavior
+            return;
+        }
+    };
+
+    assert_eq!(result.len(), array.len());
+    assert_eq!(result.dtype(), target_dtype);
+
+    // For valid casts, verify the values are correctly converted
+    // We verify up to the first 10 values (or all if less than 10)
+    for i in 0..array.len().min(10) {
+        let original = array.scalar_at(i).vortex_unwrap();
+        let casted = result.scalar_at(i).vortex_unwrap();
+
+        // For nullability-only changes, values should be identical
+        if array.dtype().eq_ignore_nullability(target_dtype) {
+            assert_eq!(
+                original, casted,
+                "Value at index {i} changed during nullability cast"
+            );
+        } else {
+            // For type conversions, at least verify we can retrieve the values
+            // and that null values remain null
+            if original.is_null() {
+                assert!(
+                    casted.is_null(),
+                    "Null value at index {i} became non-null after cast"
+                );
+            } else {
+                assert!(
+                    !casted.is_null(),
+                    "Non-null value at index {i} became null after cast"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_buffer::buffer;
+    use vortex_dtype::{DType, FieldNames, Nullability};
+
+    use super::*;
+    use crate::IntoArray;
+    use crate::arrays::{
+        BoolArray, ListArray, NullArray, PrimitiveArray, StructArray, VarBinArray,
+    };
+
+    #[test]
+    fn test_cast_conformance_u32() {
+        let array = buffer![0u32, 100, 200, 65535, 1000000].into_array();
+        test_cast_conformance(array.as_ref());
+    }
+
+    #[test]
+    fn test_cast_conformance_i32() {
+        let array = buffer![-100i32, -1, 0, 1, 100].into_array();
+        test_cast_conformance(array.as_ref());
+    }
+
+    #[test]
+    fn test_cast_conformance_f32() {
+        let array = buffer![0.0f32, 1.5, -2.5, 100.0, 1e6].into_array();
+        test_cast_conformance(array.as_ref());
+    }
+
+    #[test]
+    fn test_cast_conformance_nullable() {
+        let array = PrimitiveArray::from_option_iter([Some(1u8), None, Some(255), Some(0), None]);
+        test_cast_conformance(array.as_ref());
+    }
+
+    #[test]
+    fn test_cast_conformance_bool() {
+        let array = BoolArray::from_iter(vec![true, false, true, false]);
+        test_cast_conformance(array.as_ref());
+    }
+
+    #[test]
+    fn test_cast_conformance_null() {
+        let array = NullArray::new(5);
+        test_cast_conformance(array.as_ref());
+    }
+
+    #[test]
+    fn test_cast_conformance_utf8() {
+        let array = VarBinArray::from_iter(
+            vec![Some("hello"), None, Some("world")],
+            DType::Utf8(Nullability::Nullable),
+        );
+        test_cast_conformance(array.as_ref());
+    }
+
+    #[test]
+    fn test_cast_conformance_binary() {
+        let array = VarBinArray::from_iter(
+            vec![Some(b"data".as_slice()), None, Some(b"bytes".as_slice())],
+            DType::Binary(Nullability::Nullable),
+        );
+        test_cast_conformance(array.as_ref());
+    }
+
+    #[test]
+    fn test_cast_conformance_struct() {
+        let names: FieldNames = vec!["a".into(), "b".into()].into();
+
+        let a = buffer![1i32, 2, 3].into_array();
+        let b = VarBinArray::from_iter(
+            vec![Some("x"), None, Some("z")],
+            DType::Utf8(Nullability::Nullable),
+        )
+        .into_array();
+
+        let array =
+            StructArray::try_new(names, vec![a, b], 3, crate::validity::Validity::NonNullable)
+                .unwrap();
+        test_cast_conformance(array.as_ref());
+    }
+
+    #[test]
+    fn test_cast_conformance_list() {
+        let data = buffer![1i32, 2, 3, 4, 5, 6].into_array();
+        let offsets = buffer![0i64, 2, 2, 5, 6].into_array();
+
+        let array =
+            ListArray::try_new(data, offsets, crate::validity::Validity::NonNullable).unwrap();
+        test_cast_conformance(array.as_ref());
+    }
+}

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -19,12 +19,12 @@
 //!   interact with null values.
 //! - **Edge Cases**: Tests empty arrays, single elements, and boundary conditions.
 
-use vortex_dtype::DType;
+use vortex_dtype::{DType, Nullability, PType};
 use vortex_error::{VortexUnwrap, vortex_panic};
 use vortex_mask::Mask;
 
 use crate::arrays::{BoolArray, PrimitiveArray};
-use crate::compute::{filter, mask, take};
+use crate::compute::{Operator, and, cast, compare, filter, invert, mask, or, take};
 use crate::{Array, IntoArray};
 
 /// Tests that filter and take operations produce consistent results.
@@ -428,8 +428,7 @@ fn test_empty_operations_consistency(array: &dyn Array) {
     assert_eq!(empty_filter.dtype(), array.dtype());
 
     // Empty take
-    let empty_indices =
-        PrimitiveArray::empty::<u64>(vortex_dtype::Nullability::NonNullable).into_array();
+    let empty_indices = PrimitiveArray::empty::<u64>(Nullability::NonNullable).into_array();
     let empty_take = take(array, &empty_indices).vortex_unwrap();
     assert_eq!(empty_take.len(), 0);
     assert_eq!(empty_take.dtype(), array.dtype());
@@ -576,10 +575,6 @@ fn test_large_array_consistency(array: &dyn Array) {
 /// This test catches bugs where an encoding might implement one comparison
 /// correctly but fail on its logical inverse.
 fn test_comparison_inverse_consistency(array: &dyn Array) {
-    use vortex_dtype::DType;
-
-    use crate::compute::{Operator, compare, invert};
-
     let len = array.len();
     if len == 0 {
         return;
@@ -676,10 +671,6 @@ fn test_comparison_inverse_consistency(array: &dyn Array) {
 /// Ensures that comparison operations maintain mathematical ordering properties
 /// regardless of operand order.
 fn test_comparison_symmetry_consistency(array: &dyn Array) {
-    use vortex_dtype::DType;
-
-    use crate::compute::{Operator, compare};
-
     let len = array.len();
     if len == 0 {
         return;
@@ -757,8 +748,6 @@ fn test_comparison_symmetry_consistency(array: &dyn Array) {
 /// This test catches bugs where encodings might optimize boolean operations
 /// incorrectly, breaking fundamental logical properties.
 fn test_boolean_demorgan_consistency(array: &dyn Array) {
-    use crate::compute::{and, invert, or};
-
     if !matches!(array.dtype(), DType::Bool(_)) {
         return;
     }
@@ -891,13 +880,7 @@ fn test_slice_aggregate_consistency(array: &dyn Array) {
     }
 
     // Test nan_count for floating point types
-    if matches!(
-        array.dtype(),
-        DType::Primitive(
-            vortex_dtype::PType::F16 | vortex_dtype::PType::F32 | vortex_dtype::PType::F64,
-            _
-        )
-    ) {
+    if array.dtype().is_float() {
         if let (Ok(slice_nan_count), Ok(canonical_nan_count)) =
             (nan_count(&sliced), nan_count(&canonical_sliced))
         {
@@ -926,10 +909,6 @@ fn test_slice_aggregate_consistency(array: &dyn Array) {
 /// offset information during cast operations. Such bugs can lead to incorrect data being
 /// returned after casting a sliced array.
 fn test_cast_slice_consistency(array: &dyn Array) {
-    use vortex_dtype::{DType, Nullability, PType};
-
-    use crate::compute::cast;
-
     let len = array.len();
     if len < 5 {
         return; // Need at least 5 elements for meaningful slice

--- a/vortex-array/src/compute/conformance/mod.rs
+++ b/vortex-array/src/compute/conformance/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 pub mod binary_numeric;
+pub mod cast;
 pub mod consistency;
 pub mod filter;
 pub mod mask;


### PR DESCRIPTION
Reverts #4109 and reapplies #4086, with fix to RunEndArray casting + tests

Blocked on #4113 and #4114 