### PR TITLE
fix: error-prone f16 Scalar serde

### DIFF
--- a/vortex-array/src/arrays/constant/canonical.rs
+++ b/vortex-array/src/arrays/constant/canonical.rs
@@ -287,14 +287,14 @@ mod tests {
 
     #[test]
     fn test_canonicalize_scalar_values() {
-        let f16_scalar = Scalar::primitive(f16::from_f32(5.722046e-6), Nullability::NonNullable);
-        let scalar = Scalar::new(
-            DType::Primitive(PType::F16, Nullability::NonNullable),
-            Scalar::primitive(96u8, Nullability::NonNullable).into_value(),
-        );
-        let const_array = ConstantArray::new(scalar.clone(), 1).into_array();
+        let f16_value = f16::from_f32(5.722046e-6);
+        let f16_scalar = Scalar::primitive(f16_value, Nullability::NonNullable);
+
+        // Create a ConstantArray with the f16 scalar
+        let const_array = ConstantArray::new(f16_scalar.clone(), 1).into_array();
         let canonical_const = const_array.to_primitive().unwrap();
-        assert_eq!(canonical_const.scalar_at(0).unwrap(), scalar);
+
+        // Verify the scalar value is preserved through canonicalization
         assert_eq!(canonical_const.scalar_at(0).unwrap(), f16_scalar);
     }
 

--- a/vortex-proto/proto/scalar.proto
+++ b/vortex-proto/proto/scalar.proto
@@ -27,6 +27,7 @@ message ScalarValue {
     string string_value = 7;
     bytes bytes_value = 8;
     ListValue list_value = 9;
+    uint64 f16_value = 10;
   }
 }
 

--- a/vortex-proto/src/generated/vortex.scalar.rs
+++ b/vortex-proto/src/generated/vortex.scalar.rs
@@ -8,7 +8,7 @@ pub struct Scalar {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScalarValue {
-    #[prost(oneof = "scalar_value::Kind", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9")]
+    #[prost(oneof = "scalar_value::Kind", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
     pub kind: ::core::option::Option<scalar_value::Kind>,
 }
 /// Nested message and enum types in `ScalarValue`.
@@ -33,6 +33,8 @@ pub mod scalar_value {
         BytesValue(::prost::alloc::vec::Vec<u8>),
         #[prost(message, tag = "9")]
         ListValue(super::ListValue),
+        #[prost(uint64, tag = "10")]
+        F16Value(u64),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/vortex-scalar/src/bool.rs
+++ b/vortex-scalar/src/bool.rs
@@ -85,8 +85,7 @@ impl<'a> BoolScalar<'a> {
     pub fn into_scalar(self) -> Scalar {
         Scalar::new(
             self.dtype.clone(),
-            self
-                .value
+            self.value
                 .map(|x| ScalarValue(InnerScalarValue::Bool(x)))
                 .unwrap_or_else(|| ScalarValue(InnerScalarValue::Null)),
         )
@@ -152,10 +151,7 @@ impl TryFrom<Scalar> for Option<bool> {
 
 impl From<bool> for Scalar {
     fn from(value: bool) -> Self {
-        Self::new(
-            DType::Bool(NonNullable),
-            value.into(),
-        )
+        Self::new(DType::Bool(NonNullable), value.into())
     }
 }
 

--- a/vortex-scalar/src/bool.rs
+++ b/vortex-scalar/src/bool.rs
@@ -83,23 +83,23 @@ impl<'a> BoolScalar<'a> {
 
     /// Converts this boolean scalar into a general scalar.
     pub fn into_scalar(self) -> Scalar {
-        Scalar {
-            dtype: self.dtype.clone(),
-            value: self
+        Scalar::new(
+            self.dtype.clone(),
+            self
                 .value
                 .map(|x| ScalarValue(InnerScalarValue::Bool(x)))
                 .unwrap_or_else(|| ScalarValue(InnerScalarValue::Null)),
-        }
+        )
     }
 }
 
 impl Scalar {
     /// Creates a new boolean scalar with the given value and nullability.
     pub fn bool(value: bool, nullability: Nullability) -> Self {
-        Self {
-            dtype: DType::Bool(nullability),
-            value: ScalarValue(InnerScalarValue::Bool(value)),
-        }
+        Self::new(
+            DType::Bool(nullability),
+            ScalarValue(InnerScalarValue::Bool(value)),
+        )
     }
 }
 
@@ -152,10 +152,10 @@ impl TryFrom<Scalar> for Option<bool> {
 
 impl From<bool> for Scalar {
     fn from(value: bool) -> Self {
-        Self {
-            dtype: DType::Bool(NonNullable),
-            value: value.into(),
-        }
+        Self::new(
+            DType::Bool(NonNullable),
+            value.into(),
+        )
     }
 }
 

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -1008,4 +1008,111 @@ mod tests {
             _ => panic!("Expected U64 value to remain unchanged when too large for F16"),
         }
     }
+
+    #[test]
+    fn test_extension_dtype_coercion() {
+        // Create an extension type with f16 storage
+        let ext_id = ExtID::new("test_f16_ext".into());
+        let storage_dtype = Arc::new(DType::Primitive(PType::F16, Nullability::NonNullable));
+        let ext_dtype = Arc::new(ExtDType::new(ext_id, storage_dtype, None));
+        
+        // Test f16 value stored as u64 gets coerced through extension type
+        let f16_value = f16::from_f32(0.42);
+        let u64_bits = f16_value.to_bits() as u64;
+        
+        let scalar = Scalar::new(
+            DType::Extension(ext_dtype.clone()),
+            ScalarValue(InnerScalarValue::Primitive(PValue::U64(u64_bits))),
+        );
+        
+        // Verify the value was coerced to f16
+        match scalar.value() {
+            ScalarValue(InnerScalarValue::Primitive(PValue::F16(v))) => {
+                assert_eq!(*v, f16_value);
+            }
+            _ => panic!("Expected F16 value after extension type coercion"),
+        }
+    }
+
+    #[test]
+    fn test_extension_dtype_no_coercion() {
+        // Create an extension type with u32 storage
+        let ext_id = ExtID::new("test_u32_ext".into());
+        let storage_dtype = Arc::new(DType::Primitive(PType::U32, Nullability::NonNullable));
+        let ext_dtype = Arc::new(ExtDType::new(ext_id, storage_dtype, None));
+        
+        // Test u32 value is not coerced
+        let u32_value = 42u32;
+        
+        let scalar = Scalar::new(
+            DType::Extension(ext_dtype.clone()),
+            ScalarValue(InnerScalarValue::Primitive(PValue::U32(u32_value))),
+        );
+        
+        // Verify the value remains u32
+        match scalar.value() {
+            ScalarValue(InnerScalarValue::Primitive(PValue::U32(v))) => {
+                assert_eq!(*v, u32_value);
+            }
+            _ => panic!("Expected U32 value to remain unchanged"),
+        }
+    }
+
+    #[test]
+    fn test_extension_dtype_nested_struct_coercion() {
+        // Create an extension type with struct storage that contains f16 field
+        let ext_id = ExtID::new("test_struct_ext".into());
+        let struct_dtype = Arc::new(DType::Struct(
+            StructFields::from_iter([
+                (
+                    "id",
+                    FieldDType::from(DType::Primitive(PType::U32, Nullability::NonNullable)),
+                ),
+                (
+                    "value",
+                    FieldDType::from(DType::Primitive(PType::F16, Nullability::NonNullable)),
+                ),
+            ]),
+            Nullability::NonNullable,
+        ));
+        let ext_dtype = Arc::new(ExtDType::new(ext_id, struct_dtype, None));
+        
+        // Create struct value with f16 stored as u64
+        let f16_value = f16::from_f32(1.5);
+        let field_values = vec![
+            ScalarValue(InnerScalarValue::Primitive(PValue::U32(123))),
+            ScalarValue(InnerScalarValue::Primitive(PValue::U64(
+                f16_value.to_bits() as u64,
+            ))),
+        ];
+        
+        let scalar = Scalar::new(
+            DType::Extension(ext_dtype.clone()),
+            ScalarValue(InnerScalarValue::List(field_values.into())),
+        );
+        
+        // Verify the struct field was coerced
+        match scalar.value() {
+            ScalarValue(InnerScalarValue::List(fields)) => {
+                assert_eq!(fields.len(), 2);
+                
+                // Check ID field (no coercion)
+                match &fields[0].0 {
+                    InnerScalarValue::Primitive(PValue::U32(v)) => {
+                        assert_eq!(*v, 123);
+                    }
+                    _ => panic!("Expected U32 value for ID field"),
+                }
+                
+                // Check value field (f16 coerced from u64)
+                match &fields[1].0 {
+                    InnerScalarValue::Primitive(PValue::F16(v)) => {
+                        assert_eq!(*v, f16_value);
+                    }
+                    _ => panic!("Expected F16 value for value field after coercion"),
+                }
+            }
+            _ => panic!("Expected List value for struct storage in extension type"),
+        }
+    }
 }

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -1021,7 +1021,7 @@ mod tests {
         let u64_bits = f16_value.to_bits() as u64;
 
         let scalar = Scalar::new(
-            DType::Extension(ext_dtype.clone()),
+            DType::Extension(ext_dtype),
             ScalarValue(InnerScalarValue::Primitive(PValue::U64(u64_bits))),
         );
 
@@ -1045,7 +1045,7 @@ mod tests {
         let u32_value = 42u32;
 
         let scalar = Scalar::new(
-            DType::Extension(ext_dtype.clone()),
+            DType::Extension(ext_dtype),
             ScalarValue(InnerScalarValue::Primitive(PValue::U32(u32_value))),
         );
 
@@ -1087,7 +1087,7 @@ mod tests {
         ];
 
         let scalar = Scalar::new(
-            DType::Extension(ext_dtype.clone()),
+            DType::Extension(ext_dtype),
             ScalarValue(InnerScalarValue::List(field_values.into())),
         );
 

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -1015,16 +1015,16 @@ mod tests {
         let ext_id = ExtID::new("test_f16_ext".into());
         let storage_dtype = Arc::new(DType::Primitive(PType::F16, Nullability::NonNullable));
         let ext_dtype = Arc::new(ExtDType::new(ext_id, storage_dtype, None));
-        
+
         // Test f16 value stored as u64 gets coerced through extension type
         let f16_value = f16::from_f32(0.42);
         let u64_bits = f16_value.to_bits() as u64;
-        
+
         let scalar = Scalar::new(
             DType::Extension(ext_dtype.clone()),
             ScalarValue(InnerScalarValue::Primitive(PValue::U64(u64_bits))),
         );
-        
+
         // Verify the value was coerced to f16
         match scalar.value() {
             ScalarValue(InnerScalarValue::Primitive(PValue::F16(v))) => {
@@ -1040,15 +1040,15 @@ mod tests {
         let ext_id = ExtID::new("test_u32_ext".into());
         let storage_dtype = Arc::new(DType::Primitive(PType::U32, Nullability::NonNullable));
         let ext_dtype = Arc::new(ExtDType::new(ext_id, storage_dtype, None));
-        
+
         // Test u32 value is not coerced
         let u32_value = 42u32;
-        
+
         let scalar = Scalar::new(
             DType::Extension(ext_dtype.clone()),
             ScalarValue(InnerScalarValue::Primitive(PValue::U32(u32_value))),
         );
-        
+
         // Verify the value remains u32
         match scalar.value() {
             ScalarValue(InnerScalarValue::Primitive(PValue::U32(v))) => {
@@ -1076,7 +1076,7 @@ mod tests {
             Nullability::NonNullable,
         ));
         let ext_dtype = Arc::new(ExtDType::new(ext_id, struct_dtype, None));
-        
+
         // Create struct value with f16 stored as u64
         let f16_value = f16::from_f32(1.5);
         let field_values = vec![
@@ -1085,17 +1085,17 @@ mod tests {
                 f16_value.to_bits() as u64,
             ))),
         ];
-        
+
         let scalar = Scalar::new(
             DType::Extension(ext_dtype.clone()),
             ScalarValue(InnerScalarValue::List(field_values.into())),
         );
-        
+
         // Verify the struct field was coerced
         match scalar.value() {
             ScalarValue(InnerScalarValue::List(fields)) => {
                 assert_eq!(fields.len(), 2);
-                
+
                 // Check ID field (no coercion)
                 match &fields[0].0 {
                     InnerScalarValue::Primitive(PValue::U32(v)) => {
@@ -1103,7 +1103,7 @@ mod tests {
                     }
                     _ => panic!("Expected U32 value for ID field"),
                 }
-                
+
                 // Check value field (f16 coerced from u64)
                 match &fields[1].0 {
                     InnerScalarValue::Primitive(PValue::F16(v)) => {

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -557,11 +557,13 @@ from_vec_for_scalar!(ByteBuffer);
 #[cfg(test)]
 #[allow(clippy::panic)]
 mod tests {
-    use crate::{InnerScalarValue, PValue, Scalar, ScalarValue};
-    use rstest::rstest;
     use std::sync::Arc;
+
+    use rstest::rstest;
     use vortex_dtype::half::f16;
     use vortex_dtype::{DType, ExtDType, ExtID, FieldDType, Nullability, PType, StructFields};
+
+    use crate::{InnerScalarValue, PValue, Scalar, ScalarValue};
 
     #[rstest]
     fn null_can_cast_to_anything_nullable(
@@ -791,7 +793,7 @@ mod tests {
     }
 
     #[test]
-    fn test_f16_coercion_from_u32() {
+    fn test_f16_no_coercion_from_u32() {
         let f16_value = f16::from_f32(0.42);
         let u32_bits = f16_value.to_bits() as u32;
 
@@ -800,16 +802,17 @@ mod tests {
             ScalarValue(InnerScalarValue::Primitive(PValue::U32(u32_bits))),
         );
 
+        // No coercion expected from u32
         match scalar.value() {
-            ScalarValue(InnerScalarValue::Primitive(PValue::F16(v))) => {
-                assert_eq!(*v, f16_value);
+            ScalarValue(InnerScalarValue::Primitive(PValue::U32(v))) => {
+                assert_eq!(*v, u32_bits);
             }
-            _ => panic!("Expected F16 value after coercion"),
+            _ => panic!("Expected U32 value (no coercion)"),
         }
     }
 
     #[test]
-    fn test_f16_coercion_from_u16() {
+    fn test_f16_no_coercion_from_u16() {
         let f16_value = f16::from_f32(1.5);
         let u16_bits = f16_value.to_bits();
 
@@ -818,16 +821,17 @@ mod tests {
             ScalarValue(InnerScalarValue::Primitive(PValue::U16(u16_bits))),
         );
 
+        // No coercion expected from u16
         match scalar.value() {
-            ScalarValue(InnerScalarValue::Primitive(PValue::F16(v))) => {
-                assert_eq!(*v, f16_value);
+            ScalarValue(InnerScalarValue::Primitive(PValue::U16(v))) => {
+                assert_eq!(*v, u16_bits);
             }
-            _ => panic!("Expected F16 value after coercion"),
+            _ => panic!("Expected U16 value (no coercion)"),
         }
     }
 
     #[test]
-    fn test_f32_coercion_from_u32() {
+    fn test_f32_no_coercion_from_u32() {
         let f32_value = std::f32::consts::PI;
         let u32_bits = f32_value.to_bits();
 
@@ -836,16 +840,17 @@ mod tests {
             ScalarValue(InnerScalarValue::Primitive(PValue::U32(u32_bits))),
         );
 
+        // No coercion expected from u32
         match scalar.value() {
-            ScalarValue(InnerScalarValue::Primitive(PValue::F32(v))) => {
-                assert_eq!(*v, f32_value);
+            ScalarValue(InnerScalarValue::Primitive(PValue::U32(v))) => {
+                assert_eq!(*v, u32_bits);
             }
-            _ => panic!("Expected F32 value after coercion"),
+            _ => panic!("Expected U32 value (no coercion)"),
         }
     }
 
     #[test]
-    fn test_f64_coercion_from_u64() {
+    fn test_f64_no_coercion_from_u64() {
         let f64_value = std::f64::consts::E;
         let u64_bits = f64_value.to_bits();
 
@@ -854,18 +859,19 @@ mod tests {
             ScalarValue(InnerScalarValue::Primitive(PValue::U64(u64_bits))),
         );
 
+        // No coercion expected from u64
         match scalar.value() {
-            ScalarValue(InnerScalarValue::Primitive(PValue::F64(v))) => {
-                assert_eq!(*v, f64_value);
+            ScalarValue(InnerScalarValue::Primitive(PValue::U64(v))) => {
+                assert_eq!(*v, u64_bits);
             }
-            _ => panic!("Expected F64 value after coercion"),
+            _ => panic!("Expected U64 value (no coercion)"),
         }
     }
 
     #[test]
     fn test_struct_field_coercion() {
         let f16_value = f16::from_f32(0.42);
-        let f32_value = 3.14f32;
+        let f32_value = std::f32::consts::PI;
 
         let struct_dtype = DType::Struct(
             StructFields::from_iter([
@@ -890,9 +896,7 @@ mod tests {
             ScalarValue(InnerScalarValue::Primitive(PValue::U64(
                 f16_value.to_bits() as u64,
             ))),
-            ScalarValue(InnerScalarValue::Primitive(PValue::U32(
-                f32_value.to_bits(),
-            ))),
+            ScalarValue(InnerScalarValue::Primitive(PValue::F32(f32_value))),
         ];
 
         let scalar = Scalar::new(
@@ -919,12 +923,12 @@ mod tests {
             _ => panic!("Expected F16 value for field 'b' after coercion"),
         }
 
-        // Check third field (f32 coerced from u32)
+        // Check third field (no coercion needed)
         match fields[2].value() {
             ScalarValue(InnerScalarValue::Primitive(PValue::F32(v))) => {
                 assert_eq!(*v, f32_value);
             }
-            _ => panic!("Expected F32 value for field 'c' after coercion"),
+            _ => panic!("Expected F32 value for field 'c'"),
         }
     }
 
@@ -956,11 +960,11 @@ mod tests {
         );
 
         let elements = vec![
-            ScalarValue(InnerScalarValue::Primitive(PValue::U16(
-                f16_value1.to_bits(),
+            ScalarValue(InnerScalarValue::Primitive(PValue::U64(
+                f16_value1.to_bits() as u64,
             ))),
-            ScalarValue(InnerScalarValue::Primitive(PValue::U16(
-                f16_value2.to_bits(),
+            ScalarValue(InnerScalarValue::Primitive(PValue::U64(
+                f16_value2.to_bits() as u64,
             ))),
         ];
 
@@ -975,9 +979,9 @@ mod tests {
         for (i, expected) in [f16_value1, f16_value2].iter().enumerate() {
             match elements[i].value() {
                 ScalarValue(InnerScalarValue::Primitive(PValue::F16(v))) => {
-                    assert_eq!(v, expected, "Element {} mismatch", i);
+                    assert_eq!(v, expected, "Element {i} mismatch");
                 }
-                _ => panic!("Expected F16 value for element {} after coercion", i),
+                _ => panic!("Expected F16 value for element {i} after coercion"),
             }
         }
     }

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 pub use scalar_type::ScalarType;
 use vortex_buffer::{Buffer, BufferString, ByteBuffer};
 use vortex_dtype::half::f16;
-use vortex_dtype::{DECIMAL128_MAX_PRECISION, DType, Nullability};
+use vortex_dtype::{DECIMAL128_MAX_PRECISION, DType, Nullability, PType};
 #[cfg(feature = "arbitrary")]
 pub mod arbitrary;
 mod arrow;
@@ -47,7 +47,7 @@ pub use pvalue::*;
 pub use scalar_value::*;
 pub use struct_::*;
 pub use utf8::*;
-use vortex_error::{VortexExpect, VortexResult, vortex_bail};
+use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
 
 /// A single logical item, composed of both a [`ScalarValue`] and a logical [`DType`].
 ///
@@ -66,10 +66,91 @@ pub struct Scalar {
 impl Scalar {
     /// Creates a new scalar with the given data type and value.
     ///
-    /// FIXME(ngates): this is unchecked... we don't know that the scalar value is compatible
-    ///  with the data type.
+    /// This function performs type coercion when necessary to ensure the value matches
+    /// the expected data type. This is particularly important for backwards compatibility
+    /// with serialized scalars where floating point values may have been stored as integers.
     pub fn new(dtype: DType, value: ScalarValue) -> Self {
-        Self { dtype, value }
+        // Unwrap is safe here because coerce_value only returns errors for invalid u64 to u16 conversions
+        let coerced_value = match Self::coerce_value(&dtype, value.clone()) {
+            Ok(coerced) => coerced,
+            Err(_) => value,
+        };
+        Self {
+            dtype,
+            value: coerced_value,
+        }
+    }
+
+    /// Coerces a scalar value to match the expected data type.
+    ///
+    /// This handles cases where:
+    /// - Floating point values were serialized as their bit representation
+    /// - Struct fields need recursive coercion
+    /// - List elements need recursive coercion
+    fn coerce_value(dtype: &DType, value: ScalarValue) -> VortexResult<ScalarValue> {
+        match (dtype, &value.0) {
+            // Handle primitive type coercion
+            (DType::Primitive(ptype, _), InnerScalarValue::Primitive(pvalue)) => {
+                match (ptype, pvalue) {
+                    // F16 coercion from integer types (backwards compatibility)
+                    (PType::F16, PValue::U64(v)) if *v <= u16::MAX as u64 => {
+                        Ok(ScalarValue(InnerScalarValue::Primitive(PValue::F16(
+                            f16::from_bits(u16::try_from(*v).map_err(|_| {
+                                vortex_err!(
+                                    "bit representation of f16 has more than 16 bits: {}",
+                                    v
+                                )
+                            })?),
+                        ))))
+                    }
+                    (PType::F16, PValue::U32(v)) if *v <= u16::MAX as u32 => Ok(ScalarValue(
+                        InnerScalarValue::Primitive(PValue::F16(f16::from_bits(*v as u16))),
+                    )),
+                    (PType::F16, PValue::U16(v)) => Ok(ScalarValue(InnerScalarValue::Primitive(
+                        PValue::F16(f16::from_bits(*v)),
+                    ))),
+                    (PType::F16, PValue::U8(v)) => Ok(ScalarValue(InnerScalarValue::Primitive(
+                        PValue::F16(f16::from_bits(*v as u16)),
+                    ))),
+                    // F32 coercion from integer types (backwards compatibility)
+                    (PType::F32, PValue::U64(v)) if *v <= u32::MAX as u64 => Ok(ScalarValue(
+                        InnerScalarValue::Primitive(PValue::F32(f32::from_bits(*v as u32))),
+                    )),
+                    (PType::F32, PValue::U32(v)) => Ok(ScalarValue(InnerScalarValue::Primitive(
+                        PValue::F32(f32::from_bits(*v)),
+                    ))),
+                    // F64 coercion from integer types (backwards compatibility)
+                    (PType::F64, PValue::U64(v)) => Ok(ScalarValue(InnerScalarValue::Primitive(
+                        PValue::F64(f64::from_bits(*v)),
+                    ))),
+                    // No coercion needed
+                    _ => Ok(value),
+                }
+            }
+            // Handle struct coercion - recursively coerce fields
+            (DType::Struct(struct_fields, _), InnerScalarValue::List(field_values)) => {
+                let coerced_fields: Result<Vec<ScalarValue>, _> = struct_fields
+                    .fields()
+                    .zip(field_values.iter())
+                    .map(|(field_dtype, field_value)| {
+                        Self::coerce_value(&field_dtype, field_value.clone())
+                    })
+                    .collect();
+                Ok(ScalarValue(InnerScalarValue::List(coerced_fields?.into())))
+            }
+            // Handle list coercion - recursively coerce elements
+            (DType::List(elem_dtype, _), InnerScalarValue::List(elements)) => {
+                let coerced_elements: Result<Vec<ScalarValue>, _> = elements
+                    .iter()
+                    .map(|elem| Self::coerce_value(elem_dtype, elem.clone()))
+                    .collect();
+                Ok(ScalarValue(InnerScalarValue::List(
+                    coerced_elements?.into(),
+                )))
+            }
+            // No coercion needed for other types
+            _ => Ok(value),
+        }
     }
 
     /// Returns a reference to the scalar's data type.
@@ -497,13 +578,13 @@ from_vec_for_scalar!(BufferString);
 from_vec_for_scalar!(ByteBuffer);
 
 #[cfg(test)]
-mod test {
-    use std::sync::Arc;
-
-    use rstest::rstest;
-    use vortex_dtype::{DType, ExtDType, ExtID, Nullability, PType};
-
+#[allow(clippy::panic)]
+mod tests {
     use crate::{InnerScalarValue, PValue, Scalar, ScalarValue};
+    use rstest::rstest;
+    use std::sync::Arc;
+    use vortex_dtype::half::f16;
+    use vortex_dtype::{DType, ExtDType, ExtID, FieldDType, Nullability, PType, StructFields};
 
     #[rstest]
     fn null_can_cast_to_anything_nullable(
@@ -712,5 +793,234 @@ mod test {
 
         let c_field = scalar.field("c").unwrap();
         assert!(c_field.is_null());
+    }
+
+    #[test]
+    fn test_f16_coercion_from_u64() {
+        let f16_value = f16::from_f32(5.722046e-6);
+        let u64_bits = f16_value.to_bits() as u64;
+
+        let scalar = Scalar::new(
+            DType::Primitive(PType::F16, Nullability::NonNullable),
+            ScalarValue(InnerScalarValue::Primitive(PValue::U64(u64_bits))),
+        );
+
+        match scalar.value() {
+            ScalarValue(InnerScalarValue::Primitive(PValue::F16(v))) => {
+                assert_eq!(*v, f16_value);
+            }
+            _ => panic!("Expected F16 value after coercion"),
+        }
+    }
+
+    #[test]
+    fn test_f16_coercion_from_u32() {
+        let f16_value = f16::from_f32(0.42);
+        let u32_bits = f16_value.to_bits() as u32;
+
+        let scalar = Scalar::new(
+            DType::Primitive(PType::F16, Nullability::NonNullable),
+            ScalarValue(InnerScalarValue::Primitive(PValue::U32(u32_bits))),
+        );
+
+        match scalar.value() {
+            ScalarValue(InnerScalarValue::Primitive(PValue::F16(v))) => {
+                assert_eq!(*v, f16_value);
+            }
+            _ => panic!("Expected F16 value after coercion"),
+        }
+    }
+
+    #[test]
+    fn test_f16_coercion_from_u16() {
+        let f16_value = f16::from_f32(1.5);
+        let u16_bits = f16_value.to_bits();
+
+        let scalar = Scalar::new(
+            DType::Primitive(PType::F16, Nullability::NonNullable),
+            ScalarValue(InnerScalarValue::Primitive(PValue::U16(u16_bits))),
+        );
+
+        match scalar.value() {
+            ScalarValue(InnerScalarValue::Primitive(PValue::F16(v))) => {
+                assert_eq!(*v, f16_value);
+            }
+            _ => panic!("Expected F16 value after coercion"),
+        }
+    }
+
+    #[test]
+    fn test_f32_coercion_from_u32() {
+        let f32_value = std::f32::consts::PI;
+        let u32_bits = f32_value.to_bits();
+
+        let scalar = Scalar::new(
+            DType::Primitive(PType::F32, Nullability::NonNullable),
+            ScalarValue(InnerScalarValue::Primitive(PValue::U32(u32_bits))),
+        );
+
+        match scalar.value() {
+            ScalarValue(InnerScalarValue::Primitive(PValue::F32(v))) => {
+                assert_eq!(*v, f32_value);
+            }
+            _ => panic!("Expected F32 value after coercion"),
+        }
+    }
+
+    #[test]
+    fn test_f64_coercion_from_u64() {
+        let f64_value = std::f64::consts::E;
+        let u64_bits = f64_value.to_bits();
+
+        let scalar = Scalar::new(
+            DType::Primitive(PType::F64, Nullability::NonNullable),
+            ScalarValue(InnerScalarValue::Primitive(PValue::U64(u64_bits))),
+        );
+
+        match scalar.value() {
+            ScalarValue(InnerScalarValue::Primitive(PValue::F64(v))) => {
+                assert_eq!(*v, f64_value);
+            }
+            _ => panic!("Expected F64 value after coercion"),
+        }
+    }
+
+    #[test]
+    fn test_struct_field_coercion() {
+        let f16_value = f16::from_f32(0.42);
+        let f32_value = 3.14f32;
+
+        let struct_dtype = DType::Struct(
+            StructFields::from_iter([
+                (
+                    "a",
+                    FieldDType::from(DType::Primitive(PType::U32, Nullability::NonNullable)),
+                ),
+                (
+                    "b",
+                    FieldDType::from(DType::Primitive(PType::F16, Nullability::NonNullable)),
+                ),
+                (
+                    "c",
+                    FieldDType::from(DType::Primitive(PType::F32, Nullability::NonNullable)),
+                ),
+            ]),
+            Nullability::NonNullable,
+        );
+
+        let field_values = vec![
+            ScalarValue(InnerScalarValue::Primitive(PValue::U32(42))),
+            ScalarValue(InnerScalarValue::Primitive(PValue::U64(
+                f16_value.to_bits() as u64,
+            ))),
+            ScalarValue(InnerScalarValue::Primitive(PValue::U32(
+                f32_value.to_bits(),
+            ))),
+        ];
+
+        let scalar = Scalar::new(
+            struct_dtype,
+            ScalarValue(InnerScalarValue::List(field_values.into())),
+        );
+
+        let struct_scalar = scalar.as_struct();
+        let fields = struct_scalar.fields().unwrap();
+
+        // Check first field (no coercion needed)
+        match fields[0].value() {
+            ScalarValue(InnerScalarValue::Primitive(PValue::U32(v))) => {
+                assert_eq!(*v, 42);
+            }
+            _ => panic!("Expected U32 value for field 'a'"),
+        }
+
+        // Check second field (f16 coerced from u64)
+        match fields[1].value() {
+            ScalarValue(InnerScalarValue::Primitive(PValue::F16(v))) => {
+                assert_eq!(*v, f16_value);
+            }
+            _ => panic!("Expected F16 value for field 'b' after coercion"),
+        }
+
+        // Check third field (f32 coerced from u32)
+        match fields[2].value() {
+            ScalarValue(InnerScalarValue::Primitive(PValue::F32(v))) => {
+                assert_eq!(*v, f32_value);
+            }
+            _ => panic!("Expected F32 value for field 'c' after coercion"),
+        }
+    }
+
+    #[test]
+    fn test_no_coercion_for_matching_types() {
+        // Test that when types already match, no coercion happens
+        let i32_value = 42i32;
+        let scalar = Scalar::new(
+            DType::Primitive(PType::I32, Nullability::NonNullable),
+            ScalarValue(InnerScalarValue::Primitive(PValue::I32(i32_value))),
+        );
+
+        match scalar.value() {
+            ScalarValue(InnerScalarValue::Primitive(PValue::I32(v))) => {
+                assert_eq!(*v, i32_value);
+            }
+            _ => panic!("Expected I32 value"),
+        }
+    }
+
+    #[test]
+    fn test_list_element_coercion() {
+        let f16_value1 = f16::from_f32(1.0);
+        let f16_value2 = f16::from_f32(2.0);
+
+        let list_dtype = DType::List(
+            Arc::new(DType::Primitive(PType::F16, Nullability::NonNullable)),
+            Nullability::NonNullable,
+        );
+
+        let elements = vec![
+            ScalarValue(InnerScalarValue::Primitive(PValue::U16(
+                f16_value1.to_bits(),
+            ))),
+            ScalarValue(InnerScalarValue::Primitive(PValue::U16(
+                f16_value2.to_bits(),
+            ))),
+        ];
+
+        let scalar = Scalar::new(
+            list_dtype,
+            ScalarValue(InnerScalarValue::List(elements.into())),
+        );
+
+        let list_scalar = scalar.as_list();
+        let elements = list_scalar.elements().unwrap();
+
+        for (i, expected) in [f16_value1, f16_value2].iter().enumerate() {
+            match elements[i].value() {
+                ScalarValue(InnerScalarValue::Primitive(PValue::F16(v))) => {
+                    assert_eq!(v, expected, "Element {} mismatch", i);
+                }
+                _ => panic!("Expected F16 value for element {} after coercion", i),
+            }
+        }
+    }
+
+    #[test]
+    fn test_coercion_with_overflow_protection() {
+        // Test that values too large for target type are not coerced
+        let large_u64 = u64::MAX;
+
+        // This should NOT be coerced to F16 because it's too large
+        let scalar = Scalar::new(
+            DType::Primitive(PType::F16, Nullability::NonNullable),
+            ScalarValue(InnerScalarValue::Primitive(PValue::U64(large_u64))),
+        );
+
+        match scalar.value() {
+            ScalarValue(InnerScalarValue::Primitive(PValue::U64(v))) => {
+                assert_eq!(*v, large_u64);
+            }
+            _ => panic!("Expected U64 value to remain unchanged when too large for F16"),
+        }
     }
 }

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -125,6 +125,10 @@ impl Scalar {
                     coerced_elements?.into(),
                 )))
             }
+            // Handle extension type coercion - recursively coerce the storage scalar
+            (DType::Extension(ext_dtype), _) => {
+                Self::coerce_value(ext_dtype.storage_dtype(), value)
+            }
             // No coercion needed for other types
             _ => Ok(value),
         }

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -69,16 +69,13 @@ impl Scalar {
     /// This function performs type coercion when necessary to ensure the value matches
     /// the expected data type. This is particularly important for backwards compatibility
     /// with serialized scalars where floating point values may have been stored as integers.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be coerced to the expected data type.
     pub fn new(dtype: DType, value: ScalarValue) -> Self {
-        // Unwrap is safe here because coerce_value only returns errors for invalid u64 to u16 conversions
-        let coerced_value = match Self::coerce_value(&dtype, value.clone()) {
-            Ok(coerced) => coerced,
-            Err(_) => value,
-        };
-        Self {
-            dtype,
-            value: coerced_value,
-        }
+        let value = Self::coerce_value(&dtype, value).vortex_expect("Failed to coerce value");
+        Self { dtype, value }
     }
 
     /// Coerces a scalar value to match the expected data type.
@@ -103,26 +100,6 @@ impl Scalar {
                             })?),
                         ))))
                     }
-                    (PType::F16, PValue::U32(v)) if *v <= u16::MAX as u32 => Ok(ScalarValue(
-                        InnerScalarValue::Primitive(PValue::F16(f16::from_bits(*v as u16))),
-                    )),
-                    (PType::F16, PValue::U16(v)) => Ok(ScalarValue(InnerScalarValue::Primitive(
-                        PValue::F16(f16::from_bits(*v)),
-                    ))),
-                    (PType::F16, PValue::U8(v)) => Ok(ScalarValue(InnerScalarValue::Primitive(
-                        PValue::F16(f16::from_bits(*v as u16)),
-                    ))),
-                    // F32 coercion from integer types (backwards compatibility)
-                    (PType::F32, PValue::U64(v)) if *v <= u32::MAX as u64 => Ok(ScalarValue(
-                        InnerScalarValue::Primitive(PValue::F32(f32::from_bits(*v as u32))),
-                    )),
-                    (PType::F32, PValue::U32(v)) => Ok(ScalarValue(InnerScalarValue::Primitive(
-                        PValue::F32(f32::from_bits(*v)),
-                    ))),
-                    // F64 coercion from integer types (backwards compatibility)
-                    (PType::F64, PValue::U64(v)) => Ok(ScalarValue(InnerScalarValue::Primitive(
-                        PValue::F64(f64::from_bits(*v)),
-                    ))),
                     // No coercion needed
                     _ => Ok(value),
                 }

--- a/vortex-scalar/src/list.rs
+++ b/vortex-scalar/src/list.rs
@@ -115,10 +115,7 @@ impl<'a> ListScalar<'a> {
         self.elements
             .as_ref()
             .and_then(|l| l.get(idx))
-            .map(|value| Scalar::new(
-                self.element_dtype().clone(),
-                value.clone(),
-            ))
+            .map(|value| Scalar::new(self.element_dtype().clone(), value.clone()))
     }
 
     /// Returns all elements in the list as a vector of scalars.

--- a/vortex-scalar/src/list.rs
+++ b/vortex-scalar/src/list.rs
@@ -115,10 +115,10 @@ impl<'a> ListScalar<'a> {
         self.elements
             .as_ref()
             .and_then(|l| l.get(idx))
-            .map(|value| Scalar {
-                dtype: self.element_dtype().clone(),
-                value: value.clone(),
-            })
+            .map(|value| Scalar::new(
+                self.element_dtype().clone(),
+                value.clone(),
+            ))
     }
 
     /// Returns all elements in the list as a vector of scalars.
@@ -177,20 +177,20 @@ impl Scalar {
                 );
             }
         }
-        Self {
-            dtype: DType::List(element_dtype, nullability),
-            value: ScalarValue(InnerScalarValue::List(
+        Self::new(
+            DType::List(element_dtype, nullability),
+            ScalarValue(InnerScalarValue::List(
                 children.into_iter().map(|x| x.value).collect(),
             )),
-        }
+        )
     }
 
     /// Creates a new empty list scalar with the given element type.
     pub fn list_empty(element_dtype: Arc<DType>, nullability: Nullability) -> Self {
-        Self {
-            dtype: DType::List(element_dtype, nullability),
-            value: ScalarValue(InnerScalarValue::Null),
-        }
+        Self::new(
+            DType::List(element_dtype, nullability),
+            ScalarValue(InnerScalarValue::Null),
+        )
     }
 }
 

--- a/vortex-scalar/src/primitive.rs
+++ b/vortex-scalar/src/primitive.rs
@@ -268,10 +268,10 @@ impl Scalar {
     /// Note that an explicit PType is passed since any compatible PValue may be used as the value
     /// for a primitive type.
     pub fn primitive_value(value: PValue, ptype: PType, nullability: Nullability) -> Self {
-        Self {
-            dtype: DType::Primitive(ptype, nullability),
-            value: ScalarValue(InnerScalarValue::Primitive(value)),
-        }
+        Self::new(
+            DType::Primitive(ptype, nullability),
+            ScalarValue(InnerScalarValue::Primitive(value)),
+        )
     }
 
     /// Reinterprets the bytes of this scalar as a different primitive type.
@@ -341,10 +341,10 @@ macro_rules! primitive_scalar {
 
         impl From<$T> for Scalar {
             fn from(value: $T) -> Self {
-                Scalar {
-                    dtype: DType::Primitive(<$T>::PTYPE, Nullability::NonNullable),
-                    value: ScalarValue(InnerScalarValue::Primitive(value.into())),
-                }
+                Scalar::new(
+                    DType::Primitive(<$T>::PTYPE, Nullability::NonNullable),
+                    ScalarValue(InnerScalarValue::Primitive(value.into())),
+                )
             }
         }
     };

--- a/vortex-scalar/src/proto.rs
+++ b/vortex-scalar/src/proto.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use num_traits::ToBytes;
 use vortex_buffer::{BufferString, ByteBuffer};
-use vortex_dtype::DType;
+use vortex_dtype::{DType, half::f16};
 use vortex_error::{VortexError, vortex_err};
 use vortex_proto::scalar as pb;
 use vortex_proto::scalar::ListValue;
@@ -94,7 +94,7 @@ impl From<&PValue> for pb::ScalarValue {
                 kind: Some(Kind::Uint64Value(*v)),
             },
             PValue::F16(v) => pb::ScalarValue {
-                kind: Some(Kind::Uint64Value(v.to_bits() as u64)),
+                kind: Some(Kind::F16Value(v.to_bits() as u64)),
             },
             PValue::F32(v) => pb::ScalarValue {
                 kind: Some(Kind::F32Value(*v)),
@@ -142,6 +142,11 @@ impl TryFrom<&pb::ScalarValue> for ScalarValue {
             Kind::BoolValue(v) => Ok(ScalarValue(InnerScalarValue::Bool(*v))),
             Kind::Int64Value(v) => Ok(ScalarValue(InnerScalarValue::Primitive(PValue::I64(*v)))),
             Kind::Uint64Value(v) => Ok(ScalarValue(InnerScalarValue::Primitive(PValue::U64(*v)))),
+            Kind::F16Value(v) => Ok(ScalarValue(InnerScalarValue::Primitive(PValue::F16(
+                f16::from_bits(u16::try_from(*v).map_err(|_| {
+                    vortex_err!("f16 bitwise representation has more than 16 bits: {}", v)
+                })?),
+            )))),
             Kind::F32Value(v) => Ok(ScalarValue(InnerScalarValue::Primitive(PValue::F32(*v)))),
             Kind::F64Value(v) => Ok(ScalarValue(InnerScalarValue::Primitive(PValue::F64(*v)))),
             Kind::StringValue(v) => Ok(ScalarValue(InnerScalarValue::BufferString(Arc::new(

--- a/vortex-scalar/src/proto.rs
+++ b/vortex-scalar/src/proto.rs
@@ -239,7 +239,10 @@ mod tests {
 
     #[test]
     fn test_f16() {
-        round_trip(Scalar::primitive(f16::from_f32(0.42), Nullability::Nullable));
+        round_trip(Scalar::primitive(
+            f16::from_f32(0.42),
+            Nullability::Nullable,
+        ));
     }
 
     #[test]

--- a/vortex-scalar/src/proto.rs
+++ b/vortex-scalar/src/proto.rs
@@ -175,6 +175,7 @@ mod tests {
     use vortex_buffer::BufferString;
     use vortex_dtype::half::f16;
     use vortex_dtype::{DType, DecimalDType, FieldDType, Nullability, PType, StructFields};
+    use vortex_error::vortex_panic;
     use vortex_proto::scalar as pb;
 
     use super::*;
@@ -353,14 +354,14 @@ mod tests {
                     }
                     assert_eq!(
                         original, roundtripped,
-                        "F16 value {} did not roundtrip correctly",
-                        original
+                        "F16 value {original:?} did not roundtrip correctly"
                     );
                 }
-                _ => panic!(
-                    "Expected f16 primitive values, got {:?} and {:?}",
-                    scalar_value, read_back
-                ),
+                _ => {
+                    vortex_panic!(
+                        "Expected f16 primitive values, got {scalar_value:?} and {read_back:?}"
+                    )
+                }
             }
         }
     }
@@ -417,12 +418,11 @@ mod tests {
             let written = value.to_protobytes::<Vec<u8>>();
             let read_back = ScalarValue::from_protobytes(&written).unwrap();
 
-            let original_debug = format!("{:?}", value);
-            let roundtrip_debug = format!("{:?}", read_back);
+            let original_debug = format!("{value:?}");
+            let roundtrip_debug = format!("{read_back:?}");
             assert_eq!(
                 original_debug, roundtrip_debug,
-                "ScalarValue {} did not roundtrip exactly",
-                name
+                "ScalarValue {name} did not roundtrip exactly"
             );
         }
 
@@ -454,14 +454,12 @@ mod tests {
                 InnerScalarValue::Primitive(PValue::U64(v)) => {
                     assert_eq!(
                         *v, expected,
-                        "ScalarValue {} value not preserved: expected {}, got {}",
-                        name, expected, v
+                        "ScalarValue {name} value not preserved: expected {expected}, got {v}"
                     );
                 }
-                _ => panic!(
-                    "Unexpected type after roundtrip for {}: {:?}",
-                    name, read_back
-                ),
+                _ => {
+                    vortex_panic!("Unexpected type after roundtrip for {name}: {read_back:?}")
+                }
             }
         }
 
@@ -492,14 +490,12 @@ mod tests {
                 InnerScalarValue::Primitive(PValue::I64(v)) => {
                     assert_eq!(
                         *v, expected,
-                        "ScalarValue {} value not preserved: expected {}, got {}",
-                        name, expected, v
+                        "ScalarValue {name} value not preserved: expected {expected}, got {v}"
                     );
                 }
-                _ => panic!(
-                    "Unexpected type after roundtrip for {}: {:?}",
-                    name, read_back
-                ),
+                _ => {
+                    vortex_panic!("Unexpected type after roundtrip for {name}: {read_back:?}")
+                }
             }
         }
     }

--- a/vortex-scalar/src/proto.rs
+++ b/vortex-scalar/src/proto.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use num_traits::ToBytes;
 use vortex_buffer::{BufferString, ByteBuffer};
-use vortex_dtype::{DType, PType, half::f16};
-use vortex_error::{VortexError, vortex_bail, vortex_err};
+use vortex_dtype::DType;
+use vortex_error::{VortexError, vortex_err};
 use vortex_proto::scalar as pb;
 use vortex_proto::scalar::ListValue;
 use vortex_proto::scalar::scalar_value::Kind;
@@ -124,25 +124,7 @@ impl TryFrom<&pb::Scalar> for Scalar {
                 .ok_or_else(|| vortex_err!(InvalidSerde: "Scalar missing value"))?,
         )?;
 
-        let value = if matches!(dtype, DType::Primitive(PType::F16, _)) {
-            let pvalue = value
-                .as_pvalue()?
-                .ok_or_else(|| vortex_err!("Invalid F16 value: {value:?}"))?;
-            let f16_value =
-                match pvalue {
-                    PValue::U64(v) => f16::from_bits(u16::try_from(v).map_err(|_| {
-                        vortex_err!("F16 serialized as u64, value out of range: {v}")
-                    })?),
-                    PValue::F16(v) => v,
-                    _ => vortex_bail!("Invalid F16 value: {value:?}"),
-                };
-
-            ScalarValue(InnerScalarValue::Primitive(PValue::F16(f16_value)))
-        } else {
-            value
-        };
-
-        Ok(Self { dtype, value })
+        Ok(Scalar::new(dtype, value))
     }
 }
 
@@ -190,7 +172,7 @@ mod tests {
     use vortex_proto::scalar as pb;
 
     use super::*;
-    use crate::{InnerScalarValue, PValue, Scalar, ScalarValue, i256};
+    use crate::{InnerScalarValue, Scalar, ScalarValue, i256};
 
     fn round_trip(scalar: Scalar) {
         assert_eq!(
@@ -257,12 +239,7 @@ mod tests {
 
     #[test]
     fn test_f16() {
-        round_trip(Scalar::new(
-            DType::Primitive(PType::F16, Nullability::Nullable),
-            ScalarValue(InnerScalarValue::Primitive(PValue::F16(f16::from_f32(
-                0.42,
-            )))),
-        ));
+        round_trip(Scalar::primitive(f16::from_f32(0.42), Nullability::Nullable));
     }
 
     #[test]

--- a/vortex-scalar/src/proto.rs
+++ b/vortex-scalar/src/proto.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 
 use num_traits::ToBytes;
 use vortex_buffer::{BufferString, ByteBuffer};
-use vortex_dtype::{DType, half::f16};
+use vortex_dtype::DType;
+use vortex_dtype::half::f16;
 use vortex_error::{VortexError, vortex_err};
 use vortex_proto::scalar as pb;
 use vortex_proto::scalar::ListValue;
@@ -319,5 +320,187 @@ mod tests {
             scalar,
             Scalar::new(scalar.dtype().clone(), scalar_read_back)
         );
+    }
+
+    #[test]
+    fn test_scalar_value_direct_roundtrip_f16() {
+        // Test that ScalarValue with f16 roundtrips correctly without going through Scalar
+        let f16_values = vec![
+            f16::from_f32(0.0),
+            f16::from_f32(1.0),
+            f16::from_f32(-1.0),
+            f16::from_f32(0.42),
+            f16::from_f32(5.722046e-6),
+            f16::from_f32(std::f32::consts::PI),
+            f16::INFINITY,
+            f16::NEG_INFINITY,
+            f16::NAN,
+        ];
+
+        for f16_val in f16_values {
+            let scalar_value = ScalarValue(InnerScalarValue::Primitive(PValue::F16(f16_val)));
+            let written = scalar_value.to_protobytes::<Vec<u8>>();
+            let read_back = ScalarValue::from_protobytes(&written).unwrap();
+
+            match (&scalar_value.0, &read_back.0) {
+                (
+                    InnerScalarValue::Primitive(PValue::F16(original)),
+                    InnerScalarValue::Primitive(PValue::F16(roundtripped)),
+                ) => {
+                    if original.is_nan() && roundtripped.is_nan() {
+                        // NaN values are equal for our purposes
+                        continue;
+                    }
+                    assert_eq!(
+                        original, roundtripped,
+                        "F16 value {} did not roundtrip correctly",
+                        original
+                    );
+                }
+                _ => panic!(
+                    "Expected f16 primitive values, got {:?} and {:?}",
+                    scalar_value, read_back
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn test_scalar_value_direct_roundtrip_preserves_values() {
+        // Test that ScalarValue roundtripping preserves values (but not necessarily exact types)
+        // Note: Proto encoding consolidates integer types (u8/u16/u32 → u64, i8/i16/i32 → i64)
+
+        // Test cases that should roundtrip exactly
+        let exact_roundtrip_cases = vec![
+            ("null", ScalarValue(InnerScalarValue::Null)),
+            ("bool_true", ScalarValue(InnerScalarValue::Bool(true))),
+            ("bool_false", ScalarValue(InnerScalarValue::Bool(false))),
+            (
+                "u64",
+                ScalarValue(InnerScalarValue::Primitive(PValue::U64(
+                    18446744073709551615,
+                ))),
+            ),
+            (
+                "i64",
+                ScalarValue(InnerScalarValue::Primitive(PValue::I64(
+                    -9223372036854775808,
+                ))),
+            ),
+            (
+                "f32",
+                ScalarValue(InnerScalarValue::Primitive(PValue::F32(
+                    std::f32::consts::E,
+                ))),
+            ),
+            (
+                "f64",
+                ScalarValue(InnerScalarValue::Primitive(PValue::F64(
+                    std::f64::consts::PI,
+                ))),
+            ),
+            (
+                "string",
+                ScalarValue(InnerScalarValue::BufferString(Arc::new(
+                    BufferString::from("test"),
+                ))),
+            ),
+            (
+                "bytes",
+                ScalarValue(InnerScalarValue::Buffer(Arc::new(
+                    vec![1, 2, 3, 4, 5].into(),
+                ))),
+            ),
+        ];
+
+        for (name, value) in exact_roundtrip_cases {
+            let written = value.to_protobytes::<Vec<u8>>();
+            let read_back = ScalarValue::from_protobytes(&written).unwrap();
+
+            let original_debug = format!("{:?}", value);
+            let roundtrip_debug = format!("{:?}", read_back);
+            assert_eq!(
+                original_debug, roundtrip_debug,
+                "ScalarValue {} did not roundtrip exactly",
+                name
+            );
+        }
+
+        // Test cases where type changes but value is preserved
+        // Unsigned integers consolidate to U64
+        let unsigned_cases = vec![
+            (
+                "u8",
+                ScalarValue(InnerScalarValue::Primitive(PValue::U8(255))),
+                255u64,
+            ),
+            (
+                "u16",
+                ScalarValue(InnerScalarValue::Primitive(PValue::U16(65535))),
+                65535u64,
+            ),
+            (
+                "u32",
+                ScalarValue(InnerScalarValue::Primitive(PValue::U32(4294967295))),
+                4294967295u64,
+            ),
+        ];
+
+        for (name, value, expected) in unsigned_cases {
+            let written = value.to_protobytes::<Vec<u8>>();
+            let read_back = ScalarValue::from_protobytes(&written).unwrap();
+
+            match &read_back.0 {
+                InnerScalarValue::Primitive(PValue::U64(v)) => {
+                    assert_eq!(
+                        *v, expected,
+                        "ScalarValue {} value not preserved: expected {}, got {}",
+                        name, expected, v
+                    );
+                }
+                _ => panic!(
+                    "Unexpected type after roundtrip for {}: {:?}",
+                    name, read_back
+                ),
+            }
+        }
+
+        // Signed integers consolidate to I64
+        let signed_cases = vec![
+            (
+                "i8",
+                ScalarValue(InnerScalarValue::Primitive(PValue::I8(-128))),
+                -128i64,
+            ),
+            (
+                "i16",
+                ScalarValue(InnerScalarValue::Primitive(PValue::I16(-32768))),
+                -32768i64,
+            ),
+            (
+                "i32",
+                ScalarValue(InnerScalarValue::Primitive(PValue::I32(-2147483648))),
+                -2147483648i64,
+            ),
+        ];
+
+        for (name, value, expected) in signed_cases {
+            let written = value.to_protobytes::<Vec<u8>>();
+            let read_back = ScalarValue::from_protobytes(&written).unwrap();
+
+            match &read_back.0 {
+                InnerScalarValue::Primitive(PValue::I64(v)) => {
+                    assert_eq!(
+                        *v, expected,
+                        "ScalarValue {} value not preserved: expected {}, got {}",
+                        name, expected, v
+                    );
+                }
+                _ => panic!(
+                    "Unexpected type after roundtrip for {}: {:?}",
+                    name, read_back
+                ),
+            }
+        }
     }
 }

--- a/vortex-scalar/src/proto.rs
+++ b/vortex-scalar/src/proto.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use num_traits::ToBytes;
 use vortex_buffer::{BufferString, ByteBuffer};
-use vortex_dtype::DType;
-use vortex_error::{VortexError, vortex_err};
+use vortex_dtype::{DType, PType, half::f16};
+use vortex_error::{VortexError, vortex_bail, vortex_err};
 use vortex_proto::scalar as pb;
 use vortex_proto::scalar::ListValue;
 use vortex_proto::scalar::scalar_value::Kind;
@@ -124,6 +124,24 @@ impl TryFrom<&pb::Scalar> for Scalar {
                 .ok_or_else(|| vortex_err!(InvalidSerde: "Scalar missing value"))?,
         )?;
 
+        let value = if matches!(dtype, DType::Primitive(PType::F16, _)) {
+            let pvalue = value
+                .as_pvalue()?
+                .ok_or_else(|| vortex_err!("Invalid F16 value: {value:?}"))?;
+            let f16_value =
+                match pvalue {
+                    PValue::U64(v) => f16::from_bits(u16::try_from(v).map_err(|_| {
+                        vortex_err!("F16 serialized as u64, value out of range: {v}")
+                    })?),
+                    PValue::F16(v) => v,
+                    _ => vortex_bail!("Invalid F16 value: {value:?}"),
+                };
+
+            ScalarValue(InnerScalarValue::Primitive(PValue::F16(f16_value)))
+        } else {
+            value
+        };
+
         Ok(Self { dtype, value })
     }
 }
@@ -162,16 +180,17 @@ impl TryFrom<&pb::ScalarValue> for ScalarValue {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::sync::Arc;
 
+    use rstest::rstest;
     use vortex_buffer::BufferString;
-    use vortex_dtype::PType::{self, I32};
     use vortex_dtype::half::f16;
-    use vortex_dtype::{DType, Nullability};
+    use vortex_dtype::{DType, DecimalDType, FieldDType, Nullability, PType, StructFields};
     use vortex_proto::scalar as pb;
 
-    use crate::{InnerScalarValue, PValue, Scalar, ScalarValue};
+    use super::*;
+    use crate::{InnerScalarValue, PValue, Scalar, ScalarValue, i256};
 
     fn round_trip(scalar: Scalar) {
         assert_eq!(
@@ -196,7 +215,7 @@ mod test {
     #[test]
     fn test_primitive() {
         round_trip(Scalar::new(
-            DType::Primitive(I32, Nullability::Nullable),
+            DType::Primitive(PType::I32, Nullability::Nullable),
             ScalarValue(InnerScalarValue::Primitive(42i32.into())),
         ));
     }
@@ -223,7 +242,7 @@ mod test {
     fn test_list() {
         round_trip(Scalar::new(
             DType::List(
-                Arc::new(DType::Primitive(I32, Nullability::Nullable)),
+                Arc::new(DType::Primitive(PType::I32, Nullability::Nullable)),
                 Nullability::Nullable,
             ),
             ScalarValue(InnerScalarValue::List(
@@ -263,16 +282,6 @@ mod test {
             ScalarValue(InnerScalarValue::Primitive(i8::MAX.into())),
         ));
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use half::f16;
-    use rstest::rstest;
-    use vortex_dtype::{DType, DecimalDType, FieldDType, Nullability, PType, StructFields, half};
-
-    use super::*;
-    use crate::{Scalar, i256};
 
     #[rstest]
     #[case(Scalar::binary(ByteBuffer::copy_from(b"hello"), Nullability::NonNullable))]

--- a/vortex-scalar/src/proto.rs
+++ b/vortex-scalar/src/proto.rs
@@ -324,6 +324,29 @@ mod tests {
     }
 
     #[test]
+    fn test_backcompat_f16_serialized_as_u64() {
+        // Note that this is a backwards compatibility test for poor design in the previous implementation.
+        // Previously, f16 ScalarValues were serialized as `pb::ScalarValue::Uint64Value(v.to_bits() as u64)`.
+        let pb_scalar_value = pb::ScalarValue {
+            kind: Some(Kind::Uint64Value(f16::from_f32(0.42).to_bits() as u64)),
+        };
+        let scalar_value = ScalarValue::try_from(&pb_scalar_value).unwrap();
+        assert_eq!(
+            scalar_value.as_pvalue().unwrap(),
+            Some(PValue::U64(14008u64))
+        );
+
+        let scalar = Scalar::new(
+            DType::Primitive(PType::F16, Nullability::Nullable),
+            scalar_value,
+        );
+        assert_eq!(
+            scalar.value.as_pvalue().unwrap().unwrap(),
+            PValue::F16(f16::from_f32(0.42))
+        );
+    }
+
+    #[test]
     fn test_scalar_value_direct_roundtrip_f16() {
         // Test that ScalarValue with f16 roundtrips correctly without going through Scalar
         let f16_values = vec![

--- a/vortex-scalar/src/pvalue.rs
+++ b/vortex-scalar/src/pvalue.rs
@@ -309,16 +309,18 @@ impl TryFrom<PValue> for f64 {
     type Error = VortexError;
 
     fn try_from(value: PValue) -> Result<Self, Self::Error> {
-        // We serialize f64 as u64, but this can also sometimes be narrowed down to u8 if e.g. == 0
         match value {
-            PValue::U8(u) => Some(Self::from_bits(u as u64)),
-            PValue::U16(u) => Some(Self::from_bits(u as u64)),
-            PValue::U32(u) => Some(Self::from_bits(u as u64)),
-            PValue::U64(u) => Some(Self::from_bits(u)),
+            PValue::U8(u) => <Self as NumCast>::from(u),
+            PValue::U16(u) => <Self as NumCast>::from(u),
+            PValue::U32(u) => <Self as NumCast>::from(u),
+            PValue::U64(u) => <Self as NumCast>::from(u),
+            PValue::I8(i) => <Self as NumCast>::from(i),
+            PValue::I16(i) => <Self as NumCast>::from(i),
+            PValue::I32(i) => <Self as NumCast>::from(i),
+            PValue::I64(i) => <Self as NumCast>::from(i),
             PValue::F16(f) => <Self as NumCast>::from(f),
             PValue::F32(f) => <Self as NumCast>::from(f),
             PValue::F64(f) => <Self as NumCast>::from(f),
-            _ => None,
         }
         .ok_or_else(|| vortex_err!("Cannot read primitive value {:?} as {}", value, PType::F64))
     }
@@ -329,17 +331,18 @@ impl TryFrom<PValue> for f32 {
 
     #[allow(clippy::cast_possible_truncation)]
     fn try_from(value: PValue) -> Result<Self, Self::Error> {
-        // We serialize f32 as u32, but this can also sometimes be narrowed down to u8 if e.g. == 0
         match value {
-            PValue::U8(u) => Some(Self::from_bits(u as u32)),
-            PValue::U16(u) => Some(Self::from_bits(u as u32)),
-            PValue::U32(u) => Some(Self::from_bits(u)),
-            // We assume that the value was created from a valid f16 and only changed in serialization
-            PValue::U64(u) => <Self as NumCast>::from(Self::from_bits(u as u32)),
+            PValue::U8(u) => <Self as NumCast>::from(u),
+            PValue::U16(u) => <Self as NumCast>::from(u),
+            PValue::U32(u) => <Self as NumCast>::from(u),
+            PValue::U64(u) => <Self as NumCast>::from(u),
+            PValue::I8(i) => <Self as NumCast>::from(i),
+            PValue::I16(i) => <Self as NumCast>::from(i),
+            PValue::I32(i) => <Self as NumCast>::from(i),
+            PValue::I64(i) => <Self as NumCast>::from(i),
             PValue::F16(f) => <Self as NumCast>::from(f),
             PValue::F32(f) => <Self as NumCast>::from(f),
             PValue::F64(f) => <Self as NumCast>::from(f),
-            _ => None,
         }
         .ok_or_else(|| vortex_err!("Cannot read primitive value {:?} as {}", value, PType::F32))
     }
@@ -350,17 +353,18 @@ impl TryFrom<PValue> for f16 {
 
     #[allow(clippy::cast_possible_truncation)]
     fn try_from(value: PValue) -> Result<Self, Self::Error> {
-        // We serialize f16 as u16, but this can also sometimes be narrowed down to u8 if e.g. == 0
         match value {
-            PValue::U8(u) => Some(Self::from_bits(u as u16)),
-            PValue::U16(u) => Some(Self::from_bits(u)),
-            // We assume that the value was created from a valid f16 and only changed in serialization
-            PValue::U32(u) => Some(Self::from_bits(u as u16)),
-            PValue::U64(u) => Some(Self::from_bits(u as u16)),
-            PValue::F16(u) => Some(u),
+            PValue::U8(u) => <Self as NumCast>::from(u),
+            PValue::U16(u) => <Self as NumCast>::from(u),
+            PValue::U32(u) => <Self as NumCast>::from(u),
+            PValue::U64(u) => <Self as NumCast>::from(u),
+            PValue::I8(i) => <Self as NumCast>::from(i),
+            PValue::I16(i) => <Self as NumCast>::from(i),
+            PValue::I32(i) => <Self as NumCast>::from(i),
+            PValue::I64(i) => <Self as NumCast>::from(i),
+            PValue::F16(f) => Some(f),
             PValue::F32(f) => <Self as NumCast>::from(f),
             PValue::F64(f) => <Self as NumCast>::from(f),
-            _ => None,
         }
         .ok_or_else(|| vortex_err!("Cannot read primitive value {:?} as {}", value, PType::F16))
     }

--- a/vortex-scalar/src/struct_.rs
+++ b/vortex-scalar/src/struct_.rs
@@ -128,10 +128,10 @@ impl<'a> StructScalar<'a> {
         let fields = self
             .fields
             .vortex_expect("Can't take field out of null struct scalar");
-        Some(Scalar {
-            dtype: self.struct_fields().field_by_index(idx)?,
-            value: fields[idx].clone(),
-        })
+        Some(Scalar::new(
+            self.struct_fields().field_by_index(idx)?,
+            fields[idx].clone(),
+        ))
     }
 
     /// Returns the fields of the struct scalar, or None if the scalar is null.
@@ -175,12 +175,12 @@ impl<'a> StructScalar<'a> {
                 .iter()
                 .enumerate()
                 .map(|(i, f)| {
-                    Scalar {
-                        dtype: own_st
+                    Scalar::new(
+                        own_st
                             .field_by_index(i)
                             .vortex_expect("Iterating over scalar fields"),
-                        value: f.clone(),
-                    }
+                        f.clone(),
+                    )
                     .cast(
                         &st.field_by_index(i)
                             .vortex_expect("Iterating over scalar fields"),
@@ -188,10 +188,10 @@ impl<'a> StructScalar<'a> {
                     .map(|s| s.value)
                 })
                 .collect::<VortexResult<Vec<_>>>()?;
-            Ok(Scalar {
-                dtype: dtype.clone(),
-                value: ScalarValue(InnerScalarValue::List(fields.into())),
-            })
+            Ok(Scalar::new(
+                dtype.clone(),
+                ScalarValue(InnerScalarValue::List(fields.into())),
+            ))
         } else {
             Ok(Scalar::null(dtype.clone()))
         }
@@ -257,16 +257,16 @@ impl Scalar {
             }
         }
 
-        Self {
+        Self::new(
             dtype,
-            value: ScalarValue(InnerScalarValue::List(
+            ScalarValue(InnerScalarValue::List(
                 children
                     .into_iter()
                     .map(|x| x.into_value())
                     .collect_vec()
                     .into(),
             )),
-        }
+        )
     }
 }
 


### PR DESCRIPTION
⏺ Summary of Changes

  The diff shows comprehensive changes to fix scalar casting bugs and ensure backwards compatibility for serialized scalar values. Here are the
  key changes:

  1. Core Bug Fix: Floating-Point Conversion (vortex-scalar/src/pvalue.rs)

  - Fixed critical bug where u64 to f64 conversion was using bit reinterpretation (f64::from_bits()) instead of numeric conversion
  - Changed to use NumCast::from() for proper numeric conversions

  2. Type Coercion System (vortex-scalar/src/lib.rs)

  - Added coerce_value() method in Scalar::new() to handle backwards compatibility
  - Specifically coerces f16 values stored as u64 (for backwards compatibility with serialized data)
  - Includes recursive coercion for structs and lists containing f16 fields
  - Protected against overflow (only coerces u64 to f16 if value ≤ u16::MAX)

  3. Protobuf Support for f16 (vortex-proto/proto/scalar.proto)

  - Added dedicated f16_value field to protobuf schema (field 10)
  - Updated serialization to use this dedicated field instead of storing f16 as u64

  4. Consistent Scalar Construction

  - Updated all direct Scalar { dtype, value } constructions to use Scalar::new()
  - Ensures coercion logic is always applied
  - Changed in:
    - bool.rs: into_scalar(), bool(), From<bool>
    - primitive.rs: primitive_value(), From<$T> for Scalar
    - struct_.rs: field_by_idx(), cast(), struct_()
    - list.rs: element(), list(), list_empty()

  5. Test Coverage (vortex-scalar/src/lib.rs and proto.rs)

  - Fixed test_canonicalize_scalar_values to create f16 values properly
  - Added comprehensive coercion tests:
    - f16 coercion from u64
    - No coercion for other type combinations
    - Struct field coercion
    - List element coercion
    - Overflow protection
  - Added ScalarValue protobuf roundtrip tests:
    - Direct f16 roundtripping
    - Value preservation for all primitive types
    - Handling of type consolidation (u8/u16/u32 → u64, i8/i16/i32 → i64)

  6. Key Design Decision

  - Only f16 from u64 is coerced (minimal approach for backwards compatibility)
  - Other floating-point types (f32, f64) are NOT coerced
  - This preserves backwards compatibility while fixing the root cause

  The changes ensure that:
  1. Scalar casting now uses numeric conversion instead of bit reinterpretation
  2. Old serialized f16 values (stored as u64) are properly handled
  3. All scalar constructions go through the coercion logic
  4. Comprehensive tests verify the behavior