### PR TITLE
feat: Require expressions to be `Eq`

### DIFF
--- a/vortex-expr/src/vtable.rs
+++ b/vortex-expr/src/vtable.rs
@@ -21,6 +21,7 @@ pub trait VTable: 'static + Sized + Send + Sync + Debug {
         + Debug
         + Display
         + PartialEq
+        + Eq
         + Hash
         + Deref<Target = dyn VortexExpr>
         + IntoExpr


### PR DESCRIPTION
The main benefit (at least for me here) is being able to store generic expressions in a `HashSet`, which requires `Eq + Hash`.