### PR TITLE
fix: pr benchmark results

### DIFF
--- a/bench-vortex/src/datasets/mod.rs
+++ b/bench-vortex/src/datasets/mod.rs
@@ -39,12 +39,12 @@ pub enum BenchmarkDataset {
 }
 
 impl BenchmarkDataset {
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> String {
         match self {
-            BenchmarkDataset::TpcH { .. } => "tpch",
-            BenchmarkDataset::TpcDS { .. } => "tpcds",
-            BenchmarkDataset::ClickBench { .. } => "clickbench",
-            BenchmarkDataset::PublicBi { .. } => "public-bi",
+            BenchmarkDataset::TpcH { scale_factor } => format!("tpch_sf{scale_factor}"),
+            BenchmarkDataset::TpcDS { scale_factor } => format!("tpcds_sf{scale_factor}"),
+            BenchmarkDataset::ClickBench { .. } => "clickbench".to_string(),
+            BenchmarkDataset::PublicBi { .. } => "public-bi".to_string(),
         }
     }
 }

--- a/scripts/compare-benchmark-jsons.py
+++ b/scripts/compare-benchmark-jsons.py
@@ -16,6 +16,10 @@ import pandas as pd
 base = pd.read_json(sys.argv[1], lines=True)
 pr = pd.read_json(sys.argv[2], lines=True)
 
+# Filter duplicate entries which can result from nightly
+# runs if the commit is identical to the base commit of the PR.
+base = base.drop_duplicates(subset=["name", "storage"], keep="last")
+
 base_commit_id = set(base["commit_id"].unique())
 pr_commit_id = set(pr["commit_id"].unique())
 


### PR DESCRIPTION
To disambiguate different TPC-H runs, include the scale factor in the dataset name. In addition, we filter duplicate entries which can result from nightly runs if the commit is identical to the base commit of the PR to avoid duplicate result rows.
