### PR TITLE
chore: clippy allow unreachable function

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -3,11 +3,11 @@ allow-expect-in-tests = true
 allow-unwrap-in-tests = true
 single-char-binding-names-threshold = 2
 disallowed-types = [
-	{ path = "std::collections::HashMap", reason = "Use the HashMap in vortex_utils::aliases for better performance" }, 
+	{ path = "std::collections::HashMap", reason = "Use the HashMap in vortex_utils::aliases for better performance" },
 	{ path = "std::collections::HashSet", reason = "Use the HashSet in vortex_utils::aliases for better performance" },
 	{ path = "std::sync::Mutex", reason = "Prefer using parking_lot Mutex for improved ergonomics and performance" },
 	{ path = "std::sync::RwLock", reason = "Prefer using parking_lot RwLock for improved ergonomics and performance" }]
 
 disallowed-methods = [
-    { path = "itertools::Itertools::counts", reason = "It uses the default hasher which is slow for primitives. Just inline the loop for better performance." }
+    { path = "itertools::Itertools::counts", reason = "It uses the default hasher which is slow for primitives. Just inline the loop for better performance.", allow-invalid = true }
 ]


### PR DESCRIPTION
```
warning: `itertools::Itertools::counts` does not refer to a reachable function
  --> vortex/clippy.toml:12:5
   |
12 |     { path = "itertools::Itertools::counts", reason = "It uses the default hasher which is slow for primitives. Just inline the loop for better performance." }
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
```