### PR TITLE
build: Use Create cc to link to libc++

### DIFF
--- a/vortex-duckdb/build.rs
+++ b/vortex-duckdb/build.rs
@@ -216,12 +216,6 @@ fn main() {
         extraced_lib_path.display()
     );
 
-    if env::var("TARGET").unwrap().contains("linux") {
-        println!("cargo:rustc-link-lib=stdc++");
-    } else {
-        println!("cargo:rustc-link-lib=c++");
-    }
-
     // Compile our C++ code that exposes additional DuckDB functionality.
     cc::Build::new()
         .std("c++17")
@@ -236,6 +230,7 @@ fn main() {
         // Unused parameter warnings are disabled as we include DuckDB
         // headers with implementations that have unused parameters.
         .flag("-Wno-unused-parameter")
+        .cpp(true)
         // We include DuckDB headers from the DuckDB extension submodule.
         .include(duckdb_repo.join(format!("duckdb-{}/src/include", DUCKDB_VERSION.as_str())))
         .include("cpp/include")


### PR DESCRIPTION
Rather than manually selecting libstdc++ when the `$TARGET` is "linux", simply set the `cpp(true)` flag when calling `cc::Build` so that it delegates stdlib linking to the compiler which will always yield the correct choice, and also allow for manual override via the `$CXXSTDLIB` environment variable [1].

This fixes the out of the box test suite on Linux

 [1]: https://docs.rs/cc/latest/cc/#c-support