### PR TITLE
struct layout strategy to use channels

### DIFF
--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -122,18 +122,26 @@ impl WriteStrategyBuilder {
             executor.clone(),
         );
 
-        // 1. split columns
-        let struct_ = StructStrategy::new(stats, executor, Default::default());
-
-        // 0. repartition each column to fixed row counts
-        Arc::new(RepartitionStrategy::new(
-            struct_,
+        // 1. repartition each column to fixed row counts
+        let repartition = RepartitionStrategy::new(
+            stats,
             RepartitionWriterOptions {
                 // No minimum block size in bytes
                 block_size_minimum: 0,
                 // Always repartition into 8K row blocks
                 block_len_multiple: ROW_BLOCK_SIZE,
             },
+        );
+
+        // 0. start with splitting columns
+        Arc::new(StructStrategy::new(
+            repartition,
+            executor,
+            // TODO(os): default buffer can hold 128 elements, ideally we repartition first
+            //           so we have some understanding of column sizes. We have to have a buffer
+            //           big enough to hold a total of 2Mb of each column in memory, else buffered
+            //           writer above won't be able to make progress.
+            Default::default(),
         ))
     }
 }

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -122,18 +122,18 @@ impl WriteStrategyBuilder {
             executor.clone(),
         );
 
-        // 1. repartition each column to fixed row counts
-        let repartition = RepartitionStrategy::new(
-            stats,
+        // 1. split columns
+        let struct_ = StructStrategy::new(stats, executor, Default::default());
+
+        // 0. repartition each column to fixed row counts
+        Arc::new(RepartitionStrategy::new(
+            struct_,
             RepartitionWriterOptions {
                 // No minimum block size in bytes
                 block_size_minimum: 0,
                 // Always repartition into 8K row blocks
                 block_len_multiple: ROW_BLOCK_SIZE,
             },
-        );
-
-        // 0. start with splitting columns
-        Arc::new(StructStrategy::new(repartition, executor))
+        ))
     }
 }

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -134,6 +134,6 @@ impl WriteStrategyBuilder {
         );
 
         // 0. start with splitting columns
-        Arc::new(StructStrategy::new(repartition))
+        Arc::new(StructStrategy::new(repartition, executor))
     }
 }

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -264,7 +264,9 @@ mod tests {
     use crate::layouts::struct_::writer::StructStrategy;
     use crate::segments::{SegmentSource, SequenceWriter, TestSegments};
     use crate::sequence::SequenceId;
-    use crate::{LayoutRef, LayoutStrategy, SequentialStreamAdapter, SequentialStreamExt as _};
+    use crate::{
+        LayoutRef, LayoutStrategy, LocalExecutor, SequentialStreamAdapter, SequentialStreamExt as _,
+    };
 
     #[fixture]
     /// Create a chunked layout with three chunks of primitive arrays.
@@ -272,7 +274,7 @@ mod tests {
         let ctx = ArrayContext::empty();
         let segments = TestSegments::default();
         let sequence_writer = SequenceWriter::new(Box::new(segments.clone()));
-        let strategy = StructStrategy::new(FlatLayoutStrategy::default());
+        let strategy = StructStrategy::new(FlatLayoutStrategy::default(), Arc::new(LocalExecutor));
         let layout = block_on(
             strategy.write_stream(
                 &ctx,

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -274,7 +274,11 @@ mod tests {
         let ctx = ArrayContext::empty();
         let segments = TestSegments::default();
         let sequence_writer = SequenceWriter::new(Box::new(segments.clone()));
-        let strategy = StructStrategy::new(FlatLayoutStrategy::default(), Arc::new(LocalExecutor));
+        let strategy = StructStrategy::new(
+            FlatLayoutStrategy::default(),
+            Arc::new(LocalExecutor),
+            Default::default(),
+        );
         let layout = block_on(
             strategy.write_stream(
                 &ctx,

--- a/vortex-layout/src/layouts/struct_/writer.rs
+++ b/vortex-layout/src/layouts/struct_/writer.rs
@@ -45,7 +45,7 @@ pub struct StructStrategyOptions {
 
 impl Default for StructStrategyOptions {
     fn default() -> Self {
-        Self { buffer_size: 128 }
+        Self { buffer_size: 512 }
     }
 }
 

--- a/vortex-layout/src/layouts/struct_/writer.rs
+++ b/vortex-layout/src/layouts/struct_/writer.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures::channel::mpsc;
 use futures::future::try_join_all;
-use futures::{FutureExt, StreamExt, TryStreamExt, try_join};
+use futures::{FutureExt, SinkExt, StreamExt, TryStreamExt, try_join};
 use itertools::Itertools;
 use vortex_array::{Array, ArrayContext, ToCanonical};
 use vortex_error::{VortexError, VortexExpect as _, VortexResult, vortex_bail};
@@ -22,6 +22,7 @@ use crate::{
 pub struct StructStrategy<S> {
     child: S,
     executor: Arc<dyn TaskExecutor>,
+    options: StructStrategyOptions,
 }
 
 /// A [`LayoutStrategy`] that splits a StructArray batch into child layout writers
@@ -29,8 +30,22 @@ impl<S> StructStrategy<S>
 where
     S: LayoutStrategy,
 {
-    pub fn new(child: S, executor: Arc<dyn TaskExecutor>) -> Self {
-        Self { child, executor }
+    pub fn new(child: S, executor: Arc<dyn TaskExecutor>, options: StructStrategyOptions) -> Self {
+        Self {
+            child,
+            executor,
+            options,
+        }
+    }
+}
+
+pub struct StructStrategyOptions {
+    buffer_size: usize,
+}
+
+impl Default for StructStrategyOptions {
+    fn default() -> Self {
+        Self { buffer_size: 128 }
     }
 }
 
@@ -92,7 +107,7 @@ where
         });
 
         let (mut column_txs, column_rxs): (Vec<_>, Vec<_>) = (0..struct_dtype.nfields())
-            .map(|_| mpsc::unbounded())
+            .map(|_| mpsc::channel(self.options.buffer_size))
             .unzip();
 
         let produce_handle = self.executor.spawn(
@@ -101,13 +116,13 @@ where
                     match columns_vec_stream.next().await {
                         Some(Ok(vec_columns)) => {
                             for (tx, chunk) in column_txs.iter_mut().zip_eq(vec_columns) {
-                                let _ = tx.unbounded_send(VortexResult::Ok(chunk));
+                                let _ = tx.send(VortexResult::Ok(chunk)).await;
                             }
                         }
                         Some(Err(err)) => {
                             let shared: Arc<VortexError> = Arc::new(err);
                             for tx in column_txs.iter_mut() {
-                                let _ = tx.unbounded_send(Err(shared.clone().into()));
+                                let _ = tx.send(Err(shared.clone().into())).await;
                             }
                         }
                         None => break,
@@ -163,7 +178,11 @@ mod tests {
     #[test]
     #[should_panic]
     fn fails_on_duplicate_field() {
-        let strategy = StructStrategy::new(FlatLayoutStrategy::default(), Arc::new(LocalExecutor));
+        let strategy = StructStrategy::new(
+            FlatLayoutStrategy::default(),
+            Arc::new(LocalExecutor),
+            Default::default(),
+        );
         block_on(
             strategy.write_stream(
                 &ArrayContext::empty(),
@@ -188,7 +207,11 @@ mod tests {
 
     #[test]
     fn fails_on_top_level_nulls() {
-        let strategy = StructStrategy::new(FlatLayoutStrategy::default(), Arc::new(LocalExecutor));
+        let strategy = StructStrategy::new(
+            FlatLayoutStrategy::default(),
+            Arc::new(LocalExecutor),
+            Default::default(),
+        );
         let res = block_on(
             strategy.write_stream(
                 &ArrayContext::empty(),
@@ -227,7 +250,11 @@ mod tests {
 
     #[test]
     fn write_empty_field_struct_array() {
-        let strategy = StructStrategy::new(FlatLayoutStrategy::default(), Arc::new(LocalExecutor));
+        let strategy = StructStrategy::new(
+            FlatLayoutStrategy::default(),
+            Arc::new(LocalExecutor),
+            Default::default(),
+        );
         let res = block_on(
             strategy.write_stream(
                 &ArrayContext::empty(),

--- a/vortex-layout/src/layouts/struct_/writer.rs
+++ b/vortex-layout/src/layouts/struct_/writer.rs
@@ -1,18 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::collections::VecDeque;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll, Waker};
 
 use async_trait::async_trait;
+use futures::channel::mpsc;
 use futures::future::try_join_all;
-use futures::{FutureExt, Stream, StreamExt, TryStreamExt};
+use futures::{FutureExt, StreamExt, TryStreamExt, try_join};
 use itertools::Itertools;
-use parking_lot::Mutex;
 use vortex_array::{Array, ArrayContext, ToCanonical};
-use vortex_error::{VortexExpect as _, VortexResult, vortex_bail};
+use vortex_error::{VortexError, VortexExpect as _, VortexResult, vortex_bail};
 use vortex_utils::aliases::DefaultHashBuilder;
 use vortex_utils::aliases::hash_set::HashSet;
 
@@ -20,11 +17,11 @@ use crate::layouts::struct_::StructLayout;
 use crate::segments::SequenceWriter;
 use crate::{
     IntoLayout as _, LayoutRef, LayoutStrategy, SendableSequentialStream, SequentialStreamAdapter,
-    SequentialStreamExt,
+    SequentialStreamExt, TaskExecutor, TaskExecutorExt,
 };
-
 pub struct StructStrategy<S> {
     child: S,
+    executor: Arc<dyn TaskExecutor>,
 }
 
 /// A [`LayoutStrategy`] that splits a StructArray batch into child layout writers
@@ -32,8 +29,8 @@ impl<S> StructStrategy<S>
 where
     S: LayoutStrategy,
 {
-    pub fn new(child: S) -> Self {
-        Self { child }
+    pub fn new(child: S, executor: Arc<dyn TaskExecutor>) -> Self {
+        Self { child, executor }
     }
 }
 
@@ -49,8 +46,8 @@ where
         stream: SendableSequentialStream,
     ) -> VortexResult<LayoutRef> {
         let dtype = stream.dtype().clone();
+
         let Some(struct_dtype) = stream.dtype().as_struct().cloned() else {
-            // nothing we can do if dtype is not struct
             return self.child.write_stream(ctx, sequence_writer, stream).await;
         };
         if HashSet::<_, DefaultHashBuilder>::from_iter(struct_dtype.names().iter()).len()
@@ -67,7 +64,7 @@ where
             Ok((sequence_id, chunk))
         });
 
-        // There are now fields so this is the layout leaf
+        // There are no fields so this is the layout leaf
         if struct_dtype.nfields() == 0 {
             let row_count = stream
                 .try_fold(
@@ -79,7 +76,7 @@ where
         }
 
         // stream<struct_chunk> -> stream<vec<column_chunk>>
-        let columns_vec_stream = stream.map(|chunk| {
+        let mut columns_vec_stream = stream.map(|chunk| {
             let (sequence_id, chunk) = chunk?;
             let mut sequence_pointer = sequence_id.descend();
             let struct_chunk = chunk.to_struct()?;
@@ -94,8 +91,32 @@ where
             Ok(columns)
         });
 
-        // stream<vec<column_chunk>> -> vec<stream<column_chunk>>
-        let column_streams = transpose_stream(columns_vec_stream, struct_dtype.nfields());
+        let (mut column_txs, column_rxs): (Vec<_>, Vec<_>) = (0..struct_dtype.nfields())
+            .map(|_| mpsc::unbounded())
+            .unzip();
+
+        let produce_handle = self.executor.spawn(
+            async move {
+                loop {
+                    match columns_vec_stream.next().await {
+                        Some(Ok(vec_columns)) => {
+                            for (tx, chunk) in column_txs.iter_mut().zip_eq(vec_columns) {
+                                let _ = tx.unbounded_send(VortexResult::Ok(chunk));
+                            }
+                        }
+                        Some(Err(err)) => {
+                            let shared: Arc<VortexError> = Arc::new(err);
+                            for tx in column_txs.iter_mut() {
+                                let _ = tx.unbounded_send(Err(shared.clone().into()));
+                            }
+                        }
+                        None => break,
+                    }
+                }
+                Ok(())
+            }
+            .boxed(),
+        );
 
         let column_dtypes = (0..struct_dtype.nfields()).map(move |idx| {
             struct_dtype
@@ -104,7 +125,7 @@ where
         });
 
         let layout_futures: Vec<_> = column_dtypes
-            .zip_eq(column_streams)
+            .zip_eq(column_rxs)
             .map(move |(dtype, stream)| {
                 let column_stream = SequentialStreamAdapter::new(dtype, stream).sendable();
                 self.child
@@ -113,7 +134,7 @@ where
             })
             .collect();
 
-        let column_layouts = try_join_all(layout_futures).await?;
+        let (column_layouts, _) = try_join!(try_join_all(layout_futures), produce_handle)?;
         // TODO(os): transposed stream could count row counts as well,
         // This must hold though, all columns must have the same row count of the struct layout
         let row_count = column_layouts.first().map(|l| l.row_count()).unwrap_or(0);
@@ -121,104 +142,10 @@ where
     }
 }
 
-fn transpose_stream<T, S>(stream: S, elements: usize) -> Vec<impl Stream<Item = VortexResult<T>>>
-where
-    S: Stream<Item = VortexResult<Vec<T>>> + Unpin,
-    T: Unpin + 'static,
-{
-    let state = Arc::new(Mutex::new(TransposeState {
-        upstream: stream,
-        buffers: (0..elements).map(|_| VecDeque::new()).collect(),
-        wakers: Vec::new(),
-        exhausted: false,
-    }));
-    (0..elements)
-        .map(|index| TransposedStream {
-            index,
-            state: state.clone(),
-        })
-        .collect()
-}
-
-struct TransposeState<T, S>
-where
-    S: Stream<Item = VortexResult<Vec<T>>> + Unpin,
-    T: Unpin,
-{
-    upstream: S,
-    // TODO(os): make these buffers bounded so transposed streams can not run ahead unbounded
-    buffers: Vec<VecDeque<VortexResult<T>>>,
-    wakers: Vec<Waker>,
-    exhausted: bool,
-}
-
-struct TransposedStream<T, S>
-where
-    S: Stream<Item = VortexResult<Vec<T>>> + Unpin,
-    T: Unpin,
-{
-    index: usize,
-    state: Arc<Mutex<TransposeState<T, S>>>,
-}
-
-impl<T, S> Stream for TransposedStream<T, S>
-where
-    S: Stream<Item = VortexResult<Vec<T>>> + Unpin,
-    T: Unpin,
-{
-    type Item = VortexResult<T>;
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let mut guard = self.state.lock();
-        if let Some(item) = guard.buffers[self.index].pop_front() {
-            return Poll::Ready(Some(item));
-        }
-
-        // if we know upstream is exhausted we can skip polling it again.
-        if guard.exhausted {
-            return Poll::Ready(None);
-        }
-
-        let poll_result = match Pin::new(&mut guard.upstream).poll_next(cx) {
-            Poll::Pending => {
-                guard.wakers.push(cx.waker().clone());
-                Poll::Pending
-            }
-            Poll::Ready(None) => {
-                guard.exhausted = true;
-                Poll::Ready(None)
-            }
-            Poll::Ready(Some(Ok(vec_t))) => {
-                for (t, buffer) in vec_t.into_iter().zip_eq(guard.buffers.iter_mut()) {
-                    buffer.push_back(Ok(t));
-                }
-                let item = guard.buffers[self.index]
-                    .pop_front()
-                    .vortex_expect("just pushed");
-                Poll::Ready(Some(item))
-            }
-            Poll::Ready(Some(Err(err))) => {
-                let shared_err = Arc::new(err);
-                for buffer in guard.buffers.iter_mut() {
-                    buffer.push_back(Err(shared_err.clone().into()));
-                }
-                Poll::Ready(Some(Err(shared_err.into())))
-            }
-        };
-
-        if matches!(poll_result, Poll::Ready(_)) {
-            let wakers = std::mem::take(&mut guard.wakers);
-
-            drop(guard);
-            for waker in wakers {
-                waker.wake();
-            }
-        }
-        poll_result
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use futures::executor::block_on;
     use futures::stream;
     use vortex_array::arrays::{BoolArray, StructArray};
@@ -231,12 +158,12 @@ mod tests {
     use crate::layouts::struct_::writer::StructStrategy;
     use crate::segments::{SequenceWriter, TestSegments};
     use crate::sequence::SequenceId;
-    use crate::{LayoutStrategy, SequentialStreamAdapter, SequentialStreamExt};
+    use crate::{LayoutStrategy, LocalExecutor, SequentialStreamAdapter, SequentialStreamExt};
 
     #[test]
     #[should_panic]
     fn fails_on_duplicate_field() {
-        let strategy = StructStrategy::new(FlatLayoutStrategy::default());
+        let strategy = StructStrategy::new(FlatLayoutStrategy::default(), Arc::new(LocalExecutor));
         block_on(
             strategy.write_stream(
                 &ArrayContext::empty(),
@@ -261,7 +188,7 @@ mod tests {
 
     #[test]
     fn fails_on_top_level_nulls() {
-        let strategy = StructStrategy::new(FlatLayoutStrategy::default());
+        let strategy = StructStrategy::new(FlatLayoutStrategy::default(), Arc::new(LocalExecutor));
         let res = block_on(
             strategy.write_stream(
                 &ArrayContext::empty(),
@@ -300,7 +227,7 @@ mod tests {
 
     #[test]
     fn write_empty_field_struct_array() {
-        let strategy = StructStrategy::new(FlatLayoutStrategy::default());
+        let strategy = StructStrategy::new(FlatLayoutStrategy::default(), Arc::new(LocalExecutor));
         let res = block_on(
             strategy.write_stream(
                 &ArrayContext::empty(),


### PR DESCRIPTION
Because we now spawn consuming from upstream, and this is the very first strategy in the default vortex strategy, we have to be careful in sizing the channel. If it is too low then the channel won't fit 2Mb of each column, so buffered strategy won't be able to make progress. If it is too high then we increase our memory footprint unnecessarily. 

Previously we were only buffering only the minimum required chunk amount that would unblock the buffered writer, because everything was poll based, now we have to size the channel ourselves