### PR TITLE
Improve BoolArray::from_indices

### DIFF
--- a/vortex-array/src/arrays/bool/array.rs
+++ b/vortex-array/src/arrays/bool/array.rs
@@ -51,7 +51,7 @@ pub struct BoolArray {
 }
 
 impl BoolArray {
-    /// Create a new BoolArray from a set of indices and a length.
+    /// Create a new [`BoolArray`] from a set of indices, a length and a [`Validity`].
     /// All indices must be less than the length.
     pub fn from_indices<I: IntoIterator<Item = usize>>(
         length: usize,
@@ -59,9 +59,10 @@ impl BoolArray {
         validity: Validity,
     ) -> Self {
         let mut buffer = MutableBuffer::new_null(length);
+        let buffer_slice = buffer.as_slice_mut();
         indices
             .into_iter()
-            .for_each(|idx| arrow_buffer::bit_util::set_bit(&mut buffer, idx));
+            .for_each(|idx| arrow_buffer::bit_util::set_bit(buffer_slice, idx));
         Self::new(
             BooleanBufferBuilder::new_from_buffer(buffer, length).finish(),
             validity,


### PR DESCRIPTION
This patch extracts the deref of `MutableBuffer` out of the iterator's `for_each` call. This also improves the function document a little bit.