### PR TITLE
feat: better and more consistent validation in SerdeVTable::build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,7 +896,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -4524,7 +4524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -4557,7 +4557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -4570,7 +4570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",

--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -10,8 +10,9 @@ use vortex_array::vtable::{
 };
 use vortex_array::{Array, ArrayRef, Canonical, EncodingId, EncodingRef, vtable};
 use vortex_dtype::{DType, PType};
-use vortex_error::{VortexResult, vortex_panic};
+use vortex_error::{VortexExpect, VortexResult, vortex_ensure};
 
+use crate::ALPFloat;
 use crate::alp::{Exponents, decompress};
 
 vtable!(ALP);
@@ -51,12 +52,169 @@ pub struct ALPArray {
 pub struct ALPEncoding;
 
 impl ALPArray {
+    fn validate(
+        encoded: &dyn Array,
+        exponents: Exponents,
+        patches: Option<&Patches>,
+    ) -> VortexResult<()> {
+        vortex_ensure!(
+            matches!(
+                encoded.dtype(),
+                DType::Primitive(PType::I32 | PType::I64, _)
+            ),
+            "ALP encoded ints have invalid DType {}",
+            encoded.dtype(),
+        );
+
+        // Validate exponents are in-bounds for the float, and that patches have the proper
+        // length and type.
+        let Exponents { e, f } = exponents;
+        match encoded.dtype().as_ptype() {
+            PType::I32 => {
+                vortex_ensure!(exponents.e <= f32::MAX_EXPONENT, "e out of bounds: {e}");
+                vortex_ensure!(exponents.f <= f32::MAX_EXPONENT, "f out of bounds: {f}");
+                if let Some(patches) = patches {
+                    Self::validate_patches::<f32>(patches, encoded)?;
+                }
+            }
+            PType::I64 => {
+                vortex_ensure!(e <= f64::MAX_EXPONENT, "e out of bounds: {e}");
+                vortex_ensure!(f <= f64::MAX_EXPONENT, "f out of bounds: {f}");
+
+                if let Some(patches) = patches {
+                    Self::validate_patches::<f64>(patches, encoded)?;
+                }
+            }
+            _ => unreachable!(),
+        }
+
+        // Validate patches
+        if let Some(patches) = patches {
+            vortex_ensure!(
+                patches.array_len() == encoded.len(),
+                "patches array_len != encoded len: {} != {}",
+                patches.array_len(),
+                encoded.len()
+            );
+
+            // Verify that the patches DType are of the proper DType.
+        }
+
+        Ok(())
+    }
+
+    /// Validate that any patches provided are valid for the ALPArray.
+    fn validate_patches<T: ALPFloat>(patches: &Patches, encoded: &dyn Array) -> VortexResult<()> {
+        vortex_ensure!(
+            patches.array_len() == encoded.len(),
+            "patches array_len != encoded len: {} != {}",
+            patches.array_len(),
+            encoded.len()
+        );
+
+        let expected_type = DType::Primitive(T::PTYPE, encoded.dtype().nullability());
+        vortex_ensure!(
+            patches.dtype() == &expected_type,
+            "Expected patches type {expected_type}, actual {}",
+            patches.dtype(),
+        );
+
+        Ok(())
+    }
+}
+
+impl ALPArray {
+    /// Build a new `ALPArray` from components, panicking on validation failure.
+    ///
+    /// See [`ALPArray::try_new`] for reference on preconditions that must pass before
+    /// calling this method.
     pub fn new(encoded: ArrayRef, exponents: Exponents, patches: Option<Patches>) -> Self {
+        Self::try_new(encoded, exponents, patches).vortex_expect("ALPArray new")
+    }
+
+    /// Build a new `ALPArray` from components:
+    ///
+    /// * `encoded` contains the ALP-encoded ints. Any null values are replaced with placeholders
+    /// * `exponents` are the ALP exponents, valid range depends on the data type
+    /// * `patches` are any patch values that don't cleanly encode using the ALP conversion function
+    ///
+    /// This method validates the inputs and will return an error if any validation fails.
+    ///
+    /// # Validation
+    ///
+    /// * The `encoded` array must be either `i32` or `i64`
+    ///     * If `i32`, any `patches` must have DType `f32` with same nullability
+    ///     * If `i64`, then `patches`must have DType `f64` with same nullability
+    /// * `exponents` must be in the valid range depending on if the ALPArray is of type `f32` or
+    ///   `f64`.
+    /// * `patches` must have an `array_len` equal to the length of `encoded`
+    ///
+    /// Any failure of these preconditions will result in an error being returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use vortex_alp::{ALPArray, Exponents};
+    /// # use vortex_array::IntoArray;
+    /// # use vortex_buffer::buffer;
+    ///
+    /// // Returns error because buffer has wrong PType.
+    /// let result = ALPArray::try_new(
+    ///     buffer![1i8].into_array(),
+    ///     Exponents { e: 1, f: 1 },
+    ///     None
+    /// );
+    /// assert!(result.is_err());
+    ///
+    /// // Returns error because Exponents are out of bounds for f32
+    /// let result = ALPArray::try_new(
+    ///     buffer![1i32, 2i32].into_array(),
+    ///     Exponents { e: 100, f: 100 },
+    ///     None
+    /// );
+    /// assert!(result.is_err());
+    ///
+    /// // Success!
+    /// let value = ALPArray::try_new(
+    ///     buffer![0i32].into_array(),
+    ///     Exponents { e: 1, f: 1 },
+    ///     None
+    /// ).unwrap();
+    ///
+    /// assert_eq!(value.scalar_at(0), 0f32.into());
+    /// ```
+    pub fn try_new(
+        encoded: ArrayRef,
+        exponents: Exponents,
+        patches: Option<Patches>,
+    ) -> VortexResult<Self> {
+        Self::validate(&encoded, exponents, patches.as_ref())?;
+
         let dtype = match encoded.dtype() {
             DType::Primitive(PType::I32, nullability) => DType::Primitive(PType::F32, *nullability),
             DType::Primitive(PType::I64, nullability) => DType::Primitive(PType::F64, *nullability),
-            d => vortex_panic!(MismatchedTypes: "int32 or int64", d),
+            _ => unreachable!(),
         };
+
+        Ok(Self {
+            dtype,
+            encoded,
+            exponents,
+            patches,
+            stats_set: Default::default(),
+        })
+    }
+
+    /// Build a new `ALPArray` from components without validation.
+    ///
+    /// See [`ALPArray::try_new`] for information about the preconditions that should be checked
+    /// **before** calling this method.
+    pub(crate) fn new_unchecked(
+        encoded: ArrayRef,
+        exponents: Exponents,
+        patches: Option<Patches>,
+        dtype: DType,
+    ) -> Self {
         Self {
             dtype,
             encoded,

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -43,7 +43,12 @@ pub fn alp_encode(parray: &PrimitiveArray, exponents: Option<Exponents>) -> Vort
         _ => vortex_bail!("ALP can only encode f32 and f64"),
     };
 
-    Ok(ALPArray::new(encoded, exponents, patches))
+    Ok(ALPArray::new_unchecked(
+        encoded,
+        exponents,
+        patches,
+        parray.dtype().clone(),
+    ))
 }
 
 #[allow(clippy::cast_possible_truncation)]
@@ -65,7 +70,7 @@ where
 
     let validity = values.validity_mask()?;
     // exceptional_positions may contain exceptions at invalid positions (which contain garbage
-    // data). We remove invalid exceptional positions in order to keep the Patches small.
+    // data). We remove null exceptions in order to keep the Patches small.
     let (valid_exceptional_positions, valid_exceptional_values): (Buffer<u64>, Buffer<T>) =
         match validity {
             Mask::AllTrue(_) => (exceptional_positions, exceptional_values),

--- a/encodings/alp/src/alp/compute/cast.rs
+++ b/encodings/alp/src/alp/compute/cast.rs
@@ -23,8 +23,13 @@ impl CastKernel for ALPVTable {
             )?;
 
             Ok(Some(
-                ALPArray::new(new_encoded, array.exponents(), array.patches().cloned())
-                    .into_array(),
+                ALPArray::new_unchecked(
+                    new_encoded,
+                    array.exponents(),
+                    array.patches().cloned(),
+                    dtype.clone(),
+                )
+                .into_array(),
             ))
         } else {
             Ok(None)

--- a/encodings/alp/src/alp/compute/filter.rs
+++ b/encodings/alp/src/alp/compute/filter.rs
@@ -16,7 +16,14 @@ impl FilterKernel for ALPVTable {
             .transpose()?
             .flatten();
 
-        Ok(ALPArray::new(filter(array.encoded(), mask)?, array.exponents(), patches).to_array())
+        // All ALPArray invariants are held when filtering the values
+        Ok(ALPArray::new_unchecked(
+            filter(array.encoded(), mask)?,
+            array.exponents(),
+            patches,
+            array.dtype().clone(),
+        )
+        .to_array())
     }
 }
 

--- a/encodings/alp/src/alp/serde.rs
+++ b/encodings/alp/src/alp/serde.rs
@@ -9,7 +9,7 @@ use vortex_array::{
 };
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, PType};
-use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_panic};
+use vortex_error::{VortexError, VortexResult, vortex_bail};
 
 use super::{ALPEncoding, alp_encode};
 use crate::{ALPArray, ALPVTable, Exponents};
@@ -50,7 +50,7 @@ impl SerdeVTable<ALPVTable> for ALPVTable {
         let encoded_ptype = match &dtype {
             DType::Primitive(PType::F32, n) => DType::Primitive(PType::I32, *n),
             DType::Primitive(PType::F64, n) => DType::Primitive(PType::I64, *n),
-            d => vortex_panic!(MismatchedTypes: "f32 or f64", d),
+            d => vortex_bail!(MismatchedTypes: "f32 or f64", d),
         };
         let encoded = children.get(0, &encoded_ptype, len)?;
 
@@ -63,14 +63,14 @@ impl SerdeVTable<ALPVTable> for ALPVTable {
             })
             .transpose()?;
 
-        Ok(ALPArray::new(
+        ALPArray::try_new(
             encoded,
             Exponents {
-                e: u8::try_from(metadata.exp_e).vortex_expect("Exponent e overflow"),
-                f: u8::try_from(metadata.exp_f).vortex_expect("Exponent f overflow"),
+                e: u8::try_from(metadata.exp_e)?,
+                f: u8::try_from(metadata.exp_f)?,
             },
             patches,
-        ))
+        )
     }
 }
 

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -56,6 +56,7 @@ pub struct ALPRDArray {
 pub struct ALPRDEncoding;
 
 impl ALPRDArray {
+    /// Build a new `ALPRDArray` from components.
     pub fn try_new(
         dtype: DType,
         left_parts: ArrayRef,
@@ -114,6 +115,8 @@ impl ALPRDArray {
         ))
     }
 
+    /// Build a new `ALPRDArray` from components. This does not perform any validation, and instead
+    /// it constructs it from parts.
     pub(crate) fn new_unchecked(
         dtype: DType,
         left_parts: ArrayRef,

--- a/encodings/alp/src/alp_rd/serde.rs
+++ b/encodings/alp/src/alp_rd/serde.rs
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use itertools::Itertools;
 use vortex_array::patches::{Patches, PatchesMetadata};
 use vortex_array::serde::ArrayChildren;
 use vortex_array::vtable::{EncodeVTable, SerdeVTable, VisitorVTable};
-use vortex_array::{
-    Array, ArrayBufferVisitor, ArrayChildVisitor, Canonical, DeserializeMetadata, ProstMetadata,
-};
+use vortex_array::{Array, ArrayBufferVisitor, ArrayChildVisitor, Canonical, ProstMetadata};
 use vortex_buffer::{Buffer, ByteBuffer};
 use vortex_dtype::{DType, Nullability, PType};
-use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_bail};
+use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_bail, vortex_err};
 
 use super::{ALPRDEncoding, RDEncoder};
 use crate::{ALPRDArray, ALPRDVTable};
@@ -55,7 +54,7 @@ impl SerdeVTable<ALPRDVTable> for ALPRDVTable {
         _encoding: &ALPRDEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &<Self::Metadata as DeserializeMetadata>::Output,
+        metadata: &ALPRDMetadata,
         _buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ALPRDArray> {
@@ -68,11 +67,14 @@ impl SerdeVTable<ALPRDVTable> for ALPRDVTable {
 
         let left_parts_dtype = DType::Primitive(metadata.left_parts_ptype(), dtype.nullability());
         let left_parts = children.get(0, &left_parts_dtype, len)?;
-        let left_parts_dictionary = Buffer::from_iter(
-            metadata.dict.as_slice()[0..metadata.dict_len as usize]
-                .iter()
-                .map(|&i| u16::try_from(i).vortex_expect("Dictionary index out of range")),
-        );
+        let left_parts_dictionary: Buffer<u16> = metadata.dict.as_slice()
+            [0..metadata.dict_len as usize]
+            .iter()
+            .map(|&i| {
+                u16::try_from(i)
+                    .map_err(|_| vortex_err!("left_parts_dictionary code {i} does not fit in u16"))
+            })
+            .try_collect()?;
 
         let right_parts_dtype = match &dtype {
             DType::Primitive(PType::F32, _) => {
@@ -99,7 +101,12 @@ impl SerdeVTable<ALPRDVTable> for ALPRDVTable {
             left_parts,
             left_parts_dictionary,
             right_parts,
-            u8::try_from(metadata.right_bit_width).vortex_expect("Bit width out of range"),
+            u8::try_from(metadata.right_bit_width).map_err(|_| {
+                vortex_err!(
+                    "right_bit_width {} out of u8 range",
+                    metadata.right_bit_width
+                )
+            })?,
             left_parts_patches,
         )
     }

--- a/encodings/datetime-parts/src/serde.rs
+++ b/encodings/datetime-parts/src/serde.rs
@@ -9,7 +9,7 @@ use vortex_array::{
 };
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, Nullability, PType};
-use vortex_error::{VortexExpect, VortexResult, vortex_bail};
+use vortex_error::{VortexResult, vortex_bail};
 
 use crate::{DateTimePartsArray, DateTimePartsEncoding, DateTimePartsVTable};
 
@@ -31,12 +31,9 @@ impl SerdeVTable<DateTimePartsVTable> for DateTimePartsVTable {
 
     fn metadata(array: &DateTimePartsArray) -> VortexResult<Option<Self::Metadata>> {
         Ok(Some(ProstMetadata(DateTimePartsMetadata {
-            days_ptype: PType::try_from(array.days().dtype()).vortex_expect("Must be a valid PType")
-                as i32,
-            seconds_ptype: PType::try_from(array.seconds().dtype())
-                .vortex_expect("Must be a valid PType") as i32,
-            subseconds_ptype: PType::try_from(array.subseconds().dtype())
-                .vortex_expect("Must be a valid PType") as i32,
+            days_ptype: PType::try_from(array.days().dtype())? as i32,
+            seconds_ptype: PType::try_from(array.seconds().dtype())? as i32,
+            subseconds_ptype: PType::try_from(array.subseconds().dtype())? as i32,
         })))
     }
 

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -82,7 +82,7 @@ impl DecimalBytePartsArray {
 
     pub fn decimal_dtype(&self) -> &DecimalDType {
         self.dtype
-            .as_decimal()
+            .as_decimal_opt()
             .vortex_expect("must be a decimal dtype")
     }
 

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/serde.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/serde.rs
@@ -8,7 +8,7 @@ use vortex_array::{
 };
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, PType};
-use vortex_error::{VortexExpect, VortexResult, vortex_bail};
+use vortex_error::{VortexResult, vortex_bail};
 
 use crate::{DecimalBytePartsArray, DecimalBytePartsEncoding, DecimalBytePartsVTable};
 
@@ -25,8 +25,7 @@ impl SerdeVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
 
     fn metadata(array: &DecimalBytePartsArray) -> VortexResult<Option<Self::Metadata>> {
         Ok(Some(ProstMetadata(DecimalBytesPartsMetadata {
-            zeroth_child_ptype: PType::try_from(array.msp.dtype()).vortex_expect("must be a PType")
-                as i32,
+            zeroth_child_ptype: PType::try_from(array.msp.dtype())? as i32,
             lower_part_count: 0,
         })))
     }
@@ -39,7 +38,7 @@ impl SerdeVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
         _buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<DecimalBytePartsArray> {
-        let Some(decimal_dtype) = dtype.as_decimal() else {
+        let Some(decimal_dtype) = dtype.as_decimal_opt() else {
             vortex_bail!("decoding decimal but given non decimal dtype {}", dtype)
         };
 

--- a/encodings/dict/src/array.rs
+++ b/encodings/dict/src/array.rs
@@ -51,6 +51,7 @@ pub struct DictEncoding;
 impl DictArray {
     /// Build a new `DictArray` without validating the codes or values.
     ///
+    /// # Safety
     /// This should be called only when you can guarantee the invariants checked
     /// by the safe [`DictArray::try_new`] constructor are valid, for example when
     /// you are filtering or slicing an existing valid `DictArray`.

--- a/encodings/dict/src/array.rs
+++ b/encodings/dict/src/array.rs
@@ -49,6 +49,19 @@ pub struct DictArray {
 pub struct DictEncoding;
 
 impl DictArray {
+    /// Build a new `DictArray` without validating the codes or values.
+    ///
+    /// This should be called only when you can guarantee the invariants checked
+    /// by the safe [`DictArray::try_new`] constructor are valid, for example when
+    /// you are filtering or slicing an existing valid `DictArray`.
+    pub unsafe fn new_unchecked(codes: ArrayRef, values: ArrayRef) -> Self {
+        Self {
+            codes,
+            values,
+            stats_set: Default::default(),
+        }
+    }
+
     /// Build a new `DictArray` from its components, `codes` and `values`.
     ///
     /// This constructor will panic if `codes` or `values` do not pass validation for building

--- a/encodings/dict/src/array.rs
+++ b/encodings/dict/src/array.rs
@@ -11,7 +11,7 @@ use vortex_array::{
     Array, ArrayRef, Canonical, EncodingId, EncodingRef, IntoArray, ToCanonical, vtable,
 };
 use vortex_dtype::{DType, match_each_integer_ptype};
-use vortex_error::{VortexExpect as _, VortexResult, vortex_bail};
+use vortex_error::{VortexExpect as _, VortexResult, vortex_bail, vortex_ensure};
 use vortex_mask::{AllOr, Mask};
 
 vtable!(Dict);
@@ -49,10 +49,25 @@ pub struct DictArray {
 pub struct DictEncoding;
 
 impl DictArray {
+    /// Build a new `DictArray` from its components, `codes` and `values`.
+    ///
+    /// This constructor will panic if `codes` or `values` do not pass validation for building
+    /// a new `DictArray`. See [`DictArray::try_new`] for a description of the error conditions.
     pub fn new(codes: ArrayRef, values: ArrayRef) -> Self {
         Self::try_new(codes, values).vortex_expect("DictArray new")
     }
 
+    /// Build a new `DictArray` from its components, `codes` and `values`.
+    ///
+    /// The codes must be unsigned integers, and may be nullable. Values can be any type, and
+    /// may also be nullable. This mirrors the nullability of the Arrow `DictionaryArray`.
+    ///
+    /// # Errors
+    ///
+    /// The `codes` **must** be unsigned integers, and the maximum code must be less than the length
+    /// of the `values` array. Otherwise, this constructor returns an error.
+    ///
+    /// It is an error to provide a nullable `codes` with non-nullable `values`.
     pub fn try_new(mut codes: ArrayRef, values: ArrayRef) -> VortexResult<Self> {
         if !codes.dtype().is_unsigned_int() {
             vortex_bail!(MismatchedTypes: "unsigned int", codes.dtype());
@@ -64,13 +79,14 @@ impl DictArray {
             codes = cast(&codes, &codes.dtype().as_nullable())?;
         } else {
             // If the values are non-nullable, we assert the codes are non-nullable as well.
-            if codes.dtype().is_nullable() {
-                vortex_bail!("Cannot have nullable codes for non-nullable dict array");
-            }
+            vortex_ensure!(
+                !codes.dtype().is_nullable(),
+                "Cannot have nullable codes for non-nullable dict array"
+            );
         }
-        assert_eq!(
-            codes.dtype().nullability(),
-            values.dtype().nullability(),
+
+        vortex_ensure!(
+            codes.dtype().nullability() == values.dtype().nullability(),
             "Mismatched nullability between codes and values"
         );
 

--- a/encodings/dict/src/arrow.rs
+++ b/encodings/dict/src/arrow.rs
@@ -5,7 +5,6 @@ use arrow_array::types::ArrowDictionaryKeyType;
 use arrow_array::{AnyDictionaryArray, DictionaryArray};
 use vortex_array::ArrayRef;
 use vortex_array::arrow::FromArrowArray;
-use vortex_error::VortexUnwrap;
 
 use crate::DictArray;
 
@@ -14,6 +13,7 @@ impl<K: ArrowDictionaryKeyType> FromArrowArray<&DictionaryArray<K>> for DictArra
         let keys = AnyDictionaryArray::keys(array);
         let keys = ArrayRef::from_arrow(keys, keys.is_nullable());
         let values = ArrayRef::from_arrow(array.values().as_ref(), nullable);
-        DictArray::try_new(keys, values).vortex_unwrap()
+        // SAFETY: we assume that Arrow has checked the invariants on construction
+        unsafe { DictArray::new_unchecked(keys, values) }
     }
 }

--- a/encodings/dict/src/builders/bytes.rs
+++ b/encodings/dict/src/builders/bytes.rs
@@ -179,13 +179,17 @@ impl<Code: Unsigned + AsPrimitive<usize> + NativePType> DictEncoder for BytesDic
     }
 
     fn values(&mut self) -> VortexResult<ArrayRef> {
-        VarBinViewArray::try_new(
-            self.views.clone().freeze(),
-            Arc::from([self.values.clone().freeze()]),
-            self.dtype.clone(),
-            self.dtype.nullability().into(),
-        )
-        .map(|a| a.into_array())
+        // SAFETY: we build the views explicitly and the bytes should be checked before feeding
+        //  to the encoder.
+        unsafe {
+            Ok(VarBinViewArray::new_unchecked(
+                self.views.clone().freeze(),
+                Arc::from([self.values.clone().freeze()]),
+                self.dtype.clone(),
+                self.dtype.nullability().into(),
+            )
+            .into_array())
+        }
     }
 }
 

--- a/encodings/dict/src/builders/mod.rs
+++ b/encodings/dict/src/builders/mod.rs
@@ -26,6 +26,7 @@ pub const UNCONSTRAINED: DictConstraints = DictConstraints {
 };
 
 pub trait DictEncoder: Send {
+    /// Assign dictionary codes to the given input array.
     fn encode(&mut self, array: &dyn Array) -> VortexResult<ArrayRef>;
 
     fn values(&mut self) -> VortexResult<ArrayRef>;
@@ -55,7 +56,8 @@ pub fn dict_encode_with_constraints(
 ) -> VortexResult<DictArray> {
     let mut encoder = dict_encoder(array, constraints)?;
     let codes = downscale_integer_array(encoder.encode(array)?)?;
-    DictArray::try_new(codes, encoder.values()?)
+    // SAFETY: The encoding process will produce a value set of codes and values
+    unsafe { Ok(DictArray::new_unchecked(codes, encoder.values()?)) }
 }
 
 pub fn dict_encode(array: &dyn Array) -> VortexResult<DictArray> {

--- a/encodings/dict/src/compute/binary_numeric.rs
+++ b/encodings/dict/src/compute/binary_numeric.rs
@@ -26,13 +26,16 @@ impl NumericKernel for DictVTable {
         };
         let rhs_const_array = ConstantArray::new(rhs_scalar, array.values().len()).into_array();
 
-        Ok(Some(
-            DictArray::try_new(
-                array.codes().clone(),
-                numeric(array.values(), &rhs_const_array, op)?,
-            )?
-            .into_array(),
-        ))
+        // SAFETY: applying numeric fn to values does not change codes validity
+        unsafe {
+            Ok(Some(
+                DictArray::new_unchecked(
+                    array.codes().clone(),
+                    numeric(array.values(), &rhs_const_array, op)?,
+                )
+                .into_array(),
+            ))
+        }
     }
 }
 

--- a/encodings/dict/src/compute/cast.rs
+++ b/encodings/dict/src/compute/cast.rs
@@ -22,10 +22,12 @@ impl CastKernel for DictVTable {
             array.codes().clone()
         };
 
-        // Create a new dictionary array with the same codes but casted values
-        Ok(Some(
-            DictArray::try_new(casted_codes, casted_values)?.into_array(),
-        ))
+        // SAFETY: casting does not alter invariants of the codes
+        unsafe {
+            Ok(Some(
+                DictArray::new_unchecked(casted_codes, casted_values).into_array(),
+            ))
+        }
     }
 }
 

--- a/encodings/dict/src/compute/compare.rs
+++ b/encodings/dict/src/compute/compare.rs
@@ -36,9 +36,12 @@ impl CompareKernel for DictVTable {
                     compare_result.dtype().nullability() | lhs.dtype().nullability();
                 dict_equal_to(compare_result, lhs.codes(), result_nullability).map(Some)
             } else {
-                DictArray::try_new(lhs.codes().clone(), compare_result)
-                    .map(|a| a.into_array())
-                    .map(Some)
+                // SAFETY: values len preserved, codes all still point to valid values
+                unsafe {
+                    Ok(Some(
+                        DictArray::new_unchecked(lhs.codes().clone(), compare_result).into_array(),
+                    ))
+                }
             };
         }
 
@@ -117,7 +120,9 @@ fn dict_equal_to(
             &DType::Bool(result_nullability),
         )?,
         // more than one value matches
-        _ => DictArray::try_new(codes.clone(), bool_result.into_array())?.into_array(),
+        _ => unsafe {
+            DictArray::new_unchecked(codes.clone(), bool_result.into_array()).into_array()
+        },
     })
 }
 

--- a/encodings/dict/src/compute/fill_null.rs
+++ b/encodings/dict/src/compute/fill_null.rs
@@ -41,7 +41,8 @@ impl FillNullKernel for DictVTable {
         // And fill nulls in the values
         let values = fill_null(array.values(), fill_value)?;
 
-        Ok(DictArray::try_new(codes, values)?.into_array())
+        // SAFETY: invariants are still satisfied after patching nulls
+        unsafe { Ok(DictArray::new_unchecked(codes, values).into_array()) }
     }
 }
 

--- a/encodings/dict/src/compute/like.rs
+++ b/encodings/dict/src/compute/like.rs
@@ -22,9 +22,14 @@ impl LikeKernel for DictVTable {
         if let Some(pattern) = pattern.as_constant() {
             let pattern = ConstantArray::new(pattern, array.values().len()).into_array();
             let values = like(array.values(), &pattern, options)?;
-            Ok(Some(
-                DictArray::try_new(array.codes().clone(), values)?.into_array(),
-            ))
+
+            // SAFETY: LIKE preserves the len of the values, so codes are still pointing at
+            //  valid positions.
+            unsafe {
+                Ok(Some(
+                    DictArray::new_unchecked(array.codes().clone(), values).into_array(),
+                ))
+            }
         } else {
             Ok(None)
         }

--- a/encodings/dict/src/compute/mod.rs
+++ b/encodings/dict/src/compute/mod.rs
@@ -27,7 +27,10 @@ impl TakeKernel for DictVTable {
             .values()
             .dtype()
             .union_nullability(codes.dtype().nullability());
-        DictArray::try_new(codes, cast(array.values(), &values_dtype)?).map(|a| a.into_array())
+        // SAFETY: selecting codes doesn't change the invariants of DictArray
+        unsafe {
+            Ok(DictArray::new_unchecked(codes, cast(array.values(), &values_dtype)?).into_array())
+        }
     }
 }
 
@@ -36,7 +39,9 @@ register_kernel!(TakeKernelAdapter(DictVTable).lift());
 impl FilterKernel for DictVTable {
     fn filter(&self, array: &DictArray, mask: &Mask) -> VortexResult<ArrayRef> {
         let codes = filter(array.codes(), mask)?;
-        DictArray::try_new(codes, array.values().clone()).map(|a| a.into_array())
+
+        // SAFETY: filtering codes doesn't change invariants
+        unsafe { Ok(DictArray::new_unchecked(codes, array.values().clone()).into_array()) }
     }
 }
 

--- a/encodings/dict/src/ops.rs
+++ b/encodings/dict/src/ops.rs
@@ -23,7 +23,8 @@ impl OperationsVTable<DictVTable> for DictVTable {
                 ConstantArray::new(Scalar::null(dtype), sliced_code.len()).to_array()
             };
         }
-        DictArray::new(sliced_code, array.values().clone()).into_array()
+        // SAFETY: slicing the codes preserves invariants
+        unsafe { DictArray::new_unchecked(sliced_code, array.values().clone()).into_array() }
     }
 
     fn scalar_at(array: &DictArray, index: usize) -> Scalar {

--- a/encodings/dict/src/serde.rs
+++ b/encodings/dict/src/serde.rs
@@ -8,7 +8,7 @@ use vortex_array::{
 };
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, PType};
-use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
+use vortex_error::{VortexResult, vortex_bail, vortex_err};
 
 use crate::builders::dict_encode;
 use crate::{DictArray, DictEncoding, DictVTable};
@@ -26,10 +26,12 @@ impl SerdeVTable<DictVTable> for DictVTable {
 
     fn metadata(array: &DictArray) -> VortexResult<Option<Self::Metadata>> {
         Ok(Some(ProstMetadata(DictMetadata {
-            codes_ptype: PType::try_from(array.codes().dtype())
-                .vortex_expect("Must be a valid PType") as i32,
+            codes_ptype: PType::try_from(array.codes().dtype())? as i32,
             values_len: u32::try_from(array.values().len()).map_err(|_| {
-                vortex_err!("Diction values cannot exceed u32 in length for serialization")
+                vortex_err!(
+                    "Dictionary values size {} overflowed u32",
+                    array.values().len()
+                )
             })?,
         })))
     }
@@ -50,7 +52,6 @@ impl SerdeVTable<DictVTable> for DictVTable {
         }
         let codes_dtype = DType::Primitive(metadata.codes_ptype(), dtype.nullability());
         let codes = children.get(0, &codes_dtype, len)?;
-
         let values = children.get(1, dtype, metadata.values_len as usize)?;
 
         DictArray::try_new(codes, values)

--- a/encodings/fastlanes/src/bitpacking/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/mod.rs
@@ -17,7 +17,7 @@ use vortex_array::vtable::{
 use vortex_array::{Array, Canonical, EncodingId, EncodingRef, vtable};
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, NativePType, PType, match_each_integer_ptype};
-use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
+use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_ensure};
 
 use crate::unpack_iter::{BitPacked, BitUnpackedChunks};
 
@@ -66,7 +66,70 @@ pub struct BitPackedArray {
 #[derive(Clone, Debug)]
 pub struct BitPackedEncoding;
 
-/// NB: All non-null values in the patches array are considered patches
+impl BitPackedArray {
+    fn validate(
+        packed: &ByteBuffer,
+        ptype: PType,
+        validity: &Validity,
+        patches: Option<&Patches>,
+        bit_width: u8,
+        length: usize,
+        offset: u16,
+    ) -> VortexResult<()> {
+        vortex_ensure!(ptype.is_int(), MismatchedTypes: "integer", ptype);
+        vortex_ensure!(bit_width <= 64, "Unsupported bit width {}", bit_width);
+
+        if let Some(validity_len) = validity.maybe_len() {
+            vortex_ensure!(
+                validity_len == length,
+                "BitPackedArray validity length {validity_len} != array length {length}",
+            );
+        }
+
+        // Validate offset for sliced arrays
+        vortex_ensure!(
+            offset < 1024,
+            "Offset must be less than full block, i.e. 1024, got {}",
+            offset
+        );
+
+        // Validate patches
+        if let Some(patches) = patches {
+            Self::validate_patches(patches, ptype, length)?;
+        }
+
+        // Validate packed buffer
+        let expected_packed_len =
+            (length + offset as usize).div_ceil(1024) * (128 * bit_width as usize);
+        vortex_ensure!(
+            packed.len() == expected_packed_len,
+            "Expected {} packed bytes, got {}",
+            expected_packed_len,
+            packed.len()
+        );
+
+        Ok(())
+    }
+
+    fn validate_patches(patches: &Patches, ptype: PType, len: usize) -> VortexResult<()> {
+        // Ensure that array and patches have same ptype
+        vortex_ensure!(
+            patches.dtype().eq_ignore_nullability(ptype.into()),
+            "Patches DType {} does not match BitPackedArray dtype {}",
+            patches.dtype().as_nonnullable(),
+            ptype
+        );
+
+        vortex_ensure!(
+            patches.array_len() == len,
+            "BitPackedArray patches length {} != expected {len}",
+            patches.array_len(),
+        );
+
+        Ok(())
+    }
+}
+
 impl BitPackedArray {
     /// Create a new bitpacked array using a buffer of packed data.
     ///
@@ -109,10 +172,30 @@ impl BitPackedArray {
         }
     }
 
-    /// An unsafe constructor for a `BitPackedArray` that also specifies a slicing offset.
+    /// A safe constructor for a `BitPackedArray` from its components:
+    ///
+    /// * `packed` is ByteBuffer holding the compressed data that was packed with FastLanes
+    ///   bit-packing to a `bit_width` bits per value. `length` is the length of the original
+    ///   vector. Note that the packed is padded with zeros to the next multiple of 1024 elements
+    ///   if `length` is not divisible by 1024.
+    /// * `ptype` of the original data
+    /// * `validity` to track any nulls
+    /// * `patches` optionally provided for values that did not pack
+    ///
+    /// Any failure in validation will result in an error.
+    ///
+    /// # Validation
+    ///
+    /// * The `ptype` must be an integer
+    /// * `validity` must have `length` len
+    /// * Any patches must have any `array_len` equal to `length`
+    /// * The `packed` buffer must be exactly sized to hold `length` values of `bit_width` rounded
+    ///   up to the next multiple of 1024.
+    ///
+    /// Any violation of these preconditions will result in an error.
     ///
     /// See also [`new_unchecked`][Self::new_unchecked].
-    pub(crate) fn try_new(
+    pub fn try_new(
         packed: ByteBuffer,
         ptype: PType,
         validity: Validity,
@@ -121,46 +204,17 @@ impl BitPackedArray {
         length: usize,
         offset: u16,
     ) -> VortexResult<Self> {
+        Self::validate(
+            &packed,
+            ptype,
+            &validity,
+            patches.as_ref(),
+            bit_width,
+            length,
+            offset,
+        )?;
+
         let dtype = DType::Primitive(ptype, validity.nullability());
-        if !dtype.is_int() {
-            vortex_bail!(MismatchedTypes: "integer", dtype);
-        }
-
-        if bit_width > u64::BITS as u8 {
-            vortex_bail!("Unsupported bit width {}", bit_width);
-        }
-        if offset > 1023 {
-            vortex_bail!(
-                "Offset must be less than full block, i.e. 1024, got {}",
-                offset
-            );
-        }
-
-        if let Some(ref patches) = patches {
-            // Ensure that array and patches have same PType
-            if !patches.dtype().eq_ignore_nullability(ptype.into()) {
-                vortex_bail!(
-                    "Patches DType {} does not match BitPackedArray dtype {}",
-                    patches.dtype().as_nonnullable(),
-                    ptype
-                )
-            }
-        }
-
-        // expected packed size is in bytes
-        let expected_packed_size =
-            (length + offset as usize).div_ceil(1024) * (128 * bit_width as usize);
-        if packed.len() != expected_packed_size {
-            return Err(vortex_err!(
-                "Expected {} packed bytes, got {}",
-                expected_packed_size,
-                packed.len()
-            ));
-        }
-
-        // TODO(ngates): enforce 128 byte alignment once we have a BufferBuilder that can
-        //  enforce custom alignments.
-        // let packed = ByteBuffer::new_with_alignment(packed, FASTLANES_ALIGNMENT);
 
         Ok(Self::new_unchecked(
             packed, dtype, validity, patches, bit_width, length, offset,

--- a/encodings/fastlanes/src/bitpacking/serde.rs
+++ b/encodings/fastlanes/src/bitpacking/serde.rs
@@ -8,7 +8,7 @@ use vortex_array::vtable::{EncodeVTable, SerdeVTable, ValidityHelper, VisitorVTa
 use vortex_array::{ArrayBufferVisitor, ArrayChildVisitor, Canonical, ProstMetadata};
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, PType};
-use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_bail};
+use vortex_error::{VortexError, VortexResult, vortex_bail, vortex_err};
 
 use super::{BitPackedEncoding, bit_width_histogram, find_best_bit_width};
 use crate::{BitPackedArray, BitPackedVTable, bitpack_encode};
@@ -87,9 +87,19 @@ impl SerdeVTable<BitPackedVTable> for BitPackedVTable {
             PType::try_from(dtype)?,
             validity,
             patches,
-            u8::try_from(metadata.bit_width).vortex_expect("Bit width out of range"),
+            u8::try_from(metadata.bit_width).map_err(|_| {
+                vortex_err!(
+                    "BitPackedMetadata bit_width {} does not fit in u8",
+                    metadata.bit_width
+                )
+            })?,
             len,
-            u16::try_from(metadata.offset).vortex_expect("Offset out of range"),
+            u16::try_from(metadata.offset).map_err(|_| {
+                vortex_err!(
+                    "BitPackedMetadata offset {} does not fit in u16",
+                    metadata.offset
+                )
+            })?,
         )
     }
 }

--- a/encodings/fastlanes/src/delta/mod.rs
+++ b/encodings/fastlanes/src/delta/mod.rs
@@ -216,8 +216,8 @@ impl DeltaArray {
 
     #[inline]
     fn lanes(&self) -> usize {
-        let ptype = PType::try_from(self.dtype())
-            .vortex_expect("Failed to convert DeltaArray DType to PType");
+        let ptype =
+            PType::try_from(self.dtype()).vortex_expect("DeltaArray DType must be primitive");
         lane_count(ptype)
     }
 

--- a/encodings/fastlanes/src/delta/serde.rs
+++ b/encodings/fastlanes/src/delta/serde.rs
@@ -9,7 +9,7 @@ use vortex_array::{
 };
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, PType, match_each_unsigned_integer_ptype};
-use vortex_error::{VortexExpect, VortexResult, vortex_bail};
+use vortex_error::{VortexResult, vortex_bail, vortex_err};
 
 use super::DeltaEncoding;
 use crate::{DeltaArray, DeltaVTable};
@@ -59,7 +59,7 @@ impl SerdeVTable<DeltaVTable> for DeltaVTable {
 
         // Compute the length of the bases array
         let deltas_len = usize::try_from(metadata.deltas_len)
-            .vortex_expect("DeltaArray: deltas_len must be a valid usize");
+            .map_err(|_| vortex_err!("deltas_len {} overflowed usize", metadata.deltas_len))?;
         let num_chunks = deltas_len / 1024;
         let remainder_base_size = if deltas_len % 1024 > 0 { 1 } else { 0 };
         let bases_len = num_chunks * lanes + remainder_base_size;

--- a/encodings/fsst/src/canonical.rs
+++ b/encodings/fsst/src/canonical.rs
@@ -16,13 +16,16 @@ use crate::{FSSTArray, FSSTVTable};
 impl CanonicalVTable<FSSTVTable> for FSSTVTable {
     fn canonicalize(array: &FSSTArray) -> VortexResult<Canonical> {
         let (buffer, views) = fsst_decode_views(array, 0);
-        VarBinViewArray::try_new(
-            views,
-            Arc::new([buffer]),
-            array.dtype().clone(),
-            array.codes().validity().clone(),
-        )
-        .map(Canonical::VarBinView)
+        // SAFETY: FSST already validates the bytes for binary/UTF-8. We build views directly on
+        //  top of them, so the view pointers will all be valid.
+        unsafe {
+            Ok(Canonical::VarBinView(VarBinViewArray::new_unchecked(
+                views,
+                Arc::new([buffer]),
+                array.dtype().clone(),
+                array.codes().validity().clone(),
+            )))
+        }
     }
 
     fn append_to_builder(array: &FSSTArray, builder: &mut dyn ArrayBuilder) -> VortexResult<()> {

--- a/encodings/fsst/src/canonical.rs
+++ b/encodings/fsst/src/canonical.rs
@@ -3,47 +3,45 @@
 
 use std::sync::Arc;
 
-use fsst::Decompressor;
 use vortex_array::arrays::{BinaryView, VarBinViewArray};
 use vortex_array::builders::{ArrayBuilder, VarBinViewBuilder};
-use vortex_array::validity::Validity;
-use vortex_array::vtable::CanonicalVTable;
+use vortex_array::vtable::{CanonicalVTable, ValidityHelper};
 use vortex_array::{Canonical, IntoArray, ToCanonical};
-use vortex_buffer::{BufferMut, ByteBuffer, ByteBufferMut};
+use vortex_buffer::{Buffer, BufferMut, ByteBuffer, ByteBufferMut};
 use vortex_dtype::match_each_integer_ptype;
-use vortex_error::VortexResult;
+use vortex_error::{VortexExpect, VortexResult};
 
 use crate::{FSSTArray, FSSTVTable};
 
 impl CanonicalVTable<FSSTVTable> for FSSTVTable {
     fn canonicalize(array: &FSSTArray) -> VortexResult<Canonical> {
-        fsst_into_varbin_view(array.decompressor(), array, 0).map(Canonical::VarBinView)
+        let (buffer, views) = fsst_decode_views(array, 0);
+        VarBinViewArray::try_new(
+            views,
+            Arc::new([buffer]),
+            array.dtype().clone(),
+            array.codes().validity().clone(),
+        )
+        .map(Canonical::VarBinView)
     }
 
     fn append_to_builder(array: &FSSTArray, builder: &mut dyn ArrayBuilder) -> VortexResult<()> {
         let Some(builder) = builder.as_any_mut().downcast_mut::<VarBinViewBuilder>() else {
             return builder.extend_from_array(&array.to_canonical()?.into_array());
         };
-        let view =
-            fsst_into_varbin_view(array.decompressor(), array, builder.completed_block_count())?;
 
-        builder.push_buffer_and_adjusted_views(
-            view.buffers(),
-            view.views(),
-            array.validity_mask()?,
-        );
+        // Decompress the whole block of data into a new buffer, and create some views
+        // from it instead.
+
+        let (buffer, views) = fsst_decode_views(array, builder.completed_block_count());
+
+        builder.push_buffer_and_adjusted_views(&[buffer], &views, array.validity_mask()?);
         Ok(())
     }
 }
 
-// Decompresses a fsst encoded array into a varbinview, a block_offset can be passed if the decoding
-// if happening as part of the larger view and is used to set the block_offset in each view.
 #[allow(clippy::cast_possible_truncation)]
-fn fsst_into_varbin_view(
-    decompressor: Decompressor,
-    fsst_array: &FSSTArray,
-    block_offset: usize,
-) -> VortexResult<VarBinViewArray> {
+fn fsst_decode_views(fsst_array: &FSSTArray, buf_index: u32) -> (ByteBuffer, Buffer<BinaryView>) {
     // FSSTArray has two child arrays:
     //  1. A VarBinArray, which holds the string heap of the compressed codes.
     //  2. An uncompressed_lengths primitive array, storing the length of each original
@@ -53,7 +51,10 @@ fn fsst_into_varbin_view(
     // necessary for a VarBinViewArray and construct the canonical array.
     let bytes = fsst_array.codes().sliced_bytes();
 
-    let uncompressed_lens_array = fsst_array.uncompressed_lengths().to_primitive()?;
+    let uncompressed_lens_array = fsst_array
+        .uncompressed_lengths()
+        .to_primitive()
+        .vortex_expect("uncompressed_lens must be primitive");
 
     // Decompres the full dataset.
     #[allow(clippy::cast_possible_truncation)]
@@ -66,12 +67,11 @@ fn fsst_into_varbin_view(
     });
 
     // Bulk-decompress the entire array.
+    let decompressor = fsst_array.decompressor();
     let mut uncompressed_bytes = ByteBufferMut::with_capacity(total_size + 7);
     let len =
         decompressor.decompress_into(bytes.as_slice(), uncompressed_bytes.spare_capacity_mut());
     unsafe { uncompressed_bytes.set_len(len) };
-
-    let block_offset = u32::try_from(block_offset)?;
 
     // Directly create the binary views.
     let mut views = BufferMut::<BinaryView>::with_capacity(uncompressed_lens_array.len());
@@ -82,7 +82,7 @@ fn fsst_into_varbin_view(
             let len = *len as usize;
             let view = BinaryView::make_view(
                 &uncompressed_bytes[offset..][..len],
-                block_offset,
+                buf_index,
                 offset as u32,
             );
             // SAFETY: we reserved the right capacity beforehand
@@ -91,15 +91,7 @@ fn fsst_into_varbin_view(
         }
     });
 
-    let views = views.freeze();
-    let uncompressed_bytes_array = ByteBuffer::from(uncompressed_bytes);
-
-    VarBinViewArray::try_new(
-        views,
-        Arc::from([uncompressed_bytes_array]),
-        fsst_array.dtype().clone(),
-        Validity::copy_from_array(fsst_array.as_ref())?,
-    )
+    (uncompressed_bytes.freeze(), views.freeze())
 }
 
 #[cfg(test)]

--- a/encodings/fsst/src/serde.rs
+++ b/encodings/fsst/src/serde.rs
@@ -10,7 +10,7 @@ use vortex_array::{
 };
 use vortex_buffer::{Buffer, ByteBuffer};
 use vortex_dtype::{DType, Nullability, PType};
-use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
+use vortex_error::{VortexResult, vortex_bail, vortex_err};
 
 use crate::{FSSTArray, FSSTEncoding, FSSTVTable, fsst_compress, fsst_train_compressor};
 
@@ -25,8 +25,7 @@ impl SerdeVTable<FSSTVTable> for FSSTVTable {
 
     fn metadata(array: &FSSTArray) -> VortexResult<Option<Self::Metadata>> {
         Ok(Some(ProstMetadata(FSSTMetadata {
-            uncompressed_lengths_ptype: PType::try_from(array.uncompressed_lengths().dtype())
-                .vortex_expect("Must be a valid PType")
+            uncompressed_lengths_ptype: PType::try_from(array.uncompressed_lengths().dtype())?
                 as i32,
         })))
     }

--- a/encodings/runend/benches/run_end_compress.rs
+++ b/encodings/runend/benches/run_end_compress.rs
@@ -68,7 +68,7 @@ fn decompress<T: NativePType + PrimInt>(bencher: Bencher, (length, run_step): (u
         .collect::<Buffer<_>>()
         .into_array();
 
-    let run_end_array = RunEndArray::try_new(ends, values).unwrap();
+    let run_end_array = RunEndArray::new(ends, values);
 
     bencher
         .with_inputs(|| run_end_array.to_array())

--- a/encodings/runend/benches/run_end_null_count.rs
+++ b/encodings/runend/benches/run_end_null_count.rs
@@ -66,5 +66,5 @@ fn fixture(n: usize, run_step: usize, valid_density: f64) -> RunEndArray {
     )
     .into_array();
 
-    RunEndArray::try_new(ends, values).unwrap()
+    RunEndArray::new(ends, values)
 }

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -11,7 +11,7 @@ use vortex_array::{
     Array, ArrayRef, Canonical, EncodingId, EncodingRef, IntoArray, ToCanonical, vtable,
 };
 use vortex_dtype::DType;
-use vortex_error::{VortexExpect as _, VortexResult, vortex_bail};
+use vortex_error::{VortexExpect as _, VortexResult, vortex_bail, vortex_ensure};
 use vortex_mask::Mask;
 use vortex_scalar::PValue;
 
@@ -54,35 +54,49 @@ pub struct RunEndArray {
 pub struct RunEndEncoding;
 
 impl RunEndArray {
-    pub fn try_new(ends: ArrayRef, values: ArrayRef) -> VortexResult<Self> {
-        if !ends.dtype().is_int() || ends.dtype().is_nullable() {
-            vortex_bail!("ends must be non-nullable integer, not {}", ends.dtype());
-        }
-
-        let length = if ends.is_empty() {
-            0
-        } else {
-            ends.scalar_at(ends.len() - 1)
-                .as_primitive()
-                .as_::<usize>()
-                .vortex_expect("run ends are non-null")
-        };
-        Self::try_new_offset_length(ends, values, 0, length)
-    }
-
-    pub(crate) fn try_new_offset_length(
-        ends: ArrayRef,
-        values: ArrayRef,
+    fn validate(
+        ends: &dyn Array,
+        values: &dyn Array,
         offset: usize,
         length: usize,
-    ) -> VortexResult<Self> {
-        if !matches!(values.dtype(), &DType::Bool(_) | &DType::Primitive(_, _)) {
-            vortex_bail!(
-                "RunEnd array can only have Bool or Primitive values, {} given",
-                values.dtype()
+    ) -> VortexResult<()> {
+        // DType validation
+        vortex_ensure!(
+            ends.dtype().is_unsigned_int(),
+            "run ends must be unsigned integers, was {}",
+            ends.dtype(),
+        );
+        vortex_ensure!(
+            values.dtype().is_primitive() || values.dtype().is_boolean(),
+            "RunEnd array can only have Bool or Primitive values, {} given",
+            values.dtype()
+        );
+
+        vortex_ensure!(
+            ends.len() == values.len(),
+            "run ends len != run values len, {} != {}",
+            ends.len(),
+            values.len()
+        );
+
+        // Handle empty run-ends
+        if ends.is_empty() {
+            vortex_ensure!(
+                offset == 0,
+                "non-zero offset provided for empty RunEndArray"
             );
+            return Ok(());
         }
 
+        // Verify that the ends are strictly monotonic.
+        if let Some(is_sorted) = ends.statistics().compute_is_strict_sorted() {
+            vortex_ensure!(is_sorted, "run ends must be monotonic");
+        } else {
+            // TODO(aduffy): fallback to slow scalar scanning if computefn impl not available?
+            vortex_bail!("run ends must report IsStrictSorted");
+        }
+
+        // Validate the offset and length are valid for the given ends and values
         if offset != 0 && length != 0 {
             let first_run_end: usize = ends.scalar_at(0).as_ref().try_into()?;
             if first_run_end <= offset {
@@ -90,16 +104,107 @@ impl RunEndArray {
             }
         }
 
-        if !ends.dtype().is_unsigned_int() || ends.dtype().is_nullable() {
-            vortex_bail!(MismatchedTypes: "non-nullable unsigned int", ends.dtype());
-        }
-        if !ends.statistics().compute_is_strict_sorted().unwrap_or(true) {
-            vortex_bail!("Ends array must be strictly sorted");
-        }
+        Ok(())
+    }
+}
 
+impl RunEndArray {
+    /// Build a new `RunEndArray` from an array of run `ends` and an array of `values`.
+    ///
+    /// Panics if any of the validation conditions described in [`RunEndArray::try_new`] is
+    /// not satisfied.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use vortex_array::arrays::BoolArray;
+    /// # use vortex_array::IntoArray;
+    /// # use vortex_buffer::buffer;
+    /// # use vortex_runend::RunEndArray;
+    /// let ends = buffer![2u8, 3u8].into_array();
+    /// let values = BoolArray::from_iter([false, true]).into_array();
+    /// let run_end = RunEndArray::new(ends, values);
+    ///
+    /// // Array encodes
+    /// assert_eq!(run_end.scalar_at(0), false.into());
+    /// assert_eq!(run_end.scalar_at(1), false.into());
+    /// assert_eq!(run_end.scalar_at(2), true.into());
+    /// ```
+    pub fn new(ends: ArrayRef, values: ArrayRef) -> Self {
+        Self::try_new(ends, values).vortex_expect("RunEndArray new")
+    }
+
+    /// Build a new `RunEndArray` from components.
+    ///
+    /// # Validation
+    ///
+    /// The `ends` must be non-nullable unsigned integers. The values may be `Bool` or `Primitive`
+    /// types.
+    ///
+    /// All `ends` must be strictly monotonic. A run cannot be empty, therefore there can be no
+    /// duplicates in the `ends`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use vortex_array::arrays::{BoolArray, VarBinViewArray};
+    /// # use vortex_array::IntoArray;
+    /// # use vortex_buffer::buffer;
+    /// # use vortex_runend::RunEndArray;
+    ///
+    /// // Error to provide duplicate ends!
+    /// let result = RunEndArray::try_new(
+    ///     buffer![1u8, 1u8, 2u8].into_array(),
+    ///     buffer![100i32, 200i32, 300i32].into_array(),
+    /// );
+    /// assert!(result.is_err());
+    ///
+    /// // Error to provide incorrectly-typed values!
+    /// let result = RunEndArray::try_new(
+    ///     buffer![1u8, 2u8].into_array(),
+    ///     VarBinViewArray::from_iter_str(["bad", "dtype"]).into_array(),
+    /// );
+    /// assert!(result.is_err());
+    ///
+    /// // This array is happy
+    /// let result = RunEndArray::try_new(
+    ///     buffer![1u8, 2u8].into_array(),
+    ///     BoolArray::from_iter([false, true]).into_array(),
+    /// );
+    ///
+    /// assert!(result.is_ok());
+    /// ```
+    pub fn try_new(ends: ArrayRef, values: ArrayRef) -> VortexResult<Self> {
+        let length: usize = if ends.is_empty() {
+            0
+        } else {
+            ends.scalar_at(ends.len() - 1).as_ref().try_into()?
+        };
+
+        Self::try_new_offset_length(ends, values, 0, length)
+    }
+
+    /// Construct a new sliced `RunEndArray` with the provided offset and length.
+    ///
+    /// This performs all the same validation as [`RunEndArray::try_new`].
+    pub fn try_new_offset_length(
+        ends: ArrayRef,
+        values: ArrayRef,
+        offset: usize,
+        length: usize,
+    ) -> VortexResult<Self> {
+        Self::validate(&ends, &values, offset, length)?;
         Ok(Self::new_unchecked(ends, values, offset, length))
     }
 
+    /// Build a new `RunEndArray` without validation.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that all the validation performed in [`RunEndArray::validate`] is
+    /// satisfied before calling this function.
+    ///
+    /// See [`RunEndArray::try_new`] for the preconditions needed to build a new array.
     pub(crate) fn new_unchecked(
         ends: ArrayRef,
         values: ArrayRef,
@@ -238,11 +343,10 @@ mod tests {
 
     #[test]
     fn test_runend_constructor() {
-        let arr = RunEndArray::try_new(
+        let arr = RunEndArray::new(
             buffer![2u32, 5, 10].into_array(),
             buffer![1i32, 2, 3].into_array(),
-        )
-        .unwrap();
+        );
         assert_eq!(arr.len(), 10);
         assert_eq!(
             arr.dtype(),

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -194,7 +194,14 @@ impl RunEndArray {
         length: usize,
     ) -> VortexResult<Self> {
         Self::validate(&ends, &values, offset, length)?;
-        Ok(Self::new_unchecked(ends, values, offset, length))
+
+        Ok(Self {
+            ends,
+            values,
+            offset,
+            length,
+            stats_set: Default::default(),
+        })
     }
 
     /// Build a new `RunEndArray` without validation.
@@ -205,7 +212,7 @@ impl RunEndArray {
     /// satisfied before calling this function.
     ///
     /// See [`RunEndArray::try_new`] for the preconditions needed to build a new array.
-    pub(crate) fn new_unchecked(
+    pub unsafe fn new_unchecked(
         ends: ArrayRef,
         values: ArrayRef,
         offset: usize,
@@ -235,7 +242,15 @@ impl RunEndArray {
     pub fn encode(array: ArrayRef) -> VortexResult<Self> {
         if let Some(parray) = array.as_opt::<PrimitiveVTable>() {
             let (ends, values) = runend_encode(parray)?;
-            Self::try_new(ends.into_array(), values)
+            // SAFETY: runend_encode handles this
+            unsafe {
+                Ok(Self::new_unchecked(
+                    ends.into_array(),
+                    values,
+                    0,
+                    array.len(),
+                ))
+            }
         } else {
             vortex_bail!("REE can only encode primitive arrays")
         }
@@ -301,14 +316,17 @@ impl ValidityVTable<RunEndVTable> for RunEndVTable {
             Mask::AllTrue(_) => Mask::AllTrue(array.len()),
             Mask::AllFalse(_) => Mask::AllFalse(array.len()),
             Mask::Values(values) => {
-                let ree_validity = RunEndArray::try_new_offset_length(
-                    array.ends().clone(),
-                    values.into_array(),
-                    array.offset(),
-                    array.len(),
-                )
-                .vortex_expect("invalid array")
-                .into_array();
+                // SAFETY: we preserve ends from an existing validated RunEndArray.
+                //  Validity is checked on construction to have the correct len.
+                let ree_validity = unsafe {
+                    RunEndArray::new_unchecked(
+                        array.ends().clone(),
+                        values.into_array(),
+                        array.offset(),
+                        array.len(),
+                    )
+                    .into_array()
+                };
                 Mask::from_buffer(ree_validity.to_bool()?.boolean_buffer().clone())
             }
         })

--- a/encodings/runend/src/arrow.rs
+++ b/encodings/runend/src/arrow.rs
@@ -10,7 +10,6 @@ use vortex_array::validity::Validity;
 use vortex_array::{ArrayRef, IntoArray};
 use vortex_buffer::Buffer;
 use vortex_dtype::NativePType;
-use vortex_error::VortexUnwrap;
 use vortex_scalar::PValue;
 
 use crate::RunEndArray;
@@ -47,7 +46,8 @@ where
             )
         };
 
-        RunEndArray::try_new_offset_length(ends_slice, values_slice, offset, len).vortex_unwrap()
+        // SAFETY: arrow-rs enforces the RunEndArray invariants, we inherit their guarantees
+        unsafe { RunEndArray::new_unchecked(ends_slice, values_slice, offset, len) }
     }
 }
 

--- a/encodings/runend/src/compute/binary_numeric.rs
+++ b/encodings/runend/src/compute/binary_numeric.rs
@@ -22,15 +22,18 @@ impl NumericKernel for RunEndVTable {
 
         let rhs_const_array = ConstantArray::new(rhs_scalar, array.values().len()).into_array();
 
-        Ok(Some(
-            RunEndArray::new_unchecked(
-                array.ends().clone(),
-                numeric(array.values(), &rhs_const_array, op)?,
-                array.offset(),
-                array.len(),
-            )
-            .into_array(),
-        ))
+        // SAFETY: ends are preserved.
+        unsafe {
+            Ok(Some(
+                RunEndArray::new_unchecked(
+                    array.ends().clone(),
+                    numeric(array.values(), &rhs_const_array, op)?,
+                    array.offset(),
+                    array.len(),
+                )
+                .into_array(),
+            ))
+        }
     }
 }
 

--- a/encodings/runend/src/compute/binary_numeric.rs
+++ b/encodings/runend/src/compute/binary_numeric.rs
@@ -23,12 +23,12 @@ impl NumericKernel for RunEndVTable {
         let rhs_const_array = ConstantArray::new(rhs_scalar, array.values().len()).into_array();
 
         Ok(Some(
-            RunEndArray::try_new_offset_length(
+            RunEndArray::new_unchecked(
                 array.ends().clone(),
                 numeric(array.values(), &rhs_const_array, op)?,
                 array.offset(),
                 array.len(),
-            )?
+            )
             .into_array(),
         ))
     }

--- a/encodings/runend/src/compute/cast.rs
+++ b/encodings/runend/src/compute/cast.rs
@@ -13,15 +13,18 @@ impl CastKernel for RunEndVTable {
         // Cast the values array to the target type
         let casted_values = cast(array.values(), dtype)?;
 
-        Ok(Some(
-            RunEndArray::try_new_offset_length(
-                array.ends().clone(),
-                casted_values,
-                array.offset(),
-                array.len(),
-            )?
-            .into_array(),
-        ))
+        // SAFETY: casting does not affect the ends being valid
+        unsafe {
+            Ok(Some(
+                RunEndArray::new_unchecked(
+                    array.ends().clone(),
+                    casted_values,
+                    array.offset(),
+                    array.len(),
+                )
+                .into_array(),
+            ))
+        }
     }
 }
 

--- a/encodings/runend/src/compute/fill_null.rs
+++ b/encodings/runend/src/compute/fill_null.rs
@@ -10,13 +10,16 @@ use crate::{RunEndArray, RunEndVTable};
 
 impl FillNullKernel for RunEndVTable {
     fn fill_null(&self, array: &RunEndArray, fill_value: &Scalar) -> VortexResult<ArrayRef> {
-        Ok(RunEndArray::try_new_offset_length(
-            array.ends().clone(),
-            fill_null(array.values(), fill_value)?,
-            array.offset(),
-            array.len(),
-        )?
-        .into_array())
+        // SAFETY: modifying values only, does not affect ends
+        unsafe {
+            Ok(RunEndArray::new_unchecked(
+                array.ends().clone(),
+                fill_null(array.values(), fill_value)?,
+                array.offset(),
+                array.len(),
+            )
+            .into_array())
+        }
     }
 }
 

--- a/encodings/runend/src/compute/filter.rs
+++ b/encodings/runend/src/compute/filter.rs
@@ -46,7 +46,16 @@ impl FilterKernel for RunEndVTable {
                         });
                     let values = filter(array.values(), &values_mask)?;
 
-                    RunEndArray::try_new(run_ends.into_array(), values).map(|a| a.into_array())
+                    // SAFETY: guaranteed by implementation of filter_run_end_primitive
+                    unsafe {
+                        Ok(RunEndArray::new_unchecked(
+                            run_ends.into_array(),
+                            values,
+                            0,
+                            mask_values.true_count(),
+                        )
+                        .into_array())
+                    }
                 }
             }
         }
@@ -71,7 +80,13 @@ pub fn filter_run_end(array: &RunEndArray, mask: &Mask) -> VortexResult<ArrayRef
         });
     let values = filter(array.values(), &values_mask)?;
 
-    RunEndArray::try_new(run_ends.into_array(), values).map(|a| a.into_array())
+    // SAFETY: enforced by filter_run_end_primitive
+    unsafe {
+        Ok(
+            RunEndArray::new_unchecked(run_ends.into_array(), values, 0, mask.true_count())
+                .into_array(),
+        )
+    }
 }
 
 // Code adapted from apache arrow-rs https://github.com/apache/arrow-rs/blob/b1f5c250ebb6c1252b4e7c51d15b8e77f4c361fa/arrow-select/src/filter.rs#L425

--- a/encodings/runend/src/compute/invert.rs
+++ b/encodings/runend/src/compute/invert.rs
@@ -9,13 +9,16 @@ use crate::{RunEndArray, RunEndVTable};
 
 impl InvertKernel for RunEndVTable {
     fn invert(&self, array: &RunEndArray) -> VortexResult<ArrayRef> {
-        RunEndArray::try_new_offset_length(
-            array.ends().clone(),
-            invert(array.values())?,
-            array.len(),
-            array.offset(),
-        )
-        .map(|a| a.into_array())
+        // SAFETY: ends are preserved
+        unsafe {
+            Ok(RunEndArray::new_unchecked(
+                array.ends().clone(),
+                invert(array.values())?,
+                array.len(),
+                array.offset(),
+            )
+            .into_array())
+        }
     }
 }
 

--- a/encodings/runend/src/compute/take_from.rs
+++ b/encodings/runend/src/compute/take_from.rs
@@ -36,12 +36,15 @@ impl TakeFromKernel for RunEndVTable {
         let values = take(source, indices.values())?;
 
         // Create a new run-end array containing values as values, instead of indices as values.
-        let ree_array = RunEndArray::try_new_offset_length(
-            indices.ends().clone(),
-            values,
-            indices.offset(),
-            indices.len(),
-        )?;
+        // SAFETY: we are copying ends from an existing valid RunEndArray
+        let ree_array = unsafe {
+            RunEndArray::new_unchecked(
+                indices.ends().clone(),
+                values,
+                indices.offset(),
+                indices.len(),
+            )
+        };
 
         Ok(Some(ree_array.into_array()))
     }

--- a/encodings/runend/src/ops.rs
+++ b/encodings/runend/src/ops.rs
@@ -21,13 +21,16 @@ impl OperationsVTable<RunEndVTable> for RunEndVTable {
             return ConstantArray::new(value, new_length).into_array();
         }
 
-        RunEndArray::new_unchecked(
-            array.ends().slice(slice_begin, slice_end),
-            array.values().slice(slice_begin, slice_end),
-            start + array.offset(),
-            new_length,
-        )
-        .into_array()
+        // SAFETY: we maintain the ends invariant in our slice implementation
+        unsafe {
+            RunEndArray::new_unchecked(
+                array.ends().slice(slice_begin, slice_end),
+                array.values().slice(slice_begin, slice_end),
+                start + array.offset(),
+                new_length,
+            )
+            .into_array()
+        }
     }
 
     fn scalar_at(array: &RunEndArray, index: usize) -> Scalar {

--- a/encodings/runend/src/serde.rs
+++ b/encodings/runend/src/serde.rs
@@ -66,7 +66,16 @@ impl EncodeVTable<RunEndVTable> for RunEndVTable {
     ) -> VortexResult<Option<RunEndArray>> {
         let parray = canonical.clone().into_primitive()?;
         let (ends, values) = runend_encode(&parray)?;
-        Ok(Some(RunEndArray::try_new(ends.to_array(), values)?))
+        // SAFETY: runend_decode implementation must return valid RunEndArray
+        //  components.
+        unsafe {
+            Ok(Some(RunEndArray::new_unchecked(
+                ends.to_array(),
+                values,
+                0,
+                parray.len(),
+            )))
+        }
     }
 }
 

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -443,7 +443,10 @@ fn canonicalize_varbin_inner<I: NativePType>(
         views[patch_index_usize] = patch;
     }
 
-    let array = VarBinViewArray::try_new(views.freeze(), Arc::from(buffers), dtype, validity)?;
+    // SAFETY: views are constructed to maintain the invariants
+    let array = unsafe {
+        VarBinViewArray::new_unchecked(views.freeze(), Arc::from(buffers), dtype, validity)
+    };
 
     Ok(Canonical::VarBinView(array))
 }

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -460,19 +460,22 @@ impl ZstdArray {
             }
             DType::Binary(_) | DType::Utf8(_) => {
                 // The decompressed buffer is a bunch of interleaved u32 lengths
-                // and strings of those lengths, we we need to reconstruct the
+                // and strings of those lengths, we need to reconstruct the
                 // views into those strings by passing through the buffer.
                 let views = reconstruct_views(decompressed.clone())?.slice(
                     slice_value_idx_start - n_skipped_values
                         ..slice_value_idx_stop - n_skipped_values,
                 );
 
-                let vbv = VarBinViewArray::try_new(
-                    views,
-                    Arc::from([decompressed]),
-                    self.dtype.clone(),
-                    slice_validity,
-                )?;
+                // SAFETY: we properly construct the views inside `reconstruct_views`
+                let vbv = unsafe {
+                    VarBinViewArray::new_unchecked(
+                        views,
+                        Arc::from([decompressed]),
+                        self.dtype.clone(),
+                        slice_validity,
+                    )
+                };
                 Ok(vbv.into_array())
             }
             _ => Err(vortex_err!(

--- a/fuzz/fuzz_targets/file_io.rs
+++ b/fuzz/fuzz_targets/file_io.rs
@@ -133,19 +133,19 @@ fn compare_struct(expected: ArrayRef, actual: ArrayRef) {
 fn has_nullable_struct(dtype: &DType) -> bool {
     dtype.is_struct() && dtype.is_nullable()
         || dtype
-            .as_struct()
+            .as_struct_opt()
             .map(|sdt| sdt.fields().any(|dtype| has_nullable_struct(&dtype)))
             .unwrap_or(false)
         || dtype
-            .as_list_element()
+            .as_list_element_opt()
             .map(|e| has_nullable_struct(e.as_ref()))
             .unwrap_or(false)
 }
 
 fn has_duplicate_field_names(dtype: &DType) -> bool {
-    if let Some(struct_dtype) = dtype.as_struct() {
+    if let Some(struct_dtype) = dtype.as_struct_opt() {
         struct_has_duplicate_names(struct_dtype)
-    } else if let Some(list_elem) = dtype.as_list_element() {
+    } else if let Some(list_elem) = dtype.as_list_element_opt() {
         has_duplicate_field_names(list_elem)
     } else {
         false

--- a/vortex-array/src/arrays/bool/array.rs
+++ b/vortex-array/src/arrays/bool/array.rs
@@ -5,14 +5,14 @@ use arrow_array::BooleanArray;
 use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder, MutableBuffer};
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
-use vortex_error::{vortex_ensure, VortexResult};
+use vortex_error::{VortexResult, vortex_ensure};
 
-use crate::arrays::{bool, BoolVTable};
+use crate::Canonical;
+use crate::arrays::{BoolVTable, bool};
 use crate::builders::ArrayBuilder;
 use crate::stats::{ArrayStats, StatsSetRef};
 use crate::validity::Validity;
 use crate::vtable::{ArrayVTable, CanonicalVTable, ValidityHelper};
-use crate::Canonical;
 
 /// A boolean array that stores true/false values in a compact bit-packed format.
 ///

--- a/vortex-array/src/arrays/bool/array.rs
+++ b/vortex-array/src/arrays/bool/array.rs
@@ -3,15 +3,16 @@
 
 use arrow_array::BooleanArray;
 use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder, MutableBuffer};
+use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
-use vortex_error::{VortexResult, vortex_panic};
+use vortex_error::{vortex_ensure, VortexResult};
 
-use crate::Canonical;
-use crate::arrays::{BoolVTable, bool};
+use crate::arrays::{bool, BoolVTable};
 use crate::builders::ArrayBuilder;
 use crate::stats::{ArrayStats, StatsSetRef};
 use crate::validity::Validity;
 use crate::vtable::{ArrayVTable, CanonicalVTable, ValidityHelper};
+use crate::Canonical;
 
 /// A boolean array that stores true/false values in a compact bit-packed format.
 ///
@@ -51,7 +52,87 @@ pub struct BoolArray {
 }
 
 impl BoolArray {
-    /// Create a new [`BoolArray`] from a set of indices, a length and a [`Validity`].
+    fn validate(
+        buffer: &ByteBuffer,
+        offset: usize,
+        len: usize,
+        validity: &Validity,
+    ) -> VortexResult<()> {
+        vortex_ensure!(
+            offset < 8,
+            "offset must be less than whole byte, was {offset} bits"
+        );
+
+        // Validate the buffer is large enough to hold all the bits
+        let required_bytes = offset.saturating_add(len).div_ceil(8);
+        vortex_ensure!(
+            buffer.len() >= required_bytes,
+            "BoolArray with offset={offset} len={len} cannot be built from buffer of size {}",
+            buffer.len()
+        );
+
+        // Validate validity
+        if let Some(validity_len) = validity.maybe_len() {
+            vortex_ensure!(
+                validity_len == len,
+                "BoolArray of size {len} cannot be built with validity of size {validity_len}"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+impl BoolArray {
+    /// Construct a new `BoolArray` from its components:
+    ///
+    /// * `buffer` is a raw ByteBuffer holding the packed bits
+    /// * `offset` is the number of bits in the start of the buffer that should be skipped when
+    ///   looking up the i-th value.
+    /// * `len` is the length of the array, which should correspond to the number of bits
+    /// * `validity` holds the null values.
+    ///
+    /// # Validation
+    ///
+    /// Buffer must be at least large enough to hold `len` bits starting at `offset`.
+    ///
+    /// A provided validity array must be of size `len`.
+    ///
+    /// The offset must be less than a whole byte.
+    pub fn try_new(
+        buffer: ByteBuffer,
+        offset: usize,
+        len: usize,
+        validity: Validity,
+    ) -> VortexResult<Self> {
+        Self::validate(&buffer, offset, len, &validity)?;
+
+        Ok(Self::new(
+            BooleanBuffer::new(buffer.into_arrow_buffer(), offset, len),
+            validity,
+        ))
+    }
+
+    /// Creates a new [`BoolArray`] from a [`BooleanBuffer`] and [`Validity`] directly.
+    ///
+    /// Panics if the validity length differs from the buffer length.
+    pub fn new(buffer: BooleanBuffer, validity: Validity) -> Self {
+        if let Some(validity_len) = validity.maybe_len() {
+            assert_eq!(buffer.len(), validity_len);
+        }
+
+        // Shrink the buffer to remove any whole bytes.
+        let buffer = buffer.shrink_offset();
+        Self {
+            dtype: DType::Bool(validity.nullability()),
+            buffer,
+            validity,
+            stats_set: ArrayStats::default(),
+        }
+    }
+
+    /// Create a new BoolArray from a set of indices and a length.
+    ///
     /// All indices must be less than the length.
     pub fn from_indices<I: IntoIterator<Item = usize>>(
         length: usize,
@@ -67,29 +148,6 @@ impl BoolArray {
             BooleanBufferBuilder::new_from_buffer(buffer, length).finish(),
             validity,
         )
-    }
-
-    /// Creates a new [`BoolArray`] from a [`BooleanBuffer`] and [`Validity`], without checking
-    /// any invariants.
-    pub fn new(buffer: BooleanBuffer, validity: Validity) -> Self {
-        if let Some(len) = validity.maybe_len()
-            && buffer.len() != len
-        {
-            vortex_panic!(
-                "Buffer and validity length mismatch: buffer={}, validity={}",
-                buffer.len(),
-                len
-            );
-        }
-
-        // Shrink the buffer to remove any whole bytes.
-        let buffer = buffer.shrink_offset();
-        Self {
-            dtype: DType::Bool(validity.nullability()),
-            buffer,
-            validity,
-            stats_set: ArrayStats::default(),
-        }
     }
 
     /// Returns the underlying [`BooleanBuffer`] of the array.

--- a/vortex-array/src/arrays/bool/serde.rs
+++ b/vortex-array/src/arrays/bool/serde.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use arrow_buffer::BooleanBuffer;
 use vortex_buffer::{Alignment, ByteBuffer};
 use vortex_dtype::DType;
-use vortex_error::{VortexExpect, VortexResult, vortex_bail};
+use vortex_error::{VortexResult, vortex_bail, vortex_err};
 
 use super::BoolArray;
 use crate::arrays::BoolVTable;
@@ -25,10 +24,9 @@ impl SerdeVTable<BoolVTable> for BoolVTable {
 
     fn metadata(array: &BoolArray) -> VortexResult<Option<Self::Metadata>> {
         let bit_offset = array.boolean_buffer().offset();
-        assert!(bit_offset < 8, "Offset must be <8, got {bit_offset}");
-        Ok(Some(ProstMetadata(BoolMetadata {
-            offset: u32::try_from(bit_offset).vortex_expect("checked"),
-        })))
+        let bit_offset = u32::try_from(bit_offset)
+            .map_err(|_| vortex_err!("bit_offset {bit_offset} overflows u32"))?;
+        Ok(Some(ProstMetadata(BoolMetadata { offset: bit_offset })))
     }
 
     fn build(
@@ -42,11 +40,6 @@ impl SerdeVTable<BoolVTable> for BoolVTable {
         if buffers.len() != 1 {
             vortex_bail!("Expected 1 buffer, got {}", buffers.len());
         }
-        let buffer = BooleanBuffer::new(
-            buffers[0].clone().into_arrow_buffer(),
-            metadata.offset as usize,
-            len,
-        );
 
         let validity = if children.is_empty() {
             Validity::from(dtype.nullability())
@@ -57,7 +50,7 @@ impl SerdeVTable<BoolVTable> for BoolVTable {
             vortex_bail!("Expected 0 or 1 child, got {}", children.len());
         };
 
-        Ok(BoolArray::new(buffer, validity))
+        BoolArray::try_new(buffers[0].clone(), metadata.offset as usize, len, validity)
     }
 }
 

--- a/vortex-array/src/arrays/chunked/serde.rs
+++ b/vortex-array/src/arrays/chunked/serde.rs
@@ -4,7 +4,7 @@
 use itertools::Itertools;
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, Nullability, PType};
-use vortex_error::{VortexExpect, VortexResult, vortex_bail};
+use vortex_error::{VortexResult, vortex_bail, vortex_err};
 
 use super::ChunkedEncoding;
 use crate::arrays::{ChunkedArray, ChunkedVTable, PrimitiveArray};
@@ -51,8 +51,8 @@ impl SerdeVTable<ChunkedVTable> for ChunkedVTable {
             .tuple_windows()
             .enumerate()
             .map(|(idx, (start, end))| {
-                let chunk_len =
-                    usize::try_from(end - start).vortex_expect("chunk length exceeds usize");
+                let chunk_len = usize::try_from(end - start)
+                    .map_err(|_| vortex_err!("chunk_len {} exceeds usize range", end - start))?;
                 children.get(idx + 1, dtype, chunk_len)
             })
             .try_collect()?;

--- a/vortex-array/src/arrays/constant/canonical.rs
+++ b/vortex-array/src/arrays/constant/canonical.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use arrow_buffer::BooleanBuffer;
-use vortex_buffer::{Buffer, BufferMut, buffer};
+use vortex_buffer::{Buffer, buffer};
 use vortex_dtype::{DType, Nullability, PType, match_each_native_ptype};
 use vortex_error::{VortexExpect, VortexResult};
 use vortex_scalar::{
@@ -148,12 +148,15 @@ fn canonical_byte_view(
         None => {
             let views = buffer![BinaryView::from(0_u128); len];
 
-            VarBinViewArray::try_new(
-                views,
-                Default::default(),
-                dtype.clone(),
-                Validity::AllInvalid,
-            )
+            // SAFETY: for all-null the views and buffers are just zeroed, never accessed.
+            unsafe {
+                Ok(VarBinViewArray::new_unchecked(
+                    views,
+                    Default::default(),
+                    dtype.clone(),
+                    Validity::AllInvalid,
+                ))
+            }
         }
         Some(scalar_bytes) => {
             // Create a view to hold the scalar bytes.
@@ -165,19 +168,17 @@ fn canonical_byte_view(
             }
 
             // Clone our constant view `len` times.
-            // TODO(aduffy): switch this out for a ConstantArray once we
-            //   add u128 PType, see https://github.com/vortex-data/vortex/issues/1110
-            let mut views = BufferMut::with_capacity_aligned(len, align_of::<u128>().into());
-            for _ in 0..len {
-                views.push(view);
-            }
+            let views = buffer![view; len];
 
-            VarBinViewArray::try_new(
-                views.freeze(),
-                Arc::from(buffers),
-                dtype.clone(),
-                Validity::from(dtype.nullability()),
-            )
+            // SAFETY: all the views are identical and point to a constant value.
+            unsafe {
+                Ok(VarBinViewArray::new_unchecked(
+                    views,
+                    Arc::from(buffers),
+                    dtype.clone(),
+                    Validity::from(dtype.nullability()),
+                ))
+            }
         }
     }
 }

--- a/vortex-array/src/arrays/decimal/mod.rs
+++ b/vortex-array/src/arrays/decimal/mod.rs
@@ -9,7 +9,7 @@ mod serde;
 use arrow_buffer::BooleanBufferBuilder;
 use vortex_buffer::{Buffer, BufferMut, ByteBuffer};
 use vortex_dtype::{DType, DecimalDType};
-use vortex_error::{VortexResult, vortex_panic};
+use vortex_error::{VortexExpect, VortexResult, vortex_ensure, vortex_panic};
 use vortex_scalar::{DecimalValueType, NativeDecimalType};
 
 use crate::builders::ArrayBuilder;
@@ -134,34 +134,57 @@ pub struct DecimalArray {
 }
 
 impl DecimalArray {
-    /// Creates a new [`DecimalArray`] from a [`Buffer`] and [`Validity`], without checking
-    /// any invariants.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the validity length is not compatible with the buffer length.
-    pub fn new<T: NativeDecimalType>(
-        buffer: Buffer<T>,
-        decimal_dtype: DecimalDType,
-        validity: Validity,
-    ) -> Self {
-        if let Some(len) = validity.maybe_len()
-            && buffer.len() != len
-        {
-            vortex_panic!(
+    fn validate<T: NativeDecimalType>(buffer: &Buffer<T>, validity: &Validity) -> VortexResult<()> {
+        if let Some(len) = validity.maybe_len() {
+            vortex_ensure!(
+                buffer.len() == len,
                 "Buffer and validity length mismatch: buffer={}, validity={}",
                 buffer.len(),
                 len,
             );
         }
 
-        Self {
-            dtype: DType::Decimal(decimal_dtype, validity.nullability()),
+        Ok(())
+    }
+}
+
+impl DecimalArray {
+    /// Creates a new [`DecimalArray`] from a [`Buffer`] and [`Validity`], without checking
+    /// any invariants.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the provided buffer and validity differ in length.
+    ///
+    /// See also [`DecimalArray::try_new`].
+    pub fn new<T: NativeDecimalType>(
+        buffer: Buffer<T>,
+        decimal_dtype: DecimalDType,
+        validity: Validity,
+    ) -> Self {
+        Self::try_new(buffer, decimal_dtype, validity).vortex_expect("DecimalArray new")
+    }
+
+    /// Build a new `DecimalArray` from a component `buffer`, decimal_dtype` and `validity`.
+    ///
+    /// This constructor validates the length of the buffer and validity are equal, returning
+    /// an error otherwise.
+    ///
+    /// See [`DecimalArray::new`] for an infallible constructor that panics on validation errors.
+    pub fn try_new<T: NativeDecimalType>(
+        buffer: Buffer<T>,
+        decimal_dtype: DecimalDType,
+        validity: Validity,
+    ) -> VortexResult<Self> {
+        Self::validate(&buffer, &validity)?;
+
+        Ok(Self {
             values: buffer.into_byte_buffer(),
             values_type: T::VALUES_TYPE,
+            dtype: DType::Decimal(decimal_dtype, validity.nullability()),
             validity,
-            stats_set: ArrayStats::default(),
-        }
+            stats_set: Default::default(),
+        })
     }
 
     /// Returns the underlying [`ByteBuffer`] of the array.

--- a/vortex-array/src/arrays/decimal/serde.rs
+++ b/vortex-array/src/arrays/decimal/serde.rs
@@ -2,8 +2,10 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_buffer::{Alignment, Buffer, ByteBuffer};
-use vortex_dtype::{DType, DecimalDType};
-use vortex_error::{VortexResult, vortex_bail};
+use vortex_dtype::DType;
+#[cfg(test)]
+use vortex_dtype::DecimalDType;
+use vortex_error::{VortexResult, vortex_bail, vortex_ensure};
 use vortex_scalar::{DecimalValueType, NativeDecimalType, match_each_decimal_value_type};
 
 use super::{DecimalArray, DecimalEncoding};
@@ -51,37 +53,21 @@ impl SerdeVTable<DecimalVTable> for DecimalVTable {
             vortex_bail!("Expected 0 or 1 child, got {}", children.len());
         };
 
-        let Some(decimal_dtype) = dtype.as_decimal() else {
+        let Some(decimal_dtype) = dtype.as_decimal_opt() else {
             vortex_bail!("Expected Decimal dtype, got {:?}", dtype)
         };
 
         match_each_decimal_value_type!(metadata.values_type(), |D| {
-            check_and_build_decimal::<D>(len, buffer, *decimal_dtype, validity)
+            // Check and reinterpret-cast the buffer
+            vortex_ensure!(
+                buffer.is_aligned(Alignment::of::<D>()),
+                "DecimalArray buffer not aligned for values type {:?}",
+                D::VALUES_TYPE
+            );
+            let buffer = Buffer::<D>::from_byte_buffer(buffer);
+            DecimalArray::try_new::<D>(buffer, *decimal_dtype, validity)
         })
     }
-}
-
-fn check_and_build_decimal<T: NativeDecimalType>(
-    array_len: usize,
-    buffer: ByteBuffer,
-    decimal_dtype: DecimalDType,
-    validity: Validity,
-) -> VortexResult<DecimalArray> {
-    // Assuming 16-byte alignment for decimal values
-    if !buffer.is_aligned(Alignment::of::<T>()) {
-        vortex_bail!("Buffer is not aligned to 16-byte boundary");
-    }
-
-    let buffer = Buffer::<T>::from_byte_buffer(buffer);
-    if buffer.len() != array_len {
-        vortex_bail!(
-            "Buffer length {} does not match expected length {} for decimal values",
-            buffer.len(),
-            array_len,
-        );
-    }
-
-    Ok(DecimalArray::new(buffer, decimal_dtype, validity))
 }
 
 #[cfg(test)]

--- a/vortex-array/src/arrays/list/compute/cast.rs
+++ b/vortex-array/src/arrays/list/compute/cast.rs
@@ -88,7 +88,7 @@ mod tests {
         let list = ListArray::try_new(
             PrimitiveArray::from_iter([0i32, 2, 3, 4]).to_array(),
             PrimitiveArray::from_iter([0, 2, 3]).to_array(),
-            Validity::Array(BoolArray::from_iter(vec![false, true, true]).to_array()),
+            Validity::Array(BoolArray::from_iter(vec![false, true]).to_array()),
         )
         .unwrap();
 

--- a/vortex-array/src/arrays/list/compute/cast.rs
+++ b/vortex-array/src/arrays/list/compute/cast.rs
@@ -11,7 +11,7 @@ use crate::{ArrayRef, register_kernel};
 
 impl CastKernel for ListVTable {
     fn cast(&self, array: &Self::Array, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
-        let Some(target_element_type) = dtype.as_list_element() else {
+        let Some(target_element_type) = dtype.as_list_element_opt() else {
             return Ok(None);
         };
 

--- a/vortex-array/src/arrays/list/mod.rs
+++ b/vortex-array/src/arrays/list/mod.rs
@@ -6,16 +6,17 @@ mod serde;
 
 use std::sync::Arc;
 
+#[cfg(feature = "test-harness")]
 use itertools::Itertools;
-use num_traits::{AsPrimitive, PrimInt};
-use vortex_dtype::{DType, NativePType, match_each_native_ptype};
-use vortex_error::{VortexExpect, VortexResult, vortex_bail};
+use num_traits::{AsPrimitive, NumCast, PrimInt};
+use vortex_dtype::{DType, NativePType, match_each_integer_ptype, match_each_native_ptype};
+use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_ensure};
 use vortex_scalar::Scalar;
 
 use crate::arrays::PrimitiveVTable;
 #[cfg(feature = "test-harness")]
 use crate::builders::{ArrayBuilder, ListBuilder};
-use crate::compute::sub_scalar;
+use crate::compute::{min_max, sub_scalar};
 use crate::stats::{ArrayStats, StatsSetRef};
 use crate::validity::Validity;
 use crate::vtable::{
@@ -124,6 +125,73 @@ impl<T> OffsetPType for T where T: NativePType + PrimInt + AsPrimitive<usize> + 
 // - The size of the validity is the size-1 of the offset array
 
 impl ListArray {
+    fn validate(
+        elements: &dyn Array,
+        offsets: &dyn Array,
+        validity: &Validity,
+    ) -> VortexResult<()> {
+        // Offsets must be of integer type, and cannot go lower than 0.
+        vortex_ensure!(
+            offsets.dtype().is_int() && !offsets.dtype().is_nullable(),
+            "offsets have invalid type {}",
+            offsets.dtype()
+        );
+
+        // We can safely unwrap the DType as primitive now
+        let offsets_ptype = offsets.dtype().as_ptype();
+
+        // Offsets must be sorted (but not strictly sorted, zero-length lists are allowed)
+        if let Some(is_sorted) = offsets.statistics().compute_is_sorted() {
+            vortex_ensure!(is_sorted, "offsets must be sorted");
+        } else {
+            vortex_bail!("offsets must report is_sorted statistic");
+        }
+
+        // Validate that offsets min is non-negative, and max does not exceed the length of
+        // the elements array.
+        if let Some(min_max) = min_max(offsets)? {
+            match_each_integer_ptype!(offsets_ptype, |P| {
+                let max_offset = <P as NumCast>::from(elements.len()).unwrap_or(P::MAX);
+
+                #[allow(clippy::absurd_extreme_comparisons, unused_comparisons)]
+                {
+                    if let Some(min) = min_max.min.as_primitive().as_::<P>() {
+                        vortex_ensure!(
+                            min >= 0 && min <= max_offset,
+                            "offsets minimum {min} outside valid range [0, {max_offset}]"
+                        );
+                    }
+
+                    if let Some(max) = min_max.max.as_primitive().as_::<P>() {
+                        vortex_ensure!(
+                            max >= 0 && max <= max_offset,
+                            "offsets maximum {max} outside valid range [0, {max_offset}]"
+                        )
+                    }
+                }
+            })
+        } else {
+            // TODO(aduffy): fallback to slower validation pathway?
+            vortex_bail!(
+                "offsets array with encoding {} must support min_max compute function",
+                offsets.encoding_id()
+            );
+        };
+
+        // If a validity array is present, it must be the same length as the ListArray
+        if let Some(validity_len) = validity.maybe_len() {
+            vortex_ensure!(
+                validity_len == offsets.len() - 1,
+                "validity with size {validity_len} does not match array size {}",
+                offsets.len() - 1
+            );
+        }
+
+        Ok(())
+    }
+}
+
+impl ListArray {
     pub fn new(elements: ArrayRef, offsets: ArrayRef, validity: Validity) -> Self {
         Self::try_new(elements, offsets, validity).vortex_expect("ListArray new")
     }
@@ -145,6 +213,8 @@ impl ListArray {
         if offsets.is_empty() {
             vortex_bail!("Offsets must have at least one element, [0] for an empty list");
         }
+
+        Self::validate(&elements, &offsets, &validity)?;
 
         Ok(Self {
             dtype: DType::List(Arc::new(elements.dtype().clone()), nullability),

--- a/vortex-array/src/arrays/list/serde.rs
+++ b/vortex-array/src/arrays/list/serde.rs
@@ -3,7 +3,7 @@
 
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, Nullability, PType};
-use vortex_error::{VortexExpect, VortexResult, vortex_bail};
+use vortex_error::{VortexResult, vortex_bail};
 
 use super::{ListArray, ListVTable};
 use crate::arrays::ListEncoding;
@@ -26,8 +26,7 @@ impl SerdeVTable<ListVTable> for ListVTable {
     fn metadata(array: &ListArray) -> VortexResult<Option<Self::Metadata>> {
         Ok(Some(ProstMetadata(ListMetadata {
             elements_len: array.elements().len() as u64,
-            offset_ptype: PType::try_from(array.offsets().dtype())
-                .vortex_expect("Must be a valid PType") as i32,
+            offset_ptype: PType::try_from(array.offsets().dtype())? as i32,
         })))
     }
 
@@ -54,7 +53,7 @@ impl SerdeVTable<ListVTable> for ListVTable {
         let elements = children.get(
             0,
             element_dtype.as_ref(),
-            usize::try_from(metadata.elements_len).vortex_expect("Too many elements"),
+            usize::try_from(metadata.elements_len)?,
         )?;
 
         let offsets = children.get(

--- a/vortex-array/src/arrays/struct_/compute/cast.rs
+++ b/vortex-array/src/arrays/struct_/compute/cast.rs
@@ -12,13 +12,13 @@ use crate::{ArrayRef, IntoArray, register_kernel};
 
 impl CastKernel for StructVTable {
     fn cast(&self, array: &StructArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
-        let Some(target_sdtype) = dtype.as_struct() else {
+        let Some(target_sdtype) = dtype.as_struct_opt() else {
             return Ok(None);
         };
 
         let source_sdtype = array
             .dtype()
-            .as_struct()
+            .as_struct_opt()
             .vortex_expect("struct array must have struct dtype");
 
         if target_sdtype.names() != source_sdtype.names() {

--- a/vortex-array/src/arrays/struct_/mod.rs
+++ b/vortex-array/src/arrays/struct_/mod.rs
@@ -202,7 +202,7 @@ impl StructArray {
     }
 
     pub fn struct_fields(&self) -> &StructFields {
-        let Some(struct_dtype) = &self.dtype.as_struct() else {
+        let Some(struct_dtype) = &self.dtype.as_struct_opt() else {
             unreachable!(
                 "struct arrays must have be a DType::Struct, this is likely an internal bug."
             )

--- a/vortex-array/src/arrays/varbinview/compact.rs
+++ b/vortex-array/src/arrays/varbinview/compact.rs
@@ -28,12 +28,15 @@ impl VarBinViewArray {
         // Compaction pathways, depend on the validity
         match self.validity() {
             // The array contains no values, all buffers can be dropped.
-            Validity::AllInvalid => Ok(VarBinViewArray::try_new(
-                self.views().clone(),
-                Default::default(),
-                self.dtype().clone(),
-                self.validity().clone(),
-            )?),
+            // SAFETY: for all-invalid array, zeroed views and buffer because they are never accessed.
+            Validity::AllInvalid => unsafe {
+                Ok(VarBinViewArray::new_unchecked(
+                    self.views().clone(),
+                    Default::default(),
+                    self.dtype().clone(),
+                    self.validity().clone(),
+                ))
+            },
             // Non-null pathway
             Validity::NonNullable | Validity::AllValid => rebuild_nonnull(self),
             // Nullable pathway, requires null-checks for each value

--- a/vortex-array/src/arrays/varbinview/compute/cast.rs
+++ b/vortex-array/src/arrays/varbinview/compute/cast.rs
@@ -18,15 +18,19 @@ impl CastKernel for VarBinViewVTable {
         let new_nullability = dtype.nullability();
         let new_validity = array.validity().clone().cast_nullability(new_nullability)?;
         let new_dtype = array.dtype().with_nullability(new_nullability);
-        Ok(Some(
-            VarBinViewArray::try_new(
-                array.views().clone(),
-                array.buffers().clone(),
-                new_dtype,
-                new_validity,
-            )?
-            .into_array(),
-        ))
+
+        // SAFETY: casting just changes the DType, does not affect invariants on views/buffers.
+        unsafe {
+            Ok(Some(
+                VarBinViewArray::new_unchecked(
+                    array.views().clone(),
+                    array.buffers().clone(),
+                    new_dtype,
+                    new_validity,
+                )
+                .into_array(),
+            ))
+        }
     }
 }
 

--- a/vortex-array/src/arrays/varbinview/compute/mask.rs
+++ b/vortex-array/src/arrays/varbinview/compute/mask.rs
@@ -11,13 +11,16 @@ use crate::{ArrayRef, IntoArray, register_kernel};
 
 impl MaskKernel for VarBinViewVTable {
     fn mask(&self, array: &VarBinViewArray, mask: &Mask) -> VortexResult<ArrayRef> {
-        Ok(VarBinViewArray::try_new(
-            array.views().clone(),
-            array.buffers().clone(),
-            array.dtype().as_nullable(),
-            array.validity().mask(mask)?,
-        )?
-        .into_array())
+        // SAFETY: masking the validity does not affect the invariants
+        unsafe {
+            Ok(VarBinViewArray::new_unchecked(
+                array.views().clone(),
+                array.buffers().clone(),
+                array.dtype().as_nullable(),
+                array.validity().mask(mask)?,
+            )
+            .into_array())
+        }
     }
 }
 

--- a/vortex-array/src/arrays/varbinview/compute/take.rs
+++ b/vortex-array/src/arrays/varbinview/compute/take.rs
@@ -18,7 +18,7 @@ impl TakeKernel for VarBinViewVTable {
     fn take(&self, array: &VarBinViewArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
         // Compute the new validity
 
-        // This is valid since all elements (of all arrays) even null values are inside must be the
+        // This is valid since all elements (of all arrays) even null values must be inside
         // min-max valid range.
         let validity = array.validity().take(indices)?;
         let indices = indices.to_primitive()?;
@@ -28,15 +28,18 @@ impl TakeKernel for VarBinViewVTable {
             take_views(array.views(), indices.as_slice::<I>())
         });
 
-        Ok(VarBinViewArray::try_new(
-            views_buffer,
-            array.buffers().clone(),
-            array
-                .dtype()
-                .union_nullability(indices.dtype().nullability()),
-            validity,
-        )?
-        .into_array())
+        // SAFETY: taking all components at same indices maintains invariants
+        unsafe {
+            Ok(VarBinViewArray::new_unchecked(
+                views_buffer,
+                array.buffers().clone(),
+                array
+                    .dtype()
+                    .union_nullability(indices.dtype().nullability()),
+                validity,
+            )
+            .into_array())
+        }
     }
 }
 

--- a/vortex-array/src/arrays/varbinview/mod.rs
+++ b/vortex-array/src/arrays/varbinview/mod.rs
@@ -408,23 +408,24 @@ impl VarBinViewArray {
     where
         F: Fn(&[u8]) -> bool,
     {
-        // Check all views
         for (idx, &view) in views.iter().enumerate() {
             if validity.is_null(idx)? {
                 continue;
             }
 
             if view.is_inlined() {
+                // Validate the inline bytestring
                 let bytes = &unsafe { view.inlined }.data[..view.len() as usize];
                 vortex_ensure!(
                     validator(bytes),
                     "view at index {idx}: inlined bytes failed utf-8 validation"
                 );
             } else {
+                // Validate the view pointer
                 let view = view.as_view();
                 let buf_index = view.buffer_index as usize;
                 let start_offset = view.offset as usize;
-                let end_offset = start_offset + view.size as usize;
+                let end_offset = start_offset.saturating_add(view.size as usize);
 
                 let buf = buffers.get(buf_index).ok_or_else(||
                     vortex_err!("view at index {idx} references invalid buffer: {buf_index} out of bounds for VarBinViewArray with {} buffers",
@@ -432,12 +433,14 @@ impl VarBinViewArray {
 
                 vortex_ensure!(
                     start_offset < buf.len(),
-                    "start offset {start_offset} out of bounds for buffer {buf_index}",
+                    "start offset {start_offset} out of bounds for buffer {buf_index} with size {}",
+                    buf.len(),
                 );
 
                 vortex_ensure!(
-                    end_offset < buf.len(),
-                    "end offset {end_offset} out of bounds for buffer {buf_index}",
+                    end_offset <= buf.len(),
+                    "end offset {end_offset} out of bounds for buffer {buf_index} with size {}",
+                    buf.len(),
                 );
 
                 // Make sure the prefix data matches the buffer data.
@@ -446,6 +449,8 @@ impl VarBinViewArray {
                     view.prefix == bytes[..4],
                     "VarBinView prefix does not match full string"
                 );
+
+                // Validate the full string
                 vortex_ensure!(
                     validator(bytes),
                     "view at index {idx}: outlined bytes fails utf-8 validation"

--- a/vortex-array/src/arrays/varbinview/mod.rs
+++ b/vortex-array/src/arrays/varbinview/mod.rs
@@ -465,6 +465,7 @@ impl VarBinViewArray {
 impl VarBinViewArray {
     /// Build a new `VarBinViewArray` from components with validation.
     ///
+    /// # Safety
     /// This should only be used when you know for certain that all components are already
     /// validated, for example during array operations that preserve the invariants of the encoding.
     ///

--- a/vortex-array/src/arrays/varbinview/mod.rs
+++ b/vortex-array/src/arrays/varbinview/mod.rs
@@ -6,9 +6,11 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use static_assertions::{assert_eq_align, assert_eq_size};
-use vortex_buffer::{Alignment, Buffer, ByteBuffer};
+use vortex_buffer::{Buffer, ByteBuffer};
 use vortex_dtype::{DType, Nullability};
-use vortex_error::{VortexExpect, VortexResult, VortexUnwrap, vortex_bail, vortex_panic};
+use vortex_error::{
+    VortexExpect, VortexResult, VortexUnwrap, vortex_bail, vortex_ensure, vortex_err, vortex_panic,
+};
 
 use crate::builders::{ArrayBuilder, VarBinViewBuilder};
 use crate::stats::{ArrayStats, StatsSetRef};
@@ -373,6 +375,89 @@ pub struct VarBinViewArray {
 pub struct VarBinViewEncoding;
 
 impl VarBinViewArray {
+    fn validate(
+        views: &Buffer<BinaryView>,
+        buffers: &Arc<[ByteBuffer]>,
+        dtype: &DType,
+        validity: &Validity,
+    ) -> VortexResult<()> {
+        vortex_ensure!(
+            validity.nullability() == dtype.nullability(),
+            "validity {:?} incompatible with nullability {:?}",
+            validity,
+            dtype.nullability()
+        );
+
+        match dtype {
+            DType::Utf8(_) => Self::validate_views(views, buffers, validity, |string| {
+                std::str::from_utf8(string).is_ok()
+            })?,
+            DType::Binary(_) => Self::validate_views(views, buffers, validity, |_| true)?,
+            _ => vortex_bail!("invalid DType {dtype}"),
+        }
+
+        Ok(())
+    }
+
+    fn validate_views<F>(
+        views: &Buffer<BinaryView>,
+        buffers: &Arc<[ByteBuffer]>,
+        validity: &Validity,
+        validator: F,
+    ) -> VortexResult<()>
+    where
+        F: Fn(&[u8]) -> bool,
+    {
+        // Check all views
+        for (idx, &view) in views.iter().enumerate() {
+            if validity.is_null(idx)? {
+                continue;
+            }
+
+            if view.is_inlined() {
+                let bytes = &unsafe { view.inlined }.data[..view.len() as usize];
+                vortex_ensure!(
+                    validator(bytes),
+                    "view at index {idx}: inlined bytes failed utf-8 validation"
+                );
+            } else {
+                let view = view.as_view();
+                let buf_index = view.buffer_index as usize;
+                let start_offset = view.offset as usize;
+                let end_offset = start_offset + view.size as usize;
+
+                let buf = buffers.get(buf_index).ok_or_else(||
+                    vortex_err!("view at index {idx} references invalid buffer: {buf_index} out of bounds for VarBinViewArray with {} buffers",
+                        buffers.len()))?;
+
+                vortex_ensure!(
+                    start_offset < buf.len(),
+                    "start offset {start_offset} out of bounds for buffer {buf_index}",
+                );
+
+                vortex_ensure!(
+                    end_offset < buf.len(),
+                    "end offset {end_offset} out of bounds for buffer {buf_index}",
+                );
+
+                // Make sure the prefix data matches the buffer data.
+                let bytes = &buf[start_offset..end_offset];
+                vortex_ensure!(
+                    view.prefix == bytes[..4],
+                    "VarBinView prefix does not match full string"
+                );
+                vortex_ensure!(
+                    validator(bytes),
+                    "view at index {idx}: outlined bytes fails utf-8 validation"
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl VarBinViewArray {
     pub fn new(
         views: Buffer<BinaryView>,
         buffers: Arc<[ByteBuffer]>,
@@ -388,17 +473,7 @@ impl VarBinViewArray {
         dtype: DType,
         validity: Validity,
     ) -> VortexResult<Self> {
-        if views.alignment() != Alignment::of::<BinaryView>() {
-            vortex_bail!("Views must be aligned to a 128 bits");
-        }
-
-        if !matches!(dtype, DType::Binary(_) | DType::Utf8(_)) {
-            vortex_bail!(MismatchedTypes: "utf8 or binary", dtype);
-        }
-
-        if dtype.is_nullable() == (validity == Validity::NonNullable) {
-            vortex_bail!("incorrect validity {:?}", validity);
-        }
+        Self::validate(&views, &buffers, &dtype, &validity)?;
 
         Ok(Self {
             dtype,
@@ -426,7 +501,7 @@ impl VarBinViewArray {
 
     /// Access value bytes at a given index
     ///
-    /// Will return a bytebuffer pointing to the underlying data without performing a copy
+    /// Will return a `ByteBuffer` containing the data without performing a copy.
     #[inline]
     pub fn bytes_at(&self, index: usize) -> ByteBuffer {
         let views = self.views();

--- a/vortex-array/src/arrays/varbinview/mod.rs
+++ b/vortex-array/src/arrays/varbinview/mod.rs
@@ -463,6 +463,27 @@ impl VarBinViewArray {
 }
 
 impl VarBinViewArray {
+    /// Build a new `VarBinViewArray` from components with validation.
+    ///
+    /// This should only be used when you know for certain that all components are already
+    /// validated, for example during array operations that preserve the invariants of the encoding.
+    ///
+    /// See [`VarBinViewArray::try_new`] for a safe constructor that does validation.
+    pub unsafe fn new_unchecked(
+        views: Buffer<BinaryView>,
+        buffers: Arc<[ByteBuffer]>,
+        dtype: DType,
+        validity: Validity,
+    ) -> Self {
+        Self {
+            dtype,
+            buffers,
+            views,
+            validity,
+            stats_set: Default::default(),
+        }
+    }
+
     pub fn new(
         views: Buffer<BinaryView>,
         buffers: Arc<[ByteBuffer]>,

--- a/vortex-array/src/arrays/varbinview/serde.rs
+++ b/vortex-array/src/arrays/varbinview/serde.rs
@@ -33,9 +33,9 @@ impl SerdeVTable<VarBinViewVTable> for VarBinViewVTable {
             vortex_bail!("Expected at least 1 buffer, got {}", buffers.len());
         }
         let mut buffers: Vec<ByteBuffer> = buffers.to_vec();
+        let views = buffers.pop().vortex_expect("buffers non-empty");
 
-        let views =
-            Buffer::<BinaryView>::from_byte_buffer(buffers.pop().vortex_expect("checked above"));
+        let views = Buffer::<BinaryView>::from_byte_buffer(views);
 
         if views.len() != len {
             vortex_bail!("Expected {} views, got {}", len, views.len());

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -210,20 +210,23 @@ impl<T: ByteViewType> FromArrowArray<&GenericByteViewArray<T>> for ArrayRef {
             Buffer::from_arrow_scalar_buffer(value.views().clone()).into_byte_buffer(),
         );
 
-        VarBinViewArray::try_new(
-            views_buffer,
-            Arc::from(
-                value
-                    .data_buffers()
-                    .iter()
-                    .map(|b| ByteBuffer::from_arrow_buffer(b.clone(), Alignment::of::<u8>()))
-                    .collect::<Vec<_>>(),
-            ),
-            dtype,
-            nulls(value.nulls(), nullable),
-        )
-        .vortex_expect("Failed to convert Arrow GenericByteViewArray to Vortex VarBinViewArray")
-        .into_array()
+        // SAFETY: arrow-rs ByteViewArray already checks the same invariants, we inherit those
+        //  guarantees by zero-copy constructing from one.
+        unsafe {
+            VarBinViewArray::new_unchecked(
+                views_buffer,
+                Arc::from(
+                    value
+                        .data_buffers()
+                        .iter()
+                        .map(|b| ByteBuffer::from_arrow_buffer(b.clone(), Alignment::of::<u8>()))
+                        .collect::<Vec<_>>(),
+                ),
+                dtype,
+                nulls(value.nulls(), nullable),
+            )
+            .into_array()
+        }
     }
 }
 

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -114,8 +114,8 @@ impl VarBinViewBuilder {
         );
     }
 
-    pub fn completed_block_count(&self) -> usize {
-        self.completed.len() as usize
+    pub fn completed_block_count(&self) -> u32 {
+        self.completed.len()
     }
 
     // Pushes an array of values into the buffer, where the buffers are sections of a

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -161,13 +161,15 @@ impl VarBinViewBuilder {
             .null_buffer_builder
             .finish_with_nullability(self.nullability);
 
-        VarBinViewArray::try_new(
-            std::mem::take(&mut self.views_builder).freeze(),
-            buffers.finish(),
-            std::mem::replace(&mut self.dtype, DType::Null),
-            validity,
-        )
-        .vortex_expect("VarBinViewArray components should be valid.")
+        // SAFETY: the builder methods check safety at each step.
+        unsafe {
+            VarBinViewArray::new_unchecked(
+                std::mem::take(&mut self.views_builder).freeze(),
+                buffers.finish(),
+                std::mem::replace(&mut self.dtype, DType::Null),
+                validity,
+            )
+        }
     }
 }
 

--- a/vortex-array/src/compute/list_contains.rs
+++ b/vortex-array/src/compute/list_contains.rs
@@ -503,7 +503,11 @@ mod tests {
         #[case] value: Option<&str>,
         #[case] expected: BoolArray,
     ) {
-        let element_nullability = list_array.dtype().as_list_element().unwrap().nullability();
+        let element_nullability = list_array
+            .dtype()
+            .as_list_element_opt()
+            .unwrap()
+            .nullability();
         let scalar = match value {
             None => Scalar::null(DType::Utf8(Nullability::Nullable)),
             Some(v) => Scalar::utf8(v, element_nullability),

--- a/vortex-btrblocks/benches/dict_encode.rs
+++ b/vortex-btrblocks/benches/dict_encode.rs
@@ -38,7 +38,7 @@ fn encode_generic(bencher: Bencher) {
 fn encode_specialized(bencher: Bencher) {
     bencher
         .with_inputs(|| IntegerStats::generate(&make_array()))
-        .bench_values(|stats| dictionary_encode(&stats).unwrap());
+        .bench_values(|stats| dictionary_encode(&stats));
 }
 
 fn main() {

--- a/vortex-btrblocks/src/float.rs
+++ b/vortex-btrblocks/src/float.rs
@@ -315,7 +315,7 @@ impl Scheme for DictScheme {
         allowed_cascading: usize,
         _excludes: &[FloatCode],
     ) -> VortexResult<ArrayRef> {
-        let dict_array = dictionary_encode(stats)?;
+        let dict_array = dictionary_encode(stats);
 
         // Only compress the codes.
         let codes_stats = IntegerStats::generate_opts(
@@ -344,8 +344,8 @@ impl Scheme for DictScheme {
             &[DICT_SCHEME],
         )?;
 
-        // SAFETY: compressing codes or values does not change their value
-        unsafe { Ok(DictArray::try_new(compressed_codes, compressed_values)?.into_array()) }
+        // SAFETY: compressing codes or values does not alter the invariants
+        unsafe { Ok(DictArray::new_unchecked(compressed_codes, compressed_values).into_array()) }
     }
 }
 

--- a/vortex-btrblocks/src/float.rs
+++ b/vortex-btrblocks/src/float.rs
@@ -344,7 +344,8 @@ impl Scheme for DictScheme {
             &[DICT_SCHEME],
         )?;
 
-        Ok(DictArray::try_new(compressed_codes, compressed_values)?.into_array())
+        // SAFETY: compressing codes or values does not change their value
+        unsafe { Ok(DictArray::try_new(compressed_codes, compressed_values)?.into_array()) }
     }
 }
 

--- a/vortex-btrblocks/src/float/dictionary.rs
+++ b/vortex-btrblocks/src/float/dictionary.rs
@@ -10,7 +10,6 @@ use vortex_array::vtable::ValidityHelper;
 use vortex_buffer::Buffer;
 use vortex_dict::DictArray;
 use vortex_dtype::half::f16;
-use vortex_error::VortexResult;
 
 use crate::float::stats::{ErasedDistinctValues, FloatStats};
 
@@ -39,11 +38,12 @@ macro_rules! typed_encode {
         };
         let values = PrimitiveArray::new(values, values_validity).into_array();
 
-        DictArray::try_new(codes, values)
+        // SAFETY: enforced by the DictEncoder
+        unsafe { DictArray::new_unchecked(codes, values) }
     }};
 }
 
-pub fn dictionary_encode(stats: &FloatStats) -> VortexResult<DictArray> {
+pub fn dictionary_encode(stats: &FloatStats) -> DictArray {
     let validity = stats.src.validity();
     match &stats.distinct_values {
         ErasedDistinctValues::F16(typed) => typed_encode!(stats, typed, validity, f16),
@@ -112,7 +112,7 @@ mod tests {
         let array = PrimitiveArray::new(values, validity);
 
         let stats = FloatStats::generate(&array);
-        let dict_array = dictionary_encode(&stats).unwrap();
+        let dict_array = dictionary_encode(&stats);
         assert_eq!(dict_array.values().len(), 2);
         assert_eq!(dict_array.codes().len(), 5);
 

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -586,7 +586,7 @@ impl Scheme for DictScheme {
         // TODO(aduffy): we can be more prescriptive: we know that codes will EITHER be
         //    RLE or FOR + BP. Cascading probably wastes some time here.
 
-        let dict = dictionary_encode(stats)?;
+        let dict = dictionary_encode(stats);
 
         // Cascade the codes child
         // Don't allow SequenceArray as the codes child as it merely adds extra indirection without actually compressing data.

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -600,7 +600,10 @@ impl Scheme for DictScheme {
             &new_excludes,
         )?;
 
-        Ok(DictArray::try_new(compressed_codes, dict.values().clone())?.into_array())
+        // SAFETY: compressing codes does not change their values
+        unsafe {
+            Ok(DictArray::new_unchecked(compressed_codes, dict.values().clone()).into_array())
+        }
     }
 }
 

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -678,7 +678,13 @@ impl Scheme for RunEndScheme {
             &new_excludes,
         )?;
 
-        Ok(RunEndArray::try_new(compressed_ends, compressed_values)?.into_array())
+        // SAFETY: compression doesn't affect invariants
+        unsafe {
+            Ok(
+                RunEndArray::new_unchecked(compressed_ends, compressed_values, 0, stats.src.len())
+                    .into_array(),
+            )
+        }
     }
 }
 

--- a/vortex-btrblocks/src/integer/dictionary.rs
+++ b/vortex-btrblocks/src/integer/dictionary.rs
@@ -9,7 +9,6 @@ use vortex_array::validity::Validity;
 use vortex_array::vtable::ValidityHelper;
 use vortex_buffer::Buffer;
 use vortex_dict::DictArray;
-use vortex_error::VortexResult;
 
 use crate::integer::IntegerStats;
 use crate::integer::stats::ErasedStats;
@@ -39,12 +38,13 @@ macro_rules! typed_encode {
         };
 
         let values = PrimitiveArray::new(values, values_validity).into_array();
-        DictArray::try_new(codes, values)
+        // SAFETY: invariants enforced in DictEncoder
+        unsafe { DictArray::new_unchecked(codes, values) }
     }};
 }
 
 #[allow(clippy::cognitive_complexity)]
-pub fn dictionary_encode(stats: &IntegerStats) -> VortexResult<DictArray> {
+pub fn dictionary_encode(stats: &IntegerStats) -> DictArray {
     // We need to preserve the nullability somehow from the original
     let src_validity = stats.src.validity();
 
@@ -126,7 +126,7 @@ mod tests {
         let array = PrimitiveArray::new(data, validity);
 
         let stats = IntegerStats::generate(&array);
-        let dict_array = dictionary_encode(&stats).unwrap();
+        let dict_array = dictionary_encode(&stats);
         assert_eq!(dict_array.values().len(), 2);
         assert_eq!(dict_array.codes().len(), 5);
 

--- a/vortex-btrblocks/src/string.rs
+++ b/vortex-btrblocks/src/string.rs
@@ -213,7 +213,8 @@ impl Scheme for DictScheme {
             &[DictScheme.code()],
         )?;
 
-        Ok(DictArray::try_new(compressed_codes, compressed_values)?.into_array())
+        // SAFETY: compressing codes does not change their values
+        unsafe { Ok(DictArray::try_new(compressed_codes, compressed_values)?.into_array()) }
     }
 }
 

--- a/vortex-btrblocks/src/string.rs
+++ b/vortex-btrblocks/src/string.rs
@@ -213,8 +213,8 @@ impl Scheme for DictScheme {
             &[DictScheme.code()],
         )?;
 
-        // SAFETY: compressing codes does not change their values
-        unsafe { Ok(DictArray::try_new(compressed_codes, compressed_values)?.into_array()) }
+        // SAFETY: compressing codes or values does not alter the invariants
+        unsafe { Ok(DictArray::new_unchecked(compressed_codes, compressed_values).into_array()) }
     }
 }
 

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -218,7 +218,7 @@ impl FileFormat for VortexFormat {
 
             let struct_dtype = vxf
                 .dtype()
-                .as_struct()
+                .as_struct_opt()
                 .vortex_expect("dtype is not a struct");
 
             // Evaluate the statistics for each column that we are able to return to DataFusion.

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -402,7 +402,7 @@ impl DType {
     }
 
     /// Check returns the inner decimal type if the dtype is a decimal
-    pub fn as_decimal(&self) -> Option<&DecimalDType> {
+    pub fn as_decimal_opt(&self) -> Option<&DecimalDType> {
         match self {
             Decimal(decimal, _) => Some(decimal),
             _ => None,
@@ -410,7 +410,7 @@ impl DType {
     }
 
     /// Get the `StructDType` if `self` is a `StructDType`, otherwise `None`
-    pub fn as_struct(&self) -> Option<&StructFields> {
+    pub fn as_struct_opt(&self) -> Option<&StructFields> {
         match self {
             Struct(s, _) => Some(s),
             _ => None,
@@ -418,7 +418,7 @@ impl DType {
     }
 
     /// Get the inner dtype if `self` is a `ListDType`, otherwise `None`
-    pub fn as_list_element(&self) -> Option<&Arc<DType>> {
+    pub fn as_list_element_opt(&self) -> Option<&Arc<DType>> {
         match self {
             List(s, _) => Some(s),
             _ => None,

--- a/vortex-dtype/src/struct_.rs
+++ b/vortex-dtype/src/struct_.rs
@@ -445,10 +445,10 @@ mod test {
             Nullability::Nullable,
         );
         assert!(dtype.is_nullable());
-        assert!(dtype.as_struct().is_some());
-        assert!(a_type.as_struct().is_none());
+        assert!(dtype.as_struct_opt().is_some());
+        assert!(a_type.as_struct_opt().is_none());
 
-        let sdt = dtype.as_struct().unwrap();
+        let sdt = dtype.as_struct_opt().unwrap();
         assert_eq!(sdt.names().len(), 2);
         assert_eq!(sdt.fields().len(), 2);
         assert_eq!(sdt.names(), ["A", "B"]);

--- a/vortex-duckdb/src/convert/scalar.rs
+++ b/vortex-duckdb/src/convert/scalar.rs
@@ -94,7 +94,7 @@ impl ToDuckDBScalar for DecimalScalar<'_> {
     fn try_to_duckdb_scalar(&self) -> VortexResult<Value> {
         let decimal_type = self
             .dtype()
-            .as_decimal()
+            .as_decimal_opt()
             .ok_or_else(|| vortex_err!("decimal scalar without decimal dtype"))?;
 
         let Some(decimal_value) = self.decimal_value() else {

--- a/vortex-duckdb/src/scan.rs
+++ b/vortex-duckdb/src/scan.rs
@@ -82,7 +82,7 @@ fn extract_schema_from_vortex_file(
 
     // For now, we assume the top-level type to be a struct.
     let struct_dtype = dtype
-        .as_struct()
+        .as_struct_opt()
         .ok_or_else(|| vortex_err!("Vortex file must contain a struct array at the top level"))?;
 
     let mut column_names = Vec::new();

--- a/vortex-error/src/lib.rs
+++ b/vortex-error/src/lib.rs
@@ -430,6 +430,20 @@ macro_rules! vortex_bail {
     };
 }
 
+/// A macro that mirrors `assert!` but instead of panicking on a failed condition,
+/// it will immediately return an erroneous `VortexResult` to the calling context.
+#[macro_export]
+macro_rules! vortex_ensure {
+    ($cond:expr) => {
+        vortex_ensure!($cond, stringify!($cond));
+    };
+    ($cond:expr, $($tt:tt)*) => {
+        if !$cond {
+            $crate::vortex_bail!($($tt)*);
+        }
+    };
+}
+
 /// A convenient macro for panicking with a VortexError in the presence of a programmer error
 /// (e.g., an invariant has been violated).
 #[macro_export]

--- a/vortex-expr/src/arbitrary.rs
+++ b/vortex-expr/src/arbitrary.rs
@@ -10,7 +10,7 @@ use vortex_scalar::arbitrary::random_scalar;
 use crate::{BinaryExpr, ExprRef, Operator, and_collect, col, lit, pack};
 
 pub fn projection_expr(u: &mut Unstructured<'_>, dtype: &DType) -> AResult<Option<ExprRef>> {
-    let Some(struct_dtype) = dtype.as_struct() else {
+    let Some(struct_dtype) = dtype.as_struct_opt() else {
         return Ok(None);
     };
 
@@ -27,7 +27,7 @@ pub fn projection_expr(u: &mut Unstructured<'_>, dtype: &DType) -> AResult<Optio
 }
 
 pub fn filter_expr(u: &mut Unstructured<'_>, dtype: &DType) -> AResult<Option<ExprRef>> {
-    let Some(struct_dtype) = dtype.as_struct() else {
+    let Some(struct_dtype) = dtype.as_struct_opt() else {
         return Ok(None);
     };
 

--- a/vortex-expr/src/exprs/get_item.rs
+++ b/vortex-expr/src/exprs/get_item.rs
@@ -92,7 +92,7 @@ impl VTable for GetItemVTable {
     fn return_dtype(expr: &Self::Expr, scope: &DType) -> VortexResult<DType> {
         let input = expr.child.return_dtype(scope)?;
         input
-            .as_struct()
+            .as_struct_opt()
             .and_then(|st| st.field(expr.field()))
             .ok_or_else(|| {
                 vortex_err!(

--- a/vortex-expr/src/exprs/merge.rs
+++ b/vortex-expr/src/exprs/merge.rs
@@ -132,7 +132,7 @@ impl VTable for MergeVTable {
             }
 
             let struct_dtype = dtype
-                .as_struct()
+                .as_struct_opt()
                 .vortex_expect("merge expects struct input");
 
             for i in 0..struct_dtype.nfields() {

--- a/vortex-expr/src/exprs/select.rs
+++ b/vortex-expr/src/exprs/select.rs
@@ -128,7 +128,7 @@ impl VTable for SelectVTable {
     fn return_dtype(expr: &Self::Expr, scope: &DType) -> VortexResult<DType> {
         let child_dtype = expr.child.return_dtype(scope)?;
         let child_struct_dtype = child_dtype
-            .as_struct()
+            .as_struct_opt()
             .ok_or_else(|| vortex_err!("Select child not a struct dtype"))?;
 
         let projected = match &expr.fields {
@@ -333,7 +333,11 @@ mod tests {
 
         let select_expr = select(vec![FieldName::from("a")], root());
         let expected_dtype = DType::Struct(
-            dtype.as_struct().unwrap().project(&["a".into()]).unwrap(),
+            dtype
+                .as_struct_opt()
+                .unwrap()
+                .project(&["a".into()])
+                .unwrap(),
             Nullability::NonNullable,
         );
         assert_eq!(select_expr.return_dtype(&dtype).unwrap(), expected_dtype);
@@ -360,7 +364,7 @@ mod tests {
             select_expr_exclude.return_dtype(&dtype).unwrap(),
             DType::Struct(
                 dtype
-                    .as_struct()
+                    .as_struct_opt()
                     .unwrap()
                     .project(&["a".into(), "bool1".into(), "bool2".into()])
                     .unwrap(),

--- a/vortex-expr/src/transform/partition.rs
+++ b/vortex-expr/src/transform/partition.rs
@@ -214,7 +214,7 @@ mod tests {
 
     #[rstest]
     fn test_expr_top_level_ref(dtype: DType) {
-        let fields = dtype.as_struct().unwrap();
+        let fields = dtype.as_struct_opt().unwrap();
 
         let expr = root();
         let partitioned = partition(expr.clone(), &dtype, annotate_scope_access(fields)).unwrap();
@@ -232,7 +232,7 @@ mod tests {
 
     #[rstest]
     fn test_expr_top_level_ref_get_item_and_split(dtype: DType) {
-        let fields = dtype.as_struct().unwrap();
+        let fields = dtype.as_struct_opt().unwrap();
 
         let expr = get_item("y", get_item("a", root()));
 
@@ -242,7 +242,7 @@ mod tests {
 
     #[rstest]
     fn test_expr_top_level_ref_get_item_and_split_pack(dtype: DType) {
-        let fields = dtype.as_struct().unwrap();
+        let fields = dtype.as_struct_opt().unwrap();
 
         let expr = pack(
             [
@@ -269,7 +269,7 @@ mod tests {
 
     #[rstest]
     fn test_expr_top_level_ref_get_item_add(dtype: DType) {
-        let fields = dtype.as_struct().unwrap();
+        let fields = dtype.as_struct_opt().unwrap();
 
         let expr = and(get_item("y", get_item("a", root())), lit(1));
         let partitioned = partition(expr, &dtype, annotate_scope_access(fields)).unwrap();
@@ -280,7 +280,7 @@ mod tests {
 
     #[rstest]
     fn test_expr_top_level_ref_get_item_add_cannot_split(dtype: DType) {
-        let fields = dtype.as_struct().unwrap();
+        let fields = dtype.as_struct_opt().unwrap();
 
         let expr = and(get_item("y", get_item("a", root())), get_item("b", root()));
         let partitioned = partition(expr, &dtype, annotate_scope_access(fields)).unwrap();
@@ -292,7 +292,7 @@ mod tests {
     // Test that typed_simplify removes select and partition precise
     #[rstest]
     fn test_expr_partition_many_occurrences_of_field(dtype: DType) {
-        let fields = dtype.as_struct().unwrap();
+        let fields = dtype.as_struct_opt().unwrap();
 
         let expr = and(
             get_item("y", get_item("a", root())),
@@ -332,7 +332,7 @@ mod tests {
 
     #[rstest]
     fn test_expr_merge(dtype: DType) {
-        let fields = dtype.as_struct().unwrap();
+        let fields = dtype.as_struct_opt().unwrap();
 
         let expr = merge(
             [col("a"), pack([("b", col("b"))], NonNullable)],

--- a/vortex-expr/src/transform/remove_merge.rs
+++ b/vortex-expr/src/transform/remove_merge.rs
@@ -29,7 +29,7 @@ fn merge_transform(node: ExprRef, ctx: &DType) -> VortexResult<Transformed<ExprR
                 }
                 all_nullable = all_nullable && child_dtype.is_nullable();
 
-                let child_dtype = child_dtype.as_struct().vortex_expect("expected struct");
+                let child_dtype = child_dtype.as_struct_opt().vortex_expect("expected struct");
 
                 for name in child_dtype.names().iter() {
                     if let Some(idx) = names.iter().position(|n| n == name) {

--- a/vortex-expr/src/transform/remove_select.rs
+++ b/vortex-expr/src/transform/remove_select.rs
@@ -20,7 +20,7 @@ fn remove_select_transformer(node: ExprRef, ctx: &DType) -> VortexResult<Transfo
             let child_dtype = child.return_dtype(ctx)?;
             let child_nullability = child_dtype.nullability();
 
-            let child_dtype = child_dtype.as_struct().ok_or_else(|| {
+            let child_dtype = child_dtype.as_struct_opt().ok_or_else(|| {
                 vortex_err!(
                     "Select child must return a struct dtype, however it was a {}",
                     child_dtype

--- a/vortex-ffi/src/dtype.rs
+++ b/vortex-ffi/src/dtype.rs
@@ -155,7 +155,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_primitive_ptype(dtype: *const vx_dtype)
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_decimal_precision(dtype: *const vx_dtype) -> u8 {
     vx_dtype::as_ref(dtype)
-        .as_decimal()
+        .as_decimal_opt()
         .vortex_expect("not a decimal dtype")
         .precision()
 }
@@ -164,7 +164,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_decimal_precision(dtype: *const vx_dtyp
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_decimal_scale(dtype: *const vx_dtype) -> i8 {
     vx_dtype::as_ref(dtype)
-        .as_decimal()
+        .as_decimal_opt()
         .vortex_expect("not a decimal dtype")
         .scale()
 }
@@ -175,7 +175,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_struct_dtype(
     dtype: *const vx_dtype,
 ) -> *const vx_struct_fields {
     let struct_dtype = vx_dtype::as_ref(dtype)
-        .as_struct()
+        .as_struct_opt()
         .vortex_expect("not a struct dtype");
     vx_struct_fields::new_ref(struct_dtype)
 }
@@ -184,7 +184,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_struct_dtype(
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_list_element(dtype: *const vx_dtype) -> *const vx_dtype {
     let element_dtype = vx_dtype::as_ref(dtype)
-        .as_list_element()
+        .as_list_element_opt()
         .vortex_expect("not a list dtype");
     vx_dtype::new_ref(element_dtype)
 }

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -93,7 +93,7 @@ impl VortexFile {
         let Some((stats, fields)) = self
             .footer
             .statistics()
-            .zip(self.footer.dtype().as_struct())
+            .zip(self.footer.dtype().as_struct_opt())
         else {
             return Ok(false);
         };

--- a/vortex-jni/src/dtype.rs
+++ b/vortex-jni/src/dtype.rs
@@ -103,7 +103,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeDTypeMethods_getFieldNames(
     try_or_throw(&mut env, |env| {
         let array_list = env.new_object("java/util/ArrayList", "()V", &[])?;
         let field_names = env.get_list(&array_list)?;
-        let Some(struct_dtype) = dtype.as_struct() else {
+        let Some(struct_dtype) = dtype.as_struct_opt() else {
             throw_runtime!("DType should be STRUCT, was {dtype}");
         };
 
@@ -127,7 +127,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeDTypeMethods_getFieldTypes(
     try_or_throw(&mut env, |env| {
         let array_list = env.new_object("java/util/ArrayList", "()V", &[])?;
         let field_types = env.get_list(&array_list)?;
-        let Some(struct_dtype) = dtype.as_struct() else {
+        let Some(struct_dtype) = dtype.as_struct_opt() else {
             throw_runtime!("DType should be STRUCT, was {dtype}");
         };
 
@@ -157,7 +157,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeDTypeMethods_getElementType(
     let dtype = unsafe { &*(dtype_ptr as *const DType) };
 
     try_or_throw(&mut env, |_| {
-        let Some(element_type) = dtype.as_list_element() else {
+        let Some(element_type) = dtype.as_list_element_opt() else {
             throw_runtime!("DType should be LIST, was {dtype}");
         };
 

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use dashmap::DashMap;
 use futures::{FutureExt, join};
 use vortex_array::ArrayRef;
-use vortex_array::compute::{MinMaxResult, filter, min_max};
+use vortex_array::compute::{MinMaxResult, min_max};
 use vortex_array::stats::Precision;
 use vortex_dict::DictArray;
 use vortex_dtype::{DType, FieldMask};
@@ -196,27 +196,16 @@ impl MaskEvaluation for DictMaskEvaluation {
         }
 
         let codes = self.codes_eval.invoke(Mask::new_true(mask.len())).await?;
-        // TODO(os): remove the low density code path, does not really improve perf
-        if mask.density() < 0.1 {
-            let codes = filter(&codes, &mask)?;
-            let dict_mask = &Mask::try_from(
-                DictArray::try_new(codes, values_result)?
-                    .to_array()
-                    .as_ref(),
-            )?;
-            Ok(mask.intersect_by_rank(dict_mask))
-        } else {
-            // Creating a mask from the dict array would canonicalise it,
-            // it should be fine for now as long as values is already canonical,
-            // so different row ranges do not canonicalise the same array
-            // multiple times.
-            let dict_mask = &Mask::try_from(
-                DictArray::try_new(codes, values_result)?
-                    .to_array()
-                    .as_ref(),
-            )?;
-            Ok(mask.bitand(dict_mask))
-        }
+        // Creating a mask from the dict array would canonicalize it,
+        // it should be fine for now as long as values is already canonical,
+        // so different row ranges do not canonicalize to the same array
+        // multiple times.
+        let dict_mask = &Mask::try_from(
+            DictArray::try_new(codes, values_result)?
+                .to_array()
+                .as_ref(),
+        )?;
+        Ok(mask.bitand(dict_mask))
     }
 }
 
@@ -232,6 +221,7 @@ impl ArrayEvaluation for DictArrayEvaluation {
         let (values_result, codes) = join!(self.values_eval.clone(), self.codes_eval.invoke(mask));
         let (values_result, codes) = (values_result?, codes?);
 
+        // Validate that codes are valid for the values
         let array = DictArray::try_new(codes, values_result)?.to_array();
         self.expr.evaluate(&Scope::new(array))
     }

--- a/vortex-layout/src/layouts/file_stats.rs
+++ b/vortex-layout/src/layouts/file_stats.rs
@@ -44,7 +44,7 @@ pub struct FileStatsAccumulator {
 
 impl FileStatsAccumulator {
     fn new(dtype: &DType, stats: Arc<[Stat]>, max_variable_length_statistics_size: usize) -> Self {
-        let accumulators = Arc::new(Mutex::new(match dtype.as_struct() {
+        let accumulators = Arc::new(Mutex::new(match dtype.as_struct_opt() {
             Some(struct_dtype) => {
                 if dtype.nullability() == Nullability::Nullable {
                     // top level dtype could be nullable, but we don't support it yet

--- a/vortex-layout/src/layouts/struct_/mod.rs
+++ b/vortex-layout/src/layouts/struct_/mod.rs
@@ -94,7 +94,7 @@ impl VTable for StructVTable {
         _ctx: ArrayContext,
     ) -> VortexResult<Self::Layout> {
         let struct_dt = dtype
-            .as_struct()
+            .as_struct_opt()
             .ok_or_else(|| vortex_err!("Expected struct dtype"))?;
         if children.nchildren() != struct_dt.nfields() {
             vortex_bail!(

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -118,7 +118,7 @@ impl StructReader {
                     self.dtype(),
                     annotate_scope_access(
                         self.dtype()
-                            .as_struct()
+                            .as_struct_opt()
                             .vortex_expect("We know it's a struct DType"),
                     ),
                 )

--- a/vortex-layout/src/layouts/struct_/writer.rs
+++ b/vortex-layout/src/layouts/struct_/writer.rs
@@ -51,7 +51,7 @@ where
         stream: SendableSequentialStream,
     ) -> VortexResult<LayoutRef> {
         let dtype = stream.dtype().clone();
-        let Some(struct_dtype) = stream.dtype().as_struct().cloned() else {
+        let Some(struct_dtype) = stream.dtype().as_struct_opt().cloned() else {
             // nothing we can do if dtype is not struct
             return self.child.write_stream(ctx, sequence_writer, stream).await;
         };

--- a/vortex-scalar/src/struct_.rs
+++ b/vortex-scalar/src/struct_.rs
@@ -96,7 +96,7 @@ impl<'a> StructScalar<'a> {
     #[inline]
     pub fn struct_fields(&self) -> &StructFields {
         self.dtype
-            .as_struct()
+            .as_struct_opt()
             .vortex_expect("StructScalar always has struct dtype")
     }
 
@@ -209,7 +209,7 @@ impl<'a> StructScalar<'a> {
     pub fn project(&self, projection: &[FieldName]) -> VortexResult<Scalar> {
         let struct_dtype = self
             .dtype
-            .as_struct()
+            .as_struct_opt()
             .ok_or_else(|| vortex_err!("Not a struct dtype"))?;
         let projected_dtype = struct_dtype.project(projection)?;
         let new_fields = if let Some(fs) = self.field_values() {

--- a/vortex-scan/src/lib.rs
+++ b/vortex-scan/src/lib.rs
@@ -299,7 +299,7 @@ fn filter_and_projection_masks(
     filter: Option<&ExprRef>,
     dtype: &DType,
 ) -> VortexResult<(Vec<FieldMask>, Vec<FieldMask>)> {
-    let Some(struct_dtype) = dtype.as_struct() else {
+    let Some(struct_dtype) = dtype.as_struct_opt() else {
         return Ok(match filter {
             Some(_) => (vec![FieldMask::All], vec![FieldMask::All]),
             None => (Vec::new(), vec![FieldMask::All]),


### PR DESCRIPTION
FLUP to #4177

This removes **all** possible sources of panic inside the deserialization pathway, returning errors. This also adds more explicit and complete validation of all encodings within their `try_new` operation.

Currently, we do "best effort" on these validations, including things like

- Checking Validity is the appropriate length for the array
- Checking min/max values on offsets
- UTF-8 validation on VarBinView and validating that all views reference valid ranges of the buffers

A lot of this was new validation, some of it was moving validation from just SerdeVTable into the array type's `try_new` constructor.

Tried to add sufficient doc comments.