### PR TITLE
fix: javadoc workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Generate Javadoc for Java projects
         run: |
           cd java
-          ./gradlew javadoc -x makeTestFiles -x shadowJar
+          ./gradlew javadoc -x makeTestFiles
       - name: Copy Javadoc to docs directory
         run: |
           mkdir -p docs/_static/vortex-jni


### PR DESCRIPTION
Turns out we do need to build shadowJar to make it compile, but at least we don't need to build the Rust lib