### PR TITLE
chore[vortex-array]: facilitate third-party ToArrowKernel implementations

### DIFF
--- a/vortex-array/src/arrow/mod.rs
+++ b/vortex-array/src/arrow/mod.rs
@@ -14,6 +14,7 @@ mod datum;
 mod iter;
 mod record_batch;
 
+pub use array::*;
 pub use datum::*;
 pub use iter::*;
 

--- a/vortex-dtype/src/arrow.rs
+++ b/vortex-dtype/src/arrow.rs
@@ -127,6 +127,9 @@ impl FromArrowType<(&DataType, Nullability)> for DType {
                 List(Arc::new(Self::from_arrow(e.as_ref())), nullability)
             }
             DataType::Struct(f) => Struct(StructFields::from_arrow(f), nullability),
+            DataType::Dictionary(_, value_type) => {
+                Self::from_arrow((value_type.as_ref(), nullability))
+            }
             _ => unimplemented!("Arrow data type not yet supported: {:?}", data_type),
         }
     }


### PR DESCRIPTION
This commit has two changes that were required to write a third-party ToArrowKernel to convert vortex to dictionary arrays:

1. Re-exporting vortex-array::arrow::array publicly so that an ArrowArray can be constructed.
2. Support converting an arrow DictionaryType to a canonical DType (this is just the underlying values type).