### PR TITLE
chore: Allow coveralls step to fail in CI without failing the job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,7 @@ jobs:
             -o ${{ env.GRCOV_OUTPUT_FILE }}
       - name: Coveralls
         uses: coverallsapp/github-action@v2
+        continue-on-error: true
         with:
           parallel: true
           flag-name: run-${{ matrix.suite }}
@@ -335,6 +336,7 @@ jobs:
     steps:
       - name: Close parallel build
         uses: coverallsapp/github-action@v2
+        continue-on-error: true
         with:
           parallel-finished: true
           carryforward: "run-tests,run-tpc-h,run-ffi"


### PR DESCRIPTION
Coveralls seem to have an outage which blocks our CI. Given that its not a required check right, seems like the actual step should be optional.