### PR TITLE
Use perfetto tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ dependencies = [
  "tpchgen",
  "tpchgen-arrow",
  "tracing",
- "tracing-chrome",
+ "tracing-perfetto",
  "tracing-subscriber",
  "url",
  "uuid",
@@ -3209,6 +3209,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -4491,6 +4500,16 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
@@ -4527,6 +4546,19 @@ dependencies = [
  "regex",
  "syn 2.0.104",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5770,6 +5802,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-id"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe8f25bbdd100db7e1d34acf7fd2dc59c4bf8f7483f505eaa7d4f12f76cc0ea"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6065,17 +6107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-chrome"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
-dependencies = [
- "serde_json",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "tracing-core"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6094,6 +6125,22 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-perfetto"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf599f51530a7211f5aa92c84abdfc1137362d471f0473a4b1be8d625167fb0d"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "chrono",
+ "prost 0.12.6",
+ "rand 0.8.5",
+ "thread-id",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ tokio-stream = "0.1.17"
 tpchgen = { git = "https://github.com/clflushopt/tpchgen-rs.git", rev = "d849ff430cd52250f6891ed4d5e3adad77bb2698" }
 tpchgen-arrow = { git = "https://github.com/clflushopt/tpchgen-rs.git", rev = "d849ff430cd52250f6891ed4d5e3adad77bb2698" }
 tracing = { version = "0.1.41" }
-tracing-chrome = "0.7.2"
+tracing-perfetto = "0.1.5"
 tracing-subscriber = "0.3.19"
 url = "2.5.4"
 uuid = { version = "1.17", features = ["js"] }

--- a/bench-vortex/Cargo.toml
+++ b/bench-vortex/Cargo.toml
@@ -80,6 +80,3 @@ vortex = { workspace = true, features = [
 vortex-datafusion = { workspace = true }
 vortex-duckdb = { workspace = true }
 xshell = { workspace = true }
-
-[features]
-tracing = ["vortex-datafusion/tracing"]

--- a/bench-vortex/Cargo.toml
+++ b/bench-vortex/Cargo.toml
@@ -63,7 +63,7 @@ tokio-stream = { workspace = true }
 tpchgen = { workspace = true }
 tpchgen-arrow = { workspace = true }
 tracing = { workspace = true }
-tracing-chrome = { workspace = true }
+tracing-perfetto = { workspace = true }
 tracing-subscriber = { workspace = true, features = [
     "env-filter",
     "tracing-log",

--- a/bench-vortex/src/benchmark_driver.rs
+++ b/bench-vortex/src/benchmark_driver.rs
@@ -17,9 +17,7 @@ use crate::engines::{EngineCtx, benchmark_datafusion_query};
 use crate::measurements::{MemoryMeasurement, QueryMeasurement};
 use crate::memory::BenchmarkMemoryTracker;
 use crate::metrics::{MetricsSetExt, export_plan_spans};
-use crate::query_bench::{
-    filter_queries, print_memory_usage, print_results, setup_logging_and_tracing,
-};
+use crate::query_bench::{filter_queries, print_memory_usage, print_results};
 use crate::utils::{new_tokio_runtime, url_scheme_to_storage};
 use crate::{Engine, Format, Target, df, vortex_panic};
 
@@ -28,7 +26,6 @@ pub struct DriverConfig {
     pub targets: Vec<Target>,
     pub iterations: usize,
     pub threads: Option<usize>,
-    pub verbose: bool,
     pub display_format: DisplayFormat,
     pub disable_datafusion_cache: bool,
     pub delete_duckdb_database: bool,
@@ -44,11 +41,6 @@ pub struct DriverConfig {
 
 /// Run a benchmark using the provided implementation and configuration
 pub fn run_benchmark<B: Benchmark>(benchmark: B, config: DriverConfig) -> Result<()> {
-    setup_logging_and_tracing(
-        config.verbose,
-        &format!("{}.trace.json", benchmark.dataset_name()),
-    )?;
-
     // Generate data for each target (idempotent)
     for target in &config.targets {
         benchmark.generate_data(target)?;

--- a/bench-vortex/src/benchmark_driver.rs
+++ b/bench-vortex/src/benchmark_driver.rs
@@ -44,7 +44,7 @@ pub struct DriverConfig {
 
 /// Run a benchmark using the provided implementation and configuration
 pub fn run_benchmark<B: Benchmark>(benchmark: B, config: DriverConfig) -> Result<()> {
-    let _trace_guard = setup_logging_and_tracing(
+    setup_logging_and_tracing(
         config.verbose,
         &format!("{}.trace.json", benchmark.dataset_name()),
     )?;

--- a/bench-vortex/src/bin/compress.rs
+++ b/bench-vortex/src/bin/compress.rs
@@ -14,7 +14,7 @@ use bench_vortex::display::{DisplayFormat, print_measurements_json, render_table
 use bench_vortex::public_bi::PBI_DATASETS;
 use bench_vortex::public_bi::PBIDataset::{Arade, Bimbo, CMSprovider, Euro2016, Food, HashTags};
 use bench_vortex::utils::new_tokio_runtime;
-use bench_vortex::{Engine, Format, Target, default_env_filter, setup_logger};
+use bench_vortex::{Engine, Format, Target, setup_logging_and_tracing};
 use clap::Parser;
 use indicatif::ProgressBar;
 use itertools::Itertools;
@@ -40,13 +40,14 @@ struct Args {
     display_format: DisplayFormat,
     #[arg(short)]
     output_path: Option<PathBuf>,
+    #[arg(long)]
+    tracing: bool,
 }
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    let filter = default_env_filter(args.verbose);
-    setup_logger(filter);
+    setup_logging_and_tracing(args.verbose, args.tracing)?;
 
     let runtime = new_tokio_runtime(args.threads);
 

--- a/bench-vortex/src/bin/public_bi.rs
+++ b/bench-vortex/src/bin/public_bi.rs
@@ -12,9 +12,7 @@ use bench_vortex::metrics::MetricsSetExt;
 use bench_vortex::public_bi::{FileType, PBI_DATASETS, PBIDataset};
 use bench_vortex::utils::constants::STORAGE_NVME;
 use bench_vortex::utils::new_tokio_runtime;
-use bench_vortex::{
-    BenchmarkDataset, Format, Target, df, setup_logging_and_tracing,
-};
+use bench_vortex::{BenchmarkDataset, Format, Target, df, setup_logging_and_tracing};
 use clap::{Parser, value_parser};
 use indicatif::ProgressBar;
 use itertools::Itertools;

--- a/bench-vortex/src/bin/public_bi.rs
+++ b/bench-vortex/src/bin/public_bi.rs
@@ -12,7 +12,9 @@ use bench_vortex::metrics::MetricsSetExt;
 use bench_vortex::public_bi::{FileType, PBI_DATASETS, PBIDataset};
 use bench_vortex::utils::constants::STORAGE_NVME;
 use bench_vortex::utils::new_tokio_runtime;
-use bench_vortex::{BenchmarkDataset, Format, Target, default_env_filter, df};
+use bench_vortex::{
+    BenchmarkDataset, Format, Target, df, setup_logging_and_tracing,
+};
 use clap::{Parser, value_parser};
 use indicatif::ProgressBar;
 use itertools::Itertools;
@@ -51,43 +53,14 @@ struct Args {
     queries: Option<Vec<usize>>,
     #[arg(short)]
     output_path: Option<PathBuf>,
+    #[arg(long)]
+    tracing: bool,
 }
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    // Capture `RUST_LOG` configuration
-    let filter = default_env_filter(args.verbose);
-
-    #[cfg(not(feature = "tracing"))]
-    bench_vortex::setup_logger(filter);
-
-    // We need the guard to live to the end of the function, so can't create it in the if-block
-    #[cfg(feature = "tracing")]
-    let _trace_guard = {
-        use std::io::IsTerminal;
-
-        use tracing_subscriber::prelude::*;
-
-        let (layer, _guard) = tracing_chrome::ChromeLayerBuilder::new()
-            .include_args(true)
-            .trace_style(tracing_chrome::TraceStyle::Async)
-            .file("public_bi.trace.json")
-            .build();
-
-        let fmt_layer = tracing_subscriber::fmt::layer()
-            .with_writer(std::io::stderr)
-            .with_level(true)
-            .with_line_number(true)
-            .with_ansi(std::io::stderr().is_terminal());
-
-        tracing_subscriber::registry()
-            .with(filter)
-            .with(layer)
-            .with(fmt_layer)
-            .init();
-        _guard
-    };
+    setup_logging_and_tracing(args.verbose, args.tracing)?;
 
     let runtime = new_tokio_runtime(args.threads);
 

--- a/bench-vortex/src/bin/query_bench.rs
+++ b/bench-vortex/src/bin/query_bench.rs
@@ -3,12 +3,12 @@
 
 use std::path::PathBuf;
 
-use bench_vortex::Target;
 use bench_vortex::benchmark_driver::{DriverConfig, run_benchmark};
 use bench_vortex::clickbench::{ClickBenchBenchmark, Flavor};
 use bench_vortex::display::DisplayFormat;
 use bench_vortex::tpcds::TpcDsBenchmark;
 use bench_vortex::tpch::tpch_benchmark::TpcHBenchmark;
+use bench_vortex::{Target, setup_logging_and_tracing};
 use clap::{Parser, Subcommand, value_parser};
 
 #[derive(Parser, Debug)]
@@ -44,6 +44,9 @@ struct CommonArgs {
 
     #[arg(short, long)]
     verbose: bool,
+
+    #[arg(long)]
+    tracing: bool,
 
     #[arg(long)]
     export_spans: bool,
@@ -170,7 +173,6 @@ fn validate_scale_factor(val: &str) -> Result<String, String> {
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
-
     match args.command {
         Commands::ClickBench(clickbench_args) => run_clickbench(clickbench_args),
         Commands::TpcH(tpch_args) => run_tpch(tpch_args),
@@ -179,6 +181,8 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn run_clickbench(args: ClickBenchArgs) -> anyhow::Result<()> {
+    setup_logging_and_tracing(args.common.verbose, args.common.tracing)?;
+
     // Create benchmark instance
     let benchmark = ClickBenchBenchmark::new(
         args.flavor,
@@ -191,7 +195,6 @@ fn run_clickbench(args: ClickBenchArgs) -> anyhow::Result<()> {
         targets: args.targets,
         iterations: args.common.iterations,
         threads: args.common.threads,
-        verbose: args.common.verbose,
         display_format: args.common.display_format,
         disable_datafusion_cache: args.common.disable_datafusion_cache,
         delete_duckdb_database: args.common.delete_duckdb_database,
@@ -211,6 +214,8 @@ fn run_clickbench(args: ClickBenchArgs) -> anyhow::Result<()> {
 }
 
 fn run_tpch(args: TpcHArgs) -> anyhow::Result<()> {
+    setup_logging_and_tracing(args.common.verbose, args.common.tracing)?;
+
     // Create benchmark instance
     let benchmark = TpcHBenchmark::new(args.scale_factor, args.common.use_remote_data_dir)?;
 
@@ -219,7 +224,6 @@ fn run_tpch(args: TpcHArgs) -> anyhow::Result<()> {
         targets: args.targets,
         iterations: args.common.iterations,
         threads: args.common.threads,
-        verbose: args.common.verbose,
         display_format: args.common.display_format,
         disable_datafusion_cache: args.common.disable_datafusion_cache,
         delete_duckdb_database: args.common.delete_duckdb_database,
@@ -240,6 +244,8 @@ fn run_tpch(args: TpcHArgs) -> anyhow::Result<()> {
 }
 
 fn run_tpcds(args: TpcDSArgs) -> anyhow::Result<()> {
+    setup_logging_and_tracing(args.common.verbose, args.common.tracing)?;
+
     // Create benchmark instance
     let benchmark = TpcDsBenchmark::new(args.scale_factor, args.common.use_remote_data_dir)?;
 
@@ -248,7 +254,6 @@ fn run_tpcds(args: TpcDSArgs) -> anyhow::Result<()> {
         targets: args.targets,
         iterations: args.common.iterations,
         threads: args.common.threads,
-        verbose: args.common.verbose,
         display_format: args.common.display_format,
         disable_datafusion_cache: args.common.disable_datafusion_cache,
         delete_duckdb_database: args.common.delete_duckdb_database,

--- a/bench-vortex/src/bin/random_access.rs
+++ b/bench-vortex/src/bin/random_access.rs
@@ -12,7 +12,7 @@ use bench_vortex::measurements::TimingMeasurement;
 use bench_vortex::random_access::take::{take_parquet, take_vortex_tokio};
 use bench_vortex::utils::constants::STORAGE_NVME;
 use bench_vortex::utils::new_tokio_runtime;
-use bench_vortex::{Engine, Format, Target, default_env_filter, setup_logger};
+use bench_vortex::{Engine, Format, Target, setup_logging_and_tracing};
 use clap::Parser;
 use indicatif::ProgressBar;
 use itertools::Itertools;
@@ -34,6 +34,8 @@ struct Args {
     formats: Vec<Format>,
     #[arg(short, long)]
     verbose: bool,
+    #[arg(long)]
+    tracing: bool,
     #[arg(short, long, default_value_t, value_enum)]
     display_format: DisplayFormat,
     #[arg(short)]
@@ -42,6 +44,9 @@ struct Args {
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
+
+    setup_logging_and_tracing(args.verbose, args.tracing)?;
+
     let runtime = new_tokio_runtime(args.threads);
 
     let indices = buffer![10u64, 11, 12, 13, 100_000, 3_000_000];
@@ -50,7 +55,6 @@ fn main() -> anyhow::Result<()> {
         args.iterations,
         args.formats,
         args.display_format,
-        args.verbose,
         indices,
         &args.output_path,
     )
@@ -61,14 +65,9 @@ fn random_access(
     iterations: usize,
     formats: Vec<Format>,
     display_format: DisplayFormat,
-    verbose: bool,
     indices: Buffer<u64>,
     output_path: &Option<PathBuf>,
 ) -> anyhow::Result<()> {
-    // Capture `RUST_LOG` configuration
-    let filter = default_env_filter(verbose);
-    setup_logger(filter);
-
     let targets = formats
         .iter()
         .map(|f| Target::new(Engine::Vortex, *f))

--- a/bench-vortex/src/query_bench.rs
+++ b/bench-vortex/src/query_bench.rs
@@ -7,9 +7,9 @@ use std::fs::File;
 use std::io::{Write, stdout};
 use std::path::PathBuf;
 
+use crate::Target;
 use crate::display::{DisplayFormat, print_measurements_json, render_table};
 use crate::measurements::{MemoryMeasurement, QueryMeasurement};
-use crate::{Target, default_env_filter};
 
 /// Common benchmark configuration
 #[derive(Debug, Clone)]
@@ -22,41 +22,6 @@ pub struct BenchmarkConfig {
     pub disable_datafusion_cache: bool,
     pub queries: Option<Vec<usize>>,
     pub output_path: Option<PathBuf>,
-}
-
-/// Initialize logging/tracing for a benchmark
-pub fn setup_logging_and_tracing(verbose: bool, trace_file: &str) -> anyhow::Result<()> {
-    let filter = default_env_filter(verbose);
-
-    #[cfg(not(feature = "tracing"))]
-    {
-        let _ = trace_file; // Suppress unused warning
-        crate::setup_logger(filter);
-    }
-
-    #[cfg(feature = "tracing")]
-    {
-        use std::io::IsTerminal;
-
-        use tracing_subscriber::prelude::*;
-
-        let layer = tracing_perfetto::PerfettoLayer::new(File::create(trace_file)?)
-            .with_debug_annotations(true);
-
-        let fmt_layer = tracing_subscriber::fmt::layer()
-            .with_writer(std::io::stderr)
-            .with_level(true)
-            .with_line_number(true)
-            .with_ansi(std::io::stderr().is_terminal());
-
-        tracing_subscriber::registry()
-            .with(filter)
-            .with(layer)
-            .with(fmt_layer)
-            .init();
-    }
-
-    Ok(())
 }
 
 /// Print benchmark results

--- a/bench-vortex/src/query_bench.rs
+++ b/bench-vortex/src/query_bench.rs
@@ -3,14 +3,13 @@
 
 //! Unified benchmark infrastructure
 
-use crate::display::{DisplayFormat, print_measurements_json, render_table};
-use crate::measurements::{MemoryMeasurement, QueryMeasurement};
-use crate::{Target, default_env_filter};
 use std::fs::File;
 use std::io::{Write, stdout};
 use std::path::PathBuf;
-use std::sync::Mutex;
-use tracing_perfetto::PerfettoLayer;
+
+use crate::display::{DisplayFormat, print_measurements_json, render_table};
+use crate::measurements::{MemoryMeasurement, QueryMeasurement};
+use crate::{Target, default_env_filter};
 
 /// Common benchmark configuration
 #[derive(Debug, Clone)]
@@ -33,7 +32,6 @@ pub fn setup_logging_and_tracing(verbose: bool, trace_file: &str) -> anyhow::Res
     {
         let _ = trace_file; // Suppress unused warning
         crate::setup_logger(filter);
-        Ok(None)
     }
 
     #[cfg(feature = "tracing")]
@@ -42,8 +40,8 @@ pub fn setup_logging_and_tracing(verbose: bool, trace_file: &str) -> anyhow::Res
 
         use tracing_subscriber::prelude::*;
 
-        let layer =
-            PerfettoLayer::new(Mutex::new(File::create(trace_file)?)).with_debug_annotations(true);
+        let layer = tracing_perfetto::PerfettoLayer::new(File::create(trace_file)?)
+            .with_debug_annotations(true);
 
         let fmt_layer = tracing_subscriber::fmt::layer()
             .with_writer(std::io::stderr)
@@ -56,9 +54,9 @@ pub fn setup_logging_and_tracing(verbose: bool, trace_file: &str) -> anyhow::Res
             .with(layer)
             .with(fmt_layer)
             .init();
-
-        Ok(())
     }
+
+    Ok(())
 }
 
 /// Print benchmark results

--- a/bench-vortex/src/query_bench.rs
+++ b/bench-vortex/src/query_bench.rs
@@ -3,13 +3,14 @@
 
 //! Unified benchmark infrastructure
 
-use std::fs::File;
-use std::io::{Write, stdout};
-use std::path::PathBuf;
-
 use crate::display::{DisplayFormat, print_measurements_json, render_table};
 use crate::measurements::{MemoryMeasurement, QueryMeasurement};
 use crate::{Target, default_env_filter};
+use std::fs::File;
+use std::io::{Write, stdout};
+use std::path::PathBuf;
+use std::sync::Mutex;
+use tracing_perfetto::PerfettoLayer;
 
 /// Common benchmark configuration
 #[derive(Debug, Clone)]
@@ -25,10 +26,7 @@ pub struct BenchmarkConfig {
 }
 
 /// Initialize logging/tracing for a benchmark
-pub fn setup_logging_and_tracing(
-    verbose: bool,
-    trace_file: &str,
-) -> anyhow::Result<Option<tracing_chrome::FlushGuard>> {
+pub fn setup_logging_and_tracing(verbose: bool, trace_file: &str) -> anyhow::Result<()> {
     let filter = default_env_filter(verbose);
 
     #[cfg(not(feature = "tracing"))]
@@ -44,11 +42,8 @@ pub fn setup_logging_and_tracing(
 
         use tracing_subscriber::prelude::*;
 
-        let (layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
-            .include_args(true)
-            .trace_style(tracing_chrome::TraceStyle::Async)
-            .file(trace_file)
-            .build();
+        let layer =
+            PerfettoLayer::new(Mutex::new(File::create(trace_file)?)).with_debug_annotations(true);
 
         let fmt_layer = tracing_subscriber::fmt::layer()
             .with_writer(std::io::stderr)
@@ -62,7 +57,7 @@ pub fn setup_logging_and_tracing(
             .with(fmt_layer)
             .init();
 
-        Ok(Some(guard))
+        Ok(())
     }
 }
 

--- a/bench-vortex/src/utils/logging.rs
+++ b/bench-vortex/src/utils/logging.rs
@@ -1,20 +1,41 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::fs::File;
 use std::io::IsTerminal;
 
 use tracing::level_filters::LevelFilter;
+use tracing_perfetto::PerfettoLayer;
 use tracing_subscriber::EnvFilter;
+use tracing_subscriber::prelude::*;
 
-pub fn setup_logger(filter: EnvFilter) {
-    tracing_subscriber::fmt()
+/// Initialize logging/tracing for a benchmark
+pub fn setup_logging_and_tracing(verbose: bool, tracing: bool) -> anyhow::Result<()> {
+    let filter = default_env_filter(verbose);
+
+    let fmt_layer = tracing_subscriber::fmt::layer()
         .with_writer(std::io::stderr)
-        .with_file(true)
         .with_level(true)
+        .with_file(true)
         .with_line_number(true)
-        .with_env_filter(filter)
-        .with_ansi(std::io::stderr().is_terminal())
+        .with_ansi(std::io::stderr().is_terminal());
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(
+            tracing
+                .then(|| {
+                    Ok::<_, anyhow::Error>(
+                        PerfettoLayer::new(File::create("trace.json")?)
+                            .with_debug_annotations(true),
+                    )
+                })
+                .transpose()?,
+        )
+        .with(fmt_layer)
         .init();
+
+    Ok(())
 }
 
 pub fn default_env_filter(is_verbose: bool) -> EnvFilter {

--- a/vortex-datafusion/Cargo.toml
+++ b/vortex-datafusion/Cargo.toml
@@ -25,11 +25,8 @@ moka = { workspace = true, features = ["future"] }
 object_store = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "fs"] }
 tokio-stream = { workspace = true }
-tracing = { workspace = true, optional = true }
+tracing = { workspace = true }
 vortex = { workspace = true, features = ["object_store", "tokio"] }
-
-[features]
-tracing = ["dep:tracing", "vortex/tracing"]
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -196,8 +196,7 @@ impl FileFormat for VortexFormat {
         Ok(Arc::new(Schema::try_merge(file_schemas)?))
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all, fields(location = object.location.as_ref()
-    )))]
+    #[tracing::instrument(skip_all, fields(location = object.location.as_ref()))]
     async fn infer_stats(
         &self,
         _state: &dyn Session,

--- a/vortex-file/Cargo.toml
+++ b/vortex-file/Cargo.toml
@@ -29,7 +29,7 @@ moka = { workspace = true, features = ["future"] }
 object_store = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 tokio = { workspace = true, features = ["rt"], optional = true }
-tracing = { workspace = true, optional = true }
+tracing = { workspace = true }
 # Needed to pickup the "js" feature for wasm targets from the workspace configuration
 uuid = { workspace = true }
 vortex-alp = { workspace = true }
@@ -81,5 +81,4 @@ tokio = [
     "vortex-layout/tokio",
     "vortex-scan/tokio",
 ]
-tracing = ["dep:tracing", "vortex-io/tracing", "vortex-layout/tracing"]
 zstd = ["dep:vortex-zstd", "vortex-layout/zstd"]

--- a/vortex-io/Cargo.toml
+++ b/vortex-io/Cargo.toml
@@ -26,7 +26,7 @@ object_store = { workspace = true, optional = true }
 pin-project = { workspace = true }
 # this is the maximum subset of fetaures that is safe for wasm32 targets
 tokio = { workspace = true, features = ["io-util", "rt", "sync"] }
-tracing = { workspace = true, optional = true }
+tracing = { workspace = true }
 vortex-buffer = { workspace = true }
 vortex-error = { workspace = true }
 vortex-metrics = { workspace = true }
@@ -45,7 +45,6 @@ compio = ["dep:compio", "vortex-buffer/compio"]
 futures = ["futures-util/io"]
 object_store = ["dep:object_store", "vortex-error/object_store"]
 tokio = ["tokio/fs"]
-tracing = ["dep:tracing"]
 
 [lints]
 workspace = true

--- a/vortex-io/src/dispatcher/compio.rs
+++ b/vortex-io/src/dispatcher/compio.rs
@@ -9,7 +9,6 @@ use std::thread::JoinHandle;
 
 use compio::runtime::{JoinHandle as CompioJoinHandle, Runtime, RuntimeBuilder};
 use futures::channel::oneshot;
-#[cfg(feature = "tracing")]
 use tracing::Instrument;
 use vortex_error::{VortexResult, vortex_bail, vortex_panic};
 
@@ -22,7 +21,6 @@ trait CompioSpawn {
 struct CompioTask<F, R> {
     task: F,
     result: oneshot::Sender<R>,
-    #[cfg(feature = "tracing")]
     span: tracing::Span,
 }
 
@@ -33,19 +31,10 @@ where
     R: Send + 'static,
 {
     fn spawn(self: Box<Self>) -> CompioJoinHandle<()> {
-        let CompioTask {
-            task,
-            result,
-            #[cfg(feature = "tracing")]
-            span,
-        } = *self;
+        let CompioTask { task, result, span } = *self;
         Runtime::with_current(|rt| {
             rt.spawn(async move {
-                #[cfg(feature = "tracing")]
                 let task_output = task().instrument(span).await;
-                #[cfg(not(feature = "tracing"))]
-                let task_output = task().await;
-
                 result.send(task_output).ok();
             })
         })
@@ -119,7 +108,6 @@ impl Dispatch for CompioDispatcher {
         let compio_task = Box::new(CompioTask {
             task,
             result: tx,
-            #[cfg(feature = "tracing")]
             span: tracing::Span::current(),
         });
         match self.submitter.send(compio_task) {

--- a/vortex-io/src/dispatcher/tokio.rs
+++ b/vortex-io/src/dispatcher/tokio.rs
@@ -7,7 +7,6 @@ use std::thread::JoinHandle;
 
 use futures::channel::oneshot;
 use tokio::task::{JoinHandle as TokioJoinHandle, LocalSet};
-#[cfg(feature = "tracing")]
 use tracing::Instrument;
 use vortex_error::{VortexResult, vortex_bail, vortex_panic};
 
@@ -68,7 +67,6 @@ impl TokioDispatcher {
 struct TokioTask<F, R> {
     task: F,
     result: oneshot::Sender<R>,
-    #[cfg(feature = "tracing")]
     span: tracing::Span,
 }
 
@@ -79,18 +77,9 @@ where
     R: Send + 'static,
 {
     fn spawn(self: Box<Self>) -> TokioJoinHandle<()> {
-        let TokioTask {
-            task,
-            result,
-            #[cfg(feature = "tracing")]
-            span,
-        } = *self;
+        let TokioTask { task, result, span } = *self;
         tokio::task::spawn_local(async move {
-            #[cfg(feature = "tracing")]
             let task_output = task().instrument(span).await;
-            #[cfg(not(feature = "tracing"))]
-            let task_output = task().await;
-
             result.send(task_output).ok();
         })
     }
@@ -108,7 +97,6 @@ impl Dispatch for TokioDispatcher {
         let task = TokioTask {
             result: tx,
             task,
-            #[cfg(feature = "tracing")]
             span: tracing::Span::current(),
         };
 
@@ -156,7 +144,6 @@ mod tests {
         assert_eq!(atomic_number.load(Ordering::SeqCst), 1u32);
     }
 
-    #[cfg(feature = "tracing")]
     #[tokio::test]
     async fn test_span_propagation() {
         use tracing::{Span, info_span};

--- a/vortex-io/src/dispatcher/wasm.rs
+++ b/vortex-io/src/dispatcher/wasm.rs
@@ -6,6 +6,7 @@
 use std::future::Future;
 
 use futures::channel::oneshot;
+use tracing::Instrument;
 use vortex_error::{VortexResult, vortex_panic};
 use wasm_bindgen_futures::wasm_bindgen::__rt::Start;
 

--- a/vortex-io/src/dispatcher/wasm.rs
+++ b/vortex-io/src/dispatcher/wasm.rs
@@ -28,16 +28,11 @@ impl Dispatch for WasmDispatcher {
         Fut: Future<Output = R> + 'static,
         R: Send + 'static,
     {
-        #[cfg(feature = "tracing")]
         let span = tracing::Span::current();
 
         let (tx, rx) = oneshot::channel();
         wasm_bindgen_futures::spawn_local(async move {
-            #[cfg(feature = "tracing")]
             let result = task().instrument(span).await;
-            #[cfg(not(feature = "tracing"))]
-            let result = task().await;
-
             tx.send(result)
                 // NOTE: We don't know if the err is Debug
                 .unwrap_or_else(|_err| vortex_panic!("WasmDispatcher: task submit failed"));

--- a/vortex-io/src/object_store.rs
+++ b/vortex-io/src/object_store.rs
@@ -41,7 +41,7 @@ impl ObjectStoreReadAt {
 }
 
 impl VortexReadAt for ObjectStoreReadAt {
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all, fields(size = range.end - range.start)))]
+    #[tracing::instrument(skip_all, fields(size = range.end - range.start))]
     async fn read_byte_range(
         &self,
         range: Range<u64>,
@@ -101,7 +101,7 @@ impl VortexReadAt for ObjectStoreReadAt {
         Ok(buffer.freeze())
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+    #[tracing::instrument(skip_all)]
     async fn size(&self) -> io::Result<u64> {
         let object_store = self.object_store.clone();
         let location = self.location.clone();

--- a/vortex-io/src/tokio.rs
+++ b/vortex-io/src/tokio.rs
@@ -50,10 +50,7 @@ impl Deref for TokioFile {
 }
 
 impl VortexReadAt for TokioFile {
-    #[cfg_attr(
-        feature = "tracing",
-        tracing::instrument(skip_all, fields(range, alignment))
-    )]
+    #[tracing::instrument(skip_all, fields(range, alignment))]
     async fn read_byte_range(
         &self,
         range: Range<u64>,
@@ -75,7 +72,7 @@ impl VortexReadAt for TokioFile {
         PerformanceHint::local()
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+    #[tracing::instrument(skip_all)]
     async fn size(&self) -> io::Result<u64> {
         self.metadata().map(|metadata| metadata.len())
     }

--- a/vortex-layout/Cargo.toml
+++ b/vortex-layout/Cargo.toml
@@ -32,7 +32,7 @@ pin-project-lite = { workspace = true }
 prost = { workspace = true }
 roaring = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt"], optional = true }
-tracing = { workspace = true, optional = true }
+tracing = { workspace = true }
 vortex-array = { workspace = true }
 vortex-btrblocks = { workspace = true }
 vortex-buffer = { workspace = true }
@@ -57,7 +57,7 @@ vortex-layout = { path = ".", features = ["tokio", "test-harness"] }
 [features]
 roaring = ["dep:roaring"]
 test-harness = []
-tokio = ["dep:tokio", "vortex-error/tokio", "tracing"]
+tokio = ["dep:tokio", "vortex-error/tokio"]
 zstd = ["dep:vortex-zstd"]
 
 [lints]

--- a/vortex/Cargo.toml
+++ b/vortex/Cargo.toml
@@ -65,7 +65,6 @@ object_store = ["vortex-file/object_store"]
 parquet = ["vortex-error/parquet"]
 python = ["vortex-error/python"]
 tokio = ["vortex-file/tokio", "vortex-scan/tokio"]
-tracing = ["vortex-file/tracing", "vortex-layout/tracing"]
 zstd = ["dep:vortex-zstd", "vortex-file/zstd", "vortex-layout/zstd"]
 pretty = ["vortex-array/table-display"]
 


### PR DESCRIPTION
This backend generates actual Perfetto protobufs, and so we get events showing up on the correct threads!!

See 
<img width="1245" height="1044" alt="Screenshot 2025-08-15 at 10 33 14" src="https://github.com/user-attachments/assets/ad9cfcd6-5ca5-4db7-9265-a44c5fb8e978" />

Vs the old chrome:
<img width="1486" height="1278" alt="Screenshot 2025-08-15 at 10 33 20" src="https://github.com/user-attachments/assets/48e5545b-eb86-42ed-8a9d-a39f9d7ae845" />
