### PR TITLE
experiment: turn arbitrary into a cfg instead of a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ version = "0.1.0"
 
 [workspace.dependencies]
 anyhow = "1.0.95"
-arbitrary = "1.3.2"
+arbitrary = "1.4.2"
 arcref = "0.2.0"
 arrayref = "0.3.7"
 arrow-arith = "55.2.0"
@@ -255,6 +255,7 @@ unexpected_cfgs = { level = "deny", check-cfg = [
     "cfg(codspeed)",
     "cfg(disable_loom)",
     "cfg(vortex_nightly)",
+    "cfg(fuzzing)",
 ] }
 warnings = "warn"
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -24,15 +24,15 @@ itertools = { workspace = true }
 libfuzzer-sys = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["full"] }
-vortex-array = { workspace = true, features = ["arbitrary"] }
+vortex-array = { workspace = true }
 vortex-btrblocks = { workspace = true }
 vortex-buffer = { workspace = true }
-vortex-dtype = { workspace = true, features = ["arbitrary"] }
+vortex-dtype = { workspace = true }
 vortex-error = { workspace = true }
-vortex-expr = { workspace = true, features = ["arbitrary"] }
+vortex-expr = { workspace = true }
 vortex-file = { workspace = true, features = ["tokio"] }
 vortex-mask = { workspace = true }
-vortex-scalar = { workspace = true, features = ["arbitrary"] }
+vortex-scalar = { workspace = true }
 vortex-utils = { workspace = true }
 
 [lints]

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -4,14 +4,17 @@ This crate contains general fuzzing infrastructure and tooling for all public co
 
 ## Setup
 
-Currently, the only thing required to run the fuzzing targets is [`cargo-fuzz`](https://github.com/rust-fuzz/cargo-fuzz)
+In order to run the fuzzer you'll need (up to) three things:
+
+1. A nightly toolchain
+1. [`cargo-fuzz`](https://github.com/rust-fuzz/cargo-fuzz)
+1. If you wish to run/build some of the code directly, setting `RUSTFLAGS="--cfg fuzzing"`, which is automatically set when running `cargo fuzz`.
 
 ## Reproduce crash from CI
 
 In the case of a crash in the nightly run, you can download the crash artifact and run `cargo-fuzz` with the exact same
-input with the command `cargo fuzz run array_ops/file_io <path/to/artifact>`
+input with the command `cargo +nightly fuzz run array_ops/file_io <path/to/artifact>`
 
 ### ASAN
 
-If there are any linking (on macOS) then run `cargo fuzz run --dev --sanitizer=none ...`. `--dev` runs the fuzzer in dev
-profile.
+If there are any linking (on macOS) then run `cargo +nightly fuzz run --dev --sanitizer=none ...`. `--dev` runs the fuzzer in dev profile.

--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -17,7 +17,6 @@ version = { workspace = true }
 workspace = true
 
 [dependencies]
-arbitrary = { workspace = true, optional = true }
 arcref = { workspace = true }
 arrow-arith = { workspace = true }
 arrow-array = { workspace = true, features = ["ffi"] }
@@ -62,11 +61,6 @@ vortex-scalar = { workspace = true }
 vortex-utils = { workspace = true }
 
 [features]
-arbitrary = [
-    "dep:arbitrary",
-    "vortex-dtype/arbitrary",
-    "vortex-scalar/arbitrary",
-]
 canonical_counter = []
 table-display = ["dep:tabled"]
 test-harness = ["dep:goldenfile", "dep:rstest", "dep:rstest_reuse"]
@@ -76,6 +70,10 @@ arrow-cast = { workspace = true }
 divan = { workspace = true }
 rstest = { workspace = true }
 vortex-array = { path = ".", features = ["test-harness"] }
+
+[target.'cfg(fuzzing)'.dependencies]
+arbitrary = { workspace = true }
+vortex-dtype = { workspace = true }
 
 [[bench]]
 name = "search_sorted"

--- a/vortex-array/src/arrays/mod.rs
+++ b/vortex-array/src/arrays/mod.rs
@@ -18,8 +18,9 @@ mod struct_;
 mod varbin;
 mod varbinview;
 
-#[cfg(feature = "arbitrary")]
+#[cfg(fuzzing)]
 pub mod arbitrary;
+
 mod decimal;
 
 pub use self::bool::*;

--- a/vortex-array/src/compute/mod.rs
+++ b/vortex-array/src/compute/mod.rs
@@ -41,8 +41,9 @@ pub use zip::*;
 use crate::builders::ArrayBuilder;
 use crate::{Array, ArrayRef};
 
-#[cfg(feature = "arbitrary")]
+#[cfg(fuzzing)]
 mod arbitrary;
+
 mod between;
 mod boolean;
 mod cast;

--- a/vortex-cxx/src/lib.rs
+++ b/vortex-cxx/src/lib.rs
@@ -101,6 +101,7 @@ mod ffi {
 
     #[repr(u8)]
     #[derive(Debug, Clone, Copy)]
+    #[cfg_attr(fuzzing, derive(Arbitrary))]
     enum PType {
         U8,
         U16,

--- a/vortex-dtype/Cargo.toml
+++ b/vortex-dtype/Cargo.toml
@@ -14,7 +14,6 @@ rust-version = { workspace = true }
 version = { workspace = true }
 
 [dependencies]
-arbitrary = { workspace = true, optional = true }
 arrow-schema = { workspace = true, optional = true }
 flatbuffers = { workspace = true }
 half = { workspace = true, features = ["num-traits"] }
@@ -34,6 +33,9 @@ vortex-utils = { workspace = true }
 rstest = { workspace = true }
 serde_json = { workspace = true }
 serde_test = { workspace = true }
+
+[target.'cfg(fuzzing)'.dependencies]
+arbitrary = { workspace = true }
 
 [lints]
 workspace = true

--- a/vortex-dtype/src/lib.rs
+++ b/vortex-dtype/src/lib.rs
@@ -19,8 +19,9 @@ pub use nullability::*;
 pub use ptype::*;
 pub use struct_::*;
 
-#[cfg(feature = "arbitrary")]
+#[cfg(fuzzing)]
 mod arbitrary;
+
 #[cfg(feature = "arrow")]
 pub mod arrow;
 pub mod datetime;

--- a/vortex-expr/Cargo.toml
+++ b/vortex-expr/Cargo.toml
@@ -17,7 +17,6 @@ version = { workspace = true }
 workspace = true
 
 [dependencies]
-arbitrary = { workspace = true, optional = true }
 arcref = { workspace = true }
 dyn-hash = { workspace = true }
 itertools = { workspace = true }
@@ -39,11 +38,11 @@ anyhow = { workspace = true }
 rstest = { workspace = true }
 vortex-expr = { path = ".", features = ["test-harness"] }
 
+[target.'cfg(fuzzing)'.dependencies]
+arbitrary = { workspace = true }
+vortex-dtype = { workspace = true, features = ["serde"] }
+vortex-error = { workspace = true, features = ["serde"] }
+
 [features]
-arbitrary = [
-    "dep:arbitrary",
-    "vortex-scalar/arbitrary",
-    "vortex-dtype/arbitrary",
-]
 serde = ["dep:serde", "vortex-dtype/serde", "vortex-error/serde"]
 test-harness = []

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -10,17 +10,11 @@
 //! [Postgres]: https://www.postgresql.org/docs/current/sql-expressions.html
 //! [Apache Datafusion]: https://github.com/apache/datafusion/tree/5fac581efbaffd0e6a9edf931182517524526afd/datafusion/expr
 
-use std::any::Any;
-use std::fmt::{Debug, Display, Formatter};
-use std::hash::{Hash, Hasher};
-use std::sync::Arc;
+#[cfg(fuzzing)]
+pub mod arbitrary;
 
-use dyn_hash::DynHash;
-pub use exprs::*;
 pub mod aliases;
 mod analysis;
-#[cfg(feature = "arbitrary")]
-pub mod arbitrary;
 pub mod dyn_traits;
 mod encoding;
 mod exprs;
@@ -35,11 +29,18 @@ pub mod transform;
 pub mod traversal;
 mod vtable;
 
+use std::any::Any;
+use std::fmt::{Debug, Display, Formatter};
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
 pub use analysis::*;
 pub use between::*;
 pub use binary::*;
 pub use cast::*;
+use dyn_hash::DynHash;
 pub use encoding::*;
+pub use exprs::*;
 pub use get_item::*;
 pub use is_null::*;
 pub use like::*;

--- a/vortex-scalar/Cargo.toml
+++ b/vortex-scalar/Cargo.toml
@@ -14,16 +14,12 @@ rust-version = { workspace = true }
 version = { workspace = true }
 
 [dependencies]
-arbitrary = { workspace = true, optional = true }
 arrow-array = { workspace = true }
 arrow-buffer = { workspace = true }
 bytes = { workspace = true }
 itertools = { workspace = true }
 num-traits = { workspace = true }
 paste = { workspace = true }
-primitive-types = { workspace = true, optional = true, features = [
-    "arbitrary",
-] }
 prost = { workspace = true }
 vortex-buffer = { workspace = true }
 vortex-dtype = { workspace = true, features = ["arrow"] }
@@ -34,8 +30,9 @@ vortex-utils = { workspace = true }
 [dev-dependencies]
 rstest = { workspace = true }
 
+[target.'cfg(fuzzing)'.dependencies]
+arbitrary = { workspace = true }
+primitive-types = { workspace = true, features = ["arbitrary"] }
+
 [lints]
 workspace = true
-
-[features]
-arbitrary = ["dep:arbitrary", "primitive-types"]

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -13,12 +13,14 @@ use std::cmp::Ordering;
 use std::hash::Hash;
 use std::sync::Arc;
 
+#[cfg(fuzzing)]
+pub mod arbitrary;
+
 pub use scalar_type::ScalarType;
 use vortex_buffer::{Buffer, BufferString, ByteBuffer};
 use vortex_dtype::half::f16;
 use vortex_dtype::{DECIMAL128_MAX_PRECISION, DType, Nullability};
-#[cfg(feature = "arbitrary")]
-pub mod arbitrary;
+
 mod arrow;
 mod bigint;
 mod binary;


### PR DESCRIPTION
Inspired by [this](https://www.reddit.com/r/rust/comments/1mrmdft/speed_wins_when_fuzzing_rust_code_with/) reddit discussion, IDK what I think about it but figured I want to see how it looks.

We don't derive Arbitrary anywhere (even though I think we could for something like ptype?), so its probably not a huge difference either way, but it does remove a bunch of dependencies when running stuff like clippy with `all-features`.