### PR TITLE
chore: Add `rust-analyzer` to the `rust-toolchain.tom` file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.89"
-components = ["rust-src", "rustfmt", "clippy"]
+components = ["rust-src", "rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"


### PR DESCRIPTION
By default, Rust toolchains do not install `rust-analyzer`. 