### PR TITLE
fix: timeout crates publish after 1hr

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,4 +16,4 @@ vx = "run -p vortex-tui --"
 # means that it will block indefinitely and this config override is
 # necessary for using the -Zpublish-timeout setting.
 # See https://doc.rust-lang.org/beta/cargo/reference/unstable.html#publish-timeout
-timeout = 0
+timeout = 3600


### PR DESCRIPTION
It appears that there is possibly a bug in the cargo publish implementation with -Zpublish-timeout: https://github.com/rust-lang/cargo/blob/b2c0aea98deecdea035c0df9b20c66a23b78dde8/src/cargo/ops/registry/publish.rs#L261-L320