### PR TITLE
chore: `DType` documentation

### DIFF
--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -219,28 +219,72 @@ impl<F: Into<FieldName>> FromIterator<F> for FieldNames {
 
 /// The logical types of elements in Vortex arrays.
 ///
-/// Vortex arrays preserve a single logical type, while the encodings allow for multiple
-/// physical ways to encode that type.
+/// `DType` represents the different logical data types that can be represented in a Vortex array.
+///
+/// This is different from physical types, which represent the actual layout of data (compressed or
+/// uncompressed). The set of physical types/formats (or data layout) is surjective into the set of
+/// logical types (or in other words, all physical types map to a single logical type).
+///
+/// Note that a `DType` represents the logical type of the elements in the `Array`s, **not** the
+/// logical type of the `Array` itself.
+///
+/// For example, an array with [`DType::Primitive`]([`I32`], [`NonNullable`]) could be physically
+/// encoded as any of the following:
+///
+/// - A flat array of `i32` values.
+/// - A run-length encoded sequence.
+/// - Dictionary encoded values with bitpacked codes.
+///
+/// All of these physical encodings preserve the same logical [`I32`] type, even if the physical
+/// data is different.
+/// 
+/// [`I32`]: PType::I32
+/// [`NonNullable`]: Nullability::NonNullable
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DType {
-    /// The logical null type (only has a single value, `null`)
+    /// A logical null type.
+    ///
+    /// `Null` only has a single value, `null`.
     Null,
-    /// The logical boolean type (`true` or `false` if non-nullable; `true`, `false`, or `null` if nullable)
+
+    /// A logical boolean type.
+    ///
+    /// `Bool` can be `true` or `false` if non-nullable. It can be `true`, `false`, or `null` if
+    /// nullable.
     Bool(Nullability),
-    /// Primitive, fixed-width numeric types (e.g., `u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`, `i64`, `f32`, `f64`)
+
+    /// A logical fixed-width numeric type.
+    ///
+    /// This can be unsigned, signed, or floating point. See [`PType`] for more information.
     Primitive(PType, Nullability),
-    /// Real numbers with fixed exact precision and scale.
+
+    /// Logical real numbers with fixed precision and scale.
+    ///
+    /// See [`DecimalDType`] for more information.
     Decimal(DecimalDType, Nullability),
-    /// UTF-8 strings
+
+    /// Logical UTF-8 strings.
     Utf8(Nullability),
-    /// Binary data
+
+    /// Logical binary data.
     Binary(Nullability),
-    /// A struct is composed of an ordered list of fields, each with a corresponding name and DType
-    Struct(StructFields, Nullability),
-    /// A variable-length list type, parameterized by a single element DType
+
+    /// A logical variable-length list type.
+    ///
+    /// This is parameterized by a single `DType` that represents the element type of the inner
+    /// lists.
     List(Arc<DType>, Nullability),
-    /// User-defined extension types
+
+    /// A logical struct type.
+    ///
+    /// A `Struct` type is composed of an ordered list of fields, each with a corresponding name and
+    /// `DType`. See [`StructFields`] for more information.
+    Struct(StructFields, Nullability),
+
+    /// A user-defined extension type.
+    /// 
+    /// See [`ExtDType`] for more information.
     Extension(Arc<ExtDType>),
 }
 
@@ -341,7 +385,7 @@ impl DType {
         matches!(self, List(_, _))
     }
 
-    /// Check if `self` is a primitive tpye
+    /// Check if `self` is a primitive type
     pub fn is_primitive(&self) -> bool {
         matches!(self, Primitive(_, _))
     }

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -3,7 +3,6 @@
 
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
-use std::ops::Index;
 use std::sync::Arc;
 
 use DType::*;
@@ -13,209 +12,7 @@ use vortex_error::vortex_panic;
 
 use crate::decimal::DecimalDType;
 use crate::nullability::Nullability;
-use crate::{ExtDType, FieldDType, PType, StructFields};
-
-/// A name for a field in a struct
-pub type FieldName = Arc<str>;
-
-/// An ordered list of field names in a struct
-#[derive(Clone, PartialEq, Eq, Debug, Default, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct FieldNames(Arc<[FieldName]>);
-
-impl Display for FieldNames {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            itertools::join(self.0.iter().map(|n| format!("\"{n}\"")), ", ")
-        )
-    }
-}
-
-impl PartialEq<&FieldNames> for FieldNames {
-    fn eq(&self, other: &&FieldNames) -> bool {
-        self == *other
-    }
-}
-
-impl PartialEq<&[&str]> for FieldNames {
-    fn eq(&self, other: &&[&str]) -> bool {
-        self.len() == other.len() && self.iter().zip_eq(other.iter()).all(|(l, r)| &**l == *r)
-    }
-}
-
-impl PartialEq<&[&str]> for &FieldNames {
-    fn eq(&self, other: &&[&str]) -> bool {
-        *self == other
-    }
-}
-
-impl<const N: usize> PartialEq<[&str; N]> for FieldNames {
-    fn eq(&self, other: &[&str; N]) -> bool {
-        self == other.as_slice()
-    }
-}
-
-impl<const N: usize> PartialEq<[&str; N]> for &FieldNames {
-    fn eq(&self, other: &[&str; N]) -> bool {
-        *self == other.as_slice()
-    }
-}
-
-impl PartialEq<&[FieldName]> for FieldNames {
-    fn eq(&self, other: &&[FieldName]) -> bool {
-        self.0.as_ref() == *other
-    }
-}
-
-impl PartialEq<&[FieldName]> for &FieldNames {
-    fn eq(&self, other: &&[FieldName]) -> bool {
-        self.0.as_ref() == *other
-    }
-}
-
-impl FieldNames {
-    /// Returns the number of elements.
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Returns true if the number of elements is 0.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Returns a borrowed iterator over the field names.
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = &FieldName> {
-        FieldNamesIter {
-            inner: self,
-            idx: 0,
-        }
-    }
-
-    /// Returns a reference to a field name, or None if `index` is out of bounds.
-    pub fn get(&self, index: usize) -> Option<&FieldName> {
-        self.0.get(index)
-    }
-}
-
-impl AsRef<[FieldName]> for FieldNames {
-    fn as_ref(&self) -> &[FieldName] {
-        &self.0
-    }
-}
-
-impl Index<usize> for FieldNames {
-    type Output = FieldName;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.0[index]
-    }
-}
-
-/// Iterator of references to field names
-pub struct FieldNamesIter<'a> {
-    inner: &'a FieldNames,
-    idx: usize,
-}
-
-impl<'a> Iterator for FieldNamesIter<'a> {
-    type Item = &'a FieldName;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.idx >= self.inner.len() {
-            return None;
-        }
-
-        let i = &self.inner.0[self.idx];
-        self.idx += 1;
-        Some(i)
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.inner.len() - self.idx;
-        (len, Some(len))
-    }
-}
-
-impl ExactSizeIterator for FieldNamesIter<'_> {}
-
-/// Owned iterator of field names.
-pub struct FieldNamesIntoIter {
-    inner: FieldNames,
-    idx: usize,
-}
-
-impl Iterator for FieldNamesIntoIter {
-    type Item = FieldName;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.idx >= self.inner.len() {
-            return None;
-        }
-
-        let i = self.inner.0[self.idx].clone();
-        self.idx += 1;
-        Some(i)
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.inner.len() - self.idx;
-        (len, Some(len))
-    }
-}
-
-impl ExactSizeIterator for FieldNamesIntoIter {}
-
-impl IntoIterator for FieldNames {
-    type Item = FieldName;
-
-    type IntoIter = FieldNamesIntoIter;
-
-    fn into_iter(self) -> Self::IntoIter {
-        FieldNamesIntoIter {
-            inner: self,
-            idx: 0,
-        }
-    }
-}
-
-impl From<Vec<FieldName>> for FieldNames {
-    fn from(value: Vec<FieldName>) -> Self {
-        Self(value.into())
-    }
-}
-
-impl From<&[&'static str]> for FieldNames {
-    fn from(value: &[&'static str]) -> Self {
-        Self(value.iter().cloned().map(Arc::from).collect())
-    }
-}
-
-impl From<&[FieldName]> for FieldNames {
-    fn from(value: &[FieldName]) -> Self {
-        Self(Arc::from(value))
-    }
-}
-
-impl<const N: usize> From<[&'static str; N]> for FieldNames {
-    fn from(value: [&'static str; N]) -> Self {
-        Self(value.into_iter().map(Arc::from).collect())
-    }
-}
-
-impl<const N: usize> From<[FieldName; N]> for FieldNames {
-    fn from(value: [FieldName; N]) -> Self {
-        Self(value.into())
-    }
-}
-
-impl<F: Into<FieldName>> FromIterator<F> for FieldNames {
-    fn from_iter<T: IntoIterator<Item = F>>(iter: T) -> Self {
-        Self(iter.into_iter().map(|v| v.into()).collect())
-    }
-}
+use crate::{ExtDType, FieldDType, FieldName, PType, StructFields};
 
 /// The logical types of elements in Vortex arrays.
 ///
@@ -237,7 +34,7 @@ impl<F: Into<FieldName>> FromIterator<F> for FieldNames {
 ///
 /// All of these physical encodings preserve the same logical [`I32`] type, even if the physical
 /// data is different.
-/// 
+///
 /// [`I32`]: PType::I32
 /// [`NonNullable`]: Nullability::NonNullable
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -283,7 +80,7 @@ pub enum DType {
     Struct(StructFields, Nullability),
 
     /// A user-defined extension type.
-    /// 
+    ///
     /// See [`ExtDType`] for more information.
     Extension(Arc<ExtDType>),
 }
@@ -531,6 +328,7 @@ impl Display for DType {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::field_names::FieldNames;
 
     #[test]
     fn test_field_names_iter() {

--- a/vortex-dtype/src/field_names.rs
+++ b/vortex-dtype/src/field_names.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::fmt;
+use std::ops::Index;
+use std::sync::Arc;
+
+use itertools::Itertools;
+
+/// A name for a field in a struct.
+pub type FieldName = Arc<str>;
+
+/// An ordered list of field names in a struct.
+#[derive(Clone, PartialEq, Eq, Debug, Default, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct FieldNames(Arc<[FieldName]>);
+
+impl fmt::Display for FieldNames {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[{}]",
+            itertools::join(self.0.iter().map(|n| format!("\"{n}\"")), ", ")
+        )
+    }
+}
+
+impl PartialEq<&FieldNames> for FieldNames {
+    fn eq(&self, other: &&FieldNames) -> bool {
+        self == *other
+    }
+}
+
+impl PartialEq<&[&str]> for FieldNames {
+    fn eq(&self, other: &&[&str]) -> bool {
+        self.len() == other.len() && self.iter().zip_eq(other.iter()).all(|(l, r)| &**l == *r)
+    }
+}
+
+impl PartialEq<&[&str]> for &FieldNames {
+    fn eq(&self, other: &&[&str]) -> bool {
+        *self == other
+    }
+}
+
+impl<const N: usize> PartialEq<[&str; N]> for FieldNames {
+    fn eq(&self, other: &[&str; N]) -> bool {
+        self == other.as_slice()
+    }
+}
+
+impl<const N: usize> PartialEq<[&str; N]> for &FieldNames {
+    fn eq(&self, other: &[&str; N]) -> bool {
+        *self == other.as_slice()
+    }
+}
+
+impl PartialEq<&[FieldName]> for FieldNames {
+    fn eq(&self, other: &&[FieldName]) -> bool {
+        self.0.as_ref() == *other
+    }
+}
+
+impl PartialEq<&[FieldName]> for &FieldNames {
+    fn eq(&self, other: &&[FieldName]) -> bool {
+        self.0.as_ref() == *other
+    }
+}
+
+impl FieldNames {
+    /// Returns the number of elements.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns true if the number of elements is 0.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns a borrowed iterator over the field names.
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &FieldName> {
+        FieldNamesIter {
+            inner: self,
+            idx: 0,
+        }
+    }
+
+    /// Returns a reference to a field name, or None if `index` is out of bounds.
+    pub fn get(&self, index: usize) -> Option<&FieldName> {
+        self.0.get(index)
+    }
+}
+
+impl AsRef<[FieldName]> for FieldNames {
+    fn as_ref(&self) -> &[FieldName] {
+        &self.0
+    }
+}
+
+impl Index<usize> for FieldNames {
+    type Output = FieldName;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+/// Iterator of references to field names.
+pub struct FieldNamesIter<'a> {
+    inner: &'a FieldNames,
+    idx: usize,
+}
+
+impl<'a> Iterator for FieldNamesIter<'a> {
+    type Item = &'a FieldName;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.idx >= self.inner.len() {
+            return None;
+        }
+
+        let i = &self.inner.0[self.idx];
+        self.idx += 1;
+        Some(i)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.inner.len() - self.idx;
+        (len, Some(len))
+    }
+}
+
+impl ExactSizeIterator for FieldNamesIter<'_> {}
+
+/// Owned iterator of field names.
+pub struct FieldNamesIntoIter {
+    inner: FieldNames,
+    idx: usize,
+}
+
+impl Iterator for FieldNamesIntoIter {
+    type Item = FieldName;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.idx >= self.inner.len() {
+            return None;
+        }
+
+        let i = self.inner.0[self.idx].clone();
+        self.idx += 1;
+        Some(i)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.inner.len() - self.idx;
+        (len, Some(len))
+    }
+}
+
+impl ExactSizeIterator for FieldNamesIntoIter {}
+
+impl IntoIterator for FieldNames {
+    type Item = FieldName;
+
+    type IntoIter = FieldNamesIntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        FieldNamesIntoIter {
+            inner: self,
+            idx: 0,
+        }
+    }
+}
+
+impl From<Vec<FieldName>> for FieldNames {
+    fn from(value: Vec<FieldName>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<&[&'static str]> for FieldNames {
+    fn from(value: &[&'static str]) -> Self {
+        Self(value.iter().cloned().map(Arc::from).collect())
+    }
+}
+
+impl From<&[FieldName]> for FieldNames {
+    fn from(value: &[FieldName]) -> Self {
+        Self(Arc::from(value))
+    }
+}
+
+impl<const N: usize> From<[&'static str; N]> for FieldNames {
+    fn from(value: [&'static str; N]) -> Self {
+        Self(value.into_iter().map(Arc::from).collect())
+    }
+}
+
+impl<const N: usize> From<[FieldName; N]> for FieldNames {
+    fn from(value: [FieldName; N]) -> Self {
+        Self(value.into())
+    }
+}
+
+impl<F: Into<FieldName>> FromIterator<F> for FieldNames {
+    fn from_iter<T: IntoIterator<Item = F>>(iter: T) -> Self {
+        Self(iter.into_iter().map(|v| v.into()).collect())
+    }
+}

--- a/vortex-dtype/src/lib.rs
+++ b/vortex-dtype/src/lib.rs
@@ -9,16 +9,6 @@
 //! This crate contains the core logical type system for Vortex, including the definition of data types,
 //! and (optionally) logic for their serialization and deserialization.
 
-pub use decimal::*;
-pub use dtype::*;
-pub use extension::*;
-pub use field::*;
-pub use field_mask::*;
-pub use half;
-pub use nullability::*;
-pub use ptype::*;
-pub use struct_::*;
-
 #[cfg(feature = "arbitrary")]
 mod arbitrary;
 #[cfg(feature = "arrow")]
@@ -29,10 +19,22 @@ mod dtype;
 mod extension;
 mod field;
 mod field_mask;
+mod field_names;
 mod nullability;
 mod ptype;
 mod serde;
 mod struct_;
+
+pub use decimal::*;
+pub use dtype::*;
+pub use extension::*;
+pub use field::*;
+pub use field_mask::*;
+pub use field_names::*;
+pub use half;
+pub use nullability::*;
+pub use ptype::*;
+pub use struct_::*;
 
 pub mod proto {
     //! Protocol buffer representations for DTypes


### PR DESCRIPTION
Also moves the `FieldName` and `FieldNames` to `field_names.rs` (it was confusing going to `dtype.rs` and only seeing `DType` defined halfway down).

I'm not sure if this is too much documentation, but it feels better than having just 2 lines? 