### PR TITLE
fix: downscale FSST offsets

### DIFF
--- a/vortex-array/src/arrays/varbin/compute/take.rs
+++ b/vortex-array/src/arrays/varbin/compute/take.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::iter::Sum;
+
 use num_traits::PrimInt;
 use vortex_dtype::{DType, NativePType, match_each_integer_ptype};
 use vortex_error::{VortexResult, vortex_err, vortex_panic};
@@ -38,7 +40,7 @@ impl TakeKernel for VarBinVTable {
 
 register_kernel!(TakeKernelAdapter(VarBinVTable).lift());
 
-fn take<I: NativePType, O: NativePType + PrimInt>(
+fn take<I: NativePType, O: NativePType + PrimInt + Sum>(
     dtype: DType,
     offsets: &[O],
     data: &[u8],
@@ -57,7 +59,7 @@ fn take<I: NativePType, O: NativePType + PrimInt>(
         ));
     }
 
-    let mut builder = VarBinBuilder::<O>::with_capacity(indices.len());
+    let mut builder = VarBinBuilder::<u32>::with_capacity(indices.len());
     for &idx in indices {
         let idx = idx
             .to_usize()
@@ -81,7 +83,7 @@ fn take_nullable<I: NativePType, O: NativePType + PrimInt>(
     data_validity: Mask,
     indices_validity: Mask,
 ) -> VarBinArray {
-    let mut builder = VarBinBuilder::<O>::with_capacity(indices.len());
+    let mut builder = VarBinBuilder::<u32>::with_capacity(indices.len());
     for (idx, data_idx) in indices.iter().enumerate() {
         if !indices_validity.value(idx) {
             builder.append_null();

--- a/vortex-btrblocks/src/string.rs
+++ b/vortex-btrblocks/src/string.rs
@@ -4,7 +4,7 @@
 use vortex_array::arrays::{VarBinArray, VarBinViewArray, VarBinViewVTable};
 use vortex_array::compress::downscale_integer_array;
 use vortex_array::vtable::ValidityHelper;
-use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
+use vortex_array::{ArrayRef, IntoArray, ToCanonical};
 use vortex_dict::DictArray;
 use vortex_dict::builders::dict_encode;
 use vortex_error::{VortexExpect, VortexResult};

--- a/vortex-btrblocks/src/string.rs
+++ b/vortex-btrblocks/src/string.rs
@@ -2,8 +2,9 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::arrays::{VarBinArray, VarBinViewArray, VarBinViewVTable};
+use vortex_array::compress::downscale_integer_array;
 use vortex_array::vtable::ValidityHelper;
-use vortex_array::{ArrayRef, IntoArray, ToCanonical};
+use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
 use vortex_dict::DictArray;
 use vortex_dict::builders::dict_encode;
 use vortex_error::{VortexExpect, VortexResult};
@@ -237,15 +238,14 @@ impl Scheme for FSSTScheme {
         let fsst = fsst_compress(&stats.src.clone().into_array(), &compressor)?;
 
         let compressed_original_lengths = IntCompressor::compress(
-            &fsst.uncompressed_lengths().to_primitive()?,
+            &downscale_integer_array(fsst.uncompressed_lengths().clone())?.to_primitive()?,
             is_sample,
             allowed_cascading,
             &[],
         )?;
 
-        // We compress the var bin offsets of the FSST codes array.
         let compressed_codes_offsets = IntCompressor::compress(
-            &fsst.codes().offsets().to_primitive()?,
+            &downscale_integer_array(fsst.codes().offsets().clone())?.to_primitive()?,
             is_sample,
             allowed_cascading,
             &[],


### PR DESCRIPTION
Similar to what we do for ListArray and VarBin, the compressor should be downscaling before calling into the IntCompressor.