### PR TITLE
deny `clippy::wildcard_enum_match_arm`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,6 +295,7 @@ tests_outside_test_module = "deny"
 unwrap_in_result = "deny"
 unwrap_used = "deny"
 use_debug = "deny"
+# wildcard_enum_match_arm = "deny" # TODO(connor): Re-enable this once everything passes.
 
 [profile.release]
 codegen-units = 1

--- a/vortex-array/src/array/display/mod.rs
+++ b/vortex-array/src/array/display/mod.rs
@@ -7,8 +7,6 @@ use std::fmt::Display;
 
 use itertools::Itertools as _;
 use tree::TreeDisplayWrapper;
-#[cfg(feature = "table-display")]
-use vortex_error::VortexExpect as _;
 
 use crate::Array;
 
@@ -247,63 +245,62 @@ impl dyn Array + '_ {
             DisplayOptions::TreeDisplay => write!(f, "{}", TreeDisplayWrapper(self.to_array())),
             #[cfg(feature = "table-display")]
             DisplayOptions::TableDisplay => {
+                use vortex_dtype::DType;
+                use vortex_error::VortexExpect as _;
+
                 use crate::canonical::ToCanonical;
+
                 let mut builder = tabled::builder::Builder::default();
 
-                let table = match self.dtype() {
-                    vortex_dtype::DType::Struct(sf, _) => {
-                        let struct_ = self.to_struct().vortex_expect("struct array");
-                        builder.push_record(sf.names().iter().map(|name| name.to_string()));
-
-                        for row_idx in 0..self.len() {
-                            if !self.is_valid(row_idx).vortex_expect("index in bounds") {
-                                let null_row = vec!["null".to_string(); sf.names().len()];
-                                builder.push_record(null_row);
-                            } else {
-                                let mut row = Vec::new();
-                                for field_array in struct_.fields() {
-                                    let value = field_array.scalar_at(row_idx);
-                                    row.push(value.to_string());
-                                }
-                                builder.push_record(row);
-                            }
-                        }
-
-                        let mut table = builder.build();
-                        table.with(tabled::settings::Style::modern());
-
-                        // Center headers
-                        for col_idx in 0..sf.names().len() {
-                            table.modify((0, col_idx), tabled::settings::Alignment::center());
-                        }
-
-                        for row_idx in 0..self.len() {
-                            if !self.is_valid(row_idx).vortex_expect("index is in bounds") {
-                                table.modify(
-                                    (1 + row_idx, 0),
-                                    tabled::settings::Span::column(sf.names().len() as isize),
-                                );
-                                table.modify(
-                                    (1 + row_idx, 0),
-                                    tabled::settings::Alignment::center(),
-                                );
-                            }
-                        }
-                        table
+                // Special logic for struct arrays.
+                let DType::Struct(sf, _) = self.dtype() else {
+                    // For non-struct arrays, simply display a single column table without header.
+                    for row_idx in 0..self.len() {
+                        let value = self.scalar_at(row_idx);
+                        builder.push_record([value.to_string()]);
                     }
-                    _ => {
-                        // For non-struct arrays, display a single column table without header
-                        for row_idx in 0..self.len() {
-                            let value = self.scalar_at(row_idx);
-                            builder.push_record([value.to_string()]);
-                        }
 
-                        let mut table = builder.build();
-                        table.with(tabled::settings::Style::modern());
+                    let mut table = builder.build();
+                    table.with(tabled::settings::Style::modern());
 
-                        table
-                    }
+                    return write!(f, "{table}");
                 };
+
+                let struct_ = self.to_struct().vortex_expect("struct array");
+                builder.push_record(sf.names().iter().map(|name| name.to_string()));
+
+                for row_idx in 0..self.len() {
+                    if !self.is_valid(row_idx).vortex_expect("index in bounds") {
+                        let null_row = vec!["null".to_string(); sf.names().len()];
+                        builder.push_record(null_row);
+                    } else {
+                        let mut row = Vec::new();
+                        for field_array in struct_.fields() {
+                            let value = field_array.scalar_at(row_idx);
+                            row.push(value.to_string());
+                        }
+                        builder.push_record(row);
+                    }
+                }
+
+                let mut table = builder.build();
+                table.with(tabled::settings::Style::modern());
+
+                // Center headers
+                for col_idx in 0..sf.names().len() {
+                    table.modify((0, col_idx), tabled::settings::Alignment::center());
+                }
+
+                for row_idx in 0..self.len() {
+                    if !self.is_valid(row_idx).vortex_expect("index is in bounds") {
+                        table.modify(
+                            (1 + row_idx, 0),
+                            tabled::settings::Span::column(sf.names().len() as isize),
+                        );
+                        table.modify((1 + row_idx, 0), tabled::settings::Alignment::center());
+                    }
+                }
+
                 write!(f, "{table}")
             }
         }

--- a/vortex-array/src/arrays/chunked/decode.rs
+++ b/vortex-array/src/arrays/chunked/decode.rs
@@ -21,6 +21,7 @@ impl CanonicalVTable<ChunkedVTable> for ChunkedVTable {
         if array.nchunks() == 1 {
             return array.chunks()[0].to_canonical();
         }
+
         match array.dtype() {
             DType::Struct(struct_dtype, _) => {
                 let struct_array = swizzle_struct_chunks(
@@ -30,12 +31,18 @@ impl CanonicalVTable<ChunkedVTable> for ChunkedVTable {
                 )?;
                 Ok(Canonical::Struct(struct_array))
             }
-            DType::List(elem, _) => Ok(Canonical::List(pack_lists(
+            DType::List(elem_dtype, _) => Ok(Canonical::List(pack_lists(
                 array.chunks(),
                 Validity::copy_from_array(array.as_ref())?,
-                elem,
+                elem_dtype,
             )?)),
-            _ => {
+            DType::Null
+            | DType::Bool(_)
+            | DType::Primitive(..)
+            | DType::Decimal(..)
+            | DType::Utf8(_)
+            | DType::Binary(_)
+            | DType::Extension(_) => {
                 let mut builder = builder_with_capacity(array.dtype(), array.len());
                 array.append_to_builder(builder.as_mut())?;
                 builder.finish().to_canonical()

--- a/vortex-array/src/arrays/constant/compute/sum.rs
+++ b/vortex-array/src/arrays/constant/compute/sum.rs
@@ -37,7 +37,9 @@ fn sum_scalar(scalar: &Scalar, len: usize) -> VortexResult<ScalarValue> {
             floating: |T| { sum_float(scalar.as_primitive(), len)?.into() }
         )),
         DType::Extension(_) => sum_scalar(&scalar.as_extension().storage(), len),
-        _ => vortex_bail!("Unsupported dtype for sum: {}", scalar.dtype()),
+        DType::Null | DType::Decimal(..) | DType::Utf8(_) | DType::Binary(_) | DType::List(..) | DType::Struct(..) => {
+            vortex_bail!("Unsupported dtype for sum: {}", scalar.dtype())
+        }
     }
 }
 

--- a/vortex-array/src/arrays/datetime/mod.rs
+++ b/vortex-array/src/arrays/datetime/mod.rs
@@ -79,7 +79,9 @@ impl TemporalArray {
             TimeUnit::Ms => {
                 assert_width!(i64, array);
             }
-            _ => vortex_panic!("invalid TimeUnit {time_unit} for vortex.date"),
+            TimeUnit::Ns | TimeUnit::Us | TimeUnit::S => {
+                vortex_panic!("invalid TimeUnit {time_unit} for vortex.date")
+            }
         };
 
         let ext_dtype = ExtDType::new(

--- a/vortex-array/src/arrays/decimal/mod.rs
+++ b/vortex-array/src/arrays/decimal/mod.rs
@@ -79,7 +79,7 @@ pub fn compatible_storage_type(value_type: DecimalValueType, dtype: DecimalDType
 ///
 /// The precisions supported for each scalar type are:
 /// - **i8**: precision 1-2 digits
-/// - **i16**: precision 3-4 digits  
+/// - **i16**: precision 3-4 digits
 /// - **i32**: precision 5-9 digits
 /// - **i64**: precision 10-18 digits
 /// - **i128**: precision 19-38 digits
@@ -206,9 +206,10 @@ impl DecimalArray {
 
     /// Returns the decimal type information
     pub fn decimal_dtype(&self) -> DecimalDType {
-        match &self.dtype {
-            DType::Decimal(decimal_dtype, _) => *decimal_dtype,
-            _ => vortex_panic!("Expected Decimal dtype, got {:?}", self.dtype),
+        if let DType::Decimal(decimal_dtype, _) = self.dtype {
+            decimal_dtype
+        } else {
+            vortex_panic!("Expected Decimal dtype, got {:?}", self.dtype)
         }
     }
 

--- a/vortex-array/src/arrays/primitive/compute/take/mod.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/mod.rs
@@ -73,17 +73,17 @@ impl TakeImpl for TakeKernelScalar {
 
 impl TakeKernel for PrimitiveVTable {
     fn take(&self, array: &PrimitiveArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
-        let unsigned_indices = match indices.dtype() {
-            DType::Primitive(p, n) => {
-                if p.is_unsigned_int() {
-                    indices.to_primitive()?
-                } else {
-                    // This will fail if all values cannot be converted to unsigned
-                    cast(indices, &DType::Primitive(p.to_unsigned(), *n))?.to_primitive()?
-                }
-            }
-            _ => vortex_bail!("Invalid indices dtype: {}", indices.dtype()),
+        let DType::Primitive(ptype, null) = indices.dtype() else {
+            vortex_bail!("Invalid indices dtype: {}", indices.dtype())
         };
+
+        let unsigned_indices = if ptype.is_unsigned_int() {
+            indices.to_primitive()?
+        } else {
+            // This will fail if all values cannot be converted to unsigned
+            cast(indices, &DType::Primitive(ptype.to_unsigned(), *null))?.to_primitive()?
+        };
+
         let validity = array.validity().take(unsigned_indices.as_ref())?;
         // Delegate to the best kernel based on the target CPU
         PRIMITIVE_TAKE_KERNEL.take(array, &unsigned_indices, validity)

--- a/vortex-array/src/arrays/varbin/compute/compare.rs
+++ b/vortex-array/src/arrays/varbin/compute/compare.rs
@@ -37,16 +37,17 @@ impl CompareKernel for VarBinVTable {
                     .as_utf8()
                     .is_empty()
                     .vortex_expect("RHS should not be null"),
-                _ => vortex_bail!("VarBinArray can only have type of Binary or Utf8"),
+                DType::Null | DType::Bool(_) | DType::Primitive(..) | DType::Decimal(..) | DType::List(..) | DType::Struct(..)
+                | DType::Extension(_) => {
+                    vortex_bail!("VarBinArray can only have type of Binary or Utf8")
+                }
             };
 
             if rhs_is_empty {
                 let buffer = match operator {
-                    // Every possible value is gte ""
-                    Operator::Gte => BooleanBuffer::new_set(len),
-                    // No value is lt ""
-                    Operator::Lt => BooleanBuffer::new_unset(len),
-                    _ => {
+                    Operator::Gte => BooleanBuffer::new_set(len), // Every possible value is >= ""
+                    Operator::Lt => BooleanBuffer::new_unset(len), // No value is < ""
+                    Operator::Eq | Operator::NotEq | Operator::Gt | Operator::Lte => {
                         let lhs_offsets = lhs.offsets().to_canonical()?.into_primitive()?;
                         match_each_native_ptype!(lhs_offsets.ptype(), |P| {
                             compare_offsets_to_empty::<P>(lhs_offsets, operator)
@@ -79,7 +80,8 @@ impl CompareKernel for VarBinVTable {
                     .value()
                     .map(BinaryArray::new_scalar)
                     .unwrap_or_else(|| arrow_array::Scalar::new(BinaryArray::new_null(1))),
-                _ => vortex_bail!(
+                DType::Null | DType::Bool(_) | DType::Primitive(..) | DType::Decimal(..) | DType::List(..) | DType::Struct(..)
+                | DType::Extension(_) => vortex_bail!(
                     "VarBin array RHS can only be Utf8 or Binary, given {}",
                     rhs_const.dtype()
                 ),

--- a/vortex-array/src/arrays/varbin/compute/min_max.rs
+++ b/vortex-array/src/arrays/varbin/compute/min_max.rs
@@ -20,7 +20,7 @@ impl MinMaxKernel for VarBinVTable {
 register_kernel!(MinMaxKernelAdapter(VarBinVTable).lift());
 
 /// Compute the min and max of VarBin like array.
-pub fn compute_min_max<T: ArrayAccessor<[u8]>>(
+pub(crate) fn compute_min_max<T: ArrayAccessor<[u8]>>(
     array: &T,
     dtype: &DType,
 ) -> VortexResult<Option<MinMaxResult>> {
@@ -47,12 +47,14 @@ fn make_scalar(dtype: &DType, value: &[u8]) -> Scalar {
     match dtype {
         DType::Binary(_) => Scalar::new(dtype.clone(), value.into()),
         DType::Utf8(_) => {
-            // Safety:
-            // We trust the array's dtype here
+            // SAFETY: We only call `compute_min_max` within `varbin/`, in which we always validate
+            // the arrays, and we always pass `array.dtype()` in as the `dtype` argument.
             let value = unsafe { str::from_utf8_unchecked(value) };
             Scalar::new(dtype.clone(), value.into())
         }
-        _ => unreachable!(),
+        DType::Null | DType::Bool(_) | DType::Primitive(..) | DType::Decimal(..) | DType::List(..) | DType::Struct(..) | DType::Extension(_) => {
+            unreachable!()
+        }
     }
 }
 

--- a/vortex-array/src/arrays/varbin/compute/mod.rs
+++ b/vortex-array/src/arrays/varbin/compute/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-pub use min_max::compute_min_max;
+pub(crate) use min_max::compute_min_max;
 
 mod cast;
 mod compare;

--- a/vortex-array/src/arrays/varbin/mod.rs
+++ b/vortex-array/src/arrays/varbin/mod.rs
@@ -3,7 +3,7 @@
 
 use std::fmt::Debug;
 
-pub use compute::compute_min_max;
+pub(crate) use compute::compute_min_max;
 use num_traits::PrimInt;
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, NativePType, Nullability};

--- a/vortex-array/src/arrays/varbinview/compact.rs
+++ b/vortex-array/src/arrays/varbinview/compact.rs
@@ -63,7 +63,7 @@ impl VarBinViewArray {
     fn count_referenced_bytes(&self) -> u64 {
         match self.validity() {
             Validity::AllInvalid => 0u64,
-            _ => self
+            Validity::NonNullable | Validity::AllValid | Validity::Array(_) => self
                 .views()
                 .iter()
                 .enumerate()

--- a/vortex-array/src/arrays/varbinview/mod.rs
+++ b/vortex-array/src/arrays/varbinview/mod.rs
@@ -401,7 +401,9 @@ impl VarBinViewArray {
                 std::str::from_utf8(string).is_ok()
             })?,
             DType::Binary(_) => Self::validate_views(views, buffers, validity, |_| true)?,
-            _ => vortex_bail!("invalid DType {dtype}"),
+            DType::Null | DType::Bool(_) | DType::Primitive(..) | DType::Decimal(..) | DType::List(..) | DType::Struct(..) | DType::Extension(_) => {
+                vortex_bail!("invalid DType {dtype}")
+            }
         }
 
         Ok(())

--- a/vortex-array/src/arrow/compute/to_arrow/varbin.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/varbin.rs
@@ -8,7 +8,7 @@ use arrow_array::{
 };
 use arrow_schema::DataType;
 use vortex_dtype::{DType, NativePType, Nullability, PType};
-use vortex_error::{VortexResult, vortex_bail};
+use vortex_error::{VortexResult, vortex_bail, vortex_panic};
 
 use crate::arrays::{VarBinArray, VarBinVTable};
 use crate::arrow::compute::{ToArrowKernel, ToArrowKernelAdapter};
@@ -28,13 +28,29 @@ impl ToArrowKernel for VarBinVTable {
             None => match array.dtype() {
                 DType::Binary(_) => match offsets_ptype {
                     PType::I64 | PType::U64 => to_arrow::<i64>(array),
-                    _ => to_arrow::<i32>(array),
+                    PType::U8 | PType::U16 | PType::U32 | PType::I8 | PType::I16 | PType::I32 => {
+                        to_arrow::<i32>(array)
+                    }
+                    PType::F16 | PType::F32 | PType::F64 => {
+                        vortex_panic!("offsets array were somehow floating point")
+                    }
                 },
                 DType::Utf8(_) => match offsets_ptype {
                     PType::I64 | PType::U64 => to_arrow::<i64>(array),
-                    _ => to_arrow::<i32>(array),
+                    PType::U8 | PType::U16 | PType::U32 | PType::I8 | PType::I16 | PType::I32 => {
+                        to_arrow::<i32>(array)
+                    }
+                    PType::F16 | PType::F32 | PType::F64 => {
+                        vortex_panic!("offsets array were somehow floating point")
+                    }
                 },
-                _ => unreachable!("Unsupported DType"),
+                DType::Null
+                | DType::Bool(_)
+                | DType::Primitive(..)
+                | DType::Decimal(..)
+                | DType::List(..)
+                | DType::Struct(..)
+                | DType::Extension(_) => unreachable!("Unsupported DType"),
             },
             // Emit the requested Arrow array.
             Some(DataType::Binary) if array.dtype().is_binary() => to_arrow::<i32>(array),
@@ -67,7 +83,7 @@ fn to_arrow<O: NativePType + OffsetSizeTrait>(array: &VarBinArray) -> VortexResu
     let nulls = array.validity_mask()?.to_null_buffer();
     let data = array.bytes().clone();
 
-    // Switch on DType.
+    // Match on the `DType`.
     Ok(match array.dtype() {
         DType::Binary(_) => Arc::new(unsafe {
             GenericBinaryArray::new_unchecked(
@@ -83,6 +99,14 @@ fn to_arrow<O: NativePType + OffsetSizeTrait>(array: &VarBinArray) -> VortexResu
                 nulls,
             )
         }),
-        _ => unreachable!("expected utf8 or binary instead of {}", array.dtype()),
+        DType::Null
+        | DType::Bool(_)
+        | DType::Primitive(..)
+        | DType::Decimal(..)
+        | DType::List(..)
+        | DType::Struct(..)
+        | DType::Extension(_) => {
+            unreachable!("expected utf8 or binary instead of {}", array.dtype())
+        }
     })
 }

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -80,9 +80,9 @@ where
 }
 
 macro_rules! impl_from_arrow_primitive {
-    ($ty:path) => {
-        impl FromArrowArray<&ArrowPrimitiveArray<$ty>> for ArrayRef {
-            fn from_arrow(value: &ArrowPrimitiveArray<$ty>, nullable: bool) -> Self {
+    ($T:path) => {
+        impl FromArrowArray<&ArrowPrimitiveArray<$T>> for ArrayRef {
+            fn from_arrow(value: &ArrowPrimitiveArray<$T>, nullable: bool) -> Self {
                 let buffer = Buffer::from_arrow_scalar_buffer(value.values().clone());
                 let validity = nulls(value.nulls(), nullable);
                 PrimitiveArray::new(buffer, validity).into_array()
@@ -127,9 +127,9 @@ impl FromArrowArray<&ArrowPrimitiveArray<Decimal256Type>> for ArrayRef {
 }
 
 macro_rules! impl_from_arrow_temporal {
-    ($ty:path) => {
-        impl FromArrowArray<&ArrowPrimitiveArray<$ty>> for ArrayRef {
-            fn from_arrow(value: &ArrowPrimitiveArray<$ty>, nullable: bool) -> Self {
+    ($T:path) => {
+        impl FromArrowArray<&ArrowPrimitiveArray<$T>> for ArrayRef {
+            fn from_arrow(value: &ArrowPrimitiveArray<$T>, nullable: bool) -> Self {
                 temporal_array(value, nullable)
             }
         }
@@ -162,6 +162,9 @@ where
     )
     .into_array();
 
+    // We rely on the entrypoint in `impl FromArrowArray<&dyn ArrowArray> for ArrayRef` to handle
+    // new `DataType` variants.
+    #[allow(clippy::wildcard_enum_match_arm)]
     match value.data_type() {
         DataType::Timestamp(time_unit, tz) => {
             let tz = tz.as_ref().map(|s| s.to_string());
@@ -182,10 +185,15 @@ where
     <T as ByteArrayType>::Offset: NativePType,
 {
     fn from_arrow(value: &GenericByteArray<T>, nullable: bool) -> Self {
+        // We rely on the entrypoint in `impl FromArrowArray<&dyn ArrowArray> for ArrayRef` to
+        // handle new `DataType` variants.
+        #[allow(clippy::wildcard_enum_match_arm)]
         let dtype = match T::DATA_TYPE {
             DataType::Binary | DataType::LargeBinary => DType::Binary(nullable.into()),
             DataType::Utf8 | DataType::LargeUtf8 => DType::Utf8(nullable.into()),
-            _ => vortex_panic!("Invalid data type for ByteArray: {}", T::DATA_TYPE),
+            _ => {
+                vortex_panic!("Invalid data type for ByteArray: {}", T::DATA_TYPE)
+            }
         };
         VarBinArray::try_new(
             value.offsets().clone().into_array(),
@@ -200,10 +208,15 @@ where
 
 impl<T: ByteViewType> FromArrowArray<&GenericByteViewArray<T>> for ArrayRef {
     fn from_arrow(value: &GenericByteViewArray<T>, nullable: bool) -> Self {
+        // We rely on the entrypoint in `impl FromArrowArray<&dyn ArrowArray> for ArrayRef` to
+        // handle new `DataType` variants.
+        #[allow(clippy::wildcard_enum_match_arm)]
         let dtype = match T::DATA_TYPE {
             DataType::BinaryView => DType::Binary(nullable.into()),
             DataType::Utf8View => DType::Utf8(nullable.into()),
-            _ => vortex_panic!("Invalid data type for ByteViewArray: {}", T::DATA_TYPE),
+            _ => {
+                vortex_panic!("Invalid data type for ByteViewArray: {}", T::DATA_TYPE)
+            }
         };
 
         let views_buffer = Buffer::from_byte_buffer(
@@ -243,6 +256,9 @@ fn remove_nulls(data: arrow_data::ArrayData) -> arrow_data::ArrayData {
         return data;
     }
 
+    // We rely on the entrypoint in `impl FromArrowArray<&dyn ArrowArray> for ArrayRef` to handle
+    // new `DataType` variants.
+    #[allow(clippy::wildcard_enum_match_arm)]
     let children = match data.data_type() {
         DataType::Struct(fields) => Some(
             fields
@@ -313,11 +329,16 @@ impl FromArrowArray<&ArrowStructArray> for ArrayRef {
 
 impl<O: OffsetSizeTrait + NativePType> FromArrowArray<&GenericListArray<O>> for ArrayRef {
     fn from_arrow(value: &GenericListArray<O>, nullable: bool) -> Self {
+        // We rely on the entrypoint in `impl FromArrowArray<&dyn ArrowArray> for ArrayRef` to handle
+        // new `DataType` variants.
+        #[allow(clippy::wildcard_enum_match_arm)]
         // Extract the validity of the underlying element array
         let elem_nullable = match value.data_type() {
             DataType::List(field) => field.is_nullable(),
             DataType::LargeList(field) => field.is_nullable(),
-            dt => vortex_panic!("Invalid data type for ListArray: {dt}"),
+            dt => {
+                vortex_panic!("Invalid data type for ListArray: {dt}")
+            }
         };
         ListArray::try_new(
             Self::from_arrow(value.values().as_ref(), elem_nullable),
@@ -402,7 +423,7 @@ impl FromArrowArray<&dyn ArrowArray> for ArrayRef {
                 ArrowTimeUnit::Millisecond => {
                     Self::from_arrow(array.as_primitive::<Time32MillisecondType>(), nullable)
                 }
-                _ => unreachable!(),
+                ArrowTimeUnit::Microsecond | ArrowTimeUnit::Nanosecond => unreachable!(),
             },
             DataType::Time64(u) => match u {
                 ArrowTimeUnit::Microsecond => {
@@ -411,7 +432,7 @@ impl FromArrowArray<&dyn ArrowArray> for ArrayRef {
                 ArrowTimeUnit::Nanosecond => {
                     Self::from_arrow(array.as_primitive::<Time64NanosecondType>(), nullable)
                 }
-                _ => unreachable!(),
+                ArrowTimeUnit::Second | ArrowTimeUnit::Millisecond => unreachable!(),
             },
             DataType::Decimal128(..) => {
                 Self::from_arrow(array.as_primitive::<Decimal128Type>(), nullable)
@@ -419,10 +440,21 @@ impl FromArrowArray<&dyn ArrowArray> for ArrayRef {
             DataType::Decimal256(..) => {
                 Self::from_arrow(array.as_primitive::<Decimal256Type>(), nullable)
             }
-            _ => vortex_panic!(
-                "Array encoding not implemented for Arrow data type {}",
-                array.data_type().clone()
-            ),
+            DataType::Duration(_)
+            | DataType::Interval(_)
+            | DataType::FixedSizeBinary(_)
+            | DataType::ListView(_)
+            | DataType::FixedSizeList(..)
+            | DataType::LargeListView(_)
+            | DataType::Union(..)
+            | DataType::Dictionary(..)
+            | DataType::Map(..)
+            | DataType::RunEndEncoded(..) => {
+                vortex_panic!(
+                    "Array encoding not implemented for Arrow data type {}",
+                    array.data_type().clone()
+                )
+            }
         }
     }
 }

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -98,7 +98,12 @@ impl Canonical {
         match self {
             Canonical::VarBinView(array) => Ok(Canonical::VarBinView(array.compact_buffers()?)),
             Canonical::List(array) => Ok(Canonical::List(array.reset_offsets()?)),
-            other => Ok(other.clone()),
+            Canonical::Null(_)
+            | Canonical::Bool(_)
+            | Canonical::Primitive(_)
+            | Canonical::Decimal(_)
+            | Canonical::Struct(_)
+            | Canonical::Extension(_) => Ok(self.clone()),
         }
     }
 }
@@ -106,58 +111,66 @@ impl Canonical {
 // Unwrap canonical type back down to specialized type.
 impl Canonical {
     pub fn into_null(self) -> VortexResult<NullArray> {
-        match self {
-            Canonical::Null(a) => Ok(a),
-            _ => vortex_bail!("Cannot unwrap NullArray from {:?}", &self),
+        if let Canonical::Null(a) = self {
+            Ok(a)
+        } else {
+            vortex_bail!("Cannot unwrap NullArray from {:?}", &self)
         }
     }
 
     pub fn into_bool(self) -> VortexResult<BoolArray> {
-        match self {
-            Canonical::Bool(a) => Ok(a),
-            _ => vortex_bail!("Cannot unwrap BoolArray from {:?}", &self),
+        if let Canonical::Bool(a) = self {
+            Ok(a)
+        } else {
+            vortex_bail!("Cannot unwrap BoolArray from {:?}", &self)
         }
     }
 
     pub fn into_primitive(self) -> VortexResult<PrimitiveArray> {
-        match self {
-            Canonical::Primitive(a) => Ok(a),
-            _ => vortex_bail!("Cannot unwrap PrimitiveArray from {:?}", &self),
+        if let Canonical::Primitive(a) = self {
+            Ok(a)
+        } else {
+            vortex_bail!("Cannot unwrap PrimitiveArray from {:?}", &self)
         }
     }
 
     pub fn into_decimal(self) -> VortexResult<DecimalArray> {
-        match self {
-            Canonical::Decimal(a) => Ok(a),
-            _ => vortex_bail!("Cannot unwrap DecimalArray from {:?}", &self),
+        if let Canonical::Decimal(a) = self {
+            Ok(a)
+        } else {
+            vortex_bail!("Cannot unwrap DecimalArray from {:?}", &self)
         }
     }
 
     pub fn into_struct(self) -> VortexResult<StructArray> {
-        match self {
-            Canonical::Struct(a) => Ok(a),
-            _ => vortex_bail!("Cannot unwrap StructArray from {:?}", &self),
+        if let Canonical::Struct(a) = self {
+            Ok(a)
+        } else {
+            vortex_bail!("Cannot unwrap StructArray from {:?}", &self)
         }
     }
 
     pub fn into_list(self) -> VortexResult<ListArray> {
-        match self {
-            Canonical::List(a) => Ok(a),
-            _ => vortex_bail!("Cannot unwrap ListArray from {:?}", &self),
+        if let Canonical::List(a) = self {
+            Ok(a)
+        } else {
+            vortex_bail!("Cannot unwrap ListArray from {:?}", &self)
         }
     }
 
     pub fn into_varbinview(self) -> VortexResult<VarBinViewArray> {
-        match self {
-            Canonical::VarBinView(a) => Ok(a),
-            _ => vortex_bail!("Cannot unwrap VarBinViewArray from {:?}", &self),
+        if let Canonical::VarBinView(a) = self {
+            Ok(a)
+        } else {
+            vortex_bail!("Cannot unwrap VarBinViewArray from {:?}", &self)
         }
     }
 
     pub fn into_extension(self) -> VortexResult<ExtensionArray> {
-        match self {
-            Canonical::Extension(a) => Ok(a),
-            _ => vortex_bail!("Cannot unwrap ExtensionArray from {:?}", &self),
+        if let Canonical::Extension(a) = self {
+            Ok(a)
+        } else {
+            vortex_bail!("Cannot unwrap ExtensionArray from {:?}", &self)
         }
     }
 }

--- a/vortex-array/src/compute/conformance/binary_numeric.rs
+++ b/vortex-array/src/compute/conformance/binary_numeric.rs
@@ -198,26 +198,25 @@ where
 /// }
 /// ```
 pub fn test_binary_numeric_array(array: ArrayRef) {
-    use vortex_dtype::PType;
-
     match array.dtype() {
         vortex_dtype::DType::Primitive(ptype, _) => match ptype {
-            PType::I8 => test_binary_numeric_conformance::<i8>(array),
-            PType::I16 => test_binary_numeric_conformance::<i16>(array),
-            PType::I32 => test_binary_numeric_conformance::<i32>(array),
-            PType::I64 => test_binary_numeric_conformance::<i64>(array),
-            PType::U8 => test_binary_numeric_conformance::<u8>(array),
-            PType::U16 => test_binary_numeric_conformance::<u16>(array),
-            PType::U32 => test_binary_numeric_conformance::<u32>(array),
-            PType::U64 => test_binary_numeric_conformance::<u64>(array),
-            PType::F16 => {
+            vortex_dtype::PType::I8 => test_binary_numeric_conformance::<i8>(array),
+            vortex_dtype::PType::I16 => test_binary_numeric_conformance::<i16>(array),
+            vortex_dtype::PType::I32 => test_binary_numeric_conformance::<i32>(array),
+            vortex_dtype::PType::I64 => test_binary_numeric_conformance::<i64>(array),
+            vortex_dtype::PType::U8 => test_binary_numeric_conformance::<u8>(array),
+            vortex_dtype::PType::U16 => test_binary_numeric_conformance::<u16>(array),
+            vortex_dtype::PType::U32 => test_binary_numeric_conformance::<u32>(array),
+            vortex_dtype::PType::U64 => test_binary_numeric_conformance::<u64>(array),
+            vortex_dtype::PType::F16 => {
                 // F16 not supported in num-traits, skip
                 eprintln!("Skipping f16 binary numeric tests (not supported)");
             }
-            PType::F32 => test_binary_numeric_conformance::<f32>(array),
-            PType::F64 => test_binary_numeric_conformance::<f64>(array),
+            vortex_dtype::PType::F32 => test_binary_numeric_conformance::<f32>(array),
+            vortex_dtype::PType::F64 => test_binary_numeric_conformance::<f64>(array),
         },
-        _ => {
+        vortex_dtype::DType::Null | vortex_dtype::DType::Bool(_) | vortex_dtype::DType::Decimal(..) | vortex_dtype::DType::Utf8(_) | vortex_dtype::DType::Binary(_) | vortex_dtype::DType::List(..) | vortex_dtype::DType::Struct(..)
+        | vortex_dtype::DType::Extension(_) => {
             vortex_panic!(
                 "Binary numeric tests are only supported for primitive numeric types, got {:?}",
                 array.dtype()
@@ -234,25 +233,24 @@ pub fn test_binary_numeric_array(array: ArrayRef) {
 /// - Maximum value (tests overflow behavior)
 /// - Minimum value (tests underflow behavior)
 fn test_binary_numeric_edge_cases(array: ArrayRef) {
-    use vortex_dtype::PType;
-
     match array.dtype() {
         vortex_dtype::DType::Primitive(ptype, _) => match ptype {
-            PType::I8 => test_binary_numeric_edge_cases_signed::<i8>(array),
-            PType::I16 => test_binary_numeric_edge_cases_signed::<i16>(array),
-            PType::I32 => test_binary_numeric_edge_cases_signed::<i32>(array),
-            PType::I64 => test_binary_numeric_edge_cases_signed::<i64>(array),
-            PType::U8 => test_binary_numeric_edge_cases_unsigned::<u8>(array),
-            PType::U16 => test_binary_numeric_edge_cases_unsigned::<u16>(array),
-            PType::U32 => test_binary_numeric_edge_cases_unsigned::<u32>(array),
-            PType::U64 => test_binary_numeric_edge_cases_unsigned::<u64>(array),
-            PType::F16 => {
+            vortex_dtype::PType::I8 => test_binary_numeric_edge_cases_signed::<i8>(array),
+            vortex_dtype::PType::I16 => test_binary_numeric_edge_cases_signed::<i16>(array),
+            vortex_dtype::PType::I32 => test_binary_numeric_edge_cases_signed::<i32>(array),
+            vortex_dtype::PType::I64 => test_binary_numeric_edge_cases_signed::<i64>(array),
+            vortex_dtype::PType::U8 => test_binary_numeric_edge_cases_unsigned::<u8>(array),
+            vortex_dtype::PType::U16 => test_binary_numeric_edge_cases_unsigned::<u16>(array),
+            vortex_dtype::PType::U32 => test_binary_numeric_edge_cases_unsigned::<u32>(array),
+            vortex_dtype::PType::U64 => test_binary_numeric_edge_cases_unsigned::<u64>(array),
+            vortex_dtype::PType::F16 => {
                 eprintln!("Skipping f16 edge case tests (not supported)");
             }
-            PType::F32 => test_binary_numeric_edge_cases_float::<f32>(array),
-            PType::F64 => test_binary_numeric_edge_cases_float::<f64>(array),
+            vortex_dtype::PType::F32 => test_binary_numeric_edge_cases_float::<f32>(array),
+            vortex_dtype::PType::F64 => test_binary_numeric_edge_cases_float::<f64>(array),
         },
-        _ => {
+        vortex_dtype::DType::Null | vortex_dtype::DType::Bool(_) | vortex_dtype::DType::Decimal(..) | vortex_dtype::DType::Utf8(_) | vortex_dtype::DType::Binary(_) | vortex_dtype::DType::List(..) | vortex_dtype::DType::Struct(..)
+        | vortex_dtype::DType::Extension(_) => {
             vortex_panic!(
                 "Binary numeric edge case tests are only supported for primitive numeric types"
             );

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -559,11 +559,10 @@ fn test_comparison_inverse_consistency(array: &dyn Array) {
         return;
     }
 
-    // Skip non-comparable types
+    // Skip non-comparable types.
     match array.dtype() {
-        DType::Null | DType::Extension(_) => return,
-        DType::Struct(..) | DType::List(..) => return,
-        _ => {}
+        DType::Null | DType::Extension(_) | DType::Struct(..) | DType::List(..) => return,
+        DType::Bool(_) | DType::Primitive(..) | DType::Decimal(..) | DType::Utf8(_) | DType::Binary(_) => {}
     }
 
     // Get a test value from the middle of the array
@@ -656,11 +655,11 @@ fn test_comparison_symmetry_consistency(array: &dyn Array) {
         return;
     }
 
-    // Skip non-comparable types
+    // Skip non-comparable types.
     match array.dtype() {
         DType::Null | DType::Extension(_) => return,
         DType::Struct(..) | DType::List(..) => return,
-        _ => {}
+        DType::Bool(_) | DType::Primitive(..) | DType::Decimal(..) | DType::Utf8(_) | DType::Binary(_) => {}
     }
 
     // Get test values

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -235,7 +235,7 @@ impl TryFrom<&dyn Array> for Mask {
 pub fn arrow_filter_fn(array: &dyn Array, mask: &Mask) -> VortexResult<ArrayRef> {
     let values = match &mask {
         Mask::Values(values) => values,
-        _ => unreachable!("check in filter invoke"),
+        Mask::AllTrue(_) | Mask::AllFalse(_) => unreachable!("check in filter invoke"),
     };
 
     let array_ref = array.to_array().into_arrow_preferred()?;

--- a/vortex-array/src/compute/mod.rs
+++ b/vortex-array/src/compute/mod.rs
@@ -303,35 +303,35 @@ impl<'a> Input<'a> {
     pub fn scalar(&self) -> Option<&'a Scalar> {
         match self {
             Input::Scalar(scalar) => Some(*scalar),
-            _ => None,
+            Input::Array(_) | Input::Mask(_) | Input::Builder(_) | Input::DType(_) => None,
         }
     }
 
     pub fn array(&self) -> Option<&'a dyn Array> {
         match self {
             Input::Array(array) => Some(*array),
-            _ => None,
+            Input::Scalar(_) | Input::Mask(_) | Input::Builder(_) | Input::DType(_) => None,
         }
     }
 
     pub fn mask(&self) -> Option<&'a Mask> {
         match self {
             Input::Mask(mask) => Some(*mask),
-            _ => None,
+            Input::Scalar(_) | Input::Array(_) | Input::Builder(_) | Input::DType(_) => None,
         }
     }
 
     pub fn builder(&'a mut self) -> Option<&'a mut dyn ArrayBuilder> {
         match self {
             Input::Builder(builder) => Some(*builder),
-            _ => None,
+            Input::Scalar(_) | Input::Array(_) | Input::Mask(_) | Input::DType(_) => None,
         }
     }
 
     pub fn dtype(&self) -> Option<&'a DType> {
         match self {
             Input::DType(dtype) => Some(*dtype),
-            _ => None,
+            Input::Scalar(_) | Input::Array(_) | Input::Mask(_) | Input::Builder(_) => None,
         }
     }
 }

--- a/vortex-array/src/stats/mod.rs
+++ b/vortex-array/src/stats/mod.rs
@@ -174,13 +174,16 @@ impl Stat {
             Self::Min => data_type.clone(),
             Self::NullCount => DType::Primitive(PType::U64, NonNullable),
             Self::UncompressedSizeInBytes => DType::Primitive(PType::U64, NonNullable),
-            Self::NaNCount => match data_type {
-                DType::Primitive(ptype, ..) if ptype.is_float() => {
+            Self::NaNCount => {
+                // Only floating points support NaN counts.
+                if let DType::Primitive(ptype, ..) = data_type
+                    && ptype.is_float()
+                {
                     DType::Primitive(PType::U64, NonNullable)
+                } else {
+                    return None;
                 }
-                // Any other type does not support NaN count
-                _ => return None,
-            },
+            }
             Self::Sum => {
                 // Any array that cannot be summed has a sum DType of null.
                 // Any array that can be summed, but overflows, has a sum _value_ of null.
@@ -188,26 +191,18 @@ impl Stat {
                 match data_type {
                     DType::Bool(_) => DType::Primitive(PType::U64, Nullable),
                     DType::Primitive(ptype, _) => match ptype {
-                        PType::U8 | PType::U16 | PType::U32 | PType::U64 => {
-                            DType::Primitive(PType::U64, Nullable)
-                        }
-                        PType::I8 | PType::I16 | PType::I32 | PType::I64 => {
-                            DType::Primitive(PType::I64, Nullable)
-                        }
+                        PType::U8 | PType::U16 | PType::U32 | PType::U64 => DType::Primitive(PType::U64, Nullable),
+                        PType::I8 | PType::I16 | PType::I32 | PType::I64 => DType::Primitive(PType::I64, Nullable),
                         PType::F16 | PType::F32 | PType::F64 => {
                             // Float sums cannot overflow, but all null floats still end up as null
                             DType::Primitive(PType::F64, Nullable)
                         }
                     },
                     DType::Extension(ext_dtype) => self.dtype(ext_dtype.storage_dtype())?,
-                    // Unsupported types
-                    DType::Null
                     // TODO(aduffy): implement more stats for Decimal
-                    | DType::Decimal(..)
-                    | DType::Utf8(_)
-                    | DType::Binary(_)
-                    | DType::Struct(..)
-                    | DType::List(..) => return None,
+                    DType::Decimal(..) => return None,
+                    // Unsupported types
+                    DType::Null | DType::Utf8(_) | DType::Binary(_) | DType::Struct(..) | DType::List(..) => return None,
                 }
             }
         })

--- a/vortex-array/src/stats/precision.rs
+++ b/vortex-array/src/stats/precision.rs
@@ -40,7 +40,7 @@ impl<T> Precision<Option<T>> {
         match self {
             Exact(Some(x)) => Some(Exact(x)),
             Inexact(Some(x)) => Some(Inexact(x)),
-            _ => None,
+            Exact(None) | Inexact(None) => None,
         }
     }
 }
@@ -123,7 +123,7 @@ impl<T> Precision<T> {
         }
     }
 
-    /// Similar to `map` but handles fucntions that can fail.
+    /// Similar to `map` but handles functions that can fail.
     pub fn try_map<U, F: FnOnce(T) -> VortexResult<U>>(self, f: F) -> VortexResult<Precision<U>> {
         let precision = match self {
             Exact(value) => Exact(f(value)?),

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -58,24 +58,27 @@ impl Validity {
 
     /// If Validity is [`Validity::Array`], returns the array, otherwise returns `None`.
     pub fn into_array(self) -> Option<ArrayRef> {
-        match self {
-            Self::Array(a) => Some(a),
-            _ => None,
+        if let Self::Array(a) = self {
+            Some(a)
+        } else {
+            None
         }
     }
 
     /// If Validity is [`Validity::Array`], returns a reference to the array array, otherwise returns `None`.
     pub fn as_array(&self) -> Option<&ArrayRef> {
-        match self {
-            Self::Array(a) => Some(a),
-            _ => None,
+        if let Self::Array(a) = self {
+            Some(a)
+        } else {
+            None
         }
     }
 
     pub fn nullability(&self) -> Nullability {
-        match self {
-            Self::NonNullable => Nullability::NonNullable,
-            _ => Nullability::Nullable,
+        if matches!(self, Self::NonNullable) {
+            Nullability::NonNullable
+        } else {
+            Nullability::Nullable
         }
     }
 
@@ -139,7 +142,7 @@ impl Validity {
     pub fn slice(&self, start: usize, stop: usize) -> Self {
         match self {
             Self::Array(a) => Self::Array(a.slice(start, stop)),
-            _ => self.clone(),
+            Self::NonNullable | Self::AllValid | Self::AllInvalid => self.clone(),
         }
     }
 
@@ -311,7 +314,7 @@ impl Validity {
     pub fn into_nullable(self) -> Validity {
         match self {
             Self::NonNullable => Self::AllValid,
-            _ => self,
+            Self::AllValid | Self::AllInvalid | Self::Array(_) => self,
         }
     }
 

--- a/vortex-dtype/src/arrow.rs
+++ b/vortex-dtype/src/arrow.rs
@@ -50,7 +50,34 @@ impl TryFromArrowType<&DataType> for PType {
             DataType::Float16 => Ok(Self::F16),
             DataType::Float32 => Ok(Self::F32),
             DataType::Float64 => Ok(Self::F64),
-            _ => Err(vortex_err!(
+            DataType::Null
+            | DataType::Boolean
+            | DataType::Timestamp(..)
+            | DataType::Date32
+            | DataType::Date64
+            | DataType::Time32(_)
+            | DataType::Time64(_)
+            | DataType::Duration(_)
+            | DataType::Interval(_)
+            | DataType::Binary
+            | DataType::FixedSizeBinary(_)
+            | DataType::LargeBinary
+            | DataType::BinaryView
+            | DataType::Utf8
+            | DataType::LargeUtf8
+            | DataType::Utf8View
+            | DataType::List(_)
+            | DataType::ListView(_)
+            | DataType::FixedSizeList(..)
+            | DataType::LargeList(_)
+            | DataType::LargeListView(_)
+            | DataType::Struct(_)
+            | DataType::Union(..)
+            | DataType::Dictionary(..)
+            | DataType::Decimal128(..)
+            | DataType::Decimal256(..)
+            | DataType::Map(..)
+            | DataType::RunEndEncoded(..) => Err(vortex_err!(
                 "Arrow datatype {:?} cannot be converted to ptype",
                 value
             )),
@@ -63,7 +90,43 @@ impl TryFromArrowType<&DataType> for DecimalDType {
         match value {
             DataType::Decimal128(precision, scale) => Self::try_new(*precision, *scale),
             DataType::Decimal256(precision, scale) => Self::try_new(*precision, *scale),
-            _ => Err(vortex_err!(
+            DataType::Null
+            | DataType::Boolean
+            | DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::Float16
+            | DataType::Float32
+            | DataType::Float64
+            | DataType::Timestamp(..)
+            | DataType::Date32
+            | DataType::Date64
+            | DataType::Time32(_)
+            | DataType::Time64(_)
+            | DataType::Duration(_)
+            | DataType::Interval(_)
+            | DataType::Binary
+            | DataType::FixedSizeBinary(_)
+            | DataType::LargeBinary
+            | DataType::BinaryView
+            | DataType::Utf8
+            | DataType::LargeUtf8
+            | DataType::Utf8View
+            | DataType::List(_)
+            | DataType::ListView(_)
+            | DataType::FixedSizeList(..)
+            | DataType::LargeList(_)
+            | DataType::LargeListView(_)
+            | DataType::Struct(_)
+            | DataType::Union(..)
+            | DataType::Dictionary(..)
+            | DataType::Map(..)
+            | DataType::RunEndEncoded(..) => Err(vortex_err!(
                 "Arrow datatype {:?} cannot be converted to DecimalDType",
                 value
             )),
@@ -99,38 +162,59 @@ impl FromArrowType<&Fields> for StructFields {
 
 impl FromArrowType<(&DataType, Nullability)> for DType {
     fn from_arrow((data_type, nullability): (&DataType, Nullability)) -> Self {
-        use crate::DType::*;
-
         if data_type.is_integer() || data_type.is_floating() {
-            return Primitive(
+            return DType::Primitive(
                 PType::try_from_arrow(data_type).vortex_expect("arrow float/integer to ptype"),
                 nullability,
             );
         }
 
         match data_type {
-            DataType::Null => Null,
+            DataType::Null => DType::Null,
             DataType::Decimal128(precision, scale) | DataType::Decimal256(precision, scale) => {
-                Decimal(DecimalDType::new(*precision, *scale), nullability)
+                DType::Decimal(DecimalDType::new(*precision, *scale), nullability)
             }
-            DataType::Boolean => Bool(nullability),
-            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Utf8(nullability),
-            DataType::Binary | DataType::LargeBinary | DataType::BinaryView => Binary(nullability),
+            DataType::Boolean => DType::Bool(nullability),
+            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => DType::Utf8(nullability),
+            DataType::Binary | DataType::LargeBinary | DataType::BinaryView => {
+                DType::Binary(nullability)
+            }
             DataType::Date32
             | DataType::Date64
             | DataType::Time32(_)
             | DataType::Time64(_)
-            | DataType::Timestamp(..) => Extension(Arc::new(
+            | DataType::Timestamp(..) => DType::Extension(Arc::new(
                 make_temporal_ext_dtype(data_type).with_nullability(nullability),
             )),
             DataType::List(e) | DataType::LargeList(e) => {
-                List(Arc::new(Self::from_arrow(e.as_ref())), nullability)
+                DType::List(Arc::new(Self::from_arrow(e.as_ref())), nullability)
             }
-            DataType::Struct(f) => Struct(StructFields::from_arrow(f), nullability),
+            DataType::Struct(f) => DType::Struct(StructFields::from_arrow(f), nullability),
             DataType::Dictionary(_, value_type) => {
                 Self::from_arrow((value_type.as_ref(), nullability))
             }
-            _ => unimplemented!("Arrow data type not yet supported: {:?}", data_type),
+            DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::Float16
+            | DataType::Float32
+            | DataType::Float64
+            | DataType::Duration(..)
+            | DataType::Interval(..)
+            | DataType::FixedSizeBinary(..)
+            | DataType::ListView(..)
+            | DataType::FixedSizeList(..)
+            | DataType::LargeListView(..)
+            | DataType::Union(..)
+            | DataType::Map(..)
+            | DataType::RunEndEncoded(..) => {
+                unimplemented!("Arrow data type not yet supported: {:?}", data_type)
+            }
         }
     }
 }

--- a/vortex-dtype/src/datetime/arrow.rs
+++ b/vortex-dtype/src/datetime/arrow.rs
@@ -54,7 +54,13 @@ pub fn make_temporal_ext_dtype(data_type: &DataType) -> ExtDType {
             Arc::new(PType::I64.into()),
             Some(TemporalMetadata::Date(TimeUnit::Ms).into()),
         ),
-        _ => unimplemented!("{data_type} conversion"),
+        DataType::Null | DataType::Boolean | DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 | DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64
+        | DataType::Float16 | DataType::Float32 | DataType::Float64 | DataType::Duration(_) | DataType::Interval(_) | DataType::Binary | DataType::FixedSizeBinary(_)
+        | DataType::LargeBinary | DataType::BinaryView | DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View | DataType::List(_) | DataType::ListView(_)
+        | DataType::FixedSizeList(..) | DataType::LargeList(_) | DataType::LargeListView(_) | DataType::Struct(_) | DataType::Union(..)
+        | DataType::Dictionary(..) | DataType::Decimal128(..) | DataType::Decimal256(..) | DataType::Map(..) | DataType::RunEndEncoded(..) => {
+            unimplemented!("{data_type} conversion")
+        }
     }
 }
 
@@ -68,7 +74,7 @@ pub fn make_arrow_temporal_dtype(ext_dtype: &ExtDType) -> DataType {
         TemporalMetadata::Date(time_unit) => match time_unit {
             TimeUnit::D => DataType::Date32,
             TimeUnit::Ms => DataType::Date64,
-            _ => {
+            TimeUnit::Ns | TimeUnit::Us | TimeUnit::S => {
                 vortex_panic!(InvalidArgument: "Invalid TimeUnit {} for {}", time_unit, ext_dtype.id())
             }
         },
@@ -77,7 +83,7 @@ pub fn make_arrow_temporal_dtype(ext_dtype: &ExtDType) -> DataType {
             TimeUnit::Ms => DataType::Time32(ArrowTimeUnit::Millisecond),
             TimeUnit::Us => DataType::Time64(ArrowTimeUnit::Microsecond),
             TimeUnit::Ns => DataType::Time64(ArrowTimeUnit::Nanosecond),
-            _ => {
+            TimeUnit::D => {
                 vortex_panic!(InvalidArgument: "Invalid TimeUnit {} for {}", time_unit, ext_dtype.id())
             }
         },
@@ -86,7 +92,7 @@ pub fn make_arrow_temporal_dtype(ext_dtype: &ExtDType) -> DataType {
             TimeUnit::Us => DataType::Timestamp(ArrowTimeUnit::Microsecond, tz.map(|t| t.into())),
             TimeUnit::Ms => DataType::Timestamp(ArrowTimeUnit::Millisecond, tz.map(|t| t.into())),
             TimeUnit::S => DataType::Timestamp(ArrowTimeUnit::Second, tz.map(|t| t.into())),
-            _ => {
+            TimeUnit::D => {
                 vortex_panic!(InvalidArgument: "Invalid TimeUnit {} for {}", time_unit, ext_dtype.id())
             }
         },

--- a/vortex-dtype/src/datetime/temporal.rs
+++ b/vortex-dtype/src/datetime/temporal.rs
@@ -93,7 +93,7 @@ impl TemporalMetadata {
                 TimeUnit::D | TimeUnit::Ms => Ok(TemporalJiff::Date(
                     Date::new(1970, 1, 1)?.checked_add(unit.to_jiff_span(v)?)?,
                 )),
-                _ => {
+                TimeUnit::Ns | TimeUnit::Us | TimeUnit::S => {
                     vortex_bail!("Invalid TimeUnit {} for TemporalMetadata::Time", unit)
                 }
             },
@@ -113,11 +113,11 @@ impl TemporalMetadata {
 }
 
 macro_rules! impl_temporal_metadata_try_from {
-    ($typ:ty) => {
-        impl TryFrom<$typ> for TemporalMetadata {
+    ($T:ty) => {
+        impl TryFrom<$T> for TemporalMetadata {
             type Error = VortexError;
 
-            fn try_from(ext_dtype: $typ) -> Result<Self, Self::Error> {
+            fn try_from(ext_dtype: $T) -> Result<Self, Self::Error> {
                 let metadata = ext_dtype
                     .metadata()
                     .ok_or_else(|| vortex_err!("ExtDType is missing metadata"))?;

--- a/vortex-dtype/src/datetime/unit.rs
+++ b/vortex-dtype/src/datetime/unit.rs
@@ -7,6 +7,7 @@ use jiff::Span;
 use num_enum::IntoPrimitive;
 use vortex_error::{VortexError, VortexResult, vortex_bail};
 
+// TODO(connor): Consider renaming the enum variants to be more descriptive.
 /// Time units for temporal data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, IntoPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/vortex-dtype/src/decimal.rs
+++ b/vortex-dtype/src/decimal.rs
@@ -112,9 +112,10 @@ impl TryFrom<&DType> for DecimalDType {
     type Error = VortexError;
 
     fn try_from(value: &DType) -> Result<Self, Self::Error> {
-        match value {
-            DType::Decimal(dt, _) => Ok(*dt),
-            _ => vortex_bail!("Cannot convert DType {value} into DecimalType"),
+        if let DType::Decimal(dt, _) = value {
+            Ok(*dt)
+        } else {
+            vortex_bail!("Cannot convert DType {value} into DecimalType")
         }
     }
 }

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -92,15 +92,15 @@ const_assert_eq!(size_of::<DType>(), 16);
 const_assert_eq!(size_of::<DType>(), 8);
 
 impl DType {
-    /// The default DType for bytes
+    /// The default `DType` for bytes.
     pub const BYTES: Self = Primitive(PType::U8, Nullability::NonNullable);
 
-    /// Get the nullability of the DType
+    /// Get the nullability of the `DType`.
     pub fn nullability(&self) -> Nullability {
         self.is_nullable().into()
     }
 
-    /// Check if the DType is nullable
+    /// Check if the `DType` is [`Nullability::Nullable`].
     pub fn is_nullable(&self) -> bool {
         match self {
             Null => true,
@@ -115,12 +115,12 @@ impl DType {
         }
     }
 
-    /// Get a new DType with `Nullability::NonNullable` (but otherwise the same as `self`)
+    /// Get a new `DType` with [`Nullability::NonNullable`] (but otherwise the same as `self`)
     pub fn as_nonnullable(&self) -> Self {
         self.with_nullability(Nullability::NonNullable)
     }
 
-    /// Get a new DType with `Nullability::Nullable` (but otherwise the same as `self`)
+    /// Get a new `DType` with [`Nullability::Nullable`] (but otherwise the same as `self`)
     pub fn as_nullable(&self) -> Self {
         self.with_nullability(Nullability::Nullable)
     }
@@ -140,13 +140,13 @@ impl DType {
         }
     }
 
-    /// Union the nullability of this dtype with the other nullability, returning a new dtype.
+    /// Union the nullability of this `DType` with the other nullability, returning a new `DType`.
     pub fn union_nullability(&self, other: Nullability) -> Self {
         let nullability = self.nullability() | other;
         self.with_nullability(nullability)
     }
 
-    /// Check if `self` and `other` are equal, ignoring nullability
+    /// Check if `self` and `other` are equal, ignoring nullability.
     pub fn eq_ignore_nullability(&self, other: &Self) -> bool {
         match (self, other) {
             (Null, Null) => true,
@@ -185,11 +185,12 @@ impl DType {
         matches!(self, Primitive(_, _))
     }
 
-    /// Returns this DType's `PType` if it is a primitive type, otherwise panics.
+    /// Returns this [`DType`]'s [`PType`] if it is a primitive type, otherwise panics.
     pub fn as_ptype(&self) -> PType {
-        match self {
-            Primitive(ptype, _) => *ptype,
-            _ => vortex_panic!("DType is not a primitive type"),
+        if let Primitive(ptype, _) = self {
+            *ptype
+        } else {
+            vortex_panic!("DType is not a primitive type")
         }
     }
 
@@ -252,29 +253,28 @@ impl DType {
 
     /// Check returns the inner decimal type if the dtype is a decimal
     pub fn as_decimal_opt(&self) -> Option<&DecimalDType> {
-        match self {
-            Decimal(decimal, _) => Some(decimal),
-            _ => None,
+        if let Decimal(decimal, _) = self {
+            Some(decimal)
+        } else {
+            None
         }
     }
 
     /// Get the `StructDType` if `self` is a `StructDType`, otherwise `None`
     pub fn as_struct_opt(&self) -> Option<&StructFields> {
-        match self {
-            Struct(s, _) => Some(s),
-            _ => None,
+        if let Struct(f, _) = self {
+            Some(f)
+        } else {
+            None
         }
     }
 
     /// Get the inner dtype if `self` is a `ListDType`, otherwise `None`
     pub fn as_list_element_opt(&self) -> Option<&Arc<DType>> {
-        match self {
-            List(s, _) => Some(s),
-            _ => None,
-        }
+        if let List(s, _) = self { Some(s) } else { None }
     }
 
-    /// Convenience method for creating a struct dtype
+    /// Convenience method for creating a [`DType::Struct`].
     pub fn struct_<I: IntoIterator<Item = (impl Into<FieldName>, impl Into<FieldDType>)>>(
         iter: I,
         nullability: Nullability,

--- a/vortex-dtype/src/ptype.rs
+++ b/vortex-dtype/src/ptype.rs
@@ -13,7 +13,6 @@ use num_traits::{FromPrimitive, Num, NumCast, ToPrimitive, Unsigned};
 use vortex_error::{VortexError, VortexResult, vortex_err};
 
 use crate::DType;
-use crate::DType::*;
 use crate::half::f16;
 use crate::nullability::Nullability::NonNullable;
 
@@ -646,7 +645,9 @@ impl PType {
             Self::U16 => Self::I16,
             Self::U32 => Self::I32,
             Self::U64 => Self::I64,
-            _ => self,
+            Self::I8 | Self::I16 | Self::I32 | Self::I64 | Self::F16 | Self::F32 | Self::F64 => {
+                self
+            }
         }
     }
 
@@ -658,7 +659,9 @@ impl PType {
             Self::I16 => Self::U16,
             Self::I32 => Self::U32,
             Self::I64 => Self::U64,
-            _ => self,
+            Self::U8 | Self::U16 | Self::U32 | Self::U64 | Self::F16 | Self::F32 | Self::F64 => {
+                self
+            }
         }
     }
 }
@@ -686,9 +689,10 @@ impl TryFrom<&DType> for PType {
 
     #[inline]
     fn try_from(value: &DType) -> VortexResult<Self> {
-        match value {
-            Primitive(p, _) => Ok(*p),
-            _ => Err(vortex_err!("Cannot convert DType {} into PType", value)),
+        if let DType::Primitive(p, _) = value {
+            Ok(*p)
+        } else {
+            Err(vortex_err!("Cannot convert DType {} into PType", value))
         }
     }
 }
@@ -697,24 +701,24 @@ impl From<PType> for &DType {
     fn from(item: PType) -> Self {
         // We expand this match statement so that we can return a static reference.
         match item {
-            PType::I8 => &Primitive(PType::I8, NonNullable),
-            PType::I16 => &Primitive(PType::I16, NonNullable),
-            PType::I32 => &Primitive(PType::I32, NonNullable),
-            PType::I64 => &Primitive(PType::I64, NonNullable),
-            PType::U8 => &Primitive(PType::U8, NonNullable),
-            PType::U16 => &Primitive(PType::U16, NonNullable),
-            PType::U32 => &Primitive(PType::U32, NonNullable),
-            PType::U64 => &Primitive(PType::U64, NonNullable),
-            PType::F16 => &Primitive(PType::F16, NonNullable),
-            PType::F32 => &Primitive(PType::F32, NonNullable),
-            PType::F64 => &Primitive(PType::F64, NonNullable),
+            PType::I8 => &DType::Primitive(PType::I8, NonNullable),
+            PType::I16 => &DType::Primitive(PType::I16, NonNullable),
+            PType::I32 => &DType::Primitive(PType::I32, NonNullable),
+            PType::I64 => &DType::Primitive(PType::I64, NonNullable),
+            PType::U8 => &DType::Primitive(PType::U8, NonNullable),
+            PType::U16 => &DType::Primitive(PType::U16, NonNullable),
+            PType::U32 => &DType::Primitive(PType::U32, NonNullable),
+            PType::U64 => &DType::Primitive(PType::U64, NonNullable),
+            PType::F16 => &DType::Primitive(PType::F16, NonNullable),
+            PType::F32 => &DType::Primitive(PType::F32, NonNullable),
+            PType::F64 => &DType::Primitive(PType::F64, NonNullable),
         }
     }
 }
 
 impl From<PType> for DType {
     fn from(item: PType) -> Self {
-        Primitive(item, NonNullable)
+        DType::Primitive(item, NonNullable)
     }
 }
 
@@ -918,16 +922,49 @@ mod tests {
 
     #[test]
     fn to_dtype() {
-        assert_eq!(DType::from(PType::U8), Primitive(PType::U8, NonNullable));
-        assert_eq!(DType::from(PType::U16), Primitive(PType::U16, NonNullable));
-        assert_eq!(DType::from(PType::U32), Primitive(PType::U32, NonNullable));
-        assert_eq!(DType::from(PType::U64), Primitive(PType::U64, NonNullable));
-        assert_eq!(DType::from(PType::I8), Primitive(PType::I8, NonNullable));
-        assert_eq!(DType::from(PType::I16), Primitive(PType::I16, NonNullable));
-        assert_eq!(DType::from(PType::I32), Primitive(PType::I32, NonNullable));
-        assert_eq!(DType::from(PType::I64), Primitive(PType::I64, NonNullable));
-        assert_eq!(DType::from(PType::F16), Primitive(PType::F16, NonNullable));
-        assert_eq!(DType::from(PType::F32), Primitive(PType::F32, NonNullable));
-        assert_eq!(DType::from(PType::F64), Primitive(PType::F64, NonNullable));
+        assert_eq!(
+            DType::from(PType::U8),
+            DType::Primitive(PType::U8, NonNullable)
+        );
+        assert_eq!(
+            DType::from(PType::U16),
+            DType::Primitive(PType::U16, NonNullable)
+        );
+        assert_eq!(
+            DType::from(PType::U32),
+            DType::Primitive(PType::U32, NonNullable)
+        );
+        assert_eq!(
+            DType::from(PType::U64),
+            DType::Primitive(PType::U64, NonNullable)
+        );
+        assert_eq!(
+            DType::from(PType::I8),
+            DType::Primitive(PType::I8, NonNullable)
+        );
+        assert_eq!(
+            DType::from(PType::I16),
+            DType::Primitive(PType::I16, NonNullable)
+        );
+        assert_eq!(
+            DType::from(PType::I32),
+            DType::Primitive(PType::I32, NonNullable)
+        );
+        assert_eq!(
+            DType::from(PType::I64),
+            DType::Primitive(PType::I64, NonNullable)
+        );
+        assert_eq!(
+            DType::from(PType::F16),
+            DType::Primitive(PType::F16, NonNullable)
+        );
+        assert_eq!(
+            DType::from(PType::F32),
+            DType::Primitive(PType::F32, NonNullable)
+        );
+        assert_eq!(
+            DType::from(PType::F64),
+            DType::Primitive(PType::F64, NonNullable)
+        );
     }
 }

--- a/vortex-mask/src/lib.rs
+++ b/vortex-mask/src/lib.rs
@@ -532,9 +532,10 @@ impl Mask {
 
     /// Return [`MaskValues`] if the mask is not all true or all false.
     pub fn values(&self) -> Option<&MaskValues> {
-        match self {
-            Self::Values(values) => Some(values),
-            _ => None,
+        if let Self::Values(values) = self {
+            Some(values)
+        } else {
+            None
         }
     }
 

--- a/vortex-mask/src/tests.rs
+++ b/vortex-mask/src/tests.rs
@@ -500,11 +500,10 @@ fn test_mask_threshold_iter() {
     assert!(matches!(all_false.threshold_iter(0.5), AllOr::None));
 
     let mask = Mask::from_buffer(BooleanBuffer::from_iter([true, false, true, true, false]));
-    match mask.threshold_iter(0.7) {
-        AllOr::Some(MaskIter::Indices(indices)) => {
-            assert_eq!(indices, &[0, 2, 3]);
-        }
-        _ => panic!("Expected indices iterator"),
+    if let AllOr::Some(MaskIter::Indices(indices)) = mask.threshold_iter(0.7) {
+        assert_eq!(indices, &[0, 2, 3]);
+    } else {
+        panic!("Expected indices iterator");
     }
 }
 
@@ -668,6 +667,6 @@ fn test_intersection_indices(
         AllOr::Some(indices) if expected.is_empty() => assert!(indices.is_empty()),
         AllOr::Some(indices) => assert_eq!(indices, &expected[..]),
         AllOr::None if expected.is_empty() => {}
-        _ => panic!("Unexpected result for intersection"),
+        AllOr::None | AllOr::All => panic!("Unexpected result for intersection"),
     }
 }

--- a/vortex-scalar/src/arrow/mod.rs
+++ b/vortex-scalar/src/arrow/mod.rs
@@ -140,7 +140,9 @@ impl TryFrom<&Scalar> for Arc<dyn Datum> {
                             TimeUnit::D => {
                                 value_to_arrow_scalar!(primitive.as_::<i32>(), Date32Array)
                             }
-                            _ => vortex_bail!("Unsupported TimeUnit {u} for {}", ext.id()),
+                            TimeUnit::Ns | TimeUnit::Us | TimeUnit::S => {
+                                vortex_bail!("Unsupported TimeUnit {u} for {}", ext.id())
+                            }
                         },
                         TemporalMetadata::Timestamp(u, _) => match u {
                             TimeUnit::Ns => value_to_arrow_scalar!(

--- a/vortex-scalar/src/arrow/tests.rs
+++ b/vortex-scalar/src/arrow/tests.rs
@@ -291,7 +291,7 @@ fn test_temporal_time_to_arrow(
                 Scalar::primitive(i32_value, Nullability::NonNullable)
             }
             PType::I64 => Scalar::primitive(value, Nullability::NonNullable),
-            _ => unreachable!(),
+            PType::U8 | PType::U16 | PType::U32 | PType::U64 | PType::I8 | PType::I16 | PType::F16 | PType::F32 | PType::F64 => unreachable!(),
         },
     );
 
@@ -340,7 +340,7 @@ fn test_temporal_date_to_arrow(
                 Scalar::primitive(i32_value, Nullability::NonNullable)
             }
             PType::I64 => Scalar::primitive(value, Nullability::NonNullable),
-            _ => unreachable!(),
+            PType::U8 | PType::U16 | PType::U32 | PType::U64 | PType::I8 | PType::I16 | PType::F16 | PType::F32 | PType::F64 => unreachable!(),
         },
     );
 
@@ -365,7 +365,7 @@ fn test_temporal_date_unsupported(#[case] time_unit: TimeUnit, #[case] ptype: PT
         match ptype {
             PType::I32 => Scalar::primitive(1234i32, Nullability::NonNullable),
             PType::I64 => Scalar::primitive(1234567890000i64, Nullability::NonNullable),
-            _ => unreachable!(),
+            PType::U8 | PType::U16 | PType::U32 | PType::U64 | PType::I8 | PType::I16 | PType::F16 | PType::F32 | PType::F64 => unreachable!(),
         },
     );
 

--- a/vortex-scalar/src/decimal/mod.rs
+++ b/vortex-scalar/src/decimal/mod.rs
@@ -38,7 +38,11 @@ impl NativeDecimalType for i8 {
     fn maybe_from(decimal_type: DecimalValue) -> Option<Self> {
         match decimal_type {
             DecimalValue::I8(v) => Some(v),
-            _ => None,
+            DecimalValue::I16(_)
+            | DecimalValue::I32(_)
+            | DecimalValue::I64(_)
+            | DecimalValue::I128(_)
+            | DecimalValue::I256(_) => None,
         }
     }
 }
@@ -49,7 +53,11 @@ impl NativeDecimalType for i16 {
     fn maybe_from(decimal_type: DecimalValue) -> Option<Self> {
         match decimal_type {
             DecimalValue::I16(v) => Some(v),
-            _ => None,
+            DecimalValue::I8(_)
+            | DecimalValue::I32(_)
+            | DecimalValue::I64(_)
+            | DecimalValue::I128(_)
+            | DecimalValue::I256(_) => None,
         }
     }
 }
@@ -60,7 +68,11 @@ impl NativeDecimalType for i32 {
     fn maybe_from(decimal_type: DecimalValue) -> Option<Self> {
         match decimal_type {
             DecimalValue::I32(v) => Some(v),
-            _ => None,
+            DecimalValue::I8(_)
+            | DecimalValue::I16(_)
+            | DecimalValue::I64(_)
+            | DecimalValue::I128(_)
+            | DecimalValue::I256(_) => None,
         }
     }
 }
@@ -71,7 +83,11 @@ impl NativeDecimalType for i64 {
     fn maybe_from(decimal_type: DecimalValue) -> Option<Self> {
         match decimal_type {
             DecimalValue::I64(v) => Some(v),
-            _ => None,
+            DecimalValue::I8(_)
+            | DecimalValue::I16(_)
+            | DecimalValue::I32(_)
+            | DecimalValue::I128(_)
+            | DecimalValue::I256(_) => None,
         }
     }
 }
@@ -82,7 +98,11 @@ impl NativeDecimalType for i128 {
     fn maybe_from(decimal_type: DecimalValue) -> Option<Self> {
         match decimal_type {
             DecimalValue::I128(v) => Some(v),
-            _ => None,
+            DecimalValue::I8(_)
+            | DecimalValue::I16(_)
+            | DecimalValue::I32(_)
+            | DecimalValue::I64(_)
+            | DecimalValue::I256(_) => None,
         }
     }
 }
@@ -93,7 +113,11 @@ impl NativeDecimalType for i256 {
     fn maybe_from(decimal_type: DecimalValue) -> Option<Self> {
         match decimal_type {
             DecimalValue::I256(v) => Some(v),
-            _ => None,
+            DecimalValue::I8(_)
+            | DecimalValue::I16(_)
+            | DecimalValue::I32(_)
+            | DecimalValue::I64(_)
+            | DecimalValue::I128(_) => None,
         }
     }
 }
@@ -202,71 +226,70 @@ impl<'a> DecimalScalar<'a> {
                     let actual_value = scaled_value as f64 / scale_factor as f64;
 
                     // Cast to target primitive type
-                    use PType::*;
                     #[allow(clippy::cast_possible_truncation)]
                     let primitive_scalar = match ptype {
-                        U8 => {
+                        PType::U8 => {
                             let v = actual_value as u8;
                             if actual_value < 0.0 || actual_value > u8::MAX as f64 {
                                 vortex_bail!("Decimal value {} out of range for u8", actual_value);
                             }
                             Scalar::primitive(v, *nullability)
                         }
-                        U16 => {
+                        PType::U16 => {
                             let v = actual_value as u16;
                             if actual_value < 0.0 || actual_value > u16::MAX as f64 {
                                 vortex_bail!("Decimal value {} out of range for u16", actual_value);
                             }
                             Scalar::primitive(v, *nullability)
                         }
-                        U32 => {
+                        PType::U32 => {
                             let v = actual_value as u32;
                             if actual_value < 0.0 || actual_value > u32::MAX as f64 {
                                 vortex_bail!("Decimal value {} out of range for u32", actual_value);
                             }
                             Scalar::primitive(v, *nullability)
                         }
-                        U64 => {
+                        PType::U64 => {
                             let v = actual_value as u64;
                             if actual_value < 0.0 || actual_value > u64::MAX as f64 {
                                 vortex_bail!("Decimal value {} out of range for u64", actual_value);
                             }
                             Scalar::primitive(v, *nullability)
                         }
-                        I8 => {
+                        PType::I8 => {
                             let v = actual_value as i8;
                             if actual_value < i8::MIN as f64 || actual_value > i8::MAX as f64 {
                                 vortex_bail!("Decimal value {} out of range for i8", actual_value);
                             }
                             Scalar::primitive(v, *nullability)
                         }
-                        I16 => {
+                        PType::I16 => {
                             let v = actual_value as i16;
                             if actual_value < i16::MIN as f64 || actual_value > i16::MAX as f64 {
                                 vortex_bail!("Decimal value {} out of range for i16", actual_value);
                             }
                             Scalar::primitive(v, *nullability)
                         }
-                        I32 => {
+                        PType::I32 => {
                             let v = actual_value as i32;
                             if actual_value < i32::MIN as f64 || actual_value > i32::MAX as f64 {
                                 vortex_bail!("Decimal value {} out of range for i32", actual_value);
                             }
                             Scalar::primitive(v, *nullability)
                         }
-                        I64 => {
+                        PType::I64 => {
                             let v = actual_value as i64;
                             if actual_value < i64::MIN as f64 || actual_value > i64::MAX as f64 {
                                 vortex_bail!("Decimal value {} out of range for i64", actual_value);
                             }
                             Scalar::primitive(v, *nullability)
                         }
-                        F16 => {
+                        PType::F16 => {
                             use vortex_dtype::half::f16;
                             Scalar::primitive(f16::from_f64(actual_value), *nullability)
                         }
-                        F32 => Scalar::primitive(actual_value as f32, *nullability),
-                        F64 => Scalar::primitive(actual_value, *nullability),
+                        PType::F32 => Scalar::primitive(actual_value as f32, *nullability),
+                        PType::F64 => Scalar::primitive(actual_value, *nullability),
                     };
                     Ok(primitive_scalar)
                 } else {
@@ -274,7 +297,13 @@ impl<'a> DecimalScalar<'a> {
                     Ok(Scalar::null(dtype.clone()))
                 }
             }
-            _ => vortex_bail!(
+            DType::Null
+            | DType::Bool(_)
+            | DType::Utf8(_)
+            | DType::Binary(_)
+            | DType::List(..)
+            | DType::Struct(..)
+            | DType::Extension(_) => vortex_bail!(
                 "Cannot cast decimal to {dtype}: decimal scalars can only be cast to decimal or primitive numeric types"
             ),
         }
@@ -292,9 +321,9 @@ impl<'a> TryFrom<&'a Scalar> for DecimalScalar<'a> {
 impl Display for DecimalScalar<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self.value.as_ref() {
-            Some(&dv) => {
+            Some(&decimal_value) => {
                 // Introduce some of the scale factors instead.
-                match dv {
+                match decimal_value {
                     DecimalValue::I8(v) => write!(
                         f,
                         "decimal8({}, precision={}, scale={})",

--- a/vortex-scalar/src/decimal/tests.rs
+++ b/vortex-scalar/src/decimal/tests.rs
@@ -473,7 +473,7 @@ fn test_decimal_i8_all_primitive_casts(#[case] ptype: PType, #[case] expected: u
             scalar.as_primitive().typed_value::<i64>().unwrap() as u64,
             expected
         ),
-        _ => panic!("Unexpected type"),
+        PType::F16 | PType::F32 | PType::F64 => panic!("Unexpected type"),
     }
 }
 

--- a/vortex-scalar/src/primitive.rs
+++ b/vortex-scalar/src/primitive.rs
@@ -753,7 +753,9 @@ mod tests {
             PType::U8 => PValue::U8(source_value as u8),
             PType::U16 => PValue::U16(source_value as u16),
             PType::I32 => PValue::I32(source_value),
-            _ => unreachable!("Test case uses unexpected source type"),
+            PType::U32 | PType::U64 | PType::I16 | PType::I64 | PType::F16 | PType::F32 | PType::F64 => {
+                unreachable!("Test case uses unexpected source type")
+            }
         };
 
         let dtype = DType::Primitive(source_type, Nullability::NonNullable);

--- a/vortex-scalar/src/proto.rs
+++ b/vortex-scalar/src/proto.rs
@@ -481,7 +481,8 @@ mod tests {
                         "ScalarValue {name} value not preserved: expected {expected}, got {v}"
                     );
                 }
-                _ => {
+                InnerScalarValue::Primitive(_) | InnerScalarValue::Null | InnerScalarValue::Bool(_) | InnerScalarValue::Decimal(_) | InnerScalarValue::Buffer(_) | InnerScalarValue::BufferString(_)
+                | InnerScalarValue::List(_) => {
                     vortex_panic!("Unexpected type after roundtrip for {name}: {read_back:?}")
                 }
             }
@@ -517,7 +518,8 @@ mod tests {
                         "ScalarValue {name} value not preserved: expected {expected}, got {v}"
                     );
                 }
-                _ => {
+                InnerScalarValue::Primitive(_) | InnerScalarValue::Null | InnerScalarValue::Bool(_) | InnerScalarValue::Decimal(_) | InnerScalarValue::Buffer(_) | InnerScalarValue::BufferString(_)
+                | InnerScalarValue::List(_) => {
                     vortex_panic!("Unexpected type after roundtrip for {name}: {read_back:?}")
                 }
             }

--- a/vortex-scalar/src/pvalue.rs
+++ b/vortex-scalar/src/pvalue.rs
@@ -224,6 +224,8 @@ impl PValue {
             "Cannot reinterpret cast between types of different widths"
         );
 
+        // It is unlikely that more primitive types will be added, so fingers crossed...
+        #[allow(clippy::wildcard_enum_match_arm)]
         match self {
             PValue::U8(v) => u8::cast_signed(*v).into(),
             PValue::U16(v) => match ptype {
@@ -453,7 +455,9 @@ impl CoercePValue for f16 {
             PValue::F64(f) => {
                 <Self as NumCast>::from(f).ok_or_else(|| vortex_err!("Cannot convert f64 to f16"))
             }
-            _ => vortex_bail!("Cannot coerce {value:?} to f16: type not supported for coercion"),
+            PValue::I8(_) | PValue::I16(_) | PValue::I32(_) | PValue::I64(_) => {
+                vortex_bail!("Cannot coerce {value:?} to f16: type not supported for coercion")
+            }
         }
     }
 }
@@ -474,7 +478,9 @@ impl CoercePValue for f32 {
             PValue::F64(f) => {
                 <Self as NumCast>::from(f).ok_or_else(|| vortex_err!("Cannot convert f64 to f32"))
             }
-            _ => vortex_bail!("Unsupported PValue {value:?} type for f32"),
+            PValue::I8(_) | PValue::I16(_) | PValue::I32(_) | PValue::I64(_) => {
+                vortex_bail!("Unsupported PValue {value:?} type for f32")
+            }
         }
     }
 }
@@ -494,7 +500,9 @@ impl CoercePValue for f64 {
                 <Self as NumCast>::from(f).ok_or_else(|| vortex_err!("Cannot convert f32 to f64"))
             }
             PValue::F64(f) => Ok(f),
-            _ => vortex_bail!("Unsupported PValue {value:?} type for f64"),
+            PValue::I8(_) | PValue::I16(_) | PValue::I32(_) | PValue::I64(_) => {
+                vortex_bail!("Unsupported PValue {value:?} type for f64")
+            }
         }
     }
 }

--- a/vortex-scalar/src/scalar_value.rs
+++ b/vortex-scalar/src/scalar_value.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use bytes::BufMut;
 use itertools::Itertools;
 use prost::Message;
-use vortex_buffer::{BufferString, ByteBuffer};
 use vortex_dtype::DType;
 use vortex_error::{VortexResult, VortexUnwrap, vortex_bail, vortex_err};
 use vortex_proto::scalar as pb;
@@ -64,8 +63,8 @@ pub(crate) enum InnerScalarValue {
     Bool(bool),
     Primitive(PValue),
     Decimal(DecimalValue),
-    Buffer(Arc<ByteBuffer>),
-    BufferString(Arc<BufferString>),
+    Buffer(Arc<vortex_buffer::ByteBuffer>),
+    BufferString(Arc<vortex_buffer::BufferString>),
     List(Arc<[ScalarValue]>),
 }
 
@@ -180,12 +179,14 @@ impl ScalarValue {
     }
 
     /// Returns scalar as a binary buffer
-    pub(crate) fn as_buffer(&self) -> VortexResult<Option<Arc<ByteBuffer>>> {
+    pub(crate) fn as_buffer(&self) -> VortexResult<Option<Arc<vortex_buffer::ByteBuffer>>> {
         self.0.as_buffer()
     }
 
     /// Returns scalar as a string buffer
-    pub(crate) fn as_buffer_string(&self) -> VortexResult<Option<Arc<BufferString>>> {
+    pub(crate) fn as_buffer_string(
+        &self,
+    ) -> VortexResult<Option<Arc<vortex_buffer::BufferString>>> {
         self.0.as_buffer_string()
     }
 
@@ -225,17 +226,20 @@ impl InnerScalarValue {
     }
 
     pub(crate) fn as_null(&self) -> VortexResult<()> {
-        match self {
-            InnerScalarValue::Null => Ok(()),
-            _ => Err(vortex_err!("Expected a Null scalar, found {:?}", self)),
+        if matches!(self, InnerScalarValue::Null) {
+            Ok(())
+        } else {
+            Err(vortex_err!("Expected a Null scalar, found {:?}", self))
         }
     }
 
     pub(crate) fn as_bool(&self) -> VortexResult<Option<bool>> {
-        match &self {
-            InnerScalarValue::Null => Ok(None),
-            InnerScalarValue::Bool(b) => Ok(Some(*b)),
-            _ => Err(vortex_err!("Expected a bool scalar, found {:?}", self)),
+        if matches!(&self, InnerScalarValue::Null) {
+            Ok(None)
+        } else if let InnerScalarValue::Bool(b) = &self {
+            Ok(Some(*b))
+        } else {
+            Err(vortex_err!("Expected a bool scalar, found {:?}", self))
         }
     }
 
@@ -243,10 +247,12 @@ impl InnerScalarValue {
     ///  But the other accessors can sometimes be useful? e.g. as_buffer. But maybe we just force
     ///  the user to switch over Utf8 and Binary and use the correct Scalar wrapper?
     pub(crate) fn as_pvalue(&self) -> VortexResult<Option<PValue>> {
-        match &self {
-            InnerScalarValue::Null => Ok(None),
-            InnerScalarValue::Primitive(p) => Ok(Some(*p)),
-            _ => Err(vortex_err!("Expected a primitive scalar, found {:?}", self)),
+        if matches!(&self, InnerScalarValue::Null) {
+            Ok(None)
+        } else if let InnerScalarValue::Primitive(p) = &self {
+            Ok(Some(*p))
+        } else {
+            Err(vortex_err!("Expected a primitive scalar, found {:?}", self))
         }
     }
 
@@ -263,29 +269,46 @@ impl InnerScalarValue {
                 32 => DecimalValue::I256(i256::from_le_bytes(b.as_slice().try_into()?)),
                 l => vortex_bail!("Buffer is not a decimal value length {l}"),
             })),
-            _ => vortex_bail!("Expected a decimal scalar, found {:?}", self),
+            InnerScalarValue::Bool(_)
+            | InnerScalarValue::Primitive(_)
+            | InnerScalarValue::BufferString(_)
+            | InnerScalarValue::List(_) => {
+                vortex_bail!("Expected a decimal scalar, found {:?}", self)
+            }
         }
     }
 
-    pub(crate) fn as_buffer(&self) -> VortexResult<Option<Arc<ByteBuffer>>> {
+    pub(crate) fn as_buffer(&self) -> VortexResult<Option<Arc<vortex_buffer::ByteBuffer>>> {
         match &self {
             InnerScalarValue::Null => Ok(None),
             InnerScalarValue::Buffer(b) => Ok(Some(b.clone())),
             InnerScalarValue::BufferString(b) => {
                 Ok(Some(Arc::new(b.as_ref().clone().into_inner())))
             }
-            _ => Err(vortex_err!("Expected a binary scalar, found {:?}", self)),
+            InnerScalarValue::Bool(_)
+            | InnerScalarValue::Primitive(_)
+            | InnerScalarValue::Decimal(_)
+            | InnerScalarValue::List(_) => {
+                Err(vortex_err!("Expected a binary scalar, found {:?}", self))
+            }
         }
     }
 
-    pub(crate) fn as_buffer_string(&self) -> VortexResult<Option<Arc<BufferString>>> {
+    pub(crate) fn as_buffer_string(
+        &self,
+    ) -> VortexResult<Option<Arc<vortex_buffer::BufferString>>> {
         match &self {
             InnerScalarValue::Null => Ok(None),
-            InnerScalarValue::Buffer(b) => {
-                Ok(Some(Arc::new(BufferString::try_from(b.as_ref().clone())?)))
-            }
+            InnerScalarValue::Buffer(b) => Ok(Some(Arc::new(
+                vortex_buffer::BufferString::try_from(b.as_ref().clone())?,
+            ))),
             InnerScalarValue::BufferString(b) => Ok(Some(b.clone())),
-            _ => Err(vortex_err!("Expected a string scalar, found {:?}", self)),
+            InnerScalarValue::Bool(_)
+            | InnerScalarValue::Primitive(_)
+            | InnerScalarValue::Decimal(_)
+            | InnerScalarValue::List(_) => {
+                Err(vortex_err!("Expected a string scalar, found {:?}", self))
+            }
         }
     }
 
@@ -293,7 +316,13 @@ impl InnerScalarValue {
         match &self {
             InnerScalarValue::Null => Ok(None),
             InnerScalarValue::List(l) => Ok(Some(l)),
-            _ => Err(vortex_err!("Expected a list scalar, found {:?}", self)),
+            InnerScalarValue::Bool(_)
+            | InnerScalarValue::Primitive(_)
+            | InnerScalarValue::Decimal(_)
+            | InnerScalarValue::Buffer(_)
+            | InnerScalarValue::BufferString(_) => {
+                Err(vortex_err!("Expected a list scalar, found {:?}", self))
+            }
         }
     }
 }


### PR DESCRIPTION
This PR turns on the clippy lint `clippy::wildcard_enum_match_arm`, which prevents catch-all arms in `match` statements. You can view the docs [here](https://rust-lang.github.io/rust-clippy/master/index.html#wildcard_enum_match_arm).

If enums ever get updated (for example `DType`), catch-all arms are quite bad because the compiler won't catch if a match statement needs to be updated with the new variant.
You can opt out of this with `#[allow(clippy::wildcard_enum_match_arm)]`, or you can simply use different syntax (`if let` or `let else` or `matches!`) to avoid this.

---

For now, this is just a subset of the crates to make this reviewable.

The protocol I followed was basically:
- If the match statement clearly has only 1 possible "correct" arm, convert into an `if let` statement.
- If it is very obvious that a new variant will not be added that will affect how the existing match arms match, then we can use `#[allow(clippy::wildcard_enum_match_arm)]` with some comments.
  - _An example of this _not_ being the case if for `VarBinView`, where right now this matches against `Utf8` and `Binary`, but it may be possible for us to add `Utf16` of something in the future..._
- If it is a very large hassle to update the match statement, then we can use `#[allow(clippy::wildcard_enum_match_arm)]` with some comments.
- Otherwise, spell out every single enum variant instead of the catch-all arm.

In some cases where this becomes very verbose, I bring the enum variants all into the function scope `use DType::*;`. Usually this is not great, but I try to make sure that this only happens in a function scope where the variants are unambiguous.