### PR TITLE
Add the missing copyright profile file

### DIFF
--- a/.idea/copyright/spdx_apache.xml
+++ b/.idea/copyright/spdx_apache.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="SPDX-License-Identifier: Apache-2.0&#10;SPDX-FileCopyrightText: Copyright the Vortex contributors" />
+    <option name="myName" value="spdx-apache" />
+  </copyright>
+</component>


### PR DESCRIPTION
Combined with the other .idea files, this will automatically insert the SPDX headers to Rust files.