### PR TITLE
Deny ALL catch-all patterns.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,7 +294,7 @@ tests_outside_test_module = "deny"
 unwrap_in_result = "deny"
 unwrap_used = "deny"
 use_debug = "deny"
-# wildcard_enum_match_arm = "deny" # TODO(connor): Re-enable this once everything passes.
+wildcard_enum_match_arm = "deny" # TODO(connor): Re-enable this once everything passes.
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,6 +294,7 @@ tests_outside_test_module = "deny"
 unwrap_in_result = "deny"
 unwrap_used = "deny"
 use_debug = "deny"
+# wildcard_enum_match_arm = "deny" # TODO(connor): Re-enable this once everything passes.
 
 [profile.release]
 codegen-units = 1

--- a/bench-vortex/src/benchmark_trait.rs
+++ b/bench-vortex/src/benchmark_trait.rs
@@ -39,7 +39,7 @@ pub trait Benchmark {
                     delete_duckdb_database,
                 )?)
             }
-            _ => unreachable!("engine not supported"),
+            Engine::Vortex | Engine::Arrow => unreachable!("engine not supported"),
         }
     }
 

--- a/bench-vortex/src/bin/public_bi.rs
+++ b/bench-vortex/src/bin/public_bi.rs
@@ -89,7 +89,9 @@ fn main() -> anyhow::Result<()> {
             Format::Csv => FileType::Csv,
             Format::Parquet => FileType::Parquet,
             Format::OnDiskVortex => FileType::Vortex,
-            other => vortex_panic!("Format {other} isn't supported on Public BI"),
+            Format::Arrow | Format::VortexCompact | Format::OnDiskDuckDB => {
+                vortex_panic!("Format {format} isn't supported on Public BI")
+            }
         };
 
         runtime.block_on(dataset.register_tables(&session, file_type))?;

--- a/bench-vortex/src/clickbench/clickbench_benchmark.rs
+++ b/bench-vortex/src/clickbench/clickbench_benchmark.rs
@@ -74,59 +74,53 @@ impl Benchmark for ClickBenchBenchmark {
     }
 
     fn generate_data(&self, target: &Target) -> Result<()> {
-        match self.data_url.scheme() {
-            "file" => {
-                let basepath = clickbench_flavor(self.flavor).to_data_path();
-                let client = reqwest::blocking::Client::default();
-
-                match target.format() {
-                    Format::Parquet | Format::OnDiskDuckDB => {
-                        // Download Parquet files (idempotent - won't re-download if already present)
-                        // For DuckDB format, we typically start with Parquet and let DuckDB handle it
-                        self.flavor.download(&client, basepath.as_path())?;
-                    }
-                    Format::OnDiskVortex | Format::VortexCompact => {
-                        // First ensure Parquet files exist
-                        self.flavor.download(&client, basepath.as_path())?;
-
-                        // Then convert to Vortex format (idempotent)
-                        if self.data_url.scheme() == "file" {
-                            let file_path = self.data_url.to_file_path().map_err(|_| {
-                                anyhow::anyhow!("invalid file URL: {}", self.data_url)
-                            })?;
-
-                            // Use tokio runtime to handle async conversion
-                            let rt = tokio::runtime::Runtime::new()?;
-                            rt.block_on(async {
-                                match target.format {
-                                    Format::OnDiskVortex => {
-                                        convert_parquet_to_vortex(
-                                            &file_path,
-                                            CompactionStrategy::Default,
-                                        )
-                                        .await
-                                    }
-                                    Format::VortexCompact => {
-                                        convert_parquet_to_vortex(
-                                            &file_path,
-                                            CompactionStrategy::Compact,
-                                        )
-                                        .await
-                                    }
-                                    _ => unreachable!(),
-                                }
-                            })?
-                        }
-                    }
-                    f => {
-                        todo!("format {f} unsupported in clickbench")
-                    }
-                }
-
-                Ok(())
-            }
-            _ => Ok(()),
+        if self.data_url.scheme() != "file" {
+            return Ok(());
         }
+
+        let basepath = clickbench_flavor(self.flavor).to_data_path();
+        let client = reqwest::blocking::Client::default();
+
+        use Format::*;
+
+        match target.format() {
+            Parquet | OnDiskDuckDB => {
+                // Download Parquet files (idempotent - won't re-download if already present)
+                // For DuckDB format, we typically start with Parquet and let DuckDB handle it
+                self.flavor.download(&client, basepath.as_path())?;
+            }
+            OnDiskVortex | VortexCompact => {
+                // First ensure Parquet files exist
+                self.flavor.download(&client, basepath.as_path())?;
+
+                // Then convert to Vortex format (idempotent)
+                if self.data_url.scheme() == "file" {
+                    let file_path = self
+                        .data_url
+                        .to_file_path()
+                        .map_err(|_| anyhow::anyhow!("invalid file URL: {}", self.data_url))?;
+
+                    // Use tokio runtime to handle async conversion
+                    let rt = tokio::runtime::Runtime::new()?;
+                    rt.block_on(async {
+                        match target.format {
+                            OnDiskVortex => {
+                                convert_parquet_to_vortex(&file_path, CompactionStrategy::Default)
+                                    .await
+                            }
+                            VortexCompact => {
+                                convert_parquet_to_vortex(&file_path, CompactionStrategy::Compact)
+                                    .await
+                            }
+                            Csv | Arrow | Parquet | OnDiskDuckDB => unreachable!(),
+                        }
+                    })?
+                }
+            }
+            Csv | Arrow => todo!("format {} unsupported in clickbench", target.format()),
+        }
+
+        Ok(())
     }
 
     #[allow(async_fn_in_trait)]

--- a/bench-vortex/src/engines/ddb/mod.rs
+++ b/bench-vortex/src/engines/ddb/mod.rs
@@ -88,19 +88,25 @@ impl DuckDBCtx {
         let object = match file_format {
             Format::Parquet | Format::OnDiskVortex | Format::VortexCompact => DuckDBObject::View,
             Format::OnDiskDuckDB => DuckDBObject::Table,
-            format => anyhow::bail!("Format {format} isn't supported for DuckDB"),
+            Format::Csv | Format::Arrow => {
+                anyhow::bail!("Format {file_format} isn't supported for DuckDB")
+            }
         };
 
         let load_format = match file_format {
             // Duckdb loads values from parquet to duckdb
             Format::Parquet | Format::OnDiskDuckDB => Format::Parquet,
-            f => f,
+            Format::Csv | Format::Arrow | Format::OnDiskVortex | Format::VortexCompact => {
+                file_format
+            }
         };
 
         let effective_url = self.resolve_storage_url(base_url, load_format, dataset)?;
         let extension = match load_format {
             Format::Parquet | Format::OnDiskVortex | Format::VortexCompact => load_format.ext(),
-            other => anyhow::bail!("Format {other} isn't supported for DuckDB"),
+            Format::Csv | Format::Arrow | Format::OnDiskDuckDB => {
+                anyhow::bail!("Format {load_format} isn't supported for DuckDB")
+            }
         };
 
         // Generate and execute table registration commands

--- a/bench-vortex/src/engines/ddb/mod.rs
+++ b/bench-vortex/src/engines/ddb/mod.rs
@@ -85,28 +85,28 @@ impl DuckDBCtx {
         file_format: Format,
         dataset: &BenchmarkDataset,
     ) -> Result<()> {
-        let object = match file_format {
-            Format::Parquet | Format::OnDiskVortex | Format::VortexCompact => DuckDBObject::View,
-            Format::OnDiskDuckDB => DuckDBObject::Table,
-            Format::Csv | Format::Arrow => {
-                anyhow::bail!("Format {file_format} isn't supported for DuckDB")
-            }
-        };
+        use Format::*;
 
         let load_format = match file_format {
             // Duckdb loads values from parquet to duckdb
-            Format::Parquet | Format::OnDiskDuckDB => Format::Parquet,
-            Format::Csv | Format::Arrow | Format::OnDiskVortex | Format::VortexCompact => {
-                file_format
-            }
+            Parquet | OnDiskDuckDB => Parquet,
+            OnDiskVortex | VortexCompact => file_format,
+            Csv | Arrow => anyhow::bail!("Format {file_format} isn't supported for DuckDB"),
         };
 
         let effective_url = self.resolve_storage_url(base_url, load_format, dataset)?;
         let extension = match load_format {
-            Format::Parquet | Format::OnDiskVortex | Format::VortexCompact => load_format.ext(),
-            Format::Csv | Format::Arrow | Format::OnDiskDuckDB => {
+            Parquet | OnDiskVortex | VortexCompact => load_format.ext(),
+            OnDiskDuckDB => {
                 anyhow::bail!("Format {load_format} isn't supported for DuckDB")
             }
+            Csv | Arrow => unreachable!(),
+        };
+
+        let object = match file_format {
+            Parquet | OnDiskVortex | VortexCompact => DuckDBObject::View,
+            OnDiskDuckDB => DuckDBObject::Table,
+            Csv | Arrow => unreachable!(),
         };
 
         // Generate and execute table registration commands

--- a/bench-vortex/src/measurements.rs
+++ b/bench-vortex/src/measurements.rs
@@ -278,10 +278,12 @@ pub struct CompressionTimingMeasurement {
 
 impl ToJson for CompressionTimingMeasurement {
     fn to_json(&self) -> Box<dyn erased_serde::Serialize> {
+        use Format::*;
+
         let name = match self.format {
-            Format::OnDiskVortex => self.name.to_string(),
-            Format::Parquet => format!("parquet_rs-zstd {}", self.name),
-            Format::Csv | Format::Arrow | Format::VortexCompact | Format::OnDiskDuckDB => {
+            OnDiskVortex => self.name.to_string(),
+            Parquet => format!("parquet_rs-zstd {}", self.name),
+            Csv | Arrow | VortexCompact | OnDiskDuckDB => {
                 vortex_panic!(
                     "CompressionTimingMeasurement only supports vortex and parquet formats"
                 )

--- a/bench-vortex/src/measurements.rs
+++ b/bench-vortex/src/measurements.rs
@@ -281,9 +281,11 @@ impl ToJson for CompressionTimingMeasurement {
         let name = match self.format {
             Format::OnDiskVortex => self.name.to_string(),
             Format::Parquet => format!("parquet_rs-zstd {}", self.name),
-            _ => vortex_panic!(
-                "CompressionTimingMeasurement only supports vortex and parquet formats"
-            ),
+            Format::Csv | Format::Arrow | Format::VortexCompact | Format::OnDiskDuckDB => {
+                vortex_panic!(
+                    "CompressionTimingMeasurement only supports vortex and parquet formats"
+                )
+            }
         };
 
         Box::new(JsonValue {

--- a/bench-vortex/src/metrics.rs
+++ b/bench-vortex/src/metrics.rs
@@ -191,7 +191,7 @@ fn timestamps(plan: &dyn ExecutionPlan) -> (Option<SystemTime>, Option<SystemTim
             let mut min_start: Option<SystemTime> = None;
             let mut max_end: Option<SystemTime> = None;
             for m in metrics.iter() {
-                // TODO(connor): spell out all MetricValue variants
+                // There can only be a start and end timestamp.
                 #[allow(clippy::wildcard_enum_match_arm)]
                 match m.value() {
                     MetricValue::StartTimestamp(ts) => {

--- a/bench-vortex/src/metrics.rs
+++ b/bench-vortex/src/metrics.rs
@@ -69,13 +69,15 @@ fn aggregate_metric(metric: &mut MetricValue, to_aggregate: &MetricValue) {
             MetricValue::Gauge {
                 gauge: other_gauge, ..
             },
-        ) => match name {
-            _ if name.ends_with("max") => gauge.set_max(other_gauge.value()),
-            _ if name.ends_with("min") => {
+        ) => {
+            if name.ends_with("max") {
+                gauge.set_max(other_gauge.value())
+            } else if name.ends_with("min") {
                 gauge.set(gauge.value().min(other_gauge.value()));
+            } else {
+                gauge.add(other_gauge.value())
             }
-            _ => gauge.add(other_gauge.value()),
-        },
+        }
         (metric, to_aggregate) => metric.aggregate(to_aggregate),
     };
 }
@@ -189,6 +191,8 @@ fn timestamps(plan: &dyn ExecutionPlan) -> (Option<SystemTime>, Option<SystemTim
             let mut min_start: Option<SystemTime> = None;
             let mut max_end: Option<SystemTime> = None;
             for m in metrics.iter() {
+                // TODO(connor): spell out all MetricValue variants
+                #[allow(clippy::wildcard_enum_match_arm)]
                 match m.value() {
                     MetricValue::StartTimestamp(ts) => {
                         min_start = match (ts.value().map(|dt| dt.into()), min_start) {

--- a/bench-vortex/src/public_bi.rs
+++ b/bench-vortex/src/public_bi.rs
@@ -447,7 +447,7 @@ fn replace_with_views(schema: &DFSchema) -> Result<DFSchema> {
         .fields()
         .iter()
         .map(|f| {
-            // TODO(connor): spell out all DataType variants
+            // TODO(connor): There probably will not be more views like this, but fingers crossed...
             #[allow(clippy::wildcard_enum_match_arm)]
             match f.data_type() {
                 DataType::Binary => {

--- a/bench-vortex/src/public_bi.rs
+++ b/bench-vortex/src/public_bi.rs
@@ -446,14 +446,18 @@ fn replace_with_views(schema: &DFSchema) -> Result<DFSchema> {
     let fields: Vec<_> = schema
         .fields()
         .iter()
-        .map(|f| match f.data_type() {
-            DataType::Binary => {
-                Arc::new(<Field as Clone>::clone(f).with_data_type(DataType::BinaryView))
+        .map(|f| {
+            // TODO(connor): spell out all DataType variants
+            #[allow(clippy::wildcard_enum_match_arm)]
+            match f.data_type() {
+                DataType::Binary => {
+                    Arc::new(<Field as Clone>::clone(f).with_data_type(DataType::BinaryView))
+                }
+                DataType::Utf8 => {
+                    Arc::new(<Field as Clone>::clone(f).with_data_type(DataType::Utf8View))
+                }
+                _ => f.clone(),
             }
-            DataType::Utf8 => {
-                Arc::new(<Field as Clone>::clone(f).with_data_type(DataType::Utf8View))
-            }
-            _ => f.clone(),
         })
         .collect();
     let new_schema = Schema::new(fields);

--- a/bench-vortex/src/tpch/tpchgen.rs
+++ b/bench-vortex/src/tpch/tpchgen.rs
@@ -213,7 +213,7 @@ fn generate_table_files(
                         schema,
                         CompactionStrategy::Compact,
                     )?),
-                    _ => unreachable!(),
+                    Format::Csv | Format::Arrow | Format::OnDiskDuckDB => unreachable!(),
                 };
 
                 for batch in iter {

--- a/bench-vortex/src/tpch/tpchgen.rs
+++ b/bench-vortex/src/tpch/tpchgen.rs
@@ -201,19 +201,20 @@ fn generate_table_files(
                 let schema = iter.schema().clone();
 
                 // Create writer based on format
+                use Format::*;
                 let mut writer: Box<dyn FileWriter + Send> = match write_format {
-                    Format::Parquet => Box::new(ParquetWriter::new(path, schema).await?),
-                    Format::OnDiskVortex => Box::new(VortexWriter::new(
+                    Parquet => Box::new(ParquetWriter::new(path, schema).await?),
+                    OnDiskVortex => Box::new(VortexWriter::new(
                         path,
                         schema,
                         CompactionStrategy::Default,
                     )?),
-                    Format::VortexCompact => Box::new(VortexWriter::new(
+                    VortexCompact => Box::new(VortexWriter::new(
                         path,
                         schema,
                         CompactionStrategy::Compact,
                     )?),
-                    Format::Csv | Format::Arrow | Format::OnDiskDuckDB => unreachable!(),
+                    Csv | Arrow | OnDiskDuckDB => unreachable!("{write_format} not supported"),
                 };
 
                 for batch in iter {

--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -57,11 +57,10 @@ impl ALPArray {
         exponents: Exponents,
         patches: Option<&Patches>,
     ) -> VortexResult<()> {
+        use PType::*;
+
         vortex_ensure!(
-            matches!(
-                encoded.dtype(),
-                DType::Primitive(PType::I32 | PType::I64, _)
-            ),
+            matches!(encoded.dtype(), DType::Primitive(I32 | I64, _)),
             "ALP encoded ints have invalid DType {}",
             encoded.dtype(),
         );
@@ -70,14 +69,14 @@ impl ALPArray {
         // length and type.
         let Exponents { e, f } = exponents;
         match encoded.dtype().as_ptype() {
-            PType::I32 => {
+            I32 => {
                 vortex_ensure!(exponents.e <= f32::MAX_EXPONENT, "e out of bounds: {e}");
                 vortex_ensure!(exponents.f <= f32::MAX_EXPONENT, "f out of bounds: {f}");
                 if let Some(patches) = patches {
                     Self::validate_patches::<f32>(patches, encoded)?;
                 }
             }
-            PType::I64 => {
+            I64 => {
                 vortex_ensure!(e <= f64::MAX_EXPONENT, "e out of bounds: {e}");
                 vortex_ensure!(f <= f64::MAX_EXPONENT, "f out of bounds: {f}");
 
@@ -85,7 +84,7 @@ impl ALPArray {
                     Self::validate_patches::<f64>(patches, encoded)?;
                 }
             }
-            _ => unreachable!(),
+            U8 | U16 | U32 | U64 | I8 | I16 | F16 | F32 | F64 => unreachable!(),
         }
 
         // Validate patches
@@ -190,10 +189,13 @@ impl ALPArray {
     ) -> VortexResult<Self> {
         Self::validate(&encoded, exponents, patches.as_ref())?;
 
+        use DType::*;
+
         let dtype = match encoded.dtype() {
-            DType::Primitive(PType::I32, nullability) => DType::Primitive(PType::F32, *nullability),
-            DType::Primitive(PType::I64, nullability) => DType::Primitive(PType::F64, *nullability),
-            _ => unreachable!(),
+            Primitive(PType::I32, nullability) => Primitive(PType::F32, *nullability),
+            Primitive(PType::I64, nullability) => Primitive(PType::F64, *nullability),
+            Null | Bool(_) | Primitive(..) | Decimal(..) | Utf8(_) | Binary(_) | List(..)
+            | Struct(..) | Extension(_) => unreachable!(),
         };
 
         Ok(Self {

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -37,10 +37,14 @@ macro_rules! match_each_alp_float_ptype {
 }
 
 pub fn alp_encode(parray: &PrimitiveArray, exponents: Option<Exponents>) -> VortexResult<ALPArray> {
+    use PType::*;
+
     let (exponents, encoded, patches) = match parray.ptype() {
-        PType::F32 => alp_encode_components_typed::<f32>(parray, exponents)?,
-        PType::F64 => alp_encode_components_typed::<f64>(parray, exponents)?,
-        _ => vortex_bail!("ALP can only encode f32 and f64"),
+        F32 => alp_encode_components_typed::<f32>(parray, exponents)?,
+        F64 => alp_encode_components_typed::<f64>(parray, exponents)?,
+        U8 | U16 | U32 | U64 | I8 | I16 | I32 | I64 | F16 => {
+            vortex_bail!("ALP can only encode f32 and f64")
+        }
     };
 
     // SAFETY: alp_encode_components_typed must return well-formed components

--- a/encodings/alp/src/alp/serde.rs
+++ b/encodings/alp/src/alp/serde.rs
@@ -47,10 +47,13 @@ impl SerdeVTable<ALPVTable> for ALPVTable {
         _buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ALPArray> {
+        use DType::*;
+
         let encoded_ptype = match &dtype {
-            DType::Primitive(PType::F32, n) => DType::Primitive(PType::I32, *n),
-            DType::Primitive(PType::F64, n) => DType::Primitive(PType::I64, *n),
-            d => vortex_bail!(MismatchedTypes: "f32 or f64", d),
+            Primitive(PType::F32, n) => Primitive(PType::I32, *n),
+            Primitive(PType::F64, n) => Primitive(PType::I64, *n),
+            Null | Bool(_) | Primitive(..) | Decimal(..) | Utf8(_) | Binary(_) | List(..)
+            | Struct(..) | Extension(_) => vortex_bail!(MismatchedTypes: "f32 or f64", dtype),
         };
         let encoded = children.get(0, &encoded_ptype, len)?;
 

--- a/encodings/alp/src/alp_rd/serde.rs
+++ b/encodings/alp/src/alp_rd/serde.rs
@@ -123,18 +123,13 @@ impl EncodeVTable<ALPRDVTable> for ALPRDVTable {
 
         let alprd_array = match like {
             None => {
+                use PType::*;
                 let encoder = match parray.ptype() {
-                    PType::F32 => RDEncoder::new(parray.as_slice::<f32>()),
-                    PType::F64 => RDEncoder::new(parray.as_slice::<f64>()),
-                    ptype @ PType::U8
-                    | ptype @ PType::U16
-                    | ptype @ PType::U32
-                    | ptype @ PType::U64
-                    | ptype @ PType::I8
-                    | ptype @ PType::I16
-                    | ptype @ PType::I32
-                    | ptype @ PType::I64
-                    | ptype @ PType::F16 => vortex_bail!("cannot ALPRD compress ptype {ptype}"),
+                    F32 => RDEncoder::new(parray.as_slice::<f32>()),
+                    F64 => RDEncoder::new(parray.as_slice::<f64>()),
+                    U8 | U16 | U32 | U64 | I8 | I16 | I32 | I64 | F16 => {
+                        vortex_bail!("cannot ALPRD compress ptype {}", parray.ptype())
+                    }
                 };
                 encoder.encode(&parray)
             }

--- a/encodings/alp/src/alp_rd/serde.rs
+++ b/encodings/alp/src/alp_rd/serde.rs
@@ -65,7 +65,7 @@ impl SerdeVTable<ALPRDVTable> for ALPRDVTable {
             );
         }
 
-        let left_parts_dtype = DType::Primitive(metadata.left_parts_ptype(), dtype.nullability());
+        let left_parts_dtype = Primitive(metadata.left_parts_ptype(), dtype.nullability());
         let left_parts = children.get(0, &left_parts_dtype, len)?;
         let left_parts_dictionary: Buffer<u16> = metadata.dict.as_slice()
             [0..metadata.dict_len as usize]
@@ -76,14 +76,15 @@ impl SerdeVTable<ALPRDVTable> for ALPRDVTable {
             })
             .try_collect()?;
 
+        use DType::*;
+
         let right_parts_dtype = match &dtype {
-            DType::Primitive(PType::F32, _) => {
-                DType::Primitive(PType::U32, Nullability::NonNullable)
+            Primitive(PType::F32, _) => Primitive(PType::U32, Nullability::NonNullable),
+            Primitive(PType::F64, _) => Primitive(PType::U64, Nullability::NonNullable),
+            Null | Bool(_) | Primitive(..) | Decimal(..) | Utf8(_) | Binary(_) | List(..)
+            | Struct(..) | Extension(_) => {
+                vortex_bail!("Expected f32 or f64 dtype, got {:?}", dtype)
             }
-            DType::Primitive(PType::F64, _) => {
-                DType::Primitive(PType::U64, Nullability::NonNullable)
-            }
-            _ => vortex_bail!("Expected f32 or f64 dtype, got {:?}", dtype),
         };
         let right_parts = children.get(1, &right_parts_dtype, len)?;
 
@@ -125,7 +126,15 @@ impl EncodeVTable<ALPRDVTable> for ALPRDVTable {
                 let encoder = match parray.ptype() {
                     PType::F32 => RDEncoder::new(parray.as_slice::<f32>()),
                     PType::F64 => RDEncoder::new(parray.as_slice::<f64>()),
-                    ptype => vortex_bail!("cannot ALPRD compress ptype {ptype}"),
+                    ptype @ PType::U8
+                    | ptype @ PType::U16
+                    | ptype @ PType::U32
+                    | ptype @ PType::U64
+                    | ptype @ PType::I8
+                    | ptype @ PType::I16
+                    | ptype @ PType::I32
+                    | ptype @ PType::I64
+                    | ptype @ PType::F16 => vortex_bail!("cannot ALPRD compress ptype {ptype}"),
                 };
                 encoder.encode(&parray)
             }

--- a/encodings/dict/src/array.rs
+++ b/encodings/dict/src/array.rs
@@ -138,16 +138,20 @@ impl ArrayVTable<DictVTable> for DictVTable {
 
 impl CanonicalVTable<DictVTable> for DictVTable {
     fn canonicalize(array: &DictArray) -> VortexResult<Canonical> {
+        use DType::*;
+
         match array.dtype() {
             // NOTE: Utf8 and Binary will decompress into VarBinViewArray, which requires a full
             // decompression to construct the views child array.
             // For this case, it is *always* faster to decompress the values first and then create
             // copies of the view pointers.
-            DType::Utf8(_) | DType::Binary(_) => {
+            Utf8(_) | Binary(_) => {
                 let canonical_values: ArrayRef = array.values().to_canonical()?.into_array();
                 take(&canonical_values, array.codes())?.to_canonical()
             }
-            _ => take(array.values(), array.codes())?.to_canonical(),
+            Null | Bool(_) | Primitive(..) | Decimal(..) | List(..) | Struct(..) | Extension(_) => {
+                take(array.values(), array.codes())?.to_canonical()
+            }
         }
     }
 }

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -191,9 +191,10 @@ pub fn gather_patches(
     bit_width: u8,
     num_exceptions_hint: usize,
 ) -> VortexResult<Option<Patches>> {
-    let patch_validity = match parray.validity() {
-        Validity::NonNullable => Validity::NonNullable,
-        _ => Validity::AllValid,
+    let patch_validity = if matches!(parray.validity(), Validity::NonNullable) {
+        Validity::NonNullable
+    } else {
+        Validity::AllValid
     };
 
     let array_len = parray.len();

--- a/encodings/fsst/src/compute/compare.rs
+++ b/encodings/fsst/src/compute/compare.rs
@@ -53,12 +53,14 @@ fn compare_fsst_constant(
         }
     };
     if is_rhs_empty {
+        use Operator::*;
+
         let buffer = match operator {
             // Every possible value is gte ""
-            Operator::Gte => BooleanBuffer::new_set(left.len()),
+            Gte => BooleanBuffer::new_set(left.len()),
             // No value is lt ""
-            Operator::Lt => BooleanBuffer::new_unset(left.len()),
-            Operator::Eq | Operator::NotEq | Operator::Gt | Operator::Lte => {
+            Lt => BooleanBuffer::new_unset(left.len()),
+            Eq | NotEq | Gt | Lte => {
                 let uncompressed_lengths = left.uncompressed_lengths().to_primitive()?;
                 match_each_native_ptype!(uncompressed_lengths.ptype(), |P| {
                     compare_lengths_to_empty(

--- a/encodings/fsst/src/compute/compare.rs
+++ b/encodings/fsst/src/compute/compare.rs
@@ -37,16 +37,20 @@ fn compare_fsst_constant(
     right: &Scalar,
     operator: Operator,
 ) -> VortexResult<Option<ArrayRef>> {
+    use DType::*;
+
     let is_rhs_empty = match right.dtype() {
-        DType::Binary(_) => right
+        Binary(_) => right
             .as_binary()
             .is_empty()
             .vortex_expect("RHS should not be null"),
-        DType::Utf8(_) => right
+        Utf8(_) => right
             .as_utf8()
             .is_empty()
             .vortex_expect("RHS should not be null"),
-        _ => vortex_bail!("VarBinArray can only have type of Binary or Utf8"),
+        Null | Bool(_) | Primitive(..) | Decimal(..) | List(..) | Struct(..) | Extension(_) => {
+            vortex_bail!("VarBinArray can only have type of Binary or Utf8")
+        }
     };
     if is_rhs_empty {
         let buffer = match operator {
@@ -54,7 +58,7 @@ fn compare_fsst_constant(
             Operator::Gte => BooleanBuffer::new_set(left.len()),
             // No value is lt ""
             Operator::Lt => BooleanBuffer::new_unset(left.len()),
-            _ => {
+            Operator::Eq | Operator::NotEq | Operator::Gt | Operator::Lte => {
                 let uncompressed_lengths = left.uncompressed_lengths().to_primitive()?;
                 match_each_native_ptype!(uncompressed_lengths.ptype(), |P| {
                     compare_lengths_to_empty(
@@ -82,25 +86,27 @@ fn compare_fsst_constant(
 
     let compressor = left.compressor();
     let encoded_buffer = match left.dtype() {
-        DType::Utf8(_) => {
+        Utf8(_) => {
             let value = right
                 .as_utf8()
                 .value()
                 .vortex_expect("Expected non-null scalar");
             ByteBuffer::from(compressor.compress(value.as_bytes()))
         }
-        DType::Binary(_) => {
+        Binary(_) => {
             let value = right
                 .as_binary()
                 .value()
                 .vortex_expect("Expected non-null scalar");
             ByteBuffer::from(compressor.compress(value.as_slice()))
         }
-        _ => unreachable!("FSSTArray can only have string or binary data type"),
+        Null | Bool(_) | Primitive(..) | Decimal(..) | List(..) | Struct(..) | Extension(_) => {
+            unreachable!("FSSTArray can only have string or binary data type")
+        }
     };
 
     let encoded_scalar = Scalar::new(
-        DType::Binary(left.dtype().nullability() | right.dtype().nullability()),
+        Binary(left.dtype().nullability() | right.dtype().nullability()),
         encoded_buffer.into(),
     );
 

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -92,11 +92,10 @@ fn collect_valid(parray: &PrimitiveArray) -> VortexResult<PrimitiveArray> {
     filter(&parray.to_array(), &mask)?.to_primitive()
 }
 
-#[allow(clippy::wildcard_enum_match_arm)]
 fn vortex_err_from_pco(err: PcoError) -> VortexError {
     use pco::errors::ErrorKind::*;
-    // We use a catch-all here because pco::errors::ErrorKind is an external type
-    // and we want to handle any new variants gracefully.
+    // `ErrorKind` is `non_exhaustive`.
+    #[allow(clippy::wildcard_enum_match_arm)]
     match err.kind {
         Io(io_kind) => VortexError::from(std::io::Error::new(io_kind, err.message)),
         InvalidArgument => vortex_err!(InvalidArgument: "{}", err.message),

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -81,7 +81,9 @@ fn number_type_from_dtype(dtype: &DType) -> NumberType {
         PType::U16 => NumberType::U16,
         PType::U32 => NumberType::U32,
         PType::U64 => NumberType::U64,
-        _ => unreachable!("PType not supported by Pco: {:?}", ptype),
+        PType::U8 | PType::I8 => {
+            unreachable!("PType not supported by Pco: {:?}", ptype)
+        }
     }
 }
 
@@ -90,8 +92,11 @@ fn collect_valid(parray: &PrimitiveArray) -> VortexResult<PrimitiveArray> {
     filter(&parray.to_array(), &mask)?.to_primitive()
 }
 
+#[allow(clippy::wildcard_enum_match_arm)]
 fn vortex_err_from_pco(err: PcoError) -> VortexError {
     use pco::errors::ErrorKind::*;
+    // We use a catch-all here because pco::errors::ErrorKind is an external type
+    // and we want to handle any new variants gracefully.
     match err.kind {
         Io(io_kind) => VortexError::from(std::io::Error::new(io_kind, err.message)),
         InvalidArgument => vortex_err!(InvalidArgument: "{}", err.message),

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -346,7 +346,13 @@ impl CanonicalVTable<RunEndVTable> for RunEndVTable {
                 runend_decode_primitive(pends, pvalues, array.offset(), array.len())
                     .map(Canonical::Primitive)
             }
-            _ => vortex_bail!("Only Primitive and Bool values are supported"),
+            DType::Null
+            | DType::Utf8(_)
+            | DType::Binary(_)
+            | DType::Decimal(..)
+            | DType::List(..)
+            | DType::Struct(..)
+            | DType::Extension(_) => vortex_bail!("Only Primitive and Bool values are supported"),
         }
     }
 }

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -335,24 +335,22 @@ impl ValidityVTable<RunEndVTable> for RunEndVTable {
 
 impl CanonicalVTable<RunEndVTable> for RunEndVTable {
     fn canonicalize(array: &RunEndArray) -> VortexResult<Canonical> {
+        use DType::*;
+
         let pends = array.ends().to_primitive()?;
         match array.dtype() {
-            DType::Bool(_) => {
+            Bool(_) => {
                 let bools = array.values().to_bool()?;
                 runend_decode_bools(pends, bools, array.offset(), array.len()).map(Canonical::Bool)
             }
-            DType::Primitive(..) => {
+            Primitive(..) => {
                 let pvalues = array.values().to_primitive()?;
                 runend_decode_primitive(pends, pvalues, array.offset(), array.len())
                     .map(Canonical::Primitive)
             }
-            DType::Null
-            | DType::Utf8(_)
-            | DType::Binary(_)
-            | DType::Decimal(..)
-            | DType::List(..)
-            | DType::Struct(..)
-            | DType::Extension(_) => vortex_bail!("Only Primitive and Bool values are supported"),
+            Null | Utf8(_) | Binary(_) | Decimal(..) | List(..) | Struct(..) | Extension(_) => {
+                vortex_bail!("Only Primitive and Bool values are supported")
+            }
         }
     }
 }

--- a/encodings/zigzag/src/compress.rs
+++ b/encodings/zigzag/src/compress.rs
@@ -18,10 +18,12 @@ pub fn zigzag_encode(parray: PrimitiveArray) -> VortexResult<ZigZagArray> {
         PType::I16 => zigzag_encode_primitive::<i16>(parray.into_buffer_mut(), validity),
         PType::I32 => zigzag_encode_primitive::<i32>(parray.into_buffer_mut(), validity),
         PType::I64 => zigzag_encode_primitive::<i64>(parray.into_buffer_mut(), validity),
-        _ => vortex_bail!(
-            "ZigZag can only encode signed integers, got {}",
-            parray.ptype()
-        ),
+        PType::U8 | PType::U16 | PType::U32 | PType::U64 | PType::F16 | PType::F32 | PType::F64 => {
+            vortex_bail!(
+                "ZigZag can only encode signed integers, got {}",
+                parray.ptype()
+            )
+        }
     };
     ZigZagArray::try_new(encoded.to_array())
 }
@@ -43,10 +45,12 @@ pub fn zigzag_decode(parray: PrimitiveArray) -> VortexResult<PrimitiveArray> {
         PType::U16 => zigzag_decode_primitive::<i16>(parray.into_buffer_mut(), validity),
         PType::U32 => zigzag_decode_primitive::<i32>(parray.into_buffer_mut(), validity),
         PType::U64 => zigzag_decode_primitive::<i64>(parray.into_buffer_mut(), validity),
-        _ => vortex_bail!(
-            "ZigZag can only decode unsigned integers, got {}",
-            parray.ptype()
-        ),
+        PType::I8 | PType::I16 | PType::I32 | PType::I64 | PType::F16 | PType::F32 | PType::F64 => {
+            vortex_bail!(
+                "ZigZag can only decode unsigned integers, got {}",
+                parray.ptype()
+            )
+        }
     };
     Ok(decoded)
 }

--- a/encodings/zigzag/src/compress.rs
+++ b/encodings/zigzag/src/compress.rs
@@ -12,13 +12,15 @@ use zigzag::ZigZag as ExternalZigZag;
 use crate::ZigZagArray;
 
 pub fn zigzag_encode(parray: PrimitiveArray) -> VortexResult<ZigZagArray> {
+    use PType::*;
+
     let validity = parray.validity().clone();
     let encoded = match parray.ptype() {
-        PType::I8 => zigzag_encode_primitive::<i8>(parray.into_buffer_mut(), validity),
-        PType::I16 => zigzag_encode_primitive::<i16>(parray.into_buffer_mut(), validity),
-        PType::I32 => zigzag_encode_primitive::<i32>(parray.into_buffer_mut(), validity),
-        PType::I64 => zigzag_encode_primitive::<i64>(parray.into_buffer_mut(), validity),
-        PType::U8 | PType::U16 | PType::U32 | PType::U64 | PType::F16 | PType::F32 | PType::F64 => {
+        I8 => zigzag_encode_primitive::<i8>(parray.into_buffer_mut(), validity),
+        I16 => zigzag_encode_primitive::<i16>(parray.into_buffer_mut(), validity),
+        I32 => zigzag_encode_primitive::<i32>(parray.into_buffer_mut(), validity),
+        I64 => zigzag_encode_primitive::<i64>(parray.into_buffer_mut(), validity),
+        U8 | U16 | U32 | U64 | F16 | F32 | F64 => {
             vortex_bail!(
                 "ZigZag can only encode signed integers, got {}",
                 parray.ptype()
@@ -39,13 +41,15 @@ where
 }
 
 pub fn zigzag_decode(parray: PrimitiveArray) -> VortexResult<PrimitiveArray> {
+    use PType::*;
+
     let validity = parray.validity().clone();
     let decoded = match parray.ptype() {
-        PType::U8 => zigzag_decode_primitive::<i8>(parray.into_buffer_mut(), validity),
-        PType::U16 => zigzag_decode_primitive::<i16>(parray.into_buffer_mut(), validity),
-        PType::U32 => zigzag_decode_primitive::<i32>(parray.into_buffer_mut(), validity),
-        PType::U64 => zigzag_decode_primitive::<i64>(parray.into_buffer_mut(), validity),
-        PType::I8 | PType::I16 | PType::I32 | PType::I64 | PType::F16 | PType::F32 | PType::F64 => {
+        U8 => zigzag_decode_primitive::<i8>(parray.into_buffer_mut(), validity),
+        U16 => zigzag_decode_primitive::<i16>(parray.into_buffer_mut(), validity),
+        U32 => zigzag_decode_primitive::<i32>(parray.into_buffer_mut(), validity),
+        U64 => zigzag_decode_primitive::<i64>(parray.into_buffer_mut(), validity),
+        I8 | I16 | I32 | I64 | F16 | F32 | F64 => {
             vortex_bail!(
                 "ZigZag can only decode unsigned integers, got {}",
                 parray.ptype()

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -338,23 +338,20 @@ impl ZstdArray {
         level: i32,
         values_per_frame: usize,
     ) -> VortexResult<Option<Self>> {
+        use Canonical::*;
+
         match canonical {
-            Canonical::Primitive(parray) => Ok(Some(ZstdArray::from_primitive(
+            Primitive(parray) => Ok(Some(ZstdArray::from_primitive(
                 parray,
                 level,
                 values_per_frame,
             )?)),
-            Canonical::VarBinView(vbv) => Ok(Some(ZstdArray::from_var_bin_view(
+            VarBinView(vbv) => Ok(Some(ZstdArray::from_var_bin_view(
                 vbv,
                 level,
                 values_per_frame,
             )?)),
-            Canonical::Null(_)
-            | Canonical::Bool(_)
-            | Canonical::Decimal(_)
-            | Canonical::Struct(_)
-            | Canonical::List(_)
-            | Canonical::Extension(_) => Ok(None),
+            Null(_) | Bool(_) | Decimal(_) | Struct(_) | List(_) | Extension(_) => Ok(None),
         }
     }
 
@@ -448,8 +445,10 @@ impl ZstdArray {
             .unsliced_validity
             .slice(self.slice_start, self.slice_stop);
 
+        use DType::*;
+
         match &self.dtype {
-            DType::Primitive(..) => {
+            Primitive(..) => {
                 let slice_values_buffer = decompressed.slice(
                     (slice_value_idx_start - n_skipped_values) * byte_width
                         ..(slice_value_idx_stop - n_skipped_values) * byte_width,
@@ -463,7 +462,7 @@ impl ZstdArray {
 
                 Ok(primitive.into_array())
             }
-            DType::Binary(_) | DType::Utf8(_) => {
+            Binary(_) | Utf8(_) => {
                 // The decompressed buffer is a bunch of interleaved u32 lengths
                 // and strings of those lengths, we need to reconstruct the
                 // views into those strings by passing through the buffer.
@@ -483,15 +482,9 @@ impl ZstdArray {
                 };
                 Ok(vbv.into_array())
             }
-            DType::Null
-            | DType::Bool(_)
-            | DType::Decimal(..)
-            | DType::List(..)
-            | DType::Struct(..)
-            | DType::Extension(_) => Err(vortex_err!(
-                "Unsupported dtype for Zstd array: {:?}",
-                self.dtype
-            )),
+            Null | Bool(_) | Decimal(..) | List(..) | Struct(..) | Extension(_) => Err(
+                vortex_err!("Unsupported dtype for Zstd array: {:?}", self.dtype),
+            ),
         }
     }
 

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -107,7 +107,7 @@ fn collect_valid_vbv(vbv: &VarBinViewArray) -> VortexResult<(ByteBuffer, Vec<usi
     let mask = vbv.validity_mask()?;
     let buffer_and_value_byte_indices = match mask.boolean_buffer() {
         AllOr::None => (Buffer::empty(), Vec::new()),
-        _ => {
+        AllOr::All | AllOr::Some(_) => {
             let mut buffer = BufferMut::with_capacity(
                 usize::try_from(vbv.nbytes()).vortex_expect("must fit into buffer")
                     + mask.true_count() * size_of::<ViewLen>(),
@@ -349,7 +349,12 @@ impl ZstdArray {
                 level,
                 values_per_frame,
             )?)),
-            _ => Ok(None),
+            Canonical::Null(_)
+            | Canonical::Bool(_)
+            | Canonical::Decimal(_)
+            | Canonical::Struct(_)
+            | Canonical::List(_)
+            | Canonical::Extension(_) => Ok(None),
         }
     }
 
@@ -478,7 +483,12 @@ impl ZstdArray {
                 };
                 Ok(vbv.into_array())
             }
-            _ => Err(vortex_err!(
+            DType::Null
+            | DType::Bool(_)
+            | DType::Decimal(..)
+            | DType::List(..)
+            | DType::Struct(..)
+            | DType::Extension(_) => Err(vortex_err!(
                 "Unsupported dtype for Zstd array: {:?}",
                 self.dtype
             )),

--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -213,8 +213,10 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
 }
 
 fn actions_for_dtype(dtype: &DType) -> HashSet<usize> {
+    use DType::*;
+
     match dtype {
-        DType::Struct(sdt, _) => sdt
+        Struct(sdt, _) => sdt
             .fields()
             .map(|child| actions_for_dtype(&child))
             // exclude compare
@@ -223,8 +225,10 @@ fn actions_for_dtype(dtype: &DType) -> HashSet<usize> {
             }),
         // Once we support more list operations also recurse here on child dtype
         // compress, slice
-        DType::List(..) => [0, 1].into_iter().collect(),
-        _ => ALL_ACTIONS.collect(),
+        List(..) => [0, 1].into_iter().collect(),
+        Null | Bool(_) | Primitive(..) | Decimal(..) | Utf8(_) | Binary(_) | Extension(_) => {
+            ALL_ACTIONS.collect()
+        }
     }
 }
 

--- a/vortex-array/src/array/display/mod.rs
+++ b/vortex-array/src/array/display/mod.rs
@@ -7,8 +7,6 @@ use std::fmt::Display;
 
 use itertools::Itertools as _;
 use tree::TreeDisplayWrapper;
-#[cfg(feature = "table-display")]
-use vortex_error::VortexExpect as _;
 
 use crate::Array;
 
@@ -247,63 +245,62 @@ impl dyn Array + '_ {
             DisplayOptions::TreeDisplay => write!(f, "{}", TreeDisplayWrapper(self.to_array())),
             #[cfg(feature = "table-display")]
             DisplayOptions::TableDisplay => {
+                use vortex_dtype::DType;
+                use vortex_error::VortexExpect as _;
+
                 use crate::canonical::ToCanonical;
+
                 let mut builder = tabled::builder::Builder::default();
 
-                let table = match self.dtype() {
-                    vortex_dtype::DType::Struct(sf, _) => {
-                        let struct_ = self.to_struct().vortex_expect("struct array");
-                        builder.push_record(sf.names().iter().map(|name| name.to_string()));
-
-                        for row_idx in 0..self.len() {
-                            if !self.is_valid(row_idx).vortex_expect("index in bounds") {
-                                let null_row = vec!["null".to_string(); sf.names().len()];
-                                builder.push_record(null_row);
-                            } else {
-                                let mut row = Vec::new();
-                                for field_array in struct_.fields() {
-                                    let value = field_array.scalar_at(row_idx);
-                                    row.push(value.to_string());
-                                }
-                                builder.push_record(row);
-                            }
-                        }
-
-                        let mut table = builder.build();
-                        table.with(tabled::settings::Style::modern());
-
-                        // Center headers
-                        for col_idx in 0..sf.names().len() {
-                            table.modify((0, col_idx), tabled::settings::Alignment::center());
-                        }
-
-                        for row_idx in 0..self.len() {
-                            if !self.is_valid(row_idx).vortex_expect("index is in bounds") {
-                                table.modify(
-                                    (1 + row_idx, 0),
-                                    tabled::settings::Span::column(sf.names().len() as isize),
-                                );
-                                table.modify(
-                                    (1 + row_idx, 0),
-                                    tabled::settings::Alignment::center(),
-                                );
-                            }
-                        }
-                        table
+                // Special logic for struct arrays.
+                let DType::Struct(sf, _) = self.dtype() else {
+                    // For non-struct arrays, simply display a single column table without header.
+                    for row_idx in 0..self.len() {
+                        let value = self.scalar_at(row_idx);
+                        builder.push_record([value.to_string()]);
                     }
-                    _ => {
-                        // For non-struct arrays, display a single column table without header
-                        for row_idx in 0..self.len() {
-                            let value = self.scalar_at(row_idx);
-                            builder.push_record([value.to_string()]);
-                        }
 
-                        let mut table = builder.build();
-                        table.with(tabled::settings::Style::modern());
+                    let mut table = builder.build();
+                    table.with(tabled::settings::Style::modern());
 
-                        table
-                    }
+                    return write!(f, "{table}");
                 };
+
+                let struct_ = self.to_struct().vortex_expect("struct array");
+                builder.push_record(sf.names().iter().map(|name| name.to_string()));
+
+                for row_idx in 0..self.len() {
+                    if !self.is_valid(row_idx).vortex_expect("index in bounds") {
+                        let null_row = vec!["null".to_string(); sf.names().len()];
+                        builder.push_record(null_row);
+                    } else {
+                        let mut row = Vec::new();
+                        for field_array in struct_.fields() {
+                            let value = field_array.scalar_at(row_idx);
+                            row.push(value.to_string());
+                        }
+                        builder.push_record(row);
+                    }
+                }
+
+                let mut table = builder.build();
+                table.with(tabled::settings::Style::modern());
+
+                // Center headers
+                for col_idx in 0..sf.names().len() {
+                    table.modify((0, col_idx), tabled::settings::Alignment::center());
+                }
+
+                for row_idx in 0..self.len() {
+                    if !self.is_valid(row_idx).vortex_expect("index is in bounds") {
+                        table.modify(
+                            (1 + row_idx, 0),
+                            tabled::settings::Span::column(sf.names().len() as isize),
+                        );
+                        table.modify((1 + row_idx, 0), tabled::settings::Alignment::center());
+                    }
+                }
+
                 write!(f, "{table}")
             }
         }

--- a/vortex-array/src/arrays/chunked/decode.rs
+++ b/vortex-array/src/arrays/chunked/decode.rs
@@ -15,8 +15,6 @@ use crate::{Array as _, ArrayRef, Canonical, IntoArray, ToCanonical};
 
 impl CanonicalVTable<ChunkedVTable> for ChunkedVTable {
     fn canonicalize(array: &ChunkedArray) -> VortexResult<Canonical> {
-        use DType::*;
-
         if array.nchunks() == 0 {
             return Ok(Canonical::empty(array.dtype()));
         }
@@ -25,7 +23,7 @@ impl CanonicalVTable<ChunkedVTable> for ChunkedVTable {
         }
 
         match array.dtype() {
-            Struct(struct_dtype, _) => {
+            DType::Struct(struct_dtype, _) => {
                 let struct_array = swizzle_struct_chunks(
                     array.chunks(),
                     Validity::copy_from_array(array.as_ref())?,
@@ -33,12 +31,18 @@ impl CanonicalVTable<ChunkedVTable> for ChunkedVTable {
                 )?;
                 Ok(Canonical::Struct(struct_array))
             }
-            List(elem_dtype, _) => Ok(Canonical::List(pack_lists(
+            DType::List(elem_dtype, _) => Ok(Canonical::List(pack_lists(
                 array.chunks(),
                 Validity::copy_from_array(array.as_ref())?,
                 elem_dtype,
             )?)),
-            Null | Bool(_) | Primitive(..) | Decimal(..) | Utf8(_) | Binary(_) | Extension(_) => {
+            DType::Null
+            | DType::Bool(_)
+            | DType::Primitive(..)
+            | DType::Decimal(..)
+            | DType::Utf8(_)
+            | DType::Binary(_)
+            | DType::Extension(_) => {
                 let mut builder = builder_with_capacity(array.dtype(), array.len());
                 array.append_to_builder(builder.as_mut())?;
                 builder.finish().to_canonical()

--- a/vortex-array/src/arrays/chunked/decode.rs
+++ b/vortex-array/src/arrays/chunked/decode.rs
@@ -15,14 +15,17 @@ use crate::{Array as _, ArrayRef, Canonical, IntoArray, ToCanonical};
 
 impl CanonicalVTable<ChunkedVTable> for ChunkedVTable {
     fn canonicalize(array: &ChunkedArray) -> VortexResult<Canonical> {
+        use DType::*;
+
         if array.nchunks() == 0 {
             return Ok(Canonical::empty(array.dtype()));
         }
         if array.nchunks() == 1 {
             return array.chunks()[0].to_canonical();
         }
+
         match array.dtype() {
-            DType::Struct(struct_dtype, _) => {
+            Struct(struct_dtype, _) => {
                 let struct_array = swizzle_struct_chunks(
                     array.chunks(),
                     Validity::copy_from_array(array.as_ref())?,
@@ -30,12 +33,12 @@ impl CanonicalVTable<ChunkedVTable> for ChunkedVTable {
                 )?;
                 Ok(Canonical::Struct(struct_array))
             }
-            DType::List(elem, _) => Ok(Canonical::List(pack_lists(
+            List(elem_dtype, _) => Ok(Canonical::List(pack_lists(
                 array.chunks(),
                 Validity::copy_from_array(array.as_ref())?,
-                elem,
+                elem_dtype,
             )?)),
-            _ => {
+            Null | Bool(_) | Primitive(..) | Decimal(..) | Utf8(_) | Binary(_) | Extension(_) => {
                 let mut builder = builder_with_capacity(array.dtype(), array.len());
                 array.append_to_builder(builder.as_mut())?;
                 builder.finish().to_canonical()

--- a/vortex-array/src/arrays/constant/compute/sum.rs
+++ b/vortex-array/src/arrays/constant/compute/sum.rs
@@ -24,20 +24,24 @@ impl SumKernel for ConstantVTable {
 }
 
 fn sum_scalar(scalar: &Scalar, len: usize) -> VortexResult<ScalarValue> {
+    use DType::*;
+
     match scalar.dtype() {
-        DType::Bool(_) => Ok(ScalarValue::from(match scalar.as_bool().value() {
+        Bool(_) => Ok(ScalarValue::from(match scalar.as_bool().value() {
             None => unreachable!("Handled before reaching this point"),
             Some(false) => 0u64,
             Some(true) => len as u64,
         })),
-        DType::Primitive(ptype, _) => Ok(match_each_native_ptype!(
+        Primitive(ptype, _) => Ok(match_each_native_ptype!(
             ptype,
             unsigned: |T| { sum_integral::<u64>(scalar.as_primitive(), len)?.into() },
             signed: |T| { sum_integral::<i64>(scalar.as_primitive(), len)?.into() },
             floating: |T| { sum_float(scalar.as_primitive(), len)?.into() }
         )),
-        DType::Extension(_) => sum_scalar(&scalar.as_extension().storage(), len),
-        _ => vortex_bail!("Unsupported dtype for sum: {}", scalar.dtype()),
+        Extension(_) => sum_scalar(&scalar.as_extension().storage(), len),
+        Null | Decimal(..) | Utf8(_) | Binary(_) | List(..) | Struct(..) => {
+            vortex_bail!("Unsupported dtype for sum: {}", scalar.dtype())
+        }
     }
 }
 

--- a/vortex-array/src/arrays/datetime/mod.rs
+++ b/vortex-array/src/arrays/datetime/mod.rs
@@ -79,7 +79,9 @@ impl TemporalArray {
             TimeUnit::Ms => {
                 assert_width!(i64, array);
             }
-            _ => vortex_panic!("invalid TimeUnit {time_unit} for vortex.date"),
+            TimeUnit::Ns | TimeUnit::Us | TimeUnit::S => {
+                vortex_panic!("invalid TimeUnit {time_unit} for vortex.date")
+            }
         };
 
         let ext_dtype = ExtDType::new(

--- a/vortex-array/src/arrays/decimal/mod.rs
+++ b/vortex-array/src/arrays/decimal/mod.rs
@@ -78,7 +78,7 @@ pub fn compatible_storage_type(value_type: DecimalValueType, dtype: DecimalDType
 ///
 /// The precisions supported for each scalar type are:
 /// - **i8**: precision 1-2 digits
-/// - **i16**: precision 3-4 digits  
+/// - **i16**: precision 3-4 digits
 /// - **i32**: precision 5-9 digits
 /// - **i64**: precision 10-18 digits
 /// - **i128**: precision 19-38 digits
@@ -205,9 +205,10 @@ impl DecimalArray {
 
     /// Returns the decimal type information
     pub fn decimal_dtype(&self) -> DecimalDType {
-        match &self.dtype {
-            DType::Decimal(decimal_dtype, _) => *decimal_dtype,
-            _ => vortex_panic!("Expected Decimal dtype, got {:?}", self.dtype),
+        if let DType::Decimal(decimal_dtype, _) = self.dtype {
+            decimal_dtype
+        } else {
+            vortex_panic!("Expected Decimal dtype, got {:?}", self.dtype)
         }
     }
 

--- a/vortex-array/src/arrays/primitive/compute/take/mod.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/mod.rs
@@ -73,17 +73,17 @@ impl TakeImpl for TakeKernelScalar {
 
 impl TakeKernel for PrimitiveVTable {
     fn take(&self, array: &PrimitiveArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
-        let unsigned_indices = match indices.dtype() {
-            DType::Primitive(p, n) => {
-                if p.is_unsigned_int() {
-                    indices.to_primitive()?
-                } else {
-                    // This will fail if all values cannot be converted to unsigned
-                    cast(indices, &DType::Primitive(p.to_unsigned(), *n))?.to_primitive()?
-                }
+        let unsigned_indices = if let DType::Primitive(ptype, null) = indices.dtype() {
+            if ptype.is_unsigned_int() {
+                indices.to_primitive()?
+            } else {
+                // This will fail if all values cannot be converted to unsigned
+                cast(indices, &DType::Primitive(ptype.to_unsigned(), *null))?.to_primitive()?
             }
-            _ => vortex_bail!("Invalid indices dtype: {}", indices.dtype()),
+        } else {
+            vortex_bail!("Invalid indices dtype: {}", indices.dtype())
         };
+
         let validity = array.validity().take(unsigned_indices.as_ref())?;
         // Delegate to the best kernel based on the target CPU
         PRIMITIVE_TAKE_KERNEL.take(array, &unsigned_indices, validity)

--- a/vortex-array/src/arrays/primitive/compute/take/mod.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/mod.rs
@@ -73,15 +73,15 @@ impl TakeImpl for TakeKernelScalar {
 
 impl TakeKernel for PrimitiveVTable {
     fn take(&self, array: &PrimitiveArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
-        let unsigned_indices = if let DType::Primitive(ptype, null) = indices.dtype() {
-            if ptype.is_unsigned_int() {
-                indices.to_primitive()?
-            } else {
-                // This will fail if all values cannot be converted to unsigned
-                cast(indices, &DType::Primitive(ptype.to_unsigned(), *null))?.to_primitive()?
-            }
-        } else {
+        let DType::Primitive(ptype, null) = indices.dtype() else {
             vortex_bail!("Invalid indices dtype: {}", indices.dtype())
+        };
+
+        let unsigned_indices = if ptype.is_unsigned_int() {
+            indices.to_primitive()?
+        } else {
+            // This will fail if all values cannot be converted to unsigned
+            cast(indices, &DType::Primitive(ptype.to_unsigned(), *null))?.to_primitive()?
         };
 
         let validity = array.validity().take(unsigned_indices.as_ref())?;

--- a/vortex-array/src/arrays/varbin/compute/compare.rs
+++ b/vortex-array/src/arrays/varbin/compute/compare.rs
@@ -24,29 +24,33 @@ impl CompareKernel for VarBinVTable {
         rhs: &dyn Array,
         operator: Operator,
     ) -> VortexResult<Option<ArrayRef>> {
+        use DType::*;
+        use Operator::*;
+
         if let Some(rhs_const) = rhs.as_constant() {
             let nullable = lhs.dtype().is_nullable() || rhs_const.dtype().is_nullable();
             let len = lhs.len();
 
             let rhs_is_empty = match rhs_const.dtype() {
-                DType::Binary(_) => rhs_const
+                Binary(_) => rhs_const
                     .as_binary()
                     .is_empty()
                     .vortex_expect("RHS should not be null"),
-                DType::Utf8(_) => rhs_const
+                Utf8(_) => rhs_const
                     .as_utf8()
                     .is_empty()
                     .vortex_expect("RHS should not be null"),
-                _ => vortex_bail!("VarBinArray can only have type of Binary or Utf8"),
+                Null | Bool(_) | Primitive(..) | Decimal(..) | List(..) | Struct(..)
+                | Extension(_) => {
+                    vortex_bail!("VarBinArray can only have type of Binary or Utf8")
+                }
             };
 
             if rhs_is_empty {
                 let buffer = match operator {
-                    // Every possible value is gte ""
-                    Operator::Gte => BooleanBuffer::new_set(len),
-                    // No value is lt ""
-                    Operator::Lt => BooleanBuffer::new_unset(len),
-                    _ => {
+                    Gte => BooleanBuffer::new_set(len), // Every possible value is >= ""
+                    Lt => BooleanBuffer::new_unset(len), // No value is < ""
+                    Eq | NotEq | Gt | Lte => {
                         let lhs_offsets = lhs.offsets().to_canonical()?.into_primitive()?;
                         match_each_native_ptype!(lhs_offsets.ptype(), |P| {
                             compare_offsets_to_empty::<P>(lhs_offsets, operator)
@@ -69,29 +73,30 @@ impl CompareKernel for VarBinVTable {
 
             // TODO(robert): Handle LargeString/Binary arrays
             let arrow_rhs: &dyn arrow_array::Datum = match rhs_const.dtype() {
-                DType::Utf8(_) => &rhs_const
+                Utf8(_) => &rhs_const
                     .as_utf8()
                     .value()
                     .map(StringArray::new_scalar)
                     .unwrap_or_else(|| arrow_array::Scalar::new(StringArray::new_null(1))),
-                DType::Binary(_) => &rhs_const
+                Binary(_) => &rhs_const
                     .as_binary()
                     .value()
                     .map(BinaryArray::new_scalar)
                     .unwrap_or_else(|| arrow_array::Scalar::new(BinaryArray::new_null(1))),
-                _ => vortex_bail!(
+                Null | Bool(_) | Primitive(..) | Decimal(..) | List(..) | Struct(..)
+                | Extension(_) => vortex_bail!(
                     "VarBin array RHS can only be Utf8 or Binary, given {}",
                     rhs_const.dtype()
                 ),
             };
 
             let array = match operator {
-                Operator::Eq => cmp::eq(&lhs, arrow_rhs),
-                Operator::NotEq => cmp::neq(&lhs, arrow_rhs),
-                Operator::Gt => cmp::gt(&lhs, arrow_rhs),
-                Operator::Gte => cmp::gt_eq(&lhs, arrow_rhs),
-                Operator::Lt => cmp::lt(&lhs, arrow_rhs),
-                Operator::Lte => cmp::lt_eq(&lhs, arrow_rhs),
+                Eq => cmp::eq(&lhs, arrow_rhs),
+                NotEq => cmp::neq(&lhs, arrow_rhs),
+                Gt => cmp::gt(&lhs, arrow_rhs),
+                Gte => cmp::gt_eq(&lhs, arrow_rhs),
+                Lt => cmp::lt(&lhs, arrow_rhs),
+                Lte => cmp::lt_eq(&lhs, arrow_rhs),
             }
             .map_err(|err| vortex_err!("Failed to compare VarBin array: {}", err))?;
 

--- a/vortex-array/src/arrays/varbin/compute/compare.rs
+++ b/vortex-array/src/arrays/varbin/compute/compare.rs
@@ -25,7 +25,6 @@ impl CompareKernel for VarBinVTable {
         operator: Operator,
     ) -> VortexResult<Option<ArrayRef>> {
         use DType::*;
-        use Operator::*;
 
         if let Some(rhs_const) = rhs.as_constant() {
             let nullable = lhs.dtype().is_nullable() || rhs_const.dtype().is_nullable();
@@ -48,9 +47,9 @@ impl CompareKernel for VarBinVTable {
 
             if rhs_is_empty {
                 let buffer = match operator {
-                    Gte => BooleanBuffer::new_set(len), // Every possible value is >= ""
-                    Lt => BooleanBuffer::new_unset(len), // No value is < ""
-                    Eq | NotEq | Gt | Lte => {
+                    Operator::Gte => BooleanBuffer::new_set(len),   // Every possible value is >= ""
+                    Operator::Lt => BooleanBuffer::new_unset(len),  // No value is < ""
+                    Operator::Eq | Operator::NotEq | Operator::Gt | Operator::Lte => {
                         let lhs_offsets = lhs.offsets().to_canonical()?.into_primitive()?;
                         match_each_native_ptype!(lhs_offsets.ptype(), |P| {
                             compare_offsets_to_empty::<P>(lhs_offsets, operator)
@@ -91,12 +90,12 @@ impl CompareKernel for VarBinVTable {
             };
 
             let array = match operator {
-                Eq => cmp::eq(&lhs, arrow_rhs),
-                NotEq => cmp::neq(&lhs, arrow_rhs),
-                Gt => cmp::gt(&lhs, arrow_rhs),
-                Gte => cmp::gt_eq(&lhs, arrow_rhs),
-                Lt => cmp::lt(&lhs, arrow_rhs),
-                Lte => cmp::lt_eq(&lhs, arrow_rhs),
+                Operator::Eq => cmp::eq(&lhs, arrow_rhs),
+                Operator::NotEq => cmp::neq(&lhs, arrow_rhs),
+                Operator::Gt => cmp::gt(&lhs, arrow_rhs),
+                Operator::Gte => cmp::gt_eq(&lhs, arrow_rhs),
+                Operator::Lt => cmp::lt(&lhs, arrow_rhs),
+                Operator::Lte => cmp::lt_eq(&lhs, arrow_rhs),
             }
             .map_err(|err| vortex_err!("Failed to compare VarBin array: {}", err))?;
 

--- a/vortex-array/src/arrays/varbin/compute/min_max.rs
+++ b/vortex-array/src/arrays/varbin/compute/min_max.rs
@@ -11,9 +11,6 @@ use crate::arrays::{VarBinArray, VarBinVTable};
 use crate::compute::{MinMaxKernel, MinMaxKernelAdapter, MinMaxResult};
 use crate::register_kernel;
 
-// TODO(connor): UNSAFETY; `make_scalar` should be an unsafe function, which means `compute_min_max`
-// should also be an unsafe function.
-
 impl MinMaxKernel for VarBinVTable {
     fn min_max(&self, array: &VarBinArray) -> VortexResult<Option<MinMaxResult>> {
         compute_min_max(array, array.dtype())
@@ -23,7 +20,7 @@ impl MinMaxKernel for VarBinVTable {
 register_kernel!(MinMaxKernelAdapter(VarBinVTable).lift());
 
 /// Compute the min and max of VarBin like array.
-pub fn compute_min_max<T: ArrayAccessor<[u8]>>(
+pub(crate) fn compute_min_max<T: ArrayAccessor<[u8]>>(
     array: &T,
     dtype: &DType,
 ) -> VortexResult<Option<MinMaxResult>> {
@@ -52,10 +49,8 @@ fn make_scalar(dtype: &DType, value: &[u8]) -> Scalar {
     match dtype {
         Binary(_) => Scalar::new(dtype.clone(), value.into()),
         Utf8(_) => {
-            // TODO(connor): This is absolutely not safe!!! We cannot trust the input to a public
-            // function (via `compute_min_max`) to be correct.
-            // Safety:
-            // We trust the array's dtype here
+            // SAFETY: We only call `compute_min_max` within `varbin/`, in which we always validate
+            // the arrays, and we always pass `array.dtype()` in as the `dtype` argument.
             let value = unsafe { str::from_utf8_unchecked(value) };
             Scalar::new(dtype.clone(), value.into())
         }

--- a/vortex-array/src/arrays/varbin/compute/min_max.rs
+++ b/vortex-array/src/arrays/varbin/compute/min_max.rs
@@ -11,6 +11,9 @@ use crate::arrays::{VarBinArray, VarBinVTable};
 use crate::compute::{MinMaxKernel, MinMaxKernelAdapter, MinMaxResult};
 use crate::register_kernel;
 
+// TODO(connor): UNSAFETY; `make_scalar` should be an unsafe function, which means `compute_min_max`
+// should also be an unsafe function.
+
 impl MinMaxKernel for VarBinVTable {
     fn min_max(&self, array: &VarBinArray) -> VortexResult<Option<MinMaxResult>> {
         compute_min_max(array, array.dtype())
@@ -44,15 +47,21 @@ pub fn compute_min_max<T: ArrayAccessor<[u8]>>(
 
 /// Helper function to make sure that min/max has the right [`ScalarValue`] type.
 fn make_scalar(dtype: &DType, value: &[u8]) -> Scalar {
+    use DType::*;
+
     match dtype {
-        DType::Binary(_) => Scalar::new(dtype.clone(), value.into()),
-        DType::Utf8(_) => {
+        Binary(_) => Scalar::new(dtype.clone(), value.into()),
+        Utf8(_) => {
+            // TODO(connor): This is absolutely not safe!!! We cannot trust the input to a public
+            // function (via `compute_min_max`) to be correct.
             // Safety:
             // We trust the array's dtype here
             let value = unsafe { str::from_utf8_unchecked(value) };
             Scalar::new(dtype.clone(), value.into())
         }
-        _ => unreachable!(),
+        Null | Bool(_) | Primitive(..) | Decimal(..) | List(..) | Struct(..) | Extension(_) => {
+            unreachable!()
+        }
     }
 }
 

--- a/vortex-array/src/arrays/varbin/compute/mod.rs
+++ b/vortex-array/src/arrays/varbin/compute/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-pub use min_max::compute_min_max;
+pub(crate) use min_max::compute_min_max;
 
 mod cast;
 mod compare;

--- a/vortex-array/src/arrays/varbin/mod.rs
+++ b/vortex-array/src/arrays/varbin/mod.rs
@@ -3,7 +3,7 @@
 
 use std::fmt::Debug;
 
-pub use compute::compute_min_max;
+pub(crate) use compute::compute_min_max;
 use num_traits::PrimInt;
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, NativePType, Nullability};

--- a/vortex-array/src/arrays/varbinview/compact.rs
+++ b/vortex-array/src/arrays/varbinview/compact.rs
@@ -61,9 +61,11 @@ impl VarBinViewArray {
     // count the number of bytes addressed by the views, not including null
     // values or any inlined strings.
     fn count_referenced_bytes(&self) -> u64 {
+        use Validity::*;
+
         match self.validity() {
-            Validity::AllInvalid => 0u64,
-            _ => self
+            AllInvalid => 0u64,
+            NonNullable | AllValid | Array(_) => self
                 .views()
                 .iter()
                 .enumerate()

--- a/vortex-array/src/arrays/varbinview/mod.rs
+++ b/vortex-array/src/arrays/varbinview/mod.rs
@@ -388,12 +388,16 @@ impl VarBinViewArray {
             dtype.nullability()
         );
 
+        use DType::*;
+
         match dtype {
-            DType::Utf8(_) => Self::validate_views(views, buffers, validity, |string| {
+            Utf8(_) => Self::validate_views(views, buffers, validity, |string| {
                 std::str::from_utf8(string).is_ok()
             })?,
-            DType::Binary(_) => Self::validate_views(views, buffers, validity, |_| true)?,
-            _ => vortex_bail!("invalid DType {dtype}"),
+            Binary(_) => Self::validate_views(views, buffers, validity, |_| true)?,
+            Null | Bool(_) | Primitive(..) | Decimal(..) | List(..) | Struct(..) | Extension(_) => {
+                vortex_bail!("invalid DType {dtype}")
+            }
         }
 
         Ok(())

--- a/vortex-array/src/arrow/compute/to_arrow/varbin.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/varbin.rs
@@ -8,7 +8,7 @@ use arrow_array::{
 };
 use arrow_schema::DataType;
 use vortex_dtype::{DType, NativePType, Nullability, PType};
-use vortex_error::{VortexResult, vortex_bail};
+use vortex_error::{VortexResult, vortex_bail, vortex_panic};
 
 use crate::arrays::{VarBinArray, VarBinVTable};
 use crate::arrow::compute::{ToArrowKernel, ToArrowKernelAdapter};
@@ -31,13 +31,13 @@ impl ToArrowKernel for VarBinVTable {
             None => match array.dtype() {
                 Binary(_) => match offsets_ptype {
                     I64 | U64 => to_arrow::<i64>(array),
-                    // TODO(connor):                              vvv Is this correct?
-                    U8 | U16 | U32 | I8 | I16 | I32 | F16 | F32 | F64 => to_arrow::<i32>(array),
+                    U8 | U16 | U32 | I8 | I16 | I32 => to_arrow::<i32>(array),
+                    F16 | F32 | F64 => vortex_panic!("offsets array were somehow floating point"),
                 },
                 Utf8(_) => match offsets_ptype {
                     I64 | U64 => to_arrow::<i64>(array),
-                    // TODO(connor):                              vvv Is this correct?
-                    U8 | U16 | U32 | I8 | I16 | I32 | F16 | F32 | F64 => to_arrow::<i32>(array),
+                    U8 | U16 | U32 | I8 | I16 | I32 => to_arrow::<i32>(array),
+                    F16 | F32 | F64 => vortex_panic!("offsets array were somehow floating point"),
                 },
                 Null | Bool(_) | Primitive(..) | Decimal(..) | List(..) | Struct(..)
                 | Extension(_) => unreachable!("Unsupported DType"),

--- a/vortex-array/src/arrow/compute/to_arrow/varbin.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/varbin.rs
@@ -21,20 +21,26 @@ impl ToArrowKernel for VarBinVTable {
         array: &VarBinArray,
         arrow_type: Option<&DataType>,
     ) -> VortexResult<Option<ArrowArrayRef>> {
+        use DType::*;
+        use PType::*;
+
         let offsets_ptype = PType::try_from(array.offsets().dtype())?;
 
         match arrow_type {
             // Emit out preferred Arrow VarBin array.
             None => match array.dtype() {
-                DType::Binary(_) => match offsets_ptype {
-                    PType::I64 | PType::U64 => to_arrow::<i64>(array),
-                    _ => to_arrow::<i32>(array),
+                Binary(_) => match offsets_ptype {
+                    I64 | U64 => to_arrow::<i64>(array),
+                    // TODO(connor):                              vvv Is this correct?
+                    U8 | U16 | U32 | I8 | I16 | I32 | F16 | F32 | F64 => to_arrow::<i32>(array),
                 },
-                DType::Utf8(_) => match offsets_ptype {
-                    PType::I64 | PType::U64 => to_arrow::<i64>(array),
-                    _ => to_arrow::<i32>(array),
+                Utf8(_) => match offsets_ptype {
+                    I64 | U64 => to_arrow::<i64>(array),
+                    // TODO(connor):                              vvv Is this correct?
+                    U8 | U16 | U32 | I8 | I16 | I32 | F16 | F32 | F64 => to_arrow::<i32>(array),
                 },
-                _ => unreachable!("Unsupported DType"),
+                Null | Bool(_) | Primitive(..) | Decimal(..) | List(..) | Struct(..)
+                | Extension(_) => unreachable!("Unsupported DType"),
             },
             // Emit the requested Arrow array.
             Some(DataType::Binary) if array.dtype().is_binary() => to_arrow::<i32>(array),
@@ -57,9 +63,11 @@ impl ToArrowKernel for VarBinVTable {
 register_kernel!(ToArrowKernelAdapter(VarBinVTable).lift());
 
 fn to_arrow<O: NativePType + OffsetSizeTrait>(array: &VarBinArray) -> VortexResult<ArrowArrayRef> {
+    use DType::*;
+
     let offsets = cast(
         array.offsets(),
-        &DType::Primitive(O::PTYPE, Nullability::NonNullable),
+        &Primitive(O::PTYPE, Nullability::NonNullable),
     )?
     .to_primitive()
     .map_err(|err| err.with_context("Failed to canonicalize offsets"))?;
@@ -67,22 +75,24 @@ fn to_arrow<O: NativePType + OffsetSizeTrait>(array: &VarBinArray) -> VortexResu
     let nulls = array.validity_mask()?.to_null_buffer();
     let data = array.bytes().clone();
 
-    // Switch on DType.
+    // Match on the `DType`.
     Ok(match array.dtype() {
-        DType::Binary(_) => Arc::new(unsafe {
+        Binary(_) => Arc::new(unsafe {
             GenericBinaryArray::new_unchecked(
                 offsets.buffer::<O>().into_arrow_offset_buffer(),
                 data.into_arrow_buffer(),
                 nulls,
             )
         }),
-        DType::Utf8(_) => Arc::new(unsafe {
+        Utf8(_) => Arc::new(unsafe {
             GenericStringArray::new_unchecked(
                 offsets.buffer::<O>().into_arrow_offset_buffer(),
                 data.into_arrow_buffer(),
                 nulls,
             )
         }),
-        _ => unreachable!("expected utf8 or binary instead of {}", array.dtype()),
+        Null | Bool(_) | Primitive(..) | Decimal(..) | List(..) | Struct(..) | Extension(_) => {
+            unreachable!("expected utf8 or binary instead of {}", array.dtype())
+        }
     })
 }

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -80,9 +80,9 @@ where
 }
 
 macro_rules! impl_from_arrow_primitive {
-    ($ty:path) => {
-        impl FromArrowArray<&ArrowPrimitiveArray<$ty>> for ArrayRef {
-            fn from_arrow(value: &ArrowPrimitiveArray<$ty>, nullable: bool) -> Self {
+    ($T:path) => {
+        impl FromArrowArray<&ArrowPrimitiveArray<$T>> for ArrayRef {
+            fn from_arrow(value: &ArrowPrimitiveArray<$T>, nullable: bool) -> Self {
                 let buffer = Buffer::from_arrow_scalar_buffer(value.values().clone());
                 let validity = nulls(value.nulls(), nullable);
                 PrimitiveArray::new(buffer, validity).into_array()
@@ -127,9 +127,9 @@ impl FromArrowArray<&ArrowPrimitiveArray<Decimal256Type>> for ArrayRef {
 }
 
 macro_rules! impl_from_arrow_temporal {
-    ($ty:path) => {
-        impl FromArrowArray<&ArrowPrimitiveArray<$ty>> for ArrayRef {
-            fn from_arrow(value: &ArrowPrimitiveArray<$ty>, nullable: bool) -> Self {
+    ($T:path) => {
+        impl FromArrowArray<&ArrowPrimitiveArray<$T>> for ArrayRef {
+            fn from_arrow(value: &ArrowPrimitiveArray<$T>, nullable: bool) -> Self {
                 temporal_array(value, nullable)
             }
         }
@@ -162,6 +162,9 @@ where
     )
     .into_array();
 
+    // We rely on the entrypoint in `impl FromArrowArray<&dyn ArrowArray> for ArrayRef` to handle
+    // new `DataType` variants.
+    #[allow(clippy::wildcard_enum_match_arm)]
     match value.data_type() {
         DataType::Timestamp(time_unit, tz) => {
             let tz = tz.as_ref().map(|s| s.to_string());
@@ -182,10 +185,15 @@ where
     <T as ByteArrayType>::Offset: NativePType,
 {
     fn from_arrow(value: &GenericByteArray<T>, nullable: bool) -> Self {
+        // We rely on the entrypoint in `impl FromArrowArray<&dyn ArrowArray> for ArrayRef` to
+        // handle new `DataType` variants.
+        #[allow(clippy::wildcard_enum_match_arm)]
         let dtype = match T::DATA_TYPE {
             DataType::Binary | DataType::LargeBinary => DType::Binary(nullable.into()),
             DataType::Utf8 | DataType::LargeUtf8 => DType::Utf8(nullable.into()),
-            _ => vortex_panic!("Invalid data type for ByteArray: {}", T::DATA_TYPE),
+            _ => {
+                vortex_panic!("Invalid data type for ByteArray: {}", T::DATA_TYPE)
+            }
         };
         VarBinArray::try_new(
             value.offsets().clone().into_array(),
@@ -200,10 +208,15 @@ where
 
 impl<T: ByteViewType> FromArrowArray<&GenericByteViewArray<T>> for ArrayRef {
     fn from_arrow(value: &GenericByteViewArray<T>, nullable: bool) -> Self {
+        // We rely on the entrypoint in `impl FromArrowArray<&dyn ArrowArray> for ArrayRef` to
+        // handle new `DataType` variants.
+        #[allow(clippy::wildcard_enum_match_arm)]
         let dtype = match T::DATA_TYPE {
             DataType::BinaryView => DType::Binary(nullable.into()),
             DataType::Utf8View => DType::Utf8(nullable.into()),
-            _ => vortex_panic!("Invalid data type for ByteViewArray: {}", T::DATA_TYPE),
+            _ => {
+                vortex_panic!("Invalid data type for ByteViewArray: {}", T::DATA_TYPE)
+            }
         };
 
         let views_buffer = Buffer::from_byte_buffer(
@@ -243,6 +256,9 @@ fn remove_nulls(data: arrow_data::ArrayData) -> arrow_data::ArrayData {
         return data;
     }
 
+    // We rely on the entrypoint in `impl FromArrowArray<&dyn ArrowArray> for ArrayRef` to handle
+    // new `DataType` variants.
+    #[allow(clippy::wildcard_enum_match_arm)]
     let children = match data.data_type() {
         DataType::Struct(fields) => Some(
             fields
@@ -313,11 +329,16 @@ impl FromArrowArray<&ArrowStructArray> for ArrayRef {
 
 impl<O: OffsetSizeTrait + NativePType> FromArrowArray<&GenericListArray<O>> for ArrayRef {
     fn from_arrow(value: &GenericListArray<O>, nullable: bool) -> Self {
+        // We rely on the entrypoint in `impl FromArrowArray<&dyn ArrowArray> for ArrayRef` to handle
+        // new `DataType` variants.
+        #[allow(clippy::wildcard_enum_match_arm)]
         // Extract the validity of the underlying element array
         let elem_nullable = match value.data_type() {
             DataType::List(field) => field.is_nullable(),
             DataType::LargeList(field) => field.is_nullable(),
-            dt => vortex_panic!("Invalid data type for ListArray: {dt}"),
+            dt => {
+                vortex_panic!("Invalid data type for ListArray: {dt}")
+            }
         };
         ListArray::try_new(
             Self::from_arrow(value.values().as_ref(), elem_nullable),
@@ -356,30 +377,32 @@ fn nulls(nulls: Option<&NullBuffer>, nullable: bool) -> Validity {
 
 impl FromArrowArray<&dyn ArrowArray> for ArrayRef {
     fn from_arrow(array: &dyn ArrowArray, nullable: bool) -> Self {
+        use DataType::*;
+
         match array.data_type() {
-            DataType::Boolean => Self::from_arrow(array.as_boolean(), nullable),
-            DataType::UInt8 => Self::from_arrow(array.as_primitive::<UInt8Type>(), nullable),
-            DataType::UInt16 => Self::from_arrow(array.as_primitive::<UInt16Type>(), nullable),
-            DataType::UInt32 => Self::from_arrow(array.as_primitive::<UInt32Type>(), nullable),
-            DataType::UInt64 => Self::from_arrow(array.as_primitive::<UInt64Type>(), nullable),
-            DataType::Int8 => Self::from_arrow(array.as_primitive::<Int8Type>(), nullable),
-            DataType::Int16 => Self::from_arrow(array.as_primitive::<Int16Type>(), nullable),
-            DataType::Int32 => Self::from_arrow(array.as_primitive::<Int32Type>(), nullable),
-            DataType::Int64 => Self::from_arrow(array.as_primitive::<Int64Type>(), nullable),
-            DataType::Float16 => Self::from_arrow(array.as_primitive::<Float16Type>(), nullable),
-            DataType::Float32 => Self::from_arrow(array.as_primitive::<Float32Type>(), nullable),
-            DataType::Float64 => Self::from_arrow(array.as_primitive::<Float64Type>(), nullable),
-            DataType::Utf8 => Self::from_arrow(array.as_string::<i32>(), nullable),
-            DataType::LargeUtf8 => Self::from_arrow(array.as_string::<i64>(), nullable),
-            DataType::Binary => Self::from_arrow(array.as_binary::<i32>(), nullable),
-            DataType::LargeBinary => Self::from_arrow(array.as_binary::<i64>(), nullable),
-            DataType::BinaryView => Self::from_arrow(array.as_binary_view(), nullable),
-            DataType::Utf8View => Self::from_arrow(array.as_string_view(), nullable),
-            DataType::Struct(_) => Self::from_arrow(array.as_struct(), nullable),
-            DataType::List(_) => Self::from_arrow(array.as_list::<i32>(), nullable),
-            DataType::LargeList(_) => Self::from_arrow(array.as_list::<i64>(), nullable),
-            DataType::Null => Self::from_arrow(as_null_array(array), nullable),
-            DataType::Timestamp(u, _) => match u {
+            Boolean => Self::from_arrow(array.as_boolean(), nullable),
+            UInt8 => Self::from_arrow(array.as_primitive::<UInt8Type>(), nullable),
+            UInt16 => Self::from_arrow(array.as_primitive::<UInt16Type>(), nullable),
+            UInt32 => Self::from_arrow(array.as_primitive::<UInt32Type>(), nullable),
+            UInt64 => Self::from_arrow(array.as_primitive::<UInt64Type>(), nullable),
+            Int8 => Self::from_arrow(array.as_primitive::<Int8Type>(), nullable),
+            Int16 => Self::from_arrow(array.as_primitive::<Int16Type>(), nullable),
+            Int32 => Self::from_arrow(array.as_primitive::<Int32Type>(), nullable),
+            Int64 => Self::from_arrow(array.as_primitive::<Int64Type>(), nullable),
+            Float16 => Self::from_arrow(array.as_primitive::<Float16Type>(), nullable),
+            Float32 => Self::from_arrow(array.as_primitive::<Float32Type>(), nullable),
+            Float64 => Self::from_arrow(array.as_primitive::<Float64Type>(), nullable),
+            Utf8 => Self::from_arrow(array.as_string::<i32>(), nullable),
+            LargeUtf8 => Self::from_arrow(array.as_string::<i64>(), nullable),
+            Binary => Self::from_arrow(array.as_binary::<i32>(), nullable),
+            LargeBinary => Self::from_arrow(array.as_binary::<i64>(), nullable),
+            BinaryView => Self::from_arrow(array.as_binary_view(), nullable),
+            Utf8View => Self::from_arrow(array.as_string_view(), nullable),
+            Struct(_) => Self::from_arrow(array.as_struct(), nullable),
+            List(_) => Self::from_arrow(array.as_list::<i32>(), nullable),
+            LargeList(_) => Self::from_arrow(array.as_list::<i64>(), nullable),
+            Null => Self::from_arrow(as_null_array(array), nullable),
+            Timestamp(u, _) => match u {
                 ArrowTimeUnit::Second => {
                     Self::from_arrow(array.as_primitive::<TimestampSecondType>(), nullable)
                 }
@@ -393,36 +416,35 @@ impl FromArrowArray<&dyn ArrowArray> for ArrayRef {
                     Self::from_arrow(array.as_primitive::<TimestampNanosecondType>(), nullable)
                 }
             },
-            DataType::Date32 => Self::from_arrow(array.as_primitive::<Date32Type>(), nullable),
-            DataType::Date64 => Self::from_arrow(array.as_primitive::<Date64Type>(), nullable),
-            DataType::Time32(u) => match u {
+            Date32 => Self::from_arrow(array.as_primitive::<Date32Type>(), nullable),
+            Date64 => Self::from_arrow(array.as_primitive::<Date64Type>(), nullable),
+            Time32(u) => match u {
                 ArrowTimeUnit::Second => {
                     Self::from_arrow(array.as_primitive::<Time32SecondType>(), nullable)
                 }
                 ArrowTimeUnit::Millisecond => {
                     Self::from_arrow(array.as_primitive::<Time32MillisecondType>(), nullable)
                 }
-                _ => unreachable!(),
+                ArrowTimeUnit::Microsecond | ArrowTimeUnit::Nanosecond => unreachable!(),
             },
-            DataType::Time64(u) => match u {
+            Time64(u) => match u {
                 ArrowTimeUnit::Microsecond => {
                     Self::from_arrow(array.as_primitive::<Time64MicrosecondType>(), nullable)
                 }
                 ArrowTimeUnit::Nanosecond => {
                     Self::from_arrow(array.as_primitive::<Time64NanosecondType>(), nullable)
                 }
-                _ => unreachable!(),
+                ArrowTimeUnit::Second | ArrowTimeUnit::Millisecond => unreachable!(),
             },
-            DataType::Decimal128(..) => {
-                Self::from_arrow(array.as_primitive::<Decimal128Type>(), nullable)
+            Decimal128(..) => Self::from_arrow(array.as_primitive::<Decimal128Type>(), nullable),
+            Decimal256(..) => Self::from_arrow(array.as_primitive::<Decimal256Type>(), nullable),
+            Duration(_) | Interval(_) | FixedSizeBinary(_) | ListView(_) | FixedSizeList(..)
+            | LargeListView(_) | Union(..) | Dictionary(..) | Map(..) | RunEndEncoded(..) => {
+                vortex_panic!(
+                    "Array encoding not implemented for Arrow data type {}",
+                    array.data_type().clone()
+                )
             }
-            DataType::Decimal256(..) => {
-                Self::from_arrow(array.as_primitive::<Decimal256Type>(), nullable)
-            }
-            _ => vortex_panic!(
-                "Array encoding not implemented for Arrow data type {}",
-                array.data_type().clone()
-            ),
         }
     }
 }

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -95,10 +95,14 @@ impl Canonical {
     /// This operation is very expensive and can result in things like allocations, full-scans
     /// and copy operations.
     pub fn compact(&self) -> VortexResult<Canonical> {
+        use Canonical::*;
+
         match self {
-            Canonical::VarBinView(array) => Ok(Canonical::VarBinView(array.compact_buffers()?)),
-            Canonical::List(array) => Ok(Canonical::List(array.reset_offsets()?)),
-            other => Ok(other.clone()),
+            VarBinView(array) => Ok(VarBinView(array.compact_buffers()?)),
+            List(array) => Ok(List(array.reset_offsets()?)),
+            Null(_) | Bool(_) | Primitive(_) | Decimal(_) | Struct(_) | Extension(_) => {
+                Ok(self.clone())
+            }
         }
     }
 }
@@ -106,58 +110,66 @@ impl Canonical {
 // Unwrap canonical type back down to specialized type.
 impl Canonical {
     pub fn into_null(self) -> VortexResult<NullArray> {
-        match self {
-            Canonical::Null(a) => Ok(a),
-            _ => vortex_bail!("Cannot unwrap NullArray from {:?}", &self),
+        if let Canonical::Null(a) = self {
+            Ok(a)
+        } else {
+            vortex_bail!("Cannot unwrap NullArray from {:?}", &self)
         }
     }
 
     pub fn into_bool(self) -> VortexResult<BoolArray> {
-        match self {
-            Canonical::Bool(a) => Ok(a),
-            _ => vortex_bail!("Cannot unwrap BoolArray from {:?}", &self),
+        if let Canonical::Bool(a) = self {
+            Ok(a)
+        } else {
+            vortex_bail!("Cannot unwrap BoolArray from {:?}", &self)
         }
     }
 
     pub fn into_primitive(self) -> VortexResult<PrimitiveArray> {
-        match self {
-            Canonical::Primitive(a) => Ok(a),
-            _ => vortex_bail!("Cannot unwrap PrimitiveArray from {:?}", &self),
+        if let Canonical::Primitive(a) = self {
+            Ok(a)
+        } else {
+            vortex_bail!("Cannot unwrap PrimitiveArray from {:?}", &self)
         }
     }
 
     pub fn into_decimal(self) -> VortexResult<DecimalArray> {
-        match self {
-            Canonical::Decimal(a) => Ok(a),
-            _ => vortex_bail!("Cannot unwrap DecimalArray from {:?}", &self),
+        if let Canonical::Decimal(a) = self {
+            Ok(a)
+        } else {
+            vortex_bail!("Cannot unwrap DecimalArray from {:?}", &self)
         }
     }
 
     pub fn into_struct(self) -> VortexResult<StructArray> {
-        match self {
-            Canonical::Struct(a) => Ok(a),
-            _ => vortex_bail!("Cannot unwrap StructArray from {:?}", &self),
+        if let Canonical::Struct(a) = self {
+            Ok(a)
+        } else {
+            vortex_bail!("Cannot unwrap StructArray from {:?}", &self)
         }
     }
 
     pub fn into_list(self) -> VortexResult<ListArray> {
-        match self {
-            Canonical::List(a) => Ok(a),
-            _ => vortex_bail!("Cannot unwrap ListArray from {:?}", &self),
+        if let Canonical::List(a) = self {
+            Ok(a)
+        } else {
+            vortex_bail!("Cannot unwrap ListArray from {:?}", &self)
         }
     }
 
     pub fn into_varbinview(self) -> VortexResult<VarBinViewArray> {
-        match self {
-            Canonical::VarBinView(a) => Ok(a),
-            _ => vortex_bail!("Cannot unwrap VarBinViewArray from {:?}", &self),
+        if let Canonical::VarBinView(a) = self {
+            Ok(a)
+        } else {
+            vortex_bail!("Cannot unwrap VarBinViewArray from {:?}", &self)
         }
     }
 
     pub fn into_extension(self) -> VortexResult<ExtensionArray> {
-        match self {
-            Canonical::Extension(a) => Ok(a),
-            _ => vortex_bail!("Cannot unwrap ExtensionArray from {:?}", &self),
+        if let Canonical::Extension(a) = self {
+            Ok(a)
+        } else {
+            vortex_bail!("Cannot unwrap ExtensionArray from {:?}", &self)
         }
     }
 }

--- a/vortex-array/src/compute/conformance/binary_numeric.rs
+++ b/vortex-array/src/compute/conformance/binary_numeric.rs
@@ -198,26 +198,28 @@ where
 /// }
 /// ```
 pub fn test_binary_numeric_array(array: ArrayRef) {
-    use vortex_dtype::PType;
+    use vortex_dtype::DType::*;
+    use vortex_dtype::PType::*;
 
     match array.dtype() {
-        vortex_dtype::DType::Primitive(ptype, _) => match ptype {
-            PType::I8 => test_binary_numeric_conformance::<i8>(array),
-            PType::I16 => test_binary_numeric_conformance::<i16>(array),
-            PType::I32 => test_binary_numeric_conformance::<i32>(array),
-            PType::I64 => test_binary_numeric_conformance::<i64>(array),
-            PType::U8 => test_binary_numeric_conformance::<u8>(array),
-            PType::U16 => test_binary_numeric_conformance::<u16>(array),
-            PType::U32 => test_binary_numeric_conformance::<u32>(array),
-            PType::U64 => test_binary_numeric_conformance::<u64>(array),
-            PType::F16 => {
+        Primitive(ptype, _) => match ptype {
+            I8 => test_binary_numeric_conformance::<i8>(array),
+            I16 => test_binary_numeric_conformance::<i16>(array),
+            I32 => test_binary_numeric_conformance::<i32>(array),
+            I64 => test_binary_numeric_conformance::<i64>(array),
+            U8 => test_binary_numeric_conformance::<u8>(array),
+            U16 => test_binary_numeric_conformance::<u16>(array),
+            U32 => test_binary_numeric_conformance::<u32>(array),
+            U64 => test_binary_numeric_conformance::<u64>(array),
+            F16 => {
                 // F16 not supported in num-traits, skip
                 eprintln!("Skipping f16 binary numeric tests (not supported)");
             }
-            PType::F32 => test_binary_numeric_conformance::<f32>(array),
-            PType::F64 => test_binary_numeric_conformance::<f64>(array),
+            F32 => test_binary_numeric_conformance::<f32>(array),
+            F64 => test_binary_numeric_conformance::<f64>(array),
         },
-        _ => {
+        Null | Bool(_) | Decimal(..) | Utf8(_) | Binary(_) | List(..) | Struct(..)
+        | Extension(_) => {
             vortex_panic!(
                 "Binary numeric tests are only supported for primitive numeric types, got {:?}",
                 array.dtype()
@@ -234,25 +236,27 @@ pub fn test_binary_numeric_array(array: ArrayRef) {
 /// - Maximum value (tests overflow behavior)
 /// - Minimum value (tests underflow behavior)
 fn test_binary_numeric_edge_cases(array: ArrayRef) {
-    use vortex_dtype::PType;
+    use vortex_dtype::DType::*;
+    use vortex_dtype::PType::*;
 
     match array.dtype() {
-        vortex_dtype::DType::Primitive(ptype, _) => match ptype {
-            PType::I8 => test_binary_numeric_edge_cases_signed::<i8>(array),
-            PType::I16 => test_binary_numeric_edge_cases_signed::<i16>(array),
-            PType::I32 => test_binary_numeric_edge_cases_signed::<i32>(array),
-            PType::I64 => test_binary_numeric_edge_cases_signed::<i64>(array),
-            PType::U8 => test_binary_numeric_edge_cases_unsigned::<u8>(array),
-            PType::U16 => test_binary_numeric_edge_cases_unsigned::<u16>(array),
-            PType::U32 => test_binary_numeric_edge_cases_unsigned::<u32>(array),
-            PType::U64 => test_binary_numeric_edge_cases_unsigned::<u64>(array),
-            PType::F16 => {
+        Primitive(ptype, _) => match ptype {
+            I8 => test_binary_numeric_edge_cases_signed::<i8>(array),
+            I16 => test_binary_numeric_edge_cases_signed::<i16>(array),
+            I32 => test_binary_numeric_edge_cases_signed::<i32>(array),
+            I64 => test_binary_numeric_edge_cases_signed::<i64>(array),
+            U8 => test_binary_numeric_edge_cases_unsigned::<u8>(array),
+            U16 => test_binary_numeric_edge_cases_unsigned::<u16>(array),
+            U32 => test_binary_numeric_edge_cases_unsigned::<u32>(array),
+            U64 => test_binary_numeric_edge_cases_unsigned::<u64>(array),
+            F16 => {
                 eprintln!("Skipping f16 edge case tests (not supported)");
             }
-            PType::F32 => test_binary_numeric_edge_cases_float::<f32>(array),
-            PType::F64 => test_binary_numeric_edge_cases_float::<f64>(array),
+            F32 => test_binary_numeric_edge_cases_float::<f32>(array),
+            F64 => test_binary_numeric_edge_cases_float::<f64>(array),
         },
-        _ => {
+        Null | Bool(_) | Decimal(..) | Utf8(_) | Binary(_) | List(..) | Struct(..)
+        | Extension(_) => {
             vortex_panic!(
                 "Binary numeric edge case tests are only supported for primitive numeric types"
             );

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -559,11 +559,12 @@ fn test_comparison_inverse_consistency(array: &dyn Array) {
         return;
     }
 
-    // Skip non-comparable types
+    use DType::*;
+
+    // Skip non-comparable types.
     match array.dtype() {
-        DType::Null | DType::Extension(_) => return,
-        DType::Struct(..) | DType::List(..) => return,
-        _ => {}
+        Null | Extension(_) | Struct(..) | List(..) => return,
+        Bool(_) | Primitive(..) | Decimal(..) | Utf8(_) | Binary(_) => {}
     }
 
     // Get a test value from the middle of the array
@@ -656,11 +657,13 @@ fn test_comparison_symmetry_consistency(array: &dyn Array) {
         return;
     }
 
-    // Skip non-comparable types
+    use DType::*;
+
+    // Skip non-comparable types.
     match array.dtype() {
-        DType::Null | DType::Extension(_) => return,
-        DType::Struct(..) | DType::List(..) => return,
-        _ => {}
+        Null | Extension(_) => return,
+        Struct(..) | List(..) => return,
+        Bool(_) | Primitive(..) | Decimal(..) | Utf8(_) | Binary(_) => {}
     }
 
     // Get test values

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -235,7 +235,7 @@ impl TryFrom<&dyn Array> for Mask {
 pub fn arrow_filter_fn(array: &dyn Array, mask: &Mask) -> VortexResult<ArrayRef> {
     let values = match &mask {
         Mask::Values(values) => values,
-        _ => unreachable!("check in filter invoke"),
+        Mask::AllTrue(_) | Mask::AllFalse(_) => unreachable!("check in filter invoke"),
     };
 
     let array_ref = array.to_array().into_arrow_preferred()?;

--- a/vortex-array/src/compute/mod.rs
+++ b/vortex-array/src/compute/mod.rs
@@ -303,35 +303,35 @@ impl<'a> Input<'a> {
     pub fn scalar(&self) -> Option<&'a Scalar> {
         match self {
             Input::Scalar(scalar) => Some(*scalar),
-            _ => None,
+            Input::Array(_) | Input::Mask(_) | Input::Builder(_) | Input::DType(_) => None,
         }
     }
 
     pub fn array(&self) -> Option<&'a dyn Array> {
         match self {
             Input::Array(array) => Some(*array),
-            _ => None,
+            Input::Scalar(_) | Input::Mask(_) | Input::Builder(_) | Input::DType(_) => None,
         }
     }
 
     pub fn mask(&self) -> Option<&'a Mask> {
         match self {
             Input::Mask(mask) => Some(*mask),
-            _ => None,
+            Input::Scalar(_) | Input::Array(_) | Input::Builder(_) | Input::DType(_) => None,
         }
     }
 
     pub fn builder(&'a mut self) -> Option<&'a mut dyn ArrayBuilder> {
         match self {
             Input::Builder(builder) => Some(*builder),
-            _ => None,
+            Input::Scalar(_) | Input::Array(_) | Input::Mask(_) | Input::DType(_) => None,
         }
     }
 
     pub fn dtype(&self) -> Option<&'a DType> {
         match self {
             Input::DType(dtype) => Some(*dtype),
-            _ => None,
+            Input::Scalar(_) | Input::Array(_) | Input::Mask(_) | Input::Builder(_) => None,
         }
     }
 }

--- a/vortex-array/src/stats/mod.rs
+++ b/vortex-array/src/stats/mod.rs
@@ -166,48 +166,46 @@ impl Stat {
 
     /// Return the [`DType`] of the statistic scalar assuming the array is of the given [`DType`].
     pub fn dtype(&self, data_type: &DType) -> Option<DType> {
+        use DType::*;
+        use PType::*;
+
         Some(match self {
-            Self::IsConstant => DType::Bool(NonNullable),
-            Self::IsSorted => DType::Bool(NonNullable),
-            Self::IsStrictSorted => DType::Bool(NonNullable),
+            Self::IsConstant => Bool(NonNullable),
+            Self::IsSorted => Bool(NonNullable),
+            Self::IsStrictSorted => Bool(NonNullable),
             Self::Max => data_type.clone(),
             Self::Min => data_type.clone(),
-            Self::NullCount => DType::Primitive(PType::U64, NonNullable),
-            Self::UncompressedSizeInBytes => DType::Primitive(PType::U64, NonNullable),
-            Self::NaNCount => match data_type {
-                DType::Primitive(ptype, ..) if ptype.is_float() => {
-                    DType::Primitive(PType::U64, NonNullable)
+            Self::NullCount => Primitive(U64, NonNullable),
+            Self::UncompressedSizeInBytes => Primitive(U64, NonNullable),
+            Self::NaNCount => {
+                // Only floating points support NaN counts.
+                if let Primitive(ptype, ..) = data_type
+                    && ptype.is_float()
+                {
+                    Primitive(U64, NonNullable)
+                } else {
+                    return None;
                 }
-                // Any other type does not support NaN count
-                _ => return None,
-            },
+            }
             Self::Sum => {
                 // Any array that cannot be summed has a sum DType of null.
                 // Any array that can be summed, but overflows, has a sum _value_ of null.
                 // Therefore, we make integer sum stats nullable.
                 match data_type {
-                    DType::Bool(_) => DType::Primitive(PType::U64, Nullable),
-                    DType::Primitive(ptype, _) => match ptype {
-                        PType::U8 | PType::U16 | PType::U32 | PType::U64 => {
-                            DType::Primitive(PType::U64, Nullable)
-                        }
-                        PType::I8 | PType::I16 | PType::I32 | PType::I64 => {
-                            DType::Primitive(PType::I64, Nullable)
-                        }
-                        PType::F16 | PType::F32 | PType::F64 => {
+                    Bool(_) => Primitive(U64, Nullable),
+                    Primitive(ptype, _) => match ptype {
+                        U8 | U16 | U32 | U64 => Primitive(U64, Nullable),
+                        I8 | I16 | I32 | I64 => Primitive(I64, Nullable),
+                        F16 | F32 | F64 => {
                             // Float sums cannot overflow, but all null floats still end up as null
-                            DType::Primitive(PType::F64, Nullable)
+                            Primitive(F64, Nullable)
                         }
                     },
-                    DType::Extension(ext_dtype) => self.dtype(ext_dtype.storage_dtype())?,
-                    // Unsupported types
-                    DType::Null
+                    Extension(ext_dtype) => self.dtype(ext_dtype.storage_dtype())?,
                     // TODO(aduffy): implement more stats for Decimal
-                    | DType::Decimal(..)
-                    | DType::Utf8(_)
-                    | DType::Binary(_)
-                    | DType::Struct(..)
-                    | DType::List(..) => return None,
+                    Decimal(..) => return None,
+                    // Unsupported types
+                    Null | Utf8(_) | Binary(_) | Struct(..) | List(..) => return None,
                 }
             }
         })

--- a/vortex-array/src/stats/precision.rs
+++ b/vortex-array/src/stats/precision.rs
@@ -40,7 +40,7 @@ impl<T> Precision<Option<T>> {
         match self {
             Exact(Some(x)) => Some(Exact(x)),
             Inexact(Some(x)) => Some(Inexact(x)),
-            _ => None,
+            Exact(None) | Inexact(None) => None,
         }
     }
 }
@@ -123,7 +123,7 @@ impl<T> Precision<T> {
         }
     }
 
-    /// Similar to `map` but handles fucntions that can fail.
+    /// Similar to `map` but handles functions that can fail.
     pub fn try_map<U, F: FnOnce(T) -> VortexResult<U>>(self, f: F) -> VortexResult<Precision<U>> {
         let precision = match self {
             Exact(value) => Exact(f(value)?),

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -58,24 +58,27 @@ impl Validity {
 
     /// If Validity is [`Validity::Array`], returns the array, otherwise returns `None`.
     pub fn into_array(self) -> Option<ArrayRef> {
-        match self {
-            Self::Array(a) => Some(a),
-            _ => None,
+        if let Self::Array(a) = self {
+            Some(a)
+        } else {
+            None
         }
     }
 
     /// If Validity is [`Validity::Array`], returns a reference to the array array, otherwise returns `None`.
     pub fn as_array(&self) -> Option<&ArrayRef> {
-        match self {
-            Self::Array(a) => Some(a),
-            _ => None,
+        if let Self::Array(a) = self {
+            Some(a)
+        } else {
+            None
         }
     }
 
     pub fn nullability(&self) -> Nullability {
-        match self {
-            Self::NonNullable => Nullability::NonNullable,
-            _ => Nullability::Nullable,
+        if matches!(self, Self::NonNullable) {
+            Nullability::NonNullable
+        } else {
+            Nullability::Nullable
         }
     }
 
@@ -139,7 +142,7 @@ impl Validity {
     pub fn slice(&self, start: usize, stop: usize) -> Self {
         match self {
             Self::Array(a) => Self::Array(a.slice(start, stop)),
-            _ => self.clone(),
+            Self::NonNullable | Self::AllValid | Self::AllInvalid => self.clone(),
         }
     }
 
@@ -311,7 +314,7 @@ impl Validity {
     pub fn into_nullable(self) -> Validity {
         match self {
             Self::NonNullable => Self::AllValid,
-            _ => self,
+            Self::AllValid | Self::AllInvalid | Self::Array(_) => self,
         }
     }
 

--- a/vortex-btrblocks/src/decimal.rs
+++ b/vortex-btrblocks/src/decimal.rs
@@ -21,7 +21,7 @@ pub fn compress_decimal(decimal: &DecimalArray) -> VortexResult<ArrayRef> {
         DecimalValueType::I16 => PrimitiveArray::new(decimal.buffer::<i16>(), validity.clone()),
         DecimalValueType::I32 => PrimitiveArray::new(decimal.buffer::<i32>(), validity.clone()),
         DecimalValueType::I64 => PrimitiveArray::new(decimal.buffer::<i64>(), validity.clone()),
-        _ => return Ok(decimal.to_array()),
+        DecimalValueType::I128 | DecimalValueType::I256 | _ => return Ok(decimal.to_array()),
     };
 
     let compressed = IntCompressor::compress(&prim, false, MAX_CASCADE, &[])?;

--- a/vortex-btrblocks/src/float.rs
+++ b/vortex-btrblocks/src/float.rs
@@ -259,7 +259,15 @@ impl Scheme for ALPRDScheme {
         let encoder = match stats.source().ptype() {
             PType::F32 => RDEncoder::new(stats.source().as_slice::<f32>()),
             PType::F64 => RDEncoder::new(stats.source().as_slice::<f64>()),
-            ptype => vortex_panic!("cannot ALPRD compress ptype {ptype}"),
+            ptype @ PType::U8
+            | ptype @ PType::U16
+            | ptype @ PType::U32
+            | ptype @ PType::U64
+            | ptype @ PType::I8
+            | ptype @ PType::I16
+            | ptype @ PType::I32
+            | ptype @ PType::I64
+            | ptype @ PType::F16 => vortex_panic!("cannot ALPRD compress ptype {ptype}"),
         };
 
         let mut alp_rd = encoder.encode(stats.source());

--- a/vortex-btrblocks/src/float/stats.rs
+++ b/vortex-btrblocks/src/float/stats.rs
@@ -65,7 +65,16 @@ impl CompressorStats for FloatStats {
             PType::F16 => typed_float_stats::<f16>(input, opts.count_distinct_values),
             PType::F32 => typed_float_stats::<f32>(input, opts.count_distinct_values),
             PType::F64 => typed_float_stats::<f64>(input, opts.count_distinct_values),
-            _ => vortex_panic!("cannot generate FloatStats from ptype {}", input.ptype()),
+            PType::U8
+            | PType::U16
+            | PType::U32
+            | PType::U64
+            | PType::I8
+            | PType::I16
+            | PType::I32
+            | PType::I64 => {
+                vortex_panic!("cannot generate FloatStats from ptype {}", input.ptype())
+            }
         }
     }
 

--- a/vortex-datafusion/src/convert/scalars.rs
+++ b/vortex-datafusion/src/convert/scalars.rs
@@ -100,7 +100,9 @@ impl TryToDataFusion<ScalarValue> for Scalar {
                         TemporalMetadata::Date(u) => match u {
                             TimeUnit::Ms => ScalarValue::Date64(pv.as_::<i64>()),
                             TimeUnit::D => ScalarValue::Date32(pv.as_::<i32>()),
-                            _ => unreachable!("Unsupported TimeUnit {u} for {}", ext.id()),
+                            TimeUnit::Ns | TimeUnit::Us | TimeUnit::S => {
+                                unreachable!("Unsupported TimeUnit {u} for {}", ext.id())
+                            }
                         },
                         TemporalMetadata::Timestamp(u, tz) => match u {
                             TimeUnit::Ns => ScalarValue::TimestampNanosecond(
@@ -235,7 +237,22 @@ impl FromDataFusion<ScalarValue> for Scalar {
                     Scalar::null(DType::Decimal(decimal_dtype, nullable))
                 }
             }
-            _ => unimplemented!("Can't convert {value:?} value to a Vortex scalar"),
+            ScalarValue::List(_)
+            | ScalarValue::LargeList(_)
+            | ScalarValue::Map(_)
+            | ScalarValue::Struct(_)
+            | ScalarValue::Dictionary(..)
+            | ScalarValue::Union(..)
+            | ScalarValue::IntervalYearMonth(_)
+            | ScalarValue::IntervalDayTime(_)
+            | ScalarValue::IntervalMonthDayNano(_)
+            | ScalarValue::DurationSecond(_)
+            | ScalarValue::DurationMillisecond(_)
+            | ScalarValue::DurationMicrosecond(_)
+            | ScalarValue::DurationNanosecond(_)
+            | ScalarValue::FixedSizeList(_) => {
+                unimplemented!("Can't convert {value:?} value to a Vortex scalar")
+            }
         }
     }
 }
@@ -431,6 +448,9 @@ mod tests {
     #[case::decimal256_null(ScalarValue::Decimal256(None, 50, 10))]
     fn test_from_datafusion_decimals(#[case] df_scalar: ScalarValue) {
         let result = Scalar::from_df(&df_scalar);
+
+        // We probably are not adding other `Decimal` variants.
+        #[allow(clippy::wildcard_enum_match_arm)]
         match &df_scalar {
             ScalarValue::Decimal128(value, precision, scale) => {
                 if let DType::Decimal(decimal_type, _) = result.dtype() {

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -161,7 +161,10 @@ impl FileFormat for VortexFormat {
     ) -> DFResult<String> {
         match file_compression_type.get_variant() {
             CompressionTypeVariant::UNCOMPRESSED => Ok(self.get_ext()),
-            _ => Err(DataFusionError::Internal(
+            CompressionTypeVariant::GZIP
+            | CompressionTypeVariant::BZIP2
+            | CompressionTypeVariant::XZ
+            | CompressionTypeVariant::ZSTD => Err(DataFusionError::Internal(
                 "Vortex does not support file level compression.".into(),
             )),
         }

--- a/vortex-datafusion/src/persistent/metrics.rs
+++ b/vortex-datafusion/src/persistent/metrics.rs
@@ -137,8 +137,7 @@ fn metric_value_to_datafusion(name: &str, metric: &Metric) -> Vec<DatafusionMetr
             }
             res
         }
-        // TODO(os): add more metric types when added to VortexMetrics
-        _ => vec![],
+        Metric::Meter(_) | Metric::Gauge(_) => vec![],
     }
 }
 

--- a/vortex-dtype/src/arrow.rs
+++ b/vortex-dtype/src/arrow.rs
@@ -38,32 +38,47 @@ pub trait TryFromArrowType<T>: Sized {
 
 impl TryFromArrowType<&DataType> for PType {
     fn try_from_arrow(value: &DataType) -> VortexResult<Self> {
+        use DataType::*;
+
         match value {
-            DataType::Int8 => Ok(Self::I8),
-            DataType::Int16 => Ok(Self::I16),
-            DataType::Int32 => Ok(Self::I32),
-            DataType::Int64 => Ok(Self::I64),
-            DataType::UInt8 => Ok(Self::U8),
-            DataType::UInt16 => Ok(Self::U16),
-            DataType::UInt32 => Ok(Self::U32),
-            DataType::UInt64 => Ok(Self::U64),
-            DataType::Float16 => Ok(Self::F16),
-            DataType::Float32 => Ok(Self::F32),
-            DataType::Float64 => Ok(Self::F64),
-            _ => Err(vortex_err!(
-                "Arrow datatype {:?} cannot be converted to ptype",
-                value
-            )),
+            Int8 => Ok(Self::I8),
+            Int16 => Ok(Self::I16),
+            Int32 => Ok(Self::I32),
+            Int64 => Ok(Self::I64),
+            UInt8 => Ok(Self::U8),
+            UInt16 => Ok(Self::U16),
+            UInt32 => Ok(Self::U32),
+            UInt64 => Ok(Self::U64),
+            Float16 => Ok(Self::F16),
+            Float32 => Ok(Self::F32),
+            Float64 => Ok(Self::F64),
+            Null | Boolean | Timestamp(..) | Date32 | Date64 | Time32(_) | Time64(_)
+            | Duration(_) | Interval(_) | Binary | FixedSizeBinary(_) | LargeBinary
+            | BinaryView | Utf8 | LargeUtf8 | Utf8View | List(_) | ListView(_)
+            | FixedSizeList(..) | LargeList(_) | LargeListView(_) | Struct(_) | Union(..)
+            | Dictionary(..) | Decimal128(..) | Decimal256(..) | Map(..) | RunEndEncoded(..) => {
+                Err(vortex_err!(
+                    "Arrow datatype {:?} cannot be converted to ptype",
+                    value
+                ))
+            }
         }
     }
 }
 
 impl TryFromArrowType<&DataType> for DecimalDType {
     fn try_from_arrow(value: &DataType) -> VortexResult<Self> {
+        use DataType::*;
+
         match value {
-            DataType::Decimal128(precision, scale) => Self::try_new(*precision, *scale),
-            DataType::Decimal256(precision, scale) => Self::try_new(*precision, *scale),
-            _ => Err(vortex_err!(
+            Decimal128(precision, scale) => Self::try_new(*precision, *scale),
+            Decimal256(precision, scale) => Self::try_new(*precision, *scale),
+            Null | Boolean | Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32 | UInt64
+            | Float16 | Float32 | Float64 | Timestamp(..) | Date32 | Date64 | Time32(_)
+            | Time64(_) | Duration(_) | Interval(_) | Binary | FixedSizeBinary(_) | LargeBinary
+            | BinaryView | Utf8 | LargeUtf8 | Utf8View | List(_) | ListView(_)
+            | FixedSizeList(..) | LargeList(_) | LargeListView(_) | Struct(_) | Union(..)
+            | Dictionary(..) | Map(..) | RunEndEncoded(..) => Err(vortex_err!(
                 "Arrow datatype {:?} cannot be converted to DecimalDType",
                 value
             )),
@@ -99,38 +114,36 @@ impl FromArrowType<&Fields> for StructFields {
 
 impl FromArrowType<(&DataType, Nullability)> for DType {
     fn from_arrow((data_type, nullability): (&DataType, Nullability)) -> Self {
-        use crate::DType::*;
+        use DataType::*;
 
         if data_type.is_integer() || data_type.is_floating() {
-            return Primitive(
+            return DType::Primitive(
                 PType::try_from_arrow(data_type).vortex_expect("arrow float/integer to ptype"),
                 nullability,
             );
         }
 
         match data_type {
-            DataType::Null => Null,
-            DataType::Decimal128(precision, scale) | DataType::Decimal256(precision, scale) => {
-                Decimal(DecimalDType::new(*precision, *scale), nullability)
+            Null => DType::Null,
+            Decimal128(precision, scale) | Decimal256(precision, scale) => {
+                DType::Decimal(DecimalDType::new(*precision, *scale), nullability)
             }
-            DataType::Boolean => Bool(nullability),
-            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Utf8(nullability),
-            DataType::Binary | DataType::LargeBinary | DataType::BinaryView => Binary(nullability),
-            DataType::Date32
-            | DataType::Date64
-            | DataType::Time32(_)
-            | DataType::Time64(_)
-            | DataType::Timestamp(..) => Extension(Arc::new(
+            Boolean => DType::Bool(nullability),
+            Utf8 | LargeUtf8 | Utf8View => DType::Utf8(nullability),
+            Binary | LargeBinary | BinaryView => DType::Binary(nullability),
+            Date32 | Date64 | Time32(_) | Time64(_) | Timestamp(..) => DType::Extension(Arc::new(
                 make_temporal_ext_dtype(data_type).with_nullability(nullability),
             )),
-            DataType::List(e) | DataType::LargeList(e) => {
-                List(Arc::new(Self::from_arrow(e.as_ref())), nullability)
+            List(e) | LargeList(e) => {
+                DType::List(Arc::new(Self::from_arrow(e.as_ref())), nullability)
             }
-            DataType::Struct(f) => Struct(StructFields::from_arrow(f), nullability),
-            DataType::Dictionary(_, value_type) => {
-                Self::from_arrow((value_type.as_ref(), nullability))
+            Struct(f) => DType::Struct(StructFields::from_arrow(f), nullability),
+            Dictionary(_, value_type) => Self::from_arrow((value_type.as_ref(), nullability)),
+            Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32 | UInt64 | Float16 | Float32
+            | Float64 | Duration(..) | Interval(..) | FixedSizeBinary(..) | ListView(..)
+            | FixedSizeList(..) | LargeListView(..) | Union(..) | Map(..) | RunEndEncoded(..) => {
+                unimplemented!("Arrow data type not yet supported: {:?}", data_type)
             }
-            _ => unimplemented!("Arrow data type not yet supported: {:?}", data_type),
         }
     }
 }

--- a/vortex-dtype/src/datetime/arrow.rs
+++ b/vortex-dtype/src/datetime/arrow.rs
@@ -17,8 +17,10 @@ use crate::{ExtDType, PType};
 pub fn make_temporal_ext_dtype(data_type: &DataType) -> ExtDType {
     assert!(data_type.is_temporal(), "Must receive a temporal DataType");
 
+    use DataType::*;
+
     match data_type {
-        DataType::Timestamp(time_unit, time_zone) => {
+        Timestamp(time_unit, time_zone) => {
             let time_unit = TimeUnit::from(time_unit);
             let tz = time_zone.clone().map(|s| s.to_string());
             // PType is inferred for arrow based on the time units.
@@ -28,7 +30,7 @@ pub fn make_temporal_ext_dtype(data_type: &DataType) -> ExtDType {
                 Some(TemporalMetadata::Timestamp(time_unit, tz).into()),
             )
         }
-        DataType::Time32(time_unit) => {
+        Time32(time_unit) => {
             let time_unit = TimeUnit::from(time_unit);
             ExtDType::new(
                 TIME_ID.clone(),
@@ -36,7 +38,7 @@ pub fn make_temporal_ext_dtype(data_type: &DataType) -> ExtDType {
                 Some(TemporalMetadata::Time(time_unit).into()),
             )
         }
-        DataType::Time64(time_unit) => {
+        Time64(time_unit) => {
             let time_unit = TimeUnit::from(time_unit);
             ExtDType::new(
                 TIME_ID.clone(),
@@ -44,17 +46,23 @@ pub fn make_temporal_ext_dtype(data_type: &DataType) -> ExtDType {
                 Some(TemporalMetadata::Time(time_unit).into()),
             )
         }
-        DataType::Date32 => ExtDType::new(
+        Date32 => ExtDType::new(
             DATE_ID.clone(),
             Arc::new(PType::I32.into()),
             Some(TemporalMetadata::Date(TimeUnit::D).into()),
         ),
-        DataType::Date64 => ExtDType::new(
+        Date64 => ExtDType::new(
             DATE_ID.clone(),
             Arc::new(PType::I64.into()),
             Some(TemporalMetadata::Date(TimeUnit::Ms).into()),
         ),
-        _ => unimplemented!("{data_type} conversion"),
+        Null | Boolean | Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32 | UInt64
+        | Float16 | Float32 | Float64 | Duration(_) | Interval(_) | Binary | FixedSizeBinary(_)
+        | LargeBinary | BinaryView | Utf8 | LargeUtf8 | Utf8View | List(_) | ListView(_)
+        | FixedSizeList(..) | LargeList(_) | LargeListView(_) | Struct(_) | Union(..)
+        | Dictionary(..) | Decimal128(..) | Decimal256(..) | Map(..) | RunEndEncoded(..) => {
+            unimplemented!("{data_type} conversion")
+        }
     }
 }
 
@@ -68,7 +76,7 @@ pub fn make_arrow_temporal_dtype(ext_dtype: &ExtDType) -> DataType {
         TemporalMetadata::Date(time_unit) => match time_unit {
             TimeUnit::D => DataType::Date32,
             TimeUnit::Ms => DataType::Date64,
-            _ => {
+            TimeUnit::Ns | TimeUnit::Us | TimeUnit::S => {
                 vortex_panic!(InvalidArgument: "Invalid TimeUnit {} for {}", time_unit, ext_dtype.id())
             }
         },
@@ -77,7 +85,7 @@ pub fn make_arrow_temporal_dtype(ext_dtype: &ExtDType) -> DataType {
             TimeUnit::Ms => DataType::Time32(ArrowTimeUnit::Millisecond),
             TimeUnit::Us => DataType::Time64(ArrowTimeUnit::Microsecond),
             TimeUnit::Ns => DataType::Time64(ArrowTimeUnit::Nanosecond),
-            _ => {
+            TimeUnit::D => {
                 vortex_panic!(InvalidArgument: "Invalid TimeUnit {} for {}", time_unit, ext_dtype.id())
             }
         },
@@ -86,7 +94,7 @@ pub fn make_arrow_temporal_dtype(ext_dtype: &ExtDType) -> DataType {
             TimeUnit::Us => DataType::Timestamp(ArrowTimeUnit::Microsecond, tz.map(|t| t.into())),
             TimeUnit::Ms => DataType::Timestamp(ArrowTimeUnit::Millisecond, tz.map(|t| t.into())),
             TimeUnit::S => DataType::Timestamp(ArrowTimeUnit::Second, tz.map(|t| t.into())),
-            _ => {
+            TimeUnit::D => {
                 vortex_panic!(InvalidArgument: "Invalid TimeUnit {} for {}", time_unit, ext_dtype.id())
             }
         },

--- a/vortex-dtype/src/datetime/temporal.rs
+++ b/vortex-dtype/src/datetime/temporal.rs
@@ -93,7 +93,7 @@ impl TemporalMetadata {
                 TimeUnit::D | TimeUnit::Ms => Ok(TemporalJiff::Date(
                     Date::new(1970, 1, 1)?.checked_add(unit.to_jiff_span(v)?)?,
                 )),
-                _ => {
+                TimeUnit::Ns | TimeUnit::Us | TimeUnit::S => {
                     vortex_bail!("Invalid TimeUnit {} for TemporalMetadata::Time", unit)
                 }
             },
@@ -113,11 +113,11 @@ impl TemporalMetadata {
 }
 
 macro_rules! impl_temporal_metadata_try_from {
-    ($typ:ty) => {
-        impl TryFrom<$typ> for TemporalMetadata {
+    ($T:ty) => {
+        impl TryFrom<$T> for TemporalMetadata {
             type Error = VortexError;
 
-            fn try_from(ext_dtype: $typ) -> Result<Self, Self::Error> {
+            fn try_from(ext_dtype: $T) -> Result<Self, Self::Error> {
                 let metadata = ext_dtype
                     .metadata()
                     .ok_or_else(|| vortex_err!("ExtDType is missing metadata"))?;

--- a/vortex-dtype/src/datetime/unit.rs
+++ b/vortex-dtype/src/datetime/unit.rs
@@ -7,6 +7,7 @@ use jiff::Span;
 use num_enum::IntoPrimitive;
 use vortex_error::{VortexError, VortexResult, vortex_bail};
 
+// TODO(connor): Consider renaming the enum variants to be more descriptive.
 /// Time units for temporal data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, IntoPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/vortex-dtype/src/decimal.rs
+++ b/vortex-dtype/src/decimal.rs
@@ -112,9 +112,10 @@ impl TryFrom<&DType> for DecimalDType {
     type Error = VortexError;
 
     fn try_from(value: &DType) -> Result<Self, Self::Error> {
-        match value {
-            DType::Decimal(dt, _) => Ok(*dt),
-            _ => vortex_bail!("Cannot convert DType {value} into DecimalType"),
+        if let DType::Decimal(dt, _) = value {
+            Ok(*dt)
+        } else {
+            vortex_bail!("Cannot convert DType {value} into DecimalType")
         }
     }
 }

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -92,15 +92,15 @@ const_assert_eq!(size_of::<DType>(), 16);
 const_assert_eq!(size_of::<DType>(), 8);
 
 impl DType {
-    /// The default DType for bytes
+    /// The default `DType` for bytes.
     pub const BYTES: Self = Primitive(PType::U8, Nullability::NonNullable);
 
-    /// Get the nullability of the DType
+    /// Get the nullability of the `DType`.
     pub fn nullability(&self) -> Nullability {
         self.is_nullable().into()
     }
 
-    /// Check if the DType is nullable
+    /// Check if the `DType` is [`Nullability::Nullable`].
     pub fn is_nullable(&self) -> bool {
         match self {
             Null => true,
@@ -115,12 +115,12 @@ impl DType {
         }
     }
 
-    /// Get a new DType with `Nullability::NonNullable` (but otherwise the same as `self`)
+    /// Get a new `DType` with [`Nullability::NonNullable`] (but otherwise the same as `self`)
     pub fn as_nonnullable(&self) -> Self {
         self.with_nullability(Nullability::NonNullable)
     }
 
-    /// Get a new DType with `Nullability::Nullable` (but otherwise the same as `self`)
+    /// Get a new `DType` with [`Nullability::Nullable`] (but otherwise the same as `self`)
     pub fn as_nullable(&self) -> Self {
         self.with_nullability(Nullability::Nullable)
     }
@@ -140,13 +140,13 @@ impl DType {
         }
     }
 
-    /// Union the nullability of this dtype with the other nullability, returning a new dtype.
+    /// Union the nullability of this `DType` with the other nullability, returning a new `DType`.
     pub fn union_nullability(&self, other: Nullability) -> Self {
         let nullability = self.nullability() | other;
         self.with_nullability(nullability)
     }
 
-    /// Check if `self` and `other` are equal, ignoring nullability
+    /// Check if `self` and `other` are equal, ignoring nullability.
     pub fn eq_ignore_nullability(&self, other: &Self) -> bool {
         match (self, other) {
             (Null, Null) => true,
@@ -185,11 +185,12 @@ impl DType {
         matches!(self, Primitive(_, _))
     }
 
-    /// Returns this DType's `PType` if it is a primitive type, otherwise panics.
+    /// Returns this [`DType`]'s [`PType`] if it is a primitive type, otherwise panics.
     pub fn as_ptype(&self) -> PType {
-        match self {
-            Primitive(ptype, _) => *ptype,
-            _ => vortex_panic!("DType is not a primitive type"),
+        if let Primitive(ptype, _) = self {
+            *ptype
+        } else {
+            vortex_panic!("DType is not a primitive type")
         }
     }
 
@@ -252,29 +253,28 @@ impl DType {
 
     /// Check returns the inner decimal type if the dtype is a decimal
     pub fn as_decimal_opt(&self) -> Option<&DecimalDType> {
-        match self {
-            Decimal(decimal, _) => Some(decimal),
-            _ => None,
+        if let Decimal(decimal, _) = self {
+            Some(decimal)
+        } else {
+            None
         }
     }
 
     /// Get the `StructDType` if `self` is a `StructDType`, otherwise `None`
     pub fn as_struct_opt(&self) -> Option<&StructFields> {
-        match self {
-            Struct(s, _) => Some(s),
-            _ => None,
+        if let Struct(f, _) = self {
+            Some(f)
+        } else {
+            None
         }
     }
 
     /// Get the inner dtype if `self` is a `ListDType`, otherwise `None`
     pub fn as_list_element_opt(&self) -> Option<&Arc<DType>> {
-        match self {
-            List(s, _) => Some(s),
-            _ => None,
-        }
+        if let List(s, _) = self { Some(s) } else { None }
     }
 
-    /// Convenience method for creating a struct dtype
+    /// Convenience method for creating a [`DType::Struct`].
     pub fn struct_<I: IntoIterator<Item = (impl Into<FieldName>, impl Into<FieldDType>)>>(
         iter: I,
         nullability: Nullability,

--- a/vortex-dtype/src/ptype.rs
+++ b/vortex-dtype/src/ptype.rs
@@ -566,7 +566,9 @@ impl PType {
             Self::U16 => Self::I16,
             Self::U32 => Self::I32,
             Self::U64 => Self::I64,
-            _ => self,
+            Self::I8 | Self::I16 | Self::I32 | Self::I64 | Self::F16 | Self::F32 | Self::F64 => {
+                self
+            }
         }
     }
 
@@ -578,7 +580,9 @@ impl PType {
             Self::I16 => Self::U16,
             Self::I32 => Self::U32,
             Self::I64 => Self::U64,
-            _ => self,
+            Self::U8 | Self::U16 | Self::U32 | Self::U64 | Self::F16 | Self::F32 | Self::F64 => {
+                self
+            }
         }
     }
 }
@@ -606,9 +610,10 @@ impl TryFrom<&DType> for PType {
 
     #[inline]
     fn try_from(value: &DType) -> VortexResult<Self> {
-        match value {
-            Primitive(p, _) => Ok(*p),
-            _ => Err(vortex_err!("Cannot convert DType {} into PType", value)),
+        if let Primitive(p, _) = value {
+            Ok(*p)
+        } else {
+            Err(vortex_err!("Cannot convert DType {} into PType", value))
         }
     }
 }

--- a/vortex-duckdb/src/convert/expr.rs
+++ b/vortex-duckdb/src/convert/expr.rs
@@ -23,7 +23,12 @@ fn like_pattern_str(value: &Expression) -> VortexResult<Option<String>> {
         ExpressionClass::BoundConstant(constant) => {
             Ok(Some(format!("%{}%", constant.value.as_string().as_str())))
         }
-        _ => Ok(None),
+        ExpressionClass::BoundColumnRef(_)
+        | ExpressionClass::BoundComparison(_)
+        | ExpressionClass::BoundBetween(_)
+        | ExpressionClass::BoundOperator(_)
+        | ExpressionClass::BoundFunction(_)
+        | ExpressionClass::BoundConjunction(_) => Ok(None),
     }
 }
 
@@ -75,6 +80,8 @@ pub fn try_from_bound_expression(value: &Expression) -> VortexResult<Option<Expr
                 },
             )
         }
+        // TODO(connor): spell out all DUCKDB_VX_EXPR_TYPE variants
+        #[allow(clippy::wildcard_enum_match_arm)]
         ExpressionClass::BoundOperator(operator) => match operator.op {
             DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_OPERATOR_NOT
             | DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_OPERATOR_IS_NULL
@@ -84,6 +91,8 @@ pub fn try_from_bound_expression(value: &Expression) -> VortexResult<Option<Expr
                 let Some(child) = try_from_bound_expression(&children[0])? else {
                     return Ok(None);
                 };
+                // TODO(connor): spell out all DUCKDB_VX_EXPR_TYPE variants
+                #[allow(clippy::wildcard_enum_match_arm)]
                 match operator.op {
                     DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_OPERATOR_NOT => not(child),
                     DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_OPERATOR_IS_NULL => is_null(child),
@@ -156,6 +165,8 @@ pub fn try_from_bound_expression(value: &Expression) -> VortexResult<Option<Expr
             else {
                 return Ok(None);
             };
+            // TODO(connor): spell out all DUCKDB_VX_EXPR_TYPE variants
+            #[allow(clippy::wildcard_enum_match_arm)]
             match conj.op {
                 DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_CONJUNCTION_AND => {
                     and_collect(children).vortex_expect("cannot be empty")
@@ -173,6 +184,8 @@ impl TryFrom<DUCKDB_VX_EXPR_TYPE> for Operator {
     type Error = VortexError;
 
     fn try_from(value: DUCKDB_VX_EXPR_TYPE) -> VortexResult<Self> {
+        // TODO(connor): spell out all DUCKDB_VX_EXPR_TYPE variants
+        #[allow(clippy::wildcard_enum_match_arm)]
         Ok(match value {
             DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_INVALID => vortex_bail!("invalid expr"),
             DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_COMPARE_EQUAL => Operator::Eq,

--- a/vortex-duckdb/src/convert/scalar.rs
+++ b/vortex-duckdb/src/convert/scalar.rs
@@ -177,7 +177,9 @@ impl ToDuckDBScalar for ExtScalar<'_> {
                     .as_::<i32>()
                     .map(Value::new_date)
                     .unwrap_or_else(Value::null)),
-                _ => vortex_bail!("cannot have TimeUnit {unit}, so represent a day"),
+                TimeUnit::Ns | TimeUnit::Us | TimeUnit::Ms | TimeUnit::S => {
+                    vortex_bail!("cannot have TimeUnit {unit}, so represent a day")
+                }
             },
             TemporalMetadata::Timestamp(unit, tz) => {
                 if tz.is_some() {

--- a/vortex-duckdb/src/convert/table_filter.rs
+++ b/vortex-duckdb/src/convert/table_filter.rs
@@ -74,6 +74,8 @@ pub fn try_from_table_filter(
             list_contains(lit(list_scalar), col.clone())
         }
         TableFilterClass::Dynamic(dynamic) => {
+            // TODO(connor): spell out all DUCKDB_VX_EXPR_TYPE variants
+            #[allow(clippy::wildcard_enum_match_arm)]
             let op = match dynamic.operator {
                 DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_COMPARE_EQUAL => Operator::Eq,
                 DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_COMPARE_NOTEQUAL => Operator::NotEq,

--- a/vortex-duckdb/src/convert/vector.rs
+++ b/vortex-duckdb/src/convert/vector.rs
@@ -63,6 +63,8 @@ pub fn flat_vector_to_arrow_array(
     len: usize,
 ) -> Result<Arc<dyn Array>, Box<dyn std::error::Error>> {
     let type_id = vector.logical_type().as_type_id();
+    // TODO(connor): spell out all DUCKDB_TYPE variants
+    #[allow(clippy::wildcard_enum_match_arm)]
     match type_id {
         DUCKDB_TYPE::DUCKDB_TYPE_INTEGER => {
             let data = vector.as_slice_with_len::<i32>(len);
@@ -300,7 +302,9 @@ pub fn flat_vector_to_arrow_array(
                     let data = vector.as_slice_with_len::<i128>(len);
                     data.to_vec()
                 }
-                _ => return Err(format!("Unsupported decimal precision: {precision}").into()),
+                DecimalValueType::I8 | DecimalValueType::I256 | _ => {
+                    return Err(format!("Unsupported decimal precision: {precision}").into());
+                }
             };
 
             let decimal_array = Decimal128Array::from_iter_values_with_nulls(

--- a/vortex-duckdb/src/duckdb/expr.rs
+++ b/vortex-duckdb/src/duckdb/expr.rs
@@ -28,6 +28,8 @@ impl Expression {
 
     /// Match the subclass of the expression.
     pub fn as_class(&self) -> Option<ExpressionClass<'_>> {
+        // TODO(connor): spell out all DUCKDB_VX_EXPR_CLASS variants
+        #[allow(clippy::wildcard_enum_match_arm)]
         Some(
             match unsafe { cpp::duckdb_vx_expr_get_class(self.as_ptr()) } {
                 cpp::DUCKDB_VX_EXPR_CLASS::DUCKDB_VX_EXPR_CLASS_BOUND_COLUMN_REF => {

--- a/vortex-duckdb/src/duckdb/value.rs
+++ b/vortex-duckdb/src/duckdb/value.rs
@@ -228,43 +228,26 @@ impl Value {
         if unsafe { cpp::duckdb_is_null_value(self.as_ptr()) } {
             return Val::Null;
         }
+
+        use DUCKDB_TYPE::*;
+
         match self.logical_type().as_type_id() {
-            DUCKDB_TYPE::DUCKDB_TYPE_INVALID => vortex_panic!("Invalid type for DuckDB value"),
-            DUCKDB_TYPE::DUCKDB_TYPE_SQLNULL => Val::Null,
-            DUCKDB_TYPE::DUCKDB_TYPE_BOOLEAN => {
-                Val::Boolean(unsafe { cpp::duckdb_get_bool(self.as_ptr()) })
-            }
-            DUCKDB_TYPE::DUCKDB_TYPE_TINYINT => {
-                Val::TinyInt(unsafe { cpp::duckdb_get_int8(self.as_ptr()) })
-            }
-            DUCKDB_TYPE::DUCKDB_TYPE_SMALLINT => {
-                Val::SmallInt(unsafe { cpp::duckdb_get_int16(self.as_ptr()) })
-            }
-            DUCKDB_TYPE::DUCKDB_TYPE_INTEGER => {
-                Val::Integer(unsafe { cpp::duckdb_get_int32(self.as_ptr()) })
-            }
-            DUCKDB_TYPE::DUCKDB_TYPE_BIGINT => {
-                Val::BigInt(unsafe { cpp::duckdb_get_int64(self.as_ptr()) })
-            }
-            DUCKDB_TYPE::DUCKDB_TYPE_UTINYINT => {
-                Val::UTinyInt(unsafe { cpp::duckdb_get_uint8(self.as_ptr()) })
-            }
-            DUCKDB_TYPE::DUCKDB_TYPE_USMALLINT => {
+            DUCKDB_TYPE_INVALID => vortex_panic!("Invalid type for DuckDB value"),
+            DUCKDB_TYPE_SQLNULL => Val::Null,
+            DUCKDB_TYPE_BOOLEAN => Val::Boolean(unsafe { cpp::duckdb_get_bool(self.as_ptr()) }),
+            DUCKDB_TYPE_TINYINT => Val::TinyInt(unsafe { cpp::duckdb_get_int8(self.as_ptr()) }),
+            DUCKDB_TYPE_SMALLINT => Val::SmallInt(unsafe { cpp::duckdb_get_int16(self.as_ptr()) }),
+            DUCKDB_TYPE_INTEGER => Val::Integer(unsafe { cpp::duckdb_get_int32(self.as_ptr()) }),
+            DUCKDB_TYPE_BIGINT => Val::BigInt(unsafe { cpp::duckdb_get_int64(self.as_ptr()) }),
+            DUCKDB_TYPE_UTINYINT => Val::UTinyInt(unsafe { cpp::duckdb_get_uint8(self.as_ptr()) }),
+            DUCKDB_TYPE_USMALLINT => {
                 Val::USmallInt(unsafe { cpp::duckdb_get_uint16(self.as_ptr()) })
             }
-            DUCKDB_TYPE::DUCKDB_TYPE_UINTEGER => {
-                Val::UInteger(unsafe { cpp::duckdb_get_uint32(self.as_ptr()) })
-            }
-            DUCKDB_TYPE::DUCKDB_TYPE_UBIGINT => {
-                Val::UBigInt(unsafe { cpp::duckdb_get_uint64(self.as_ptr()) })
-            }
-            DUCKDB_TYPE::DUCKDB_TYPE_FLOAT => {
-                Val::Float(unsafe { cpp::duckdb_get_float(self.as_ptr()) })
-            }
-            DUCKDB_TYPE::DUCKDB_TYPE_DOUBLE => {
-                Val::Double(unsafe { cpp::duckdb_get_double(self.as_ptr()) })
-            }
-            DUCKDB_TYPE::DUCKDB_TYPE_VARCHAR => {
+            DUCKDB_TYPE_UINTEGER => Val::UInteger(unsafe { cpp::duckdb_get_uint32(self.as_ptr()) }),
+            DUCKDB_TYPE_UBIGINT => Val::UBigInt(unsafe { cpp::duckdb_get_uint64(self.as_ptr()) }),
+            DUCKDB_TYPE_FLOAT => Val::Float(unsafe { cpp::duckdb_get_float(self.as_ptr()) }),
+            DUCKDB_TYPE_DOUBLE => Val::Double(unsafe { cpp::duckdb_get_double(self.as_ptr()) }),
+            DUCKDB_TYPE_VARCHAR => {
                 let ptr = unsafe { cpp::duckdb_get_varchar(self.as_ptr()) };
                 let cstr = unsafe { CStr::from_ptr(ptr) };
                 let string = BufferString::from(
@@ -275,7 +258,7 @@ impl Value {
                 unsafe { cpp::duckdb_free(ptr.cast()) };
                 Val::Varchar(string)
             }
-            DUCKDB_TYPE::DUCKDB_TYPE_BLOB => {
+            DUCKDB_TYPE_BLOB => {
                 // TODO(ngates): for blobs and strings, we could write our own C functions to
                 //  get the values by reference, avoiding a double copy since these C functions
                 //  also copy on the CPP side.
@@ -286,25 +269,21 @@ impl Value {
                 unsafe { cpp::duckdb_free(blob.data) };
                 Val::Blob(bytes)
             }
-            DUCKDB_TYPE::DUCKDB_TYPE_DATE => {
-                Val::Date(unsafe { cpp::duckdb_get_date(self.as_ptr()).days })
-            }
-            DUCKDB_TYPE::DUCKDB_TYPE_TIME => {
-                Val::Time(unsafe { cpp::duckdb_get_time(self.as_ptr()).micros })
-            }
-            DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_NS => {
+            DUCKDB_TYPE_DATE => Val::Date(unsafe { cpp::duckdb_get_date(self.as_ptr()).days }),
+            DUCKDB_TYPE_TIME => Val::Time(unsafe { cpp::duckdb_get_time(self.as_ptr()).micros }),
+            DUCKDB_TYPE_TIMESTAMP_NS => {
                 Val::TimestampNs(unsafe { cpp::duckdb_get_timestamp_ns(self.as_ptr()).nanos })
             }
-            DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP => {
+            DUCKDB_TYPE_TIMESTAMP => {
                 Val::Timestamp(unsafe { cpp::duckdb_get_timestamp(self.as_ptr()).micros })
             }
-            DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_MS => {
+            DUCKDB_TYPE_TIMESTAMP_MS => {
                 Val::TimestampMs(unsafe { cpp::duckdb_get_timestamp_ms(self.as_ptr()).millis })
             }
-            DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_S => {
+            DUCKDB_TYPE_TIMESTAMP_S => {
                 Val::TimestampS(unsafe { cpp::duckdb_get_timestamp_s(self.as_ptr()).seconds })
             }
-            DUCKDB_TYPE::DUCKDB_TYPE_DECIMAL => {
+            DUCKDB_TYPE_DECIMAL => {
                 let decimal = unsafe { cpp::duckdb_get_decimal(self.as_ptr()) };
                 let value = i128_from_parts(decimal.value.upper, decimal.value.lower);
                 Val::Decimal(
@@ -314,7 +293,19 @@ impl Value {
                 )
             }
             // ...other types remain unimplemented...
-            _ => vortex_panic!("Unsupported DuckDB value type {:?}", self),
+            DUCKDB_TYPE_TIMESTAMP_TZ
+            | DUCKDB_TYPE_TIME_TZ
+            | DUCKDB_TYPE_INTERVAL
+            | DUCKDB_TYPE_HUGEINT
+            | DUCKDB_TYPE_UUID
+            | DUCKDB_TYPE_LIST
+            | DUCKDB_TYPE_STRUCT
+            | DUCKDB_TYPE_MAP
+            | DUCKDB_TYPE_ARRAY
+            | DUCKDB_TYPE_ENUM
+            | DUCKDB_TYPE_UNION
+            | DUCKDB_TYPE_BIT
+            | _ => vortex_panic!("Unsupported DuckDB value type {:?}", self),
         }
     }
 }

--- a/vortex-expr/src/exprs/dynamic.rs
+++ b/vortex-expr/src/exprs/dynamic.rs
@@ -219,7 +219,7 @@ impl AnalysisExpr for DynamicComparisonExpr {
                 }
                 .into_expr(),
             ),
-            _ => None,
+            Operator::Eq | Operator::NotEq => None,
         }
     }
 }

--- a/vortex-expr/src/exprs/operators.rs
+++ b/vortex-expr/src/exprs/operators.rs
@@ -128,7 +128,14 @@ impl Operator {
         match self {
             Operator::And => Some(Operator::Or),
             Operator::Or => Some(Operator::And),
-            _ => None,
+            Operator::Eq
+            | Operator::NotEq
+            | Operator::Gt
+            | Operator::Gte
+            | Operator::Lt
+            | Operator::Lte
+            | Operator::Add
+            | Operator::Sub => None,
         }
     }
 
@@ -156,7 +163,7 @@ impl Operator {
             Operator::Lte => Some(compute::Operator::Lte),
             Operator::Gt => Some(compute::Operator::Gt),
             Operator::Gte => Some(compute::Operator::Gte),
-            _ => None,
+            Operator::And | Operator::Or | Operator::Add | Operator::Sub => None,
         }
     }
 }

--- a/vortex-expr/src/transform/match_between.rs
+++ b/vortex-expr/src/transform/match_between.rs
@@ -136,7 +136,14 @@ fn maybe_strict_comparison(op: Operator) -> Option<StrictComparison> {
     match op {
         Operator::Lt => Some(StrictComparison::Strict),
         Operator::Lte => Some(StrictComparison::NonStrict),
-        _ => None,
+        Operator::Eq
+        | Operator::NotEq
+        | Operator::Gt
+        | Operator::Gte
+        | Operator::And
+        | Operator::Or
+        | Operator::Add
+        | Operator::Sub => None,
     }
 }
 

--- a/vortex-ffi/src/dtype.rs
+++ b/vortex-ffi/src/dtype.rs
@@ -193,9 +193,10 @@ pub unsafe extern "C-unwind" fn vx_dtype_list_element(dtype: *const vx_dtype) ->
 pub unsafe extern "C-unwind" fn vx_dtype_is_time(dtype: *const DType) -> bool {
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
 
-    match dtype {
-        DType::Extension(ext_dtype) => ext_dtype.id() == &*TIME_ID,
-        _ => false,
+    if let DType::Extension(ext_dtype) = dtype {
+        ext_dtype.id() == &*TIME_ID
+    } else {
+        false
     }
 }
 
@@ -203,9 +204,10 @@ pub unsafe extern "C-unwind" fn vx_dtype_is_time(dtype: *const DType) -> bool {
 pub unsafe extern "C-unwind" fn vx_dtype_is_date(dtype: *const DType) -> bool {
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
 
-    match dtype {
-        DType::Extension(ext_dtype) => ext_dtype.id() == &*DATE_ID,
-        _ => false,
+    if let DType::Extension(ext_dtype) = dtype {
+        ext_dtype.id() == &*DATE_ID
+    } else {
+        false
     }
 }
 
@@ -213,9 +215,10 @@ pub unsafe extern "C-unwind" fn vx_dtype_is_date(dtype: *const DType) -> bool {
 pub unsafe extern "C-unwind" fn vx_dtype_is_timestamp(dtype: *const DType) -> bool {
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
 
-    match dtype {
-        DType::Extension(ext_dtype) => ext_dtype.id() == &*TIMESTAMP_ID,
-        _ => false,
+    if let DType::Extension(ext_dtype) = dtype {
+        ext_dtype.id() == &*TIMESTAMP_ID
+    } else {
+        false
     }
 }
 
@@ -256,7 +259,9 @@ pub unsafe extern "C-unwind" fn vx_dtype_time_zone(
                 unsafe { *len = 0 };
             }
         }
-        _ => vortex_panic!("DType_time_zone: not a timestamp metadata: {ext_dtype:?}"),
+        TemporalMetadata::Time(_) | TemporalMetadata::Date(_) => {
+            vortex_panic!("DType_time_zone: not a timestamp metadata: {ext_dtype:?}")
+        }
     }
 }
 

--- a/vortex-ffi/src/file.rs
+++ b/vortex-ffi/src/file.rs
@@ -356,7 +356,7 @@ fn make_object_store(
             let store = Arc::new(builder.build()?);
             Ok(store)
         }
-        store => {
+        store @ ObjectStoreScheme::Memory | store @ ObjectStoreScheme::Http | store => {
             vortex_bail!("Unsupported store scheme: {store:?}");
         }
     }

--- a/vortex-ipc/src/iterator.rs
+++ b/vortex-ipc/src/iterator.rs
@@ -22,12 +22,13 @@ impl<R: Read> SyncIPCReader<R> {
     pub fn try_new(read: R, registry: ArrayRegistry) -> VortexResult<Self> {
         let mut reader = SyncMessageReader::new(read, registry);
         match reader.next().transpose()? {
-            Some(msg) => match msg {
-                DecoderMessage::DType(dtype) => Ok(SyncIPCReader { reader, dtype }),
-                msg => {
+            Some(msg) => {
+                if let DecoderMessage::DType(dtype) = msg {
+                    Ok(SyncIPCReader { reader, dtype })
+                } else {
                     vortex_bail!("Expected DType message, got {:?}", msg);
                 }
-            },
+            }
             None => vortex_bail!("Expected DType message, got EOF"),
         }
     }
@@ -44,24 +45,27 @@ impl<R: Read> Iterator for SyncIPCReader<R> {
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.reader.next()? {
-            Ok(msg) => match msg {
-                DecoderMessage::Array((array_parts, ctx, row_count)) => Some(
-                    array_parts
-                        .decode(&ctx, &self.dtype, row_count)
-                        .and_then(|array| {
-                            if array.dtype() != self.dtype() {
-                                Err(vortex_err!(
-                                    "Array data type mismatch: expected {:?}, got {:?}",
-                                    self.dtype(),
-                                    array.dtype()
-                                ))
-                            } else {
-                                Ok(array)
-                            }
-                        }),
-                ),
-                msg => Some(Err(vortex_err!("Expected Array message, got {:?}", msg))),
-            },
+            Ok(msg) => {
+                if let DecoderMessage::Array((array_parts, ctx, row_count)) = msg {
+                    Some(
+                        array_parts
+                            .decode(&ctx, &self.dtype, row_count)
+                            .and_then(|array| {
+                                if array.dtype() != self.dtype() {
+                                    Err(vortex_err!(
+                                        "Array data type mismatch: expected {:?}, got {:?}",
+                                        self.dtype(),
+                                        array.dtype()
+                                    ))
+                                } else {
+                                    Ok(array)
+                                }
+                            }),
+                    )
+                } else {
+                    Some(Err(vortex_err!("Expected Array message, got {:?}", msg)))
+                }
+            }
             Err(e) => Some(Err(e)),
         }
     }

--- a/vortex-ipc/src/messages/decoder.rs
+++ b/vortex-ipc/src/messages/decoder.rs
@@ -177,7 +177,9 @@ mod test {
         let mut buffer = BytesMut::from(ipc_bytes.as_ref());
         let (array_parts, ctx, row_count) = match decoder.read_next(&mut buffer).unwrap() {
             PollRead::Some(DecoderMessage::Array(array_parts)) => array_parts,
-            otherwise => vortex_panic!("Expected an array, got {:?}", otherwise),
+            otherwise @ PollRead::Some(_) | otherwise @ PollRead::NeedMore(_) => {
+                vortex_panic!("Expected an array, got {:?}", otherwise)
+            }
         };
 
         // Decode the array parts with the context

--- a/vortex-ipc/src/stream.rs
+++ b/vortex-ipc/src/stream.rs
@@ -29,12 +29,13 @@ impl<R: AsyncRead + Unpin> AsyncIPCReader<R> {
         let mut reader = AsyncMessageReader::new(read, registry);
 
         let dtype = match reader.next().await.transpose()? {
-            Some(msg) => match msg {
-                DecoderMessage::DType(dtype) => dtype,
-                msg => {
+            Some(msg) => {
+                if let DecoderMessage::DType(dtype) = msg {
+                    dtype
+                } else {
                     vortex_bail!("Expected DType message, got {:?}", msg);
                 }
-            },
+            }
             None => vortex_bail!("Expected DType message, got EOF"),
         };
 

--- a/vortex-jni/src/array.rs
+++ b/vortex-jni/src/array.rs
@@ -140,7 +140,31 @@ fn data_type_no_views(data_type: DataType) -> DataType {
         DataType::Map(..) => unreachable!("Vortex never returns Map"),
         DataType::RunEndEncoded(..) => unreachable!("Vortex never returns RunEndEncoded"),
         // The non-nested non-view types stay the same.
-        dt => dt,
+        dt @ DataType::Null
+        | dt @ DataType::Boolean
+        | dt @ DataType::Int8
+        | dt @ DataType::Int16
+        | dt @ DataType::Int32
+        | dt @ DataType::Int64
+        | dt @ DataType::UInt8
+        | dt @ DataType::UInt16
+        | dt @ DataType::UInt32
+        | dt @ DataType::UInt64
+        | dt @ DataType::Float16
+        | dt @ DataType::Float32
+        | dt @ DataType::Float64
+        | dt @ DataType::Timestamp(..)
+        | dt @ DataType::Date32
+        | dt @ DataType::Date64
+        | dt @ DataType::Time32(_)
+        | dt @ DataType::Time64(_)
+        | dt @ DataType::Duration(_)
+        | dt @ DataType::Interval(_)
+        | dt @ DataType::Binary
+        | dt @ DataType::FixedSizeBinary(_)
+        | dt @ DataType::LargeBinary
+        | dt @ DataType::Utf8
+        | dt @ DataType::LargeUtf8 => dt,
     }
 }
 

--- a/vortex-jni/src/dtype.rs
+++ b/vortex-jni/src/dtype.rs
@@ -286,9 +286,10 @@ pub extern "system" fn Java_dev_vortex_jni_NativeDTypeMethods_isDecimal(
     dtype_ptr: jlong,
 ) -> jboolean {
     let dtype = unsafe { &*(dtype_ptr as *const DType) };
-    match dtype {
-        DType::Decimal(..) => JNI_TRUE,
-        _ => JNI_FALSE,
+    if let DType::Decimal(..) = dtype {
+        JNI_TRUE
+    } else {
+        JNI_FALSE
     }
 }
 
@@ -573,7 +574,9 @@ pub extern "system" fn Java_dev_vortex_jni_NativeDTypeMethods_newDate(
         let ptype = match time_unit {
             TimeUnit::D => PType::I32,
             TimeUnit::Ms => PType::I64,
-            unit => throw_runtime!("invalid time_unit for Date type {unit}"),
+            unit @ TimeUnit::Ns | unit @ TimeUnit::Us | unit @ TimeUnit::S => {
+                throw_runtime!("invalid time_unit for Date type {unit}")
+            }
         };
 
         let metadata = TemporalMetadata::Date(time_unit);

--- a/vortex-jni/src/object_store.rs
+++ b/vortex-jni/src/object_store.rs
@@ -111,7 +111,7 @@ pub(crate) fn make_object_store(
 
             Arc::new(builder.build()?)
         }
-        store => {
+        store @ ObjectStoreScheme::Memory | store @ ObjectStoreScheme::Http | store => {
             vortex_bail!("Unsupported store scheme: {store:?}");
         }
     };

--- a/vortex-layout/src/layouts/compact.rs
+++ b/vortex-layout/src/layouts/compact.rs
@@ -126,7 +126,9 @@ impl CompactCompressor {
                         .into_array(),
                 )
             }
-            other => Ok(other.into_array()),
+            other @ Canonical::Null(_)
+            | other @ Canonical::Bool(_)
+            | other @ Canonical::Decimal(_) => Ok(other.into_array()),
         }
     }
 }

--- a/vortex-layout/src/layouts/flat/writer.rs
+++ b/vortex-layout/src/layouts/flat/writer.rs
@@ -108,7 +108,13 @@ impl LayoutStrategy for FlatLayoutStrategy {
                     }
                 }
             }
-            _ => {}
+            DType::Null
+            | DType::Bool(_)
+            | DType::Primitive(..)
+            | DType::Decimal(..)
+            | DType::List(..)
+            | DType::Struct(..)
+            | DType::Extension(_) => {}
         }
 
         // TODO(os): spawn serialization

--- a/vortex-layout/src/layouts/zoned/builder.rs
+++ b/vortex-layout/src/layouts/zoned/builder.rs
@@ -33,7 +33,13 @@ pub fn stats_builder_with_capacity(
                 BoolBuilder::with_capacity(Nullability::NonNullable, capacity),
                 max_length,
             )),
-            _ => Box::new(StatNameArrayBuilder::new(stat, values_builder)),
+            DType::Null
+            | DType::Bool(_)
+            | DType::Primitive(..)
+            | DType::Decimal(..)
+            | DType::List(..)
+            | DType::Struct(..)
+            | DType::Extension(_) => Box::new(StatNameArrayBuilder::new(stat, values_builder)),
         },
         Stat::Min => match dtype {
             DType::Utf8(_) => Box::new(TruncatedMinBinaryStatsBuilder::<Utf8Scalar>::new(
@@ -46,9 +52,21 @@ pub fn stats_builder_with_capacity(
                 BoolBuilder::with_capacity(Nullability::NonNullable, capacity),
                 max_length,
             )),
-            _ => Box::new(StatNameArrayBuilder::new(stat, values_builder)),
+            DType::Null
+            | DType::Bool(_)
+            | DType::Primitive(..)
+            | DType::Decimal(..)
+            | DType::List(..)
+            | DType::Struct(..)
+            | DType::Extension(_) => Box::new(StatNameArrayBuilder::new(stat, values_builder)),
         },
-        _ => Box::new(StatNameArrayBuilder::new(stat, values_builder)),
+        Stat::IsConstant
+        | Stat::IsSorted
+        | Stat::IsStrictSorted
+        | Stat::Sum
+        | Stat::NullCount
+        | Stat::UncompressedSizeInBytes
+        | Stat::NaNCount => Box::new(StatNameArrayBuilder::new(stat, values_builder)),
     }
 }
 
@@ -112,7 +130,13 @@ impl StatsArrayBuilder for StatNameArrayBuilder {
                 names: vec![self.stat.name().into(), MIN_IS_TRUNCATED.into()],
                 arrays: vec![array, ConstantArray::new(false, len).into_array()],
             },
-            _ => NamedArrays {
+            Stat::IsConstant
+            | Stat::IsSorted
+            | Stat::IsStrictSorted
+            | Stat::Sum
+            | Stat::NullCount
+            | Stat::UncompressedSizeInBytes
+            | Stat::NaNCount => NamedArrays {
                 names: vec![self.stat.name().into()],
                 arrays: vec![array],
             },

--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -70,7 +70,13 @@ impl ZoneMap {
                             (s.name(), dt),
                             (MIN_IS_TRUNCATED, DType::Bool(Nullability::NonNullable)),
                         ],
-                        _ => vec![(s.name(), dt)],
+                        Stat::IsConstant
+                        | Stat::IsSorted
+                        | Stat::IsStrictSorted
+                        | Stat::Sum
+                        | Stat::NullCount
+                        | Stat::UncompressedSizeInBytes
+                        | Stat::NaNCount => vec![(s.name(), dt)],
                     }),
             ),
             Nullability::NonNullable,

--- a/vortex-mask/src/lib.rs
+++ b/vortex-mask/src/lib.rs
@@ -532,9 +532,10 @@ impl Mask {
 
     /// Return [`MaskValues`] if the mask is not all true or all false.
     pub fn values(&self) -> Option<&MaskValues> {
-        match self {
-            Self::Values(values) => Some(values),
-            _ => None,
+        if let Self::Values(values) = self {
+            Some(values)
+        } else {
+            None
         }
     }
 

--- a/vortex-mask/src/tests.rs
+++ b/vortex-mask/src/tests.rs
@@ -500,11 +500,10 @@ fn test_mask_threshold_iter() {
     assert!(matches!(all_false.threshold_iter(0.5), AllOr::None));
 
     let mask = Mask::from_buffer(BooleanBuffer::from_iter([true, false, true, true, false]));
-    match mask.threshold_iter(0.7) {
-        AllOr::Some(MaskIter::Indices(indices)) => {
-            assert_eq!(indices, &[0, 2, 3]);
-        }
-        _ => panic!("Expected indices iterator"),
+    if let AllOr::Some(MaskIter::Indices(indices)) = mask.threshold_iter(0.7) {
+        assert_eq!(indices, &[0, 2, 3]);
+    } else {
+        panic!("Expected indices iterator");
     }
 }
 
@@ -668,6 +667,6 @@ fn test_intersection_indices(
         AllOr::Some(indices) if expected.is_empty() => assert!(indices.is_empty()),
         AllOr::Some(indices) => assert_eq!(indices, &expected[..]),
         AllOr::None if expected.is_empty() => {}
-        _ => panic!("Unexpected result for intersection"),
+        AllOr::None | AllOr::All => panic!("Unexpected result for intersection"),
     }
 }

--- a/vortex-metrics/src/lib.rs
+++ b/vortex-metrics/src/lib.rs
@@ -212,9 +212,10 @@ mod tests {
                 .with_tag("file", "a")
                 .with_tag("partition", "1")
         );
-        match metric {
-            Metric::Counter(c) => assert_eq!(c.count(), 1),
-            _ => return Err("metric is not a counter"),
+        if let Metric::Counter(c) = metric {
+            assert_eq!(c.count(), 1);
+        } else {
+            return Err("metric is not a counter");
         }
         Ok(())
     }
@@ -246,9 +247,10 @@ mod tests {
                 .with_tag("service", "vortex")
                 .with_tag("instance", "child1")
         );
-        match metric {
-            Metric::Counter(c) => assert_eq!(c.count(), 1),
-            _ => return Err("metric is not a counter"),
+        if let Metric::Counter(c) = metric {
+            assert_eq!(c.count(), 1);
+        } else {
+            return Err("metric is not a counter");
         }
 
         // Verify child2 metrics
@@ -260,9 +262,10 @@ mod tests {
                 .with_tag("service", "vortex")
                 .with_tag("instance", "child2")
         );
-        match metric {
-            Metric::Counter(c) => assert_eq!(c.count(), 2),
-            _ => return Err("metric is not a counter"),
+        if let Metric::Counter(c) = metric {
+            assert_eq!(c.count(), 2);
+        } else {
+            return Err("metric is not a counter");
         }
         Ok(())
     }
@@ -289,9 +292,10 @@ mod tests {
                 .with_tag("environment", "test")
                 .with_tag("instance", "child1")
         );
-        match metric {
-            Metric::Counter(c) => assert_eq!(c.count(), 1),
-            _ => return Err("metric is not a counter"),
+        if let Metric::Counter(c) = metric {
+            assert_eq!(c.count(), 1);
+        } else {
+            return Err("metric is not a counter");
         }
         Ok(())
     }

--- a/vortex-python/src/object_store_urls.rs
+++ b/vortex-python/src/object_store_urls.rs
@@ -19,6 +19,9 @@ pub(crate) fn object_store_from_url(
     let url = Url::parse(url_str)?;
 
     let (scheme, path) = ObjectStoreScheme::parse(&url).map_err(object_store::Error::from)?;
+
+    // `ObjectStoreScheme` is `non_exhaustive`.
+    #[allow(clippy::wildcard_enum_match_arm)]
     let store: Arc<dyn ObjectStore> = match scheme {
         ObjectStoreScheme::Local => Arc::new(LocalFileSystem::default()),
         ObjectStoreScheme::AmazonS3 => {
@@ -39,7 +42,7 @@ pub(crate) fn object_store_from_url(
                 .with_url(&url[..url::Position::BeforePath])
                 .build()?,
         ),
-        otherwise => vortex_bail!("unrecognized object store scheme: {:?}", otherwise),
+        _ => vortex_bail!("unrecognized object store scheme: {:?}", scheme),
     };
 
     Ok((scheme, store, path))

--- a/vortex-scalar/src/arrow/mod.rs
+++ b/vortex-scalar/src/arrow/mod.rs
@@ -140,7 +140,9 @@ impl TryFrom<&Scalar> for Arc<dyn Datum> {
                             TimeUnit::D => {
                                 value_to_arrow_scalar!(primitive.as_::<i32>(), Date32Array)
                             }
-                            _ => vortex_bail!("Unsupported TimeUnit {u} for {}", ext.id()),
+                            TimeUnit::Ns | TimeUnit::Us | TimeUnit::S => {
+                                vortex_bail!("Unsupported TimeUnit {u} for {}", ext.id())
+                            }
                         },
                         TemporalMetadata::Timestamp(u, _) => match u {
                             TimeUnit::Ns => value_to_arrow_scalar!(

--- a/vortex-scalar/src/arrow/tests.rs
+++ b/vortex-scalar/src/arrow/tests.rs
@@ -283,15 +283,17 @@ fn test_temporal_time_to_arrow(
         Some(metadata.into()),
     ));
 
+    use PType::*;
+
     let scalar = Scalar::extension(
         ext_dtype,
         match ptype {
-            PType::I32 => {
+            I32 => {
                 let i32_value = i32::try_from(value).expect("test value should fit in i32");
                 Scalar::primitive(i32_value, Nullability::NonNullable)
             }
-            PType::I64 => Scalar::primitive(value, Nullability::NonNullable),
-            _ => unreachable!(),
+            I64 => Scalar::primitive(value, Nullability::NonNullable),
+            U8 | U16 | U32 | U64 | I8 | I16 | F16 | F32 | F64 => unreachable!(),
         },
     );
 
@@ -332,15 +334,17 @@ fn test_temporal_date_to_arrow(
         Some(metadata.into()),
     ));
 
+    use PType::*;
+
     let scalar = Scalar::extension(
         ext_dtype,
         match ptype {
-            PType::I32 => {
+            I32 => {
                 let i32_value = i32::try_from(value).expect("test value should fit in i32");
                 Scalar::primitive(i32_value, Nullability::NonNullable)
             }
-            PType::I64 => Scalar::primitive(value, Nullability::NonNullable),
-            _ => unreachable!(),
+            I64 => Scalar::primitive(value, Nullability::NonNullable),
+            U8 | U16 | U32 | U64 | I8 | I16 | F16 | F32 | F64 => unreachable!(),
         },
     );
 
@@ -360,12 +364,14 @@ fn test_temporal_date_unsupported(#[case] time_unit: TimeUnit, #[case] ptype: PT
         Some(metadata.into()),
     ));
 
+    use PType::*;
+
     let scalar = Scalar::extension(
         ext_dtype,
         match ptype {
-            PType::I32 => Scalar::primitive(1234i32, Nullability::NonNullable),
-            PType::I64 => Scalar::primitive(1234567890000i64, Nullability::NonNullable),
-            _ => unreachable!(),
+            I32 => Scalar::primitive(1234i32, Nullability::NonNullable),
+            I64 => Scalar::primitive(1234567890000i64, Nullability::NonNullable),
+            U8 | U16 | U32 | U64 | I8 | I16 | F16 | F32 | F64 => unreachable!(),
         },
     );
 

--- a/vortex-scalar/src/decimal/mod.rs
+++ b/vortex-scalar/src/decimal/mod.rs
@@ -10,6 +10,7 @@ use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
 
+use DecimalValue::*;
 use num_traits::ToPrimitive as NumToPrimitive;
 use vortex_dtype::{DType, DecimalDType, Nullability, PType};
 use vortex_error::{VortexError, VortexResult, vortex_bail, vortex_err};
@@ -37,8 +38,8 @@ impl NativeDecimalType for i8 {
 
     fn maybe_from(decimal_type: DecimalValue) -> Option<Self> {
         match decimal_type {
-            DecimalValue::I8(v) => Some(v),
-            _ => None,
+            I8(v) => Some(v),
+            I16(_) | I32(_) | I64(_) | I128(_) | I256(_) => None,
         }
     }
 }
@@ -48,8 +49,8 @@ impl NativeDecimalType for i16 {
 
     fn maybe_from(decimal_type: DecimalValue) -> Option<Self> {
         match decimal_type {
-            DecimalValue::I16(v) => Some(v),
-            _ => None,
+            I16(v) => Some(v),
+            I8(_) | I32(_) | I64(_) | I128(_) | I256(_) => None,
         }
     }
 }
@@ -59,8 +60,8 @@ impl NativeDecimalType for i32 {
 
     fn maybe_from(decimal_type: DecimalValue) -> Option<Self> {
         match decimal_type {
-            DecimalValue::I32(v) => Some(v),
-            _ => None,
+            I32(v) => Some(v),
+            I8(_) | I16(_) | I64(_) | I128(_) | I256(_) => None,
         }
     }
 }
@@ -70,8 +71,8 @@ impl NativeDecimalType for i64 {
 
     fn maybe_from(decimal_type: DecimalValue) -> Option<Self> {
         match decimal_type {
-            DecimalValue::I64(v) => Some(v),
-            _ => None,
+            I64(v) => Some(v),
+            I8(_) | I16(_) | I32(_) | I128(_) | I256(_) => None,
         }
     }
 }
@@ -81,8 +82,8 @@ impl NativeDecimalType for i128 {
 
     fn maybe_from(decimal_type: DecimalValue) -> Option<Self> {
         match decimal_type {
-            DecimalValue::I128(v) => Some(v),
-            _ => None,
+            I128(v) => Some(v),
+            I8(_) | I16(_) | I32(_) | I64(_) | I256(_) => None,
         }
     }
 }
@@ -92,8 +93,8 @@ impl NativeDecimalType for i256 {
 
     fn maybe_from(decimal_type: DecimalValue) -> Option<Self> {
         match decimal_type {
-            DecimalValue::I256(v) => Some(v),
-            _ => None,
+            I256(v) => Some(v),
+            I8(_) | I16(_) | I32(_) | I64(_) | I128(_) => None,
         }
     }
 }
@@ -101,12 +102,12 @@ impl NativeDecimalType for i256 {
 impl Display for DecimalValue {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            DecimalValue::I8(v8) => write!(f, "decimal8({v8})"),
-            DecimalValue::I16(v16) => write!(f, "decimal16({v16})"),
-            DecimalValue::I32(v32) => write!(f, "decimal32({v32})"),
-            DecimalValue::I64(v32) => write!(f, "decimal64({v32})"),
-            DecimalValue::I128(v128) => write!(f, "decimal128({v128})"),
-            DecimalValue::I256(v256) => write!(f, "decimal256({v256})"),
+            I8(v8) => write!(f, "decimal8({v8})"),
+            I16(v16) => write!(f, "decimal16({v16})"),
+            I32(v32) => write!(f, "decimal32({v32})"),
+            I64(v32) => write!(f, "decimal64({v32})"),
+            I128(v128) => write!(f, "decimal128({v128})"),
+            I256(v256) => write!(f, "decimal256({v256})"),
         }
     }
 }
@@ -170,9 +171,7 @@ impl<'a> DecimalScalar<'a> {
                     // Same decimal type, just change nullability if needed
                     return Ok(Scalar::new(
                         dtype.clone(),
-                        ScalarValue(InnerScalarValue::Decimal(
-                            self.value.unwrap_or(DecimalValue::I128(0)),
-                        )),
+                        ScalarValue(InnerScalarValue::Decimal(self.value.unwrap_or(I128(0)))),
                     ));
                 }
 
@@ -274,7 +273,13 @@ impl<'a> DecimalScalar<'a> {
                     Ok(Scalar::null(dtype.clone()))
                 }
             }
-            _ => vortex_bail!(
+            DType::Null
+            | DType::Bool(_)
+            | DType::Utf8(_)
+            | DType::Binary(_)
+            | DType::List(..)
+            | DType::Struct(..)
+            | DType::Extension(_) => vortex_bail!(
                 "Cannot cast decimal to {dtype}: decimal scalars can only be cast to decimal or primitive numeric types"
             ),
         }
@@ -292,45 +297,45 @@ impl<'a> TryFrom<&'a Scalar> for DecimalScalar<'a> {
 impl Display for DecimalScalar<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self.value.as_ref() {
-            Some(&dv) => {
+            Some(&decimal_value) => {
                 // Introduce some of the scale factors instead.
-                match dv {
-                    DecimalValue::I8(v) => write!(
+                match decimal_value {
+                    I8(v) => write!(
                         f,
                         "decimal8({}, precision={}, scale={})",
                         v,
                         self.decimal_type.precision(),
                         self.decimal_type.scale()
                     ),
-                    DecimalValue::I16(v) => write!(
+                    I16(v) => write!(
                         f,
                         "decimal16({}, precision={}, scale={})",
                         v,
                         self.decimal_type.precision(),
                         self.decimal_type.scale()
                     ),
-                    DecimalValue::I32(v) => write!(
+                    I32(v) => write!(
                         f,
                         "decimal32({}, precision={}, scale={})",
                         v,
                         self.decimal_type.precision(),
                         self.decimal_type.scale()
                     ),
-                    DecimalValue::I64(v) => write!(
+                    I64(v) => write!(
                         f,
                         "decimal64({}, precision={}, scale={})",
                         v,
                         self.decimal_type.precision(),
                         self.decimal_type.scale()
                     ),
-                    DecimalValue::I128(v) => write!(
+                    I128(v) => write!(
                         f,
                         "decimal128({}, precision={}, scale={})",
                         v,
                         self.decimal_type.precision(),
                         self.decimal_type.scale()
                     ),
-                    DecimalValue::I256(v) => write!(
+                    I256(v) => write!(
                         f,
                         "decimal256({}, precision={}, scale={})",
                         v,

--- a/vortex-scalar/src/decimal/tests.rs
+++ b/vortex-scalar/src/decimal/tests.rs
@@ -473,7 +473,7 @@ fn test_decimal_i8_all_primitive_casts(#[case] ptype: PType, #[case] expected: u
             scalar.as_primitive().typed_value::<i64>().unwrap() as u64,
             expected
         ),
-        _ => panic!("Unexpected type"),
+        PType::F16 | PType::F32 | PType::F64 => panic!("Unexpected type"),
     }
 }
 

--- a/vortex-scalar/src/primitive.rs
+++ b/vortex-scalar/src/primitive.rs
@@ -748,12 +748,16 @@ mod tests {
         #[case] target_type: PType,
         #[case] should_succeed: bool,
     ) {
+        use PType::*;
+
         let source_pvalue = match source_type {
-            PType::I8 => PValue::I8(source_value as i8),
-            PType::U8 => PValue::U8(source_value as u8),
-            PType::U16 => PValue::U16(source_value as u16),
-            PType::I32 => PValue::I32(source_value),
-            _ => unreachable!("Test case uses unexpected source type"),
+            I8 => PValue::I8(source_value as i8),
+            U8 => PValue::U8(source_value as u8),
+            U16 => PValue::U16(source_value as u16),
+            I32 => PValue::I32(source_value),
+            U32 | U64 | I16 | I64 | F16 | F32 | F64 => {
+                unreachable!("Test case uses unexpected source type")
+            }
         };
 
         let dtype = DType::Primitive(source_type, Nullability::NonNullable);

--- a/vortex-scalar/src/proto.rs
+++ b/vortex-scalar/src/proto.rs
@@ -474,14 +474,17 @@ mod tests {
             let written = value.to_protobytes::<Vec<u8>>();
             let read_back = ScalarValue::from_protobytes(&written).unwrap();
 
+            use InnerScalarValue::*;
+
             match &read_back.0 {
-                InnerScalarValue::Primitive(PValue::U64(v)) => {
+                Primitive(PValue::U64(v)) => {
                     assert_eq!(
                         *v, expected,
                         "ScalarValue {name} value not preserved: expected {expected}, got {v}"
                     );
                 }
-                _ => {
+                Primitive(_) | Null | Bool(_) | Decimal(_) | Buffer(_) | BufferString(_)
+                | List(_) => {
                     vortex_panic!("Unexpected type after roundtrip for {name}: {read_back:?}")
                 }
             }
@@ -510,14 +513,17 @@ mod tests {
             let written = value.to_protobytes::<Vec<u8>>();
             let read_back = ScalarValue::from_protobytes(&written).unwrap();
 
+            use InnerScalarValue::*;
+
             match &read_back.0 {
-                InnerScalarValue::Primitive(PValue::I64(v)) => {
+                Primitive(PValue::I64(v)) => {
                     assert_eq!(
                         *v, expected,
                         "ScalarValue {name} value not preserved: expected {expected}, got {v}"
                     );
                 }
-                _ => {
+                Primitive(_) | Null | Bool(_) | Decimal(_) | Buffer(_) | BufferString(_)
+                | List(_) => {
                     vortex_panic!("Unexpected type after roundtrip for {name}: {read_back:?}")
                 }
             }

--- a/vortex-scalar/src/pvalue.rs
+++ b/vortex-scalar/src/pvalue.rs
@@ -224,6 +224,8 @@ impl PValue {
             "Cannot reinterpret cast between types of different widths"
         );
 
+        // It is unlikely that more primitive types will be added, so fingers crossed...
+        #[allow(clippy::wildcard_enum_match_arm)]
         match self {
             PValue::U8(v) => u8::cast_signed(*v).into(),
             PValue::U16(v) => match ptype {
@@ -453,7 +455,9 @@ impl CoercePValue for f16 {
             PValue::F64(f) => {
                 <Self as NumCast>::from(f).ok_or_else(|| vortex_err!("Cannot convert f64 to f16"))
             }
-            _ => vortex_bail!("Cannot coerce {value:?} to f16: type not supported for coercion"),
+            PValue::I8(_) | PValue::I16(_) | PValue::I32(_) | PValue::I64(_) => {
+                vortex_bail!("Cannot coerce {value:?} to f16: type not supported for coercion")
+            }
         }
     }
 }
@@ -474,7 +478,9 @@ impl CoercePValue for f32 {
             PValue::F64(f) => {
                 <Self as NumCast>::from(f).ok_or_else(|| vortex_err!("Cannot convert f64 to f32"))
             }
-            _ => vortex_bail!("Unsupported PValue {value:?} type for f32"),
+            PValue::I8(_) | PValue::I16(_) | PValue::I32(_) | PValue::I64(_) => {
+                vortex_bail!("Unsupported PValue {value:?} type for f32")
+            }
         }
     }
 }
@@ -494,7 +500,9 @@ impl CoercePValue for f64 {
                 <Self as NumCast>::from(f).ok_or_else(|| vortex_err!("Cannot convert f32 to f64"))
             }
             PValue::F64(f) => Ok(f),
-            _ => vortex_bail!("Unsupported PValue {value:?} type for f64"),
+            PValue::I8(_) | PValue::I16(_) | PValue::I32(_) | PValue::I64(_) => {
+                vortex_bail!("Unsupported PValue {value:?} type for f64")
+            }
         }
     }
 }

--- a/vortex-scalar/src/scalar_value.rs
+++ b/vortex-scalar/src/scalar_value.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use bytes::BufMut;
 use itertools::Itertools;
 use prost::Message;
-use vortex_buffer::{BufferString, ByteBuffer};
 use vortex_dtype::DType;
 use vortex_error::{VortexResult, VortexUnwrap, vortex_bail, vortex_err};
 use vortex_proto::scalar as pb;
@@ -64,8 +63,8 @@ pub(crate) enum InnerScalarValue {
     Bool(bool),
     Primitive(PValue),
     Decimal(DecimalValue),
-    Buffer(Arc<ByteBuffer>),
-    BufferString(Arc<BufferString>),
+    Buffer(Arc<vortex_buffer::ByteBuffer>),
+    BufferString(Arc<vortex_buffer::BufferString>),
     List(Arc<[ScalarValue]>),
 }
 
@@ -180,12 +179,14 @@ impl ScalarValue {
     }
 
     /// Returns scalar as a binary buffer
-    pub(crate) fn as_buffer(&self) -> VortexResult<Option<Arc<ByteBuffer>>> {
+    pub(crate) fn as_buffer(&self) -> VortexResult<Option<Arc<vortex_buffer::ByteBuffer>>> {
         self.0.as_buffer()
     }
 
     /// Returns scalar as a string buffer
-    pub(crate) fn as_buffer_string(&self) -> VortexResult<Option<Arc<BufferString>>> {
+    pub(crate) fn as_buffer_string(
+        &self,
+    ) -> VortexResult<Option<Arc<vortex_buffer::BufferString>>> {
         self.0.as_buffer_string()
     }
 
@@ -225,17 +226,20 @@ impl InnerScalarValue {
     }
 
     pub(crate) fn as_null(&self) -> VortexResult<()> {
-        match self {
-            InnerScalarValue::Null => Ok(()),
-            _ => Err(vortex_err!("Expected a Null scalar, found {:?}", self)),
+        if matches!(self, InnerScalarValue::Null) {
+            Ok(())
+        } else {
+            Err(vortex_err!("Expected a Null scalar, found {:?}", self))
         }
     }
 
     pub(crate) fn as_bool(&self) -> VortexResult<Option<bool>> {
-        match &self {
-            InnerScalarValue::Null => Ok(None),
-            InnerScalarValue::Bool(b) => Ok(Some(*b)),
-            _ => Err(vortex_err!("Expected a bool scalar, found {:?}", self)),
+        if matches!(&self, InnerScalarValue::Null) {
+            Ok(None)
+        } else if let InnerScalarValue::Bool(b) = &self {
+            Ok(Some(*b))
+        } else {
+            Err(vortex_err!("Expected a bool scalar, found {:?}", self))
         }
     }
 
@@ -243,57 +247,76 @@ impl InnerScalarValue {
     ///  But the other accessors can sometimes be useful? e.g. as_buffer. But maybe we just force
     ///  the user to switch over Utf8 and Binary and use the correct Scalar wrapper?
     pub(crate) fn as_pvalue(&self) -> VortexResult<Option<PValue>> {
-        match &self {
-            InnerScalarValue::Null => Ok(None),
-            InnerScalarValue::Primitive(p) => Ok(Some(*p)),
-            _ => Err(vortex_err!("Expected a primitive scalar, found {:?}", self)),
+        if matches!(&self, InnerScalarValue::Null) {
+            Ok(None)
+        } else if let InnerScalarValue::Primitive(p) = &self {
+            Ok(Some(*p))
+        } else {
+            Err(vortex_err!("Expected a primitive scalar, found {:?}", self))
         }
     }
 
     pub(crate) fn as_decimal(&self) -> VortexResult<Option<DecimalValue>> {
+        use DecimalValue::*;
+        use InnerScalarValue::*;
+
         match self {
-            InnerScalarValue::Null => Ok(None),
-            InnerScalarValue::Decimal(v) => Ok(Some(*v)),
-            InnerScalarValue::Buffer(b) => Ok(Some(match b.len() {
-                1 => DecimalValue::I8(b[0] as i8),
-                2 => DecimalValue::I16(i16::from_le_bytes(b.as_slice().try_into()?)),
-                4 => DecimalValue::I32(i32::from_le_bytes(b.as_slice().try_into()?)),
-                8 => DecimalValue::I64(i64::from_le_bytes(b.as_slice().try_into()?)),
-                16 => DecimalValue::I128(i128::from_le_bytes(b.as_slice().try_into()?)),
-                32 => DecimalValue::I256(i256::from_le_bytes(b.as_slice().try_into()?)),
+            Null => Ok(None),
+            Decimal(v) => Ok(Some(*v)),
+            Buffer(b) => Ok(Some(match b.len() {
+                1 => I8(b[0] as i8),
+                2 => I16(i16::from_le_bytes(b.as_slice().try_into()?)),
+                4 => I32(i32::from_le_bytes(b.as_slice().try_into()?)),
+                8 => I64(i64::from_le_bytes(b.as_slice().try_into()?)),
+                16 => I128(i128::from_le_bytes(b.as_slice().try_into()?)),
+                32 => I256(i256::from_le_bytes(b.as_slice().try_into()?)),
                 l => vortex_bail!("Buffer is not a decimal value length {l}"),
             })),
-            _ => vortex_bail!("Expected a decimal scalar, found {:?}", self),
+            Bool(_) | Primitive(_) | BufferString(_) | List(_) => {
+                vortex_bail!("Expected a decimal scalar, found {:?}", self)
+            }
         }
     }
 
-    pub(crate) fn as_buffer(&self) -> VortexResult<Option<Arc<ByteBuffer>>> {
+    pub(crate) fn as_buffer(&self) -> VortexResult<Option<Arc<vortex_buffer::ByteBuffer>>> {
+        use InnerScalarValue::*;
+
         match &self {
-            InnerScalarValue::Null => Ok(None),
-            InnerScalarValue::Buffer(b) => Ok(Some(b.clone())),
-            InnerScalarValue::BufferString(b) => {
-                Ok(Some(Arc::new(b.as_ref().clone().into_inner())))
+            Null => Ok(None),
+            Buffer(b) => Ok(Some(b.clone())),
+            BufferString(b) => Ok(Some(Arc::new(b.as_ref().clone().into_inner()))),
+            Bool(_) | Primitive(_) | Decimal(_) | List(_) => {
+                Err(vortex_err!("Expected a binary scalar, found {:?}", self))
             }
-            _ => Err(vortex_err!("Expected a binary scalar, found {:?}", self)),
         }
     }
 
-    pub(crate) fn as_buffer_string(&self) -> VortexResult<Option<Arc<BufferString>>> {
+    pub(crate) fn as_buffer_string(
+        &self,
+    ) -> VortexResult<Option<Arc<vortex_buffer::BufferString>>> {
+        use InnerScalarValue::*;
+
         match &self {
-            InnerScalarValue::Null => Ok(None),
-            InnerScalarValue::Buffer(b) => {
-                Ok(Some(Arc::new(BufferString::try_from(b.as_ref().clone())?)))
+            Null => Ok(None),
+            Buffer(b) => Ok(Some(Arc::new(vortex_buffer::BufferString::try_from(
+                b.as_ref().clone(),
+            )?))),
+            BufferString(b) => Ok(Some(b.clone())),
+            Bool(_) | Primitive(_) | Decimal(_) | List(_) => {
+                Err(vortex_err!("Expected a string scalar, found {:?}", self))
             }
-            InnerScalarValue::BufferString(b) => Ok(Some(b.clone())),
-            _ => Err(vortex_err!("Expected a string scalar, found {:?}", self)),
         }
     }
 
     pub(crate) fn as_list(&self) -> VortexResult<Option<&Arc<[ScalarValue]>>> {
+        use InnerScalarValue::*;
+
         match &self {
-            InnerScalarValue::Null => Ok(None),
-            InnerScalarValue::List(l) => Ok(Some(l)),
-            _ => Err(vortex_err!("Expected a list scalar, found {:?}", self)),
+            Null => Ok(None),
+            List(l) => Ok(Some(l)),
+            Bool(_) | Primitive(_) | Decimal(_) | Buffer(_) | BufferString(_) => {
+                Err(vortex_err!("Expected a list scalar, found {:?}", self))
+            }
         }
     }
 }


### PR DESCRIPTION
Based off of #4317, so this will remain a draft until that PR gets merged.

This PR _fully_ turns on the clippy lint `clippy::wildcard_enum_match_arm`, which prevents catch-all arms in `match` statements. You can view the docs [here](https://rust-lang.github.io/rust-clippy/master/index.html#wildcard_enum_match_arm).

If enums ever get updated (for example `DType`), catch-all arms are quite bad because the compiler won't catch if a match statement needs to be updated with the new variant.
You can opt out of this with `#[allow(clippy::wildcard_enum_match_arm)]`, or you can simply use different syntax (`if let` or `let else` or `matches!`) to avoid this.

---

The protocol I followed was basically:

- If the match statement clearly has only 1 possible "correct" arm, convert into an `if let` statement.
- If it is very obvious that a new variant will not be added that will affect how the existing match arms match, then we can use `#[allow(clippy::wildcard_enum_match_arm)]` with some comments.
  - _An example of this _not_ being the case if for `VarBinView`, where right now this matches against `Utf8` and `Binary`, but it may be possible for us to add `Utf16` of something in the future..._
- If it is a very large hassle to update the match statement, then we can use `#[allow(clippy::wildcard_enum_match_arm)]` with some comments.
- Otherwise, spell out every single enum variant instead of the catch-all arm.

In some cases where this becomes very verbose, I bring the enum variants all into the function scope `use DType::*;`. Usually this is not great, but I try to make sure that this only happens in a function scope where the variants are unambiguous.