### PR TITLE
fix(java): Spark writer properly handles string and array data

### DIFF
--- a/java/testfiles/Cargo.lock
+++ b/java/testfiles/Cargo.lock
@@ -269,6 +269,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +595,12 @@ name = "fsst-rs"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e510410999d2709546c991f25e634bb1e9050d4146f556a221d8e9bc135fc3a9"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1536,6 +1554,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,6 +1831,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "target-features"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2056,7 +2086,9 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "arrow-string",
+ "bitvec",
  "cfg-if",
+ "dyn-hash",
  "enum-iterator",
  "flatbuffers",
  "futures-util",
@@ -2196,6 +2228,7 @@ dependencies = [
  "jiff",
  "num-traits",
  "num_enum",
+ "paste",
  "prost",
  "serde",
  "static_assertions",
@@ -2245,6 +2278,7 @@ dependencies = [
  "fastlanes",
  "itertools",
  "lending-iterator",
+ "log",
  "num-traits",
  "prost",
  "vortex-array",
@@ -2884,6 +2918,15 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "yoke"

--- a/java/vortex-spark/src/main/java/dev/vortex/spark/write/VortexDataWriter.java
+++ b/java/vortex-spark/src/main/java/dev/vortex/spark/write/VortexDataWriter.java
@@ -8,6 +8,7 @@ import dev.vortex.relocated.org.apache.arrow.memory.BufferAllocator;
 import dev.vortex.relocated.org.apache.arrow.memory.RootAllocator;
 import dev.vortex.relocated.org.apache.arrow.vector.*;
 import dev.vortex.relocated.org.apache.arrow.vector.VectorSchemaRoot;
+import dev.vortex.relocated.org.apache.arrow.vector.complex.ListVector;
 import dev.vortex.relocated.org.apache.arrow.vector.ipc.ArrowStreamWriter;
 import dev.vortex.spark.SparkTypes;
 import java.io.ByteArrayOutputStream;
@@ -20,6 +21,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.SpecializedGetters;
+import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.connector.write.DataWriter;
 import org.apache.spark.sql.connector.write.WriterCommitMessage;
 import org.apache.spark.sql.types.*;
@@ -185,7 +188,8 @@ public final class VortexDataWriter implements DataWriter<InternalRow>, AutoClos
     /**
      * Populates an Arrow vector with a value from an InternalRow.
      */
-    private void populateVector(FieldVector vector, DataType dataType, InternalRow row, int fieldIndex, int rowIndex) {
+    private void populateVector(
+            FieldVector vector, DataType dataType, SpecializedGetters row, int fieldIndex, int rowIndex) {
         if (dataType instanceof BooleanType) {
             ((BitVector) vector).set(rowIndex, row.getBoolean(fieldIndex) ? 1 : 0);
         } else if (dataType instanceof ByteType) {
@@ -203,12 +207,12 @@ public final class VortexDataWriter implements DataWriter<InternalRow>, AutoClos
         } else if (dataType instanceof StringType) {
             UTF8String str = row.getUTF8String(fieldIndex);
             if (str != null) {
-                ((VarCharVector) vector).set(rowIndex, str.getBytes());
+                ((VarCharVector) vector).setSafe(rowIndex, str.getBytes());
             }
         } else if (dataType instanceof BinaryType) {
             byte[] bytes = row.getBinary(fieldIndex);
             if (bytes != null) {
-                ((VarBinaryVector) vector).set(rowIndex, bytes);
+                ((VarBinaryVector) vector).setSafe(rowIndex, bytes);
             }
         } else if (dataType instanceof DecimalType) {
             DecimalType decType = (DecimalType) dataType;
@@ -218,9 +222,19 @@ public final class VortexDataWriter implements DataWriter<InternalRow>, AutoClos
                         .toJavaBigDecimal();
                 ((DecimalVector) vector).set(rowIndex, decimal);
             }
+        } else if (dataType instanceof ArrayType) {
+            ArrayType arrayType = (ArrayType) dataType;
+            ArrayData data = row.getArray(fieldIndex);
+            ListVector listVector = ((ListVector) vector);
+            int writtenElements = listVector.getElementEndIndex(listVector.getLastSet());
+            listVector.startNewValue(rowIndex);
+            for (int i = 0; i < data.numElements(); i++) {
+                populateVector(listVector.getDataVector(), arrayType.elementType(), data, i, writtenElements + i);
+            }
+            listVector.endValue(rowIndex, data.numElements());
         } else {
             // For unsupported types, set null
-            vector.setNull(rowIndex);
+            throw new IllegalArgumentException("Unsupported data type: " + dataType);
         }
     }
 

--- a/java/vortex-spark/src/test/java/dev/vortex/spark/VortexDataSourceWriteTest.java
+++ b/java/vortex-spark/src/test/java/dev/vortex/spark/VortexDataSourceWriteTest.java
@@ -15,12 +15,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.spark.sql.*;
-import org.apache.spark.sql.api.java.UDF1;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -284,14 +282,12 @@ public final class VortexDataSourceWriteTest {
      * and their string representations.
      */
     private Dataset<Row> createTestDataFrame(int numRows) {
-        // Register UDF for integer to string conversion
-        spark.udf().register("intToString", (UDF1<Integer, String>) value -> "value_" + value, DataTypes.StringType);
-
         // Create DataFrame with monotonically increasing integers
-        Dataset<Row> df = spark.range(0, numRows)
-                .selectExpr("cast(id as int) as id", "concat('value_', cast(id as string)) as value");
-
-        return df;
+        return spark.range(0, numRows)
+                .selectExpr(
+                        "cast(id as int) as id",
+                        "concat('value_', cast(id as string)) as value",
+                        "array('Alpha', 'Bravo', 'Charlie') AS elements");
     }
 
     /**

--- a/java/vortex-spark/src/test/java/dev/vortex/spark/VortexDataSourceWriteTest.java
+++ b/java/vortex-spark/src/test/java/dev/vortex/spark/VortexDataSourceWriteTest.java
@@ -66,7 +66,7 @@ public final class VortexDataSourceWriteTest {
 
         // Verify original data
         assertEquals(numRows, originalDf.count(), "Original DataFrame should have " + numRows + " rows");
-        assertEquals(2, originalDf.columns().length, "Original DataFrame should have 2 columns");
+        assertEquals(3, originalDf.columns().length, "Original DataFrame should have 2 columns");
 
         // When: Repartition to 2 partitions and write as Vortex
         Path outputPath = tempDir.resolve("vortex_output");


### PR DESCRIPTION
We need to use setSafe() as the initial allocation might not be large enough to hold all of the string data in the InternalRow, and a realloc might be required.

Also adds support for Spark `ArrayType`, and augments the existing roundtrip writer unit test to include an `array<string>`