### PR TITLE
feat: teach VortexDataset get_fragments

### DIFF
--- a/docs/api/python/dataset.rst
+++ b/docs/api/python/dataset.rst
@@ -11,6 +11,7 @@ encodings, this property holds true even when the filter condition specifies a s
 
    ~vortex.dataset.VortexDataset
    ~vortex.dataset.VortexScanner
+   ~vortex.dataset.VortexFragment
 
 .. raw:: html
 

--- a/vortex-python/python/vortex/dataset.py
+++ b/vortex-python/python/vortex/dataset.py
@@ -90,11 +90,9 @@ class VortexDataset(pyarrow.dataset.Dataset):
         )
 
     @override
-    def get_fragments(
-        self, filter: pyarrow.dataset.Expression | Expr | None = None
-    ) -> Iterator[pyarrow.dataset.Fragment]:
-        """Not implemented."""
-        raise NotImplementedError("get_fragments")
+    def get_fragments(self, filter: pyarrow.dataset.Expression | Expr | None = None) -> Iterator[VortexFragment]:
+        """A fragment for each file in the Dataset."""
+        yield VortexFragment(self)
 
     @override
     def head(
@@ -493,6 +491,199 @@ class VortexDataset(pyarrow.dataset.Dataset):
 
 def from_url(url: str) -> VortexDataset:
     return VortexDataset(_dataset.dataset_from_url(url))
+
+
+@final
+class VortexFragment(pyarrow.dataset.Fragment):
+    """Fragment of data from a :class:`.VortexDataset`."""
+
+    def __init__(self, dataset: VortexDataset):
+        self._dataset = dataset
+
+    @property
+    @override
+    def physical_schema(self) -> pyarrow.Schema:
+        """Return the physical schema of this Fragment. This schema can be
+        different from the dataset read schema."""
+        return self._dataset.schema
+
+    @property
+    @override
+    def partition_expression(self) -> pyarrow.dataset.Expression:
+        """An Expression which evaluates to true for all data viewed by this
+        Fragment."""
+        raise NotImplementedError
+
+    @override
+    def scanner(
+        self,
+        schema: pyarrow.Schema | None = None,
+        columns: list[str] | None = None,
+        filter: pyarrow.dataset.Expression | Expr | None = None,
+        batch_size: int | None = None,
+        batch_readahead: int | None = None,
+        fragment_readahead: int | None = None,
+        fragment_scan_options: pyarrow.dataset.FragmentScanOptions | None = None,
+        use_threads: bool | None = None,
+        cache_metadata: bool = True,
+        memory_pool: pyarrow.MemoryPool | None = None,
+    ) -> pyarrow.dataset.Scanner:
+        """See :class:`vortex.dataset.VortexDataset.scanner`"""
+        if schema:
+            raise ValueError("schema is not supported")
+        return self._dataset.scanner(
+            columns=columns,
+            filter=filter,
+            batch_size=batch_size,
+            batch_readahead=batch_readahead,
+            fragment_readahead=fragment_readahead,
+            fragment_scan_options=fragment_scan_options,
+            use_threads=use_threads,
+            cache_metadata=cache_metadata,
+            memory_pool=memory_pool,
+        )
+
+    @override
+    def to_batches(
+        self,
+        columns: list[str] | None = None,
+        filter: pyarrow.dataset.Expression | Expr | None = None,
+        batch_size: int | None = None,
+        batch_readahead: int | None = None,
+        fragment_readahead: int | None = None,
+        fragment_scan_options: pyarrow.dataset.FragmentScanOptions | None = None,
+        use_threads: bool | None = None,
+        cache_metadata: bool = True,
+        memory_pool: pyarrow.MemoryPool | None = None,
+    ) -> Iterator[pyarrow.RecordBatch]:
+        """See :class:`vortex.dataset.VortexDataset.scanner`"""
+        return self._dataset.to_batches(
+            columns=columns,
+            filter=filter,
+            batch_size=batch_size,
+            batch_readahead=batch_readahead,
+            fragment_readahead=fragment_readahead,
+            fragment_scan_options=fragment_scan_options,
+            use_threads=use_threads,
+            cache_metadata=cache_metadata,
+            memory_pool=memory_pool,
+        )
+
+    @override
+    def to_table(
+        self,
+        columns: list[str] | None = None,
+        filter: pyarrow.dataset.Expression | Expr | None = None,
+        batch_size: int | None = None,
+        batch_readahead: int | None = None,
+        fragment_readahead: int | None = None,
+        fragment_scan_options: pyarrow.dataset.FragmentScanOptions | None = None,
+        use_threads: bool | None = None,
+        cache_metadata: bool = True,
+        memory_pool: pyarrow.MemoryPool | None = None,
+    ) -> pyarrow.Table:
+        """See :class:`vortex.dataset.VortexDataset.scanner`"""
+        return self._dataset.to_table(
+            columns=columns,
+            filter=filter,
+            batch_size=batch_size,
+            batch_readahead=batch_readahead,
+            fragment_readahead=fragment_readahead,
+            fragment_scan_options=fragment_scan_options,
+            use_threads=use_threads,
+            cache_metadata=cache_metadata,
+            memory_pool=memory_pool,
+        )
+
+    @override
+    def take(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+        indices: pyarrow.Array[
+            pyarrow.Int8Scalar
+            | pyarrow.Int16Scalar
+            | pyarrow.Int32Scalar
+            | pyarrow.Int64Scalar
+            | pyarrow.UInt8Scalar
+            | pyarrow.UInt16Scalar
+            | pyarrow.UInt32Scalar
+            | pyarrow.UInt64Scalar
+        ],
+        columns: list[str] | None = None,
+        filter: pyarrow.dataset.Expression | Expr | None = None,
+        batch_size: int | None = None,
+        batch_readahead: int | None = None,
+        fragment_readahead: int | None = None,
+        fragment_scan_options: pyarrow.dataset.FragmentScanOptions | None = None,
+        use_threads: bool | None = None,
+        cache_metadata: bool = True,
+        memory_pool: pyarrow.MemoryPool | None = None,
+    ) -> pyarrow.Table:
+        """See :class:`vortex.dataset.VortexDataset.scanner`"""
+        return self._dataset.take(
+            indices=indices,
+            columns=columns,
+            filter=filter,
+            batch_size=batch_size,
+            batch_readahead=batch_readahead,
+            fragment_readahead=fragment_readahead,
+            fragment_scan_options=fragment_scan_options,
+            use_threads=use_threads,
+            cache_metadata=cache_metadata,
+            memory_pool=memory_pool,
+        )
+
+    @override
+    def head(
+        self,
+        num_rows: int,
+        columns: list[str] | None = None,
+        filter: pyarrow.dataset.Expression | Expr | None = None,
+        batch_size: int | None = None,
+        batch_readahead: int | None = None,
+        fragment_readahead: int | None = None,
+        fragment_scan_options: pyarrow.dataset.FragmentScanOptions | None = None,
+        use_threads: bool | None = None,
+        cache_metadata: bool = True,
+        memory_pool: pyarrow.MemoryPool | None = None,
+    ) -> pyarrow.Table:
+        """See :class:`vortex.dataset.VortexDataset.scanner`"""
+        return self._dataset.head(
+            num_rows=num_rows,
+            columns=columns,
+            filter=filter,
+            batch_size=batch_size,
+            batch_readahead=batch_readahead,
+            fragment_readahead=fragment_readahead,
+            fragment_scan_options=fragment_scan_options,
+            use_threads=use_threads,
+            cache_metadata=cache_metadata,
+            memory_pool=memory_pool,
+        )
+
+    # regarding the ignore: https://github.com/zen-xu/pyarrow-stubs/pull/258
+    @override
+    def count_rows(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+        filter: pyarrow.dataset.Expression | Expr | None = None,
+        batch_size: int | None = None,
+        batch_readahead: int | None = None,
+        fragment_readahead: int | None = None,
+        fragment_scan_options: pyarrow.dataset.FragmentScanOptions | None = None,
+        use_threads: bool | None = None,
+        cache_metadata: bool = True,
+        memory_pool: pyarrow.MemoryPool | None = None,
+    ) -> int:
+        """See :class:`vortex.dataset.VortexDataset.scanner`"""
+        return self._dataset.count_rows(
+            filter=filter,
+            batch_size=batch_size,
+            batch_readahead=batch_readahead,
+            fragment_readahead=fragment_readahead,
+            fragment_scan_options=fragment_scan_options,
+            use_threads=use_threads,
+            cache_metadata=cache_metadata,
+            memory_pool=memory_pool,
+        )
 
 
 @final

--- a/vortex-python/test/test_dataset.py
+++ b/vortex-python/test/test_dataset.py
@@ -109,9 +109,8 @@ def test_to_record_batch_reader_with_polars(ds: pd.Dataset):
     assert pldf.schema["float"] == polars.Float64
 
 
-def test_to_record_batch_reader_with_duckdb(ds: pd.Dataset):
+def test_duckdb(ds: vx.dataset.VortexDataset):
     assert ds  # pyright cannot determine that ds is used by duckdb.execute
-
     # This would be a nice test but we do not support IsNotNull which duckdb uses
     # tbl = duckdb.execute("select * from ds where string >= '950000' and float < 975.0").arrow()
     # assert len(tbl) == 10_000
@@ -130,3 +129,75 @@ def test_to_record_batch_reader_with_duckdb(ds: pd.Dataset):
     tbl = duckdb.execute("select string as hi_mom, float as yolo from ds").arrow()
     assert len(tbl) == 1_000_000
     assert tbl.schema == pa.schema([("hi_mom", pa.utf8()), ("yolo", pa.float64())])
+
+
+def test_fragment_schema(ds: vx.dataset.VortexDataset):
+    fragments = ds.get_fragments()
+    for i, f in enumerate(fragments):
+        assert f.physical_schema == pa.schema(
+            [("bool", pa.bool_()), ("float", pa.float64()), ("index", pa.int64()), ("string", pa.string_view())]
+        ), (f, i)
+
+    assert ds.head(1).to_pylist() == [{"index": 0, "string": "0", "bool": True, "float": 0.0}]
+
+
+def test_fragment_take(ds: vx.dataset.VortexDataset):
+    fragments = list(ds.get_fragments())
+    assert len(fragments) == 1
+    f = fragments[0]
+    assert f.take(pa.array([10, 50, 1_000, 999_999])).to_pylist() == [
+        {"index": 10, "string": "10", "bool": True, "float": math.sqrt(10)},
+        {"index": 50, "string": "50", "bool": True, "float": math.sqrt(50.0)},
+        {"index": 1000, "string": "1000", "bool": True, "float": math.sqrt(1000.0)},
+        {"index": 999999, "string": "999999", "bool": False, "float": math.sqrt(999999.0)},
+    ]
+
+
+def test_fragment_to_batches(ds: vx.dataset.VortexDataset):
+    fragments = list(ds.get_fragments())
+    assert len(fragments) == 1
+    f = fragments[0]
+
+    assert sum(len(x) for x in f.to_batches(columns=["float", "bool"])) == 1_000_000
+
+    schema = pa.struct([("string", pa.string_view()), ("bool", pa.bool_())])
+
+    chunk0 = next(f.to_batches(columns=["string", "bool"]))
+    assert chunk0.to_struct_array() == pa.array(
+        [record(x, columns=["string", "bool"]) for x in range(len(chunk0))], type=schema
+    )
+
+
+@pytest.mark.parametrize("batch_size", [1234, 8192, 1 << 31])
+def test_fragment_to_batch_size(ds: vx.dataset.VortexDataset, batch_size: int):
+    fragments = list(ds.get_fragments())
+    assert len(fragments) == 1
+    f = fragments[0]
+
+    batch_sizes = [len(x) for x in f.to_batches(batch_size=batch_size)]
+    n_rows = f.count_rows()
+    if n_rows < batch_size:
+        assert batch_sizes == [n_rows]
+    if n_rows % batch_size == 0:
+        assert batch_sizes == [batch_size for _ in batch_sizes]
+    else:
+        assert batch_sizes[:-1] == [batch_size for _ in batch_sizes[:-1]]
+        assert batch_sizes[-1] == n_rows % batch_size
+
+
+def test_fragment_to_table(ds: vx.dataset.VortexDataset):
+    fragments = list(ds.get_fragments())
+    assert len(fragments) == 1
+    f = fragments[0]
+
+    tbl = f.to_table(columns=["bool", "float"], filter=pc.field("float") > 100)
+    assert tbl.slice(0, 10) == pa.Table.from_struct_array(  # pyright: ignore[reportUnknownMemberType]
+        pa.array([record(x, columns={"float", "bool"}) for x in range(10001, 10011)])
+    )
+
+    assert f.to_table(columns=["bool", "string"]).schema == pa.schema(
+        [("bool", pa.bool_()), ("string", pa.string_view())]
+    )
+    assert f.to_table(columns=["string", "bool"]).schema == pa.schema(
+        [("string", pa.string_view()), ("bool", pa.bool_())]
+    )


### PR DESCRIPTION
Since VortexDataset always represents a single file, we simply return one fragment. In the future, we could support folders of Vortex files, sub-file fragments, or both.