### PR TITLE
chore: add PyO3 environment variables

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -17,3 +17,8 @@ vx = "run -p vortex-tui --"
 # necessary for using the -Zpublish-timeout setting.
 # See https://doc.rust-lang.org/beta/cargo/reference/unstable.html#publish-timeout
 timeout = 3600
+
+# Environment variables for PyO3. Ensures reproducible builds and avoids spurious recompilations.
+[env]
+PYO3_PYTHON = { value = ".venv/bin/python", relative = true, force = true }
+PYO3_ENVIRONMENT_SIGNATURE = { value = "cpython-3.11-64bit", force = true }


### PR DESCRIPTION
This should make builds a bit more consistent.

I also believe it prevents rebuilding some things. If you change terminals or if something related to the python installation changes, PyO3 will rebuild everything that is dependent on it. Not sure how important that is in practice, but this seems like a good thing to have.