### PR TITLE
Revert "Re-open DuckDB context between iterations"

### DIFF
--- a/bench-vortex/src/benchmark_driver.rs
+++ b/bench-vortex/src/benchmark_driver.rs
@@ -188,9 +188,6 @@ fn execute_queries<B: Benchmark>(
                 let mut row_count = None;
 
                 for _ in 0..iterations {
-                    // Ensure we reopen the database to clear caches between runs.
-                    ctx.reopen()?;
-
                     let (duration, current_row_count) =
                         ctx.execute_query(query_string).unwrap_or_else(|err| {
                             vortex_panic!("query: {query_idx} failed with: {err}")

--- a/bench-vortex/src/engines/ddb/mod.rs
+++ b/bench-vortex/src/engines/ddb/mod.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
@@ -31,7 +30,6 @@ impl DuckDBObject {
 pub struct DuckDBCtx {
     pub db: Database,
     pub connection: Connection,
-    pub db_path: Option<PathBuf>,
 }
 
 impl DuckDBCtx {
@@ -53,40 +51,17 @@ impl DuckDBCtx {
         if delete_database {
             std::fs::remove_file(&db_path)?;
         }
-        let db = Database::open(&db_path)?;
+        let db = Database::open(db_path)?;
         let connection = db.connect()?;
         vortex_duckdb::register_table_functions(&connection)?;
-
-        Ok(Self {
-            db,
-            connection,
-            db_path: Some(db_path),
-        })
-    }
-
-    pub fn reopen(&mut self) -> Result<()> {
-        let mut db = match &self.db_path {
-            Some(path) => Database::open(path),
-            None => Database::open_in_memory(),
-        }?;
-        let mut connection = db.connect()?;
-        vortex_duckdb::register_table_functions(&connection)?;
-
-        std::mem::swap(&mut self.connection, &mut connection);
-        std::mem::swap(&mut self.db, &mut db);
-
-        Ok(())
+        Ok(Self { db, connection })
     }
 
     pub fn new_in_memory() -> Result<Self> {
         let db = Database::open_in_memory()?;
         let connection = db.connect()?;
         vortex_duckdb::register_table_functions(&connection)?;
-        Ok(Self {
-            db,
-            connection,
-            db_path: None,
-        })
+        Ok(Self { db, connection })
     }
 
     /// Execute DuckDB queries for benchmarks using the internal connection


### PR DESCRIPTION
Reverts vortex-data/vortex#4346

Seems to be causing segfault on TPC-H NVMe