### PR TITLE
chore: update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,19 @@
   ],
   "packageRules": [
     {
+      "matchPackageNames": [
+        "arrow{/,}**",
+        "parquet{/,}**"
+      ],
+      "enabled": false
+    },
+    {
+      "matchPackageNames": [
+        "ubuntu"
+      ],
+      "enabled": false
+    },
+    {
       "matchUpdateTypes": [
         "major",
         "minor",
@@ -35,8 +48,7 @@
       "matchPackageNames": [
         "arrow{/,}**",
         "parquet{/,}**",
-        "datafusion{/,}**",
-        "pyo3{/,}**"
+        "datafusion{/,}**"
       ]
     },
     {


### PR DESCRIPTION
- don't try to upgrade arrow/parquet except when datafusion updates
- don't try to update ubuntu container image (since we purposefully pin to 20.04 for glibc 2.31)