### PR TITLE
chore[ci]: pin nightly toolchain uses

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -2,14 +2,14 @@ name: "Setup Rust"
 description: "Toolchain setup and Initial compilation"
 
 inputs:
-  toolchain:
-    description: "optional override for the toolchain version (e.g. nightly)"
+  toolchain-file:
+    description: "optional override for the toolchain file (e.g., rust-toolchain.toml)"
     required: false
   components:
-    description: "optional override for the components to install for the step (e.g. clippy, rustfmt, miri)"
+    description: "optional override for the components to install for the step (e.g., clippy, rustfmt, miri)"
     required: false
   targets:
-    description: "optional targets override (e.g. wasm32-unknown-unknown)"
+    description: "optional targets override (e.g., wasm32-unknown-unknown)"
     required: false
 
 runs:
@@ -18,7 +18,8 @@ runs:
     - name: Rust Version
       id: rust-version
       shell: bash
-      run: echo "version=$(cat rust-toolchain.toml | grep channel | awk -F'\"' '{print $2}')" >> $GITHUB_OUTPUT
+      run: |
+        echo "version=$(cat '${{ inputs.toolchain-file || 'rust-toolchain.toml' }}' | grep channel | awk -F'\"' '{print $2}')" >> $GITHUB_OUTPUT
 
     - name: Install Mold
       uses: rui314/setup-mold@v1
@@ -28,9 +29,15 @@ runs:
       uses: dtolnay/rust-toolchain@master
       if: steps.rustup-cache.outputs.cache-hit != 'true'
       with:
-        toolchain: "${{ inputs.toolchain || steps.rust-version.outputs.version }}"
+        toolchain: "${{ steps.rust-version.outputs.version }}"
         targets: "${{inputs.targets || ''}}"
         components: "${{ inputs.components || 'clippy, rustfmt' }}"
+
+    - name: Pin Toolchain Version
+      id: pin-toolchain
+      shell: bash
+      run: |
+        rustup override set ${{ steps.rust-version.outputs.version }}
 
     - name: Rust Dependency Cache
       uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,9 +228,9 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: nightly
+          toolchain-file: rust-toolchain-nightly.toml
       - name: Rust Lint - Format
-        run: cargo +nightly fmt --all --check
+        run: cargo fmt --all --check
       - name: Rustc check
         run: cargo check --locked --all-features --all-targets
       - name: Rust Lint - Clippy All Features
@@ -292,6 +292,9 @@ jobs:
           sccache: s3
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-rust
+        with:
+          toolchain-file: rust-toolchain-nightly.toml
+          components: "rust-src, rustfmt, clippy, llvm-tools-preview"
       - name: Install grcov
         uses: taiki-e/install-action@grcov
       - name: Install nextest
@@ -301,7 +304,7 @@ jobs:
       - name: Rust Tests
         if: ${{ matrix.suite == 'tests' }}
         run: |
-          cargo +nightly nextest run --locked --workspace --all-features --no-fail-fast
+          cargo nextest run --locked --workspace --all-features --no-fail-fast
       - name: Run TPC-H
         if: ${{ matrix.suite == 'tpc-h' }}
         run: |
@@ -313,7 +316,6 @@ jobs:
           cargo run -p vortex-ffi --example hello_vortex
       - name: Generate coverage report
         run: |
-          rustup component add llvm-tools-preview
           grcov . --binary-path target/debug/ -s . -t lcov --llvm --ignore-not-existing \
             --ignore '../*' --ignore '/*' --ignore 'fuzz/*' --ignore 'bench-vortex/*' \
             --ignore 'home/*' --ignore 'xtask/*' --ignore 'target/*'\
@@ -349,8 +351,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: nightly
-          components: "rust-src, rustfmt, clippy, llvm-tools-preview"
+          toolchain-file: rust-toolchain-nightly.toml
       - name: Install nextest
         uses: taiki-e/install-action@v2
         with:
@@ -358,7 +359,7 @@ jobs:
       - name: Rust Tests
         # vortex-duckdb-ext currently fails linking for cargo test targets.
         run: |
-          cargo +nightly nextest run --locked --workspace --all-features --no-fail-fast --target x86_64-unknown-linux-gnu
+          cargo nextest run --locked --workspace --all-features --no-fail-fast --target x86_64-unknown-linux-gnu
 
   build-java:
     name: "Java"
@@ -491,13 +492,12 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: nightly-2025-06-26
+          toolchain-file: rust-toolchain-nightly.toml
           targets: "wasm32-wasip1"
           components: "rust-src"
       - name: Setup Wasmer
         uses: wasmerio/setup-wasmer@v3.1
-        # there is a compiler bug in nightly (but not in nightly-2025-06-26)
-      - run: cargo +nightly-2025-06-26 -Zbuild-std=panic_abort,std build --target wasm32-wasip1
+      - run: cargo -Zbuild-std=panic_abort,std build --target wasm32-wasip1
         working-directory: ./wasm-test
       - run: wasmer run ./target/wasm32-wasip1/debug/wasm-test.wasm
         working-directory: ./wasm-test
@@ -514,13 +514,13 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: nightly
+          toolchain-file: rust-toolchain-nightly.toml
           components: "rust-src, rustfmt, clippy, miri"
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest@0.9.98
       - name: Run Miri
-        run: cargo +nightly miri nextest run --no-fail-fast -p vortex-buffer -p vortex-ffi
+        run: cargo miri nextest run --no-fail-fast -p vortex-buffer -p vortex-ffi
 
   generated-files:
     name: "Check generated source files are up to date"
@@ -530,7 +530,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: nightly
+          toolchain-file: rust-toolchain-nightly.toml
       - uses: ./.github/actions/setup-flatc
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
@@ -542,7 +542,7 @@ jobs:
           cargo xtask generate-proto
       - name: "regenerate FFI header file"
         run: |
-          cargo +nightly build -p vortex-ffi
+          cargo build -p vortex-ffi
       - name: "Make sure no files changed after regenerating"
         run: |
           git status --porcelain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,10 +227,9 @@ jobs:
           sccache: s3
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-rust
-        with:
-          toolchain-file: rust-toolchain-nightly.toml
       - name: Rust Lint - Format
-        run: cargo fmt --all --check
+        # this is the one place where we always want latest nightly
+        run: cargo +nightly fmt --all --check
       - name: Rustc check
         run: cargo check --locked --all-features --all-targets
       - name: Rust Lint - Clippy All Features

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: nightly
+          toolchain-file: rust-toolchain-nightly.toml
       - name: Install llvm
         uses: aminya/setup-cpp@v1
         with:
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: nightly
+          toolchain-file: rust-toolchain-nightly.toml
       - name: Install llvm
         uses: aminya/setup-cpp@v1
         with:

--- a/.github/workflows/minimize_fuzz_corpus.yml
+++ b/.github/workflows/minimize_fuzz_corpus.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: nightly
+          toolchain-file: rust-toolchain-nightly.toml
       - name: Install cargo fuzz
         run: cargo install --locked cargo-fuzz
       - name: Restore corpus
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: nightly
+          toolchain-file: rust-toolchain-nightly.toml
       - name: Install cargo fuzz
         run: cargo install --locked cargo-fuzz
       - name: Restore corpus

--- a/rust-toolchain-nightly.toml
+++ b/rust-toolchain-nightly.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2025-08-07"
+components = ["rust-src", "rustfmt", "clippy", "rust-analyzer"]
+profile = "minimal"


### PR DESCRIPTION
Adds a `rust-toolchain-nightly.toml` file for CI to use where we need nightly. Figured it is cleaner & easier to maintain rather than inlining a string everywhere.

The implicit change here is that specifying this file is essentially imposing a semantic of "run the whole job as if this were `rust-toolchain.toml`", and thus overrides the toolchain for the whole job. I think that's actually less confusing than the current setup, but curious for feedback.