### PR TITLE
fix: cleanup old to_record_batch_reader

### DIFF
--- a/docs/quickstart/python.rst
+++ b/docs/quickstart/python.rst
@@ -28,22 +28,6 @@ Vortex array:
    >>> vtx.nbytes
    141024
 
-Compress
---------
-
-Use :func:`~vortex.compress` to compress the Vortex array and check the relative size:
-
-.. doctest::
-
-   >>> cvtx = vx.compress(vtx)
-   >>> cvtx.nbytes
-   14298
-   >>> cvtx.nbytes / vtx.nbytes
-   0.10...
-
-Vortex uses nearly ten times fewer bytes than Arrow. Fewer bytes means more of your data fits in
-cache and RAM.
-
 Write
 -----
 
@@ -51,7 +35,7 @@ Use :func:`~vortex.io.write` to write the Vortex array to disk:
 
 .. doctest::
 
-   >>> vortex.io.write(cvtx, "example.vortex")
+   >>> vortex.io.write(cvtx, "example.vortex") # doctest: +SKIP
 
 Small Vortex files (this one is just 71KiB) currently have substantial overhead relative to their
 size. This will be addressed shortly. On files with at least tens of megabytes of data, Vortex is
@@ -71,3 +55,17 @@ Use :func:`~vortex.open` to open and read the Vortex array from disk:
 .. doctest::
 
    >>> cvtx = vortex.open("example.vortex").scan().read_all()
+
+
+Vortex is architected to achieve fast random access, in many cases hundreds of times faster
+than what can be achieved with Parquet.
+
+If you have an external index that gives you specific rows to pull out of the Vortex file, you can skip a lot more
+IO and decoding and read just the data that is relevant to you:
+
+.. doctest::
+
+    >>> vf = vortex.open("example.vortex")
+    >>> # row indices must be ordered and unique
+    >>> result = vf.scan(indices=vortex.array([1, 2, 10])).read_all()
+    >>> assert len(result) == 3

--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -11,7 +11,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyString;
 use vortex::dtype::FieldName;
 use vortex::error::VortexResult;
-use vortex::expr::{root, select, ExprRef, SelectExpr};
+use vortex::expr::{ExprRef, SelectExpr, root, select};
 use vortex::file::{VortexFile, VortexOpenOptions};
 use vortex::iter::ArrayIteratorExt;
 use vortex::scan::SplitBy;
@@ -21,7 +21,7 @@ use crate::arrays::PyArrayRef;
 use crate::arrow::{IntoPyArrow, ToPyArrow};
 use crate::expr::PyExpr;
 use crate::object_store_urls::object_store_from_url;
-use crate::{install_module, TOKIO_RUNTIME};
+use crate::{TOKIO_RUNTIME, install_module};
 
 pub(crate) fn init(py: Python, parent: &Bound<PyModule>) -> PyResult<()> {
     let m = PyModule::new(py, "dataset")?;

--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -11,7 +11,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyString;
 use vortex::dtype::FieldName;
 use vortex::error::VortexResult;
-use vortex::expr::{ExprRef, SelectExpr, root, select};
+use vortex::expr::{root, select, ExprRef, SelectExpr};
 use vortex::file::{VortexFile, VortexOpenOptions};
 use vortex::iter::ArrayIteratorExt;
 use vortex::scan::SplitBy;
@@ -21,7 +21,7 @@ use crate::arrays::PyArrayRef;
 use crate::arrow::{IntoPyArrow, ToPyArrow};
 use crate::expr::PyExpr;
 use crate::object_store_urls::object_store_from_url;
-use crate::{TOKIO_RUNTIME, install_module};
+use crate::{install_module, TOKIO_RUNTIME};
 
 pub(crate) fn init(py: Python, parent: &Bound<PyModule>) -> PyResult<()> {
     let m = PyModule::new(py, "dataset")?;
@@ -127,25 +127,19 @@ impl PyVortexDataset {
         Ok(PyArrayRef::from(array))
     }
 
-    #[pyo3(signature = (*, columns = None, row_filter = None, indices = None, split_by = None))]
+    #[pyo3(signature = (*, columns = None, row_filter = None, split_by = None))]
     pub fn to_record_batch_reader(
         self_: PyRef<Self>,
         columns: Option<Vec<Bound<'_, PyAny>>>,
         row_filter: Option<&Bound<'_, PyExpr>>,
-        indices: Option<PyArrayRef>,
         split_by: Option<usize>,
     ) -> PyResult<PyObject> {
-        let mut scan = self_
+        let scan = self_
             .vxf
             .scan()?
             .with_projection(projection_from_python(columns)?)
             .with_some_filter(filter_from_python(row_filter))
             .with_split_by(split_by.map(SplitBy::RowCount).unwrap_or(SplitBy::Layout));
-
-        if let Some(indices) = indices.map(|i| i.inner().clone()) {
-            let indices = indices.to_primitive()?.into_buffer();
-            scan = scan.with_row_indices(indices);
-        }
 
         // TODO(ngates): should we use multi-threaded read or not?
         let schema = Arc::new(scan.dtype()?.to_arrow_schema()?);

--- a/vortex-python/test/test_dataset.py
+++ b/vortex-python/test/test_dataset.py
@@ -99,7 +99,6 @@ def test_to_table(ds: pd.Dataset):
         [("string", pa.string_view()), ("bool", pa.bool_())]
     )
 
-
 def test_to_record_batch_reader_with_polars(ds: pd.Dataset):
     pldf = polars.scan_pyarrow_dataset(ds).collect()  # pyright: ignore[reportUnknownMemberType]
     assert len(pldf) == 1_000_000

--- a/vortex-python/test/test_dataset.py
+++ b/vortex-python/test/test_dataset.py
@@ -99,6 +99,7 @@ def test_to_table(ds: pd.Dataset):
         [("string", pa.string_view()), ("bool", pa.bool_())]
     )
 
+
 def test_to_record_batch_reader_with_polars(ds: pd.Dataset):
     pldf = polars.scan_pyarrow_dataset(ds).collect()  # pyright: ignore[reportUnknownMemberType]
     assert len(pldf) == 1_000_000

--- a/vortex-python/test/test_file.py
+++ b/vortex-python/test/test_file.py
@@ -44,6 +44,12 @@ def test_scan(vxf: VortexFile):
     for _ in vxf.scan():
         pass
 
+def test_scan_with_indices(vxf: VortexFile):
+    total_rows = 0
+    for rb in vxf.scan(indices=vx.array([1, 10, 1_000, 999_999])):
+        total_rows += len(rb)
+    assert total_rows == 4
+
 
 def test_to_arrow_batch_size(vxf: VortexFile):
     assert len(list(vxf.to_arrow(batch_size=1_000_000))) == 1, "batch_size=1_000_000"

--- a/vortex-python/test/test_file.py
+++ b/vortex-python/test/test_file.py
@@ -44,6 +44,7 @@ def test_scan(vxf: VortexFile):
     for _ in vxf.scan():
         pass
 
+
 def test_scan_with_indices(vxf: VortexFile):
     total_rows = 0
     for rb in vxf.scan(indices=vx.array([1, 10, 1_000, 999_999])):


### PR DESCRIPTION
Confusing and incomplete API, instead we just expose via the `VortexFile::scan` method