### PR TITLE
Feature: Add `DType::FixedSizeList` variant

### DIFF
--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -88,6 +88,9 @@ impl CanonicalVTable<SparseVTable> for SparseVTable {
                     *nullability,
                 )
             }
+            DType::FixedSizeList(..) => {
+                unimplemented!("TODO(connor)[FixedSizeList]")
+            }
             DType::Extension(_ext_dtype) => todo!(),
         }
     }

--- a/fuzz/src/array/compare.rs
+++ b/fuzz/src/array/compare.rs
@@ -116,6 +116,7 @@ pub fn compare_canonical_array(
             )
             .into_array())
         }
+        DType::FixedSizeList(..) => unimplemented!("TODO(connor)[FixedSizeList]"),
         d @ (DType::Null | DType::Extension(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }

--- a/fuzz/src/array/filter.rs
+++ b/fuzz/src/array/filter.rs
@@ -108,6 +108,7 @@ pub fn filter_canonical_array(array: &dyn Array, filter: &[bool]) -> VortexResul
             }
             take_canonical_array_non_nullable_indices(array, indices.as_slice())
         }
+        DType::FixedSizeList(..) => unimplemented!("TODO(connor)[FixedSizeList]"),
         d @ (DType::Null | DType::Extension(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }

--- a/fuzz/src/array/search_sorted.rs
+++ b/fuzz/src/array/search_sorted.rs
@@ -124,6 +124,7 @@ pub fn search_sorted_canonical_array(
             let scalar_vals = (0..array.len()).map(|i| array.scalar_at(i)).collect_vec();
             Ok(scalar_vals.search_sorted(&scalar.cast(array.dtype())?, side))
         }
+        DType::FixedSizeList(..) => unimplemented!("TODO(connor)[FixedSizeList]"),
         d @ (DType::Null | DType::Extension(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }

--- a/fuzz/src/array/slice.rs
+++ b/fuzz/src/array/slice.rs
@@ -86,6 +86,7 @@ pub fn slice_canonical_array(
             .into_array();
             ListArray::try_new(elements, offsets, validity).map(|a| a.into_array())
         }
+        DType::FixedSizeList(..) => unimplemented!("TODO(connor)[FixedSizeList]"),
         DType::Decimal(decimal_dtype, _) => {
             let decimal_array = array.to_decimal()?;
             Ok(

--- a/fuzz/src/array/sort.rs
+++ b/fuzz/src/array/sort.rs
@@ -81,6 +81,7 @@ pub fn sort_canonical_array(array: &dyn Array) -> VortexResult<ArrayRef> {
             });
             take_canonical_array_non_nullable_indices(array, &sort_indices)
         }
+        DType::FixedSizeList(..) => unimplemented!("TODO(connor)[FixedSizeList]"),
         d @ (DType::Null | DType::Extension(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }

--- a/fuzz/src/array/take.rs
+++ b/fuzz/src/array/take.rs
@@ -124,6 +124,7 @@ pub fn take_canonical_array(
             }
             Ok(builder.finish())
         }
+        DType::FixedSizeList(..) => unimplemented!("TODO(connor)[FixedSizeList]"),
         d @ (DType::Null | DType::Extension(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }

--- a/vortex-array/src/arrays/arbitrary.rs
+++ b/vortex-array/src/arrays/arbitrary.rs
@@ -124,6 +124,9 @@ fn random_array(u: &mut Unstructured, dtype: &DType, len: Option<usize>) -> Resu
                     .into_array())
                 }
                 DType::List(ldt, n) => random_list(u, ldt, *n, chunk_len),
+                DType::FixedSizeList(..) => {
+                    unimplemented!("TODO(connor)[FixedSizeList]")
+                }
                 DType::Extension(..) => {
                     todo!("Extension arrays are not implemented")
                 }

--- a/vortex-array/src/arrays/constant/canonical.rs
+++ b/vortex-array/src/arrays/constant/canonical.rs
@@ -128,6 +128,9 @@ impl CanonicalVTable<ConstantVTable> for ConstantVTable {
                     array.len(),
                 )?)
             }
+            DType::FixedSizeList(..) => {
+                unimplemented!("TODO(connor)[FixedSizeList]")
+            }
             DType::Extension(ext_dtype) => {
                 let s = ExtScalar::try_from(scalar)?;
 

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -276,14 +276,14 @@ mod tests {
     }
 
     #[test]
-    fn test_non_null_fails() {
+    fn test_append_empty_list() {
         let dtype: Arc<DType> = Arc::new(I32.into());
         let mut builder = ListBuilder::<u32>::with_capacity(dtype.clone(), NonNullable, 0);
 
         assert!(
             builder
                 .append_value(Scalar::list_empty(dtype, NonNullable).as_list())
-                .is_err()
+                .is_ok()
         )
     }
 

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -166,6 +166,9 @@ pub fn builder_with_capacity(dtype: &DType, capacity: usize) -> Box<dyn ArrayBui
             *n,
             capacity,
         )),
+        DType::FixedSizeList(..) => {
+            unimplemented!("TODO(connor)[FixedSizeList]")
+        }
         DType::Extension(ext_dtype) => {
             Box::new(ExtensionBuilder::with_capacity(ext_dtype.clone(), capacity))
         }
@@ -247,6 +250,9 @@ pub trait ArrayBuilderExt: ArrayBuilder {
                 .downcast_mut::<ListBuilder<u64>>()
                 .ok_or_else(|| vortex_err!("Cannot append list scalar to non-list builder"))?
                 .append_value(ListScalar::try_from(scalar)?)?,
+            DType::FixedSizeList(..) => {
+                unimplemented!("TODO(connor)[FixedSizeList]")
+            }
             DType::Extension(..) => self
                 .as_any_mut()
                 .downcast_mut::<ExtensionBuilder>()

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -72,6 +72,7 @@ pub enum Canonical {
     Struct(StructArray),
     // TODO(joe): maybe this should be a ListView, however this will be annoying in spiral
     List(ListArray),
+    // TODO(connor)[FixedSizeList]
     VarBinView(VarBinViewArray),
     Extension(ExtensionArray),
 }

--- a/vortex-array/src/compute/conformance/cast.rs
+++ b/vortex-array/src/compute/conformance/cast.rs
@@ -50,6 +50,7 @@ pub fn test_cast_conformance(array: &dyn Array) {
         DType::Binary(nullability) => test_cast_from_binary(array, *nullability),
         DType::Struct(_, nullability) => test_cast_from_struct(array, *nullability),
         DType::List(_, nullability) => test_cast_from_list(array, *nullability),
+        DType::FixedSizeList(..) => unimplemented!("TODO(connor)[FixedSizeList]"),
         DType::Extension(_) => test_cast_from_extension(array),
     }
 }

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -998,6 +998,9 @@ fn test_cast_slice_consistency(array: &dyn Array) {
             };
             vec![DType::List(element_type.clone(), opposite)]
         }
+        DType::FixedSizeList(..) => {
+            unimplemented!("TODO(connor)[FixedSizeList]")
+        }
         DType::Extension(_) => vec![], // Extension types typically only cast to themselves
     };
 

--- a/vortex-datafusion/src/convert/scalars.rs
+++ b/vortex-datafusion/src/convert/scalars.rs
@@ -73,12 +73,9 @@ impl TryToDataFusion<ScalarValue> for Scalar {
                     .value()
                     .map(|b| Vec::<u8>::from(b.into_inner())),
             ),
-            DType::Struct(..) => {
-                todo!("struct scalar conversion")
-            }
-            DType::List(..) => {
-                todo!("list scalar conversion")
-            }
+            DType::Struct(..) => todo!("struct scalar conversion"),
+            DType::List(..) => todo!("list scalar conversion"),
+            DType::FixedSizeList(..) => unimplemented!("TODO(connor)[FixedSizeList]"),
             DType::Extension(ext) => {
                 let storage_scalar = self.as_extension().storage();
 

--- a/vortex-dtype/src/arbitrary.rs
+++ b/vortex-dtype/src/arbitrary.rs
@@ -18,7 +18,7 @@ impl<'a> Arbitrary<'a> for DType {
 
 fn random_dtype(u: &mut Unstructured<'_>, depth: u8) -> Result<DType> {
     const BASE_TYPE_COUNT: i32 = 5;
-    const CONTAINER_TYPE_COUNT: i32 = 2;
+    const CONTAINER_TYPE_COUNT: i32 = 2; // TODO(connor)[FixedSizeList]: Make this 3.
     let max_dtype_kind = if depth == 0 {
         BASE_TYPE_COUNT
     } else {
@@ -35,6 +35,7 @@ fn random_dtype(u: &mut Unstructured<'_>, depth: u8) -> Result<DType> {
         // container types
         6 => DType::Struct(random_struct_dtype(u, depth - 1)?, u.arbitrary()?),
         7 => DType::List(Arc::new(random_dtype(u, depth - 1)?), u.arbitrary()?),
+        // 8 => unimplemented!("TODO(connor)[FixedSizeList]"),
         // Null,
         // Extension(ExtDType, Nullability),
         _ => unreachable!("Number out of range"),

--- a/vortex-dtype/src/arrow.rs
+++ b/vortex-dtype/src/arrow.rs
@@ -126,6 +126,11 @@ impl FromArrowType<(&DataType, Nullability)> for DType {
             DataType::List(e) | DataType::LargeList(e) => {
                 DType::List(Arc::new(Self::from_arrow(e.as_ref())), nullability)
             }
+            DataType::FixedSizeList(e, size) => DType::FixedSizeList(
+                Arc::new(Self::from_arrow(e.as_ref())),
+                *size as u32,
+                nullability,
+            ),
             DataType::Struct(f) => DType::Struct(StructFields::from_arrow(f), nullability),
             DataType::Dictionary(_, value_type) => {
                 Self::from_arrow((value_type.as_ref(), nullability))
@@ -207,10 +212,17 @@ impl DType {
             // There are four kinds of lists: List (32-bit offsets), Large List (64-bit), List View
             // (32-bit), Large List View (64-bit). We cannot both guarantee zero-copy and commit to an
             // Arrow dtype because we do not how large our offsets are.
-            DType::List(l, _) => DataType::List(FieldRef::new(Field::new_list_field(
-                l.to_arrow_dtype()?,
-                l.nullability().into(),
+            DType::List(elem_dtype, _) => DataType::List(FieldRef::new(Field::new_list_field(
+                elem_dtype.to_arrow_dtype()?,
+                elem_dtype.nullability().into(),
             ))),
+            DType::FixedSizeList(elem_dtype, size, _) => DataType::FixedSizeList(
+                FieldRef::new(Field::new_list_field(
+                    elem_dtype.to_arrow_dtype()?,
+                    elem_dtype.nullability().into(),
+                )),
+                *size as i32,
+            ),
             DType::Extension(ext_dtype) => {
                 // Try and match against the known extension DTypes.
                 if is_temporal_ext_type(ext_dtype.id()) {

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -73,6 +73,15 @@ pub enum DType {
     /// lists.
     List(Arc<DType>, Nullability),
 
+    /// A logical fixed-size list type.
+    ///
+    /// This is parameterized by a `DType` that represents the element type of the inner lists, as
+    /// well as a `u32` size that determines the fixed length of each `FixedSizeList` scalar.
+    ///
+    /// This variant has not yet been implemented. Please add a comment with
+    /// `TODO(connor)[FixedSizeList]` if you need to match against `DType`.
+    FixedSizeList(Arc<DType>, u32, Nullability),
+
     /// A logical struct type.
     ///
     /// A `Struct` type is composed of an ordered list of fields, each with a corresponding name and
@@ -89,7 +98,7 @@ pub enum DType {
 const_assert_eq!(size_of::<DType>(), 16);
 
 #[cfg(target_arch = "wasm32")]
-const_assert_eq!(size_of::<DType>(), 8);
+const_assert_eq!(size_of::<DType>(), 12);
 
 impl DType {
     /// The default `DType` for bytes.
@@ -111,7 +120,8 @@ impl DType {
             | Utf8(null)
             | Binary(null)
             | Struct(_, null)
-            | List(_, null) => matches!(null, Nullability::Nullable),
+            | List(_, null)
+            | FixedSizeList(_, _, null) => matches!(null, Nullability::Nullable),
         }
     }
 
@@ -136,6 +146,7 @@ impl DType {
             Binary(_) => Binary(nullability),
             Struct(sf, _) => Struct(sf.clone(), nullability),
             List(edt, _) => List(edt.clone(), nullability),
+            FixedSizeList(edt, size, _) => FixedSizeList(edt.clone(), *size, nullability),
             Extension(ext) => Extension(Arc::new(ext.with_nullability(nullability))),
         }
     }
@@ -156,6 +167,9 @@ impl DType {
             (Utf8(_), Utf8(_)) => true,
             (Binary(_), Binary(_)) => true,
             (List(lhs_dtype, _), List(rhs_dtype, _)) => lhs_dtype.eq_ignore_nullability(rhs_dtype),
+            (FixedSizeList(lhs_dtype, lhs_size, _), FixedSizeList(rhs_dtype, rhs_size, _)) => {
+                lhs_size == rhs_size && lhs_dtype.eq_ignore_nullability(rhs_dtype)
+            }
             (Struct(lhs_dtype, _), Struct(rhs_dtype, _)) => {
                 (lhs_dtype.names() == rhs_dtype.names())
                     && (lhs_dtype
@@ -170,14 +184,9 @@ impl DType {
         }
     }
 
-    /// Check if `self` is a `StructDType`
-    pub fn is_struct(&self) -> bool {
-        matches!(self, Struct(_, _))
-    }
-
-    /// Check if `self` is a `ListDType`
-    pub fn is_list(&self) -> bool {
-        matches!(self, List(_, _))
+    /// Check if `self` is a boolean
+    pub fn is_boolean(&self) -> bool {
+        matches!(self, Bool(_))
     }
 
     /// Check if `self` is a primitive type
@@ -226,32 +235,42 @@ impl DType {
         false
     }
 
-    /// Check if `self` is a boolean
-    pub fn is_boolean(&self) -> bool {
-        matches!(self, Bool(_))
-    }
-
-    /// Check if `self` is a binary
-    pub fn is_binary(&self) -> bool {
-        matches!(self, Binary(_))
-    }
-
-    /// Check if `self` is a utf8
-    pub fn is_utf8(&self) -> bool {
-        matches!(self, Utf8(_))
-    }
-
-    /// Check if `self` is an extension type
-    pub fn is_extension(&self) -> bool {
-        matches!(self, Extension(_))
-    }
-
-    /// Check if `self` is a decimal type
+    /// Check if `self` is a [`DType::Decimal`].
     pub fn is_decimal(&self) -> bool {
         matches!(self, Decimal(..))
     }
 
-    /// Check returns the inner decimal type if the dtype is a decimal
+    /// Check if `self` is a [`DType::Utf8`]
+    pub fn is_utf8(&self) -> bool {
+        matches!(self, Utf8(_))
+    }
+
+    /// Check if `self` is a [`DType::Binary`]
+    pub fn is_binary(&self) -> bool {
+        matches!(self, Binary(_))
+    }
+
+    /// Check if `self` is a [`DType::List`].
+    pub fn is_list(&self) -> bool {
+        matches!(self, List(_, _))
+    }
+
+    /// Check if `self` is a [`DType::FixedSizeList`],
+    pub fn is_fixed_size_list(&self) -> bool {
+        matches!(self, FixedSizeList(..))
+    }
+
+    /// Check if `self` is a [`DType::Struct`]
+    pub fn is_struct(&self) -> bool {
+        matches!(self, Struct(_, _))
+    }
+
+    /// Check if `self` is a [`DType::Extension`] type
+    pub fn is_extension(&self) -> bool {
+        matches!(self, Extension(_))
+    }
+
+    /// Check returns the inner decimal type if the dtype is a [`DType::Decimal`].
     pub fn as_decimal_opt(&self) -> Option<&DecimalDType> {
         if let Decimal(decimal, _) = self {
             Some(decimal)
@@ -260,6 +279,19 @@ impl DType {
         }
     }
 
+    /// Get the inner element dtype if `self` is a [`DType::List`] or [`DType::FixedSizeList`],
+    /// otherwise returns `None`
+    pub fn as_list_element_opt(&self) -> Option<&Arc<DType>> {
+        if let List(edt, _) = self {
+            Some(edt)
+        } else if let FixedSizeList(edt, ..) = self {
+            Some(edt)
+        } else {
+            None
+        }
+    }
+
+    // TODO(connor): This should probably be named `as_struct_fieds_opt`.
     /// Get the `StructDType` if `self` is a `StructDType`, otherwise `None`
     pub fn as_struct_opt(&self) -> Option<&StructFields> {
         if let Struct(f, _) = self {
@@ -269,9 +301,9 @@ impl DType {
         }
     }
 
-    /// Get the inner dtype if `self` is a `ListDType`, otherwise `None`
-    pub fn as_list_element_opt(&self) -> Option<&Arc<DType>> {
-        if let List(s, _) = self { Some(s) } else { None }
+    /// Convenience method for creating a [`DType::List`].
+    pub fn list(dtype: impl Into<DType>, nullability: Nullability) -> Self {
+        List(Arc::new(dtype.into()), nullability)
     }
 
     /// Convenience method for creating a [`DType::Struct`].
@@ -280,11 +312,6 @@ impl DType {
         nullability: Nullability,
     ) -> Self {
         Struct(StructFields::from_iter(iter), nullability)
-    }
-
-    /// Convenience method for creating a list dtype
-    pub fn list(dtype: impl Into<DType>, nullability: Nullability) -> Self {
-        List(Arc::new(dtype.into()), nullability)
     }
 }
 
@@ -307,6 +334,7 @@ impl Display for DType {
                     .join(", "),
             ),
             List(edt, null) => write!(f, "list({edt}){null}"),
+            FixedSizeList(edt, size, null) => write!(f, "fixed_size_list({edt})[{size}]{null}"),
             Extension(ext) => write!(
                 f,
                 "ext({}, {}{}){}",

--- a/vortex-dtype/src/field.rs
+++ b/vortex-dtype/src/field.rs
@@ -22,7 +22,8 @@ use crate::{DType, FieldName};
 pub enum Field {
     /// Address a field of a [`crate::DType::Struct`].
     Name(FieldName),
-    /// Address the element type of a [`crate::DType::List`].
+    // TODO(connor): Actually make use of this variant.
+    /// Address the element type of a [`crate::DType::List`] or [`crate::DType::FixedSizeList`].
     ElementType,
 }
 

--- a/vortex-dtype/src/serde/flatbuffers/mod.rs
+++ b/vortex-dtype/src/serde/flatbuffers/mod.rs
@@ -257,6 +257,10 @@ impl WriteFlatBuffer for DType {
                 )
                 .as_union_value()
             }
+            Self::FixedSizeList(..) => {
+                // TODO(connor)[FixedSizeList]: Add a `fb::FixedSizeList` type.
+                unimplemented!("TODO(connor)[FixedSizeList]")
+            }
             Self::Extension(ext) => {
                 let id = Some(fbb.create_string(ext.id().as_ref()));
                 let storage_dtype = Some(ext.storage_dtype().write_flatbuffer(fbb));
@@ -282,6 +286,9 @@ impl WriteFlatBuffer for DType {
             Self::Binary(_) => fb::Type::Binary,
             Self::Struct(..) => fb::Type::Struct_,
             Self::List(..) => fb::Type::List,
+            Self::FixedSizeList(..) => {
+                unimplemented!("TODO(connor)[FixedSizeList]")
+            }
             Self::Extension { .. } => fb::Type::Extension,
         };
 
@@ -375,6 +382,7 @@ mod test {
             Arc::new(DType::Primitive(PType::F32, Nullability::Nullable)),
             Nullability::NonNullable,
         ));
+        // TODO(connor)[FixedSizeList]
         roundtrip_dtype(DType::Struct(
             StructFields::new(
                 ["strings", "ints"].into(),

--- a/vortex-dtype/src/serde/proto.rs
+++ b/vortex-dtype/src/serde/proto.rs
@@ -99,6 +99,10 @@ impl From<&DType> for pb::DType {
                     element_type: Some(Box::new(l.as_ref().into())),
                     nullable: (*n).into(),
                 })),
+                DType::FixedSizeList(..) => {
+                    // TODO(connor)[FixedSizeList]
+                    unimplemented!("TODO(connor)[FixedSizeList]")
+                }
                 DType::Extension(e) => DtypeType::Extension(Box::new(pb::Extension {
                     id: e.id().as_ref().into(),
                     storage_dtype: Some(Box::new(e.storage_dtype().into())),

--- a/vortex-duckdb/src/convert/dtype.rs
+++ b/vortex-duckdb/src/convert/dtype.rs
@@ -312,6 +312,9 @@ impl TryFrom<&DType> for LogicalType {
                 let element_logical_type = LogicalType::try_from(element_dtype.as_ref())?;
                 return LogicalType::list_type(element_logical_type);
             }
+            DType::FixedSizeList(..) => {
+                unimplemented!("TODO(connor)[FixedSizeList]")
+            }
             DType::Extension(ext_dtype) => {
                 if datetime::is_temporal_ext_type(ext_dtype.id()) {
                     return LogicalType::temporal_type(ext_dtype);

--- a/vortex-duckdb/src/convert/scalar.rs
+++ b/vortex-duckdb/src/convert/scalar.rs
@@ -59,7 +59,7 @@ impl ToDuckDBScalar for Scalar {
             DType::Extension(..) => self.as_extension().try_to_duckdb_scalar(),
             DType::Utf8(_) => self.as_utf8().try_to_duckdb_scalar(),
             DType::Binary(_) => self.as_binary().try_to_duckdb_scalar(),
-            DType::Struct(..) | DType::List(..) => todo!(),
+            DType::Struct(..) | DType::List(..) | DType::FixedSizeList(..) => todo!(),
         }
     }
 }
@@ -156,7 +156,7 @@ impl ToDuckDBScalar for ExtScalar<'_> {
                     vortex_err!("Cannot have a temporal time type not packed by a primitive scalar")
                 })?
                 .as_::<i64>()
-                .ok_or_else(|| vortex_err!("temporal types must be convertable to i64"))
+                .ok_or_else(|| vortex_err!("temporal types must be convertible to i64"))
         };
         match time {
             TemporalMetadata::Time(unit) => match unit {

--- a/vortex-ffi/src/dtype.rs
+++ b/vortex-ffi/src/dtype.rs
@@ -58,6 +58,9 @@ impl From<&DType> for vx_dtype_variant {
             DType::Binary(_) => vx_dtype_variant::DTYPE_BINARY,
             DType::Struct(..) => vx_dtype_variant::DTYPE_STRUCT,
             DType::List(..) => vx_dtype_variant::DTYPE_LIST,
+            DType::FixedSizeList(..) => {
+                unimplemented!("TODO(connor)[FixedSizeList]")
+            }
             DType::Extension(_) => vx_dtype_variant::DTYPE_EXTENSION,
         }
     }

--- a/vortex-jni/src/dtype.rs
+++ b/vortex-jni/src/dtype.rs
@@ -73,6 +73,9 @@ pub extern "system" fn Java_dev_vortex_jni_NativeDTypeMethods_getVariant(
         DType::Binary(_) => DTYPE_BINARY,
         DType::Struct(..) => DTYPE_STRUCT,
         DType::List(..) => DTYPE_LIST,
+        DType::FixedSizeList(..) => {
+            unimplemented!("TODO(connor)[FixedSizeList]")
+        }
         DType::Extension(_) => DTYPE_EXTENSION,
     }
 }

--- a/vortex-python/src/dtype/mod.rs
+++ b/vortex-python/src/dtype/mod.rs
@@ -106,6 +106,9 @@ impl PyDType {
             DType::Binary(..) => Self::with_subclass(py, dtype, PyBinaryDType),
             DType::Struct(..) => Self::with_subclass(py, dtype, PyStructDType),
             DType::List(..) => Self::with_subclass(py, dtype, PyListDType),
+            DType::FixedSizeList(..) => {
+                unimplemented!("TODO(connor)[FixedSizeList]")
+            }
             DType::Extension(..) => Self::with_subclass(py, dtype, PyExtensionDType),
         }
     }

--- a/vortex-python/src/python_repr.rs
+++ b/vortex-python/src/python_repr.rs
@@ -78,6 +78,13 @@ impl Display for DTypePythonRepr<'_> {
                 edt.python_repr(),
                 n.python_repr()
             ),
+            DType::FixedSizeList(edt, size, n) => write!(
+                f,
+                "fixed_size_list({}, {}, nullable={})",
+                edt.python_repr(),
+                size,
+                n.python_repr()
+            ),
             DType::Extension(ext) => {
                 write!(
                     f,

--- a/vortex-python/src/scalar/into_py.rs
+++ b/vortex-python/src/scalar/into_py.rs
@@ -53,6 +53,7 @@ impl<'py> IntoPyObject<'py> for PyVortex<&'_ Scalar> {
             DType::Binary(_) => self.0.as_binary().value().map(PyVortex).into_pyobject(py),
             DType::Struct(..) => PyVortex(self.0.as_struct()).into_pyobject(py),
             DType::List(..) => PyVortex(self.0.as_list()).into_pyobject(py),
+            DType::FixedSizeList(..) => unimplemented!("TODO(connor)[FixedSizeList]"),
             DType::Extension(_) => PyVortex(&self.0.as_extension().storage()).into_pyobject(py),
         }
     }

--- a/vortex-python/src/scalar/mod.rs
+++ b/vortex-python/src/scalar/mod.rs
@@ -102,6 +102,7 @@ impl PyScalar {
             DType::Binary(..) => Self::with_subclass(py, scalar, PyBinaryScalar),
             DType::Struct(..) => Self::with_subclass(py, scalar, PyStructScalar),
             DType::List(..) => Self::with_subclass(py, scalar, PyListScalar),
+            DType::FixedSizeList(..) => unimplemented!("TODO(connor)[FixedSizeList]"),
             DType::Extension(..) => Self::with_subclass(py, scalar, PyExtensionScalar),
         }
     }

--- a/vortex-scalar/src/arbitrary/mod.rs
+++ b/vortex-scalar/src/arbitrary/mod.rs
@@ -46,12 +46,19 @@ fn random_scalar_value(u: &mut Unstructured, dtype: &DType) -> Result<ScalarValu
         ))),
         DType::List(edt, _) => Ok(ScalarValue(InnerScalarValue::List(
             iter::from_fn(|| {
+                // Creates `Some(_)` with 1/4 probability.
                 u.arbitrary()
                     .unwrap_or(false)
                     .then(|| random_scalar_value(u, edt))
             })
             .collect::<Result<Vec<_>>>()?
             .into(),
+        ))),
+        DType::FixedSizeList(edt, size, _) => Ok(ScalarValue(InnerScalarValue::List(
+            (0..*size)
+                .map(|_| random_scalar_value(u, edt))
+                .collect::<Result<Vec<_>>>()?
+                .into(),
         ))),
         DType::Extension(..) => {
             unreachable!("Can't yet generate arbitrary scalars for ext dtype")

--- a/vortex-scalar/src/arrow/mod.rs
+++ b/vortex-scalar/src/arrow/mod.rs
@@ -104,6 +104,7 @@ impl TryFrom<&Scalar> for Arc<dyn Datum> {
             DType::List(..) => {
                 todo!("list scalar conversion")
             }
+            DType::FixedSizeList(..) => unimplemented!("TODO(connor)[FixedSizeList]"),
             DType::Extension(ext) => {
                 if is_temporal_ext_type(ext.id()) {
                     let metadata = TemporalMetadata::try_from(ext.as_ref())?;

--- a/vortex-scalar/src/display.rs
+++ b/vortex-scalar/src/display.rs
@@ -17,7 +17,7 @@ impl Display for Scalar {
             DType::Utf8(_) => write!(f, "{}", self.as_utf8()),
             DType::Binary(_) => write!(f, "{}", self.as_binary()),
             DType::Struct(..) => write!(f, "{}", self.as_struct()),
-            DType::List(..) => write!(f, "{}", self.as_list()),
+            DType::List(..) | DType::FixedSizeList(..) => write!(f, "{}", self.as_list()),
             DType::Extension(_) => write!(f, "{}", self.as_extension()),
         }
     }

--- a/vortex-scalar/src/list.rs
+++ b/vortex-scalar/src/list.rs
@@ -189,7 +189,7 @@ impl Scalar {
     pub fn list_empty(element_dtype: Arc<DType>, nullability: Nullability) -> Self {
         Self::new(
             DType::List(element_dtype, nullability),
-            ScalarValue(InnerScalarValue::Null),
+            ScalarValue(InnerScalarValue::List(vec![].into())),
         )
     }
 }
@@ -237,7 +237,7 @@ mod tests {
     #[test]
     fn test_empty_list() {
         let element_dtype = Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable));
-        let list_scalar = Scalar::list(element_dtype, vec![], Nullability::NonNullable);
+        let list_scalar = Scalar::list_empty(element_dtype, Nullability::NonNullable);
 
         let list = ListScalar::try_from(&list_scalar).unwrap();
         assert_eq!(list.len(), 0);
@@ -248,10 +248,9 @@ mod tests {
     #[test]
     fn test_null_list() {
         let element_dtype = Arc::new(DType::Primitive(PType::I32, Nullability::Nullable));
-        let list_scalar = Scalar::list_empty(element_dtype, Nullability::Nullable);
+        let null = Scalar::null(DType::List(element_dtype, Nullability::Nullable));
 
-        let list = ListScalar::try_from(&list_scalar).unwrap();
-        assert_eq!(list.len(), 0);
+        let list = ListScalar::try_from(&null).unwrap();
         assert!(list.is_empty());
         assert!(list.is_null());
     }
@@ -318,16 +317,6 @@ mod tests {
         let display = format!("{list}");
         assert!(display.contains("1"));
         assert!(display.contains("2"));
-    }
-
-    #[test]
-    fn test_null_list_display() {
-        let element_dtype = Arc::new(DType::Primitive(PType::I32, Nullability::Nullable));
-        let list_scalar = Scalar::list_empty(element_dtype, Nullability::Nullable);
-
-        let list = ListScalar::try_from(&list_scalar).unwrap();
-        let display = format!("{list}");
-        assert_eq!(display, "null");
     }
 
     #[test]
@@ -445,12 +434,12 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_conversion_null_list() {
+    fn test_vec_conversion_empty_list() {
         let element_dtype = Arc::new(DType::Primitive(PType::I32, Nullability::Nullable));
         let list_scalar = Scalar::list_empty(element_dtype, Nullability::Nullable);
 
-        let result: Result<Vec<i32>, VortexError> = Vec::try_from(&list_scalar);
-        assert!(result.is_err());
+        let result: VortexResult<Vec<i32>> = Vec::try_from(&list_scalar);
+        assert!(result.unwrap().is_empty());
     }
 
     #[test]

--- a/vortex-scalar/src/null.rs
+++ b/vortex-scalar/src/null.rs
@@ -124,20 +124,6 @@ mod tests {
     }
 
     #[test]
-    fn test_null_list() {
-        use std::sync::Arc;
-
-        use vortex_dtype::PType;
-
-        let element_dtype = Arc::new(DType::Primitive(PType::I32, Nullability::Nullable));
-        let null_list = Scalar::list_empty(element_dtype, Nullability::Nullable);
-
-        // NOTE: Unexpected behavior - TryFrom succeeds for typed null scalars
-        let result = <()>::try_from(&null_list);
-        assert!(result.is_ok());
-    }
-
-    #[test]
     fn test_null_struct() {
         use vortex_dtype::{FieldDType, StructFields};
 

--- a/vortex-scalar/src/scalar.rs
+++ b/vortex-scalar/src/scalar.rs
@@ -117,10 +117,6 @@ impl Scalar {
             }
         }
 
-        if self.dtype().eq_ignore_nullability(target) {
-            return Ok(Scalar::new(target.clone(), self.value.clone()));
-        }
-
         match &self.dtype {
             DType::Null => unreachable!(), // handled by if is_null case
             DType::Bool(_) => self.as_bool().cast(target),
@@ -130,6 +126,7 @@ impl Scalar {
             DType::Binary(_) => self.as_binary().cast(target),
             DType::Struct(..) => self.as_struct().cast(target),
             DType::List(..) => self.as_list().cast(target),
+            DType::FixedSizeList(..) => unimplemented!("TODO(connor)[FixedSizeList]"),
             DType::Extension(..) => self.as_extension().cast(target),
         }
     }
@@ -166,15 +163,17 @@ impl Scalar {
                 .fields()
                 .map(|fields| fields.into_iter().map(|f| f.nbytes()).sum::<usize>())
                 .unwrap_or_default(),
-            DType::List(_dtype, _) => self
+            DType::List(..) => self
                 .as_list()
                 .elements()
                 .map(|fields| fields.into_iter().map(|f| f.nbytes()).sum::<usize>())
                 .unwrap_or_default(),
+            DType::FixedSizeList(..) => unimplemented!("TODO(connor)[FixedSizeList]"),
             DType::Extension(_ext_dtype) => self.as_extension().storage().nbytes(),
         }
     }
 
+    // TODO(connor): This should probably take a `&DType`.
     /// Creates a "default" scalar value for the given data type.
     ///
     /// For nullable types, returns null. For non-nullable types, returns
@@ -199,7 +198,8 @@ impl Scalar {
                 let fields: Vec<_> = sf.fields().map(Scalar::default_value).collect();
                 Self::struct_(DType::Struct(sf, nullability), fields)
             }
-            DType::List(dt, nullability) => Self::list(dt, vec![], nullability),
+            DType::List(edt, nullability) => Self::list(edt, vec![], nullability),
+            DType::FixedSizeList(..) => unimplemented!("TODO(connor)[FixedSizeList]"),
             DType::Extension(dt) => {
                 let scalar = Self::default_value(dt.storage_dtype().clone());
                 Self::extension(dt, scalar)
@@ -330,7 +330,7 @@ where
     T: ScalarType,
     Scalar: From<T>,
 {
-    /// A blanket implementation for all `Option<T>`
+    /// A blanket implementation for all `Option<T>`.
     fn from(value: Option<T>) -> Self {
         value
             .map(Scalar::from)
@@ -398,6 +398,7 @@ impl PartialEq for Scalar {
             DType::Binary(_) => self.as_binary() == other.as_binary(),
             DType::Struct(..) => self.as_struct() == other.as_struct(),
             DType::List(..) => self.as_list() == other.as_list(),
+            DType::FixedSizeList(..) => unimplemented!("TODO(connor)[FixedSizeList]"),
             DType::Extension(_) => self.as_extension() == other.as_extension(),
         }
     }
@@ -447,6 +448,7 @@ impl PartialOrd for Scalar {
             DType::Binary(_) => self.as_binary().partial_cmp(&other.as_binary()),
             DType::Struct(..) => self.as_struct().partial_cmp(&other.as_struct()),
             DType::List(..) => self.as_list().partial_cmp(&other.as_list()),
+            DType::FixedSizeList(..) => unimplemented!("TODO(connor)[FixedSizeList]"),
             DType::Extension(_) => self.as_extension().partial_cmp(&other.as_extension()),
         }
     }
@@ -463,6 +465,7 @@ impl Hash for Scalar {
             DType::Binary(_) => self.as_binary().hash(state),
             DType::Struct(..) => self.as_struct().hash(state),
             DType::List(..) => self.as_list().hash(state),
+            DType::FixedSizeList(..) => unimplemented!("TODO(connor)[FixedSizeList]"),
             DType::Extension(_) => self.as_extension().hash(state),
         }
     }

--- a/vortex-scalar/src/tests/core.rs
+++ b/vortex-scalar/src/tests/core.rs
@@ -59,7 +59,76 @@ mod tests {
     }
 
     #[test]
-    fn list_casts() {
+    fn test_list_cast_element_types() {
+        // Test casting list elements between different primitive types.
+        let list = Scalar::new(
+            DType::List(
+                Arc::from(DType::Primitive(PType::U16, Nullability::Nullable)),
+                Nullability::Nullable,
+            ),
+            ScalarValue(InnerScalarValue::List(Arc::from([
+                ScalarValue(InnerScalarValue::Primitive(PValue::U16(6))),
+                ScalarValue(InnerScalarValue::Primitive(PValue::U16(100))),
+            ]))),
+        );
+
+        // Cast U16 -> U32.
+        let target_u32 = DType::List(
+            Arc::from(DType::Primitive(PType::U32, Nullability::Nullable)),
+            Nullability::Nullable,
+        );
+        let casted = list.cast(&target_u32).unwrap();
+        assert_eq!(casted.dtype(), &target_u32);
+
+        // Cast U16 -> U8 (with values that fit).
+        let target_u8 = DType::List(
+            Arc::from(DType::Primitive(PType::U8, Nullability::Nullable)),
+            Nullability::Nullable,
+        );
+        let casted = list.cast(&target_u8).unwrap();
+        assert_eq!(casted.dtype(), &target_u8);
+
+        // Cast U16 -> I32.
+        let target_i32 = DType::List(
+            Arc::from(DType::Primitive(PType::I32, Nullability::Nullable)),
+            Nullability::Nullable,
+        );
+        let casted = list.cast(&target_i32).unwrap();
+        assert_eq!(casted.dtype(), &target_i32);
+    }
+
+    #[test]
+    fn test_list_cast_element_overflow() {
+        // Test that casting U16 values too large for U8 fails.
+        let list_with_large_values = Scalar::new(
+            DType::List(
+                Arc::from(DType::Primitive(PType::U16, Nullability::Nullable)),
+                Nullability::Nullable,
+            ),
+            ScalarValue(InnerScalarValue::List(Arc::from([
+                ScalarValue(InnerScalarValue::Primitive(PValue::U16(100))),
+                ScalarValue(InnerScalarValue::Primitive(PValue::U16(256))), // Too large for U8
+                ScalarValue(InnerScalarValue::Primitive(PValue::U16(1000))), // Too large for U8
+            ]))),
+        );
+
+        let target_u8 = DType::List(
+            Arc::from(DType::Primitive(PType::U8, Nullability::Nullable)),
+            Nullability::Nullable,
+        );
+
+        let result = list_with_large_values.cast(&target_u8);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Cannot cast u16 to u8")
+        );
+    }
+
+    #[test]
+    fn test_list_cast_nullability_changes() {
         let list = Scalar::new(
             DType::List(
                 Arc::from(DType::Primitive(PType::U16, Nullability::Nullable)),
@@ -70,33 +139,75 @@ mod tests {
             )]))),
         );
 
-        let target_u32 = DType::List(
-            Arc::from(DType::Primitive(PType::U32, Nullability::Nullable)),
-            Nullability::Nullable,
-        );
-        assert_eq!(list.cast(&target_u32).unwrap().dtype(), &target_u32);
-
-        let target_u32_nonnull = DType::List(
-            Arc::from(DType::Primitive(PType::U32, Nullability::NonNullable)),
+        // Change element nullability from Nullable to NonNullable.
+        let target_elem_nonnull = DType::List(
+            Arc::from(DType::Primitive(PType::U16, Nullability::NonNullable)),
             Nullability::Nullable,
         );
         assert_eq!(
-            list.cast(&target_u32_nonnull).unwrap().dtype(),
-            &target_u32_nonnull
+            list.cast(&target_elem_nonnull).unwrap().dtype(),
+            &target_elem_nonnull
         );
 
-        let target_nonnull = DType::List(
-            Arc::from(DType::Primitive(PType::U32, Nullability::Nullable)),
+        // Change list nullability from Nullable to NonNullable.
+        let target_list_nonnull = DType::List(
+            Arc::from(DType::Primitive(PType::U16, Nullability::Nullable)),
             Nullability::NonNullable,
         );
-        assert_eq!(list.cast(&target_nonnull).unwrap().dtype(), &target_nonnull);
+        assert_eq!(
+            list.cast(&target_list_nonnull).unwrap().dtype(),
+            &target_list_nonnull
+        );
 
-        let target_u8 = DType::List(
+        // Change both element and list nullability.
+        let target_both_nonnull = DType::List(
+            Arc::from(DType::Primitive(PType::U16, Nullability::NonNullable)),
+            Nullability::NonNullable,
+        );
+        assert_eq!(
+            list.cast(&target_both_nonnull).unwrap().dtype(),
+            &target_both_nonnull
+        );
+    }
+
+    #[test]
+    fn test_list_cast_with_null_elements() {
+        let list_with_null = Scalar::new(
+            DType::List(
+                Arc::from(DType::Primitive(PType::U16, Nullability::Nullable)),
+                Nullability::Nullable,
+            ),
+            ScalarValue(InnerScalarValue::List(Arc::from([
+                ScalarValue(InnerScalarValue::Primitive(PValue::U16(6))),
+                ScalarValue(InnerScalarValue::Null),
+                ScalarValue(InnerScalarValue::Primitive(PValue::U16(10))),
+            ]))),
+        );
+
+        // Cast to different element type with nullable elements - should succeed.
+        let target_u8_nullable = DType::List(
             Arc::from(DType::Primitive(PType::U8, Nullability::Nullable)),
             Nullability::Nullable,
         );
-        assert_eq!(list.cast(&target_u8).unwrap().dtype(), &target_u8);
+        assert_eq!(
+            list_with_null.cast(&target_u8_nullable).unwrap().dtype(),
+            &target_u8_nullable
+        );
 
+        // Cast to non-nullable U16 elements should fail because we have null elements.
+        let target_u16_nonnull = DType::List(
+            Arc::from(DType::Primitive(PType::U16, Nullability::NonNullable)),
+            Nullability::Nullable,
+        );
+        let result = list_with_null.cast(&target_u16_nonnull);
+        assert!(
+            result.is_err(),
+            "Expected cast to fail when casting list with null elements to non-nullable element type"
+        );
+    }
+
+    #[test]
+    fn test_list_cast_null_to_nonnull_error() {
         let list_with_null = Scalar::new(
             DType::List(
                 Arc::from(DType::Primitive(PType::U16, Nullability::Nullable)),
@@ -107,17 +218,134 @@ mod tests {
                 ScalarValue(InnerScalarValue::Null),
             ]))),
         );
-        let target_u8 = DType::List(
-            Arc::from(DType::Primitive(PType::U8, Nullability::Nullable)),
-            Nullability::Nullable,
-        );
-        assert_eq!(list_with_null.cast(&target_u8).unwrap().dtype(), &target_u8);
 
-        let target_u32_nonnull = DType::List(
+        // Casting to non-nullable element type should fail.
+        let target_nonnull = DType::List(
             Arc::from(DType::Primitive(PType::U32, Nullability::NonNullable)),
             Nullability::Nullable,
         );
-        assert!(list_with_null.cast(&target_u32_nonnull).is_err());
+        assert!(list_with_null.cast(&target_nonnull).is_err());
+    }
+
+    #[test]
+    fn test_list_cast_nested_lists() {
+        // Create a list of lists.
+        let inner_list1 = Scalar::list(
+            Arc::from(DType::Primitive(PType::I32, Nullability::NonNullable)),
+            vec![
+                Scalar::primitive(1i32, Nullability::NonNullable),
+                Scalar::primitive(2i32, Nullability::NonNullable),
+            ],
+            Nullability::NonNullable,
+        );
+        let inner_list2 = Scalar::list(
+            Arc::from(DType::Primitive(PType::I32, Nullability::NonNullable)),
+            vec![
+                Scalar::primitive(3i32, Nullability::NonNullable),
+                Scalar::primitive(4i32, Nullability::NonNullable),
+            ],
+            Nullability::NonNullable,
+        );
+        let nested_list = Scalar::list(
+            Arc::from(DType::List(
+                Arc::from(DType::Primitive(PType::I32, Nullability::NonNullable)),
+                Nullability::NonNullable,
+            )),
+            vec![inner_list1, inner_list2],
+            Nullability::NonNullable,
+        );
+
+        // Cast to nested list with I64 elements.
+        let target = DType::List(
+            Arc::from(DType::List(
+                Arc::from(DType::Primitive(PType::I64, Nullability::NonNullable)),
+                Nullability::NonNullable,
+            )),
+            Nullability::NonNullable,
+        );
+        let casted = nested_list.cast(&target).unwrap();
+        assert_eq!(casted.dtype(), &target);
+    }
+
+    #[test]
+    fn test_list_cast_string_elements() {
+        // Create a list of strings.
+        let string_list = Scalar::list(
+            Arc::from(DType::Utf8(Nullability::NonNullable)),
+            vec![
+                Scalar::utf8("hello", Nullability::NonNullable),
+                Scalar::utf8("world", Nullability::NonNullable),
+            ],
+            Nullability::NonNullable,
+        );
+
+        // Cast to nullable strings.
+        let target = DType::List(
+            Arc::from(DType::Utf8(Nullability::Nullable)),
+            Nullability::NonNullable,
+        );
+        let casted = string_list.cast(&target).unwrap();
+        assert_eq!(casted.dtype(), &target);
+    }
+
+    #[test]
+    fn test_list_cast_struct_elements() {
+        // Create a list of structs.
+        let struct_dtype = DType::struct_(
+            [
+                ("a", DType::Primitive(PType::I32, Nullability::NonNullable)),
+                ("b", DType::Primitive(PType::I64, Nullability::NonNullable)),
+            ],
+            Nullability::NonNullable,
+        );
+        let struct1 = Scalar::struct_(
+            struct_dtype.clone(),
+            vec![
+                Scalar::primitive(1i32, Nullability::NonNullable),
+                Scalar::primitive(10i64, Nullability::NonNullable),
+            ],
+        );
+        let struct2 = Scalar::struct_(
+            struct_dtype.clone(),
+            vec![
+                Scalar::primitive(2i32, Nullability::NonNullable),
+                Scalar::primitive(20i64, Nullability::NonNullable),
+            ],
+        );
+        let struct_list = Scalar::list(
+            Arc::from(struct_dtype),
+            vec![struct1, struct2],
+            Nullability::NonNullable,
+        );
+
+        // Cast struct fields.
+        let target_struct_dtype = DType::struct_(
+            [
+                ("a", DType::Primitive(PType::I64, Nullability::NonNullable)),
+                ("b", DType::Primitive(PType::I32, Nullability::NonNullable)),
+            ],
+            Nullability::NonNullable,
+        );
+        let target = DType::List(Arc::from(target_struct_dtype), Nullability::NonNullable);
+        let casted = struct_list.cast(&target).unwrap();
+        assert_eq!(casted.dtype(), &target);
+    }
+
+    #[test]
+    fn test_list_cast_incompatible_element_types() {
+        // Create a list of integers.
+        let int_list = Scalar::list(
+            Arc::from(DType::Primitive(PType::I32, Nullability::NonNullable)),
+            vec![Scalar::primitive(1i32, Nullability::NonNullable)],
+            Nullability::NonNullable,
+        );
+
+        // Try to cast to list of strings - should fail.
+        let target = DType::List(
+            Arc::from(DType::Utf8(Nullability::NonNullable)),
+            Nullability::NonNullable,
+        );
+        assert!(int_list.cast(&target).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Tracking Issue: https://github.com/vortex-data/vortex/issues/4372

Adds the variant `DType::FixedSizeList`, but without most of the implementations. The `unimplemented!`s and `TODO(connor)[FixedSizeList]` will be fixed in later PRs.

Also fixes a bug and incorrect tests with `list_empty` in `vortex-scalar`, where creating an empty list made a null scalar.

Finally, adds some more casting tests in `vortex-scalar` (which found a bug in `vortex-scalar/src/scalar.rs` where the logic did not work for nested scalars).

(Tracking Issue incoming soon)