### PR TITLE
Pretty tree display for Vortex expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3157,6 +3157,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
+dependencies = [
+ "console 0.15.11",
+ "once_cell",
+ "similar",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5832,6 +5843,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "testing_table"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6740,12 +6757,14 @@ dependencies = [
  "arbitrary",
  "arcref",
  "dyn-hash",
+ "insta",
  "itertools 0.14.0",
  "parking_lot",
  "paste",
  "prost 0.14.1",
  "rstest",
  "serde",
+ "termtree",
  "vortex-array",
  "vortex-buffer",
  "vortex-dtype",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ half = { version = "2.6", features = ["std", "num-traits"] }
 hashbrown = "0.15.1"
 humansize = "2.1.3"
 indicatif = "0.18.0"
+insta = "1.43"
 inventory = "0.3.20"
 itertools = "0.14.0"
 jiff = "0.2.0"
@@ -179,6 +180,7 @@ take_mut = "0.2.2"
 tar = "0.4"
 target-lexicon = "0.13"
 tempfile = "3"
+termtree = { version = "0.5" }
 thiserror = "2.0.3"
 tokio = { version = "1.46" }
 tokio-stream = "0.1.17"

--- a/bench-vortex/src/datasets/struct_list_of_ints.rs
+++ b/bench-vortex/src/datasets/struct_list_of_ints.rs
@@ -39,7 +39,7 @@ impl Dataset for StructListOfInts {
 
     async fn to_vortex_array(&self) -> ArrayRef {
         let names: FieldNames = (0..self.num_columns)
-            .map(|col_idx| (col_idx.to_string()))
+            .map(|col_idx| col_idx.to_string())
             .collect();
         let mut rng = rand::rngs::StdRng::seed_from_u64(0);
 

--- a/vortex-expr/Cargo.toml
+++ b/vortex-expr/Cargo.toml
@@ -25,7 +25,7 @@ parking_lot = { workspace = true }
 paste = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
-termtree = { workspace = true, optional = true }
+termtree = { workspace = true }
 vortex-array = { workspace = true }
 vortex-buffer = { workspace = true }
 vortex-dtype = { workspace = true }
@@ -39,10 +39,9 @@ vortex-utils = { workspace = true }
 anyhow = { workspace = true }
 insta = { workspace = true }
 rstest = { workspace = true }
-vortex-expr = { path = ".", features = ["test-harness", "pretty"] }
+vortex-expr = { path = ".", features = ["test-harness"] }
 
 [features]
-pretty = ["dep:termtree"]
 arbitrary = [
     "dep:arbitrary",
     "vortex-scalar/arbitrary",

--- a/vortex-expr/Cargo.toml
+++ b/vortex-expr/Cargo.toml
@@ -25,6 +25,7 @@ parking_lot = { workspace = true }
 paste = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
+termtree = { workspace = true, optional = true }
 vortex-array = { workspace = true }
 vortex-buffer = { workspace = true }
 vortex-dtype = { workspace = true }
@@ -36,10 +37,12 @@ vortex-utils = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+insta = { workspace = true }
 rstest = { workspace = true }
-vortex-expr = { path = ".", features = ["test-harness"] }
+vortex-expr = { path = ".", features = ["test-harness", "pretty"] }
 
 [features]
+pretty = ["dep:termtree"]
 arbitrary = [
     "dep:arbitrary",
     "vortex-scalar/arbitrary",

--- a/vortex-expr/src/display.rs
+++ b/vortex-expr/src/display.rs
@@ -3,7 +3,6 @@
 
 pub enum DisplayFormat {
     Dense,
-    #[cfg(feature = "pretty")]
     Tree,
 }
 
@@ -16,10 +15,8 @@ pub trait DisplayAs {
     }
 }
 
-#[cfg(feature = "pretty")]
 pub struct DisplayTreeExpr<'a>(pub &'a dyn crate::VortexExpr);
 
-#[cfg(feature = "pretty")]
 impl std::fmt::Display for DisplayTreeExpr<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         pub use termtree::Tree;
@@ -56,10 +53,8 @@ impl std::fmt::Display for DisplayTreeExpr<'_> {
     }
 }
 
-#[cfg(feature = "pretty")]
 struct TreeNodeDisplay<'a>(&'a dyn crate::VortexExpr);
 
-#[cfg(feature = "pretty")]
 impl<'a> std::fmt::Display for TreeNodeDisplay<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt_as(DisplayFormat::Tree, f)
@@ -85,7 +80,6 @@ mod tests {
         println!("{}", expr.display_tree());
     }
 
-    #[cfg(feature = "pretty")]
     #[test]
     fn test_child_names_debug() {
         // Simple test to debug child names display
@@ -104,7 +98,6 @@ mod tests {
         println!("Between expr tree:\n{}", between_expr.display_tree());
     }
 
-    #[cfg(feature = "pretty")]
     #[test]
     fn test_display_tree() {
         use insta::assert_snapshot;

--- a/vortex-expr/src/display.rs
+++ b/vortex-expr/src/display.rs
@@ -111,14 +111,14 @@ mod tests {
 
         let get_item_expr = get_item("my_field", root());
         assert_snapshot!(get_item_expr.display_tree().to_string(), @r"
-        GetItem(field = my_field)
+        GetItem(my_field)
         └── Root
         ");
 
         let binary_expr = gt(get_item("x", root()), lit(10));
         assert_snapshot!(binary_expr.display_tree().to_string(), @r"
         Binary(>)
-        ├── lhs: GetItem(field = x)
+        ├── lhs: GetItem(x)
         │   └── Root
         └── rhs: Literal(value: 10i32, dtype: i32)
         ");
@@ -130,11 +130,11 @@ mod tests {
         assert_snapshot!(complex_binary.display_tree().to_string(), @r#"
         Binary(and)
         ├── lhs: Binary(=)
-        │   ├── lhs: GetItem(field = name)
+        │   ├── lhs: GetItem(name)
         │   │   └── Root
         │   └── rhs: Literal(value: "alice", dtype: utf8)
         └── rhs: Binary(>)
-            ├── lhs: GetItem(field = age)
+            ├── lhs: GetItem(age)
             │   └── Root
             └── rhs: Literal(value: 18i32, dtype: i32)
         "#);
@@ -157,7 +157,7 @@ mod tests {
         );
         assert_snapshot!(cast_expr.display_tree().to_string(), @r"
         Cast(target: i64)
-        └── GetItem(field = value)
+        └── GetItem(value)
             └── Root
         ");
 
@@ -165,7 +165,7 @@ mod tests {
         assert_snapshot!(not_expr.display_tree().to_string(), @r"
         Not
         └── Binary(=)
-            ├── lhs: GetItem(field = active)
+            ├── lhs: GetItem(active)
             │   └── Root
             └── rhs: Literal(value: true, dtype: bool)
         ");
@@ -181,7 +181,7 @@ mod tests {
         );
         assert_snapshot!(between_expr.display_tree().to_string(), @r"
         Between
-        ├── array: GetItem(field = score)
+        ├── array: GetItem(score)
         │   └── Root
         ├── lower (NonStrict): Literal(value: 0i32, dtype: i32)
         └── upper (NonStrict): Literal(value: 100i32, dtype: i32)
@@ -207,7 +207,7 @@ mod tests {
         Select(include): ["result"]
         └── Cast(target: bool)
             └── Between
-                ├── array: GetItem(field = score)
+                ├── array: GetItem(score)
                 │   └── Root
                 ├── lower (Strict): Literal(value: 50i32, dtype: i32)
                 └── upper (NonStrict): Literal(value: 100i32, dtype: i32)
@@ -231,7 +231,7 @@ mod tests {
             ├── bar: Literal(value: 5i32, dtype: i32)
             └── buzz: Binary(=)
                 ├── lhs: Literal(value: 42i32, dtype: i32)
-                └── rhs: GetItem(field = answer)
+                └── rhs: GetItem(answer)
                     └── Root
         "#);
     }

--- a/vortex-expr/src/display.rs
+++ b/vortex-expr/src/display.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 pub enum DisplayFormat {
-    Dense,
+    Compact,
     Tree,
 }
 

--- a/vortex-expr/src/display.rs
+++ b/vortex-expr/src/display.rs
@@ -104,23 +104,23 @@ mod tests {
 
         use crate::{pack, select_exclude};
         let root_expr = root();
-        assert_snapshot!(root_expr.display_tree().to_string(), @"RootExpr");
+        assert_snapshot!(root_expr.display_tree().to_string(), @"Root");
 
         let lit_expr = lit(42);
-        assert_snapshot!(lit_expr.display_tree().to_string(), @"LiteralExpr(value: 42i32, dtype: i32)");
+        assert_snapshot!(lit_expr.display_tree().to_string(), @"Literal(value: 42i32, dtype: i32)");
 
         let get_item_expr = get_item("my_field", root());
         assert_snapshot!(get_item_expr.display_tree().to_string(), @r"
-        GetItemExpr(field = my_field)
-        └── RootExpr
+        GetItem(field = my_field)
+        └── Root
         ");
 
         let binary_expr = gt(get_item("x", root()), lit(10));
         assert_snapshot!(binary_expr.display_tree().to_string(), @r"
-        BinaryExpr(>)
-        ├── lhs: GetItemExpr(field = x)
-        │   └── RootExpr
-        └── rhs: LiteralExpr(value: 10i32, dtype: i32)
+        Binary(>)
+        ├── lhs: GetItem(field = x)
+        │   └── Root
+        └── rhs: Literal(value: 10i32, dtype: i32)
         ");
 
         let complex_binary = and(
@@ -128,27 +128,27 @@ mod tests {
             gt(get_item("age", root()), lit(18)),
         );
         assert_snapshot!(complex_binary.display_tree().to_string(), @r#"
-        BinaryExpr(and)
-        ├── lhs: BinaryExpr(=)
-        │   ├── lhs: GetItemExpr(field = name)
-        │   │   └── RootExpr
-        │   └── rhs: LiteralExpr(value: "alice", dtype: utf8)
-        └── rhs: BinaryExpr(>)
-            ├── lhs: GetItemExpr(field = age)
-            │   └── RootExpr
-            └── rhs: LiteralExpr(value: 18i32, dtype: i32)
+        Binary(and)
+        ├── lhs: Binary(=)
+        │   ├── lhs: GetItem(field = name)
+        │   │   └── Root
+        │   └── rhs: Literal(value: "alice", dtype: utf8)
+        └── rhs: Binary(>)
+            ├── lhs: GetItem(field = age)
+            │   └── Root
+            └── rhs: Literal(value: 18i32, dtype: i32)
         "#);
 
         let select_expr = select(["name", "age"], root());
         assert_snapshot!(select_expr.display_tree().to_string(), @r#"
-        SelectExpr(include): ["name", "age"]
-        └── RootExpr
+        Select(include): ["name", "age"]
+        └── Root
         "#);
 
         let select_exclude_expr = select_exclude(["internal_id", "metadata"], root());
         assert_snapshot!(select_exclude_expr.display_tree().to_string(), @r#"
-        SelectExpr(exclude): ["internal_id", "metadata"]
-        └── RootExpr
+        Select(exclude): ["internal_id", "metadata"]
+        └── Root
         "#);
 
         let cast_expr = cast(
@@ -156,18 +156,18 @@ mod tests {
             DType::Primitive(PType::I64, Nullability::NonNullable),
         );
         assert_snapshot!(cast_expr.display_tree().to_string(), @r"
-        CastExpr(target: i64)
-        └── GetItemExpr(field = value)
-            └── RootExpr
+        Cast(target: i64)
+        └── GetItem(field = value)
+            └── Root
         ");
 
         let not_expr = not(eq(get_item("active", root()), lit(true)));
         assert_snapshot!(not_expr.display_tree().to_string(), @r"
-        NotExpr
-        └── BinaryExpr(=)
-            ├── lhs: GetItemExpr(field = active)
-            │   └── RootExpr
-            └── rhs: LiteralExpr(value: true, dtype: bool)
+        Not
+        └── Binary(=)
+            ├── lhs: GetItem(field = active)
+            │   └── Root
+            └── rhs: Literal(value: true, dtype: bool)
         ");
 
         let between_expr = between(
@@ -180,11 +180,11 @@ mod tests {
             },
         );
         assert_snapshot!(between_expr.display_tree().to_string(), @r"
-        BetweenExpr
-        ├── array: GetItemExpr(field = score)
-        │   └── RootExpr
-        ├── lower (NonStrict): LiteralExpr(value: 0i32, dtype: i32)
-        └── upper (NonStrict): LiteralExpr(value: 100i32, dtype: i32)
+        Between
+        ├── array: GetItem(field = score)
+        │   └── Root
+        ├── lower (NonStrict): Literal(value: 0i32, dtype: i32)
+        └── upper (NonStrict): Literal(value: 100i32, dtype: i32)
         ");
 
         // Test nested expression
@@ -204,13 +204,13 @@ mod tests {
             ),
         );
         assert_snapshot!(nested_expr.display_tree().to_string(), @r#"
-        SelectExpr(include): ["result"]
-        └── CastExpr(target: bool)
-            └── BetweenExpr
-                ├── array: GetItemExpr(field = score)
-                │   └── RootExpr
-                ├── lower (Strict): LiteralExpr(value: 50i32, dtype: i32)
-                └── upper (NonStrict): LiteralExpr(value: 100i32, dtype: i32)
+        Select(include): ["result"]
+        └── Cast(target: bool)
+            └── Between
+                ├── array: GetItem(field = score)
+                │   └── Root
+                ├── lower (Strict): Literal(value: 50i32, dtype: i32)
+                └── upper (NonStrict): Literal(value: 100i32, dtype: i32)
         "#);
 
         let select_from_pack_expr = select(
@@ -225,14 +225,14 @@ mod tests {
             ),
         );
         assert_snapshot!(select_from_pack_expr.display_tree().to_string(), @r#"
-        SelectExpr(include): ["fizz", "buzz"]
-        └── PackExpr
-            ├── fizz: RootExpr
-            ├── bar: LiteralExpr(value: 5i32, dtype: i32)
-            └── buzz: BinaryExpr(=)
-                ├── lhs: LiteralExpr(value: 42i32, dtype: i32)
-                └── rhs: GetItemExpr(field = answer)
-                    └── RootExpr
+        Select(include): ["fizz", "buzz"]
+        └── Pack
+            ├── fizz: Root
+            ├── bar: Literal(value: 5i32, dtype: i32)
+            └── buzz: Binary(=)
+                ├── lhs: Literal(value: 42i32, dtype: i32)
+                └── rhs: GetItem(field = answer)
+                    └── Root
         "#);
     }
 }

--- a/vortex-expr/src/display.rs
+++ b/vortex-expr/src/display.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use crate::VortexExpr;
-
 pub enum DisplayFormat {
     Dense,
     #[cfg(feature = "pretty")]
@@ -19,13 +17,13 @@ pub trait DisplayAs {
 }
 
 #[cfg(feature = "pretty")]
-pub struct DisplayTreeExpr<'a>(pub &'a dyn VortexExpr);
+pub struct DisplayTreeExpr<'a>(pub &'a dyn crate::VortexExpr);
 
 #[cfg(feature = "pretty")]
 impl std::fmt::Display for DisplayTreeExpr<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         pub use termtree::Tree;
-        fn make_tree(expr: &dyn VortexExpr) -> Result<Tree<String>, std::fmt::Error> {
+        fn make_tree(expr: &dyn crate::VortexExpr) -> Result<Tree<String>, std::fmt::Error> {
             let node_name = TreeNodeDisplay(expr).to_string();
 
             // Get child names for display purposes
@@ -59,7 +57,7 @@ impl std::fmt::Display for DisplayTreeExpr<'_> {
 }
 
 #[cfg(feature = "pretty")]
-struct TreeNodeDisplay<'a>(&'a dyn VortexExpr);
+struct TreeNodeDisplay<'a>(&'a dyn crate::VortexExpr);
 
 #[cfg(feature = "pretty")]
 impl<'a> std::fmt::Display for TreeNodeDisplay<'a> {

--- a/vortex-expr/src/display.rs
+++ b/vortex-expr/src/display.rs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use crate::VortexExpr;
+
+pub enum DisplayFormat {
+    Dense,
+    #[cfg(feature = "pretty")]
+    Tree,
+}
+
+/// Configurable display trait for expressions.
+pub trait DisplayAs {
+    fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result;
+
+    fn child_names(&self) -> Option<Vec<String>> {
+        None
+    }
+}
+
+#[cfg(feature = "pretty")]
+pub struct DisplayTreeExpr<'a>(pub &'a dyn VortexExpr);
+
+#[cfg(feature = "pretty")]
+impl std::fmt::Display for DisplayTreeExpr<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        pub use termtree::Tree;
+        fn make_tree(expr: &dyn VortexExpr) -> Result<Tree<String>, std::fmt::Error> {
+            let node_name = TreeNodeDisplay(expr).to_string();
+
+            // Get child names for display purposes
+            let child_names = DisplayAs::child_names(expr);
+            let children = expr.children();
+
+            let child_trees: Result<Vec<Tree<String>>, _> = if let Some(names) = child_names
+                && names.len() == children.len()
+            {
+                children
+                    .iter()
+                    .zip(names.iter())
+                    .map(|(child, name)| {
+                        let child_tree = make_tree(child.as_ref())?;
+                        Ok(Tree::new(format!("{}: {}", name, child_tree.root))
+                            .with_leaves(child_tree.leaves))
+                    })
+                    .collect()
+            } else {
+                children
+                    .iter()
+                    .map(|child| make_tree(child.as_ref()))
+                    .collect()
+            };
+
+            Ok(Tree::new(node_name).with_leaves(child_trees?))
+        }
+
+        write!(f, "{}", make_tree(self.0)?)
+    }
+}
+
+#[cfg(feature = "pretty")]
+struct TreeNodeDisplay<'a>(&'a dyn VortexExpr);
+
+#[cfg(feature = "pretty")]
+impl<'a> std::fmt::Display for TreeNodeDisplay<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt_as(DisplayFormat::Tree, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_array::compute::{BetweenOptions, StrictComparison};
+    use vortex_dtype::{DType, Nullability, PType};
+
+    use crate::{and, between, cast, eq, get_item, gt, lit, not, root, select};
+
+    #[test]
+    fn tree_display_getitem() {
+        let expr = get_item("x", root());
+        println!("{}", expr.display_tree());
+    }
+
+    #[test]
+    fn tree_display_binary() {
+        let expr = gt(get_item("x", root()), lit(5));
+        println!("{}", expr.display_tree());
+    }
+
+    #[cfg(feature = "pretty")]
+    #[test]
+    fn test_child_names_debug() {
+        // Simple test to debug child names display
+        let binary_expr = gt(get_item("x", root()), lit(10));
+        println!("Binary expr tree:\n{}", binary_expr.display_tree());
+
+        let between_expr = between(
+            get_item("score", root()),
+            lit(0),
+            lit(100),
+            BetweenOptions {
+                lower_strict: StrictComparison::NonStrict,
+                upper_strict: StrictComparison::NonStrict,
+            },
+        );
+        println!("Between expr tree:\n{}", between_expr.display_tree());
+    }
+
+    #[cfg(feature = "pretty")]
+    #[test]
+    fn test_display_tree() {
+        use insta::assert_snapshot;
+
+        use crate::select_exclude;
+        let root_expr = root();
+        assert_snapshot!(root_expr.display_tree().to_string(), @"RootExpr");
+
+        let lit_expr = lit(42);
+        assert_snapshot!(lit_expr.display_tree().to_string(), @"LiteralExpr(value: 42i32, dtype: i32)");
+
+        let get_item_expr = get_item("my_field", root());
+        assert_snapshot!(get_item_expr.display_tree().to_string(), @r"
+        GetItemExpr(field = my_field)
+        └── RootExpr
+        ");
+
+        let binary_expr = gt(get_item("x", root()), lit(10));
+        assert_snapshot!(binary_expr.display_tree().to_string(), @r"
+        BinaryExpr(>)
+        ├── lhs: GetItemExpr(field = x)
+        │   └── RootExpr
+        └── rhs: LiteralExpr(value: 10i32, dtype: i32)
+        ");
+
+        let complex_binary = and(
+            eq(get_item("name", root()), lit("alice")),
+            gt(get_item("age", root()), lit(18)),
+        );
+        assert_snapshot!(complex_binary.display_tree().to_string(), @r#"
+        BinaryExpr(and)
+        ├── lhs: BinaryExpr(=)
+        │   ├── lhs: GetItemExpr(field = name)
+        │   │   └── RootExpr
+        │   └── rhs: LiteralExpr(value: "alice", dtype: utf8)
+        └── rhs: BinaryExpr(>)
+            ├── lhs: GetItemExpr(field = age)
+            │   └── RootExpr
+            └── rhs: LiteralExpr(value: 18i32, dtype: i32)
+        "#);
+
+        let select_expr = select(["name", "age"], root());
+        assert_snapshot!(select_expr.display_tree().to_string(), @r#"
+        SelectExpr(include): ["name", "age"]
+        └── RootExpr
+        "#);
+
+        let select_exclude_expr = select_exclude(["internal_id", "metadata"], root());
+        assert_snapshot!(select_exclude_expr.display_tree().to_string(), @r#"
+        SelectExpr(exclude): ["internal_id", "metadata"]
+        └── RootExpr
+        "#);
+
+        let cast_expr = cast(
+            get_item("value", root()),
+            DType::Primitive(PType::I64, Nullability::NonNullable),
+        );
+        assert_snapshot!(cast_expr.display_tree().to_string(), @r"
+        CastExpr(target: i64)
+        └── GetItemExpr(field = value)
+            └── RootExpr
+        ");
+
+        let not_expr = not(eq(get_item("active", root()), lit(true)));
+        assert_snapshot!(not_expr.display_tree().to_string(), @r"
+        NotExpr
+        └── BinaryExpr(=)
+            ├── lhs: GetItemExpr(field = active)
+            │   └── RootExpr
+            └── rhs: LiteralExpr(value: true, dtype: bool)
+        ");
+
+        let between_expr = between(
+            get_item("score", root()),
+            lit(0),
+            lit(100),
+            BetweenOptions {
+                lower_strict: StrictComparison::NonStrict,
+                upper_strict: StrictComparison::NonStrict,
+            },
+        );
+        assert_snapshot!(between_expr.display_tree().to_string(), @r"
+        BetweenExpr
+        ├── array: GetItemExpr(field = score)
+        │   └── RootExpr
+        ├── lower (NonStrict): LiteralExpr(value: 0i32, dtype: i32)
+        └── upper (NonStrict): LiteralExpr(value: 100i32, dtype: i32)
+        ");
+
+        // Test nested expression
+        let nested_expr = select(
+            ["result"],
+            cast(
+                between(
+                    get_item("score", root()),
+                    lit(50),
+                    lit(100),
+                    BetweenOptions {
+                        lower_strict: StrictComparison::Strict,
+                        upper_strict: StrictComparison::NonStrict,
+                    },
+                ),
+                DType::Bool(Nullability::NonNullable),
+            ),
+        );
+        assert_snapshot!(nested_expr.display_tree().to_string(), @r#"
+        SelectExpr(include): ["result"]
+        └── CastExpr(target: bool)
+            └── BetweenExpr
+                ├── array: GetItemExpr(field = score)
+                │   └── RootExpr
+                ├── lower (Strict): LiteralExpr(value: 50i32, dtype: i32)
+                └── upper (NonStrict): LiteralExpr(value: 100i32, dtype: i32)
+        "#);
+    }
+}

--- a/vortex-expr/src/display.rs
+++ b/vortex-expr/src/display.rs
@@ -109,7 +109,7 @@ mod tests {
     fn test_display_tree() {
         use insta::assert_snapshot;
 
-        use crate::select_exclude;
+        use crate::{pack, select_exclude};
         let root_expr = root();
         assert_snapshot!(root_expr.display_tree().to_string(), @"RootExpr");
 
@@ -218,6 +218,28 @@ mod tests {
                 │   └── RootExpr
                 ├── lower (Strict): LiteralExpr(value: 50i32, dtype: i32)
                 └── upper (NonStrict): LiteralExpr(value: 100i32, dtype: i32)
+        "#);
+
+        let select_from_pack_expr = select(
+            ["fizz", "buzz"],
+            pack(
+                [
+                    ("fizz", root()),
+                    ("bar", lit(5)),
+                    ("buzz", eq(lit(42), get_item("answer", root()))),
+                ],
+                Nullability::Nullable,
+            ),
+        );
+        assert_snapshot!(select_from_pack_expr.display_tree().to_string(), @r#"
+        SelectExpr(include): ["fizz", "buzz"]
+        └── PackExpr
+            ├── fizz: RootExpr
+            ├── bar: LiteralExpr(value: 5i32, dtype: i32)
+            └── buzz: BinaryExpr(=)
+                ├── lhs: LiteralExpr(value: 42i32, dtype: i32)
+                └── rhs: GetItemExpr(field = answer)
+                    └── RootExpr
         "#);
     }
 }

--- a/vortex-expr/src/exprs/between.rs
+++ b/vortex-expr/src/exprs/between.rs
@@ -177,7 +177,7 @@ impl DisplayAs for BetweenExpr {
                 )
             }
             DisplayFormat::Tree => {
-                write!(f, "BetweenExpr")
+                write!(f, "Between")
             }
         }
     }

--- a/vortex-expr/src/exprs/between.rs
+++ b/vortex-expr/src/exprs/between.rs
@@ -10,6 +10,7 @@ use vortex_dtype::DType::Bool;
 use vortex_error::{VortexResult, vortex_bail};
 use vortex_proto::expr as pb;
 
+use crate::display::{DisplayAs, DisplayFormat};
 use crate::{
     AnalysisExpr, BinaryExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTable, vtable,
 };
@@ -163,15 +164,38 @@ impl BetweenExpr {
 
 impl Display for BetweenExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "({} {} {} {} {})",
-            self.lower,
-            self.options.lower_strict.to_operator(),
-            self.arr,
-            self.options.upper_strict.to_operator(),
-            self.upper
-        )
+        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
+    }
+}
+
+impl DisplayAs for BetweenExpr {
+    fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match df {
+            DisplayFormat::Dense => {
+                write!(
+                    f,
+                    "({} {} {} {} {})",
+                    self.lower,
+                    self.options.lower_strict.to_operator(),
+                    self.arr,
+                    self.options.upper_strict.to_operator(),
+                    self.upper
+                )
+            }
+            #[cfg(feature = "pretty")]
+            DisplayFormat::Tree => {
+                write!(f, "BetweenExpr")
+            }
+        }
+    }
+
+    fn child_names(&self) -> Option<Vec<String>> {
+        // Children are: arr, lower, upper (based on the order in the children() method)
+        Some(vec![
+            "array".to_string(),
+            format!("lower ({:?})", self.options.lower_strict),
+            format!("upper ({:?})", self.options.upper_strict),
+        ])
     }
 }
 
@@ -194,4 +218,36 @@ impl AnalysisExpr for BetweenExpr {}
 /// ```
 pub fn between(arr: ExprRef, lower: ExprRef, upper: ExprRef, options: BetweenOptions) -> ExprRef {
     BetweenExpr::new(arr, lower, upper, options).into_expr()
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_array::compute::{BetweenOptions, StrictComparison};
+
+    use crate::{between, get_item, lit, root};
+
+    #[test]
+    fn test_display() {
+        let expr = between(
+            get_item("score", root()),
+            lit(10),
+            lit(50),
+            BetweenOptions {
+                lower_strict: StrictComparison::NonStrict,
+                upper_strict: StrictComparison::Strict,
+            },
+        );
+        assert_eq!(expr.to_string(), "(10i32 <= $.score < 50i32)");
+
+        let expr2 = between(
+            root(),
+            lit(0),
+            lit(100),
+            BetweenOptions {
+                lower_strict: StrictComparison::Strict,
+                upper_strict: StrictComparison::NonStrict,
+            },
+        );
+        assert_eq!(expr2.to_string(), "(0i32 < $ <= 100i32)");
+    }
 }

--- a/vortex-expr/src/exprs/between.rs
+++ b/vortex-expr/src/exprs/between.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 
 use vortex_array::compute::{BetweenOptions, StrictComparison, between as between_compute};
 use vortex_array::{ArrayRef, DeserializeMetadata, ProstMetadata};
@@ -162,12 +162,6 @@ impl BetweenExpr {
     }
 }
 
-impl Display for BetweenExpr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
-    }
-}
-
 impl DisplayAs for BetweenExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
@@ -182,7 +176,6 @@ impl DisplayAs for BetweenExpr {
                     self.upper
                 )
             }
-            #[cfg(feature = "pretty")]
             DisplayFormat::Tree => {
                 write!(f, "BetweenExpr")
             }

--- a/vortex-expr/src/exprs/between.rs
+++ b/vortex-expr/src/exprs/between.rs
@@ -165,7 +165,7 @@ impl BetweenExpr {
 impl DisplayAs for BetweenExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
-            DisplayFormat::Dense => {
+            DisplayFormat::Compact => {
                 write!(
                     f,
                     "({} {} {} {} {})",

--- a/vortex-expr/src/exprs/binary.rs
+++ b/vortex-expr/src/exprs/binary.rs
@@ -10,6 +10,7 @@ use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_bail};
 use vortex_proto::expr as pb;
 
+use crate::display::{DisplayAs, DisplayFormat};
 use crate::{
     AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Operator, Scope, StatsCatalog,
     VTable, lit, vtable,
@@ -133,7 +134,25 @@ impl BinaryExpr {
 
 impl Display for BinaryExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "({} {} {})", self.lhs, self.operator, self.rhs)
+        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
+    }
+}
+
+impl DisplayAs for BinaryExpr {
+    fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match df {
+            DisplayFormat::Dense => {
+                write!(f, "({} {} {})", self.lhs, self.operator, self.rhs)
+            }
+            #[cfg(feature = "pretty")]
+            DisplayFormat::Tree => {
+                write!(f, "BinaryExpr({})", self.operator)
+            }
+        }
+    }
+
+    fn child_names(&self) -> Option<Vec<String>> {
+        Some(vec!["lhs".to_string(), "rhs".to_string()])
     }
 }
 

--- a/vortex-expr/src/exprs/binary.rs
+++ b/vortex-expr/src/exprs/binary.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::fmt::Display;
 use std::hash::Hash;
 
 use vortex_array::compute::{Operator as ArrayOperator, add, and_kleene, compare, or_kleene, sub};
@@ -132,19 +131,12 @@ impl BinaryExpr {
     }
 }
 
-impl Display for BinaryExpr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
-    }
-}
-
 impl DisplayAs for BinaryExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
             DisplayFormat::Dense => {
                 write!(f, "({} {} {})", self.lhs, self.operator, self.rhs)
             }
-            #[cfg(feature = "pretty")]
             DisplayFormat::Tree => {
                 write!(f, "BinaryExpr({})", self.operator)
             }

--- a/vortex-expr/src/exprs/binary.rs
+++ b/vortex-expr/src/exprs/binary.rs
@@ -138,7 +138,7 @@ impl DisplayAs for BinaryExpr {
                 write!(f, "({} {} {})", self.lhs, self.operator, self.rhs)
             }
             DisplayFormat::Tree => {
-                write!(f, "BinaryExpr({})", self.operator)
+                write!(f, "Binary({})", self.operator)
             }
         }
     }

--- a/vortex-expr/src/exprs/binary.rs
+++ b/vortex-expr/src/exprs/binary.rs
@@ -134,7 +134,7 @@ impl BinaryExpr {
 impl DisplayAs for BinaryExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
-            DisplayFormat::Dense => {
+            DisplayFormat::Compact => {
                 write!(f, "({} {} {})", self.lhs, self.operator, self.rhs)
             }
             DisplayFormat::Tree => {

--- a/vortex-expr/src/exprs/cast.rs
+++ b/vortex-expr/src/exprs/cast.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-
 use vortex_array::compute::cast as compute_cast;
 use vortex_array::{ArrayRef, DeserializeMetadata, ProstMetadata};
 use vortex_dtype::DType;

--- a/vortex-expr/src/exprs/cast.rs
+++ b/vortex-expr/src/exprs/cast.rs
@@ -102,7 +102,7 @@ impl CastExpr {
 impl DisplayAs for CastExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
-            DisplayFormat::Dense => {
+            DisplayFormat::Compact => {
                 write!(f, "cast({}, {})", self.child, self.target)
             }
             DisplayFormat::Tree => {

--- a/vortex-expr/src/exprs/cast.rs
+++ b/vortex-expr/src/exprs/cast.rs
@@ -106,7 +106,7 @@ impl DisplayAs for CastExpr {
                 write!(f, "cast({}, {})", self.child, self.target)
             }
             DisplayFormat::Tree => {
-                write!(f, "CastExpr(target: {})", self.target)
+                write!(f, "Cast(target: {})", self.target)
             }
         }
     }

--- a/vortex-expr/src/exprs/cast.rs
+++ b/vortex-expr/src/exprs/cast.rs
@@ -9,6 +9,7 @@ use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_bail, vortex_err};
 use vortex_proto::expr as pb;
 
+use crate::display::{DisplayAs, DisplayFormat};
 use crate::{AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTable, vtable};
 
 vtable!(Cast);
@@ -102,7 +103,21 @@ impl CastExpr {
 
 impl Display for CastExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "cast({}, {})", self.child, self.target)
+        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
+    }
+}
+
+impl DisplayAs for CastExpr {
+    fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match df {
+            DisplayFormat::Dense => {
+                write!(f, "cast({}, {})", self.child, self.target)
+            }
+            #[cfg(feature = "pretty")]
+            DisplayFormat::Tree => {
+                write!(f, "CastExpr(target: {})", self.target)
+            }
+        }
     }
 }
 
@@ -166,5 +181,17 @@ mod tests {
             result.dtype(),
             &DType::Primitive(PType::I64, Nullability::NonNullable)
         );
+    }
+
+    #[test]
+    fn test_display() {
+        let expr = cast(
+            get_item("value", root()),
+            DType::Primitive(PType::I64, Nullability::NonNullable),
+        );
+        assert_eq!(expr.to_string(), "cast($.value, i64)");
+
+        let expr2 = cast(root(), DType::Bool(Nullability::Nullable));
+        assert_eq!(expr2.to_string(), "cast($, bool?)");
     }
 }

--- a/vortex-expr/src/exprs/cast.rs
+++ b/vortex-expr/src/exprs/cast.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::fmt::Display;
 
 use vortex_array::compute::cast as compute_cast;
 use vortex_array::{ArrayRef, DeserializeMetadata, ProstMetadata};
@@ -101,19 +100,12 @@ impl CastExpr {
     }
 }
 
-impl Display for CastExpr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
-    }
-}
-
 impl DisplayAs for CastExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
             DisplayFormat::Dense => {
                 write!(f, "cast({}, {})", self.child, self.target)
             }
-            #[cfg(feature = "pretty")]
             DisplayFormat::Tree => {
                 write!(f, "CastExpr(target: {})", self.target)
             }

--- a/vortex-expr/src/exprs/dynamic.rs
+++ b/vortex-expr/src/exprs/dynamic.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
@@ -171,12 +171,6 @@ impl DynamicComparisonExpr {
     }
 }
 
-impl Display for DynamicComparisonExpr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
-    }
-}
-
 impl DisplayAs for DynamicComparisonExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
@@ -187,7 +181,6 @@ impl DisplayAs for DynamicComparisonExpr {
                     &self.lhs, self.operator, &self.rhs.dtype,
                 )
             }
-            #[cfg(feature = "pretty")]
             DisplayFormat::Tree => {
                 write!(f, "DynamicComparisonExpr")
             }

--- a/vortex-expr/src/exprs/dynamic.rs
+++ b/vortex-expr/src/exprs/dynamic.rs
@@ -14,6 +14,7 @@ use vortex_error::{VortexExpect, VortexResult, vortex_bail};
 use vortex_proto::expr as pb;
 use vortex_scalar::{Scalar, ScalarValue};
 
+use crate::display::{DisplayAs, DisplayFormat};
 use crate::traversal::{NodeExt, NodeVisitor, TraversalOrder};
 use crate::{
     AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, StatsCatalog, VTable, vtable,
@@ -172,11 +173,25 @@ impl DynamicComparisonExpr {
 
 impl Display for DynamicComparisonExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{} {} dynamic({})",
-            &self.lhs, self.operator, &self.rhs.dtype,
-        )
+        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
+    }
+}
+
+impl DisplayAs for DynamicComparisonExpr {
+    fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match df {
+            DisplayFormat::Dense => {
+                write!(
+                    f,
+                    "{} {} dynamic({})",
+                    &self.lhs, self.operator, &self.rhs.dtype,
+                )
+            }
+            #[cfg(feature = "pretty")]
+            DisplayFormat::Tree => {
+                write!(f, "DynamicComparisonExpr")
+            }
+        }
     }
 }
 

--- a/vortex-expr/src/exprs/dynamic.rs
+++ b/vortex-expr/src/exprs/dynamic.rs
@@ -182,7 +182,7 @@ impl DisplayAs for DynamicComparisonExpr {
                 )
             }
             DisplayFormat::Tree => {
-                write!(f, "DynamicComparisonExpr")
+                write!(f, "DynamicComparison")
             }
         }
     }

--- a/vortex-expr/src/exprs/dynamic.rs
+++ b/vortex-expr/src/exprs/dynamic.rs
@@ -174,7 +174,7 @@ impl DynamicComparisonExpr {
 impl DisplayAs for DynamicComparisonExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
-            DisplayFormat::Dense => {
+            DisplayFormat::Compact => {
                 write!(
                     f,
                     "{} {} dynamic({})",

--- a/vortex-expr/src/exprs/get_item.rs
+++ b/vortex-expr/src/exprs/get_item.rs
@@ -160,7 +160,7 @@ impl DisplayAs for GetItemExpr {
                 write!(f, "{}.{}", self.child, &self.field)
             }
             DisplayFormat::Tree => {
-                write!(f, "GetItemExpr(field = {})", self.field)
+                write!(f, "GetItem(field = {})", self.field)
             }
         }
     }

--- a/vortex-expr/src/exprs/get_item.rs
+++ b/vortex-expr/src/exprs/get_item.rs
@@ -156,7 +156,7 @@ pub fn get_item(field: impl Into<FieldName>, child: ExprRef) -> ExprRef {
 impl DisplayAs for GetItemExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut Formatter) -> std::fmt::Result {
         match df {
-            DisplayFormat::Dense => {
+            DisplayFormat::Compact => {
                 write!(f, "{}.{}", self.child, &self.field)
             }
             DisplayFormat::Tree => {

--- a/vortex-expr/src/exprs/get_item.rs
+++ b/vortex-expr/src/exprs/get_item.rs
@@ -160,7 +160,7 @@ impl DisplayAs for GetItemExpr {
                 write!(f, "{}.{}", self.child, &self.field)
             }
             DisplayFormat::Tree => {
-                write!(f, "GetItem(field = {})", self.field)
+                write!(f, "GetItem({})", self.field)
             }
         }
     }

--- a/vortex-expr/src/exprs/get_item.rs
+++ b/vortex-expr/src/exprs/get_item.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::fmt::{Debug, Display, Formatter};
+use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
 
 use vortex_array::stats::Stat;
@@ -153,19 +153,12 @@ pub fn get_item(field: impl Into<FieldName>, child: ExprRef) -> ExprRef {
     GetItemExpr::new(field, child).into_expr()
 }
 
-impl Display for GetItemExpr {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
-    }
-}
-
 impl DisplayAs for GetItemExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut Formatter) -> std::fmt::Result {
         match df {
             DisplayFormat::Dense => {
                 write!(f, "{}.{}", self.child, &self.field)
             }
-            #[cfg(feature = "pretty")]
             DisplayFormat::Tree => {
                 write!(f, "GetItemExpr(field = {})", self.field)
             }

--- a/vortex-expr/src/exprs/get_item.rs
+++ b/vortex-expr/src/exprs/get_item.rs
@@ -10,6 +10,7 @@ use vortex_dtype::{DType, FieldName, FieldPath};
 use vortex_error::{VortexResult, vortex_bail, vortex_err};
 use vortex_proto::expr as pb;
 
+use crate::display::{DisplayAs, DisplayFormat};
 use crate::{
     AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, StatsCatalog, VTable, root,
     vtable,
@@ -154,10 +155,23 @@ pub fn get_item(field: impl Into<FieldName>, child: ExprRef) -> ExprRef {
 
 impl Display for GetItemExpr {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}.{}", self.child, &self.field)
+        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
     }
 }
 
+impl DisplayAs for GetItemExpr {
+    fn fmt_as(&self, df: DisplayFormat, f: &mut Formatter) -> std::fmt::Result {
+        match df {
+            DisplayFormat::Dense => {
+                write!(f, "{}.{}", self.child, &self.field)
+            }
+            #[cfg(feature = "pretty")]
+            DisplayFormat::Tree => {
+                write!(f, "GetItemExpr(field = {})", self.field)
+            }
+        }
+    }
+}
 impl AnalysisExpr for GetItemExpr {
     fn max(&self, catalog: &mut dyn StatsCatalog) -> Option<ExprRef> {
         catalog.stats_ref(&self.field_path()?, Stat::Max)

--- a/vortex-expr/src/exprs/is_null.rs
+++ b/vortex-expr/src/exprs/is_null.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::fmt::Display;
 use std::ops::Not;
 
 use vortex_array::arrays::{BoolArray, ConstantArray};
@@ -89,19 +88,12 @@ impl IsNullExpr {
     }
 }
 
-impl Display for IsNullExpr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
-    }
-}
-
 impl DisplayAs for IsNullExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
             DisplayFormat::Dense => {
                 write!(f, "is_null({})", self.child)
             }
-            #[cfg(feature = "pretty")]
             DisplayFormat::Tree => {
                 write!(f, "IsNullExpr")
             }

--- a/vortex-expr/src/exprs/is_null.rs
+++ b/vortex-expr/src/exprs/is_null.rs
@@ -95,7 +95,7 @@ impl DisplayAs for IsNullExpr {
                 write!(f, "is_null({})", self.child)
             }
             DisplayFormat::Tree => {
-                write!(f, "IsNullExpr")
+                write!(f, "IsNull")
             }
         }
     }

--- a/vortex-expr/src/exprs/is_null.rs
+++ b/vortex-expr/src/exprs/is_null.rs
@@ -91,7 +91,7 @@ impl IsNullExpr {
 impl DisplayAs for IsNullExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
-            DisplayFormat::Dense => {
+            DisplayFormat::Compact => {
                 write!(f, "is_null({})", self.child)
             }
             DisplayFormat::Tree => {

--- a/vortex-expr/src/exprs/is_null.rs
+++ b/vortex-expr/src/exprs/is_null.rs
@@ -10,6 +10,7 @@ use vortex_dtype::{DType, Nullability};
 use vortex_error::{VortexResult, vortex_bail};
 use vortex_mask::Mask;
 
+use crate::display::{DisplayAs, DisplayFormat};
 use crate::{AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTable, vtable};
 
 vtable!(IsNull);
@@ -90,7 +91,21 @@ impl IsNullExpr {
 
 impl Display for IsNullExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "is_null({})", self.child)
+        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
+    }
+}
+
+impl DisplayAs for IsNullExpr {
+    fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match df {
+            DisplayFormat::Dense => {
+                write!(f, "is_null({})", self.child)
+            }
+            #[cfg(feature = "pretty")]
+            DisplayFormat::Tree => {
+                write!(f, "IsNullExpr")
+            }
+        }
     }
 }
 
@@ -211,5 +226,14 @@ mod tests {
                 Scalar::bool(*expected_value, Nullability::NonNullable)
             );
         }
+    }
+
+    #[test]
+    fn test_display() {
+        let expr = is_null(get_item("name", root()));
+        assert_eq!(expr.to_string(), "is_null($.name)");
+
+        let expr2 = is_null(root());
+        assert_eq!(expr2.to_string(), "is_null($)");
     }
 }

--- a/vortex-expr/src/exprs/like.rs
+++ b/vortex-expr/src/exprs/like.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::fmt::Display;
 use std::hash::Hash;
 
 use vortex_array::compute::{LikeOptions, like};
@@ -146,19 +145,12 @@ impl LikeExpr {
     }
 }
 
-impl Display for LikeExpr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
-    }
-}
-
 impl DisplayAs for LikeExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
             DisplayFormat::Dense => {
                 write!(f, "{} LIKE {}", self.child(), self.pattern())
             }
-            #[cfg(feature = "pretty")]
             DisplayFormat::Tree => {
                 write!(f, "LikeExpr")
             }

--- a/vortex-expr/src/exprs/like.rs
+++ b/vortex-expr/src/exprs/like.rs
@@ -10,6 +10,7 @@ use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_bail};
 use vortex_proto::expr as pb;
 
+use crate::display::{DisplayAs, DisplayFormat};
 use crate::{AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTable, vtable};
 
 vtable!(Like);
@@ -147,7 +148,25 @@ impl LikeExpr {
 
 impl Display for LikeExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} LIKE {}", self.child(), self.pattern())
+        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
+    }
+}
+
+impl DisplayAs for LikeExpr {
+    fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match df {
+            DisplayFormat::Dense => {
+                write!(f, "{} LIKE {}", self.child(), self.pattern())
+            }
+            #[cfg(feature = "pretty")]
+            DisplayFormat::Tree => {
+                write!(f, "LikeExpr")
+            }
+        }
+    }
+
+    fn child_names(&self) -> Option<Vec<String>> {
+        Some(vec!["child".to_string(), "pattern".to_string()])
     }
 }
 
@@ -159,7 +178,7 @@ mod tests {
     use vortex_array::arrays::BoolArray;
     use vortex_dtype::{DType, Nullability};
 
-    use crate::{LikeExpr, Scope, lit, not, root};
+    use crate::{LikeExpr, Scope, get_item, lit, not, root};
 
     #[test]
     fn invert_booleans() {
@@ -186,5 +205,14 @@ mod tests {
             like_expr.return_dtype(&dtype).unwrap(),
             DType::Bool(Nullability::NonNullable)
         );
+    }
+
+    #[test]
+    fn test_display() {
+        let expr = LikeExpr::new(get_item("name", root()), lit("%john%"), false, false);
+        assert_eq!(expr.to_string(), "$.name LIKE \"%john%\"");
+
+        let expr2 = LikeExpr::new(root(), lit("test*"), true, true);
+        assert_eq!(expr2.to_string(), "$ LIKE \"test*\"");
     }
 }

--- a/vortex-expr/src/exprs/like.rs
+++ b/vortex-expr/src/exprs/like.rs
@@ -152,7 +152,7 @@ impl DisplayAs for LikeExpr {
                 write!(f, "{} LIKE {}", self.child(), self.pattern())
             }
             DisplayFormat::Tree => {
-                write!(f, "LikeExpr")
+                write!(f, "Like")
             }
         }
     }

--- a/vortex-expr/src/exprs/like.rs
+++ b/vortex-expr/src/exprs/like.rs
@@ -148,7 +148,7 @@ impl LikeExpr {
 impl DisplayAs for LikeExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
-            DisplayFormat::Dense => {
+            DisplayFormat::Compact => {
                 write!(f, "{} LIKE {}", self.child(), self.pattern())
             }
             DisplayFormat::Tree => {

--- a/vortex-expr/src/exprs/list_contains.rs
+++ b/vortex-expr/src/exprs/list_contains.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::fmt::{Debug, Display, Formatter};
+use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
 
 use vortex_array::compute::list_contains as compute_list_contains;
@@ -118,19 +118,12 @@ pub fn list_contains(list: ExprRef, value: ExprRef) -> ExprRef {
     ListContainsExpr::new(list, value).into_expr()
 }
 
-impl Display for ListContainsExpr {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
-    }
-}
-
 impl DisplayAs for ListContainsExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut Formatter) -> std::fmt::Result {
         match df {
             DisplayFormat::Dense => {
                 write!(f, "contains({}, {})", &self.list, &self.value)
             }
-            #[cfg(feature = "pretty")]
             DisplayFormat::Tree => {
                 write!(f, "ListContainsExpr")
             }

--- a/vortex-expr/src/exprs/list_contains.rs
+++ b/vortex-expr/src/exprs/list_contains.rs
@@ -9,6 +9,7 @@ use vortex_array::{ArrayRef, DeserializeMetadata, EmptyMetadata};
 use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_bail};
 
+use crate::display::{DisplayAs, DisplayFormat};
 use crate::{
     AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, LiteralVTable, Scope, StatsCatalog,
     VTable, and, gt, lit, lt, or, vtable,
@@ -119,7 +120,25 @@ pub fn list_contains(list: ExprRef, value: ExprRef) -> ExprRef {
 
 impl Display for ListContainsExpr {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "contains({}, {})", &self.list, &self.value)
+        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
+    }
+}
+
+impl DisplayAs for ListContainsExpr {
+    fn fmt_as(&self, df: DisplayFormat, f: &mut Formatter) -> std::fmt::Result {
+        match df {
+            DisplayFormat::Dense => {
+                write!(f, "contains({}, {})", &self.list, &self.value)
+            }
+            #[cfg(feature = "pretty")]
+            DisplayFormat::Tree => {
+                write!(f, "ListContainsExpr")
+            }
+        }
+    }
+
+    fn child_names(&self) -> Option<Vec<String>> {
+        Some(vec!["list".to_string(), "value".to_string()])
     }
 }
 
@@ -322,5 +341,14 @@ mod tests {
                 HashSet::from([Stat::Min, Stat::Max])
             )])
         );
+    }
+
+    #[test]
+    pub fn test_display() {
+        let expr = list_contains(get_item("tags", root()), lit("urgent"));
+        assert_eq!(expr.to_string(), "contains($.tags, \"urgent\")");
+
+        let expr2 = list_contains(root(), lit(42));
+        assert_eq!(expr2.to_string(), "contains($, 42i32)");
     }
 }

--- a/vortex-expr/src/exprs/list_contains.rs
+++ b/vortex-expr/src/exprs/list_contains.rs
@@ -121,7 +121,7 @@ pub fn list_contains(list: ExprRef, value: ExprRef) -> ExprRef {
 impl DisplayAs for ListContainsExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut Formatter) -> std::fmt::Result {
         match df {
-            DisplayFormat::Dense => {
+            DisplayFormat::Compact => {
                 write!(f, "contains({}, {})", &self.list, &self.value)
             }
             DisplayFormat::Tree => {

--- a/vortex-expr/src/exprs/list_contains.rs
+++ b/vortex-expr/src/exprs/list_contains.rs
@@ -125,7 +125,7 @@ impl DisplayAs for ListContainsExpr {
                 write!(f, "contains({}, {})", &self.list, &self.value)
             }
             DisplayFormat::Tree => {
-                write!(f, "ListContainsExpr")
+                write!(f, "ListContains")
             }
         }
     }

--- a/vortex-expr/src/exprs/literal.rs
+++ b/vortex-expr/src/exprs/literal.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-
 use vortex_array::arrays::ConstantArray;
 use vortex_array::{ArrayRef, DeserializeMetadata, IntoArray, ProstMetadata};
 use vortex_dtype::{DType, match_each_float_ptype};

--- a/vortex-expr/src/exprs/literal.rs
+++ b/vortex-expr/src/exprs/literal.rs
@@ -106,7 +106,7 @@ impl DisplayAs for LiteralExpr {
             DisplayFormat::Tree => {
                 write!(
                     f,
-                    "LiteralExpr(value: {}, dtype: {})",
+                    "Literal(value: {}, dtype: {})",
                     self.value,
                     self.value.dtype()
                 )

--- a/vortex-expr/src/exprs/literal.rs
+++ b/vortex-expr/src/exprs/literal.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::fmt::Display;
 
 use vortex_array::arrays::ConstantArray;
 use vortex_array::{ArrayRef, DeserializeMetadata, IntoArray, ProstMetadata};
@@ -10,8 +9,7 @@ use vortex_error::{VortexResult, vortex_bail, vortex_err};
 use vortex_proto::expr as pb;
 use vortex_scalar::Scalar;
 
-use crate::display::DisplayAs;
-use crate::display::DisplayFormat::Dense;
+use crate::display::{DisplayAs, DisplayFormat};
 use crate::{
     AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, StatsCatalog, VTable, vtable,
 };
@@ -100,24 +98,13 @@ impl LiteralExpr {
     }
 }
 
-impl Display for LiteralExpr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        DisplayAs::fmt_as(self, Dense, f)
-    }
-}
-
 impl DisplayAs for LiteralExpr {
-    fn fmt_as(
-        &self,
-        df: crate::display::DisplayFormat,
-        f: &mut std::fmt::Formatter,
-    ) -> std::fmt::Result {
+    fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
-            Dense => {
+            DisplayFormat::Dense => {
                 write!(f, "{}", self.value)
             }
-            #[cfg(feature = "pretty")]
-            crate::display::DisplayFormat::Tree => {
+            DisplayFormat::Tree => {
                 write!(
                     f,
                     "LiteralExpr(value: {}, dtype: {})",

--- a/vortex-expr/src/exprs/literal.rs
+++ b/vortex-expr/src/exprs/literal.rs
@@ -10,6 +10,8 @@ use vortex_error::{VortexResult, vortex_bail, vortex_err};
 use vortex_proto::expr as pb;
 use vortex_scalar::Scalar;
 
+use crate::display::DisplayAs;
+use crate::display::DisplayFormat::Dense;
 use crate::{
     AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, StatsCatalog, VTable, vtable,
 };
@@ -100,7 +102,30 @@ impl LiteralExpr {
 
 impl Display for LiteralExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.value)
+        DisplayAs::fmt_as(self, Dense, f)
+    }
+}
+
+impl DisplayAs for LiteralExpr {
+    fn fmt_as(
+        &self,
+        df: crate::display::DisplayFormat,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        match df {
+            Dense => {
+                write!(f, "{}", self.value)
+            }
+            #[cfg(feature = "pretty")]
+            crate::display::DisplayFormat::Tree => {
+                write!(
+                    f,
+                    "LiteralExpr(value: {}, dtype: {})",
+                    self.value,
+                    self.value.dtype()
+                )
+            }
+        }
     }
 }
 

--- a/vortex-expr/src/exprs/literal.rs
+++ b/vortex-expr/src/exprs/literal.rs
@@ -100,7 +100,7 @@ impl LiteralExpr {
 impl DisplayAs for LiteralExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
-            DisplayFormat::Dense => {
+            DisplayFormat::Compact => {
                 write!(f, "{}", self.value)
             }
             DisplayFormat::Tree => {

--- a/vortex-expr/src/exprs/merge.rs
+++ b/vortex-expr/src/exprs/merge.rs
@@ -11,6 +11,7 @@ use vortex_array::{Array, ArrayRef, DeserializeMetadata, EmptyMetadata, IntoArra
 use vortex_dtype::{DType, FieldNames, Nullability, StructFields};
 use vortex_error::{VortexExpect as _, VortexResult, vortex_bail};
 
+use crate::display::{DisplayAs, DisplayFormat};
 use crate::{AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTable, vtable};
 
 vtable!(Merge);
@@ -191,12 +192,26 @@ pub fn merge(
 
 impl Display for MergeExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "merge({}){}",
-            self.values.iter().format(", "),
-            self.nullability
-        )
+        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
+    }
+}
+
+impl DisplayAs for MergeExpr {
+    fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match df {
+            DisplayFormat::Dense => {
+                write!(
+                    f,
+                    "merge({}){}",
+                    self.values.iter().format(", "),
+                    self.nullability
+                )
+            }
+            #[cfg(feature = "pretty")]
+            DisplayFormat::Tree => {
+                write!(f, "MergeExpr")
+            }
+        }
     }
 }
 
@@ -210,7 +225,7 @@ mod tests {
     use vortex_dtype::Nullability;
     use vortex_error::{VortexResult, vortex_bail};
 
-    use crate::{MergeExpr, Scope, get_item, root};
+    use crate::{MergeExpr, Scope, get_item, merge, root};
 
     fn primitive_field(array: &dyn Array, field_path: &[&str]) -> VortexResult<PrimitiveArray> {
         let mut field_path = field_path.iter();
@@ -432,5 +447,17 @@ mod tests {
         .into_array();
         let actual_array = expr.evaluate(&Scope::new(test_array.clone())).unwrap();
         assert!(actual_array.dtype().is_nullable());
+    }
+
+    #[test]
+    pub fn test_display() {
+        let expr = merge(
+            [get_item("struct1", root()), get_item("struct2", root())],
+            Nullability::NonNullable,
+        );
+        assert_eq!(expr.to_string(), "merge($.struct1, $.struct2)");
+
+        let expr2 = MergeExpr::new(vec![get_item("a", root())], Nullability::Nullable);
+        assert_eq!(expr2.to_string(), "merge($.a)?");
     }
 }

--- a/vortex-expr/src/exprs/merge.rs
+++ b/vortex-expr/src/exprs/merge.rs
@@ -192,7 +192,7 @@ pub fn merge(
 impl DisplayAs for MergeExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
-            DisplayFormat::Dense => {
+            DisplayFormat::Compact => {
                 write!(
                     f,
                     "merge({}){}",

--- a/vortex-expr/src/exprs/merge.rs
+++ b/vortex-expr/src/exprs/merge.rs
@@ -201,7 +201,7 @@ impl DisplayAs for MergeExpr {
                 )
             }
             DisplayFormat::Tree => {
-                write!(f, "MergeExpr")
+                write!(f, "Merge")
             }
         }
     }

--- a/vortex-expr/src/exprs/merge.rs
+++ b/vortex-expr/src/exprs/merge.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::fmt::Display;
 use std::hash::Hash;
 
 use itertools::Itertools as _;
@@ -190,12 +189,6 @@ pub fn merge(
     MergeExpr::new(values, nullability).into_expr()
 }
 
-impl Display for MergeExpr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
-    }
-}
-
 impl DisplayAs for MergeExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
@@ -207,7 +200,6 @@ impl DisplayAs for MergeExpr {
                     self.nullability
                 )
             }
-            #[cfg(feature = "pretty")]
             DisplayFormat::Tree => {
                 write!(f, "MergeExpr")
             }

--- a/vortex-expr/src/exprs/not.rs
+++ b/vortex-expr/src/exprs/not.rs
@@ -101,7 +101,7 @@ impl DisplayAs for NotExpr {
                 write!(f, "(!{})", self.child)
             }
             DisplayFormat::Tree => {
-                write!(f, "NotExpr")
+                write!(f, "Not")
             }
         }
     }

--- a/vortex-expr/src/exprs/not.rs
+++ b/vortex-expr/src/exprs/not.rs
@@ -9,6 +9,7 @@ use vortex_array::{ArrayRef, DeserializeMetadata, EmptyMetadata};
 use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_bail};
 
+use crate::display::{DisplayAs, DisplayFormat};
 use crate::{AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTable, vtable};
 
 vtable!(Not);
@@ -96,7 +97,21 @@ impl NotExpr {
 
 impl Display for NotExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "(!{})", self.child)
+        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
+    }
+}
+
+impl DisplayAs for NotExpr {
+    fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match df {
+            DisplayFormat::Dense => {
+                write!(f, "(!{})", self.child)
+            }
+            #[cfg(feature = "pretty")]
+            DisplayFormat::Tree => {
+                write!(f, "NotExpr")
+            }
+        }
     }
 }
 

--- a/vortex-expr/src/exprs/not.rs
+++ b/vortex-expr/src/exprs/not.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::fmt::Display;
 use std::hash::Hash;
 
 use vortex_array::compute::invert;
@@ -95,19 +94,12 @@ impl NotExpr {
     }
 }
 
-impl Display for NotExpr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
-    }
-}
-
 impl DisplayAs for NotExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
             DisplayFormat::Dense => {
                 write!(f, "(!{})", self.child)
             }
-            #[cfg(feature = "pretty")]
             DisplayFormat::Tree => {
                 write!(f, "NotExpr")
             }

--- a/vortex-expr/src/exprs/not.rs
+++ b/vortex-expr/src/exprs/not.rs
@@ -97,7 +97,7 @@ impl NotExpr {
 impl DisplayAs for NotExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
-            DisplayFormat::Dense => {
+            DisplayFormat::Compact => {
                 write!(f, "(!{})", self.child)
             }
             DisplayFormat::Tree => {

--- a/vortex-expr/src/exprs/pack.rs
+++ b/vortex-expr/src/exprs/pack.rs
@@ -228,6 +228,10 @@ impl DisplayAs for PackExpr {
             }
         }
     }
+
+    fn child_names(&self) -> Option<Vec<String>> {
+        Some(self.names.iter().map(|n| n.to_string()).collect())
+    }
 }
 
 impl AnalysisExpr for PackExpr {}

--- a/vortex-expr/src/exprs/pack.rs
+++ b/vortex-expr/src/exprs/pack.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::fmt::Display;
 use std::hash::Hash;
 
 use itertools::Itertools as _;
@@ -202,12 +201,6 @@ pub fn pack(
         .into_expr()
 }
 
-impl Display for PackExpr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
-    }
-}
-
 impl DisplayAs for PackExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
@@ -222,7 +215,6 @@ impl DisplayAs for PackExpr {
                     self.nullability
                 )
             }
-            #[cfg(feature = "pretty")]
             DisplayFormat::Tree => {
                 write!(f, "PackExpr")
             }

--- a/vortex-expr/src/exprs/pack.rs
+++ b/vortex-expr/src/exprs/pack.rs
@@ -216,7 +216,7 @@ impl DisplayAs for PackExpr {
                 )
             }
             DisplayFormat::Tree => {
-                write!(f, "PackExpr")
+                write!(f, "Pack")
             }
         }
     }

--- a/vortex-expr/src/exprs/pack.rs
+++ b/vortex-expr/src/exprs/pack.rs
@@ -12,6 +12,7 @@ use vortex_dtype::{DType, FieldName, FieldNames, Nullability, StructFields};
 use vortex_error::{VortexExpect as _, VortexResult, vortex_bail, vortex_err};
 use vortex_proto::expr as pb;
 
+use crate::display::{DisplayAs, DisplayFormat};
 use crate::{AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTable, vtable};
 
 vtable!(Pack);
@@ -203,15 +204,29 @@ pub fn pack(
 
 impl Display for PackExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "pack({}){}",
-            self.names
-                .iter()
-                .zip(&self.values)
-                .format_with(", ", |(name, expr), f| f(&format_args!("{name}: {expr}"))),
-            self.nullability
-        )
+        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
+    }
+}
+
+impl DisplayAs for PackExpr {
+    fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match df {
+            DisplayFormat::Dense => {
+                write!(
+                    f,
+                    "pack({}){}",
+                    self.names
+                        .iter()
+                        .zip(&self.values)
+                        .format_with(", ", |(name, expr), f| f(&format_args!("{name}: {expr}"))),
+                    self.nullability
+                )
+            }
+            #[cfg(feature = "pretty")]
+            DisplayFormat::Tree => {
+                write!(f, "PackExpr")
+            }
+        }
     }
 }
 
@@ -228,7 +243,7 @@ mod tests {
     use vortex_dtype::{FieldNames, Nullability};
     use vortex_error::{VortexResult, vortex_bail};
 
-    use crate::{IntoExpr, PackExpr, Scope, col};
+    use crate::{IntoExpr, PackExpr, Scope, col, pack};
 
     fn test_array() -> ArrayRef {
         StructArray::from_fields(&[
@@ -375,5 +390,22 @@ mod tests {
 
         assert_eq!(actual_array.names(), ["one", "two", "three"]);
         assert_eq!(actual_array.validity(), &Validity::AllValid);
+    }
+
+    #[test]
+    pub fn test_display() {
+        let expr = pack(
+            [("id", col("user_id")), ("name", col("username"))],
+            Nullability::NonNullable,
+        );
+        assert_eq!(expr.to_string(), "pack(id: $.user_id, name: $.username)");
+
+        let expr2 = PackExpr::try_new(
+            ["x", "y"].into(),
+            vec![col("a"), col("b")],
+            Nullability::Nullable,
+        )
+        .unwrap();
+        assert_eq!(expr2.to_string(), "pack(x: $.a, y: $.b)?");
     }
 }

--- a/vortex-expr/src/exprs/pack.rs
+++ b/vortex-expr/src/exprs/pack.rs
@@ -204,7 +204,7 @@ pub fn pack(
 impl DisplayAs for PackExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
-            DisplayFormat::Dense => {
+            DisplayFormat::Compact => {
                 write!(
                     f,
                     "pack({}){}",

--- a/vortex-expr/src/exprs/root.rs
+++ b/vortex-expr/src/exprs/root.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-
 use vortex_array::stats::Stat;
 use vortex_array::{ArrayRef, DeserializeMetadata, EmptyMetadata};
 use vortex_dtype::{DType, FieldPath};

--- a/vortex-expr/src/exprs/root.rs
+++ b/vortex-expr/src/exprs/root.rs
@@ -8,6 +8,7 @@ use vortex_array::{ArrayRef, DeserializeMetadata, EmptyMetadata};
 use vortex_dtype::{DType, FieldPath};
 use vortex_error::{VortexResult, vortex_bail};
 
+use crate::display::{DisplayAs, DisplayFormat};
 use crate::{
     AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, StatsCatalog, VTable, vtable,
 };
@@ -70,7 +71,21 @@ impl VTable for RootVTable {
 
 impl Display for RootExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "$")
+        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
+    }
+}
+
+impl DisplayAs for RootExpr {
+    fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match df {
+            DisplayFormat::Dense => {
+                write!(f, "$")
+            }
+            #[cfg(feature = "pretty")]
+            DisplayFormat::Tree => {
+                write!(f, "RootExpr")
+            }
+        }
     }
 }
 

--- a/vortex-expr/src/exprs/root.rs
+++ b/vortex-expr/src/exprs/root.rs
@@ -70,7 +70,7 @@ impl VTable for RootVTable {
 impl DisplayAs for RootExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
-            DisplayFormat::Dense => {
+            DisplayFormat::Compact => {
                 write!(f, "$")
             }
             DisplayFormat::Tree => {

--- a/vortex-expr/src/exprs/root.rs
+++ b/vortex-expr/src/exprs/root.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::fmt::Display;
 
 use vortex_array::stats::Stat;
 use vortex_array::{ArrayRef, DeserializeMetadata, EmptyMetadata};
@@ -69,19 +68,12 @@ impl VTable for RootVTable {
     }
 }
 
-impl Display for RootExpr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
-    }
-}
-
 impl DisplayAs for RootExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
             DisplayFormat::Dense => {
                 write!(f, "$")
             }
-            #[cfg(feature = "pretty")]
             DisplayFormat::Tree => {
                 write!(f, "RootExpr")
             }

--- a/vortex-expr/src/exprs/root.rs
+++ b/vortex-expr/src/exprs/root.rs
@@ -74,7 +74,7 @@ impl DisplayAs for RootExpr {
                 write!(f, "$")
             }
             DisplayFormat::Tree => {
-                write!(f, "RootExpr")
+                write!(f, "Root")
             }
         }
     }

--- a/vortex-expr/src/exprs/select.rs
+++ b/vortex-expr/src/exprs/select.rs
@@ -279,7 +279,7 @@ impl Display for SelectField {
 impl DisplayAs for SelectExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
-            DisplayFormat::Dense => {
+            DisplayFormat::Compact => {
                 write!(f, "{}{}", self.child, self.fields)
             }
             DisplayFormat::Tree => {

--- a/vortex-expr/src/exprs/select.rs
+++ b/vortex-expr/src/exprs/select.rs
@@ -289,7 +289,7 @@ impl DisplayAs for SelectExpr {
                     "exclude"
                 };
 
-                write!(f, "SelectExpr({}): {}", field_type, self.fields().fields())
+                write!(f, "Select({}): {}", field_type, self.fields().fields())
             }
         }
     }

--- a/vortex-expr/src/exprs/select.rs
+++ b/vortex-expr/src/exprs/select.rs
@@ -10,6 +10,7 @@ use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
 use vortex_proto::expr::select_opts::Opts;
 use vortex_proto::expr::{FieldNames as ProtoFieldNames, SelectOpts};
 
+use crate::display::{DisplayAs, DisplayFormat};
 use crate::field::DisplayFieldNames;
 use crate::{AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTable, vtable};
 
@@ -275,9 +276,34 @@ impl Display for SelectField {
     }
 }
 
+impl DisplayAs for SelectExpr {
+    fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match df {
+            DisplayFormat::Dense => {
+                write!(f, "{}{}", self.child, self.fields)
+            }
+            #[cfg(feature = "pretty")]
+            DisplayFormat::Tree => {
+                let field_type = if self.fields.is_include() {
+                    "include"
+                } else {
+                    "exclude"
+                };
+
+                write!(f, "SelectExpr({}): {}", field_type, self.fields().fields())
+            }
+        }
+    }
+
+    fn child_names(&self) -> Option<Vec<String>> {
+        // Single child - no need to name it, the tree structure makes it obvious
+        None
+    }
+}
+
 impl Display for SelectExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}{}", self.child, self.fields)
+        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
     }
 }
 

--- a/vortex-expr/src/exprs/select.rs
+++ b/vortex-expr/src/exprs/select.rs
@@ -282,7 +282,6 @@ impl DisplayAs for SelectExpr {
             DisplayFormat::Dense => {
                 write!(f, "{}{}", self.child, self.fields)
             }
-            #[cfg(feature = "pretty")]
             DisplayFormat::Tree => {
                 let field_type = if self.fields.is_include() {
                     "include"
@@ -298,12 +297,6 @@ impl DisplayAs for SelectExpr {
     fn child_names(&self) -> Option<Vec<String>> {
         // Single child - no need to name it, the tree structure makes it obvious
         None
-    }
-}
-
-impl Display for SelectExpr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
     }
 }
 

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -177,7 +177,7 @@ impl dyn VortexExpr + '_ {
     ///
     /// ```rust
     /// # use vortex_dtype::{DType, Nullability, PType};
-    /// # use vortex_expr::{and, cast, eq, get_item, gt, lit, not, root, select, LikeExpr};
+    /// # use vortex_expr::{and, cast, eq, get_item, gt, lit, not, root, select, IntoExpr, LikeExpr};
     /// // Build a complex nested expression
     /// let complex_expr = select(
     ///     ["result"],

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -167,6 +167,56 @@ impl dyn VortexExpr + '_ {
         Ok(result)
     }
 
+    /// Display the expression as a formatted tree structure.
+    ///
+    /// This provides a hierarchical view of the expression that shows the relationships
+    /// between parent and child expressions, making complex nested expressions easier
+    /// to understand and debug.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use vortex_dtype::{DType, Nullability, PType};
+    /// # use vortex_expr::{and, cast, eq, get_item, gt, lit, not, root, select, LikeExpr};
+    /// // Build a complex nested expression
+    /// let complex_expr = select(
+    ///     ["result"],
+    ///     and(
+    ///         not(eq(get_item("status", root()), lit("inactive"))),
+    ///         and(
+    ///             LikeExpr::new(get_item("name", root()), lit("%admin%"), false, false).into_expr(),
+    ///             gt(
+    ///                 cast(get_item("score", root()), DType::Primitive(PType::F64, Nullability::NonNullable)),
+    ///                 lit(75.0)
+    ///             )
+    ///         )
+    ///     )
+    /// );
+    ///
+    /// println!("{}", complex_expr.display_tree());
+    /// ```
+    ///
+    /// This produces output like:
+    ///
+    /// ```text
+    /// SelectExpr(include): {result}
+    /// └── BinaryExpr(and)
+    ///     ├── lhs: NotExpr
+    ///     │   └── BinaryExpr(=)
+    ///     │       ├── lhs: GetItemExpr(field = status)
+    ///     │       │   └── RootExpr
+    ///     │       └── rhs: LiteralExpr(value: "inactive", dtype: utf8)
+    ///     └── rhs: BinaryExpr(and)
+    ///         ├── lhs: LikeExpr
+    ///         │   ├── child: GetItemExpr(field = name)
+    ///         │   │   └── RootExpr
+    ///         │   └── pattern: LiteralExpr(value: "%admin%", dtype: utf8)
+    ///         └── rhs: BinaryExpr(>)
+    ///             ├── lhs: CastExpr(target: f64)
+    ///             │   └── GetItemExpr(field = score)
+    ///             │       └── RootExpr
+    ///             └── rhs: LiteralExpr(value: 75f64, dtype: f64)
+    /// ```
     #[cfg(feature = "pretty")]
     pub fn display_tree(&self) -> impl Display {
         display::DisplayTreeExpr(self)

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -215,7 +215,7 @@ impl dyn VortexExpr + '_ {
 
 impl Display for dyn VortexExpr + '_ {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
+        DisplayAs::fmt_as(self, DisplayFormat::Compact, f)
     }
 }
 
@@ -286,7 +286,7 @@ impl<V: VTable> Debug for ExprAdapter<V> {
 
 impl<V: VTable> Display for ExprAdapter<V> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        DisplayAs::fmt_as(&self.0, DisplayFormat::Dense, f)
+        DisplayAs::fmt_as(&self.0, DisplayFormat::Compact, f)
     }
 }
 

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -77,16 +77,7 @@ pub type ExprRef = Arc<dyn VortexExpr>;
 
 /// Represents logical operation on [`ArrayRef`]s
 pub trait VortexExpr:
-    'static
-    + Send
-    + Sync
-    + Debug
-    + Display
-    + DisplayAs
-    + DynEq
-    + DynHash
-    + private::Sealed
-    + AnalysisExpr
+    'static + Send + Sync + Debug + DisplayAs + DynEq + DynHash + AnalysisExpr + private::Sealed
 {
     /// Convert expression reference to reference of [`Any`] type
     fn as_any(&self) -> &dyn Any;
@@ -160,7 +151,7 @@ impl dyn VortexExpr + '_ {
             result.dtype(),
             &self.return_dtype(scope.dtype())?,
             "Expression {} returned dtype {} but declared return_dtype of {}",
-            self,
+            &self,
             result.dtype(),
             self.return_dtype(scope.dtype())?,
         );
@@ -217,9 +208,14 @@ impl dyn VortexExpr + '_ {
     ///             │       └── RootExpr
     ///             └── rhs: LiteralExpr(value: 75f64, dtype: f64)
     /// ```
-    #[cfg(feature = "pretty")]
     pub fn display_tree(&self) -> impl Display {
         display::DisplayTreeExpr(self)
+    }
+}
+
+impl Display for dyn VortexExpr + '_ {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
     }
 }
 
@@ -296,11 +292,7 @@ impl<V: VTable> Display for ExprAdapter<V> {
 
 impl<V: VTable> DisplayAs for ExprAdapter<V> {
     fn fmt_as(&self, df: DisplayFormat, f: &mut Formatter) -> std::fmt::Result {
-        match df {
-            DisplayFormat::Dense => DisplayAs::fmt_as(&self.0, DisplayFormat::Dense, f),
-            #[cfg(feature = "pretty")]
-            DisplayFormat::Tree => DisplayAs::fmt_as(&self.0, DisplayFormat::Tree, f),
-        }
+        DisplayAs::fmt_as(&self.0, df, f)
     }
 
     fn child_names(&self) -> Option<Vec<String>> {

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -190,23 +190,23 @@ impl dyn VortexExpr + '_ {
     /// This produces output like:
     ///
     /// ```text
-    /// SelectExpr(include): {result}
-    /// └── BinaryExpr(and)
-    ///     ├── lhs: NotExpr
-    ///     │   └── BinaryExpr(=)
-    ///     │       ├── lhs: GetItemExpr(field = status)
-    ///     │       │   └── RootExpr
-    ///     │       └── rhs: LiteralExpr(value: "inactive", dtype: utf8)
-    ///     └── rhs: BinaryExpr(and)
-    ///         ├── lhs: LikeExpr
-    ///         │   ├── child: GetItemExpr(field = name)
-    ///         │   │   └── RootExpr
-    ///         │   └── pattern: LiteralExpr(value: "%admin%", dtype: utf8)
-    ///         └── rhs: BinaryExpr(>)
-    ///             ├── lhs: CastExpr(target: f64)
-    ///             │   └── GetItemExpr(field = score)
-    ///             │       └── RootExpr
-    ///             └── rhs: LiteralExpr(value: 75f64, dtype: f64)
+    /// Select(include): {result}
+    /// └── Binary(and)
+    ///     ├── lhs: Not
+    ///     │   └── Binary(=)
+    ///     │       ├── lhs: GetItem(status)
+    ///     │       │   └── Root
+    ///     │       └── rhs: Literal(value: "inactive", dtype: utf8)
+    ///     └── rhs: Binary(and)
+    ///         ├── lhs: Like
+    ///         │   ├── child: GetItem(name)
+    ///         │   │   └── Root
+    ///         │   └── pattern: Literal(value: "%admin%", dtype: utf8)
+    ///         └── rhs: Binary(>)
+    ///             ├── lhs: Cast(target: f64)
+    ///             │   └── GetItem(score)
+    ///             │       └── Root
+    ///             └── rhs: Literal(value: 75f64, dtype: f64)
     /// ```
     pub fn display_tree(&self) -> impl Display {
         display::DisplayTreeExpr(self)

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -62,6 +62,9 @@ use vortex_error::{VortexExpect, VortexResult, VortexUnwrap, vortex_bail};
 use vortex_utils::aliases::hash_set::HashSet;
 pub use vtable::*;
 
+pub mod display;
+
+use crate::display::{DisplayAs, DisplayFormat};
 use crate::dyn_traits::DynEq;
 use crate::traversal::{NodeExt, ReferenceCollector};
 
@@ -74,7 +77,16 @@ pub type ExprRef = Arc<dyn VortexExpr>;
 
 /// Represents logical operation on [`ArrayRef`]s
 pub trait VortexExpr:
-    'static + Send + Sync + Debug + Display + DynEq + DynHash + private::Sealed + AnalysisExpr
+    'static
+    + Send
+    + Sync
+    + Debug
+    + Display
+    + DisplayAs
+    + DynEq
+    + DynHash
+    + private::Sealed
+    + AnalysisExpr
 {
     /// Convert expression reference to reference of [`Any`] type
     fn as_any(&self) -> &dyn Any;
@@ -154,6 +166,11 @@ impl dyn VortexExpr + '_ {
         );
         Ok(result)
     }
+
+    #[cfg(feature = "pretty")]
+    pub fn display_tree(&self) -> impl Display {
+        display::DisplayTreeExpr(self)
+    }
 }
 
 pub trait VortexExprExt {
@@ -223,7 +240,21 @@ impl<V: VTable> Debug for ExprAdapter<V> {
 
 impl<V: VTable> Display for ExprAdapter<V> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        Display::fmt(&self.0, f)
+        DisplayAs::fmt_as(&self.0, DisplayFormat::Dense, f)
+    }
+}
+
+impl<V: VTable> DisplayAs for ExprAdapter<V> {
+    fn fmt_as(&self, df: DisplayFormat, f: &mut Formatter) -> std::fmt::Result {
+        match df {
+            DisplayFormat::Dense => DisplayAs::fmt_as(&self.0, DisplayFormat::Dense, f),
+            #[cfg(feature = "pretty")]
+            DisplayFormat::Tree => DisplayAs::fmt_as(&self.0, DisplayFormat::Tree, f),
+        }
+    }
+
+    fn child_names(&self) -> Option<Vec<String>> {
+        DisplayAs::child_names(&self.0)
     }
 }
 

--- a/vortex-expr/src/vtable.rs
+++ b/vortex-expr/src/vtable.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::Deref;
 
@@ -9,6 +9,7 @@ use vortex_array::{ArrayRef, DeserializeMetadata, SerializeMetadata};
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 
+use crate::display::DisplayAs;
 use crate::{
     AnalysisExpr, ExprEncoding, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VortexExpr,
 };
@@ -19,7 +20,7 @@ pub trait VTable: 'static + Sized + Send + Sync + Debug {
         + Sync
         + Clone
         + Debug
-        + Display
+        + DisplayAs
         + PartialEq
         + Eq
         + Hash

--- a/vortex-layout/src/layouts/row_idx/expr.rs
+++ b/vortex-layout/src/layouts/row_idx/expr.rs
@@ -6,10 +6,9 @@ use std::fmt::{Display, Formatter};
 use vortex_array::{ArrayRef, DeserializeMetadata, EmptyMetadata};
 use vortex_dtype::{DType, Nullability, PType};
 use vortex_error::{VortexResult, vortex_bail};
+use vortex_expr::display::{DisplayAs, DisplayFormat};
 use vortex_expr::{
-    AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTable,
-    display::{DisplayAs, DisplayFormat},
-    vtable,
+    AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTable, vtable,
 };
 
 vtable!(RowIdx);

--- a/vortex-layout/src/layouts/row_idx/expr.rs
+++ b/vortex-layout/src/layouts/row_idx/expr.rs
@@ -7,7 +7,9 @@ use vortex_array::{ArrayRef, DeserializeMetadata, EmptyMetadata};
 use vortex_dtype::{DType, Nullability, PType};
 use vortex_error::{VortexResult, vortex_bail};
 use vortex_expr::{
-    AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTable, vtable,
+    AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTable,
+    display::{DisplayAs, DisplayFormat},
+    vtable,
 };
 
 vtable!(RowIdx);
@@ -19,6 +21,12 @@ impl AnalysisExpr for RowIdxExpr {}
 
 impl Display for RowIdxExpr {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
+    }
+}
+
+impl DisplayAs for RowIdxExpr {
+    fn fmt_as(&self, _df: DisplayFormat, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "#row_idx")
     }
 }

--- a/vortex-layout/src/layouts/row_idx/expr.rs
+++ b/vortex-layout/src/layouts/row_idx/expr.rs
@@ -22,7 +22,7 @@ impl DisplayAs for RowIdxExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut Formatter) -> std::fmt::Result {
         match df {
             DisplayFormat::Compact => write!(f, "#row_idx"),
-            DisplayFormat::Tree => write!(f, "RowIdxExpr"),
+            DisplayFormat::Tree => write!(f, "RowIdx"),
         }
     }
 }

--- a/vortex-layout/src/layouts/row_idx/expr.rs
+++ b/vortex-layout/src/layouts/row_idx/expr.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::fmt::{Display, Formatter};
+use std::fmt::Formatter;
 
 use vortex_array::{ArrayRef, DeserializeMetadata, EmptyMetadata};
 use vortex_dtype::{DType, Nullability, PType};
@@ -18,15 +18,12 @@ pub struct RowIdxExpr;
 
 impl AnalysisExpr for RowIdxExpr {}
 
-impl Display for RowIdxExpr {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        DisplayAs::fmt_as(self, DisplayFormat::Dense, f)
-    }
-}
-
 impl DisplayAs for RowIdxExpr {
-    fn fmt_as(&self, _df: DisplayFormat, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "#row_idx")
+    fn fmt_as(&self, df: DisplayFormat, f: &mut Formatter) -> std::fmt::Result {
+        match df {
+            DisplayFormat::Dense => write!(f, "#row_idx"),
+            DisplayFormat::Tree => write!(f, "RowIdxExpr"),
+        }
     }
 }
 

--- a/vortex-layout/src/layouts/row_idx/expr.rs
+++ b/vortex-layout/src/layouts/row_idx/expr.rs
@@ -21,7 +21,7 @@ impl AnalysisExpr for RowIdxExpr {}
 impl DisplayAs for RowIdxExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut Formatter) -> std::fmt::Result {
         match df {
-            DisplayFormat::Dense => write!(f, "#row_idx"),
+            DisplayFormat::Compact => write!(f, "#row_idx"),
             DisplayFormat::Tree => write!(f, "RowIdxExpr"),
         }
     }

--- a/vortex/Cargo.toml
+++ b/vortex/Cargo.toml
@@ -66,7 +66,7 @@ object_store = ["vortex-file/object_store"]
 python = ["vortex-error/python"]
 tokio = ["vortex-file/tokio", "vortex-scan/tokio"]
 zstd = ["dep:vortex-zstd", "vortex-file/zstd", "vortex-layout/zstd"]
-pretty = ["vortex-array/table-display"]
+pretty = ["vortex-array/table-display", "vortex-expr/pretty"]
 
 [[bench]]
 name = "single_encoding_throughput"

--- a/vortex/Cargo.toml
+++ b/vortex/Cargo.toml
@@ -66,7 +66,7 @@ object_store = ["vortex-file/object_store"]
 python = ["vortex-error/python"]
 tokio = ["vortex-file/tokio", "vortex-scan/tokio"]
 zstd = ["dep:vortex-zstd", "vortex-file/zstd", "vortex-layout/zstd"]
-pretty = ["vortex-array/table-display", "vortex-expr/pretty"]
+pretty = ["vortex-array/table-display"]
 
 [[bench]]
 name = "single_encoding_throughput"


### PR DESCRIPTION
My main motivations here are:
1. Display that is easier to understand quickly, especially in deeply nested cases.
2. Easier to diff when using `insta`.

I've made it hidden behind a feature, but not sure that's actually desirable here, it adds one small dependency and it seems unlikely that the code would be misused in some way that will really bomb perf.