### PR TITLE
chore: Unify `slice` methods to use Range arguments

### DIFF
--- a/encodings/alp/src/alp/ops.rs
+++ b/encodings/alp/src/alp/ops.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::{Array, ArrayRef, IntoArray};
 use vortex_error::VortexExpect;
@@ -9,11 +11,13 @@ use vortex_scalar::Scalar;
 use crate::{ALPArray, ALPFloat, ALPVTable, match_each_alp_float_ptype};
 
 impl OperationsVTable<ALPVTable> for ALPVTable {
-    fn slice(array: &ALPArray, start: usize, stop: usize) -> ArrayRef {
+    fn slice(array: &ALPArray, range: Range<usize>) -> ArrayRef {
         ALPArray::new(
-            array.encoded().slice(start, stop),
+            array.encoded().slice(range.clone()),
             array.exponents(),
-            array.patches().and_then(|p| p.slice(start, stop)),
+            array
+                .patches()
+                .and_then(|p| p.slice(range)),
         )
         .into_array()
     }

--- a/encodings/alp/src/alp/ops.rs
+++ b/encodings/alp/src/alp/ops.rs
@@ -15,9 +15,7 @@ impl OperationsVTable<ALPVTable> for ALPVTable {
         ALPArray::new(
             array.encoded().slice(range.clone()),
             array.exponents(),
-            array
-                .patches()
-                .and_then(|p| p.slice(range)),
+            array.patches().and_then(|p| p.slice(range)),
         )
         .into_array()
     }

--- a/encodings/alp/src/alp_rd/ops.rs
+++ b/encodings/alp/src/alp_rd/ops.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::ops::Range;
+
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::{Array, ArrayRef, IntoArray};
 use vortex_error::VortexExpect;
@@ -93,7 +94,7 @@ mod test {
 
         assert!(encoded.left_parts_patches().is_some());
 
-        let decoded = encoded.slice(1, 3).to_primitive().unwrap();
+        let decoded = encoded.slice(1..4).to_primitive().unwrap();
 
         assert_eq!(decoded.as_slice::<T>(), &[b, outlier]);
     }

--- a/encodings/alp/src/alp_rd/ops.rs
+++ b/encodings/alp/src/alp_rd/ops.rs
@@ -94,7 +94,7 @@ mod test {
 
         assert!(encoded.left_parts_patches().is_some());
 
-        let decoded = encoded.slice(1..4).to_primitive().unwrap();
+        let decoded = encoded.slice(1..3).to_primitive().unwrap();
 
         assert_eq!(decoded.as_slice::<T>(), &[b, outlier]);
     }

--- a/encodings/alp/src/alp_rd/ops.rs
+++ b/encodings/alp/src/alp_rd/ops.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::{Array, ArrayRef, IntoArray};
 use vortex_error::VortexExpect;
@@ -9,18 +10,18 @@ use vortex_scalar::Scalar;
 use crate::{ALPRDArray, ALPRDVTable};
 
 impl OperationsVTable<ALPRDVTable> for ALPRDVTable {
-    fn slice(array: &ALPRDArray, start: usize, stop: usize) -> ArrayRef {
+    fn slice(array: &ALPRDArray, range: Range<usize>) -> ArrayRef {
         let left_parts_exceptions = array
             .left_parts_patches()
-            .and_then(|patches| patches.slice(start, stop));
+            .and_then(|patches| patches.slice(range.clone()));
 
         // SAFETY: slicing components does not change the encoded values
         unsafe {
             ALPRDArray::new_unchecked(
                 array.dtype().clone(),
-                array.left_parts().slice(start, stop),
+                array.left_parts().slice(range.clone()),
                 array.left_parts_dictionary().clone(),
-                array.right_parts().slice(start, stop),
+                array.right_parts().slice(range),
                 array.right_bit_width(),
                 left_parts_exceptions,
             )

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use arrow_buffer::BooleanBuffer;
 use std::fmt::Debug;
 use std::ops::Range;
+
+use arrow_buffer::BooleanBuffer;
 use vortex_array::arrays::BoolArray;
 use vortex_array::stats::{ArrayStats, StatsSetRef};
 use vortex_array::validity::Validity;

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::fmt::Debug;
-
 use arrow_buffer::BooleanBuffer;
+use std::fmt::Debug;
+use std::ops::Range;
 use vortex_array::arrays::BoolArray;
 use vortex_array::stats::{ArrayStats, StatsSetRef};
 use vortex_array::validity::Validity;
@@ -120,10 +120,10 @@ impl CanonicalVTable<ByteBoolVTable> for ByteBoolVTable {
 }
 
 impl OperationsVTable<ByteBoolVTable> for ByteBoolVTable {
-    fn slice(array: &ByteBoolArray, start: usize, stop: usize) -> ArrayRef {
+    fn slice(array: &ByteBoolArray, range: Range<usize>) -> ArrayRef {
         ByteBoolArray::new(
-            array.buffer().slice(start..stop),
-            array.validity().slice(start, stop),
+            array.buffer().slice(range.clone()),
+            array.validity().slice(range),
         )
         .into_array()
     }

--- a/encodings/bytebool/src/compute.rs
+++ b/encodings/bytebool/src/compute.rs
@@ -86,7 +86,7 @@ mod tests {
         let original = vec![Some(true), Some(true), None, Some(false), None];
         let vortex_arr = ByteBoolArray::from(original);
 
-        let sliced_arr = vortex_arr.slice(1, 4);
+        let sliced_arr = vortex_arr.slice(1..4);
         let sliced_arr = sliced_arr.as_::<ByteBoolVTable>();
 
         let s = sliced_arr.scalar_at(0);

--- a/encodings/datetime-parts/src/ops.rs
+++ b/encodings/datetime-parts/src/ops.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::{Array, ArrayRef, IntoArray};
 use vortex_dtype::DType;
@@ -12,14 +14,14 @@ use crate::timestamp::TimestampParts;
 use crate::{DateTimePartsArray, DateTimePartsVTable, timestamp};
 
 impl OperationsVTable<DateTimePartsVTable> for DateTimePartsVTable {
-    fn slice(array: &DateTimePartsArray, start: usize, stop: usize) -> ArrayRef {
+    fn slice(array: &DateTimePartsArray, range: Range<usize>) -> ArrayRef {
         // SAFETY: slicing all components preserves values
         unsafe {
             DateTimePartsArray::new_unchecked(
                 array.dtype().clone(),
-                array.days().slice(start, stop),
-                array.seconds().slice(start, stop),
-                array.subseconds().slice(start, stop),
+                array.days().slice(range.clone()),
+                array.seconds().slice(range.clone()),
+                array.subseconds().slice(range),
             )
             .into_array()
         }

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -134,11 +134,8 @@ impl OperationsVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
     fn slice(array: &DecimalBytePartsArray, range: Range<usize>) -> ArrayRef {
         // SAFETY: slicing encoded MSP does not change the encoded values
         unsafe {
-            DecimalBytePartsArray::new_unchecked(
-                array.msp.slice(range),
-                *array.decimal_dtype(),
-            )
-            .into_array()
+            DecimalBytePartsArray::new_unchecked(array.msp.slice(range), *array.decimal_dtype())
+                .into_array()
         }
     }
 

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -4,6 +4,8 @@
 mod compute;
 mod serde;
 
+use std::ops::Range;
+
 use vortex_array::arrays::DecimalArray;
 use vortex_array::stats::{ArrayStats, StatsSetRef};
 use vortex_array::vtable::{
@@ -129,11 +131,11 @@ impl CanonicalVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
 }
 
 impl OperationsVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
-    fn slice(array: &DecimalBytePartsArray, start: usize, stop: usize) -> ArrayRef {
+    fn slice(array: &DecimalBytePartsArray, range: Range<usize>) -> ArrayRef {
         // SAFETY: slicing encoded MSP does not change the encoded values
         unsafe {
             DecimalBytePartsArray::new_unchecked(
-                array.msp.slice(start, stop),
+                array.msp.slice(range),
                 *array.decimal_dtype(),
             )
             .into_array()

--- a/encodings/dict/benches/dict_compare.rs
+++ b/encodings/dict/benches/dict_compare.rs
@@ -105,7 +105,7 @@ fn bench_compare_sliced_dict_primitive(
 ) {
     let primitive_arr = gen_primitive_for_dict::<i32>(codes_len.max(values_len), values_len);
     let dict = dict_encode(primitive_arr.as_ref()).unwrap();
-    let dict = dict.slice(0, codes_len);
+    let dict = dict.slice(0..codes_len);
     let value = primitive_arr.as_slice::<i32>()[0];
 
     bencher.with_inputs(|| dict.clone()).bench_refs(|dict| {
@@ -125,7 +125,7 @@ fn bench_compare_sliced_dict_varbinview(
 ) {
     let varbin_arr = VarBinArray::from(gen_varbin_words(codes_len.max(values_len), values_len));
     let dict = dict_encode(varbin_arr.as_ref()).unwrap();
-    let dict = dict.slice(0, codes_len);
+    let dict = dict.slice(0..codes_len);
     let bytes = varbin_arr
         .with_iterator(|i| i.next().unwrap().unwrap().to_vec())
         .unwrap();

--- a/encodings/dict/src/compute/binary_numeric.rs
+++ b/encodings/dict/src/compute/binary_numeric.rs
@@ -78,7 +78,7 @@ mod tests {
     #[case::dict_u64_basic(dict_encode(PrimitiveArray::from_iter([5000u64, 6000, 5000, 7000, 6000]).as_ref()).unwrap().into_array())]
     #[case::dict_f32_basic(dict_encode(PrimitiveArray::from_iter([1.5f32, 2.5, 1.5, 3.5, 2.5]).as_ref()).unwrap().into_array())]
     #[case::dict_f64_basic(dict_encode(PrimitiveArray::from_iter([10.1f64, 20.2, 10.1, 30.3, 20.2]).as_ref()).unwrap().into_array())]
-    #[case::dict_i32_sliced(dict_encode(PrimitiveArray::from_iter([100i32, 200, 100, 300, 200, 100]).as_ref()).unwrap().slice(1..6))]
+    #[case::dict_i32_sliced(dict_encode(PrimitiveArray::from_iter([100i32, 200, 100, 300, 200, 100]).as_ref()).unwrap().slice(1..5))]
     #[case::dict_nullable(dict_encode(PrimitiveArray::from_option_iter([Some(42i32), None, Some(42), Some(1), None]).as_ref()).unwrap().into_array())]
     fn test_dict_binary_numeric_rstest(#[case] array: ArrayRef) {
         test_binary_numeric_array(array)

--- a/encodings/dict/src/compute/binary_numeric.rs
+++ b/encodings/dict/src/compute/binary_numeric.rs
@@ -60,7 +60,7 @@ mod tests {
             Some(5),
         ]);
         let dict = dict_encode(reference.as_ref()).unwrap();
-        dict.slice(1, 4)
+        dict.slice(1..4)
     }
 
     #[test]
@@ -78,7 +78,7 @@ mod tests {
     #[case::dict_u64_basic(dict_encode(PrimitiveArray::from_iter([5000u64, 6000, 5000, 7000, 6000]).as_ref()).unwrap().into_array())]
     #[case::dict_f32_basic(dict_encode(PrimitiveArray::from_iter([1.5f32, 2.5, 1.5, 3.5, 2.5]).as_ref()).unwrap().into_array())]
     #[case::dict_f64_basic(dict_encode(PrimitiveArray::from_iter([10.1f64, 20.2, 10.1, 30.3, 20.2]).as_ref()).unwrap().into_array())]
-    #[case::dict_i32_sliced(dict_encode(PrimitiveArray::from_iter([100i32, 200, 100, 300, 200, 100]).as_ref()).unwrap().slice(1, 5))]
+    #[case::dict_i32_sliced(dict_encode(PrimitiveArray::from_iter([100i32, 200, 100, 300, 200, 100]).as_ref()).unwrap().slice(1..6))]
     #[case::dict_nullable(dict_encode(PrimitiveArray::from_option_iter([Some(42i32), None, Some(42), Some(1), None]).as_ref()).unwrap().into_array())]
     fn test_dict_binary_numeric_rstest(#[case] array: ArrayRef) {
         test_binary_numeric_array(array)

--- a/encodings/dict/src/compute/mod.rs
+++ b/encodings/dict/src/compute/mod.rs
@@ -152,7 +152,7 @@ mod test {
             Some(5),
         ]);
         let dict = dict_encode(reference.as_ref()).unwrap();
-        dict.slice(1, 4)
+        dict.slice(1..4)
     }
 
     #[test]

--- a/encodings/dict/src/ops.rs
+++ b/encodings/dict/src/ops.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 use vortex_array::arrays::{ConstantArray, ConstantVTable};
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::{Array, ArrayRef, IntoArray};
@@ -10,8 +12,8 @@ use vortex_scalar::Scalar;
 use crate::{DictArray, DictVTable};
 
 impl OperationsVTable<DictVTable> for DictVTable {
-    fn slice(array: &DictArray, start: usize, stop: usize) -> ArrayRef {
-        let sliced_code = array.codes().slice(start, stop);
+    fn slice(array: &DictArray, range: Range<usize>) -> ArrayRef {
+        let sliced_code = array.codes().slice(range);
         if sliced_code.is::<ConstantVTable>() {
             let code = &sliced_code.scalar_at(0).as_primitive().as_::<usize>();
             return if let Some(code) = code {
@@ -55,12 +57,12 @@ mod tests {
 
         assert_eq!(
             Some(Scalar::new(dict.dtype().clone(), 0i32.into())),
-            dict.slice(0, 1).as_constant()
+            dict.slice(0..1).as_constant()
         );
 
         assert_eq!(
             Some(Scalar::null(dict.dtype().clone())),
-            dict.slice(1, 2).as_constant()
+            dict.slice(1..2).as_constant()
         );
     }
 }

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -622,7 +622,7 @@ mod test {
         let bitpacked = bitpack_encode(&zeros, 10, None).unwrap();
         assert_eq!(bitpacked.len(), 1025);
         assert!(bitpacked.patches().is_some());
-        let bitpacked = bitpacked.slice(1023, 1025);
+        let bitpacked = bitpacked.slice(1023..1025);
         let actual = unpack(bitpacked.as_::<BitPackedVTable>()).unwrap();
         let actual = actual.as_slice::<u16>();
         assert_eq!(actual, &[1535, 1536]);
@@ -637,7 +637,7 @@ mod test {
         let bitpacked = bitpack_encode(&zeros, 10, None).unwrap();
         assert_eq!(bitpacked.len(), 2229);
         assert!(bitpacked.patches().is_some());
-        let bitpacked = bitpacked.slice(1023, 2049);
+        let bitpacked = bitpacked.slice(1023..2049);
         let actual = unpack(bitpacked.as_::<BitPackedVTable>()).unwrap();
         let actual = actual.as_slice::<u16>();
         assert_eq!(actual, &(1023..2049).map(|x| x + 512).collect::<Vec<_>>());

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -181,7 +181,7 @@ mod test {
         // Create a u8 array modulo 63.
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
         let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 6).unwrap();
-        let sliced = bitpacked.slice(128, 2050);
+        let sliced = bitpacked.slice(128..2050);
 
         let mask = Mask::from_indices(sliced.len(), vec![1919, 1921]);
 

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -181,7 +181,7 @@ mod test {
         // Create a u8 array modulo 63.
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
         let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 6).unwrap();
-        let sliced = bitpacked.slice(128, 2050);
+        let sliced = bitpacked.slice(128..2050);
 
         let primitive_result = take(&sliced, &indices).unwrap().to_primitive().unwrap();
         let res_bytes = primitive_result.as_slice::<u8>();

--- a/encodings/fastlanes/src/bitpacking/ops.rs
+++ b/encodings/fastlanes/src/bitpacking/ops.rs
@@ -27,10 +27,10 @@ impl OperationsVTable<BitPackedVTable> for BitPackedVTable {
             BitPackedArray::new_unchecked(
                 array.packed().slice(encoded_start..encoded_stop),
                 array.dtype.clone(),
-                array.validity().slice(range.start..range.end),
+                array.validity().slice(range.clone()),
                 array
                     .patches()
-                    .and_then(|p| p.slice(range.start..range.end)),
+                    .and_then(|p| p.slice(range.clone())),
                 array.bit_width(),
                 range.len(),
                 offset as u16,

--- a/encodings/fastlanes/src/bitpacking/ops.rs
+++ b/encodings/fastlanes/src/bitpacking/ops.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::cmp::max;
+use std::ops::Range;
 
 use vortex_array::vtable::{OperationsVTable, ValidityHelper};
 use vortex_array::{ArrayRef, IntoArray};
@@ -10,9 +11,9 @@ use vortex_scalar::Scalar;
 use crate::{BitPackedArray, BitPackedVTable, unpack_single};
 
 impl OperationsVTable<BitPackedVTable> for BitPackedVTable {
-    fn slice(array: &BitPackedArray, start: usize, stop: usize) -> ArrayRef {
-        let offset_start = start + array.offset() as usize;
-        let offset_stop = stop + array.offset() as usize;
+    fn slice(array: &BitPackedArray, range: Range<usize>) -> ArrayRef {
+        let offset_start = range.start + array.offset() as usize;
+        let offset_stop = range.end + array.offset() as usize;
         let offset = offset_start % 1024;
         let block_start = max(0, offset_start - offset);
         let block_stop = offset_stop.div_ceil(1024) * 1024;
@@ -26,10 +27,12 @@ impl OperationsVTable<BitPackedVTable> for BitPackedVTable {
             BitPackedArray::new_unchecked(
                 array.packed().slice(encoded_start..encoded_stop),
                 array.dtype.clone(),
-                array.validity().slice(start, stop),
-                array.patches().and_then(|p| p.slice(start, stop)),
+                array.validity().slice(range.start..range.end),
+                array
+                    .patches()
+                    .and_then(|p| p.slice(range.start..range.end)),
                 array.bit_width(),
-                stop - start,
+                range.len(),
                 offset as u16,
             )
             .into_array()
@@ -67,7 +70,7 @@ mod test {
             6,
         )
         .unwrap();
-        let sliced = arr.slice(1024, 2048).as_::<BitPackedVTable>().clone();
+        let sliced = arr.slice(1024..2048).as_::<BitPackedVTable>().clone();
         assert_eq!(sliced.scalar_at(0), (1024u32 % 64).into());
         assert_eq!(sliced.scalar_at(1023), (2047u32 % 64).into());
         assert_eq!(sliced.offset(), 0);
@@ -82,7 +85,7 @@ mod test {
         )
         .unwrap()
         .into_array();
-        let sliced = arr.slice(512, 1434).as_::<BitPackedVTable>().clone();
+        let sliced = arr.slice(512..1434).as_::<BitPackedVTable>().clone();
         assert_eq!(sliced.scalar_at(0), (512u32 % 64).into());
         assert_eq!(sliced.scalar_at(921), (1433u32 % 64).into());
         assert_eq!(sliced.offset(), 512);
@@ -97,7 +100,7 @@ mod test {
         )
         .unwrap();
 
-        let compressed = packed.slice(768, 9999);
+        let compressed = packed.slice(768..9999);
         assert_eq!(compressed.scalar_at(0), ((768 % 63) as u8).into());
         assert_eq!(
             compressed.scalar_at(compressed.len() - 1),
@@ -113,7 +116,7 @@ mod test {
         )
         .unwrap();
 
-        let compressed = packed.slice(7168, 9216);
+        let compressed = packed.slice(7168..9216);
         assert_eq!(compressed.scalar_at(0), ((7168 % 63) as u8).into());
         assert_eq!(
             compressed.scalar_at(compressed.len() - 1),
@@ -129,12 +132,12 @@ mod test {
         )
         .unwrap()
         .into_array();
-        let sliced = arr.slice(512, 1434).as_::<BitPackedVTable>().clone();
+        let sliced = arr.slice(512..1434).as_::<BitPackedVTable>().clone();
         assert_eq!(sliced.scalar_at(0), (512u32 % 64).into());
         assert_eq!(sliced.scalar_at(921), (1433u32 % 64).into());
         assert_eq!(sliced.offset(), 512);
         assert_eq!(sliced.len(), 922);
-        let doubly_sliced = sliced.slice(127, 911).as_::<BitPackedVTable>().clone();
+        let doubly_sliced = sliced.slice(127..911).as_::<BitPackedVTable>().clone();
         assert_eq!(doubly_sliced.scalar_at(0), ((512u32 + 127) % 64).into());
         assert_eq!(doubly_sliced.scalar_at(783), ((512u32 + 910) % 64).into());
         assert_eq!(doubly_sliced.offset(), 639);
@@ -153,7 +156,7 @@ mod test {
         assert_eq!(patch_indices.len(), 1);
 
         // Slicing drops the empty patches array.
-        let sliced = array.slice(0, 64);
+        let sliced = array.slice(0..64);
         let sliced_bp = sliced.as_::<BitPackedVTable>();
         assert!(sliced_bp.patches().is_none());
     }
@@ -168,7 +171,7 @@ mod test {
 
         // Slice the array.
         // The resulting array will still have 3 1024-element chunks.
-        let sliced = array.slice(922, 2061);
+        let sliced = array.slice(922..2061);
 
         // Take one element from each chunk.
         // Chunk 1: physical indices  922-1023, logical indices    0-101

--- a/encodings/fastlanes/src/bitpacking/ops.rs
+++ b/encodings/fastlanes/src/bitpacking/ops.rs
@@ -28,9 +28,7 @@ impl OperationsVTable<BitPackedVTable> for BitPackedVTable {
                 array.packed().slice(encoded_start..encoded_stop),
                 array.dtype.clone(),
                 array.validity().slice(range.clone()),
-                array
-                    .patches()
-                    .and_then(|p| p.slice(range.clone())),
+                array.patches().and_then(|p| p.slice(range.clone())),
                 array.bit_width(),
                 range.len(),
                 offset as u16,

--- a/encodings/fastlanes/src/delta/compress.rs
+++ b/encodings/fastlanes/src/delta/compress.rs
@@ -108,7 +108,7 @@ pub fn delta_decompress(array: &DeltaArray) -> VortexResult<PrimitiveArray> {
     });
 
     decoded
-        .slice(array.offset(), array.offset() + array.len())
+        .slice(array.offset()..array.offset() + array.len())
         .to_primitive()
 }
 

--- a/encodings/fastlanes/src/delta/ops.rs
+++ b/encodings/fastlanes/src/delta/ops.rs
@@ -3,6 +3,7 @@
 
 use std::cmp::min;
 use std::ops::Range;
+
 use vortex_array::vtable::{OperationsVTable, ValidityHelper};
 use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
 use vortex_error::VortexExpect;
@@ -48,7 +49,7 @@ impl OperationsVTable<DeltaVTable> for DeltaVTable {
 
     fn scalar_at(array: &DeltaArray, index: usize) -> Scalar {
         let decompressed = array
-            .slice(index..=index)
+            .slice(index..index + 1)
             .to_primitive()
             .vortex_expect("delta must decode to primitive");
         decompressed.scalar_at(0)
@@ -84,7 +85,7 @@ mod test {
 
         assert_eq!(
             delta
-                .slice(1024 + 10, 1024 + 250)
+                .slice(1024 + 10..1024 + 250)
                 .to_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
@@ -112,7 +113,7 @@ mod test {
 
         assert_eq!(
             delta
-                .slice(2040, 2050)
+                .slice(2040..2050)
                 .to_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
@@ -126,7 +127,7 @@ mod test {
 
         assert_eq!(
             delta
-                .slice(0, 4096)
+                .slice(0..4096)
                 .to_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
@@ -139,13 +140,13 @@ mod test {
         let delta = DeltaArray::try_from_vec((0u32..4096).collect()).unwrap();
 
         assert_eq!(
-            delta.slice(0, 0).to_primitive().unwrap().as_slice::<u32>(),
+            delta.slice(0..0).to_primitive().unwrap().as_slice::<u32>(),
             Vec::<u32>::new(),
         );
 
         assert_eq!(
             delta
-                .slice(4096, 4096)
+                .slice(4096..4096)
                 .to_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
@@ -154,7 +155,7 @@ mod test {
 
         assert_eq!(
             delta
-                .slice(1024, 1024)
+                .slice(1024..1024)
                 .to_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
@@ -168,7 +169,7 @@ mod test {
 
         assert_eq!(
             delta
-                .slice(1024 + 10, 1024 + 250)
+                .slice(1024 + 10..1024 + 250)
                 .to_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
@@ -181,13 +182,13 @@ mod test {
         let delta = DeltaArray::try_from_vec((0u32..4000).collect()).unwrap();
 
         assert_eq!(
-            delta.slice(0, 0).to_primitive().unwrap().as_slice::<u32>(),
+            delta.slice(0..0).to_primitive().unwrap().as_slice::<u32>(),
             Vec::<u32>::new(),
         );
 
         assert_eq!(
             delta
-                .slice(4000, 4000)
+                .slice(4000..4000)
                 .to_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
@@ -196,7 +197,7 @@ mod test {
 
         assert_eq!(
             delta
-                .slice(1024, 1024)
+                .slice(1024..1024)
                 .to_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
@@ -208,8 +209,8 @@ mod test {
     fn test_slice_of_slice_of_non_jagged() {
         let delta = DeltaArray::try_from_vec((0u32..2048).collect()).unwrap();
 
-        let sliced = delta.slice(10, 1013);
-        let sliced_again = sliced.slice(0, 2);
+        let sliced = delta.slice(10..1013);
+        let sliced_again = sliced.slice(0..2);
 
         assert_eq!(
             sliced_again.to_primitive().unwrap().as_slice::<u32>(),
@@ -221,8 +222,8 @@ mod test {
     fn test_slice_of_slice_of_jagged() {
         let delta = DeltaArray::try_from_vec((0u32..2000).collect()).unwrap();
 
-        let sliced = delta.slice(10, 1013);
-        let sliced_again = sliced.slice(0, 2);
+        let sliced = delta.slice(10..1013);
+        let sliced_again = sliced.slice(0..2);
 
         assert_eq!(
             sliced_again.to_primitive().unwrap().as_slice::<u32>(),
@@ -234,8 +235,8 @@ mod test {
     fn test_slice_of_slice_second_chunk_of_non_jagged() {
         let delta = DeltaArray::try_from_vec((0u32..2048).collect()).unwrap();
 
-        let sliced = delta.slice(1034, 1050);
-        let sliced_again = sliced.slice(0, 2);
+        let sliced = delta.slice(1034..1050);
+        let sliced_again = sliced.slice(0..2);
 
         assert_eq!(
             sliced_again.to_primitive().unwrap().as_slice::<u32>(),
@@ -247,8 +248,8 @@ mod test {
     fn test_slice_of_slice_second_chunk_of_jagged() {
         let delta = DeltaArray::try_from_vec((0u32..2000).collect()).unwrap();
 
-        let sliced = delta.slice(1034, 1050);
-        let sliced_again = sliced.slice(0, 2);
+        let sliced = delta.slice(1034..1050);
+        let sliced_again = sliced.slice(0..2);
 
         assert_eq!(
             sliced_again.to_primitive().unwrap().as_slice::<u32>(),
@@ -260,8 +261,8 @@ mod test {
     fn test_slice_of_slice_spanning_two_chunks_of_non_jagged() {
         let delta = DeltaArray::try_from_vec((0u32..2048).collect()).unwrap();
 
-        let sliced = delta.slice(1010, 1050);
-        let sliced_again = sliced.slice(5, 20);
+        let sliced = delta.slice(1010..1050);
+        let sliced_again = sliced.slice(5..20);
 
         assert_eq!(
             sliced_again.to_primitive().unwrap().as_slice::<u32>(),
@@ -273,8 +274,8 @@ mod test {
     fn test_slice_of_slice_spanning_two_chunks_of_jagged() {
         let delta = DeltaArray::try_from_vec((0u32..2000).collect()).unwrap();
 
-        let sliced = delta.slice(1010, 1050);
-        let sliced_again = sliced.slice(5, 20);
+        let sliced = delta.slice(1010..1050);
+        let sliced_again = sliced.slice(5..20);
 
         assert_eq!(
             sliced_again.to_primitive().unwrap().as_slice::<u32>(),

--- a/encodings/fastlanes/src/delta/ops.rs
+++ b/encodings/fastlanes/src/delta/ops.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::cmp::min;
-
+use std::ops::Range;
 use vortex_array::vtable::{OperationsVTable, ValidityHelper};
 use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
 use vortex_error::VortexExpect;
@@ -11,9 +11,9 @@ use vortex_scalar::Scalar;
 use crate::{DeltaArray, DeltaVTable};
 
 impl OperationsVTable<DeltaVTable> for DeltaVTable {
-    fn slice(array: &DeltaArray, start: usize, stop: usize) -> ArrayRef {
-        let physical_start = start + array.offset();
-        let physical_stop = stop + array.offset();
+    fn slice(array: &DeltaArray, range: Range<usize>) -> ArrayRef {
+        let physical_start = range.start + array.offset();
+        let physical_stop = range.end + array.offset();
 
         let start_chunk = physical_start / 1024;
         let stop_chunk = physical_stop.div_ceil(1024);
@@ -24,18 +24,14 @@ impl OperationsVTable<DeltaVTable> for DeltaVTable {
         let lanes = array.lanes();
 
         let new_bases = bases.slice(
-            min(start_chunk * lanes, array.bases_len()),
-            min(stop_chunk * lanes, array.bases_len()),
+            min(start_chunk * lanes, array.bases_len())..min(stop_chunk * lanes, array.bases_len()),
         );
 
         let new_deltas = deltas.slice(
-            min(start_chunk * 1024, array.deltas_len()),
-            min(stop_chunk * 1024, array.deltas_len()),
+            min(start_chunk * 1024, array.deltas_len())..min(stop_chunk * 1024, array.deltas_len()),
         );
 
-        let new_validity = validity.slice(start, stop);
-
-        let logical_len = stop - start;
+        let new_validity = validity.slice(range.clone());
 
         // SAFETY: slicing valid bases/deltas preserves correctness
         unsafe {
@@ -44,7 +40,7 @@ impl OperationsVTable<DeltaVTable> for DeltaVTable {
                 new_deltas,
                 new_validity,
                 physical_start % 1024,
-                logical_len,
+                range.len(),
             )
             .into_array()
         }
@@ -52,7 +48,7 @@ impl OperationsVTable<DeltaVTable> for DeltaVTable {
 
     fn scalar_at(array: &DeltaArray, index: usize) -> Scalar {
         let decompressed = array
-            .slice(index, index + 1)
+            .slice(index..=index)
             .to_primitive()
             .vortex_expect("delta must decode to primitive");
         decompressed.scalar_at(0)
@@ -74,7 +70,7 @@ mod test {
 
         assert_eq!(
             delta
-                .slice(10, 250)
+                .slice(10..250)
                 .to_primitive()
                 .unwrap()
                 .as_slice::<u32>(),
@@ -102,7 +98,7 @@ mod test {
 
         assert_eq!(
             delta
-                .slice(1000, 1048)
+                .slice(1000..1048)
                 .to_primitive()
                 .unwrap()
                 .as_slice::<u32>(),

--- a/encodings/fastlanes/src/for/ops.rs
+++ b/encodings/fastlanes/src/for/ops.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::{Array, ArrayRef, IntoArray};
 use vortex_dtype::match_each_integer_ptype;
@@ -10,11 +12,11 @@ use vortex_scalar::Scalar;
 use crate::{FoRArray, FoRVTable};
 
 impl OperationsVTable<FoRVTable> for FoRVTable {
-    fn slice(array: &FoRArray, start: usize, stop: usize) -> ArrayRef {
+    fn slice(array: &FoRArray, range: Range<usize>) -> ArrayRef {
         // SAFETY: just slicing encoded data does not affect FOR
         unsafe {
             FoRArray::new_unchecked(
-                array.encoded().slice(start, stop),
+                array.encoded().slice(range),
                 array.reference_scalar().clone(),
             )
             .into_array()

--- a/encodings/fsst/src/ops.rs
+++ b/encodings/fsst/src/ops.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 use vortex_array::arrays::{VarBinVTable, varbin_scalar};
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::{Array, ArrayRef, IntoArray};
@@ -11,7 +13,7 @@ use vortex_scalar::Scalar;
 use crate::{FSSTArray, FSSTVTable};
 
 impl OperationsVTable<FSSTVTable> for FSSTVTable {
-    fn slice(array: &FSSTArray, start: usize, stop: usize) -> ArrayRef {
+    fn slice(array: &FSSTArray, range: Range<usize>) -> ArrayRef {
         // SAFETY: slicing the `codes` leaves the symbol table intact
         unsafe {
             FSSTArray::new_unchecked(
@@ -20,10 +22,10 @@ impl OperationsVTable<FSSTVTable> for FSSTVTable {
                 array.symbol_lengths().clone(),
                 array
                     .codes()
-                    .slice(start, stop)
+                    .slice(range.clone())
                     .as_::<VarBinVTable>()
                     .clone(),
-                array.uncompressed_lengths().slice(start, stop),
+                array.uncompressed_lengths().slice(range),
             )
             .into_array()
         }

--- a/encodings/fsst/src/tests.rs
+++ b/encodings/fsst/src/tests.rs
@@ -53,7 +53,7 @@ fn test_fsst_array_ops() {
     );
 
     // test slice
-    let fsst_sliced = fsst_array.slice(1, 3);
+    let fsst_sliced = fsst_array.slice(1..3);
     assert_eq!(fsst_sliced.encoding_id(), FSSTEncoding.id());
     assert_eq!(fsst_sliced.len(), 2);
     assert_nth_scalar!(

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -3,6 +3,7 @@
 
 use std::cmp;
 use std::fmt::Debug;
+use std::ops::Range;
 
 use pco::data_types::{Number, NumberType};
 use pco::errors::PcoError;
@@ -242,7 +243,7 @@ impl PcoArray {
             values_byte_buffer,
             self.dtype.as_ptype(),
             self.unsliced_validity
-                .slice(self.slice_start, self.slice_stop),
+                .slice(self.slice_start..self.slice_stop),
             self.slice_stop - self.slice_start,
         )?;
         Ok(primitive.into_array())
@@ -370,8 +371,8 @@ impl CanonicalVTable<PcoVTable> for PcoVTable {
 }
 
 impl OperationsVTable<PcoVTable> for PcoVTable {
-    fn slice(array: &PcoArray, start: usize, stop: usize) -> ArrayRef {
-        array._slice(start, stop).into_array()
+    fn slice(array: &PcoArray, range: Range<usize>) -> ArrayRef {
+        array._slice(range.start, range.end).into_array()
     }
 
     fn scalar_at(array: &PcoArray, index: usize) -> Scalar {

--- a/encodings/pco/src/test.rs
+++ b/encodings/pco/src/test.rs
@@ -30,14 +30,14 @@ fn test_compress_decompress() {
     assert_eq!(decompressed.as_slice::<i32>(), &data);
 
     // check slicing works
-    let slice = compressed.slice(100, 105);
+    let slice = compressed.slice(100..105);
     for i in 0_i32..5 {
         assert_nth_scalar!(slice, i as usize, 100 + i);
     }
     let primitive = slice.to_primitive().unwrap();
     assert_eq!(primitive.as_slice::<i32>(), &[100, 101, 102, 103, 104]);
 
-    let slice = compressed.slice(200, 200);
+    let slice = compressed.slice(200..200);
     let primitive = slice.to_primitive().unwrap();
     assert_eq!(primitive.as_slice::<i32>(), &Vec::<i32>::new());
 }
@@ -83,7 +83,7 @@ fn test_validity_and_multiple_chunks_and_pages() {
     assert_nth_scalar!(compressed, 199, 199);
 
     // check slicing works
-    let slice = compressed.slice(100, 103);
+    let slice = compressed.slice(100..103);
     assert_nth_scalar!(slice, 0, 100);
     assert_nth_scalar!(slice, 2, 102);
     let primitive = slice.to_primitive().unwrap();
@@ -107,7 +107,7 @@ fn test_validity_vtable() {
         Mask::from_iter(mask_bools)
     );
     assert_eq!(
-        compressed.slice(1, 4).validity_mask().unwrap(),
+        compressed.slice(1..4).validity_mask().unwrap(),
         Mask::from_iter(vec![true, true, false])
     );
 }

--- a/encodings/runend/src/arrow.rs
+++ b/encodings/runend/src/arrow.rs
@@ -41,8 +41,8 @@ where
                 + 1;
 
             (
-                ends.slice(slice_begin, slice_end),
-                values.slice(slice_begin, slice_end),
+                ends.slice(slice_begin..slice_end),
+                values.slice(slice_begin..slice_end),
             )
         };
 

--- a/encodings/runend/src/compute/cast.rs
+++ b/encodings/runend/src/compute/cast.rs
@@ -99,7 +99,7 @@ mod tests {
         .unwrap();
 
         // Slice it to get offset 3, length 5: [200, 200, 300, 300, 300]
-        let sliced = runend.slice(3, 8);
+        let sliced = runend.slice(3..8);
 
         // Verify the slice is correct before casting
         let sliced_decoded = sliced.to_canonical().unwrap().into_primitive().unwrap();

--- a/encodings/runend/src/compute/filter.rs
+++ b/encodings/runend/src/compute/filter.rs
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn filter_sliced_run_end() {
-        let arr = ree_array().slice(2, 7);
+        let arr = ree_array().slice(2..7);
         let filtered = filter_run_end(
             arr.as_::<RunEndVTable>(),
             &Mask::from_iter([true, false, false, true, true]),

--- a/encodings/runend/src/compute/take.rs
+++ b/encodings/runend/src/compute/take.rs
@@ -128,7 +128,7 @@ mod test {
 
     #[test]
     fn sliced_take() {
-        let sliced = ree_array().slice(4, 9);
+        let sliced = ree_array().slice(4..9);
         let taken = take(
             sliced.as_ref(),
             PrimitiveArray::from_iter([1, 3, 4]).as_ref(),
@@ -198,13 +198,13 @@ mod test {
     }
 
     #[rstest]
-    #[case(ree_array().slice(3, 6))]
+    #[case(ree_array().slice(3..9))]
     #[case({
         let array = RunEndArray::encode(
             PrimitiveArray::from_iter([1i32, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]).into_array(),
         )
         .unwrap();
-        array.slice(2, 8)
+        array.slice(2..10)
     })]
     fn test_take_sliced_runend_conformance(#[case] sliced: ArrayRef) {
         test_take_conformance(sliced.as_ref());

--- a/encodings/runend/src/compute/take.rs
+++ b/encodings/runend/src/compute/take.rs
@@ -198,13 +198,13 @@ mod test {
     }
 
     #[rstest]
-    #[case(ree_array().slice(3..9))]
+    #[case(ree_array().slice(3..6))]
     #[case({
         let array = RunEndArray::encode(
             PrimitiveArray::from_iter([1i32, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]).into_array(),
         )
         .unwrap();
-        array.slice(2..10)
+        array.slice(2..8)
     })]
     fn test_take_sliced_runend_conformance(#[case] sliced: ArrayRef) {
         test_take_conformance(sliced.as_ref());

--- a/encodings/runend/src/ops.rs
+++ b/encodings/runend/src/ops.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 use vortex_array::arrays::ConstantArray;
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::{Array, ArrayRef, IntoArray};
@@ -9,11 +11,11 @@ use vortex_scalar::Scalar;
 use crate::{RunEndArray, RunEndVTable};
 
 impl OperationsVTable<RunEndVTable> for RunEndVTable {
-    fn slice(array: &RunEndArray, start: usize, stop: usize) -> ArrayRef {
-        let new_length = stop - start;
+    fn slice(array: &RunEndArray, range: Range<usize>) -> ArrayRef {
+        let new_length = range.len();
 
-        let slice_begin = array.find_physical_index(start);
-        let slice_end = array.find_physical_index(stop) + 1;
+        let slice_begin = array.find_physical_index(range.start);
+        let slice_end = array.find_physical_index(range.end) + 1;
 
         // If the sliced range contains only a single run, opt to return a ConstantArray.
         if slice_begin + 1 == slice_end {
@@ -24,9 +26,9 @@ impl OperationsVTable<RunEndVTable> for RunEndVTable {
         // SAFETY: we maintain the ends invariant in our slice implementation
         unsafe {
             RunEndArray::new_unchecked(
-                array.ends().slice(slice_begin, slice_end),
-                array.values().slice(slice_begin, slice_end),
-                start + array.offset(),
+                array.ends().slice(slice_begin..slice_end),
+                array.values().slice(slice_begin..slice_end),
+                range.start + array.offset(),
                 new_length,
             )
             .into_array()
@@ -54,7 +56,7 @@ mod tests {
             buffer![1i32, 2, 3].into_array(),
         )
         .unwrap()
-        .slice(3, 8);
+        .slice(3..8);
         assert_eq!(
             arr.dtype(),
             &DType::Primitive(PType::I32, Nullability::NonNullable)
@@ -74,10 +76,10 @@ mod tests {
             buffer![1i32, 2, 3].into_array(),
         )
         .unwrap()
-        .slice(3, 8);
+        .slice(3..8);
         assert_eq!(arr.len(), 5);
 
-        let doubly_sliced = arr.slice(0, 3);
+        let doubly_sliced = arr.slice(0..3);
 
         assert_eq!(
             doubly_sliced.to_primitive().unwrap().as_slice::<i32>(),
@@ -92,7 +94,7 @@ mod tests {
             buffer![1i32, 2, 3].into_array(),
         )
         .unwrap()
-        .slice(4, 10);
+        .slice(4..10);
         assert_eq!(
             arr.dtype(),
             &DType::Primitive(PType::I32, Nullability::NonNullable)
@@ -115,7 +117,7 @@ mod tests {
 
         assert_eq!(re_array.len(), 10);
 
-        let sliced_array = re_array.slice(re_array.len(), re_array.len());
+        let sliced_array = re_array.slice(re_array.len()..re_array.len());
         assert!(sliced_array.is_empty());
     }
 
@@ -129,7 +131,7 @@ mod tests {
 
         assert_eq!(re_array.len(), 10);
 
-        let sliced_array = re_array.slice(2, 5);
+        let sliced_array = re_array.slice(2..5);
 
         assert!(sliced_array.is_constant())
     }

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use num_traits::cast::FromPrimitive;
 use std::ops::Range;
+
+use num_traits::cast::FromPrimitive;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::stats::{ArrayStats, StatsSetRef};
 use vortex_array::vtable::{
@@ -279,7 +280,7 @@ mod tests {
     fn test_sequence_slice_canonical() {
         let arr = SequenceArray::typed_new(2i64, 3, Nullability::NonNullable, 4)
             .unwrap()
-            .slice(2, 3);
+            .slice(2..3);
 
         let canon = PrimitiveArray::from_iter((2..3).map(|i| 2i64 + i * 3));
 

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use num_traits::cast::FromPrimitive;
+use std::ops::Range;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::stats::{ArrayStats, StatsSetRef};
 use vortex_array::vtable::{
@@ -202,13 +203,13 @@ impl CanonicalVTable<SequenceVTable> for SequenceVTable {
 }
 
 impl OperationsVTable<SequenceVTable> for SequenceVTable {
-    fn slice(array: &SequenceArray, start: usize, stop: usize) -> ArrayRef {
+    fn slice(array: &SequenceArray, range: Range<usize>) -> ArrayRef {
         SequenceArray::unchecked_new(
-            array.index_value(start),
+            array.index_value(range.start),
             array.multiplier,
             array.ptype(),
             array.dtype().nullability(),
-            stop - start,
+            range.len(),
         )
         .to_array()
     }

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -221,7 +221,7 @@ fn canonicalize_sparse_lists_inner<I: NativePType, SmallestViableOffsetType: Off
         for _ in next_index..next_patched_index {
             builder.extend_from_array(&fill_value_array)?;
         }
-        builder.extend_from_array(&values.slice(patch_values_index, patch_values_index + 1))?;
+        builder.extend_from_array(&values.slice(patch_values_index..patch_values_index + 1))?;
         next_index = next_patched_index + 1;
     }
 
@@ -1050,7 +1050,7 @@ mod test {
         let lists = ListArray::try_new(elements, offsets, Validity::AllValid)
             .unwrap()
             .into_array();
-        let lists = lists.slice(2, 6);
+        let lists = lists.slice(2..6);
 
         let indices = buffer![0u8, 3u8, 4u8, 5u8].into_array();
         let fill_value = Scalar::null(lists.dtype().clone());

--- a/encodings/sparse/src/compute/take.rs
+++ b/encodings/sparse/src/compute/take.rs
@@ -77,7 +77,7 @@ mod test {
     #[test]
     fn take_with_non_zero_offset() {
         let sparse = sparse_array();
-        let sparse = sparse.slice(30..70);
+        let sparse = sparse.slice(30..40);
         let sparse = take(&sparse, &buffer![6, 7, 8].into_array()).unwrap();
         assert_eq!(sparse.scalar_at(0), test_array_fill_value());
         assert_eq!(sparse.scalar_at(1), Scalar::from(Some(0.47)));

--- a/encodings/sparse/src/compute/take.rs
+++ b/encodings/sparse/src/compute/take.rs
@@ -77,7 +77,7 @@ mod test {
     #[test]
     fn take_with_non_zero_offset() {
         let sparse = sparse_array();
-        let sparse = sparse.slice(30, 40);
+        let sparse = sparse.slice(30..70);
         let sparse = take(&sparse, &buffer![6, 7, 8].into_array()).unwrap();
         assert_eq!(sparse.scalar_at(0), test_array_fill_value());
         assert_eq!(sparse.scalar_at(1), Scalar::from(Some(0.47)));

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -407,13 +407,13 @@ mod test {
 
     #[test]
     pub fn scalar_at_sliced() {
-        let sliced = sparse_array(nullable_fill()).slice(2, 7);
+        let sliced = sparse_array(nullable_fill()).slice(2..7);
         assert_eq!(usize::try_from(&sliced.scalar_at(0)).unwrap(), 100);
     }
 
     #[test]
     pub fn validity_mask_sliced_null_fill() {
-        let sliced = sparse_array(nullable_fill()).slice(2, 7);
+        let sliced = sparse_array(nullable_fill()).slice(2..7);
         assert_eq!(
             sliced.validity_mask().unwrap(),
             Mask::from_iter(vec![true, false, false, true, false])
@@ -433,7 +433,7 @@ mod test {
             Scalar::primitive(1.0f32, Nullability::Nullable),
         )
         .unwrap()
-        .slice(2, 7);
+        .slice(2..7);
 
         assert_eq!(
             sliced.validity_mask().unwrap(),
@@ -443,10 +443,10 @@ mod test {
 
     #[test]
     pub fn scalar_at_sliced_twice() {
-        let sliced_once = sparse_array(nullable_fill()).slice(1, 8);
+        let sliced_once = sparse_array(nullable_fill()).slice(1..8);
         assert_eq!(usize::try_from(&sliced_once.scalar_at(1)).unwrap(), 100);
 
-        let sliced_twice = sliced_once.slice(1, 6);
+        let sliced_twice = sliced_once.slice(1..6);
         assert_eq!(usize::try_from(&sliced_twice.scalar_at(3)).unwrap(), 200);
     }
 

--- a/encodings/sparse/src/ops.rs
+++ b/encodings/sparse/src/ops.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 use vortex_array::arrays::ConstantArray;
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::{Array, ArrayRef, IntoArray};
@@ -9,11 +11,11 @@ use vortex_scalar::Scalar;
 use crate::{SparseArray, SparseVTable};
 
 impl OperationsVTable<SparseVTable> for SparseVTable {
-    fn slice(array: &SparseArray, start: usize, stop: usize) -> ArrayRef {
-        let new_patches = array.patches().slice(start, stop);
+    fn slice(array: &SparseArray, range: Range<usize>) -> ArrayRef {
+        let new_patches = array.patches().slice(range.start..range.end);
 
         let Some(new_patches) = new_patches else {
-            return ConstantArray::new(array.fill_scalar().clone(), stop - start).into_array();
+            return ConstantArray::new(array.fill_scalar().clone(), range.len()).into_array();
         };
 
         // If the number of values in the sparse array matches the array length, then all
@@ -47,7 +49,7 @@ mod tests {
         let indices = buffer![0u8].into_array();
 
         let sparse = SparseArray::try_new(indices, values, 1000, 999u64.into()).unwrap();
-        let sliced = sparse.slice(0, 1000);
+        let sliced = sparse.slice(0..1000);
         let mut expected = vec![999u64; 1000];
         expected[0] = 0;
 

--- a/encodings/sparse/src/ops.rs
+++ b/encodings/sparse/src/ops.rs
@@ -12,7 +12,7 @@ use crate::{SparseArray, SparseVTable};
 
 impl OperationsVTable<SparseVTable> for SparseVTable {
     fn slice(array: &SparseArray, range: Range<usize>) -> ArrayRef {
-        let new_patches = array.patches().slice(range.start..range.end);
+        let new_patches = array.patches().slice(range.clone());
 
         let Some(new_patches) = new_patches else {
             return ConstantArray::new(array.fill_scalar().clone(), range.len()).into_array();

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 use vortex_array::stats::{ArrayStats, StatsSetRef};
 use vortex_array::vtable::{
     ArrayVTable, CanonicalVTable, NotSupported, OperationsVTable, VTable, ValidityChild,
@@ -103,8 +105,8 @@ impl CanonicalVTable<ZigZagVTable> for ZigZagVTable {
 }
 
 impl OperationsVTable<ZigZagVTable> for ZigZagVTable {
-    fn slice(array: &ZigZagArray, start: usize, stop: usize) -> ArrayRef {
-        ZigZagArray::new(array.encoded().slice(start, stop)).into_array()
+    fn slice(array: &ZigZagArray, range: Range<usize>) -> ArrayRef {
+        ZigZagArray::new(array.encoded().slice(range.start..range.end)).into_array()
     }
 
     fn scalar_at(array: &ZigZagArray, index: usize) -> Scalar {
@@ -160,7 +162,7 @@ mod test {
             array.statistics().compute_is_constant()
         );
 
-        let sliced = zigzag.slice(0, 2);
+        let sliced = zigzag.slice(0..2);
         let sliced = sliced.as_::<ZigZagVTable>();
         assert_eq!(sliced.scalar_at(sliced.len() - 1), Scalar::from(-5i32));
 

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -106,7 +106,7 @@ impl CanonicalVTable<ZigZagVTable> for ZigZagVTable {
 
 impl OperationsVTable<ZigZagVTable> for ZigZagVTable {
     fn slice(array: &ZigZagArray, range: Range<usize>) -> ArrayRef {
-        ZigZagArray::new(array.encoded().slice(range.start..range.end)).into_array()
+        ZigZagArray::new(array.encoded().slice(range)).into_array()
     }
 
     fn scalar_at(array: &ZigZagArray, index: usize) -> Scalar {

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::fmt::Debug;
+use std::ops::Range;
 use std::sync::Arc;
 
 use vortex_array::accessor::ArrayAccessor;
@@ -442,7 +443,7 @@ impl ZstdArray {
         // Last, we slice the exact values requested out of the decompressed data.
         let slice_validity = self
             .unsliced_validity
-            .slice(self.slice_start, self.slice_stop);
+            .slice(self.slice_start..self.slice_stop);
 
         match &self.dtype {
             DType::Primitive(..) => {
@@ -539,8 +540,8 @@ impl CanonicalVTable<ZstdVTable> for ZstdVTable {
 }
 
 impl OperationsVTable<ZstdVTable> for ZstdVTable {
-    fn slice(array: &ZstdArray, start: usize, stop: usize) -> ArrayRef {
-        array._slice(start, stop).into_array()
+    fn slice(array: &ZstdArray, range: Range<usize>) -> ArrayRef {
+        array._slice(range.start, range.end).into_array()
     }
 
     fn scalar_at(array: &ZstdArray, index: usize) -> Scalar {

--- a/encodings/zstd/src/test.rs
+++ b/encodings/zstd/src/test.rs
@@ -33,14 +33,14 @@ fn test_zstd_compress_decompress() {
     assert_eq!(decompressed.as_slice::<i32>(), &data);
 
     // check slicing works
-    let slice = compressed.slice(100, 105);
+    let slice = compressed.slice(100..105);
     for i in 0_i32..5 {
         assert_nth_scalar!(slice, i as usize, 100 + i);
     }
     let primitive = slice.to_primitive().unwrap();
     assert_eq!(primitive.as_slice::<i32>(), &[100, 101, 102, 103, 104]);
 
-    let slice = compressed.slice(200, 200);
+    let slice = compressed.slice(200..200);
     let primitive = slice.to_primitive().unwrap();
     assert_eq!(primitive.as_slice::<i32>(), &Vec::<i32>::new());
 }
@@ -84,7 +84,7 @@ fn test_zstd_with_validity_and_multi_frame() {
     assert_eq!(decompressed.validity(), array.validity());
 
     // check slicing works
-    let slice = compressed.slice(176, 179);
+    let slice = compressed.slice(176..179);
     let primitive = slice.to_primitive().unwrap();
     assert_eq!(primitive.as_slice::<i32>()[1], 177);
     assert_eq!(
@@ -111,7 +111,7 @@ fn test_zstd_with_dict() {
     assert_eq!(decompressed.validity(), array.validity());
 
     // check slicing works
-    let slice = compressed.slice(176, 179);
+    let slice = compressed.slice(176..179);
     let primitive = slice.to_primitive().unwrap();
     assert_eq!(primitive.as_slice::<i32>(), &[176, 177, 178]);
 }
@@ -129,7 +129,7 @@ fn test_validity_vtable() {
         Mask::from_iter(mask_bools)
     );
     assert_eq!(
-        compressed.slice(1, 4).validity_mask().unwrap(),
+        compressed.slice(1..4).validity_mask().unwrap(),
         Mask::from_iter(vec![true, true, false])
     );
 }
@@ -153,7 +153,7 @@ fn test_zstd_var_bin_view() {
     assert_nth_scalar!(compressed, 3, "Lorem ipsum dolor sit amet");
     assert_nth_scalar!(compressed, 4, "baz");
 
-    let sliced = compressed.slice(1, 4);
+    let sliced = compressed.slice(1..4);
     assert_nth_scalar!(sliced, 0, "bar");
     assert_nth_scalar!(sliced, 1, None::<String>);
     assert_nth_scalar!(sliced, 2, "Lorem ipsum dolor sit amet");

--- a/fuzz/fuzz_targets/array_ops.rs
+++ b/fuzz/fuzz_targets/array_ops.rs
@@ -33,7 +33,7 @@ fuzz_target!(|fuzz_action: FuzzArrayAction| -> Corpus {
                 assert_array_eq(&expected.array(), &current_array, i).unwrap();
             }
             Action::Slice(range) => {
-                current_array = current_array.slice(range.start..range.end);
+                current_array = current_array.slice(range);
                 assert_array_eq(&expected.array(), &current_array, i).unwrap();
             }
             Action::Take(indices) => {

--- a/fuzz/fuzz_targets/array_ops.rs
+++ b/fuzz/fuzz_targets/array_ops.rs
@@ -33,7 +33,7 @@ fuzz_target!(|fuzz_action: FuzzArrayAction| -> Corpus {
                 assert_array_eq(&expected.array(), &current_array, i).unwrap();
             }
             Action::Slice(range) => {
-                current_array = current_array.slice(range.start, range.end);
+                current_array = current_array.slice(range.start..range.end);
                 assert_array_eq(&expected.array(), &current_array, i).unwrap();
             }
             Action::Take(indices) => {

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -6,8 +6,7 @@ mod visitor;
 
 use std::any::Any;
 use std::fmt::{Debug, Formatter};
-use std::ops::RangeBounds;
-use std::range::Bound;
+use std::ops::Range;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -59,7 +58,7 @@ pub trait Array: 'static + private::Sealed + Send + Sync + Debug + ArrayVisitor 
     fn encoding_id(&self) -> EncodingId;
 
     /// Performs a constant-time slice of the array.
-    fn slice(&self, range: impl RangeBounds<usize>) -> ArrayRef;
+    fn slice(&self, range: Range<usize>) -> ArrayRef;
 
     /// Fetch the scalar at the given index.
     ///
@@ -184,7 +183,7 @@ impl Array for Arc<dyn Array> {
         self.as_ref().encoding_id()
     }
 
-    fn slice(&self, range: impl RangeBounds<usize>) -> ArrayRef {
+    fn slice(&self, range: Range<usize>) -> ArrayRef {
         self.as_ref().slice(range)
     }
 
@@ -386,18 +385,9 @@ impl<V: VTable> Array for ArrayAdapter<V> {
         V::encoding(&self.0).id()
     }
 
-    fn slice(&self, range: impl RangeBounds<usize>) -> ArrayRef {
-        let start = match range.start_bound() {
-            Bound::Included(&n) => n,
-            Bound::Excluded(&n) => n.checked_add(1).vortex_expect("out of range"),
-            Bound::Unbounded => 0,
-        };
-
-        let stop = match range.end_bound() {
-            Bound::Included(&n) => n.checked_add(1).vortex_expect("out of range"),
-            Bound::Excluded(&n) => n,
-            Bound::Unbounded => self.len(),
-        };
+    fn slice(&self, range: Range<usize>) -> ArrayRef {
+        let start = range.start;
+        let stop = range.end;
 
         if start == 0 && stop == self.len() {
             return self.to_array();
@@ -420,7 +410,7 @@ impl<V: VTable> Array for ArrayAdapter<V> {
             return Canonical::empty(self.dtype()).into_array();
         }
 
-        let sliced = <V::OperationsVTable as OperationsVTable<V>>::slice(&self.0, start..stop);
+        let sliced = <V::OperationsVTable as OperationsVTable<V>>::slice(&self.0, range);
 
         assert_eq!(
             sliced.len(),

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -6,6 +6,8 @@ mod visitor;
 
 use std::any::Any;
 use std::fmt::{Debug, Formatter};
+use std::ops::RangeBounds;
+use std::range::Bound;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -57,7 +59,7 @@ pub trait Array: 'static + private::Sealed + Send + Sync + Debug + ArrayVisitor 
     fn encoding_id(&self) -> EncodingId;
 
     /// Performs a constant-time slice of the array.
-    fn slice(&self, start: usize, end: usize) -> ArrayRef;
+    fn slice(&self, range: impl RangeBounds<usize>) -> ArrayRef;
 
     /// Fetch the scalar at the given index.
     ///
@@ -182,8 +184,8 @@ impl Array for Arc<dyn Array> {
         self.as_ref().encoding_id()
     }
 
-    fn slice(&self, start: usize, end: usize) -> ArrayRef {
-        self.as_ref().slice(start, end)
+    fn slice(&self, range: impl RangeBounds<usize>) -> ArrayRef {
+        self.as_ref().slice(range)
     }
 
     fn scalar_at(&self, index: usize) -> Scalar {
@@ -384,7 +386,19 @@ impl<V: VTable> Array for ArrayAdapter<V> {
         V::encoding(&self.0).id()
     }
 
-    fn slice(&self, start: usize, stop: usize) -> ArrayRef {
+    fn slice(&self, range: impl RangeBounds<usize>) -> ArrayRef {
+        let start = match range.start_bound() {
+            Bound::Included(&n) => n,
+            Bound::Excluded(&n) => n.checked_add(1).vortex_expect("out of range"),
+            Bound::Unbounded => 0,
+        };
+
+        let stop = match range.end_bound() {
+            Bound::Included(&n) => n.checked_add(1).vortex_expect("out of range"),
+            Bound::Excluded(&n) => n,
+            Bound::Unbounded => self.len(),
+        };
+
         if start == 0 && stop == self.len() {
             return self.to_array();
         }
@@ -406,7 +420,7 @@ impl<V: VTable> Array for ArrayAdapter<V> {
             return Canonical::empty(self.dtype()).into_array();
         }
 
-        let sliced = <V::OperationsVTable as OperationsVTable<V>>::slice(&self.0, start, stop);
+        let sliced = <V::OperationsVTable as OperationsVTable<V>>::slice(&self.0, start..stop);
 
         assert_eq!(
             sliced.len(),

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -6,6 +6,7 @@ mod visitor;
 
 use std::any::Any;
 use std::fmt::{Debug, Formatter};
+use std::ops::RangeBounds;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -30,6 +31,22 @@ use crate::vtable::{
     ValidityVTable, VisitorVTable,
 };
 use crate::{Canonical, EncodingId, EncodingRef, SerializeMetadata};
+
+/// Helper function to convert range bounds to (start, end) tuple
+fn range_bounds_to_start_end<R: RangeBounds<usize>>(range: R, len: usize) -> (usize, usize) {
+    use std::ops::Bound;
+    let start = match range.start_bound() {
+        Bound::Included(&n) => n,
+        Bound::Excluded(&n) => n + 1,
+        Bound::Unbounded => 0,
+    };
+    let end = match range.end_bound() {
+        Bound::Included(&n) => n + 1,
+        Bound::Excluded(&n) => n,
+        Bound::Unbounded => len,
+    };
+    (start, end)
+}
 
 /// The public API trait for all Vortex arrays.
 pub trait Array: 'static + private::Sealed + Send + Sync + Debug + ArrayVisitor {
@@ -259,6 +276,16 @@ impl ToOwned for dyn Array {
 }
 
 impl dyn Array + '_ {
+    /// Performs a constant-time slice of the array using a range.
+    pub fn slice_range<R>(&self, range: R) -> ArrayRef
+    where
+        R: RangeBounds<usize>,
+    {
+        let (start, end) = range_bounds_to_start_end(range, self.len());
+        self.slice(start, end)
+    }
+
+    // Existing methods below...
     /// Returns the array downcast to the given `A`.
     pub fn as_<V: VTable>(&self) -> &V::Array {
         self.as_opt::<V>().vortex_expect("Failed to downcast")
@@ -709,5 +736,29 @@ impl<V: VTable> ArrayVisitor for ArrayAdapter<V> {
             Ok(None) => write!(f, "<serde not supported>"),
             Ok(Some(metadata)) => Debug::fmt(&metadata, f),
         }
+    }
+}
+
+/// Helper trait to support indexing with ranges
+/// This provides an alternative to std::ops::Index that can return by value
+pub trait ArrayIndex<Idx> {
+    fn index(&self, index: Idx) -> ArrayRef;
+}
+
+impl<R> ArrayIndex<R> for dyn Array
+where
+    R: RangeBounds<usize>,
+{
+    fn index(&self, range: R) -> ArrayRef {
+        self.slice_range(range)
+    }
+}
+
+impl<R> ArrayIndex<R> for ArrayRef
+where
+    R: RangeBounds<usize>,
+{
+    fn index(&self, range: R) -> ArrayRef {
+        self.slice_range(range)
     }
 }

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -6,7 +6,6 @@ mod visitor;
 
 use std::any::Any;
 use std::fmt::{Debug, Formatter};
-use std::ops::RangeBounds;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -31,22 +30,6 @@ use crate::vtable::{
     ValidityVTable, VisitorVTable,
 };
 use crate::{Canonical, EncodingId, EncodingRef, SerializeMetadata};
-
-/// Helper function to convert range bounds to (start, end) tuple
-fn range_bounds_to_start_end<R: RangeBounds<usize>>(range: R, len: usize) -> (usize, usize) {
-    use std::ops::Bound;
-    let start = match range.start_bound() {
-        Bound::Included(&n) => n,
-        Bound::Excluded(&n) => n + 1,
-        Bound::Unbounded => 0,
-    };
-    let end = match range.end_bound() {
-        Bound::Included(&n) => n + 1,
-        Bound::Excluded(&n) => n,
-        Bound::Unbounded => len,
-    };
-    (start, end)
-}
 
 /// The public API trait for all Vortex arrays.
 pub trait Array: 'static + private::Sealed + Send + Sync + Debug + ArrayVisitor {
@@ -276,16 +259,6 @@ impl ToOwned for dyn Array {
 }
 
 impl dyn Array + '_ {
-    /// Performs a constant-time slice of the array using a range.
-    pub fn slice_range<R>(&self, range: R) -> ArrayRef
-    where
-        R: RangeBounds<usize>,
-    {
-        let (start, end) = range_bounds_to_start_end(range, self.len());
-        self.slice(start, end)
-    }
-
-    // Existing methods below...
     /// Returns the array downcast to the given `A`.
     pub fn as_<V: VTable>(&self) -> &V::Array {
         self.as_opt::<V>().vortex_expect("Failed to downcast")
@@ -736,29 +709,5 @@ impl<V: VTable> ArrayVisitor for ArrayAdapter<V> {
             Ok(None) => write!(f, "<serde not supported>"),
             Ok(Some(metadata)) => Debug::fmt(&metadata, f),
         }
-    }
-}
-
-/// Helper trait to support indexing with ranges
-/// This provides an alternative to std::ops::Index that can return by value
-pub trait ArrayIndex<Idx> {
-    fn index(&self, index: Idx) -> ArrayRef;
-}
-
-impl<R> ArrayIndex<R> for dyn Array
-where
-    R: RangeBounds<usize>,
-{
-    fn index(&self, range: R) -> ArrayRef {
-        self.slice_range(range)
-    }
-}
-
-impl<R> ArrayIndex<R> for ArrayRef
-where
-    R: RangeBounds<usize>,
-{
-    fn index(&self, range: R) -> ArrayRef {
-        self.slice_range(range)
     }
 }

--- a/vortex-array/src/arrays/bool/array.rs
+++ b/vortex-array/src/arrays/bool/array.rs
@@ -36,7 +36,7 @@ use crate::vtable::{ArrayVTable, CanonicalVTable, ValidityHelper};
 /// let array: BoolArray = [true, false, true, false].into_iter().collect();
 ///
 /// // Slice the array
-/// let sliced = array.slice(1, 3);
+/// let sliced = array.slice(1..3);
 /// assert_eq!(sliced.len(), 2);
 ///
 /// // Access individual values
@@ -317,7 +317,7 @@ mod tests {
             builder.append_n(11, true);
             BoolArray::from(builder.finish())
         };
-        let sliced = arr.slice(4, 12);
+        let sliced = arr.slice(4..12);
         let sliced_len = sliced.len();
         let (values, offset) = sliced.to_bool().unwrap().into_boolean_builder();
         assert_eq!(offset, 4);
@@ -347,7 +347,7 @@ mod tests {
     #[test]
     fn slice_array_in_middle() {
         let arr = BoolArray::from(BooleanBuffer::new_set(16));
-        let sliced = arr.slice(4, 12);
+        let sliced = arr.slice(4..12);
         let sliced_len = sliced.len();
         let (values, offset) = sliced.to_bool().unwrap().into_boolean_builder();
         assert_eq!(offset, 4);

--- a/vortex-array/src/arrays/bool/ops.rs
+++ b/vortex-array/src/arrays/bool/ops.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 use vortex_scalar::Scalar;
 
 use crate::arrays::{BoolArray, BoolVTable};
@@ -8,10 +10,10 @@ use crate::vtable::{OperationsVTable, ValidityHelper};
 use crate::{ArrayRef, IntoArray};
 
 impl OperationsVTable<BoolVTable> for BoolVTable {
-    fn slice(array: &BoolArray, start: usize, stop: usize) -> ArrayRef {
+    fn slice(array: &BoolArray, range: Range<usize>) -> ArrayRef {
         BoolArray::new(
-            array.boolean_buffer().slice(start, stop - start),
-            array.validity().slice(start, stop),
+            array.boolean_buffer().slice(range.start, range.len()),
+            array.validity().slice(range),
         )
         .into_array()
     }
@@ -32,7 +34,7 @@ mod tests {
     #[test]
     fn test_slice_large() {
         let arr = BoolArray::from_iter(std::iter::repeat_n(Some(true), 100));
-        let sliced_arr = arr.slice(8, 16).to_bool().unwrap();
+        let sliced_arr = arr.slice(8..16).to_bool().unwrap();
         assert_eq!(sliced_arr.len(), 8);
         assert_eq!(sliced_arr.boolean_buffer().len(), 8);
         assert_eq!(sliced_arr.boolean_buffer().offset(), 0);
@@ -41,7 +43,7 @@ mod tests {
     #[test]
     fn test_slice() {
         let arr = BoolArray::from_iter([Some(true), Some(true), None, Some(false), None]);
-        let sliced_arr = arr.slice(1, 4).to_bool().unwrap();
+        let sliced_arr = arr.slice(1..4).to_bool().unwrap();
 
         assert_eq!(sliced_arr.len(), 3);
 

--- a/vortex-array/src/arrays/bool/patch.rs
+++ b/vortex-array/src/arrays/bool/patch.rs
@@ -51,7 +51,7 @@ mod tests {
     #[test]
     fn patch_sliced_bools() {
         let arr = BoolArray::from(BooleanBuffer::new_set(12));
-        let sliced = arr.slice(4, 12);
+        let sliced = arr.slice(4..12);
         let (values, offset) = sliced.to_bool().unwrap().into_boolean_builder();
         assert_eq!(offset, 4);
         assert_eq!(values.len(), 12);
@@ -61,7 +61,7 @@ mod tests {
     #[test]
     fn patch_sliced_bools_offset() {
         let arr = BoolArray::from(BooleanBuffer::new_set(15));
-        let sliced = arr.slice(4, 15);
+        let sliced = arr.slice(4..15);
         let (values, offset) = sliced.to_bool().unwrap().into_boolean_builder();
         assert_eq!(offset, 4);
         assert_eq!(values.as_slice(), &[255, 127]);

--- a/vortex-array/src/arrays/chunked/compute/compare.rs
+++ b/vortex-array/src/arrays/chunked/compute/compare.rs
@@ -24,7 +24,7 @@ impl CompareKernel for ChunkedVTable {
         );
 
         for chunk in lhs.non_empty_chunks() {
-            let sliced = rhs.slice(idx, idx + chunk.len());
+            let sliced = rhs.slice(idx..idx + chunk.len());
             let cmp_result = compare(chunk, &sliced, operator)?;
 
             bool_builder.extend_from_array(&cmp_result)?;

--- a/vortex-array/src/arrays/chunked/compute/elementwise.rs
+++ b/vortex-array/src/arrays/chunked/compute/elementwise.rs
@@ -50,7 +50,7 @@ fn invoke_elementwise(
         inputs.push(chunk.clone());
         for i in 1..args.inputs.len() {
             let input = args.inputs[i].array().vortex_expect("checked already");
-            let sliced = input.slice(idx, idx + chunk.len());
+            let sliced = input.slice(idx..idx + chunk.len());
             inputs.push(sliced);
         }
 

--- a/vortex-array/src/arrays/chunked/compute/take.rs
+++ b/vortex-array/src/arrays/chunked/compute/take.rs
@@ -38,7 +38,7 @@ impl TakeKernel for ChunkedVTable {
                 // Start a new chunk
                 let indices_in_chunk_array = PrimitiveArray::new(
                     indices_in_chunk.clone().freeze(),
-                    Validity::from_mask(indices_mask.slice(start, stop - start), nullability),
+                    Validity::from_mask(indices_mask.slice(start..stop), nullability),
                 );
                 chunks.push(take(
                     array.chunk(prev_chunk_idx),
@@ -56,7 +56,7 @@ impl TakeKernel for ChunkedVTable {
         if !indices_in_chunk.is_empty() {
             let indices_in_chunk_array = PrimitiveArray::new(
                 indices_in_chunk.freeze(),
-                Validity::from_mask(indices_mask.slice(start, stop - start), nullability),
+                Validity::from_mask(indices_mask.slice(start..stop), nullability),
             );
             chunks.push(take(
                 array.chunk(prev_chunk_idx),

--- a/vortex-array/src/arrays/chunked/decode.rs
+++ b/vortex-array/src/arrays/chunked/decode.rs
@@ -106,7 +106,7 @@ fn pack_lists(
         elements.push(
             chunk
                 .elements()
-                .slice(first_offset_value, last_offset_value),
+                .slice(first_offset_value..last_offset_value),
         );
 
         let adjustment_from_previous = *offsets

--- a/vortex-array/src/arrays/chunked/ops.rs
+++ b/vortex-array/src/arrays/chunked/ops.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 use itertools::Itertools;
 use vortex_scalar::Scalar;
 
@@ -10,10 +12,12 @@ use crate::vtable::OperationsVTable;
 use crate::{Array, ArrayRef, IntoArray};
 
 impl OperationsVTable<ChunkedVTable> for ChunkedVTable {
-    fn slice(array: &ChunkedArray, start: usize, stop: usize) -> ArrayRef {
+    fn slice(array: &ChunkedArray, range: Range<usize>) -> ArrayRef {
         assert!(
-            !array.is_empty() || (start > 0 && stop > 0),
-            "Empty chunked array can't be sliced from {start} to {stop}"
+            !array.is_empty() || (range.start > 0 && range.end > 0),
+            "Empty chunked array can't be sliced from {} to {}",
+            range.start,
+            range.end
         );
 
         if array.is_empty() {
@@ -23,25 +27,25 @@ impl OperationsVTable<ChunkedVTable> for ChunkedVTable {
             }
         }
 
-        let (offset_chunk, offset_in_first_chunk) = array.find_chunk_idx(start);
-        let (length_chunk, length_in_last_chunk) = array.find_chunk_idx(stop);
+        let (offset_chunk, offset_in_first_chunk) = array.find_chunk_idx(range.start);
+        let (length_chunk, length_in_last_chunk) = array.find_chunk_idx(range.end);
 
         if length_chunk == offset_chunk {
             let chunk = array.chunk(offset_chunk);
-            return chunk.slice(offset_in_first_chunk, length_in_last_chunk);
+            return chunk.slice(offset_in_first_chunk..length_in_last_chunk);
         }
 
         let mut chunks = (offset_chunk..length_chunk + 1)
             .map(|i| array.chunk(i).clone())
             .collect_vec();
         if let Some(c) = chunks.first_mut() {
-            *c = c.slice(offset_in_first_chunk, c.len());
+            *c = c.slice(offset_in_first_chunk..c.len());
         }
 
         if length_in_last_chunk == 0 {
             chunks.pop();
         } else if let Some(c) = chunks.last_mut() {
-            *c = c.slice(0, length_in_last_chunk);
+            *c = c.slice(0..length_in_last_chunk);
         }
 
         // SAFETY: all chunks still have same DType
@@ -91,38 +95,38 @@ mod tests {
 
     #[test]
     fn slice_middle() {
-        assert_equal_slices(&chunked_array().slice(2, 5), &[3u64, 4, 5])
+        assert_equal_slices(&chunked_array().slice(2..5), &[3u64, 4, 5])
     }
 
     #[test]
     fn slice_begin() {
-        assert_equal_slices(&chunked_array().slice(1, 3), &[2u64, 3]);
+        assert_equal_slices(&chunked_array().slice(1..3), &[2u64, 3]);
     }
 
     #[test]
     fn slice_aligned() {
-        assert_equal_slices(&chunked_array().slice(3, 6), &[4u64, 5, 6]);
+        assert_equal_slices(&chunked_array().slice(3..6), &[4u64, 5, 6]);
     }
 
     #[test]
     fn slice_many_aligned() {
-        assert_equal_slices(&chunked_array().slice(0, 6), &[1u64, 2, 3, 4, 5, 6]);
+        assert_equal_slices(&chunked_array().slice(0..6), &[1u64, 2, 3, 4, 5, 6]);
     }
 
     #[test]
     fn slice_end() {
-        assert_equal_slices(&chunked_array().slice(7, 8), &[8u64]);
+        assert_equal_slices(&chunked_array().slice(7..8), &[8u64]);
     }
 
     #[test]
     fn slice_exactly_end() {
-        assert_equal_slices(&chunked_array().slice(6, 9), &[7u64, 8, 9]);
+        assert_equal_slices(&chunked_array().slice(6..9), &[7u64, 8, 9]);
     }
 
     #[test]
     fn slice_empty() {
         let chunked = ChunkedArray::try_new(vec![], PType::U32.into()).unwrap();
-        let sliced = chunked.slice(0, 0);
+        let sliced = chunked.slice(0..0);
 
         assert!(sliced.is_empty());
     }

--- a/vortex-array/src/arrays/constant/mod.rs
+++ b/vortex-array/src/arrays/constant/mod.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 pub use compute::ConstantOperator;
 use vortex_buffer::ByteBufferMut;
 use vortex_dtype::DType;
@@ -91,8 +93,8 @@ impl ArrayVTable<ConstantVTable> for ConstantVTable {
 }
 
 impl OperationsVTable<ConstantVTable> for ConstantVTable {
-    fn slice(array: &ConstantArray, start: usize, stop: usize) -> ArrayRef {
-        ConstantArray::new(array.scalar.clone(), stop - start).into_array()
+    fn slice(array: &ConstantArray, range: Range<usize>) -> ArrayRef {
+        ConstantArray::new(array.scalar.clone(), range.len()).into_array()
     }
 
     fn scalar_at(array: &ConstantArray, _index: usize) -> Scalar {

--- a/vortex-array/src/arrays/decimal/ops.rs
+++ b/vortex-array/src/arrays/decimal/ops.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 use vortex_buffer::Buffer;
 use vortex_dtype::DecimalDType;
 use vortex_scalar::{DecimalValue, NativeDecimalType, Scalar, match_each_decimal_value_type};
@@ -11,12 +13,11 @@ use crate::vtable::OperationsVTable;
 use crate::{ArrayRef, IntoArray};
 
 impl OperationsVTable<DecimalVTable> for DecimalVTable {
-    fn slice(array: &DecimalArray, start: usize, stop: usize) -> ArrayRef {
+    fn slice(array: &DecimalArray, range: Range<usize>) -> ArrayRef {
         match_each_decimal_value_type!(array.values_type(), |D| {
             slice_typed(
                 array.buffer::<D>(),
-                start,
-                stop,
+                range,
                 array.decimal_dtype(),
                 array.validity.clone(),
             )
@@ -36,13 +37,12 @@ impl OperationsVTable<DecimalVTable> for DecimalVTable {
 
 fn slice_typed<T: NativeDecimalType>(
     values: Buffer<T>,
-    start: usize,
-    end: usize,
+    range: Range<usize>,
     decimal_dtype: DecimalDType,
     validity: Validity,
 ) -> ArrayRef {
-    let sliced = values.slice(start..end);
-    let validity = validity.slice(start, end);
+    let sliced = values.slice(range.clone());
+    let validity = validity.slice(range);
     DecimalArray::new(sliced, decimal_dtype, validity).into_array()
 }
 
@@ -65,7 +65,7 @@ mod tests {
         )
         .to_array();
 
-        let sliced = array.slice(1, 3);
+        let sliced = array.slice(1..3);
         assert_eq!(sliced.len(), 2);
 
         let decimal = sliced.as_::<DecimalVTable>();
@@ -81,7 +81,7 @@ mod tests {
         )
         .to_array();
 
-        let sliced = array.slice(1, 3);
+        let sliced = array.slice(1..3);
         assert_eq!(sliced.len(), 2);
     }
 

--- a/vortex-array/src/arrays/extension/mod.rs
+++ b/vortex-array/src/arrays/extension/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
 use std::sync::Arc;
 
 use vortex_dtype::{DType, ExtDType, ExtID};
@@ -190,12 +191,8 @@ impl CanonicalVTable<ExtensionVTable> for ExtensionVTable {
 }
 
 impl OperationsVTable<ExtensionVTable> for ExtensionVTable {
-    fn slice(array: &ExtensionArray, start: usize, stop: usize) -> ArrayRef {
-        ExtensionArray::new(
-            array.ext_dtype().clone(),
-            array.storage().slice(start, stop),
-        )
-        .into_array()
+    fn slice(array: &ExtensionArray, range: Range<usize>) -> ArrayRef {
+        ExtensionArray::new(array.ext_dtype().clone(), array.storage().slice(range)).into_array()
     }
 
     fn scalar_at(array: &ExtensionArray, index: usize) -> Scalar {

--- a/vortex-array/src/arrays/list/compute/is_constant.rs
+++ b/vortex-array/src/arrays/list/compute/is_constant.rs
@@ -32,10 +32,10 @@ impl IsConstantKernel for ListVTable {
 
         if array.len() > SMALL_ARRAY_THRESHOLD {
             // check the rest of the element lengths
-            let start_offsets = array.offsets.slice(SMALL_ARRAY_THRESHOLD, array.len());
+            let start_offsets = array.offsets.slice(SMALL_ARRAY_THRESHOLD..array.len());
             let end_offsets = array
                 .offsets
-                .slice(SMALL_ARRAY_THRESHOLD + 1, array.len() + 1);
+                .slice(SMALL_ARRAY_THRESHOLD + 1..array.len() + 1);
             let list_lengths = numeric(&end_offsets, &start_offsets, NumericOperator::Sub)?;
 
             if !list_lengths.is_constant() {

--- a/vortex-array/src/arrays/list/mod.rs
+++ b/vortex-array/src/arrays/list/mod.rs
@@ -4,6 +4,7 @@
 mod compute;
 mod serde;
 
+use std::ops::Range;
 use std::sync::Arc;
 
 #[cfg(feature = "test-harness")]
@@ -177,14 +178,14 @@ impl ListArray {
     pub fn elements_at(&self, index: usize) -> ArrayRef {
         let start = self.offset_at(index);
         let end = self.offset_at(index + 1);
-        self.elements().slice(start, end)
+        self.elements().slice(start..end)
     }
 
     /// Returns elements of the list array referenced by the offsets array
     pub fn sliced_elements(&self) -> ArrayRef {
         let start = self.offset_at(0);
         let end = self.offset_at(self.len());
-        self.elements().slice(start, end)
+        self.elements().slice(start..end)
     }
 
     /// Returns the offsets array.
@@ -295,11 +296,11 @@ impl ArrayVTable<ListVTable> for ListVTable {
 }
 
 impl OperationsVTable<ListVTable> for ListVTable {
-    fn slice(array: &ListArray, start: usize, stop: usize) -> ArrayRef {
+    fn slice(array: &ListArray, range: Range<usize>) -> ArrayRef {
         ListArray::new(
             array.elements().clone(),
-            array.offsets().slice(start, stop + 1),
-            array.validity().slice(start, stop),
+            array.offsets().slice(range.start..range.end + 1),
+            array.validity().slice(range),
         )
         .into_array()
     }

--- a/vortex-array/src/arrays/list/tests.rs
+++ b/vortex-array/src/arrays/list/tests.rs
@@ -143,7 +143,7 @@ fn test_offset_to_0() {
             .as_list(),
         )
         .vortex_unwrap();
-    let list = builder.finish().slice(2, 4);
+    let list = builder.finish().slice(2..4);
     let list = list.as_::<ListVTable>().reset_offsets().unwrap();
     assert_eq!(list.len(), 2);
     assert_eq!(list.offsets().len(), 3);
@@ -349,7 +349,7 @@ fn test_list_of_lists() {
     assert_eq!(list_scalar.len(), 2);
 
     // Test slicing.
-    let sliced = list_of_lists.slice(1, 3);
+    let sliced = list_of_lists.slice(1..3);
     let sliced_list = sliced.as_::<ListVTable>();
     assert_eq!(sliced_list.len(), 2);
 

--- a/vortex-array/src/arrays/null/compute/mod.rs
+++ b/vortex-array/src/arrays/null/compute/mod.rs
@@ -75,7 +75,7 @@ mod test {
     #[test]
     fn test_slice_nulls() {
         let nulls = NullArray::new(10);
-        let sliced = nulls.slice(0, 4).to_null().unwrap();
+        let sliced = nulls.slice(0..4).to_null().unwrap();
 
         assert_eq!(sliced.len(), 4);
         assert!(matches!(sliced.validity_mask().unwrap(), Mask::AllFalse(4)));

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
@@ -62,7 +64,7 @@ impl VTable for NullVTable {
 /// let array = NullArray::new(5);
 ///
 /// // Slice the array - still contains nulls
-/// let sliced = array.slice(1, 3);
+/// let sliced = array.slice(1..4);
 /// assert_eq!(sliced.len(), 2);
 ///
 /// // All elements are null
@@ -133,8 +135,8 @@ impl CanonicalVTable<NullVTable> for NullVTable {
 }
 
 impl OperationsVTable<NullVTable> for NullVTable {
-    fn slice(_array: &NullArray, start: usize, stop: usize) -> ArrayRef {
-        NullArray::new(stop - start).into_array()
+    fn slice(_array: &NullArray, range: Range<usize>) -> ArrayRef {
+        NullArray::new(range.len()).into_array()
     }
 
     fn scalar_at(_array: &NullArray, _index: usize) -> Scalar {

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -64,7 +64,7 @@ impl VTable for NullVTable {
 /// let array = NullArray::new(5);
 ///
 /// // Slice the array - still contains nulls
-/// let sliced = array.slice(1..4);
+/// let sliced = array.slice(1..3);
 /// assert_eq!(sliced.len(), 2);
 ///
 /// // All elements are null

--- a/vortex-array/src/arrays/primitive/mod.rs
+++ b/vortex-array/src/arrays/primitive/mod.rs
@@ -78,7 +78,7 @@ impl VTable for PrimitiveVTable {
 /// let array: PrimitiveArray = [1i32, 2, 3, 4, 5].into_iter().collect();
 ///
 /// // Slice the array
-/// let sliced = array.slice(1, 3);
+/// let sliced = array.slice(1..4);
 ///
 /// // Access individual values
 /// let value = sliced.scalar_at(0);

--- a/vortex-array/src/arrays/primitive/mod.rs
+++ b/vortex-array/src/arrays/primitive/mod.rs
@@ -78,7 +78,7 @@ impl VTable for PrimitiveVTable {
 /// let array: PrimitiveArray = [1i32, 2, 3, 4, 5].into_iter().collect();
 ///
 /// // Slice the array
-/// let sliced = array.slice(1..4);
+/// let sliced = array.slice(1..3);
 ///
 /// // Access individual values
 /// let value = sliced.scalar_at(0);

--- a/vortex-array/src/arrays/primitive/ops.rs
+++ b/vortex-array/src/arrays/primitive/ops.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 use vortex_dtype::match_each_native_ptype;
 use vortex_scalar::Scalar;
 
@@ -9,11 +11,11 @@ use crate::vtable::{OperationsVTable, ValidityHelper};
 use crate::{ArrayRef, IntoArray};
 
 impl OperationsVTable<PrimitiveVTable> for PrimitiveVTable {
-    fn slice(array: &PrimitiveArray, start: usize, stop: usize) -> ArrayRef {
+    fn slice(array: &PrimitiveArray, range: Range<usize>) -> ArrayRef {
         match_each_native_ptype!(array.ptype(), |T| {
             PrimitiveArray::new(
-                array.buffer::<T>().slice(start..stop),
-                array.validity().slice(start, stop),
+                array.buffer::<T>().slice(range.clone()),
+                array.validity().slice(range),
             )
             .into_array()
         })

--- a/vortex-array/src/arrays/primitive/ops.rs
+++ b/vortex-array/src/arrays/primitive/ops.rs
@@ -13,7 +13,7 @@ impl OperationsVTable<PrimitiveVTable> for PrimitiveVTable {
         match_each_native_ptype!(array.ptype(), |T| {
             PrimitiveArray::new(
                 array.buffer::<T>().slice(start..stop),
-                array.validity().slice(start, stop),
+                array.validity().slice_range(start..stop),
             )
             .into_array()
         })

--- a/vortex-array/src/arrays/primitive/ops.rs
+++ b/vortex-array/src/arrays/primitive/ops.rs
@@ -13,7 +13,7 @@ impl OperationsVTable<PrimitiveVTable> for PrimitiveVTable {
         match_each_native_ptype!(array.ptype(), |T| {
             PrimitiveArray::new(
                 array.buffer::<T>().slice(start..stop),
-                array.validity().slice_range(start..stop),
+                array.validity().slice(start, stop),
             )
             .into_array()
         })

--- a/vortex-array/src/arrays/primitive/patch.rs
+++ b/vortex-array/src/arrays/primitive/patch.rs
@@ -68,7 +68,7 @@ mod tests {
     #[test]
     fn patch_sliced() {
         let input = PrimitiveArray::new(buffer![2u32; 10], Validity::AllValid);
-        let sliced = input.slice(2, 8);
+        let sliced = input.slice(2..8);
         assert_eq!(sliced.to_primitive().unwrap().as_slice::<u32>(), &[2u32; 6]);
     }
 }

--- a/vortex-array/src/arrays/struct_/mod.rs
+++ b/vortex-array/src/arrays/struct_/mod.rs
@@ -3,6 +3,7 @@
 
 use std::fmt::Debug;
 use std::iter::once;
+use std::ops::Range;
 
 use itertools::Itertools;
 use vortex_dtype::{DType, FieldName, FieldNames, StructFields};
@@ -442,17 +443,17 @@ impl CanonicalVTable<StructVTable> for StructVTable {
 }
 
 impl OperationsVTable<StructVTable> for StructVTable {
-    fn slice(array: &StructArray, start: usize, stop: usize) -> ArrayRef {
+    fn slice(array: &StructArray, range: Range<usize>) -> ArrayRef {
         let fields = array
             .fields()
             .iter()
-            .map(|field| field.slice(start, stop))
+            .map(|field| field.slice(range.clone()))
             .collect_vec();
         StructArray::new_unchecked(
             fields,
             array.struct_fields().clone(),
-            stop - start,
-            array.validity().slice(start, stop),
+            range.len(),
+            array.validity().slice(range),
         )
         .into_array()
     }

--- a/vortex-array/src/arrays/varbin/mod.rs
+++ b/vortex-array/src/arrays/varbin/mod.rs
@@ -315,7 +315,7 @@ mod test {
 
     #[rstest]
     pub fn slice_array(binary_array: ArrayRef) {
-        let binary_arr = binary_array.slice(1, 2);
+        let binary_arr = binary_array.slice(1..2);
         assert_eq!(
             binary_arr.scalar_at(0),
             "hello world this is a long string".into()

--- a/vortex-array/src/arrays/varbin/ops.rs
+++ b/vortex-array/src/arrays/varbin/ops.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 use vortex_scalar::Scalar;
 
 use crate::arrays::{VarBinArray, VarBinVTable, varbin_scalar};
@@ -8,12 +10,12 @@ use crate::vtable::{OperationsVTable, ValidityHelper};
 use crate::{Array, ArrayRef, IntoArray};
 
 impl OperationsVTable<VarBinVTable> for VarBinVTable {
-    fn slice(array: &VarBinArray, start: usize, stop: usize) -> ArrayRef {
+    fn slice(array: &VarBinArray, range: Range<usize>) -> ArrayRef {
         VarBinArray::new(
-            array.offsets().slice(start, stop + 1),
+            array.offsets().slice(range.start..range.end + 1),
             array.bytes().clone(),
             array.dtype().clone(),
-            array.validity().slice(start, stop),
+            array.validity().slice(range),
         )
         .into_array()
     }

--- a/vortex-array/src/arrays/varbinview/mod.rs
+++ b/vortex-array/src/arrays/varbinview/mod.rs
@@ -744,7 +744,7 @@ mod test {
     pub fn slice_array() {
         let binary_arr =
             VarBinViewArray::from_iter_str(["hello world", "hello world this is a long string"])
-                .slice(1, 2);
+                .slice(1..2);
         assert_eq!(
             binary_arr.scalar_at(0),
             Scalar::from("hello world this is a long string")

--- a/vortex-array/src/arrays/varbinview/ops.rs
+++ b/vortex-array/src/arrays/varbinview/ops.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 use vortex_scalar::Scalar;
 
 use crate::arrays::{VarBinViewArray, VarBinViewVTable, varbin_scalar};
@@ -8,14 +10,14 @@ use crate::vtable::{OperationsVTable, ValidityHelper};
 use crate::{ArrayRef, IntoArray};
 
 impl OperationsVTable<VarBinViewVTable> for VarBinViewVTable {
-    fn slice(array: &VarBinViewArray, start: usize, stop: usize) -> ArrayRef {
-        let views = array.views().slice(start..stop);
+    fn slice(array: &VarBinViewArray, range: Range<usize>) -> ArrayRef {
+        let views = array.views().slice(range.clone());
 
         VarBinViewArray::new(
             views,
             array.buffers().clone(),
             array.dtype().clone(),
-            array.validity().slice(start, stop),
+            array.validity().slice(range),
         )
         .into_array()
     }

--- a/vortex-array/src/arrow/array.rs
+++ b/vortex-array/src/arrow/array.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::fmt::Debug;
+use std::ops::Range;
 
 use arrow_array::ArrayRef as ArrowArrayRef;
 use vortex_dtype::arrow::FromArrowType;
@@ -93,8 +94,8 @@ impl CanonicalVTable<ArrowVTable> for ArrowVTable {
 }
 
 impl OperationsVTable<ArrowVTable> for ArrowVTable {
-    fn slice(array: &ArrowArray, start: usize, stop: usize) -> ArrayRef {
-        let inner = array.inner.slice(start, stop - start);
+    fn slice(array: &ArrowArray, range: Range<usize>) -> ArrayRef {
+        let inner = array.inner.slice(range.start, range.len());
         let new_array = ArrowArray {
             inner,
             dtype: array.dtype.clone(),

--- a/vortex-array/src/arrow/datum.rs
+++ b/vortex-array/src/arrow/datum.rs
@@ -21,7 +21,7 @@ impl Datum {
     pub fn try_new(array: &dyn Array) -> VortexResult<Self> {
         if array.is_constant() {
             Ok(Self {
-                array: array.slice(0, 1).into_arrow_preferred()?,
+                array: array.slice(0..1).into_arrow_preferred()?,
                 is_scalar: true,
             })
         } else {
@@ -38,7 +38,7 @@ impl Datum {
     ) -> VortexResult<Self> {
         if array.is_constant() {
             Ok(Self {
-                array: array.slice(0, 1).into_arrow(target_datatype)?,
+                array: array.slice(0..1).into_arrow(target_datatype)?,
                 is_scalar: true,
             })
         } else {

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -166,7 +166,7 @@ impl<O: OffsetPType> ArrayBuilder for ListBuilder<O> {
         let n_leading_junk_values_scalar = offsets.scalar_at(0).cast(index_dtype)?;
         let n_leading_junk_values = usize::try_from(&n_leading_junk_values_scalar)?;
 
-        let casted_offsets = cast(&offsets.slice(1, offsets.len()), index_dtype)?;
+        let casted_offsets = cast(&offsets.slice(1..offsets.len()), index_dtype)?;
         let offsets_without_leading_junk =
             sub_scalar(&casted_offsets, n_leading_junk_values_scalar)?;
         let offsets_into_builder =
@@ -174,7 +174,7 @@ impl<O: OffsetPType> ArrayBuilder for ListBuilder<O> {
 
         let last_offset = offsets.scalar_at(offsets.len() - 1);
         let last_offset = usize::try_from(&last_offset)?;
-        let non_junk_values = elements.slice(n_leading_junk_values, last_offset);
+        let non_junk_values = elements.slice(n_leading_junk_values..last_offset);
 
         self.nulls.append_validity_mask(array.validity_mask()?);
         self.index_builder
@@ -339,8 +339,8 @@ mod tests {
 
         builder.extend_from_array(&list).unwrap();
         builder.extend_from_array(&list).unwrap();
-        builder.extend_from_array(&list.slice(0, 0)).unwrap();
-        builder.extend_from_array(&list.slice(1, 3)).unwrap();
+        builder.extend_from_array(&list.slice(0..0)).unwrap();
+        builder.extend_from_array(&list.slice(1..3)).unwrap();
 
         let expected = ListArray::from_iter_opt_slow::<O, _, _>(
             [

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -483,8 +483,8 @@ mod tests {
         array.append_to_builder(&mut builder).unwrap();
         assert_eq!(builder.completed_block_count(), 1);
 
-        array.slice(1, 2).append_to_builder(&mut builder).unwrap();
-        array.slice(0, 1).append_to_builder(&mut builder).unwrap();
+        array.slice(1..2).append_to_builder(&mut builder).unwrap();
+        array.slice(0..1).append_to_builder(&mut builder).unwrap();
         assert_eq!(builder.completed_block_count(), 1);
 
         let array2 = {
@@ -497,8 +497,8 @@ mod tests {
         array2.append_to_builder(&mut builder).unwrap();
         assert_eq!(builder.completed_block_count(), 2);
 
-        array.slice(0, 1).append_to_builder(&mut builder).unwrap();
-        array2.slice(0, 1).append_to_builder(&mut builder).unwrap();
+        array.slice(0..1).append_to_builder(&mut builder).unwrap();
+        array2.slice(0..1).append_to_builder(&mut builder).unwrap();
         assert_eq!(builder.completed_block_count(), 2);
     }
 }

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -269,7 +269,7 @@ fn test_slice_filter_consistency(array: &dyn Array) {
     let filtered = filter(array, &mask).vortex_unwrap();
 
     // Slice should produce the same result
-    let sliced = array.slice(1, 4.min(len));
+    let sliced = array.slice(1..4.min(len));
 
     assert_eq!(
         filtered.len(),
@@ -316,7 +316,7 @@ fn test_take_slice_consistency(array: &dyn Array) {
     let taken = take(array, &indices).vortex_unwrap();
 
     // Slice from 1 to end
-    let sliced = array.slice(1, end);
+    let sliced = array.slice(1..end);
 
     assert_eq!(
         taken.len(),
@@ -420,7 +420,7 @@ fn test_empty_operations_consistency(array: &dyn Array) {
 
     // Empty slice (if array is non-empty)
     if len > 0 {
-        let empty_slice = array.slice(0, 0);
+        let empty_slice = array.slice(0..0);
         assert_eq!(empty_slice.len(), 0);
         assert_eq!(empty_slice.dtype(), array.dtype());
     }
@@ -806,9 +806,9 @@ fn test_slice_aggregate_consistency(array: &dyn Array) {
     let end = (len - 1).min(start + 10); // Take up to 10 elements
 
     // Get sliced array and canonical slice
-    let sliced = array.slice(start, end);
+    let sliced = array.slice(start..end);
     let canonical = array.to_canonical().vortex_unwrap();
-    let canonical_sliced = canonical.as_ref().slice(start, end);
+    let canonical_sliced = canonical.as_ref().slice(start..end);
 
     // Test null count through invalid_count
     if let (Ok(slice_null_count), Ok(canonical_null_count)) =
@@ -1007,7 +1007,7 @@ fn test_cast_slice_consistency(array: &dyn Array) {
     // Test each target dtype
     for target_dtype in target_dtypes {
         // Slice the array
-        let sliced = array.slice(start, end);
+        let sliced = array.slice(start..end);
 
         // Try to cast the sliced array
         let slice_then_cast = match cast(&sliced, &target_dtype) {
@@ -1057,7 +1057,7 @@ fn test_cast_slice_consistency(array: &dyn Array) {
             Ok(result) => result,
             Err(_) => continue, // Skip if cast fails
         };
-        let cast_then_slice = casted.slice(start, end);
+        let cast_then_slice = casted.slice(start..end);
 
         // Verify the two approaches produce identical results
         assert_eq!(

--- a/vortex-array/src/compute/list_contains.rs
+++ b/vortex-array/src/compute/list_contains.rs
@@ -217,7 +217,7 @@ fn list_contains_scalar(
 ) -> VortexResult<ArrayRef> {
     // If the list array is constant, we perform a single comparison.
     if array.len() > 1 && array.is_constant() {
-        let contains = list_contains_scalar(&array.slice(0, 1), value, nullability)?;
+        let contains = list_contains_scalar(&array.slice(0..1), value, nullability)?;
         return Ok(ConstantArray::new(contains.scalar_at(0), array.len()).into_array());
     }
 
@@ -378,7 +378,7 @@ pub fn list_elem_len(array: &dyn Array) -> VortexResult<ArrayRef> {
 
     // Short-circuit for constant list arrays.
     if array.is_constant() && array.len() > 1 {
-        let elem_lens = list_elem_len(&array.slice(0, 1))?;
+        let elem_lens = list_elem_len(&array.slice(0..1))?;
         return Ok(ConstantArray::new(elem_lens.scalar_at(0), array.len()).into_array());
     }
 

--- a/vortex-array/src/compute/zip.rs
+++ b/vortex-array/src/compute/zip.rs
@@ -195,11 +195,11 @@ pub(crate) fn zip_impl_with_builder(
         AllOr::None => Ok(if_false.to_array()),
         AllOr::Some(slices) => {
             for (start, end) in slices {
-                builder.extend_from_array(&if_false.slice(builder.len(), *start))?;
-                builder.extend_from_array(&if_true.slice(*start, *end))?;
+                builder.extend_from_array(&if_false.slice(builder.len()..*start))?;
+                builder.extend_from_array(&if_true.slice(*start..*end))?;
             }
             if builder.len() < if_false.len() {
-                builder.extend_from_array(&if_false.slice(builder.len(), if_false.len()))?;
+                builder.extend_from_array(&if_false.slice(builder.len()..if_false.len()))?;
             }
             Ok(builder.finish())
         }

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use arrow_buffer::BooleanBuffer;
-use itertools::Itertools as _;
-use num_traits::{NumCast, ToPrimitive};
-use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::Range;
+
+use arrow_buffer::BooleanBuffer;
+use itertools::Itertools as _;
+use num_traits::{NumCast, ToPrimitive};
+use serde::{Deserialize, Serialize};
 use vortex_buffer::BufferMut;
 use vortex_dtype::Nullability::NonNullable;
 use vortex_dtype::{
@@ -764,7 +765,7 @@ mod test {
 
     #[rstest]
     fn search_sliced(patches: Patches) {
-        let sliced = patches.slice(7, 20).unwrap();
+        let sliced = patches.slice(7..20).unwrap();
         assert_eq!(
             sliced.search_sorted(22, SearchSortedSide::Left).unwrap(),
             SearchResult::NotFound(2)
@@ -841,7 +842,7 @@ mod test {
 
         let patches = Patches::new(101, 0, indices, values);
 
-        let sliced = patches.slice(15, 100).unwrap();
+        let sliced = patches.slice(15..100).unwrap();
         assert_eq!(sliced.array_len(), 100 - 15);
         let primitive = sliced.values().to_primitive().unwrap();
 
@@ -855,13 +856,13 @@ mod test {
 
         let patches = Patches::new(101, 0, indices, values);
 
-        let sliced = patches.slice(15, 100).unwrap();
+        let sliced = patches.slice(15..100).unwrap();
         assert_eq!(sliced.array_len(), 100 - 15);
         let primitive = sliced.values().to_primitive().unwrap();
 
         assert_eq!(primitive.as_slice::<u32>(), &[13531]);
 
-        let doubly_sliced = sliced.slice(35, 36).unwrap();
+        let doubly_sliced = sliced.slice(35..71).unwrap();
         let primitive_doubly_sliced = doubly_sliced.values().to_primitive().unwrap();
 
         assert_eq!(primitive_doubly_sliced.as_slice::<u32>(), &[13531]);
@@ -1042,7 +1043,7 @@ mod test {
             buffer![100i32, 200, 300].into_array(),
         );
 
-        let sliced = patches.slice(0, 10).unwrap();
+        let sliced = patches.slice(0..10).unwrap();
 
         let indices = sliced.indices().to_primitive().unwrap();
         let values = sliced.values().to_primitive().unwrap();
@@ -1060,7 +1061,7 @@ mod test {
         );
 
         // Slice from 3 to 8 (includes patch at 5)
-        let sliced = patches.slice(3, 8).unwrap();
+        let sliced = patches.slice(3..8).unwrap();
 
         let indices = sliced.indices().to_primitive().unwrap();
         let values = sliced.values().to_primitive().unwrap();
@@ -1080,7 +1081,7 @@ mod test {
         );
 
         // Slice from 6 to 7 (no patches in this range)
-        let sliced = patches.slice(6, 7);
+        let sliced = patches.slice(6..7);
         assert!(sliced.is_none());
     }
 
@@ -1094,7 +1095,7 @@ mod test {
         );
 
         // Slice from 3 to 8 (includes patch at actual index 5)
-        let sliced = patches.slice(3, 8).unwrap();
+        let sliced = patches.slice(3..8).unwrap();
 
         let indices = sliced.indices().to_primitive().unwrap();
         let values = sliced.values().to_primitive().unwrap();

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -862,7 +862,7 @@ mod test {
 
         assert_eq!(primitive.as_slice::<u32>(), &[13531]);
 
-        let doubly_sliced = sliced.slice(35..71).unwrap();
+        let doubly_sliced = sliced.slice(35..36).unwrap();
         let primitive_doubly_sliced = doubly_sliced.values().to_primitive().unwrap();
 
         assert_eq!(primitive_doubly_sliced.as_slice::<u32>(), &[13531]);

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::cmp::Ordering;
-use std::fmt::Debug;
-use std::hash::Hash;
-
 use arrow_buffer::BooleanBuffer;
 use itertools::Itertools as _;
 use num_traits::{NumCast, ToPrimitive};
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::ops::Range;
 use vortex_buffer::BufferMut;
 use vortex_dtype::Nullability::NonNullable;
 use vortex_dtype::{
@@ -356,21 +356,21 @@ impl Patches {
     }
 
     /// Slice the patches by a range of the patched array.
-    pub fn slice(&self, start: usize, stop: usize) -> Option<Self> {
-        let patch_start = self.search_index(start).to_index();
-        let patch_stop = self.search_index(stop).to_index();
+    pub fn slice(&self, range: Range<usize>) -> Option<Self> {
+        let patch_start = self.search_index(range.start).to_index();
+        let patch_stop = self.search_index(range.end).to_index();
 
         if patch_start == patch_stop {
             return None;
         }
 
         // Slice out the values and indices
-        let values = self.values().slice(patch_start, patch_stop);
-        let indices = self.indices().slice(patch_start, patch_stop);
+        let values = self.values().slice(patch_start..patch_stop);
+        let indices = self.indices().slice(patch_start..patch_stop);
 
         Some(Self::new(
-            stop - start,
-            start + self.offset(),
+            range.len(),
+            range.start + self.offset(),
             indices,
             values,
         ))

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -146,16 +146,6 @@ impl Validity {
         }
     }
 
-    pub fn slice_range<R>(&self, range: R) -> Self
-    where
-        R: std::ops::RangeBounds<usize>,
-    {
-        match self {
-            Self::Array(a) => Self::Array(a.slice_range(range)),
-            Self::NonNullable | Self::AllValid | Self::AllInvalid => self.clone(),
-        }
-    }
-
     pub fn take(&self, indices: &dyn Array) -> VortexResult<Self> {
         match self {
             Self::NonNullable => match indices.validity_mask()?.boolean_buffer() {

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -146,6 +146,16 @@ impl Validity {
         }
     }
 
+    pub fn slice_range<R>(&self, range: R) -> Self
+    where
+        R: std::ops::RangeBounds<usize>,
+    {
+        match self {
+            Self::Array(a) => Self::Array(a.slice_range(range)),
+            Self::NonNullable | Self::AllValid | Self::AllInvalid => self.clone(),
+        }
+    }
+
     pub fn take(&self, indices: &dyn Array) -> VortexResult<Self> {
         match self {
             Self::NonNullable => match indices.validity_mask()?.boolean_buffer() {

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -4,7 +4,7 @@
 //! Array validity and nullability behavior, used by arrays and compute functions.
 
 use std::fmt::Debug;
-use std::ops::{BitAnd, Not};
+use std::ops::{BitAnd, Not, Range};
 
 use arrow_buffer::{BooleanBuffer, NullBuffer};
 use vortex_dtype::{DType, Nullability};
@@ -139,9 +139,9 @@ impl Validity {
         Ok(!self.is_valid(index)?)
     }
 
-    pub fn slice(&self, start: usize, stop: usize) -> Self {
+    pub fn slice(&self, range: Range<usize>) -> Self {
         match self {
-            Self::Array(a) => Self::Array(a.slice(start, stop)),
+            Self::Array(a) => Self::Array(a.slice(range)),
             Self::NonNullable | Self::AllValid | Self::AllInvalid => self.clone(),
         }
     }

--- a/vortex-array/src/vtable/operations.rs
+++ b/vortex-array/src/vtable/operations.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
 use vortex_scalar::Scalar;
 
 use crate::ArrayRef;
@@ -18,7 +19,7 @@ pub trait OperationsVTable<V: VTable> {
     /// ## Preconditions
     ///
     /// Bounds-checking has already been performed by the time this function is called.
-    fn slice(array: &V::Array, start: usize, stop: usize) -> ArrayRef;
+    fn slice(array: &V::Array, range: Range<usize>) -> ArrayRef;
 
     /// Fetch the scalar at the given index.
     ///

--- a/vortex-array/src/vtable/operations.rs
+++ b/vortex-array/src/vtable/operations.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::ops::Range;
+
 use vortex_scalar::Scalar;
 
 use crate::ArrayRef;

--- a/vortex-array/src/vtable/validity.rs
+++ b/vortex-array/src/vtable/validity.rs
@@ -73,7 +73,7 @@ pub trait ValiditySliceHelper {
 
     fn sliced_validity(&self) -> Validity {
         let (unsliced_validity, start, stop) = self.unsliced_validity_and_slice();
-        unsliced_validity.slice(start, stop)
+        unsliced_validity.slice(start..stop)
     }
 }
 

--- a/vortex-btrblocks/src/sample.rs
+++ b/vortex-btrblocks/src/sample.rs
@@ -23,7 +23,7 @@ pub(crate) fn sample(input: &dyn Array, sample_size: u32, sample_count: u32) -> 
     ChunkedArray::try_new(
         slices
             .into_iter()
-            .map(|(start, end)| input.slice(start, end))
+            .map(|(start, end)| input.slice(start..end))
             .collect(),
         input.dtype().clone(),
     )

--- a/vortex-ffi/src/array.rs
+++ b/vortex-ffi/src/array.rs
@@ -71,7 +71,7 @@ pub unsafe extern "C-unwind" fn vx_array_slice(
     _error_out: *mut *mut vx_error,
 ) -> *const vx_array {
     let array = vx_array::as_ref(array);
-    let sliced = array.slice(start as usize, stop as usize);
+    let sliced = array.slice(start as usize..stop as usize);
     vx_array::new(sliced)
 }
 

--- a/vortex-jni/src/array.rs
+++ b/vortex-jni/src/array.rs
@@ -220,7 +220,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_slice(
     let array_ref = unsafe { NativeArray::from_ptr(array_ptr) };
 
     try_or_throw(&mut env, |_| {
-        let sliced_array = array_ref.inner.as_ref().slice(start as usize, end as usize);
+        let sliced_array = array_ref.inner.as_ref().slice(start as usize..end as usize);
         Ok(NativeArray::new(sliced_array).into_raw())
     })
 }

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -254,7 +254,7 @@ impl PruningEvaluation for ChunkedPruningEvaluation {
         let masks: Vec<_> = FuturesOrdered::from_iter(
             self.mask_ranges
                 .iter()
-                .map(|range| mask.slice(range.start, range.end - range.start))
+                .map(|range| mask.slice(range.start..range.end))
                 .zip_eq(&self.chunk_evals)
                 .map(|(mask, chunk_eval)| {
                     if mask.all_false() {
@@ -297,7 +297,7 @@ impl MaskEvaluation for ChunkedMaskEvaluation {
         let masks: Vec<_> = FuturesOrdered::from_iter(
             self.mask_ranges
                 .iter()
-                .map(|range| mask.slice(range.start, range.end - range.start))
+                .map(|range| mask.slice(range.start..range.end))
                 .zip_eq(&self.chunk_evals)
                 .map(|(mask, chunk_eval)| {
                     if mask.all_false() {
@@ -334,7 +334,7 @@ impl ArrayEvaluation for ChunkedArrayEvaluation {
         let chunks: Vec<_> = FuturesOrdered::from_iter(
             self.mask_ranges
                 .iter()
-                .map(|range| mask.slice(range.start, range.end - range.start))
+                .map(|range| mask.slice(range.start..range.end))
                 .zip_eq(&self.chunk_evals)
                 .filter(|(mask, _chunk_eval)| mask.true_count() > 0)
                 .map(|(mask, chunk_eval)| chunk_eval.invoke(mask)),

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -254,7 +254,7 @@ impl PruningEvaluation for ChunkedPruningEvaluation {
         let masks: Vec<_> = FuturesOrdered::from_iter(
             self.mask_ranges
                 .iter()
-                .map(|range| mask.slice(range.start..range.end))
+                .map(|range| mask.slice(range.clone()))
                 .zip_eq(&self.chunk_evals)
                 .map(|(mask, chunk_eval)| {
                     if mask.all_false() {
@@ -297,7 +297,7 @@ impl MaskEvaluation for ChunkedMaskEvaluation {
         let masks: Vec<_> = FuturesOrdered::from_iter(
             self.mask_ranges
                 .iter()
-                .map(|range| mask.slice(range.start..range.end))
+                .map(|range| mask.slice(range.clone()))
                 .zip_eq(&self.chunk_evals)
                 .map(|(mask, chunk_eval)| {
                     if mask.all_false() {
@@ -334,7 +334,7 @@ impl ArrayEvaluation for ChunkedArrayEvaluation {
         let chunks: Vec<_> = FuturesOrdered::from_iter(
             self.mask_ranges
                 .iter()
-                .map(|range| mask.slice(range.start..range.end))
+                .map(|range| mask.slice(range.clone()))
                 .zip_eq(&self.chunk_evals)
                 .filter(|(mask, _chunk_eval)| mask.true_count() > 0)
                 .map(|(mask, chunk_eval)| chunk_eval.invoke(mask)),

--- a/vortex-layout/src/layouts/dict/writer/mod.rs
+++ b/vortex-layout/src/layouts/dict/writer/mod.rs
@@ -491,5 +491,5 @@ fn encode_chunk(
 }
 
 fn remainder(array: &dyn Array, encoded_len: usize) -> Option<ArrayRef> {
-    (encoded_len < array.len()).then(|| array.slice(encoded_len, array.len()))
+    (encoded_len < array.len()).then(|| array.slice(encoded_len..array.len()))
 }

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -170,7 +170,7 @@ impl MaskEvaluation for FlatEvaluation {
 
         // Slice the array based on the row mask.
         if self.row_range.start > 0 || self.row_range.end < array.len() {
-            array = array.slice(self.row_range.start, self.row_range.end);
+            array = array.slice(self.row_range.clone());
         }
 
         // TODO(ngates): the mask may actually be dense within a range, as is often the case when
@@ -217,7 +217,7 @@ impl ArrayEvaluation for FlatEvaluation {
 
         // Slice the array based on the row mask.
         if self.row_range.start > 0 || self.row_range.end < array.len() {
-            array = array.slice(self.row_range.start, self.row_range.end);
+            array = array.slice(self.row_range.clone());
         }
 
         // Filter the array based on the row mask.

--- a/vortex-layout/src/layouts/repartition.rs
+++ b/vortex-layout/src/layouts/repartition.rs
@@ -78,7 +78,7 @@ where
                 let mut offset = 0;
                 while offset < chunk.len() {
                     let end = (offset + options.block_len_multiple).min(chunk.len());
-                    let sliced = chunk.slice(offset, end);
+                    let sliced = chunk.slice(offset..end);
                     chunks.push_back(sliced);
                     offset = end;
 
@@ -153,8 +153,8 @@ impl ChunksBuffer {
             let len = chunk.len();
 
             if len > remaining {
-                let left = chunk.slice(0, remaining);
-                let right = chunk.slice(remaining, len);
+                let left = chunk.slice(0..remaining);
+                let right = chunk.slice(remaining..len);
                 self.push_front(right);
                 res.push(left);
                 remaining = 0;

--- a/vortex-mask/src/lib.rs
+++ b/vortex-mask/src/lib.rs
@@ -475,6 +475,27 @@ impl Mask {
         }
     }
 
+    /// Slice the mask using a range.
+    pub fn slice_range<R>(&self, range: R) -> Self
+    where
+        R: std::ops::RangeBounds<usize>,
+    {
+        use std::ops::Bound;
+        let start = match range.start_bound() {
+            Bound::Included(&n) => n,
+            Bound::Excluded(&n) => n + 1,
+            Bound::Unbounded => 0,
+        };
+        let end = match range.end_bound() {
+            Bound::Included(&n) => n + 1,
+            Bound::Excluded(&n) => n,
+            Bound::Unbounded => self.len(),
+        };
+        assert!(start <= end && end <= self.len(), "Invalid range");
+        let length = end - start;
+        self.slice(start, length)
+    }
+
     /// Return the boolean buffer representation of the mask.
     pub fn boolean_buffer(&self) -> AllOr<&BooleanBuffer> {
         match &self {

--- a/vortex-mask/src/lib.rs
+++ b/vortex-mask/src/lib.rs
@@ -475,27 +475,6 @@ impl Mask {
         }
     }
 
-    /// Slice the mask using a range.
-    pub fn slice_range<R>(&self, range: R) -> Self
-    where
-        R: std::ops::RangeBounds<usize>,
-    {
-        use std::ops::Bound;
-        let start = match range.start_bound() {
-            Bound::Included(&n) => n,
-            Bound::Excluded(&n) => n + 1,
-            Bound::Unbounded => 0,
-        };
-        let end = match range.end_bound() {
-            Bound::Included(&n) => n + 1,
-            Bound::Excluded(&n) => n,
-            Bound::Unbounded => self.len(),
-        };
-        assert!(start <= end && end <= self.len(), "Invalid range");
-        let length = end - start;
-        self.slice(start, length)
-    }
-
     /// Return the boolean buffer representation of the mask.
     pub fn boolean_buffer(&self) -> AllOr<&BooleanBuffer> {
         match &self {

--- a/vortex-mask/src/lib.rs
+++ b/vortex-mask/src/lib.rs
@@ -13,6 +13,7 @@ mod tests;
 
 use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter};
+use std::ops::Range;
 use std::sync::{Arc, OnceLock};
 
 use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder, NullBuffer};
@@ -466,12 +467,14 @@ impl Mask {
     }
 
     /// Slice the mask.
-    pub fn slice(&self, offset: usize, length: usize) -> Self {
-        assert!(offset + length <= self.len());
+    pub fn slice(&self, range: Range<usize>) -> Self {
+        assert!(range.end <= self.len());
         match &self {
-            Self::AllTrue(_) => Self::new_true(length),
-            Self::AllFalse(_) => Self::new_false(length),
-            Self::Values(values) => Self::from_buffer(values.buffer.slice(offset, length)),
+            Self::AllTrue(_) => Self::new_true(range.len()),
+            Self::AllFalse(_) => Self::new_false(range.len()),
+            Self::Values(values) => {
+                Self::from_buffer(values.buffer.slice(range.start, range.len()))
+            }
         }
     }
 

--- a/vortex-mask/src/tests.rs
+++ b/vortex-mask/src/tests.rs
@@ -119,7 +119,7 @@ fn test_mask_false_count() {
 fn test_mask_slice() {
     let mask = Mask::from_buffer(BooleanBuffer::from_iter([true, false, true, true, false]));
 
-    let sliced = mask.slice(1..3);
+    let sliced = mask.slice(1..4);
     assert_eq!(sliced.len(), 3);
     assert_eq!(sliced.true_count(), 2);
     assert!(!sliced.value(0)); // false from index 1
@@ -127,12 +127,12 @@ fn test_mask_slice() {
     assert!(sliced.value(2)); // true from index 3
 
     let all_true = Mask::new_true(10);
-    let sliced_true = all_true.slice(2..5);
+    let sliced_true = all_true.slice(2..7);
     assert!(sliced_true.all_true());
     assert_eq!(sliced_true.len(), 5);
 
     let all_false = Mask::new_false(10);
-    let sliced_false = all_false.slice(2..5);
+    let sliced_false = all_false.slice(2..7);
     assert!(sliced_false.all_false());
     assert_eq!(sliced_false.len(), 5);
 }
@@ -141,7 +141,7 @@ fn test_mask_slice() {
 #[should_panic]
 fn test_mask_slice_out_of_bounds() {
     let mask = Mask::new_true(5);
-    let _ = mask.slice(3..5); // offset + length > len
+    let _ = mask.slice(3..8); // offset + length > len
 }
 
 // Limit operations

--- a/vortex-mask/src/tests.rs
+++ b/vortex-mask/src/tests.rs
@@ -119,7 +119,7 @@ fn test_mask_false_count() {
 fn test_mask_slice() {
     let mask = Mask::from_buffer(BooleanBuffer::from_iter([true, false, true, true, false]));
 
-    let sliced = mask.slice(1, 3);
+    let sliced = mask.slice(1..3);
     assert_eq!(sliced.len(), 3);
     assert_eq!(sliced.true_count(), 2);
     assert!(!sliced.value(0)); // false from index 1
@@ -127,12 +127,12 @@ fn test_mask_slice() {
     assert!(sliced.value(2)); // true from index 3
 
     let all_true = Mask::new_true(10);
-    let sliced_true = all_true.slice(2, 5);
+    let sliced_true = all_true.slice(2..5);
     assert!(sliced_true.all_true());
     assert_eq!(sliced_true.len(), 5);
 
     let all_false = Mask::new_false(10);
-    let sliced_false = all_false.slice(2, 5);
+    let sliced_false = all_false.slice(2..5);
     assert!(sliced_false.all_false());
     assert_eq!(sliced_false.len(), 5);
 }
@@ -141,7 +141,7 @@ fn test_mask_slice() {
 #[should_panic]
 fn test_mask_slice_out_of_bounds() {
     let mask = Mask::new_true(5);
-    let _ = mask.slice(3, 5); // offset + length > len
+    let _ = mask.slice(3..5); // offset + length > len
 }
 
 // Limit operations

--- a/vortex-python/src/arrays/mod.rs
+++ b/vortex-python/src/arrays/mod.rs
@@ -501,7 +501,7 @@ impl PyArray {
     #[pyo3(signature = (start, end))]
     fn slice(slf: Bound<Self>, start: usize, end: usize) -> PyResult<PyArrayRef> {
         let slf = PyArrayRef::extract_bound(slf.as_any())?.into_inner();
-        let inner = slf.slice(start, end);
+        let inner = slf.slice(start..end);
         Ok(PyArrayRef::from(inner))
     }
 

--- a/vortex-python/src/arrays/py/vtable.rs
+++ b/vortex-python/src/arrays/py/vtable.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use pyo3::{Python, intern};
@@ -69,7 +71,7 @@ impl CanonicalVTable<PythonVTable> for PythonVTable {
 }
 
 impl OperationsVTable<PythonVTable> for PythonVTable {
-    fn slice(_array: &PythonArray, _start: usize, _stop: usize) -> ArrayRef {
+    fn slice(_array: &PythonArray, _range: Range<usize>) -> ArrayRef {
         todo!()
     }
 


### PR DESCRIPTION
Closes #4389: Unifies inconsistent slice method signatures by introducing Range-based APIs.

Generated with [Claude Code](https://claude.ai/code)