### PR TITLE
fix: ubuntu uses dash which lacks pipefail

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -166,7 +166,7 @@ jobs:
         run: ldd --version
       - name: Verify GLIBC version
         run: |
-          set -eux -o pipefail
+          set -eux
 
           ldd --version | grep 'GLIBC 2.31'
       - uses: actions/setup-java@v5


### PR DESCRIPTION
We do not need it in this case. If ldd fails, grep should not receive thestring GLIBC 2.31