### PR TITLE
chore: rust depends on rust, java on java, and python on python

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,6 @@ jobs:
   publish-rust:
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    needs: [prepare-python, prepare-java-macos, prepare-java-linux]
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Currently, Python depends only on the prepare-python jobs, Java depends only on the prepare-java jobs, and Rust depends on both prepare-python and prepare-java (there are no prepare-rust jobs).

After this PR, Rust, Python, and Java can all independently publish as long as their publish sequence succeeds.