### PR TITLE
Expand expression pushdown to DataFusion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6587,6 +6587,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-pruning",
  "futures",
+ "insta",
  "itertools 0.14.0",
  "log",
  "moka",

--- a/vortex-datafusion/Cargo.toml
+++ b/vortex-datafusion/Cargo.toml
@@ -42,6 +42,7 @@ vortex-utils = { workspace = true, features = ["dashmap"] }
 [dev-dependencies]
 anyhow = { workspace = true }
 datafusion = { workspace = true }
+insta = { workspace = true }
 rstest = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util", "rt-multi-thread", "fs"] }

--- a/vortex-datafusion/src/convert/exprs.rs
+++ b/vortex-datafusion/src/convert/exprs.rs
@@ -121,14 +121,14 @@ impl TryFromDataFusion<DFOperator> for Operator {
     }
 }
 
-pub(crate) fn can_be_pushed_down(expr: &PhysicalExprRef, schema: &Schema) -> bool {
+pub(crate) fn can_be_pushed_down(df_expr: &PhysicalExprRef, schema: &Schema) -> bool {
     // We currently do not support pushdown of dynamic expressions in DF.
     // See issue: https://github.com/vortex-data/vortex/issues/4034
-    if is_dynamic_physical_expr(expr) {
+    if is_dynamic_physical_expr(df_expr) {
         return false;
     }
 
-    let expr = expr.as_any();
+    let expr = df_expr.as_any();
     if let Some(binary) = expr.downcast_ref::<df_expr::BinaryExpr>() {
         can_binary_be_pushed_down(binary, schema)
     } else if let Some(col) = expr.downcast_ref::<df_expr::Column>() {
@@ -143,7 +143,7 @@ pub(crate) fn can_be_pushed_down(expr: &PhysicalExprRef, schema: &Schema) -> boo
     } else if let Some(cast) = expr.downcast_ref::<df_expr::CastExpr>() {
         supported_data_types(cast.cast_type()) && can_be_pushed_down(cast.expr(), schema)
     } else {
-        log::debug!("DataFusion expression can't be pushed down: {expr:?}");
+        tracing::debug!(%df_expr, "DataFusion expression can't be pushed down");
         false
     }
 }
@@ -259,9 +259,6 @@ mod tests {
     }
 
     #[rstest]
-    #[case::minus(DFOperator::Minus)]
-    #[case::multiply(DFOperator::Multiply)]
-    #[case::divide(DFOperator::Divide)]
     #[case::modulo(DFOperator::Modulo)]
     #[case::bitwise_and(DFOperator::BitwiseAnd)]
     #[case::regex_match(DFOperator::RegexMatch)]
@@ -428,8 +425,11 @@ mod tests {
         let left = Arc::new(df_expr::Column::new("id", 0)) as Arc<dyn PhysicalExpr>;
         let right =
             Arc::new(df_expr::Literal::new(ScalarValue::Int32(Some(42)))) as Arc<dyn PhysicalExpr>;
-        let binary_expr = Arc::new(df_expr::BinaryExpr::new(left, DFOperator::Minus, right))
-            as Arc<dyn PhysicalExpr>;
+        let binary_expr = Arc::new(df_expr::BinaryExpr::new(
+            left,
+            DFOperator::AtQuestion,
+            right,
+        )) as Arc<dyn PhysicalExpr>;
 
         assert!(!can_be_pushed_down(&binary_expr, &test_schema));
     }

--- a/vortex-datafusion/src/convert/exprs.rs
+++ b/vortex-datafusion/src/convert/exprs.rs
@@ -153,7 +153,7 @@ impl TryFromDataFusion<DFOperator> for Operator {
             | DFOperator::Question
             | DFOperator::QuestionAnd
             | DFOperator::QuestionPipe => {
-                eprintln!("Can't pushdown {value} operator");
+                tracing::debug!(operator = %value, "Can't pushdown binary_operator operator");
                 Err(vortex_err!("Unsupported datafusion operator {value}"))
             }
         }

--- a/vortex-datafusion/src/convert/exprs.rs
+++ b/vortex-datafusion/src/convert/exprs.rs
@@ -8,11 +8,13 @@ use datafusion_expr::Operator as DFOperator;
 use datafusion_physical_expr::{PhysicalExpr, PhysicalExprRef};
 use datafusion_physical_expr_common::physical_expr::is_dynamic_physical_expr;
 use datafusion_physical_plan::expressions as df_expr;
+use itertools::Itertools;
 use vortex::dtype::arrow::FromArrowType;
 use vortex::dtype::{DType, Nullability};
 use vortex::error::{VortexResult, vortex_bail, vortex_err};
 use vortex::expr::{
-    BinaryExpr, ExprRef, LikeExpr, Operator, and, cast, get_item, is_null, lit, not, root,
+    BinaryExpr, ExprRef, LikeExpr, Operator, and, cast, get_item, is_null, list_contains, lit, not,
+    root,
 };
 use vortex::scalar::Scalar;
 
@@ -76,6 +78,30 @@ impl TryFromDataFusion<dyn PhysicalExpr> for ExprRef {
         if let Some(is_not_null_expr) = df.as_any().downcast_ref::<df_expr::IsNotNullExpr>() {
             let arg = ExprRef::try_from_df(is_not_null_expr.arg().as_ref())?;
             return Ok(not(is_null(arg)));
+        }
+
+        if let Some(in_list) = df.as_any().downcast_ref::<df_expr::InListExpr>() {
+            let value = ExprRef::try_from_df(in_list.expr().as_ref())?;
+            let list_elements: Vec<_> = in_list
+                .list()
+                .iter()
+                .map(|e| {
+                    if let Some(lit) = e.as_any().downcast_ref::<df_expr::Literal>() {
+                        Ok(Scalar::from_df(lit.value()))
+                    } else {
+                        Err(vortex_err!("Failed to cast sub-expression"))
+                    }
+                })
+                .try_collect()?;
+
+            let list = Scalar::list(
+                list_elements[0].dtype().clone(),
+                list_elements,
+                Nullability::Nullable,
+            );
+            let expr = list_contains(lit(list), value);
+
+            return Ok(if in_list.negated() { not(expr) } else { expr });
         }
 
         vortex_bail!("Couldn't convert DataFusion physical {df} expression to a vortex expression")
@@ -159,8 +185,11 @@ pub(crate) fn can_be_pushed_down(df_expr: &PhysicalExprRef, schema: &Schema) -> 
         can_be_pushed_down(is_null.arg(), schema)
     } else if let Some(is_not_null) = expr.downcast_ref::<df_expr::IsNotNullExpr>() {
         can_be_pushed_down(is_not_null.arg(), schema)
+    } else if let Some(in_list) = expr.downcast_ref::<df_expr::InListExpr>() {
+        can_be_pushed_down(in_list.expr(), schema)
+            && in_list.list().iter().all(|e| can_be_pushed_down(e, schema))
     } else {
-        tracing::warn!(%df_expr, "DataFusion expression can't be pushed down");
+        tracing::debug!(%df_expr, "DataFusion expression can't be pushed down");
         false
     }
 }

--- a/vortex-datafusion/src/convert/exprs.rs
+++ b/vortex-datafusion/src/convert/exprs.rs
@@ -11,7 +11,9 @@ use datafusion_physical_plan::expressions as df_expr;
 use vortex::dtype::arrow::FromArrowType;
 use vortex::dtype::{DType, Nullability};
 use vortex::error::{VortexResult, vortex_bail, vortex_err};
-use vortex::expr::{BinaryExpr, ExprRef, LikeExpr, Operator, and, cast, get_item, lit, root};
+use vortex::expr::{
+    BinaryExpr, ExprRef, LikeExpr, Operator, and, cast, get_item, is_null, lit, not, root,
+};
 use vortex::scalar::Scalar;
 
 use crate::convert::{FromDataFusion, TryFromDataFusion};
@@ -66,6 +68,16 @@ impl TryFromDataFusion<dyn PhysicalExpr> for ExprRef {
             return Ok(cast(child, cast_dtype));
         }
 
+        if let Some(is_null_expr) = df.as_any().downcast_ref::<df_expr::IsNullExpr>() {
+            let arg = ExprRef::try_from_df(is_null_expr.arg().as_ref())?;
+            return Ok(is_null(arg));
+        }
+
+        if let Some(is_not_null_expr) = df.as_any().downcast_ref::<df_expr::IsNotNullExpr>() {
+            let arg = ExprRef::try_from_df(is_not_null_expr.arg().as_ref())?;
+            return Ok(not(is_null(arg)));
+        }
+
         vortex_bail!("Couldn't convert DataFusion physical {df} expression to a vortex expression")
     }
 }
@@ -115,6 +127,7 @@ impl TryFromDataFusion<DFOperator> for Operator {
             | DFOperator::Question
             | DFOperator::QuestionAnd
             | DFOperator::QuestionPipe => {
+                eprintln!("Can't pushdown {value} operator");
                 Err(vortex_err!("Unsupported datafusion operator {value}"))
             }
         }
@@ -142,8 +155,12 @@ pub(crate) fn can_be_pushed_down(df_expr: &PhysicalExprRef, schema: &Schema) -> 
         supported_data_types(&lit.value().data_type())
     } else if let Some(cast) = expr.downcast_ref::<df_expr::CastExpr>() {
         supported_data_types(cast.cast_type()) && can_be_pushed_down(cast.expr(), schema)
+    } else if let Some(is_null) = expr.downcast_ref::<df_expr::IsNullExpr>() {
+        can_be_pushed_down(is_null.arg(), schema)
+    } else if let Some(is_not_null) = expr.downcast_ref::<df_expr::IsNotNullExpr>() {
+        can_be_pushed_down(is_not_null.arg(), schema)
     } else {
-        tracing::debug!(%df_expr, "DataFusion expression can't be pushed down");
+        tracing::warn!(%df_expr, "DataFusion expression can't be pushed down");
         false
     }
 }
@@ -163,8 +180,10 @@ fn supported_data_types(dt: &DataType) -> bool {
             dt,
             Boolean
                 | Utf8
+                | LargeUtf8
                 | Utf8View
                 | Binary
+                | LargeBinary
                 | BinaryView
                 | Date32
                 | Date64

--- a/vortex-datafusion/src/convert/exprs.rs
+++ b/vortex-datafusion/src/convert/exprs.rs
@@ -16,16 +16,6 @@ use vortex::scalar::Scalar;
 
 use crate::convert::{FromDataFusion, TryFromDataFusion};
 
-const SUPPORTED_BINARY_OPS: &[DFOperator] = &[
-    DFOperator::Eq,
-    DFOperator::NotEq,
-    DFOperator::Gt,
-    DFOperator::GtEq,
-    DFOperator::Lt,
-    DFOperator::LtEq,
-    DFOperator::Plus,
-];
-
 /// Tries to convert the expressions into a vortex conjunction. Will return Ok(None) iff the input conjunction is empty.
 pub(crate) fn make_vortex_predicate(
     predicate: &[&Arc<dyn PhysicalExpr>],
@@ -92,6 +82,9 @@ impl TryFromDataFusion<DFOperator> for Operator {
             DFOperator::And => Ok(Operator::And),
             DFOperator::Or => Ok(Operator::Or),
             DFOperator::Plus => Ok(Operator::Add),
+            DFOperator::Minus => Ok(Operator::Sub),
+            DFOperator::Multiply => Ok(Operator::Mul),
+            DFOperator::Divide => Ok(Operator::Div),
             DFOperator::IsDistinctFrom
             | DFOperator::IsNotDistinctFrom
             | DFOperator::RegexMatch
@@ -110,9 +103,6 @@ impl TryFromDataFusion<DFOperator> for Operator {
             | DFOperator::StringConcat
             | DFOperator::AtArrow
             | DFOperator::ArrowAt
-            | DFOperator::Minus
-            | DFOperator::Multiply
-            | DFOperator::Divide
             | DFOperator::Modulo
             | DFOperator::Arrow
             | DFOperator::LongArrow
@@ -159,16 +149,10 @@ pub(crate) fn can_be_pushed_down(expr: &PhysicalExprRef, schema: &Schema) -> boo
 }
 
 fn can_binary_be_pushed_down(binary: &df_expr::BinaryExpr, schema: &Schema) -> bool {
-    let is_op_supported =
-        binary.op().is_logic_operator() || SUPPORTED_BINARY_OPS.contains(binary.op());
-    let r = is_op_supported
+    let is_op_supported = Operator::try_from_df(binary.op()).is_ok();
+    is_op_supported
         && can_be_pushed_down(binary.left(), schema)
-        && can_be_pushed_down(binary.right(), schema);
-
-    println!("{binary}");
-    println!("r = {r}");
-
-    r
+        && can_be_pushed_down(binary.right(), schema)
 }
 
 fn supported_data_types(dt: &DataType) -> bool {
@@ -263,6 +247,9 @@ mod tests {
     #[case::and(DFOperator::And, Operator::And)]
     #[case::or(DFOperator::Or, Operator::Or)]
     #[case::plus(DFOperator::Plus, Operator::Add)]
+    #[case::plus(DFOperator::Minus, Operator::Sub)]
+    #[case::plus(DFOperator::Multiply, Operator::Mul)]
+    #[case::plus(DFOperator::Divide, Operator::Div)]
     fn test_operator_conversion_supported(
         #[case] df_op: DFOperator,
         #[case] expected_vortex_op: Operator,

--- a/vortex-datafusion/src/convert/exprs.rs
+++ b/vortex-datafusion/src/convert/exprs.rs
@@ -8,8 +8,10 @@ use datafusion_expr::Operator as DFOperator;
 use datafusion_physical_expr::{PhysicalExpr, PhysicalExprRef};
 use datafusion_physical_expr_common::physical_expr::is_dynamic_physical_expr;
 use datafusion_physical_plan::expressions as df_expr;
+use vortex::dtype::arrow::FromArrowType;
+use vortex::dtype::{DType, Nullability};
 use vortex::error::{VortexResult, vortex_bail, vortex_err};
-use vortex::expr::{BinaryExpr, ExprRef, LikeExpr, Operator, and, get_item, lit, root};
+use vortex::expr::{BinaryExpr, ExprRef, LikeExpr, Operator, and, cast, get_item, lit, root};
 use vortex::scalar::Scalar;
 
 use crate::convert::{FromDataFusion, TryFromDataFusion};
@@ -21,6 +23,7 @@ const SUPPORTED_BINARY_OPS: &[DFOperator] = &[
     DFOperator::GtEq,
     DFOperator::Lt,
     DFOperator::LtEq,
+    DFOperator::Plus,
 ];
 
 /// Tries to convert the expressions into a vortex conjunction. Will return Ok(None) iff the input conjunction is empty.
@@ -67,6 +70,12 @@ impl TryFromDataFusion<dyn PhysicalExpr> for ExprRef {
             return Ok(lit(value));
         }
 
+        if let Some(cast_expr) = df.as_any().downcast_ref::<df_expr::CastExpr>() {
+            let cast_dtype = DType::from_arrow((cast_expr.cast_type(), Nullability::Nullable));
+            let child = ExprRef::try_from_df(cast_expr.expr().as_ref())?;
+            return Ok(cast(child, cast_dtype));
+        }
+
         vortex_bail!("Couldn't convert DataFusion physical {df} expression to a vortex expression")
     }
 }
@@ -82,6 +91,7 @@ impl TryFromDataFusion<DFOperator> for Operator {
             DFOperator::GtEq => Ok(Operator::Gte),
             DFOperator::And => Ok(Operator::And),
             DFOperator::Or => Ok(Operator::Or),
+            DFOperator::Plus => Ok(Operator::Add),
             DFOperator::IsDistinctFrom
             | DFOperator::IsNotDistinctFrom
             | DFOperator::RegexMatch
@@ -100,7 +110,6 @@ impl TryFromDataFusion<DFOperator> for Operator {
             | DFOperator::StringConcat
             | DFOperator::AtArrow
             | DFOperator::ArrowAt
-            | DFOperator::Plus
             | DFOperator::Minus
             | DFOperator::Multiply
             | DFOperator::Divide
@@ -141,6 +150,8 @@ pub(crate) fn can_be_pushed_down(expr: &PhysicalExprRef, schema: &Schema) -> boo
         can_be_pushed_down(like.expr(), schema) && can_be_pushed_down(like.pattern(), schema)
     } else if let Some(lit) = expr.downcast_ref::<df_expr::Literal>() {
         supported_data_types(&lit.value().data_type())
+    } else if let Some(cast) = expr.downcast_ref::<df_expr::CastExpr>() {
+        supported_data_types(cast.cast_type()) && can_be_pushed_down(cast.expr(), schema)
     } else {
         log::debug!("DataFusion expression can't be pushed down: {expr:?}");
         false
@@ -150,9 +161,14 @@ pub(crate) fn can_be_pushed_down(expr: &PhysicalExprRef, schema: &Schema) -> boo
 fn can_binary_be_pushed_down(binary: &df_expr::BinaryExpr, schema: &Schema) -> bool {
     let is_op_supported =
         binary.op().is_logic_operator() || SUPPORTED_BINARY_OPS.contains(binary.op());
-    is_op_supported
+    let r = is_op_supported
         && can_be_pushed_down(binary.left(), schema)
-        && can_be_pushed_down(binary.right(), schema)
+        && can_be_pushed_down(binary.right(), schema);
+
+    println!("{binary}");
+    println!("r = {r}");
+
+    r
 }
 
 fn supported_data_types(dt: &DataType) -> bool {
@@ -189,8 +205,9 @@ mod tests {
     use datafusion_expr::Operator as DFOperator;
     use datafusion_physical_expr::PhysicalExpr;
     use datafusion_physical_plan::expressions as df_expr;
+    use insta::assert_snapshot;
     use rstest::rstest;
-    use vortex::expr::{BinaryVTable, ExprRef, GetItemVTable, LikeVTable, LiteralVTable, Operator};
+    use vortex::expr::{ExprRef, Operator};
 
     use super::*;
 
@@ -245,31 +262,16 @@ mod tests {
     #[case::gte(DFOperator::GtEq, Operator::Gte)]
     #[case::and(DFOperator::And, Operator::And)]
     #[case::or(DFOperator::Or, Operator::Or)]
+    #[case::plus(DFOperator::Plus, Operator::Add)]
     fn test_operator_conversion_supported(
         #[case] df_op: DFOperator,
         #[case] expected_vortex_op: Operator,
     ) {
         let result = Operator::try_from_df(&df_op).unwrap();
-        // We can't directly compare operators, so let's check they convert successfully
-        // and have the expected behavior by converting back or through other means
-        match (&result, &expected_vortex_op) {
-            (Operator::Eq, Operator::Eq) => (),
-            (Operator::NotEq, Operator::NotEq) => (),
-            (Operator::Lt, Operator::Lt) => (),
-            (Operator::Lte, Operator::Lte) => (),
-            (Operator::Gt, Operator::Gt) => (),
-            (Operator::Gte, Operator::Gte) => (),
-            (Operator::And, Operator::And) => (),
-            (Operator::Or, Operator::Or) => (),
-            _ => panic!(
-                "Operator conversion mismatch: expected {:?}, got {:?}",
-                expected_vortex_op, result
-            ),
-        }
+        assert_eq!(result, expected_vortex_op);
     }
 
     #[rstest]
-    #[case::plus(DFOperator::Plus)]
     #[case::minus(DFOperator::Minus)]
     #[case::multiply(DFOperator::Multiply)]
     #[case::divide(DFOperator::Divide)]
@@ -293,9 +295,10 @@ mod tests {
         let col_expr = df_expr::Column::new("test_column", 0);
         let result = ExprRef::try_from_df(&col_expr).unwrap();
 
-        // Verify it's a column reference (get_item expression)
-        // We can't easily inspect the internal structure, but we can verify it converts without error
-        assert!(result.is::<GetItemVTable>());
+        assert_snapshot!(result.display_tree().to_string(), @r"
+        GetItem(test_column)
+        └── Root
+        ");
     }
 
     #[test]
@@ -303,8 +306,7 @@ mod tests {
         let literal_expr = df_expr::Literal::new(ScalarValue::Int32(Some(42)));
         let result = ExprRef::try_from_df(&literal_expr).unwrap();
 
-        // Verify it's a literal expression
-        assert!(result.is::<LiteralVTable>());
+        assert_snapshot!(result.display_tree().to_string(), @"Literal(value: 42i32, dtype: i32)");
     }
 
     #[test]
@@ -316,8 +318,12 @@ mod tests {
 
         let result = ExprRef::try_from_df(&binary_expr).unwrap();
 
-        // Verify it's a binary expression
-        assert!(result.is::<BinaryVTable>());
+        assert_snapshot!(result.display_tree().to_string(), @r"
+        Binary(=)
+        ├── lhs: GetItem(left)
+        │   └── Root
+        └── rhs: Literal(value: 42i32, dtype: i32)
+        ");
     }
 
     #[rstest]
@@ -334,8 +340,12 @@ mod tests {
 
         let result = ExprRef::try_from_df(&like_expr).unwrap();
 
-        // Verify it's a like expression
-        assert!(dbg!(result).is::<LikeVTable>());
+        assert_snapshot!(result.display_tree().to_string(), @r#"
+        Like
+        ├── child: GetItem(text_col)
+        │   └── Root
+        └── pattern: Literal(value: "test%", dtype: utf8)
+        "#);
     }
 
     #[rstest]
@@ -431,7 +441,7 @@ mod tests {
         let left = Arc::new(df_expr::Column::new("id", 0)) as Arc<dyn PhysicalExpr>;
         let right =
             Arc::new(df_expr::Literal::new(ScalarValue::Int32(Some(42)))) as Arc<dyn PhysicalExpr>;
-        let binary_expr = Arc::new(df_expr::BinaryExpr::new(left, DFOperator::Plus, right))
+        let binary_expr = Arc::new(df_expr::BinaryExpr::new(left, DFOperator::Minus, right))
             as Arc<dyn PhysicalExpr>;
 
         assert!(!can_be_pushed_down(&binary_expr, &test_schema));

--- a/vortex-datafusion/src/persistent/mod.rs
+++ b/vortex-datafusion/src/persistent/mod.rs
@@ -34,12 +34,19 @@ fn register_vortex_format_factory(
 mod tests {
     use std::sync::Arc;
 
+    use arrow_schema::{DataType, Field, Schema};
+    use datafusion::arrow::array::{Int8Array, RecordBatch};
+    use datafusion::arrow::util::pretty::pretty_format_batches;
     use datafusion::datasource::listing::{
         ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
     };
+    use datafusion::execution::SessionStateBuilder;
     use datafusion::prelude::SessionContext;
+    use datafusion_datasource::file_format::format_as_file_type;
+    use datafusion_expr::LogicalPlanBuilder;
+    use insta::assert_snapshot;
     use rstest::rstest;
-    use tempfile::tempdir;
+    use tempfile::{TempDir, tempdir};
     use tokio::fs::OpenOptions;
     use vortex::IntoArray;
     use vortex::arrays::{ChunkedArray, StructArray, VarBinArray};
@@ -48,7 +55,8 @@ mod tests {
     use vortex::file::VortexWriteOptions;
     use vortex::validity::Validity;
 
-    use crate::persistent::VortexFormat;
+    use crate::VortexFormatFactory;
+    use crate::persistent::{VortexFormat, register_vortex_format_factory};
 
     #[rstest]
     #[case(Some(1))]
@@ -119,6 +127,64 @@ mod tests {
             .await?;
 
         assert_eq!(row_count, limit.unwrap_or(total_row_count));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_addition_pushdown() -> anyhow::Result<()> {
+        let dir = TempDir::new()?;
+
+        let factory = VortexFormatFactory::new();
+        let mut session_state_builder = SessionStateBuilder::new().with_default_features();
+        register_vortex_format_factory(factory, &mut session_state_builder);
+        let session = SessionContext::new_with_state(session_state_builder.build());
+
+        let data = session.read_batch(RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new("a", DataType::Int8, false)])),
+            vec![Arc::new(Int8Array::from_iter_values(0_i8..5))],
+        )?)?;
+
+        let logical_plan = LogicalPlanBuilder::copy_to(
+            data.logical_plan().clone(),
+            dir.path().to_str().unwrap().to_string(),
+            format_as_file_type(Arc::new(VortexFormatFactory::new())),
+            Default::default(),
+            vec![],
+        )?
+        .build()?;
+
+        session
+            .execute_logical_plan(logical_plan)
+            .await?
+            .collect()
+            .await?;
+
+        // Validate the output by reading back the written files
+        session
+            .sql(&format!(
+                "CREATE EXTERNAL TABLE written_data \
+                    (a TINYINT NOT NULL) \
+                STORED AS vortex 
+                LOCATION '{}/';",
+                dir.path().to_str().unwrap()
+            ))
+            .await?;
+
+        let result = session
+            .sql("SELECT a, a + 5 as five, a + 6 as six FROM written_data WHERE a + 5 > 7;")
+            .await?
+            .collect()
+            .await?;
+
+        assert_snapshot!(pretty_format_batches(&result)?, @r"
+        +---+------+-----+
+        | a | five | six |
+        +---+------+-----+
+        | 3 | 8    | 9   |
+        | 4 | 9    | 10  |
+        +---+------+-----+
+        ");
 
         Ok(())
     }

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -284,14 +284,14 @@ mod tests {
     use chrono::Utc;
     use datafusion::arrow::array::RecordBatch;
     use datafusion::arrow::datatypes::{DataType, Schema};
-    use datafusion::arrow::util::pretty::print_batches;
+    use datafusion::arrow::util::display::FormatOptions;
     use datafusion::common::record_batch;
     use datafusion::datasource::schema_adapter::DefaultSchemaAdapterFactory;
     use datafusion::logical_expr::{col, lit};
     use datafusion::physical_expr::planner::logical2physical;
     use datafusion::physical_expr_adapter::DefaultPhysicalExprAdapterFactory;
     use datafusion::scalar::ScalarValue;
-    use futures::stream::BoxStream;
+    use insta::assert_snapshot;
     use itertools::Itertools;
     use object_store::ObjectMeta;
     use object_store::memory::InMemory;
@@ -362,22 +362,6 @@ mod tests {
         Ok(summary.size())
     }
 
-    async fn count_data(
-        mut stream: BoxStream<'static, Result<RecordBatch, DataFusionError>>,
-    ) -> anyhow::Result<(usize, usize)> {
-        let mut batches = vec![];
-
-        while let Some(rb) = stream.next().await {
-            let rb = rb?;
-
-            batches.push(rb);
-        }
-
-        print_batches(&batches)?;
-        let num_rows = batches.iter().map(|v| v.num_rows()).sum::<usize>();
-        Ok((batches.len(), num_rows))
-    }
-
     fn make_meta(path: &str, data_size: u64) -> FileMeta {
         FileMeta {
             object_meta: ObjectMeta {
@@ -444,7 +428,11 @@ mod tests {
             .unwrap()
             .await
             .unwrap();
-        let (num_batches, num_rows) = count_data(stream).await?;
+
+        let data = stream.try_collect::<Vec<_>>().await?;
+        let num_batches = data.len();
+        let num_rows = data.iter().map(|rb| rb.num_rows()).sum::<usize>();
+
         assert_eq!((num_batches, num_rows), expected_result1);
 
         // filter doesn't matches partition value
@@ -457,7 +445,10 @@ mod tests {
             .unwrap()
             .await
             .unwrap();
-        let (num_batches, num_rows) = count_data(stream).await?;
+
+        let data = stream.try_collect::<Vec<_>>().await?;
+        let num_batches = data.len();
+        let num_rows = data.iter().map(|rb| rb.num_rows()).sum::<usize>();
         assert_eq!((num_batches, num_rows), expected_result2);
 
         Ok(())
@@ -474,6 +465,8 @@ mod tests {
     async fn test_open_files_different_table_schema(
         #[case] expr_adapter_factory: Option<Arc<dyn PhysicalExprAdapterFactory>>,
     ) -> anyhow::Result<()> {
+        use datafusion::arrow::util::pretty::pretty_format_batches_with_options;
+
         let vx_session = Arc::new(VortexSession::default());
         let object_store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
         let file1_path = "/path/file1.vortex";
@@ -509,23 +502,39 @@ mod tests {
 
         let opener1 = make_opener(filter.clone());
         let stream = opener1
-            .open(make_meta(file1_path, data_size1), file1)
-            .unwrap()
-            .await
-            .unwrap();
-        let (num_batches, num_rows) = count_data(stream).await?;
-        assert_eq!(num_batches, 1);
-        assert_eq!(num_rows, 3);
+            .open(make_meta(file1_path, data_size1), file1)?
+            .await?;
+
+        let format_opts = FormatOptions::new().with_types_info(true);
+
+        let data = stream.try_collect::<Vec<_>>().await?;
+        assert_snapshot!(pretty_format_batches_with_options(&data, &format_opts)?.to_string(), @r"
+        +-------+
+        | a     |
+        | Int32 |
+        +-------+
+        | 1     |
+        | 2     |
+        | 3     |
+        +-------+
+        ");
 
         let opener2 = make_opener(filter.clone());
         let stream = opener2
-            .open(make_meta(file2_path, data_size2), file2)
-            .unwrap()
-            .await
-            .unwrap();
-        let (num_batches, num_rows) = count_data(stream).await?;
-        assert_eq!(num_batches, 1);
-        assert_eq!(num_rows, 3);
+            .open(make_meta(file2_path, data_size2), file2)?
+            .await?;
+
+        let data = stream.try_collect::<Vec<_>>().await?;
+        assert_snapshot!(pretty_format_batches_with_options(&data, &format_opts)?.to_string(), @r"
+        +-------+
+        | a     |
+        | Int32 |
+        +-------+
+        | -1    |
+        | -2    |
+        | -3    |
+        +-------+
+        ");
 
         Ok(())
     }

--- a/vortex-datafusion/src/persistent/source.rs
+++ b/vortex-datafusion/src/persistent/source.rs
@@ -256,7 +256,7 @@ impl FileSource for VortexSource {
             None => conjunction(supported),
         };
 
-        tracing::debug!(predicate, "Saving predicate");
+        tracing::debug!(%predicate, "Saving predicate");
 
         source.predicate = Some(predicate);
 

--- a/vortex-datafusion/src/persistent/source.rs
+++ b/vortex-datafusion/src/persistent/source.rs
@@ -255,6 +255,9 @@ impl FileSource for VortexSource {
             Some(predicate) => conjunction(std::iter::once(predicate).chain(supported)),
             None => conjunction(supported),
         };
+
+        println!("Updated predicate: {predicate}");
+
         source.predicate = Some(predicate);
 
         let pushdown_propagation = if source.predicate.clone().is_some() {

--- a/vortex-datafusion/src/persistent/source.rs
+++ b/vortex-datafusion/src/persistent/source.rs
@@ -256,7 +256,7 @@ impl FileSource for VortexSource {
             None => conjunction(supported),
         };
 
-        println!("Updated predicate: {predicate}");
+        tracing::debug!(predicate, "Saving predicate");
 
         source.predicate = Some(predicate);
 

--- a/vortex-expr/src/exprs/binary.rs
+++ b/vortex-expr/src/exprs/binary.rs
@@ -96,6 +96,7 @@ impl VTable for BinaryVTable {
             Operator::Sub => sub(&lhs, &rhs),
             Operator::Mul => mul(&lhs, &rhs),
             Operator::Div => div(&lhs, &rhs),
+            Operator::RDiv => div(&rhs, &lhs),
         }
     }
 
@@ -292,7 +293,7 @@ impl AnalysisExpr for BinaryExpr {
                 self.lhs.stat_falsification(catalog)?,
                 self.rhs.stat_falsification(catalog)?,
             )),
-            Operator::Add | Operator::Sub | Operator::Mul | Operator::Div => None,
+            Operator::Add | Operator::Sub | Operator::Mul | Operator::Div | Operator::RDiv => None,
         }
     }
 }

--- a/vortex-expr/src/exprs/binary.rs
+++ b/vortex-expr/src/exprs/binary.rs
@@ -4,7 +4,7 @@
 use std::hash::Hash;
 use std::sync::Arc;
 
-use vortex_array::compute::{add, and_kleene, compare, or_kleene, sub};
+use vortex_array::compute::{add, and_kleene, compare, div, mul, or_kleene, sub};
 use vortex_array::operator::OperatorRef;
 use vortex_array::operator::compare::CompareOperator;
 use vortex_array::{ArrayRef, DeserializeMetadata, ProstMetadata, compute};
@@ -94,6 +94,8 @@ impl VTable for BinaryVTable {
             Operator::Or => or_kleene(&lhs, &rhs),
             Operator::Add => add(&lhs, &rhs),
             Operator::Sub => sub(&lhs, &rhs),
+            Operator::Mul => mul(&lhs, &rhs),
+            Operator::Div => div(&lhs, &rhs),
         }
     }
 
@@ -290,7 +292,7 @@ impl AnalysisExpr for BinaryExpr {
                 self.lhs.stat_falsification(catalog)?,
                 self.rhs.stat_falsification(catalog)?,
             )),
-            Operator::Add | Operator::Sub => None,
+            Operator::Add | Operator::Sub | Operator::Mul | Operator::Div => None,
         }
     }
 }

--- a/vortex-expr/src/exprs/binary.rs
+++ b/vortex-expr/src/exprs/binary.rs
@@ -96,7 +96,6 @@ impl VTable for BinaryVTable {
             Operator::Sub => sub(&lhs, &rhs),
             Operator::Mul => mul(&lhs, &rhs),
             Operator::Div => div(&lhs, &rhs),
-            Operator::RDiv => div(&rhs, &lhs),
         }
     }
 
@@ -293,7 +292,7 @@ impl AnalysisExpr for BinaryExpr {
                 self.lhs.stat_falsification(catalog)?,
                 self.rhs.stat_falsification(catalog)?,
             )),
-            Operator::Add | Operator::Sub | Operator::Mul | Operator::Div | Operator::RDiv => None,
+            Operator::Add | Operator::Sub | Operator::Mul | Operator::Div => None,
         }
     }
 }

--- a/vortex-expr/src/exprs/operators.rs
+++ b/vortex-expr/src/exprs/operators.rs
@@ -68,6 +68,8 @@ impl From<Operator> for BinaryOp {
             Operator::Or => BinaryOp::Or,
             Operator::Add => BinaryOp::Add,
             Operator::Sub => BinaryOp::Sub,
+            Operator::Mul => BinaryOp::Mul,
+            Operator::Div => BinaryOp::Div,
         }
     }
 }
@@ -93,6 +95,8 @@ impl From<BinaryOp> for Operator {
             BinaryOp::Or => Operator::Or,
             BinaryOp::Add => Operator::Add,
             BinaryOp::Sub => Operator::Sub,
+            BinaryOp::Mul => Operator::Mul,
+            BinaryOp::Div => Operator::Div,
         }
     }
 }
@@ -110,6 +114,8 @@ impl Display for Operator {
             Operator::Or => "or",
             Operator::Add => "+",
             Operator::Sub => "-",
+            Operator::Mul => "*",
+            Operator::Div => "/",
         };
         Display::fmt(display, f)
     }
@@ -124,7 +130,12 @@ impl Operator {
             Operator::Gte => Some(Operator::Lt),
             Operator::Lt => Some(Operator::Gte),
             Operator::Lte => Some(Operator::Gt),
-            Operator::And | Operator::Or | Operator::Add | Operator::Sub => None,
+            Operator::And
+            | Operator::Or
+            | Operator::Add
+            | Operator::Sub
+            | Operator::Mul
+            | Operator::Div => None,
         }
     }
 
@@ -149,6 +160,8 @@ impl Operator {
             Operator::Or => Operator::Or,
             Operator::Add => Operator::Add,
             Operator::Sub => Operator::Sub,
+            Operator::Mul => Operator::Mul,
+            Operator::Div => Operator::Div, //RDiv?
         }
     }
 

--- a/vortex-expr/src/exprs/operators.rs
+++ b/vortex-expr/src/exprs/operators.rs
@@ -46,6 +46,8 @@ pub enum Operator {
     Mul,
     /// Divide the left side by the right side
     Div,
+    /// Divide the right side by the left side
+    RDiv,
 }
 
 impl From<Operator> for i32 {
@@ -70,6 +72,7 @@ impl From<Operator> for BinaryOp {
             Operator::Sub => BinaryOp::Sub,
             Operator::Mul => BinaryOp::Mul,
             Operator::Div => BinaryOp::Div,
+            Operator::RDiv => BinaryOp::RDiv,
         }
     }
 }
@@ -97,6 +100,7 @@ impl From<BinaryOp> for Operator {
             BinaryOp::Sub => Operator::Sub,
             BinaryOp::Mul => Operator::Mul,
             BinaryOp::Div => Operator::Div,
+            BinaryOp::RDiv => Operator::RDiv,
         }
     }
 }
@@ -115,7 +119,7 @@ impl Display for Operator {
             Operator::Add => "+",
             Operator::Sub => "-",
             Operator::Mul => "*",
-            Operator::Div => "/",
+            Operator::Div | Operator::RDiv => "/",
         };
         Display::fmt(display, f)
     }
@@ -135,7 +139,8 @@ impl Operator {
             | Operator::Add
             | Operator::Sub
             | Operator::Mul
-            | Operator::Div => None,
+            | Operator::Div
+            | Operator::RDiv => None,
         }
     }
 
@@ -147,7 +152,7 @@ impl Operator {
         }
     }
 
-    /// Change the sides of the operator, where changing lhs and rhs won't change the result of the operation
+    /// Change the sides of the operator, so that changing lhs and rhs won't change the result of the operation
     pub fn swap(self) -> Self {
         match self {
             Operator::Eq => Operator::Eq,
@@ -161,7 +166,8 @@ impl Operator {
             Operator::Add => Operator::Add,
             Operator::Sub => Operator::Sub,
             Operator::Mul => Operator::Mul,
-            Operator::Div => Operator::Div, //RDiv?
+            Operator::Div => Operator::RDiv,
+            Operator::RDiv => Operator::Div,
         }
     }
 

--- a/vortex-expr/src/exprs/operators.rs
+++ b/vortex-expr/src/exprs/operators.rs
@@ -46,8 +46,6 @@ pub enum Operator {
     Mul,
     /// Divide the left side by the right side
     Div,
-    /// Divide the right side by the left side
-    RDiv,
 }
 
 impl From<Operator> for i32 {
@@ -72,7 +70,6 @@ impl From<Operator> for BinaryOp {
             Operator::Sub => BinaryOp::Sub,
             Operator::Mul => BinaryOp::Mul,
             Operator::Div => BinaryOp::Div,
-            Operator::RDiv => BinaryOp::RDiv,
         }
     }
 }
@@ -100,7 +97,6 @@ impl From<BinaryOp> for Operator {
             BinaryOp::Sub => Operator::Sub,
             BinaryOp::Mul => Operator::Mul,
             BinaryOp::Div => Operator::Div,
-            BinaryOp::RDiv => Operator::RDiv,
         }
     }
 }
@@ -119,7 +115,7 @@ impl Display for Operator {
             Operator::Add => "+",
             Operator::Sub => "-",
             Operator::Mul => "*",
-            Operator::Div | Operator::RDiv => "/",
+            Operator::Div => "/",
         };
         Display::fmt(display, f)
     }
@@ -139,8 +135,7 @@ impl Operator {
             | Operator::Add
             | Operator::Sub
             | Operator::Mul
-            | Operator::Div
-            | Operator::RDiv => None,
+            | Operator::Div => None,
         }
     }
 
@@ -153,21 +148,19 @@ impl Operator {
     }
 
     /// Change the sides of the operator, so that changing lhs and rhs won't change the result of the operation
-    pub fn swap(self) -> Self {
+    pub fn swap(self) -> Option<Self> {
         match self {
-            Operator::Eq => Operator::Eq,
-            Operator::NotEq => Operator::NotEq,
-            Operator::Gt => Operator::Lt,
-            Operator::Gte => Operator::Lte,
-            Operator::Lt => Operator::Gt,
-            Operator::Lte => Operator::Gte,
-            Operator::And => Operator::And,
-            Operator::Or => Operator::Or,
-            Operator::Add => Operator::Add,
-            Operator::Sub => Operator::Sub,
-            Operator::Mul => Operator::Mul,
-            Operator::Div => Operator::RDiv,
-            Operator::RDiv => Operator::Div,
+            Operator::Eq => Some(Operator::Eq),
+            Operator::NotEq => Some(Operator::NotEq),
+            Operator::Gt => Some(Operator::Lt),
+            Operator::Gte => Some(Operator::Lte),
+            Operator::Lt => Some(Operator::Gt),
+            Operator::Lte => Some(Operator::Gte),
+            Operator::And => Some(Operator::And),
+            Operator::Or => Some(Operator::Or),
+            Operator::Add => Some(Operator::Add),
+            Operator::Mul => Some(Operator::Mul),
+            Operator::Sub | Operator::Div => None,
         }
     }
 

--- a/vortex-expr/src/exprs/operators.rs
+++ b/vortex-expr/src/exprs/operators.rs
@@ -42,6 +42,10 @@ pub enum Operator {
     ///
     /// The result is null at any index that either input is null.
     Sub,
+    /// Multiple two numbers
+    Mul,
+    /// Divide the left side by the right side
+    Div,
 }
 
 impl From<Operator> for i32 {

--- a/vortex-expr/src/transform/match_between.rs
+++ b/vortex-expr/src/transform/match_between.rs
@@ -59,7 +59,7 @@ fn maybe_match(lhs: &ExprRef, rhs: &ExprRef) -> Option<ExprRef> {
             (
                 lhs.lhs().clone(),
                 lhs.rhs().clone(),
-                lhs.op().swap(),
+                lhs.op().swap()?,
                 rhs.rhs().clone(),
                 rhs.op(),
             )
@@ -67,9 +67,9 @@ fn maybe_match(lhs: &ExprRef, rhs: &ExprRef) -> Option<ExprRef> {
             (
                 lhs.lhs().clone(),
                 lhs.rhs().clone(),
-                lhs.op().swap(),
+                lhs.op().swap()?,
                 rhs.lhs().clone(),
-                rhs.op().swap(),
+                rhs.op().swap()?,
             )
         } else if GetItemExpr::is(lhs.rhs()) && lhs.rhs().eq(rhs.lhs()) {
             (
@@ -85,7 +85,7 @@ fn maybe_match(lhs: &ExprRef, rhs: &ExprRef) -> Option<ExprRef> {
                 lhs.lhs().clone(),
                 lhs.op(),
                 rhs.lhs().clone(),
-                rhs.op().swap(),
+                rhs.op().swap()?,
             )
         } else {
             return None;
@@ -111,10 +111,11 @@ fn maybe_match(lhs: &ExprRef, rhs: &ExprRef) -> Option<ExprRef> {
         maybe_strict_comparison(right_op),
     ) {
         (left_op, right_op)
-    } else if let (Some(left_op), Some(right_op)) = (
-        maybe_strict_comparison(left_op.swap()),
-        maybe_strict_comparison(right_op.swap()),
-    ) {
+    } else if let Some((left_op, right_op)) = left_op
+        .swap()
+        .zip(right_op.swap())
+        .and_then(|(l, r)| maybe_strict_comparison(l).zip(maybe_strict_comparison(r)))
+    {
         (left_op, right_op)
     } else {
         return None;

--- a/vortex-proto/proto/expr.proto
+++ b/vortex-proto/proto/expr.proto
@@ -51,6 +51,8 @@ message BinaryOpts {
     Or = 7;
     Add = 8;
     Sub = 9;
+    Mul = 10;
+    Div = 11;
   }
 }
 

--- a/vortex-proto/proto/expr.proto
+++ b/vortex-proto/proto/expr.proto
@@ -53,6 +53,7 @@ message BinaryOpts {
     Sub = 9;
     Mul = 10;
     Div = 11;
+    RDiv = 12;
   }
 }
 

--- a/vortex-proto/proto/expr.proto
+++ b/vortex-proto/proto/expr.proto
@@ -53,7 +53,6 @@ message BinaryOpts {
     Sub = 9;
     Mul = 10;
     Div = 11;
-    RDiv = 12;
   }
 }
 

--- a/vortex-proto/src/generated/vortex.expr.rs
+++ b/vortex-proto/src/generated/vortex.expr.rs
@@ -64,7 +64,6 @@ pub mod binary_opts {
         Sub = 9,
         Mul = 10,
         Div = 11,
-        RDiv = 12,
     }
     impl BinaryOp {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -85,7 +84,6 @@ pub mod binary_opts {
                 Self::Sub => "Sub",
                 Self::Mul => "Mul",
                 Self::Div => "Div",
-                Self::RDiv => "RDiv",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -103,7 +101,6 @@ pub mod binary_opts {
                 "Sub" => Some(Self::Sub),
                 "Mul" => Some(Self::Mul),
                 "Div" => Some(Self::Div),
-                "RDiv" => Some(Self::RDiv),
                 _ => None,
             }
         }

--- a/vortex-proto/src/generated/vortex.expr.rs
+++ b/vortex-proto/src/generated/vortex.expr.rs
@@ -62,6 +62,8 @@ pub mod binary_opts {
         Or = 7,
         Add = 8,
         Sub = 9,
+        Mul = 10,
+        Div = 11,
     }
     impl BinaryOp {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -80,6 +82,8 @@ pub mod binary_opts {
                 Self::Or => "Or",
                 Self::Add => "Add",
                 Self::Sub => "Sub",
+                Self::Mul => "Mul",
+                Self::Div => "Div",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -95,6 +99,8 @@ pub mod binary_opts {
                 "Or" => Some(Self::Or),
                 "Add" => Some(Self::Add),
                 "Sub" => Some(Self::Sub),
+                "Mul" => Some(Self::Mul),
+                "Div" => Some(Self::Div),
                 _ => None,
             }
         }

--- a/vortex-proto/src/generated/vortex.expr.rs
+++ b/vortex-proto/src/generated/vortex.expr.rs
@@ -64,6 +64,7 @@ pub mod binary_opts {
         Sub = 9,
         Mul = 10,
         Div = 11,
+        RDiv = 12,
     }
     impl BinaryOp {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -84,6 +85,7 @@ pub mod binary_opts {
                 Self::Sub => "Sub",
                 Self::Mul => "Mul",
                 Self::Div => "Div",
+                Self::RDiv => "RDiv",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -101,6 +103,7 @@ pub mod binary_opts {
                 "Sub" => Some(Self::Sub),
                 "Mul" => Some(Self::Mul),
                 "Div" => Some(Self::Div),
+                "RDiv" => Some(Self::RDiv),
                 _ => None,
             }
         }


### PR DESCRIPTION
Started as a demo for @danking to show how to add more pushdown to Datafusion, now it includes some more expression (`IS NULL`, `IS NOT NULL` and `IN LIST`), which only leaves `substr` and dynamic expressions.
It also allows for pushing more binary operators for arithmetic operations.

`vortex-compact` seems really noise, but clickbench still shows nice improvements in a bunch of queries for the btrblocks compression.