### PR TITLE
Chore: Rename `TimeUnit` variants to be more descriptive

### DIFF
--- a/encodings/datetime-parts/src/canonical.rs
+++ b/encodings/datetime-parts/src/canonical.rs
@@ -34,11 +34,11 @@ pub fn decode_to_temporal(array: &DateTimePartsArray) -> VortexResult<TemporalAr
     };
 
     let divisor = match temporal_metadata.time_unit() {
-        TimeUnit::Ns => 1_000_000_000,
-        TimeUnit::Us => 1_000_000,
-        TimeUnit::Ms => 1_000,
-        TimeUnit::S => 1,
-        TimeUnit::D => vortex_bail!(InvalidArgument: "cannot decode into TimeUnit::D"),
+        TimeUnit::Nanoseconds => 1_000_000_000,
+        TimeUnit::Microseconds => 1_000_000,
+        TimeUnit::Milliseconds => 1_000,
+        TimeUnit::Seconds => 1,
+        TimeUnit::Days => vortex_bail!(InvalidArgument: "cannot decode into TimeUnit::D"),
     };
 
     let days_buf = cast(
@@ -130,7 +130,7 @@ mod test {
         );
         let date_times = DateTimePartsArray::try_from(TemporalArray::new_timestamp(
             milliseconds.clone().into_array(),
-            TimeUnit::Ms,
+            TimeUnit::Milliseconds,
             Some("UTC".to_string()),
         ))
         .unwrap();

--- a/encodings/datetime-parts/src/compress.rs
+++ b/encodings/datetime-parts/src/compress.rs
@@ -91,8 +91,11 @@ mod tests {
             validity.clone(),
         )
         .into_array();
-        let temporal_array =
-            TemporalArray::new_timestamp(milliseconds, TimeUnit::Ms, Some("UTC".to_string()));
+        let temporal_array = TemporalArray::new_timestamp(
+            milliseconds,
+            TimeUnit::Milliseconds,
+            Some("UTC".to_string()),
+        );
         let TemporalParts {
             days,
             seconds,

--- a/encodings/datetime-parts/src/compute/cast.rs
+++ b/encodings/datetime-parts/src/compute/cast.rs
@@ -55,7 +55,7 @@ mod tests {
                 validity,
             )
             .into_array(),
-            TimeUnit::Ms,
+            TimeUnit::Milliseconds,
             Some("UTC".to_string()),
         ))
         .unwrap()
@@ -115,7 +115,7 @@ mod tests {
             259_200_000, // 3 days in ms
             345_600_000, // 4 days in ms
         ]).into_array(),
-        TimeUnit::Ms,
+        TimeUnit::Milliseconds,
         Some("UTC".to_string())
     )).unwrap())]
     #[case(DateTimePartsArray::try_from(TemporalArray::new_timestamp(
@@ -126,12 +126,12 @@ mod tests {
             Some(259_200_000), // 3 days in ms
             None,
         ]).into_array(),
-        TimeUnit::Ms,
+        TimeUnit::Milliseconds,
         Some("UTC".to_string())
     )).unwrap())]
     #[case(DateTimePartsArray::try_from(TemporalArray::new_timestamp(
         PrimitiveArray::from_iter([86_400_000_000_000i64]).into_array(), // 1 day in ns
-        TimeUnit::Ns,
+        TimeUnit::Nanoseconds,
         Some("UTC".to_string())
     )).unwrap())]
     fn test_cast_datetime_parts_conformance(#[case] array: DateTimePartsArray) {

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -207,7 +207,7 @@ mod test {
     ) -> DateTimePartsArray {
         DateTimePartsArray::try_from(TemporalArray::new_timestamp(
             PrimitiveArray::new(buffer![value], validity).into_array(),
-            TimeUnit::S,
+            TimeUnit::Seconds,
             Some("UTC".to_string()),
         ))
         .expect("Failed to construct DateTimePartsArray from TemporalArray")
@@ -282,7 +282,7 @@ mod test {
     ) {
         let temporal_array = TemporalArray::new_timestamp(
             PrimitiveArray::new(buffer![0i64], lhs_validity.clone()).into_array(),
-            TimeUnit::S,
+            TimeUnit::Seconds,
             Some("UTC".to_string()),
         );
 

--- a/encodings/datetime-parts/src/compute/filter.rs
+++ b/encodings/datetime-parts/src/compute/filter.rs
@@ -42,8 +42,11 @@ mod test {
         ])
         .into_array();
 
-        let temporal =
-            TemporalArray::new_timestamp(timestamps, TimeUnit::Ms, Some("UTC".to_string()));
+        let temporal = TemporalArray::new_timestamp(
+            timestamps,
+            TimeUnit::Milliseconds,
+            Some("UTC".to_string()),
+        );
 
         let array = DateTimePartsArray::try_from(temporal).unwrap();
         test_filter_conformance(array.as_ref());
@@ -58,8 +61,11 @@ mod test {
         ])
         .into_array();
 
-        let temporal =
-            TemporalArray::new_timestamp(timestamps, TimeUnit::Ms, Some("UTC".to_string()));
+        let temporal = TemporalArray::new_timestamp(
+            timestamps,
+            TimeUnit::Milliseconds,
+            Some("UTC".to_string()),
+        );
 
         let array = DateTimePartsArray::try_from(temporal).unwrap();
         test_filter_conformance(array.as_ref());

--- a/encodings/datetime-parts/src/compute/mod.rs
+++ b/encodings/datetime-parts/src/compute/mod.rs
@@ -23,46 +23,46 @@ mod tests {
     // Basic datetime arrays
     #[case::datetime_seconds(DateTimePartsArray::try_from(TemporalArray::new_timestamp(
         PrimitiveArray::from_iter([0i64, 86400, 172800, 259200, 345600]).into_array(),
-        TimeUnit::S,
+        TimeUnit::Seconds,
         Some("UTC".to_string()),
     )).unwrap())]
     #[case::datetime_millis(DateTimePartsArray::try_from(TemporalArray::new_timestamp(
         PrimitiveArray::from_iter([0i64, 86400000, 172800000]).into_array(),
-        TimeUnit::Ms,
+        TimeUnit::Milliseconds,
         Some("UTC".to_string()),
     )).unwrap())]
     #[case::datetime_micros(DateTimePartsArray::try_from(TemporalArray::new_timestamp(
         PrimitiveArray::from_iter([0i64, 86400000000, 172800000000]).into_array(),
-        TimeUnit::Us,
+        TimeUnit::Microseconds,
         Some("UTC".to_string()),
     )).unwrap())]
     #[case::datetime_nanos(DateTimePartsArray::try_from(TemporalArray::new_timestamp(
         PrimitiveArray::from_iter([0i64, 86400000000000]).into_array(),
-        TimeUnit::Ns,
+        TimeUnit::Nanoseconds,
         Some("UTC".to_string()),
     )).unwrap())]
     // Nullable arrays
     #[case::datetime_nullable_seconds(DateTimePartsArray::try_from(TemporalArray::new_timestamp(
         PrimitiveArray::from_option_iter([Some(0i64), None, Some(86400), Some(172800), None]).into_array(),
-        TimeUnit::S,
+        TimeUnit::Seconds,
         Some("UTC".to_string()),
     )).unwrap())]
     // Edge cases
     #[case::datetime_single(DateTimePartsArray::try_from(TemporalArray::new_timestamp(
         buffer![1234567890i64].into_array(),
-        TimeUnit::S,
+        TimeUnit::Seconds,
         Some("UTC".to_string()),
     )).unwrap())]
     // Large arrays (> 1024 elements)
     #[case::datetime_large(DateTimePartsArray::try_from(TemporalArray::new_timestamp(
         PrimitiveArray::from_iter((0..1500).map(|i| i as i64 * 86400)).into_array(),
-        TimeUnit::S,
+        TimeUnit::Seconds,
         Some("UTC".to_string()),
     )).unwrap())]
     // Different time patterns
     #[case::datetime_with_subseconds(DateTimePartsArray::try_from(TemporalArray::new_timestamp(
         PrimitiveArray::from_iter([123456789i64, 234567890, 345678901, 456789012, 567890123]).into_array(),
-        TimeUnit::Ms,
+        TimeUnit::Milliseconds,
         Some("UTC".to_string()),
     )).unwrap())]
 

--- a/encodings/datetime-parts/src/compute/take.rs
+++ b/encodings/datetime-parts/src/compute/take.rs
@@ -104,7 +104,7 @@ mod tests {
             259_200_000, // 3 days in ms
             345_600_000, // 4 days in ms
         ]).into_array(),
-        TimeUnit::Ms,
+        TimeUnit::Milliseconds,
         Some("UTC".to_string())
     )).unwrap())]
     #[case(DateTimePartsArray::try_from(TemporalArray::new_timestamp(
@@ -115,12 +115,12 @@ mod tests {
             Some(259_200_000), // 3 days in ms
             None,
         ]).into_array(),
-        TimeUnit::Ms,
+        TimeUnit::Milliseconds,
         Some("UTC".to_string())
     )).unwrap())]
     #[case(DateTimePartsArray::try_from(TemporalArray::new_timestamp(
         PrimitiveArray::from_iter([86_400_000i64]).into_array(),
-        TimeUnit::Ms,
+        TimeUnit::Milliseconds,
         Some("UTC".to_string())
     )).unwrap())]
     fn test_take_datetime_parts_conformance(#[case] array: DateTimePartsArray) {

--- a/encodings/datetime-parts/src/timestamp.rs
+++ b/encodings/datetime-parts/src/timestamp.rs
@@ -30,11 +30,11 @@ pub struct TimestampParts {
 /// Returns an error if `time_unit` is days, which cannot be split.
 pub fn split(timestamp: i64, time_unit: TimeUnit) -> VortexResult<TimestampParts> {
     let divisor = match time_unit {
-        TimeUnit::Ns => 1_000_000_000,
-        TimeUnit::Us => 1_000_000,
-        TimeUnit::Ms => 1_000,
-        TimeUnit::S => 1,
-        TimeUnit::D => vortex_bail!("Cannot handle day-level data"),
+        TimeUnit::Nanoseconds => 1_000_000_000,
+        TimeUnit::Microseconds => 1_000_000,
+        TimeUnit::Milliseconds => 1_000,
+        TimeUnit::Seconds => 1,
+        TimeUnit::Days => vortex_bail!("Cannot handle day-level data"),
     };
 
     let ticks_per_day = SECONDS_PER_DAY * divisor;
@@ -57,11 +57,11 @@ pub fn split(timestamp: i64, time_unit: TimeUnit) -> VortexResult<TimestampParts
 /// Returns an error if `time_unit` is days, which cannot be combined.
 pub fn combine(ts_parts: TimestampParts, time_unit: TimeUnit) -> i64 {
     let divisor = match time_unit {
-        TimeUnit::Ns => 1_000_000_000,
-        TimeUnit::Us => 1_000_000,
-        TimeUnit::Ms => 1_000,
-        TimeUnit::S => 1,
-        TimeUnit::D => vortex_panic!("Cannot handle day-level data"),
+        TimeUnit::Nanoseconds => 1_000_000_000,
+        TimeUnit::Microseconds => 1_000_000,
+        TimeUnit::Milliseconds => 1_000,
+        TimeUnit::Seconds => 1,
+        TimeUnit::Days => vortex_panic!("Cannot handle day-level data"),
     };
 
     ts_parts.days * SECONDS_PER_DAY * divisor + ts_parts.seconds * divisor + ts_parts.subseconds
@@ -75,7 +75,7 @@ mod tests {
     fn test_split_seconds() {
         // 1970-01-02 01:02:03 UTC
         let ts = SECONDS_PER_DAY + 3723; // 1 day + (1*3600 + 2*60 + 3) seconds
-        let parts = split(ts, TimeUnit::S).unwrap();
+        let parts = split(ts, TimeUnit::Seconds).unwrap();
         assert_eq!(parts.days, 1);
         assert_eq!(parts.seconds, 3723);
         assert_eq!(parts.subseconds, 0);
@@ -85,7 +85,7 @@ mod tests {
     fn test_split_milliseconds() {
         // 1970-01-02 01:02:03.456 UTC
         let ts = (SECONDS_PER_DAY + 3723) * 1000 + 456;
-        let parts = split(ts, TimeUnit::Ms).unwrap();
+        let parts = split(ts, TimeUnit::Milliseconds).unwrap();
         assert_eq!(parts.days, 1);
         assert_eq!(parts.seconds, 3723);
         assert_eq!(parts.subseconds, 456);
@@ -95,7 +95,7 @@ mod tests {
     fn test_split_microseconds() {
         // 1970-01-02 01:02:03.456789 UTC
         let ts = (SECONDS_PER_DAY + 3723) * 1_000_000 + 456789;
-        let parts = split(ts, TimeUnit::Us).unwrap();
+        let parts = split(ts, TimeUnit::Microseconds).unwrap();
         assert_eq!(parts.days, 1);
         assert_eq!(parts.seconds, 3723);
         assert_eq!(parts.subseconds, 456789);
@@ -105,7 +105,7 @@ mod tests {
     fn test_split_nanoseconds() {
         // 1970-01-02 01:02:03.456789123 UTC
         let ts = (SECONDS_PER_DAY + 3723) * 1_000_000_000 + 456789123;
-        let parts = split(ts, TimeUnit::Ns).unwrap();
+        let parts = split(ts, TimeUnit::Nanoseconds).unwrap();
         assert_eq!(parts.days, 1);
         assert_eq!(parts.seconds, 3723);
         assert_eq!(parts.subseconds, 456789123);
@@ -114,7 +114,12 @@ mod tests {
     #[test]
     fn test_split_epoch() {
         let ts = 0;
-        for unit in [TimeUnit::S, TimeUnit::Ms, TimeUnit::Us, TimeUnit::Ns] {
+        for unit in [
+            TimeUnit::Seconds,
+            TimeUnit::Milliseconds,
+            TimeUnit::Microseconds,
+            TimeUnit::Nanoseconds,
+        ] {
             let parts = split(ts, unit).unwrap();
             assert_eq!(parts.days, 0);
             assert_eq!(parts.seconds, 0);
@@ -124,7 +129,7 @@ mod tests {
 
     #[test]
     fn test_split_days_error() {
-        assert!(split(1, TimeUnit::D).is_err());
+        assert!(split(1, TimeUnit::Days).is_err());
     }
 
     #[test]
@@ -135,7 +140,7 @@ mod tests {
             seconds: 3723, // 1*3600 + 2*60 + 3
             subseconds: 0,
         };
-        let ts = combine(parts, TimeUnit::S);
+        let ts = combine(parts, TimeUnit::Seconds);
         assert_eq!(ts, SECONDS_PER_DAY + 3723);
     }
 
@@ -147,7 +152,7 @@ mod tests {
             seconds: 3723,
             subseconds: 456,
         };
-        let ts = combine(parts, TimeUnit::Ms);
+        let ts = combine(parts, TimeUnit::Milliseconds);
         assert_eq!(ts, (SECONDS_PER_DAY + 3723) * 1000 + 456);
     }
 
@@ -159,7 +164,7 @@ mod tests {
             seconds: 3723,
             subseconds: 456789,
         };
-        let ts = combine(parts, TimeUnit::Us);
+        let ts = combine(parts, TimeUnit::Microseconds);
         assert_eq!(ts, (SECONDS_PER_DAY + 3723) * 1_000_000 + 456789);
     }
 
@@ -171,7 +176,7 @@ mod tests {
             seconds: 3723,
             subseconds: 456789123,
         };
-        let ts = combine(parts, TimeUnit::Ns);
+        let ts = combine(parts, TimeUnit::Nanoseconds);
         assert_eq!(ts, (SECONDS_PER_DAY + 3723) * 1_000_000_000 + 456789123);
     }
 
@@ -183,6 +188,6 @@ mod tests {
             seconds: 0,
             subseconds: 0,
         };
-        combine(parts, TimeUnit::D);
+        combine(parts, TimeUnit::Days);
     }
 }

--- a/vortex-array/src/arrays/datetime/mod.rs
+++ b/vortex-array/src/arrays/datetime/mod.rs
@@ -73,13 +73,13 @@ impl TemporalArray {
     /// If any other time unit is provided, it panics.
     pub fn new_date(array: ArrayRef, time_unit: TimeUnit) -> Self {
         match time_unit {
-            TimeUnit::D => {
+            TimeUnit::Days => {
                 assert_width!(i32, array);
             }
-            TimeUnit::Ms => {
+            TimeUnit::Milliseconds => {
                 assert_width!(i64, array);
             }
-            TimeUnit::Ns | TimeUnit::Us | TimeUnit::S => {
+            TimeUnit::Nanoseconds | TimeUnit::Microseconds | TimeUnit::Seconds => {
                 vortex_panic!("invalid TimeUnit {time_unit} for vortex.date")
             }
         };
@@ -117,9 +117,9 @@ impl TemporalArray {
     /// If the time unit is nanoseconds, and the array is not of primitive I64 type, it panics.
     pub fn new_time(array: ArrayRef, time_unit: TimeUnit) -> Self {
         match time_unit {
-            TimeUnit::S | TimeUnit::Ms => assert_width!(i32, array),
-            TimeUnit::Us | TimeUnit::Ns => assert_width!(i64, array),
-            TimeUnit::D => vortex_panic!("invalid unit D for vortex.time data"),
+            TimeUnit::Seconds | TimeUnit::Milliseconds => assert_width!(i32, array),
+            TimeUnit::Microseconds | TimeUnit::Nanoseconds => assert_width!(i64, array),
+            TimeUnit::Days => vortex_panic!("invalid unit D for vortex.time data"),
         }
 
         let temporal_metadata = TemporalMetadata::Time(time_unit);

--- a/vortex-array/src/arrays/datetime/test.rs
+++ b/vortex-array/src/arrays/datetime/test.rs
@@ -46,25 +46,25 @@ test_success_case!(
     test_roundtrip_time32_second,
     i32,
     TemporalArray::new_time,
-    TimeUnit::S
+    TimeUnit::Seconds
 );
 test_success_case!(
     test_roundtrip_time32_millisecond,
     i32,
     TemporalArray::new_time,
-    TimeUnit::Ms
+    TimeUnit::Milliseconds
 );
 test_fail_case!(
     test_fail_time32_micro,
     i32,
     TemporalArray::new_time,
-    TimeUnit::Us
+    TimeUnit::Microseconds
 );
 test_fail_case!(
     test_fail_time32_nano,
     i32,
     TemporalArray::new_time,
-    TimeUnit::Ns
+    TimeUnit::Nanoseconds
 );
 
 // Time64 conformance tests
@@ -72,31 +72,31 @@ test_success_case!(
     test_roundtrip_time64_us,
     i64,
     TemporalArray::new_time,
-    TimeUnit::Us
+    TimeUnit::Microseconds
 );
 test_success_case!(
     test_roundtrip_time64_ns,
     i64,
     TemporalArray::new_time,
-    TimeUnit::Ns
+    TimeUnit::Nanoseconds
 );
 test_fail_case!(
     test_fail_time64_ms,
     i64,
     TemporalArray::new_time,
-    TimeUnit::Ms
+    TimeUnit::Milliseconds
 );
 test_fail_case!(
     test_fail_time64_s,
     i64,
     TemporalArray::new_time,
-    TimeUnit::S
+    TimeUnit::Seconds
 );
 test_fail_case!(
     test_fail_time64_i32,
     i32,
     TemporalArray::new_time,
-    TimeUnit::Ns
+    TimeUnit::Nanoseconds
 );
 
 // Date32 conformance tests
@@ -104,18 +104,28 @@ test_success_case!(
     test_roundtrip_date32,
     i32,
     TemporalArray::new_date,
-    TimeUnit::D
+    TimeUnit::Days
 );
-test_fail_case!(test_fail_date32, i64, TemporalArray::new_date, TimeUnit::D);
+test_fail_case!(
+    test_fail_date32,
+    i64,
+    TemporalArray::new_date,
+    TimeUnit::Days
+);
 
 // Date64 conformance tests
 test_success_case!(
     test_roundtrip_date64,
     i64,
     TemporalArray::new_date,
-    TimeUnit::Ms
+    TimeUnit::Milliseconds
 );
-test_fail_case!(test_fail_date64, i32, TemporalArray::new_date, TimeUnit::Ms);
+test_fail_case!(
+    test_fail_date64,
+    i32,
+    TemporalArray::new_date,
+    TimeUnit::Milliseconds
+);
 
 // We test Timestamp explicitly to avoid the macro getting too complex.
 #[test]
@@ -123,7 +133,12 @@ fn test_timestamp() {
     let ts = PrimitiveArray::from_iter([100i64]);
     let ts_array = ts.into_array();
 
-    for unit in [TimeUnit::S, TimeUnit::Ms, TimeUnit::Us, TimeUnit::Ns] {
+    for unit in [
+        TimeUnit::Seconds,
+        TimeUnit::Milliseconds,
+        TimeUnit::Microseconds,
+        TimeUnit::Nanoseconds,
+    ] {
         for tz in [Some("UTC".to_string()), None] {
             let temporal_array =
                 TemporalArray::new_timestamp(ts_array.to_array(), unit, tz.clone());
@@ -144,7 +159,7 @@ fn test_timestamp_fails_i32() {
     let ts = PrimitiveArray::from_iter([100i32]);
     let ts_array = ts.into_array();
 
-    let _ = TemporalArray::new_timestamp(ts_array, TimeUnit::S, None);
+    let _ = TemporalArray::new_timestamp(ts_array, TimeUnit::Seconds, None);
 }
 
 #[rstest]
@@ -162,8 +177,11 @@ fn test_validity_preservation(#[case] validity: Validity) {
         validity.clone(),
     )
     .into_array();
-    let temporal_array =
-        TemporalArray::new_timestamp(milliseconds, TimeUnit::Ms, Some("UTC".to_string()));
+    let temporal_array = TemporalArray::new_timestamp(
+        milliseconds,
+        TimeUnit::Milliseconds,
+        Some("UTC".to_string()),
+    );
     assert_eq!(
         temporal_array
             .temporal_values()

--- a/vortex-array/src/arrays/extension/compute/cast.rs
+++ b/vortex-array/src/arrays/extension/compute/cast.rs
@@ -56,7 +56,7 @@ mod tests {
         let ext_dtype = Arc::new(ExtDType::new(
             TIMESTAMP_ID.clone(),
             Arc::new(PType::I64.into()),
-            Some(TemporalMetadata::Timestamp(TimeUnit::Ms, None).into()),
+            Some(TemporalMetadata::Timestamp(TimeUnit::Milliseconds, None).into()),
         ));
         let storage = PrimitiveArray::from_iter(Vec::<i64>::new()).into_array();
 
@@ -73,7 +73,7 @@ mod tests {
         let ext_dtype = Arc::new(ExtDType::new(
             TIMESTAMP_ID.clone(),
             Arc::new(PType::I64.into()),
-            Some(TemporalMetadata::Timestamp(TimeUnit::Ms, None).into()),
+            Some(TemporalMetadata::Timestamp(TimeUnit::Milliseconds, None).into()),
         ));
         let storage = PrimitiveArray::from_iter(Vec::<i64>::new()).into_array();
 
@@ -93,13 +93,13 @@ mod tests {
         let original_dtype = Arc::new(ExtDType::new(
             TIMESTAMP_ID.clone(),
             Arc::new(PType::I64.into()),
-            Some(TemporalMetadata::Timestamp(TimeUnit::Ms, None).into()),
+            Some(TemporalMetadata::Timestamp(TimeUnit::Milliseconds, None).into()),
         ));
         let target_dtype = Arc::new(ExtDType::new(
             TIMESTAMP_ID.clone(),
             Arc::new(PType::I64.into()),
             // Note NS here instead of MS
-            Some(TemporalMetadata::Timestamp(TimeUnit::Ns, None).into()),
+            Some(TemporalMetadata::Timestamp(TimeUnit::Nanoseconds, None).into()),
         ));
 
         let storage = PrimitiveArray::from_iter(Vec::<i64>::new()).into_array();
@@ -109,10 +109,10 @@ mod tests {
     }
 
     #[rstest]
-    #[case(create_timestamp_array(TimeUnit::Ms, false))]
-    #[case(create_timestamp_array(TimeUnit::Us, true))]
-    #[case(create_timestamp_array(TimeUnit::Ns, false))]
-    #[case(create_timestamp_array(TimeUnit::S, true))]
+    #[case(create_timestamp_array(TimeUnit::Milliseconds, false))]
+    #[case(create_timestamp_array(TimeUnit::Microseconds, true))]
+    #[case(create_timestamp_array(TimeUnit::Nanoseconds, false))]
+    #[case(create_timestamp_array(TimeUnit::Seconds, true))]
     fn test_cast_extension_conformance(#[case] array: ExtensionArray) {
         test_cast_conformance(array.as_ref());
     }

--- a/vortex-array/src/arrow/compute/to_arrow/temporal.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/temporal.rs
@@ -45,41 +45,43 @@ impl Kernel for ToArrowTemporal {
             .unwrap_or_else(|| array.dtype().to_arrow_dtype())?;
 
         let arrow_array: ArrowArrayRef = match (array.temporal_metadata(), &arrow_type) {
-            (TemporalMetadata::Date(TimeUnit::D), DataType::Date32) => {
+            (TemporalMetadata::Date(TimeUnit::Days), DataType::Date32) => {
                 to_arrow_temporal::<Date32Type>(&array)
             }
-            (TemporalMetadata::Date(TimeUnit::Ms), DataType::Date64) => {
+            (TemporalMetadata::Date(TimeUnit::Milliseconds), DataType::Date64) => {
                 to_arrow_temporal::<Date64Type>(&array)
             }
-            (TemporalMetadata::Time(TimeUnit::S), DataType::Time32(ArrowTimeUnit::Second)) => {
-                to_arrow_temporal::<Time32SecondType>(&array)
-            }
             (
-                TemporalMetadata::Time(TimeUnit::Ms),
+                TemporalMetadata::Time(TimeUnit::Seconds),
+                DataType::Time32(ArrowTimeUnit::Second),
+            ) => to_arrow_temporal::<Time32SecondType>(&array),
+            (
+                TemporalMetadata::Time(TimeUnit::Milliseconds),
                 DataType::Time32(ArrowTimeUnit::Millisecond),
             ) => to_arrow_temporal::<Time32MillisecondType>(&array),
             (
-                TemporalMetadata::Time(TimeUnit::Us),
+                TemporalMetadata::Time(TimeUnit::Microseconds),
                 DataType::Time64(ArrowTimeUnit::Microsecond),
             ) => to_arrow_temporal::<Time64MicrosecondType>(&array),
 
-            (TemporalMetadata::Time(TimeUnit::Ns), DataType::Time64(ArrowTimeUnit::Nanosecond)) => {
-                to_arrow_temporal::<Time64NanosecondType>(&array)
-            }
             (
-                TemporalMetadata::Timestamp(TimeUnit::S, _),
+                TemporalMetadata::Time(TimeUnit::Nanoseconds),
+                DataType::Time64(ArrowTimeUnit::Nanosecond),
+            ) => to_arrow_temporal::<Time64NanosecondType>(&array),
+            (
+                TemporalMetadata::Timestamp(TimeUnit::Seconds, _),
                 DataType::Timestamp(ArrowTimeUnit::Second, arrow_tz),
             ) => to_arrow_timestamp::<TimestampSecondType>(&array, arrow_tz),
             (
-                TemporalMetadata::Timestamp(TimeUnit::Ms, _),
+                TemporalMetadata::Timestamp(TimeUnit::Milliseconds, _),
                 DataType::Timestamp(ArrowTimeUnit::Millisecond, arrow_tz),
             ) => to_arrow_timestamp::<TimestampMillisecondType>(&array, arrow_tz),
             (
-                TemporalMetadata::Timestamp(TimeUnit::Us, _),
+                TemporalMetadata::Timestamp(TimeUnit::Microseconds, _),
                 DataType::Timestamp(ArrowTimeUnit::Microsecond, arrow_tz),
             ) => to_arrow_timestamp::<TimestampMicrosecondType>(&array, arrow_tz),
             (
-                TemporalMetadata::Timestamp(TimeUnit::Ns, _),
+                TemporalMetadata::Timestamp(TimeUnit::Nanoseconds, _),
                 DataType::Timestamp(ArrowTimeUnit::Nanosecond, arrow_tz),
             ) => to_arrow_timestamp::<TimestampNanosecondType>(&array, arrow_tz),
             _ => vortex_bail!(

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -169,8 +169,8 @@ where
         }
         DataType::Time32(time_unit) => TemporalArray::new_time(arr, time_unit.into()).into(),
         DataType::Time64(time_unit) => TemporalArray::new_time(arr, time_unit.into()).into(),
-        DataType::Date32 => TemporalArray::new_date(arr, TimeUnit::D).into(),
-        DataType::Date64 => TemporalArray::new_date(arr, TimeUnit::Ms).into(),
+        DataType::Date32 => TemporalArray::new_date(arr, TimeUnit::Days).into(),
+        DataType::Date64 => TemporalArray::new_date(arr, TimeUnit::Milliseconds).into(),
         DataType::Duration(_) => unimplemented!(),
         DataType::Interval(_) => unimplemented!(),
         _ => vortex_panic!("Invalid temporal type: {}", value.data_type()),
@@ -775,13 +775,16 @@ mod tests {
 
         // Verify metadata - should be TemporalArray with Second time unit
         let temporal_array = TemporalArray::try_from(vortex_array.clone()).unwrap();
-        assert_eq!(temporal_array.temporal_metadata().time_unit(), TimeUnit::S);
+        assert_eq!(
+            temporal_array.temporal_metadata().time_unit(),
+            TimeUnit::Seconds
+        );
 
         let temporal_array_non_null =
             TemporalArray::try_from(vortex_array_non_null.clone()).unwrap();
         assert_eq!(
             temporal_array_non_null.temporal_metadata().time_unit(),
-            TimeUnit::S
+            TimeUnit::Seconds
         );
     }
 
@@ -830,7 +833,10 @@ mod tests {
             &DType::Extension(Arc::new(ExtDType::new(
                 TIMESTAMP_ID.clone(),
                 Arc::new(DType::Primitive(PType::I64, Nullability::Nullable)),
-                Some(TemporalMetadata::Timestamp(TimeUnit::Us, Some("UTC".to_string())).into())
+                Some(
+                    TemporalMetadata::Timestamp(TimeUnit::Microseconds, Some("UTC".to_string()))
+                        .into()
+                )
             )))
         );
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -839,7 +845,10 @@ mod tests {
             &DType::Extension(Arc::new(ExtDType::new(
                 TIMESTAMP_ID.clone(),
                 Arc::new(DType::Primitive(PType::I64, Nullability::NonNullable)),
-                Some(TemporalMetadata::Timestamp(TimeUnit::Us, Some("UTC".to_string())).into())
+                Some(
+                    TemporalMetadata::Timestamp(TimeUnit::Microseconds, Some("UTC".to_string()))
+                        .into()
+                )
             )))
         );
     }
@@ -870,13 +879,16 @@ mod tests {
 
         // Verify metadata - should be TemporalArray with Second time unit
         let temporal_array = TemporalArray::try_from(vortex_array.clone()).unwrap();
-        assert_eq!(temporal_array.temporal_metadata().time_unit(), TimeUnit::S);
+        assert_eq!(
+            temporal_array.temporal_metadata().time_unit(),
+            TimeUnit::Seconds
+        );
 
         let temporal_array_non_null =
             TemporalArray::try_from(vortex_array_non_null.clone()).unwrap();
         assert_eq!(
             temporal_array_non_null.temporal_metadata().time_unit(),
-            TimeUnit::S
+            TimeUnit::Seconds
         );
     }
 

--- a/vortex-datafusion/src/convert/scalars.rs
+++ b/vortex-datafusion/src/convert/scalars.rs
@@ -86,36 +86,40 @@ impl TryToDataFusion<ScalarValue> for Scalar {
                     let pv = storage_scalar.as_primitive();
                     return Ok(match metadata {
                         TemporalMetadata::Time(u) => match u {
-                            TimeUnit::Ns => ScalarValue::Time64Nanosecond(pv.as_::<i64>()),
-                            TimeUnit::Us => ScalarValue::Time64Microsecond(pv.as_::<i64>()),
-                            TimeUnit::Ms => ScalarValue::Time32Millisecond(pv.as_::<i32>()),
-                            TimeUnit::S => ScalarValue::Time32Second(pv.as_::<i32>()),
-                            TimeUnit::D => {
+                            TimeUnit::Nanoseconds => ScalarValue::Time64Nanosecond(pv.as_::<i64>()),
+                            TimeUnit::Microseconds => {
+                                ScalarValue::Time64Microsecond(pv.as_::<i64>())
+                            }
+                            TimeUnit::Milliseconds => {
+                                ScalarValue::Time32Millisecond(pv.as_::<i32>())
+                            }
+                            TimeUnit::Seconds => ScalarValue::Time32Second(pv.as_::<i32>()),
+                            TimeUnit::Days => {
                                 unreachable!("Unsupported TimeUnit {u} for {}", ext.id())
                             }
                         },
                         TemporalMetadata::Date(u) => match u {
-                            TimeUnit::Ms => ScalarValue::Date64(pv.as_::<i64>()),
-                            TimeUnit::D => ScalarValue::Date32(pv.as_::<i32>()),
+                            TimeUnit::Milliseconds => ScalarValue::Date64(pv.as_::<i64>()),
+                            TimeUnit::Days => ScalarValue::Date32(pv.as_::<i32>()),
                             _ => unreachable!("Unsupported TimeUnit {u} for {}", ext.id()),
                         },
                         TemporalMetadata::Timestamp(u, tz) => match u {
-                            TimeUnit::Ns => ScalarValue::TimestampNanosecond(
+                            TimeUnit::Nanoseconds => ScalarValue::TimestampNanosecond(
                                 pv.as_::<i64>(),
                                 tz.map(|t| t.into()),
                             ),
-                            TimeUnit::Us => ScalarValue::TimestampMicrosecond(
+                            TimeUnit::Microseconds => ScalarValue::TimestampMicrosecond(
                                 pv.as_::<i64>(),
                                 tz.map(|t| t.into()),
                             ),
-                            TimeUnit::Ms => ScalarValue::TimestampMillisecond(
+                            TimeUnit::Milliseconds => ScalarValue::TimestampMillisecond(
                                 pv.as_::<i64>(),
                                 tz.map(|t| t.into()),
                             ),
-                            TimeUnit::S => {
+                            TimeUnit::Seconds => {
                                 ScalarValue::TimestampSecond(pv.as_::<i64>(), tz.map(|t| t.into()))
                             }
-                            TimeUnit::D => {
+                            TimeUnit::Days => {
                                 unreachable!("Unsupported TimeUnit {u} for {}", ext.id())
                             }
                         },

--- a/vortex-dtype/src/datetime/arrow.rs
+++ b/vortex-dtype/src/datetime/arrow.rs
@@ -47,12 +47,12 @@ pub fn make_temporal_ext_dtype(data_type: &DataType) -> ExtDType {
         DataType::Date32 => ExtDType::new(
             DATE_ID.clone(),
             Arc::new(PType::I32.into()),
-            Some(TemporalMetadata::Date(TimeUnit::D).into()),
+            Some(TemporalMetadata::Date(TimeUnit::Days).into()),
         ),
         DataType::Date64 => ExtDType::new(
             DATE_ID.clone(),
             Arc::new(PType::I64.into()),
-            Some(TemporalMetadata::Date(TimeUnit::Ms).into()),
+            Some(TemporalMetadata::Date(TimeUnit::Milliseconds).into()),
         ),
         _ => unimplemented!("{data_type} conversion"),
     }
@@ -66,27 +66,33 @@ pub fn make_arrow_temporal_dtype(ext_dtype: &ExtDType) -> DataType {
         .vortex_expect("make_arrow_temporal_dtype must be called with a temporal ExtDType")
     {
         TemporalMetadata::Date(time_unit) => match time_unit {
-            TimeUnit::D => DataType::Date32,
-            TimeUnit::Ms => DataType::Date64,
-            TimeUnit::Ns | TimeUnit::Us | TimeUnit::S => {
+            TimeUnit::Days => DataType::Date32,
+            TimeUnit::Milliseconds => DataType::Date64,
+            TimeUnit::Nanoseconds | TimeUnit::Microseconds | TimeUnit::Seconds => {
                 vortex_panic!(InvalidArgument: "Invalid TimeUnit {} for {}", time_unit, ext_dtype.id())
             }
         },
         TemporalMetadata::Time(time_unit) => match time_unit {
-            TimeUnit::S => DataType::Time32(ArrowTimeUnit::Second),
-            TimeUnit::Ms => DataType::Time32(ArrowTimeUnit::Millisecond),
-            TimeUnit::Us => DataType::Time64(ArrowTimeUnit::Microsecond),
-            TimeUnit::Ns => DataType::Time64(ArrowTimeUnit::Nanosecond),
-            TimeUnit::D => {
+            TimeUnit::Seconds => DataType::Time32(ArrowTimeUnit::Second),
+            TimeUnit::Milliseconds => DataType::Time32(ArrowTimeUnit::Millisecond),
+            TimeUnit::Microseconds => DataType::Time64(ArrowTimeUnit::Microsecond),
+            TimeUnit::Nanoseconds => DataType::Time64(ArrowTimeUnit::Nanosecond),
+            TimeUnit::Days => {
                 vortex_panic!(InvalidArgument: "Invalid TimeUnit {} for {}", time_unit, ext_dtype.id())
             }
         },
         TemporalMetadata::Timestamp(time_unit, tz) => match time_unit {
-            TimeUnit::Ns => DataType::Timestamp(ArrowTimeUnit::Nanosecond, tz.map(|t| t.into())),
-            TimeUnit::Us => DataType::Timestamp(ArrowTimeUnit::Microsecond, tz.map(|t| t.into())),
-            TimeUnit::Ms => DataType::Timestamp(ArrowTimeUnit::Millisecond, tz.map(|t| t.into())),
-            TimeUnit::S => DataType::Timestamp(ArrowTimeUnit::Second, tz.map(|t| t.into())),
-            TimeUnit::D => {
+            TimeUnit::Nanoseconds => {
+                DataType::Timestamp(ArrowTimeUnit::Nanosecond, tz.map(|t| t.into()))
+            }
+            TimeUnit::Microseconds => {
+                DataType::Timestamp(ArrowTimeUnit::Microsecond, tz.map(|t| t.into()))
+            }
+            TimeUnit::Milliseconds => {
+                DataType::Timestamp(ArrowTimeUnit::Millisecond, tz.map(|t| t.into()))
+            }
+            TimeUnit::Seconds => DataType::Timestamp(ArrowTimeUnit::Second, tz.map(|t| t.into())),
+            TimeUnit::Days => {
                 vortex_panic!(InvalidArgument: "Invalid TimeUnit {} for {}", time_unit, ext_dtype.id())
             }
         },
@@ -102,10 +108,10 @@ impl From<&ArrowTimeUnit> for TimeUnit {
 impl From<ArrowTimeUnit> for TimeUnit {
     fn from(value: ArrowTimeUnit) -> Self {
         match value {
-            ArrowTimeUnit::Second => Self::S,
-            ArrowTimeUnit::Millisecond => Self::Ms,
-            ArrowTimeUnit::Microsecond => Self::Us,
-            ArrowTimeUnit::Nanosecond => Self::Ns,
+            ArrowTimeUnit::Second => Self::Seconds,
+            ArrowTimeUnit::Millisecond => Self::Milliseconds,
+            ArrowTimeUnit::Microsecond => Self::Microseconds,
+            ArrowTimeUnit::Nanosecond => Self::Nanoseconds,
         }
     }
 }
@@ -115,10 +121,10 @@ impl TryFrom<TimeUnit> for ArrowTimeUnit {
 
     fn try_from(value: TimeUnit) -> VortexResult<Self> {
         Ok(match value {
-            TimeUnit::S => Self::Second,
-            TimeUnit::Ms => Self::Millisecond,
-            TimeUnit::Us => Self::Microsecond,
-            TimeUnit::Ns => Self::Nanosecond,
+            TimeUnit::Seconds => Self::Second,
+            TimeUnit::Milliseconds => Self::Millisecond,
+            TimeUnit::Microseconds => Self::Microsecond,
+            TimeUnit::Nanoseconds => Self::Nanosecond,
             _ => vortex_bail!("Cannot convert {value} to Arrow TimeUnit"),
         })
     }
@@ -133,7 +139,7 @@ mod tests {
         let ext_dtype = ExtDType::new(
             TIMESTAMP_ID.clone(),
             Arc::new(PType::I64.into()),
-            Some(TemporalMetadata::Timestamp(TimeUnit::Ms, None).into()),
+            Some(TemporalMetadata::Timestamp(TimeUnit::Milliseconds, None).into()),
         );
         let expected_arrow_type = DataType::Timestamp(ArrowTimeUnit::Millisecond, None);
 
@@ -149,7 +155,7 @@ mod tests {
         let ext_dtype = ExtDType::new(
             TIME_ID.clone(),
             Arc::new(PType::I32.into()),
-            Some(TemporalMetadata::Time(TimeUnit::Ms).into()),
+            Some(TemporalMetadata::Time(TimeUnit::Milliseconds).into()),
         );
         let expected_arrow_type = DataType::Time32(ArrowTimeUnit::Millisecond);
         let arrow_dtype = make_arrow_temporal_dtype(&ext_dtype);
@@ -164,7 +170,7 @@ mod tests {
         let ext_dtype = ExtDType::new(
             TIME_ID.clone(),
             Arc::new(PType::I64.into()),
-            Some(TemporalMetadata::Time(TimeUnit::Us).into()),
+            Some(TemporalMetadata::Time(TimeUnit::Microseconds).into()),
         );
         let expected_arrow_type = DataType::Time64(ArrowTimeUnit::Microsecond);
         let arrow_dtype = make_arrow_temporal_dtype(&ext_dtype);
@@ -179,7 +185,7 @@ mod tests {
         let ext_dtype = ExtDType::new(
             DATE_ID.clone(),
             Arc::new(PType::I32.into()),
-            Some(TemporalMetadata::Date(TimeUnit::D).into()),
+            Some(TemporalMetadata::Date(TimeUnit::Days).into()),
         );
         let expected_arrow_type = DataType::Date32;
         let arrow_dtype = make_arrow_temporal_dtype(&ext_dtype);
@@ -194,7 +200,7 @@ mod tests {
         let ext_dtype = ExtDType::new(
             DATE_ID.clone(),
             Arc::new(PType::I64.into()),
-            Some(TemporalMetadata::Date(TimeUnit::Ms).into()),
+            Some(TemporalMetadata::Date(TimeUnit::Milliseconds).into()),
         );
         let expected_arrow_type = DataType::Date64;
         let arrow_dtype = make_arrow_temporal_dtype(&ext_dtype);

--- a/vortex-dtype/src/datetime/temporal.rs
+++ b/vortex-dtype/src/datetime/temporal.rs
@@ -83,21 +83,21 @@ impl TemporalMetadata {
     /// Convert a timestamp value to a Jiff value.
     pub fn to_jiff(&self, v: i64) -> VortexResult<TemporalJiff> {
         match self {
-            TemporalMetadata::Time(TimeUnit::D) => {
+            TemporalMetadata::Time(TimeUnit::Days) => {
                 vortex_bail!("Invalid TimeUnit TimeUnit::D for TemporalMetadata::Time")
             }
             TemporalMetadata::Time(unit) => Ok(TemporalJiff::Time(
                 Time::MIN.checked_add(unit.to_jiff_span(v)?)?,
             )),
             TemporalMetadata::Date(unit) => match unit {
-                TimeUnit::D | TimeUnit::Ms => Ok(TemporalJiff::Date(
+                TimeUnit::Days | TimeUnit::Milliseconds => Ok(TemporalJiff::Date(
                     Date::new(1970, 1, 1)?.checked_add(unit.to_jiff_span(v)?)?,
                 )),
-                TimeUnit::Ns | TimeUnit::Us | TimeUnit::S => {
+                TimeUnit::Nanoseconds | TimeUnit::Microseconds | TimeUnit::Seconds => {
                     vortex_bail!("Invalid TimeUnit {} for TemporalMetadata::Time", unit)
                 }
             },
-            TemporalMetadata::Timestamp(TimeUnit::D, _) => {
+            TemporalMetadata::Timestamp(TimeUnit::Days, _) => {
                 vortex_bail!("Invalid TimeUnit TimeUnit::D for TemporalMetadata::Timestamp")
             }
             TemporalMetadata::Timestamp(unit, None) => Ok(TemporalJiff::Unzoned(
@@ -218,7 +218,7 @@ mod tests {
     #[test]
     fn test_roundtrip_metadata() {
         let meta: ExtMetadata =
-            TemporalMetadata::Timestamp(TimeUnit::Ms, Some("UTC".to_string())).into();
+            TemporalMetadata::Timestamp(TimeUnit::Milliseconds, Some("UTC".to_string())).into();
 
         assert_eq!(
             meta.as_ref(),
@@ -239,7 +239,7 @@ mod tests {
 
         assert_eq!(
             temporal_metadata,
-            TemporalMetadata::Timestamp(TimeUnit::Ms, Some("UTC".to_string()))
+            TemporalMetadata::Timestamp(TimeUnit::Milliseconds, Some("UTC".to_string()))
         );
     }
 }

--- a/vortex-dtype/src/datetime/unit.rs
+++ b/vortex-dtype/src/datetime/unit.rs
@@ -7,22 +7,21 @@ use jiff::Span;
 use num_enum::IntoPrimitive;
 use vortex_error::{VortexError, VortexResult, vortex_bail};
 
-// TODO(connor): Consider renaming the enum variants to be more descriptive.
 /// Time units for temporal data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, IntoPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u8)]
 pub enum TimeUnit {
     /// Nanoseconds
-    Ns = 0,
+    Nanoseconds = 0,
     /// Microseconds
-    Us = 1,
+    Microseconds = 1,
     /// Milliseconds
-    Ms = 2,
+    Milliseconds = 2,
     /// Seconds
-    S = 3,
+    Seconds = 3,
     /// Days
-    D = 4,
+    Days = 4,
 }
 
 impl TryFrom<u8> for TimeUnit {
@@ -30,11 +29,11 @@ impl TryFrom<u8> for TimeUnit {
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(TimeUnit::Ns),
-            1 => Ok(TimeUnit::Us),
-            2 => Ok(TimeUnit::Ms),
-            3 => Ok(TimeUnit::S),
-            4 => Ok(TimeUnit::D),
+            0 => Ok(TimeUnit::Nanoseconds),
+            1 => Ok(TimeUnit::Microseconds),
+            2 => Ok(TimeUnit::Milliseconds),
+            3 => Ok(TimeUnit::Seconds),
+            4 => Ok(TimeUnit::Days),
             _ => vortex_bail!("invalid time unit: {value}u8"),
         }
     }
@@ -44,11 +43,11 @@ impl TimeUnit {
     /// Convert to a Jiff span.
     pub fn to_jiff_span(&self, v: i64) -> VortexResult<Span> {
         Ok(match self {
-            TimeUnit::Ns => Span::new().try_nanoseconds(v)?,
-            TimeUnit::Us => Span::new().try_microseconds(v)?,
-            TimeUnit::Ms => Span::new().try_milliseconds(v)?,
-            TimeUnit::S => Span::new().try_seconds(v)?,
-            TimeUnit::D => Span::new().try_days(v)?,
+            TimeUnit::Nanoseconds => Span::new().try_nanoseconds(v)?,
+            TimeUnit::Microseconds => Span::new().try_microseconds(v)?,
+            TimeUnit::Milliseconds => Span::new().try_milliseconds(v)?,
+            TimeUnit::Seconds => Span::new().try_seconds(v)?,
+            TimeUnit::Days => Span::new().try_days(v)?,
         })
     }
 }
@@ -56,11 +55,11 @@ impl TimeUnit {
 impl Display for TimeUnit {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Ns => write!(f, "ns"),
-            Self::Us => write!(f, "µs"),
-            Self::Ms => write!(f, "ms"),
-            Self::S => write!(f, "s"),
-            Self::D => write!(f, "days"),
+            Self::Nanoseconds => write!(f, "ns"),
+            Self::Microseconds => write!(f, "µs"),
+            Self::Milliseconds => write!(f, "ms"),
+            Self::Seconds => write!(f, "s"),
+            Self::Days => write!(f, "days"),
         }
     }
 }

--- a/vortex-duckdb/src/convert/dtype.rs
+++ b/vortex-duckdb/src/convert/dtype.rs
@@ -117,17 +117,17 @@ impl LogicalType {
             .map_err(|e| vortex_err!("Failed to extract temporal metadata: {}", e))?;
 
         let duckdb_type = match temporal_metadata {
-            TemporalMetadata::Date(TimeUnit::D) => DUCKDB_TYPE::DUCKDB_TYPE_DATE,
+            TemporalMetadata::Date(TimeUnit::Days) => DUCKDB_TYPE::DUCKDB_TYPE_DATE,
             TemporalMetadata::Date(time_unit) => {
                 vortex_bail!("Invalid TimeUnit {} for date", time_unit);
             }
-            TemporalMetadata::Time(TimeUnit::Us) => DUCKDB_TYPE::DUCKDB_TYPE_TIME,
+            TemporalMetadata::Time(TimeUnit::Microseconds) => DUCKDB_TYPE::DUCKDB_TYPE_TIME,
             TemporalMetadata::Time(time_unit) => {
                 vortex_bail!("Invalid TimeUnit {} for time", time_unit);
             }
             TemporalMetadata::Timestamp(time_unit, tz) => match time_unit {
-                TimeUnit::Ns => DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_NS,
-                TimeUnit::Us => {
+                TimeUnit::Nanoseconds => DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_NS,
+                TimeUnit::Microseconds => {
                     if let Some(tz) = tz {
                         if tz != "UTC" {
                             vortex_bail!("Invalid timezone for timestamp: {tz}");
@@ -137,8 +137,8 @@ impl LogicalType {
                         DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP
                     }
                 }
-                TimeUnit::Ms => DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_MS,
-                TimeUnit::S => DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_S,
+                TimeUnit::Milliseconds => DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_MS,
+                TimeUnit::Seconds => DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_S,
                 _ => vortex_bail!("Invalid TimeUnit {} for timestamp", time_unit),
             },
         };
@@ -187,37 +187,40 @@ impl FromLogicalType for DType {
             DUCKDB_TYPE::DUCKDB_TYPE_DATE => DType::Extension(Arc::new(ExtDType::new(
                 DATE_ID.clone(),
                 Arc::new(DType::Primitive(I32, nullability)),
-                Some(TemporalMetadata::Date(TimeUnit::D).into()),
+                Some(TemporalMetadata::Date(TimeUnit::Days).into()),
             ))),
             DUCKDB_TYPE::DUCKDB_TYPE_TIME => DType::Extension(Arc::new(ExtDType::new(
                 TIME_ID.clone(),
                 Arc::new(DType::Primitive(I64, nullability)),
-                Some(TemporalMetadata::Date(TimeUnit::Us).into()),
+                Some(TemporalMetadata::Date(TimeUnit::Microseconds).into()),
             ))),
             DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_S => DType::Extension(Arc::new(ExtDType::new(
                 TIMESTAMP_ID.clone(),
                 Arc::new(DType::Primitive(I64, nullability)),
-                Some(TemporalMetadata::Timestamp(TimeUnit::S, None).into()),
+                Some(TemporalMetadata::Timestamp(TimeUnit::Seconds, None).into()),
             ))),
             DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_MS => DType::Extension(Arc::new(ExtDType::new(
                 TIMESTAMP_ID.clone(),
                 Arc::new(DType::Primitive(I64, nullability)),
-                Some(TemporalMetadata::Timestamp(TimeUnit::Ms, None).into()),
+                Some(TemporalMetadata::Timestamp(TimeUnit::Milliseconds, None).into()),
             ))),
             DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP => DType::Extension(Arc::new(ExtDType::new(
                 TIMESTAMP_ID.clone(),
                 Arc::new(DType::Primitive(I64, nullability)),
-                Some(TemporalMetadata::Timestamp(TimeUnit::Us, None).into()),
+                Some(TemporalMetadata::Timestamp(TimeUnit::Microseconds, None).into()),
             ))),
             DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_TZ => DType::Extension(Arc::new(ExtDType::new(
                 TIMESTAMP_ID.clone(),
                 Arc::new(DType::Primitive(I64, nullability)),
-                Some(TemporalMetadata::Timestamp(TimeUnit::Us, Some("UTC".to_string())).into()),
+                Some(
+                    TemporalMetadata::Timestamp(TimeUnit::Microseconds, Some("UTC".to_string()))
+                        .into(),
+                ),
             ))),
             DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_NS => DType::Extension(Arc::new(ExtDType::new(
                 TIMESTAMP_ID.clone(),
                 Arc::new(DType::Primitive(I64, nullability)),
-                Some(TemporalMetadata::Timestamp(TimeUnit::Ns, None).into()),
+                Some(TemporalMetadata::Timestamp(TimeUnit::Nanoseconds, None).into()),
             ))),
             DUCKDB_TYPE::DUCKDB_TYPE_TIME_TZ => todo!(),
             DUCKDB_TYPE::DUCKDB_TYPE_INTERVAL => todo!(),
@@ -477,7 +480,7 @@ mod tests {
         let ext_dtype = ExtDType::new(
             DATE_ID.clone(),
             Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable)),
-            Some(TemporalMetadata::Date(TimeUnit::D).into()),
+            Some(TemporalMetadata::Date(TimeUnit::Days).into()),
         );
         let dtype = DType::Extension(Arc::new(ext_dtype));
         let logical_type = LogicalType::try_from(&dtype).unwrap();
@@ -498,7 +501,7 @@ mod tests {
         let ext_dtype = ExtDType::new(
             TIME_ID.clone(),
             Arc::new(DType::Primitive(PType::I64, Nullability::NonNullable)),
-            Some(TemporalMetadata::Time(TimeUnit::Us).into()),
+            Some(TemporalMetadata::Time(TimeUnit::Microseconds).into()),
         );
         let dtype = DType::Extension(Arc::new(ext_dtype));
         let logical_type = LogicalType::try_from(&dtype).unwrap();
@@ -517,10 +520,19 @@ mod tests {
         use vortex::dtype::{ExtDType, PType};
 
         let test_cases = [
-            (TimeUnit::Ns, cpp::DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_NS),
-            (TimeUnit::Us, cpp::DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP),
-            (TimeUnit::Ms, cpp::DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_MS),
-            (TimeUnit::S, cpp::DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_S),
+            (
+                TimeUnit::Nanoseconds,
+                cpp::DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_NS,
+            ),
+            (
+                TimeUnit::Microseconds,
+                cpp::DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP,
+            ),
+            (
+                TimeUnit::Milliseconds,
+                cpp::DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_MS,
+            ),
+            (TimeUnit::Seconds, cpp::DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_S),
         ];
 
         for (time_unit, expected_type) in test_cases {
@@ -546,7 +558,9 @@ mod tests {
         let ext_dtype = ExtDType::new(
             TIMESTAMP_ID.clone(),
             Arc::new(DType::Primitive(PType::I64, Nullability::NonNullable)),
-            Some(TemporalMetadata::Timestamp(TimeUnit::Us, Some("UTC".to_string())).into()),
+            Some(
+                TemporalMetadata::Timestamp(TimeUnit::Microseconds, Some("UTC".to_string())).into(),
+            ),
         );
         let dtype = DType::Extension(Arc::new(ext_dtype));
 
@@ -567,7 +581,7 @@ mod tests {
         let ext_dtype = ExtDType::new(
             DATE_ID.clone(),
             Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable)),
-            Some(TemporalMetadata::Date(TimeUnit::Ms).into()),
+            Some(TemporalMetadata::Date(TimeUnit::Milliseconds).into()),
         );
         let dtype = DType::Extension(Arc::new(ext_dtype));
         assert!(LogicalType::try_from(&dtype).is_err());
@@ -576,7 +590,7 @@ mod tests {
         let ext_dtype = ExtDType::new(
             TIME_ID.clone(),
             Arc::new(DType::Primitive(PType::I64, Nullability::NonNullable)),
-            Some(TemporalMetadata::Time(TimeUnit::Ms).into()),
+            Some(TemporalMetadata::Time(TimeUnit::Milliseconds).into()),
         );
         let dtype = DType::Extension(Arc::new(ext_dtype));
         assert!(LogicalType::try_from(&dtype).is_err());

--- a/vortex-duckdb/src/convert/scalar.rs
+++ b/vortex-duckdb/src/convert/scalar.rs
@@ -160,15 +160,15 @@ impl ToDuckDBScalar for ExtScalar<'_> {
         };
         match time {
             TemporalMetadata::Time(unit) => match unit {
-                TimeUnit::Us => Ok(Value::new_time(value()?)),
-                TimeUnit::Ms => Ok(Value::new_time(value()? * 1000)),
-                TimeUnit::S => Ok(Value::new_time(value()? * 1000 * 1000)),
-                TimeUnit::Ns | TimeUnit::D => {
+                TimeUnit::Microseconds => Ok(Value::new_time(value()?)),
+                TimeUnit::Milliseconds => Ok(Value::new_time(value()? * 1000)),
+                TimeUnit::Seconds => Ok(Value::new_time(value()? * 1000 * 1000)),
+                TimeUnit::Nanoseconds | TimeUnit::Days => {
                     vortex_bail!("cannot convert timeunit {unit} to a duckdb MS time")
                 }
             },
             TemporalMetadata::Date(unit) => match unit {
-                TimeUnit::D => Ok(self
+                TimeUnit::Days => Ok(self
                     .storage()
                     .as_primitive_opt()
                     .ok_or_else(|| {
@@ -184,11 +184,11 @@ impl ToDuckDBScalar for ExtScalar<'_> {
                     todo!("timezones to duckdb scalar")
                 }
                 match unit {
-                    TimeUnit::Ns => Ok(Value::new_timestamp_ns(value()?)),
-                    TimeUnit::Us => Ok(Value::new_timestamp_us(value()?)),
-                    TimeUnit::Ms => Ok(Value::new_timestamp_ms(value()?)),
-                    TimeUnit::S => Ok(Value::new_timestamp_s(value()?)),
-                    TimeUnit::D => {
+                    TimeUnit::Nanoseconds => Ok(Value::new_timestamp_ns(value()?)),
+                    TimeUnit::Microseconds => Ok(Value::new_timestamp_us(value()?)),
+                    TimeUnit::Milliseconds => Ok(Value::new_timestamp_ms(value()?)),
+                    TimeUnit::Seconds => Ok(Value::new_timestamp_s(value()?)),
+                    TimeUnit::Days => {
                         vortex_bail!("timestamp(d) is cannot be converted to duckdb scalar")
                     }
                 }
@@ -233,7 +233,7 @@ impl TryFrom<&Value> for Scalar {
                 Arc::new(ExtDType::new(
                     DATE_ID.clone(),
                     Arc::new(DType::Primitive(I32, Nullable)),
-                    Some(TemporalMetadata::Date(TimeUnit::D).into()),
+                    Some(TemporalMetadata::Date(TimeUnit::Days).into()),
                 )),
                 Scalar::new(DType::Primitive(I32, Nullable), ScalarValue::from(days)),
             )),
@@ -241,7 +241,7 @@ impl TryFrom<&Value> for Scalar {
                 Arc::new(ExtDType::new(
                     TIME_ID.clone(),
                     Arc::new(DType::Primitive(I64, Nullable)),
-                    Some(TemporalMetadata::Time(TimeUnit::Us).into()),
+                    Some(TemporalMetadata::Time(TimeUnit::Microseconds).into()),
                 )),
                 Scalar::new(DType::Primitive(I64, Nullable), ScalarValue::from(micros)),
             )),
@@ -249,7 +249,7 @@ impl TryFrom<&Value> for Scalar {
                 Arc::new(ExtDType::new(
                     TIMESTAMP_ID.clone(),
                     Arc::new(DType::Primitive(I64, Nullable)),
-                    Some(TemporalMetadata::Timestamp(TimeUnit::Ns, None).into()),
+                    Some(TemporalMetadata::Timestamp(TimeUnit::Nanoseconds, None).into()),
                 )),
                 Scalar::new(DType::Primitive(I64, Nullable), ScalarValue::from(nanos)),
             )),
@@ -257,7 +257,7 @@ impl TryFrom<&Value> for Scalar {
                 Arc::new(ExtDType::new(
                     TIMESTAMP_ID.clone(),
                     Arc::new(DType::Primitive(I64, Nullable)),
-                    Some(TemporalMetadata::Timestamp(TimeUnit::Us, None).into()),
+                    Some(TemporalMetadata::Timestamp(TimeUnit::Microseconds, None).into()),
                 )),
                 Scalar::new(DType::Primitive(I64, Nullable), ScalarValue::from(micros)),
             )),
@@ -265,7 +265,7 @@ impl TryFrom<&Value> for Scalar {
                 Arc::new(ExtDType::new(
                     TIMESTAMP_ID.clone(),
                     Arc::new(DType::Primitive(I64, Nullable)),
-                    Some(TemporalMetadata::Timestamp(TimeUnit::Ms, None).into()),
+                    Some(TemporalMetadata::Timestamp(TimeUnit::Milliseconds, None).into()),
                 )),
                 Scalar::new(DType::Primitive(I64, Nullable), ScalarValue::from(millis)),
             )),
@@ -273,7 +273,7 @@ impl TryFrom<&Value> for Scalar {
                 Arc::new(ExtDType::new(
                     TIMESTAMP_ID.clone(),
                     Arc::new(DType::Primitive(I64, Nullable)),
-                    Some(TemporalMetadata::Timestamp(TimeUnit::S, None).into()),
+                    Some(TemporalMetadata::Timestamp(TimeUnit::Seconds, None).into()),
                 )),
                 Scalar::new(DType::Primitive(I64, Nullable), ScalarValue::from(seconds)),
             )),
@@ -322,10 +322,10 @@ mod tests {
         use vortex::scalar::{Scalar, ScalarValue};
 
         let test_cases = [
-            (TimeUnit::S, 1703980800i64),           // 2023-12-30 16:00:00 UTC
-            (TimeUnit::Ms, 1703980800123i64),       // 2023-12-30 16:00:00.123 UTC
-            (TimeUnit::Us, 1703980800123456i64),    // 2023-12-30 16:00:00.123456 UTC
-            (TimeUnit::Ns, 1703980800123456789i64), // 2023-12-30 16:00:00.123456789 UTC
+            (TimeUnit::Seconds, 1703980800i64), // 2023-12-30 16:00:00 UTC
+            (TimeUnit::Milliseconds, 1703980800123i64), // 2023-12-30 16:00:00.123 UTC
+            (TimeUnit::Microseconds, 1703980800123456i64), // 2023-12-30 16:00:00.123456 UTC
+            (TimeUnit::Nanoseconds, 1703980800123456789i64), // 2023-12-30 16:00:00.123456789 UTC
         ];
 
         for (time_unit, timestamp_value) in test_cases {

--- a/vortex-duckdb/src/convert/scalar.rs
+++ b/vortex-duckdb/src/convert/scalar.rs
@@ -321,11 +321,12 @@ mod tests {
         use vortex::dtype::{DType, ExtDType, Nullability, PType};
         use vortex::scalar::{Scalar, ScalarValue};
 
+        #[rustfmt::skip]
         let test_cases = [
-            (TimeUnit::Seconds, 1703980800i64), // 2023-12-30 16:00:00 UTC
-            (TimeUnit::Milliseconds, 1703980800123i64), // 2023-12-30 16:00:00.123 UTC
-            (TimeUnit::Microseconds, 1703980800123456i64), // 2023-12-30 16:00:00.123456 UTC
-            (TimeUnit::Nanoseconds, 1703980800123456789i64), // 2023-12-30 16:00:00.123456789 UTC
+            (TimeUnit::Seconds, 1703980800i64),                 // 2023-12-30 16:00:00 UTC
+            (TimeUnit::Milliseconds, 1703980800123i64),         // 2023-12-30 16:00:00.123 UTC
+            (TimeUnit::Microseconds, 1703980800123456i64),      // 2023-12-30 16:00:00.123456 UTC
+            (TimeUnit::Nanoseconds, 1703980800123456789i64),    // 2023-12-30 16:00:00.123456789 UTC
         ];
 
         for (time_unit, timestamp_value) in test_cases {

--- a/vortex-duckdb/src/exporter/temporal.rs
+++ b/vortex-duckdb/src/exporter/temporal.rs
@@ -39,7 +39,7 @@ mod tests {
     fn test_timestamp_s() {
         let arr = TemporalArray::new_timestamp(
             PrimitiveArray::from_iter(1750265024i64..(1750265024 + 10)).to_array(),
-            TimeUnit::S,
+            TimeUnit::Seconds,
             None,
         );
         let mut chunk =
@@ -64,7 +64,7 @@ mod tests {
         let arr = TemporalArray::new_timestamp(
             PrimitiveArray::from_iter((0..10).map(|i| 1_000_000 * i + 1750265188000001i64))
                 .to_array(),
-            TimeUnit::Us,
+            TimeUnit::Microseconds,
             None,
         );
         let mut chunk = DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_TIMESTAMP)]);
@@ -87,7 +87,7 @@ mod tests {
     fn test_timestamp_time_us() {
         let arr = TemporalArray::new_time(
             PrimitiveArray::from_iter((1i64..10).map(|i| 1_000_000 * i)).to_array(),
-            TimeUnit::Us,
+            TimeUnit::Microseconds,
         );
 
         let mut chunk = DataChunk::new([LogicalType::try_from(arr.dtype()).unwrap()]);

--- a/vortex-jni/src/dtype.rs
+++ b/vortex-jni/src/dtype.rs
@@ -246,11 +246,11 @@ pub extern "system" fn Java_dev_vortex_jni_NativeDTypeMethods_getTimeUnit(
 
         let temporal = TemporalMetadata::try_from(ext_dtype)?;
         Ok(match temporal.time_unit() {
-            TimeUnit::Ns => 0,
-            TimeUnit::Us => 1,
-            TimeUnit::Ms => 2,
-            TimeUnit::S => 3,
-            TimeUnit::D => 4,
+            TimeUnit::Nanoseconds => 0,
+            TimeUnit::Microseconds => 1,
+            TimeUnit::Milliseconds => 2,
+            TimeUnit::Seconds => 3,
+            TimeUnit::Days => 4,
         })
     })
 }
@@ -574,8 +574,8 @@ pub extern "system" fn Java_dev_vortex_jni_NativeDTypeMethods_newDate(
         let time_unit = TimeUnit::try_from(time_unit as u8).map_err(JNIError::Vortex)?;
 
         let ptype = match time_unit {
-            TimeUnit::D => PType::I32,
-            TimeUnit::Ms => PType::I64,
+            TimeUnit::Days => PType::I32,
+            TimeUnit::Milliseconds => PType::I64,
             unit => throw_runtime!("invalid time_unit for Date type {unit}"),
         };
 
@@ -602,8 +602,8 @@ pub extern "system" fn Java_dev_vortex_jni_NativeDTypeMethods_newTime(
         let time_unit = TimeUnit::try_from(time_unit as u8).map_err(JNIError::Vortex)?;
 
         let ptype = match time_unit {
-            TimeUnit::S | TimeUnit::Ms => PType::I32,
-            TimeUnit::Us | TimeUnit::Ns => PType::I64,
+            TimeUnit::Seconds | TimeUnit::Milliseconds => PType::I32,
+            TimeUnit::Microseconds | TimeUnit::Nanoseconds => PType::I64,
             unit => throw_runtime!("invalid time_unit for Time type {unit}"),
         };
 

--- a/vortex-scalar/src/arrow/mod.rs
+++ b/vortex-scalar/src/arrow/mod.rs
@@ -117,53 +117,53 @@ impl TryFrom<&Scalar> for Arc<dyn Datum> {
 
                     return match metadata {
                         TemporalMetadata::Time(u) => match u {
-                            TimeUnit::Ns => value_to_arrow_scalar!(
+                            TimeUnit::Nanoseconds => value_to_arrow_scalar!(
                                 primitive.as_::<i64>(),
                                 Time64NanosecondArray
                             ),
-                            TimeUnit::Us => value_to_arrow_scalar!(
+                            TimeUnit::Microseconds => value_to_arrow_scalar!(
                                 primitive.as_::<i64>(),
                                 Time64MicrosecondArray
                             ),
-                            TimeUnit::Ms => value_to_arrow_scalar!(
+                            TimeUnit::Milliseconds => value_to_arrow_scalar!(
                                 primitive.as_::<i32>(),
                                 Time32MillisecondArray
                             ),
-                            TimeUnit::S => {
+                            TimeUnit::Seconds => {
                                 value_to_arrow_scalar!(primitive.as_::<i32>(), Time32SecondArray)
                             }
-                            TimeUnit::D => {
+                            TimeUnit::Days => {
                                 vortex_bail!("Unsupported TimeUnit {u} for {}", ext.id())
                             }
                         },
                         TemporalMetadata::Date(u) => match u {
-                            TimeUnit::Ms => {
+                            TimeUnit::Milliseconds => {
                                 value_to_arrow_scalar!(primitive.as_::<i64>(), Date64Array)
                             }
-                            TimeUnit::D => {
+                            TimeUnit::Days => {
                                 value_to_arrow_scalar!(primitive.as_::<i32>(), Date32Array)
                             }
-                            TimeUnit::Ns | TimeUnit::Us | TimeUnit::S => {
+                            TimeUnit::Nanoseconds | TimeUnit::Microseconds | TimeUnit::Seconds => {
                                 vortex_bail!("Unsupported TimeUnit {u} for {}", ext.id())
                             }
                         },
                         TemporalMetadata::Timestamp(u, _) => match u {
-                            TimeUnit::Ns => value_to_arrow_scalar!(
+                            TimeUnit::Nanoseconds => value_to_arrow_scalar!(
                                 primitive.as_::<i64>(),
                                 TimestampNanosecondArray
                             ),
-                            TimeUnit::Us => value_to_arrow_scalar!(
+                            TimeUnit::Microseconds => value_to_arrow_scalar!(
                                 primitive.as_::<i64>(),
                                 TimestampMicrosecondArray
                             ),
-                            TimeUnit::Ms => value_to_arrow_scalar!(
+                            TimeUnit::Milliseconds => value_to_arrow_scalar!(
                                 primitive.as_::<i64>(),
                                 TimestampMillisecondArray
                             ),
-                            TimeUnit::S => {
+                            TimeUnit::Seconds => {
                                 value_to_arrow_scalar!(primitive.as_::<i64>(), TimestampSecondArray)
                             }
-                            TimeUnit::D => {
+                            TimeUnit::Days => {
                                 vortex_bail!("Unsupported TimeUnit {u} for {}", ext.id())
                             }
                         },

--- a/vortex-scalar/src/arrow/tests.rs
+++ b/vortex-scalar/src/arrow/tests.rs
@@ -267,10 +267,10 @@ fn test_non_temporal_extension_to_arrow_todo() {
 }
 
 #[rstest]
-#[case(TimeUnit::Ns, PType::I64, 123456789i64)]
-#[case(TimeUnit::Us, PType::I64, 123456789i64)]
-#[case(TimeUnit::Ms, PType::I32, 123456i64)]
-#[case(TimeUnit::S, PType::I32, 1234i64)]
+#[case(TimeUnit::Nanoseconds, PType::I64, 123456789i64)]
+#[case(TimeUnit::Microseconds, PType::I64, 123456789i64)]
+#[case(TimeUnit::Milliseconds, PType::I32, 123456i64)]
+#[case(TimeUnit::Seconds, PType::I32, 1234i64)]
 fn test_temporal_time_to_arrow(
     #[case] time_unit: TimeUnit,
     #[case] ptype: PType,
@@ -301,7 +301,7 @@ fn test_temporal_time_to_arrow(
 
 #[test]
 fn test_temporal_time_d_unsupported() {
-    let metadata = TemporalMetadata::Time(TimeUnit::D);
+    let metadata = TemporalMetadata::Time(TimeUnit::Days);
     let ext_dtype = Arc::new(ExtDType::new(
         TIME_ID.clone(),
         Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable)),
@@ -318,8 +318,8 @@ fn test_temporal_time_d_unsupported() {
 }
 
 #[rstest]
-#[case(TimeUnit::Ms, PType::I64, 1234567890000i64)]
-#[case(TimeUnit::D, PType::I32, 19000i64)]
+#[case(TimeUnit::Milliseconds, PType::I64, 1234567890000i64)]
+#[case(TimeUnit::Days, PType::I32, 19000i64)]
 fn test_temporal_date_to_arrow(
     #[case] time_unit: TimeUnit,
     #[case] ptype: PType,
@@ -349,9 +349,9 @@ fn test_temporal_date_to_arrow(
 }
 
 #[rstest]
-#[case(TimeUnit::Ns, PType::I64)]
-#[case(TimeUnit::Us, PType::I64)]
-#[case(TimeUnit::S, PType::I32)]
+#[case(TimeUnit::Nanoseconds, PType::I64)]
+#[case(TimeUnit::Microseconds, PType::I64)]
+#[case(TimeUnit::Seconds, PType::I32)]
 fn test_temporal_date_unsupported(#[case] time_unit: TimeUnit, #[case] ptype: PType) {
     let metadata = TemporalMetadata::Date(time_unit);
     let ext_dtype = Arc::new(ExtDType::new(
@@ -377,10 +377,10 @@ fn test_temporal_date_unsupported(#[case] time_unit: TimeUnit, #[case] ptype: PT
 }
 
 #[rstest]
-#[case(TimeUnit::Ns, 1234567890000000000i64)]
-#[case(TimeUnit::Us, 1234567890000000i64)]
-#[case(TimeUnit::Ms, 1234567890000i64)]
-#[case(TimeUnit::S, 1234567890i64)]
+#[case(TimeUnit::Nanoseconds, 1234567890000000000i64)]
+#[case(TimeUnit::Microseconds, 1234567890000000i64)]
+#[case(TimeUnit::Milliseconds, 1234567890000i64)]
+#[case(TimeUnit::Seconds, 1234567890i64)]
 fn test_temporal_timestamp_to_arrow(#[case] time_unit: TimeUnit, #[case] value: i64) {
     let metadata = TemporalMetadata::Timestamp(time_unit, None);
     let ext_dtype = Arc::new(ExtDType::new(
@@ -400,7 +400,7 @@ fn test_temporal_timestamp_to_arrow(#[case] time_unit: TimeUnit, #[case] value: 
 
 #[test]
 fn test_temporal_timestamp_d_unsupported() {
-    let metadata = TemporalMetadata::Timestamp(TimeUnit::D, None);
+    let metadata = TemporalMetadata::Timestamp(TimeUnit::Days, None);
     let ext_dtype = Arc::new(ExtDType::new(
         TIMESTAMP_ID.clone(),
         Arc::new(DType::Primitive(PType::I64, Nullability::NonNullable)),
@@ -421,7 +421,7 @@ fn test_temporal_timestamp_d_unsupported() {
 
 #[test]
 fn test_temporal_with_null_value() {
-    let metadata = TemporalMetadata::Time(TimeUnit::Ns);
+    let metadata = TemporalMetadata::Time(TimeUnit::Nanoseconds);
     let ext_dtype = Arc::new(ExtDType::new(
         TIME_ID.clone(),
         Arc::new(DType::Primitive(PType::I64, Nullability::Nullable)),
@@ -439,7 +439,7 @@ fn test_temporal_with_null_value() {
 
 #[test]
 fn test_temporal_non_primitive_storage_error() {
-    let metadata = TemporalMetadata::Time(TimeUnit::Ns);
+    let metadata = TemporalMetadata::Time(TimeUnit::Nanoseconds);
     let ext_dtype = Arc::new(ExtDType::new(
         TIME_ID.clone(),
         Arc::new(DType::Utf8(Nullability::NonNullable)),

--- a/vortex-scalar/src/display.rs
+++ b/vortex-scalar/src/display.rs
@@ -190,7 +190,7 @@ mod tests {
             DType::Extension(Arc::new(ExtDType::new(
                 TIME_ID.clone(),
                 Arc::new(DType::Primitive(PType::I32, Nullable)),
-                Some(ExtMetadata::from(TemporalMetadata::Time(TimeUnit::S))),
+                Some(ExtMetadata::from(TemporalMetadata::Time(TimeUnit::Seconds))),
             )))
         }
 
@@ -214,7 +214,7 @@ mod tests {
             DType::Extension(Arc::new(ExtDType::new(
                 DATE_ID.clone(),
                 Arc::new(DType::Primitive(PType::I32, Nullable)),
-                Some(ExtMetadata::from(TemporalMetadata::Date(TimeUnit::D))),
+                Some(ExtMetadata::from(TemporalMetadata::Date(TimeUnit::Days))),
             )))
         }
 
@@ -261,7 +261,7 @@ mod tests {
                 TIMESTAMP_ID.clone(),
                 Arc::new(DType::Primitive(PType::I32, Nullable)),
                 Some(ExtMetadata::from(TemporalMetadata::Timestamp(
-                    TimeUnit::S,
+                    TimeUnit::Seconds,
                     None,
                 ))),
             )))
@@ -291,7 +291,7 @@ mod tests {
                 TIMESTAMP_ID.clone(),
                 Arc::new(DType::Primitive(PType::I64, Nullable)),
                 Some(ExtMetadata::from(TemporalMetadata::Timestamp(
-                    TimeUnit::S,
+                    TimeUnit::Seconds,
                     Some(String::from("Pacific/Guam")),
                 ))),
             )))


### PR DESCRIPTION
I feel like there's no good reason to use abbreviations in general, as it makes things harder to read, and also for this case there's no places where it makes the code cleaner.