### PR TITLE
Chore: Rename `as_struct_opt` to `as_struct_fields_opt`

### DIFF
--- a/fuzz/fuzz_targets/file_io.rs
+++ b/fuzz/fuzz_targets/file_io.rs
@@ -133,7 +133,7 @@ fn compare_struct(expected: ArrayRef, actual: ArrayRef) {
 fn has_nullable_struct(dtype: &DType) -> bool {
     dtype.is_struct() && dtype.is_nullable()
         || dtype
-            .as_struct_opt()
+            .as_struct_fields_opt()
             .map(|sdt| sdt.fields().any(|dtype| has_nullable_struct(&dtype)))
             .unwrap_or(false)
         || dtype
@@ -143,7 +143,7 @@ fn has_nullable_struct(dtype: &DType) -> bool {
 }
 
 fn has_duplicate_field_names(dtype: &DType) -> bool {
-    if let Some(struct_dtype) = dtype.as_struct_opt() {
+    if let Some(struct_dtype) = dtype.as_struct_fields_opt() {
         struct_has_duplicate_names(struct_dtype)
     } else if let Some(list_elem) = dtype.as_list_element_opt() {
         has_duplicate_field_names(list_elem)

--- a/vortex-array/src/arrays/struct_/compute/cast.rs
+++ b/vortex-array/src/arrays/struct_/compute/cast.rs
@@ -12,13 +12,13 @@ use crate::{ArrayRef, IntoArray, register_kernel};
 
 impl CastKernel for StructVTable {
     fn cast(&self, array: &StructArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
-        let Some(target_sdtype) = dtype.as_struct_opt() else {
+        let Some(target_sdtype) = dtype.as_struct_fields_opt() else {
             return Ok(None);
         };
 
         let source_sdtype = array
             .dtype()
-            .as_struct_opt()
+            .as_struct_fields_opt()
             .vortex_expect("struct array must have struct dtype");
 
         if target_sdtype.names() != source_sdtype.names() {

--- a/vortex-array/src/arrays/struct_/mod.rs
+++ b/vortex-array/src/arrays/struct_/mod.rs
@@ -204,7 +204,7 @@ impl StructArray {
     }
 
     pub fn struct_fields(&self) -> &StructFields {
-        let Some(struct_dtype) = &self.dtype.as_struct_opt() else {
+        let Some(struct_dtype) = &self.dtype.as_struct_fields_opt() else {
             unreachable!(
                 "struct arrays must have be a DType::Struct, this is likely an internal bug."
             )

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -218,7 +218,7 @@ impl FileFormat for VortexFormat {
 
             let struct_dtype = vxf
                 .dtype()
-                .as_struct_opt()
+                .as_struct_fields_opt()
                 .vortex_expect("dtype is not a struct");
 
             // Evaluate the statistics for each column that we are able to return to DataFusion.

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -291,9 +291,8 @@ impl DType {
         }
     }
 
-    // TODO(connor): This should probably be named `as_struct_fieds_opt`.
     /// Get the `StructDType` if `self` is a `StructDType`, otherwise `None`
-    pub fn as_struct_opt(&self) -> Option<&StructFields> {
+    pub fn as_struct_fields_opt(&self) -> Option<&StructFields> {
         if let Struct(f, _) = self {
             Some(f)
         } else {

--- a/vortex-dtype/src/struct_.rs
+++ b/vortex-dtype/src/struct_.rs
@@ -445,10 +445,10 @@ mod test {
             Nullability::Nullable,
         );
         assert!(dtype.is_nullable());
-        assert!(dtype.as_struct_opt().is_some());
-        assert!(a_type.as_struct_opt().is_none());
+        assert!(dtype.as_struct_fields_opt().is_some());
+        assert!(a_type.as_struct_fields_opt().is_none());
 
-        let sdt = dtype.as_struct_opt().unwrap();
+        let sdt = dtype.as_struct_fields_opt().unwrap();
         assert_eq!(sdt.names().len(), 2);
         assert_eq!(sdt.fields().len(), 2);
         assert_eq!(sdt.names(), ["A", "B"]);

--- a/vortex-duckdb/src/scan.rs
+++ b/vortex-duckdb/src/scan.rs
@@ -86,7 +86,7 @@ fn extract_schema_from_vortex_file(
 
     // For now, we assume the top-level type to be a struct.
     let struct_dtype = dtype
-        .as_struct_opt()
+        .as_struct_fields_opt()
         .ok_or_else(|| vortex_err!("Vortex file must contain a struct array at the top level"))?;
 
     let mut column_names = Vec::new();

--- a/vortex-expr/src/arbitrary.rs
+++ b/vortex-expr/src/arbitrary.rs
@@ -10,7 +10,7 @@ use vortex_scalar::arbitrary::random_scalar;
 use crate::{BinaryExpr, ExprRef, Operator, and_collect, col, lit, pack};
 
 pub fn projection_expr(u: &mut Unstructured<'_>, dtype: &DType) -> AResult<Option<ExprRef>> {
-    let Some(struct_dtype) = dtype.as_struct_opt() else {
+    let Some(struct_dtype) = dtype.as_struct_fields_opt() else {
         return Ok(None);
     };
 
@@ -27,7 +27,7 @@ pub fn projection_expr(u: &mut Unstructured<'_>, dtype: &DType) -> AResult<Optio
 }
 
 pub fn filter_expr(u: &mut Unstructured<'_>, dtype: &DType) -> AResult<Option<ExprRef>> {
-    let Some(struct_dtype) = dtype.as_struct_opt() else {
+    let Some(struct_dtype) = dtype.as_struct_fields_opt() else {
         return Ok(None);
     };
 

--- a/vortex-expr/src/exprs/get_item.rs
+++ b/vortex-expr/src/exprs/get_item.rs
@@ -93,7 +93,7 @@ impl VTable for GetItemVTable {
     fn return_dtype(expr: &Self::Expr, scope: &DType) -> VortexResult<DType> {
         let input = expr.child.return_dtype(scope)?;
         input
-            .as_struct_opt()
+            .as_struct_fields_opt()
             .and_then(|st| st.field(expr.field()))
             .ok_or_else(|| {
                 vortex_err!(

--- a/vortex-expr/src/exprs/merge.rs
+++ b/vortex-expr/src/exprs/merge.rs
@@ -132,7 +132,7 @@ impl VTable for MergeVTable {
             }
 
             let struct_dtype = dtype
-                .as_struct_opt()
+                .as_struct_fields_opt()
                 .vortex_expect("merge expects struct input");
 
             for i in 0..struct_dtype.nfields() {

--- a/vortex-expr/src/exprs/select.rs
+++ b/vortex-expr/src/exprs/select.rs
@@ -129,7 +129,7 @@ impl VTable for SelectVTable {
     fn return_dtype(expr: &Self::Expr, scope: &DType) -> VortexResult<DType> {
         let child_dtype = expr.child.return_dtype(scope)?;
         let child_struct_dtype = child_dtype
-            .as_struct_opt()
+            .as_struct_fields_opt()
             .ok_or_else(|| vortex_err!("Select child not a struct dtype"))?;
 
         let projected = match &expr.fields {
@@ -353,7 +353,7 @@ mod tests {
         let select_expr = select(vec![FieldName::from("a")], root());
         let expected_dtype = DType::Struct(
             dtype
-                .as_struct_opt()
+                .as_struct_fields_opt()
                 .unwrap()
                 .project(&["a".into()])
                 .unwrap(),
@@ -383,7 +383,7 @@ mod tests {
             select_expr_exclude.return_dtype(&dtype).unwrap(),
             DType::Struct(
                 dtype
-                    .as_struct_opt()
+                    .as_struct_fields_opt()
                     .unwrap()
                     .project(&["a".into(), "bool1".into(), "bool2".into()])
                     .unwrap(),

--- a/vortex-expr/src/transform/partition.rs
+++ b/vortex-expr/src/transform/partition.rs
@@ -214,7 +214,7 @@ mod tests {
 
     #[rstest]
     fn test_expr_top_level_ref(dtype: DType) {
-        let fields = dtype.as_struct_opt().unwrap();
+        let fields = dtype.as_struct_fields_opt().unwrap();
 
         let expr = root();
         let partitioned = partition(expr.clone(), &dtype, annotate_scope_access(fields)).unwrap();
@@ -232,7 +232,7 @@ mod tests {
 
     #[rstest]
     fn test_expr_top_level_ref_get_item_and_split(dtype: DType) {
-        let fields = dtype.as_struct_opt().unwrap();
+        let fields = dtype.as_struct_fields_opt().unwrap();
 
         let expr = get_item("y", get_item("a", root()));
 
@@ -242,7 +242,7 @@ mod tests {
 
     #[rstest]
     fn test_expr_top_level_ref_get_item_and_split_pack(dtype: DType) {
-        let fields = dtype.as_struct_opt().unwrap();
+        let fields = dtype.as_struct_fields_opt().unwrap();
 
         let expr = pack(
             [
@@ -269,7 +269,7 @@ mod tests {
 
     #[rstest]
     fn test_expr_top_level_ref_get_item_add(dtype: DType) {
-        let fields = dtype.as_struct_opt().unwrap();
+        let fields = dtype.as_struct_fields_opt().unwrap();
 
         let expr = and(get_item("y", get_item("a", root())), lit(1));
         let partitioned = partition(expr, &dtype, annotate_scope_access(fields)).unwrap();
@@ -280,7 +280,7 @@ mod tests {
 
     #[rstest]
     fn test_expr_top_level_ref_get_item_add_cannot_split(dtype: DType) {
-        let fields = dtype.as_struct_opt().unwrap();
+        let fields = dtype.as_struct_fields_opt().unwrap();
 
         let expr = and(get_item("y", get_item("a", root())), get_item("b", root()));
         let partitioned = partition(expr, &dtype, annotate_scope_access(fields)).unwrap();
@@ -292,7 +292,7 @@ mod tests {
     // Test that typed_simplify removes select and partition precise
     #[rstest]
     fn test_expr_partition_many_occurrences_of_field(dtype: DType) {
-        let fields = dtype.as_struct_opt().unwrap();
+        let fields = dtype.as_struct_fields_opt().unwrap();
 
         let expr = and(
             get_item("y", get_item("a", root())),
@@ -332,7 +332,7 @@ mod tests {
 
     #[rstest]
     fn test_expr_merge(dtype: DType) {
-        let fields = dtype.as_struct_opt().unwrap();
+        let fields = dtype.as_struct_fields_opt().unwrap();
 
         let expr = merge(
             [col("a"), pack([("b", col("b"))], NonNullable)],

--- a/vortex-expr/src/transform/remove_merge.rs
+++ b/vortex-expr/src/transform/remove_merge.rs
@@ -29,7 +29,9 @@ fn merge_transform(node: ExprRef, ctx: &DType) -> VortexResult<Transformed<ExprR
                 }
                 all_nullable = all_nullable && child_dtype.is_nullable();
 
-                let child_dtype = child_dtype.as_struct_opt().vortex_expect("expected struct");
+                let child_dtype = child_dtype
+                    .as_struct_fields_opt()
+                    .vortex_expect("expected struct");
 
                 for name in child_dtype.names().iter() {
                     if let Some(idx) = names.iter().position(|n| n == name) {

--- a/vortex-expr/src/transform/remove_select.rs
+++ b/vortex-expr/src/transform/remove_select.rs
@@ -20,7 +20,7 @@ fn remove_select_transformer(node: ExprRef, ctx: &DType) -> VortexResult<Transfo
             let child_dtype = child.return_dtype(ctx)?;
             let child_nullability = child_dtype.nullability();
 
-            let child_dtype = child_dtype.as_struct_opt().ok_or_else(|| {
+            let child_dtype = child_dtype.as_struct_fields_opt().ok_or_else(|| {
                 vortex_err!(
                     "Select child must return a struct dtype, however it was a {}",
                     child_dtype

--- a/vortex-ffi/src/dtype.rs
+++ b/vortex-ffi/src/dtype.rs
@@ -181,7 +181,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_struct_dtype(
     dtype: *const vx_dtype,
 ) -> *const vx_struct_fields {
     let struct_dtype = vx_dtype::as_ref(dtype)
-        .as_struct_opt()
+        .as_struct_fields_opt()
         .vortex_expect("not a struct dtype");
     vx_struct_fields::new_ref(struct_dtype)
 }

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -93,7 +93,7 @@ impl VortexFile {
         let Some((stats, fields)) = self
             .footer
             .statistics()
-            .zip(self.footer.dtype().as_struct_opt())
+            .zip(self.footer.dtype().as_struct_fields_opt())
         else {
             return Ok(false);
         };

--- a/vortex-jni/src/dtype.rs
+++ b/vortex-jni/src/dtype.rs
@@ -106,7 +106,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeDTypeMethods_getFieldNames(
     try_or_throw(&mut env, |env| {
         let array_list = env.new_object("java/util/ArrayList", "()V", &[])?;
         let field_names = env.get_list(&array_list)?;
-        let Some(struct_dtype) = dtype.as_struct_opt() else {
+        let Some(struct_dtype) = dtype.as_struct_fields_opt() else {
             throw_runtime!("DType should be STRUCT, was {dtype}");
         };
 
@@ -130,7 +130,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeDTypeMethods_getFieldTypes(
     try_or_throw(&mut env, |env| {
         let array_list = env.new_object("java/util/ArrayList", "()V", &[])?;
         let field_types = env.get_list(&array_list)?;
-        let Some(struct_dtype) = dtype.as_struct_opt() else {
+        let Some(struct_dtype) = dtype.as_struct_fields_opt() else {
             throw_runtime!("DType should be STRUCT, was {dtype}");
         };
 

--- a/vortex-layout/src/layouts/file_stats.rs
+++ b/vortex-layout/src/layouts/file_stats.rs
@@ -44,7 +44,7 @@ pub struct FileStatsAccumulator {
 
 impl FileStatsAccumulator {
     fn new(dtype: &DType, stats: Arc<[Stat]>, max_variable_length_statistics_size: usize) -> Self {
-        let accumulators = Arc::new(Mutex::new(match dtype.as_struct_opt() {
+        let accumulators = Arc::new(Mutex::new(match dtype.as_struct_fields_opt() {
             Some(struct_dtype) => {
                 if dtype.nullability() == Nullability::Nullable {
                     // top level dtype could be nullable, but we don't support it yet

--- a/vortex-layout/src/layouts/struct_/mod.rs
+++ b/vortex-layout/src/layouts/struct_/mod.rs
@@ -94,7 +94,7 @@ impl VTable for StructVTable {
         _ctx: ArrayContext,
     ) -> VortexResult<Self::Layout> {
         let struct_dt = dtype
-            .as_struct_opt()
+            .as_struct_fields_opt()
             .ok_or_else(|| vortex_err!("Expected struct dtype"))?;
         if children.nchildren() != struct_dt.nfields() {
             vortex_bail!(

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -118,7 +118,7 @@ impl StructReader {
                     self.dtype(),
                     annotate_scope_access(
                         self.dtype()
-                            .as_struct_opt()
+                            .as_struct_fields_opt()
                             .vortex_expect("We know it's a struct DType"),
                     ),
                 )

--- a/vortex-layout/src/layouts/struct_/writer.rs
+++ b/vortex-layout/src/layouts/struct_/writer.rs
@@ -51,7 +51,7 @@ where
         stream: SendableSequentialStream,
     ) -> VortexResult<LayoutRef> {
         let dtype = stream.dtype().clone();
-        let Some(struct_dtype) = stream.dtype().as_struct_opt().cloned() else {
+        let Some(struct_dtype) = stream.dtype().as_struct_fields_opt().cloned() else {
             // nothing we can do if dtype is not struct
             return self.child.write_stream(ctx, sequence_writer, stream).await;
         };

--- a/vortex-scalar/src/struct_.rs
+++ b/vortex-scalar/src/struct_.rs
@@ -96,7 +96,7 @@ impl<'a> StructScalar<'a> {
     #[inline]
     pub fn struct_fields(&self) -> &StructFields {
         self.dtype
-            .as_struct_opt()
+            .as_struct_fields_opt()
             .vortex_expect("StructScalar always has struct dtype")
     }
 
@@ -209,7 +209,7 @@ impl<'a> StructScalar<'a> {
     pub fn project(&self, projection: &[FieldName]) -> VortexResult<Scalar> {
         let struct_dtype = self
             .dtype
-            .as_struct_opt()
+            .as_struct_fields_opt()
             .ok_or_else(|| vortex_err!("Not a struct dtype"))?;
         let projected_dtype = struct_dtype.project(projection)?;
         let new_fields = if let Some(fs) = self.field_values() {

--- a/vortex-scan/src/lib.rs
+++ b/vortex-scan/src/lib.rs
@@ -299,7 +299,7 @@ fn filter_and_projection_masks(
     filter: Option<&ExprRef>,
     dtype: &DType,
 ) -> VortexResult<(Vec<FieldMask>, Vec<FieldMask>)> {
-    let Some(struct_dtype) = dtype.as_struct_opt() else {
+    let Some(struct_dtype) = dtype.as_struct_fields_opt() else {
         return Ok(match filter {
             Some(_) => (vec![FieldMask::All], vec![FieldMask::All]),
             None => (Vec::new(), vec![FieldMask::All]),


### PR DESCRIPTION
I think the name is misleading.