### PR TITLE
feature: ValidityVTable functions are non fallible

### DIFF
--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -71,7 +71,7 @@ where
 
     let encoded_array = PrimitiveArray::new(encoded, values.validity().clone()).into_array();
 
-    let validity = values.validity_mask()?;
+    let validity = values.validity_mask();
     // exceptional_positions may contain exceptions at invalid positions (which contain garbage
     // data). We remove null exceptions in order to keep the Patches small.
     let (valid_exceptional_positions, valid_exceptional_values): (Buffer<u64>, Buffer<T>) =
@@ -204,7 +204,7 @@ mod tests {
         let decoded = decompress(&encoded).unwrap();
         assert_eq!(decoded.scalar_at(0), array.scalar_at(0));
         assert_eq!(decoded.scalar_at(1), array.scalar_at(1));
-        assert!(!decoded.is_valid(2).unwrap());
+        assert!(!decoded.is_valid(2));
         assert_eq!(decoded.scalar_at(3), array.scalar_at(3));
     }
 
@@ -228,7 +228,7 @@ mod tests {
             assert!(s.is_valid());
         }
 
-        assert!(!encoded.is_valid(4).unwrap());
+        assert!(!encoded.is_valid(4));
         let s = encoded.scalar_at(4);
         assert!(s.is_null());
 

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -98,7 +98,7 @@ impl ALPRDArray {
 
         let left_parts_patches = left_parts_patches
             .map(|patches| {
-                if !patches.values().all_valid()? {
+                if !patches.values().all_valid() {
                     vortex_bail!("patches must be all valid: {}", patches.values());
                 }
                 // TODO(ngates): assert the DType, don't cast it.

--- a/encodings/alp/src/alp_rd/compute/take.rs
+++ b/encodings/alp/src/alp_rd/compute/take.rs
@@ -105,7 +105,7 @@ mod test {
 
         assert_eq!(taken.as_slice::<T>()[0], a);
         assert_eq!(taken.as_slice::<T>()[1], outlier);
-        assert!(!taken.validity_mask().unwrap().value(2));
+        assert!(!taken.validity_mask().value(2));
     }
 
     #[rstest]

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -175,14 +175,14 @@ mod tests {
         assert_eq!(v_len, arr.len());
 
         for idx in 0..arr.len() {
-            assert!(arr.is_valid(idx).unwrap());
+            assert!(arr.is_valid(idx));
         }
 
         let v = vec![Some(true), None, Some(false)];
         let arr = ByteBoolArray::from(v);
-        assert!(arr.is_valid(0).unwrap());
-        assert!(!arr.is_valid(1).unwrap());
-        assert!(arr.is_valid(2).unwrap());
+        assert!(arr.is_valid(0));
+        assert!(!arr.is_valid(1));
+        assert!(arr.is_valid(2));
         assert_eq!(arr.len(), 3);
 
         let v: Vec<Option<bool>> = vec![None, None];
@@ -192,7 +192,7 @@ mod tests {
         assert_eq!(v_len, arr.len());
 
         for idx in 0..arr.len() {
-            assert!(!arr.is_valid(idx).unwrap());
+            assert!(!arr.is_valid(idx));
         }
         assert_eq!(arr.len(), 2);
     }

--- a/encodings/bytebool/src/compute.rs
+++ b/encodings/bytebool/src/compute.rs
@@ -93,7 +93,7 @@ mod tests {
         assert_eq!(s.as_bool().value(), Some(true));
 
         let s = sliced_arr.scalar_at(1);
-        assert!(!sliced_arr.is_valid(1).unwrap());
+        assert!(!sliced_arr.is_valid(1));
         assert!(s.is_null());
         assert_eq!(s.as_bool().value(), None);
 

--- a/encodings/datetime-parts/src/canonical.rs
+++ b/encodings/datetime-parts/src/canonical.rs
@@ -102,7 +102,6 @@ pub fn decode_to_temporal(array: &DateTimePartsArray) -> VortexResult<TemporalAr
 
 #[cfg(test)]
 mod test {
-
     use rstest::rstest;
     use vortex_array::arrays::{PrimitiveArray, TemporalArray};
     use vortex_array::validity::Validity;
@@ -136,8 +135,8 @@ mod test {
         .unwrap();
 
         assert_eq!(
-            date_times.validity_mask().unwrap(),
-            validity.to_mask(date_times.len()).unwrap()
+            date_times.validity_mask(),
+            validity.to_mask(date_times.len())
         );
 
         let primitive_values = decode_to_temporal(&date_times)

--- a/encodings/datetime-parts/src/ops.rs
+++ b/encodings/datetime-parts/src/ops.rs
@@ -39,7 +39,7 @@ impl OperationsVTable<DateTimePartsVTable> for DateTimePartsVTable {
             vortex_panic!(ComputeError: "must decode TemporalMetadata from extension metadata");
         };
 
-        if !array.is_valid(index).vortex_expect("validity access") {
+        if !array.is_valid(index) {
             return Scalar::null(DType::Extension(ext));
         }
 

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/compare.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/compare.rs
@@ -46,7 +46,7 @@ impl CompareKernel for DecimalBytePartsVTable {
                 // (depending on the `sign`) than all values in MSP.
                 // If the LHS or the RHS contain nulls, then we must fallback to the canonicalized
                 // implementation which does null-checking instead.
-                if lhs.all_valid()? && rhs.all_valid()? {
+                if lhs.all_valid() && rhs.all_valid() {
                     Ok(Some(
                         ConstantArray::new(
                             unconvertible_value(sign, operator, nullability),

--- a/encodings/dict/src/array.rs
+++ b/encodings/dict/src/array.rs
@@ -154,11 +154,11 @@ impl CanonicalVTable<DictVTable> for DictVTable {
 }
 
 impl ValidityVTable<DictVTable> for DictVTable {
-    fn is_valid(array: &DictArray, index: usize) -> VortexResult<bool> {
+    fn is_valid(array: &DictArray, index: usize) -> bool {
         let scalar = array.codes().scalar_at(index);
 
         if scalar.is_null() {
-            return Ok(false);
+            return false;
         };
         let values_index: usize = scalar
             .as_ref()
@@ -167,20 +167,23 @@ impl ValidityVTable<DictVTable> for DictVTable {
         array.values().is_valid(values_index)
     }
 
-    fn all_valid(array: &DictArray) -> VortexResult<bool> {
-        Ok(array.codes().all_valid()? && array.values().all_valid()?)
+    fn all_valid(array: &DictArray) -> bool {
+        array.codes().all_valid() && array.values().all_valid()
     }
 
-    fn all_invalid(array: &DictArray) -> VortexResult<bool> {
-        Ok(array.codes().all_invalid()? || array.values().all_invalid()?)
+    fn all_invalid(array: &DictArray) -> bool {
+        array.codes().all_invalid() || array.values().all_invalid()
     }
 
-    fn validity_mask(array: &DictArray) -> VortexResult<Mask> {
-        let codes_validity = array.codes().validity_mask()?;
+    fn validity_mask(array: &DictArray) -> Mask {
+        let codes_validity = array.codes().validity_mask();
         match codes_validity.boolean_buffer() {
             AllOr::All => {
-                let primitive_codes = array.codes().to_primitive()?;
-                let values_mask = array.values().validity_mask()?;
+                let primitive_codes = array
+                    .codes()
+                    .to_primitive()
+                    .vortex_expect("dict codes must be primitive");
+                let values_mask = array.values().validity_mask();
                 let is_valid_buffer = match_each_integer_ptype!(primitive_codes.ptype(), |P| {
                     let codes_slice = primitive_codes.as_slice::<P>();
                     BooleanBuffer::collect_bool(array.len(), |idx| {
@@ -188,12 +191,15 @@ impl ValidityVTable<DictVTable> for DictVTable {
                         values_mask.value(codes_slice[idx] as usize)
                     })
                 });
-                Ok(Mask::from_buffer(is_valid_buffer))
+                Mask::from_buffer(is_valid_buffer)
             }
-            AllOr::None => Ok(Mask::AllFalse(array.len())),
+            AllOr::None => Mask::AllFalse(array.len()),
             AllOr::Some(validity_buff) => {
-                let primitive_codes = array.codes().to_primitive()?;
-                let values_mask = array.values().validity_mask()?;
+                let primitive_codes = array
+                    .codes()
+                    .to_primitive()
+                    .vortex_expect("dict codes must be primitive");
+                let values_mask = array.values().validity_mask();
                 let is_valid_buffer = match_each_integer_ptype!(primitive_codes.ptype(), |P| {
                     let codes_slice = primitive_codes.as_slice::<P>();
                     #[allow(clippy::cast_possible_truncation)]
@@ -201,7 +207,7 @@ impl ValidityVTable<DictVTable> for DictVTable {
                         validity_buff.value(idx) && values_mask.value(codes_slice[idx] as usize)
                     })
                 });
-                Ok(Mask::from_buffer(is_valid_buffer))
+                Mask::from_buffer(is_valid_buffer)
             }
         }
     }
@@ -236,7 +242,7 @@ mod test {
             PrimitiveArray::new(buffer![3, 6, 9], Validity::AllValid).into_array(),
         )
         .unwrap();
-        let mask = dict.validity_mask().unwrap();
+        let mask = dict.validity_mask();
         let AllOr::Some(indices) = mask.indices() else {
             vortex_panic!("Expected indices from mask")
         };
@@ -254,7 +260,7 @@ mod test {
             .into_array(),
         )
         .unwrap();
-        let mask = dict.validity_mask().unwrap();
+        let mask = dict.validity_mask();
         let AllOr::Some(indices) = mask.indices() else {
             vortex_panic!("Expected indices from mask")
         };
@@ -276,7 +282,7 @@ mod test {
             .into_array(),
         )
         .unwrap();
-        let mask = dict.validity_mask().unwrap();
+        let mask = dict.validity_mask();
         let AllOr::Some(indices) = mask.indices() else {
             vortex_panic!("Expected indices from mask")
         };
@@ -332,8 +338,8 @@ mod test {
 
         assert_eq!(into_prim.as_slice::<u64>(), prim_into.as_slice::<u64>());
         assert_eq!(
-            into_prim.validity_mask().unwrap().boolean_buffer(),
-            prim_into.validity_mask().unwrap().boolean_buffer()
+            into_prim.validity_mask().boolean_buffer(),
+            prim_into.validity_mask().boolean_buffer()
         )
     }
 }

--- a/encodings/dict/src/compute/compare.rs
+++ b/encodings/dict/src/compute/compare.rs
@@ -59,7 +59,7 @@ fn dict_equal_to(
     result_nullability: Nullability,
 ) -> VortexResult<ArrayRef> {
     let bool_result = values_compare.to_bool()?;
-    let result_validity = bool_result.validity_mask()?;
+    let result_validity = bool_result.validity_mask();
     let bool_buffer = bool_result.boolean_buffer();
     let (first_match, second_match) = match result_validity.boolean_buffer() {
         AllOr::All => {
@@ -83,7 +83,7 @@ fn dict_equal_to(
                     &ConstantArray::new(Scalar::bool(false, result_nullability), codes.len())
                         .into_array(),
                 )?;
-                result_builder.set_validity(codes.validity_mask()?);
+                result_builder.set_validity(codes.validity_mask());
                 result_builder.finish()
             }
             Mask::AllFalse(_) => ConstantArray::new(
@@ -101,7 +101,7 @@ fn dict_equal_to(
                 result_builder.set_validity(
                     Validity::from_mask(result_validity, bool_result.dtype().nullability())
                         .take(codes)?
-                        .to_mask(codes.len())?,
+                        .to_mask(codes.len()),
                 );
                 result_builder.finish()
             }
@@ -205,10 +205,7 @@ mod tests {
             vec![false, false, false]
         );
         assert_eq!(res.dtype().nullability(), Nullability::Nullable);
-        assert_eq!(
-            res.validity_mask().unwrap(),
-            Mask::from_iter([false, true, false])
-        );
+        assert_eq!(res.validity_mask(), Mask::from_iter([false, true, false]));
     }
 
     #[test]
@@ -235,9 +232,6 @@ mod tests {
             vec![false, false, false]
         );
         assert_eq!(res.dtype().nullability(), Nullability::Nullable);
-        assert_eq!(
-            res.validity_mask().unwrap(),
-            Mask::from_iter([true, true, false])
-        );
+        assert_eq!(res.validity_mask(), Mask::from_iter([true, true, false]));
     }
 }

--- a/encodings/dict/src/compute/fill_null.rs
+++ b/encodings/dict/src/compute/fill_null.rs
@@ -81,6 +81,6 @@ mod tests {
         .vortex_unwrap();
         let filled_primitive = filled.to_primitive().vortex_unwrap();
         assert_eq!(filled_primitive.as_slice::<i32>(), [10, 20, 20]);
-        assert!(filled_primitive.all_valid().vortex_unwrap());
+        assert!(filled_primitive.all_valid());
     }
 }

--- a/encodings/dict/src/compute/mod.rs
+++ b/encodings/dict/src/compute/mod.rs
@@ -89,10 +89,7 @@ mod test {
         assert_eq!(actual.as_slice::<i32>(), expected.as_slice());
 
         let expected_valid_count = values.iter().filter(|x| x.is_some()).count();
-        assert_eq!(
-            actual.validity_mask().unwrap().true_count(),
-            expected_valid_count
-        );
+        assert_eq!(actual.validity_mask().true_count(), expected_valid_count);
     }
 
     #[test]

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -197,7 +197,7 @@ pub fn gather_patches(
     };
 
     let array_len = parray.len();
-    let validity_mask = parray.validity_mask()?;
+    let validity_mask = parray.validity_mask();
 
     let patches = if array_len < u8::MAX as usize {
         match_each_integer_ptype!(parray.ptype(), |T| {
@@ -294,7 +294,7 @@ pub(crate) fn unpack_into<T: BitPacked>(
     builder: &mut PrimitiveBuilder<T>,
 ) -> VortexResult<()> {
     // Append a dense null Mask.
-    builder.append_mask(array.validity_mask()?);
+    builder.append_mask(array.validity_mask());
 
     let mut uninit = builder.uninit_range(array.len());
     let mut bit_packed_iter = array.unpacked_chunks();
@@ -323,7 +323,7 @@ fn apply_patches<T: NativePType>(dst: &mut UninitRange<T>, patches: &Patches) ->
 
     let indices = patches.indices().to_primitive()?;
     let values = patches.values().to_primitive()?;
-    let validity = values.validity_mask()?;
+    let validity = values.validity_mask();
     let values = values.as_slice::<T>();
     match_each_unsigned_integer_ptype!(indices.ptype(), |P| {
         insert_values_and_validity_at_indices(
@@ -458,7 +458,7 @@ fn bit_width_histogram_typed<T: NativePType + PrimInt>(
         |v: T| (8 * size_of::<T>()) - (PrimInt::leading_zeros(v) as usize);
 
     let mut bit_widths = vec![0usize; size_of::<T>() * 8 + 1];
-    match array.validity_mask()?.boolean_buffer() {
+    match array.validity_mask().boolean_buffer() {
         AllOr::All => {
             // All values are valid.
             for v in array.as_slice::<T>() {
@@ -668,7 +668,6 @@ mod test {
             (0..(1 << 4)).collect::<Vec<_>>(),
             compressed
                 .validity_mask()
-                .unwrap()
                 .to_null_buffer()
                 .unwrap()
                 .into_inner()

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -248,7 +248,7 @@ mod test {
         .to_primitive()
         .unwrap();
         assert_eq!(taken_primitive.as_slice::<i32>(), &[1i32, 2, 1, 4]);
-        assert_eq!(taken_primitive.invalid_count().unwrap(), 1);
+        assert_eq!(taken_primitive.invalid_count(), 1);
     }
 
     #[rstest]

--- a/encodings/fsst/src/canonical.rs
+++ b/encodings/fsst/src/canonical.rs
@@ -38,7 +38,7 @@ impl CanonicalVTable<FSSTVTable> for FSSTVTable {
 
         let (buffer, views) = fsst_decode_views(array, builder.completed_block_count());
 
-        builder.push_buffer_and_adjusted_views(&[buffer], &views, array.validity_mask()?);
+        builder.push_buffer_and_adjusted_views(&[buffer], &views, array.validity_mask());
         Ok(())
     }
 }

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -88,7 +88,7 @@ fn number_type_from_dtype(dtype: &DType) -> NumberType {
 }
 
 fn collect_valid(parray: &PrimitiveArray) -> VortexResult<PrimitiveArray> {
-    let mask = parray.validity_mask()?;
+    let mask = parray.validity_mask();
     filter(&parray.to_array(), &mask)?.to_primitive()
 }
 
@@ -255,7 +255,7 @@ impl PcoArray {
         let slice_n_rows = self.slice_stop - self.slice_start;
         let slice_value_indices = self
             .unsliced_validity
-            .to_mask(self.unsliced_n_rows)?
+            .to_mask(self.unsliced_n_rows)
             .valid_counts_for_indices(&[self.slice_start, self.slice_stop])?;
         let slice_value_start = slice_value_indices[0];
         let slice_value_stop = slice_value_indices[1];

--- a/encodings/pco/src/test.rs
+++ b/encodings/pco/src/test.rs
@@ -102,12 +102,9 @@ fn test_validity_vtable() {
         Validity::Array(BoolArray::from_iter(mask_bools.clone()).to_array()),
     );
     let compressed = PcoArray::from_primitive(&array, 3, 0).unwrap();
+    assert_eq!(compressed.validity_mask(), Mask::from_iter(mask_bools));
     assert_eq!(
-        compressed.validity_mask().unwrap(),
-        Mask::from_iter(mask_bools)
-    );
-    assert_eq!(
-        compressed.slice(1..4).validity_mask().unwrap(),
+        compressed.slice(1..4).validity_mask(),
         Mask::from_iter(vec![true, true, false])
     );
 }

--- a/encodings/runend/benches/run_end_null_count.rs
+++ b/encodings/runend/benches/run_end_null_count.rs
@@ -49,7 +49,7 @@ fn null_count_run_end(bencher: Bencher, (n, run_step, valid_density): (usize, us
 
     bencher
         .with_inputs(|| array.clone())
-        .bench_refs(|array| array.invalid_count().unwrap());
+        .bench_refs(|array| array.invalid_count());
 }
 
 fn fixture(n: usize, run_step: usize, valid_density: f64) -> RunEndArray {

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -299,21 +299,21 @@ impl ArrayVTable<RunEndVTable> for RunEndVTable {
 }
 
 impl ValidityVTable<RunEndVTable> for RunEndVTable {
-    fn is_valid(array: &RunEndArray, index: usize) -> VortexResult<bool> {
+    fn is_valid(array: &RunEndArray, index: usize) -> bool {
         let physical_idx = array.find_physical_index(index);
         array.values().is_valid(physical_idx)
     }
 
-    fn all_valid(array: &RunEndArray) -> VortexResult<bool> {
+    fn all_valid(array: &RunEndArray) -> bool {
         array.values().all_valid()
     }
 
-    fn all_invalid(array: &RunEndArray) -> VortexResult<bool> {
+    fn all_invalid(array: &RunEndArray) -> bool {
         array.values().all_invalid()
     }
 
-    fn validity_mask(array: &RunEndArray) -> VortexResult<Mask> {
-        Ok(match array.values().validity_mask()? {
+    fn validity_mask(array: &RunEndArray) -> Mask {
+        match array.values().validity_mask() {
             Mask::AllTrue(_) => Mask::AllTrue(array.len()),
             Mask::AllFalse(_) => Mask::AllFalse(array.len()),
             Mask::Values(values) => {
@@ -328,9 +328,15 @@ impl ValidityVTable<RunEndVTable> for RunEndVTable {
                     )
                     .into_array()
                 };
-                Mask::from_buffer(ree_validity.to_bool()?.boolean_buffer().clone())
+                Mask::from_buffer(
+                    ree_validity
+                        .to_bool()
+                        .vortex_expect("must be a bool array")
+                        .boolean_buffer()
+                        .clone(),
+                )
             }
-        })
+        }
     }
 }
 

--- a/encodings/runend/src/compress.rs
+++ b/encodings/runend/src/compress.rs
@@ -157,7 +157,7 @@ pub fn runend_decode_primitive(
             runend_decode_typed_primitive(
                 trimmed_ends_iter(ends.as_slice::<E>(), offset, length),
                 values.as_slice::<P>(),
-                values.validity_mask()?,
+                values.validity_mask(),
                 values.dtype().nullability(),
                 length,
             )
@@ -175,7 +175,7 @@ pub fn runend_decode_bools(
         runend_decode_typed_bool(
             trimmed_ends_iter(ends.as_slice::<E>(), offset, length),
             values.boolean_buffer().clone(),
-            values.validity_mask()?,
+            values.validity_mask(),
             values.dtype().nullability(),
             length,
         )

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -224,20 +224,20 @@ impl OperationsVTable<SequenceVTable> for SequenceVTable {
 }
 
 impl ValidityVTable<SequenceVTable> for SequenceVTable {
-    fn is_valid(_array: &SequenceArray, _index: usize) -> VortexResult<bool> {
-        Ok(true)
+    fn is_valid(_array: &SequenceArray, _index: usize) -> bool {
+        true
     }
 
-    fn all_valid(_array: &SequenceArray) -> VortexResult<bool> {
-        Ok(true)
+    fn all_valid(_array: &SequenceArray) -> bool {
+        true
     }
 
-    fn all_invalid(_array: &SequenceArray) -> VortexResult<bool> {
-        Ok(false)
+    fn all_invalid(_array: &SequenceArray) -> bool {
+        false
     }
 
-    fn validity_mask(array: &SequenceArray) -> VortexResult<Mask> {
-        Ok(Mask::AllTrue(array.len()))
+    fn validity_mask(array: &SequenceArray) -> Mask {
+        Mask::AllTrue(array.len())
     }
 }
 

--- a/encodings/sequence/src/compress.rs
+++ b/encodings/sequence/src/compress.rs
@@ -22,7 +22,7 @@ pub fn sequence_encode(primitive_array: &PrimitiveArray) -> VortexResult<Option<
         return Ok(None);
     }
 
-    if !primitive_array.all_valid()? {
+    if !primitive_array.all_valid() {
         return Ok(None);
     }
 

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -160,9 +160,7 @@ fn canonicalize_sparse_lists(
     let n_filled = array.len() - resolved_patches.num_patches();
     let total_canonical_values = values.elements().len() + fill_value.len() * n_filled;
 
-    let validity = array
-        .validity_mask()
-        .map(|x| Validity::from_mask(x, nullability))?;
+    let validity = Validity::from_mask(array.validity_mask(), nullability);
 
     match_each_integer_ptype!(indices.ptype(), |I| {
         match_smallest_offset_type!(total_canonical_values, |O| {
@@ -341,7 +339,7 @@ fn canonicalize_sparse_struct(
             unresolved_patches.offset(),
             unresolved_patches.indices(),
             &Validity::from_mask(
-                unresolved_patches.values().validity_mask()?,
+                unresolved_patches.values().validity_mask(),
                 Nullability::Nullable,
             ),
         )?
@@ -403,9 +401,7 @@ fn canonicalize_varbin(
     let patches = array.resolved_patches()?;
     let indices = patches.indices().to_primitive()?;
     let values = patches.values().to_varbinview()?;
-    let validity = array
-        .validity_mask()
-        .map(|x| Validity::from_mask(x, dtype.nullability()))?;
+    let validity = Validity::from_mask(array.validity_mask(), dtype.nullability());
     let len = array.len();
 
     match_each_integer_ptype!(indices.ptype(), |I| {
@@ -507,18 +503,15 @@ mod test {
         assert_eq!(flat_bools.validity(), expected.validity());
 
         assert!(flat_bools.boolean_buffer().value(0));
-        assert!(flat_bools.validity().is_valid(0).unwrap());
+        assert!(flat_bools.validity().is_valid(0));
         assert_eq!(
             flat_bools.boolean_buffer().value(1),
             fill_value.unwrap_or_default()
         );
-        assert!(!flat_bools.validity().is_valid(1).unwrap());
-        assert_eq!(
-            flat_bools.validity().is_valid(2).unwrap(),
-            fill_value.is_some()
-        );
+        assert!(!flat_bools.validity().is_valid(1));
+        assert_eq!(flat_bools.validity().is_valid(2), fill_value.is_some());
         assert!(!flat_bools.boolean_buffer().value(7));
-        assert!(flat_bools.validity().is_valid(7).unwrap());
+        assert!(flat_bools.validity().is_valid(7));
     }
 
     fn bool_array_from_nullable_vec(
@@ -563,19 +556,16 @@ mod test {
         assert_eq!(flat_ints.validity(), expected.validity());
 
         assert_eq!(flat_ints.as_slice::<i32>()[0], 0);
-        assert!(flat_ints.validity().is_valid(0).unwrap());
+        assert!(flat_ints.validity().is_valid(0));
         assert_eq!(flat_ints.as_slice::<i32>()[1], 0);
-        assert!(!flat_ints.validity().is_valid(1).unwrap());
+        assert!(!flat_ints.validity().is_valid(1));
         assert_eq!(
             flat_ints.as_slice::<i32>()[2],
             fill_value.unwrap_or_default()
         );
-        assert_eq!(
-            flat_ints.validity().is_valid(2).unwrap(),
-            fill_value.is_some()
-        );
+        assert_eq!(flat_ints.validity().is_valid(2), fill_value.is_some());
         assert_eq!(flat_ints.as_slice::<i32>()[7], 1);
-        assert!(flat_ints.validity().is_valid(7).unwrap());
+        assert!(flat_ints.validity().is_valid(7));
     }
 
     #[test]

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -156,7 +156,7 @@ impl SparseArray {
                 fill_value.dtype()
             )
         }
-        let mask = array.validity_mask()?;
+        let mask = array.validity_mask();
 
         if mask.all_false() {
             // Array is constant NULL
@@ -251,51 +251,55 @@ impl ArrayVTable<SparseVTable> for SparseVTable {
 }
 
 impl ValidityVTable<SparseVTable> for SparseVTable {
-    fn is_valid(array: &SparseArray, index: usize) -> VortexResult<bool> {
-        Ok(match array.patches().get_patched(index) {
+    fn is_valid(array: &SparseArray, index: usize) -> bool {
+        match array.patches().get_patched(index) {
             None => array.fill_scalar().is_valid(),
             Some(patch_value) => patch_value.is_valid(),
-        })
+        }
     }
 
-    fn all_valid(array: &SparseArray) -> VortexResult<bool> {
+    fn all_valid(array: &SparseArray) -> bool {
         if array.fill_scalar().is_null() {
             // We need _all_ values to be patched, and all patches to be valid
-            return Ok(array.patches().values().len() == array.len()
-                && array.patches().values().all_valid()?);
+            return array.patches().values().len() == array.len()
+                && array.patches().values().all_valid();
         }
 
         array.patches().values().all_valid()
     }
 
-    fn all_invalid(array: &SparseArray) -> VortexResult<bool> {
+    fn all_invalid(array: &SparseArray) -> bool {
         if !array.fill_scalar().is_null() {
             // We need _all_ values to be patched, and all patches to be invalid
-            return Ok(array.patches().values().len() == array.len()
-                && array.patches().values().all_invalid()?);
+            return array.patches().values().len() == array.len()
+                && array.patches().values().all_invalid();
         }
 
         array.patches().values().all_invalid()
     }
 
     #[allow(clippy::unnecessary_fallible_conversions)]
-    fn validity_mask(array: &SparseArray) -> VortexResult<Mask> {
+    fn validity_mask(array: &SparseArray) -> Mask {
         let fill_is_valid = array.fill_scalar().is_valid();
-        let values_validity = array.patches().values().validity_mask()?;
+        let values_validity = array.patches().values().validity_mask();
         let len = array.len();
 
         if matches!(values_validity, Mask::AllTrue(_)) && fill_is_valid {
-            return Ok(Mask::AllTrue(len));
+            return Mask::AllTrue(len);
         }
         if matches!(values_validity, Mask::AllFalse(_)) && !fill_is_valid {
-            return Ok(Mask::AllFalse(len));
+            return Mask::AllFalse(len);
         }
 
         // TODO(ngates): use vortex-buffer::BitBufferMut when it exists.
         let mut is_valid_buffer = BooleanBufferBuilder::new(len);
         is_valid_buffer.append_n(len, fill_is_valid);
 
-        let indices = array.patches().indices().to_primitive()?;
+        let indices = array
+            .patches()
+            .indices()
+            .to_primitive()
+            .vortex_expect("sparse indices must be primitive");
         let index_offset = array.patches().offset();
 
         match_each_integer_ptype!(indices.ptype(), |I| {
@@ -303,7 +307,7 @@ impl ValidityVTable<SparseVTable> for SparseVTable {
             patch_validity(&mut is_valid_buffer, indices, index_offset, values_validity);
         });
 
-        Ok(Mask::from_buffer(is_valid_buffer.finish()))
+        Mask::from_buffer(is_valid_buffer.finish())
     }
 }
 
@@ -415,7 +419,7 @@ mod test {
     pub fn validity_mask_sliced_null_fill() {
         let sliced = sparse_array(nullable_fill()).slice(2..7);
         assert_eq!(
-            sliced.validity_mask().unwrap(),
+            sliced.validity_mask(),
             Mask::from_iter(vec![true, false, false, true, false])
         );
     }
@@ -436,7 +440,7 @@ mod test {
         .slice(2..7);
 
         assert_eq!(
-            sliced.validity_mask().unwrap(),
+            sliced.validity_mask(),
             Mask::from_iter(vec![false, true, true, false, true])
         );
     }
@@ -456,7 +460,6 @@ mod test {
         assert_eq!(
             array
                 .validity_mask()
-                .unwrap()
                 .to_boolean_buffer()
                 .iter()
                 .collect_vec(),
@@ -469,7 +472,7 @@ mod test {
     #[test]
     fn sparse_validity_mask_non_null_fill() {
         let array = sparse_array(non_nullable_fill());
-        assert!(array.validity_mask().unwrap().all_true());
+        assert!(array.validity_mask().all_true());
     }
 
     #[test]
@@ -504,7 +507,7 @@ mod test {
         .vortex_unwrap();
         let canonical = sparse.to_primitive().vortex_unwrap();
         assert_eq!(
-            sparse.validity_mask().unwrap(),
+            sparse.validity_mask(),
             Mask::from_iter(vec![
                 true, true, false, true, false, true, false, true, true, false, true, false,
             ])
@@ -521,7 +524,7 @@ mod test {
         let values = PrimitiveArray::from_option_iter([Some(0i16), Some(1), None, None, Some(4)])
             .into_array();
         let array = SparseArray::try_new(indices, values, 10, Scalar::null_typed::<i16>()).unwrap();
-        let actual = array.validity_mask().unwrap();
+        let actual = array.validity_mask();
         let expected = Mask::from_iter([
             true, false, true, false, false, false, false, false, true, false,
         ]);

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -101,12 +101,12 @@ fn choose_max_dict_size(uncompressed_size: usize) -> usize {
 }
 
 fn collect_valid_primitive(parray: &PrimitiveArray) -> VortexResult<PrimitiveArray> {
-    let mask = parray.validity_mask()?;
+    let mask = parray.validity_mask();
     filter(&parray.to_array(), &mask)?.to_primitive()
 }
 
 fn collect_valid_vbv(vbv: &VarBinViewArray) -> VortexResult<(ByteBuffer, Vec<usize>)> {
-    let mask = vbv.validity_mask()?;
+    let mask = vbv.validity_mask();
     let buffer_and_value_byte_indices = match mask.boolean_buffer() {
         AllOr::None => (Buffer::empty(), Vec::new()),
         _ => {
@@ -375,7 +375,7 @@ impl ZstdArray {
         let slice_n_rows = self.slice_stop - self.slice_start;
         let slice_value_indices = self
             .unsliced_validity
-            .to_mask(self.unsliced_n_rows)?
+            .to_mask(self.unsliced_n_rows)
             .valid_counts_for_indices(&[self.slice_start, self.slice_stop])?;
 
         let slice_value_idx_start = slice_value_indices[0];

--- a/encodings/zstd/src/test.rs
+++ b/encodings/zstd/src/test.rs
@@ -124,12 +124,9 @@ fn test_validity_vtable() {
         Validity::Array(BoolArray::from_iter(mask_bools.clone()).to_array()),
     );
     let compressed = ZstdArray::from_primitive(&array, 3, 0).unwrap();
+    assert_eq!(compressed.validity_mask(), Mask::from_iter(mask_bools));
     assert_eq!(
-        compressed.validity_mask().unwrap(),
-        Mask::from_iter(mask_bools)
-    );
-    assert_eq!(
-        compressed.slice(1..4).validity_mask().unwrap(),
+        compressed.slice(1..4).validity_mask(),
         Mask::from_iter(vec![true, true, false])
     );
 }

--- a/fuzz/fuzz_targets/file_io.rs
+++ b/fuzz/fuzz_targets/file_io.rs
@@ -41,7 +41,7 @@ fuzz_target!(|fuzz: FuzzFileAction| -> Corpus {
             .unwrap_or_else(|| lit(true))
             .evaluate(&Scope::new(array_data.clone()))
             .vortex_unwrap();
-        let mask = Mask::try_from(&bool_mask.to_bool().vortex_unwrap()).vortex_unwrap();
+        let mask = Mask::from(&bool_mask.to_bool().vortex_unwrap());
         let filtered = filter(&array_data, &mask).vortex_unwrap();
         projection_expr
             .clone()
@@ -97,8 +97,7 @@ fuzz_target!(|fuzz: FuzzFileAction| -> Corpus {
             .vortex_unwrap();
         let true_count = bool_result.boolean_buffer().count_set_bits();
         if true_count != expected_array.len()
-            && (bool_result.all_valid().vortex_unwrap()
-                || expected_array.all_valid().vortex_unwrap())
+            && (bool_result.all_valid() || expected_array.all_valid())
         {
             vortex_panic!(
                 "Failed to match original array {}with{}",

--- a/fuzz/src/array/cast.rs
+++ b/fuzz/src/array/cast.rs
@@ -32,7 +32,7 @@ pub fn cast_canonical_array(array: &ArrayRef, target: &DType) -> VortexResult<Op
                         .iter()
                         .map(|v| *v as Out)
                         .collect::<Buffer<Out>>(),
-                    Validity::from_mask(array.validity_mask()?, target.nullability()),
+                    Validity::from_mask(array.validity_mask(), target.nullability()),
                 )
                 .to_array()
             })

--- a/fuzz/src/array/compare.rs
+++ b/fuzz/src/array/compare.rs
@@ -37,7 +37,7 @@ pub fn compare_canonical_array(
                     .to_bool()?
                     .boolean_buffer()
                     .iter()
-                    .zip(array.validity_mask()?.to_boolean_buffer().iter())
+                    .zip(array.validity_mask().to_boolean_buffer().iter())
                     .map(|(b, v)| v.then_some(b)),
                 bool,
                 operator,
@@ -55,7 +55,7 @@ pub fn compare_canonical_array(
                         .as_slice::<P>()
                         .iter()
                         .copied()
-                        .zip(array.validity_mask()?.to_boolean_buffer().iter())
+                        .zip(array.validity_mask().to_boolean_buffer().iter())
                         .map(|(b, v)| v.then_some(b)),
                     pval,
                     operator,
@@ -76,7 +76,7 @@ pub fn compare_canonical_array(
                     buf.as_slice()
                         .iter()
                         .copied()
-                        .zip(array.validity_mask()?.to_boolean_buffer().iter())
+                        .zip(array.validity_mask().to_boolean_buffer().iter())
                         .map(|(b, v)| v.then_some(b)),
                     dval,
                     operator,

--- a/fuzz/src/array/filter.rs
+++ b/fuzz/src/array/filter.rs
@@ -16,7 +16,7 @@ use crate::array::take_canonical_array_non_nullable_indices;
 
 pub fn filter_canonical_array(array: &dyn Array, filter: &[bool]) -> VortexResult<ArrayRef> {
     let validity = if array.dtype().is_nullable() {
-        let validity_buff = array.validity_mask()?.to_boolean_buffer();
+        let validity_buff = array.validity_mask().to_boolean_buffer();
         Validity::from_iter(
             filter
                 .iter()

--- a/fuzz/src/array/search_sorted.rs
+++ b/fuzz/src/array/search_sorted.rs
@@ -55,7 +55,7 @@ pub fn search_sorted_canonical_array(
     match array.dtype() {
         DType::Bool(_) => {
             let bool_array = array.to_bool()?;
-            let validity = bool_array.validity_mask()?.to_boolean_buffer();
+            let validity = bool_array.validity_mask().to_boolean_buffer();
             let opt_values = bool_array
                 .boolean_buffer()
                 .iter()
@@ -67,7 +67,7 @@ pub fn search_sorted_canonical_array(
         }
         DType::Primitive(p, _) => {
             let primitive_array = array.to_primitive()?;
-            let validity = primitive_array.validity_mask()?.to_boolean_buffer();
+            let validity = primitive_array.validity_mask().to_boolean_buffer();
             match_each_native_ptype!(p, |P| {
                 let opt_values = primitive_array
                     .as_slice::<P>()
@@ -82,7 +82,7 @@ pub fn search_sorted_canonical_array(
         }
         DType::Decimal(d, _) => {
             let decimal_array = array.to_decimal()?;
-            let validity = decimal_array.validity_mask()?.to_boolean_buffer();
+            let validity = decimal_array.validity_mask().to_boolean_buffer();
             match_each_decimal_value_type!(decimal_array.values_type(), |D| {
                 let buf = decimal_array.buffer::<D>();
                 let opt_values = buf

--- a/fuzz/src/array/slice.rs
+++ b/fuzz/src/array/slice.rs
@@ -20,7 +20,7 @@ pub fn slice_canonical_array(
     stop: usize,
 ) -> VortexResult<ArrayRef> {
     let validity = if array.dtype().is_nullable() {
-        let bool_buff = array.validity_mask()?.to_boolean_buffer();
+        let bool_buff = array.validity_mask().to_boolean_buffer();
         Validity::from(bool_buff.slice(start, stop - start))
     } else {
         Validity::NonNullable

--- a/fuzz/src/array/sort.rs
+++ b/fuzz/src/array/sort.rs
@@ -19,7 +19,7 @@ pub fn sort_canonical_array(array: &dyn Array) -> VortexResult<ArrayRef> {
             let mut opt_values = bool_array
                 .boolean_buffer()
                 .iter()
-                .zip(bool_array.validity_mask()?.to_boolean_buffer().iter())
+                .zip(bool_array.validity_mask().to_boolean_buffer().iter())
                 .map(|(b, v)| v.then_some(b))
                 .collect::<Vec<_>>();
             opt_values.sort();
@@ -32,7 +32,7 @@ pub fn sort_canonical_array(array: &dyn Array) -> VortexResult<ArrayRef> {
                     .as_slice::<P>()
                     .iter()
                     .copied()
-                    .zip(primitive_array.validity_mask()?.to_boolean_buffer().iter())
+                    .zip(primitive_array.validity_mask().to_boolean_buffer().iter())
                     .map(|(p, v)| v.then_some(p))
                     .collect::<Vec<_>>();
                 sort_primitive_slice(&mut opt_values);
@@ -47,7 +47,7 @@ pub fn sort_canonical_array(array: &dyn Array) -> VortexResult<ArrayRef> {
                     .as_slice()
                     .iter()
                     .copied()
-                    .zip(decimal_array.validity_mask()?.to_boolean_buffer().iter())
+                    .zip(decimal_array.validity_mask().to_boolean_buffer().iter())
                     .map(|(p, v)| v.then_some(p))
                     .collect::<Vec<_>>();
                 opt_values.sort();

--- a/fuzz/src/array/take.rs
+++ b/fuzz/src/array/take.rs
@@ -36,7 +36,7 @@ pub fn take_canonical_array(
     };
 
     let validity = if array.dtype().is_nullable() || nullable == Nullability::Nullable {
-        let validity_idx = array.validity_mask()?.to_boolean_buffer();
+        let validity_idx = array.validity_mask().to_boolean_buffer();
 
         Validity::from_iter(
             indices

--- a/java/testfiles/Cargo.lock
+++ b/java/testfiles/Cargo.lock
@@ -564,18 +564,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "spin",
-]
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,10 +700,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -997,6 +983,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kanal"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3953adf0cd667798b396c2fa13552d6d9b3269d7dd1154c4c416442d1ff574"
+dependencies = [
+ "futures-core",
+ "lock_api",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,15 +1178,6 @@ dependencies = [
  "quote",
  "syn 2.0.106",
  "target-features",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1777,15 +1764,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1847,6 +1825,12 @@ name = "target-features"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1bbb9f3c5c463a01705937a24fdabc5047929ac764b2d5b9cf681c1f5041ed5"
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "testfiles"
@@ -2268,6 +2252,7 @@ dependencies = [
  "parking_lot",
  "paste",
  "prost",
+ "termtree",
  "vortex-array",
  "vortex-buffer",
  "vortex-dtype",
@@ -2369,10 +2354,10 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "cfg-if",
- "flume",
  "futures",
  "futures-util",
  "getrandom 0.3.3",
+ "kanal",
  "pin-project",
  "tokio",
  "tracing",

--- a/vortex-array/src/array/display/mod.rs
+++ b/vortex-array/src/array/display/mod.rs
@@ -270,7 +270,7 @@ impl dyn Array + '_ {
                 builder.push_record(sf.names().iter().map(|name| name.to_string()));
 
                 for row_idx in 0..self.len() {
-                    if !self.is_valid(row_idx).vortex_expect("index in bounds") {
+                    if !self.is_valid(row_idx) {
                         let null_row = vec!["null".to_string(); sf.names().len()];
                         builder.push_record(null_row);
                     } else {
@@ -292,7 +292,7 @@ impl dyn Array + '_ {
                 }
 
                 for row_idx in 0..self.len() {
-                    if !self.is_valid(row_idx).vortex_expect("index is in bounds") {
+                    if !self.is_valid(row_idx) {
                         table.modify(
                             (1 + row_idx, 0),
                             tabled::settings::Span::column(sf.names().len() as isize),

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 pub use visitor::*;
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, Nullability};
-use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
+use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err, vortex_panic};
 use vortex_mask::Mask;
 use vortex_scalar::Scalar;
 
@@ -94,29 +94,29 @@ pub trait Array: 'static + private::Sealed + Send + Sync + Debug + ArrayVisitor 
     }
 
     /// Returns whether the item at `index` is valid.
-    fn is_valid(&self, index: usize) -> VortexResult<bool>;
+    fn is_valid(&self, index: usize) -> bool;
 
     /// Returns whether the item at `index` is invalid.
-    fn is_invalid(&self, index: usize) -> VortexResult<bool>;
+    fn is_invalid(&self, index: usize) -> bool;
 
     /// Returns whether all items in the array are valid.
     ///
     /// This is usually cheaper than computing a precise `valid_count`.
-    fn all_valid(&self) -> VortexResult<bool>;
+    fn all_valid(&self) -> bool;
 
     /// Returns whether the array is all invalid.
     ///
     /// This is usually cheaper than computing a precise `invalid_count`.
-    fn all_invalid(&self) -> VortexResult<bool>;
+    fn all_invalid(&self) -> bool;
 
     /// Returns the number of valid elements in the array.
-    fn valid_count(&self) -> VortexResult<usize>;
+    fn valid_count(&self) -> usize;
 
     /// Returns the number of invalid elements in the array.
-    fn invalid_count(&self) -> VortexResult<usize>;
+    fn invalid_count(&self) -> usize;
 
     /// Returns the canonical validity mask for the array.
-    fn validity_mask(&self) -> VortexResult<Mask>;
+    fn validity_mask(&self) -> Mask;
 
     /// Returns the canonical representation of the array.
     fn to_canonical(&self) -> VortexResult<Canonical>;
@@ -191,31 +191,31 @@ impl Array for Arc<dyn Array> {
         self.as_ref().scalar_at(index)
     }
 
-    fn is_valid(&self, index: usize) -> VortexResult<bool> {
+    fn is_valid(&self, index: usize) -> bool {
         self.as_ref().is_valid(index)
     }
 
-    fn is_invalid(&self, index: usize) -> VortexResult<bool> {
+    fn is_invalid(&self, index: usize) -> bool {
         self.as_ref().is_invalid(index)
     }
 
-    fn all_valid(&self) -> VortexResult<bool> {
+    fn all_valid(&self) -> bool {
         self.as_ref().all_valid()
     }
 
-    fn all_invalid(&self) -> VortexResult<bool> {
+    fn all_invalid(&self) -> bool {
         self.as_ref().all_invalid()
     }
 
-    fn valid_count(&self) -> VortexResult<usize> {
+    fn valid_count(&self) -> usize {
         self.as_ref().valid_count()
     }
 
-    fn invalid_count(&self) -> VortexResult<usize> {
+    fn invalid_count(&self) -> usize {
         self.as_ref().invalid_count()
     }
 
-    fn validity_mask(&self) -> VortexResult<Mask> {
+    fn validity_mask(&self) -> Mask {
         self.as_ref().validity_mask()
     }
 
@@ -449,7 +449,7 @@ impl<V: VTable> Array for ArrayAdapter<V> {
 
     fn scalar_at(&self, index: usize) -> Scalar {
         assert!(index < self.len(), "index {index} out of bounds");
-        if self.is_invalid(index).vortex_expect("index out of bounds") {
+        if self.is_invalid(index) {
             return Scalar::null(self.dtype().clone());
         }
         let scalar = <V::OperationsVTable as OperationsVTable<V>>::scalar_at(&self.0, index);
@@ -457,61 +457,61 @@ impl<V: VTable> Array for ArrayAdapter<V> {
         scalar
     }
 
-    fn is_valid(&self, index: usize) -> VortexResult<bool> {
+    fn is_valid(&self, index: usize) -> bool {
         if index >= self.len() {
-            vortex_bail!(OutOfBounds: index, 0, self.len());
+            vortex_panic!(OutOfBounds: index, 0, self.len());
         }
         <V::ValidityVTable as ValidityVTable<V>>::is_valid(&self.0, index)
     }
 
-    fn is_invalid(&self, index: usize) -> VortexResult<bool> {
-        self.is_valid(index).map(|valid| !valid)
+    fn is_invalid(&self, index: usize) -> bool {
+        !self.is_valid(index)
     }
 
-    fn all_valid(&self) -> VortexResult<bool> {
+    fn all_valid(&self) -> bool {
         <V::ValidityVTable as ValidityVTable<V>>::all_valid(&self.0)
     }
 
-    fn all_invalid(&self) -> VortexResult<bool> {
+    fn all_invalid(&self) -> bool {
         <V::ValidityVTable as ValidityVTable<V>>::all_invalid(&self.0)
     }
 
-    fn valid_count(&self) -> VortexResult<usize> {
+    fn valid_count(&self) -> usize {
         if let Some(Precision::Exact(invalid_count)) =
             self.statistics().get_as::<usize>(Stat::NullCount)
         {
-            return Ok(self.len() - invalid_count);
+            return self.len() - invalid_count;
         }
 
-        let count = <V::ValidityVTable as ValidityVTable<V>>::valid_count(&self.0)?;
+        let count = <V::ValidityVTable as ValidityVTable<V>>::valid_count(&self.0);
         assert!(count <= self.len(), "Valid count exceeds array length");
 
         self.statistics()
             .set(Stat::NullCount, Precision::exact(self.len() - count));
 
-        Ok(count)
+        count
     }
 
-    fn invalid_count(&self) -> VortexResult<usize> {
+    fn invalid_count(&self) -> usize {
         if let Some(Precision::Exact(invalid_count)) =
             self.statistics().get_as::<usize>(Stat::NullCount)
         {
-            return Ok(invalid_count);
+            return invalid_count;
         }
 
-        let count = <V::ValidityVTable as ValidityVTable<V>>::invalid_count(&self.0)?;
+        let count = <V::ValidityVTable as ValidityVTable<V>>::invalid_count(&self.0);
         assert!(count <= self.len(), "Invalid count exceeds array length");
 
         self.statistics()
             .set(Stat::NullCount, Precision::exact(count));
 
-        Ok(count)
+        count
     }
 
-    fn validity_mask(&self) -> VortexResult<Mask> {
-        let mask = <V::ValidityVTable as ValidityVTable<V>>::validity_mask(&self.0)?;
+    fn validity_mask(&self) -> Mask {
+        let mask = <V::ValidityVTable as ValidityVTable<V>>::validity_mask(&self.0);
         assert_eq!(mask.len(), self.len(), "Validity mask length mismatch");
-        Ok(mask)
+        mask
     }
 
     fn to_canonical(&self) -> VortexResult<Canonical> {

--- a/vortex-array/src/arrays/bool/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/bool/compute/is_sorted.rs
@@ -10,7 +10,7 @@ use crate::register_kernel;
 
 impl IsSortedKernel for BoolVTable {
     fn is_sorted(&self, array: &BoolArray) -> VortexResult<bool> {
-        match array.validity_mask()? {
+        match array.validity_mask() {
             Mask::AllFalse(_) => Ok(true),
             Mask::AllTrue(_) => Ok(array.boolean_buffer().iter().is_sorted()),
             Mask::Values(mask_values) => {
@@ -29,7 +29,7 @@ impl IsSortedKernel for BoolVTable {
     }
 
     fn is_strict_sorted(&self, array: &BoolArray) -> VortexResult<bool> {
-        match array.validity_mask()? {
+        match array.validity_mask() {
             Mask::AllFalse(_) => Ok(false),
             Mask::AllTrue(_) => Ok(array.boolean_buffer().iter().is_strict_sorted()),
             Mask::Values(mask_values) => {

--- a/vortex-array/src/arrays/bool/compute/min_max.rs
+++ b/vortex-array/src/arrays/bool/compute/min_max.rs
@@ -13,7 +13,7 @@ use crate::register_kernel;
 
 impl MinMaxKernel for BoolVTable {
     fn min_max(&self, array: &BoolArray) -> VortexResult<Option<MinMaxResult>> {
-        let x = match array.validity_mask()? {
+        let x = match array.validity_mask() {
             Mask::AllTrue(_) => array.boolean_buffer().clone(),
             Mask::AllFalse(_) => return Ok(None),
             Mask::Values(v) => array.boolean_buffer().bitand(v.boolean_buffer()),

--- a/vortex-array/src/arrays/bool/compute/sum.rs
+++ b/vortex-array/src/arrays/bool/compute/sum.rs
@@ -13,7 +13,7 @@ use crate::register_kernel;
 
 impl SumKernel for BoolVTable {
     fn sum(&self, array: &BoolArray) -> VortexResult<Scalar> {
-        let true_count: Option<u64> = match array.validity_mask()?.boolean_buffer() {
+        let true_count: Option<u64> = match array.validity_mask().boolean_buffer() {
             AllOr::All => {
                 // All-valid
                 Some(array.boolean_buffer().count_set_bits() as u64)

--- a/vortex-array/src/arrays/bool/compute/take.rs
+++ b/vortex-array/src/arrays/bool/compute/take.rs
@@ -16,7 +16,7 @@ use crate::{Array, ArrayRef, IntoArray, ToCanonical, register_kernel};
 
 impl TakeKernel for BoolVTable {
     fn take(&self, array: &BoolArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
-        let indices_nulls_zeroed = match indices.validity_mask()? {
+        let indices_nulls_zeroed = match indices.validity_mask() {
             Mask::AllTrue(_) => indices.to_array(),
             Mask::AllFalse(_) => {
                 return Ok(ConstantArray::new(

--- a/vortex-array/src/arrays/bool/ops.rs
+++ b/vortex-array/src/arrays/bool/ops.rs
@@ -51,7 +51,7 @@ mod tests {
         assert_eq!(s.as_bool().value(), Some(true));
 
         let s = sliced_arr.scalar_at(1);
-        assert!(!sliced_arr.is_valid(1).unwrap());
+        assert!(!sliced_arr.is_valid(1));
         assert!(s.is_null());
 
         let s = sliced_arr.scalar_at(2);

--- a/vortex-array/src/arrays/bool/test.rs
+++ b/vortex-array/src/arrays/bool/test.rs
@@ -9,7 +9,7 @@ use crate::arrays::BoolArray;
 impl BoolArray {
     pub fn opt_bool_vec(&self) -> VortexResult<Vec<Option<bool>>> {
         Ok(self
-            .validity_mask()?
+            .validity_mask()
             .to_boolean_buffer()
             .into_iter()
             .zip(self.boolean_buffer().iter())
@@ -18,7 +18,7 @@ impl BoolArray {
     }
 
     pub fn bool_vec(&self) -> VortexResult<Vec<bool>> {
-        self.validity_mask()?
+        self.validity_mask()
             .to_boolean_buffer()
             .into_iter()
             .zip(self.boolean_buffer().iter())

--- a/vortex-array/src/arrays/chunked/array.rs
+++ b/vortex-array/src/arrays/chunked/array.rs
@@ -8,7 +8,6 @@
 use std::fmt::Debug;
 
 use futures_util::stream;
-use itertools::Itertools;
 use vortex_buffer::{Buffer, BufferMut};
 use vortex_dtype::DType;
 use vortex_error::{VortexExpect as _, VortexResult, VortexUnwrap, vortex_bail};
@@ -201,44 +200,40 @@ impl ArrayVTable<ChunkedVTable> for ChunkedVTable {
 }
 
 impl ValidityVTable<ChunkedVTable> for ChunkedVTable {
-    fn is_valid(array: &ChunkedArray, index: usize) -> VortexResult<bool> {
+    fn is_valid(array: &ChunkedArray, index: usize) -> bool {
         if !array.dtype.is_nullable() {
-            return Ok(true);
+            return true;
         }
         let (chunk, offset_in_chunk) = array.find_chunk_idx(index);
         array.chunk(chunk).is_valid(offset_in_chunk)
     }
 
-    fn all_valid(array: &ChunkedArray) -> VortexResult<bool> {
+    fn all_valid(array: &ChunkedArray) -> bool {
         if !array.dtype().is_nullable() {
-            return Ok(true);
+            return true;
         }
         for chunk in array.non_empty_chunks() {
-            if !chunk.all_valid()? {
-                return Ok(false);
+            if !chunk.all_valid() {
+                return false;
             }
         }
-        Ok(true)
+        true
     }
 
-    fn all_invalid(array: &ChunkedArray) -> VortexResult<bool> {
+    fn all_invalid(array: &ChunkedArray) -> bool {
         if !array.dtype().is_nullable() {
-            return Ok(false);
+            return false;
         }
         for chunk in array.non_empty_chunks() {
-            if !chunk.all_invalid()? {
-                return Ok(false);
+            if !chunk.all_invalid() {
+                return false;
             }
         }
-        Ok(true)
+        true
     }
 
-    fn validity_mask(array: &ChunkedArray) -> VortexResult<Mask> {
-        array
-            .chunks()
-            .iter()
-            .map(|a| a.validity_mask())
-            .try_collect()
+    fn validity_mask(array: &ChunkedArray) -> Mask {
+        array.chunks().iter().map(|a| a.validity_mask()).collect()
     }
 }
 
@@ -376,8 +371,8 @@ mod test {
             ChunkedArray::try_new(chunks, DType::Primitive(PType::U64, Nullability::Nullable))?;
 
         // Should be all_valid since all non-empty chunks are all_valid
-        assert!(chunked.all_valid()?);
-        assert!(!chunked.all_invalid()?);
+        assert!(chunked.all_valid());
+        assert!(!chunked.all_invalid());
 
         Ok(())
     }
@@ -396,8 +391,8 @@ mod test {
             ChunkedArray::try_new(chunks, DType::Primitive(PType::U64, Nullability::Nullable))?;
 
         // Should be all_invalid since all non-empty chunks are all_invalid
-        assert!(!chunked.all_valid()?);
-        assert!(chunked.all_invalid()?);
+        assert!(!chunked.all_valid());
+        assert!(chunked.all_invalid());
 
         Ok(())
     }
@@ -416,8 +411,8 @@ mod test {
             ChunkedArray::try_new(chunks, DType::Primitive(PType::U64, Nullability::Nullable))?;
 
         // Should be neither all_valid nor all_invalid
-        assert!(!chunked.all_valid()?);
-        assert!(!chunked.all_invalid()?);
+        assert!(!chunked.all_valid());
+        assert!(!chunked.all_invalid());
 
         Ok(())
     }

--- a/vortex-array/src/arrays/chunked/compute/take.rs
+++ b/vortex-array/src/arrays/chunked/compute/take.rs
@@ -21,7 +21,7 @@ impl TakeKernel for ChunkedVTable {
 
         // TODO(joe): Should we split this implementation based on indices nullability?
         let nullability = indices.dtype().nullability();
-        let indices_mask = indices.validity_mask()?;
+        let indices_mask = indices.validity_mask();
         let indices = indices.as_slice::<u64>();
 
         let mut chunks = Vec::new();

--- a/vortex-array/src/arrays/constant/canonical.rs
+++ b/vortex-array/src/arrays/constant/canonical.rs
@@ -102,7 +102,7 @@ impl CanonicalVTable<ConstantVTable> for ConstantVTable {
                         .map(|s| ConstantArray::new(s, array.len()).into_array())
                         .collect(),
                     None => {
-                        assert!(validity.all_invalid()?);
+                        assert!(validity.all_invalid());
                         struct_dtype
                             .fields()
                             .map(|dt| {
@@ -397,7 +397,7 @@ mod tests {
 
         let struct_array = array.to_struct().unwrap();
         assert_eq!(struct_array.len(), 3);
-        assert_eq!(struct_array.valid_count().unwrap(), 0);
+        assert_eq!(struct_array.valid_count(), 0);
 
         let field = struct_array.field_by_name("non_null_field").unwrap();
 

--- a/vortex-array/src/arrays/constant/compute/take.rs
+++ b/vortex-array/src/arrays/constant/compute/take.rs
@@ -12,7 +12,7 @@ use crate::{Array, ArrayRef, IntoArray, register_kernel};
 
 impl TakeKernel for ConstantVTable {
     fn take(&self, array: &ConstantArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
-        match indices.validity_mask()?.boolean_buffer() {
+        match indices.validity_mask().boolean_buffer() {
             AllOr::All => {
                 let scalar = Scalar::new(
                     array
@@ -86,10 +86,7 @@ mod tests {
             taken.to_primitive().unwrap().as_slice::<i32>(),
             &[42, 42, 42]
         );
-        assert_eq!(
-            taken.validity_mask().unwrap().indices(),
-            AllOr::Some(valid_indices)
-        );
+        assert_eq!(taken.validity_mask().indices(), AllOr::Some(valid_indices));
     }
 
     #[test]
@@ -108,7 +105,7 @@ mod tests {
             taken.to_primitive().unwrap().as_slice::<i32>(),
             &[42, 42, 42]
         );
-        assert_eq!(taken.validity_mask().unwrap().indices(), AllOr::All);
+        assert_eq!(taken.validity_mask().indices(), AllOr::All);
     }
 
     #[rstest]

--- a/vortex-array/src/arrays/constant/mod.rs
+++ b/vortex-array/src/arrays/constant/mod.rs
@@ -6,7 +6,6 @@ use std::ops::Range;
 pub use compute::ConstantOperator;
 use vortex_buffer::ByteBufferMut;
 use vortex_dtype::DType;
-use vortex_error::VortexResult;
 use vortex_mask::Mask;
 use vortex_scalar::Scalar;
 
@@ -103,23 +102,23 @@ impl OperationsVTable<ConstantVTable> for ConstantVTable {
 }
 
 impl ValidityVTable<ConstantVTable> for ConstantVTable {
-    fn is_valid(array: &ConstantArray, _index: usize) -> VortexResult<bool> {
-        Ok(!array.scalar().is_null())
+    fn is_valid(array: &ConstantArray, _index: usize) -> bool {
+        !array.scalar().is_null()
     }
 
-    fn all_valid(array: &ConstantArray) -> VortexResult<bool> {
-        Ok(!array.scalar().is_null())
+    fn all_valid(array: &ConstantArray) -> bool {
+        !array.scalar().is_null()
     }
 
-    fn all_invalid(array: &ConstantArray) -> VortexResult<bool> {
-        Ok(array.scalar().is_null())
+    fn all_invalid(array: &ConstantArray) -> bool {
+        array.scalar().is_null()
     }
 
-    fn validity_mask(array: &ConstantArray) -> VortexResult<Mask> {
-        Ok(match array.scalar().is_null() {
+    fn validity_mask(array: &ConstantArray) -> Mask {
+        match array.scalar().is_null() {
             true => Mask::AllFalse(array.len()),
             false => Mask::AllTrue(array.len()),
-        })
+        }
     }
 }
 

--- a/vortex-array/src/arrays/decimal/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/decimal/compute/is_sorted.rs
@@ -32,7 +32,7 @@ fn compute_is_sorted<T: NativeDecimalType>(array: &DecimalArray, strict: bool) -
 where
     dyn Iterator<Item = T>: IsSortedIteratorExt,
 {
-    match array.validity_mask()? {
+    match array.validity_mask() {
         Mask::AllFalse(_) => Ok(!strict),
         Mask::AllTrue(_) => {
             let buf = array.buffer::<T>();

--- a/vortex-array/src/arrays/decimal/compute/min_max.rs
+++ b/vortex-array/src/arrays/decimal/compute/min_max.rs
@@ -28,7 +28,7 @@ fn compute_min_max_with_validity<D>(array: &DecimalArray) -> VortexResult<Option
 where
     D: Into<DecimalValue> + NativeDecimalType,
 {
-    Ok(match array.validity_mask()? {
+    Ok(match array.validity_mask() {
         Mask::AllTrue(_) => compute_min_max(array.buffer::<D>().iter(), array.dtype()),
         Mask::AllFalse(_) => None,
         Mask::Values(v) => compute_min_max(

--- a/vortex-array/src/arrays/decimal/compute/sum.rs
+++ b/vortex-array/src/arrays/decimal/compute/sum.rs
@@ -35,7 +35,7 @@ impl SumKernel for DecimalVTable {
         let decimal_dtype = array.decimal_dtype();
         let nullability = array.dtype.nullability();
 
-        match array.validity_mask()? {
+        match array.validity_mask() {
             Mask::AllFalse(_) => {
                 vortex_bail!("invalid state, all-null array should be checked by top-level sum fn")
             }

--- a/vortex-array/src/arrays/list/compute/filter.rs
+++ b/vortex-array/src/arrays/list/compute/filter.rs
@@ -20,7 +20,7 @@ impl FilterKernel for ListVTable {
     fn filter(&self, array: &Self::Array, mask: &Mask) -> VortexResult<ArrayRef> {
         let offsets = array.offsets.to_primitive()?;
 
-        match array.validity_mask()? {
+        match array.validity_mask() {
             Mask::AllTrue(_) => {
                 match_each_integer_ptype!(offsets.ptype(), |I| {
                     filter_all_valid::<I>(

--- a/vortex-array/src/arrays/list/compute/take.rs
+++ b/vortex-array/src/arrays/list/compute/take.rs
@@ -25,8 +25,8 @@ impl TakeKernel for ListVTable {
                     array,
                     offsets.as_slice::<O>(),
                     &indices,
-                    array.validity_mask()?,
-                    indices.validity_mask()?,
+                    array.validity_mask(),
+                    indices.validity_mask(),
                 )
             })
         })
@@ -206,7 +206,7 @@ mod test {
 
         let element_dtype: Arc<DType> = Arc::new(I32.into());
 
-        assert!(result.is_valid(0).unwrap());
+        assert!(result.is_valid(0));
         assert_eq!(
             result.scalar_at(0),
             Scalar::list(
@@ -216,9 +216,9 @@ mod test {
             )
         );
 
-        assert!(result.is_invalid(1).unwrap());
+        assert!(result.is_invalid(1));
 
-        assert!(result.is_valid(2).unwrap());
+        assert!(result.is_valid(2));
         assert_eq!(
             result.scalar_at(2),
             Scalar::list(
@@ -228,7 +228,7 @@ mod test {
             )
         );
 
-        assert!(result.is_valid(3).unwrap());
+        assert!(result.is_valid(3));
         assert_eq!(
             result.scalar_at(3),
             Scalar::list(element_dtype, vec![], Nullability::Nullable)
@@ -286,7 +286,7 @@ mod test {
 
         let element_dtype: Arc<DType> = Arc::new(I32.into());
 
-        assert!(result.is_valid(0).unwrap());
+        assert!(result.is_valid(0));
         assert_eq!(
             result.scalar_at(0),
             Scalar::list(
@@ -296,7 +296,7 @@ mod test {
             )
         );
 
-        assert!(result.is_valid(1).unwrap());
+        assert!(result.is_valid(1));
         assert_eq!(
             result.scalar_at(1),
             Scalar::list(
@@ -306,7 +306,7 @@ mod test {
             )
         );
 
-        assert!(result.is_valid(2).unwrap());
+        assert!(result.is_valid(2));
         assert_eq!(
             result.scalar_at(2),
             Scalar::list(element_dtype, vec![], Nullability::NonNullable)

--- a/vortex-array/src/arrays/null/compute/mod.rs
+++ b/vortex-array/src/arrays/null/compute/mod.rs
@@ -78,7 +78,7 @@ mod test {
         let sliced = nulls.slice(0..4).to_null().unwrap();
 
         assert_eq!(sliced.len(), 4);
-        assert!(matches!(sliced.validity_mask().unwrap(), Mask::AllFalse(4)));
+        assert!(matches!(sliced.validity_mask(), Mask::AllFalse(4)));
     }
 
     #[test]
@@ -90,7 +90,7 @@ mod test {
             .unwrap();
 
         assert_eq!(taken.len(), 5);
-        assert!(matches!(taken.validity_mask().unwrap(), Mask::AllFalse(5)));
+        assert!(matches!(taken.validity_mask(), Mask::AllFalse(5)));
     }
 
     #[test]

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -145,19 +145,19 @@ impl OperationsVTable<NullVTable> for NullVTable {
 }
 
 impl ValidityVTable<NullVTable> for NullVTable {
-    fn is_valid(_array: &NullArray, _index: usize) -> VortexResult<bool> {
-        Ok(false)
+    fn is_valid(_array: &NullArray, _index: usize) -> bool {
+        false
     }
 
-    fn all_valid(array: &NullArray) -> VortexResult<bool> {
-        Ok(array.is_empty())
+    fn all_valid(array: &NullArray) -> bool {
+        array.is_empty()
     }
 
-    fn all_invalid(array: &NullArray) -> VortexResult<bool> {
-        Ok(!array.is_empty())
+    fn all_invalid(array: &NullArray) -> bool {
+        !array.is_empty()
     }
 
-    fn validity_mask(array: &NullArray) -> VortexResult<Mask> {
-        Ok(Mask::AllFalse(array.len))
+    fn validity_mask(array: &NullArray) -> Mask {
+        Mask::AllFalse(array.len)
     }
 }

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -25,7 +25,7 @@ impl CastKernel for PrimitiveVTable {
         } else if new_nullability == Nullability::Nullable {
             // from non-nullable to nullable
             array.validity().clone().into_nullable()
-        } else if new_nullability == Nullability::NonNullable && array.validity().all_valid()? {
+        } else if new_nullability == Nullability::NonNullable && array.validity().all_valid() {
             // from nullable but all valid, to non-nullable
             Validity::NonNullable
         } else {

--- a/vortex-array/src/arrays/primitive/compute/fill_null.rs
+++ b/vortex-array/src/arrays/primitive/compute/fill_null.rs
@@ -72,7 +72,7 @@ mod test {
             .to_primitive()
             .unwrap();
         assert_eq!(p.as_slice::<u8>(), vec![42, 8, 42, 10, 42]);
-        assert!(p.validity_mask().unwrap().all_true());
+        assert!(p.validity_mask().all_true());
     }
 
     #[test]
@@ -84,7 +84,7 @@ mod test {
             .to_primitive()
             .unwrap();
         assert_eq!(p.as_slice::<u8>(), vec![255, 255, 255, 255, 255]);
-        assert!(p.validity_mask().unwrap().all_true());
+        assert!(p.validity_mask().all_true());
     }
 
     #[test]
@@ -98,7 +98,7 @@ mod test {
             .to_primitive()
             .unwrap();
         assert_eq!(p.as_slice::<u8>(), vec![8, 10, 12, 14, 16]);
-        assert!(p.validity_mask().unwrap().all_true());
+        assert!(p.validity_mask().all_true());
     }
 
     #[test]
@@ -109,6 +109,6 @@ mod test {
             .to_primitive()
             .unwrap();
         assert_eq!(p.as_slice::<u8>(), vec![8u8, 10, 12, 14, 16]);
-        assert!(p.validity_mask().unwrap().all_true());
+        assert!(p.validity_mask().all_true());
     }
 }

--- a/vortex-array/src/arrays/primitive/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/primitive/compute/is_sorted.rs
@@ -53,7 +53,7 @@ where
 }
 
 fn compute_is_sorted<T: NativePType>(array: &PrimitiveArray, strict: bool) -> VortexResult<bool> {
-    match array.validity_mask()? {
+    match array.validity_mask() {
         Mask::AllFalse(_) => Ok(!strict),
         Mask::AllTrue(_) => {
             let slice = array.as_slice::<T>();

--- a/vortex-array/src/arrays/primitive/compute/min_max.rs
+++ b/vortex-array/src/arrays/primitive/compute/min_max.rs
@@ -26,7 +26,7 @@ fn compute_min_max_with_validity<T>(array: &PrimitiveArray) -> VortexResult<Opti
 where
     T: Into<ScalarValue> + NativePType,
 {
-    Ok(match array.validity_mask()? {
+    Ok(match array.validity_mask() {
         Mask::AllTrue(_) => compute_min_max(array.as_slice::<T>().iter(), array.dtype()),
         Mask::AllFalse(_) => None,
         Mask::Values(v) => compute_min_max(

--- a/vortex-array/src/arrays/primitive/compute/nan_count.rs
+++ b/vortex-array/src/arrays/primitive/compute/nan_count.rs
@@ -12,7 +12,7 @@ use crate::register_kernel;
 impl NaNCountKernel for PrimitiveVTable {
     fn nan_count(&self, array: &PrimitiveArray) -> VortexResult<usize> {
         Ok(match_each_float_ptype!(array.ptype(), |F| {
-            compute_nan_count_with_validity(array.as_slice::<F>(), array.validity_mask()?)
+            compute_nan_count_with_validity(array.as_slice::<F>(), array.validity_mask())
         }))
     }
 }

--- a/vortex-array/src/arrays/primitive/compute/pipeline.rs
+++ b/vortex-array/src/arrays/primitive/compute/pipeline.rs
@@ -17,7 +17,7 @@ use crate::vtable::ValidityHelper;
 
 impl PipelineVTable<PrimitiveVTable> for PrimitiveVTable {
     fn to_operator(array: &PrimitiveArray) -> VortexResult<Option<Rc<dyn Operator>>> {
-        if !array.validity().all_valid()? {
+        if !array.validity().all_valid() {
             vortex_bail!(
                 "PipelineVTable::to_operator is not supported for arrays with invalid values"
             );

--- a/vortex-array/src/arrays/primitive/compute/sum.rs
+++ b/vortex-array/src/arrays/primitive/compute/sum.rs
@@ -16,7 +16,7 @@ use crate::stats::Stat;
 
 impl SumKernel for PrimitiveVTable {
     fn sum(&self, array: &PrimitiveArray) -> VortexResult<Scalar> {
-        Ok(match array.validity_mask()?.boolean_buffer() {
+        Ok(match array.validity_mask().boolean_buffer() {
             AllOr::All => {
                 // All-valid
                 match_each_native_ptype!(

--- a/vortex-array/src/arrays/primitive/top_value.rs
+++ b/vortex-array/src/arrays/primitive/top_value.rs
@@ -19,12 +19,12 @@ impl PrimitiveArray {
             return Ok(None);
         }
 
-        if self.all_invalid()? {
+        if self.all_invalid() {
             return Ok(None);
         }
 
         match_each_native_ptype!(self.ptype(), |P| {
-            let (top, count) = typed_top_value(self.as_slice::<P>(), self.validity_mask()?);
+            let (top, count) = typed_top_value(self.as_slice::<P>(), self.validity_mask());
             Ok(Some((top.into(), count)))
         })
     }

--- a/vortex-array/src/arrays/varbin/canonical.rs
+++ b/vortex-array/src/arrays/varbin/canonical.rs
@@ -74,8 +74,8 @@ mod test {
         let canonical = varbin.to_varbinview().unwrap();
         assert_eq!(canonical.dtype(), &dtype);
 
-        assert!(!canonical.is_valid(0).unwrap());
-        assert!(!canonical.is_valid(1).unwrap());
+        assert!(!canonical.is_valid(0));
+        assert!(!canonical.is_valid(1));
 
         // First value is inlined (12 bytes)
         assert!(canonical.views()[2].is_inlined());

--- a/vortex-array/src/arrays/varbin/compute/compare.rs
+++ b/vortex-array/src/arrays/varbin/compute/compare.rs
@@ -150,7 +150,7 @@ mod test {
         .unwrap();
 
         assert_eq!(
-            &result.validity_mask().unwrap().to_boolean_buffer(),
+            &result.validity_mask().to_boolean_buffer(),
             &BooleanBuffer::from_iter([true, false, true])
         );
         assert_eq!(
@@ -175,7 +175,7 @@ mod test {
             .unwrap();
 
         assert_eq!(
-            &result.validity_mask().unwrap().to_boolean_buffer(),
+            &result.validity_mask().to_boolean_buffer(),
             &BooleanBuffer::from_iter([false, false, true])
         );
         assert_eq!(

--- a/vortex-array/src/arrays/varbin/compute/filter.rs
+++ b/vortex-array/src/arrays/varbin/compute/filter.rs
@@ -48,7 +48,7 @@ fn filter_select_var_bin_by_slice(
             offsets.as_slice::<O>(),
             values.bytes().as_slice(),
             mask_slices,
-            values.validity_mask()?,
+            values.validity_mask(),
             selection_count,
         )
     })
@@ -163,7 +163,7 @@ fn filter_select_var_bin_by_index_primitive_offset<O: NativePType + PrimInt>(
 ) -> VortexResult<VarBinArray> {
     let mut builder = VarBinBuilder::<O>::with_capacity(selection_count);
     for idx in mask_indices.iter().copied() {
-        if validity.is_valid(idx)? {
+        if validity.is_valid(idx) {
             let (start, end) = (
                 offsets[idx].to_usize().ok_or_else(|| {
                     vortex_err!("Failed to convert offset to usize: {}", offsets[idx])

--- a/vortex-array/src/arrays/varbin/compute/take.rs
+++ b/vortex-array/src/arrays/varbin/compute/take.rs
@@ -29,8 +29,8 @@ impl TakeKernel for VarBinVTable {
                     offsets.as_slice::<O>(),
                     data.as_slice(),
                     indices.as_slice::<I>(),
-                    array.validity_mask()?,
-                    indices.validity_mask()?,
+                    array.validity_mask(),
+                    indices.validity_mask(),
                 )?
                 .into_array())
             })

--- a/vortex-array/src/arrays/varbinview/compact.rs
+++ b/vortex-array/src/arrays/varbinview/compact.rs
@@ -4,7 +4,7 @@
 //! Defines a compaction operation for VarBinViewArrays that evicts unused buffers so they can
 //! be dropped.
 
-use vortex_error::{VortexResult, VortexUnwrap};
+use vortex_error::VortexResult;
 
 use crate::arrays::VarBinViewArray;
 use crate::builders::{ArrayBuilder, VarBinViewBuilder};
@@ -68,7 +68,7 @@ impl VarBinViewArray {
                 .iter()
                 .enumerate()
                 .map(|(idx, &view)| {
-                    if !self.is_valid(idx).vortex_unwrap() || view.is_inlined() {
+                    if !self.is_valid(idx) || view.is_inlined() {
                         0u64
                     } else {
                         view.len() as u64
@@ -84,7 +84,7 @@ impl VarBinViewArray {
 fn rebuild_nullable(array: &VarBinViewArray) -> VortexResult<VarBinViewArray> {
     let mut builder = VarBinViewBuilder::with_capacity(array.dtype().clone(), array.len());
     for i in 0..array.len() {
-        if !array.is_valid(i)? {
+        if !array.is_valid(i) {
             builder.append_null();
         } else {
             let bytes = array.bytes_at(i);

--- a/vortex-array/src/arrays/varbinview/mod.rs
+++ b/vortex-array/src/arrays/varbinview/mod.rs
@@ -417,7 +417,7 @@ impl VarBinViewArray {
         F: Fn(&[u8]) -> bool,
     {
         for (idx, &view) in views.iter().enumerate() {
-            if validity.is_null(idx)? {
+            if validity.is_null(idx) {
                 continue;
             }
 

--- a/vortex-array/src/arrow/array.rs
+++ b/vortex-array/src/arrow/array.rs
@@ -110,24 +110,24 @@ impl OperationsVTable<ArrowVTable> for ArrowVTable {
 }
 
 impl ValidityVTable<ArrowVTable> for ArrowVTable {
-    fn is_valid(array: &ArrowArray, index: usize) -> VortexResult<bool> {
-        Ok(array.inner.is_valid(index))
+    fn is_valid(array: &ArrowArray, index: usize) -> bool {
+        array.inner.is_valid(index)
     }
 
-    fn all_valid(array: &ArrowArray) -> VortexResult<bool> {
-        Ok(array.inner.logical_null_count() == 0)
+    fn all_valid(array: &ArrowArray) -> bool {
+        array.inner.logical_null_count() == 0
     }
 
-    fn all_invalid(array: &ArrowArray) -> VortexResult<bool> {
-        Ok(array.inner.logical_null_count() == array.inner.len())
+    fn all_invalid(array: &ArrowArray) -> bool {
+        array.inner.logical_null_count() == array.inner.len()
     }
 
-    fn validity_mask(array: &ArrowArray) -> VortexResult<Mask> {
-        Ok(array
+    fn validity_mask(array: &ArrowArray) -> Mask {
+        array
             .inner
             .logical_nulls()
             .map(|null_buffer| Mask::from_buffer(null_buffer.inner().clone()))
-            .unwrap_or_else(|| Mask::new_true(array.inner.len())))
+            .unwrap_or_else(|| Mask::new_true(array.inner.len()))
     }
 }
 

--- a/vortex-array/src/arrow/compute/to_arrow/canonical.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/canonical.rs
@@ -200,12 +200,12 @@ fn to_arrow_null(array: NullArray) -> VortexResult<ArrowArrayRef> {
 fn to_arrow_bool(array: BoolArray) -> VortexResult<ArrowArrayRef> {
     Ok(Arc::new(ArrowBoolArray::new(
         array.boolean_buffer().clone(),
-        array.validity_mask()?.to_null_buffer(),
+        array.validity_mask().to_null_buffer(),
     )))
 }
 
 fn to_arrow_primitive<T: ArrowPrimitiveType>(array: PrimitiveArray) -> VortexResult<ArrowArrayRef> {
-    let null_buffer = array.validity_mask()?.to_null_buffer();
+    let null_buffer = array.validity_mask().to_null_buffer();
     let len = array.len();
     let buffer = array.into_byte_buffer().into_arrow_buffer();
     Ok(Arc::new(ArrowPrimitiveArray::<T>::new(
@@ -215,7 +215,7 @@ fn to_arrow_primitive<T: ArrowPrimitiveType>(array: PrimitiveArray) -> VortexRes
 }
 
 fn to_arrow_decimal128(array: DecimalArray) -> VortexResult<ArrowArrayRef> {
-    let null_buffer = array.validity_mask()?.to_null_buffer();
+    let null_buffer = array.validity_mask().to_null_buffer();
     let buffer: Buffer<i128> = match array.values_type() {
         DecimalValueType::I8 => {
             Buffer::from_trusted_len_iter(array.buffer::<i8>().into_iter().map(|x| x.as_()))
@@ -250,7 +250,7 @@ fn to_arrow_decimal128(array: DecimalArray) -> VortexResult<ArrowArrayRef> {
 }
 
 fn to_arrow_decimal256(array: DecimalArray) -> VortexResult<ArrowArrayRef> {
-    let null_buffer = array.validity_mask()?.to_null_buffer();
+    let null_buffer = array.validity_mask().to_null_buffer();
     let buffer: Buffer<i256> = match array.values_type() {
         DecimalValueType::I8 => {
             Buffer::from_trusted_len_iter(array.buffer::<i8>().into_iter().map(|x| x.as_()))
@@ -302,7 +302,7 @@ fn to_arrow_struct(
             // We check that the Vortex array nullability is compatible with the field
             // nullability. In other words, make sure we don't return any nulls for a
             // non-nullable field.
-            if arr.dtype().is_nullable() && !field.is_nullable() && !arr.all_valid()? {
+            if arr.dtype().is_nullable() && !field.is_nullable() && !arr.all_valid() {
                 vortex_bail!(
                     "Field {} is non-nullable but has nulls {}",
                     field,
@@ -319,7 +319,7 @@ fn to_arrow_struct(
         })
         .collect::<VortexResult<Vec<_>>>()?;
 
-    let nulls = array.validity_mask()?.to_null_buffer();
+    let nulls = array.validity_mask().to_null_buffer();
 
     if field_arrays.is_empty() {
         return Ok(Arc::new(ArrowStructArray::new_empty_fields(
@@ -366,7 +366,7 @@ fn to_arrow_list<O: NativePType + OffsetSizeTrait>(
     } else {
         array.elements().clone().into_arrow(element.data_type())?
     };
-    let nulls = array.validity_mask()?.to_null_buffer();
+    let nulls = array.validity_mask().to_null_buffer();
 
     Ok(Arc::new(GenericListArray::new(
         element.clone(),
@@ -384,10 +384,7 @@ fn to_arrow_varbinview<T: ByteViewType>(array: VarBinViewArray) -> VortexResult<
         .iter()
         .map(|buffer| buffer.clone().into_arrow_buffer())
         .collect();
-    let nulls = array
-        .validity_mask()
-        .vortex_expect("VarBinViewArray: failed to get logical validity")
-        .to_null_buffer();
+    let nulls = array.validity_mask().to_null_buffer();
 
     // SAFETY: our own VarBinView array is considered safe.
     Ok(Arc::new(unsafe {

--- a/vortex-array/src/arrow/compute/to_arrow/temporal.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/temporal.rs
@@ -108,7 +108,7 @@ where
         .to_primitive()?
         .into_buffer()
         .into_arrow_scalar_buffer();
-    let nulls = array.temporal_values().validity_mask()?.to_null_buffer();
+    let nulls = array.temporal_values().validity_mask().to_null_buffer();
     Ok(ArrowPrimitiveArray::<T>::new(values, nulls))
 }
 

--- a/vortex-array/src/arrow/compute/to_arrow/varbin.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/varbin.rs
@@ -74,7 +74,7 @@ fn to_arrow<O: NativePType + OffsetSizeTrait>(array: &VarBinArray) -> VortexResu
     .to_primitive()
     .map_err(|err| err.with_context("Failed to canonicalize offsets"))?;
 
-    let nulls = array.validity_mask()?.to_null_buffer();
+    let nulls = array.validity_mask().to_null_buffer();
     let data = array.bytes().clone();
 
     // Match on the `DType`.

--- a/vortex-array/src/builders/bool.rs
+++ b/vortex-array/src/builders/bool.rs
@@ -84,7 +84,7 @@ impl ArrayBuilder for BoolBuilder {
         };
 
         self.inner.append_buffer(array.boolean_buffer());
-        self.nulls.append_validity_mask(array.validity_mask()?);
+        self.nulls.append_validity_mask(array.validity_mask());
 
         Ok(())
     }

--- a/vortex-array/src/builders/decimal.rs
+++ b/vortex-array/src/builders/decimal.rs
@@ -259,7 +259,7 @@ impl ArrayBuilder for DecimalBuilder {
             self.extend_from_buffer(&array.buffer::<D>())
         });
 
-        self.extend_with_validity_mask(array.validity_mask()?);
+        self.extend_with_validity_mask(array.validity_mask());
 
         Ok(())
     }

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -178,7 +178,7 @@ impl<O: OffsetPType> ArrayBuilder for ListBuilder<O> {
         let last_offset = usize::try_from(&last_offset)?;
         let non_junk_values = elements.slice(n_leading_junk_values..last_offset);
 
-        self.nulls.append_validity_mask(array.validity_mask()?);
+        self.nulls.append_validity_mask(array.validity_mask());
         self.index_builder
             .extend_from_array(&offsets_into_builder)?;
         self.value_builder.ensure_capacity(non_junk_values.len());

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -154,7 +154,7 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
 
         self.values.extend_from_slice(array.as_slice::<T>());
 
-        self.extend_with_validity_mask(array.validity_mask()?);
+        self.extend_with_validity_mask(array.validity_mask());
 
         Ok(())
     }

--- a/vortex-array/src/builders/struct_.rs
+++ b/vortex-array/src/builders/struct_.rs
@@ -115,7 +115,7 @@ impl ArrayBuilder for StructBuilder {
             a.append_to_builder(builder.as_mut())?;
         }
 
-        self.validity.append_validity_mask(array.validity_mask()?);
+        self.validity.append_validity_mask(array.validity_mask());
         Ok(())
     }
 

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -236,7 +236,7 @@ impl ArrayBuilder for VarBinViewBuilder {
             }
         }
 
-        self.push_only_validity_mask(array.validity_mask()?);
+        self.push_only_validity_mask(array.validity_mask());
 
         Ok(())
     }

--- a/vortex-array/src/compute/between.rs
+++ b/vortex-array/src/compute/between.rs
@@ -104,7 +104,7 @@ impl ComputeFnVTable for Between {
 
         // A quick check to see if either array might is a null constant array.
         // Note: Depends on returning early if array is empty for is_invalid check.
-        if (lower.is_invalid(0)? || upper.is_invalid(0)?)
+        if (lower.is_invalid(0) || upper.is_invalid(0))
             && let (Some(c_lower), Some(c_upper)) = (lower.as_constant(), upper.as_constant())
             && (c_lower.is_null() || c_upper.is_null())
         {

--- a/vortex-array/src/compute/conformance/cast.rs
+++ b/vortex-array/src/compute/conformance/cast.rs
@@ -204,9 +204,7 @@ fn test_cast_allvalid_to_nonnullable_and_back(array: &dyn Array) {
     }
 
     // Only test if array has no nulls
-    if let Ok(null_count) = array.invalid_count()
-        && null_count == 0
-    {
+    if array.invalid_count() == 0 {
         // Test casting to NonNullable if currently Nullable
         if array.dtype().nullability() == Nullability::Nullable {
             let non_nullable_dtype = array.dtype().with_nullability(Nullability::NonNullable);

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -46,7 +46,7 @@ fn test_filter_take_consistency(array: &dyn Array) {
 
     // Create a test mask (keep elements where index % 3 != 1)
     let mask_pattern: Vec<bool> = (0..len).map(|i| i % 3 != 1).collect();
-    let mask = Mask::try_from(&BoolArray::from_iter(mask_pattern.clone())).vortex_unwrap();
+    let mask = Mask::from(&BoolArray::from_iter(mask_pattern.clone()));
 
     // Filter the array
     let filtered = filter(array, &mask).vortex_unwrap();
@@ -108,8 +108,8 @@ fn test_double_mask_consistency(array: &dyn Array) {
     let mask1_pattern: Vec<bool> = (0..len).map(|i| i % 3 == 0).collect();
     let mask2_pattern: Vec<bool> = (0..len).map(|i| i % 2 == 0).collect();
 
-    let mask1 = Mask::try_from(&BoolArray::from_iter(mask1_pattern.clone())).vortex_unwrap();
-    let mask2 = Mask::try_from(&BoolArray::from_iter(mask2_pattern.clone())).vortex_unwrap();
+    let mask1 = Mask::from(&BoolArray::from_iter(mask1_pattern.clone()));
+    let mask2 = Mask::from(&BoolArray::from_iter(mask2_pattern.clone()));
 
     // Apply masks sequentially
     let first_masked = mask(array, &mask1).vortex_unwrap();
@@ -121,7 +121,7 @@ fn test_double_mask_consistency(array: &dyn Array) {
         .zip(mask2_pattern.iter())
         .map(|(&a, &b)| a || b)
         .collect();
-    let combined_mask = Mask::try_from(&BoolArray::from_iter(combined_pattern)).vortex_unwrap();
+    let combined_mask = Mask::from(&BoolArray::from_iter(combined_pattern));
 
     // Apply combined mask directly
     let directly_masked = mask(array, &combined_mask).vortex_unwrap();
@@ -265,7 +265,7 @@ fn test_slice_filter_consistency(array: &dyn Array) {
     let mut mask_pattern = vec![false; len];
     mask_pattern[1..4.min(len)].fill(true);
 
-    let mask = Mask::try_from(&BoolArray::from_iter(mask_pattern)).vortex_unwrap();
+    let mask = Mask::from(&BoolArray::from_iter(mask_pattern));
     let filtered = filter(array, &mask).vortex_unwrap();
 
     // Slice should produce the same result
@@ -347,7 +347,7 @@ fn test_filter_preserves_order(array: &dyn Array) {
 
     // Create a mask that selects elements at indices 0, 2, 3
     let mask_pattern: Vec<bool> = (0..len).map(|i| i == 0 || i == 2 || i == 3).collect();
-    let mask = Mask::try_from(&BoolArray::from_iter(mask_pattern)).vortex_unwrap();
+    let mask = Mask::from(&BoolArray::from_iter(mask_pattern));
 
     let filtered = filter(array, &mask).vortex_unwrap();
 
@@ -386,12 +386,12 @@ fn test_mask_filter_null_consistency(array: &dyn Array) {
 
     // First mask some elements
     let mask_pattern: Vec<bool> = (0..len).map(|i| i % 2 == 0).collect();
-    let mask_array = Mask::try_from(&BoolArray::from_iter(mask_pattern)).vortex_unwrap();
+    let mask_array = Mask::from(&BoolArray::from_iter(mask_pattern));
     let masked = mask(array, &mask_array).vortex_unwrap();
 
     // Then filter to remove the nulls
     let filter_pattern: Vec<bool> = (0..len).map(|i| i % 2 != 0).collect();
-    let filter_mask = Mask::try_from(&BoolArray::from_iter(filter_pattern)).vortex_unwrap();
+    let filter_mask = Mask::from(&BoolArray::from_iter(filter_pattern));
     let filtered = filter(&masked, &filter_mask).vortex_unwrap();
 
     // This should be equivalent to directly filtering the original array
@@ -527,7 +527,7 @@ fn test_large_array_consistency(array: &dyn Array) {
 
     // Create equivalent filter mask
     let mask_pattern: Vec<bool> = (0..len).map(|i| i % 10 == 0).collect();
-    let mask = Mask::try_from(&BoolArray::from_iter(mask_pattern)).vortex_unwrap();
+    let mask = Mask::from(&BoolArray::from_iter(mask_pattern));
     let filtered = filter(array, &mask).vortex_unwrap();
 
     // Results should match
@@ -811,15 +811,14 @@ fn test_slice_aggregate_consistency(array: &dyn Array) {
     let canonical_sliced = canonical.as_ref().slice(start..end);
 
     // Test null count through invalid_count
-    if let (Ok(slice_null_count), Ok(canonical_null_count)) =
-        (sliced.invalid_count(), canonical_sliced.invalid_count())
-    {
-        assert_eq!(
-            slice_null_count, canonical_null_count,
-            "null_count on sliced array should match canonical. \
-             Sliced: {slice_null_count}, Canonical: {canonical_null_count}"
-        );
-    }
+    assert_eq!(
+        sliced.invalid_count(),
+        canonical_sliced.invalid_count(),
+        "null_count on sliced array should match canonical. \
+             Sliced: {}, Canonical: {}",
+        sliced.invalid_count(),
+        canonical_sliced.invalid_count()
+    );
 
     // Test sum for numeric types
     if !matches!(array.dtype(), DType::Primitive(..)) {

--- a/vortex-array/src/compute/conformance/filter.rs
+++ b/vortex-array/src/compute/conformance/filter.rs
@@ -93,7 +93,7 @@ fn test_selective_filter(array: &dyn Array) {
     // Test alternating pattern
     let mask_values: Vec<bool> = (0..len).map(|i| i % 2 == 0).collect();
     let expected_count = mask_values.iter().filter(|&&v| v).count();
-    let mask = Mask::try_from(&BoolArray::from_iter(mask_values)).vortex_unwrap();
+    let mask = Mask::from(&BoolArray::from_iter(mask_values));
     let filtered = filter(array, &mask).vortex_unwrap();
     assert_eq!(filtered.len(), expected_count);
 
@@ -107,7 +107,7 @@ fn test_selective_filter(array: &dyn Array) {
         let mut mask_values = vec![false; len];
         mask_values[0] = true;
         mask_values[len - 1] = true;
-        let mask = Mask::try_from(&BoolArray::from_iter(mask_values)).vortex_unwrap();
+        let mask = Mask::from(&BoolArray::from_iter(mask_values));
         let filtered = filter(array, &mask).vortex_unwrap();
         assert_eq!(filtered.len(), 2);
         assert_eq!(filtered.scalar_at(0), array.scalar_at(0));
@@ -124,7 +124,7 @@ fn test_single_element_filter(array: &dyn Array) {
     // Test selecting only the first element
     let mut mask_values = vec![false; len];
     mask_values[0] = true;
-    let mask = Mask::try_from(&BoolArray::from_iter(mask_values)).vortex_unwrap();
+    let mask = Mask::from(&BoolArray::from_iter(mask_values));
     let filtered = filter(array, &mask).vortex_unwrap();
     assert_eq!(filtered.len(), 1);
     assert_eq!(filtered.scalar_at(0), array.scalar_at(0));
@@ -133,7 +133,7 @@ fn test_single_element_filter(array: &dyn Array) {
     if len > 1 {
         let mut mask_values = vec![false; len];
         mask_values[len - 1] = true;
-        let mask = Mask::try_from(&BoolArray::from_iter(mask_values)).vortex_unwrap();
+        let mask = Mask::from(&BoolArray::from_iter(mask_values));
         let filtered = filter(array, &mask).vortex_unwrap();
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered.scalar_at(0), array.scalar_at(len - 1));
@@ -160,7 +160,7 @@ fn test_nullable_filter(array: &dyn Array) {
     let validity = crate::validity::Validity::from_iter(validity_values.clone());
     let nullable_mask = BoolArray::new(bool_array.boolean_buffer().clone(), validity);
 
-    let mask = Mask::try_from(&nullable_mask).vortex_unwrap();
+    let mask = Mask::from(&nullable_mask);
     let filtered = filter(array, &mask).vortex_unwrap();
     assert_eq!(filtered.len(), expected_count);
 
@@ -215,7 +215,7 @@ fn test_alternating_pattern_filter(array: &dyn Array) {
     let pattern = create_alternating_pattern(len);
     let expected_count = pattern.iter().filter(|&&v| v).count();
 
-    let mask = Mask::try_from(&BoolArray::from_iter(pattern.clone())).vortex_unwrap();
+    let mask = Mask::from(&BoolArray::from_iter(pattern.clone()));
     let filtered = filter(array, &mask).vortex_unwrap();
     assert_eq!(filtered.len(), expected_count);
 
@@ -240,7 +240,7 @@ fn test_runs_pattern_filter(array: &dyn Array) {
     let pattern = create_runs_pattern(len, run_length);
     let expected_count = pattern.iter().filter(|&&v| v).count();
 
-    let mask = Mask::try_from(&BoolArray::from_iter(pattern)).vortex_unwrap();
+    let mask = Mask::from(&BoolArray::from_iter(pattern));
     let filtered = filter(array, &mask).vortex_unwrap();
     assert_eq!(filtered.len(), expected_count);
 }
@@ -256,7 +256,7 @@ fn test_sparse_true_filter(array: &dyn Array) {
     let pattern = create_sparse_pattern(len, 0.1);
     let expected_count = pattern.iter().filter(|&&v| v).count();
 
-    let mask = Mask::try_from(&BoolArray::from_iter(pattern)).vortex_unwrap();
+    let mask = Mask::from(&BoolArray::from_iter(pattern));
     let filtered = filter(array, &mask).vortex_unwrap();
     assert_eq!(filtered.len(), expected_count);
 }
@@ -272,7 +272,7 @@ fn test_sparse_false_filter(array: &dyn Array) {
     let pattern = create_sparse_pattern(len, 0.9);
     let expected_count = pattern.iter().filter(|&&v| v).count();
 
-    let mask = Mask::try_from(&BoolArray::from_iter(pattern)).vortex_unwrap();
+    let mask = Mask::from(&BoolArray::from_iter(pattern));
     let filtered = filter(array, &mask).vortex_unwrap();
     assert_eq!(filtered.len(), expected_count);
 }
@@ -287,7 +287,7 @@ fn test_random_pattern_filter(array: &dyn Array) {
         .collect();
     let expected_count = pattern.iter().filter(|&&v| v).count();
 
-    let mask = Mask::try_from(&BoolArray::from_iter(pattern)).vortex_unwrap();
+    let mask = Mask::from(&BoolArray::from_iter(pattern));
     let filtered = filter(array, &mask).vortex_unwrap();
     assert_eq!(filtered.len(), expected_count);
 }
@@ -314,7 +314,7 @@ fn test_nullable_mask_input(array: &dyn Array) {
     let validity = crate::validity::Validity::from_iter(validity_values.clone());
     let nullable_mask = BoolArray::new(bool_array.boolean_buffer().clone(), validity);
 
-    let mask = Mask::try_from(&nullable_mask).vortex_unwrap();
+    let mask = Mask::from(&nullable_mask);
     let filtered = filter(array, &mask).vortex_unwrap();
     assert_eq!(filtered.len(), expected_count);
 

--- a/vortex-array/src/compute/conformance/mask.rs
+++ b/vortex-array/src/compute/conformance/mask.rs
@@ -37,7 +37,7 @@ fn test_heterogenous_mask(array: &dyn Array) {
 
     // Create a pattern where roughly half the values are masked
     let mask_pattern: Vec<bool> = (0..len).map(|i| i % 3 != 1).collect();
-    let mask_array = Mask::try_from(&BoolArray::from_iter(mask_pattern.clone())).vortex_unwrap();
+    let mask_array = Mask::from(&BoolArray::from_iter(mask_pattern.clone()));
 
     let masked = mask(array, &mask_array).vortex_unwrap();
     assert_eq!(masked.len(), array.len());
@@ -45,7 +45,7 @@ fn test_heterogenous_mask(array: &dyn Array) {
     // Verify masked elements are null and unmasked elements are preserved
     for (i, &masked_out) in mask_pattern.iter().enumerate() {
         if masked_out {
-            assert!(!masked.is_valid(i).vortex_unwrap());
+            assert!(!masked.is_valid(i));
         } else {
             assert_eq!(masked.scalar_at(i), array.scalar_at(i).into_nullable());
         }
@@ -56,7 +56,7 @@ fn test_heterogenous_mask(array: &dyn Array) {
 fn test_empty_mask(array: &dyn Array) {
     let len = array.len();
     let all_unmasked = vec![false; len];
-    let mask_array = Mask::try_from(&BoolArray::from_iter(all_unmasked)).vortex_unwrap();
+    let mask_array = Mask::from(&BoolArray::from_iter(all_unmasked));
 
     let masked = mask(array, &mask_array).vortex_unwrap();
     assert_eq!(masked.len(), array.len());
@@ -71,14 +71,14 @@ fn test_empty_mask(array: &dyn Array) {
 fn test_full_mask(array: &dyn Array) {
     let len = array.len();
     let all_masked = vec![true; len];
-    let mask_array = Mask::try_from(&BoolArray::from_iter(all_masked)).vortex_unwrap();
+    let mask_array = Mask::from(&BoolArray::from_iter(all_masked));
 
     let masked = mask(array, &mask_array).vortex_unwrap();
     assert_eq!(masked.len(), array.len());
 
     // All elements should be null
     for i in 0..len {
-        assert!(!masked.is_valid(i).vortex_unwrap());
+        assert!(!masked.is_valid(i));
     }
 }
 
@@ -86,14 +86,14 @@ fn test_full_mask(array: &dyn Array) {
 fn test_alternating_mask(array: &dyn Array) {
     let len = array.len();
     let pattern: Vec<bool> = (0..len).map(|i| i % 2 == 0).collect();
-    let mask_array = Mask::try_from(&BoolArray::from_iter(pattern)).vortex_unwrap();
+    let mask_array = Mask::from(&BoolArray::from_iter(pattern));
 
     let masked = mask(array, &mask_array).vortex_unwrap();
     assert_eq!(masked.len(), array.len());
 
     for i in 0..len {
         if i % 2 == 0 {
-            assert!(!masked.is_valid(i).vortex_unwrap());
+            assert!(!masked.is_valid(i));
         } else {
             assert_eq!(masked.scalar_at(i), array.scalar_at(i).into_nullable());
         }
@@ -109,21 +109,19 @@ fn test_sparse_mask(array: &dyn Array) {
 
     // Mask only about 10% of elements
     let pattern: Vec<bool> = (0..len).map(|i| i % 10 == 0).collect();
-    let mask_array = Mask::try_from(&BoolArray::from_iter(pattern.clone())).vortex_unwrap();
+    let mask_array = Mask::from(&BoolArray::from_iter(pattern.clone()));
 
     let masked = mask(array, &mask_array).vortex_unwrap();
     assert_eq!(masked.len(), array.len());
 
     // Count how many elements are valid after masking
-    let valid_count = (0..len)
-        .filter(|&i| masked.is_valid(i).vortex_unwrap())
-        .count();
+    let valid_count = (0..len).filter(|&i| masked.is_valid(i)).count();
 
     // Count how many elements should be invalid:
     // - Elements that were masked (pattern[i] == true)
     // - Elements that were already invalid in the original array
     let expected_invalid_count = (0..len)
-        .filter(|&i| pattern[i] || !array.is_valid(i).vortex_unwrap())
+        .filter(|&i| pattern[i] || !array.is_valid(i))
         .count();
 
     assert_eq!(valid_count, len - expected_invalid_count);
@@ -136,10 +134,10 @@ fn test_single_element_mask(array: &dyn Array) {
     // Mask only the first element
     let mut pattern = vec![false; len];
     pattern[0] = true;
-    let mask_array = Mask::try_from(&BoolArray::from_iter(pattern)).vortex_unwrap();
+    let mask_array = Mask::from(&BoolArray::from_iter(pattern));
 
     let masked = mask(array, &mask_array).vortex_unwrap();
-    assert!(!masked.is_valid(0).vortex_unwrap());
+    assert!(!masked.is_valid(0));
 
     for i in 1..len {
         assert_eq!(masked.scalar_at(i), array.scalar_at(i).into_nullable());
@@ -154,8 +152,8 @@ fn test_double_mask(array: &dyn Array) {
     let mask1_pattern: Vec<bool> = (0..len).map(|i| i % 3 == 0).collect();
     let mask2_pattern: Vec<bool> = (0..len).map(|i| i % 2 == 0).collect();
 
-    let mask1 = Mask::try_from(&BoolArray::from_iter(mask1_pattern.clone())).vortex_unwrap();
-    let mask2 = Mask::try_from(&BoolArray::from_iter(mask2_pattern.clone())).vortex_unwrap();
+    let mask1 = Mask::from(&BoolArray::from_iter(mask1_pattern.clone()));
+    let mask2 = Mask::from(&BoolArray::from_iter(mask2_pattern.clone()));
 
     let first_masked = mask(array, &mask1).vortex_unwrap();
     let double_masked = mask(&first_masked, &mask2).vortex_unwrap();
@@ -163,7 +161,7 @@ fn test_double_mask(array: &dyn Array) {
     // Elements should be null if either mask is true
     for i in 0..len {
         if mask1_pattern[i] || mask2_pattern[i] {
-            assert!(!double_masked.is_valid(i).vortex_unwrap());
+            assert!(!double_masked.is_valid(i));
         } else {
             assert_eq!(
                 double_masked.scalar_at(i),
@@ -188,13 +186,13 @@ fn test_nullable_mask_input(array: &dyn Array) {
     let validity = crate::validity::Validity::from_iter(validity_values.clone());
     let nullable_mask = BoolArray::new(bool_array.boolean_buffer().clone(), validity);
 
-    let mask_array = Mask::try_from(&nullable_mask).vortex_unwrap();
+    let mask_array = Mask::from(&nullable_mask);
     let masked = mask(array, &mask_array).vortex_unwrap();
 
     // Elements are masked only if the mask is true AND valid
     for i in 0..len {
         if bool_values[i] && validity_values[i] {
-            assert!(!masked.is_valid(i).vortex_unwrap());
+            assert!(!masked.is_valid(i));
         } else {
             assert_eq!(masked.scalar_at(i), array.scalar_at(i).into_nullable());
         }

--- a/vortex-array/src/compute/fill_null.rs
+++ b/vortex-array/src/compute/fill_null.rs
@@ -71,7 +71,7 @@ impl ComputeFnVTable for FillNull {
             return Ok(array.to_array().into());
         }
 
-        if array.all_valid()? {
+        if array.all_valid() {
             return Ok(cast(array, fill_value.dtype())?.into());
         }
 

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -192,27 +192,25 @@ impl<V: VTable + FilterKernel> Kernel for FilterKernelAdapter<V> {
     }
 }
 
-impl TryFrom<&BoolArray> for Mask {
-    type Error = VortexError;
-
-    fn try_from(array: &BoolArray) -> Result<Self, Self::Error> {
+impl From<&BoolArray> for Mask {
+    fn from(array: &BoolArray) -> Self {
         if let Some(constant) = array.as_constant() {
             let bool_constant = constant.as_bool();
             if bool_constant.value().unwrap_or(false) {
-                return Ok(Self::new_true(array.len()));
+                return Self::new_true(array.len());
             } else {
-                return Ok(Self::new_false(array.len()));
+                return Self::new_false(array.len());
             }
         }
 
         // Extract a boolean buffer, treating null values to false
-        let buffer = match array.validity_mask()? {
+        let buffer = match array.validity_mask() {
             Mask::AllTrue(_) => array.boolean_buffer().clone(),
-            Mask::AllFalse(_) => return Ok(Self::new_false(array.len())),
+            Mask::AllFalse(_) => return Self::new_false(array.len()),
             Mask::Values(validity) => validity.boolean_buffer().bitand(array.boolean_buffer()),
         };
 
-        Ok(Self::from_buffer(buffer))
+        Self::from_buffer(buffer)
     }
 }
 
@@ -228,7 +226,7 @@ impl TryFrom<&dyn Array> for Mask {
         // Convert nulls to false first in case this can be done cheaply by the encoding.
         let array = fill_null(array, &Scalar::bool(false, array.dtype().nullability()))?;
 
-        Self::try_from(&array.to_bool()?)
+        Ok(Self::from(&array.to_bool()?))
     }
 }
 
@@ -259,7 +257,7 @@ mod test {
         let items =
             PrimitiveArray::from_option_iter([Some(0i32), None, Some(1i32), None, Some(2i32)])
                 .into_array();
-        let mask = Mask::try_from(&BoolArray::from_iter([true, false, true, false, true])).unwrap();
+        let mask = Mask::from(&BoolArray::from_iter([true, false, true, false, true]));
 
         let filtered = filter(&items, &mask).unwrap();
         assert_eq!(

--- a/vortex-array/src/compute/is_constant.rs
+++ b/vortex-array/src/compute/is_constant.rs
@@ -126,12 +126,12 @@ fn is_constant_impl(
         return Ok(Some(true));
     }
 
-    let all_invalid = array.all_invalid()?;
+    let all_invalid = array.all_invalid();
     if all_invalid {
         return Ok(Some(true));
     }
 
-    let all_valid = array.all_valid()?;
+    let all_valid = array.all_valid();
 
     // If we have some nulls, array can't be constant
     if !all_valid && !all_invalid {

--- a/vortex-array/src/compute/is_sorted.rs
+++ b/vortex-array/src/compute/is_sorted.rs
@@ -231,13 +231,13 @@ fn is_sorted_impl(
 
     // Enforce strictness before we even try to check if the array is sorted.
     if strict {
-        let invalid_count = array.invalid_count()?;
+        let invalid_count = array.invalid_count();
         match invalid_count {
             // We can keep going
             0 => {}
             // If we have a potential null value - it has to be the first one.
             1 => {
-                if !array.is_invalid(0)? {
+                if !array.is_invalid(0) {
                     return Ok(false);
                 }
             }

--- a/vortex-array/src/compute/list_contains.rs
+++ b/vortex-array/src/compute/list_contains.rs
@@ -97,7 +97,7 @@ impl ComputeFnVTable for ListContains {
             );
         };
 
-        if value.all_invalid()? || array.all_invalid()? {
+        if value.all_invalid() || array.all_invalid() {
             return Ok(Output::Array(
                 ConstantArray::new(
                     Scalar::null(DType::Bool(Nullability::Nullable)),

--- a/vortex-array/src/compute/mask.rs
+++ b/vortex-array/src/compute/mask.rs
@@ -46,11 +46,11 @@ static MASK_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
 ///
 /// let masked = mask(array.as_ref(), &mask_array).unwrap();
 /// assert_eq!(masked.len(), 5);
-/// assert!(!masked.is_valid(0).unwrap());
-/// assert!(!masked.is_valid(1).unwrap());
+/// assert!(!masked.is_valid(0));
+/// assert!(!masked.is_valid(1));
 /// assert_eq!(masked.scalar_at(2), Scalar::from(Some(1)));
-/// assert!(!masked.is_valid(3).unwrap());
-/// assert!(!masked.is_valid(4).unwrap());
+/// assert!(!masked.is_valid(3));
+/// assert!(!masked.is_valid(4));
 /// ```
 ///
 pub fn mask(array: &dyn Array, mask: &Mask) -> VortexResult<ArrayRef> {

--- a/vortex-array/src/compute/min_max.rs
+++ b/vortex-array/src/compute/min_max.rs
@@ -125,7 +125,7 @@ fn min_max_impl(
     array: &dyn Array,
     kernels: &[ArcRef<dyn Kernel>],
 ) -> VortexResult<Option<MinMaxResult>> {
-    if array.is_empty() || array.valid_count()? == 0 {
+    if array.is_empty() || array.valid_count() == 0 {
         return Ok(None);
     }
 

--- a/vortex-array/src/compute/nan_count.rs
+++ b/vortex-array/src/compute/nan_count.rs
@@ -100,7 +100,7 @@ impl<V: VTable + NaNCountKernel> Kernel for NaNCountKernelAdapter<V> {
 }
 
 fn nan_count_impl(array: &dyn Array, kernels: &[ArcRef<dyn Kernel>]) -> VortexResult<usize> {
-    if array.is_empty() || array.valid_count()? == 0 {
+    if array.is_empty() || array.valid_count() == 0 {
         return Ok(0);
     }
 

--- a/vortex-array/src/compute/sum.rs
+++ b/vortex-array/src/compute/sum.rs
@@ -129,7 +129,7 @@ pub fn sum_impl(
     }
 
     // Sum of all null is null.
-    if array.all_invalid()? {
+    if array.all_invalid() {
         return Ok(Scalar::null(sum_dtype));
     }
 

--- a/vortex-array/src/compute/take.rs
+++ b/vortex-array/src/compute/take.rs
@@ -62,7 +62,7 @@ impl ComputeFnVTable for Take {
         // TODO(ngates): if indices min is quite high, we could slice self and offset the indices
         //  such that canonicalize does less work.
 
-        if indices.all_invalid()? {
+        if indices.all_invalid() {
             return Ok(ConstantArray::new(
                 Scalar::null(array.dtype().as_nullable()),
                 indices.len(),

--- a/vortex-array/src/compute/zip.rs
+++ b/vortex-array/src/compute/zip.rs
@@ -215,8 +215,7 @@ mod tests {
 
     #[test]
     fn test_zip_basic() {
-        let mask =
-            Mask::try_from(&BoolArray::from_iter([true, false, false, true, false])).unwrap();
+        let mask = Mask::from(&BoolArray::from_iter([true, false, false, true, false]));
         let if_true = PrimitiveArray::from_iter([10, 20, 30, 40, 50]).into_array();
         let if_false = PrimitiveArray::from_iter([1, 2, 3, 4, 5]).into_array();
 

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -15,9 +15,7 @@ use vortex_dtype::Nullability::NonNullable;
 use vortex_dtype::{
     DType, NativePType, PType, match_each_integer_ptype, match_each_unsigned_integer_ptype,
 };
-use vortex_error::{
-    VortexError, VortexExpect, VortexResult, VortexUnwrap, vortex_bail, vortex_err,
-};
+use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_bail, vortex_err};
 use vortex_mask::{AllOr, Mask};
 use vortex_scalar::{PValue, Scalar};
 use vortex_utils::aliases::hash_map::HashMap;
@@ -518,7 +516,7 @@ where
             I::from(v)
                 .and_then(|v| {
                     // If we have to take nulls the take index doesn't matter, make it 0 for consistency
-                    if include_nulls && take_indices_validity.is_null(i).vortex_unwrap() {
+                    if include_nulls && take_indices_validity.is_null(i) {
                         Some(0)
                     } else {
                         indices
@@ -575,7 +573,7 @@ where
             iter.enumerate()
                 .filter_map(|(idx_in_take, ti)| {
                     // If we have to take nulls the take index doesn't matter, make it 0 for consistency
-                    if include_nulls && take_indices_validity.is_null(idx_in_take).vortex_unwrap() {
+                    if include_nulls && take_indices_validity.is_null(idx_in_take) {
                         Some((idx_in_take as u64, 0))
                     } else if ti < min_index || ti > max_index {
                         None
@@ -830,7 +828,7 @@ mod test {
         assert_eq!(taken.array_len(), 2);
         assert_eq!(primitive_values.as_slice::<i32>(), [44]);
         assert_eq!(
-            primitive_values.validity_mask().unwrap(),
+            primitive_values.validity_mask(),
             Mask::from_iter(vec![true])
         );
     }
@@ -897,9 +895,9 @@ mod test {
         // No patch values should be masked
         let masked_values = masked.values().to_primitive().unwrap();
         assert_eq!(masked_values.as_slice::<i32>(), &[100, 200, 300]);
-        assert!(masked_values.is_valid(0).unwrap());
-        assert!(masked_values.is_valid(1).unwrap());
-        assert!(masked_values.is_valid(2).unwrap());
+        assert!(masked_values.is_valid(0));
+        assert!(masked_values.is_valid(1));
+        assert!(masked_values.is_valid(2));
 
         // Indices should remain unchanged
         let indices = masked.indices().to_primitive().unwrap();
@@ -976,8 +974,8 @@ mod test {
         // Values should be the null and 300
         let masked_values = masked.values().to_primitive().unwrap();
         assert_eq!(masked_values.len(), 2);
-        assert!(!masked_values.is_valid(0).unwrap()); // the null value at index 5
-        assert!(masked_values.is_valid(1).unwrap()); // the 300 value at index 8
+        assert!(!masked_values.is_valid(0)); // the null value at index 5
+        assert!(masked_values.is_valid(1)); // the 300 value at index 8
         assert_eq!(i32::try_from(&masked_values.scalar_at(1)).unwrap(), 300i32);
     }
 

--- a/vortex-array/src/stats/array.rs
+++ b/vortex-array/src/stats/array.rs
@@ -137,7 +137,7 @@ impl StatsSetRef<'_> {
                     })
                     .transpose()?
             }
-            Stat::NullCount => Some(self.dyn_array_ref.invalid_count()?.into()),
+            Stat::NullCount => Some(self.dyn_array_ref.invalid_count().into()),
             Stat::IsConstant => {
                 if self.dyn_array_ref.is_empty() {
                     None

--- a/vortex-array/src/test_harness.rs
+++ b/vortex-array/src/test_harness.rs
@@ -31,7 +31,7 @@ where
 /// Outputs the indices of the true values in a BoolArray
 pub fn to_int_indices(indices_bits: BoolArray) -> VortexResult<Vec<u64>> {
     let buffer = indices_bits.boolean_buffer();
-    let mask = indices_bits.validity_mask()?;
+    let mask = indices_bits.validity_mask();
     Ok(buffer
         .iter()
         .enumerate()

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -90,38 +90,34 @@ impl Validity {
         }
     }
 
-    pub fn all_valid(&self) -> VortexResult<bool> {
-        Ok(match self {
+    pub fn all_valid(&self) -> bool {
+        match self {
             Validity::NonNullable | Validity::AllValid => true,
             Validity::AllInvalid => false,
-            Validity::Array(array) => sum(array)
-                .map(|v| {
-                    v.as_primitive()
-                        .typed_value::<u64>()
-                        .map(|count| count == array.len() as u64)
-                })?
-                .ok_or_else(|| vortex_err!("Failed to compute sum for validity array"))?,
-        })
+            Validity::Array(array) => {
+                usize::try_from(&sum(array).vortex_expect("must have sum for bool array"))
+                    .vortex_expect("sum must be a usize")
+                    == array.len()
+            }
+        }
     }
 
-    pub fn all_invalid(&self) -> VortexResult<bool> {
-        Ok(match self {
+    pub fn all_invalid(&self) -> bool {
+        match self {
             Validity::NonNullable | Validity::AllValid => false,
             Validity::AllInvalid => true,
-            Validity::Array(array) => sum(array)
-                .map(|v| {
-                    v.as_primitive()
-                        .typed_value::<u64>()
-                        .map(|count| count == 0u64)
-                })?
-                .ok_or_else(|| vortex_err!("Failed to compute sum for validity array"))?,
-        })
+            Validity::Array(array) => {
+                usize::try_from(&sum(array).vortex_expect("must have sum for bool array"))
+                    .vortex_expect("sum must be a usize")
+                    == 0
+            }
+        }
     }
 
     /// Returns whether the `index` item is valid.
     #[inline]
-    pub fn is_valid(&self, index: usize) -> VortexResult<bool> {
-        Ok(match self {
+    pub fn is_valid(&self, index: usize) -> bool {
+        match self {
             Self::NonNullable | Self::AllValid => true,
             Self::AllInvalid => false,
             Self::Array(a) => {
@@ -131,12 +127,12 @@ impl Validity {
                     .value()
                     .vortex_expect("Validity must be non-nullable")
             }
-        })
+        }
     }
 
     #[inline]
-    pub fn is_null(&self, index: usize) -> VortexResult<bool> {
-        Ok(!self.is_valid(index)?)
+    pub fn is_null(&self, index: usize) -> bool {
+        !self.is_valid(index)
     }
 
     pub fn slice(&self, range: Range<usize>) -> Self {
@@ -148,7 +144,7 @@ impl Validity {
 
     pub fn take(&self, indices: &dyn Array) -> VortexResult<Self> {
         match self {
-            Self::NonNullable => match indices.validity_mask()?.boolean_buffer() {
+            Self::NonNullable => match indices.validity_mask().boolean_buffer() {
                 AllOr::All => {
                     if indices.dtype().is_nullable() {
                         Ok(Self::AllValid)
@@ -159,7 +155,7 @@ impl Validity {
                 AllOr::None => Ok(Self::AllInvalid),
                 AllOr::Some(buf) => Ok(Validity::from(buf.clone())),
             },
-            Self::AllValid => match indices.validity_mask()?.boolean_buffer() {
+            Self::AllValid => match indices.validity_mask().boolean_buffer() {
                 AllOr::All => Ok(Self::AllValid),
                 AllOr::None => Ok(Self::AllInvalid),
                 AllOr::Some(buf) => Ok(Validity::from(buf.clone())),
@@ -209,8 +205,8 @@ impl Validity {
         }
     }
 
-    pub fn to_mask(&self, length: usize) -> VortexResult<Mask> {
-        Ok(match self {
+    pub fn to_mask(&self, length: usize) -> Mask {
+        match self {
             Self::NonNullable | Self::AllValid => Mask::AllTrue(length),
             Self::AllInvalid => Mask::AllFalse(length),
             Self::Array(is_valid) => {
@@ -221,9 +217,13 @@ impl Validity {
                     is_valid.len(),
                     length,
                 );
-                Mask::try_from(&is_valid.to_bool()?)?
+                Mask::from(
+                    &is_valid
+                        .to_bool()
+                        .vortex_expect("validity array must be bool"),
+                )
             }
-        })
+        }
     }
 
     /// Logically & two Validity values of the same length
@@ -350,7 +350,7 @@ impl Validity {
     /// Create Validity by copying the given array's validity.
     pub fn copy_from_array(array: &dyn Array) -> VortexResult<Self> {
         Ok(Validity::from_mask(
-            array.validity_mask()?,
+            array.validity_mask(),
             array.dtype().nullability(),
         ))
     }

--- a/vortex-array/src/variants.rs
+++ b/vortex-array/src/variants.rs
@@ -105,10 +105,7 @@ impl PrimitiveTyped<'_> {
 
     /// Return the primitive value at the given index.
     pub fn value(&self, idx: usize) -> Option<PValue> {
-        self.0
-            .is_valid(idx)
-            .vortex_expect("is valid")
-            .then(|| self.value_unchecked(idx))
+        self.0.is_valid(idx).then(|| self.value_unchecked(idx))
     }
 
     /// Return the primitive value at the given index, ignoring nullability.
@@ -134,7 +131,7 @@ impl IndexOrd<Option<PValue>> for PrimitiveTyped<'_> {
 // TODO(ngates): add generics to the `value` function and implement this over T.
 impl IndexOrd<PValue> for PrimitiveTyped<'_> {
     fn index_cmp(&self, idx: usize, elem: &PValue) -> Option<Ordering> {
-        assert!(self.0.all_valid().vortex_expect("all valid"));
+        assert!(self.0.all_valid());
         self.value_unchecked(idx).partial_cmp(elem)
     }
 

--- a/vortex-array/src/vtable/validity.rs
+++ b/vortex-array/src/vtable/validity.rs
@@ -1,38 +1,36 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
 use crate::Array;
 use crate::validity::Validity;
 use crate::vtable::VTable;
 
-// TODO(aduffy): these methods should be infallible.
 pub trait ValidityVTable<V: VTable> {
-    fn is_valid(array: &V::Array, index: usize) -> VortexResult<bool>;
+    fn is_valid(array: &V::Array, index: usize) -> bool;
 
-    fn all_valid(array: &V::Array) -> VortexResult<bool>;
+    fn all_valid(array: &V::Array) -> bool;
 
-    fn all_invalid(array: &V::Array) -> VortexResult<bool>;
+    fn all_invalid(array: &V::Array) -> bool;
 
     /// Returns the number of valid elements in the array.
     ///
     /// ## Post-conditions
     /// - The count is less than or equal to the length of the array.
-    fn valid_count(array: &V::Array) -> VortexResult<usize> {
-        Ok(Self::validity_mask(array)?.true_count())
+    fn valid_count(array: &V::Array) -> usize {
+        Self::validity_mask(array).true_count()
     }
 
     /// Returns the number of invalid elements in the array.
     ///
     /// ## Post-conditions
     /// - The count is less than or equal to the length of the array.
-    fn invalid_count(array: &V::Array) -> VortexResult<usize> {
-        Ok(Self::validity_mask(array)?.false_count())
+    fn invalid_count(array: &V::Array) -> usize {
+        Self::validity_mask(array).false_count()
     }
 
-    fn validity_mask(array: &V::Array) -> VortexResult<Mask>;
+    fn validity_mask(array: &V::Array) -> Mask;
 }
 
 /// An implementation of the [`ValidityVTable`] for arrays that hold validity as a child array.
@@ -47,19 +45,19 @@ impl<V: VTable> ValidityVTable<V> for ValidityVTableFromValidityHelper
 where
     V::Array: ValidityHelper,
 {
-    fn is_valid(array: &V::Array, index: usize) -> VortexResult<bool> {
+    fn is_valid(array: &V::Array, index: usize) -> bool {
         array.validity().is_valid(index)
     }
 
-    fn all_valid(array: &V::Array) -> VortexResult<bool> {
+    fn all_valid(array: &V::Array) -> bool {
         array.validity().all_valid()
     }
 
-    fn all_invalid(array: &V::Array) -> VortexResult<bool> {
+    fn all_invalid(array: &V::Array) -> bool {
         array.validity().all_invalid()
     }
 
-    fn validity_mask(array: &V::Array) -> VortexResult<Mask> {
+    fn validity_mask(array: &V::Array) -> Mask {
         array.validity().to_mask(array.len())
     }
 }
@@ -81,20 +79,20 @@ impl<V: VTable> ValidityVTable<V> for ValidityVTableFromValiditySliceHelper
 where
     V::Array: ValiditySliceHelper,
 {
-    fn is_valid(array: &V::Array, index: usize) -> VortexResult<bool> {
+    fn is_valid(array: &V::Array, index: usize) -> bool {
         let (unsliced_validity, start, _) = array.unsliced_validity_and_slice();
         unsliced_validity.is_valid(start + index)
     }
 
-    fn all_valid(array: &V::Array) -> VortexResult<bool> {
+    fn all_valid(array: &V::Array) -> bool {
         array.sliced_validity().all_valid()
     }
 
-    fn all_invalid(array: &V::Array) -> VortexResult<bool> {
+    fn all_invalid(array: &V::Array) -> bool {
         array.sliced_validity().all_invalid()
     }
 
-    fn validity_mask(array: &V::Array) -> VortexResult<Mask> {
+    fn validity_mask(array: &V::Array) -> Mask {
         array.sliced_validity().to_mask(array.len())
     }
 }
@@ -111,19 +109,19 @@ impl<V: VTable> ValidityVTable<V> for ValidityVTableFromChild
 where
     V: ValidityChild<V>,
 {
-    fn is_valid(array: &V::Array, index: usize) -> VortexResult<bool> {
+    fn is_valid(array: &V::Array, index: usize) -> bool {
         V::validity_child(array).is_valid(index)
     }
 
-    fn all_valid(array: &V::Array) -> VortexResult<bool> {
+    fn all_valid(array: &V::Array) -> bool {
         V::validity_child(array).all_valid()
     }
 
-    fn all_invalid(array: &V::Array) -> VortexResult<bool> {
+    fn all_invalid(array: &V::Array) -> bool {
         V::validity_child(array).all_invalid()
     }
 
-    fn validity_mask(array: &V::Array) -> VortexResult<Mask> {
+    fn validity_mask(array: &V::Array) -> Mask {
         V::validity_child(array).validity_mask()
     }
 }

--- a/vortex-btrblocks/src/float/stats.rs
+++ b/vortex-btrblocks/src/float/stats.rs
@@ -103,7 +103,7 @@ where
             }
             .into(),
         };
-    } else if array.all_invalid().vortex_expect("all_invalid") {
+    } else if array.all_invalid() {
         return FloatStats {
             src: array.clone(),
             null_count: array.len().try_into().vortex_expect("null_count"),
@@ -131,7 +131,7 @@ where
         HashSet::with_hasher(FxBuildHasher)
     };
 
-    let validity = array.validity_mask().vortex_expect("logical_validity");
+    let validity = array.validity_mask();
 
     let mut runs = 1;
     let head_idx = validity

--- a/vortex-btrblocks/src/integer/stats.rs
+++ b/vortex-btrblocks/src/integer/stats.rs
@@ -176,7 +176,7 @@ where
             }
             .into(),
         };
-    } else if array.all_invalid().vortex_expect("all_invalid") {
+    } else if array.all_invalid() {
         return IntegerStats {
             src: array.clone(),
             null_count: array.len().try_into().vortex_expect("null_count"),
@@ -194,7 +194,7 @@ where
         };
     }
 
-    let validity = array.validity_mask().vortex_expect("logical_validity");
+    let validity = array.validity_mask();
     let null_count = validity.false_count();
     let value_count = validity.true_count();
 

--- a/vortex-duckdb/src/exporter/bool.rs
+++ b/vortex-duckdb/src/exporter/bool.rs
@@ -17,7 +17,7 @@ struct BoolExporter {
 pub(crate) fn new_exporter(array: &BoolArray) -> VortexResult<Box<dyn ColumnExporter>> {
     Ok(Box::new(BoolExporter {
         array: array.clone(),
-        validity: array.validity_mask()?,
+        validity: array.validity_mask(),
     }))
 }
 

--- a/vortex-duckdb/src/exporter/decimal.rs
+++ b/vortex-duckdb/src/exporter/decimal.rs
@@ -22,7 +22,7 @@ struct DecimalExporter<D: NativeDecimalType, N: NativeDecimalType> {
 }
 
 pub(crate) fn new_exporter(array: &DecimalArray) -> VortexResult<Box<dyn ColumnExporter>> {
-    let validity = array.validity_mask()?;
+    let validity = array.validity_mask();
     let dest_values_type = precision_to_duckdb_storage_size(&array.decimal_dtype())?;
 
     match_each_decimal_value_type!(array.values_type(), |D| {

--- a/vortex-duckdb/src/exporter/list.rs
+++ b/vortex-duckdb/src/exporter/list.rs
@@ -30,7 +30,7 @@ pub(crate) fn new_exporter(
     let offsets = array.offsets().to_primitive()?;
     let boxed = match_each_integer_ptype!(offsets.ptype(), |T| {
         Box::new(ListExporter {
-            validity: array.validity_mask()?,
+            validity: array.validity_mask(),
             elements_exporter,
             offsets,
             offset_type: PhantomData::<T>,

--- a/vortex-duckdb/src/exporter/primitive.rs
+++ b/vortex-duckdb/src/exporter/primitive.rs
@@ -22,7 +22,7 @@ pub(crate) fn new_exporter(array: &PrimitiveArray) -> VortexResult<Box<dyn Colum
         Box::new(PrimitiveExporter {
             array: array.clone(),
             array_type: PhantomData::<T>,
-            validity: array.validity_mask()?,
+            validity: array.validity_mask(),
         })
     }))
 }

--- a/vortex-duckdb/src/exporter/varbinview.rs
+++ b/vortex-duckdb/src/exporter/varbinview.rs
@@ -21,7 +21,7 @@ pub(crate) fn new_exporter(array: &VarBinViewArray) -> VortexResult<Box<dyn Colu
     Ok(Box::new(VarBinViewExporter {
         views: array.views().clone(),
         buffers: array.buffers().to_vec(),
-        validity: array.validity_mask()?,
+        validity: array.validity_mask(),
     }))
 }
 

--- a/vortex-expr/src/exprs/is_null.rs
+++ b/vortex-expr/src/exprs/is_null.rs
@@ -66,7 +66,7 @@ impl VTable for IsNullVTable {
 
     fn evaluate(expr: &Self::Expr, scope: &Scope) -> VortexResult<ArrayRef> {
         let array = expr.child.unchecked_evaluate(scope)?;
-        match array.validity_mask()? {
+        match array.validity_mask() {
             Mask::AllTrue(len) => Ok(ConstantArray::new(false, len).into_array()),
             Mask::AllFalse(len) => Ok(ConstantArray::new(true, len).into_array()),
             Mask::Values(mask) => Ok(BoolArray::from(mask.boolean_buffer().not()).into_array()),

--- a/vortex-expr/src/exprs/list_contains.rs
+++ b/vortex-expr/src/exprs/list_contains.rs
@@ -271,7 +271,7 @@ mod tests {
         let item = expr.evaluate(&Scope::new(arr)).unwrap();
 
         assert_eq!(item.scalar_at(0), Scalar::bool(true, Nullability::Nullable));
-        assert!(!item.is_valid(1).unwrap());
+        assert!(!item.is_valid(1));
     }
 
     #[test]

--- a/vortex-ffi/cinclude/vortex.h
+++ b/vortex-ffi/cinclude/vortex.h
@@ -352,7 +352,7 @@ const vx_array *vx_array_slice(const vx_array *array,
                                uint32_t stop,
                                vx_error **_error_out);
 
-bool vx_array_is_null(const vx_array *array, uint32_t index, vx_error **error_out);
+bool vx_array_is_null(const vx_array *array, uint32_t index, vx_error **_error_out);
 
 uint32_t vx_array_null_count(const vx_array *array, vx_error **error_out);
 

--- a/vortex-ffi/src/array.rs
+++ b/vortex-ffi/src/array.rs
@@ -79,19 +79,20 @@ pub unsafe extern "C-unwind" fn vx_array_slice(
 pub unsafe extern "C-unwind" fn vx_array_is_null(
     array: *const vx_array,
     index: u32,
-    error_out: *mut *mut vx_error,
+    _error_out: *mut *mut vx_error,
 ) -> bool {
     let array = vx_array::as_ref(array);
-    try_or_default(error_out, || array.is_invalid(index as usize))
+    array.is_invalid(index as usize)
 }
 
+// TODO(robert): Make this return usize and remove error
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_array_null_count(
     array: *const vx_array,
     error_out: *mut *mut vx_error,
 ) -> u32 {
     let array = vx_array::as_ref(array);
-    try_or_default(error_out, || Ok(array.invalid_count()?.try_into()?))
+    try_or_default(error_out, || Ok(array.invalid_count().try_into()?))
 }
 
 macro_rules! ffiarray_get_ptype {

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -1130,12 +1130,12 @@ fn write_nullable_nested_struct() -> VortexResult<()> {
 
     assert_eq!(result.len(), 3);
     assert_eq!(result.fields().len(), 1);
-    assert!(result.all_valid()?);
+    assert!(result.all_valid());
 
     let nested_struct = result.field_by_name("struct")?.to_struct()?;
     assert_eq!(nested_struct.dtype(), &nested_dtype);
     assert_eq!(nested_struct.len(), 3);
-    assert!(nested_struct.all_invalid()?);
+    assert!(nested_struct.all_invalid());
 
     Ok(())
 }

--- a/vortex-jni/src/array.rs
+++ b/vortex-jni/src/array.rs
@@ -234,7 +234,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getNull(
 ) -> jboolean {
     let array_ref = unsafe { NativeArray::from_ptr(array_ptr) };
     try_or_throw(&mut env, |_| {
-        let is_null = array_ref.inner.is_invalid(index as usize)?;
+        let is_null = array_ref.inner.is_invalid(index as usize);
         if is_null { Ok(JNI_TRUE) } else { Ok(JNI_FALSE) }
     })
 }
@@ -247,7 +247,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getNullCount(
 ) -> jint {
     let array_ref = unsafe { NativeArray::from_ptr(array_ptr) };
     try_or_throw(&mut env, |_| {
-        let count = array_ref.inner.invalid_count()?;
+        let count = array_ref.inner.invalid_count();
         Ok(jint::try_from(count).unwrap_or(-1))
     })
 }

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -191,7 +191,7 @@ impl MaskEvaluation for DictMaskEvaluation {
             if min.as_bool().value().unwrap_or(false) {
                 // All values are true, but we still need to respect codes validity
                 let codes = self.codes_eval.invoke(Mask::new_true(mask.len())).await?;
-                return Ok(mask.bitand(&codes.validity_mask()?));
+                return Ok(mask.bitand(&codes.validity_mask()));
             }
         }
 
@@ -451,7 +451,7 @@ mod tests {
             .invoke(Mask::new_true(layout.row_count().try_into().unwrap()))
             .await
             .unwrap();
-        let expected = array.validity_mask().unwrap().into_array();
+        let expected = array.validity_mask().into_array();
         let actual = actual.into_arrow_preferred().unwrap();
         let expected = expected.into_arrow_preferred().unwrap();
         assert_eq!(actual.data_type(), expected.data_type());

--- a/vortex-layout/src/layouts/flat/writer.rs
+++ b/vortex-layout/src/layouts/flat/writer.rs
@@ -291,7 +291,7 @@ mod tests {
                 .unwrap();
 
             assert_eq!(
-                result.validity_mask().unwrap().boolean_buffer(),
+                result.validity_mask().boolean_buffer(),
                 AllOr::Some(&validity_boolean_buffer)
             );
             assert_eq!(

--- a/vortex-layout/src/layouts/struct_/writer.rs
+++ b/vortex-layout/src/layouts/struct_/writer.rs
@@ -63,7 +63,7 @@ where
 
         let stream = stream.map(|chunk| {
             let (sequence_id, chunk) = chunk?;
-            if !chunk.all_valid()? {
+            if !chunk.all_valid() {
                 vortex_bail!("Cannot push struct chunks with top level invalid values");
             };
             Ok((sequence_id, chunk))

--- a/vortex-layout/src/layouts/zoned/builder.rs
+++ b/vortex-layout/src/layouts/zoned/builder.rs
@@ -59,7 +59,7 @@ pub struct NamedArrays {
 }
 
 impl NamedArrays {
-    pub fn all_invalid(&self) -> VortexResult<bool> {
+    pub fn all_invalid(&self) -> bool {
         // by convention we assume that the first array is the one we care about for logical validity
         self.arrays[0].all_invalid()
     }

--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -201,10 +201,7 @@ impl StatsAccumulator {
             let values = builder.finish();
 
             // We drop any all-null stats columns
-            if values
-                .all_invalid()
-                .vortex_expect("failed to get invalid count")
-            {
+            if values.all_invalid() {
                 continue;
             }
 

--- a/vortex-python/src/arrays/py/vtable.rs
+++ b/vortex-python/src/arrays/py/vtable.rs
@@ -81,19 +81,19 @@ impl OperationsVTable<PythonVTable> for PythonVTable {
 }
 
 impl ValidityVTable<PythonVTable> for PythonVTable {
-    fn is_valid(_array: &PythonArray, _index: usize) -> VortexResult<bool> {
+    fn is_valid(_array: &PythonArray, _index: usize) -> bool {
         todo!()
     }
 
-    fn all_valid(_array: &PythonArray) -> VortexResult<bool> {
+    fn all_valid(_array: &PythonArray) -> bool {
         todo!()
     }
 
-    fn all_invalid(_array: &PythonArray) -> VortexResult<bool> {
+    fn all_invalid(_array: &PythonArray) -> bool {
         todo!()
     }
 
-    fn validity_mask(_array: &PythonArray) -> VortexResult<Mask> {
+    fn validity_mask(_array: &PythonArray) -> Mask {
         todo!()
     }
 }


### PR DESCRIPTION
Since we made ArrayOperations non fallible these were only ever fallible because canonical is fallible but since we validate all the arguments these shouldn't be fallible anymore

Signed-off-by: Robert Kruszewski <github@robertk.io>
