### PR TITLE
Feature: Add `FixedSizeListBuilder`

### DIFF
--- a/vortex-array/src/arrays/fixed_size_list/tests/basic.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/basic.rs
@@ -29,6 +29,27 @@ fn test_basic_fixed_size_list() {
         DType::FixedSizeList(elem_dtype, 3, Nullability::NonNullable)
             if matches!(elem_dtype.as_ref(), DType::Primitive(PType::I32, Nullability::NonNullable))
     ));
+
+    // Check the actual values in each list.
+    let first_list = fsl.fixed_size_list_at(0);
+    assert_eq!(first_list.scalar_at(0), 1i32.into());
+    assert_eq!(first_list.scalar_at(1), 2i32.into());
+    assert_eq!(first_list.scalar_at(2), 3i32.into());
+
+    let second_list = fsl.fixed_size_list_at(1);
+    assert_eq!(second_list.scalar_at(0), 4i32.into());
+    assert_eq!(second_list.scalar_at(1), 5i32.into());
+    assert_eq!(second_list.scalar_at(2), 6i32.into());
+
+    let third_list = fsl.fixed_size_list_at(2);
+    assert_eq!(third_list.scalar_at(0), 7i32.into());
+    assert_eq!(third_list.scalar_at(1), 8i32.into());
+    assert_eq!(third_list.scalar_at(2), 9i32.into());
+
+    let fourth_list = fsl.fixed_size_list_at(3);
+    assert_eq!(fourth_list.scalar_at(0), 10i32.into());
+    assert_eq!(fourth_list.scalar_at(1), 11i32.into());
+    assert_eq!(fourth_list.scalar_at(2), 12i32.into());
 }
 
 #[test]
@@ -50,6 +71,12 @@ fn test_scalar_at() {
         )
     );
 
+    // Additionally check individual elements via fixed_size_list_at.
+    let first_list = fsl.fixed_size_list_at(0);
+    assert_eq!(first_list.scalar_at(0), 1i32.into());
+    assert_eq!(first_list.scalar_at(1), 2i32.into());
+    assert_eq!(first_list.scalar_at(2), 3i32.into());
+
     // Second list: [4, 5, 6].
     let second = fsl.scalar_at(1);
     assert_eq!(
@@ -60,6 +87,12 @@ fn test_scalar_at() {
             Nullability::NonNullable,
         )
     );
+
+    // Additionally check individual elements via fixed_size_list_at.
+    let second_list = fsl.fixed_size_list_at(1);
+    assert_eq!(second_list.scalar_at(0), 4i32.into());
+    assert_eq!(second_list.scalar_at(1), 5i32.into());
+    assert_eq!(second_list.scalar_at(2), 6i32.into());
 }
 
 #[test]

--- a/vortex-array/src/arrays/fixed_size_list/tests/nested.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/nested.rs
@@ -9,7 +9,7 @@ use vortex_scalar::Scalar;
 use crate::arrays::{FixedSizeListArray, PrimitiveArray, StructArray};
 use crate::builders::{ArrayBuilder, ArrayBuilderExt, ListBuilder};
 use crate::validity::Validity;
-use crate::{Array, IntoArray};
+use crate::{Array, IntoArray, ToCanonical};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // FSL of FSL tests
@@ -64,6 +64,61 @@ fn test_fsl_of_fsl_basic() {
     // We can check by slicing and examining scalars.
     let first_scalar = outer_fsl.scalar_at(0);
     assert!(!first_scalar.is_null());
+
+    // Check the actual values in the nested structure.
+    // First outer list contains: [[1,2], [3,4], [5,6]].
+    let first_outer_list = outer_fsl.fixed_size_list_at(0);
+
+    // Check first inner list [1,2].
+    let inner_list_0 = first_outer_list
+        .to_fixed_size_list()
+        .unwrap()
+        .fixed_size_list_at(0);
+    assert_eq!(inner_list_0.scalar_at(0), 1i32.into());
+    assert_eq!(inner_list_0.scalar_at(1), 2i32.into());
+
+    // Check second inner list [3,4].
+    let inner_list_1 = first_outer_list
+        .to_fixed_size_list()
+        .unwrap()
+        .fixed_size_list_at(1);
+    assert_eq!(inner_list_1.scalar_at(0), 3i32.into());
+    assert_eq!(inner_list_1.scalar_at(1), 4i32.into());
+
+    // Check third inner list [5,6].
+    let inner_list_2 = first_outer_list
+        .to_fixed_size_list()
+        .unwrap()
+        .fixed_size_list_at(2);
+    assert_eq!(inner_list_2.scalar_at(0), 5i32.into());
+    assert_eq!(inner_list_2.scalar_at(1), 6i32.into());
+
+    // Second outer list contains: [[7,8], [9,10], [11,12]].
+    let second_outer_list = outer_fsl.fixed_size_list_at(1);
+
+    // Check first inner list [7,8].
+    let inner_list_0 = second_outer_list
+        .to_fixed_size_list()
+        .unwrap()
+        .fixed_size_list_at(0);
+    assert_eq!(inner_list_0.scalar_at(0), 7i32.into());
+    assert_eq!(inner_list_0.scalar_at(1), 8i32.into());
+
+    // Check second inner list [9,10].
+    let inner_list_1 = second_outer_list
+        .to_fixed_size_list()
+        .unwrap()
+        .fixed_size_list_at(1);
+    assert_eq!(inner_list_1.scalar_at(0), 9i32.into());
+    assert_eq!(inner_list_1.scalar_at(1), 10i32.into());
+
+    // Check third inner list [11,12].
+    let inner_list_2 = second_outer_list
+        .to_fixed_size_list()
+        .unwrap()
+        .fixed_size_list_at(2);
+    assert_eq!(inner_list_2.scalar_at(0), 11i32.into());
+    assert_eq!(inner_list_2.scalar_at(1), 12i32.into());
 }
 
 #[test]
@@ -153,6 +208,36 @@ fn test_deeply_nested_fsl() {
                     )
             )
     ));
+
+    // Check the actual deeply nested values.
+    // Structure: [[[1,2],[3,4]],[[5,6],[7,8]]].
+    let top_level = level3.fixed_size_list_at(0);
+    let level2_0 = top_level
+        .to_fixed_size_list()
+        .unwrap()
+        .fixed_size_list_at(0);
+    let level2_1 = top_level
+        .to_fixed_size_list()
+        .unwrap()
+        .fixed_size_list_at(1);
+
+    // First level-2 list: [[1,2],[3,4]].
+    let level1_0_0 = level2_0.to_fixed_size_list().unwrap().fixed_size_list_at(0);
+    assert_eq!(level1_0_0.scalar_at(0), 1i32.into());
+    assert_eq!(level1_0_0.scalar_at(1), 2i32.into());
+
+    let level1_0_1 = level2_0.to_fixed_size_list().unwrap().fixed_size_list_at(1);
+    assert_eq!(level1_0_1.scalar_at(0), 3i32.into());
+    assert_eq!(level1_0_1.scalar_at(1), 4i32.into());
+
+    // Second level-2 list: [[5,6],[7,8]].
+    let level1_1_0 = level2_1.to_fixed_size_list().unwrap().fixed_size_list_at(0);
+    assert_eq!(level1_1_0.scalar_at(0), 5i32.into());
+    assert_eq!(level1_1_0.scalar_at(1), 6i32.into());
+
+    let level1_1_1 = level2_1.to_fixed_size_list().unwrap().fixed_size_list_at(1);
+    assert_eq!(level1_1_1.scalar_at(0), 7i32.into());
+    assert_eq!(level1_1_1.scalar_at(1), 8i32.into());
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/vortex-array/src/arrays/fixed_size_list/tests/nullability.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/nullability.rs
@@ -35,6 +35,11 @@ fn test_nullable_fsl_with_nulls() {
         )
     );
 
+    // Check individual elements of the first list.
+    let first_list = fsl.fixed_size_list_at(0);
+    assert_eq!(first_list.scalar_at(0), 1i32.into());
+    assert_eq!(first_list.scalar_at(1), 2i32.into());
+
     // Second list is null.
     let second = fsl.scalar_at(1);
     assert!(second.is_null());
@@ -50,6 +55,11 @@ fn test_nullable_fsl_with_nulls() {
             Nullability::Nullable,
         )
     );
+
+    // Check individual elements of the third list.
+    let third_list = fsl.fixed_size_list_at(2);
+    assert_eq!(third_list.scalar_at(0), 5i32.into());
+    assert_eq!(third_list.scalar_at(1), 6i32.into());
 
     // Fourth list is null.
     let fourth = fsl.scalar_at(3);
@@ -125,6 +135,11 @@ fn test_nullable_elements_and_nullable_lists() {
         )
     );
 
+    // Check individual elements of the first list.
+    let first_list = fsl.fixed_size_list_at(0);
+    assert_eq!(first_list.scalar_at(0), Some(10u16).into());
+    assert_eq!(first_list.scalar_at(1), None::<u16>.into());
+
     // Second list is null (but elements would be [Some(20), Some(30)]).
     let second = fsl.scalar_at(1);
     assert!(second.is_null());
@@ -140,6 +155,11 @@ fn test_nullable_elements_and_nullable_lists() {
             Nullability::Nullable,
         )
     );
+
+    // Check individual elements of the third list.
+    let third_list = fsl.fixed_size_list_at(2);
+    assert_eq!(third_list.scalar_at(0), None::<u16>.into());
+    assert_eq!(third_list.scalar_at(1), None::<u16>.into());
 }
 
 #[test]

--- a/vortex-array/src/builders/fixed_size_list.rs
+++ b/vortex-array/src/builders/fixed_size_list.rs
@@ -84,6 +84,20 @@ impl FixedSizeListBuilder {
         Ok(())
     }
 
+    /// The [`DType`] of the inner elements. Note that this is **not** the same as the [`DType`] of
+    /// the outer `FixedSizeList`.
+    pub fn element_dtype(&self) -> &DType {
+        let DType::FixedSizeList(element_dtype, ..) = &self.dtype else {
+            vortex_panic!(
+                "`FixedSizeListBuilder` has an incorrect dtype: {}",
+                self.dtype
+            );
+        };
+
+        element_dtype
+    }
+
+    /// The size of each fixed-size list.
     pub fn list_size(&self) -> u32 {
         let DType::FixedSizeList(_, list_size, _) = self.dtype else {
             vortex_panic!(
@@ -139,25 +153,30 @@ impl ArrayBuilder for FixedSizeListBuilder {
         self.nulls.append_n_non_nulls(n);
     }
 
-    /// We define the null value of a fixed-size list of size `m` to be a list of `m` null values.
+    /// We define the null value of a fixed-size list of size `m` to be a list of `m` placeholder values.
     ///
-    /// We append `n * m` of these null values to the underlying `elements` array.
+    /// We append `n * m` placeholder values to the underlying `elements` array.
+    ///
+    /// The placeholder values depend on the nullability of the element type:
+    /// - If elements are nullable, we use null values
+    /// - If elements are non-nullable, we use zero values
     fn append_nulls(&mut self, n: usize) {
-        self.elements_builder
-            .append_nulls(n * self.list_size() as usize);
+        let element_count = n * self.list_size() as usize;
+
+        // TODO(connor): Does the behavior of `append_nulls` make sense here?
+        // Use nulls if the element type is nullable, otherwise use zeros.
+        if self.element_dtype().is_nullable() {
+            self.elements_builder.append_nulls(element_count);
+        } else {
+            self.elements_builder.append_zeros(element_count);
+        }
+
         self.nulls.append_n_nulls(n);
     }
 
     /// This will increase the capacity if extending with this `array` would go past the original
     /// capacity.
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
-        // TODO(connor): This check should be in every single `extend_from_array` implementation.
-        assert_eq!(
-            self.dtype(),
-            array.dtype(),
-            "tried to extend an array with an array of a different `DType`"
-        );
-
         let fsl = array.to_fixed_size_list()?;
         if fsl.is_empty() {
             return Ok(());
@@ -186,10 +205,11 @@ impl ArrayBuilder for FixedSizeListBuilder {
     }
 
     fn finish(&mut self) -> ArrayRef {
+        let final_len = self.len();
         assert_eq!(
             self.elements_builder.len(),
-            self.nulls.len() * self.list_size() as usize,
-            "elements length must be equal to the null length times the list size"
+            final_len * self.list_size() as usize,
+            "elements length must be equal to the array length times the list size"
         );
 
         // TODO(connor): Use `new_unchecked` here.
@@ -197,9 +217,468 @@ impl ArrayBuilder for FixedSizeListBuilder {
             self.elements_builder.finish(),
             self.list_size(),
             self.nulls.finish_with_nullability(self.nullability()),
-            self.len(),
+            final_len,
         )
         .vortex_expect("tried to create an invalid `FixedSizeListArray` from a builder")
         .into_array()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use vortex_dtype::DType;
+    use vortex_dtype::Nullability::{NonNullable, Nullable};
+    use vortex_dtype::PType::I32;
+    use vortex_scalar::Scalar;
+
+    use super::FixedSizeListBuilder;
+    use crate::array::Array;
+    use crate::arrays::FixedSizeListArray;
+    use crate::builders::ArrayBuilder;
+    use crate::validity::Validity;
+    use crate::vtable::ValidityHelper;
+    use crate::{IntoArray as _, ToCanonical};
+
+    #[test]
+    fn test_empty() {
+        let mut builder =
+            FixedSizeListBuilder::with_capacity(Arc::new(I32.into()), 3, NonNullable, 0);
+
+        let fsl = builder.finish();
+        assert_eq!(fsl.len(), 0);
+    }
+
+    #[test]
+    fn test_values() {
+        let dtype: Arc<DType> = Arc::new(I32.into());
+        let mut builder = FixedSizeListBuilder::with_capacity(dtype.clone(), 3, NonNullable, 0);
+
+        builder
+            .append_value(
+                Scalar::fixed_size_list(
+                    dtype.clone(),
+                    vec![1i32.into(), 2i32.into(), 3i32.into()],
+                    NonNullable,
+                )
+                .as_list(),
+            )
+            .unwrap();
+
+        builder
+            .append_value(
+                Scalar::fixed_size_list(
+                    dtype,
+                    vec![4i32.into(), 5i32.into(), 6i32.into()],
+                    NonNullable,
+                )
+                .as_list(),
+            )
+            .unwrap();
+
+        let fsl = builder.finish();
+        assert_eq!(fsl.len(), 2);
+
+        let fsl_array = fsl.to_fixed_size_list().unwrap();
+        assert_eq!(fsl_array.elements().len(), 6);
+        assert_eq!(fsl_array.list_size(), 3);
+    }
+
+    #[test]
+    fn test_degenerate_size_zero_non_nullable() {
+        let dtype: Arc<DType> = Arc::new(I32.into());
+        let mut builder =
+            FixedSizeListBuilder::with_capacity(dtype.clone(), 0, NonNullable, 10000000);
+
+        // Append multiple "empty" lists.
+        for _ in 0..100 {
+            builder
+                .append_value(Scalar::fixed_size_list(dtype.clone(), vec![], NonNullable).as_list())
+                .unwrap();
+        }
+
+        let fsl = builder.finish();
+        assert_eq!(fsl.len(), 100);
+
+        let fsl_array = fsl.to_fixed_size_list().unwrap();
+        assert_eq!(fsl_array.list_size(), 0);
+        // The elements array should be empty since list_size is 0.
+        assert_eq!(fsl_array.elements().len(), 0);
+    }
+
+    #[test]
+    fn test_degenerate_size_zero_nullable() {
+        // Use nullable elements since we'll be appending nulls
+        let dtype: Arc<DType> = Arc::new(DType::Primitive(I32, Nullable));
+        let mut builder = FixedSizeListBuilder::with_capacity(dtype.clone(), 0, Nullable, 10000000);
+
+        // Mix of null and non-null empty lists.
+        for i in 0..100 {
+            if i % 2 == 0 {
+                builder
+                    .append_value(
+                        Scalar::fixed_size_list(dtype.clone(), vec![], Nullable).as_list(),
+                    )
+                    .unwrap();
+            } else {
+                builder.append_null();
+            }
+        }
+
+        let fsl = builder.finish();
+        assert_eq!(fsl.len(), 100);
+
+        let fsl_array = fsl.to_fixed_size_list().unwrap();
+        assert_eq!(fsl_array.list_size(), 0);
+        assert_eq!(fsl_array.elements().len(), 0);
+    }
+
+    #[test]
+    fn test_capacity_growth() {
+        let dtype: Arc<DType> = Arc::new(I32.into());
+        // Start with capacity 0.
+        let mut builder = FixedSizeListBuilder::with_capacity(dtype.clone(), 2, NonNullable, 0);
+
+        // Add more items than initial capacity.
+        for i in 0..5 {
+            builder
+                .append_value(
+                    Scalar::fixed_size_list(
+                        dtype.clone(),
+                        vec![(i * 2).into(), (i * 2 + 1).into()],
+                        NonNullable,
+                    )
+                    .as_list(),
+                )
+                .unwrap();
+        }
+
+        let fsl = builder.finish();
+        assert_eq!(fsl.len(), 5);
+
+        let fsl_array = fsl.to_fixed_size_list().unwrap();
+        assert_eq!(fsl_array.elements().len(), 10);
+    }
+
+    #[test]
+    fn test_large_size_zero_capacity_empty_result() {
+        let dtype: Arc<DType> = Arc::new(I32.into());
+        // Large list size but zero capacity and no appends.
+        let mut builder = FixedSizeListBuilder::with_capacity(dtype, 100000000, NonNullable, 0);
+
+        let fsl = builder.finish();
+        assert_eq!(fsl.len(), 0);
+
+        let fsl_array = fsl.to_fixed_size_list().unwrap();
+        assert_eq!(fsl_array.list_size(), 100000000);
+        assert_eq!(fsl_array.elements().len(), 0);
+    }
+
+    #[test]
+    fn test_nullable_lists_non_nullable_elements() {
+        let dtype: Arc<DType> = Arc::new(DType::Primitive(I32, NonNullable));
+        let mut builder = FixedSizeListBuilder::with_capacity(dtype.clone(), 2, Nullable, 0);
+
+        builder
+            .append_value(
+                Scalar::fixed_size_list(dtype.clone(), vec![1i32.into(), 2i32.into()], Nullable)
+                    .as_list(),
+            )
+            .unwrap();
+
+        builder.append_null();
+
+        builder
+            .append_value(
+                Scalar::fixed_size_list(dtype, vec![3i32.into(), 4i32.into()], Nullable).as_list(),
+            )
+            .unwrap();
+
+        let fsl = builder.finish();
+        assert_eq!(fsl.len(), 3);
+
+        let fsl_array = fsl.to_fixed_size_list().unwrap();
+        assert!(fsl_array.validity().is_valid(0));
+        assert!(!fsl_array.validity().is_valid(1));
+        assert!(fsl_array.validity().is_valid(2));
+    }
+
+    #[test]
+    fn test_non_nullable_lists_nullable_elements() {
+        let dtype: Arc<DType> = Arc::new(DType::Primitive(I32, Nullable));
+        let mut builder = FixedSizeListBuilder::with_capacity(dtype.clone(), 3, NonNullable, 0);
+
+        builder
+            .append_value(
+                Scalar::fixed_size_list(
+                    dtype.clone(),
+                    vec![
+                        Scalar::primitive(1i32, Nullable),
+                        Scalar::null(dtype.as_ref().clone()),
+                        Scalar::primitive(3i32, Nullable),
+                    ],
+                    NonNullable,
+                )
+                .as_list(),
+            )
+            .unwrap();
+
+        builder
+            .append_value(
+                Scalar::fixed_size_list(
+                    dtype,
+                    vec![
+                        Scalar::primitive(4i32, Nullable),
+                        Scalar::primitive(5i32, Nullable),
+                        Scalar::primitive(6i32, Nullable),
+                    ],
+                    NonNullable,
+                )
+                .as_list(),
+            )
+            .unwrap();
+
+        let fsl = builder.finish();
+        assert_eq!(fsl.len(), 2);
+
+        let fsl_array = fsl.to_fixed_size_list().unwrap();
+        assert_eq!(fsl_array.elements().len(), 6);
+    }
+
+    #[test]
+    fn test_append_zeros() {
+        let dtype: Arc<DType> = Arc::new(I32.into());
+        let mut builder = FixedSizeListBuilder::with_capacity(dtype, 3, NonNullable, 0);
+
+        builder.append_zeros(5);
+
+        let fsl = builder.finish();
+        assert_eq!(fsl.len(), 5);
+
+        let fsl_array = fsl.to_fixed_size_list().unwrap();
+        assert_eq!(fsl_array.list_size(), 3);
+        assert_eq!(fsl_array.elements().len(), 15);
+
+        // Check that all elements are zeros.
+        let elements_array = fsl_array.elements().to_primitive().unwrap();
+        let elements = elements_array.as_slice::<i32>();
+        assert!(elements.iter().all(|&x| x == 0));
+    }
+
+    #[test]
+    fn test_append_nulls() {
+        // Elements must be nullable if we're going to append null lists
+        let dtype: Arc<DType> = Arc::new(DType::Primitive(I32, Nullable));
+        let mut builder = FixedSizeListBuilder::with_capacity(dtype, 2, Nullable, 0);
+
+        assert_eq!(builder.nullability(), Nullable);
+        builder.append_nulls(3);
+        assert_eq!(builder.len(), 3);
+
+        let fsl = builder.finish();
+        assert_eq!(fsl.len(), 3);
+
+        let fsl_array = fsl.to_fixed_size_list().unwrap();
+        assert_eq!(fsl_array.list_size(), 2);
+
+        // Check that all lists are null.
+        for i in 0..3 {
+            assert!(!fsl_array.validity().is_valid(i));
+        }
+    }
+
+    #[test]
+    fn test_append_zeros_degenerate() {
+        let dtype: Arc<DType> = Arc::new(I32.into());
+        let mut builder = FixedSizeListBuilder::with_capacity(dtype, 0, NonNullable, 0);
+
+        assert_eq!(builder.len(), 0);
+        builder.append_zeros(1000);
+        assert_eq!(builder.len(), 1000);
+
+        let fsl = builder.finish();
+        assert_eq!(fsl.len(), 1000);
+
+        let fsl_array = fsl.to_fixed_size_list().unwrap();
+        assert_eq!(fsl_array.list_size(), 0);
+        assert_eq!(fsl_array.elements().len(), 0);
+    }
+
+    #[test]
+    fn test_invalid_size_error() {
+        let dtype: Arc<DType> = Arc::new(I32.into());
+        let mut builder = FixedSizeListBuilder::with_capacity(dtype.clone(), 3, NonNullable, 0);
+
+        // Try to append a list with wrong size.
+        let result = builder.append_value(
+            Scalar::fixed_size_list(
+                dtype,
+                vec![1i32.into(), 2i32.into()], // Only 2 elements, not 3.
+                NonNullable,
+            )
+            .as_list(),
+        );
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("with fixed size of 3")
+        );
+    }
+
+    #[test]
+    fn test_extend_from_array() {
+        let dtype: Arc<DType> = Arc::new(I32.into());
+
+        // Create a source array.
+        let source = FixedSizeListArray::new(
+            crate::arrays::PrimitiveArray::from_iter([1i32, 2, 3, 4, 5, 6]).into_array(),
+            2,
+            Validity::from_iter([true, false, true]),
+            3,
+        );
+
+        let mut builder = FixedSizeListBuilder::with_capacity(dtype, 2, Nullable, 0);
+
+        let source_array = source.into_array();
+        builder.extend_from_array(&source_array).unwrap();
+        builder.extend_from_array(&source_array).unwrap();
+
+        let fsl = builder.finish();
+        assert_eq!(fsl.len(), 6);
+
+        let fsl_array = fsl.to_fixed_size_list().unwrap();
+        assert_eq!(fsl_array.elements().len(), 12);
+
+        // Check validity pattern is repeated.
+        assert!(fsl_array.validity().is_valid(0));
+        assert!(!fsl_array.validity().is_valid(1));
+        assert!(fsl_array.validity().is_valid(2));
+        assert!(fsl_array.validity().is_valid(3));
+        assert!(!fsl_array.validity().is_valid(4));
+        assert!(fsl_array.validity().is_valid(5));
+    }
+
+    #[test]
+    fn test_extend_degenerate_arrays() {
+        let dtype: Arc<DType> = Arc::new(I32.into());
+
+        // Create degenerate source arrays (size = 0).
+        let source1 = FixedSizeListArray::new(
+            crate::arrays::PrimitiveArray::from_iter::<[i32; 0]>([]).into_array(),
+            0,
+            Validity::from_iter([true, false, true]),
+            3,
+        );
+
+        let source2 = FixedSizeListArray::new(
+            crate::arrays::PrimitiveArray::from_iter::<[i32; 0]>([]).into_array(),
+            0,
+            Validity::from_iter([false, true]),
+            2,
+        );
+
+        let mut builder = FixedSizeListBuilder::with_capacity(dtype, 0, Nullable, 0);
+
+        builder.extend_from_array(&source1.into_array()).unwrap();
+        builder.extend_from_array(&source2.into_array()).unwrap();
+
+        let fsl = builder.finish();
+        assert_eq!(fsl.len(), 5);
+
+        let fsl_array = fsl.to_fixed_size_list().unwrap();
+        assert_eq!(fsl_array.list_size(), 0);
+        assert_eq!(fsl_array.elements().len(), 0);
+
+        // Check validity pattern.
+        assert!(fsl_array.validity().is_valid(0));
+        assert!(!fsl_array.validity().is_valid(1));
+        assert!(fsl_array.validity().is_valid(2));
+        assert!(!fsl_array.validity().is_valid(3));
+        assert!(fsl_array.validity().is_valid(4));
+    }
+
+    #[test]
+    fn test_extend_empty_array() {
+        let dtype: Arc<DType> = Arc::new(I32.into());
+
+        // Create an empty source array.
+        let source = FixedSizeListArray::new(
+            crate::arrays::PrimitiveArray::from_iter::<[i32; 0]>([]).into_array(),
+            3,
+            Validity::NonNullable,
+            0,
+        );
+
+        let mut builder = FixedSizeListBuilder::with_capacity(dtype.clone(), 3, NonNullable, 0);
+
+        // Add some initial data.
+        builder
+            .append_value(
+                Scalar::fixed_size_list(
+                    dtype,
+                    vec![1i32.into(), 2i32.into(), 3i32.into()],
+                    NonNullable,
+                )
+                .as_list(),
+            )
+            .unwrap();
+
+        // Extend with empty array (should be no-op).
+        builder.extend_from_array(&source.into_array()).unwrap();
+
+        let fsl = builder.finish();
+        assert_eq!(fsl.len(), 1);
+    }
+
+    #[test]
+    fn test_mixed_operations() {
+        // Use nullable elements since we'll be appending nulls
+        let dtype: Arc<DType> = Arc::new(DType::Primitive(I32, Nullable));
+        let mut builder = FixedSizeListBuilder::with_capacity(dtype.clone(), 2, Nullable, 0);
+
+        // Mix of operations.
+        builder
+            .append_value(
+                Scalar::fixed_size_list(
+                    dtype,
+                    vec![
+                        Scalar::primitive(1i32, Nullable),
+                        Scalar::primitive(2i32, Nullable),
+                    ],
+                    Nullable,
+                )
+                .as_list(),
+            )
+            .unwrap();
+        builder.append_null();
+        builder.append_zeros(2);
+        builder.append_null();
+
+        // Create source with nullable elements to match builder dtype
+        let source = FixedSizeListArray::new(
+            crate::arrays::PrimitiveArray::from_option_iter([Some(5i32), Some(6)]).into_array(),
+            2,
+            Validity::AllValid,
+            1,
+        );
+        builder.extend_from_array(&source.into_array()).unwrap();
+
+        let fsl = builder.finish();
+        assert_eq!(fsl.len(), 6);
+
+        let fsl_array = fsl.to_fixed_size_list().unwrap();
+        assert_eq!(fsl_array.elements().len(), 12);
+
+        // Check validity.
+        assert!(fsl_array.validity().is_valid(0)); // append_value
+        assert!(!fsl_array.validity().is_valid(1)); // append_null
+        assert!(fsl_array.validity().is_valid(2)); // append_zeros
+        assert!(fsl_array.validity().is_valid(3)); // append_zeros
+        assert!(!fsl_array.validity().is_valid(4)); // append_nulls
+        assert!(fsl_array.validity().is_valid(5)); // extend_from_array
     }
 }

--- a/vortex-array/src/builders/fixed_size_list.rs
+++ b/vortex-array/src/builders/fixed_size_list.rs
@@ -163,8 +163,7 @@ impl ArrayBuilder for FixedSizeListBuilder {
     fn append_nulls(&mut self, n: usize) {
         let element_count = n * self.list_size() as usize;
 
-        // TODO(connor): Does the behavior of `append_nulls` make sense here?
-        // Use nulls if the element type is nullable, otherwise use zeros.
+        // TODO(connor): `append_default()`
         if self.element_dtype().is_nullable() {
             self.elements_builder.append_nulls(element_count);
         } else {

--- a/vortex-array/src/builders/fixed_size_list.rs
+++ b/vortex-array/src/builders/fixed_size_list.rs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::any::Any;
+use std::sync::Arc;
+
+use vortex_dtype::{DType, Nullability};
+use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_panic};
+use vortex_mask::Mask;
+use vortex_scalar::ListScalar;
+
+use crate::arrays::FixedSizeListArray;
+use crate::builders::lazy_validity_builder::LazyNullBufferBuilder;
+use crate::builders::{ArrayBuilder, ArrayBuilderExt, builder_with_capacity};
+use crate::{Array, ArrayRef, IntoArray, ToCanonical};
+
+/// An [`ArrayBuilder`] for creating [`FixedSizeListArray`].
+pub struct FixedSizeListBuilder {
+    /// The [`DType`] of the `FixedSizeList`. This **must** be a [`DType::FixedSizeList`].
+    dtype: DType,
+
+    /// The builder for the underlying elements of the [`FixedSizeListArray`].
+    ///
+    /// This builder will have a capacity equal to the `list_size * capacity`.
+    elements_builder: Box<dyn ArrayBuilder>,
+
+    /// The null map builder of the [`FixedSizeListArray`].
+    ///
+    /// We also use this type to store the length of the final output array.
+    nulls: LazyNullBufferBuilder,
+}
+
+impl FixedSizeListBuilder {
+    /// Creates a new [`FixedSizeListArray`] builder.
+    pub fn with_capacity(
+        element_dtype: Arc<DType>,
+        list_size: u32,
+        nullability: Nullability,
+        capacity: usize,
+    ) -> Self {
+        let elements_capacity = capacity * list_size as usize;
+
+        let elements_builder = builder_with_capacity(&element_dtype, elements_capacity);
+        let fsl_dtype = DType::FixedSizeList(element_dtype, list_size, nullability);
+        let nulls = LazyNullBufferBuilder::new(capacity);
+
+        Self {
+            dtype: fsl_dtype,
+            elements_builder,
+            nulls,
+        }
+    }
+
+    /// Adds a value to the [`FixedSizeListArray`] that we are building.
+    ///
+    /// Note that a [`ListScalar`] can represent both a [`ListArray`] scalar **and** a
+    /// [`FixedSizeListArray`] scalar.
+    ///
+    /// [`ListArray`]: crate::arrays::ListArray
+    pub fn append_value(&mut self, value: ListScalar) -> VortexResult<()> {
+        // Validate that the list scalar has an equal size to our `list_size`.
+
+        if value.len() != self.list_size() as usize {
+            vortex_bail!(
+                "Tried to append a `ListScalar` with length {} to a `FixedSizeListScalar` with fixed size of {}",
+                value.len(),
+                self.list_size()
+            );
+        }
+
+        let Some(elements) = value.elements() else {
+            // If `elements` is `None`, then the `value` is a null value.
+            self.append_null();
+            return Ok(());
+        };
+
+        for scalar in elements {
+            // TODO(connor): This is slow, we should be able to append multiple values at once, or
+            // the list scalar should hold an Array
+            self.elements_builder.append_scalar(&scalar)?;
+        }
+        self.nulls.append_non_null();
+
+        Ok(())
+    }
+
+    pub fn list_size(&self) -> u32 {
+        let DType::FixedSizeList(_, list_size, _) = self.dtype else {
+            vortex_panic!(
+                "`FixedSizeListBuilder` has an incorrect dtype: {}",
+                self.dtype
+            );
+        };
+
+        list_size
+    }
+
+    pub fn nullability(&self) -> Nullability {
+        let DType::FixedSizeList(_, _, nullability) = self.dtype else {
+            vortex_panic!(
+                "`FixedSizeListBuilder` has an incorrect dtype: {}",
+                self.dtype
+            );
+        };
+
+        nullability
+    }
+
+    /// Returns the current length of underlying `elements` array.
+    fn elements_len(&self) -> usize {
+        self.len() * self.list_size() as usize
+    }
+}
+
+impl ArrayBuilder for FixedSizeListBuilder {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn dtype(&self) -> &DType {
+        &self.dtype
+    }
+
+    fn len(&self) -> usize {
+        self.nulls.len()
+    }
+
+    /// We define the "zero" value of a fixed-size list of size `m` to be a list of `m` zero values
+    /// (where "zero value" is defined by the element [`DType`]).
+    ///
+    /// We append `n * m` of these values to the underlying `elements` array.
+    fn append_zeros(&mut self, n: usize) {
+        self.elements_builder
+            .append_zeros(n * self.list_size() as usize);
+        self.nulls.append_n_non_nulls(n);
+    }
+
+    /// We define the null value of a fixed-size list of size `m` to be a list of `m` null values.
+    ///
+    /// We append `n * m` of these null values to the underlying `elements` array.
+    fn append_nulls(&mut self, n: usize) {
+        self.elements_builder
+            .append_nulls(n * self.list_size() as usize);
+        self.nulls.append_n_nulls(n);
+    }
+
+    /// This will increase the capacity if extending with this `array` would go past the original
+    /// capacity.
+    fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
+        // TODO(connor): This check should be in every single `extend_from_array` implementation.
+        assert_eq!(
+            self.dtype(),
+            array.dtype(),
+            "tried to extend an array with an array of a different `DType`"
+        );
+
+        let fsl = array.to_fixed_size_list()?;
+        if fsl.is_empty() {
+            return Ok(());
+        }
+
+        let new_elements = fsl.elements();
+
+        self.elements_builder
+            .ensure_capacity(self.elements_len() + new_elements.len());
+        self.elements_builder.extend_from_array(new_elements)?;
+
+        self.nulls.append_validity_mask(array.validity_mask());
+
+        Ok(())
+    }
+
+    fn ensure_capacity(&mut self, capacity: usize) {
+        self.elements_builder
+            .ensure_capacity(capacity * self.list_size() as usize);
+        self.nulls.ensure_capacity(capacity);
+    }
+
+    fn set_validity(&mut self, validity: Mask) {
+        self.nulls = LazyNullBufferBuilder::new(validity.len());
+        self.nulls.append_validity_mask(validity);
+    }
+
+    fn finish(&mut self) -> ArrayRef {
+        assert_eq!(
+            self.elements_builder.len(),
+            self.nulls.len() * self.list_size() as usize,
+            "elements length must be equal to the null length times the list size"
+        );
+
+        // TODO(connor): Use `new_unchecked` here.
+        FixedSizeListArray::try_new(
+            self.elements_builder.finish(),
+            self.list_size(),
+            self.nulls.finish_with_nullability(self.nullability()),
+            self.len(),
+        )
+        .vortex_expect("tried to create an invalid `FixedSizeListArray` from a builder")
+        .into_array()
+    }
+}

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -147,12 +147,6 @@ impl<O: OffsetPType> ArrayBuilder for ListBuilder<O> {
     }
 
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
-        assert_eq!(
-            self.dtype(),
-            array.dtype(),
-            "tried to extend an array with an array of a different `DType`"
-        );
-
         let list = array.to_list()?;
         if list.is_empty() {
             return Ok(());

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -22,6 +22,7 @@ pub struct ListBuilder<O: NativePType> {
     /// Represents the offsets into the values array.
     index_builder: PrimitiveBuilder<O>,
     nulls: LazyNullBufferBuilder,
+    // TODO(connor): This can probably be removed since we store it in the `dtype` field as well.
     nullability: Nullability,
     dtype: DType,
 }
@@ -85,8 +86,8 @@ impl<O: OffsetPType> ListBuilder<O> {
             }
             Some(elements) => {
                 for scalar in elements {
-                    // TODO(joe): This is slow, we should be able to append multiple values at once,
-                    // or the list scalar should hold an Array
+                    // TODO(connor): This is slow, we should be able to append multiple values at
+                    // once, or the list scalar should hold an Array
                     self.value_builder.append_scalar(&scalar)?;
                 }
                 self.nulls.append_non_null();
@@ -146,6 +147,12 @@ impl<O: OffsetPType> ArrayBuilder for ListBuilder<O> {
     }
 
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
+        assert_eq!(
+            self.dtype(),
+            array.dtype(),
+            "tried to extend an array with an array of a different `DType`"
+        );
+
         let list = array.to_list()?;
         if list.is_empty() {
             return Ok(());
@@ -205,6 +212,7 @@ impl<O: OffsetPType> ArrayBuilder for ListBuilder<O> {
             "Indices length must be one more than nulls length."
         );
 
+        // TODO(connor): Use `new_unchecked` here.
         ListArray::try_new(
             self.value_builder.finish(),
             self.index_builder.finish(),

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -31,6 +31,7 @@
 mod bool;
 mod decimal;
 mod extension;
+mod fixed_size_list;
 mod lazy_validity_builder;
 mod list;
 mod null;
@@ -43,6 +44,7 @@ use std::any::Any;
 pub use bool::*;
 pub use decimal::*;
 pub use extension::*;
+pub use fixed_size_list::*;
 pub use list::*;
 pub use null::*;
 pub use primitive::*;

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -74,6 +74,8 @@ pub trait ArrayBuilder: Send {
         self.len() == 0
     }
 
+    // TODO(connor): We should probably merge these 4 methods to `append_defaults`.
+
     /// Append a "zero" value to the array.
     fn append_zero(&mut self) {
         self.append_zeros(1)
@@ -90,6 +92,8 @@ pub trait ArrayBuilder: Send {
     /// Appends n "null" values to the array.
     fn append_nulls(&mut self, n: usize);
 
+    // TODO(connor): Document the fact that the passed in `array` is validated to have the correct
+    // dtype via the VTable.
     /// Extends the array with the provided array, canonicalizing if necessary.
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()>;
 

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -141,6 +141,7 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
         self.nulls.append_n_non_nulls(n);
     }
 
+    // TODO(connor): Shouldn't this check if the dtype is nullable? Otherwise this is just wrong...
     fn append_nulls(&mut self, n: usize) {
         self.values.push_n(T::default(), n);
         self.nulls.append_n_nulls(n);

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -141,7 +141,6 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
         self.nulls.append_n_non_nulls(n);
     }
 
-    // TODO(connor): Shouldn't this check if the dtype is nullable? Otherwise this is just wrong...
     fn append_nulls(&mut self, n: usize) {
         self.values.push_n(T::default(), n);
         self.nulls.append_n_nulls(n);


### PR DESCRIPTION
Tracking Issue: https://github.com/vortex-data/vortex/issues/4372

Adds support for `FixedSizeListBuilder: ArrayBuilder`. I don't actually _use_ the builder where it needs to be yet, but I am going to leave that for a followup PR.

Additionally adds unit tests for the builder, making sure to test the degenerate cases.

Also note that some of the TODOs with respect to the `append_zero` and `append_null`s will be solved in the next PR I do so don't worry too much about those...