### PR TITLE
chore: better cast errors

### DIFF
--- a/vortex-expr/src/exprs/cast.rs
+++ b/vortex-expr/src/exprs/cast.rs
@@ -81,7 +81,13 @@ impl VTable for CastVTable {
 
     fn evaluate(expr: &Self::Expr, scope: &Scope) -> VortexResult<ArrayRef> {
         let array = expr.child.evaluate(scope)?;
-        compute_cast(&array, &expr.target)
+        compute_cast(&array, &expr.target).map_err(|e| {
+            e.with_context(format!(
+                "Failed to cast array of dtype {} to {}",
+                array.dtype(),
+                expr.target
+            ))
+        })
     }
 
     fn return_dtype(expr: &Self::Expr, _scope: &DType) -> VortexResult<DType> {

--- a/vortex-expr/src/exprs/pack.rs
+++ b/vortex-expr/src/exprs/pack.rs
@@ -107,7 +107,15 @@ impl VTable for PackVTable {
         let value_arrays = expr
             .values
             .iter()
-            .map(|value_expr| value_expr.unchecked_evaluate(scope))
+            .zip_eq(expr.names.iter())
+            .map(|(value_expr, name)| {
+                value_expr.unchecked_evaluate(scope).map_err(|e| {
+                    e.with_context(format!(
+                        "Can't evaluate '{name}'\nvalues:{}'",
+                        scope.display_values()
+                    ))
+                })
+            })
             .process_results(|it| it.collect::<Vec<_>>())?;
         let validity = match expr.nullability {
             Nullability::NonNullable => Validity::NonNullable,

--- a/vortex-expr/src/exprs/pack.rs
+++ b/vortex-expr/src/exprs/pack.rs
@@ -109,12 +109,9 @@ impl VTable for PackVTable {
             .iter()
             .zip_eq(expr.names.iter())
             .map(|(value_expr, name)| {
-                value_expr.unchecked_evaluate(scope).map_err(|e| {
-                    e.with_context(format!(
-                        "Can't evaluate '{name}'\nvalues:{}'",
-                        scope.display_values()
-                    ))
-                })
+                value_expr
+                    .unchecked_evaluate(scope)
+                    .map_err(|e| e.with_context(format!("Can't evaluate '{name}'")))
             })
             .process_results(|it| it.collect::<Vec<_>>())?;
         let validity = match expr.nullability {


### PR DESCRIPTION
Without this PR it just shows: `Error: Vortex error: Cannot cast array with invalid values to non-nullable type.` - super hard to understand what columns are involved