### PR TITLE
chore: rudimentary Python benchmarks & support more Polars types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,11 @@ jobs:
           uv run --all-packages pytest --benchmark-disable test/
         working-directory: vortex-python/
 
+      - name: Pytest Benchmarks - Vortex
+        run: |
+          uv run --all-packages pytest --benchmark-only benchmark/
+        working-directory: vortex-python/
+
       - name: Doctest - PyVortex
         run: |
           uv run --all-packages make doctest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev-dependencies = [
     "pytest>=7.4.0",
     "ruff>=0.7.1",
     "ray>=2.48",
+    "pytest-benchmark>=5.1.0",
 ]
 
 [tool.uv.workspace]

--- a/uv.lock
+++ b/uv.lock
@@ -1645,6 +1645,7 @@ dev = [
     { name = "pandas-stubs" },
     { name = "pcodec" },
     { name = "pyarrow-stubs" },
+    { name = "pytest-benchmark" },
 ]
 
 [package.metadata]
@@ -1666,6 +1667,7 @@ dev = [
     { name = "pandas-stubs", specifier = ">=2.2.3.241126" },
     { name = "pcodec", specifier = ">=0.3.3" },
     { name = "pyarrow-stubs", specifier = ">=17.16" },
+    { name = "pytest-benchmark", specifier = ">=5.1.0" },
 ]
 
 [[package]]
@@ -1850,6 +1852,7 @@ dev = [
     { name = "pyarrow-stubs", specifier = ">=17.16" },
     { name = "pytest", specifier = ">=7.4.0" },
     { name = "pytest-benchmark", specifier = ">=4.0.0" },
+    { name = "pytest-benchmark", specifier = ">=5.1.0" },
     { name = "ray", specifier = ">=2.48" },
     { name = "ruff", specifier = ">=0.7.1" },
 ]

--- a/vortex-python/benchmark/__init__.py
+++ b/vortex-python/benchmark/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors

--- a/vortex-python/benchmark/conftest.py
+++ b/vortex-python/benchmark/conftest.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+from typing import Any
+import hashlib
+import math
+import os
+import pyarrow as pa
+import pytest
+import vortex as vx
+
+
+@pytest.fixture(
+    scope="session",
+    params=[{"x"}, {"x", "y"}, {"x", "z"}, {"x", "y", "z"}],
+    ids=["int", "int_str", "int_float", "int_str_float"],
+)
+def vxf(tmpdir_factory: pytest.TempPathFactory, request: pytest.FixtureRequest) -> vx.VortexFile:
+    fname = tmpdir_factory.mktemp("data") / "foo.vortex"
+
+    if not os.path.exists(fname):
+        length = 100_000
+
+        columns: dict[str, list[int] | list[float] | list[str]] = {}
+        assert "x" in request.param  # pyright: ignore[reportAny]
+        columns["x"] = list(range(length))
+
+        if "y" in request.param:  # pyright: ignore[reportAny]
+            columns["y"] = [hashlib.md5(x.to_bytes(length=4), usedforsecurity=False).hexdigest() for x in range(length)]
+        if "z" in request.param:  # pyright: ignore[reportAny]
+            columns["z"] = [math.sqrt(x) for x in range(length)]
+
+        a = vx.array(pa.table(columns))  # pyright: ignore[reportCallIssue, reportUnknownArgumentType, reportArgumentType]
+        vx.io.write(a, str(fname))
+    return vx.open(str(fname))

--- a/vortex-python/benchmark/conftest.py
+++ b/vortex-python/benchmark/conftest.py
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-from typing import Any
 import hashlib
 import math
 import os
+
 import pyarrow as pa
 import pytest
+
 import vortex as vx
 
 

--- a/vortex-python/benchmark/test_aggregation.py
+++ b/vortex-python/benchmark/test_aggregation.py
@@ -2,12 +2,14 @@
 # SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 from typing import Literal
+
 import duckdb
-import vortex as vx
 import pyarrow as pa
-from pyarrow.types import is_integer, is_floating
 import pytest
+from pyarrow.types import is_floating, is_integer
 from pytest_benchmark.fixture import BenchmarkFixture  # pyright: ignore[reportMissingTypeStubs]
+
+import vortex as vx
 
 
 def _has_mean(t: pa.DataType) -> bool:

--- a/vortex-python/benchmark/test_aggregation.py
+++ b/vortex-python/benchmark/test_aggregation.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+from typing import Literal
+import duckdb
+import vortex as vx
+import pyarrow as pa
+from pyarrow.types import is_integer, is_floating
+import pytest
+from pytest_benchmark.fixture import BenchmarkFixture  # pyright: ignore[reportMissingTypeStubs]
+
+
+def _has_mean(t: pa.DataType) -> bool:
+    return is_integer(t) or is_floating(t)
+
+
+@pytest.mark.benchmark(group="aggregation", disable_gc=True)
+def test_arrow_table_aggregation(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
+    aggregations: list[tuple[str, Literal["mean"]]] = [
+        (field.name, "mean")
+        for field in vxf.dtype.to_arrow_schema()  # pyright: ignore[reportUnknownVariableType]
+        if _has_mean(field.type)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+    ]
+    benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in vxf.scan()).group_by([]).aggregate(aggregations))
+
+
+@pytest.mark.benchmark(group="aggregation", disable_gc=True)
+def test_polars_aggregation(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
+    lf = vxf.to_polars()
+    benchmark(lambda: lf.mean().collect().to_arrow())
+
+
+@pytest.mark.benchmark(group="aggregation", disable_gc=True)
+def test_polars_streaming_aggregation(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
+    lf = vxf.to_polars()
+    benchmark(lambda: lf.mean().collect(engine="streaming").to_arrow())
+
+
+@pytest.mark.benchmark(group="aggregation", disable_gc=True)
+def test_duckdb_aggregation(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
+    conn = duckdb.connect(database=":memory:")  # pyright: ignore[reportUnknownMemberType]
+    ds = vxf.to_dataset()
+    _ = conn.register("ds", ds)
+    aggregations = ",".join(
+        [f"avg(ds.{field.name}) as {field.name}" for field in vxf.dtype.to_arrow_schema() if _has_mean(field.type)]  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType, reportUnknownArgumentType]
+    )
+    print(aggregations)
+    query = f"select {aggregations} from ds"
+    benchmark(lambda: conn.sql(query).to_arrow_table())

--- a/vortex-python/benchmark/test_filter.py
+++ b/vortex-python/benchmark/test_filter.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+import duckdb
+import polars as pl
+import pyarrow as pa
+import pytest
+import vortex as vx
+from vortex.expr import column
+from pytest_benchmark.fixture import BenchmarkFixture  # pyright: ignore[reportMissingTypeStubs]
+
+
+@pytest.mark.benchmark(group="filter", disable_gc=True)
+def test_scan_filter(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
+    benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in vxf.scan(expr=column("x") >= 50_000)))
+
+
+@pytest.mark.benchmark(group="filter", disable_gc=True)
+def test_repeated_scan_filter(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
+    rscan = vxf.to_repeated_scan(expr=column("x") > 50_000)
+    benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in rscan.execute()))
+
+
+@pytest.mark.benchmark(group="filter", disable_gc=True)
+def test_polars_filter(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
+    lf = vxf.to_polars()
+    benchmark(lambda: lf.filter(pl.col("x") >= pl.lit(50_000).cast(pl.Int64)).collect().to_arrow())
+
+
+@pytest.mark.benchmark(group="filter", disable_gc=True)
+def test_polars_streaming_filter(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
+    lf = vxf.to_polars()
+    benchmark(lambda: lf.filter(pl.col("x") >= pl.lit(50_000).cast(pl.Int64)).collect(engine="streaming").to_arrow())
+
+
+@pytest.mark.benchmark(group="filter", disable_gc=True)
+def test_duckdb_filter(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
+    conn = duckdb.connect(database=":memory:")  # pyright: ignore[reportUnknownMemberType]
+    ds = vxf.to_dataset()
+    _ = conn.register("ds", ds)
+    benchmark(lambda: conn.sql("select ds.x from ds where x >= 50000").to_arrow_table())

--- a/vortex-python/benchmark/test_filter.py
+++ b/vortex-python/benchmark/test_filter.py
@@ -5,9 +5,10 @@ import duckdb
 import polars as pl
 import pyarrow as pa
 import pytest
+from pytest_benchmark.fixture import BenchmarkFixture  # pyright: ignore[reportMissingTypeStubs]
+
 import vortex as vx
 from vortex.expr import column
-from pytest_benchmark.fixture import BenchmarkFixture  # pyright: ignore[reportMissingTypeStubs]
 
 
 @pytest.mark.benchmark(group="filter", disable_gc=True)

--- a/vortex-python/benchmark/test_scalar_at.py
+++ b/vortex-python/benchmark/test_scalar_at.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+import duckdb
+import pyarrow as pa
+import pytest
+import vortex as vx
+from pytest_benchmark.fixture import BenchmarkFixture  # pyright: ignore[reportMissingTypeStubs]
+
+
+@pytest.mark.benchmark(group="scalar_at", disable_gc=True)
+def test_scan_scalar_at(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
+    benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in vxf.scan(indices=vx.array([50_000]))))
+
+
+@pytest.mark.benchmark(group="scalar_at", disable_gc=True)
+def test_repeated_scan_scalar_at(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
+    rscan = vxf.to_repeated_scan()
+    benchmark(lambda: rscan.scalar_at(50_000))
+
+
+@pytest.mark.benchmark(group="scalar_at", disable_gc=True)
+def test_polars_scalar_at(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
+    lf = vxf.to_polars()
+    benchmark(lambda: lf.slice(50_000, 50_001).collect().to_arrow())
+
+
+@pytest.mark.benchmark(group="scalar_at", disable_gc=True)
+def test_polars_streaming_scalar_at(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
+    lf = vxf.to_polars()
+    benchmark(lambda: lf.slice(50_000, 50_001).collect(engine="streaming").to_arrow())
+
+
+@pytest.mark.benchmark(group="scalar_at", disable_gc=True)
+def test_duckdb_scalar_at(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
+    conn = duckdb.connect(database=":memory:")  # pyright: ignore[reportUnknownMemberType]
+    ds = vxf.to_dataset()
+    _ = conn.register("ds", ds)
+    benchmark(lambda: conn.sql("select ds.x from ds offset 50000 limit 1").to_arrow_table())

--- a/vortex-python/benchmark/test_scalar_at.py
+++ b/vortex-python/benchmark/test_scalar_at.py
@@ -4,8 +4,9 @@
 import duckdb
 import pyarrow as pa
 import pytest
-import vortex as vx
 from pytest_benchmark.fixture import BenchmarkFixture  # pyright: ignore[reportMissingTypeStubs]
+
+import vortex as vx
 
 
 @pytest.mark.benchmark(group="scalar_at", disable_gc=True)

--- a/vortex-python/benchmark/test_scan.py
+++ b/vortex-python/benchmark/test_scan.py
@@ -1,101 +1,39 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-import os
-
 import duckdb
-import polars as pl
 import pyarrow as pa
 import pytest
+import vortex as vx
 from pytest_benchmark.fixture import BenchmarkFixture  # pyright: ignore[reportMissingTypeStubs]
 
-import vortex as vx
-from vortex.expr import column
 
-
-@pytest.fixture(scope="session")
-def vxf(tmpdir_factory: pytest.TempPathFactory) -> vx.VortexFile:
-    fname = tmpdir_factory.mktemp("data") / "foo.vortex"
-
-    if not os.path.exists(fname):
-        a = vx.array(pa.table({"x": list(range(1_000_000))}))
-        vx.io.write(a, str(fname))
-    return vx.open(str(fname))
-
-
+@pytest.mark.benchmark(group="scan", disable_gc=True)
 def test_scan(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in vxf.scan()))
 
 
-def test_scan_scalar_at(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
-    benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in vxf.scan(indices=vx.array([50_000]))))
-
-
-def test_scan_filter(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
-    benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in vxf.scan(expr=column("x") >= 500_000)))
-
-
+@pytest.mark.benchmark(group="scan", disable_gc=True)
 def test_repeated_scan(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     rscan = vxf.to_repeated_scan()
     benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in rscan.execute()))
 
 
-def test_repeated_scan_scalar_at(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
-    rscan = vxf.to_repeated_scan()
-    benchmark(lambda: rscan.scalar_at(50_000))
-
-
-def test_repeated_scan_filter(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
-    rscan = vxf.to_repeated_scan(expr=column("x") > 500_000)
-    benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in rscan.execute()))
-
-
+@pytest.mark.benchmark(group="scan", disable_gc=True)
 def test_polars(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     lf = vxf.to_polars()
     benchmark(lambda: lf.collect().to_arrow())
 
 
-def test_polars_scalar_at(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
-    lf = vxf.to_polars()
-    benchmark(lambda: lf.slice(50_000, 50_001).collect().to_arrow())
-
-
-def test_polars_filter(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
-    lf = vxf.to_polars()
-    benchmark(lambda: lf.filter(pl.col("x") >= pl.lit(500000).cast(pl.Int64)).collect().to_arrow())
-
-
+@pytest.mark.benchmark(group="scan", disable_gc=True)
 def test_polars_streaming(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     lf = vxf.to_polars()
     benchmark(lambda: lf.collect(engine="streaming").to_arrow())
 
 
-def test_polars_streaming_scalar_at(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
-    lf = vxf.to_polars()
-    benchmark(lambda: lf.slice(50_000, 50_001).collect(engine="streaming").to_arrow())
-
-
-def test_polars_streaming_filter(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
-    lf = vxf.to_polars()
-    benchmark(lambda: lf.filter(pl.col("x") >= pl.lit(500000).cast(pl.Int64)).collect(engine="streaming").to_arrow())
-
-
+@pytest.mark.benchmark(group="scan", disable_gc=True)
 def test_duckdb(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     conn = duckdb.connect(database=":memory:")  # pyright: ignore[reportUnknownMemberType]
     ds = vxf.to_dataset()
     _ = conn.register("ds", ds)
     benchmark(lambda: conn.sql("select ds.x from ds").to_arrow_table())
-
-
-def test_duckdb_scalar_at(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
-    conn = duckdb.connect(database=":memory:")  # pyright: ignore[reportUnknownMemberType]
-    ds = vxf.to_dataset()
-    _ = conn.register("ds", ds)
-    benchmark(lambda: conn.sql("select ds.x from ds offset 50000 limit 1").to_arrow_table())
-
-
-def test_duckdb_filter(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
-    conn = duckdb.connect(database=":memory:")  # pyright: ignore[reportUnknownMemberType]
-    ds = vxf.to_dataset()
-    _ = conn.register("ds", ds)
-    benchmark(lambda: conn.sql("select ds.x from ds where x >= 500000").to_arrow_table())

--- a/vortex-python/benchmark/test_scan.py
+++ b/vortex-python/benchmark/test_scan.py
@@ -4,8 +4,9 @@
 import duckdb
 import pyarrow as pa
 import pytest
-import vortex as vx
 from pytest_benchmark.fixture import BenchmarkFixture  # pyright: ignore[reportMissingTypeStubs]
+
+import vortex as vx
 
 
 @pytest.mark.benchmark(group="scan", disable_gc=True)

--- a/vortex-python/benchmark/test_scan.py
+++ b/vortex-python/benchmark/test_scan.py
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-import duckdb
 import os
+
+import duckdb
 import polars as pl
 import pyarrow as pa
 import pytest
-import vortex as vx
 from pytest_benchmark.fixture import BenchmarkFixture  # pyright: ignore[reportMissingTypeStubs]
+
+import vortex as vx
 from vortex.expr import column
 
 

--- a/vortex-python/benchmark/test_scan.py
+++ b/vortex-python/benchmark/test_scan.py
@@ -9,13 +9,13 @@ from vortex.expr import column
 
 
 @pytest.fixture(scope="session")
-def vxf(tmpdir_factory) -> vx.VortexFile:  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
-    fname = tmpdir_factory.mktemp("data") / "foo.vortex"  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+def vxf(tmpdir_factory: pytest.TempPathFactory) -> vx.VortexFile:
+    fname = tmpdir_factory.mktemp("data") / "foo.vortex"
 
-    if not os.path.exists(fname):  # pyright: ignore[reportUnknownArgumentType]
+    if not os.path.exists(fname):
         a = vx.array(pa.table({"x": list(range(1_000_000))}))
-        vx.io.write(a, str(fname))  # pyright: ignore[reportUnknownArgumentType]
-    return vx.open(str(fname))  # pyright: ignore[reportUnknownArgumentType]
+        vx.io.write(a, str(fname))
+    return vx.open(str(fname))
 
 
 def test_scan(benchmark: BenchmarkFixture, vxf: vx.VortexFile):

--- a/vortex-python/benchmark/test_scan.py
+++ b/vortex-python/benchmark/test_scan.py
@@ -4,6 +4,7 @@ import polars as pl
 import pyarrow as pa
 import pytest
 import vortex as vx
+from pytest_benchmark.fixture import BenchmarkFixture  # pyright: ignore[reportMissingTypeStubs]
 from vortex.expr import column
 
 
@@ -17,78 +18,78 @@ def vxf(tmpdir_factory) -> vx.VortexFile:  # pyright: ignore[reportUnknownParame
     return vx.open(str(fname))  # pyright: ignore[reportUnknownArgumentType]
 
 
-def test_scan(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+def test_scan(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in vxf.scan()))
 
 
-def test_scan_scalar_at(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+def test_scan_scalar_at(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in vxf.scan(indices=vx.array([50_000]))))
 
 
-def test_scan_filter(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+def test_scan_filter(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in vxf.scan(expr=column("x") >= 500_000)))
 
 
-def test_repeated_scan(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+def test_repeated_scan(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     rscan = vxf.to_repeated_scan()
     benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in rscan.execute()))
 
 
-def test_repeated_scan_scalar_at(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+def test_repeated_scan_scalar_at(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     rscan = vxf.to_repeated_scan()
     benchmark(lambda: rscan.scalar_at(50_000))
 
 
-def test_repeated_scan_filter(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+def test_repeated_scan_filter(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     rscan = vxf.to_repeated_scan(expr=column("x") > 500_000)
     benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in rscan.execute()))
 
 
-def test_polars(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+def test_polars(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     lf = vxf.to_polars()
     benchmark(lambda: lf.collect().to_arrow())
 
 
-def test_polars_scalar_at(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+def test_polars_scalar_at(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     lf = vxf.to_polars()
     benchmark(lambda: lf.slice(50_000, 50_001).collect().to_arrow())
 
 
-def test_polars_filter(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+def test_polars_filter(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     lf = vxf.to_polars()
     benchmark(lambda: lf.filter(pl.col("x") >= pl.lit(500000).cast(pl.Int64)).collect().to_arrow())
 
 
-def test_polars_streaming(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+def test_polars_streaming(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     lf = vxf.to_polars()
     benchmark(lambda: lf.collect(engine="streaming").to_arrow())
 
 
-def test_polars_streaming_scalar_at(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+def test_polars_streaming_scalar_at(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     lf = vxf.to_polars()
     benchmark(lambda: lf.slice(50_000, 50_001).collect(engine="streaming").to_arrow())
 
 
-def test_polars_streaming_filter(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+def test_polars_streaming_filter(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     lf = vxf.to_polars()
     benchmark(lambda: lf.filter(pl.col("x") >= pl.lit(500000).cast(pl.Int64)).collect(engine="streaming").to_arrow())
 
 
-def test_duckdb(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+def test_duckdb(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     conn = duckdb.connect(database=":memory:")  # pyright: ignore[reportUnknownMemberType]
     ds = vxf.to_dataset()
     _ = conn.register("ds", ds)
     benchmark(lambda: conn.sql("select ds.x from ds").to_arrow_table())
 
 
-def test_duckdb_scalar_at(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+def test_duckdb_scalar_at(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     conn = duckdb.connect(database=":memory:")  # pyright: ignore[reportUnknownMemberType]
     ds = vxf.to_dataset()
     _ = conn.register("ds", ds)
     benchmark(lambda: conn.sql("select ds.x from ds offset 50000 limit 1").to_arrow_table())
 
 
-def test_duckdb_filter(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+def test_duckdb_filter(benchmark: BenchmarkFixture, vxf: vx.VortexFile):
     conn = duckdb.connect(database=":memory:")  # pyright: ignore[reportUnknownMemberType]
     ds = vxf.to_dataset()
     _ = conn.register("ds", ds)

--- a/vortex-python/benchmark/test_scan.py
+++ b/vortex-python/benchmark/test_scan.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
 import duckdb
 import os
 import polars as pl

--- a/vortex-python/benchmark/test_scan.py
+++ b/vortex-python/benchmark/test_scan.py
@@ -1,0 +1,95 @@
+import duckdb
+import os
+import polars as pl
+import pyarrow as pa
+import pytest
+import vortex as vx
+from vortex.expr import column
+
+
+@pytest.fixture(scope="session")
+def vxf(tmpdir_factory) -> vx.VortexFile:  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+    fname = tmpdir_factory.mktemp("data") / "foo.vortex"  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+
+    if not os.path.exists(fname):  # pyright: ignore[reportUnknownArgumentType]
+        a = vx.array(pa.table({"x": list(range(1_000_000))}))
+        vx.io.write(a, str(fname))  # pyright: ignore[reportUnknownArgumentType]
+    return vx.open(str(fname))  # pyright: ignore[reportUnknownArgumentType]
+
+
+def test_scan(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+    benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in vxf.scan()))
+
+
+def test_scan_scalar_at(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+    benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in vxf.scan(indices=vx.array([50_000]))))
+
+
+def test_scan_filter(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+    benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in vxf.scan(expr=column("x") >= 500_000)))
+
+
+def test_repeated_scan(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+    rscan = vxf.to_repeated_scan()
+    benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in rscan.execute()))
+
+
+def test_repeated_scan_scalar_at(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+    rscan = vxf.to_repeated_scan()
+    benchmark(lambda: rscan.scalar_at(50_000))
+
+
+def test_repeated_scan_filter(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+    rscan = vxf.to_repeated_scan(expr=column("x") > 500_000)
+    benchmark(lambda: pa.concat_tables(x.to_arrow_table() for x in rscan.execute()))
+
+
+def test_polars(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+    lf = vxf.to_polars()
+    benchmark(lambda: lf.collect().to_arrow())
+
+
+def test_polars_scalar_at(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+    lf = vxf.to_polars()
+    benchmark(lambda: lf.slice(50_000, 50_001).collect().to_arrow())
+
+
+def test_polars_filter(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+    lf = vxf.to_polars()
+    benchmark(lambda: lf.filter(pl.col("x") >= pl.lit(500000).cast(pl.Int64)).collect().to_arrow())
+
+
+def test_polars_streaming(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+    lf = vxf.to_polars()
+    benchmark(lambda: lf.collect(engine="streaming").to_arrow())
+
+
+def test_polars_streaming_scalar_at(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+    lf = vxf.to_polars()
+    benchmark(lambda: lf.slice(50_000, 50_001).collect(engine="streaming").to_arrow())
+
+
+def test_polars_streaming_filter(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+    lf = vxf.to_polars()
+    benchmark(lambda: lf.filter(pl.col("x") >= pl.lit(500000).cast(pl.Int64)).collect(engine="streaming").to_arrow())
+
+
+def test_duckdb(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+    conn = duckdb.connect(database=":memory:")  # pyright: ignore[reportUnknownMemberType]
+    ds = vxf.to_dataset()
+    _ = conn.register("ds", ds)
+    benchmark(lambda: conn.sql("select ds.x from ds").to_arrow_table())
+
+
+def test_duckdb_scalar_at(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+    conn = duckdb.connect(database=":memory:")  # pyright: ignore[reportUnknownMemberType]
+    ds = vxf.to_dataset()
+    _ = conn.register("ds", ds)
+    benchmark(lambda: conn.sql("select ds.x from ds offset 50000 limit 1").to_arrow_table())
+
+
+def test_duckdb_filter(benchmark, vxf: vx.VortexFile):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+    conn = duckdb.connect(database=":memory:")  # pyright: ignore[reportUnknownMemberType]
+    ds = vxf.to_dataset()
+    _ = conn.register("ds", ds)
+    benchmark(lambda: conn.sql("select ds.x from ds where x >= 500000").to_arrow_table())

--- a/vortex-python/pyproject.toml
+++ b/vortex-python/pyproject.toml
@@ -72,4 +72,5 @@ dev = [
     "pandas-stubs>=2.2.3.241126",
     "pcodec>=0.3.3",
     "pyarrow-stubs>=17.16",
+    "pytest-benchmark>=5.1.0",
 ]

--- a/vortex-python/python/vortex/polars_.py
+++ b/vortex-python/python/vortex/polars_.py
@@ -84,8 +84,20 @@ def _polars_to_vortex(expr: dict[str, Any]) -> ve.Expr:  # pyright: ignore[repor
         elif "Float" in scalar:
             value = scalar["Float"]  # pyright: ignore[reportAny]
             dtype = "Float64"
+        elif "Float32" in scalar:
+            value = scalar["Float32"]  # pyright: ignore[reportAny]
+            dtype = "Float32"
+        elif "Float64" in scalar:
+            value = scalar["Float64"]  # pyright: ignore[reportAny]
+            dtype = "Float64"
+        elif "Int32" in scalar:
+            value = scalar["Int32"]  # pyright: ignore[reportAny]
+            dtype = "Int32"
+        elif "Int64" in scalar:
+            value = scalar["Int64"]  # pyright: ignore[reportAny]
+            dtype = "Int64"
         else:
-            raise ValueError(f"Unsupported Polars scalar value type {scalar}")
+            raise ValueError(f"Cannot convert to Vortex: unsupported Polars scalar value type {scalar}")
 
         return ve.literal(_LITERAL_TYPES[dtype](value), value)
 


### PR DESCRIPTION
I had to patch a hole in Polars type conversion as well.

I do not understand why duckdb is so slow. Maybe Arrow conversion is very expensive?

Ideally there should be no gap between `test_scan_XXX` and each engine's XXX benchmark because all of these queries are simple O(N) scans.

```
# uv run pytest benchmark --benchmark-only benchmark --benchmark-sort=mean --benchmark-columns=mean,ops,rounds,iterations

---------------------------------------- benchmark 'aggregation': 16 tests -----------------------------------------
Name (time in us)                                          Mean                    OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------
test_polars_aggregation[int]                            76.1717 (1.0)      13,128.2425 (1.0)        1130           1
test_arrow_table_aggregation[int]                       89.4690 (1.17)     11,177.0619 (0.85)        527           1
test_polars_aggregation[int_str]                       152.8442 (2.01)      6,542.6081 (0.50)       1983           1
test_arrow_table_aggregation[int_float]                207.9757 (2.73)      4,808.2543 (0.37)       2509           1
test_polars_streaming_aggregation[int]                 222.3492 (2.92)      4,497.4297 (0.34)        843           1
test_polars_aggregation[int_float]                     269.4515 (3.54)      3,711.2432 (0.28)       2074           1
test_polars_streaming_aggregation[int_str]             277.1106 (3.64)      3,608.6669 (0.27)       1970           1
test_duckdb_aggregation[int]                           279.6023 (3.67)      3,576.5088 (0.27)       1469           1
test_duckdb_aggregation[int_str]                       287.2120 (3.77)      3,481.7487 (0.27)       2264           1
test_polars_aggregation[int_str_float]                 329.0523 (4.32)      3,039.0306 (0.23)       1445           1
test_polars_streaming_aggregation[int_float]           376.7064 (4.95)      2,654.5870 (0.20)       1724           1
test_polars_streaming_aggregation[int_str_float]       434.7588 (5.71)      2,300.1257 (0.18)       1585           1
test_duckdb_aggregation[int_float]                     522.4205 (6.86)      1,914.1669 (0.15)       1452           1
test_duckdb_aggregation[int_str_float]                 538.3008 (7.07)      1,857.6975 (0.14)       1384           1
test_arrow_table_aggregation[int_str]                1,082.2129 (14.21)       924.0326 (0.07)        712           1
test_arrow_table_aggregation[int_str_float]          1,324.7391 (17.39)       754.8656 (0.06)        405           1
--------------------------------------------------------------------------------------------------------------------

---------------------------------------- benchmark 'filter': 20 tests ----------------------------------------
Name (time in us)                                     Mean                   OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------
test_repeated_scan_filter[int]                    143.3732 (1.0)      6,974.8023 (1.0)        3558           1
test_scan_filter[int]                             174.0772 (1.21)     5,744.5787 (0.82)       2870           1
test_repeated_scan_filter[int_float]              238.3200 (1.66)     4,196.0381 (0.60)       3379           1
test_polars_filter[int]                           243.8517 (1.70)     4,100.8533 (0.59)       1269           1
test_scan_filter[int_float]                       295.5555 (2.06)     3,383.4591 (0.49)       2303           1
test_polars_streaming_filter[int]                 370.5649 (2.58)     2,698.5827 (0.39)       1662           1
test_polars_filter[int_float]                     382.5942 (2.67)     2,613.7357 (0.37)       1336           1
test_repeated_scan_filter[int_str]                480.1820 (3.35)     2,082.5437 (0.30)       1300           1
test_polars_streaming_filter[int_float]           502.9034 (3.51)     1,988.4535 (0.29)       1471           1
test_duckdb_filter[int]                           536.2415 (3.74)     1,864.8313 (0.27)       1012           1
test_duckdb_filter[int_str]                       561.2234 (3.91)     1,781.8218 (0.26)       1017           1
test_duckdb_filter[int_float]                     563.5287 (3.93)     1,774.5326 (0.25)       1026           1
test_repeated_scan_filter[int_str_float]          566.4368 (3.95)     1,765.4220 (0.25)       1243           1
test_scan_filter[int_str]                         598.6775 (4.18)     1,670.3483 (0.24)        950           1
test_duckdb_filter[int_str_float]                 599.1449 (4.18)     1,669.0454 (0.24)        924           1
test_scan_filter[int_str_float]                   722.3346 (5.04)     1,384.3999 (0.20)        712           1
test_polars_filter[int_str]                       802.2062 (5.60)     1,246.5622 (0.18)        741           1
test_polars_filter[int_str_float]                 910.6698 (6.35)     1,098.0928 (0.16)        621           1
test_polars_streaming_filter[int_str]           1,139.4421 (7.95)       877.6225 (0.13)        664           1
test_polars_streaming_filter[int_str_float]     1,247.2020 (8.70)       801.7947 (0.11)        724           1
--------------------------------------------------------------------------------------------------------------

----------------------------------------- benchmark 'scalar_at': 20 tests -----------------------------------------
Name (time in us)                                        Mean                     OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------
test_repeated_scan_scalar_at[int]                      1.5545 (1.0)      643,309.8354 (1.0)       36419           1
test_repeated_scan_scalar_at[int_float]                3.4765 (2.24)     287,645.4425 (0.45)      26345           1
test_repeated_scan_scalar_at[int_str]                  4.4134 (2.84)     226,582.2627 (0.35)       3084           1
test_repeated_scan_scalar_at[int_str_float]            5.7624 (3.71)     173,539.0100 (0.27)      23881           1
test_scan_scalar_at[int]                              36.5195 (23.49)     27,382.6489 (0.04)       6826           1
test_scan_scalar_at[int_float]                        47.3951 (30.49)     21,099.2283 (0.03)       6478           1
test_scan_scalar_at[int_str]                          63.7556 (41.01)     15,684.8922 (0.02)       5342           1
test_polars_scalar_at[int]                            64.5703 (41.54)     15,487.0055 (0.02)       3841           1
test_scan_scalar_at[int_str_float]                    85.1729 (54.79)     11,740.8176 (0.02)       4372           1
test_duckdb_scalar_at[int]                           146.7574 (94.41)      6,813.9672 (0.01)       2665           1
test_duckdb_scalar_at[int_float]                     169.2891 (108.91)     5,907.0551 (0.01)       2522           1
test_duckdb_scalar_at[int_str]                       170.4412 (109.65)     5,867.1253 (0.01)       2476           1
test_duckdb_scalar_at[int_str_float]                 181.6621 (116.87)     5,504.7259 (0.01)       2004           1
test_polars_streaming_scalar_at[int]                 190.2632 (122.40)     5,255.8767 (0.01)       2904           1
test_polars_scalar_at[int_float]                     206.2914 (132.71)     4,847.5126 (0.01)       1883           1
test_polars_streaming_scalar_at[int_float]           355.9984 (229.02)     2,809.0011 (0.00)       2112           1
test_polars_scalar_at[int_str]                       772.4669 (496.94)     1,294.5539 (0.00)        955           1
test_polars_scalar_at[int_str_float]                 899.1975 (578.46)     1,112.1027 (0.00)        791           1
test_polars_streaming_scalar_at[int_str]           1,244.5020 (800.60)       803.5343 (0.00)        763           1
test_polars_streaming_scalar_at[int_str_float]     1,364.4143 (877.74)       732.9152 (0.00)        628           1
-------------------------------------------------------------------------------------------------------------------

-------------------------------------- benchmark 'scan': 20 tests --------------------------------------
Name (time in us)                              Mean                    OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------
test_repeated_scan[int]                     18.6398 (1.0)      53,648.6559 (1.0)       23438           1
test_scan[int]                              40.7512 (2.19)     24,539.1330 (0.46)       8025           1
test_polars[int]                            62.7679 (3.37)     15,931.7213 (0.30)       3935           1
test_repeated_scan[int_float]              112.4321 (6.03)      8,894.2578 (0.17)       7985           1
test_scan[int_float]                       138.4804 (7.43)      7,221.2388 (0.13)       2913           1
test_polars[int_float]                     194.1688 (10.42)     5,150.1572 (0.10)       2170           1
test_polars_streaming[int]                 196.7833 (10.56)     5,081.7320 (0.09)       3155           1
test_polars_streaming[int_float]           343.3220 (18.42)     2,912.7172 (0.05)       1917           1
test_duckdb[int]                           381.1628 (20.45)     2,623.5511 (0.05)       1695           1
test_duckdb[int_float]                     382.8268 (20.54)     2,612.1476 (0.05)       1469           1
test_duckdb[int_str]                       383.9420 (20.60)     2,604.5604 (0.05)       1617           1
test_duckdb[int_str_float]                 403.7574 (21.66)     2,476.7348 (0.05)       1040           1
test_repeated_scan[int_str]                828.1792 (44.43)     1,207.4681 (0.02)       1115           1
test_repeated_scan[int_str_float]          960.0624 (51.51)     1,041.5990 (0.02)        899           1
test_scan[int_str]                         964.7217 (51.76)     1,036.5684 (0.02)        763           1
test_scan[int_str_float]                 1,151.4723 (61.77)       868.4534 (0.02)        651           1
test_polars[int_str]                     1,157.6436 (62.11)       863.8237 (0.02)        491           1
test_polars[int_str_float]               1,261.5061 (67.68)       792.7032 (0.01)        487           1
test_polars_streaming[int_str]           1,606.7522 (86.20)       622.3735 (0.01)        568           1
test_polars_streaming[int_str_float]     1,702.0797 (91.31)       587.5166 (0.01)        549           1
--------------------------------------------------------------------------------------------------------

```