### PR TITLE
Feature: Add `eq_with_nullability_subset ` and `eq_with_nullability_superset ` and validate `extend_from_array`

### DIFF
--- a/vortex-array/src/arrays/arbitrary.rs
+++ b/vortex-array/src/arrays/arbitrary.rs
@@ -10,7 +10,7 @@ use builders::ListBuilder;
 use vortex_buffer::Buffer;
 use vortex_dtype::{DType, NativePType, Nullability, PType};
 use vortex_error::{VortexExpect, VortexUnwrap};
-use vortex_scalar::arbitrary::{random_decimal, random_scalar};
+use vortex_scalar::arbitrary::random_scalar;
 use vortex_scalar::{Scalar, match_each_decimal_value_type};
 
 use super::{
@@ -47,90 +47,14 @@ fn split_number_into_parts(n: usize, parts: usize) -> Vec<usize> {
         .collect()
 }
 
+/// Creates a random array with a random number of chunks.
 fn random_array(u: &mut Unstructured, dtype: &DType, len: Option<usize>) -> Result<ArrayRef> {
     let num_chunks = u.int_in_range(1..=3)?;
     let chunk_lens = len.map(|l| split_number_into_parts(l, num_chunks));
     let mut chunks = (0..num_chunks)
         .map(|i| {
             let chunk_len = chunk_lens.as_ref().map(|c| c[i]);
-            match dtype {
-                DType::Null => Ok(NullArray::new(
-                    chunk_len
-                        .map(Ok)
-                        .unwrap_or_else(|| u.int_in_range(0..=100))?,
-                )
-                .into_array()),
-                DType::Bool(n) => random_bool(u, *n, chunk_len),
-                DType::Primitive(ptype, n) => match ptype {
-                    PType::U8 => random_primitive::<u8>(u, *n, chunk_len),
-                    PType::U16 => random_primitive::<u16>(u, *n, chunk_len),
-                    PType::U32 => random_primitive::<u32>(u, *n, chunk_len),
-                    PType::U64 => random_primitive::<u64>(u, *n, chunk_len),
-                    PType::I8 => random_primitive::<i8>(u, *n, chunk_len),
-                    PType::I16 => random_primitive::<i16>(u, *n, chunk_len),
-                    PType::I32 => random_primitive::<i32>(u, *n, chunk_len),
-                    PType::I64 => random_primitive::<i64>(u, *n, chunk_len),
-                    PType::F16 => Ok(random_primitive::<u16>(u, *n, chunk_len)?
-                        .to_primitive()
-                        .vortex_unwrap()
-                        .reinterpret_cast(PType::F16)
-                        .into_array()),
-                    PType::F32 => random_primitive::<f32>(u, *n, chunk_len),
-                    PType::F64 => random_primitive::<f64>(u, *n, chunk_len),
-                },
-                DType::Decimal(decimal, n) => {
-                    let elem_len = chunk_len.unwrap_or(u.int_in_range(0..=20)?);
-                    match_each_decimal_value_type!(smallest_storage_type(decimal), |DVT| {
-                        let mut builder =
-                            DecimalBuilder::new::<DVT>(decimal.precision(), decimal.scale(), *n);
-                        for _i in 0..elem_len {
-                            builder
-                                .append_scalar_value(random_decimal(u, decimal)?)
-                                .vortex_unwrap();
-                        }
-                        Ok(builder.finish())
-                    })
-                }
-                DType::Utf8(n) => random_string(u, *n, chunk_len),
-                DType::Binary(n) => random_bytes(u, *n, chunk_len),
-                DType::Struct(sdt, n) => {
-                    let first_array = sdt
-                        .fields()
-                        .next()
-                        .map(|d| random_array(u, &d, chunk_len))
-                        .transpose()?;
-                    let resolved_len = first_array
-                        .as_ref()
-                        .map(|a| a.len())
-                        .or(chunk_len)
-                        .map(Ok)
-                        .unwrap_or_else(|| u.int_in_range(0..=100))?;
-                    let children = first_array
-                        .into_iter()
-                        .map(Ok)
-                        .chain(
-                            sdt.fields()
-                                .skip(1)
-                                .map(|d| random_array(u, &d, Some(resolved_len))),
-                        )
-                        .collect::<Result<Vec<_>>>()?;
-                    Ok(StructArray::try_new(
-                        sdt.names().clone(),
-                        children,
-                        resolved_len,
-                        random_validity(u, *n, resolved_len)?,
-                    )
-                    .vortex_unwrap()
-                    .into_array())
-                }
-                DType::List(ldt, n) => random_list(u, ldt, *n, chunk_len),
-                DType::FixedSizeList(..) => {
-                    unimplemented!("TODO(connor)[FixedSizeList]: Create canonical fixed-size list")
-                }
-                DType::Extension(..) => {
-                    todo!("Extension arrays are not implemented")
-                }
-            }
+            random_array_chunk(u, dtype, chunk_len)
         })
         .collect::<Result<Vec<_>>>()?;
 
@@ -141,6 +65,93 @@ fn random_array(u: &mut Unstructured, dtype: &DType, len: Option<usize>) -> Resu
         Ok(ChunkedArray::try_new(chunks, dtype)
             .vortex_unwrap()
             .into_array())
+    }
+}
+
+/// Creates a random array chunk.
+fn random_array_chunk(
+    u: &mut Unstructured<'_>,
+    dtype: &DType,
+    chunk_len: Option<usize>,
+) -> std::result::Result<Arc<dyn Array + 'static>, arbitrary::Error> {
+    match dtype {
+        DType::Null => Ok(NullArray::new(
+            chunk_len
+                .map(Ok)
+                .unwrap_or_else(|| u.int_in_range(0..=100))?,
+        )
+        .into_array()),
+        DType::Bool(n) => random_bool(u, *n, chunk_len),
+        DType::Primitive(ptype, n) => match ptype {
+            PType::U8 => random_primitive::<u8>(u, *n, chunk_len),
+            PType::U16 => random_primitive::<u16>(u, *n, chunk_len),
+            PType::U32 => random_primitive::<u32>(u, *n, chunk_len),
+            PType::U64 => random_primitive::<u64>(u, *n, chunk_len),
+            PType::I8 => random_primitive::<i8>(u, *n, chunk_len),
+            PType::I16 => random_primitive::<i16>(u, *n, chunk_len),
+            PType::I32 => random_primitive::<i32>(u, *n, chunk_len),
+            PType::I64 => random_primitive::<i64>(u, *n, chunk_len),
+            PType::F16 => Ok(random_primitive::<u16>(u, *n, chunk_len)?
+                .to_primitive()
+                .vortex_unwrap()
+                .reinterpret_cast(PType::F16)
+                .into_array()),
+            PType::F32 => random_primitive::<f32>(u, *n, chunk_len),
+            PType::F64 => random_primitive::<f64>(u, *n, chunk_len),
+        },
+        DType::Decimal(decimal, n) => {
+            let elem_len = chunk_len.unwrap_or(u.int_in_range(0..=20)?);
+            match_each_decimal_value_type!(smallest_storage_type(decimal), |DVT| {
+                let mut builder =
+                    DecimalBuilder::new::<DVT>(decimal.precision(), decimal.scale(), *n);
+                for _i in 0..elem_len {
+                    let random_decimal = random_scalar(u, &DType::Decimal(*decimal, *n))?;
+                    builder.append_scalar(&random_decimal).vortex_expect(
+                        "was somehow unable to append a decimal to a decimal builder",
+                    );
+                }
+                Ok(builder.finish())
+            })
+        }
+        DType::Utf8(n) => random_string(u, *n, chunk_len),
+        DType::Binary(n) => random_bytes(u, *n, chunk_len),
+        DType::Struct(sdt, n) => {
+            let first_array = sdt
+                .fields()
+                .next()
+                .map(|d| random_array(u, &d, chunk_len))
+                .transpose()?;
+            let resolved_len = first_array
+                .as_ref()
+                .map(|a| a.len())
+                .or(chunk_len)
+                .map(Ok)
+                .unwrap_or_else(|| u.int_in_range(0..=100))?;
+            let children = first_array
+                .into_iter()
+                .map(Ok)
+                .chain(
+                    sdt.fields()
+                        .skip(1)
+                        .map(|d| random_array(u, &d, Some(resolved_len))),
+                )
+                .collect::<Result<Vec<_>>>()?;
+            Ok(StructArray::try_new(
+                sdt.names().clone(),
+                children,
+                resolved_len,
+                random_validity(u, *n, resolved_len)?,
+            )
+            .vortex_unwrap()
+            .into_array())
+        }
+        DType::List(ldt, n) => random_list(u, ldt, *n, chunk_len),
+        DType::FixedSizeList(..) => {
+            unimplemented!("TODO(connor)[FixedSizeList]: Create canonical fixed-size list")
+        }
+        DType::Extension(..) => {
+            todo!("Extension arrays are not implemented")
+        }
     }
 }
 

--- a/vortex-array/src/builders/bool.rs
+++ b/vortex-array/src/builders/bool.rs
@@ -9,8 +9,8 @@ use vortex_error::{VortexExpect, VortexResult, vortex_bail};
 use vortex_mask::Mask;
 
 use crate::arrays::BoolArray;
-use crate::builders::ArrayBuilder;
 use crate::builders::lazy_validity_builder::LazyNullBufferBuilder;
+use crate::builders::{ArrayBuilder, DEFAULT_BUILDER_CAPACITY};
 use crate::{Array, ArrayRef, IntoArray, ToCanonical};
 
 pub struct BoolBuilder {
@@ -22,7 +22,7 @@ pub struct BoolBuilder {
 
 impl BoolBuilder {
     pub fn new(nullability: Nullability) -> Self {
-        Self::with_capacity(nullability, 1024) // Same as Arrow builders
+        Self::with_capacity(nullability, DEFAULT_BUILDER_CAPACITY)
     }
 
     pub fn with_capacity(nullability: Nullability, capacity: usize) -> Self {

--- a/vortex-array/src/builders/bool.rs
+++ b/vortex-array/src/builders/bool.rs
@@ -78,7 +78,7 @@ impl ArrayBuilder for BoolBuilder {
     }
 
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
-        if !self.dtype.is_superset_of(array.dtype()) {
+        if !self.dtype.eq_with_nullability_superset(array.dtype()) {
             vortex_bail!(
                 "tried to extend a builder with `DType` {} with an array with `DType {}",
                 self.dtype,

--- a/vortex-array/src/builders/bool.rs
+++ b/vortex-array/src/builders/bool.rs
@@ -5,13 +5,13 @@ use std::any::Any;
 
 use arrow_buffer::BooleanBufferBuilder;
 use vortex_dtype::{DType, Nullability};
-use vortex_error::{VortexResult, vortex_bail};
+use vortex_error::{VortexExpect, VortexResult, vortex_bail};
 use vortex_mask::Mask;
 
 use crate::arrays::BoolArray;
 use crate::builders::ArrayBuilder;
 use crate::builders::lazy_validity_builder::LazyNullBufferBuilder;
-use crate::{Array, ArrayRef, Canonical, IntoArray};
+use crate::{Array, ArrayRef, IntoArray, ToCanonical};
 
 pub struct BoolBuilder {
     inner: BooleanBufferBuilder,
@@ -86,13 +86,12 @@ impl ArrayBuilder for BoolBuilder {
             );
         }
 
-        let array = array.to_canonical()?;
-        let Canonical::Bool(array) = array else {
-            vortex_bail!("Expected Canonical::Bool, found {:?}", array);
-        };
+        let bool_array = array
+            .to_bool()
+            .vortex_expect("we checked that the array had `DType` boolean");
 
-        self.inner.append_buffer(array.boolean_buffer());
-        self.nulls.append_validity_mask(array.validity_mask());
+        self.inner.append_buffer(bool_array.boolean_buffer());
+        self.nulls.append_validity_mask(bool_array.validity_mask());
 
         Ok(())
     }

--- a/vortex-array/src/builders/bool.rs
+++ b/vortex-array/src/builders/bool.rs
@@ -78,6 +78,14 @@ impl ArrayBuilder for BoolBuilder {
     }
 
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
+        if !self.dtype.is_superset_of(array.dtype()) {
+            vortex_bail!(
+                "tried to extend a builder with `DType` {} with an array with `DType {}",
+                self.dtype,
+                array.dtype()
+            );
+        }
+
         let array = array.to_canonical()?;
         let Canonical::Bool(array) = array else {
             vortex_bail!("Expected Canonical::Bool, found {:?}", array);

--- a/vortex-array/src/builders/decimal.rs
+++ b/vortex-array/src/builders/decimal.rs
@@ -35,9 +35,9 @@ impl Default for DecimalBuffer {
 }
 
 macro_rules! impl_from_buffer {
-    ($typ:ty, $variant:ident) => {
-        impl From<BufferMut<$typ>> for DecimalBuffer {
-            fn from(buffer: BufferMut<$typ>) -> Self {
+    ($T:ty, $variant:ident) => {
+        impl From<BufferMut<$T>> for DecimalBuffer {
+            fn from(buffer: BufferMut<$T>) -> Self {
                 Self::$variant(buffer)
             }
         }
@@ -241,19 +241,15 @@ impl ArrayBuilder for DecimalBuilder {
     }
 
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
-        let array = array.to_decimal()?;
-
-        let DType::Decimal(decimal_dtype, _) = self.dtype else {
-            vortex_panic!("DecimalBuilder must have Decimal DType");
-        };
-
-        if array.decimal_dtype() != decimal_dtype {
+        if !self.dtype.is_superset_of(array.dtype()) {
             vortex_bail!(
-                "Cannot extend from array with different decimal type: {:?} != {:?}",
-                array.decimal_dtype(),
-                decimal_dtype
+                "tried to extend a builder with `DType` {} with an array with `DType {}",
+                self.dtype,
+                array.dtype()
             );
         }
+
+        let array = array.to_decimal()?;
 
         match_each_decimal_value_type!(array.values_type(), |D| {
             self.extend_from_buffer(&array.buffer::<D>())

--- a/vortex-array/src/builders/decimal.rs
+++ b/vortex-array/src/builders/decimal.rs
@@ -10,8 +10,8 @@ use vortex_mask::Mask;
 use vortex_scalar::{BigCast, NativeDecimalType, i256, match_each_decimal_value_type};
 
 use crate::arrays::DecimalArray;
-use crate::builders::ArrayBuilder;
 use crate::builders::lazy_validity_builder::LazyNullBufferBuilder;
+use crate::builders::{ArrayBuilder, DEFAULT_BUILDER_CAPACITY};
 use crate::{Array, ArrayRef, IntoArray, ToCanonical};
 
 /// Wrapper around the typed builder.
@@ -138,8 +138,6 @@ pub struct DecimalBuilder {
     nulls: LazyNullBufferBuilder,
     dtype: DType,
 }
-
-const DEFAULT_BUILDER_CAPACITY: usize = 1024;
 
 impl DecimalBuilder {
     pub fn new<T: NativeDecimalType>(precision: u8, scale: i8, nullability: Nullability) -> Self {

--- a/vortex-array/src/builders/decimal.rs
+++ b/vortex-array/src/builders/decimal.rs
@@ -249,13 +249,13 @@ impl ArrayBuilder for DecimalBuilder {
             );
         }
 
-        let array = array.to_decimal()?;
+        let decimal_array = array.to_decimal()?;
 
-        match_each_decimal_value_type!(array.values_type(), |D| {
-            self.extend_from_buffer(&array.buffer::<D>())
+        match_each_decimal_value_type!(decimal_array.values_type(), |D| {
+            self.extend_from_buffer(&decimal_array.buffer::<D>())
         });
 
-        self.extend_with_validity_mask(array.validity_mask());
+        self.extend_with_validity_mask(decimal_array.validity_mask());
 
         Ok(())
     }

--- a/vortex-array/src/builders/decimal.rs
+++ b/vortex-array/src/builders/decimal.rs
@@ -3,7 +3,7 @@
 
 use std::any::Any;
 
-use vortex_buffer::{Buffer, BufferMut};
+use vortex_buffer::BufferMut;
 use vortex_dtype::{DType, DecimalDType, Nullability};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_panic};
 use vortex_mask::Mask;
@@ -14,11 +14,22 @@ use crate::builders::lazy_validity_builder::LazyNullBufferBuilder;
 use crate::builders::{ArrayBuilder, DEFAULT_BUILDER_CAPACITY};
 use crate::{Array, ArrayRef, IntoArray, ToCanonical};
 
+/// An [`ArrayBuilder`] for `Decimal` typed arrays.
+///
+/// The output will be a new [`DecimalArray`] holding values of `T`. Any value that is a valid
+/// [decimal type][NativeDecimalType] can be appended to the builder and it will be immediately
+/// coerced into the target type.
+pub struct DecimalBuilder {
+    dtype: DType,
+    values: DecimalBuffer,
+    nulls: LazyNullBufferBuilder,
+}
+
 /// Wrapper around the typed builder.
 ///
-/// We want to be able to downcast a `Box<dyn ArrayBuilder>` to a [`DecimalBuilder`] and we generally
-/// don't have enough type information to get the `T` at the call site, so we instead use this
-/// to hold values and can push values into the correct buffer type generically.
+/// We want to be able to downcast a `Box<dyn ArrayBuilder>` to a [`DecimalBuilder`] and we
+/// generally don't have enough type information to get the `T` at the call site, so we instead use
+/// this to hold values and can push values into the correct buffer type generically.
 enum DecimalBuffer {
     I8(BufferMut<i8>),
     I16(BufferMut<i16>),
@@ -27,28 +38,6 @@ enum DecimalBuffer {
     I128(BufferMut<i128>),
     I256(BufferMut<i256>),
 }
-
-impl Default for DecimalBuffer {
-    fn default() -> Self {
-        Self::I8(BufferMut::<i8>::empty())
-    }
-}
-
-macro_rules! impl_from_buffer {
-    ($T:ty, $variant:ident) => {
-        impl From<BufferMut<$T>> for DecimalBuffer {
-            fn from(buffer: BufferMut<$T>) -> Self {
-                Self::$variant(buffer)
-            }
-        }
-    };
-}
-impl_from_buffer!(i8, I8);
-impl_from_buffer!(i16, I16);
-impl_from_buffer!(i32, I32);
-impl_from_buffer!(i64, I64);
-impl_from_buffer!(i128, I128);
-impl_from_buffer!(i256, I256);
 
 macro_rules! delegate_fn {
     ($self:expr, | $tname:ident, $buffer:ident | $body:block) => {{
@@ -88,58 +77,8 @@ macro_rules! delegate_fn {
     }};
 }
 
-impl DecimalBuffer {
-    fn push<V: NativeDecimalType>(&mut self, value: V) {
-        delegate_fn!(self, |T, buffer| {
-            buffer.push(<T as BigCast>::from(value).vortex_expect("decimal conversion failure"))
-        });
-    }
-
-    fn push_n<V: NativeDecimalType>(&mut self, value: V, n: usize) {
-        delegate_fn!(self, |T, buffer| {
-            buffer.push_n(
-                <T as BigCast>::from(value).vortex_expect("decimal conversion failure"),
-                n,
-            )
-        });
-    }
-
-    fn reserve(&mut self, additional: usize) {
-        delegate_fn!(self, |T, buffer| { buffer.reserve(additional) })
-    }
-
-    fn capacity(&self) -> usize {
-        delegate_fn!(self, |T, buffer| { buffer.capacity() })
-    }
-
-    fn len(&self) -> usize {
-        delegate_fn!(self, |T, buffer| { buffer.len() })
-    }
-
-    pub fn extend<I, V: NativeDecimalType>(&mut self, iter: I)
-    where
-        I: Iterator<Item = V>,
-    {
-        delegate_fn!(self, |T, buffer| {
-            buffer.extend(
-                iter.map(|x| <T as BigCast>::from(x).vortex_expect("decimal conversion failure")),
-            )
-        })
-    }
-}
-
-/// An [`ArrayBuilder`] for `Decimal` typed arrays.
-///
-/// The output will be a new [`DecimalArray`] holding values of `T`. Any value that is
-/// a valid [decimal type][NativeDecimalType] can be appended to the builder and it will be
-/// immediately coerced into the target type.
-pub struct DecimalBuilder {
-    values: DecimalBuffer,
-    nulls: LazyNullBufferBuilder,
-    dtype: DType,
-}
-
 impl DecimalBuilder {
+    /// Creates a new `DecimalBuilder` with a capacity of [`DEFAULT_BUILDER_CAPACITY`].
     pub fn new<T: NativeDecimalType>(precision: u8, scale: i8, nullability: Nullability) -> Self {
         Self::with_capacity::<T>(
             DEFAULT_BUILDER_CAPACITY,
@@ -148,66 +87,57 @@ impl DecimalBuilder {
         )
     }
 
+    /// Creates a new `DecimalBuilder` with the given `capacity`.
     pub fn with_capacity<T: NativeDecimalType>(
         capacity: usize,
         decimal: DecimalDType,
         nullability: Nullability,
     ) -> Self {
         Self {
+            dtype: DType::Decimal(decimal, nullability),
             values: match_each_decimal_value_type!(T::VALUES_TYPE, |D| {
                 DecimalBuffer::from(BufferMut::<D>::with_capacity(capacity))
             }),
             nulls: LazyNullBufferBuilder::new(capacity),
-            dtype: DType::Decimal(decimal, nullability),
         }
     }
-}
 
-impl DecimalBuilder {
-    fn extend_with_validity_mask(&mut self, validity_mask: Mask) {
-        self.nulls.append_validity_mask(validity_mask);
-    }
-
-    /// Extend the values buffer from another buffer of type V where V can be coerced
-    /// to the builder type.
-    fn extend_from_buffer<V: NativeDecimalType>(&mut self, values: &Buffer<V>) {
-        self.values.extend(values.iter().copied());
-    }
-}
-
-impl DecimalBuilder {
+    /// Appends a decimal `value` to the builder.
     pub fn append_value<V: NativeDecimalType>(&mut self, value: V) {
         self.values.push(value);
-        self.nulls.append(true);
+        self.nulls.append_non_null();
     }
 
+    /// Appends an optional decimal (representing a nullable decimal) to the builder.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if the input is `None` and the builder is non-nullable.
     pub fn append_option<V: NativeDecimalType>(&mut self, value: Option<V>) {
         match value {
-            Some(value) => {
-                self.values.push(value);
-                self.nulls.append(true);
-            }
+            Some(value) => self.append_value(value),
             None => self.append_null(),
         }
     }
 
-    /// Append a `Mask` to the null buffer.
-    pub fn append_mask(&mut self, mask: Mask) {
-        self.nulls.append_validity_mask(mask);
-    }
-}
-
-impl DecimalBuilder {
+    /// Finishes the builder directly into a [`DecimalArray`].
     pub fn finish_into_decimal(&mut self) -> DecimalArray {
         let validity = self.nulls.finish_with_nullability(self.dtype.nullability());
 
-        let DType::Decimal(decimal_dtype, _) = self.dtype else {
-            vortex_panic!("DecimalBuilder must have Decimal DType");
-        };
+        let decimal_dtype = *self.decimal_dtype();
 
         delegate_fn!(std::mem::take(&mut self.values), |T, values| {
             DecimalArray::new::<T>(values.freeze(), decimal_dtype, validity)
         })
+    }
+
+    /// The [`DecimalDType`] of this builder.
+    pub fn decimal_dtype(&self) -> &DecimalDType {
+        let DType::Decimal(decimal_dtype, _) = &self.dtype else {
+            vortex_panic!("`DecimalBuilder` somehow had dtype {}", self.dtype);
+        };
+
+        decimal_dtype
     }
 }
 
@@ -250,10 +180,14 @@ impl ArrayBuilder for DecimalBuilder {
         let decimal_array = array.to_decimal()?;
 
         match_each_decimal_value_type!(decimal_array.values_type(), |D| {
-            self.extend_from_buffer(&decimal_array.buffer::<D>())
+            // Extends the values buffer from another buffer of type D where D can be coerced to the
+            // builder type.
+            self.values
+                .extend(decimal_array.buffer::<D>().iter().copied());
         });
 
-        self.extend_with_validity_mask(decimal_array.validity_mask());
+        self.nulls
+            .append_validity_mask(decimal_array.validity_mask());
 
         Ok(())
     }
@@ -275,21 +209,89 @@ impl ArrayBuilder for DecimalBuilder {
     }
 }
 
+impl DecimalBuffer {
+    fn push<V: NativeDecimalType>(&mut self, value: V) {
+        delegate_fn!(self, |T, buffer| {
+            buffer.push(<T as BigCast>::from(value).vortex_expect("decimal conversion failure"))
+        });
+    }
+
+    fn push_n<V: NativeDecimalType>(&mut self, value: V, n: usize) {
+        delegate_fn!(self, |T, buffer| {
+            buffer.push_n(
+                <T as BigCast>::from(value).vortex_expect("decimal conversion failure"),
+                n,
+            )
+        });
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        delegate_fn!(self, |T, buffer| { buffer.reserve(additional) })
+    }
+
+    fn capacity(&self) -> usize {
+        delegate_fn!(self, |T, buffer| { buffer.capacity() })
+    }
+
+    fn len(&self) -> usize {
+        delegate_fn!(self, |T, buffer| { buffer.len() })
+    }
+
+    pub fn extend<I, V: NativeDecimalType>(&mut self, iter: I)
+    where
+        I: Iterator<Item = V>,
+    {
+        delegate_fn!(self, |T, buffer| {
+            buffer.extend(
+                iter.map(|x| <T as BigCast>::from(x).vortex_expect("decimal conversion failure")),
+            )
+        })
+    }
+}
+
+macro_rules! impl_from_buffer {
+    ($T:ty, $variant:ident) => {
+        impl From<BufferMut<$T>> for DecimalBuffer {
+            fn from(buffer: BufferMut<$T>) -> Self {
+                Self::$variant(buffer)
+            }
+        }
+    };
+}
+
+impl_from_buffer!(i8, I8);
+impl_from_buffer!(i16, I16);
+impl_from_buffer!(i32, I32);
+impl_from_buffer!(i64, I64);
+impl_from_buffer!(i128, I128);
+impl_from_buffer!(i256, I256);
+
+impl Default for DecimalBuffer {
+    fn default() -> Self {
+        Self::I8(BufferMut::<i8>::empty())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::builders::{ArrayBuilder, DecimalBuilder};
 
     #[test]
     fn test_mixed_extend() {
+        let values = 42i8;
+
         let mut i8s = DecimalBuilder::new::<i8>(2, 1, false.into());
-        i8s.append_value(10);
-        i8s.append_value(11);
-        i8s.append_value(12);
+        for v in 0..values {
+            i8s.append_value(v);
+        }
         let i8s = i8s.finish();
 
         let mut i128s = DecimalBuilder::new::<i128>(2, 1, false.into());
         i128s.extend_from_array(&i8s).unwrap();
-        let i128s = i128s.finish_into_decimal();
-        assert_eq!(i128s.buffer::<i128>().as_slice(), &[10, 11, 12]);
+        let i128s = i128s.finish();
+
+        for i in 0..i8s.len() {
+            assert_eq!(i8s.scalar_at(i), i128s.scalar_at(i));
+        }
     }
 }

--- a/vortex-array/src/builders/decimal.rs
+++ b/vortex-array/src/builders/decimal.rs
@@ -169,7 +169,7 @@ impl ArrayBuilder for DecimalBuilder {
     }
 
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
-        if !self.dtype.is_superset_of(array.dtype()) {
+        if !self.dtype.eq_with_nullability_superset(array.dtype()) {
             vortex_bail!(
                 "tried to extend a builder with `DType` {} with an array with `DType {}",
                 self.dtype,

--- a/vortex-array/src/builders/extension.rs
+++ b/vortex-array/src/builders/extension.rs
@@ -81,7 +81,7 @@ impl ArrayBuilder for ExtensionBuilder {
     }
 
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
-        if !self.dtype.is_superset_of(array.dtype()) {
+        if !self.dtype.eq_with_nullability_superset(array.dtype()) {
             vortex_bail!(
                 "tried to extend a builder with `DType` {} with an array with `DType {}",
                 self.dtype,

--- a/vortex-array/src/builders/extension.rs
+++ b/vortex-array/src/builders/extension.rs
@@ -11,7 +11,7 @@ use vortex_scalar::ExtScalar;
 
 use crate::arrays::ExtensionArray;
 use crate::builders::{ArrayBuilder, ArrayBuilderExt, builder_with_capacity};
-use crate::{Array, ArrayRef, Canonical, IntoArray};
+use crate::{Array, ArrayRef, IntoArray};
 
 pub struct ExtensionBuilder {
     storage: Box<dyn ArrayBuilder>,
@@ -79,10 +79,15 @@ impl ArrayBuilder for ExtensionBuilder {
     }
 
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
-        let array = array.to_canonical()?;
-        let Canonical::Extension(array) = array else {
-            vortex_bail!("Expected Extension array, got {:?}", array);
-        };
+        if !self.dtype.is_superset_of(array.dtype()) {
+            vortex_bail!(
+                "tried to extend a builder with `DType` {} with an array with `DType {}",
+                self.dtype,
+                array.dtype()
+            );
+        }
+
+        let array = array.to_canonical()?.into_extension()?;
         array.storage().append_to_builder(self.storage.as_mut())
     }
 

--- a/vortex-array/src/builders/extension.rs
+++ b/vortex-array/src/builders/extension.rs
@@ -10,7 +10,9 @@ use vortex_mask::Mask;
 use vortex_scalar::ExtScalar;
 
 use crate::arrays::ExtensionArray;
-use crate::builders::{ArrayBuilder, ArrayBuilderExt, builder_with_capacity};
+use crate::builders::{
+    ArrayBuilder, ArrayBuilderExt, DEFAULT_BUILDER_CAPACITY, builder_with_capacity,
+};
 use crate::{Array, ArrayRef, IntoArray, ToCanonical};
 
 pub struct ExtensionBuilder {
@@ -20,7 +22,7 @@ pub struct ExtensionBuilder {
 
 impl ExtensionBuilder {
     pub fn new(ext_dtype: Arc<ExtDType>) -> Self {
-        Self::with_capacity(ext_dtype, 1024)
+        Self::with_capacity(ext_dtype, DEFAULT_BUILDER_CAPACITY)
     }
 
     pub fn with_capacity(ext_dtype: Arc<ExtDType>, capacity: usize) -> Self {

--- a/vortex-array/src/builders/extension.rs
+++ b/vortex-array/src/builders/extension.rs
@@ -11,7 +11,7 @@ use vortex_scalar::ExtScalar;
 
 use crate::arrays::ExtensionArray;
 use crate::builders::{ArrayBuilder, ArrayBuilderExt, builder_with_capacity};
-use crate::{Array, ArrayRef, IntoArray};
+use crate::{Array, ArrayRef, IntoArray, ToCanonical};
 
 pub struct ExtensionBuilder {
     storage: Box<dyn ArrayBuilder>,
@@ -87,8 +87,8 @@ impl ArrayBuilder for ExtensionBuilder {
             );
         }
 
-        let array = array.to_canonical()?.into_extension()?;
-        array.storage().append_to_builder(self.storage.as_mut())
+        let ext_array = array.to_extension()?;
+        self.storage.extend_from_array(ext_array.storage())
     }
 
     fn ensure_capacity(&mut self, capacity: usize) {

--- a/vortex-array/src/builders/fixed_size_list.rs
+++ b/vortex-array/src/builders/fixed_size_list.rs
@@ -176,7 +176,7 @@ impl ArrayBuilder for FixedSizeListBuilder {
     /// This will increase the capacity if extending with this `array` would go past the original
     /// capacity.
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
-        if !self.dtype.is_superset_of(array.dtype()) {
+        if !self.dtype.eq_with_nullability_superset(array.dtype()) {
             vortex_bail!(
                 "tried to extend a builder with `DType` {} with an array with `DType {}",
                 self.dtype,

--- a/vortex-array/src/builders/fixed_size_list.rs
+++ b/vortex-array/src/builders/fixed_size_list.rs
@@ -176,6 +176,14 @@ impl ArrayBuilder for FixedSizeListBuilder {
     /// This will increase the capacity if extending with this `array` would go past the original
     /// capacity.
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
+        if !self.dtype.is_superset_of(array.dtype()) {
+            vortex_bail!(
+                "tried to extend a builder with `DType` {} with an array with `DType {}",
+                self.dtype,
+                array.dtype()
+            );
+        }
+
         let fsl = array.to_fixed_size_list()?;
         if fsl.is_empty() {
             return Ok(());

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -148,6 +148,14 @@ impl<O: OffsetPType> ArrayBuilder for ListBuilder<O> {
     }
 
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
+        if !self.dtype.is_superset_of(array.dtype()) {
+            vortex_bail!(
+                "tried to extend a builder with `DType` {} with an array with `DType {}",
+                self.dtype,
+                array.dtype()
+            );
+        }
+
         let list = array.to_list()?;
         if list.is_empty() {
             return Ok(());

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -148,7 +148,7 @@ impl<O: OffsetPType> ArrayBuilder for ListBuilder<O> {
     }
 
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
-        if !self.dtype.is_superset_of(array.dtype()) {
+        if !self.dtype.eq_with_nullability_superset(array.dtype()) {
             vortex_bail!(
                 "tried to extend a builder with `DType` {} with an array with `DType {}",
                 self.dtype,

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -55,7 +55,7 @@ use vortex_error::{VortexResult, vortex_bail, vortex_err};
 use vortex_mask::Mask;
 use vortex_scalar::{
     BinaryScalar, BoolScalar, DecimalValue, ExtScalar, ListScalar, PrimitiveScalar, Scalar,
-    ScalarValue, StructScalar, Utf8Scalar, match_each_decimal_value, match_each_decimal_value_type,
+    StructScalar, Utf8Scalar, match_each_decimal_value, match_each_decimal_value_type,
 };
 
 use crate::arrays::smallest_storage_type;
@@ -182,16 +182,6 @@ pub fn builder_with_capacity(dtype: &DType, capacity: usize) -> Box<dyn ArrayBui
 }
 
 pub trait ArrayBuilderExt: ArrayBuilder {
-    /// A generic function to append a scalar value to the builder.
-    fn append_scalar_value(&mut self, value: ScalarValue) -> VortexResult<()> {
-        if value.is_null() {
-            self.append_null();
-            Ok(())
-        } else {
-            self.append_scalar(&Scalar::new(self.dtype().clone(), value))
-        }
-    }
-
     /// A generic function to append a scalar to the builder.
     fn append_scalar(&mut self, scalar: &Scalar) -> VortexResult<()> {
         if scalar.dtype() != self.dtype() {

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -28,6 +28,19 @@
 //! assert_eq!(strings.scalar_at(3), "d".into());
 //! ```
 
+use std::any::Any;
+
+use vortex_dtype::{DType, match_each_native_ptype};
+use vortex_error::{VortexResult, vortex_bail, vortex_err};
+use vortex_mask::Mask;
+use vortex_scalar::{
+    BinaryScalar, BoolScalar, DecimalValue, ExtScalar, ListScalar, PrimitiveScalar, Scalar,
+    StructScalar, Utf8Scalar, match_each_decimal_value, match_each_decimal_value_type,
+};
+
+use crate::arrays::smallest_storage_type;
+use crate::{Array, ArrayRef};
+
 mod bool;
 mod decimal;
 mod extension;
@@ -39,8 +52,6 @@ mod primitive;
 mod struct_;
 mod varbinview;
 
-use std::any::Any;
-
 pub use bool::*;
 pub use decimal::*;
 pub use extension::*;
@@ -50,16 +61,11 @@ pub use null::*;
 pub use primitive::*;
 pub use struct_::*;
 pub use varbinview::*;
-use vortex_dtype::{DType, match_each_native_ptype};
-use vortex_error::{VortexResult, vortex_bail, vortex_err};
-use vortex_mask::Mask;
-use vortex_scalar::{
-    BinaryScalar, BoolScalar, DecimalValue, ExtScalar, ListScalar, PrimitiveScalar, Scalar,
-    StructScalar, Utf8Scalar, match_each_decimal_value, match_each_decimal_value_type,
-};
 
-use crate::arrays::smallest_storage_type;
-use crate::{Array, ArrayRef};
+/// The default capacity for builders.
+///
+/// This is equal to the default capacity for Arrow Arrays.
+pub const DEFAULT_BUILDER_CAPACITY: usize = 1024;
 
 pub trait ArrayBuilder: Send {
     fn as_any(&self) -> &dyn Any;

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -147,6 +147,14 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
     }
 
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
+        if !self.dtype.is_superset_of(array.dtype()) {
+            vortex_bail!(
+                "tried to extend a builder with `DType` {} with an array with `DType {}",
+                self.dtype,
+                array.dtype()
+            );
+        }
+
         let array = array.to_primitive()?;
         if array.ptype() != T::PTYPE {
             vortex_bail!("Cannot extend from array with different ptype");

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -147,7 +147,7 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
     }
 
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
-        if !self.dtype.is_superset_of(array.dtype()) {
+        if !self.dtype.eq_with_nullability_superset(array.dtype()) {
             vortex_bail!(
                 "tried to extend a builder with `DType` {} with an array with `DType {}",
                 self.dtype,

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -11,8 +11,8 @@ use vortex_error::{VortexResult, vortex_bail};
 use vortex_mask::Mask;
 
 use crate::arrays::PrimitiveArray;
-use crate::builders::ArrayBuilder;
 use crate::builders::lazy_validity_builder::LazyNullBufferBuilder;
+use crate::builders::{ArrayBuilder, DEFAULT_BUILDER_CAPACITY};
 use crate::{Array, ArrayRef, IntoArray, ToCanonical};
 
 /// Builder for [`PrimitiveArray`].
@@ -24,7 +24,7 @@ pub struct PrimitiveBuilder<T> {
 
 impl<T: NativePType> PrimitiveBuilder<T> {
     pub fn new(nullability: Nullability) -> Self {
-        Self::with_capacity(nullability, 1024) // Same as Arrow builders
+        Self::with_capacity(nullability, DEFAULT_BUILDER_CAPACITY)
     }
 
     pub fn with_capacity(nullability: Nullability, capacity: usize) -> Self {

--- a/vortex-array/src/builders/struct_.rs
+++ b/vortex-array/src/builders/struct_.rs
@@ -98,15 +98,15 @@ impl ArrayBuilder for StructBuilder {
     }
 
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
-        let array = array.to_struct()?;
-
-        if array.dtype() != self.dtype() {
+        if !self.dtype.is_superset_of(array.dtype()) {
             vortex_bail!(
-                "Cannot extend from array with different dtype: expected {}, found {}",
-                self.dtype(),
+                "tried to extend a builder with `DType` {} with an array with `DType {}",
+                self.dtype,
                 array.dtype()
             );
         }
+
+        let array = array.to_struct()?;
 
         for (a, builder) in (0..array.struct_fields().nfields())
             .map(|i| &array.fields()[i])

--- a/vortex-array/src/builders/struct_.rs
+++ b/vortex-array/src/builders/struct_.rs
@@ -98,7 +98,7 @@ impl ArrayBuilder for StructBuilder {
     }
 
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
-        if !self.dtype.is_superset_of(array.dtype()) {
+        if !self.dtype.eq_with_nullability_superset(array.dtype()) {
             vortex_bail!(
                 "tried to extend a builder with `DType` {} with an array with `DType {}",
                 self.dtype,

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -213,7 +213,7 @@ impl ArrayBuilder for VarBinViewBuilder {
 
     #[inline]
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
-        if !self.dtype.is_superset_of(array.dtype()) {
+        if !self.dtype.eq_with_nullability_superset(array.dtype()) {
             vortex_bail!(
                 "tried to extend a builder with `DType` {} with an array with `DType {}",
                 self.dtype,

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use vortex_buffer::{Buffer, BufferMut, ByteBuffer, ByteBufferMut};
 use vortex_dtype::{DType, Nullability};
-use vortex_error::{VortexExpect, VortexResult};
+use vortex_error::{VortexExpect, VortexResult, vortex_bail};
 use vortex_mask::Mask;
 use vortex_utils::aliases::hash_map::{Entry, HashMap};
 
@@ -213,6 +213,14 @@ impl ArrayBuilder for VarBinViewBuilder {
 
     #[inline]
     fn extend_from_array(&mut self, array: &dyn Array) -> VortexResult<()> {
+        if !self.dtype.is_superset_of(array.dtype()) {
+            vortex_bail!(
+                "tried to extend a builder with `DType` {} with an array with `DType {}",
+                self.dtype,
+                array.dtype()
+            );
+        }
+
         let array = array.to_varbinview()?;
         self.flush_in_progress();
 

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -184,6 +184,40 @@ impl DType {
         }
     }
 
+    /// Returns `true` if `self` is a subset type of `other, otherwise `false`.
+    ///
+    /// If `self` is nullable, this means that the other `DType` must also be nullable (since a
+    /// nullable type represents more values than a non-nullable type) and equal.
+    ///
+    /// If `self` is non-nullable, then the other `DType` must be equal ignoring nullabillity.
+    ///
+    /// We implement this functionality as a complement to `is_superset_of`.
+    pub fn eq_with_nullability_subset(&self, other: &Self) -> bool {
+        if self.is_nullable() {
+            self == other
+        } else {
+            self.eq_ignore_nullability(other)
+        }
+    }
+
+    /// Returns `true` if `self` is a superset type of `other, otherwise `false`.
+    ///
+    /// If `self` is non-nullable, this means that the other `DType` must also be non-nullable
+    /// (since a non-nullable type represents less values than a nullable type) and equal.
+    ///
+    /// If `self` is nullable, then the other `DType` must be equal ignoring nullabillity.
+    ///
+    /// This function is useful (in the `vortex-array` crate) for determining if an `Array` can
+    /// extend a given `ArrayBuilder`: it can only extend it if the `DType` of the builder is a
+    /// superset of the `Array`.
+    pub fn eq_with_nullability_superset(&self, other: &Self) -> bool {
+        if self.is_nullable() {
+            self.eq_ignore_nullability(other)
+        } else {
+            self == other
+        }
+    }
+
     /// Check if `self` is a boolean
     pub fn is_boolean(&self) -> bool {
         matches!(self, Bool(_))


### PR DESCRIPTION
This will be helpful in my refactoring of the `builders` module in `vortex-array` (in draft right now: https://github.com/vortex-data/vortex/pull/4440)

Note that `extend_from_array` is called in many non-test places yet is not validated at all. Given that this is a public method, this is a bug waiting to happen...

I have an interesting thought though: should a `DType::Primitive(U64, nullable)` be a superset of `DType::Primitive(U16, non-nullable)`?

In theory, we should be able to extend an array builder of nullable `U64` with an array of non-nullable `U8`.

I'll leave that to a separate PR since this idea might have some other implications.