### PR TITLE
Chore: Clean up `PrimitiveBuilder` API

### DIFF
--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::mem::MaybeUninit;
-
 use fastlanes::BitPacking;
 use itertools::Itertools;
 use num_traits::{AsPrimitive, PrimInt};
@@ -359,7 +357,7 @@ fn insert_values_and_validity_at_indices<
     match values_validity {
         Mask::AllTrue(_) => {
             for (index, &value) in indices.iter().zip_eq(values) {
-                dst[index.as_() - indices_offset] = MaybeUninit::new(value);
+                dst.set_value(index.as_() - indices_offset, value);
             }
         }
         Mask::AllFalse(_) => {
@@ -370,7 +368,7 @@ fn insert_values_and_validity_at_indices<
         Mask::Values(vb) => {
             for (index, &value) in indices.iter().zip_eq(values) {
                 let out_index = index.as_() - indices_offset;
-                dst[out_index] = MaybeUninit::new(value);
+                dst.set_value(out_index, value);
                 dst.set_bit(out_index, vb.value(out_index));
             }
         }
@@ -539,7 +537,8 @@ mod test {
     use rand::rngs::StdRng;
     use vortex_array::ToCanonical as _;
     use vortex_array::arrays::ChunkedArray;
-    use vortex_buffer::buffer;
+    use vortex_buffer::{Buffer, buffer};
+    use vortex_dtype::Nullability;
     use vortex_error::VortexError;
 
     use super::*;
@@ -743,5 +742,73 @@ mod test {
             into_ca.as_slice::<i32>(),
             ca_into.to_primitive().as_slice::<i32>()
         );
+    }
+
+    #[test]
+    fn test_unpack_into_empty_array() {
+        let empty: PrimitiveArray = PrimitiveArray::from_iter(Vec::<u32>::new());
+        let bitpacked = bitpack_encode(&empty, 0, None).unwrap();
+
+        let mut builder = PrimitiveBuilder::<u32>::new(Nullability::NonNullable);
+        unpack_into(&bitpacked, &mut builder);
+
+        let result = builder.finish_into_primitive();
+        assert_eq!(
+            result.len(),
+            0,
+            "Empty array should result in empty builder"
+        );
+    }
+
+    /// This test ensures that the mask is properly appended to the range, not the builder.
+    #[test]
+    fn test_unpack_into_with_validity_mask() {
+        // Create an array with some null values.
+        let values = Buffer::from_iter([1u32, 0, 3, 4, 0]);
+        let validity = Validity::from_iter([true, false, true, true, false]);
+        let array = PrimitiveArray::new(values, validity);
+
+        // Bitpack the array.
+        let bitpacked = bitpack_encode(&array, 3, None).unwrap();
+
+        // Unpack into a new builder.
+        let mut builder = PrimitiveBuilder::<u32>::with_capacity(Nullability::Nullable, 5);
+        unpack_into(&bitpacked, &mut builder);
+
+        let result = builder.finish_into_primitive();
+
+        // Verify the validity mask was correctly applied.
+        assert_eq!(result.len(), 5);
+        assert!(!result.scalar_at(0).is_null());
+        assert!(result.scalar_at(1).is_null());
+        assert!(!result.scalar_at(2).is_null());
+        assert!(!result.scalar_at(3).is_null());
+        assert!(result.scalar_at(4).is_null());
+    }
+
+    /// Test that `unpack_into` correctly handles arrays with patches.
+    #[test]
+    fn test_unpack_into_with_patches() {
+        // Create an array where most values fit in 4 bits but some need patches.
+        let values: Vec<u32> = (0..100)
+            .map(|i| if i % 20 == 0 { 1000 + i } else { i % 16 })
+            .collect();
+        let array = PrimitiveArray::from_iter(values.clone());
+
+        // Bitpack with a bit width that will require patches.
+        let bitpacked = bitpack_encode(&array, 4, None).unwrap();
+        assert!(
+            bitpacked.patches().is_some(),
+            "Should have patches for values > 15"
+        );
+
+        // Unpack into a new builder.
+        let mut builder = PrimitiveBuilder::<u32>::with_capacity(Nullability::NonNullable, 100);
+        unpack_into(&bitpacked, &mut builder);
+
+        let result = builder.finish_into_primitive();
+
+        // Verify all values were correctly unpacked including patches.
+        assert_eq!(result.as_slice::<u32>(), &values);
     }
 }

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -293,27 +293,38 @@ pub(crate) fn unpack_into<T: BitPacked>(
     // TODO(ngates): do we want to use fastlanes alignment for this buffer?
     builder: &mut PrimitiveBuilder<T>,
 ) {
-    // Append a dense null Mask.
-    builder.append_mask(array.validity_mask());
-
-    let mut uninit = builder.uninit_range(array.len());
-    let mut bit_packed_iter = array.unpacked_chunks();
-
-    if let Some(header) = bit_packed_iter.initial() {
-        uninit.copy_from_init(0, header.len(), header);
+    // If the array is empty, then we don't need to add anything to the builder.
+    if array.is_empty() {
+        return;
     }
 
-    let out_idx = bit_packed_iter.decode_full_chunks_into(&mut uninit);
+    let mut uninit_range = builder.uninit_range(array.len());
 
+    // SAFETY: We later initialize the the uninitialized range of values with `copy_from_slice`.
+    unsafe {
+        // Append a dense null Mask.
+        uninit_range.append_mask(array.validity_mask());
+    }
+
+    let mut bit_packed_iter = array.unpacked_chunks();
+    if let Some(header) = bit_packed_iter.initial() {
+        uninit_range.copy_from_slice(0, header);
+    }
+
+    let out_idx = bit_packed_iter.decode_full_chunks_into(&mut uninit_range);
     if let Some(trailer) = bit_packed_iter.trailer() {
-        uninit.copy_from_init(out_idx, trailer.len(), trailer);
+        uninit_range.copy_from_slice(out_idx, trailer);
     }
 
     if let Some(patches) = array.patches() {
-        apply_patches(&mut uninit, patches);
+        apply_patches(&mut uninit_range, patches);
     };
 
-    uninit.finish();
+    // SAFETY: We have set a correct validity mask via `append_mask` with `array.len()` values and
+    // initialized the same number of values needed via calls to `copy_from_slice`.
+    unsafe {
+        uninit_range.finish();
+    }
 }
 
 fn apply_patches<T: NativePType>(dst: &mut UninitRange<T>, patches: &Patches) {
@@ -323,6 +334,7 @@ fn apply_patches<T: NativePType>(dst: &mut UninitRange<T>, patches: &Patches) {
     let values = patches.values().to_primitive();
     let validity = values.validity_mask();
     let values = values.as_slice::<T>();
+
     match_each_unsigned_integer_ptype!(indices.ptype(), |P| {
         insert_values_and_validity_at_indices(
             dst,

--- a/encodings/fastlanes/src/bitpacking/unpack_iter.rs
+++ b/encodings/fastlanes/src/bitpacking/unpack_iter.rs
@@ -128,19 +128,23 @@ impl<T: BitPacked> BitUnpackedChunks<T> {
         )
     }
 
-    /// Unpack full chunks into output range and return the last index that was written to
+    /// Unpack full chunks into output range and return the next local index to write to.
     pub fn decode_full_chunks_into(&mut self, output: &mut UninitRange<T>) -> usize {
         let first_chunk_is_sliced = self.first_chunk_is_sliced();
-        // If there's only one chunk and that chunk is sliced it has been handled already by `header` method
+        // If there's only one chunk and that chunk is sliced it has been handled already by
+        // `header` method
         if first_chunk_is_sliced && self.num_chunks == 1 {
-            return self.len;
+            // Return the length since the header already wrote everything.
+            return CHUNK_SIZE - self.offset;
         }
 
         let last_chunk_is_sliced = self.last_chunk_is_sliced();
         let full_chunks_range =
             (first_chunk_is_sliced as usize)..(self.num_chunks - last_chunk_is_sliced as usize);
 
-        let mut out_idx = if first_chunk_is_sliced {
+        // Track position relative to the start of the UninitRange.
+        let mut local_idx = if first_chunk_is_sliced {
+            // The header already wrote from 0 to (CHUNK_SIZE - self.offset).
             CHUNK_SIZE - self.offset
         } else {
             0
@@ -152,13 +156,15 @@ impl<T: BitPacked> BitUnpackedChunks<T> {
             let chunk = &packed_slice[i * elems_per_chunk..][..elems_per_chunk];
 
             unsafe {
+                // SAFETY: We're about to initialize CHUNK_SIZE elements at local_idx.
+                let uninit_dst = output.slice_uninit_mut(local_idx, CHUNK_SIZE);
                 // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout
-                let dst: &mut [T::Physical] = mem::transmute(&mut output[out_idx..][..CHUNK_SIZE]);
+                let dst: &mut [T::Physical] = mem::transmute(uninit_dst);
                 BitPacking::unchecked_unpack(self.bit_width, chunk, dst);
             }
-            out_idx += CHUNK_SIZE;
+            local_idx += CHUNK_SIZE;
         }
-        out_idx
+        local_idx
     }
 
     /// Access last chunk of the array if the last chunk has fewer than 1024 due to slicing

--- a/vortex-array/src/builders/bool.rs
+++ b/vortex-array/src/builders/bool.rs
@@ -12,10 +12,9 @@ use crate::builders::{ArrayBuilder, DEFAULT_BUILDER_CAPACITY, LazyNullBufferBuil
 use crate::{Array, ArrayRef, IntoArray, ToCanonical};
 
 pub struct BoolBuilder {
+    dtype: DType,
     inner: BooleanBufferBuilder,
     nulls: LazyNullBufferBuilder,
-    nullability: Nullability,
-    dtype: DType,
 }
 
 impl BoolBuilder {
@@ -27,7 +26,6 @@ impl BoolBuilder {
         Self {
             inner: BooleanBufferBuilder::new(capacity),
             nulls: LazyNullBufferBuilder::new(capacity),
-            nullability,
             dtype: DType::Bool(nullability),
         }
     }
@@ -58,6 +56,20 @@ impl BoolBuilder {
             Some(value) => self.append_value(value),
             None => self.append_null(),
         }
+    }
+
+    /// Finishes the builder directly into a [`BoolArray`].
+    pub fn finish_into_bool(&mut self) -> BoolArray {
+        assert_eq!(
+            self.nulls.len(),
+            self.inner.len(),
+            "Null count and value count should match when calling BoolBuilder::finish."
+        );
+
+        BoolArray::new(
+            self.inner.finish(),
+            self.nulls.finish_with_nullability(self.dtype.nullability()),
+        )
     }
 }
 
@@ -107,17 +119,7 @@ impl ArrayBuilder for BoolBuilder {
     }
 
     fn finish(&mut self) -> ArrayRef {
-        assert_eq!(
-            self.nulls.len(),
-            self.inner.len(),
-            "Null count and value count should match when calling BoolBuilder::finish."
-        );
-
-        BoolArray::new(
-            self.inner.finish(),
-            self.nulls.finish_with_nullability(self.nullability),
-        )
-        .into_array()
+        self.finish_into_bool().into_array()
     }
 }
 

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -253,7 +253,9 @@ pub trait ArrayBuilder: Send {
     /// Ensure that the builder can hold at least `capacity` number of items
     fn ensure_capacity(&mut self, capacity: usize);
 
-    /// Override builders validity with the one provided
+    /// Override builders validity with the one provided.
+    ///
+    /// Note that this will have no effect on the final array if the array builder is non-nullable.
     fn set_validity(&mut self, validity: Mask);
 
     /// Constructs an Array from the builder components.

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -3,7 +3,6 @@
 
 use std::any::Any;
 use std::mem::MaybeUninit;
-use std::ops::{Deref, DerefMut};
 
 use vortex_buffer::BufferMut;
 use vortex_dtype::{DType, NativePType, Nullability};
@@ -77,12 +76,12 @@ impl<T: NativePType> PrimitiveBuilder<T> {
     /// let mut builder: PrimitiveBuilder<i32> =
     ///     PrimitiveBuilder::with_capacity(Nullability::NonNullable, 5);
     ///
-    /// // Populate the values in reverse order.
-    /// let mut range = builder.uninit_range(5);
-    /// for i in [4, 3, 2, 1, 0] {
-    ///     range[i] = MaybeUninit::new(i as i32);
-    /// }
-    /// range.finish();
+    /// // Populate the values.
+    /// let mut uninit_range = builder.uninit_range(5);
+    /// uninit_range.copy_from_slice(0, &[0, 1, 2, 3, 4]);
+    ///
+    /// // SAFETY: We have initialized all 5 values in the range.
+    /// unsafe { uninit_range.finish(); }
     ///
     /// let built = builder.finish_into_primitive();
     ///
@@ -91,18 +90,14 @@ impl<T: NativePType> PrimitiveBuilder<T> {
     pub fn uninit_range(&mut self, len: usize) -> UninitRange<'_, T> {
         assert_ne!(0, len, "cannot create an uninit range of length 0");
 
-        let offset = self.values.len();
+        let current_len = self.values.len();
         assert!(
-            offset + len <= self.values.capacity(),
+            current_len + len <= self.values.capacity(),
             "uninit_range of len {len} exceeds builder capacity {}",
             self.values.capacity()
         );
 
-        UninitRange {
-            offset,
-            len,
-            builder: self,
-        }
+        UninitRange { len, builder: self }
     }
 
     /// Finishes the builder directly into a [`PrimitiveArray`].
@@ -181,12 +176,32 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
 
 /// A range of uninitialized values in the primitive builder that can be filled.
 pub struct UninitRange<'a, T> {
-    offset: usize,
     len: usize,
     builder: &'a mut PrimitiveBuilder<T>,
 }
 
 impl<T> UninitRange<'_, T> {
+    /// Returns the length of this uninitialized range.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns true if this range has zero length.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Set a value at the given index within this range.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is out of bounds.
+    pub fn set_value(&mut self, index: usize, value: T) {
+        assert!(index < self.len, "index out of bounds");
+        let spare = self.builder.values.spare_capacity_mut();
+        spare[index] = MaybeUninit::new(value);
+    }
+
     /// Append a [`Mask`] to this builder's null buffer.
     ///
     /// # Panics
@@ -212,32 +227,65 @@ impl<T> UninitRange<'_, T> {
         self.builder.nulls.append_validity_mask(mask);
     }
 
-    /// Set a validity bit at the given index. The index is relative to the start of this range
-    /// of the builder.
+    /// Set a validity bit at the given index.
+    ///
+    /// The index is relative to the start of this range (not relative to the values already in the
+    /// builder).
+    ///
+    /// Note that this will have no effect if the builder is non-nullable.
     pub fn set_bit(&mut self, index: usize, v: bool) {
+        assert!(index < self.len, "set_bit index out of bounds");
         // Note that this won't panic because we can only create an `UninitRange` within the
         // capacity of the builder (it will not automatically resize).
-        self.builder.nulls.set_bit(self.offset + index, v);
+        let absolute_index = self.builder.values.len() + index;
+        self.builder.nulls.set_bit(absolute_index, v);
     }
 
     /// Set values from an initialized range.
     ///
     /// Note that the input `offset` should be an offset relative to the local `UninitRange`, not
     /// the entire `PrimitiveBuilder`.
-    pub fn copy_from_slice(&mut self, offset: usize, src: &[T])
+    pub fn copy_from_slice(&mut self, local_offset: usize, src: &[T])
     where
         T: Copy,
     {
         debug_assert!(
-            offset + src.len() <= self.len,
+            local_offset + src.len() <= self.len,
             "tried to copy a slice into a `UninitRange` past its boundary"
         );
 
         // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout.
         let uninit_src: &[MaybeUninit<T>] = unsafe { std::mem::transmute(src) };
 
-        let dst = &mut self[offset..][..src.len()];
+        // Note: spare_capacity_mut() returns the spare capacity starting from the current length,
+        // so we just use local_offset directly.
+        let dst =
+            &mut self.builder.values.spare_capacity_mut()[local_offset..local_offset + src.len()];
         dst.copy_from_slice(uninit_src);
+    }
+
+    /// Get a mutable slice of uninitialized memory at the specified offset within this range.
+    ///
+    /// Note that the offsets are relative to this local range, not to the values already in the
+    /// builder.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that they properly initialize the returned memory before calling
+    /// `finish()` on this range.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `offset + len` exceeds the range bounds.
+    pub unsafe fn slice_uninit_mut(&mut self, offset: usize, len: usize) -> &mut [MaybeUninit<T>] {
+        assert!(
+            offset + len <= self.len,
+            "slice_uninit_mut: offset {} + len {} exceeds range length {}",
+            offset,
+            len,
+            self.len
+        );
+        &mut self.builder.values.spare_capacity_mut()[offset..offset + len]
     }
 
     /// Finish building this range, marking it as initialized and advancing the length of the
@@ -252,40 +300,237 @@ impl<T> UninitRange<'_, T> {
     /// [`set_bit`]: UninitRange::set_bit
     /// [`append_mask`]: UninitRange::append_mask
     pub unsafe fn finish(self) {
-        // SAFETY: constructor enforces that offset + len does not exceed the capacity of the array.
-        unsafe { self.builder.values.set_len(self.offset + self.len) };
+        // SAFETY: constructor enforces that current length + len does not exceed the capacity of the array.
+        let new_len = self.builder.values.len() + self.len;
+        unsafe { self.builder.values.set_len(new_len) };
     }
 }
 
-/// Note that we only implement `Deref` for parity with `DerefMut`.
-impl<T> Deref for UninitRange<'_, T> {
-    type Target = [MaybeUninit<T>];
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    /// Returns a [`MaybeUninit`] slice of the [`PrimitiveBuilder`]'s uninitialized memory capacity
-    /// (which is simply the length).
-    fn deref(&self) -> &[MaybeUninit<T>] {
-        // We implement this manually since there is no `spare_capacity()` method on the internal
-        // `BytesMut` type.
-        let base = self.builder.values.as_ptr();
+    /// REGRESSION TEST: This test verifies that multiple sequential ranges have correct offsets.
+    ///
+    /// This would have caught the `Deref` bug where it always returned from the start of the
+    /// buffer.
+    #[test]
+    fn test_multiple_uninit_ranges_correct_offsets() {
+        let mut builder = PrimitiveBuilder::<i32>::with_capacity(Nullability::NonNullable, 10);
 
-        // SAFETY: `offset` is derived from the existing buffer in memory, so this won't wrap.
-        let start = unsafe { base.add(self.offset) };
+        // First range.
+        let mut range1 = builder.uninit_range(3);
+        range1.copy_from_slice(0, &[1, 2, 3]);
 
+        // SAFETY: We initialized all 3 values.
         unsafe {
-            // SAFETY: `start + len` is checked on construction of `UninitRange` to be within the
-            // total capacity of the builder.
-            let dst = std::slice::from_raw_parts(start, self.len);
+            range1.finish();
+        }
 
-            // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout
-            let dst: &[MaybeUninit<T>] = std::mem::transmute(dst);
+        // Verify the builder now has these values.
+        assert_eq!(builder.values(), &[1, 2, 3]);
 
-            dst
+        // Second range - this would fail with the old Deref implementation.
+        let mut range2 = builder.uninit_range(2);
+
+        // Set values using copy_from_slice.
+        range2.copy_from_slice(0, &[4, 5]);
+
+        // SAFETY: We initialized both values.
+        unsafe {
+            range2.finish();
+        }
+
+        // Verify the builder now has all 5 values.
+        assert_eq!(builder.values(), &[1, 2, 3, 4, 5]);
+
+        let array = builder.finish_into_primitive();
+        assert_eq!(array.as_slice::<i32>(), &[1, 2, 3, 4, 5]);
+    }
+
+    /// REGRESSION TEST: This test verifies that `append_mask` was correctly moved from
+    /// `PrimitiveBuilder` to `UninitRange`.
+    ///
+    /// The old API had `append_mask` on the builder, which was confusing when used with ranges.
+    /// This test ensures the new API works correctly.
+    #[test]
+    fn test_append_mask_on_uninit_range() {
+        let mut builder = PrimitiveBuilder::<i32>::with_capacity(Nullability::Nullable, 5);
+        let mut range = builder.uninit_range(3);
+
+        // Create a mask for 3 values.
+        let mask = Mask::from_iter([true, false, true]);
+
+        // SAFETY: We're about to initialize the values.
+        unsafe {
+            range.append_mask(mask);
+        }
+
+        // Initialize the values.
+        range.copy_from_slice(0, &[10, 20, 30]);
+
+        // SAFETY: We've initialized all values and set the mask.
+        unsafe {
+            range.finish();
+        }
+
+        let array = builder.finish_into_primitive();
+        assert_eq!(array.len(), 3);
+        // Check validity using scalar_at - nulls will return is_null() = true.
+        assert!(!array.scalar_at(0).is_null());
+        assert!(array.scalar_at(1).is_null());
+        assert!(!array.scalar_at(2).is_null());
+    }
+
+    /// REGRESSION TEST: This test verifies that `append_mask` validates the mask length.
+    ///
+    /// This ensures that masks can only be appended if they match the range length.
+    #[test]
+    #[should_panic(
+        expected = "Tried to append a mask to an `UninitRange` that was beyond the allowed range"
+    )]
+    fn test_append_mask_wrong_length_panics() {
+        let mut builder = PrimitiveBuilder::<i32>::with_capacity(Nullability::Nullable, 10);
+        let mut range = builder.uninit_range(5);
+
+        // Try to append a mask with wrong length (3 instead of 5).
+        let wrong_mask = Mask::from_iter([true, false, true]);
+
+        // SAFETY: This is expected to panic due to length mismatch.
+        unsafe {
+            range.append_mask(wrong_mask);
         }
     }
-}
 
-impl<T> DerefMut for UninitRange<'_, T> {
-    fn deref_mut(&mut self) -> &mut [MaybeUninit<T>] {
-        &mut self.builder.values.spare_capacity_mut()[..self.len]
+    /// Test that `copy_from_slice` works correctly with different offsets.
+    ///
+    /// This verifies the new simplified API without the redundant `len` parameter.
+    #[test]
+    fn test_copy_from_slice_with_offsets() {
+        let mut builder = PrimitiveBuilder::<i32>::with_capacity(Nullability::NonNullable, 10);
+        let mut range = builder.uninit_range(6);
+
+        // Copy to different offsets.
+        range.copy_from_slice(0, &[1, 2]);
+        range.copy_from_slice(2, &[3, 4]);
+        range.copy_from_slice(4, &[5, 6]);
+
+        // SAFETY: We've initialized all 6 values.
+        unsafe {
+            range.finish();
+        }
+
+        let array = builder.finish_into_primitive();
+        assert_eq!(array.as_slice::<i32>(), &[1, 2, 3, 4, 5, 6]);
+    }
+
+    /// Test that `set_bit` uses relative indexing within the range.
+    ///
+    /// Note: `set_bit` requires the null buffer to already be initialized, so we first
+    /// use `append_mask` to set up the buffer, then demonstrate that `set_bit` can
+    /// modify individual bits with relative indexing.
+    #[test]
+    fn test_set_bit_relative_indexing() {
+        let mut builder = PrimitiveBuilder::<i32>::with_capacity(Nullability::Nullable, 10);
+
+        // First add some values to the builder.
+        builder.append_value(100);
+        builder.append_value(200);
+
+        // Create a range for new values.
+        let mut range = builder.uninit_range(3);
+
+        // Use append_mask to initialize the validity buffer for this range.
+        let initial_mask = Mask::from_iter([false, false, false]);
+        // SAFETY: We're about to initialize the values.
+        unsafe {
+            range.append_mask(initial_mask);
+        }
+
+        // Now we can use set_bit to modify individual bits with relative indexing.
+        range.set_bit(0, true); // Change first bit to valid
+        range.set_bit(2, true); // Change third bit to valid
+        // Leave middle bit as false (null)
+
+        // Initialize the values.
+        range.copy_from_slice(0, &[10, 20, 30]);
+
+        // SAFETY: We've initialized all 3 values and set their validity.
+        unsafe {
+            range.finish();
+        }
+
+        let array = builder.finish_into_primitive();
+
+        // Verify the total length and values.
+        assert_eq!(array.len(), 5);
+        assert_eq!(array.as_slice::<i32>(), &[100, 200, 10, 20, 30]);
+
+        // Check validity - the first two should be valid (from append_value).
+        assert!(!array.scalar_at(0).is_null()); // initial value 100
+        assert!(!array.scalar_at(1).is_null()); // initial value 200
+
+        // Check the range items with modified validity.
+        assert!(!array.scalar_at(2).is_null()); // range index 0 - set to valid
+        assert!(array.scalar_at(3).is_null()); // range index 1 - left as null
+        assert!(!array.scalar_at(4).is_null()); // range index 2 - set to valid
+    }
+
+    /// Test that creating a zero-length uninit range panics.
+    #[test]
+    #[should_panic(expected = "cannot create an uninit range of length 0")]
+    fn test_zero_length_uninit_range_panics() {
+        let mut builder = PrimitiveBuilder::<i32>::new(Nullability::NonNullable);
+        let _range = builder.uninit_range(0);
+    }
+
+    /// Test that creating an uninit range exceeding capacity panics.
+    #[test]
+    #[should_panic(expected = "uninit_range of len 10 exceeds builder capacity")]
+    fn test_uninit_range_exceeds_capacity_panics() {
+        let mut builder = PrimitiveBuilder::<i32>::with_capacity(Nullability::NonNullable, 5);
+        let _range = builder.uninit_range(10);
+    }
+
+    /// Test that `copy_from_slice` debug asserts on out-of-bounds access.
+    ///
+    /// Note: This only panics in debug mode due to `debug_assert!`.
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "tried to copy a slice into a `UninitRange` past its boundary")]
+    fn test_copy_from_slice_out_of_bounds() {
+        let mut builder = PrimitiveBuilder::<i32>::with_capacity(Nullability::NonNullable, 10);
+        let mut range = builder.uninit_range(3);
+
+        // Try to copy 3 elements starting at offset 1 (would need 4 slots total).
+        range.copy_from_slice(1, &[1, 2, 3]);
+    }
+
+    /// Test that the unsafe contract of `finish` is documented and works correctly.
+    ///
+    /// This test demonstrates proper usage of the unsafe `finish` method.
+    #[test]
+    fn test_finish_unsafe_contract() {
+        let mut builder = PrimitiveBuilder::<i32>::with_capacity(Nullability::Nullable, 5);
+        let mut range = builder.uninit_range(3);
+
+        // Set validity mask.
+        let mask = Mask::from_iter([true, true, false]);
+        // SAFETY: We're about to initialize the matching number of values.
+        unsafe {
+            range.append_mask(mask);
+        }
+
+        // Initialize all values.
+        range.copy_from_slice(0, &[10, 20, 30]);
+
+        // SAFETY: We have initialized all 3 values and set their validity.
+        unsafe {
+            range.finish();
+        }
+
+        let array = builder.finish_into_primitive();
+        assert_eq!(array.len(), 3);
+        assert_eq!(array.as_slice::<i32>(), &[10, 20, 30]);
     }
 }

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -35,11 +35,6 @@ impl<T: NativePType> PrimitiveBuilder<T> {
         }
     }
 
-    /// Append a [`Mask`] to this builder's null buffer.
-    pub fn append_mask(&mut self, mask: Mask) {
-        self.nulls.append_validity_mask(mask);
-    }
-
     /// Appends a primitive `value` to the builder.
     pub fn append_value(&mut self, value: T) {
         self.values.push(value);
@@ -94,6 +89,8 @@ impl<T: NativePType> PrimitiveBuilder<T> {
     /// assert_eq!(built.as_slice::<i32>(), &[0i32, 1, 2, 3, 4]);
     /// ```
     pub fn uninit_range(&mut self, len: usize) -> UninitRange<'_, T> {
+        assert_ne!(0, len, "cannot create an uninit range of length 0");
+
         let offset = self.values.len();
         assert!(
             offset + len <= self.values.capacity(),
@@ -189,13 +186,94 @@ pub struct UninitRange<'a, T> {
     builder: &'a mut PrimitiveBuilder<T>,
 }
 
+impl<T> UninitRange<'_, T> {
+    /// Append a [`Mask`] to this builder's null buffer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the mask length is not equal to the the length of the current `UninitRange`.
+    ///
+    /// # Safety
+    ///
+    /// - The caller must ensure that they safely initialize `mask.len()` primitive values via
+    ///   [`UninitRange::copy_from_slice`].
+    /// - The caller must also ensure that they only call this method once.
+    pub unsafe fn append_mask(&mut self, mask: Mask) {
+        assert_eq!(
+            mask.len(),
+            self.len,
+            "Tried to append a mask to an `UninitRange` that was beyond the allowed range"
+        );
+
+        // TODO(connor): Ideally, we would call this function `set_mask` and directly set all of the
+        // bits (so that we can call this multiple times), but the underlying `BooleanBuffer` does
+        // not have an easy way to do this correctly.
+
+        self.builder.nulls.append_validity_mask(mask);
+    }
+
+    /// Set a validity bit at the given index. The index is relative to the start of this range
+    /// of the builder.
+    pub fn set_bit(&mut self, index: usize, v: bool) {
+        // Note that this won't panic because we can only create an `UninitRange` within the
+        // capacity of the builder (it will not automatically resize).
+        self.builder.nulls.set_bit(self.offset + index, v);
+    }
+
+    /// Set values from an initialized range.
+    ///
+    /// Note that the input `offset` should be an offset relative to the local `UninitRange`, not
+    /// the entire `PrimitiveBuilder`.
+    pub fn copy_from_slice(&mut self, offset: usize, src: &[T])
+    where
+        T: Copy,
+    {
+        debug_assert!(
+            offset + src.len() <= self.len,
+            "tried to copy a slice into a `UninitRange` past its boundary"
+        );
+
+        // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout.
+        let uninit_src: &[MaybeUninit<T>] = unsafe { std::mem::transmute(src) };
+
+        let dst = &mut self[offset..][..src.len()];
+        dst.copy_from_slice(uninit_src);
+    }
+
+    /// Finish building this range, marking it as initialized and advancing the length of the
+    /// underlying values buffer.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that they have safely initialized all `len` values via
+    /// [`UninitRange::copy_from_slice`] as well as correctly set all of the null bits via
+    /// [`set_bit`] or [`append_mask`] if the builder is nullable.
+    ///
+    /// [`set_bit`]: UninitRange::set_bit
+    /// [`append_mask`]: UninitRange::append_mask
+    pub unsafe fn finish(self) {
+        // SAFETY: constructor enforces that offset + len does not exceed the capacity of the array.
+        unsafe { self.builder.values.set_len(self.offset + self.len) };
+    }
+}
+
+/// Note that we only implement `Deref` for parity with `DerefMut`.
 impl<T> Deref for UninitRange<'_, T> {
     type Target = [MaybeUninit<T>];
 
+    /// Returns a [`MaybeUninit`] slice of the [`PrimitiveBuilder`]'s uninitialized memory capacity
+    /// (which is simply the length).
     fn deref(&self) -> &[MaybeUninit<T>] {
-        let start = self.builder.values.as_ptr();
+        // We implement this manually since there is no `spare_capacity()` method on the internal
+        // `BytesMut` type.
+        let base = self.builder.values.as_ptr();
+
+        // SAFETY: `offset` is derived from the existing buffer in memory, so this won't wrap.
+        let start = unsafe { base.add(self.offset) };
+
         unsafe {
-            // SAFETY: start + len is checked on construction to be in range.
+            // SAFETY: `start + len` is checked on construction of `UninitRange` to be within the
+            // total capacity of the builder.
             let dst = std::slice::from_raw_parts(start, self.len);
 
             // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout
@@ -209,32 +287,5 @@ impl<T> Deref for UninitRange<'_, T> {
 impl<T> DerefMut for UninitRange<'_, T> {
     fn deref_mut(&mut self) -> &mut [MaybeUninit<T>] {
         &mut self.builder.values.spare_capacity_mut()[..self.len]
-    }
-}
-
-impl<T> UninitRange<'_, T> {
-    /// Set a validity bit at the given index. The index is relative to the start of this range
-    /// of the builder.
-    pub fn set_bit(&mut self, index: usize, v: bool) {
-        self.builder.nulls.set_bit(self.offset + index, v);
-    }
-
-    /// Set values from an initialized range.
-    pub fn copy_from_init(&mut self, offset: usize, len: usize, src: &[T])
-    where
-        T: Copy,
-    {
-        // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout
-        let uninit_src: &[MaybeUninit<T>] = unsafe { std::mem::transmute(src) };
-
-        let dst = &mut self[offset..][..len];
-        dst.copy_from_slice(uninit_src);
-    }
-
-    /// Finish building this range, marking it as initialized and advancing the length of the
-    /// underlying values buffer.
-    pub fn finish(self) {
-        // SAFETY: constructor enforces that offset + len does not exceed the capacity of the array.
-        unsafe { self.builder.values.set_len(self.offset + self.len) };
     }
 }

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -65,6 +65,11 @@ impl<T: NativePType> PrimitiveBuilder<T> {
     /// All reads/writes through the handle to the values buffer or the validity buffer will operate
     /// on indices relative to the start of the range.
     ///
+    /// # Panics
+    ///
+    /// Panics if `len` is 0 or if the current length of the builder plus `len` would exceed the
+    /// capacity of the builder's memory.
+    ///
     /// ## Example
     ///
     /// ```
@@ -80,7 +85,8 @@ impl<T: NativePType> PrimitiveBuilder<T> {
     /// let mut uninit_range = builder.uninit_range(5);
     /// uninit_range.copy_from_slice(0, &[0, 1, 2, 3, 4]);
     ///
-    /// // SAFETY: We have initialized all 5 values in the range.
+    /// // SAFETY: We have initialized all 5 values in the range, and since the array builder is
+    /// // non-nullable, we don't need to set any null bits.
     /// unsafe { uninit_range.finish(); }
     ///
     /// let built = builder.finish_into_primitive();
@@ -176,17 +182,27 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
 
 /// A range of uninitialized values in the primitive builder that can be filled.
 pub struct UninitRange<'a, T> {
+    /// The length of the uninitialized range.
+    ///
+    /// This is guaranteed to be within the memory capacity of the builder.
     len: usize,
+
+    /// A mutable reference to the builder.
+    ///
+    /// Since this is a mutable reference, we can guarantee that nothing else can modify the builder
+    /// while this `UninitRange` exists.
     builder: &'a mut PrimitiveBuilder<T>,
 }
 
 impl<T> UninitRange<'_, T> {
     /// Returns the length of this uninitialized range.
+    #[inline]
     pub fn len(&self) -> usize {
         self.len
     }
 
     /// Returns true if this range has zero length.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }
@@ -196,6 +212,7 @@ impl<T> UninitRange<'_, T> {
     /// # Panics
     ///
     /// Panics if the index is out of bounds.
+    #[inline]
     pub fn set_value(&mut self, index: usize, value: T) {
         assert!(index < self.len, "index out of bounds");
         let spare = self.builder.values.spare_capacity_mut();


### PR DESCRIPTION
Fixes part of #4220 (not too sure about the strict provenance violations yet)

The `Deref` implementation for `UninitRange` always returned slices from the start of the buffer instead of tracking the current position, causing incorrect memory access when multiple ranges were used sequentially. Additionally, `Deref` inconsistently sliced the entire builder's buffer while `DerefMut` only sliced the uninitialized memory up to capacity.

### Changes

- Removed `Deref`/`DerefMut` implementations entirely to prevent confusion
- Moved `append_mask()` from `PrimitiveBuilder` to `UninitRange` where it logically belongs
- Added explicit methods: `len`, `set_value()`, `copy_from_slice()`, `slice_uninit_mut()` to account for the fact that we don't have `Deref` to a slice anymore (which actually returned the wrong length slice)
- Fixed offset tracking to be relative to each range
- Added a bunch of safety comments for unsafe things
- Add regression tests
