### PR TITLE
Remove caching the array on flat layout reader, rely on the segment cache instead

### DIFF
--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -3,7 +3,7 @@
 
 use std::collections::BTreeSet;
 use std::ops::{BitAnd, Range};
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::FutureExt;
@@ -37,7 +37,6 @@ pub struct FlatReader {
     layout: FlatLayout,
     name: Arc<str>,
     segment_source: Arc<dyn SegmentSource>,
-    array: OnceLock<SharedArrayFuture>,
 }
 
 impl FlatReader {
@@ -50,7 +49,6 @@ impl FlatReader {
             layout,
             name,
             segment_source,
-            array: Default::default(),
         }
     }
 
@@ -69,21 +67,16 @@ impl FlatReader {
         // This is gross... see the function's TODO for a maybe better solution?
         let segment_fut = self.segment_source.request(self.layout.segment_id());
 
-        Ok(self
-            .array
-            .get_or_init(|| {
-                let ctx = self.layout.ctx.clone();
-                let dtype = self.layout.dtype().clone();
-                async move {
-                    let segment = segment_fut.await?;
-                    ArrayParts::try_from(segment)?
-                        .decode(&ctx, &dtype, row_count)
-                        .map_err(Arc::new)
-                }
-                .boxed()
-                .shared()
-            })
-            .clone())
+        let ctx = self.layout.ctx.clone();
+        let dtype = self.layout.dtype().clone();
+        Ok(async move {
+            let segment = segment_fut.await?;
+            ArrayParts::try_from(segment)?
+                .decode(&ctx, &dtype, row_count)
+                .map_err(Arc::new)
+        }
+        .boxed()
+        .shared())
     }
 }
 

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -52,14 +52,8 @@ impl FlatReader {
         }
     }
 
-    /// Returns a cached future that resolves this array.
-    ///
-    /// This method is idempotent, and returns a cached future on subsequent calls, all of which
-    /// will use the original segment reader.
-    // TODO(ngates): caching this and ignoring SegmentReaders may be a terrible idea... we may
-    //  instead want to store all segment futures and race them, so if a layout requests a
-    //  projection future before a pruning future, the pruning isn't blocked.
-    fn array_future(&self) -> VortexResult<SharedArrayFuture> {
+    /// Register the segment request and return a future that would resolve into the deserialised array.
+    fn array_future(&self) -> SharedArrayFuture {
         let row_count = usize::try_from(self.layout.row_count()).vortex_unwrap();
 
         // We create the segment_fut here to ensure we give the segment reader visibility into
@@ -69,14 +63,14 @@ impl FlatReader {
 
         let ctx = self.layout.ctx.clone();
         let dtype = self.layout.dtype().clone();
-        Ok(async move {
+        async move {
             let segment = segment_fut.await?;
             ArrayParts::try_from(segment)?
                 .decode(&ctx, &dtype, row_count)
                 .map_err(Arc::new)
         }
         .boxed()
-        .shared())
+        .shared()
     }
 }
 
@@ -123,7 +117,7 @@ impl LayoutReader for FlatReader {
 
         Ok(Box::new(FlatEvaluation {
             name: self.name.clone(),
-            array: self.array_future()?,
+            array: self.array_future(),
             row_range,
             expr: expr.clone(),
         }))
@@ -140,7 +134,7 @@ impl LayoutReader for FlatReader {
                 .vortex_expect("Row range end must fit within FlatLayout size");
         Ok(Box::new(FlatEvaluation {
             name: self.name.clone(),
-            array: self.array_future()?,
+            array: self.array_future(),
             row_range,
             expr: expr.clone(),
         }))


### PR DESCRIPTION
With this we don't hold references to arrays in the flat reader, so we can configure the segment cache to have more control on memory held by a layoutref instance. There doesn't seem to be a noticeable regression, other than one query in clickbench datafusion (q23 - 20%).

Another approach could be to have weak references instead.
LayoutRef would still hold cache zone maps and dict values after this change, I did not remove them because they are somewhat bounded