### PR TITLE
chore(deps): Update `tracing-subscriber`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ tpchgen = { git = "https://github.com/clflushopt/tpchgen-rs.git", rev = "d849ff4
 tpchgen-arrow = { git = "https://github.com/clflushopt/tpchgen-rs.git", rev = "d849ff430cd52250f6891ed4d5e3adad77bb2698" }
 tracing = { version = "0.1.41" }
 tracing-perfetto = "0.1.5"
-tracing-subscriber = "0.3.19"
+tracing-subscriber = "0.3.20"
 url = "2.5.4"
 uuid = { version = "1.17", features = ["js"] }
 walkdir = "2.5.0"


### PR DESCRIPTION
Github says we should update

<img width="1503" height="808" alt="Zen Browser 2025-09-01 20 03 55" src="https://github.com/user-attachments/assets/e07b7124-eba8-4fc6-b3a7-04432b60d65a" />

Dependabot has actually done it: https://github.com/vortex-data/vortex/pull/4439 - but it updated only lockfile so now we have

https://github.com/vortex-data/vortex/blob/63b60ff8434d91773c25feb25c765d0666db784d/Cargo.lock#L6249-L6250

https://github.com/vortex-data/vortex/blob/63b60ff8434d91773c25feb25c765d0666db784d/Cargo.toml#L194

(how is that even allowed???)