### PR TITLE
Feature: add `to_canonical` to `ArrayBuilder`

### DIFF
--- a/encodings/dict/src/array.rs
+++ b/encodings/dict/src/array.rs
@@ -329,7 +329,7 @@ mod test {
         array.clone().append_to_builder(builder.as_mut());
 
         let into_prim = array.to_primitive();
-        let prim_into = builder.finish().to_primitive();
+        let prim_into = builder.to_canonical().into_primitive();
 
         assert_eq!(into_prim.as_slice::<u64>(), prim_into.as_slice::<u64>());
         assert_eq!(

--- a/encodings/dict/src/array.rs
+++ b/encodings/dict/src/array.rs
@@ -329,7 +329,7 @@ mod test {
         array.clone().append_to_builder(builder.as_mut());
 
         let into_prim = array.to_primitive();
-        let prim_into = builder.to_canonical().into_primitive();
+        let prim_into = builder.finish_into_canonical().into_primitive();
 
         assert_eq!(into_prim.as_slice::<u64>(), prim_into.as_slice::<u64>());
         assert_eq!(

--- a/encodings/fsst/src/canonical.rs
+++ b/encodings/fsst/src/canonical.rs
@@ -166,7 +166,7 @@ mod tests {
         chunked_arr.append_to_builder(&mut builder);
 
         {
-            let arr = builder.to_canonical().into_varbinview();
+            let arr = builder.finish_into_canonical().into_varbinview();
             let res1 = arr
                 .with_iterator(|iter| iter.map(|b| b.map(|v| v.to_vec())).collect::<Vec<_>>())
                 .unwrap();

--- a/encodings/fsst/src/canonical.rs
+++ b/encodings/fsst/src/canonical.rs
@@ -54,7 +54,7 @@ fn fsst_decode_views(fsst_array: &FSSTArray, buf_index: u32) -> (ByteBuffer, Buf
 
     let uncompressed_lens_array = fsst_array.uncompressed_lengths().to_primitive();
 
-    // Decompres the full dataset.
+    // Decompress the full dataset.
     #[allow(clippy::cast_possible_truncation)]
     let total_size: usize = match_each_integer_ptype!(uncompressed_lens_array.ptype(), |P| {
         uncompressed_lens_array
@@ -166,7 +166,7 @@ mod tests {
         chunked_arr.append_to_builder(&mut builder);
 
         {
-            let arr = builder.finish().to_varbinview();
+            let arr = builder.to_canonical().into_varbinview();
             let res1 = arr
                 .with_iterator(|iter| iter.map(|b| b.map(|v| v.to_vec())).collect::<Vec<_>>())
                 .unwrap();

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -229,7 +229,7 @@ fn canonicalize_sparse_lists_inner<I: NativePType, SmallestViableOffsetType: Off
         builder.extend_from_array(&fill_value_array);
     }
 
-    builder.to_canonical()
+    builder.finish_into_canonical()
 }
 
 fn canonicalize_sparse_lists_inner_with_null_fill_value<I: NativePType, O: OffsetPType>(

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -229,7 +229,7 @@ fn canonicalize_sparse_lists_inner<I: NativePType, SmallestViableOffsetType: Off
         builder.extend_from_array(&fill_value_array);
     }
 
-    builder.finish().to_canonical()
+    builder.to_canonical()
 }
 
 fn canonicalize_sparse_lists_inner_with_null_fill_value<I: NativePType, O: OffsetPType>(

--- a/vortex-array/src/arrays/chunked/decode.rs
+++ b/vortex-array/src/arrays/chunked/decode.rs
@@ -39,7 +39,7 @@ impl CanonicalVTable<ChunkedVTable> for ChunkedVTable {
             _ => {
                 let mut builder = builder_with_capacity(array.dtype(), array.len());
                 array.append_to_builder(builder.as_mut());
-                builder.finish().to_canonical()
+                builder.to_canonical()
             }
         }
     }

--- a/vortex-array/src/arrays/chunked/decode.rs
+++ b/vortex-array/src/arrays/chunked/decode.rs
@@ -39,7 +39,7 @@ impl CanonicalVTable<ChunkedVTable> for ChunkedVTable {
             _ => {
                 let mut builder = builder_with_capacity(array.dtype(), array.len());
                 array.append_to_builder(builder.as_mut());
-                builder.to_canonical()
+                builder.finish_into_canonical()
             }
         }
     }

--- a/vortex-array/src/builders/bool.rs
+++ b/vortex-array/src/builders/bool.rs
@@ -9,7 +9,8 @@ use vortex_mask::Mask;
 
 use crate::arrays::BoolArray;
 use crate::builders::{ArrayBuilder, DEFAULT_BUILDER_CAPACITY, LazyNullBufferBuilder};
-use crate::{Array, ArrayRef, IntoArray, ToCanonical};
+use crate::canonical::{Canonical, ToCanonical};
+use crate::{Array, ArrayRef, IntoArray};
 
 pub struct BoolBuilder {
     dtype: DType,
@@ -120,6 +121,10 @@ impl ArrayBuilder for BoolBuilder {
 
     fn finish(&mut self) -> ArrayRef {
         self.finish_into_bool().into_array()
+    }
+
+    fn to_canonical(&mut self) -> Canonical {
+        Canonical::Bool(self.finish_into_bool())
     }
 }
 

--- a/vortex-array/src/builders/bool.rs
+++ b/vortex-array/src/builders/bool.rs
@@ -164,8 +164,8 @@ mod tests {
 
         let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
         chunk.clone().append_to_builder(builder.as_mut());
-        let canon_into = builder.finish().to_bool();
 
+        let canon_into = builder.finish().to_bool();
         let into_canon = chunk.to_bool();
 
         assert_eq!(canon_into.validity(), into_canon.validity());

--- a/vortex-array/src/builders/bool.rs
+++ b/vortex-array/src/builders/bool.rs
@@ -123,7 +123,7 @@ impl ArrayBuilder for BoolBuilder {
         self.finish_into_bool().into_array()
     }
 
-    fn to_canonical(&mut self) -> Canonical {
+    fn finish_into_canonical(&mut self) -> Canonical {
         Canonical::Bool(self.finish_into_bool())
     }
 }

--- a/vortex-array/src/builders/decimal.rs
+++ b/vortex-array/src/builders/decimal.rs
@@ -201,7 +201,7 @@ impl ArrayBuilder for DecimalBuilder {
         self.finish_into_decimal().into_array()
     }
 
-    fn to_canonical(&mut self) -> Canonical {
+    fn finish_into_canonical(&mut self) -> Canonical {
         Canonical::Decimal(self.finish_into_decimal())
     }
 }

--- a/vortex-array/src/builders/decimal.rs
+++ b/vortex-array/src/builders/decimal.rs
@@ -11,6 +11,7 @@ use vortex_scalar::{BigCast, NativeDecimalType, i256, match_each_decimal_value_t
 
 use crate::arrays::DecimalArray;
 use crate::builders::{ArrayBuilder, DEFAULT_BUILDER_CAPACITY, LazyNullBufferBuilder};
+use crate::canonical::Canonical;
 use crate::{Array, ArrayRef, IntoArray, ToCanonical};
 
 /// The builder for building a [`DecimalArray`].
@@ -198,6 +199,10 @@ impl ArrayBuilder for DecimalBuilder {
 
     fn finish(&mut self) -> ArrayRef {
         self.finish_into_decimal().into_array()
+    }
+
+    fn to_canonical(&mut self) -> Canonical {
+        Canonical::Decimal(self.finish_into_decimal())
     }
 }
 

--- a/vortex-array/src/builders/extension.rs
+++ b/vortex-array/src/builders/extension.rs
@@ -11,7 +11,8 @@ use vortex_scalar::ExtScalar;
 
 use crate::arrays::ExtensionArray;
 use crate::builders::{ArrayBuilder, DEFAULT_BUILDER_CAPACITY, builder_with_capacity};
-use crate::{Array, ArrayRef, IntoArray, ToCanonical};
+use crate::canonical::{Canonical, ToCanonical};
+use crate::{Array, ArrayRef, IntoArray};
 
 /// The builder for building a [`ExtensionArray`].
 pub struct ExtensionBuilder {
@@ -112,5 +113,9 @@ impl ArrayBuilder for ExtensionBuilder {
 
     fn finish(&mut self) -> ArrayRef {
         self.finish_into_extension().into_array()
+    }
+
+    fn to_canonical(&mut self) -> Canonical {
+        Canonical::Extension(self.finish_into_extension())
     }
 }

--- a/vortex-array/src/builders/extension.rs
+++ b/vortex-array/src/builders/extension.rs
@@ -115,7 +115,7 @@ impl ArrayBuilder for ExtensionBuilder {
         self.finish_into_extension().into_array()
     }
 
-    fn to_canonical(&mut self) -> Canonical {
+    fn finish_into_canonical(&mut self) -> Canonical {
         Canonical::Extension(self.finish_into_extension())
     }
 }

--- a/vortex-array/src/builders/fixed_size_list.rs
+++ b/vortex-array/src/builders/fixed_size_list.rs
@@ -238,7 +238,7 @@ impl ArrayBuilder for FixedSizeListBuilder {
         self.finish_into_fixed_size_list().into_array()
     }
 
-    fn to_canonical(&mut self) -> Canonical {
+    fn finish_into_canonical(&mut self) -> Canonical {
         Canonical::FixedSizeList(self.finish_into_fixed_size_list())
     }
 }

--- a/vortex-array/src/builders/fixed_size_list.rs
+++ b/vortex-array/src/builders/fixed_size_list.rs
@@ -13,7 +13,8 @@ use crate::arrays::FixedSizeListArray;
 use crate::builders::{
     ArrayBuilder, DEFAULT_BUILDER_CAPACITY, LazyNullBufferBuilder, builder_with_capacity,
 };
-use crate::{Array, ArrayRef, IntoArray, ToCanonical};
+use crate::canonical::{Canonical, ToCanonical};
+use crate::{Array, ArrayRef, IntoArray};
 
 /// The builder for building a [`FixedSizeListArray`].
 pub struct FixedSizeListBuilder {
@@ -235,6 +236,10 @@ impl ArrayBuilder for FixedSizeListBuilder {
 
     fn finish(&mut self) -> ArrayRef {
         self.finish_into_fixed_size_list().into_array()
+    }
+
+    fn to_canonical(&mut self) -> Canonical {
+        Canonical::FixedSizeList(self.finish_into_fixed_size_list())
     }
 }
 

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -15,8 +15,9 @@ use crate::builders::{
     ArrayBuilder, DEFAULT_BUILDER_CAPACITY, LazyNullBufferBuilder, PrimitiveBuilder,
     builder_with_capacity,
 };
+use crate::canonical::{Canonical, ToCanonical};
 use crate::compute::{add_scalar, cast, sub_scalar};
-use crate::{Array, ArrayRef, IntoArray, ToCanonical};
+use crate::{Array, ArrayRef, IntoArray};
 
 /// The builder for building a [`ListArray`], parametrized by the `PType` of the offsets buffer.
 pub struct ListBuilder<O: NativePType> {
@@ -252,6 +253,10 @@ impl<O: OffsetPType> ArrayBuilder for ListBuilder<O> {
 
     fn finish(&mut self) -> ArrayRef {
         self.finish_into_list().into_array()
+    }
+
+    fn to_canonical(&mut self) -> Canonical {
+        Canonical::List(self.finish_into_list())
     }
 }
 

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -255,7 +255,7 @@ impl<O: OffsetPType> ArrayBuilder for ListBuilder<O> {
         self.finish_into_list().into_array()
     }
 
-    fn to_canonical(&mut self) -> Canonical {
+    fn finish_into_canonical(&mut self) -> Canonical {
         Canonical::List(self.finish_into_list())
     }
 }
@@ -405,7 +405,7 @@ mod tests {
         .unwrap()
         .to_list();
 
-        let actual = builder.to_canonical().into_list();
+        let actual = builder.finish_into_canonical().into_list();
 
         assert_eq!(
             actual.elements().to_primitive().as_slice::<i32>(),

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -405,7 +405,7 @@ mod tests {
         .unwrap()
         .to_list();
 
-        let actual = builder.finish().to_list();
+        let actual = builder.to_canonical().into_list();
 
         assert_eq!(
             actual.elements().to_primitive().as_slice::<i32>(),

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -275,7 +275,7 @@ pub trait ArrayBuilder: Send {
     /// This method provides a default implementation that creates an [`ArrayRef`] via `finish` and
     /// then converts it to canonical form. Specific builders can override this with optimized
     /// implementations that avoid the intermediate [`Array`] creation.
-    fn to_canonical(&mut self) -> Canonical {
+    fn finish_into_canonical(&mut self) -> Canonical {
         self.finish().to_canonical()
     }
 }

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -41,6 +41,7 @@ use vortex_scalar::{
 };
 
 use crate::arrays::smallest_storage_type;
+use crate::canonical::Canonical;
 use crate::{Array, ArrayRef};
 
 mod lazy_null_builder;
@@ -268,6 +269,15 @@ pub trait ArrayBuilder: Send {
     /// [PrimitiveBuilder]'s [vortex_buffer::BufferMut] does not match the number of validity bits,
     /// the PrimitiveBuilder's [Self::finish] will panic.
     fn finish(&mut self) -> ArrayRef;
+
+    /// Constructs a canonical array directly from the builder.
+    ///
+    /// This method provides a default implementation that creates an [`ArrayRef`] via `finish` and
+    /// then converts it to canonical form. Specific builders can override this with optimized
+    /// implementations that avoid the intermediate [`Array`] creation.
+    fn to_canonical(&mut self) -> Canonical {
+        self.finish().to_canonical()
+    }
 }
 
 /// Construct a new canonical builder for the given [`DType`].

--- a/vortex-array/src/builders/null.rs
+++ b/vortex-array/src/builders/null.rs
@@ -8,6 +8,7 @@ use vortex_mask::Mask;
 
 use crate::arrays::NullArray;
 use crate::builders::ArrayBuilder;
+use crate::canonical::Canonical;
 use crate::{Array, ArrayRef, IntoArray};
 
 /// The builder for building a [`NullArray`].
@@ -64,5 +65,9 @@ impl ArrayBuilder for NullBuilder {
 
     fn finish(&mut self) -> ArrayRef {
         NullArray::new(self.length).into_array()
+    }
+
+    fn to_canonical(&mut self) -> Canonical {
+        Canonical::Null(NullArray::new(self.length))
     }
 }

--- a/vortex-array/src/builders/null.rs
+++ b/vortex-array/src/builders/null.rs
@@ -67,7 +67,7 @@ impl ArrayBuilder for NullBuilder {
         NullArray::new(self.length).into_array()
     }
 
-    fn to_canonical(&mut self) -> Canonical {
+    fn finish_into_canonical(&mut self) -> Canonical {
         Canonical::Null(NullArray::new(self.length))
     }
 }

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -10,7 +10,8 @@ use vortex_mask::Mask;
 
 use crate::arrays::PrimitiveArray;
 use crate::builders::{ArrayBuilder, DEFAULT_BUILDER_CAPACITY, LazyNullBufferBuilder};
-use crate::{Array, ArrayRef, IntoArray, ToCanonical};
+use crate::canonical::{Canonical, ToCanonical};
+use crate::{Array, ArrayRef, IntoArray};
 
 /// The builder for building a [`PrimitiveArray`], parametrized by the `PType`.
 pub struct PrimitiveBuilder<T> {
@@ -177,6 +178,10 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
 
     fn finish(&mut self) -> ArrayRef {
         self.finish_into_primitive().into_array()
+    }
+
+    fn to_canonical(&mut self) -> Canonical {
+        Canonical::Primitive(self.finish_into_primitive())
     }
 }
 

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -180,7 +180,7 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
         self.finish_into_primitive().into_array()
     }
 
-    fn to_canonical(&mut self) -> Canonical {
+    fn finish_into_canonical(&mut self) -> Canonical {
         Canonical::Primitive(self.finish_into_primitive())
     }
 }

--- a/vortex-array/src/builders/struct_.rs
+++ b/vortex-array/src/builders/struct_.rs
@@ -13,7 +13,8 @@ use crate::arrays::StructArray;
 use crate::builders::{
     ArrayBuilder, DEFAULT_BUILDER_CAPACITY, LazyNullBufferBuilder, builder_with_capacity,
 };
-use crate::{Array, ArrayRef, IntoArray, ToCanonical};
+use crate::canonical::{Canonical, ToCanonical};
+use crate::{Array, ArrayRef, IntoArray};
 
 /// The builder for building a [`StructArray`].
 pub struct StructBuilder {
@@ -186,6 +187,10 @@ impl ArrayBuilder for StructBuilder {
 
     fn finish(&mut self) -> ArrayRef {
         self.finish_into_struct().into_array()
+    }
+
+    fn to_canonical(&mut self) -> Canonical {
+        Canonical::Struct(self.finish_into_struct())
     }
 }
 

--- a/vortex-array/src/builders/struct_.rs
+++ b/vortex-array/src/builders/struct_.rs
@@ -189,7 +189,7 @@ impl ArrayBuilder for StructBuilder {
         self.finish_into_struct().into_array()
     }
 
-    fn to_canonical(&mut self) -> Canonical {
+    fn finish_into_canonical(&mut self) -> Canonical {
         Canonical::Struct(self.finish_into_struct())
     }
 }

--- a/vortex-array/src/builders/tests.rs
+++ b/vortex-array/src/builders/tests.rs
@@ -236,7 +236,7 @@ where
     fill_builder(builder2.as_mut());
 
     // Get canonical arrays using both methods.
-    let canonical_direct = builder1.to_canonical();
+    let canonical_direct = builder1.finish_into_canonical();
     let canonical_indirect = builder2.finish().to_canonical();
 
     // Convert both to arrays for comparison.
@@ -413,7 +413,7 @@ fn test_to_canonical_decimal() {
 fn test_to_canonical_i8() {
     let dtype = DType::Primitive(PType::I8, Nullability::NonNullable);
     compare_to_canonical_methods(&dtype, |builder| {
-        for i in 0..5 {
+        for i in 0..5i8 {
             let value = Scalar::primitive(i, Nullability::NonNullable);
             builder.append_scalar(&value).unwrap();
         }

--- a/vortex-array/src/builders/tests.rs
+++ b/vortex-array/src/builders/tests.rs
@@ -7,7 +7,7 @@ use rstest::rstest;
 use vortex_dtype::{DType, DecimalDType, ExtDType, ExtID, Nullability, PType, StructFields};
 use vortex_scalar::Scalar;
 
-use crate::builders::builder_with_capacity;
+use crate::builders::{ArrayBuilder, builder_with_capacity};
 
 /// Test that `append_zeros` produces the same result as manually appending `Scalar::default_value`.
 ///
@@ -217,4 +217,227 @@ fn test_append_defaults_behavior(#[case] dtype: DType, #[case] should_be_null: b
             }
         }
     }
+}
+
+/// Helper function that fills two builders with the same values and compares the results
+/// of `to_canonical()` vs `finish().to_canonical()`.
+fn compare_to_canonical_methods<F>(dtype: &DType, mut fill_builder: F)
+where
+    F: FnMut(&mut dyn ArrayBuilder),
+{
+    use crate::IntoArray;
+
+    // Create two identical builders.
+    let mut builder1 = builder_with_capacity(dtype, 10);
+    let mut builder2 = builder_with_capacity(dtype, 10);
+
+    // Fill both builders with the same data.
+    fill_builder(builder1.as_mut());
+    fill_builder(builder2.as_mut());
+
+    // Get canonical arrays using both methods.
+    let canonical_direct = builder1.to_canonical();
+    let canonical_indirect = builder2.finish().to_canonical();
+
+    // Convert both to arrays for comparison.
+    let array_direct = canonical_direct.into_array();
+    let array_indirect = canonical_indirect.into_array();
+
+    // Verify they have the same length.
+    assert_eq!(array_direct.len(), array_indirect.len());
+
+    // Compare each element.
+    for i in 0..array_direct.len() {
+        let scalar_direct = array_direct.scalar_at(i);
+        let scalar_indirect = array_indirect.scalar_at(i);
+
+        assert_eq!(
+            scalar_direct, scalar_indirect,
+            "Element at index {} should be equal for dtype {:?}",
+            i, dtype
+        );
+    }
+}
+
+#[test]
+fn test_to_canonical_bool() {
+    let dtype = DType::Bool(Nullability::NonNullable);
+    compare_to_canonical_methods(&dtype, |builder| {
+        for i in 0..5 {
+            let value = Scalar::bool(i % 2 == 0, Nullability::NonNullable);
+            builder.append_scalar(&value).unwrap();
+        }
+    });
+}
+
+#[test]
+fn test_to_canonical_bool_nullable() {
+    let dtype = DType::Bool(Nullability::Nullable);
+    compare_to_canonical_methods(&dtype, |builder| {
+        for i in 0..5 {
+            let value = Scalar::bool(i % 2 == 0, Nullability::Nullable);
+            builder.append_scalar(&value).unwrap();
+        }
+        builder.append_nulls(1);
+    });
+}
+
+#[test]
+fn test_to_canonical_i32() {
+    let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
+    compare_to_canonical_methods(&dtype, |builder| {
+        for i in 0..5 {
+            let value = Scalar::primitive(i, Nullability::NonNullable);
+            builder.append_scalar(&value).unwrap();
+        }
+    });
+}
+
+#[test]
+fn test_to_canonical_i32_nullable() {
+    let dtype = DType::Primitive(PType::I32, Nullability::Nullable);
+    compare_to_canonical_methods(&dtype, |builder| {
+        for i in 0..5 {
+            let value = Scalar::primitive(i, Nullability::Nullable);
+            builder.append_scalar(&value).unwrap();
+        }
+        builder.append_nulls(1);
+    });
+}
+
+#[test]
+fn test_to_canonical_f64() {
+    let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
+    compare_to_canonical_methods(&dtype, |builder| {
+        for i in 0..5 {
+            let value = Scalar::primitive(i as f64, Nullability::NonNullable);
+            builder.append_scalar(&value).unwrap();
+        }
+    });
+}
+
+#[test]
+fn test_to_canonical_utf8() {
+    let dtype = DType::Utf8(Nullability::NonNullable);
+    compare_to_canonical_methods(&dtype, |builder| {
+        let values = ["hello", "world", "test", "data", "vortex"];
+        for value in &values {
+            let scalar = Scalar::utf8(*value, Nullability::NonNullable);
+            builder.append_scalar(&scalar).unwrap();
+        }
+    });
+}
+
+#[test]
+fn test_to_canonical_utf8_nullable() {
+    let dtype = DType::Utf8(Nullability::Nullable);
+    compare_to_canonical_methods(&dtype, |builder| {
+        let values = ["hello", "world", "test"];
+        for value in &values {
+            let scalar = Scalar::utf8(*value, Nullability::Nullable);
+            builder.append_scalar(&scalar).unwrap();
+        }
+        builder.append_nulls(1);
+    });
+}
+
+#[test]
+fn test_to_canonical_binary() {
+    let dtype = DType::Binary(Nullability::NonNullable);
+    compare_to_canonical_methods(&dtype, |builder| {
+        let values = [b"hello", b"world", b"vortx", b"bytes", b"tests"];
+        for value in &values {
+            let scalar = Scalar::binary(value.to_vec(), Nullability::NonNullable);
+            builder.append_scalar(&scalar).unwrap();
+        }
+    });
+}
+
+#[test]
+fn test_to_canonical_struct() {
+    let dtype = DType::Struct(
+        StructFields::from_iter([
+            ("a", DType::Primitive(PType::I32, Nullability::NonNullable)),
+            ("b", DType::Utf8(Nullability::NonNullable)),
+        ]),
+        Nullability::NonNullable,
+    );
+    compare_to_canonical_methods(&dtype, |builder| {
+        for _ in 0..3 {
+            let value = Scalar::default_value(dtype.clone());
+            builder.append_scalar(&value).unwrap();
+        }
+    });
+}
+
+#[test]
+fn test_to_canonical_extension() {
+    let dtype = DType::Extension(Arc::new(ExtDType::new(
+        ExtID::from("test.extension"),
+        Arc::new(DType::Primitive(PType::I64, Nullability::NonNullable)),
+        None,
+    )));
+    compare_to_canonical_methods(&dtype, |builder| {
+        let ext_dtype = match &dtype {
+            DType::Extension(ext) => ext.clone(),
+            _ => unreachable!(),
+        };
+        for i in 0..5 {
+            let storage_value = Scalar::from(i as i64);
+            let ext_scalar = Scalar::extension(ext_dtype.clone(), storage_value);
+            builder.append_scalar(&ext_scalar).unwrap();
+        }
+    });
+}
+
+#[test]
+fn test_to_canonical_null() {
+    let dtype = DType::Null;
+    compare_to_canonical_methods(&dtype, |builder| {
+        builder.append_nulls(5);
+    });
+}
+
+#[test]
+fn test_to_canonical_decimal() {
+    let dtype = DType::Decimal(DecimalDType::new(10, 2), Nullability::NonNullable);
+    compare_to_canonical_methods(&dtype, |builder| {
+        for _ in 0..5 {
+            let value = Scalar::default_value(dtype.clone());
+            builder.append_scalar(&value).unwrap();
+        }
+    });
+}
+
+#[test]
+fn test_to_canonical_i8() {
+    let dtype = DType::Primitive(PType::I8, Nullability::NonNullable);
+    compare_to_canonical_methods(&dtype, |builder| {
+        for i in 0..5 {
+            let value = Scalar::primitive(i, Nullability::NonNullable);
+            builder.append_scalar(&value).unwrap();
+        }
+    });
+}
+
+#[test]
+fn test_to_canonical_u64() {
+    let dtype = DType::Primitive(PType::U64, Nullability::NonNullable);
+    compare_to_canonical_methods(&dtype, |builder| {
+        for i in 0..5 {
+            let value = Scalar::primitive(i as u64, Nullability::NonNullable);
+            builder.append_scalar(&value).unwrap();
+        }
+    });
+}
+
+#[test]
+fn test_to_canonical_f32() {
+    let dtype = DType::Primitive(PType::F32, Nullability::NonNullable);
+    compare_to_canonical_methods(&dtype, |builder| {
+        for i in 0..5 {
+            let value = Scalar::primitive(i as f32, Nullability::NonNullable);
+            builder.append_scalar(&value).unwrap();
+        }
+    });
 }

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -257,7 +257,7 @@ impl ArrayBuilder for VarBinViewBuilder {
         self.finish_into_varbinview().into_array()
     }
 
-    fn to_canonical(&mut self) -> Canonical {
+    fn finish_into_canonical(&mut self) -> Canonical {
         Canonical::VarBinView(self.finish_into_varbinview())
     }
 }
@@ -446,7 +446,7 @@ mod tests {
         builder.append_nulls(2);
         builder.append_value("Hello3");
 
-        let arr = builder.to_canonical().into_varbinview();
+        let arr = builder.finish_into_canonical().into_varbinview();
 
         let arr = arr
             .with_iterator(|iter| {

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -388,7 +388,6 @@ mod tests {
     use itertools::Itertools;
     use vortex_dtype::{DType, Nullability};
 
-    use crate::ToCanonical;
     use crate::accessor::ArrayAccessor;
     use crate::arrays::VarBinViewVTable;
     use crate::builders::{ArrayBuilder, VarBinViewBuilder};
@@ -447,7 +446,7 @@ mod tests {
         builder.append_nulls(2);
         builder.append_value("Hello3");
 
-        let arr = builder.finish().to_varbinview();
+        let arr = builder.to_canonical().into_varbinview();
 
         let arr = arr
             .with_iterator(|iter| {

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -15,7 +15,8 @@ use vortex_utils::aliases::hash_map::{Entry, HashMap};
 
 use crate::arrays::{BinaryView, VarBinViewArray};
 use crate::builders::{ArrayBuilder, LazyNullBufferBuilder};
-use crate::{Array, ArrayRef, IntoArray, ToCanonical};
+use crate::canonical::{Canonical, ToCanonical};
+use crate::{Array, ArrayRef, IntoArray};
 
 /// The builder for building a [`VarBinViewArray`].
 pub struct VarBinViewBuilder {
@@ -254,6 +255,10 @@ impl ArrayBuilder for VarBinViewBuilder {
 
     fn finish(&mut self) -> ArrayRef {
         self.finish_into_varbinview().into_array()
+    }
+
+    fn to_canonical(&mut self) -> Canonical {
+        Canonical::VarBinView(self.finish_into_varbinview())
     }
 }
 

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -81,7 +81,7 @@ pub enum Canonical {
 impl Canonical {
     /// Create an empty canonical array of the given dtype.
     pub fn empty(dtype: &DType) -> Canonical {
-        builder_with_capacity(dtype, 0).finish().to_canonical()
+        builder_with_capacity(dtype, 0).to_canonical()
     }
 }
 

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -81,7 +81,7 @@ pub enum Canonical {
 impl Canonical {
     /// Create an empty canonical array of the given dtype.
     pub fn empty(dtype: &DType) -> Canonical {
-        builder_with_capacity(dtype, 0).to_canonical()
+        builder_with_capacity(dtype, 0).finish_into_canonical()
     }
 }
 


### PR DESCRIPTION
It seems somewhat wasteful to always finish the builders into type-erased `ArrayRef`, when all of them can directly finish into a canonical array.

This PR adds `to_canonical` to the `ArrayBuilder` method, which saves an allocation in a few cases. This is mostly a "nice-to-have" rather than something that is necessary.

Side note: I think that it might be worth going through our conversion naming since `finish().to_primitive()` and `to_canonical().into_primitive()` sound like they do different things...