### PR TITLE
chore: `#[inline]` fns vortex-array

### DIFF
--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -158,62 +158,77 @@ pub trait Array: 'static + private::Sealed + Send + Sync + Debug + ArrayVisitor 
 }
 
 impl Array for Arc<dyn Array> {
+    #[inline]
     fn as_any(&self) -> &dyn Any {
         self.as_ref().as_any()
     }
 
+    #[inline]
     fn to_array(&self) -> ArrayRef {
         self.clone()
     }
 
+    #[inline]
     fn len(&self) -> usize {
         self.as_ref().len()
     }
 
+    #[inline]
     fn dtype(&self) -> &DType {
         self.as_ref().dtype()
     }
 
+    #[inline]
     fn encoding(&self) -> EncodingRef {
         self.as_ref().encoding()
     }
 
+    #[inline]
     fn encoding_id(&self) -> EncodingId {
         self.as_ref().encoding_id()
     }
 
+    #[inline]
     fn slice(&self, range: Range<usize>) -> ArrayRef {
         self.as_ref().slice(range)
     }
 
+    #[inline]
     fn scalar_at(&self, index: usize) -> Scalar {
         self.as_ref().scalar_at(index)
     }
 
+    #[inline]
     fn is_valid(&self, index: usize) -> bool {
         self.as_ref().is_valid(index)
     }
 
+    #[inline]
     fn is_invalid(&self, index: usize) -> bool {
         self.as_ref().is_invalid(index)
     }
 
+    #[inline]
     fn all_valid(&self) -> bool {
         self.as_ref().all_valid()
     }
 
+    #[inline]
     fn all_invalid(&self) -> bool {
         self.as_ref().all_invalid()
     }
 
+    #[inline]
     fn valid_count(&self) -> usize {
         self.as_ref().valid_count()
     }
 
+    #[inline]
     fn invalid_count(&self) -> usize {
         self.as_ref().invalid_count()
     }
 
+    #[inline]
     fn validity_mask(&self) -> Mask {
         self.as_ref().validity_mask()
     }

--- a/vortex-array/src/iter.rs
+++ b/vortex-array/src/iter.rs
@@ -21,6 +21,7 @@ pub trait ArrayIterator: Iterator<Item = VortexResult<ArrayRef>> {
 }
 
 impl ArrayIterator for Box<dyn ArrayIterator + Send> {
+    #[inline]
     fn dtype(&self) -> &DType {
         self.as_ref().dtype()
     }
@@ -32,6 +33,7 @@ pub struct ArrayIteratorAdapter<I> {
 }
 
 impl<I> ArrayIteratorAdapter<I> {
+    #[inline]
     pub fn new(dtype: DType, inner: I) -> Self {
         Self { dtype, inner }
     }
@@ -43,6 +45,7 @@ where
 {
     type Item = VortexResult<ArrayRef>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
@@ -52,6 +55,7 @@ impl<I> ArrayIterator for ArrayIteratorAdapter<I>
 where
     I: Iterator<Item = VortexResult<ArrayRef>>,
 {
+    #[inline]
     fn dtype(&self) -> &DType {
         &self.dtype
     }
@@ -107,6 +111,7 @@ enum ArrayChunkIterator {
 impl Iterator for ArrayChunkIterator {
     type Item = VortexResult<ArrayRef>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             ArrayChunkIterator::Single(array) => array.take().map(Ok),

--- a/vortex-array/src/metadata.rs
+++ b/vortex-array/src/metadata.rs
@@ -74,6 +74,7 @@ pub struct ProstMetadata<M>(pub M);
 impl<M> Deref for ProstMetadata<M> {
     type Target = M;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/vortex-array/src/partial_ord.rs
+++ b/vortex-array/src/partial_ord.rs
@@ -18,6 +18,7 @@ where
     }
 }
 
+#[inline]
 pub fn partial_min<T: PartialMin>(a: T, b: T) -> Option<T> {
     a.partial_min(b)
 }
@@ -41,6 +42,7 @@ where
 
 impl<T: PartialOrd> PartialMax for T {}
 
+#[inline]
 pub fn partial_max<T: PartialMax>(a: T, b: T) -> Option<T> {
     a.partial_max(b)
 }

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -37,6 +37,7 @@ pub struct PatchesMetadata {
 }
 
 impl PatchesMetadata {
+    #[inline]
     pub fn new(len: usize, offset: usize, indices_ptype: PType) -> Self {
         Self {
             len: len as u64,
@@ -134,46 +135,57 @@ impl Patches {
         }
     }
 
+    #[inline]
     pub fn array_len(&self) -> usize {
         self.array_len
     }
 
+    #[inline]
     pub fn num_patches(&self) -> usize {
         self.indices.len()
     }
 
+    #[inline]
     pub fn dtype(&self) -> &DType {
         self.values.dtype()
     }
 
+    #[inline]
     pub fn indices(&self) -> &ArrayRef {
         &self.indices
     }
 
+    #[inline]
     pub fn into_indices(self) -> ArrayRef {
         self.indices
     }
 
+    #[inline]
     pub fn indices_mut(&mut self) -> &mut ArrayRef {
         &mut self.indices
     }
 
+    #[inline]
     pub fn values(&self) -> &ArrayRef {
         &self.values
     }
 
+    #[inline]
     pub fn into_values(self) -> ArrayRef {
         self.values
     }
 
+    #[inline]
     pub fn values_mut(&mut self) -> &mut ArrayRef {
         &mut self.values
     }
 
+    #[inline]
     pub fn offset(&self) -> usize {
         self.offset
     }
 
+    #[inline]
     pub fn indices_ptype(&self) -> PType {
         PType::try_from(self.indices.dtype()).vortex_expect("primitive indices")
     }

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -35,6 +35,7 @@ impl Validity {
     pub const DTYPE: DType = DType::Bool(Nullability::NonNullable);
 
     /// If Validity is [`Validity::Array`], returns the array, otherwise returns `None`.
+    #[inline]
     pub fn into_array(self) -> Option<ArrayRef> {
         if let Self::Array(a) = self {
             Some(a)
@@ -44,6 +45,7 @@ impl Validity {
     }
 
     /// If Validity is [`Validity::Array`], returns a reference to the array array, otherwise returns `None`.
+    #[inline]
     pub fn as_array(&self) -> Option<&ArrayRef> {
         if let Self::Array(a) = self {
             Some(a)
@@ -52,6 +54,7 @@ impl Validity {
         }
     }
 
+    #[inline]
     pub fn nullability(&self) -> Nullability {
         if matches!(self, Self::NonNullable) {
             Nullability::NonNullable
@@ -61,6 +64,7 @@ impl Validity {
     }
 
     /// The union nullability and validity.
+    #[inline]
     pub fn union_nullability(self, nullability: Nullability) -> Self {
         match nullability {
             Nullability::NonNullable => self,
@@ -68,6 +72,7 @@ impl Validity {
         }
     }
 
+    #[inline]
     pub fn all_valid(&self) -> bool {
         match self {
             Validity::NonNullable | Validity::AllValid => true,
@@ -80,6 +85,7 @@ impl Validity {
         }
     }
 
+    #[inline]
     pub fn all_invalid(&self) -> bool {
         match self {
             Validity::NonNullable | Validity::AllValid => false,
@@ -113,6 +119,7 @@ impl Validity {
         !self.is_valid(index)
     }
 
+    #[inline]
     pub fn slice(&self, range: Range<usize>) -> Self {
         match self {
             Self::Array(a) => Self::Array(a.slice(range)),
@@ -165,6 +172,7 @@ impl Validity {
     /// Set to false any entries for which the mask is true.
     ///
     /// The result is always nullable. The result has the same length as self.
+    #[inline]
     pub fn mask(&self, mask: &Mask) -> Self {
         match mask.boolean_buffer() {
             AllOr::All => Validity::AllInvalid,
@@ -183,6 +191,7 @@ impl Validity {
         }
     }
 
+    #[inline]
     pub fn to_mask(&self, length: usize) -> Mask {
         match self {
             Self::NonNullable | Self::AllValid => Mask::AllTrue(length),
@@ -201,6 +210,7 @@ impl Validity {
     }
 
     /// Logically & two Validity values of the same length
+    #[inline]
     pub fn and(self, rhs: Validity) -> Validity {
         match (self, rhs) {
             // Should be pretty clear
@@ -280,6 +290,7 @@ impl Validity {
     }
 
     /// Convert into a nullable variant
+    #[inline]
     pub fn into_nullable(self) -> Validity {
         match self {
             Self::NonNullable => Self::AllValid,
@@ -288,6 +299,7 @@ impl Validity {
     }
 
     /// Convert into a non-nullable variant
+    #[inline]
     pub fn into_non_nullable(self) -> Option<Validity> {
         match self {
             Self::NonNullable => Some(Self::NonNullable),
@@ -307,6 +319,7 @@ impl Validity {
     }
 
     /// Convert into a variant compatible with the given nullability, if possible.
+    #[inline]
     pub fn cast_nullability(self, nullability: Nullability) -> VortexResult<Validity> {
         match nullability {
             Nullability::NonNullable => self.into_non_nullable().ok_or_else(|| {
@@ -317,6 +330,7 @@ impl Validity {
     }
 
     /// Create Validity by copying the given array's validity.
+    #[inline]
     pub fn copy_from_array(array: &dyn Array) -> Self {
         Validity::from_mask(array.validity_mask(), array.dtype().nullability())
     }
@@ -325,6 +339,7 @@ impl Validity {
     ///
     /// Note: You want to pass the nullability of parent array and not the nullability of the validity array itself
     ///     as that is always nonnullable
+    #[inline]
     fn from_array(value: ArrayRef, nullability: Nullability) -> Self {
         if !matches!(value.dtype(), DType::Bool(Nullability::NonNullable)) {
             vortex_panic!("Expected a non-nullable boolean array")
@@ -336,6 +351,7 @@ impl Validity {
     }
 
     /// Returns the length of the validity array, if it exists.
+    #[inline]
     pub fn maybe_len(&self) -> Option<usize> {
         match self {
             Self::NonNullable | Self::AllValid | Self::AllInvalid => None,
@@ -343,6 +359,7 @@ impl Validity {
         }
     }
 
+    #[inline]
     pub fn uncompressed_size(&self) -> usize {
         if let Validity::Array(a) = self {
             a.len().div_ceil(8)
@@ -353,6 +370,7 @@ impl Validity {
 }
 
 impl PartialEq for Validity {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::NonNullable, Self::NonNullable) => true,
@@ -369,6 +387,7 @@ impl PartialEq for Validity {
 }
 
 impl From<BooleanBuffer> for Validity {
+    #[inline]
     fn from(value: BooleanBuffer) -> Self {
         if value.count_set_bits() == value.len() {
             Self::AllValid
@@ -381,24 +400,28 @@ impl From<BooleanBuffer> for Validity {
 }
 
 impl From<NullBuffer> for Validity {
+    #[inline]
     fn from(value: NullBuffer) -> Self {
         value.into_inner().into()
     }
 }
 
 impl FromIterator<Mask> for Validity {
+    #[inline]
     fn from_iter<T: IntoIterator<Item = Mask>>(iter: T) -> Self {
         Validity::from_mask(iter.into_iter().collect(), Nullability::Nullable)
     }
 }
 
 impl FromIterator<bool> for Validity {
+    #[inline]
     fn from_iter<T: IntoIterator<Item = bool>>(iter: T) -> Self {
         Validity::from(BooleanBuffer::from_iter(iter))
     }
 }
 
 impl From<Nullability> for Validity {
+    #[inline]
     fn from(value: Nullability) -> Self {
         match value {
             Nullability::NonNullable => Validity::NonNullable,
@@ -425,6 +448,7 @@ impl Validity {
 }
 
 impl IntoArray for Mask {
+    #[inline]
     fn into_array(self) -> ArrayRef {
         match self {
             Self::AllTrue(len) => ConstantArray::new(true, len).into_array(),
@@ -435,6 +459,7 @@ impl IntoArray for Mask {
 }
 
 impl IntoArray for &MaskValues {
+    #[inline]
     fn into_array(self) -> ArrayRef {
         BoolArray::new(self.boolean_buffer().clone(), Validity::NonNullable).into_array()
     }


### PR DESCRIPTION
Annotates small functions in vortex-array with `#[inline]` that could benefit from cross crate inlining.