### PR TITLE
chore: `#[inline]` fns vortex-mask

### DIFF
--- a/vortex-mask/src/eq.rs
+++ b/vortex-mask/src/eq.rs
@@ -4,6 +4,7 @@
 use crate::Mask;
 
 impl PartialEq for Mask {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         if self.len() != other.len() {
             return false;

--- a/vortex-mask/src/iter_bools.rs
+++ b/vortex-mask/src/iter_bools.rs
@@ -13,6 +13,7 @@ impl Mask {
     ///
     /// Note that bool iteration might not be the fastest way to achieve whatever is it you're
     /// trying to do!
+    #[inline]
     pub fn iter_bools<F, T>(&self, mut f: F) -> T
     where
         F: FnMut(&mut dyn Iterator<Item = bool>) -> T,

--- a/vortex-mask/src/lib.rs
+++ b/vortex-mask/src/lib.rs
@@ -32,6 +32,7 @@ pub enum AllOr<T> {
 
 impl<T> AllOr<T> {
     /// Returns the `Some` variant of the enum, or a default value.
+    #[inline]
     pub fn unwrap_or_else<F, G>(self, all_true: F, all_false: G) -> T
     where
         F: FnOnce() -> T,
@@ -47,6 +48,7 @@ impl<T> AllOr<T> {
 
 impl<T> AllOr<&T> {
     /// Clone the inner value.
+    #[inline]
     pub fn cloned(self) -> AllOr<T>
     where
         T: Clone,
@@ -132,16 +134,19 @@ impl MaskValues {
     }
 
     /// Returns the true count of the mask.
+    #[inline]
     pub fn true_count(&self) -> usize {
         self.true_count
     }
 
     /// Returns the boolean buffer representation of the mask.
+    #[inline]
     pub fn boolean_buffer(&self) -> &BooleanBuffer {
         &self.buffer
     }
 
     /// Returns the boolean value at a given index.
+    #[inline]
     pub fn value(&self, index: usize) -> bool {
         self.buffer.value(index)
     }
@@ -197,11 +202,13 @@ impl MaskValues {
 
 impl Mask {
     /// Create a new Mask where all values are set.
+    #[inline]
     pub fn new_true(length: usize) -> Self {
         Self::AllTrue(length)
     }
 
     /// Create a new Mask where no values are set.
+    #[inline]
     pub fn new_false(length: usize) -> Self {
         Self::AllFalse(length)
     }
@@ -441,6 +448,7 @@ impl Mask {
     /// ## Panics
     ///
     /// Panics if the index is out of bounds.
+    #[inline]
     pub fn value(&self, idx: usize) -> bool {
         match self {
             Mask::AllTrue(_) => true,
@@ -467,6 +475,7 @@ impl Mask {
     }
 
     /// Slice the mask.
+    #[inline]
     pub fn slice(&self, range: Range<usize>) -> Self {
         assert!(range.end <= self.len());
         match &self {
@@ -479,6 +488,7 @@ impl Mask {
     }
 
     /// Return the boolean buffer representation of the mask.
+    #[inline]
     pub fn boolean_buffer(&self) -> AllOr<&BooleanBuffer> {
         match &self {
             Self::AllTrue(_) => AllOr::All,
@@ -489,6 +499,7 @@ impl Mask {
 
     /// Return a boolean buffer representation of the mask, allocating new buffers for all-true
     /// and all-false variants.
+    #[inline]
     pub fn to_boolean_buffer(&self) -> BooleanBuffer {
         match self {
             Self::AllTrue(l) => BooleanBuffer::new_set(*l),
@@ -498,6 +509,7 @@ impl Mask {
     }
 
     /// Returns an Arrow null buffer representation of the mask.
+    #[inline]
     pub fn to_null_buffer(&self) -> Option<NullBuffer> {
         match self {
             Mask::AllTrue(_) => None,
@@ -507,6 +519,7 @@ impl Mask {
     }
 
     /// Return the indices representation of the mask.
+    #[inline]
     pub fn indices(&self) -> AllOr<&[usize]> {
         match &self {
             Self::AllTrue(_) => AllOr::All,
@@ -516,6 +529,7 @@ impl Mask {
     }
 
     /// Return the slices representation of the mask.
+    #[inline]
     pub fn slices(&self) -> AllOr<&[(usize, usize)]> {
         match &self {
             Self::AllTrue(_) => AllOr::All,
@@ -525,6 +539,7 @@ impl Mask {
     }
 
     /// Return an iterator over either indices or slices of the mask based on a density threshold.
+    #[inline]
     pub fn threshold_iter(&self, threshold: f64) -> AllOr<MaskIter<'_>> {
         match &self {
             Self::AllTrue(_) => AllOr::All,
@@ -534,6 +549,7 @@ impl Mask {
     }
 
     /// Return [`MaskValues`] if the mask is not all true or all false.
+    #[inline]
     pub fn values(&self) -> Option<&MaskValues> {
         if let Self::Values(values) = self {
             Some(values)
@@ -640,12 +656,14 @@ pub enum MaskIter<'a> {
 }
 
 impl From<BooleanBuffer> for Mask {
+    #[inline]
     fn from(value: BooleanBuffer) -> Self {
         Self::from_buffer(value)
     }
 }
 
 impl FromIterator<bool> for Mask {
+    #[inline]
     fn from_iter<T: IntoIterator<Item = bool>>(iter: T) -> Self {
         Self::from_buffer(BooleanBuffer::from_iter(iter))
     }


### PR DESCRIPTION
Annotates small functions in vortex-mask with `#[inline]` that could benefit from cross crate inlining.
