### PR TITLE
chore: `#[inline]` fns vortex-scan

### DIFF
--- a/vortex-scan/src/arrow.rs
+++ b/vortex-scan/src/arrow.rs
@@ -74,6 +74,7 @@ where
 {
     type Item = Result<RecordBatch, ArrowError>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
     }
@@ -83,6 +84,7 @@ impl<I> RecordBatchReader for RecordBatchIteratorAdapter<I>
 where
     I: Iterator<Item = Result<RecordBatch, ArrowError>>,
 {
+    #[inline]
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }

--- a/vortex-scan/src/filter.rs
+++ b/vortex-scan/src/filter.rs
@@ -52,16 +52,19 @@ impl FilterExpr {
     }
 
     /// The conjuncts that make up this filter expression.
+    #[inline]
     pub fn conjuncts(&self) -> &[ExprRef] {
         &self.conjuncts
     }
 
     /// The dynamic updates for the given conjunct, if any.
+    #[inline]
     pub fn dynamic_updates(&self, conjunct_idx: usize) -> Option<&DynamicExprUpdates> {
         self.dynamic_conjuncts[conjunct_idx].as_ref()
     }
 
     /// Returns the next preferred conjunct to evaluate.
+    #[inline]
     pub fn next_conjunct(&self, remaining: &BitVec) -> Option<usize> {
         let read = self.ordering.read();
         // Take the first remaining conjunct in the ordered list.

--- a/vortex-scan/src/multi_scan.rs
+++ b/vortex-scan/src/multi_scan.rs
@@ -57,6 +57,7 @@ impl<T> Clone for MultiScanIterator<T> {
 impl<T: Send + Sync + 'static> Iterator for MultiScanIterator<T> {
     type Item = VortexResult<T>;
 
+    #[inline]
     fn next(&mut self) -> Option<VortexResult<T>> {
         loop {
             match self.inner.next()? {

--- a/vortex-scan/src/row_mask.rs
+++ b/vortex-scan/src/row_mask.rs
@@ -16,16 +16,19 @@ pub(crate) struct RowMask {
 }
 
 impl RowMask {
+    #[inline]
     pub fn new(row_offset: u64, mask: Mask) -> Self {
         Self { row_offset, mask }
     }
 
+    #[inline]
     /// The row range of the [`RowMask`].
     pub fn row_range(&self) -> Range<u64> {
         self.row_offset..self.row_offset + self.mask.len() as u64
     }
 
     /// The mask of the [`RowMask`].
+    #[inline]
     pub fn mask(&self) -> &Mask {
         &self.mask
     }

--- a/vortex-scan/src/work_stealing_iter.rs
+++ b/vortex-scan/src/work_stealing_iter.rs
@@ -73,6 +73,7 @@ impl Clone for WorkStealingArrayIterator {
 }
 
 impl ArrayIterator for WorkStealingArrayIterator {
+    #[inline]
     fn dtype(&self) -> &DType {
         &self.dtype
     }
@@ -81,6 +82,7 @@ impl ArrayIterator for WorkStealingArrayIterator {
 impl Iterator for WorkStealingArrayIterator {
     type Item = VortexResult<ArrayRef>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         futures::executor::block_on(self.stream.next())
     }


### PR DESCRIPTION
Annotates small functions in vortex-scan with `#[inline]` that could benefit from cross crate inlining.