### PR TITLE
Feature: Implement Compute Functions for `FixedSizeListArray`

### DIFF
--- a/encodings/runend/src/compute/filter.rs
+++ b/encodings/runend/src/compute/filter.rs
@@ -9,10 +9,10 @@ use num_traits::AsPrimitive;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::compute::{FilterKernel, FilterKernelAdapter, filter};
 use vortex_array::validity::Validity;
-use vortex_array::{Array, ArrayRef, Canonical, IntoArray, ToCanonical, register_kernel};
+use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical, register_kernel};
 use vortex_buffer::buffer_mut;
 use vortex_dtype::{NativePType, match_each_unsigned_integer_ptype};
-use vortex_error::{VortexExpect, VortexResult, VortexUnwrap};
+use vortex_error::{VortexExpect, VortexResult, VortexUnwrap, vortex_panic};
 use vortex_mask::Mask;
 
 use crate::compute::take::take_indices_unchecked;
@@ -22,41 +22,39 @@ const FILTER_TAKE_THRESHOLD: f64 = 0.1;
 
 impl FilterKernel for RunEndVTable {
     fn filter(&self, array: &RunEndArray, mask: &Mask) -> VortexResult<ArrayRef> {
-        match mask {
-            Mask::AllTrue(_) => Ok(array.to_array()),
-            Mask::AllFalse(_) => Ok(Canonical::empty(array.dtype()).into()),
-            Mask::Values(mask_values) => {
-                let runs_ratio = mask_values.true_count() as f64 / array.ends().len() as f64;
+        let Mask::Values(mask_values) = mask else {
+            vortex_panic!("FilterKernel invariant was incorrect");
+        };
 
-                if runs_ratio < FILTER_TAKE_THRESHOLD || mask_values.true_count() < 25 {
-                    // This strategy is directly proportional to the number of indices.
-                    take_indices_unchecked(array, mask_values.indices(), &Validity::NonNullable)
-                } else {
-                    // This strategy ends up being close to fixed cost based on the number of runs,
-                    // rather than the number of indices.
-                    let primitive_run_ends = array.ends().to_primitive();
-                    let (run_ends, values_mask) =
-                        match_each_unsigned_integer_ptype!(primitive_run_ends.ptype(), |P| {
-                            filter_run_end_primitive(
-                                primitive_run_ends.as_slice::<P>(),
-                                array.offset() as u64,
-                                array.len() as u64,
-                                mask_values.boolean_buffer(),
-                            )?
-                        });
-                    let values = filter(array.values(), &values_mask)?;
+        let runs_ratio = mask_values.true_count() as f64 / array.ends().len() as f64;
 
-                    // SAFETY: guaranteed by implementation of filter_run_end_primitive
-                    unsafe {
-                        Ok(RunEndArray::new_unchecked(
-                            run_ends.into_array(),
-                            values,
-                            0,
-                            mask_values.true_count(),
-                        )
-                        .into_array())
-                    }
-                }
+        if runs_ratio < FILTER_TAKE_THRESHOLD || mask_values.true_count() < 25 {
+            // This strategy is directly proportional to the number of indices.
+            take_indices_unchecked(array, mask_values.indices(), &Validity::NonNullable)
+        } else {
+            // This strategy ends up being close to fixed cost based on the number of runs, rather
+            // than the number of indices.
+            let primitive_run_ends = array.ends().to_primitive();
+            let (run_ends, values_mask) =
+                match_each_unsigned_integer_ptype!(primitive_run_ends.ptype(), |P| {
+                    filter_run_end_primitive(
+                        primitive_run_ends.as_slice::<P>(),
+                        array.offset() as u64,
+                        array.len() as u64,
+                        mask_values.boolean_buffer(),
+                    )?
+                });
+            let values = filter(array.values(), &values_mask)?;
+
+            // SAFETY: guaranteed by implementation of filter_run_end_primitive
+            unsafe {
+                Ok(RunEndArray::new_unchecked(
+                    run_ends.into_array(),
+                    values,
+                    0,
+                    mask_values.true_count(),
+                )
+                .into_array())
             }
         }
     }

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -9,7 +9,7 @@ Currently, the only thing required to run the fuzzing targets is [`cargo-fuzz`](
 ## Reproduce crash from CI
 
 In the case of a crash in the nightly run, you can download the crash artifact and run `cargo-fuzz` with the exact same
-input with the command `cargo fuzz run array_ops/file_io <path/to/artifact>`
+input with the command `cargo fuzz run array_ops <path/to/artifact>` or `cargo fuzz run file_io <path/to/artifact>`
 
 ### ASAN
 

--- a/vortex-array/src/arrays/arbitrary.rs
+++ b/vortex-array/src/arrays/arbitrary.rs
@@ -18,7 +18,7 @@ use super::{
     smallest_storage_type,
 };
 use crate::arrays::{VarBinArray, VarBinViewArray};
-use crate::builders::{ArrayBuilder, DecimalBuilder};
+use crate::builders::{ArrayBuilder, DecimalBuilder, FixedSizeListBuilder};
 use crate::validity::Validity;
 use crate::{Array, ArrayRef, IntoArray, ToCanonical, builders};
 
@@ -144,9 +144,9 @@ fn random_array_chunk(
             .vortex_unwrap()
             .into_array())
         }
-        DType::List(ldt, n) => random_list(u, ldt, *n, chunk_len),
-        DType::FixedSizeList(..) => {
-            unimplemented!("TODO(connor)[FixedSizeList]: Create canonical fixed-size list")
+        DType::List(elem_dtype, null) => random_list(u, elem_dtype, *null, chunk_len),
+        DType::FixedSizeList(elem_dtype, list_size, null) => {
+            random_fixed_size_list(u, elem_dtype, *list_size, *null, chunk_len)
         }
         DType::Extension(..) => {
             todo!("Extension arrays are not implemented")
@@ -154,53 +154,92 @@ fn random_array_chunk(
     }
 }
 
+/// Creates a random fixed-size list array.
+///
+/// If the `chunk_len` is specified, the length of the array will be equal to the chunk length.
+fn random_fixed_size_list(
+    u: &mut Unstructured,
+    elem_dtype: &Arc<DType>,
+    list_size: u32,
+    null: Nullability,
+    chunk_len: Option<usize>,
+) -> Result<ArrayRef> {
+    let array_length = chunk_len.unwrap_or(u.int_in_range(0..=20)?);
+
+    let mut builder =
+        FixedSizeListBuilder::with_capacity(elem_dtype.clone(), list_size, null, array_length);
+
+    for _ in 0..array_length {
+        if null == Nullability::Nullable && u.arbitrary::<bool>()? {
+            builder.append_null();
+        } else {
+            builder
+                .append_value(random_list_scalar(u, elem_dtype, list_size, null)?.as_list())
+                .vortex_expect("can append value");
+        }
+    }
+
+    Ok(builder.finish())
+}
+
+/// Creates a random list array.
+///
+/// If the `chunk_len` is specified, the length of the array will be equal to the chunk length.
 fn random_list(
     u: &mut Unstructured,
-    ldt: &Arc<DType>,
-    n: Nullability,
+    elem_dtype: &Arc<DType>,
+    null: Nullability,
     chunk_len: Option<usize>,
 ) -> Result<ArrayRef> {
     match u.int_in_range(0..=5)? {
-        0 => random_list_offset::<i16>(u, ldt, n, chunk_len),
-        1 => random_list_offset::<i32>(u, ldt, n, chunk_len),
-        2 => random_list_offset::<i64>(u, ldt, n, chunk_len),
-        3 => random_list_offset::<u16>(u, ldt, n, chunk_len),
-        4 => random_list_offset::<u32>(u, ldt, n, chunk_len),
-        5 => random_list_offset::<u64>(u, ldt, n, chunk_len),
+        0 => random_list_with_offset_type::<i16>(u, elem_dtype, null, chunk_len),
+        1 => random_list_with_offset_type::<i32>(u, elem_dtype, null, chunk_len),
+        2 => random_list_with_offset_type::<i64>(u, elem_dtype, null, chunk_len),
+        3 => random_list_with_offset_type::<u16>(u, elem_dtype, null, chunk_len),
+        4 => random_list_with_offset_type::<u32>(u, elem_dtype, null, chunk_len),
+        5 => random_list_with_offset_type::<u64>(u, elem_dtype, null, chunk_len),
         _ => unreachable!("int_in_range returns a value in the above range"),
     }
 }
 
-fn random_list_offset<O: OffsetPType>(
+/// Creates a random list array with the given [`OffsetPType`] for the internal offsets child.
+///
+/// If the `chunk_len` is specified, the length of the array will be equal to the chunk length.
+fn random_list_with_offset_type<O: OffsetPType>(
     u: &mut Unstructured,
-    ldt: &Arc<DType>,
-    n: Nullability,
+    elem_dtype: &Arc<DType>,
+    null: Nullability,
     chunk_len: Option<usize>,
 ) -> Result<ArrayRef> {
-    let list_len = chunk_len.unwrap_or(u.int_in_range(0..=20)?);
-    let mut builder = ListBuilder::<O>::with_capacity(ldt.clone(), n, 10);
-    for _ in 0..list_len {
-        if n == Nullability::Nullable && u.arbitrary::<bool>()? {
+    let array_length = chunk_len.unwrap_or(u.int_in_range(0..=20)?);
+
+    let mut builder = ListBuilder::<O>::with_capacity(elem_dtype.clone(), null, 10);
+
+    for _ in 0..array_length {
+        if null == Nullability::Nullable && u.arbitrary::<bool>()? {
             builder.append_null();
         } else {
+            let list_size = u.int_in_range(0..=20)?;
             builder
-                .append_value(random_list_scalar(u, ldt, n)?.as_list())
+                .append_value(random_list_scalar(u, elem_dtype, list_size, null)?.as_list())
                 .vortex_expect("can append value");
         }
     }
+
     Ok(builder.finish())
 }
 
+/// Creates a random list scalar with the specified list size.
 fn random_list_scalar(
     u: &mut Unstructured,
     elem_dtype: &Arc<DType>,
-    n: Nullability,
+    list_size: u32,
+    null: Nullability,
 ) -> Result<Scalar> {
-    let elem_len = u.int_in_range(0..=20)?;
-    let elems = (0..elem_len)
+    let elems = (0..list_size)
         .map(|_| random_scalar(u, elem_dtype))
         .collect::<Result<Vec<_>>>()?;
-    Ok(Scalar::list(elem_dtype.clone(), elems, n))
+    Ok(Scalar::list(elem_dtype.clone(), elems, null))
 }
 
 fn random_string(

--- a/vortex-array/src/arrays/fixed_size_list/compute/cast.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/cast.rs
@@ -9,6 +9,10 @@ use crate::compute::{CastKernel, CastKernelAdapter, cast};
 use crate::vtable::ValidityHelper;
 use crate::{ArrayRef, register_kernel};
 
+/// Cast implementation for [`FixedSizeListArray`].
+///
+/// Recursively casts the inner elements array to the target element type while preserving the list
+/// structure.
 impl CastKernel for FixedSizeListVTable {
     fn cast(&self, array: &FixedSizeListArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         let Some(target_element_type) = dtype.as_list_element_opt() else {

--- a/vortex-array/src/arrays/fixed_size_list/compute/cast.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/cast.rs
@@ -26,8 +26,19 @@ impl CastKernel for FixedSizeListVTable {
             .clone()
             .cast_nullability(dtype.nullability())?;
 
-        FixedSizeListArray::try_new(elements, array.list_size(), validity, array.len())
-            .map(|a| Some(a.to_array()))
+        Ok(Some(
+            // SAFETY: The only requirements for safety here are related to lengths, and no lengths
+            // have changed here. So as long as the original array is valid, this is also valid.
+            unsafe {
+                FixedSizeListArray::new_unchecked(
+                    elements,
+                    array.list_size(),
+                    validity,
+                    array.len(),
+                )
+            }
+            .to_array(),
+        ))
     }
 }
 

--- a/vortex-array/src/arrays/fixed_size_list/compute/cast.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/cast.rs
@@ -10,7 +10,7 @@ use crate::vtable::ValidityHelper;
 use crate::{ArrayRef, register_kernel};
 
 impl CastKernel for FixedSizeListVTable {
-    fn cast(&self, array: &Self::Array, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
+    fn cast(&self, array: &FixedSizeListArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         let Some(target_element_type) = dtype.as_list_element_opt() else {
             return Ok(None);
         };

--- a/vortex-array/src/arrays/fixed_size_list/compute/cast.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/cast.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+
+use crate::arrays::{FixedSizeListArray, FixedSizeListVTable};
+use crate::compute::{CastKernel, CastKernelAdapter, cast};
+use crate::vtable::ValidityHelper;
+use crate::{ArrayRef, register_kernel};
+
+impl CastKernel for FixedSizeListVTable {
+    fn cast(&self, array: &Self::Array, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
+        let Some(target_element_type) = dtype.as_list_element_opt() else {
+            return Ok(None);
+        };
+
+        // The list elements could technically be from either `FixedSizeList` or `List`.
+        if dtype.is_list() {
+            return Ok(None);
+        }
+
+        let elements = cast(array.elements(), target_element_type)?;
+        let validity = array
+            .validity()
+            .clone()
+            .cast_nullability(dtype.nullability())?;
+
+        FixedSizeListArray::try_new(elements, array.list_size(), validity, array.len())
+            .map(|a| Some(a.to_array()))
+    }
+}
+
+register_kernel!(CastKernelAdapter(FixedSizeListVTable).lift());

--- a/vortex-array/src/arrays/fixed_size_list/compute/cast.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/cast.rs
@@ -15,14 +15,9 @@ use crate::{ArrayRef, register_kernel};
 /// structure.
 impl CastKernel for FixedSizeListVTable {
     fn cast(&self, array: &FixedSizeListArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
-        let Some(target_element_type) = dtype.as_list_element_opt() else {
+        let Some(target_element_type) = dtype.as_fixed_size_list_element_opt() else {
             return Ok(None);
         };
-
-        // The list elements could technically be from either `FixedSizeList` or `List`.
-        if dtype.is_list() {
-            return Ok(None);
-        }
 
         let elements = cast(array.elements(), target_element_type)?;
         let validity = array

--- a/vortex-array/src/arrays/fixed_size_list/compute/filter.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/filter.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+use vortex_mask::Mask;
+
+use crate::arrays::FixedSizeListVTable;
+use crate::compute::{FilterKernel, FilterKernelAdapter};
+use crate::{ArrayRef, register_kernel};
+
+impl FilterKernel for FixedSizeListVTable {
+    fn filter(&self, array: &Self::Array, mask: &Mask) -> VortexResult<ArrayRef> {
+        todo!()
+    }
+}
+
+register_kernel!(FilterKernelAdapter(FixedSizeListVTable).lift());

--- a/vortex-array/src/arrays/fixed_size_list/compute/filter.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/filter.rs
@@ -2,13 +2,29 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_error::VortexResult;
-use vortex_mask::Mask;
+use vortex_mask::{Mask, MaskIter};
 use vortex_scalar::Scalar;
 
 use crate::arrays::{ConstantArray, FixedSizeListArray, FixedSizeListVTable};
 use crate::compute::{self, FilterKernel, FilterKernelAdapter};
 use crate::vtable::ValidityHelper;
 use crate::{ArrayRef, IntoArray, register_kernel};
+
+/// Density threshold for choosing between indices and slices representation when expanding masks.
+///
+/// When the mask density is below this threshold, we use indices. Otherwise, we use slices.
+///
+/// Note that this is somewhat arbitrarily chosen...
+const FSL_MASK_EXPANSION_DENSITY_THRESHOLD: f64 = 0.1;
+
+/// List size threshold for choosing between indices and slices in sparse mask expansion.
+///
+/// When expanding sparse masks, if the list size is at or above this threshold, we convert
+/// indices to slices to avoid materializing too many individual indices. This prevents
+/// memory bloat when each FSL element contains many items.
+///
+/// Note that this is somewhat arbitrarily chosen...
+const FSL_SPARSE_MASK_LIST_SIZE_THRESHOLD: usize = 8;
 
 impl FilterKernel for FixedSizeListVTable {
     fn filter(&self, array: &FixedSizeListArray, selection_mask: &Mask) -> VortexResult<ArrayRef> {
@@ -17,11 +33,9 @@ impl FilterKernel for FixedSizeListVTable {
 
         // If the entire array is null, then we only need to adjust the length of the array.
         if let Mask::AllFalse(_) = null_mask {
-            return Ok(ConstantArray::new(
-                Scalar::null(array.dtype().clone()),
-                selection_mask.true_count(),
-            )
-            .into_array());
+            return Ok(
+                ConstantArray::new(Scalar::null(array.dtype().clone()), new_len).into_array(),
+            );
         }
 
         let elements = array.elements();
@@ -33,7 +47,7 @@ impl FilterKernel for FixedSizeListVTable {
         let new_elements = {
             // We want to create a new mask specialized to the underlying `elements` of the array.
             if list_size != 0 {
-                let elements_mask = compute_fsl_elements_mask(selection_mask, list_size);
+                let elements_mask = compute_fsl_elements_mask(selection_mask, list_size as usize);
 
                 // Allow the child array to filter themselves.
                 let new_elements = compute::filter(elements, &elements_mask)?;
@@ -77,24 +91,61 @@ register_kernel!(FilterKernelAdapter(FixedSizeListVTable).lift());
 
 /// Given a mask for a fixed-size list array, creates a new mask for the underlying elements.
 ///
-/// This function simply "expands" out the input `fsl_mask` by duplicating each bit `list_size`
-/// times.
+/// This function simply "expands" out the input `selection_mask` by duplicating each bit
+/// `list_size` times.
 ///
-/// The output `Mask` is guaranteed to have a length equal to `fsl_mask.len() * list_size`.
-fn compute_fsl_elements_mask(fsl_mask: &Mask, list_size: u32) -> Mask {
-    let expanded_len = fsl_mask.len() * list_size as usize;
+/// The output `Mask` is guaranteed to have a length equal to `selection_mask.len() * list_size`.
+fn compute_fsl_elements_mask(selection_mask: &Mask, list_size: usize) -> Mask {
+    let expanded_len = selection_mask.len() * list_size;
 
-    match fsl_mask {
+    match selection_mask {
         Mask::AllTrue(_) => Mask::AllTrue(expanded_len),
         Mask::AllFalse(_) => Mask::AllFalse(expanded_len),
         Mask::Values(values) => {
-            let mut builder = arrow_buffer::BooleanBufferBuilder::new(expanded_len);
-
-            for value in values.boolean_buffer().iter() {
-                builder.append_n(list_size as usize, value);
+            // Use threshold_iter to choose the optimal representation based on density.
+            match values.threshold_iter(FSL_MASK_EXPANSION_DENSITY_THRESHOLD) {
+                MaskIter::Slices(slices) => expand_dense_mask(slices, list_size, expanded_len),
+                MaskIter::Indices(indices) => expand_sparse_mask(indices, list_size, expanded_len),
             }
-
-            Mask::from_buffer(builder.finish())
         }
+    }
+}
+
+/// Expands a dense mask (represented as slices) by scaling each slice by `list_size`.
+fn expand_dense_mask(slices: &[(usize, usize)], list_size: usize, expanded_len: usize) -> Mask {
+    let expanded_slices: Vec<(usize, usize)> = slices
+        .iter()
+        .map(|&(start, end)| (start * list_size, end * list_size))
+        .collect();
+
+    Mask::from_slices(expanded_len, expanded_slices)
+}
+
+/// Expands a sparse mask (represented as indices) by duplicating each index `list_size` times.
+fn expand_sparse_mask(indices: &[usize], list_size: usize, expanded_len: usize) -> Mask {
+    if list_size < FSL_SPARSE_MASK_LIST_SIZE_THRESHOLD {
+        // For small list sizes, expand each index into individual indices.
+        let expanded_indices: Vec<usize> = indices
+            .iter()
+            .flat_map(|&idx| {
+                let start = idx * list_size;
+                start..start + list_size
+            })
+            .collect();
+
+        Mask::from_indices(expanded_len, expanded_indices)
+    } else {
+        // For sparse masks with large list sizes, it's more efficient to create slices rather than
+        // materializing all individual indices.
+        let expanded_slices: Vec<(usize, usize)> = indices
+            .iter()
+            .map(|&idx| {
+                let start = idx * list_size;
+                let end = (idx + 1) * list_size;
+                (start, end)
+            })
+            .collect();
+
+        Mask::from_slices(expanded_len, expanded_slices)
     }
 }

--- a/vortex-array/src/arrays/fixed_size_list/compute/filter.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/filter.rs
@@ -17,15 +17,6 @@ use crate::{ArrayRef, IntoArray, register_kernel};
 /// Note that this is somewhat arbitrarily chosen...
 const FSL_MASK_EXPANSION_DENSITY_THRESHOLD: f64 = 0.1;
 
-/// List size threshold for choosing between indices and slices in sparse mask expansion.
-///
-/// When expanding sparse masks, if the list size is above this threshold, we convert indices to
-/// slices to avoid materializing too many individual indices. This prevents memory bloat when each
-/// FSL element contains many items.
-///
-/// Note that this is somewhat arbitrarily chosen...
-const FSL_SPARSE_MASK_LIST_SIZE_THRESHOLD: usize = 4;
-
 impl FilterKernel for FixedSizeListVTable {
     fn filter(&self, array: &FixedSizeListArray, selection_mask: &Mask) -> VortexResult<ArrayRef> {
         let new_len = selection_mask.true_count();
@@ -122,30 +113,19 @@ fn expand_dense_mask(slices: &[(usize, usize)], list_size: usize, expanded_len: 
 }
 
 /// Expands a sparse mask (represented as indices) by duplicating each index `list_size` times.
+///
+/// Note that in the worst case, it is possible that we create only a few slices with a small range
+/// (for example, when `list_size <= 2`). This could be further optimized, but we choose simplicity
+/// for now.
 fn expand_sparse_mask(indices: &[usize], list_size: usize, expanded_len: usize) -> Mask {
-    if list_size <= FSL_SPARSE_MASK_LIST_SIZE_THRESHOLD {
-        // For small list sizes, expand each index into individual indices.
-        let expanded_indices: Vec<usize> = indices
-            .iter()
-            .flat_map(|&idx| {
-                let start = idx * list_size;
-                start..start + list_size
-            })
-            .collect();
+    let expanded_slices: Vec<(usize, usize)> = indices
+        .iter()
+        .map(|&idx| {
+            let start = idx * list_size;
+            let end = (idx + 1) * list_size;
+            (start, end)
+        })
+        .collect();
 
-        Mask::from_indices(expanded_len, expanded_indices)
-    } else {
-        // For sparse masks with large list sizes, it's more efficient to create slices rather than
-        // materializing all individual indices.
-        let expanded_slices: Vec<(usize, usize)> = indices
-            .iter()
-            .map(|&idx| {
-                let start = idx * list_size;
-                let end = (idx + 1) * list_size;
-                (start, end)
-            })
-            .collect();
-
-        Mask::from_slices(expanded_len, expanded_slices)
-    }
+    Mask::from_slices(expanded_len, expanded_slices)
 }

--- a/vortex-array/src/arrays/fixed_size_list/compute/filter.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/filter.rs
@@ -17,6 +17,10 @@ use crate::{ArrayRef, IntoArray, register_kernel};
 /// Note that this is somewhat arbitrarily chosen...
 const FSL_MASK_EXPANSION_DENSITY_THRESHOLD: f64 = 0.1;
 
+/// Filter implementation for [`FixedSizeListArray`].
+///
+/// Expands the selection mask to cover all elements within selected lists and pushes the expanded
+/// mask down to the child elements array.
 impl FilterKernel for FixedSizeListVTable {
     fn filter(&self, array: &FixedSizeListArray, selection_mask: &Mask) -> VortexResult<ArrayRef> {
         let new_len = selection_mask.true_count();
@@ -40,7 +44,7 @@ impl FilterKernel for FixedSizeListVTable {
             if list_size != 0 {
                 let elements_mask = compute_fsl_elements_mask(selection_mask, list_size as usize);
 
-                // Allow the child array to filter themselves.
+                // Allow the child array to filter itself.
                 let new_elements = compute::filter(elements, &elements_mask)?;
                 debug_assert_eq!(new_elements.len(), new_len * list_size as usize);
 
@@ -89,43 +93,38 @@ register_kernel!(FilterKernelAdapter(FixedSizeListVTable).lift());
 fn compute_fsl_elements_mask(selection_mask: &Mask, list_size: usize) -> Mask {
     let expanded_len = selection_mask.len() * list_size;
 
-    match selection_mask {
-        Mask::AllTrue(_) => Mask::AllTrue(expanded_len),
-        Mask::AllFalse(_) => Mask::AllFalse(expanded_len),
-        Mask::Values(values) => {
-            // Use threshold_iter to choose the optimal representation based on density.
-            match values.threshold_iter(FSL_MASK_EXPANSION_DENSITY_THRESHOLD) {
-                MaskIter::Slices(slices) => expand_dense_mask(slices, list_size, expanded_len),
-                MaskIter::Indices(indices) => expand_sparse_mask(indices, list_size, expanded_len),
-            }
+    let values = match selection_mask {
+        Mask::AllTrue(_) => return Mask::AllTrue(expanded_len),
+        Mask::AllFalse(_) => return Mask::AllFalse(expanded_len),
+        Mask::Values(values) => values,
+    };
+
+    // Use threshold_iter to choose the optimal representation based on density.
+    let expanded_slices = match values.threshold_iter(FSL_MASK_EXPANSION_DENSITY_THRESHOLD) {
+        MaskIter::Slices(slices) => {
+            // Expand a dense mask (represented as slices) by scaling each slice by `list_size`.
+            slices
+                .iter()
+                .map(|&(start, end)| (start * list_size, end * list_size))
+                .collect()
         }
-    }
-}
-
-/// Expands a dense mask (represented as slices) by scaling each slice by `list_size`.
-fn expand_dense_mask(slices: &[(usize, usize)], list_size: usize, expanded_len: usize) -> Mask {
-    let expanded_slices: Vec<(usize, usize)> = slices
-        .iter()
-        .map(|&(start, end)| (start * list_size, end * list_size))
-        .collect();
-
-    Mask::from_slices(expanded_len, expanded_slices)
-}
-
-/// Expands a sparse mask (represented as indices) by duplicating each index `list_size` times.
-///
-/// Note that in the worst case, it is possible that we create only a few slices with a small range
-/// (for example, when `list_size <= 2`). This could be further optimized, but we choose simplicity
-/// for now.
-fn expand_sparse_mask(indices: &[usize], list_size: usize, expanded_len: usize) -> Mask {
-    let expanded_slices: Vec<(usize, usize)> = indices
-        .iter()
-        .map(|&idx| {
-            let start = idx * list_size;
-            let end = (idx + 1) * list_size;
-            (start, end)
-        })
-        .collect();
+        MaskIter::Indices(indices) => {
+            // Expand a sparse mask (represented as indices) by duplicating each index `list_size`
+            // times.
+            //
+            // Note that in the worst case, it is possible that we create only a few slices with a
+            // small range (for example, when list_size <= 2). This could be further optimized,
+            // but we choose simplicity for now.
+            indices
+                .iter()
+                .map(|&idx| {
+                    let start = idx * list_size;
+                    let end = (idx + 1) * list_size;
+                    (start, end)
+                })
+                .collect()
+        }
+    };
 
     Mask::from_slices(expanded_len, expanded_slices)
 }

--- a/vortex-array/src/arrays/fixed_size_list/compute/filter.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/filter.rs
@@ -3,15 +3,98 @@
 
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
+use vortex_scalar::Scalar;
 
-use crate::arrays::FixedSizeListVTable;
-use crate::compute::{FilterKernel, FilterKernelAdapter};
-use crate::{ArrayRef, register_kernel};
+use crate::arrays::{ConstantArray, FixedSizeListArray, FixedSizeListVTable};
+use crate::compute::{self, FilterKernel, FilterKernelAdapter};
+use crate::vtable::ValidityHelper;
+use crate::{ArrayRef, IntoArray, register_kernel};
 
 impl FilterKernel for FixedSizeListVTable {
-    fn filter(&self, array: &Self::Array, mask: &Mask) -> VortexResult<ArrayRef> {
-        todo!()
+    fn filter(&self, array: &FixedSizeListArray, selection_mask: &Mask) -> VortexResult<ArrayRef> {
+        let new_len = selection_mask.true_count();
+        let null_mask = array.validity_mask();
+
+        // If the entire array is null, then we only need to adjust the length of the array.
+        if let Mask::AllFalse(_) = null_mask {
+            return Ok(ConstantArray::new(
+                Scalar::null(array.dtype().clone()),
+                selection_mask.true_count(),
+            )
+            .into_array());
+        }
+
+        let elements = array.elements();
+        let list_size = array.list_size();
+
+        let new_validity = array.validity().filter(selection_mask)?;
+        debug_assert!(new_validity.maybe_len().is_none_or(|len| len == new_len));
+
+        let new_elements = {
+            // We want to create a new mask specialized to the underlying `elements` of the array.
+            if list_size != 0 {
+                let elements_mask = compute_fsl_elements_mask(selection_mask, list_size);
+
+                // Allow the child array to filter themselves.
+                let new_elements = compute::filter(elements, &elements_mask)?;
+                debug_assert_eq!(new_elements.len(), new_len * list_size as usize);
+
+                new_elements
+            } else {
+                // We make a special case for degenerate `FixedSizeList` arrays.
+                debug_assert_eq!(
+                    elements.len(),
+                    0,
+                    "degenerate FixedSizeListArray is invalid"
+                );
+
+                // NB: The safety comment for the `list_size == 0` case is here for clarity.
+
+                // SAFETY: We have verified that when `list_size == 0`
+                // - `elements` has length 0 (since it came from a valid `FixedSizeListArray`)
+                // - `new_validity` has the correct length because we filter with the same
+                //   `selection_mask` as the array itself
+                elements.clone()
+            }
+        };
+
+        Ok(
+            // SAFETY: We have verified that
+            // - The case when `list_size == 0` is safe (see above)
+            // - The `new_elements` array is guaranteed to have a length that is a multiple of
+            //   `list_size`
+            // - `new_validity` has the correct length because we filter with the same
+            //   `selection_mask` as the array itself
+            unsafe {
+                FixedSizeListArray::new_unchecked(new_elements, list_size, new_validity, new_len)
+            }
+            .into_array(),
+        )
     }
 }
 
 register_kernel!(FilterKernelAdapter(FixedSizeListVTable).lift());
+
+/// Given a mask for a fixed-size list array, creates a new mask for the underlying elements.
+///
+/// This function simply "expands" out the input `fsl_mask` by duplicating each bit `list_size`
+/// times.
+///
+/// The output `Mask` is guaranteed to have a length equal to `fsl_mask.len() * list_size`.
+fn compute_fsl_elements_mask(fsl_mask: &Mask, list_size: u32) -> Mask {
+    let expanded_len = fsl_mask.len() * list_size as usize;
+
+    match fsl_mask {
+        Mask::AllTrue(_) => Mask::AllTrue(expanded_len),
+        Mask::AllFalse(_) => Mask::AllFalse(expanded_len),
+        Mask::Values(values) => {
+            let mut builder = arrow_buffer::BooleanBufferBuilder::new(expanded_len);
+
+            for value in values.boolean_buffer().iter() {
+                builder.append_n(list_size as usize, value);
+            }
+
+            Mask::from_buffer(builder.finish())
+        }
+    }
+}

--- a/vortex-array/src/arrays/fixed_size_list/compute/filter.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/filter.rs
@@ -19,12 +19,12 @@ const FSL_MASK_EXPANSION_DENSITY_THRESHOLD: f64 = 0.1;
 
 /// List size threshold for choosing between indices and slices in sparse mask expansion.
 ///
-/// When expanding sparse masks, if the list size is at or above this threshold, we convert
-/// indices to slices to avoid materializing too many individual indices. This prevents
-/// memory bloat when each FSL element contains many items.
+/// When expanding sparse masks, if the list size is above this threshold, we convert indices to
+/// slices to avoid materializing too many individual indices. This prevents memory bloat when each
+/// FSL element contains many items.
 ///
 /// Note that this is somewhat arbitrarily chosen...
-const FSL_SPARSE_MASK_LIST_SIZE_THRESHOLD: usize = 8;
+const FSL_SPARSE_MASK_LIST_SIZE_THRESHOLD: usize = 4;
 
 impl FilterKernel for FixedSizeListVTable {
     fn filter(&self, array: &FixedSizeListArray, selection_mask: &Mask) -> VortexResult<ArrayRef> {
@@ -123,7 +123,7 @@ fn expand_dense_mask(slices: &[(usize, usize)], list_size: usize, expanded_len: 
 
 /// Expands a sparse mask (represented as indices) by duplicating each index `list_size` times.
 fn expand_sparse_mask(indices: &[usize], list_size: usize, expanded_len: usize) -> Mask {
-    if list_size < FSL_SPARSE_MASK_LIST_SIZE_THRESHOLD {
+    if list_size <= FSL_SPARSE_MASK_LIST_SIZE_THRESHOLD {
         // For small list sizes, expand each index into individual indices.
         let expanded_indices: Vec<usize> = indices
             .iter()

--- a/vortex-array/src/arrays/fixed_size_list/compute/filter.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/filter.rs
@@ -3,9 +3,8 @@
 
 use vortex_error::VortexResult;
 use vortex_mask::{Mask, MaskIter};
-use vortex_scalar::Scalar;
 
-use crate::arrays::{ConstantArray, FixedSizeListArray, FixedSizeListVTable};
+use crate::arrays::{FixedSizeListArray, FixedSizeListVTable};
 use crate::compute::{self, FilterKernel, FilterKernelAdapter};
 use crate::vtable::ValidityHelper;
 use crate::{ArrayRef, IntoArray, register_kernel};
@@ -23,17 +22,8 @@ const FSL_MASK_EXPANSION_DENSITY_THRESHOLD: f64 = 0.1;
 /// mask down to the child elements array.
 impl FilterKernel for FixedSizeListVTable {
     fn filter(&self, array: &FixedSizeListArray, selection_mask: &Mask) -> VortexResult<ArrayRef> {
-        let new_len = selection_mask.true_count();
-        let null_mask = array.validity_mask();
-
-        // If the entire array is null, then we only need to adjust the length of the array.
-        if let Mask::AllFalse(_) = null_mask {
-            return Ok(
-                ConstantArray::new(Scalar::null(array.dtype().clone()), new_len).into_array(),
-            );
-        }
-
         let elements = array.elements();
+        let new_len = selection_mask.true_count();
         let list_size = array.list_size();
 
         let new_validity = array.validity().filter(selection_mask)?;

--- a/vortex-array/src/arrays/fixed_size_list/compute/is_constant.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/is_constant.rs
@@ -7,6 +7,9 @@ use crate::arrays::{FixedSizeListArray, FixedSizeListVTable};
 use crate::compute::{IsConstantKernel, IsConstantKernelAdapter, IsConstantOpts};
 use crate::register_kernel;
 
+/// IsConstant implementation for [`FixedSizeListArray`].
+///
+/// Compares each list scalar against the first to determine if all lists are identical.
 impl IsConstantKernel for FixedSizeListVTable {
     fn is_constant(
         &self,

--- a/vortex-array/src/arrays/fixed_size_list/compute/is_constant.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/is_constant.rs
@@ -11,9 +11,27 @@ impl IsConstantKernel for FixedSizeListVTable {
     fn is_constant(
         &self,
         array: &FixedSizeListArray,
-        opts: &IsConstantOpts,
+        _opts: &IsConstantOpts,
     ) -> VortexResult<Option<bool>> {
-        todo!()
+        // Since all of the lists have fixed size, we just need to check that each list scalar is
+        // identical. Note that this check is always "expensive".
+
+        debug_assert!(
+            array.len() > 1,
+            "precondition for `is_constant` is incorrect"
+        );
+        let first_scalar = array.scalar_at(0); // We checked the array length above.
+
+        // TODO(connor): There must be a more efficient way to do this. Each `scalar_at()` call
+        // makes several allocations...
+        for i in 1..array.len() {
+            let current_scalar = array.scalar_at(i);
+            if current_scalar != first_scalar {
+                return Ok(Some(false));
+            }
+        }
+
+        Ok(Some(true))
     }
 }
 

--- a/vortex-array/src/arrays/fixed_size_list/compute/is_constant.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/is_constant.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+
+use crate::arrays::{FixedSizeListArray, FixedSizeListVTable};
+use crate::compute::{IsConstantKernel, IsConstantKernelAdapter, IsConstantOpts};
+use crate::register_kernel;
+
+impl IsConstantKernel for FixedSizeListVTable {
+    fn is_constant(
+        &self,
+        array: &FixedSizeListArray,
+        opts: &IsConstantOpts,
+    ) -> VortexResult<Option<bool>> {
+        todo!()
+    }
+}
+
+register_kernel!(IsConstantKernelAdapter(FixedSizeListVTable).lift());

--- a/vortex-array/src/arrays/fixed_size_list/compute/mask.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/mask.rs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+use vortex_mask::Mask;
+
+use crate::arrays::{FixedSizeListArray, FixedSizeListVTable};
+use crate::compute::{MaskKernel, MaskKernelAdapter};
+use crate::vtable::ValidityHelper;
+use crate::{ArrayRef, IntoArray, register_kernel};
+
+impl MaskKernel for FixedSizeListVTable {
+    fn mask(&self, array: &FixedSizeListArray, mask: &Mask) -> VortexResult<ArrayRef> {
+        FixedSizeListArray::try_new(
+            array.elements().clone(),
+            array.list_size(),
+            array.validity().mask(mask),
+            array.len(),
+        )
+        .map(|a| a.into_array())
+    }
+}
+
+register_kernel!(MaskKernelAdapter(FixedSizeListVTable).lift());

--- a/vortex-array/src/arrays/fixed_size_list/compute/mask.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/mask.rs
@@ -9,6 +9,9 @@ use crate::compute::{MaskKernel, MaskKernelAdapter};
 use crate::vtable::ValidityHelper;
 use crate::{ArrayRef, IntoArray, register_kernel};
 
+/// Mask implementation for [`FixedSizeListArray`].
+///
+/// Applies a validity mask to the array without modifying the underlying element data.
 impl MaskKernel for FixedSizeListVTable {
     fn mask(&self, array: &FixedSizeListArray, mask: &Mask) -> VortexResult<ArrayRef> {
         // SAFETY: The only thing that changes here is the validity mask, which will have the same

--- a/vortex-array/src/arrays/fixed_size_list/compute/mask.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/mask.rs
@@ -11,13 +11,17 @@ use crate::{ArrayRef, IntoArray, register_kernel};
 
 impl MaskKernel for FixedSizeListVTable {
     fn mask(&self, array: &FixedSizeListArray, mask: &Mask) -> VortexResult<ArrayRef> {
-        FixedSizeListArray::try_new(
-            array.elements().clone(),
-            array.list_size(),
-            array.validity().mask(mask),
-            array.len(),
-        )
-        .map(|a| a.into_array())
+        // SAFETY: The only thing that changes here is the validity mask, which will have the same
+        // length. So as long as the original array is valid, this is also valid.
+        Ok(unsafe {
+            FixedSizeListArray::new_unchecked(
+                array.elements().clone(),
+                array.list_size(),
+                array.validity().mask(mask),
+                array.len(),
+            )
+        }
+        .into_array())
     }
 }
 

--- a/vortex-array/src/arrays/fixed_size_list/compute/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/mod.rs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+mod cast;
+mod filter;
+mod is_constant;
+mod mask;
+mod take;

--- a/vortex-array/src/arrays/fixed_size_list/compute/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/take.rs
@@ -29,54 +29,25 @@ fn take_with_indices<I: NativePType>(
 ) -> VortexResult<ArrayRef> {
     let list_size = array.list_size() as usize;
 
-    let array_validity = array.validity_mask();
-    let indices_validity = indices_array.validity_mask();
+    if list_size == 0 {
+        return Ok(take_degenerate_fsl::<I>(array, indices_array));
+    }
 
     let indices: &[I] = indices_array.as_slice::<I>();
     let len = indices.len();
 
-    if list_size == 0 {
-        // If the `list_size` is 0, then we simply need figure out where the nulls are and return
-        // an array with empty elements and the correct length.
+    let array_validity = array.validity_mask();
+    let indices_validity = indices_array.validity_mask();
 
-        debug_assert!(array.elements().is_empty(), "degenerate list is invalid");
-
-        let mut new_validity = BooleanBufferBuilder::new(len);
-
-        // We iterate over each data index as well as if each data index is null.
-        indices_validity.iter_bools(|validity_iter| {
-            for (data_idx, is_valid) in indices.iter().zip(validity_iter) {
-                let data_idx = data_idx.to_usize().unwrap_or_else(|| {
-                    vortex_panic!("Failed to convert index to usize: {}", data_idx)
-                });
-
-                new_validity.append(is_valid && array_validity.value(data_idx));
-            }
-        });
-
-        let new_validity = Validity::from(new_validity.finish());
-        debug_assert!(new_validity.maybe_len().is_none_or(|vl| vl == len));
-
-        // SAFETY: The `list_size` is 0, the elements array is empty, and the validity has the
-        // correct length.
-        return Ok(unsafe {
-            FixedSizeListArray::new_unchecked(
-                array.elements().clone(),
-                array.list_size(),
-                new_validity,
-                len,
-            )
-        }
-        .into_array());
-    }
-
-    // We will create new indices specialized for the child `element` array.
-    let mut elements_indices =
-        PrimitiveBuilder::<I>::with_capacity(Nullability::Nullable, len * list_size);
-    let mut new_validity = BooleanBufferBuilder::new(len);
+    let new_nullability = array.dtype().nullability() | indices_array.dtype().nullability();
 
     // We iterate over each data index as well as if each data index is null.
     indices_validity.iter_bools(|validity_iter| {
+        // We will create new indices specialized for the child `element` array.
+        let mut elements_indices =
+            PrimitiveBuilder::<I>::with_capacity(Nullability::NonNullable, len * list_size);
+        let mut new_validity_builder = BooleanBufferBuilder::new(len);
+
         for (data_idx, is_valid) in indices.iter().zip(validity_iter) {
             let data_idx = data_idx
                 .to_usize()
@@ -84,8 +55,13 @@ fn take_with_indices<I: NativePType>(
 
             // If we have a null index (null code), then we treat this as referencing a null list.
             if !is_valid || !array_validity.value(data_idx) {
-                elements_indices.append_nulls(list_size);
-                new_validity.append(false);
+                debug_assert!(
+                    indices_array.dtype().is_nullable() || array.dtype().is_nullable(),
+                    "Somehow had an invalid index from non-nullable array"
+                );
+
+                elements_indices.append_zeros(list_size); // TODO(connor): Is this right?
+                new_validity_builder.append(false);
                 continue;
             }
 
@@ -97,7 +73,7 @@ fn take_with_indices<I: NativePType>(
                 elements_indices.append_value(I::from_usize(i).vortex_expect("i < additional"))
             }
 
-            new_validity.append(true);
+            new_validity_builder.append(true);
         }
 
         let elements_indices = elements_indices.finish();
@@ -106,7 +82,7 @@ fn take_with_indices<I: NativePType>(
         let new_elements = compute::take(array.elements(), elements_indices.as_ref())?;
         debug_assert_eq!(new_elements.len(), len * list_size);
 
-        let new_validity = Validity::from(new_validity.finish());
+        let new_validity = compute_validity_from_bool_buffer(new_validity_builder, new_nullability);
         debug_assert!(new_validity.maybe_len().is_none_or(|vl| vl == len));
 
         // SAFETY: We checked above that `list_size` is not 0, that the length of the elements array
@@ -116,4 +92,87 @@ fn take_with_indices<I: NativePType>(
         }
         .into_array())
     })
+}
+
+fn take_degenerate_fsl<I: NativePType>(
+    array: &FixedSizeListArray,
+    indices_array: &PrimitiveArray,
+) -> ArrayRef {
+    debug_assert_eq!(array.list_size(), 0);
+
+    let array_validity = array.validity_mask();
+    let indices_validity = indices_array.validity_mask();
+
+    let indices: &[I] = indices_array.as_slice::<I>();
+    let len = indices.len();
+
+    let new_nullability = array.dtype().nullability() | indices_array.dtype().nullability();
+
+    // If the `list_size` is 0, then we simply need figure out where the nulls are and return
+    // an array with empty elements and the correct length.
+
+    debug_assert!(array.elements().is_empty(), "degenerate list is invalid");
+
+    let mut new_validity_builder = BooleanBufferBuilder::new(len);
+
+    // We iterate over each data index as well as if each data index is null.
+    indices_validity.iter_bools(|validity_iter| {
+        for (data_idx, is_valid) in indices.iter().zip(validity_iter) {
+            let data_idx = data_idx
+                .to_usize()
+                .unwrap_or_else(|| vortex_panic!("Failed to convert index to usize: {}", data_idx));
+
+            if !is_valid || !array_validity.value(data_idx) {
+                debug_assert!(
+                    indices_array.dtype().is_nullable() || array.dtype().is_nullable(),
+                    "Somehow had an invalid index from non-nullable array"
+                );
+
+                new_validity_builder.append(false);
+            } else {
+                new_validity_builder.append(true);
+            }
+        }
+    });
+
+    let new_validity = compute_validity_from_bool_buffer(new_validity_builder, new_nullability);
+    debug_assert!(new_validity.maybe_len().is_none_or(|vl| vl == len));
+
+    // SAFETY: The `list_size` is 0, the elements array is empty, and the validity has the correct
+    // length.
+    unsafe {
+        FixedSizeListArray::new_unchecked(
+            array.elements().clone(),
+            array.list_size(),
+            new_validity,
+            len,
+        )
+    }
+    .into_array()
+}
+
+fn compute_validity_from_bool_buffer(
+    mut bool_buffer: BooleanBufferBuilder,
+    nullability: Nullability,
+) -> Validity {
+    match nullability {
+        Nullability::Nullable => {
+            // If the outer array is nullable, then we simply derive from the boolean buffer.
+            Validity::from(bool_buffer.finish())
+        }
+        Nullability::NonNullable => {
+            // Otherwise, the array remains non-nullable.
+
+            {
+                for i in 0..bool_buffer.len() {
+                    println!("{}", bool_buffer.get_bit(i))
+                }
+            }
+
+            #[cfg(debug_assertions)]
+            assert_eq!(Validity::from(bool_buffer.finish()), Validity::AllValid);
+
+            Validity::NonNullable
+        }
+    }
 }

--- a/vortex-array/src/arrays/fixed_size_list/compute/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/take.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+
+use crate::arrays::{FixedSizeListArray, FixedSizeListVTable};
+use crate::compute::{TakeKernel, TakeKernelAdapter};
+use crate::{Array, ArrayRef, register_kernel};
+
+impl TakeKernel for FixedSizeListVTable {
+    fn take(&self, array: &FixedSizeListArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
+        todo!()
+    }
+}
+
+register_kernel!(TakeKernelAdapter(FixedSizeListVTable).lift());

--- a/vortex-array/src/arrays/fixed_size_list/compute/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/take.rs
@@ -9,14 +9,13 @@ use crate::arrays::{FixedSizeListArray, FixedSizeListVTable, PrimitiveArray};
 use crate::builders::{ArrayBuilder, PrimitiveBuilder};
 use crate::compute::{self, TakeKernel, TakeKernelAdapter};
 use crate::validity::Validity;
+use crate::vtable::ValidityHelper;
 use crate::{Array, ArrayRef, IntoArray, ToCanonical, register_kernel};
 
 impl TakeKernel for FixedSizeListVTable {
     fn take(&self, array: &FixedSizeListArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
-        let indices = indices.to_primitive();
-
-        match_each_integer_ptype!(indices.ptype(), |I| {
-            take_with_indices::<I>(array, &indices)
+        match_each_integer_ptype!(indices.dtype().as_ptype(), |I| {
+            take_with_indices::<I>(array, indices)
         })
     }
 }
@@ -26,9 +25,11 @@ register_kernel!(TakeKernelAdapter(FixedSizeListVTable).lift());
 /// Dispatches to the appropriate take implementation based on list size and nullability.
 fn take_with_indices<I: NativePType>(
     array: &FixedSizeListArray,
-    indices_array: &PrimitiveArray,
+    indices: &dyn Array,
 ) -> VortexResult<ArrayRef> {
     let list_size = array.list_size() as usize;
+
+    let indices_array = indices.to_primitive();
 
     // Make sure to handle degenerate case where lists have size 0 (these can take fast paths).
     if list_size == 0 {
@@ -37,85 +38,30 @@ fn take_with_indices<I: NativePType>(
             "degenerate list must have empty elements"
         );
 
-        // The result's nullability is the union of the input nullabilities.
-        if array.dtype().is_nullable() || indices_array.dtype().is_nullable() {
-            Ok(take_degenerate_nullable::<I>(array, indices_array))
-        } else {
-            Ok(take_degenerate_non_nullable(array, indices_array))
-        }
+        // Since there are no elements to take, we just need to take on the validity map.
+        let new_validity = array.validity().take(indices)?;
+        let new_len = indices_array.len();
+
+        Ok(
+            // SAFETY: list_size is 0, elements array is empty, and validity has the correct length.
+            unsafe {
+                FixedSizeListArray::new_unchecked(
+                    array.elements().clone(), // Remember that this is an empty array.
+                    array.list_size(),
+                    new_validity,
+                    new_len,
+                )
+            }
+            .into_array(),
+        )
     } else {
         // The result's nullability is the union of the input nullabilities.
         if array.dtype().is_nullable() || indices_array.dtype().is_nullable() {
-            take_nullable_fsl::<I>(array, indices_array)
+            take_nullable_fsl::<I>(array, &indices_array)
         } else {
-            take_non_nullable_fsl::<I>(array, indices_array)
+            take_non_nullable_fsl::<I>(array, &indices_array)
         }
     }
-}
-
-/// Returns empty non-nullable lists with the requested length.
-fn take_degenerate_non_nullable(
-    array: &FixedSizeListArray,
-    indices_array: &PrimitiveArray,
-) -> ArrayRef {
-    let len = indices_array.len();
-
-    // SAFETY: list_size is 0, elements array is empty, and both arrays are non-nullable.
-    unsafe {
-        FixedSizeListArray::new_unchecked(
-            array.elements().clone(),
-            array.list_size(),
-            Validity::NonNullable,
-            len,
-        )
-    }
-    .into_array()
-}
-
-/// Returns empty lists with computed validity for the nullable case.
-fn take_degenerate_nullable<I: NativePType>(
-    array: &FixedSizeListArray,
-    indices_array: &PrimitiveArray,
-) -> ArrayRef {
-    let indices: &[I] = indices_array.as_slice::<I>();
-    let len = indices.len();
-
-    let array_validity = array.validity_mask();
-    let indices_validity = indices_array.validity_mask();
-
-    // Compute the validity for each empty list.
-    let mut new_validity_builder = BooleanBufferBuilder::new(len);
-
-    // Check the validity of each indexed position.
-    for (idx, data_idx) in indices.iter().enumerate() {
-        let data_idx = data_idx
-            .to_usize()
-            .unwrap_or_else(|| vortex_panic!("Failed to convert index to usize: {}", data_idx));
-
-        let is_index_valid = indices_validity.value(idx);
-
-        // The list is null if the index is null or the indexed element is null.
-        if !is_index_valid || !array_validity.value(data_idx) {
-            new_validity_builder.append(false);
-        } else {
-            new_validity_builder.append(true);
-        }
-    }
-
-    // At least one input was nullable, so the result is nullable.
-    let new_validity = Validity::from(new_validity_builder.finish());
-    debug_assert!(new_validity.maybe_len().is_none_or(|vl| vl == len));
-
-    // SAFETY: list_size is 0, elements array is empty, and validity has the correct length.
-    unsafe {
-        FixedSizeListArray::new_unchecked(
-            array.elements().clone(),
-            array.list_size(),
-            new_validity,
-            len,
-        )
-    }
-    .into_array()
 }
 
 /// Takes from an array when both the array and indices are non-nullable.

--- a/vortex-array/src/arrays/fixed_size_list/compute/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/take.rs
@@ -23,123 +23,90 @@ impl TakeKernel for FixedSizeListVTable {
 
 register_kernel!(TakeKernelAdapter(FixedSizeListVTable).lift());
 
+/// Dispatches to the appropriate take implementation based on list size and nullability.
 fn take_with_indices<I: NativePType>(
     array: &FixedSizeListArray,
     indices_array: &PrimitiveArray,
 ) -> VortexResult<ArrayRef> {
     let list_size = array.list_size() as usize;
 
+    // Make sure to handle degenerate case where lists have size 0 (these can take fast paths).
     if list_size == 0 {
-        return Ok(take_degenerate_fsl::<I>(array, indices_array));
+        debug_assert!(
+            array.elements().is_empty(),
+            "degenerate list must have empty elements"
+        );
+
+        // The result's nullability is the union of the input nullabilities.
+        if array.dtype().is_nullable() || indices_array.dtype().is_nullable() {
+            Ok(take_degenerate_nullable::<I>(array, indices_array))
+        } else {
+            Ok(take_degenerate_non_nullable(array, indices_array))
+        }
+    } else {
+        // The result's nullability is the union of the input nullabilities.
+        if array.dtype().is_nullable() || indices_array.dtype().is_nullable() {
+            take_nullable_fsl::<I>(array, indices_array)
+        } else {
+            take_non_nullable_fsl::<I>(array, indices_array)
+        }
     }
-
-    let indices: &[I] = indices_array.as_slice::<I>();
-    let len = indices.len();
-
-    let array_validity = array.validity_mask();
-    let indices_validity = indices_array.validity_mask();
-
-    let new_nullability = array.dtype().nullability() | indices_array.dtype().nullability();
-
-    // We iterate over each data index as well as if each data index is null.
-    indices_validity.iter_bools(|validity_iter| {
-        // We will create new indices specialized for the child `element` array.
-        let mut elements_indices =
-            PrimitiveBuilder::<I>::with_capacity(Nullability::NonNullable, len * list_size);
-        let mut new_validity_builder = BooleanBufferBuilder::new(len);
-
-        for (data_idx, is_valid) in indices.iter().zip(validity_iter) {
-            let data_idx = data_idx
-                .to_usize()
-                .unwrap_or_else(|| vortex_panic!("Failed to convert index to usize: {}", data_idx));
-
-            // If we have a null index (null code), then we treat this as referencing a null list.
-            if !is_valid || !array_validity.value(data_idx) {
-                debug_assert!(
-                    indices_array.dtype().is_nullable() || array.dtype().is_nullable(),
-                    "Somehow had an invalid index from non-nullable array"
-                );
-
-                elements_indices.append_zeros(list_size); // TODO(connor): Is this right?
-                new_validity_builder.append(false);
-                continue;
-            }
-
-            let list_start = data_idx * list_size;
-            let list_end = (data_idx + 1) * list_size;
-
-            for i in list_start..list_end {
-                // TODO(connor): This can be optimized with `UninitRange`.
-                elements_indices.append_value(I::from_usize(i).vortex_expect("i < additional"))
-            }
-
-            new_validity_builder.append(true);
-        }
-
-        let elements_indices = elements_indices.finish();
-        debug_assert_eq!(elements_indices.len(), len * list_size);
-
-        let new_elements = compute::take(array.elements(), elements_indices.as_ref())?;
-        debug_assert_eq!(new_elements.len(), len * list_size);
-
-        let new_validity = compute_validity_from_bool_buffer(new_validity_builder, new_nullability);
-        debug_assert!(new_validity.maybe_len().is_none_or(|vl| vl == len));
-
-        // SAFETY: We checked above that `list_size` is not 0, that the length of the elements array
-        // is a multiple of the `list_size`, and the validity will have the correct length.
-        Ok(unsafe {
-            FixedSizeListArray::new_unchecked(new_elements, array.list_size(), new_validity, len)
-        }
-        .into_array())
-    })
 }
 
-fn take_degenerate_fsl<I: NativePType>(
+/// Returns empty non-nullable lists with the requested length.
+fn take_degenerate_non_nullable(
     array: &FixedSizeListArray,
     indices_array: &PrimitiveArray,
 ) -> ArrayRef {
-    debug_assert_eq!(array.list_size(), 0);
+    let len = indices_array.len();
+
+    // SAFETY: list_size is 0, elements array is empty, and both arrays are non-nullable.
+    unsafe {
+        FixedSizeListArray::new_unchecked(
+            array.elements().clone(),
+            array.list_size(),
+            Validity::NonNullable,
+            len,
+        )
+    }
+    .into_array()
+}
+
+/// Returns empty lists with computed validity for the nullable case.
+fn take_degenerate_nullable<I: NativePType>(
+    array: &FixedSizeListArray,
+    indices_array: &PrimitiveArray,
+) -> ArrayRef {
+    let indices: &[I] = indices_array.as_slice::<I>();
+    let len = indices.len();
 
     let array_validity = array.validity_mask();
     let indices_validity = indices_array.validity_mask();
 
-    let indices: &[I] = indices_array.as_slice::<I>();
-    let len = indices.len();
-
-    let new_nullability = array.dtype().nullability() | indices_array.dtype().nullability();
-
-    // If the `list_size` is 0, then we simply need figure out where the nulls are and return
-    // an array with empty elements and the correct length.
-
-    debug_assert!(array.elements().is_empty(), "degenerate list is invalid");
-
+    // Compute the validity for each empty list.
     let mut new_validity_builder = BooleanBufferBuilder::new(len);
 
-    // We iterate over each data index as well as if each data index is null.
-    indices_validity.iter_bools(|validity_iter| {
-        for (data_idx, is_valid) in indices.iter().zip(validity_iter) {
-            let data_idx = data_idx
-                .to_usize()
-                .unwrap_or_else(|| vortex_panic!("Failed to convert index to usize: {}", data_idx));
+    // Check the validity of each indexed position.
+    for (idx, data_idx) in indices.iter().enumerate() {
+        let data_idx = data_idx
+            .to_usize()
+            .unwrap_or_else(|| vortex_panic!("Failed to convert index to usize: {}", data_idx));
 
-            if !is_valid || !array_validity.value(data_idx) {
-                debug_assert!(
-                    indices_array.dtype().is_nullable() || array.dtype().is_nullable(),
-                    "Somehow had an invalid index from non-nullable array"
-                );
+        let is_index_valid = indices_validity.value(idx);
 
-                new_validity_builder.append(false);
-            } else {
-                new_validity_builder.append(true);
-            }
+        // The list is null if the index is null or the indexed element is null.
+        if !is_index_valid || !array_validity.value(data_idx) {
+            new_validity_builder.append(false);
+        } else {
+            new_validity_builder.append(true);
         }
-    });
+    }
 
-    let new_validity = compute_validity_from_bool_buffer(new_validity_builder, new_nullability);
+    // At least one input was nullable, so the result is nullable.
+    let new_validity = Validity::from(new_validity_builder.finish());
     debug_assert!(new_validity.maybe_len().is_none_or(|vl| vl == len));
 
-    // SAFETY: The `list_size` is 0, the elements array is empty, and the validity has the correct
-    // length.
+    // SAFETY: list_size is 0, elements array is empty, and validity has the correct length.
     unsafe {
         FixedSizeListArray::new_unchecked(
             array.elements().clone(),
@@ -151,28 +118,110 @@ fn take_degenerate_fsl<I: NativePType>(
     .into_array()
 }
 
-fn compute_validity_from_bool_buffer(
-    mut bool_buffer: BooleanBufferBuilder,
-    nullability: Nullability,
-) -> Validity {
-    match nullability {
-        Nullability::Nullable => {
-            // If the outer array is nullable, then we simply derive from the boolean buffer.
-            Validity::from(bool_buffer.finish())
-        }
-        Nullability::NonNullable => {
-            // Otherwise, the array remains non-nullable.
+/// Takes from an array when both the array and indices are non-nullable.
+fn take_non_nullable_fsl<I: NativePType>(
+    array: &FixedSizeListArray,
+    indices_array: &PrimitiveArray,
+) -> VortexResult<ArrayRef> {
+    let list_size = array.list_size() as usize;
+    let indices: &[I] = indices_array.as_slice::<I>();
+    let len = indices.len();
 
-            {
-                for i in 0..bool_buffer.len() {
-                    println!("{}", bool_buffer.get_bit(i))
-                }
-            }
+    // Build the element indices directly without validity tracking.
+    let mut elements_indices =
+        PrimitiveBuilder::<I>::with_capacity(Nullability::NonNullable, len * list_size);
 
-            #[cfg(debug_assertions)]
-            assert_eq!(Validity::from(bool_buffer.finish()), Validity::AllValid);
+    // Build the element indices for each list.
+    for data_idx in indices {
+        let data_idx = data_idx
+            .to_usize()
+            .unwrap_or_else(|| vortex_panic!("Failed to convert index to usize: {}", data_idx));
 
-            Validity::NonNullable
+        let list_start = data_idx * list_size;
+        let list_end = (data_idx + 1) * list_size;
+
+        // Expand the list into individual element indices.
+        for i in list_start..list_end {
+            elements_indices.append_value(I::from_usize(i).vortex_expect("i < list_end"))
         }
     }
+
+    let elements_indices = elements_indices.finish();
+    debug_assert_eq!(elements_indices.len(), len * list_size);
+
+    let new_elements = compute::take(array.elements(), elements_indices.as_ref())?;
+    debug_assert_eq!(new_elements.len(), len * list_size);
+
+    // Both inputs are non-nullable, so the result is non-nullable.
+    Ok(unsafe {
+        FixedSizeListArray::new_unchecked(
+            new_elements,
+            array.list_size(),
+            Validity::NonNullable,
+            len,
+        )
+    }
+    .into_array())
+}
+
+/// Takes from an array when either the array or indices are nullable.
+fn take_nullable_fsl<I: NativePType>(
+    array: &FixedSizeListArray,
+    indices_array: &PrimitiveArray,
+) -> VortexResult<ArrayRef> {
+    let list_size = array.list_size() as usize;
+    let indices: &[I] = indices_array.as_slice::<I>();
+    let len = indices.len();
+
+    let array_validity = array.validity_mask();
+    let indices_validity = indices_array.validity_mask();
+
+    // We must use placeholder zeros for null lists to maintain the array length without
+    // propagating nullability to the element array's take operation.
+    let mut elements_indices =
+        PrimitiveBuilder::<I>::with_capacity(Nullability::NonNullable, len * list_size);
+    let mut new_validity_builder = BooleanBufferBuilder::new(len);
+
+    // Build the element indices while tracking which lists are null.
+    for (idx, data_idx) in indices.iter().enumerate() {
+        let data_idx = data_idx
+            .to_usize()
+            .unwrap_or_else(|| vortex_panic!("Failed to convert index to usize: {}", data_idx));
+
+        let is_index_valid = indices_validity.value(idx);
+
+        // The list is null if the index is null or the indexed element is null.
+        if !is_index_valid || !array_validity.value(data_idx) {
+            // Append placeholder zeros for null lists. These will be masked by the validity array.
+            // We cannot use append_nulls here as explained above.
+            elements_indices.append_zeros(list_size);
+            new_validity_builder.append(false);
+        } else {
+            // Append the actual element indices for this list.
+            let list_start = data_idx * list_size;
+            let list_end = (data_idx + 1) * list_size;
+
+            // Expand the list into individual element indices.
+            for i in list_start..list_end {
+                elements_indices.append_value(I::from_usize(i).vortex_expect("i < list_end"))
+            }
+
+            new_validity_builder.append(true);
+        }
+    }
+
+    let elements_indices = elements_indices.finish();
+    debug_assert_eq!(elements_indices.len(), len * list_size);
+
+    let new_elements = compute::take(array.elements(), elements_indices.as_ref())?;
+    debug_assert_eq!(new_elements.len(), len * list_size);
+
+    // At least one input was nullable, so the result is nullable.
+    let new_validity = Validity::from(new_validity_builder.finish());
+    debug_assert!(new_validity.maybe_len().is_none_or(|vl| vl == len));
+
+    Ok(unsafe {
+        FixedSizeListArray::new_unchecked(new_elements, array.list_size(), new_validity, len)
+    }
+    .into_array())
 }

--- a/vortex-array/src/arrays/fixed_size_list/compute/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/take.rs
@@ -1,16 +1,119 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_error::VortexResult;
+use arrow_buffer::BooleanBufferBuilder;
+use vortex_dtype::{NativePType, Nullability, match_each_integer_ptype};
+use vortex_error::{VortexExpect, VortexResult, vortex_panic};
 
-use crate::arrays::{FixedSizeListArray, FixedSizeListVTable};
-use crate::compute::{TakeKernel, TakeKernelAdapter};
-use crate::{Array, ArrayRef, register_kernel};
+use crate::arrays::{FixedSizeListArray, FixedSizeListVTable, PrimitiveArray};
+use crate::builders::{ArrayBuilder, PrimitiveBuilder};
+use crate::compute::{self, TakeKernel, TakeKernelAdapter};
+use crate::validity::Validity;
+use crate::{Array, ArrayRef, IntoArray, ToCanonical, register_kernel};
 
 impl TakeKernel for FixedSizeListVTable {
     fn take(&self, array: &FixedSizeListArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
-        todo!()
+        let indices = indices.to_primitive();
+
+        match_each_integer_ptype!(indices.ptype(), |I| {
+            take_with_indices::<I>(array, &indices)
+        })
     }
 }
 
 register_kernel!(TakeKernelAdapter(FixedSizeListVTable).lift());
+
+fn take_with_indices<I: NativePType>(
+    array: &FixedSizeListArray,
+    indices_array: &PrimitiveArray,
+) -> VortexResult<ArrayRef> {
+    let list_size = array.list_size() as usize;
+
+    let array_validity = array.validity_mask();
+    let indices_validity = indices_array.validity_mask();
+
+    let indices: &[I] = indices_array.as_slice::<I>();
+    let len = indices.len();
+
+    if list_size == 0 {
+        // If the `list_size` is 0, then we simply need figure out where the nulls are and return
+        // an array with empty elements and the correct length.
+
+        debug_assert!(array.elements().is_empty(), "degenerate list is invalid");
+
+        let mut new_validity = BooleanBufferBuilder::new(len);
+
+        // We iterate over each data index as well as if each data index is null.
+        indices_validity.iter_bools(|validity_iter| {
+            for (data_idx, is_valid) in indices.iter().zip(validity_iter) {
+                let data_idx = data_idx.to_usize().unwrap_or_else(|| {
+                    vortex_panic!("Failed to convert index to usize: {}", data_idx)
+                });
+
+                new_validity.append(is_valid && array_validity.value(data_idx));
+            }
+        });
+
+        let new_validity = Validity::from(new_validity.finish());
+        debug_assert!(new_validity.maybe_len().is_none_or(|vl| vl == len));
+
+        // SAFETY: The `list_size` is 0, the elements array is empty, and the validity has the
+        // correct length.
+        return Ok(unsafe {
+            FixedSizeListArray::new_unchecked(
+                array.elements().clone(),
+                array.list_size(),
+                new_validity,
+                len,
+            )
+        }
+        .into_array());
+    }
+
+    // We will create new indices specialized for the child `element` array.
+    let mut elements_indices =
+        PrimitiveBuilder::<I>::with_capacity(Nullability::Nullable, len * list_size);
+    let mut new_validity = BooleanBufferBuilder::new(len);
+
+    // We iterate over each data index as well as if each data index is null.
+    indices_validity.iter_bools(|validity_iter| {
+        for (data_idx, is_valid) in indices.iter().zip(validity_iter) {
+            let data_idx = data_idx
+                .to_usize()
+                .unwrap_or_else(|| vortex_panic!("Failed to convert index to usize: {}", data_idx));
+
+            // If we have a null index (null code), then we treat this as referencing a null list.
+            if !is_valid || !array_validity.value(data_idx) {
+                elements_indices.append_nulls(list_size);
+                new_validity.append(false);
+                continue;
+            }
+
+            let list_start = data_idx * list_size;
+            let list_end = (data_idx + 1) * list_size;
+
+            for i in list_start..list_end {
+                // TODO(connor): This can be optimized with `UninitRange`.
+                elements_indices.append_value(I::from_usize(i).vortex_expect("i < additional"))
+            }
+
+            new_validity.append(true);
+        }
+
+        let elements_indices = elements_indices.finish();
+        debug_assert_eq!(elements_indices.len(), len * list_size);
+
+        let new_elements = compute::take(array.elements(), elements_indices.as_ref())?;
+        debug_assert_eq!(new_elements.len(), len * list_size);
+
+        let new_validity = Validity::from(new_validity.finish());
+        debug_assert!(new_validity.maybe_len().is_none_or(|vl| vl == len));
+
+        // SAFETY: We checked above that `list_size` is not 0, that the length of the elements array
+        // is a multiple of the `list_size`, and the validity will have the correct length.
+        Ok(unsafe {
+            FixedSizeListArray::new_unchecked(new_elements, array.list_size(), new_validity, len)
+        }
+        .into_array())
+    })
+}

--- a/vortex-array/src/arrays/fixed_size_list/compute/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/take.rs
@@ -12,6 +12,9 @@ use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 use crate::{Array, ArrayRef, IntoArray, ToCanonical, register_kernel};
 
+/// Take implementation for [`FixedSizeListArray`].
+///
+/// Expands list indices into element indices and pushes them down to the child elements array.
 impl TakeKernel for FixedSizeListVTable {
     fn take(&self, array: &FixedSizeListArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
         match_each_integer_ptype!(indices.dtype().as_ptype(), |I| {
@@ -71,11 +74,11 @@ fn take_non_nullable_fsl<I: NativePType>(
 ) -> VortexResult<ArrayRef> {
     let list_size = array.list_size() as usize;
     let indices: &[I] = indices_array.as_slice::<I>();
-    let len = indices.len();
+    let new_len = indices.len();
 
     // Build the element indices directly without validity tracking.
     let mut elements_indices =
-        PrimitiveBuilder::<I>::with_capacity(Nullability::NonNullable, len * list_size);
+        PrimitiveBuilder::<I>::with_capacity(Nullability::NonNullable, new_len * list_size);
 
     // Build the element indices for each list.
     for data_idx in indices {
@@ -93,10 +96,10 @@ fn take_non_nullable_fsl<I: NativePType>(
     }
 
     let elements_indices = elements_indices.finish();
-    debug_assert_eq!(elements_indices.len(), len * list_size);
+    debug_assert_eq!(elements_indices.len(), new_len * list_size);
 
     let new_elements = compute::take(array.elements(), elements_indices.as_ref())?;
-    debug_assert_eq!(new_elements.len(), len * list_size);
+    debug_assert_eq!(new_elements.len(), new_len * list_size);
 
     // Both inputs are non-nullable, so the result is non-nullable.
     Ok(unsafe {
@@ -104,7 +107,7 @@ fn take_non_nullable_fsl<I: NativePType>(
             new_elements,
             array.list_size(),
             Validity::NonNullable,
-            len,
+            new_len,
         )
     }
     .into_array())
@@ -117,7 +120,7 @@ fn take_nullable_fsl<I: NativePType>(
 ) -> VortexResult<ArrayRef> {
     let list_size = array.list_size() as usize;
     let indices: &[I] = indices_array.as_slice::<I>();
-    let len = indices.len();
+    let new_len = indices.len();
 
     let array_validity = array.validity_mask();
     let indices_validity = indices_array.validity_mask();
@@ -125,16 +128,16 @@ fn take_nullable_fsl<I: NativePType>(
     // We must use placeholder zeros for null lists to maintain the array length without
     // propagating nullability to the element array's take operation.
     let mut elements_indices =
-        PrimitiveBuilder::<I>::with_capacity(Nullability::NonNullable, len * list_size);
-    let mut new_validity_builder = BooleanBufferBuilder::new(len);
+        PrimitiveBuilder::<I>::with_capacity(Nullability::NonNullable, new_len * list_size);
+    let mut new_validity_builder = BooleanBufferBuilder::new(new_len);
 
     // Build the element indices while tracking which lists are null.
-    for (idx, data_idx) in indices.iter().enumerate() {
+    for (i, data_idx) in indices.iter().enumerate() {
         let data_idx = data_idx
             .to_usize()
             .unwrap_or_else(|| vortex_panic!("Failed to convert index to usize: {}", data_idx));
 
-        let is_index_valid = indices_validity.value(idx);
+        let is_index_valid = indices_validity.value(i);
 
         // The list is null if the index is null or the indexed element is null.
         if !is_index_valid || !array_validity.value(data_idx) {
@@ -157,17 +160,17 @@ fn take_nullable_fsl<I: NativePType>(
     }
 
     let elements_indices = elements_indices.finish();
-    debug_assert_eq!(elements_indices.len(), len * list_size);
+    debug_assert_eq!(elements_indices.len(), new_len * list_size);
 
     let new_elements = compute::take(array.elements(), elements_indices.as_ref())?;
-    debug_assert_eq!(new_elements.len(), len * list_size);
+    debug_assert_eq!(new_elements.len(), new_len * list_size);
 
     // At least one input was nullable, so the result is nullable.
     let new_validity = Validity::from(new_validity_builder.finish());
-    debug_assert!(new_validity.maybe_len().is_none_or(|vl| vl == len));
+    debug_assert!(new_validity.maybe_len().is_none_or(|vl| vl == new_len));
 
     Ok(unsafe {
-        FixedSizeListArray::new_unchecked(new_elements, array.list_size(), new_validity, len)
+        FixedSizeListArray::new_unchecked(new_elements, array.list_size(), new_validity, new_len)
     }
     .into_array())
 }

--- a/vortex-array/src/arrays/fixed_size_list/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/mod.rs
@@ -75,16 +75,10 @@ impl FixedSizeListArray {
     ///
     /// # Errors
     ///
-    /// Returns an error if the inputs are invalid. The inputs are **valid** if:
+    /// Returns an error if the inputs are invalid. See [`new_unchecked()`] for more details on what
+    /// the validity requirements are.
     ///
-    /// - The `list_size` is 0 and:
-    ///   - The `elements` array is empty.
-    ///   - The `len` is equal to the length of the `validity` map.
-    /// - The length of the `elements` array is a multiple of the size of the fixed-size lists
-    ///   (`list_size`).
-    /// - The `Validity` length (if it exists) times the `list_size` is equal to the length of the
-    ///   `elements` (or put another way, the length of the array divided by the size of each
-    ///   fixed-size list is equal to the length of the validity).
+    /// [`new_unchecked()`]: Self::new_unchecked
     pub fn try_new(
         elements: ArrayRef,
         list_size: u32,
@@ -101,10 +95,16 @@ impl FixedSizeListArray {
     ///
     /// # Safety
     ///
-    /// This function is only safe to call if the inputs are valid. See [`try_new()`] for more
-    /// details on what the validity requirements are.
+    /// The inputs are **valid** if:
     ///
-    /// [`try_new()`]: Self::try_new
+    /// - The `list_size` is 0 and:
+    ///   - The `elements` array is empty.
+    ///   - The `len` is equal to the length of the `validity` map.
+    /// - The length of the `elements` array is a multiple of the size of the fixed-size lists
+    ///   (`list_size`).
+    /// - The `Validity` length (if it exists) times the `list_size` is equal to the length of the
+    ///   `elements` (or put another way, the length of the array divided by the size of each
+    ///   fixed-size list is equal to the length of the validity).
     pub unsafe fn new_unchecked(
         elements: ArrayRef,
         list_size: u32,

--- a/vortex-array/src/arrays/fixed_size_list/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/mod.rs
@@ -16,6 +16,8 @@ pub use vtable::{FixedSizeListEncoding, FixedSizeListVTable};
 #[cfg(test)]
 mod tests;
 
+mod compute;
+
 /// The canonical encoding for fixed-size list arrays.
 #[derive(Clone, Debug)]
 pub struct FixedSizeListArray {

--- a/vortex-array/src/arrays/fixed_size_list/tests/filter.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/filter.rs
@@ -140,19 +140,70 @@ fn test_filter_single_element() {
     assert_eq!(filtered_fsl.elements().len(), 0);
 }
 
-#[test]
-fn test_filter_degenerate_list_size_zero() {
+// Consolidated parameterized test for degenerate (list_size=0) cases.
+#[rstest]
+#[case::basic_degenerate(
+    5,
+    Validity::NonNullable,
+    vec![true, false, true, false, true],
+    3,
+    false
+)]
+#[case::degenerate_with_nulls(
+    5,
+    Validity::from_iter([true, false, true, true, false]),
+    vec![true, false, true, true, false],
+    3,
+    false
+)]
+#[case::degenerate_to_empty(
+    3,
+    Validity::NonNullable,
+    vec![false, false, false],
+    0,
+    false
+)]
+#[case::degenerate_all_null(
+    4,
+    Validity::AllInvalid,
+    vec![true, true, false, true],
+    3,
+    true
+)]
+#[case::large_degenerate(
+    1000,
+    Validity::NonNullable,
+    vec![true; 500].into_iter().chain(vec![false; 500]).collect(),
+    500,
+    false
+)]
+fn test_filter_degenerate_list_size_zero(
+    #[case] num_lists: usize,
+    #[case] validity: Validity,
+    #[case] mask_values: Vec<bool>,
+    #[case] expected_len: usize,
+    #[case] expect_constant_array: bool,
+) {
     // Degenerate case where list_size == 0.
     let elements = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
-    let fsl = FixedSizeListArray::new(elements.into_array(), 0, Validity::NonNullable, 5);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 0, validity, num_lists);
 
-    let mask = Mask::from(BooleanBuffer::from(vec![true, false, true, false, true]));
+    let mask = Mask::from(BooleanBuffer::from(mask_values));
     let filtered = filter(fsl.as_ref(), &mask).unwrap();
-    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
 
-    assert_eq!(filtered_fsl.len(), 3);
-    assert_eq!(filtered_fsl.list_size(), 0);
-    assert_eq!(filtered_fsl.elements().len(), 0);
+    assert_eq!(filtered.len(), expected_len);
+
+    if expect_constant_array {
+        // Should return a ConstantArray of nulls when all are invalid.
+        let filtered_const = filtered.as_::<ConstantVTable>();
+        for i in 0..expected_len {
+            assert!(filtered_const.scalar_at(i).is_null());
+        }
+    } else {
+        let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
+        assert_eq!(filtered_fsl.list_size(), 0);
+        assert_eq!(filtered_fsl.elements().len(), 0);
+    }
 }
 
 #[test]
@@ -252,25 +303,18 @@ fn test_filter_nested_fixed_size_lists() {
     assert_eq!(inner_list_2.scalar_at(1), 12i32.into());
 }
 
-#[test]
-fn test_filter_mask_types() {
+// Parameterized test for different mask types.
+#[rstest]
+#[case::all_true(Mask::AllTrue(3), 3)]
+#[case::all_false(Mask::AllFalse(3), 0)]
+#[case::values_partial(Mask::from(BooleanBuffer::from(vec![true, true, false])), 2)]
+#[case::values_alternating(Mask::from(BooleanBuffer::from(vec![true, false, true])), 2)]
+fn test_filter_mask_types(#[case] mask: Mask, #[case] expected_len: usize) {
     let elements = PrimitiveArray::from_iter([1u32, 2, 3, 4, 5, 6]);
     let fsl = FixedSizeListArray::new(elements.into_array(), 2, Validity::NonNullable, 3);
 
-    // Test with Mask::AllTrue.
-    let mask = Mask::AllTrue(3);
     let filtered = filter(fsl.as_ref(), &mask).unwrap();
-    assert_eq!(filtered.len(), 3);
-
-    // Test with Mask::AllFalse.
-    let mask = Mask::AllFalse(3);
-    let filtered = filter(fsl.as_ref(), &mask).unwrap();
-    assert_eq!(filtered.len(), 0);
-
-    // Test with Mask::Values.
-    let mask = Mask::from(BooleanBuffer::from(vec![true, true, false]));
-    let filtered = filter(fsl.as_ref(), &mask).unwrap();
-    assert_eq!(filtered.len(), 2);
+    assert_eq!(filtered.len(), expected_len);
 }
 
 #[test]
@@ -436,54 +480,8 @@ fn test_filter_large_list_size() {
     assert_eq!(list_2.scalar_at(0), 400i64.into()); // Start of original list 4.
 }
 
-#[test]
-fn test_filter_degenerate_with_nulls() {
-    // FSL with list_size == 0 and mixed validity (some null, some valid empty lists).
-    let elements = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
-    let validity = Validity::from_iter([true, false, true, true, false]);
-    let fsl = FixedSizeListArray::new(elements.into_array(), 0, validity, 5);
-
-    // Filter to keep indices 0, 2, 3 (keeping both null and non-null empty lists).
-    let mask = Mask::from(BooleanBuffer::from(vec![true, false, true, true, false]));
-    let filtered = filter(fsl.as_ref(), &mask).unwrap();
-    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
-
-    assert_eq!(filtered_fsl.len(), 3);
-    assert_eq!(filtered_fsl.list_size(), 0);
-    assert_eq!(filtered_fsl.elements().len(), 0);
-
-    // Check that validity is preserved correctly.
-    // Original validity: [true, false, true, true, false]
-    // After filter with mask [true, false, true, true, false]: [true, true, true]
-    assert!(!filtered_fsl.scalar_at(0).is_null()); // Valid empty list.
-    assert!(!filtered_fsl.scalar_at(1).is_null()); // Valid empty list.
-    assert!(!filtered_fsl.scalar_at(2).is_null()); // Valid empty list.
-}
-
-#[test]
-fn test_filter_degenerate_all_null() {
-    // FSL with list_size == 0 where all lists are null.
-    let elements = PrimitiveArray::empty::<f64>(Nullability::NonNullable);
-    let validity = Validity::AllInvalid;
-    let fsl = FixedSizeListArray::new(elements.into_array(), 0, validity, 4);
-
-    let mask = Mask::from(BooleanBuffer::from(vec![true, true, false, true]));
-    let filtered = filter(fsl.as_ref(), &mask).unwrap();
-
-    // Should return a ConstantArray of nulls.
-    let filtered_const = filtered.as_::<ConstantVTable>();
-    assert_eq!(filtered_const.len(), 3);
-    assert!(filtered_const.scalar_at(0).is_null());
-    assert!(filtered_const.scalar_at(1).is_null());
-    assert!(filtered_const.scalar_at(2).is_null());
-
-    // Verify the dtype is preserved.
-    assert!(matches!(
-        filtered.dtype(),
-        DType::FixedSizeList(elem_dtype, 0, Nullability::Nullable)
-            if matches!(elem_dtype.as_ref(), DType::Primitive(PType::F64, Nullability::NonNullable))
-    ));
-}
+// Note: test_filter_degenerate_with_nulls and test_filter_degenerate_all_null
+// have been consolidated into the parameterized test_filter_degenerate_list_size_zero above.
 
 #[test]
 fn test_filter_all_null_various_list_sizes() {
@@ -521,33 +519,7 @@ fn test_filter_all_null_various_list_sizes() {
     assert!(filtered10.scalar_at(4).is_null());
 }
 
-#[test]
-fn test_filter_to_empty_degenerate() {
-    // FSL with list_size == 0 filtered to empty result.
-    let elements = PrimitiveArray::empty::<u32>(Nullability::NonNullable);
-    let fsl = FixedSizeListArray::new(elements.into_array(), 0, Validity::NonNullable, 5);
-
-    // Filter with all false mask.
-    let mask = Mask::AllFalse(5);
-    let filtered = filter(fsl.as_ref(), &mask).unwrap();
-    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
-
-    assert_eq!(filtered_fsl.len(), 0);
-    assert_eq!(filtered_fsl.list_size(), 0);
-    assert_eq!(filtered_fsl.elements().len(), 0);
-
-    // Also test with mixed validity.
-    let elements2 = PrimitiveArray::empty::<u32>(Nullability::NonNullable);
-    let validity = Validity::from_iter([true, false, true, false, true]);
-    let fsl2 = FixedSizeListArray::new(elements2.into_array(), 0, validity, 5);
-
-    let mask2 = Mask::from(BooleanBuffer::from(vec![false, false, false, false, false]));
-    let filtered2 = filter(fsl2.as_ref(), &mask2).unwrap();
-    let filtered_fsl2 = filtered2.as_::<FixedSizeListVTable>();
-
-    assert_eq!(filtered_fsl2.len(), 0);
-    assert_eq!(filtered_fsl2.list_size(), 0);
-}
+// Note: test_filter_to_empty_degenerate has been consolidated into test_filter_degenerate_list_size_zero above.
 
 #[test]
 fn test_mask_expansion_threshold_boundary() {
@@ -609,121 +581,8 @@ fn test_mask_expansion_threshold_boundary() {
     assert_eq!(filtered_fsl7.list_size(), list_size_7);
 }
 
-#[test]
-fn test_nested_degenerate_filter() {
-    // Case 1: Inner FSL has list_size == 0.
-    let inner_elements = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
-    let inner_fsl = FixedSizeListArray::new(
-        inner_elements.into_array(),
-        0, // Inner list size is 0.
-        Validity::NonNullable,
-        6, // 6 empty inner lists.
-    );
+// Note: test_nested_degenerate_filter has been consolidated into test_filter_nested_fixed_size_lists.
 
-    let outer_fsl = FixedSizeListArray::new(
-        inner_fsl.into_array(),
-        3, // Each outer list contains 3 inner lists.
-        Validity::NonNullable,
-        2, // 2 outer lists.
-    );
+// Note: test_large_degenerate_array has been consolidated into test_filter_degenerate_list_size_zero above.
 
-    let mask = Mask::from(BooleanBuffer::from(vec![false, true]));
-    let filtered = filter(outer_fsl.as_ref(), &mask).unwrap();
-    let filtered_outer = filtered.as_::<FixedSizeListVTable>();
-
-    assert_eq!(filtered_outer.len(), 1);
-    assert_eq!(filtered_outer.list_size(), 3);
-
-    let filtered_inner = filtered_outer.elements().as_::<FixedSizeListVTable>();
-    assert_eq!(filtered_inner.len(), 3);
-    assert_eq!(filtered_inner.list_size(), 0);
-    assert_eq!(filtered_inner.elements().len(), 0);
-
-    // Case 2: Outer FSL has list_size == 0.
-    // When outer list_size is 0, the elements array must also be empty.
-    let inner_elements2 = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
-    let inner_fsl2 = FixedSizeListArray::new(
-        inner_elements2.into_array(),
-        2, // Inner list would have size 2, but there are 0 of them.
-        Validity::NonNullable,
-        0, // 0 inner lists since outer list_size is 0.
-    );
-
-    let outer_fsl2 = FixedSizeListArray::new(
-        inner_fsl2.into_array(),
-        0, // Outer list size is 0.
-        Validity::NonNullable,
-        5, // 5 outer lists (each containing 0 inner lists).
-    );
-
-    let mask2 = Mask::from(BooleanBuffer::from(vec![true, true, false, true, false]));
-    let filtered2 = filter(outer_fsl2.as_ref(), &mask2).unwrap();
-    let filtered_outer2 = filtered2.as_::<FixedSizeListVTable>();
-
-    assert_eq!(filtered_outer2.len(), 3);
-    assert_eq!(filtered_outer2.list_size(), 0);
-    // Elements should be an empty FSL array.
-    assert_eq!(filtered_outer2.elements().len(), 0);
-}
-
-#[test]
-fn test_large_degenerate_array() {
-    // Large array with list_size == 0.
-    let num_lists = 10000;
-    let elements = PrimitiveArray::empty::<i64>(Nullability::NonNullable);
-    let fsl = FixedSizeListArray::new(elements.into_array(), 0, Validity::NonNullable, num_lists);
-
-    // Create a selection mask that keeps every 3rd element.
-    let mask_vec: Vec<bool> = (0..num_lists).map(|i| i % 3 == 0).collect();
-    let mask = Mask::from(BooleanBuffer::from(mask_vec));
-
-    let filtered = filter(fsl.as_ref(), &mask).unwrap();
-    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
-
-    let expected_len = num_lists / 3 + if num_lists % 3 > 0 { 1 } else { 0 };
-    assert_eq!(filtered_fsl.len(), expected_len);
-    assert_eq!(filtered_fsl.list_size(), 0);
-    assert_eq!(filtered_fsl.elements().len(), 0);
-
-    // Also test with nullability.
-    let elements2 = PrimitiveArray::empty::<i64>(Nullability::NonNullable);
-    let validity = Validity::from_iter((0..num_lists).map(|i| i % 7 != 0));
-    let fsl2 = FixedSizeListArray::new(elements2.into_array(), 0, validity, num_lists);
-
-    let filtered2 = filter(fsl2.as_ref(), &mask).unwrap();
-    let filtered_fsl2 = filtered2.as_::<FixedSizeListVTable>();
-
-    assert_eq!(filtered_fsl2.len(), expected_len);
-    assert_eq!(filtered_fsl2.list_size(), 0);
-}
-
-#[test]
-fn test_degenerate_all_mask_types() {
-    // Test degenerate arrays with different mask types.
-    let elements = PrimitiveArray::empty::<u16>(Nullability::NonNullable);
-    let validity = Validity::from_iter([true, false, true]);
-    let fsl = FixedSizeListArray::new(elements.into_array(), 0, validity, 3);
-
-    // Test with Mask::AllTrue.
-    let mask_all_true = Mask::AllTrue(3);
-    let filtered_true = filter(fsl.as_ref(), &mask_all_true).unwrap();
-    let fsl_true = filtered_true.as_::<FixedSizeListVTable>();
-    assert_eq!(fsl_true.len(), 3);
-    assert!(!fsl_true.scalar_at(0).is_null());
-    assert!(fsl_true.scalar_at(1).is_null());
-    assert!(!fsl_true.scalar_at(2).is_null());
-
-    // Test with Mask::AllFalse.
-    let mask_all_false = Mask::AllFalse(3);
-    let filtered_false = filter(fsl.as_ref(), &mask_all_false).unwrap();
-    let fsl_false = filtered_false.as_::<FixedSizeListVTable>();
-    assert_eq!(fsl_false.len(), 0);
-
-    // Test with Mask::Values.
-    let mask_values = Mask::from(BooleanBuffer::from(vec![false, true, true]));
-    let filtered_values = filter(fsl.as_ref(), &mask_values).unwrap();
-    let fsl_values = filtered_values.as_::<FixedSizeListVTable>();
-    assert_eq!(fsl_values.len(), 2);
-    assert!(fsl_values.scalar_at(0).is_null()); // Second element was null.
-    assert!(!fsl_values.scalar_at(1).is_null()); // Third element was valid.
-}
+// Note: test_degenerate_all_mask_types has been consolidated into the parameterized tests above.

--- a/vortex-array/src/arrays/fixed_size_list/tests/filter.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/filter.rs
@@ -1,0 +1,729 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use arrow_buffer::BooleanBuffer;
+use rstest::rstest;
+use vortex_dtype::{DType, Nullability, PType};
+use vortex_mask::Mask;
+
+use crate::arrays::{ConstantVTable, FixedSizeListArray, FixedSizeListVTable, PrimitiveArray};
+use crate::compute::conformance::filter::{
+    LARGE_SIZE, MEDIUM_SIZE, SMALL_SIZE, test_filter_conformance,
+};
+use crate::compute::filter;
+use crate::validity::Validity;
+use crate::{Array, ArrayRef, IntoArray};
+
+#[test]
+fn test_filter_all_true() {
+    let elements = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5, 6]);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 2, Validity::NonNullable, 3);
+
+    let mask = Mask::from(BooleanBuffer::from(vec![true, true, true]));
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_fsl.len(), 3);
+    assert_eq!(filtered_fsl.list_size(), 2);
+    assert_eq!(filtered_fsl.elements().len(), 6);
+
+    // Verify the data is unchanged.
+    assert_eq!(filtered_fsl.scalar_at(0), fsl.scalar_at(0));
+    assert_eq!(filtered_fsl.scalar_at(1), fsl.scalar_at(1));
+    assert_eq!(filtered_fsl.scalar_at(2), fsl.scalar_at(2));
+}
+
+#[test]
+fn test_filter_all_false() {
+    let elements = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5, 6]);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 2, Validity::NonNullable, 3);
+
+    let mask = Mask::from(BooleanBuffer::from(vec![false, false, false]));
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_fsl.len(), 0);
+    assert_eq!(filtered_fsl.list_size(), 2);
+    assert_eq!(filtered_fsl.elements().len(), 0);
+}
+
+#[test]
+fn test_filter_alternating() {
+    let elements = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5, 6, 7, 8]);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 2, Validity::NonNullable, 4);
+
+    let mask = Mask::from(BooleanBuffer::from(vec![true, false, true, false]));
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_fsl.len(), 2);
+    assert_eq!(filtered_fsl.list_size(), 2);
+    assert_eq!(filtered_fsl.elements().len(), 4);
+
+    // First list should be [1, 2].
+    let first = filtered_fsl.fixed_size_list_at(0);
+    assert_eq!(first.scalar_at(0), 1i32.into());
+    assert_eq!(first.scalar_at(1), 2i32.into());
+
+    // Second list should be [5, 6].
+    let second = filtered_fsl.fixed_size_list_at(1);
+    assert_eq!(second.scalar_at(0), 5i32.into());
+    assert_eq!(second.scalar_at(1), 6i32.into());
+}
+
+#[test]
+fn test_filter_selective() {
+    let elements = PrimitiveArray::from_iter([1.0f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 3, Validity::NonNullable, 3);
+
+    let mask = Mask::from(BooleanBuffer::from(vec![false, true, true]));
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_fsl.len(), 2);
+    assert_eq!(filtered_fsl.list_size(), 3);
+    assert_eq!(filtered_fsl.elements().len(), 6);
+
+    // First list should be [4.0, 5.0, 6.0].
+    let first = filtered_fsl.fixed_size_list_at(0);
+    assert_eq!(first.scalar_at(0), 4.0f64.into());
+    assert_eq!(first.scalar_at(1), 5.0f64.into());
+    assert_eq!(first.scalar_at(2), 6.0f64.into());
+
+    // Second list should be [7.0, 8.0, 9.0].
+    let second = filtered_fsl.fixed_size_list_at(1);
+    assert_eq!(second.scalar_at(0), 7.0f64.into());
+    assert_eq!(second.scalar_at(1), 8.0f64.into());
+    assert_eq!(second.scalar_at(2), 9.0f64.into());
+}
+
+#[test]
+fn test_filter_empty_array() {
+    let elements = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 2, Validity::NonNullable, 0);
+
+    let mask = Mask::AllTrue(0);
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_fsl.len(), 0);
+    assert_eq!(filtered_fsl.list_size(), 2);
+    assert_eq!(filtered_fsl.elements().len(), 0);
+}
+
+#[test]
+fn test_filter_single_element() {
+    let elements = PrimitiveArray::from_iter([42i32, 43, 44]);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 3, Validity::NonNullable, 1);
+
+    // Keep the single element.
+    let mask = Mask::from(BooleanBuffer::from(vec![true]));
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_fsl.len(), 1);
+    assert_eq!(filtered_fsl.list_size(), 3);
+    assert_eq!(filtered_fsl.elements().len(), 3);
+
+    let first = filtered_fsl.fixed_size_list_at(0);
+    assert_eq!(first.scalar_at(0), 42i32.into());
+    assert_eq!(first.scalar_at(1), 43i32.into());
+    assert_eq!(first.scalar_at(2), 44i32.into());
+
+    // Filter out the single element.
+    let mask = Mask::from(BooleanBuffer::from(vec![false]));
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_fsl.len(), 0);
+    assert_eq!(filtered_fsl.list_size(), 3);
+    assert_eq!(filtered_fsl.elements().len(), 0);
+}
+
+#[test]
+fn test_filter_degenerate_list_size_zero() {
+    // Degenerate case where list_size == 0.
+    let elements = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 0, Validity::NonNullable, 5);
+
+    let mask = Mask::from(BooleanBuffer::from(vec![true, false, true, false, true]));
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_fsl.len(), 3);
+    assert_eq!(filtered_fsl.list_size(), 0);
+    assert_eq!(filtered_fsl.elements().len(), 0);
+}
+
+#[test]
+fn test_filter_with_nulls() {
+    let elements =
+        PrimitiveArray::from_option_iter([Some(1i32), Some(2), None, Some(4), Some(5), Some(6)]);
+    let validity = Validity::from_iter([true, false, true]);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 2, validity, 3);
+
+    let mask = Mask::from(BooleanBuffer::from(vec![true, false, true]));
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_fsl.len(), 2);
+    assert_eq!(filtered_fsl.list_size(), 2);
+
+    // First list should be [1, 2] and valid.
+    let first = filtered_fsl.fixed_size_list_at(0);
+    assert_eq!(first.scalar_at(0), 1i32.into());
+    assert_eq!(first.scalar_at(1), 2i32.into());
+
+    // Second list should be [5, 6] and valid.
+    let second = filtered_fsl.fixed_size_list_at(1);
+    assert_eq!(second.scalar_at(0), 5i32.into());
+    assert_eq!(second.scalar_at(1), 6i32.into());
+}
+
+#[test]
+fn test_filter_all_null_array() {
+    // Create an array where all elements are null.
+    let elements = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5, 6]);
+    let validity = Validity::AllInvalid;
+    let fsl = FixedSizeListArray::new(elements.into_array(), 2, validity, 3);
+
+    let mask = Mask::from(BooleanBuffer::from(vec![true, false, true]));
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+
+    // This should return a ConstantArray of nulls.
+    let filtered_const = filtered.as_::<ConstantVTable>();
+    assert_eq!(filtered_const.len(), 2);
+    assert!(filtered_const.scalar_at(0).is_null());
+    assert!(filtered_const.scalar_at(1).is_null());
+}
+
+#[test]
+fn test_filter_nested_fixed_size_lists() {
+    // Create nested fixed-size lists: FSL<FSL<i32>>.
+    // Inner lists are of size 2, outer lists are of size 3.
+    // So we have 2 outer lists, each containing 3 inner lists, each containing 2 i32s.
+    let inner_elements = PrimitiveArray::from_iter([
+        1i32, 2, // First inner list of first outer list.
+        3, 4, // Second inner list of first outer list.
+        5, 6, // Third inner list of first outer list.
+        7, 8, // First inner list of second outer list.
+        9, 10, // Second inner list of second outer list.
+        11, 12, // Third inner list of second outer list.
+    ]);
+
+    let inner_fsl = FixedSizeListArray::new(
+        inner_elements.into_array(),
+        2, // Inner list size.
+        Validity::NonNullable,
+        6, // 6 inner lists total.
+    );
+
+    let outer_fsl = FixedSizeListArray::new(
+        inner_fsl.into_array(),
+        3, // Outer list size (3 inner lists per outer list).
+        Validity::NonNullable,
+        2, // 2 outer lists.
+    );
+
+    // Filter to keep only the second outer list.
+    let mask = Mask::from(BooleanBuffer::from(vec![false, true]));
+    let filtered = filter(outer_fsl.as_ref(), &mask).unwrap();
+    let filtered_outer = filtered.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_outer.len(), 1);
+    assert_eq!(filtered_outer.list_size(), 3);
+
+    // The inner array should also be filtered appropriately.
+    let filtered_inner = filtered_outer.elements().as_::<FixedSizeListVTable>();
+    assert_eq!(filtered_inner.len(), 3);
+    assert_eq!(filtered_inner.list_size(), 2);
+
+    // Check the actual values.
+    let inner_list_0 = filtered_inner.fixed_size_list_at(0);
+    assert_eq!(inner_list_0.scalar_at(0), 7i32.into());
+    assert_eq!(inner_list_0.scalar_at(1), 8i32.into());
+
+    let inner_list_1 = filtered_inner.fixed_size_list_at(1);
+    assert_eq!(inner_list_1.scalar_at(0), 9i32.into());
+    assert_eq!(inner_list_1.scalar_at(1), 10i32.into());
+
+    let inner_list_2 = filtered_inner.fixed_size_list_at(2);
+    assert_eq!(inner_list_2.scalar_at(0), 11i32.into());
+    assert_eq!(inner_list_2.scalar_at(1), 12i32.into());
+}
+
+#[test]
+fn test_filter_mask_types() {
+    let elements = PrimitiveArray::from_iter([1u32, 2, 3, 4, 5, 6]);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 2, Validity::NonNullable, 3);
+
+    // Test with Mask::AllTrue.
+    let mask = Mask::AllTrue(3);
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    assert_eq!(filtered.len(), 3);
+
+    // Test with Mask::AllFalse.
+    let mask = Mask::AllFalse(3);
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    assert_eq!(filtered.len(), 0);
+
+    // Test with Mask::Values.
+    let mask = Mask::from(BooleanBuffer::from(vec![true, true, false]));
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    assert_eq!(filtered.len(), 2);
+}
+
+#[test]
+fn test_filter_preserves_dtype() {
+    let elements = PrimitiveArray::from_iter([1.5f32, 2.5, 3.5, 4.5]);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 2, Validity::AllValid, 2);
+
+    let mask = Mask::from(BooleanBuffer::from(vec![true, false]));
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
+
+    // Check that the dtype is preserved.
+    assert!(matches!(
+        filtered_fsl.dtype(),
+        DType::FixedSizeList(elem_dtype, 2, Nullability::Nullable)
+            if matches!(elem_dtype.as_ref(), DType::Primitive(PType::F32, Nullability::NonNullable))
+    ));
+}
+
+// Conformance tests using rstest for various array configurations.
+#[rstest]
+#[case(create_fsl_i32(SMALL_SIZE))]
+#[case(create_fsl_f64(SMALL_SIZE))]
+#[case(create_fsl_nullable(SMALL_SIZE))]
+#[case(create_fsl_i32(MEDIUM_SIZE))]
+#[case(create_fsl_f64(MEDIUM_SIZE))]
+#[case(create_fsl_nullable(MEDIUM_SIZE))]
+#[case(create_fsl_i32(LARGE_SIZE))]
+#[case(create_fsl_mixed_nulls())]
+#[case(create_fsl_single_element())]
+#[case(create_fsl_empty())]
+fn test_filter_fsl_conformance(#[case] array: ArrayRef) {
+    test_filter_conformance(array.as_ref());
+}
+
+// Helper functions for creating test arrays.
+fn create_fsl_i32(num_lists: usize) -> ArrayRef {
+    let list_size = 3u32;
+    let elements: Vec<i32> = (0..(num_lists * list_size as usize))
+        .map(|i| i32::try_from(i).unwrap())
+        .collect();
+    let elements = PrimitiveArray::from_iter(elements);
+    FixedSizeListArray::new(
+        elements.into_array(),
+        list_size,
+        Validity::NonNullable,
+        num_lists,
+    )
+    .into_array()
+}
+
+fn create_fsl_f64(num_lists: usize) -> ArrayRef {
+    let list_size = 4u32;
+    let elements: Vec<f64> = (0..(num_lists * list_size as usize))
+        .map(|i| i as f64 * 0.5)
+        .collect();
+    let elements = PrimitiveArray::from_iter(elements);
+    FixedSizeListArray::new(
+        elements.into_array(),
+        list_size,
+        Validity::NonNullable,
+        num_lists,
+    )
+    .into_array()
+}
+
+fn create_fsl_nullable(num_lists: usize) -> ArrayRef {
+    let list_size = 2u32;
+    let elements: Vec<Option<i32>> = (0..(num_lists * list_size as usize))
+        .map(|i| {
+            if i % 5 == 0 {
+                None
+            } else {
+                Some(i32::try_from(i).unwrap())
+            }
+        })
+        .collect();
+    let elements = PrimitiveArray::from_option_iter(elements);
+
+    let validity = Validity::from_iter((0..num_lists).map(|i| i % 3 != 0));
+
+    FixedSizeListArray::new(elements.into_array(), list_size, validity, num_lists).into_array()
+}
+
+fn create_fsl_mixed_nulls() -> ArrayRef {
+    let elements =
+        PrimitiveArray::from_option_iter([Some(1i32), None, Some(3), Some(4), None, Some(6)]);
+    let validity = Validity::from_iter([true, false, true]);
+    FixedSizeListArray::new(elements.into_array(), 2, validity, 3).into_array()
+}
+
+fn create_fsl_single_element() -> ArrayRef {
+    let elements = PrimitiveArray::from_iter([100u64, 200, 300, 400, 500]);
+    FixedSizeListArray::new(elements.into_array(), 5, Validity::NonNullable, 1).into_array()
+}
+
+fn create_fsl_empty() -> ArrayRef {
+    let elements = PrimitiveArray::empty::<f32>(Nullability::NonNullable);
+    FixedSizeListArray::new(elements.into_array(), 3, Validity::NonNullable, 0).into_array()
+}
+
+#[test]
+fn test_complex_filter_pattern() {
+    // Create a larger array to test complex patterns.
+    let elements = PrimitiveArray::from_iter((0..30i32).collect::<Vec<_>>());
+    let fsl = FixedSizeListArray::new(elements.into_array(), 3, Validity::NonNullable, 10);
+
+    // Complex mask pattern: [T, T, F, T, F, F, T, T, T, F].
+    let mask = Mask::from(BooleanBuffer::from(vec![
+        true, true, false, true, false, false, true, true, true, false,
+    ]));
+
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_fsl.len(), 6);
+    assert_eq!(filtered_fsl.list_size(), 3);
+    assert_eq!(filtered_fsl.elements().len(), 18);
+
+    // Verify the filtered lists are correct.
+    // Original indices kept: 0, 1, 3, 6, 7, 8.
+    let expected_starts = [0i32, 3, 9, 18, 21, 24];
+    for (i, &start) in expected_starts.iter().enumerate() {
+        let list = filtered_fsl.fixed_size_list_at(i);
+        assert_eq!(list.scalar_at(0), (start).into());
+        assert_eq!(list.scalar_at(1), (start + 1).into());
+        assert_eq!(list.scalar_at(2), (start + 2).into());
+    }
+}
+
+#[test]
+fn test_filter_large_list_size() {
+    // Test with a large list size.
+    let list_size = 100u32;
+    let num_lists = 5;
+    let elements: Vec<i64> = (0..(num_lists * list_size as usize))
+        .map(|i| i as i64)
+        .collect();
+    let elements = PrimitiveArray::from_iter(elements);
+    let fsl = FixedSizeListArray::new(
+        elements.into_array(),
+        list_size,
+        Validity::NonNullable,
+        num_lists,
+    );
+
+    let mask = Mask::from(BooleanBuffer::from(vec![false, true, false, true, true]));
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_fsl.len(), 3);
+    assert_eq!(filtered_fsl.list_size(), list_size);
+    assert_eq!(filtered_fsl.elements().len(), 3 * list_size as usize);
+
+    // Check that the correct lists were kept (indices 1, 3, 4).
+    let list_0 = filtered_fsl.fixed_size_list_at(0);
+    assert_eq!(list_0.scalar_at(0), 100i64.into()); // Start of original list 1.
+
+    let list_1 = filtered_fsl.fixed_size_list_at(1);
+    assert_eq!(list_1.scalar_at(0), 300i64.into()); // Start of original list 3.
+
+    let list_2 = filtered_fsl.fixed_size_list_at(2);
+    assert_eq!(list_2.scalar_at(0), 400i64.into()); // Start of original list 4.
+}
+
+#[test]
+fn test_filter_degenerate_with_nulls() {
+    // FSL with list_size == 0 and mixed validity (some null, some valid empty lists).
+    let elements = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
+    let validity = Validity::from_iter([true, false, true, true, false]);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 0, validity, 5);
+
+    // Filter to keep indices 0, 2, 3 (keeping both null and non-null empty lists).
+    let mask = Mask::from(BooleanBuffer::from(vec![true, false, true, true, false]));
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_fsl.len(), 3);
+    assert_eq!(filtered_fsl.list_size(), 0);
+    assert_eq!(filtered_fsl.elements().len(), 0);
+
+    // Check that validity is preserved correctly.
+    // Original validity: [true, false, true, true, false]
+    // After filter with mask [true, false, true, true, false]: [true, true, true]
+    assert!(!filtered_fsl.scalar_at(0).is_null()); // Valid empty list.
+    assert!(!filtered_fsl.scalar_at(1).is_null()); // Valid empty list.
+    assert!(!filtered_fsl.scalar_at(2).is_null()); // Valid empty list.
+}
+
+#[test]
+fn test_filter_degenerate_all_null() {
+    // FSL with list_size == 0 where all lists are null.
+    let elements = PrimitiveArray::empty::<f64>(Nullability::NonNullable);
+    let validity = Validity::AllInvalid;
+    let fsl = FixedSizeListArray::new(elements.into_array(), 0, validity, 4);
+
+    let mask = Mask::from(BooleanBuffer::from(vec![true, true, false, true]));
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+
+    // Should return a ConstantArray of nulls.
+    let filtered_const = filtered.as_::<ConstantVTable>();
+    assert_eq!(filtered_const.len(), 3);
+    assert!(filtered_const.scalar_at(0).is_null());
+    assert!(filtered_const.scalar_at(1).is_null());
+    assert!(filtered_const.scalar_at(2).is_null());
+
+    // Verify the dtype is preserved.
+    assert!(matches!(
+        filtered.dtype(),
+        DType::FixedSizeList(elem_dtype, 0, Nullability::Nullable)
+            if matches!(elem_dtype.as_ref(), DType::Primitive(PType::F64, Nullability::NonNullable))
+    ));
+}
+
+#[test]
+fn test_filter_all_null_various_list_sizes() {
+    // Test filtering with all-null arrays of different list sizes.
+    // The implementation returns ConstantArray only when validity_mask() is Mask::AllFalse.
+
+    // Case 1: list_size == 0
+    let elements0 = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
+    let fsl0 = FixedSizeListArray::new(elements0.into_array(), 0, Validity::AllInvalid, 3);
+    let mask0 = Mask::from(BooleanBuffer::from(vec![true, false, true]));
+    let filtered0 = filter(fsl0.as_ref(), &mask0).unwrap();
+    assert_eq!(filtered0.len(), 2);
+    // Check that all elements are null (might be ConstantArray or FixedSizeListArray)
+    assert!(filtered0.scalar_at(0).is_null());
+    assert!(filtered0.scalar_at(1).is_null());
+
+    // Case 2: list_size == 1
+    let elements1 = PrimitiveArray::from_iter([1i32, 2, 3]);
+    let fsl1 = FixedSizeListArray::new(elements1.into_array(), 1, Validity::AllInvalid, 3);
+    let mask1 = Mask::from(BooleanBuffer::from(vec![false, true, true]));
+    let filtered1 = filter(fsl1.as_ref(), &mask1).unwrap();
+    assert_eq!(filtered1.len(), 2);
+    // Check that all elements are null
+    assert!(filtered1.scalar_at(0).is_null());
+    assert!(filtered1.scalar_at(1).is_null());
+
+    // Case 3: list_size == 10 (large)
+    let elements10 = PrimitiveArray::from_iter((0..50i32).collect::<Vec<_>>());
+    let fsl10 = FixedSizeListArray::new(elements10.into_array(), 10, Validity::AllInvalid, 5);
+    let mask10 = Mask::AllTrue(5);
+    let filtered10 = filter(fsl10.as_ref(), &mask10).unwrap();
+    assert_eq!(filtered10.len(), 5);
+    // Check that all elements are null
+    assert!(filtered10.scalar_at(0).is_null());
+    assert!(filtered10.scalar_at(4).is_null());
+}
+
+#[test]
+fn test_filter_to_empty_degenerate() {
+    // FSL with list_size == 0 filtered to empty result.
+    let elements = PrimitiveArray::empty::<u32>(Nullability::NonNullable);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 0, Validity::NonNullable, 5);
+
+    // Filter with all false mask.
+    let mask = Mask::AllFalse(5);
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_fsl.len(), 0);
+    assert_eq!(filtered_fsl.list_size(), 0);
+    assert_eq!(filtered_fsl.elements().len(), 0);
+
+    // Also test with mixed validity.
+    let elements2 = PrimitiveArray::empty::<u32>(Nullability::NonNullable);
+    let validity = Validity::from_iter([true, false, true, false, true]);
+    let fsl2 = FixedSizeListArray::new(elements2.into_array(), 0, validity, 5);
+
+    let mask2 = Mask::from(BooleanBuffer::from(vec![false, false, false, false, false]));
+    let filtered2 = filter(fsl2.as_ref(), &mask2).unwrap();
+    let filtered_fsl2 = filtered2.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_fsl2.len(), 0);
+    assert_eq!(filtered_fsl2.list_size(), 0);
+}
+
+#[test]
+fn test_mask_expansion_threshold_boundary() {
+    // Test with list_size == 8 (the FSL_SPARSE_MASK_LIST_SIZE_THRESHOLD).
+    let list_size = 8u32;
+    let num_lists = 100;
+    let elements: Vec<i32> = (0..(num_lists * list_size as usize))
+        .map(|i| i32::try_from(i).unwrap())
+        .collect();
+    let elements = PrimitiveArray::from_iter(elements);
+    let fsl = FixedSizeListArray::new(
+        elements.into_array(),
+        list_size,
+        Validity::NonNullable,
+        num_lists,
+    );
+
+    // Test with very sparse mask (density < 0.1).
+    let mut sparse_mask = vec![false; num_lists];
+    sparse_mask[5] = true;
+    sparse_mask[25] = true;
+    sparse_mask[75] = true;
+    let mask = Mask::from(BooleanBuffer::from(sparse_mask));
+
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_fsl.len(), 3);
+    assert_eq!(filtered_fsl.list_size(), list_size);
+    assert_eq!(filtered_fsl.elements().len(), 3 * list_size as usize);
+
+    // Verify correct elements were kept.
+    let first = filtered_fsl.fixed_size_list_at(0);
+    assert_eq!(first.scalar_at(0), (5i32 * list_size as i32).into());
+
+    let second = filtered_fsl.fixed_size_list_at(1);
+    assert_eq!(second.scalar_at(0), (25i32 * list_size as i32).into());
+
+    let third = filtered_fsl.fixed_size_list_at(2);
+    assert_eq!(third.scalar_at(0), (75i32 * list_size as i32).into());
+
+    // Test with list_size == 7 (just below threshold).
+    let list_size_7 = 7u32;
+    let elements7: Vec<i32> = (0..(num_lists * list_size_7 as usize))
+        .map(|i| i32::try_from(i).unwrap())
+        .collect();
+    let elements7 = PrimitiveArray::from_iter(elements7);
+    let fsl7 = FixedSizeListArray::new(
+        elements7.into_array(),
+        list_size_7,
+        Validity::NonNullable,
+        num_lists,
+    );
+
+    let filtered7 = filter(fsl7.as_ref(), &mask).unwrap();
+    let filtered_fsl7 = filtered7.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_fsl7.len(), 3);
+    assert_eq!(filtered_fsl7.list_size(), list_size_7);
+}
+
+#[test]
+fn test_nested_degenerate_filter() {
+    // Case 1: Inner FSL has list_size == 0.
+    let inner_elements = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
+    let inner_fsl = FixedSizeListArray::new(
+        inner_elements.into_array(),
+        0, // Inner list size is 0.
+        Validity::NonNullable,
+        6, // 6 empty inner lists.
+    );
+
+    let outer_fsl = FixedSizeListArray::new(
+        inner_fsl.into_array(),
+        3, // Each outer list contains 3 inner lists.
+        Validity::NonNullable,
+        2, // 2 outer lists.
+    );
+
+    let mask = Mask::from(BooleanBuffer::from(vec![false, true]));
+    let filtered = filter(outer_fsl.as_ref(), &mask).unwrap();
+    let filtered_outer = filtered.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_outer.len(), 1);
+    assert_eq!(filtered_outer.list_size(), 3);
+
+    let filtered_inner = filtered_outer.elements().as_::<FixedSizeListVTable>();
+    assert_eq!(filtered_inner.len(), 3);
+    assert_eq!(filtered_inner.list_size(), 0);
+    assert_eq!(filtered_inner.elements().len(), 0);
+
+    // Case 2: Outer FSL has list_size == 0.
+    // When outer list_size is 0, the elements array must also be empty.
+    let inner_elements2 = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
+    let inner_fsl2 = FixedSizeListArray::new(
+        inner_elements2.into_array(),
+        2, // Inner list would have size 2, but there are 0 of them.
+        Validity::NonNullable,
+        0, // 0 inner lists since outer list_size is 0.
+    );
+
+    let outer_fsl2 = FixedSizeListArray::new(
+        inner_fsl2.into_array(),
+        0, // Outer list size is 0.
+        Validity::NonNullable,
+        5, // 5 outer lists (each containing 0 inner lists).
+    );
+
+    let mask2 = Mask::from(BooleanBuffer::from(vec![true, true, false, true, false]));
+    let filtered2 = filter(outer_fsl2.as_ref(), &mask2).unwrap();
+    let filtered_outer2 = filtered2.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_outer2.len(), 3);
+    assert_eq!(filtered_outer2.list_size(), 0);
+    // Elements should be an empty FSL array.
+    assert_eq!(filtered_outer2.elements().len(), 0);
+}
+
+#[test]
+fn test_large_degenerate_array() {
+    // Large array with list_size == 0.
+    let num_lists = 10000;
+    let elements = PrimitiveArray::empty::<i64>(Nullability::NonNullable);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 0, Validity::NonNullable, num_lists);
+
+    // Create a selection mask that keeps every 3rd element.
+    let mask_vec: Vec<bool> = (0..num_lists).map(|i| i % 3 == 0).collect();
+    let mask = Mask::from(BooleanBuffer::from(mask_vec));
+
+    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered_fsl = filtered.as_::<FixedSizeListVTable>();
+
+    let expected_len = num_lists / 3 + if num_lists % 3 > 0 { 1 } else { 0 };
+    assert_eq!(filtered_fsl.len(), expected_len);
+    assert_eq!(filtered_fsl.list_size(), 0);
+    assert_eq!(filtered_fsl.elements().len(), 0);
+
+    // Also test with nullability.
+    let elements2 = PrimitiveArray::empty::<i64>(Nullability::NonNullable);
+    let validity = Validity::from_iter((0..num_lists).map(|i| i % 7 != 0));
+    let fsl2 = FixedSizeListArray::new(elements2.into_array(), 0, validity, num_lists);
+
+    let filtered2 = filter(fsl2.as_ref(), &mask).unwrap();
+    let filtered_fsl2 = filtered2.as_::<FixedSizeListVTable>();
+
+    assert_eq!(filtered_fsl2.len(), expected_len);
+    assert_eq!(filtered_fsl2.list_size(), 0);
+}
+
+#[test]
+fn test_degenerate_all_mask_types() {
+    // Test degenerate arrays with different mask types.
+    let elements = PrimitiveArray::empty::<u16>(Nullability::NonNullable);
+    let validity = Validity::from_iter([true, false, true]);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 0, validity, 3);
+
+    // Test with Mask::AllTrue.
+    let mask_all_true = Mask::AllTrue(3);
+    let filtered_true = filter(fsl.as_ref(), &mask_all_true).unwrap();
+    let fsl_true = filtered_true.as_::<FixedSizeListVTable>();
+    assert_eq!(fsl_true.len(), 3);
+    assert!(!fsl_true.scalar_at(0).is_null());
+    assert!(fsl_true.scalar_at(1).is_null());
+    assert!(!fsl_true.scalar_at(2).is_null());
+
+    // Test with Mask::AllFalse.
+    let mask_all_false = Mask::AllFalse(3);
+    let filtered_false = filter(fsl.as_ref(), &mask_all_false).unwrap();
+    let fsl_false = filtered_false.as_::<FixedSizeListVTable>();
+    assert_eq!(fsl_false.len(), 0);
+
+    // Test with Mask::Values.
+    let mask_values = Mask::from(BooleanBuffer::from(vec![false, true, true]));
+    let filtered_values = filter(fsl.as_ref(), &mask_values).unwrap();
+    let fsl_values = filtered_values.as_::<FixedSizeListVTable>();
+    assert_eq!(fsl_values.len(), 2);
+    assert!(fsl_values.scalar_at(0).is_null()); // Second element was null.
+    assert!(!fsl_values.scalar_at(1).is_null()); // Third element was valid.
+}

--- a/vortex-array/src/arrays/fixed_size_list/tests/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/mod.rs
@@ -3,5 +3,6 @@
 
 mod basic;
 mod degenerate;
+mod filter;
 mod nested;
 mod nullability;

--- a/vortex-array/src/arrays/fixed_size_list/tests/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/mod.rs
@@ -6,3 +6,4 @@ mod degenerate;
 mod filter;
 mod nested;
 mod nullability;
+mod take;

--- a/vortex-array/src/arrays/fixed_size_list/tests/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/take.rs
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::{DType, Nullability, PType};
+use vortex_scalar::Scalar;
+
+use crate::arrays::{FixedSizeListArray, FixedSizeListVTable, PrimitiveArray};
+use crate::builders::{ArrayBuilder, FixedSizeListBuilder};
+use crate::compute::take;
+use crate::validity::Validity;
+use crate::{Array, IntoArray};
+
+#[test]
+fn test_take_basic() {
+    // Create a FSL array with 3 lists, each containing 2 elements.
+    let elements = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5, 6]);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 2, Validity::NonNullable, 3);
+
+    // Take indices [2, 0, 1].
+    let indices = PrimitiveArray::from_iter([2u32, 0, 1]);
+    let result = take(fsl.as_ref(), indices.as_ref()).unwrap();
+    let result_fsl = result.as_::<FixedSizeListVTable>();
+
+    assert_eq!(result_fsl.len(), 3);
+    assert_eq!(result_fsl.list_size(), 2);
+
+    // First list should be the original third list [5, 6].
+    let first = result_fsl.fixed_size_list_at(0);
+    assert_eq!(first.scalar_at(0), 5i32.into());
+    assert_eq!(first.scalar_at(1), 6i32.into());
+
+    // Second list should be the original first list [1, 2].
+    let second = result_fsl.fixed_size_list_at(1);
+    assert_eq!(second.scalar_at(0), 1i32.into());
+    assert_eq!(second.scalar_at(1), 2i32.into());
+
+    // Third list should be the original second list [3, 4].
+    let third = result_fsl.fixed_size_list_at(2);
+    assert_eq!(third.scalar_at(0), 3i32.into());
+    assert_eq!(third.scalar_at(1), 4i32.into());
+}
+
+#[test]
+fn test_take_with_duplicates() {
+    // Create a FSL array with 2 lists, each containing 3 elements.
+    let elements = PrimitiveArray::from_iter([1.0f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 3, Validity::NonNullable, 2);
+
+    // Take indices [0, 0, 1, 1, 0] - duplicating lists.
+    let indices = PrimitiveArray::from_iter([0i32, 0, 1, 1, 0]);
+    let result = take(fsl.as_ref(), indices.as_ref()).unwrap();
+    let result_fsl = result.as_::<FixedSizeListVTable>();
+
+    assert_eq!(result_fsl.len(), 5);
+    assert_eq!(result_fsl.list_size(), 3);
+
+    // Verify the lists are correctly duplicated.
+    assert_eq!(result_fsl.scalar_at(0), fsl.scalar_at(0));
+    assert_eq!(result_fsl.scalar_at(1), fsl.scalar_at(0));
+    assert_eq!(result_fsl.scalar_at(2), fsl.scalar_at(1));
+    assert_eq!(result_fsl.scalar_at(3), fsl.scalar_at(1));
+    assert_eq!(result_fsl.scalar_at(4), fsl.scalar_at(0));
+}
+
+#[test]
+fn test_take_empty_indices() {
+    let elements = PrimitiveArray::from_iter([1i32, 2, 3, 4]);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 2, Validity::NonNullable, 2);
+
+    // Take with empty indices.
+    let indices = PrimitiveArray::from_iter(Vec::<u32>::new());
+    let result = take(fsl.as_ref(), indices.as_ref()).unwrap();
+    let result_fsl = result.as_::<FixedSizeListVTable>();
+
+    assert_eq!(result_fsl.len(), 0);
+    assert_eq!(result_fsl.list_size(), 2);
+    assert_eq!(result_fsl.elements().len(), 0);
+}
+
+#[test]
+fn test_take_single_index() {
+    let elements = PrimitiveArray::from_iter([10i64, 20, 30, 40, 50, 60]);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 2, Validity::NonNullable, 3);
+
+    // Take a single index [1].
+    let indices = PrimitiveArray::from_iter([1u64]);
+    let result = take(fsl.as_ref(), indices.as_ref()).unwrap();
+    let result_fsl = result.as_::<FixedSizeListVTable>();
+
+    assert_eq!(result_fsl.len(), 1);
+    assert_eq!(result_fsl.list_size(), 2);
+
+    let list = result_fsl.fixed_size_list_at(0);
+    assert_eq!(list.scalar_at(0), 30i64.into());
+    assert_eq!(list.scalar_at(1), 40i64.into());
+}
+
+#[test]
+fn test_take_with_null_indices() {
+    let elements = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5, 6]);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 2, Validity::NonNullable, 3);
+
+    // Create indices with nulls: [1, null, 0].
+    let indices = PrimitiveArray::from_option_iter([Some(1u32), None, Some(0)]);
+    let result = take(fsl.as_ref(), indices.as_ref()).unwrap();
+    let result_fsl = result.as_::<FixedSizeListVTable>();
+
+    assert_eq!(result_fsl.len(), 3);
+    assert_eq!(result_fsl.list_size(), 2);
+
+    // First list should be [3, 4].
+    assert!(!result_fsl.scalar_at(0).is_null());
+    let first = result_fsl.fixed_size_list_at(0);
+    assert_eq!(first.scalar_at(0), 3i32.into());
+    assert_eq!(first.scalar_at(1), 4i32.into());
+
+    // Second list should be null.
+    assert!(result_fsl.scalar_at(1).is_null());
+
+    // Third list should be [1, 2].
+    assert!(!result_fsl.scalar_at(2).is_null());
+    let third = result_fsl.fixed_size_list_at(2);
+    assert_eq!(third.scalar_at(0), 1i32.into());
+    assert_eq!(third.scalar_at(1), 2i32.into());
+}
+
+#[test]
+fn test_take_nullable_array() {
+    // Create a nullable FSL array where the second list is null.
+    let mut builder = FixedSizeListBuilder::with_capacity(
+        DType::Primitive(PType::I32, Nullability::NonNullable).into(),
+        2,
+        Nullability::Nullable,
+        3,
+    );
+
+    builder
+        .append_value(
+            Scalar::list(
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                vec![1i32.into(), 2i32.into()],
+                Nullability::NonNullable,
+            )
+            .as_list(),
+        )
+        .unwrap();
+    builder.append_null();
+    builder
+        .append_value(
+            Scalar::list(
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                vec![5i32.into(), 6i32.into()],
+                Nullability::NonNullable,
+            )
+            .as_list(),
+        )
+        .unwrap();
+
+    let fsl = builder.finish();
+
+    // Take indices [2, 1, 0].
+    let indices = PrimitiveArray::from_iter([2u32, 1, 0]);
+    let result = take(fsl.as_ref(), indices.as_ref()).unwrap();
+    let result_fsl = result.as_::<FixedSizeListVTable>();
+
+    assert_eq!(result_fsl.len(), 3);
+
+    // First result should be the third list [5, 6].
+    assert!(!result_fsl.scalar_at(0).is_null());
+
+    // Second result should be null (original second list).
+    assert!(result_fsl.scalar_at(1).is_null());
+
+    // Third result should be the first list [1, 2].
+    assert!(!result_fsl.scalar_at(2).is_null());
+}
+
+#[test]
+fn test_take_nullable_array_with_null_indices() {
+    // Create a nullable FSL array.
+    let mut builder = FixedSizeListBuilder::with_capacity(
+        DType::Primitive(PType::I32, Nullability::NonNullable).into(),
+        2,
+        Nullability::Nullable,
+        3,
+    );
+
+    builder
+        .append_value(
+            Scalar::list(
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                vec![1i32.into(), 2i32.into()],
+                Nullability::NonNullable,
+            )
+            .as_list(),
+        )
+        .unwrap();
+    builder.append_null();
+    builder
+        .append_value(
+            Scalar::list(
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                vec![5i32.into(), 6i32.into()],
+                Nullability::NonNullable,
+            )
+            .as_list(),
+        )
+        .unwrap();
+
+    let fsl = builder.finish();
+
+    // Create indices with nulls: [0, null, 1, 2].
+    let indices = PrimitiveArray::from_option_iter([Some(0u32), None, Some(1), Some(2)]);
+    let result = take(fsl.as_ref(), indices.as_ref()).unwrap();
+    let result_fsl = result.as_::<FixedSizeListVTable>();
+
+    assert_eq!(result_fsl.len(), 4);
+
+    // First result should be [1, 2].
+    assert!(!result_fsl.scalar_at(0).is_null());
+
+    // Second result should be null (null index).
+    assert!(result_fsl.scalar_at(1).is_null());
+
+    // Third result should be null (array's second element is null).
+    assert!(result_fsl.scalar_at(2).is_null());
+
+    // Fourth result should be [5, 6].
+    assert!(!result_fsl.scalar_at(3).is_null());
+}
+
+#[test]
+fn test_take_degenerate_list() {
+    // Create a degenerate FSL array with list_size = 0.
+    let elements = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 0, Validity::NonNullable, 5);
+
+    // Take indices [3, 1, 4, 0, 2].
+    let indices = PrimitiveArray::from_iter([3u32, 1, 4, 0, 2]);
+    let result = take(fsl.as_ref(), indices.as_ref()).unwrap();
+    let result_fsl = result.as_::<FixedSizeListVTable>();
+
+    assert_eq!(result_fsl.len(), 5);
+    assert_eq!(result_fsl.list_size(), 0);
+    assert_eq!(result_fsl.elements().len(), 0);
+}
+
+#[test]
+fn test_take_degenerate_list_with_nulls() {
+    // Create a nullable degenerate FSL array where some lists are null.
+    let elements = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
+    let validity = Validity::from_iter([true, false, true, true, false]);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 0, validity, 5);
+
+    // Take indices [1, 3, null, 0].
+    let indices = PrimitiveArray::from_option_iter([Some(1u32), Some(3), None, Some(0)]);
+    let result = take(fsl.as_ref(), indices.as_ref()).unwrap();
+    let result_fsl = result.as_::<FixedSizeListVTable>();
+
+    assert_eq!(result_fsl.len(), 4);
+    assert_eq!(result_fsl.list_size(), 0);
+    assert_eq!(result_fsl.elements().len(), 0);
+
+    // First result should be null (index 1 is null in original).
+    assert!(result_fsl.scalar_at(0).is_null());
+
+    // Second result should not be null (index 3 is valid in original).
+    assert!(!result_fsl.scalar_at(1).is_null());
+
+    // Third result should be null (null index).
+    assert!(result_fsl.scalar_at(2).is_null());
+
+    // Fourth result should not be null (index 0 is valid in original).
+    assert!(!result_fsl.scalar_at(3).is_null());
+}
+
+#[test]
+fn test_take_large_list_size() {
+    // Create a FSL array with large list size.
+    let elements = PrimitiveArray::from_iter(0i32..30);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 10, Validity::NonNullable, 3);
+
+    // Take indices [2, 0].
+    let indices = PrimitiveArray::from_iter([2u16, 0]);
+    let result = take(fsl.as_ref(), indices.as_ref()).unwrap();
+    let result_fsl = result.as_::<FixedSizeListVTable>();
+
+    assert_eq!(result_fsl.len(), 2);
+    assert_eq!(result_fsl.list_size(), 10);
+
+    // First list should be [20..30].
+    let first = result_fsl.fixed_size_list_at(0);
+    for i in 0..10i32 {
+        assert_eq!(first.scalar_at(i as usize), (20 + i).into());
+    }
+
+    // Second list should be [0..10].
+    let second = result_fsl.fixed_size_list_at(1);
+    for i in 0..10i32 {
+        assert_eq!(second.scalar_at(i as usize), i.into());
+    }
+}
+
+#[test]
+fn test_take_all_indices() {
+    // Create a FSL array.
+    let elements = PrimitiveArray::from_iter([1u8, 2, 3, 4, 5, 6, 7, 8]);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 2, Validity::NonNullable, 4);
+
+    // Take all indices in order [0, 1, 2, 3].
+    let indices = PrimitiveArray::from_iter([0i64, 1, 2, 3]);
+    let result = take(fsl.as_ref(), indices.as_ref()).unwrap();
+    let result_fsl = result.as_::<FixedSizeListVTable>();
+
+    assert_eq!(result_fsl.len(), 4);
+    assert_eq!(result_fsl.list_size(), 2);
+
+    // Verify all lists are the same as the original.
+    for i in 0..4 {
+        assert_eq!(result_fsl.scalar_at(i), fsl.scalar_at(i));
+    }
+}
+
+#[test]
+fn test_take_reverse_order() {
+    // Create a FSL array.
+    let elements = PrimitiveArray::from_iter([100i16, 200, 300, 400, 500, 600]);
+    let fsl = FixedSizeListArray::new(elements.into_array(), 2, Validity::NonNullable, 3);
+
+    // Take indices in reverse order [2, 1, 0].
+    let indices = PrimitiveArray::from_iter([2u32, 1, 0]);
+    let result = take(fsl.as_ref(), indices.as_ref()).unwrap();
+    let result_fsl = result.as_::<FixedSizeListVTable>();
+
+    assert_eq!(result_fsl.len(), 3);
+
+    // Verify the lists are in reverse order.
+    assert_eq!(result_fsl.scalar_at(0), fsl.scalar_at(2));
+    assert_eq!(result_fsl.scalar_at(1), fsl.scalar_at(1));
+    assert_eq!(result_fsl.scalar_at(2), fsl.scalar_at(0));
+}

--- a/vortex-array/src/arrays/fixed_size_list/tests/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/take.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use rstest::rstest;
 use vortex_dtype::{DType, Nullability, PType};
 use vortex_scalar::Scalar;
 
@@ -124,154 +125,107 @@ fn test_take_with_null_indices() {
     assert_eq!(third.scalar_at(1), 2i32.into());
 }
 
-#[test]
-fn test_take_nullable_array() {
-    // Create a nullable FSL array where the second list is null.
+// Parameterized test for nullable array scenarios.
+#[rstest]
+#[case::nullable_array_basic(
+    vec![Some(vec![1i32, 2]), None, Some(vec![5, 6])],
+    vec![Some(2u32), Some(1), Some(0)],
+    vec![false, true, false] // Expected nulls
+)]
+#[case::nullable_array_with_null_indices(
+    vec![Some(vec![1i32, 2]), None, Some(vec![5, 6])],
+    vec![Some(0u32), None, Some(1), Some(2)],
+    vec![false, true, true, false] // Expected nulls
+)]
+fn test_take_nullable_arrays(
+    #[case] array_values: Vec<Option<Vec<i32>>>,
+    #[case] indices: Vec<Option<u32>>,
+    #[case] expected_nulls: Vec<bool>,
+) {
+    // Build the nullable FSL array.
+    let list_size = if let Some(Some(first)) = array_values.first() {
+        u32::try_from(first.len()).unwrap()
+    } else {
+        2 // Default size
+    };
+
     let mut builder = FixedSizeListBuilder::with_capacity(
         DType::Primitive(PType::I32, Nullability::NonNullable).into(),
-        2,
+        list_size,
         Nullability::Nullable,
-        3,
+        array_values.len(),
     );
 
-    builder
-        .append_value(
-            Scalar::list(
-                DType::Primitive(PType::I32, Nullability::NonNullable),
-                vec![1i32.into(), 2i32.into()],
-                Nullability::NonNullable,
-            )
-            .as_list(),
-        )
-        .unwrap();
-    builder.append_null();
-    builder
-        .append_value(
-            Scalar::list(
-                DType::Primitive(PType::I32, Nullability::NonNullable),
-                vec![5i32.into(), 6i32.into()],
-                Nullability::NonNullable,
-            )
-            .as_list(),
-        )
-        .unwrap();
+    for value in array_values {
+        match value {
+            Some(list) => {
+                let scalars: Vec<Scalar> = list.into_iter().map(|v| v.into()).collect();
+                builder
+                    .append_value(
+                        Scalar::list(
+                            DType::Primitive(PType::I32, Nullability::NonNullable),
+                            scalars,
+                            Nullability::NonNullable,
+                        )
+                        .as_list(),
+                    )
+                    .unwrap();
+            }
+            None => builder.append_null(),
+        }
+    }
 
     let fsl = builder.finish();
 
-    // Take indices [2, 1, 0].
-    let indices = PrimitiveArray::from_iter([2u32, 1, 0]);
-    let result = take(fsl.as_ref(), indices.as_ref()).unwrap();
+    // Create indices (with possible nulls).
+    let indices_array = PrimitiveArray::from_option_iter(indices.clone());
+    let result = take(fsl.as_ref(), indices_array.as_ref()).unwrap();
     let result_fsl = result.as_::<FixedSizeListVTable>();
 
-    assert_eq!(result_fsl.len(), 3);
+    assert_eq!(result_fsl.len(), indices.len());
 
-    // First result should be the third list [5, 6].
-    assert!(!result_fsl.scalar_at(0).is_null());
-
-    // Second result should be null (original second list).
-    assert!(result_fsl.scalar_at(1).is_null());
-
-    // Third result should be the first list [1, 2].
-    assert!(!result_fsl.scalar_at(2).is_null());
+    // Check nullability of results.
+    for (i, expected_null) in expected_nulls.iter().enumerate() {
+        assert_eq!(result_fsl.scalar_at(i).is_null(), *expected_null);
+    }
 }
 
-#[test]
-fn test_take_nullable_array_with_null_indices() {
-    // Create a nullable FSL array.
-    let mut builder = FixedSizeListBuilder::with_capacity(
-        DType::Primitive(PType::I32, Nullability::NonNullable).into(),
-        2,
-        Nullability::Nullable,
-        3,
-    );
-
-    builder
-        .append_value(
-            Scalar::list(
-                DType::Primitive(PType::I32, Nullability::NonNullable),
-                vec![1i32.into(), 2i32.into()],
-                Nullability::NonNullable,
-            )
-            .as_list(),
-        )
-        .unwrap();
-    builder.append_null();
-    builder
-        .append_value(
-            Scalar::list(
-                DType::Primitive(PType::I32, Nullability::NonNullable),
-                vec![5i32.into(), 6i32.into()],
-                Nullability::NonNullable,
-            )
-            .as_list(),
-        )
-        .unwrap();
-
-    let fsl = builder.finish();
-
-    // Create indices with nulls: [0, null, 1, 2].
-    let indices = PrimitiveArray::from_option_iter([Some(0u32), None, Some(1), Some(2)]);
-    let result = take(fsl.as_ref(), indices.as_ref()).unwrap();
-    let result_fsl = result.as_::<FixedSizeListVTable>();
-
-    assert_eq!(result_fsl.len(), 4);
-
-    // First result should be [1, 2].
-    assert!(!result_fsl.scalar_at(0).is_null());
-
-    // Second result should be null (null index).
-    assert!(result_fsl.scalar_at(1).is_null());
-
-    // Third result should be null (array's second element is null).
-    assert!(result_fsl.scalar_at(2).is_null());
-
-    // Fourth result should be [5, 6].
-    assert!(!result_fsl.scalar_at(3).is_null());
-}
-
-#[test]
-fn test_take_degenerate_list() {
+// Parameterized test for degenerate (list_size=0) cases.
+#[rstest]
+#[case::basic_degenerate(
+    Validity::NonNullable,
+    vec![Some(3u32), Some(1), Some(4), Some(0), Some(2)],
+    5,
+    vec![false; 5]
+)]
+#[case::degenerate_with_nulls(
+    Validity::from_iter([true, false, true, true, false]),
+    vec![Some(1u32), Some(3), None, Some(0)],
+    4,
+    vec![true, false, true, false] // Expected nulls based on indices
+)]
+fn test_take_degenerate_lists(
+    #[case] validity: Validity,
+    #[case] indices: Vec<Option<u32>>,
+    #[case] expected_len: usize,
+    #[case] expected_nulls: Vec<bool>,
+) {
     // Create a degenerate FSL array with list_size = 0.
     let elements = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
-    let fsl = FixedSizeListArray::new(elements.into_array(), 0, Validity::NonNullable, 5);
-
-    // Take indices [3, 1, 4, 0, 2].
-    let indices = PrimitiveArray::from_iter([3u32, 1, 4, 0, 2]);
-    let result = take(fsl.as_ref(), indices.as_ref()).unwrap();
-    let result_fsl = result.as_::<FixedSizeListVTable>();
-
-    assert_eq!(result_fsl.len(), 5);
-    assert_eq!(result_fsl.list_size(), 0);
-    assert_eq!(result_fsl.elements().len(), 0);
-}
-
-#[test]
-fn test_take_degenerate_list_with_nulls() {
-    // Create a nullable degenerate FSL array where some lists are null.
-    let elements = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
-    let validity = Validity::from_iter([true, false, true, true, false]);
     let fsl = FixedSizeListArray::new(elements.into_array(), 0, validity, 5);
 
-    // Take indices [1, 3, null, 0].
-    let indices = PrimitiveArray::from_option_iter([Some(1u32), Some(3), None, Some(0)]);
-    let result = take(fsl.as_ref(), indices.as_ref()).unwrap();
+    let indices_array = PrimitiveArray::from_option_iter(indices);
+    let result = take(fsl.as_ref(), indices_array.as_ref()).unwrap();
     let result_fsl = result.as_::<FixedSizeListVTable>();
 
-    assert_eq!(result_fsl.len(), 4);
+    assert_eq!(result_fsl.len(), expected_len);
     assert_eq!(result_fsl.list_size(), 0);
     assert_eq!(result_fsl.elements().len(), 0);
 
-    // First result should be null (index 1 is null in original).
-    assert!(result_fsl.scalar_at(0).is_null());
-
-    // Second result should not be null (index 3 is valid in original).
-    assert!(!result_fsl.scalar_at(1).is_null());
-
-    // Third result should be null (null index).
-    assert!(result_fsl.scalar_at(2).is_null());
-
-    // Fourth result should not be null (index 0 is valid in original).
-    assert!(!result_fsl.scalar_at(3).is_null());
+    // Check nullability of results.
+    for (i, expected_null) in expected_nulls.iter().enumerate() {
+        assert_eq!(result_fsl.scalar_at(i).is_null(), *expected_null);
+    }
 }
 
 #[test]

--- a/vortex-array/src/arrays/list/compute/cast.rs
+++ b/vortex-array/src/arrays/list/compute/cast.rs
@@ -15,11 +15,6 @@ impl CastKernel for ListVTable {
             return Ok(None);
         };
 
-        // The list elements could technically be from either `FixedSizeList` or `List`.
-        if dtype.is_fixed_size_list() {
-            return Ok(None);
-        }
-
         let validity = array
             .validity()
             .clone()

--- a/vortex-array/src/arrays/list/compute/cast.rs
+++ b/vortex-array/src/arrays/list/compute/cast.rs
@@ -15,6 +15,11 @@ impl CastKernel for ListVTable {
             return Ok(None);
         };
 
+        // The list elements could technically be from either `FixedSizeList` or `List`.
+        if dtype.is_fixed_size_list() {
+            return Ok(None);
+        }
+
         let validity = array
             .validity()
             .clone()

--- a/vortex-array/src/arrays/list/compute/filter.rs
+++ b/vortex-array/src/arrays/list/compute/filter.rs
@@ -68,102 +68,68 @@ fn compute_filtered_elements_and_offsets<O: NativePType + AsPrimitive<usize> + A
         .vortex_expect("`AllTrue` and `AllFalse` are handled by filter entry point");
     let true_count = selection_mask.true_count();
 
+    let mut new_offsets = BufferMut::<O>::with_capacity(true_count + 1);
+    let mut new_mask_builder = BooleanBufferBuilder::new(elements.len());
+    let mut next_offset: O = O::zero(); // Offsets always start at zero.
+
+    new_offsets.push(next_offset);
+
     // Choose the optimal iteration strategy based on selection mask density.
-    // Both paths build a `BooleanBuffer` for the element mask (as opposed to creating a mask from
-    // indices or slices since we don't know how dense the mask will be).
     match values.threshold_iter(LIST_SELECTION_MASK_DENSITY_THRESHOLD) {
         MaskIter::Slices(slices) => {
-            compute_filtered_elements_and_offsets_slices(elements, offsets, slices, true_count)
+            // Dense iteration: process ranges of consecutive selected lists.
+            for &(start, end) in slices {
+                // This represents `start - end` lists in the final array.
+                let elems_start = offsets[start].as_();
+                let elems_end = offsets[end].as_();
+                let elems_len = elems_end - elems_start;
+
+                // Remove any unnecessary elements before the start of the `start` list.
+                new_mask_builder.append_n(elems_start - new_mask_builder.len(), false);
+                // Keep the elements that _are_ in the list.
+                new_mask_builder.append_n(elems_len, true);
+
+                // Add the offsets for each list in this range.
+                for i in start..end {
+                    let list_len = offsets[i + 1] - offsets[i];
+                    next_offset += list_len;
+                    new_offsets.push(next_offset);
+                }
+            }
+
+            // Remove any trailing elements.
+            if new_mask_builder.len() < elements.len() {
+                new_mask_builder.append_n(elements.len() - new_mask_builder.len(), false);
+            }
         }
         MaskIter::Indices(indices) => {
-            compute_filtered_elements_and_offsets_indices(elements, offsets, indices, true_count)
+            // Sparse iteration: process individual selected lists.
+            let mut last_elem_end: usize = 0;
+
+            for &idx in indices {
+                let list_start = offsets[idx].as_();
+                let list_end = offsets[idx + 1].as_();
+                let list_len = list_end - list_start;
+
+                // Fill false values up to the start of this list.
+                if list_start > last_elem_end {
+                    new_mask_builder.append_n(list_start - last_elem_end, false);
+                }
+                // Keep the elements in this list.
+                new_mask_builder.append_n(list_len, true);
+                last_elem_end = list_end;
+
+                // Add the offset for this list.
+                let offset_len = offsets[idx + 1] - offsets[idx];
+                next_offset += offset_len;
+                new_offsets.push(next_offset);
+            }
+
+            // For sparse iteration, handle any gap after the last processed element.
+            if last_elem_end < elements.len() {
+                new_mask_builder.append_n(elements.len() - last_elem_end, false);
+            }
         }
-    }
-}
-
-/// Handles filtering when iterating over selection mask as slices (dense iteration).
-/// Builds a BooleanBuffer for the element mask.
-fn compute_filtered_elements_and_offsets_slices<O: NativePType + AsPrimitive<usize>>(
-    elements: &dyn Array,
-    offsets: &[O],
-    slices: &[(usize, usize)],
-    true_count: usize,
-) -> VortexResult<(ArrayRef, PrimitiveArray)> {
-    let mut new_offsets = BufferMut::<O>::with_capacity(true_count + 1);
-    let mut new_mask_builder = BooleanBufferBuilder::new(elements.len());
-    let mut next_offset: O = O::zero(); // Offsets always start at zero.
-
-    new_offsets.push(next_offset);
-
-    // We batch this operation for the mask builder (but not the offsets).
-    for &(start, end) in slices {
-        // This represents `start - end` lists in the final array.
-        let elems_start = offsets[start].as_();
-        let elems_end = offsets[end].as_();
-        let elems_len = elems_end - elems_start;
-
-        // Remove any unnecessary elements before the start of the `start` list.
-        new_mask_builder.append_n(elems_start - new_mask_builder.len(), false);
-        // Keep the elements that _are_ in the list.
-        new_mask_builder.append_n(elems_len, true);
-
-        // Add the offsets for each list in this range.
-        for i in start..end {
-            let list_len = offsets[i + 1] - offsets[i];
-            next_offset = next_offset + list_len;
-            new_offsets.push(next_offset);
-        }
-    }
-
-    // Remove any trailing elements.
-    new_mask_builder.append_n(elements.len() - new_mask_builder.len(), false);
-
-    // Allow the child array to filter themselves.
-    // The `Mask` can determine the best representation based on the buffer's density in the future.
-    let new_elements = filter(elements, &Mask::from_buffer(new_mask_builder.finish()))?;
-    let new_offsets = PrimitiveArray::new(new_offsets, Validity::NonNullable);
-
-    Ok((new_elements, new_offsets))
-}
-
-/// Handles filtering when iterating over selection mask as indices (sparse iteration).
-/// Builds a BooleanBuffer for the element mask.
-fn compute_filtered_elements_and_offsets_indices<O: NativePType + AsPrimitive<usize>>(
-    elements: &dyn Array,
-    offsets: &[O],
-    indices: &[usize],
-    true_count: usize,
-) -> VortexResult<(ArrayRef, PrimitiveArray)> {
-    let mut new_offsets = BufferMut::<O>::with_capacity(true_count + 1);
-    let mut new_mask_builder = BooleanBufferBuilder::new(elements.len());
-    let mut next_offset: O = O::zero(); // Offsets always start at zero.
-    let mut last_elem_end: usize = 0;
-
-    new_offsets.push(next_offset);
-
-    // For sparse masks, we iterate over individual indices.
-    for &idx in indices {
-        let list_start = offsets[idx].as_();
-        let list_end = offsets[idx + 1].as_();
-        let list_len = list_end - list_start;
-
-        // Fill false values up to the start of this list.
-        if list_start > last_elem_end {
-            new_mask_builder.append_n(list_start - last_elem_end, false);
-        }
-        // Keep the elements in this list.
-        new_mask_builder.append_n(list_len, true);
-        last_elem_end = list_end;
-
-        // Add the offset for this list.
-        let list_len = offsets[idx + 1] - offsets[idx];
-        next_offset = next_offset + list_len;
-        new_offsets.push(next_offset);
-    }
-
-    // Remove any trailing elements.
-    if last_elem_end < elements.len() {
-        new_mask_builder.append_n(elements.len() - last_elem_end, false);
     }
 
     // Allow the child array to filter themselves.

--- a/vortex-array/src/arrays/list/compute/filter.rs
+++ b/vortex-array/src/arrays/list/compute/filter.rs
@@ -49,8 +49,14 @@ impl FilterKernel for ListVTable {
             )?
         });
 
-        // TODO(connor): Use `new_unchecked` here.
-        Ok(ListArray::try_new(new_elements, new_offsets.into_array(), new_validity)?.into_array())
+        // SAFETY: Filter operation maintains all ListArray invariants:
+        // - Offsets are monotonically increasing (built correctly above).
+        // - Elements are properly filtered to match the offsets.
+        // - Validity matches the original array's nullability.
+        Ok(unsafe {
+            ListArray::new_unchecked(new_elements, new_offsets.into_array(), new_validity)
+        }
+        .into_array())
     }
 }
 
@@ -135,6 +141,8 @@ fn compute_filtered_elements_and_offsets<O: NativePType + AsPrimitive<usize> + A
     // Allow the child array to filter themselves.
     // The `Mask` can determine the best representation based on the buffer's density in the future.
     let new_elements = filter(elements, &Mask::from_buffer(new_mask_builder.finish()))?;
+
+    // TODO(connor): Use `new_unchecked` here to avoid a branch?
     let new_offsets = PrimitiveArray::new(new_offsets, Validity::NonNullable);
 
     Ok((new_elements, new_offsets))

--- a/vortex-array/src/arrays/list/compute/filter.rs
+++ b/vortex-array/src/arrays/list/compute/filter.rs
@@ -9,9 +9,8 @@ use vortex_buffer::BufferMut;
 use vortex_dtype::{NativePType, match_each_integer_ptype};
 use vortex_error::{VortexExpect, VortexResult};
 use vortex_mask::{Mask, MaskIter};
-use vortex_scalar::Scalar;
 
-use crate::arrays::{ConstantArray, ListArray, ListVTable, PrimitiveArray};
+use crate::arrays::{ListArray, ListVTable, PrimitiveArray};
 use crate::compute::{FilterKernel, FilterKernelAdapter, filter};
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
@@ -25,21 +24,15 @@ const LIST_SELECTION_MASK_DENSITY_THRESHOLD: f64 = 0.1;
 
 impl FilterKernel for ListVTable {
     fn filter(&self, array: &ListArray, selection_mask: &Mask) -> VortexResult<ArrayRef> {
-        let null_mask = array.validity_mask();
-        let new_len = selection_mask.true_count();
-
-        // If the entire array is null, then we only need to adjust the length of the array.
-        if let Mask::AllFalse(_) = null_mask {
-            return Ok(
-                ConstantArray::new(Scalar::null(array.dtype().clone()), new_len).into_array(),
-            );
-        }
-
         let elements = array.elements();
         let offsets = array.offsets.to_primitive();
 
         let new_validity = array.validity().filter(selection_mask)?;
-        debug_assert!(new_validity.maybe_len().is_none_or(|len| len == new_len));
+        debug_assert!(
+            new_validity
+                .maybe_len()
+                .is_none_or(|len| len == selection_mask.true_count())
+        );
 
         let (new_elements, new_offsets) = match_each_integer_ptype!(offsets.ptype(), |O| {
             compute_filtered_elements_and_offsets::<O>(

--- a/vortex-array/src/arrays/list/compute/filter.rs
+++ b/vortex-array/src/arrays/list/compute/filter.rs
@@ -3,12 +3,11 @@
 
 use std::ops::AddAssign;
 
-use arrow_buffer::BooleanBufferBuilder;
 use num_traits::AsPrimitive;
 use vortex_buffer::BufferMut;
 use vortex_dtype::{NativePType, match_each_integer_ptype};
 use vortex_error::{VortexExpect, VortexResult};
-use vortex_mask::Mask;
+use vortex_mask::{Mask, MaskIter};
 use vortex_scalar::Scalar;
 
 use crate::arrays::{ConstantArray, ListArray, ListVTable, PrimitiveArray};
@@ -16,6 +15,13 @@ use crate::compute::{FilterKernel, FilterKernelAdapter, filter};
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 use crate::{Array, ArrayRef, IntoArray, ToCanonical, register_kernel};
+
+/// Density threshold for choosing between indices and slices representation when filtering lists.
+///
+/// When the mask density is below this threshold, we use indices. Otherwise, we use slices.
+///
+/// Note that this is somewhat arbitrarily chosen...
+const LIST_MASK_EXPANSION_DENSITY_THRESHOLD: f64 = 0.1;
 
 impl FilterKernel for ListVTable {
     fn filter(&self, array: &ListArray, selection_mask: &Mask) -> VortexResult<ArrayRef> {
@@ -57,41 +63,97 @@ fn compute_filtered_elements_and_offsets<O: NativePType + AsPrimitive<usize> + A
     offsets: &[O],
     selection_mask: &Mask,
 ) -> VortexResult<(ArrayRef, PrimitiveArray)> {
-    let mut new_offsets = BufferMut::<O>::with_capacity(selection_mask.true_count() + 1);
-    let mut new_mask_builder = BooleanBufferBuilder::new(elements.len());
+    let values = selection_mask
+        .values()
+        .vortex_expect("`AllTrue` and `AllFalse` are handled by filter entry point");
+    let true_count = selection_mask.true_count();
+
+    // Choose the optimal iteration strategy based on mask density.
+    match values.threshold_iter(LIST_MASK_EXPANSION_DENSITY_THRESHOLD) {
+        MaskIter::Slices(slices) => {
+            compute_filtered_elements_and_offsets_dense(elements, offsets, slices, true_count)
+        }
+        MaskIter::Indices(indices) => {
+            compute_filtered_elements_and_offsets_sparse(elements, offsets, indices, true_count)
+        }
+    }
+}
+
+/// Handles filtering for dense masks (represented as slices).
+fn compute_filtered_elements_and_offsets_dense<O: NativePType + AsPrimitive<usize> + AddAssign>(
+    elements: &dyn Array,
+    offsets: &[O],
+    slices: &[(usize, usize)],
+    true_count: usize,
+) -> VortexResult<(ArrayRef, PrimitiveArray)> {
+    let mut new_offsets = BufferMut::<O>::with_capacity(true_count + 1);
+    let mut element_slices = Vec::with_capacity(slices.len());
     let mut next_offset: O = O::zero(); // Offsets always start at zero.
 
     new_offsets.push(next_offset);
 
-    // We can batch this operation for the mask builder (but not the offsets).
-    for &(start, end) in selection_mask
-        .values()
-        .vortex_expect("`AllTrue` and `AllFalse` are handled by filter entry point")
-        .slices()
-    {
+    // Collect the element ranges for each range of selected lists.
+    for &(start, end) in slices {
         // This represents `start - end` lists in the final array.
         let elems_start = offsets[start].as_();
         let elems_end = offsets[end].as_();
-        let elems_len = elems_end - elems_start;
 
-        // Remove any unnecessary elements before the start of the `start` list.
-        new_mask_builder.append_n(elems_start - new_mask_builder.len(), false);
-        // Keep the elements that _are_ in the list.
-        new_mask_builder.append_n(elems_len, true);
+        // Add this range of elements to keep (only if non-empty).
+        if elems_start < elems_end {
+            element_slices.push((elems_start, elems_end));
+        }
 
         // Add the offsets for each list in this range.
-        for i in start..end {
-            let list_len = offsets[i + 1] - offsets[i];
+        for list_idx in start..end {
+            let list_len = offsets[list_idx + 1] - offsets[list_idx];
             next_offset += list_len;
             new_offsets.push(next_offset);
         }
     }
 
-    // Remove any trailing elements.
-    new_mask_builder.append_n(elements.len() - new_mask_builder.len(), false);
+    // Create a mask from the collected slices.
+    let elements_mask = Mask::from_slices(elements.len(), element_slices);
 
     // Allow the child array to filter themselves.
-    let new_elements = filter(elements, &Mask::from_buffer(new_mask_builder.finish()))?;
+    let new_elements = filter(elements, &elements_mask)?;
+    let new_offsets = PrimitiveArray::new(new_offsets, Validity::NonNullable);
+
+    Ok((new_elements, new_offsets))
+}
+
+/// Handles filtering for sparse masks (represented as indices).
+fn compute_filtered_elements_and_offsets_sparse<O: NativePType + AsPrimitive<usize> + AddAssign>(
+    elements: &dyn Array,
+    offsets: &[O],
+    indices: &[usize],
+    true_count: usize,
+) -> VortexResult<(ArrayRef, PrimitiveArray)> {
+    let mut new_offsets = BufferMut::<O>::with_capacity(true_count + 1);
+    let mut element_slices = Vec::with_capacity(indices.len());
+    let mut next_offset: O = O::zero(); // Offsets always start at zero.
+
+    new_offsets.push(next_offset);
+
+    // For sparse masks, we collect the element ranges for each selected list.
+    for &list_idx in indices {
+        let elem_start = offsets[list_idx].as_();
+        let elem_end = offsets[list_idx + 1].as_();
+
+        // Add this range of elements to keep (only if non-empty).
+        if elem_start < elem_end {
+            element_slices.push((elem_start, elem_end));
+        }
+
+        let list_len = offsets[list_idx + 1] - offsets[list_idx];
+        next_offset += list_len;
+        new_offsets.push(next_offset);
+    }
+
+    // Create a mask from the collected slices.
+    let elements_mask = Mask::from_slices(elements.len(), element_slices);
+
+    // Allow the child array to filter themselves.
+    let new_elements = filter(elements, &elements_mask)?;
     let new_offsets = PrimitiveArray::new(new_offsets, Validity::NonNullable);
 
     Ok((new_elements, new_offsets))

--- a/vortex-array/src/arrays/list/compute/filter.rs
+++ b/vortex-array/src/arrays/list/compute/filter.rs
@@ -17,35 +17,38 @@ use crate::validity::Validity;
 use crate::{Array, ArrayRef, IntoArray, ToCanonical, register_kernel};
 
 impl FilterKernel for ListVTable {
-    fn filter(&self, array: &Self::Array, mask: &Mask) -> VortexResult<ArrayRef> {
+    fn filter(&self, array: &Self::Array, selection_mask: &Mask) -> VortexResult<ArrayRef> {
         let offsets = array.offsets.to_primitive();
 
+        // Check the null mask.
         match array.validity_mask() {
             Mask::AllTrue(_) => {
                 match_each_integer_ptype!(offsets.ptype(), |I| {
                     filter_all_valid::<I>(
                         offsets.as_slice::<I>(),
                         array.elements().as_ref(),
-                        mask,
+                        selection_mask,
                         array.dtype().nullability(),
                     )
                 })
             }
             Mask::AllFalse(_) => {
                 // If all array offsets are null, then the array is simply null?
-                Ok(
-                    ConstantArray::new(Scalar::null(array.dtype().clone()), mask.true_count())
-                        .into_array(),
+                Ok(ConstantArray::new(
+                    Scalar::null(array.dtype().clone()),
+                    selection_mask.true_count(),
                 )
+                .into_array())
             }
             Mask::Values(_) => {
                 // TODO(ngates): implemented null filtering
-                arrow_filter_fn(array.as_ref(), mask)
+                arrow_filter_fn(array.as_ref(), selection_mask)
             }
         }
     }
 }
 
+// TODO(connor): We can use this for the `Mask::Value` case as long as we modify the validity.
 fn filter_all_valid<I: NativePType + AsPrimitive<usize> + AddAssign>(
     offsets: &[I],
     elements: &dyn Array,

--- a/vortex-array/src/arrays/list/compute/filter.rs
+++ b/vortex-array/src/arrays/list/compute/filter.rs
@@ -6,86 +6,93 @@ use std::ops::AddAssign;
 use arrow_buffer::BooleanBufferBuilder;
 use num_traits::AsPrimitive;
 use vortex_buffer::BufferMut;
-use vortex_dtype::{NativePType, Nullability, match_each_integer_ptype};
+use vortex_dtype::{NativePType, match_each_integer_ptype};
 use vortex_error::{VortexExpect, VortexResult};
 use vortex_mask::Mask;
 use vortex_scalar::Scalar;
 
 use crate::arrays::{ConstantArray, ListArray, ListVTable, PrimitiveArray};
-use crate::compute::{FilterKernel, FilterKernelAdapter, arrow_filter_fn, filter};
+use crate::compute::{FilterKernel, FilterKernelAdapter, filter};
 use crate::validity::Validity;
+use crate::vtable::ValidityHelper;
 use crate::{Array, ArrayRef, IntoArray, ToCanonical, register_kernel};
 
 impl FilterKernel for ListVTable {
-    fn filter(&self, array: &Self::Array, selection_mask: &Mask) -> VortexResult<ArrayRef> {
+    fn filter(&self, array: &ListArray, selection_mask: &Mask) -> VortexResult<ArrayRef> {
+        let null_mask = array.validity_mask();
+        let new_len = selection_mask.true_count();
+
+        // If the entire array is null, then we only need to adjust the length of the array.
+        if let Mask::AllFalse(_) = null_mask {
+            return Ok(
+                ConstantArray::new(Scalar::null(array.dtype().clone()), new_len).into_array(),
+            );
+        }
+
+        let elements = array.elements();
         let offsets = array.offsets.to_primitive();
 
-        // Check the null mask.
-        match array.validity_mask() {
-            Mask::AllTrue(_) => {
-                match_each_integer_ptype!(offsets.ptype(), |I| {
-                    filter_all_valid::<I>(
-                        offsets.as_slice::<I>(),
-                        array.elements().as_ref(),
-                        selection_mask,
-                        array.dtype().nullability(),
-                    )
-                })
-            }
-            Mask::AllFalse(_) => {
-                // If all array offsets are null, then the array is simply null?
-                Ok(ConstantArray::new(
-                    Scalar::null(array.dtype().clone()),
-                    selection_mask.true_count(),
-                )
-                .into_array())
-            }
-            Mask::Values(_) => {
-                // TODO(ngates): implemented null filtering
-                arrow_filter_fn(array.as_ref(), selection_mask)
-            }
-        }
+        let new_validity = array.validity().filter(selection_mask)?;
+        debug_assert!(new_validity.maybe_len().is_none_or(|len| len == new_len));
+
+        let (new_elements, new_offsets) = match_each_integer_ptype!(offsets.ptype(), |O| {
+            compute_filtered_elements_and_offsets::<O>(
+                elements.as_ref(),
+                offsets.as_slice::<O>(),
+                selection_mask,
+            )?
+        });
+
+        // TODO(connor): Use `new_unchecked` here.
+        Ok(ListArray::try_new(new_elements, new_offsets.into_array(), new_validity)?.into_array())
     }
-}
-
-// TODO(connor): We can use this for the `Mask::Value` case as long as we modify the validity.
-fn filter_all_valid<I: NativePType + AsPrimitive<usize> + AddAssign>(
-    offsets: &[I],
-    elements: &dyn Array,
-    mask: &Mask,
-    nullability: Nullability,
-) -> VortexResult<ArrayRef> {
-    // We compute a new set of offsets, as well as a mask for filtering the elements.
-    let mut new_offsets = BufferMut::<I>::with_capacity(mask.true_count() + 1);
-    new_offsets.push(I::zero());
-    let mut new_offset: I = I::zero();
-
-    let mut mask_builder = BooleanBufferBuilder::new(elements.len());
-    for &(start, end) in mask
-        .values()
-        .vortex_expect("all true and all false are handled by filter entry point")
-        .slices()
-    {
-        let elem_start: usize = offsets[start].as_();
-        let elem_end: usize = offsets[end].as_();
-        let elem_len = elem_end - elem_start;
-        mask_builder.append_n(elem_start - mask_builder.len(), false);
-        mask_builder.append_n(elem_len, true);
-
-        // Add each of the new offsets into the result
-        for i in start..end {
-            let elem_len = offsets[i + 1] - offsets[i];
-            new_offset += elem_len;
-            new_offsets.push(new_offset);
-        }
-    }
-    mask_builder.append_n(elements.len() - mask_builder.len(), false);
-
-    let new_elements = filter(elements, &Mask::from_buffer(mask_builder.finish()))?;
-
-    let new_offsets = PrimitiveArray::new(new_offsets, Validity::NonNullable).into_array();
-
-    Ok(ListArray::try_new(new_elements, new_offsets, Validity::from(nullability))?.into_array())
 }
 
 register_kernel!(FilterKernelAdapter(ListVTable).lift());
+
+/// Given a selection filter mask, computes new offsets and an element array for a list array's
+/// child elements array.
+fn compute_filtered_elements_and_offsets<O: NativePType + AsPrimitive<usize> + AddAssign>(
+    elements: &dyn Array,
+    offsets: &[O],
+    selection_mask: &Mask,
+) -> VortexResult<(ArrayRef, PrimitiveArray)> {
+    let mut new_offsets = BufferMut::<O>::with_capacity(selection_mask.true_count() + 1);
+    let mut new_mask_builder = BooleanBufferBuilder::new(elements.len());
+    let mut next_offset: O = O::zero(); // Offsets always start at zero.
+
+    new_offsets.push(next_offset);
+
+    // We can batch this operation for the mask builder (but not the offsets).
+    for &(start, end) in selection_mask
+        .values()
+        .vortex_expect("`AllTrue` and `AllFalse` are handled by filter entry point")
+        .slices()
+    {
+        // This represents `start - end` lists in the final array.
+        let elems_start = offsets[start].as_();
+        let elems_end = offsets[end].as_();
+        let elems_len = elems_end - elems_start;
+
+        // Remove any unnecessary elements before the start of the `start` list.
+        new_mask_builder.append_n(elems_start - new_mask_builder.len(), false);
+        // Keep the elements that _are_ in the list.
+        new_mask_builder.append_n(elems_len, true);
+
+        // Add the offsets for each list in this range.
+        for i in start..end {
+            let list_len = offsets[i + 1] - offsets[i];
+            next_offset += list_len;
+            new_offsets.push(next_offset);
+        }
+    }
+
+    // Remove any trailing elements.
+    new_mask_builder.append_n(elements.len() - new_mask_builder.len(), false);
+
+    // Allow the child array to filter themselves.
+    let new_elements = filter(elements, &Mask::from_buffer(new_mask_builder.finish()))?;
+    let new_offsets = PrimitiveArray::new(new_offsets, Validity::NonNullable);
+
+    Ok((new_elements, new_offsets))
+}

--- a/vortex-array/src/arrays/list/compute/filter.rs
+++ b/vortex-array/src/arrays/list/compute/filter.rs
@@ -3,6 +3,7 @@
 
 use std::ops::AddAssign;
 
+use arrow_buffer::BooleanBufferBuilder;
 use num_traits::AsPrimitive;
 use vortex_buffer::BufferMut;
 use vortex_dtype::{NativePType, match_each_integer_ptype};
@@ -16,12 +17,11 @@ use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 use crate::{Array, ArrayRef, IntoArray, ToCanonical, register_kernel};
 
-/// Density threshold for choosing between indices and slices representation when filtering lists.
+/// Density threshold for choosing between indices and slices iteration for the selection mask.
 ///
-/// When the mask density is below this threshold, we use indices. Otherwise, we use slices.
-///
-/// Note that this is somewhat arbitrarily chosen...
-const LIST_MASK_EXPANSION_DENSITY_THRESHOLD: f64 = 0.1;
+/// When the mask density is below this threshold, we use indices iteration; otherwise, we use
+/// slices iteration. Note that both paths build a BooleanBuffer for the element mask.
+const LIST_SELECTION_MASK_DENSITY_THRESHOLD: f64 = 0.1;
 
 impl FilterKernel for ListVTable {
     fn filter(&self, array: &ListArray, selection_mask: &Mask) -> VortexResult<ArrayRef> {
@@ -68,92 +68,107 @@ fn compute_filtered_elements_and_offsets<O: NativePType + AsPrimitive<usize> + A
         .vortex_expect("`AllTrue` and `AllFalse` are handled by filter entry point");
     let true_count = selection_mask.true_count();
 
-    // Choose the optimal iteration strategy based on mask density.
-    match values.threshold_iter(LIST_MASK_EXPANSION_DENSITY_THRESHOLD) {
+    // Choose the optimal iteration strategy based on selection mask density.
+    // Both paths build a `BooleanBuffer` for the element mask (as opposed to creating a mask from
+    // indices or slices since we don't know how dense the mask will be).
+    match values.threshold_iter(LIST_SELECTION_MASK_DENSITY_THRESHOLD) {
         MaskIter::Slices(slices) => {
-            compute_filtered_elements_and_offsets_dense(elements, offsets, slices, true_count)
+            compute_filtered_elements_and_offsets_slices(elements, offsets, slices, true_count)
         }
         MaskIter::Indices(indices) => {
-            compute_filtered_elements_and_offsets_sparse(elements, offsets, indices, true_count)
+            compute_filtered_elements_and_offsets_indices(elements, offsets, indices, true_count)
         }
     }
 }
 
-/// Handles filtering for dense masks (represented as slices).
-fn compute_filtered_elements_and_offsets_dense<O: NativePType + AsPrimitive<usize> + AddAssign>(
+/// Handles filtering when iterating over selection mask as slices (dense iteration).
+/// Builds a BooleanBuffer for the element mask.
+fn compute_filtered_elements_and_offsets_slices<O: NativePType + AsPrimitive<usize>>(
     elements: &dyn Array,
     offsets: &[O],
     slices: &[(usize, usize)],
     true_count: usize,
 ) -> VortexResult<(ArrayRef, PrimitiveArray)> {
     let mut new_offsets = BufferMut::<O>::with_capacity(true_count + 1);
-    let mut element_slices = Vec::with_capacity(slices.len());
+    let mut new_mask_builder = BooleanBufferBuilder::new(elements.len());
     let mut next_offset: O = O::zero(); // Offsets always start at zero.
 
     new_offsets.push(next_offset);
 
-    // Collect the element ranges for each range of selected lists.
+    // We batch this operation for the mask builder (but not the offsets).
     for &(start, end) in slices {
         // This represents `start - end` lists in the final array.
         let elems_start = offsets[start].as_();
         let elems_end = offsets[end].as_();
+        let elems_len = elems_end - elems_start;
 
-        // Add this range of elements to keep (only if non-empty).
-        if elems_start < elems_end {
-            element_slices.push((elems_start, elems_end));
-        }
+        // Remove any unnecessary elements before the start of the `start` list.
+        new_mask_builder.append_n(elems_start - new_mask_builder.len(), false);
+        // Keep the elements that _are_ in the list.
+        new_mask_builder.append_n(elems_len, true);
 
         // Add the offsets for each list in this range.
-        for list_idx in start..end {
-            let list_len = offsets[list_idx + 1] - offsets[list_idx];
-            next_offset += list_len;
+        for i in start..end {
+            let list_len = offsets[i + 1] - offsets[i];
+            next_offset = next_offset + list_len;
             new_offsets.push(next_offset);
         }
     }
 
-    // Create a mask from the collected slices.
-    let elements_mask = Mask::from_slices(elements.len(), element_slices);
+    // Remove any trailing elements.
+    new_mask_builder.append_n(elements.len() - new_mask_builder.len(), false);
 
     // Allow the child array to filter themselves.
-    let new_elements = filter(elements, &elements_mask)?;
+    // The `Mask` can determine the best representation based on the buffer's density in the future.
+    let new_elements = filter(elements, &Mask::from_buffer(new_mask_builder.finish()))?;
     let new_offsets = PrimitiveArray::new(new_offsets, Validity::NonNullable);
 
     Ok((new_elements, new_offsets))
 }
 
-/// Handles filtering for sparse masks (represented as indices).
-fn compute_filtered_elements_and_offsets_sparse<O: NativePType + AsPrimitive<usize> + AddAssign>(
+/// Handles filtering when iterating over selection mask as indices (sparse iteration).
+/// Builds a BooleanBuffer for the element mask.
+fn compute_filtered_elements_and_offsets_indices<O: NativePType + AsPrimitive<usize>>(
     elements: &dyn Array,
     offsets: &[O],
     indices: &[usize],
     true_count: usize,
 ) -> VortexResult<(ArrayRef, PrimitiveArray)> {
     let mut new_offsets = BufferMut::<O>::with_capacity(true_count + 1);
-    let mut element_slices = Vec::with_capacity(indices.len());
+    let mut new_mask_builder = BooleanBufferBuilder::new(elements.len());
     let mut next_offset: O = O::zero(); // Offsets always start at zero.
+    let mut last_elem_end: usize = 0;
 
     new_offsets.push(next_offset);
 
-    // For sparse masks, we collect the element ranges for each selected list.
-    for &list_idx in indices {
-        let elem_start = offsets[list_idx].as_();
-        let elem_end = offsets[list_idx + 1].as_();
+    // For sparse masks, we iterate over individual indices.
+    for &idx in indices {
+        let list_start = offsets[idx].as_();
+        let list_end = offsets[idx + 1].as_();
+        let list_len = list_end - list_start;
 
-        // Add this range of elements to keep (only if non-empty).
-        if elem_start < elem_end {
-            element_slices.push((elem_start, elem_end));
+        // Fill false values up to the start of this list.
+        if list_start > last_elem_end {
+            new_mask_builder.append_n(list_start - last_elem_end, false);
         }
+        // Keep the elements in this list.
+        new_mask_builder.append_n(list_len, true);
+        last_elem_end = list_end;
 
-        let list_len = offsets[list_idx + 1] - offsets[list_idx];
-        next_offset += list_len;
+        // Add the offset for this list.
+        let list_len = offsets[idx + 1] - offsets[idx];
+        next_offset = next_offset + list_len;
         new_offsets.push(next_offset);
     }
 
-    // Create a mask from the collected slices.
-    let elements_mask = Mask::from_slices(elements.len(), element_slices);
+    // Remove any trailing elements.
+    if last_elem_end < elements.len() {
+        new_mask_builder.append_n(elements.len() - last_elem_end, false);
+    }
 
     // Allow the child array to filter themselves.
-    let new_elements = filter(elements, &elements_mask)?;
+    // The `Mask` can determine the best representation based on the buffer's density in the future.
+    let new_elements = filter(elements, &Mask::from_buffer(new_mask_builder.finish()))?;
     let new_offsets = PrimitiveArray::new(new_offsets, Validity::NonNullable);
 
     Ok((new_elements, new_offsets))

--- a/vortex-array/src/arrays/list/compute/is_constant.rs
+++ b/vortex-array/src/arrays/list/compute/is_constant.rs
@@ -18,6 +18,8 @@ impl IsConstantKernel for ListVTable {
 
         let manual_check_until = std::cmp::min(SMALL_ARRAY_THRESHOLD, array.len());
 
+        // We can first quickly check if all of the list lengths are equal. If not, then we know the
+        // array cannot be constant.
         let first_list_len = array.offset_at(1) - array.offset_at(0);
         for i in 1..manual_check_until {
             let current_list_len = array.offset_at(i + 1) - array.offset_at(i);
@@ -26,10 +28,13 @@ impl IsConstantKernel for ListVTable {
             }
         }
 
+        // Since we were not able to determine that this list array was **not** constant, and the
+        // cost is negligible, then don't bother doing the rest of this expensive check.
         if opts.is_negligible_cost() {
             return Ok(None);
         }
 
+        // If the array is long, do an optimistic check on the remainder of the list lengths.
         if array.len() > SMALL_ARRAY_THRESHOLD {
             // check the rest of the element lengths
             let start_offsets = array.offsets.slice(SMALL_ARRAY_THRESHOLD..array.len());
@@ -43,8 +48,13 @@ impl IsConstantKernel for ListVTable {
             }
         }
 
-        // If all lists have the same length, compare the actual list contents
-        let first_scalar = array.scalar_at(0);
+        debug_assert!(
+            array.len() > 1,
+            "precondition for `is_constant` is incorrect"
+        );
+        let first_scalar = array.scalar_at(0); // We checked the array length above.
+
+        // All lists have the same length, so compare the actual list contents.
         for i in 1..array.len() {
             let current_scalar = array.scalar_at(i);
             if current_scalar != first_scalar {

--- a/vortex-array/src/arrays/list/compute/take.rs
+++ b/vortex-array/src/arrays/list/compute/take.rs
@@ -109,16 +109,22 @@ fn _take_nullable<I: NativePType, O: OffsetPType + NativePType + PrimInt>(
     data_validity: Mask,
     indices_validity: Mask,
 ) -> VortexResult<ArrayRef> {
-    // TODO(connor): The primitive builders here have the same ptype...
     let mut new_offsets = PrimitiveBuilder::with_capacity(Nullability::NonNullable, indices.len());
+
+    // This will be the indices we push down to the child array to call `take` with.
+    //
+    // There are 2 things to note here:
+    // - We do not know how many elements we need to take from our child since lists are variable
+    //   size: thus we arbitrarily choose a capacity of `2 * # of indices`.
+    // - The type of the primitive builder needs to fit the largest offset of the (parent)
+    //   `ListArray`, so we make this `PrimitiveBuilder` generic over `O` (instead of `I`).
     let mut elements_to_take =
-        PrimitiveBuilder::with_capacity(Nullability::NonNullable, 2 * indices.len());
+        PrimitiveBuilder::<O>::with_capacity(Nullability::NonNullable, 2 * indices.len());
 
     let mut current_offset = O::zero();
     new_offsets.append_zero();
 
-    // TODO(connor): Why is this 2 x length???
-    let mut new_validity = BooleanBufferBuilder::new(2 * indices.len());
+    let mut new_validity = BooleanBufferBuilder::new(indices.len());
 
     for (idx, data_idx) in indices.iter().enumerate() {
         if !indices_validity.value(idx) {
@@ -142,7 +148,6 @@ fn _take_nullable<I: NativePType, O: OffsetPType + NativePType + PrimInt>(
 
             elements_to_take.ensure_capacity(elements_to_take.len() + additional);
             for i in 0..additional {
-                // TODO(connor): This should probably be `I::from_usize`?
                 elements_to_take
                     .append_value(start + O::from_usize(i).vortex_expect("i < additional"));
             }

--- a/vortex-array/src/arrays/list/compute/take.rs
+++ b/vortex-array/src/arrays/list/compute/take.rs
@@ -109,12 +109,15 @@ fn _take_nullable<I: NativePType, O: OffsetPType + NativePType + PrimInt>(
     data_validity: Mask,
     indices_validity: Mask,
 ) -> VortexResult<ArrayRef> {
+    // TODO(connor): The primitive builders here have the same ptype...
     let mut new_offsets = PrimitiveBuilder::with_capacity(Nullability::NonNullable, indices.len());
     let mut elements_to_take =
         PrimitiveBuilder::with_capacity(Nullability::NonNullable, 2 * indices.len());
 
     let mut current_offset = O::zero();
     new_offsets.append_zero();
+
+    // TODO(connor): Why is this 2 x length???
     let mut new_validity = BooleanBufferBuilder::new(2 * indices.len());
 
     for (idx, data_idx) in indices.iter().enumerate() {
@@ -139,6 +142,7 @@ fn _take_nullable<I: NativePType, O: OffsetPType + NativePType + PrimInt>(
 
             elements_to_take.ensure_capacity(elements_to_take.len() + additional);
             for i in 0..additional {
+                // TODO(connor): This should probably be `I::from_usize`?
                 elements_to_take
                     .append_value(start + O::from_usize(i).vortex_expect("i < additional"));
             }

--- a/vortex-array/src/arrays/list/tests.rs
+++ b/vortex-array/src/arrays/list/tests.rs
@@ -90,6 +90,262 @@ fn test_simple_list_filter() {
 }
 
 #[test]
+fn test_list_filter_dense_mask() {
+    // Test filtering with a dense mask (high density of true values).
+    let elements = PrimitiveArray::from_iter(0..100);
+    let offsets = PrimitiveArray::from_iter([0, 10, 25, 40, 60, 85, 100]);
+    let validity = Validity::AllValid;
+
+    let list = ListArray::try_new(elements.into_array(), offsets.into_array(), validity)
+        .unwrap()
+        .into_array();
+
+    // Dense mask: keep most elements (indices 1, 2, 3, 4, 5).
+    let mask = Mask::from(BooleanBuffer::from(vec![
+        false, true, true, true, true, true,
+    ]));
+
+    let filtered = filter(&list, &mask).unwrap();
+    let filtered_list = filtered.as_::<ListVTable>();
+
+    // Should have 5 lists remaining.
+    assert_eq!(filtered_list.len(), 5);
+
+    // Verify first remaining list (originally index 1) has correct elements.
+    let first_list = filtered_list.elements_at(0);
+    assert_eq!(first_list.len(), 15); // 25 - 10
+    assert_eq!(first_list.scalar_at(0), 10.into());
+    assert_eq!(first_list.scalar_at(14), 24.into());
+}
+
+#[test]
+fn test_list_filter_sparse_mask() {
+    // Test filtering with a sparse mask (low density of true values).
+    let elements = PrimitiveArray::from_iter(0..100);
+    let offsets = PrimitiveArray::from_iter([0, 10, 25, 40, 60, 85, 100]);
+    let validity = Validity::AllValid;
+
+    let list = ListArray::try_new(elements.into_array(), offsets.into_array(), validity)
+        .unwrap()
+        .into_array();
+
+    // Sparse mask: keep only a few elements (indices 0 and 5).
+    let mask = Mask::from(BooleanBuffer::from(vec![
+        true, false, false, false, false, true,
+    ]));
+
+    let filtered = filter(&list, &mask).unwrap();
+    let filtered_list = filtered.as_::<ListVTable>();
+
+    // Should have 2 lists remaining.
+    assert_eq!(filtered_list.len(), 2);
+
+    // Verify first list (originally index 0).
+    let first_list = filtered_list.elements_at(0);
+    assert_eq!(first_list.len(), 10);
+    assert_eq!(first_list.scalar_at(0), 0.into());
+    assert_eq!(first_list.scalar_at(9), 9.into());
+
+    // Verify second list (originally index 5).
+    let second_list = filtered_list.elements_at(1);
+    assert_eq!(second_list.len(), 15); // 100 - 85
+    assert_eq!(second_list.scalar_at(0), 85.into());
+    assert_eq!(second_list.scalar_at(14), 99.into());
+}
+
+#[test]
+fn test_list_filter_empty_lists() {
+    // Test filtering arrays that contain empty lists.
+    let elements = PrimitiveArray::from_iter(0..10);
+    let offsets = PrimitiveArray::from_iter([0, 0, 3, 3, 7, 10, 10]); // Lists at indices 0, 2, 5 are empty.
+    let validity = Validity::AllValid;
+
+    let list = ListArray::try_new(elements.into_array(), offsets.into_array(), validity)
+        .unwrap()
+        .into_array();
+
+    let mask = Mask::from(BooleanBuffer::from(vec![
+        true, true, true, false, false, true,
+    ]));
+
+    let filtered = filter(&list, &mask).unwrap();
+    let filtered_list = filtered.as_::<ListVTable>();
+
+    assert_eq!(filtered_list.len(), 4);
+
+    // First list is empty.
+    assert_eq!(filtered_list.elements_at(0).len(), 0);
+
+    // Second list has 3 elements.
+    let second_list = filtered_list.elements_at(1);
+    assert_eq!(second_list.len(), 3);
+    assert_eq!(second_list.scalar_at(0), 0.into());
+
+    // Third list is empty.
+    assert_eq!(filtered_list.elements_at(2).len(), 0);
+
+    // Fourth list is empty.
+    assert_eq!(filtered_list.elements_at(3).len(), 0);
+}
+
+#[test]
+fn test_list_filter_with_nulls() {
+    // Test filtering lists with null validity.
+    let elements = PrimitiveArray::from_iter(0..15);
+    let offsets = PrimitiveArray::from_iter([0, 3, 7, 10, 12, 15]);
+    let validity = Validity::from_mask(
+        Mask::from(BooleanBuffer::from(vec![true, false, true, false, true])),
+        Nullability::Nullable,
+    );
+
+    let list = ListArray::try_new(elements.into_array(), offsets.into_array(), validity)
+        .unwrap()
+        .into_array();
+
+    let mask = Mask::from(BooleanBuffer::from(vec![true, true, false, true, true]));
+
+    let filtered = filter(&list, &mask).unwrap();
+    let filtered_list = filtered.as_::<ListVTable>();
+
+    assert_eq!(filtered_list.len(), 4);
+
+    // Check validity of filtered array.
+    assert!(filtered_list.scalar_at(0).is_valid());
+    assert!(!filtered_list.scalar_at(1).is_valid()); // Was null.
+    assert!(!filtered_list.scalar_at(2).is_valid()); // Was null.
+    assert!(filtered_list.scalar_at(3).is_valid());
+}
+
+#[test]
+fn test_list_filter_all_true() {
+    // Test filtering with an all-true mask.
+    let elements = PrimitiveArray::from_iter(0..20);
+    let offsets = PrimitiveArray::from_iter([0, 5, 10, 15, 20]);
+    let validity = Validity::AllValid;
+
+    let list = ListArray::try_new(elements.into_array(), offsets.into_array(), validity)
+        .unwrap()
+        .into_array();
+
+    let mask = Mask::AllTrue(4);
+
+    let filtered = filter(&list, &mask).unwrap();
+    let filtered_list = filtered.as_::<ListVTable>();
+
+    // All lists should be preserved.
+    assert_eq!(filtered_list.len(), 4);
+
+    // Verify all lists are intact.
+    for i in 0..4i32 {
+        let list_at_i = filtered_list.elements_at(i as usize);
+        assert_eq!(list_at_i.len(), 5);
+        assert_eq!(list_at_i.scalar_at(0), (i * 5).into());
+    }
+}
+
+#[test]
+fn test_list_filter_all_false() {
+    // Test filtering with an all-false mask.
+    let elements = PrimitiveArray::from_iter(0..20);
+    let offsets = PrimitiveArray::from_iter([0, 5, 10, 15, 20]);
+    let validity = Validity::AllValid;
+
+    let list = ListArray::try_new(elements.into_array(), offsets.into_array(), validity)
+        .unwrap()
+        .into_array();
+
+    let mask = Mask::AllFalse(4);
+
+    let filtered = filter(&list, &mask).unwrap();
+    let filtered_list = filtered.as_::<ListVTable>();
+
+    // No lists should remain.
+    assert_eq!(filtered_list.len(), 0);
+}
+
+#[test]
+fn test_list_filter_single_element() {
+    // Test filtering to keep only one element.
+    let elements = PrimitiveArray::from_iter(0..50);
+    let offsets = PrimitiveArray::from_iter([0, 10, 20, 30, 40, 50]);
+    let validity = Validity::AllValid;
+
+    let list = ListArray::try_new(elements.into_array(), offsets.into_array(), validity)
+        .unwrap()
+        .into_array();
+
+    let mask = Mask::from(BooleanBuffer::from(vec![false, false, true, false, false]));
+
+    let filtered = filter(&list, &mask).unwrap();
+    let filtered_list = filtered.as_::<ListVTable>();
+
+    assert_eq!(filtered_list.len(), 1);
+
+    let single_list = filtered_list.elements_at(0);
+    assert_eq!(single_list.len(), 10);
+    assert_eq!(single_list.scalar_at(0), 20.into());
+    assert_eq!(single_list.scalar_at(9), 29.into());
+}
+
+#[test]
+fn test_list_filter_alternating_pattern() {
+    // Test filtering with an alternating pattern.
+    let elements = PrimitiveArray::from_iter(0..60);
+    let offsets = PrimitiveArray::from_iter([0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60]);
+    let validity = Validity::AllValid;
+
+    let list = ListArray::try_new(elements.into_array(), offsets.into_array(), validity)
+        .unwrap()
+        .into_array();
+
+    // Keep every other list.
+    let mask = Mask::from(BooleanBuffer::from(vec![
+        true, false, true, false, true, false, true, false, true, false, true, false,
+    ]));
+
+    let filtered = filter(&list, &mask).unwrap();
+    let filtered_list = filtered.as_::<ListVTable>();
+
+    assert_eq!(filtered_list.len(), 6);
+
+    // Verify that we have the correct lists (0, 2, 4, 6, 8, 10).
+    for (i, expected_start) in [0, 10, 20, 30, 40, 50].iter().enumerate() {
+        let list_at_i = filtered_list.elements_at(i);
+        assert_eq!(list_at_i.len(), 5);
+        assert_eq!(list_at_i.scalar_at(0), (*expected_start).into());
+    }
+}
+
+#[test]
+fn test_list_filter_variable_sizes() {
+    // Test filtering lists with highly variable sizes.
+    let elements = PrimitiveArray::from_iter(0..100);
+    let offsets = PrimitiveArray::from_iter([0, 1, 2, 5, 10, 20, 35, 60, 100]);
+    let validity = Validity::AllValid;
+
+    let list = ListArray::try_new(elements.into_array(), offsets.into_array(), validity)
+        .unwrap()
+        .into_array();
+
+    let mask = Mask::from(BooleanBuffer::from(vec![
+        true, false, true, true, false, true, true, true,
+    ]));
+
+    let filtered = filter(&list, &mask).unwrap();
+    let filtered_list = filtered.as_::<ListVTable>();
+
+    assert_eq!(filtered_list.len(), 6);
+
+    // Verify sizes of filtered lists.
+    assert_eq!(filtered_list.elements_at(0).len(), 1); // Size 1
+    assert_eq!(filtered_list.elements_at(1).len(), 3); // Size 3
+    assert_eq!(filtered_list.elements_at(2).len(), 5); // Size 5
+    assert_eq!(filtered_list.elements_at(3).len(), 15); // Size 15
+    assert_eq!(filtered_list.elements_at(4).len(), 25); // Size 25
+    assert_eq!(filtered_list.elements_at(5).len(), 40); // Size 40
+}
+
+#[test]
 fn test_offset_to_0() {
     let mut builder =
         ListBuilder::<u32>::with_capacity(Arc::new(I32.into()), Nullability::NonNullable, 5);

--- a/vortex-array/src/arrow/compute/to_arrow/canonical.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/canonical.rs
@@ -11,8 +11,9 @@ use arrow_array::types::{
 use arrow_array::{
     Array, ArrayRef as ArrowArrayRef, ArrowPrimitiveType, BooleanArray as ArrowBoolArray,
     Decimal128Array as ArrowDecimal128Array, Decimal256Array as ArrowDecimal256Array,
-    GenericByteArray, GenericByteViewArray, GenericListArray, NullArray as ArrowNullArray,
-    OffsetSizeTrait, PrimitiveArray as ArrowPrimitiveArray, StructArray as ArrowStructArray,
+    FixedSizeListArray as ArrowFixedSizeListArray, GenericByteArray, GenericByteViewArray,
+    GenericListArray, NullArray as ArrowNullArray, OffsetSizeTrait,
+    PrimitiveArray as ArrowPrimitiveArray, StructArray as ArrowStructArray,
 };
 use arrow_buffer::{ScalarBuffer, i256};
 use arrow_schema::{DataType, Field, FieldRef, Fields};
@@ -24,7 +25,8 @@ use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
 use vortex_scalar::DecimalValueType;
 
 use crate::arrays::{
-    BoolArray, DecimalArray, ListArray, NullArray, PrimitiveArray, StructArray, VarBinViewArray,
+    BoolArray, DecimalArray, FixedSizeListArray, ListArray, NullArray, PrimitiveArray, StructArray,
+    VarBinViewArray,
 };
 use crate::arrow::IntoArrowArray;
 use crate::arrow::array::ArrowArray;
@@ -53,6 +55,10 @@ impl Kernel for ToArrowCanonical {
             .cloned()
             .map(Ok)
             .unwrap_or_else(|| array.dtype().to_arrow_dtype())?;
+
+        // When `arrow_type` is `None`, conversion should respect conversion to the encoding's
+        // preferred Arrow type if the array has child arrays (struct, list, and fixed-size list).
+        let to_preferred = arrow_type_opt.is_none();
 
         let arrow_array = match (array.to_canonical(), &arrow_type) {
             (Canonical::Null(array), DataType::Null) => to_arrow_null(array),
@@ -139,7 +145,7 @@ impl Kernel for ToArrowCanonical {
                 to_arrow_decimal256(array)
             }
             (Canonical::Struct(array), DataType::Struct(fields)) => {
-                to_arrow_struct(array, fields.as_ref(), arrow_type_opt.is_none())
+                to_arrow_struct(array, fields.as_ref(), to_preferred)
             }
             (Canonical::List(array), DataType::List(field)) => {
                 to_arrow_list::<i32>(array, arrow_type_opt.map(|_| field))
@@ -147,8 +153,8 @@ impl Kernel for ToArrowCanonical {
             (Canonical::List(array), DataType::LargeList(field)) => {
                 to_arrow_list::<i64>(array, arrow_type_opt.map(|_| field))
             }
-            (Canonical::FixedSizeList(..), DataType::FixedSizeList(..)) => {
-                unimplemented!("TODO(connor)[FixedSizeList]")
+            (Canonical::FixedSizeList(array), DataType::FixedSizeList(field, list_size)) => {
+                to_arrow_fixed_size_list(array, field, *list_size, to_preferred)
             }
             (Canonical::VarBinView(array), DataType::BinaryView) if array.dtype().is_binary() => {
                 to_arrow_varbinview::<BinaryViewType>(array)
@@ -381,6 +387,39 @@ fn to_arrow_list<O: NativePType + OffsetSizeTrait>(
     Ok(Arc::new(GenericListArray::new(
         element_field,
         arrow_offsets.buffer::<O>().into_arrow_offset_buffer(),
+        values,
+        nulls,
+    )))
+}
+
+fn to_arrow_fixed_size_list(
+    array: FixedSizeListArray,
+    element: &FieldRef,
+    list_size: i32,
+    to_preferred: bool,
+) -> VortexResult<ArrowArrayRef> {
+    assert!(
+        list_size >= 0,
+        "somehow had a negative list size for arrow fixed-size lists"
+    );
+
+    if list_size as u32 != array.list_size() {
+        vortex_bail!(
+            "Cannot convert a Vortex `FixedSizeListArray` with list size {} to an Arrow `FixedSizeListArray` with list size {list_size}",
+            array.list_size()
+        );
+    }
+
+    let values = if to_preferred {
+        array.elements().clone().into_arrow_preferred()?
+    } else {
+        array.elements().clone().into_arrow(element.data_type())?
+    };
+    let nulls = array.validity_mask().to_null_buffer();
+
+    Ok(Arc::new(ArrowFixedSizeListArray::new(
+        element.clone(),
+        list_size,
         values,
         nulls,
     )))

--- a/vortex-array/src/arrow/compute/to_arrow/canonical.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/canonical.rs
@@ -154,7 +154,7 @@ impl Kernel for ToArrowCanonical {
                 to_arrow_list::<i64>(array, arrow_type_opt.map(|_| field))
             }
             (Canonical::FixedSizeList(array), DataType::FixedSizeList(field, list_size)) => {
-                to_arrow_fixed_size_list(array, field, *list_size, to_preferred)
+                to_arrow_fixed_size_list(array, arrow_type_opt.map(|_| field), *list_size)
             }
             (Canonical::VarBinView(array), DataType::BinaryView) if array.dtype().is_binary() => {
                 to_arrow_varbinview::<BinaryViewType>(array)
@@ -394,9 +394,8 @@ fn to_arrow_list<O: NativePType + OffsetSizeTrait>(
 
 fn to_arrow_fixed_size_list(
     array: FixedSizeListArray,
-    element: &FieldRef,
+    element: Option<&FieldRef>,
     list_size: i32,
-    to_preferred: bool,
 ) -> VortexResult<ArrowArrayRef> {
     assert!(
         list_size >= 0,
@@ -410,15 +409,23 @@ fn to_arrow_fixed_size_list(
         );
     }
 
-    let values = if to_preferred {
-        array.elements().clone().into_arrow_preferred()?
+    let (values, element_field) = if let Some(element) = element {
+        (
+            array.elements().clone().into_arrow(element.data_type())?,
+            element.clone(),
+        )
     } else {
-        array.elements().clone().into_arrow(element.data_type())?
+        let values = array.elements().clone().into_arrow_preferred()?;
+        let element_field = Arc::new(Field::new_list_field(
+            values.data_type().clone(),
+            array.elements().dtype().is_nullable(),
+        ));
+        (values, element_field)
     };
     let nulls = array.validity_mask().to_null_buffer();
 
     Ok(Arc::new(ArrowFixedSizeListArray::new(
-        element.clone(),
+        element_field,
         list_size,
         values,
         nulls,

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-// TODO(connor): Make the methods on all builders consistent (`_opt` methods).
-
 //! Builders for Vortex arrays.
 //!
 //! Every logical type in Vortex has a canonical (uncompressed) in-memory encoding. This module

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -274,7 +274,7 @@ fn test_slice_filter_consistency(array: &dyn Array) {
         filtered.len(),
         sliced.len(),
         "Filter with contiguous mask and slice should produce same length. \
-         Filtered length: {}, Sliced length: {}",
+         \nFiltered length: {}\nSliced length: {}",
         filtered.len(),
         sliced.len()
     );
@@ -285,7 +285,7 @@ fn test_slice_filter_consistency(array: &dyn Array) {
         assert_eq!(
             filtered_val, sliced_val,
             "Filter with contiguous mask and slice produced different values at index {i}. \
-             Filtered value: {filtered_val:?}, Sliced value: {sliced_val:?}"
+             \nFiltered value: {filtered_val:?}\nSliced value: {sliced_val:?}"
         );
     }
 }
@@ -321,7 +321,7 @@ fn test_take_slice_consistency(array: &dyn Array) {
         taken.len(),
         sliced.len(),
         "Take with sequential indices and slice should produce same length. \
-         Taken length: {}, Sliced length: {}",
+         \nTaken length: {}\nSliced length: {}",
         taken.len(),
         sliced.len()
     );
@@ -332,7 +332,7 @@ fn test_take_slice_consistency(array: &dyn Array) {
         assert_eq!(
             taken_val, sliced_val,
             "Take with sequential indices and slice produced different values at index {i}. \
-             Taken value: {taken_val:?}, Sliced value: {sliced_val:?}"
+             \nTaken value: {taken_val:?}\nSliced value: {sliced_val:?}"
         );
     }
 }

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -87,6 +87,15 @@ impl ComputeFnVTable for Filter {
             return Ok(array.to_array().into());
         }
 
+        // If the entire array is null, then we only need to adjust the length of the array.
+        if array.validity_mask().true_count() == 0 {
+            return Ok(
+                ConstantArray::new(Scalar::null(array.dtype().clone()), true_count)
+                    .into_array()
+                    .into(),
+            );
+        }
+
         for kernel in kernels {
             if let Some(output) = kernel.invoke(args)? {
                 return Ok(output);
@@ -174,6 +183,8 @@ pub trait FilterKernel: VTable {
     /// selection mask, leaving only `Mask::Values` to be handled by this function.
     ///
     /// Additionally, the array length is guaranteed to have the same length as the selection mask.
+    ///
+    /// Finally, the array validity mask is guaranteed not to have a true count of 0 (all nulls).
     fn filter(&self, array: &Self::Array, selection_mask: &Mask) -> VortexResult<ArrayRef>;
 }
 

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -69,6 +69,12 @@ impl ComputeFnVTable for Filter {
     ) -> VortexResult<Output> {
         let FilterArgs { array, mask } = FilterArgs::try_from(args)?;
 
+        debug_assert_eq!(
+            array.len(),
+            mask.len(),
+            "Tried to filter an array via a mask with the wrong length"
+        );
+
         let true_count = mask.true_count();
 
         // Fast-path for empty mask.
@@ -162,9 +168,13 @@ inventory::collect!(FilterKernelRef);
 pub trait FilterKernel: VTable {
     /// Filter an array by the provided predicate.
     ///
-    /// Note that the entry-point filter functions handles `Mask::AllTrue` and `Mask::AllFalse`,
-    /// leaving only `Mask::Values` to be handled by this function.
-    fn filter(&self, array: &Self::Array, mask: &Mask) -> VortexResult<ArrayRef>;
+    /// # Preconditions
+    ///
+    /// The entry-point filter functions will handle `Mask::AllTrue` and `Mask::AllFalse` on the
+    /// selection mask, leaving only `Mask::Values` to be handled by this function.
+    ///
+    /// Additionally, the array length is guaranteed to have the same length as the selection mask.
+    fn filter(&self, array: &Self::Array, selection_mask: &Mask) -> VortexResult<ArrayRef>;
 }
 
 /// Adapter to convert a [`FilterKernel`] into a [`Kernel`].

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -170,7 +170,7 @@ pub trait FilterKernel: VTable {
     ///
     /// # Preconditions
     ///
-    /// The entry-point filter functions will handle `Mask::AllTrue` and `Mask::AllFalse` on the
+    /// The entrypoint filter functions will handle `Mask::AllTrue` and `Mask::AllFalse` on the
     /// selection mask, leaving only `Mask::Values` to be handled by this function.
     ///
     /// Additionally, the array length is guaranteed to have the same length as the selection mask.

--- a/vortex-dtype/src/arbitrary.rs
+++ b/vortex-dtype/src/arbitrary.rs
@@ -4,6 +4,7 @@
 use std::sync::Arc;
 
 use arbitrary::{Arbitrary, Result, Unstructured};
+use vortex_error::VortexExpect;
 
 use crate::{
     DECIMAL256_MAX_PRECISION, DECIMAL256_MAX_SCALE, DType, DecimalDType, FieldName, FieldNames,
@@ -18,7 +19,7 @@ impl<'a> Arbitrary<'a> for DType {
 
 fn random_dtype(u: &mut Unstructured<'_>, depth: u8) -> Result<DType> {
     const BASE_TYPE_COUNT: i32 = 5;
-    const CONTAINER_TYPE_COUNT: i32 = 2; // TODO(connor)[FixedSizeList]: Make this 3.
+    const CONTAINER_TYPE_COUNT: i32 = 3;
     let max_dtype_kind = if depth == 0 {
         BASE_TYPE_COUNT
     } else {
@@ -35,15 +36,12 @@ fn random_dtype(u: &mut Unstructured<'_>, depth: u8) -> Result<DType> {
         // container types
         6 => DType::Struct(random_struct_dtype(u, depth - 1)?, u.arbitrary()?),
         7 => DType::List(Arc::new(random_dtype(u, depth - 1)?), u.arbitrary()?),
-        8 => {
-            unimplemented!("TODO(connor)[FixedSizeList]");
-            // DType::FixedSizeList(
-            //     Arc::new(random_dtype(u, depth - 1)?),
-            //     // We limit the list size to 3 rather (following random struct fields).
-            //     u.choose_index(3)?.try_into().vortex_expect("impossible"),
-            //     u.arbitrary()?,
-            // )
-        }
+        8 => DType::FixedSizeList(
+            Arc::new(random_dtype(u, depth - 1)?),
+            // We limit the list size to 3 rather (following random struct fields).
+            u.choose_index(3)?.try_into().vortex_expect("impossible"),
+            u.arbitrary()?,
+        ),
         // Null,
         // Extension(ExtDType, Nullability),
         _ => unreachable!("Number out of range"),

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -315,12 +315,35 @@ impl DType {
         }
     }
 
-    /// Get the inner element dtype if `self` is a [`DType::List`] or [`DType::FixedSizeList`],
-    /// otherwise returns `None`
+    /// Get the inner element dtype if `self` is a [`DType::List`], otherwise returns `None`.
+    ///
+    /// Note that this does _not_ return `Some` if `self` is a [`DType::FixedSizeList`].
     pub fn as_list_element_opt(&self) -> Option<&Arc<DType>> {
         if let List(edt, _) = self {
             Some(edt)
-        } else if let FixedSizeList(edt, ..) = self {
+        } else {
+            None
+        }
+    }
+
+    /// Get the inner element dtype if `self` is a [`DType::FixedSizeList`], otherwise returns
+    /// `None`.
+    ///
+    /// Note that this does _not_ return `Some` if `self` is a [`DType::List`].
+    pub fn as_fixed_size_list_element_opt(&self) -> Option<&Arc<DType>> {
+        if let FixedSizeList(edt, ..) = self {
+            Some(edt)
+        } else {
+            None
+        }
+    }
+
+    /// Get the inner element dtype if `self` is **either** a [`DType::List`] or a
+    /// [`DType::FixedSizeList`], otherwise returns `None`
+    pub fn as_any_size_list_element_opt(&self) -> Option<&Arc<DType>> {
+        if let FixedSizeList(edt, ..) = self {
+            Some(edt)
+        } else if let List(edt, ..) = self {
             Some(edt)
         } else {
             None

--- a/vortex-scalar/src/list.rs
+++ b/vortex-scalar/src/list.rs
@@ -116,7 +116,7 @@ impl<'a> ListScalar<'a> {
     /// Returns the data type of the list's elements.
     pub fn element_dtype(&self) -> &DType {
         self.dtype
-            .as_list_element_opt()
+            .as_any_size_list_element_opt()
             .unwrap_or_else(|| vortex_panic!("`ListScalar` somehow had dtype {}", self.dtype))
             .as_ref()
     }
@@ -154,7 +154,7 @@ impl<'a> ListScalar<'a> {
     /// [`FixedSizeList`]: DType::FixedSizeList
     pub(crate) fn cast(&self, dtype: &DType) -> VortexResult<Scalar> {
         let target_element_dtype = dtype
-            .as_list_element_opt()
+            .as_any_size_list_element_opt()
             .ok_or_else(|| {
                 vortex_err!(
                     "Cannot cast {} to {}: list can only be cast to a list or fixed-size list",
@@ -274,7 +274,7 @@ impl<'a> TryFrom<&'a Scalar> for ListScalar<'a> {
     fn try_from(value: &'a Scalar) -> Result<Self, Self::Error> {
         let element_dtype = value
             .dtype()
-            .as_list_element_opt()
+            .as_any_size_list_element_opt()
             .ok_or_else(|| vortex_err!("Expected list scalar, found {}", value.dtype()))?;
 
         Ok(Self {


### PR DESCRIPTION
Tracking Issue: https://github.com/vortex-data/vortex/issues/4372

Implements the same compute functions as `ListArray`, but for `FixedSizeListArray`.

- Take: Select elements by indices with optimized paths for nullable/non-nullable data
- Filter: Apply boolean masks with density-based expansion strategy (not sure it this is a premature optimization)
- Cast
- IsConstant: Check if all lists in the array are identical (this is super expensive and it might be worth revisiting the compute function characteristics itself, cc @gatesn) 
- Mask
- Fuzzing: Extended arbitrary data generation to support `FixedSizeListArray`
- Arrow conversion
- Refactored `ListArray` filter compute function with a similar density check

The two complicated compute functions here are `filter` and `take`, with `take` being significantly more complicated. Those are accompanied by tests since the logic is a lot harder.

Nice-to-have-but-I'm-too-tired:
- Tests for each compute function (missing for cast, is_constant, and mask)
- Refactor the `ListArray` `take` compute function