### PR TITLE
Concurrent filters

### DIFF
--- a/vortex-array/src/pipeline/operators/mask_future.rs
+++ b/vortex-array/src/pipeline/operators/mask_future.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use futures_util::future::{BoxFuture, SelectAll, Shared};
 use futures_util::{FutureExt, TryFutureExt};
-use vortex_error::{vortex_panic, SharedVortexResult, VortexError, VortexResult};
+use vortex_error::{SharedVortexResult, VortexError, VortexResult, vortex_panic};
 use vortex_mask::Mask;
 
 /// A future that resolves to a mask.

--- a/vortex-array/src/pipeline/operators/mask_future.rs
+++ b/vortex-array/src/pipeline/operators/mask_future.rs
@@ -2,12 +2,12 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::future::Future;
-use std::ops::Range;
+use std::ops::{BitAnd, Range};
 use std::sync::Arc;
 
-use futures_util::future::{BoxFuture, Shared};
+use futures_util::future::{BoxFuture, SelectAll, Shared};
 use futures_util::{FutureExt, TryFutureExt};
-use vortex_error::{SharedVortexResult, VortexError, VortexResult, vortex_panic};
+use vortex_error::{vortex_panic, SharedVortexResult, VortexError, VortexResult};
 use vortex_mask::Mask;
 
 /// A future that resolves to a mask.
@@ -62,6 +62,68 @@ impl MaskFuture {
     pub fn slice(&self, range: Range<usize>) -> Self {
         let inner = self.inner.clone();
         Self::new(range.len(), async move { Ok(inner.await?.slice(range)) })
+    }
+
+    /// Create a MaskFuture that resolves to the intersection of multiple MaskFutures.
+    ///
+    /// If the accumulated intersection is all false at any point, the future will resolve early,
+    /// dropping any remaining futures.
+    pub fn intersect(init: MaskFuture, mut futures: Vec<MaskFuture>) -> Self {
+        if futures.is_empty() {
+            return init;
+        }
+        if futures.iter().any(|m| m.len() != init.len()) {
+            vortex_panic!("MaskFuture::intersect called with futures of different lengths");
+        }
+        let len = init.len();
+        // Include the initial future in the list also
+        futures.push(init);
+
+        MaskFuture::new(len, async move {
+            // Now we race all futures, intersect their results as they come in, and return early
+            // if the intersection is all false.
+            let mut futures = SelectAll::from_iter(futures);
+            let mut acc = Mask::new_true(len);
+
+            loop {
+                let (mask, _index, remaining) = futures.await;
+                acc = acc.bitand(&mask?);
+
+                if acc.all_false() {
+                    return Ok(acc);
+                }
+                if remaining.is_empty() {
+                    return Ok(acc);
+                }
+
+                futures = SelectAll::from_iter(remaining);
+            }
+        })
+    }
+
+    /// Runs a set of futures concurrently, but passes the result mask into each future from left
+    /// to right.
+    ///
+    /// In other words, the individual futures will each make progress concurrently until they
+    /// await their input mask, at which point they will block waiting for the previous future to
+    /// complete. The overall result is the intersection of all the futures.
+    pub fn fold_intersect<F>(init: MaskFuture, fns: impl Iterator<Item = F>) -> Self
+    where
+        F: FnOnce(MaskFuture) -> MaskFuture,
+    {
+        let mut current = init.clone();
+        let mut futures = Vec::new();
+        for f in fns {
+            let fut = f(current.clone());
+            assert_eq!(
+                fut.len(),
+                init.len(),
+                "MaskFuture::fold called with futures of different lengths"
+            );
+            futures.push(fut.clone());
+            current = fut;
+        }
+        MaskFuture::intersect(init, futures)
     }
 }
 

--- a/vortex-file/src/driver.rs
+++ b/vortex-file/src/driver.rs
@@ -12,7 +12,7 @@ use futures::{Stream, StreamExt};
 use itertools::Itertools;
 use linked_hash_set::LinkedHashSet;
 use vortex_buffer::{Alignment, ByteBuffer};
-use vortex_error::{vortex_panic, VortexError, VortexExpect, VortexResult};
+use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_panic};
 use vortex_io::{PerformanceHint, VortexReadAt};
 use vortex_layout::segments::{SegmentEvent, SegmentId, SegmentRequest};
 use vortex_metrics::{Counter, VortexMetrics};

--- a/vortex-file/src/driver.rs
+++ b/vortex-file/src/driver.rs
@@ -12,7 +12,7 @@ use futures::{Stream, StreamExt};
 use itertools::Itertools;
 use linked_hash_set::LinkedHashSet;
 use vortex_buffer::{Alignment, ByteBuffer};
-use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_panic};
+use vortex_error::{vortex_panic, VortexError, VortexExpect, VortexResult};
 use vortex_io::{PerformanceHint, VortexReadAt};
 use vortex_layout::segments::{SegmentEvent, SegmentId, SegmentRequest};
 use vortex_metrics::{Counter, VortexMetrics};
@@ -81,8 +81,9 @@ impl CoalescedDriver {
             coalesced_bytes_counter: metrics.counter("vortex.file.coalesced.bytes"),
 
             performance_hint,
-            max_prefetch_bytes: 32 << 20, // 32 MB
-            max_prefetch_inflight_requests: 1,
+            // max_prefetch_bytes: 32 << 20, // 32 MB
+            max_prefetch_bytes: 0,
+            max_prefetch_inflight_requests: 0,
             first_poll: false,
             state: Default::default(),
             requested: Default::default(),

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -5,22 +5,20 @@ use std::collections::BTreeSet;
 use std::ops::Range;
 use std::sync::Arc;
 
-use futures::future::BoxFuture;
 use futures::stream::FuturesOrdered;
 use futures::{FutureExt, TryStreamExt};
-use vortex_array::ArrayRef;
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::pipeline::operators::MaskFuture;
 use vortex_array::stats::Precision;
 use vortex_dtype::{DType, FieldMask};
-use vortex_error::{VortexExpect, VortexResult, vortex_panic};
+use vortex_error::{vortex_panic, VortexExpect, VortexResult};
 use vortex_expr::ExprRef;
 use vortex_mask::Mask;
 
 use crate::layouts::chunked::ChunkedLayout;
 use crate::reader::LayoutReader;
 use crate::segments::SegmentSource;
-use crate::{LayoutReaderRef, LazyReaderChildren};
+use crate::{ArrayFuture, LayoutReaderRef, LazyReaderChildren};
 
 /// A [`LayoutReader`] for chunked layouts.
 pub struct ChunkedReader {
@@ -238,7 +236,7 @@ impl LayoutReader for ChunkedReader {
         row_range: &Range<u64>,
         expr: &ExprRef,
         mask: MaskFuture,
-    ) -> VortexResult<BoxFuture<'static, VortexResult<ArrayRef>>> {
+    ) -> VortexResult<ArrayFuture> {
         let dtype = expr.return_dtype(self.dtype())?;
         let mut chunk_evals = vec![];
 

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -11,7 +11,7 @@ use vortex_array::arrays::ChunkedArray;
 use vortex_array::pipeline::operators::MaskFuture;
 use vortex_array::stats::Precision;
 use vortex_dtype::{DType, FieldMask};
-use vortex_error::{vortex_panic, VortexExpect, VortexResult};
+use vortex_error::{VortexExpect, VortexResult, vortex_panic};
 use vortex_expr::ExprRef;
 use vortex_mask::Mask;
 

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -5,14 +5,14 @@ use std::collections::BTreeSet;
 use std::ops::{BitAnd, Range};
 use std::sync::{Arc, OnceLock};
 
-use futures::{try_join, FutureExt, TryFutureExt};
-use vortex_array::compute::{min_max, take, MinMaxResult};
+use futures::{FutureExt, TryFutureExt, try_join};
+use vortex_array::compute::{MinMaxResult, min_max, take};
 use vortex_array::pipeline::operators::MaskFuture;
 use vortex_array::stats::Precision;
 use vortex_dict::DictArray;
 use vortex_dtype::{DType, FieldMask};
 use vortex_error::{VortexError, VortexExpect, VortexResult};
-use vortex_expr::{root, ExprRef, Scope};
+use vortex_expr::{ExprRef, Scope, root};
 use vortex_mask::Mask;
 use vortex_utils::aliases::dash_map::DashMap;
 

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -5,23 +5,21 @@ use std::collections::BTreeSet;
 use std::ops::{BitAnd, Range};
 use std::sync::{Arc, OnceLock};
 
-use futures::future::BoxFuture;
-use futures::{FutureExt, TryFutureExt, try_join};
-use vortex_array::ArrayRef;
-use vortex_array::compute::{MinMaxResult, min_max, take};
+use futures::{try_join, FutureExt, TryFutureExt};
+use vortex_array::compute::{min_max, take, MinMaxResult};
 use vortex_array::pipeline::operators::MaskFuture;
 use vortex_array::stats::Precision;
 use vortex_dict::DictArray;
 use vortex_dtype::{DType, FieldMask};
 use vortex_error::{VortexError, VortexExpect, VortexResult};
-use vortex_expr::{ExprRef, Scope, root};
+use vortex_expr::{root, ExprRef, Scope};
 use vortex_mask::Mask;
 use vortex_utils::aliases::dash_map::DashMap;
 
 use super::DictLayout;
 use crate::layouts::SharedArrayFuture;
 use crate::segments::SegmentSource;
-use crate::{LayoutReader, LayoutReaderRef};
+use crate::{ArrayFuture, LayoutReader, LayoutReaderRef};
 
 pub struct DictReader {
     layout: DictLayout,
@@ -184,7 +182,7 @@ impl LayoutReader for DictReader {
         row_range: &Range<u64>,
         expr: &ExprRef,
         mask: MaskFuture,
-    ) -> VortexResult<BoxFuture<'static, VortexResult<ArrayRef>>> {
+    ) -> VortexResult<ArrayFuture> {
         let values_eval = self.values_eval(root());
         let codes_eval = self.codes.projection_evaluation(row_range, &root(), mask)?;
         let expr = expr.clone();

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -6,24 +6,23 @@ use std::ops::{BitAnd, Range};
 use std::sync::Arc;
 
 use futures::FutureExt;
-use futures::future::BoxFuture;
 use vortex_array::compute::filter;
 use vortex_array::pipeline::operators::MaskFuture;
 use vortex_array::pipeline::{
-    N, export_canonical_pipeline_expr, export_canonical_pipeline_expr_offset,
+    export_canonical_pipeline_expr, export_canonical_pipeline_expr_offset, N,
 };
 use vortex_array::serde::ArrayParts;
 use vortex_array::stats::Precision;
 use vortex_array::{Array, ArrayRef, IntoArray};
 use vortex_dtype::{DType, FieldMask, Nullability};
 use vortex_error::{VortexExpect, VortexResult, VortexUnwrap as _};
-use vortex_expr::{ExprRef, Scope, VortexExprExt, is_root};
+use vortex_expr::{is_root, ExprRef, Scope, VortexExprExt};
 use vortex_mask::Mask;
 
-use crate::LayoutReader;
-use crate::layouts::SharedArrayFuture;
 use crate::layouts::flat::FlatLayout;
+use crate::layouts::SharedArrayFuture;
 use crate::segments::SegmentSource;
+use crate::{ArrayFuture, LayoutReader};
 
 /// The threshold of mask density below which we will evaluate the expression only over the
 /// selected rows, and above which we evaluate the expression over all rows and then select
@@ -178,7 +177,7 @@ impl LayoutReader for FlatReader {
         row_range: &Range<u64>,
         expr: &ExprRef,
         mask: MaskFuture,
-    ) -> VortexResult<BoxFuture<'static, VortexResult<ArrayRef>>> {
+    ) -> VortexResult<ArrayFuture> {
         let row_range = usize::try_from(row_range.start)
             .vortex_expect("Row range begin must fit within FlatLayout size")
             ..usize::try_from(row_range.end)

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -9,18 +9,18 @@ use futures::FutureExt;
 use vortex_array::compute::filter;
 use vortex_array::pipeline::operators::MaskFuture;
 use vortex_array::pipeline::{
-    export_canonical_pipeline_expr, export_canonical_pipeline_expr_offset, N,
+    N, export_canonical_pipeline_expr, export_canonical_pipeline_expr_offset,
 };
 use vortex_array::serde::ArrayParts;
 use vortex_array::stats::Precision;
 use vortex_array::{Array, ArrayRef, IntoArray};
 use vortex_dtype::{DType, FieldMask, Nullability};
 use vortex_error::{VortexExpect, VortexResult, VortexUnwrap as _};
-use vortex_expr::{is_root, ExprRef, Scope, VortexExprExt};
+use vortex_expr::{ExprRef, Scope, VortexExprExt, is_root};
 use vortex_mask::Mask;
 
-use crate::layouts::flat::FlatLayout;
 use crate::layouts::SharedArrayFuture;
+use crate::layouts::flat::FlatLayout;
 use crate::segments::SegmentSource;
 use crate::{ArrayFuture, LayoutReader};
 

--- a/vortex-layout/src/layouts/row_idx/mod.rs
+++ b/vortex-layout/src/layouts/row_idx/mod.rs
@@ -8,21 +8,21 @@ use std::fmt::{Display, Formatter};
 use std::ops::{BitAnd, Range};
 use std::sync::Arc;
 
+use Nullability::NonNullable;
 pub use expr::*;
 use futures::FutureExt;
+use vortex_array::IntoArray;
 use vortex_array::compute::filter;
 use vortex_array::pipeline::operators::MaskFuture;
 use vortex_array::stats::Precision;
-use vortex_array::IntoArray;
 use vortex_dtype::{DType, FieldMask, Nullability, PType};
 use vortex_error::{VortexExpect, VortexResult};
-use vortex_expr::transform::{partition, replace, PartitionedExpr};
-use vortex_expr::{is_root, root, ExactExpr, ExprRef, Scope};
+use vortex_expr::transform::{PartitionedExpr, partition, replace};
+use vortex_expr::{ExactExpr, ExprRef, Scope, is_root, root};
 use vortex_mask::Mask;
 use vortex_scalar::PValue;
 use vortex_sequence::SequenceArray;
 use vortex_utils::aliases::dash_map::DashMap;
-use Nullability::NonNullable;
 
 use crate::layouts::partitioned::PartitionedExprEval;
 use crate::{ArrayFuture, LayoutReader};
@@ -259,7 +259,7 @@ mod tests {
     use vortex_expr::{eq, gt, lit, or, root};
 
     use crate::layouts::flat::writer::FlatLayoutStrategy;
-    use crate::layouts::row_idx::{row_idx, RowIdxLayoutReader};
+    use crate::layouts::row_idx::{RowIdxLayoutReader, row_idx};
     use crate::segments::{SegmentSource, SequenceWriter, TestSegments};
     use crate::sequence::SequenceId;
     use crate::{LayoutReader, LayoutStrategy, SequentialStreamAdapter, SequentialStreamExt};

--- a/vortex-layout/src/layouts/row_idx/mod.rs
+++ b/vortex-layout/src/layouts/row_idx/mod.rs
@@ -8,22 +8,21 @@ use std::fmt::{Display, Formatter};
 use std::ops::{BitAnd, Range};
 use std::sync::Arc;
 
-use Nullability::NonNullable;
 pub use expr::*;
 use futures::FutureExt;
-use futures::future::BoxFuture;
 use vortex_array::compute::filter;
 use vortex_array::pipeline::operators::MaskFuture;
 use vortex_array::stats::Precision;
-use vortex_array::{ArrayRef, IntoArray};
+use vortex_array::IntoArray;
 use vortex_dtype::{DType, FieldMask, Nullability, PType};
 use vortex_error::{VortexExpect, VortexResult};
-use vortex_expr::transform::{PartitionedExpr, partition, replace};
-use vortex_expr::{ExactExpr, ExprRef, Scope, is_root, root};
+use vortex_expr::transform::{partition, replace, PartitionedExpr};
+use vortex_expr::{is_root, root, ExactExpr, ExprRef, Scope};
 use vortex_mask::Mask;
 use vortex_scalar::PValue;
 use vortex_sequence::SequenceArray;
 use vortex_utils::aliases::dash_map::DashMap;
+use Nullability::NonNullable;
 
 use crate::layouts::partitioned::PartitionedExprEval;
 use crate::{ArrayFuture, LayoutReader};
@@ -181,7 +180,7 @@ impl LayoutReader for RowIdxLayoutReader {
         row_range: &Range<u64>,
         expr: &ExprRef,
         mask: MaskFuture,
-    ) -> VortexResult<BoxFuture<'static, VortexResult<ArrayRef>>> {
+    ) -> VortexResult<ArrayFuture> {
         match &self.partition_expr(expr) {
             Partitioning::RowIdx(expr) => {
                 Ok(row_idx_array_future(self.row_offset, row_range, expr, mask))
@@ -260,7 +259,7 @@ mod tests {
     use vortex_expr::{eq, gt, lit, or, root};
 
     use crate::layouts::flat::writer::FlatLayoutStrategy;
-    use crate::layouts::row_idx::{RowIdxLayoutReader, row_idx};
+    use crate::layouts::row_idx::{row_idx, RowIdxLayoutReader};
     use crate::segments::{SegmentSource, SequenceWriter, TestSegments};
     use crate::sequence::SequenceId;
     use crate::{LayoutReader, LayoutStrategy, SequentialStreamAdapter, SequentialStreamExt};

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -5,18 +5,16 @@ use std::collections::BTreeSet;
 use std::ops::Range;
 use std::sync::Arc;
 
-use futures::future::BoxFuture;
 use itertools::Itertools;
-use vortex_array::ArrayRef;
 use vortex_array::pipeline::operators::MaskFuture;
 use vortex_array::stats::Precision;
 use vortex_dtype::{DType, FieldMask, FieldName, StructFields};
-use vortex_error::{VortexExpect, VortexResult, vortex_err};
+use vortex_error::{vortex_err, VortexExpect, VortexResult};
 use vortex_expr::transform::immediate_access::annotate_scope_access;
 use vortex_expr::transform::{
-    PartitionedExpr, partition, replace, replace_root_fields, simplify_typed,
+    partition, replace, replace_root_fields, simplify_typed, PartitionedExpr,
 };
-use vortex_expr::{ExactExpr, ExprRef, col, root};
+use vortex_expr::{col, root, ExactExpr, ExprRef};
 use vortex_mask::Mask;
 use vortex_utils::aliases::dash_map::DashMap;
 use vortex_utils::aliases::hash_map::HashMap;
@@ -24,7 +22,7 @@ use vortex_utils::aliases::hash_map::HashMap;
 use crate::layouts::partitioned::PartitionedExprEval;
 use crate::layouts::struct_::StructLayout;
 use crate::segments::SegmentSource;
-use crate::{LayoutReader, LayoutReaderRef, LazyReaderChildren};
+use crate::{ArrayFuture, LayoutReader, LayoutReaderRef, LazyReaderChildren};
 
 pub struct StructReader {
     layout: StructLayout,
@@ -236,7 +234,7 @@ impl LayoutReader for StructReader {
         row_range: &Range<u64>,
         expr: &ExprRef,
         mask: MaskFuture,
-    ) -> VortexResult<BoxFuture<'static, VortexResult<ArrayRef>>> {
+    ) -> VortexResult<ArrayFuture> {
         // Partition the expression into expressions that can be evaluated over individual fields
         match &self.partition_expr(expr.clone()) {
             Partitioned::Single(name, partition) => self

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -9,12 +9,12 @@ use itertools::Itertools;
 use vortex_array::pipeline::operators::MaskFuture;
 use vortex_array::stats::Precision;
 use vortex_dtype::{DType, FieldMask, FieldName, StructFields};
-use vortex_error::{vortex_err, VortexExpect, VortexResult};
+use vortex_error::{VortexExpect, VortexResult, vortex_err};
 use vortex_expr::transform::immediate_access::annotate_scope_access;
 use vortex_expr::transform::{
-    partition, replace, replace_root_fields, simplify_typed, PartitionedExpr,
+    PartitionedExpr, partition, replace, replace_root_fields, simplify_typed,
 };
-use vortex_expr::{col, root, ExactExpr, ExprRef};
+use vortex_expr::{ExactExpr, ExprRef, col, root};
 use vortex_mask::Mask;
 use vortex_utils::aliases::dash_map::DashMap;
 use vortex_utils::aliases::hash_map::HashMap;

--- a/vortex-layout/src/layouts/zoned/reader.rs
+++ b/vortex-layout/src/layouts/zoned/reader.rs
@@ -10,19 +10,19 @@ use futures::future::{BoxFuture, Shared};
 use futures::{FutureExt, TryFutureExt};
 use itertools::Itertools;
 use parking_lot::RwLock;
+use vortex_array::ToCanonical;
 use vortex_array::pipeline::operators::MaskFuture;
 use vortex_array::stats::Precision;
-use vortex_array::ToCanonical;
 use vortex_dtype::{DType, FieldMask, FieldPath, FieldPathSet};
 use vortex_error::{SharedVortexResult, VortexError, VortexExpect, VortexResult};
 use vortex_expr::dynamic::DynamicExprUpdates;
 use vortex_expr::pruning::checked_pruning_expr;
-use vortex_expr::{root, ExprRef};
+use vortex_expr::{ExprRef, root};
 use vortex_mask::Mask;
 use vortex_utils::aliases::dash_map::DashMap;
 
-use crate::layouts::zoned::zone_map::ZoneMap;
 use crate::layouts::zoned::ZonedLayout;
+use crate::layouts::zoned::zone_map::ZoneMap;
 use crate::segments::SegmentSource;
 use crate::{ArrayFuture, LayoutReader};
 

--- a/vortex-layout/src/layouts/zoned/reader.rs
+++ b/vortex-layout/src/layouts/zoned/reader.rs
@@ -12,19 +12,19 @@ use itertools::Itertools;
 use parking_lot::RwLock;
 use vortex_array::pipeline::operators::MaskFuture;
 use vortex_array::stats::Precision;
-use vortex_array::{ArrayRef, ToCanonical};
+use vortex_array::ToCanonical;
 use vortex_dtype::{DType, FieldMask, FieldPath, FieldPathSet};
 use vortex_error::{SharedVortexResult, VortexError, VortexExpect, VortexResult};
 use vortex_expr::dynamic::DynamicExprUpdates;
 use vortex_expr::pruning::checked_pruning_expr;
-use vortex_expr::{ExprRef, root};
+use vortex_expr::{root, ExprRef};
 use vortex_mask::Mask;
 use vortex_utils::aliases::dash_map::DashMap;
 
-use crate::LayoutReader;
-use crate::layouts::zoned::ZonedLayout;
 use crate::layouts::zoned::zone_map::ZoneMap;
+use crate::layouts::zoned::ZonedLayout;
 use crate::segments::SegmentSource;
+use crate::{ArrayFuture, LayoutReader};
 
 type SharedZoneMap = Shared<BoxFuture<'static, SharedVortexResult<ZoneMap>>>;
 type SharedPruningResult = Shared<BoxFuture<'static, SharedVortexResult<Arc<PruningResult>>>>;
@@ -282,7 +282,7 @@ impl LayoutReader for ZonedReader {
         row_range: &Range<u64>,
         expr: &ExprRef,
         mask: MaskFuture,
-    ) -> VortexResult<BoxFuture<'static, VortexResult<ArrayRef>>> {
+    ) -> VortexResult<ArrayFuture> {
         // TODO(ngates): there are some projection expressions that we may also be able to
         //  short-circuit with statistics.
         self.data_child.projection_evaluation(row_range, expr, mask)

--- a/vortex-layout/src/reader.rs
+++ b/vortex-layout/src/reader.rs
@@ -7,11 +7,11 @@ use std::sync::Arc;
 
 use futures::future::BoxFuture;
 use once_cell::sync::OnceCell;
-use vortex_array::ArrayRef;
 use vortex_array::pipeline::operators::MaskFuture;
 use vortex_array::stats::Precision;
+use vortex_array::ArrayRef;
 use vortex_dtype::{DType, FieldMask};
-use vortex_error::{VortexResult, vortex_bail};
+use vortex_error::{vortex_bail, VortexResult};
 use vortex_expr::ExprRef;
 use vortex_mask::Mask;
 

--- a/vortex-layout/src/reader.rs
+++ b/vortex-layout/src/reader.rs
@@ -7,11 +7,11 @@ use std::sync::Arc;
 
 use futures::future::BoxFuture;
 use once_cell::sync::OnceCell;
+use vortex_array::ArrayRef;
 use vortex_array::pipeline::operators::MaskFuture;
 use vortex_array::stats::Precision;
-use vortex_array::ArrayRef;
 use vortex_dtype::{DType, FieldMask};
-use vortex_error::{vortex_bail, VortexResult};
+use vortex_error::{VortexResult, vortex_bail};
 use vortex_expr::ExprRef;
 use vortex_mask::Mask;
 

--- a/vortex-scan/src/filter.rs
+++ b/vortex-scan/src/filter.rs
@@ -3,14 +3,13 @@
 
 use std::iter;
 
-use bit_vec::BitVec;
 use itertools::Itertools;
 use parking_lot::RwLock;
 use sketches_ddsketch::DDSketch;
-use vortex_error::{vortex_err, vortex_panic, VortexExpect};
+use vortex_error::{VortexExpect, vortex_err, vortex_panic};
+use vortex_expr::ExprRef;
 use vortex_expr::dynamic::DynamicExprUpdates;
 use vortex_expr::forms::conjuncts;
-use vortex_expr::ExprRef;
 
 /// The selectivity histogram quantile to use for reordering conjuncts. Where 0 == no rows match.
 const DEFAULT_SELECTIVITY_QUANTILE: f64 = 0.1;

--- a/vortex-scan/src/filter.rs
+++ b/vortex-scan/src/filter.rs
@@ -7,10 +7,10 @@ use bit_vec::BitVec;
 use itertools::Itertools;
 use parking_lot::RwLock;
 use sketches_ddsketch::DDSketch;
-use vortex_error::{VortexExpect, vortex_err, vortex_panic};
-use vortex_expr::ExprRef;
+use vortex_error::{vortex_err, vortex_panic, VortexExpect};
 use vortex_expr::dynamic::DynamicExprUpdates;
 use vortex_expr::forms::conjuncts;
+use vortex_expr::ExprRef;
 
 /// The selectivity histogram quantile to use for reordering conjuncts. Where 0 == no rows match.
 const DEFAULT_SELECTIVITY_QUANTILE: f64 = 0.1;
@@ -51,6 +51,11 @@ impl FilterExpr {
         }
     }
 
+    /// Returns the order of the conjuncts by their expected selectivity.
+    pub fn order(&self) -> Vec<usize> {
+        self.ordering.read().clone()
+    }
+
     /// The conjuncts that make up this filter expression.
     #[inline]
     pub fn conjuncts(&self) -> &[ExprRef] {
@@ -61,14 +66,6 @@ impl FilterExpr {
     #[inline]
     pub fn dynamic_updates(&self, conjunct_idx: usize) -> Option<&DynamicExprUpdates> {
         self.dynamic_conjuncts[conjunct_idx].as_ref()
-    }
-
-    /// Returns the next preferred conjunct to evaluate.
-    #[inline]
-    pub fn next_conjunct(&self, remaining: &BitVec) -> Option<usize> {
-        let read = self.ordering.read();
-        // Take the first remaining conjunct in the ordered list.
-        read.iter().find(|&idx| remaining[*idx]).copied()
     }
 
     /// Report the selectivity of a conjunct, i.e. 0 means no rows matched the predicate.

--- a/vortex-scan/src/tasks.rs
+++ b/vortex-scan/src/tasks.rs
@@ -6,20 +6,38 @@
 use std::ops::{BitAnd, Range};
 use std::sync::Arc;
 
-use bit_vec::BitVec;
-use futures::FutureExt;
-use futures::future::{BoxFuture, ok};
-use vortex_array::ArrayRef;
+use futures::future::{ok, BoxFuture};
+use futures::{FutureExt, TryFutureExt};
+use itertools::Itertools;
+use parking_lot::Mutex;
 use vortex_array::pipeline::operators::MaskFuture;
+use vortex_array::ArrayRef;
 use vortex_error::VortexResult;
 use vortex_expr::ExprRef;
-use vortex_layout::LayoutReader;
+use vortex_layout::{LayoutReader, LayoutReaderRef};
 use vortex_mask::Mask;
 
-use crate::Selection;
 use crate::filter::FilterExpr;
+use crate::Selection;
 
 pub type TaskFuture<A> = BoxFuture<'static, VortexResult<A>>;
+
+/// Information needed to execute a single split task.
+pub(super) struct TaskContext<A> {
+    /// A caller-provided range of the file to read. All tasks should intersect their reads
+    /// with this range to ensure that they are split as well.
+    pub(super) row_range: Option<Range<u64>>,
+    /// A row selection to apply.
+    pub(super) selection: Selection,
+    /// The shared filter expression.
+    pub(super) filter: Option<Arc<FilterExpr>>,
+    /// The layout reader.
+    pub(super) reader: Arc<dyn LayoutReader>,
+    /// The projection expression to apply to gather the scanned rows.
+    pub(super) projection: ExprRef,
+    /// Function that maps into an A.
+    pub(super) mapper: Arc<dyn Fn(ArrayRef) -> VortexResult<A> + Send + Sync>,
+}
 
 /// Logic for executing a single split reading task.
 ///
@@ -77,73 +95,12 @@ pub(super) fn split_exec<A: 'static + Send>(
 
             MaskFuture::ready(row_mask)
         }
-        Some(filter) => {
-            // NOTE: it's very important that the pruning and filter evaluations are built OUTSIDE
-            // the future. Registering these row ranges eagerly is a hint to the IO system that
-            // we want to start prefetching the IO for this split.
-            let reader = ctx.reader.clone();
-            let filter = filter.clone();
-            let row_range = row_range.clone();
-
-            MaskFuture::new(row_mask.len(), async move {
-                let mut mask = row_mask;
-                let mut dynamic_versions = vec![None; filter.conjuncts().len()];
-
-                // TODO(ngates): we could use FuturedUnordered to intersect the masks in parallel.
-                for (idx, conjunct) in filter.conjuncts().iter().enumerate() {
-                    if mask.all_false() {
-                        return Ok(mask);
-                    }
-
-                    // Store the latest version of the dynamic expression prior to pruning.
-                    // We will re-run the pruning later if the version has changed in the meantime.
-                    dynamic_versions[idx] = filter.dynamic_updates(idx).map(|du| du.version());
-
-                    let conjunct_mask = reader
-                        .pruning_evaluation(&row_range, conjunct, mask.clone())?
-                        .await?;
-                    mask = mask.bitand(&conjunct_mask);
-                }
-
-                // Now we loop through the conjuncts in the preferred order and evaluate them.
-                let mut remaining = BitVec::from_elem(filter.conjuncts().len(), true);
-                while let Some(idx) = filter.next_conjunct(&remaining) {
-                    remaining.set(idx, false);
-                    if mask.all_false() {
-                        return Ok(mask);
-                    }
-
-                    let conjunct = &filter.conjuncts()[idx];
-
-                    // If the dynamic expression has changed since pruning, re-run the pruning.
-                    // Store the dynamic update once to avoid TOCTOU race condition
-                    let current_version = filter.dynamic_updates(idx).map(|du| du.version());
-                    if let Some(dv) = current_version
-                        && dynamic_versions[idx].is_none_or(|v| v < dv)
-                    {
-                        // The dynamic expression has been updated, re-run the pruning.
-                        dynamic_versions[idx] = Some(dv);
-                        let conjunct_mask = reader
-                            .pruning_evaluation(&row_range, conjunct, mask.clone())?
-                            .await?;
-                        mask = mask.bitand(&conjunct_mask);
-                    }
-                    if mask.all_false() {
-                        return Ok(mask);
-                    }
-
-                    let conjunct_mask = reader
-                        .filter_evaluation(&row_range, conjunct, MaskFuture::ready(mask))?
-                        .await?;
-                    filter.report_selectivity(idx, conjunct_mask.density());
-
-                    // Filter evaluations return a mask already intersected with the input mask.
-                    mask = conjunct_mask;
-                }
-
-                Ok(mask)
-            })
-        }
+        Some(filter) => filter_mask(
+            row_mask,
+            row_range.clone(),
+            filter.clone(),
+            ctx.reader.clone(),
+        ),
     };
 
     // Step 4: execute the projection, only at the mask for rows which match the filter
@@ -165,19 +122,107 @@ pub(super) fn split_exec<A: 'static + Send>(
     Ok(array_fut.boxed())
 }
 
-/// Information needed to execute a single split task.
-pub(super) struct TaskContext<A> {
-    /// A caller-provided range of the file to read. All tasks should intersect their reads
-    /// with this range to ensure that they are split as well.
-    pub(super) row_range: Option<Range<u64>>,
-    /// A row selection to apply.
-    pub(super) selection: Selection,
-    /// The shared filter expression.
-    pub(super) filter: Option<Arc<FilterExpr>>,
-    /// The layout reader.
-    pub(super) reader: Arc<dyn LayoutReader>,
-    /// The projection expression to apply to gather the scanned rows.
-    pub(super) projection: ExprRef,
-    /// Function that maps into an A.
-    pub(super) mapper: Arc<dyn Fn(ArrayRef) -> VortexResult<A> + Send + Sync>,
+fn filter_mask(
+    mask: Mask,
+    row_range: Range<u64>,
+    filter: Arc<FilterExpr>,
+    reader: LayoutReaderRef,
+) -> MaskFuture {
+    MaskFuture::new(mask.len(), async move {
+        // We collect together the dynamic version for each conjunct prior to evaluation.
+        // This allows us to detect if a dynamic expression has changed prior to actual evaluation
+        // and to re-run the pruning step if needed.
+        let mut dynamic_versions = Vec::with_capacity(filter.conjuncts().len());
+        for idx in 0..filter.conjuncts().len() {
+            dynamic_versions.push(Arc::new(Mutex::new(
+                filter.dynamic_updates(idx).map(|du| du.version()),
+            )))
+        }
+
+        // Now we create a MaskFuture to perform pruning concurrently.
+        let mask = MaskFuture::intersect(
+            MaskFuture::ready(mask.clone()),
+            filter
+                .conjuncts()
+                .iter()
+                .map(|conjunct| {
+                    reader.pruning_evaluation(&row_range, conjunct, Mask::new_true(mask.len()))
+                })
+                .try_collect()?,
+        );
+
+        // Now we loop through the conjuncts in the preferred order and evaluate them.
+        let idxs = filter.order().into_iter();
+
+        // For each conjunct, we create a function that takes an input MaskFuture, and returns a
+        // MaskFuture that performs the following steps:
+        // 1. If the current mask is all false, return early.
+        // 2. If the dynamic expression has changed since pruning, re-run the pruning step
+        //    and update the mask.
+        // 3. Run the full filter evaluation and update the mask.
+        // 4. Report the selectivity of the conjunct.
+        let fns = idxs.map(|idx| {
+            // For each filter, we re-run the pruning step _just before_ the mask
+            // is awaited.
+            let conjunct = filter.conjuncts()[idx].clone();
+            let dynamic_version = dynamic_versions[idx].clone();
+            let filter = filter.clone();
+            let reader = reader.clone();
+            let row_range = row_range.clone();
+
+            move |mask: MaskFuture| {
+                MaskFuture::new(
+                    mask.len(),
+                    mask.and_then(move |mut mask| async move {
+                        if mask.all_false() {
+                            // No need to re-run pruning if the mask is already all false.
+                            return Ok(mask);
+                        }
+
+                        // If the dynamic expression has changed since pruning, re-run the pruning.
+                        // Store the dynamic update once to avoid TOCTOU race condition
+                        let current_version = filter.dynamic_updates(idx).map(|du| du.version());
+                        let reprune = {
+                            let mut dv = dynamic_version.lock();
+                            match current_version {
+                                None => dv.is_some(),
+                                Some(current_version) => {
+                                    let reprune = dv.is_none_or(|v| v < current_version);
+                                    *dv = Some(current_version);
+                                    reprune
+                                }
+                            }
+                        };
+
+                        if reprune {
+                            mask = mask.bitand(
+                                &reader
+                                    .pruning_evaluation(&row_range, &conjunct, mask.clone())?
+                                    .await?,
+                            );
+                        }
+                        if mask.all_false() {
+                            return Ok(mask);
+                        }
+
+                        // Otherwise, run the full filter evaluation.
+                        let mask = reader
+                            .filter_evaluation(
+                                &row_range,
+                                &conjunct,
+                                MaskFuture::ready(mask.clone()),
+                            )?
+                            .await?;
+                        filter.report_selectivity(idx, mask.density());
+
+                        Ok(mask)
+                    }),
+                )
+            }
+        });
+
+        // Finally, we create a future that runs each conjunct future concurrently but passes the
+        // output mask of each conjunct to the next one in order.
+        MaskFuture::fold_intersect(mask, fns).await
+    })
 }

--- a/vortex-scan/src/tasks.rs
+++ b/vortex-scan/src/tasks.rs
@@ -6,19 +6,19 @@
 use std::ops::{BitAnd, Range};
 use std::sync::Arc;
 
-use futures::future::{ok, BoxFuture};
+use futures::future::{BoxFuture, ok};
 use futures::{FutureExt, TryFutureExt};
 use itertools::Itertools;
 use parking_lot::Mutex;
-use vortex_array::pipeline::operators::MaskFuture;
 use vortex_array::ArrayRef;
+use vortex_array::pipeline::operators::MaskFuture;
 use vortex_error::VortexResult;
 use vortex_expr::ExprRef;
 use vortex_layout::{LayoutReader, LayoutReaderRef};
 use vortex_mask::Mask;
 
-use crate::filter::FilterExpr;
 use crate::Selection;
+use crate::filter::FilterExpr;
 
 pub type TaskFuture<A> = BoxFuture<'static, VortexResult<A>>;
 

--- a/vortex-scan/src/tests/loom.rs
+++ b/vortex-scan/src/tests/loom.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use bit_vec::BitVec;
 use futures::future;
 use loom::sync::atomic::{AtomicUsize, Ordering};
 use loom::sync::{Arc, Mutex};
@@ -156,46 +155,6 @@ fn test_work_stealing_concurrent_factory_construction() {
         // Verify factories were constructed
         let final_count = counter.load(Ordering::SeqCst);
         assert!(final_count > 0 && final_count <= 3);
-    });
-}
-
-#[test]
-fn test_filter_expr_concurrent_selectivity_reporting() {
-    // Test concurrent selectivity reporting in FilterExpr
-    loom::model(|| {
-        let expr = lit(true); // Simple expression for testing
-        let filter = Arc::new(FilterExpr::new(expr));
-
-        let filter1 = filter.clone();
-        let filter2 = filter.clone();
-        let filter3 = filter;
-
-        // Multiple threads reporting selectivity
-        let handle1 = thread::spawn(move || {
-            filter1.report_selectivity(0, 0.5);
-            filter1.report_selectivity(0, 0.6);
-        });
-
-        let handle2 = thread::spawn(move || {
-            filter2.report_selectivity(0, 0.7);
-            filter2.report_selectivity(0, 0.4);
-        });
-
-        // Reader thread
-        let handle3 = thread::spawn(move || {
-            let mut remaining = BitVec::from_elem(1, true);
-            let conjunct = filter3.next_conjunct(&remaining);
-            assert_eq!(conjunct, Some(0));
-
-            // Mark as evaluated
-            remaining.set(0, false);
-            let conjunct = filter3.next_conjunct(&remaining);
-            assert_eq!(conjunct, None);
-        });
-
-        handle1.join().unwrap();
-        handle2.join().unwrap();
-        handle3.join().unwrap();
     });
 }
 
@@ -416,79 +375,6 @@ fn test_work_stealing_memory_ordering() {
         let mut final_values = seen_clone.lock().unwrap().clone();
         final_values.sort();
         assert_eq!(final_values, vec![100, 101, 102, 200, 201, 300]);
-    });
-}
-
-#[test]
-fn test_concurrent_filter_ordering_updates() {
-    // Test race conditions in filter ordering updates
-    // Multiple threads reading ordering while one updates it
-    loom::model(|| {
-        let expr = and(
-            gt(get_item("a", root()), lit(5)),
-            and(
-                lt(get_item("b", root()), lit(10)),
-                gt(get_item("c", root()), lit(0)),
-            ),
-        );
-        let filter = Arc::new(FilterExpr::new(expr));
-
-        // Create multiple reader threads and one writer thread
-        let filter_reader1 = filter.clone();
-        let filter_reader2 = filter.clone();
-        let filter_writer = filter;
-
-        // Writer thread continuously updates selectivity
-        let writer = thread::spawn(move || {
-            // Report different selectivities to trigger reordering
-            filter_writer.report_selectivity(0, 0.9); // Low selectivity
-            filter_writer.report_selectivity(1, 0.1); // High selectivity
-            filter_writer.report_selectivity(2, 0.5); // Medium selectivity
-
-            // Report more to potentially trigger reordering
-            filter_writer.report_selectivity(0, 0.8);
-            filter_writer.report_selectivity(1, 0.2);
-        });
-
-        // Reader threads continuously read the ordering
-        let reader1 = thread::spawn(move || {
-            let mut remaining = BitVec::from_elem(3, true);
-            let mut seen = Vec::new();
-
-            while let Some(idx) = filter_reader1.next_conjunct(&remaining) {
-                seen.push(idx);
-                remaining.set(idx, false);
-            }
-            seen
-        });
-
-        let reader2 = thread::spawn(move || {
-            let mut remaining = BitVec::from_elem(3, true);
-            let mut seen = Vec::new();
-
-            while let Some(idx) = filter_reader2.next_conjunct(&remaining) {
-                seen.push(idx);
-                remaining.set(idx, false);
-            }
-            seen
-        });
-
-        writer.join().unwrap();
-        let order1 = reader1.join().unwrap();
-        let order2 = reader2.join().unwrap();
-
-        // Both readers should see a valid ordering (all indices present)
-        assert_eq!(order1.len(), 3);
-        assert_eq!(order2.len(), 3);
-
-        // Check all indices are present
-        let mut sorted1 = order1;
-        sorted1.sort();
-        assert_eq!(sorted1, vec![0, 1, 2]);
-
-        let mut sorted2 = order2;
-        sorted2.sort();
-        assert_eq!(sorted2, vec![0, 1, 2]);
     });
 }
 


### PR DESCRIPTION
Use the new MaskFuture to perform concurrent filtering.

TODO(ngates): try racing the mask future in projection evaluations 