### PR TITLE
fix: teach zstd to include correct validity when decompressing utf8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7236,6 +7236,7 @@ dependencies = [
 name = "vortex-zstd"
 version = "0.1.0"
 dependencies = [
+ "itertools 0.14.0",
  "prost 0.14.1",
  "rstest",
  "vortex-array",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7245,6 +7245,7 @@ dependencies = [
  "vortex-error",
  "vortex-mask",
  "vortex-scalar",
+ "vortex-sparse",
  "zstd",
 ]
 

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache{ pub(crate) slice_start: () }2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::cmp;

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache{ pub(crate) slice_start: () }2.0
+// SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::cmp;

--- a/encodings/zstd/Cargo.toml
+++ b/encodings/zstd/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 [dependencies]
 prost = { workspace = true }
 vortex-array = { workspace = true }
+vortex-sparse = { workspace = true }
 vortex-buffer = { workspace = true }
 vortex-dtype = { workspace = true }
 vortex-error = { workspace = true }

--- a/encodings/zstd/Cargo.toml
+++ b/encodings/zstd/Cargo.toml
@@ -20,12 +20,12 @@ workspace = true
 itertools = { workspace = true }
 prost = { workspace = true }
 vortex-array = { workspace = true }
-vortex-sparse = { workspace = true }
 vortex-buffer = { workspace = true }
 vortex-dtype = { workspace = true }
 vortex-error = { workspace = true }
 vortex-mask = { workspace = true }
 vortex-scalar = { workspace = true }
+vortex-sparse = { workspace = true }
 zstd = { workspace = true }
 
 [dev-dependencies]

--- a/encodings/zstd/Cargo.toml
+++ b/encodings/zstd/Cargo.toml
@@ -17,6 +17,7 @@ version = { workspace = true }
 workspace = true
 
 [dependencies]
+itertools = { workspace = true }
 prost = { workspace = true }
 vortex-array = { workspace = true }
 vortex-sparse = { workspace = true }

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -6,7 +6,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use vortex_array::accessor::ArrayAccessor;
-use vortex_array::arrays::{BinaryView, PrimitiveArray, VarBinViewArray};
+use vortex_array::arrays::{BinaryView, ConstantArray, PrimitiveArray, VarBinViewArray};
 use vortex_array::compute::filter;
 use vortex_array::stats::{ArrayStats, StatsSetRef};
 use vortex_array::validity::Validity;
@@ -20,6 +20,7 @@ use vortex_dtype::DType;
 use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_err, vortex_panic};
 use vortex_mask::AllOr;
 use vortex_scalar::Scalar;
+use vortex_sparse::SparseArray;
 
 use crate::serde::{ZstdFrameMetadata, ZstdMetadata};
 
@@ -482,10 +483,31 @@ impl ZstdArray {
                         views,
                         Arc::from([decompressed]),
                         self.dtype.clone(),
-                        slice_validity,
+                        Validity::AllValid,
                     )
-                };
-                vbv.into_array()
+                }
+                .into_array();
+                match slice_validity.to_mask(slice_n_rows).indices() {
+                    AllOr::All => vbv,
+                    AllOr::None => {
+                        ConstantArray::new(Scalar::null(self.dtype.clone()), slice_n_rows)
+                            .into_array()
+                    }
+                    AllOr::Some(indices) => SparseArray::try_new(
+                        PrimitiveArray::from_iter(indices.into_iter().map(|x| *x as u64))
+                            .into_array(),
+                        vbv,
+                        slice_n_rows,
+                        Scalar::null(self.dtype.clone()),
+                    )
+                    // 1. Set indices should match string length by construction above.
+                    //
+                    // 2. Indices are strict-sorted because they come from a Validity mask.
+                    //
+                    // 3. Last index must be less than slice_n_rows because we sliced the Validity to slice_start .. slice_stop above.
+                    .vortex_expect("bad indices in utf8/binary zstd")
+                    .into_array(),
+                }
             }
             _ => vortex_panic!("Unsupported dtype for Zstd array: {}", self.dtype),
         }

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 use std::ops::Range;
 use std::sync::Arc;
 
+use itertools::Itertools as _;
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::{BinaryView, ConstantArray, PrimitiveArray, VarBinViewArray};
 use vortex_array::compute::filter;
@@ -20,7 +21,6 @@ use vortex_dtype::DType;
 use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_err, vortex_panic};
 use vortex_mask::AllOr;
 use vortex_scalar::Scalar;
-use vortex_sparse::SparseArray;
 
 use crate::serde::{ZstdFrameMetadata, ZstdMetadata};
 
@@ -469,44 +469,56 @@ impl ZstdArray {
                 primitive.into_array()
             }
             DType::Binary(_) | DType::Utf8(_) => {
-                // The decompressed buffer is a bunch of interleaved u32 lengths
-                // and strings of those lengths, we need to reconstruct the
-                // views into those strings by passing through the buffer.
-                let views = reconstruct_views(decompressed.clone()).slice(
-                    slice_value_idx_start - n_skipped_values
-                        ..slice_value_idx_stop - n_skipped_values,
-                );
-
-                // SAFETY: we properly construct the views inside `reconstruct_views`
-                let vbv = unsafe {
-                    VarBinViewArray::new_unchecked(
-                        views,
-                        Arc::from([decompressed]),
-                        self.dtype.clone(),
-                        Validity::AllValid,
-                    )
-                }
-                .into_array();
                 match slice_validity.to_mask(slice_n_rows).indices() {
-                    AllOr::All => vbv,
+                    AllOr::All => {
+                        // the decompressed buffer is a bunch of interleaved u32 lengths
+                        // and strings of those lengths, we need to reconstruct the
+                        // views into those strings by passing through the buffer.
+                        let valid_views = reconstruct_views(decompressed.clone()).slice(
+                            slice_value_idx_start - n_skipped_values
+                                ..slice_value_idx_stop - n_skipped_values,
+                        );
+
+                        // SAFETY: we properly construct the views inside `reconstruct_views`
+                        unsafe {
+                            VarBinViewArray::new_unchecked(
+                                valid_views,
+                                Arc::from([decompressed]),
+                                self.dtype.clone(),
+                                slice_validity,
+                            )
+                        }
+                        .into_array()
+                    }
                     AllOr::None => {
                         ConstantArray::new(Scalar::null(self.dtype.clone()), slice_n_rows)
                             .into_array()
                     }
-                    AllOr::Some(indices) => SparseArray::try_new(
-                        PrimitiveArray::from_iter(indices.into_iter().map(|x| *x as u64))
-                            .into_array(),
-                        vbv,
-                        slice_n_rows,
-                        Scalar::null(self.dtype.clone()),
-                    )
-                    // 1. Set indices should match string length by construction above.
-                    //
-                    // 2. Indices are strict-sorted because they come from a Validity mask.
-                    //
-                    // 3. Last index must be less than slice_n_rows because we sliced the Validity to slice_start .. slice_stop above.
-                    .vortex_expect("bad indices in utf8/binary zstd")
-                    .into_array(),
+                    AllOr::Some(valid_indices) => {
+                        // the decompressed buffer is a bunch of interleaved u32 lengths
+                        // and strings of those lengths, we need to reconstruct the
+                        // views into those strings by passing through the buffer.
+                        let valid_views = reconstruct_views(decompressed.clone()).slice(
+                            slice_value_idx_start - n_skipped_values
+                                ..slice_value_idx_stop - n_skipped_values,
+                        );
+
+                        let mut views = BufferMut::<BinaryView>::zeroed(slice_n_rows);
+                        for (view, index) in valid_views.into_iter().zip_eq(valid_indices) {
+                            views[*index] = view
+                        }
+
+                        // SAFETY: we properly construct the views inside `reconstruct_views`
+                        unsafe {
+                            VarBinViewArray::new_unchecked(
+                                views.freeze(),
+                                Arc::from([decompressed]),
+                                self.dtype.clone(),
+                                slice_validity,
+                            )
+                        }
+                        .into_array()
+                    }
                 }
             }
             _ => vortex_panic!("Unsupported dtype for Zstd array: {}", self.dtype),

--- a/encodings/zstd/src/test.rs
+++ b/encodings/zstd/src/test.rs
@@ -155,3 +155,29 @@ fn test_zstd_var_bin_view() {
     assert_nth_scalar!(sliced, 1, None::<String>);
     assert_nth_scalar!(sliced, 2, "Lorem ipsum dolor sit amet");
 }
+
+#[test]
+fn test_zstd_decompress_var_bin_view() {
+    let data: [Option<&'static [u8]>; 5] = [
+        Some(b"foo"),
+        Some(b"bar"),
+        None,
+        Some(b"Lorem ipsum dolor sit amet"),
+        Some(b"baz"),
+    ];
+    let array = VarBinViewArray::from_iter(data, DType::Utf8(Nullability::Nullable));
+
+    let compressed = ZstdArray::from_var_bin_view(&array, 0, 3).unwrap();
+    assert!(compressed.dictionary.is_none());
+    assert_nth_scalar!(compressed, 0, "foo");
+    assert_nth_scalar!(compressed, 1, "bar");
+    assert_nth_scalar!(compressed, 2, None::<String>);
+    assert_nth_scalar!(compressed, 3, "Lorem ipsum dolor sit amet");
+    assert_nth_scalar!(compressed, 4, "baz");
+    let decompressed = compressed.decompress().to_varbinview();
+    assert_nth_scalar!(decompressed, 0, "foo");
+    assert_nth_scalar!(decompressed, 1, "bar");
+    assert_nth_scalar!(decompressed, 2, None::<String>);
+    assert_nth_scalar!(decompressed, 3, "Lorem ipsum dolor sit amet");
+    assert_nth_scalar!(decompressed, 4, "baz");
+}


### PR DESCRIPTION
Zstd only stores the non-null values. When decompressing integers, it iterates through the set
indices of the validity to "spread" the non-null values to their correct positions. When
decompressing utf8, no such work is done. As a result, the Validity's length (which is the correct
length of the array) does not match the length of the VarBinView's values (which are just the
non-null values). Unfortunately, zstd uses `VarBinViewArray::new_unchecked` so the validity's length
is never verified to equal the array's length.

I implemented the simplest fix of which I could think: wrap the VarBin array in a Sparse array whose
indices are the valid indices.

---

The test fails this way on develop:

```
running 1 test
test test::test_zstd_decompress_var_bin_view ... FAILED

failures:

---- test::test_zstd_decompress_var_bin_view stdout ----

thread 'test::test_zstd_decompress_var_bin_view' panicked at encodings/zstd/src/test.rs:181:5:
assertion `left == right` failed
  left: Scalar { dtype: Utf8(Nullable), value: ScalarValue(BufferString(BufferString { string: "baz" })) }
 right: Scalar { dtype: Utf8(NonNullable), value: ScalarValue(BufferString(BufferString { string: "Lorem ipsum dolor sit amet" })) }
```