### PR TITLE
fix: use correct & safe bitwise-slicing in duckdb validity export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6720,6 +6720,7 @@ dependencies = [
  "bitvec",
  "cbindgen",
  "cc",
+ "codspeed-divan-compat",
  "futures",
  "glob",
  "itertools 0.14.0",

--- a/vortex-duckdb/Cargo.toml
+++ b/vortex-duckdb/Cargo.toml
@@ -39,10 +39,18 @@ url = { workspace = true }
 vortex = { workspace = true, features = ["files"] }
 vortex-file = { workspace = true, features = ["tokio", "object_store"] }
 vortex-utils = { workspace = true, features = ["dashmap"] }
+divan = { workspace = true, optional = true }
 
 [dev-dependencies]
 jiff = { workspace = true }
 rstest = { workspace = true }
+
+[features]
+bench = ["dep:divan"]
+
+[[bench]]
+name = "benchmark"
+harness = false
 
 [lints]
 workspace = true

--- a/vortex-duckdb/benches/benchmark.rs
+++ b/vortex-duckdb/benches/benchmark.rs
@@ -1,0 +1,5 @@
+extern crate vortex_duckdb; // Ensure benchmarks aren't optimised away
+
+fn main() {
+    divan::main()
+}

--- a/vortex-duckdb/src/exporter/mod.rs
+++ b/vortex-duckdb/src/exporter/mod.rs
@@ -233,46 +233,11 @@ fn copy_from_byte_slice(
     offset: usize,
     len: usize,
 ) -> usize {
-    assert!(target.len() == len, "{} {}", target.len(), len);
-    assert!(source.len() * 8 >= len, "{} {}", source.len(), len);
-
-    let (start, middle, end) = unsafe { source.align_to::<u64>() };
-    let start = start.view_bits::<Lsb0>();
-    let middle = middle.view_bits::<Lsb0>();
-    let end = end.view_bits::<Lsb0>();
-
-    let start_offset = std::cmp::min(offset, start.len());
-    let start_len = std::cmp::min(len, start.len() - start_offset);
-
-    let start_slice = &start[start_offset..][..start_len];
-    for (slice_index, value) in start_slice.iter().enumerate() {
-        target.set(slice_index, *value);
-    }
-
-    let target_cursor = start_slice.len();
-
-    let remaining_offset = offset.saturating_sub(start.len());
-    let remaining_len = len.saturating_sub(start_slice.len());
-
-    let middle_offset = std::cmp::min(remaining_offset, middle.len());
-    let middle_len = std::cmp::min(remaining_len, middle.len() - middle_offset);
-
-    let middle_slice = &middle[middle_offset..][..middle_len];
-    target[target_cursor..][..middle_len].copy_from_bitslice(middle_slice);
-
-    let target_cursor = target_cursor + middle_len;
-
-    let end_offset = remaining_offset.saturating_sub(middle.len());
-    let end_len = remaining_len.saturating_sub(middle_slice.len());
-
-    assert!(end_offset <= end.len(), "{} {}", end_offset, end.len());
-    assert!(end_len <= end.len(), "{} {}", end_len, end.len());
-
-    let end_slice = &end[end_offset..][..end_len];
-    for (slice_index, value) in end_slice.iter().enumerate() {
-        target.set(target_cursor + slice_index, *value);
-    }
-
+    let (start, middle, end) = unsafe { target.align_to_mut::<u8>() };
+    assert!(start.is_empty());
+    assert!(end.is_empty());
+    assert!(middle.len() == len, "{} {}", middle.len(), len);
+    middle.copy_from_bitslice(&source.view_bits()[offset..][..len]);
     target.count_ones()
 }
 
@@ -606,6 +571,88 @@ mod tests {
             target[1], 0xe0_40_38_30_2f_e7_ef_f7_u64,
             "{:#08x} == {:#08x}",
             target[1], 0xe0_40_38_30_2f_e7_ef_f7_u64,
+        );
+    }
+}
+
+#[cfg(feature = "bench")]
+pub mod benchmarks {
+    use crate::exporter::{copy_from_byte_slice, copy_from_byte_slice_fast};
+    use bitvec::order::Lsb0;
+    use bitvec::view::AsMutBits;
+
+    #[divan::bench(args = [64, 1024, 32768, 1048576, 33554432])]
+    fn test_bench_copy_from_byte_slice(n: u64) {
+        let mut target = (0..(n / 64)).map(|_| 0_u64).collect::<Vec<_>>();
+        let source = (0..(n / 8)).map(|x| (x % 255) as u8).collect::<Vec<_>>();
+
+        copy_from_byte_slice(
+            target.as_mut_bits::<Lsb0>(),
+            &source,
+            0,
+            usize::try_from(n).unwrap(),
+        );
+    }
+
+    fn copy_from_byte_slice_fast(
+        target: &mut BitSlice<u64, Lsb0>,
+        source: &[u8],
+        offset: usize,
+        len: usize,
+    ) -> usize {
+        assert!(target.len() == len, "{} {}", target.len(), len);
+        assert!(source.len() * 8 >= len, "{} {}", source.len(), len);
+
+        let (start, middle, end) = unsafe { source.align_to::<u64>() };
+        let start = start.view_bits::<Lsb0>();
+        let middle = middle.view_bits::<Lsb0>();
+        let end = end.view_bits::<Lsb0>();
+
+        let start_offset = std::cmp::min(offset, start.len());
+        let start_len = std::cmp::min(len, start.len() - start_offset);
+
+        let start_slice = &start[start_offset..][..start_len];
+        for (slice_index, value) in start_slice.iter().enumerate() {
+            target.set(slice_index, *value);
+        }
+
+        let target_cursor = start_slice.len();
+
+        let remaining_offset = offset.saturating_sub(start.len());
+        let remaining_len = len.saturating_sub(start_slice.len());
+
+        let middle_offset = std::cmp::min(remaining_offset, middle.len());
+        let middle_len = std::cmp::min(remaining_len, middle.len() - middle_offset);
+
+        let middle_slice = &middle[middle_offset..][..middle_len];
+        target[target_cursor..][..middle_len].copy_from_bitslice(middle_slice);
+
+        let target_cursor = target_cursor + middle_len;
+
+        let end_offset = remaining_offset.saturating_sub(middle.len());
+        let end_len = remaining_len.saturating_sub(middle_slice.len());
+
+        assert!(end_offset <= end.len(), "{} {}", end_offset, end.len());
+        assert!(end_len <= end.len(), "{} {}", end_len, end.len());
+
+        let end_slice = &end[end_offset..][..end_len];
+        for (slice_index, value) in end_slice.iter().enumerate() {
+            target.set(target_cursor + slice_index, *value);
+        }
+
+        target.count_ones()
+    }
+
+    #[divan::bench(args = [64, 1024, 32768, 1048576, 33554432])]
+    fn test_bench_copy_from_byte_slice_fast(n: u64) {
+        let mut target = (0..(n / 64)).map(|_| 0_u64).collect::<Vec<_>>();
+        let source = (0..(n / 8)).map(|x| (x % 255) as u8).collect::<Vec<_>>();
+
+        copy_from_byte_slice_fast(
+            target.as_mut_bits::<Lsb0>(),
+            &source,
+            0,
+            usize::try_from(n).unwrap(),
         );
     }
 }

--- a/vortex-duckdb/src/exporter/mod.rs
+++ b/vortex-duckdb/src/exporter/mod.rs
@@ -211,7 +211,7 @@ impl VectorExt for Vector {
                 true
             }
             Mask::Values(arr) => {
-                // SAFETY: Caller guaranteees this.
+                // SAFETY: Caller guarantees this.
                 let target = &mut unsafe { self.ensure_validity_slice(len) }[..len];
                 let source = arr.boolean_buffer().inner().as_slice();
 

--- a/vortex-duckdb/src/exporter/mod.rs
+++ b/vortex-duckdb/src/exporter/mod.rs
@@ -16,6 +16,7 @@ mod varbinview;
 use std::sync::Arc;
 
 use bitvec::prelude::Lsb0;
+use bitvec::slice::BitSlice;
 use bitvec::view::BitView;
 pub use cache::ConversionCache;
 pub use decimal::precision_to_duckdb_storage_size;
@@ -210,42 +211,82 @@ impl VectorExt for Vector {
                 true
             }
             Mask::Values(arr) => {
-                let arr_bits: &[u64] = {
-                    let byte_slice = arr.boolean_buffer().inner().as_slice();
-                    unsafe {
-                        std::slice::from_raw_parts(
-                            byte_slice.as_ptr() as _,
-                            byte_slice.len().div_ceil(size_of::<u64>()),
-                        )
-                    }
-                };
-                let sliced_bits = &arr_bits.view_bits::<Lsb0>()[offset..][..len];
-                let true_count = sliced_bits.count_ones();
-                if true_count == len {
-                    if let Some(validity) = unsafe { self.validity_slice_mut(len) } {
-                        validity.fill(true);
-                    }
-                } else if true_count == 0 {
-                    unsafe { self.ensure_validity_slice(len) }.fill(false);
-                } else {
-                    // SAFETY: Caller guaranteees this.
-                    let validity = unsafe { self.ensure_validity_slice(len) };
-                    validity[..len].copy_from_bitslice(sliced_bits);
-                }
-                true_count == 0
+                // SAFETY: Caller guaranteees this.
+                let target = &mut unsafe { self.ensure_validity_slice(len) }[..len];
+                let source = arr.boolean_buffer().inner().as_slice();
+
+                let n_set_bits = copy_from_byte_slice(target, source, offset, len);
+                n_set_bits == 0
             }
         }
     }
 }
 
+/// Copy the sliced bits from source into target. Returns the number of now set bits in target.
+///
+/// Offset and length are a _bit_ offset and a _bit_ length into source.
+///
+/// `target.len()` must equal `len`.
+fn copy_from_byte_slice(
+    target: &mut BitSlice<u64, Lsb0>,
+    source: &[u8],
+    offset: usize,
+    len: usize,
+) -> usize {
+    assert!(target.len() == len, "{} {}", target.len(), len);
+    assert!(source.len() * 8 >= len, "{} {}", source.len(), len);
+
+    let (start, middle, end) = unsafe { source.align_to::<u64>() };
+    let start = start.view_bits::<Lsb0>();
+    let middle = middle.view_bits::<Lsb0>();
+    let end = end.view_bits::<Lsb0>();
+
+    let start_offset = std::cmp::min(offset, start.len());
+    let start_len = std::cmp::min(len, start.len() - start_offset);
+
+    let start_slice = &start[start_offset..][..start_len];
+    for (slice_index, value) in start_slice.iter().enumerate() {
+        target.set(slice_index, *value);
+    }
+
+    let target_cursor = start_slice.len();
+
+    let remaining_offset = offset.saturating_sub(start.len());
+    let remaining_len = len.saturating_sub(start_slice.len());
+
+    let middle_offset = std::cmp::min(remaining_offset, middle.len());
+    let middle_len = std::cmp::min(remaining_len, middle.len() - middle_offset);
+
+    let middle_slice = &middle[middle_offset..][..middle_len];
+    target[target_cursor..][..middle_len].copy_from_bitslice(middle_slice);
+
+    let target_cursor = target_cursor + middle_len;
+
+    let end_offset = remaining_offset.saturating_sub(middle.len());
+    let end_len = remaining_len.saturating_sub(middle_slice.len());
+
+    assert!(end_offset <= end.len(), "{} {}", end_offset, end.len());
+    assert!(end_len <= end.len(), "{} {}", end_len, end.len());
+
+    let end_slice = &end[end_offset..][..end_len];
+    for (slice_index, value) in end_slice.iter().enumerate() {
+        target.set(target_cursor + slice_index, *value);
+    }
+
+    target.count_ones()
+}
+
 #[cfg(test)]
 mod tests {
     use arrow_buffer::buffer::BooleanBuffer;
+    use bitvec::order::Lsb0;
+    use bitvec::view::AsMutBits;
     use vortex::mask::Mask;
 
     use super::VectorExt;
     use crate::cpp::DUCKDB_TYPE;
     use crate::duckdb::{LogicalType, Vector};
+    use crate::exporter::copy_from_byte_slice;
 
     #[test]
     fn test_set_validity_all_true() {
@@ -391,5 +432,180 @@ mod tests {
         for i in 0..60 {
             assert_eq!(validity[i], bits[i + 5]);
         }
+    }
+
+    #[test]
+    fn test_copy_from_byte_slice_empty_to_empty() {
+        let target = [].as_mut_bits::<Lsb0>();
+        let source = Vec::<u8>::new();
+        copy_from_byte_slice(target, &source, 0, 0);
+    }
+
+    #[test]
+    fn test_copy_from_byte_slice_64_to_empty() {
+        let target = [].as_mut_bits::<Lsb0>();
+        let source = [1u8, 2, 3, 50, 51, 52, 100, 101];
+        copy_from_byte_slice(target, &source, 0, 0);
+        copy_from_byte_slice(target, &source, 5, 0);
+        copy_from_byte_slice(target, &source, 8, 0);
+    }
+
+    #[test]
+    fn test_copy_from_byte_slice_64_to_64() {
+        let mut target = vec![0u64];
+        let source = [1u8, 2, 3, 50, 51, 52, 100, 101];
+        copy_from_byte_slice(target.as_mut_bits::<Lsb0>(), &source, 0, 64);
+        assert_eq!(
+            target[0], 0x65_64_34_33_32_03_02_01_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0x65_64_34_33_32_03_02_01_u64,
+        );
+    }
+
+    #[test]
+    fn test_copy_from_byte_slice_80_to_0() {
+        let target = [].as_mut_bits::<Lsb0>();
+        let source = [1u8, 2, 3, 50, 51, 52, 100, 101, 254, 255];
+        copy_from_byte_slice(target, &source, 0, 0);
+        copy_from_byte_slice(target, &source, 8, 0);
+        copy_from_byte_slice(target, &source, 10, 0);
+    }
+
+    #[test]
+    fn test_copy_from_byte_slice_80_to_64_case_1() {
+        let mut target = [0u64];
+        let source = [1u8, 2, 3, 50, 51, 52, 100, 101, 254, 255];
+        copy_from_byte_slice(target.as_mut_bits::<Lsb0>(), &source, 16, 64);
+        assert_eq!(
+            target[0], 0xff_fe_65_64_34_33_32_03_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0xff_fe_65_64_34_33_32_03_u64,
+        );
+    }
+
+    #[test]
+    fn test_copy_from_byte_slice_80_to_64_case_2() {
+        let mut target = [0u64];
+        let source = [1u8, 2, 3, 50, 51, 52, 100, 101, 254, 255];
+        copy_from_byte_slice(target.as_mut_bits::<Lsb0>(), &source, 8, 64);
+        assert_eq!(
+            target[0], 0xfe_65_64_34_33_32_03_02_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0xfe_65_64_34_33_32_03_02_u64,
+        );
+    }
+
+    #[test]
+    fn test_copy_from_byte_slice_80_to_64_case_3() {
+        let mut target = [0u64];
+        let source = [1u8, 2, 3, 50, 51, 52, 100, 101, 254, 255];
+        copy_from_byte_slice(target.as_mut_bits::<Lsb0>(), &source, 0, 64);
+        assert_eq!(
+            target[0], 0x65_64_34_33_32_03_02_01_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0x65_64_34_33_32_03_02_01_u64,
+        );
+    }
+
+    #[test]
+    fn test_copy_from_byte_slice_80_to_64_case_4() {
+        let mut target = [0u64];
+        let source = [1u8, 2, 3, 50, 51, 52, 100, 101, 254, 255];
+        copy_from_byte_slice(target.as_mut_bits::<Lsb0>(), &source, 10, 64);
+        assert_eq!(
+            target[0],
+            0xff_99_59_0d_0c_cc_80_c0_u64, // Python: hex(0xff_fe_65_64_34_33_32_03_02 >> 2), then remove the high two hexits
+            "{:#08x} == {:#08x}",
+            target[0],
+            0xff_99_59_0d_0c_cc_80_c0_u64
+        );
+    }
+
+    #[test]
+    fn test_copy_from_byte_slice_248_to_128_middle_non_empty() {
+        let mut target = [0u64, 0u64];
+        let source: [u8; 31] = [
+            0x01, 0x02, 0x03, 0x04, 0xff, 0xfe, 0xfd, 0xfc, 0x05, 0x06, 0x07, 0x08, 0xfc, 0xfb,
+            0xfa, 0xf9, 0x01, 0x02, 0x03, 0x04, 0xff, 0xfe, 0xfd, 0xfc, 0x05, 0x06, 0x07, 0x08,
+            0xfc, 0xfb, 0xfa,
+        ];
+        // In a span of 248 bits (31 bytes) there should be at least one 8-byte aligned span.
+        let (_, middle, _) = unsafe { source.align_to::<u64>() };
+        assert!(middle.len() != 0);
+
+        copy_from_byte_slice(target.as_mut_bits::<Lsb0>(), &source, 0, 128);
+        assert_eq!(
+            target[0], 0xfc_fd_fe_ff_04_03_02_01_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0xfc_fd_fe_ff_04_03_02_01_u64,
+        );
+        assert_eq!(
+            target[1], 0xf9_fa_fb_fc_08_07_06_05_u64,
+            "{:#08x} == {:#08x}",
+            target[1], 0xf9_fa_fb_fc_08_07_06_05_u64,
+        );
+
+        copy_from_byte_slice(target.as_mut_bits::<Lsb0>(), &source, 8, 128);
+        assert_eq!(
+            target[0], 0x05_fc_fd_fe_ff_04_03_02_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0x05_fc_fd_fe_ff_04_03_02_u64,
+        );
+        assert_eq!(
+            target[1], 0x01_f9_fa_fb_fc_08_07_06_u64,
+            "{:#08x} == {:#08x}",
+            target[1], 0x01_f9_fa_fb_fc_08_07_06_u64,
+        );
+
+        copy_from_byte_slice(target.as_mut_bits::<Lsb0>(), &source, 8 * 8, 128);
+        assert_eq!(
+            target[0], 0xf9_fa_fb_fc_08_07_06_05_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0xf9_fa_fb_fc_08_07_06_05_u64,
+        );
+        assert_eq!(
+            target[1], 0xfc_fd_fe_ff_04_03_02_01_u64,
+            "{:#08x} == {:#08x}",
+            target[1], 0xfc_fd_fe_ff_04_03_02_01_u64,
+        );
+
+        copy_from_byte_slice(target.as_mut_bits::<Lsb0>(), &source, 8 * 12, 128);
+        assert_eq!(
+            target[0], 0x04_03_02_01_f9_fa_fb_fc_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0x04_03_02_01_f9_fa_fb_fc_u64,
+        );
+        assert_eq!(
+            target[1], 0x08_07_06_05_fc_fd_fe_ff_u64,
+            "{:#08x} == {:#08x}",
+            target[1], 0x08_07_06_05_fc_fd_fe_ff_u64,
+        );
+
+        copy_from_byte_slice(target.as_mut_bits::<Lsb0>(), &source, 8 * 12 + 4, 128);
+        // Find the 12th byte, skip the first hexit, take the next 32 hexits (i.e. 16 bytesor 128
+        // bits).
+        assert_eq!(
+            target[0], 0xf0_40_30_20_1f_9f_af_bf_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0xf0_40_30_20_1f_9f_af_bf_u64,
+        );
+        assert_eq!(
+            target[1], 0xc0_80_70_60_5f_cf_df_ef_u64,
+            "{:#08x} == {:#08x}",
+            target[1], 0xc0_80_70_60_5f_cf_df_ef_u64,
+        );
+
+        // Take the above and shift one bit towards the right-hand-side.
+        copy_from_byte_slice(target.as_mut_bits::<Lsb0>(), &source, 8 * 12 + 4 + 1, 128);
+        assert_eq!(
+            target[0], 0xf8_20_18_10_0f_cf_d7_df_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0xf8_20_18_10_0f_cf_d7_df_u64,
+        );
+        assert_eq!(
+            target[1], 0xe0_40_38_30_2f_e7_ef_f7_u64,
+            "{:#08x} == {:#08x}",
+            target[1], 0xe0_40_38_30_2f_e7_ef_f7_u64,
+        );
     }
 }

--- a/vortex-duckdb/src/exporter/mod.rs
+++ b/vortex-duckdb/src/exporter/mod.rs
@@ -531,7 +531,7 @@ mod tests {
         ];
         // In a span of 248 bits (31 bytes) there should be at least one 8-byte aligned span.
         let (_, middle, _) = unsafe { source.align_to::<u64>() };
-        assert!(middle.len() != 0);
+        assert!(!middle.is_empty());
 
         copy_from_byte_slice(target.as_mut_bits::<Lsb0>(), &source, 0, 128);
         assert_eq!(


### PR DESCRIPTION
I use align_to to find a prefix, suffix, and 8-byte aligned slices. The 8-byte aligned slice uses the fast `copy_from_bitslice`. The other two loop.