### PR TITLE
feat: teach vortex-tui to show full name paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7203,6 +7203,7 @@ dependencies = [
  "futures-util",
  "humansize",
  "indicatif",
+ "itertools 0.14.0",
  "parquet",
  "ratatui",
  "taffy",

--- a/vortex-tui/Cargo.toml
+++ b/vortex-tui/Cargo.toml
@@ -22,6 +22,7 @@ futures-executor = { workspace = true }
 futures-util = { workspace = true }
 humansize = { workspace = true }
 indicatif = { workspace = true, features = ["futures"] }
+itertools = { workspace = true }
 parquet = { workspace = true, features = ["arrow", "async"] }
 ratatui = { workspace = true }
 taffy = { workspace = true }

--- a/vortex-tui/src/segments.rs
+++ b/vortex-tui/src/segments.rs
@@ -23,7 +23,6 @@ pub async fn segments(file: impl AsRef<Path>) -> VortexResult<()> {
     let mut queue = VecDeque::<(Vec<Arc<str>>, LayoutRef)>::from_iter([(Vec::new(), root_layout)]);
     while !queue.is_empty() {
         let (path, layout) = queue.pop_front().vortex_expect("queue is not empty");
-
         for segment in layout.segment_ids() {
             segment_paths[*segment as usize] = Some(path.clone());
         }

--- a/vortex-tui/src/segments.rs
+++ b/vortex-tui/src/segments.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use itertools::Itertools as _;
 use std::collections::VecDeque;
 use std::fmt::Display;
 use std::path::Path;
 use std::sync::Arc;
 
+use itertools::Itertools as _;
 use vortex::error::{VortexExpect, VortexResult};
 use vortex::file::VortexOpenOptions;
 use vortex::layout::LayoutRef;

--- a/vortex-tui/src/segments.rs
+++ b/vortex-tui/src/segments.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use itertools::Itertools as _;
 use std::collections::VecDeque;
+use std::fmt::Display;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -14,23 +16,25 @@ pub async fn segments(file: impl AsRef<Path>) -> VortexResult<()> {
 
     let segment_map = vxf.footer().segment_map();
 
-    let mut segment_names: Vec<Option<Arc<str>>> = vec![None; segment_map.len()];
+    let mut segment_paths: Vec<Option<Vec<Arc<str>>>> = vec![None; segment_map.len()];
 
     let root_layout = vxf.footer().layout().clone();
 
-    let mut queue = VecDeque::<(Arc<str>, LayoutRef)>::from_iter([("".into(), root_layout)]);
+    let mut queue = VecDeque::<(Vec<Arc<str>>, LayoutRef)>::from_iter([(Vec::new(), root_layout)]);
     while !queue.is_empty() {
-        let (name, layout) = queue.pop_front().vortex_expect("queue is not empty");
-        for segment in layout.segment_ids() {
-            segment_names[*segment as usize] = Some(name.clone());
-        }
+        let (path, layout) = queue.pop_front().vortex_expect("queue is not empty");
 
         for (child_layout, child_name) in layout.children()?.into_iter().zip(layout.child_names()) {
-            queue.push_back((child_name, child_layout));
+            let child_path = path.iter().cloned().chain([child_name]).collect();
+            queue.push_back((child_path, child_layout));
+        }
+
+        for segment in layout.segment_ids() {
+            segment_paths[*segment as usize] = Some(path.clone());
         }
     }
 
-    for (i, name) in segment_names.iter().enumerate() {
+    for (i, name) in segment_paths.iter().enumerate() {
         println!(
             "{}: {}..{} (len={}, alignment={}) - {}",
             i,
@@ -38,7 +42,10 @@ pub async fn segments(file: impl AsRef<Path>) -> VortexResult<()> {
             segment_map[i].offset + segment_map[i].length as u64,
             segment_map[i].length,
             segment_map[i].alignment,
-            name.clone().unwrap_or_else(|| "<missing>".into())
+            match name.as_ref() {
+                Some(path) => &path.iter().format(".") as &dyn Display,
+                None => &"<missing>",
+            }
         );
     }
 

--- a/vortex-tui/src/segments.rs
+++ b/vortex-tui/src/segments.rs
@@ -24,13 +24,13 @@ pub async fn segments(file: impl AsRef<Path>) -> VortexResult<()> {
     while !queue.is_empty() {
         let (path, layout) = queue.pop_front().vortex_expect("queue is not empty");
 
+        for segment in layout.segment_ids() {
+            segment_paths[*segment as usize] = Some(path.clone());
+        }
+
         for (child_layout, child_name) in layout.children()?.into_iter().zip(layout.child_names()) {
             let child_path = path.iter().cloned().chain([child_name]).collect();
             queue.push_back((child_path, child_layout));
-        }
-
-        for segment in layout.segment_ids() {
-            segment_paths[*segment as usize] = Some(path.clone());
         }
     }
 


### PR DESCRIPTION
For example:
```
0: 8..140 (len=132, alignment=8) - CHROM.data.codes
1: 144..280 (len=136, alignment=8) - CHROM.data.values
2: 280..508 (len=228, alignment=8) - POS.data
3: 512..700 (len=188, alignment=8) - ID.data.codes
4: 704..1152 (len=448, alignment=8) - ID.data.values
5: 1152..1324 (len=172, alignment=8) - REF.data.codes
6: 1328..1512 (len=184, alignment=8) - REF.data.values
7: 1512..1980 (len=468, alignment=8) - ALT.data
8: 1984..2144 (len=160, alignment=8) - QUAL.data
9: 2144..2652 (len=508, alignment=8) - FILTER.data
10: 2656..55668 (len=53012, alignment=8) - GT.data
11: 55672..185084 (len=129412, alignment=8) - GQ.data
12: 185088..342284 (len=157196, alignment=8) - DP.data
13: 342288..395500 (len=53212, alignment=8) - AD.data
14: 395504..556044 (len=160540, alignment=8) - MIN_DP.data
15: 556048..558268 (len=2220, alignment=8) - PGT.data
16: 558272..561180 (len=2908, alignment=8) - PID.data
17: 561184..575804 (len=14620, alignment=8) - PL.data
18: 575808..591980 (len=16172, alignment=8) - SB.data
19: 591984..592448 (len=464, alignment=8) - CHROM.zones
20: 592448..593012 (len=564, alignment=8) - POS.zones
21: 593016..593480 (len=464, alignment=8) - ID.zones
22: 593480..593936 (len=456, alignment=8) - REF.zones
23: 593936..594120 (len=184, alignment=8) - ALT.zones
24: 594120..594384 (len=264, alignment=8) - QUAL.zones
25: 594384..594568 (len=184, alignment=8) - FILTER.zones
26: 594568..594752 (len=184, alignment=8) - GT.zones
27: 594752..594936 (len=184, alignment=8) - GQ.zones
28: 594936..595120 (len=184, alignment=8) - DP.zones
29: 595120..595304 (len=184, alignment=8) - AD.zones
30: 595304..595488 (len=184, alignment=8) - MIN_DP.zones
31: 595488..595672 (len=184, alignment=8) - PGT.zones
32: 595672..595856 (len=184, alignment=8) - PID.zones
33: 595856..596040 (len=184, alignment=8) - PL.zones
34: 596040..596224 (len=184, alignment=8) - SB.zones
```