### PR TITLE
fix: fix deserialization bug in pco

### DIFF
--- a/encodings/pco/src/serde.rs
+++ b/encodings/pco/src/serde.rs
@@ -61,17 +61,17 @@ impl SerdeVTable<PcoVTable> for PcoVTable {
             vortex_bail!("PcoArray expected 0 or 1 child, got {}", children.len());
         };
 
-        let mut chunk_metas = vec![];
-        let mut pages = vec![];
-        let mut buffer_idx = 0;
-        for chunk_info in &metadata.chunks {
-            chunk_metas.push(buffers[buffer_idx].clone());
-            buffer_idx += 1;
-            for _ in &chunk_info.pages {
-                pages.push(buffers[buffer_idx].clone());
-                buffer_idx += 1;
-            }
-        }
+        let chunk_metas = buffers[..metadata.chunks.len()]
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        let pages = buffers[metadata.chunks.len()..]
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let expected_n_pages = metadata.chunks.iter().map(|info| info.pages.len()).sum();
+        assert_eq!(pages.len(), expected_n_pages);
 
         Ok(PcoArray::new(
             chunk_metas,

--- a/encodings/pco/src/serde.rs
+++ b/encodings/pco/src/serde.rs
@@ -7,7 +7,7 @@ use vortex_array::vtable::{EncodeVTable, SerdeVTable, VisitorVTable};
 use vortex_array::{ArrayBufferVisitor, ArrayChildVisitor, ProstMetadata};
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
-use vortex_error::{VortexResult, vortex_bail};
+use vortex_error::{VortexResult, vortex_bail, vortex_ensure};
 
 use crate::{PcoArray, PcoEncoding, PcoVTable};
 
@@ -61,6 +61,7 @@ impl SerdeVTable<PcoVTable> for PcoVTable {
             vortex_bail!("PcoArray expected 0 or 1 child, got {}", children.len());
         };
 
+        vortex_ensure!(buffers.len() >= metadata.chunks.len());
         let chunk_metas = buffers[..metadata.chunks.len()].to_vec();
         let pages = buffers[metadata.chunks.len()..].to_vec();
 
@@ -69,7 +70,7 @@ impl SerdeVTable<PcoVTable> for PcoVTable {
             .iter()
             .map(|info| info.pages.len())
             .sum::<usize>();
-        assert_eq!(pages.len(), expected_n_pages);
+        vortex_ensure!(pages.len() == expected_n_pages);
 
         Ok(PcoArray::new(
             chunk_metas,

--- a/encodings/pco/src/serde.rs
+++ b/encodings/pco/src/serde.rs
@@ -61,16 +61,14 @@ impl SerdeVTable<PcoVTable> for PcoVTable {
             vortex_bail!("PcoArray expected 0 or 1 child, got {}", children.len());
         };
 
-        let chunk_metas = buffers[..metadata.chunks.len()]
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>();
-        let pages = buffers[metadata.chunks.len()..]
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>();
+        let chunk_metas = buffers[..metadata.chunks.len()].to_vec();
+        let pages = buffers[metadata.chunks.len()..].to_vec();
 
-        let expected_n_pages = metadata.chunks.iter().map(|info| info.pages.len()).sum();
+        let expected_n_pages = metadata
+            .chunks
+            .iter()
+            .map(|info| info.pages.len())
+            .sum::<usize>();
         assert_eq!(pages.len(), expected_n_pages);
 
         Ok(PcoArray::new(

--- a/encodings/pco/src/test.rs
+++ b/encodings/pco/src/test.rs
@@ -2,15 +2,18 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 #![allow(clippy::cast_possible_truncation)]
 
-use vortex_array::ToCanonical;
 use vortex_array::arrays::{BoolArray, PrimitiveArray};
+use vortex_array::arrow::compute::to_arrow_preferred;
+use vortex_array::serde::{ArrayParts, SerializeOptions};
 use vortex_array::validity::Validity;
 use vortex_array::vtable::ValidityHelper;
-use vortex_buffer::Buffer;
+use vortex_array::{ArrayContext, ArrayRegistry, EncodingRef, ToCanonical};
+use vortex_buffer::{Buffer, BufferMut};
+use vortex_dtype::{DType, Nullability, PType};
 use vortex_mask::Mask;
 use vortex_scalar::Scalar;
 
-use crate::PcoArray;
+use crate::{PcoArray, PcoEncoding};
 
 macro_rules! assert_nth_scalar {
     ($arr:expr, $n:expr, $expected:expr) => {
@@ -118,5 +121,45 @@ fn test_validity_vtable() {
     assert_eq!(
         compressed.slice(1..4).validity_mask(),
         Mask::from_iter(vec![true, true, false])
+    );
+}
+
+#[test]
+fn test_serde() {
+    let data: BufferMut<i32> = (0..1_000_000).collect();
+    let pco = PcoArray::from_primitive(&PrimitiveArray::new(data, Validity::NonNullable), 3, 100)
+        .unwrap()
+        .to_array();
+    let context = ArrayContext::empty().with_many(
+        ArrayRegistry::canonical_only()
+            .vtables()
+            .cloned()
+            .chain([EncodingRef::new_ref(PcoEncoding.as_ref())]),
+    );
+    let bytes = pco
+        .serialize(
+            &context,
+            &SerializeOptions {
+                offset: 0,
+                include_padding: true,
+            },
+        )
+        .unwrap()
+        .into_iter()
+        .flat_map(|x| x.into_iter())
+        .collect::<BufferMut<u8>>()
+        .freeze();
+
+    let parts = ArrayParts::try_from(bytes).unwrap();
+    let decoded = parts
+        .decode(
+            &context,
+            &DType::Primitive(PType::I32, Nullability::NonNullable),
+            1_000_000,
+        )
+        .unwrap();
+    assert_eq!(
+        &to_arrow_preferred(&pco).unwrap(),
+        &to_arrow_preferred(&decoded).unwrap()
     );
 }

--- a/vortex-error/src/lib.rs
+++ b/vortex-error/src/lib.rs
@@ -430,7 +430,7 @@ macro_rules! vortex_bail {
 #[macro_export]
 macro_rules! vortex_ensure {
     ($cond:expr) => {
-        vortex_ensure!($cond, stringify!($cond));
+        vortex_ensure!($cond, AssertionFailed: "{}", stringify!($cond));
     };
     ($cond:expr, $($tt:tt)*) => {
         if !$cond {


### PR DESCRIPTION
The buffer visitor pretty clearly visits all the chunk metadata followed by all the page metadata.

I can see a cache efficiency argument for meta0 meta0_page1 meta0_page2 ... meta1 ... but this PR at least allows deserialization of already-written pco arrays.