### PR TITLE
fix: teach vortex-duckdb to safely copy validity

### DIFF
--- a/vortex-duckdb/src/convert/vector.rs
+++ b/vortex-duckdb/src/convert/vector.rs
@@ -467,7 +467,7 @@ mod tests {
 
         // Set middle element as null
         // SAFETY: Vector was created with this length.
-        let validity_slice = unsafe { vector.ensure_validity_slice(len) };
+        let validity_slice = unsafe { vector.ensure_validity_bitslice(len) };
         validity_slice.set(1, false);
 
         // Test conversion
@@ -584,7 +584,7 @@ mod tests {
 
         // Set middle element as null
         // SAFETY: Vector was created with this length.
-        let validity_slice = unsafe { vector.ensure_validity_slice(len) };
+        let validity_slice = unsafe { vector.ensure_validity_bitslice(len) };
         validity_slice.set(1, false);
 
         // Test conversion

--- a/vortex-duckdb/src/duckdb/vector.rs
+++ b/vortex-duckdb/src/duckdb/vector.rs
@@ -8,6 +8,7 @@ use arrow_buffer;
 use arrow_buffer::Buffer;
 use bitvec::macros::internal::funty::Fundamental;
 use bitvec::slice::BitSlice;
+use bitvec::view::BitView;
 use vortex::error::{VortexResult, VortexUnwrap, vortex_bail, vortex_err};
 
 use crate::cpp::duckdb_vx_error;
@@ -142,7 +143,17 @@ impl Vector {
     /// # SAFETY
     ///
     /// The provided capacity *must* be the actual capacity of this vector.
-    pub unsafe fn ensure_validity_slice(&mut self, capacity: usize) -> &mut BitSlice<u64> {
+    pub unsafe fn ensure_validity_bitslice(&mut self, capacity: usize) -> &mut BitSlice<u64> {
+        unsafe { self.ensure_validity_slice(capacity) }.view_bits_mut()
+    }
+
+    #[allow(clippy::expect_used)]
+    /// Ensure the validity slice is writable.
+    ///
+    /// # SAFETY
+    ///
+    /// The provided capacity *must* be the actual capacity of this vector.
+    pub unsafe fn ensure_validity_slice(&mut self, capacity: usize) -> &mut [u64] {
         unsafe {
             cpp::duckdb_vector_ensure_validity_writable(self.as_ptr());
             self.validity_slice_mut(capacity)
@@ -155,13 +166,21 @@ impl Vector {
     /// # SAFETY
     ///
     /// The provided capacity *must* be the actual capacity of this vector.
-    pub unsafe fn validity_slice_mut(&mut self, capacity: usize) -> Option<&mut BitSlice<u64>> {
+    pub unsafe fn validity_slice_mut(&mut self, capacity: usize) -> Option<&mut [u64]> {
         let ptr = unsafe { cpp::duckdb_vector_get_validity(self.as_ptr()) };
         unsafe { ptr.as_mut() }.map(|ptr| {
             let len = capacity.div_ceil(64);
-            let slice = unsafe { std::slice::from_raw_parts_mut(ptr, len) };
-            BitSlice::from_slice_mut(slice)
+            unsafe { std::slice::from_raw_parts_mut(ptr, len) }
         })
+    }
+
+    /// Returns the validity slice of the vector, if it exists.
+    ///
+    /// # SAFETY
+    ///
+    /// The provided capacity *must* be the actual capacity of this vector.
+    pub unsafe fn validity_bitslice_mut(&mut self, capacity: usize) -> Option<&mut BitSlice<u64>> {
+        unsafe { self.validity_slice_mut(capacity) }.map(|slice| slice.view_bits_mut())
     }
 
     pub fn validity_ref(&self, len: usize) -> ValidityRef<'_> {
@@ -278,7 +297,7 @@ mod tests {
 
         // Set some positions as null
         // SAFETY: Vector was created with this length.
-        let validity_slice = unsafe { vector.ensure_validity_slice(len) };
+        let validity_slice = unsafe { vector.ensure_validity_bitslice(len) };
         validity_slice.set(1, false); // null at position 1
         validity_slice.set(3, false); // null at position 3
         validity_slice.set(7, false); // null at position 7
@@ -314,7 +333,7 @@ mod tests {
         let mut vector = Vector::with_capacity(logical_type, len);
 
         // SAFETY: Vector was created with this length.
-        let validity_slice = unsafe { vector.ensure_validity_slice(len) };
+        let validity_slice = unsafe { vector.ensure_validity_bitslice(len) };
         validity_slice.set(0, false); // null at position 0
 
         let validity = vector.validity_ref(len);
@@ -335,7 +354,7 @@ mod tests {
 
         // Ensure validity slice exists but don't set any nulls
         // SAFETY: Vector was created with this length.
-        let _validity_slice = unsafe { vector.ensure_validity_slice(len) };
+        let _validity_slice = unsafe { vector.ensure_validity_bitslice(len) };
 
         let validity = vector.validity_ref(len);
         let null_buffer = validity.to_null_buffer();
@@ -367,7 +386,7 @@ mod tests {
         let mut vector = Vector::with_capacity(logical_type, len);
 
         // SAFETY: Vector was created with this length.
-        let validity_slice = unsafe { vector.ensure_validity_slice(len) };
+        let validity_slice = unsafe { vector.ensure_validity_bitslice(len) };
         // Set all positions as null
         for i in 0..len {
             validity_slice.set(i, false);
@@ -410,7 +429,7 @@ mod tests {
 
         // Set some positions as null
         // SAFETY: Vector was created with this length.
-        let validity_slice = unsafe { vector.ensure_validity_slice(len) };
+        let validity_slice = unsafe { vector.ensure_validity_bitslice(len) };
         validity_slice.set(1, false); // null at position 1
         validity_slice.set(3, false); // null at position 3
         validity_slice.set(7, false); // null at position 7
@@ -438,7 +457,7 @@ mod tests {
         let mut vector = Vector::with_capacity(logical_type, len);
 
         // SAFETY: Vector was created with this length.
-        let validity_slice = unsafe { vector.ensure_validity_slice(len) };
+        let validity_slice = unsafe { vector.ensure_validity_bitslice(len) };
         // Set all positions as null
         for i in 0..len {
             validity_slice.set(i, false);
@@ -460,7 +479,7 @@ mod tests {
         let mut vector = Vector::with_capacity(logical_type, len);
 
         // SAFETY: Vector was created with this length.
-        let validity_slice = unsafe { vector.ensure_validity_slice(len) };
+        let validity_slice = unsafe { vector.ensure_validity_bitslice(len) };
         validity_slice.set(0, false); // null at position 0
 
         let validity = vector.validity_ref(len);
@@ -477,7 +496,7 @@ mod tests {
 
         // Ensure validity slice exists but element is valid
         // SAFETY: Vector was created with this length.
-        let _validity_slice = unsafe { vector.ensure_validity_slice(len) };
+        let _validity_slice = unsafe { vector.ensure_validity_bitslice(len) };
 
         let validity = vector.validity_ref(len);
 
@@ -492,7 +511,7 @@ mod tests {
         let mut vector = Vector::with_capacity(logical_type, len);
 
         // SAFETY: Vector was created with this length.
-        let validity_slice = unsafe { vector.ensure_validity_slice(len) };
+        let validity_slice = unsafe { vector.ensure_validity_bitslice(len) };
 
         // Set specific positions as null to test bit manipulation
         validity_slice.set(0, false); // First bit of first u64

--- a/vortex-duckdb/src/exporter/mod.rs
+++ b/vortex-duckdb/src/exporter/mod.rs
@@ -242,10 +242,8 @@ fn copy_from_slice(target: &mut [u64], source: &[u8], offset: usize, len: usize)
     let (start, middle, end) = unsafe { target.align_to_mut::<u8>() };
     assert!(start.is_empty());
     assert!(end.is_empty());
-    assert!(middle.len() * 8 == len, "{} {}", middle.len(), len);
-    middle
-        .view_bits_mut::<Lsb0>()
-        .copy_from_bitslice(&source.view_bits()[offset..][..len]);
+    let target = &mut middle.view_bits_mut::<Lsb0>()[..len];
+    target.copy_from_bitslice(&source.view_bits()[offset..][..len]);
 }
 
 #[cfg(test)]

--- a/vortex-duckdb/src/exporter/mod.rs
+++ b/vortex-duckdb/src/exporter/mod.rs
@@ -199,43 +199,53 @@ impl VectorExt for Vector {
             Mask::AllTrue(_) => {
                 // We only need to blank out validity if there is already a slice allocated.
                 // SAFETY: Caller guaranteees this.
-                if let Some(validity) = unsafe { self.validity_slice_mut(len) } {
+                if let Some(validity) = unsafe { self.validity_bitslice_mut(len) } {
                     validity.fill(true);
                 }
                 false
             }
             Mask::AllFalse(_) => {
                 // SAFETY: Caller guaranteees this.
-                unsafe { self.ensure_validity_slice(len) }.fill(false);
+                unsafe { self.ensure_validity_bitslice(len) }.fill(false);
                 true
             }
             Mask::Values(arr) => {
-                let arr_bits: &[u64] = {
-                    let byte_slice = arr.boolean_buffer().inner().as_slice();
-                    unsafe {
-                        std::slice::from_raw_parts(
-                            byte_slice.as_ptr() as _,
-                            byte_slice.len().div_ceil(size_of::<u64>()),
-                        )
-                    }
-                };
-                let sliced_bits = &arr_bits.view_bits::<Lsb0>()[offset..][..len];
-                let true_count = sliced_bits.count_ones();
+                let true_count = arr.boolean_buffer().count_set_bits();
                 if true_count == len {
                     if let Some(validity) = unsafe { self.validity_slice_mut(len) } {
-                        validity.fill(true);
+                        validity.view_bits_mut::<Lsb0>().fill(true);
                     }
                 } else if true_count == 0 {
-                    unsafe { self.ensure_validity_slice(len) }.fill(false);
+                    unsafe { self.ensure_validity_bitslice(len) }.fill(false);
                 } else {
-                    // SAFETY: Caller guaranteees this.
-                    let validity = unsafe { self.ensure_validity_slice(len) };
-                    validity[..len].copy_from_bitslice(sliced_bits);
+                    let source = arr.boolean_buffer().inner().as_slice();
+                    copy_from_slice(
+                        unsafe { self.ensure_validity_slice(len) },
+                        source,
+                        offset,
+                        len,
+                    );
                 }
+
                 true_count == 0
             }
         }
     }
+}
+
+/// Copy the sliced bits from source into target.
+///
+/// Offset and length are a _bit_ offset and a _bit_ length into source.
+///
+/// `target.len()` must equal `len`.
+fn copy_from_slice(target: &mut [u64], source: &[u8], offset: usize, len: usize) {
+    let (start, middle, end) = unsafe { target.align_to_mut::<u8>() };
+    assert!(start.is_empty());
+    assert!(end.is_empty());
+    assert!(middle.len() * 8 == len, "{} {}", middle.len(), len);
+    middle
+        .view_bits_mut::<Lsb0>()
+        .copy_from_bitslice(&source.view_bits()[offset..][..len]);
 }
 
 #[cfg(test)]
@@ -246,6 +256,7 @@ mod tests {
     use super::VectorExt;
     use crate::cpp::DUCKDB_TYPE;
     use crate::duckdb::{LogicalType, Vector};
+    use crate::exporter::copy_from_slice;
 
     #[test]
     fn test_set_validity_all_true() {
@@ -268,7 +279,7 @@ mod tests {
 
         assert!(all_null);
 
-        let validity = unsafe { vector.validity_slice_mut(10).unwrap() };
+        let validity = unsafe { vector.validity_bitslice_mut(10).unwrap() };
         assert!(validity.iter().all(|v| !v));
     }
 
@@ -287,7 +298,7 @@ mod tests {
 
         // When all values are true, the mask may be optimized to AllTrue,
         // so validity_slice_mut may return None (no validity allocated)
-        if let Some(validity) = unsafe { vector.validity_slice_mut(10) } {
+        if let Some(validity) = unsafe { vector.validity_bitslice_mut(10) } {
             assert!(validity.iter().all(|v| *v));
         }
     }
@@ -305,7 +316,7 @@ mod tests {
 
         assert!(all_null);
 
-        let validity = unsafe { vector.validity_slice_mut(10).unwrap() };
+        let validity = unsafe { vector.validity_bitslice_mut(10).unwrap() };
         assert!(validity.iter().all(|v| !v));
     }
 
@@ -324,7 +335,7 @@ mod tests {
 
         assert!(!all_null);
 
-        let validity = unsafe { vector.validity_slice_mut(10).unwrap() };
+        let validity = unsafe { vector.validity_bitslice_mut(10).unwrap() };
         for (i, bit) in bits.iter().enumerate() {
             assert_eq!(validity[i], *bit);
         }
@@ -345,7 +356,7 @@ mod tests {
 
         assert!(!all_null);
 
-        let validity = unsafe { vector.validity_slice_mut(8).unwrap() };
+        let validity = unsafe { vector.validity_bitslice_mut(8).unwrap() };
         for i in 0..8 {
             assert_eq!(validity[i], bits[i + 2]);
         }
@@ -367,7 +378,7 @@ mod tests {
 
         assert!(!all_null);
 
-        let validity = unsafe { vector.validity_slice_mut(5).unwrap() };
+        let validity = unsafe { vector.validity_bitslice_mut(5).unwrap() };
         for i in 0..5 {
             assert_eq!(validity[i], bits[i + 3]);
         }
@@ -387,9 +398,184 @@ mod tests {
 
         assert!(!all_null);
 
-        let validity = unsafe { vector.validity_slice_mut(60).unwrap() };
+        let validity = unsafe { vector.validity_bitslice_mut(60).unwrap() };
         for i in 0..60 {
             assert_eq!(validity[i], bits[i + 5]);
         }
+    }
+
+    #[test]
+    fn test_copy_from_slice_empty_to_empty() {
+        let target = &mut [];
+        let source = Vec::<u8>::new();
+        copy_from_slice(target, &source, 0, 0);
+    }
+
+    #[test]
+    fn test_copy_from_slice_64_to_empty() {
+        let target = &mut [];
+        let source = [1u8, 2, 3, 50, 51, 52, 100, 101];
+        copy_from_slice(target, &source, 0, 0);
+        copy_from_slice(target, &source, 5, 0);
+        copy_from_slice(target, &source, 8, 0);
+    }
+
+    #[test]
+    fn test_copy_from_slice_64_to_64() {
+        let mut target = vec![0u64];
+        let source = [1u8, 2, 3, 50, 51, 52, 100, 101];
+        copy_from_slice(&mut target, &source, 0, 64);
+        assert_eq!(
+            target[0], 0x65_64_34_33_32_03_02_01_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0x65_64_34_33_32_03_02_01_u64,
+        );
+    }
+
+    #[test]
+    fn test_copy_from_slice_80_to_0() {
+        let target = &mut [];
+        let source = [1u8, 2, 3, 50, 51, 52, 100, 101, 254, 255];
+        copy_from_slice(target, &source, 0, 0);
+        copy_from_slice(target, &source, 8, 0);
+        copy_from_slice(target, &source, 10, 0);
+    }
+
+    #[test]
+    fn test_copy_from_slice_80_to_64_case_1() {
+        let mut target = [0u64];
+        let source = [1u8, 2, 3, 50, 51, 52, 100, 101, 254, 255];
+        copy_from_slice(&mut target, &source, 16, 64);
+        assert_eq!(
+            target[0], 0xff_fe_65_64_34_33_32_03_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0xff_fe_65_64_34_33_32_03_u64,
+        );
+    }
+
+    #[test]
+    fn test_copy_from_slice_80_to_64_case_2() {
+        let mut target = [0u64];
+        let source = [1u8, 2, 3, 50, 51, 52, 100, 101, 254, 255];
+        copy_from_slice(&mut target, &source, 8, 64);
+        assert_eq!(
+            target[0], 0xfe_65_64_34_33_32_03_02_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0xfe_65_64_34_33_32_03_02_u64,
+        );
+    }
+
+    #[test]
+    fn test_copy_from_slice_80_to_64_case_3() {
+        let mut target = [0u64];
+        let source = [1u8, 2, 3, 50, 51, 52, 100, 101, 254, 255];
+        copy_from_slice(&mut target, &source, 0, 64);
+        assert_eq!(
+            target[0], 0x65_64_34_33_32_03_02_01_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0x65_64_34_33_32_03_02_01_u64,
+        );
+    }
+
+    #[test]
+    fn test_copy_from_slice_80_to_64_case_4() {
+        let mut target = [0u64];
+        let source = [1u8, 2, 3, 50, 51, 52, 100, 101, 254, 255];
+        copy_from_slice(&mut target, &source, 10, 64);
+        assert_eq!(
+            target[0],
+            0xff_99_59_0d_0c_cc_80_c0_u64, // Python: hex(0xff_fe_65_64_34_33_32_03_02 >> 2), then remove the high two hexits
+            "{:#08x} == {:#08x}",
+            target[0],
+            0xff_99_59_0d_0c_cc_80_c0_u64
+        );
+    }
+
+    #[test]
+    fn test_copy_from_slice_248_to_128_middle_non_empty() {
+        let mut target = [0u64, 0u64];
+        let source: [u8; 31] = [
+            0x01, 0x02, 0x03, 0x04, 0xff, 0xfe, 0xfd, 0xfc, 0x05, 0x06, 0x07, 0x08, 0xfc, 0xfb,
+            0xfa, 0xf9, 0x01, 0x02, 0x03, 0x04, 0xff, 0xfe, 0xfd, 0xfc, 0x05, 0x06, 0x07, 0x08,
+            0xfc, 0xfb, 0xfa,
+        ];
+        // In a span of 248 bits (31 bytes) there should be at least one 8-byte aligned span.
+        let (_, middle, _) = unsafe { source.align_to::<u64>() };
+        assert!(!middle.is_empty());
+
+        copy_from_slice(&mut target, &source, 0, 128);
+        assert_eq!(
+            target[0], 0xfc_fd_fe_ff_04_03_02_01_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0xfc_fd_fe_ff_04_03_02_01_u64,
+        );
+        assert_eq!(
+            target[1], 0xf9_fa_fb_fc_08_07_06_05_u64,
+            "{:#08x} == {:#08x}",
+            target[1], 0xf9_fa_fb_fc_08_07_06_05_u64,
+        );
+
+        copy_from_slice(&mut target, &source, 8, 128);
+        assert_eq!(
+            target[0], 0x05_fc_fd_fe_ff_04_03_02_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0x05_fc_fd_fe_ff_04_03_02_u64,
+        );
+        assert_eq!(
+            target[1], 0x01_f9_fa_fb_fc_08_07_06_u64,
+            "{:#08x} == {:#08x}",
+            target[1], 0x01_f9_fa_fb_fc_08_07_06_u64,
+        );
+
+        copy_from_slice(&mut target, &source, 8 * 8, 128);
+        assert_eq!(
+            target[0], 0xf9_fa_fb_fc_08_07_06_05_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0xf9_fa_fb_fc_08_07_06_05_u64,
+        );
+        assert_eq!(
+            target[1], 0xfc_fd_fe_ff_04_03_02_01_u64,
+            "{:#08x} == {:#08x}",
+            target[1], 0xfc_fd_fe_ff_04_03_02_01_u64,
+        );
+
+        copy_from_slice(&mut target, &source, 8 * 12, 128);
+        assert_eq!(
+            target[0], 0x04_03_02_01_f9_fa_fb_fc_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0x04_03_02_01_f9_fa_fb_fc_u64,
+        );
+        assert_eq!(
+            target[1], 0x08_07_06_05_fc_fd_fe_ff_u64,
+            "{:#08x} == {:#08x}",
+            target[1], 0x08_07_06_05_fc_fd_fe_ff_u64,
+        );
+
+        copy_from_slice(&mut target, &source, 8 * 12 + 4, 128);
+        // Find the 12th byte, skip the first hexit, take the next 32 hexits (i.e. 16 bytesor 128
+        // bits).
+        assert_eq!(
+            target[0], 0xf0_40_30_20_1f_9f_af_bf_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0xf0_40_30_20_1f_9f_af_bf_u64,
+        );
+        assert_eq!(
+            target[1], 0xc0_80_70_60_5f_cf_df_ef_u64,
+            "{:#08x} == {:#08x}",
+            target[1], 0xc0_80_70_60_5f_cf_df_ef_u64,
+        );
+
+        // Take the above and shift one bit towards the right-hand-side.
+        copy_from_slice(&mut target, &source, 8 * 12 + 4 + 1, 128);
+        assert_eq!(
+            target[0], 0xf8_20_18_10_0f_cf_d7_df_u64,
+            "{:#08x} == {:#08x}",
+            target[0], 0xf8_20_18_10_0f_cf_d7_df_u64,
+        );
+        assert_eq!(
+            target[1], 0xe0_40_38_30_2f_e7_ef_f7_u64,
+            "{:#08x} == {:#08x}",
+            target[1], 0xe0_40_38_30_2f_e7_ef_f7_u64,
+        );
     }
 }


### PR DESCRIPTION
First attempt here: https://github.com/vortex-data/vortex/pull/4528.

I suspect the reason the API was designed to return BitSlice rather than `&mut [u64]` is that there's an ambiguity as to which bit is bit zero.

I doubt this change affects the benchmark results reported in #4528. This implementation is probably ~140% the runtime of the version that uses u64 copies where possible.