### PR TITLE
fix: default to no explicit setting  of cache_metadata

### DIFF
--- a/vortex-python/python/vortex/dataset.py
+++ b/vortex-python/python/vortex/dataset.py
@@ -67,8 +67,8 @@ class VortexDataset(pyarrow.dataset.Dataset):
             raise ValueError("fragment_scan_options not supported")
         if use_threads:
             warnings.warn("Vortex does not support threading. Ignoring use_threads=True")
-        if cache_metadata:
-            warnings.warn("Vortex does not support cache_metadata. Ignoring cache_metadata=True")
+        if cache_metadata is not None:
+            warnings.warn("Vortex does not support cache_metadata. Ignoring cache_metadata setting.")
         del memory_pool
         return self._dataset.count_rows(
             row_filter=self._filter_expression(filter), split_by=batch_size, row_range=_row_range
@@ -94,6 +94,7 @@ class VortexDataset(pyarrow.dataset.Dataset):
     @override
     def get_fragments(self, filter: pyarrow.dataset.Expression | Expr | None = None) -> Iterator[VortexFragment]:
         """A fragment for each file in the Dataset."""
+
         for left, right in self._dataset.splits():
             yield VortexFragment(self, (left, right))
 
@@ -108,7 +109,7 @@ class VortexDataset(pyarrow.dataset.Dataset):
         fragment_readahead: int | None = None,
         fragment_scan_options: pyarrow.dataset.FragmentScanOptions | None = None,
         use_threads: bool | None = None,
-        cache_metadata: bool = False,
+        cache_metadata: bool | None = None,
         memory_pool: pyarrow.MemoryPool | None = None,
         _row_range: tuple[int, int] | None = None,
     ) -> pyarrow.Table:
@@ -153,8 +154,8 @@ class VortexDataset(pyarrow.dataset.Dataset):
             warnings.warn("Vortex does not support threading. Ignoring use_threads=True")
         if columns is not None and len(columns) == 0:
             raise ValueError("empty projections are not currently supported")
-        if cache_metadata:
-            warnings.warn("Vortex does not support cache_metadata. Ignoring cache_metadata=True")
+        if cache_metadata is not None:
+            warnings.warn("Vortex does not support cache_metadata. Ignoring cache_metadata setting.")
         del memory_pool
 
         return (
@@ -210,7 +211,7 @@ class VortexDataset(pyarrow.dataset.Dataset):
         fragment_readahead: int | None = None,
         fragment_scan_options: pyarrow.dataset.FragmentScanOptions | None = None,
         use_threads: bool | None = None,
-        cache_metadata: bool = False,
+        cache_metadata: bool | None = None,
         memory_pool: pyarrow.MemoryPool | None = None,
         _row_range: tuple[int, int] | None = None,
     ) -> pyarrow.dataset.Scanner:
@@ -280,7 +281,7 @@ class VortexDataset(pyarrow.dataset.Dataset):
         fragment_readahead: int | None = None,
         fragment_scan_options: pyarrow.dataset.FragmentScanOptions | None = None,
         use_threads: bool | None = None,
-        cache_metadata: bool = False,
+        cache_metadata: bool | None = None,
         memory_pool: pyarrow.MemoryPool | None = None,
         _row_range: tuple[int, int] | None = None,
     ) -> pyarrow.Table:
@@ -370,8 +371,8 @@ class VortexDataset(pyarrow.dataset.Dataset):
             raise ValueError("fragment_scan_options not supported")
         if use_threads:
             warnings.warn("Vortex does not support threading. Ignoring use_threads=True")
-        if cache_metadata:
-            warnings.warn("Vortex does not support cache_metadata. Ignoring cache_metadata=True")
+        if cache_metadata is not None:
+            warnings.warn("Vortex does not support cache_metadata. Ignoring cache_metadata setting.")
         if columns is not None and len(columns) == 0:
             raise ValueError("empty projections are not currently supported")
         del memory_pool
@@ -389,7 +390,7 @@ class VortexDataset(pyarrow.dataset.Dataset):
         fragment_readahead: int | None = None,
         fragment_scan_options: pyarrow.dataset.FragmentScanOptions | None = None,
         use_threads: bool | None = None,
-        cache_metadata: bool = False,
+        cache_metadata: bool | None = None,
         memory_pool: pyarrow.MemoryPool | None = None,
         _row_range: tuple[int, int] | None = None,
     ) -> Iterator[pyarrow.RecordBatch]:
@@ -450,7 +451,7 @@ class VortexDataset(pyarrow.dataset.Dataset):
         fragment_readahead: int | None = None,
         fragment_scan_options: pyarrow.dataset.FragmentScanOptions | None = None,
         use_threads: bool | None = None,
-        cache_metadata: bool = True,
+        cache_metadata: bool | None = None,
         memory_pool: pyarrow.MemoryPool | None = None,
         _row_range: tuple[int, int] | None = None,
     ) -> pyarrow.Table:
@@ -491,8 +492,8 @@ class VortexDataset(pyarrow.dataset.Dataset):
             raise ValueError("fragment_scan_options not supported")
         if use_threads:
             warnings.warn("Vortex does not support threading. Ignoring use_threads=True")
-        if cache_metadata:
-            warnings.warn("Vortex does not support cache_metadata. Ignoring cache_metadata=True")
+        if cache_metadata is not None:
+            warnings.warn("Vortex does not support cache_metadata. Ignoring cache_metadata setting.")
         if columns is not None and len(columns) == 0:
             raise ValueError("empty projections are not currently supported")
         del memory_pool
@@ -548,7 +549,7 @@ class VortexFragment(pyarrow.dataset.Fragment):
         fragment_readahead: int | None = None,
         fragment_scan_options: pyarrow.dataset.FragmentScanOptions | None = None,
         use_threads: bool | None = None,
-        cache_metadata: bool = True,
+        cache_metadata: bool | None = None,
         memory_pool: pyarrow.MemoryPool | None = None,
     ) -> pyarrow.dataset.Scanner:
         """See :class:`vortex.dataset.VortexDataset.scanner`"""
@@ -608,7 +609,7 @@ class VortexFragment(pyarrow.dataset.Fragment):
         fragment_readahead: int | None = None,
         fragment_scan_options: pyarrow.dataset.FragmentScanOptions | None = None,
         use_threads: bool | None = None,
-        cache_metadata: bool = True,
+        cache_metadata: bool | None = None,
         memory_pool: pyarrow.MemoryPool | None = None,
     ) -> pyarrow.Table:
         """See :class:`vortex.dataset.VortexDataset.to_table`"""
@@ -647,7 +648,7 @@ class VortexFragment(pyarrow.dataset.Fragment):
         fragment_readahead: int | None = None,
         fragment_scan_options: pyarrow.dataset.FragmentScanOptions | None = None,
         use_threads: bool | None = None,
-        cache_metadata: bool = True,
+        cache_metadata: bool | None = None,
         memory_pool: pyarrow.MemoryPool | None = None,
     ) -> pyarrow.Table:
         """See :class:`vortex.dataset.VortexDataset.take`
@@ -683,7 +684,7 @@ class VortexFragment(pyarrow.dataset.Fragment):
         fragment_readahead: int | None = None,
         fragment_scan_options: pyarrow.dataset.FragmentScanOptions | None = None,
         use_threads: bool | None = None,
-        cache_metadata: bool = True,
+        cache_metadata: bool | None = None,
         memory_pool: pyarrow.MemoryPool | None = None,
     ) -> pyarrow.Table:
         """See :class:`vortex.dataset.VortexDataset.head`"""
@@ -711,7 +712,7 @@ class VortexFragment(pyarrow.dataset.Fragment):
         fragment_readahead: int | None = None,
         fragment_scan_options: pyarrow.dataset.FragmentScanOptions | None = None,
         use_threads: bool | None = None,
-        cache_metadata: bool = True,
+        cache_metadata: bool | None = None,
         memory_pool: pyarrow.MemoryPool | None = None,
     ) -> int:
         """See :class:`vortex.dataset.VortexDataset.count_rows`"""
@@ -770,7 +771,7 @@ class VortexScanner(pyarrow.dataset.Scanner):
         fragment_readahead: int | None = None,
         fragment_scan_options: pyarrow.dataset.FragmentScanOptions | None = None,
         use_threads: bool | None = None,
-        cache_metadata: bool = False,
+        cache_metadata: bool | None = None,
         memory_pool: pyarrow.MemoryPool | None = None,
         _row_range: tuple[int, int] | None = None,
     ):


### PR DESCRIPTION
I have not yet figured out how we should consider this option, if at all.

We currently sometimes default to True and sometimes to False. I set all the defaults to None. We now only warn if it is not the default setting (None).