### PR TITLE
Scoped runtime handles

### DIFF
--- a/vortex-io/src/runtime/current.rs
+++ b/vortex-io/src/runtime/current.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use futures::{Stream, StreamExt};
 use smol::{Executor, block_on};
 
-use crate::runtime::Handle;
+use crate::runtime::{Handle, Task};
 
 /// A current thread runtime allows users to explicitly drive Vortex futures from multiple worker
 /// threads that they manage. This is useful in environments where the user already has a thread
@@ -15,14 +15,14 @@ pub struct CurrentThreadRuntime;
 
 impl CurrentThreadRuntime {
     /// Drive the given Vortex future on the underlying current thread runtime.
-    pub fn block_on<'rt, F, Fut, R>(f: F) -> R
+    pub fn block_on<'scope, F, Fut, R>(f: F) -> R
     where
-        F: FnOnce(Handle<'rt>) -> Fut,
-        Fut: Future<Output = R> + 'rt,
-        R: Send + 'static,
+        F: FnOnce(Handle<'scope, 'static>) -> Fut,
+        Fut: Future<Output = R> + 'scope,
+        R: Send + 'scope,
     {
         let executor = Arc::new(Executor::new());
-        let fut = f(Handle(executor.clone()));
+        let fut = f(Handle::new(executor.clone()));
         block_on(executor.run(fut))
     }
 
@@ -30,37 +30,32 @@ impl CurrentThreadRuntime {
     ///
     /// Note the resulting [`Iterator`] supports [`Clone`] in order to drive the stream from
     /// multiple threads.
-    pub fn block_on_stream<'rt, F, S, R>(f: F) -> impl Iterator<Item = R> + Clone
+    pub fn block_on_stream<'scope, F, S, R>(f: F) -> impl Iterator<Item = R> + Clone + 'scope
     where
-        F: FnOnce(Handle<'rt>) -> S,
-        S: Stream<Item = R> + Send + Unpin + 'rt,
-        R: Send + 'rt,
+        F: FnOnce(Handle<'scope, 'static>) -> S,
+        S: Stream<Item = R> + Send + Unpin + 'scope,
+        R: Send + 'scope,
     {
         let executor = Arc::new(Executor::new());
-        let stream = f(Handle(executor.clone()));
+        let handle = Handle::new(executor.clone());
+        let stream = f(handle.clone());
 
         // We create an MPMC result channel and spawn a task to drive the stream and send results.
         // This allows multiple worker threads to drive the executor while all waiting for results
         // on the channel.
         let (result_tx, result_rx) = kanal::unbounded();
-        executor
-            .spawn(async move {
-                futures::pin_mut!(stream);
-                while let Some(item) = stream.next().await {
-                    // Ignore send errors, which happen if all receivers are dropped.
-                    let _ = result_tx.send(item);
-                }
-            })
-            .detach();
-
-        // SAFETY: the returned stream is self-referential and lives as long as the executor.
-        //  We therefore extend the lifetime of the executor to 'static.
-        let executor: Arc<Executor<'static>> =
-            unsafe { std::mem::transmute::<Arc<Executor<'_>>, Arc<Executor<'static>>>(executor) };
+        let task = handle.spawn(async move {
+            futures::pin_mut!(stream);
+            while let Some(item) = stream.next().await {
+                // Ignore send errors, which happen if all receivers are dropped.
+                let _ = result_tx.send(item);
+            }
+        });
 
         BlockingStream {
             executor,
             results: result_rx.to_async(),
+            _task : Arc::new(task),
         }
     }
 }
@@ -68,22 +63,25 @@ impl CurrentThreadRuntime {
 /// A stream that wraps up the stream with the executor that drives it.
 ///
 /// This allows the resulting stream to have a static lifetime.
-struct BlockingStream<T> {
+struct BlockingStream<'scope, T> {
     executor: Arc<Executor<'static>>,
     results: kanal::AsyncReceiver<T>,
+    // We hold onto the task to ensure it lives as long as the stream.
+    _task: Arc<Task<'scope, ()>>,
 }
 
 // Manually implement Clone since `T` doesn't need to be `Clone`.
-impl<T> Clone for BlockingStream<T> {
+impl<T> Clone for BlockingStream<'_, T> {
     fn clone(&self) -> Self {
         BlockingStream {
             executor: self.executor.clone(),
             results: self.results.clone(),
+            _task: self._task.clone(),
         }
     }
 }
 
-impl<T> Iterator for BlockingStream<T> {
+impl<T> Iterator for BlockingStream<'_, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/vortex-io/src/runtime/handle.rs
+++ b/vortex-io/src/runtime/handle.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll, ready};
@@ -12,36 +13,101 @@ use crate::file::{FileRead, IntoIoSource, IoRequestStream};
 use crate::kanal_ext::KanalExt;
 use crate::runtime::{AbortHandle, IoTask, Runtime};
 
-/// A handle to an active Vortex runtime.
+/// A handle represents scoped access to spawn work onto an active Vortex runtime.
 ///
-/// Users should obtain a handle from one of the runtime constructors and use it to spawn new
-/// async tasks or CPU-heavy worker.
+/// This model enforces structured concurrency where all spawned tasks must complete before the
+/// end of the scope. Only for handles with a `'static` scope may tasks be detached to run in the
+/// background.
+///
+/// Users should obtain an initial handle from one of the runtime constructors and use it to spawn
+/// new async tasks or CPU-heavy work.
 #[derive(Clone)]
-pub struct Handle<'rt>(pub(crate) Arc<dyn Runtime<'rt> + 'rt>);
+pub struct Handle<'scope, 'rt> {
+    runtime: Arc<dyn Runtime<'rt> + 'rt>,
+    _scope: PhantomData<&'scope ()>,
+}
 
-impl<'rt> Handle<'rt> {
-    /// Spawn a new future onto the runtime.
+impl<'rt> Handle<'rt, 'rt> {
+    // Create a new top-level handle where the scope == runtime lifetime.
+    pub(crate) fn new(runtime: Arc<dyn Runtime<'rt> + 'rt>) -> Self {
+        Self {
+            runtime,
+            _scope: PhantomData,
+        }
+    }
+}
+
+impl<'scope, 'rt> Handle<'scope, 'rt> where 'rt: 'scope
+{
+    /// Enter a new nested scope. All tasks spawned with the provided handle will have to complete
+    /// or be dropped before this function returns.
+    pub async fn scope<'child_scope, F, Fut, R>(&self, f: F) -> R
+    where
+        F: (FnOnce(Handle<'child_scope, 'rt>) -> Fut) + Send + 'child_scope,
+        Fut: Future<Output=R> + Send + 'child_scope,
+        'scope: 'child_scope,  // Parent scope outlives child
+    {
+        // Create handle for the child scope
+        let child_handle: Handle<'child_scope, 'rt> = Handle {
+            runtime: self.runtime.clone(),
+            _scope: PhantomData,
+        };
+
+        // Execute the closure with the child handle, and await the future.
+        let result = f(child_handle).await;
+
+        // When we return, all tasks spawned in 'child_scope must be complete
+        // This is enforced by the Task<'child_scope, _> types.
+        for task in self.tasks {
+            task.await_termination().await
+        }
+        // FIXME(ngates): we should track spawned tasks and ensure they are complete here.
+
+        result
+    }
+
+    /// Spawns work onto the runtime within the current scope.
     ///
     /// These futures are expected to not perform expensive CPU work and instead simply schedule
     /// either CPU tasks or I/O tasks. See [`Handle::spawn_cpu`] for spawning CPU-bound work.
     ///
     /// See [`Task`] for details on cancelling or detaching the spawned task.
-    pub fn spawn<Fut, R>(&self, f: Fut) -> Task<'rt, R>
+    pub fn spawn<Fut, R>(&self, f: Fut) -> Task<'scope, R>
     where
-        Fut: Future<Output = R> + Send + 'rt,
-        R: Send + 'rt,
+        Fut: Future<Output=R> + Send + 'scope,
+        R: Send + 'scope,
     {
         let (send, recv) = oneshot::channel();
-        let abort_handle = self.0.spawn(
-            async move {
-                // Task::detach allows the receiver to be dropped, so we ignore send errors.
-                let _ = send.send(f.await);
-            }
-            .boxed(),
-        );
+
+        // Create a future with the narrowed handle
+        let fut = async move {
+            // Task::detach allows the receiver to be dropped, so we ignore send errors.
+            let _ = send.send(f.await);
+        };
+
+        // Extend lifetime to 'rt for the runtime
+        // SAFETY: Task<'scope, R> ensures it's awaited within 'scope
+        let extended = unsafe {
+            std::mem::transmute::<
+                Pin<Box<dyn Future<Output=()> + Send + 'scope>>,
+                Pin<Box<dyn Future<Output=()> + Send + 'rt>>,
+            >(Box::pin(fut))
+        };
+
+        let abort_handle = self.runtime.spawn(extended);
+
+        // Shorten lifetime back to 'scope for the Task
+        // SAFETY: Task<'scope, R> ensures it's awaited within 'scope
+        let shortened = unsafe {
+            std::mem::transmute::<
+                Box<dyn AbortHandle + 'rt>,
+                Box<dyn AbortHandle + 'scope>,
+            >(abort_handle)
+        };
+
         Task {
             recv,
-            abort_handle: Some(abort_handle),
+            abort_handle: Some(shortened),
         }
     }
 
@@ -52,26 +118,44 @@ impl<'rt> Handle<'rt> {
     ///
     /// See [`Task`] for details on cancelling or detaching the spawned work, although note that
     /// once started, CPU work cannot be cancelled.
-    pub fn spawn_cpu<F, R>(&self, f: F) -> Task<'rt, R>
+    pub fn spawn_cpu<F, R>(&self, f: F) -> Task<'scope, R>
     where
-        // Unlike scheduling futures, the CPU task should have a static lifetime because it
-        // doesn't need to access to handle to spawn more work.
-        F: FnOnce() -> R + Send + 'static,
-        R: Send + 'static,
+    // Unlike scheduling futures, the CPU task should have a static lifetime because it
+    // doesn't need to access to handle to spawn more work.
+        F: FnOnce() -> R + Send + 'scope,
+        R: Send + 'scope,
     {
-        // TODO(ngates): we want a droppable handle for this.
         let (send, recv) = oneshot::channel();
-        let abort_handle = self.0.spawn_cpu(Box::new(move || {
+
+        let task = Box::new(move || {
             // Task::detach allows the receiver to be dropped, so we ignore send errors.
             let _ = send.send(f());
-        }));
+        });
+
+        // Extend lifetime to 'rt for the runtime
+        // SAFETY: Task<'scope, R> ensures it's awaited within 'scope
+        let extended = unsafe {
+            std::mem::transmute::<
+                Box<dyn FnOnce() + Send + 'scope>,
+                Box<dyn FnOnce() + Send + 'rt>,
+            >(task)
+        };
+
+        let abort_handle = self.runtime.spawn_cpu(extended);
         Task {
             recv,
             abort_handle: Some(abort_handle),
         }
     }
+}
 
+impl<'rt> Handle<'rt, 'rt> {
     /// Open a file for I/O on this runtime.
+    ///
+    /// Since I/O tasks are processed by spawned background tasks on the runtime, we can only
+    /// support opening files with the `'rt` lifetime. To give a counter-example, we open a file
+    /// using a scoped handle, the scope ends and data is released, but the background tasks are
+    /// still processing the request queue, potentially triggering a use-after-free.
     pub fn open_read<S: IntoIoSource>(&self, source: S) -> VortexResult<FileRead<'rt>> {
         let source = source.into_io_source()?;
 
@@ -83,7 +167,7 @@ impl<'rt> Handle<'rt> {
         )
         .boxed();
 
-        self.0.spawn_io(IoTask::new(source, stream, self.clone()));
+        self.runtime.spawn_io(IoTask::new(source, stream, self.clone()));
 
         Ok(read)
     }
@@ -93,19 +177,22 @@ impl<'rt> Handle<'rt> {
 ///
 /// If this handle is dropped, the task is cancelled where possible. In order to allow the task to
 /// continue running in the background, call [`Task::detach`].
-pub struct Task<'rt, T> {
+#[must_use = "When a Task is dropped without being awaited, it is cancelled"]
+pub struct Task<'scope, T> {
     recv: oneshot::Receiver<T>,
-    abort_handle: Option<Box<dyn AbortHandle<'rt> + 'rt>>,
+    abort_handle: Option<Box<dyn AbortHandle + 'scope>>,
 }
 
-impl<'rt, T> Task<'rt, T> {
+impl<'scope, T> Task<'scope, T> {
     /// Detach the task, allowing it to continue running in the background after being dropped.
-    pub fn detach(mut self) {
+    ///
+    /// This is only possible if the task was spawned with a `'static` scope.
+    pub fn detach(mut self) where 'scope: 'static {
         drop(self.abort_handle.take());
     }
 }
 
-impl<'rt, T> Future for Task<'rt, T> {
+impl<'scope, T> Future for Task<'scope, T> {
     type Output = T;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -129,5 +216,29 @@ impl<T> Drop for Task<'_, T> {
         if let Some(handle) = self.abort_handle.take() {
             handle.abort();
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::runtime::single::SingleThreadRuntime;
+
+    #[test]
+    fn test_borrow_scope() {
+        let a = 1;
+        SingleThreadRuntime::block_on(|h| async {
+            // We can spawn a future that borrows from the current scope
+            assert_eq!(h.spawn(async {a + 1 }).await, 2);
+
+            // But to borrow from _this_ closure, we need a nested scope
+            let mut b = 2;
+            h.scope(|h| {
+                b += 1;
+                h.spawn(async {
+                    b += 1;
+                })
+            }).await;
+            assert_eq!(b, 4);
+        })
     }
 }

--- a/vortex-io/src/runtime/mod.rs
+++ b/vortex-io/src/runtime/mod.rs
@@ -6,13 +6,13 @@ mod handle;
 use std::sync::Arc;
 
 pub use handle::*;
-#[cfg(feature = "smol")]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod current;
-#[cfg(feature = "smol")]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod multi;
-#[cfg(feature = "smol")]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod single;
-#[cfg(feature = "smol")]
+#[cfg(not(target_arch = "wasm32"))]
 mod smol;
 // TODO(ngates): feature-flag this by Tokio once we add I/O support for runtimes.
 #[cfg(not(target_arch = "wasm32"))]
@@ -50,7 +50,7 @@ pub(crate) trait Runtime<'rt>: Send + Sync {
     ///
     /// The returned `AbortHandle` may be used to optimistically cancel the task if it has not
     /// yet started executing.
-    fn spawn_cpu(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef<'rt>;
+    fn spawn_cpu(&self, task: Box<dyn FnOnce() + Send + 'rt>) -> AbortHandleRef<'rt>;
 
     /// Spawns an I/O task for execution on the runtime.
     /// The runtime can choose to invoke the task's `Send` or `!Send` versions.
@@ -61,24 +61,24 @@ pub(crate) trait Runtime<'rt>: Send + Sync {
 ///
 /// If dropped, the task should continue to completion.
 /// If explicitly aborted, the task should be cancelled if it has not yet started executing.
-pub(crate) trait AbortHandle<'rt>: Send + Sync {
+pub(crate) trait AbortHandle: Send + Sync {
     fn abort(self: Box<Self>);
 }
 
-pub(crate) type AbortHandleRef<'rt> = Box<dyn AbortHandle<'rt> + 'rt>;
+pub(crate) type AbortHandleRef<'scope> = Box<dyn AbortHandle + 'scope>;
 
 /// A task for driving I/O requests against a source.
 pub(crate) struct IoTask<'rt> {
     source: Arc<dyn IoSource>,
     stream: BoxStream<'rt, IoRequest>,
-    handle: Handle<'rt>,
+    handle: Handle<'rt, 'rt>,
 }
 
 impl<'rt> IoTask<'rt> {
     pub(crate) fn new(
         source: Arc<dyn IoSource>,
         stream: BoxStream<'rt, IoRequest>,
-        handle: Handle<'rt>,
+        handle: Handle<'rt, 'rt>,
     ) -> Self {
         IoTask {
             source,

--- a/vortex-io/src/runtime/multi.rs
+++ b/vortex-io/src/runtime/multi.rs
@@ -49,38 +49,27 @@ impl<'rt> MultiThreadRuntime<'rt> {
     }
 
     /// Drive the given Vortex future on the underlying multithreaded runtime.
-    pub fn block_on<'fut, F, Fut, R>(&self, f: F) -> R
+    pub fn block_on<'scope, F, Fut, R>(&self, f: F) -> R
     where
-        F: FnOnce(Handle<'rt>) -> Fut,
-        Fut: Future<Output = R> + 'fut,
-        R: Send + 'static,
+        F: FnOnce(Handle<'scope, 'rt>) -> Fut,
+        Fut: Future<Output = R> + 'scope,
+        R: Send + 'scope,
+        'rt: 'scope,
     {
-        let fut = f(Handle(self.executor.clone()));
+        let fut = f(Handle::new(self.executor.clone()));
         block_on(self.executor.run(fut))
     }
 
     /// Drive the given Vortex stream on the underlying multithreaded runtime.
-    pub fn block_on_stream<F, S, R>(&self, f: F) -> impl Iterator<Item = R>
+    pub fn block_on_stream<'scope, F, S, R>(&self, f: F) -> impl Iterator<Item = R> + 'scope
     where
-        F: FnOnce(Handle<'rt>) -> S,
-        S: Stream<Item = R> + Send + Unpin,
-        R: Send + 'static,
+        F: FnOnce(Handle<'scope, 'rt>) -> S,
+        S: Stream<Item = R> + Send + Unpin + 'scope,
+        R: Send + 'scope,
+        'rt: 'scope,
     {
-        let stream = f(Handle(self.executor.clone()));
-
-        // SAFETY: The stream contains references to `rt` with lifetime 'rt.
-        // We're transmuting this to 'static, which is sound because:
-        // 1. Both `rt` and `stream` will be moved into BlockingStream
-        // 2. BlockingStream will drop them in the correct order (stream first, then rt)
-        // 3. The stream will never outlive the runtime it references
-        let stream: BoxStream<'static, R> = unsafe {
-            std::mem::transmute::<BoxStream<'_, R>, BoxStream<'static, R>>(stream.boxed())
-        };
-        let executor: Arc<Executor<'static>> = unsafe {
-            std::mem::transmute::<Arc<Executor<'_>>, Arc<Executor<'static>>>(self.executor.clone())
-        };
-
-        BlockingStream { executor, stream }
+        let stream = f(Handle::new(self.executor.clone()));
+        BlockingStream { executor: self.executor.clone(), stream: stream.boxed() }
     }
 }
 
@@ -93,12 +82,12 @@ impl Default for MultiThreadRuntime<'_> {
 /// A stream that wraps up the stream with the executor that drives it.
 ///
 /// This allows the resulting stream to have a static lifetime.
-struct BlockingStream<T> {
-    executor: Arc<Executor<'static>>,
-    stream: BoxStream<'static, T>,
+struct BlockingStream<'scope, 'rt, T> {
+    executor: Arc<Executor<'rt>>,
+    stream: BoxStream<'scope, T>,
 }
 
-impl<T> Iterator for BlockingStream<T> {
+impl<T> Iterator for BlockingStream<'_, '_, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/vortex-io/src/runtime/single.rs
+++ b/vortex-io/src/runtime/single.rs
@@ -19,7 +19,7 @@ use crate::runtime::{AbortHandle, AbortHandleRef, Handle, IoTask, Runtime};
 /// capable of running `!Send` I/O futures.
 pub struct SingleThreadRuntime<'rt> {
     scheduling: kanal::Sender<SpawnFuture<'rt>>,
-    cpu: kanal::Sender<SpawnCpu>,
+    cpu: kanal::Sender<SpawnCpu<'rt>>,
     io: kanal::Sender<IoTask<'rt>>,
 }
 
@@ -28,7 +28,7 @@ impl<'rt> SingleThreadRuntime<'rt> {
     where
         'rt: 'ex,
     {
-        let (scheduling_send, scheduling_recv) = kanal::unbounded::<SpawnFuture<'rt>>();
+        let (scheduling_send, scheduling_recv) = kanal::unbounded::<SpawnFuture>();
         let (cpu_send, cpu_recv) = kanal::unbounded::<SpawnCpu>();
         let (io_send, io_recv) = kanal::unbounded::<IoTask>();
 
@@ -86,27 +86,27 @@ impl<'rt> SingleThreadRuntime<'rt> {
     }
 
     /// Drive the given Vortex future on the underlying single-threaded runtime.
-    pub fn block_on<'fut, F, Fut, R>(f: F) -> R
+    pub fn block_on<'scope, F, Fut, R>(f: F) -> R
     where
-        F: FnOnce(Handle<'rt>) -> Fut,
-        Fut: Future<Output = R> + 'fut,
-        R: Send + 'static,
+        F: FnOnce(Handle<'scope, 'rt>) -> Fut,
+        Fut: Future<Output = R> + 'scope,
+        'rt: 'scope,
     {
         let (rt, executor) = SingleThreadRuntime::new();
-        let fut = f(Handle(Arc::new(rt)));
+        let fut = f(Handle::new(Arc::new(rt)));
         block_on(executor.run(fut))
     }
 
     /// Drive the given Vortex stream on the underlying single-threaded runtime.
-    pub fn block_on_stream<F, S, R>(f: F) -> impl Iterator<Item = R>
+    pub fn block_on_stream<'scope, F, S, R>(f: F) -> impl Iterator<Item = R>
     where
-        F: FnOnce(Handle<'rt>) -> S,
-        S: Stream<Item = R> + Unpin,
-        R: Send + 'static,
+        F: FnOnce(Handle<'scope, 'rt>) -> S,
+        S: Stream<Item = R> + Unpin + 'scope,
+        'rt: 'scope,
     {
         // Create a new static executor.
         let (rt, executor) = SingleThreadRuntime::new();
-        let stream = f(Handle(Arc::new(rt)));
+        let stream = f(Handle::new(Arc::new(rt)));
 
         // SAFETY: The stream contains references to `rt` with lifetime 'rt.
         // We're transmuting this to static, which is sound because:
@@ -114,9 +114,10 @@ impl<'rt> SingleThreadRuntime<'rt> {
         // 2. BlockingStream will drop them in the correct order (stream first, then rt)
         // 3. The stream will never outlive the runtime it references
         let stream: LocalBoxStream<'static, R> = unsafe {
-            std::mem::transmute::<LocalBoxStream<'_, R>, LocalBoxStream<'static, R>>(
-                stream.boxed_local(),
-            )
+            std::mem::transmute::<
+                LocalBoxStream<'_, R>,
+                LocalBoxStream<'static, R>,
+            >(stream.boxed_local())
         };
         let executor: Rc<LocalExecutor<'static>> = unsafe {
             std::mem::transmute::<Rc<LocalExecutor<'_>>, Rc<LocalExecutor<'static>>>(executor)
@@ -142,7 +143,7 @@ impl<'rt> Runtime<'rt> for SingleThreadRuntime<'rt> {
         Box::new(SmolAbortHandle { task })
     }
 
-    fn spawn_cpu(&self, cpu: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef<'rt> {
+    fn spawn_cpu(&self, cpu: Box<dyn FnOnce() + Send + 'rt>) -> AbortHandleRef<'rt> {
         let task = Arc::new(Mutex::new(None));
         if let Err(e) = self.cpu.send(SpawnCpu {
             cpu,
@@ -167,8 +168,8 @@ struct SpawnFuture<'rt> {
 }
 
 // A spawn request for a CPU job.
-struct SpawnCpu {
-    cpu: Box<dyn FnOnce() + Send + 'static>,
+struct SpawnCpu<'rt> {
+    cpu: Box<dyn FnOnce() + Send + 'rt>,
     task: Arc<Mutex<Option<smol::Task<()>>>>,
 }
 
@@ -176,7 +177,7 @@ struct SmolAbortHandle {
     task: Arc<Mutex<Option<smol::Task<()>>>>,
 }
 
-impl<'rt> AbortHandle<'rt> for SmolAbortHandle {
+impl AbortHandle for SmolAbortHandle {
     fn abort(self: Box<Self>) {
         // Aborting a smol::Task is done by dropping it.
         if let Some(task) = self.task.lock().take() {
@@ -226,12 +227,11 @@ mod tests {
 
     #[test]
     fn test_spawn_cpu_task() {
-        let counter = Arc::new(AtomicUsize::new(0));
-        let c = counter.clone();
+        let counter = AtomicUsize::new(0);
 
-        let result = SingleThreadRuntime::block_on(|handle| async move {
+        let result = SingleThreadRuntime::block_on(|handle| async {
             handle
-                .spawn_cpu(move || c.fetch_add(1, Ordering::SeqCst))
+                .spawn_cpu(move || counter.fetch_add(1, Ordering::SeqCst))
                 .await
         });
 

--- a/vortex-io/src/runtime/smol.rs
+++ b/vortex-io/src/runtime/smol.rs
@@ -11,7 +11,7 @@ impl<'rt> Runtime<'rt> for Executor<'rt> {
         SmolAbortHandle::new_handle(self.spawn(fut))
     }
 
-    fn spawn_cpu(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef<'rt> {
+    fn spawn_cpu(&self, task: Box<dyn FnOnce() + Send + 'rt>) -> AbortHandleRef<'rt> {
         // For now, we spawn CPU work back onto the same executor.
         SmolAbortHandle::new_handle(self.spawn(async move { task() }))
     }
@@ -26,13 +26,13 @@ pub(crate) struct SmolAbortHandle<T> {
     task: Option<smol::Task<T>>,
 }
 
-impl<'rt, T: 'rt + Send> SmolAbortHandle<T> {
-    pub(crate) fn new_handle(task: smol::Task<T>) -> AbortHandleRef<'rt> {
+impl<'scope, T: 'scope + Send> SmolAbortHandle<T> {
+    pub(crate) fn new_handle(task: smol::Task<T>) -> AbortHandleRef<'scope> {
         Box::new(Self { task: Some(task) })
     }
 }
 
-impl<T: Send> AbortHandle<'_> for SmolAbortHandle<T> {
+impl<T: Send> AbortHandle for SmolAbortHandle<T> {
     fn abort(mut self: Box<Self>) {
         // Aborting a smol::Task is done by dropping it.
         drop(self.task.take());

--- a/vortex-io/src/runtime/tokio.rs
+++ b/vortex-io/src/runtime/tokio.rs
@@ -12,13 +12,13 @@ use crate::runtime::{AbortHandle, AbortHandleRef, Handle, IoTask, Runtime};
 pub struct TokioRuntime(TokioHandle);
 
 impl TokioRuntime {
-    pub fn with(handle: TokioHandle) -> Handle<'static> {
-        Handle(Arc::new(Self(handle)))
+    pub fn with(handle: TokioHandle) -> Handle<'static, 'static> {
+        Handle::new(Arc::new(Self(handle)))
     }
 
     /// Return the current Tokio runtime handle wrapped in a Vortex handle.
-    pub fn handle() -> Handle<'static> {
-        Handle(Arc::new(TokioRuntime(TokioHandle::current())))
+    pub fn handle() -> Handle<'static, 'static> {
+        Handle::new(Arc::new(TokioRuntime(TokioHandle::current())))
     }
 }
 
@@ -36,7 +36,7 @@ impl Runtime<'static> for TokioRuntime {
     }
 }
 
-impl AbortHandle<'_> for tokio::task::AbortHandle {
+impl AbortHandle for tokio::task::AbortHandle {
     fn abort(self: Box<Self>) {
         tokio::task::AbortHandle::abort(&self)
     }


### PR DESCRIPTION
We currently have a problem where we cannot spawn nested futures on the handles due to an overly restrictive runtime lifetime.

This is an experiment to support this case