### PR TITLE
Make `FieldName` an actual type an not just an alias

### DIFF
--- a/vortex-array/src/array/display/mod.rs
+++ b/vortex-array/src/array/display/mod.rs
@@ -330,7 +330,7 @@ mod test {
     #[test]
     fn test_empty_struct() {
         let s = StructArray::try_new(
-            FieldNames::from(vec![]),
+            FieldNames::empty(),
             vec![],
             3,
             Validity::Array(BoolArray::from_iter([true, false, true]).into_array()),

--- a/vortex-array/src/arrays/chunked/decode.rs
+++ b/vortex-array/src/arrays/chunked/decode.rs
@@ -151,7 +151,7 @@ mod tests {
     #[test]
     pub fn pack_nested_structs() {
         let struct_array = StructArray::try_new(
-            vec!["a".into()].into(),
+            ["a"].into(),
             vec![VarBinViewArray::from_iter_str(["foo", "bar", "baz", "quak"]).into_array()],
             4,
             Validity::NonNullable,

--- a/vortex-array/src/arrays/struct_/compute/cast.rs
+++ b/vortex-array/src/arrays/struct_/compute/cast.rs
@@ -67,7 +67,7 @@ mod tests {
     }
 
     fn create_test_struct(nullable: bool) -> StructArray {
-        let names: FieldNames = vec!["a".into(), "b".into()].into();
+        let names = FieldNames::from(["a", "b"]);
 
         let a = buffer![1i32, 2, 3].into_array();
         let b = VarBinArray::from_iter(
@@ -91,7 +91,7 @@ mod tests {
 
     fn create_nested_struct() -> StructArray {
         // Create inner struct
-        let inner_names: FieldNames = vec!["x".into(), "y".into()].into();
+        let inner_names = FieldNames::from(["x", "y"]);
 
         let x = buffer![1.0f32, 2.0, 3.0].into_array();
         let y = buffer![4.0f32, 5.0, 6.0].into_array();
@@ -105,7 +105,7 @@ mod tests {
         .into_array();
 
         // Create outer struct with inner struct as a field
-        let outer_names: FieldNames = vec!["id".into(), "point".into()].into();
+        let outer_names: FieldNames = ["id", "point"].into();
         // Outer struct would have fields: id (I64) and point (inner struct)
 
         let ids = buffer![100i64, 200, 300].into_array();
@@ -120,7 +120,7 @@ mod tests {
     }
 
     fn create_simple_struct() -> StructArray {
-        let names: FieldNames = vec!["value".into()].into();
+        let names = FieldNames::from(["value"]);
         // Simple struct with a single U8 field
 
         let values = buffer![42u8].into_array();

--- a/vortex-array/src/arrays/struct_/compute/mod.rs
+++ b/vortex-array/src/arrays/struct_/compute/mod.rs
@@ -111,7 +111,7 @@ mod tests {
     #[test]
     fn filter_empty_struct() {
         let struct_arr =
-            StructArray::try_new(vec![].into(), vec![], 10, Validity::NonNullable).unwrap();
+            StructArray::try_new(FieldNames::empty(), vec![], 10, Validity::NonNullable).unwrap();
         let mask = vec![
             false, true, false, true, false, true, false, true, false, true,
         ];
@@ -122,7 +122,7 @@ mod tests {
     #[test]
     fn take_empty_struct() {
         let struct_arr =
-            StructArray::try_new(vec![].into(), vec![], 10, Validity::NonNullable).unwrap();
+            StructArray::try_new(FieldNames::empty(), vec![], 10, Validity::NonNullable).unwrap();
         let indices = PrimitiveArray::from_option_iter([Some(1), None]);
         let taken = take(struct_arr.as_ref(), indices.as_ref()).unwrap();
         assert_eq!(taken.len(), 2);
@@ -168,7 +168,7 @@ mod tests {
     #[test]
     fn filter_empty_struct_with_empty_filter() {
         let struct_arr =
-            StructArray::try_new(vec![].into(), vec![], 0, Validity::NonNullable).unwrap();
+            StructArray::try_new(FieldNames::empty(), vec![], 0, Validity::NonNullable).unwrap();
         let filtered = filter(struct_arr.as_ref(), &Mask::from_iter::<[bool; 0]>([])).unwrap();
         assert_eq!(filtered.len(), 0);
     }
@@ -176,7 +176,7 @@ mod tests {
     #[test]
     fn test_mask_empty_struct() {
         test_mask_conformance(
-            StructArray::try_new(vec![].into(), vec![], 5, Validity::NonNullable)
+            StructArray::try_new(FieldNames::empty(), vec![], 5, Validity::NonNullable)
                 .unwrap()
                 .as_ref(),
         );
@@ -219,7 +219,7 @@ mod tests {
     #[test]
     fn test_filter_empty_struct() {
         test_filter_conformance(
-            StructArray::try_new(vec![].into(), vec![], 5, Validity::NonNullable)
+            StructArray::try_new(FieldNames::empty(), vec![], 5, Validity::NonNullable)
                 .unwrap()
                 .as_ref(),
         );
@@ -401,7 +401,7 @@ mod tests {
     #[test]
     fn test_take_empty_struct_conformance() {
         test_take_conformance(
-            StructArray::try_new(vec![].into(), vec![], 5, Validity::NonNullable)
+            StructArray::try_new(FieldNames::empty(), vec![], 5, Validity::NonNullable)
                 .unwrap()
                 .as_ref(),
         );
@@ -539,7 +539,7 @@ mod tests {
         .unwrap()
     })]
     // Additional test cases
-    #[case::empty_struct(StructArray::try_new(vec![].into(), vec![], 5, Validity::NonNullable).unwrap())]
+    #[case::empty_struct(StructArray::try_new(FieldNames::empty(), vec![], 5, Validity::NonNullable).unwrap())]
     #[case::single_field({
         let xs = buffer![42i64].into_array();
         StructArray::try_new(["xs"].into(), vec![xs], 1, Validity::NonNullable).unwrap()

--- a/vortex-array/src/arrays/validation_tests.rs
+++ b/vortex-array/src/arrays/validation_tests.rs
@@ -195,7 +195,7 @@ mod tests {
         let field1 = PrimitiveArray::from_iter([1i32, 2, 3]).into_array();
         let field2 = PrimitiveArray::from_iter([4.0f64, 5.0, 6.0]).into_array();
         let fields = vec![field1, field2];
-        let names = vec!["a".into(), "b".into()];
+        let names = ["a", "b"];
         let result = StructArray::try_new(names.into(), fields, 3, Validity::NonNullable);
         assert!(result.is_ok());
     }
@@ -206,7 +206,7 @@ mod tests {
         let field1 = PrimitiveArray::from_iter([1i32, 2, 3]).into_array();
         let field2 = PrimitiveArray::from_iter([4.0f64, 5.0]).into_array(); // Length 2, not 3.
         let fields = vec![field1, field2];
-        let names = vec!["a".into(), "b".into()];
+        let names = ["a", "b"];
         let result = StructArray::try_new(names.into(), fields, 3, Validity::NonNullable);
         assert!(result.is_err());
     }

--- a/vortex-array/src/arrow/compute/to_arrow/canonical.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/canonical.rs
@@ -344,7 +344,7 @@ fn to_arrow_struct(
         .zip(fields.iter())
         .map(|((name, field_array), target_field)| {
             Field::new(
-                &**name,
+                name.as_ref(),
                 field_array.data_type().clone(),
                 target_field.is_nullable(),
             )

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -1179,8 +1179,8 @@ mod tests {
         // Verify metadata - should be StructArray with correct field names
         let struct_vortex_array = vortex_array.as_::<StructVTable>();
         assert_eq!(struct_vortex_array.names().len(), 2);
-        assert_eq!(struct_vortex_array.names()[0], "field1".into());
-        assert_eq!(struct_vortex_array.names()[1], "field2".into());
+        assert_eq!(struct_vortex_array.names()[0], "field1");
+        assert_eq!(struct_vortex_array.names()[1], "field2");
 
         // Test nullable struct
         let nullable_array = StructArray::new(
@@ -1200,8 +1200,8 @@ mod tests {
         // Verify metadata for nullable struct
         let struct_vortex_nullable_array = vortex_nullable_array.as_::<StructVTable>();
         assert_eq!(struct_vortex_nullable_array.names().len(), 2);
-        assert_eq!(struct_vortex_nullable_array.names()[0], "field1".into());
-        assert_eq!(struct_vortex_nullable_array.names()[1], "field2".into());
+        assert_eq!(struct_vortex_nullable_array.names()[0], "field1");
+        assert_eq!(struct_vortex_nullable_array.names()[1], "field2");
     }
 
     // Test list array conversions

--- a/vortex-array/src/builders/struct_.rs
+++ b/vortex-array/src/builders/struct_.rs
@@ -196,7 +196,6 @@ impl ArrayBuilder for StructBuilder {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use vortex_dtype::PType::I32;
     use vortex_dtype::{DType, Nullability, StructFields};
@@ -207,10 +206,7 @@ mod tests {
 
     #[test]
     fn test_struct_builder() {
-        let sdt = StructFields::new(
-            vec![Arc::from("a"), Arc::from("b")].into(),
-            vec![I32.into(), I32.into()],
-        );
+        let sdt = StructFields::new(["a", "b"].into(), vec![I32.into(), I32.into()]);
         let dtype = DType::Struct(sdt.clone(), Nullability::NonNullable);
         let mut builder = StructBuilder::with_capacity(sdt, Nullability::NonNullable, 0);
 
@@ -225,10 +221,7 @@ mod tests {
 
     #[test]
     fn test_append_nullable_struct() {
-        let sdt = StructFields::new(
-            vec![Arc::from("a"), Arc::from("b")].into(),
-            vec![I32.into(), I32.into()],
-        );
+        let sdt = StructFields::new(["a", "b"].into(), vec![I32.into(), I32.into()]);
         let dtype = DType::Struct(sdt.clone(), Nullability::Nullable);
         let mut builder = StructBuilder::with_capacity(sdt, Nullability::Nullable, 0);
 

--- a/vortex-array/src/compute/conformance/cast.rs
+++ b/vortex-array/src/compute/conformance/cast.rs
@@ -607,7 +607,7 @@ mod tests {
 
     #[test]
     fn test_cast_conformance_struct() {
-        let names: FieldNames = vec!["a".into(), "b".into()].into();
+        let names = FieldNames::from(["a", "b"]);
 
         let a = buffer![1i32, 2, 3].into_array();
         let b = VarBinArray::from_iter(

--- a/vortex-dtype/src/arbitrary.rs
+++ b/vortex-dtype/src/arbitrary.rs
@@ -17,6 +17,13 @@ impl<'a> Arbitrary<'a> for DType {
     }
 }
 
+impl<'a> Arbitrary<'a> for FieldName {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        let i: Arc<str> = Arbitrary::arbitrary(u)?;
+        Ok(Self::from(i))
+    }
+}
+
 fn random_dtype(u: &mut Unstructured<'_>, depth: u8) -> Result<DType> {
     const BASE_TYPE_COUNT: i32 = 5;
     const CONTAINER_TYPE_COUNT: i32 = 3;

--- a/vortex-dtype/src/field.rs
+++ b/vortex-dtype/src/field.rs
@@ -32,7 +32,7 @@ impl Field {
     /// Retrieve a field name if it has one
     pub fn as_name(&self) -> Option<&str> {
         match self {
-            Field::Name(name) => Some(name),
+            Field::Name(name) => Some(name.as_ref()),
             Field::ElementType => None,
         }
     }
@@ -51,6 +51,12 @@ impl From<&str> for Field {
 
 impl From<Arc<str>> for Field {
     fn from(value: Arc<str>) -> Self {
+        Self::Name(FieldName::from(value))
+    }
+}
+
+impl From<FieldName> for Field {
+    fn from(value: FieldName) -> Self {
         Self::Name(value)
     }
 }

--- a/vortex-dtype/src/field_names.rs
+++ b/vortex-dtype/src/field_names.rs
@@ -90,6 +90,11 @@ impl FieldNames {
     pub fn get(&self, index: usize) -> Option<&FieldName> {
         self.0.get(index)
     }
+
+    /// Returns whether this instance contains a specified name.
+    pub fn contains(&self, s: &str) -> bool {
+        self.0.iter().any(|n| n.as_ref() == s)
+    }
 }
 
 impl AsRef<[FieldName]> for FieldNames {

--- a/vortex-dtype/src/field_names.rs
+++ b/vortex-dtype/src/field_names.rs
@@ -12,6 +12,13 @@ use itertools::Itertools;
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FieldName(Arc<str>);
 
+impl FieldName {
+    /// Returns a reference to the inner string
+    pub fn inner(&self) -> &Arc<str> {
+        &self.0
+    }
+}
+
 // We manually implement serde for `FieldName` so it can round-trip with any string type
 #[cfg(feature = "serde")]
 impl serde::ser::Serialize for FieldName {

--- a/vortex-dtype/src/field_names.rs
+++ b/vortex-dtype/src/field_names.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::borrow::Borrow;
 use std::fmt;
 use std::ops::Index;
 use std::sync::Arc;
@@ -8,7 +9,126 @@ use std::sync::Arc;
 use itertools::Itertools;
 
 /// A name for a field in a struct.
-pub type FieldName = Arc<str>;
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FieldName(Arc<str>);
+
+// We manually implement serde for `FieldName` so it can round-trip with any string type
+#[cfg(feature = "serde")]
+impl serde::ser::Serialize for FieldName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_ref())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::de::Deserialize<'de> for FieldName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s: Arc<str> = serde::de::Deserialize::deserialize(deserializer)?;
+        Ok(Self::from(s))
+    }
+}
+
+impl fmt::Display for FieldName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl AsRef<str> for FieldName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Borrow<str> for FieldName {
+    fn borrow(&self) -> &str {
+        self.as_ref()
+    }
+}
+
+impl Borrow<str> for &FieldName {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl PartialEq<&FieldName> for FieldName {
+    fn eq(&self, other: &&FieldName) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}
+
+impl PartialEq<FieldName> for &FieldName {
+    fn eq(&self, other: &FieldName) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}
+
+impl PartialEq<&str> for FieldName {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_ref() == *other
+    }
+}
+
+impl PartialEq<FieldName> for str {
+    fn eq(&self, other: &FieldName) -> bool {
+        self == other.as_ref()
+    }
+}
+
+impl PartialEq<&str> for &FieldName {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_ref() == *other
+    }
+}
+
+impl PartialEq<String> for FieldName {
+    fn eq(&self, other: &String) -> bool {
+        self.as_ref() == other
+    }
+}
+
+impl PartialEq<&String> for FieldName {
+    fn eq(&self, other: &&String) -> bool {
+        self.as_ref() == *other
+    }
+}
+
+impl From<Arc<str>> for FieldName {
+    fn from(value: Arc<str>) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for FieldName {
+    fn from(value: &str) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<String> for FieldName {
+    fn from(value: String) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<FieldName> for String {
+    fn from(value: FieldName) -> Self {
+        value.as_ref().to_string()
+    }
+}
+
+impl From<FieldName> for Arc<str> {
+    fn from(value: FieldName) -> Self {
+        value.0
+    }
+}
 
 /// An ordered list of field names in a struct.
 #[derive(Clone, PartialEq, Eq, Debug, Default, Hash)]
@@ -33,7 +153,7 @@ impl PartialEq<&FieldNames> for FieldNames {
 
 impl PartialEq<&[&str]> for FieldNames {
     fn eq(&self, other: &&[&str]) -> bool {
-        self.len() == other.len() && self.iter().zip_eq(other.iter()).all(|(l, r)| &**l == *r)
+        self.len() == other.len() && self.iter().zip_eq(other.iter()).all(|(l, r)| l == r)
     }
 }
 
@@ -68,6 +188,10 @@ impl PartialEq<&[FieldName]> for &FieldNames {
 }
 
 impl FieldNames {
+    /// Returns an empty list of names.
+    pub fn empty() -> Self {
+        Self([].into())
+    }
     /// Returns the number of elements.
     pub fn len(&self) -> usize {
         self.0.len()
@@ -89,11 +213,6 @@ impl FieldNames {
     /// Returns a reference to a field name, or None if `index` is out of bounds.
     pub fn get(&self, index: usize) -> Option<&FieldName> {
         self.0.get(index)
-    }
-
-    /// Returns whether this instance contains a specified name.
-    pub fn contains(&self, s: &str) -> bool {
-        self.0.iter().any(|n| n.as_ref() == s)
     }
 }
 
@@ -184,9 +303,15 @@ impl From<Vec<FieldName>> for FieldNames {
     }
 }
 
+impl From<Vec<Arc<str>>> for FieldNames {
+    fn from(value: Vec<Arc<str>>) -> Self {
+        value.into_iter().collect()
+    }
+}
+
 impl From<&[&'static str]> for FieldNames {
     fn from(value: &[&'static str]) -> Self {
-        Self(value.iter().cloned().map(Arc::from).collect())
+        Self(value.iter().cloned().map(FieldName::from).collect())
     }
 }
 
@@ -198,7 +323,7 @@ impl From<&[FieldName]> for FieldNames {
 
 impl<const N: usize> From<[&'static str; N]> for FieldNames {
     fn from(value: [&'static str; N]) -> Self {
-        Self(value.into_iter().map(Arc::from).collect())
+        Self(value.into_iter().map(FieldName::from).collect())
     }
 }
 
@@ -282,5 +407,33 @@ mod tests {
         let f = format!("{names}");
 
         assert_eq!(f, r#"["a", "b", "c"]"#);
+    }
+
+    /// Tests both that contains is correct but also that the types are set up correctly.
+    #[test]
+    fn test_field_names_contains() {
+        let names = FieldNames::from(["a", "b", "c"]);
+        assert!(names.iter().contains("b"))
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_field_name_serde() {
+        let s = "hello world";
+        let value = serde_json::to_value(s).unwrap();
+        let name = serde_json::from_value::<FieldName>(value).unwrap();
+        assert_eq!(name, s);
+        let value = serde_json::to_value(name.clone()).unwrap();
+        let s = serde_json::from_value::<String>(value).unwrap();
+        assert_eq!(name, s);
+    }
+
+    /// Verify hashing is unchanged and behaves as expected
+    #[test]
+    fn test_hash_behavior() {
+        use std::hash::BuildHasher;
+
+        let rs = std::hash::RandomState::new();
+        assert_eq!(rs.hash_one("hello"), rs.hash_one(FieldName::from("hello")));
     }
 }

--- a/vortex-dtype/src/serde/flatbuffers/project.rs
+++ b/vortex-dtype/src/serde/flatbuffers/project.rs
@@ -20,7 +20,7 @@ pub fn resolve_field<'a, 'b: 'a>(fb: fb::Struct_<'b>, field: &'a Field) -> Vorte
                 .ok_or_else(|| vortex_err!("Missing field names"))?;
             names
                 .iter()
-                .position(|name| name == &**n)
+                .position(|name| name == n)
                 .ok_or_else(|| vortex_err!("Unknown field name {n}"))
         }
         _ => vortex_bail!("Only field names are supported for now"),

--- a/vortex-expr/src/exprs/select.rs
+++ b/vortex-expr/src/exprs/select.rs
@@ -329,7 +329,7 @@ mod tests {
             .unwrap()
             .to_struct();
         let selected_names = selected.names().clone();
-        assert_eq!(selected_names.as_ref(), &["a".into()]);
+        assert_eq!(selected_names.as_ref(), &["a"]);
     }
 
     #[test]
@@ -341,7 +341,7 @@ mod tests {
             .unwrap()
             .to_struct();
         let selected_names = selected.names().clone();
-        assert_eq!(selected_names.as_ref(), &["b".into()]);
+        assert_eq!(selected_names.as_ref(), &["b"]);
     }
 
     #[test]

--- a/vortex-expr/src/transform/partition.rs
+++ b/vortex-expr/src/transform/partition.rs
@@ -119,7 +119,7 @@ impl<A: Annotation + Display> PartitionedExpr<A> {
         let id = FieldName::from(id.to_string());
         self.partition_names
             .iter()
-            .position(|field| field == &id)
+            .position(|field| field == id)
             .map(|idx| &self.partitions[idx])
     }
 }
@@ -296,7 +296,7 @@ mod tests {
 
         let expr = and(
             get_item("y", get_item("a", root())),
-            select(vec!["a".into(), "b".into()], root()),
+            select(["a", "b"], root()),
         );
         let expr = simplify_typed(expr, &dtype).unwrap();
         let partitioned = partition(expr, &dtype, annotate_scope_access(fields)).unwrap();

--- a/vortex-ffi/src/struct_fields.rs
+++ b/vortex-ffi/src/struct_fields.rs
@@ -42,7 +42,8 @@ pub unsafe extern "C-unwind" fn vx_struct_fields_field_name(
     if idx >= struct_dtype.nfields() {
         return ptr::null();
     }
-    vx_string::new_ref(&struct_dtype.names()[idx])
+    let name = struct_dtype.names()[idx].clone().into();
+    vx_string::new_ref(&name)
 }
 
 /// Returns an *owned* reference to the dtype of the field at the given index.

--- a/vortex-ffi/src/struct_fields.rs
+++ b/vortex-ffi/src/struct_fields.rs
@@ -42,8 +42,8 @@ pub unsafe extern "C-unwind" fn vx_struct_fields_field_name(
     if idx >= struct_dtype.nfields() {
         return ptr::null();
     }
-    let name = struct_dtype.names()[idx].clone().into();
-    vx_string::new_ref(&name)
+    let name = struct_dtype.names()[idx].inner();
+    vx_string::new_ref(name)
 }
 
 /// Returns an *owned* reference to the dtype of the field at the given index.

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -222,7 +222,7 @@ fn test_read_projection() {
     assert_eq!(
         array.dtype(),
         &DType::Struct(
-            StructFields::new(vec!["strings".into()].into(), vec![strings_dtype]),
+            StructFields::new(["strings"].into(), vec![strings_dtype]),
             Nullability::NonNullable,
         )
     );

--- a/vortex-layout/src/layout.rs
+++ b/vortex-layout/src/layout.rs
@@ -90,7 +90,7 @@ impl LayoutChildType {
             LayoutChildType::Chunk((idx, _offset)) => format!("[{idx}]").into(),
             LayoutChildType::Auxiliary(name) => name.clone(),
             LayoutChildType::Transparent(name) => name.clone(),
-            LayoutChildType::Field(name) => name.clone(),
+            LayoutChildType::Field(name) => name.clone().into(),
         }
     }
 
@@ -275,7 +275,7 @@ mod tests {
         assert_eq!(chunk.name().as_ref(), "[5]");
 
         // Test Field variant
-        let field = LayoutChildType::Field(Arc::from("customer_id"));
+        let field = LayoutChildType::Field(FieldName::from("customer_id"));
         assert_eq!(field.name().as_ref(), "customer_id");
 
         // Test Auxiliary variant
@@ -294,7 +294,7 @@ mod tests {
         assert_eq!(chunk.row_offset(), Some(42));
 
         // Field should return 0
-        let field = LayoutChildType::Field(Arc::from("field1"));
+        let field = LayoutChildType::Field(FieldName::from("field1"));
         assert_eq!(field.row_offset(), Some(0));
 
         // Auxiliary should return None
@@ -319,9 +319,9 @@ mod tests {
         assert_ne!(chunk1, chunk4);
 
         // Test Field equality
-        let field1 = LayoutChildType::Field(Arc::from("name"));
-        let field2 = LayoutChildType::Field(Arc::from("name"));
-        let field3 = LayoutChildType::Field(Arc::from("age"));
+        let field1 = LayoutChildType::Field(FieldName::from("name"));
+        let field2 = LayoutChildType::Field(FieldName::from("name"));
+        let field3 = LayoutChildType::Field(FieldName::from("age"));
 
         assert_eq!(field1, field2);
         assert_ne!(field1, field3);
@@ -351,9 +351,9 @@ mod tests {
     #[rstest]
     #[case(LayoutChildType::Chunk((0, 0)), "[0]", Some(0))]
     #[case(LayoutChildType::Chunk((999, 1000000)), "[999]", Some(1000000))]
-    #[case(LayoutChildType::Field(Arc::from("")), "", Some(0))]
+    #[case(LayoutChildType::Field(FieldName::from("")), "", Some(0))]
     #[case(
-        LayoutChildType::Field(Arc::from("very_long_field_name_that_is_quite_lengthy")),
+        LayoutChildType::Field(FieldName::from("very_long_field_name_that_is_quite_lengthy")),
         "very_long_field_name_that_is_quite_lengthy",
         Some(0)
     )]
@@ -401,7 +401,7 @@ mod tests {
         ];
 
         for field_name in special_fields {
-            let field = LayoutChildType::Field(field_name.clone());
+            let field = LayoutChildType::Field(field_name.clone().into());
             assert_eq!(field.name(), field_name);
             assert_eq!(field.row_offset(), Some(0));
         }

--- a/vortex-layout/src/layouts/compact.rs
+++ b/vortex-layout/src/layouts/compact.rs
@@ -191,6 +191,7 @@ mod tests {
     use vortex_array::validity::Validity;
     use vortex_array::{IntoArray, ToCanonical};
     use vortex_buffer::buffer;
+    use vortex_dtype::FieldName;
 
     use super::*;
 
@@ -209,7 +210,8 @@ mod tests {
         .iter()
         .map(|a| a.clone().into_array())
         .collect::<Vec<_>>();
-        let field_names = vec!["f64_field".into(), "i32_field".into(), "u8_field".into()];
+        let field_names: Vec<FieldName> =
+            vec!["f64_field".into(), "i32_field".into(), "u8_field".into()];
 
         let n_rows = columns[0].len();
         let struct_array = StructArray::try_new(
@@ -230,7 +232,7 @@ mod tests {
 
         // Verify each field can be accessed and has correct data
         for (i, name) in decompressed_struct.names().iter().enumerate() {
-            assert_eq!(name, &field_names[i]);
+            assert_eq!(name, field_names[i]);
             let decompressed_array = decompressed_struct
                 .field_by_name(name)
                 .unwrap()

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -292,7 +292,7 @@ mod tests {
                 SequentialStreamAdapter::new(
                     DType::Struct(
                         StructFields::new(
-                            vec!["a".into(), "b".into(), "c".into()].into(),
+                            ["a", "b", "c"].into(),
                             vec![I32.into(), I32.into(), I32.into()],
                         ),
                         NonNullable,

--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -266,10 +266,10 @@ mod tests {
         assert_eq!(
             stats_table.array.names().as_ref(),
             &[
-                Stat::Max.name().into(),
-                MAX_IS_TRUNCATED.into(),
-                Stat::Min.name().into(),
-                MIN_IS_TRUNCATED.into(),
+                Stat::Max.name(),
+                MAX_IS_TRUNCATED,
+                Stat::Min.name(),
+                MIN_IS_TRUNCATED,
             ]
         );
         assert_eq!(
@@ -291,11 +291,11 @@ mod tests {
         assert_eq!(
             stats_table.array.names().as_ref(),
             &[
-                Stat::Max.name().into(),
-                MAX_IS_TRUNCATED.into(),
-                Stat::Min.name().into(),
-                MIN_IS_TRUNCATED.into(),
-                Stat::Sum.name().into(),
+                Stat::Max.name(),
+                MAX_IS_TRUNCATED,
+                Stat::Min.name(),
+                MIN_IS_TRUNCATED,
+                Stat::Sum.name(),
             ]
         );
         assert_eq!(

--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyString;
-use vortex::dtype::FieldName;
+use vortex::dtype::{FieldName, FieldNames};
 use vortex::error::VortexResult;
 use vortex::expr::{ExprRef, SelectExpr, root, select};
 use vortex::file::{VortexFile, VortexOpenOptions};
@@ -179,7 +179,7 @@ impl PyVortexDataset {
         let mut scan = self_
             .vxf
             .scan()?
-            .with_projection(select(vec![], root()))
+            .with_projection(select(FieldNames::empty(), root()))
             .with_some_filter(filter_from_python(row_filter))
             .with_split_by(split_by.map(SplitBy::RowCount).unwrap_or(SplitBy::Layout));
         if let Some((l, r)) = row_range {

--- a/vortex-python/src/dtype/factory.rs
+++ b/vortex-python/src/dtype/factory.rs
@@ -8,7 +8,7 @@ use pyo3::prelude::PyAnyMethods;
 use pyo3::types::PyDict;
 use pyo3::{Bound, PyResult, Python, pyfunction};
 use vortex::dtype::{
-    DType, DecimalDType, ExtDType, ExtID, ExtMetadata, FieldName, PType, StructFields,
+    DType, DecimalDType, ExtDType, ExtID, ExtMetadata, FieldName, FieldNames, PType, StructFields,
 };
 
 use crate::dtype::PyDType;
@@ -361,7 +361,10 @@ pub(super) fn dtype_struct<'py>(
     } else {
         PyDType::init(
             py,
-            DType::Struct(StructFields::new(vec![].into(), vec![]), nullable.into()),
+            DType::Struct(
+                StructFields::new(FieldNames::empty(), vec![]),
+                nullable.into(),
+            ),
         )
     }
 }

--- a/vortex-python/src/file.rs
+++ b/vortex-python/src/file.rs
@@ -9,7 +9,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyList;
 use vortex::compute::cast;
 use vortex::dtype::Nullability::NonNullable;
-use vortex::dtype::{DType, PType};
+use vortex::dtype::{DType, FieldNames, PType};
 use vortex::error::VortexResult;
 use vortex::expr::{ExprRef, root, select};
 use vortex::file::segments::MokaSegmentCache;
@@ -193,7 +193,7 @@ impl<'py> FromPyObject<'py> for PyIntoProjection {
                 .map(|item| item.extract::<String>())
                 .collect::<PyResult<Vec<String>>>()?;
             return Ok(PyIntoProjection(select(
-                cols.into_iter().map(Arc::<str>::from).collect::<Vec<_>>(),
+                cols.into_iter().collect::<FieldNames>(),
                 root(),
             )));
         }

--- a/vortex-python/src/scalar/factory.rs
+++ b/vortex-python/src/scalar/factory.rs
@@ -102,7 +102,7 @@ fn scalar_helper_inner(value: &Bound<'_, PyAny>, dtype: Option<&DType>) -> PyRes
             .keys()
             .iter()
             .map(|key| key.extract::<String>())
-            .map_ok(Arc::from)
+            .map_ok(FieldName::from)
             .collect::<PyResult<Vec<FieldName>>>()?
             .into();
 

--- a/vortex-scalar/src/display.rs
+++ b/vortex-scalar/src/display.rs
@@ -30,7 +30,7 @@ mod tests {
     use vortex_buffer::ByteBuffer;
     use vortex_dtype::Nullability::{NonNullable, Nullable};
     use vortex_dtype::datetime::{DATE_ID, TIME_ID, TIMESTAMP_ID, TemporalMetadata, TimeUnit};
-    use vortex_dtype::{DType, ExtDType, ExtMetadata, PType, StructFields};
+    use vortex_dtype::{DType, ExtDType, ExtMetadata, FieldName, PType, StructFields};
 
     use crate::{InnerScalarValue, PValue, Scalar, ScalarValue};
 
@@ -108,7 +108,7 @@ mod tests {
         fn dtype() -> DType {
             DType::Struct(
                 StructFields::new(
-                    [Arc::from("foo")].into(),
+                    [FieldName::from("foo")].into(),
                     vec![DType::Primitive(PType::U32, Nullable)],
                 ),
                 Nullable,
@@ -141,7 +141,7 @@ mod tests {
         let f2 = DType::Primitive(PType::U32, Nullable);
         let dtype = DType::Struct(
             StructFields::new(
-                [Arc::from("foo"), Arc::from("bar")].into(),
+                [FieldName::from("foo"), FieldName::from("bar")].into(),
                 vec![f1.clone(), f2.clone()],
             ),
             Nullable,

--- a/vortex-scalar/src/struct_.rs
+++ b/vortex-scalar/src/struct_.rs
@@ -294,10 +294,7 @@ mod tests {
         let f1_dt = DType::Utf8(Nullability::NonNullable);
 
         let dtype = DType::Struct(
-            StructFields::new(
-                vec!["a".into(), "b".into()].into(),
-                vec![f0_dt.clone(), f1_dt.clone()],
-            ),
+            StructFields::new(["a", "b"].into(), vec![f0_dt.clone(), f1_dt.clone()]),
             Nullability::Nullable,
         );
 
@@ -424,7 +421,7 @@ mod tests {
     fn test_struct_cast_to_struct() {
         // Create source struct
         let source_fields = StructFields::new(
-            vec!["x".into(), "y".into()].into(),
+            ["x", "y"].into(),
             vec![
                 DType::Primitive(I32, Nullability::NonNullable),
                 DType::Primitive(I32, Nullability::NonNullable),
@@ -434,7 +431,7 @@ mod tests {
 
         // Create target struct with different field types
         let target_fields = StructFields::new(
-            vec!["x".into(), "y".into()].into(),
+            ["x", "y"].into(),
             vec![
                 DType::Primitive(vortex_dtype::PType::I64, Nullability::NonNullable),
                 DType::Primitive(vortex_dtype::PType::I64, Nullability::NonNullable),
@@ -458,13 +455,13 @@ mod tests {
     #[test]
     fn test_struct_cast_mismatched_fields() {
         let source_fields = StructFields::new(
-            vec!["a".into()].into(),
+            ["a"].into(),
             vec![DType::Primitive(I32, Nullability::NonNullable)],
         );
         let source_dtype = DType::Struct(source_fields, Nullability::NonNullable);
 
         let target_fields = StructFields::new(
-            vec!["a".into(), "b".into()].into(),
+            ["a", "b"].into(),
             vec![
                 DType::Primitive(I32, Nullability::NonNullable),
                 DType::Primitive(I32, Nullability::NonNullable),
@@ -585,7 +582,7 @@ mod tests {
         // Different struct types cannot be compared
         let other_dtype = DType::Struct(
             StructFields::new(
-                vec!["c".into()].into(),
+                ["c"].into(),
                 vec![DType::Primitive(I32, Nullability::NonNullable)],
             ),
             Nullability::NonNullable,

--- a/vortex-tui/src/browse/ui/segments.rs
+++ b/vortex-tui/src/browse/ui/segments.rs
@@ -14,6 +14,7 @@ use taffy::{
     AvailableSpace, Dimension, FlexDirection, LengthPercentage, NodeId, PrintTree, Size, Style,
     TaffyTree, TraversePartialTree,
 };
+use vortex::dtype::FieldName;
 use vortex::error::{VortexExpect, VortexResult, VortexUnwrap, vortex_err};
 use vortex::file::SegmentSpec;
 use vortex::layout::{Layout, LayoutChildType};
@@ -67,12 +68,12 @@ impl SegmentGridState<'_> {
 
 #[derive(Debug, Clone)]
 pub struct NodeContents<'a> {
-    title: Arc<str>,
+    title: FieldName,
     contents: Vec<Line<'a>>,
 }
 
 pub struct SegmentDisplay {
-    name: Arc<str>,
+    name: FieldName,
     spec: SegmentSpec,
     row_offset: u64,
     row_count: u64,
@@ -204,7 +205,7 @@ fn render_tree(
         }
 
         let block = Block::new()
-            .title(&*blk_content.title)
+            .title(blk_content.title.as_ref())
             .borders(Borders::ALL);
 
         if !blk_content.contents.is_empty() {
@@ -336,7 +337,7 @@ fn to_display_segment_tree<'a>(
             node_contents.insert(
                 node_id,
                 NodeContents {
-                    title: name.clone(),
+                    title: name,
                     contents: Vec::new(),
                 },
             );
@@ -369,14 +370,14 @@ fn collect_segment_tree(root_layout: &dyn Layout, segments: &Arc<[SegmentSpec]>)
 }
 
 struct SegmentTree {
-    segments: HashMap<Arc<str>, Vec<SegmentDisplay>>,
-    segment_ordering: Vec<Arc<str>>,
+    segments: HashMap<FieldName, Vec<SegmentDisplay>>,
+    segment_ordering: Vec<FieldName>,
 }
 
 fn segments_by_name_impl(
     root: &dyn Layout,
-    group_name: Option<Arc<str>>,
-    name: Option<Arc<str>>,
+    group_name: Option<FieldName>,
+    name: Option<FieldName>,
     row_offset: Option<u64>,
     segments: &Arc<[SegmentSpec]>,
     segment_tree: &mut SegmentTree,
@@ -390,7 +391,7 @@ fn segments_by_name_impl(
                 Some(
                     name.as_ref()
                         .map(|n| format!("{n}.{sub_name}").into())
-                        .unwrap_or_else(|| sub_name),
+                        .unwrap_or_else(|| sub_name.into()),
                 ),
                 row_offset,
                 segments,
@@ -402,7 +403,7 @@ fn segments_by_name_impl(
                 Some(
                     name.as_ref()
                         .map(|n| format!("{n}.{aux_name}").into())
-                        .unwrap_or_else(|| aux_name),
+                        .unwrap_or_else(|| aux_name.into()),
                 ),
                 Some(0),
                 segments,
@@ -446,7 +447,7 @@ fn segments_by_name_impl(
 
     let current_segments = segment_tree
         .segments
-        .entry(group_name.unwrap_or_else(|| Arc::from("root")))
+        .entry(group_name.unwrap_or_else(|| FieldName::from("root")))
         .or_default();
 
     for segment_id in root.segment_ids() {


### PR DESCRIPTION
Makes `FieldName` its own type (like `FieldNames`), including many `PartialEq` implementations to make it as ergonomic as possible, while keeping other behaviors.