### PR TITLE
feat: teach Footer to (de)serialize itself as FlatBuffer

### DIFF
--- a/vortex-file/src/footer/mod.rs
+++ b/vortex-file/src/footer/mod.rs
@@ -18,16 +18,19 @@ use std::sync::Arc;
 
 pub(crate) use file_layout::*;
 pub(crate) use file_statistics::*;
-use flatbuffers::root;
+use flatbuffers::{FlatBufferBuilder, root};
 use itertools::Itertools;
 pub(crate) use postscript::*;
 pub use segment::*;
-use vortex_array::ArrayRegistry;
 use vortex_array::stats::StatsSet;
+use vortex_array::{ArrayContext, ArrayRegistry};
+use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_bail, vortex_err};
-use vortex_flatbuffers::{FlatBuffer, footer as fb};
-use vortex_layout::{LayoutRef, LayoutRegistry, layout_from_flatbuffer};
+use vortex_flatbuffers::{FlatBuffer, ReadFlatBuffer, WriteFlatBuffer, footer as fb};
+use vortex_layout::{
+    LayoutContext, LayoutRef, LayoutRegistry, layout_from_fb_layout, layout_from_flatbuffer,
+};
 
 /// Captures the layout information of a Vortex file.
 #[derive(Debug, Clone)]
@@ -35,6 +38,104 @@ pub struct Footer {
     root_layout: LayoutRef,
     segments: Arc<[SegmentSpec]>,
     statistics: Option<FileStatistics>,
+}
+
+impl Footer {
+    /// Deserialize a Footer from its FlatBuffer-serialized form.
+    // We cannot impl ReadFlatBuffer because reading a Layout *requires* an owned bytes and the
+    // ReadFlatBuffer interface would only provide an `fb::FullFooter`.
+    pub fn from_flatbuffer(
+        bytes: FlatBuffer,
+        dtype: DType,
+        layout_ctx: &LayoutContext,
+        array_ctx: &ArrayContext,
+    ) -> VortexResult<Self> {
+        let full_footer = root::<fb::FullFooter>(bytes.as_ref())?;
+        let root_layout = layout_from_fb_layout(
+            bytes.clone(),
+            full_footer
+                .layout()
+                .ok_or_else(|| vortex_err!("layout missing"))?,
+            &dtype,
+            layout_ctx,
+            array_ctx,
+        )?;
+        let footer = full_footer
+            .footer()
+            .ok_or_else(|| vortex_err!("footer missing"))?;
+        let segments = footer
+            .segment_specs()
+            .unwrap_or_default()
+            .iter()
+            .map(SegmentSpec::try_from)
+            .try_collect()?;
+        let statistics = full_footer
+            .statistics()
+            .as_ref()
+            .map(FileStatistics::read_flatbuffer)
+            .transpose()?;
+        Ok(Footer {
+            root_layout,
+            segments,
+            statistics,
+        })
+    }
+
+    /// Serialize a Footer to FlatBuffer bytes.
+    ///
+    /// To later reconstruct a Footer with [Self::from_flatbuffer], you will also need the root
+    /// [DType], which can likewise be serialized as a FlatBuffer.
+    ///
+    /// See also: [Self::write_flatbuffer].
+    pub fn write_flatbuffer_bytes(
+        &self,
+        layout_ctx: &LayoutContext,
+        array_ctx: &ArrayContext,
+    ) -> FlatBuffer {
+        let mut fbb = FlatBufferBuilder::new();
+        let root_offset = self.write_flatbuffer(&mut fbb, layout_ctx, array_ctx);
+        fbb.finish_minimal(root_offset);
+        let (vec, start) = fbb.collapse();
+        let end = vec.len();
+        FlatBuffer::align_from(ByteBuffer::from(vec).slice(start..end))
+    }
+
+    /// Serialize a Footer to its FlatBuffer-serialized form.
+    // We cannot implement WriteFlatBuffer because that trait requires us to be able to write into a
+    // FlatBufferBuilder with *any* possible lifetime. We can only write into a builder with a
+    // lifetime shorter than ours. Rust does not allow us to add this constraint to our
+    // implementation.
+    pub fn write_flatbuffer<'fb, 'a: 'fb>(
+        &'a self,
+        fbb: &mut FlatBufferBuilder<'fb>,
+        layout_ctx: &'fb LayoutContext,
+        array_ctx: &ArrayContext,
+    ) -> flatbuffers::WIPOffset<fb::FullFooter<'fb>> {
+        // The order inentionally mirrors teh order in vortex-file/src/writer.rs for pleasing symmetry.
+        let layout = self
+            .root_layout
+            .flatbuffer_writer(layout_ctx)
+            .write_flatbuffer(fbb);
+        let file_statistics = self
+            .statistics
+            .as_ref()
+            .map(|statistics| statistics.write_flatbuffer(fbb));
+        let footer = FooterFlatBufferWriter {
+            ctx: array_ctx.clone(),
+            layout_ctx: layout_ctx.clone(),
+            segment_specs: self.segments.clone(),
+        }
+        .write_flatbuffer(fbb);
+
+        fb::FullFooter::create(
+            fbb,
+            &fb::FullFooterArgs {
+                footer: Some(footer),
+                layout: Some(layout),
+                statistics: file_statistics,
+            },
+        )
+    }
 }
 
 impl Footer {
@@ -51,7 +152,7 @@ impl Footer {
     }
 
     /// Read the [`Footer`] from a flatbuffer.
-    pub(crate) fn from_flatbuffer(
+    pub(crate) fn from_parts(
         footer_bytes: FlatBuffer,
         layout_bytes: FlatBuffer,
         dtype: DType,

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -39,14 +39,15 @@
 //!
 //! Succinctly, the file format specification is as follows:
 //!
-//! 1. Data is written first, in a form that is describable by a Layout (typically Array IPC Messages).
-//!    1. To allow for more efficient IO & pruning, our writer implementation first writes the "data" arrays,
+//! 1. The four bytes "VXTF" are written first.
+//! 2. Data is written second, in a form described by a Layout (typically Array IPC Messages).
+//!    1. For more efficient IO & pruning, our writer implementation first writes the "data" arrays,
 //!       and then writes the "metadata" arrays (i.e., per-column statistics)
-//! 2. We write what is collectively referred to as the "Footer", which contains:
-//!    1. An optional Schema, which if present is a valid flatbuffer representing a message::Schema
+//! 3. The "Footer", which contains:
+//!    1. An optional DType, which if present is a valid flatbuffer representing a message::DType
 //!    2. The Layout, which is a valid footer::Layout flatbuffer, and describes the physical byte ranges & relationships amongst
 //!       the those byte ranges that we wrote in part 1.
-//!    3. The Postscript, which is a valid footer::Postscript flatbuffer, containing the absolute start offsets of the Schema & Layout
+//!    3. The Postscript, which is a valid footer::Postscript flatbuffer, containing the absolute start offsets of the DType & Layout
 //!       flatbuffers within the file.
 //!    4. The End-of-File marker, which is 8 bytes, and contains the u16 version, u16 postscript length, and 4 magic bytes.
 //!
@@ -54,20 +55,28 @@
 //! ```text
 //! ┌────────────────────────────┐
 //! │                            │
+//! │    Magic Bytes ("VXTF")    │
+//! │                            │
+//! ├────────────────────────────┤
+//! │                            │
 //! │            Data            │
 //! │    (Array IPC Messages)    │
 //! │                            │
 //! ├────────────────────────────┤
 //! │                            │
-//! │   Per-Column Statistics    │
+//! │      DType Flatbuffer      │
 //! │                            │
 //! ├────────────────────────────┤
 //! │                            │
-//! │     Schema Flatbuffer      │
+//! │      Layout Flatbuffer     │
 //! │                            │
 //! ├────────────────────────────┤
 //! │                            │
-//! │     Layout Flatbuffer      │
+//! │  FileStatistics Flatbuffer │
+//! │                            │
+//! ├────────────────────────────┤
+//! │                            │
+//! │      Footer Flatbuffer     │
 //! │                            │
 //! ├────────────────────────────┤
 //! │                            │

--- a/vortex-file/src/open.rs
+++ b/vortex-file/src/open.rs
@@ -192,7 +192,7 @@ impl<F: FileType> VortexOpenOptions<F> {
             &initial_read[layout_offset..layout_offset + (layout_segment.length as usize)],
         );
 
-        Footer::from_flatbuffer(
+        Footer::from_parts(
             footer_bytes,
             layout_bytes,
             dtype,

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -12,20 +12,24 @@ use vortex_array::arrays::{
     ChunkedArray, ConstantArray, DecimalArray, ListArray, PrimitiveArray, StructArray, VarBinArray,
     VarBinViewArray,
 };
+use vortex_array::arrow::IntoArrowArray;
 use vortex_array::iter::ArrayIteratorExt;
 use vortex_array::stream::ArrayStreamExt;
 use vortex_array::validity::Validity;
-use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
+use vortex_array::{Array, ArrayContext, ArrayRef, IntoArray, ToCanonical};
 use vortex_buffer::{Buffer, ByteBufferMut, buffer};
 use vortex_dict::{DictEncoding, DictVTable};
 use vortex_dtype::PType::I32;
 use vortex_dtype::{DType, DecimalDType, Nullability, PType, StructFields};
 use vortex_error::VortexResult;
 use vortex_expr::{PackExpr, and, eq, get_item, gt, gt_eq, lit, lt, lt_eq, or, root, select};
+use vortex_layout::LayoutContext;
 use vortex_scalar::Scalar;
 use vortex_scan::ScanBuilder;
 
-use crate::{V1_FOOTER_FBS_SIZE, VERSION, VortexFile, VortexOpenOptions, VortexWriteOptions};
+use crate::{
+    Footer, V1_FOOTER_FBS_SIZE, VERSION, VortexFile, VortexOpenOptions, VortexWriteOptions,
+};
 
 #[test]
 fn test_eof_values() {
@@ -1199,5 +1203,36 @@ fn test_array_stream_no_double_dict_encode() -> VortexResult<()> {
         DictEncoding.id(),
         "dictionary codes should not be dictionary encoded"
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_external_footer() -> VortexResult<()> {
+    let layout_ctx = &LayoutContext::empty();
+    let array_ctx = &ArrayContext::empty();
+    let expected = buffer![1, 2, 3, 4].into_array();
+    let expected_dtype = expected.dtype();
+    let mut buf = Vec::new();
+    let footer =
+        VortexWriteOptions::default().write_blocking(&mut buf, expected.to_array_stream())?;
+
+    let footer_bytes = footer.write_flatbuffer_bytes(layout_ctx, array_ctx);
+
+    let deserialized_footer =
+        Footer::from_flatbuffer(footer_bytes, expected_dtype.clone(), layout_ctx, array_ctx)?;
+
+    let file = VortexOpenOptions::in_memory()
+        .with_footer(deserialized_footer)
+        .open(buf)?;
+    let stream = file.scan().unwrap().into_tokio_array_stream()?;
+    let actual = stream.read_all().await?;
+
+    assert_eq!(actual.len(), 4);
+    assert_eq!(actual.dtype(), expected_dtype);
+    assert_eq!(
+        &actual.into_arrow_preferred().unwrap(),
+        &expected.into_arrow_preferred().unwrap()
+    );
+
     Ok(())
 }

--- a/vortex-flatbuffers/flatbuffers/vortex-file/footer.fbs
+++ b/vortex-flatbuffers/flatbuffers/vortex-file/footer.fbs
@@ -112,6 +112,13 @@ table EncryptionSpec {
 }
 // [footer]
 
+table FullFooter {
+  footer: Footer;
+  layout: Layout;
+  statistics: FileStatistics;
+}
+
+root_type FullFooter;
 root_type FileStatistics;
 root_type Footer;
 root_type Postscript;

--- a/vortex-flatbuffers/src/generated/footer.rs
+++ b/vortex-flatbuffers/src/generated/footer.rs
@@ -1314,6 +1314,137 @@ impl core::fmt::Debug for EncryptionSpec<'_> {
       ds.finish()
   }
 }
+pub enum FullFooterOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct FullFooter<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for FullFooter<'a> {
+  type Inner = FullFooter<'a>;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: flatbuffers::Table::new(buf, loc) }
+  }
+}
+
+impl<'a> FullFooter<'a> {
+  pub const VT_FOOTER: flatbuffers::VOffsetT = 4;
+  pub const VT_LAYOUT: flatbuffers::VOffsetT = 6;
+  pub const VT_STATISTICS: flatbuffers::VOffsetT = 8;
+
+  #[inline]
+  pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    FullFooter { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+    args: &'args FullFooterArgs<'args>
+  ) -> flatbuffers::WIPOffset<FullFooter<'bldr>> {
+    let mut builder = FullFooterBuilder::new(_fbb);
+    if let Some(x) = args.statistics { builder.add_statistics(x); }
+    if let Some(x) = args.layout { builder.add_layout(x); }
+    if let Some(x) = args.footer { builder.add_footer(x); }
+    builder.finish()
+  }
+
+
+  #[inline]
+  pub fn footer(&self) -> Option<Footer<'a>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<Footer>>(FullFooter::VT_FOOTER, None)}
+  }
+  #[inline]
+  pub fn layout(&self) -> Option<Layout<'a>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<Layout>>(FullFooter::VT_LAYOUT, None)}
+  }
+  #[inline]
+  pub fn statistics(&self) -> Option<FileStatistics<'a>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<FileStatistics>>(FullFooter::VT_STATISTICS, None)}
+  }
+}
+
+impl flatbuffers::Verifiable for FullFooter<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<flatbuffers::ForwardsUOffset<Footer>>("footer", Self::VT_FOOTER, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<Layout>>("layout", Self::VT_LAYOUT, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<FileStatistics>>("statistics", Self::VT_STATISTICS, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct FullFooterArgs<'a> {
+    pub footer: Option<flatbuffers::WIPOffset<Footer<'a>>>,
+    pub layout: Option<flatbuffers::WIPOffset<Layout<'a>>>,
+    pub statistics: Option<flatbuffers::WIPOffset<FileStatistics<'a>>>,
+}
+impl<'a> Default for FullFooterArgs<'a> {
+  #[inline]
+  fn default() -> Self {
+    FullFooterArgs {
+      footer: None,
+      layout: None,
+      statistics: None,
+    }
+  }
+}
+
+pub struct FullFooterBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> FullFooterBuilder<'a, 'b, A> {
+  #[inline]
+  pub fn add_footer(&mut self, footer: flatbuffers::WIPOffset<Footer<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Footer>>(FullFooter::VT_FOOTER, footer);
+  }
+  #[inline]
+  pub fn add_layout(&mut self, layout: flatbuffers::WIPOffset<Layout<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Layout>>(FullFooter::VT_LAYOUT, layout);
+  }
+  #[inline]
+  pub fn add_statistics(&mut self, statistics: flatbuffers::WIPOffset<FileStatistics<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<FileStatistics>>(FullFooter::VT_STATISTICS, statistics);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> FullFooterBuilder<'a, 'b, A> {
+    let start = _fbb.start_table();
+    FullFooterBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<FullFooter<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for FullFooter<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("FullFooter");
+      ds.field("footer", &self.footer());
+      ds.field("layout", &self.layout());
+      ds.field("statistics", &self.statistics());
+      ds.finish()
+  }
+}
 #[inline]
 /// Verifies that a buffer of bytes contains a `Postscript`
 /// and returns it.

--- a/vortex-layout/src/flatbuffers.rs
+++ b/vortex-layout/src/flatbuffers.rs
@@ -39,6 +39,16 @@ pub fn layout_from_flatbuffer(
     array_ctx: &ArrayContext,
 ) -> VortexResult<LayoutRef> {
     let fb_layout = root_with_opts::<layout::Layout>(&LAYOUT_VERIFIER, &flatbuffer)?;
+    layout_from_fb_layout(flatbuffer.clone(), fb_layout, dtype, layout_ctx, array_ctx)
+}
+
+pub fn layout_from_fb_layout(
+    flatbuffer: FlatBuffer,
+    fb_layout: layout::Layout,
+    dtype: &DType,
+    layout_ctx: &LayoutContext,
+    array_ctx: &ArrayContext,
+) -> VortexResult<LayoutRef> {
     let encoding = layout_ctx
         .lookup_encoding(fb_layout.encoding())
         .ok_or_else(|| vortex_err!("Invalid encoding ID: {}", fb_layout.encoding()))?;
@@ -46,7 +56,7 @@ pub fn layout_from_flatbuffer(
     // SAFETY: we validate the flatbuffer above in the `root` call, and extract a loc.
     let viewed_children = unsafe {
         ViewedLayoutChildren::new_unchecked(
-            flatbuffer.clone(),
+            flatbuffer,
             fb_layout._tab.loc(),
             array_ctx.clone(),
             layout_ctx.clone(),


### PR DESCRIPTION
I believe this provides SpiralDB with the remaining functionality necessary to persist a written Vortex Footer into metadata at write time, deserialize it, and use it at read time.

DTypes already have a serialized form, so I didn't include it in the Footer. Moreover, I think Spiral can deduce the DType itself without serializing it.