### PR TITLE
Feature: Add DuckDB conversion for fixed-size lists / ARRAY type

### DIFF
--- a/vortex-duckdb/src/convert/dtype.rs
+++ b/vortex-duckdb/src/convert/dtype.rs
@@ -99,6 +99,23 @@ impl LogicalType {
         }
     }
 
+    /// Creates a DuckDB fixed-size list logical type with the specified element type and list size.
+    ///
+    /// Note that DuckDB calls what we call a fixed-size list the ARRAY type.
+    fn fixed_size_list_type(element_type: LogicalType, list_size: u32) -> VortexResult<Self> {
+        // SAFETY: We trust that DuckDB correctly gives us a valid pointer or `NULL`.
+        let ptr = unsafe {
+            cpp::duckdb_create_array_type(element_type.as_ptr(), list_size as cpp::idx_t)
+        };
+
+        if ptr.is_null() {
+            vortex_bail!("Failed to create fixed-size list (array) type");
+        }
+
+        // SAFETY: This pointer came directly from DuckDB, and we checked that it was not `NULL`.
+        Ok(unsafe { Self::own(ptr) })
+    }
+
     /// Converts temporal extension types to corresponding DuckDB types.
     ///
     /// # Arguments
@@ -315,8 +332,9 @@ impl TryFrom<&DType> for LogicalType {
                 let element_logical_type = LogicalType::try_from(element_dtype.as_ref())?;
                 return LogicalType::list_type(element_logical_type);
             }
-            DType::FixedSizeList(..) => {
-                unimplemented!("TODO(connor)[FixedSizeList]")
+            DType::FixedSizeList(element_dtype, list_size, _) => {
+                let element_logical_type = LogicalType::try_from(element_dtype.as_ref())?;
+                return LogicalType::fixed_size_list_type(element_logical_type, *list_size);
             }
             DType::Extension(ext_dtype) => {
                 if datetime::is_temporal_ext_type(ext_dtype.id()) {

--- a/vortex-duckdb/src/duckdb/logical_type.rs
+++ b/vortex-duckdb/src/duckdb/logical_type.rs
@@ -31,6 +31,18 @@ impl LogicalType {
         unsafe { Self::own(duckdb_create_list_type(element_dtype.as_ptr())) }
     }
 
+    pub fn new_array(element_dtype: DUCKDB_TYPE, array_size: u32) -> Self {
+        let element_dtype = Self::new(element_dtype);
+
+        // SAFETY: The element_dtype is created by `Self::new` which ensures it is valid.
+        unsafe {
+            Self::own(duckdb_create_array_type(
+                element_dtype.as_ptr(),
+                array_size as idx_t,
+            ))
+        }
+    }
+
     pub fn as_type_id(&self) -> DUCKDB_TYPE {
         unsafe { duckdb_get_type_id(self.as_ptr()) }
     }
@@ -50,6 +62,10 @@ impl LogicalType {
 
     pub fn array_child_type(&self) -> Self {
         unsafe { LogicalType::own(duckdb_array_type_child_type(self.as_ptr())) }
+    }
+
+    pub fn array_type_array_size(&self) -> idx_t {
+        unsafe { duckdb_array_type_array_size(self.as_ptr()) }
     }
 
     pub fn list_child_type(&self) -> Self {

--- a/vortex-duckdb/src/duckdb/vector.rs
+++ b/vortex-duckdb/src/duckdb/vector.rs
@@ -228,6 +228,13 @@ impl Vector {
         unsafe { Self::borrow(cpp::duckdb_list_vector_get_child(self.as_ptr())) }
     }
 
+    pub fn array_vector_get_child(&self) -> Self {
+        // SAFETY: duckdb_array_vector_get_child dereferences the vector pointer which must be
+        // valid and point to an ARRAY type vector. The returned child vector is borrowed and
+        // remains valid as long as the parent vector is valid.
+        unsafe { Self::borrow(cpp::duckdb_array_vector_get_child(self.as_ptr())) }
+    }
+
     pub fn list_vector_set_size(&self, size: u64) -> VortexResult<()> {
         let state = unsafe { cpp::duckdb_list_vector_set_size(self.as_ptr(), size) };
         match state {

--- a/vortex-duckdb/src/exporter/fixed_size_list.rs
+++ b/vortex-duckdb/src/exporter/fixed_size_list.rs
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Export support for Vortex FixedSizeListArray to DuckDB ARRAY type.
+//!
+//! DuckDB distinguishes between LIST (variable-size) and ARRAY (fixed-size) types.
+//! The ARRAY type in DuckDB corresponds to Vortex's [`DType::FixedSizeList`], where all
+//! lists have the same number of elements.
+//!
+//! [`DType::FixedSizeList`]: vortex_dtype::DType::FixedSizeList
+
+use vortex::arrays::FixedSizeListArray;
+use vortex::error::VortexResult;
+use vortex::mask::Mask;
+
+use super::{ConversionCache, new_array_exporter};
+use crate::duckdb::Vector;
+use crate::exporter::{ColumnExporter, VectorExt};
+
+/// Exporter for converting Vortex [`FixedSizeListArray`] to DuckDB ARRAY vectors.
+struct FixedSizeListExporter {
+    /// Validity mask indicating which lists/arrays are null.
+    validity: Mask,
+    /// Exporter for the underlying elements array.
+    elements_exporter: Box<dyn ColumnExporter>,
+    /// The fixed number of elements in each list.
+    list_size: u32,
+}
+
+/// Creates a new exporter for converting a [`FixedSizeListArray`] to DuckDB ARRAY format.
+pub(crate) fn new_exporter(
+    array: &FixedSizeListArray,
+    cache: &ConversionCache,
+) -> VortexResult<Box<dyn ColumnExporter>> {
+    let elements_exporter = new_array_exporter(array.elements(), cache)?;
+
+    Ok(Box::new(FixedSizeListExporter {
+        validity: array.validity_mask(),
+        elements_exporter,
+        list_size: array.list_size(),
+    }))
+}
+
+impl ColumnExporter for FixedSizeListExporter {
+    fn export(&self, offset: usize, len: usize, vector: &mut Vector) -> VortexResult<()> {
+        // Verify that offset + len doesn't exceed the validity mask length.
+        assert!(
+            offset + len <= self.validity.len(),
+            "Export range [{}, {}) exceeds validity mask length {}",
+            offset,
+            offset + len,
+            self.validity.len()
+        );
+
+        // TODO(connor): Should `export` be `unsafe` instead? We have no way to verify this without
+        // making an assertion.
+
+        // Set validity if necessary.
+        // SAFETY: We've asserted that offset + len <= self.validity.len(), which ensures
+        // we won't read past the validity mask bounds.
+        if unsafe { vector.set_validity(&self.validity, offset, len) } {
+            // All values are null, so no point copying the data.
+            return Ok(());
+        }
+
+        // Get the child vector for array elements.
+        let mut elements_vector = vector.array_vector_get_child();
+
+        // Export elements directly.
+        // For fixed-size lists: elements start at offset * list_size
+        // and we export len * list_size elements.
+        let element_offset = offset * self.list_size as usize;
+        let element_count = len * self.list_size as usize;
+
+        self.elements_exporter
+            .export(element_offset, element_count, &mut elements_vector)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex::IntoArray as _;
+    use vortex::buffer::buffer;
+    use vortex::validity::Validity;
+
+    use super::*;
+    use crate::cpp;
+    use crate::duckdb::{DataChunk, LogicalType, Vector};
+
+    /// Helper function to verify array elements in a DuckDB vector.
+    fn verify_array_elements(
+        vector: &Vector,
+        expected_values: &[i32],
+        list_size: usize,
+        num_lists: usize,
+    ) {
+        let child = vector.array_vector_get_child();
+        let slice = child.as_slice_with_len::<i32>(list_size * num_lists);
+        assert_eq!(slice, expected_values);
+    }
+
+    #[test]
+    fn test_export_empty_fixed_size_list() {
+        // Create an empty FixedSizeListArray with list_size=3.
+        let fsl = FixedSizeListArray::new(
+            buffer![0i32; 0].into_array(), // Empty elements
+            3,                             // list_size
+            Validity::AllValid,
+            0, // len (no lists)
+        );
+
+        let array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 3);
+        let mut chunk = DataChunk::new([array_type]);
+
+        new_exporter(&fsl, &ConversionCache::new(0))
+            .unwrap()
+            .export(0, 0, &mut chunk.get_vector(0))
+            .unwrap();
+        chunk.set_len(0);
+
+        // Should produce an empty chunk.
+        assert_eq!(chunk.len(), 0);
+    }
+
+    #[test]
+    fn test_export_non_empty_fixed_size_list() {
+        // Create a FixedSizeListArray with 3 lists of size 2.
+        // Lists: [1, 2], [3, 4], [5, 6]
+        let fsl = FixedSizeListArray::new(
+            buffer![1i32, 2, 3, 4, 5, 6].into_array(),
+            2, // list_size
+            Validity::AllValid,
+            3, // len (3 lists)
+        );
+
+        let array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 2);
+        let mut chunk = DataChunk::new([array_type]);
+
+        new_exporter(&fsl, &ConversionCache::new(0))
+            .unwrap()
+            .export(0, 3, &mut chunk.get_vector(0))
+            .unwrap();
+        chunk.set_len(3);
+
+        // Verify the chunk contains the expected data.
+        assert_eq!(chunk.len(), 3);
+
+        // Verify the actual array values.
+        let vector = chunk.get_vector(0);
+        verify_array_elements(&vector, &[1, 2, 3, 4, 5, 6], 2, 3);
+    }
+
+    #[test]
+    fn test_export_fixed_size_list_with_nulls() {
+        // Create a FixedSizeListArray with 4 lists of size 3, with 2nd list null.
+        // Lists: [1, 2, 3], NULL, [7, 8, 9], [10, 11, 12]
+        let fsl = FixedSizeListArray::new(
+            buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].into_array(),
+            3, // list_size
+            Validity::from_iter([true, false, true, true]),
+            4, // len (4 lists)
+        );
+
+        let array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 3);
+        let mut chunk = DataChunk::new([array_type]);
+
+        new_exporter(&fsl, &ConversionCache::new(0))
+            .unwrap()
+            .export(0, 4, &mut chunk.get_vector(0))
+            .unwrap();
+        chunk.set_len(4);
+
+        assert_eq!(chunk.len(), 4);
+
+        // Verify nullability.
+        let vector = chunk.get_vector(0);
+        assert!(!vector.row_is_null(0));
+        assert!(vector.row_is_null(1));
+        assert!(!vector.row_is_null(2));
+        assert!(!vector.row_is_null(3));
+
+        // Verify the values (note: elements for null list still exist in storage).
+        verify_array_elements(&vector, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], 3, 4);
+    }
+
+    #[test]
+    fn test_export_all_null_lists() {
+        // Create a FixedSizeListArray where all lists are null.
+        let fsl = FixedSizeListArray::new(
+            buffer![0i32; 6].into_array(), // Elements (unused due to nulls)
+            2,                             // list_size
+            Validity::from_iter([false, false, false]),
+            3, // len (3 lists, all null)
+        );
+
+        let array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 2);
+        let mut chunk = DataChunk::new([array_type]);
+
+        new_exporter(&fsl, &ConversionCache::new(0))
+            .unwrap()
+            .export(0, 3, &mut chunk.get_vector(0))
+            .unwrap();
+        chunk.set_len(3);
+
+        assert_eq!(chunk.len(), 3);
+
+        // All lists should be null.
+        let vector = chunk.get_vector(0);
+        assert!(vector.row_is_null(0));
+        assert!(vector.row_is_null(1));
+        assert!(vector.row_is_null(2));
+    }
+
+    #[test]
+    fn test_export_alternating_null_pattern() {
+        // Create a FixedSizeListArray with alternating null/valid pattern.
+        // Lists: NULL, [2, 3], NULL, [6, 7], NULL
+        let fsl = FixedSizeListArray::new(
+            buffer![0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_array(),
+            2, // list_size
+            Validity::from_iter([false, true, false, true, false]),
+            5, // len (5 lists)
+        );
+
+        let array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 2);
+        let mut chunk = DataChunk::new([array_type]);
+
+        new_exporter(&fsl, &ConversionCache::new(0))
+            .unwrap()
+            .export(0, 5, &mut chunk.get_vector(0))
+            .unwrap();
+        chunk.set_len(5);
+
+        assert_eq!(chunk.len(), 5);
+
+        // Verify alternating null pattern.
+        let vector = chunk.get_vector(0);
+        assert!(vector.row_is_null(0));
+        assert!(!vector.row_is_null(1));
+        assert!(vector.row_is_null(2));
+        assert!(!vector.row_is_null(3));
+        assert!(vector.row_is_null(4));
+    }
+
+    #[test]
+    fn test_export_list_size_zero() {
+        // Create a FixedSizeListArray with list_size=0 (degenerate case).
+        // This represents arrays with no elements.
+        let fsl = FixedSizeListArray::new(
+            buffer![0i32; 0].into_array(), // No elements needed
+            0,                             // list_size = 0
+            Validity::AllValid,
+            3, // len (3 empty lists)
+        );
+
+        let array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 0);
+        let mut chunk = DataChunk::new([array_type]);
+
+        new_exporter(&fsl, &ConversionCache::new(0))
+            .unwrap()
+            .export(0, 3, &mut chunk.get_vector(0))
+            .unwrap();
+        chunk.set_len(3);
+
+        // Should have 3 lists, each with 0 elements.
+        assert_eq!(chunk.len(), 3);
+    }
+
+    #[test]
+    fn test_export_list_size_one() {
+        // Create a FixedSizeListArray with list_size=1 (single element arrays).
+        // Lists: [10], [20], [30], [40]
+        let fsl = FixedSizeListArray::new(
+            buffer![10i32, 20, 30, 40].into_array(),
+            1, // list_size = 1
+            Validity::AllValid,
+            4, // len (4 lists)
+        );
+
+        let array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 1);
+        let mut chunk = DataChunk::new([array_type]);
+
+        new_exporter(&fsl, &ConversionCache::new(0))
+            .unwrap()
+            .export(0, 4, &mut chunk.get_vector(0))
+            .unwrap();
+        chunk.set_len(4);
+
+        assert_eq!(chunk.len(), 4);
+
+        // Verify the single-element arrays.
+        let vector = chunk.get_vector(0);
+        verify_array_elements(&vector, &[10, 20, 30, 40], 1, 4);
+    }
+
+    #[test]
+    fn test_export_partial_range() {
+        // Test exporting a partial range from the middle of the array.
+        // Lists: [1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]
+        let fsl = FixedSizeListArray::new(
+            buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].into_array(),
+            3, // list_size
+            Validity::AllValid,
+            4, // len (4 lists)
+        );
+
+        let array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 3);
+        let mut chunk = DataChunk::new([array_type]);
+
+        // Export only the middle 2 lists (indices 1 and 2).
+        new_exporter(&fsl, &ConversionCache::new(0))
+            .unwrap()
+            .export(1, 2, &mut chunk.get_vector(0))
+            .unwrap();
+        chunk.set_len(2);
+
+        assert_eq!(chunk.len(), 2);
+
+        // Should contain [4, 5, 6], [7, 8, 9].
+        let vector = chunk.get_vector(0);
+        verify_array_elements(&vector, &[4, 5, 6, 7, 8, 9], 3, 2);
+    }
+}

--- a/vortex-duckdb/src/exporter/fixed_size_list.rs
+++ b/vortex-duckdb/src/exporter/fixed_size_list.rs
@@ -42,6 +42,8 @@ pub(crate) fn new_exporter(
 }
 
 impl ColumnExporter for FixedSizeListExporter {
+    // TODO(connor): Should `export` be `unsafe` instead? We have no way to verify this without
+    // making an assertion.
     fn export(&self, offset: usize, len: usize, vector: &mut Vector) -> VortexResult<()> {
         // Verify that offset + len doesn't exceed the validity mask length.
         assert!(
@@ -51,9 +53,6 @@ impl ColumnExporter for FixedSizeListExporter {
             offset + len,
             self.validity.len()
         );
-
-        // TODO(connor): Should `export` be `unsafe` instead? We have no way to verify this without
-        // making an assertion.
 
         // Set validity if necessary.
         // SAFETY: We've asserted that offset + len <= self.validity.len(), which ensures
@@ -87,6 +86,47 @@ mod tests {
     use crate::cpp;
     use crate::duckdb::{DataChunk, LogicalType, Vector};
 
+    /// Sets up a DataChunk, exports the array to it, and returns the chunk.
+    fn export_to_chunk(
+        fsl: &FixedSizeListArray,
+        list_size: u32,
+        offset: usize,
+        len: usize,
+    ) -> DataChunk {
+        let array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, list_size);
+
+        // TODO(connor): This mutable API is brittle. Maybe bundle this logic?
+        let mut chunk = DataChunk::new([array_type]);
+
+        new_exporter(fsl, &ConversionCache::new(0))
+            .unwrap()
+            .export(offset, len, &mut chunk.get_vector(0))
+            .unwrap();
+        chunk.set_len(len);
+
+        chunk
+    }
+
+    /// Asserts that the null pattern in a vector matches the expected pattern.
+    /// true = valid (not null), false = null
+    fn assert_nulls(vector: &Vector, expected: &[bool]) {
+        for (i, &expected_valid) in expected.iter().enumerate() {
+            if expected_valid {
+                assert!(
+                    !vector.row_is_null(i as u64),
+                    "Row {} should be valid but is null",
+                    i
+                );
+            } else {
+                assert!(
+                    vector.row_is_null(i as u64),
+                    "Row {} should be null but is valid",
+                    i
+                );
+            }
+        }
+    }
+
     /// Helper function to verify array elements in a DuckDB vector.
     fn verify_array_elements(
         vector: &Vector,
@@ -102,21 +142,8 @@ mod tests {
     #[test]
     fn test_export_empty_fixed_size_list() {
         // Create an empty FixedSizeListArray with list_size=3.
-        let fsl = FixedSizeListArray::new(
-            buffer![0i32; 0].into_array(), // Empty elements
-            3,                             // list_size
-            Validity::AllValid,
-            0, // len (no lists)
-        );
-
-        let array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 3);
-        let mut chunk = DataChunk::new([array_type]);
-
-        new_exporter(&fsl, &ConversionCache::new(0))
-            .unwrap()
-            .export(0, 0, &mut chunk.get_vector(0))
-            .unwrap();
-        chunk.set_len(0);
+        let fsl = FixedSizeListArray::new(buffer![0i32; 0].into_array(), 3, Validity::AllValid, 0);
+        let chunk = export_to_chunk(&fsl, 3, 0, 0);
 
         // Should produce an empty chunk.
         assert_eq!(chunk.len(), 0);
@@ -128,19 +155,11 @@ mod tests {
         // Lists: [1, 2], [3, 4], [5, 6]
         let fsl = FixedSizeListArray::new(
             buffer![1i32, 2, 3, 4, 5, 6].into_array(),
-            2, // list_size
+            2,
             Validity::AllValid,
-            3, // len (3 lists)
+            3,
         );
-
-        let array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 2);
-        let mut chunk = DataChunk::new([array_type]);
-
-        new_exporter(&fsl, &ConversionCache::new(0))
-            .unwrap()
-            .export(0, 3, &mut chunk.get_vector(0))
-            .unwrap();
-        chunk.set_len(3);
+        let chunk = export_to_chunk(&fsl, 2, 0, 3);
 
         // Verify the chunk contains the expected data.
         assert_eq!(chunk.len(), 3);
@@ -156,28 +175,17 @@ mod tests {
         // Lists: [1, 2, 3], NULL, [7, 8, 9], [10, 11, 12]
         let fsl = FixedSizeListArray::new(
             buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].into_array(),
-            3, // list_size
+            3,
             Validity::from_iter([true, false, true, true]),
-            4, // len (4 lists)
+            4,
         );
-
-        let array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 3);
-        let mut chunk = DataChunk::new([array_type]);
-
-        new_exporter(&fsl, &ConversionCache::new(0))
-            .unwrap()
-            .export(0, 4, &mut chunk.get_vector(0))
-            .unwrap();
-        chunk.set_len(4);
+        let chunk = export_to_chunk(&fsl, 3, 0, 4);
 
         assert_eq!(chunk.len(), 4);
 
         // Verify nullability.
         let vector = chunk.get_vector(0);
-        assert!(!vector.row_is_null(0));
-        assert!(vector.row_is_null(1));
-        assert!(!vector.row_is_null(2));
-        assert!(!vector.row_is_null(3));
+        assert_nulls(&vector, &[true, false, true, true]);
 
         // Verify the values (note: elements for null list still exist in storage).
         verify_array_elements(&vector, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], 3, 4);
@@ -187,28 +195,18 @@ mod tests {
     fn test_export_all_null_lists() {
         // Create a FixedSizeListArray where all lists are null.
         let fsl = FixedSizeListArray::new(
-            buffer![0i32; 6].into_array(), // Elements (unused due to nulls)
-            2,                             // list_size
+            buffer![0i32; 6].into_array(),
+            2,
             Validity::from_iter([false, false, false]),
-            3, // len (3 lists, all null)
+            3,
         );
-
-        let array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 2);
-        let mut chunk = DataChunk::new([array_type]);
-
-        new_exporter(&fsl, &ConversionCache::new(0))
-            .unwrap()
-            .export(0, 3, &mut chunk.get_vector(0))
-            .unwrap();
-        chunk.set_len(3);
+        let chunk = export_to_chunk(&fsl, 2, 0, 3);
 
         assert_eq!(chunk.len(), 3);
 
         // All lists should be null.
         let vector = chunk.get_vector(0);
-        assert!(vector.row_is_null(0));
-        assert!(vector.row_is_null(1));
-        assert!(vector.row_is_null(2));
+        assert_nulls(&vector, &[false, false, false]);
     }
 
     #[test]
@@ -217,50 +215,25 @@ mod tests {
         // Lists: NULL, [2, 3], NULL, [6, 7], NULL
         let fsl = FixedSizeListArray::new(
             buffer![0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_array(),
-            2, // list_size
+            2,
             Validity::from_iter([false, true, false, true, false]),
-            5, // len (5 lists)
+            5,
         );
-
-        let array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 2);
-        let mut chunk = DataChunk::new([array_type]);
-
-        new_exporter(&fsl, &ConversionCache::new(0))
-            .unwrap()
-            .export(0, 5, &mut chunk.get_vector(0))
-            .unwrap();
-        chunk.set_len(5);
+        let chunk = export_to_chunk(&fsl, 2, 0, 5);
 
         assert_eq!(chunk.len(), 5);
 
         // Verify alternating null pattern.
         let vector = chunk.get_vector(0);
-        assert!(vector.row_is_null(0));
-        assert!(!vector.row_is_null(1));
-        assert!(vector.row_is_null(2));
-        assert!(!vector.row_is_null(3));
-        assert!(vector.row_is_null(4));
+        assert_nulls(&vector, &[false, true, false, true, false]);
     }
 
     #[test]
     fn test_export_list_size_zero() {
         // Create a FixedSizeListArray with list_size=0 (degenerate case).
         // This represents arrays with no elements.
-        let fsl = FixedSizeListArray::new(
-            buffer![0i32; 0].into_array(), // No elements needed
-            0,                             // list_size = 0
-            Validity::AllValid,
-            3, // len (3 empty lists)
-        );
-
-        let array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 0);
-        let mut chunk = DataChunk::new([array_type]);
-
-        new_exporter(&fsl, &ConversionCache::new(0))
-            .unwrap()
-            .export(0, 3, &mut chunk.get_vector(0))
-            .unwrap();
-        chunk.set_len(3);
+        let fsl = FixedSizeListArray::new(buffer![0i32; 0].into_array(), 0, Validity::AllValid, 3);
+        let chunk = export_to_chunk(&fsl, 0, 0, 3);
 
         // Should have 3 lists, each with 0 elements.
         assert_eq!(chunk.len(), 3);
@@ -272,19 +245,11 @@ mod tests {
         // Lists: [10], [20], [30], [40]
         let fsl = FixedSizeListArray::new(
             buffer![10i32, 20, 30, 40].into_array(),
-            1, // list_size = 1
+            1,
             Validity::AllValid,
-            4, // len (4 lists)
+            4,
         );
-
-        let array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 1);
-        let mut chunk = DataChunk::new([array_type]);
-
-        new_exporter(&fsl, &ConversionCache::new(0))
-            .unwrap()
-            .export(0, 4, &mut chunk.get_vector(0))
-            .unwrap();
-        chunk.set_len(4);
+        let chunk = export_to_chunk(&fsl, 1, 0, 4);
 
         assert_eq!(chunk.len(), 4);
 
@@ -299,26 +264,32 @@ mod tests {
         // Lists: [1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]
         let fsl = FixedSizeListArray::new(
             buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].into_array(),
-            3, // list_size
+            3,
             Validity::AllValid,
-            4, // len (4 lists)
+            4,
         );
 
-        let array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 3);
-        let mut chunk = DataChunk::new([array_type]);
-
         // Export only the middle 2 lists (indices 1 and 2).
-        new_exporter(&fsl, &ConversionCache::new(0))
-            .unwrap()
-            .export(1, 2, &mut chunk.get_vector(0))
-            .unwrap();
-        chunk.set_len(2);
+        let chunk = export_to_chunk(&fsl, 3, 1, 2);
 
         assert_eq!(chunk.len(), 2);
 
         // Should contain [4, 5, 6], [7, 8, 9].
         let vector = chunk.get_vector(0);
         verify_array_elements(&vector, &[4, 5, 6, 7, 8, 9], 3, 2);
+    }
+
+    /// Helper to create nested array type for DuckDB.
+    fn create_nested_array_type(inner_list_size: u32, outer_list_size: u32) -> LogicalType {
+        let inner_array_type =
+            LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, inner_list_size);
+        // SAFETY: inner_array_type is a valid LogicalType created above.
+        unsafe {
+            LogicalType::own(cpp::duckdb_create_array_type(
+                inner_array_type.as_ptr(),
+                outer_list_size as cpp::idx_t,
+            ))
+        }
     }
 
     #[test]
@@ -335,7 +306,7 @@ mod tests {
         // First create the inner FSL with all the flattened elements.
         let inner_fsl = FixedSizeListArray::new(
             buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].into_array(),
-            2, // inner list_size
+            2,
             Validity::AllValid,
             6, // 6 inner lists total (3 per outer list * 2 outer lists)
         );
@@ -348,17 +319,8 @@ mod tests {
             2, // 2 outer lists
         );
 
-        // Create the nested array type for DuckDB.
-        // First create the inner array type, then use it for the outer.
-        let inner_array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 2);
-        // SAFETY: inner_array_type is a valid LogicalType created above.
-        let outer_array_type = unsafe {
-            LogicalType::own(cpp::duckdb_create_array_type(
-                inner_array_type.as_ptr(),
-                3 as cpp::idx_t,
-            ))
-        };
-
+        // Create the nested array type and export.
+        let outer_array_type = create_nested_array_type(2, 3);
         let mut chunk = DataChunk::new([outer_array_type]);
 
         new_exporter(&outer_fsl, &ConversionCache::new(0))
@@ -393,7 +355,7 @@ mod tests {
                 1i32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18
             ]
             .into_array(),
-            2, // inner list_size
+            2,
             Validity::from_iter([
                 true, true, true, // First outer's inner arrays
                 true, true, true, // Second outer's inner arrays (unused due to outer null)
@@ -410,16 +372,8 @@ mod tests {
             3, // 3 outer lists
         );
 
-        // Create the nested array type.
-        let inner_array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 2);
-        // SAFETY: inner_array_type is a valid LogicalType created above.
-        let outer_array_type = unsafe {
-            LogicalType::own(cpp::duckdb_create_array_type(
-                inner_array_type.as_ptr(),
-                3 as cpp::idx_t,
-            ))
-        };
-
+        // Create the nested array type and export.
+        let outer_array_type = create_nested_array_type(2, 3);
         let mut chunk = DataChunk::new([outer_array_type]);
 
         new_exporter(&outer_fsl, &ConversionCache::new(0))
@@ -432,9 +386,7 @@ mod tests {
 
         // Verify outer level nullability.
         let outer_vector = chunk.get_vector(0);
-        assert!(!outer_vector.row_is_null(0)); // First outer array is valid
-        assert!(outer_vector.row_is_null(1)); // Second outer array is null
-        assert!(!outer_vector.row_is_null(2)); // Third outer array is valid
+        assert_nulls(&outer_vector, &[true, false, true]);
 
         // Verify inner level structure and nullability.
         let inner_vector = outer_vector.array_vector_get_child();

--- a/vortex-duckdb/src/exporter/fixed_size_list.rs
+++ b/vortex-duckdb/src/exporter/fixed_size_list.rs
@@ -320,4 +320,139 @@ mod tests {
         let vector = chunk.get_vector(0);
         verify_array_elements(&vector, &[4, 5, 6, 7, 8, 9], 3, 2);
     }
+
+    #[test]
+    fn test_export_nested_fixed_size_list() {
+        // Test nested fixed-size lists: FSL<FSL<i32, 2>, 3>
+        // This represents an array of arrays, where:
+        // - The outer array has 3 elements
+        // - Each element is itself an array of 2 i32 values
+        //
+        // We'll create 2 outer arrays:
+        // Outer array 1: [[1, 2], [3, 4], [5, 6]]
+        // Outer array 2: [[7, 8], [9, 10], [11, 12]]
+
+        // First create the inner FSL with all the flattened elements.
+        let inner_fsl = FixedSizeListArray::new(
+            buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].into_array(),
+            2, // inner list_size
+            Validity::AllValid,
+            6, // 6 inner lists total (3 per outer list * 2 outer lists)
+        );
+
+        // Now create the outer FSL that contains the inner FSL.
+        let outer_fsl = FixedSizeListArray::new(
+            inner_fsl.into_array(),
+            3, // outer list_size (3 inner lists per outer list)
+            Validity::AllValid,
+            2, // 2 outer lists
+        );
+
+        // Create the nested array type for DuckDB.
+        // First create the inner array type, then use it for the outer.
+        let inner_array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 2);
+        // SAFETY: inner_array_type is a valid LogicalType created above.
+        let outer_array_type = unsafe {
+            LogicalType::own(cpp::duckdb_create_array_type(
+                inner_array_type.as_ptr(),
+                3 as cpp::idx_t,
+            ))
+        };
+
+        let mut chunk = DataChunk::new([outer_array_type]);
+
+        new_exporter(&outer_fsl, &ConversionCache::new(0))
+            .unwrap()
+            .export(0, 2, &mut chunk.get_vector(0))
+            .unwrap();
+        chunk.set_len(2);
+
+        assert_eq!(chunk.len(), 2);
+
+        // Verify the nested structure.
+        let outer_vector = chunk.get_vector(0);
+        let inner_vector = outer_vector.array_vector_get_child();
+        let elements_vector = inner_vector.array_vector_get_child();
+
+        // The elements should be all 12 integers in order.
+        let elements = elements_vector.as_slice_with_len::<i32>(12);
+        assert_eq!(elements, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    }
+
+    #[test]
+    fn test_export_nested_fixed_size_list_with_nulls() {
+        // Test nested FSL with nulls at different levels.
+        // Outer structure: FSL<FSL<i32, 2>, 3> with 3 outer arrays
+        // Outer array 1: [[1, 2], [3, 4], [5, 6]]    - valid
+        // Outer array 2: NULL                         - null outer array
+        // Outer array 3: [[13, 14], NULL, [17, 18]]  - valid outer with null inner
+
+        // Create inner FSL with mixed validity.
+        let inner_fsl = FixedSizeListArray::new(
+            buffer![
+                1i32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18
+            ]
+            .into_array(),
+            2, // inner list_size
+            Validity::from_iter([
+                true, true, true, // First outer's inner arrays
+                true, true, true, // Second outer's inner arrays (unused due to outer null)
+                true, false, true, // Third outer's inner arrays (middle one is null)
+            ]),
+            9, // 9 inner lists total
+        );
+
+        // Create outer FSL with null in the middle.
+        let outer_fsl = FixedSizeListArray::new(
+            inner_fsl.into_array(),
+            3, // outer list_size
+            Validity::from_iter([true, false, true]),
+            3, // 3 outer lists
+        );
+
+        // Create the nested array type.
+        let inner_array_type = LogicalType::new_array(cpp::DUCKDB_TYPE::DUCKDB_TYPE_INTEGER, 2);
+        // SAFETY: inner_array_type is a valid LogicalType created above.
+        let outer_array_type = unsafe {
+            LogicalType::own(cpp::duckdb_create_array_type(
+                inner_array_type.as_ptr(),
+                3 as cpp::idx_t,
+            ))
+        };
+
+        let mut chunk = DataChunk::new([outer_array_type]);
+
+        new_exporter(&outer_fsl, &ConversionCache::new(0))
+            .unwrap()
+            .export(0, 3, &mut chunk.get_vector(0))
+            .unwrap();
+        chunk.set_len(3);
+
+        assert_eq!(chunk.len(), 3);
+
+        // Verify outer level nullability.
+        let outer_vector = chunk.get_vector(0);
+        assert!(!outer_vector.row_is_null(0)); // First outer array is valid
+        assert!(outer_vector.row_is_null(1)); // Second outer array is null
+        assert!(!outer_vector.row_is_null(2)); // Third outer array is valid
+
+        // Verify inner level structure and nullability.
+        let inner_vector = outer_vector.array_vector_get_child();
+
+        // For the third outer array, check its inner null pattern.
+        // Inner arrays are at indices 6, 7, 8 (3rd outer array's children).
+        assert!(!inner_vector.row_is_null(6)); // [13, 14] - valid
+        assert!(inner_vector.row_is_null(7)); // NULL
+        assert!(!inner_vector.row_is_null(8)); // [17, 18] - valid
+
+        // Verify all elements are present in storage.
+        let elements_vector = inner_vector.array_vector_get_child();
+        let elements = elements_vector.as_slice_with_len::<i32>(18);
+        assert_eq!(
+            elements,
+            &[
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18
+            ]
+        );
+    }
 }

--- a/vortex-duckdb/src/exporter/list.rs
+++ b/vortex-duckdb/src/exporter/list.rs
@@ -125,7 +125,7 @@ mod tests {
     }
 
     #[test]
-    fn test_export_non_empty_list_with_preceeding_and_trailing_garbage() {
+    fn test_export_non_empty_list_with_preceding_and_trailing_garbage() {
         let list = ListArray::try_new(
             buffer![0, 1, 2, 3, 4, 5].into_array(),
             buffer![1u8, 2, 3, 4].into_array(),

--- a/vortex-duckdb/src/exporter/mod.rs
+++ b/vortex-duckdb/src/exporter/mod.rs
@@ -6,6 +6,7 @@ mod cache;
 mod constant;
 mod decimal;
 mod dict;
+mod fixed_size_list;
 mod list;
 mod primitive;
 mod run_end;
@@ -171,7 +172,7 @@ fn new_array_exporter(
             vortex_bail!("Struct arrays are not supported in DuckDB export yet");
         }
         Canonical::List(array) => list::new_exporter(&array, cache),
-        Canonical::FixedSizeList(_) => todo!("TODO(connor)[FixedSizeList]"),
+        Canonical::FixedSizeList(array) => fixed_size_list::new_exporter(&array, cache),
         Canonical::VarBinView(array) => varbinview::new_exporter(&array),
         Canonical::Extension(ext) => {
             if is_temporal_ext_type(ext.id()) {

--- a/vortex-ffi/cinclude/vortex.h
+++ b/vortex-ffi/cinclude/vortex.h
@@ -509,22 +509,22 @@ vx_dtype_variant vx_dtype_get_variant(const vx_dtype *dtype);
 bool vx_dtype_is_nullable(const vx_dtype *dtype);
 
 /**
- * Return the [`vx_ptype`] of a primitive data type.
+ * Returns the [`vx_ptype`] of a primitive.
  */
 vx_ptype vx_dtype_primitive_ptype(const vx_dtype *dtype);
 
 /**
- * Return the precision of a decimal data type.
+ * Returns the precision of a decimal.
  */
 uint8_t vx_dtype_decimal_precision(const vx_dtype *dtype);
 
 /**
- * Return the scale of a decimal data type.
+ * Returns the scale of a decimal.
  */
 int8_t vx_dtype_decimal_scale(const vx_dtype *dtype);
 
 /**
- * Return a borrowed reference to the [`vx_struct_fields`] of a struct data type.
+ * Return a borrowed reference to the [`vx_struct_fields`] of a struct.
  *
  * The returned pointer is valid as long as the struct dtype is valid.
  * Do NOT free the returned pointer - it shares the lifetime of the struct dtype.
@@ -532,7 +532,7 @@ int8_t vx_dtype_decimal_scale(const vx_dtype *dtype);
 const vx_struct_fields *vx_dtype_struct_dtype(const vx_dtype *dtype);
 
 /**
- * Return the `element` type of a list data type.
+ * Returns the element type of a list.
  *
  * The returned pointer is valid as long as the list dtype is valid.
  * Do NOT free the returned dtype pointer - it shares the lifetime of the list dtype.
@@ -540,7 +540,7 @@ const vx_struct_fields *vx_dtype_struct_dtype(const vx_dtype *dtype);
 const vx_dtype *vx_dtype_list_element(const vx_dtype *dtype);
 
 /**
- * Return the `element` type of a fixed-size list data type.
+ * Returns the element type of a fixed-size list.
  *
  * The returned pointer is valid as long as the fixed-size list dtype is valid.
  * Do NOT free the returned dtype pointer - it shares the lifetime of the fixed-size list dtype.
@@ -548,18 +548,33 @@ const vx_dtype *vx_dtype_list_element(const vx_dtype *dtype);
 const vx_dtype *vx_dtype_fixed_size_list_element(const vx_dtype *dtype);
 
 /**
- * Return the size of a fixed-size list data type.
+ * Returns the size of a fixed-size list.
  */
 uint32_t vx_dtype_fixed_size_list_size(const vx_dtype *dtype);
 
+/**
+ * Checks if the type is time.
+ */
 bool vx_dtype_is_time(const DType *dtype);
 
+/**
+ * Checks if the type is a date.
+ */
 bool vx_dtype_is_date(const DType *dtype);
 
+/**
+ * Checks if the type is a timestamp.
+ */
 bool vx_dtype_is_timestamp(const DType *dtype);
 
+/**
+ * Returns the time unit, assuming the type is time.
+ */
 uint8_t vx_dtype_time_unit(const DType *dtype);
 
+/**
+ * Returns the time zone, assuming the type is time.
+ */
 void vx_dtype_time_zone(const DType *dtype, void *dst, int *len);
 
 /**

--- a/vortex-ffi/cinclude/vortex.h
+++ b/vortex-ffi/cinclude/vortex.h
@@ -19,41 +19,45 @@
  */
 typedef enum {
   /**
-   * Null type
+   * Null type.
    */
   DTYPE_NULL = 0,
   /**
-   * Boolean type
+   * Boolean type.
    */
   DTYPE_BOOL = 1,
   /**
-   * Primitive types (e.g., u8, i16, f32, etc.)
+   * Primitive types (e.g., u8, i16, f32, etc.).
    */
   DTYPE_PRIMITIVE = 2,
   /**
-   * Variable-length UTF-8 string type
+   * Variable-length UTF-8 string type.
    */
   DTYPE_UTF8 = 3,
   /**
-   * Variable-length binary data type
+   * Variable-length binary data type.
    */
   DTYPE_BINARY = 4,
   /**
-   * Nested struct type
+   * Nested struct type.
    */
   DTYPE_STRUCT = 5,
   /**
-   * Nested list type
+   * Nested list type.
    */
   DTYPE_LIST = 6,
   /**
-   * User-defined extension type
+   * User-defined extension type.
    */
   DTYPE_EXTENSION = 7,
   /**
-   * Decimal type with fixed precision and scale
+   * Decimal type with fixed precision and scale.
    */
   DTYPE_DECIMAL = 8,
+  /**
+   * Nested fixed-size list type.
+   */
+  DTYPE_FIXED_SIZE_LIST = 9,
 } vx_dtype_variant;
 
 /**
@@ -221,7 +225,7 @@ typedef struct vx_dtype vx_dtype;
 typedef struct vx_error vx_error;
 
 /**
- * A handle to a Vortex file encapsulating ther footer and logic for instantiating a reader.
+ * A handle to a Vortex file encapsulating the footer and logic for instantiating a reader.
  */
 typedef struct vx_file vx_file;
 
@@ -474,6 +478,15 @@ const vx_dtype *vx_dtype_new_binary(bool is_nullable);
 const vx_dtype *vx_dtype_new_list(const vx_dtype *element, bool is_nullable);
 
 /**
+ * Create a new fixed-size list data type.
+ *
+ * Takes ownership of the `element` pointer.
+ */
+const vx_dtype *vx_dtype_new_fixed_size_list(const vx_dtype *element,
+                                             uint32_t size,
+                                             bool is_nullable);
+
+/**
  * Create a new struct data type.
  *
  * Takes ownership of the `struct_dtype` pointer.
@@ -525,6 +538,19 @@ const vx_struct_fields *vx_dtype_struct_dtype(const vx_dtype *dtype);
  * Do NOT free the returned dtype pointer - it shares the lifetime of the list dtype.
  */
 const vx_dtype *vx_dtype_list_element(const vx_dtype *dtype);
+
+/**
+ * Return the `element` type of a fixed-size list data type.
+ *
+ * The returned pointer is valid as long as the fixed-size list dtype is valid.
+ * Do NOT free the returned dtype pointer - it shares the lifetime of the fixed-size list dtype.
+ */
+const vx_dtype *vx_dtype_fixed_size_list_element(const vx_dtype *dtype);
+
+/**
+ * Return the size of a fixed-size list data type.
+ */
+uint32_t vx_dtype_fixed_size_list_size(const vx_dtype *dtype);
 
 bool vx_dtype_is_time(const DType *dtype);
 

--- a/vortex-ffi/src/dtype.rs
+++ b/vortex-ffi/src/dtype.rs
@@ -27,24 +27,26 @@ arc_wrapper!(
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum vx_dtype_variant {
-    /// Null type
+    /// Null type.
     DTYPE_NULL = 0,
-    /// Boolean type
+    /// Boolean type.
     DTYPE_BOOL = 1,
-    /// Primitive types (e.g., u8, i16, f32, etc.)
+    /// Primitive types (e.g., u8, i16, f32, etc.).
     DTYPE_PRIMITIVE = 2,
-    /// Variable-length UTF-8 string type
+    /// Variable-length UTF-8 string type.
     DTYPE_UTF8 = 3,
-    /// Variable-length binary data type
+    /// Variable-length binary data type.
     DTYPE_BINARY = 4,
-    /// Nested struct type
+    /// Nested struct type.
     DTYPE_STRUCT = 5,
-    /// Nested list type
+    /// Nested list type.
     DTYPE_LIST = 6,
-    /// User-defined extension type
+    /// User-defined extension type.
     DTYPE_EXTENSION = 7,
-    /// Decimal type with fixed precision and scale
+    /// Decimal type with fixed precision and scale.
     DTYPE_DECIMAL = 8,
+    /// Nested fixed-size list type.
+    DTYPE_FIXED_SIZE_LIST = 9,
 }
 
 impl From<&DType> for vx_dtype_variant {
@@ -58,9 +60,7 @@ impl From<&DType> for vx_dtype_variant {
             DType::Binary(_) => vx_dtype_variant::DTYPE_BINARY,
             DType::Struct(..) => vx_dtype_variant::DTYPE_STRUCT,
             DType::List(..) => vx_dtype_variant::DTYPE_LIST,
-            DType::FixedSizeList(..) => {
-                unimplemented!("TODO(connor)[FixedSizeList]")
-            }
+            DType::FixedSizeList(..) => vx_dtype_variant::DTYPE_FIXED_SIZE_LIST,
             DType::Extension(_) => vx_dtype_variant::DTYPE_EXTENSION,
         }
     }
@@ -109,6 +109,23 @@ pub unsafe extern "C-unwind" fn vx_dtype_new_list(
 ) -> *const vx_dtype {
     let element = vx_dtype::into_arc(element);
     vx_dtype::new(Arc::new(DType::List(element, is_nullable.into())))
+}
+
+/// Create a new fixed-size list data type.
+///
+/// Takes ownership of the `element` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_dtype_new_fixed_size_list(
+    element: *const vx_dtype,
+    size: u32,
+    is_nullable: bool,
+) -> *const vx_dtype {
+    let element = vx_dtype::into_arc(element);
+    vx_dtype::new(Arc::new(DType::FixedSizeList(
+        element,
+        size,
+        is_nullable.into(),
+    )))
 }
 
 /// Create a new struct data type.
@@ -196,6 +213,30 @@ pub unsafe extern "C-unwind" fn vx_dtype_list_element(dtype: *const vx_dtype) ->
         .as_list_element_opt()
         .vortex_expect("not a list dtype");
     vx_dtype::new_ref(element_dtype)
+}
+
+/// Return the `element` type of a fixed-size list data type.
+///
+/// The returned pointer is valid as long as the fixed-size list dtype is valid.
+/// Do NOT free the returned dtype pointer - it shares the lifetime of the fixed-size list dtype.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_dtype_fixed_size_list_element(
+    dtype: *const vx_dtype,
+) -> *const vx_dtype {
+    let element_dtype = vx_dtype::as_ref(dtype)
+        .as_fixed_size_list_element_opt()
+        .vortex_expect("not a fixed-size list dtype");
+    vx_dtype::new_ref(element_dtype)
+}
+
+/// Return the size of a fixed-size list data type.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_dtype_fixed_size_list_size(dtype: *const vx_dtype) -> u32 {
+    let dtype_ref = vx_dtype::as_ref(dtype);
+    match dtype_ref {
+        DType::FixedSizeList(_, size, _) => *size,
+        _ => vortex_panic!("not a fixed-size list dtype"),
+    }
 }
 
 #[unsafe(no_mangle)]
@@ -408,6 +449,95 @@ mod tests {
     }
 
     #[test]
+    fn test_dtype_fixed_size_list() {
+        unsafe {
+            let element_dtype = vx_dtype_new_primitive(vx_ptype::PTYPE_F64, false);
+            let fsl_dtype = vx_dtype_new_fixed_size_list(element_dtype, 3, true);
+
+            assert_eq!(
+                vx_dtype_get_variant(fsl_dtype),
+                vx_dtype_variant::DTYPE_FIXED_SIZE_LIST
+            );
+            assert!(vx_dtype_is_nullable(fsl_dtype));
+
+            // Test element accessor
+            let element = vx_dtype_fixed_size_list_element(fsl_dtype);
+            assert_eq!(
+                vx_dtype_get_variant(element),
+                vx_dtype_variant::DTYPE_PRIMITIVE
+            );
+            assert_eq!(vx_dtype_primitive_ptype(element), vx_ptype::PTYPE_F64);
+
+            // Test size accessor
+            let size = vx_dtype_fixed_size_list_size(fsl_dtype);
+            assert_eq!(size, 3);
+
+            vx_dtype_free(fsl_dtype);
+        }
+    }
+
+    #[test]
+    fn test_dtype_fixed_size_list_non_nullable() {
+        unsafe {
+            let element_dtype = vx_dtype_new_utf8(true);
+            let fsl_dtype = vx_dtype_new_fixed_size_list(element_dtype, 10, false);
+
+            assert_eq!(
+                vx_dtype_get_variant(fsl_dtype),
+                vx_dtype_variant::DTYPE_FIXED_SIZE_LIST
+            );
+            assert!(!vx_dtype_is_nullable(fsl_dtype));
+
+            let element = vx_dtype_fixed_size_list_element(fsl_dtype);
+            assert_eq!(vx_dtype_get_variant(element), vx_dtype_variant::DTYPE_UTF8);
+            assert!(vx_dtype_is_nullable(element));
+
+            let size = vx_dtype_fixed_size_list_size(fsl_dtype);
+            assert_eq!(size, 10);
+
+            vx_dtype_free(fsl_dtype);
+        }
+    }
+
+    #[test]
+    fn test_nested_fixed_size_lists() {
+        unsafe {
+            // Create inner fixed-size list: FSL<i32>[5]
+            let inner_element = vx_dtype_new_primitive(vx_ptype::PTYPE_I32, false);
+            let inner_fsl = vx_dtype_new_fixed_size_list(inner_element, 5, false);
+
+            // Create outer fixed-size list: FSL<FSL<i32>[5]>[3]
+            let outer_fsl = vx_dtype_new_fixed_size_list(inner_fsl, 3, true);
+
+            assert_eq!(
+                vx_dtype_get_variant(outer_fsl),
+                vx_dtype_variant::DTYPE_FIXED_SIZE_LIST
+            );
+            assert!(vx_dtype_is_nullable(outer_fsl));
+            assert_eq!(vx_dtype_fixed_size_list_size(outer_fsl), 3);
+
+            // Check inner FSL
+            let inner = vx_dtype_fixed_size_list_element(outer_fsl);
+            assert_eq!(
+                vx_dtype_get_variant(inner),
+                vx_dtype_variant::DTYPE_FIXED_SIZE_LIST
+            );
+            assert!(!vx_dtype_is_nullable(inner));
+            assert_eq!(vx_dtype_fixed_size_list_size(inner), 5);
+
+            // Check innermost element
+            let innermost = vx_dtype_fixed_size_list_element(inner);
+            assert_eq!(
+                vx_dtype_get_variant(innermost),
+                vx_dtype_variant::DTYPE_PRIMITIVE
+            );
+            assert_eq!(vx_dtype_primitive_ptype(innermost), vx_ptype::PTYPE_I32);
+
+            vx_dtype_free(outer_fsl);
+        }
+    }
+
+    #[test]
     fn test_dtype_decimal() {
         unsafe {
             let decimal_dtype = vx_dtype_new_decimal(10, 2, true);
@@ -453,6 +583,11 @@ mod tests {
             DType::Decimal(DecimalDType::new(10, 2), true.into()),
             DType::Utf8(false.into()),
             DType::Binary(true.into()),
+            DType::FixedSizeList(
+                Arc::new(DType::Primitive(vortex::dtype::PType::U8, false.into())),
+                4,
+                true.into(),
+            ),
         ];
 
         for dtype in dtypes {
@@ -464,6 +599,9 @@ mod tests {
                 DType::Decimal(..) => assert_eq!(variant, vx_dtype_variant::DTYPE_DECIMAL),
                 DType::Utf8(_) => assert_eq!(variant, vx_dtype_variant::DTYPE_UTF8),
                 DType::Binary(_) => assert_eq!(variant, vx_dtype_variant::DTYPE_BINARY),
+                DType::FixedSizeList(..) => {
+                    assert_eq!(variant, vx_dtype_variant::DTYPE_FIXED_SIZE_LIST)
+                }
                 _ => {}
             }
         }

--- a/vortex-ffi/src/dtype.rs
+++ b/vortex-ffi/src/dtype.rs
@@ -165,13 +165,13 @@ pub unsafe extern "C-unwind" fn vx_dtype_is_nullable(dtype: *const vx_dtype) -> 
     vx_dtype::as_ref(dtype).is_nullable()
 }
 
-/// Return the [`vx_ptype`] of a primitive data type.
+/// Returns the [`vx_ptype`] of a primitive.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_primitive_ptype(dtype: *const vx_dtype) -> vx_ptype {
     vx_dtype::as_ref(dtype).as_ptype().into()
 }
 
-/// Return the precision of a decimal data type.
+/// Returns the precision of a decimal.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_decimal_precision(dtype: *const vx_dtype) -> u8 {
     vx_dtype::as_ref(dtype)
@@ -180,7 +180,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_decimal_precision(dtype: *const vx_dtyp
         .precision()
 }
 
-/// Return the scale of a decimal data type.
+/// Returns the scale of a decimal.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_decimal_scale(dtype: *const vx_dtype) -> i8 {
     vx_dtype::as_ref(dtype)
@@ -189,7 +189,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_decimal_scale(dtype: *const vx_dtype) -
         .scale()
 }
 
-/// Return a borrowed reference to the [`vx_struct_fields`] of a struct data type.
+/// Return a borrowed reference to the [`vx_struct_fields`] of a struct.
 ///
 /// The returned pointer is valid as long as the struct dtype is valid.
 /// Do NOT free the returned pointer - it shares the lifetime of the struct dtype.
@@ -203,7 +203,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_struct_dtype(
     vx_struct_fields::new_ref(struct_dtype)
 }
 
-/// Return the `element` type of a list data type.
+/// Returns the element type of a list.
 ///
 /// The returned pointer is valid as long as the list dtype is valid.
 /// Do NOT free the returned dtype pointer - it shares the lifetime of the list dtype.
@@ -215,7 +215,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_list_element(dtype: *const vx_dtype) ->
     vx_dtype::new_ref(element_dtype)
 }
 
-/// Return the `element` type of a fixed-size list data type.
+/// Returns the element type of a fixed-size list.
 ///
 /// The returned pointer is valid as long as the fixed-size list dtype is valid.
 /// Do NOT free the returned dtype pointer - it shares the lifetime of the fixed-size list dtype.
@@ -229,7 +229,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_fixed_size_list_element(
     vx_dtype::new_ref(element_dtype)
 }
 
-/// Return the size of a fixed-size list data type.
+/// Returns the size of a fixed-size list.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_fixed_size_list_size(dtype: *const vx_dtype) -> u32 {
     let dtype_ref = vx_dtype::as_ref(dtype);
@@ -239,6 +239,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_fixed_size_list_size(dtype: *const vx_d
     }
 }
 
+/// Checks if the type is time.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_is_time(dtype: *const DType) -> bool {
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
@@ -249,6 +250,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_is_time(dtype: *const DType) -> bool {
     }
 }
 
+/// Checks if the type is a date.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_is_date(dtype: *const DType) -> bool {
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
@@ -259,6 +261,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_is_date(dtype: *const DType) -> bool {
     }
 }
 
+/// Checks if the type is a timestamp.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_is_timestamp(dtype: *const DType) -> bool {
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
@@ -269,6 +272,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_is_timestamp(dtype: *const DType) -> bo
     }
 }
 
+/// Returns the time unit, assuming the type is time.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_time_unit(dtype: *const DType) -> u8 {
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
@@ -282,6 +286,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_time_unit(dtype: *const DType) -> u8 {
     metadata.as_ref()[0]
 }
 
+/// Returns the time zone, assuming the type is time.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_time_zone(
     dtype: *const DType,

--- a/vortex-ffi/src/file.rs
+++ b/vortex-ffi/src/file.rs
@@ -32,7 +32,7 @@ use crate::session::{FileKey, vx_session};
 use crate::{arc_wrapper, get_runtime, to_string_vec};
 
 arc_wrapper!(
-    /// A handle to a Vortex file encapsulating ther footer and logic for instantiating a reader.
+    /// A handle to a Vortex file encapsulating the footer and logic for instantiating a reader.
     VortexFile,
     vx_file
 );


### PR DESCRIPTION
Tracking issue: https://github.com/vortex-data/vortex/issues/4372

Relevant DuckDB docs for their ARRAY type: https://duckdb.org/docs/stable/sql/data_types/array.html

Adds conversion methods and an exporter for fixed-size list type to DuckDB.

Also adds `vortex-ffi` bindings for fixed-size lists.