### PR TITLE
Chore: Add missing `FixedSizeListEncoding`

### DIFF
--- a/fuzz/fuzz_targets/array_ops.rs
+++ b/fuzz/fuzz_targets/array_ops.rs
@@ -7,10 +7,7 @@
 use std::backtrace::Backtrace;
 
 use libfuzzer_sys::{Corpus, fuzz_target};
-use vortex_array::arrays::{
-    BoolEncoding, ConstantArray, FixedSizeListEncoding, ListEncoding, PrimitiveEncoding,
-    StructEncoding, VarBinEncoding, VarBinViewEncoding,
-};
+use vortex_array::arrays::ConstantArray;
 use vortex_array::compute::{cast, compare, filter, take};
 use vortex_array::search_sorted::{SearchResult, SearchSorted, SearchSortedSide};
 use vortex_array::{Array, ArrayRef, IntoArray};

--- a/fuzz/fuzz_targets/array_ops.rs
+++ b/fuzz/fuzz_targets/array_ops.rs
@@ -8,8 +8,8 @@ use std::backtrace::Backtrace;
 
 use libfuzzer_sys::{Corpus, fuzz_target};
 use vortex_array::arrays::{
-    BoolEncoding, ConstantArray, ListEncoding, PrimitiveEncoding, StructEncoding, VarBinEncoding,
-    VarBinViewEncoding,
+    BoolEncoding, ConstantArray, FixedSizeListEncoding, ListEncoding, PrimitiveEncoding,
+    StructEncoding, VarBinEncoding, VarBinViewEncoding,
 };
 use vortex_array::compute::{cast, compare, filter, take};
 use vortex_array::search_sorted::{SearchResult, SearchSorted, SearchSortedSide};
@@ -19,7 +19,6 @@ use vortex_error::{VortexUnwrap, vortex_panic};
 use vortex_fuzz::error::{VortexFuzzError, VortexFuzzResult};
 use vortex_fuzz::{Action, FuzzArrayAction, sort_canonical_array};
 use vortex_scalar::Scalar;
-use vortex_utils::aliases::hash_set::HashSet;
 
 fuzz_target!(|fuzz_action: FuzzArrayAction| -> Corpus {
     let FuzzArrayAction { array, actions } = fuzz_action;
@@ -46,16 +45,9 @@ fuzz_target!(|fuzz_action: FuzzArrayAction| -> Corpus {
             Action::SearchSorted(s, side) => {
                 // TODO(robert): Ideally we'd preserve the encoding perfectly but this is close enough
                 let mut sorted = sort_canonical_array(&current_array).vortex_unwrap();
-                if !HashSet::from([
-                    PrimitiveEncoding.id(),
-                    VarBinEncoding.id(),
-                    VarBinViewEncoding.id(),
-                    BoolEncoding.id(),
-                    StructEncoding.id(),
-                    ListEncoding.id(),
-                ])
-                .contains(&current_array.encoding_id())
-                {
+
+                // If the current array is not in one of these canonical encodings, compress again.
+                if !current_array.is_canonical() {
                     sorted = BtrBlocksCompressor::default()
                         .compress(&sorted)
                         .vortex_unwrap();

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -67,7 +67,10 @@ use crate::{Array, ArrayRef, IntoArray};
 ///
 /// # For Developers
 ///
-/// If you add another variant to this enum, make sure to update [`Array::is_canonical`].
+/// If you add another variant to this enum, make sure to update [`Array::is_canonical`],
+/// [`ArrayRegistry::canonical_only`], and the fuzzer in `fuzz/fuzz_targets/array_ops.rs`.
+///
+/// [`ArrayRegistry::canonical_only`]: crate::ArrayRegistry::canonical_only
 #[derive(Debug, Clone)]
 pub enum Canonical {
     Null(NullArray),

--- a/vortex-array/src/context.rs
+++ b/vortex-array/src/context.rs
@@ -12,8 +12,8 @@ use vortex_utils::aliases::hash_map::HashMap;
 use crate::EncodingRef;
 use crate::arrays::{
     BoolEncoding, ChunkedEncoding, ConstantEncoding, DecimalEncoding, ExtensionEncoding,
-    ListEncoding, NullEncoding, PrimitiveEncoding, StructEncoding, VarBinEncoding,
-    VarBinViewEncoding,
+    FixedSizeListEncoding, ListEncoding, NullEncoding, PrimitiveEncoding, StructEncoding,
+    VarBinEncoding, VarBinViewEncoding,
 };
 
 /// A collection of array encodings.
@@ -33,6 +33,7 @@ impl ArrayRegistry {
             EncodingRef::new_ref(DecimalEncoding.as_ref()),
             EncodingRef::new_ref(StructEncoding.as_ref()),
             EncodingRef::new_ref(ListEncoding.as_ref()),
+            EncodingRef::new_ref(FixedSizeListEncoding.as_ref()),
             EncodingRef::new_ref(VarBinEncoding.as_ref()),
             EncodingRef::new_ref(VarBinViewEncoding.as_ref()),
             EncodingRef::new_ref(ExtensionEncoding.as_ref()),


### PR DESCRIPTION
Tracking Issue: https://github.com/vortex-data/vortex/issues/4372

Nearly missed these...

Also I'm not entirely sure that `Action::SearchSorted` is supported for `FixedSizeList` in the fuzzer, but I also don't see if `List` is supported either so it's probably fine?