### PR TITLE
DictionaryEncoder to store nulls in values

### DIFF
--- a/encodings/dict/src/builders/bytes.rs
+++ b/encodings/dict/src/builders/bytes.rs
@@ -5,8 +5,8 @@ use std::hash::BuildHasher;
 use std::sync::Arc;
 
 use arrow_buffer::NullBufferBuilder;
-use num_traits::sign::Unsigned;
 use num_traits::AsPrimitive;
+use num_traits::sign::Unsigned;
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::{
     BinaryView, PrimitiveArray, VarBinVTable, VarBinViewArray, VarBinViewVTable,
@@ -15,7 +15,7 @@ use vortex_array::validity::Validity;
 use vortex_array::{Array, ArrayRef, IntoArray};
 use vortex_buffer::{BufferMut, ByteBufferMut};
 use vortex_dtype::{DType, NativePType};
-use vortex_error::{vortex_bail, vortex_panic, VortexExpect, VortexResult, VortexUnwrap};
+use vortex_error::{VortexExpect, VortexResult, VortexUnwrap, vortex_bail, vortex_panic};
 use vortex_utils::aliases::hash_map::{DefaultHashBuilder, HashTable, HashTableEntry, RandomState};
 
 use super::DictConstraints;
@@ -190,9 +190,9 @@ impl<Code: Unsigned + AsPrimitive<usize> + NativePType> DictEncoder for BytesDic
 mod test {
     use std::str;
 
+    use vortex_array::ToCanonical;
     use vortex_array::accessor::ArrayAccessor;
     use vortex_array::arrays::VarBinArray;
-    use vortex_array::ToCanonical;
 
     use crate::builders::dict_encode;
 

--- a/encodings/dict/src/builders/bytes.rs
+++ b/encodings/dict/src/builders/bytes.rs
@@ -5,8 +5,8 @@ use std::hash::BuildHasher;
 use std::sync::Arc;
 
 use arrow_buffer::NullBufferBuilder;
-use num_traits::AsPrimitive;
 use num_traits::sign::Unsigned;
+use num_traits::AsPrimitive;
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::{
     BinaryView, PrimitiveArray, VarBinVTable, VarBinViewArray, VarBinViewVTable,
@@ -15,7 +15,7 @@ use vortex_array::validity::Validity;
 use vortex_array::{Array, ArrayRef, IntoArray};
 use vortex_buffer::{BufferMut, ByteBufferMut};
 use vortex_dtype::{DType, NativePType};
-use vortex_error::{VortexExpect, VortexResult, VortexUnwrap, vortex_bail, vortex_panic};
+use vortex_error::{vortex_bail, vortex_panic, VortexExpect, VortexResult, VortexUnwrap};
 use vortex_utils::aliases::hash_map::{DefaultHashBuilder, HashTable, HashTableEntry, RandomState};
 
 use super::DictConstraints;
@@ -26,6 +26,7 @@ pub struct BytesDictBuilder<Codes> {
     lookup: Option<HashTable<Codes>>,
     views: BufferMut<BinaryView>,
     values: ByteBufferMut,
+    values_nulls: NullBufferBuilder,
     hasher: RandomState,
     dtype: DType,
     max_dict_bytes: usize,
@@ -47,6 +48,7 @@ impl<Code: Unsigned + AsPrimitive<usize> + NativePType> BytesDictBuilder<Code> {
             lookup: Some(HashTable::new()),
             views: BufferMut::<BinaryView>::empty(),
             values: BufferMut::empty(),
+            values_nulls: NullBufferBuilder::new(0),
             hasher: DefaultHashBuilder::default(),
             dtype,
             max_dict_bytes: constraints.max_bytes,
@@ -59,17 +61,19 @@ impl<Code: Unsigned + AsPrimitive<usize> + NativePType> BytesDictBuilder<Code> {
     }
 
     #[inline]
-    fn lookup_bytes(&self, idx: usize) -> &[u8] {
-        let bin_view = &self.views[idx];
-        if bin_view.is_inlined() {
-            bin_view.as_inlined().value()
-        } else {
-            &self.values[bin_view.as_view().to_range()]
-        }
+    fn lookup_bytes(&self, idx: usize) -> Option<&[u8]> {
+        self.values_nulls.is_valid(idx).then(|| {
+            let bin_view = &self.views[idx];
+            if bin_view.is_inlined() {
+                bin_view.as_inlined().value()
+            } else {
+                &self.values[bin_view.as_view().to_range()]
+            }
+        })
     }
 
     #[inline]
-    fn encode_value(&mut self, lookup: &mut HashTable<Code>, val: &[u8]) -> Option<Code> {
+    fn encode_value(&mut self, lookup: &mut HashTable<Code>, val: Option<&[u8]>) -> Option<Code> {
         match lookup.entry(
             self.hasher.hash_one(val),
             |idx| val == self.lookup_bytes(idx.as_()),
@@ -82,22 +86,36 @@ impl<Code: Unsigned + AsPrimitive<usize> + NativePType> BytesDictBuilder<Code> {
                 }
 
                 let next_code = self.views.len();
-                let view =
-                    BinaryView::make_view(val, 0, u32::try_from(self.values.len()).vortex_unwrap());
-                let additional_bytes = if view.is_inlined() {
-                    size_of::<BinaryView>()
-                } else {
-                    size_of::<BinaryView>() + val.len()
-                };
+                match val {
+                    None => {
+                        // Null value
+                        self.views.push(BinaryView::default());
+                        self.values_nulls.append_null();
+                    }
+                    Some(val) => {
+                        let view = BinaryView::make_view(
+                            val,
+                            0,
+                            u32::try_from(self.values.len()).vortex_unwrap(),
+                        );
+                        let additional_bytes = if view.is_inlined() {
+                            size_of::<BinaryView>()
+                        } else {
+                            size_of::<BinaryView>() + val.len()
+                        };
 
-                if self.dict_bytes() + additional_bytes > self.max_dict_bytes {
-                    return None;
+                        if self.dict_bytes() + additional_bytes > self.max_dict_bytes {
+                            return None;
+                        }
+
+                        self.views.push(view);
+                        self.values_nulls.append_non_null();
+                        if !view.is_inlined() {
+                            self.values.extend_from_slice(val);
+                        }
+                    }
                 }
 
-                self.views.push(view);
-                if !view.is_inlined() {
-                    self.values.extend_from_slice(val);
-                }
                 let next_code = Code::from_usize(next_code).unwrap_or_else(|| {
                     vortex_panic!("{next_code} has to fit into {}", Code::PTYPE)
                 });
@@ -114,47 +132,19 @@ impl<Code: Unsigned + AsPrimitive<usize> + NativePType> BytesDictBuilder<Code> {
         let mut local_lookup = self.lookup.take().vortex_expect("Must have a lookup dict");
         let mut codes: BufferMut<Code> = BufferMut::with_capacity(len);
 
-        let (codes, validity) = if self.dtype.is_nullable() {
-            let mut null_buf = NullBufferBuilder::new(len);
-
-            accessor.with_iterator(|it| {
-                for value in it {
-                    let (code, validity) = match value {
-                        Some(v) => match self.encode_value(&mut local_lookup, v) {
-                            Some(code) => (code, true),
-                            None => break,
-                        },
-                        None => (Code::zero(), false),
-                    };
-                    null_buf.append(validity);
-                    unsafe { codes.push_unchecked(code) }
-                }
-            })?;
-            (
-                codes,
-                null_buf
-                    .finish()
-                    .map(Validity::from)
-                    .unwrap_or(Validity::AllValid),
-            )
-        } else {
-            accessor.with_iterator(|it| {
-                for value in it {
-                    let Some(code) = self.encode_value(
-                        &mut local_lookup,
-                        value.vortex_expect("Dict encode null value in non-nullable array"),
-                    ) else {
-                        break;
-                    };
-                    unsafe { codes.push_unchecked(code) }
-                }
-            })?;
-            (codes, Validity::NonNullable)
-        };
+        accessor.with_iterator(|it| {
+            for value in it {
+                let Some(code) = self.encode_value(&mut local_lookup, value) else {
+                    break;
+                };
+                unsafe { codes.push_unchecked(code) }
+            }
+        })?;
 
         // Restore lookup dictionary back into the struct
         self.lookup = Some(local_lookup);
-        Ok(PrimitiveArray::new(codes, validity).into_array())
+
+        Ok(PrimitiveArray::new(codes, Validity::NonNullable).into_array())
     }
 }
 
@@ -186,7 +176,10 @@ impl<Code: Unsigned + AsPrimitive<usize> + NativePType> DictEncoder for BytesDic
                 self.views.clone().freeze(),
                 Arc::from([self.values.clone().freeze()]),
                 self.dtype.clone(),
-                self.dtype.nullability().into(),
+                Validity::from_null_buffer(
+                    self.values_nulls.finish_cloned(),
+                    self.dtype.nullability(),
+                ),
             )
             .into_array())
         }
@@ -197,9 +190,9 @@ impl<Code: Unsigned + AsPrimitive<usize> + NativePType> DictEncoder for BytesDic
 mod test {
     use std::str;
 
-    use vortex_array::ToCanonical;
     use vortex_array::accessor::ArrayAccessor;
     use vortex_array::arrays::VarBinArray;
+    use vortex_array::ToCanonical;
 
     use crate::builders::dict_encode;
 
@@ -241,7 +234,7 @@ mod test {
         let dict = dict_encode(arr.as_ref()).unwrap();
         assert_eq!(
             dict.codes().to_primitive().as_slice::<u8>(),
-            &[0, 0, 1, 0, 0, 2, 1, 0]
+            &[0, 1, 2, 0, 1, 3, 2, 1]
         );
         dict.values()
             .to_varbinview()
@@ -249,7 +242,7 @@ mod test {
                 assert_eq!(
                     iter.map(|b| b.map(|v| unsafe { str::from_utf8_unchecked(v) }))
                         .collect::<Vec<_>>(),
-                    vec![Some("hello"), Some("world"), Some("again")]
+                    vec![Some("hello"), None, Some("world"), Some("again")]
                 );
             })
             .unwrap();

--- a/encodings/dict/src/builders/primitive.rs
+++ b/encodings/dict/src/builders/primitive.rs
@@ -12,7 +12,7 @@ use vortex_array::validity::Validity;
 use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
 use vortex_buffer::BufferMut;
 use vortex_dtype::{NativePType, Nullability, PType};
-use vortex_error::{vortex_bail, vortex_panic, VortexResult};
+use vortex_error::{VortexResult, vortex_bail, vortex_panic};
 use vortex_utils::aliases::hash_map::{Entry, HashMap};
 
 use super::DictConstraints;

--- a/encodings/dict/src/builders/primitive.rs
+++ b/encodings/dict/src/builders/primitive.rs
@@ -12,7 +12,7 @@ use vortex_array::validity::Validity;
 use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
 use vortex_buffer::BufferMut;
 use vortex_dtype::{NativePType, Nullability, PType};
-use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_panic};
+use vortex_error::{vortex_bail, vortex_panic, VortexResult};
 use vortex_utils::aliases::hash_map::{Entry, HashMap};
 
 use super::DictConstraints;
@@ -64,14 +64,15 @@ where
         Self {
             lookup: HashMap::with_hasher(FxBuildHasher),
             values: BufferMut::<T>::empty(),
+            values_nulls: NullBufferBuilder::new(0),
             nullability,
             max_dict_len,
         }
     }
 
     #[inline]
-    fn encode_value(&mut self, v: T) -> Option<Code> {
-        match self.lookup.entry(NativeValue(v)) {
+    fn encode_value(&mut self, v: Option<T>) -> Option<Code> {
+        match self.lookup.entry(v.map(NativeValue)) {
             Entry::Occupied(o) => Some(*o.get()),
             Entry::Vacant(vac) => {
                 if self.values.len() >= self.max_dict_len {
@@ -81,7 +82,16 @@ where
                     vortex_panic!("{} has to fit into {}", self.values.len(), Code::PTYPE)
                 });
                 vac.insert(next_code);
-                self.values.push(v);
+                match v {
+                    None => {
+                        self.values.push(T::default());
+                        self.values_nulls.append_null();
+                    }
+                    Some(v) => {
+                        self.values.push(v);
+                        self.values_nulls.append_non_null();
+                    }
+                }
                 Some(next_code)
             }
         }
@@ -89,10 +99,12 @@ where
 }
 
 /// Dictionary encode primitive array with given PType.
-/// Null values in the original array are encoded in the dictionary.
+///
+/// Null values are stored in the values of the dictionary such that codes are always non-null.
 pub struct PrimitiveDictBuilder<T, Codes> {
-    lookup: HashMap<NativeValue<T>, Codes, FxBuildHasher>,
+    lookup: HashMap<Option<NativeValue<T>>, Codes, FxBuildHasher>,
     values: BufferMut<T>,
+    values_nulls: NullBufferBuilder,
     nullability: Nullability,
     max_dict_len: usize,
 }
@@ -107,57 +119,32 @@ where
             vortex_bail!("Can only encode arrays of {}", T::PTYPE);
         }
         let mut codes = BufferMut::<Code>::with_capacity(array.len());
-        let primitive = array.to_primitive();
 
-        let codes = if array.dtype().is_nullable() {
-            let mut null_buf = NullBufferBuilder::new(array.len());
-            primitive.with_iterator(|it| {
-                for value in it {
-                    let (code, validity) = match value {
-                        Some(v) => match self.encode_value(*v) {
-                            Some(code) => (code, true),
-                            None => break,
-                        },
-                        None => (Code::zero(), false),
-                    };
-                    null_buf.append(validity);
-                    unsafe { codes.push_unchecked(code) }
-                }
-            })?;
-            PrimitiveArray::new(
-                codes,
-                null_buf
-                    .finish()
-                    .map(Validity::from)
-                    .unwrap_or(Validity::AllValid),
-            )
-        } else {
-            primitive.with_iterator(|it| {
-                for value in it {
-                    let Some(code) = self.encode_value(
-                        *value.vortex_expect("Dict encode null value in non-nullable array"),
-                    ) else {
-                        break;
-                    };
-                    unsafe { codes.push_unchecked(code) }
-                }
-            })?;
+        array.to_primitive().with_iterator(|it| {
+            for value in it {
+                let Some(code) = self.encode_value(value.copied()) else {
+                    break;
+                };
+                unsafe { codes.push_unchecked(code) }
+            }
+        })?;
 
-            PrimitiveArray::new(codes, Validity::NonNullable)
-        };
-
-        Ok(codes.into_array())
+        Ok(PrimitiveArray::new(codes, Validity::NonNullable).into_array())
     }
 
     fn values(&mut self) -> VortexResult<ArrayRef> {
-        Ok(PrimitiveArray::new(self.values.clone(), self.nullability.into()).into_array())
+        Ok(PrimitiveArray::new(
+            self.values.clone(),
+            Validity::from_null_buffer(self.values_nulls.finish_cloned(), self.nullability),
+        )
+        .into_array())
     }
 }
 
 #[cfg(test)]
 mod test {
-    use vortex_array::ToCanonical;
     use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::{Array, ToCanonical};
     use vortex_dtype::Nullability::Nullable;
     use vortex_scalar::Scalar;
 
@@ -189,10 +176,13 @@ mod test {
         let dict = dict_encode(arr.as_ref()).unwrap();
         assert_eq!(
             dict.codes().to_primitive().as_slice::<u8>(),
-            &[0, 0, 0, 1, 1, 0, 1, 0]
+            &[0, 0, 1, 2, 2, 1, 2, 1],
         );
         let dict_values = dict.values();
         assert_eq!(dict_values.scalar_at(0), Scalar::primitive(1, Nullable));
-        assert_eq!(dict_values.scalar_at(1), Scalar::primitive(3, Nullable));
+        assert_eq!(
+            dict_values.scalar_at(1),
+            Scalar::null(dict_values.dtype().clone())
+        );
     }
 }

--- a/encodings/dict/src/compute/compare.rs
+++ b/encodings/dict/src/compute/compare.rs
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::arrays::ConstantArray;
-use vortex_array::compute::{compare, CompareKernel, CompareKernelAdapter, Operator};
-use vortex_array::{register_kernel, Array, ArrayRef, IntoArray};
+use vortex_array::compute::{CompareKernel, CompareKernelAdapter, Operator, compare};
+use vortex_array::{Array, ArrayRef, IntoArray, register_kernel};
 use vortex_error::VortexResult;
 
 use crate::{DictArray, DictVTable};
@@ -48,7 +48,7 @@ register_kernel!(CompareKernelAdapter(DictVTable).lift());
 #[cfg(test)]
 mod tests {
     use vortex_array::arrays::{ConstantArray, PrimitiveArray};
-    use vortex_array::compute::{compare, Operator};
+    use vortex_array::compute::{Operator, compare};
     use vortex_array::validity::Validity;
     use vortex_array::{IntoArray, ToCanonical};
     use vortex_buffer::buffer;

--- a/encodings/dict/src/compute/compare.rs
+++ b/encodings/dict/src/compute/compare.rs
@@ -2,14 +2,9 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::arrays::ConstantArray;
-use vortex_array::builders::builder_with_capacity;
-use vortex_array::compute::{CompareKernel, CompareKernelAdapter, Operator, cast, compare};
-use vortex_array::validity::Validity;
-use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical, register_kernel};
-use vortex_dtype::{DType, Nullability};
+use vortex_array::compute::{compare, CompareKernel, CompareKernelAdapter, Operator};
+use vortex_array::{register_kernel, Array, ArrayRef, IntoArray};
 use vortex_error::VortexResult;
-use vortex_mask::{AllOr, Mask};
-use vortex_scalar::Scalar;
 
 use crate::{DictArray, DictVTable};
 
@@ -24,6 +19,7 @@ impl CompareKernel for DictVTable {
         if lhs.values().len() > lhs.codes().len() {
             return Ok(None);
         }
+
         // If the RHS is constant, then we just need to compare against our encoded values.
         if let Some(rhs) = rhs.as_constant() {
             let compare_result = compare(
@@ -31,18 +27,14 @@ impl CompareKernel for DictVTable {
                 ConstantArray::new(rhs, lhs.values().len()).as_ref(),
                 operator,
             )?;
-            return if operator == Operator::Eq {
-                let result_nullability =
-                    compare_result.dtype().nullability() | lhs.dtype().nullability();
-                dict_equal_to(compare_result, lhs.codes(), result_nullability).map(Some)
-            } else {
-                // SAFETY: values len preserved, codes all still point to valid values
-                unsafe {
-                    Ok(Some(
-                        DictArray::new_unchecked(lhs.codes().clone(), compare_result).into_array(),
-                    ))
-                }
+
+            // SAFETY: values len preserved, codes all still point to valid values
+            let result = unsafe {
+                DictArray::new_unchecked(lhs.codes().clone(), compare_result).into_array()
             };
+
+            // We canonicalize the result because dictionary-encoded bools is dumb.
+            return Ok(Some(result.to_canonical().into_array()));
         }
 
         // It's a little more complex, but we could perform a comparison against the dictionary
@@ -53,83 +45,10 @@ impl CompareKernel for DictVTable {
 
 register_kernel!(CompareKernelAdapter(DictVTable).lift());
 
-fn dict_equal_to(
-    values_compare: ArrayRef,
-    codes: &ArrayRef,
-    result_nullability: Nullability,
-) -> VortexResult<ArrayRef> {
-    let bool_result = values_compare.to_bool();
-    let result_validity = bool_result.validity_mask();
-    let bool_buffer = bool_result.boolean_buffer();
-    let (first_match, second_match) = match result_validity.boolean_buffer() {
-        AllOr::All => {
-            let mut indices_iter = bool_buffer.set_indices();
-            (indices_iter.next(), indices_iter.next())
-        }
-        AllOr::None => (None, None),
-        AllOr::Some(v) => {
-            let mut indices_iter = bool_buffer.set_indices().filter(|i| v.value(*i));
-            (indices_iter.next(), indices_iter.next())
-        }
-    };
-
-    Ok(match (first_match, second_match) {
-        // Couldn't find a value match, so the result is all false
-        (None, _) => match result_validity {
-            Mask::AllTrue(_) => {
-                let mut result_builder =
-                    builder_with_capacity(&DType::Bool(result_nullability), codes.len());
-                result_builder.extend_from_array(
-                    &ConstantArray::new(Scalar::bool(false, result_nullability), codes.len())
-                        .into_array(),
-                );
-                result_builder.set_validity(codes.validity_mask());
-                result_builder.finish()
-            }
-            Mask::AllFalse(_) => ConstantArray::new(
-                Scalar::null(DType::Bool(Nullability::Nullable)),
-                codes.len(),
-            )
-            .into_array(),
-            Mask::Values(_) => {
-                let mut result_builder =
-                    builder_with_capacity(&DType::Bool(result_nullability), codes.len());
-                result_builder.extend_from_array(
-                    &ConstantArray::new(Scalar::bool(false, result_nullability), codes.len())
-                        .into_array(),
-                );
-                result_builder.set_validity(
-                    Validity::from_mask(result_validity, bool_result.dtype().nullability())
-                        .take(codes)?
-                        .to_mask(codes.len()),
-                );
-                result_builder.finish()
-            }
-        },
-        // We found a single matching value so we can compare the codes directly.
-        // Note: the codes include nullability so we can just compare the codes directly, to the found code.
-        (Some(code), None) => cast(
-            &compare(
-                codes,
-                &cast(
-                    ConstantArray::new(code, codes.len()).as_ref(),
-                    codes.dtype(),
-                )?,
-                Operator::Eq,
-            )?,
-            &DType::Bool(result_nullability),
-        )?,
-        // more than one value matches
-        _ => unsafe {
-            DictArray::new_unchecked(codes.clone(), bool_result.into_array()).into_array()
-        },
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use vortex_array::arrays::{ConstantArray, PrimitiveArray};
-    use vortex_array::compute::{Operator, compare};
+    use vortex_array::compute::{compare, Operator};
     use vortex_array::validity::Validity;
     use vortex_array::{IntoArray, ToCanonical};
     use vortex_buffer::buffer;

--- a/encodings/dict/src/compute/mod.rs
+++ b/encodings/dict/src/compute/mod.rs
@@ -10,9 +10,9 @@ mod like;
 mod min_max;
 
 use vortex_array::compute::{
-    filter, take, FilterKernel, FilterKernelAdapter, TakeKernel, TakeKernelAdapter,
+    FilterKernel, FilterKernelAdapter, TakeKernel, TakeKernelAdapter, filter, take,
 };
-use vortex_array::{register_kernel, Array, ArrayRef, IntoArray};
+use vortex_array::{Array, ArrayRef, IntoArray, register_kernel};
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
@@ -46,7 +46,7 @@ mod test {
     use vortex_array::compute::conformance::filter::test_filter_conformance;
     use vortex_array::compute::conformance::mask::test_mask_conformance;
     use vortex_array::compute::conformance::take::test_take_conformance;
-    use vortex_array::compute::{compare, take, Operator};
+    use vortex_array::compute::{Operator, compare, take};
     use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
     use vortex_dtype::PType::I32;
     use vortex_dtype::{DType, Nullability};
@@ -266,13 +266,13 @@ mod test {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_array::IntoArray;
     use vortex_array::arrays::{PrimitiveArray, VarBinArray};
     use vortex_array::compute::conformance::consistency::test_array_consistency;
-    use vortex_array::IntoArray;
     use vortex_dtype::{DType, Nullability};
 
-    use crate::builders::dict_encode;
     use crate::DictArray;
+    use crate::builders::dict_encode;
 
     #[rstest]
     // Primitive arrays

--- a/encodings/dict/src/compute/mod.rs
+++ b/encodings/dict/src/compute/mod.rs
@@ -10,9 +10,9 @@ mod like;
 mod min_max;
 
 use vortex_array::compute::{
-    FilterKernel, FilterKernelAdapter, TakeKernel, TakeKernelAdapter, filter, take,
+    filter, take, FilterKernel, FilterKernelAdapter, TakeKernel, TakeKernelAdapter,
 };
-use vortex_array::{Array, ArrayRef, IntoArray, register_kernel};
+use vortex_array::{register_kernel, Array, ArrayRef, IntoArray};
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
@@ -46,7 +46,7 @@ mod test {
     use vortex_array::compute::conformance::filter::test_filter_conformance;
     use vortex_array::compute::conformance::mask::test_mask_conformance;
     use vortex_array::compute::conformance::take::test_take_conformance;
-    use vortex_array::compute::{Operator, compare, take};
+    use vortex_array::compute::{compare, take, Operator};
     use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
     use vortex_dtype::PType::I32;
     use vortex_dtype::{DType, Nullability};
@@ -70,10 +70,10 @@ mod test {
 
         let expected: Vec<i32> = (0..65)
             .map(|i| match i % 3 {
-                // Compressor puts 0 as a code for invalid values which we end up using in take
-                // thus invalid values on decompression turn into whatever is at 0th position in dictionary
-                0 | 2 => 42,
+                // Compressor puts 0 as a code for invalid values
+                0 => 42,
                 1 => -9,
+                2 => 0,
                 _ => unreachable!(),
             })
             .collect();
@@ -266,13 +266,13 @@ mod test {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
-    use vortex_array::IntoArray;
     use vortex_array::arrays::{PrimitiveArray, VarBinArray};
     use vortex_array::compute::conformance::consistency::test_array_consistency;
+    use vortex_array::IntoArray;
     use vortex_dtype::{DType, Nullability};
 
-    use crate::DictArray;
     use crate::builders::dict_encode;
+    use crate::DictArray;
 
     #[rstest]
     // Primitive arrays

--- a/vortex-array/src/arrays/varbinview/mod.rs
+++ b/vortex-array/src/arrays/varbinview/mod.rs
@@ -10,7 +10,7 @@ use static_assertions::{assert_eq_align, assert_eq_size};
 use vortex_buffer::{Buffer, ByteBuffer};
 use vortex_dtype::{DType, Nullability};
 use vortex_error::{
-    vortex_bail, vortex_ensure, vortex_err, vortex_panic, VortexExpect, VortexResult, VortexUnwrap,
+    VortexExpect, VortexResult, VortexUnwrap, vortex_bail, vortex_ensure, vortex_err, vortex_panic,
 };
 
 use crate::builders::{ArrayBuilder, VarBinViewBuilder};
@@ -20,7 +20,7 @@ use crate::vtable::{
     ArrayVTable, CanonicalVTable, NotSupported, VTable, ValidityHelper,
     ValidityVTableFromValidityHelper,
 };
-use crate::{vtable, Canonical, EncodingId, EncodingRef};
+use crate::{Canonical, EncodingId, EncodingRef, vtable};
 
 mod accessor;
 mod compact;

--- a/vortex-array/src/arrays/varbinview/mod.rs
+++ b/vortex-array/src/arrays/varbinview/mod.rs
@@ -10,7 +10,7 @@ use static_assertions::{assert_eq_align, assert_eq_size};
 use vortex_buffer::{Buffer, ByteBuffer};
 use vortex_dtype::{DType, Nullability};
 use vortex_error::{
-    VortexExpect, VortexResult, VortexUnwrap, vortex_bail, vortex_ensure, vortex_err, vortex_panic,
+    vortex_bail, vortex_ensure, vortex_err, vortex_panic, VortexExpect, VortexResult, VortexUnwrap,
 };
 
 use crate::builders::{ArrayBuilder, VarBinViewBuilder};
@@ -20,7 +20,7 @@ use crate::vtable::{
     ArrayVTable, CanonicalVTable, NotSupported, VTable, ValidityHelper,
     ValidityVTableFromValidityHelper,
 };
-use crate::{Canonical, EncodingId, EncodingRef, vtable};
+use crate::{vtable, Canonical, EncodingId, EncodingRef};
 
 mod accessor;
 mod compact;
@@ -113,6 +113,12 @@ assert_eq_align!(BinaryView, u128);
 impl Hash for BinaryView {
     fn hash<H: Hasher>(&self, state: &mut H) {
         unsafe { std::mem::transmute::<&BinaryView, &[u8; 16]>(self) }.hash(state);
+    }
+}
+
+impl Default for BinaryView {
+    fn default() -> Self {
+        Self::make_view(&[], 0, 0)
     }
 }
 

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -8,7 +8,7 @@ use std::ops::{BitAnd, Not, Range};
 
 use arrow_buffer::{BooleanBuffer, NullBuffer};
 use vortex_dtype::{DType, Nullability};
-use vortex_error::{VortexExpect as _, VortexResult, vortex_err, vortex_panic};
+use vortex_error::{vortex_err, vortex_panic, VortexExpect as _, VortexResult};
 use vortex_mask::{AllOr, Mask, MaskValues};
 use vortex_scalar::Scalar;
 
@@ -434,6 +434,20 @@ impl From<Nullability> for Validity {
 }
 
 impl Validity {
+    pub fn from_null_buffer(buffer: Option<NullBuffer>, nullability: Nullability) -> Self {
+        match buffer {
+            // If there are no nulls, then we infer from nullability
+            None => nullability.into(),
+            Some(nulls) => {
+                if nulls.null_count() == nulls.len() {
+                    Validity::AllInvalid
+                } else {
+                    Validity::Array(BoolArray::from(nulls.into_inner()).into_array())
+                }
+            }
+        }
+    }
+
     pub fn from_mask(mask: Mask, nullability: Nullability) -> Self {
         assert!(
             nullability == Nullability::Nullable || matches!(mask, Mask::AllTrue(_)),
@@ -472,7 +486,7 @@ impl IntoArray for &MaskValues {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
-    use vortex_buffer::{Buffer, buffer};
+    use vortex_buffer::{buffer, Buffer};
     use vortex_dtype::Nullability;
     use vortex_mask::Mask;
 

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -8,7 +8,7 @@ use std::ops::{BitAnd, Not, Range};
 
 use arrow_buffer::{BooleanBuffer, NullBuffer};
 use vortex_dtype::{DType, Nullability};
-use vortex_error::{vortex_err, vortex_panic, VortexExpect as _, VortexResult};
+use vortex_error::{VortexExpect as _, VortexResult, vortex_err, vortex_panic};
 use vortex_mask::{AllOr, Mask, MaskValues};
 use vortex_scalar::Scalar;
 
@@ -486,7 +486,7 @@ impl IntoArray for &MaskValues {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
-    use vortex_buffer::{buffer, Buffer};
+    use vortex_buffer::{Buffer, buffer};
     use vortex_dtype::Nullability;
     use vortex_mask::Mask;
 


### PR DESCRIPTION
Two reasons:
1. We can do much better push-down if our codes are non-null (all scalar operations)
2. We can know up-front the DType of the codes array coming out of DictEncoder. This is important for DictLayout where we currently get lucky that all chunks of a dict column have the same nullability :(