### PR TITLE
Chore: Add no-op `IsSorted` and `MinMax` compute kernels for `FixedSizeListVTable`

### DIFF
--- a/vortex-array/src/arrays/fixed_size_list/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/is_sorted.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+
+use crate::arrays::{FixedSizeListArray, FixedSizeListVTable};
+use crate::compute::{IsSortedKernel, IsSortedKernelAdapter};
+use crate::register_kernel;
+
+// TODO(connor): Right now this does nothing.
+/// IsSorted implementation for [`FixedSizeListArray`].
+impl IsSortedKernel for FixedSizeListVTable {
+    fn is_sorted(&self, _array: &FixedSizeListArray) -> VortexResult<Option<bool>> {
+        Ok(None)
+    }
+
+    fn is_strict_sorted(&self, _array: &FixedSizeListArray) -> VortexResult<Option<bool>> {
+        Ok(None)
+    }
+}
+
+register_kernel!(IsSortedKernelAdapter(FixedSizeListVTable).lift());

--- a/vortex-array/src/arrays/fixed_size_list/compute/min_max.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/min_max.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+
+use crate::arrays::{FixedSizeListArray, FixedSizeListVTable};
+use crate::compute::{MinMaxKernel, MinMaxKernelAdapter, MinMaxResult};
+use crate::register_kernel;
+
+// TODO(connor): Right now this does nothing.
+/// MinMax implementation for [`FixedSizeListArray`].
+impl MinMaxKernel for FixedSizeListVTable {
+    fn min_max(&self, _array: &FixedSizeListArray) -> VortexResult<Option<MinMaxResult>> {
+        Ok(None)
+    }
+}
+
+register_kernel!(MinMaxKernelAdapter(FixedSizeListVTable).lift());

--- a/vortex-array/src/arrays/fixed_size_list/compute/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/mod.rs
@@ -4,5 +4,7 @@
 mod cast;
 mod filter;
 mod is_constant;
+mod is_sorted;
 mod mask;
+mod min_max;
 mod take;


### PR DESCRIPTION
Tracking Issue: https://github.com/vortex-data/vortex/issues/4372

This follows the list implementation that is also a no-op (is no-op the right word here?)