### PR TITLE
Fix: restore and correct dict compare where only single value matches the search

### DIFF
--- a/encodings/dict/src/array.rs
+++ b/encodings/dict/src/array.rs
@@ -4,12 +4,9 @@
 use std::fmt::Debug;
 
 use arrow_buffer::BooleanBuffer;
-use vortex_array::compute::take;
 use vortex_array::stats::{ArrayStats, StatsSetRef};
-use vortex_array::vtable::{ArrayVTable, CanonicalVTable, NotSupported, VTable, ValidityVTable};
-use vortex_array::{
-    Array, ArrayRef, Canonical, EncodingId, EncodingRef, IntoArray, ToCanonical, vtable,
-};
+use vortex_array::vtable::{ArrayVTable, NotSupported, VTable, ValidityVTable};
+use vortex_array::{Array, ArrayRef, EncodingId, EncodingRef, ToCanonical, vtable};
 use vortex_dtype::{DType, match_each_integer_ptype};
 use vortex_error::{VortexExpect as _, VortexResult, vortex_bail};
 use vortex_mask::{AllOr, Mask};
@@ -118,26 +115,6 @@ impl ArrayVTable<DictVTable> for DictVTable {
 
     fn stats(array: &DictArray) -> StatsSetRef<'_> {
         array.stats_set.to_ref(array.as_ref())
-    }
-}
-
-impl CanonicalVTable<DictVTable> for DictVTable {
-    fn canonicalize(array: &DictArray) -> Canonical {
-        match array.dtype() {
-            // NOTE: Utf8 and Binary will decompress into VarBinViewArray, which requires a full
-            // decompression to construct the views child array.
-            // For this case, it is *always* faster to decompress the values first and then create
-            // copies of the view pointers.
-            DType::Utf8(_) | DType::Binary(_) => {
-                let canonical_values: ArrayRef = array.values().to_canonical().into_array();
-                take(&canonical_values, array.codes())
-                    .vortex_expect("taking codes from dictionary values shouldn't fail")
-                    .to_canonical()
-            }
-            _ => take(array.values(), array.codes())
-                .vortex_expect("taking codes from dictionary values shouldn't fail")
-                .to_canonical(),
-        }
     }
 }
 

--- a/encodings/dict/src/canonical.rs
+++ b/encodings/dict/src/canonical.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::ops::Not;
+
+use arrow_buffer::BooleanBuffer;
+use vortex_array::arrays::{BoolArray, ConstantArray};
+use vortex_array::compute::{Operator, cast, compare, mask, take};
+use vortex_array::validity::Validity;
+use vortex_array::vtable::CanonicalVTable;
+use vortex_array::{Array, ArrayRef, Canonical, IntoArray, ToCanonical};
+use vortex_dtype::{DType, Nullability};
+use vortex_error::{VortexExpect, VortexResult};
+use vortex_mask::{AllOr, Mask};
+use vortex_scalar::Scalar;
+
+use crate::{DictArray, DictVTable};
+
+impl CanonicalVTable<DictVTable> for DictVTable {
+    fn canonicalize(array: &DictArray) -> Canonical {
+        match array.dtype() {
+            // NOTE: Utf8 and Binary will decompress into VarBinViewArray, which requires a full
+            // decompression to construct the views child array.
+            // For this case, it is *always* faster to decompress the values first and then create
+            // copies of the view pointers.
+            DType::Utf8(_) | DType::Binary(_) => {
+                let canonical_values: ArrayRef = array.values().to_canonical().into_array();
+                take(&canonical_values, array.codes())
+                    .vortex_expect("taking codes from dictionary values shouldn't fail")
+                    .to_canonical()
+            }
+            DType::Bool(_) => {
+                dict_bool_take(array).vortex_expect("Canonicalizing dict bool array shouldn't fail")
+            }
+            _ => take(array.values(), array.codes())
+                .vortex_expect("taking codes from dictionary values shouldn't fail")
+                .to_canonical(),
+        }
+    }
+}
+
+fn dict_bool_take(dict_array: &DictArray) -> VortexResult<Canonical> {
+    let values = dict_array.values();
+    let codes = dict_array.codes();
+    let result_nullability = dict_array.dtype().nullability();
+
+    let bool_values = values.to_bool();
+    let result_validity = bool_values.validity_mask();
+    let bool_buffer = bool_values.boolean_buffer();
+    let (first_match, second_match) = match result_validity.boolean_buffer() {
+        AllOr::All => {
+            let mut indices_iter = bool_buffer.set_indices();
+            (indices_iter.next(), indices_iter.next())
+        }
+        AllOr::None => (None, None),
+        AllOr::Some(v) => {
+            let mut indices_iter = bool_buffer.set_indices().filter(|i| v.value(*i));
+            (indices_iter.next(), indices_iter.next())
+        }
+    };
+
+    Ok(match (first_match, second_match) {
+        // Couldn't find a value match, so the result is all false
+        (None, _) => match result_validity {
+            Mask::AllTrue(_) => BoolArray::from_bool_buffer(
+                BooleanBuffer::new_unset(codes.len()),
+                Validity::copy_from_array(codes),
+            )
+            .to_canonical(),
+            Mask::AllFalse(_) => ConstantArray::new(
+                Scalar::null(DType::Bool(Nullability::Nullable)),
+                codes.len(),
+            )
+            .to_canonical(),
+            Mask::Values(_) => BoolArray::from_bool_buffer(
+                BooleanBuffer::new_unset(codes.len()),
+                Validity::from_mask(result_validity, bool_values.dtype().nullability())
+                    .take(codes)?,
+            )
+            .to_canonical(),
+        },
+        // We found a single matching value so we can compare the codes directly.
+        (Some(code), None) => match result_validity {
+            Mask::AllTrue(_) => cast(
+                &compare(
+                    codes,
+                    &cast(
+                        ConstantArray::new(code, codes.len()).as_ref(),
+                        codes.dtype(),
+                    )?,
+                    Operator::Eq,
+                )?,
+                &DType::Bool(result_nullability),
+            )?
+            .to_canonical(),
+            Mask::AllFalse(_) => ConstantArray::new(
+                Scalar::null(DType::Bool(Nullability::Nullable)),
+                codes.len(),
+            )
+            .to_canonical(),
+            Mask::Values(rv) => mask(
+                &compare(
+                    codes,
+                    &cast(
+                        ConstantArray::new(code, codes.len()).as_ref(),
+                        codes.dtype(),
+                    )?,
+                    Operator::Eq,
+                )?,
+                &Mask::from_buffer(
+                    take(BoolArray::from(rv.boolean_buffer().clone()).as_ref(), codes)?
+                        .to_bool()
+                        .boolean_buffer()
+                        .not(),
+                ),
+            )?
+            .to_canonical(),
+        },
+        // more than one value matches
+        _ => take(bool_values.as_ref(), codes)
+            .vortex_expect("taking codes from dictionary values shouldn't fail")
+            .to_canonical(),
+    })
+}

--- a/encodings/dict/src/compute/compare.rs
+++ b/encodings/dict/src/compute/compare.rs
@@ -19,6 +19,7 @@ impl CompareKernel for DictVTable {
         if lhs.values().len() > lhs.codes().len() {
             return Ok(None);
         }
+
         // If the RHS is constant, then we just need to compare against our encoded values.
         if let Some(rhs) = rhs.as_constant() {
             let compare_result = compare(
@@ -26,11 +27,14 @@ impl CompareKernel for DictVTable {
                 ConstantArray::new(rhs, lhs.values().len()).as_ref(),
                 operator,
             )?;
+
             // SAFETY: values len preserved, codes all still point to valid values
-            let arr = unsafe {
+            let result = unsafe {
                 DictArray::new_unchecked(lhs.codes().clone(), compare_result).into_array()
             };
-            return Ok(Some(arr.to_canonical().into_array()));
+
+            // We canonicalize the result because dictionary-encoded bools is dumb.
+            return Ok(Some(result.to_canonical().into_array()));
         }
 
         // It's a little more complex, but we could perform a comparison against the dictionary

--- a/encodings/dict/src/compute/compare.rs
+++ b/encodings/dict/src/compute/compare.rs
@@ -19,7 +19,6 @@ impl CompareKernel for DictVTable {
         if lhs.values().len() > lhs.codes().len() {
             return Ok(None);
         }
-
         // If the RHS is constant, then we just need to compare against our encoded values.
         if let Some(rhs) = rhs.as_constant() {
             let compare_result = compare(
@@ -27,14 +26,11 @@ impl CompareKernel for DictVTable {
                 ConstantArray::new(rhs, lhs.values().len()).as_ref(),
                 operator,
             )?;
-
             // SAFETY: values len preserved, codes all still point to valid values
-            let result = unsafe {
+            let arr = unsafe {
                 DictArray::new_unchecked(lhs.codes().clone(), compare_result).into_array()
             };
-
-            // We canonicalize the result because dictionary-encoded bools is dumb.
-            return Ok(Some(result.to_canonical().into_array()));
+            return Ok(Some(arr.to_canonical().into_array()));
         }
 
         // It's a little more complex, but we could perform a comparison against the dictionary

--- a/encodings/dict/src/compute/mod.rs
+++ b/encodings/dict/src/compute/mod.rs
@@ -279,7 +279,11 @@ mod tests {
     #[rstest]
     // Primitive arrays
     #[case::dict_i32(dict_encode(&buffer![1i32, 2, 3, 2, 1].into_array()).unwrap())]
-    #[case::dict_nullable_i32(dict_encode(
+    #[case::dict_nullable_codes(DictArray::try_new(
+        buffer![0u32, 1, 2, 2, 0].into_array(),
+        PrimitiveArray::from_option_iter([Some(10), Some(20), None]).into_array(),
+    ).unwrap())]
+    #[case::dict_nullable_values(dict_encode(
         PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None]).as_ref()
     ).unwrap())]
     #[case::dict_u64(dict_encode(&buffer![100u64, 200, 100, 300, 200].into_array()).unwrap())]
@@ -300,7 +304,6 @@ mod tests {
     #[case::dict_single(dict_encode(&buffer![42i32].into_array()).unwrap())]
     #[case::dict_all_same(dict_encode(&buffer![5i32, 5, 5, 5, 5].into_array()).unwrap())]
     #[case::dict_large(dict_encode(&PrimitiveArray::from_iter((0..1000).map(|i| i % 10)).into_array()).unwrap())]
-
     fn test_dict_consistency(#[case] array: DictArray) {
         test_array_consistency(array.as_ref());
     }

--- a/encodings/dict/src/lib.rs
+++ b/encodings/dict/src/lib.rs
@@ -11,6 +11,7 @@ mod array;
 #[cfg(feature = "arrow")]
 mod arrow;
 pub mod builders;
+mod canonical;
 mod compute;
 mod display;
 mod ops;

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -25,7 +25,7 @@ use vortex_dtype::{DType, Nullability, PType};
 use vortex_error::{VortexUnwrap, vortex_panic};
 use vortex_mask::Mask;
 
-use crate::arrays::{BoolArray, PrimitiveArray};
+use crate::arrays::{BoolArray, ConstantArray, PrimitiveArray};
 use crate::compute::{Operator, and, cast, compare, filter, invert, mask, or, take};
 use crate::{Array, IntoArray};
 
@@ -573,7 +573,7 @@ fn test_comparison_inverse_consistency(array: &dyn Array) {
     };
 
     // Test Eq vs NotEq
-    let const_array = crate::arrays::ConstantArray::new(test_scalar, len);
+    let const_array = ConstantArray::new(test_scalar, len);
     if let (Ok(eq_result), Ok(neq_result)) = (
         compare(array, const_array.as_ref(), Operator::Eq),
         compare(array, const_array.as_ref(), Operator::NotEq),
@@ -669,7 +669,7 @@ fn test_comparison_symmetry_consistency(array: &dyn Array) {
     };
 
     // Create a constant array with the test scalar for reverse comparison
-    let const_array = crate::arrays::ConstantArray::new(test_scalar, len);
+    let const_array = ConstantArray::new(test_scalar, len);
 
     // Test Gt vs Lt symmetry
     if let (Ok(arr_gt_scalar), Ok(scalar_lt_arr)) = (


### PR DESCRIPTION
This optimisation was generally applicable to canonicalizing DictArray
with bool values. I have moved the logic there and fixed the issue with
not respecting validity of the values array

fix #4599 

Signed-off-by: Robert Kruszewski <github@robertk.io>
