### PR TITLE
chore: add r/place and airquality datasets to benchmark

### DIFF
--- a/bench-vortex/src/bin/compress.rs
+++ b/bench-vortex/src/bin/compress.rs
@@ -11,6 +11,7 @@ use bench_vortex::datasets::struct_list_of_ints::StructListOfInts;
 use bench_vortex::datasets::taxi_data::TaxiData;
 use bench_vortex::datasets::tpch_l_comment::{TPCHLCommentCanonical, TPCHLCommentChunked};
 use bench_vortex::display::{DisplayFormat, print_measurements_json, render_table};
+use bench_vortex::downloadable_dataset::DownloadableDataset;
 use bench_vortex::public_bi::PBI_DATASETS;
 use bench_vortex::public_bi::PBIDataset::{Arade, Bimbo, CMSprovider, Euro2016, Food, HashTags};
 use bench_vortex::utils::new_tokio_runtime;
@@ -99,14 +100,19 @@ fn compress(
         // YaleLanguages, // 4th column looks like integer but also contains Y
         &TPCHLCommentChunked,
         &TPCHLCommentCanonical,
+        &DownloadableDataset::RPlace,
+        &DownloadableDataset::AirQuality,
     ]
     .into_iter()
     .chain(structlistofints.iter().map(|d| d as &dyn Dataset))
     .filter(|d| {
-        datasets_filter.is_none()
-            || datasets_filter
-                .as_ref()
-                .is_some_and(|ds| ds.is_match(d.name()))
+        if let Some(filter) = datasets_filter.as_ref() {
+            filter.is_match(d.name())
+        } else {
+            // These download data from pcodec's public bucket, presumably creating egress charges for
+            // pcodec. As such, we do not run in CI.
+            d.name() != "airquality" && d.name() != "rplace"
+        }
     })
     .collect();
 

--- a/bench-vortex/src/downloadable_dataset.rs
+++ b/bench-vortex/src/downloadable_dataset.rs
@@ -19,11 +19,11 @@ use crate::{IdempotentPath, idempotent_async};
 /// Twitter, CMS, and CalHousing are all TSVs, some compressed, so need some pre-processing
 ///
 /// - Taxi. Already in datasets/taxi_data.rs.
-/// - California Housing https://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.html
-/// - CMS payments https://openpaymentsdata.cms.gov/dataset/fb3a65aa-c901-4a38-a813-b04b00dfa2a9
-/// - Twitter https://snap.stanford.edu/data/ego-Twitter.html
-/// - r/place data https://pcodec-public.s3.amazonaws.com/reddit_2022_place_numerical.parquet (https://github.com/pcodec/pcodec/blob/main/docs/benchmark_results.md)
-/// - AirQuality https://pcodec-public.s3.amazonaws.com/devinrsmith-air-quality.20220714.zstd.parquet
+/// - California Housing <https://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.html>.
+/// - CMS payments <https://openpaymentsdata.cms.gov/dataset/fb3a65aa-c901-4a38-a813-b04b00dfa2a9>.
+/// - Twitter <https://snap.stanford.edu/data/ego-Twitter.html>.
+/// - r/place data <https://pcodec-public.s3.amazonaws.com/reddit_2022_place_numerical.parquet> (<https://github.com/pcodec/pcodec/blob/main/docs/benchmark_results.md>).
+/// - AirQuality <https://pcodec-public.s3.amazonaws.com/devinrsmith-air-quality.20220714.zstd.parquet>.
 pub enum DownloadableDataset {
     RPlace,
     AirQuality,

--- a/bench-vortex/src/downloadable_dataset.rs
+++ b/bench-vortex/src/downloadable_dataset.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use async_trait::async_trait;
+use tokio::fs::File;
+use vortex::ArrayRef;
+use vortex::file::{VortexOpenOptions, VortexWriteOptions};
+use vortex::iter::ArrayIteratorExt;
+
+use crate::conversions::parquet_to_vortex;
+use crate::datasets::Dataset;
+use crate::datasets::data_downloads::download_data;
+use crate::{IdempotentPath, idempotent_async};
+
+/// Datasets which can be downloaded over HTTP in Parquet format.
+///
+/// # The Pcodec datasets
+///
+/// Twitter, CMS, and CalHousing are all TSVs, some compressed, so need some pre-processing
+///
+/// - Taxi. Already in datasets/taxi_data.rs.
+/// - California Housing https://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.html
+/// - CMS payments https://openpaymentsdata.cms.gov/dataset/fb3a65aa-c901-4a38-a813-b04b00dfa2a9
+/// - Twitter https://snap.stanford.edu/data/ego-Twitter.html
+/// - r/place data https://pcodec-public.s3.amazonaws.com/reddit_2022_place_numerical.parquet (https://github.com/pcodec/pcodec/blob/main/docs/benchmark_results.md)
+/// - AirQuality https://pcodec-public.s3.amazonaws.com/devinrsmith-air-quality.20220714.zstd.parquet
+pub enum DownloadableDataset {
+    RPlace,
+    AirQuality,
+}
+
+impl DownloadableDataset {
+    fn parquet_url(&self) -> &str {
+        match self {
+            DownloadableDataset::RPlace => {
+                "https://pcodec-public.s3.amazonaws.com/reddit_2022_place_numerical.parquet"
+            }
+            DownloadableDataset::AirQuality => {
+                "https://pcodec-public.s3.amazonaws.com/devinrsmith-air-quality.20220714.zstd.parquet"
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl Dataset for DownloadableDataset {
+    fn name(&self) -> &str {
+        match self {
+            DownloadableDataset::AirQuality => "airquality",
+            DownloadableDataset::RPlace => "rplace",
+        }
+    }
+
+    async fn to_vortex_array(&self) -> anyhow::Result<ArrayRef> {
+        let dir = format!("{}/", self.name()).to_data_path();
+        let parquet = dir.join(format!("{}.parquet", self.name()));
+        let vortex = dir.join(format!("{}.vortex", self.name()));
+        download_data(parquet.clone(), self.parquet_url()).await?;
+        idempotent_async(&vortex, async |path| -> anyhow::Result<()> {
+            VortexWriteOptions::default()
+                .write_tokio(
+                    &mut File::create(path)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("Failed to create file: {}", e))?,
+                    parquet_to_vortex(parquet)?,
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to write vortex file: {}", e))?;
+            Ok(())
+        })
+        .await?;
+
+        Ok(VortexOpenOptions::file()
+            .open(&vortex)
+            .await?
+            .scan()?
+            .into_array_iter_multithread()?
+            .read_all()?)
+    }
+}

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -25,6 +25,7 @@ pub mod compress;
 pub mod conversions;
 pub mod datasets;
 pub mod display;
+pub mod downloadable_dataset;
 pub mod engines;
 pub mod measurements;
 pub mod memory;


### PR DESCRIPTION
I did not add them to CI because I do not want to incur egress charges constantly for the pcodec project. Probably the right thing to do is to download all these datasets and upload them, as Parquet, to an S3 bucket we control. None of the other datasets currently use authenticated downloads and I did not want to figure that out today.