### PR TITLE
chore: expose DeserializeStep

### DIFF
--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -109,7 +109,7 @@ mod writer;
 use std::sync::{Arc, LazyLock};
 
 pub use file::*;
-pub use footer::{DeserializeStep, Footer, SegmentSpec};
+pub use footer::*;
 pub use forever_constant::*;
 pub use generic::*;
 pub use memory::*;

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -109,7 +109,7 @@ mod writer;
 use std::sync::{Arc, LazyLock};
 
 pub use file::*;
-pub use footer::{Footer, SegmentSpec};
+pub use footer::{DeserializeStep, Footer, SegmentSpec};
 pub use forever_constant::*;
 pub use generic::*;
 pub use memory::*;


### PR DESCRIPTION
I'm not sure how else to interact with this enum. It is returned by `footer.into_deserializer().deserialize()`.