### PR TITLE
Convert handles to hold weak reference to their executor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ concurrency:
 
 on:
   push:
-    branches: [ "develop" ]
-  pull_request: { }
-  workflow_dispatch: { }
+    branches: ["develop"]
+  pull_request: {}
+  workflow_dispatch: {}
 
 permissions:
   actions: read
@@ -395,7 +395,7 @@ jobs:
   bench-codspeed:
     strategy:
       matrix:
-        shard: [ 1, 2 ]
+        shard: [1, 2]
     name: "Benchmark with Codspeed (Shard #${{ matrix.shard }})"
     timeout-minutes: 120
     runs-on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ concurrency:
 
 on:
   push:
-    branches: ["develop"]
-  pull_request: {}
-  workflow_dispatch: {}
+    branches: [ "develop" ]
+  pull_request: { }
+  workflow_dispatch: { }
 
 permissions:
   actions: read
@@ -166,12 +166,6 @@ jobs:
           - name: "with tokio dispatcher"
             command: "build"
             args: "--no-default-features --features tokio --all-targets --ignore-unknown-features"
-          - name: "with compio dispatcher"
-            command: "build"
-            args: "--no-default-features --features compio --all-targets --ignore-unknown-features"
-          - name: "with tokio+compio dispatcher"
-            command: "build"
-            args: "--no-default-features --features tokio,compio --all-targets --ignore-unknown-features"
           - name: "wasm32 with default features"
             command: "build"
             target: wasm32-unknown-unknown
@@ -401,7 +395,7 @@ jobs:
   bench-codspeed:
     strategy:
       matrix:
-        shard: [1, 2]
+        shard: [ 1, 2 ]
     name: "Benchmark with Codspeed (Shard #${{ matrix.shard }})"
     timeout-minutes: 120
     runs-on:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6928,7 +6928,6 @@ dependencies = [
  "vortex-expr",
  "vortex-flatbuffers",
  "vortex-io",
- "vortex-layout",
  "vortex-mask",
  "vortex-pco",
  "vortex-scalar",

--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -349,8 +349,7 @@ impl<B: BlockingRuntime> BlockingWrite<B> {
         write: W,
         iter: impl ArrayIterator + Send + 'static,
     ) -> VortexResult<WriteSummary> {
-        let handle = self.runtime.handle();
-        self.runtime.block_on(async move {
+        self.runtime.block_on(|handle| async move {
             self.options
                 .with_handle(handle)
                 .write(BlockingWriteAdapter(write), iter.into_array_stream())
@@ -381,7 +380,7 @@ pub struct BlockingWriter<'w, B: BlockingRuntime> {
 
 impl<B: BlockingRuntime> BlockingWriter<'_, B> {
     pub fn push(&mut self, chunk: ArrayRef) -> VortexResult<()> {
-        self.runtime.block_on(self.writer.push(chunk))
+        self.runtime.block_on(|_| self.writer.push(chunk))
     }
 
     pub fn bytes_written(&self) -> u64 {
@@ -389,7 +388,7 @@ impl<B: BlockingRuntime> BlockingWriter<'_, B> {
     }
 
     pub fn finish(self) -> VortexResult<WriteSummary> {
-        self.runtime.block_on(self.writer.finish())
+        self.runtime.block_on(|_| self.writer.finish())
     }
 }
 

--- a/vortex-io/src/runtime/blocking.rs
+++ b/vortex-io/src/runtime/blocking.rs
@@ -17,13 +17,15 @@ pub trait BlockingRuntime {
     ///
     /// The future is provided a [`Handle`] to the runtime so that it may spawn additional tasks
     /// to be executed concurrently.
-    fn block_on<Fut, R>(&self, f: Fut) -> R
+    fn block_on<F, Fut, R>(&self, f: F) -> R
     where
+        F: FnOnce(Handle) -> Fut,
         Fut: Future<Output = R>;
 
     /// Returns an iterator wrapper around a stream, blocking the current thread for each item.
-    fn block_on_stream<'a, S, R>(&self, f: S) -> Self::BlockingIterator<'a, R>
+    fn block_on_stream<'a, F, S, R>(&self, f: F) -> Self::BlockingIterator<'a, R>
     where
-        S: Stream<Item = R> + Send + Unpin + 'a,
+        F: FnOnce(Handle) -> S,
+        S: Stream<Item = R> + Send + 'a,
         R: Send + 'a;
 }

--- a/vortex-io/src/runtime/current.rs
+++ b/vortex-io/src/runtime/current.rs
@@ -3,35 +3,75 @@
 
 use std::sync::Arc;
 
+use futures::stream::BoxStream;
 use futures::{Stream, StreamExt};
-use smol::{Executor, block_on};
+use smol::block_on;
 
-use crate::runtime::Handle;
+use crate::runtime::{BlockingRuntime, Executor, Handle};
 
 /// A current thread runtime allows users to explicitly drive Vortex futures from multiple worker
 /// threads that they manage. This is useful in environments where the user already has a thread
 /// pool and wants to integrate Vortex into that pool, for example query engines.
-pub struct CurrentThreadRuntime;
+#[derive(Default)]
+pub struct CurrentThreadRuntime {
+    executor: Arc<smol::Executor<'static>>,
+}
 
-impl CurrentThreadRuntime {
-    /// Drive the given Vortex stream on the underlying current thread runtime.
-    ///
-    /// Note the resulting [`Iterator`] supports [`Clone`] in order to drive the stream from
-    /// multiple threads.
-    pub fn block_on_stream<F, S, R>(f: F) -> impl Iterator<Item = R> + Clone
+impl BlockingRuntime for CurrentThreadRuntime {
+    type BlockingIterator<'a, R: 'a> = CurrentThreadIterator<'a, R>;
+
+    fn handle(&self) -> Handle {
+        let executor: Arc<dyn Executor> = self.executor.clone();
+        Handle::new(Arc::downgrade(&executor))
+    }
+
+    fn block_on<F, Fut, R>(&self, f: F) -> R
+    where
+        F: FnOnce(Handle) -> Fut,
+        Fut: Future<Output = R>,
+    {
+        block_on(self.executor.run(f(self.handle())))
+    }
+
+    fn block_on_stream<'a, F, S, R>(&self, f: F) -> Self::BlockingIterator<'a, R>
     where
         F: FnOnce(Handle) -> S,
-        S: Stream<Item = R> + Send + Unpin + 'static,
+        S: Stream<Item = R> + Send + 'a,
+        R: Send + 'a,
+    {
+        CurrentThreadIterator {
+            executor: self.executor.clone(),
+            stream: f(self.handle()).boxed(),
+        }
+    }
+}
+
+impl CurrentThreadRuntime {
+    /// Create a new current thread runtime.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns an iterator wrapper around a stream, blocking the current thread for each item.
+    ///
+    /// ## Multi-threaded Usage
+    ///
+    /// To drive the iterator from multiple threads, simply clone it and call `next()` on each
+    /// clone. Results on each thread are ordered with respect to the stream, but there is no
+    /// ordering guarantee between threads.
+    pub fn block_on_stream_thread_safe<F, S, R>(&self, f: F) -> ThreadSafeIterator<R>
+    where
+        F: FnOnce(Handle) -> S,
+        S: Stream<Item = R> + Send + 'static,
         R: Send + 'static,
     {
-        let executor = Arc::new(Executor::new());
-        let stream = f(Handle::new(executor.clone()));
+        let stream = f(self.handle());
 
         // We create an MPMC result channel and spawn a task to drive the stream and send results.
         // This allows multiple worker threads to drive the executor while all waiting for results
         // on the channel.
         let (result_tx, result_rx) = kanal::bounded_async(1);
-        executor
+        self.executor
             .spawn(async move {
                 futures::pin_mut!(stream);
                 while let Some(item) = stream.next().await {
@@ -44,32 +84,44 @@ impl CurrentThreadRuntime {
             })
             .detach();
 
-        BlockingStream {
-            executor,
+        ThreadSafeIterator {
+            executor: self.executor.clone(),
             results: result_rx,
         }
     }
 }
 
-/// A stream that wraps up the stream with the executor that drives it.
-///
-/// This allows the resulting stream to have a static lifetime.
-struct BlockingStream<T> {
-    executor: Arc<Executor<'static>>,
+/// An iterator that wraps up a stream to drive it using the current thread executor.
+pub struct CurrentThreadIterator<'a, T> {
+    executor: Arc<smol::Executor<'static>>,
+    stream: BoxStream<'a, T>,
+}
+
+impl<T> Iterator for CurrentThreadIterator<'_, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        block_on(self.executor.run(self.stream.next()))
+    }
+}
+
+/// An iterator that drives a stream from multiple threads.
+pub struct ThreadSafeIterator<T> {
+    executor: Arc<smol::Executor<'static>>,
     results: kanal::AsyncReceiver<T>,
 }
 
-// Manually implement Clone since `T` doesn't need to be `Clone`.
-impl<T> Clone for BlockingStream<T> {
+// Manual clone implementation since `T` does not need to be `Clone`.
+impl<T> Clone for ThreadSafeIterator<T> {
     fn clone(&self) -> Self {
-        BlockingStream {
+        Self {
             executor: self.executor.clone(),
             results: self.results.clone(),
         }
     }
 }
 
-impl<T> Iterator for BlockingStream<T> {
+impl<T> Iterator for ThreadSafeIterator<T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -92,9 +144,8 @@ mod tests {
 
     #[test]
     fn test_block_on_stream_single_thread() {
-        let mut iter = CurrentThreadRuntime::block_on_stream(|_handle| {
-            stream::iter(vec![1, 2, 3, 4, 5]).boxed()
-        });
+        let mut iter = CurrentThreadRuntime::new()
+            .block_on_stream(|_h| stream::iter(vec![1, 2, 3, 4, 5]).boxed());
 
         assert_eq!(iter.next(), Some(1));
         assert_eq!(iter.next(), Some(2));
@@ -111,9 +162,8 @@ mod tests {
         let items_per_thread = 25;
         let total_items = 100;
 
-        let iter = CurrentThreadRuntime::block_on_stream(move |_handle| {
-            stream::iter(0..total_items).boxed()
-        });
+        let iter = CurrentThreadRuntime::new()
+            .block_on_stream_thread_safe(|_h| stream::iter(0..total_items).boxed());
 
         let barrier = Arc::new(Barrier::new(num_threads));
         let results = Arc::new(Mutex::new(Vec::new()));
@@ -158,9 +208,9 @@ mod tests {
         let num_items = 50;
         let num_threads = 3;
 
-        let iter = CurrentThreadRuntime::block_on_stream(move |handle| {
+        let iter = CurrentThreadRuntime::new().block_on_stream_thread_safe(|h| {
             stream::unfold(0, move |state| {
-                let h = handle.clone();
+                let h = h.clone();
                 async move {
                     if state < num_items {
                         h.spawn_cpu(move || {
@@ -174,7 +224,6 @@ mod tests {
                     }
                 }
             })
-            .boxed()
         });
 
         let collected = Arc::new(Mutex::new(Vec::new()));
@@ -217,8 +266,8 @@ mod tests {
 
     #[test]
     fn test_block_on_stream_async_work() {
-        let iter = CurrentThreadRuntime::block_on_stream(|handle| {
-            stream::unfold((handle, 0), |(h, state)| async move {
+        let iter = CurrentThreadRuntime::new().block_on_stream(|h| {
+            stream::unfold((h, 0), |(h, state)| async move {
                 if state < 10 {
                     let value = h
                         .spawn(async move { futures::future::ready(state * 2).await })
@@ -228,7 +277,6 @@ mod tests {
                     None
                 }
             })
-            .boxed()
         });
 
         let results: Vec<_> = iter.collect();
@@ -240,7 +288,7 @@ mod tests {
         let counter = Arc::new(AtomicUsize::new(0));
         let c = counter.clone();
 
-        let mut iter = CurrentThreadRuntime::block_on_stream(move |_handle| {
+        let mut iter = CurrentThreadRuntime::new().block_on_stream(|_h| {
             stream::unfold(0, move |state| {
                 let c = c.clone();
                 async move {
@@ -269,7 +317,8 @@ mod tests {
     #[test]
     fn test_block_on_stream_interleaved_access() {
         let barrier = Arc::new(Barrier::new(2));
-        let iter = CurrentThreadRuntime::block_on_stream(|_handle| stream::iter(0..20).boxed());
+        let iter = CurrentThreadRuntime::new()
+            .block_on_stream_thread_safe(|_h| stream::iter(0..20).boxed());
 
         let iter1 = iter.clone();
         let iter2 = iter;
@@ -323,9 +372,8 @@ mod tests {
         let num_threads = 10;
         let num_items = 1000;
 
-        let iter = CurrentThreadRuntime::block_on_stream(move |_handle| {
-            stream::iter(0..num_items).boxed()
-        });
+        let iter = CurrentThreadRuntime::new()
+            .block_on_stream_thread_safe(|_h| stream::iter(0..num_items).boxed());
 
         let received = Arc::new(Mutex::new(Vec::new()));
         let barrier = Arc::new(Barrier::new(num_threads));

--- a/vortex-io/src/runtime/handle.rs
+++ b/vortex-io/src/runtime/handle.rs
@@ -8,7 +8,7 @@ use std::task::{Context, Poll, ready};
 use futures::{FutureExt, StreamExt};
 use vortex_error::{VortexResult, vortex_panic};
 
-use crate::file::{FileRead, IntoReadSource, IoRequestStream};
+use crate::file::{FileRead, IntoIoSource, IoRequestStream};
 use crate::kanal_ext::KanalExt;
 use crate::runtime::{AbortHandleRef, Executor, IoTask};
 
@@ -135,8 +135,8 @@ impl Handle {
     }
 
     /// Open a file for I/O on this runtime.
-    pub fn open_read<S: IntoReadSource>(&self, source: S) -> VortexResult<FileRead> {
-        let source = source.into_read_source(self.clone())?;
+    pub fn open_read<S: IntoIoSource>(&self, source: S) -> VortexResult<FileRead<'_>> {
+        let source = source.into_io_source(self.clone())?;
 
         let (send, recv) = kanal::unbounded();
 

--- a/vortex-io/src/runtime/handle.rs
+++ b/vortex-io/src/runtime/handle.rs
@@ -2,28 +2,37 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::task::{Context, Poll, ready};
 
 use futures::{FutureExt, StreamExt};
 use vortex_error::{VortexResult, vortex_panic};
 
-use crate::file::{FileRead, IntoIoSource, IoRequestStream};
+use crate::file::{FileRead, IntoReadSource, IoRequestStream};
 use crate::kanal_ext::KanalExt;
-use crate::runtime::{AbortHandleRef, IoTask, Runtime};
+use crate::runtime::{AbortHandleRef, Executor, IoTask};
 
 /// A handle to an active Vortex runtime.
 ///
-/// Users should obtain a handle from one of the runtime constructors and use it to spawn new
-/// async tasks or CPU-heavy worker.
+/// Users should obtain a handle from one of the Vortex runtime's and use it to spawn new async
+/// tasks, blocking I/O tasks, CPU-heavy tasks, or to open files for reading or writing.
+///
+/// Note that a [`Handle`] is a weak reference to the underlying runtime. If the associated
+/// runtime has been dropped, then any requests to spawn new tasks will panic.
 #[derive(Clone)]
 pub struct Handle {
-    runtime: Arc<dyn Runtime>,
+    runtime: Weak<dyn Executor>,
 }
 
 impl Handle {
-    pub(crate) fn new(runtime: Arc<dyn Runtime>) -> Self {
+    pub(crate) fn new(runtime: Weak<dyn Executor>) -> Self {
         Self { runtime }
+    }
+
+    fn runtime(&self) -> Arc<dyn Executor> {
+        self.runtime.upgrade().unwrap_or_else(|| {
+            vortex_panic!("Attempted to use a Handle after its runtime was dropped")
+        })
     }
 
     /// Returns a handle to the current runtime, if such a reasonable choice exists.
@@ -54,7 +63,7 @@ impl Handle {
         R: Send + 'static,
     {
         let (send, recv) = oneshot::channel();
-        let abort_handle = self.runtime.spawn(
+        let abort_handle = self.runtime().spawn(
             async move {
                 // Task::detach allows the receiver to be dropped, so we ignore send errors.
                 let _ = send.send(f.await);
@@ -92,7 +101,7 @@ impl Handle {
         R: Send + 'static,
     {
         let (send, recv) = oneshot::channel();
-        let abort_handle = self.runtime.spawn_cpu(Box::new(move || {
+        let abort_handle = self.runtime().spawn_cpu(Box::new(move || {
             // Optimistically avoid the work if the result won't be used.
             if !send.is_closed() {
                 // Task::detach allows the receiver to be dropped, so we ignore send errors.
@@ -112,7 +121,7 @@ impl Handle {
         R: Send + 'static,
     {
         let (send, recv) = oneshot::channel();
-        let abort_handle = self.runtime.spawn_blocking(Box::new(move || {
+        let abort_handle = self.runtime().spawn_blocking(Box::new(move || {
             // Optimistically avoid the work if the result won't be used.
             if !send.is_closed() {
                 // Task::detach allows the receiver to be dropped, so we ignore send errors.
@@ -126,8 +135,8 @@ impl Handle {
     }
 
     /// Open a file for I/O on this runtime.
-    pub fn open_read<S: IntoIoSource>(&self, source: S) -> VortexResult<FileRead<'_>> {
-        let source = source.into_io_source(self.clone())?;
+    pub fn open_read<S: IntoReadSource>(&self, source: S) -> VortexResult<FileRead> {
+        let source = source.into_read_source(self.clone())?;
 
         let (send, recv) = kanal::unbounded();
 
@@ -139,7 +148,7 @@ impl Handle {
         )
         .boxed();
 
-        self.runtime.clone().spawn_io(IoTask::new(source, stream));
+        self.runtime().spawn_io(IoTask::new(source, stream));
 
         Ok(read)
     }

--- a/vortex-io/src/runtime/mod.rs
+++ b/vortex-io/src/runtime/mod.rs
@@ -1,23 +1,37 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+//! A Vortex runtime provides an abstract way of scheduling mixed I/O and CPU workloads onto the
+//! various threading models supported by Vortex.
+//!
+//! In the future, it may also include a buffer manager or other shared resources.
+//!
+//! The threading models we currently support are:
+//! * Single-threaded: all work is driven on the current thread.
+//! * Multi-threaded: work is driven on a pool of threads managed by Vortex.
+//! * Worker Pool: work is driven on a pool of threads provided by the caller.
+//! * Tokio: work is driven on a Tokio runtime provided by the caller.
+//!
+
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 
-use crate::file::{IoRequest, IoSourceRef};
+use crate::file::IoRequest;
 
 mod blocking;
 pub use blocking::*;
 mod handle;
 pub use handle::*;
+
+use crate::file::ReadSourceRef;
+
 #[cfg(not(target_arch = "wasm32"))]
 pub mod current;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod single;
 #[cfg(not(target_arch = "wasm32"))]
 mod smol;
-// TODO(ngates): feature-flag this by Tokio once we add I/O support for runtimes.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "tokio")]
 pub mod tokio;
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;
@@ -25,19 +39,8 @@ pub mod wasm;
 #[cfg(test)]
 mod tests;
 
-/// A Vortex runtime provides an abstract way of scheduling mixed I/O and CPU workloads onto the
-/// various threading models supported by Vortex.
-///
-/// In the future, it may also include a buffer manager or other shared resources.
-///
-/// The threading models we currently support are:
-/// * Single-threaded: all work is driven on the current thread.
-/// * Multi-threaded: work is driven on a pool of threads managed by Vortex.
-/// * Worker Pool: work is driven on a pool of threads provided by the caller.
-/// * Tokio: work is driven on a Tokio runtime provided by the caller.
-///
-/// Note: users interact with the [`Handle`] API rather than the [`Runtime`] trait.
-pub(crate) trait Runtime: Send + Sync {
+/// Trait used to abstract over different async runtimes.
+pub(crate) trait Executor: Send + Sync {
     /// Spawns a future to be executed on the runtime.
     ///
     /// The future should continue to be polled in the background by the runtime.
@@ -82,12 +85,12 @@ pub(crate) type AbortHandleRef = Box<dyn AbortHandle>;
 // NOTE(ngates): We could in theory make IoSource support as_any if we wanted each runtime to implement the
 // actual read logic themselves? Not sure yet...
 pub(crate) struct IoTask {
-    pub(crate) source: IoSourceRef,
+    pub(crate) source: ReadSourceRef,
     pub(crate) stream: BoxStream<'static, IoRequest>,
 }
 
 impl IoTask {
-    pub(crate) fn new(source: IoSourceRef, stream: BoxStream<'static, IoRequest>) -> Self {
+    pub(crate) fn new(source: ReadSourceRef, stream: BoxStream<'static, IoRequest>) -> Self {
         IoTask { source, stream }
     }
 }

--- a/vortex-io/src/runtime/mod.rs
+++ b/vortex-io/src/runtime/mod.rs
@@ -23,7 +23,7 @@ pub use blocking::*;
 mod handle;
 pub use handle::*;
 
-use crate::file::ReadSourceRef;
+use crate::file::IoSourceRef;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod current;
@@ -85,12 +85,12 @@ pub(crate) type AbortHandleRef = Box<dyn AbortHandle>;
 // NOTE(ngates): We could in theory make IoSource support as_any if we wanted each runtime to implement the
 // actual read logic themselves? Not sure yet...
 pub(crate) struct IoTask {
-    pub(crate) source: ReadSourceRef,
+    pub(crate) source: IoSourceRef,
     pub(crate) stream: BoxStream<'static, IoRequest>,
 }
 
 impl IoTask {
-    pub(crate) fn new(source: ReadSourceRef, stream: BoxStream<'static, IoRequest>) -> Self {
+    pub(crate) fn new(source: IoSourceRef, stream: BoxStream<'static, IoRequest>) -> Self {
         IoTask { source, stream }
     }
 }

--- a/vortex-io/src/runtime/single.rs
+++ b/vortex-io/src/runtime/single.rs
@@ -12,7 +12,7 @@ use smol::LocalExecutor;
 use vortex_error::vortex_panic;
 
 use crate::runtime::smol::SmolAbortHandle;
-use crate::runtime::{AbortHandle, AbortHandleRef, BlockingRuntime, Handle, IoTask, Runtime};
+use crate::runtime::{AbortHandle, AbortHandleRef, BlockingRuntime, Executor, Handle, IoTask};
 
 /// A runtime that drives all work on the current thread.
 ///
@@ -121,7 +121,7 @@ impl Sender {
 /// we cannot just `impl Runtime for LocalExecutor`. Instead, we create channels that the handle
 /// can forward its work into, and we drive the resulting tasks on a [`LocalExecutor`] on the
 /// calling thread.
-impl Runtime for Sender {
+impl Executor for Sender {
     fn spawn(&self, future: BoxFuture<'static, ()>) -> AbortHandleRef {
         let (send, recv) = oneshot::channel();
         if let Err(e) = self.scheduling.send(SpawnAsync {
@@ -172,24 +172,27 @@ impl BlockingRuntime for SingleThreadRuntime {
     type BlockingIterator<'a, R: 'a> = SingleThreadIterator<'a, R>;
 
     fn handle(&self) -> Handle {
-        Handle::new(self.sender.clone())
+        let executor: Arc<dyn Executor> = self.sender.clone();
+        Handle::new(Arc::downgrade(&executor))
     }
 
-    fn block_on<Fut, R>(&self, fut: Fut) -> R
+    fn block_on<F, Fut, R>(&self, f: F) -> R
     where
+        F: FnOnce(Handle) -> Fut,
         Fut: Future<Output = R>,
     {
-        smol::block_on(self.executor.run(fut))
+        smol::block_on(self.executor.run(f(self.handle())))
     }
 
-    fn block_on_stream<'a, S, R>(&self, stream: S) -> Self::BlockingIterator<'a, R>
+    fn block_on_stream<'a, F, S, R>(&self, f: F) -> Self::BlockingIterator<'a, R>
     where
-        S: Stream<Item = R> + Send + Unpin + 'a,
+        F: FnOnce(Handle) -> S,
+        S: Stream<Item = R> + Send + 'a,
         R: Send + 'a,
     {
         SingleThreadIterator {
             executor: self.executor.clone(),
-            stream: stream.boxed_local(),
+            stream: f(self.handle()).boxed_local(),
         }
     }
 }
@@ -203,9 +206,7 @@ where
     F: FnOnce(Handle) -> Fut,
     Fut: Future<Output = R>,
 {
-    let runtime = SingleThreadRuntime::default();
-    let fut = f(runtime.handle());
-    runtime.block_on(fut)
+    SingleThreadRuntime::default().block_on(f)
 }
 
 /// Returns an iterator wrapper around a stream, blocking the current thread for each item.
@@ -215,9 +216,7 @@ where
     S: Stream<Item = R> + Send + Unpin + 'a,
     R: Send + 'a,
 {
-    let runtime = SingleThreadRuntime::default();
-    let stream = f(runtime.handle());
-    runtime.block_on_stream(stream)
+    SingleThreadRuntime::default().block_on_stream(f)
 }
 
 /// A spawn request for a future.
@@ -281,7 +280,7 @@ mod tests {
 
     #[test]
     fn test_drive_simple_future() {
-        let result = SingleThreadRuntime::default().block_on(async { 123 }.boxed_local());
+        let result = SingleThreadRuntime::default().block_on(|_h| async { 123 }.boxed_local());
         assert_eq!(result, 123);
     }
 

--- a/vortex-io/src/runtime/smol.rs
+++ b/vortex-io/src/runtime/smol.rs
@@ -2,18 +2,19 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use futures::future::BoxFuture;
-use smol::Executor;
 
-use crate::runtime::{AbortHandle, AbortHandleRef, IoTask, Runtime};
+use crate::runtime::{AbortHandle, AbortHandleRef, Executor, IoTask};
 
-impl Runtime for Executor<'static> {
+// NOTE(ngates): we implement this for a Weak reference to adhere to the constraint that this
+//  trait should not hold strong references to the underlying runtime.
+impl Executor for smol::Executor<'static> {
     fn spawn(&self, fut: BoxFuture<'static, ()>) -> AbortHandleRef {
-        SmolAbortHandle::new_handle(self.spawn(fut))
+        SmolAbortHandle::new_handle(smol::Executor::spawn(self, fut))
     }
 
     fn spawn_cpu(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
         // For now, we spawn CPU work back onto the same executor.
-        SmolAbortHandle::new_handle(self.spawn(async move { task() }))
+        SmolAbortHandle::new_handle(smol::Executor::spawn(self, async move { task() }))
     }
 
     fn spawn_blocking(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
@@ -21,7 +22,7 @@ impl Runtime for Executor<'static> {
     }
 
     fn spawn_io(&self, task: IoTask) {
-        self.spawn(task.source.drive_send(task.stream)).detach()
+        smol::Executor::spawn(self, task.source.drive_send(task.stream)).detach()
     }
 }
 

--- a/vortex-io/src/runtime/tests.rs
+++ b/vortex-io/src/runtime/tests.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+#![cfg(feature = "tokio")]
 #![allow(clippy::cast_possible_truncation)]
 
 use std::sync::Arc;
@@ -13,7 +14,7 @@ use tempfile::NamedTempFile;
 use vortex_buffer::{Alignment, ByteBuffer, ByteBufferMut};
 use vortex_error::VortexResult;
 
-use crate::file::{IntoIoSource, IoRequest, IoSource, IoSourceRef};
+use crate::file::{IntoReadSource, IoRequest, ReadSource, ReadSourceRef};
 use crate::runtime::Handle;
 use crate::runtime::single::block_on;
 use crate::runtime::tokio::TokioRuntime;
@@ -221,7 +222,7 @@ struct CountingIoSource {
     read_count: Arc<AtomicUsize>,
 }
 
-impl IoSource for CountingIoSource {
+impl ReadSource for CountingIoSource {
     fn uri(&self) -> &Arc<str> {
         static URI: std::sync::LazyLock<Arc<str>> =
             std::sync::LazyLock::new(|| Arc::from("counting://test"));
@@ -265,8 +266,8 @@ impl IoSource for CountingIoSource {
     }
 }
 
-impl IntoIoSource for CountingIoSource {
-    fn into_io_source(self, _handle: Handle) -> VortexResult<IoSourceRef> {
+impl IntoReadSource for CountingIoSource {
+    fn into_read_source(self, _handle: Handle) -> VortexResult<ReadSourceRef> {
         Ok(Arc::new(self))
     }
 }

--- a/vortex-io/src/runtime/tests.rs
+++ b/vortex-io/src/runtime/tests.rs
@@ -14,7 +14,7 @@ use tempfile::NamedTempFile;
 use vortex_buffer::{Alignment, ByteBuffer, ByteBufferMut};
 use vortex_error::VortexResult;
 
-use crate::file::{IntoReadSource, IoRequest, ReadSource, ReadSourceRef};
+use crate::file::{IntoIoSource, IoRequest, IoSource, IoSourceRef};
 use crate::runtime::Handle;
 use crate::runtime::single::block_on;
 use crate::runtime::tokio::TokioRuntime;
@@ -222,7 +222,7 @@ struct CountingIoSource {
     read_count: Arc<AtomicUsize>,
 }
 
-impl ReadSource for CountingIoSource {
+impl IoSource for CountingIoSource {
     fn uri(&self) -> &Arc<str> {
         static URI: std::sync::LazyLock<Arc<str>> =
             std::sync::LazyLock::new(|| Arc::from("counting://test"));
@@ -266,8 +266,8 @@ impl ReadSource for CountingIoSource {
     }
 }
 
-impl IntoReadSource for CountingIoSource {
-    fn into_read_source(self, _handle: Handle) -> VortexResult<ReadSourceRef> {
+impl IntoIoSource for CountingIoSource {
+    fn into_io_source(self, _handle: Handle) -> VortexResult<IoSourceRef> {
         Ok(Arc::new(self))
     }
 }

--- a/vortex-io/src/runtime/tokio.rs
+++ b/vortex-io/src/runtime/tokio.rs
@@ -4,67 +4,78 @@
 use std::sync::{Arc, LazyLock};
 
 use futures::future::BoxFuture;
-use tokio::runtime::Handle as TokioHandle;
 
-use crate::runtime::{AbortHandle, AbortHandleRef, Handle, IoTask, Runtime};
+use crate::runtime::{AbortHandle, AbortHandleRef, BlockingRuntime, Executor, Handle, IoTask};
 
-/// A Vortex runtime that drives all work the currently scoped Tokio runtime.
-#[allow(dead_code)]
-pub struct TokioRuntime(Arc<TokioHandle>);
+/// A Vortex runtime that drives all work the enclosed Tokio runtime handle.
+pub struct TokioRuntime(Arc<tokio::runtime::Handle>);
 
 impl TokioRuntime {
-    pub fn with(handle: TokioHandle) -> Handle {
-        Handle::new(Arc::new(handle))
+    /// Create a new [`Handle`] that always uses the currently scoped Tokio runtime at the time
+    /// each operation is invoked.
+    pub fn current() -> Handle {
+        static CURRENT: LazyLock<Arc<dyn Executor>> =
+            LazyLock::new(|| Arc::new(CurrentTokioRuntime));
+        Handle::new(Arc::downgrade(&CURRENT))
+    }
+}
+
+impl From<&tokio::runtime::Handle> for TokioRuntime {
+    fn from(value: &tokio::runtime::Handle) -> Self {
+        Self::from(value.clone())
+    }
+}
+
+impl From<tokio::runtime::Handle> for TokioRuntime {
+    fn from(value: tokio::runtime::Handle) -> Self {
+        TokioRuntime(Arc::new(value))
+    }
+}
+
+impl Executor for tokio::runtime::Handle {
+    fn spawn(&self, fut: BoxFuture<'static, ()>) -> AbortHandleRef {
+        Box::new(tokio::runtime::Handle::spawn(self, fut).abort_handle())
     }
 
-    /// Return the current Tokio runtime handle wrapped in a Vortex handle.
-    pub fn current() -> Handle {
-        static CURRENT: LazyLock<Arc<CurrentTokioRuntime>> =
-            LazyLock::new(|| Arc::new(CurrentTokioRuntime));
-        Handle::new(CURRENT.clone())
+    fn spawn_cpu(&self, cpu: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
+        Box::new(tokio::runtime::Handle::spawn(self, async move { cpu() }).abort_handle())
+    }
+
+    fn spawn_blocking(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
+        Box::new(tokio::runtime::Handle::spawn_blocking(self, task).abort_handle())
+    }
+
+    fn spawn_io(&self, task: IoTask) {
+        tokio::runtime::Handle::spawn(self, task.source.drive_send(task.stream));
     }
 }
 
 /// A runtime implementation that grabs the current Tokio runtime handle on each call.
 struct CurrentTokioRuntime;
 
-impl Runtime for CurrentTokioRuntime {
+impl Executor for CurrentTokioRuntime {
     fn spawn(&self, fut: BoxFuture<'static, ()>) -> AbortHandleRef {
-        Box::new(TokioHandle::current().spawn(fut).abort_handle())
+        Box::new(tokio::runtime::Handle::current().spawn(fut).abort_handle())
     }
 
     fn spawn_cpu(&self, cpu: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
         Box::new(
-            TokioHandle::current()
+            tokio::runtime::Handle::current()
                 .spawn(async move { cpu() })
                 .abort_handle(),
         )
     }
 
     fn spawn_blocking(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
-        Box::new(TokioHandle::current().spawn_blocking(task).abort_handle())
+        Box::new(
+            tokio::runtime::Handle::current()
+                .spawn_blocking(task)
+                .abort_handle(),
+        )
     }
 
     fn spawn_io(&self, task: IoTask) {
-        TokioHandle::current().spawn(task.source.drive_send(task.stream));
-    }
-}
-
-impl Runtime for TokioHandle {
-    fn spawn(&self, fut: BoxFuture<'static, ()>) -> AbortHandleRef {
-        Box::new(TokioHandle::spawn(self, fut).abort_handle())
-    }
-
-    fn spawn_cpu(&self, cpu: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
-        Box::new(TokioHandle::spawn(self, async move { cpu() }).abort_handle())
-    }
-
-    fn spawn_blocking(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
-        Box::new(TokioHandle::spawn_blocking(self, task).abort_handle())
-    }
-
-    fn spawn_io(&self, task: IoTask) {
-        TokioHandle::spawn(self, task.source.drive_send(task.stream));
+        tokio::runtime::Handle::current().spawn(task.source.drive_send(task.stream));
     }
 }
 
@@ -75,46 +86,49 @@ impl AbortHandle for tokio::task::AbortHandle {
 }
 
 // We depend on Tokio's rt-multi-thread feature for block-in-place
-#[cfg(feature = "tokio")]
-impl crate::runtime::BlockingRuntime for TokioRuntime {
+impl BlockingRuntime for TokioRuntime {
     type BlockingIterator<'a, R: 'a> = TokioBlockingIterator<'a, R>;
 
     fn handle(&self) -> Handle {
-        Handle::new(self.0.clone())
+        let executor: Arc<dyn Executor> = self.0.clone();
+        Handle::new(Arc::downgrade(&executor))
     }
 
-    fn block_on<Fut, R>(&self, fut: Fut) -> R
+    fn block_on<F, Fut, R>(&self, f: F) -> R
     where
+        F: FnOnce(Handle) -> Fut,
         Fut: Future<Output = R>,
     {
         // Assert that we're not currently inside the Tokio context.
-        if TokioHandle::try_current().is_ok() {
+        if tokio::runtime::Handle::try_current().is_ok() {
             vortex_error::vortex_panic!("block_on cannot be called from within a Tokio runtime");
         }
         let handle = self.0.clone();
+        let fut = f(self.handle());
         tokio::task::block_in_place(move || handle.block_on(fut))
     }
 
-    fn block_on_stream<'a, S, R>(&self, stream: S) -> Self::BlockingIterator<'a, R>
+    fn block_on_stream<'a, F, S, R>(&self, f: F) -> Self::BlockingIterator<'a, R>
     where
-        S: futures::Stream<Item = R> + Send + Unpin + 'a,
+        F: FnOnce(Handle) -> S,
+        S: futures::Stream<Item = R> + Send + 'a,
         R: Send + 'a,
     {
         // Assert that we're not currently inside the Tokio context.
-        if TokioHandle::try_current().is_ok() {
+        if tokio::runtime::Handle::try_current().is_ok() {
             vortex_error::vortex_panic!(
                 "block_on_stream cannot be called from within a Tokio runtime"
             );
         }
         let handle = self.0.clone();
-        let stream = Box::pin(stream);
+        let stream = Box::pin(f(self.handle()));
         TokioBlockingIterator { handle, stream }
     }
 }
 
 #[cfg(feature = "tokio")]
 pub struct TokioBlockingIterator<'a, T> {
-    handle: Arc<TokioHandle>,
+    handle: Arc<tokio::runtime::Handle>,
     stream: futures::stream::BoxStream<'a, T>,
 }
 
@@ -135,7 +149,6 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use futures::FutureExt;
-    use futures::executor::block_on;
     use tokio::runtime::Runtime as TokioRt;
 
     use super::*;
@@ -143,18 +156,20 @@ mod tests {
     #[test]
     fn test_spawn_simple_future() {
         let tokio_rt = TokioRt::new().unwrap();
-        let handle = TokioRuntime::with(tokio_rt.handle().clone());
-        let result = block_on(handle.spawn(async {
-            let fut = async { 77 };
-            fut.await
-        }));
+        let runtime = TokioRuntime::from(tokio_rt.handle());
+        let result = runtime.block_on(|h| {
+            h.spawn(async {
+                let fut = async { 77 };
+                fut.await
+            })
+        });
         assert_eq!(result, 77);
     }
 
     #[test]
     fn test_spawn_and_abort() {
         let tokio_rt = TokioRt::new().unwrap();
-        let handle = TokioRuntime::with(tokio_rt.handle().clone());
+        let runtime = TokioRuntime::from(tokio_rt.handle());
 
         let counter = Arc::new(AtomicUsize::new(0));
         let c = counter.clone();
@@ -166,7 +181,7 @@ mod tests {
             let _ = recv.await;
             c.fetch_add(1, Ordering::SeqCst);
         };
-        let task = handle.spawn(fut.boxed());
+        let task = runtime.handle().spawn(fut.boxed());
         drop(task);
 
         // Now we release the channel to let the future proceed if it wasn't aborted

--- a/vortex-io/src/runtime/wasm.rs
+++ b/vortex-io/src/runtime/wasm.rs
@@ -13,9 +13,9 @@ pub struct WasmRuntime;
 
 impl WasmRuntime {
     pub fn handle() -> Handle {
-        static RUNTIME: LazyLock<Arc<WasmRuntime>> = LazyLock::new(|| Arc::new(WasmRuntime));
+        static RUNTIME: LazyLock<Arc<dyn Executor>> = LazyLock::new(|| Arc::new(WasmRuntime));
 
-        Handle::new(RUNTIME.clone())
+        Handle::new(Arc::downgrade(&RUNTIME))
     }
 }
 

--- a/vortex-io/src/runtime/wasm.rs
+++ b/vortex-io/src/runtime/wasm.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, LazyLock};
 use futures::future::BoxFuture;
 use wasm_bindgen_futures::spawn_local;
 
-use crate::runtime::{AbortHandle, AbortHandleRef, Handle, IoTask, Runtime};
+use crate::runtime::{AbortHandle, AbortHandleRef, Executor, Handle, IoTask};
 
 /// A Vortex runtime that drives work in a WebAssembly environment.
 pub struct WasmRuntime;
@@ -19,7 +19,7 @@ impl WasmRuntime {
     }
 }
 
-impl Runtime for WasmRuntime {
+impl Executor for WasmRuntime {
     fn spawn(&self, fut: BoxFuture<'static, ()>) -> AbortHandleRef {
         spawn_local(fut);
         Box::new(NoOpAbortHandle)

--- a/vortex-layout/Cargo.toml
+++ b/vortex-layout/Cargo.toml
@@ -56,7 +56,7 @@ vortex-zstd = { workspace = true, optional = true }
 futures = { workspace = true, features = ["executor"] }
 rstest = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
-vortex-layout = { path = ".", features = ["tokio", "test-harness"] }
+vortex-io = { path = "../vortex-io", features = ["tokio"] }
 
 [features]
 test-harness = []

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -212,7 +212,7 @@ mod tests {
     use vortex_array::{ArrayContext, IntoArray as _};
     use vortex_dtype::{DType, FieldName, FieldNames, Nullability};
     use vortex_expr::{is_null, not, pack, root};
-    use vortex_io::runtime::tokio::TokioRuntime;
+    use vortex_io::runtime::single::block_on;
 
     use crate::layouts::dict::writer::{DictLayoutOptions, DictStrategy};
     use crate::layouts::flat::writer::FlatLayoutStrategy;
@@ -222,90 +222,92 @@ mod tests {
     };
     use crate::{LayoutId, LayoutRef, LayoutStrategy};
 
-    #[tokio::test]
-    async fn reading_nested_packs_works() {
-        let strategy = DictStrategy::new(
-            FlatLayoutStrategy::default(),
-            FlatLayoutStrategy::default(),
-            FlatLayoutStrategy::default(),
-            DictLayoutOptions::default(),
-        );
+    #[test]
+    fn reading_nested_packs_works() {
+        block_on(|handle| async move {
+            let strategy = DictStrategy::new(
+                FlatLayoutStrategy::default(),
+                FlatLayoutStrategy::default(),
+                FlatLayoutStrategy::default(),
+                DictLayoutOptions::default(),
+            );
 
-        let array = VarBinArray::from_iter(
-            [
-                Some("abc"),
-                Some("def"),
-                None,
-                Some("abc"),
-                Some("def"),
-                None,
-                Some("abc"),
-                Some("def"),
-                None,
-            ],
-            DType::Utf8(Nullability::Nullable),
-        )
-        .to_array();
-        let array_to_write = array.clone();
-        let ctx = ArrayContext::empty();
-        let segments = Arc::new(TestSegments::default());
-        let (ptr, eof) = SequenceId::root().split();
-        let layout: LayoutRef = strategy
-            .write_stream(
-                ctx,
-                segments.clone(),
-                SequentialStreamAdapter::new(
-                    DType::Utf8(Nullability::Nullable),
-                    array_to_write.to_array_stream().sequenced(ptr),
+            let array = VarBinArray::from_iter(
+                [
+                    Some("abc"),
+                    Some("def"),
+                    None,
+                    Some("abc"),
+                    Some("def"),
+                    None,
+                    Some("abc"),
+                    Some("def"),
+                    None,
+                ],
+                DType::Utf8(Nullability::Nullable),
+            )
+            .to_array();
+            let array_to_write = array.clone();
+            let ctx = ArrayContext::empty();
+            let segments = Arc::new(TestSegments::default());
+            let (ptr, eof) = SequenceId::root().split();
+            let layout: LayoutRef = strategy
+                .write_stream(
+                    ctx,
+                    segments.clone(),
+                    SequentialStreamAdapter::new(
+                        DType::Utf8(Nullability::Nullable),
+                        array_to_write.to_array_stream().sequenced(ptr),
+                    )
+                    .sendable(),
+                    eof,
+                    handle,
                 )
-                .sendable(),
-                eof,
-                TokioRuntime::current(),
-            )
-            .await
-            .unwrap();
+                .await
+                .unwrap();
 
-        let expression = pack(
-            [(
-                "top",
-                pack([("one", root()), ("two", root())], Nullability::NonNullable),
-            )],
-            Nullability::NonNullable,
-        );
-        assert!(layout.encoding_id() == LayoutId::new_ref("vortex.dict"));
-        let actual = layout
-            .new_reader("".into(), segments)
-            .unwrap()
-            .projection_evaluation(
-                &(0..layout.row_count()),
-                &expression,
-                MaskFuture::new_true(layout.row_count().try_into().unwrap()),
-            )
-            .unwrap()
-            .await
-            .unwrap();
-        let expected = StructArray::try_new(
-            FieldNames::from([FieldName::from("top")]),
-            vec![
-                StructArray::try_new(
-                    FieldNames::from([FieldName::from("one"), FieldName::from("two")]),
-                    vec![array.clone(), array],
-                    9,
-                    Validity::NonNullable,
+            let expression = pack(
+                [(
+                    "top",
+                    pack([("one", root()), ("two", root())], Nullability::NonNullable),
+                )],
+                Nullability::NonNullable,
+            );
+            assert!(layout.encoding_id() == LayoutId::new_ref("vortex.dict"));
+            let actual = layout
+                .new_reader("".into(), segments)
+                .unwrap()
+                .projection_evaluation(
+                    &(0..layout.row_count()),
+                    &expression,
+                    MaskFuture::new_true(layout.row_count().try_into().unwrap()),
                 )
                 .unwrap()
-                .into_array(),
-            ],
-            9,
-            Validity::NonNullable,
-        )
-        .unwrap()
-        .into_array();
-        let actual = actual.into_arrow_preferred().unwrap();
-        let expected_arrow_dtype = expected.dtype().to_arrow_dtype().unwrap();
-        let expected = expected.into_arrow(&expected_arrow_dtype).unwrap();
-        assert_eq!(actual.data_type(), expected.data_type());
-        assert_eq!(&actual, &expected);
+                .await
+                .unwrap();
+            let expected = StructArray::try_new(
+                FieldNames::from([FieldName::from("top")]),
+                vec![
+                    StructArray::try_new(
+                        FieldNames::from([FieldName::from("one"), FieldName::from("two")]),
+                        vec![array.clone(), array],
+                        9,
+                        Validity::NonNullable,
+                    )
+                    .unwrap()
+                    .into_array(),
+                ],
+                9,
+                Validity::NonNullable,
+            )
+            .unwrap()
+            .into_array();
+            let actual = actual.into_arrow_preferred().unwrap();
+            let expected_arrow_dtype = expected.dtype().to_arrow_dtype().unwrap();
+            let expected = expected.into_arrow(&expected_arrow_dtype).unwrap();
+            assert_eq!(actual.data_type(), expected.data_type());
+            assert_eq!(&actual, &expected);
+        })
     }
 
     #[rstest]
@@ -319,120 +321,124 @@ mod tests {
         "", // Filter for empty string
         vec![false, false, false], // Expected: all false, no dict values match
     )]
-    #[tokio::test]
-    async fn shortpathes_filtering(
+    #[test]
+    fn shortpathes_filtering(
         #[case] data: Vec<Option<&str>>,
         #[case] filter_value: &str,
         #[case] expected: Vec<bool>,
     ) {
-        let strategy = DictStrategy::new(
-            FlatLayoutStrategy::default(),
-            FlatLayoutStrategy::default(),
-            FlatLayoutStrategy::default(),
-            DictLayoutOptions::default(),
-        );
+        block_on(|handle| async move {
+            let strategy = DictStrategy::new(
+                FlatLayoutStrategy::default(),
+                FlatLayoutStrategy::default(),
+                FlatLayoutStrategy::default(),
+                DictLayoutOptions::default(),
+            );
 
-        let array = VarBinArray::from_iter(data, DType::Utf8(Nullability::Nullable)).to_array();
+            let array = VarBinArray::from_iter(data, DType::Utf8(Nullability::Nullable)).to_array();
 
-        let ctx = ArrayContext::empty();
-        let segments = Arc::new(TestSegments::default());
-        let (ptr, eof) = SequenceId::root().split();
-        let layout: LayoutRef = strategy
-            .write_stream(
-                ctx,
-                segments.clone(),
-                SequentialStreamAdapter::new(
-                    DType::Utf8(Nullability::Nullable),
-                    array.to_array_stream().sequenced(ptr),
+            let ctx = ArrayContext::empty();
+            let segments = Arc::new(TestSegments::default());
+            let (ptr, eof) = SequenceId::root().split();
+            let layout: LayoutRef = strategy
+                .write_stream(
+                    ctx,
+                    segments.clone(),
+                    SequentialStreamAdapter::new(
+                        DType::Utf8(Nullability::Nullable),
+                        array.to_array_stream().sequenced(ptr),
+                    )
+                    .sendable(),
+                    eof,
+                    handle,
                 )
-                .sendable(),
-                eof,
-                TokioRuntime::current(),
-            )
-            .await
-            .unwrap();
+                .await
+                .unwrap();
 
-        let filter = vortex_expr::eq(
-            root(),
-            vortex_expr::lit(vortex_scalar::Scalar::utf8(
-                filter_value,
-                Nullability::Nullable,
-            )),
-        );
-        let mask = layout
-            .new_reader("".into(), segments)
-            .unwrap()
-            .filter_evaluation(&(0..3), &filter, MaskFuture::new_true(3))
-            .unwrap()
-            .await
-            .unwrap();
+            let filter = vortex_expr::eq(
+                root(),
+                vortex_expr::lit(vortex_scalar::Scalar::utf8(
+                    filter_value,
+                    Nullability::Nullable,
+                )),
+            );
+            let mask = layout
+                .new_reader("".into(), segments)
+                .unwrap()
+                .filter_evaluation(&(0..3), &filter, MaskFuture::new_true(3))
+                .unwrap()
+                .await
+                .unwrap();
 
-        assert_eq!(
-            mask.to_boolean_buffer().iter().collect::<Vec<_>>(),
-            expected
-        );
+            assert_eq!(
+                mask.to_boolean_buffer().iter().collect::<Vec<_>>(),
+                expected
+            );
+        })
     }
 
-    #[tokio::test]
-    async fn reading_is_null_works() {
-        let strategy = DictStrategy::new(
-            FlatLayoutStrategy::default(),
-            FlatLayoutStrategy::default(),
-            FlatLayoutStrategy::default(),
-            DictLayoutOptions::default(),
-        );
+    #[test]
+    fn reading_is_null_works() {
+        block_on(|handle| async move {
+            let strategy = DictStrategy::new(
+                FlatLayoutStrategy::default(),
+                FlatLayoutStrategy::default(),
+                FlatLayoutStrategy::default(),
+                DictLayoutOptions::default(),
+            );
 
-        let array = VarBinArray::from_iter(
-            [
-                Some("abc"),
-                Some("def"),
-                None,
-                Some("abc"),
-                Some("def"),
-                None,
-                Some("abc"),
-                Some("def"),
-                None,
-            ],
-            DType::Utf8(Nullability::Nullable),
-        )
-        .to_array();
-        let array_to_write = array.clone();
-        let ctx = ArrayContext::empty();
-        let segments = Arc::new(TestSegments::default());
-        let (ptr, eof) = SequenceId::root().split();
-        let layout: LayoutRef = strategy
-            .write_stream(
-                ctx,
-                segments.clone(),
-                SequentialStreamAdapter::new(
-                    DType::Utf8(Nullability::Nullable),
-                    array_to_write.to_array_stream().sequenced(ptr),
+            let array = VarBinArray::from_iter(
+                [
+                    Some("abc"),
+                    Some("def"),
+                    None,
+                    Some("abc"),
+                    Some("def"),
+                    None,
+                    Some("abc"),
+                    Some("def"),
+                    None,
+                ],
+                DType::Utf8(Nullability::Nullable),
+            )
+            .to_array();
+            let array_to_write = array.clone();
+            let ctx = ArrayContext::empty();
+            let segments = Arc::new(TestSegments::default());
+            let (ptr, eof) = SequenceId::root().split();
+            let layout: LayoutRef = strategy
+                .write_stream(
+                    ctx,
+                    segments.clone(),
+                    SequentialStreamAdapter::new(
+                        DType::Utf8(Nullability::Nullable),
+                        array_to_write.to_array_stream().sequenced(ptr),
+                    )
+                    .sendable(),
+                    eof,
+                    handle,
                 )
-                .sendable(),
-                eof,
-                TokioRuntime::current(),
-            )
-            .await
-            .unwrap();
+                .await
+                .unwrap();
 
-        let expression = not(is_null(root())); // easier to test not_is_null b/c that's the validity array
-        assert!(layout.encoding_id() == LayoutId::new_ref("vortex.dict"));
-        let actual = layout
-            .new_reader("".into(), segments)
-            .unwrap()
-            .projection_evaluation(
-                &(0..layout.row_count()),
-                &expression,
-                MaskFuture::new_true(layout.row_count().try_into().unwrap()),
-            )
-            .unwrap()
-            .await
-            .unwrap();
-        let expected = array.validity_mask().into_array();
-        let actual = actual.into_arrow_preferred().unwrap();
-        let expected = expected.into_arrow_preferred().unwrap();
-        assert_eq!(actual.data_type(), expected.data_type());
-        assert_eq!(&actual, &expected);
+            let expression = not(is_null(root())); // easier to test not_is_null b/c that's the validity array
+            assert!(layout.encoding_id() == LayoutId::new_ref("vortex.dict"));
+            let actual = layout
+                .new_reader("".into(), segments)
+                .unwrap()
+                .projection_evaluation(
+                    &(0..layout.row_count()),
+                    &expression,
+                    MaskFuture::new_true(layout.row_count().try_into().unwrap()),
+                )
+                .unwrap()
+                .await
+                .unwrap();
+            let expected = array.validity_mask().into_array();
+            let actual = actual.into_arrow_preferred().unwrap();
+            let expected = expected.into_arrow_preferred().unwrap();
+            assert_eq!(actual.data_type(), expected.data_type());
+            assert_eq!(&actual, &expected);
+        })
     }
 }


### PR DESCRIPTION
This fixes a problem where we can spawn a task that holds onto handle (since it has a static lifetime, ergh) can keep a runtime alive even after the caller drops it. For futures that use channels, e.g. the FileRead I/O, this results in read futures that hang forever when the runtime is dropped (because the executor holds the pending recv end of the channel, and the executor is kept alive by the send end of the channel...)

We also impl BlockingRuntime for CurrentThreadRuntime as this will likely become the default runtime for language bindings to use.