### PR TITLE
Remove pending segments in favor of weak futures

### DIFF
--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -5,8 +5,9 @@ use std::collections::BTreeSet;
 use std::ops::{BitAnd, Range};
 use std::sync::Arc;
 
-use futures::FutureExt;
-use futures::future::BoxFuture;
+use futures::future::{BoxFuture, WeakShared};
+use futures::{FutureExt, TryFutureExt};
+use parking_lot::Mutex;
 use vortex_array::compute::filter;
 use vortex_array::pipeline::operators::MaskFuture;
 use vortex_array::pipeline::{
@@ -15,8 +16,9 @@ use vortex_array::pipeline::{
 use vortex_array::serde::ArrayParts;
 use vortex_array::stats::Precision;
 use vortex_array::{Array, ArrayRef, IntoArray};
+use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, FieldMask, Nullability};
-use vortex_error::{VortexExpect, VortexResult, VortexUnwrap as _};
+use vortex_error::{SharedVortexResult, VortexExpect, VortexResult, VortexUnwrap as _};
 use vortex_expr::{ExprRef, Scope, VortexExprExt, is_root};
 use vortex_mask::Mask;
 
@@ -36,6 +38,10 @@ pub struct FlatReader {
     layout: FlatLayout,
     name: Arc<str>,
     segment_source: Arc<dyn SegmentSource>,
+
+    // We use a weak shared future to avoid submitting multiple read requests for the same
+    // flat layout when used from multiple evaluations.
+    future: Mutex<Option<WeakShared<BoxFuture<'static, SharedVortexResult<ByteBuffer>>>>>,
 }
 
 impl FlatReader {
@@ -48,6 +54,7 @@ impl FlatReader {
             layout,
             name,
             segment_source,
+            future: Mutex::new(None),
         }
     }
 
@@ -58,12 +65,30 @@ impl FlatReader {
         // We create the segment_fut here to ensure we give the segment reader visibility into
         // how to prioritize this segment, even if the `array` future has already been initialized.
         // This is gross... see the function's TODO for a maybe better solution?
-        let segment_fut = self.segment_source.request(self.layout.segment_id());
+        let segment_future = {
+            let mut future = self.future.lock();
+            if let Some(upgraded) = future.as_ref().and_then(|f| f.upgrade()) {
+                upgraded
+            } else {
+                let new_future = self
+                    .segment_source
+                    .request(self.layout.segment_id())
+                    .map_err(Arc::new)
+                    .boxed()
+                    .shared();
+                *future = Some(
+                    new_future
+                        .downgrade()
+                        .vortex_expect("not yet polled to completion"),
+                );
+                new_future
+            }
+        };
 
         let ctx = self.layout.ctx.clone();
         let dtype = self.layout.dtype().clone();
         async move {
-            let segment = segment_fut.await?;
+            let segment = segment_future.await?;
             ArrayParts::try_from(segment)?
                 .decode(&ctx, &dtype, row_count)
                 .map_err(Arc::new)

--- a/vortex-layout/src/segments/events.rs
+++ b/vortex-layout/src/segments/events.rs
@@ -8,11 +8,12 @@ use std::sync::{Arc, atomic};
 use std::task::{Context, Poll};
 
 use futures::channel::{mpsc, oneshot};
-use futures::future::BoxFuture;
+use futures::future::{BoxFuture, Shared, WeakShared};
 use futures::stream::BoxStream;
 use futures::{FutureExt, StreamExt, TryFutureExt};
 use vortex_buffer::ByteBuffer;
-use vortex_error::{SharedVortexResult, VortexError, VortexResult, vortex_err};
+use vortex_error::{SharedVortexResult, VortexError, VortexExpect, VortexResult, vortex_err};
+use vortex_utils::aliases::dash_map::{DashMap, Entry};
 
 use crate::segments::{SegmentFuture, SegmentId, SegmentSource};
 
@@ -21,6 +22,7 @@ use crate::segments::{SegmentFuture, SegmentId, SegmentSource};
 /// Also performs de-duplication of requests for the same segment, while tracking when the all
 /// requesters have been dropped.
 pub struct SegmentEvents {
+    pending: DashMap<SegmentId, PendingSegment>,
     events: mpsc::UnboundedSender<SegmentEvent>,
 }
 
@@ -28,7 +30,10 @@ impl SegmentEvents {
     pub fn create() -> (Arc<dyn SegmentSource>, BoxStream<'static, SegmentEvent>) {
         let (send, recv) = mpsc::unbounded();
 
-        let events = Arc::new(Self { events: send });
+        let events = Arc::new(Self {
+            pending: Default::default(),
+            events: send,
+        });
 
         let source = Arc::new(EventsSegmentSource { events });
         let stream = recv.boxed();
@@ -84,9 +89,33 @@ impl SegmentRequest {
 }
 
 impl SegmentEvents {
-    /// Create a segment future for the given segment ID.
-    fn segment_future(self: Arc<Self>, id: SegmentId) -> SegmentEventsFuture {
-        SegmentEventsFuture::new(id, self)
+    /// Get or create a segment future for the given segment ID.
+    fn segment_future(self: Arc<Self>, id: SegmentId) -> Shared<SegmentEventsFuture> {
+        loop {
+            // Loop in case the pending future has no strong references, in which case we clear it
+            // out of the map and create a new one on the next iteration.
+            match self.pending.entry(id) {
+                Entry::Occupied(e) => {
+                    if let Some(fut) = e.get().future() {
+                        return fut;
+                    } else {
+                        log::debug!("Re-requesting dropped segment from segment reader {id}");
+                        e.remove();
+                    }
+                }
+                Entry::Vacant(e) => {
+                    let fut = SegmentEventsFuture::new(id, self.clone()).shared();
+                    // Create a new pending segment with a weak reference to the future.
+                    e.insert(PendingSegment {
+                        id,
+                        fut: fut
+                            .downgrade()
+                            .vortex_expect("cannot fail, only just created"),
+                    });
+                    return fut;
+                }
+            }
+        }
     }
 
     /// Submit a segment event.
@@ -108,6 +137,30 @@ impl SegmentSource for EventsSegmentSource {
             .segment_future(id)
             .map_err(VortexError::from)
             .boxed()
+    }
+}
+
+/// A pending segment returned by the [`SegmentSource`].
+struct PendingSegment {
+    id: SegmentId,
+    /// A weak shared future that we hand out to all requesters. Once all requesters have been
+    /// dropped, typically because their row split has completed (or been pruned), then the weak
+    /// future is no longer upgradable, and the segment can be dropped.
+    fut: WeakShared<SegmentEventsFuture>,
+}
+
+impl Debug for PendingSegment {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PendingSegment")
+            .field("id", &self.id)
+            .finish()
+    }
+}
+
+impl PendingSegment {
+    /// Create a new future resolving this segment, provided the segment is still alive.
+    fn future(&self) -> Option<Shared<SegmentEventsFuture>> {
+        self.fut.upgrade()
     }
 }
 

--- a/vortex-layout/src/segments/events.rs
+++ b/vortex-layout/src/segments/events.rs
@@ -8,12 +8,11 @@ use std::sync::{Arc, atomic};
 use std::task::{Context, Poll};
 
 use futures::channel::{mpsc, oneshot};
-use futures::future::{BoxFuture, Shared, WeakShared};
+use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 use futures::{FutureExt, StreamExt, TryFutureExt};
 use vortex_buffer::ByteBuffer;
-use vortex_error::{SharedVortexResult, VortexError, VortexExpect, VortexResult, vortex_err};
-use vortex_utils::aliases::dash_map::{DashMap, Entry};
+use vortex_error::{SharedVortexResult, VortexError, VortexResult, vortex_err};
 
 use crate::segments::{SegmentFuture, SegmentId, SegmentSource};
 
@@ -22,7 +21,6 @@ use crate::segments::{SegmentFuture, SegmentId, SegmentSource};
 /// Also performs de-duplication of requests for the same segment, while tracking when the all
 /// requesters have been dropped.
 pub struct SegmentEvents {
-    pending: DashMap<SegmentId, PendingSegment>,
     events: mpsc::UnboundedSender<SegmentEvent>,
 }
 
@@ -30,10 +28,7 @@ impl SegmentEvents {
     pub fn create() -> (Arc<dyn SegmentSource>, BoxStream<'static, SegmentEvent>) {
         let (send, recv) = mpsc::unbounded();
 
-        let events = Arc::new(Self {
-            pending: Default::default(),
-            events: send,
-        });
+        let events = Arc::new(Self { events: send });
 
         let source = Arc::new(EventsSegmentSource { events });
         let stream = recv.boxed();
@@ -89,33 +84,9 @@ impl SegmentRequest {
 }
 
 impl SegmentEvents {
-    /// Get or create a segment future for the given segment ID.
-    fn segment_future(self: Arc<Self>, id: SegmentId) -> Shared<SegmentEventsFuture> {
-        loop {
-            // Loop in case the pending future has no strong references, in which case we clear it
-            // out of the map and create a new one on the next iteration.
-            match self.pending.entry(id) {
-                Entry::Occupied(e) => {
-                    if let Some(fut) = e.get().future() {
-                        return fut;
-                    } else {
-                        log::debug!("Re-requesting dropped segment from segment reader {id}");
-                        e.remove();
-                    }
-                }
-                Entry::Vacant(e) => {
-                    let fut = SegmentEventsFuture::new(id, self.clone()).shared();
-                    // Create a new pending segment with a weak reference to the future.
-                    e.insert(PendingSegment {
-                        id,
-                        fut: fut
-                            .downgrade()
-                            .vortex_expect("cannot fail, only just created"),
-                    });
-                    return fut;
-                }
-            }
-        }
+    /// Create a segment future for the given segment ID.
+    fn segment_future(self: Arc<Self>, id: SegmentId) -> SegmentEventsFuture {
+        SegmentEventsFuture::new(id, self)
     }
 
     /// Submit a segment event.
@@ -137,30 +108,6 @@ impl SegmentSource for EventsSegmentSource {
             .segment_future(id)
             .map_err(VortexError::from)
             .boxed()
-    }
-}
-
-/// A pending segment returned by the [`SegmentSource`].
-struct PendingSegment {
-    id: SegmentId,
-    /// A weak shared future that we hand out to all requesters. Once all requesters have been
-    /// dropped, typically because their row split has completed (or been pruned), then the weak
-    /// future is no longer upgradable, and the segment can be dropped.
-    fut: WeakShared<SegmentEventsFuture>,
-}
-
-impl Debug for PendingSegment {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PendingSegment")
-            .field("id", &self.id)
-            .finish()
-    }
-}
-
-impl PendingSegment {
-    /// Create a new future resolving this segment, provided the segment is still alive.
-    fn future(&self) -> Option<Shared<SegmentEventsFuture>> {
-        self.fut.upgrade()
     }
 }
 


### PR DESCRIPTION
We made a change to remove shared futures from the layout readers, and this had little to no impact on performance @onursatici - the reason was our segment source was performing internal de-duplicating of segment requests.

It's nicer I think for the dedupe logic to happen in the scan / layout reader explicitly, rather than relying on different segment sources to implement this logic.

Prep work for https://github.com/vortex-data/vortex/pull/4626