### PR TITLE
Explicitly register wall kernels in compute vtables in benchmarks

### DIFF
--- a/encodings/alp/benches/alp_compress.rs
+++ b/encodings/alp/benches/alp_compress.rs
@@ -8,11 +8,13 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng as _};
 use vortex_alp::{ALPFloat, ALPRDFloat, RDEncoder, alp_encode};
 use vortex_array::arrays::PrimitiveArray;
+use vortex_array::compute::warm_up_vtables;
 use vortex_array::validity::Validity;
 use vortex_buffer::buffer;
 use vortex_dtype::NativePType;
 
 fn main() {
+    warm_up_vtables();
     divan::main();
 }
 

--- a/encodings/dict/benches/chunked_dict_array_builder.rs
+++ b/encodings/dict/benches/chunked_dict_array_builder.rs
@@ -5,11 +5,13 @@ use divan::Bencher;
 use rand::distr::{Distribution, StandardUniform};
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::builders::builder_with_capacity;
+use vortex_array::compute::warm_up_vtables;
 use vortex_array::{Array, ArrayRef, IntoArray};
 use vortex_dict::test::{gen_dict_fsst_test_data, gen_dict_primitive_chunks};
 use vortex_dtype::NativePType;
 
 fn main() {
+    warm_up_vtables();
     divan::main();
 }
 

--- a/encodings/dict/benches/dict_compare.rs
+++ b/encodings/dict/benches/dict_compare.rs
@@ -7,11 +7,12 @@ use std::str::from_utf8;
 
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::{ConstantArray, VarBinArray, VarBinViewArray};
-use vortex_array::compute::{Operator, compare};
+use vortex_array::compute::{Operator, compare, warm_up_vtables};
 use vortex_dict::builders::dict_encode;
 use vortex_dict::test::{gen_primitive_for_dict, gen_varbin_words};
 
 fn main() {
+    warm_up_vtables();
     divan::main();
 }
 

--- a/encodings/dict/benches/dict_compress.rs
+++ b/encodings/dict/benches/dict_compress.rs
@@ -6,11 +6,13 @@
 use divan::Bencher;
 use rand::distr::{Distribution, StandardUniform};
 use vortex_array::arrays::{VarBinArray, VarBinViewArray};
+use vortex_array::compute::warm_up_vtables;
 use vortex_dict::builders::dict_encode;
 use vortex_dict::test::{gen_primitive_for_dict, gen_varbin_words};
 use vortex_dtype::NativePType;
 
 fn main() {
+    warm_up_vtables();
     divan::main();
 }
 

--- a/encodings/dict/benches/dict_mask.rs
+++ b/encodings/dict/benches/dict_mask.rs
@@ -8,11 +8,12 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use vortex_array::IntoArray;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::compute::mask;
+use vortex_array::compute::{mask, warm_up_vtables};
 use vortex_dict::DictArray;
 use vortex_mask::Mask;
 
 fn main() {
+    warm_up_vtables();
     divan::main();
 }
 

--- a/encodings/fastlanes/benches/bitpacking_decompress_selection.rs
+++ b/encodings/fastlanes/benches/bitpacking_decompress_selection.rs
@@ -12,7 +12,7 @@ use divan::Bencher;
 use rand::rngs::StdRng;
 use rand::{Rng as _, SeedableRng as _};
 use vortex_array::arrays::BooleanBuffer;
-use vortex_array::compute::filter;
+use vortex_array::compute::{filter, warm_up_vtables};
 use vortex_array::{Array, IntoArray as _, ToCanonical};
 use vortex_buffer::BufferMut;
 use vortex_dtype::NativePType;
@@ -20,6 +20,7 @@ use vortex_fastlanes::bitpack_to_best_bit_width;
 use vortex_mask::Mask;
 
 fn main() {
+    warm_up_vtables();
     divan::main();
 }
 

--- a/encodings/fastlanes/benches/bitpacking_take.rs
+++ b/encodings/fastlanes/benches/bitpacking_take.rs
@@ -10,12 +10,13 @@ use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng, rng};
 use vortex_array::IntoArray as _;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::compute::take;
+use vortex_array::compute::{take, warm_up_vtables};
 use vortex_array::validity::Validity;
 use vortex_buffer::{Buffer, buffer};
 use vortex_fastlanes::bitpack_to_best_bit_width;
 
 fn main() {
+    warm_up_vtables();
     divan::main();
 }
 

--- a/encodings/fastlanes/benches/canonicalize_bench.rs
+++ b/encodings/fastlanes/benches/canonicalize_bench.rs
@@ -6,11 +6,13 @@ use rand::SeedableRng;
 use rand::prelude::StdRng;
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::builders::{ArrayBuilder, PrimitiveBuilder};
+use vortex_array::compute::warm_up_vtables;
 use vortex_array::{Array, IntoArray};
 use vortex_error::VortexExpect;
 use vortex_fastlanes::test_harness::make_array;
 
 fn main() {
+    warm_up_vtables();
     divan::main();
 }
 

--- a/encodings/fastlanes/benches/compute_between.rs
+++ b/encodings/fastlanes/benches/compute_between.rs
@@ -6,12 +6,14 @@ use rand::Rng;
 use rand::rngs::StdRng;
 use vortex_alp::{ALPArray, alp_encode};
 use vortex_array::arrays::PrimitiveArray;
+use vortex_array::compute::warm_up_vtables;
 use vortex_array::{ArrayRef, IntoArray, ToCanonical};
 use vortex_dtype::NativePType;
 use vortex_error::VortexExpect;
 use vortex_fastlanes::bitpack_to_best_bit_width;
 
 fn main() {
+    warm_up_vtables();
     divan::main();
 }
 

--- a/encodings/fastlanes/benches/pipeline_bitpacking.rs
+++ b/encodings/fastlanes/benches/pipeline_bitpacking.rs
@@ -9,7 +9,7 @@ use divan::Bencher;
 use mimalloc::MiMalloc;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
-use vortex_array::compute::filter;
+use vortex_array::compute::{filter, warm_up_vtables};
 use vortex_array::pipeline::{Element, export_canonical_pipeline_expr};
 use vortex_array::{IntoArray, ToCanonical};
 use vortex_buffer::BufferMut;
@@ -21,6 +21,7 @@ use vortex_mask::Mask;
 static GLOBAL: MiMalloc = MiMalloc;
 
 pub fn main() {
+    warm_up_vtables();
     divan::main();
 }
 

--- a/encodings/fastlanes/benches/pipeline_bitpacking_compare_scalar.rs
+++ b/encodings/fastlanes/benches/pipeline_bitpacking_compare_scalar.rs
@@ -9,7 +9,7 @@ use divan::Bencher;
 use mimalloc::MiMalloc;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
-use vortex_array::compute::filter;
+use vortex_array::compute::{filter, warm_up_vtables};
 use vortex_array::pipeline::{Element, export_canonical_pipeline_expr};
 use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
 use vortex_buffer::BufferMut;
@@ -25,6 +25,7 @@ use vortex_scalar::Scalar;
 static GLOBAL: MiMalloc = MiMalloc;
 
 pub fn main() {
+    warm_up_vtables();
     divan::main();
 }
 

--- a/encodings/fastlanes/benches/pipeline_bitpacking_kernel.rs
+++ b/encodings/fastlanes/benches/pipeline_bitpacking_kernel.rs
@@ -11,7 +11,7 @@ use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
 use vortex_array::ToCanonical;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::compute::filter;
+use vortex_array::compute::{filter, warm_up_vtables};
 use vortex_array::pipeline::bits::BitView;
 use vortex_array::pipeline::view::ViewMut;
 use vortex_array::pipeline::{Element, Kernel, KernelContext, N, N_WORDS};
@@ -25,6 +25,7 @@ use vortex_mask::Mask;
 static GLOBAL: MiMalloc = MiMalloc;
 
 pub fn main() {
+    warm_up_vtables();
     divan::main();
 }
 

--- a/encodings/fastlanes/benches/pipeline_for.rs
+++ b/encodings/fastlanes/benches/pipeline_for.rs
@@ -9,7 +9,7 @@ use divan::Bencher;
 use mimalloc::MiMalloc;
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
-use vortex_array::compute::filter;
+use vortex_array::compute::{filter, warm_up_vtables};
 use vortex_array::pipeline::{Element, export_canonical_pipeline_expr};
 use vortex_array::{IntoArray, ToCanonical};
 use vortex_buffer::BufferMut;
@@ -21,6 +21,7 @@ use vortex_mask::Mask;
 static GLOBAL: MiMalloc = MiMalloc;
 
 pub fn main() {
+    warm_up_vtables();
     divan::main();
 }
 

--- a/encodings/fsst/benches/fsst_compress.rs
+++ b/encodings/fsst/benches/fsst_compress.rs
@@ -9,12 +9,13 @@ use rand::{Rng, SeedableRng};
 use vortex_array::IntoArray;
 use vortex_array::arrays::{ChunkedArray, ConstantArray, VarBinArray};
 use vortex_array::builders::{ArrayBuilder, VarBinViewBuilder};
-use vortex_array::compute::{Operator, compare};
+use vortex_array::compute::{Operator, compare, warm_up_vtables};
 use vortex_dtype::{DType, Nullability};
 use vortex_fsst::{fsst_compress, fsst_train_compressor};
 use vortex_scalar::Scalar;
 
 fn main() {
+    warm_up_vtables();
     divan::main();
 }
 

--- a/encodings/runend/benches/run_end_compress.rs
+++ b/encodings/runend/benches/run_end_compress.rs
@@ -7,7 +7,7 @@ use divan::Bencher;
 use itertools::repeat_n;
 use num_traits::PrimInt;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::compute::take;
+use vortex_array::compute::{take, warm_up_vtables};
 use vortex_array::validity::Validity;
 use vortex_array::{Array, IntoArray};
 use vortex_buffer::Buffer;
@@ -16,6 +16,7 @@ use vortex_runend::RunEndArray;
 use vortex_runend::compress::runend_encode;
 
 fn main() {
+    warm_up_vtables();
     divan::main();
 }
 

--- a/encodings/runend/benches/run_end_filter.rs
+++ b/encodings/runend/benches/run_end_filter.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::cast_possible_truncation)]
 
 use divan::Bencher;
+use vortex_array::compute::warm_up_vtables;
 use vortex_array::validity::Validity;
 use vortex_array::{Array, IntoArray};
 use vortex_buffer::Buffer;
@@ -13,6 +14,7 @@ use vortex_runend::_benchmarking::{filter_run_end, take_indices_unchecked};
 use vortex_runend::RunEndArray;
 
 fn main() {
+    warm_up_vtables();
     divan::main();
 }
 

--- a/encodings/runend/benches/run_end_null_count.rs
+++ b/encodings/runend/benches/run_end_null_count.rs
@@ -7,11 +7,13 @@ use divan::Bencher;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use vortex_array::arrays::PrimitiveArray;
+use vortex_array::compute::warm_up_vtables;
 use vortex_array::{Array, IntoArray};
 use vortex_buffer::Buffer;
 use vortex_runend::RunEndArray;
 
 fn main() {
+    warm_up_vtables();
     divan::main();
 }
 

--- a/vortex-array/src/arrow/compute/mod.rs
+++ b/vortex-array/src/arrow/compute/mod.rs
@@ -3,4 +3,5 @@
 
 mod to_arrow;
 
+pub(crate) use to_arrow::warm_up_vtable;
 pub use to_arrow::*;

--- a/vortex-array/src/arrow/compute/to_arrow/mod.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/mod.rs
@@ -33,6 +33,10 @@ static TO_ARROW_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    TO_ARROW_FN.kernels().len()
+}
+
 /// Convert a Vortex array to an Arrow array with the encoding's preferred `DataType`.
 ///
 /// For example, a `VarBinArray` will be converted to an Arrow `VarBin` array, instead of the

--- a/vortex-array/src/arrow/mod.rs
+++ b/vortex-array/src/arrow/mod.rs
@@ -14,9 +14,8 @@ mod datum;
 mod iter;
 mod record_batch;
 
-pub(crate) use compute::warm_up_vtable;
-
 pub use array::*;
+pub(crate) use compute::warm_up_vtable;
 pub use datum::*;
 pub use iter::*;
 

--- a/vortex-array/src/arrow/mod.rs
+++ b/vortex-array/src/arrow/mod.rs
@@ -14,6 +14,8 @@ mod datum;
 mod iter;
 mod record_batch;
 
+pub(crate) use compute::warm_up_vtable;
+
 pub use array::*;
 pub use datum::*;
 pub use iter::*;

--- a/vortex-array/src/compute/between.rs
+++ b/vortex-array/src/compute/between.rs
@@ -25,6 +25,10 @@ static BETWEEN_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    BETWEEN_FN.kernels().len()
+}
+
 /// Compute between (a <= x <= b).
 ///
 /// This is an optimized implementation that is equivalent to `(a <= x) AND (x <= b)`.

--- a/vortex-array/src/compute/boolean.rs
+++ b/vortex-array/src/compute/boolean.rs
@@ -23,6 +23,10 @@ static BOOLEAN_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    BOOLEAN_FN.kernels().len()
+}
+
 /// Point-wise logical _and_ between two Boolean arrays.
 ///
 /// This method uses Arrow-style null propagation rather than the Kleene logic semantics. This

--- a/vortex-array/src/compute/cast.rs
+++ b/vortex-array/src/compute/cast.rs
@@ -19,6 +19,10 @@ static CAST_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    CAST_FN.kernels().len()
+}
+
 /// Attempt to cast an array to a desired DType.
 ///
 /// Some array support the ability to narrow or upcast.

--- a/vortex-array/src/compute/compare.rs
+++ b/vortex-array/src/compute/compare.rs
@@ -27,6 +27,10 @@ static COMPARE_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    COMPARE_FN.kernels().len()
+}
+
 /// Compares two arrays and returns a new boolean array with the result of the comparison.
 /// Or, returns None if comparison is not supported for these arrays.
 pub fn compare(left: &dyn Array, right: &dyn Array, operator: Operator) -> VortexResult<ArrayRef> {

--- a/vortex-array/src/compute/fill_null.rs
+++ b/vortex-array/src/compute/fill_null.rs
@@ -20,6 +20,10 @@ static FILL_NULL_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    FILL_NULL_FN.kernels().len()
+}
+
 pub fn fill_null(array: &dyn Array, fill_value: &Scalar) -> VortexResult<ArrayRef> {
     FILL_NULL_FN
         .invoke(&InvocationArgs {

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -25,6 +25,10 @@ static FILTER_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    FILTER_FN.kernels().len()
+}
+
 /// Keep only the elements for which the corresponding mask value is true.
 ///
 /// # Examples

--- a/vortex-array/src/compute/invert.rs
+++ b/vortex-array/src/compute/invert.rs
@@ -19,6 +19,10 @@ static INVERT_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    INVERT_FN.kernels().len()
+}
+
 /// Logically invert a boolean array, preserving its validity.
 pub fn invert(array: &dyn Array) -> VortexResult<ArrayRef> {
     INVERT_FN

--- a/vortex-array/src/compute/is_constant.rs
+++ b/vortex-array/src/compute/is_constant.rs
@@ -23,6 +23,10 @@ static IS_CONSTANT_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    IS_CONSTANT_FN.kernels().len()
+}
+
 /// Computes whether an array has constant values. If the array's encoding doesn't implement the
 /// relevant VTable, it'll try and canonicalize in order to make a determination.
 ///

--- a/vortex-array/src/compute/is_sorted.rs
+++ b/vortex-array/src/compute/is_sorted.rs
@@ -23,6 +23,10 @@ static IS_SORTED_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    IS_SORTED_FN.kernels().len()
+}
+
 pub fn is_sorted(array: &dyn Array) -> VortexResult<Option<bool>> {
     is_sorted_opts(array, false)
 }

--- a/vortex-array/src/compute/like.rs
+++ b/vortex-array/src/compute/like.rs
@@ -21,6 +21,10 @@ static LIKE_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    LIKE_FN.kernels().len()
+}
+
 /// Perform SQL left LIKE right
 ///
 /// There are two wildcards supported with the LIKE operator:

--- a/vortex-array/src/compute/list_contains.rs
+++ b/vortex-array/src/compute/list_contains.rs
@@ -31,6 +31,10 @@ static LIST_CONTAINS_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    LIST_CONTAINS_FN.kernels().len()
+}
+
 /// Compute a `Bool`-typed array the same length as `array` where elements is `true` if the list
 /// item contains the `value`, `false` otherwise.
 ///

--- a/vortex-array/src/compute/mask.rs
+++ b/vortex-array/src/compute/mask.rs
@@ -24,6 +24,10 @@ static MASK_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    MASK_FN.kernels().len()
+}
+
 /// Replace values with null where the mask is true.
 ///
 /// The returned array is nullable but otherwise has the same dtype and length as `array`.

--- a/vortex-array/src/compute/min_max.rs
+++ b/vortex-array/src/compute/min_max.rs
@@ -22,6 +22,10 @@ static MIN_MAX_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    MIN_MAX_FN.kernels().len()
+}
+
 /// The minimum and maximum non-null values of an array, or None if there are no non-null values.
 ///
 /// The return value dtype is the non-nullable version of the array dtype.

--- a/vortex-array/src/compute/mod.rs
+++ b/vortex-array/src/compute/mod.rs
@@ -72,6 +72,32 @@ pub struct ComputeFn {
     kernels: RwLock<Vec<ArcRef<dyn Kernel>>>,
 }
 
+/// Force all the default [`ComputeFn`] vtables to register all available compute kernels.
+///
+/// Mostly useful for small benchmarks where the overhead might cause noise depending on the order of benchmarks.
+pub fn warm_up_vtables() {
+    crate::arrow::warm_up_vtable();
+    #[allow(unused_qualifications)]
+    between::warm_up_vtable();
+    boolean::warm_up_vtable();
+    cast::warm_up_vtable();
+    compare::warm_up_vtable();
+    fill_null::warm_up_vtable();
+    filter::warm_up_vtable();
+    invert::warm_up_vtable();
+    is_constant::warm_up_vtable();
+    is_sorted::warm_up_vtable();
+    like::warm_up_vtable();
+    list_contains::warm_up_vtable();
+    mask::warm_up_vtable();
+    min_max::warm_up_vtable();
+    nan_count::warm_up_vtable();
+    numeric::warm_up_vtable();
+    sum::warm_up_vtable();
+    take::warm_up_vtable();
+    zip::warm_up_vtable();
+}
+
 impl ComputeFn {
     /// Create a new compute function from the given [`ComputeFnVTable`].
     pub fn new(id: ArcRef<str>, vtable: ArcRef<dyn ComputeFnVTable>) -> Self {

--- a/vortex-array/src/compute/nan_count.rs
+++ b/vortex-array/src/compute/nan_count.rs
@@ -21,6 +21,10 @@ static NAN_COUNT_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    NAN_COUNT_FN.kernels().len()
+}
+
 /// Computes the number of NaN values in the array.
 pub fn nan_count(array: &dyn Array) -> VortexResult<usize> {
     Ok(NAN_COUNT_FN

--- a/vortex-array/src/compute/numeric.rs
+++ b/vortex-array/src/compute/numeric.rs
@@ -23,6 +23,10 @@ static NUMERIC_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    NUMERIC_FN.kernels().len()
+}
+
 /// Point-wise add two numeric arrays.
 ///
 /// Errs at runtime if the sum would overflow or underflow.

--- a/vortex-array/src/compute/sum.rs
+++ b/vortex-array/src/compute/sum.rs
@@ -21,6 +21,10 @@ static SUM_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    SUM_FN.kernels().len()
+}
+
 /// Sum an array.
 ///
 /// If the sum overflows, a null scalar will be returned.

--- a/vortex-array/src/compute/take.rs
+++ b/vortex-array/src/compute/take.rs
@@ -22,6 +22,10 @@ static TAKE_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    TAKE_FN.kernels().len() + TAKE_FROM_FN.kernels().len()
+}
+
 /// Creates a new array using the elements from the input `array` indexed by `indices`.
 ///
 /// For example, if we have an `array` `[1, 2, 3, 4, 5]` and `indices` `[4, 2]`, the resulting

--- a/vortex-array/src/compute/zip.rs
+++ b/vortex-array/src/compute/zip.rs
@@ -35,6 +35,10 @@ pub static ZIP_FN: LazyLock<ComputeFn> = LazyLock::new(|| {
     compute
 });
 
+pub(crate) fn warm_up_vtable() -> usize {
+    ZIP_FN.kernels().len()
+}
+
 struct Zip;
 
 impl ComputeFnVTable for Zip {


### PR DESCRIPTION
Noticed that some benchmarks had significant swings just because the ComputeFn lock would appear in some runs compared to others. This PR introduces a function which should force loading all existing kernels for the default functions.

The example I have right now is [this](https://codspeed.io/vortex-data/vortex/branches/adamg%2Finline-some-dtype-code?uri=encodings%2Ffastlanes%2Fbenches%2Fcompute_between.rs%3A%3Abitpack%3A%3Anew_bp_prim_test_between%255Bi16%252C%25202048%255D).