### PR TITLE
buffered bytes counter in layout strategy

### DIFF
--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -222,12 +222,14 @@ impl VortexWriteOptions {
 
         let write = CountingVortexWrite::new(write);
         let bytes_written = write.counter();
+        let strategy = self.strategy.clone();
         let future = self.write(write, arrays).boxed_local().fuse();
 
         Writer {
             arrays: Some(arrays_send),
             future,
             bytes_written,
+            strategy,
         }
     }
 }
@@ -240,6 +242,8 @@ pub struct Writer<'w> {
     future: Fuse<LocalBoxFuture<'w, VortexResult<WriteSummary>>>,
     // The bytes written so far.
     bytes_written: Arc<AtomicU64>,
+    // The layout strategy that is being used for the write.
+    strategy: Arc<dyn LayoutStrategy>,
 }
 
 impl Writer<'_> {
@@ -317,6 +321,17 @@ impl Writer<'_> {
             .load(std::sync::atomic::Ordering::Relaxed)
     }
 
+    /// Returns the number of bytes currently buffered by the layout writers.
+    pub fn buffered_bytes(&self) -> u64 {
+        self.strategy.buffered_bytes()
+    }
+
+    /// Returns the total number of bytes (written + buffered).
+    /// This provides a more accurate estimate of the final file size.
+    pub fn total_bytes(&self) -> u64 {
+        self.bytes_written() + self.buffered_bytes()
+    }
+
     /// Finish writing the Vortex file, flushing any remaining buffers and returning the
     /// new file's footer.
     pub async fn finish(mut self) -> VortexResult<WriteSummary> {
@@ -387,6 +402,14 @@ impl<B: BlockingRuntime> BlockingWriter<'_, B> {
 
     pub fn bytes_written(&self) -> u64 {
         self.writer.bytes_written()
+    }
+
+    pub fn buffered_bytes(&self) -> u64 {
+        self.writer.buffered_bytes()
+    }
+
+    pub fn total_bytes(&self) -> u64 {
+        self.writer.total_bytes()
     }
 
     pub fn finish(self) -> VortexResult<WriteSummary> {

--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -326,12 +326,6 @@ impl Writer<'_> {
         self.strategy.buffered_bytes()
     }
 
-    /// Returns the total number of bytes (written + buffered).
-    /// This provides a more accurate estimate of the final file size.
-    pub fn total_bytes(&self) -> u64 {
-        self.bytes_written() + self.buffered_bytes()
-    }
-
     /// Finish writing the Vortex file, flushing any remaining buffers and returning the
     /// new file's footer.
     pub async fn finish(mut self) -> VortexResult<WriteSummary> {
@@ -406,10 +400,6 @@ impl<B: BlockingRuntime> BlockingWriter<'_, B> {
 
     pub fn buffered_bytes(&self) -> u64 {
         self.writer.buffered_bytes()
-    }
-
-    pub fn total_bytes(&self) -> u64 {
-        self.writer.total_bytes()
     }
 
     pub fn finish(self) -> VortexResult<WriteSummary> {

--- a/vortex-layout/src/layouts/buffered.rs
+++ b/vortex-layout/src/layouts/buffered.rs
@@ -3,6 +3,7 @@
 
 use std::collections::VecDeque;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use async_stream::try_stream;
 use async_trait::async_trait;
@@ -21,6 +22,7 @@ use crate::{LayoutRef, LayoutStrategy};
 pub struct BufferedStrategy {
     child: Arc<dyn LayoutStrategy>,
     buffer_size: u64,
+    buffered_bytes: Arc<AtomicU64>,
 }
 
 impl BufferedStrategy {
@@ -28,6 +30,7 @@ impl BufferedStrategy {
         Self {
             child: Arc::new(child),
             buffer_size,
+            buffered_bytes: Arc::new(AtomicU64::new(0)),
         }
     }
 }
@@ -50,13 +53,16 @@ impl LayoutStrategy for BufferedStrategy {
         // cause deadlocks with other columns that are waiting for us to flush.
         let mut final_flush = eof.split_off();
 
+        let buffered_bytes_counter = self.buffered_bytes.clone();
         let buffered_stream = try_stream! {
             let mut nbytes = 0u64;
             let mut chunks = VecDeque::new();
 
             while let Some(chunk) = stream.as_mut().next().await {
                 let (sequence_id, chunk) = chunk?;
-                nbytes += chunk.nbytes();
+                let chunk_size = chunk.nbytes();
+                nbytes += chunk_size;
+                buffered_bytes_counter.fetch_add(chunk_size, Ordering::Relaxed);
                 chunks.push_back(chunk);
 
                 if nbytes < 2 * buffer_size {
@@ -70,13 +76,17 @@ impl LayoutStrategy for BufferedStrategy {
                     let Some(chunk) = chunks.pop_front() else {
                         break;
                     };
-                    nbytes -= chunk.nbytes();
+                    let chunk_size = chunk.nbytes();
+                    nbytes -= chunk_size;
+                    buffered_bytes_counter.fetch_sub(chunk_size, Ordering::Relaxed);
                     yield (sequence_ptr.advance(), chunk)
                 }
             }
 
             // Now the input stream has ended, flush everything
             while let Some(chunk) = chunks.pop_front() {
+                let chunk_size = chunk.nbytes();
+                buffered_bytes_counter.fetch_sub(chunk_size, Ordering::Relaxed);
                 yield (final_flush.advance(), chunk)
             }
         };
@@ -90,5 +100,9 @@ impl LayoutStrategy for BufferedStrategy {
                 handle,
             )
             .await
+    }
+
+    fn buffered_bytes(&self) -> u64 {
+        self.buffered_bytes.load(Ordering::Relaxed) + self.child.buffered_bytes()
     }
 }

--- a/vortex-layout/src/layouts/chunked/writer.rs
+++ b/vortex-layout/src/layouts/chunked/writer.rs
@@ -90,4 +90,8 @@ impl LayoutStrategy for ChunkedLayoutStrategy {
             .into_layout())
         }
     }
+
+    fn buffered_bytes(&self) -> u64 {
+        self.chunk_strategy.buffered_bytes()
+    }
 }

--- a/vortex-layout/src/layouts/compressed.rs
+++ b/vortex-layout/src/layouts/compressed.rs
@@ -153,4 +153,8 @@ impl LayoutStrategy for CompressingStrategy {
             )
             .await
     }
+
+    fn buffered_bytes(&self) -> u64 {
+        self.child.buffered_bytes()
+    }
 }

--- a/vortex-layout/src/layouts/dict/writer.rs
+++ b/vortex-layout/src/layouts/dict/writer.rs
@@ -184,6 +184,10 @@ impl LayoutStrategy for DictStrategy {
         )
         .into_layout())
     }
+
+    fn buffered_bytes(&self) -> u64 {
+        self.codes.buffered_bytes() + self.values.buffered_bytes() + self.fallback.buffered_bytes()
+    }
 }
 
 enum DictionaryChunk {

--- a/vortex-layout/src/layouts/flat/writer.rs
+++ b/vortex-layout/src/layouts/flat/writer.rs
@@ -133,6 +133,11 @@ impl LayoutStrategy for FlatLayoutStrategy {
                 .into_layout(),
         )
     }
+
+    fn buffered_bytes(&self) -> u64 {
+        // FlatLayoutStrategy is a leaf strategy with no child strategies and no buffering
+        0
+    }
 }
 
 #[cfg(test)]

--- a/vortex-layout/src/layouts/repartition.rs
+++ b/vortex-layout/src/layouts/repartition.rs
@@ -122,6 +122,14 @@ impl LayoutStrategy for RepartitionStrategy {
             )
             .await
     }
+
+    fn buffered_bytes(&self) -> u64 {
+        // TODO(os): we should probably add the buffered bytes from this strategy on top,
+        // it is currently better to not add it at all because these buffered arrays are
+        // potentially sliced and uncompressed. They would overestimate the actual bytes
+        // that will end up in the file when flushed.
+        self.child.buffered_bytes()
+    }
 }
 
 struct ChunksBuffer {

--- a/vortex-layout/src/layouts/struct_/writer.rs
+++ b/vortex-layout/src/layouts/struct_/writer.rs
@@ -152,6 +152,10 @@ impl LayoutStrategy for StructStrategy {
         let row_count = column_layouts.first().map(|l| l.row_count()).unwrap_or(0);
         Ok(StructLayout::new(row_count, dtype, column_layouts).into_layout())
     }
+
+    fn buffered_bytes(&self) -> u64 {
+        self.child.buffered_bytes()
+    }
 }
 
 #[cfg(test)]

--- a/vortex-layout/src/layouts/zoned/writer.rs
+++ b/vortex-layout/src/layouts/zoned/writer.rs
@@ -155,4 +155,8 @@ impl LayoutStrategy for ZonedStrategy {
         )
         .into_layout())
     }
+
+    fn buffered_bytes(&self) -> u64 {
+        self.child.buffered_bytes() + self.stats.buffered_bytes()
+    }
 }

--- a/vortex-layout/src/strategy.rs
+++ b/vortex-layout/src/strategy.rs
@@ -53,5 +53,14 @@ pub trait LayoutStrategy: 'static + Send + Sync {
         eof: SequencePointer,
         handle: Handle,
     ) -> VortexResult<LayoutRef>;
+
+    /// Returns the number of bytes currently buffered by this strategy and any child strategies.
+    ///
+    /// This method allows tracking of data that has been processed by the strategy but not yet
+    /// written to the underlying sink, providing more accurate estimates of final file size
+    /// during write operations.
+    fn buffered_bytes(&self) -> u64 {
+        0
+    }
 }
 // [layout writer]


### PR DESCRIPTION
Fixes https://github.com/vortex-data/vortex/issues/4636

LayoutStrategy to return the total buffered bytes as accurate as it can, but it will still undershoot to some extent, because there is no good way to get the actual size of all buffered data.

Currently a new LayoutStrategy instance is created per `VortexOpenOptions`, so returning the total buffered size across all streams being processed by a LayoutStrategy instance should be fine.