### PR TITLE
Remove local path optimization for object store

### DIFF
--- a/vortex-file/src/open.rs
+++ b/vortex-file/src/open.rs
@@ -295,24 +295,12 @@ impl VortexOpenOptions {
         object_store: &Arc<dyn object_store::ObjectStore>,
         path: &str,
     ) -> VortexResult<VortexFile> {
-        use std::path::Path;
-
         use vortex_io::file::object_store::ObjectStoreReadSource;
 
-        // If the file is local, we much prefer to use TokioFile since object store re-opens the
-        // file on every read. This check is a little naive... but we hope that ObjectStore will
-        // soon expose the scheme in a way that we can check more thoroughly.
-        // See: https://github.com/apache/arrow-rs-object-store/issues/259
-        let local_path = Path::new("/").join(path);
-        if local_path.exists() {
-            // Local disk is too fast to justify prefetching.
-            self.open(local_path).await
-        } else {
-            self.open(ObjectStoreReadSource::new(
-                object_store.clone(),
-                path.into(),
-            ))
-            .await
-        }
+        self.open(ObjectStoreReadSource::new(
+            object_store.clone(),
+            path.into(),
+        ))
+        .await
     }
 }


### PR DESCRIPTION
Closes #4672

This optimization is a bit weird. If the user explicitly asks for object store, and has configured it with telemetry etc, then it's odd for us to then ignore that request and use our own I/O layer.

Also assuming an absolute path from root was too naive.

Users are encouraged to either `open_object_store`, or `open(&Path)`. If we had our own registry of object stores, we could also support `impl IntoReadSource for Url`

