### PR TITLE
fix: duckdb dict ownership in `export`

### DIFF
--- a/vortex-duckdb/cpp/include/duckdb_vx/vector.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/vector.h
@@ -18,6 +18,11 @@ void duckdb_vx_set_dictionary_vector_id(duckdb_vector dict, const char *id, unsi
 
 void duckdb_vx_set_dictionary_vector_length(duckdb_vector dict, unsigned int len);
 
+/// Turn vector into a dictionary vector. In contrast to `duckdb_vx_vector_slice_to_dictionary` this
+/// call creates a dictionary that holds a strong reference to its children.
+void duckdb_vx_vector_dictionary(duckdb_vector ffi_vector, duckdb_vector ffi_dict, idx_t dictionary_size,
+                                 duckdb_selection_vector ffi_sel_vec, idx_t count);
+
 // Add the buffer to the string vector (basically, keep it alive as long as the vector).
 void duckdb_vx_string_vector_add_buffer(duckdb_vector ffi_vector, duckdb_vx_data buffer);
 

--- a/vortex-duckdb/cpp/include/duckdb_vx/vector.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/vector.h
@@ -14,14 +14,14 @@ extern "C" {
 void duckdb_vx_vector_slice_to_dictionary(duckdb_vector ffi_vector, duckdb_selection_vector selection_vector,
                                           idx_t selection_vector_length);
 
-void duckdb_vx_set_dictionary_vector_id(duckdb_vector dict, const char *id, unsigned int id_len);
-
-void duckdb_vx_set_dictionary_vector_length(duckdb_vector dict, unsigned int len);
-
 /// Turn vector into a dictionary vector. In contrast to `duckdb_vx_vector_slice_to_dictionary` this
 /// call creates a dictionary that holds a strong reference to its children.
 void duckdb_vx_vector_dictionary(duckdb_vector ffi_vector, duckdb_vector ffi_dict, idx_t dictionary_size,
                                  duckdb_selection_vector ffi_sel_vec, idx_t count);
+
+void duckdb_vx_set_dictionary_vector_id(duckdb_vector dict, const char *id, unsigned int id_len);
+
+void duckdb_vx_set_dictionary_vector_length(duckdb_vector dict, unsigned int len);
 
 // Add the buffer to the string vector (basically, keep it alive as long as the vector).
 void duckdb_vx_string_vector_add_buffer(duckdb_vector ffi_vector, duckdb_vx_data buffer);

--- a/vortex-duckdb/cpp/vector.cpp
+++ b/vortex-duckdb/cpp/vector.cpp
@@ -17,6 +17,15 @@ extern "C" void duckdb_vx_vector_slice_to_dictionary(duckdb_vector ffi_vector,
     vector->Slice(*sel_vec, selection_vector_length);
 }
 
+extern "C" void duckdb_vx_vector_dictionary(duckdb_vector ffi_vector, duckdb_vector ffi_dict,
+                                            idx_t dictionary_size, duckdb_selection_vector ffi_sel_vec,
+                                            idx_t count) {
+    auto vector = reinterpret_cast<Vector *>(ffi_vector);
+    auto dict = reinterpret_cast<Vector *>(ffi_dict);
+    auto sel_vec = reinterpret_cast<SelectionVector *>(ffi_sel_vec);
+    vector->Dictionary(*dict, dictionary_size, *sel_vec, count);
+}
+
 extern "C" void duckdb_vx_set_dictionary_vector_id(duckdb_vector dict, const char *id, unsigned int id_len) {
     auto ddict = reinterpret_cast<duckdb::Vector *>(dict);
     DictionaryVector::SetDictionaryId(*ddict, std::string(id, id_len));

--- a/vortex-duckdb/src/duckdb/vector.rs
+++ b/vortex-duckdb/src/duckdb/vector.rs
@@ -127,6 +127,24 @@ impl Vector {
         unsafe { cpp::duckdb_vx_string_vector_add_buffer(self.as_ptr(), data.into_ptr()) }
     }
 
+    pub fn dictionary(
+        &self,
+        dict: &Vector,
+        dictionary_size: usize,
+        sel_vec: &SelectionVector,
+        count: usize,
+    ) {
+        unsafe {
+            cpp::duckdb_vx_vector_dictionary(
+                self.as_ptr(),
+                dict.as_ptr(),
+                dictionary_size as _,
+                sel_vec.as_ptr(),
+                count as _,
+            )
+        }
+    }
+
     /// Assigns the element at the specified index with a string value.
     /// FIXME(ngates): remove this.
     pub fn assign_string_element(&self, idx: usize, value: &CStr) {

--- a/vortex-duckdb/src/duckdb/vector.rs
+++ b/vortex-duckdb/src/duckdb/vector.rs
@@ -63,6 +63,26 @@ impl Vector {
         }
     }
 
+    /// Turn vector into a dictionary vector. In contrast to `slice_to_dictionary` this
+    /// call creates a dictionary that holds a strong reference to its children.
+    pub fn dictionary(
+        &self,
+        dict: &Vector,
+        dictionary_size: usize,
+        sel_vec: &SelectionVector,
+        count: usize,
+    ) {
+        unsafe {
+            cpp::duckdb_vx_vector_dictionary(
+                self.as_ptr(),
+                dict.as_ptr(),
+                dictionary_size as _,
+                sel_vec.as_ptr(),
+                count as _,
+            )
+        }
+    }
+
     // Used to by duckdb to know the dictionary value length (since each vector doesn't know its own
     // length only its capacity).
     pub fn set_dictionary_len(&mut self, len: u32) {
@@ -125,24 +145,6 @@ impl Vector {
     pub fn add_string_buffer<T>(&self, buffer: T) {
         let data = Data::from(Box::new(buffer));
         unsafe { cpp::duckdb_vx_string_vector_add_buffer(self.as_ptr(), data.into_ptr()) }
-    }
-
-    pub fn dictionary(
-        &self,
-        dict: &Vector,
-        dictionary_size: usize,
-        sel_vec: &SelectionVector,
-        count: usize,
-    ) {
-        unsafe {
-            cpp::duckdb_vx_vector_dictionary(
-                self.as_ptr(),
-                dict.as_ptr(),
-                dictionary_size as _,
-                sel_vec.as_ptr(),
-                count as _,
-            )
-        }
     }
 
     /// Assigns the element at the specified index with a string value.

--- a/vortex-duckdb/src/exporter/dict.rs
+++ b/vortex-duckdb/src/exporter/dict.rs
@@ -80,10 +80,7 @@ pub(crate) fn new_exporter(
 
 impl<I: NativePType + AsPrimitive<u32>> ColumnExporter for DictExporter<I> {
     fn export(&self, offset: usize, len: usize, vector: &mut Vector) -> VortexResult<()> {
-        // Copy across the dictionary values.
-        vector.reference(&self.values_vector.lock());
-
-        // Slice with a selection vector from the codes.
+        // Create a selection vector from the codes.
         let mut sel_vec = SelectionVector::with_capacity(len);
         let mut_sel_vec = unsafe { sel_vec.as_slice_mut(len) };
         for (dst, src) in mut_sel_vec.iter_mut().zip(
@@ -94,7 +91,13 @@ impl<I: NativePType + AsPrimitive<u32>> ColumnExporter for DictExporter<I> {
             *dst = src
         }
 
-        vector.slice_to_dictionary(sel_vec, len);
+        vector.dictionary(
+            &self.values_vector.lock(),
+            self.values_len as usize,
+            &sel_vec,
+            len,
+        );
+
         // Use a unique id to each dictionary data array -- telling duckdb that the dict value vector
         // is the same as reuse the hash in a join.
         vector.set_dictionary_id(format!("{}-{}", self.cache_id, self.value_id));


### PR DESCRIPTION
The issue with `slice_to_dictionary` is that it neither properly initializes the dict nor holds a strong reference to it.