### PR TITLE
fix: duckdb test type mismatch

### DIFF
--- a/vortex-duckdb/src/duckdb/connection.rs
+++ b/vortex-duckdb/src/duckdb/connection.rs
@@ -154,7 +154,7 @@ mod tests {
         let result = conn.query("SELECT 42").unwrap();
         let chunk = result.into_iter().next().unwrap();
         let vec = chunk.get_vector(0);
-        let slice = vec.as_slice_with_len::<i64>(chunk.len().as_());
+        let slice = vec.as_slice_with_len::<i32>(chunk.len().as_());
 
         assert_eq!(chunk.column_count(), 1);
         assert_eq!(chunk.len(), 1);


### PR DESCRIPTION
Fixes the unit test failing when run with ASAN:
```
---- duckdb::connection::tests::test_query_single_value stdout ----

thread 'duckdb::connection::tests::test_query_single_value' panicked at vortex-duckdb/src/duckdb/connection.rs:161:9:
assertion `left == right` failed
  left: 481036337194
 right: 42
```

We were reading 4 extra bytes here that don't happen to be 0 in the ASAN case.