### PR TITLE
fix: zero sized duckdb array

### DIFF
--- a/vortex-duckdb/src/exporter/fixed_size_list.rs
+++ b/vortex-duckdb/src/exporter/fixed_size_list.rs
@@ -229,17 +229,6 @@ mod tests {
     }
 
     #[test]
-    fn test_export_list_size_zero() {
-        // Create a FixedSizeListArray with list_size=0 (degenerate case).
-        // This represents arrays with no elements.
-        let fsl = FixedSizeListArray::new(buffer![0i32; 0].into_array(), 0, Validity::AllValid, 3);
-        let chunk = export_to_chunk(&fsl, 0, 0, 3);
-
-        // Should have 3 lists, each with 0 elements.
-        assert_eq!(chunk.len(), 3);
-    }
-
-    #[test]
     fn test_export_list_size_one() {
         // Create a FixedSizeListArray with list_size=1 (single element arrays).
         // Lists: [10], [20], [30], [40]


### PR DESCRIPTION
Zero sized arrays are not valid in DuckDB. https://github.com/duckdb/duckdb/blob/0dcf633f603a629981d089202f93b9080cb1a3e9/src/common/types.cpp#L1911 

The removed unit test fired the assertion when running DuckDB in debug mode.