### PR TITLE
Rename functions in SelectExpr to make API clearer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3311,9 +3311,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.80"
+version = "0.3.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
+checksum = "6247da8b8658ad4e73a186e747fcc5fc2a29f979d6fe6269127fdb5fd08298d0"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -7245,9 +7245,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.103"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
+checksum = "4ad224d2776649cfb4f4471124f8176e54c1cca67a88108e30a0cd98b90e7ad3"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7258,9 +7258,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.103"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
+checksum = "3a1364104bdcd3c03f22b16a3b1c9620891469f5e9f09bc38b2db121e593e732"
 dependencies = [
  "bumpalo",
  "log",
@@ -7272,9 +7272,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.53"
+version = "0.4.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b221ff421256839509adbb55998214a70d829d3a28c69b4a6672e9d2a42f67"
+checksum = "9c0a08ecf5d99d5604a6666a70b3cde6ab7cc6142f5e641a8ef48fc744ce8854"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7285,9 +7285,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.103"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
+checksum = "0d7ab4ca3e367bb1ed84ddbd83cc6e41e115f8337ed047239578210214e36c76"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7295,9 +7295,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.103"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
+checksum = "4a518014843a19e2dbbd0ed5dfb6b99b23fb886b14e6192a00803a3e14c552b0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7308,9 +7308,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.103"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
+checksum = "255eb0aa4cc2eea3662a00c2bbd66e93911b7361d5e0fcd62385acfd7e15dcee"
 dependencies = [
  "unicode-ident",
 ]
@@ -7330,9 +7330,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.80"
+version = "0.3.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
+checksum = "50462a022f46851b81d5441d1a6f5bac0b21a1d72d64bd4906fbdd4bf7230ec7"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/vortex-dtype/src/struct_.rs
+++ b/vortex-dtype/src/struct_.rs
@@ -91,6 +91,7 @@ impl Hash for FieldDTypeInner {
 
 impl FieldDType {
     /// Returns the concrete DType, parsing it from the underlying buffer if necessary.
+    #[inline]
     pub fn value(&self) -> VortexResult<DType> {
         self.inner.value()
     }

--- a/vortex-expr/src/exprs/select.rs
+++ b/vortex-expr/src/exprs/select.rs
@@ -206,11 +206,11 @@ impl SelectExpr {
     /// For example:
     /// ```rust
     /// # use vortex_expr::root;
-    /// # use vortex_expr::{SelectExpr, SelectField};
+    /// # use vortex_expr::{FieldSelection, SelectExpr};
     /// # use vortex_dtype::FieldNames;
     /// let field_names = FieldNames::from(["a", "b", "c"]);
-    /// let include = SelectExpr::new(SelectField::Include(["a"].into()), root());
-    /// let exclude = SelectExpr::new(SelectField::Exclude(["b", "c"].into()), root());
+    /// let include = SelectExpr::new(FieldSelection::Include(["a"].into()), root());
+    /// let exclude = SelectExpr::new(FieldSelection::Exclude(["b", "c"].into()), root());
     /// assert_eq!(
     ///     &include.as_include(&field_names).unwrap(),
     ///     &exclude.as_include(&field_names).unwrap()

--- a/vortex-expr/src/exprs/select.rs
+++ b/vortex-expr/src/exprs/select.rs
@@ -15,7 +15,7 @@ use crate::field::DisplayFieldNames;
 use crate::{AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTable, vtable};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum SelectField {
+pub enum FieldSelection {
     Include(FieldNames),
     Exclude(FieldNames),
 }
@@ -25,13 +25,13 @@ vtable!(Select);
 #[derive(Debug, Clone, Hash, Eq)]
 #[allow(clippy::derived_hash_with_manual_eq)]
 pub struct SelectExpr {
-    fields: SelectField,
+    selection: FieldSelection,
     child: ExprRef,
 }
 
 impl PartialEq for SelectExpr {
     fn eq(&self, other: &Self) -> bool {
-        self.fields == other.fields && self.child.eq(&other.child)
+        self.selection == other.selection && self.child.eq(&other.child)
     }
 }
 
@@ -52,13 +52,13 @@ impl VTable for SelectVTable {
 
     fn metadata(expr: &Self::Expr) -> Option<Self::Metadata> {
         let names = expr
-            .fields()
-            .fields()
+            .selection()
+            .field_names()
             .iter()
             .map(|f| f.to_string())
             .collect_vec();
 
-        let opts = if expr.fields().is_include() {
+        let opts = if expr.selection().is_include() {
             Opts::Include(ProtoFieldNames { names })
         } else {
             Opts::Exclude(ProtoFieldNames { names })
@@ -73,7 +73,7 @@ impl VTable for SelectVTable {
 
     fn with_children(expr: &Self::Expr, children: Vec<ExprRef>) -> VortexResult<Self::Expr> {
         Ok(SelectExpr {
-            fields: expr.fields.clone(),
+            selection: expr.selection.clone(),
             child: children[0].clone(),
         })
     }
@@ -89,10 +89,10 @@ impl VTable for SelectVTable {
 
         let fields = match metadata.opts.as_ref() {
             Some(opts) => match opts {
-                Opts::Include(field_names) => SelectField::Include(FieldNames::from_iter(
+                Opts::Include(field_names) => FieldSelection::Include(FieldNames::from_iter(
                     field_names.names.iter().map(|s| s.as_str()),
                 )),
-                Opts::Exclude(field_names) => SelectField::Exclude(FieldNames::from_iter(
+                Opts::Exclude(field_names) => FieldSelection::Exclude(FieldNames::from_iter(
                     field_names.names.iter().map(|s| s.as_str()),
                 )),
             },
@@ -106,14 +106,17 @@ impl VTable for SelectVTable {
             .next()
             .vortex_expect("number of children validated to be one");
 
-        Ok(SelectExpr { fields, child })
+        Ok(SelectExpr {
+            selection: fields,
+            child,
+        })
     }
 
     fn evaluate(expr: &Self::Expr, scope: &Scope) -> VortexResult<ArrayRef> {
         let batch = expr.child.unchecked_evaluate(scope)?.to_struct();
-        Ok(match &expr.fields {
-            SelectField::Include(f) => batch.project(f.as_ref()),
-            SelectField::Exclude(names) => {
+        Ok(match &expr.selection {
+            FieldSelection::Include(f) => batch.project(f.as_ref()),
+            FieldSelection::Exclude(names) => {
                 let included_names = batch
                     .names()
                     .iter()
@@ -132,9 +135,9 @@ impl VTable for SelectVTable {
             .as_struct_fields_opt()
             .ok_or_else(|| vortex_err!("Select child not a struct dtype"))?;
 
-        let projected = match &expr.fields {
-            SelectField::Include(fields) => child_struct_dtype.project(fields.as_ref())?,
-            SelectField::Exclude(fields) => child_struct_dtype
+        let projected = match &expr.selection {
+            FieldSelection::Include(fields) => child_struct_dtype.project(fields.as_ref())?,
+            FieldSelection::Exclude(fields) => child_struct_dtype
                 .names()
                 .iter()
                 .cloned()
@@ -154,8 +157,8 @@ impl VTable for SelectVTable {
 /// # use vortex_expr::{select, root};
 /// let expr = select(["name", "age"], root());
 /// ```
-pub fn select(fields: impl Into<FieldNames>, child: ExprRef) -> ExprRef {
-    SelectExpr::include_expr(fields.into(), child)
+pub fn select(field_names: impl Into<FieldNames>, child: ExprRef) -> ExprRef {
+    SelectExpr::include_expr(field_names.into(), child)
 }
 
 /// Creates an expression that excludes specific fields from an array.
@@ -171,24 +174,27 @@ pub fn select_exclude(fields: impl Into<FieldNames>, child: ExprRef) -> ExprRef 
 }
 
 impl SelectExpr {
-    pub fn new(fields: SelectField, child: ExprRef) -> Self {
-        Self { fields, child }
+    pub fn new(fields: FieldSelection, child: ExprRef) -> Self {
+        Self {
+            selection: fields,
+            child,
+        }
     }
 
-    pub fn new_expr(fields: SelectField, child: ExprRef) -> ExprRef {
+    pub fn new_expr(fields: FieldSelection, child: ExprRef) -> ExprRef {
         Self::new(fields, child).into_expr()
     }
 
     pub fn include_expr(columns: FieldNames, child: ExprRef) -> ExprRef {
-        Self::new(SelectField::Include(columns), child).into_expr()
+        Self::new(FieldSelection::Include(columns), child).into_expr()
     }
 
     pub fn exclude_expr(columns: FieldNames, child: ExprRef) -> ExprRef {
-        Self::new(SelectField::Exclude(columns), child).into_expr()
+        Self::new(FieldSelection::Exclude(columns), child).into_expr()
     }
 
-    pub fn fields(&self) -> &SelectField {
-        &self.fields
+    pub fn selection(&self) -> &FieldSelection {
+        &self.selection
     }
 
     pub fn child(&self) -> &ExprRef {
@@ -212,14 +218,14 @@ impl SelectExpr {
     /// ```
     pub fn as_include(&self, field_names: &FieldNames) -> VortexResult<ExprRef> {
         Ok(Self::new(
-            SelectField::Include(self.fields.as_include_names(field_names)?),
+            FieldSelection::Include(self.selection.as_include_names(field_names)?),
             self.child.clone(),
         )
         .into_expr())
     }
 }
 
-impl SelectField {
+impl FieldSelection {
     pub fn include(columns: FieldNames) -> Self {
         assert_eq!(columns.iter().unique().collect_vec().len(), columns.len());
         Self::Include(columns)
@@ -238,15 +244,15 @@ impl SelectField {
         matches!(self, Self::Exclude(_))
     }
 
-    pub fn fields(&self) -> &FieldNames {
-        let (SelectField::Include(fields) | SelectField::Exclude(fields)) = self;
+    pub fn field_names(&self) -> &FieldNames {
+        let (FieldSelection::Include(fields) | FieldSelection::Exclude(fields)) = self;
 
         fields
     }
 
     pub fn as_include_names(&self, field_names: &FieldNames) -> VortexResult<FieldNames> {
         if self
-            .fields()
+            .field_names()
             .iter()
             .any(|f| !field_names.iter().contains(f))
         {
@@ -257,8 +263,8 @@ impl SelectField {
             );
         }
         match self {
-            SelectField::Include(fields) => Ok(fields.clone()),
-            SelectField::Exclude(exc_fields) => Ok(field_names
+            FieldSelection::Include(fields) => Ok(fields.clone()),
+            FieldSelection::Exclude(exc_fields) => Ok(field_names
                 .iter()
                 .filter(|f| !exc_fields.iter().contains(f))
                 .cloned()
@@ -267,11 +273,11 @@ impl SelectField {
     }
 }
 
-impl Display for SelectField {
+impl Display for FieldSelection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SelectField::Include(fields) => write!(f, "{{{}}}", DisplayFieldNames(fields)),
-            SelectField::Exclude(fields) => write!(f, "~{{{}}}", DisplayFieldNames(fields)),
+            FieldSelection::Include(fields) => write!(f, "{{{}}}", DisplayFieldNames(fields)),
+            FieldSelection::Exclude(fields) => write!(f, "~{{{}}}", DisplayFieldNames(fields)),
         }
     }
 }
@@ -280,16 +286,21 @@ impl DisplayAs for SelectExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
             DisplayFormat::Compact => {
-                write!(f, "{}{}", self.child, self.fields)
+                write!(f, "{}{}", self.child, self.selection)
             }
             DisplayFormat::Tree => {
-                let field_type = if self.fields.is_include() {
+                let field_type = if self.selection.is_include() {
                     "include"
                 } else {
                     "exclude"
                 };
 
-                write!(f, "Select({}): {}", field_type, self.fields().fields())
+                write!(
+                    f,
+                    "Select({}): {}",
+                    field_type,
+                    self.selection().field_names()
+                )
             }
         }
     }
@@ -310,7 +321,7 @@ mod tests {
     use vortex_buffer::buffer;
     use vortex_dtype::{DType, FieldName, FieldNames, Nullability};
 
-    use crate::{Scope, SelectExpr, SelectField, root, select, select_exclude, test_harness};
+    use crate::{FieldSelection, Scope, SelectExpr, root, select, select_exclude, test_harness};
 
     fn test_array() -> StructArray {
         StructArray::from_fields(&[
@@ -393,8 +404,8 @@ mod tests {
     #[test]
     fn test_as_include_names() {
         let field_names = FieldNames::from(["a", "b", "c"]);
-        let include = SelectExpr::new(SelectField::Include(["a"].into()), root());
-        let exclude = SelectExpr::new(SelectField::Exclude(["b", "c"].into()), root());
+        let include = SelectExpr::new(FieldSelection::Include(["a"].into()), root());
+        let exclude = SelectExpr::new(FieldSelection::Exclude(["b", "c"].into()), root());
         assert_eq!(
             &include.as_include(&field_names).unwrap(),
             &exclude.as_include(&field_names).unwrap()

--- a/vortex-expr/src/transform/remove_select.rs
+++ b/vortex-expr/src/transform/remove_select.rs
@@ -29,12 +29,12 @@ fn remove_select_transformer(node: ExprRef, ctx: &DType) -> VortexResult<Transfo
 
             let expr = pack(
                 select
-                    .fields()
+                    .selection()
                     .as_include_names(child_dtype.names())
                     .map_err(|e| {
                         e.with_context(format!(
                             "Select fields {:?} must be a subset of child fields {:?}",
-                            select.fields(),
+                            select.selection(),
                             child_dtype.names()
                         ))
                     })?

--- a/vortex-expr/src/traversal/references.rs
+++ b/vortex-expr/src/traversal/references.rs
@@ -37,7 +37,8 @@ impl NodeVisitor<'_> for ReferenceCollector {
             self.fields.insert(get_item.field().clone());
         }
         if let Some(sel) = node.as_opt::<SelectVTable>() {
-            self.fields.extend(sel.fields().fields().iter().cloned());
+            self.fields
+                .extend(sel.selection().field_names().iter().cloned());
         }
         Ok(TraversalOrder::Continue)
     }

--- a/vortex-scalar/src/struct_.rs
+++ b/vortex-scalar/src/struct_.rs
@@ -164,7 +164,7 @@ impl<'a> StructScalar<'a> {
     }
 
     /// Returns the fields of the struct scalar, or None if the scalar is null.
-    pub fn fields(&self) -> Option<impl Iterator<Item = Scalar>> {
+    pub fn fields(&self) -> Option<impl ExactSizeIterator<Item = Scalar>> {
         let fields = self.fields?;
         Some(
             fields


### PR DESCRIPTION
Unfortunately a minor breaking change to the API, but the amount of `fields()` functions we have is just too much.