### PR TITLE
docs: clarify duckdb dictionary and dictionary slice

### DIFF
--- a/vortex-duckdb/cpp/include/duckdb_vx/vector.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/vector.h
@@ -10,12 +10,19 @@
 extern "C" {
 #endif
 
-/// Slice to a dictionary vector.
+/// Slice the vector to a new dictionary vector, using the current vector's values and
+/// the provided selection vector.
+///
+/// A dictionary slice holds a strong reference to all memory it uses.
 void duckdb_vx_vector_slice_to_dictionary(duckdb_vector ffi_vector, duckdb_selection_vector selection_vector,
                                           idx_t selection_vector_length);
 
-/// Turn vector into a dictionary vector. In contrast to `duckdb_vx_vector_slice_to_dictionary` this
-/// call creates a dictionary that holds a strong reference to its children.
+/// Creates a dictionary vector for a given values vector and selection vector.
+///
+/// A dictionary holds a strong reference to all memory it uses.
+///
+/// `dictionary` differs from `slice_to_dictionary` in that it initializes hash caching:
+/// https://github.com/duckdb/duckdb/blob/0dcf633f603a629981d089202f93b9080cb1a3e9/src/common/types/vector.cpp#L293
 void duckdb_vx_vector_dictionary(duckdb_vector ffi_vector, duckdb_vector ffi_dict, idx_t dictionary_size,
                                  duckdb_selection_vector ffi_sel_vec, idx_t count);
 

--- a/vortex-duckdb/src/duckdb/vector.rs
+++ b/vortex-duckdb/src/duckdb/vector.rs
@@ -53,6 +53,8 @@ impl Vector {
 
     /// Slice the vector to a new dictionary vector, using the current vector's values and
     /// the provided selection vector.
+    ///
+    /// A dictionary slice holds a strong reference to all memory it uses.
     pub fn slice_to_dictionary(&mut self, sel_vec: SelectionVector, sel_vec_length: usize) {
         unsafe {
             cpp::duckdb_vx_vector_slice_to_dictionary(
@@ -63,8 +65,12 @@ impl Vector {
         }
     }
 
-    /// Turn vector into a dictionary vector. In contrast to `slice_to_dictionary` this
-    /// call creates a dictionary that holds a strong reference to its children.
+    /// Creates a dictionary vector for a given values vector and selection vector.
+    ///
+    /// A dictionary holds a strong reference to all memory it uses.
+    ///
+    /// `dictionary` differs from `slice_to_dictionary` in that it initializes hash caching.
+    /// See: <https://github.com/duckdb/duckdb/blob/0dcf633f603a629981d089202f93b9080cb1a3e9/src/common/types/vector.cpp#L293>
     pub fn dictionary(
         &self,
         dict: &Vector,
@@ -561,5 +567,49 @@ mod tests {
         assert!(validity.is_valid(32), "Row 32 should be valid");
         assert!(validity.is_valid(62), "Row 62 should be valid");
         assert!(validity.is_valid(65), "Row 65 should be valid");
+    }
+
+    #[test]
+    fn test_slice_to_dictionary() {
+        let len = 2;
+        let logical_type = LogicalType::new(DUCKDB_TYPE::DUCKDB_TYPE_INTEGER);
+        let mut vector = Vector::with_capacity(logical_type, len);
+
+        let slice = unsafe { vector.as_slice_mut::<i32>(len) };
+        slice[0] = 10;
+        slice[1] = 20;
+
+        let mut sel_vec = SelectionVector::with_capacity(2);
+        let sel_slice = unsafe { sel_vec.as_slice_mut(2) };
+        sel_slice[0] = 1;
+        sel_slice[1] = 0;
+
+        vector.slice_to_dictionary(sel_vec, 2);
+        vector.flatten(2);
+
+        assert_eq!(vector.as_slice_with_len::<i32>(2), &[20, 10]);
+    }
+
+    #[test]
+    fn test_dictionary() {
+        let logical_type = LogicalType::new(DUCKDB_TYPE::DUCKDB_TYPE_INTEGER);
+
+        let mut dict = Vector::with_capacity(logical_type.clone(), 2);
+        let dict_slice = unsafe { dict.as_slice_mut::<i32>(2) };
+        dict_slice[0] = 100;
+        dict_slice[1] = 200;
+
+        let vector = Vector::with_capacity(logical_type, 3);
+
+        let mut sel_vec = SelectionVector::with_capacity(3);
+        let sel_slice = unsafe { sel_vec.as_slice_mut(3) };
+        sel_slice[0] = 0;
+        sel_slice[1] = 1;
+        sel_slice[2] = 0;
+
+        vector.dictionary(&dict, 2, &sel_vec, 3);
+        vector.flatten(3);
+
+        assert_eq!(vector.as_slice_with_len::<i32>(3), &[100, 200, 100]);
     }
 }


### PR DESCRIPTION
I read a bit more in the DuckDB source code concluding that both hold a strong ref to all memory that they use.
