### PR TITLE
chore: drop "invalid sql" test as it triggers exception breakpoints

### DIFF
--- a/vortex-duckdb/src/duckdb/connection.rs
+++ b/vortex-duckdb/src/duckdb/connection.rs
@@ -93,15 +93,6 @@ mod tests {
     }
 
     #[test]
-    fn test_execute_invalid_sql() {
-        let conn = test_connection().unwrap();
-        let result = conn.query("INVALID SQL STATEMENT");
-        assert!(result.is_err());
-        let error_msg = result.unwrap_err().to_string();
-        assert!(error_msg.contains("Failed to execute query"));
-    }
-
-    #[test]
     fn test_execute_with_null_bytes() {
         let conn = test_connection().unwrap();
         let result = conn.query("SELECT\0 1");


### PR DESCRIPTION
This lead to poor DX when running `vortex-duckdb` unit tests, as `lldb` stops multiple times on exception breakpoints. It is expected though and correct behavior that DuckDB throws an exception for invalid SQL queries.