### PR TITLE
Chore: rename some methods

### DIFF
--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -321,7 +321,7 @@ fn canonicalize_sparse_fixed_size_list_inner<I: NativePType>(
 
         // Append the patch value, handling null patches by appending defaults.
         if values.validity().is_valid(patch_idx) {
-            let patch_list = values.fixed_size_list_at(patch_idx);
+            let patch_list = values.fixed_size_list_elements_at(patch_idx);
             for i in 0..list_size as usize {
                 builder
                     .append_scalar(&patch_list.scalar_at(i))

--- a/vortex-array/src/arrays/constant/canonical.rs
+++ b/vortex-array/src/arrays/constant/canonical.rs
@@ -471,7 +471,7 @@ mod tests {
 
         // Check that each list is [10, 20, 30].
         for i in 0..4 {
-            let list = canonical.fixed_size_list_at(i);
+            let list = canonical.fixed_size_list_elements_at(i);
             let list_primitive = list.to_primitive();
             assert_eq!(list_primitive.as_slice::<i32>(), [10, 20, 30]);
         }

--- a/vortex-array/src/arrays/fixed_size_list/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/mod.rs
@@ -145,12 +145,12 @@ impl FixedSizeListArray {
         self.list_size
     }
 
-    /// Returns the elements at the given index from the list array.
+    /// Returns the elements of the fixed-size list scalar at the given index of the list array.
     ///
     /// # Panics
     ///
     /// Panics if the index is out of bounds.
-    pub fn fixed_size_list_at(&self, index: usize) -> ArrayRef {
+    pub fn fixed_size_list_elements_at(&self, index: usize) -> ArrayRef {
         debug_assert!(
             index < self.len,
             "index out of bounds: the len is {} but the index is {index}",

--- a/vortex-array/src/arrays/fixed_size_list/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/mod.rs
@@ -19,6 +19,49 @@ mod tests;
 mod compute;
 
 /// The canonical encoding for fixed-size list arrays.
+///
+/// A fixed-size list array stores lists where each list has the same number of elements. This is
+/// similar to a 2D array or matrix where the inner dimension is fixed.
+///
+/// ## Data Layout
+///
+/// Unlike [`ListArray`] which uses offsets, `FixedSizeListArray` stores elements contiguously and
+/// uses a fixed `list_size`:
+///
+/// - **Elements array**: A flat array containing all list elements concatenated together
+/// - **List size**: The fixed number of elements in each list
+/// - **Validity**: Optional mask indicating which lists are null
+///
+/// The list at index `i` contains elements from `elements[i * list_size..(i + 1) * list_size]`.
+///
+/// [`ListArray`]: crate::arrays::ListArray
+///
+/// # Examples
+///
+/// ```
+/// use vortex_array::arrays::{FixedSizeListArray, PrimitiveArray};
+/// use vortex_array::validity::Validity;
+/// use vortex_array::IntoArray;
+/// use vortex_buffer::buffer;
+///
+/// // Create a fixed-size list array representing [[1, 2] [3, 4], [5, 6], [7, 8]]
+/// let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8].into_array();
+/// let list_size = 2;
+///
+/// let fixed_list_array = FixedSizeListArray::new(
+///     elements.into_array(),
+///     list_size,
+///     Validity::NonNullable,
+///     4, // 4 lists
+/// );
+///
+/// assert_eq!(fixed_list_array.len(), 4);
+/// assert_eq!(fixed_list_array.list_size(), 2);
+///
+/// // Access individual lists
+/// let first_list = fixed_list_array.fixed_size_list_elements_at(0);
+/// assert_eq!(first_list.len(), 2);
+/// ```
 #[derive(Clone, Debug)]
 pub struct FixedSizeListArray {
     /// The [`DType`] of the fixed-size list.

--- a/vortex-array/src/arrays/fixed_size_list/tests/basic.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/basic.rs
@@ -32,22 +32,22 @@ fn test_basic_fixed_size_list() {
     ));
 
     // Check the actual values in each list.
-    let first_list = fsl.fixed_size_list_at(0);
+    let first_list = fsl.fixed_size_list_elements_at(0);
     assert_eq!(first_list.scalar_at(0), 1i32.into());
     assert_eq!(first_list.scalar_at(1), 2i32.into());
     assert_eq!(first_list.scalar_at(2), 3i32.into());
 
-    let second_list = fsl.fixed_size_list_at(1);
+    let second_list = fsl.fixed_size_list_elements_at(1);
     assert_eq!(second_list.scalar_at(0), 4i32.into());
     assert_eq!(second_list.scalar_at(1), 5i32.into());
     assert_eq!(second_list.scalar_at(2), 6i32.into());
 
-    let third_list = fsl.fixed_size_list_at(2);
+    let third_list = fsl.fixed_size_list_elements_at(2);
     assert_eq!(third_list.scalar_at(0), 7i32.into());
     assert_eq!(third_list.scalar_at(1), 8i32.into());
     assert_eq!(third_list.scalar_at(2), 9i32.into());
 
-    let fourth_list = fsl.fixed_size_list_at(3);
+    let fourth_list = fsl.fixed_size_list_elements_at(3);
     assert_eq!(fourth_list.scalar_at(0), 10i32.into());
     assert_eq!(fourth_list.scalar_at(1), 11i32.into());
     assert_eq!(fourth_list.scalar_at(2), 12i32.into());
@@ -73,7 +73,7 @@ fn test_scalar_at() {
     );
 
     // Additionally check individual elements via fixed_size_list_at.
-    let first_list = fsl.fixed_size_list_at(0);
+    let first_list = fsl.fixed_size_list_elements_at(0);
     assert_eq!(first_list.scalar_at(0), 1i32.into());
     assert_eq!(first_list.scalar_at(1), 2i32.into());
     assert_eq!(first_list.scalar_at(2), 3i32.into());
@@ -90,7 +90,7 @@ fn test_scalar_at() {
     );
 
     // Additionally check individual elements via fixed_size_list_at.
-    let second_list = fsl.fixed_size_list_at(1);
+    let second_list = fsl.fixed_size_list_elements_at(1);
     assert_eq!(second_list.scalar_at(0), 4i32.into());
     assert_eq!(second_list.scalar_at(1), 5i32.into());
     assert_eq!(second_list.scalar_at(2), 6i32.into());
@@ -105,13 +105,13 @@ fn test_fixed_size_list_at() {
     let fsl = FixedSizeListArray::new(elements, list_size, Validity::AllValid, len);
 
     // Get the first list [1.0, 2.0].
-    let first_list = fsl.fixed_size_list_at(0);
+    let first_list = fsl.fixed_size_list_elements_at(0);
     assert_eq!(first_list.len(), list_size as usize);
     assert_eq!(first_list.scalar_at(0), 1.0f64.into());
     assert_eq!(first_list.scalar_at(1), 2.0f64.into());
 
     // Get the third list [5.0, 6.0].
-    let third_list = fsl.fixed_size_list_at(2);
+    let third_list = fsl.fixed_size_list_elements_at(2);
     assert_eq!(third_list.len(), list_size as usize);
     assert_eq!(third_list.scalar_at(0), 5.0f64.into());
     assert_eq!(third_list.scalar_at(1), 6.0f64.into());

--- a/vortex-array/src/arrays/fixed_size_list/tests/filter.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/filter.rs
@@ -62,12 +62,12 @@ fn test_filter_alternating() {
     assert_eq!(filtered_fsl.elements().len(), 4);
 
     // First list should be [1, 2].
-    let first = filtered_fsl.fixed_size_list_at(0);
+    let first = filtered_fsl.fixed_size_list_elements_at(0);
     assert_eq!(first.scalar_at(0), 1i32.into());
     assert_eq!(first.scalar_at(1), 2i32.into());
 
     // Second list should be [5, 6].
-    let second = filtered_fsl.fixed_size_list_at(1);
+    let second = filtered_fsl.fixed_size_list_elements_at(1);
     assert_eq!(second.scalar_at(0), 5i32.into());
     assert_eq!(second.scalar_at(1), 6i32.into());
 }
@@ -86,13 +86,13 @@ fn test_filter_selective() {
     assert_eq!(filtered_fsl.elements().len(), 6);
 
     // First list should be [4.0, 5.0, 6.0].
-    let first = filtered_fsl.fixed_size_list_at(0);
+    let first = filtered_fsl.fixed_size_list_elements_at(0);
     assert_eq!(first.scalar_at(0), 4.0f64.into());
     assert_eq!(first.scalar_at(1), 5.0f64.into());
     assert_eq!(first.scalar_at(2), 6.0f64.into());
 
     // Second list should be [7.0, 8.0, 9.0].
-    let second = filtered_fsl.fixed_size_list_at(1);
+    let second = filtered_fsl.fixed_size_list_elements_at(1);
     assert_eq!(second.scalar_at(0), 7.0f64.into());
     assert_eq!(second.scalar_at(1), 8.0f64.into());
     assert_eq!(second.scalar_at(2), 9.0f64.into());
@@ -126,7 +126,7 @@ fn test_filter_single_element() {
     assert_eq!(filtered_fsl.list_size(), 3);
     assert_eq!(filtered_fsl.elements().len(), 3);
 
-    let first = filtered_fsl.fixed_size_list_at(0);
+    let first = filtered_fsl.fixed_size_list_elements_at(0);
     assert_eq!(first.scalar_at(0), 42i32.into());
     assert_eq!(first.scalar_at(1), 43i32.into());
     assert_eq!(first.scalar_at(2), 44i32.into());
@@ -222,12 +222,12 @@ fn test_filter_with_nulls() {
     assert_eq!(filtered_fsl.list_size(), 2);
 
     // First list should be [1, 2] and valid.
-    let first = filtered_fsl.fixed_size_list_at(0);
+    let first = filtered_fsl.fixed_size_list_elements_at(0);
     assert_eq!(first.scalar_at(0), 1i32.into());
     assert_eq!(first.scalar_at(1), 2i32.into());
 
     // Second list should be [5, 6] and valid.
-    let second = filtered_fsl.fixed_size_list_at(1);
+    let second = filtered_fsl.fixed_size_list_elements_at(1);
     assert_eq!(second.scalar_at(0), 5i32.into());
     assert_eq!(second.scalar_at(1), 6i32.into());
 }
@@ -292,15 +292,15 @@ fn test_filter_nested_fixed_size_lists() {
     assert_eq!(filtered_inner.list_size(), 2);
 
     // Check the actual values.
-    let inner_list_0 = filtered_inner.fixed_size_list_at(0);
+    let inner_list_0 = filtered_inner.fixed_size_list_elements_at(0);
     assert_eq!(inner_list_0.scalar_at(0), 7i32.into());
     assert_eq!(inner_list_0.scalar_at(1), 8i32.into());
 
-    let inner_list_1 = filtered_inner.fixed_size_list_at(1);
+    let inner_list_1 = filtered_inner.fixed_size_list_elements_at(1);
     assert_eq!(inner_list_1.scalar_at(0), 9i32.into());
     assert_eq!(inner_list_1.scalar_at(1), 10i32.into());
 
-    let inner_list_2 = filtered_inner.fixed_size_list_at(2);
+    let inner_list_2 = filtered_inner.fixed_size_list_elements_at(2);
     assert_eq!(inner_list_2.scalar_at(0), 11i32.into());
     assert_eq!(inner_list_2.scalar_at(1), 12i32.into());
 }
@@ -442,7 +442,7 @@ fn test_complex_filter_pattern() {
     // Original indices kept: 0, 1, 3, 6, 7, 8.
     let expected_starts = [0i32, 3, 9, 18, 21, 24];
     for (i, &start) in expected_starts.iter().enumerate() {
-        let list = filtered_fsl.fixed_size_list_at(i);
+        let list = filtered_fsl.fixed_size_list_elements_at(i);
         assert_eq!(list.scalar_at(0), (start).into());
         assert_eq!(list.scalar_at(1), (start + 1).into());
         assert_eq!(list.scalar_at(2), (start + 2).into());
@@ -474,13 +474,13 @@ fn test_filter_large_list_size() {
     assert_eq!(filtered_fsl.elements().len(), 3 * list_size as usize);
 
     // Check that the correct lists were kept (indices 1, 3, 4).
-    let list_0 = filtered_fsl.fixed_size_list_at(0);
+    let list_0 = filtered_fsl.fixed_size_list_elements_at(0);
     assert_eq!(list_0.scalar_at(0), 100i64.into()); // Start of original list 1.
 
-    let list_1 = filtered_fsl.fixed_size_list_at(1);
+    let list_1 = filtered_fsl.fixed_size_list_elements_at(1);
     assert_eq!(list_1.scalar_at(0), 300i64.into()); // Start of original list 3.
 
-    let list_2 = filtered_fsl.fixed_size_list_at(2);
+    let list_2 = filtered_fsl.fixed_size_list_elements_at(2);
     assert_eq!(list_2.scalar_at(0), 400i64.into()); // Start of original list 4.
 }
 
@@ -556,13 +556,13 @@ fn test_mask_expansion_threshold_boundary() {
     assert_eq!(filtered_fsl.elements().len(), 3 * list_size as usize);
 
     // Verify correct elements were kept.
-    let first = filtered_fsl.fixed_size_list_at(0);
+    let first = filtered_fsl.fixed_size_list_elements_at(0);
     assert_eq!(first.scalar_at(0), (5i32 * list_size as i32).into());
 
-    let second = filtered_fsl.fixed_size_list_at(1);
+    let second = filtered_fsl.fixed_size_list_elements_at(1);
     assert_eq!(second.scalar_at(0), (25i32 * list_size as i32).into());
 
-    let third = filtered_fsl.fixed_size_list_at(2);
+    let third = filtered_fsl.fixed_size_list_elements_at(2);
     assert_eq!(third.scalar_at(0), (75i32 * list_size as i32).into());
 
     // Test with list_size == 7 (just below threshold).

--- a/vortex-array/src/arrays/fixed_size_list/tests/nested.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/nested.rs
@@ -58,7 +58,7 @@ fn test_fsl_of_fsl_basic() {
     ));
 
     // Get the first outer list.
-    let first_outer = outer_fsl.fixed_size_list_at(0);
+    let first_outer = outer_fsl.fixed_size_list_elements_at(0);
     assert_eq!(first_outer.len(), outer_list_size as usize);
 
     // The first outer list should contain 3 inner lists.
@@ -68,38 +68,50 @@ fn test_fsl_of_fsl_basic() {
 
     // Check the actual values in the nested structure.
     // First outer list contains: [[1,2], [3,4], [5,6]].
-    let first_outer_list = outer_fsl.fixed_size_list_at(0);
+    let first_outer_list = outer_fsl.fixed_size_list_elements_at(0);
 
     // Check first inner list [1,2].
-    let inner_list_0 = first_outer_list.to_fixed_size_list().fixed_size_list_at(0);
+    let inner_list_0 = first_outer_list
+        .to_fixed_size_list()
+        .fixed_size_list_elements_at(0);
     assert_eq!(inner_list_0.scalar_at(0), 1i32.into());
     assert_eq!(inner_list_0.scalar_at(1), 2i32.into());
 
     // Check second inner list [3,4].
-    let inner_list_1 = first_outer_list.to_fixed_size_list().fixed_size_list_at(1);
+    let inner_list_1 = first_outer_list
+        .to_fixed_size_list()
+        .fixed_size_list_elements_at(1);
     assert_eq!(inner_list_1.scalar_at(0), 3i32.into());
     assert_eq!(inner_list_1.scalar_at(1), 4i32.into());
 
     // Check third inner list [5,6].
-    let inner_list_2 = first_outer_list.to_fixed_size_list().fixed_size_list_at(2);
+    let inner_list_2 = first_outer_list
+        .to_fixed_size_list()
+        .fixed_size_list_elements_at(2);
     assert_eq!(inner_list_2.scalar_at(0), 5i32.into());
     assert_eq!(inner_list_2.scalar_at(1), 6i32.into());
 
     // Second outer list contains: [[7,8], [9,10], [11,12]].
-    let second_outer_list = outer_fsl.fixed_size_list_at(1);
+    let second_outer_list = outer_fsl.fixed_size_list_elements_at(1);
 
     // Check first inner list [7,8].
-    let inner_list_0 = second_outer_list.to_fixed_size_list().fixed_size_list_at(0);
+    let inner_list_0 = second_outer_list
+        .to_fixed_size_list()
+        .fixed_size_list_elements_at(0);
     assert_eq!(inner_list_0.scalar_at(0), 7i32.into());
     assert_eq!(inner_list_0.scalar_at(1), 8i32.into());
 
     // Check second inner list [9,10].
-    let inner_list_1 = second_outer_list.to_fixed_size_list().fixed_size_list_at(1);
+    let inner_list_1 = second_outer_list
+        .to_fixed_size_list()
+        .fixed_size_list_elements_at(1);
     assert_eq!(inner_list_1.scalar_at(0), 9i32.into());
     assert_eq!(inner_list_1.scalar_at(1), 10i32.into());
 
     // Check third inner list [11,12].
-    let inner_list_2 = second_outer_list.to_fixed_size_list().fixed_size_list_at(2);
+    let inner_list_2 = second_outer_list
+        .to_fixed_size_list()
+        .fixed_size_list_elements_at(2);
     assert_eq!(inner_list_2.scalar_at(0), 11i32.into());
     assert_eq!(inner_list_2.scalar_at(1), 12i32.into());
 }
@@ -194,25 +206,29 @@ fn test_deeply_nested_fsl() {
 
     // Check the actual deeply nested values.
     // Structure: [[[1,2],[3,4]],[[5,6],[7,8]]].
-    let top_level = level3.fixed_size_list_at(0);
-    let level2_0 = top_level.to_fixed_size_list().fixed_size_list_at(0);
-    let level2_1 = top_level.to_fixed_size_list().fixed_size_list_at(1);
+    let top_level = level3.fixed_size_list_elements_at(0);
+    let level2_0 = top_level
+        .to_fixed_size_list()
+        .fixed_size_list_elements_at(0);
+    let level2_1 = top_level
+        .to_fixed_size_list()
+        .fixed_size_list_elements_at(1);
 
     // First level-2 list: [[1,2],[3,4]].
-    let level1_0_0 = level2_0.to_fixed_size_list().fixed_size_list_at(0);
+    let level1_0_0 = level2_0.to_fixed_size_list().fixed_size_list_elements_at(0);
     assert_eq!(level1_0_0.scalar_at(0), 1i32.into());
     assert_eq!(level1_0_0.scalar_at(1), 2i32.into());
 
-    let level1_0_1 = level2_0.to_fixed_size_list().fixed_size_list_at(1);
+    let level1_0_1 = level2_0.to_fixed_size_list().fixed_size_list_elements_at(1);
     assert_eq!(level1_0_1.scalar_at(0), 3i32.into());
     assert_eq!(level1_0_1.scalar_at(1), 4i32.into());
 
     // Second level-2 list: [[5,6],[7,8]].
-    let level1_1_0 = level2_1.to_fixed_size_list().fixed_size_list_at(0);
+    let level1_1_0 = level2_1.to_fixed_size_list().fixed_size_list_elements_at(0);
     assert_eq!(level1_1_0.scalar_at(0), 5i32.into());
     assert_eq!(level1_1_0.scalar_at(1), 6i32.into());
 
-    let level1_1_1 = level2_1.to_fixed_size_list().fixed_size_list_at(1);
+    let level1_1_1 = level2_1.to_fixed_size_list().fixed_size_list_elements_at(1);
     assert_eq!(level1_1_1.scalar_at(0), 7i32.into());
     assert_eq!(level1_1_1.scalar_at(1), 8i32.into());
 }

--- a/vortex-array/src/arrays/fixed_size_list/tests/nullability.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/nullability.rs
@@ -37,7 +37,7 @@ fn test_nullable_fsl_with_nulls() {
     );
 
     // Check individual elements of the first list.
-    let first_list = fsl.fixed_size_list_at(0);
+    let first_list = fsl.fixed_size_list_elements_at(0);
     assert_eq!(first_list.scalar_at(0), 1i32.into());
     assert_eq!(first_list.scalar_at(1), 2i32.into());
 
@@ -58,7 +58,7 @@ fn test_nullable_fsl_with_nulls() {
     );
 
     // Check individual elements of the third list.
-    let third_list = fsl.fixed_size_list_at(2);
+    let third_list = fsl.fixed_size_list_elements_at(2);
     assert_eq!(third_list.scalar_at(0), 5i32.into());
     assert_eq!(third_list.scalar_at(1), 6i32.into());
 
@@ -137,7 +137,7 @@ fn test_nullable_elements_and_nullable_lists() {
     );
 
     // Check individual elements of the first list.
-    let first_list = fsl.fixed_size_list_at(0);
+    let first_list = fsl.fixed_size_list_elements_at(0);
     assert_eq!(first_list.scalar_at(0), Some(10u16).into());
     assert_eq!(first_list.scalar_at(1), None::<u16>.into());
 
@@ -158,7 +158,7 @@ fn test_nullable_elements_and_nullable_lists() {
     );
 
     // Check individual elements of the third list.
-    let third_list = fsl.fixed_size_list_at(2);
+    let third_list = fsl.fixed_size_list_elements_at(2);
     assert_eq!(third_list.scalar_at(0), None::<u16>.into());
     assert_eq!(third_list.scalar_at(1), None::<u16>.into());
 }

--- a/vortex-array/src/arrays/fixed_size_list/tests/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/take.rs
@@ -27,17 +27,17 @@ fn test_take_basic() {
     assert_eq!(result_fsl.list_size(), 2);
 
     // First list should be the original third list [5, 6].
-    let first = result_fsl.fixed_size_list_at(0);
+    let first = result_fsl.fixed_size_list_elements_at(0);
     assert_eq!(first.scalar_at(0), 5i32.into());
     assert_eq!(first.scalar_at(1), 6i32.into());
 
     // Second list should be the original first list [1, 2].
-    let second = result_fsl.fixed_size_list_at(1);
+    let second = result_fsl.fixed_size_list_elements_at(1);
     assert_eq!(second.scalar_at(0), 1i32.into());
     assert_eq!(second.scalar_at(1), 2i32.into());
 
     // Third list should be the original second list [3, 4].
-    let third = result_fsl.fixed_size_list_at(2);
+    let third = result_fsl.fixed_size_list_elements_at(2);
     assert_eq!(third.scalar_at(0), 3i32.into());
     assert_eq!(third.scalar_at(1), 4i32.into());
 }
@@ -92,7 +92,7 @@ fn test_take_single_index() {
     assert_eq!(result_fsl.len(), 1);
     assert_eq!(result_fsl.list_size(), 2);
 
-    let list = result_fsl.fixed_size_list_at(0);
+    let list = result_fsl.fixed_size_list_elements_at(0);
     assert_eq!(list.scalar_at(0), 30i64.into());
     assert_eq!(list.scalar_at(1), 40i64.into());
 }
@@ -112,7 +112,7 @@ fn test_take_with_null_indices() {
 
     // First list should be [3, 4].
     assert!(!result_fsl.scalar_at(0).is_null());
-    let first = result_fsl.fixed_size_list_at(0);
+    let first = result_fsl.fixed_size_list_elements_at(0);
     assert_eq!(first.scalar_at(0), 3i32.into());
     assert_eq!(first.scalar_at(1), 4i32.into());
 
@@ -121,7 +121,7 @@ fn test_take_with_null_indices() {
 
     // Third list should be [1, 2].
     assert!(!result_fsl.scalar_at(2).is_null());
-    let third = result_fsl.fixed_size_list_at(2);
+    let third = result_fsl.fixed_size_list_elements_at(2);
     assert_eq!(third.scalar_at(0), 1i32.into());
     assert_eq!(third.scalar_at(1), 2i32.into());
 }
@@ -244,13 +244,13 @@ fn test_take_large_list_size() {
     assert_eq!(result_fsl.list_size(), 10);
 
     // First list should be [20..30].
-    let first = result_fsl.fixed_size_list_at(0);
+    let first = result_fsl.fixed_size_list_elements_at(0);
     for i in 0..10i32 {
         assert_eq!(first.scalar_at(i as usize), (20 + i).into());
     }
 
     // Second list should be [0..10].
-    let second = result_fsl.fixed_size_list_at(1);
+    let second = result_fsl.fixed_size_list_elements_at(1);
     for i in 0..10i32 {
         assert_eq!(second.scalar_at(i as usize), i.into());
     }

--- a/vortex-array/src/arrays/fixed_size_list/vtable/operations.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/operations.rs
@@ -40,7 +40,8 @@ impl OperationsVTable<FixedSizeListVTable> for FixedSizeListVTable {
     }
 
     fn scalar_at(array: &FixedSizeListArray, index: usize) -> Scalar {
-        let list = array.fixed_size_list_at(index);
+        // By the preconditions we know that the list scalar is not null.
+        let list = array.fixed_size_list_elements_at(index);
         let children_elements: Vec<Scalar> = (0..list.len()).map(|i| list.scalar_at(i)).collect();
 
         debug_assert_eq!(children_elements.len(), array.list_size() as usize);

--- a/vortex-array/src/arrays/list/mod.rs
+++ b/vortex-array/src/arrays/list/mod.rs
@@ -97,10 +97,10 @@ impl VTable for ListVTable {
 /// assert_eq!(list_array.len(), 3);
 ///
 /// // Access individual lists
-/// let first_list = list_array.elements_at(0);
+/// let first_list = list_array.list_elements_at(0);
 /// assert_eq!(first_list.len(), 2); // [1, 2]
 ///
-/// let third_list = list_array.elements_at(2);
+/// let third_list = list_array.list_elements_at(2);
 /// assert!(third_list.is_empty()); // []
 /// ```
 #[derive(Clone, Debug)]
@@ -280,14 +280,17 @@ impl ListArray {
             })
     }
 
-    /// Returns the elements at the given index from the list array.
-    pub fn elements_at(&self, index: usize) -> ArrayRef {
+    /// Returns the elements of the list scalar at the given index of the list array.
+    pub fn list_elements_at(&self, index: usize) -> ArrayRef {
         let start = self.offset_at(index);
         let end = self.offset_at(index + 1);
         self.elements().slice(start..end)
     }
 
-    /// Returns elements of the list array referenced by the offsets array
+    /// Returns elements of the list array referenced by the offsets array.
+    ///
+    /// This is useful for discarding any potentially unused parts of the underlying `elements`
+    /// child array.
     pub fn sliced_elements(&self) -> ArrayRef {
         let start = self.offset_at(0);
         let end = self.offset_at(self.len());
@@ -304,7 +307,8 @@ impl ListArray {
         &self.elements
     }
 
-    /// Create a copy of this array by adjusting offsets to start at 0 and removing elements not referenced by the offsets
+    /// Create a copy of this array by adjusting `offsets` to start at `0` and removing elements not
+    /// referenced by the `offsets`.
     pub fn reset_offsets(&self) -> VortexResult<Self> {
         let elements = self.sliced_elements();
         let offsets = self.offsets();
@@ -340,11 +344,12 @@ impl OperationsVTable<ListVTable> for ListVTable {
     }
 
     fn scalar_at(array: &ListArray, index: usize) -> Scalar {
-        let elem = array.elements_at(index);
-        let scalars: Vec<Scalar> = (0..elem.len()).map(|i| elem.scalar_at(i)).collect();
+        // By the preconditions we know that the list scalar is not null.
+        let elems = array.list_elements_at(index);
+        let scalars: Vec<Scalar> = (0..elems.len()).map(|i| elems.scalar_at(i)).collect();
 
         Scalar::list(
-            Arc::new(elem.dtype().clone()),
+            Arc::new(elems.dtype().clone()),
             scalars,
             array.dtype().nullability(),
         )

--- a/vortex-array/src/arrays/list/tests.rs
+++ b/vortex-array/src/arrays/list/tests.rs
@@ -113,7 +113,7 @@ fn test_list_filter_dense_mask() {
     assert_eq!(filtered_list.len(), 5);
 
     // Verify first remaining list (originally index 1) has correct elements.
-    let first_list = filtered_list.elements_at(0);
+    let first_list = filtered_list.list_elements_at(0);
     assert_eq!(first_list.len(), 15); // 25 - 10
     assert_eq!(first_list.scalar_at(0), 10.into());
     assert_eq!(first_list.scalar_at(14), 24.into());
@@ -142,13 +142,13 @@ fn test_list_filter_sparse_mask() {
     assert_eq!(filtered_list.len(), 2);
 
     // Verify first list (originally index 0).
-    let first_list = filtered_list.elements_at(0);
+    let first_list = filtered_list.list_elements_at(0);
     assert_eq!(first_list.len(), 10);
     assert_eq!(first_list.scalar_at(0), 0.into());
     assert_eq!(first_list.scalar_at(9), 9.into());
 
     // Verify second list (originally index 5).
-    let second_list = filtered_list.elements_at(1);
+    let second_list = filtered_list.list_elements_at(1);
     assert_eq!(second_list.len(), 15); // 100 - 85
     assert_eq!(second_list.scalar_at(0), 85.into());
     assert_eq!(second_list.scalar_at(14), 99.into());
@@ -175,18 +175,18 @@ fn test_list_filter_empty_lists() {
     assert_eq!(filtered_list.len(), 4);
 
     // First list is empty.
-    assert_eq!(filtered_list.elements_at(0).len(), 0);
+    assert_eq!(filtered_list.list_elements_at(0).len(), 0);
 
     // Second list has 3 elements.
-    let second_list = filtered_list.elements_at(1);
+    let second_list = filtered_list.list_elements_at(1);
     assert_eq!(second_list.len(), 3);
     assert_eq!(second_list.scalar_at(0), 0.into());
 
     // Third list is empty.
-    assert_eq!(filtered_list.elements_at(2).len(), 0);
+    assert_eq!(filtered_list.list_elements_at(2).len(), 0);
 
     // Fourth list is empty.
-    assert_eq!(filtered_list.elements_at(3).len(), 0);
+    assert_eq!(filtered_list.list_elements_at(3).len(), 0);
 }
 
 #[test]
@@ -238,7 +238,7 @@ fn test_list_filter_all_true() {
 
     // Verify all lists are intact.
     for i in 0..4i32 {
-        let list_at_i = filtered_list.elements_at(i as usize);
+        let list_at_i = filtered_list.list_elements_at(i as usize);
         assert_eq!(list_at_i.len(), 5);
         assert_eq!(list_at_i.scalar_at(0), (i * 5).into());
     }
@@ -282,7 +282,7 @@ fn test_list_filter_single_element() {
 
     assert_eq!(filtered_list.len(), 1);
 
-    let single_list = filtered_list.elements_at(0);
+    let single_list = filtered_list.list_elements_at(0);
     assert_eq!(single_list.len(), 10);
     assert_eq!(single_list.scalar_at(0), 20.into());
     assert_eq!(single_list.scalar_at(9), 29.into());
@@ -311,7 +311,7 @@ fn test_list_filter_alternating_pattern() {
 
     // Verify that we have the correct lists (0, 2, 4, 6, 8, 10).
     for (i, expected_start) in [0, 10, 20, 30, 40, 50].iter().enumerate() {
-        let list_at_i = filtered_list.elements_at(i);
+        let list_at_i = filtered_list.list_elements_at(i);
         assert_eq!(list_at_i.len(), 5);
         assert_eq!(list_at_i.scalar_at(0), (*expected_start).into());
     }
@@ -338,12 +338,12 @@ fn test_list_filter_variable_sizes() {
     assert_eq!(filtered_list.len(), 6);
 
     // Verify sizes of filtered lists.
-    assert_eq!(filtered_list.elements_at(0).len(), 1); // Size 1
-    assert_eq!(filtered_list.elements_at(1).len(), 3); // Size 3
-    assert_eq!(filtered_list.elements_at(2).len(), 5); // Size 5
-    assert_eq!(filtered_list.elements_at(3).len(), 15); // Size 15
-    assert_eq!(filtered_list.elements_at(4).len(), 25); // Size 25
-    assert_eq!(filtered_list.elements_at(5).len(), 40); // Size 40
+    assert_eq!(filtered_list.list_elements_at(0).len(), 1); // Size 1
+    assert_eq!(filtered_list.list_elements_at(1).len(), 3); // Size 3
+    assert_eq!(filtered_list.list_elements_at(2).len(), 5); // Size 5
+    assert_eq!(filtered_list.list_elements_at(3).len(), 15); // Size 15
+    assert_eq!(filtered_list.list_elements_at(4).len(), 25); // Size 25
+    assert_eq!(filtered_list.list_elements_at(5).len(), 40); // Size 40
 }
 
 #[test]
@@ -559,43 +559,43 @@ fn test_list_of_lists() {
     ));
 
     // Access the first list of lists and verify its contents.
-    let first_outer = list_of_lists.elements_at(0);
+    let first_outer = list_of_lists.list_elements_at(0);
     let first_outer_list = first_outer.as_::<ListVTable>();
     assert_eq!(first_outer_list.len(), 2);
 
     // Check first inner list [1, 2].
-    let first_inner = first_outer_list.elements_at(0);
+    let first_inner = first_outer_list.list_elements_at(0);
     assert_eq!(first_inner.len(), 2);
     assert_eq!(first_inner.scalar_at(0), 1.into());
     assert_eq!(first_inner.scalar_at(1), 2.into());
 
     // Check second inner list [3].
-    let second_inner = first_outer_list.elements_at(1);
+    let second_inner = first_outer_list.list_elements_at(1);
     assert_eq!(second_inner.len(), 1);
     assert_eq!(second_inner.scalar_at(0), 3.into());
 
     // Check the second list of lists [[4, 5, 6]].
-    let second_outer = list_of_lists.elements_at(1);
+    let second_outer = list_of_lists.list_elements_at(1);
     let second_outer_list = second_outer.as_::<ListVTable>();
     assert_eq!(second_outer_list.len(), 1);
 
-    let inner = second_outer_list.elements_at(0);
+    let inner = second_outer_list.list_elements_at(0);
     assert_eq!(inner.len(), 3);
     assert_eq!(inner.scalar_at(0), 4.into());
     assert_eq!(inner.scalar_at(1), 5.into());
     assert_eq!(inner.scalar_at(2), 6.into());
 
     // Check the third list of lists (empty).
-    let third_outer = list_of_lists.elements_at(2);
+    let third_outer = list_of_lists.list_elements_at(2);
     let third_outer_list = third_outer.as_::<ListVTable>();
     assert_eq!(third_outer_list.len(), 0);
 
     // Check the fourth list of lists [[7]].
-    let fourth_outer = list_of_lists.elements_at(3);
+    let fourth_outer = list_of_lists.list_elements_at(3);
     let fourth_outer_list = fourth_outer.as_::<ListVTable>();
     assert_eq!(fourth_outer_list.len(), 1);
 
-    let inner = fourth_outer_list.elements_at(0);
+    let inner = fourth_outer_list.list_elements_at(0);
     assert_eq!(inner.len(), 1);
     assert_eq!(inner.scalar_at(0), 7.into());
 
@@ -611,12 +611,12 @@ fn test_list_of_lists() {
     assert_eq!(sliced_list.len(), 2);
 
     // First element of slice should be [[4, 5, 6]].
-    let first_sliced = sliced_list.elements_at(0);
+    let first_sliced = sliced_list.list_elements_at(0);
     let first_sliced_list = first_sliced.as_::<ListVTable>();
     assert_eq!(first_sliced_list.len(), 1);
 
     // Second element of slice should be empty [].
-    let second_sliced = sliced_list.elements_at(1);
+    let second_sliced = sliced_list.list_elements_at(1);
     let second_sliced_list = second_sliced.as_::<ListVTable>();
     assert_eq!(second_sliced_list.len(), 0);
 }
@@ -653,14 +653,14 @@ fn test_list_of_lists_nullable_outer() {
     assert!(second.is_null());
 
     // Third element should be [[4, 5, 6]].
-    let third = list_of_lists.elements_at(2);
+    let third = list_of_lists.list_elements_at(2);
     let third_list = third.as_::<ListVTable>();
     assert_eq!(third_list.len(), 1);
-    let inner = third_list.elements_at(0);
+    let inner = third_list.list_elements_at(0);
     assert_eq!(inner.len(), 3);
 
     // Fourth element should be [[7]].
-    let fourth = list_of_lists.elements_at(3);
+    let fourth = list_of_lists.list_elements_at(3);
     let fourth_list = fourth.as_::<ListVTable>();
     assert_eq!(fourth_list.len(), 1);
 }
@@ -697,7 +697,7 @@ fn test_list_of_lists_nullable_inner() {
     ));
 
     // First outer list should have 3 inner lists with the second being null.
-    let first_outer = list_of_lists.elements_at(0);
+    let first_outer = list_of_lists.list_elements_at(0);
     let first_list = first_outer.as_::<ListVTable>();
     assert_eq!(first_list.len(), 3);
 
@@ -732,12 +732,12 @@ fn test_list_of_lists_both_nullable() {
     // First outer list should have 2 elements, second is null inner list.
     let first_outer = list_of_lists.scalar_at(0);
     assert!(!first_outer.is_null());
-    let first_outer_array = list_of_lists.elements_at(0);
+    let first_outer_array = list_of_lists.list_elements_at(0);
     let first_list = first_outer_array.as_::<ListVTable>();
     assert_eq!(first_list.len(), 2);
 
     // First inner list should be [1, 2].
-    let first_inner = first_list.elements_at(0);
+    let first_inner = first_list.list_elements_at(0);
     assert_eq!(first_inner.len(), 2);
 
     // Second inner list should be null.
@@ -749,15 +749,15 @@ fn test_list_of_lists_both_nullable() {
     assert!(second_outer.is_null());
 
     // Third outer list should have [3].
-    let third_outer = list_of_lists.elements_at(2);
+    let third_outer = list_of_lists.list_elements_at(2);
     let third_list = third_outer.as_::<ListVTable>();
     assert_eq!(third_list.len(), 1);
-    let inner = third_list.elements_at(0);
+    let inner = third_list.list_elements_at(0);
     assert_eq!(inner.len(), 1);
     assert_eq!(inner.scalar_at(0), 3.into());
 
     // Fourth outer list should have a null inner list.
-    let fourth_outer = list_of_lists.elements_at(3);
+    let fourth_outer = list_of_lists.list_elements_at(3);
     let fourth_list = fourth_outer.as_::<ListVTable>();
     assert_eq!(fourth_list.len(), 1);
     let inner = fourth_list.scalar_at(0);
@@ -846,7 +846,7 @@ fn test_offsets_constant() {
     // This should succeed as it represents empty lists
     let list = ListArray::try_new(elements, offsets, validity).unwrap();
     assert_eq!(list.len(), 3);
-    assert_eq!(list.elements_at(0).len(), 0);
-    assert_eq!(list.elements_at(1).len(), 0);
-    assert_eq!(list.elements_at(2).len(), 0);
+    assert_eq!(list.list_elements_at(0).len(), 0);
+    assert_eq!(list.list_elements_at(1).len(), 0);
+    assert_eq!(list.list_elements_at(2).len(), 0);
 }

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -310,8 +310,8 @@ mod tests {
 
         let list_array = list.to_list();
 
-        assert_eq!(list_array.elements_at(0).len(), 3);
-        assert_eq!(list_array.elements_at(1).len(), 3);
+        assert_eq!(list_array.list_elements_at(0).len(), 3);
+        assert_eq!(list_array.list_elements_at(1).len(), 3);
     }
 
     #[test]
@@ -362,9 +362,9 @@ mod tests {
 
         let list_array = list.to_list();
 
-        assert_eq!(list_array.elements_at(0).len(), 3);
-        assert_eq!(list_array.elements_at(1).len(), 0);
-        assert_eq!(list_array.elements_at(2).len(), 3);
+        assert_eq!(list_array.list_elements_at(0).len(), 3);
+        assert_eq!(list_array.list_elements_at(1).len(), 0);
+        assert_eq!(list_array.list_elements_at(2).len(), 3);
     }
 
     fn test_extend_builder_gen<O: OffsetPType>() {


### PR DESCRIPTION
Makes 2 method names more consistent:

- `fixed_size_list_at` -> `fixed_size_list_elements_at` for `FixedSizeListArray`
- `elements_at` -> `list_elements_at` for `ListArray`

Also adds a better doc comment for `FixedSizeListArray`