### PR TITLE
chore: use DuckDB debug build in `Rust tests (sanitizer)`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,6 +345,8 @@ jobs:
       ASAN_OPTIONS: "symbolize=1:print_stats=1:check_initialization_order=1:detect_leaks=1:halt_on_error=0:verbosity=1:leak_check_at_exit=1"
       LSAN_OPTIONS: "verbosity=1:report_objects=1"
       ASAN_SYMBOLIZER_PATH: "/usr/bin/llvm-symbolizer"
+      # Link against DuckDB debug build
+      VX_DUCKDB_DEBUG: "1"
       # Keep frame pointers for better stack traces
       CARGO_PROFILE_DEV_DEBUG: "true"
       CARGO_PROFILE_TEST_DEBUG: "true"
@@ -361,6 +363,10 @@ jobs:
         with:
           toolchain: nightly
           components: "rust-src, rustfmt, clippy, llvm-tools-preview"
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build cmake
       - name: Install nextest
         uses: taiki-e/install-action@v2
         with:
@@ -376,37 +382,9 @@ jobs:
             --all-features \
             --no-fail-fast \
             --target x86_64-unknown-linux-gnu \
-            --verbose
-
-  vortex-duckdb-test:
-    name: "Rust tests (vortex-duckdb)"
-    timeout-minutes: 120
-    runs-on:
-      - runs-on=${{ github.run_id }}
-      - family=m7i+m7i-flex+m7a
-      - cpu=8
-      - image=ubuntu24-full-x64
-      - extras=s3-cache
-      - tag=vortex-duckdb-test
-    env:
-      VX_DUCKDB_DEBUG: "1"
-    steps:
-      - uses: runs-on/action@v2
-        with:
-          sccache: s3
-      - uses: actions/checkout@v5
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ninja-build cmake
-      - uses: ./.github/actions/setup-rust
-      - name: Install nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: nextest@0.9.98
-      - name: Vortex DuckDB tests
-        run: |
-          cargo nextest run -p vortex-duckdb -- --skip test_vortex_scan_ultra_deep_nesting
+            --verbose \
+            -- \
+            --skip test_vortex_scan_ultra_deep_nesting
 
   build-java:
     name: "Java"


### PR DESCRIPTION
Use DuckDB debug build as part of `Rust tests (sanitizer)` but without enabling `VX_DUCKDB_ASAN=1`.
