### PR TITLE
chore: drop invalid sql test as it triggers exception breakpoints

### DIFF
--- a/vortex-duckdb/src/duckdb/connection.rs
+++ b/vortex-duckdb/src/duckdb/connection.rs
@@ -133,13 +133,6 @@ mod tests {
     }
 
     #[test]
-    fn test_query_invalid_sql() {
-        let conn = test_connection().unwrap();
-        let result = conn.query("INVALID SQL");
-        assert!(result.is_err());
-    }
-
-    #[test]
     fn test_query_single_value() {
         let conn = test_connection().unwrap();
         let result = conn.query("SELECT 42").unwrap();


### PR DESCRIPTION
This lead to poor DX when running `vortex-duckdb` unit tests, as `lldb` stops multiple times on exception breakpoints. It is expected though and correct behavior that DuckDB throws an exception for invalid SQL queries.