### PR TITLE
chore: switch to metal instance for codspeed benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,7 +408,7 @@ jobs:
     timeout-minutes: 120
     runs-on:
       - runs-on=${{ github.run_id }}
-      - family=c6id.8xlarge
+      - family=c6a.metal
       - extras=s3-cache
       - image=ubuntu24-full-x64
       - tag=bench-codspeed


### PR DESCRIPTION
Switches the CI runner to `c6a.metal` for Codspeed in order to reduce jitter between benchmarks runs.