### PR TITLE
Bug: DuckDB List Validation assertion failure

### DIFF
--- a/vortex-duckdb/src/e2e_test/vortex_scan_test.rs
+++ b/vortex-duckdb/src/e2e_test/vortex_scan_test.rs
@@ -391,11 +391,63 @@ fn test_write_timestamps() {
 }
 
 #[test]
+#[ignore = "Assertion fail in DuckDB (`child.GetVectorType() == VectorType::FLAT_VECTOR`) with debug"]
+fn test_vortex_scan_fixed_size_list_utf8() {
+    // Test a simple FixedSizeList of Utf8 strings to ensure proper materialization.
+
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let file = runtime.block_on(async {
+        // Create a large number of strings to stress test.
+        let strings: Vec<&str> = (0..24)
+            .map(|i| match i % 6 {
+                0 => "first",
+                1 => "second",
+                2 => "third",
+                3 => "fourth",
+                4 => "fifth",
+                _ => "sixth",
+            })
+            .collect();
+
+        let strings_array = VarBinViewArray::from_iter_str(strings);
+
+        // Create fixed-size lists of strings.
+        let fsl = FixedSizeListArray::new(
+            strings_array.into_array(),
+            4, // 4 strings per list
+            Validity::AllValid,
+            6, // 6 lists total
+        );
+
+        write_single_column_vortex_file("string_lists", fsl).await
+    });
+
+    let conn = database_connection();
+    let file_path = file.path().to_string_lossy();
+
+    // Query the structure.
+    let result = conn
+        .query(&format!(
+            "SELECT string_lists FROM vortex_scan('{file_path}')"
+        ))
+        .unwrap();
+
+    let mut row_count = 0;
+    for chunk in result {
+        row_count += chunk.len();
+        // Accessing the structure should not cause a segfault.
+        let _vec = chunk.get_vector(0);
+    }
+    assert_eq!(row_count, 6, "Should have retrieved 6 lists");
+}
+
+#[test]
+#[ignore = "Assertion fail in DuckDB (`child.GetVectorType() == VectorType::FLAT_VECTOR`) with debug"]
 fn test_vortex_scan_nested_fixed_size_list_utf8() {
     // Regression test for a segfault that occurs inside query 7 and 8 of the `statpopgen` benchmark
     // when running with `FixedSizeList` instead of `List`.
 
-    // Test FixedSizeList of Utf8 to ensure proper materialization.
+    // Test FixedSizeList of FixedSizeList of Utf8 to ensure proper materialization.
 
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let file = runtime.block_on(async {
@@ -452,6 +504,125 @@ fn test_vortex_scan_nested_fixed_size_list_utf8() {
 }
 
 #[test]
+#[ignore = "Assertion fail in DuckDB (`le.offset + le.length <= child_size`) with debug"]
+fn test_vortex_scan_list_of_ints() {
+    // Test a simple List of integers.
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let file = runtime.block_on(async {
+        // Create integers that will be grouped into lists.
+        let integers = PrimitiveArray::from_iter([
+            10i32, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150,
+        ]);
+
+        // Create variable-length lists using offsets.
+        // List 0: [10, 20, 30] (indices 0-2)
+        // List 1: [40, 50, 60, 70] (indices 3-6)
+        // List 2: [80] (indices 7-7)
+        // List 3: [90, 100, 110, 120, 130] (indices 8-12)
+        // List 4: [140, 150] (indices 13-14)
+        let offsets = buffer![0i32, 3, 7, 8, 13, 15];
+        let list_array = ListArray::try_new(
+            integers.into_array(),
+            offsets.into_array(),
+            Validity::AllValid,
+        )
+        .unwrap();
+
+        write_single_column_vortex_file("int_list", list_array).await
+    });
+
+    let conn = database_connection();
+    let file_path = file.path().to_string_lossy();
+
+    // Query the list structure to verify row count.
+    let result = conn
+        .query(&format!("SELECT COUNT(*) FROM vortex_scan('{file_path}')"))
+        .unwrap();
+    let chunk = result.into_iter().next().unwrap();
+    let vec = chunk.get_vector(0);
+    let count = vec.as_slice_with_len::<i64>(chunk.len().as_())[0];
+    assert_eq!(count, 5, "Should have 5 lists");
+
+    // Try to access the data - this tests for segfaults.
+    let result = conn
+        .query(&format!("SELECT int_list FROM vortex_scan('{file_path}')"))
+        .unwrap();
+
+    let mut row_count = 0;
+    for chunk in result {
+        row_count += chunk.len();
+        let _vec = chunk.get_vector(0);
+    }
+    assert_eq!(row_count, 5, "Should have retrieved 5 rows");
+}
+
+#[test]
+#[ignore = "Assertion fail in DuckDB (`le.offset + le.length <= child_size`) with debug"]
+fn test_vortex_scan_list_of_utf8() {
+    // Test a simple List of UTF8 strings.
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let file = runtime.block_on(async {
+        // Create UTF8 strings that will be grouped into lists.
+        let strings = VarBinViewArray::from_iter_str(vec![
+            "apple",
+            "banana",
+            "cherry",
+            "date",
+            "elderberry",
+            "fig",
+            "grape",
+            "honeydew",
+            "kiwi",
+            "lemon",
+            "mango",
+            "nectarine",
+        ]);
+
+        // Create variable-length lists using offsets.
+        // List 0: [apple, banana, cherry] (indices 0-2)
+        // List 1: [date, elderberry] (indices 3-4)
+        // List 2: [fig, grape, honeydew, kiwi] (indices 5-8)
+        // List 3: [lemon, mango, nectarine] (indices 9-11)
+        let offsets = buffer![0i32, 3, 5, 9, 12];
+        let list_array = ListArray::try_new(
+            strings.into_array(),
+            offsets.into_array(),
+            Validity::AllValid,
+        )
+        .unwrap();
+
+        write_single_column_vortex_file("string_list", list_array).await
+    });
+
+    let conn = database_connection();
+    let file_path = file.path().to_string_lossy();
+
+    // Query the list structure to verify row count.
+    let result = conn
+        .query(&format!("SELECT COUNT(*) FROM vortex_scan('{file_path}')"))
+        .unwrap();
+    let chunk = result.into_iter().next().unwrap();
+    let vec = chunk.get_vector(0);
+    let count = vec.as_slice_with_len::<i64>(chunk.len().as_())[0];
+    assert_eq!(count, 4, "Should have 4 lists");
+
+    // Try to access the data - this tests for segfaults.
+    let result = conn
+        .query(&format!(
+            "SELECT string_list FROM vortex_scan('{file_path}')"
+        ))
+        .unwrap();
+
+    let mut row_count = 0;
+    for chunk in result {
+        row_count += chunk.len();
+        let _vec = chunk.get_vector(0);
+    }
+    assert_eq!(row_count, 4, "Should have retrieved 4 rows");
+}
+
+#[test]
+#[ignore = "Assertion fail in DuckDB (`le.offset + le.length <= child_size`) with debug"]
 fn test_vortex_scan_ultra_deep_nesting() {
     // Test ultra-deep nesting: Multiple levels of FSL and List combinations with UTF8.
     // FSL[List[FSL[List[FSL[UTF8]]]]]


### PR DESCRIPTION
On develop, if we run all 3 of these tests with `VX_DUCKDB_DEBUG=1`, we get an assertion failure when DuckDB validates the list view entries. So for now, we should ignore them.

For context, I have been migrating `List` to use `ListViewArray` instead of `ListArray`, and I reimplemented `export` under `vortex-duckdb/src/exporter/list.rs` to export directly from a `ListView`.

It seems like we might be interpreting memory incorrectly? Here is the relevant code (on develop):

###### vortex-duckdb/src/exporter/list.rs
```rust
pub struct duckdb_list_entry {
    pub offset: u64,
    pub length: u64,
}

<-- snip -->

let offsets_slice: &mut [cpp::duckdb_list_entry] =
    unsafe { vector.as_slice_mut::<cpp::duckdb_list_entry>(len) };

<-- snip -->

// Ordering doesn't really seem to matter here but maybe it does?
vector.list_vector_reserve(sum_of_list_lens)?;
let mut elements_vector = vector.list_vector_get_child();
vector.list_vector_set_size(sum_of_list_lens)?;

self.elements_exporter.export(
    usize::try_from(start_offset)?,
    usize::try_from(sum_of_list_lens)?,
    &mut elements_vector,
)
```

Here is an example assertion failure:

```
---- e2e_test::vortex_scan_test::test_vortex_scan_list_of_ints stdout ----

thread 'e2e_test::vortex_scan_test::test_vortex_scan_list_of_ints' panicked at vortex-duckdb/src/e2e_test/vortex_scan_test.rs:488:10:
called `Result::unwrap()` on an `Err` value: Failed to execute query:
>   INTERNAL Error: Assertion triggered in file "/Users/connor/spiral/vortex-data/vortex-develop/target/duckdb-source-v1.4.0/duckdb-1.4.0/src/common/types/vector.cpp"
>   on line 1802: le.offset + le.length <= child_size

<-- snip -->
4        duckdb::InternalException::InternalException<char const*, int, char const*>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, char const*, int, char const*) + 80
5        duckdb::DuckDBAssertInternal(bool, char const*, char const*, int) + 124
6        duckdb::Vector::Verify(duckdb::Vector&, duckdb::SelectionVector const&, unsigned long long) + 4572
7        duckdb::Vector::Verify(unsigned long long) + 56
8        duckdb::DataChunk::Verify() + 152
9        duckdb::PipelineExecutor::EndOperator(duckdb::PhysicalOperator&, duckdb::optional_ptr<duckdb::DataChunk, true>) + 84
<-- snip -->
```

I double checked that the values that we write into that vector are correct (both on develop and on my branch where the list view `offsets` and `sizes` are definitely correct). So it is likely the case that we are writing correct values, but writing it in the wrong place (or at least duckdb is expecting it somewhere else).

I'd like to go into lldb and figure out what exactly `le.offset` and `le.length` are, but I wasn't able to figure out how to do that easily since a new process is spawned.

CC @0ax1 @danking 


---

Also adds a test that is slightly simpler than `test_vortex_scan_nested_fixed_size_list_utf8`, simply removes the outer fixed-size list layer (and the other assertion error `child.GetVectorType() == VectorType::FLAT_VECTOR` still triggers)

---

Edit: Somewhat resolved in comments below?

Something of note that is VERY weird that happened to me more than once (but not every time):

- If I do a clean build it fails immediately. 
- If I make a trivial change anywhere (add `dbg!("");` somewhere) and run with only `VX_DUCKDB_DEBUG`, **it sometimes stops failing, pretty consistently**
- If I add `VX_DUCKDB_ASAN` and compile tests again, it starts to fail again

There seems to be something strange going on with the builds as well because in certain cases the tests will start passing again seemingly randomly, and I cannot replicate it consistently.



