### PR TITLE
Revert "chore: switch to metal instance for codspeed benchmarks"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,7 +408,7 @@ jobs:
     timeout-minutes: 120
     runs-on:
       - runs-on=${{ github.run_id }}
-      - family=c6a.metal
+      - family=c6id.8xlarge
       - extras=s3-cache
       - image=ubuntu24-full-x64
       - tag=bench-codspeed


### PR DESCRIPTION
Reverts vortex-data/vortex#4732, metal runners are scarce, we are queuing a lot now 