### PR TITLE
chore: enable `test_vortex_scan_ultra_deep_nesting` on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,9 +382,7 @@ jobs:
             --all-features \
             --no-fail-fast \
             --target x86_64-unknown-linux-gnu \
-            --verbose \
-            -- \
-            --skip test_vortex_scan_ultra_deep_nesting
+            --verbose
 
   build-java:
     name: "Java"

--- a/vortex-duckdb/src/exporter/dict.rs
+++ b/vortex-duckdb/src/exporter/dict.rs
@@ -104,7 +104,7 @@ impl<I: NativePType + AsPrimitive<u32>> ColumnExporter for DictExporter<I> {
 
         vector.dictionary(&new_values_vector, self.values_len as usize, &sel_vec, len);
 
-        // Use a unique id to each dictionary data array -- telling duckdb that
+        // Use a unique id for each dictionary data array -- telling duckdb that
         // the dict value vector is the same as reuse the hash in a join.
         vector.set_dictionary_id(format!("{}-{}", self.cache_id, self.value_id));
         vector.set_dictionary_len(self.values_len);


### PR DESCRIPTION
The issue was fixed as part of https://github.com/vortex-data/vortex/commit/f4052d5487baad2b98a345b6070c3ae6ee2508cb.