### PR TITLE
feat[dtype]: Rename and move `ScalarType` ->`NativeDType`, scalar -> dtype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6661,6 +6661,7 @@ dependencies = [
  "serde_json",
  "serde_test",
  "static_assertions",
+ "vortex-buffer",
  "vortex-error",
  "vortex-flatbuffers",
  "vortex-proto",

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -8,10 +8,9 @@ use vortex_array::validity::Validity;
 use vortex_array::vtable::ValidityHelper;
 use vortex_array::{ArrayRef, IntoArray, ToCanonical};
 use vortex_buffer::{Buffer, BufferMut};
-use vortex_dtype::{NativePType, PType};
+use vortex_dtype::{NativeDType, NativePType, PType};
 use vortex_error::{VortexResult, vortex_bail};
 use vortex_mask::Mask;
-use vortex_scalar::ScalarType;
 
 use crate::Exponents;
 use crate::alp::{ALPArray, ALPFloat};
@@ -62,7 +61,7 @@ fn alp_encode_components_typed<T>(
 where
     T: ALPFloat + NativePType,
     T::ALPInt: NativePType,
-    T: ScalarType,
+    T: NativeDType,
 {
     let values_slice = values.as_slice::<T>();
 

--- a/encodings/alp/src/alp/compute/between.rs
+++ b/encodings/alp/src/alp/compute/between.rs
@@ -10,7 +10,7 @@ use vortex_array::compute::{
 use vortex_array::{Array, ArrayRef, register_kernel};
 use vortex_dtype::{NativeDType, NativePType, Nullability};
 use vortex_error::VortexResult;
-use vortex_scalar::{Scalar};
+use vortex_scalar::Scalar;
 
 use crate::{ALPArray, ALPFloat, ALPVTable, match_each_alp_float_ptype};
 

--- a/encodings/alp/src/alp/compute/between.rs
+++ b/encodings/alp/src/alp/compute/between.rs
@@ -8,9 +8,9 @@ use vortex_array::compute::{
     BetweenKernel, BetweenKernelAdapter, BetweenOptions, StrictComparison, between,
 };
 use vortex_array::{Array, ArrayRef, register_kernel};
-use vortex_dtype::{NativePType, Nullability};
+use vortex_dtype::{NativeDType, NativePType, Nullability};
 use vortex_error::VortexResult;
-use vortex_scalar::{Scalar, ScalarType};
+use vortex_scalar::{Scalar};
 
 use crate::{ALPArray, ALPFloat, ALPVTable, match_each_alp_float_ptype};
 
@@ -57,7 +57,7 @@ fn between_impl<T: NativePType + ALPFloat>(
 ) -> VortexResult<ArrayRef>
 where
     Scalar: From<T::ALPInt>,
-    <T as ALPFloat>::ALPInt: ScalarType + Debug,
+    <T as ALPFloat>::ALPInt: NativeDType + Debug,
 {
     let exponents = array.exponents();
 

--- a/vortex-dtype/Cargo.toml
+++ b/vortex-dtype/Cargo.toml
@@ -29,6 +29,7 @@ paste = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true, optional = true, features = ["rc", "derive"] }
 static_assertions = { workspace = true }
+vortex-buffer = { workspace = true }
 vortex-error = { workspace = true, features = ["flatbuffers"] }
 vortex-flatbuffers = { workspace = true, features = ["dtype"] }
 vortex-proto = { workspace = true, features = ["dtype"] }

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -99,7 +99,7 @@ pub enum DType {
 /// e.g. `&str` -> `DType::Utf8`
 ///      `bool` -> `DType::Bool`
 ///
-/// The dtype is the one closet matching the domain of the rust type e.g. option<T> -> nullable dtype.
+/// The dtype is the one closet matching the domain of the rust type e.g. `Option<T>` -> nullable dtype.
 pub trait NativeDType {
     /// Returns the Vortex data type for this scalar type.
     fn dtype() -> DType;

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -94,13 +94,15 @@ pub enum DType {
     Extension(Arc<ExtDType>),
 }
 
-/// A trait implemented for most native Rust types, mapping them to a `DType`.
+/// This trait is implemented by native Rust types that can be converted
+/// to and from Vortex scalar values.
 /// e.g. `&str` -> `DType::Utf8`
-/// e.g. `bool` -> `DType::Bool`
-/// ...
+///      `bool` -> `DType::Bool`
+///
+/// The dtype is the one closet matching the domain of the rust type e.g. option<T> -> nullable dtype.
 pub trait NativeDType {
-    /// The `DType` that this type maps to.
-    fn dtype(nullability: Nullability) -> DType;
+    /// Returns the Vortex data type for this scalar type.
+    fn dtype() -> DType;
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -424,51 +426,5 @@ impl Display for DType {
                 ext.storage_dtype().nullability(),
             ),
         }
-    }
-}
-
-impl NativeDType for &str {
-    fn dtype(nullability: Nullability) -> DType {
-        Utf8(nullability)
-    }
-}
-
-impl NativeDType for &[u8] {
-    fn dtype(nullability: Nullability) -> DType {
-        Binary(nullability)
-    }
-}
-
-impl NativeDType for bool {
-    fn dtype(nullability: Nullability) -> DType {
-        Bool(nullability)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use half::f16;
-
-    use crate::dtype::NativeDType;
-    use crate::{DType, Nullability, PType};
-
-    #[test]
-    fn test_native_dtype() {
-        assert_eq!(
-            <&str as NativeDType>::dtype(Nullability::Nullable),
-            DType::Utf8(Nullability::Nullable)
-        );
-        assert_eq!(
-            <bool as NativeDType>::dtype(Nullability::Nullable),
-            DType::Bool(Nullability::Nullable)
-        );
-        assert_eq!(
-            <f16 as NativeDType>::dtype(Nullability::Nullable),
-            DType::Primitive(PType::F16, Nullability::Nullable)
-        );
-        assert_eq!(
-            <u64 as NativeDType>::dtype(Nullability::Nullable),
-            DType::Primitive(PType::U64, Nullability::Nullable)
-        );
     }
 }

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -94,6 +94,15 @@ pub enum DType {
     Extension(Arc<ExtDType>),
 }
 
+/// A trait implemented for most native Rust types, mapping them to a `DType`.
+/// e.g. `&str` -> `DType::Utf8`
+/// e.g. `bool` -> `DType::Bool`
+/// ...
+pub trait NativeDType {
+    /// The `DType` that this type maps to.
+    fn dtype(nullability: Nullability) -> DType;
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 const_assert_eq!(size_of::<DType>(), 16);
 
@@ -415,5 +424,51 @@ impl Display for DType {
                 ext.storage_dtype().nullability(),
             ),
         }
+    }
+}
+
+impl NativeDType for &str {
+    fn dtype(nullability: Nullability) -> DType {
+        Utf8(nullability)
+    }
+}
+
+impl NativeDType for &[u8] {
+    fn dtype(nullability: Nullability) -> DType {
+        Binary(nullability)
+    }
+}
+
+impl NativeDType for bool {
+    fn dtype(nullability: Nullability) -> DType {
+        Bool(nullability)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use half::f16;
+
+    use crate::dtype::NativeDType;
+    use crate::{DType, Nullability, PType};
+
+    #[test]
+    fn test_native_dtype() {
+        assert_eq!(
+            <&str as NativeDType>::dtype(Nullability::Nullable),
+            DType::Utf8(Nullability::Nullable)
+        );
+        assert_eq!(
+            <bool as NativeDType>::dtype(Nullability::Nullable),
+            DType::Bool(Nullability::Nullable)
+        );
+        assert_eq!(
+            <f16 as NativeDType>::dtype(Nullability::Nullable),
+            DType::Primitive(PType::F16, Nullability::Nullable)
+        );
+        assert_eq!(
+            <u64 as NativeDType>::dtype(Nullability::Nullable),
+            DType::Primitive(PType::U64, Nullability::Nullable)
+        );
     }
 }

--- a/vortex-dtype/src/lib.rs
+++ b/vortex-dtype/src/lib.rs
@@ -20,13 +20,14 @@ mod extension;
 mod field;
 mod field_mask;
 mod field_names;
+mod native_dtype;
 mod nullability;
 mod ptype;
 mod serde;
 mod struct_;
 
 pub use decimal::*;
-pub use dtype::*;
+pub use dtype::{DType, NativeDType};
 pub use extension::*;
 pub use field::*;
 pub use field_mask::*;

--- a/vortex-dtype/src/native_dtype.rs
+++ b/vortex-dtype/src/native_dtype.rs
@@ -2,99 +2,55 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::sync::Arc;
-
-use vortex_buffer::{BufferString, ByteBuffer};
-use vortex_dtype::half::f16;
-use vortex_dtype::{DType, NativePType, Nullability};
-
-/// A trait for types that can be used as scalar values.
-///
-/// This trait is implemented by native Rust types that can be converted
-/// to and from Vortex scalar values.
-///
-/// Unless the type is an `Option<T>`, the `DType` that is returned by `dtype()` should **ALWAYS**
-/// be [`NonNullable`](Nullability::NonNullable).
-pub trait ScalarType {
-    /// Returns the Vortex data type for this scalar type.
-    fn dtype() -> DType;
-}
+use vortex_buffer::ByteBuffer;
+use crate::{DType, Nullability};
+use crate::dtype::NativeDType;
 
 /// It is common to represent a nullable type `T` as an `Option<T>`, so we implement a blanket
 /// implementation for all `Option<T>` to simply be a nullable `T`.
-impl<T> ScalarType for Option<T>
+impl<T> NativeDType for Option<T>
 where
-    T: ScalarType,
+    T: NativeDType,
 {
     fn dtype() -> DType {
         T::dtype().as_nullable()
     }
 }
 
-impl<T> ScalarType for Vec<T>
+impl<T> NativeDType for Vec<T>
 where
-    T: ScalarType,
+    T: NativeDType,
 {
     fn dtype() -> DType {
         DType::List(Arc::new(T::dtype()), Nullability::NonNullable)
     }
 }
 
-impl ScalarType for bool {
+impl NativeDType for bool {
     fn dtype() -> DType {
         DType::Bool(Nullability::NonNullable)
     }
 }
 
-/// We manually implement `ScalarType` for the primitive types because doing a blanket
-/// implementation would cause a conflict.
-///
-/// If you don't believe this, see for yourself! Try uncommenting this:
-///
-/// ```ignore
-/// impl<T> ScalarType for T
-/// where
-///     T: NativePType,
-/// {
-///     fn dtype() -> DType {
-///         DType::Primitive(T::PTYPE, Nullability::NonNullable)
-///     }
-/// }
-/// ```
-macro_rules! scalar_type_for_native_ptype {
-    ($T:ty) => {
-        impl ScalarType for $T {
-            fn dtype() -> DType {
-                DType::Primitive(<$T>::PTYPE, Nullability::NonNullable)
-            }
-        }
-    };
-}
-
-scalar_type_for_native_ptype!(u8); // Vec<u8> could be either Binary or List(U8)
-scalar_type_for_native_ptype!(u16);
-scalar_type_for_native_ptype!(u32);
-scalar_type_for_native_ptype!(u64);
-scalar_type_for_native_ptype!(i8);
-scalar_type_for_native_ptype!(i16);
-scalar_type_for_native_ptype!(i32);
-scalar_type_for_native_ptype!(i64);
-scalar_type_for_native_ptype!(f16);
-scalar_type_for_native_ptype!(f32);
-scalar_type_for_native_ptype!(f64);
-
-impl ScalarType for String {
+impl NativeDType for String {
     fn dtype() -> DType {
         DType::Utf8(Nullability::NonNullable)
     }
 }
 
-impl ScalarType for BufferString {
+impl NativeDType for &str {
     fn dtype() -> DType {
         DType::Utf8(Nullability::NonNullable)
     }
 }
 
-impl ScalarType for ByteBuffer {
+impl NativeDType for &[u8] {
+    fn dtype() -> DType {
+        DType::Binary(Nullability::NonNullable)
+    }
+}
+
+impl NativeDType for ByteBuffer {
     fn dtype() -> DType {
         DType::Binary(Nullability::NonNullable)
     }
@@ -102,18 +58,18 @@ impl ScalarType for ByteBuffer {
 
 #[cfg(test)]
 mod tests {
-    use vortex_dtype::PType;
-
+    use half::f16;
     use super::*;
+    use crate::PType;
 
     #[test]
-    fn test_bool_scalar_type() {
+    fn test_bool_native_dtype() {
         let dtype = bool::dtype();
         assert_eq!(dtype, DType::Bool(Nullability::NonNullable));
     }
 
     #[test]
-    fn test_primitive_scalar_types() {
+    fn test_primitive_native_dtypes() {
         assert_eq!(
             u8::dtype(),
             DType::Primitive(PType::U8, Nullability::NonNullable)
@@ -163,18 +119,12 @@ mod tests {
     }
 
     #[test]
-    fn test_string_scalar_types() {
+    fn test_string_native_dtypes() {
         assert_eq!(String::dtype(), DType::Utf8(Nullability::NonNullable));
-        assert_eq!(BufferString::dtype(), DType::Utf8(Nullability::NonNullable));
     }
 
     #[test]
-    fn test_byte_buffer_scalar_type() {
-        assert_eq!(ByteBuffer::dtype(), DType::Binary(Nullability::NonNullable));
-    }
-
-    #[test]
-    fn test_vec_option_scalar_type() {
+    fn test_vec_option_native_dtype() {
         // Test that Vec<Option<T>> has non-nullable List dtype even though elements are nullable.
         assert_eq!(
             Vec::<Option<i32>>::dtype(),
@@ -202,7 +152,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_scalar_types() {
+    fn test_vec_native_dtypes() {
         // Test Vec<primitive> types
         assert_eq!(
             Vec::<u16>::dtype(),
@@ -238,17 +188,9 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_string_scalar_type() {
+    fn test_vec_string_native_dtype() {
         assert_eq!(
             Vec::<String>::dtype(),
-            DType::List(
-                Arc::new(DType::Utf8(Nullability::NonNullable)),
-                Nullability::NonNullable
-            )
-        );
-
-        assert_eq!(
-            Vec::<BufferString>::dtype(),
             DType::List(
                 Arc::new(DType::Utf8(Nullability::NonNullable)),
                 Nullability::NonNullable
@@ -257,13 +199,10 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_byte_buffer_scalar_type() {
+    fn test_str_native_dtype() {
         assert_eq!(
-            Vec::<ByteBuffer>::dtype(),
-            DType::List(
-                Arc::new(DType::Binary(Nullability::NonNullable)),
-                Nullability::NonNullable
-            )
+            <&str as NativeDType>::dtype(),
+            DType::Utf8(Nullability::NonNullable)
         );
     }
 }

--- a/vortex-dtype/src/native_dtype.rs
+++ b/vortex-dtype/src/native_dtype.rs
@@ -2,9 +2,11 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::sync::Arc;
+
 use vortex_buffer::ByteBuffer;
-use crate::{DType, Nullability};
+
 use crate::dtype::NativeDType;
+use crate::{DType, Nullability};
 
 /// It is common to represent a nullable type `T` as an `Option<T>`, so we implement a blanket
 /// implementation for all `Option<T>` to simply be a nullable `T`.
@@ -59,6 +61,7 @@ impl NativeDType for ByteBuffer {
 #[cfg(test)]
 mod tests {
     use half::f16;
+
     use super::*;
     use crate::PType;
 

--- a/vortex-dtype/src/ptype.rs
+++ b/vortex-dtype/src/ptype.rs
@@ -12,9 +12,9 @@ use num_traits::bounds::UpperBounded;
 use num_traits::{FromPrimitive, Num, NumCast, ToPrimitive, Unsigned};
 use vortex_error::{VortexError, VortexResult, vortex_err};
 
-use crate::DType;
 use crate::half::f16;
 use crate::nullability::Nullability::NonNullable;
+use crate::{DType, Nullability};
 
 /// Physical type enum, represents the in-memory physical layout but might represent a different logical type.
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Hash, prost::Enumeration)]
@@ -112,7 +112,7 @@ pub trait NativePType:
 }
 
 /// A visitor trait for converting a `NativePType` to another parameterized type.
-#[allow(missing_docs)] // Kind of obvious..
+#[allow(missing_docs)] // Kind of obvious.
 pub trait PTypeVisitor {
     type Output<T: NativePType>;
 
@@ -181,6 +181,12 @@ macro_rules! impl_ptype_downcast {
 
 macro_rules! native_ptype {
     ($T:ty, $ptype:tt) => {
+        impl crate::NativeDType for $T {
+            fn dtype(nullability: Nullability) -> DType {
+                DType::Primitive(PType::$ptype, nullability)
+            }
+        }
+
         impl NativePType for $T {
             const PTYPE: PType = PType::$ptype;
 
@@ -213,6 +219,12 @@ impl<T: PTypeVisitorMut + ?Sized> PTypeVisitorMutExt for T {}
 
 macro_rules! native_float_ptype {
     ($T:ty, $ptype:tt) => {
+        impl crate::NativeDType for $T {
+            fn dtype(nullability: Nullability) -> DType {
+                DType::Primitive(PType::$ptype, nullability)
+            }
+        }
+
         impl NativePType for $T {
             const PTYPE: PType = PType::$ptype;
 

--- a/vortex-dtype/src/ptype.rs
+++ b/vortex-dtype/src/ptype.rs
@@ -12,9 +12,9 @@ use num_traits::bounds::UpperBounded;
 use num_traits::{FromPrimitive, Num, NumCast, ToPrimitive, Unsigned};
 use vortex_error::{VortexError, VortexResult, vortex_err};
 
+use crate::DType;
 use crate::half::f16;
 use crate::nullability::Nullability::NonNullable;
-use crate::{DType, Nullability};
 
 /// Physical type enum, represents the in-memory physical layout but might represent a different logical type.
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Hash, prost::Enumeration)]
@@ -182,8 +182,8 @@ macro_rules! impl_ptype_downcast {
 macro_rules! native_ptype {
     ($T:ty, $ptype:tt) => {
         impl crate::NativeDType for $T {
-            fn dtype(nullability: Nullability) -> DType {
-                DType::Primitive(PType::$ptype, nullability)
+            fn dtype() -> DType {
+                DType::Primitive(PType::$ptype, crate::Nullability::NonNullable)
             }
         }
 
@@ -220,8 +220,8 @@ impl<T: PTypeVisitorMut + ?Sized> PTypeVisitorMutExt for T {}
 macro_rules! native_float_ptype {
     ($T:ty, $ptype:tt) => {
         impl crate::NativeDType for $T {
-            fn dtype(nullability: Nullability) -> DType {
-                DType::Primitive(PType::$ptype, nullability)
+             fn dtype() -> DType {
+                DType::Primitive(PType::$ptype, crate::Nullability::NonNullable)
             }
         }
 

--- a/vortex-dtype/src/ptype.rs
+++ b/vortex-dtype/src/ptype.rs
@@ -220,7 +220,7 @@ impl<T: PTypeVisitorMut + ?Sized> PTypeVisitorMutExt for T {}
 macro_rules! native_float_ptype {
     ($T:ty, $ptype:tt) => {
         impl crate::NativeDType for $T {
-             fn dtype() -> DType {
+            fn dtype() -> DType {
                 DType::Primitive(PType::$ptype, crate::Nullability::NonNullable)
             }
         }

--- a/vortex-scalar/src/lib.rs
+++ b/vortex-scalar/src/lib.rs
@@ -28,7 +28,6 @@ mod primitive;
 mod proto;
 mod pvalue;
 mod scalar;
-mod scalar_type;
 mod scalar_value;
 mod struct_;
 #[cfg(test)]
@@ -44,7 +43,6 @@ pub use list::*;
 pub use primitive::*;
 pub use pvalue::*;
 pub use scalar::*;
-pub use scalar_type::*;
 pub use scalar_value::*;
 pub use struct_::*;
 pub use utf8::*;

--- a/vortex-scalar/src/scalar.rs
+++ b/vortex-scalar/src/scalar.rs
@@ -6,7 +6,7 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use vortex_buffer::Buffer;
-use vortex_dtype::{DECIMAL128_MAX_PRECISION, DType, Nullability};
+use vortex_dtype::{DECIMAL128_MAX_PRECISION, DType, NativeDType, Nullability};
 use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_bail, vortex_err};
 
 use super::*;
@@ -104,7 +104,7 @@ impl Scalar {
     /// Creates a null scalar for the given scalar type.
     ///
     /// The resulting scalar will have a nullable version of the type's data type.
-    pub fn null_typed<T: ScalarType>() -> Self {
+    pub fn null_typed<T: NativeDType>() -> Self {
         Self {
             dtype: T::dtype().as_nullable(),
             value: ScalarValue(InnerScalarValue::Null),
@@ -370,7 +370,7 @@ impl Scalar {
 /// implementation for all `Option<T>` to simply be a nullable `T`.
 impl<T> From<Option<T>> for Scalar
 where
-    T: ScalarType,
+    T: NativeDType,
     Scalar: From<T>,
 {
     /// A blanket implementation for all `Option<T>`.
@@ -387,7 +387,7 @@ where
 
 impl<T> From<Vec<T>> for Scalar
 where
-    T: ScalarType,
+    T: NativeDType,
     Scalar: From<T>,
 {
     /// Converts a vector into a `Scalar` (where the value is a `ListScalar`).

--- a/vortex-scalar/src/scalar_value.rs
+++ b/vortex-scalar/src/scalar_value.rs
@@ -8,12 +8,13 @@ use bytes::BufMut;
 use itertools::Itertools;
 use prost::Message;
 use vortex_buffer::{BufferString, ByteBuffer};
+use vortex_dtype::NativeDType;
 use vortex_error::{VortexResult, VortexUnwrap, vortex_bail, vortex_err};
 use vortex_proto::scalar as pb;
 
 use crate::decimal::DecimalValue;
 use crate::pvalue::PValue;
-use crate::{Scalar, ScalarType, i256};
+use crate::{Scalar, i256};
 
 /// Represents the internal data of a scalar value. Must be interpreted by wrapping up with a
 /// [`vortex_dtype::DType`] to make a [`super::Scalar`].
@@ -28,7 +29,7 @@ pub struct ScalarValue(pub(crate) InnerScalarValue);
 /// implementation for all `Option<T>` to simply be a nullable `T`.
 impl<T> From<Option<T>> for ScalarValue
 where
-    T: ScalarType,
+    T: NativeDType,
     ScalarValue: From<T>,
 {
     fn from(value: Option<T>) -> Self {
@@ -40,7 +41,7 @@ where
 
 impl<T> From<Vec<T>> for ScalarValue
 where
-    T: ScalarType,
+    T: NativeDType,
     Scalar: From<T>,
 {
     /// Converts a vector into a `ScalarValue` (specifically a `ListScalar`).


### PR DESCRIPTION
We add this trait for non-nested types