### PR TITLE
fix[encodings]: fix visit_children on sliced PCO/ZSTD encoded arrays

### DIFF
--- a/encodings/pco/src/serde.rs
+++ b/encodings/pco/src/serde.rs
@@ -106,6 +106,6 @@ impl VisitorVTable<PcoVTable> for PcoVTable {
     }
 
     fn visit_children(array: &PcoArray, visitor: &mut dyn ArrayChildVisitor) {
-        visitor.visit_validity(&array.unsliced_validity, array.len());
+        visitor.visit_validity(&array.unsliced_validity, array.unsliced_n_rows());
     }
 }

--- a/encodings/zstd/src/serde.rs
+++ b/encodings/zstd/src/serde.rs
@@ -92,6 +92,6 @@ impl VisitorVTable<ZstdVTable> for ZstdVTable {
     }
 
     fn visit_children(array: &ZstdArray, visitor: &mut dyn ArrayChildVisitor) {
-        visitor.visit_validity(&array.unsliced_validity, array.len());
+        visitor.visit_validity(&array.unsliced_validity, array.unsliced_n_rows());
     }
 }

--- a/encodings/zstd/src/test.rs
+++ b/encodings/zstd/src/test.rs
@@ -181,3 +181,12 @@ fn test_zstd_decompress_var_bin_view() {
     assert_nth_scalar!(decompressed, 3, "Lorem ipsum dolor sit amet");
     assert_nth_scalar!(decompressed, 4, "baz");
 }
+
+#[test]
+fn test_sliced_array_children() {
+    let data: Vec<Option<i32>> = (0..10).map(|v| (v != 5).then_some(v)).collect();
+    let compressed =
+        ZstdArray::from_primitive(&PrimitiveArray::from_option_iter(data), 0, 100).unwrap();
+    let sliced = compressed.slice(0..4);
+    let _ = sliced.children();
+}


### PR DESCRIPTION
Fixes #4803 