### PR TITLE
Fallback to ArrayBuilder in `ChunkedArray::take`

### DIFF
--- a/vortex-array/src/arrays/chunked/compute/take.rs
+++ b/vortex-array/src/arrays/chunked/compute/take.rs
@@ -7,9 +7,16 @@ use vortex_error::VortexResult;
 
 use crate::arrays::chunked::ChunkedArray;
 use crate::arrays::{ChunkedVTable, PrimitiveArray};
+use crate::builders::{ArrayBuilder, builder_with_capacity};
 use crate::compute::{TakeKernel, TakeKernelAdapter, cast, take};
 use crate::validity::Validity;
 use crate::{Array, ArrayRef, IntoArray, ToCanonical, register_kernel};
+
+/// The multiplier for determining the maximum number of resulting chunks before we fall back
+/// to using an ArrayBuilder. The threshold is calculated as initial_chunks * CHUNK_GROWTH_MULTIPLIER.
+/// When the indices are unsorted, the number of chunks can grow to be as large as the number
+/// of indices (worst case), which can lead to poor performance.
+const CHUNK_GROWTH_MULTIPLIER: usize = 2;
 
 impl TakeKernel for ChunkedVTable {
     fn take(&self, array: &ChunkedArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
@@ -24,10 +31,13 @@ impl TakeKernel for ChunkedVTable {
         let indices_mask = indices.validity_mask();
         let indices = indices.as_slice::<u64>();
 
-        let mut chunks = Vec::new();
+        let mut chunks: Vec<ArrayRef> = Vec::new();
         let mut indices_in_chunk = BufferMut::<u64>::empty();
         let mut start = 0;
         let mut stop = 0;
+        let mut builder: Option<Box<dyn ArrayBuilder>> = None;
+        let max_chunks_threshold = array.nchunks() * CHUNK_GROWTH_MULTIPLIER;
+
         // We assume indices are non-empty as it's handled in the top-level `take` function
         let mut prev_chunk_idx = array.find_chunk_idx(indices[0].try_into()?).0;
         for idx in indices {
@@ -35,15 +45,32 @@ impl TakeKernel for ChunkedVTable {
             let (chunk_idx, idx_in_chunk) = array.find_chunk_idx(idx);
 
             if chunk_idx != prev_chunk_idx {
-                // Start a new chunk
+                // Check if we're exceeding the threshold
+                if chunks.len() >= max_chunks_threshold && builder.is_none() {
+                    // Initialize builder and canonicalize all existing chunks
+                    let mut new_builder = builder_with_capacity(
+                        &array.dtype().clone().union_nullability(nullability),
+                        indices.len(),
+                    );
+                    for chunk in chunks.drain(..) {
+                        new_builder.extend_from_array(chunk.as_ref());
+                    }
+                    builder = Some(new_builder);
+                }
+
+                // Process the completed chunk
                 let indices_in_chunk_array = PrimitiveArray::new(
                     indices_in_chunk.clone().freeze(),
                     Validity::from_mask(indices_mask.slice(start..stop), nullability),
                 );
-                chunks.push(take(
-                    array.chunk(prev_chunk_idx),
-                    indices_in_chunk_array.as_ref(),
-                )?);
+                let taken = take(array.chunk(prev_chunk_idx), indices_in_chunk_array.as_ref())?;
+
+                if let Some(ref mut b) = builder {
+                    b.extend_from_array(taken.as_ref());
+                } else {
+                    chunks.push(taken);
+                }
+
                 indices_in_chunk.clear();
                 start = stop;
             }
@@ -58,19 +85,31 @@ impl TakeKernel for ChunkedVTable {
                 indices_in_chunk.freeze(),
                 Validity::from_mask(indices_mask.slice(start..stop), nullability),
             );
-            chunks.push(take(
-                array.chunk(prev_chunk_idx),
-                indices_in_chunk_array.as_ref(),
-            )?);
+            let taken = take(array.chunk(prev_chunk_idx), indices_in_chunk_array.as_ref())?;
+
+            if let Some(ref mut b) = builder {
+                b.extend_from_array(taken.as_ref());
+            } else {
+                chunks.push(taken);
+            }
         }
 
-        // SAFETY: take on chunks that all have same DType retains same DType
-        unsafe {
-            Ok(ChunkedArray::new_unchecked(
-                chunks,
-                array.dtype().clone().union_nullability(nullability),
-            )
-            .into_array())
+        if let Some(mut b) = builder {
+            log::trace!(
+                "Started with {}, exceeded threshold of {} chunks, merging chunks into a single array",
+                array.nchunks(),
+                max_chunks_threshold,
+            );
+            Ok(b.finish())
+        } else {
+            // SAFETY: take on chunks that all have same DType retains same DType
+            unsafe {
+                Ok(ChunkedArray::new_unchecked(
+                    chunks,
+                    array.dtype().clone().union_nullability(nullability),
+                )
+                .into_array())
+            }
         }
     }
 }
@@ -175,5 +214,60 @@ mod test {
         )
         .unwrap();
         test_take_conformance(arr.as_ref());
+    }
+
+    #[test]
+    fn test_take_unsorted_exceeds_threshold() {
+        // Create a chunked array with many chunks
+        let chunk = buffer![1i32, 2, 3].into_array();
+        let chunks: Vec<_> = (0..100).map(|_| chunk.clone()).collect();
+        let arr = ChunkedArray::try_new(chunks, chunk.dtype().clone()).unwrap();
+
+        // Create unsorted indices that will create more than MAX_CHUNKS_THRESHOLD chunks
+        // Each alternating index will be from a different chunk
+        let mut indices = Vec::new();
+        for i in 0..100 {
+            indices.push((i * 3) as u64); // First element of each chunk
+        }
+        // Now add indices in reverse order to create an unsorted pattern
+        for i in (0..100).rev() {
+            indices.push(((i * 3) + 1) as u64); // Second element of each chunk
+        }
+
+        let indices_array = PrimitiveArray::new(indices, Validity::NonNullable);
+        let result = take(arr.as_ref(), indices_array.as_ref()).unwrap();
+
+        // Verify the result is correct
+        assert_eq!(result.len(), 200);
+        let result_primitive = result.to_primitive();
+        let result_slice = result_primitive.as_slice::<i32>();
+
+        // First 100 elements should be 1s (first element of each chunk)
+        for i in 0..100 {
+            assert_eq!(result_slice[i], 1);
+        }
+        // Next 100 elements should be 2s (second element of each chunk)
+        for i in 100..200 {
+            assert_eq!(result_slice[i], 2);
+        }
+    }
+
+    #[test]
+    fn test_take_unsorted_within_threshold() {
+        // Create a smaller chunked array that won't exceed the threshold
+        let chunk = buffer![10i32, 20, 30].into_array();
+        let chunks: Vec<_> = (0..10)
+            .map(|idx| buffer![10 * idx, 1 + 10 * idx, 2 + 10 * idx].into_array())
+            .collect();
+        let arr = ChunkedArray::try_new(chunks, chunk.dtype().clone()).unwrap();
+
+        // Create unsorted indices
+        let indices = buffer![0u64, 15, 5, 20, 10, 25].into_array();
+        let result = take(arr.as_ref(), indices.as_ref()).unwrap();
+
+        // Verify the result is correct
+        assert_eq!(result.len(), 6);
+        let result_primitive = result.to_primitive();
+        assert_eq!(result_primitive.as_slice::<i32>(), &[0, 50, 12, 62, 31, 81]);
     }
 }


### PR DESCRIPTION
The existing code assumes that the take indices are sorted, so it can create up to `indices` chunks which will worsen performance for any subsequent use of the array.