### PR TITLE
perf[duckdb]: use a single external data/vector buffer per exporter

### DIFF
--- a/vortex-duckdb/build.rs
+++ b/vortex-duckdb/build.rs
@@ -316,6 +316,7 @@ fn main() {
         .file("cpp/table_function.cpp")
         .file("cpp/value.cpp")
         .file("cpp/vector.cpp")
+        .file("cpp/vector_buffer.cpp")
         .compile("vortex-duckdb-extras");
 
     // Generate the _exported_ bindings from our Rust code.

--- a/vortex-duckdb/cpp/include/duckdb_vx.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx.h
@@ -17,3 +17,4 @@
 #include "duckdb_vx/table_function.h"
 #include "duckdb_vx/value.h"
 #include "duckdb_vx/vector.h"
+#include "duckdb_vx/vector_buffer.h"

--- a/vortex-duckdb/cpp/include/duckdb_vx/vector.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/vector.h
@@ -35,14 +35,14 @@ void duckdb_vx_set_dictionary_vector_length(duckdb_vector dict, unsigned int len
 // Add the buffer to the string vector (basically, keep it alive as long as the vector).
 void duckdb_vx_string_vector_add_buffer(duckdb_vector ffi_vector, duckdb_vx_data buffer);
 
-void duckdb_vx_string_vector_add_shared_data_buffer(duckdb_vector ffi_vector, duckdb_vx_vector_buffer buffer);
+void duckdb_vx_string_vector_add_vector_data_buffer(duckdb_vector ffi_vector, duckdb_vx_vector_buffer buffer);
 
 
 // Add the buffer to the data vector (basically, keep it alive as long as the vector) and set the data pointer.
 // You must ensure that the ptr is valid for the lifetime of the vector and the ptr addr + size is valid.
 void duckdb_vx_vector_set_data_buffer(duckdb_vector ffi_vector, duckdb_vx_data buffer);
 
-void duckdb_vx_vector_set_shared_data_buffer(duckdb_vector ffi_vector, duckdb_vx_vector_buffer buffer);
+void duckdb_vx_vector_set_vector_data_buffer(duckdb_vector ffi_vector, duckdb_vx_vector_buffer buffer);
 
 // Set the data pointer for the vector. This is the start of the values array in the vector.
 void duckdb_vx_vector_set_data_ptr(duckdb_vector ffi_vector, void *ptr);

--- a/vortex-duckdb/cpp/include/duckdb_vx/vector.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/vector.h
@@ -33,15 +33,11 @@ void duckdb_vx_set_dictionary_vector_id(duckdb_vector dict, const char *id, unsi
 void duckdb_vx_set_dictionary_vector_length(duckdb_vector dict, unsigned int len);
 
 // Add the buffer to the string vector (basically, keep it alive as long as the vector).
-void duckdb_vx_string_vector_add_buffer(duckdb_vector ffi_vector, duckdb_vx_data buffer);
-
 void duckdb_vx_string_vector_add_vector_data_buffer(duckdb_vector ffi_vector, duckdb_vx_vector_buffer buffer);
 
 
 // Add the buffer to the data vector (basically, keep it alive as long as the vector) and set the data pointer.
 // You must ensure that the ptr is valid for the lifetime of the vector and the ptr addr + size is valid.
-void duckdb_vx_vector_set_data_buffer(duckdb_vector ffi_vector, duckdb_vx_data buffer);
-
 void duckdb_vx_vector_set_vector_data_buffer(duckdb_vector ffi_vector, duckdb_vx_vector_buffer buffer);
 
 // Set the data pointer for the vector. This is the start of the values array in the vector.

--- a/vortex-duckdb/cpp/include/duckdb_vx/vector.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/vector.h
@@ -6,17 +6,11 @@
 #include "duckdb.h"
 #include "duckdb_vx/data.h"
 #include "duckdb_vx/error.h"
+#include "duckdb_vx/vector_buffer.h"
 
 #ifdef __cplusplus /* If compiled as C++, use C ABI */
 extern "C" {
 #endif
-
-typedef struct duckdb_vx_shared_buffer_ *duckdb_vx_shared_buffer;
-
-duckdb_vx_shared_buffer duckdb_vx_shared_buffer_create(duckdb_vx_data buffer);
-
-void duckdb_vx_shared_buffer_destroy(duckdb_vx_shared_buffer *buffer);
-
 
 /// Slice the vector to a new dictionary vector, using the current vector's values and
 /// the provided selection vector.
@@ -41,11 +35,14 @@ void duckdb_vx_set_dictionary_vector_length(duckdb_vector dict, unsigned int len
 // Add the buffer to the string vector (basically, keep it alive as long as the vector).
 void duckdb_vx_string_vector_add_buffer(duckdb_vector ffi_vector, duckdb_vx_data buffer);
 
+void duckdb_vx_string_vector_add_shared_data_buffer(duckdb_vector ffi_vector, duckdb_vx_vector_buffer buffer);
+
+
 // Add the buffer to the data vector (basically, keep it alive as long as the vector) and set the data pointer.
 // You must ensure that the ptr is valid for the lifetime of the vector and the ptr addr + size is valid.
 void duckdb_vx_vector_set_data_buffer(duckdb_vector ffi_vector, duckdb_vx_data buffer);
 
-void duckdb_vx_vector_set_shared_data_buffer(duckdb_vector ffi_vector, duckdb_vx_shared_buffer buffer);
+void duckdb_vx_vector_set_shared_data_buffer(duckdb_vector ffi_vector, duckdb_vx_vector_buffer buffer);
 
 // Set the data pointer for the vector. This is the start of the values array in the vector.
 void duckdb_vx_vector_set_data_ptr(duckdb_vector ffi_vector, void *ptr);

--- a/vortex-duckdb/cpp/include/duckdb_vx/vector.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/vector.h
@@ -11,6 +11,13 @@
 extern "C" {
 #endif
 
+typedef struct duckdb_vx_shared_buffer_ *duckdb_vx_shared_buffer;
+
+duckdb_vx_shared_buffer duckdb_vx_shared_buffer_create(duckdb_vx_data buffer);
+
+void duckdb_vx_shared_buffer_destroy(duckdb_vx_shared_buffer *buffer);
+
+
 /// Slice the vector to a new dictionary vector, using the current vector's values and
 /// the provided selection vector.
 ///
@@ -37,6 +44,8 @@ void duckdb_vx_string_vector_add_buffer(duckdb_vector ffi_vector, duckdb_vx_data
 // Add the buffer to the data vector (basically, keep it alive as long as the vector) and set the data pointer.
 // You must ensure that the ptr is valid for the lifetime of the vector and the ptr addr + size is valid.
 void duckdb_vx_vector_set_data_buffer(duckdb_vector ffi_vector, duckdb_vx_data buffer);
+
+void duckdb_vx_vector_set_shared_data_buffer(duckdb_vector ffi_vector, duckdb_vx_shared_buffer buffer);
 
 // Set the data pointer for the vector. This is the start of the values array in the vector.
 void duckdb_vx_vector_set_data_ptr(duckdb_vector ffi_vector, void *ptr);

--- a/vortex-duckdb/cpp/include/duckdb_vx/vector_buffer.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/vector_buffer.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+#pragma once
+
+#include "duckdb.h"
+#include "duckdb_vx/data.h"
+#include "duckdb_vx/error.h"
+
+#ifdef __cplusplus /* If compiled as C++, use C ABI */
+extern "C" {
+#endif
+
+typedef struct duckdb_vx_vector_buffer_ *duckdb_vx_vector_buffer;
+
+duckdb_vx_vector_buffer duckdb_vx_vector_buffer_create(duckdb_vx_data buffer);
+
+void duckdb_vx_vector_buffer_destroy(duckdb_vx_vector_buffer *buffer);
+
+#ifdef __cplusplus /* End C ABI */
+}
+#endif

--- a/vortex-duckdb/cpp/include/duckdb_vx/vector_buffer.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/vector_buffer.h
@@ -13,8 +13,10 @@ extern "C" {
 
 typedef struct duckdb_vx_vector_buffer_ *duckdb_vx_vector_buffer;
 
+// Create a external vector buffer from an existing data buffer, used to allow DuckDB to keep a reference to the buffer.
 duckdb_vx_vector_buffer duckdb_vx_vector_buffer_create(duckdb_vx_data buffer);
 
+// Destroy the vector buffer.
 void duckdb_vx_vector_buffer_destroy(duckdb_vx_vector_buffer *buffer);
 
 #ifdef __cplusplus /* End C ABI */

--- a/vortex-duckdb/cpp/include/duckdb_vx/vector_buffer.hpp
+++ b/vortex-duckdb/cpp/include/duckdb_vx/vector_buffer.hpp
@@ -14,11 +14,11 @@ namespace vortex {
 // freed once the vector is done with the buffer.
 class ExternalVectorBuffer : public duckdb::VectorBuffer {
 public:
-    explicit ExternalVectorBuffer(unique_ptr<CData> data) : data(std::move(data)) {
+    explicit ExternalVectorBuffer(duckdb::unique_ptr<CData> data) : data(std::move(data)) {
     }
 
 private:
-    unique_ptr<CData> data;
+    duckdb::unique_ptr<CData> data;
 };
 
 } // namespace vortex

--- a/vortex-duckdb/cpp/include/duckdb_vx/vector_buffer.hpp
+++ b/vortex-duckdb/cpp/include/duckdb_vx/vector_buffer.hpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+#pragma once
+
+#include "duckdb/common/vector.hpp"
+#include "duckdb/common/types/vector.hpp"
+
+#include "duckdb_vx/data.hpp"
+
+namespace vortex {
+
+// This is a wrapper around an externally managed buffer, which can be assigned to a Vector and
+// freed once the vector is done with the buffer.
+class ExternalVectorBuffer : public duckdb::VectorBuffer {
+public:
+    explicit ExternalVectorBuffer(unique_ptr<CData> data) : data(std::move(data)) {
+    }
+
+private:
+    unique_ptr<CData> data;
+};
+
+} // namespace vortex

--- a/vortex-duckdb/cpp/vector.cpp
+++ b/vortex-duckdb/cpp/vector.cpp
@@ -66,7 +66,7 @@ extern "C" void duckdb_vx_string_vector_add_buffer(duckdb_vector ffi_vector, duc
     StringVector::AddBuffer(*vector, ext_buffer);
 }
 
-extern "C" void duckdb_vx_string_vector_add_shared_data_buffer(duckdb_vector ffi_vector, duckdb_vx_vector_buffer buffer) {
+extern "C" void duckdb_vx_string_vector_add_vector_data_buffer(duckdb_vector ffi_vector, duckdb_vx_vector_buffer buffer) {
     auto vector = reinterpret_cast<Vector *>(ffi_vector);
     auto data = reinterpret_cast<shared_ptr<vortex::ExternalVectorBuffer> *>(buffer);
     StringVector::AddBuffer(*vector, *data);
@@ -80,7 +80,7 @@ extern "C" void duckdb_vx_vector_set_data_buffer(duckdb_vector ffi_vector, duckd
     dvector->SetDataBuffer(ext_buffer);
 }
 
-extern "C" void duckdb_vx_vector_set_shared_data_buffer(duckdb_vector ffi_vector, duckdb_vx_vector_buffer buffer) {
+extern "C" void duckdb_vx_vector_set_vector_data_buffer(duckdb_vector ffi_vector, duckdb_vx_vector_buffer buffer) {
     auto vector = reinterpret_cast<Vector *>(ffi_vector);
     auto dvector = reinterpret_cast<vortex::DataVector *>(vector);
     auto data = reinterpret_cast<shared_ptr<vortex::ExternalVectorBuffer> *>(buffer);

--- a/vortex-duckdb/cpp/vector.cpp
+++ b/vortex-duckdb/cpp/vector.cpp
@@ -69,6 +69,23 @@ public:
 
 } // namespace vortex
 
+extern "C" duckdb_vx_shared_buffer duckdb_vx_shared_buffer_create(duckdb_vx_data buffer) {
+    auto data = reinterpret_cast<vortex::CData *>(buffer);
+//    auto shared_buffer = new duckdb::shared_ptr<vortex::ExternalVectorBuffer>(unique_ptr<vortex::CData>(data));
+    auto* shared_buffer = new duckdb::shared_ptr<vortex::ExternalVectorBuffer>(
+        duckdb::make_shared_ptr<vortex::ExternalVectorBuffer>(unique_ptr<vortex::CData>(data))
+    );
+    return reinterpret_cast<duckdb_vx_shared_buffer>(shared_buffer);
+}
+
+extern "C" void duckdb_vx_shared_buffer_destroy(duckdb_vx_shared_buffer *buffer) {
+    if (buffer != nullptr && *buffer != nullptr) {
+        auto shared_buffer = reinterpret_cast<shared_ptr<vortex::ExternalVectorBuffer> *>(*buffer);
+        delete shared_buffer;
+        *buffer = nullptr;
+    }
+}
+
 extern "C" void duckdb_vx_string_vector_add_buffer(duckdb_vector ffi_vector, duckdb_vx_data buffer) {
     auto vector = reinterpret_cast<Vector *>(ffi_vector);
     auto data = reinterpret_cast<vortex::CData *>(buffer);
@@ -82,6 +99,13 @@ extern "C" void duckdb_vx_vector_set_data_buffer(duckdb_vector ffi_vector, duckd
     auto data = reinterpret_cast<vortex::CData *>(buffer);
     auto ext_buffer = duckdb::make_shared_ptr<vortex::ExternalVectorBuffer>(unique_ptr<vortex::CData>(data));
     dvector->SetDataBuffer(ext_buffer);
+}
+
+extern "C" void duckdb_vx_vector_set_shared_data_buffer(duckdb_vector ffi_vector, duckdb_vx_shared_buffer buffer) {
+    auto vector = reinterpret_cast<Vector *>(ffi_vector);
+    auto dvector = reinterpret_cast<vortex::DataVector *>(vector);
+    auto data = reinterpret_cast<shared_ptr<vortex::ExternalVectorBuffer> *>(buffer);
+    dvector->SetDataBuffer(*data);
 }
 
 extern "C" void duckdb_vx_vector_set_data_ptr(duckdb_vector ffi_vector, void *ptr) {

--- a/vortex-duckdb/cpp/vector.cpp
+++ b/vortex-duckdb/cpp/vector.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/common/types/vector.hpp"
 
 #include "duckdb_vx.h"
-#include "duckdb_vx/data.hpp"
+#include "duckdb_vx/vector_buffer.hpp"
 
 using namespace duckdb;
 
@@ -44,17 +44,6 @@ extern "C" void duckdb_vx_sequence_vector(duckdb_vector c_vector, int64_t start,
 
 namespace vortex {
 
-// This is a wrapper around an externally managed buffer, which can be assigned to a Vector and
-// freed once the vector is done with the buffer.
-class ExternalVectorBuffer : public VectorBuffer {
-public:
-    explicit ExternalVectorBuffer(unique_ptr<vortex::CData> data) : data(std::move(data)) {
-    }
-
-private:
-    unique_ptr<vortex::CData> data;
-};
-
 // This is a complete hack to access the data buffer and pointer of a vector.
 class DataVector : public Vector {
 public:
@@ -69,28 +58,18 @@ public:
 
 } // namespace vortex
 
-extern "C" duckdb_vx_shared_buffer duckdb_vx_shared_buffer_create(duckdb_vx_data buffer) {
-    auto data = reinterpret_cast<vortex::CData *>(buffer);
-//    auto shared_buffer = new duckdb::shared_ptr<vortex::ExternalVectorBuffer>(unique_ptr<vortex::CData>(data));
-    auto* shared_buffer = new duckdb::shared_ptr<vortex::ExternalVectorBuffer>(
-        duckdb::make_shared_ptr<vortex::ExternalVectorBuffer>(unique_ptr<vortex::CData>(data))
-    );
-    return reinterpret_cast<duckdb_vx_shared_buffer>(shared_buffer);
-}
-
-extern "C" void duckdb_vx_shared_buffer_destroy(duckdb_vx_shared_buffer *buffer) {
-    if (buffer != nullptr && *buffer != nullptr) {
-        auto shared_buffer = reinterpret_cast<shared_ptr<vortex::ExternalVectorBuffer> *>(*buffer);
-        delete shared_buffer;
-        *buffer = nullptr;
-    }
-}
 
 extern "C" void duckdb_vx_string_vector_add_buffer(duckdb_vector ffi_vector, duckdb_vx_data buffer) {
     auto vector = reinterpret_cast<Vector *>(ffi_vector);
     auto data = reinterpret_cast<vortex::CData *>(buffer);
     auto ext_buffer = duckdb::make_shared_ptr<vortex::ExternalVectorBuffer>(unique_ptr<vortex::CData>(data));
     StringVector::AddBuffer(*vector, ext_buffer);
+}
+
+extern "C" void duckdb_vx_string_vector_add_shared_data_buffer(duckdb_vector ffi_vector, duckdb_vx_vector_buffer buffer) {
+    auto vector = reinterpret_cast<Vector *>(ffi_vector);
+    auto data = reinterpret_cast<shared_ptr<vortex::ExternalVectorBuffer> *>(buffer);
+    StringVector::AddBuffer(*vector, *data);
 }
 
 extern "C" void duckdb_vx_vector_set_data_buffer(duckdb_vector ffi_vector, duckdb_vx_data buffer) {
@@ -101,7 +80,7 @@ extern "C" void duckdb_vx_vector_set_data_buffer(duckdb_vector ffi_vector, duckd
     dvector->SetDataBuffer(ext_buffer);
 }
 
-extern "C" void duckdb_vx_vector_set_shared_data_buffer(duckdb_vector ffi_vector, duckdb_vx_shared_buffer buffer) {
+extern "C" void duckdb_vx_vector_set_shared_data_buffer(duckdb_vector ffi_vector, duckdb_vx_vector_buffer buffer) {
     auto vector = reinterpret_cast<Vector *>(ffi_vector);
     auto dvector = reinterpret_cast<vortex::DataVector *>(vector);
     auto data = reinterpret_cast<shared_ptr<vortex::ExternalVectorBuffer> *>(buffer);

--- a/vortex-duckdb/cpp/vector.cpp
+++ b/vortex-duckdb/cpp/vector.cpp
@@ -58,26 +58,10 @@ public:
 
 } // namespace vortex
 
-
-extern "C" void duckdb_vx_string_vector_add_buffer(duckdb_vector ffi_vector, duckdb_vx_data buffer) {
-    auto vector = reinterpret_cast<Vector *>(ffi_vector);
-    auto data = reinterpret_cast<vortex::CData *>(buffer);
-    auto ext_buffer = duckdb::make_shared_ptr<vortex::ExternalVectorBuffer>(unique_ptr<vortex::CData>(data));
-    StringVector::AddBuffer(*vector, ext_buffer);
-}
-
 extern "C" void duckdb_vx_string_vector_add_vector_data_buffer(duckdb_vector ffi_vector, duckdb_vx_vector_buffer buffer) {
     auto vector = reinterpret_cast<Vector *>(ffi_vector);
     auto data = reinterpret_cast<shared_ptr<vortex::ExternalVectorBuffer> *>(buffer);
     StringVector::AddBuffer(*vector, *data);
-}
-
-extern "C" void duckdb_vx_vector_set_data_buffer(duckdb_vector ffi_vector, duckdb_vx_data buffer) {
-    auto vector = reinterpret_cast<Vector *>(ffi_vector);
-    auto dvector = reinterpret_cast<vortex::DataVector *>(vector);
-    auto data = reinterpret_cast<vortex::CData *>(buffer);
-    auto ext_buffer = duckdb::make_shared_ptr<vortex::ExternalVectorBuffer>(unique_ptr<vortex::CData>(data));
-    dvector->SetDataBuffer(ext_buffer);
 }
 
 extern "C" void duckdb_vx_vector_set_vector_data_buffer(duckdb_vector ffi_vector, duckdb_vx_vector_buffer buffer) {

--- a/vortex-duckdb/cpp/vector_buffer.cpp
+++ b/vortex-duckdb/cpp/vector_buffer.cpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+#include "duckdb/common/vector.hpp"
+#include "duckdb/common/types/vector.hpp"
+
+#include "duckdb_vx.h"
+#include "duckdb_vx/data.hpp"
+#include "duckdb_vx/vector_buffer.hpp"
+
+using namespace duckdb;
+
+extern "C" duckdb_vx_vector_buffer duckdb_vx_vector_buffer_create(duckdb_vx_data buffer) {
+    auto data = reinterpret_cast<vortex::CData *>(buffer);
+    auto* shared_buffer = new duckdb::shared_ptr<vortex::ExternalVectorBuffer>(
+        duckdb::make_shared_ptr<vortex::ExternalVectorBuffer>(unique_ptr<vortex::CData>(data))
+    );
+    return reinterpret_cast<duckdb_vx_vector_buffer>(shared_buffer);
+}
+
+extern "C" void duckdb_vx_vector_buffer_destroy(duckdb_vx_vector_buffer *buffer) {
+    if (buffer != nullptr && *buffer != nullptr) {
+        auto shared_buffer = reinterpret_cast<shared_ptr<vortex::ExternalVectorBuffer> *>(*buffer);
+        delete shared_buffer;
+        *buffer = nullptr;
+    }
+}

--- a/vortex-duckdb/src/duckdb/mod.rs
+++ b/vortex-duckdb/src/duckdb/mod.rs
@@ -21,6 +21,7 @@ mod table_filter;
 mod table_function;
 mod value;
 mod vector;
+mod vector_buffer;
 
 use std::ffi::c_void;
 use std::ptr;
@@ -43,6 +44,7 @@ pub use table_filter::*;
 pub use table_function::*;
 pub use value::*;
 pub use vector::*;
+pub use vector_buffer::*;
 use vortex::error::VortexResult;
 
 use crate::cpp;

--- a/vortex-duckdb/src/duckdb/vector.rs
+++ b/vortex-duckdb/src/duckdb/vector.rs
@@ -12,7 +12,6 @@ use bitvec::view::BitView;
 use vortex::error::{VortexResult, VortexUnwrap, vortex_bail, vortex_err};
 
 use crate::cpp::duckdb_vx_error;
-use crate::duckdb::data::Data;
 use crate::duckdb::vector_buffer::VectorBuffer;
 use crate::duckdb::{LogicalType, SelectionVector, Value};
 use crate::{cpp, wrapper};
@@ -146,7 +145,7 @@ impl Vector {
         unsafe { cpp::duckdb_vx_vector_set_vector_data_buffer(self.as_ptr(), buffer.as_ptr()) }
     }
 
-    pub fn add_string_vector_buffer<T>(&self, buffer: &VectorBuffer) {
+    pub fn add_string_vector_buffer(&self, buffer: &VectorBuffer) {
         unsafe {
             cpp::duckdb_vx_string_vector_add_vector_data_buffer(self.as_ptr(), buffer.as_ptr())
         }

--- a/vortex-duckdb/src/duckdb/vector.rs
+++ b/vortex-duckdb/src/duckdb/vector.rs
@@ -13,27 +13,11 @@ use vortex::error::{VortexResult, VortexUnwrap, vortex_bail, vortex_err};
 
 use crate::cpp::duckdb_vx_error;
 use crate::duckdb::data::Data;
+use crate::duckdb::vector_buffer::VectorBuffer;
 use crate::duckdb::{LogicalType, SelectionVector, Value};
 use crate::{cpp, wrapper};
 
 pub const DUCKDB_STANDARD_VECTOR_SIZE: usize = 2048;
-
-wrapper!(
-    VectorBuffer,
-    cpp::duckdb_vx_shared_buffer,
-    cpp::duckdb_vx_shared_buffer_destroy
-);
-
-impl VectorBuffer {
-    pub fn new<T>(data: T) -> Self {
-        let data = Data::from(Box::new(data));
-        Self::create(data)
-    }
-
-    pub fn create(buffer: Data) -> Self {
-        unsafe { Self::own(cpp::duckdb_vx_shared_buffer_create(buffer.as_ptr())) }
-    }
-}
 
 wrapper!(Vector, cpp::duckdb_vector, cpp::duckdb_destroy_vector);
 
@@ -158,24 +142,19 @@ impl Vector {
         !is_valid
     }
 
-    /// Sets the data buffer for the vector.
-    pub unsafe fn set_data_buffer<T>(&self, buffer: T) {
-        let data = Data::from(Box::new(buffer));
-        unsafe { cpp::duckdb_vx_vector_set_data_buffer(self.as_ptr(), data.into_ptr()) }
+    pub unsafe fn set_vector_buffer(&self, buffer: &VectorBuffer) {
+        unsafe { cpp::duckdb_vx_vector_set_vector_data_buffer(self.as_ptr(), buffer.as_ptr()) }
     }
 
-    pub unsafe fn set_vector_buffer(&self, buffer: &VectorBuffer) {
-        unsafe { cpp::duckdb_vx_vector_set_shared_data_buffer(self.as_ptr(), buffer.as_ptr()) }
+    pub fn add_string_vector_buffer<T>(&self, buffer: &VectorBuffer) {
+        unsafe {
+            cpp::duckdb_vx_string_vector_add_vector_data_buffer(self.as_ptr(), buffer.as_ptr())
+        }
     }
 
     /// Sets the data pointer for the vector. This is the start of the values array in the vector.
     pub unsafe fn set_data_ptr<T>(&self, ptr: *mut T) {
         unsafe { cpp::duckdb_vx_vector_set_data_ptr(self.as_ptr(), ptr as *mut c_void) }
-    }
-
-    pub fn add_string_buffer<T>(&self, buffer: T) {
-        let data = Data::from(Box::new(buffer));
-        unsafe { cpp::duckdb_vx_string_vector_add_buffer(self.as_ptr(), data.into_ptr()) }
     }
 
     /// Assigns the element at the specified index with a string value.

--- a/vortex-duckdb/src/duckdb/vector.rs
+++ b/vortex-duckdb/src/duckdb/vector.rs
@@ -18,6 +18,23 @@ use crate::{cpp, wrapper};
 
 pub const DUCKDB_STANDARD_VECTOR_SIZE: usize = 2048;
 
+wrapper!(
+    VectorBuffer,
+    cpp::duckdb_vx_shared_buffer,
+    cpp::duckdb_vx_shared_buffer_destroy
+);
+
+impl VectorBuffer {
+    pub fn new<T>(data: T) -> Self {
+        let data = Data::from(Box::new(data));
+        Self::create(data)
+    }
+
+    pub fn create(buffer: Data) -> Self {
+        unsafe { Self::own(cpp::duckdb_vx_shared_buffer_create(buffer.as_ptr())) }
+    }
+}
+
 wrapper!(Vector, cpp::duckdb_vector, cpp::duckdb_destroy_vector);
 
 /// Safety: It is safe to mark `Vector` as `Send` as the memory it points is `Send`.
@@ -145,6 +162,10 @@ impl Vector {
     pub unsafe fn set_data_buffer<T>(&self, buffer: T) {
         let data = Data::from(Box::new(buffer));
         unsafe { cpp::duckdb_vx_vector_set_data_buffer(self.as_ptr(), data.into_ptr()) }
+    }
+
+    pub unsafe fn set_vector_buffer(&self, buffer: &VectorBuffer) {
+        unsafe { cpp::duckdb_vx_vector_set_shared_data_buffer(self.as_ptr(), buffer.as_ptr()) }
     }
 
     /// Sets the data pointer for the vector. This is the start of the values array in the vector.

--- a/vortex-duckdb/src/duckdb/vector_buffer.rs
+++ b/vortex-duckdb/src/duckdb/vector_buffer.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use crate::duckdb::Data;
+use crate::{cpp, wrapper};
+
+wrapper!(
+    VectorBuffer,
+    cpp::duckdb_vx_vector_buffer,
+    cpp::duckdb_vx_vector_buffer_destroy
+);
+
+impl VectorBuffer {
+    pub fn new<T>(data: T) -> Self {
+        let data = Data::from(Box::new(data));
+        unsafe { Self::own(cpp::duckdb_vx_vector_buffer_create(data.as_ptr())) }
+    }
+}

--- a/vortex-duckdb/src/duckdb/vector_buffer.rs
+++ b/vortex-duckdb/src/duckdb/vector_buffer.rs
@@ -4,6 +4,8 @@
 use crate::duckdb::Data;
 use crate::{cpp, wrapper};
 
+// A wrapped buffer that give duckdb a strong reference to a vortex buffer.
+
 wrapper!(
     VectorBuffer,
     cpp::duckdb_vx_vector_buffer,

--- a/vortex-duckdb/src/exporter/decimal.rs
+++ b/vortex-duckdb/src/exporter/decimal.rs
@@ -128,8 +128,10 @@ mod tests {
 
         assert_eq!(array.values_type(), dest_values_type);
         match_each_decimal_value_type!(array.values_type(), |D| {
+            let buffer = array.buffer::<D>();
             Ok(Box::new(DecimalZeroCopyExporter {
-                values: array.buffer::<D>(),
+                values: buffer.clone(),
+                shared_buffer: VectorBuffer::new(buffer),
                 validity,
             }))
         })

--- a/vortex-duckdb/src/exporter/decimal.rs
+++ b/vortex-duckdb/src/exporter/decimal.rs
@@ -11,7 +11,7 @@ use vortex::error::{VortexExpect, VortexResult, vortex_bail};
 use vortex::mask::Mask;
 use vortex::scalar::{BigCast, DecimalValueType, NativeDecimalType, match_each_decimal_value_type};
 
-use crate::duckdb::Vector;
+use crate::duckdb::{Vector, VectorBuffer};
 use crate::exporter::ColumnExporter;
 
 struct DecimalExporter<D: NativeDecimalType, N: NativeDecimalType> {
@@ -23,6 +23,7 @@ struct DecimalExporter<D: NativeDecimalType, N: NativeDecimalType> {
 
 struct DecimalZeroCopyExporter<D: NativeDecimalType> {
     values: Buffer<D>,
+    shared_buffer: VectorBuffer,
     validity: Mask,
 }
 
@@ -32,8 +33,10 @@ pub(crate) fn new_exporter(array: &DecimalArray) -> VortexResult<Box<dyn ColumnE
 
     if array.values_type() == dest_values_type {
         match_each_decimal_value_type!(array.values_type(), |D| {
+            let buffer = array.buffer::<D>();
             return Ok(Box::new(DecimalZeroCopyExporter {
-                values: array.buffer::<D>(),
+                values: buffer.clone(),
+                shared_buffer: VectorBuffer::new(buffer),
                 validity,
             }));
         })
@@ -100,7 +103,7 @@ impl<D: NativeDecimalType> ColumnExporter for DecimalZeroCopyExporter<D> {
         assert!(self.values.len() >= offset + len);
 
         let pos = unsafe { self.values.as_ptr().add(offset) };
-        unsafe { vector.set_data_buffer(self.values.clone()) };
+        unsafe { vector.set_vector_buffer(&self.shared_buffer) };
         // While we are setting a *mut T this is an artifact of the C API, this is in fact const.
         unsafe { vector.set_data_ptr(pos as *mut D) };
 

--- a/vortex-duckdb/src/exporter/primitive.rs
+++ b/vortex-duckdb/src/exporter/primitive.rs
@@ -6,17 +6,20 @@ use vortex::buffer::Buffer;
 use vortex::dtype::{NativePType, match_each_native_ptype};
 use vortex::error::VortexResult;
 
-use crate::duckdb::Vector;
+use crate::duckdb::{Vector, VectorBuffer};
 use crate::exporter::{ColumnExporter, validity};
 
 struct PrimitiveExporter<T: NativePType> {
     buffer: Buffer<T>,
+    shared_buffer: VectorBuffer,
 }
 
 pub fn new_exporter(array: &PrimitiveArray) -> VortexResult<Box<dyn ColumnExporter>> {
     let prim = match_each_native_ptype!(array.ptype(), |T| {
+        let buffer = array.buffer::<T>();
         Box::new(PrimitiveExporter {
-            buffer: array.buffer::<T>(),
+            buffer: buffer.clone(),
+            shared_buffer: VectorBuffer::new(buffer),
         }) as Box<dyn ColumnExporter>
     });
     Ok(if array.dtype().is_nullable() {
@@ -31,7 +34,7 @@ impl<T: NativePType> ColumnExporter for PrimitiveExporter<T> {
         assert!(self.buffer.len() >= offset + len);
 
         let pos = unsafe { self.buffer.as_ptr().add(offset) };
-        unsafe { vector.set_data_buffer(self.buffer.clone()) };
+        unsafe { vector.set_vector_buffer(&self.shared_buffer) };
         // While we are setting a *mut T this is an artifact of the C API, this is in fact const.
         unsafe { vector.set_data_ptr(pos as *mut T) };
 

--- a/vortex-duckdb/src/exporter/varbinview.rs
+++ b/vortex-duckdb/src/exporter/varbinview.rs
@@ -59,7 +59,7 @@ impl ColumnExporter for VarBinViewExporter {
 
         // We register our buffers zero-copy with DuckDB and re-use them in each vector.
         for buffer in &self.vector_buffers {
-            vector.add_string_vector_buffer(buffer.clone());
+            vector.add_string_vector_buffer(buffer);
         }
 
         Ok(())

--- a/vortex-duckdb/src/exporter/varbinview.rs
+++ b/vortex-duckdb/src/exporter/varbinview.rs
@@ -3,17 +3,19 @@
 
 use std::ffi::c_char;
 
+use itertools::Itertools;
 use vortex::arrays::{BinaryView, Inlined, VarBinViewArray};
 use vortex::buffer::{Buffer, ByteBuffer};
 use vortex::error::VortexResult;
 use vortex::mask::Mask;
 
-use crate::duckdb::Vector;
+use crate::duckdb::{Vector, VectorBuffer};
 use crate::exporter::{ColumnExporter, all_invalid};
 
 struct VarBinViewExporter {
     views: Buffer<BinaryView>,
     buffers: Vec<ByteBuffer>,
+    vector_buffers: Vec<VectorBuffer>,
     validity: Mask,
 }
 
@@ -29,6 +31,12 @@ pub(crate) fn new_exporter(array: &VarBinViewArray) -> VortexResult<Box<dyn Colu
     Ok(Box::new(VarBinViewExporter {
         views: array.views().clone(),
         buffers: array.buffers().to_vec(),
+        vector_buffers: array
+            .buffers()
+            .iter()
+            .cloned()
+            .map(|b| VectorBuffer::new(b))
+            .collect_vec(),
         validity: array.validity_mask(),
     }))
 }
@@ -50,8 +58,8 @@ impl ColumnExporter for VarBinViewExporter {
         unsafe { vector.set_validity(&self.validity, offset, len) };
 
         // We register our buffers zero-copy with DuckDB and re-use them in each vector.
-        for buffer in &self.buffers {
-            vector.add_string_buffer(buffer.clone());
+        for buffer in &self.vector_buffers {
+            vector.add_string_vector_buffer(buffer.clone());
         }
 
         Ok(())

--- a/vortex-duckdb/src/exporter/varbinview.rs
+++ b/vortex-duckdb/src/exporter/varbinview.rs
@@ -35,7 +35,7 @@ pub(crate) fn new_exporter(array: &VarBinViewArray) -> VortexResult<Box<dyn Colu
             .buffers()
             .iter()
             .cloned()
-            .map(|b| VectorBuffer::new(b))
+            .map(VectorBuffer::new)
             .collect_vec(),
         validity: array.validity_mask(),
     }))


### PR DESCRIPTION
This should reduce the number of Arc and std::shared_ptr reference count changes