### PR TITLE
feat: FineWeb as a benchmark dataset

### DIFF
--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -69,6 +69,14 @@ on:
               "targets": "duckdb:parquet,duckdb:vortex,duckdb:vortex-compact",
               "scale_factor": "--scale-factor 100"
             },
+            {
+              "id": "fineweb",
+              "subcommand": "fineweb",
+              "name": "FineWeb",
+              "local_dir": "bench-vortex/data/fineweb",
+              "targets": "duckdb:parquet,duckdb:vortex,duckdb:vortex-compact,datafusion:parquet,datafusion:vortex,datafusion:vortex-compact",
+              "scale_factor": "--scale-factor 100"
+            },
           ]
 
 jobs:

--- a/bench-vortex/src/bin/query_bench.rs
+++ b/bench-vortex/src/bin/query_bench.rs
@@ -222,6 +222,10 @@ struct FinewebArgs {
           ]
     )]
     targets: Vec<Target>,
+
+    // Dummy, unused but we are required to accept it to make the CI automation happy
+    #[arg(long)]
+    scale_factor: u64,
 }
 
 fn validate_scale_factor(val: &str) -> Result<String, String> {

--- a/bench-vortex/src/bin/query_bench.rs
+++ b/bench-vortex/src/bin/query_bench.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use bench_vortex::benchmark_driver::{DriverConfig, run_benchmark};
 use bench_vortex::clickbench::{ClickBenchBenchmark, Flavor};
 use bench_vortex::display::DisplayFormat;
+use bench_vortex::fineweb::Fineweb;
 use bench_vortex::statpopgen::StatPopGenBenchmark;
 use bench_vortex::tpcds::TpcDsBenchmark;
 use bench_vortex::tpch::tpch_benchmark::TpcHBenchmark;
@@ -37,6 +38,9 @@ enum Commands {
     /// Run Statisical & Population Genetics queries
     #[command(name = "statpopgen")]
     StatPopGen(StatPopGenArgs),
+
+    #[command(name = "fineweb")]
+    Fineweb(FinewebArgs),
 }
 
 /// Common arguments shared across benchmarks
@@ -202,6 +206,24 @@ struct StatPopGenArgs {
     scale_factor: u64,
 }
 
+#[derive(Parser, Debug)]
+struct FinewebArgs {
+    #[command(flatten)]
+    common: CommonArgs,
+
+    #[arg(long, value_delimiter = ',', value_parser = value_parser!(Target),
+        default_values = vec![
+              "duckdb:parquet",
+              "duckdb:vortex",
+              "duckdb:vortex-compact",
+              "datafusion:parquet",
+              "datafusion:vortex",
+              "datafusion:vortex-compact",
+          ]
+    )]
+    targets: Vec<Target>,
+}
+
 fn validate_scale_factor(val: &str) -> Result<String, String> {
     match val.parse::<f32>() {
         Ok(n) if [0.01, 0.1, 1., 10., 100., 1000.].contains(&n) => {
@@ -230,6 +252,7 @@ fn main() -> anyhow::Result<()> {
         Commands::TpcH(tpch_args) => run_tpch(tpch_args),
         Commands::TpcDS(tpcds_args) => run_tpcds(tpcds_args),
         Commands::StatPopGen(stat_pop_gen_args) => run_statpopgen(stat_pop_gen_args),
+        Commands::Fineweb(fineweb_args) => run_fineweb(fineweb_args),
     }
 }
 
@@ -365,5 +388,36 @@ fn run_statpopgen(args: StatPopGenArgs) -> anyhow::Result<()> {
     };
 
     // Run benchmark using the trait system
+    run_benchmark(benchmark, config)
+}
+
+fn run_fineweb(args: FinewebArgs) -> anyhow::Result<()> {
+    setup_logging_and_tracing(args.common.verbose, args.common.tracing)?;
+
+    let data_url = Url::from_directory_path("fineweb".to_data_path())
+        .map_err(|_| anyhow::anyhow!("bad data path"))?;
+
+    let benchmark = Fineweb::new(data_url);
+
+    let config = DriverConfig {
+        targets: args.targets,
+        iterations: args.common.iterations,
+        threads: args.common.threads,
+        display_format: args.common.display_format,
+        disable_datafusion_cache: args.common.disable_datafusion_cache,
+        delete_duckdb_database: args.common.delete_duckdb_database,
+        queries: args.common.queries,
+        exclude_queries: args.common.exclude_queries,
+        output_path: args.common.output_path,
+        emit_plan: args.common.emit_plan,
+        export_spans: args.common.export_spans,
+        show_metrics: args.common.show_metrics,
+        hide_progress_bar: args.common.hide_progress_bar,
+        track_memory: args.common.track_memory,
+        skip_generate: args.common.skip_generate,
+        explain: args.common.explain,
+        explain_analyze: args.common.explain_analyze,
+    };
+
     run_benchmark(benchmark, config)
 }

--- a/bench-vortex/src/datasets/file.rs
+++ b/bench-vortex/src/datasets/file.rs
@@ -74,7 +74,9 @@ pub async fn register_vortex_files(
     dataset: &BenchmarkDataset,
 ) -> Result<()> {
     match dataset {
-        BenchmarkDataset::TpcH { .. } | BenchmarkDataset::TpcDS { .. } => {
+        BenchmarkDataset::TpcH { .. }
+        | BenchmarkDataset::TpcDS { .. }
+        | BenchmarkDataset::Fineweb => {
             info!(
                 "Registering table from {}, with glob {:?}",
                 &file_url,
@@ -156,6 +158,7 @@ pub async fn register_vortex_compact_files(
         }
         BenchmarkDataset::PublicBi { .. } => todo!(),
         BenchmarkDataset::StatPopGen { .. } => todo!(),
+        BenchmarkDataset::Fineweb => todo!(),
     }
 
     Ok(())

--- a/bench-vortex/src/datasets/mod.rs
+++ b/bench-vortex/src/datasets/mod.rs
@@ -11,7 +11,7 @@ use url::Url;
 use vortex::ArrayRef;
 
 use crate::clickbench::Flavor;
-use crate::{Format, clickbench, statpopgen};
+use crate::{Format, clickbench, fineweb, statpopgen};
 
 pub mod data_downloads;
 pub mod file;
@@ -38,6 +38,8 @@ pub enum BenchmarkDataset {
     PublicBi { name: String },
     #[serde(rename = "statpopgen")]
     StatPopGen { n_rows: u64 },
+    #[serde(rename = "fineweb")]
+    Fineweb,
 }
 
 impl BenchmarkDataset {
@@ -48,6 +50,7 @@ impl BenchmarkDataset {
             BenchmarkDataset::ClickBench { .. } => "clickbench",
             BenchmarkDataset::PublicBi { .. } => "public-bi",
             BenchmarkDataset::StatPopGen { .. } => "statpopgen",
+            BenchmarkDataset::Fineweb => "fineweb",
         }
     }
 }
@@ -63,6 +66,7 @@ impl Display for BenchmarkDataset {
             },
             BenchmarkDataset::PublicBi { name } => write!(f, "public-bi({name})"),
             BenchmarkDataset::StatPopGen { n_rows } => write!(f, "statpopgen(n_rows={n_rows})"),
+            BenchmarkDataset::Fineweb => write!(f, "fineweb"),
         }
     }
 }
@@ -102,6 +106,7 @@ impl BenchmarkDataset {
             ],
             BenchmarkDataset::ClickBench { .. } | BenchmarkDataset::PublicBi { .. } => todo!(),
             BenchmarkDataset::StatPopGen { .. } => &["statpopgen"],
+            BenchmarkDataset::Fineweb => &["fineweb"],
         }
     }
 
@@ -152,6 +157,9 @@ impl BenchmarkDataset {
             }
             (BenchmarkDataset::StatPopGen { .. }, format) => {
                 anyhow::bail!("StatPopGen in {format} unsupported in DataFusion")
+            }
+            (BenchmarkDataset::Fineweb, format) => {
+                fineweb::register_table(session, base_url, format).await?
             }
         }
 

--- a/bench-vortex/src/engines/ddb/mod.rs
+++ b/bench-vortex/src/engines/ddb/mod.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use log::trace;
+use log::{info, trace};
 use url::Url;
 use vortex::error::VortexExpect;
 use vortex_duckdb::duckdb::{Config, Connection, Database};
@@ -51,6 +51,7 @@ impl DuckDBCtx {
             BenchmarkDataset::StatPopGen { n_rows } => {
                 format!("statpopgen/{n_rows}/{}", format.name()).to_data_path()
             }
+            BenchmarkDataset::Fineweb => format!("fineweb/{}", format.name()).to_data_path(),
         };
         std::fs::create_dir_all(&dir)?;
         let db_path = dir.join("duckdb.db");
@@ -163,7 +164,7 @@ impl DuckDBCtx {
 
         // Generate and execute table registration commands
         let commands = self.generate_table_commands(&effective_url, extension, dataset, object);
-        trace!("Executing table registration commands: {commands}");
+        info!("Executing table registration commands: {commands}");
         self.execute_query(&commands)?;
 
         Ok(())
@@ -199,7 +200,9 @@ impl DuckDBCtx {
     ) -> String {
         // Base path contains trailing /.
         let base_dir = base_url.as_str();
+        info!("base_dir1: {base_dir}");
         let base_dir = base_dir.strip_prefix("file://").unwrap_or(base_dir);
+        info!("base_dir2: {base_dir}");
         match dataset {
             BenchmarkDataset::TpcH { .. } => {
                 let mut commands = String::new();
@@ -242,6 +245,13 @@ impl DuckDBCtx {
                 format!(
                     "CREATE {} IF NOT EXISTS statpopgen AS SELECT * FROM read_{extension}('{path}');",
                     duckdb_object.to_str()
+                )
+            }
+            BenchmarkDataset::Fineweb => {
+                let path = format!("{base_dir}*.{extension}");
+                format!(
+                    "CREATE {} IF NOT EXISTS fineweb AS SELECT * FROM read_{extension}('{path}');",
+                    duckdb_object.to_str(),
                 )
             }
         }

--- a/bench-vortex/src/engines/ddb/mod.rs
+++ b/bench-vortex/src/engines/ddb/mod.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use log::{info, trace};
+use log::trace;
 use url::Url;
 use vortex::error::VortexExpect;
 use vortex_duckdb::duckdb::{Config, Connection, Database};
@@ -164,7 +164,7 @@ impl DuckDBCtx {
 
         // Generate and execute table registration commands
         let commands = self.generate_table_commands(&effective_url, extension, dataset, object);
-        info!("Executing table registration commands: {commands}");
+        trace!("Executing table registration commands: {commands}");
         self.execute_query(&commands)?;
 
         Ok(())
@@ -200,9 +200,7 @@ impl DuckDBCtx {
     ) -> String {
         // Base path contains trailing /.
         let base_dir = base_url.as_str();
-        info!("base_dir1: {base_dir}");
         let base_dir = base_dir.strip_prefix("file://").unwrap_or(base_dir);
-        info!("base_dir2: {base_dir}");
         match dataset {
             BenchmarkDataset::TpcH { .. } => {
                 let mut commands = String::new();

--- a/bench-vortex/src/fineweb/mod.rs
+++ b/bench-vortex/src/fineweb/mod.rs
@@ -94,7 +94,10 @@ impl Benchmark for Fineweb {
     fn generate_data(&self, target: &Target) -> anyhow::Result<()> {
         // Before downloading anything, make sure we are using a supported target.
         anyhow::ensure!(
-            matches!(target.format, Format::Parquet | Format::OnDiskVortex),
+            matches!(
+                target.format,
+                Format::Parquet | Format::OnDiskVortex | Format::VortexCompact
+            ),
             "unsupported format for `fineweb` bench: {}",
             target.format
         );

--- a/bench-vortex/src/fineweb/mod.rs
+++ b/bench-vortex/src/fineweb/mod.rs
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use datafusion::datasource::file_format::parquet::ParquetFormat;
+use datafusion::datasource::listing::{
+    ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
+};
+use datafusion::prelude::SessionContext;
+use futures::StreamExt;
+use log::info;
+use parquet::arrow::async_writer::AsyncFileWriter;
+use url::Url;
+use vortex::compressor::CompactCompressor;
+use vortex::file::{VortexWriteOptions, WriteStrategyBuilder};
+use vortex_datafusion::VortexFormat;
+
+use crate::benchmark_trait::Benchmark;
+use crate::conversions::parquet_to_vortex;
+use crate::engines::EngineCtx;
+use crate::{BenchmarkDataset, Format, Target, idempotent_async};
+
+/// URL to the sample file
+const SAMPLE_URL: &str = "https://huggingface.co/datasets/HuggingFaceFW/fineweb/resolve/v1.4.0/sample/10BT/001_00000.parquet";
+
+/// Some basic string-focused queries.
+const QUERIES: &[&str] = &[
+    // simple summary
+    "select count(distinct dump) from fineweb",
+    // selective string equality filter
+    "select * from fineweb where dump = 'CC-MAIN-2016-30'",
+    // LIKE with prefix filter
+    "select * from fineweb where date like '2020-10-%'",
+    // LIKE with simple containment filter
+    "select * from fineweb where url like '%google%' and text like '%Google%'",
+    // LIKE with larger containment filter
+    "select * from fineweb where url like '%.google.%' or text like '% Google %'",
+    "select * from fineweb where text like '% vortex %'",
+    // More LIKE filters
+    "select * from fineweb where url like '%espn%' and language = 'en' and language_score > 0.92",
+    "select * from fineweb where url like '%espn%' or url like '%www.espn.go.com%' or url like '%espn.go.com%'",
+    // no results, stats cannot prune but tokenized bloom filters could
+    "select * from fineweb where file_path like '%/CC-MAIN-2014-%'",
+];
+
+/// A benchmark using the HuggingFace FineWeb dataset.
+///
+/// This is a very string-heavy dataset, and exercises dictionary and FSST encoding heavily.
+///
+/// The queries for this benchmark are hand-crafted to showcase just how many of these we have here.
+pub struct Fineweb {
+    data_url: Url,
+}
+
+impl Fineweb {
+    pub fn new(data_url: Url) -> Self {
+        Self { data_url }
+    }
+}
+
+impl Fineweb {
+    fn parquet_path(&self) -> anyhow::Result<PathBuf> {
+        self.data_url
+            .join("parquet/")?
+            .join("sample.parquet")?
+            .to_file_path()
+            .map_err(|_| anyhow::anyhow!("Failed to convert data URL to filesystem path - ensure data_url uses 'file://' scheme"))
+    }
+
+    fn vortex_path(&self) -> anyhow::Result<PathBuf> {
+        self.data_url
+            .join("vortex-file-compressed/")?
+            .join("sample.vortex")?
+            .to_file_path()
+            .map_err(|_| anyhow::anyhow!("Failed to convert data URL to filesystem path - ensure data_url uses 'file://' scheme"))
+    }
+
+    fn vortex_compact_path(&self) -> anyhow::Result<PathBuf> {
+        self.data_url
+            .join("vortex-compact/")?
+            .join("sample.vortex")?
+            .to_file_path()
+            .map_err(|_| anyhow::anyhow!("Failed to convert data URL to filesystem path - ensure data_url uses 'file://' scheme"))
+    }
+}
+
+impl Benchmark for Fineweb {
+    fn queries(&self) -> anyhow::Result<Vec<(usize, String)>> {
+        Ok(QUERIES.iter().map(|s| s.to_string()).enumerate().collect())
+    }
+
+    fn generate_data(&self, target: &Target) -> anyhow::Result<()> {
+        // Before downloading anything, make sure we are using a supported target.
+        anyhow::ensure!(
+            matches!(target.format, Format::Parquet | Format::OnDiskVortex),
+            "unsupported format for `fineweb` bench: {}",
+            target.format
+        );
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()?;
+
+        // Write the parquet data to disk.
+        let parquet = rt.block_on(idempotent_async(
+            &self.parquet_path()?,
+            |parquet_path| async move {
+                info!("Downloading FineWeb Parquet source from HuggingFace");
+                // Download the file from HuggingFace snapshot
+                let client = reqwest::Client::new();
+                let response = client
+                    .get(SAMPLE_URL)
+                    .send()
+                    .await?
+                    .error_for_status()
+                    .map_err(|err| {
+                        anyhow::anyhow!("error fetching fineweb sample from HuggingFace: {err}")
+                    })?;
+
+                // On success, stream the response body to file.
+                let mut bytes = response.bytes_stream();
+                let mut w = tokio::fs::File::create(parquet_path).await?;
+
+                while let Some(next) = bytes.next().await {
+                    let chunk = next?;
+                    w.write(chunk).await?;
+                }
+
+                Ok(())
+            },
+        ))?;
+
+        let target_dir = match target.format {
+            Format::Parquet => {
+                // Nothing to do here
+                parquet
+            }
+            Format::OnDiskVortex => rt.block_on(idempotent_async(
+                &self.vortex_path()?,
+                |vortex_path| async move {
+                    info!("Converting FineWeb to Vortex with default compressor");
+                    let array_stream = parquet_to_vortex(parquet)?;
+                    let w = tokio::fs::File::create(vortex_path).await?;
+                    VortexWriteOptions::default()
+                        .write(w, array_stream)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("Failed to write to VortexWriter: {e}"))
+                },
+            ))?,
+            Format::VortexCompact => rt.block_on(idempotent_async(
+                &self.vortex_compact_path()?,
+                |vortex_path| async move {
+                    info!("Converting FineWeb to Vortex with Compact compressor");
+                    let array_stream = parquet_to_vortex(parquet)?;
+                    let w = tokio::fs::File::create(vortex_path).await?;
+                    VortexWriteOptions::default()
+                        .with_strategy(
+                            WriteStrategyBuilder::new()
+                                .with_compressor(CompactCompressor::default())
+                                .build(),
+                        )
+                        .write(w, array_stream)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("Failed to write to VortexWriter: {e}"))
+                },
+            ))?,
+            _ => {
+                anyhow::bail!("unsupported format for `fineweb` bench: {}", target.format)
+            }
+        };
+
+        info!("fineweb data generated in {}", target_dir.display());
+
+        Ok(())
+    }
+
+    async fn register_tables(&self, engine_ctx: &EngineCtx, format: Format) -> anyhow::Result<()> {
+        let dataset = self.dataset();
+
+        match engine_ctx {
+            EngineCtx::DataFusion(ctx) => {
+                dataset
+                    .register_tables(&ctx.session, &self.data_url, format)
+                    .await
+            }
+            EngineCtx::DuckDB(ctx) => ctx.register_tables(&self.data_url, format, &dataset),
+        }
+    }
+
+    fn dataset(&self) -> BenchmarkDataset {
+        BenchmarkDataset::Fineweb
+    }
+
+    fn dataset_name(&self) -> &str {
+        "fineweb"
+    }
+
+    fn dataset_display(&self) -> String {
+        "fineweb".to_owned()
+    }
+
+    fn data_url(&self) -> &Url {
+        &self.data_url
+    }
+}
+
+pub async fn register_table(
+    session: &SessionContext,
+    base_url: &Url,
+    format: Format,
+) -> anyhow::Result<()> {
+    let table_path = base_url.join(&format!("{}/", format))?;
+    info!("registering table for FINEWEB: {table_path}");
+    let table_url = ListingTableUrl::try_new(table_path, None)?;
+    let config = ListingTableConfig::new(table_url)
+        .with_listing_options(
+            ListingOptions::new(match format {
+                Format::Parquet => Arc::from(ParquetFormat::new()),
+                Format::OnDiskVortex | Format::VortexCompact => Arc::from(VortexFormat::default()),
+                _ => anyhow::bail!("unsupported format for `fineweb` bench: {}", format),
+            })
+            .with_session_config_options(session.state().config()),
+        )
+        .infer_schema(&session.state())
+        .await?;
+    let listing_table = Arc::new(ListingTable::try_new(config)?);
+    session.register_table("fineweb", listing_table)?;
+    Ok(())
+}

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -27,6 +27,7 @@ pub mod datasets;
 pub mod display;
 pub mod downloadable_dataset;
 pub mod engines;
+pub mod fineweb;
 pub mod measurements;
 pub mod memory;
 pub mod metrics;

--- a/bench-vortex/src/tpch/tpch_benchmark.rs
+++ b/bench-vortex/src/tpch/tpch_benchmark.rs
@@ -86,9 +86,10 @@ impl Benchmark for TpcHBenchmark {
                 };
 
                 // Skip CSV generation as it's not supported by tpchgen
-                if format == Format::Csv {
-                    anyhow::bail!("CSV format is not supported by tpchgen");
-                }
+                anyhow::ensure!(
+                    format != Format::Csv,
+                    "CSV format is not supported by tpchgen"
+                );
 
                 let base_data_dir = self
                     .data_url


### PR DESCRIPTION
[FineWeb](https://huggingface.co/datasets/HuggingFaceFW/fineweb) is a string-focused ML training dataset provided by HuggingFace.

This PR adds some data from the fineweb sample as a new benchmark. I hand-crafted some queries, also the benchmarks are quite fast, I'm only pulling a 2GB subset of the data so we might want to pull the full ~25GB sample.

FineWeb contains data extracts from CommonCrawl, and has a number of string fields. We don't really have many string-filtering-heavy benchmarks and I think this can be a useful one to evaluate things like #4548 or #4132 