### PR TITLE
Feature: `ListView` rebuilding strategies

### DIFF
--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -4,15 +4,13 @@
 use std::sync::Arc;
 
 use num_traits::AsPrimitive;
-use vortex_dtype::{DType, IntegerPType, Nullability, match_each_integer_ptype};
-use vortex_error::{VortexExpect, VortexResult, vortex_ensure, vortex_err};
+use vortex_dtype::{DType, IntegerPType, match_each_integer_ptype};
+use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_ensure, vortex_err};
 
-use crate::arrays::{ListArray, PrimitiveVTable};
-use crate::builders::PrimitiveBuilder;
+use crate::arrays::{ListViewShape, PrimitiveArray, PrimitiveVTable};
 use crate::stats::ArrayStats;
 use crate::validity::Validity;
-use crate::vtable::ValidityHelper;
-use crate::{Array, ArrayRef, Canonical, IntoArray, ToCanonical};
+use crate::{Array, ArrayRef, ToCanonical};
 
 /// The canonical encoding for variable-length list arrays.
 ///
@@ -39,23 +37,27 @@ use crate::{Array, ArrayRef, Canonical, IntoArray, ToCanonical};
 /// # Examples
 ///
 /// ```
-/// use vortex_array::arrays::{ListViewArray, PrimitiveArray};
-/// use vortex_array::validity::Validity;
-/// use vortex_array::IntoArray;
-/// use vortex_buffer::buffer;
-/// use std::sync::Arc;
+/// # use vortex_array::arrays::{ListViewArray, ListViewShape, PrimitiveArray};
+/// # use vortex_array::validity::Validity;
+/// # use vortex_array::IntoArray;
+/// # use vortex_buffer::buffer;
+/// # use std::sync::Arc;
+/// #
+/// // Create a list view array representing [[3, 4], [1], [2, 3]].
+/// // Note: Unlike `ListArray`, offsets don't need to be monotonic.
 ///
-/// // Create a list view array representing [[3, 4], [1], [2, 5]]
-/// // Note: Unlike ListArray, offsets don't need to be monotonic
 /// let elements = buffer![1i32, 2, 3, 4, 5].into_array();
 /// let offsets = buffer![2u32, 0, 1].into_array();  // Out-of-order offsets
-/// let sizes = buffer![2u32, 1, 2].into_array();  // Corresponding sizes
+/// let sizes = buffer![2u32, 1, 2].into_array();  // The sizes cause overlaps
 ///
 /// let list_view = ListViewArray::try_new(
 ///     elements.into_array(),
 ///     offsets.into_array(),
 ///     sizes.into_array(),
 ///     Validity::NonNullable,
+///     ListViewShape::as_zero_copy_to_list()
+///         .with_sorted_offsets(false)
+///         .with_no_overlaps(false),
 /// ).unwrap();
 ///
 /// assert_eq!(list_view.len(), 3);
@@ -95,6 +97,13 @@ pub struct ListViewArray {
     /// we want to access.
     sizes: ArrayRef,
 
+    /// The "shape" of the `ListViewArray` data.
+    ///
+    /// We use this information to help us more efficiently rebuild / compact our data.
+    ///
+    /// See the documentation for [`ListViewShape`] for more information.
+    shape: ListViewShape,
+
     /// The validity / null map of the array.
     ///
     /// Note that this null map refers to which list scalars are null, **not** which sub-elements of
@@ -112,8 +121,14 @@ impl ListViewArray {
     ///
     /// Panics if the provided components do not satisfy the invariants documented
     /// in [`ListViewArray::new_unchecked`].
-    pub fn new(elements: ArrayRef, offsets: ArrayRef, sizes: ArrayRef, validity: Validity) -> Self {
-        Self::try_new(elements, offsets, sizes, validity)
+    pub fn new(
+        elements: ArrayRef,
+        offsets: ArrayRef,
+        sizes: ArrayRef,
+        validity: Validity,
+        shape: ListViewShape,
+    ) -> Self {
+        Self::try_new(elements, offsets, sizes, validity, shape)
             .vortex_expect("ListViewArray construction failed")
     }
 
@@ -127,11 +142,12 @@ impl ListViewArray {
         offsets: ArrayRef,
         sizes: ArrayRef,
         validity: Validity,
+        shape: ListViewShape,
     ) -> VortexResult<Self> {
-        Self::validate(&elements, &offsets, &sizes, &validity)?;
+        Self::validate(&elements, &offsets, &sizes, &validity, shape)?;
 
         // SAFETY: validate ensures all invariants are met.
-        Ok(unsafe { Self::new_unchecked(elements, offsets, sizes, validity) })
+        Ok(unsafe { Self::new_unchecked(elements, offsets, sizes, validity, shape) })
     }
 
     /// Creates a new [`ListViewArray`] without validation.
@@ -143,16 +159,19 @@ impl ListViewArray {
     /// - `offsets` and `sizes` must be non-nullable integer arrays.
     /// - `offsets` and `sizes` must have the same length.
     /// - Size integer width must be smaller than or equal to offset type (to prevent overflow).
-    /// - For each `i`, `offsets[i] + sizes[i]` must not overflow and must be `<= elements.len()`.
+    /// - For each `i`, `offsets[i] + sizes[i]` must not overflow and must be `<= elements.len()`
+    ///   (even if the corresponding view is defined as null by the validity array).
     /// - If validity is an array, its length must equal `offsets.len()`.
+    /// - The `shape` that is passed in correctly describes the shape of the `ListViewArray` data.
     pub unsafe fn new_unchecked(
         elements: ArrayRef,
         offsets: ArrayRef,
         sizes: ArrayRef,
         validity: Validity,
+        shape: ListViewShape,
     ) -> Self {
         #[cfg(debug_assertions)]
-        Self::validate(&elements, &offsets, &sizes, &validity)
+        Self::validate(&elements, &offsets, &sizes, &validity, shape)
             .vortex_expect("[Debug Assertion]: Invalid `ListViewArray` parameters");
 
         Self {
@@ -161,6 +180,7 @@ impl ListViewArray {
             offsets,
             sizes,
             validity,
+            shape,
             stats_set: Default::default(),
         }
     }
@@ -171,6 +191,7 @@ impl ListViewArray {
         offsets: &dyn Array,
         sizes: &dyn Array,
         validity: &Validity,
+        shape: ListViewShape,
     ) -> VortexResult<()> {
         // Check that offsets and sizes are integer arrays and non-nullable.
         vortex_ensure!(
@@ -207,6 +228,15 @@ impl ListViewArray {
             offset_max
         );
 
+        // If a validity array is present, it must be the same length as the `ListViewArray`.
+        if let Some(validity_len) = validity.maybe_len() {
+            vortex_ensure!(
+                validity_len == offsets.len(),
+                "validity with size {validity_len} does not match array size {}",
+                offsets.len()
+            );
+        }
+
         let offsets_primitive = offsets.to_primitive();
         let sizes_primitive = sizes.to_primitive();
 
@@ -224,19 +254,17 @@ impl ListViewArray {
             })
         });
 
-        // If a validity array is present, it must be the same length as the ListView.
-        if let Some(validity_len) = validity.maybe_len() {
-            vortex_ensure!(
-                validity_len == offsets.len(),
-                "validity with size {validity_len} does not match array size {}",
-                offsets.len()
-            );
-        }
+        // Validate the `ListViewShape`.
+        validate_shape(shape, elements, offsets_primitive, sizes_primitive)?;
 
         Ok(())
     }
 
     /// Returns the offset at the given index.
+    ///
+    /// Note that it is possible the corresponding list view is null (which is only defined by the
+    /// validity map). Regardless, we are still guaranteed that this offset is valid by the
+    /// invariants of [`ListViewArray`].
     pub fn offset_at(&self, index: usize) -> usize {
         assert!(
             index < self.len(),
@@ -259,6 +287,10 @@ impl ListViewArray {
     }
 
     /// Returns the size at the given index.
+    ///
+    /// Note that it is possible the corresponding list view is null (which is only defined by the
+    /// validity map). Regardless, we are still guaranteed that this size is valid by the invariants
+    /// of [`ListViewArray`].
     pub fn size_at(&self, index: usize) -> usize {
         assert!(
             index < self.len(),
@@ -301,6 +333,13 @@ impl ListViewArray {
     /// Returns the elements array.
     pub fn elements(&self) -> &ArrayRef {
         &self.elements
+    }
+
+    /// Returns the shape of the `ListViewArray`.
+    ///
+    /// See the documentation of [`ListViewShape`] for more information.
+    pub fn shape(&self) -> ListViewShape {
+        self.shape
     }
 }
 
@@ -346,73 +385,76 @@ where
     Ok(())
 }
 
-/// Create a [`ListViewArray`] from a [`ListArray`](crate::arrays::ListArray) by computing `sizes`
-/// from `offsets`.
-pub fn list_view_from_list(list: ListArray) -> ListViewArray {
-    // TODO(connor)[ListView]: Create a version of `Canonical::empty` for `ListView`. It might
-    // also be worth specializing that for all canonical encodings.
-    // If the list is empty, create an empty `ListView` with the same offset dtype as the input.
-    if list.is_empty() {
-        let empty_offsets = Canonical::empty(list.offsets().dtype()).into_array();
-        let empty_sizes = Canonical::empty(list.offsets().dtype()).into_array();
-        let empty_validity = list.validity().clone();
-
-        // SAFETY: Everything is empty so all the variants are satisfied.
-        return unsafe {
-            ListViewArray::new_unchecked(
-                list.elements().clone(),
-                empty_offsets,
-                empty_sizes,
-                empty_validity,
-            )
-        };
+/// Helper function to validate if the [`ListViewShape`] correctly describes the data.
+fn validate_shape(
+    shape: ListViewShape,
+    elements: &dyn Array,
+    offsets_primitive: PrimitiveArray,
+    sizes_primitive: PrimitiveArray,
+) -> VortexResult<()> {
+    if shape.has_sorted_offsets() {
+        // Offsets must be sorted (but not strictly sorted, zero-length lists are allowed), even
+        // if there are null views.
+        if let Some(is_sorted) = offsets_primitive.statistics().compute_is_sorted() {
+            vortex_ensure!(is_sorted, "offsets must be sorted");
+        } else {
+            vortex_bail!("offsets must report is_sorted statistic");
+        }
     }
 
-    let len = list.len();
+    if !(shape.has_no_gaps() || shape.has_no_overlaps()) {
+        return Ok(());
+    }
 
-    // Get the `offsets` array directly from the `ListArray` (preserving its type).
-    let list_offsets = list.offsets().clone();
+    let mut element_references = vec![0u8; elements.len()];
 
-    // We need to slice the `offsets` to remove the last element (`ListArray` has n+1 offsets).
-    let adjusted_offsets = list_offsets.slice(0..len);
+    fn count_references<O: IntegerPType, S: IntegerPType>(
+        element_references: &mut [u8],
+        offsets_primitive: PrimitiveArray,
+        sizes_primitive: PrimitiveArray,
+    ) {
+        let offsets_slice = offsets_primitive.as_slice::<O>();
+        let sizes_slice = sizes_primitive.as_slice::<S>();
 
-    // Create sizes array by computing differences between consecutive offsets.
-    // Use the same dtype as the offsets array to ensure compatibility.
-    let sizes = match_each_integer_ptype!(list_offsets.dtype().as_ptype(), |P| {
-        let mut sizes_builder = PrimitiveBuilder::<P>::with_capacity(Nullability::NonNullable, len);
-
-        // Create uninit range for direct memory access.
-        let mut sizes_range = sizes_builder.uninit_range(len);
-
-        // Compute sizes as the difference between consecutive offsets.
-        for i in 0..len {
-            let start = list.offset_at(i);
-            let end = list.offset_at(i + 1);
-            let size = end - start;
-
-            // Set size value directly without creating scalar.
-            sizes_range.set_value(
-                i,
-                P::try_from(size).vortex_expect("size must fit in offset type"),
-            );
+        // Note that we ignore nulls here, as the "null" view metadata must still maintain the same
+        // invariants as non-null views, even for a `ListViewShape` information.
+        for i in 0..offsets_slice.len() {
+            let offset: usize = offsets_slice[i].as_();
+            let size: usize = sizes_slice[i].as_();
+            for j in offset..offset + size {
+                element_references[j] = element_references[j].saturating_add(1);
+            }
         }
+    }
 
-        // SAFETY: We have initialized all values in the range.
-        unsafe {
-            sizes_range.finish();
-        }
-
-        sizes_builder.finish_into_primitive().into_array()
+    match_each_integer_ptype!(offsets_primitive.ptype(), |O| {
+        match_each_integer_ptype!(sizes_primitive.ptype(), |S| {
+            count_references::<O, S>(&mut element_references, offsets_primitive, sizes_primitive);
+        })
     });
 
-    // SAFETY: Since everything came from an existing valid `ListArray`, and the `sizes` were
-    // derived from valid and in-order `offsets`, we know these fields are valid.
-    unsafe {
-        ListViewArray::new_unchecked(
-            list.elements().clone(),
-            adjusted_offsets,
-            sizes,
-            list.validity().clone(),
-        )
+    if shape.has_no_gaps() {
+        // Allow leading and trailing unreferenced elements, but not gaps in the middle.
+        let leftmost_used = element_references
+            .iter()
+            .position(|&references| references != 0);
+        let rightmost_used = element_references
+            .iter()
+            .rposition(|&references| references != 0);
+
+        if let (Some(first_ref), Some(last_ref)) = (leftmost_used, rightmost_used) {
+            vortex_ensure!(
+                element_references[first_ref..=last_ref]
+                    .iter()
+                    .all(|&references| references != 0),
+                "found gap in elements array between first and last referenced elements"
+            );
+        }
     }
+
+    if shape.has_no_overlaps() {
+        vortex_ensure!(element_references.iter().all(|&references| references <= 1))
+    }
+
+    Ok(())
 }

--- a/vortex-array/src/arrays/listview/compute/cast.rs
+++ b/vortex-array/src/arrays/listview/compute/cast.rs
@@ -31,6 +31,7 @@ impl CastKernel for ListViewVTable {
                     array.offsets().clone(),
                     array.sizes().clone(),
                     validity,
+                    array.shape(),
                 )
             }
             .to_array(),

--- a/vortex-array/src/arrays/listview/compute/filter.rs
+++ b/vortex-array/src/arrays/listview/compute/filter.rs
@@ -45,16 +45,26 @@ impl FilterKernel for ListViewVTable {
                 .is_none_or(|len| len == selection_mask.true_count())
         );
 
-        // Filter the offsets and sizes arrays.
+        // Simply filter the offsets and sizes arrays.
         let new_offsets = compute::filter(offsets.as_ref(), selection_mask)?;
         let new_sizes = compute::filter(sizes.as_ref(), selection_mask)?;
+
+        // Filters keep scalars in order, and it cannot cause overlaps to form. However, filters
+        // **will** create gaps of unused elements.
+        let new_shape = array.shape().with_no_gaps(false);
 
         // SAFETY: Filter operation maintains all `ListViewArray` invariants:
         // - Offsets and sizes are derived from existing valid child arrays.
         // - Offsets and sizes have the same length (both filtered by `selection_mask`).
         // - Validity matches the filtered array's nullability.
         let new_array = unsafe {
-            ListViewArray::new_unchecked(elements.clone(), new_offsets, new_sizes, new_validity)
+            ListViewArray::new_unchecked(
+                elements.clone(),
+                new_offsets,
+                new_sizes,
+                new_validity,
+                new_shape,
+            )
         };
 
         // TODO(connor)[ListView]: IsZeroCopyToList optimization.

--- a/vortex-array/src/arrays/listview/compute/mask.rs
+++ b/vortex-array/src/arrays/listview/compute/mask.rs
@@ -16,6 +16,7 @@ impl MaskKernel for ListViewVTable {
             array.offsets().clone(),
             array.sizes().clone(),
             array.validity().mask(mask),
+            array.shape(),
         )
         .map(|a| a.into_array())
     }

--- a/vortex-array/src/arrays/listview/compute/take.rs
+++ b/vortex-array/src/arrays/listview/compute/take.rs
@@ -6,7 +6,7 @@ use vortex_dtype::{Nullability, match_each_integer_ptype};
 use vortex_error::VortexResult;
 use vortex_scalar::Scalar;
 
-use crate::arrays::{ListViewArray, ListViewVTable};
+use crate::arrays::{ListViewArray, ListViewShape, ListViewVTable};
 use crate::compute::{self, TakeKernel, TakeKernelAdapter};
 use crate::vtable::ValidityHelper;
 use crate::{Array, ArrayRef, IntoArray, register_kernel};
@@ -62,6 +62,10 @@ impl TakeKernel for ListViewVTable {
             )?
         });
 
+        // Take can reorder offsets, create gaps, and may introduce overlaps if the `indices`
+        // contain duplicates.
+        let new_shape = ListViewShape::default();
+
         // SAFETY: Take operation maintains all `ListViewArray` invariants:
         // - `new_offsets` and `new_sizes` are derived from existing valid child arrays.
         // - `new_offsets` and `new_sizes` are non-nullable.
@@ -69,11 +73,14 @@ impl TakeKernel for ListViewVTable {
         //   `indices`).
         // - Validity correctly reflects the combination of array and indices validity.
         let new_array = unsafe {
-            ListViewArray::new_unchecked(elements.clone(), new_offsets, new_sizes, new_validity)
+            ListViewArray::new_unchecked(
+                elements.clone(),
+                new_offsets,
+                new_sizes,
+                new_validity,
+                new_shape,
+            )
         };
-
-        // TODO(connor)[ListView]: IsZeroCopyToList optimization.
-        // TODO(connor)[ListView]: Rebuild if the threshold is too low.
 
         Ok(new_array.into_array())
     }

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::{IntegerPType, Nullability, match_each_integer_ptype};
+use vortex_error::VortexExpect;
+
+use crate::arrays::{ListArray, ListViewArray, ListViewShape};
+use crate::builders::{ArrayBuilder, ListBuilder, PrimitiveBuilder};
+use crate::vtable::ValidityHelper;
+use crate::{ArrayRef, Canonical, IntoArray, ToCanonical};
+
+/// Creates a [`ListViewArray`] from a [`ListArray`] by computing `sizes` from `offsets`.
+pub fn list_view_from_list(list: ListArray) -> ListViewArray {
+    // TODO(connor)[ListView]: Create a version of `Canonical::empty` for `ListView` once `ListView`
+    // is canonicalized. It might also be worth specializing that for all canonical encodings.
+
+    // If the list is empty, create an empty `ListViewArray` with the same offset `DType` as the
+    // input.
+    if list.is_empty() {
+        let empty_offsets = Canonical::empty(list.offsets().dtype()).into_array();
+        let empty_sizes = Canonical::empty(list.offsets().dtype()).into_array();
+        let empty_validity = list.validity().clone();
+        let shape = ListViewShape::as_zero_copy_to_list();
+
+        // SAFETY: Everything is empty so all the variants are satisfied.
+        return unsafe {
+            ListViewArray::new_unchecked(
+                list.elements().clone(),
+                empty_offsets,
+                empty_sizes,
+                empty_validity,
+                shape,
+            )
+        };
+    }
+
+    let len = list.len();
+
+    // Get the `offsets` array directly from the `ListArray` (preserving its type).
+    let list_offsets = list.offsets().clone();
+
+    // We need to slice the `offsets` to remove the last element (`ListArray` has n+1 offsets).
+    let adjusted_offsets = list_offsets.slice(0..len);
+
+    // Create sizes array by computing differences between consecutive offsets.
+    // Use the same dtype as the offsets array to ensure compatibility.
+    let sizes = match_each_integer_ptype!(list_offsets.dtype().as_ptype(), |O| {
+        build_sizes_from_offsets::<O>(&list)
+    });
+
+    // Since the data came from a valid `ListArray`, we know it is zero-copyable to a `ListArray`.
+    let shape = ListViewShape::as_zero_copy_to_list();
+
+    // SAFETY: Since everything came from an existing valid `ListArray`, and the `sizes` were
+    // derived from valid and in-order `offsets`, we know these fields are valid.
+    unsafe {
+        ListViewArray::new_unchecked(
+            list.elements().clone(),
+            adjusted_offsets,
+            sizes,
+            list.validity().clone(),
+            shape,
+        )
+    }
+}
+
+/// Builds a sizes array from a [`ListArray`] by computing differences between consecutive offsets.
+fn build_sizes_from_offsets<O: IntegerPType>(list: &ListArray) -> ArrayRef {
+    let len = list.len();
+    let mut sizes_builder = PrimitiveBuilder::<O>::with_capacity(Nullability::NonNullable, len);
+
+    // Create `UninitRange` for direct memory access.
+    let mut sizes_range = sizes_builder.uninit_range(len);
+    let offsets = list.offsets().to_primitive();
+    let offsets_slice = offsets.as_slice::<O>();
+
+    // Compute sizes as the difference between consecutive offsets.
+    for i in 0..len {
+        let size = offsets_slice[i + 1] - offsets_slice[i];
+        sizes_range.set_value(i, size);
+    }
+
+    // SAFETY: We have initialized all values in the range.
+    unsafe {
+        sizes_range.finish();
+    }
+
+    sizes_builder.finish_into_primitive().into_array()
+}
+
+/// Creates a [`ListArray`] from a [`ListViewArray`].
+///
+/// If the [`ListViewShape::is_zero_copy_to_list`] is `true`, then this operation is fast (note that
+/// it is not exactly zero-copy because we have to add a single offset at the end, but it is fast
+/// enough).
+///
+/// Otherwise, this function fall back to the expensive path and will rebuild the `ListArray` from
+/// scratch.
+///
+/// [`as_zero_copy_to_list()`]: ListViewShape::as_zero_copy_to_list
+pub fn list_from_list_view(list_view: ListViewArray) -> ListArray {
+    if list_view.shape().is_zero_copy_to_list() {
+        let list_offsets = match_each_integer_ptype!(list_view.offsets().dtype().as_ptype(), |O| {
+            // SAFETY: We checked that the shape of the array is correct.
+            unsafe { build_list_offsets_from_list_view::<O>(&list_view) }
+        });
+
+        // SAFETY: Because the shape of the `ListViewArray` is zero-copyable to a `ListArray`, we
+        // can simply reuse all of the data (besides the offsets).
+        // See the documentation of `ListViewShape` for more information.
+        return unsafe {
+            ListArray::new_unchecked(
+                list_view.elements().clone(),
+                list_offsets,
+                list_view.validity().clone(),
+            )
+        };
+    }
+
+    let elements_dtype = list_view
+        .dtype()
+        .as_list_element_opt()
+        .vortex_expect("`DType` of `ListView` was somehow not a `List`");
+    let nullability = list_view.dtype().nullability();
+    let len = list_view.len();
+
+    match_each_integer_ptype!(list_view.offsets().dtype().as_ptype(), |O| {
+        let mut builder = ListBuilder::<O>::with_capacity(
+            elements_dtype.clone(),
+            nullability,
+            list_view.elements().len(),
+            len,
+        );
+
+        for i in 0..len {
+            builder
+                .append_scalar(&list_view.scalar_at(i))
+                .vortex_expect(
+                    "The `ListView` scalars are `ListScalar`, which the `ListBuilder` must accept",
+                )
+        }
+
+        builder.finish_into_list()
+    })
+}
+
+/// Builds a [`ListArray`] offsets array from a [`ListViewArray`] by constructing n+1 offsets.
+/// The last offset is computed as last_offset + last_size.
+///
+/// # Safety
+///
+/// The [`ListViewArray`] must have a shape that allows (near) zero-copying to [`ListArray`].
+unsafe fn build_list_offsets_from_list_view<O: IntegerPType>(
+    list_view: &ListViewArray,
+) -> ArrayRef {
+    let len = list_view.len();
+    let mut offsets_builder =
+        PrimitiveBuilder::<O>::with_capacity(Nullability::NonNullable, len + 1);
+
+    // Create uninit range for direct memory access.
+    let mut offsets_range = offsets_builder.uninit_range(len + 1);
+
+    let offsets = list_view.offsets().to_primitive();
+    let offsets_slice = offsets.as_slice::<O>();
+
+    // Copy the existing n offsets.
+    offsets_range.copy_from_slice(0, offsets_slice);
+
+    // Append the final offset (last offset + last size).
+    let final_offset = if len != 0 {
+        let last_offset = offsets_slice[len - 1];
+
+        let last_size = list_view.size_at(len - 1);
+        let last_size =
+            O::from_usize(last_size).vortex_expect("size somehow did not fit into offsets");
+
+        last_offset + last_size
+    } else {
+        O::zero()
+    };
+
+    offsets_range.set_value(len, final_offset);
+
+    // SAFETY: We have initialized all values in the range.
+    unsafe {
+        offsets_range.finish();
+    }
+
+    offsets_builder.finish_into_primitive().into_array()
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_buffer::buffer;
+
+    use super::super::tests::common::{
+        create_basic_listview, create_empty_lists_listview, create_nullable_listview,
+        create_overlapping_listview,
+    };
+    use crate::arrays::{
+        BoolArray, ListArray, PrimitiveArray, list_from_list_view, list_view_from_list,
+    };
+    use crate::validity::Validity;
+    use crate::vtable::ValidityHelper;
+    use crate::{IntoArray, assert_arrays_eq};
+
+    #[test]
+    fn test_list_to_listview_basic() {
+        // Create a basic ListArray: [[0,1,2], [3,4], [5,6], [7,8,9]].
+        let elements = buffer![0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
+        let offsets = buffer![0u32, 3, 5, 7, 10].into_array();
+        let list_array =
+            ListArray::try_new(elements.clone(), offsets.clone(), Validity::NonNullable).unwrap();
+
+        let list_view = list_view_from_list(list_array.clone());
+
+        // Verify structure.
+        assert_eq!(list_view.len(), 4);
+        assert_arrays_eq!(elements, list_view.elements().clone());
+
+        // Verify offsets (should be same but without last element).
+        let expected_offsets = buffer![0u32, 3, 5, 7].into_array();
+        assert_arrays_eq!(expected_offsets, list_view.offsets().clone());
+
+        // Verify sizes.
+        let expected_sizes = buffer![3u32, 2, 2, 3].into_array();
+        assert_arrays_eq!(expected_sizes, list_view.sizes().clone());
+
+        // Verify shape is zero-copyable.
+        assert!(list_view.shape().is_zero_copy_to_list());
+
+        // Verify data integrity.
+        assert_arrays_eq!(list_array, list_view);
+    }
+
+    #[test]
+    fn test_listview_to_list_zero_copy() {
+        let list_view = create_basic_listview();
+        assert!(list_view.shape().is_zero_copy_to_list());
+
+        let list_array = list_from_list_view(list_view.clone());
+
+        // Should have same elements.
+        assert_arrays_eq!(list_view.elements().clone(), list_array.elements().clone());
+
+        // ListArray offsets should have n+1 elements for n lists (add the final offset).
+        // Check that the first n offsets match.
+        let list_array_offsets_without_last = list_array.offsets().slice(0..list_view.len());
+        assert_arrays_eq!(list_view.offsets().clone(), list_array_offsets_without_last);
+
+        // Verify data integrity.
+        assert_arrays_eq!(list_view, list_array);
+    }
+
+    #[test]
+    fn test_empty_array_conversions() {
+        // Empty ListArray to ListViewArray.
+        let empty_elements = PrimitiveArray::from_iter::<[i32; 0]>([]).into_array();
+        let empty_offsets = buffer![0u32].into_array();
+        let empty_list =
+            ListArray::try_new(empty_elements.clone(), empty_offsets, Validity::NonNullable)
+                .unwrap();
+
+        // This conversion will create an empty ListViewArray.
+        // Note: list_view_from_list handles the empty case specially.
+        let empty_list_view = list_view_from_list(empty_list.clone());
+        assert_eq!(empty_list_view.len(), 0);
+        assert!(empty_list_view.shape().is_zero_copy_to_list());
+
+        // Convert back.
+        let converted_back = list_from_list_view(empty_list_view);
+        assert_eq!(converted_back.len(), 0);
+        // For empty arrays, we can't use assert_arrays_eq directly since the offsets might differ.
+        // Just check that it's empty.
+        assert_eq!(empty_list.len(), converted_back.len());
+    }
+
+    #[test]
+    fn test_nullable_conversions() {
+        // Create nullable ListArray: [[10,20], null, [50]].
+        let elements = buffer![10i32, 20, 30, 40, 50].into_array();
+        let offsets = buffer![0u32, 2, 4, 5].into_array();
+        let validity = Validity::Array(BoolArray::from_iter(vec![true, false, true]).into_array());
+        let nullable_list =
+            ListArray::try_new(elements.clone(), offsets.clone(), validity.clone()).unwrap();
+
+        let nullable_list_view = list_view_from_list(nullable_list.clone());
+
+        // Verify validity is preserved.
+        assert_eq!(nullable_list_view.validity(), &validity);
+        assert_eq!(nullable_list_view.len(), 3);
+
+        // Round-trip conversion.
+        let converted_back = list_from_list_view(nullable_list_view);
+        assert_arrays_eq!(nullable_list, converted_back);
+    }
+
+    #[test]
+    fn test_non_zero_copy_listview_to_list() {
+        // Create ListViewArray with overlapping lists (not zero-copyable).
+        let list_view = create_overlapping_listview();
+        assert!(!list_view.shape().is_zero_copy_to_list());
+
+        let list_array = list_from_list_view(list_view.clone());
+
+        // The data should still be correct even though it required a rebuild.
+        assert_arrays_eq!(list_view, list_array.clone());
+
+        // The resulting ListArray should have monotonic offsets.
+        for i in 0..list_array.len() {
+            let start = list_array.offset_at(i);
+            let end = list_array.offset_at(i + 1);
+            assert!(end >= start, "Offsets should be monotonic after conversion");
+        }
+    }
+
+    #[test]
+    fn test_empty_sublists() {
+        let empty_lists_view = create_empty_lists_listview();
+
+        // Convert to ListArray.
+        let list_array = list_from_list_view(empty_lists_view.clone());
+        assert_eq!(list_array.len(), 4);
+
+        // All sublists should be empty.
+        for i in 0..list_array.len() {
+            assert_eq!(list_array.list_elements_at(i).len(), 0);
+        }
+
+        // Round-trip.
+        let converted_back = list_view_from_list(list_array);
+        assert_arrays_eq!(empty_lists_view, converted_back);
+    }
+
+    #[test]
+    fn test_different_offset_types() {
+        // Test with i32 offsets.
+        let elements = buffer![1i32, 2, 3, 4, 5].into_array();
+        let i32_offsets = buffer![0i32, 2, 5].into_array();
+        let list_i32 =
+            ListArray::try_new(elements.clone(), i32_offsets.clone(), Validity::NonNullable)
+                .unwrap();
+
+        let list_view_i32 = list_view_from_list(list_i32.clone());
+        assert_eq!(list_view_i32.offsets().dtype(), i32_offsets.dtype());
+        assert_eq!(list_view_i32.sizes().dtype(), i32_offsets.dtype());
+
+        // Test with i64 offsets.
+        let i64_offsets = buffer![0i64, 2, 5].into_array();
+        let list_i64 =
+            ListArray::try_new(elements.clone(), i64_offsets.clone(), Validity::NonNullable)
+                .unwrap();
+
+        let list_view_i64 = list_view_from_list(list_i64.clone());
+        assert_eq!(list_view_i64.offsets().dtype(), i64_offsets.dtype());
+        assert_eq!(list_view_i64.sizes().dtype(), i64_offsets.dtype());
+
+        // Verify data integrity.
+        assert_arrays_eq!(list_i32, list_view_i32);
+        assert_arrays_eq!(list_i64, list_view_i64);
+    }
+
+    #[test]
+    fn test_round_trip_conversions() {
+        // Test 1: Basic round-trip.
+        let original = create_basic_listview();
+        let to_list = list_from_list_view(original.clone());
+        let back_to_view = list_view_from_list(to_list);
+        assert_arrays_eq!(original, back_to_view);
+
+        // Test 2: Nullable round-trip.
+        let nullable = create_nullable_listview();
+        let nullable_to_list = list_from_list_view(nullable.clone());
+        let nullable_back = list_view_from_list(nullable_to_list);
+        assert_arrays_eq!(nullable, nullable_back);
+
+        // Test 3: Non-zero-copyable round-trip.
+        // Note: After conversion to ListArray and back, the shape will be zero-copyable.
+        let overlapping = create_overlapping_listview();
+        assert!(!overlapping.shape().is_zero_copy_to_list());
+
+        let overlapping_to_list = list_from_list_view(overlapping.clone());
+        let overlapping_back = list_view_from_list(overlapping_to_list);
+        assert!(overlapping_back.shape().is_zero_copy_to_list()); // Now it's zero-copyable!
+        assert_arrays_eq!(overlapping, overlapping_back);
+    }
+
+    #[test]
+    fn test_single_element_lists() {
+        // Create lists with single elements: [[100], [200], [300]].
+        let elements = buffer![100i32, 200, 300].into_array();
+        let offsets = buffer![0u32, 1, 2, 3].into_array();
+        let single_elem_list =
+            ListArray::try_new(elements.clone(), offsets, Validity::NonNullable).unwrap();
+
+        let list_view = list_view_from_list(single_elem_list.clone());
+        assert_eq!(list_view.len(), 3);
+
+        // Verify sizes are all 1.
+        let expected_sizes = buffer![1u32, 1, 1].into_array();
+        assert_arrays_eq!(expected_sizes, list_view.sizes().clone());
+
+        // Round-trip.
+        let converted_back = list_from_list_view(list_view.clone());
+        assert_arrays_eq!(single_elem_list, converted_back);
+    }
+
+    #[test]
+    fn test_mixed_empty_and_non_empty_lists() {
+        // Create: [[1,2], [], [3], [], [4,5,6]].
+        let elements = buffer![1i32, 2, 3, 4, 5, 6].into_array();
+        let offsets = buffer![0u32, 2, 2, 3, 3, 6].into_array();
+        let mixed_list =
+            ListArray::try_new(elements.clone(), offsets.clone(), Validity::NonNullable).unwrap();
+
+        let list_view = list_view_from_list(mixed_list.clone());
+        assert_eq!(list_view.len(), 5);
+
+        // Verify sizes.
+        let expected_sizes = buffer![2u32, 0, 1, 0, 3].into_array();
+        assert_arrays_eq!(expected_sizes, list_view.sizes().clone());
+
+        // Round-trip.
+        let converted_back = list_from_list_view(list_view.clone());
+        assert_arrays_eq!(mixed_list, converted_back);
+    }
+}

--- a/vortex-array/src/arrays/listview/mod.rs
+++ b/vortex-array/src/arrays/listview/mod.rs
@@ -2,15 +2,21 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 mod array;
-pub use array::{ListViewArray, list_view_from_list};
+pub use array::ListViewArray;
+
+mod conversion;
+pub use conversion::{list_from_list_view, list_view_from_list};
+
+mod rebuild;
+pub use rebuild::ListViewRebuildMode;
+
+mod shape;
+pub use shape::ListViewShape;
 
 mod compute;
 
 mod vtable;
 pub use vtable::{ListViewEncoding, ListViewVTable};
-
-mod rebuild;
-pub use rebuild::ListViewRebuildMode;
 
 #[cfg(test)]
 mod tests;

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use num_traits::{FromPrimitive, Zero};
 use vortex_dtype::{IntegerPType, Nullability, match_each_integer_ptype};
 use vortex_error::VortexExpect;
+use vortex_scalar::Scalar;
 
-use crate::arrays::ListViewArray;
+use crate::arrays::{ListViewArray, PrimitiveArray};
 use crate::builders::{ArrayBuilder, ListViewBuilder, PrimitiveBuilder, builder_with_capacity};
 use crate::vtable::ValidityHelper;
-use crate::{Array, IntoArray, ToCanonical};
+use crate::{Array, IntoArray, ToCanonical, compute};
 
 /// Modes for rebuilding a [`ListViewArray`].
 pub enum ListViewRebuildMode {
@@ -20,11 +22,27 @@ pub enum ListViewRebuildMode {
     /// [`ListArray`]: crate::arrays::ListArray
     MakeZeroCopyToList,
 
+    /// Removes any leading or trailing elements that are unused / not referenced by any views in
+    /// the [`ListViewArray`].
+    TrimElements,
+
     /// Removes any unused data from the underlying `elements` array.
     ///
     /// This mode will rebuild the `elements` array in the process, but it will keep any overlapping
     /// lists if they exist.
+    ///
+    /// Note that this is a more heavyweight version of `TrimElements`, as it will trim any leading
+    /// or trailing elements as well as remove inner gaps.
+    ///
+    /// Also note that we do not remove gaps caused by null views. Use the `RemoveNulls` variant of
+    /// `ListViewRebuildMode` if you need that functionality.
     RemoveGaps,
+
+    /// Rebuilds in a similar manner to `RemoveGaps` but also removes any unused data caused by null
+    /// views.
+    ///
+    /// If the [`ListViewArray`] is non-nullable this has the same effect as `RemoveGaps`.
+    RemoveNulls,
 
     // TODO(connor)[ListView]: Implement some version of this.
     /// Finds the shortest packing / overlapping of list elements.
@@ -38,9 +56,15 @@ pub enum ListViewRebuildMode {
 impl ListViewArray {
     /// Rebuilds the [`ListViewArray`] according to the specified mode.
     pub fn rebuild(&self, mode: ListViewRebuildMode) -> ListViewArray {
+        if self.is_empty() {
+            return self.clone();
+        }
+
         match mode {
-            ListViewRebuildMode::RemoveGaps => self.rebuild_remove_gaps(),
             ListViewRebuildMode::MakeZeroCopyToList => self.rebuild_zero_copy_to_list(),
+            ListViewRebuildMode::TrimElements => self.rebuild_trim_elements(),
+            ListViewRebuildMode::RemoveGaps => self.rebuild_remove_gaps::<false>(),
+            ListViewRebuildMode::RemoveNulls => self.rebuild_remove_gaps::<true>(),
             ListViewRebuildMode::OverlapCompression => unimplemented!("Does P=NP?"),
         }
     }
@@ -53,6 +77,11 @@ impl ListViewArray {
     ///
     /// [`ListArray`]: crate::arrays::ListArray
     fn rebuild_zero_copy_to_list(&self) -> ListViewArray {
+        if self.shape().is_zero_copy_to_list() {
+            // Note that since everything in `ListViewArray` is `Arc`ed, this is quite cheap.
+            return self.clone();
+        }
+
         let element_dtype = self
             .dtype()
             .as_list_element_opt()
@@ -76,6 +105,65 @@ impl ListViewArray {
         })
     }
 
+    /// Rebuilds a [`ListViewArray`] by trimming any unused / unreferenced leading and trailing
+    /// elements, which is defined as a contiguous run of values in the `elements` array that are
+    /// not referecened by any views in the corresponding [`ListViewArray`].
+    fn rebuild_trim_elements(&self) -> ListViewArray {
+        let start = if self.shape().has_sorted_offsets() {
+            // If offsets are sorted, then the minimum offset is the first offset.
+            self.offset_at(0)
+        } else {
+            self.offsets().statistics().compute_min().vortex_expect(
+                "[ListViewArray::rebuild]: `offsets` must report min statistic that is a `usize`",
+            )
+        };
+
+        let end = if self.shape().has_sorted_offsets() && self.shape().has_no_overlaps() {
+            // If offsets are sorted and there are no overlaps (views are always "increasing"), we
+            // can just grab the last offset and last size.
+            let last_offset = self.offset_at(self.len() - 1);
+            let last_size = self.size_at(self.len() - 1);
+            last_offset + last_size
+        } else {
+            let min_max = compute::min_max(
+                &compute::add(self.offsets(), self.sizes())
+                    .vortex_expect("`offsets + sizes` somehow overflowed"),
+            )
+            .vortex_expect("Something went wrong while computing min and max")
+            .vortex_expect("We checked that the array was not empty in the top-level `rebuild`");
+
+            min_max
+                .max
+                .as_primitive()
+                .as_::<usize>()
+                .vortex_expect("unable to interpret the max `offset + size` as a `usize`")
+        };
+
+        let adjusted_offsets = match_each_integer_ptype!(self.offsets().dtype().as_ptype(), |O| {
+            let offset = <O as FromPrimitive>::from_usize(start)
+                .vortex_expect("unable to convert the min offset `start` into a `usize`");
+            let scalar = Scalar::primitive(offset, Nullability::NonNullable);
+
+            compute::sub_scalar(self.offsets(), scalar)
+                .vortex_expect("was somehow unable to adjust offsets down by their minimum")
+        });
+
+        let sliced_elements = self.elements().slice(start..end);
+
+        // SAFETY: The only thing we changed was the elements (which we verify through mins and
+        // maxes that all adjusted offsets + sizes are within the correct bounds), so the parameters
+        // are valid.
+        unsafe {
+            ListViewArray::new_unchecked(
+                sliced_elements,
+                adjusted_offsets,
+                self.sizes().clone(),
+                self.validity().clone(),
+                self.shape(),
+            )
+        }
+    }
+
     /// Rebuilds a [`ListViewArray`] by removing unreferenced elements while preserving overlaps.
     ///
     /// This removes "garbage" elements that are not referenced by any list. Unlike
@@ -83,20 +171,31 @@ impl ListViewArray {
     /// the same elements.
     ///
     /// [`rebuild_flatten()`]: Self::rebuild_flatten
-    fn rebuild_remove_gaps(&self) -> ListViewArray {
-        if self.is_empty() {
-            return self.clone();
+    #[allow(clippy::cognitive_complexity)]
+    fn rebuild_remove_gaps<const REMOVE_NULLS: bool>(&self) -> ListViewArray {
+        // If there are already no gaps, then we can just trim the `elements` array.
+        // However, if we are removing nulls and it is possible we might have null viws, we must
+        // fall back to the inner function.
+        if self.shape().has_no_gaps() && (!REMOVE_NULLS || !self.dtype().is_nullable()) {
+            return self.rebuild_trim_elements();
         }
 
         let offset_ptype = self.offsets().dtype().as_ptype();
         let size_ptype = self.sizes().dtype().as_ptype();
 
         match_each_integer_ptype!(offset_ptype, |O| {
-            match_each_integer_ptype!(size_ptype, |S| { self.rebuild_remove_gaps_inner::<O, S>() })
+            match_each_integer_ptype!(size_ptype, |S| {
+                if REMOVE_NULLS && self.dtype().is_nullable() {
+                    self.rebuild_remove_gaps_inner::<O, S, true>()
+                } else {
+                    self.rebuild_remove_gaps_inner::<O, S, false>()
+                }
+            })
         })
     }
 
-    fn rebuild_remove_gaps_inner<O, S>(&self) -> ListViewArray
+    /// The inner function for [`rebuild_remove_gaps()`](Self::rebuild_remove_gaps).
+    fn rebuild_remove_gaps_inner<O, S, const REMOVE_NULLS: bool>(&self) -> ListViewArray
     where
         O: IntegerPType,
         S: IntegerPType,
@@ -106,9 +205,20 @@ impl ListViewArray {
         let offsets_slice = offsets_primitive.as_slice::<O>();
         let sizes_slice = sizes_primitive.as_slice::<S>();
 
+        // Some `dyn` magic to generically iterate over the indices we want. We need to store
+        // `validity` outside of the `if` statement otherwise it does not live long enough.
+        let validity = REMOVE_NULLS.then(|| self.validity.to_mask(self.len()).to_boolean_buffer());
+        let indices: &mut dyn Iterator<Item = usize> = if let Some(ref validity) = validity {
+            &mut (0..self.len())
+                .zip(validity.iter())
+                .filter_map(|(i, is_valid)| is_valid.then_some(i))
+        } else {
+            &mut (0..self.len())
+        };
+
         // Mark which elements in the elements array are referenced by at least one list.
         let mut referenced_elements = vec![false; self.elements().len()];
-        for i in 0..self.len() {
+        for i in indices {
             let offset: usize = offsets_slice[i].as_();
             let size: usize = sizes_slice[i].as_();
             for j in offset..offset + size {
@@ -155,6 +265,31 @@ impl ListViewArray {
             new_offsets_builder.append_value(offset_value);
         }
 
+        // We set the size of any view that is denoted as null to be 0 (to ensure all views are
+        // still valid).
+        let new_sizes = if REMOVE_NULLS && self.dtype().is_nullable() {
+            let primitive_sizes = self.sizes().to_primitive();
+            let view_validity = self.validity.clone();
+
+            match_each_integer_ptype!(primitive_sizes.dtype().as_ptype(), |S| {
+                // Create a nullable version of `sizes` and then fill with nulls.
+                let nullable_sizes =
+                    PrimitiveArray::try_new(primitive_sizes.into_buffer::<S>(), view_validity)
+                        .vortex_expect("validity length somehow not matching `sizes` length");
+
+                // Filling with a non-nullable scalar will result in a non-nullable array.
+                let zero_scalar = Scalar::primitive(<S as Zero>::zero(), Nullability::NonNullable);
+
+                compute::fill_null(nullable_sizes.as_ref(), &zero_scalar)
+                    .vortex_expect("fill_null should not fail filling with zeros")
+            })
+        } else {
+            self.sizes().clone()
+        };
+
+        // Create a new `ListViewShape` but set `has_no_gaps` to `true`.
+        let new_shape = self.shape().with_no_gaps(true);
+
         // SAFETY: The new offsets array is guaranteed to be valid because:
         // 1. Each new offset is derived from prefix_sum[old_offset], which maps to a valid index
         //    in the compacted elements array (guaranteed by the prefix sum construction).
@@ -165,8 +300,9 @@ impl ListViewArray {
             ListViewArray::new_unchecked(
                 elements_builder.finish(),
                 new_offsets_builder.finish().into_array(),
-                self.sizes().clone(),
+                new_sizes,
                 self.validity().clone(),
+                new_shape,
             )
         }
     }
@@ -174,64 +310,51 @@ impl ListViewArray {
 
 #[cfg(test)]
 mod tests {
+    use arrow_buffer::BooleanBuffer;
     use vortex_dtype::Nullability;
 
-    use crate::arrays::{ListViewArray, PrimitiveArray};
+    use super::ListViewRebuildMode;
+    use crate::arrays::{BoolArray, ListViewArray, ListViewShape, PrimitiveArray};
     use crate::validity::Validity;
     use crate::vtable::ValidityHelper;
     use crate::{IntoArray, ToCanonical};
 
     #[test]
-    fn test_rebuild_remove_gaps_with_leading_garbage() {
-        // Create a list view with garbage at the beginning: [_, _, A, B, C]
+    fn test_rebuild_remove_gaps_leading_and_trailing() {
+        // Combine testing of both leading and trailing garbage removal.
+        // Create a list view with garbage at both ends: [_, _, A, B, C, _, _]
         // List 0: offset=2, size=2 -> [A, B]
         // List 1: offset=3, size=2 -> [B, C]
-        let elements = PrimitiveArray::from_iter(vec![99i32, 98, 1, 2, 3]).into_array();
+        let elements = PrimitiveArray::from_iter(vec![99i32, 98, 1, 2, 3, 97, 96]).into_array();
         let offsets = PrimitiveArray::from_iter(vec![2u32, 3]).into_array();
         let sizes = PrimitiveArray::from_iter(vec![2u32, 2]).into_array();
 
-        let listview =
-            ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap();
+        let listview = ListViewArray::try_new(
+            elements,
+            offsets,
+            sizes,
+            Validity::NonNullable,
+            ListViewShape::as_zero_copy_to_list().with_no_overlaps(false),
+        )
+        .unwrap();
 
-        let compacted = listview.rebuild_remove_gaps();
+        let compacted = listview.rebuild(ListViewRebuildMode::RemoveGaps);
 
-        // After GC: elements should be [A, B, C] = [1, 2, 3]
+        // After GC: elements should be [A, B, C] = [1, 2, 3].
         assert_eq!(compacted.elements().len(), 3);
 
-        // Offsets should be remapped: old offset 2 -> new offset 0, old offset 3 -> new offset 1
+        // Offsets should be remapped: old offset 2 -> new offset 0, old offset 3 -> new offset 1.
         assert_eq!(compacted.offset_at(0), 0);
         assert_eq!(compacted.size_at(0), 2);
         assert_eq!(compacted.offset_at(1), 1);
         assert_eq!(compacted.size_at(1), 2);
 
-        // Verify the data is correct by reading the lists
+        // Verify the data is correct by reading the lists.
         let list0 = compacted.list_elements_at(0).to_primitive();
         assert_eq!(list0.as_slice::<i32>(), &[1, 2]);
 
         let list1 = compacted.list_elements_at(1).to_primitive();
         assert_eq!(list1.as_slice::<i32>(), &[2, 3]);
-    }
-
-    #[test]
-    fn test_rebuild_remove_gaps_with_trailing_garbage() {
-        // Create a list view with garbage at the end: [A, B, C, _, _]
-        // List 0: offset=0, size=2 -> [A, B]
-        // List 1: offset=1, size=2 -> [B, C]
-        let elements = PrimitiveArray::from_iter(vec![1i32, 2, 3, 99, 98]).into_array();
-        let offsets = PrimitiveArray::from_iter(vec![0u32, 1]).into_array();
-        let sizes = PrimitiveArray::from_iter(vec![2u32, 2]).into_array();
-
-        let listview =
-            ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap();
-
-        let compacted = listview.rebuild_remove_gaps();
-
-        // After GC: elements should be [A, B, C] = [1, 2, 3]
-        assert_eq!(compacted.elements().len(), 3);
-
-        // Offsets should remain the same since no leading garbage
-        assert_eq!(compacted.offset_at(0), 0);
-        assert_eq!(compacted.offset_at(1), 1);
     }
 
     #[test]
@@ -243,10 +366,16 @@ mod tests {
         let offsets = PrimitiveArray::from_iter(vec![0u32, 2]).into_array();
         let sizes = PrimitiveArray::from_iter(vec![2u32, 1]).into_array();
 
-        let listview =
-            ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap();
+        let listview = ListViewArray::try_new(
+            elements,
+            offsets,
+            sizes,
+            Validity::NonNullable,
+            ListViewShape::as_zero_copy_to_list(),
+        )
+        .unwrap();
 
-        let compacted = listview.rebuild_remove_gaps();
+        let compacted = listview.rebuild(ListViewRebuildMode::RemoveGaps);
 
         // Should be unchanged (fast path)
         assert_eq!(compacted.elements().len(), 3);
@@ -263,10 +392,16 @@ mod tests {
         let offsets = PrimitiveArray::from_iter(vec![1u32, 2]).into_array();
         let sizes = PrimitiveArray::from_iter(vec![3u32, 2]).into_array();
 
-        let listview =
-            ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap();
+        let listview = ListViewArray::try_new(
+            elements,
+            offsets,
+            sizes,
+            Validity::NonNullable,
+            ListViewShape::as_zero_copy_to_list().with_no_overlaps(false),
+        )
+        .unwrap();
 
-        let compacted = listview.rebuild_remove_gaps();
+        let compacted = listview.rebuild(ListViewRebuildMode::RemoveGaps);
 
         // After GC: elements should be [A, B, C] = [1, 2, 3]
         assert_eq!(compacted.elements().len(), 3);
@@ -300,10 +435,16 @@ mod tests {
         let offsets = PrimitiveArray::from_iter(vec![1u32, 4, 7]).into_array();
         let sizes = PrimitiveArray::from_iter(vec![2u32, 2, 2]).into_array();
 
-        let listview =
-            ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap();
+        let listview = ListViewArray::try_new(
+            elements,
+            offsets,
+            sizes,
+            Validity::NonNullable,
+            ListViewShape::as_zero_copy_to_list().with_no_gaps(false),
+        )
+        .unwrap();
 
-        let compacted = listview.rebuild_remove_gaps();
+        let compacted = listview.rebuild(ListViewRebuildMode::RemoveGaps);
 
         // After GC: elements should be [A, B, C, D, E, F] = [1, 2, 3, 4, 5, 6]
         assert_eq!(compacted.elements().len(), 6);
@@ -340,10 +481,16 @@ mod tests {
         let offsets = PrimitiveArray::from_iter(vec![0u32, 1]).into_array();
         let sizes = PrimitiveArray::from_iter(vec![3u32, 2]).into_array();
 
-        let listview =
-            ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap();
+        let listview = ListViewArray::try_new(
+            elements,
+            offsets,
+            sizes,
+            Validity::NonNullable,
+            ListViewShape::as_zero_copy_to_list().with_no_overlaps(false),
+        )
+        .unwrap();
 
-        let flattened = listview.rebuild_zero_copy_to_list();
+        let flattened = listview.rebuild(ListViewRebuildMode::MakeZeroCopyToList);
 
         // After flatten: elements should be [A, B, C, B, C] = [1, 2, 3, 2, 3]
         // Lists should be sequential with no overlaps
@@ -366,11 +513,10 @@ mod tests {
     #[ignore = "TODO(connor)[ListView]: Reenable when `ListView` becomes canonical"]
     #[test]
     fn test_rebuild_flatten_with_nullable() {
-        use arrow_buffer::BooleanBuffer;
-
-        use crate::arrays::BoolArray;
-
-        // Create a nullable list view with a null list
+        // Create a nullable list view: [A, B, C]
+        // List 0: offset=0, size=2 -> [A, B] (valid)
+        // List 1: offset=1, size=1 -> null
+        // List 2: offset=2, size=1 -> [C] (valid)
         let elements = PrimitiveArray::from_iter(vec![1i32, 2, 3]).into_array();
         let offsets = PrimitiveArray::from_iter(vec![0u32, 1, 2]).into_array();
         let sizes = PrimitiveArray::from_iter(vec![2u32, 1, 1]).into_array();
@@ -378,9 +524,16 @@ mod tests {
             BoolArray::from(BooleanBuffer::from(vec![true, false, true])).into_array(),
         );
 
-        let listview = ListViewArray::try_new(elements, offsets, sizes, validity).unwrap();
+        let listview = ListViewArray::try_new(
+            elements,
+            offsets,
+            sizes,
+            validity,
+            ListViewShape::as_zero_copy_to_list().with_no_overlaps(false),
+        )
+        .unwrap();
 
-        let flattened = listview.rebuild_zero_copy_to_list();
+        let flattened = listview.rebuild(ListViewRebuildMode::MakeZeroCopyToList);
 
         // Verify nullability is preserved
         assert_eq!(flattened.dtype().nullability(), Nullability::Nullable);
@@ -394,5 +547,199 @@ mod tests {
 
         let list2 = flattened.list_elements_at(2).to_primitive();
         assert_eq!(list2.as_slice::<i32>(), &[3]);
+    }
+
+    #[test]
+    fn test_rebuild_remove_gaps_complex() {
+        // Test with unsorted offsets, gaps, and overlaps combined.
+        // Elements: [_, A, B, C, _, D, E, _]
+        //            0  1  2  3  4  5  6  7
+        // List 0: offset=5, size=2 -> [D, E]
+        // List 1: offset=1, size=3 -> [A, B, C]
+        // List 2: offset=2, size=2 -> [B, C] (overlaps with List 1)
+        let elements = PrimitiveArray::from_iter(vec![99i32, 1, 2, 3, 98, 4, 5, 97]).into_array();
+        let offsets = PrimitiveArray::from_iter(vec![5u32, 1, 2]).into_array();
+        let sizes = PrimitiveArray::from_iter(vec![2u32, 3, 2]).into_array();
+
+        let listview = ListViewArray::try_new(
+            elements,
+            offsets,
+            sizes,
+            Validity::NonNullable,
+            ListViewShape::as_zero_copy_to_list()
+                .with_sorted_offsets(false)
+                .with_no_overlaps(false)
+                .with_no_gaps(false),
+        )
+        .unwrap();
+
+        let compacted = listview.rebuild(ListViewRebuildMode::RemoveGaps);
+
+        // After GC: elements should be [A, B, C, D, E] = [1, 2, 3, 4, 5].
+        assert_eq!(compacted.elements().len(), 5);
+
+        // Verify offset remapping:
+        // old offset 5 -> new offset 3 (D is at index 3 in compacted)
+        // old offset 1 -> new offset 0 (A is at index 0 in compacted)
+        // old offset 2 -> new offset 1 (B is at index 1 in compacted)
+        assert_eq!(compacted.offset_at(0), 3);
+        assert_eq!(compacted.size_at(0), 2);
+        assert_eq!(compacted.offset_at(1), 0);
+        assert_eq!(compacted.size_at(1), 3);
+        assert_eq!(compacted.offset_at(2), 1);
+        assert_eq!(compacted.size_at(2), 2);
+
+        // Verify the data is correct.
+        let list0 = compacted.list_elements_at(0).to_primitive();
+        assert_eq!(list0.as_slice::<i32>(), &[4, 5]);
+
+        let list1 = compacted.list_elements_at(1).to_primitive();
+        assert_eq!(list1.as_slice::<i32>(), &[1, 2, 3]);
+
+        let list2 = compacted.list_elements_at(2).to_primitive();
+        assert_eq!(list2.as_slice::<i32>(), &[2, 3]);
+    }
+
+    #[test]
+    fn test_rebuild_trim_elements_basic() {
+        // Test trimming both leading and trailing unused elements while preserving gaps in the
+        // middle.
+        // Elements: [_, _, A, B, _, C, D, _, _]
+        //            0  1  2  3  4  5  6  7  8
+        // List 0: offset=2, size=2 -> [A, B]
+        // List 1: offset=5, size=2 -> [C, D]
+        // Should trim to: [A, B, _, C, D] with adjusted offsets.
+        let elements =
+            PrimitiveArray::from_iter(vec![99i32, 98, 1, 2, 97, 3, 4, 96, 95]).into_array();
+        let offsets = PrimitiveArray::from_iter(vec![2u32, 5]).into_array();
+        let sizes = PrimitiveArray::from_iter(vec![2u32, 2]).into_array();
+
+        let listview = ListViewArray::try_new(
+            elements,
+            offsets,
+            sizes,
+            Validity::NonNullable,
+            ListViewShape::as_zero_copy_to_list().with_no_gaps(false),
+        )
+        .unwrap();
+
+        let trimmed = listview.rebuild(ListViewRebuildMode::TrimElements);
+
+        // After trimming: elements should be [A, B, _, C, D] = [1, 2, 97, 3, 4].
+        assert_eq!(trimmed.elements().len(), 5);
+
+        // Offsets should be adjusted: old offset 2 -> new offset 0, old offset 5 -> new offset 3.
+        assert_eq!(trimmed.offset_at(0), 0);
+        assert_eq!(trimmed.size_at(0), 2);
+        assert_eq!(trimmed.offset_at(1), 3);
+        assert_eq!(trimmed.size_at(1), 2);
+
+        // Verify the data is correct.
+        let list0 = trimmed.list_elements_at(0).to_primitive();
+        assert_eq!(list0.as_slice::<i32>(), &[1, 2]);
+
+        let list1 = trimmed.list_elements_at(1).to_primitive();
+        assert_eq!(list1.as_slice::<i32>(), &[3, 4]);
+
+        // Note that element at index 2 (97) is preserved as a gap.
+        let all_elements = trimmed.elements().to_primitive();
+        assert_eq!(all_elements.scalar_at(2), 97i32.into());
+    }
+
+    #[test]
+    fn test_rebuild_remove_nulls_basic() {
+        // Test removing elements that are only referenced by null views.
+        // Elements: [A, B, C, D, E]
+        // List 0: offset=0, size=2 -> [A, B] (valid)
+        // List 1: offset=2, size=2 -> [C, D] (null)
+        // List 2: offset=4, size=1 -> [E] (valid)
+        // After rebuild: should remove [C, D] since only referenced by null view.
+        let elements = PrimitiveArray::from_iter(vec![1i32, 2, 3, 4, 5]).into_array();
+        let offsets = PrimitiveArray::from_iter(vec![0u32, 2, 4]).into_array();
+        let sizes = PrimitiveArray::from_iter(vec![2u32, 2, 1]).into_array();
+        let validity = Validity::Array(
+            BoolArray::from(BooleanBuffer::from(vec![true, false, true])).into_array(),
+        );
+
+        let listview = ListViewArray::try_new(
+            elements,
+            offsets,
+            sizes,
+            validity,
+            ListViewShape::as_zero_copy_to_list(),
+        )
+        .unwrap();
+
+        let rebuilt = listview.rebuild(ListViewRebuildMode::RemoveNulls);
+
+        // After removing nulls: elements should be [A, B, E] = [1, 2, 5].
+        assert_eq!(rebuilt.elements().len(), 3);
+
+        // Offsets should be adjusted: offset 0 stays 0, offset 2 would be mapped but unused,
+        // offset 4 -> 2.
+        assert_eq!(rebuilt.offset_at(0), 0);
+        assert_eq!(rebuilt.size_at(0), 2);
+
+        // The null view's size should be 0 (filled by fill_null).
+        assert_eq!(rebuilt.size_at(1), 0);
+
+        assert_eq!(rebuilt.offset_at(2), 2);
+        assert_eq!(rebuilt.size_at(2), 1);
+
+        // Verify validity is preserved.
+        assert!(rebuilt.validity().is_valid(0));
+        assert!(!rebuilt.validity().is_valid(1));
+        assert!(rebuilt.validity().is_valid(2));
+
+        // Verify the valid lists contain correct data.
+        let list0 = rebuilt.list_elements_at(0).to_primitive();
+        assert_eq!(list0.as_slice::<i32>(), &[1, 2]);
+
+        let list2 = rebuilt.list_elements_at(2).to_primitive();
+        assert_eq!(list2.as_slice::<i32>(), &[5]);
+    }
+
+    #[test]
+    fn test_rebuild_remove_nulls_non_nullable() {
+        // Test that non-nullable arrays behave identically to RemoveGaps mode.
+        // Elements: [_, A, B, _, C, D, _]
+        //            0  1  2  3  4  5  6
+        // List 0: offset=1, size=2 -> [A, B]
+        // List 1: offset=4, size=2 -> [C, D]
+        let elements = PrimitiveArray::from_iter(vec![99i32, 1, 2, 98, 3, 4, 97]).into_array();
+        let offsets = PrimitiveArray::from_iter(vec![1u32, 4]).into_array();
+        let sizes = PrimitiveArray::from_iter(vec![2u32, 2]).into_array();
+
+        let listview = ListViewArray::try_new(
+            elements,
+            offsets,
+            sizes,
+            Validity::NonNullable,
+            ListViewShape::as_zero_copy_to_list().with_no_gaps(false),
+        )
+        .unwrap();
+
+        // Apply both RemoveNulls and RemoveGaps to verify they produce identical results.
+        let remove_nulls_result = listview.rebuild(ListViewRebuildMode::RemoveNulls);
+        let remove_gaps_result = listview.rebuild(ListViewRebuildMode::RemoveGaps);
+
+        // Both should produce the same compacted result.
+        assert_eq!(
+            remove_nulls_result.elements().len(),
+            remove_gaps_result.elements().len()
+        );
+        assert_eq!(
+            remove_nulls_result.offset_at(0),
+            remove_gaps_result.offset_at(0)
+        );
+        assert_eq!(
+            remove_nulls_result.offset_at(1),
+            remove_gaps_result.offset_at(1)
+        );
+
+        // Verify the result is correct: [A, B, C, D] = [1, 2, 3, 4].
+        assert_eq!(remove_nulls_result.elements().len(), 4);
+        assert_eq!(remove_nulls_result.offset_at(0), 0);
+        assert_eq!(remove_nulls_result.offset_at(1), 2);
     }
 }

--- a/vortex-array/src/arrays/listview/shape.rs
+++ b/vortex-array/src/arrays/listview/shape.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+#[allow(unused)] // Used for documentation.
+use crate::arrays::{ListArray, ListViewArray};
+
+/// The "shape" of the a [`ListViewArray`]'s data.
+///
+/// ### Why do we need this?
+///
+/// In comparison to [`ListArray`], [`ListViewArray`] has much more relaxed invariants:
+///
+/// - Offsets are allowed to stored be out-of-order (since size is not implicit via
+///   `offsets[i+1] - offsets[i]` and is instead stored separately)
+/// - Views (which we define the a tuple `(offset, size)` denoting a range of elements) are allowed
+///   to overlap with each other / share elements in the `elements` child array
+/// - Views do not have to perfectly cover the `elements` child array, and there can be gaps of
+///   "unused" elements that are not referenced by any views
+///
+/// This allows for more flexibility in how we store data, but at the same time it restricts what
+/// operations we are able to do.
+///
+/// For example, we cannot do a constant-time slice of a [`ListViewArray`] unless we know that:
+/// 1. The offsets are in sorted order
+/// 2. There are no overlaps caused sizes larger than the gaps between offsets.
+///
+/// This type keeps track of information that allows us to perform operations like slicing and
+/// rebuilding much more efficiently.
+///
+/// ### Zero-copy to [`ListArray`]
+///
+/// If all of the flags in this struct are set to `true`, then we know that the corresponding
+/// [`ListViewArray`] is "zero-copyable" to a [`ListArray`]. Note that technically it can never be
+/// truly zero-copyable since we must add a single `offset` to get the correct `n+1` offsets that
+/// [`ListArray`] needs, but the data is zero-copyable in spirit.
+///
+/// This is not only helpful when we want to get a [`ListArray`] from a [`ListViewArray`], but we
+/// also can know that operations like slicing can be done efficiently.
+///
+/// _Note that in the actual `slice` implementation of [`ListViewArray`], we do not actually perform
+/// a slice of the underlying `elements` array, and we defer that operation to when the array gets
+/// rebuilt via [`ListViewArray::rebuild`].
+///
+/// ### Nulls
+///
+/// We do not consider null views as part of the "shape" of a `ListView`. In other words, even if a
+/// view is null, the corresponding offset must still be in order with the rest of the `offsets`
+/// array for us to consider `has_sorted_offsets` to be `true`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ListViewShape {
+    /// A flag indicating if the `offsets` array is sorted (not strictly sorted).
+    ///
+    /// Even if a view is defined as null in the validity array, the offsets must still be in sorted
+    /// order.
+    has_sorted_offsets: bool,
+
+    /// A flag indicating that no views overlap / share elements with each other.
+    has_no_overlaps: bool,
+
+    /// A flag indicating that there are no unused elements between views (ignoring any leading or
+    /// trailing unused elements).
+    has_no_gaps: bool,
+}
+
+impl ListViewShape {
+    /// Creates a new `ListViewShape`.
+    pub fn new(has_sorted_offsets: bool, has_no_overlaps: bool, has_no_gaps: bool) -> Self {
+        Self {
+            has_sorted_offsets,
+            has_no_overlaps,
+            has_no_gaps,
+        }
+    }
+
+    /// Checks if the shape of the [`ListViewArray`] allows for zero-copying to a [`ListArray`].
+    pub fn is_zero_copy_to_list(&self) -> bool {
+        self.has_sorted_offsets && self.has_no_overlaps && self.has_no_gaps
+    }
+
+    /// Creates a `ListViewShape` that indicates that the corresponding [`ListViewArray`] is
+    /// zero-copyable to [`ListArray`], as well as that it can be constant-time sliced.
+    pub fn as_zero_copy_to_list() -> Self {
+        Self::default()
+            .with_sorted_offsets(true)
+            .with_no_overlaps(true)
+            .with_no_gaps(true)
+    }
+
+    /// Returns a new `ListViewShape` with the sorted offsets flag updated.
+    pub fn with_sorted_offsets(self, has_sorted_offsets: bool) -> Self {
+        Self {
+            has_sorted_offsets,
+            ..self
+        }
+    }
+
+    /// Returns a new `ListViewShape` with the no overlaps flag updated.
+    pub fn with_no_overlaps(self, has_no_overlaps: bool) -> Self {
+        Self {
+            has_no_overlaps,
+            ..self
+        }
+    }
+
+    /// Returns a new `ListViewShape` with the no gaps flag updated.
+    pub fn with_no_gaps(self, has_no_gaps: bool) -> Self {
+        Self {
+            has_no_gaps,
+            ..self
+        }
+    }
+
+    /// Returns whether the offsets are sorted.
+    pub fn has_sorted_offsets(&self) -> bool {
+        self.has_sorted_offsets
+    }
+
+    /// Returns whether views have no overlapping elements.
+    pub fn has_no_overlaps(&self) -> bool {
+        self.has_no_overlaps
+    }
+
+    /// Returns whether there are no unused elements between views.
+    pub fn has_no_gaps(&self) -> bool {
+        self.has_no_gaps
+    }
+}

--- a/vortex-array/src/arrays/listview/tests/basic.rs
+++ b/vortex-array/src/arrays/listview/tests/basic.rs
@@ -8,6 +8,7 @@ use vortex_buffer::buffer;
 use vortex_dtype::{DType, Nullability, PType};
 use vortex_scalar::Scalar;
 
+use crate::arrays::listview::ListViewShape;
 use crate::arrays::{
     BoolArray, ConstantArray, ListArray, ListViewArray, PrimitiveArray, list_view_from_list,
 };
@@ -17,11 +18,18 @@ use crate::{Array, IntoArray};
 #[test]
 fn test_basic_listview_comprehensive() {
     // Comprehensive test for basic ListView functionality including scalar_at.
+    // Logical lists: [[1,2,3], [4,5], [6,7,8,9]]
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
     let offsets = buffer![0i32, 3, 5].into_array();
     let sizes = buffer![3i32, 2, 4].into_array();
 
-    let listview = ListViewArray::new(elements.into_array(), offsets, sizes, Validity::NonNullable);
+    let listview = ListViewArray::new(
+        elements.into_array(),
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list(),
+    );
 
     assert_eq!(listview.len(), 3);
     assert!(!listview.is_empty());
@@ -67,11 +75,18 @@ fn test_basic_listview_comprehensive() {
 #[test]
 fn test_out_of_order_offsets() {
     // ListView-specific: Tests that offsets can be non-sequential and out-of-order.
+    // Logical lists: [[7,8,9], [1,2,3], [4,5,6]]
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
-    let offsets = buffer![6i32, 0, 3].into_array(); // Out-of-order: [7,8,9], [1,2,3], [4,5,6].
+    let offsets = buffer![6i32, 0, 3].into_array(); // Out-of-order offsets.
     let sizes = buffer![3i32, 3, 3].into_array();
 
-    let listview = ListViewArray::new(elements.into_array(), offsets, sizes, Validity::NonNullable);
+    let listview = ListViewArray::new(
+        elements.into_array(),
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list().with_sorted_offsets(false),
+    );
 
     assert_eq!(listview.len(), 3);
 
@@ -91,13 +106,19 @@ fn test_out_of_order_offsets() {
 #[test]
 fn test_empty_listview() {
     // Test empty ListView array (0 lists).
+    // Logical lists: [] (empty ListView)
     let elements = buffer![1i32].into_array(); // Dummy element.
     let offsets = buffer![0i32; 0].into_array();
     let sizes = buffer![0i32; 0].into_array();
 
-    let listview =
-        ListViewArray::try_new(elements.into_array(), offsets, sizes, Validity::NonNullable)
-            .unwrap();
+    let listview = ListViewArray::try_new(
+        elements.into_array(),
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list(),
+    )
+    .unwrap();
 
     assert_eq!(listview.len(), 0);
     assert!(listview.is_empty());
@@ -106,6 +127,7 @@ fn test_empty_listview() {
 #[test]
 fn test_from_list_array() {
     // Test conversion from ListArray to ListViewArray.
+    // Logical lists: [[1,2], null, [5,6,7]]
     let offsets = buffer![0i64, 2, 4, 7].into_array();
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7].into_array();
     let validity = Validity::from_iter([true, false, true]);
@@ -138,6 +160,10 @@ fn test_from_list_array() {
 #[case::constant_offsets(false, true)] // Varying sizes, constant offsets
 #[case::both_constant(true, true)] // Both constant
 fn test_listview_with_constant_arrays(#[case] const_sizes: bool, #[case] const_offsets: bool) {
+    // Logical lists vary by case:
+    // - constant_sizes: [[1,2,3], [4,5,6], [7,8,9]] (size 3 each, varying offsets)
+    // - constant_offsets: [[1,2,3], [1,2], [1]] (all start at 0, varying sizes)
+    // - both_constant: [[1,2,3], [1,2,3], [1,2,3]] (all identical)
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9, 10].into_array();
 
     let offsets = if const_offsets {
@@ -152,11 +178,24 @@ fn test_listview_with_constant_arrays(#[case] const_sizes: bool, #[case] const_o
         buffer![3i32, 2, 1].into_array()
     };
 
-    let listview = ListViewArray::new(elements.into_array(), offsets, sizes, Validity::NonNullable);
+    // Determine shape flags based on test case.
+    let has_overlaps = if const_offsets {
+        false // All lists start at same offset, so they overlap
+    } else {
+        true // Different offsets with no overlap
+    };
+
+    let listview = ListViewArray::new(
+        elements.into_array(),
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list().with_no_overlaps(has_overlaps),
+    );
     assert_eq!(listview.len(), 3);
 
     if const_sizes && const_offsets {
-        // All lists are identical [1, 2, 3].
+        // All lists are identical [1, 2, 3] (overlapping).
         for i in 0..3 {
             let list = listview.list_elements_at(i);
             assert_eq!(list.scalar_at(0), 1i32.into());
@@ -164,12 +203,12 @@ fn test_listview_with_constant_arrays(#[case] const_sizes: bool, #[case] const_o
             assert_eq!(list.scalar_at(2), 3i32.into());
         }
     } else if const_sizes {
-        // All lists have size 3, different offsets.
+        // All lists have size 3, different offsets (no overlap).
         assert_eq!(listview.list_elements_at(0).len(), 3);
         assert_eq!(listview.list_elements_at(1).len(), 3);
         assert_eq!(listview.list_elements_at(2).len(), 3);
     } else if const_offsets {
-        // All lists start at offset 0, different sizes.
+        // All lists start at offset 0, different sizes (overlapping).
         assert_eq!(listview.list_elements_at(0).scalar_at(0), 1i32.into());
         assert_eq!(listview.list_elements_at(1).scalar_at(0), 1i32.into());
         assert_eq!(listview.list_elements_at(2).scalar_at(0), 1i32.into());
@@ -205,6 +244,7 @@ fn test_validation_errors(
         offsets.into_array(),
         sizes.into_array(),
         Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list(),
     );
 
     assert!(result.is_err());
@@ -213,11 +253,18 @@ fn test_validation_errors(
 
 #[test]
 fn test_validate_nullable_offsets() {
+    // Logical lists (invalid due to nullable offsets): [[1,2], [3], ???]
     let elements = buffer![1i32, 2, 3, 4, 5].into_array();
     let offsets = PrimitiveArray::from_option_iter(vec![Some(0u32), Some(2), None]).into_array();
     let sizes = buffer![2u32, 1, 2].into_array();
 
-    let result = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable);
+    let result = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list(),
+    );
 
     assert!(result.is_err());
     assert!(
@@ -230,11 +277,18 @@ fn test_validate_nullable_offsets() {
 
 #[test]
 fn test_validate_nullable_sizes() {
+    // Logical lists (invalid due to nullable sizes): [[1,2], ???, [2,3]]
     let elements = buffer![1i32, 2, 3, 4, 5].into_array();
     let offsets = buffer![0u32, 2, 1].into_array();
     let sizes = PrimitiveArray::from_option_iter(vec![Some(2u32), None, Some(2)]).into_array();
 
-    let result = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable);
+    let result = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list(),
+    );
 
     assert!(result.is_err());
     assert!(
@@ -247,12 +301,19 @@ fn test_validate_nullable_sizes() {
 
 #[test]
 fn test_validate_size_type_too_large() {
+    // Logical lists (invalid due to size type > offset type): [[1,2], [3], [2,3]]
     let elements = buffer![1i32, 2, 3, 4, 5].into_array();
     // Use u64 for sizes and u32 for offsets (sizes type is larger).
     let offsets = buffer![0u32, 2, 1].into_array();
     let sizes = buffer![2u64, 1, 2].into_array();
 
-    let result = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable);
+    let result = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list(),
+    );
 
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("size type"));
@@ -260,12 +321,19 @@ fn test_validate_size_type_too_large() {
 
 #[test]
 fn test_validate_offset_plus_size_overflow() {
+    // Logical lists (invalid due to overflow): would overflow, [[1], [1]]
     let elements = buffer![1i32, 2, 3, 4, 5].into_array();
     // Create an offset + size that would overflow.
     let offsets = buffer![u32::MAX - 1, 0, 0].into_array();
     let sizes = buffer![2u32, 1, 1].into_array();
 
-    let result = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable);
+    let result = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list(),
+    );
 
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -277,13 +345,20 @@ fn test_validate_offset_plus_size_overflow() {
 
 #[test]
 fn test_validate_invalid_validity_length() {
+    // Logical lists (invalid due to validity length mismatch): [[1,2], [3,4], [5]]
     let elements = buffer![1i32, 2, 3, 4, 5].into_array();
     let offsets = buffer![0u32, 2, 4].into_array();
     let sizes = buffer![2u32, 2, 1].into_array();
     // Validity has wrong length.
     let validity = Validity::Array(BoolArray::from_iter(vec![true, false]).into_array());
 
-    let result = ListViewArray::try_new(elements, offsets, sizes, validity);
+    let result = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        validity,
+        ListViewShape::as_zero_copy_to_list(),
+    );
 
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -295,12 +370,19 @@ fn test_validate_invalid_validity_length() {
 
 #[test]
 fn test_validate_non_integer_offsets() {
+    // Logical lists (invalid due to float offsets): [[1,2], [3,4], [5]]
     let elements = buffer![1i32, 2, 3, 4, 5].into_array();
     // Try to use float offsets.
     let offsets = buffer![0.0f32, 2.0, 4.0].into_array();
     let sizes = buffer![2u32, 2, 1].into_array();
 
-    let result = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable);
+    let result = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list(),
+    );
 
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -313,22 +395,38 @@ fn test_validate_non_integer_offsets() {
 #[test]
 fn test_validate_different_int_types() {
     // Test that different integer types work as long as sizes type ≤ offsets type.
+    // Logical lists: [[1,2], [3], [2,3]]
     let elements = buffer![1i32, 2, 3, 4, 5].into_array();
     let offsets = buffer![0u64, 2, 1].into_array();
     let sizes = buffer![2u32, 1, 2].into_array();
 
-    let result = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable);
+    let result = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list()
+            .with_sorted_offsets(false)
+            .with_no_overlaps(false),
+    );
     assert!(result.is_ok());
 }
 
 #[test]
 fn test_validate_u64_overflow() {
     // Test overflow with u64 offsets and sizes.
+    // Logical lists (invalid due to u64 overflow): would overflow, [[0], [0]]
     let elements = PrimitiveArray::from_iter(0i32..100).into_array();
     let offsets = buffer![u64::MAX - 10, 0, 0].into_array();
     let sizes = buffer![20u64, 1, 1].into_array();
 
-    let result = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable);
+    let result = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list(),
+    );
 
     assert!(result.is_err());
     let err = result.unwrap_err();

--- a/vortex-array/src/arrays/listview/tests/common.rs
+++ b/vortex-array/src/arrays/listview/tests/common.rs
@@ -6,6 +6,7 @@
 use vortex_buffer::buffer;
 
 use crate::IntoArray;
+use crate::arrays::listview::ListViewShape;
 use crate::arrays::{BoolArray, ListViewArray, PrimitiveArray};
 use crate::validity::Validity;
 
@@ -14,7 +15,14 @@ pub fn create_basic_listview() -> ListViewArray {
     let elements = buffer![0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
     let offsets = buffer![0u32, 3, 5, 7].into_array();
     let sizes = buffer![3u32, 2, 2, 3].into_array();
-    ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap()
+    ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list(),
+    )
+    .unwrap()
 }
 
 /// Creates a nullable ListView: [[10,20], null, [50]]
@@ -23,7 +31,14 @@ pub fn create_nullable_listview() -> ListViewArray {
     let offsets = buffer![0u32, 2, 4].into_array();
     let sizes = buffer![2u32, 2, 1].into_array();
     let validity = Validity::Array(BoolArray::from_iter(vec![true, false, true]).into_array());
-    ListViewArray::try_new(elements, offsets, sizes, validity).unwrap()
+    ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        validity,
+        ListViewShape::as_zero_copy_to_list(),
+    )
+    .unwrap()
 }
 
 /// Creates a ListView with empty lists: [[], [], [], []]
@@ -31,7 +46,14 @@ pub fn create_empty_lists_listview() -> ListViewArray {
     let elements = buffer![99i32].into_array();
     let offsets = buffer![0u32, 0, 0, 0].into_array();
     let sizes = buffer![0u32, 0, 0, 0].into_array();
-    ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap()
+    ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list(),
+    )
+    .unwrap()
 }
 
 /// Creates a ListView with overlapping lists and out-of-order offsets
@@ -40,7 +62,16 @@ pub fn create_overlapping_listview() -> ListViewArray {
     let elements = buffer![0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
     let offsets = buffer![5u32, 2, 8, 0, 1].into_array();
     let sizes = buffer![3u32, 2, 2, 2, 4].into_array();
-    ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap()
+    ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list()
+            .with_sorted_offsets(false)
+            .with_no_overlaps(false),
+    )
+    .unwrap()
 }
 
 /// Creates a large ListView for performance testing
@@ -48,5 +79,12 @@ pub fn create_large_listview() -> ListViewArray {
     let elements = PrimitiveArray::from_iter(0i32..1000).into_array();
     let offsets = buffer![0u32, 100, 200, 300, 400, 500, 600, 700, 800, 900].into_array();
     let sizes = buffer![50u32, 50, 50, 50, 50, 50, 50, 50, 50, 50].into_array();
-    ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap()
+    ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list().with_no_gaps(false),
+    )
+    .unwrap()
 }

--- a/vortex-array/src/arrays/listview/tests/filter.rs
+++ b/vortex-array/src/arrays/listview/tests/filter.rs
@@ -10,6 +10,7 @@ use super::common::{
     create_basic_listview, create_empty_lists_listview, create_large_listview,
     create_nullable_listview, create_overlapping_listview,
 };
+use crate::arrays::listview::ListViewShape;
 use crate::arrays::{ConstantArray, ListViewArray, PrimitiveArray};
 use crate::compute::conformance::filter::test_filter_conformance;
 use crate::compute::filter;
@@ -30,13 +31,24 @@ fn test_filter_listview_conformance(#[case] listview: ListViewArray) {
 #[test]
 fn test_filter_preserves_unreferenced_elements() {
     // ListView-specific: Test that filter preserves the entire elements array.
+    //
+    // Logical list: [[5,6,7], [2,3], [8,9], [0,1], [1,2,3,4]]
+    // Elements: [0,1,2,3,4,5,6,7,8,9]
     let elements = buffer![0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
     let offsets = buffer![5u32, 2, 8, 0, 1].into_array();
     let sizes = buffer![3u32, 2, 2, 2, 4].into_array();
 
-    let listview = ListViewArray::try_new(elements.clone(), offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview = ListViewArray::try_new(
+        elements.clone(),
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list()
+            .with_sorted_offsets(false)
+            .with_no_overlaps(false),
+    )
+    .unwrap()
+    .to_array();
 
     // Filter to keep only 2 lists.
     let mask = Mask::from_iter([true, false, false, true, false]);
@@ -61,14 +73,25 @@ fn test_filter_preserves_unreferenced_elements() {
 #[test]
 fn test_filter_with_gaps() {
     // ListView-specific: Test filtering with gaps in elements array.
-    // Elements with gaps (999 values are "gaps" between used ranges).
+    //
+    // Logical list: [[1,2,3], [7,8,9], [11,12], [2,3], [8,9]]
+    // Elements: [1,2,3,999,999,999,7,8,9,999,11,12] (999 values are gaps)
     let elements = buffer![1i32, 2, 3, 999, 999, 999, 7, 8, 9, 999, 11, 12].into_array();
     let offsets = buffer![0u32, 6, 10, 1, 7].into_array();
     let sizes = buffer![3u32, 3, 2, 2, 2].into_array();
 
-    let listview = ListViewArray::try_new(elements.clone(), offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview = ListViewArray::try_new(
+        elements.clone(),
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list()
+            .with_sorted_offsets(false)
+            .with_no_overlaps(false)
+            .with_no_gaps(false),
+    )
+    .unwrap()
+    .to_array();
 
     // Filter to keep lists with gaps and overlaps.
     let mask = Mask::from_iter([false, true, true, true, false]);
@@ -102,6 +125,7 @@ fn test_filter_constant_arrays() {
     let elements = buffer![100i32, 200, 300, 400, 500, 600, 700, 800].into_array();
 
     // Case 1: Constant offsets (all lists start at same position).
+    // Logical list: [[300], [300,400], [300,400,500], [300,400,500,600]]
     let constant_offsets = ConstantArray::new(2u32, 4).into_array();
     let varying_sizes = buffer![1u32, 2, 3, 4].into_array();
 
@@ -110,6 +134,7 @@ fn test_filter_constant_arrays() {
         constant_offsets,
         varying_sizes,
         Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list().with_no_overlaps(false),
     )
     .unwrap()
     .to_array();
@@ -125,6 +150,7 @@ fn test_filter_constant_arrays() {
     assert_eq!(result1_list.size_at(1), 3);
 
     // Case 2: Both constant (all lists are identical).
+    // Logical list: [[200,300,400], [200,300,400], [200,300,400]]
     let both_constant_offsets = ConstantArray::new(1u32, 3).into_array();
     let both_constant_sizes = ConstantArray::new(3u32, 3).into_array();
 
@@ -133,6 +159,7 @@ fn test_filter_constant_arrays() {
         both_constant_offsets,
         both_constant_sizes,
         Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list().with_no_overlaps(false),
     )
     .unwrap()
     .to_array();
@@ -154,12 +181,21 @@ fn test_filter_extreme_offsets() {
     let elements = PrimitiveArray::from_iter(0i32..10000).into_array();
 
     // Lists at extremes: beginning, middle, and end of the array.
+    // Logical list: [[0..5], [4999..5001], [9995..10000], [2500..2503], [7500..7504]]
     let offsets = buffer![0u32, 4999, 9995, 2500, 7500].into_array();
     let sizes = buffer![5u32, 2, 5, 3, 4].into_array();
 
-    let listview = ListViewArray::try_new(elements.clone(), offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview = ListViewArray::try_new(
+        elements.clone(),
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list()
+            .with_sorted_offsets(false)
+            .with_no_gaps(false),
+    )
+    .unwrap()
+    .to_array();
 
     // Filter to keep only 2 lists, demonstrating we keep all 10000 elements.
     let mask = Mask::from_iter([false, true, false, false, true]);

--- a/vortex-array/src/arrays/listview/tests/mod.rs
+++ b/vortex-array/src/arrays/listview/tests/mod.rs
@@ -21,8 +21,9 @@ impl ToListView for ArrayRef {
     }
 }
 
+pub(super) mod common;
+
 mod basic;
-mod common;
 mod filter;
 mod nested;
 mod nullability;

--- a/vortex-array/src/arrays/listview/tests/nested.rs
+++ b/vortex-array/src/arrays/listview/tests/nested.rs
@@ -4,6 +4,7 @@
 use vortex_buffer::buffer;
 use vortex_dtype::{DType, FieldNames, Nullability, PType, StructFields};
 
+use crate::arrays::listview::ListViewShape;
 use crate::arrays::{ListViewArray, ListViewVTable, PrimitiveArray, StructArray};
 use crate::validity::Validity;
 use crate::{Array, IntoArray};
@@ -19,6 +20,7 @@ fn test_listview_of_listview_with_overlapping() {
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8].into_array();
 
     // Create inner ListView where lists overlap:
+    // Logical inner lists: [[1,2,3], [3,4,5], [2,3,4], [6,7,8], [1,2], [7,8]]
     // inner[0]: elements[0..3] = [1, 2, 3]
     // inner[1]: elements[2..5] = [3, 4, 5] (overlaps with inner[0])
     // inner[2]: elements[1..4] = [2, 3, 4] (overlaps with both)
@@ -28,11 +30,19 @@ fn test_listview_of_listview_with_overlapping() {
     let inner_offsets = buffer![0u32, 2, 1, 5, 0, 6].into_array();
     let inner_sizes = buffer![3u32, 3, 3, 3, 2, 2].into_array();
 
-    let inner_listview =
-        ListViewArray::try_new(elements, inner_offsets, inner_sizes, Validity::NonNullable)
-            .unwrap();
+    let inner_listview = ListViewArray::try_new(
+        elements,
+        inner_offsets,
+        inner_sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list()
+            .with_sorted_offsets(false)
+            .with_no_overlaps(false),
+    )
+    .unwrap();
 
     // Create outer ListView that groups the inner lists:
+    // Logical outer lists: [inner[0..3], inner[3..6]]
     // outer[0]: contains inner[0..3] (3 inner lists)
     // outer[1]: contains inner[3..6] (3 inner lists)
     let outer_offsets = buffer![0u32, 3].into_array();
@@ -43,6 +53,7 @@ fn test_listview_of_listview_with_overlapping() {
         outer_offsets,
         outer_sizes,
         Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list(),
     )
     .unwrap();
 
@@ -85,14 +96,22 @@ fn test_deeply_nested_out_of_order() {
 
     // Level 1: ListView with out-of-order offsets.
     // 8 inner lists, accessed in scrambled order.
+    // Logical lists: [[9,10], [1,2], [5,6], [13,14], [3,4], [11,12], [7,8], [15,16]]
     let l1_offsets = buffer![8u32, 0, 4, 12, 2, 10, 6, 14].into_array();
     let l1_sizes = buffer![2u32, 2, 2, 2, 2, 2, 2, 2].into_array();
 
-    let level1 =
-        ListViewArray::try_new(elements, l1_offsets, l1_sizes, Validity::NonNullable).unwrap();
+    let level1 = ListViewArray::try_new(
+        elements,
+        l1_offsets,
+        l1_sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list().with_sorted_offsets(false),
+    )
+    .unwrap();
 
     // Level 2: Group level1 lists, also out-of-order.
     // 4 lists of 2 inner lists each.
+    // Logical lists: [level1[6..8], level1[2..4], level1[0..2], level1[4..6]]
     let l2_offsets = buffer![6u32, 2, 0, 4].into_array();
     let l2_sizes = buffer![2u32, 2, 2, 2].into_array();
 
@@ -101,11 +120,13 @@ fn test_deeply_nested_out_of_order() {
         l2_offsets,
         l2_sizes,
         Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list().with_sorted_offsets(false),
     )
     .unwrap();
 
     // Level 3: Top level groups.
     // 2 lists of 2 level2 lists each.
+    // Logical lists: [level2[2..4], level2[0..2]]
     let l3_offsets = buffer![2u32, 0].into_array();
     let l3_sizes = buffer![2u32, 2].into_array();
 
@@ -114,6 +135,7 @@ fn test_deeply_nested_out_of_order() {
         l3_offsets,
         l3_sizes,
         Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list().with_sorted_offsets(false),
     )
     .unwrap();
 
@@ -152,6 +174,7 @@ fn test_mixed_offset_size_types() {
     let elements = PrimitiveArray::from_iter(0i32..256).into_array();
 
     // Inner ListView with u32 offsets and u16 sizes.
+    // Logical lists: [[0..5], [10..18], [20..30], [30..37], [40..55], [50..70], [100..125], [150..180], [200..250]]
     let inner_offsets = buffer![0u32, 10, 20, 30, 40, 50, 100, 150, 200].into_array();
     let inner_sizes = buffer![5u16, 8, 10, 7, 15, 20, 25, 30, 50].into_array();
 
@@ -160,11 +183,15 @@ fn test_mixed_offset_size_types() {
         inner_offsets.clone(),
         inner_sizes.clone(),
         Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list()
+            .with_no_overlaps(false)
+            .with_no_gaps(false),
     )
     .unwrap();
 
     // Outer ListView with u64 offsets and u8 sizes.
     // Using small sizes that fit in u8 to test the type difference.
+    // Logical lists: [inner[0..3], inner[3..6], inner[6..9]]
     let outer_offsets = buffer![0u64, 3, 6].into_array();
     let outer_sizes = buffer![3u8, 3, 3].into_array();
 
@@ -173,6 +200,7 @@ fn test_mixed_offset_size_types() {
         outer_offsets,
         outer_sizes,
         Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list().with_no_gaps(false),
     )
     .unwrap();
 
@@ -202,6 +230,7 @@ fn test_listview_zero_and_overlapping() {
     let elements = buffer![1i32, 2, 3, 4, 5].into_array();
 
     // Create inner lists with various patterns:
+    // Logical lists: [[], [1,2,3], [], [2,3,4], [5], [], [1,2,3,4,5], []]
     // inner[0]: empty list
     // inner[1]: [1, 2, 3] (normal)
     // inner[2]: empty list
@@ -213,11 +242,19 @@ fn test_listview_zero_and_overlapping() {
     let inner_offsets = buffer![0u32, 0, 3, 1, 4, 0, 0, 2].into_array();
     let inner_sizes = buffer![0u32, 3, 0, 3, 1, 0, 5, 0].into_array();
 
-    let inner_listview =
-        ListViewArray::try_new(elements, inner_offsets, inner_sizes, Validity::NonNullable)
-            .unwrap();
+    let inner_listview = ListViewArray::try_new(
+        elements,
+        inner_offsets,
+        inner_sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list()
+            .with_sorted_offsets(false)
+            .with_no_overlaps(false),
+    )
+    .unwrap();
 
     // Create outer lists that group these:
+    // Logical lists: [inner[0..3], inner[3..6], inner[6..8]]
     // outer[0]: [empty, [1,2,3], empty] - mix of empty and non-empty
     // outer[1]: [[2,3,4], [5], empty] - overlapping and empty
     // outer[2]: [[1,2,3,4,5], empty] - full and empty
@@ -229,6 +266,7 @@ fn test_listview_zero_and_overlapping() {
         outer_offsets,
         outer_sizes,
         Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list().with_no_gaps(false),
     )
     .unwrap();
 
@@ -300,6 +338,7 @@ fn test_listview_of_struct_with_nulls() {
     .unwrap();
 
     // Create ListView of structs with variable sizes and overlapping.
+    // Logical lists: [structs[0..2], structs[1..4], structs[3..6]]
     // list[0]: structs[0..2] - one has null field
     // list[1]: structs[1..4] - one entire struct is null, overlaps with list[0]
     // list[2]: structs[3..6] - one entire struct is null
@@ -311,6 +350,7 @@ fn test_listview_of_struct_with_nulls() {
         offsets,
         sizes,
         Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list().with_no_overlaps(false),
     )
     .unwrap();
 

--- a/vortex-array/src/arrays/listview/tests/nullability.rs
+++ b/vortex-array/src/arrays/listview/tests/nullability.rs
@@ -9,18 +9,27 @@ use vortex_dtype::{DType, Nullability, PType};
 use vortex_scalar::Scalar;
 
 use crate::IntoArray;
+use crate::arrays::listview::ListViewShape;
 use crate::arrays::{BoolArray, ListViewArray, PrimitiveArray};
 use crate::validity::Validity;
 
 #[test]
 fn test_nullable_listview_comprehensive() {
     // Comprehensive test for nullable ListView including scalar_at with nulls.
+    // Logical lists: [[1,2], null, [5,6]]
     let elements = buffer![1i32, 2, 3, 4, 5, 6].into_array();
     let offsets = buffer![0i32, 2, 4].into_array();
     let sizes = buffer![2i32, 2, 2].into_array();
     let validity = Validity::from_iter([true, false, true]);
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, validity).unwrap();
+    let listview = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        validity,
+        ListViewShape::as_zero_copy_to_list(),
+    )
+    .unwrap();
 
     assert_eq!(listview.len(), 3);
 
@@ -74,11 +83,19 @@ fn test_nullable_listview_comprehensive() {
 #[case::all_valid(Validity::AllValid, vec![true, true, true])]
 #[case::mixed(Validity::from_iter([false, true, false]), vec![false, true, false])]
 fn test_nullable_patterns(#[case] validity: Validity, #[case] expected_validity: Vec<bool>) {
+    // Logical lists: [[1,2], [3,4], [5,6]] with varying validity
     let elements = buffer![1i32, 2, 3, 4, 5, 6].into_array();
     let offsets = buffer![0i32, 2, 4].into_array();
     let sizes = buffer![2i32, 2, 2].into_array();
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, validity).unwrap();
+    let listview = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        validity,
+        ListViewShape::default(), // Don't bother checking this in this test.
+    )
+    .unwrap();
 
     for (i, &expected) in expected_validity.iter().enumerate() {
         assert_eq!(listview.is_valid(i), expected);
@@ -88,13 +105,21 @@ fn test_nullable_patterns(#[case] validity: Validity, #[case] expected_validity:
 #[test]
 fn test_nullable_elements() {
     // Test with nullable elements inside the lists.
+    // Logical lists: [[Some(1), None], [Some(3), None], [Some(5), Some(6)]]
     let elements =
         PrimitiveArray::from_option_iter([Some(1i32), None, Some(3), None, Some(5), Some(6)])
             .into_array();
     let offsets = buffer![0i32, 2, 4].into_array();
     let sizes = buffer![2i32, 2, 2].into_array();
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::AllValid).unwrap();
+    let listview = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::AllValid,
+        ListViewShape::as_zero_copy_to_list(),
+    )
+    .unwrap();
 
     // First list: [Some(1), None].
     let first_list = listview.list_elements_at(0);
@@ -125,13 +150,20 @@ fn test_nullable_elements() {
 
 #[test]
 fn test_validity_length_mismatch() {
+    // Logical lists (invalid due to validity length mismatch): [[1,2], [3,4]]
     let elements = buffer![1i32, 2, 3, 4].into_array();
     let offsets = buffer![0i32, 2].into_array();
     let sizes = buffer![2i32, 2].into_array();
     // Wrong length validity.
     let validity = Validity::Array(BoolArray::from_iter(vec![true, false, true]).into_array());
 
-    let result = ListViewArray::try_new(elements, offsets, sizes, validity);
+    let result = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        validity,
+        ListViewShape::as_zero_copy_to_list(),
+    );
 
     assert!(result.is_err());
     let err = result.unwrap_err();

--- a/vortex-array/src/arrays/listview/tests/operations.rs
+++ b/vortex-array/src/arrays/listview/tests/operations.rs
@@ -10,6 +10,7 @@ use vortex_mask::Mask;
 
 use super::ToListView;
 use super::common::{create_basic_listview, create_large_listview, create_nullable_listview};
+use crate::arrays::listview::ListViewShape;
 use crate::arrays::{BoolArray, ConstantArray, ListViewArray, ListViewVTable};
 use crate::compute::conformance::mask::test_mask_conformance;
 use crate::compute::{cast, is_constant, mask};
@@ -23,13 +24,20 @@ use crate::{Array, IntoArray};
 #[test]
 fn test_slice_comprehensive() {
     // Comprehensive test for basic slicing, full array, and single element cases.
+    // Logical lists: [[1,2,3], [4,5], [6,7,8], [9,10]]
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9, 10].into_array();
     let offsets = buffer![0i32, 3, 5, 7].into_array();
     let sizes = buffer![3i32, 2, 3, 2].into_array();
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .into_array();
+    let listview = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list().with_no_overlaps(false),
+    )
+    .unwrap()
+    .into_array();
 
     // Test basic slice [1..3] - middle portion.
     let sliced = listview.slice(1..3);
@@ -65,13 +73,23 @@ fn test_slice_comprehensive() {
 #[test]
 fn test_slice_out_of_order() {
     // ListView-specific: Test slicing with out-of-order offsets.
+    // Logical lists: [[70,80], [10,20,30], [40,50,60], [90], [30]]
     let elements = buffer![10i32, 20, 30, 40, 50, 60, 70, 80, 90].into_array();
     let offsets = buffer![6i32, 0, 3, 8, 2].into_array(); // Out of order.
     let sizes = buffer![2i32, 3, 3, 1, 1].into_array();
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .into_array();
+    let listview = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list()
+            .with_sorted_offsets(false)
+            .with_no_overlaps(false)
+            .with_no_gaps(false),
+    )
+    .unwrap()
+    .into_array();
 
     // Slice [1..4] should maintain the out-of-order offsets.
     let sliced = listview.slice(1..4);
@@ -115,15 +133,22 @@ fn test_slice_out_of_order() {
 #[test]
 fn test_slice_with_nulls() {
     // Test slicing with nullable ListView.
+    // Logical lists: [[1,2], null, [5,6], null]
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8].into_array();
     let offsets = buffer![0i32, 2, 4, 6].into_array();
     let sizes = buffer![2i32, 2, 2, 2].into_array();
     let validity =
         Validity::Array(BoolArray::from_iter(vec![true, false, true, false]).into_array());
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, validity)
-        .unwrap()
-        .into_array();
+    let listview = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        validity,
+        ListViewShape::as_zero_copy_to_list(),
+    )
+    .unwrap()
+    .into_array();
 
     // Slice [1..3] should preserve nulls.
     let sliced = listview.slice(1..3);
@@ -154,9 +179,15 @@ fn test_slice_edge_cases(
     let offsets = buffer![0i32, 2, 4].into_array();
     let sizes = buffer![2i32, 2, 2].into_array();
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .into_array();
+    let listview = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list(),
+    )
+    .unwrap()
+    .into_array();
 
     match expected_len {
         Some(len) => {
@@ -202,9 +233,15 @@ fn test_cast_numeric_types(#[case] from_ptype: PType, #[case] to_ptype: PType) {
         _ => panic!("Unexpected type"),
     };
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list(),
+    )
+    .unwrap()
+    .to_array();
 
     let target_dtype = DType::List(
         Arc::new(DType::Primitive(to_ptype, Nullability::NonNullable)),
@@ -230,14 +267,21 @@ fn test_cast_numeric_types(#[case] from_ptype: PType, #[case] to_ptype: PType) {
 
 #[test]
 fn test_cast_with_nulls() {
+    // Logical lists: [[10,20], null]
     let elements = buffer![10i32, 20, 30, 40].into_array();
     let offsets = buffer![0u32, 2].into_array();
     let sizes = buffer![2u32, 2].into_array();
     let validity = Validity::Array(BoolArray::from_iter(vec![true, false]).into_array());
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, validity)
-        .unwrap()
-        .to_array();
+    let listview = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        validity,
+        ListViewShape::as_zero_copy_to_list(),
+    )
+    .unwrap()
+    .to_array();
 
     let target_dtype = DType::List(
         Arc::new(DType::Primitive(PType::I64, Nullability::NonNullable)),
@@ -274,9 +318,17 @@ fn test_cast_special_patterns(#[case] expected_sizes: Vec<usize>, #[case] list_c
         )
     };
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list()
+            .with_sorted_offsets(false)
+            .with_no_overlaps(false),
+    )
+    .unwrap()
+    .to_array();
 
     let target_dtype = if is_empty_case {
         DType::List(
@@ -303,6 +355,7 @@ fn test_cast_special_patterns(#[case] expected_sizes: Vec<usize>, #[case] list_c
 #[test]
 fn test_cast_large_dataset() {
     // Test with larger data.
+    // Logical lists: [[0..4], [4..8], [8..12], ..., [76..80]] (20 lists of size 4)
     let elements = buffer![0u16..100].into_array();
     let offsets = buffer![
         0u32, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76
@@ -310,9 +363,15 @@ fn test_cast_large_dataset() {
     .into_array();
     let sizes = buffer![4u32; 20].into_array();
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list(),
+    )
+    .unwrap()
+    .to_array();
 
     let target_dtype = DType::List(
         Arc::new(DType::Primitive(PType::U32, Nullability::NonNullable)),
@@ -381,6 +440,7 @@ fn test_is_constant_basic(
         offsets.into_array(),
         sizes.into_array(),
         validity,
+        ListViewShape::as_zero_copy_to_list().with_no_overlaps(false),
     )
     .unwrap()
     .into_array();
@@ -391,13 +451,20 @@ fn test_is_constant_basic(
 #[test]
 fn test_constant_with_constant_elements() {
     // Test with ConstantArray as elements - all lists point to same constant value.
+    // Logical lists: [[42,42], [42,42], [42,42]]
     let elements = ConstantArray::new(42i32, 10).into_array();
     let offsets = buffer![0i32, 2, 4].into_array();
     let sizes = buffer![2i32, 2, 2].into_array();
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .into_array();
+    let listview = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list(),
+    )
+    .unwrap()
+    .into_array();
 
     // All lists contain [42, 42] so should be constant.
     assert_eq!(is_constant(&listview).unwrap(), Some(true));
@@ -406,6 +473,7 @@ fn test_constant_with_constant_elements() {
 #[test]
 fn test_constant_with_nulls() {
     // Test nullable ListView scenarios.
+    // Logical lists: [[1,2], [3,4]] (validity varies by case)
     let elements = buffer![1i32, 2, 3, 4].into_array();
     let offsets = buffer![0i32, 2].into_array();
     let sizes = buffer![2i32, 2].into_array();
@@ -417,6 +485,7 @@ fn test_constant_with_nulls() {
         offsets.clone(),
         sizes.clone(),
         validity_mixed,
+        ListViewShape::as_zero_copy_to_list(),
     )
     .unwrap()
     .into_array();
@@ -429,6 +498,7 @@ fn test_constant_with_nulls() {
         offsets.clone(),
         sizes.clone(),
         validity_all_null,
+        ListViewShape::as_zero_copy_to_list(),
     )
     .unwrap()
     .into_array();
@@ -438,13 +508,20 @@ fn test_constant_with_nulls() {
 #[test]
 fn test_constant_repeated_same_lists() {
     // Test multiple lists that are identical (overlapping).
+    // Logical lists: [[10,20,30], [10,20,30], [10,20,30], [10,20,30]]
     let elements = buffer![10i32, 20, 30].into_array();
     let offsets = buffer![0i32, 0, 0, 0].into_array(); // All point to same start.
     let sizes = buffer![3i32, 3, 3, 3].into_array(); // All same size.
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .into_array();
+    let listview = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list().with_no_overlaps(false),
+    )
+    .unwrap()
+    .into_array();
 
     // All lists are [10, 20, 30] so should be constant.
     assert_eq!(is_constant(&listview).unwrap(), Some(true));
@@ -466,13 +543,20 @@ fn test_mask_listview_conformance(#[case] listview: ListViewArray) {
 #[test]
 fn test_mask_preserves_structure() {
     // ListView-specific: Verify mask preserves offsets and sizes.
+    // Logical lists: [[1,2], [3,4], [5,6], [7,8]]
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8].into_array();
     let offsets = buffer![0u32, 2, 4, 6].into_array();
     let sizes = buffer![2u32, 2, 2, 2].into_array();
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list(),
+    )
+    .unwrap()
+    .to_array();
 
     // Mask sets elements to null where true.
     let selection = Mask::from_iter([true, false, true, true]);
@@ -501,14 +585,21 @@ fn test_mask_preserves_structure() {
 #[test]
 fn test_mask_with_existing_nulls() {
     // ListView-specific: Test interaction between existing nulls and mask.
+    // Logical lists: [[10,20], null, [50,60]]
     let elements = buffer![10i32, 20, 30, 40, 50, 60].into_array();
     let offsets = buffer![0u32, 2, 4].into_array();
     let sizes = buffer![2u32, 2, 2].into_array();
     let validity = Validity::Array(BoolArray::from_iter(vec![true, false, true]).into_array());
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, validity)
-        .unwrap()
-        .to_array();
+    let listview = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        validity,
+        ListViewShape::as_zero_copy_to_list(),
+    )
+    .unwrap()
+    .to_array();
 
     // Mask additional elements.
     let selection = Mask::from_iter([false, true, true]);
@@ -524,13 +615,20 @@ fn test_mask_with_existing_nulls() {
 #[test]
 fn test_mask_with_gaps() {
     // ListView-specific: Mask with gaps in elements.
+    // Logical lists: [[1,2], [5,6], [9,10]] (999 values are gaps)
     let elements = buffer![1i32, 2, 999, 999, 5, 6, 999, 999, 9, 10].into_array();
     let offsets = buffer![0u32, 4, 8].into_array();
     let sizes = buffer![2u32, 2, 2].into_array();
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview = ListViewArray::try_new(
+        elements,
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list().with_no_gaps(false),
+    )
+    .unwrap()
+    .to_array();
 
     let selection = Mask::from_iter([true, false, false]);
     let result = mask(&listview, &selection).unwrap();
@@ -549,6 +647,7 @@ fn test_mask_with_gaps() {
 #[test]
 fn test_mask_constant_arrays() {
     // ListView-specific: Test mask with ConstantArray offsets/sizes.
+    // Logical lists: [[200,300], [200,300], [200,300]]
     let elements = buffer![100i32, 200, 300, 400, 500, 600].into_array();
 
     // All lists start at offset 1 and have size 2.
@@ -560,6 +659,7 @@ fn test_mask_constant_arrays() {
         constant_offsets,
         constant_sizes,
         Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list().with_no_overlaps(false),
     )
     .unwrap()
     .to_array();

--- a/vortex-array/src/arrays/listview/tests/take.rs
+++ b/vortex-array/src/arrays/listview/tests/take.rs
@@ -9,6 +9,7 @@ use super::common::{
     create_basic_listview, create_empty_lists_listview, create_large_listview,
     create_nullable_listview, create_overlapping_listview,
 };
+use crate::arrays::listview::ListViewShape;
 use crate::arrays::{ConstantArray, ListViewArray, PrimitiveArray};
 use crate::compute::conformance::take::test_take_conformance;
 use crate::compute::take;
@@ -37,9 +38,17 @@ fn test_take_preserves_unreferenced_elements() {
     let offsets = buffer![5u32, 2, 8, 0, 1].into_array();
     let sizes = buffer![3u32, 2, 2, 2, 4].into_array();
 
-    let listview = ListViewArray::try_new(elements.clone(), offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview = ListViewArray::try_new(
+        elements.clone(),
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list()
+            .with_sorted_offsets(false)
+            .with_no_overlaps(false),
+    )
+    .unwrap()
+    .to_array();
 
     // Take only 2 lists.
     let indices = buffer![1u32, 3].into_array();
@@ -68,9 +77,18 @@ fn test_take_with_gaps() {
     let offsets = buffer![0u32, 6, 10, 1, 7].into_array();
     let sizes = buffer![3u32, 3, 2, 2, 2].into_array();
 
-    let listview = ListViewArray::try_new(elements.clone(), offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview = ListViewArray::try_new(
+        elements.clone(),
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list()
+            .with_sorted_offsets(false)
+            .with_no_overlaps(false)
+            .with_no_gaps(false),
+    )
+    .unwrap()
+    .to_array();
 
     let indices = buffer![1u32, 3, 4, 2].into_array();
     let result = take(&listview, &indices).unwrap();
@@ -104,6 +122,7 @@ fn test_take_constant_arrays() {
         constant_offsets,
         varying_sizes,
         Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list().with_no_overlaps(false),
     )
     .unwrap()
     .to_array();
@@ -129,6 +148,7 @@ fn test_take_constant_arrays() {
         both_constant_offsets,
         both_constant_sizes,
         Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list().with_no_overlaps(false),
     )
     .unwrap()
     .to_array();
@@ -154,9 +174,17 @@ fn test_take_extreme_offsets() {
     let offsets = buffer![0u32, 4999, 9995, 2500, 7500].into_array();
     let sizes = buffer![5u32, 2, 5, 3, 4].into_array();
 
-    let listview = ListViewArray::try_new(elements.clone(), offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview = ListViewArray::try_new(
+        elements.clone(),
+        offsets,
+        sizes,
+        Validity::NonNullable,
+        ListViewShape::as_zero_copy_to_list()
+            .with_sorted_offsets(false)
+            .with_no_gaps(false),
+    )
+    .unwrap()
+    .to_array();
 
     // Take only 2 lists, demonstrating we keep all 10000 elements.
     let indices = buffer![1u32, 4].into_array();

--- a/vortex-array/src/arrays/listview/vtable/operations.rs
+++ b/vortex-array/src/arrays/listview/vtable/operations.rs
@@ -7,13 +7,26 @@ use std::sync::Arc;
 use vortex_scalar::Scalar;
 
 use crate::arrays::{ListViewArray, ListViewVTable};
-use crate::vtable::OperationsVTable;
+use crate::vtable::{OperationsVTable, ValidityHelper};
 use crate::{ArrayRef, IntoArray};
 
 impl OperationsVTable<ListViewVTable> for ListViewVTable {
     fn slice(array: &ListViewArray, range: Range<usize>) -> ArrayRef {
         let start = range.start;
         let end = range.end;
+
+        // We implement slice by simply slicing the views. We leave the child `elements` array alone
+        // since slicing could potentially require calculating which elements are referenced by the
+        // new set of views.
+
+        // If the listview has out-of-order offsets, it is possible that slicing can cause gaps to
+        // appear (parts of `elements` can become unused). But if the offsets are sorted, then the
+        // status of `has_no_gaps` does not change.
+        let new_shape = if !array.shape().has_sorted_offsets() {
+            array.shape().with_sorted_offsets(false).with_no_gaps(false)
+        } else {
+            array.shape()
+        };
 
         // SAFETY: The preconditions of `slice` mean that the bounds have already been checked, and
         // slicing the components of an existing valid array is still valid.
@@ -22,7 +35,8 @@ impl OperationsVTable<ListViewVTable> for ListViewVTable {
                 array.elements().clone(),
                 array.offsets().slice(start..end),
                 array.sizes().slice(start..end),
-                array.validity.slice(start..end),
+                array.validity().slice(start..end),
+                new_shape,
             )
         }
         .into_array()

--- a/vortex-array/src/arrays/listview/vtable/serde.rs
+++ b/vortex-array/src/arrays/listview/vtable/serde.rs
@@ -5,7 +5,7 @@ use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, Nullability, PType};
 use vortex_error::{VortexResult, vortex_bail, vortex_ensure};
 
-use crate::arrays::{ListViewArray, ListViewEncoding, ListViewVTable};
+use crate::arrays::{ListViewArray, ListViewEncoding, ListViewShape, ListViewVTable};
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
 use crate::vtable::SerdeVTable;
@@ -19,16 +19,26 @@ pub struct ListViewMetadata {
     offset_ptype: i32,
     #[prost(enumeration = "PType", tag = "3")]
     size_ptype: i32,
+    #[prost(bool, tag = "4", default = false)]
+    has_sorted_offsets: bool,
+    #[prost(bool, tag = "5", default = false)]
+    has_no_overlaps: bool,
+    #[prost(bool, tag = "6", default = false)]
+    has_no_gaps: bool,
 }
 
 impl SerdeVTable<ListViewVTable> for ListViewVTable {
     type Metadata = ProstMetadata<ListViewMetadata>;
 
     fn metadata(array: &ListViewArray) -> VortexResult<Option<Self::Metadata>> {
+        let shape = array.shape();
         Ok(Some(ProstMetadata(ListViewMetadata {
             elements_len: array.elements().len() as u64,
             offset_ptype: PType::try_from(array.offsets().dtype())? as i32,
             size_ptype: PType::try_from(array.sizes().dtype())? as i32,
+            has_sorted_offsets: shape.has_sorted_offsets(),
+            has_no_overlaps: shape.has_no_overlaps(),
+            has_no_gaps: shape.has_no_gaps(),
         })))
     }
 
@@ -82,6 +92,13 @@ impl SerdeVTable<ListViewVTable> for ListViewVTable {
             len,
         )?;
 
-        ListViewArray::try_new(elements, offsets, sizes, validity)
+        // Extract shape from metadata.
+        let shape = ListViewShape::new(
+            metadata.has_sorted_offsets,
+            metadata.has_no_overlaps,
+            metadata.has_no_gaps,
+        );
+
+        ListViewArray::try_new(elements, offsets, sizes, validity, shape)
     }
 }

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -17,7 +17,7 @@ use vortex_scalar::{ListScalar, Scalar};
 
 use super::lazy_null_builder::LazyNullBufferBuilder;
 use crate::array::{Array, ArrayRef, IntoArray};
-use crate::arrays::{ListViewArray, list_view_from_list};
+use crate::arrays::{ListViewArray, ListViewShape, list_view_from_list};
 use crate::builders::{
     ArrayBuilder, DEFAULT_BUILDER_CAPACITY, PrimitiveBuilder, builder_with_capacity,
 };
@@ -150,7 +150,11 @@ impl<O: IntegerPType, S: IntegerPType> ListViewBuilder<O, S> {
         let sizes = self.sizes_builder.finish();
         let validity = self.nulls.finish_with_nullability(self.dtype.nullability());
 
-        ListViewArray::try_new(elements, offsets, sizes, validity)
+        // Because we built the `ListViewArray` up list by list, and we did not create any overlaps
+        // or gaps, we can guarantee that this is zero-copyable to `ListArray`.
+        let shape = ListViewShape::as_zero_copy_to_list();
+
+        ListViewArray::try_new(elements, offsets, sizes, validity, shape)
             .vortex_expect("Failed to create ListViewArray")
     }
 


### PR DESCRIPTION
Tracking Issue: https://github.com/vortex-data/vortex/issues/4699

Adds `ListViewShape` and more `ListViewRebuildMode` variants and functionality. Additionally adds a `list_from_list_view` function and tests.

The main goal of these changes is to allow us to rebuild the `ListViewArray`s to have a similar shape as our `ListArray`s. There are no benchmarks here yet since we have yet to make `ListView` the canonical encoding for `List` (the next and probably last PR for `ListView`), but the hope here is that by adding this functionality now we can mimic the behavior of `ListArray` in benchmarks, meaning we won't have a regression.