### PR TITLE
Use DataFusion's FilePruner to prune files based on stats and partition values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6585,6 +6585,7 @@ dependencies = [
  "datafusion-physical-expr-adapter",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
+ "datafusion-pruning",
  "futures",
  "itertools 0.14.0",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ datafusion-physical-expr = { version = "50" }
 datafusion-physical-expr-adapter = { version = "50" }
 datafusion-physical-expr-common = { version = "50" }
 datafusion-physical-plan = { version = "50" }
+datafusion-pruning = { version = "50" }
 dirs = "6.0.0"
 divan = { package = "codspeed-divan-compat", version = "3.0" }
 dyn-hash = "0.2.0"

--- a/vortex-datafusion/Cargo.toml
+++ b/vortex-datafusion/Cargo.toml
@@ -27,6 +27,7 @@ datafusion-physical-expr = { workspace = true }
 datafusion-physical-expr-adapter = { workspace = true }
 datafusion-physical-expr-common = { workspace = true }
 datafusion-physical-plan = { workspace = true }
+datafusion-pruning = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -13,6 +13,9 @@ use datafusion_datasource::{FileRange, PartitionedFile};
 use datafusion_physical_expr::simplifier::PhysicalExprSimplifier;
 use datafusion_physical_expr::{PhysicalExprRef, split_conjunction};
 use datafusion_physical_expr_adapter::PhysicalExprAdapterFactory;
+use datafusion_physical_expr_common::physical_expr::is_dynamic_physical_expr;
+use datafusion_physical_plan::metrics::Count;
+use datafusion_pruning::FilePruner;
 use futures::{FutureExt, StreamExt, TryStreamExt, stream};
 use object_store::ObjectStore;
 use object_store::path::Path;
@@ -74,6 +77,30 @@ impl FileOpener for VortexOpener {
             .create(projected_schema, logical_schema.clone());
 
         Ok(async move {
+            let mut file_pruner = filter
+                .as_ref()
+                .map(|predicate| {
+                    Ok::<_, DataFusionError>(
+                        (is_dynamic_physical_expr(predicate) | file.has_statistics()).then_some(
+                            FilePruner::new(
+                                predicate.clone(),
+                                &logical_schema,
+                                partition_fields.clone(),
+                                file.clone(),
+                                Count::default(),
+                            )?,
+                        ),
+                    )
+                })
+                .transpose()?
+                .flatten();
+
+            if let Some(file_pruner) = &mut file_pruner
+                && file_pruner.should_prune()?
+            {
+                return Ok(stream::empty().boxed());
+            }
+
             let vxf = file_cache
                 .try_get(&file_meta.object_meta, object_store)
                 .await


### PR DESCRIPTION
Just took it out of the Parquet datasource implementation. Some local experimentation shows that it should improve clickbench perf by a bit, which is exciting.