### PR TITLE
binary view debug impl

### DIFF
--- a/vortex-array/src/arrays/varbinview/mod.rs
+++ b/vortex-array/src/arrays/varbinview/mod.rs
@@ -284,9 +284,9 @@ impl Debug for BinaryView {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut s = f.debug_struct("BinaryView");
         if self.is_inlined() {
-            s.field("inline", &"i".to_string());
+            s.field("inline", &self.as_inlined());
         } else {
-            s.field("ref", &"r".to_string());
+            s.field("ref", &self.as_view());
         }
         s.finish()
     }


### PR DESCRIPTION
I think this was changed way before at https://github.com/vortex-data/vortex/pull/1082 , I don't think we use this on any tests, and I needed to see what the references are during working on varbinviews recently