### PR TITLE
Use the original DataFusion provided predicate to dynamically prune files

### DIFF
--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -36,7 +36,13 @@ pub(crate) struct VortexOpener {
     pub object_store: Arc<dyn ObjectStore>,
     /// Projection by index of the file's columns
     pub projection: Option<Arc<[usize]>>,
+    /// Filter expression optimized for pushdown into Vortex scan operations.
+    /// This may be a subset of file_pruning_predicate containing only expressions
+    /// that Vortex can efficiently evaluate.
     pub filter: Option<PhysicalExprRef>,
+    /// Filter expression used by DataFusion's FilePruner to eliminate files based on
+    /// statistics and partition values without opening them.
+    pub file_pruning_predicate: Option<PhysicalExprRef>,
     pub expr_adapter_factory: Option<Arc<dyn PhysicalExprAdapterFactory>>,
     pub schema_adapter_factory: Arc<dyn SchemaAdapterFactory>,
     /// Hive-style partitioning columns
@@ -56,6 +62,7 @@ impl FileOpener for VortexOpener {
         let object_store = self.object_store.clone();
         let projection = self.projection.clone();
         let mut filter = self.filter.clone();
+        let file_pruning_predicate = self.file_pruning_predicate.clone();
         let expr_adapter_factory = self.expr_adapter_factory.clone();
         let partition_fields = self.partition_fields.clone();
         let file_cache = self.file_cache.clone();
@@ -77,11 +84,17 @@ impl FileOpener for VortexOpener {
             .create(projected_schema, logical_schema.clone());
 
         Ok(async move {
-            let mut file_pruner = filter
-                .as_ref()
+            // Create FilePruner when we have a predicate and either dynamic expressions
+            // or file statistics available. The pruner can eliminate files without
+            // opening them based on:
+            // - Partition column values (e.g., date=2024-01-01)
+            // - File-level statistics (min/max values per column)
+            let mut file_pruner = file_pruning_predicate
                 .map(|predicate| {
+                    // Only create pruner if we have dynamic expressions or file statistics
+                    // to work with. Static predicates without stats won't benefit from pruning.
                     Ok::<_, DataFusionError>(
-                        (is_dynamic_physical_expr(predicate) | file.has_statistics()).then_some(
+                        (is_dynamic_physical_expr(&predicate) | file.has_statistics()).then_some(
                             FilePruner::new(
                                 predicate.clone(),
                                 &logical_schema,
@@ -95,6 +108,8 @@ impl FileOpener for VortexOpener {
                 .transpose()?
                 .flatten();
 
+            // Check if this file should be pruned based on statistics/partition values.
+            // Returns empty stream if file can be skipped entirely.
             if let Some(file_pruner) = &mut file_pruner
                 && file_pruner.should_prune()?
             {
@@ -407,6 +422,7 @@ mod tests {
             object_store: object_store.clone(),
             projection: Some([0].into()),
             filter: Some(filter),
+            file_pruning_predicate: None,
             expr_adapter_factory: expr_adapter_factory.clone(),
             schema_adapter_factory: Arc::new(DefaultSchemaAdapterFactory),
             partition_fields: vec![Arc::new(Field::new("part", DataType::Int32, false))],
@@ -486,6 +502,7 @@ mod tests {
             object_store: object_store.clone(),
             projection: Some([0].into()),
             filter: Some(filter),
+            file_pruning_predicate: None,
             expr_adapter_factory: expr_adapter_factory.clone(),
             schema_adapter_factory: Arc::new(DefaultSchemaAdapterFactory),
             partition_fields: vec![],

--- a/vortex-datafusion/src/persistent/source.rs
+++ b/vortex-datafusion/src/persistent/source.rs
@@ -41,7 +41,12 @@ use crate::convert::exprs::can_be_pushed_down;
 #[derive(Clone)]
 pub struct VortexSource {
     pub(crate) file_cache: VortexFileCache,
-    pub(crate) predicate: Option<PhysicalExprRef>,
+    /// Combined predicate expression containing all filters from DataFusion query planning.
+    /// Used with FilePruner to skip files based on statistics and partition values.
+    pub(crate) full_predicate: Option<PhysicalExprRef>,
+    /// Subset of predicates that can be pushed down into Vortex scan operations.
+    /// These are expressions that Vortex can efficiently evaluate during scanning.
+    pub(crate) vortex_predicate: Option<PhysicalExprRef>,
     pub(crate) batch_size: Option<usize>,
     pub(crate) projected_statistics: Option<Statistics>,
     /// This is the file schema the table expects, which is the table's schema without partition columns, and **not** the file's physical schema.
@@ -61,7 +66,8 @@ impl VortexSource {
         Self {
             file_cache,
             metrics,
-            predicate: None,
+            full_predicate: None,
+            vortex_predicate: None,
             batch_size: None,
             projected_statistics: None,
             arrow_file_schema: None,
@@ -131,7 +137,8 @@ impl FileSource for VortexSource {
         let opener = VortexOpener {
             object_store,
             projection,
-            filter: self.predicate.clone(),
+            filter: self.vortex_predicate.clone(),
+            file_pruning_predicate: self.full_predicate.clone(),
             expr_adapter_factory,
             schema_adapter_factory,
             partition_fields: base_config.table_partition_cols.clone(),
@@ -182,7 +189,7 @@ impl FileSource for VortexSource {
             .clone()
             .vortex_expect("projected_statistics must be set");
 
-        if self.predicate.is_some() {
+        if self.vortex_predicate.is_some() {
             Ok(statistics.to_inexact())
         } else {
             Ok(statistics)
@@ -196,13 +203,13 @@ impl FileSource for VortexSource {
     fn fmt_extra(&self, t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
-                if let Some(ref predicate) = self.predicate {
+                if let Some(ref predicate) = self.vortex_predicate {
                     write!(f, ", predicate: {predicate}")?;
                 }
             }
             // Use TreeRender style key=value formatting to display the predicate
             DisplayFormatType::TreeRender => {
-                if let Some(ref predicate) = self.predicate {
+                if let Some(ref predicate) = self.vortex_predicate {
                     writeln!(f, "predicate={}", fmt_sql(predicate.as_ref()))?;
                 };
             }
@@ -223,7 +230,16 @@ impl FileSource for VortexSource {
 
         let mut source = self.clone();
 
-        let filters = filters
+        // Combine new filters with existing predicate for file pruning.
+        // This full predicate is used by FilePruner to eliminate files.
+        source.full_predicate = match source.full_predicate {
+            Some(predicate) => Some(conjunction(
+                std::iter::once(predicate).chain(filters.clone()),
+            )),
+            None => Some(conjunction(filters.clone())),
+        };
+
+        let supported_filters = filters
             .into_iter()
             .map(|expr| {
                 if can_be_pushed_down(&expr, schema) {
@@ -234,16 +250,16 @@ impl FileSource for VortexSource {
             })
             .collect::<Vec<_>>();
 
-        if filters
+        if supported_filters
             .iter()
             .all(|p| matches!(p.discriminant, PushedDown::No))
         {
             return Ok(FilterPushdownPropagation::with_parent_pushdown_result(
-                vec![PushedDown::No; filters.len()],
+                vec![PushedDown::No; supported_filters.len()],
             ));
         }
 
-        let supported = filters
+        let supported = supported_filters
             .iter()
             .filter_map(|p| match p.discriminant {
                 PushedDown::Yes => Some(&p.predicate),
@@ -251,24 +267,24 @@ impl FileSource for VortexSource {
             })
             .cloned();
 
-        let predicate = match source.predicate {
+        let predicate = match source.vortex_predicate {
             Some(predicate) => conjunction(std::iter::once(predicate).chain(supported)),
             None => conjunction(supported),
         };
 
         tracing::debug!(%predicate, "Saving predicate");
 
-        source.predicate = Some(predicate);
+        source.vortex_predicate = Some(predicate);
 
-        let pushdown_propagation = if source.predicate.clone().is_some() {
+        let pushdown_propagation = if source.vortex_predicate.clone().is_some() {
             FilterPushdownPropagation::with_parent_pushdown_result(
-                filters.iter().map(|f| f.discriminant).collect(),
+                supported_filters.iter().map(|f| f.discriminant).collect(),
             )
             .with_updated_node(Arc::new(source) as _)
         } else {
             FilterPushdownPropagation::with_parent_pushdown_result(vec![
                 PushedDown::No;
-                filters.len()
+                supported_filters.len()
             ])
         };
 

--- a/vortex-datafusion/src/persistent/source.rs
+++ b/vortex-datafusion/src/persistent/source.rs
@@ -256,7 +256,8 @@ impl FileSource for VortexSource {
         {
             return Ok(FilterPushdownPropagation::with_parent_pushdown_result(
                 vec![PushedDown::No; supported_filters.len()],
-            ));
+            )
+            .with_updated_node(Arc::new(source) as _));
         }
 
         let supported = supported_filters
@@ -276,19 +277,10 @@ impl FileSource for VortexSource {
 
         source.vortex_predicate = Some(predicate);
 
-        let pushdown_propagation = if source.vortex_predicate.clone().is_some() {
-            FilterPushdownPropagation::with_parent_pushdown_result(
-                supported_filters.iter().map(|f| f.discriminant).collect(),
-            )
-            .with_updated_node(Arc::new(source) as _)
-        } else {
-            FilterPushdownPropagation::with_parent_pushdown_result(vec![
-                PushedDown::No;
-                supported_filters.len()
-            ])
-        };
-
-        Ok(pushdown_propagation)
+        Ok(FilterPushdownPropagation::with_parent_pushdown_result(
+            supported_filters.iter().map(|f| f.discriminant).collect(),
+        )
+        .with_updated_node(Arc::new(source) as _))
     }
 
     fn with_schema_adapter_factory(


### PR DESCRIPTION
The biggest benefit here would be that it allows us to take advantage of dynamic filter expressions without pushing them fully into our scan.