### PR TITLE
wider tables in compress bench

### DIFF
--- a/bench-vortex/src/bin/compress.rs
+++ b/bench-vortex/src/bin/compress.rs
@@ -78,12 +78,12 @@ fn compress(
         .collect_vec();
 
     let structlistofints = vec![
-        StructListOfInts::new(10, 1000, 1),
         StructListOfInts::new(100, 1000, 1),
         StructListOfInts::new(1000, 1000, 1),
-        StructListOfInts::new(10, 1000, 50),
+        StructListOfInts::new(10000, 1000, 1),
         StructListOfInts::new(100, 1000, 50),
         StructListOfInts::new(1000, 1000, 50),
+        StructListOfInts::new(10000, 1000, 50),
     ];
     let datasets: Vec<&dyn Dataset> = [
         &TaxiData as &dyn Dataset,


### PR DESCRIPTION
removed 10 column example and added a 10k column example. 10 cols 1000 rows is small and noisy to measure, and the widest we had before, 1000 columns, is not wide enough to capture perf differences between us and parquet. (parquet is faster currently for wider tables, which I am addressing)