### PR TITLE
cheaper StructArray::clone

### DIFF
--- a/vortex-array/src/array/display/mod.rs
+++ b/vortex-array/src/array/display/mod.rs
@@ -274,7 +274,7 @@ impl dyn Array + '_ {
                         builder.push_record(null_row);
                     } else {
                         let mut row = Vec::new();
-                        for field_array in struct_.fields() {
+                        for field_array in struct_.fields().iter() {
                             let value = field_array.scalar_at(row_idx);
                             row.push(value.to_string());
                         }

--- a/vortex-array/src/arrays/struct_/array.rs
+++ b/vortex-array/src/arrays/struct_/array.rs
@@ -141,8 +141,8 @@ pub struct StructArray {
 }
 
 impl StructArray {
-    pub fn fields(&self) -> &[ArrayRef] {
-        &self.fields
+    pub fn fields(&self) -> Arc<[ArrayRef]> {
+        self.fields.clone()
     }
 
     pub fn field_by_name(&self, name: impl AsRef<str>) -> VortexResult<&ArrayRef> {
@@ -378,6 +378,7 @@ impl StructArray {
         let mut children = Vec::with_capacity(projection.len());
         let mut names = Vec::with_capacity(projection.len());
 
+        let fields = self.fields();
         for f_name in projection.iter() {
             let idx = self
                 .names()
@@ -386,7 +387,7 @@ impl StructArray {
                 .ok_or_else(|| vortex_err!("Unknown field {f_name}"))?;
 
             names.push(self.names()[idx].clone());
-            children.push(self.fields()[idx].clone());
+            children.push(fields[idx].clone());
         }
 
         StructArray::try_new(
@@ -409,10 +410,7 @@ impl StructArray {
             .iter()
             .position(|field_name| field_name.as_ref() == name.as_ref())?;
 
-        // Get the field being removed (clone it since we need to return it)
         let field = self.fields[position].clone();
-
-        // Reconstruct the Arc without the removed field
         let new_fields: Arc<[ArrayRef]> = self
             .fields
             .iter()

--- a/vortex-array/src/arrays/struct_/array.rs
+++ b/vortex-array/src/arrays/struct_/array.rs
@@ -3,6 +3,7 @@
 
 use std::fmt::Debug;
 use std::iter::once;
+use std::sync::Arc;
 
 use vortex_dtype::{DType, FieldName, FieldNames, StructFields};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
@@ -134,7 +135,7 @@ use crate::{Array, ArrayRef, IntoArray};
 pub struct StructArray {
     pub(super) len: usize,
     pub(super) dtype: DType,
-    pub(super) fields: Vec<ArrayRef>,
+    pub(super) fields: Arc<[ArrayRef]>,
     pub(super) validity: Validity,
     pub(super) stats_set: ArrayStats,
 }
@@ -191,7 +192,7 @@ impl StructArray {
     /// in [`StructArray::new_unchecked`].
     pub fn new(
         names: FieldNames,
-        fields: Vec<ArrayRef>,
+        fields: impl Into<Arc<[ArrayRef]>>,
         length: usize,
         validity: Validity,
     ) -> Self {
@@ -209,10 +210,11 @@ impl StructArray {
     /// [`StructArray::new_unchecked`].
     pub fn try_new(
         names: FieldNames,
-        fields: Vec<ArrayRef>,
+        fields: impl Into<Arc<[ArrayRef]>>,
         length: usize,
         validity: Validity,
     ) -> VortexResult<Self> {
+        let fields = fields.into();
         let field_dtypes: Vec<_> = fields.iter().map(|d| d.dtype()).cloned().collect();
         let dtype = StructFields::new(names, field_dtypes);
 
@@ -248,11 +250,13 @@ impl StructArray {
     ///
     /// - If `validity` is [`Validity::Array`], its length must exactly equal `length`.
     pub unsafe fn new_unchecked(
-        fields: Vec<ArrayRef>,
+        fields: impl Into<Arc<[ArrayRef]>>,
         dtype: StructFields,
         length: usize,
         validity: Validity,
     ) -> Self {
+        let fields = fields.into();
+
         #[cfg(debug_assertions)]
         Self::validate(&fields, &dtype, length, &validity)
             .vortex_expect("[Debug Assertion]: Invalid `StructArray` parameters");
@@ -320,11 +324,12 @@ impl StructArray {
     }
 
     pub fn try_new_with_dtype(
-        fields: Vec<ArrayRef>,
+        fields: impl Into<Arc<[ArrayRef]>>,
         dtype: StructFields,
         length: usize,
         validity: Validity,
     ) -> VortexResult<Self> {
+        let fields = fields.into();
         Self::validate(&fields, &dtype, length, &validity)?;
 
         // SAFETY: validate ensures all invariants are met.
@@ -404,9 +409,20 @@ impl StructArray {
             .iter()
             .position(|field_name| field_name.as_ref() == name.as_ref())?;
 
-        let field = self.fields.remove(position);
+        // Get the field being removed (clone it since we need to return it)
+        let field = self.fields[position].clone();
+
+        // Reconstruct the Arc without the removed field
+        let new_fields: Arc<[ArrayRef]> = self
+            .fields
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != position)
+            .map(|(_, f)| f.clone())
+            .collect();
 
         if let Ok(new_dtype) = struct_dtype.without_field(position) {
+            self.fields = new_fields;
             self.dtype = DType::Struct(new_dtype, self.dtype.nullability());
             return Some(field);
         }
@@ -422,8 +438,7 @@ impl StructArray {
         let types = struct_dtype.fields().chain(once(array.dtype().clone()));
         let new_fields = StructFields::new(names.collect(), types.collect());
 
-        let mut children = self.fields.clone();
-        children.push(array);
+        let children: Arc<[ArrayRef]> = self.fields.iter().cloned().chain(once(array)).collect();
 
         Self::try_new_with_dtype(children, new_fields, self.len, self.validity.clone())
     }

--- a/vortex-array/src/arrays/struct_/compute/cast.rs
+++ b/vortex-array/src/arrays/struct_/compute/cast.rs
@@ -37,7 +37,7 @@ impl CastKernel for StructVTable {
                 .iter()
                 .zip_eq(target_sdtype.fields())
                 .map(|(field, dtype)| cast(field, &dtype))
-                .try_collect()?,
+                .collect::<Result<Vec<_>, _>>()?,
             array.len(),
             validity,
         )

--- a/vortex-array/src/arrays/struct_/compute/mask.rs
+++ b/vortex-array/src/arrays/struct_/compute/mask.rs
@@ -14,7 +14,7 @@ impl MaskKernel for StructVTable {
         let validity = array.validity().mask(filter_mask);
 
         StructArray::try_new_with_dtype(
-            array.fields().to_vec(),
+            array.fields(),
             array.struct_fields().clone(),
             array.len(),
             validity,

--- a/vortex-array/src/arrays/struct_/compute/mod.rs
+++ b/vortex-array/src/arrays/struct_/compute/mod.rs
@@ -6,7 +6,6 @@ mod filter;
 mod mask;
 mod zip;
 
-use itertools::Itertools;
 use vortex_dtype::Nullability::NonNullable;
 use vortex_error::VortexResult;
 use vortex_scalar::Scalar;
@@ -44,7 +43,7 @@ impl TakeKernel for StructVTable {
                 .fields()
                 .iter()
                 .map(|field| take(field, inner_indices))
-                .try_collect()?,
+                .collect::<Result<Vec<_>, _>>()?,
             array.struct_fields().clone(),
             indices.len(),
             array.validity().take(indices)?,

--- a/vortex-array/src/arrays/struct_/compute/mod.rs
+++ b/vortex-array/src/arrays/struct_/compute/mod.rs
@@ -26,7 +26,7 @@ impl TakeKernel for StructVTable {
         // an out of bounds element
         if array.is_empty() {
             return StructArray::try_new_with_dtype(
-                array.fields().to_vec(),
+                array.fields(),
                 array.struct_fields().clone(),
                 indices.len(),
                 Validity::AllInvalid,

--- a/vortex-array/src/arrays/struct_/vtable/pipeline.rs
+++ b/vortex-array/src/arrays/struct_/vtable/pipeline.rs
@@ -18,7 +18,7 @@ use crate::operator::{
 };
 use crate::validity::Validity;
 use crate::vtable::PipelineVTable;
-use crate::{Array, Canonical, IntoArray};
+use crate::{Array, ArrayRef, Canonical, IntoArray};
 
 impl PipelineVTable<StructVTable> for StructVTable {
     fn to_operator(array: &StructArray) -> VortexResult<Option<OperatorRef>> {
@@ -168,7 +168,7 @@ impl BatchExecution for StructExecution {
     async fn execute(self: Box<Self>) -> VortexResult<Canonical> {
         let children: Vec<_> =
             try_join_all(self.children.into_iter().map(|child| child.execute())).await?;
-        let children = children
+        let children: Vec<ArrayRef> = children
             .into_iter()
             .map(|canonical| canonical.into_array())
             .collect();

--- a/vortex-array/src/arrays/struct_/vtable/pipeline.rs
+++ b/vortex-array/src/arrays/struct_/vtable/pipeline.rs
@@ -23,7 +23,7 @@ use crate::{Array, ArrayRef, Canonical, IntoArray};
 impl PipelineVTable<StructVTable> for StructVTable {
     fn to_operator(array: &StructArray) -> VortexResult<Option<OperatorRef>> {
         let mut children = Vec::with_capacity(array.fields.len());
-        for field in array.fields() {
+        for field in array.fields().iter() {
             if let Some(operator) = field.to_operator()? {
                 children.push(operator);
             } else {

--- a/vortex-array/src/arrays/struct_/vtable/serde.rs
+++ b/vortex-array/src/arrays/struct_/vtable/serde.rs
@@ -46,7 +46,7 @@ impl SerdeVTable<StructVTable> for StructVTable {
             );
         };
 
-        let children = (0..struct_dtype.nfields())
+        let children: Vec<_> = (0..struct_dtype.nfields())
             .map(|i| {
                 let child_dtype = struct_dtype
                     .field_by_index(i)

--- a/vortex-array/src/arrays/struct_/vtable/visitor.rs
+++ b/vortex-array/src/arrays/struct_/vtable/visitor.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use itertools::Itertools;
+
 use crate::arrays::struct_::{StructArray, StructVTable};
 use crate::vtable::{ValidityHelper, VisitorVTable};
 use crate::{ArrayBufferVisitor, ArrayChildVisitor};
@@ -10,8 +12,8 @@ impl VisitorVTable<StructVTable> for StructVTable {
 
     fn visit_children(array: &StructArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_validity(array.validity(), array.len());
-        for (idx, name) in array.names().iter().enumerate() {
-            visitor.visit_child(name.as_ref(), &array.fields()[idx]);
+        for (name, field) in array.names().iter().zip_eq(array.fields().iter()) {
+            visitor.visit_child(name.as_ref(), field);
         }
     }
 }

--- a/vortex-array/src/arrow/compute/to_arrow/canonical.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/canonical.rs
@@ -420,7 +420,7 @@ fn to_arrow_struct(
 
     let field_arrays = fields
         .iter()
-        .zip_eq(array.fields())
+        .zip_eq(array.fields().iter())
         .map(|(field, arr)| {
             // We check that the Vortex array nullability is compatible with the field
             // nullability. In other words, make sure we don't return any nulls for a

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -322,7 +322,7 @@ impl FromArrowArray<&ArrowStructArray> for ArrayRef {
                         Self::from_arrow(c.as_ref(), field.is_nullable())
                     }
                 })
-                .collect(),
+                .collect::<Vec<_>>(),
             value.len(),
             nulls(value.nulls(), nullable),
         )

--- a/vortex-array/src/builders/struct_.rs
+++ b/vortex-array/src/builders/struct_.rs
@@ -158,8 +158,10 @@ impl ArrayBuilder for StructBuilder {
     unsafe fn extend_from_array_unchecked(&mut self, array: &dyn Array) {
         let array = array.to_struct();
 
-        for (a, builder) in (0..array.struct_fields().nfields())
-            .map(|i| &array.fields()[i])
+        for (a, builder) in array
+            .fields()
+            .iter()
+            .cloned()
             .zip_eq(self.builders.iter_mut())
         {
             a.append_to_builder(builder.as_mut());

--- a/vortex-btrblocks/src/lib.rs
+++ b/vortex-btrblocks/src/lib.rs
@@ -33,7 +33,6 @@
 use std::fmt::Debug;
 use std::hash::Hash;
 
-use itertools::Itertools;
 use vortex_array::arrays::{
     ExtensionArray, FixedSizeListArray, ListArray, StructArray, TemporalArray,
 };
@@ -389,7 +388,7 @@ impl BtrBlocksCompressor {
                     .fields()
                     .iter()
                     .map(|field| self.compress(field))
-                    .try_collect()?;
+                    .collect::<Result<Vec<_>, _>>()?;
 
                 Ok(StructArray::try_new(
                     struct_array.names().clone(),

--- a/vortex-expr/src/exprs/merge.rs
+++ b/vortex-expr/src/exprs/merge.rs
@@ -98,9 +98,11 @@ impl VTable for MergeVTable {
 
             let struct_array = value_array.to_struct();
 
-            for (i, field_name) in struct_array.names().iter().enumerate() {
-                let array = struct_array.fields()[i].clone();
-
+            for (field_name, array) in struct_array
+                .names()
+                .iter()
+                .zip_eq(struct_array.fields().iter().cloned())
+            {
                 // Update or insert field.
                 if let Some(idx) = field_names.iter().position(|name| name == field_name) {
                     arrays[idx] = array;

--- a/vortex-layout/src/layouts/file_stats.rs
+++ b/vortex-layout/src/layouts/file_stats.rs
@@ -87,7 +87,12 @@ impl FileStatsAccumulator {
         let (sequence_id, chunk) = chunk?;
         if chunk.dtype().is_struct() {
             let chunk = chunk.to_struct();
-            for (acc, field) in self.accumulators.lock().iter_mut().zip_eq(chunk.fields()) {
+            for (acc, field) in self
+                .accumulators
+                .lock()
+                .iter_mut()
+                .zip_eq(chunk.fields().iter())
+            {
                 acc.push_chunk(field)?;
             }
         } else {

--- a/vortex-layout/src/layouts/struct_/writer.rs
+++ b/vortex-layout/src/layouts/struct_/writer.rs
@@ -82,13 +82,10 @@ impl LayoutStrategy for StructStrategy {
             let (sequence_id, chunk) = chunk?;
             let mut sequence_pointer = sequence_id.descend();
             let struct_chunk = chunk.to_struct();
-            let columns: Vec<_> = (0..struct_chunk.struct_fields().nfields())
-                .map(|idx| {
-                    (
-                        sequence_pointer.advance(),
-                        struct_chunk.fields()[idx].to_array(),
-                    )
-                })
+            let columns: Vec<_> = struct_chunk
+                .fields()
+                .iter()
+                .map(|field| (sequence_pointer.advance(), field.to_array()))
                 .collect();
             Ok(columns)
         });


### PR DESCRIPTION
for struct arrays with lots of columns, cloning is expensive because of the vec that stores the fields