### PR TITLE
Chore: move public BI benchmark script to scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,7 +212,6 @@ profile.json.gz
 *.trace.json
 *.folded
 
-
 # LLVM profiles
 *.profraw
 

--- a/bench-vortex/.gitignore
+++ b/bench-vortex/.gitignore
@@ -1,3 +1,2 @@
-data
-public_bi/.git
-public_bi/benchmark
+data/
+public_bi/

--- a/bench-vortex/scripts/fetch_public_bi_schemas_and_queries.sh
+++ b/bench-vortex/scripts/fetch_public_bi_schemas_and_queries.sh
@@ -8,7 +8,10 @@ set -Eeuox pipefail
 # https://stackoverflow.com/questions/59895/how-do-i-get-the-directory-where-a-bash-script-is-located-from-within-the-script
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-cd "${SCRIPT_DIR}"
+# Set up the public_bi directory relative to the script directory.
+PUBLIC_BI_DIR="${SCRIPT_DIR}/../public_bi"
+mkdir -p "${PUBLIC_BI_DIR}"
+cd "${PUBLIC_BI_DIR}"
 
 if [ -d ".git" ]; then
     git reset --hard  # restore deleted files if any

--- a/bench-vortex/src/public_bi.rs
+++ b/bench-vortex/src/public_bi.rs
@@ -98,10 +98,10 @@ pub enum PBIDataset {
 }
 
 pub fn fetch_schemas_and_queries() -> anyhow::Result<PathBuf> {
-    let base_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("public_bi");
+    let scripts_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts");
     let output = Command::new(
-        base_dir
-            .join("fetch_schemas_and_queries.sh")
+        scripts_dir
+            .join("fetch_public_bi_schemas_and_queries.sh")
             .to_str()
             .unwrap(),
     )
@@ -112,7 +112,9 @@ pub fn fetch_schemas_and_queries() -> anyhow::Result<PathBuf> {
         let stderr = String::from_utf8_lossy(&output.stderr);
         bail!("public_bi fetch failed: stdout=\"{stdout}\", stderr=\"{stderr}\"");
     }
-    Ok(base_dir)
+
+    // Return the public_bi directory where the git repo is initialized.
+    Ok(Path::new(env!("CARGO_MANIFEST_DIR")).join("public_bi"))
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Since `public_bi` becomes a git repository, that script remains in there, always untracked.

Adjusts the script to initialize the repository in a sibling directory to the directory of the script.

~~I don't actually know if we need to gitignore this but I don't think it will hurt.~~