### PR TITLE
Don't require field name copy for expression partitioning

### DIFF
--- a/vortex-expr/src/exprs/pack.rs
+++ b/vortex-expr/src/exprs/pack.rs
@@ -125,7 +125,7 @@ impl VTable for PackVTable {
             .values
             .iter()
             .map(|value_expr| value_expr.return_dtype(scope))
-            .process_results(|it| it.collect())?;
+            .collect::<VortexResult<Vec<_>>>()?;
         Ok(DType::Struct(
             StructFields::new(expr.names.clone(), value_dtypes),
             expr.nullability,
@@ -234,7 +234,6 @@ impl AnalysisExpr for PackExpr {}
 
 #[cfg(test)]
 mod tests {
-
     use vortex_array::arrays::{PrimitiveArray, StructArray};
     use vortex_array::validity::Validity;
     use vortex_array::vtable::ValidityHelper;

--- a/vortex-expr/src/transform/partition.rs
+++ b/vortex-expr/src/transform/partition.rs
@@ -67,11 +67,10 @@ where
         partition_dtypes.push(expr_dtype);
     }
 
-    let partition_names = FieldNames::from_iter(
-        partition_annotations
-            .iter()
-            .map(|id| FieldName::from(id.clone())),
-    );
+    let partition_names = partition_annotations
+        .iter()
+        .map(|id| FieldName::from(id.clone()))
+        .collect::<FieldNames>();
     let root_scope = DType::Struct(
         StructFields::new(partition_names.clone(), partition_dtypes.clone()),
         Nullability::NonNullable,

--- a/vortex-expr/src/transform/partition.rs
+++ b/vortex-expr/src/transform/partition.rs
@@ -33,6 +33,7 @@ pub fn partition<A: AnnotationFn>(
 ) -> VortexResult<PartitionedExpr<A::Annotation>>
 where
     A::Annotation: Display,
+    FieldName: From<A::Annotation>,
 {
     // Annotate each expression with the annotations that any of its descendent expressions have.
     let annotations = descendent_annotations(&expr, annotate_fn);
@@ -66,8 +67,11 @@ where
         partition_dtypes.push(expr_dtype);
     }
 
-    let partition_names =
-        FieldNames::from_iter(partition_annotations.iter().map(|id| id.to_string()));
+    let partition_names = FieldNames::from_iter(
+        partition_annotations
+            .iter()
+            .map(|id| FieldName::from(id.clone())),
+    );
     let root_scope = DType::Struct(
         StructFields::new(partition_names.clone(), partition_dtypes.clone()),
         Nullability::NonNullable,
@@ -112,11 +116,14 @@ impl<A: Display> Display for PartitionedExpr<A> {
     }
 }
 
-impl<A: Annotation + Display> PartitionedExpr<A> {
+impl<A: Annotation> PartitionedExpr<A>
+where
+    FieldName: From<A>,
+{
     /// Return the partition for a given field, if it exists.
     // FIXME(ngates): this should return an iterator since an annotation may have multiple partitions.
     pub fn find_partition(&self, id: &A) -> Option<&ExprRef> {
-        let id = FieldName::from(id.to_string());
+        let id = FieldName::from(id.clone());
         self.partition_names
             .iter()
             .position(|field| field == id)
@@ -145,7 +152,10 @@ impl<'a, A: Annotation + Display> StructFieldExpressionSplitter<'a, A> {
     }
 }
 
-impl<A: Annotation + Display> NodeRewriter for StructFieldExpressionSplitter<'_, A> {
+impl<A: Annotation + Display> NodeRewriter for StructFieldExpressionSplitter<'_, A>
+where
+    FieldName: From<A>,
+{
     type NodeTy = ExprRef;
 
     fn visit_down(&mut self, node: Self::NodeTy) -> VortexResult<Transformed<Self::NodeTy>> {
@@ -161,7 +171,7 @@ impl<A: Annotation + Display> NodeRewriter for StructFieldExpressionSplitter<'_,
                 sub_exprs.push(node.clone());
                 let value = get_item(
                     StructFieldExpressionSplitter::field_name(annotation, idx),
-                    get_item(FieldName::from(annotation.to_string()), root()),
+                    get_item(FieldName::from(annotation.clone()), root()),
                 );
                 Ok(Transformed {
                     value,

--- a/vortex-layout/src/layouts/row_idx/mod.rs
+++ b/vortex-layout/src/layouts/row_idx/mod.rs
@@ -15,7 +15,7 @@ use futures::future::BoxFuture;
 use vortex_array::compute::filter;
 use vortex_array::stats::Precision;
 use vortex_array::{ArrayRef, IntoArray, MaskFuture};
-use vortex_dtype::{DType, FieldMask, Nullability, PType};
+use vortex_dtype::{DType, FieldMask, FieldName, Nullability, PType};
 use vortex_error::{VortexExpect, VortexResult};
 use vortex_expr::transform::{PartitionedExpr, partition, replace};
 use vortex_expr::{ExactExpr, ExprRef, Scope, is_root, root};
@@ -100,12 +100,24 @@ enum Partition {
     Child,
 }
 
+impl Partition {
+    pub fn name(&self) -> &str {
+        match self {
+            Partition::RowIdx => "row_idx",
+            Partition::Child => "child",
+        }
+    }
+}
+
+impl From<Partition> for FieldName {
+    fn from(value: Partition) -> Self {
+        FieldName::from(value.name())
+    }
+}
+
 impl Display for Partition {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Partition::RowIdx => write!(f, "row_idx"),
-            Partition::Child => write!(f, "child"),
-        }
+        write!(f, "{}", self.name())
     }
 }
 


### PR DESCRIPTION
Since FieldName is Arc<str> we can clone

Signed-off-by: Robert Kruszewski <github@robertk.io>
