### PR TITLE
chore: allow `pack` to return a different array from scope len

### DIFF
--- a/vortex-expr/src/exprs/pack.rs
+++ b/vortex-expr/src/exprs/pack.rs
@@ -6,7 +6,7 @@ use std::hash::Hash;
 use itertools::Itertools as _;
 use vortex_array::arrays::StructArray;
 use vortex_array::validity::Validity;
-use vortex_array::{ArrayRef, DeserializeMetadata, IntoArray, ProstMetadata};
+use vortex_array::{Array, ArrayRef, DeserializeMetadata, IntoArray, ProstMetadata};
 use vortex_dtype::{DType, FieldName, FieldNames, Nullability, StructFields};
 use vortex_error::{VortexExpect as _, VortexResult, vortex_bail, vortex_err};
 use vortex_proto::expr as pb;
@@ -102,7 +102,6 @@ impl VTable for PackVTable {
     }
 
     fn evaluate(expr: &Self::Expr, scope: &Scope) -> VortexResult<ArrayRef> {
-        let len = scope.len();
         let value_arrays = expr
             .values
             .iter()
@@ -117,6 +116,10 @@ impl VTable for PackVTable {
             Nullability::NonNullable => Validity::NonNullable,
             Nullability::Nullable => Validity::AllValid,
         };
+
+        // [`PackExpr::try_new`] ensures that `value_arrays` is non-empty
+        let len = value_arrays[0].len();
+
         Ok(StructArray::try_new(expr.names.clone(), value_arrays, len, validity)?.into_array())
     }
 
@@ -141,6 +144,9 @@ impl PackExpr {
     ) -> VortexResult<Self> {
         if names.len() != values.len() {
             vortex_bail!("length mismatch {} {}", names.len(), values.len());
+        }
+        if names.is_empty() {
+            vortex_bail!("pack must have at least one field");
         }
         Ok(PackExpr {
             names,


### PR DESCRIPTION
https://spiraldb.slack.com/archives/C07BV3GKAJ2/p1760103400110299