### PR TITLE
Chore: bump lance to version 2.0->2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,6 +1028,7 @@ dependencies = [
  "indicatif",
  "itertools 0.14.0",
  "lance",
+ "lance-encoding",
  "log",
  "mimalloc",
  "noodles-bgzf",

--- a/bench-vortex/Cargo.toml
+++ b/bench-vortex/Cargo.toml
@@ -17,7 +17,8 @@ version = { workspace = true }
 workspace = true
 
 [dependencies]
-lance = "0.38.1"
+lance = "0.38.2"
+lance-encoding = "0.38.2"
 
 anyhow = { workspace = true }
 arrow-array = { workspace = true }

--- a/bench-vortex/src/compress/lance.rs
+++ b/bench-vortex/src/compress/lance.rs
@@ -21,6 +21,7 @@ use arrow_array::{RecordBatch, RecordBatchIterator};
 use arrow_schema::Schema;
 use futures::StreamExt;
 use lance::dataset::{Dataset, WriteParams};
+use lance_encoding::version::LanceFileVersion;
 use tempfile::TempDir;
 
 use crate::utils::parquet_utils::{convert_utf8view_batch, convert_utf8view_schema};
@@ -33,7 +34,7 @@ pub async fn lance_compress_write_only(
 ) -> anyhow::Result<()> {
     let path = dataset_path.to_str().unwrap();
     let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
-    let write_params = WriteParams::default();
+    let write_params = WriteParams::with_storage_version(LanceFileVersion::V2_1);
     Dataset::write(reader, path, Some(write_params)).await?;
     Ok(())
 }
@@ -111,7 +112,7 @@ pub async fn lance_compress_write(
     let path = dataset_dir.to_str().unwrap();
 
     let reader = RecordBatchIterator::new(converted_batches.into_iter().map(Ok), converted_schema);
-    let write_params = WriteParams::default();
+    let write_params = WriteParams::with_storage_version(LanceFileVersion::V2_1);
     Dataset::write(reader, path, Some(write_params)).await?;
 
     Ok(path.to_string())

--- a/bench-vortex/src/datasets/taxi_data.rs
+++ b/bench-vortex/src/datasets/taxi_data.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use async_trait::async_trait;
 use lance::dataset::{Dataset as LanceDataset, WriteParams};
+use lance_encoding::version::LanceFileVersion;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use tokio::fs::File as TokioFile;
 use tokio::io::AsyncWriteExt;
@@ -96,7 +97,7 @@ pub async fn taxi_data_lance() -> Result<PathBuf> {
         let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
         let reader = builder.build()?;
 
-        let write_params = WriteParams::default();
+        let write_params = WriteParams::with_storage_version(LanceFileVersion::V2_1);
         LanceDataset::write(reader, output_fname.to_str().unwrap(), Some(write_params)).await?;
 
         Ok(output_fname.to_path_buf())

--- a/bench-vortex/src/utils/parquet_utils.rs
+++ b/bench-vortex/src/utils/parquet_utils.rs
@@ -11,6 +11,7 @@ use arrow_array::{RecordBatch, RecordBatchReader};
 use arrow_cast::cast;
 use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef};
 use lance::dataset::{Dataset as LanceDataset, WriteParams};
+use lance_encoding::version::LanceFileVersion;
 use log::info;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use tokio::fs::create_dir_all;
@@ -166,14 +167,14 @@ pub async fn convert_parquet_to_lance(
             LanceDataset::write(
                 Box::new(converting_iter),
                 lance_path_str,
-                Some(WriteParams::default()),
+                Some(WriteParams::with_storage_version(LanceFileVersion::V2_1)),
             )
             .await?;
         } else {
             LanceDataset::write(
                 Box::new(batch_iter),
                 lance_path_str,
-                Some(WriteParams::default()),
+                Some(WriteParams::with_storage_version(LanceFileVersion::V2_1)),
             )
             .await?;
         }


### PR DESCRIPTION
Following guidance from Weston, we can bump lance to v2.1, which has improvements in everything but might hit random access?