### PR TITLE
Release the GIL before block_on

### DIFF
--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -11,7 +11,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyString;
 use vortex::dtype::{FieldName, FieldNames};
 use vortex::error::VortexResult;
-use vortex::expr::{ExprRef, SelectExpr, root, select};
+use vortex::expr::{root, select, ExprRef, SelectExpr};
 use vortex::file::{VortexFile, VortexOpenOptions};
 use vortex::iter::ArrayIteratorExt;
 use vortex::scan::SplitBy;
@@ -21,7 +21,7 @@ use crate::arrays::PyArrayRef;
 use crate::arrow::{IntoPyArrow, ToPyArrow};
 use crate::expr::PyExpr;
 use crate::object_store_urls::object_store_from_url;
-use crate::{RUNTIME, TOKIO_RUNTIME, install_module};
+use crate::{install_module, RUNTIME, TOKIO_RUNTIME};
 
 pub(crate) fn init(py: Python, parent: &Bound<PyModule>) -> PyResult<()> {
     let m = PyModule::new(py, "dataset")?;
@@ -209,6 +209,6 @@ impl PyVortexDataset {
 }
 
 #[pyfunction]
-pub fn dataset_from_url(url: &str) -> PyResult<PyVortexDataset> {
-    Ok(TOKIO_RUNTIME.block_on(PyVortexDataset::from_url(url))?)
+pub fn dataset_from_url(py: Python, url: &str) -> PyResult<PyVortexDataset> {
+    Ok(py.detach(|| TOKIO_RUNTIME.block_on(PyVortexDataset::from_url(url)))?)
 }

--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -11,7 +11,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyString;
 use vortex::dtype::{FieldName, FieldNames};
 use vortex::error::VortexResult;
-use vortex::expr::{root, select, ExprRef, SelectExpr};
+use vortex::expr::{ExprRef, SelectExpr, root, select};
 use vortex::file::{VortexFile, VortexOpenOptions};
 use vortex::iter::ArrayIteratorExt;
 use vortex::scan::SplitBy;
@@ -21,7 +21,7 @@ use crate::arrays::PyArrayRef;
 use crate::arrow::{IntoPyArrow, ToPyArrow};
 use crate::expr::PyExpr;
 use crate::object_store_urls::object_store_from_url;
-use crate::{install_module, RUNTIME, TOKIO_RUNTIME};
+use crate::{RUNTIME, TOKIO_RUNTIME, install_module};
 
 pub(crate) fn init(py: Python, parent: &Bound<PyModule>) -> PyResult<()> {
     let m = PyModule::new(py, "dataset")?;

--- a/vortex-python/src/file.rs
+++ b/vortex-python/src/file.rs
@@ -40,16 +40,18 @@ pub(crate) fn init(py: Python, parent: &Bound<PyModule>) -> PyResult<()> {
 
 #[pyfunction]
 #[pyo3(signature = (path, *, without_segment_cache = false))]
-pub fn open(path: &str, without_segment_cache: bool) -> PyResult<PyVortexFile> {
-    let vxf = RUNTIME.block_on(|h| async move {
-        let mut options = VortexOpenOptions::new();
-        if without_segment_cache {
-            options = options.without_segment_cache();
-        } else {
-            // TODO(ngates): use a globally shared segment cache for all files
-            options = options.with_segment_cache(Arc::new(MokaSegmentCache::new(256 << 20)));
-        }
-        options.with_handle(h).open(path).await
+pub fn open(py: Python, path: &str, without_segment_cache: bool) -> PyResult<PyVortexFile> {
+    let vxf = py.detach(|| {
+        RUNTIME.block_on(|h| async move {
+            let mut options = VortexOpenOptions::new();
+            if without_segment_cache {
+                options = options.without_segment_cache();
+            } else {
+                // TODO(ngates): use a globally shared segment cache for all files
+                options = options.with_segment_cache(Arc::new(MokaSegmentCache::new(256 << 20)));
+            }
+            options.with_handle(h).open(path).await
+        })
     })?;
 
     Ok(PyVortexFile { vxf })

--- a/vortex-python/src/io.rs
+++ b/vortex-python/src/io.rs
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use arrow_array::ffi_stream::ArrowArrayStreamReader;
 use arrow_array::RecordBatchReader;
+use arrow_array::ffi_stream::ArrowArrayStreamReader;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::pyfunction;
 use tokio::fs::File;
 use vortex::arrow::FromArrowArray;
 use vortex::compressor::CompactCompressor;
-use vortex::dtype::arrow::FromArrowType;
 use vortex::dtype::DType;
+use vortex::dtype::arrow::FromArrowType;
 use vortex::error::{VortexError, VortexResult};
 use vortex::file::{VortexWriteOptions, WriteStrategyBuilder};
 use vortex::iter::{ArrayIterator, ArrayIteratorAdapter, ArrayIteratorExt};
@@ -21,7 +21,7 @@ use crate::arrow::FromPyArrow;
 use crate::dataset::PyVortexDataset;
 use crate::expr::PyExpr;
 use crate::iter::PyArrayIterator;
-use crate::{install_module, PyVortex, TOKIO_RUNTIME};
+use crate::{PyVortex, TOKIO_RUNTIME, install_module};
 
 pub(crate) fn init(py: Python, parent: &Bound<PyModule>) -> PyResult<()> {
     let m = PyModule::new(py, "io")?;

--- a/vortex-python/src/io.rs
+++ b/vortex-python/src/io.rs
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use arrow_array::RecordBatchReader;
 use arrow_array::ffi_stream::ArrowArrayStreamReader;
+use arrow_array::RecordBatchReader;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::pyfunction;
 use tokio::fs::File;
 use vortex::arrow::FromArrowArray;
 use vortex::compressor::CompactCompressor;
-use vortex::dtype::DType;
 use vortex::dtype::arrow::FromArrowType;
+use vortex::dtype::DType;
 use vortex::error::{VortexError, VortexResult};
 use vortex::file::{VortexWriteOptions, WriteStrategyBuilder};
 use vortex::iter::{ArrayIterator, ArrayIteratorAdapter, ArrayIteratorExt};
@@ -21,7 +21,7 @@ use crate::arrow::FromPyArrow;
 use crate::dataset::PyVortexDataset;
 use crate::expr::PyExpr;
 use crate::iter::PyArrayIterator;
-use crate::{PyVortex, TOKIO_RUNTIME, install_module};
+use crate::{install_module, PyVortex, TOKIO_RUNTIME};
 
 pub(crate) fn init(py: Python, parent: &Bound<PyModule>) -> PyResult<()> {
     let m = PyModule::new(py, "io")?;
@@ -95,13 +95,14 @@ pub(crate) fn init(py: Python, parent: &Bound<PyModule>) -> PyResult<()> {
 #[pyfunction]
 #[pyo3(signature = (url, *, projection = None, row_filter = None, indices = None, row_range = None))]
 pub fn read_url<'py>(
+    py: Python<'py>,
     url: &str,
     projection: Option<Vec<Bound<'py, PyAny>>>,
     row_filter: Option<&Bound<'py, PyExpr>>,
     indices: Option<PyArrayRef>,
     row_range: Option<(u64, u64)>,
 ) -> PyResult<PyArrayRef> {
-    let dataset = TOKIO_RUNTIME.block_on(PyVortexDataset::from_url(url))?;
+    let dataset = py.detach(|| TOKIO_RUNTIME.block_on(PyVortexDataset::from_url(url)))?;
     dataset.to_array(projection, row_filter, indices, row_range)
 }
 
@@ -157,12 +158,14 @@ pub fn read_url<'py>(
 /// :func:`vortex.io.VortexWriteOptions`
 #[pyfunction]
 #[pyo3(signature = (iter, path))]
-pub fn write(iter: PyIntoArrayIterator, path: &str) -> PyResult<()> {
-    TOKIO_RUNTIME.block_on(async move {
-        let mut file = File::create(path).await?;
-        VortexWriteOptions::default()
-            .write(&mut file, iter.into_inner().into_array_stream())
-            .await
+pub fn write(py: Python, iter: PyIntoArrayIterator, path: &str) -> PyResult<()> {
+    py.detach(|| {
+        TOKIO_RUNTIME.block_on(async move {
+            let mut file = File::create(path).await?;
+            VortexWriteOptions::default()
+                .write(&mut file, iter.into_inner().into_array_stream())
+                .await
+        })
     })?;
 
     Ok(())
@@ -268,19 +271,21 @@ impl PyVortexWriteOptions {
     ///
     /// :func:`vortex.io.write`
     #[pyo3(signature = (iter, path))]
-    pub fn write_path(&self, iter: PyIntoArrayIterator, path: &str) -> PyResult<()> {
-        TOKIO_RUNTIME.block_on(async move {
-            let mut file = File::create(path).await?;
+    pub fn write_path(&self, py: Python, iter: PyIntoArrayIterator, path: &str) -> PyResult<()> {
+        py.detach(|| {
+            TOKIO_RUNTIME.block_on(async move {
+                let mut file = File::create(path).await?;
 
-            let mut strategy = WriteStrategyBuilder::new();
-            if let Some(compressor) = self.compressor.as_ref() {
-                strategy = strategy.with_compressor(compressor.clone())
-            }
+                let mut strategy = WriteStrategyBuilder::new();
+                if let Some(compressor) = self.compressor.as_ref() {
+                    strategy = strategy.with_compressor(compressor.clone())
+                }
 
-            VortexWriteOptions::default()
-                .with_strategy(strategy.build())
-                .write(&mut file, iter.into_inner().into_array_stream())
-                .await
+                VortexWriteOptions::default()
+                    .with_strategy(strategy.build())
+                    .write(&mut file, iter.into_inner().into_array_stream())
+                    .await
+            })
         })?;
 
         Ok(())


### PR DESCRIPTION
Fixes #4895

We were deadlocking when calling back into Python's parquet reader because we held the GIL within our Tokio runtime.
We should probably follow up with a pass to release the GIL in more places.