### PR TITLE
perf: annotate primitive array fns with `#[inline]`

### DIFF
--- a/vortex-array/src/arrays/primitive/vtable/array.rs
+++ b/vortex-array/src/arrays/primitive/vtable/array.rs
@@ -8,14 +8,17 @@ use crate::stats::StatsSetRef;
 use crate::vtable::ArrayVTable;
 
 impl ArrayVTable<PrimitiveVTable> for PrimitiveVTable {
+    #[inline]
     fn len(array: &PrimitiveArray) -> usize {
         array.byte_buffer().len() / array.ptype().byte_width()
     }
 
+    #[inline]
     fn dtype(array: &PrimitiveArray) -> &DType {
         &array.dtype
     }
 
+    #[inline]
     fn stats(array: &PrimitiveArray) -> StatsSetRef<'_> {
         array.stats_set.to_ref(array.as_ref())
     }

--- a/vortex-array/src/arrays/primitive/vtable/pipeline.rs
+++ b/vortex-array/src/arrays/primitive/vtable/pipeline.rs
@@ -43,22 +43,27 @@ impl OperatorEq for PrimitiveArray {
 }
 
 impl Operator for PrimitiveArray {
+    #[inline]
     fn id(&self) -> OperatorId {
         self.encoding_id()
     }
 
+    #[inline]
     fn as_any(&self) -> &dyn Any {
         self
     }
 
+    #[inline]
     fn dtype(&self) -> &DType {
         &self.dtype
     }
 
+    #[inline]
     fn bounds(&self) -> LengthBounds {
         LengthBounds::from(self.buffer.len() / self.dtype.as_ptype().byte_width())
     }
 
+    #[inline]
     fn children(&self) -> &[OperatorRef] {
         &[]
     }
@@ -67,10 +72,12 @@ impl Operator for PrimitiveArray {
         write!(f, "PrimitiveArray(ptype={})", self.ptype())
     }
 
+    #[inline]
     fn with_children(self: Arc<Self>, _children: Vec<OperatorRef>) -> VortexResult<OperatorRef> {
         Ok(self)
     }
 
+    #[inline]
     fn as_batch(&self) -> Option<&dyn BatchOperator> {
         Some(self)
     }

--- a/vortex-array/src/arrays/primitive/vtable/serde.rs
+++ b/vortex-array/src/arrays/primitive/vtable/serde.rs
@@ -15,6 +15,7 @@ use crate::vtable::SerdeVTable;
 impl SerdeVTable<PrimitiveVTable> for PrimitiveVTable {
     type Metadata = EmptyMetadata;
 
+    #[inline]
     fn metadata(_array: &PrimitiveArray) -> VortexResult<Option<Self::Metadata>> {
         Ok(Some(EmptyMetadata))
     }

--- a/vortex-array/src/arrays/primitive/vtable/validity.rs
+++ b/vortex-array/src/arrays/primitive/vtable/validity.rs
@@ -6,6 +6,7 @@ use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
 impl ValidityHelper for PrimitiveArray {
+    #[inline]
     fn validity(&self) -> &Validity {
         &self.validity
     }


### PR DESCRIPTION
Annotates small functions defined on `PrimitiveArray` with `#[inline]` in case they're good candidates for performance improvement.