### PR TITLE
Chore: feature flag lance

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -1,3 +1,5 @@
+# Runs once when we add the `benchmark` tag to a pull request.
+
 name: PR Benchmarks
 
 on:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,3 +1,5 @@
+# Runs after every commit to `develop` (or in other words, _after_ every pull request merges).
+
 name: Benchmarks
 
 on:
@@ -65,8 +67,9 @@ jobs:
         shell: bash
         env:
           RUSTFLAGS: "-C target-cpu=native -C force-frame-pointers=yes"
+        # The main difference between this and `bench-pr.yml` is that we add the `lance` feature.
         run: |
-          cargo build --bin ${{ matrix.benchmark.id }} --package bench-vortex --profile release_debug
+          cargo build --bin ${{ matrix.benchmark.id }} --package bench-vortex --profile release_debug --features lance
 
       - name: Setup Polar Signals
         uses: polarsignals/gh-actions-ps-profiling@v0.6.0
@@ -82,7 +85,7 @@ jobs:
         env:
           RUST_BACKTRACE: full
         run: |
-          target/release_debug/${{ matrix.benchmark.id }} -d gh-json -o ${{ matrix.benchmark.id }}.json
+          target/release_debug/${{ matrix.benchmark.id }} -d gh-json -o ${{ matrix.benchmark.id }}.json --formats parquet,lance,vortex
 
       - name: Setup AWS CLI
         uses: aws-actions/configure-aws-credentials@v5
@@ -99,3 +102,72 @@ jobs:
     secrets: inherit
     with:
       mode: "develop"
+      benchmark_matrix: |
+          [
+            {
+              "id": "clickbench-nvme",
+              "subcommand": "clickbench",
+              "name": "Clickbench on NVME",
+              "targets": "datafusion:parquet,datafusion:vortex,datafusion:vortex-compact,datafusion:lance,duckdb:parquet,duckdb:vortex,duckdb:vortex-compact,duckdb:duckdb",
+              "build_args": "--features lance"
+            },
+            {
+              "id": "tpch-nvme",
+              "subcommand": "tpch",
+              "name": "TPC-H SF=1 on NVME",
+              "targets": "datafusion:arrow,datafusion:parquet,datafusion:vortex,datafusion:vortex-compact,datafusion:lance,duckdb:parquet,duckdb:vortex,duckdb:vortex-compact,duckdb:duckdb",
+              "scale_factor": "--scale-factor 1.0",
+              "build_args": "--features lance"
+            },
+            {
+              "id": "tpch-s3",
+              "subcommand": "tpch",
+              "name": "TPC-H SF=1 on S3",
+              "local_dir": "bench-vortex/data/tpch/1.0",
+              "remote_storage": "s3://vortex-bench-dev-eu/${{github.ref_name}}/tpch/1.0/",
+              "targets": "datafusion:parquet,datafusion:vortex,datafusion:vortex-compact,datafusion:lance,duckdb:parquet,duckdb:vortex,duckdb:vortex-compact",
+              "scale_factor": "--scale-factor 1.0",
+              "build_args": "--features lance"
+            },
+            {
+              "id": "tpch-nvme-10",
+              "subcommand": "tpch",
+              "name": "TPC-H SF=10 on NVME",
+              "targets": "datafusion:arrow,datafusion:parquet,datafusion:vortex,datafusion:vortex-compact,datafusion:lance,duckdb:parquet,duckdb:vortex,duckdb:vortex-compact,duckdb:duckdb",
+              "scale_factor": "--scale-factor 10.0",
+              "build_args": "--features lance"
+            },
+            {
+              "id": "tpch-s3-10",
+              "subcommand": "tpch",
+              "name": "TPC-H SF=10 on S3",
+              "local_dir": "bench-vortex/data/tpch/10.0",
+              "remote_storage": "s3://vortex-bench-dev-eu/${{github.ref_name}}/tpch/10.0/",
+              "targets": "datafusion:parquet,datafusion:vortex,datafusion:vortex-compact,datafusion:lance,duckdb:parquet,duckdb:vortex,duckdb:vortex-compact",
+              "scale_factor": "--scale-factor 10.0",
+              "build_args": "--features lance"
+            },
+            {
+              "id": "tpcds-nvme",
+              "subcommand": "tpcds",
+              "name": "TPC-DS SF=1 on NVME",
+              "targets": "datafusion:parquet,datafusion:vortex,datafusion:vortex-compact,duckdb:parquet,duckdb:vortex,duckdb:vortex-compact,duckdb:duckdb",
+              "scale_factor": "--scale-factor 1.0"
+            },
+            {
+              "id": "statpopgen",
+              "subcommand": "statpopgen",
+              "name": "Statistical and Population Genetics",
+              "local_dir": "bench-vortex/data/statpopgen",
+              "targets": "duckdb:parquet,duckdb:vortex,duckdb:vortex-compact",
+              "scale_factor": "--scale-factor 100"
+            },
+            {
+              "id": "fineweb",
+              "subcommand": "fineweb",
+              "name": "FineWeb",
+              "local_dir": "bench-vortex/data/fineweb",
+              "targets": "duckdb:parquet,duckdb:vortex,duckdb:vortex-compact,datafusion:parquet,datafusion:vortex,datafusion:vortex-compact",
+              "scale_factor": "--scale-factor 100"
+            },
+          ]

--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -26,7 +26,8 @@ jobs:
             "subcommand": "tpch",
             "name": "TPC-H on NVME",
             "targets": "datafusion:parquet,datafusion:vortex,datafusion:lance,duckdb:parquet,duckdb:vortex,duckdb:duckdb",
-            "scale_factor": "--scale-factor 10.0"
+            "scale_factor": "--scale-factor 10.0",
+            "build_args": "--features lance"
           },
           {
             "id": "tpch-s3",
@@ -35,7 +36,8 @@ jobs:
             "local_dir": "bench-vortex/data/tpch/10.0",
             "remote_storage": "s3://vortex-bench-dev-eu/${{github.ref_name}}/tpch/10.0/",
             "targets": "datafusion:parquet,datafusion:vortex,datafusion:lance,duckdb:parquet,duckdb:vortex",
-            "scale_factor": "--scale-factor 10.0"
+            "scale_factor": "--scale-factor 10.0",
+            "build_args": "--features lance"
           },
           {
             "id": "tpch-nvme",

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -14,6 +14,7 @@ on:
         required: false
         type: string
         description: "JSON string containing the matrix configuration"
+        # We do not include lance in the default configuration.
         default: |
           [
             {
@@ -119,7 +120,7 @@ jobs:
         env:
           RUSTFLAGS: "-C target-cpu=native -C force-frame-pointers=yes"
         run: |
-          cargo build --bin query_bench --package bench-vortex --profile release_debug
+          cargo build --bin query_bench --package bench-vortex --profile release_debug ${{ matrix.build_args }}
 
       - name: Generate data
         shell: bash

--- a/.github/workflows/sql-pr.yml
+++ b/.github/workflows/sql-pr.yml
@@ -1,3 +1,5 @@
+# Runs once when we add the `benchmark-sql` tag to a pull request.
+
 name: PR SQL Benchmarks
 
 on:

--- a/bench-vortex/Cargo.toml
+++ b/bench-vortex/Cargo.toml
@@ -16,9 +16,12 @@ version = { workspace = true }
 [lints]
 workspace = true
 
+[features]
+lance = ["dep:lance", "dep:lance-encoding"]
+
 [dependencies]
-lance = "0.38.2"
-lance-encoding = "0.38.2"
+lance = { version = "0.38.2", optional = true }
+lance-encoding = { version = "0.38.2", optional = true }
 
 anyhow = { workspace = true }
 arrow-array = { workspace = true }

--- a/bench-vortex/src/bin/compress.rs
+++ b/bench-vortex/src/bin/compress.rs
@@ -28,7 +28,6 @@ use vortex::builders::builder_with_capacity;
 use vortex::utils::aliases::hash_map::HashMap;
 use vortex::{Array, IntoArray};
 
-// TODO(connor): Remove the Lance format from default values.
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
@@ -36,7 +35,7 @@ struct Args {
         long,
         value_delimiter = ',',
         value_enum,
-        default_values_t = vec![Format::Parquet, Format::Lance, Format::OnDiskVortex]
+        default_values_t = vec![Format::Parquet, Format::OnDiskVortex]
     )]
     formats: Vec<Format>,
     #[arg(short, long, default_value_t = 5)]
@@ -238,6 +237,7 @@ pub fn benchmark_compress(
                     let compress_fn: CompressFn = match format {
                         Format::OnDiskVortex => compress::benchmark_vortex_compress,
                         Format::Parquet => compress::benchmark_parquet_compress,
+                        #[cfg(feature = "lance")]
                         Format::Lance => compress::benchmark_lance_compress,
                         _ => unimplemented!("Compress bench not implemented for {format}"),
                     };
@@ -255,6 +255,7 @@ pub fn benchmark_compress(
                     let decompress_fn: DecompressFn = match format {
                         Format::OnDiskVortex => compress::benchmark_vortex_decompress,
                         Format::Parquet => compress::benchmark_parquet_decompress,
+                        #[cfg(feature = "lance")]
                         Format::Lance => compress::benchmark_lance_decompress,
                         _ => unimplemented!("Decompress bench not implemented for {format}"),
                     };

--- a/bench-vortex/src/bin/random_access.rs
+++ b/bench-vortex/src/bin/random_access.rs
@@ -108,10 +108,9 @@ fn random_access(
     for format in formats {
         let engine = match format {
             Format::OnDiskVortex | Format::VortexCompact => Engine::Vortex,
-            #[cfg(feature = "lance")]
-            Format::Parquet | Format::Lance => Engine::Arrow,
-            #[cfg(not(feature = "lance"))]
             Format::Parquet => Engine::Arrow,
+            #[cfg(feature = "lance")]
+            Format::Lance => Engine::Arrow,
             Format::Csv | Format::Arrow | Format::OnDiskDuckDB => unimplemented!(),
         };
         let target = Target::new(engine, format);

--- a/bench-vortex/src/bin/random_access.rs
+++ b/bench-vortex/src/bin/random_access.rs
@@ -9,7 +9,9 @@ use bench_vortex::bench_run::run_with_setup;
 use bench_vortex::datasets::taxi_data::*;
 use bench_vortex::display::{DisplayFormat, print_measurements_json, render_table};
 use bench_vortex::measurements::TimingMeasurement;
-use bench_vortex::random_access::take::{take_lance, take_parquet, take_vortex_tokio};
+#[cfg(feature = "lance")]
+use bench_vortex::random_access::take::take_lance;
+use bench_vortex::random_access::take::{take_parquet, take_vortex_tokio};
 use bench_vortex::utils::constants::STORAGE_NVME;
 use bench_vortex::utils::new_tokio_runtime;
 use bench_vortex::{Engine, Format, Target, setup_logging_and_tracing};
@@ -29,7 +31,7 @@ struct Args {
         long,
         value_delimiter = ',',
         value_enum,
-        default_values_t = vec![Format::Parquet, Format::Lance, Format::OnDiskVortex]
+        default_values_t = vec![Format::Parquet, Format::OnDiskVortex]
     )]
     formats: Vec<Format>,
     #[arg(short, long, default_value_t = 10)]
@@ -106,7 +108,10 @@ fn random_access(
     for format in formats {
         let engine = match format {
             Format::OnDiskVortex | Format::VortexCompact => Engine::Vortex,
+            #[cfg(feature = "lance")]
             Format::Parquet | Format::Lance => Engine::Arrow,
+            #[cfg(not(feature = "lance"))]
+            Format::Parquet => Engine::Arrow,
             Format::Csv | Format::Arrow | Format::OnDiskDuckDB => unimplemented!(),
         };
         let target = Target::new(engine, format);
@@ -156,6 +161,7 @@ fn random_access(
                     target,
                 )
             }
+            #[cfg(feature = "lance")]
             Format::Lance => {
                 let taxi_lance = runtime.block_on(taxi_data_lance())?;
 

--- a/bench-vortex/src/clickbench/clickbench_benchmark.rs
+++ b/bench-vortex/src/clickbench/clickbench_benchmark.rs
@@ -119,6 +119,7 @@ impl Benchmark for ClickBenchBenchmark {
                             })?
                         }
                     }
+                    #[cfg(feature = "lance")]
                     Format::Lance => {
                         // Lance manages its own partitioning internally, so flavor doesn't matter.
                         if self.flavor == Flavor::Single {

--- a/bench-vortex/src/clickbench/clickbench_data.rs
+++ b/bench-vortex/src/clickbench/clickbench_data.rs
@@ -30,8 +30,10 @@ use vortex::file::VortexWriteOptions;
 use vortex_datafusion::VortexFormat;
 
 use crate::conversions::parquet_to_vortex;
+#[cfg(feature = "lance")]
+use crate::utils;
 use crate::utils::file_utils::{idempotent, idempotent_async};
-use crate::{CompactionStrategy, Format, utils};
+use crate::{CompactionStrategy, Format};
 
 pub static HITS_SCHEMA: LazyLock<Schema> = LazyLock::new(|| {
     use DataType::*;
@@ -223,6 +225,7 @@ pub async fn convert_parquet_to_vortex(
 /// Convert Parquet files to Lance format for ClickBench.
 /// Lance manages its own internal partitioning, so we convert all Parquet files
 /// (whether Single or Partitioned flavor) into a single Lance dataset.
+#[cfg(feature = "lance")]
 pub async fn convert_parquet_to_lance(input_path: &Path) -> anyhow::Result<()> {
     let lance_dir = input_path.join(Format::Lance.name());
     let parquet_dir = input_path.join(Format::Parquet.name());

--- a/bench-vortex/src/compress/bench.rs
+++ b/bench-vortex/src/compress/bench.rs
@@ -2,16 +2,23 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::borrow::Cow;
+#[cfg(not(feature = "lance"))]
+use std::fmt;
+#[cfg(feature = "lance")]
 use std::path::PathBuf;
+#[cfg(feature = "lance")]
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
+#[cfg(feature = "lance")]
 use std::{fmt, fs};
 
 use anyhow::Result;
+#[cfg(feature = "lance")]
 use arrow_array::RecordBatch;
 use bytes::Bytes;
 use clap::ValueEnum;
+#[cfg(feature = "lance")]
 use parking_lot::Mutex;
 use parquet::basic::{Compression, ZstdLevel};
 use serde::Serialize;
@@ -21,12 +28,17 @@ use vortex::arrays::ChunkedVTable;
 use vortex::utils::aliases::hash_map::HashMap;
 
 use crate::Format;
+#[cfg(not(feature = "lance"))]
+use crate::bench_run::run;
+#[cfg(feature = "lance")]
 use crate::bench_run::{run, run_with_setup};
 use crate::compress::chunked_to_vec_record_batch;
+#[cfg(feature = "lance")]
 use crate::compress::lance::*;
 use crate::compress::parquet::{parquet_compress_write, parquet_decompress_read};
 use crate::compress::vortex::{vortex_compress_write, vortex_decompress_read};
 use crate::measurements::{CompressionTimingMeasurement, CustomUnitMeasurement};
+#[cfg(feature = "lance")]
 use crate::utils::{convert_utf8view_batch, convert_utf8view_schema};
 
 #[derive(Default)]
@@ -217,6 +229,7 @@ pub fn benchmark_parquet_decompress(
     Ok((time, timing))
 }
 
+#[cfg(feature = "lance")]
 pub fn benchmark_lance_compress(
     runtime: &Runtime,
     uncompressed: &dyn Array,
@@ -297,6 +310,7 @@ pub fn benchmark_lance_compress(
     Ok((time, lance_compressed_size_val, ratios, timing))
 }
 
+#[cfg(feature = "lance")]
 pub fn benchmark_lance_decompress(
     runtime: &Runtime,
     uncompressed: &dyn Array,
@@ -380,42 +394,45 @@ pub fn calculate_ratios(
         });
     }
 
-    // Size ratio: vortex vs lance.
-    if let (Some(vortex_size), Some(lance_size)) = (
-        compressed_sizes.get(&Format::OnDiskVortex),
-        compressed_sizes.get(&Format::Lance),
-    ) {
-        ratios.push(CustomUnitMeasurement {
-            name: format!("vortex:lance size/{bench_name}"),
-            format: Format::OnDiskVortex,
-            unit: Cow::from("ratio"),
-            value: *vortex_size as f64 / *lance_size as f64,
-        });
-    }
+    #[cfg(feature = "lance")]
+    {
+        // Size ratio: vortex vs lance.
+        if let (Some(vortex_size), Some(lance_size)) = (
+            compressed_sizes.get(&Format::OnDiskVortex),
+            compressed_sizes.get(&Format::Lance),
+        ) {
+            ratios.push(CustomUnitMeasurement {
+                name: format!("vortex:lance size/{bench_name}"),
+                format: Format::OnDiskVortex,
+                unit: Cow::from("ratio"),
+                value: *vortex_size as f64 / *lance_size as f64,
+            });
+        }
 
-    // Compress time ratio: vortex vs lance.
-    if let (Some(vortex_time), Some(lance_time)) = (
-        measurements.get(&(Format::OnDiskVortex, CompressOp::Compress)),
-        measurements.get(&(Format::Lance, CompressOp::Compress)),
-    ) {
-        ratios.push(CustomUnitMeasurement {
-            name: format!("vortex:lance ratio compress time/{bench_name}"),
-            format: Format::OnDiskVortex,
-            unit: Cow::from("ratio"),
-            value: vortex_time.as_nanos() as f64 / lance_time.as_nanos() as f64,
-        });
-    }
+        // Compress time ratio: vortex vs lance.
+        if let (Some(vortex_time), Some(lance_time)) = (
+            measurements.get(&(Format::OnDiskVortex, CompressOp::Compress)),
+            measurements.get(&(Format::Lance, CompressOp::Compress)),
+        ) {
+            ratios.push(CustomUnitMeasurement {
+                name: format!("vortex:lance ratio compress time/{bench_name}"),
+                format: Format::OnDiskVortex,
+                unit: Cow::from("ratio"),
+                value: vortex_time.as_nanos() as f64 / lance_time.as_nanos() as f64,
+            });
+        }
 
-    // Decompress time ratio: vortex vs lance.
-    if let (Some(vortex_time), Some(lance_time)) = (
-        measurements.get(&(Format::OnDiskVortex, CompressOp::Decompress)),
-        measurements.get(&(Format::Lance, CompressOp::Decompress)),
-    ) {
-        ratios.push(CustomUnitMeasurement {
-            name: format!("vortex:lance ratio decompress time/{bench_name}"),
-            format: Format::OnDiskVortex,
-            unit: Cow::from("ratio"),
-            value: vortex_time.as_nanos() as f64 / lance_time.as_nanos() as f64,
-        });
+        // Decompress time ratio: vortex vs lance.
+        if let (Some(vortex_time), Some(lance_time)) = (
+            measurements.get(&(Format::OnDiskVortex, CompressOp::Decompress)),
+            measurements.get(&(Format::Lance, CompressOp::Decompress)),
+        ) {
+            ratios.push(CustomUnitMeasurement {
+                name: format!("vortex:lance ratio decompress time/{bench_name}"),
+                format: Format::OnDiskVortex,
+                unit: Cow::from("ratio"),
+                value: vortex_time.as_nanos() as f64 / lance_time.as_nanos() as f64,
+            });
+        }
     }
 }

--- a/bench-vortex/src/compress/bench.rs
+++ b/bench-vortex/src/compress/bench.rs
@@ -2,44 +2,39 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::borrow::Cow;
-#[cfg(not(feature = "lance"))]
 use std::fmt;
-#[cfg(feature = "lance")]
-use std::path::PathBuf;
-#[cfg(feature = "lance")]
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
-#[cfg(feature = "lance")]
-use std::{fmt, fs};
 
 use anyhow::Result;
-#[cfg(feature = "lance")]
-use arrow_array::RecordBatch;
 use bytes::Bytes;
 use clap::ValueEnum;
-#[cfg(feature = "lance")]
-use parking_lot::Mutex;
 use parquet::basic::{Compression, ZstdLevel};
 use serde::Serialize;
 use tokio::runtime::Runtime;
 use vortex::Array;
 use vortex::arrays::ChunkedVTable;
 use vortex::utils::aliases::hash_map::HashMap;
+#[cfg(feature = "lance")]
+use {
+    super::lance::*,
+    crate::{
+        bench_run::run_with_setup,
+        utils::{convert_utf8view_batch, convert_utf8view_schema},
+    },
+    arrow_array::RecordBatch,
+    parking_lot::Mutex,
+    std::fs,
+    std::path::PathBuf,
+    std::sync::Arc,
+};
 
 use crate::Format;
-#[cfg(not(feature = "lance"))]
 use crate::bench_run::run;
-#[cfg(feature = "lance")]
-use crate::bench_run::{run, run_with_setup};
 use crate::compress::chunked_to_vec_record_batch;
-#[cfg(feature = "lance")]
-use crate::compress::lance::*;
 use crate::compress::parquet::{parquet_compress_write, parquet_decompress_read};
 use crate::compress::vortex::{vortex_compress_write, vortex_decompress_read};
 use crate::measurements::{CompressionTimingMeasurement, CustomUnitMeasurement};
-#[cfg(feature = "lance")]
-use crate::utils::{convert_utf8view_batch, convert_utf8view_schema};
 
 #[derive(Default)]
 pub struct CompressMeasurements {
@@ -355,6 +350,18 @@ pub fn calculate_ratios(
     bench_name: &str,
     ratios: &mut Vec<CustomUnitMeasurement>,
 ) {
+    calculate_vortex_parquet_ratios(measurements, compressed_sizes, bench_name, ratios);
+
+    #[cfg(feature = "lance")]
+    calculate_vortex_lance_ratios(measurements, compressed_sizes, bench_name, ratios);
+}
+
+fn calculate_vortex_parquet_ratios(
+    measurements: &HashMap<(Format, CompressOp), Duration>,
+    compressed_sizes: &HashMap<Format, u64>,
+    bench_name: &str,
+    ratios: &mut Vec<CustomUnitMeasurement>,
+) {
     // Size ratio: vortex vs parquet.
     if let (Some(vortex_size), Some(parquet_size)) = (
         compressed_sizes.get(&Format::OnDiskVortex),
@@ -393,46 +400,51 @@ pub fn calculate_ratios(
             value: vortex_time.as_nanos() as f64 / parquet_time.as_nanos() as f64,
         });
     }
+}
 
-    #[cfg(feature = "lance")]
-    {
-        // Size ratio: vortex vs lance.
-        if let (Some(vortex_size), Some(lance_size)) = (
-            compressed_sizes.get(&Format::OnDiskVortex),
-            compressed_sizes.get(&Format::Lance),
-        ) {
-            ratios.push(CustomUnitMeasurement {
-                name: format!("vortex:lance size/{bench_name}"),
-                format: Format::OnDiskVortex,
-                unit: Cow::from("ratio"),
-                value: *vortex_size as f64 / *lance_size as f64,
-            });
-        }
+#[cfg(feature = "lance")]
+fn calculate_vortex_lance_ratios(
+    measurements: &HashMap<(Format, CompressOp), Duration>,
+    compressed_sizes: &HashMap<Format, u64>,
+    bench_name: &str,
+    ratios: &mut Vec<CustomUnitMeasurement>,
+) {
+    // Size ratio: vortex vs lance.
+    if let (Some(vortex_size), Some(lance_size)) = (
+        compressed_sizes.get(&Format::OnDiskVortex),
+        compressed_sizes.get(&Format::Lance),
+    ) {
+        ratios.push(CustomUnitMeasurement {
+            name: format!("vortex:lance size/{bench_name}"),
+            format: Format::OnDiskVortex,
+            unit: Cow::from("ratio"),
+            value: *vortex_size as f64 / *lance_size as f64,
+        });
+    }
 
-        // Compress time ratio: vortex vs lance.
-        if let (Some(vortex_time), Some(lance_time)) = (
-            measurements.get(&(Format::OnDiskVortex, CompressOp::Compress)),
-            measurements.get(&(Format::Lance, CompressOp::Compress)),
-        ) {
-            ratios.push(CustomUnitMeasurement {
-                name: format!("vortex:lance ratio compress time/{bench_name}"),
-                format: Format::OnDiskVortex,
-                unit: Cow::from("ratio"),
-                value: vortex_time.as_nanos() as f64 / lance_time.as_nanos() as f64,
-            });
-        }
+    // Compress time ratio: vortex vs lance.
+    if let (Some(vortex_time), Some(lance_time)) = (
+        measurements.get(&(Format::OnDiskVortex, CompressOp::Compress)),
+        measurements.get(&(Format::Lance, CompressOp::Compress)),
+    ) {
+        ratios.push(CustomUnitMeasurement {
+            name: format!("vortex:lance ratio compress time/{bench_name}"),
+            format: Format::OnDiskVortex,
+            unit: Cow::from("ratio"),
+            value: vortex_time.as_nanos() as f64 / lance_time.as_nanos() as f64,
+        });
+    }
 
-        // Decompress time ratio: vortex vs lance.
-        if let (Some(vortex_time), Some(lance_time)) = (
-            measurements.get(&(Format::OnDiskVortex, CompressOp::Decompress)),
-            measurements.get(&(Format::Lance, CompressOp::Decompress)),
-        ) {
-            ratios.push(CustomUnitMeasurement {
-                name: format!("vortex:lance ratio decompress time/{bench_name}"),
-                format: Format::OnDiskVortex,
-                unit: Cow::from("ratio"),
-                value: vortex_time.as_nanos() as f64 / lance_time.as_nanos() as f64,
-            });
-        }
+    // Decompress time ratio: vortex vs lance.
+    if let (Some(vortex_time), Some(lance_time)) = (
+        measurements.get(&(Format::OnDiskVortex, CompressOp::Decompress)),
+        measurements.get(&(Format::Lance, CompressOp::Decompress)),
+    ) {
+        ratios.push(CustomUnitMeasurement {
+            name: format!("vortex:lance ratio decompress time/{bench_name}"),
+            format: Format::OnDiskVortex,
+            unit: Cow::from("ratio"),
+            value: vortex_time.as_nanos() as f64 / lance_time.as_nanos() as f64,
+        });
     }
 }

--- a/bench-vortex/src/compress/mod.rs
+++ b/bench-vortex/src/compress/mod.rs
@@ -1,16 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-pub mod bench;
-pub mod lance;
-pub mod parquet;
-pub mod vortex;
-
 use std::sync::Arc;
 
 use ::vortex::arrays::ChunkedArray;
 use arrow_array::RecordBatch;
 use arrow_schema::Schema;
+
+pub mod bench;
+
+pub mod parquet;
+pub mod vortex;
+
+#[cfg(feature = "lance")]
+pub mod lance;
 
 pub fn chunked_to_vec_record_batch(chunked: ChunkedArray) -> (Vec<RecordBatch>, Arc<Schema>) {
     let chunks_vec = chunked.chunks();

--- a/bench-vortex/src/datasets/file.rs
+++ b/bench-vortex/src/datasets/file.rs
@@ -11,16 +11,12 @@ use datafusion::datasource::listing::{
 };
 use datafusion::prelude::SessionContext;
 use glob::Pattern;
-#[cfg(feature = "lance")]
-use lance::datafusion::LanceTableProvider;
-#[cfg(feature = "lance")]
-use lance::dataset::Dataset;
 use tracing::info;
 use url::Url;
 use vortex_datafusion::VortexFormat;
-
 #[cfg(feature = "lance")]
-use crate::Format;
+use {crate::Format, lance::datafusion::LanceTableProvider, lance::dataset::Dataset};
+
 use crate::datasets::BenchmarkDataset;
 
 pub async fn register_parquet_files(

--- a/bench-vortex/src/datasets/file.rs
+++ b/bench-vortex/src/datasets/file.rs
@@ -11,12 +11,15 @@ use datafusion::datasource::listing::{
 };
 use datafusion::prelude::SessionContext;
 use glob::Pattern;
+#[cfg(feature = "lance")]
 use lance::datafusion::LanceTableProvider;
+#[cfg(feature = "lance")]
 use lance::dataset::Dataset;
 use tracing::info;
 use url::Url;
 use vortex_datafusion::VortexFormat;
 
+#[cfg(feature = "lance")]
 use crate::Format;
 use crate::datasets::BenchmarkDataset;
 
@@ -167,6 +170,7 @@ pub async fn register_vortex_compact_files(
     Ok(())
 }
 
+#[cfg(feature = "lance")]
 pub async fn register_lance_files(
     session: &SessionContext,
     table_name: &str,

--- a/bench-vortex/src/datasets/mod.rs
+++ b/bench-vortex/src/datasets/mod.rs
@@ -11,6 +11,7 @@ use url::Url;
 use vortex::ArrayRef;
 
 use crate::clickbench::Flavor;
+#[cfg(feature = "lance")]
 use crate::file::register_lance_files;
 use crate::{Format, clickbench, fineweb, statpopgen};
 
@@ -144,6 +145,7 @@ impl BenchmarkDataset {
                 )
                 .await?;
             }
+            #[cfg(feature = "lance")]
             (cb @ BenchmarkDataset::ClickBench { .. }, Format::Lance) => {
                 register_lance_files(session, "hits", base_url, cb).await?;
             }

--- a/bench-vortex/src/datasets/taxi_data.rs
+++ b/bench-vortex/src/datasets/taxi_data.rs
@@ -1,23 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-#[cfg(feature = "lance")]
-use std::fs::File;
 use std::path::PathBuf;
 
 use anyhow::Result;
 use async_trait::async_trait;
-#[cfg(feature = "lance")]
-use lance::dataset::{Dataset as LanceDataset, WriteParams};
-#[cfg(feature = "lance")]
-use lance_encoding::version::LanceFileVersion;
-#[cfg(feature = "lance")]
-use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use tokio::fs::File as TokioFile;
 use tokio::io::AsyncWriteExt;
 use vortex::ArrayRef;
 use vortex::file::{VortexOpenOptions, VortexWriteOptions};
 use vortex::stream::ArrayStreamExt;
+#[cfg(feature = "lance")]
+use {
+    lance::dataset::{Dataset as LanceDataset, WriteParams},
+    lance_encoding::version::LanceFileVersion,
+    parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder,
+    std::fs::File,
+};
 
 use crate::conversions::parquet_to_vortex;
 use crate::datasets::Dataset;

--- a/bench-vortex/src/datasets/taxi_data.rs
+++ b/bench-vortex/src/datasets/taxi_data.rs
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+#[cfg(feature = "lance")]
 use std::fs::File;
 use std::path::PathBuf;
 
 use anyhow::Result;
 use async_trait::async_trait;
+#[cfg(feature = "lance")]
 use lance::dataset::{Dataset as LanceDataset, WriteParams};
+#[cfg(feature = "lance")]
 use lance_encoding::version::LanceFileVersion;
+#[cfg(feature = "lance")]
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use tokio::fs::File as TokioFile;
 use tokio::io::AsyncWriteExt;
@@ -89,6 +93,7 @@ pub async fn taxi_data_vortex_compact() -> Result<PathBuf> {
     .await
 }
 
+#[cfg(feature = "lance")]
 pub async fn taxi_data_lance() -> Result<PathBuf> {
     idempotent_async("taxi/taxi.lance", |output_fname| async move {
         let parquet_path = taxi_data_parquet().await?;

--- a/bench-vortex/src/engines/ddb/mod.rs
+++ b/bench-vortex/src/engines/ddb/mod.rs
@@ -147,6 +147,7 @@ impl DuckDBCtx {
         let object = match file_format {
             Format::Parquet | Format::OnDiskVortex | Format::VortexCompact => DuckDBObject::View,
             Format::OnDiskDuckDB => DuckDBObject::Table,
+            #[cfg(feature = "lance")]
             Format::Lance => {
                 anyhow::bail!(
                     "Lance format is not supported for DuckDB engine. \

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -107,8 +107,6 @@ impl Display for Target {
     }
 }
 
-// TODO(connor): Add a lance feature flag.
-
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, ValueEnum, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Format {
@@ -127,6 +125,7 @@ pub enum Format {
     #[clap(name = "duckdb")]
     #[serde(rename = "duckdb")]
     OnDiskDuckDB,
+    #[cfg(feature = "lance")]
     #[clap(name = "lance")]
     #[serde(rename = "lance")]
     Lance,
@@ -147,6 +146,7 @@ impl Format {
             Format::OnDiskVortex => "vortex-file-compressed",
             Format::VortexCompact => "vortex-compact",
             Format::OnDiskDuckDB => "duckdb",
+            #[cfg(feature = "lance")]
             Format::Lance => "lance",
         }
     }
@@ -159,6 +159,7 @@ impl Format {
             Format::OnDiskVortex => "vortex",
             Format::VortexCompact => "vortex",
             Format::OnDiskDuckDB => "duckdb",
+            #[cfg(feature = "lance")]
             Format::Lance => "lance",
         }
     }

--- a/bench-vortex/src/measurements.rs
+++ b/bench-vortex/src/measurements.rs
@@ -281,6 +281,7 @@ impl ToJson for CompressionTimingMeasurement {
         let (name, engine) = match self.format {
             Format::OnDiskVortex => (self.name.to_string(), Engine::Vortex),
             Format::Parquet => (format!("parquet_rs-zstd {}", self.name), Engine::Arrow),
+            #[cfg(feature = "lance")]
             Format::Lance => (format!("lance {}", self.name), Engine::Arrow),
             _ => vortex_panic!(
                 "CompressionTimingMeasurement only supports vortex, lance, and parquet formats"
@@ -324,7 +325,10 @@ impl ToJson for CustomUnitMeasurement {
     fn to_json(&self) -> Box<dyn erased_serde::Serialize> {
         let engine = match self.format {
             Format::OnDiskVortex | Format::VortexCompact => Engine::Vortex,
+            #[cfg(feature = "lance")]
             Format::Lance | Format::Parquet => Engine::Arrow,
+            #[cfg(not(feature = "lance"))]
+            Format::Parquet => Engine::Arrow,
             _ => Engine::Vortex, // Default to Vortex for other formats.
         };
 

--- a/bench-vortex/src/measurements.rs
+++ b/bench-vortex/src/measurements.rs
@@ -325,10 +325,9 @@ impl ToJson for CustomUnitMeasurement {
     fn to_json(&self) -> Box<dyn erased_serde::Serialize> {
         let engine = match self.format {
             Format::OnDiskVortex | Format::VortexCompact => Engine::Vortex,
-            #[cfg(feature = "lance")]
-            Format::Lance | Format::Parquet => Engine::Arrow,
-            #[cfg(not(feature = "lance"))]
             Format::Parquet => Engine::Arrow,
+            #[cfg(feature = "lance")]
+            Format::Lance => Engine::Arrow,
             _ => Engine::Vortex, // Default to Vortex for other formats.
         };
 

--- a/bench-vortex/src/random_access/take.rs
+++ b/bench-vortex/src/random_access/take.rs
@@ -10,6 +10,7 @@ use arrow_select::concat::concat_batches;
 use arrow_select::take::take_record_batch;
 use futures::stream;
 use itertools::Itertools;
+#[cfg(feature = "lance")]
 use lance::dataset::{Dataset, ProjectionRequest};
 use parquet::arrow::ParquetRecordBatchStreamBuilder;
 use parquet::arrow::arrow_reader::ArrowReaderOptions;
@@ -113,6 +114,7 @@ async fn parquet_take_from_stream<T: AsyncFileReader + Unpin + Send + 'static>(
     Ok(concat_batches(&schema, &batches)?)
 }
 
+#[cfg(feature = "lance")]
 pub async fn take_lance(path: &Path, indices: Buffer<u64>) -> anyhow::Result<RecordBatch> {
     let dataset = Dataset::open(path.to_str().unwrap()).await?;
     let projection = ProjectionRequest::from_schema(dataset.schema().clone()); // All columns.

--- a/bench-vortex/src/statpopgen/statpopgen_benchmark.rs
+++ b/bench-vortex/src/statpopgen/statpopgen_benchmark.rs
@@ -164,6 +164,7 @@ pub async fn register_table(
                         "DuckDB format should not be registered through DataFusion"
                     ));
                 }
+                #[cfg(feature = "lance")]
                 Format::Lance => unimplemented!(),
             })
             .with_session_config_options(session.state().config()),
@@ -208,6 +209,7 @@ impl Benchmark for StatPopGenBenchmark {
                         // DuckDBCtx::register_tables will automatically rewrite the Parquet file
                         // into a duckdb file.
                     }
+                    #[cfg(feature = "lance")]
                     Format::Lance => unimplemented!(),
                 }
                 Ok(())

--- a/bench-vortex/src/tpcds/duckdb.rs
+++ b/bench-vortex/src/tpcds/duckdb.rs
@@ -67,6 +67,7 @@ pub fn generate_tpcds(base_dir: PathBuf, scale_factor: String, format: Format) -
         Format::OnDiskDuckDB | Format::Arrow => {
             // These formats don't need export
         }
+        #[cfg(feature = "lance")]
         Format::Lance => unimplemented!(),
     }
 

--- a/bench-vortex/src/tpcds/tpcds_benchmark.rs
+++ b/bench-vortex/src/tpcds/tpcds_benchmark.rs
@@ -188,6 +188,7 @@ impl TpcDsBenchmark {
                 }
                 Format::OnDiskDuckDB => unreachable!("duckdb never supported with datafusion"),
                 Format::Csv => todo!(),
+                #[cfg(feature = "lance")]
                 Format::Lance => unimplemented!(),
             }
         }

--- a/bench-vortex/src/tpch/tpch_benchmark.rs
+++ b/bench-vortex/src/tpch/tpch_benchmark.rs
@@ -14,19 +14,17 @@ use log::{info, warn};
 use similar::{ChangeTag, TextDiff};
 use tokio::runtime::Runtime;
 use url::Url;
+#[cfg(feature = "lance")]
+use {crate::file::register_lance_files, crate::utils};
 
 use crate::benchmark_trait::Benchmark;
 use crate::engines::{EngineCtx, ddb};
-#[cfg(feature = "lance")]
-use crate::file::register_lance_files;
 use crate::tpch::schema::{CUSTOMER, LINEITEM, NATION, ORDERS, PART, PARTSUPP, REGION, SUPPLIER};
 use crate::tpch::tpchgen::TpchGenOptions;
 use crate::tpch::{
     EXPECTED_ROW_COUNTS_SF1, EXPECTED_ROW_COUNTS_SF10, register_arrow, register_parquet,
     register_vortex_compact_file, register_vortex_file, tpch_queries, tpchgen,
 };
-#[cfg(feature = "lance")]
-use crate::utils;
 use crate::{BenchmarkDataset, Format, IdempotentPath, Target};
 
 /// TPCH benchmark implementation

--- a/bench-vortex/src/tpch/tpch_benchmark.rs
+++ b/bench-vortex/src/tpch/tpch_benchmark.rs
@@ -17,6 +17,7 @@ use url::Url;
 
 use crate::benchmark_trait::Benchmark;
 use crate::engines::{EngineCtx, ddb};
+#[cfg(feature = "lance")]
 use crate::file::register_lance_files;
 use crate::tpch::schema::{CUSTOMER, LINEITEM, NATION, ORDERS, PART, PARTSUPP, REGION, SUPPLIER};
 use crate::tpch::tpchgen::TpchGenOptions;
@@ -24,7 +25,9 @@ use crate::tpch::{
     EXPECTED_ROW_COUNTS_SF1, EXPECTED_ROW_COUNTS_SF10, register_arrow, register_parquet,
     register_vortex_compact_file, register_vortex_file, tpch_queries, tpchgen,
 };
-use crate::{BenchmarkDataset, Format, IdempotentPath, Target, utils};
+#[cfg(feature = "lance")]
+use crate::utils;
+use crate::{BenchmarkDataset, Format, IdempotentPath, Target};
 
 /// TPCH benchmark implementation
 pub struct TpcHBenchmark {
@@ -86,6 +89,7 @@ impl Benchmark for TpcHBenchmark {
                     .map_err(|_| anyhow!("Invalid file URL: {}", self.data_url))?;
 
                 match target.format() {
+                    #[cfg(feature = "lance")]
                     Format::Lance => {
                         // For Lance: first generate Parquet, then convert
                         let options =
@@ -241,6 +245,7 @@ impl TpcHBenchmark {
                 }
                 Format::OnDiskDuckDB => unreachable!("duckdb never supported with datafusion"),
                 Format::Csv => todo!("csv unsupported for tpch benchmark"),
+                #[cfg(feature = "lance")]
                 Format::Lance => {
                     register_lance_files(session, name, &path, &self.dataset()).await?
                 }
@@ -341,6 +346,7 @@ impl TpcHBenchmark {
 }
 
 /// Convert TPCH Parquet tables to Lance format.
+#[cfg(feature = "lance")]
 pub async fn convert_all_tpch_to_lance(parquet_dir: &Path, lance_dir: &Path) -> Result<()> {
     let tables = [
         "customer", "lineitem", "nation", "orders", "part", "partsupp", "region", "supplier",

--- a/bench-vortex/src/tpch/tpchgen.rs
+++ b/bench-vortex/src/tpch/tpchgen.rs
@@ -171,7 +171,12 @@ fn generate_table_files(
         Format::Parquet | Format::Arrow | Format::OnDiskDuckDB => Format::Parquet,
         Format::OnDiskVortex => Format::OnDiskVortex,
         Format::VortexCompact => Format::VortexCompact,
+        #[cfg(feature = "lance")]
         f @ Format::Csv | f @ Format::Lance => {
+            anyhow::bail!("{f} format is not supported by tpchgen");
+        }
+        #[cfg(not(feature = "lance"))]
+        f @ Format::Csv => {
             anyhow::bail!("{f} format is not supported by tpchgen");
         }
     };

--- a/bench-vortex/src/utils/parquet_utils.rs
+++ b/bench-vortex/src/utils/parquet_utils.rs
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+#[cfg(feature = "lance")]
 use std::fs;
 use std::fs::File;
+#[cfg(not(feature = "lance"))]
+use std::path::PathBuf;
+#[cfg(feature = "lance")]
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -10,12 +14,17 @@ use anyhow::anyhow;
 use arrow_array::{RecordBatch, RecordBatchReader};
 use arrow_cast::cast;
 use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef};
+#[cfg(feature = "lance")]
 use lance::dataset::{Dataset as LanceDataset, WriteParams};
+#[cfg(feature = "lance")]
 use lance_encoding::version::LanceFileVersion;
+#[cfg(feature = "lance")]
 use log::info;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+#[cfg(feature = "lance")]
 use tokio::fs::create_dir_all;
 
+#[cfg(feature = "lance")]
 use crate::utils::idempotent_async;
 
 /// A streaming iterator that reads RecordBatches from multiple Parquet files sequentially.
@@ -91,6 +100,7 @@ impl RecordBatchReader for ParquetFilesIterator {
 ///
 /// If `convert_utf8view` is true, any Utf8View columns will be converted to Utf8
 /// (required for datasets like TPCH since Lance doesn't support Utf8View).
+#[cfg(feature = "lance")]
 pub async fn convert_parquet_to_lance(
     parquet_dir: &Path,
     lance_dir: &Path,

--- a/bench-vortex/src/utils/parquet_utils.rs
+++ b/bench-vortex/src/utils/parquet_utils.rs
@@ -1,31 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-#[cfg(feature = "lance")]
-use std::fs;
 use std::fs::File;
 #[cfg(not(feature = "lance"))]
 use std::path::PathBuf;
-#[cfg(feature = "lance")]
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::anyhow;
 use arrow_array::{RecordBatch, RecordBatchReader};
 use arrow_cast::cast;
 use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef};
-#[cfg(feature = "lance")]
-use lance::dataset::{Dataset as LanceDataset, WriteParams};
-#[cfg(feature = "lance")]
-use lance_encoding::version::LanceFileVersion;
-#[cfg(feature = "lance")]
-use log::info;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 #[cfg(feature = "lance")]
-use tokio::fs::create_dir_all;
-
-#[cfg(feature = "lance")]
-use crate::utils::idempotent_async;
+use {
+    crate::utils::idempotent_async,
+    lance::dataset::{Dataset as LanceDataset, WriteParams},
+    lance_encoding::version::LanceFileVersion,
+    log::info,
+    std::fs,
+    std::path::{Path, PathBuf},
+    tokio::fs::create_dir_all,
+};
 
 /// A streaming iterator that reads RecordBatches from multiple Parquet files sequentially.
 /// Works equally well for single files and multiple files.


### PR DESCRIPTION
Also modifies the actions so that we only run lance benchmarks in 2 places: _after_ a PR is merged and during nightly benchmarks.

Also let's hold off on merging this until tomorrow just in case it breaks something on the website.

Also note that the benchmark summaries on github (below) are going to be off since they no longer include lance