### PR TITLE
chore: Fuzzer can use builtin compare for nested types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8953,12 +8953,9 @@ dependencies = [
 name = "vortex-fuzz"
 version = "0.1.0"
 dependencies = [
- "arrow-buffer",
- "arrow-ord",
  "itertools 0.14.0",
  "libfuzzer-sys",
  "strum 0.27.2",
- "tokio",
  "vortex-array",
  "vortex-btrblocks",
  "vortex-buffer",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -18,12 +18,9 @@ version = { workspace = true }
 cargo-fuzz = true
 
 [dependencies]
-arrow-buffer = { workspace = true }
-arrow-ord = { workspace = true }
 itertools = { workspace = true }
 libfuzzer-sys = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
-tokio = { workspace = true, features = ["full"] }
 vortex-array = { workspace = true, features = ["arbitrary"] }
 vortex-btrblocks = { workspace = true }
 vortex-buffer = { workspace = true }

--- a/fuzz/fuzz_targets/file_io.rs
+++ b/fuzz/fuzz_targets/file_io.rs
@@ -4,15 +4,11 @@
 #![no_main]
 #![allow(clippy::result_large_err)]
 
-use arrow_buffer::BooleanBuffer;
-use arrow_ord::ord::make_comparator;
-use arrow_ord::sort::SortOptions;
 use itertools::Itertools;
 use libfuzzer_sys::{Corpus, fuzz_target};
 use vortex_array::arrays::ChunkedArray;
-use vortex_array::arrow::IntoArrowArray;
 use vortex_array::compute::{Operator, compare, filter};
-use vortex_array::{Array, ArrayRef, Canonical, IntoArray, ToCanonical};
+use vortex_array::{Array, Canonical, IntoArray, ToCanonical};
 use vortex_buffer::ByteBufferMut;
 use vortex_dtype::{DType, StructFields};
 use vortex_error::{VortexExpect, VortexUnwrap, vortex_panic};
@@ -87,48 +83,21 @@ fuzz_target!(|fuzz: FuzzFileAction| -> Corpus {
         output_array.dtype()
     );
 
-    if matches!(
-        expected_array.dtype(),
-        DType::Struct(_, _) | DType::List(_, _)
-    ) {
-        compare_struct(expected_array, output_array);
-    } else {
-        let bool_result = compare(&expected_array, &output_array, Operator::Eq)
-            .vortex_unwrap()
-            .to_bool();
-        let true_count = bool_result.boolean_buffer().count_set_bits();
-        if true_count != expected_array.len()
-            && (bool_result.all_valid() || expected_array.all_valid())
-        {
-            vortex_panic!(
-                "Failed to match original array {}with{}",
-                expected_array.display_tree(),
-                output_array.display_tree()
-            );
-        }
+    let bool_result = compare(&expected_array, &output_array, Operator::Eq)
+        .vortex_unwrap()
+        .to_bool();
+    let true_count = bool_result.boolean_buffer().count_set_bits();
+    if true_count != expected_array.len() && (bool_result.all_valid() || expected_array.all_valid())
+    {
+        vortex_panic!(
+            "Failed to match original array {}with{}",
+            expected_array.display_tree(),
+            output_array.display_tree()
+        );
     }
 
     Corpus::Keep
 });
-
-fn compare_struct(expected: ArrayRef, actual: ArrayRef) {
-    let arrow_expected = expected.clone().into_arrow_preferred().vortex_unwrap();
-    let arrow_actual = actual.clone().into_arrow_preferred().vortex_unwrap();
-
-    let cmp_fn =
-        make_comparator(&arrow_expected, &arrow_actual, SortOptions::default()).vortex_unwrap();
-
-    let comparison_result =
-        BooleanBuffer::collect_bool(arrow_expected.len(), |idx| cmp_fn(idx, idx).is_eq());
-
-    assert_eq!(
-        comparison_result.count_set_bits(),
-        arrow_expected.len(),
-        "\nEXPECTED: {}ACTUAL: {}",
-        expected.display_tree(),
-        actual.display_tree()
-    );
-}
 
 fn has_nullable_struct(dtype: &DType) -> bool {
     dtype.is_struct() && dtype.is_nullable()

--- a/fuzz/src/array/compare.rs
+++ b/fuzz/src/array/compare.rs
@@ -4,9 +4,8 @@
 use std::fmt::Debug;
 use std::ops::Deref;
 
-use arrow_buffer::BooleanBuffer;
 use vortex_array::accessor::ArrayAccessor;
-use vortex_array::arrays::BoolArray;
+use vortex_array::arrays::{BoolArray, BooleanBuffer};
 use vortex_array::compute::{Operator, scalar_cmp};
 use vortex_array::validity::Validity;
 use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};

--- a/vortex-expr/src/arbitrary.rs
+++ b/vortex-expr/src/arbitrary.rs
@@ -34,17 +34,10 @@ pub fn filter_expr(u: &mut Unstructured<'_>, dtype: &DType) -> AResult<Option<Ex
     let filter_count = u.int_in_range::<usize>(0..=max(struct_dtype.nfields(), 10))?;
 
     let filters = (0..filter_count)
-        .filter_map(|_| {
-            match u.choose_iter(struct_dtype.names().iter().zip(struct_dtype.fields())) {
-                Ok((col, dtype)) => {
-                    if dtype.is_struct() || dtype.is_list() {
-                        None
-                    } else {
-                        Some(random_comparison(u, col, &dtype))
-                    }
-                }
-                Err(e) => Some(Err(e)),
-            }
+        .map(|_| {
+            let (col, dtype) =
+                u.choose_iter(struct_dtype.names().iter().zip(struct_dtype.fields()))?;
+            random_comparison(u, col, &dtype)
         })
         .collect::<AResult<Vec<_>>>()?;
 


### PR DESCRIPTION
in #4783 we added arrow compare fallback to vortex compare method therefore we don't need special handling in the fuzzer to avoid comparing nested types