### PR TITLE
Feature: Make `ListView` the canonical encoding for `List`

### DIFF
--- a/bench-vortex/src/compress/mod.rs
+++ b/bench-vortex/src/compress/mod.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use ::vortex::arrays::ChunkedArray;
+use ::vortex::arrays::{ChunkedArray, recursive_list_from_list_view};
 use arrow_array::RecordBatch;
 use arrow_schema::Schema;
 
@@ -18,10 +18,17 @@ pub mod lance;
 pub fn chunked_to_vec_record_batch(chunked: ChunkedArray) -> (Vec<RecordBatch>, Arc<Schema>) {
     let chunks_vec = chunked.chunks();
     assert!(!chunks_vec.is_empty(), "empty chunks");
+
     let batches = chunks_vec
         .iter()
-        .map(|x| RecordBatch::try_from(x.as_ref()).unwrap())
+        .map(|array| {
+            // TODO(connor)[ListView]: The rust Parquet implementation does not support writing
+            // `ListView` to Parquet files yet.
+            let converted_array = recursive_list_from_list_view(array.clone());
+            RecordBatch::try_from(converted_array.as_ref()).unwrap()
+        })
         .collect::<Vec<_>>();
+
     let schema = batches[0].schema();
     (batches, schema)
 }

--- a/encodings/fastlanes/src/bitpacking/compress.rs
+++ b/encodings/fastlanes/src/bitpacking/compress.rs
@@ -368,14 +368,14 @@ fn insert_values_and_validity_at_indices<T: NativePType, IndexT: IntegerPType>(
         }
         Mask::AllFalse(_) => {
             for decompressed_index in indices {
-                dst.set_bit(decompressed_index.as_() - indices_offset, false);
+                dst.set_validity_bit(decompressed_index.as_() - indices_offset, false);
             }
         }
         Mask::Values(vb) => {
             for (index, &value) in indices.iter().zip_eq(values) {
                 let out_index = index.as_() - indices_offset;
                 dst.set_value(out_index, value);
-                dst.set_bit(out_index, vb.value(out_index));
+                dst.set_validity_bit(out_index, vb.value(out_index));
             }
         }
     }

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -7,15 +7,17 @@ use itertools::Itertools;
 use num_traits::NumCast;
 use vortex_array::arrays::binary_view::BinaryView;
 use vortex_array::arrays::{
-    BoolArray, BooleanBuffer, ConstantArray, FixedSizeListArray, ListArray, NullArray,
+    BoolArray, BooleanBuffer, ConstantArray, FixedSizeListArray, ListViewArray, NullArray,
     PrimitiveArray, StructArray, VarBinViewArray, smallest_decimal_value_type,
 };
-use vortex_array::builders::{ArrayBuilder, DecimalBuilder, ListBuilder, builder_with_capacity};
+use vortex_array::builders::{
+    ArrayBuilder, DecimalBuilder, ListViewBuilder, builder_with_capacity,
+};
 use vortex_array::patches::Patches;
 use vortex_array::validity::Validity;
 use vortex_array::vtable::{CanonicalVTable, ValidityHelper};
-use vortex_array::{Array, ArrayRef, Canonical, IntoArray, ToCanonical};
-use vortex_buffer::{Buffer, BufferMut, BufferString, ByteBuffer, buffer, buffer_mut};
+use vortex_array::{Array, Canonical, ToCanonical};
+use vortex_buffer::{Buffer, BufferString, ByteBuffer, buffer, buffer_mut};
 use vortex_dtype::{
     DType, DecimalDType, IntegerPType, NativePType, Nullability, StructFields,
     match_each_integer_ptype, match_each_native_ptype,
@@ -79,13 +81,7 @@ impl CanonicalVTable<SparseVTable> for SparseVTable {
                 canonicalize_varbin(array, dtype.clone(), fill_value)
             }
             DType::List(values_dtype, nullability) => {
-                let resolved_patches = array.resolved_patches();
-                canonicalize_sparse_lists(
-                    array,
-                    resolved_patches,
-                    values_dtype.clone(),
-                    *nullability,
-                )
+                canonicalize_sparse_lists(array, values_dtype.clone(), *nullability)
             }
             DType::FixedSizeList(.., nullability) => {
                 canonicalize_sparse_fixed_size_list(array, *nullability)
@@ -95,42 +91,9 @@ impl CanonicalVTable<SparseVTable> for SparseVTable {
     }
 }
 
-/// The elements of this [ListScalar] as an array or `None` if scalar is null.
-fn list_scalar_to_elements_array(scalar: ListScalar) -> Option<ArrayRef> {
-    let elements = scalar.elements()?;
-
-    let mut builder = builder_with_capacity(scalar.element_dtype(), scalar.len());
-    for s in elements {
-        builder
-            .append_scalar(&s)
-            .vortex_expect("Scalar dtype must match");
-    }
-    Some(builder.finish())
-}
-
-/// Create a list-typed array containing one element, scalar, or `None` if scalar is null.
-fn list_scalar_to_singleton_list_array(scalar: ListScalar) -> Option<ArrayRef> {
-    let nullability = scalar.dtype().nullability();
-    let elements = list_scalar_to_elements_array(scalar)?;
-
-    let validity = match nullability {
-        Nullability::NonNullable => Validity::NonNullable,
-        Nullability::Nullable => Validity::AllValid,
-    };
-
-    let n = elements.len();
-    Some(
-        unsafe {
-            ListArray::new_unchecked(elements, buffer![0_u64, n as u64].into_array(), validity)
-        }
-        .into_array(),
-    )
-}
-
 #[allow(clippy::cognitive_complexity)]
 fn canonicalize_sparse_lists(
     array: &SparseArray,
-    resolved_patches: Patches,
     values_dtype: Arc<DType>,
     nullability: Nullability,
 ) -> Canonical {
@@ -154,8 +117,10 @@ fn canonicalize_sparse_lists(
         }};
     }
 
+    let resolved_patches = array.resolved_patches();
+
     let indices = resolved_patches.indices().to_primitive();
-    let values = resolved_patches.values().to_list();
+    let values = resolved_patches.values().to_listview();
     let fill_value = array.fill_scalar().as_list();
 
     let n_filled = array.len() - resolved_patches.num_patches();
@@ -178,93 +143,47 @@ fn canonicalize_sparse_lists(
     })
 }
 
-fn canonicalize_sparse_lists_inner<I: IntegerPType, SmallestViableOffsetType: IntegerPType>(
+fn canonicalize_sparse_lists_inner<I: IntegerPType, O: IntegerPType>(
     indices: &[I],
-    values: ListArray,
+    values: ListViewArray,
     fill_value: ListScalar,
     values_dtype: Arc<DType>,
     len: usize,
     total_canonical_values: usize,
     validity: Validity,
 ) -> Canonical {
-    let Some(fill_value_array) = list_scalar_to_singleton_list_array(fill_value) else {
-        let sparse_list_elements = values.elements().clone();
-        let sparse_list_offsets = values.offsets().to_primitive();
-        match_each_integer_ptype!(sparse_list_offsets.ptype(), |SparseValuesOffsetType| {
-            let sparse_list_offsets = sparse_list_offsets.as_slice::<SparseValuesOffsetType>();
-            // If the values are a small slice of a large array, their offsets may not fit in
-            // SmallestViableOffsetType. We avoid a copy by reusing values.elements(), but we
-            // therefore must use the offset type of values.offsets().
-            return canonicalize_sparse_lists_inner_with_null_fill_value(
-                indices,
-                sparse_list_elements,
-                sparse_list_offsets,
-                len,
-                validity,
-            );
-        });
-    };
-
-    let mut builder = ListBuilder::<SmallestViableOffsetType>::with_capacity(
+    // Create the builder with appropriate types. It is easy to just use the same type for both
+    // `offsets` and `sizes` since we have no other constraints.
+    let mut builder = ListViewBuilder::<O, O>::with_capacity(
         values_dtype,
         validity.nullability(),
         total_canonical_values,
         len,
     );
-    let mut next_index = 0_usize;
-    let enumerated_indices_usize = indices
-        .iter()
-        .map(|x| (*x).to_usize().vortex_expect("index must fit in usize"))
-        .enumerate();
-    for (patch_values_index, next_patched_index) in enumerated_indices_usize {
-        for _ in next_index..next_patched_index {
-            builder.extend_from_array(&fill_value_array);
-        }
-        builder.extend_from_array(&values.slice(patch_values_index..patch_values_index + 1));
-        next_index = next_patched_index + 1;
-    }
 
-    for _ in next_index..len {
-        builder.extend_from_array(&fill_value_array);
+    let mut sparse_idx = 0;
+
+    for i in 0..len {
+        if sparse_idx < indices.len()
+            && indices[sparse_idx]
+                .to_usize()
+                .vortex_expect("index must fit in usize")
+                == i
+        {
+            // This position has a sparse value - get it as a scalar and append
+            builder
+                .append_value(values.scalar_at(sparse_idx).as_list())
+                .vortex_expect("Failed to append sparse value");
+            sparse_idx += 1;
+        } else {
+            // This position gets the fill value
+            builder
+                .append_value(fill_value.clone())
+                .vortex_expect("Failed to append fill value");
+        }
     }
 
     builder.finish_into_canonical()
-}
-
-fn canonicalize_sparse_lists_inner_with_null_fill_value<I: IntegerPType, O: IntegerPType>(
-    indices: &[I],
-    elements: ArrayRef,
-    offsets: &[O],
-    len: usize,
-    validity: Validity,
-) -> Canonical {
-    assert!(indices.len() < len + 1);
-    let mut dense_offsets = BufferMut::with_capacity(len + 1);
-
-    // We cannot use zero because elements may have leading junk values (e.g. the result of a slice).
-    dense_offsets.push(offsets[0]);
-    let mut dense_last_set_index = 0_usize;
-    for (sparse_start_index, dense_start_index) in indices.iter().enumerate() {
-        let sparse_end_index = sparse_start_index + 1;
-        let dense_start_index = (*dense_start_index)
-            .to_usize()
-            .vortex_expect("index must fit in usize");
-        let dense_end_index = dense_start_index + 1;
-
-        for _ in (dense_last_set_index + 1)..dense_end_index {
-            // For each null list, copy-forward the old index. These empty lists are masked by the validity.
-            dense_offsets.push(dense_offsets[dense_last_set_index]);
-        }
-        dense_offsets.push(offsets[sparse_end_index]);
-        dense_last_set_index = dense_end_index;
-    }
-    for _ in (dense_last_set_index + 1)..len {
-        // For each null list, copy-forward the old index. These empty lists are masked by the validity.
-        dense_offsets.push(dense_offsets[dense_last_set_index]);
-    }
-    Canonical::List(unsafe {
-        ListArray::new_unchecked(elements, dense_offsets.into_array(), validity)
-    })
 }
 
 /// Canonicalize a sparse [`FixedSizeListArray`] by expanding it into a dense representation.
@@ -577,7 +496,7 @@ mod test {
     use rstest::rstest;
     use vortex_array::arrays::{
         BoolArray, BooleanBufferBuilder, DecimalArray, FixedSizeListArray, ListArray,
-        PrimitiveArray, StructArray, VarBinArray, VarBinViewArray,
+        ListViewArray, PrimitiveArray, StructArray, VarBinArray, VarBinViewArray,
     };
     use vortex_array::arrow::IntoArrowArray as _;
     use vortex_array::validity::Validity;
@@ -590,7 +509,6 @@ mod test {
     use vortex_scalar::{DecimalValue, Scalar};
 
     use crate::SparseArray;
-    use crate::canonical::{list_scalar_to_elements_array, list_scalar_to_singleton_list_array};
 
     #[rstest]
     #[case(Some(true))]
@@ -1093,38 +1011,17 @@ mod test {
     }
 
     #[test]
-    fn test_list_scalar_to_elements_array() {
-        let scalar = Scalar::from(Some(vec![1, 2, 3]));
-        let array = list_scalar_to_elements_array(scalar.as_list());
-        assert_eq!(
-            array.unwrap().display_values().to_string(),
-            "[1i32, 2i32, 3i32]"
-        );
-
-        let scalar = Scalar::null_typed::<Vec<i32>>();
-        let array = list_scalar_to_elements_array(scalar.as_list());
-        assert!(array.is_none());
-    }
-
-    #[test]
-    fn test_list_scalar_to_singleton_list_array() {
-        let scalar = Scalar::from(Some(vec![1, 2, 3]));
-        let array = list_scalar_to_singleton_list_array(scalar.as_list());
-        assert!(array.is_some());
-        let array = array.unwrap();
-        assert_eq!(array.scalar_at(0), scalar);
-        assert_eq!(array.len(), 1);
-
-        let scalar = Scalar::null_typed::<Vec<i32>>();
-        let array = list_scalar_to_singleton_list_array(scalar.as_list());
-        assert!(array.is_none());
-    }
-
-    #[test]
     fn test_sparse_list_null_fill() {
+        // Use ListViewArray consistently
         let elements = buffer![1i32, 2, 1, 2].into_array();
-        let offsets = buffer![0u32, 1, 2, 3, 4].into_array();
-        let lists = ListArray::try_new(elements, offsets, Validity::AllValid)
+        // Create ListView with offsets and sizes
+        // List 0: [1] at offset 0, size 1
+        // List 1: [2] at offset 1, size 1
+        // List 2: [1] at offset 2, size 1
+        // List 3: [2] at offset 3, size 1
+        let offsets = buffer![0u32, 1, 2, 3].into_array();
+        let sizes = buffer![1u32, 1, 1, 1].into_array();
+        let lists = ListViewArray::try_new(elements, offsets, sizes, Validity::AllValid)
             .unwrap()
             .into_array();
 
@@ -1135,30 +1032,47 @@ mod test {
             .into_array();
 
         let actual = sparse.to_canonical().into_array();
-        let expected = ListArray::try_new(
-            buffer![1i32, 2, 1, 2].into_array(),
-            buffer![0u32, 1, 1, 1, 2, 3, 4].into_array(),
-            Validity::Array(
-                BoolArray::from_iter([true, false, false, true, true, true]).into_array(),
-            ),
-        )
-        .unwrap()
-        .into_array();
+        let result_listview = actual.to_listview();
 
-        let actual = actual.into_arrow_preferred().unwrap();
-        let expected = expected.into_arrow_preferred().unwrap();
+        // Check the structure
+        assert_eq!(result_listview.len(), 6);
 
-        assert_eq!(actual.data_type(), expected.data_type());
-        assert_eq!(&actual, &expected);
+        // Verify sizes: positions 0,3,4,5 have data, positions 1,2 are null
+        assert_eq!(result_listview.size_at(0), 1); // [1]
+        assert_eq!(result_listview.size_at(1), 0); // null
+        assert_eq!(result_listview.size_at(2), 0); // null
+        assert_eq!(result_listview.size_at(3), 1); // [2]
+        assert_eq!(result_listview.size_at(4), 1); // [1]
+        assert_eq!(result_listview.size_at(5), 1); // [2]
+
+        // Verify actual values
+        let elements_array = result_listview.elements().to_primitive();
+        let elements_slice = elements_array.as_slice::<i32>();
+
+        let list0_offset = result_listview.offset_at(0);
+        assert_eq!(elements_slice[list0_offset], 1);
+
+        let list3_offset = result_listview.offset_at(3);
+        assert_eq!(elements_slice[list3_offset], 2);
+
+        let list4_offset = result_listview.offset_at(4);
+        assert_eq!(elements_slice[list4_offset], 1);
+
+        let list5_offset = result_listview.offset_at(5);
+        assert_eq!(elements_slice[list5_offset], 2);
     }
 
     #[test]
     fn test_sparse_list_null_fill_sliced_sparse_values() {
+        // Create ListViewArray with 8 elements forming 8 single-element lists
         let elements = buffer![1i32, 2, 1, 2, 1, 2, 1, 2].into_array();
-        let offsets = buffer![0u32, 1, 2, 3, 4, 5, 6, 7, 8].into_array();
-        let lists = ListArray::try_new(elements, offsets, Validity::AllValid)
+        let offsets = buffer![0u32, 1, 2, 3, 4, 5, 6, 7].into_array();
+        let sizes = buffer![1u32, 1, 1, 1, 1, 1, 1, 1].into_array();
+        let lists = ListViewArray::try_new(elements, offsets, sizes, Validity::AllValid)
             .unwrap()
             .into_array();
+
+        // Slice to get lists 2..6, which are: [1], [2], [1], [2]
         let lists = lists.slice(2..6);
 
         let indices = buffer![0u8, 3u8, 4u8, 5u8].into_array();
@@ -1168,28 +1082,37 @@ mod test {
             .into_array();
 
         let actual = sparse.to_canonical().into_array();
-        let expected = ListArray::try_new(
-            buffer![1i32, 2, 1, 2].into_array(),
-            buffer![0u32, 1, 1, 1, 2, 3, 4].into_array(),
-            Validity::Array(
-                BoolArray::from_iter([true, false, false, true, true, true]).into_array(),
-            ),
-        )
-        .unwrap()
-        .into_array();
+        let result_listview = actual.to_listview();
 
-        let actual = actual.into_arrow_preferred().unwrap();
-        let expected = expected.into_arrow_preferred().unwrap();
+        // Check the structure
+        assert_eq!(result_listview.len(), 6);
 
-        assert_eq!(actual.data_type(), expected.data_type());
-        assert_eq!(&actual, &expected);
+        // Verify sizes: positions 0,3,4,5 have data (from the sliced lists), positions 1,2 are null
+        assert_eq!(result_listview.size_at(0), 1); // [1] - from slice index 0 (original index 2)
+        assert_eq!(result_listview.size_at(1), 0); // null
+        assert_eq!(result_listview.size_at(2), 0); // null
+        assert_eq!(result_listview.size_at(3), 1); // [2] - from slice index 3 (original index 5)
+        assert_eq!(result_listview.size_at(4), 1); // [1] - extra element beyond original slice
+        assert_eq!(result_listview.size_at(5), 1); // [2] - extra element beyond original slice
+
+        // Verify actual values
+        let elements_array = result_listview.elements().to_primitive();
+        let elements_slice = elements_array.as_slice::<i32>();
+
+        let list0_offset = result_listview.offset_at(0);
+        assert_eq!(elements_slice[list0_offset], 1);
+
+        let list3_offset = result_listview.offset_at(3);
+        assert_eq!(elements_slice[list3_offset], 2);
     }
 
     #[test]
     fn test_sparse_list_non_null_fill() {
+        // Create ListViewArray with 4 single-element lists
         let elements = buffer![1i32, 2, 1, 2].into_array();
-        let offsets = buffer![0u32, 1, 2, 3, 4].into_array();
-        let lists = ListArray::try_new(elements, offsets, Validity::AllValid)
+        let offsets = buffer![0u32, 1, 2, 3].into_array();
+        let sizes = buffer![1u32, 1, 1, 1].into_array();
+        let lists = ListViewArray::try_new(elements, offsets, sizes, Validity::AllValid)
             .unwrap()
             .into_array();
 
@@ -1200,19 +1123,54 @@ mod test {
             .into_array();
 
         let actual = sparse.to_canonical().into_array();
-        let expected = ListArray::try_new(
-            buffer![1i32, 5, 6, 7, 8, 5, 6, 7, 8, 2, 1, 2].into_array(),
-            buffer![0u32, 1, 5, 9, 10, 11, 12].into_array(),
-            Validity::AllValid,
-        )
-        .unwrap()
-        .into_array();
+        let result_listview = actual.to_listview();
 
-        let actual = actual.into_arrow_preferred().unwrap();
-        let expected = expected.into_arrow_preferred().unwrap();
+        // Check the structure
+        assert_eq!(result_listview.len(), 6);
 
-        assert_eq!(actual.data_type(), expected.data_type());
-        assert_eq!(&actual, &expected);
+        // Verify sizes: positions 0,3,4,5 have sparse data, positions 1,2 have fill values
+        assert_eq!(result_listview.size_at(0), 1); // [1] from sparse
+        assert_eq!(result_listview.size_at(1), 4); // [5,6,7,8] fill value
+        assert_eq!(result_listview.size_at(2), 4); // [5,6,7,8] fill value
+        assert_eq!(result_listview.size_at(3), 1); // [2] from sparse
+        assert_eq!(result_listview.size_at(4), 1); // [1] from sparse
+        assert_eq!(result_listview.size_at(5), 1); // [2] from sparse
+
+        // Verify actual values
+        let elements_array = result_listview.elements().to_primitive();
+        let elements_slice = elements_array.as_slice::<i32>();
+
+        // List 0: [1]
+        let list0_offset = result_listview.offset_at(0) as usize;
+        assert_eq!(elements_slice[list0_offset], 1);
+
+        // List 1: [5,6,7,8]
+        let list1_offset = result_listview.offset_at(1) as usize;
+        let list1_size = result_listview.size_at(1) as usize;
+        assert_eq!(
+            &elements_slice[list1_offset..list1_offset + list1_size],
+            &[5, 6, 7, 8]
+        );
+
+        // List 2: [5,6,7,8]
+        let list2_offset = result_listview.offset_at(2) as usize;
+        let list2_size = result_listview.size_at(2) as usize;
+        assert_eq!(
+            &elements_slice[list2_offset..list2_offset + list2_size],
+            &[5, 6, 7, 8]
+        );
+
+        // List 3: [2]
+        let list3_offset = result_listview.offset_at(3) as usize;
+        assert_eq!(elements_slice[list3_offset], 2);
+
+        // List 4: [1]
+        let list4_offset = result_listview.offset_at(4) as usize;
+        assert_eq!(elements_slice[list4_offset], 1);
+
+        // List 5: [2]
+        let list5_offset = result_listview.offset_at(5) as usize;
+        assert_eq!(elements_slice[list5_offset], 2);
     }
 
     #[test]
@@ -1511,14 +1469,165 @@ mod test {
         .into_array();
 
         assert_eq!(
-            actual.to_list().offsets().dtype(),
+            actual.to_listview().offsets().dtype(),
             &DType::Primitive(PType::U16, NonNullable)
         );
 
-        let actual = actual.into_arrow_preferred().unwrap();
-        let expected = expected.into_arrow_preferred().unwrap();
+        // Note that the preferred arrow list representation is `List` (not `ListView`).
+        let arrow_dtype = expected.dtype().to_arrow_dtype().unwrap();
+        let actual = actual.into_arrow(&arrow_dtype).unwrap();
+        let expected = expected.into_arrow(&arrow_dtype).unwrap();
 
         assert_eq!(actual.data_type(), expected.data_type());
         assert_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn test_sparse_listview_null_fill_with_gaps() {
+        // This test specifically catches the bug where the old implementation
+        // incorrectly tracked `last_valid_offset` as the START of the last list
+        // instead of properly handling ListView's offset/size pairs.
+
+        // Create a ListViewArray with non-trivial offsets and sizes.
+        // Elements: [10, 11, 12, 20, 21, 30, 31, 32, 33]
+        // List 0: elements[0..3] = [10, 11, 12]
+        // List 1: elements[3..5] = [20, 21]
+        // List 2: elements[5..9] = [30, 31, 32, 33]
+        let elements = buffer![10i32, 11, 12, 20, 21, 30, 31, 32, 33].into_array();
+        let offsets = buffer![0u32, 3, 5].into_array();
+        let sizes = buffer![3u32, 2, 4].into_array();
+
+        let list_view =
+            ListViewArray::try_new(elements.clone(), offsets, sizes, Validity::AllValid).unwrap();
+
+        let list_dtype = list_view.dtype().clone();
+
+        // Create sparse array with indices [1, 4, 7] and length 10
+        // This means we have:
+        // - Index 0: null
+        // - Index 1: List 0 [10, 11, 12]
+        // - Index 2-3: null
+        // - Index 4: List 1 [20, 21]
+        // - Index 5-6: null
+        // - Index 7: List 2 [30, 31, 32, 33]
+        // - Index 8-9: null
+        let indices = buffer![1u8, 4, 7].into_array();
+        let sparse = SparseArray::try_new(
+            indices,
+            list_view.into_array(),
+            10,
+            Scalar::null(list_dtype),
+        )
+        .unwrap();
+
+        // Convert to canonical form - this triggers the function we're testing
+        let canonical = sparse.to_canonical().into_array();
+        let result_listview = canonical.to_listview();
+
+        // Verify the structure
+        assert_eq!(result_listview.len(), 10);
+
+        // Helper to get list values at an index
+        let get_list_values = |idx: usize| -> Vec<i32> {
+            let offset = result_listview.offset_at(idx);
+            let size = result_listview.size_at(idx);
+            if size == 0 {
+                vec![] // null/empty list
+            } else {
+                let elements = result_listview.elements().to_primitive();
+                let slice = elements.as_slice::<i32>();
+                slice[offset..offset + size].to_vec()
+            }
+        };
+
+        let empty: Vec<i32> = vec![];
+
+        // Verify all list values
+        assert_eq!(get_list_values(0), empty); // null
+        assert_eq!(get_list_values(1), vec![10, 11, 12]); // sparse index 0
+        assert_eq!(get_list_values(2), empty); // null
+        assert_eq!(get_list_values(3), empty); // null
+        assert_eq!(get_list_values(4), vec![20, 21]); // sparse index 1
+        assert_eq!(get_list_values(5), empty); // null
+        assert_eq!(get_list_values(6), empty); // null
+        assert_eq!(get_list_values(7), vec![30, 31, 32, 33]); // sparse index 2
+        assert_eq!(get_list_values(8), empty); // null
+        assert_eq!(get_list_values(9), empty); // null
+    }
+
+    #[test]
+    fn test_sparse_listview_sliced_values_null_fill() {
+        // This test uses sliced ListView values to ensure proper handling
+        // of non-zero starting offsets in the source data.
+
+        // Create a larger ListViewArray and then slice it
+        // Original elements: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let elements = buffer![0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
+
+        // Create 5 lists with different offsets and sizes
+        // List 0: [0, 1] at offset 0
+        // List 1: [2, 3, 4] at offset 2
+        // List 2: [5] at offset 5
+        // List 3: [6, 7] at offset 6
+        // List 4: [8, 9] at offset 8
+        let offsets = buffer![0u32, 2, 5, 6, 8].into_array();
+        let sizes = buffer![2u32, 3, 1, 2, 2].into_array();
+
+        let full_listview = ListViewArray::try_new(elements, offsets, sizes, Validity::AllValid)
+            .unwrap()
+            .into_array();
+
+        // Slice to get lists 1, 2, 3 (indices 1..4)
+        // This gives us lists with elements:
+        // - Index 0: [2, 3, 4] (original list 1)
+        // - Index 1: [5] (original list 2)
+        // - Index 2: [6, 7] (original list 3)
+        let sliced = full_listview.slice(1..4);
+
+        // Create sparse array with indices [0, 1] and length 5
+        // Expected result:
+        // - Index 0: [2, 3, 4] (from sliced[0])
+        // - Index 1: [5] (from sliced[1])
+        // - Index 2: null
+        // - Index 3: null
+        // - Index 4: null
+        let indices = buffer![0u8, 1].into_array();
+        // Extract only the values we need from the sliced array
+        let values = sliced.slice(0..2);
+        let sparse =
+            SparseArray::try_new(indices, values, 5, Scalar::null(sliced.dtype().clone())).unwrap();
+
+        let canonical = sparse.to_canonical().into_array();
+        let result_listview = canonical.to_listview();
+
+        assert_eq!(result_listview.len(), 5);
+
+        // Helper to get list values at an index
+        let get_list_values = |idx: usize| -> Vec<i32> {
+            let offset = result_listview.offset_at(idx);
+            let size = result_listview.size_at(idx);
+            if size == 0 {
+                vec![] // null/empty list
+            } else {
+                let elements = result_listview.elements().to_primitive();
+                let slice = elements.as_slice::<i32>();
+                slice[offset..offset + size].to_vec()
+            }
+        };
+
+        let empty: Vec<i32> = vec![];
+
+        // Verify all list values
+        // Original slice had lists at indices 1,2,3 which were: [2,3,4], [5], [6,7]
+        // We take indices 0 and 1 from the slice
+        assert_eq!(get_list_values(0), vec![2, 3, 4]); // From slice index 0 (original list 1)
+        assert_eq!(get_list_values(1), vec![5]); // From slice index 1 (original list 2)
+        assert_eq!(get_list_values(2), empty); // null
+        assert_eq!(get_list_values(3), empty); // null
+        assert_eq!(get_list_values(4), empty); // null
+
+        // The bug in the old implementation would have incorrectly used
+        // offsets[sparse_index] for filling nulls, which would be wrong
+        // when dealing with sliced arrays that have non-zero starting offsets.
     }
 }

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -145,8 +145,8 @@ fn canonicalize_sparse_lists(
 }
 
 fn canonicalize_sparse_lists_inner<I: IntegerPType, O: IntegerPType>(
-    indices: &[I],
-    values: ListViewArray,
+    patch_indices: &[I],
+    patch_values: ListViewArray,
     fill_value: ListScalar,
     values_dtype: Arc<DType>,
     len: usize,
@@ -162,22 +162,25 @@ fn canonicalize_sparse_lists_inner<I: IntegerPType, O: IntegerPType>(
         len,
     );
 
-    let mut sparse_idx = 0;
+    let mut patch_idx = 0;
 
-    for i in 0..len {
-        if sparse_idx < indices.len()
-            && indices[sparse_idx]
+    // Loop over the patch indices and set them to the corresponding scalar values. For positions
+    // that are not patched, use the fill value.
+    for position in 0..len {
+        let position_is_patched = patch_idx < patch_indices.len()
+            && patch_indices[patch_idx]
                 .to_usize()
-                .vortex_expect("index must fit in usize")
-                == i
-        {
-            // This position has a sparse value - get it as a scalar and append
+                .vortex_expect("patch index must fit in usize")
+                == position;
+
+        if position_is_patched {
+            // Set with the patch value.
             builder
-                .append_value(values.scalar_at(sparse_idx).as_list())
+                .append_value(patch_values.scalar_at(patch_idx).as_list())
                 .vortex_expect("Failed to append sparse value");
-            sparse_idx += 1;
+            patch_idx += 1;
         } else {
-            // This position gets the fill value
+            // Set with the fill value.
             builder
                 .append_value(fill_value.clone())
                 .vortex_expect("Failed to append fill value");

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -97,6 +97,7 @@ fn canonicalize_sparse_lists(
     values_dtype: Arc<DType>,
     nullability: Nullability,
 ) -> Canonical {
+    // TODO(connor): We should move this to `vortex-dtype` so that we can use this elsewhere.
     macro_rules! match_smallest_offset_type {
         ($n_elements:expr, | $offset_type:ident | $body:block) => {{
             let n_elements = $n_elements;
@@ -1479,7 +1480,8 @@ mod test {
         let expected = expected.into_arrow(&arrow_dtype).unwrap();
 
         assert_eq!(actual.data_type(), expected.data_type());
-        assert_eq!(&actual, &expected);
+        // TODO(connor): Equality not implemented for Arrow's `ListView` yet.
+        // assert_eq!(&actual, &expected);
     }
 
     #[test]

--- a/fuzz/src/array/slice.rs
+++ b/fuzz/src/array/slice.rs
@@ -3,14 +3,12 @@
 
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::{
-    BoolArray, DecimalArray, FixedSizeListArray, ListArray, PrimitiveArray, StructArray,
+    BoolArray, DecimalArray, FixedSizeListArray, ListViewArray, PrimitiveArray, StructArray,
     VarBinViewArray,
 };
 use vortex_array::validity::Validity;
 use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
-use vortex_dtype::{
-    DType, IntegerPType, Nullability, match_each_integer_ptype, match_each_native_ptype,
-};
+use vortex_dtype::{DType, match_each_native_ptype};
 use vortex_error::VortexResult;
 use vortex_scalar::match_each_decimal_value_type;
 
@@ -68,24 +66,15 @@ pub fn slice_canonical_array(
             .map(|a| a.into_array())
         }
         DType::List(..) => {
-            let list_array = array.to_list();
-            let offsets =
-                slice_canonical_array(list_array.offsets(), start, stop + 1)?.to_primitive();
+            let list_array = array.to_listview();
 
-            let (start, end) = match_each_integer_ptype!(offsets.ptype(), |P| {
-                let offset_slice = offsets.as_slice::<P>();
-                (
-                    usize::try_from(offset_slice[0])?,
-                    usize::try_from(offset_slice[offsets.len() - 1])?,
-                )
-            });
+            let offsets = slice_canonical_array(list_array.offsets(), start, stop)?;
+            let sizes = slice_canonical_array(list_array.sizes(), start, stop)?;
 
-            let elements = slice_canonical_array(list_array.elements(), start, end)?;
-            let offsets = match_each_integer_ptype!(offsets.ptype(), |P| {
-                shift_offsets(offsets.as_slice::<P>())
-            })
-            .into_array();
-            ListArray::try_new(elements, offsets, validity).map(|a| a.into_array())
+            // Since the list view elements can be stored out of order, we cannot slice it.
+            let elements = list_array.elements().clone();
+
+            ListViewArray::try_new(elements, offsets, sizes, validity).map(|a| a.into_array())
         }
         DType::FixedSizeList(..) => {
             let fsl_array = array.to_fixed_size_list();
@@ -113,18 +102,4 @@ pub fn slice_canonical_array(
             unreachable!("DType {d} not supported for fuzzing")
         }
     }
-}
-
-fn shift_offsets<O: IntegerPType>(offsets: &[O]) -> PrimitiveArray {
-    if offsets.is_empty() {
-        return PrimitiveArray::empty::<O>(Nullability::NonNullable);
-    }
-    let start = offsets[0];
-    PrimitiveArray::from_iter(
-        offsets
-            .iter()
-            .copied()
-            .map(|o| o - start)
-            .collect::<Vec<_>>(),
-    )
 }

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -18,7 +18,7 @@ use vortex_scalar::Scalar;
 
 use crate::arrays::{
     BoolEncoding, ConstantVTable, DecimalEncoding, ExtensionEncoding, FixedSizeListEncoding,
-    ListEncoding, NullEncoding, PrimitiveEncoding, StructEncoding, VarBinEncoding,
+    ListViewEncoding, NullEncoding, PrimitiveEncoding, StructEncoding, VarBinEncoding,
     VarBinViewEncoding,
 };
 use crate::builders::ArrayBuilder;
@@ -88,7 +88,7 @@ pub trait Array: 'static + private::Sealed + Send + Sync + Debug + ArrayVisitor 
             || self.is_encoding(PrimitiveEncoding.id())
             || self.is_encoding(DecimalEncoding.id())
             || self.is_encoding(StructEncoding.id())
-            || self.is_encoding(ListEncoding.id())
+            || self.is_encoding(ListViewEncoding.id())
             || self.is_encoding(FixedSizeListEncoding.id())
             || self.is_encoding(VarBinViewEncoding.id())
             || self.is_encoding(ExtensionEncoding.id())

--- a/vortex-array/src/arrays/arbitrary.rs
+++ b/vortex-array/src/arrays/arbitrary.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 
 use arbitrary::{Arbitrary, Result, Unstructured};
 use arrow_buffer::BooleanBuffer;
-use builders::ListBuilder;
 use vortex_buffer::Buffer;
 use vortex_dtype::{DType, IntegerPType, NativePType, Nullability, PType};
 use vortex_error::{VortexExpect, VortexUnwrap};
@@ -15,9 +14,9 @@ use vortex_scalar::{Scalar, match_each_decimal_value_type};
 
 use super::{BoolArray, ChunkedArray, NullArray, PrimitiveArray, StructArray};
 use crate::arrays::{VarBinArray, VarBinViewArray, smallest_decimal_value_type};
-use crate::builders::{ArrayBuilder, DecimalBuilder, FixedSizeListBuilder};
+use crate::builders::{ArrayBuilder, DecimalBuilder, FixedSizeListBuilder, ListViewBuilder};
 use crate::validity::Validity;
-use crate::{Array, ArrayRef, IntoArray, ToCanonical, builders};
+use crate::{Array, ArrayRef, IntoArray, ToCanonical};
 
 /// A wrapper type to implement `Arbitrary` for `ArrayRef`.
 #[derive(Clone, Debug)]
@@ -210,7 +209,7 @@ fn random_list_with_offset_type<O: IntegerPType>(
 ) -> Result<ArrayRef> {
     let array_length = chunk_len.unwrap_or(u.int_in_range(0..=20)?);
 
-    let mut builder = ListBuilder::<O>::with_capacity(elem_dtype.clone(), null, 20, 10);
+    let mut builder = ListViewBuilder::<O, O>::with_capacity(elem_dtype.clone(), null, 20, 10);
 
     for _ in 0..array_length {
         if null == Nullability::Nullable && u.arbitrary::<bool>()? {

--- a/vortex-array/src/arrays/chunked/tests.rs
+++ b/vortex-array/src/arrays/chunked/tests.rs
@@ -186,7 +186,7 @@ pub fn pack_nested_lists() {
         ),
     );
 
-    let canon_values = chunked_list.unwrap().to_list();
+    let canon_values = chunked_list.unwrap().to_listview();
 
     assert_eq!(l1.scalar_at(0), canon_values.scalar_at(0));
     assert_eq!(l2.scalar_at(0), canon_values.scalar_at(1));

--- a/vortex-array/src/arrays/chunked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/chunked/vtable/canonical.rs
@@ -82,28 +82,38 @@ fn swizzle_struct_chunks(
     unsafe { StructArray::new_unchecked(field_arrays, struct_dtype.clone(), len, validity) }
 }
 
+/// Packs list arrays together into a chunked `ListViewArray`.
+///
+/// There is guaranteed to be at least 2 chunks.
 fn pack_lists(chunks: &[ArrayRef], validity: Validity, elem_dtype: &DType) -> ListViewArray {
     let len: usize = chunks.iter().map(|c| c.len()).sum();
 
-    // Estimate total elements capacity by summing the element counts of all chunks.
-    let elements_capacity: usize = chunks
-        .iter()
-        .map(|c| c.to_listview().elements().len())
-        .sum();
+    assert_eq!(
+        chunks[0]
+            .dtype()
+            .as_list_element_opt()
+            .vortex_expect("DType was somehow not a list")
+            .as_ref(),
+        elem_dtype
+    );
 
-    // Note that since views can be out of order, it is easier to just rebuild the entire array than
-    // to recalculate views based on new offsets for each chunk.
-    let mut elements_builder = builder_with_capacity(elem_dtype, elements_capacity);
+    // Since each list array in `chunks` has offsets local to each array, we can reuse the existing
+    // array's child `elements` as the chunks and recompute offsets.
+    let mut list_elements_chunks = Vec::with_capacity(chunks.len());
+    let mut num_elements = 0;
 
     // TODO(connor)[ListView]: We could potentially choose a smaller type here, but that would make
     // this much more complicated.
-
-    // We (somewhat arbitrarily) choose `u64` for our offsets and sizes here.
+    // We (somewhat arbitrarily) choose `u64` for our offsets and sizes here. These can always be
+    // narrowed later by the compressor.
     let mut offsets = BufferMut::<u64>::with_capacity(len);
     let mut sizes = BufferMut::<u64>::with_capacity(len);
 
     for chunk in chunks {
         let chunk = chunk.to_listview();
+
+        // Add the `elements` of the current array as a new chunk.
+        list_elements_chunks.push(chunk.elements().clone());
 
         // Cast offsets and sizes to u64.
         let offsets_arr = cast(
@@ -123,18 +133,18 @@ fn pack_lists(chunks: &[ArrayRef], validity: Validity, elem_dtype: &DType) -> Li
         let offsets_slice = offsets_arr.as_slice::<u64>();
         let sizes_slice = sizes_arr.as_slice::<u64>();
 
-        // Track the current position in our combined elements array.
-        let current_elements_offset = elements_builder.len() as u64;
-
-        // Append all elements from this chunk.
-        elements_builder.extend_from_array(chunk.elements());
-
         // Append offsets and sizes, adjusting offsets to point into the combined array.
-        offsets.extend(offsets_slice.iter().map(|o| o + current_elements_offset));
+        offsets.extend(offsets_slice.iter().map(|o| o + num_elements));
         sizes.extend(sizes_slice);
+
+        num_elements += chunk.elements().len() as u64;
     }
 
-    let elements = elements_builder.finish();
+    // SAFETY: elements are sliced from valid `ListViewArray`s (from `to_listview()`).
+    let chunked_elements =
+        unsafe { ChunkedArray::new_unchecked(list_elements_chunks, elem_dtype.clone()) }
+            .into_array();
+
     let offsets = PrimitiveArray::new(offsets.freeze(), Validity::NonNullable).into_array();
     let sizes = PrimitiveArray::new(sizes.freeze(), Validity::NonNullable).into_array();
 
@@ -143,7 +153,7 @@ fn pack_lists(chunks: &[ArrayRef], validity: Validity, elem_dtype: &DType) -> Li
     // - Each `offset[i] + size[i]` list view is within bounds of elements array because it came
     //   from valid chunks
     // - Validity came from the outer chunked array so it must have the same length
-    unsafe { ListViewArray::new_unchecked(elements, offsets, sizes, validity) }
+    unsafe { ListViewArray::new_unchecked(chunked_elements, offsets, sizes, validity) }
 }
 
 #[cfg(test)]

--- a/vortex-array/src/arrays/chunked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/chunked/vtable/canonical.rs
@@ -23,14 +23,14 @@ impl CanonicalVTable<ChunkedVTable> for ChunkedVTable {
 
         match array.dtype() {
             DType::Struct(struct_dtype, _) => {
-                let struct_array = swizzle_struct_chunks(
+                let struct_array = pack_struct_chunks(
                     array.chunks(),
                     Validity::copy_from_array(array.as_ref()),
                     struct_dtype,
                 );
                 Canonical::Struct(struct_array)
             }
-            DType::List(elem_dtype, _) => Canonical::List(pack_lists(
+            DType::List(elem_dtype, _) => Canonical::List(swizzle_list_chunks(
                 array.chunks(),
                 Validity::copy_from_array(array.as_ref()),
                 elem_dtype,
@@ -50,9 +50,11 @@ impl CanonicalVTable<ChunkedVTable> for ChunkedVTable {
     }
 }
 
-/// Swizzle the pointers within a ChunkedArray of StructArrays to instead be a single
-/// StructArray, where the Array for each Field is a ChunkedArray.
-fn swizzle_struct_chunks(
+/// Packs many [`StructArray`]s to instead be a single [`StructArray`], where the [`Array`] for each
+/// field is a [`ChunkedArray`].
+///
+/// The caller guarantees there are at least 2 chunks.
+fn pack_struct_chunks(
     chunks: &[ArrayRef],
     validity: Validity,
     struct_dtype: &StructFields,
@@ -71,6 +73,7 @@ fn swizzle_struct_chunks(
                     .to_array()
             })
             .collect::<Vec<_>>();
+
         // SAFETY: field_chunks are extracted from valid StructArrays with matching dtypes.
         // Each chunk's field array is guaranteed to be valid for field_dtype.
         let field_array = unsafe { ChunkedArray::new_unchecked(field_chunks, field_dtype.clone()) };
@@ -82,10 +85,16 @@ fn swizzle_struct_chunks(
     unsafe { StructArray::new_unchecked(field_arrays, struct_dtype.clone(), len, validity) }
 }
 
-/// Packs list arrays together into a chunked `ListViewArray`.
+/// Packs [`ListViewArray`]s together into a chunked `ListViewArray`.
 ///
-/// There is guaranteed to be at least 2 chunks.
-fn pack_lists(chunks: &[ArrayRef], validity: Validity, elem_dtype: &DType) -> ListViewArray {
+/// We use the existing arrays (chunks) to form a chunked array of `elements` (the child array).
+///
+/// The caller guarantees there are at least 2 chunks.
+fn swizzle_list_chunks(
+    chunks: &[ArrayRef],
+    validity: Validity,
+    elem_dtype: &DType,
+) -> ListViewArray {
     let len: usize = chunks.iter().map(|c| c.len()).sum();
 
     assert_eq!(
@@ -99,6 +108,7 @@ fn pack_lists(chunks: &[ArrayRef], validity: Validity, elem_dtype: &DType) -> Li
 
     // Since each list array in `chunks` has offsets local to each array, we can reuse the existing
     // array's child `elements` as the chunks and recompute offsets.
+
     let mut list_elements_chunks = Vec::with_capacity(chunks.len());
     let mut num_elements = 0;
 
@@ -110,24 +120,24 @@ fn pack_lists(chunks: &[ArrayRef], validity: Validity, elem_dtype: &DType) -> Li
     let mut sizes = BufferMut::<u64>::with_capacity(len);
 
     for chunk in chunks {
-        let chunk = chunk.to_listview();
+        let chunk_array = chunk.to_listview();
 
         // Add the `elements` of the current array as a new chunk.
-        list_elements_chunks.push(chunk.elements().clone());
+        list_elements_chunks.push(chunk_array.elements().clone());
 
-        // Cast offsets and sizes to u64.
+        // Cast offsets and sizes to `u64`.
         let offsets_arr = cast(
-            chunk.offsets(),
+            chunk_array.offsets(),
             &DType::Primitive(PType::U64, Nullability::NonNullable),
         )
-        .vortex_expect("Must fit array offsets in u64")
+        .vortex_expect("Must be able to fit array offsets in u64")
         .to_primitive();
 
         let sizes_arr = cast(
-            chunk.sizes(),
+            chunk_array.sizes(),
             &DType::Primitive(PType::U64, Nullability::NonNullable),
         )
-        .vortex_expect("Must fit array sizes in u64")
+        .vortex_expect("Must be able to fit array offsets in u64")
         .to_primitive();
 
         let offsets_slice = offsets_arr.as_slice::<u64>();
@@ -137,7 +147,7 @@ fn pack_lists(chunks: &[ArrayRef], validity: Validity, elem_dtype: &DType) -> Li
         offsets.extend(offsets_slice.iter().map(|o| o + num_elements));
         sizes.extend(sizes_slice);
 
-        num_elements += chunk.elements().len() as u64;
+        num_elements += chunk_array.elements().len() as u64;
     }
 
     // SAFETY: elements are sliced from valid `ListViewArray`s (from `to_listview()`).

--- a/vortex-array/src/arrays/chunked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/chunked/vtable/canonical.rs
@@ -3,9 +3,9 @@
 
 use vortex_buffer::BufferMut;
 use vortex_dtype::{DType, Nullability, PType, StructFields};
-use vortex_error::{VortexExpect, VortexUnwrap, vortex_err};
+use vortex_error::VortexExpect;
 
-use crate::arrays::{ChunkedArray, ChunkedVTable, ListArray, PrimitiveArray, StructArray};
+use crate::arrays::{ChunkedArray, ChunkedVTable, ListViewArray, PrimitiveArray, StructArray};
 use crate::builders::{ArrayBuilder, builder_with_capacity};
 use crate::compute::cast;
 use crate::validity::Validity;
@@ -82,15 +82,30 @@ fn swizzle_struct_chunks(
     unsafe { StructArray::new_unchecked(field_arrays, struct_dtype.clone(), len, validity) }
 }
 
-fn pack_lists(chunks: &[ArrayRef], validity: Validity, elem_dtype: &DType) -> ListArray {
+fn pack_lists(chunks: &[ArrayRef], validity: Validity, elem_dtype: &DType) -> ListViewArray {
     let len: usize = chunks.iter().map(|c| c.len()).sum();
-    let mut offsets = BufferMut::<u64>::with_capacity(len + 1);
-    offsets.push(0);
-    let mut elements = Vec::new();
+
+    // Estimate total elements capacity by summing the element counts of all chunks.
+    let elements_capacity: usize = chunks
+        .iter()
+        .map(|c| c.to_listview().elements().len())
+        .sum();
+
+    // Note that since views can be out of order, it is easier to just rebuild the entire array than
+    // to recalculate views based on new offsets for each chunk.
+    let mut elements_builder = builder_with_capacity(elem_dtype, elements_capacity);
+
+    // TODO(connor)[ListView]: We could potentially choose a smaller type here, but that would make
+    // this much more complicated.
+
+    // We (somewhat arbitrarily) choose `u64` for our offsets and sizes here.
+    let mut offsets = BufferMut::<u64>::with_capacity(len);
+    let mut sizes = BufferMut::<u64>::with_capacity(len);
 
     for chunk in chunks {
-        let chunk = chunk.to_list();
-        // TODO: handle i32 offsets if they fit.
+        let chunk = chunk.to_listview();
+
+        // Cast offsets and sizes to u64.
         let offsets_arr = cast(
             chunk.offsets(),
             &DType::Primitive(PType::U64, Nullability::NonNullable),
@@ -98,40 +113,37 @@ fn pack_lists(chunks: &[ArrayRef], validity: Validity, elem_dtype: &DType) -> Li
         .vortex_expect("Must fit array offsets in u64")
         .to_primitive();
 
-        let first_offset_value: usize =
-            usize::try_from(&offsets_arr.scalar_at(0)).vortex_expect("Offset must be a usize");
-        let last_offset_value: usize =
-            usize::try_from(&offsets_arr.scalar_at(offsets_arr.len() - 1))
-                .vortex_expect("Offset must be a usize");
-        elements.push(
-            chunk
-                .elements()
-                .slice(first_offset_value..last_offset_value),
-        );
+        let sizes_arr = cast(
+            chunk.sizes(),
+            &DType::Primitive(PType::U64, Nullability::NonNullable),
+        )
+        .vortex_expect("Must fit array sizes in u64")
+        .to_primitive();
 
-        let adjustment_from_previous = *offsets
-            .last()
-            .ok_or_else(|| vortex_err!("List offsets must have at least one element"))
-            .vortex_unwrap();
-        offsets.extend_trusted(
-            offsets_arr
-                .as_slice::<u64>()
-                .iter()
-                .skip(1)
-                .map(|off| off + adjustment_from_previous - first_offset_value as u64),
-        );
+        let offsets_slice = offsets_arr.as_slice::<u64>();
+        let sizes_slice = sizes_arr.as_slice::<u64>();
+
+        // Track the current position in our combined elements array.
+        let current_elements_offset = elements_builder.len() as u64;
+
+        // Append all elements from this chunk.
+        elements_builder.extend_from_array(chunk.elements());
+
+        // Append offsets and sizes, adjusting offsets to point into the combined array.
+        offsets.extend(offsets_slice.iter().map(|o| o + current_elements_offset));
+        sizes.extend(sizes_slice);
     }
-    // SAFETY: elements are sliced from valid ListArrays with matching elem_dtype.
-    // All elements arrays are guaranteed to be valid for elem_dtype.
-    let chunked_elements =
-        unsafe { ChunkedArray::new_unchecked(elements, elem_dtype.clone()) }.into_array();
-    let offsets = PrimitiveArray::new(offsets.freeze(), Validity::NonNullable);
 
-    // SAFETY: chunked_elements contains valid elements from the original lists.
-    // Offsets are monotonically increasing starting from 0, with each offset[i+1] >= offset[i],
-    // and the last offset equals the total length of chunked_elements.
-    // The validity matches the number of lists (offsets.len() - 1).
-    unsafe { ListArray::new_unchecked(chunked_elements, offsets.into_array(), validity) }
+    let elements = elements_builder.finish();
+    let offsets = PrimitiveArray::new(offsets.freeze(), Validity::NonNullable).into_array();
+    let sizes = PrimitiveArray::new(sizes.freeze(), Validity::NonNullable).into_array();
+
+    // SAFETY:
+    // - `offsets` and `sizes` are non-nullable u64 arrays of the same length
+    // - Each `offset[i] + size[i]` list view is within bounds of elements array because it came
+    //   from valid chunks
+    // - Validity came from the outer chunked array so it must have the same length
+    unsafe { ListViewArray::new_unchecked(elements, offsets, sizes, validity) }
 }
 
 #[cfg(test)]
@@ -201,7 +213,7 @@ mod tests {
             List(Arc::new(Primitive(I32, NonNullable)), NonNullable),
         );
 
-        let canon_values = chunked_list.unwrap().to_list();
+        let canon_values = chunked_list.unwrap().to_listview();
 
         assert_eq!(l1.scalar_at(0), canon_values.scalar_at(0));
         assert_eq!(l2.scalar_at(0), canon_values.scalar_at(1));

--- a/vortex-array/src/arrays/constant/vtable/canonical.rs
+++ b/vortex-array/src/arrays/constant/vtable/canonical.rs
@@ -16,10 +16,10 @@ use crate::arrays::binary_view::BinaryView;
 use crate::arrays::constant::ConstantArray;
 use crate::arrays::primitive::PrimitiveArray;
 use crate::arrays::{
-    BoolArray, ConstantVTable, DecimalArray, ExtensionArray, FixedSizeListArray, ListArray,
+    BoolArray, ConstantVTable, DecimalArray, ExtensionArray, FixedSizeListArray, ListViewArray,
     NullArray, StructArray, VarBinViewArray, smallest_decimal_value_type,
 };
-use crate::builders::builder_with_capacity;
+use crate::builders::{ArrayBuilder, ListViewBuilder, builder_with_capacity};
 use crate::validity::Validity;
 use crate::vtable::CanonicalVTable;
 use crate::{Canonical, IntoArray};
@@ -100,14 +100,22 @@ impl CanonicalVTable<ConstantVTable> for ConstantVTable {
                     .vortex_expect("Must be a utf8 scalar")
                     .value();
                 let const_value = value.as_ref().map(|v| v.as_bytes());
-                Canonical::VarBinView(canonical_byte_view(const_value, array.dtype(), array.len()))
+                Canonical::VarBinView(constant_canonical_byte_view(
+                    const_value,
+                    array.dtype(),
+                    array.len(),
+                ))
             }
             DType::Binary(_) => {
                 let value = BinaryScalar::try_from(scalar)
                     .vortex_expect("must be a binary scalar")
                     .value();
                 let const_value = value.as_ref().map(|v| v.as_slice());
-                Canonical::VarBinView(canonical_byte_view(const_value, array.dtype(), array.len()))
+                Canonical::VarBinView(constant_canonical_byte_view(
+                    const_value,
+                    array.dtype(),
+                    array.len(),
+                ))
             }
             DType::Struct(struct_dtype, _) => {
                 let value = StructScalar::try_from(scalar).vortex_expect("must be struct");
@@ -133,19 +141,11 @@ impl CanonicalVTable<ConstantVTable> for ConstantVTable {
                     StructArray::new_unchecked(fields, struct_dtype.clone(), array.len(), validity)
                 })
             }
-            DType::List(..) => {
-                let value = ListScalar::try_from(scalar).vortex_expect("must be list");
-                Canonical::List(canonical_list_array(
-                    value.elements(),
-                    value.element_dtype(),
-                    value.dtype().nullability(),
-                    array.len(),
-                ))
-            }
+            DType::List(..) => Canonical::List(constant_canonical_list_array(scalar, array.len())),
             DType::FixedSizeList(element_dtype, list_size, _) => {
                 let value = ListScalar::try_from(scalar).vortex_expect("must be list");
 
-                Canonical::FixedSizeList(canonical_fixed_size_list_array(
+                Canonical::FixedSizeList(constant_canonical_fixed_size_list_array(
                     value.elements(),
                     element_dtype,
                     *list_size,
@@ -164,7 +164,11 @@ impl CanonicalVTable<ConstantVTable> for ConstantVTable {
     }
 }
 
-fn canonical_byte_view(scalar_bytes: Option<&[u8]>, dtype: &DType, len: usize) -> VarBinViewArray {
+fn constant_canonical_byte_view(
+    scalar_bytes: Option<&[u8]>,
+    dtype: &DType,
+    len: usize,
+) -> VarBinViewArray {
     match scalar_bytes {
         None => {
             let views = buffer![BinaryView::from(0_u128); len];
@@ -204,58 +208,54 @@ fn canonical_byte_view(scalar_bytes: Option<&[u8]>, dtype: &DType, len: usize) -
     }
 }
 
-fn canonical_list_array(
-    values: Option<Vec<Scalar>>,
-    element_dtype: &DType,
-    list_nullability: Nullability,
-    len: usize,
-) -> ListArray {
-    match values {
-        None => unsafe {
-            ListArray::new_unchecked(
-                Canonical::empty(element_dtype).into_array(),
-                ConstantArray::new(
-                    Scalar::new(
-                        DType::Primitive(PType::U64, Nullability::NonNullable),
-                        ScalarValue::from(0),
-                    ),
-                    len + 1,
-                )
-                .into_array(),
+/// Creates a [`ListViewArray`] with constant values.
+fn constant_canonical_list_array(scalar: &Scalar, len: usize) -> ListViewArray {
+    let value = ListScalar::try_from(scalar).vortex_expect("must be list");
+
+    let Some(elements) = value.elements() else {
+        // If all values are null, both the `offsets` and `sizes` should be all zeros.
+        let zeros = ConstantArray::new(
+            Scalar::new(
+                DType::Primitive(PType::U64, Nullability::NonNullable),
+                ScalarValue::from(0),
+            ),
+            len,
+        )
+        .into_array();
+
+        // SAFETY: Everything is length 0 so all invariants are satisfied.
+        return unsafe {
+            ListViewArray::new_unchecked(
+                Canonical::empty(value.element_dtype()).into_array(),
+                zeros.clone(),
+                zeros,
                 Validity::AllInvalid,
             )
-        },
-        Some(values) => {
-            let mut elements_builder = builder_with_capacity(element_dtype, len * values.len());
-            for _ in 0..len {
-                for v in &values {
-                    elements_builder
-                        .append_scalar(v)
-                        .vortex_expect("must be a same dtype");
-                }
-            }
-            let offsets = if values.is_empty() {
-                Buffer::zeroed(len + 1)
-            } else {
-                Buffer::from_trusted_len_iter(
-                    (0..=len * values.len())
-                        .step_by(values.len())
-                        .map(|i| i as u64),
-                )
-            };
+        };
+    };
 
-            unsafe {
-                ListArray::new_unchecked(
-                    elements_builder.finish(),
-                    offsets.into_array(),
-                    Validity::from(list_nullability),
-                )
-            }
-        }
+    let mut listview_builder = ListViewBuilder::<u64, u64>::with_capacity(
+        scalar
+            .dtype()
+            .as_list_element_opt()
+            .vortex_expect("somehow not a list")
+            .clone(),
+        scalar.dtype().nullability(),
+        elements.len() * len,
+        len,
+    );
+
+    // Simply append the same scalar to the `ListViewBuilder` `len` times.
+    for _ in 0..len {
+        listview_builder
+            .append_scalar(scalar)
+            .vortex_expect("somehow unable to append list scalar to listview builder");
     }
+
+    listview_builder.finish_into_listview()
 }
 
-fn canonical_fixed_size_list_array(
+fn constant_canonical_fixed_size_list_array(
     values: Option<Vec<Scalar>>,
     element_dtype: &DType,
     list_size: u32,
@@ -383,14 +383,18 @@ mod tests {
             Nullability::NonNullable,
         );
         let const_array = ConstantArray::new(list_scalar, 2).into_array();
-        let canonical_const = const_array.to_list();
+        let canonical_const = const_array.to_listview();
         assert_eq!(
             canonical_const.elements().to_primitive().as_slice::<u64>(),
             [1u64, 2, 1, 2]
         );
         assert_eq!(
             canonical_const.offsets().to_primitive().as_slice::<u64>(),
-            [0u64, 2, 4]
+            [0u64, 2]
+        );
+        assert_eq!(
+            canonical_const.sizes().to_primitive().as_slice::<u64>(),
+            [2u64, 2]
         );
     }
 
@@ -402,11 +406,15 @@ mod tests {
             Nullability::NonNullable,
         );
         let const_array = ConstantArray::new(list_scalar, 2).into_array();
-        let canonical_const = const_array.to_list();
+        let canonical_const = const_array.to_listview();
         assert!(canonical_const.elements().to_primitive().is_empty());
         assert_eq!(
             canonical_const.offsets().to_primitive().as_slice::<u64>(),
-            [0u64, 0, 0]
+            [0u64, 0]
+        );
+        assert_eq!(
+            canonical_const.sizes().to_primitive().as_slice::<u64>(),
+            [0u64, 0]
         );
     }
 
@@ -417,11 +425,15 @@ mod tests {
             Nullability::Nullable,
         ));
         let const_array = ConstantArray::new(list_scalar, 2).into_array();
-        let canonical_const = const_array.to_list();
+        let canonical_const = const_array.to_listview();
         assert!(canonical_const.elements().to_primitive().is_empty());
         assert_eq!(
             canonical_const.offsets().to_primitive().as_slice::<u64>(),
-            [0u64, 0, 0]
+            [0u64, 0]
+        );
+        assert_eq!(
+            canonical_const.sizes().to_primitive().as_slice::<u64>(),
+            [0u64, 0]
         );
     }
 

--- a/vortex-array/src/arrays/constant/vtable/canonical.rs
+++ b/vortex-array/src/arrays/constant/vtable/canonical.rs
@@ -5,11 +5,11 @@ use std::sync::Arc;
 
 use arrow_buffer::BooleanBuffer;
 use vortex_buffer::{Buffer, buffer};
-use vortex_dtype::{DType, Nullability, PType, match_each_native_ptype};
+use vortex_dtype::{DType, Nullability, match_each_native_ptype};
 use vortex_error::VortexExpect;
 use vortex_scalar::{
-    BinaryScalar, BoolScalar, DecimalValue, ExtScalar, ListScalar, Scalar, ScalarValue,
-    StructScalar, Utf8Scalar, match_each_decimal_value, match_each_decimal_value_type,
+    BinaryScalar, BoolScalar, DecimalValue, ExtScalar, ListScalar, Scalar, StructScalar,
+    Utf8Scalar, match_each_decimal_value, match_each_decimal_value_type,
 };
 
 use crate::arrays::binary_view::BinaryView;
@@ -19,7 +19,7 @@ use crate::arrays::{
     BoolArray, ConstantVTable, DecimalArray, ExtensionArray, FixedSizeListArray, ListViewArray,
     NullArray, StructArray, VarBinViewArray, smallest_decimal_value_type,
 };
-use crate::builders::{ArrayBuilder, ListViewBuilder, builder_with_capacity};
+use crate::builders::builder_with_capacity;
 use crate::validity::Validity;
 use crate::vtable::CanonicalVTable;
 use crate::{Canonical, IntoArray};
@@ -209,50 +209,54 @@ fn constant_canonical_byte_view(
 }
 
 /// Creates a [`ListViewArray`] with constant values.
+///
+/// We basically just project the list scalar value into list view components. If the caller wants
+/// a fully decompressed and non-overlapping array, they can rebuild the array.
 fn constant_canonical_list_array(scalar: &Scalar, len: usize) -> ListViewArray {
-    let value = ListScalar::try_from(scalar).vortex_expect("must be list");
+    let list = ListScalar::try_from(scalar).vortex_expect("must be list");
 
-    let Some(elements) = value.elements() else {
-        // If all values are null, both the `offsets` and `sizes` should be all zeros.
-        let zeros = ConstantArray::new(
-            Scalar::new(
-                DType::Primitive(PType::U64, Nullability::NonNullable),
-                ScalarValue::from(0),
-            ),
-            len,
-        )
-        .into_array();
-
-        // SAFETY: Everything is length 0 so all invariants are satisfied.
-        return unsafe {
-            ListViewArray::new_unchecked(
-                Canonical::empty(value.element_dtype()).into_array(),
-                zeros.clone(),
-                zeros,
-                Validity::AllInvalid,
-            )
-        };
+    // We can just have all of the views point to the same scalar.
+    let elements = if let Some(elements) = list.elements() {
+        // Extract the list elements out of the scalar into a new array.
+        let mut builder = builder_with_capacity(
+            list.dtype()
+                .as_list_element_opt()
+                .vortex_expect("list scalar somehow did not have a list DType"),
+            list.len(),
+        );
+        for scalar in &elements {
+            builder
+                .append_scalar(scalar)
+                .vortex_expect("list element scalar was invalid");
+        }
+        builder.finish()
+    } else {
+        // Otherwise all values are null, and we don't need to store anything (`list.len() == 0`).
+        Canonical::empty(list.element_dtype()).into_array()
     };
 
-    let mut listview_builder = ListViewBuilder::<u64, u64>::with_capacity(
-        scalar
-            .dtype()
-            .as_list_element_opt()
-            .vortex_expect("somehow not a list")
-            .clone(),
-        scalar.dtype().nullability(),
-        elements.len() * len,
-        len,
-    );
+    let validity = if scalar.dtype().is_nullable() {
+        if list.is_null() {
+            Validity::AllInvalid
+        } else {
+            Validity::AllValid
+        }
+    } else {
+        debug_assert!(!list.is_null());
+        Validity::NonNullable
+    };
 
-    // Simply append the same scalar to the `ListViewBuilder` `len` times.
-    for _ in 0..len {
-        listview_builder
-            .append_scalar(scalar)
-            .vortex_expect("somehow unable to append list scalar to listview builder");
-    }
+    // Somewhat arbitrarily choose `u64` as the type for offsets and sizes.
+    let offsets = ConstantArray::new::<u64>(0, len).into_array();
+    let sizes = ConstantArray::new::<u64>(list.len() as u64, len).into_array();
 
-    listview_builder.finish_into_listview()
+    debug_assert!(!offsets.dtype().is_nullable());
+    debug_assert!(!sizes.dtype().is_nullable());
+
+    // SAFETY: All views point to the same range [0, list.len()) in the elements array.
+    // The elements array contains `len` copies of the same value, offsets are all 0,
+    // and sizes are all equal to the list length. The validity matches the scalar's nullability.
+    unsafe { ListViewArray::new_unchecked(elements, offsets, sizes, validity) }
 }
 
 fn constant_canonical_fixed_size_list_array(
@@ -308,7 +312,7 @@ mod tests {
     use vortex_dtype::{DType, Nullability, PType};
     use vortex_scalar::Scalar;
 
-    use crate::arrays::ConstantArray;
+    use crate::arrays::{ConstantArray, ListViewRebuildMode};
     use crate::canonical::ToCanonical;
     use crate::stats::{Stat, StatsProvider};
     use crate::validity::Validity;
@@ -384,16 +388,17 @@ mod tests {
         );
         let const_array = ConstantArray::new(list_scalar, 2).into_array();
         let canonical_const = const_array.to_listview();
+        let list_array = canonical_const.rebuild(ListViewRebuildMode::MakeZeroCopyToList);
         assert_eq!(
-            canonical_const.elements().to_primitive().as_slice::<u64>(),
+            list_array.elements().to_primitive().as_slice::<u64>(),
             [1u64, 2, 1, 2]
         );
         assert_eq!(
-            canonical_const.offsets().to_primitive().as_slice::<u64>(),
+            list_array.offsets().to_primitive().as_slice::<u64>(),
             [0u64, 2]
         );
         assert_eq!(
-            canonical_const.sizes().to_primitive().as_slice::<u64>(),
+            list_array.sizes().to_primitive().as_slice::<u64>(),
             [2u64, 2]
         );
     }

--- a/vortex-array/src/arrays/constant/vtable/canonical.rs
+++ b/vortex-array/src/arrays/constant/vtable/canonical.rs
@@ -215,7 +215,8 @@ fn constant_canonical_byte_view(
 fn constant_canonical_list_array(scalar: &Scalar, len: usize) -> ListViewArray {
     let list = ListScalar::try_from(scalar).vortex_expect("must be list");
 
-    // We can just have all of the views point to the same scalar.
+    // Since "canonicalize" only applies to the top level array, we can simply have 1 scalar in our
+    // child `elements` and have all list views point to that scalar.
     let elements = if let Some(elements) = list.elements() {
         // Extract the list elements out of the scalar into a new array.
         let mut builder = builder_with_capacity(
@@ -231,7 +232,7 @@ fn constant_canonical_list_array(scalar: &Scalar, len: usize) -> ListViewArray {
         }
         builder.finish()
     } else {
-        // Otherwise all values are null, and we don't need to store anything (`list.len() == 0`).
+        // Otherwise all values are null, and we don't need to store anything in our `elements`.
         Canonical::empty(list.element_dtype()).into_array()
     };
 

--- a/vortex-array/src/arrays/list/compute/take.rs
+++ b/vortex-array/src/arrays/list/compute/take.rs
@@ -7,6 +7,7 @@ use crate::arrays::{ListArray, ListVTable, list_view_from_list};
 use crate::compute::{self, TakeKernel, TakeKernelAdapter};
 use crate::{Array, ArrayRef, IntoArray, register_kernel};
 
+// TODO(connor): For very short arrays it is probably more efficient to build the list from scratch.
 /// Take implementation for [`ListArray`].
 ///
 /// This implementation converts the [`ListArray`] to a [`ListViewArray`] and then delegates to its

--- a/vortex-array/src/arrays/list/compute/take.rs
+++ b/vortex-array/src/arrays/list/compute/take.rs
@@ -1,178 +1,29 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use arrow_buffer::BooleanBufferBuilder;
-use vortex_dtype::{IntegerPType, Nullability, match_each_integer_ptype};
-use vortex_error::{VortexExpect, VortexResult, vortex_panic};
-use vortex_mask::Mask;
+use vortex_error::VortexResult;
 
-use crate::arrays::{ListArray, ListVTable, PrimitiveArray};
-use crate::builders::{ArrayBuilder, PrimitiveBuilder};
-use crate::compute::{TakeKernel, TakeKernelAdapter, take};
-use crate::validity::Validity;
-use crate::vtable::ValidityHelper;
-use crate::{Array, ArrayRef, ToCanonical, register_kernel};
+use crate::arrays::{ListArray, ListVTable, list_view_from_list};
+use crate::compute::{self, TakeKernel, TakeKernelAdapter};
+use crate::{Array, ArrayRef, IntoArray, register_kernel};
 
 /// Take implementation for [`ListArray`].
 ///
-/// Unlike `ListView`, `ListArray` must rebuild the elements array to maintain its invariant
-/// that lists are stored contiguously and in-order (`offset[i+1] >= offset[i]`). Taking
-/// non-contiguous indices would violate this requirement.
+/// This implementation converts the [`ListArray`] to a [`ListViewArray`] and then delegates to its
+/// `take` implementation. This approach avoids the need to rebuild the `elements` array.
+///
+/// The resulting [`ListViewArray`] can represent non-contiguous and out-of-order lists, which would
+/// violate [`ListArray`]'s invariants (but not [`ListViewArray`]'s).
+///
+/// [`ListViewArray`]: crate::arrays::ListViewArray
 impl TakeKernel for ListVTable {
     fn take(&self, array: &ListArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
-        let indices = indices.to_primitive();
-        let offsets = array.offsets().to_primitive();
-
-        match_each_integer_ptype!(offsets.dtype().as_ptype(), |O| {
-            match_each_integer_ptype!(indices.ptype(), |I| {
-                _take::<I, O>(
-                    array,
-                    offsets.as_slice::<O>(),
-                    &indices,
-                    array.validity_mask(),
-                    indices.validity_mask(),
-                )
-            })
-        })
+        let list_view = list_view_from_list(array.clone());
+        compute::take(&list_view.into_array(), indices)
     }
 }
 
 register_kernel!(TakeKernelAdapter(ListVTable).lift());
-
-fn _take<I: IntegerPType, O: IntegerPType>(
-    array: &ListArray,
-    offsets: &[O],
-    indices_array: &PrimitiveArray,
-    data_validity: Mask,
-    indices_validity_mask: Mask,
-) -> VortexResult<ArrayRef> {
-    let indices: &[I] = indices_array.as_slice::<I>();
-
-    if !indices_validity_mask.all_true() || !data_validity.all_true() {
-        return _take_nullable::<I, O>(
-            array,
-            offsets,
-            indices,
-            data_validity,
-            indices_validity_mask,
-        );
-    }
-
-    let mut new_offsets = PrimitiveBuilder::with_capacity(Nullability::NonNullable, indices.len());
-    let mut elements_to_take =
-        PrimitiveBuilder::with_capacity(Nullability::NonNullable, 2 * indices.len());
-
-    let mut current_offset = O::zero();
-    new_offsets.append_zero();
-
-    for &data_idx in indices {
-        let data_idx = data_idx
-            .to_usize()
-            .unwrap_or_else(|| vortex_panic!("Failed to convert index to usize: {}", data_idx));
-
-        let start = offsets[data_idx];
-        let stop = offsets[data_idx + 1];
-
-        // Annoyingly, we can't turn (start..end) into a range, so we're doing that manually.
-        //
-        // We could convert start and end to usize, but that would impose a potentially
-        // harder constraint - now we don't care if they fit into usize as long as their
-        // difference does.
-        let additional = (stop - start).to_usize().unwrap_or_else(|| {
-            vortex_panic!("Failed to convert range length to usize: {}", stop - start)
-        });
-
-        elements_to_take.reserve_exact(additional);
-        for i in 0..additional {
-            elements_to_take.append_value(start + O::from_usize(i).vortex_expect("i < additional"));
-        }
-        current_offset += stop - start;
-        new_offsets.append_value(current_offset);
-    }
-
-    let elements_to_take = elements_to_take.finish();
-    let new_offsets = new_offsets.finish();
-
-    let new_elements = take(array.elements(), elements_to_take.as_ref())?;
-
-    Ok(ListArray::try_new(
-        new_elements,
-        new_offsets,
-        indices_array
-            .validity()
-            .clone()
-            .and(array.validity().clone()),
-    )?
-    .to_array())
-}
-
-fn _take_nullable<I: IntegerPType, O: IntegerPType>(
-    array: &ListArray,
-    offsets: &[O],
-    indices: &[I],
-    data_validity: Mask,
-    indices_validity: Mask,
-) -> VortexResult<ArrayRef> {
-    let mut new_offsets = PrimitiveBuilder::with_capacity(Nullability::NonNullable, indices.len());
-
-    // This will be the indices we push down to the child array to call `take` with.
-    //
-    // There are 2 things to note here:
-    // - We do not know how many elements we need to take from our child since lists are variable
-    //   size: thus we arbitrarily choose a capacity of `2 * # of indices`.
-    // - The type of the primitive builder needs to fit the largest offset of the (parent)
-    //   `ListArray`, so we make this `PrimitiveBuilder` generic over `O` (instead of `I`).
-    let mut elements_to_take =
-        PrimitiveBuilder::<O>::with_capacity(Nullability::NonNullable, 2 * indices.len());
-
-    let mut current_offset = O::zero();
-    new_offsets.append_zero();
-
-    let mut new_validity = BooleanBufferBuilder::new(indices.len());
-
-    for (idx, data_idx) in indices.iter().enumerate() {
-        if !indices_validity.value(idx) {
-            new_offsets.append_value(current_offset);
-            new_validity.append(false);
-            continue;
-        }
-
-        let data_idx = data_idx
-            .to_usize()
-            .unwrap_or_else(|| vortex_panic!("Failed to convert index to usize: {}", data_idx));
-
-        if data_validity.value(data_idx) {
-            let start = offsets[data_idx];
-            let stop = offsets[data_idx + 1];
-
-            // See the note it the `take` on the reasoning
-            let additional = (stop - start).to_usize().unwrap_or_else(|| {
-                vortex_panic!("Failed to convert range length to usize: {}", stop - start)
-            });
-
-            elements_to_take.reserve_exact(additional);
-            for i in 0..additional {
-                elements_to_take
-                    .append_value(start + O::from_usize(i).vortex_expect("i < additional"));
-            }
-            current_offset += stop - start;
-            new_offsets.append_value(current_offset);
-            new_validity.append(true);
-        } else {
-            new_offsets.append_value(current_offset);
-            new_validity.append(false);
-        }
-    }
-
-    let elements_to_take = elements_to_take.finish();
-    let new_offsets = new_offsets.finish();
-    let new_elements = take(array.elements(), elements_to_take.as_ref())?;
-
-    let new_validity: Validity = Validity::from(new_validity.finish());
-    // data are indexes are nullable, so the final result is also nullable.
-
-    Ok(ListArray::try_new(new_elements, new_offsets, new_validity)?.to_array())
-}
 
 #[cfg(test)]
 mod test {
@@ -214,7 +65,7 @@ mod test {
             )
         );
 
-        let result = result.to_list();
+        let result = result.to_listview();
 
         assert_eq!(result.len(), 4);
 
@@ -294,7 +145,7 @@ mod test {
             )
         );
 
-        let result = result.to_list();
+        let result = result.to_listview();
 
         assert_eq!(result.len(), 3);
 

--- a/vortex-array/src/arrays/list/tests.rs
+++ b/vortex-array/src/arrays/list/tests.rs
@@ -13,7 +13,7 @@ use vortex_scalar::Scalar;
 
 use super::*;
 use crate::IntoArray;
-use crate::arrays::PrimitiveArray;
+use crate::arrays::{ListVTable, PrimitiveArray};
 use crate::builders::{ArrayBuilder, ListBuilder};
 use crate::compute::filter;
 use crate::validity::Validity;
@@ -262,10 +262,10 @@ fn test_list_filter_all_false() {
     let mask = Mask::AllFalse(4);
 
     let filtered = filter(&list, &mask).unwrap();
-    let filtered_list = filtered.as_::<ListVTable>();
 
-    // No lists should remain.
-    assert_eq!(filtered_list.len(), 0);
+    // When mask is AllFalse, filter returns a canonical empty array (ListViewArray).
+    // We need to check the length directly without casting to a specific type.
+    assert_eq!(filtered.len(), 0);
 }
 
 #[test]
@@ -405,11 +405,20 @@ fn test_offset_to_0() {
         )
         .vortex_unwrap();
     let list = builder.finish().slice(2..4);
-    let list = list.as_::<ListVTable>().reset_offsets(false).unwrap();
+
+    // The sliced list should be a ListArray since we built it with ListBuilder
+    // and slice doesn't change the encoding
     assert_eq!(list.len(), 2);
-    assert_eq!(list.offsets().len(), 3);
-    assert_eq!(list.elements().len(), 6);
-    assert_eq!(list.offsets().scalar_at(0), 0u32.into());
+
+    // For a sliced ListArray, we need to check it's still a ListArray
+    let list_array = list.as_::<ListVTable>();
+
+    // Check the offsets array has correct length (n+1 for n lists)
+    assert_eq!(list_array.offsets().len(), 3);
+
+    // Each list has 3 elements
+    assert_eq!(list_array.list_elements_at(0).len(), 3);
+    assert_eq!(list_array.list_elements_at(1).len(), 3);
 }
 
 type OptVec<T> = Vec<Option<T>>;
@@ -591,8 +600,8 @@ fn test_list_of_lists() {
 
     // Check the third list of lists (empty).
     let third_outer = list_of_lists.list_elements_at(2);
-    let third_outer_list = third_outer.as_::<ListVTable>();
-    assert_eq!(third_outer_list.len(), 0);
+    // Empty slices return canonical form (`ListViewArray`), so we check length directly.
+    assert_eq!(third_outer.len(), 0);
 
     // Check the fourth list of lists [[7]].
     let fourth_outer = list_of_lists.list_elements_at(3);
@@ -621,8 +630,8 @@ fn test_list_of_lists() {
 
     // Second element of slice should be empty [].
     let second_sliced = sliced_list.list_elements_at(1);
-    let second_sliced_list = second_sliced.as_::<ListVTable>();
-    assert_eq!(second_sliced_list.len(), 0);
+    // Empty slices return canonical form (`ListViewArray`), so we check length directly
+    assert_eq!(second_sliced.len(), 0);
 }
 
 #[test]

--- a/vortex-array/src/arrays/list/vtable/canonical.rs
+++ b/vortex-array/src/arrays/list/vtable/canonical.rs
@@ -2,11 +2,11 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use crate::Canonical;
-use crate::arrays::{ListArray, ListVTable};
+use crate::arrays::{ListArray, ListVTable, list_view_from_list};
 use crate::vtable::CanonicalVTable;
 
 impl CanonicalVTable<ListVTable> for ListVTable {
     fn canonicalize(array: &ListArray) -> Canonical {
-        Canonical::List(array.clone())
+        Canonical::List(list_view_from_list(array.clone()))
     }
 }

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -4,15 +4,13 @@
 use std::sync::Arc;
 
 use num_traits::AsPrimitive;
-use vortex_dtype::{DType, IntegerPType, Nullability, match_each_integer_ptype};
+use vortex_dtype::{DType, IntegerPType, match_each_integer_ptype};
 use vortex_error::{VortexExpect, VortexResult, vortex_ensure, vortex_err};
 
-use crate::arrays::{ListArray, PrimitiveVTable};
-use crate::builders::PrimitiveBuilder;
+use crate::arrays::PrimitiveVTable;
 use crate::stats::ArrayStats;
 use crate::validity::Validity;
-use crate::vtable::ValidityHelper;
-use crate::{Array, ArrayRef, Canonical, IntoArray, ToCanonical};
+use crate::{Array, ArrayRef, ToCanonical};
 
 /// The canonical encoding for variable-length list arrays.
 ///
@@ -39,17 +37,18 @@ use crate::{Array, ArrayRef, Canonical, IntoArray, ToCanonical};
 /// # Examples
 ///
 /// ```
-/// use vortex_array::arrays::{ListViewArray, PrimitiveArray};
-/// use vortex_array::validity::Validity;
-/// use vortex_array::IntoArray;
-/// use vortex_buffer::buffer;
-/// use std::sync::Arc;
+/// # use vortex_array::arrays::{ListViewArray, PrimitiveArray};
+/// # use vortex_array::validity::Validity;
+/// # use vortex_array::IntoArray;
+/// # use vortex_buffer::buffer;
+/// # use std::sync::Arc;
+/// #
+/// // Create a list view array representing [[3, 4], [1], [2, 3]].
+/// // Note: Unlike `ListArray`, offsets don't need to be monotonic.
 ///
-/// // Create a list view array representing [[3, 4], [1], [2, 5]]
-/// // Note: Unlike ListArray, offsets don't need to be monotonic
 /// let elements = buffer![1i32, 2, 3, 4, 5].into_array();
 /// let offsets = buffer![2u32, 0, 1].into_array();  // Out-of-order offsets
-/// let sizes = buffer![2u32, 1, 2].into_array();  // Corresponding sizes
+/// let sizes = buffer![2u32, 1, 2].into_array();  // The sizes cause overlaps
 ///
 /// let list_view = ListViewArray::try_new(
 ///     elements.into_array(),
@@ -238,6 +237,10 @@ impl ListViewArray {
     }
 
     /// Returns the offset at the given index.
+    ///
+    /// Note that it is possible the corresponding list view is null (which is only defined by the
+    /// validity map). Regardless, we are still guaranteed that this offset is valid by the
+    /// invariants of [`ListViewArray`].
     pub fn offset_at(&self, index: usize) -> usize {
         assert!(
             index < self.len(),
@@ -260,6 +263,10 @@ impl ListViewArray {
     }
 
     /// Returns the size at the given index.
+    ///
+    /// Note that it is possible the corresponding list view is null (which is only defined by the
+    /// validity map). Regardless, we are still guaranteed that this size is valid by the invariants
+    /// of [`ListViewArray`].
     pub fn size_at(&self, index: usize) -> usize {
         assert!(
             index < self.len(),
@@ -345,75 +352,4 @@ where
     }
 
     Ok(())
-}
-
-/// Create a [`ListViewArray`] from a [`ListArray`](crate::arrays::ListArray) by computing `sizes`
-/// from `offsets`.
-pub fn list_view_from_list(list: ListArray) -> ListViewArray {
-    // TODO(connor)[ListView]: Create a version of `Canonical::empty` for `ListView`. It might
-    // also be worth specializing that for all canonical encodings.
-    // If the list is empty, create an empty `ListView` with the same offset dtype as the input.
-    if list.is_empty() {
-        let empty_offsets = Canonical::empty(list.offsets().dtype()).into_array();
-        let empty_sizes = Canonical::empty(list.offsets().dtype()).into_array();
-        let empty_validity = list.validity().clone();
-
-        // SAFETY: Everything is empty so all the variants are satisfied.
-        return unsafe {
-            ListViewArray::new_unchecked(
-                list.elements().clone(),
-                empty_offsets,
-                empty_sizes,
-                empty_validity,
-            )
-        };
-    }
-
-    let len = list.len();
-
-    // Get the `offsets` array directly from the `ListArray` (preserving its type).
-    let list_offsets = list.offsets().clone();
-
-    // We need to slice the `offsets` to remove the last element (`ListArray` has n+1 offsets).
-    let adjusted_offsets = list_offsets.slice(0..len);
-
-    // Create sizes array by computing differences between consecutive offsets.
-    // Use the same dtype as the offsets array to ensure compatibility.
-    let sizes = match_each_integer_ptype!(list_offsets.dtype().as_ptype(), |P| {
-        let mut sizes_builder = PrimitiveBuilder::<P>::with_capacity(Nullability::NonNullable, len);
-
-        // Create uninit range for direct memory access.
-        let mut sizes_range = sizes_builder.uninit_range(len);
-
-        // Compute sizes as the difference between consecutive offsets.
-        for i in 0..len {
-            let start = list.offset_at(i);
-            let end = list.offset_at(i + 1);
-            let size = end - start;
-
-            // Set size value directly without creating scalar.
-            sizes_range.set_value(
-                i,
-                P::try_from(size).vortex_expect("size must fit in offset type"),
-            );
-        }
-
-        // SAFETY: We have initialized all values in the range.
-        unsafe {
-            sizes_range.finish();
-        }
-
-        sizes_builder.finish_into_primitive().into_array()
-    });
-
-    // SAFETY: Since everything came from an existing valid `ListArray`, and the `sizes` were
-    // derived from valid and in-order `offsets`, we know these fields are valid.
-    unsafe {
-        ListViewArray::new_unchecked(
-            list.elements().clone(),
-            adjusted_offsets,
-            sizes,
-            list.validity().clone(),
-        )
-    }
 }

--- a/vortex-array/src/arrays/listview/compute/filter.rs
+++ b/vortex-array/src/arrays/listview/compute/filter.rs
@@ -4,7 +4,7 @@
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
-use crate::arrays::{ListViewArray, ListViewVTable};
+use crate::arrays::{ListViewArray, ListViewRebuildMode, ListViewVTable};
 use crate::compute::{self, FilterKernel, FilterKernelAdapter};
 use crate::vtable::ValidityHelper;
 use crate::{ArrayRef, IntoArray, register_kernel};
@@ -45,7 +45,9 @@ impl FilterKernel for ListViewVTable {
                 .is_none_or(|len| len == selection_mask.true_count())
         );
 
-        // Filter the offsets and sizes arrays.
+        // Simply filter the offsets and sizes arrays.
+        // Filters keep scalars in order, and it cannot cause overlaps to form. However, filters
+        // **will** create gaps of unused elements.
         let new_offsets = compute::filter(offsets.as_ref(), selection_mask)?;
         let new_sizes = compute::filter(sizes.as_ref(), selection_mask)?;
 
@@ -57,10 +59,11 @@ impl FilterKernel for ListViewVTable {
             ListViewArray::new_unchecked(elements.clone(), new_offsets, new_sizes, new_validity)
         };
 
-        // TODO(connor)[ListView]: IsZeroCopyToList optimization.
-        // TODO(connor)[ListView]: Rebuild if the threshold is too low.
+        // TODO(connor)[ListView]: Rebuild if the threshold is too low, not unconditionally.
 
-        Ok(new_array.into_array())
+        Ok(new_array
+            .rebuild(ListViewRebuildMode::MakeZeroCopyToList)
+            .into_array())
     }
 }
 

--- a/vortex-array/src/arrays/listview/compute/filter.rs
+++ b/vortex-array/src/arrays/listview/compute/filter.rs
@@ -59,7 +59,9 @@ impl FilterKernel for ListViewVTable {
             ListViewArray::new_unchecked(elements.clone(), new_offsets, new_sizes, new_validity)
         };
 
-        // TODO(connor)[ListView]: Rebuild if the threshold is too low, not unconditionally.
+        // TODO(connor)[ListView]: Ideally, we would only rebuild after all `take`s and `filter`
+        // compute functions have run, at the "top" of the operator tree. However, we cannot do this
+        // right now, so we will just rebuild every time (similar to `ListArray`).
 
         Ok(new_array
             .rebuild(ListViewRebuildMode::MakeZeroCopyToList)

--- a/vortex-array/src/arrays/listview/compute/take.rs
+++ b/vortex-array/src/arrays/listview/compute/take.rs
@@ -6,7 +6,7 @@ use vortex_dtype::{Nullability, match_each_integer_ptype};
 use vortex_error::VortexResult;
 use vortex_scalar::Scalar;
 
-use crate::arrays::{ListViewArray, ListViewVTable};
+use crate::arrays::{ListViewArray, ListViewRebuildMode, ListViewVTable};
 use crate::compute::{self, TakeKernel, TakeKernelAdapter};
 use crate::vtable::ValidityHelper;
 use crate::{Array, ArrayRef, IntoArray, register_kernel};
@@ -44,6 +44,8 @@ impl TakeKernel for ListViewVTable {
         let new_validity = array.validity().take(indices)?;
 
         // Take the offsets and sizes arrays at the requested indices.
+        // Take can reorder offsets, create gaps, and may introduce overlaps if the `indices`
+        // contain duplicates.
         let nullable_new_offsets = compute::take(offsets.as_ref(), indices)?;
         let nullable_new_sizes = compute::take(sizes.as_ref(), indices)?;
 
@@ -72,10 +74,11 @@ impl TakeKernel for ListViewVTable {
             ListViewArray::new_unchecked(elements.clone(), new_offsets, new_sizes, new_validity)
         };
 
-        // TODO(connor)[ListView]: IsZeroCopyToList optimization.
-        // TODO(connor)[ListView]: Rebuild if the threshold is too low.
+        // TODO(connor)[ListView]: Rebuild if the threshold is too low, not unconditionally.
 
-        Ok(new_array.into_array())
+        Ok(new_array
+            .rebuild(ListViewRebuildMode::MakeZeroCopyToList)
+            .into_array())
     }
 }
 

--- a/vortex-array/src/arrays/listview/compute/take.rs
+++ b/vortex-array/src/arrays/listview/compute/take.rs
@@ -74,7 +74,9 @@ impl TakeKernel for ListViewVTable {
             ListViewArray::new_unchecked(elements.clone(), new_offsets, new_sizes, new_validity)
         };
 
-        // TODO(connor)[ListView]: Rebuild if the threshold is too low, not unconditionally.
+        // TODO(connor)[ListView]: Ideally, we would only rebuild after all `take`s and `filter`
+        // compute functions have run, at the "top" of the operator tree. However, we cannot do this
+        // right now, so we will just rebuild every time (similar to `ListArray`).
 
         Ok(new_array
             .rebuild(ListViewRebuildMode::MakeZeroCopyToList)

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::sync::Arc;
+
 use vortex_dtype::{IntegerPType, Nullability, match_each_integer_ptype};
 use vortex_error::VortexExpect;
 
-use crate::arrays::{ListArray, ListViewArray};
+use crate::arrays::{ExtensionArray, FixedSizeListArray, ListArray, ListViewArray, StructArray};
 use crate::builders::{ArrayBuilder, ListBuilder, PrimitiveBuilder};
 use crate::vtable::ValidityHelper;
-use crate::{ArrayRef, Canonical, IntoArray, ToCanonical};
+use crate::{Array, ArrayRef, Canonical, IntoArray, ToCanonical};
 
 /// Creates a [`ListViewArray`] from a [`ListArray`] by computing `sizes` from `offsets`.
 pub fn list_view_from_list(list: ListArray) -> ListViewArray {
@@ -96,16 +98,111 @@ pub fn list_from_list_view(list_view: ListViewArray) -> ListArray {
     })
 }
 
+/// Recursively converts all [`ListViewArray`]s to [`ListArray`]s in a nested array structure.
+///
+/// The conversion happens bottom-up, processing children before parents.
+pub fn recursive_list_from_list_view(array: ArrayRef) -> ArrayRef {
+    if !array.dtype().is_nested() {
+        return array;
+    }
+
+    let canonical = array.to_canonical();
+
+    match canonical {
+        Canonical::List(listview) => {
+            let converted_elements = recursive_list_from_list_view(listview.elements().clone());
+
+            // Avoid cloning if elements didn't change.
+            let listview_with_converted_elements =
+                if !Arc::ptr_eq(&converted_elements, listview.elements()) {
+                    ListViewArray::try_new(
+                        converted_elements,
+                        listview.offsets().clone(),
+                        listview.sizes().clone(),
+                        listview.validity().clone(),
+                    )
+                    .vortex_expect("ListView reconstruction should not fail with valid components")
+                } else {
+                    listview
+                };
+
+            let list_array = list_from_list_view(listview_with_converted_elements);
+            list_array.into_array()
+        }
+        Canonical::FixedSizeList(fixed_size_list) => {
+            let converted_elements =
+                recursive_list_from_list_view(fixed_size_list.elements().clone());
+
+            // Avoid cloning if elements didn't change.
+            if !Arc::ptr_eq(&converted_elements, fixed_size_list.elements()) {
+                FixedSizeListArray::try_new(
+                    converted_elements,
+                    fixed_size_list.list_size(),
+                    fixed_size_list.validity().clone(),
+                    fixed_size_list.len(),
+                )
+                .vortex_expect(
+                    "FixedSizeListArray reconstruction should not fail with valid components",
+                )
+                .into_array()
+            } else {
+                fixed_size_list.into_array()
+            }
+        }
+        Canonical::Struct(struct_array) => {
+            let fields = struct_array.fields();
+            let mut converted_fields = Vec::with_capacity(fields.len());
+            let mut any_changed = false;
+
+            for field in fields.iter() {
+                let converted_field = recursive_list_from_list_view(field.clone());
+                // Avoid cloning if elements didn't change.
+                any_changed |= !Arc::ptr_eq(&converted_field, field);
+                converted_fields.push(converted_field);
+            }
+
+            if any_changed {
+                StructArray::try_new(
+                    struct_array.names().clone(),
+                    converted_fields,
+                    struct_array.len(),
+                    struct_array.validity().clone(),
+                )
+                .vortex_expect("StructArray reconstruction should not fail with valid components")
+                .into_array()
+            } else {
+                struct_array.into_array()
+            }
+        }
+        Canonical::Extension(ext_array) => {
+            let converted_storage = recursive_list_from_list_view(ext_array.storage().clone());
+
+            // Avoid cloning if elements didn't change.
+            if !Arc::ptr_eq(&converted_storage, ext_array.storage()) {
+                ExtensionArray::new(ext_array.ext_dtype().clone(), converted_storage).into_array()
+            } else {
+                ext_array.into_array()
+            }
+        }
+        _ => unreachable!(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use vortex_buffer::buffer;
+    use vortex_dtype::FieldNames;
 
     use super::super::tests::common::{
         create_basic_listview, create_empty_lists_listview, create_nullable_listview,
         create_overlapping_listview,
     };
+    use super::recursive_list_from_list_view;
     use crate::arrays::{
-        BoolArray, ListArray, PrimitiveArray, list_from_list_view, list_view_from_list,
+        BoolArray, FixedSizeListArray, ListArray, ListViewArray, PrimitiveArray, StructArray,
+        list_from_list_view, list_view_from_list,
     };
     use crate::validity::Validity;
     use crate::vtable::ValidityHelper;
@@ -319,5 +416,157 @@ mod tests {
         // Round-trip.
         let converted_back = list_from_list_view(list_view.clone());
         assert_arrays_eq!(mixed_list, converted_back);
+    }
+
+    #[test]
+    fn test_recursive_simple_listview() {
+        let list_view = create_basic_listview();
+        let result = recursive_list_from_list_view(list_view.clone().into_array());
+
+        assert_eq!(result.len(), list_view.len());
+        assert_arrays_eq!(list_view.into_array(), result);
+    }
+
+    #[test]
+    fn test_recursive_nested_listview() {
+        let inner_elements = buffer![1i32, 2, 3].into_array();
+        let inner_offsets = buffer![0u32, 2].into_array();
+        let inner_sizes = buffer![2u32, 1].into_array();
+        let inner_listview = ListViewArray::try_new(
+            inner_elements,
+            inner_offsets,
+            inner_sizes,
+            Validity::NonNullable,
+        )
+        .unwrap();
+
+        let outer_offsets = buffer![0u32, 1].into_array();
+        let outer_sizes = buffer![1u32, 1].into_array();
+        let outer_listview = ListViewArray::try_new(
+            inner_listview.into_array(),
+            outer_offsets,
+            outer_sizes,
+            Validity::NonNullable,
+        )
+        .unwrap();
+
+        let result = recursive_list_from_list_view(outer_listview.clone().into_array());
+
+        assert_eq!(result.len(), 2);
+        assert_arrays_eq!(outer_listview.into_array(), result);
+    }
+
+    #[test]
+    fn test_recursive_struct_with_listview_fields() {
+        let listview_field = create_basic_listview().into_array();
+        let primitive_field = buffer![10i32, 20, 30, 40].into_array();
+
+        let struct_array = StructArray::try_new(
+            FieldNames::from(["lists", "values"]),
+            vec![listview_field, primitive_field],
+            4,
+            Validity::NonNullable,
+        )
+        .unwrap();
+
+        let result = recursive_list_from_list_view(struct_array.clone().into_array());
+
+        assert_eq!(result.len(), 4);
+        assert_arrays_eq!(struct_array.into_array(), result);
+    }
+
+    #[test]
+    fn test_recursive_fixed_size_list_with_listview_elements() {
+        let lv1_elements = buffer![1i32, 2].into_array();
+        let lv1_offsets = buffer![0u32].into_array();
+        let lv1_sizes = buffer![2u32].into_array();
+        let lv1 =
+            ListViewArray::try_new(lv1_elements, lv1_offsets, lv1_sizes, Validity::NonNullable)
+                .unwrap();
+
+        let lv2_elements = buffer![3i32, 4].into_array();
+        let lv2_offsets = buffer![0u32].into_array();
+        let lv2_sizes = buffer![2u32].into_array();
+        let lv2 =
+            ListViewArray::try_new(lv2_elements, lv2_offsets, lv2_sizes, Validity::NonNullable)
+                .unwrap();
+
+        let dtype = lv1.dtype().clone();
+        let chunked_listviews =
+            crate::arrays::ChunkedArray::try_new(vec![lv1.into_array(), lv2.into_array()], dtype)
+                .unwrap();
+
+        let fixed_list =
+            FixedSizeListArray::new(chunked_listviews.into_array(), 1, Validity::NonNullable, 2);
+
+        let result = recursive_list_from_list_view(fixed_list.clone().into_array());
+
+        assert_eq!(result.len(), 2);
+        assert_arrays_eq!(fixed_list.into_array(), result);
+    }
+
+    #[test]
+    fn test_recursive_deep_nesting() {
+        let innermost_elements = buffer![1i32, 2, 3].into_array();
+        let innermost_offsets = buffer![0u32, 2].into_array();
+        let innermost_sizes = buffer![2u32, 1].into_array();
+        let innermost_listview = ListViewArray::try_new(
+            innermost_elements,
+            innermost_offsets,
+            innermost_sizes,
+            Validity::NonNullable,
+        )
+        .unwrap();
+
+        let struct_array = StructArray::try_new(
+            FieldNames::from(["inner_lists"]),
+            vec![innermost_listview.into_array()],
+            2,
+            Validity::NonNullable,
+        )
+        .unwrap();
+
+        let outer_offsets = buffer![0u32, 1].into_array();
+        let outer_sizes = buffer![1u32, 1].into_array();
+        let outer_listview = ListViewArray::try_new(
+            struct_array.into_array(),
+            outer_offsets,
+            outer_sizes,
+            Validity::NonNullable,
+        )
+        .unwrap();
+
+        let result = recursive_list_from_list_view(outer_listview.clone().into_array());
+
+        assert_eq!(result.len(), 2);
+        assert_arrays_eq!(outer_listview.into_array(), result);
+    }
+
+    #[test]
+    fn test_recursive_primitive_unchanged() {
+        let prim = buffer![1i32, 2, 3].into_array();
+        let prim_clone = prim.clone();
+        let result = recursive_list_from_list_view(prim);
+
+        assert!(Arc::ptr_eq(&result, &prim_clone));
+    }
+
+    #[test]
+    fn test_recursive_mixed_listview_and_list() {
+        let listview = create_basic_listview();
+        let list = list_from_list_view(listview.clone());
+
+        let struct_array = StructArray::try_new(
+            FieldNames::from(["listview_field", "list_field"]),
+            vec![listview.into_array(), list.into_array()],
+            4,
+            Validity::NonNullable,
+        )
+        .unwrap();
+
+        let result = recursive_list_from_list_view(struct_array.clone().into_array());
+
+        assert_eq!(result.len(), 4);
+        assert_arrays_eq!(struct_array.into_array(), result);
     }
 }

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -126,6 +126,7 @@ pub fn recursive_list_from_list_view(array: ArrayRef) -> ArrayRef {
                     listview
                 };
 
+            // Make the conversion to `ListArray`.
             let list_array = list_from_list_view(listview_with_converted_elements);
             list_array.into_array()
         }

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -11,25 +11,10 @@ use crate::{ArrayRef, Canonical, IntoArray, ToCanonical};
 
 /// Creates a [`ListViewArray`] from a [`ListArray`] by computing `sizes` from `offsets`.
 pub fn list_view_from_list(list: ListArray) -> ListViewArray {
-    // TODO(connor)[ListView]: Create a version of `Canonical::empty` for `ListView` once `ListView`
-    // is canonicalized. It might also be worth specializing that for all canonical encodings.
-
     // If the list is empty, create an empty `ListViewArray` with the same offset `DType` as the
     // input.
     if list.is_empty() {
-        let empty_offsets = Canonical::empty(list.offsets().dtype()).into_array();
-        let empty_sizes = Canonical::empty(list.offsets().dtype()).into_array();
-        let empty_validity = list.validity().clone();
-
-        // SAFETY: Everything is empty so all the variants are satisfied.
-        return unsafe {
-            ListViewArray::new_unchecked(
-                list.elements().clone(),
-                empty_offsets,
-                empty_sizes,
-                empty_validity,
-            )
-        };
+        return Canonical::empty(list.dtype()).into_listview();
     }
 
     let len = list.len();
@@ -83,15 +68,6 @@ fn build_sizes_from_offsets<O: IntegerPType>(list: &ListArray) -> ArrayRef {
 }
 
 /// Creates a [`ListArray`] from a [`ListViewArray`].
-///
-/// If the [`ListViewShape::is_zero_copy_to_list`] is `true`, then this operation is fast (note that
-/// it is not exactly zero-copy because we have to add a single offset at the end, but it is fast
-/// enough).
-///
-/// Otherwise, this function fall back to the expensive path and will rebuild the `ListArray` from
-/// scratch.
-///
-/// [`as_zero_copy_to_list()`]: ListViewShape::as_zero_copy_to_list
 pub fn list_from_list_view(list_view: ListViewArray) -> ListArray {
     let elements_dtype = list_view
         .dtype()

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -1,0 +1,347 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::{IntegerPType, Nullability, match_each_integer_ptype};
+use vortex_error::VortexExpect;
+
+use crate::arrays::{ListArray, ListViewArray};
+use crate::builders::{ArrayBuilder, ListBuilder, PrimitiveBuilder};
+use crate::vtable::ValidityHelper;
+use crate::{ArrayRef, Canonical, IntoArray, ToCanonical};
+
+/// Creates a [`ListViewArray`] from a [`ListArray`] by computing `sizes` from `offsets`.
+pub fn list_view_from_list(list: ListArray) -> ListViewArray {
+    // TODO(connor)[ListView]: Create a version of `Canonical::empty` for `ListView` once `ListView`
+    // is canonicalized. It might also be worth specializing that for all canonical encodings.
+
+    // If the list is empty, create an empty `ListViewArray` with the same offset `DType` as the
+    // input.
+    if list.is_empty() {
+        let empty_offsets = Canonical::empty(list.offsets().dtype()).into_array();
+        let empty_sizes = Canonical::empty(list.offsets().dtype()).into_array();
+        let empty_validity = list.validity().clone();
+
+        // SAFETY: Everything is empty so all the variants are satisfied.
+        return unsafe {
+            ListViewArray::new_unchecked(
+                list.elements().clone(),
+                empty_offsets,
+                empty_sizes,
+                empty_validity,
+            )
+        };
+    }
+
+    let len = list.len();
+
+    // Get the `offsets` array directly from the `ListArray` (preserving its type).
+    let list_offsets = list.offsets().clone();
+
+    // We need to slice the `offsets` to remove the last element (`ListArray` has n+1 offsets).
+    let adjusted_offsets = list_offsets.slice(0..len);
+
+    // Create sizes array by computing differences between consecutive offsets.
+    // Use the same dtype as the offsets array to ensure compatibility.
+    let sizes = match_each_integer_ptype!(list_offsets.dtype().as_ptype(), |O| {
+        build_sizes_from_offsets::<O>(&list)
+    });
+
+    // SAFETY: Since everything came from an existing valid `ListArray`, and the `sizes` were
+    // derived from valid and in-order `offsets`, we know these fields are valid.
+    unsafe {
+        ListViewArray::new_unchecked(
+            list.elements().clone(),
+            adjusted_offsets,
+            sizes,
+            list.validity().clone(),
+        )
+    }
+}
+
+/// Builds a sizes array from a [`ListArray`] by computing differences between consecutive offsets.
+fn build_sizes_from_offsets<O: IntegerPType>(list: &ListArray) -> ArrayRef {
+    let len = list.len();
+    let mut sizes_builder = PrimitiveBuilder::<O>::with_capacity(Nullability::NonNullable, len);
+
+    // Create `UninitRange` for direct memory access.
+    let mut sizes_range = sizes_builder.uninit_range(len);
+    let offsets = list.offsets().to_primitive();
+    let offsets_slice = offsets.as_slice::<O>();
+
+    // Compute sizes as the difference between consecutive offsets.
+    for i in 0..len {
+        let size = offsets_slice[i + 1] - offsets_slice[i];
+        sizes_range.set_value(i, size);
+    }
+
+    // SAFETY: We have initialized all values in the range.
+    unsafe {
+        sizes_range.finish();
+    }
+
+    sizes_builder.finish_into_primitive().into_array()
+}
+
+/// Creates a [`ListArray`] from a [`ListViewArray`].
+///
+/// If the [`ListViewShape::is_zero_copy_to_list`] is `true`, then this operation is fast (note that
+/// it is not exactly zero-copy because we have to add a single offset at the end, but it is fast
+/// enough).
+///
+/// Otherwise, this function fall back to the expensive path and will rebuild the `ListArray` from
+/// scratch.
+///
+/// [`as_zero_copy_to_list()`]: ListViewShape::as_zero_copy_to_list
+pub fn list_from_list_view(list_view: ListViewArray) -> ListArray {
+    let elements_dtype = list_view
+        .dtype()
+        .as_list_element_opt()
+        .vortex_expect("`DType` of `ListView` was somehow not a `List`");
+    let nullability = list_view.dtype().nullability();
+    let len = list_view.len();
+
+    match_each_integer_ptype!(list_view.offsets().dtype().as_ptype(), |O| {
+        let mut builder = ListBuilder::<O>::with_capacity(
+            elements_dtype.clone(),
+            nullability,
+            list_view.elements().len(),
+            len,
+        );
+
+        for i in 0..len {
+            builder
+                .append_scalar(&list_view.scalar_at(i))
+                .vortex_expect(
+                    "The `ListView` scalars are `ListScalar`, which the `ListBuilder` must accept",
+                )
+        }
+
+        builder.finish_into_list()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_buffer::buffer;
+
+    use super::super::tests::common::{
+        create_basic_listview, create_empty_lists_listview, create_nullable_listview,
+        create_overlapping_listview,
+    };
+    use crate::arrays::{
+        BoolArray, ListArray, PrimitiveArray, list_from_list_view, list_view_from_list,
+    };
+    use crate::validity::Validity;
+    use crate::vtable::ValidityHelper;
+    use crate::{IntoArray, assert_arrays_eq};
+
+    #[test]
+    fn test_list_to_listview_basic() {
+        // Create a basic ListArray: [[0,1,2], [3,4], [5,6], [7,8,9]].
+        let elements = buffer![0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
+        let offsets = buffer![0u32, 3, 5, 7, 10].into_array();
+        let list_array =
+            ListArray::try_new(elements.clone(), offsets.clone(), Validity::NonNullable).unwrap();
+
+        let list_view = list_view_from_list(list_array.clone());
+
+        // Verify structure.
+        assert_eq!(list_view.len(), 4);
+        assert_arrays_eq!(elements, list_view.elements().clone());
+
+        // Verify offsets (should be same but without last element).
+        let expected_offsets = buffer![0u32, 3, 5, 7].into_array();
+        assert_arrays_eq!(expected_offsets, list_view.offsets().clone());
+
+        // Verify sizes.
+        let expected_sizes = buffer![3u32, 2, 2, 3].into_array();
+        assert_arrays_eq!(expected_sizes, list_view.sizes().clone());
+
+        // Verify data integrity.
+        assert_arrays_eq!(list_array, list_view);
+    }
+
+    #[test]
+    fn test_listview_to_list_zero_copy() {
+        let list_view = create_basic_listview();
+        let list_array = list_from_list_view(list_view.clone());
+
+        // Should have same elements.
+        assert_arrays_eq!(list_view.elements().clone(), list_array.elements().clone());
+
+        // ListArray offsets should have n+1 elements for n lists (add the final offset).
+        // Check that the first n offsets match.
+        let list_array_offsets_without_last = list_array.offsets().slice(0..list_view.len());
+        assert_arrays_eq!(list_view.offsets().clone(), list_array_offsets_without_last);
+
+        // Verify data integrity.
+        assert_arrays_eq!(list_view, list_array);
+    }
+
+    #[test]
+    fn test_empty_array_conversions() {
+        // Empty ListArray to ListViewArray.
+        let empty_elements = PrimitiveArray::from_iter::<[i32; 0]>([]).into_array();
+        let empty_offsets = buffer![0u32].into_array();
+        let empty_list =
+            ListArray::try_new(empty_elements.clone(), empty_offsets, Validity::NonNullable)
+                .unwrap();
+
+        // This conversion will create an empty ListViewArray.
+        // Note: list_view_from_list handles the empty case specially.
+        let empty_list_view = list_view_from_list(empty_list.clone());
+        assert_eq!(empty_list_view.len(), 0);
+
+        // Convert back.
+        let converted_back = list_from_list_view(empty_list_view);
+        assert_eq!(converted_back.len(), 0);
+        // For empty arrays, we can't use assert_arrays_eq directly since the offsets might differ.
+        // Just check that it's empty.
+        assert_eq!(empty_list.len(), converted_back.len());
+    }
+
+    #[test]
+    fn test_nullable_conversions() {
+        // Create nullable ListArray: [[10,20], null, [50]].
+        let elements = buffer![10i32, 20, 30, 40, 50].into_array();
+        let offsets = buffer![0u32, 2, 4, 5].into_array();
+        let validity = Validity::Array(BoolArray::from_iter(vec![true, false, true]).into_array());
+        let nullable_list =
+            ListArray::try_new(elements.clone(), offsets.clone(), validity.clone()).unwrap();
+
+        let nullable_list_view = list_view_from_list(nullable_list.clone());
+
+        // Verify validity is preserved.
+        assert_eq!(nullable_list_view.validity(), &validity);
+        assert_eq!(nullable_list_view.len(), 3);
+
+        // Round-trip conversion.
+        let converted_back = list_from_list_view(nullable_list_view);
+        assert_arrays_eq!(nullable_list, converted_back);
+    }
+
+    #[test]
+    fn test_non_zero_copy_listview_to_list() {
+        // Create ListViewArray with overlapping lists (not zero-copyable).
+        let list_view = create_overlapping_listview();
+        let list_array = list_from_list_view(list_view.clone());
+
+        // The data should still be correct even though it required a rebuild.
+        assert_arrays_eq!(list_view, list_array.clone());
+
+        // The resulting ListArray should have monotonic offsets.
+        for i in 0..list_array.len() {
+            let start = list_array.offset_at(i);
+            let end = list_array.offset_at(i + 1);
+            assert!(end >= start, "Offsets should be monotonic after conversion");
+        }
+    }
+
+    #[test]
+    fn test_empty_sublists() {
+        let empty_lists_view = create_empty_lists_listview();
+
+        // Convert to ListArray.
+        let list_array = list_from_list_view(empty_lists_view.clone());
+        assert_eq!(list_array.len(), 4);
+
+        // All sublists should be empty.
+        for i in 0..list_array.len() {
+            assert_eq!(list_array.list_elements_at(i).len(), 0);
+        }
+
+        // Round-trip.
+        let converted_back = list_view_from_list(list_array);
+        assert_arrays_eq!(empty_lists_view, converted_back);
+    }
+
+    #[test]
+    fn test_different_offset_types() {
+        // Test with i32 offsets.
+        let elements = buffer![1i32, 2, 3, 4, 5].into_array();
+        let i32_offsets = buffer![0i32, 2, 5].into_array();
+        let list_i32 =
+            ListArray::try_new(elements.clone(), i32_offsets.clone(), Validity::NonNullable)
+                .unwrap();
+
+        let list_view_i32 = list_view_from_list(list_i32.clone());
+        assert_eq!(list_view_i32.offsets().dtype(), i32_offsets.dtype());
+        assert_eq!(list_view_i32.sizes().dtype(), i32_offsets.dtype());
+
+        // Test with i64 offsets.
+        let i64_offsets = buffer![0i64, 2, 5].into_array();
+        let list_i64 =
+            ListArray::try_new(elements.clone(), i64_offsets.clone(), Validity::NonNullable)
+                .unwrap();
+
+        let list_view_i64 = list_view_from_list(list_i64.clone());
+        assert_eq!(list_view_i64.offsets().dtype(), i64_offsets.dtype());
+        assert_eq!(list_view_i64.sizes().dtype(), i64_offsets.dtype());
+
+        // Verify data integrity.
+        assert_arrays_eq!(list_i32, list_view_i32);
+        assert_arrays_eq!(list_i64, list_view_i64);
+    }
+
+    #[test]
+    fn test_round_trip_conversions() {
+        // Test 1: Basic round-trip.
+        let original = create_basic_listview();
+        let to_list = list_from_list_view(original.clone());
+        let back_to_view = list_view_from_list(to_list);
+        assert_arrays_eq!(original, back_to_view);
+
+        // Test 2: Nullable round-trip.
+        let nullable = create_nullable_listview();
+        let nullable_to_list = list_from_list_view(nullable.clone());
+        let nullable_back = list_view_from_list(nullable_to_list);
+        assert_arrays_eq!(nullable, nullable_back);
+
+        // Test 3: Non-zero-copyable round-trip.
+        let overlapping = create_overlapping_listview();
+
+        let overlapping_to_list = list_from_list_view(overlapping.clone());
+        let overlapping_back = list_view_from_list(overlapping_to_list);
+        assert_arrays_eq!(overlapping, overlapping_back);
+    }
+
+    #[test]
+    fn test_single_element_lists() {
+        // Create lists with single elements: [[100], [200], [300]].
+        let elements = buffer![100i32, 200, 300].into_array();
+        let offsets = buffer![0u32, 1, 2, 3].into_array();
+        let single_elem_list =
+            ListArray::try_new(elements.clone(), offsets, Validity::NonNullable).unwrap();
+
+        let list_view = list_view_from_list(single_elem_list.clone());
+        assert_eq!(list_view.len(), 3);
+
+        // Verify sizes are all 1.
+        let expected_sizes = buffer![1u32, 1, 1].into_array();
+        assert_arrays_eq!(expected_sizes, list_view.sizes().clone());
+
+        // Round-trip.
+        let converted_back = list_from_list_view(list_view.clone());
+        assert_arrays_eq!(single_elem_list, converted_back);
+    }
+
+    #[test]
+    fn test_mixed_empty_and_non_empty_lists() {
+        // Create: [[1,2], [], [3], [], [4,5,6]].
+        let elements = buffer![1i32, 2, 3, 4, 5, 6].into_array();
+        let offsets = buffer![0u32, 2, 2, 3, 3, 6].into_array();
+        let mixed_list =
+            ListArray::try_new(elements.clone(), offsets.clone(), Validity::NonNullable).unwrap();
+
+        let list_view = list_view_from_list(mixed_list.clone());
+        assert_eq!(list_view.len(), 5);
+
+        // Verify sizes.
+        let expected_sizes = buffer![2u32, 0, 1, 0, 3].into_array();
+        assert_arrays_eq!(expected_sizes, list_view.sizes().clone());
+
+        // Round-trip.
+        let converted_back = list_from_list_view(list_view.clone());
+        assert_arrays_eq!(mixed_list, converted_back);
+    }
+}

--- a/vortex-array/src/arrays/listview/mod.rs
+++ b/vortex-array/src/arrays/listview/mod.rs
@@ -5,7 +5,7 @@ mod array;
 pub use array::ListViewArray;
 
 mod conversion;
-pub use conversion::{list_from_list_view, list_view_from_list};
+pub use conversion::{list_from_list_view, list_view_from_list, recursive_list_from_list_view};
 
 mod compute;
 

--- a/vortex-array/src/arrays/listview/mod.rs
+++ b/vortex-array/src/arrays/listview/mod.rs
@@ -2,7 +2,10 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 mod array;
-pub use array::{ListViewArray, list_view_from_list};
+pub use array::ListViewArray;
+
+mod conversion;
+pub use conversion::{list_from_list_view, list_view_from_list};
 
 mod compute;
 

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -330,7 +330,6 @@ mod tests {
         assert_eq!(list2.as_slice::<i32>(), &[5, 6]);
     }
 
-    #[ignore = "TODO(connor)[ListView]: Reenable when `ListView` becomes canonical"]
     #[test]
     fn test_rebuild_flatten_removes_overlaps() {
         // Create a list view with overlapping lists: [A, B, C]
@@ -363,7 +362,6 @@ mod tests {
         assert_eq!(list1.as_slice::<i32>(), &[2, 3]);
     }
 
-    #[ignore = "TODO(connor)[ListView]: Reenable when `ListView` becomes canonical"]
     #[test]
     fn test_rebuild_flatten_with_nullable() {
         use arrow_buffer::BooleanBuffer;

--- a/vortex-array/src/arrays/listview/tests/basic.rs
+++ b/vortex-array/src/arrays/listview/tests/basic.rs
@@ -138,6 +138,10 @@ fn test_from_list_array() {
 #[case::constant_offsets(false, true)] // Varying sizes, constant offsets
 #[case::both_constant(true, true)] // Both constant
 fn test_listview_with_constant_arrays(#[case] const_sizes: bool, #[case] const_offsets: bool) {
+    // Logical lists vary by case:
+    // - constant_sizes: [[1,2,3], [4,5,6], [7,8,9]] (size 3 each, varying offsets)
+    // - constant_offsets: [[1,2,3], [1,2], [1]] (all start at 0, varying sizes)
+    // - both_constant: [[1,2,3], [1,2,3], [1,2,3]] (all identical)
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9, 10].into_array();
 
     let offsets = if const_offsets {
@@ -156,7 +160,7 @@ fn test_listview_with_constant_arrays(#[case] const_sizes: bool, #[case] const_o
     assert_eq!(listview.len(), 3);
 
     if const_sizes && const_offsets {
-        // All lists are identical [1, 2, 3].
+        // All lists are identical [1, 2, 3] (overlapping).
         for i in 0..3 {
             let list = listview.list_elements_at(i);
             assert_eq!(list.scalar_at(0), 1i32.into());
@@ -164,12 +168,12 @@ fn test_listview_with_constant_arrays(#[case] const_sizes: bool, #[case] const_o
             assert_eq!(list.scalar_at(2), 3i32.into());
         }
     } else if const_sizes {
-        // All lists have size 3, different offsets.
+        // All lists have size 3, different offsets (no overlap).
         assert_eq!(listview.list_elements_at(0).len(), 3);
         assert_eq!(listview.list_elements_at(1).len(), 3);
         assert_eq!(listview.list_elements_at(2).len(), 3);
     } else if const_offsets {
-        // All lists start at offset 0, different sizes.
+        // All lists start at offset 0, different sizes (overlapping).
         assert_eq!(listview.list_elements_at(0).scalar_at(0), 1i32.into());
         assert_eq!(listview.list_elements_at(1).scalar_at(0), 1i32.into());
         assert_eq!(listview.list_elements_at(2).scalar_at(0), 1i32.into());
@@ -213,6 +217,7 @@ fn test_validation_errors(
 
 #[test]
 fn test_validate_nullable_offsets() {
+    // Logical lists (invalid due to nullable offsets): [[1,2], [3], ???]
     let elements = buffer![1i32, 2, 3, 4, 5].into_array();
     let offsets = PrimitiveArray::from_option_iter(vec![Some(0u32), Some(2), None]).into_array();
     let sizes = buffer![2u32, 1, 2].into_array();
@@ -230,6 +235,7 @@ fn test_validate_nullable_offsets() {
 
 #[test]
 fn test_validate_nullable_sizes() {
+    // Logical lists (invalid due to nullable sizes): [[1,2], ???, [2,3]]
     let elements = buffer![1i32, 2, 3, 4, 5].into_array();
     let offsets = buffer![0u32, 2, 1].into_array();
     let sizes = PrimitiveArray::from_option_iter(vec![Some(2u32), None, Some(2)]).into_array();
@@ -247,6 +253,7 @@ fn test_validate_nullable_sizes() {
 
 #[test]
 fn test_validate_size_type_too_large() {
+    // Logical lists (invalid due to size type > offset type): [[1,2], [3], [2,3]]
     let elements = buffer![1i32, 2, 3, 4, 5].into_array();
     // Use u64 for sizes and u32 for offsets (sizes type is larger).
     let offsets = buffer![0u32, 2, 1].into_array();
@@ -260,6 +267,7 @@ fn test_validate_size_type_too_large() {
 
 #[test]
 fn test_validate_offset_plus_size_overflow() {
+    // Logical lists (invalid due to overflow): would overflow, [[1], [1]]
     let elements = buffer![1i32, 2, 3, 4, 5].into_array();
     // Create an offset + size that would overflow.
     let offsets = buffer![u32::MAX - 1, 0, 0].into_array();
@@ -277,6 +285,7 @@ fn test_validate_offset_plus_size_overflow() {
 
 #[test]
 fn test_validate_invalid_validity_length() {
+    // Logical lists (invalid due to validity length mismatch): [[1,2], [3,4], [5]]
     let elements = buffer![1i32, 2, 3, 4, 5].into_array();
     let offsets = buffer![0u32, 2, 4].into_array();
     let sizes = buffer![2u32, 2, 1].into_array();
@@ -295,6 +304,7 @@ fn test_validate_invalid_validity_length() {
 
 #[test]
 fn test_validate_non_integer_offsets() {
+    // Logical lists (invalid due to float offsets): [[1,2], [3,4], [5]]
     let elements = buffer![1i32, 2, 3, 4, 5].into_array();
     // Try to use float offsets.
     let offsets = buffer![0.0f32, 2.0, 4.0].into_array();
@@ -313,6 +323,7 @@ fn test_validate_non_integer_offsets() {
 #[test]
 fn test_validate_different_int_types() {
     // Test that different integer types work as long as sizes type ≤ offsets type.
+    // Logical lists: [[1,2], [3], [2,3]]
     let elements = buffer![1i32, 2, 3, 4, 5].into_array();
     let offsets = buffer![0u64, 2, 1].into_array();
     let sizes = buffer![2u32, 1, 2].into_array();
@@ -324,6 +335,7 @@ fn test_validate_different_int_types() {
 #[test]
 fn test_validate_u64_overflow() {
     // Test overflow with u64 offsets and sizes.
+    // Logical lists (invalid due to u64 overflow): would overflow, [[0], [0]]
     let elements = PrimitiveArray::from_iter(0i32..100).into_array();
     let offsets = buffer![u64::MAX - 10, 0, 0].into_array();
     let sizes = buffer![20u64, 1, 1].into_array();

--- a/vortex-array/src/arrays/listview/tests/filter.rs
+++ b/vortex-array/src/arrays/listview/tests/filter.rs
@@ -5,7 +5,6 @@ use rstest::rstest;
 use vortex_buffer::buffer;
 use vortex_mask::Mask;
 
-use super::ToListView;
 use super::common::{
     create_basic_listview, create_empty_lists_listview, create_large_listview,
     create_nullable_listview, create_overlapping_listview,
@@ -27,9 +26,14 @@ fn test_filter_listview_conformance(#[case] listview: ListViewArray) {
     test_filter_conformance(listview.as_ref());
 }
 
+#[ignore = "TODO(connor)[ListView]: Don't rebuild ListView after every `filter`"]
 #[test]
 fn test_filter_preserves_unreferenced_elements() {
     // ListView-specific: Test that filter preserves the entire elements array.
+    //
+    //
+    // Logical list: [[5,6,7], [2,3], [8,9], [0,1], [1,2,3,4]]
+    // Elements: [0,1,2,3,4,5,6,7,8,9]
     let elements = buffer![0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
     let offsets = buffer![5u32, 2, 8, 0, 1].into_array();
     let sizes = buffer![3u32, 2, 2, 2, 4].into_array();
@@ -58,10 +62,13 @@ fn test_filter_preserves_unreferenced_elements() {
     assert_eq!(result_list.offset_at(1), 0, "Wrong offset at index 3");
 }
 
+#[ignore = "TODO(connor)[ListView]: Don't rebuild ListView after every `filter`"]
 #[test]
 fn test_filter_with_gaps() {
     // ListView-specific: Test filtering with gaps in elements array.
-    // Elements with gaps (999 values are "gaps" between used ranges).
+    //
+    // Logical list: [[1,2,3], [7,8,9], [11,12], [2,3], [8,9]]
+    // Elements: [1,2,3,999,999,999,7,8,9,999,11,12] (999 values are gaps)
     let elements = buffer![1i32, 2, 3, 999, 999, 999, 7, 8, 9, 999, 11, 12].into_array();
     let offsets = buffer![0u32, 6, 10, 1, 7].into_array();
     let sizes = buffer![3u32, 3, 2, 2, 2].into_array();
@@ -96,12 +103,14 @@ fn test_filter_with_gaps() {
     assert_eq!(list0.scalar_at(2).as_primitive().as_::<i32>().unwrap(), 9);
 }
 
+#[ignore = "TODO(connor)[ListView]: Don't rebuild ListView after every `filter`"]
 #[test]
 fn test_filter_constant_arrays() {
     // ListView-specific: Test filter with ConstantArray for offsets/sizes.
     let elements = buffer![100i32, 200, 300, 400, 500, 600, 700, 800].into_array();
 
     // Case 1: Constant offsets (all lists start at same position).
+    // Logical list: [[300], [300,400], [300,400,500], [300,400,500,600]]
     let constant_offsets = ConstantArray::new(2u32, 4).into_array();
     let varying_sizes = buffer![1u32, 2, 3, 4].into_array();
 
@@ -125,6 +134,7 @@ fn test_filter_constant_arrays() {
     assert_eq!(result1_list.size_at(1), 3);
 
     // Case 2: Both constant (all lists are identical).
+    // Logical list: [[200,300,400], [200,300,400], [200,300,400]]
     let both_constant_offsets = ConstantArray::new(1u32, 3).into_array();
     let both_constant_sizes = ConstantArray::new(3u32, 3).into_array();
 
@@ -148,12 +158,14 @@ fn test_filter_constant_arrays() {
     assert_eq!(result2_list.size_at(1), 3);
 }
 
+#[ignore = "TODO(connor)[ListView]: Don't rebuild ListView after every `filter`"]
 #[test]
 fn test_filter_extreme_offsets() {
     // ListView-specific: Test with very large offsets.
     let elements = PrimitiveArray::from_iter(0i32..10000).into_array();
 
     // Lists at extremes: beginning, middle, and end of the array.
+    // Logical list: [[0..5], [4999..5001], [9995..10000], [2500..2503], [7500..7504]]
     let offsets = buffer![0u32, 4999, 9995, 2500, 7500].into_array();
     let sizes = buffer![5u32, 2, 5, 3, 4].into_array();
 

--- a/vortex-array/src/arrays/listview/tests/mod.rs
+++ b/vortex-array/src/arrays/listview/tests/mod.rs
@@ -1,28 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_error::vortex_panic;
-
-use crate::ArrayRef;
-use crate::arrays::{ListViewArray, ListViewVTable};
-
-// TODO(connor)[ListView]: Once `ListViewArray` replaces `ListArray` as the default `List` encoding,
-// we can remove this and simply use `to_list` via `ToCanonical`.
-/// Helper trait to extract ListViewArray from ArrayRef.
-trait ToListView {
-    fn to_listview(&self) -> ListViewArray;
-}
-
-impl ToListView for ArrayRef {
-    fn to_listview(&self) -> ListViewArray {
-        self.as_opt::<ListViewVTable>()
-            .unwrap_or_else(|| vortex_panic!("Expected ListViewArray"))
-            .clone()
-    }
-}
+pub(super) mod common;
 
 mod basic;
-mod common;
 mod filter;
 mod nested;
 mod nullability;

--- a/vortex-array/src/arrays/listview/tests/nested.rs
+++ b/vortex-array/src/arrays/listview/tests/nested.rs
@@ -19,6 +19,7 @@ fn test_listview_of_listview_with_overlapping() {
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8].into_array();
 
     // Create inner ListView where lists overlap:
+    // Logical inner lists: [[1,2,3], [3,4,5], [2,3,4], [6,7,8], [1,2], [7,8]]
     // inner[0]: elements[0..3] = [1, 2, 3]
     // inner[1]: elements[2..5] = [3, 4, 5] (overlaps with inner[0])
     // inner[2]: elements[1..4] = [2, 3, 4] (overlaps with both)
@@ -33,6 +34,7 @@ fn test_listview_of_listview_with_overlapping() {
             .unwrap();
 
     // Create outer ListView that groups the inner lists:
+    // Logical outer lists: [inner[0..3], inner[3..6]]
     // outer[0]: contains inner[0..3] (3 inner lists)
     // outer[1]: contains inner[3..6] (3 inner lists)
     let outer_offsets = buffer![0u32, 3].into_array();
@@ -85,6 +87,7 @@ fn test_deeply_nested_out_of_order() {
 
     // Level 1: ListView with out-of-order offsets.
     // 8 inner lists, accessed in scrambled order.
+    // Logical lists: [[9,10], [1,2], [5,6], [13,14], [3,4], [11,12], [7,8], [15,16]]
     let l1_offsets = buffer![8u32, 0, 4, 12, 2, 10, 6, 14].into_array();
     let l1_sizes = buffer![2u32, 2, 2, 2, 2, 2, 2, 2].into_array();
 
@@ -93,6 +96,7 @@ fn test_deeply_nested_out_of_order() {
 
     // Level 2: Group level1 lists, also out-of-order.
     // 4 lists of 2 inner lists each.
+    // Logical lists: [level1[6..8], level1[2..4], level1[0..2], level1[4..6]]
     let l2_offsets = buffer![6u32, 2, 0, 4].into_array();
     let l2_sizes = buffer![2u32, 2, 2, 2].into_array();
 
@@ -106,6 +110,7 @@ fn test_deeply_nested_out_of_order() {
 
     // Level 3: Top level groups.
     // 2 lists of 2 level2 lists each.
+    // Logical lists: [level2[2..4], level2[0..2]]
     let l3_offsets = buffer![2u32, 0].into_array();
     let l3_sizes = buffer![2u32, 2].into_array();
 
@@ -152,6 +157,8 @@ fn test_mixed_offset_size_types() {
     let elements = PrimitiveArray::from_iter(0i32..256).into_array();
 
     // Inner ListView with u32 offsets and u16 sizes.
+    // Logical lists: [[0..5], [10..18], [20..30], [30..37], [40..55], [50..70], [100..125],
+    //                 [150..180], [200..250]]
     let inner_offsets = buffer![0u32, 10, 20, 30, 40, 50, 100, 150, 200].into_array();
     let inner_sizes = buffer![5u16, 8, 10, 7, 15, 20, 25, 30, 50].into_array();
 
@@ -165,6 +172,7 @@ fn test_mixed_offset_size_types() {
 
     // Outer ListView with u64 offsets and u8 sizes.
     // Using small sizes that fit in u8 to test the type difference.
+    // Logical lists: [inner[0..3], inner[3..6], inner[6..9]]
     let outer_offsets = buffer![0u64, 3, 6].into_array();
     let outer_sizes = buffer![3u8, 3, 3].into_array();
 
@@ -202,6 +210,7 @@ fn test_listview_zero_and_overlapping() {
     let elements = buffer![1i32, 2, 3, 4, 5].into_array();
 
     // Create inner lists with various patterns:
+    // Logical lists: [[], [1,2,3], [], [2,3,4], [5], [], [1,2,3,4,5], []]
     // inner[0]: empty list
     // inner[1]: [1, 2, 3] (normal)
     // inner[2]: empty list
@@ -218,6 +227,7 @@ fn test_listview_zero_and_overlapping() {
             .unwrap();
 
     // Create outer lists that group these:
+    // Logical lists: [inner[0..3], inner[3..6], inner[6..8]]
     // outer[0]: [empty, [1,2,3], empty] - mix of empty and non-empty
     // outer[1]: [[2,3,4], [5], empty] - overlapping and empty
     // outer[2]: [[1,2,3,4,5], empty] - full and empty
@@ -300,6 +310,7 @@ fn test_listview_of_struct_with_nulls() {
     .unwrap();
 
     // Create ListView of structs with variable sizes and overlapping.
+    // Logical lists: [structs[0..2], structs[1..4], structs[3..6]]
     // list[0]: structs[0..2] - one has null field
     // list[1]: structs[1..4] - one entire struct is null, overlaps with list[0]
     // list[2]: structs[3..6] - one entire struct is null

--- a/vortex-array/src/arrays/listview/tests/nullability.rs
+++ b/vortex-array/src/arrays/listview/tests/nullability.rs
@@ -15,6 +15,7 @@ use crate::validity::Validity;
 #[test]
 fn test_nullable_listview_comprehensive() {
     // Comprehensive test for nullable ListView including scalar_at with nulls.
+    // Logical lists: [[1,2], null, [5,6]]
     let elements = buffer![1i32, 2, 3, 4, 5, 6].into_array();
     let offsets = buffer![0i32, 2, 4].into_array();
     let sizes = buffer![2i32, 2, 2].into_array();
@@ -74,6 +75,7 @@ fn test_nullable_listview_comprehensive() {
 #[case::all_valid(Validity::AllValid, vec![true, true, true])]
 #[case::mixed(Validity::from_iter([false, true, false]), vec![false, true, false])]
 fn test_nullable_patterns(#[case] validity: Validity, #[case] expected_validity: Vec<bool>) {
+    // Logical lists: [[1,2], [3,4], [5,6]] with varying validity
     let elements = buffer![1i32, 2, 3, 4, 5, 6].into_array();
     let offsets = buffer![0i32, 2, 4].into_array();
     let sizes = buffer![2i32, 2, 2].into_array();
@@ -88,6 +90,7 @@ fn test_nullable_patterns(#[case] validity: Validity, #[case] expected_validity:
 #[test]
 fn test_nullable_elements() {
     // Test with nullable elements inside the lists.
+    // Logical lists: [[Some(1), None], [Some(3), None], [Some(5), Some(6)]]
     let elements =
         PrimitiveArray::from_option_iter([Some(1i32), None, Some(3), None, Some(5), Some(6)])
             .into_array();
@@ -125,6 +128,7 @@ fn test_nullable_elements() {
 
 #[test]
 fn test_validity_length_mismatch() {
+    // Logical lists (invalid due to validity length mismatch): [[1,2], [3,4]]
     let elements = buffer![1i32, 2, 3, 4].into_array();
     let offsets = buffer![0i32, 2].into_array();
     let sizes = buffer![2i32, 2].into_array();

--- a/vortex-array/src/arrays/listview/tests/operations.rs
+++ b/vortex-array/src/arrays/listview/tests/operations.rs
@@ -8,13 +8,12 @@ use vortex_buffer::buffer;
 use vortex_dtype::{DType, Nullability, PType};
 use vortex_mask::Mask;
 
-use super::ToListView;
 use super::common::{create_basic_listview, create_large_listview, create_nullable_listview};
 use crate::arrays::{BoolArray, ConstantArray, ListViewArray, ListViewVTable};
 use crate::compute::conformance::mask::test_mask_conformance;
 use crate::compute::{cast, is_constant, mask};
 use crate::validity::Validity;
-use crate::{Array, IntoArray};
+use crate::{Array, IntoArray, ToCanonical};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Slice tests
@@ -23,6 +22,7 @@ use crate::{Array, IntoArray};
 #[test]
 fn test_slice_comprehensive() {
     // Comprehensive test for basic slicing, full array, and single element cases.
+    // Logical lists: [[1,2,3], [4,5], [6,7,8], [9,10]]
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9, 10].into_array();
     let offsets = buffer![0i32, 3, 5, 7].into_array();
     let sizes = buffer![3i32, 2, 3, 2].into_array();
@@ -65,6 +65,7 @@ fn test_slice_comprehensive() {
 #[test]
 fn test_slice_out_of_order() {
     // ListView-specific: Test slicing with out-of-order offsets.
+    // Logical lists: [[70,80], [10,20,30], [40,50,60], [90], [30]]
     let elements = buffer![10i32, 20, 30, 40, 50, 60, 70, 80, 90].into_array();
     let offsets = buffer![6i32, 0, 3, 8, 2].into_array(); // Out of order.
     let sizes = buffer![2i32, 3, 3, 1, 1].into_array();
@@ -115,6 +116,7 @@ fn test_slice_out_of_order() {
 #[test]
 fn test_slice_with_nulls() {
     // Test slicing with nullable ListView.
+    // Logical lists: [[1,2], null, [5,6], null]
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8].into_array();
     let offsets = buffer![0i32, 2, 4, 6].into_array();
     let sizes = buffer![2i32, 2, 2, 2].into_array();
@@ -230,6 +232,7 @@ fn test_cast_numeric_types(#[case] from_ptype: PType, #[case] to_ptype: PType) {
 
 #[test]
 fn test_cast_with_nulls() {
+    // Logical lists: [[10,20], null]
     let elements = buffer![10i32, 20, 30, 40].into_array();
     let offsets = buffer![0u32, 2].into_array();
     let sizes = buffer![2u32, 2].into_array();
@@ -303,6 +306,7 @@ fn test_cast_special_patterns(#[case] expected_sizes: Vec<usize>, #[case] list_c
 #[test]
 fn test_cast_large_dataset() {
     // Test with larger data.
+    // Logical lists: [[0..4], [4..8], [8..12], ..., [76..80]] (20 lists of size 4)
     let elements = buffer![0u16..100].into_array();
     let offsets = buffer![
         0u32, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76
@@ -391,6 +395,7 @@ fn test_is_constant_basic(
 #[test]
 fn test_constant_with_constant_elements() {
     // Test with ConstantArray as elements - all lists point to same constant value.
+    // Logical lists: [[42,42], [42,42], [42,42]]
     let elements = ConstantArray::new(42i32, 10).into_array();
     let offsets = buffer![0i32, 2, 4].into_array();
     let sizes = buffer![2i32, 2, 2].into_array();
@@ -406,6 +411,7 @@ fn test_constant_with_constant_elements() {
 #[test]
 fn test_constant_with_nulls() {
     // Test nullable ListView scenarios.
+    // Logical lists: [[1,2], [3,4]] (validity varies by case)
     let elements = buffer![1i32, 2, 3, 4].into_array();
     let offsets = buffer![0i32, 2].into_array();
     let sizes = buffer![2i32, 2].into_array();
@@ -438,6 +444,7 @@ fn test_constant_with_nulls() {
 #[test]
 fn test_constant_repeated_same_lists() {
     // Test multiple lists that are identical (overlapping).
+    // Logical lists: [[10,20,30], [10,20,30], [10,20,30], [10,20,30]]
     let elements = buffer![10i32, 20, 30].into_array();
     let offsets = buffer![0i32, 0, 0, 0].into_array(); // All point to same start.
     let sizes = buffer![3i32, 3, 3, 3].into_array(); // All same size.
@@ -466,6 +473,7 @@ fn test_mask_listview_conformance(#[case] listview: ListViewArray) {
 #[test]
 fn test_mask_preserves_structure() {
     // ListView-specific: Verify mask preserves offsets and sizes.
+    // Logical lists: [[1,2], [3,4], [5,6], [7,8]]
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8].into_array();
     let offsets = buffer![0u32, 2, 4, 6].into_array();
     let sizes = buffer![2u32, 2, 2, 2].into_array();
@@ -501,6 +509,7 @@ fn test_mask_preserves_structure() {
 #[test]
 fn test_mask_with_existing_nulls() {
     // ListView-specific: Test interaction between existing nulls and mask.
+    // Logical lists: [[10,20], null, [50,60]]
     let elements = buffer![10i32, 20, 30, 40, 50, 60].into_array();
     let offsets = buffer![0u32, 2, 4].into_array();
     let sizes = buffer![2u32, 2, 2].into_array();
@@ -524,6 +533,7 @@ fn test_mask_with_existing_nulls() {
 #[test]
 fn test_mask_with_gaps() {
     // ListView-specific: Mask with gaps in elements.
+    // Logical lists: [[1,2], [5,6], [9,10]] (999 values are gaps)
     let elements = buffer![1i32, 2, 999, 999, 5, 6, 999, 999, 9, 10].into_array();
     let offsets = buffer![0u32, 4, 8].into_array();
     let sizes = buffer![2u32, 2, 2].into_array();
@@ -549,6 +559,7 @@ fn test_mask_with_gaps() {
 #[test]
 fn test_mask_constant_arrays() {
     // ListView-specific: Test mask with ConstantArray offsets/sizes.
+    // Logical lists: [[200,300], [200,300], [200,300]]
     let elements = buffer![100i32, 200, 300, 400, 500, 600].into_array();
 
     // All lists start at offset 1 and have size 2.

--- a/vortex-array/src/arrays/listview/tests/take.rs
+++ b/vortex-array/src/arrays/listview/tests/take.rs
@@ -4,7 +4,6 @@
 use rstest::rstest;
 use vortex_buffer::buffer;
 
-use super::ToListView;
 use super::common::{
     create_basic_listview, create_empty_lists_listview, create_large_listview,
     create_nullable_listview, create_overlapping_listview,
@@ -22,13 +21,13 @@ use crate::{Array, IntoArray, ToCanonical};
 #[case::empty_lists(create_empty_lists_listview())]
 #[case::overlapping(create_overlapping_listview())]
 #[case::large(create_large_listview())]
-#[ignore = "TODO(connor)[ListView]: Enable once ListViewArray canonicalization is implemented."]
 fn test_take_listview_conformance(#[case] listview: ListViewArray) {
     test_take_conformance(listview.as_ref());
 }
 
 // ListView-specific tests that aren't covered by conformance.
 
+#[ignore = "TODO(connor)[ListView]: Don't rebuild ListView after every `take`"]
 #[test]
 fn test_take_preserves_unreferenced_elements() {
     // ListView-specific: Test that take preserves the entire elements array
@@ -60,6 +59,7 @@ fn test_take_preserves_unreferenced_elements() {
     assert_eq!(result_list.offset_at(1), 0); // List 3
 }
 
+#[ignore = "TODO(connor)[ListView]: Don't rebuild ListView after every `take`"]
 #[test]
 fn test_take_with_gaps() {
     // ListView-specific: Test with gaps in elements array.
@@ -90,6 +90,7 @@ fn test_take_with_gaps() {
     assert_eq!(list0.scalar_at(2).as_primitive().as_::<i32>().unwrap(), 9);
 }
 
+#[ignore = "TODO(connor)[ListView]: Don't rebuild ListView after every `take`"]
 #[test]
 fn test_take_constant_arrays() {
     // ListView-specific: Test with ConstantArray for offsets/sizes.
@@ -144,6 +145,7 @@ fn test_take_constant_arrays() {
     assert_eq!(result2_list.size_at(1), 3);
 }
 
+#[ignore = "TODO(connor)[ListView]: Don't rebuild ListView after every `take`"]
 #[test]
 fn test_take_extreme_offsets() {
     // ListView-specific: Test with very large offsets to demonstrate

--- a/vortex-array/src/arrays/listview/vtable/canonical.rs
+++ b/vortex-array/src/arrays/listview/vtable/canonical.rs
@@ -6,7 +6,7 @@ use crate::arrays::{ListViewArray, ListViewVTable};
 use crate::vtable::CanonicalVTable;
 
 impl CanonicalVTable<ListViewVTable> for ListViewVTable {
-    fn canonicalize(_array: &ListViewArray) -> Canonical {
-        unimplemented!("TODO(connor)[ListView]: ListViewArray canonicalization")
+    fn canonicalize(array: &ListViewArray) -> Canonical {
+        Canonical::List(array.clone())
     }
 }

--- a/vortex-array/src/arrays/listview/vtable/operations.rs
+++ b/vortex-array/src/arrays/listview/vtable/operations.rs
@@ -15,6 +15,10 @@ impl OperationsVTable<ListViewVTable> for ListViewVTable {
         let start = range.start;
         let end = range.end;
 
+        // We implement slice by simply slicing the views. We leave the child `elements` array alone
+        // since slicing could potentially require calculating which elements are referenced by the
+        // new set of views.
+
         // SAFETY: The preconditions of `slice` mean that the bounds have already been checked, and
         // slicing the components of an existing valid array is still valid.
         unsafe {

--- a/vortex-array/src/arrow/compute/to_arrow/canonical.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/canonical.rs
@@ -13,7 +13,7 @@ use arrow_array::{
     Decimal32Array as ArrowDecimal32Array, Decimal64Array as ArrowDecimal64Array,
     Decimal128Array as ArrowDecimal128Array, Decimal256Array as ArrowDecimal256Array,
     FixedSizeListArray as ArrowFixedSizeListArray, GenericByteArray, GenericByteViewArray,
-    GenericListArray, NullArray as ArrowNullArray, OffsetSizeTrait,
+    GenericListArray, GenericListViewArray, NullArray as ArrowNullArray, OffsetSizeTrait,
     PrimitiveArray as ArrowPrimitiveArray, StructArray as ArrowStructArray,
 };
 use arrow_buffer::{ScalarBuffer, i256};
@@ -27,12 +27,13 @@ use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
 use vortex_scalar::DecimalValueType;
 
 use crate::arrays::{
-    BoolArray, DecimalArray, FixedSizeListArray, ListArray, NullArray, PrimitiveArray, StructArray,
-    VarBinViewArray,
+    BoolArray, DecimalArray, FixedSizeListArray, ListViewArray, NullArray, PrimitiveArray,
+    StructArray, VarBinViewArray,
 };
 use crate::arrow::IntoArrowArray;
 use crate::arrow::array::ArrowArray;
 use crate::arrow::compute::ToArrowArgs;
+use crate::builders::{ArrayBuilder, ListBuilder};
 use crate::compute::{InvocationArgs, Kernel, Output, cast};
 use crate::{Array as _, Canonical, IntoArray, ToCanonical};
 
@@ -176,6 +177,12 @@ impl Kernel for ToArrowCanonical {
             }
             (Canonical::Struct(array), DataType::Struct(fields)) => {
                 to_arrow_struct(array, fields.as_ref(), to_preferred)
+            }
+            (Canonical::List(array), DataType::ListView(field)) => {
+                to_arrow_listview::<i32>(array, arrow_type_opt.map(|_| field))
+            }
+            (Canonical::List(array), DataType::LargeListView(field)) => {
+                to_arrow_listview::<i64>(array, arrow_type_opt.map(|_| field))
             }
             (Canonical::List(array), DataType::List(field)) => {
                 to_arrow_list::<i32>(array, arrow_type_opt.map(|_| field))
@@ -474,35 +481,101 @@ fn to_arrow_struct(
     )?))
 }
 
+/// Converts a Vortex [`ListViewArray`] into an arrow [`GenericListArray`].
 fn to_arrow_list<O: IntegerPType + OffsetSizeTrait>(
-    array: ListArray,
+    array: ListViewArray,
+    element_field: Option<&FieldRef>,
+) -> VortexResult<ArrowArrayRef> {
+    // Since `ListViewArray` can have lists stored out-of-order, we must rebuild the entire array.
+    // We also can't use `list_from_list_view` because we need this specific `O` type for offsets.
+    let mut list_builder = ListBuilder::<O>::with_capacity(
+        array
+            .dtype()
+            .as_list_element_opt()
+            .vortex_expect("`ListViewArray` somehow was not of type `List`")
+            .clone(),
+        array.dtype().nullability(),
+        array.elements().len(), // This might be wrong, but it's better than nothing.
+        array.len(),
+    );
+
+    list_builder.extend_from_array(&array.to_array());
+    let list_array = list_builder.finish_into_list();
+
+    // Now that we have a normal `ListArray`, we can convert all the child arrays.
+
+    // Convert the child `elements` array to Arrow.
+    let (elements, element_field) = if let Some(element_field) = element_field {
+        let elements = list_array
+            .elements()
+            .clone()
+            .into_arrow(element_field.data_type())?;
+        let element_field = element_field.clone();
+        (elements, element_field)
+    } else {
+        let elements = list_array.elements().clone().into_arrow_preferred()?;
+        let element_field = Arc::new(Field::new_list_field(
+            elements.data_type().clone(),
+            list_array.elements().dtype().is_nullable(),
+        ));
+        (elements, element_field)
+    };
+
+    // Convert the child `offsets` and `validity` array to Arrow.
+    let offsets = list_array
+        .offsets()
+        .to_primitive()
+        .buffer::<O>()
+        .into_arrow_offset_buffer();
+    let nulls = list_array.validity_mask().to_null_buffer();
+
+    Ok(Arc::new(GenericListArray::new(
+        element_field,
+        offsets,
+        elements,
+        nulls,
+    )))
+}
+
+/// Converts a Vortex [`ListViewArray`] into an arrow [`GenericListViewArray`].
+fn to_arrow_listview<O: IntegerPType + OffsetSizeTrait>(
+    array: ListViewArray,
     element: Option<&FieldRef>,
 ) -> VortexResult<ArrowArrayRef> {
-    // First we cast the offsets into the correct width.
+    // First we cast the offsets and sizes into the specified width (determined by `O::PTYPE`).
     let offsets_dtype = DType::Primitive(O::PTYPE, array.dtype().nullability());
-    let arrow_offsets = cast(array.offsets(), &offsets_dtype)
+    let offsets = cast(array.offsets(), &offsets_dtype)
         .map_err(|err| err.with_context(format!("Failed to cast offsets to {offsets_dtype}")))?
         .to_primitive();
+    let sizes = cast(array.sizes(), &offsets_dtype)
+        .map_err(|err| err.with_context(format!("Failed to cast sizes to {offsets_dtype}")))?
+        .to_primitive();
 
-    let (values, element_field) = if let Some(element) = element {
+    // Convert `offsets`, `sizes`, and `validity` to Arrow buffers.
+    let arrow_offsets = offsets.buffer::<O>().into_arrow_scalar_buffer();
+    let arrow_sizes = sizes.buffer::<O>().into_arrow_scalar_buffer();
+    let nulls = array.validity_mask().to_null_buffer();
+
+    // Convert the child `elements` array to Arrow.
+    let (elements, element_field) = if let Some(element) = element {
         (
             array.elements().clone().into_arrow(element.data_type())?,
             element.clone(),
         )
     } else {
-        let values = array.elements().clone().into_arrow_preferred()?;
+        let elements = array.elements().clone().into_arrow_preferred()?;
         let element_field = Arc::new(Field::new_list_field(
-            values.data_type().clone(),
+            elements.data_type().clone(),
             array.elements().dtype().is_nullable(),
         ));
-        (values, element_field)
+        (elements, element_field)
     };
-    let nulls = array.validity_mask().to_null_buffer();
 
-    Ok(Arc::new(GenericListArray::new(
+    Ok(Arc::new(GenericListViewArray::new(
         element_field,
-        arrow_offsets.buffer::<O>().into_arrow_offset_buffer(),
-        values,
+        arrow_offsets,
+        arrow_sizes,
+        elements,
         nulls,
     )))
 }
@@ -598,7 +671,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{Array, Decimal128Array, Decimal256Array};
+    use arrow_array::{
+        Array, Decimal128Array, Decimal256Array, GenericListArray, GenericListViewArray,
+    };
     use arrow_buffer::i256;
     use arrow_schema::{DataType, Field};
     use rstest::rstest;
@@ -607,7 +682,7 @@ mod tests {
     use vortex_scalar::NativeDecimalType;
 
     use crate::IntoArray;
-    use crate::arrays::{DecimalArray, ListArray, PrimitiveArray, StructArray};
+    use crate::arrays::{DecimalArray, ListViewArray, PrimitiveArray, StructArray};
     use crate::arrow::IntoArrowArray;
     use crate::arrow::compute::to_arrow;
     use crate::builders::{ArrayBuilder, DecimalBuilder};
@@ -797,16 +872,189 @@ mod tests {
     }
 
     #[test]
-    fn to_arrow_list_preferred() {
-        let elements = PrimitiveArray::new(buffer![1u8, 2, 3, 4, 5], Validity::NonNullable);
-        let offsets = PrimitiveArray::new(buffer![0i32, 3, 5], Validity::NonNullable);
-        let list_array = ListArray::try_new(
+    fn test_to_arrow_list_i32() {
+        // Create a ListViewArray with i32 elements: [[1, 2, 3], [4, 5]]
+        let elements = PrimitiveArray::new(buffer![1i32, 2, 3, 4, 5], Validity::NonNullable);
+        let offsets = PrimitiveArray::new(buffer![0i32, 3], Validity::NonNullable);
+        let sizes = PrimitiveArray::new(buffer![3i32, 2], Validity::NonNullable);
+
+        let list_array = ListViewArray::try_new(
             elements.into_array(),
             offsets.into_array(),
+            sizes.into_array(),
             Validity::AllValid,
         )
         .unwrap();
 
-        list_array.into_array().into_arrow_preferred().unwrap();
+        // Convert to Arrow List with i32 offsets.
+        let field = Field::new("item", DataType::Int32, false);
+        let arrow_dt = DataType::List(field.into());
+        let arrow_array = list_array.into_array().into_arrow(&arrow_dt).unwrap();
+
+        // Verify the type is correct.
+        assert_eq!(arrow_array.data_type(), &arrow_dt);
+
+        // Downcast and verify the structure.
+        let list = arrow_array
+            .as_any()
+            .downcast_ref::<GenericListArray<i32>>()
+            .unwrap();
+
+        assert_eq!(list.len(), 2);
+        assert!(!list.is_null(0));
+        assert!(!list.is_null(1));
+
+        // Verify the values in the first list.
+        let first_list = list.value(0);
+        assert_eq!(first_list.len(), 3);
+        let first_values = first_list
+            .as_any()
+            .downcast_ref::<arrow_array::Int32Array>()
+            .unwrap();
+        assert_eq!(first_values.value(0), 1);
+        assert_eq!(first_values.value(1), 2);
+        assert_eq!(first_values.value(2), 3);
+
+        // Verify the values in the second list.
+        let second_list = list.value(1);
+        assert_eq!(second_list.len(), 2);
+        let second_values = second_list
+            .as_any()
+            .downcast_ref::<arrow_array::Int32Array>()
+            .unwrap();
+        assert_eq!(second_values.value(0), 4);
+        assert_eq!(second_values.value(1), 5);
+    }
+
+    #[test]
+    fn test_to_arrow_list_i64() {
+        // Create a ListViewArray with i64 offsets: [[10, 20], [30]]
+        let elements = PrimitiveArray::new(buffer![10i64, 20, 30], Validity::NonNullable);
+        let offsets = PrimitiveArray::new(buffer![0i64, 2], Validity::NonNullable);
+        let sizes = PrimitiveArray::new(buffer![2i64, 1], Validity::NonNullable);
+
+        let list_array = ListViewArray::try_new(
+            elements.into_array(),
+            offsets.into_array(),
+            sizes.into_array(),
+            Validity::AllValid,
+        )
+        .unwrap();
+
+        // Convert to Arrow LargeList with i64 offsets.
+        let field = Field::new("item", DataType::Int64, false);
+        let arrow_dt = DataType::LargeList(field.into());
+        let arrow_array = list_array.into_array().into_arrow(&arrow_dt).unwrap();
+
+        // Verify the type is correct.
+        assert_eq!(arrow_array.data_type(), &arrow_dt);
+
+        // Downcast and verify the structure.
+        let list = arrow_array
+            .as_any()
+            .downcast_ref::<GenericListArray<i64>>()
+            .unwrap();
+
+        assert_eq!(list.len(), 2);
+        assert!(!list.is_null(0));
+        assert!(!list.is_null(1));
+    }
+
+    #[test]
+    fn test_to_arrow_listview_i32() {
+        // Create a ListViewArray with overlapping views: [[1, 2], [2, 3], [3, 4]]
+        let elements = PrimitiveArray::new(buffer![1i32, 2, 3, 4], Validity::NonNullable);
+        let offsets = PrimitiveArray::new(buffer![0i32, 1, 2], Validity::NonNullable);
+        let sizes = PrimitiveArray::new(buffer![2i32, 2, 2], Validity::NonNullable);
+
+        let list_array = ListViewArray::try_new(
+            elements.into_array(),
+            offsets.into_array(),
+            sizes.into_array(),
+            Validity::AllValid,
+        )
+        .unwrap();
+
+        // Convert to Arrow ListView with i32 offsets.
+        let field = Field::new("item", DataType::Int32, false);
+        let arrow_dt = DataType::ListView(field.into());
+        let arrow_array = list_array.into_array().into_arrow(&arrow_dt).unwrap();
+
+        // Verify the type is correct.
+        assert_eq!(arrow_array.data_type(), &arrow_dt);
+
+        // Downcast and verify the structure.
+        let listview = arrow_array
+            .as_any()
+            .downcast_ref::<GenericListViewArray<i32>>()
+            .unwrap();
+
+        assert_eq!(listview.len(), 3);
+
+        // Verify first list view [1, 2].
+        let first_list = listview.value(0);
+        assert_eq!(first_list.len(), 2);
+        let first_values = first_list
+            .as_any()
+            .downcast_ref::<arrow_array::Int32Array>()
+            .unwrap();
+        assert_eq!(first_values.value(0), 1);
+        assert_eq!(first_values.value(1), 2);
+
+        // Verify second list view [2, 3].
+        let second_list = listview.value(1);
+        assert_eq!(second_list.len(), 2);
+        let second_values = second_list
+            .as_any()
+            .downcast_ref::<arrow_array::Int32Array>()
+            .unwrap();
+        assert_eq!(second_values.value(0), 2);
+        assert_eq!(second_values.value(1), 3);
+    }
+
+    #[test]
+    fn test_to_arrow_listview_i64() {
+        // Create a ListViewArray with nullable elements: [[100], null, [200, 300]]
+        let elements = PrimitiveArray::new(buffer![100i64, 200, 300], Validity::NonNullable);
+        let offsets = PrimitiveArray::new(buffer![0i64, 0, 1], Validity::NonNullable);
+        let sizes = PrimitiveArray::new(buffer![1i64, 0, 2], Validity::NonNullable);
+        let validity = Validity::from_iter([true, false, true]);
+
+        let list_array = ListViewArray::try_new(
+            elements.into_array(),
+            offsets.into_array(),
+            sizes.into_array(),
+            validity,
+        )
+        .unwrap();
+
+        // Convert to Arrow LargeListView with i64 offsets.
+        let field = Field::new("item", DataType::Int64, false);
+        let arrow_dt = DataType::LargeListView(field.into());
+        let arrow_array = list_array.into_array().into_arrow(&arrow_dt).unwrap();
+
+        // Verify the type is correct.
+        assert_eq!(arrow_array.data_type(), &arrow_dt);
+
+        // Downcast and verify the structure.
+        let listview = arrow_array
+            .as_any()
+            .downcast_ref::<GenericListViewArray<i64>>()
+            .unwrap();
+
+        assert_eq!(listview.len(), 3);
+        assert!(!listview.is_null(0));
+        assert!(listview.is_null(1));
+        assert!(!listview.is_null(2));
+
+        // Verify the third list [200, 300].
+        let third_list = listview.value(2);
+        assert_eq!(third_list.len(), 2);
+        let third_values = third_list
+            .as_any()
+            .downcast_ref::<arrow_array::Int64Array>()
+            .unwrap();
+        assert_eq!(third_values.value(0), 200);
+        assert_eq!(third_values.value(1), 300);
     }
 }

--- a/vortex-array/src/arrow/compute/to_arrow/canonical.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/canonical.rs
@@ -178,17 +178,17 @@ impl Kernel for ToArrowCanonical {
             (Canonical::Struct(array), DataType::Struct(fields)) => {
                 to_arrow_struct(array, fields.as_ref(), to_preferred)
             }
-            (Canonical::List(array), DataType::ListView(field)) => {
-                to_arrow_listview::<i32>(array, arrow_type_opt.map(|_| field))
+            (Canonical::List(list_view), DataType::ListView(field)) => {
+                to_arrow_listview::<i32>(list_view, arrow_type_opt.map(|_| field))
             }
-            (Canonical::List(array), DataType::LargeListView(field)) => {
-                to_arrow_listview::<i64>(array, arrow_type_opt.map(|_| field))
+            (Canonical::List(list_view), DataType::LargeListView(field)) => {
+                to_arrow_listview::<i64>(list_view, arrow_type_opt.map(|_| field))
             }
-            (Canonical::List(array), DataType::List(field)) => {
-                to_arrow_list::<i32>(array, arrow_type_opt.map(|_| field))
+            (Canonical::List(list_view), DataType::List(field)) => {
+                to_arrow_list::<i32>(list_view, arrow_type_opt.map(|_| field))
             }
-            (Canonical::List(array), DataType::LargeList(field)) => {
-                to_arrow_list::<i64>(array, arrow_type_opt.map(|_| field))
+            (Canonical::List(list_view), DataType::LargeList(field)) => {
+                to_arrow_list::<i64>(list_view, arrow_type_opt.map(|_| field))
             }
             (Canonical::FixedSizeList(array), DataType::FixedSizeList(field, list_size)) => {
                 to_arrow_fixed_size_list(array, arrow_type_opt.map(|_| field), *list_size)
@@ -499,26 +499,33 @@ fn to_arrow_list<O: IntegerPType + OffsetSizeTrait>(
         array.len(),
     );
 
+    // TODO(connor)[ListView]: We can potentially make a generic version of `list_from_list_view`
+    // over the offsets so we don't have to rewrite this.
+
     list_builder.extend_from_array(&array.to_array());
     let list_array = list_builder.finish_into_list();
 
     // Now that we have a normal `ListArray`, we can convert all the child arrays.
 
     // Convert the child `elements` array to Arrow.
-    let (elements, element_field) = if let Some(element_field) = element_field {
-        let elements = list_array
-            .elements()
-            .clone()
-            .into_arrow(element_field.data_type())?;
-        let element_field = element_field.clone();
-        (elements, element_field)
-    } else {
-        let elements = list_array.elements().clone().into_arrow_preferred()?;
-        let element_field = Arc::new(Field::new_list_field(
-            elements.data_type().clone(),
-            list_array.elements().dtype().is_nullable(),
-        ));
-        (elements, element_field)
+    let (elements, element_field) = {
+        if let Some(element_field) = element_field {
+            // Convert elements to the specific Arrow type the caller wants.
+            let elements = list_array
+                .elements()
+                .clone()
+                .into_arrow(element_field.data_type())?;
+            let element_field = element_field.clone();
+            (elements, element_field)
+        } else {
+            // Otherwise, convert into whatever Arrow prefers.
+            let elements = list_array.elements().clone().into_arrow_preferred()?;
+            let element_field = Arc::new(Field::new_list_field(
+                elements.data_type().clone(),
+                list_array.elements().dtype().is_nullable(),
+            ));
+            (elements, element_field)
+        }
     };
 
     // Convert the child `offsets` and `validity` array to Arrow.
@@ -557,18 +564,22 @@ fn to_arrow_listview<O: IntegerPType + OffsetSizeTrait>(
     let nulls = array.validity_mask().to_null_buffer();
 
     // Convert the child `elements` array to Arrow.
-    let (elements, element_field) = if let Some(element) = element {
-        (
-            array.elements().clone().into_arrow(element.data_type())?,
-            element.clone(),
-        )
-    } else {
-        let elements = array.elements().clone().into_arrow_preferred()?;
-        let element_field = Arc::new(Field::new_list_field(
-            elements.data_type().clone(),
-            array.elements().dtype().is_nullable(),
-        ));
-        (elements, element_field)
+    let (elements, element_field) = {
+        if let Some(element) = element {
+            // Convert elements to the specific Arrow type the caller wants.
+            (
+                array.elements().clone().into_arrow(element.data_type())?,
+                element.clone(),
+            )
+        } else {
+            // Otherwise, convert into whatever Arrow prefers.
+            let elements = array.elements().clone().into_arrow_preferred()?;
+            let element_field = Arc::new(Field::new_list_field(
+                elements.data_type().clone(),
+                array.elements().dtype().is_nullable(),
+            ));
+            (elements, element_field)
+        }
     };
 
     Ok(Arc::new(GenericListViewArray::new(

--- a/vortex-array/src/arrow/compute/to_arrow/list.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/list.rs
@@ -22,7 +22,8 @@ impl ToArrowKernel for ListVTable {
     ) -> VortexResult<Option<ArrowArrayRef>> {
         match arrow_type {
             None => {
-                // Default to a `ListArray` with `i32` offsets when no type is specified.
+                // Default to a `ListArray` with `i32` offsets (preferred) when no `arrow_type` is
+                // specified.
                 list_array_to_arrow_list::<i32>(array, None)
             }
             Some(DataType::List(field)) => list_array_to_arrow_list::<i32>(array, Some(field)),
@@ -33,7 +34,7 @@ impl ToArrowKernel for ListVTable {
                 Ok(list_view.into_array().into_arrow(dt)?)
             }
             _ => vortex_bail!(
-                "Cannot convert ListArray to non-list Arrow type: {:?}",
+                "Cannot convert `ListArray` to non-list Arrow type: {:?}",
                 arrow_type
             ),
         }
@@ -59,18 +60,22 @@ fn list_array_to_arrow_list<O: IntegerPType + OffsetSizeTrait>(
     let nulls = array.validity_mask().to_null_buffer();
 
     // Convert the child `elements` array to Arrow.
-    let (elements, element_field) = if let Some(element) = element {
-        (
-            array.elements().clone().into_arrow(element.data_type())?,
-            element.clone(),
-        )
-    } else {
-        let elements = array.elements().clone().into_arrow_preferred()?;
-        let element_field = Arc::new(Field::new_list_field(
-            elements.data_type().clone(),
-            array.elements().dtype().is_nullable(),
-        ));
-        (elements, element_field)
+    let (elements, element_field) = {
+        if let Some(element) = element {
+            // Convert elements to the specific Arrow type the caller wants.
+            (
+                array.elements().clone().into_arrow(element.data_type())?,
+                element.clone(),
+            )
+        } else {
+            // Otherwise, convert into whatever Arrow prefers.
+            let elements = array.elements().clone().into_arrow_preferred()?;
+            let element_field = Arc::new(Field::new_list_field(
+                elements.data_type().clone(),
+                array.elements().dtype().is_nullable(),
+            ));
+            (elements, element_field)
+        }
     };
 
     Ok(Arc::new(GenericListArray::new(

--- a/vortex-array/src/arrow/compute/to_arrow/list.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/list.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::sync::Arc;
+
+use arrow_array::{ArrayRef as ArrowArrayRef, GenericListArray, OffsetSizeTrait};
+use arrow_schema::{DataType, Field, FieldRef};
+use vortex_dtype::{DType, IntegerPType};
+use vortex_error::{VortexResult, vortex_bail};
+
+use crate::arrays::{ListArray, ListVTable, list_view_from_list};
+use crate::arrow::IntoArrowArray;
+use crate::arrow::compute::{ToArrowKernel, ToArrowKernelAdapter};
+use crate::compute::cast;
+use crate::{IntoArray, ToCanonical, register_kernel};
+
+impl ToArrowKernel for ListVTable {
+    fn to_arrow(
+        &self,
+        array: &ListArray,
+        arrow_type: Option<&DataType>,
+    ) -> VortexResult<Option<ArrowArrayRef>> {
+        match arrow_type {
+            None => {
+                // Default to a `ListArray` with `i32` offsets when no type is specified.
+                list_array_to_arrow_list::<i32>(array, None)
+            }
+            Some(DataType::List(field)) => list_array_to_arrow_list::<i32>(array, Some(field)),
+            Some(DataType::LargeList(field)) => list_array_to_arrow_list::<i64>(array, Some(field)),
+            Some(dt @ DataType::ListView(_)) | Some(dt @ DataType::LargeListView(_)) => {
+                // Convert `ListArray` to `ListViewArray`, then use the canonical conversion.
+                let list_view = list_view_from_list(array.clone());
+                Ok(list_view.into_array().into_arrow(dt)?)
+            }
+            _ => vortex_bail!(
+                "Cannot convert ListArray to non-list Arrow type: {:?}",
+                arrow_type
+            ),
+        }
+        .map(Some)
+    }
+}
+
+register_kernel!(ToArrowKernelAdapter(ListVTable).lift());
+
+/// Converts a Vortex [`ListArray`] directly into an arrow [`GenericListArray`].
+fn list_array_to_arrow_list<O: IntegerPType + OffsetSizeTrait>(
+    array: &ListArray,
+    element: Option<&FieldRef>,
+) -> VortexResult<ArrowArrayRef> {
+    // First we cast the offsets and sizes into the specified width (determined by `O::PTYPE`).
+    let offsets_dtype = DType::Primitive(O::PTYPE, array.dtype().nullability());
+    let offsets = cast(array.offsets(), &offsets_dtype)
+        .map_err(|err| err.with_context(format!("Failed to cast offsets to {offsets_dtype}")))?
+        .to_primitive();
+
+    // Convert `offsets` and `validity` to Arrow buffers.
+    let arrow_offsets = offsets.buffer::<O>().into_arrow_offset_buffer();
+    let nulls = array.validity_mask().to_null_buffer();
+
+    // Convert the child `elements` array to Arrow.
+    let (elements, element_field) = if let Some(element) = element {
+        (
+            array.elements().clone().into_arrow(element.data_type())?,
+            element.clone(),
+        )
+    } else {
+        let elements = array.elements().clone().into_arrow_preferred()?;
+        let element_field = Arc::new(Field::new_list_field(
+            elements.data_type().clone(),
+            array.elements().dtype().is_nullable(),
+        ));
+        (elements, element_field)
+    };
+
+    Ok(Arc::new(GenericListArray::new(
+        element_field,
+        arrow_offsets,
+        elements,
+        nulls,
+    )))
+}

--- a/vortex-array/src/arrow/compute/to_arrow/mod.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 mod canonical;
+mod list;
 mod temporal;
 mod varbin;
 

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -14,7 +14,7 @@ use arrow_array::types::{
 use arrow_array::{
     Array as ArrowArray, ArrowPrimitiveType, BooleanArray as ArrowBooleanArray,
     FixedSizeListArray as ArrowFixedSizeListArray, GenericByteArray, GenericByteViewArray,
-    GenericListArray, NullArray as ArrowNullArray, OffsetSizeTrait,
+    GenericListArray, GenericListViewArray, NullArray as ArrowNullArray, OffsetSizeTrait,
     PrimitiveArray as ArrowPrimitiveArray, RecordBatch, StructArray as ArrowStructArray,
     make_array,
 };
@@ -29,8 +29,8 @@ use vortex_error::{VortexExpect as _, vortex_panic};
 use vortex_scalar::i256;
 
 use crate::arrays::{
-    BoolArray, DecimalArray, FixedSizeListArray, ListArray, NullArray, PrimitiveArray, StructArray,
-    TemporalArray, VarBinArray, VarBinViewArray,
+    BoolArray, DecimalArray, FixedSizeListArray, ListArray, ListViewArray, NullArray,
+    PrimitiveArray, StructArray, TemporalArray, VarBinArray, VarBinViewArray,
 };
 use crate::arrow::FromArrowArray;
 use crate::validity::Validity;
@@ -333,20 +333,44 @@ impl FromArrowArray<&ArrowStructArray> for ArrayRef {
 
 impl<O: IntegerPType + OffsetSizeTrait> FromArrowArray<&GenericListArray<O>> for ArrayRef {
     fn from_arrow(value: &GenericListArray<O>, nullable: bool) -> Self {
-        // Extract the validity of the underlying element array
-        let elem_nullable = match value.data_type() {
+        // Extract the validity of the underlying element array.
+        let elements_are_nullable = match value.data_type() {
             DataType::List(field) => field.is_nullable(),
             DataType::LargeList(field) => field.is_nullable(),
             dt => vortex_panic!("Invalid data type for ListArray: {dt}"),
         };
-        ListArray::try_new(
-            Self::from_arrow(value.values().as_ref(), elem_nullable),
-            // offsets are always non-nullable
-            value.offsets().clone().into_array(),
-            nulls(value.nulls(), nullable),
-        )
-        .vortex_expect("Failed to convert Arrow ListArray to Vortex ListArray")
-        .into_array()
+
+        let elements = Self::from_arrow(value.values().as_ref(), elements_are_nullable);
+
+        // `offsets` are always non-nullable.
+        let offsets = value.offsets().clone().into_array();
+        let nulls = nulls(value.nulls(), nullable);
+
+        ListArray::try_new(elements, offsets, nulls)
+            .vortex_expect("Failed to convert Arrow ListArray to Vortex ListArray")
+            .into_array()
+    }
+}
+
+impl<O: OffsetSizeTrait + NativePType> FromArrowArray<&GenericListViewArray<O>> for ArrayRef {
+    fn from_arrow(array: &GenericListViewArray<O>, nullable: bool) -> Self {
+        // Extract the validity of the underlying element array.
+        let elements_are_nullable = match array.data_type() {
+            DataType::ListView(field) => field.is_nullable(),
+            DataType::LargeListView(field) => field.is_nullable(),
+            dt => vortex_panic!("Invalid data type for ListViewArray: {dt}"),
+        };
+
+        let elements = Self::from_arrow(array.values().as_ref(), elements_are_nullable);
+
+        // `offsets` and `sizes` are always non-nullable.
+        let offsets = array.offsets().clone().into_array();
+        let sizes = array.sizes().clone().into_array();
+        let nulls = nulls(array.nulls(), nullable);
+
+        ListViewArray::try_new(elements, offsets, sizes, nulls)
+            .vortex_expect("Failed to convert Arrow ListViewArray to Vortex ListViewArray")
+            .into_array()
     }
 }
 
@@ -415,6 +439,8 @@ impl FromArrowArray<&dyn ArrowArray> for ArrayRef {
             DataType::Struct(_) => Self::from_arrow(array.as_struct(), nullable),
             DataType::List(_) => Self::from_arrow(array.as_list::<i32>(), nullable),
             DataType::LargeList(_) => Self::from_arrow(array.as_list::<i64>(), nullable),
+            DataType::ListView(_) => Self::from_arrow(array.as_list_view::<i32>(), nullable),
+            DataType::LargeListView(_) => Self::from_arrow(array.as_list_view::<i64>(), nullable),
             DataType::FixedSizeList(..) => Self::from_arrow(array.as_fixed_size_list(), nullable),
             DataType::Null => Self::from_arrow(as_null_array(array), nullable),
             DataType::Timestamp(u, _) => match u {
@@ -490,8 +516,9 @@ mod tests {
     };
     use arrow_array::types::{ArrowPrimitiveType, Float16Type};
     use arrow_array::{
-        Array as ArrowArray, BinaryArray, BooleanArray, Date32Array, Date64Array, Float32Array,
-        Float64Array, Int8Array, Int16Array, Int32Array, Int64Array, LargeBinaryArray,
+        Array as ArrowArray, BinaryArray, BooleanArray, Date32Array, Date64Array,
+        FixedSizeListArray as ArrowFixedSizeListArray, Float32Array, Float64Array,
+        GenericListViewArray, Int8Array, Int16Array, Int32Array, Int64Array, LargeBinaryArray,
         LargeStringArray, NullArray, RecordBatch, StringArray, StructArray, Time32MillisecondArray,
         Time32SecondArray, Time64MicrosecondArray, Time64NanosecondArray,
         TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
@@ -503,8 +530,8 @@ mod tests {
     use vortex_dtype::{DType, ExtDType, Nullability, PType};
 
     use crate::arrays::{
-        DecimalVTable, ListVTable, PrimitiveVTable, StructVTable, TemporalArray, VarBinVTable,
-        VarBinViewVTable,
+        DecimalVTable, FixedSizeListVTable, ListVTable, ListViewVTable, PrimitiveVTable,
+        StructVTable, TemporalArray, VarBinVTable, VarBinViewVTable,
     };
     use crate::arrow::FromArrowArray as _;
     use crate::{ArrayRef, IntoArray};
@@ -1297,6 +1324,161 @@ mod tests {
             .as_::<PrimitiveVTable>();
         assert_eq!(offsets_array_non_null.len(), 3); // n+1 offsets for n lists
         assert_eq!(offsets_array_non_null.ptype(), PType::I64); // Large lists use I64 offsets
+    }
+
+    #[test]
+    fn test_fixed_size_list_array_conversion() {
+        // Create elements for the fixed-size lists
+        let values = Int32Array::from(vec![
+            Some(1),
+            Some(2),
+            Some(3), // First list
+            Some(4),
+            None,
+            Some(6), // Second list (with null element)
+            Some(7),
+            Some(8),
+            Some(9), // Third list
+            Some(10),
+            Some(11),
+            Some(12), // Fourth list
+        ]);
+
+        // Create a FixedSizeListArray with list_size=3
+        let field = Arc::new(Field::new("item", DataType::Int32, true));
+        let arrow_array =
+            ArrowFixedSizeListArray::try_new(field.clone(), 3, Arc::new(values), None).unwrap();
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, false);
+
+        assert_eq!(vortex_array.len(), 4);
+
+        // Verify metadata - should be FixedSizeListArray with correct list size
+        let fsl_vortex_array = vortex_array.as_::<FixedSizeListVTable>();
+        assert_eq!(fsl_vortex_array.list_size(), 3);
+        assert_eq!(fsl_vortex_array.elements().len(), 12); // 4 lists * 3 elements
+
+        // Test nullable fixed-size list
+        let values_nullable = Int32Array::from(vec![
+            Some(1),
+            Some(2),
+            Some(3), // First list
+            Some(4),
+            None,
+            Some(6), // Second list (will be null)
+            Some(7),
+            Some(8),
+            Some(9), // Third list
+        ]);
+
+        // Create nulls buffer - second list is null
+        let null_buffer =
+            arrow_buffer::NullBuffer::new(BooleanBuffer::from(vec![true, false, true]));
+
+        let arrow_array_nullable = ArrowFixedSizeListArray::try_new(
+            field,
+            3,
+            Arc::new(values_nullable),
+            Some(null_buffer),
+        )
+        .unwrap();
+        let vortex_array_nullable = ArrayRef::from_arrow(&arrow_array_nullable, true);
+
+        assert_eq!(vortex_array_nullable.len(), 3);
+
+        // Verify metadata for nullable array
+        let fsl_vortex_array_nullable = vortex_array_nullable.as_::<FixedSizeListVTable>();
+        assert_eq!(fsl_vortex_array_nullable.list_size(), 3);
+        assert_eq!(fsl_vortex_array_nullable.elements().len(), 9); // 3 lists * 3 elements
+    }
+
+    #[test]
+    fn test_list_view_array_conversion() {
+        // Create values array for the lists
+        let values = Int32Array::from(vec![
+            Some(1),
+            Some(2),
+            Some(3), // First list [1, 2, 3]
+            Some(4),
+            Some(5), // Second list [4, 5]
+            Some(6), // Third list [6]
+            Some(7),
+            Some(8),
+            Some(9),
+            Some(10), // Fourth list [7, 8, 9, 10]
+        ]);
+
+        // Create offsets and sizes for ListView
+        let offsets = ScalarBuffer::from(vec![0i32, 3, 5, 6]);
+        let sizes = ScalarBuffer::from(vec![3i32, 2, 1, 4]);
+
+        let field = Arc::new(Field::new("item", DataType::Int32, true));
+        let arrow_array = GenericListViewArray::try_new(
+            field.clone(),
+            offsets.clone(),
+            sizes.clone(),
+            Arc::new(values.clone()),
+            None,
+        )
+        .unwrap();
+
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, false);
+        assert_eq!(vortex_array.len(), 4);
+
+        // Verify metadata - should be ListViewArray with correct offsets and sizes
+        let list_view_vortex_array = vortex_array.as_::<ListViewVTable>();
+        let offsets_array = list_view_vortex_array.offsets().as_::<PrimitiveVTable>();
+        let sizes_array = list_view_vortex_array.sizes().as_::<PrimitiveVTable>();
+
+        assert_eq!(offsets_array.len(), 4);
+        assert_eq!(offsets_array.ptype(), PType::I32);
+        assert_eq!(sizes_array.len(), 4);
+        assert_eq!(sizes_array.ptype(), PType::I32);
+
+        // Test nullable ListView
+        let null_buffer =
+            arrow_buffer::NullBuffer::new(BooleanBuffer::from(vec![true, false, true, true]));
+
+        let arrow_array_nullable = GenericListViewArray::try_new(
+            field.clone(),
+            offsets,
+            sizes,
+            Arc::new(values.clone()),
+            Some(null_buffer),
+        )
+        .unwrap();
+
+        let vortex_array_nullable = ArrayRef::from_arrow(&arrow_array_nullable, true);
+        assert_eq!(vortex_array_nullable.len(), 4);
+
+        // Test LargeListView (i64 offsets and sizes)
+        let large_offsets = ScalarBuffer::from(vec![0i64, 3, 5, 6]);
+        let large_sizes = ScalarBuffer::from(vec![3i64, 2, 1, 4]);
+
+        let large_arrow_array = GenericListViewArray::try_new(
+            field,
+            large_offsets,
+            large_sizes,
+            Arc::new(values),
+            None,
+        )
+        .unwrap();
+
+        let large_vortex_array = ArrayRef::from_arrow(&large_arrow_array, false);
+        assert_eq!(large_vortex_array.len(), 4);
+
+        // Verify metadata for large ListView
+        let large_list_view_vortex_array = large_vortex_array.as_::<ListViewVTable>();
+        let large_offsets_array = large_list_view_vortex_array
+            .offsets()
+            .as_::<PrimitiveVTable>();
+        let large_sizes_array = large_list_view_vortex_array
+            .sizes()
+            .as_::<PrimitiveVTable>();
+
+        assert_eq!(large_offsets_array.len(), 4);
+        assert_eq!(large_offsets_array.ptype(), PType::I64); // Large ListView uses I64 offsets
+        assert_eq!(large_sizes_array.len(), 4);
+        assert_eq!(large_sizes_array.ptype(), PType::I64); // Large ListView uses I64 sizes
     }
 
     // Test null array conversions

--- a/vortex-array/src/arrow/mod.rs
+++ b/vortex-array/src/arrow/mod.rs
@@ -32,8 +32,8 @@ pub trait IntoArrowArray {
 }
 
 impl IntoArrowArray for crate::ArrayRef {
-    /// Convert this [`crate::ArrayRef`] into an Arrow [`crate::ArrayRef`] by using the array's preferred
-    /// Arrow [`DataType`].
+    /// Convert this [`crate::ArrayRef`] into an Arrow [`crate::ArrayRef`] by using the array's
+    /// preferred Arrow [`DataType`].
     fn into_arrow_preferred(self) -> VortexResult<ArrowArrayRef> {
         compute::to_arrow_opts(&self, &ToArrowOptions { arrow_type: None })
     }

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -5,18 +5,17 @@ use std::any::Any;
 use std::sync::Arc;
 
 use vortex_dtype::Nullability::NonNullable;
-use vortex_dtype::{DType, IntegerPType, Nullability};
+use vortex_dtype::{DType, IntegerPType, Nullability, match_each_integer_ptype};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_ensure, vortex_panic};
 use vortex_mask::Mask;
 use vortex_scalar::{ListScalar, Scalar};
 
-use crate::arrays::ListArray;
+use crate::arrays::{ListArray, list_view_from_list};
 use crate::builders::{
     ArrayBuilder, DEFAULT_BUILDER_CAPACITY, LazyNullBufferBuilder, PrimitiveBuilder,
     builder_with_capacity,
 };
 use crate::canonical::{Canonical, ToCanonical};
-use crate::compute::cast;
 use crate::{Array, ArrayRef, IntoArray};
 
 /// The builder for building a [`ListArray`], parametrized by the [`IntegerPType`] of the `offsets`
@@ -181,55 +180,62 @@ impl<O: IntegerPType> ArrayBuilder for ListBuilder<O> {
     }
 
     unsafe fn extend_from_array_unchecked(&mut self, array: &dyn Array) {
-        let list = array.to_list();
+        let list = array.to_listview();
         if list.is_empty() {
             return;
         }
 
-        let builder_len = self.elements_builder.len();
-        let builder_len_offset = match O::from_usize(builder_len) {
-            Some(v) => v,
-            None => {
-                vortex_panic!(
-                    "cannot convert length {} to type {:?}",
-                    builder_len,
-                    O::PTYPE
-                )
-            }
-        };
+        // Append validity information.
+        self.nulls.append_validity_mask(array.validity_mask());
 
-        let offsets = list.offsets();
+        // Note that `ListViewArray` has `n` offsets and sizes, not `n+1` offsets like `ListArray`.
         let elements = list.elements();
+        let offsets = list.offsets().to_primitive();
+        let sizes = list.sizes().to_primitive();
 
-        let index_dtype = self.offsets_builder.dtype();
+        fn extend_inner<O, OffsetType, SizeType>(
+            builder: &mut ListBuilder<O>,
+            elements: &ArrayRef,
+            offsets: &[OffsetType],
+            sizes: &[SizeType],
+        ) where
+            O: IntegerPType,
+            OffsetType: IntegerPType,
+            SizeType: IntegerPType,
+        {
+            // We need to append each list individually, converting from `ListViewArray` format
+            // to the `ListArray` format that `ListBuilder` expects.
+            for i in 0..offsets.len() {
+                let offset: usize = offsets[i].as_();
+                let size: usize = sizes[i].as_();
 
-        // Cast offsets to the correct type upfront.
-        let casted_offsets =
-            cast(offsets, index_dtype).vortex_expect("Offsets must be castable to index dtype");
+                if size > 0 {
+                    let list_elements = elements.slice(offset..offset + size);
+                    unsafe {
+                        builder
+                            .elements_builder
+                            .extend_from_array_unchecked(&list_elements);
+                    }
+                }
 
-        // Convert to primitive and get as slice.
-        let offsets_primitive = casted_offsets.to_primitive();
-        let offsets_slice = offsets_primitive.as_slice::<O>();
-
-        // Get the first offset (leading junk values count).
-        let n_leading_junk_values = offsets_slice[0];
-        let n_leading_junk_values_usize: usize = n_leading_junk_values.as_();
-
-        // Manually adjust offsets and append to index_builder.
-        for i in 1..offsets_slice.len() {
-            let offset = offsets_slice[i];
-            let adjusted = offset - n_leading_junk_values + builder_len_offset;
-            self.offsets_builder.append_value(adjusted);
+                // TODO(connor): We can use `UninitRange` for the `offsets_builder` here.
+                // Update the index with the new position.
+                let new_offset = O::from_usize(builder.elements_builder.len())
+                    .vortex_expect("Failed to convert offset");
+                builder.offsets_builder.append_value(new_offset);
+            }
         }
 
-        // Extract non-junk values.
-        let last_offset = offsets_slice[offsets_slice.len() - 1];
-        let last_offset_usize: usize = last_offset.as_();
-        let non_junk_values = elements.slice(n_leading_junk_values_usize..last_offset_usize);
-
-        self.nulls.append_validity_mask(array.validity_mask());
-        self.elements_builder.reserve_exact(non_junk_values.len());
-        self.elements_builder.extend_from_array(&non_junk_values);
+        match_each_integer_ptype!(offsets.ptype(), |OffsetType| {
+            match_each_integer_ptype!(sizes.ptype(), |SizeType| {
+                extend_inner(
+                    self,
+                    elements,
+                    offsets.as_slice::<OffsetType>(),
+                    sizes.as_slice::<SizeType>(),
+                )
+            })
+        })
     }
 
     fn reserve_exact(&mut self, additional: usize) {
@@ -248,7 +254,7 @@ impl<O: IntegerPType> ArrayBuilder for ListBuilder<O> {
     }
 
     fn finish_into_canonical(&mut self) -> Canonical {
-        Canonical::List(self.finish_into_list())
+        Canonical::List(list_view_from_list(self.finish_into_list()))
     }
 }
 
@@ -309,7 +315,7 @@ mod tests {
         let list = builder.finish();
         assert_eq!(list.len(), 2);
 
-        let list_array = list.to_list();
+        let list_array = list.to_listview();
 
         assert_eq!(list_array.list_elements_at(0).len(), 3);
         assert_eq!(list_array.list_elements_at(1).len(), 3);
@@ -361,7 +367,7 @@ mod tests {
         let list = builder.finish();
         assert_eq!(list.len(), 3);
 
-        let list_array = list.to_list();
+        let list_array = list.to_listview();
 
         assert_eq!(list_array.list_elements_at(0).len(), 3);
         assert_eq!(list_array.list_elements_at(1).len(), 0);
@@ -396,9 +402,9 @@ mod tests {
             Arc::new(DType::Primitive(I32, NonNullable)),
         )
         .unwrap()
-        .to_list();
+        .to_listview();
 
-        let actual = builder.finish_into_canonical().into_list();
+        let actual = builder.finish_into_canonical().into_listview();
 
         assert_eq!(
             actual.elements().to_primitive().as_slice::<i32>(),
@@ -450,7 +456,7 @@ mod tests {
             DType::List(Arc::new(DType::Primitive(I32, NonNullable)), NonNullable),
         );
 
-        let canon_values = chunked_list.unwrap().to_list();
+        let canon_values = chunked_list.unwrap().to_listview();
 
         assert_eq!(
             one_trailing_unused_element.scalar_at(0),

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -61,7 +61,7 @@ impl<O: IntegerPType> ListBuilder<O> {
         capacity: usize,
     ) -> Self {
         let elements_builder = builder_with_capacity(value_dtype.as_ref(), elements_capacity);
-        let mut offsets_builder = PrimitiveBuilder::<O>::with_capacity(NonNullable, capacity);
+        let mut offsets_builder = PrimitiveBuilder::<O>::with_capacity(NonNullable, capacity + 1);
 
         // The first offset is always 0 and represents an empty list.
         offsets_builder.append_zero();
@@ -106,7 +106,7 @@ impl<O: IntegerPType> ListBuilder<O> {
         assert_eq!(
             self.offsets_builder.len(),
             self.nulls.len() + 1,
-            "Indices length must be one more than nulls length."
+            "offsets length must be one more than nulls length."
         );
 
         ListArray::try_new(
@@ -195,35 +195,41 @@ impl<O: IntegerPType> ArrayBuilder for ListBuilder<O> {
 
         fn extend_inner<O, OffsetType, SizeType>(
             builder: &mut ListBuilder<O>,
-            elements: &ArrayRef,
-            offsets: &[OffsetType],
-            sizes: &[SizeType],
+            new_elements: &ArrayRef,
+            new_offsets: &[OffsetType],
+            new_sizes: &[SizeType],
         ) where
             O: IntegerPType,
             OffsetType: IntegerPType,
             SizeType: IntegerPType,
         {
-            // We need to append each list individually, converting from `ListViewArray` format
-            // to the `ListArray` format that `ListBuilder` expects.
-            for i in 0..offsets.len() {
-                let offset: usize = offsets[i].as_();
-                let size: usize = sizes[i].as_();
+            let num_lists = new_offsets.len();
+            debug_assert_eq!(num_lists, new_sizes.len());
+
+            let mut curr_offset = builder.elements_builder.len();
+            let mut offsets_range = builder.offsets_builder.uninit_range(num_lists);
+
+            // We need to append each list individually, converting from `ListViewArray` format to
+            // the `ListArray` format that `ListBuilder` expects.
+            for i in 0..new_offsets.len() {
+                let offset: usize = new_offsets[i].as_();
+                let size: usize = new_sizes[i].as_();
 
                 if size > 0 {
-                    let list_elements = elements.slice(offset..offset + size);
-                    unsafe {
-                        builder
-                            .elements_builder
-                            .extend_from_array_unchecked(&list_elements);
-                    }
+                    let list_elements = new_elements.slice(offset..offset + size);
+                    builder.elements_builder.extend_from_array(&list_elements);
+                    curr_offset += size;
                 }
 
-                // TODO(connor): We can use `UninitRange` for the `offsets_builder` here.
-                // Update the index with the new position.
-                let new_offset = O::from_usize(builder.elements_builder.len())
-                    .vortex_expect("Failed to convert offset");
-                builder.offsets_builder.append_value(new_offset);
+                let new_offset =
+                    O::from_usize(curr_offset).vortex_expect("Failed to convert offset");
+
+                offsets_range.set_value(i, new_offset);
             }
+
+            // SAFETY: We have initialized all `num_lists` values, and since the `offsets` array is
+            // non-nullable, we are done.
+            unsafe { offsets_range.finish() };
         }
 
         match_each_integer_ptype!(offsets.ptype(), |OffsetType| {
@@ -380,8 +386,9 @@ mod tests {
             Arc::new(I32.into()),
         )
         .unwrap();
+        assert_eq!(list.len(), 3);
 
-        let mut builder = ListBuilder::<O>::with_capacity(Arc::new(I32.into()), Nullable, 12, 6);
+        let mut builder = ListBuilder::<O>::with_capacity(Arc::new(I32.into()), Nullable, 18, 9);
 
         builder.extend_from_array(&list);
         builder.extend_from_array(&list);

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -17,7 +17,7 @@ use vortex_scalar::{ListScalar, Scalar};
 
 use super::lazy_null_builder::LazyNullBufferBuilder;
 use crate::array::{Array, ArrayRef, IntoArray};
-use crate::arrays::{ListViewArray, list_view_from_list};
+use crate::arrays::ListViewArray;
 use crate::builders::{
     ArrayBuilder, DEFAULT_BUILDER_CAPACITY, PrimitiveBuilder, builder_with_capacity,
 };
@@ -104,7 +104,6 @@ impl<O: IntegerPType, S: IntegerPType> ListViewBuilder<O, S> {
         }
     }
 
-    // TODO(connor): This should probably take a `&ListScalar` instead.
     /// Append a list of values to the builder.
     ///
     /// This method extends the value builder with the provided values and records
@@ -233,13 +232,13 @@ impl<O: IntegerPType, S: IntegerPType> ArrayBuilder for ListViewBuilder<O, S> {
     }
 
     unsafe fn extend_from_array_unchecked(&mut self, array: &dyn Array) {
-        let list_array = array.to_list();
-        if list_array.is_empty() {
+        let listview_array = array.to_listview();
+        if listview_array.is_empty() {
             return;
         }
 
-        // TODO(connor)[ListView]: fix this after list view is canonical
-        let listview_array = list_view_from_list(list_array);
+        // TODO(connor)[ListView]: We could potentially concatenate the new elements on top of the
+        // existing elements and recalculate offsets (and then use `UninitRange`).
 
         // We assume the worst case scenario, where the list view array is stored completely out of
         // order, with many out-of-order offsets, and lots of garbage data. Thus, we simply iterate
@@ -269,8 +268,7 @@ impl<O: IntegerPType, S: IntegerPType> ArrayBuilder for ListViewBuilder<O, S> {
     }
 
     fn finish_into_canonical(&mut self) -> Canonical {
-        // TODO(connor)[ListView]: fix this after list view is canonical
-        unimplemented!("TODO(connor)[ListView]: fix this after list view is canonical")
+        Canonical::List(self.finish_into_listview())
     }
 }
 

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -238,7 +238,9 @@ impl<O: IntegerPType, S: IntegerPType> ArrayBuilder for ListViewBuilder<O, S> {
         }
 
         // TODO(connor)[ListView]: We could potentially concatenate the new elements on top of the
-        // existing elements and recalculate offsets (and then use `UninitRange`).
+        // existing elements and recalculate offsets (and then use `UninitRange`). However, that
+        // would mean we lose the guarantee that the output `ListViewArray` does not look like a
+        // `ListArray` (because the incoming array could have garbage data).
 
         // We assume the worst case scenario, where the list view array is stored completely out of
         // order, with many out-of-order offsets, and lots of garbage data. Thus, we simply iterate

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -264,10 +264,10 @@ pub fn builder_with_capacity(dtype: &DType, capacity: usize) -> Box<dyn ArrayBui
             *n,
             capacity,
         )),
-        DType::List(dtype, n) => Box::new(ListBuilder::<u64>::with_capacity(
+        DType::List(dtype, n) => Box::new(ListViewBuilder::<u64, u64>::with_capacity(
             dtype.clone(),
             *n,
-            2 * capacity,
+            2 * capacity, // Arbitrarily choose 2 times the `offsets` capacity here.
             capacity,
         )),
         DType::FixedSizeList(elem_dtype, list_size, null) => Box::new(

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -258,7 +258,7 @@ impl<T> UninitRange<'_, T> {
     /// builder).
     ///
     /// Note that this will have no effect if the builder is non-nullable.
-    pub fn set_bit(&mut self, index: usize, v: bool) {
+    pub fn set_validity_bit(&mut self, index: usize, v: bool) {
         assert!(index < self.len, "set_bit index out of bounds");
         // Note that this won't panic because we can only create an `UninitRange` within the
         // capacity of the builder (it will not automatically resize).
@@ -319,11 +319,13 @@ impl<T> UninitRange<'_, T> {
     /// # Safety
     ///
     /// The caller must ensure that they have safely initialized all `len` values via
-    /// [`UninitRange::copy_from_slice`] as well as correctly set all of the null bits via
-    /// [`set_bit`] or [`append_mask`] if the builder is nullable.
+    /// [`copy_from_slice()`] or [`set_value()`], as well as correctly set all of the null bits via
+    /// [`set_validity_bit()`] or [`append_mask()`] if the builder is nullable.
     ///
-    /// [`set_bit`]: UninitRange::set_bit
-    /// [`append_mask`]: UninitRange::append_mask
+    /// [`copy_from_slice()`]: UninitRange::copy_from_slice
+    /// [`set_value()`]: UninitRange::set_value
+    /// [`set_validity_bit()`]: UninitRange::set_validity_bit
+    /// [`append_mask()`]: UninitRange::append_mask
     pub unsafe fn finish(self) {
         // SAFETY: constructor enforces that current length + len does not exceed the capacity of the array.
         let new_len = self.builder.values.len() + self.len;
@@ -473,8 +475,8 @@ mod tests {
         }
 
         // Now we can use set_bit to modify individual bits with relative indexing.
-        range.set_bit(0, true); // Change first bit to valid
-        range.set_bit(2, true); // Change third bit to valid
+        range.set_validity_bit(0, true); // Change first bit to valid
+        range.set_validity_bit(2, true); // Change third bit to valid
         // Leave middle bit as false (null)
 
         // Initialize the values.

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -7,8 +7,8 @@ use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_panic};
 
 use crate::arrays::{
-    BoolArray, DecimalArray, ExtensionArray, FixedSizeListArray, ListArray, NullArray,
-    PrimitiveArray, StructArray, VarBinViewArray,
+    BoolArray, DecimalArray, ExtensionArray, FixedSizeListArray, ListViewArray,
+    ListViewRebuildMode, NullArray, PrimitiveArray, StructArray, VarBinViewArray,
 };
 use crate::builders::builder_with_capacity;
 use crate::{Array, ArrayRef, IntoArray};
@@ -41,7 +41,7 @@ use crate::{Array, ArrayRef, IntoArray};
 /// * `PrimitiveArray`: [`arrow_array::PrimitiveArray`]
 /// * `DecimalArray`: [`arrow_array::Decimal128Array`] and [`arrow_array::Decimal256Array`]
 /// * `VarBinViewArray`: [`arrow_array::GenericByteViewArray`]
-/// * `ListArray`: [`arrow_array::ListArray`]
+/// * `ListViewArray`: [`arrow_array::ListViewArray`]
 /// * `FixedSizeListArray`: [`arrow_array::FixedSizeListArray`]
 /// * `StructArray`: [`arrow_array::StructArray`]
 ///
@@ -78,14 +78,14 @@ pub enum Canonical {
     Primitive(PrimitiveArray),
     Decimal(DecimalArray),
     VarBinView(VarBinViewArray),
-    // TODO(connor)[ListView]: Convert the canonical encoding of `List` to `ListViewArray`.
-    List(ListArray),
+    List(ListViewArray),
     FixedSizeList(FixedSizeListArray),
     Struct(StructArray),
     Extension(ExtensionArray),
 }
 
 impl Canonical {
+    // TODO(connor): This can probably be specialized for each of the canonical arrays.
     /// Create an empty canonical array of the given dtype.
     pub fn empty(dtype: &DType) -> Canonical {
         builder_with_capacity(dtype, 0).finish_into_canonical()
@@ -103,7 +103,9 @@ impl Canonical {
     pub fn compact(&self) -> VortexResult<Canonical> {
         match self {
             Canonical::VarBinView(array) => Ok(Canonical::VarBinView(array.compact_buffers()?)),
-            Canonical::List(array) => Ok(Canonical::List(array.reset_offsets(true)?)),
+            Canonical::List(array) => Ok(Canonical::List(
+                array.rebuild(ListViewRebuildMode::MakeZeroCopyToList),
+            )),
             _ => Ok(self.clone()),
         }
     }
@@ -191,7 +193,7 @@ impl Canonical {
         }
     }
 
-    pub fn as_list(&self) -> &ListArray {
+    pub fn as_listview(&self) -> &ListViewArray {
         if let Canonical::List(a) = self {
             a
         } else {
@@ -199,7 +201,7 @@ impl Canonical {
         }
     }
 
-    pub fn into_list(self) -> ListArray {
+    pub fn into_listview(self) -> ListViewArray {
         if let Canonical::List(a) = self {
             a
         } else {
@@ -294,34 +296,35 @@ impl IntoArray for Canonical {
 ///
 /// This trait has a blanket implementation for all types implementing [ToCanonical].
 pub trait ToCanonical {
-    /// Canonicalize into a [`NullArray`] if the target is [`Null`][DType::Null] typed.
+    /// Canonicalize into a [`NullArray`] if the target is [`Null`](DType::Null) typed.
     fn to_null(&self) -> NullArray;
 
-    /// Canonicalize into a [`BoolArray`] if the target is [`Bool`][DType::Bool] typed.
+    /// Canonicalize into a [`BoolArray`] if the target is [`Bool`](DType::Bool) typed.
     fn to_bool(&self) -> BoolArray;
 
-    /// Canonicalize into a [`PrimitiveArray`] if the target is [`Primitive`][DType::Primitive]
+    /// Canonicalize into a [`PrimitiveArray`] if the target is [`Primitive`](DType::Primitive)
     /// typed.
     fn to_primitive(&self) -> PrimitiveArray;
 
-    /// Canonicalize into a [`DecimalArray`] if the target is [`Decimal`][DType::Decimal]
+    /// Canonicalize into a [`DecimalArray`] if the target is [`Decimal`](DType::Decimal)
     /// typed.
     fn to_decimal(&self) -> DecimalArray;
 
-    /// Canonicalize into a [`StructArray`] if the target is [`Struct`][DType::Struct] typed.
+    /// Canonicalize into a [`StructArray`] if the target is [`Struct`](DType::Struct) typed.
     fn to_struct(&self) -> StructArray;
 
-    /// Canonicalize into a [`ListArray`] if the target is [`List`][DType::List] typed.
-    fn to_list(&self) -> ListArray;
+    /// Canonicalize into a [`ListViewArray`] if the target is [`List`](DType::List) typed.
+    fn to_listview(&self) -> ListViewArray;
 
-    /// Canonicalize into a [`ListArray`] if the target is [`List`][DType::List] typed.
+    /// Canonicalize into a [`FixedSizeListArray`] if the target is [`List`](DType::FixedSizeList)
+    /// typed.
     fn to_fixed_size_list(&self) -> FixedSizeListArray;
 
-    /// Canonicalize into a [`VarBinViewArray`] if the target is [`Utf8`][DType::Utf8]
-    /// or [`Binary`][DType::Binary] typed.
+    /// Canonicalize into a [`VarBinViewArray`] if the target is [`Utf8`](DType::Utf8)
+    /// or [`Binary`](DType::Binary) typed.
     fn to_varbinview(&self) -> VarBinViewArray;
 
-    /// Canonicalize into an [`ExtensionArray`] if the array is [`Extension`][DType::Extension]
+    /// Canonicalize into an [`ExtensionArray`] if the array is [`Extension`](DType::Extension)
     /// typed.
     fn to_extension(&self) -> ExtensionArray;
 }
@@ -348,8 +351,8 @@ impl<A: Array + ?Sized> ToCanonical for A {
         self.to_canonical().into_struct()
     }
 
-    fn to_list(&self) -> ListArray {
-        self.to_canonical().into_list()
+    fn to_listview(&self) -> ListViewArray {
+        self.to_canonical().into_listview()
     }
 
     fn to_fixed_size_list(&self) -> FixedSizeListArray {

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -13,14 +13,18 @@ use crate::arrays::{
 use crate::builders::builder_with_capacity;
 use crate::{Array, ArrayRef, IntoArray};
 
-/// An enum capturing the default uncompressed encodings for each [Vortex type][DType].
+/// An enum capturing the default uncompressed encodings for each [Vortex type](DType).
 ///
-/// Any array can be decoded into canonical form via the [`to_canonical`][Array::to_canonical]
+/// Any array can be decoded into canonical form via the [`to_canonical`](Array::to_canonical)
 /// trait method. This is the simplest encoding for a type, and will not be compressed but may
 /// contain compressed child arrays.
 ///
 /// Canonical form is useful for doing type-specific compute where you need to know that all
 /// elements are laid out decompressed and contiguous in memory.
+///
+/// Each `Canonical` variant has a corresponding [`DType`] variant, with the notable exception of
+/// [`Canonical::VarBinView`], which is the canonical encoding for both [`DType::Utf8`] and
+/// [`DType::Binary`].
 ///
 /// # Laziness
 ///

--- a/vortex-array/src/compute/compare.rs
+++ b/vortex-array/src/compute/compare.rs
@@ -451,6 +451,7 @@ mod tests {
         assert_eq!(res.to_bool().boolean_buffer().count_set_bits(), left.len());
     }
 
+    #[ignore = "Arrow's ListView cannot be compared"]
     #[test]
     fn test_list_array_comparison() {
         // Create two simple list arrays with integers
@@ -494,6 +495,7 @@ mod tests {
         assert!(bool_result.boolean_buffer().value(2)); // [5,6] < [7,8] = true
     }
 
+    #[ignore = "Arrow's ListView cannot be compared"]
     #[test]
     fn test_list_array_constant_comparison() {
         use std::sync::Arc;

--- a/vortex-array/src/compute/list_contains.rs
+++ b/vortex-array/src/compute/list_contains.rs
@@ -3,20 +3,22 @@
 
 //! List-related compute operations.
 
+// TODO(connor)[ListView]: Should this compute function be moved up the `arrays/listview`?
+// TODO(connor)[ListView]: Clean up this file.
+
 use std::sync::LazyLock;
 
 use arcref::ArcRef;
 use arrow_buffer::BooleanBuffer;
 use arrow_buffer::bit_iterator::BitIndexIterator;
-use vortex_buffer::Buffer;
+use num_traits::Zero;
 use vortex_dtype::{DType, IntegerPType, Nullability, match_each_integer_ptype};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail};
 use vortex_scalar::{ListScalar, Scalar};
 
-use crate::arrays::{BoolArray, ConstantArray, ListArray};
+use crate::arrays::{BoolArray, ConstantArray, ListViewArray, PrimitiveArray};
 use crate::compute::{
-    BinaryArgs, ComputeFn, ComputeFnVTable, InvocationArgs, Kernel, Operator, Output, compare,
-    fill_null, or,
+    self, BinaryArgs, ComputeFn, ComputeFnVTable, InvocationArgs, Kernel, Operator, Output,
 };
 use crate::validity::Validity;
 use crate::vtable::{VTable, ValidityHelper};
@@ -50,19 +52,27 @@ pub(crate) fn warm_up_vtable() -> usize {
 /// ## Example
 ///
 /// ```rust
-/// use vortex_array::{Array, IntoArray, ToCanonical};
-/// use vortex_array::arrays::{ConstantArray, ListArray, VarBinArray};
-/// use vortex_array::compute::list_contains;
-/// use vortex_array::validity::Validity;
-/// use vortex_buffer::buffer;
-/// use vortex_dtype::DType;
-/// use vortex_scalar::Scalar;
+/// # use vortex_array::{Array, IntoArray, ToCanonical};
+/// # use vortex_array::arrays::{ConstantArray, ListViewArray, VarBinArray};
+/// # use vortex_array::compute;
+/// # use vortex_array::validity::Validity;
+/// # use vortex_buffer::buffer;
+/// # use vortex_dtype::DType;
+/// # use vortex_scalar::Scalar;
+/// #
 /// let elements = VarBinArray::from_vec(
 ///         vec!["a", "a", "b", "a", "c"], DType::Utf8(false.into())).into_array();
-/// let offsets = buffer![0u32, 1, 3, 5].into_array();
-/// let list_array = ListArray::try_new(elements, offsets, Validity::NonNullable).unwrap();
+/// let offsets = buffer![0u32, 1, 3].into_array();
+/// let sizes = buffer![1u32, 2, 2].into_array();
+/// let list_array =
+///     ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap();
 ///
-/// let matches = list_contains(list_array.as_ref(), ConstantArray::new(Scalar::from("b"), list_array.len()).as_ref()).unwrap();
+/// let matches = compute::list_contains(
+///     list_array.as_ref(),
+///     ConstantArray::new(Scalar::from("b"),
+///     list_array.len()).as_ref()
+/// ).unwrap();
+///
 /// let to_vec: Vec<bool> = matches.to_bool().boolean_buffer().iter().collect();
 /// assert_eq!(to_vec, vec![false, true, false]);
 /// ```
@@ -94,7 +104,7 @@ impl ComputeFnVTable for ListContains {
         };
         if !elem_dtype.as_ref().eq_ignore_nullability(value.dtype()) {
             vortex_bail!(
-                "Element type {} of ListArray does not match search value {}",
+                "Element type {} of `ListViewArray` does not match search value {}",
                 elem_dtype,
                 value.dtype(),
             );
@@ -196,8 +206,8 @@ fn constant_list_scalar_contains(
     let mut result: Option<ArrayRef> = None;
     let false_scalar = Scalar::bool(false, nullability);
     for element in elements {
-        let res = fill_null(
-            &compare(
+        let res = compute::fill_null(
+            &compute::compare(
                 ConstantArray::new(element, len).as_ref(),
                 values,
                 Operator::Eq,
@@ -205,7 +215,7 @@ fn constant_list_scalar_contains(
             &false_scalar,
         )?;
         if let Some(acc) = result {
-            result = Some(or(&acc, &res)?)
+            result = Some(compute::or(&acc, &res)?)
         } else {
             result = Some(res);
         }
@@ -213,6 +223,7 @@ fn constant_list_scalar_contains(
     Ok(result.unwrap_or_else(|| ConstantArray::new(false_scalar, len).to_array()))
 }
 
+/// Returns a [`BoolArray`] where each bit represents if a list contains the scalar.
 fn list_contains_scalar(
     array: &dyn Array,
     value: &Scalar,
@@ -224,9 +235,7 @@ fn list_contains_scalar(
         return Ok(ConstantArray::new(contains.scalar_at(0), array.len()).into_array());
     }
 
-    // Canonicalize to a list array.
-    // NOTE(ngates): we may wish to add elements and offsets accessors to the ListArrayTrait.
-    let list_array = array.to_list();
+    let list_array = array.to_listview();
 
     let elems = list_array.elements();
     if elems.is_empty() {
@@ -235,7 +244,7 @@ fn list_contains_scalar(
     }
 
     let rhs = ConstantArray::new(value.clone(), elems.len());
-    let matching_elements = compare(elems, rhs.as_ref(), Operator::Eq)?;
+    let matching_elements = compute::compare(elems, rhs.as_ref(), Operator::Eq)?;
     let matches = matching_elements.to_bool();
 
     // Fast path: no elements match.
@@ -267,19 +276,59 @@ fn list_contains_scalar(
         };
     }
 
-    let ends = list_array.offsets().to_primitive();
-    match_each_integer_ptype!(ends.ptype(), |T| {
-        Ok(reduce_with_ends(
-            ends.as_slice::<T>(),
-            matches.boolean_buffer(),
-            list_array.validity().clone().union_nullability(nullability),
-        ))
-    })
+    // Get the offsets and sizes as primitive arrays.
+    let offsets = list_array.offsets().to_primitive();
+    let sizes = list_array.sizes().to_primitive();
+
+    // Process based on the offset and size types.
+    let list_matches = match_each_integer_ptype!(offsets.ptype(), |O| {
+        match_each_integer_ptype!(sizes.ptype(), |S| {
+            process_matches::<O, S>(matches, list_array.len(), offsets, sizes)
+        })
+    });
+
+    Ok(BoolArray::from_bool_buffer(
+        list_matches,
+        list_array.validity().clone().union_nullability(nullability),
+    )
+    .into_array())
+}
+
+/// Returns a [`BooleanBuffer`] where each bit represents if a list contains the scalar, derived
+/// from a [`BoolArray`] of matches on the child elements array.
+fn process_matches<O, S>(
+    matches: BoolArray,
+    list_array_len: usize,
+    offsets: PrimitiveArray,
+    sizes: PrimitiveArray,
+) -> BooleanBuffer
+where
+    O: IntegerPType,
+    S: IntegerPType,
+{
+    let offsets_slice = offsets.as_slice::<O>();
+    let sizes_slice = sizes.as_slice::<S>();
+
+    (0..list_array_len)
+        .map(|i| {
+            let offset = offsets_slice[i].as_();
+            let size = sizes_slice[i].as_();
+
+            // BitIndexIterator yields indices of true bits only. If `.next()` returns
+            // `Some(_)`, at least one element in this list's range matches.
+            let mut set_bits =
+                BitIndexIterator::new(matches.boolean_buffer().values(), offset, size);
+            set_bits.next().is_some()
+        })
+        .collect::<BooleanBuffer>()
 }
 
 /// Returns a `Bool` array with `false` for lists that are valid,
 /// or `NULL` if the list itself is null.
-fn list_false_or_null(list_array: &ListArray, nullability: Nullability) -> VortexResult<ArrayRef> {
+fn list_false_or_null(
+    list_array: &ListViewArray,
+    nullability: Nullability,
+) -> VortexResult<ArrayRef> {
     match list_array.validity() {
         Validity::NonNullable => {
             // All false.
@@ -313,7 +362,10 @@ fn list_false_or_null(list_array: &ListArray, nullability: Nullability) -> Vorte
 
 /// Returns a `Bool` array with `true` for lists which are NOT empty, or `false` if they are empty,
 /// or `NULL` if the list itself is null.
-fn list_is_not_empty(list_array: &ListArray, nullability: Nullability) -> VortexResult<ArrayRef> {
+fn list_is_not_empty(
+    list_array: &ListViewArray,
+    nullability: Nullability,
+) -> VortexResult<ArrayRef> {
     // Short-circuit for all invalid.
     if matches!(list_array.validity(), Validity::AllInvalid) {
         return Ok(ConstantArray::new(
@@ -323,9 +375,9 @@ fn list_is_not_empty(list_array: &ListArray, nullability: Nullability) -> Vortex
         .into_array());
     }
 
-    let offsets = list_array.offsets().to_primitive();
-    let buffer = match_each_integer_ptype!(offsets.ptype(), |T| {
-        element_is_not_empty(offsets.as_slice::<T>())
+    let sizes = list_array.sizes().to_primitive();
+    let buffer = match_each_integer_ptype!(sizes.ptype(), |S| {
+        BooleanBuffer::from_iter(sizes.as_slice::<S>().iter().map(|&size| size != S::zero()))
     });
 
     // Copy over the validity mask from the input.
@@ -334,78 +386,6 @@ fn list_is_not_empty(list_array: &ListArray, nullability: Nullability) -> Vortex
         list_array.validity().clone().union_nullability(nullability),
     )
     .into_array())
-}
-
-/// Reduces each boolean values into a Mask that indicates which elements in the
-/// ListArray contain the matching value.
-fn reduce_with_ends<T: IntegerPType>(
-    ends: &[T],
-    matches: &BooleanBuffer,
-    validity: Validity,
-) -> ArrayRef {
-    let mask: BooleanBuffer = ends
-        .windows(2)
-        .map(|window| {
-            let len = window[1].as_() - window[0].as_();
-            let mut set_bits = BitIndexIterator::new(matches.values(), window[0].as_(), len);
-            set_bits.next().is_some()
-        })
-        .collect();
-
-    BoolArray::from_bool_buffer(mask, validity).into_array()
-}
-
-/// Returns a new array of `u64` representing the length of each list element.
-///
-/// ## Example
-///
-/// ```rust
-/// use vortex_array::arrays::{ListArray, VarBinArray};
-/// use vortex_array::{Array, IntoArray};
-/// use vortex_array::compute::{list_elem_len};
-/// use vortex_array::validity::Validity;
-/// use vortex_buffer::buffer;
-/// use vortex_dtype::DType;
-///
-/// let elements = VarBinArray::from_vec(
-///         vec!["a", "a", "b", "a", "c"], DType::Utf8(false.into())).into_array();
-/// let offsets = buffer![0u32, 1, 3, 5].into_array();
-/// let list_array = ListArray::try_new(elements, offsets, Validity::NonNullable).unwrap();
-///
-/// let lens = list_elem_len(list_array.as_ref()).unwrap();
-/// assert_eq!(lens.scalar_at(0), 1u32.into());
-/// assert_eq!(lens.scalar_at(1), 2u32.into());
-/// assert_eq!(lens.scalar_at(2), 2u32.into());
-/// ```
-pub fn list_elem_len(array: &dyn Array) -> VortexResult<ArrayRef> {
-    if !matches!(array.dtype(), DType::List(..)) {
-        vortex_bail!("Array must be of list type");
-    }
-
-    // Short-circuit for constant list arrays.
-    if array.is_constant() && array.len() > 1 {
-        let elem_lens = list_elem_len(&array.slice(0..1))?;
-        return Ok(ConstantArray::new(elem_lens.scalar_at(0), array.len()).into_array());
-    }
-
-    let list_array = array.to_list();
-    let offsets = list_array.offsets().to_primitive();
-    let lens_array = match_each_integer_ptype!(offsets.ptype(), |T| {
-        element_lens(offsets.as_slice::<T>()).into_array()
-    });
-
-    Ok(lens_array)
-}
-
-fn element_lens<T: IntegerPType>(values: &[T]) -> Buffer<T> {
-    values
-        .windows(2)
-        .map(|window| window[1] - window[0])
-        .collect()
-}
-
-fn element_is_not_empty<T: IntegerPType>(values: &[T]) -> BooleanBuffer {
-    BooleanBuffer::from_iter(values.windows(2).map(|window| window[1] != window[0]))
 }
 
 #[cfg(test)]
@@ -419,7 +399,8 @@ mod tests {
     use vortex_scalar::Scalar;
 
     use crate::arrays::{
-        BoolArray, ConstantArray, ConstantVTable, ListArray, PrimitiveArray, VarBinArray,
+        BoolArray, ConstantArray, ConstantVTable, ListArray, ListVTable, ListViewArray,
+        PrimitiveArray, VarBinArray, list_view_from_list,
     };
     use crate::canonical::ToCanonical;
     use crate::compute::list_contains;
@@ -428,12 +409,21 @@ mod tests {
     use crate::{Array, ArrayRef, IntoArray};
 
     fn nonnull_strings(values: Vec<Vec<&str>>) -> ArrayRef {
-        ListArray::from_iter_slow::<u64, _>(values, Arc::new(DType::Utf8(Nullability::NonNullable)))
+        list_view_from_list(
+            ListArray::from_iter_slow::<u64, _>(
+                values,
+                Arc::new(DType::Utf8(Nullability::NonNullable)),
+            )
             .unwrap()
+            .as_::<ListVTable>()
+            .clone(),
+        )
+        .into_array()
     }
 
     fn null_strings(values: Vec<Vec<Option<&str>>>) -> ArrayRef {
         let elements = values.iter().flatten().cloned().collect_vec();
+
         let mut offsets = values
             .iter()
             .scan(0u64, |st, v| {
@@ -447,8 +437,7 @@ mod tests {
         let elements =
             VarBinArray::from_iter(elements, DType::Utf8(Nullability::Nullable)).into_array();
 
-        ListArray::try_new(elements, offsets, Validity::NonNullable)
-            .unwrap()
+        list_view_from_list(ListArray::try_new(elements, offsets, Validity::NonNullable).unwrap())
             .into_array()
     }
 
@@ -548,7 +537,7 @@ mod tests {
         assert!(contains.is::<ConstantVTable>(), "Expected constant result");
         assert_eq!(
             contains.to_bool().boolean_buffer().iter().collect_vec(),
-            vec![true, true],
+            vec![true, true]
         );
     }
 
@@ -600,6 +589,139 @@ mod tests {
                 Some(false),
                 Some(true)
             ]
+        );
+    }
+
+    #[test]
+    fn test_list_contains_empty_listview() {
+        // Create a completely empty ListView with no elements
+        let empty_elements = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
+        let offsets = Buffer::from_iter([0u32, 0, 0, 0]).into_array();
+        let sizes = Buffer::from_iter([0u32, 0, 0, 0]).into_array();
+
+        let list_array = ListViewArray::try_new(
+            empty_elements.into_array(),
+            offsets,
+            sizes,
+            Validity::NonNullable,
+        )
+        .unwrap();
+
+        // Test with a non-null search value
+        let search = ConstantArray::new(Scalar::from(42i32), list_array.len());
+        let result = list_contains(list_array.as_ref(), search.as_ref()).unwrap();
+
+        // All lists are empty, so all should return false
+        assert_eq!(result.len(), 4);
+        assert_eq!(
+            result.to_bool().bool_vec().unwrap(),
+            vec![false, false, false, false]
+        );
+    }
+
+    #[test]
+    fn test_list_contains_all_null_elements() {
+        // Create lists containing only null elements
+        let elements = PrimitiveArray::from_option_iter::<i32, _>([None, None, None, None, None]);
+        let offsets = Buffer::from_iter([0u32, 2, 4]).into_array();
+        let sizes = Buffer::from_iter([2u32, 2, 1]).into_array();
+
+        let list_array =
+            ListViewArray::try_new(elements.into_array(), offsets, sizes, Validity::NonNullable)
+                .unwrap();
+
+        // Test searching for a null value
+        let null_search = ConstantArray::new(
+            Scalar::null(DType::Primitive(PType::I32, Nullability::Nullable)),
+            list_array.len(),
+        );
+        let result = list_contains(list_array.as_ref(), null_search.as_ref()).unwrap();
+
+        // Searching for null in lists with null elements should return null
+        assert_eq!(result.len(), 3);
+        assert_eq!(result.to_bool().validity(), &Validity::AllInvalid);
+
+        // Test searching for a non-null value
+        let non_null_search = ConstantArray::new(Scalar::from(42i32), list_array.len());
+        let result2 = list_contains(list_array.as_ref(), non_null_search.as_ref()).unwrap();
+
+        // All comparisons result in null, but search is not null, so should return false
+        assert_eq!(result2.len(), 3);
+        assert_eq!(
+            result2.to_bool().bool_vec().unwrap(),
+            vec![false, false, false]
+        );
+    }
+
+    #[test]
+    fn test_list_contains_large_offsets() {
+        // Test with large offset values that are still valid
+        // ListView allows non-contiguous views into the elements array
+        let elements = Buffer::from_iter([1i32, 2, 3, 4, 5]).into_array();
+
+        // Create lists with various offsets, testing the flexibility of ListView
+        // List 0: element at offset 0 (value 1)
+        // List 1: elements at offset 1-2 (values 2, 3)
+        // List 2: element at offset 4 (value 5)
+        // List 3: empty list
+        let offsets = Buffer::from_iter([0u32, 1, 4, 0]).into_array();
+        let sizes = Buffer::from_iter([1u32, 2, 1, 0]).into_array();
+
+        let list_array =
+            ListViewArray::try_new(elements.into_array(), offsets, sizes, Validity::NonNullable)
+                .unwrap();
+
+        // Test searching for value 2, which appears only in list 1
+        let search = ConstantArray::new(Scalar::from(2i32), list_array.len());
+        let result = list_contains(list_array.as_ref(), search.as_ref()).unwrap();
+
+        assert_eq!(result.len(), 4);
+        assert_eq!(
+            result.to_bool().bool_vec().unwrap(),
+            vec![false, true, false, false] // Value 2 is only in list 1
+        );
+
+        // Test searching for value 5, which appears only in list 2
+        let search5 = ConstantArray::new(Scalar::from(5i32), list_array.len());
+        let result5 = list_contains(list_array.as_ref(), search5.as_ref()).unwrap();
+
+        assert_eq!(
+            result5.to_bool().bool_vec().unwrap(),
+            vec![false, false, true, false] // Value 5 is only in list 2
+        );
+    }
+
+    #[test]
+    fn test_list_contains_offset_size_boundary() {
+        // Test edge case where offset + size approaches type boundaries
+        // We create lists where the last valid index (offset + size - 1) is at various boundaries
+
+        // For u8 boundary
+        let elements = Buffer::from_iter(0..256).into_array();
+        let offsets = Buffer::from_iter([0u8, 100, 200, 254]).into_array();
+        let sizes = Buffer::from_iter([50u8, 50, 54, 2]).into_array(); // Last list goes to index 255
+
+        let list_array =
+            ListViewArray::try_new(elements.into_array(), offsets, sizes, Validity::NonNullable)
+                .unwrap();
+
+        // Search for value 255 which should only be in the last list
+        let search = ConstantArray::new(Scalar::from(255i32), list_array.len());
+        let result = list_contains(list_array.as_ref(), search.as_ref()).unwrap();
+
+        assert_eq!(result.len(), 4);
+        assert_eq!(
+            result.to_bool().bool_vec().unwrap(),
+            vec![false, false, false, true]
+        );
+
+        // Search for value 0 which should only be in the first list
+        let search_zero = ConstantArray::new(Scalar::from(0i32), list_array.len());
+        let result_zero = list_contains(list_array.as_ref(), search_zero.as_ref()).unwrap();
+
+        assert_eq!(
+            result_zero.to_bool().bool_vec().unwrap(),
+            vec![true, false, false, false]
         );
     }
 }

--- a/vortex-array/src/context.rs
+++ b/vortex-array/src/context.rs
@@ -12,7 +12,7 @@ use vortex_utils::aliases::hash_map::HashMap;
 use crate::EncodingRef;
 use crate::arrays::{
     BoolEncoding, ChunkedEncoding, ConstantEncoding, DecimalEncoding, ExtensionEncoding,
-    FixedSizeListEncoding, ListEncoding, MaskedEncoding, NullEncoding, PrimitiveEncoding,
+    FixedSizeListEncoding, ListViewEncoding, MaskedEncoding, NullEncoding, PrimitiveEncoding,
     StructEncoding, VarBinEncoding, VarBinViewEncoding,
 };
 
@@ -25,21 +25,21 @@ impl ArrayRegistry {
     pub fn canonical_only() -> Self {
         let mut this = Self::empty();
 
-        // Register the canonical encodings
+        // Register the canonical encodings.
         this.register_many([
             EncodingRef::new_ref(NullEncoding.as_ref()) as EncodingRef,
             EncodingRef::new_ref(BoolEncoding.as_ref()),
             EncodingRef::new_ref(PrimitiveEncoding.as_ref()),
             EncodingRef::new_ref(DecimalEncoding.as_ref()),
             EncodingRef::new_ref(StructEncoding.as_ref()),
-            EncodingRef::new_ref(ListEncoding.as_ref()),
+            EncodingRef::new_ref(ListViewEncoding.as_ref()),
             EncodingRef::new_ref(FixedSizeListEncoding.as_ref()),
             EncodingRef::new_ref(VarBinEncoding.as_ref()),
             EncodingRef::new_ref(VarBinViewEncoding.as_ref()),
             EncodingRef::new_ref(ExtensionEncoding.as_ref()),
         ]);
 
-        // Register the utility encodings
+        // Register the utility encodings.
         this.register_many([
             EncodingRef::new_ref(ConstantEncoding.as_ref()) as EncodingRef,
             EncodingRef::new_ref(MaskedEncoding.as_ref()),

--- a/vortex-array/src/context.rs
+++ b/vortex-array/src/context.rs
@@ -12,8 +12,8 @@ use vortex_utils::aliases::hash_map::HashMap;
 use crate::EncodingRef;
 use crate::arrays::{
     BoolEncoding, ChunkedEncoding, ConstantEncoding, DecimalEncoding, ExtensionEncoding,
-    FixedSizeListEncoding, ListViewEncoding, MaskedEncoding, NullEncoding, PrimitiveEncoding,
-    StructEncoding, VarBinEncoding, VarBinViewEncoding,
+    FixedSizeListEncoding, ListEncoding, ListViewEncoding, MaskedEncoding, NullEncoding,
+    PrimitiveEncoding, StructEncoding, VarBinEncoding, VarBinViewEncoding,
 };
 
 /// A collection of array encodings.
@@ -31,19 +31,20 @@ impl ArrayRegistry {
             EncodingRef::new_ref(BoolEncoding.as_ref()),
             EncodingRef::new_ref(PrimitiveEncoding.as_ref()),
             EncodingRef::new_ref(DecimalEncoding.as_ref()),
-            EncodingRef::new_ref(StructEncoding.as_ref()),
+            EncodingRef::new_ref(VarBinViewEncoding.as_ref()),
             EncodingRef::new_ref(ListViewEncoding.as_ref()),
             EncodingRef::new_ref(FixedSizeListEncoding.as_ref()),
-            EncodingRef::new_ref(VarBinEncoding.as_ref()),
-            EncodingRef::new_ref(VarBinViewEncoding.as_ref()),
+            EncodingRef::new_ref(StructEncoding.as_ref()),
             EncodingRef::new_ref(ExtensionEncoding.as_ref()),
         ]);
 
         // Register the utility encodings.
         this.register_many([
+            EncodingRef::new_ref(ChunkedEncoding.as_ref()),
             EncodingRef::new_ref(ConstantEncoding.as_ref()) as EncodingRef,
             EncodingRef::new_ref(MaskedEncoding.as_ref()),
-            EncodingRef::new_ref(ChunkedEncoding.as_ref()),
+            EncodingRef::new_ref(ListEncoding.as_ref()),
+            EncodingRef::new_ref(VarBinEncoding.as_ref()),
         ]);
 
         this

--- a/vortex-array/src/context.rs
+++ b/vortex-array/src/context.rs
@@ -27,7 +27,7 @@ impl ArrayRegistry {
 
         // Register the canonical encodings.
         this.register_many([
-            EncodingRef::new_ref(NullEncoding.as_ref()) as EncodingRef,
+            EncodingRef::new_ref(NullEncoding.as_ref()),
             EncodingRef::new_ref(BoolEncoding.as_ref()),
             EncodingRef::new_ref(PrimitiveEncoding.as_ref()),
             EncodingRef::new_ref(DecimalEncoding.as_ref()),
@@ -41,7 +41,7 @@ impl ArrayRegistry {
         // Register the utility encodings.
         this.register_many([
             EncodingRef::new_ref(ChunkedEncoding.as_ref()),
-            EncodingRef::new_ref(ConstantEncoding.as_ref()) as EncodingRef,
+            EncodingRef::new_ref(ConstantEncoding.as_ref()),
             EncodingRef::new_ref(MaskedEncoding.as_ref()),
             EncodingRef::new_ref(ListEncoding.as_ref()),
             EncodingRef::new_ref(VarBinEncoding.as_ref()),

--- a/vortex-btrblocks/src/lib.rs
+++ b/vortex-btrblocks/src/lib.rs
@@ -34,7 +34,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 use vortex_array::arrays::{
-    ExtensionArray, FixedSizeListArray, ListArray, StructArray, TemporalArray,
+    ExtensionArray, FixedSizeListArray, ListViewArray, StructArray, TemporalArray,
 };
 use vortex_array::vtable::{VTable, ValidityHelper};
 use vortex_array::{Array, ArrayRef, Canonical, IntoArray, ToCanonical};
@@ -399,8 +399,10 @@ impl BtrBlocksCompressor {
                 .into_array())
             }
             Canonical::List(list_array) => {
-                // Compress the inner
+                // Compress the inner elements.
                 let compressed_elems = self.compress(list_array.elements())?;
+
+                // Compress the offsets.
                 let compressed_offsets = IntCompressor::compress_no_dict(
                     &list_array.offsets().to_primitive().narrow()?,
                     false,
@@ -408,9 +410,18 @@ impl BtrBlocksCompressor {
                     &[],
                 )?;
 
-                Ok(ListArray::try_new(
+                // Compress the sizes.
+                let compressed_sizes = IntCompressor::compress_no_dict(
+                    &list_array.sizes().to_primitive().narrow()?,
+                    false,
+                    MAX_CASCADE,
+                    &[],
+                )?;
+
+                Ok(ListViewArray::try_new(
                     compressed_elems,
                     compressed_offsets,
+                    compressed_sizes,
                     list_array.validity().clone(),
                 )?
                 .into_array())

--- a/vortex-btrblocks/src/lib.rs
+++ b/vortex-btrblocks/src/lib.rs
@@ -402,6 +402,9 @@ impl BtrBlocksCompressor {
                 // Compress the inner elements.
                 let compressed_elems = self.compress(list_array.elements())?;
 
+                // Note that since the type of our offsets and sizes is not encoded in our `DType`,
+                // we can narrow the widths.
+
                 // Compress the offsets.
                 let compressed_offsets = IntCompressor::compress_no_dict(
                     &list_array.offsets().to_primitive().narrow()?,

--- a/vortex-dtype/src/arrow.rs
+++ b/vortex-dtype/src/arrow.rs
@@ -212,6 +212,20 @@ impl DType {
             }
             DType::Utf8(_) => DataType::Utf8View,
             DType::Binary(_) => DataType::BinaryView,
+            // There are four kinds of lists: List (32-bit offsets), Large List (64-bit), List View
+            // (32-bit), Large List View (64-bit). We cannot both guarantee zero-copy and commit to an
+            // Arrow dtype because we do not how large our offsets are.
+            DType::List(elem_dtype, _) => DataType::ListView(FieldRef::new(Field::new_list_field(
+                elem_dtype.to_arrow_dtype()?,
+                elem_dtype.nullability().into(),
+            ))),
+            DType::FixedSizeList(elem_dtype, size, _) => DataType::FixedSizeList(
+                FieldRef::new(Field::new_list_field(
+                    elem_dtype.to_arrow_dtype()?,
+                    elem_dtype.nullability().into(),
+                )),
+                *size as i32,
+            ),
             DType::Struct(struct_dtype, _) => {
                 let mut fields = Vec::with_capacity(struct_dtype.names().len());
                 for (field_name, field_dt) in struct_dtype.names().iter().zip(struct_dtype.fields())
@@ -225,20 +239,6 @@ impl DType {
 
                 DataType::Struct(Fields::from(fields))
             }
-            // There are four kinds of lists: List (32-bit offsets), Large List (64-bit), List View
-            // (32-bit), Large List View (64-bit). We cannot both guarantee zero-copy and commit to an
-            // Arrow dtype because we do not how large our offsets are.
-            DType::List(elem_dtype, _) => DataType::List(FieldRef::new(Field::new_list_field(
-                elem_dtype.to_arrow_dtype()?,
-                elem_dtype.nullability().into(),
-            ))),
-            DType::FixedSizeList(elem_dtype, size, _) => DataType::FixedSizeList(
-                FieldRef::new(Field::new_list_field(
-                    elem_dtype.to_arrow_dtype()?,
-                    elem_dtype.nullability().into(),
-                )),
-                *size as i32,
-            ),
             DType::Extension(ext_dtype) => {
                 // Try and match against the known extension DTypes.
                 if is_temporal_ext_type(ext_dtype.id()) {
@@ -326,11 +326,11 @@ mod test {
         assert_ne!(arrow_list_non_nullable, arrow_list_nullable);
         assert_eq!(
             arrow_list_nullable,
-            DataType::new_list(DataType::Int64, true)
+            DataType::ListView(Arc::new(Field::new_list_field(DataType::Int64, true))),
         );
         assert_eq!(
             arrow_list_non_nullable,
-            DataType::new_list(DataType::Int64, false)
+            DataType::ListView(Arc::new(Field::new_list_field(DataType::Int64, false))),
         );
     }
 

--- a/vortex-dtype/src/arrow.rs
+++ b/vortex-dtype/src/arrow.rs
@@ -127,7 +127,10 @@ impl FromArrowType<(&DataType, Nullability)> for DType {
             | DataType::Timestamp(..) => DType::Extension(Arc::new(
                 make_temporal_ext_dtype(data_type).with_nullability(nullability),
             )),
-            DataType::List(e) | DataType::LargeList(e) => {
+            DataType::List(e)
+            | DataType::LargeList(e)
+            | DataType::ListView(e)
+            | DataType::LargeListView(e) => {
                 DType::List(Arc::new(Self::from_arrow(e.as_ref())), nullability)
             }
             DataType::FixedSizeList(e, size) => DType::FixedSizeList(

--- a/vortex-duckdb/src/exporter/dict.rs
+++ b/vortex-duckdb/src/exporter/dict.rs
@@ -150,6 +150,7 @@ impl<I: IntegerPType + AsPrimitive<u32>> ColumnExporter for DictExporter<I> {
 mod tests {
     use vortex::IntoArray;
     use vortex::arrays::{ConstantArray, PrimitiveArray};
+    use vortex::buffer::Buffer;
     use vortex::encodings::dict::DictArray;
     use vortex::error::VortexResult;
 
@@ -226,5 +227,29 @@ mod tests {
 - FLAT INTEGER: 3 = [ NULL, 10, NULL]
 "#
         )
+    }
+
+    #[ignore = "TODO(connor)[4809]: Exporters do not correctly handle empty vectors"]
+    #[test]
+    fn test_export_empty_dict() {
+        let arr = DictArray::new(
+            Buffer::<u32>::empty().into_array(),
+            Buffer::<u32>::empty().into_array(),
+        );
+
+        let mut chunk = DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_INTEGER)]);
+
+        new_exporter(&arr, &ConversionCache::default())
+            .unwrap()
+            .export(0, 0, &mut chunk.get_vector(0))
+            .unwrap();
+        chunk.set_len(0);
+
+        assert_eq!(
+            format!("{}", String::try_from(&chunk).unwrap()),
+            r#"Chunk - [1 Columns]
+- FLAT INTEGER: 0 = [ ]
+"#
+        );
     }
 }

--- a/vortex-duckdb/src/exporter/list.rs
+++ b/vortex-duckdb/src/exporter/list.rs
@@ -55,7 +55,6 @@ pub(crate) fn new_exporter(
                 Vector::with_capacity(elements.dtype().try_into()?, elements.len());
             let elements_exporter = new_array_exporter_with_flatten(array.elements(), cache, true)?;
 
-            // TODO(connor)[4809]: THIS IS A HACK, we should be checking this everywhere.
             if !elements.is_empty() {
                 elements_exporter.export(0, elements.len(), &mut duckdb_elements)?;
             }
@@ -151,7 +150,7 @@ mod tests {
     use crate::exporter::new_array_exporter;
 
     #[test]
-    #[ignore = "TODO(connor): Exporters do not correctly handle empty vectors"]
+    #[ignore = "TODO(connor)[4809]: Exporters do not correctly handle empty vectors"]
     fn test_export_empty_list() {
         let list = ListViewArray::try_new(
             Buffer::<u32>::empty().into_array(),

--- a/vortex-duckdb/src/exporter/list.rs
+++ b/vortex-duckdb/src/exporter/list.rs
@@ -2,10 +2,11 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::marker::PhantomData;
+use std::sync::Arc;
 
-use itertools::Itertools as _;
-use vortex::ToCanonical as _;
-use vortex::arrays::{ListArray, PrimitiveArray};
+use parking_lot::Mutex;
+use vortex::ToCanonical;
+use vortex::arrays::{ListViewArray, PrimitiveArray};
 use vortex::dtype::{IntegerPType, match_each_integer_ptype};
 use vortex::error::{VortexResult, vortex_err};
 use vortex::mask::Mask;
@@ -15,74 +16,125 @@ use crate::cpp;
 use crate::duckdb::Vector;
 use crate::exporter::ColumnExporter;
 
-struct ListExporter<T> {
+struct ListExporter<O, S> {
     validity: Mask,
-    elements_exporter: Box<dyn ColumnExporter>,
+    /// We cache the child elements of our list array so that we don't have to export it every time,
+    /// and we also share it across any other exporters who want to export this array.
+    ///
+    /// Note that we are trading less compute for more memory here, as we will export the entire
+    /// array in the constructor of the exporter (`new_exporter`) even if some of the elements are
+    /// unreachable.
+    duckdb_elements: Arc<Mutex<Vector>>,
     offsets: PrimitiveArray,
-    offset_type: PhantomData<T>,
+    sizes: PrimitiveArray,
+    num_elements: usize,
+    offset_type: PhantomData<O>,
+    size_type: PhantomData<S>,
 }
 
 pub(crate) fn new_exporter(
-    array: &ListArray,
+    array: &ListViewArray,
     cache: &ConversionCache,
 ) -> VortexResult<Box<dyn ColumnExporter>> {
-    let elements_exporter = new_array_exporter_with_flatten(array.elements(), cache, true)?;
+    // Cache an `elements` vector up front so that future exports can reference it.
+    let elements = array.elements();
+    let num_elements = elements.len();
+
+    let values_key = Arc::as_ptr(elements).addr();
+    // Check if we have a cached vector and extract it if we do.
+    let cached_elements = cache
+        .values_cache
+        .get(&values_key)
+        .map(|entry| entry.value().1.clone());
+
+    let shared_elements = match cached_elements {
+        Some(elements) => elements,
+        None => {
+            // We have no cached the vector yet, so create a new DuckDB vector for the elements.
+            let mut duckdb_elements =
+                Vector::with_capacity(elements.dtype().try_into()?, elements.len());
+            let elements_exporter = new_array_exporter_with_flatten(array.elements(), cache, true)?;
+
+            // TODO(connor)[4809]: THIS IS A HACK, we should be checking this everywhere.
+            if !elements.is_empty() {
+                elements_exporter.export(0, elements.len(), &mut duckdb_elements)?;
+            }
+
+            let shared_elements = Arc::new(Mutex::new(duckdb_elements));
+            cache
+                .values_cache
+                .insert(values_key, (elements.clone(), shared_elements.clone()));
+
+            shared_elements
+        }
+    };
+
     let offsets = array.offsets().to_primitive();
-    let boxed = match_each_integer_ptype!(offsets.ptype(), |T| {
-        Box::new(ListExporter {
-            validity: array.validity_mask(),
-            elements_exporter,
-            offsets,
-            offset_type: PhantomData::<T>,
-        }) as Box<dyn ColumnExporter>
+    let sizes = array.sizes().to_primitive();
+
+    let boxed = match_each_integer_ptype!(offsets.ptype(), |O| {
+        match_each_integer_ptype!(sizes.ptype(), |S| {
+            Box::new(ListExporter {
+                validity: array.validity_mask(),
+                duckdb_elements: shared_elements,
+                offsets,
+                sizes,
+                num_elements,
+                offset_type: PhantomData::<O>,
+                size_type: PhantomData::<S>,
+            }) as Box<dyn ColumnExporter>
+        })
     });
+
     Ok(boxed)
 }
 
-impl<T: IntegerPType> ColumnExporter for ListExporter<T> {
+impl<O: IntegerPType, S: IntegerPType> ColumnExporter for ListExporter<O, S> {
     fn export(&self, offset: usize, len: usize, vector: &mut Vector) -> VortexResult<()> {
+        // Verify that offset + len doesn't exceed the validity mask length.
+        assert!(
+            offset + len <= self.validity.len(),
+            "Export range [{}, {}) exceeds validity mask length {}",
+            offset,
+            offset + len,
+            self.validity.len()
+        );
+
         // Set validity if necessary.
         if unsafe { vector.set_validity(&self.validity, offset, len) } {
             // All values are null, so no point copying the data.
             return Ok(());
         }
 
-        let offsets = &self.offsets.as_slice::<T>()[offset..][..(len + 1)];
-        let start_offset = offsets[0]
-            .to_u64()
-            .ok_or_else(|| vortex_err!("list offsets must fit in u64"))?;
-        let mut sum_of_list_lens = 0_u64;
+        let offsets = &self.offsets.as_slice::<O>()[offset..offset + len];
+        let sizes = &self.sizes.as_slice::<S>()[offset..offset + len];
+        debug_assert_eq!(offsets.len(), len);
+        debug_assert_eq!(sizes.len(), len);
 
-        let offsets_slice: &mut [cpp::duckdb_list_entry] =
+        // SAFETY: TODO(connor): Pretty sure that `export` needs to be `unsafe`.
+        let duckdb_list_views: &mut [cpp::duckdb_list_entry] =
             unsafe { vector.as_slice_mut::<cpp::duckdb_list_entry>(len) };
+        debug_assert_eq!(duckdb_list_views.len(), len);
 
-        for (window, destination) in offsets.windows(2).zip_eq(offsets_slice) {
-            let start = window[0]
+        for i in 0..len {
+            let offset = offsets[i]
                 .to_u64()
-                .ok_or_else(|| vortex_err!("list offsets must fit in u64"))?;
-            let end = window[1]
+                .ok_or_else(|| vortex_err!("somehow unable to convert an offset to u64"))?;
+            let length = sizes[i]
                 .to_u64()
-                .ok_or_else(|| vortex_err!("list offsets must fit in u64"))?;
-            let len = end - start;
-            sum_of_list_lens += len;
-            *destination = cpp::duckdb_list_entry {
-                offset: start - start_offset,
-                length: len,
-            };
+                .ok_or_else(|| vortex_err!("somehow unable to convert an offset to u64"))?;
+
+            debug_assert!(offset + length <= self.num_elements as u64);
+
+            duckdb_list_views[i] = cpp::duckdb_list_entry { offset, length };
         }
 
-        // TODO(DK): This calls `list_vector_reserve` once for each call to `export`. Moreover, we
-        // copy slices of the elements once for each call to `export`. Would `export` be faster if
-        // we copied all the elements on the first call to `export` so that subsequent calls need
-        // only copy the correct slice of offsets?
-        vector.list_vector_reserve(sum_of_list_lens)?;
-        let mut elements_vector = vector.list_vector_get_child();
-        vector.list_vector_set_size(sum_of_list_lens)?;
-        self.elements_exporter.export(
-            usize::try_from(start_offset)?,
-            usize::try_from(sum_of_list_lens)?,
-            &mut elements_vector,
-        )
+        let mut child = vector.list_vector_get_child();
+        child.reference(&self.duckdb_elements.lock());
+
+        vector.list_vector_set_size(self.num_elements as u64)?;
+
+        Ok(())
     }
 }
 
@@ -99,10 +151,12 @@ mod tests {
     use crate::exporter::new_array_exporter;
 
     #[test]
+    #[ignore = "TODO(connor): Exporters do not correctly handle empty vectors"]
     fn test_export_empty_list() {
-        let list = ListArray::try_new(
+        let list = ListViewArray::try_new(
             Buffer::<u32>::empty().into_array(),
-            buffer![0u8].into_array(),
+            Buffer::<u32>::empty().into_array(),
+            Buffer::<u32>::empty().into_array(),
             Validity::AllValid,
         )
         .unwrap()
@@ -127,9 +181,10 @@ mod tests {
 
     #[test]
     fn test_export_non_empty_list_with_preceding_and_trailing_garbage() {
-        let list = ListArray::try_new(
+        let list = ListViewArray::try_new(
             buffer![0, 1, 2, 3, 4, 5].into_array(),
-            buffer![1u8, 2, 3, 4].into_array(),
+            buffer![1u8, 2, 3].into_array(),
+            buffer![1u8, 1, 1].into_array(),
             Validity::AllValid,
         )
         .unwrap()
@@ -154,7 +209,7 @@ mod tests {
 
     #[test]
     fn test_export_non_empty_list_of_strings() {
-        let list = ListArray::try_new(
+        let list = ListViewArray::try_new(
             <VarBinArray as FromIterator<_>>::from_iter([
                 Some("abc"),
                 Some("def"),
@@ -162,7 +217,8 @@ mod tests {
                 Some("ghi"),
             ])
             .into_array(),
-            buffer![0u8, 0, 3, 4, 4].into_array(),
+            buffer![0u8, 0, 3, 4].into_array(),
+            buffer![0u8, 3, 1, 0].into_array(),
             Validity::from_iter([true, true, false, true]),
         )
         .unwrap()

--- a/vortex-layout/src/layouts/compact.rs
+++ b/vortex-layout/src/layouts/compact.rs
@@ -134,6 +134,9 @@ impl CompactCompressor {
             }
             Canonical::List(list_array) => {
                 let compressed_elems = self.compress(list_array.elements())?;
+
+                // Note that since the type of our offsets and sizes is not encoded in our `DType`,
+                // we can narrow the widths.
                 let compressed_offsets =
                     self.compress(&list_array.offsets().to_primitive().narrow()?.into_array())?;
                 let compressed_sizes =

--- a/vortex-layout/src/layouts/compact.rs
+++ b/vortex-layout/src/layouts/compact.rs
@@ -2,7 +2,8 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::arrays::{
-    ExtensionArray, FixedSizeListArray, ListArray, PrimitiveArray, StructArray, narrowed_decimal,
+    ExtensionArray, FixedSizeListArray, ListViewArray, PrimitiveArray, StructArray,
+    narrowed_decimal,
 };
 use vortex_array::vtable::ValidityHelper;
 use vortex_array::{Array, ArrayRef, Canonical, IntoArray};
@@ -132,19 +133,19 @@ impl CompactCompressor {
                 .into_array()
             }
             Canonical::List(list_array) => {
-                // recurse
                 let compressed_elems = self.compress(list_array.elements())?;
                 let compressed_offsets = self.compress(list_array.offsets())?;
+                let compressed_sizes = self.compress(list_array.sizes())?;
 
-                ListArray::try_new(
+                ListViewArray::try_new(
                     compressed_elems,
                     compressed_offsets,
+                    compressed_sizes,
                     list_array.validity().clone(),
                 )?
                 .into_array()
             }
             Canonical::FixedSizeList(list_array) => {
-                // recurse
                 let compressed_elems = self.compress(list_array.elements())?;
 
                 FixedSizeListArray::try_new(
@@ -156,7 +157,6 @@ impl CompactCompressor {
                 .into_array()
             }
             Canonical::Extension(ext_array) => {
-                // recurse
                 let compressed_storage = self.compress(ext_array.storage())?;
 
                 ExtensionArray::new(ext_array.ext_dtype().clone(), compressed_storage).into_array()

--- a/vortex-layout/src/layouts/compact.rs
+++ b/vortex-layout/src/layouts/compact.rs
@@ -6,7 +6,7 @@ use vortex_array::arrays::{
     narrowed_decimal,
 };
 use vortex_array::vtable::ValidityHelper;
-use vortex_array::{Array, ArrayRef, Canonical, IntoArray};
+use vortex_array::{Array, ArrayRef, Canonical, IntoArray, ToCanonical};
 use vortex_decimal_byte_parts::DecimalBytePartsArray;
 use vortex_dtype::PType;
 use vortex_error::VortexResult;
@@ -134,8 +134,10 @@ impl CompactCompressor {
             }
             Canonical::List(list_array) => {
                 let compressed_elems = self.compress(list_array.elements())?;
-                let compressed_offsets = self.compress(list_array.offsets())?;
-                let compressed_sizes = self.compress(list_array.sizes())?;
+                let compressed_offsets =
+                    self.compress(&list_array.offsets().to_primitive().narrow()?.into_array())?;
+                let compressed_sizes =
+                    self.compress(&list_array.sizes().to_primitive().narrow()?.into_array())?;
 
                 ListViewArray::try_new(
                     compressed_elems,

--- a/vortex-scalar/src/binary.rs
+++ b/vortex-scalar/src/binary.rs
@@ -15,7 +15,7 @@ use crate::{InnerScalarValue, Scalar, ScalarValue};
 ///
 /// This type provides a view into a binary scalar value, which can be either
 /// a valid byte buffer or null.
-#[derive(Debug, Hash)]
+#[derive(Debug, Clone, Hash)]
 pub struct BinaryScalar<'a> {
     dtype: &'a DType,
     value: Option<Arc<ByteBuffer>>,

--- a/vortex-scalar/src/bool.rs
+++ b/vortex-scalar/src/bool.rs
@@ -14,7 +14,7 @@ use crate::{InnerScalarValue, Scalar, ScalarValue};
 ///
 /// This type provides a view into a boolean scalar value, which can be either
 /// true, false, or null.
-#[derive(Debug, Hash, Eq)]
+#[derive(Debug, Clone, Hash, Eq)]
 pub struct BoolScalar<'a> {
     dtype: &'a DType,
     value: Option<bool>,

--- a/vortex-scalar/src/extension.rs
+++ b/vortex-scalar/src/extension.rs
@@ -14,7 +14,7 @@ use crate::{Scalar, ScalarValue};
 /// A scalar value representing an extension type.
 ///
 /// Extension types allow wrapping a storage type with custom semantics.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ExtScalar<'a> {
     ext_dtype: &'a ExtDType,
     value: &'a ScalarValue,

--- a/vortex-scalar/src/list.rs
+++ b/vortex-scalar/src/list.rs
@@ -23,7 +23,7 @@ use crate::{InnerScalarValue, Scalar, ScalarValue};
 /// number of `elements` is equal to the `size` field of the [`FixedSizeList`].
 ///
 /// [`FixedSizeList`]: DType::FixedSizeList
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ListScalar<'a> {
     dtype: &'a DType,
     element_dtype: &'a Arc<DType>,

--- a/vortex-scalar/src/struct_.rs
+++ b/vortex-scalar/src/struct_.rs
@@ -19,7 +19,7 @@ use crate::{InnerScalarValue, Scalar, ScalarValue};
 ///
 /// This type provides a view into a struct scalar value, which can contain
 /// named fields with different types, or be null.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StructScalar<'a> {
     dtype: &'a DType,
     fields: Option<&'a Arc<[ScalarValue]>>,

--- a/vortex-scalar/src/utf8.rs
+++ b/vortex-scalar/src/utf8.rs
@@ -15,7 +15,7 @@ use crate::{InnerScalarValue, Scalar, ScalarValue};
 ///
 /// This type provides a view into a UTF-8 string scalar value, which can be either
 /// a valid UTF-8 string or null.
-#[derive(Debug, Hash, Eq)]
+#[derive(Debug, Clone, Hash, Eq)]
 pub struct Utf8Scalar<'a> {
     dtype: &'a DType,
     value: Option<Arc<BufferString>>,


### PR DESCRIPTION
Tracking Issue: https://github.com/vortex-data/vortex/issues/4699

Revived from: https://github.com/vortex-data/vortex/pull/4853 and https://github.com/vortex-data/vortex/pull/4830

This PR makes `ListViewArray` the canonical encoding of `DType::List`, which used to be `ListArray`.

We will probably have a large regression in term of performance for now, but that can be improved in the future.