### PR TITLE
feat: `take_search` constant time index lookups

### DIFF
--- a/encodings/fastlanes/src/bitpacking/serde.rs
+++ b/encodings/fastlanes/src/bitpacking/serde.rs
@@ -71,14 +71,10 @@ impl SerdeVTable<BitPackedVTable> for BitPackedVTable {
             }
         };
 
-        let validity_idx = if let Some(patches_meta) = &metadata.patches {
-            if patches_meta.chunk_offsets_dtype().is_some() {
-                3
-            } else {
-                2
-            }
-        } else {
-            0
+        let validity_idx = match &metadata.patches {
+            None => 0,
+            Some(patches_meta) if patches_meta.chunk_offsets_dtype().is_some() => 3,
+            Some(_) => 2,
         };
 
         let validity = load_validity(validity_idx)?;

--- a/vortex-array/benches/take_patches.rs
+++ b/vortex-array/benches/take_patches.rs
@@ -38,7 +38,22 @@ const BENCH_ARGS: &[(f64, f64)] = &[
 #[divan::bench(args = BENCH_ARGS)]
 fn take_search(bencher: Bencher, (patches_sparsity, index_multiple): (f64, f64)) {
     let mut rng = StdRng::seed_from_u64(0);
-    let patches = fixture(16384, patches_sparsity, &mut rng);
+    let patches = fixture(65536, patches_sparsity, &mut rng);
+    let indices = indices(
+        patches.array_len(),
+        (patches.array_len() as f64 * index_multiple) as usize,
+        &mut rng,
+    );
+
+    bencher
+        .with_inputs(|| (&patches, indices.clone()))
+        .bench_values(|(patches, indices)| patches.take_search(indices.to_primitive(), false));
+}
+
+#[divan::bench(args = BENCH_ARGS)]
+fn take_search_chunked(bencher: Bencher, (patches_sparsity, index_multiple): (f64, f64)) {
+    let mut rng = StdRng::seed_from_u64(0);
+    let patches = fixture_with_chunk_offsets(16384, patches_sparsity, &mut rng);
     let indices = indices(
         patches.array_len(),
         (patches.array_len() as f64 * index_multiple) as usize,
@@ -53,7 +68,7 @@ fn take_search(bencher: Bencher, (patches_sparsity, index_multiple): (f64, f64))
 #[divan::bench(args = BENCH_ARGS)]
 fn take_map(bencher: Bencher, (patches_sparsity, index_multiple): (f64, f64)) {
     let mut rng = StdRng::seed_from_u64(0);
-    let patches = fixture(16384, patches_sparsity, &mut rng);
+    let patches = fixture(65536, patches_sparsity, &mut rng);
     let indices = indices(
         patches.array_len(),
         (patches.array_len() as f64 * index_multiple) as usize,
@@ -79,6 +94,32 @@ fn fixture(len: usize, sparsity: f64, rng: &mut StdRng) -> Patches {
         values,
         // TODO(0ax1): handle chunk offsets
         None,
+    )
+}
+
+fn fixture_with_chunk_offsets(len: usize, sparsity: f64, rng: &mut StdRng) -> Patches {
+    let patch_indices = (0..len)
+        .filter(|_| rng.random_bool(sparsity))
+        .map(|x| x as u64)
+        .collect::<Vec<u64>>();
+
+    let sparse_len = patch_indices.len();
+    let values = Buffer::from_iter((0..sparse_len).map(|x| x as u64)).into_array();
+
+    const PATCH_CHUNK_SIZE: usize = 1024;
+    let chunk_offsets: Vec<u64> = (0..len)
+        .step_by(PATCH_CHUNK_SIZE)
+        .map(|chunk_start| {
+            patch_indices.partition_point(|&idx| (idx as usize) < chunk_start) as u64
+        })
+        .collect();
+
+    Patches::new(
+        len,
+        0,
+        Buffer::from(patch_indices).into_array(),
+        values,
+        Some(Buffer::from(chunk_offsets).into_array()),
     )
 }
 

--- a/vortex-array/benches/take_patches.rs
+++ b/vortex-array/benches/take_patches.rs
@@ -53,7 +53,7 @@ fn take_search(bencher: Bencher, (patches_sparsity, index_multiple): (f64, f64))
 #[divan::bench(args = BENCH_ARGS)]
 fn take_search_chunked(bencher: Bencher, (patches_sparsity, index_multiple): (f64, f64)) {
     let mut rng = StdRng::seed_from_u64(0);
-    let patches = fixture_with_chunk_offsets(16384, patches_sparsity, &mut rng);
+    let patches = fixture_with_chunk_offsets(65536, patches_sparsity, &mut rng);
     let indices = indices(
         patches.array_len(),
         (patches.array_len() as f64 * index_multiple) as usize,

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -8,6 +8,7 @@ use std::ops::Range;
 
 use arrow_buffer::BooleanBuffer;
 use itertools::Itertools;
+use num_traits::NumCast;
 use vortex_buffer::BufferMut;
 use vortex_dtype::Nullability::NonNullable;
 use vortex_dtype::{
@@ -331,36 +332,6 @@ impl Patches {
         Self::search_index_binary_search(&self.indices, index + self.offset)
     }
 
-    /// Batch version of `search_index`.
-    ///
-    /// In contrast to `search_index`, this function requires indices as
-    /// well as chunk_offsets to be passed as slices. This is to avoid
-    /// redundant canonicalization and `scalar_at` lookups across calls.
-    pub fn search_index_batch<T, O>(
-        &self,
-        indices: &[T],
-        chunk_offsets: Option<&[O]>,
-        index: T,
-    ) -> SearchResult
-    where
-        T: UnsignedPType,
-        O: UnsignedPType,
-        O: TryFrom<usize>,
-        usize: TryFrom<T>,
-        usize: TryFrom<O>,
-    {
-        if let Some(chunk_offsets) = chunk_offsets {
-            return self.search_index_chunked_batch(indices, chunk_offsets, index);
-        } else {
-            let Some(offset) = T::from(self.offset) else {
-                // If the offset cannot be converted to T, it's larger than all values in this array.
-                return SearchResult::NotFound(indices.len());
-            };
-
-            indices.search_sorted(&(index + offset), SearchSortedSide::Left)
-        }
-    }
-
     /// Binary searches for `needle` in the indices array.
     ///
     /// # Returns
@@ -448,7 +419,6 @@ impl Patches {
     where
         T: UnsignedPType,
         O: UnsignedPType,
-        O: TryFrom<usize>,
         usize: TryFrom<T>,
         usize: TryFrom<O>,
     {
@@ -487,7 +457,7 @@ impl Patches {
         let patches_end_idx = if chunk_idx < chunk_offsets.len() - 1 {
             let base_offset_end = chunk_offsets[chunk_idx + 1];
 
-            let Ok(offset_within_chunk) = O::try_from(offset_within_chunk) else {
+            let Some(offset_within_chunk) = O::from(offset_within_chunk) else {
                 vortex_panic!("offset_within_chunk failed to convert to O");
             };
 
@@ -702,53 +672,44 @@ impl Patches {
         let (values_indices, new_indices): (BufferMut<u64>, BufferMut<u64>) =
             match_each_unsigned_integer_ptype!(patch_indices.ptype(), |PatchT| {
                 let patch_indices_slice = patch_indices.as_slice::<PatchT>();
+                match_each_integer_ptype!(take_indices.ptype(), |TakeT| {
+                    let take_slice = take_indices.as_slice::<TakeT>();
 
-                let take = |search_fn: &dyn Fn(PatchT) -> SearchResult| {
-                    match_each_integer_ptype!(take_indices.ptype(), |TakeT| {
-                        take_indices
-                            .as_slice::<TakeT>()
-                            .iter()
-                            .enumerate()
-                            .filter_map(|(new_patch_idx, &take_idx)| {
-                                if include_nulls && take_indices_validity.is_null(new_patch_idx) {
-                                    // For nulls, patch index doesn't matter - use 0 for consistency
-                                    Some((0u64, new_patch_idx as u64))
-                                } else {
-                                    let search_result = PatchT::try_from(take_idx)
-                                        .map(|converted_take_idx| search_fn(converted_take_idx))
-                                        .unwrap_or(SearchResult::NotFound(
-                                            patch_indices_slice.len(),
-                                        ));
-
-                                    search_result
-                                        .to_found()
-                                        .map(|patch_idx| (patch_idx as u64, new_patch_idx as u64))
-                                }
-                            })
-                            .unzip()
-                    })
-                };
-
-                if let Some(chunk_offsets) = chunk_offsets {
-                    match_each_unsigned_integer_ptype!(chunk_offsets.ptype(), |OffsetT| {
-                        let chunk_offsets_slice = chunk_offsets.as_slice::<OffsetT>();
-                        take(&|take_idx| {
-                            self.search_index_batch(
+                    if let Some(chunk_offsets) = chunk_offsets {
+                        match_each_unsigned_integer_ptype!(chunk_offsets.ptype(), |OffsetT| {
+                            let chunk_offsets = chunk_offsets.as_slice::<OffsetT>();
+                            take_indices_with_search_fn(
                                 patch_indices_slice,
-                                Some(chunk_offsets_slice),
-                                take_idx,
+                                take_slice,
+                                take_indices.validity_mask(),
+                                include_nulls,
+                                |take_idx| {
+                                    self.search_index_chunked_batch(
+                                        patch_indices_slice,
+                                        chunk_offsets,
+                                        take_idx,
+                                    )
+                                },
                             )
                         })
-                    })
-                } else {
-                    take(&|take_idx| {
-                        self.search_index_batch(
+                    } else {
+                        take_indices_with_search_fn(
                             patch_indices_slice,
-                            Option::<&[u8]>::None,
-                            take_idx,
+                            take_slice,
+                            take_indices.validity_mask(),
+                            include_nulls,
+                            |take_idx| {
+                                let Some(offset) = <PatchT as NumCast>::from(self.offset) else {
+                                    // If the offset cannot be converted to T, it's larger than all values in this array.
+                                    return SearchResult::NotFound(patch_indices_slice.len());
+                                };
+
+                                patch_indices_slice
+                                    .search_sorted(&(take_idx + offset), SearchSortedSide::Left)
+                            },
                         )
-                    })
-                }
+                    }
+                })
             });
 
         if new_indices.is_empty() {
@@ -997,6 +958,33 @@ fn filter_patches_with_mask<T: IntegerPType>(
         // TODO(0ax1): Chunk offsets are invalid after a filter is applied.
         None,
     )))
+}
+
+fn take_indices_with_search_fn<I: UnsignedPType, T: IntegerPType, F: Fn(I) -> SearchResult>(
+    indices: &[I],
+    take_indices: &[T],
+    take_validity: Mask,
+    include_nulls: bool,
+    search_fn: F,
+) -> (BufferMut<u64>, BufferMut<u64>) {
+    take_indices
+        .iter()
+        .enumerate()
+        .filter_map(|(new_patch_idx, &take_idx)| {
+            if include_nulls && !take_validity.value(new_patch_idx) {
+                // For nulls, patch index doesn't matter - use 0 for consistency
+                Some((0u64, new_patch_idx as u64))
+            } else {
+                let search_result = I::from(take_idx)
+                    .map(|converted_take_idx| search_fn(converted_take_idx))
+                    .unwrap_or(SearchResult::NotFound(indices.len()));
+
+                search_result
+                    .to_found()
+                    .map(|patch_idx| (patch_idx as u64, new_patch_idx as u64))
+            }
+        })
+        .unzip()
 }
 
 #[cfg(test)]

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -1160,7 +1160,7 @@ mod test {
             0,
             BufferMut::from_iter(0..1500u64).into_array(),
             BufferMut::from_iter(0..1500i32).into_array(),
-            None,
+            Some(buffer![0u64, 1024u64].into_array()),
         );
 
         let taken = patches

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -660,6 +660,7 @@ impl Patches {
         }
     }
 
+    #[allow(clippy::cognitive_complexity)]
     pub fn take_search(
         &self,
         take_indices: PrimitiveArray,
@@ -976,7 +977,7 @@ fn take_indices_with_search_fn<I: UnsignedPType, T: IntegerPType, F: Fn(I) -> Se
                 Some((0u64, new_patch_idx as u64))
             } else {
                 let search_result = I::from(take_idx)
-                    .map(|converted_take_idx| search_fn(converted_take_idx))
+                    .map(&search_fn)
                     .unwrap_or(SearchResult::NotFound(indices.len()));
 
                 search_result

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use vortex_buffer::BufferMut;
 use vortex_dtype::Nullability::NonNullable;
 use vortex_dtype::{
-    DType, IntegerPType, NativePType, PType, match_each_integer_ptype,
+    DType, IntegerPType, NativePType, PType, UnsignedPType, match_each_integer_ptype,
     match_each_unsigned_integer_ptype,
 };
 use vortex_error::{
@@ -331,6 +331,36 @@ impl Patches {
         Self::search_index_binary_search(&self.indices, index + self.offset)
     }
 
+    /// Batch version of `search_index`.
+    ///
+    /// In contrast to `search_index`, this function requires indices as
+    /// well as chunk_offsets to be passed as slices. This is to avoid
+    /// redundant canonicalization and `scalar_at` lookups across calls.
+    pub fn search_index_batch<T, O>(
+        &self,
+        indices: &[T],
+        chunk_offsets: Option<&[O]>,
+        index: T,
+    ) -> SearchResult
+    where
+        T: UnsignedPType,
+        O: UnsignedPType,
+        O: TryFrom<usize>,
+        usize: TryFrom<T>,
+        usize: TryFrom<O>,
+    {
+        if let Some(chunk_offsets) = chunk_offsets {
+            return self.search_index_chunked_batch(indices, chunk_offsets, index);
+        } else {
+            let Some(offset) = T::from(self.offset) else {
+                // If the offset cannot be converted to T, it's larger than all values in this array.
+                return SearchResult::NotFound(indices.len());
+            };
+
+            indices.search_sorted(&(index + offset), SearchSortedSide::Left)
+        }
+    }
+
     /// Binary searches for `needle` in the indices array.
     ///
     /// # Returns
@@ -400,13 +430,85 @@ impl Patches {
             self.indices.len()
         };
 
-        if patches_start_idx == patches_end_idx {
-            // Return NotFound in case there are no patches in this chunk.
-            return SearchResult::NotFound(patches_start_idx);
-        }
-
         let chunk_indices = self.indices.slice(patches_start_idx..patches_end_idx);
         let result = Self::search_index_binary_search(&chunk_indices, index + self.offset);
+
+        match result {
+            SearchResult::Found(idx) => SearchResult::Found(patches_start_idx + idx),
+            SearchResult::NotFound(idx) => SearchResult::NotFound(patches_start_idx + idx),
+        }
+    }
+
+    fn search_index_chunked_batch<T, O>(
+        &self,
+        indices: &[T],
+        chunk_offsets: &[O],
+        index: T,
+    ) -> SearchResult
+    where
+        T: UnsignedPType,
+        O: UnsignedPType,
+        O: TryFrom<usize>,
+        usize: TryFrom<T>,
+        usize: TryFrom<O>,
+    {
+        let Some(offset_within_chunk) = self.offset_within_chunk else {
+            vortex_panic!("offset_within_chunk is required to be set")
+        };
+
+        let chunk_idx = {
+            let Ok(index) = usize::try_from(index) else {
+                // If the needle cannot be converted to usize, it's larger than all values in this array.
+                return SearchResult::NotFound(indices.len());
+            };
+
+            if index >= self.array_len() {
+                return SearchResult::NotFound(self.indices().len());
+            }
+
+            (index + self.offset % PATCH_CHUNK_SIZE) / PATCH_CHUNK_SIZE
+        };
+
+        // Patch index offsets are absolute and need to be offset by the first chunk of the current slice.
+        let Ok(chunk_offset_diff) = usize::try_from(chunk_offsets[chunk_idx] - chunk_offsets[0])
+        else {
+            vortex_panic!("chunk_offset failed to convert to usize")
+        };
+
+        let patches_start_idx = chunk_offset_diff
+            // Chunk offsets are only sliced off in case the slice is fully
+            // outside of the chunk range.
+            //
+            // Though the range for indices and values is sliced in terms of
+            // individual elements, not chunks. To account for that we do a
+            // saturating sub when adjusting the indices based on the chunk offset.
+            .saturating_sub(offset_within_chunk);
+
+        let patches_end_idx = if chunk_idx < chunk_offsets.len() - 1 {
+            let base_offset_end = chunk_offsets[chunk_idx + 1];
+
+            let Ok(offset_within_chunk) = O::try_from(offset_within_chunk) else {
+                vortex_panic!("offset_within_chunk failed to convert to O");
+            };
+
+            let Ok(patches_end_idx) =
+                usize::try_from(base_offset_end - chunk_offsets[0] - offset_within_chunk)
+            else {
+                vortex_panic!("patches_end_idx failed to convert to usize")
+            };
+
+            patches_end_idx
+        } else {
+            self.indices.len()
+        };
+
+        let Some(offset) = T::from(self.offset) else {
+            // If the offset cannot be converted to T, it's larger than all values in this array.
+            return SearchResult::NotFound(indices.len());
+        };
+
+        let chunk_indices = &indices[patches_start_idx..patches_end_idx];
+        let result = chunk_indices.search_sorted(&(index + offset), SearchSortedSide::Left);
 
         match result {
             SearchResult::Found(idx) => SearchResult::Found(patches_start_idx + idx),
@@ -593,32 +695,89 @@ impl Patches {
         take_indices: PrimitiveArray,
         include_nulls: bool,
     ) -> VortexResult<Option<Self>> {
-        let indices = self.indices.to_primitive();
-        let new_length = take_indices.len();
+        let take_indices_validity = take_indices.validity();
+        let patch_indices = self.indices.to_primitive();
+        let chunk_offsets = self.chunk_offsets().as_ref().map(|co| co.to_primitive());
 
-        let Some((new_indices, values_indices)) =
-            match_each_unsigned_integer_ptype!(indices.ptype(), |Indices| {
-                match_each_integer_ptype!(take_indices.ptype(), |TakeIndices| {
-                    take_search_inner::<_, TakeIndices>(
-                        indices.as_slice::<Indices>(),
-                        take_indices,
-                        self.offset(),
-                        include_nulls,
-                    )?
-                })
-            })
-        else {
+        let (values_indices, new_indices): (BufferMut<u64>, BufferMut<u64>) =
+            match_each_unsigned_integer_ptype!(patch_indices.ptype(), |PatchT| {
+                let patch_indices_slice = patch_indices.as_slice::<PatchT>();
+
+                let take = |search_fn: &dyn Fn(PatchT) -> SearchResult| {
+                    match_each_integer_ptype!(take_indices.ptype(), |TakeT| {
+                        take_indices
+                            .as_slice::<TakeT>()
+                            .iter()
+                            .enumerate()
+                            .filter_map(|(new_patch_idx, &take_idx)| {
+                                if include_nulls && take_indices_validity.is_null(new_patch_idx) {
+                                    // For nulls, patch index doesn't matter - use 0 for consistency
+                                    Some((0u64, new_patch_idx as u64))
+                                } else {
+                                    let search_result = PatchT::try_from(take_idx)
+                                        .map(|converted_take_idx| search_fn(converted_take_idx))
+                                        .unwrap_or(SearchResult::NotFound(
+                                            patch_indices_slice.len(),
+                                        ));
+
+                                    search_result
+                                        .to_found()
+                                        .map(|patch_idx| (patch_idx as u64, new_patch_idx as u64))
+                                }
+                            })
+                            .unzip()
+                    })
+                };
+
+                if let Some(chunk_offsets) = chunk_offsets {
+                    match_each_unsigned_integer_ptype!(chunk_offsets.ptype(), |OffsetT| {
+                        let chunk_offsets_slice = chunk_offsets.as_slice::<OffsetT>();
+                        take(&|take_idx| {
+                            self.search_index_batch(
+                                patch_indices_slice,
+                                Some(chunk_offsets_slice),
+                                take_idx,
+                            )
+                        })
+                    })
+                } else {
+                    take(&|take_idx| {
+                        self.search_index_batch(
+                            patch_indices_slice,
+                            Option::<&[u8]>::None,
+                            take_idx,
+                        )
+                    })
+                }
+            });
+
+        if new_indices.is_empty() {
             return Ok(None);
-        };
+        }
+
+        let new_indices = new_indices.into_array();
+        let new_array_len = take_indices.len();
+        let num_chunks = new_array_len.div_ceil(PATCH_CHUNK_SIZE);
+        let values_validity = take_indices_validity.take(&new_indices)?;
+
+        // Indices are rewritten during take such that they are strictly
+        // monotonically increasing, starting from 0. Therefore, we know
+        // that there's 1024 entries per chunk, except for the last.
+        let mut chunk_offsets_buf = BufferMut::<u64>::with_capacity(num_chunks);
+        for chunk_idx in 0..num_chunks {
+            chunk_offsets_buf.push((chunk_idx * PATCH_CHUNK_SIZE) as u64);
+        }
 
         Ok(Some(Self {
-            array_len: new_length,
+            array_len: new_array_len,
             offset: 0,
             indices: new_indices.clone(),
-            values: take(self.values(), &values_indices)?,
-            // TODO(0ax1): Chunk offsets are invalid after take is applied.
-            chunk_offsets: None,
-            offset_within_chunk: self.offset_within_chunk,
+            values: take(
+                self.values(),
+                &PrimitiveArray::new(values_indices, values_validity).into_array(),
+            )?,
+            chunk_offsets: Some(chunk_offsets_buf.into_array()),
+            offset_within_chunk: Some(0), // Reset when creating new Patches.
         }))
     }
 
@@ -682,52 +841,6 @@ impl Patches {
             offset_within_chunk: self.offset_within_chunk,
         })
     }
-}
-
-fn take_search_inner<I: IntegerPType, T: IntegerPType>(
-    indices: &[I],
-    take_indices: PrimitiveArray,
-    indices_offset: usize,
-    include_nulls: bool,
-) -> VortexResult<Option<(ArrayRef, ArrayRef)>>
-where
-    usize: TryFrom<T>,
-    VortexError: From<<usize as TryFrom<T>>::Error>,
-{
-    let take_indices_validity = take_indices.validity();
-    let indices_offset = I::from(indices_offset).vortex_expect("indices_offset out of range");
-
-    let (values_indices, new_indices): (BufferMut<u64>, BufferMut<u64>) = take_indices
-        .as_slice::<T>()
-        .iter()
-        .enumerate()
-        .filter_map(|(i, &v)| {
-            I::from(v)
-                .and_then(|v| {
-                    // If we have to take nulls the take index doesn't matter, make it 0 for consistency
-                    if include_nulls && take_indices_validity.is_null(i) {
-                        Some(0)
-                    } else {
-                        indices
-                            .search_sorted(&(v + indices_offset), SearchSortedSide::Left)
-                            .to_found()
-                            .map(|patch_idx| patch_idx as u64)
-                    }
-                })
-                .map(|patch_idx| (patch_idx, i as u64))
-        })
-        .unzip();
-
-    if new_indices.is_empty() {
-        return Ok(None);
-    }
-
-    let new_indices = new_indices.into_array();
-    let values_validity = take_indices_validity.take(&new_indices)?;
-    Ok(Some((
-        new_indices,
-        PrimitiveArray::new(values_indices, values_validity).into_array(),
-    )))
 }
 
 fn take_map<I: NativePType + Hash + Eq + TryFrom<usize>, T: NativePType>(
@@ -888,8 +1001,7 @@ fn filter_patches_with_mask<T: IntegerPType>(
 
 #[cfg(test)]
 mod test {
-    use rstest::{fixture, rstest};
-    use vortex_buffer::buffer;
+    use vortex_buffer::{BufferMut, buffer};
     use vortex_mask::Mask;
 
     use crate::arrays::PrimitiveArray;
@@ -919,19 +1031,16 @@ mod test {
         assert_eq!(values.as_slice::<i32>(), &[100, 200]);
     }
 
-    #[fixture]
-    fn patches() -> Patches {
-        Patches::new(
+    #[test]
+    fn take_with_nulls() {
+        let patches = Patches::new(
             20,
             0,
             buffer![2u64, 9, 15].into_array(),
             PrimitiveArray::new(buffer![33_i32, 44, 55], Validity::AllValid).into_array(),
             None,
-        )
-    }
+        );
 
-    #[rstest]
-    fn take_with_nulls(patches: Patches) {
         let taken = patches
             .take(
                 &PrimitiveArray::new(buffer![9, 0], Validity::from_iter(vec![true, false]))
@@ -940,11 +1049,148 @@ mod test {
             .unwrap()
             .unwrap();
         let primitive_values = taken.values().to_primitive();
+        let primitive_indices = taken.indices().to_primitive();
         assert_eq!(taken.array_len(), 2);
         assert_eq!(primitive_values.as_slice::<i32>(), [44]);
+        assert_eq!(primitive_indices.as_slice::<u64>(), [0]);
         assert_eq!(
             primitive_values.validity_mask(),
             Mask::from_iter(vec![true])
+        );
+    }
+
+    #[test]
+    fn take_search_with_nulls_chunked() {
+        let patches = Patches::new(
+            20,
+            0,
+            buffer![2u64, 9, 15].into_array(),
+            buffer![33_i32, 44, 55].into_array(),
+            Some(buffer![0u64].into_array()),
+        );
+
+        let taken = patches
+            .take_search(
+                PrimitiveArray::new(buffer![9, 0], Validity::from_iter([true, false])),
+                true,
+            )
+            .unwrap()
+            .unwrap();
+
+        let primitive_values = taken.values().to_primitive();
+        let primitive_indices = taken.indices().to_primitive();
+        assert_eq!(taken.array_len(), 2);
+        assert_eq!(primitive_values.as_slice::<i32>(), [44, 33]);
+        assert_eq!(primitive_indices.as_slice::<u64>(), [0, 1]);
+
+        assert_eq!(
+            primitive_values.validity_mask(),
+            Mask::from_iter([true, false])
+        );
+
+        let chunk_offsets = taken.chunk_offsets().as_ref().unwrap().to_primitive();
+        assert_eq!(chunk_offsets.as_slice::<u64>(), &[0]);
+    }
+
+    #[test]
+    fn take_search_chunked_multiple_chunks() {
+        let patches = Patches::new(
+            2048,
+            0,
+            buffer![100u64, 500, 1200, 1800].into_array(),
+            buffer![10_i32, 20, 30, 40].into_array(),
+            Some(buffer![0u64, 2].into_array()),
+        );
+
+        let taken = patches
+            .take_search(
+                PrimitiveArray::new(buffer![500, 1200, 999], Validity::AllValid),
+                true,
+            )
+            .unwrap()
+            .unwrap();
+
+        let primitive_values = taken.values().to_primitive();
+        assert_eq!(taken.array_len(), 3);
+        assert_eq!(primitive_values.as_slice::<i32>(), [20, 30]);
+
+        let chunk_offsets = taken.chunk_offsets().as_ref().unwrap().to_primitive();
+        assert_eq!(chunk_offsets.as_slice::<u64>(), &[0]);
+    }
+
+    #[test]
+    fn take_search_chunked_indices_with_no_patches() {
+        let patches = Patches::new(
+            20,
+            0,
+            buffer![2u64, 9, 15].into_array(),
+            buffer![33_i32, 44, 55].into_array(),
+            Some(buffer![0u64].into_array()),
+        );
+
+        let taken = patches
+            .take_search(
+                PrimitiveArray::new(buffer![3, 4, 5], Validity::AllValid),
+                true,
+            )
+            .unwrap();
+
+        assert!(taken.is_none());
+    }
+
+    #[test]
+    fn take_search_chunked_interleaved() {
+        let patches = Patches::new(
+            30,
+            0,
+            buffer![5u64, 10, 20, 25].into_array(),
+            buffer![100_i32, 200, 300, 400].into_array(),
+            Some(buffer![0u64].into_array()),
+        );
+
+        let taken = patches
+            .take_search(
+                PrimitiveArray::new(buffer![10, 15, 20, 99], Validity::AllValid),
+                true,
+            )
+            .unwrap()
+            .unwrap();
+
+        let primitive_values = taken.values().to_primitive();
+        assert_eq!(taken.array_len(), 4);
+        assert_eq!(primitive_values.as_slice::<i32>(), [200, 300]);
+
+        let chunk_offsets = taken.chunk_offsets().as_ref().unwrap().to_primitive();
+        assert_eq!(chunk_offsets.as_slice::<u64>(), &[0]);
+    }
+
+    #[test]
+    fn test_take_search_multiple_chunk_offsets() {
+        let patches = Patches::new(
+            1500,
+            0,
+            BufferMut::from_iter(0..1500u64).into_array(),
+            BufferMut::from_iter(0..1500i32).into_array(),
+            None,
+        );
+
+        let taken = patches
+            .take_search(
+                PrimitiveArray::new(BufferMut::from_iter(0..1500u64), Validity::AllValid),
+                false,
+            )
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(taken.array_len(), 1500);
+        assert_eq!(
+            taken
+                .chunk_offsets()
+                .as_ref()
+                .unwrap()
+                .to_primitive()
+                .as_slice::<u64>(),
+            &[0, 1024]
         );
     }
 


### PR DESCRIPTION
Note that the micro-benchmarks in `take_patches.rs` "regress" as we increase the array size to `65536`.