### PR TITLE
Fix: temporarily fix Arrow FixedSizeList bug

### DIFF
--- a/vortex-array/src/arrays/fixed_size_list/array.rs
+++ b/vortex-array/src/arrays/fixed_size_list/array.rs
@@ -111,16 +111,8 @@ impl FixedSizeListArray {
     ///
     /// # Errors
     ///
-    /// Returns an error if the inputs are invalid. The inputs are **valid** if:
-    ///
-    /// - The `list_size` is 0 and:
-    ///   - The `elements` array is empty.
-    ///   - The `len` is equal to the length of the `validity` map.
-    /// - The length of the `elements` array is a multiple of the size of the fixed-size lists
-    ///   (`list_size`).
-    /// - The `Validity` length (if it exists) times the `list_size` is equal to the length of the
-    ///   `elements` (or put another way, the length of the array divided by the size of each
-    ///   fixed-size list is equal to the length of the validity).
+    /// Returns an error if the provided components do not satisfy the invariants documented
+    /// in [`FixedSizeListArray::new_unchecked`].
     pub fn try_new(
         elements: ArrayRef,
         list_size: u32,
@@ -144,14 +136,11 @@ impl FixedSizeListArray {
     ///
     /// The inputs are **valid** if:
     ///
-    /// - The `list_size` is 0 and:
-    ///   - The `elements` array is empty.
-    ///   - The `len` is equal to the length of the `validity` map.
-    /// - The length of the `elements` array is a multiple of the size of the fixed-size lists
-    ///   (`list_size`).
     /// - The `Validity` length (if it exists) times the `list_size` is equal to the length of the
     ///   `elements` (or put another way, the length of the array divided by the size of each
     ///   fixed-size list is equal to the length of the validity).
+    /// - The length of the `elements` array is equal to the length of the outer array times the
+    ///   `list_size` (`elements.len() == list_size * len`).
     pub unsafe fn new_unchecked(
         elements: ArrayRef,
         list_size: u32,
@@ -183,24 +172,6 @@ impl FixedSizeListArray {
         list_size: u32,
         validity: &Validity,
     ) -> VortexResult<()> {
-        // A fixed-size list array where each list scalar is empty is completely useless, but we can
-        // support it regardless.
-        if list_size == 0 {
-            vortex_ensure!(
-                elements.is_empty() && validity.maybe_len().is_none_or(|vlen| vlen == len),
-                "an empty `FixedSizeList` should have no elements"
-            );
-            return Ok(());
-        }
-
-        let num_elements = elements.len();
-
-        vortex_ensure!(
-            len * list_size as usize == num_elements,
-            "the `elements` array has the incorrect number of elements to construct a \
-                `FixedSizeList[{list_size}] array of length {len}",
-        );
-
         // If a validity array is present, it must be the same length as the fixed-size list array.
         if let Some(validity_len) = validity.maybe_len() {
             vortex_ensure!(
@@ -208,6 +179,22 @@ impl FixedSizeListArray {
                 "validity with size {validity_len} does not match fixed-size list array size {len}",
             );
         }
+
+        // A fixed-size list array where each list scalar is empty is completely useless, but we can
+        // support it regardless.
+        if list_size == 0 {
+            vortex_ensure!(
+                elements.is_empty(),
+                "a degenerate (`list_size == 0`) `FixedSizeList` should have no underlying elements"
+            );
+            return Ok(());
+        }
+
+        vortex_ensure!(
+            len * list_size as usize == elements.len(),
+            "the `elements` array has the incorrect number of elements to construct a \
+                `FixedSizeList[{list_size}] array of length {len}",
+        );
 
         Ok(())
     }

--- a/vortex-array/src/arrays/fixed_size_list/tests/degenerate.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/degenerate.rs
@@ -283,12 +283,9 @@ fn test_fsl_size_0_validation() {
             len,
         );
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("empty `FixedSizeList` should have no elements")
-        );
+        assert!(result.unwrap_err().to_string().contains(
+            "a degenerate (`list_size == 0`) `FixedSizeList` should have no underlying elements"
+        ));
     }
 
     // Should succeed: validity length matches array length.

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -121,7 +121,8 @@ impl ListViewArray {
     ///
     /// # Errors
     ///
-    /// Returns an error if the provided components do not satisfy the invariants.
+    /// Returns an error if the provided components do not satisfy the invariants documented
+    /// in [`ListViewArray::new_unchecked`].
     pub fn try_new(
         elements: ArrayRef,
         offsets: ArrayRef,

--- a/vortex-array/src/arrow/compute/to_arrow/canonical.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/canonical.rs
@@ -17,6 +17,7 @@ use arrow_array::{
     PrimitiveArray as ArrowPrimitiveArray, StructArray as ArrowStructArray,
 };
 use arrow_buffer::{ScalarBuffer, i256};
+use arrow_data::ArrayData;
 use arrow_schema::{DataType, Field, FieldRef, Fields};
 use itertools::Itertools;
 use num_traits::{AsPrimitive, ToPrimitive};
@@ -538,12 +539,28 @@ fn to_arrow_fixed_size_list(
     };
     let nulls = array.validity_mask().to_null_buffer();
 
-    Ok(Arc::new(ArrowFixedSizeListArray::new(
-        element_field,
-        list_size,
-        values,
-        nulls,
-    )))
+    // TODO(connor): Revert this once the issue below is resolved.
+    // Ok(Arc::new(ArrowFixedSizeListArray::new(
+    //     element_field,
+    //     list_size,
+    //     values,
+    //     nulls,
+    // )))
+
+    // Build ArrayData directly to avoid the length calculation bug in try_new.
+    // See: https://github.com/apache/arrow-rs/issues/8623
+    let data_type = DataType::FixedSizeList(element_field, list_size);
+    let list_data = ArrayData::builder(data_type)
+        .len(array.len())
+        .add_child_data(values.into_data())
+        .nulls(nulls)
+        .build()?;
+
+    let arrow_array = ArrowFixedSizeListArray::from(list_data);
+
+    assert_eq!(array.len(), arrow_array.len());
+
+    Ok(Arc::new(arrow_array))
 }
 
 fn to_arrow_varbinview<T: ByteViewType>(array: VarBinViewArray) -> VortexResult<ArrowArrayRef> {


### PR DESCRIPTION
A temporary fix for https://github.com/apache/arrow-rs/issues/8623. We just use the `From<ArrayData>` implementation instead of `try_new`.

Also cleans up some other things.

(Fixes the fuzzer issues for now so it will not get blocked on this)