### PR TITLE
feat: GithubArchive benchmark for nested data

### DIFF
--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -66,12 +66,18 @@ on:
               "id": "statpopgen",
               "subcommand": "statpopgen",
               "name": "Statistical and Population Genetics",
-              "local_dir": "bench-vortex/data/statpopgen",
               "targets": "duckdb:parquet,duckdb:vortex,duckdb:vortex-compact",
               "scale_factor": "--scale-factor 100"
             },
             {
               "id": "fineweb",
+              "subcommand": "fineweb",
+              "name": "FineWeb",
+              "targets": "duckdb:parquet,duckdb:vortex,duckdb:vortex-compact,datafusion:parquet,datafusion:vortex,datafusion:vortex-compact",
+              "scale_factor": "--scale-factor 100"
+            },
+            {
+              "id": "fineweb-s3",
               "subcommand": "fineweb",
               "name": "FineWeb",
               "local_dir": "bench-vortex/data/fineweb",
@@ -80,9 +86,16 @@ on:
               "scale_factor": "--scale-factor 100"
             },
             {
-              "id": "gharchive",
+              "id": "gharchive-nvme",
               "subcommand": "gharchive",
-              "name": "GitHub Archive",
+              "name": "GitHub Archive (NVMe)",
+              "targets": "duckdb:parquet,duckdb:vortex,duckdb:vortex-compact,datafusion:parquet,datafusion:vortex,datafusion:vortex-compact",
+              "scale_factor": "--scale-factor 100"
+            },
+            {
+              "id": "gharchive-s3",
+              "subcommand": "gharchive",
+              "name": "GitHub Archive (S3)",
               "local_dir": "bench-vortex/data/gharchive",
               "remote_storage": "s3://vortex-bench-dev-eu/${{github.ref_name}}/gharchive/",
               "targets": "duckdb:parquet,duckdb:vortex,duckdb:vortex-compact,datafusion:parquet,datafusion:vortex,datafusion:vortex-compact",

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -72,14 +72,14 @@ on:
             {
               "id": "fineweb",
               "subcommand": "fineweb",
-              "name": "FineWeb",
+              "name": "FineWeb NVMe",
               "targets": "duckdb:parquet,duckdb:vortex,duckdb:vortex-compact,datafusion:parquet,datafusion:vortex,datafusion:vortex-compact",
               "scale_factor": "--scale-factor 100"
             },
             {
               "id": "fineweb-s3",
               "subcommand": "fineweb",
-              "name": "FineWeb",
+              "name": "FineWeb S3",
               "local_dir": "bench-vortex/data/fineweb",
               "remote_storage": "s3://vortex-bench-dev-eu/${{github.ref_name}}/fineweb/",
               "targets": "duckdb:parquet,duckdb:vortex,duckdb:vortex-compact,datafusion:parquet,datafusion:vortex,datafusion:vortex-compact",

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -75,6 +75,16 @@ on:
               "subcommand": "fineweb",
               "name": "FineWeb",
               "local_dir": "bench-vortex/data/fineweb",
+              "remote_storage": "s3://vortex-bench-dev-eu/${{github.ref_name}}/fineweb/",
+              "targets": "duckdb:parquet,duckdb:vortex,duckdb:vortex-compact,datafusion:parquet,datafusion:vortex,datafusion:vortex-compact",
+              "scale_factor": "--scale-factor 100"
+            },
+            {
+              "id": "gharchive",
+              "subcommand": "gharchive",
+              "name": "GitHub Archive",
+              "local_dir": "bench-vortex/data/gharchive",
+              "remote_storage": "s3://vortex-bench-dev-eu/${{github.ref_name}}/gharchive/",
               "targets": "duckdb:parquet,duckdb:vortex,duckdb:vortex-compact,datafusion:parquet,datafusion:vortex,datafusion:vortex-compact",
               "scale_factor": "--scale-factor 100"
             },

--- a/bench-vortex/src/bin/query_bench.rs
+++ b/bench-vortex/src/bin/query_bench.rs
@@ -7,6 +7,7 @@ use bench_vortex::benchmark_driver::{DriverConfig, run_benchmark};
 use bench_vortex::clickbench::{ClickBenchBenchmark, Flavor};
 use bench_vortex::display::DisplayFormat;
 use bench_vortex::fineweb::Fineweb;
+use bench_vortex::realnest::gharchive::GithubArchive;
 use bench_vortex::statpopgen::StatPopGenBenchmark;
 use bench_vortex::tpcds::TpcDsBenchmark;
 use bench_vortex::tpch::tpch_benchmark::TpcHBenchmark;
@@ -41,6 +42,9 @@ enum Commands {
 
     #[command(name = "fineweb")]
     Fineweb(FinewebArgs),
+
+    #[command(name = "gharchive")]
+    GhArchive(GhArchiveArgs),
 }
 
 /// Common arguments shared across benchmarks
@@ -228,6 +232,28 @@ struct FinewebArgs {
     scale_factor: u64,
 }
 
+#[derive(Parser, Debug)]
+struct GhArchiveArgs {
+    #[command(flatten)]
+    common: CommonArgs,
+
+    #[arg(long, value_delimiter = ',', value_parser = value_parser!(Target),
+        default_values = vec![
+              "duckdb:parquet",
+              "duckdb:vortex",
+              "duckdb:vortex-compact",
+              "datafusion:parquet",
+              "datafusion:vortex",
+              "datafusion:vortex-compact",
+          ]
+    )]
+    targets: Vec<Target>,
+
+    // Dummy, unused but we are required to accept it to make the CI automation happy
+    #[arg(long)]
+    scale_factor: u64,
+}
+
 fn validate_scale_factor(val: &str) -> Result<String, String> {
     match val.parse::<f32>() {
         Ok(n) if [0.01, 0.1, 1., 10., 100., 1000.].contains(&n) => {
@@ -257,6 +283,7 @@ fn main() -> anyhow::Result<()> {
         Commands::TpcDS(tpcds_args) => run_tpcds(tpcds_args),
         Commands::StatPopGen(stat_pop_gen_args) => run_statpopgen(stat_pop_gen_args),
         Commands::Fineweb(fineweb_args) => run_fineweb(fineweb_args),
+        Commands::GhArchive(gh_archive_args) => run_gharchive(gh_archive_args),
     }
 }
 
@@ -402,6 +429,37 @@ fn run_fineweb(args: FinewebArgs) -> anyhow::Result<()> {
         .map_err(|_| anyhow::anyhow!("bad data path"))?;
 
     let benchmark = Fineweb::new(data_url);
+
+    let config = DriverConfig {
+        targets: args.targets,
+        iterations: args.common.iterations,
+        threads: args.common.threads,
+        display_format: args.common.display_format,
+        disable_datafusion_cache: args.common.disable_datafusion_cache,
+        delete_duckdb_database: args.common.delete_duckdb_database,
+        queries: args.common.queries,
+        exclude_queries: args.common.exclude_queries,
+        output_path: args.common.output_path,
+        emit_plan: args.common.emit_plan,
+        export_spans: args.common.export_spans,
+        show_metrics: args.common.show_metrics,
+        hide_progress_bar: args.common.hide_progress_bar,
+        track_memory: args.common.track_memory,
+        skip_generate: args.common.skip_generate,
+        explain: args.common.explain,
+        explain_analyze: args.common.explain_analyze,
+    };
+
+    run_benchmark(benchmark, config)
+}
+
+fn run_gharchive(args: GhArchiveArgs) -> anyhow::Result<()> {
+    setup_logging_and_tracing(args.common.verbose, args.common.tracing)?;
+
+    let data_url = Url::from_directory_path("gharchive".to_data_path())
+        .map_err(|_| anyhow::anyhow!("bad data path"))?;
+
+    let benchmark = GithubArchive::new(data_url);
 
     let config = DriverConfig {
         targets: args.targets,

--- a/bench-vortex/src/datasets/file.rs
+++ b/bench-vortex/src/datasets/file.rs
@@ -78,7 +78,8 @@ pub async fn register_vortex_files(
     match dataset {
         BenchmarkDataset::TpcH { .. }
         | BenchmarkDataset::TpcDS { .. }
-        | BenchmarkDataset::Fineweb => {
+        | BenchmarkDataset::Fineweb
+        | BenchmarkDataset::GhArchive => {
             info!(
                 "Registering table from {}, with glob {:?}",
                 &file_url,
@@ -161,6 +162,7 @@ pub async fn register_vortex_compact_files(
         BenchmarkDataset::PublicBi { .. } => todo!(),
         BenchmarkDataset::StatPopGen { .. } => todo!(),
         BenchmarkDataset::Fineweb => todo!(),
+        BenchmarkDataset::GhArchive => todo!(),
     }
 
     Ok(())

--- a/bench-vortex/src/datasets/mod.rs
+++ b/bench-vortex/src/datasets/mod.rs
@@ -13,6 +13,7 @@ use vortex::ArrayRef;
 use crate::clickbench::Flavor;
 #[cfg(feature = "lance")]
 use crate::file::register_lance_files;
+use crate::realnest::gharchive;
 use crate::{Format, clickbench, fineweb, statpopgen};
 
 pub mod data_downloads;
@@ -42,6 +43,8 @@ pub enum BenchmarkDataset {
     StatPopGen { n_rows: u64 },
     #[serde(rename = "fineweb")]
     Fineweb,
+    #[serde(rename = "gharchive")]
+    GhArchive,
 }
 
 impl BenchmarkDataset {
@@ -53,6 +56,7 @@ impl BenchmarkDataset {
             BenchmarkDataset::PublicBi { .. } => "public-bi",
             BenchmarkDataset::StatPopGen { .. } => "statpopgen",
             BenchmarkDataset::Fineweb => "fineweb",
+            BenchmarkDataset::GhArchive => "gharchive",
         }
     }
 }
@@ -69,6 +73,7 @@ impl Display for BenchmarkDataset {
             BenchmarkDataset::PublicBi { name } => write!(f, "public-bi({name})"),
             BenchmarkDataset::StatPopGen { n_rows } => write!(f, "statpopgen(n_rows={n_rows})"),
             BenchmarkDataset::Fineweb => write!(f, "fineweb"),
+            BenchmarkDataset::GhArchive => write!(f, "gharchive"),
         }
     }
 }
@@ -109,6 +114,7 @@ impl BenchmarkDataset {
             BenchmarkDataset::ClickBench { .. } | BenchmarkDataset::PublicBi { .. } => todo!(),
             BenchmarkDataset::StatPopGen { .. } => &["statpopgen"],
             BenchmarkDataset::Fineweb => &["fineweb"],
+            BenchmarkDataset::GhArchive => &["events"],
         }
     }
 
@@ -166,6 +172,9 @@ impl BenchmarkDataset {
             }
             (BenchmarkDataset::Fineweb, format) => {
                 fineweb::register_table(session, base_url, format).await?
+            }
+            (BenchmarkDataset::GhArchive, format) => {
+                gharchive::register_table(session, base_url, format).await?
             }
         }
 

--- a/bench-vortex/src/engines/ddb/mod.rs
+++ b/bench-vortex/src/engines/ddb/mod.rs
@@ -52,6 +52,7 @@ impl DuckDBCtx {
                 format!("statpopgen/{n_rows}/{}", format.name()).to_data_path()
             }
             BenchmarkDataset::Fineweb => format!("fineweb/{}", format.name()).to_data_path(),
+            BenchmarkDataset::GhArchive => format!("gharchive/{}", format.name()).to_data_path(),
         };
         std::fs::create_dir_all(&dir)?;
         let db_path = dir.join("duckdb.db");
@@ -256,6 +257,13 @@ impl DuckDBCtx {
                 let path = format!("{base_dir}*.{extension}");
                 format!(
                     "CREATE {} IF NOT EXISTS fineweb AS SELECT * FROM read_{extension}('{path}');",
+                    duckdb_object.to_str(),
+                )
+            }
+            BenchmarkDataset::GhArchive => {
+                let path = format!("{base_dir}*.{extension}");
+                format!(
+                    "CREATE {} IF NOT EXISTS events AS SELECT * FROM read_{extension}('{path}');",
                     duckdb_object.to_str(),
                 )
             }

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -34,6 +34,7 @@ pub mod metrics;
 pub mod public_bi;
 pub mod query_bench;
 pub mod random_access;
+pub mod realnest;
 pub mod statpopgen;
 pub mod tpcds;
 pub mod tpch;

--- a/bench-vortex/src/realnest/gharchive.rs
+++ b/bench-vortex/src/realnest/gharchive.rs
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Data from the GitHub Archive.
+//!
+//! This dataset applies a bunch of events this way
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Arc;
+
+use datafusion::datasource::file_format::parquet::ParquetFormat;
+use datafusion::datasource::listing::{
+    ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
+};
+use datafusion::prelude::SessionContext;
+use futures::StreamExt;
+use log::info;
+use parquet::arrow::async_writer::AsyncFileWriter;
+use url::Url;
+use vortex::compressor::CompactCompressor;
+use vortex::file::{VortexWriteOptions, WriteStrategyBuilder};
+use vortex_datafusion::VortexFormat;
+
+use crate::benchmark_trait::Benchmark;
+use crate::conversions::parquet_to_vortex;
+use crate::engines::EngineCtx;
+use crate::{BenchmarkDataset, Format, Target, idempotent, idempotent_async};
+
+const JSON_URL: &str = "https://data.gharchive.org/2024-10-01-1.json.gz";
+
+const QUERIES: &[&str] = &[
+    "select * from events where payload.ref = 'refs/heads/main'",
+    "select distinct org.id as org_id from events order by org_id limit 100",
+    "select actor.login, count() as freq from events group by actor.login order by freq desc limit 10",
+    "select actor.avatar_url from events where actor.login = 'renovate[bot]'",
+];
+
+pub struct GithubArchive {
+    data_url: Url,
+}
+
+impl GithubArchive {
+    pub fn new(data_url: Url) -> Self {
+        Self { data_url }
+    }
+}
+
+impl GithubArchive {
+    fn json_path(&self) -> anyhow::Result<PathBuf> {
+        self.data_url
+            .join("json/")?
+            .join("events.json.gz")?
+            .to_file_path()
+            .map_err(|_| anyhow::anyhow!("Failed to convert data URL to filesystem path - ensure data_url uses 'file://' scheme"))
+    }
+
+    fn parquet_path(&self) -> anyhow::Result<PathBuf> {
+        self.data_url
+            .join("parquet/")?
+            .join("events.parquet")?
+            .to_file_path()
+            .map_err(|_| anyhow::anyhow!("Failed to convert data URL to filesystem path - ensure data_url uses 'file://' scheme"))
+    }
+
+    fn vortex_path(&self) -> anyhow::Result<PathBuf> {
+        self.data_url
+            .join("vortex-file-compressed/")?
+            .join("events.vortex")?
+            .to_file_path()
+            .map_err(|_| anyhow::anyhow!("Failed to convert data URL to filesystem path - ensure data_url uses 'file://' scheme"))
+    }
+
+    fn vortex_compact_path(&self) -> anyhow::Result<PathBuf> {
+        self.data_url
+            .join("vortex-compact/")?
+            .join("events.vortex")?
+            .to_file_path()
+            .map_err(|_| anyhow::anyhow!("Failed to convert data URL to filesystem path - ensure data_url uses 'file://' scheme"))
+    }
+}
+
+impl Benchmark for GithubArchive {
+    fn queries(&self) -> anyhow::Result<Vec<(usize, String)>> {
+        Ok(QUERIES
+            .iter()
+            .map(|s| (s.to_string()))
+            .enumerate()
+            .collect())
+    }
+
+    fn generate_data(&self, target: &Target) -> anyhow::Result<()> {
+        // Before downloading anything, make sure we are using a supported target.
+        anyhow::ensure!(
+            matches!(
+                target.format,
+                Format::Parquet | Format::OnDiskVortex | Format::VortexCompact
+            ),
+            "unsupported format for `fineweb` bench: {}",
+            target.format
+        );
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()?;
+
+        // Write the JSON data to disk
+        let json = rt.block_on(idempotent_async(
+            &self.json_path()?,
+            |json_path| async move {
+                info!("Downloading GithubArchive JSON source");
+                // Download the file from HuggingFace snapshot
+                let client = reqwest::Client::new();
+                let response = client
+                    .get(JSON_URL)
+                    .send()
+                    .await?
+                    .error_for_status()
+                    .map_err(|err| anyhow::anyhow!("error fetching gharchive data: {err}"))?;
+
+                // On success, stream the response body to file.
+                let mut bytes = response.bytes_stream();
+                let mut w = tokio::fs::File::create(json_path).await?;
+
+                while let Some(next) = bytes.next().await {
+                    let chunk = next?;
+                    w.write(chunk).await?;
+                }
+
+                Ok(())
+            },
+        ))?;
+
+        let json_path = json.display().to_string();
+
+        let parquet = idempotent(&self.parquet_path()?, move |parquet_path| {
+            let parquet = parquet_path.display().to_string();
+            info!(
+                "Converting GithubArchive JSON to Parquet with DuckDB @ {}",
+                parquet_path.display()
+            );
+            let result = Command::new("duckdb")
+                    .arg("-c")
+                    .arg(format!("
+                    CREATE TABLE events AS select * from read_ndjson_auto('{json_path}', ignore_errors = true);
+                    COPY events TO '{parquet}' (FORMAT parquet);
+                    "))
+                    .spawn()?
+                    .wait()?;
+
+            if !result.success() {
+                anyhow::bail!("DuckDB subprocess failed converting JSON to Parquet");
+            }
+
+            Ok(())
+        })?;
+
+        let target_path = match target.format {
+            Format::Parquet => parquet,
+            Format::OnDiskVortex => rt.block_on(idempotent_async(
+                &self.vortex_path()?,
+                |vortex_path| async move {
+                    info!("Converting Parquet to Vortex with default compressor");
+                    let array_stream = parquet_to_vortex(parquet)?;
+                    let w = tokio::fs::File::create(vortex_path).await?;
+                    VortexWriteOptions::default()
+                        .write(w, array_stream)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("Failed to write to VortexWriter: {e}"))
+                },
+            ))?,
+            Format::VortexCompact => rt.block_on(idempotent_async(
+                &self.vortex_compact_path()?,
+                |vortex_path| async move {
+                    info!("Converting FineWeb to Vortex with Compact compressor");
+                    let array_stream = parquet_to_vortex(parquet)?;
+                    let w = tokio::fs::File::create(vortex_path).await?;
+                    VortexWriteOptions::default()
+                        .with_strategy(
+                            WriteStrategyBuilder::new()
+                                .with_compressor(CompactCompressor::default())
+                                .build(),
+                        )
+                        .write(w, array_stream)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("Failed to write to VortexWriter: {e}"))
+                },
+            ))?,
+            _ => anyhow::bail!("unsupported format for `gharchive` bench"),
+        };
+
+        info!("gharchive data generated in {}", target_path.display());
+
+        Ok(())
+    }
+
+    async fn register_tables(&self, engine_ctx: &EngineCtx, format: Format) -> anyhow::Result<()> {
+        let dataset = self.dataset();
+
+        match engine_ctx {
+            EngineCtx::DataFusion(ctx) => {
+                dataset
+                    .register_tables(&ctx.session, &self.data_url, format)
+                    .await
+            }
+            EngineCtx::DuckDB(ctx) => ctx.register_tables(&self.data_url, format, &dataset),
+        }
+    }
+
+    fn dataset(&self) -> BenchmarkDataset {
+        BenchmarkDataset::GhArchive
+    }
+
+    fn dataset_name(&self) -> &str {
+        "gharchive"
+    }
+
+    fn dataset_display(&self) -> String {
+        "gharchive".to_owned()
+    }
+
+    fn data_url(&self) -> &Url {
+        &self.data_url
+    }
+}
+
+pub async fn register_table(
+    session: &SessionContext,
+    base_url: &Url,
+    format: Format,
+) -> anyhow::Result<()> {
+    let table_path = base_url.join(&format!("{}/", format))?;
+    info!("registering table for GHARCHIVE: {table_path}");
+    let table_url = ListingTableUrl::try_new(table_path, None)?;
+    let config = ListingTableConfig::new(table_url)
+        .with_listing_options(
+            ListingOptions::new(match format {
+                Format::Parquet => Arc::from(ParquetFormat::new()),
+                Format::OnDiskVortex | Format::VortexCompact => Arc::from(VortexFormat::default()),
+                _ => anyhow::bail!("unsupported format for `gharchive` bench: {}", format),
+            })
+            .with_session_config_options(session.state().config()),
+        )
+        .infer_schema(&session.state())
+        .await?;
+    let listing_table = Arc::new(ListingTable::try_new(config)?);
+    session.register_table("events", listing_table)?;
+    Ok(())
+}

--- a/bench-vortex/src/realnest/gharchive.rs
+++ b/bench-vortex/src/realnest/gharchive.rs
@@ -35,6 +35,7 @@ fn raw_json_url(hour: usize) -> String {
 
 const QUERIES: &[&str] = &[
     "select * from events where payload.ref = 'refs/heads/main'",
+    "select distinct repo.name from events where repo.name like 'spiraldb/%'",
     "select distinct org.id as org_id from events order by org_id limit 100",
     "select actor.login, count() as freq from events group by actor.login order by freq desc limit 10",
     "select actor.avatar_url from events where actor.login = 'renovate[bot]'",

--- a/bench-vortex/src/realnest/gharchive.rs
+++ b/bench-vortex/src/realnest/gharchive.rs
@@ -27,7 +27,11 @@ use crate::conversions::parquet_to_vortex;
 use crate::engines::EngineCtx;
 use crate::{BenchmarkDataset, Format, Target, idempotent, idempotent_async};
 
-const JSON_URL: &str = "https://data.gharchive.org/2024-10-01-1.json.gz";
+/// Template URL for raw JSON dataset
+fn raw_json_url(hour: usize) -> String {
+    assert!(hour <= 23);
+    format!("https://data.gharchive.org/2024-10-01-{hour}.json.gz")
+}
 
 const QUERIES: &[&str] = &[
     "select * from events where payload.ref = 'refs/heads/main'",
@@ -108,23 +112,26 @@ impl Benchmark for GithubArchive {
         let json = rt.block_on(idempotent_async(
             &self.json_path()?,
             |json_path| async move {
-                info!("Downloading GithubArchive JSON source");
-                // Download the file from HuggingFace snapshot
-                let client = reqwest::Client::new();
-                let response = client
-                    .get(JSON_URL)
-                    .send()
-                    .await?
-                    .error_for_status()
-                    .map_err(|err| anyhow::anyhow!("error fetching gharchive data: {err}"))?;
-
-                // On success, stream the response body to file.
-                let mut bytes = response.bytes_stream();
+                info!("Downloading GithubArchive JSON source files");
+                // Download the files from gharchive.
+                // They are all gzipped, so they can be concatenated into a single output file.
                 let mut w = tokio::fs::File::create(json_path).await?;
+                let client = reqwest::Client::new();
+                for hour in 0..=23 {
+                    let url = raw_json_url(hour);
+                    info!("Downloading archive {url}");
+                    let response = client
+                        .get(url)
+                        .send()
+                        .await?
+                        .error_for_status()
+                        .map_err(|err| anyhow::anyhow!("error fetching gharchive data: {err}"))?;
+                    let mut bytes = response.bytes_stream();
 
-                while let Some(next) = bytes.next().await {
-                    let chunk = next?;
-                    w.write(chunk).await?;
+                    while let Some(next) = bytes.next().await {
+                        let chunk = next?;
+                        w.write(chunk).await?;
+                    }
                 }
 
                 Ok(())

--- a/bench-vortex/src/realnest/mod.rs
+++ b/bench-vortex/src/realnest/mod.rs
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+pub mod gharchive;

--- a/vortex-array/src/arrow/record_batch.rs
+++ b/vortex-array/src/arrow/record_batch.rs
@@ -1,18 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::sync::Arc;
-
 use arrow_array::RecordBatch;
 use arrow_array::cast::AsArray;
-use vortex_error::{VortexError, VortexResult, vortex_bail};
-use vortex_mask::Mask;
+use vortex_error::{VortexError, VortexResult, vortex_bail, vortex_ensure};
 
 use crate::arrow::compute::to_arrow_preferred;
-use crate::compute::filter;
-use crate::validity::Validity;
-use crate::vtable::ValidityHelper;
-use crate::{Array, Canonical, ToCanonical};
+use crate::{Array, Canonical};
 
 impl TryFrom<&dyn Array> for RecordBatch {
     type Error = VortexError;
@@ -21,26 +15,13 @@ impl TryFrom<&dyn Array> for RecordBatch {
         let Canonical::Struct(struct_array) = value.to_canonical() else {
             vortex_bail!("RecordBatch can only be constructed from ")
         };
-        // If there are any top-level nulls, mask them from the result.
-        match struct_array.validity() {
-            // Easy
-            Validity::NonNullable | Validity::AllValid => Ok(RecordBatch::from(
-                to_arrow_preferred(struct_array.as_ref())?.as_struct(),
-            )),
-            Validity::AllInvalid => {
-                // New empty struct array
-                let schema = Arc::new(value.dtype().to_arrow_schema()?);
-                Ok(RecordBatch::new_empty(schema))
-            }
-            Validity::Array(validity) => {
-                // Create new ones here instead
-                let valid = Mask::from_buffer(validity.to_bool().boolean_buffer().clone());
-                let masked = filter(value, &valid)?;
 
-                Ok(RecordBatch::from(
-                    to_arrow_preferred(masked.as_ref())?.as_struct(),
-                ))
-            }
-        }
+        vortex_ensure!(
+            struct_array.all_valid(),
+            "RecordBatch can only be constructed from StructArray with no nulls"
+        );
+
+        let array_ref = to_arrow_preferred(struct_array.as_ref())?;
+        Ok(RecordBatch::from(array_ref.as_struct()))
     }
 }

--- a/vortex-array/src/arrow/record_batch.rs
+++ b/vortex-array/src/arrow/record_batch.rs
@@ -1,32 +1,46 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::sync::Arc;
+
 use arrow_array::RecordBatch;
 use arrow_array::cast::AsArray;
-use arrow_schema::{DataType, Schema};
-use vortex_error::{VortexError, VortexResult};
+use vortex_error::{VortexError, VortexResult, vortex_bail};
+use vortex_mask::Mask;
 
-use crate::arrays::StructArray;
-use crate::arrow::compute::{to_arrow, to_arrow_preferred};
-use crate::{Array, ToCanonical};
+use crate::arrow::compute::to_arrow_preferred;
+use crate::compute::filter;
+use crate::validity::Validity;
+use crate::vtable::ValidityHelper;
+use crate::{Array, Canonical, ToCanonical};
 
 impl TryFrom<&dyn Array> for RecordBatch {
     type Error = VortexError;
 
     fn try_from(value: &dyn Array) -> VortexResult<Self> {
-        value.to_struct().into_record_batch()
-    }
-}
+        let Canonical::Struct(struct_array) = value.to_canonical() else {
+            vortex_bail!("RecordBatch can only be constructed from ")
+        };
+        // If there are any top-level nulls, mask them from the result.
+        match struct_array.validity() {
+            // Easy
+            Validity::NonNullable | Validity::AllValid => Ok(RecordBatch::from(
+                to_arrow_preferred(struct_array.as_ref())?.as_struct(),
+            )),
+            Validity::AllInvalid => {
+                // New empty struct array
+                let schema = Arc::new(value.dtype().to_arrow_schema()?);
+                Ok(RecordBatch::new_empty(schema))
+            }
+            Validity::Array(validity) => {
+                // Create new ones here instead
+                let valid = Mask::from_buffer(validity.to_bool().boolean_buffer().clone());
+                let masked = filter(value, &valid)?;
 
-impl StructArray {
-    pub fn into_record_batch(self) -> VortexResult<RecordBatch> {
-        let array_ref = to_arrow_preferred(self.as_ref())?;
-        Ok(RecordBatch::from(array_ref.as_struct()))
-    }
-
-    pub fn into_record_batch_with_schema(self, schema: &Schema) -> VortexResult<RecordBatch> {
-        let data_type = DataType::Struct(schema.fields.clone());
-        let array_ref = to_arrow(self.as_ref(), &data_type)?;
-        Ok(RecordBatch::from(array_ref.as_struct()))
+                Ok(RecordBatch::from(
+                    to_arrow_preferred(masked.as_ref())?.as_struct(),
+                ))
+            }
+        }
     }
 }

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -26,7 +26,9 @@ pub enum Validity {
     AllValid,
     /// All items are null
     AllInvalid,
-    /// Specified items are null
+    /// The validity of each position in the array is determined by a boolean array.
+    ///
+    /// True values are valid, false values are invalid ("null").
     Array(ArrayRef),
 }
 

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -5,6 +5,7 @@ use std::ops::Range;
 use std::sync::{Arc, Weak};
 
 use arrow_schema::{ArrowError, Field, SchemaRef};
+use datafusion_common::arrow::array::RecordBatch;
 use datafusion_common::{DataFusionError, Result as DFResult};
 use datafusion_datasource::file_meta::FileMeta;
 use datafusion_datasource::file_stream::{FileOpenFuture, FileOpener};
@@ -20,13 +21,13 @@ use futures::{FutureExt, StreamExt, TryStreamExt, stream};
 use object_store::ObjectStore;
 use object_store::path::Path;
 use tracing::Instrument;
+use vortex::ArrayRef;
 use vortex::dtype::FieldName;
 use vortex::error::VortexError;
 use vortex::expr::{root, select};
 use vortex::layout::LayoutReader;
 use vortex::metrics::VortexMetrics;
 use vortex::scan::ScanBuilder;
-use vortex::{ArrayRef, ToCanonical};
 use vortex_utils::aliases::dash_map::{DashMap, Entry};
 
 use super::cache::VortexFileCache;
@@ -229,7 +230,7 @@ impl FileOpener for VortexOpener {
                 .with_projection(projection_expr)
                 .with_some_filter(filter)
                 .with_ordered(has_output_ordering)
-                .map(|chunk| chunk.to_struct().into_record_batch())
+                .map(|chunk| RecordBatch::try_from(chunk.as_ref()))
                 .into_stream()
                 .map_err(|e| {
                     DataFusionError::Execution(format!("Failed to create Vortex stream: {e}"))

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -5,10 +5,9 @@ use std::collections::BTreeSet;
 use std::ops::Range;
 use std::sync::Arc;
 
-use futures::future::BoxFuture;
 use itertools::Itertools;
+use vortex_array::MaskFuture;
 use vortex_array::stats::Precision;
-use vortex_array::{ArrayRef, MaskFuture};
 use vortex_dtype::{DType, FieldMask, FieldName, StructFields};
 use vortex_error::{VortexExpect, VortexResult, vortex_err};
 use vortex_expr::transform::immediate_access::annotate_scope_access;
@@ -23,7 +22,7 @@ use vortex_utils::aliases::hash_map::HashMap;
 use crate::layouts::partitioned::PartitionedExprEval;
 use crate::layouts::struct_::StructLayout;
 use crate::segments::SegmentSource;
-use crate::{LayoutReader, LayoutReaderRef, LazyReaderChildren};
+use crate::{ArrayFuture, LayoutReader, LayoutReaderRef, LazyReaderChildren};
 
 pub struct StructReader {
     layout: StructLayout,
@@ -235,7 +234,7 @@ impl LayoutReader for StructReader {
         row_range: &Range<u64>,
         expr: &ExprRef,
         mask: MaskFuture,
-    ) -> VortexResult<BoxFuture<'static, VortexResult<ArrayRef>>> {
+    ) -> VortexResult<ArrayFuture> {
         // Partition the expression into expressions that can be evaluated over individual fields
         match &self.partition_expr(expr.clone()) {
             Partitioned::Single(name, partition) => self


### PR DESCRIPTION
GithubArchive is an archival dataset of Github event logs, hosted at https://www.gharchive.org/.

It's also distributed as part of RealNest from CWI.

This is our first benchmark to test nested data access with Vortex.


I want to get this in before we merge #4942 or any other follow on work for nested data support.

TODOs:

- [x] Add more data files. Currently queries finish way too fast
- [x] Add a few more queries