### PR TITLE
feat: teach merge to optionally error on duplicates

### DIFF
--- a/vortex-expr/src/exprs/merge.rs
+++ b/vortex-expr/src/exprs/merge.rs
@@ -392,7 +392,8 @@ mod tests {
     }
 
     #[test]
-    pub fn test_merge_duplicate_flag() {
+    #[should_panic(expected = "merge: duplicate fields in children")]
+    pub fn test_merge_duplicate_flag_return_dtype() {
         let expr = MergeExpr::new_opts(
             vec![get_item("0", root()), get_item("1", root())],
             DuplicateHandling::Error,
@@ -410,25 +411,30 @@ mod tests {
         .unwrap()
         .into_array();
 
-        let actual = expr.return_dtype(test_array.dtype());
-        assert!(
-            actual.as_ref().is_err_and(|e| {
-                e.to_string()
-                    .contains("merge: duplicate fields in children")
-            }),
-            "{:?}",
-            actual
-        );
+        expr.return_dtype(test_array.dtype()).unwrap();
+    }
 
-        let actual = expr.evaluate(&Scope::new(test_array));
-        assert!(
-            actual.as_ref().is_err_and(|e| {
-                e.to_string()
-                    .contains("merge: duplicate fields in children")
-            }),
-            "{:?}",
-            actual
+    #[test]
+    #[should_panic(expected = "merge: duplicate fields in children")]
+    pub fn test_merge_duplicate_flag_evaluate() {
+        let expr = MergeExpr::new_opts(
+            vec![get_item("0", root()), get_item("1", root())],
+            DuplicateHandling::Error,
         );
+        let test_array = StructArray::try_from_iter([
+            (
+                "0",
+                StructArray::try_from_iter([("a", buffer![1]), ("b", buffer![1])]).unwrap(),
+            ),
+            (
+                "1",
+                StructArray::try_from_iter([("c", buffer![1]), ("b", buffer![1])]).unwrap(),
+            ),
+        ])
+        .unwrap()
+        .into_array();
+
+        expr.evaluate(&Scope::new(test_array)).unwrap();
     }
 
     #[test]

--- a/vortex-expr/src/exprs/merge.rs
+++ b/vortex-expr/src/exprs/merge.rs
@@ -36,9 +36,9 @@ pub struct MergeExpr {
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum DuplicateHandling {
     /// If two structs share a field name, take the value from the right-most struct.
-    #[default]
     RightMost,
     /// If two structs share a field name, error.
+    #[default]
     Error,
 }
 

--- a/vortex-expr/src/exprs/merge.rs
+++ b/vortex-expr/src/exprs/merge.rs
@@ -32,6 +32,12 @@ pub struct MergeExpr {
     duplicate_handling: DuplicateHandling,
 }
 
+impl MergeExpr {
+    pub fn duplicate_handling(&self) -> DuplicateHandling {
+        self.duplicate_handling
+    }
+}
+
 /// What to do when merged structs share a field name.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum DuplicateHandling {
@@ -99,39 +105,26 @@ impl VTable for MergeVTable {
     }
 
     fn evaluate(expr: &Self::Expr, scope: &Scope) -> VortexResult<ArrayRef> {
-        let len = scope.len();
-        let children = expr
-            .values
-            .iter()
-            .map(|value_expr| {
-                // TODO(marko): When nullable, we need to merge struct validity into field validity.
-                let array = value_expr.unchecked_evaluate(scope)?;
-                if array.dtype().is_nullable() {
-                    vortex_bail!("merge expects non-nullable input");
-                }
-                if !array.dtype().is_struct() {
-                    vortex_bail!("merge expects struct input");
-                }
-                Ok(array.to_struct())
-            })
-            .process_results(|it| it.collect::<Vec<_>>())?;
-
-        if expr.duplicate_handling == DuplicateHandling::Error {
-            let names = children
-                .iter()
-                .flat_map(|a| a.names().iter())
-                .collect::<Vec<_>>();
-            error_if_duplicates_present(&names)?;
-        }
-
         // Collect fields in order of appearance. Later fields overwrite earlier fields.
         let mut field_names = Vec::new();
         let mut arrays = Vec::new();
+        let mut duplicate_names = HashSet::<_>::new();
 
-        for child in children.iter() {
-            for (field_name, array) in child.names().iter().zip_eq(child.fields().iter().cloned()) {
+        for expr in expr.values.iter() {
+            // TODO(marko): When nullable, we need to merge struct validity into field validity.
+            let array = expr.unchecked_evaluate(scope)?;
+            if array.dtype().is_nullable() {
+                vortex_bail!("merge expects non-nullable input");
+            }
+            if !array.dtype().is_struct() {
+                vortex_bail!("merge expects struct input");
+            }
+            let array = array.to_struct();
+
+            for (field_name, array) in array.names().iter().zip_eq(array.fields().iter().cloned()) {
                 // Update or insert field.
                 if let Some(idx) = field_names.iter().position(|name| name == field_name) {
+                    duplicate_names.insert(field_name.clone());
                     arrays[idx] = array;
                 } else {
                     field_names.push(field_name.clone());
@@ -140,8 +133,16 @@ impl VTable for MergeVTable {
             }
         }
 
+        if expr.duplicate_handling == DuplicateHandling::Error && !duplicate_names.is_empty() {
+            vortex_bail!(
+                "merge: duplicate fields in children: {}",
+                duplicate_names.into_iter().format(", ")
+            )
+        }
+
         // TODO(DK): When children are allowed to be nullable, this needs to change.
         let validity = Validity::NonNullable;
+        let len = scope.len();
         Ok(
             StructArray::try_new(FieldNames::from(field_names), arrays, len, validity)?
                 .into_array(),
@@ -149,38 +150,25 @@ impl VTable for MergeVTable {
     }
 
     fn return_dtype(expr: &Self::Expr, scope: &DType) -> VortexResult<DType> {
-        let children_struct_dtypes = expr
-            .values
-            .iter()
-            .map(|a| {
-                let dtype = a.return_dtype(scope)?;
-                let Some(fields) = dtype.as_struct_fields_opt().cloned() else {
-                    vortex_bail!("merge expects struct input");
-                };
-                if dtype.is_nullable() {
-                    vortex_bail!("merge expects non-nullable input");
-                }
-                Ok((fields, dtype.nullability()))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        if expr.duplicate_handling == DuplicateHandling::Error {
-            let names = children_struct_dtypes
-                .iter()
-                .flat_map(|(fields, _)| fields.names().iter())
-                .collect::<Vec<_>>();
-            error_if_duplicates_present(&names)?;
-        }
-
         let mut field_names = Vec::new();
         let mut arrays = Vec::new();
         let mut merge_nullability = Nullability::NonNullable;
+        let mut duplicate_names = HashSet::<_>::new();
 
-        for (fields, nullability) in children_struct_dtypes {
-            merge_nullability |= nullability;
+        for expr in expr.values.iter() {
+            let dtype = expr.return_dtype(scope)?;
+            let Some(fields) = dtype.as_struct_fields_opt().cloned() else {
+                vortex_bail!("merge expects struct input");
+            };
+            if dtype.is_nullable() {
+                vortex_bail!("merge expects non-nullable input");
+            }
+
+            merge_nullability |= dtype.nullability();
 
             for (field_name, field_dtype) in fields.names().iter().zip_eq(fields.fields()) {
                 if let Some(idx) = field_names.iter().position(|name| name == field_name) {
+                    duplicate_names.insert(field_name.clone());
                     arrays[idx] = field_dtype;
                 } else {
                     field_names.push(field_name.clone());
@@ -189,36 +177,18 @@ impl VTable for MergeVTable {
             }
         }
 
+        if expr.duplicate_handling == DuplicateHandling::Error && !duplicate_names.is_empty() {
+            vortex_bail!(
+                "merge: duplicate fields in children: {}",
+                duplicate_names.into_iter().format(", ")
+            )
+        }
+
         Ok(DType::Struct(
             StructFields::new(FieldNames::from(field_names), arrays),
             merge_nullability,
         ))
     }
-}
-
-fn error_if_duplicates_present<T: Display + Eq + Hash>(names: &[T]) -> VortexResult<()> {
-    let dupes = duplicates(names);
-
-    if !dupes.is_empty() {
-        vortex_bail!(
-            "merge: duplicate fields in children: {}",
-            dupes.into_iter().format(", ")
-        )
-    }
-
-    Ok(())
-}
-
-/// Return any items which appear more than once in this slice.
-fn duplicates<T: Eq + Hash>(items: &[T]) -> HashSet<&T> {
-    let mut dupes = HashSet::new();
-    let mut seen = HashSet::new();
-    for item in items {
-        if !seen.insert(item) {
-            dupes.insert(item);
-        }
-    }
-    dupes
 }
 
 impl MergeExpr {
@@ -294,9 +264,7 @@ mod tests {
     use vortex_array::{Array, IntoArray, ToCanonical};
     use vortex_buffer::buffer;
     use vortex_error::{VortexResult, vortex_bail};
-    use vortex_utils::aliases::hash_set::HashSet;
 
-    use crate::merge::duplicates;
     use crate::{DuplicateHandling, MergeExpr, Scope, get_item, merge, root};
 
     fn primitive_field(array: &dyn Array, field_path: &[&str]) -> VortexResult<PrimitiveArray> {
@@ -314,12 +282,15 @@ mod tests {
     }
 
     #[test]
-    pub fn test_merge() {
-        let expr = MergeExpr::new(vec![
-            get_item("0", root()),
-            get_item("1", root()),
-            get_item("2", root()),
-        ]);
+    pub fn test_merge_right_most() {
+        let expr = MergeExpr::new_opts(
+            vec![
+                get_item("0", root()),
+                get_item("1", root()),
+                get_item("2", root()),
+            ],
+            DuplicateHandling::RightMost,
+        );
 
         let test_array = StructArray::from_fields(&[
             (
@@ -393,7 +364,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "merge: duplicate fields in children")]
-    pub fn test_merge_duplicate_flag_return_dtype() {
+    pub fn test_merge_error_on_dupe_return_dtype() {
         let expr = MergeExpr::new_opts(
             vec![get_item("0", root()), get_item("1", root())],
             DuplicateHandling::Error,
@@ -416,7 +387,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "merge: duplicate fields in children")]
-    pub fn test_merge_duplicate_flag_evaluate() {
+    pub fn test_merge_error_on_dupe_evaluate() {
         let expr = MergeExpr::new_opts(
             vec![get_item("0", root()), get_item("1", root())],
             DuplicateHandling::Error,
@@ -453,7 +424,10 @@ mod tests {
     pub fn test_nested_merge() {
         // Nested structs are not merged!
 
-        let expr = MergeExpr::new(vec![get_item("0", root()), get_item("1", root())]);
+        let expr = MergeExpr::new_opts(
+            vec![get_item("0", root()), get_item("1", root())],
+            DuplicateHandling::RightMost,
+        );
 
         let test_array = StructArray::from_fields(&[
             (
@@ -539,34 +513,9 @@ mod tests {
     #[test]
     pub fn test_display() {
         let expr = merge([get_item("struct1", root()), get_item("struct2", root())]);
-        assert_eq!(expr.to_string(), "merge[right-most]($.struct1, $.struct2)");
+        assert_eq!(expr.to_string(), "merge[error]($.struct1, $.struct2)");
 
         let expr2 = MergeExpr::new(vec![get_item("a", root())]);
-        assert_eq!(expr2.to_string(), "merge[right-most]($.a)");
-    }
-
-    #[test]
-    pub fn test_has_duplicates() {
-        assert_eq!(duplicates(&[1]), HashSet::new());
-        assert_eq!(duplicates(&[1, 2]), HashSet::new());
-        assert_eq!(duplicates(&[2, 1]), HashSet::new());
-        assert_eq!(duplicates(&[1, 1]), [1].iter().collect::<HashSet<_>>());
-        assert_eq!(duplicates(&[2, 1, 3]), HashSet::new());
-        assert_eq!(
-            duplicates(&[2, 1, 3, 2]),
-            [2].iter().collect::<HashSet<_>>()
-        );
-        assert_eq!(
-            duplicates(&[2, 1, 3, 1]),
-            [1].iter().collect::<HashSet<_>>()
-        );
-        assert_eq!(
-            duplicates(&[2, 1, 3, 3]),
-            [3].iter().collect::<HashSet<_>>()
-        );
-        assert_eq!(
-            duplicates(&[2, 1, 3, 3, 1]),
-            [1, 3].iter().collect::<HashSet<_>>()
-        );
+        assert_eq!(expr2.to_string(), "merge[error]($.a)");
     }
 }

--- a/vortex-expr/src/exprs/merge.rs
+++ b/vortex-expr/src/exprs/merge.rs
@@ -1,14 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::fmt::Display;
 use std::hash::Hash;
 
 use itertools::Itertools as _;
 use vortex_array::arrays::StructArray;
 use vortex_array::validity::Validity;
-use vortex_array::{Array, ArrayRef, DeserializeMetadata, EmptyMetadata, IntoArray, ToCanonical};
+use vortex_array::{
+    Array, ArrayRef, DeserializeMetadata, EmptyMetadata, IntoArray as _, ToCanonical,
+};
 use vortex_dtype::{DType, FieldNames, Nullability, StructFields};
-use vortex_error::{VortexExpect as _, VortexResult, vortex_bail};
+use vortex_error::{VortexResult, vortex_bail};
+use vortex_utils::aliases::hash_set::HashSet;
 
 use crate::display::{DisplayAs, DisplayFormat};
 use crate::{AnalysisExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTable, vtable};
@@ -25,6 +29,26 @@ vtable!(Merge);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MergeExpr {
     values: Vec<ExprRef>,
+    duplicate_handling: DuplicateHandling,
+}
+
+/// What to do when merged structs share a field name.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum DuplicateHandling {
+    /// If two structs share a field name, take the value from the right-most struct.
+    #[default]
+    RightMost,
+    /// If two structs share a field name, error.
+    Error,
+}
+
+impl Display for DuplicateHandling {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DuplicateHandling::Error => write!(f, "error"),
+            DuplicateHandling::RightMost => write!(f, "right-most"),
+        }
+    }
 }
 
 pub struct MergeExprEncoding;
@@ -50,8 +74,11 @@ impl VTable for MergeVTable {
         expr.values.iter().collect()
     }
 
-    fn with_children(_expr: &Self::Expr, children: Vec<ExprRef>) -> VortexResult<Self::Expr> {
-        Ok(MergeExpr { values: children })
+    fn with_children(expr: &Self::Expr, children: Vec<ExprRef>) -> VortexResult<Self::Expr> {
+        Ok(MergeExpr {
+            values: children,
+            duplicate_handling: expr.duplicate_handling,
+        })
     }
 
     fn build(
@@ -65,37 +92,44 @@ impl VTable for MergeVTable {
                 children
             );
         }
-        Ok(MergeExpr { values: children })
+        Ok(MergeExpr {
+            values: children,
+            duplicate_handling: DuplicateHandling::default(),
+        })
     }
 
     fn evaluate(expr: &Self::Expr, scope: &Scope) -> VortexResult<ArrayRef> {
         let len = scope.len();
-        let value_arrays = expr
+        let children = expr
             .values
             .iter()
-            .map(|value_expr| value_expr.unchecked_evaluate(scope))
+            .map(|value_expr| {
+                // TODO(marko): When nullable, we need to merge struct validity into field validity.
+                let array = value_expr.unchecked_evaluate(scope)?;
+                if array.dtype().is_nullable() {
+                    vortex_bail!("merge expects non-nullable input");
+                }
+                if !array.dtype().is_struct() {
+                    vortex_bail!("merge expects struct input");
+                }
+                Ok(array.to_struct())
+            })
             .process_results(|it| it.collect::<Vec<_>>())?;
+
+        if expr.duplicate_handling == DuplicateHandling::Error {
+            let names = children
+                .iter()
+                .flat_map(|a| a.names().iter())
+                .collect::<Vec<_>>();
+            error_if_duplicates_present(&names)?;
+        }
 
         // Collect fields in order of appearance. Later fields overwrite earlier fields.
         let mut field_names = Vec::new();
         let mut arrays = Vec::new();
 
-        for value_array in value_arrays.iter() {
-            // TODO(marko): When nullable, we need to merge struct validity into field validity.
-            if value_array.dtype().is_nullable() {
-                todo!("merge nullable structs");
-            }
-            if !value_array.dtype().is_struct() {
-                vortex_bail!("merge expects non-nullable struct input");
-            }
-
-            let struct_array = value_array.to_struct();
-
-            for (field_name, array) in struct_array
-                .names()
-                .iter()
-                .zip_eq(struct_array.fields().iter().cloned())
-            {
+        for child in children.iter() {
+            for (field_name, array) in child.names().iter().zip_eq(child.fields().iter().cloned()) {
                 // Update or insert field.
                 if let Some(idx) = field_names.iter().position(|name| name == field_name) {
                     arrays[idx] = array;
@@ -115,28 +149,37 @@ impl VTable for MergeVTable {
     }
 
     fn return_dtype(expr: &Self::Expr, scope: &DType) -> VortexResult<DType> {
+        let children_struct_dtypes = expr
+            .values
+            .iter()
+            .map(|a| {
+                let dtype = a.return_dtype(scope)?;
+                let Some(fields) = dtype.as_struct_fields_opt().cloned() else {
+                    vortex_bail!("merge expects struct input");
+                };
+                if dtype.is_nullable() {
+                    vortex_bail!("merge expects non-nullable input");
+                }
+                Ok((fields, dtype.nullability()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if expr.duplicate_handling == DuplicateHandling::Error {
+            let names = children_struct_dtypes
+                .iter()
+                .flat_map(|(fields, _)| fields.names().iter())
+                .collect::<Vec<_>>();
+            error_if_duplicates_present(&names)?;
+        }
+
         let mut field_names = Vec::new();
         let mut arrays = Vec::new();
+        let mut merge_nullability = Nullability::NonNullable;
 
-        let mut nullability = Nullability::NonNullable;
+        for (fields, nullability) in children_struct_dtypes {
+            merge_nullability |= nullability;
 
-        for value in expr.values.iter() {
-            let dtype = value.return_dtype(scope)?;
-            if !dtype.is_struct() {
-                vortex_bail!("merge expects struct input");
-            }
-            if dtype.is_nullable() {
-                vortex_bail!("merge expects non-nullable input");
-            }
-            nullability |= dtype.nullability();
-
-            let struct_dtype = dtype
-                .as_struct_fields_opt()
-                .vortex_expect("merge expects struct input");
-
-            for i in 0..struct_dtype.nfields() {
-                let field_name = struct_dtype.field_name(i).vortex_expect("never OOB");
-                let field_dtype = struct_dtype.field_by_index(i).vortex_expect("never OOB");
+            for (field_name, field_dtype) in fields.names().iter().zip_eq(fields.fields()) {
                 if let Some(idx) = field_names.iter().position(|name| name == field_name) {
                     arrays[idx] = field_dtype;
                 } else {
@@ -148,18 +191,57 @@ impl VTable for MergeVTable {
 
         Ok(DType::Struct(
             StructFields::new(FieldNames::from(field_names), arrays),
-            nullability,
+            merge_nullability,
         ))
     }
 }
 
+fn error_if_duplicates_present<T: Display + Eq + Hash>(names: &[T]) -> VortexResult<()> {
+    let dupes = duplicates(names);
+
+    if !dupes.is_empty() {
+        vortex_bail!(
+            "merge: duplicate fields in children: {}",
+            dupes.into_iter().format(", ")
+        )
+    }
+
+    Ok(())
+}
+
+/// Return any items which appear more than once in this slice.
+fn duplicates<T: Eq + Hash>(items: &[T]) -> HashSet<&T> {
+    let mut dupes = HashSet::new();
+    let mut seen = HashSet::new();
+    for item in items {
+        if !seen.insert(item) {
+            dupes.insert(item);
+        }
+    }
+    dupes
+}
+
 impl MergeExpr {
     pub fn new(values: Vec<ExprRef>) -> Self {
-        MergeExpr { values }
+        MergeExpr {
+            values,
+            duplicate_handling: DuplicateHandling::default(),
+        }
     }
 
     pub fn new_expr(values: Vec<ExprRef>) -> ExprRef {
         Self::new(values).into_expr()
+    }
+
+    pub fn new_opts(values: Vec<ExprRef>, duplicate_handling: DuplicateHandling) -> Self {
+        MergeExpr {
+            values,
+            duplicate_handling,
+        }
+    }
+
+    pub fn new_expr_opts(values: Vec<ExprRef>, duplicate_handling: DuplicateHandling) -> ExprRef {
+        Self::new_opts(values, duplicate_handling).into_expr()
     }
 }
 
@@ -178,11 +260,24 @@ pub fn merge(elements: impl IntoIterator<Item = impl Into<ExprRef>>) -> ExprRef 
     MergeExpr::new(values).into_expr()
 }
 
+pub fn merge_opts(
+    elements: impl IntoIterator<Item = impl Into<ExprRef>>,
+    duplicate_handling: DuplicateHandling,
+) -> ExprRef {
+    let values = elements.into_iter().map(|value| value.into()).collect_vec();
+    MergeExpr::new_opts(values, duplicate_handling).into_expr()
+}
+
 impl DisplayAs for MergeExpr {
     fn fmt_as(&self, df: DisplayFormat, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match df {
             DisplayFormat::Compact => {
-                write!(f, "merge({})", self.values.iter().format(", "),)
+                write!(
+                    f,
+                    "merge[{}]({})",
+                    self.duplicate_handling,
+                    self.values.iter().format(", "),
+                )
             }
             DisplayFormat::Tree => {
                 write!(f, "Merge")
@@ -199,8 +294,10 @@ mod tests {
     use vortex_array::{Array, IntoArray, ToCanonical};
     use vortex_buffer::buffer;
     use vortex_error::{VortexResult, vortex_bail};
+    use vortex_utils::aliases::hash_set::HashSet;
 
-    use crate::{MergeExpr, Scope, get_item, merge, root};
+    use crate::merge::duplicates;
+    use crate::{DuplicateHandling, MergeExpr, Scope, get_item, merge, root};
 
     fn primitive_field(array: &dyn Array, field_path: &[&str]) -> VortexResult<PrimitiveArray> {
         let mut field_path = field_path.iter();
@@ -291,6 +388,46 @@ mod tests {
                 .unwrap()
                 .as_slice::<i32>(),
             [5, 5, 5]
+        );
+    }
+
+    #[test]
+    pub fn test_merge_duplicate_flag() {
+        let expr = MergeExpr::new_opts(
+            vec![get_item("0", root()), get_item("1", root())],
+            DuplicateHandling::Error,
+        );
+        let test_array = StructArray::try_from_iter([
+            (
+                "0",
+                StructArray::try_from_iter([("a", buffer![1]), ("b", buffer![1])]).unwrap(),
+            ),
+            (
+                "1",
+                StructArray::try_from_iter([("c", buffer![1]), ("b", buffer![1])]).unwrap(),
+            ),
+        ])
+        .unwrap()
+        .into_array();
+
+        let actual = expr.return_dtype(test_array.dtype());
+        assert!(
+            actual.as_ref().is_err_and(|e| {
+                e.to_string()
+                    .contains("merge: duplicate fields in children")
+            }),
+            "{:?}",
+            actual
+        );
+
+        let actual = expr.evaluate(&Scope::new(test_array));
+        assert!(
+            actual.as_ref().is_err_and(|e| {
+                e.to_string()
+                    .contains("merge: duplicate fields in children")
+            }),
+            "{:?}",
+            actual
         );
     }
 
@@ -396,9 +533,34 @@ mod tests {
     #[test]
     pub fn test_display() {
         let expr = merge([get_item("struct1", root()), get_item("struct2", root())]);
-        assert_eq!(expr.to_string(), "merge($.struct1, $.struct2)");
+        assert_eq!(expr.to_string(), "merge[right-most]($.struct1, $.struct2)");
 
         let expr2 = MergeExpr::new(vec![get_item("a", root())]);
-        assert_eq!(expr2.to_string(), "merge($.a)");
+        assert_eq!(expr2.to_string(), "merge[right-most]($.a)");
+    }
+
+    #[test]
+    pub fn test_has_duplicates() {
+        assert_eq!(duplicates(&[1]), HashSet::new());
+        assert_eq!(duplicates(&[1, 2]), HashSet::new());
+        assert_eq!(duplicates(&[2, 1]), HashSet::new());
+        assert_eq!(duplicates(&[1, 1]), [1].iter().collect::<HashSet<_>>());
+        assert_eq!(duplicates(&[2, 1, 3]), HashSet::new());
+        assert_eq!(
+            duplicates(&[2, 1, 3, 2]),
+            [2].iter().collect::<HashSet<_>>()
+        );
+        assert_eq!(
+            duplicates(&[2, 1, 3, 1]),
+            [1].iter().collect::<HashSet<_>>()
+        );
+        assert_eq!(
+            duplicates(&[2, 1, 3, 3]),
+            [3].iter().collect::<HashSet<_>>()
+        );
+        assert_eq!(
+            duplicates(&[2, 1, 3, 3, 1]),
+            [1, 3].iter().collect::<HashSet<_>>()
+        );
     }
 }

--- a/vortex-expr/src/exprs/merge.rs
+++ b/vortex-expr/src/exprs/merge.rs
@@ -157,7 +157,7 @@ impl VTable for MergeVTable {
 
         for expr in expr.values.iter() {
             let dtype = expr.return_dtype(scope)?;
-            let Some(fields) = dtype.as_struct_fields_opt().cloned() else {
+            let Some(fields) = dtype.as_struct_fields_opt() else {
                 vortex_bail!("merge expects struct input");
             };
             if dtype.is_nullable() {

--- a/vortex-expr/src/transform/remove_merge.rs
+++ b/vortex-expr/src/transform/remove_merge.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_error::{VortexExpect, VortexResult, vortex_err};
+use itertools::Itertools as _;
+use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
+use vortex_utils::aliases::hash_set::HashSet;
 
 use crate::traversal::{NodeExt, Transformed};
-use crate::{DType, ExprRef, MergeVTable, get_item, pack};
+use crate::{DType, DuplicateHandling, ExprRef, MergeVTable, get_item, pack};
 
 /// Replaces [crate::MergeExpr] with combination of [crate::GetItem] and [crate::Pack] expressions.
 pub(crate) fn remove_merge(e: ExprRef, ctx: &DType) -> VortexResult<ExprRef> {
@@ -20,6 +22,7 @@ fn merge_transform(node: ExprRef, ctx: &DType) -> VortexResult<Transformed<ExprR
             let mut names = Vec::with_capacity(merge.children().len() * 2);
             let mut children = Vec::with_capacity(merge.children().len() * 2);
             let mut all_nullable = true;
+            let mut duplicate_names = HashSet::<_>::new();
             for child in merge.children() {
                 let child_dtype = child.return_dtype(ctx)?;
                 if !child_dtype.is_struct() {
@@ -36,11 +39,21 @@ fn merge_transform(node: ExprRef, ctx: &DType) -> VortexResult<Transformed<ExprR
 
                 for name in child_dtype.names().iter() {
                     if let Some(idx) = names.iter().position(|n| n == name) {
+                        duplicate_names.insert(name.clone());
                         children[idx] = child.clone();
                     } else {
                         names.push(name.clone());
                         children.push(child.clone());
                     }
+                }
+
+                if merge.duplicate_handling() == DuplicateHandling::Error
+                    && !duplicate_names.is_empty()
+                {
+                    vortex_bail!(
+                        "merge: duplicate fields in children: {}",
+                        duplicate_names.into_iter().format(", ")
+                    )
                 }
             }
             let expr = pack(
@@ -62,7 +75,7 @@ mod tests {
     use vortex_dtype::PType::{I32, I64, U32, U64};
 
     use crate::transform::remove_merge::remove_merge;
-    use crate::{PackVTable, get_item, merge, root};
+    use crate::{DuplicateHandling, PackVTable, get_item, merge_opts, root};
 
     #[test]
     fn test_remove_merge() {
@@ -74,7 +87,10 @@ mod tests {
             NonNullable,
         );
 
-        let e = merge([get_item("0", root()), get_item("1", root())]);
+        let e = merge_opts(
+            [get_item("0", root()), get_item("1", root())],
+            DuplicateHandling::RightMost,
+        );
         let e = remove_merge(e, &dtype).unwrap();
 
         assert!(e.is::<PackVTable>());


### PR DESCRIPTION
Error on duplicates is better for new users who accidentally collide names.