### PR TITLE
chore: change 4 lines; eliminate countless Arc clones

### DIFF
--- a/vortex-array/src/arrays/struct_/array.rs
+++ b/vortex-array/src/arrays/struct_/array.rs
@@ -141,8 +141,8 @@ pub struct StructArray {
 }
 
 impl StructArray {
-    pub fn fields(&self) -> Arc<[ArrayRef]> {
-        self.fields.clone()
+    pub fn fields(&self) -> &Arc<[ArrayRef]> {
+        &self.fields
     }
 
     pub fn field_by_name(&self, name: impl AsRef<str>) -> VortexResult<&ArrayRef> {

--- a/vortex-array/src/arrays/struct_/compute/mask.rs
+++ b/vortex-array/src/arrays/struct_/compute/mask.rs
@@ -14,7 +14,7 @@ impl MaskKernel for StructVTable {
         let validity = array.validity().mask(filter_mask);
 
         StructArray::try_new_with_dtype(
-            array.fields(),
+            array.fields().clone(),
             array.struct_fields().clone(),
             array.len(),
             validity,

--- a/vortex-array/src/arrays/struct_/compute/mod.rs
+++ b/vortex-array/src/arrays/struct_/compute/mod.rs
@@ -26,7 +26,7 @@ impl TakeKernel for StructVTable {
         // an out of bounds element
         if array.is_empty() {
             return StructArray::try_new_with_dtype(
-                array.fields(),
+                array.fields().clone(),
                 array.struct_fields().clone(),
                 indices.len(),
                 Validity::AllInvalid,


### PR DESCRIPTION
If a consumer needs an owned version they can clone. There are like 50 spots in the code where we only need the slice, not an owned Arc.