### PR TITLE
fix[vortex-expr]: implement stat_falsification for BetweenExpr

### DIFF
--- a/vortex-expr/src/exprs/between.rs
+++ b/vortex-expr/src/exprs/between.rs
@@ -22,7 +22,8 @@ use vortex_proto::expr as pb;
 
 use crate::display::{DisplayAs, DisplayFormat};
 use crate::{
-    AnalysisExpr, BinaryExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, VTable, vtable,
+    AnalysisExpr, BinaryExpr, ExprEncodingRef, ExprId, ExprRef, IntoExpr, Scope, StatsCatalog,
+    VTable, vtable,
 };
 
 vtable!(Between);
@@ -219,7 +220,11 @@ impl DisplayAs for BetweenExpr {
     }
 }
 
-impl AnalysisExpr for BetweenExpr {}
+impl AnalysisExpr for BetweenExpr {
+    fn stat_falsification(&self, catalog: &mut dyn StatsCatalog) -> Option<ExprRef> {
+        self.to_binary_expr().stat_falsification(catalog)
+    }
+}
 
 /// Creates an expression that checks if values are between two bounds.
 ///

--- a/vortex-expr/src/pruning/pruning_expr.rs
+++ b/vortex-expr/src/pruning/pruning_expr.rs
@@ -102,12 +102,15 @@ pub fn checked_pruning_expr(
 #[cfg(test)]
 mod tests {
     use rstest::{fixture, rstest};
+    use vortex_array::compute::{BetweenOptions, StrictComparison};
     use vortex_array::stats::Stat;
     use vortex_dtype::{FieldName, FieldPath, FieldPathSet};
 
     use crate::pruning::pruning_expr::HashMap;
     use crate::pruning::{checked_pruning_expr, field_path_stat_field_name};
-    use crate::{HashSet, and, col, eq, get_item, gt, gt_eq, lit, lt, lt_eq, not_eq, or, root};
+    use crate::{
+        HashSet, and, between, col, eq, get_item, gt, gt_eq, lit, lt, lt_eq, not_eq, or, root,
+    };
 
     // Implement some checked pruning expressions.
     #[fixture]
@@ -462,5 +465,30 @@ mod tests {
                 gt_eq(col("int_col_min"), lit(10)),
             )
         )
+    }
+
+    #[rstest]
+    fn pruning_between(available_stats: FieldPathSet) {
+        let expr = between(
+            col("a"),
+            lit(10),
+            lit(50),
+            BetweenOptions {
+                lower_strict: StrictComparison::NonStrict,
+                upper_strict: StrictComparison::NonStrict,
+            },
+        );
+        let (converted, refs) = checked_pruning_expr(&expr, &available_stats).unwrap();
+        assert_eq!(
+            refs.map(),
+            &HashMap::from_iter([(
+                FieldPath::from_name("a"),
+                HashSet::from_iter([Stat::Min, Stat::Max])
+            )])
+        );
+        assert_eq!(
+            &converted,
+            &or(gt(lit(10), col("a_max")), gt(col("a_min"), lit(50)))
+        );
     }
 }


### PR DESCRIPTION
This would otherwise cause chunks to not be pruned when they could be with range filters.