### PR TITLE
fix: Continue to prefer List over ListView by default in ToArrow

### DIFF
--- a/vortex-dtype/src/arrow.rs
+++ b/vortex-dtype/src/arrow.rs
@@ -326,11 +326,11 @@ mod test {
         assert_ne!(arrow_list_non_nullable, arrow_list_nullable);
         assert_eq!(
             arrow_list_nullable,
-            DataType::ListView(Arc::new(Field::new_list_field(DataType::Int64, true))),
+            DataType::List(Arc::new(Field::new_list_field(DataType::Int64, true))),
         );
         assert_eq!(
             arrow_list_non_nullable,
-            DataType::ListView(Arc::new(Field::new_list_field(DataType::Int64, false))),
+            DataType::List(Arc::new(Field::new_list_field(DataType::Int64, false))),
         );
     }
 

--- a/vortex-dtype/src/arrow.rs
+++ b/vortex-dtype/src/arrow.rs
@@ -215,7 +215,7 @@ impl DType {
             // There are four kinds of lists: List (32-bit offsets), Large List (64-bit), List View
             // (32-bit), Large List View (64-bit). We cannot both guarantee zero-copy and commit to an
             // Arrow dtype because we do not how large our offsets are.
-            DType::List(elem_dtype, _) => DataType::ListView(FieldRef::new(Field::new_list_field(
+            DType::List(elem_dtype, _) => DataType::List(FieldRef::new(Field::new_list_field(
                 elem_dtype.to_arrow_dtype()?,
                 elem_dtype.nullability().into(),
             ))),


### PR DESCRIPTION
Turns out, arrow-rs/DataFusion lacks complete support for ListView. Until that is resolved, for now the default to_arrow_preferred should prefer returning List over ListView.

See https://github.com/vortex-data/vortex/actions/runs/18591096514/job/53006051293?pr=4977 for example failure