### PR TITLE
Chore: reorganize compute function files in `vortex-array`

### DIFF
--- a/vortex-array/src/arrays/constant/compute/mod.rs
+++ b/vortex-array/src/arrays/constant/compute/mod.rs
@@ -13,11 +13,13 @@ mod take;
 
 #[cfg(test)]
 mod test {
+    use rstest::rstest;
     use vortex_dtype::half::f16;
     use vortex_scalar::Scalar;
 
     use crate::IntoArray;
-    use crate::arrays::constant::ConstantArray;
+    use crate::arrays::ConstantArray;
+    use crate::compute::conformance::consistency::test_array_consistency;
     use crate::compute::conformance::filter::test_filter_conformance;
     use crate::compute::conformance::mask::test_mask_conformance;
 
@@ -40,15 +42,6 @@ mod test {
             &ConstantArray::new(Scalar::from(f16::from_f32(3.0f32)), 5).into_array(),
         );
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use rstest::rstest;
-    use vortex_scalar::Scalar;
-
-    use crate::arrays::ConstantArray;
-    use crate::compute::conformance::consistency::test_array_consistency;
 
     #[rstest]
     // From test_all_consistency

--- a/vortex-array/src/arrays/extension/compute/cast.rs
+++ b/vortex-array/src/arrays/extension/compute/cast.rs
@@ -4,7 +4,7 @@
 use vortex_dtype::DType;
 
 use crate::arrays::{ExtensionArray, ExtensionVTable};
-use crate::compute::{CastKernel, CastKernelAdapter, cast};
+use crate::compute::{self, CastKernel, CastKernelAdapter};
 use crate::{ArrayRef, IntoArray, register_kernel};
 
 impl CastKernel for ExtensionVTable {
@@ -21,7 +21,7 @@ impl CastKernel for ExtensionVTable {
             unreachable!("Already verified we have an extension dtype");
         };
 
-        let new_storage = match cast(array.storage(), ext_dtype.storage_dtype()) {
+        let new_storage = match compute::cast(array.storage(), ext_dtype.storage_dtype()) {
             Ok(arr) => arr,
             Err(e) => {
                 log::warn!("Failed to cast storage array: {e}");
@@ -49,6 +49,7 @@ mod tests {
     use super::*;
     use crate::IntoArray;
     use crate::arrays::PrimitiveArray;
+    use crate::compute::cast;
     use crate::compute::conformance::cast::test_cast_conformance;
 
     #[test]

--- a/vortex-array/src/arrays/extension/compute/compare.rs
+++ b/vortex-array/src/arrays/extension/compute/compare.rs
@@ -4,7 +4,7 @@
 use vortex_error::VortexResult;
 
 use crate::arrays::{ConstantArray, ExtensionArray, ExtensionVTable};
-use crate::compute::{CompareKernel, CompareKernelAdapter, Operator, compare};
+use crate::compute::{self, CompareKernel, CompareKernelAdapter, Operator};
 use crate::{Array, ArrayRef, register_kernel};
 
 impl CompareKernel for ExtensionVTable {
@@ -17,7 +17,7 @@ impl CompareKernel for ExtensionVTable {
         // If the RHS is a constant, we can extract the storage scalar.
         if let Some(const_ext) = rhs.as_constant() {
             let storage_scalar = const_ext.as_extension().storage();
-            return compare(
+            return compute::compare(
                 lhs.storage(),
                 ConstantArray::new(storage_scalar, lhs.len()).as_ref(),
                 operator,
@@ -27,7 +27,7 @@ impl CompareKernel for ExtensionVTable {
 
         // If the RHS is an extension array matching ours, we can extract the storage.
         if let Some(rhs_ext) = rhs.as_opt::<ExtensionVTable>() {
-            return compare(lhs.storage(), rhs_ext.storage(), operator).map(Some);
+            return compute::compare(lhs.storage(), rhs_ext.storage(), operator).map(Some);
         }
 
         // Otherwise, we need the RHS to handle this comparison.

--- a/vortex-array/src/arrays/extension/compute/filter.rs
+++ b/vortex-array/src/arrays/extension/compute/filter.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+use vortex_mask::Mask;
+
+use crate::arrays::{ExtensionArray, ExtensionVTable};
+use crate::compute::{self, FilterKernel, FilterKernelAdapter};
+use crate::{ArrayRef, IntoArray, register_kernel};
+
+impl FilterKernel for ExtensionVTable {
+    fn filter(&self, array: &ExtensionArray, mask: &Mask) -> VortexResult<ArrayRef> {
+        Ok(ExtensionArray::new(
+            array.ext_dtype().clone(),
+            compute::filter(array.storage(), mask)?,
+        )
+        .into_array())
+    }
+}
+
+register_kernel!(FilterKernelAdapter(ExtensionVTable).lift());

--- a/vortex-array/src/arrays/extension/compute/is_constant.rs
+++ b/vortex-array/src/arrays/extension/compute/is_constant.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+
+use crate::arrays::{ExtensionArray, ExtensionVTable};
+use crate::compute::{self, IsConstantKernel, IsConstantKernelAdapter, IsConstantOpts};
+use crate::register_kernel;
+
+impl IsConstantKernel for ExtensionVTable {
+    fn is_constant(
+        &self,
+        array: &ExtensionArray,
+        opts: &IsConstantOpts,
+    ) -> VortexResult<Option<bool>> {
+        compute::is_constant_opts(array.storage(), opts)
+    }
+}
+
+register_kernel!(IsConstantKernelAdapter(ExtensionVTable).lift());

--- a/vortex-array/src/arrays/extension/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/extension/compute/is_sorted.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+
+use crate::arrays::{ExtensionArray, ExtensionVTable};
+use crate::compute::{self, IsSortedKernel, IsSortedKernelAdapter};
+use crate::register_kernel;
+
+impl IsSortedKernel for ExtensionVTable {
+    fn is_sorted(&self, array: &ExtensionArray) -> VortexResult<Option<bool>> {
+        compute::is_sorted(array.storage())
+    }
+
+    fn is_strict_sorted(&self, array: &ExtensionArray) -> VortexResult<Option<bool>> {
+        compute::is_strict_sorted(array.storage())
+    }
+}
+
+register_kernel!(IsSortedKernelAdapter(ExtensionVTable).lift());

--- a/vortex-array/src/arrays/extension/compute/mask.rs
+++ b/vortex-array/src/arrays/extension/compute/mask.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::sync::Arc;
+
+use vortex_dtype::ExtDType;
+use vortex_error::VortexResult;
+use vortex_mask::Mask;
+
+use crate::arrays::{ExtensionArray, ExtensionVTable};
+use crate::compute::{self, MaskKernel, MaskKernelAdapter};
+use crate::{ArrayRef, IntoArray, register_kernel};
+
+impl MaskKernel for ExtensionVTable {
+    fn mask(&self, array: &ExtensionArray, mask_array: &Mask) -> VortexResult<ArrayRef> {
+        let masked_storage = compute::mask(array.storage(), mask_array)?;
+        if masked_storage.dtype().nullability() == array.ext_dtype().storage_dtype().nullability() {
+            Ok(ExtensionArray::new(array.ext_dtype().clone(), masked_storage).into_array())
+        } else {
+            // The storage dtype changed (i.e., became nullable due to masking)
+            let ext_dtype = Arc::new(ExtDType::new(
+                array.ext_dtype().id().clone(),
+                Arc::new(masked_storage.dtype().clone()),
+                array.ext_dtype().metadata().cloned(),
+            ));
+            Ok(ExtensionArray::new(ext_dtype, masked_storage).into_array())
+        }
+    }
+}
+
+register_kernel!(MaskKernelAdapter(ExtensionVTable).lift());

--- a/vortex-array/src/arrays/extension/compute/min_max.rs
+++ b/vortex-array/src/arrays/extension/compute/min_max.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+use vortex_scalar::Scalar;
+
+use crate::arrays::{ExtensionArray, ExtensionVTable};
+use crate::compute::{self, MinMaxKernel, MinMaxKernelAdapter, MinMaxResult};
+use crate::register_kernel;
+
+impl MinMaxKernel for ExtensionVTable {
+    fn min_max(&self, array: &ExtensionArray) -> VortexResult<Option<MinMaxResult>> {
+        Ok(
+            compute::min_max(array.storage())?.map(|MinMaxResult { min, max }| MinMaxResult {
+                min: Scalar::extension(array.ext_dtype().clone(), min),
+                max: Scalar::extension(array.ext_dtype().clone(), max),
+            }),
+        )
+    }
+}
+
+register_kernel!(MinMaxKernelAdapter(ExtensionVTable).lift());

--- a/vortex-array/src/arrays/extension/compute/mod.rs
+++ b/vortex-array/src/arrays/extension/compute/mod.rs
@@ -3,117 +3,13 @@
 
 mod cast;
 mod compare;
-
-use std::sync::Arc;
-
-use vortex_dtype::ExtDType;
-use vortex_error::VortexResult;
-use vortex_mask::Mask;
-use vortex_scalar::Scalar;
-
-use crate::arrays::ExtensionVTable;
-use crate::arrays::extension::ExtensionArray;
-use crate::compute::{
-    FilterKernel, FilterKernelAdapter, IsConstantKernel, IsConstantKernelAdapter, IsConstantOpts,
-    IsSortedKernel, IsSortedKernelAdapter, MaskKernel, MaskKernelAdapter, MinMaxKernel,
-    MinMaxKernelAdapter, MinMaxResult, SumKernel, SumKernelAdapter, TakeKernel, TakeKernelAdapter,
-    filter, is_constant_opts, is_sorted, is_strict_sorted, mask, min_max, sum, take,
-};
-use crate::{Array, ArrayRef, IntoArray, register_kernel};
-
-impl FilterKernel for ExtensionVTable {
-    fn filter(&self, array: &ExtensionArray, mask: &Mask) -> VortexResult<ArrayRef> {
-        Ok(
-            ExtensionArray::new(array.ext_dtype().clone(), filter(array.storage(), mask)?)
-                .into_array(),
-        )
-    }
-}
-
-register_kernel!(FilterKernelAdapter(ExtensionVTable).lift());
-
-impl MaskKernel for ExtensionVTable {
-    fn mask(&self, array: &ExtensionArray, mask_array: &Mask) -> VortexResult<ArrayRef> {
-        let masked_storage = mask(array.storage(), mask_array)?;
-        if masked_storage.dtype().nullability() == array.ext_dtype().storage_dtype().nullability() {
-            Ok(ExtensionArray::new(array.ext_dtype().clone(), masked_storage).into_array())
-        } else {
-            // The storage dtype changed (i.e., became nullable due to masking)
-            let ext_dtype = Arc::new(ExtDType::new(
-                array.ext_dtype().id().clone(),
-                Arc::new(masked_storage.dtype().clone()),
-                array.ext_dtype().metadata().cloned(),
-            ));
-            Ok(ExtensionArray::new(ext_dtype, masked_storage).into_array())
-        }
-    }
-}
-
-register_kernel!(MaskKernelAdapter(ExtensionVTable).lift());
-
-impl SumKernel for ExtensionVTable {
-    fn sum(&self, array: &ExtensionArray) -> VortexResult<Scalar> {
-        sum(array.storage())
-    }
-}
-
-register_kernel!(SumKernelAdapter(ExtensionVTable).lift());
-
-impl TakeKernel for ExtensionVTable {
-    fn take(&self, array: &ExtensionArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
-        let taken_storage = take(array.storage(), indices)?;
-        if taken_storage.dtype().nullability() == array.ext_dtype().storage_dtype().nullability() {
-            Ok(ExtensionArray::new(array.ext_dtype().clone(), taken_storage).into_array())
-        } else {
-            // The storage dtype changed (i.e., became nullable due to nullable indices)
-            let ext_dtype = Arc::new(ExtDType::new(
-                array.ext_dtype().id().clone(),
-                Arc::new(taken_storage.dtype().clone()),
-                array.ext_dtype().metadata().cloned(),
-            ));
-            Ok(ExtensionArray::new(ext_dtype, taken_storage).into_array())
-        }
-    }
-}
-
-register_kernel!(TakeKernelAdapter(ExtensionVTable).lift());
-
-impl MinMaxKernel for ExtensionVTable {
-    fn min_max(&self, array: &ExtensionArray) -> VortexResult<Option<MinMaxResult>> {
-        Ok(
-            min_max(array.storage())?.map(|MinMaxResult { min, max }| MinMaxResult {
-                min: Scalar::extension(array.ext_dtype().clone(), min),
-                max: Scalar::extension(array.ext_dtype().clone(), max),
-            }),
-        )
-    }
-}
-
-register_kernel!(MinMaxKernelAdapter(ExtensionVTable).lift());
-
-impl IsConstantKernel for ExtensionVTable {
-    fn is_constant(
-        &self,
-        array: &ExtensionArray,
-        opts: &IsConstantOpts,
-    ) -> VortexResult<Option<bool>> {
-        is_constant_opts(array.storage(), opts)
-    }
-}
-
-register_kernel!(IsConstantKernelAdapter(ExtensionVTable).lift());
-
-impl IsSortedKernel for ExtensionVTable {
-    fn is_sorted(&self, array: &ExtensionArray) -> VortexResult<Option<bool>> {
-        is_sorted(array.storage())
-    }
-
-    fn is_strict_sorted(&self, array: &ExtensionArray) -> VortexResult<Option<bool>> {
-        is_strict_sorted(array.storage())
-    }
-}
-
-register_kernel!(IsSortedKernelAdapter(ExtensionVTable).lift());
+mod filter;
+mod is_constant;
+mod is_sorted;
+mod mask;
+mod min_max;
+mod sum;
+mod take;
 
 #[cfg(test)]
 mod test {

--- a/vortex-array/src/arrays/extension/compute/sum.rs
+++ b/vortex-array/src/arrays/extension/compute/sum.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+use vortex_scalar::Scalar;
+
+use crate::arrays::{ExtensionArray, ExtensionVTable};
+use crate::compute::{self, SumKernel, SumKernelAdapter};
+use crate::register_kernel;
+
+impl SumKernel for ExtensionVTable {
+    fn sum(&self, array: &ExtensionArray) -> VortexResult<Scalar> {
+        compute::sum(array.storage())
+    }
+}
+
+register_kernel!(SumKernelAdapter(ExtensionVTable).lift());

--- a/vortex-array/src/arrays/extension/compute/take.rs
+++ b/vortex-array/src/arrays/extension/compute/take.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::sync::Arc;
+
+use vortex_dtype::ExtDType;
+use vortex_error::VortexResult;
+
+use crate::arrays::{ExtensionArray, ExtensionVTable};
+use crate::compute::{self, TakeKernel, TakeKernelAdapter};
+use crate::{Array, ArrayRef, IntoArray, register_kernel};
+
+impl TakeKernel for ExtensionVTable {
+    fn take(&self, array: &ExtensionArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
+        let taken_storage = compute::take(array.storage(), indices)?;
+        if taken_storage.dtype().nullability() == array.ext_dtype().storage_dtype().nullability() {
+            Ok(ExtensionArray::new(array.ext_dtype().clone(), taken_storage).into_array())
+        } else {
+            // The storage dtype changed (i.e., became nullable due to nullable indices)
+            let ext_dtype = Arc::new(ExtDType::new(
+                array.ext_dtype().id().clone(),
+                Arc::new(taken_storage.dtype().clone()),
+                array.ext_dtype().metadata().cloned(),
+            ));
+            Ok(ExtensionArray::new(ext_dtype, taken_storage).into_array())
+        }
+    }
+}
+
+register_kernel!(TakeKernelAdapter(ExtensionVTable).lift());

--- a/vortex-array/src/arrays/null/compute/filter.rs
+++ b/vortex-array/src/arrays/null/compute/filter.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+use vortex_mask::Mask;
+
+use crate::arrays::{NullArray, NullVTable};
+use crate::compute::{FilterKernel, FilterKernelAdapter};
+use crate::{ArrayRef, IntoArray, register_kernel};
+
+impl FilterKernel for NullVTable {
+    fn filter(&self, _array: &Self::Array, mask: &Mask) -> VortexResult<ArrayRef> {
+        Ok(NullArray::new(mask.true_count()).into_array())
+    }
+}
+
+register_kernel!(FilterKernelAdapter(NullVTable).lift());

--- a/vortex-array/src/arrays/null/compute/mask.rs
+++ b/vortex-array/src/arrays/null/compute/mask.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+use vortex_mask::Mask;
+
+use crate::arrays::{NullArray, NullVTable};
+use crate::compute::{MaskKernel, MaskKernelAdapter};
+use crate::{ArrayRef, register_kernel};
+
+impl MaskKernel for NullVTable {
+    fn mask(&self, array: &NullArray, _mask: &Mask) -> VortexResult<ArrayRef> {
+        Ok(array.to_array())
+    }
+}
+
+register_kernel!(MaskKernelAdapter(NullVTable).lift());

--- a/vortex-array/src/arrays/null/compute/min_max.rs
+++ b/vortex-array/src/arrays/null/compute/min_max.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+
+use crate::arrays::{NullArray, NullVTable};
+use crate::compute::{MinMaxKernel, MinMaxKernelAdapter, MinMaxResult};
+use crate::register_kernel;
+
+impl MinMaxKernel for NullVTable {
+    fn min_max(&self, _array: &NullArray) -> VortexResult<Option<MinMaxResult>> {
+        Ok(None)
+    }
+}
+
+register_kernel!(MinMaxKernelAdapter(NullVTable).lift());

--- a/vortex-array/src/arrays/null/compute/mod.rs
+++ b/vortex-array/src/arrays/null/compute/mod.rs
@@ -2,70 +2,20 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 mod cast;
-
-use vortex_dtype::match_each_integer_ptype;
-use vortex_error::{VortexResult, vortex_bail};
-use vortex_mask::Mask;
-
-use crate::arrays::NullVTable;
-use crate::arrays::null::NullArray;
-use crate::compute::{
-    FilterKernel, FilterKernelAdapter, MaskKernel, MaskKernelAdapter, MinMaxKernel,
-    MinMaxKernelAdapter, MinMaxResult, TakeKernel, TakeKernelAdapter,
-};
-use crate::{Array, ArrayRef, IntoArray, ToCanonical, register_kernel};
-
-impl FilterKernel for NullVTable {
-    fn filter(&self, _array: &Self::Array, mask: &Mask) -> VortexResult<ArrayRef> {
-        Ok(NullArray::new(mask.true_count()).into_array())
-    }
-}
-
-register_kernel!(FilterKernelAdapter(NullVTable).lift());
-
-impl MaskKernel for NullVTable {
-    fn mask(&self, array: &NullArray, _mask: &Mask) -> VortexResult<ArrayRef> {
-        Ok(array.to_array())
-    }
-}
-
-register_kernel!(MaskKernelAdapter(NullVTable).lift());
-
-impl TakeKernel for NullVTable {
-    #[allow(clippy::cast_possible_truncation)]
-    fn take(&self, array: &NullArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
-        let indices = indices.to_primitive();
-
-        // Enforce all indices are valid
-        match_each_integer_ptype!(indices.ptype(), |T| {
-            for index in indices.as_slice::<T>() {
-                if (*index as usize) >= array.len() {
-                    vortex_bail!(OutOfBounds: *index as usize, 0, array.len());
-                }
-            }
-        });
-
-        Ok(NullArray::new(indices.len()).into_array())
-    }
-}
-
-register_kernel!(TakeKernelAdapter(NullVTable).lift());
-
-impl MinMaxKernel for NullVTable {
-    fn min_max(&self, _array: &NullArray) -> VortexResult<Option<MinMaxResult>> {
-        Ok(None)
-    }
-}
-
-register_kernel!(MinMaxKernelAdapter(NullVTable).lift());
+mod filter;
+mod mask;
+mod min_max;
+mod take;
 
 #[cfg(test)]
 mod test {
+    use rstest::rstest;
     use vortex_buffer::buffer;
     use vortex_dtype::DType;
     use vortex_mask::Mask;
 
-    use crate::arrays::null::NullArray;
+    use crate::arrays::NullArray;
+    use crate::compute::conformance::consistency::test_array_consistency;
     use crate::compute::conformance::filter::test_filter_conformance;
     use crate::compute::conformance::mask::test_mask_conformance;
     use crate::compute::conformance::take::test_take_conformance;
@@ -119,14 +69,6 @@ mod test {
         test_take_conformance(NullArray::new(1).as_ref());
         test_take_conformance(NullArray::new(10).as_ref());
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use rstest::rstest;
-
-    use crate::arrays::NullArray;
-    use crate::compute::conformance::consistency::test_array_consistency;
 
     #[rstest]
     // From test_all_consistency

--- a/vortex-array/src/arrays/null/compute/take.rs
+++ b/vortex-array/src/arrays/null/compute/take.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::match_each_integer_ptype;
+use vortex_error::{VortexResult, vortex_bail};
+
+use crate::arrays::{NullArray, NullVTable};
+use crate::compute::{TakeKernel, TakeKernelAdapter};
+use crate::{Array, ArrayRef, IntoArray, ToCanonical, register_kernel};
+
+impl TakeKernel for NullVTable {
+    #[allow(clippy::cast_possible_truncation)]
+    fn take(&self, array: &NullArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
+        let indices = indices.to_primitive();
+
+        // Enforce all indices are valid
+        match_each_integer_ptype!(indices.ptype(), |T| {
+            for index in indices.as_slice::<T>() {
+                if (*index as usize) >= array.len() {
+                    vortex_bail!(OutOfBounds: *index as usize, 0, array.len());
+                }
+            }
+        });
+
+        Ok(NullArray::new(indices.len()).into_array())
+    }
+}
+
+register_kernel!(TakeKernelAdapter(NullVTable).lift());

--- a/vortex-array/src/arrays/struct_/compute/is_constant.rs
+++ b/vortex-array/src/arrays/struct_/compute/is_constant.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+
+use crate::arrays::{StructArray, StructVTable};
+use crate::compute::{self, IsConstantKernel, IsConstantKernelAdapter, IsConstantOpts};
+use crate::register_kernel;
+
+impl IsConstantKernel for StructVTable {
+    fn is_constant(
+        &self,
+        array: &StructArray,
+        opts: &IsConstantOpts,
+    ) -> VortexResult<Option<bool>> {
+        let children = array.children();
+        if children.is_empty() {
+            return Ok(Some(true));
+        }
+
+        for child in children.iter() {
+            match compute::is_constant_opts(child, opts)? {
+                // Un-determined
+                None => return Ok(None),
+                Some(false) => return Ok(Some(false)),
+                Some(true) => {}
+            }
+        }
+
+        Ok(Some(true))
+    }
+}
+
+register_kernel!(IsConstantKernelAdapter(StructVTable).lift());

--- a/vortex-array/src/arrays/struct_/compute/min_max.rs
+++ b/vortex-array/src/arrays/struct_/compute/min_max.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+
+use crate::arrays::{StructArray, StructVTable};
+use crate::compute::{MinMaxKernel, MinMaxKernelAdapter, MinMaxResult};
+use crate::register_kernel;
+
+impl MinMaxKernel for StructVTable {
+    fn min_max(&self, _array: &StructArray) -> VortexResult<Option<MinMaxResult>> {
+        // TODO(joe): Implement struct min max
+        Ok(None)
+    }
+}
+
+register_kernel!(MinMaxKernelAdapter(StructVTable).lift());

--- a/vortex-array/src/arrays/struct_/compute/mod.rs
+++ b/vortex-array/src/arrays/struct_/compute/mod.rs
@@ -3,91 +3,11 @@
 
 mod cast;
 mod filter;
+mod is_constant;
 mod mask;
+mod min_max;
+mod take;
 mod zip;
-
-use vortex_dtype::Nullability::NonNullable;
-use vortex_error::VortexResult;
-use vortex_scalar::Scalar;
-
-use crate::arrays::StructVTable;
-use crate::arrays::struct_::StructArray;
-use crate::compute::{
-    IsConstantKernel, IsConstantKernelAdapter, IsConstantOpts, MinMaxKernel, MinMaxKernelAdapter,
-    MinMaxResult, TakeKernel, TakeKernelAdapter, fill_null, is_constant_opts, take,
-};
-use crate::validity::Validity;
-use crate::vtable::ValidityHelper;
-use crate::{Array, ArrayRef, IntoArray, register_kernel};
-
-impl TakeKernel for StructVTable {
-    fn take(&self, array: &StructArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
-        // If the struct array is empty then the indices must be all null, otherwise it will access
-        // an out of bounds element
-        if array.is_empty() {
-            return StructArray::try_new_with_dtype(
-                array.fields().clone(),
-                array.struct_fields().clone(),
-                indices.len(),
-                Validity::AllInvalid,
-            )
-            .map(StructArray::into_array);
-        }
-        // The validity is applied to the struct validity,
-        let inner_indices = &fill_null(
-            indices,
-            &Scalar::default_value(indices.dtype().with_nullability(NonNullable)),
-        )?;
-        StructArray::try_new_with_dtype(
-            array
-                .fields()
-                .iter()
-                .map(|field| take(field, inner_indices))
-                .collect::<Result<Vec<_>, _>>()?,
-            array.struct_fields().clone(),
-            indices.len(),
-            array.validity().take(indices)?,
-        )
-        .map(|a| a.into_array())
-    }
-}
-
-register_kernel!(TakeKernelAdapter(StructVTable).lift());
-
-impl MinMaxKernel for StructVTable {
-    fn min_max(&self, _array: &StructArray) -> VortexResult<Option<MinMaxResult>> {
-        // TODO(joe): Implement struct min max
-        Ok(None)
-    }
-}
-
-register_kernel!(MinMaxKernelAdapter(StructVTable).lift());
-
-impl IsConstantKernel for StructVTable {
-    fn is_constant(
-        &self,
-        array: &StructArray,
-        opts: &IsConstantOpts,
-    ) -> VortexResult<Option<bool>> {
-        let children = array.children();
-        if children.is_empty() {
-            return Ok(Some(true));
-        }
-
-        for child in children.iter() {
-            match is_constant_opts(child, opts)? {
-                // Un-determined
-                None => return Ok(None),
-                Some(false) => return Ok(Some(false)),
-                Some(true) => {}
-            }
-        }
-
-        Ok(Some(true))
-    }
-}
-
-register_kernel!(IsConstantKernelAdapter(StructVTable).lift());
 
 #[cfg(test)]
 mod tests {

--- a/vortex-array/src/arrays/struct_/compute/take.rs
+++ b/vortex-array/src/arrays/struct_/compute/take.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::Nullability;
+use vortex_error::VortexResult;
+use vortex_scalar::Scalar;
+
+use crate::arrays::{StructArray, StructVTable};
+use crate::compute::{self, TakeKernel, TakeKernelAdapter};
+use crate::validity::Validity;
+use crate::vtable::ValidityHelper;
+use crate::{Array, ArrayRef, IntoArray, register_kernel};
+
+impl TakeKernel for StructVTable {
+    fn take(&self, array: &StructArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
+        // If the struct array is empty then the indices must be all null, otherwise it will access
+        // an out of bounds element
+        if array.is_empty() {
+            return StructArray::try_new_with_dtype(
+                array.fields().clone(),
+                array.struct_fields().clone(),
+                indices.len(),
+                Validity::AllInvalid,
+            )
+            .map(StructArray::into_array);
+        }
+        // The validity is applied to the struct validity,
+        let inner_indices = &compute::fill_null(
+            indices,
+            &Scalar::default_value(indices.dtype().with_nullability(Nullability::NonNullable)),
+        )?;
+        StructArray::try_new_with_dtype(
+            array
+                .fields()
+                .iter()
+                .map(|field| compute::take(field, inner_indices))
+                .collect::<Result<Vec<_>, _>>()?,
+            array.struct_fields().clone(),
+            indices.len(),
+            array.validity().take(indices)?,
+        )
+        .map(|a| a.into_array())
+    }
+}
+
+register_kernel!(TakeKernelAdapter(StructVTable).lift());

--- a/vortex-array/src/arrays/varbinview/compute/mod.rs
+++ b/vortex-array/src/arrays/varbinview/compute/mod.rs
@@ -8,6 +8,7 @@ mod is_sorted;
 mod mask;
 mod min_max;
 mod take;
+
 #[cfg(test)]
 mod tests {
     use vortex_buffer::buffer;


### PR DESCRIPTION
Makes sure each compute function implementation has its own file.

Note that this is a purely cosmetic change.

Yes, this is verbose, but also it's better to be consistent (and it also helps with discoverability, for example "which compute functions exist for this array type?).