### PR TITLE
fix[vortex-io]: register read_at intent in InstrumentedReadAt

### DIFF
--- a/vortex-io/src/read.rs
+++ b/vortex-io/src/read.rs
@@ -204,10 +204,10 @@ impl<T: VortexReadAt> VortexReadAt for InstrumentedReadAt<T> {
     ) -> BoxFuture<'static, VortexResult<ByteBuffer>> {
         let durations = self.durations.clone();
         let sizes = self.sizes.clone();
-        let read = self.read.clone();
+        let read_fut = self.read.read_at(offset, length, alignment);
         async move {
             let _timer = durations.time();
-            let buf = read.read_at(offset, length, alignment).await;
+            let buf = read_fut.await;
             sizes.update(length as i64);
             buf
         }


### PR DESCRIPTION
This VortexReadAt implementation was unintentionally not registering its read_at intent until polled, which breaks scan pipeline coalescing.

Just for informational purposes, this reduced our object store requests by 80% for an example file scan.