### PR TITLE
Stop enabling `pyo3/extension-modules` by default

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -20,5 +20,4 @@ timeout = 3600
 
 # Environment variables for PyO3. Ensures reproducible builds and avoids spurious recompilations.
 [env]
-PYO3_PYTHON = { value = ".venv/bin/python", relative = true, force = true }
 PYO3_ENVIRONMENT_SIGNATURE = { value = "cpython-3.11-64bit", force = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ primitive-types = { version = "0.14.0" }
 prost = "0.14"
 prost-build = "0.14"
 prost-types = "0.14"
-pyo3 = { version = "0.26.0", features = ["extension-module", "abi3-py310"] }
+pyo3 = { version = "0.26.0", features = ["abi3", "abi3-py310"] }
 pyo3-log = "0.13.0"
 rand = "0.9.0"
 rand_distr = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ primitive-types = { version = "0.14.0" }
 prost = "0.14"
 prost-build = "0.14"
 prost-types = "0.14"
-pyo3 = { version = "0.26.0", features = ["abi3", "abi3-py310"] }
+pyo3 = { version = "0.26.0" }
 pyo3-log = "0.13.0"
 rand = "0.9.0"
 rand_distr = "0.5"

--- a/vortex-python/Cargo.toml
+++ b/vortex-python/Cargo.toml
@@ -30,7 +30,7 @@ log = { workspace = true }
 mimalloc = { workspace = true }
 object_store = { workspace = true, features = ["aws", "gcp", "azure", "http"] }
 parking_lot = { workspace = true }
-pyo3 = { workspace = true, features = ["abi3-py311"] }
+pyo3 = { workspace = true, features = ["abi3", "abi3-py311"] }
 pyo3-log = { workspace = true }
 tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
 url = { workspace = true }


### PR DESCRIPTION
See [this](https://pyo3.rs/main/building-and-distribution#the-extension-module-feature) section the pyo3's docs. We already enable it when building the whl with maturin.