### PR TITLE
performance[vortex-scan]: improve IO pipelining

### DIFF
--- a/vortex-scan/src/repeated_scan.rs
+++ b/vortex-scan/src/repeated_scan.rs
@@ -5,8 +5,9 @@ use std::ops::Range;
 use std::sync::Arc;
 use std::{cmp, iter};
 
-use futures::Stream;
 use futures::future::BoxFuture;
+use futures::stream::{FuturesOrdered, FuturesUnordered};
+use futures::{Stream, StreamExt};
 use itertools::{Either, Itertools};
 use vortex_array::ArrayRef;
 use vortex_array::iter::{ArrayIterator, ArrayIteratorAdapter};
@@ -166,23 +167,61 @@ impl<A: 'static + Send> RepeatedScan<A> {
         &self,
         row_range: Option<Range<u64>>,
     ) -> VortexResult<impl Stream<Item = VortexResult<A>> + Send + 'static + use<A>> {
-        use futures::StreamExt;
         let num_workers = std::thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(1);
         let concurrency = self.concurrency * num_workers;
         let handle = self.handle.clone();
 
-        let stream =
-            futures::stream::iter(self.execute(row_range)?).map(move |task| handle.spawn(task));
+        let tasks = self.execute(row_range)?;
+        let ordered = self.ordered;
 
-        let stream = if self.ordered {
-            stream.buffered(concurrency).boxed()
+        let stream = if tasks.len() < concurrency {
+            let stream = futures::stream::iter(tasks).map(move |task| handle.spawn(task));
+            let stream = if ordered {
+                stream.buffered(concurrency).boxed()
+            } else {
+                stream.buffer_unordered(concurrency).boxed()
+            };
+            stream
+                .filter_map(|chunk| async move { chunk.transpose() })
+                .boxed()
         } else {
-            stream.buffer_unordered(concurrency).boxed()
+            // Each group of tasks.len() / concurrency will be spawned
+            // separately. Since individual tasks may be blocked awaiting IO
+            // results, grouping them allows polling other tasks in the
+            // meantime that in turn will trigger IO requests and therefore
+            // offer better IO pipelining.
+            let chunk_size = tasks.len() / concurrency;
+            let task_chunks: Vec<Vec<_>> = tasks
+                .into_iter()
+                .chunks(chunk_size)
+                .into_iter()
+                .map(|chunk| chunk.collect())
+                .collect();
+
+            let stream = futures::stream::iter(task_chunks.into_iter().map(move |chunk| {
+                if ordered {
+                    Either::Left(FuturesOrdered::from_iter(chunk).collect::<Vec<_>>())
+                } else {
+                    Either::Right(FuturesUnordered::from_iter(chunk).collect::<Vec<_>>())
+                }
+            }))
+            .map(move |task| handle.spawn(task));
+
+            let stream = if ordered {
+                stream.buffered(concurrency).boxed()
+            } else {
+                stream.buffer_unordered(concurrency).boxed()
+            };
+
+            stream
+                .flat_map(futures::stream::iter)
+                .filter_map(|chunk| async move { chunk.transpose() })
+                .boxed()
         };
 
-        Ok(stream.filter_map(|chunk| async move { chunk.transpose() }))
+        Ok(stream)
     }
 }
 


### PR DESCRIPTION
> [!NOTE]
> This PR is a proposal and might not be merged in its current form or at all. The primary motivation is performance, but I would also like to trigger a discussion about the intended scheduling strategy for scans. The downside is that we reduce or even eliminate the ability for the user to perform backpressure on the scan by not polling from the stream. However, at the same time there seems to be an assumption/expectation that we highly parallelize IO: https://github.com/vortex-data/vortex/blob/d37444ac497590c2a6139e7ccee49b36a7997f81/vortex-io/src/file/object_store.rs#L24. Another way to achieve the same result as this PR is to simply bump up the scan builder concurrency knob, which I guess is a way for the user to explicitly opt-in to more IO parallelization as a consequence. 

The issue with the current approach of using `buffered(concurrency)` is that all of the `concurrency` tasks currently executing might be awaiting the same coalesced IO operation, which stops other `split_exec` tasks from making progress by issuing and awaiting their own IO requests.

The approach proposed in this commit is to group all `split_exec` tasks into `concurrency` Futures{Ordered,Unordered} groups so `concurrency` tasks are executing in parallel, but other futures in that group can make progress concurrently (not in parallel) during IO awaits.

This results in better pipelining IO operations with the downside of possibly increased memory use. This patch was motivated because drive_send seems to expect to expect to execute `CONCURRENCY` (192 by default): https://github.com/vortex-data/vortex/blob/d37444ac497590c2a6139e7ccee49b36a7997f81/vortex-io/src/file/object_store.rs#L24 concurrent requests but this is in practice much less because of the split_exec scheduling strategy.

Before:
<img width="1274" height="495" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/9ad8545c-bcf6-4fd7-9552-aa05df4126e8" />

After:
<img width="1265" height="494" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/9a9f1244-f6ed-499c-b899-0a6833a70b06" />
