### PR TITLE
Clear up difference between struct fields and columns

### DIFF
--- a/bench-vortex/src/bin/random_access.rs
+++ b/bench-vortex/src/bin/random_access.rs
@@ -207,10 +207,10 @@ fn validate_vortex_array(array: ArrayRef) {
     let struct_ = array.to_struct();
     assert_eq!(struct_.len(), 6, "expected 6 rows");
     let pu_location_id = struct_
-        .field_by_name("PULocationID")
+        .column_by_name("PULocationID")
         .vortex_expect("could not get PULocationID");
     let do_location_id = struct_
-        .field_by_name("DOLocationID")
+        .column_by_name("DOLocationID")
         .vortex_expect("could not get DOLocationID");
     for (idx, loc) in [90i32, 249, 230, 79, 239, 236].iter().enumerate() {
         assert_eq!(

--- a/encodings/sequence/src/serde.rs
+++ b/encodings/sequence/src/serde.rs
@@ -104,7 +104,7 @@ mod tests {
     #[tokio::test]
     async fn round_trip_seq() {
         let seq = SequenceArray::typed_new(2i8, 3, Nullability::NonNullable, 4).unwrap();
-        let st = StructArray::from_fields(&[("a", seq.to_array())]).unwrap();
+        let st = StructArray::from_columns(&[("a", seq.to_array())]).unwrap();
 
         let mut file = tokio::fs::File::create("/tmp/abc.vx").await.unwrap();
         VortexWriteOptions::default()

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -19,8 +19,8 @@ use vortex_array::vtable::{CanonicalVTable, ValidityHelper};
 use vortex_array::{Array, Canonical, ToCanonical};
 use vortex_buffer::{Buffer, BufferString, ByteBuffer, buffer, buffer_mut};
 use vortex_dtype::{
-    DType, DecimalDType, IntegerPType, NativePType, Nullability, StructFields,
-    match_each_integer_ptype, match_each_native_ptype,
+    DType, DecimalDType, Fields, IntegerPType, NativePType, Nullability, match_each_integer_ptype,
+    match_each_native_ptype,
 };
 use vortex_error::{VortexError, VortexExpect, vortex_panic};
 use vortex_scalar::{
@@ -352,14 +352,14 @@ fn canonicalize_sparse_primitives<
 }
 
 fn canonicalize_sparse_struct(
-    struct_fields: &StructFields,
+    struct_fields: &Fields,
     fill_struct: StructScalar,
     dtype: &DType,
     // Resolution is unnecessary b/c we're just pushing the patches into the fields.
     unresolved_patches: &Patches,
     len: usize,
 ) -> Canonical {
-    let (fill_values, top_level_fill_validity) = match fill_struct.fields() {
+    let (fill_values, top_level_fill_validity) = match fill_struct.columns() {
         Some(fill_values) => (fill_values.collect::<Vec<_>>(), Validity::AllValid),
         None => (
             struct_fields
@@ -370,7 +370,7 @@ fn canonicalize_sparse_struct(
         ),
     };
     let patch_values_as_struct = unresolved_patches.values().to_struct();
-    let columns_patch_values = patch_values_as_struct.fields();
+    let columns_patch_values = patch_values_as_struct.columns();
     let names = patch_values_as_struct.names();
     let validity = if dtype.is_nullable() {
         top_level_fill_validity.patch(
@@ -508,7 +508,7 @@ mod test {
     use vortex_array::{IntoArray, ToCanonical};
     use vortex_buffer::{ByteBuffer, buffer, buffer_mut};
     use vortex_dtype::Nullability::{NonNullable, Nullable};
-    use vortex_dtype::{DType, DecimalDType, FieldNames, PType, StructFields};
+    use vortex_dtype::{DType, DecimalDType, FieldNames, Fields, PType};
     use vortex_mask::Mask;
     use vortex_scalar::{DecimalValue, Scalar};
 
@@ -619,7 +619,7 @@ mod test {
             DType::Primitive(PType::I32, Nullable),
             DType::Primitive(PType::I32, Nullable),
         ];
-        let struct_fields = StructFields::new(field_names, field_types);
+        let struct_fields = Fields::new(field_names, field_types);
         let struct_dtype = DType::Struct(struct_fields.clone(), Nullable);
 
         let indices = buffer![0u64, 1, 7, 8].into_array();
@@ -697,7 +697,7 @@ mod test {
             DType::Primitive(PType::I32, Nullable),
             DType::Primitive(PType::I32, Nullable),
         ];
-        let struct_fields = StructFields::new(field_names, field_types);
+        let struct_fields = Fields::new(field_names, field_types);
         let struct_dtype = DType::Struct(struct_fields.clone(), Nullable);
 
         let indices = buffer![0u64, 1, 7, 8].into_array();

--- a/fuzz/fuzz_targets/file_io.rs
+++ b/fuzz/fuzz_targets/file_io.rs
@@ -10,7 +10,7 @@ use vortex_array::arrays::ChunkedArray;
 use vortex_array::compute::{Operator, compare, filter};
 use vortex_array::{Array, Canonical, IntoArray, ToCanonical};
 use vortex_buffer::ByteBufferMut;
-use vortex_dtype::{DType, StructFields};
+use vortex_dtype::{DType, Fields};
 use vortex_error::{VortexExpect, VortexUnwrap, vortex_panic};
 use vortex_expr::{Scope, lit, root};
 use vortex_file::{VortexOpenOptions, VortexWriteOptions, WriteStrategyBuilder};
@@ -133,7 +133,7 @@ fn has_duplicate_field_names(dtype: &DType) -> bool {
     }
 }
 
-fn struct_has_duplicate_names(struct_dtype: &StructFields) -> bool {
+fn struct_has_duplicate_names(struct_dtype: &Fields) -> bool {
     HashSet::<_, DefaultHashBuilder>::from_iter(struct_dtype.names().iter()).len()
         != struct_dtype.names().len()
         || struct_dtype

--- a/fuzz/src/array/filter.rs
+++ b/fuzz/src/array/filter.rs
@@ -86,14 +86,14 @@ pub fn filter_canonical_array(array: &dyn Array, filter: &[bool]) -> VortexResul
         DType::Struct(..) => {
             let struct_array = array.to_struct();
             let filtered_children = struct_array
-                .fields()
+                .columns()
                 .iter()
                 .map(|c| filter_canonical_array(c, filter))
                 .collect::<VortexResult<Vec<_>>>()?;
 
             StructArray::try_new_with_dtype(
                 filtered_children,
-                struct_array.struct_fields().clone(),
+                struct_array.fields().clone(),
                 filter.iter().filter(|b| **b).map(|b| *b as usize).sum(),
                 validity,
             )

--- a/fuzz/src/array/slice.rs
+++ b/fuzz/src/array/slice.rs
@@ -53,13 +53,13 @@ pub fn slice_canonical_array(
         DType::Struct(..) => {
             let struct_array = array.to_struct();
             let sliced_children = struct_array
-                .fields()
+                .columns()
                 .iter()
                 .map(|c| slice_canonical_array(c, start, stop))
                 .collect::<VortexResult<Vec<_>>>()?;
             StructArray::try_new_with_dtype(
                 sliced_children,
-                struct_array.struct_fields().clone(),
+                struct_array.fields().clone(),
                 stop - start,
                 validity,
             )

--- a/fuzz/src/array/take.rs
+++ b/fuzz/src/array/take.rs
@@ -100,7 +100,7 @@ pub fn take_canonical_array(
         DType::Struct(..) => {
             let struct_array = array.to_struct();
             let taken_children = struct_array
-                .fields()
+                .columns()
                 .iter()
                 .map(|c| take_canonical_array_non_nullable_indices(c, indices_slice_non_opt))
                 .collect::<VortexResult<Vec<_>>>()?;

--- a/vortex-array/src/array/display/mod.rs
+++ b/vortex-array/src/array/display/mod.rs
@@ -70,7 +70,7 @@ pub enum DisplayOptions {
     /// # use vortex_array::arrays::StructArray;
     /// # use vortex_array::IntoArray;
     /// # use vortex_buffer::buffer;
-    /// let s = StructArray::from_fields(&[
+    /// let s = StructArray::from_columns(&[
     ///     ("x", buffer![1, 2].into_array()),
     ///     ("y", buffer![3, 4].into_array()),
     /// ]).unwrap().into_array();
@@ -199,7 +199,7 @@ impl dyn Array + '_ {
     /// # use vortex_array::arrays::StructArray;
     /// # use vortex_array::IntoArray;
     /// # use vortex_buffer::buffer;
-    /// let s = StructArray::from_fields(&[
+    /// let s = StructArray::from_columns(&[
     ///     ("x", buffer![1, 2].into_array()),
     ///     ("y", buffer![3, 4].into_array()),
     /// ]).unwrap().into_array();
@@ -274,7 +274,7 @@ impl dyn Array + '_ {
                         builder.push_record(null_row);
                     } else {
                         let mut row = Vec::new();
-                        for field_array in struct_.fields().iter() {
+                        for field_array in struct_.columns().iter() {
                             let value = field_array.scalar_at(row_idx);
                             row.push(value.to_string());
                         }
@@ -342,7 +342,7 @@ mod test {
 
     #[test]
     fn test_simple_struct() {
-        let s = StructArray::from_fields(&[
+        let s = StructArray::from_columns(&[
             ("x", buffer![1, 2, 3, 4].into_array()),
             ("y", buffer![-1, -2, -3, -4].into_array()),
         ])

--- a/vortex-array/src/arrays/chunked/tests.rs
+++ b/vortex-array/src/arrays/chunked/tests.rs
@@ -151,8 +151,8 @@ pub fn pack_nested_structs() {
     .unwrap()
     .into_array();
     let canonical_struct = chunked.to_struct();
-    let canonical_varbin = canonical_struct.fields()[0].to_varbinview();
-    let original_varbin = struct_array.fields()[0].to_varbinview();
+    let canonical_varbin = canonical_struct.columns()[0].to_varbinview();
+    let original_varbin = struct_array.columns()[0].to_varbinview();
     let orig_values = original_varbin
         .with_iterator(|it| it.map(|a| a.map(|v| v.to_vec())).collect::<Vec<_>>())
         .unwrap();

--- a/vortex-array/src/arrays/chunked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/chunked/vtable/canonical.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_buffer::BufferMut;
-use vortex_dtype::{DType, Nullability, PType, StructFields};
+use vortex_dtype::{DType, Nullability, PType, Fields};
 use vortex_error::VortexExpect;
 
 use crate::arrays::{ChunkedArray, ChunkedVTable, ListViewArray, PrimitiveArray, StructArray};
@@ -57,7 +57,7 @@ impl CanonicalVTable<ChunkedVTable> for ChunkedVTable {
 fn pack_struct_chunks(
     chunks: &[ArrayRef],
     validity: Validity,
-    struct_dtype: &StructFields,
+    struct_dtype: &Fields,
 ) -> StructArray {
     let len = chunks.iter().map(|chunk| chunk.len()).sum();
     let mut field_arrays = Vec::new();
@@ -67,7 +67,7 @@ fn pack_struct_chunks(
             .iter()
             .map(|c| {
                 c.to_struct()
-                    .fields()
+                    .columns()
                     .get(field_idx)
                     .vortex_expect("Invalid field index")
                     .to_array()
@@ -201,8 +201,8 @@ mod tests {
         .unwrap()
         .into_array();
         let canonical_struct = chunked.to_struct();
-        let canonical_varbin = canonical_struct.fields()[0].to_varbinview();
-        let original_varbin = struct_array.fields()[0].to_varbinview();
+        let canonical_varbin = canonical_struct.columns()[0].to_varbinview();
+        let original_varbin = struct_array.columns()[0].to_varbinview();
         let orig_values = original_varbin
             .with_iterator(|it| it.map(|a| a.map(|v| v.to_vec())).collect::<Vec<_>>())
             .unwrap();

--- a/vortex-array/src/arrays/chunked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/chunked/vtable/canonical.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_buffer::BufferMut;
-use vortex_dtype::{DType, Nullability, PType, Fields};
+use vortex_dtype::{DType, Fields, Nullability, PType};
 use vortex_error::VortexExpect;
 
 use crate::arrays::{ChunkedArray, ChunkedVTable, ListViewArray, PrimitiveArray, StructArray};

--- a/vortex-array/src/arrays/constant/vtable/canonical.rs
+++ b/vortex-array/src/arrays/constant/vtable/canonical.rs
@@ -119,7 +119,7 @@ impl CanonicalVTable<ConstantVTable> for ConstantVTable {
             }
             DType::Struct(struct_dtype, _) => {
                 let value = StructScalar::try_from(scalar).vortex_expect("must be struct");
-                let fields: Vec<_> = match value.fields() {
+                let fields: Vec<_> = match value.columns() {
                     Some(fields) => fields
                         .into_iter()
                         .map(|s| ConstantArray::new(s, array.len()).into_array())
@@ -460,7 +460,7 @@ mod tests {
         assert_eq!(struct_array.len(), 3);
         assert_eq!(struct_array.valid_count(), 0);
 
-        let field = struct_array.field_by_name("non_null_field").unwrap();
+        let field = struct_array.column_by_name("non_null_field").unwrap();
 
         assert_eq!(
             field.dtype(),

--- a/vortex-array/src/arrays/fixed_size_list/tests/nested.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/nested.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use vortex_buffer::buffer;
-use vortex_dtype::{DType, FieldNames, Nullability, PType, Fields};
+use vortex_dtype::{DType, FieldNames, Fields, Nullability, PType};
 use vortex_scalar::Scalar;
 
 use crate::arrays::{FixedSizeListArray, PrimitiveArray, StructArray};

--- a/vortex-array/src/arrays/fixed_size_list/tests/nested.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/nested.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use vortex_buffer::buffer;
-use vortex_dtype::{DType, FieldNames, Nullability, PType, StructFields};
+use vortex_dtype::{DType, FieldNames, Nullability, PType, Fields};
 use vortex_scalar::Scalar;
 
 use crate::arrays::{FixedSizeListArray, PrimitiveArray, StructArray};
@@ -387,7 +387,7 @@ fn test_fsl_of_struct() {
     let fsl_size = 3u32;
 
     // Create a struct with two fields: a: i32, b: f64.
-    let struct_fields = StructFields::new(
+    let struct_fields = Fields::new(
         FieldNames::from(["a", "b"].as_slice()),
         vec![
             DType::Primitive(PType::I32, Nullability::NonNullable),
@@ -432,7 +432,7 @@ fn test_fsl_of_nullable_struct() {
     let fsl_size = 2u32;
 
     // Create a nullable struct.
-    let struct_fields = StructFields::new(
+    let struct_fields = Fields::new(
         FieldNames::from(["x", "y"].as_slice()),
         vec![
             DType::Primitive(PType::U32, Nullability::NonNullable),
@@ -478,7 +478,7 @@ fn test_fsl_with_empty_struct() {
     let fsl_size = 3u32;
 
     // Create an empty struct (no fields).
-    let struct_fields = StructFields::empty();
+    let struct_fields = Fields::empty();
 
     let struct_array = StructArray::try_new(
         struct_fields.names().clone(),
@@ -509,7 +509,7 @@ fn test_struct_of_fsl() {
     let fsl2_elements = buffer![1.1f64, 2.2, 3.3, 4.4, 5.5, 6.6].into_array();
     let fsl2 = FixedSizeListArray::new(fsl2_elements, 2, Validity::NonNullable, 3);
 
-    let struct_fields = StructFields::new(
+    let struct_fields = Fields::new(
         FieldNames::from(["int_lists", "float_lists"].as_slice()),
         vec![
             DType::FixedSizeList(

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -151,7 +151,7 @@ pub fn recursive_list_from_list_view(array: ArrayRef) -> ArrayRef {
             }
         }
         Canonical::Struct(struct_array) => {
-            let fields = struct_array.fields();
+            let fields = struct_array.columns();
             let mut converted_fields = Vec::with_capacity(fields.len());
             let mut any_changed = false;
 

--- a/vortex-array/src/arrays/listview/tests/nested.rs
+++ b/vortex-array/src/arrays/listview/tests/nested.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_buffer::buffer;
-use vortex_dtype::{DType, FieldNames, Nullability, PType, Fields};
+use vortex_dtype::{DType, FieldNames, Fields, Nullability, PType};
 
 use crate::arrays::{ListViewArray, ListViewVTable, PrimitiveArray, StructArray};
 use crate::validity::Validity;

--- a/vortex-array/src/arrays/listview/tests/nested.rs
+++ b/vortex-array/src/arrays/listview/tests/nested.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_buffer::buffer;
-use vortex_dtype::{DType, FieldNames, Nullability, PType, StructFields};
+use vortex_dtype::{DType, FieldNames, Nullability, PType, Fields};
 
 use crate::arrays::{ListViewArray, ListViewVTable, PrimitiveArray, StructArray};
 use crate::validity::Validity;
@@ -278,7 +278,7 @@ fn test_listview_zero_and_overlapping() {
 #[test]
 fn test_listview_of_struct_with_nulls() {
     // Create structs with fields that could be null.
-    let struct_fields = StructFields::new(
+    let struct_fields = Fields::new(
         FieldNames::from(["id", "value"].as_slice()),
         vec![
             DType::Primitive(PType::U32, Nullability::NonNullable),

--- a/vortex-array/src/arrays/struct_/array.rs
+++ b/vortex-array/src/arrays/struct_/array.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use std::iter::once;
 use std::sync::Arc;
 
-use vortex_dtype::{DType, FieldName, FieldNames, StructFields};
+use vortex_dtype::{DType, FieldName, FieldNames, Fields};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
 
 use crate::stats::ArrayStats;
@@ -21,7 +21,7 @@ use crate::{Array, ArrayRef, IntoArray};
 /// ## Data Layout
 ///
 /// The struct array uses a columnar layout where:
-/// - Each field is stored as a separate child array
+/// - Each columns is stored as a separate child array
 /// - All fields must have the same length (number of rows)
 /// - Field names and types are defined in the struct's dtype
 /// - An optional validity mask indicates which entire rows are null
@@ -29,7 +29,7 @@ use crate::{Array, ArrayRef, IntoArray};
 /// ## Row-level nulls
 ///
 /// The StructArray contains its own top-level nulls, which are superimposed on top of the
-/// field-level validity values. This can be the case even if the fields themselves are non-nullable,
+/// field-level validity values. This can be the case even if the columns themselves are non-nullable,
 /// accessing a particular row can yield nulls even if all children are valid at that position.
 ///
 /// ```
@@ -51,7 +51,7 @@ use crate::{Array, ArrayRef, IntoArray};
 ///     Validity::Array(BoolArray::from_iter([true, false]).into_array()), // row 1 is null
 /// ).unwrap();
 ///
-/// // Row 0 is valid - returns a struct scalar with field values
+/// // Row 0 is valid - returns a struct scalar with column values
 /// let row0 = struct_array.scalar_at(0);
 /// assert!(!row0.is_null());
 ///
@@ -83,25 +83,25 @@ use crate::{Array, ArrayRef, IntoArray};
 ///     Validity::NonNullable,
 /// ).unwrap();
 ///
-/// // field_by_name returns the FIRST "data" field
-/// let first_data = struct_array.field_by_name("data").unwrap();
+/// // column_by_name returns the FIRST "data" field
+/// let first_data = struct_array.column_by_name("data").unwrap();
 /// assert_eq!(first_data.scalar_at(0), 1i32.into());
 /// ```
 ///
 /// ## Field Operations
 ///
 /// Struct arrays support efficient column operations:
-/// - **Projection**: Select/reorder fields without copying data
+/// - **Projection**: Select/reorder columns without copying data
 /// - **Field access**: Get columns by name or index
-/// - **Column addition**: Add new fields to create extended structs
-/// - **Column removal**: Remove fields to create narrower structs
+/// - **Column addition**: Add new columns to create extended structs
+/// - **Column removal**: Remove columns to create narrower structs
 ///
 /// ## Validity Semantics
 ///
 /// - Row-level nulls are tracked in the struct's validity child
-/// - Individual field nulls are tracked in each field's own validity
-/// - A null struct row means all fields in that row are conceptually null
-/// - Field-level nulls can exist independently of struct-level nulls
+/// - Individual column nulls are tracked in each columns's own validity
+/// - A null struct row means all columns in that row are conceptually null
+/// - Column-level nulls can exist independently of struct-level nulls
 ///
 /// # Examples
 ///
@@ -127,27 +127,27 @@ use crate::{Array, ArrayRef, IntoArray};
 /// assert_eq!(struct_array.len(), 3);
 /// assert_eq!(struct_array.names().len(), 2);
 ///
-/// // Access field by name
-/// let id_field = struct_array.field_by_name("id").unwrap();
+/// // Access column by name
+/// let id_field = struct_array.column_by_name("id").unwrap();
 /// assert_eq!(id_field.len(), 3);
 /// ```
 #[derive(Clone, Debug)]
 pub struct StructArray {
     pub(super) len: usize,
     pub(super) dtype: DType,
-    pub(super) fields: Arc<[ArrayRef]>,
+    pub(super) columns: Arc<[ArrayRef]>,
     pub(super) validity: Validity,
     pub(super) stats_set: ArrayStats,
 }
 
 impl StructArray {
-    pub fn fields(&self) -> &Arc<[ArrayRef]> {
-        &self.fields
+    pub fn columns(&self) -> &Arc<[ArrayRef]> {
+        &self.columns
     }
 
-    pub fn field_by_name(&self, name: impl AsRef<str>) -> VortexResult<&ArrayRef> {
+    pub fn column_by_name(&self, name: impl AsRef<str>) -> VortexResult<&ArrayRef> {
         let name = name.as_ref();
-        self.field_by_name_opt(name).ok_or_else(|| {
+        self.column_by_name_opt(name).ok_or_else(|| {
             vortex_err!(
                 "Field {name} not found in struct array with names {:?}",
                 self.names()
@@ -155,16 +155,16 @@ impl StructArray {
         })
     }
 
-    pub fn field_by_name_opt(&self, name: impl AsRef<str>) -> Option<&ArrayRef> {
+    pub fn column_by_name_opt(&self, name: impl AsRef<str>) -> Option<&ArrayRef> {
         let name = name.as_ref();
-        self.struct_fields().find(name).map(|idx| &self.fields[idx])
+        self.fields().find(name).map(|idx| &self.columns[idx])
     }
 
     pub fn names(&self) -> &FieldNames {
-        self.struct_fields().names()
+        self.fields().names()
     }
 
-    pub fn struct_fields(&self) -> &StructFields {
+    pub fn fields(&self) -> &Fields {
         let Some(struct_dtype) = &self.dtype.as_struct_fields_opt() else {
             unreachable!(
                 "struct arrays must have be a DType::Struct, this is likely an internal bug."
@@ -192,11 +192,11 @@ impl StructArray {
     /// in [`StructArray::new_unchecked`].
     pub fn new(
         names: FieldNames,
-        fields: impl Into<Arc<[ArrayRef]>>,
+        columns: impl Into<Arc<[ArrayRef]>>,
         length: usize,
         validity: Validity,
     ) -> Self {
-        Self::try_new(names, fields, length, validity)
+        Self::try_new(names, columns, length, validity)
             .vortex_expect("StructArray construction failed")
     }
 
@@ -210,18 +210,18 @@ impl StructArray {
     /// [`StructArray::new_unchecked`].
     pub fn try_new(
         names: FieldNames,
-        fields: impl Into<Arc<[ArrayRef]>>,
+        columns: impl Into<Arc<[ArrayRef]>>,
         length: usize,
         validity: Validity,
     ) -> VortexResult<Self> {
-        let fields = fields.into();
-        let field_dtypes: Vec<_> = fields.iter().map(|d| d.dtype()).cloned().collect();
-        let dtype = StructFields::new(names, field_dtypes);
+        let columns = columns.into();
+        let field_dtypes: Vec<_> = columns.iter().map(|d| d.dtype()).cloned().collect();
+        let dtype = Fields::new(names, field_dtypes);
 
-        Self::validate(&fields, &dtype, length, &validity)?;
+        Self::validate(&columns, &dtype, length, &validity)?;
 
         // SAFETY: validate ensures all invariants are met.
-        Ok(unsafe { Self::new_unchecked(fields, dtype, length, validity) })
+        Ok(unsafe { Self::new_unchecked(columns, dtype, length, validity) })
     }
 
     /// Creates a new [`StructArray`] without validation from these components:
@@ -250,21 +250,21 @@ impl StructArray {
     ///
     /// - If `validity` is [`Validity::Array`], its length must exactly equal `length`.
     pub unsafe fn new_unchecked(
-        fields: impl Into<Arc<[ArrayRef]>>,
-        dtype: StructFields,
+        columns: impl Into<Arc<[ArrayRef]>>,
+        dtype: Fields,
         length: usize,
         validity: Validity,
     ) -> Self {
-        let fields = fields.into();
+        let columns = columns.into();
 
         #[cfg(debug_assertions)]
-        Self::validate(&fields, &dtype, length, &validity)
+        Self::validate(&columns, &dtype, length, &validity)
             .vortex_expect("[Debug Assertion]: Invalid `StructArray` parameters");
 
         Self {
             len: length,
             dtype: DType::Struct(dtype, validity.nullability()),
-            fields,
+            columns,
             validity,
             stats_set: Default::default(),
         }
@@ -274,36 +274,36 @@ impl StructArray {
     ///
     /// This function checks all the invariants required by [`StructArray::new_unchecked`].
     pub fn validate(
-        fields: &[ArrayRef],
-        dtype: &StructFields,
+        columns: &[ArrayRef],
+        dtype: &Fields,
         length: usize,
         validity: &Validity,
     ) -> VortexResult<()> {
         // Check field count matches
-        if fields.len() != dtype.names().len() {
+        if columns.len() != dtype.names().len() {
             vortex_bail!(
                 "Got {} fields but dtype has {} names",
-                fields.len(),
+                columns.len(),
                 dtype.names().len()
             );
         }
 
         // Check each field's length and dtype
-        for (i, (field, struct_dt)) in fields.iter().zip(dtype.fields()).enumerate() {
-            if field.len() != length {
+        for (i, (column, struct_dt)) in columns.iter().zip(dtype.fields()).enumerate() {
+            if column.len() != length {
                 vortex_bail!(
                     "Field {} has length {} but expected {}",
                     i,
-                    field.len(),
+                    column.len(),
                     length
                 );
             }
 
-            if field.dtype() != &struct_dt {
+            if column.dtype() != &struct_dt {
                 vortex_bail!(
                     "Field {} has dtype {} but expected {}",
                     i,
-                    field.dtype(),
+                    column.dtype(),
                     struct_dt
                 );
             }
@@ -324,19 +324,19 @@ impl StructArray {
     }
 
     pub fn try_new_with_dtype(
-        fields: impl Into<Arc<[ArrayRef]>>,
-        dtype: StructFields,
+        columns: impl Into<Arc<[ArrayRef]>>,
+        dtype: Fields,
         length: usize,
         validity: Validity,
     ) -> VortexResult<Self> {
-        let fields = fields.into();
-        Self::validate(&fields, &dtype, length, &validity)?;
+        let columns = columns.into();
+        Self::validate(&columns, &dtype, length, &validity)?;
 
         // SAFETY: validate ensures all invariants are met.
-        Ok(unsafe { Self::new_unchecked(fields, dtype, length, validity) })
+        Ok(unsafe { Self::new_unchecked(columns, dtype, length, validity) })
     }
 
-    pub fn from_fields<N: AsRef<str>>(items: &[(N, ArrayRef)]) -> VortexResult<Self> {
+    pub fn from_columns<N: AsRef<str>>(items: &[(N, ArrayRef)]) -> VortexResult<Self> {
         Self::try_from_iter(items.iter().map(|(a, b)| (a, b.to_array())))
     }
 
@@ -348,16 +348,16 @@ impl StructArray {
         iter: T,
         validity: Validity,
     ) -> VortexResult<Self> {
-        let (names, fields): (Vec<FieldName>, Vec<ArrayRef>) = iter
+        let (names, columns): (Vec<FieldName>, Vec<ArrayRef>) = iter
             .into_iter()
             .map(|(name, fields)| (FieldName::from(name.as_ref()), fields.into_array()))
             .unzip();
-        let len = fields
+        let len = columns
             .first()
             .map(|f| f.len())
             .ok_or_else(|| vortex_err!("StructArray cannot be constructed from an empty slice of arrays because the length is unspecified"))?;
 
-        Self::try_new(FieldNames::from_iter(names), fields, len, validity)
+        Self::try_new(FieldNames::from_iter(names), columns, len, validity)
     }
 
     pub fn try_from_iter<N: AsRef<str>, A: IntoArray, T: IntoIterator<Item = (N, A)>>(
@@ -378,7 +378,7 @@ impl StructArray {
         let mut children = Vec::with_capacity(projection.len());
         let mut names = Vec::with_capacity(projection.len());
 
-        let fields = self.fields();
+        let fields = self.columns();
         for f_name in projection.iter() {
             let idx = self
                 .names()
@@ -403,16 +403,16 @@ impl StructArray {
     pub fn remove_column(&mut self, name: impl Into<FieldName>) -> Option<ArrayRef> {
         let name = name.into();
 
-        let struct_dtype = self.struct_fields().clone();
+        let struct_dtype = self.fields().clone();
 
         let position = struct_dtype
             .names()
             .iter()
             .position(|field_name| field_name.as_ref() == name.as_ref())?;
 
-        let field = self.fields[position].clone();
+        let field = self.columns[position].clone();
         let new_fields: Arc<[ArrayRef]> = self
-            .fields
+            .columns
             .iter()
             .enumerate()
             .filter(|(i, _)| *i != position)
@@ -420,7 +420,7 @@ impl StructArray {
             .collect();
 
         if let Ok(new_dtype) = struct_dtype.without_field(position) {
-            self.fields = new_fields;
+            self.columns = new_fields;
             self.dtype = DType::Struct(new_dtype, self.dtype.nullability());
             return Some(field);
         }
@@ -430,13 +430,13 @@ impl StructArray {
     /// Create a new StructArray by appending a new column onto the existing array.
     pub fn with_column(&self, name: impl Into<FieldName>, array: ArrayRef) -> VortexResult<Self> {
         let name = name.into();
-        let struct_dtype = self.struct_fields().clone();
+        let struct_dtype = self.fields().clone();
 
         let names = struct_dtype.names().iter().cloned().chain(once(name));
         let types = struct_dtype.fields().chain(once(array.dtype().clone()));
-        let new_fields = StructFields::new(names.collect(), types.collect());
+        let new_fields = Fields::new(names.collect(), types.collect());
 
-        let children: Arc<[ArrayRef]> = self.fields.iter().cloned().chain(once(array)).collect();
+        let children: Arc<[ArrayRef]> = self.columns.iter().cloned().chain(once(array)).collect();
 
         Self::try_new_with_dtype(children, new_fields, self.len, self.validity.clone())
     }

--- a/vortex-array/src/arrays/struct_/compute/cast.rs
+++ b/vortex-array/src/arrays/struct_/compute/cast.rs
@@ -33,7 +33,7 @@ impl CastKernel for StructVTable {
         StructArray::try_new(
             target_sdtype.names().clone(),
             array
-                .fields()
+                .columns()
                 .iter()
                 .zip_eq(target_sdtype.fields())
                 .map(|(field, dtype)| cast(field, &dtype))

--- a/vortex-array/src/arrays/struct_/compute/filter.rs
+++ b/vortex-array/src/arrays/struct_/compute/filter.rs
@@ -15,7 +15,7 @@ impl FilterKernel for StructVTable {
         let validity = array.validity().filter(mask)?;
 
         let fields: Vec<ArrayRef> = array
-            .fields()
+            .columns()
             .iter()
             .map(|field| filter(field, mask))
             .try_collect()?;
@@ -24,7 +24,7 @@ impl FilterKernel for StructVTable {
             .map(|a| a.len())
             .unwrap_or_else(|| mask.true_count());
 
-        StructArray::try_new_with_dtype(fields, array.struct_fields().clone(), length, validity)
+        StructArray::try_new_with_dtype(fields, array.fields().clone(), length, validity)
             .map(|a| a.into_array())
     }
 }

--- a/vortex-array/src/arrays/struct_/compute/mask.rs
+++ b/vortex-array/src/arrays/struct_/compute/mask.rs
@@ -14,8 +14,8 @@ impl MaskKernel for StructVTable {
         let validity = array.validity().mask(filter_mask);
 
         StructArray::try_new_with_dtype(
+            array.columns().clone(),
             array.fields().clone(),
-            array.struct_fields().clone(),
             array.len(),
             validity,
         )

--- a/vortex-array/src/arrays/struct_/compute/mod.rs
+++ b/vortex-array/src/arrays/struct_/compute/mod.rs
@@ -14,7 +14,7 @@ mod tests {
     use Nullability::{NonNullable, Nullable};
     use rstest::rstest;
     use vortex_buffer::buffer;
-    use vortex_dtype::{DType, FieldNames, Nullability, PType, Fields};
+    use vortex_dtype::{DType, FieldNames, Fields, Nullability, PType};
     use vortex_error::VortexUnwrap;
     use vortex_mask::Mask;
     use vortex_scalar::Scalar;
@@ -182,15 +182,12 @@ mod tests {
         let array = StructArray::try_new(FieldNames::default(), vec![], 5, Validity::NonNullable)
             .unwrap()
             .into_array();
-        let non_nullable_dtype = DType::Struct(
-            Fields::new(FieldNames::default(), vec![]),
-            NonNullable,
-        );
+        let non_nullable_dtype =
+            DType::Struct(Fields::new(FieldNames::default(), vec![]), NonNullable);
         let casted = cast(&array, &non_nullable_dtype).unwrap();
         assert_eq!(casted.dtype(), &non_nullable_dtype);
 
-        let nullable_dtype =
-            DType::Struct(Fields::new(FieldNames::default(), vec![]), Nullable);
+        let nullable_dtype = DType::Struct(Fields::new(FieldNames::default(), vec![]), Nullable);
         let casted = cast(&array, &nullable_dtype).unwrap();
         assert_eq!(casted.dtype(), &nullable_dtype);
     }

--- a/vortex-array/src/arrays/struct_/compute/mod.rs
+++ b/vortex-array/src/arrays/struct_/compute/mod.rs
@@ -14,7 +14,7 @@ mod tests {
     use Nullability::{NonNullable, Nullable};
     use rstest::rstest;
     use vortex_buffer::buffer;
-    use vortex_dtype::{DType, FieldNames, Nullability, PType, StructFields};
+    use vortex_dtype::{DType, FieldNames, Nullability, PType, Fields};
     use vortex_error::VortexUnwrap;
     use vortex_mask::Mask;
     use vortex_scalar::Scalar;
@@ -50,14 +50,14 @@ mod tests {
         assert_eq!(
             taken.scalar_at(0),
             Scalar::struct_(
-                DType::Struct(StructFields::new(FieldNames::default(), vec![]), Nullable),
+                DType::Struct(Fields::new(FieldNames::default(), vec![]), Nullable),
                 vec![]
             )
         );
         assert_eq!(
             taken.scalar_at(1),
             Scalar::null(DType::Struct(
-                StructFields::new(FieldNames::default(), vec![]),
+                Fields::new(FieldNames::default(), vec![]),
                 Nullable
             ))
         );
@@ -65,7 +65,7 @@ mod tests {
 
     #[test]
     fn take_field_struct() {
-        let struct_arr = StructArray::from_fields(&[("a", buffer![0..10].into_array())]).unwrap();
+        let struct_arr = StructArray::from_columns(&[("a", buffer![0..10].into_array())]).unwrap();
         let indices = PrimitiveArray::from_option_iter([Some(1), None]);
         let taken = take(struct_arr.as_ref(), indices.as_ref()).unwrap();
         assert_eq!(taken.len(), 2);
@@ -183,14 +183,14 @@ mod tests {
             .unwrap()
             .into_array();
         let non_nullable_dtype = DType::Struct(
-            StructFields::new(FieldNames::default(), vec![]),
+            Fields::new(FieldNames::default(), vec![]),
             NonNullable,
         );
         let casted = cast(&array, &non_nullable_dtype).unwrap();
         assert_eq!(casted.dtype(), &non_nullable_dtype);
 
         let nullable_dtype =
-            DType::Struct(StructFields::new(FieldNames::default(), vec![]), Nullable);
+            DType::Struct(Fields::new(FieldNames::default(), vec![]), Nullable);
         let casted = cast(&array, &nullable_dtype).unwrap();
         assert_eq!(casted.dtype(), &nullable_dtype);
     }
@@ -214,7 +214,7 @@ mod tests {
         let result = cast(
             array.as_ref(),
             &DType::Struct(
-                StructFields::new(
+                Fields::new(
                     FieldNames::from(["ys", "xs", "zs"]),
                     vec![tu8.clone(), tu8.clone(), tu8],
                 ),
@@ -263,11 +263,11 @@ mod tests {
         assert_eq!(casted.dtype(), &top_level_non_nullable);
 
         let non_null_xs_right = DType::Struct(
-            StructFields::new(
+            Fields::new(
                 ["xs", "ys", "zs"].into(),
                 vec![
                     DType::Struct(
-                        StructFields::new(
+                        Fields::new(
                             ["left", "right"].into(),
                             vec![
                                 DType::Primitive(PType::I64, NonNullable),
@@ -286,11 +286,11 @@ mod tests {
         assert_eq!(casted.dtype(), &non_null_xs_right);
 
         let non_null_xs = DType::Struct(
-            StructFields::new(
+            Fields::new(
                 ["xs", "ys", "zs"].into(),
                 vec![
                     DType::Struct(
-                        StructFields::new(
+                        Fields::new(
                             ["left", "right"].into(),
                             vec![
                                 DType::Primitive(PType::I64, Nullable),

--- a/vortex-array/src/arrays/struct_/compute/take.rs
+++ b/vortex-array/src/arrays/struct_/compute/take.rs
@@ -17,8 +17,8 @@ impl TakeKernel for StructVTable {
         // an out of bounds element
         if array.is_empty() {
             return StructArray::try_new_with_dtype(
+                array.columns().clone(),
                 array.fields().clone(),
-                array.struct_fields().clone(),
                 indices.len(),
                 Validity::AllInvalid,
             )
@@ -31,11 +31,11 @@ impl TakeKernel for StructVTable {
         )?;
         StructArray::try_new_with_dtype(
             array
-                .fields()
+                .columns()
                 .iter()
                 .map(|field| compute::take(field, inner_indices))
                 .collect::<Result<Vec<_>, _>>()?,
-            array.struct_fields().clone(),
+            array.fields().clone(),
             indices.len(),
             array.validity().take(indices)?,
         )

--- a/vortex-array/src/arrays/struct_/compute/zip.rs
+++ b/vortex-array/src/arrays/struct_/compute/zip.rs
@@ -34,9 +34,9 @@ impl ZipKernel for StructVTable {
         );
 
         let fields = if_true
-            .fields()
+            .columns()
             .iter()
-            .zip(if_false.fields().iter())
+            .zip(if_false.columns().iter())
             .map(|(t, f)| zip(t, f, mask))
             .collect::<VortexResult<Vec<_>>>()?;
 

--- a/vortex-array/src/arrays/struct_/tests.rs
+++ b/vortex-array/src/arrays/struct_/tests.rs
@@ -38,13 +38,13 @@ fn test_project() {
 
     assert_eq!(struct_b.len(), 5);
 
-    let bools = &struct_b.fields[0];
+    let bools = &struct_b.columns[0];
     assert_eq!(
         bools.to_bool().boolean_buffer().iter().collect::<Vec<_>>(),
         vec![true, true, true, false, false]
     );
 
-    let prims = &struct_b.fields[1];
+    let prims = &struct_b.columns[1];
     assert_eq!(prims.to_primitive().as_slice::<i64>(), [0i64, 1, 2, 3, 4]);
 }
 
@@ -69,14 +69,14 @@ fn test_remove_column() {
     assert_eq!(removed.to_primitive().as_slice::<i64>(), [0i64, 1, 2, 3, 4]);
 
     assert_eq!(struct_a.names(), &["ys"]);
-    assert_eq!(struct_a.fields.len(), 1);
+    assert_eq!(struct_a.columns.len(), 1);
     assert_eq!(struct_a.len(), 5);
     assert_eq!(
-        struct_a.fields[0].dtype(),
+        struct_a.columns[0].dtype(),
         &DType::Primitive(PType::U64, Nullability::NonNullable)
     );
     assert_eq!(
-        struct_a.fields[0].to_primitive().as_slice::<u64>(),
+        struct_a.columns[0].to_primitive().as_slice::<u64>(),
         [4u64, 5, 6, 7, 8]
     );
 
@@ -104,22 +104,22 @@ fn test_duplicate_field_names() {
     )
     .unwrap();
 
-    // field_by_name should return the first field with the matching name
-    let first_value_field = struct_array.field_by_name("value").unwrap();
+    // column_by_name should return the first field with the matching name
+    let first_value_field = struct_array.column_by_name("value").unwrap();
     assert_eq!(
         first_value_field.to_primitive().as_slice::<i32>(),
         [1i32, 2, 3] // This is field1, not field3
     );
 
-    // Verify field_by_name_opt also returns the first match
-    let opt_field = struct_array.field_by_name_opt("value").unwrap();
+    // Verify column_by_name_opt also returns the first match
+    let opt_field = struct_array.column_by_name_opt("value").unwrap();
     assert_eq!(
         opt_field.to_primitive().as_slice::<i32>(),
         [1i32, 2, 3] // First "value" field
     );
 
     // Verify the third field (second "value") can be accessed by index
-    let third_field = &struct_array.fields()[2];
+    let third_field = &struct_array.columns()[2];
     assert_eq!(
         third_field.to_primitive().as_slice::<i32>(),
         [100i32, 200, 300]

--- a/vortex-array/src/arrays/struct_/vtable/operations.rs
+++ b/vortex-array/src/arrays/struct_/vtable/operations.rs
@@ -13,7 +13,7 @@ use crate::{ArrayRef, IntoArray};
 impl OperationsVTable<StructVTable> for StructVTable {
     fn slice(array: &StructArray, range: Range<usize>) -> ArrayRef {
         let fields = array
-            .fields()
+            .columns()
             .iter()
             .map(|field| field.slice(range.clone()))
             .collect_vec();
@@ -25,7 +25,7 @@ impl OperationsVTable<StructVTable> for StructVTable {
         unsafe {
             StructArray::new_unchecked(
                 fields,
-                array.struct_fields().clone(),
+                array.fields().clone(),
                 range.len(),
                 array.validity().slice(range),
             )
@@ -37,7 +37,7 @@ impl OperationsVTable<StructVTable> for StructVTable {
         Scalar::struct_(
             array.dtype().clone(),
             array
-                .fields()
+                .columns()
                 .iter()
                 .map(|field| field.scalar_at(index))
                 .collect_vec(),

--- a/vortex-array/src/arrays/struct_/vtable/pipeline.rs
+++ b/vortex-array/src/arrays/struct_/vtable/pipeline.rs
@@ -22,8 +22,8 @@ use crate::{Array, ArrayRef, Canonical, IntoArray};
 
 impl PipelineVTable<StructVTable> for StructVTable {
     fn to_operator(array: &StructArray) -> VortexResult<Option<OperatorRef>> {
-        let mut children = Vec::with_capacity(array.fields.len());
-        for field in array.fields().iter() {
+        let mut children = Vec::with_capacity(array.columns.len());
+        for field in array.columns().iter() {
             if let Some(operator) = field.to_operator()? {
                 children.push(operator);
             } else {

--- a/vortex-array/src/arrays/struct_/vtable/visitor.rs
+++ b/vortex-array/src/arrays/struct_/vtable/visitor.rs
@@ -12,7 +12,7 @@ impl VisitorVTable<StructVTable> for StructVTable {
 
     fn visit_children(array: &StructArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_validity(array.validity(), array.len());
-        for (name, field) in array.names().iter().zip_eq(array.fields().iter()) {
+        for (name, field) in array.names().iter().zip_eq(array.columns().iter()) {
             visitor.visit_child(name.as_ref(), field);
         }
     }

--- a/vortex-array/src/arrow/compute/to_arrow/canonical.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/canonical.rs
@@ -418,17 +418,17 @@ fn to_arrow_struct(
     fields: &[FieldRef],
     to_preferred: bool,
 ) -> VortexResult<ArrowArrayRef> {
-    if array.fields().len() != fields.len() {
+    if array.columns().len() != fields.len() {
         vortex_bail!(
             "StructArray has {} fields, but target Arrow type has {} fields",
-            array.fields().len(),
+            array.columns().len(),
             fields.len()
         );
     }
 
     let field_arrays = fields
         .iter()
-        .zip_eq(array.fields().iter())
+        .zip_eq(array.columns().iter())
         .map(|(field, arr)| {
             // We check that the Vortex array nullability is compatible with the field
             // nullability. In other words, make sure we don't return any nulls for a

--- a/vortex-array/src/arrow/compute/to_arrow/mod.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/mod.rs
@@ -232,7 +232,7 @@ mod tests {
 
     #[test]
     fn test_to_arrow() {
-        let array = arrays::StructArray::from_fields(
+        let array = arrays::StructArray::from_columns(
             vec![
                 (
                     "a",

--- a/vortex-array/src/builders/struct_.rs
+++ b/vortex-array/src/builders/struct_.rs
@@ -4,7 +4,7 @@
 use std::any::Any;
 
 use itertools::Itertools;
-use vortex_dtype::{DType, Nullability, StructFields};
+use vortex_dtype::{DType, Fields, Nullability};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_ensure, vortex_panic};
 use vortex_mask::Mask;
 use vortex_scalar::{Scalar, StructScalar};
@@ -25,16 +25,12 @@ pub struct StructBuilder {
 
 impl StructBuilder {
     /// Creates a new `StructBuilder` with a capacity of [`DEFAULT_BUILDER_CAPACITY`].
-    pub fn new(struct_dtype: StructFields, nullability: Nullability) -> Self {
+    pub fn new(struct_dtype: Fields, nullability: Nullability) -> Self {
         Self::with_capacity(struct_dtype, nullability, DEFAULT_BUILDER_CAPACITY)
     }
 
     /// Creates a new `StructBuilder` with the given `capacity`.
-    pub fn with_capacity(
-        struct_dtype: StructFields,
-        nullability: Nullability,
-        capacity: usize,
-    ) -> Self {
+    pub fn with_capacity(struct_dtype: Fields, nullability: Nullability, capacity: usize) -> Self {
         let builders = struct_dtype
             .fields()
             .map(|dt| builder_with_capacity(&dt, capacity))
@@ -53,16 +49,16 @@ impl StructBuilder {
             vortex_bail!("Tried to append a null `StructScalar` to a non-nullable struct builder",);
         }
 
-        if struct_scalar.struct_fields() != self.struct_fields() {
+        if struct_scalar.fields() != self.fields() {
             vortex_bail!(
                 "Tried to append a `StructScalar` with fields {} to a \
                     struct builder with fields {}",
-                struct_scalar.struct_fields(),
-                self.struct_fields()
+                struct_scalar.fields(),
+                self.fields()
             );
         }
 
-        if let Some(fields) = struct_scalar.fields() {
+        if let Some(fields) = struct_scalar.columns() {
             for (builder, field) in self.builders.iter_mut().zip_eq(fields) {
                 builder.append_scalar(&field)?;
             }
@@ -96,12 +92,12 @@ impl StructBuilder {
 
         let validity = self.nulls.finish_with_nullability(self.dtype.nullability());
 
-        StructArray::try_new_with_dtype(fields, self.struct_fields().clone(), len, validity)
+        StructArray::try_new_with_dtype(fields, self.fields().clone(), len, validity)
             .vortex_expect("Fields must all have same length.")
     }
 
-    /// The [`StructFields`] of this struct builder.
-    pub fn struct_fields(&self) -> &StructFields {
+    /// The [`Fields`] of this struct builder.
+    pub fn fields(&self) -> &Fields {
         let DType::Struct(struct_fields, _) = &self.dtype else {
             vortex_panic!("`StructBuilder` somehow had dtype {}", self.dtype);
         };
@@ -159,7 +155,7 @@ impl ArrayBuilder for StructBuilder {
         let array = array.to_struct();
 
         for (a, builder) in array
-            .fields()
+            .columns()
             .iter()
             .cloned()
             .zip_eq(self.builders.iter_mut())
@@ -195,7 +191,7 @@ impl ArrayBuilder for StructBuilder {
 mod tests {
 
     use vortex_dtype::PType::I32;
-    use vortex_dtype::{DType, Nullability, StructFields};
+    use vortex_dtype::{DType, Fields, Nullability};
     use vortex_scalar::Scalar;
 
     use crate::builders::ArrayBuilder;
@@ -203,7 +199,7 @@ mod tests {
 
     #[test]
     fn test_struct_builder() {
-        let sdt = StructFields::new(["a", "b"].into(), vec![I32.into(), I32.into()]);
+        let sdt = Fields::new(["a", "b"].into(), vec![I32.into(), I32.into()]);
         let dtype = DType::Struct(sdt.clone(), Nullability::NonNullable);
         let mut builder = StructBuilder::with_capacity(sdt, Nullability::NonNullable, 0);
 
@@ -218,7 +214,7 @@ mod tests {
 
     #[test]
     fn test_append_nullable_struct() {
-        let sdt = StructFields::new(["a", "b"].into(), vec![I32.into(), I32.into()]);
+        let sdt = Fields::new(["a", "b"].into(), vec![I32.into(), I32.into()]);
         let dtype = DType::Struct(sdt.clone(), Nullability::Nullable);
         let mut builder = StructBuilder::with_capacity(sdt, Nullability::Nullable, 0);
 
@@ -236,7 +232,7 @@ mod tests {
         use vortex_scalar::Scalar;
 
         let dtype = DType::Struct(
-            StructFields::from_iter([
+            Fields::from_iter([
                 ("a", DType::Primitive(I32, Nullability::Nullable)),
                 ("b", DType::Utf8(Nullability::Nullable)),
             ]),
@@ -280,7 +276,7 @@ mod tests {
 
         let scalar0 = array.scalar_at(0);
         let struct0 = scalar0.as_struct();
-        if let Some(fields0) = struct0.fields() {
+        if let Some(fields0) = struct0.columns() {
             let fields0 = fields0.collect::<Vec<_>>();
             assert_eq!(fields0[0].as_primitive().typed_value::<i32>(), Some(42));
             assert_eq!(fields0[1].as_utf8().value().as_deref(), Some("hello"));
@@ -288,7 +284,7 @@ mod tests {
 
         let scalar1 = array.scalar_at(1);
         let struct1 = scalar1.as_struct();
-        if let Some(fields1) = struct1.fields() {
+        if let Some(fields1) = struct1.columns() {
             let fields1 = fields1.collect::<Vec<_>>();
             assert_eq!(fields1[0].as_primitive().typed_value::<i32>(), Some(84));
             assert_eq!(fields1[1].as_utf8().value().as_deref(), Some("world"));
@@ -296,7 +292,7 @@ mod tests {
 
         let scalar2 = array.scalar_at(2);
         let struct2 = scalar2.as_struct();
-        assert!(struct2.fields().is_none()); // Null struct has no fields.
+        assert!(struct2.columns().is_none()); // Null struct has no fields.
 
         // Check validity - first two should be valid, third should be null.
         use crate::vtable::ValidityHelper;

--- a/vortex-array/src/builders/tests.rs
+++ b/vortex-array/src/builders/tests.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use rstest::rstest;
 use vortex_dtype::half::f16;
-use vortex_dtype::{DType, DecimalDType, ExtDType, ExtID, Nullability, PType, StructFields};
+use vortex_dtype::{DType, DecimalDType, ExtDType, ExtID, Nullability, PType, Fields};
 use vortex_scalar::Scalar;
 
 use crate::builders::{ArrayBuilder, builder_with_capacity};
@@ -30,17 +30,17 @@ use crate::builders::{ArrayBuilder, builder_with_capacity};
 #[case::binary(DType::Binary(Nullability::NonNullable))]
 #[case::decimal128(DType::Decimal(DecimalDType::new(10, 2), Nullability::NonNullable))]
 #[case::struct_simple(DType::Struct(
-    StructFields::from_iter([
+    Fields::from_iter([
         ("a", DType::Primitive(PType::I32, Nullability::NonNullable)),
         ("b", DType::Utf8(Nullability::NonNullable)),
     ]),
     Nullability::NonNullable
 ))]
 #[case::struct_nested(DType::Struct(
-    StructFields::from_iter([
+    Fields::from_iter([
         ("field1", DType::Bool(Nullability::NonNullable)),
         ("field2", DType::Struct(
-            StructFields::from_iter([
+            Fields::from_iter([
                 ("nested", DType::Primitive(PType::F64, Nullability::NonNullable)),
             ]),
             Nullability::NonNullable
@@ -146,13 +146,13 @@ fn test_append_zeros_matches_default_value(#[case] dtype: DType) {
     3
 )]
 #[case::struct_type(DType::Struct(
-    StructFields::from_iter([
+    Fields::from_iter([
         ("a", DType::Primitive(PType::I32, Nullability::NonNullable)),
     ]),
     Nullability::NonNullable
 ), 1)]
 #[case::struct_type_multiple(DType::Struct(
-    StructFields::from_iter([
+    Fields::from_iter([
         ("a", DType::Primitive(PType::I32, Nullability::NonNullable)),
     ]),
     Nullability::NonNullable
@@ -355,7 +355,7 @@ fn test_to_canonical_binary() {
 #[test]
 fn test_to_canonical_struct() {
     let dtype = DType::Struct(
-        StructFields::from_iter([
+        Fields::from_iter([
             ("a", DType::Primitive(PType::I32, Nullability::NonNullable)),
             ("b", DType::Utf8(Nullability::NonNullable)),
         ]),
@@ -472,14 +472,14 @@ fn test_to_canonical_f32() {
 ))]
 #[case::decimal128_nullable(DType::Decimal(DecimalDType::new(10, 2), Nullability::Nullable))]
 #[case::struct_simple(DType::Struct(
-    StructFields::from_iter([
+    Fields::from_iter([
         ("a", DType::Primitive(PType::I32, Nullability::NonNullable)),
         ("b", DType::Utf8(Nullability::NonNullable)),
     ]),
     Nullability::NonNullable
 ))]
 #[case::struct_nullable(DType::Struct(
-    StructFields::from_iter([
+    Fields::from_iter([
         ("x", DType::Primitive(PType::F64, Nullability::NonNullable)),
     ]),
     Nullability::Nullable

--- a/vortex-array/src/builders/tests.rs
+++ b/vortex-array/src/builders/tests.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use rstest::rstest;
 use vortex_dtype::half::f16;
-use vortex_dtype::{DType, DecimalDType, ExtDType, ExtID, Nullability, PType, Fields};
+use vortex_dtype::{DType, DecimalDType, ExtDType, ExtID, Fields, Nullability, PType};
 use vortex_scalar::Scalar;
 
 use crate::builders::{ArrayBuilder, builder_with_capacity};

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -410,11 +410,11 @@ mod test {
     #[test]
     fn test_canonicalize_nested_struct() {
         // Create a struct array with multiple internal components.
-        let nested_struct_array = StructArray::from_fields(&[
+        let nested_struct_array = StructArray::from_columns(&[
             ("a", buffer![1u64].into_array()),
             (
                 "b",
-                StructArray::from_fields(&[(
+                StructArray::from_columns(&[(
                     "inner_a",
                     // The nested struct contains a ConstantArray representing the primitive array
                     //   [100i64]

--- a/vortex-array/src/compute/compare.rs
+++ b/vortex-array/src/compute/compare.rs
@@ -537,13 +537,13 @@ mod tests {
         let bool_field2 = BoolArray::from_iter([Some(true), Some(false), Some(false)]);
         let int_field2 = PrimitiveArray::from_iter([1i32, 2, 4]);
 
-        let struct1 = StructArray::from_fields(&[
+        let struct1 = StructArray::from_columns(&[
             ("bool_col", bool_field1.into_array()),
             ("int_col", int_field1.into_array()),
         ])
         .unwrap();
 
-        let struct2 = StructArray::from_fields(&[
+        let struct2 = StructArray::from_columns(&[
             ("bool_col", bool_field2.into_array()),
             ("int_col", int_field2.into_array()),
         ])

--- a/vortex-array/src/compute/min_max.rs
+++ b/vortex-array/src/compute/min_max.rs
@@ -4,7 +4,7 @@
 use std::sync::LazyLock;
 
 use arcref::ArcRef;
-use vortex_dtype::{DType, Nullability, Fields};
+use vortex_dtype::{DType, Fields, Nullability};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail};
 use vortex_scalar::Scalar;
 

--- a/vortex-array/src/compute/min_max.rs
+++ b/vortex-array/src/compute/min_max.rs
@@ -4,7 +4,7 @@
 use std::sync::LazyLock;
 
 use arcref::ArcRef;
-use vortex_dtype::{DType, Nullability, StructFields};
+use vortex_dtype::{DType, Nullability, Fields};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail};
 use vortex_scalar::Scalar;
 
@@ -108,7 +108,7 @@ impl ComputeFnVTable for MinMax {
         // We return a min/max struct scalar, where the overall struct is nullable in the case
         // that the array is all null or empty.
         Ok(DType::Struct(
-            StructFields::new(
+            Fields::new(
                 ["min", "max"].into(),
                 vec![array.dtype().clone(), array.dtype().clone()],
             ),
@@ -200,7 +200,7 @@ impl<V: VTable + MinMaxKernel> Kernel for MinMaxKernelAdapter<V> {
             return Ok(None);
         };
         let dtype = DType::Struct(
-            StructFields::new(
+            Fields::new(
                 ["min", "max"].into(),
                 vec![array.dtype().clone(), array.dtype().clone()],
             ),

--- a/vortex-btrblocks/src/lib.rs
+++ b/vortex-btrblocks/src/lib.rs
@@ -385,7 +385,7 @@ impl BtrBlocksCompressor {
             Canonical::Decimal(decimal) => compress_decimal(&decimal),
             Canonical::Struct(struct_array) => {
                 let fields = struct_array
-                    .fields()
+                    .columns()
                     .iter()
                     .map(|field| self.compress(field))
                     .collect::<Result<Vec<_>, _>>()?;

--- a/vortex-dtype/src/arbitrary.rs
+++ b/vortex-dtype/src/arbitrary.rs
@@ -8,7 +8,7 @@ use vortex_error::VortexExpect;
 
 use crate::{
     DECIMAL256_MAX_PRECISION, DECIMAL256_MAX_SCALE, DType, DecimalDType, FieldName, FieldNames,
-    Nullability, PType, Fields,
+    Fields, Nullability, PType,
 };
 
 impl<'a> Arbitrary<'a> for DType {

--- a/vortex-dtype/src/arbitrary.rs
+++ b/vortex-dtype/src/arbitrary.rs
@@ -8,7 +8,7 @@ use vortex_error::VortexExpect;
 
 use crate::{
     DECIMAL256_MAX_PRECISION, DECIMAL256_MAX_SCALE, DType, DecimalDType, FieldName, FieldNames,
-    Nullability, PType, StructFields,
+    Nullability, PType, Fields,
 };
 
 impl<'a> Arbitrary<'a> for DType {
@@ -98,13 +98,13 @@ impl<'a> Arbitrary<'a> for DecimalDType {
     }
 }
 
-impl<'a> Arbitrary<'a> for StructFields {
+impl<'a> Arbitrary<'a> for Fields {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         random_struct_dtype(u, 1)
     }
 }
 
-fn random_struct_dtype(u: &mut Unstructured<'_>, depth: u8) -> Result<StructFields> {
+fn random_struct_dtype(u: &mut Unstructured<'_>, depth: u8) -> Result<Fields> {
     let field_count = u.choose_index(3)?;
     let names: FieldNames = (0..field_count)
         .map(|_| FieldName::arbitrary(u))
@@ -112,5 +112,5 @@ fn random_struct_dtype(u: &mut Unstructured<'_>, depth: u8) -> Result<StructFiel
     let dtypes = (0..names.len())
         .map(|_| random_dtype(u, depth))
         .collect::<Result<Vec<_>>>()?;
-    Ok(StructFields::new(names, dtypes))
+    Ok(Fields::new(names, dtypes))
 }

--- a/vortex-dtype/src/arrow.rs
+++ b/vortex-dtype/src/arrow.rs
@@ -15,12 +15,14 @@
 
 use std::sync::Arc;
 
-use arrow_schema::{DataType, Field, FieldRef, Fields, Schema, SchemaBuilder, SchemaRef};
+use arrow_schema::{
+    DataType, Field, FieldRef, Fields as ArrowFields, Schema, SchemaBuilder, SchemaRef,
+};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
 
 use crate::datetime::arrow::{make_arrow_temporal_dtype, make_temporal_ext_dtype};
 use crate::datetime::is_temporal_ext_type;
-use crate::{DType, DecimalDType, FieldName, Nullability, PType, StructFields};
+use crate::{DType, DecimalDType, FieldName, Fields, Nullability, PType};
 
 /// Trait for converting Arrow types to Vortex types.
 pub trait FromArrowType<T>: Sized {
@@ -81,15 +83,15 @@ impl FromArrowType<SchemaRef> for DType {
 impl FromArrowType<&Schema> for DType {
     fn from_arrow(value: &Schema) -> Self {
         Self::Struct(
-            StructFields::from_arrow(value.fields()),
+            Fields::from_arrow(value.fields()),
             Nullability::NonNullable, // Must match From<RecordBatch> for Array
         )
     }
 }
 
-impl FromArrowType<&Fields> for StructFields {
-    fn from_arrow(value: &Fields) -> Self {
-        StructFields::from_iter(value.into_iter().map(|f| {
+impl FromArrowType<&ArrowFields> for Fields {
+    fn from_arrow(value: &ArrowFields) -> Self {
+        Fields::from_iter(value.into_iter().map(|f| {
             (
                 FieldName::from(f.name().as_str()),
                 DType::from_arrow(f.as_ref()),
@@ -138,7 +140,7 @@ impl FromArrowType<(&DataType, Nullability)> for DType {
                 *size as u32,
                 nullability,
             ),
-            DataType::Struct(f) => DType::Struct(StructFields::from_arrow(f), nullability),
+            DataType::Struct(f) => DType::Struct(Fields::from_arrow(f), nullability),
             DataType::Dictionary(_, value_type) => {
                 Self::from_arrow((value_type.as_ref(), nullability))
             }
@@ -237,7 +239,7 @@ impl DType {
                     )));
                 }
 
-                DataType::Struct(Fields::from(fields))
+                DataType::Struct(ArrowFields::from(fields))
             }
             DType::Extension(ext_dtype) => {
                 // Try and match against the known extension DTypes.
@@ -253,11 +255,11 @@ impl DType {
 
 #[cfg(test)]
 mod test {
-    use arrow_schema::{DataType, Field, FieldRef, Fields, Schema};
+    use arrow_schema::{DataType, Field, FieldRef, Fields as ArrowFields, Schema};
     use rstest::{fixture, rstest};
 
     use super::*;
-    use crate::{DType, ExtDType, ExtID, FieldName, FieldNames, Nullability, PType, StructFields};
+    use crate::{DType, ExtDType, ExtID, FieldName, FieldNames, Fields, Nullability, PType};
 
     #[test]
     fn test_dtype_conversion_success() {
@@ -301,7 +303,7 @@ mod test {
             )
             .to_arrow_dtype()
             .unwrap(),
-            DataType::Struct(Fields::from(vec![
+            DataType::Struct(ArrowFields::from(vec![
                 FieldRef::from(Field::new("field_a", DataType::Boolean, false)),
                 FieldRef::from(Field::new("field_b", DataType::Utf8View, true)),
             ]))
@@ -347,8 +349,8 @@ mod test {
     }
 
     #[fixture]
-    fn the_struct() -> StructFields {
-        StructFields::new(
+    fn the_struct() -> Fields {
+        Fields::new(
             FieldNames::from([
                 FieldName::from("field_a"),
                 FieldName::from("field_b"),
@@ -363,12 +365,12 @@ mod test {
     }
 
     #[rstest]
-    fn test_schema_conversion(the_struct: StructFields) {
+    fn test_schema_conversion(the_struct: Fields) {
         let schema_nonnull = DType::Struct(the_struct, Nullability::NonNullable);
 
         assert_eq!(
             schema_nonnull.to_arrow_schema().unwrap(),
-            Schema::new(Fields::from(vec![
+            Schema::new(ArrowFields::from(vec![
                 Field::new("field_a", DataType::Boolean, false),
                 Field::new("field_b", DataType::Utf8View, false),
                 Field::new("field_c", DataType::Int32, true),
@@ -378,7 +380,7 @@ mod test {
 
     #[rstest]
     #[should_panic]
-    fn test_schema_conversion_panics(the_struct: StructFields) {
+    fn test_schema_conversion_panics(the_struct: Fields) {
         let schema_null = DType::Struct(the_struct, Nullability::Nullable);
         let _ = schema_null.to_arrow_schema().unwrap();
     }

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -12,7 +12,7 @@ use vortex_error::vortex_panic;
 
 use crate::decimal::DecimalDType;
 use crate::nullability::Nullability;
-use crate::{ExtDType, FieldDType, FieldName, PType, StructFields};
+use crate::{ExtDType, FieldDType, FieldName, Fields, PType};
 
 /// The logical types of elements in Vortex arrays.
 ///
@@ -82,8 +82,8 @@ pub enum DType {
     /// A logical struct type.
     ///
     /// A `Struct` type is composed of an ordered list of fields, each with a corresponding name and
-    /// `DType`. See [`StructFields`] for more information.
-    Struct(StructFields, Nullability),
+    /// `DType`. See [`Fields`] for more information.
+    Struct(Fields, Nullability),
 
     /// A user-defined extension type.
     ///
@@ -370,7 +370,7 @@ impl DType {
     }
 
     /// Get the `StructDType` if `self` is a `StructDType`, otherwise `None`
-    pub fn as_struct_fields_opt(&self) -> Option<&StructFields> {
+    pub fn as_struct_fields_opt(&self) -> Option<&Fields> {
         if let Struct(f, _) = self {
             Some(f)
         } else {
@@ -388,7 +388,7 @@ impl DType {
         iter: I,
         nullability: Nullability,
     ) -> Self {
-        Struct(StructFields::from_iter(iter), nullability)
+        Struct(Fields::from_iter(iter), nullability)
     }
 }
 

--- a/vortex-dtype/src/field.rs
+++ b/vortex-dtype/src/field.rs
@@ -150,11 +150,11 @@ impl FieldPath {
     /// use vortex_dtype::Nullability::*;
     ///
     /// let dtype = DType::Struct(
-    ///     StructFields::from_iter([(
+    ///     Fields::from_iter([(
     ///         "a",
     ///         DType::List(
     ///             Arc::new(DType::Struct(
-    ///                 StructFields::from_iter([(
+    ///                 Fields::from_iter([(
     ///                     "b",
     ///                     DType::Primitive(PType::U32, NonNullable),
     ///                 )]),
@@ -241,7 +241,7 @@ impl FromIterator<FieldPath> for FieldPathSet {
 mod tests {
     use super::*;
     use crate::Nullability::*;
-    use crate::{DType, PType, StructFields};
+    use crate::{DType, Fields, PType};
 
     #[test]
     fn test_field_path() {
@@ -282,7 +282,7 @@ mod tests {
         );
 
         let outer = DType::Struct(
-            StructFields::from_iter([("outer_a", DType::Bool(NonNullable)), ("outer_b", inner)]),
+            Fields::from_iter([("outer_a", DType::Bool(NonNullable)), ("outer_b", inner)]),
             NonNullable,
         );
 

--- a/vortex-dtype/src/serde/flatbuffers/mod.rs
+++ b/vortex-dtype/src/serde/flatbuffers/mod.rs
@@ -9,7 +9,7 @@ use vortex_error::{VortexError, VortexResult, vortex_bail, vortex_err};
 use vortex_flatbuffers::{FlatBuffer, FlatBufferRoot, WriteFlatBuffer, dtype as fbd};
 
 use crate::{
-    DType, DecimalDType, ExtDType, ExtID, ExtMetadata, FieldDType, PType, StructFields,
+    DType, DecimalDType, ExtDType, ExtID, ExtMetadata, FieldDType, PType, Fields,
     flatbuffers as fb,
 };
 
@@ -45,7 +45,7 @@ impl ViewedDType {
     }
 }
 
-impl StructFields {
+impl Fields {
     /// Creates a new instance from a flatbuffer-defined object and its underlying buffer.
     fn from_fb(fb_struct: fbd::Struct_<'_>, buffer: FlatBuffer) -> VortexResult<Self> {
         let names = fb_struct
@@ -61,7 +61,7 @@ impl StructFields {
             .map(|dt| FieldDType::from(ViewedDType::from_fb_loc(dt._tab.loc(), buffer.clone())))
             .collect::<Vec<_>>();
 
-        Ok(StructFields::from_fields(names, dtypes))
+        Ok(Fields::from_fields(names, dtypes))
     }
 }
 
@@ -155,7 +155,7 @@ impl TryFrom<ViewedDType> for DType {
                 let fb_struct = fb
                     .type__as_struct_()
                     .ok_or_else(|| vortex_err!("failed to parse struct from flatbuffer"))?;
-                let struct_dtype = StructFields::from_fb(fb_struct, vfdt.buffer().clone())?;
+                let struct_dtype = Fields::from_fb(fb_struct, vfdt.buffer().clone())?;
 
                 Ok(Self::Struct(struct_dtype, fb_struct.nullable().into()))
             }
@@ -374,7 +374,7 @@ mod test {
 
     use crate::nullability::Nullability;
     use crate::serde::flatbuffers::ViewedDType;
-    use crate::{DType, PType, StructFields, flatbuffers as fb};
+    use crate::{DType, PType, Fields, flatbuffers as fb};
 
     fn roundtrip_dtype(dtype: DType) {
         let bytes = dtype.write_flatbuffer_bytes();
@@ -412,7 +412,7 @@ mod test {
             Nullability::NonNullable,
         ));
         roundtrip_dtype(DType::Struct(
-            StructFields::new(
+            Fields::new(
                 ["strings", "ints"].into(),
                 vec![
                     DType::Utf8(Nullability::NonNullable),

--- a/vortex-dtype/src/serde/flatbuffers/mod.rs
+++ b/vortex-dtype/src/serde/flatbuffers/mod.rs
@@ -9,8 +9,7 @@ use vortex_error::{VortexError, VortexResult, vortex_bail, vortex_err};
 use vortex_flatbuffers::{FlatBuffer, FlatBufferRoot, WriteFlatBuffer, dtype as fbd};
 
 use crate::{
-    DType, DecimalDType, ExtDType, ExtID, ExtMetadata, FieldDType, PType, Fields,
-    flatbuffers as fb,
+    DType, DecimalDType, ExtDType, ExtID, ExtMetadata, FieldDType, Fields, PType, flatbuffers as fb,
 };
 
 mod project;
@@ -374,7 +373,7 @@ mod test {
 
     use crate::nullability::Nullability;
     use crate::serde::flatbuffers::ViewedDType;
-    use crate::{DType, PType, Fields, flatbuffers as fb};
+    use crate::{DType, Fields, PType, flatbuffers as fb};
 
     fn roundtrip_dtype(dtype: DType) {
         let bytes = dtype.write_flatbuffer_bytes();

--- a/vortex-dtype/src/serde/flatbuffers/project.rs
+++ b/vortex-dtype/src/serde/flatbuffers/project.rs
@@ -7,7 +7,7 @@ use vortex_error::{VortexResult, vortex_bail, vortex_err};
 use vortex_flatbuffers::FlatBuffer;
 
 use crate::field::Field;
-use crate::{DType, StructFields, flatbuffers as fb};
+use crate::{DType, Fields, flatbuffers as fb};
 
 /// Convert name references in projection list into index references.
 ///
@@ -58,10 +58,7 @@ pub fn project_and_deserialize(
         .map(|idx| idx.and_then(|i| read_field(fb_struct, i, buffer)))
         .collect::<VortexResult<Vec<_>>>()?;
 
-    Ok(DType::Struct(
-        StructFields::from_iter(struct_dtype),
-        nullability,
-    ))
+    Ok(DType::Struct(Fields::from_iter(struct_dtype), nullability))
 }
 
 fn read_field(
@@ -88,11 +85,11 @@ mod tests {
     use vortex_flatbuffers::WriteFlatBufferExt;
 
     use super::*;
-    use crate::{DType, FieldName, Nullability, PType, StructFields};
+    use crate::{DType, FieldName, Fields, Nullability, PType};
 
     fn create_test_struct_dtype() -> DType {
         DType::Struct(
-            StructFields::from_iter([
+            Fields::from_iter([
                 ("id", DType::Primitive(PType::I64, Nullability::NonNullable)),
                 ("name", DType::Utf8(Nullability::Nullable)),
                 ("age", DType::Primitive(PType::I32, Nullability::Nullable)),
@@ -108,7 +105,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_field_by_name() {
+    fn test_resolve_column_by_name() {
         let dtype = create_test_struct_dtype();
         let buffer = serialize_dtype(&dtype);
         let fb_dtype = fb::root_as_dtype(buffer.as_ref()).unwrap();

--- a/vortex-dtype/src/serde/proto.rs
+++ b/vortex-dtype/src/serde/proto.rs
@@ -9,7 +9,7 @@ use crate::field::{Field, FieldPath};
 use crate::proto::dtype as pb;
 use crate::proto::dtype::d_type::DtypeType;
 use crate::proto::dtype::field::FieldType;
-use crate::{DType, DecimalDType, ExtDType, ExtID, ExtMetadata, PType, StructFields};
+use crate::{DType, DecimalDType, ExtDType, ExtID, ExtMetadata, PType, Fields};
 
 impl TryFrom<&pb::DType> for DType {
     type Error = VortexError;
@@ -31,7 +31,7 @@ impl TryFrom<&pb::DType> for DType {
             DtypeType::Utf8(u) => Ok(Self::Utf8(u.nullable.into())),
             DtypeType::Binary(b) => Ok(Self::Binary(b.nullable.into())),
             DtypeType::Struct(s) => Ok(Self::Struct(
-                StructFields::new(
+                Fields::new(
                     s.names.iter().map(|s| s.as_str()).collect(),
                     s.dtypes
                         .iter()
@@ -194,7 +194,7 @@ mod tests {
     use crate::proto::dtype::field::FieldType;
     use crate::{
         DType, DecimalDType, ExtDType, ExtID, ExtMetadata, Field, FieldPath, Nullability, PType,
-        StructFields,
+        Fields,
     };
 
     fn round_trip_dtype(dtype: &DType) -> DType {
@@ -238,7 +238,7 @@ mod tests {
     #[test]
     fn test_struct_round_trip() {
         let struct_dtype = DType::Struct(
-            StructFields::from_iter([
+            Fields::from_iter([
                 ("id", DType::Primitive(PType::I64, Nullability::NonNullable)),
                 ("name", DType::Utf8(Nullability::Nullable)),
                 ("active", DType::Bool(Nullability::NonNullable)),
@@ -253,7 +253,7 @@ mod tests {
     #[test]
     fn test_nested_struct_round_trip() {
         let inner_struct = DType::Struct(
-            StructFields::from_iter([
+            Fields::from_iter([
                 ("street", DType::Utf8(Nullability::NonNullable)),
                 ("city", DType::Utf8(Nullability::NonNullable)),
             ]),
@@ -261,7 +261,7 @@ mod tests {
         );
 
         let outer_struct = DType::Struct(
-            StructFields::from_iter([
+            Fields::from_iter([
                 ("name", DType::Utf8(Nullability::NonNullable)),
                 ("address", inner_struct),
             ]),

--- a/vortex-dtype/src/serde/proto.rs
+++ b/vortex-dtype/src/serde/proto.rs
@@ -9,7 +9,7 @@ use crate::field::{Field, FieldPath};
 use crate::proto::dtype as pb;
 use crate::proto::dtype::d_type::DtypeType;
 use crate::proto::dtype::field::FieldType;
-use crate::{DType, DecimalDType, ExtDType, ExtID, ExtMetadata, PType, Fields};
+use crate::{DType, DecimalDType, ExtDType, ExtID, ExtMetadata, Fields, PType};
 
 impl TryFrom<&pb::DType> for DType {
     type Error = VortexError;
@@ -193,8 +193,8 @@ mod tests {
     use crate::proto::dtype::d_type::DtypeType;
     use crate::proto::dtype::field::FieldType;
     use crate::{
-        DType, DecimalDType, ExtDType, ExtID, ExtMetadata, Field, FieldPath, Nullability, PType,
-        Fields,
+        DType, DecimalDType, ExtDType, ExtID, ExtMetadata, Field, FieldPath, Fields, Nullability,
+        PType,
     };
 
     fn round_trip_dtype(dtype: &DType) -> DType {

--- a/vortex-dtype/src/struct_.rs
+++ b/vortex-dtype/src/struct_.rs
@@ -167,19 +167,19 @@ impl<'de> serde::de::Visitor<'de> for FieldDTypeDeVisitor {
 
 /// Type information for a struct column.
 ///
-/// The `StructFields` holds all field names and field types, and provides
+/// The `Fields` holds all field names and field types, and provides
 /// access to them by index or by name.
 ///
 /// ## Duplicate field names
 ///
-/// In memory, it is not an error for a `StructFields` to contain duplicate
+/// In memory, it is not an error for a `Fields` to contain duplicate
 /// field names. In that case, any name-based access to fields will resolve
 /// to the first such field with a given name.
 ///
 /// ```rust
-/// # use vortex_dtype::{DType, Nullability, PType, StructFields};
+/// # use vortex_dtype::{DType, Nullability, PType, Fields};
 ///
-/// let fields = StructFields::from_iter([
+/// let fields = Fields::from_iter([
 ///     ("string_col", DType::Utf8(Nullability::NonNullable)),
 ///     ("binary_col", DType::Binary(Nullability::NonNullable)),
 ///     ("int_col", DType::Primitive(PType::I32, Nullability::Nullable)),
@@ -191,18 +191,18 @@ impl<'de> serde::de::Visitor<'de> for FieldDTypeDeVisitor {
 /// ```
 #[derive(Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct StructFields(Arc<StructFieldsInner>);
+pub struct Fields(Arc<FieldsInner>);
 
-impl std::fmt::Debug for StructFields {
+impl std::fmt::Debug for Fields {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("StructFields")
+        f.debug_struct("Fields")
             .field("names", &self.0.names)
             .field("dtypes", &self.0.dtypes)
             .finish()
     }
 }
 
-impl Display for StructFields {
+impl Display for Fields {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -217,14 +217,14 @@ impl Display for StructFields {
 }
 
 #[derive(Default)]
-struct StructFieldsInner {
+struct FieldsInner {
     names: FieldNames,
     dtypes: Arc<[FieldDType]>,
     // Derived from names, maps from field name to first index.
     indices: OnceLock<HashMap<FieldName, usize>>,
 }
 
-impl StructFieldsInner {
+impl FieldsInner {
     fn from_fields(names: FieldNames, dtypes: Arc<[FieldDType]>) -> Self {
         Self {
             names,
@@ -244,15 +244,15 @@ impl StructFieldsInner {
     }
 }
 
-impl PartialEq for StructFieldsInner {
+impl PartialEq for FieldsInner {
     fn eq(&self, other: &Self) -> bool {
         self.names == other.names && self.dtypes == other.dtypes
     }
 }
 
-impl Eq for StructFieldsInner {}
+impl Eq for FieldsInner {}
 
-impl Hash for StructFieldsInner {
+impl Hash for FieldsInner {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.names.hash(state);
         self.dtypes.hash(state);
@@ -260,14 +260,14 @@ impl Hash for StructFieldsInner {
 }
 
 #[cfg(feature = "serde")]
-impl serde::Serialize for StructFieldsInner {
+impl serde::Serialize for FieldsInner {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
         use serde::ser::SerializeStruct;
 
-        let mut state = serializer.serialize_struct("StructFieldsInner", 2)?;
+        let mut state = serializer.serialize_struct("FieldsInner", 2)?;
         state.serialize_field("names", &self.names)?;
         state.serialize_field("dtypes", &self.dtypes)?;
         state.end()
@@ -275,39 +275,39 @@ impl serde::Serialize for StructFieldsInner {
 }
 
 #[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for StructFieldsInner {
+impl<'de> serde::Deserialize<'de> for FieldsInner {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         #[derive(serde::Deserialize)]
-        struct StructFieldsInnerHelper {
+        struct FieldsInnerHelper {
             names: FieldNames,
             dtypes: Arc<[FieldDType]>,
         }
 
-        let helper = StructFieldsInnerHelper::deserialize(deserializer)?;
-        Ok(StructFieldsInner::from_fields(helper.names, helper.dtypes))
+        let helper = FieldsInnerHelper::deserialize(deserializer)?;
+        Ok(FieldsInner::from_fields(helper.names, helper.dtypes))
     }
 }
 
-impl Default for StructFields {
+impl Default for Fields {
     fn default() -> Self {
         Self::empty()
     }
 }
 
-impl StructFields {
+impl Fields {
     /// The fields of the empty struct.
     pub fn empty() -> Self {
-        Self(Arc::new(StructFieldsInner {
+        Self(Arc::new(FieldsInner {
             names: FieldNames::default(),
             dtypes: Arc::from([]),
             indices: OnceLock::new(),
         }))
     }
 
-    /// Create a new [`StructFields`] from a list of names and dtypes
+    /// Create a new [`Fields`] from a list of names and dtypes
     pub fn new(names: FieldNames, dtypes: Vec<DType>) -> Self {
         if names.len() != dtypes.len() {
             vortex_panic!(
@@ -327,7 +327,7 @@ impl StructFields {
         Self::from_fields(names, dtypes)
     }
 
-    /// Create a new [`StructFields`] from a  list of names and [`FieldDType`] which can be either lazily or eagerly serialized.
+    /// Create a new [`Fields`] from a  list of names and [`FieldDType`] which can be either lazily or eagerly serialized.
     pub fn from_fields(names: FieldNames, dtypes: Vec<FieldDType>) -> Self {
         if names.len() != dtypes.len() {
             vortex_panic!(
@@ -336,10 +336,7 @@ impl StructFields {
                 dtypes.len()
             );
         }
-        Self(Arc::new(StructFieldsInner::from_fields(
-            names,
-            dtypes.into(),
-        )))
+        Self(Arc::new(FieldsInner::from_fields(names, dtypes.into())))
     }
 
     /// Get the names of the fields in the struct
@@ -399,10 +396,10 @@ impl StructFields {
             dtypes.push(self.0.dtypes[idx].clone());
         }
 
-        Ok(StructFields::from_fields(names.into(), dtypes))
+        Ok(Fields::from_fields(names.into(), dtypes))
     }
 
-    /// Returns a new [`StructFields`] without the field at the given index.
+    /// Returns a new [`Fields`] without the field at the given index.
     ///
     /// ## Errors
     /// Returns an error if the index is out of bounds for the struct fields.
@@ -433,10 +430,10 @@ impl StructFields {
             .map(|(_, dtype)| dtype.clone())
             .collect::<Vec<_>>();
 
-        Ok(StructFields::from_fields(names, dtypes))
+        Ok(Fields::from_fields(names, dtypes))
     }
 
-    /// Merge two [`StructFields`] instances into a new one.
+    /// Merge two [`Fields`] instances into a new one.
     /// Order of fields in arguments is preserved
     ///
     /// # Errors
@@ -466,7 +463,7 @@ impl StructFields {
     }
 }
 
-impl<T, V> FromIterator<(T, V)> for StructFields
+impl<T, V> FromIterator<(T, V)> for Fields
 where
     T: Into<FieldName>,
     V: Into<FieldDType>,
@@ -476,7 +473,7 @@ where
             .into_iter()
             .map(|(name, dtype)| (name.into(), dtype.into()))
             .unzip();
-        StructFields::from_fields(names.into(), dtypes)
+        Fields::from_fields(names.into(), dtypes)
     }
 }
 
@@ -485,13 +482,13 @@ mod test {
     use itertools::Itertools;
 
     use crate::dtype::DType;
-    use crate::{FieldNames, Nullability, PType, StructFields};
+    use crate::{FieldNames, Fields, Nullability, PType};
 
     #[test]
     fn nullability() {
         assert!(
             !DType::Struct(
-                StructFields::new(FieldNames::default(), Vec::new()),
+                Fields::new(FieldNames::default(), Vec::new()),
                 Nullability::NonNullable
             )
             .is_nullable()
@@ -509,7 +506,7 @@ mod test {
         let b_type = DType::Bool(Nullability::NonNullable);
 
         let dtype = DType::Struct(
-            StructFields::from_iter([("A", a_type.clone()), ("B", b_type.clone())]),
+            Fields::from_iter([("A", a_type.clone()), ("B", b_type.clone())]),
             Nullability::Nullable,
         );
         assert!(dtype.is_nullable());
@@ -542,7 +539,7 @@ mod test {
     fn test_without_field_out_of_bounds() {
         let a_type = DType::Primitive(PType::I32, Nullability::Nullable);
         let b_type = DType::Bool(Nullability::NonNullable);
-        let sdt = StructFields::from_iter([("A", a_type), ("B", b_type)]);
+        let sdt = Fields::from_iter([("A", a_type), ("B", b_type)]);
 
         let result = sdt.without_field(2);
         assert!(result.is_err());
@@ -556,7 +553,7 @@ mod test {
     fn test_without_field_deprecated() {
         let a_type = DType::Primitive(PType::I32, Nullability::Nullable);
         let b_type = DType::Bool(Nullability::NonNullable);
-        let sdt = StructFields::from_iter([("A", a_type), ("B", b_type.clone())]);
+        let sdt = Fields::from_iter([("A", a_type), ("B", b_type.clone())]);
 
         let without_a = sdt.without_field(0).unwrap();
         assert_eq!(without_a.names(), ["B"]);
@@ -570,24 +567,24 @@ mod test {
         let child_b = DType::Bool(Nullability::Nullable);
         let child_c = DType::Utf8(Nullability::NonNullable);
 
-        let sf1 = StructFields::from_iter([("A", child_a.clone()), ("B", child_b.clone())]);
+        let sf1 = Fields::from_iter([("A", child_a.clone()), ("B", child_b.clone())]);
 
-        let sf2 = StructFields::from_iter([("C", child_c.clone())]);
+        let sf2 = Fields::from_iter([("C", child_c.clone())]);
 
-        let merged = StructFields::disjoint_merge(&sf1, &sf2).unwrap();
+        let merged = Fields::disjoint_merge(&sf1, &sf2).unwrap();
         assert_eq!(merged.names(), ["A", "B", "C"]);
         assert_eq!(
             merged.fields().collect_vec(),
             vec![child_a, child_b, child_c]
         );
 
-        let err = StructFields::disjoint_merge(&sf1, &sf1).err().unwrap();
+        let err = Fields::disjoint_merge(&sf1, &sf1).err().unwrap();
         assert!(err.to_string().contains("duplicate names"),);
     }
 
     #[test]
     fn test_display() {
-        let fields = StructFields::from_iter([
+        let fields = Fields::from_iter([
             ("name", DType::Utf8(Nullability::NonNullable)),
             ("age", DType::Primitive(PType::I32, Nullability::Nullable)),
             ("active", DType::Bool(Nullability::NonNullable)),
@@ -596,11 +593,11 @@ mod test {
         assert_eq!(fields.to_string(), "{name=utf8, age=i32?, active=bool}");
 
         // Test empty struct
-        let empty = StructFields::empty();
+        let empty = Fields::empty();
         assert_eq!(empty.to_string(), "{}");
 
         // Test nested struct
-        let nested = StructFields::from_iter([
+        let nested = Fields::from_iter([
             ("id", DType::Primitive(PType::U64, Nullability::NonNullable)),
             ("data", DType::Struct(fields, Nullability::Nullable)),
         ]);

--- a/vortex-duckdb/src/convert/dtype.rs
+++ b/vortex-duckdb/src/convert/dtype.rs
@@ -34,7 +34,7 @@ use std::sync::Arc;
 use vortex::dtype::PType::{F32, F64, I8, I16, I32, I64, U8, U16, U32, U64};
 use vortex::dtype::datetime::{DATE_ID, TIME_ID, TIMESTAMP_ID, TemporalMetadata, TimeUnit};
 use vortex::dtype::{
-    DType, DecimalDType, ExtDType, FieldName, Nullability, PType, StructFields, datetime,
+    DType, DecimalDType, ExtDType, FieldName, Nullability, PType, Fields, datetime,
 };
 use vortex::error::{VortexError, VortexResult, vortex_bail, vortex_err};
 
@@ -164,7 +164,7 @@ impl FromLogicalType for DType {
     }
 }
 
-pub fn from_duckdb_table<I, S>(iter: I) -> VortexResult<StructFields>
+pub fn from_duckdb_table<I, S>(iter: I) -> VortexResult<Fields>
 where
     I: Iterator<Item = (S, LogicalType, Nullability)>,
     S: AsRef<str>,
@@ -175,7 +175,7 @@ where
             DType::from_logical_type(type_, nullability)?,
         ))
     })
-    .collect::<VortexResult<StructFields>>()
+    .collect::<VortexResult<Fields>>()
 }
 
 impl TryFrom<&DType> for LogicalType {
@@ -269,7 +269,7 @@ mod tests {
     use std::sync::Arc;
 
     use rstest::rstest;
-    use vortex::dtype::{DType, FieldName, FieldNames, Nullability, PType, StructFields};
+    use vortex::dtype::{DType, FieldName, FieldNames, Nullability, PType, Fields};
 
     use crate::cpp;
     use crate::duckdb::LogicalType;
@@ -345,7 +345,7 @@ mod tests {
             DType::Primitive(PType::I32, Nullability::NonNullable),
             DType::Utf8(Nullability::NonNullable),
         ];
-        let struct_fields = StructFields::new(field_names, field_types);
+        let struct_fields = Fields::new(field_names, field_types);
         let dtype = DType::Struct(struct_fields, Nullability::NonNullable);
         let logical_type = LogicalType::try_from(&dtype).unwrap();
 
@@ -359,7 +359,7 @@ mod tests {
     fn test_struct_with_invalid_field_name() {
         let field_names = FieldNames::from([FieldName::from("field\0with_null")]);
         let field_types = vec![DType::Primitive(PType::I32, Nullability::NonNullable)];
-        let struct_fields = StructFields::new(field_names, field_types);
+        let struct_fields = Fields::new(field_names, field_types);
         let dtype = DType::Struct(struct_fields, Nullability::NonNullable);
 
         let result = LogicalType::try_from(&dtype);
@@ -368,7 +368,7 @@ mod tests {
 
     #[test]
     fn test_empty_struct() {
-        let struct_fields = StructFields::new(FieldNames::default(), [].into());
+        let struct_fields = Fields::new(FieldNames::default(), [].into());
         let dtype = DType::Struct(struct_fields, Nullability::NonNullable);
 
         let logical_type = LogicalType::try_from(&dtype).unwrap();

--- a/vortex-duckdb/src/convert/dtype.rs
+++ b/vortex-duckdb/src/convert/dtype.rs
@@ -34,7 +34,7 @@ use std::sync::Arc;
 use vortex::dtype::PType::{F32, F64, I8, I16, I32, I64, U8, U16, U32, U64};
 use vortex::dtype::datetime::{DATE_ID, TIME_ID, TIMESTAMP_ID, TemporalMetadata, TimeUnit};
 use vortex::dtype::{
-    DType, DecimalDType, ExtDType, FieldName, Nullability, PType, Fields, datetime,
+    DType, DecimalDType, ExtDType, FieldName, Fields, Nullability, PType, datetime,
 };
 use vortex::error::{VortexError, VortexResult, vortex_bail, vortex_err};
 
@@ -269,7 +269,7 @@ mod tests {
     use std::sync::Arc;
 
     use rstest::rstest;
-    use vortex::dtype::{DType, FieldName, FieldNames, Nullability, PType, Fields};
+    use vortex::dtype::{DType, FieldName, FieldNames, Fields, Nullability, PType};
 
     use crate::cpp;
     use crate::duckdb::LogicalType;

--- a/vortex-duckdb/src/copy.rs
+++ b/vortex-duckdb/src/copy.rs
@@ -13,7 +13,7 @@ use tokio::task::JoinHandle;
 use tokio_stream::wrappers::ReceiverStream;
 use vortex::ArrayRef;
 use vortex::dtype::Nullability::{NonNullable, Nullable};
-use vortex::dtype::{DType, StructFields};
+use vortex::dtype::{DType, Fields};
 use vortex::error::{VortexExpect, VortexResult, vortex_err};
 use vortex::file::{VortexWriteOptions, WriteSummary};
 use vortex::stream::ArrayStreamAdapter;
@@ -26,7 +26,7 @@ pub struct VortexCopyFunction;
 
 pub struct BindData {
     dtype: DType,
-    fields: StructFields,
+    fields: Fields,
 }
 
 static COPY_RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {

--- a/vortex-duckdb/src/e2e_test/vortex_scan_test.rs
+++ b/vortex-duckdb/src/e2e_test/vortex_scan_test.rs
@@ -135,7 +135,7 @@ async fn write_vortex_file_to_dir(
     field_name: &str,
     array: impl IntoArray,
 ) -> NamedTempFile {
-    let struct_array = StructArray::from_fields(&[(field_name, array.into_array())]).unwrap();
+    let struct_array = StructArray::from_columns(&[(field_name, array.into_array())]).unwrap();
     let temp_file_path = tempfile::Builder::new()
         .suffix(".vortex")
         .tempfile_in(dir)

--- a/vortex-duckdb/src/exporter/mod.rs
+++ b/vortex-duckdb/src/exporter/mod.rs
@@ -91,7 +91,7 @@ pub struct ArrayExporter {
 impl ArrayExporter {
     pub fn try_new(array: &StructArray, cache: &ConversionCache) -> VortexResult<Self> {
         let fields = array
-            .fields()
+            .columns()
             .iter()
             .map(|field| new_array_exporter(field.as_ref(), cache))
             .try_collect()?;

--- a/vortex-duckdb/src/exporter/struct_.rs
+++ b/vortex-duckdb/src/exporter/struct_.rs
@@ -22,7 +22,7 @@ pub(crate) fn new_exporter(
     let validity_for_mask = array.dtype().is_nullable().then(|| !&validity);
 
     let children = array
-        .fields()
+        .columns()
         .iter()
         .map(|child| {
             if let Some(mv) = validity_for_mask.as_ref() {
@@ -72,7 +72,7 @@ mod tests {
             VarBinViewArray::from_iter_str(vec!["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"])
                 .into_array();
         let arr =
-            StructArray::from_fields(&[("a", prim), ("b", strings)]).vortex_expect("struct array");
+            StructArray::from_columns(&[("a", prim), ("b", strings)]).vortex_expect("struct array");
         let mut chunk = DataChunk::new([LogicalType::struct_type(
             vec![
                 LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_INTEGER),

--- a/vortex-expr/benches/large_struct_pack.rs
+++ b/vortex-expr/benches/large_struct_pack.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::unwrap_used)]
 
 use divan::Bencher;
-use vortex_dtype::{DType, FieldName, Nullability, PType, Fields};
+use vortex_dtype::{DType, FieldName, Fields, Nullability, PType};
 use vortex_expr::{get_item, pack, root};
 
 fn main() {

--- a/vortex-expr/benches/large_struct_pack.rs
+++ b/vortex-expr/benches/large_struct_pack.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::unwrap_used)]
 
 use divan::Bencher;
-use vortex_dtype::{DType, FieldName, Nullability, PType, StructFields};
+use vortex_dtype::{DType, FieldName, Nullability, PType, Fields};
 use vortex_expr::{get_item, pack, root};
 
 fn main() {
@@ -19,7 +19,7 @@ fn pack_return_dtype(bencher: Bencher, num_fields: usize) {
         .collect();
     let field_types = vec![DType::Primitive(PType::I64, Nullability::Nullable); num_fields];
 
-    let struct_fields = StructFields::new(field_names.clone().into(), field_types);
+    let struct_fields = Fields::new(field_names.clone().into(), field_types);
     let dtype = DType::Struct(struct_fields, Nullability::NonNullable);
 
     let root_expr = root();

--- a/vortex-expr/src/exprs/cast.rs
+++ b/vortex-expr/src/exprs/cast.rs
@@ -161,7 +161,7 @@ mod tests {
 
     #[test]
     fn evaluate() {
-        let test_array = StructArray::from_fields(&[
+        let test_array = StructArray::from_columns(&[
             ("a", buffer![0i32, 1, 2].into_array()),
             ("b", buffer![4i64, 5, 6].into_array()),
         ])

--- a/vortex-expr/src/exprs/concat.rs
+++ b/vortex-expr/src/exprs/concat.rs
@@ -178,7 +178,7 @@ mod tests {
     use crate::{ConcatExpr, Scope, col, concat, lit, root};
 
     fn test_array() -> vortex_array::ArrayRef {
-        vortex_array::arrays::StructArray::from_fields(&[
+        vortex_array::arrays::StructArray::from_columns(&[
             ("a", buffer![1, 2, 3].into_array()),
             ("b", buffer![4, 5, 6].into_array()),
         ])

--- a/vortex-expr/src/exprs/get_item.rs
+++ b/vortex-expr/src/exprs/get_item.rs
@@ -86,7 +86,7 @@ impl VTable for GetItemVTable {
 
     fn evaluate(expr: &Self::Expr, scope: &Scope) -> VortexResult<ArrayRef> {
         let input = expr.child.unchecked_evaluate(scope)?.to_struct();
-        let field = input.field_by_name(expr.field()).cloned()?;
+        let field = input.column_by_name(expr.field()).cloned()?;
 
         match input.dtype().nullability() {
             Nullability::NonNullable => Ok(field),
@@ -204,7 +204,7 @@ mod tests {
     use crate::{Scope, root};
 
     fn test_array() -> StructArray {
-        StructArray::from_fields(&[
+        StructArray::from_columns(&[
             ("a", buffer![0i32, 1, 2].into_array()),
             ("b", buffer![4i64, 5, 6].into_array()),
         ])

--- a/vortex-expr/src/exprs/is_null.rs
+++ b/vortex-expr/src/exprs/is_null.rs
@@ -210,7 +210,7 @@ mod tests {
 
     #[test]
     fn evaluate_struct() {
-        let test_array = StructArray::from_fields(&[(
+        let test_array = StructArray::from_columns(&[(
             "a",
             PrimitiveArray::from_option_iter(vec![Some(1), None, Some(2), None, Some(3)])
                 .into_array(),

--- a/vortex-expr/src/exprs/list_contains.rs
+++ b/vortex-expr/src/exprs/list_contains.rs
@@ -178,7 +178,7 @@ mod tests {
     use vortex_array::{Array, ArrayRef, IntoArray};
     use vortex_buffer::buffer;
     use vortex_dtype::PType::I32;
-    use vortex_dtype::{DType, Field, FieldPath, FieldPathSet, Nullability, StructFields};
+    use vortex_dtype::{DType, Field, FieldPath, FieldPathSet, Nullability, Fields};
     use vortex_scalar::Scalar;
     use vortex_utils::aliases::hash_map::HashMap;
 
@@ -278,7 +278,7 @@ mod tests {
     #[test]
     pub fn test_return_type() {
         let scope = DType::Struct(
-            StructFields::new(
+            Fields::new(
                 ["array"].into(),
                 vec![DType::List(
                     Arc::new(DType::Primitive(I32, Nullability::NonNullable)),

--- a/vortex-expr/src/exprs/list_contains.rs
+++ b/vortex-expr/src/exprs/list_contains.rs
@@ -178,7 +178,7 @@ mod tests {
     use vortex_array::{Array, ArrayRef, IntoArray};
     use vortex_buffer::buffer;
     use vortex_dtype::PType::I32;
-    use vortex_dtype::{DType, Field, FieldPath, FieldPathSet, Nullability, Fields};
+    use vortex_dtype::{DType, Field, FieldPath, FieldPathSet, Fields, Nullability};
     use vortex_scalar::Scalar;
     use vortex_utils::aliases::hash_map::HashMap;
 

--- a/vortex-expr/src/exprs/literal.rs
+++ b/vortex-expr/src/exprs/literal.rs
@@ -175,7 +175,7 @@ pub fn lit(value: impl Into<Scalar>) -> ExprRef {
 
 #[cfg(test)]
 mod tests {
-    use vortex_dtype::{DType, Nullability, PType, StructFields};
+    use vortex_dtype::{DType, Nullability, PType, Fields};
     use vortex_scalar::Scalar;
 
     use crate::{lit, test_harness};
@@ -204,7 +204,7 @@ mod tests {
         );
 
         let sdtype = DType::Struct(
-            StructFields::new(
+            Fields::new(
                 ["dog", "cat"].into(),
                 vec![
                     DType::Primitive(PType::U32, Nullability::NonNullable),

--- a/vortex-expr/src/exprs/literal.rs
+++ b/vortex-expr/src/exprs/literal.rs
@@ -175,7 +175,7 @@ pub fn lit(value: impl Into<Scalar>) -> ExprRef {
 
 #[cfg(test)]
 mod tests {
-    use vortex_dtype::{DType, Nullability, PType, Fields};
+    use vortex_dtype::{DType, Fields, Nullability, PType};
     use vortex_scalar::Scalar;
 
     use crate::{lit, test_harness};

--- a/vortex-expr/src/exprs/merge.rs
+++ b/vortex-expr/src/exprs/merge.rs
@@ -7,7 +7,7 @@ use itertools::Itertools as _;
 use vortex_array::arrays::StructArray;
 use vortex_array::validity::Validity;
 use vortex_array::{Array, ArrayRef, DeserializeMetadata, EmptyMetadata, IntoArray, ToCanonical};
-use vortex_dtype::{DType, FieldNames, Nullability, StructFields};
+use vortex_dtype::{DType, FieldNames, Nullability, Fields};
 use vortex_error::{VortexExpect as _, VortexResult, vortex_bail};
 
 use crate::display::{DisplayAs, DisplayFormat};
@@ -94,7 +94,7 @@ impl VTable for MergeVTable {
             for (field_name, array) in struct_array
                 .names()
                 .iter()
-                .zip_eq(struct_array.fields().iter().cloned())
+                .zip_eq(struct_array.columns().iter().cloned())
             {
                 // Update or insert field.
                 if let Some(idx) = field_names.iter().position(|name| name == field_name) {
@@ -147,7 +147,7 @@ impl VTable for MergeVTable {
         }
 
         Ok(DType::Struct(
-            StructFields::new(FieldNames::from(field_names), arrays),
+            Fields::new(FieldNames::from(field_names), arrays),
             nullability,
         ))
     }
@@ -209,9 +209,9 @@ mod tests {
             vortex_bail!("empty field path");
         };
 
-        let mut array = array.to_struct().field_by_name(field)?.clone();
+        let mut array = array.to_struct().column_by_name(field)?.clone();
         for field in field_path {
-            array = array.to_struct().field_by_name(field)?.clone();
+            array = array.to_struct().column_by_name(field)?.clone();
         }
         Ok(array.to_primitive())
     }
@@ -224,10 +224,10 @@ mod tests {
             get_item("2", root()),
         ]);
 
-        let test_array = StructArray::from_fields(&[
+        let test_array = StructArray::from_columns(&[
             (
                 "0",
-                StructArray::from_fields(&[
+                StructArray::from_columns(&[
                     ("a", buffer![0, 0, 0].into_array()),
                     ("b", buffer![1, 1, 1].into_array()),
                 ])
@@ -236,7 +236,7 @@ mod tests {
             ),
             (
                 "1",
-                StructArray::from_fields(&[
+                StructArray::from_columns(&[
                     ("b", buffer![2, 2, 2].into_array()),
                     ("c", buffer![3, 3, 3].into_array()),
                 ])
@@ -245,7 +245,7 @@ mod tests {
             ),
             (
                 "2",
-                StructArray::from_fields(&[
+                StructArray::from_columns(&[
                     ("d", buffer![4, 4, 4].into_array()),
                     ("e", buffer![5, 5, 5].into_array()),
                 ])
@@ -298,7 +298,7 @@ mod tests {
     pub fn test_empty_merge() {
         let expr = MergeExpr::new(Vec::new());
 
-        let test_array = StructArray::from_fields(&[("a", buffer![0, 1, 2].into_array())])
+        let test_array = StructArray::from_columns(&[("a", buffer![0, 1, 2].into_array())])
             .unwrap()
             .into_array();
         let actual_array = expr.evaluate(&Scope::new(test_array.clone())).unwrap();
@@ -312,12 +312,12 @@ mod tests {
 
         let expr = MergeExpr::new(vec![get_item("0", root()), get_item("1", root())]);
 
-        let test_array = StructArray::from_fields(&[
+        let test_array = StructArray::from_columns(&[
             (
                 "0",
-                StructArray::from_fields(&[(
+                StructArray::from_columns(&[(
                     "a",
-                    StructArray::from_fields(&[
+                    StructArray::from_columns(&[
                         ("x", buffer![0, 0, 0].into_array()),
                         ("y", buffer![1, 1, 1].into_array()),
                     ])
@@ -329,9 +329,9 @@ mod tests {
             ),
             (
                 "1",
-                StructArray::from_fields(&[(
+                StructArray::from_columns(&[(
                     "a",
-                    StructArray::from_fields(&[("x", buffer![0, 0, 0].into_array())])
+                    StructArray::from_columns(&[("x", buffer![0, 0, 0].into_array())])
                         .unwrap()
                         .into_array(),
                 )])
@@ -348,7 +348,7 @@ mod tests {
 
         assert_eq!(
             actual_array
-                .field_by_name("a")
+                .column_by_name("a")
                 .unwrap()
                 .to_struct()
                 .names()
@@ -363,10 +363,10 @@ mod tests {
     pub fn test_merge_order() {
         let expr = MergeExpr::new(vec![get_item("0", root()), get_item("1", root())]);
 
-        let test_array = StructArray::from_fields(&[
+        let test_array = StructArray::from_columns(&[
             (
                 "0",
-                StructArray::from_fields(&[
+                StructArray::from_columns(&[
                     ("a", buffer![0, 0, 0].into_array()),
                     ("c", buffer![1, 1, 1].into_array()),
                 ])
@@ -375,7 +375,7 @@ mod tests {
             ),
             (
                 "1",
-                StructArray::from_fields(&[
+                StructArray::from_columns(&[
                     ("b", buffer![2, 2, 2].into_array()),
                     ("d", buffer![3, 3, 3].into_array()),
                 ])

--- a/vortex-expr/src/exprs/merge.rs
+++ b/vortex-expr/src/exprs/merge.rs
@@ -7,7 +7,7 @@ use itertools::Itertools as _;
 use vortex_array::arrays::StructArray;
 use vortex_array::validity::Validity;
 use vortex_array::{Array, ArrayRef, DeserializeMetadata, EmptyMetadata, IntoArray, ToCanonical};
-use vortex_dtype::{DType, FieldNames, Nullability, Fields};
+use vortex_dtype::{DType, FieldNames, Fields, Nullability};
 use vortex_error::{VortexExpect as _, VortexResult, vortex_bail};
 
 use crate::display::{DisplayAs, DisplayFormat};

--- a/vortex-expr/src/exprs/pack.rs
+++ b/vortex-expr/src/exprs/pack.rs
@@ -7,7 +7,7 @@ use itertools::Itertools as _;
 use vortex_array::arrays::StructArray;
 use vortex_array::validity::Validity;
 use vortex_array::{ArrayRef, DeserializeMetadata, IntoArray, ProstMetadata};
-use vortex_dtype::{DType, FieldName, FieldNames, Nullability, StructFields};
+use vortex_dtype::{DType, FieldName, FieldNames, Fields, Nullability};
 use vortex_error::{VortexExpect as _, VortexResult, vortex_bail, vortex_err};
 use vortex_proto::expr as pb;
 
@@ -35,7 +35,7 @@ vtable!(Pack);
 /// let packed = example.evaluate(&Scope::new(buffer![100, 110, 200].into_array())).unwrap();
 /// let x_copy = packed
 ///     .to_struct()
-///     .field_by_name("x copy")
+///     .column_by_name("x copy")
 ///     .unwrap()
 ///     .clone();
 /// assert_eq!(x_copy.scalar_at(0), Scalar::from(100));
@@ -127,7 +127,7 @@ impl VTable for PackVTable {
             .map(|value_expr| value_expr.return_dtype(scope))
             .collect::<VortexResult<Vec<_>>>()?;
         Ok(DType::Struct(
-            StructFields::new(expr.names.clone(), value_dtypes),
+            Fields::new(expr.names.clone(), value_dtypes),
             expr.nullability,
         ))
     }
@@ -245,7 +245,7 @@ mod tests {
     use crate::{IntoExpr, PackExpr, Scope, col, pack};
 
     fn test_array() -> ArrayRef {
-        StructArray::from_fields(&[
+        StructArray::from_columns(&[
             ("a", buffer![0, 1, 2].into_array()),
             ("b", buffer![4, 5, 6].into_array()),
         ])
@@ -260,9 +260,9 @@ mod tests {
             vortex_bail!("empty field path");
         };
 
-        let mut array = array.to_struct().field_by_name(field)?.clone();
+        let mut array = array.to_struct().column_by_name(field)?.clone();
         for field in field_path {
-            array = array.to_struct().field_by_name(field)?.clone();
+            array = array.to_struct().column_by_name(field)?.clone();
         }
         Ok(array.to_primitive())
     }
@@ -275,7 +275,7 @@ mod tests {
         let test_array = test_array();
         let actual_array = expr.evaluate(&Scope::new(test_array.clone())).unwrap();
         assert_eq!(actual_array.len(), test_array.len());
-        assert_eq!(actual_array.to_struct().struct_fields().nfields(), 0);
+        assert_eq!(actual_array.to_struct().fields().nfields(), 0);
     }
 
     #[test]

--- a/vortex-expr/src/exprs/select.rs
+++ b/vortex-expr/src/exprs/select.rs
@@ -324,7 +324,7 @@ mod tests {
     use crate::{FieldSelection, Scope, SelectExpr, root, select, select_exclude, test_harness};
 
     fn test_array() -> StructArray {
-        StructArray::from_fields(&[
+        StructArray::from_columns(&[
             ("a", buffer![0, 1, 2].into_array()),
             ("b", buffer![4, 5, 6].into_array()),
         ])

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -389,7 +389,7 @@ impl Hash for ExactExpr {
 
 #[cfg(feature = "test-harness")]
 pub mod test_harness {
-    use vortex_dtype::{DType, Nullability, PType, Fields};
+    use vortex_dtype::{DType, Fields, Nullability, PType};
 
     pub fn struct_dtype() -> DType {
         DType::Struct(
@@ -410,7 +410,7 @@ pub mod test_harness {
 
 #[cfg(test)]
 mod tests {
-    use vortex_dtype::{DType, FieldNames, Nullability, PType, Fields};
+    use vortex_dtype::{DType, FieldNames, Fields, Nullability, PType};
     use vortex_scalar::Scalar;
 
     use super::*;

--- a/vortex-expr/src/lib.rs
+++ b/vortex-expr/src/lib.rs
@@ -389,11 +389,11 @@ impl Hash for ExactExpr {
 
 #[cfg(feature = "test-harness")]
 pub mod test_harness {
-    use vortex_dtype::{DType, Nullability, PType, StructFields};
+    use vortex_dtype::{DType, Nullability, PType, Fields};
 
     pub fn struct_dtype() -> DType {
         DType::Struct(
-            StructFields::new(
+            Fields::new(
                 ["a", "col1", "col2", "bool1", "bool2"].into(),
                 vec![
                     DType::Primitive(PType::I32, Nullability::NonNullable),
@@ -410,7 +410,7 @@ pub mod test_harness {
 
 #[cfg(test)]
 mod tests {
-    use vortex_dtype::{DType, FieldNames, Nullability, PType, StructFields};
+    use vortex_dtype::{DType, FieldNames, Nullability, PType, Fields};
     use vortex_scalar::Scalar;
 
     use super::*;
@@ -520,7 +520,7 @@ mod tests {
         assert_eq!(
             lit(Scalar::struct_(
                 DType::Struct(
-                    StructFields::new(
+                    Fields::new(
                         FieldNames::from(["dog", "cat"]),
                         vec![
                             DType::Primitive(PType::U32, Nullability::NonNullable),

--- a/vortex-expr/src/transform/immediate_access.rs
+++ b/vortex-expr/src/transform/immediate_access.rs
@@ -37,18 +37,12 @@ pub fn annotate_scope_access(scope: &Fields) -> impl AnnotationFn<Annotation = F
 /// Note: This is a very naive, but simple analysis to find the fields that are accessed directly on an
 /// identity node. This is combined to provide an over-approximation of the fields that are accessed
 /// by an expression.
-pub fn immediate_scope_accesses<'a>(
-    expr: &'a ExprRef,
-    scope: &'a Fields,
-) -> FieldAccesses<'a> {
+pub fn immediate_scope_accesses<'a>(expr: &'a ExprRef, scope: &'a Fields) -> FieldAccesses<'a> {
     descendent_annotations(expr, annotate_scope_access(scope))
 }
 
 /// This returns the immediate scope_access (as explained `immediate_scope_accesses`) for `expr`.
-pub fn immediate_scope_access<'a>(
-    expr: &'a ExprRef,
-    scope: &'a Fields,
-) -> HashSet<FieldName> {
+pub fn immediate_scope_access<'a>(expr: &'a ExprRef, scope: &'a Fields) -> HashSet<FieldName> {
     immediate_scope_accesses(expr, scope)
         .get(expr)
         .vortex_expect("Expression missing from scope accesses, this is a internal bug")

--- a/vortex-expr/src/transform/immediate_access.rs
+++ b/vortex-expr/src/transform/immediate_access.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_dtype::{FieldName, StructFields};
+use vortex_dtype::{FieldName, Fields};
 use vortex_error::VortexExpect;
 use vortex_utils::aliases::hash_set::HashSet;
 
@@ -11,7 +11,7 @@ use crate::{ExprRef, GetItemVTable, SelectVTable, is_root};
 pub type FieldAccesses<'a> = Annotations<'a, FieldName>;
 
 /// An [`AnnotationFn`] for annotating scope accesses.
-pub fn annotate_scope_access(scope: &StructFields) -> impl AnnotationFn<Annotation = FieldName> {
+pub fn annotate_scope_access(scope: &Fields) -> impl AnnotationFn<Annotation = FieldName> {
     move |expr: &ExprRef| {
         assert!(
             !expr.is::<SelectVTable>(),
@@ -39,7 +39,7 @@ pub fn annotate_scope_access(scope: &StructFields) -> impl AnnotationFn<Annotati
 /// by an expression.
 pub fn immediate_scope_accesses<'a>(
     expr: &'a ExprRef,
-    scope: &'a StructFields,
+    scope: &'a Fields,
 ) -> FieldAccesses<'a> {
     descendent_annotations(expr, annotate_scope_access(scope))
 }
@@ -47,7 +47,7 @@ pub fn immediate_scope_accesses<'a>(
 /// This returns the immediate scope_access (as explained `immediate_scope_accesses`) for `expr`.
 pub fn immediate_scope_access<'a>(
     expr: &'a ExprRef,
-    scope: &'a StructFields,
+    scope: &'a Fields,
 ) -> HashSet<FieldName> {
     immediate_scope_accesses(expr, scope)
         .get(expr)

--- a/vortex-expr/src/transform/partition.rs
+++ b/vortex-expr/src/transform/partition.rs
@@ -4,7 +4,7 @@
 use std::fmt::{Display, Formatter};
 
 use itertools::Itertools;
-use vortex_dtype::{DType, FieldName, FieldNames, Nullability, Fields};
+use vortex_dtype::{DType, FieldName, FieldNames, Fields, Nullability};
 use vortex_error::{VortexExpect, VortexResult};
 use vortex_utils::aliases::hash_map::HashMap;
 

--- a/vortex-expr/src/transform/partition.rs
+++ b/vortex-expr/src/transform/partition.rs
@@ -4,7 +4,7 @@
 use std::fmt::{Display, Formatter};
 
 use itertools::Itertools;
-use vortex_dtype::{DType, FieldName, FieldNames, Nullability, StructFields};
+use vortex_dtype::{DType, FieldName, FieldNames, Nullability, Fields};
 use vortex_error::{VortexExpect, VortexResult};
 use vortex_utils::aliases::hash_map::HashMap;
 
@@ -72,7 +72,7 @@ where
         .map(|id| FieldName::from(id.clone()))
         .collect::<FieldNames>();
     let root_scope = DType::Struct(
-        StructFields::new(partition_names.clone(), partition_dtypes.clone()),
+        Fields::new(partition_names.clone(), partition_dtypes.clone()),
         Nullability::NonNullable,
     );
 
@@ -194,7 +194,7 @@ mod tests {
     use rstest::{fixture, rstest};
     use vortex_dtype::Nullability::NonNullable;
     use vortex_dtype::PType::I32;
-    use vortex_dtype::{DType, StructFields};
+    use vortex_dtype::{DType, Fields};
 
     use super::*;
     use crate::transform::immediate_access::annotate_scope_access;
@@ -206,11 +206,11 @@ mod tests {
     #[fixture]
     fn dtype() -> DType {
         DType::Struct(
-            StructFields::from_iter([
+            Fields::from_iter([
                 (
                     "a",
                     DType::Struct(
-                        StructFields::from_iter([("x", I32.into()), ("y", DType::from(I32))]),
+                        Fields::from_iter([("x", I32.into()), ("y", DType::from(I32))]),
                         NonNullable,
                     ),
                 ),

--- a/vortex-expr/src/transform/remove_select.rs
+++ b/vortex-expr/src/transform/remove_select.rs
@@ -53,7 +53,7 @@ mod tests {
 
     use vortex_dtype::Nullability::Nullable;
     use vortex_dtype::PType::I32;
-    use vortex_dtype::{DType, StructFields};
+    use vortex_dtype::{DType, Fields};
 
     use crate::transform::remove_select::remove_select;
     use crate::{PackVTable, root, select};
@@ -61,7 +61,7 @@ mod tests {
     #[test]
     fn test_remove_select() {
         let dtype = DType::Struct(
-            StructFields::new(["a", "b"].into(), vec![I32.into(), I32.into()]),
+            Fields::new(["a", "b"].into(), vec![I32.into(), I32.into()]),
             Nullable,
         );
         let e = select(["a", "b"], root());

--- a/vortex-expr/src/transform/replace.rs
+++ b/vortex-expr/src/transform/replace.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_dtype::{Nullability, Fields};
+use vortex_dtype::{Fields, Nullability};
 use vortex_error::{VortexExpect, VortexResult};
 
 use crate::traversal::{NodeExt, Transformed};

--- a/vortex-expr/src/transform/replace.rs
+++ b/vortex-expr/src/transform/replace.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_dtype::{Nullability, StructFields};
+use vortex_dtype::{Nullability, Fields};
 use vortex_error::{VortexExpect, VortexResult};
 
 use crate::traversal::{NodeExt, Transformed};
@@ -15,7 +15,7 @@ pub fn replace(expr: ExprRef, needle: &ExprRef, replacement: ExprRef) -> ExprRef
 }
 
 /// Expand the `root` expression with a pack of the given struct fields.
-pub fn replace_root_fields(expr: ExprRef, fields: &StructFields) -> ExprRef {
+pub fn replace_root_fields(expr: ExprRef, fields: &Fields) -> ExprRef {
     replace(
         expr,
         &root(),

--- a/vortex-ffi/src/array.rs
+++ b/vortex-ffi/src/array.rs
@@ -53,7 +53,7 @@ pub unsafe extern "C-unwind" fn vx_array_get_field(
 
         let field_array = array
             .to_struct()
-            .fields()
+            .columns()
             .get(index as usize)
             .ok_or_else(|| vortex_err!("Field index out of bounds"))?
             .clone();

--- a/vortex-ffi/src/struct_fields.rs
+++ b/vortex-ffi/src/struct_fields.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 use std::ptr;
 use std::sync::Arc;
 
-use vortex::dtype::{DType, StructFields};
+use vortex::dtype::{DType, Fields};
 use vortex::error::VortexExpect;
 
 use crate::dtype::vx_dtype;
@@ -14,7 +14,7 @@ use crate::{arc_wrapper, box_wrapper};
 
 arc_wrapper!(
     /// Represents a Vortex struct data type, without top-level nullability.
-    StructFields,
+    Fields,
     vx_struct_fields
 );
 
@@ -121,6 +121,6 @@ pub unsafe extern "C-unwind" fn vx_struct_fields_builder_finalize(
     builder: *mut vx_struct_fields_builder,
 ) -> *const vx_struct_fields {
     let builder = vx_struct_fields_builder::into_box(builder);
-    let struct_dtype = StructFields::new(builder.names.into(), builder.fields);
+    let struct_dtype = Fields::new(builder.names.into(), builder.fields);
     vx_struct_fields::new(Arc::new(struct_dtype))
 }

--- a/vortex-file/src/pruning.rs
+++ b/vortex-file/src/pruning.rs
@@ -7,7 +7,7 @@ use vortex_array::ArrayRef;
 use vortex_array::arrays::{ConstantArray, StructArray};
 use vortex_array::stats::{Stat, StatsProvider, StatsSet};
 use vortex_array::validity::Validity;
-use vortex_dtype::{Field, FieldName, FieldNames, FieldPath, StructFields};
+use vortex_dtype::{Field, FieldName, FieldNames, FieldPath, Fields};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
 use vortex_expr::pruning::field_path_stat_field_name;
 use vortex_utils::aliases::hash_map::HashMap;
@@ -16,7 +16,7 @@ use vortex_utils::aliases::hash_set::HashSet;
 pub fn extract_relevant_file_stats_as_struct_row(
     access: &HashMap<FieldPath, HashSet<Stat>>,
     stats_sets: &Arc<[StatsSet]>,
-    struct_dtype: &StructFields,
+    struct_dtype: &Fields,
 ) -> VortexResult<Option<ArrayRef>> {
     if access.is_empty() {
         return StructArray::try_new(FieldNames::default(), vec![], 1, Validity::NonNullable)
@@ -62,6 +62,6 @@ pub fn extract_relevant_file_stats_as_struct_row(
         }
     }
     Ok(Some(
-        StructArray::from_fields(columns.as_slice())?.to_array(),
+        StructArray::from_columns(columns.as_slice())?.to_array(),
     ))
 }

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -20,7 +20,7 @@ use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
 use vortex_buffer::{Buffer, ByteBufferMut, buffer};
 use vortex_dict::{DictEncoding, DictVTable};
 use vortex_dtype::PType::I32;
-use vortex_dtype::{DType, DecimalDType, Nullability, PType, Fields};
+use vortex_dtype::{DType, DecimalDType, Fields, Nullability, PType};
 use vortex_error::VortexResult;
 use vortex_expr::{PackExpr, and, eq, get_item, gt, gt_eq, lit, lt, lt_eq, or, root, select};
 use vortex_scalar::Scalar;

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -20,7 +20,7 @@ use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
 use vortex_buffer::{Buffer, ByteBufferMut, buffer};
 use vortex_dict::{DictEncoding, DictVTable};
 use vortex_dtype::PType::I32;
-use vortex_dtype::{DType, DecimalDType, Nullability, PType, StructFields};
+use vortex_dtype::{DType, DecimalDType, Nullability, PType, Fields};
 use vortex_error::VortexResult;
 use vortex_expr::{PackExpr, and, eq, get_item, gt, gt_eq, lit, lt, lt_eq, or, root, select};
 use vortex_scalar::Scalar;
@@ -51,7 +51,7 @@ async fn test_read_simple() {
     ])
     .into_array();
 
-    let st = StructArray::from_fields(&[("strings", strings), ("numbers", numbers)]).unwrap();
+    let st = StructArray::from_columns(&[("strings", strings), ("numbers", numbers)]).unwrap();
     let mut buf = ByteBufferMut::empty();
     VortexWriteOptions::default()
         .write(&mut buf, st.to_array_stream())
@@ -119,7 +119,7 @@ async fn test_round_trip_many_types() {
     )
     .into_array();
 
-    let st = StructArray::from_fields(&[
+    let st = StructArray::from_columns(&[
         ("strings", strings),
         ("numbers", numbers),
         ("decimal_2", decimal_2),
@@ -182,7 +182,7 @@ async fn test_read_simple_with_spawn() {
     .into_array();
 
     let st =
-        StructArray::from_fields(&[("strings", strings), ("numbers", numbers), ("lists", lists)])
+        StructArray::from_columns(&[("strings", strings), ("numbers", numbers), ("lists", lists)])
             .unwrap();
 
     let mut buf = ByteBufferMut::empty();
@@ -213,7 +213,7 @@ async fn test_read_projection() {
     .into_array();
     let numbers_dtype = numbers.dtype().clone();
 
-    let st = StructArray::from_fields(&[("strings", strings), ("numbers", numbers)]).unwrap();
+    let st = StructArray::from_columns(&[("strings", strings), ("numbers", numbers)]).unwrap();
 
     let mut buf = ByteBufferMut::empty();
     VortexWriteOptions::default()
@@ -235,12 +235,12 @@ async fn test_read_projection() {
     assert_eq!(
         array.dtype(),
         &DType::Struct(
-            StructFields::new(["strings"].into(), vec![strings_dtype]),
+            Fields::new(["strings"].into(), vec![strings_dtype]),
             Nullability::NonNullable,
         )
     );
 
-    let actual = array.to_struct().fields()[0]
+    let actual = array.to_struct().columns()[0]
         .to_varbinview()
         .with_iterator(|x| {
             x.map(|x| unsafe { String::from_utf8_unchecked(x.unwrap().to_vec()) })
@@ -262,12 +262,12 @@ async fn test_read_projection() {
     assert_eq!(
         array.dtype(),
         &DType::Struct(
-            StructFields::new(["numbers"].into(), vec![numbers_dtype]),
+            Fields::new(["numbers"].into(), vec![numbers_dtype]),
             Nullability::NonNullable,
         )
     );
 
-    let primitive_array = array.to_struct().fields()[0].to_primitive();
+    let primitive_array = array.to_struct().columns()[0].to_primitive();
     let actual = primitive_array.as_slice::<u32>();
     assert_eq!(actual, numbers_expected);
 }
@@ -287,7 +287,7 @@ async fn unequal_batches() {
     ])
     .into_array();
 
-    let st = StructArray::from_fields(&[("strings", strings), ("numbers", numbers)]).unwrap();
+    let st = StructArray::from_columns(&[("strings", strings), ("numbers", numbers)]).unwrap();
     let mut buf = ByteBufferMut::empty();
     VortexWriteOptions::default()
         .write(&mut buf, st.to_array_stream())
@@ -311,7 +311,7 @@ async fn unequal_batches() {
 
         let numbers = array
             .to_struct()
-            .field_by_name("numbers")
+            .column_by_name("numbers")
             .unwrap()
             .to_primitive();
         assert_eq!(numbers.ptype(), PType::U32);
@@ -373,7 +373,7 @@ async fn write_chunked() {
 async fn test_empty_varbin_array_roundtrip() {
     let empty = VarBinArray::from(Vec::<&str>::new()).into_array();
 
-    let st = StructArray::from_fields(&[("a", empty)]).unwrap();
+    let st = StructArray::from_columns(&[("a", empty)]).unwrap();
 
     let mut buf = ByteBufferMut::empty();
     VortexWriteOptions::default()
@@ -433,7 +433,7 @@ async fn filter_string() {
         .unwrap();
 
     assert_eq!(result.len(), 1);
-    let names = result[0].to_struct().fields()[0].clone();
+    let names = result[0].to_struct().columns()[0].clone();
     assert_eq!(
         names
             .to_varbinview()
@@ -444,7 +444,7 @@ async fn filter_string() {
             .unwrap(),
         vec!["Joseph".to_string()]
     );
-    let ages = result[0].to_struct().fields()[1].clone();
+    let ages = result[0].to_struct().columns()[1].clone();
     assert_eq!(ages.to_primitive().as_slice::<i32>(), vec![25]);
 }
 
@@ -490,7 +490,7 @@ async fn filter_or() {
         .unwrap();
 
     assert_eq!(result.len(), 1);
-    let names = result[0].to_struct().fields()[0].clone();
+    let names = result[0].to_struct().columns()[0].clone();
     assert_eq!(
         names
             .to_varbinview()
@@ -501,7 +501,7 @@ async fn filter_or() {
             .unwrap(),
         vec!["Joseph".to_string(), "Angela".to_string()]
     );
-    let ages = result[0].to_struct().fields()[1].clone();
+    let ages = result[0].to_struct().columns()[1].clone();
     assert_eq!(
         ages.to_primitive()
             .with_iterator(|iter| iter.map(|x| x.cloned()).collect::<Vec<_>>())
@@ -549,7 +549,7 @@ async fn filter_and() {
         .unwrap();
 
     assert_eq!(result.len(), 1);
-    let names = result[0].to_struct().fields()[0].clone();
+    let names = result[0].to_struct().columns()[0].clone();
     assert_eq!(
         names
             .to_varbinview()
@@ -559,7 +559,7 @@ async fn filter_and() {
             .unwrap(),
         vec![Some("Joseph".to_string()), None]
     );
-    let ages = result[0].to_struct().fields()[1].clone();
+    let ages = result[0].to_struct().columns()[1].clone();
     assert_eq!(ages.to_primitive().as_slice::<i32>(), vec![25, 31]);
 }
 
@@ -567,7 +567,7 @@ async fn filter_and() {
 #[cfg_attr(miri, ignore)]
 async fn test_with_indices_simple() {
     let expected_numbers_split: Vec<Buffer<i16>> = (0..5).map(|_| (0_i16..100).collect()).collect();
-    let expected_array = StructArray::from_fields(&[(
+    let expected_array = StructArray::from_columns(&[(
         "numbers",
         ChunkedArray::from_iter(
             expected_numbers_split
@@ -615,7 +615,7 @@ async fn test_with_indices_simple() {
         .await
         .unwrap()
         .to_struct();
-    let actual_kept_numbers_array = actual_kept_array.fields()[0].to_primitive();
+    let actual_kept_numbers_array = actual_kept_array.columns()[0].to_primitive();
 
     let expected_kept_numbers: Vec<i16> = kept_indices
         .iter()
@@ -636,7 +636,7 @@ async fn test_with_indices_simple() {
         .await
         .unwrap()
         .to_struct();
-    let actual_numbers_array = actual_array.fields()[0].to_primitive();
+    let actual_numbers_array = actual_array.columns()[0].to_primitive();
     let actual_numbers = actual_numbers_array.as_slice::<i16>();
 
     assert_eq!(expected_numbers, actual_numbers);
@@ -659,7 +659,7 @@ async fn test_with_indices_on_two_columns() {
     ])
     .into_array();
 
-    let st = StructArray::from_fields(&[("strings", strings), ("numbers", numbers)]).unwrap();
+    let st = StructArray::from_columns(&[("strings", strings), ("numbers", numbers)]).unwrap();
     let mut buf = ByteBufferMut::empty();
     VortexWriteOptions::default()
         .write(&mut buf, st.to_array_stream())
@@ -681,7 +681,7 @@ async fn test_with_indices_on_two_columns() {
         .to_struct()
         .to_struct();
 
-    let strings_actual = array.fields()[0]
+    let strings_actual = array.columns()[0]
         .to_varbinview()
         .with_iterator(|x| {
             x.map(|x| unsafe { String::from_utf8_unchecked(x.unwrap().to_vec()) })
@@ -696,7 +696,7 @@ async fn test_with_indices_on_two_columns() {
             .collect::<Vec<_>>()
     );
 
-    let numbers_actual_array = array.fields()[1].to_primitive();
+    let numbers_actual_array = array.columns()[1].to_primitive();
     let numbers_actual = numbers_actual_array.as_slice::<u32>();
     assert_eq!(
         numbers_actual,
@@ -711,7 +711,7 @@ async fn test_with_indices_on_two_columns() {
 #[cfg_attr(miri, ignore)]
 async fn test_with_indices_and_with_row_filter_simple() {
     let expected_numbers_split: Vec<Buffer<i16>> = (0..5).map(|_| (0_i16..100).collect()).collect();
-    let expected_array = StructArray::from_fields(&[(
+    let expected_array = StructArray::from_columns(&[(
         "numbers",
         ChunkedArray::from_iter(
             expected_numbers_split
@@ -761,7 +761,7 @@ async fn test_with_indices_and_with_row_filter_simple() {
         .unwrap()
         .to_struct();
 
-    let actual_kept_numbers_array = actual_kept_array.fields()[0].to_primitive();
+    let actual_kept_numbers_array = actual_kept_array.columns()[0].to_primitive();
 
     let expected_kept_numbers: Buffer<i16> = kept_indices
         .iter()
@@ -785,7 +785,7 @@ async fn test_with_indices_and_with_row_filter_simple() {
         .unwrap()
         .to_struct();
 
-    let actual_numbers_array = actual_array.fields()[0].to_primitive();
+    let actual_numbers_array = actual_array.columns()[0].to_primitive();
     let actual_numbers = actual_numbers_array.as_slice::<i16>();
 
     assert_eq!(
@@ -815,10 +815,10 @@ async fn filter_string_chunked() {
     let age_chunk2 =
         PrimitiveArray::from_option_iter([Some(57_i32), Some(18), None, Some(32)]).into_array();
 
-    let chunk1 = StructArray::from_fields(&[("name", name_chunk1), ("age", age_chunk1)])
+    let chunk1 = StructArray::from_columns(&[("name", name_chunk1), ("age", age_chunk1)])
         .unwrap()
         .into_array();
-    let chunk2 = StructArray::from_fields(&[("name", name_chunk2), ("age", age_chunk2)])
+    let chunk2 = StructArray::from_columns(&[("name", name_chunk2), ("age", age_chunk2)])
         .unwrap()
         .into_array();
     let dtype = chunk1.dtype().clone();
@@ -847,7 +847,7 @@ async fn filter_string_chunked() {
         .to_struct();
 
     assert_eq!(actual_array.len(), 1);
-    let names = &actual_array.fields()[0];
+    let names = &actual_array.columns()[0];
     assert_eq!(
         names
             .to_varbinview()
@@ -858,7 +858,7 @@ async fn filter_string_chunked() {
             .unwrap(),
         vec!["Joseph".to_string()]
     );
-    let ages = &actual_array.fields()[1];
+    let ages = &actual_array.columns()[1];
     assert_eq!(ages.to_primitive().as_slice::<i32>(), vec![25]);
 }
 
@@ -900,16 +900,16 @@ async fn test_pruning_with_or() {
     let number_chunk4 =
         PrimitiveArray::from_option_iter([Some(66_i32), Some(77), Some(88)]).into_array();
 
-    let chunk1 = StructArray::from_fields(&[("letter", letter_chunk1), ("number", number_chunk1)])
+    let chunk1 = StructArray::from_columns(&[("letter", letter_chunk1), ("number", number_chunk1)])
         .unwrap()
         .into_array();
-    let chunk2 = StructArray::from_fields(&[("letter", letter_chunk2), ("number", number_chunk2)])
+    let chunk2 = StructArray::from_columns(&[("letter", letter_chunk2), ("number", number_chunk2)])
         .unwrap()
         .into_array();
-    let chunk3 = StructArray::from_fields(&[("letter", letter_chunk3), ("number", number_chunk3)])
+    let chunk3 = StructArray::from_columns(&[("letter", letter_chunk3), ("number", number_chunk3)])
         .unwrap()
         .into_array();
-    let chunk4 = StructArray::from_fields(&[("letter", letter_chunk4), ("number", number_chunk4)])
+    let chunk4 = StructArray::from_columns(&[("letter", letter_chunk4), ("number", number_chunk4)])
         .unwrap()
         .into_array();
     let dtype = chunk1.dtype().clone();
@@ -941,7 +941,7 @@ async fn test_pruning_with_or() {
         .to_struct();
 
     assert_eq!(actual_array.len(), 10);
-    let letters = &actual_array.fields()[0];
+    let letters = &actual_array.columns()[0];
     assert_eq!(
         letters
             .to_varbinview()
@@ -962,7 +962,7 @@ async fn test_pruning_with_or() {
             Some("P".to_string())
         ]
     );
-    let numbers = &actual_array.fields()[1];
+    let numbers = &actual_array.columns()[1];
     assert_eq!(
         (0..numbers.len())
             .map(|index| -> Option<i32> {
@@ -992,11 +992,11 @@ async fn test_repeated_projection() {
     ])
     .into_array();
 
-    let single_column_array = StructArray::from_fields(&[("strings", strings.clone())])
+    let single_column_array = StructArray::from_columns(&[("strings", strings.clone())])
         .unwrap()
         .into_array();
 
-    let expected = StructArray::from_fields(&[("strings", strings.clone()), ("strings", strings)])
+    let expected = StructArray::from_columns(&[("strings", strings.clone()), ("strings", strings)])
         .unwrap()
         .into_array();
 
@@ -1172,10 +1172,10 @@ async fn write_nullable_nested_struct() -> VortexResult<()> {
     let result = round_trip(&array, Ok).await?.to_struct();
 
     assert_eq!(result.len(), 3);
-    assert_eq!(result.fields().len(), 1);
+    assert_eq!(result.columns().len(), 1);
     assert!(result.all_valid());
 
-    let nested_struct = result.field_by_name("struct")?.to_struct();
+    let nested_struct = result.column_by_name("struct")?.to_struct();
     assert_eq!(nested_struct.dtype(), &nested_dtype);
     assert_eq!(nested_struct.len(), 3);
     assert!(nested_struct.all_invalid());
@@ -1215,7 +1215,7 @@ async fn test_into_tokio_array_stream() -> VortexResult<()> {
     ])
     .into_array();
 
-    let st = StructArray::from_fields(&[("strings", strings), ("numbers", numbers)]).unwrap();
+    let st = StructArray::from_columns(&[("strings", strings), ("numbers", numbers)]).unwrap();
     let mut buf = ByteBufferMut::empty();
     VortexWriteOptions::default()
         .write(&mut buf, st.to_array_stream())
@@ -1260,7 +1260,7 @@ async fn test_array_stream_no_double_dict_encode() -> VortexResult<()> {
 async fn test_writer_basic_push() -> VortexResult<()> {
     let strings = VarBinArray::from(vec!["ab", "foo", "bar", "baz"]).into_array();
     let numbers = buffer![1u32, 2, 3, 4].into_array();
-    let st = StructArray::from_fields(&[("strings", strings), ("numbers", numbers)])?.into_array();
+    let st = StructArray::from_columns(&[("strings", strings), ("numbers", numbers)])?.into_array();
     let dtype = st.dtype().clone();
 
     let mut buf = ByteBufferMut::empty();
@@ -1283,11 +1283,11 @@ async fn test_writer_basic_push() -> VortexResult<()> {
 #[tokio::test]
 async fn test_writer_multiple_pushes() -> VortexResult<()> {
     let chunk1 =
-        StructArray::from_fields(&[("numbers", buffer![1u32, 2, 3].into_array())])?.into_array();
+        StructArray::from_columns(&[("numbers", buffer![1u32, 2, 3].into_array())])?.into_array();
     let chunk2 =
-        StructArray::from_fields(&[("numbers", buffer![4u32, 5, 6].into_array())])?.into_array();
+        StructArray::from_columns(&[("numbers", buffer![4u32, 5, 6].into_array())])?.into_array();
     let chunk3 =
-        StructArray::from_fields(&[("numbers", buffer![7u32, 8, 9].into_array())])?.into_array();
+        StructArray::from_columns(&[("numbers", buffer![7u32, 8, 9].into_array())])?.into_array();
 
     let dtype = chunk1.dtype().clone();
 
@@ -1305,7 +1305,7 @@ async fn test_writer_multiple_pushes() -> VortexResult<()> {
     let result = file.scan()?.into_array_stream()?.read_all().await?;
 
     assert_eq!(result.len(), 9);
-    let numbers = result.to_struct().field_by_name("numbers")?.to_primitive();
+    let numbers = result.to_struct().column_by_name("numbers")?.to_primitive();
     assert_eq!(numbers.as_slice::<u32>(), &[1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
     Ok(())
@@ -1314,9 +1314,9 @@ async fn test_writer_multiple_pushes() -> VortexResult<()> {
 #[tokio::test]
 async fn test_writer_push_stream() -> VortexResult<()> {
     let chunk1 =
-        StructArray::from_fields(&[("numbers", buffer![1u32, 2, 3].into_array())])?.into_array();
+        StructArray::from_columns(&[("numbers", buffer![1u32, 2, 3].into_array())])?.into_array();
     let chunk2 =
-        StructArray::from_fields(&[("numbers", buffer![4u32, 5, 6].into_array())])?.into_array();
+        StructArray::from_columns(&[("numbers", buffer![4u32, 5, 6].into_array())])?.into_array();
 
     let dtype = chunk1.dtype().clone();
 
@@ -1335,7 +1335,7 @@ async fn test_writer_push_stream() -> VortexResult<()> {
     let result = file.scan()?.into_array_stream()?.read_all().await?;
 
     assert_eq!(result.len(), 6);
-    let numbers = result.to_struct().field_by_name("numbers")?.to_primitive();
+    let numbers = result.to_struct().column_by_name("numbers")?.to_primitive();
     assert_eq!(numbers.as_slice::<u32>(), &[1, 2, 3, 4, 5, 6]);
 
     Ok(())
@@ -1343,7 +1343,7 @@ async fn test_writer_push_stream() -> VortexResult<()> {
 
 #[tokio::test]
 async fn test_writer_bytes_written() -> VortexResult<()> {
-    let array = StructArray::from_fields(&[("numbers", buffer![1u32, 2, 3, 4, 5].into_array())])?
+    let array = StructArray::from_columns(&[("numbers", buffer![1u32, 2, 3, 4, 5].into_array())])?
         .into_array();
     let dtype = array.dtype().clone();
 
@@ -1371,13 +1371,13 @@ async fn test_writer_bytes_written() -> VortexResult<()> {
 
 #[tokio::test]
 async fn test_writer_empty_chunks() -> VortexResult<()> {
-    let empty = StructArray::from_fields(&[(
+    let empty = StructArray::from_columns(&[(
         "numbers",
         PrimitiveArray::new::<u32>(buffer![], Validity::NonNullable).into_array(),
     )])?
     .into_array();
     let non_empty =
-        StructArray::from_fields(&[("numbers", buffer![1u32, 2].into_array())])?.into_array();
+        StructArray::from_columns(&[("numbers", buffer![1u32, 2].into_array())])?.into_array();
 
     let dtype = empty.dtype().clone();
 
@@ -1395,7 +1395,7 @@ async fn test_writer_empty_chunks() -> VortexResult<()> {
     let result = file.scan()?.into_array_stream()?.read_all().await?;
 
     assert_eq!(result.len(), 2);
-    let numbers = result.to_struct().field_by_name("numbers")?.to_primitive();
+    let numbers = result.to_struct().column_by_name("numbers")?.to_primitive();
     assert_eq!(numbers.as_slice::<u32>(), &[1, 2]);
 
     Ok(())
@@ -1404,11 +1404,11 @@ async fn test_writer_empty_chunks() -> VortexResult<()> {
 #[tokio::test]
 async fn test_writer_mixed_push_and_stream() -> VortexResult<()> {
     let chunk1 =
-        StructArray::from_fields(&[("numbers", buffer![1u32, 2].into_array())])?.into_array();
+        StructArray::from_columns(&[("numbers", buffer![1u32, 2].into_array())])?.into_array();
     let chunk2 =
-        StructArray::from_fields(&[("numbers", buffer![3u32, 4].into_array())])?.into_array();
+        StructArray::from_columns(&[("numbers", buffer![3u32, 4].into_array())])?.into_array();
     let chunk3 =
-        StructArray::from_fields(&[("numbers", buffer![5u32, 6].into_array())])?.into_array();
+        StructArray::from_columns(&[("numbers", buffer![5u32, 6].into_array())])?.into_array();
 
     let dtype = chunk1.dtype().clone();
 
@@ -1429,7 +1429,7 @@ async fn test_writer_mixed_push_and_stream() -> VortexResult<()> {
     let result = file.scan()?.into_array_stream()?.read_all().await?;
 
     assert_eq!(result.len(), 6);
-    let numbers = result.to_struct().field_by_name("numbers")?.to_primitive();
+    let numbers = result.to_struct().column_by_name("numbers")?.to_primitive();
     assert_eq!(numbers.as_slice::<u32>(), &[1, 2, 3, 4, 5, 6]);
 
     Ok(())
@@ -1444,7 +1444,7 @@ async fn test_writer_with_complex_types() -> VortexResult<()> {
         Arc::new(I32.into()),
     )?;
 
-    let chunk = StructArray::from_fields(&[
+    let chunk = StructArray::from_columns(&[
         ("strings", strings),
         ("numbers", numbers),
         ("lists", lists.into_array()),
@@ -1467,7 +1467,7 @@ async fn test_writer_with_complex_types() -> VortexResult<()> {
     assert_eq!(result.len(), 3);
     assert_eq!(result.dtype(), &dtype);
 
-    let strings_field = result.to_struct().field_by_name("strings").cloned()?;
+    let strings_field = result.to_struct().column_by_name("strings").cloned()?;
     let strings = strings_field.to_varbinview().with_iterator(|iter| {
         iter.map(|s| s.map(|st| unsafe { String::from_utf8_unchecked(st.to_vec()) }))
             .collect::<Vec<_>>()
@@ -1486,7 +1486,7 @@ async fn test_writer_with_complex_types() -> VortexResult<()> {
 
 #[tokio::test]
 async fn test_writer_with_statistics() -> VortexResult<()> {
-    let array = StructArray::from_fields(&[("numbers", buffer![1u32, 2, 3, 4, 5].into_array())])?
+    let array = StructArray::from_columns(&[("numbers", buffer![1u32, 2, 3, 4, 5].into_array())])?
         .into_array();
 
     let mut buf = ByteBufferMut::empty();

--- a/vortex-jni/src/array.rs
+++ b/vortex-jni/src/array.rs
@@ -201,7 +201,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getField(
         let field = array_ref
             .inner
             .to_struct()
-            .fields()
+            .columns()
             .get(index as usize)
             .cloned()
             .ok_or_else(|| vortex_err!("Field index out of bounds"))?;

--- a/vortex-jni/src/dtype.rs
+++ b/vortex-jni/src/dtype.rs
@@ -7,7 +7,7 @@ use jni::JNIEnv;
 use jni::objects::{JClass, JLongArray, JObject, JObjectArray, JString, JValue};
 use jni::sys::{JNI_FALSE, JNI_TRUE, jboolean, jbyte, jint, jlong, jobject, jstring};
 use vortex::dtype::datetime::{DATE_ID, TIME_ID, TIMESTAMP_ID, TemporalMetadata, TimeUnit};
-use vortex::dtype::{DType, DecimalDType, ExtDType, Nullability, PType, Fields};
+use vortex::dtype::{DType, DecimalDType, ExtDType, Fields, Nullability, PType};
 use vortex::error::vortex_err;
 
 use crate::errors::{JNIError, try_or_throw};

--- a/vortex-jni/src/dtype.rs
+++ b/vortex-jni/src/dtype.rs
@@ -7,7 +7,7 @@ use jni::JNIEnv;
 use jni::objects::{JClass, JLongArray, JObject, JObjectArray, JString, JValue};
 use jni::sys::{JNI_FALSE, JNI_TRUE, jboolean, jbyte, jint, jlong, jobject, jstring};
 use vortex::dtype::datetime::{DATE_ID, TIME_ID, TIMESTAMP_ID, TemporalMetadata, TimeUnit};
-use vortex::dtype::{DType, DecimalDType, ExtDType, Nullability, PType, StructFields};
+use vortex::dtype::{DType, DecimalDType, ExtDType, Nullability, PType, Fields};
 use vortex::error::vortex_err;
 
 use crate::errors::{JNIError, try_or_throw};
@@ -521,7 +521,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeDTypeMethods_newStruct<'local>(
             dtypes.push(dtype);
         }
 
-        let fields = StructFields::new(field_names_arc.into(), dtypes);
+        let fields = Fields::new(field_names_arc.into(), dtypes);
 
         let struct_type = DType::Struct(fields, to_nullability(is_nullable));
         Ok(Box::into_raw(Box::new(struct_type)) as jlong)

--- a/vortex-layout/src/layouts/compact.rs
+++ b/vortex-layout/src/layouts/compact.rs
@@ -119,7 +119,7 @@ impl CompactCompressor {
             Canonical::Struct(struct_array) => {
                 // recurse
                 let fields = struct_array
-                    .fields()
+                    .columns()
                     .iter()
                     .map(|field| self.compress(field))
                     .collect::<VortexResult<Vec<_>>>()?;
@@ -239,7 +239,7 @@ mod tests {
         for (i, name) in decompressed_struct.names().iter().enumerate() {
             assert_eq!(name, field_names[i]);
             let decompressed_array = decompressed_struct
-                .field_by_name(name)
+                .column_by_name(name)
                 .unwrap()
                 .to_primitive();
             // is there no direct way to assert_eq on (primitive) arrays?

--- a/vortex-layout/src/layouts/file_stats.rs
+++ b/vortex-layout/src/layouts/file_stats.rs
@@ -91,7 +91,7 @@ impl FileStatsAccumulator {
                 .accumulators
                 .lock()
                 .iter_mut()
-                .zip_eq(chunk.fields().iter())
+                .zip_eq(chunk.columns().iter())
             {
                 acc.push_chunk(field)?;
             }

--- a/vortex-layout/src/layouts/flat/writer.rs
+++ b/vortex-layout/src/layouts/flat/writer.rs
@@ -322,7 +322,7 @@ mod tests {
             assert_eq!(
                 result
                     .to_struct()
-                    .field_by_name("a")
+                    .column_by_name("a")
                     .unwrap()
                     .to_primitive()
                     .as_slice::<u64>(),
@@ -331,7 +331,7 @@ mod tests {
             assert_eq!(
                 result
                     .to_struct()
-                    .field_by_name("b")
+                    .column_by_name("b")
                     .unwrap()
                     .to_primitive()
                     .as_slice::<u64>(),

--- a/vortex-layout/src/layouts/struct_/mod.rs
+++ b/vortex-layout/src/layouts/struct_/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use reader::StructReader;
 use vortex_array::{ArrayContext, DeserializeMetadata, EmptyMetadata};
-use vortex_dtype::{DType, Field, FieldMask, StructFields};
+use vortex_dtype::{DType, Field, FieldMask, Fields};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err, vortex_panic};
 
 use crate::children::{LayoutChildren, OwnedLayoutChildren};
@@ -49,14 +49,14 @@ impl VTable for StructVTable {
     }
 
     fn nchildren(layout: &Self::Layout) -> usize {
-        layout.struct_fields().nfields()
+        layout.fields().nfields()
     }
 
     fn child(layout: &Self::Layout, idx: usize) -> VortexResult<LayoutRef> {
         layout.children.child(
             idx,
             &layout
-                .struct_fields()
+                .fields()
                 .field_by_index(idx)
                 .ok_or_else(|| vortex_err!("Missing field {idx}"))?,
         )
@@ -65,7 +65,7 @@ impl VTable for StructVTable {
     fn child_type(layout: &Self::Layout, idx: usize) -> LayoutChildType {
         LayoutChildType::Field(
             layout
-                .struct_fields()
+                .fields()
                 .field_name(idx)
                 .vortex_expect("Field index out of bounds")
                 .clone(),
@@ -130,7 +130,7 @@ impl StructLayout {
         }
     }
 
-    pub fn struct_fields(&self) -> &StructFields {
+    pub fn fields(&self) -> &Fields {
         let DType::Struct(dtype, _) = self.dtype() else {
             vortex_panic!("Mismatched dtype {} for struct layout", self.dtype());
         };
@@ -143,7 +143,7 @@ impl StructLayout {
     {
         // If the field mask contains an `All` fields, then enumerate all fields.
         if field_mask.iter().any(|mask| mask.matches_all()) {
-            for idx in 0..self.struct_fields().nfields() {
+            for idx in 0..self.fields().nfields() {
                 per_child(FieldMask::All, idx)?;
             }
             return Ok(());
@@ -159,7 +159,7 @@ impl StructLayout {
                 vortex_bail!("Expected field name, got {field:?}");
             };
             let idx = self
-                .struct_fields()
+                .fields()
                 .find(field_name)
                 .ok_or_else(|| vortex_err!("Field not found: {field_name}"))?;
 

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 use vortex_array::MaskFuture;
 use vortex_array::stats::Precision;
-use vortex_dtype::{DType, FieldMask, FieldName, StructFields};
+use vortex_dtype::{DType, FieldMask, FieldName, Fields};
 use vortex_error::{VortexExpect, VortexResult, vortex_err};
 use vortex_expr::transform::immediate_access::annotate_scope_access;
 use vortex_expr::transform::{
@@ -43,7 +43,7 @@ impl StructReader {
         name: Arc<str>,
         segment_source: Arc<dyn SegmentSource>,
     ) -> VortexResult<Self> {
-        let struct_dt = layout.struct_fields();
+        let struct_dt = layout.fields();
 
         // NOTE: This number is arbitrary and likely depends on the longest common prefix of field names
         let field_lookup = (struct_dt.nfields() > 80).then(|| {
@@ -73,9 +73,9 @@ impl StructReader {
         })
     }
 
-    /// Return the [`StructFields`] of this layout.
-    fn struct_fields(&self) -> &StructFields {
-        self.layout.struct_fields()
+    /// Return the [`Fields`] of this layout.
+    fn fields(&self) -> &Fields {
+        self.layout.fields()
     }
 
     /// Return the child reader for the field.
@@ -84,7 +84,7 @@ impl StructReader {
             .field_lookup
             .as_ref()
             .and_then(|lookup| lookup.get(name).copied())
-            .or_else(|| self.struct_fields().find(name))
+            .or_else(|| self.fields().find(name))
             .ok_or_else(|| vortex_err!("Field {} not found in struct layout", name))?;
         self.child_by_idx(idx)
     }
@@ -92,10 +92,10 @@ impl StructReader {
     /// Return the child reader for the field, by index.
     fn child_by_idx(&self, idx: usize) -> VortexResult<&LayoutReaderRef> {
         let field_dtype = self
-            .struct_fields()
+            .fields()
             .field_by_index(idx)
             .ok_or_else(|| vortex_err!("Missing field {idx}"))?;
-        let name = &self.struct_fields().names()[idx];
+        let name = &self.fields().names()[idx];
         self.lazy_children
             .get(idx, &field_dtype, &format!("{}.{}", self.name, name).into())
     }
@@ -283,7 +283,7 @@ mod tests {
             strategy.write_stream(
                 ctx,
                 segments.clone(),
-                StructArray::from_fields(
+                StructArray::from_columns(
                     [
                         ("a", buffer![7, 2, 3].into_array()),
                         ("b", buffer![4, 5, 6].into_array()),
@@ -394,7 +394,7 @@ mod tests {
         assert_eq!(
             result
                 .to_struct()
-                .field_by_name("a")
+                .column_by_name("a")
                 .unwrap()
                 .to_primitive()
                 .as_slice::<i32>(),
@@ -404,7 +404,7 @@ mod tests {
         assert_eq!(
             result
                 .to_struct()
-                .field_by_name("b")
+                .column_by_name("b")
                 .unwrap()
                 .to_primitive()
                 .as_slice::<i32>(),

--- a/vortex-layout/src/layouts/struct_/writer.rs
+++ b/vortex-layout/src/layouts/struct_/writer.rs
@@ -83,7 +83,7 @@ impl LayoutStrategy for StructStrategy {
             let mut sequence_pointer = sequence_id.descend();
             let struct_chunk = chunk.to_struct();
             let columns: Vec<_> = struct_chunk
-                .fields()
+                .columns()
                 .iter()
                 .map(|field| (sequence_pointer.advance(), field.to_array()))
                 .collect();

--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -9,7 +9,7 @@ use vortex_array::compute::sum;
 use vortex_array::stats::{Precision, Stat, StatsProvider, StatsSet};
 use vortex_array::validity::Validity;
 use vortex_array::{Array, ArrayRef};
-use vortex_dtype::{DType, Nullability, PType, Fields};
+use vortex_dtype::{DType, Fields, Nullability, PType};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail};
 use vortex_expr::{ExprRef, Scope};
 use vortex_mask::Mask;

--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -9,7 +9,7 @@ use vortex_array::compute::sum;
 use vortex_array::stats::{Precision, Stat, StatsProvider, StatsSet};
 use vortex_array::validity::Validity;
 use vortex_array::{Array, ArrayRef};
-use vortex_dtype::{DType, Nullability, PType, StructFields};
+use vortex_dtype::{DType, Nullability, PType, Fields};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail};
 use vortex_expr::{ExprRef, Scope};
 use vortex_mask::Mask;
@@ -61,7 +61,7 @@ impl ZoneMap {
     pub fn dtype_for_stats_table(column_dtype: &DType, present_stats: &[Stat]) -> DType {
         assert!(present_stats.is_sorted(), "Stats must be sorted");
         DType::Struct(
-            StructFields::from_iter(
+            Fields::from_iter(
                 present_stats
                     .iter()
                     .filter_map(|stat| {
@@ -126,7 +126,7 @@ impl ZoneMap {
 
     /// Returns the array for a given stat.
     pub fn get_stat(&self, stat: Stat) -> VortexResult<Option<ArrayRef>> {
-        Ok(self.array.field_by_name_opt(stat.name()).cloned())
+        Ok(self.array.column_by_name_opt(stat.name()).cloned())
     }
 
     /// Apply a pruning predicate against the ZoneMap, yielding a mask indicating which zones can
@@ -285,11 +285,11 @@ mod tests {
             ]
         );
         assert_eq!(
-            stats_table.array.fields()[1].to_bool().boolean_buffer(),
+            stats_table.array.columns()[1].to_bool().boolean_buffer(),
             &BooleanBuffer::from(vec![false, true])
         );
         assert_eq!(
-            stats_table.array.fields()[3].to_bool().boolean_buffer(),
+            stats_table.array.columns()[3].to_bool().boolean_buffer(),
             &BooleanBuffer::from(vec![true, false])
         );
     }
@@ -311,11 +311,11 @@ mod tests {
             ]
         );
         assert_eq!(
-            stats_table.array.fields()[1].to_bool().boolean_buffer(),
+            stats_table.array.columns()[1].to_bool().boolean_buffer(),
             &BooleanBuffer::from(vec![false])
         );
         assert_eq!(
-            stats_table.array.fields()[3].to_bool().boolean_buffer(),
+            stats_table.array.columns()[3].to_bool().boolean_buffer(),
             &BooleanBuffer::from(vec![false])
         );
     }
@@ -341,7 +341,7 @@ mod tests {
         // +----------+----------+
         let zone_map = ZoneMap::try_new(
             PType::I32.into(),
-            StructArray::from_fields(&[
+            StructArray::from_columns(&[
                 (
                     "max",
                     PrimitiveArray::new(buffer![5i32, 6i32, 7i32], Validity::AllValid).into_array(),

--- a/vortex-python/src/arrays/builtins/struct_.rs
+++ b/vortex-python/src/arrays/builtins/struct_.rs
@@ -20,7 +20,7 @@ impl EncodingSubclass for PyStructArray {
 impl PyStructArray {
     /// Returns the given field of the struct array.
     pub fn field(self_: PyRef<'_, Self>, name: &str) -> PyResult<PyArrayRef> {
-        let field = self_.as_array_ref().field_by_name(name)?.clone();
+        let field = self_.as_array_ref().column_by_name(name)?.clone();
         Ok(PyArrayRef::from(field))
     }
 
@@ -28,7 +28,7 @@ impl PyStructArray {
     pub fn names(self_: PyRef<'_, Self>) -> PyResult<Vec<String>> {
         Ok(self_
             .as_array_ref()
-            .struct_fields()
+            .fields()
             .names()
             .iter()
             .map(|f| f.to_string())

--- a/vortex-python/src/dtype/factory.rs
+++ b/vortex-python/src/dtype/factory.rs
@@ -8,7 +8,7 @@ use pyo3::prelude::PyAnyMethods;
 use pyo3::types::PyDict;
 use pyo3::{Bound, PyResult, Python, pyfunction};
 use vortex::dtype::{
-    DType, DecimalDType, ExtDType, ExtID, ExtMetadata, FieldName, FieldNames, PType, StructFields,
+    DType, DecimalDType, ExtDType, ExtID, ExtMetadata, FieldName, FieldNames, PType, Fields,
 };
 
 use crate::dtype::PyDType;
@@ -356,13 +356,13 @@ pub(super) fn dtype_struct<'py>(
 
         PyDType::init(
             py,
-            DType::Struct(StructFields::new(names.into(), dtypes), nullable.into()),
+            DType::Struct(Fields::new(names.into(), dtypes), nullable.into()),
         )
     } else {
         PyDType::init(
             py,
             DType::Struct(
-                StructFields::new(FieldNames::empty(), vec![]),
+                Fields::new(FieldNames::empty(), vec![]),
                 nullable.into(),
             ),
         )

--- a/vortex-python/src/dtype/factory.rs
+++ b/vortex-python/src/dtype/factory.rs
@@ -8,7 +8,7 @@ use pyo3::prelude::PyAnyMethods;
 use pyo3::types::PyDict;
 use pyo3::{Bound, PyResult, Python, pyfunction};
 use vortex::dtype::{
-    DType, DecimalDType, ExtDType, ExtID, ExtMetadata, FieldName, FieldNames, PType, Fields,
+    DType, DecimalDType, ExtDType, ExtID, ExtMetadata, FieldName, FieldNames, Fields, PType,
 };
 
 use crate::dtype::PyDType;
@@ -361,10 +361,7 @@ pub(super) fn dtype_struct<'py>(
     } else {
         PyDType::init(
             py,
-            DType::Struct(
-                Fields::new(FieldNames::empty(), vec![]),
-                nullable.into(),
-            ),
+            DType::Struct(Fields::new(FieldNames::empty(), vec![]), nullable.into()),
         )
     }
 }

--- a/vortex-python/src/scalar/factory.rs
+++ b/vortex-python/src/scalar/factory.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PyString};
-use vortex::dtype::{DType, FieldName, FieldNames, Nullability, Fields};
+use vortex::dtype::{DType, FieldName, FieldNames, Fields, Nullability};
 use vortex::scalar::Scalar;
 
 use crate::dtype::PyDType;

--- a/vortex-python/src/scalar/factory.rs
+++ b/vortex-python/src/scalar/factory.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PyString};
-use vortex::dtype::{DType, FieldName, FieldNames, Nullability, StructFields};
+use vortex::dtype::{DType, FieldName, FieldNames, Nullability, Fields};
 use vortex::scalar::Scalar;
 
 use crate::dtype::PyDType;
@@ -129,7 +129,7 @@ fn scalar_helper_inner(value: &Bound<'_, PyAny>, dtype: Option<&DType>) -> PyRes
                 .map(|value| scalar_helper_inner(&value, None))
                 .try_collect()?;
             let dtype = DType::Struct(
-                StructFields::new(
+                Fields::new(
                     names,
                     values.iter().map(|value| value.dtype().clone()).collect(),
                 ),

--- a/vortex-python/src/scalar/into_py.rs
+++ b/vortex-python/src/scalar/into_py.rs
@@ -85,7 +85,7 @@ impl<'py> IntoPyObject<'py> for PyVortex<StructScalar<'_>> {
     type Error = PyErr;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        let Some(fields) = self.0.fields() else {
+        let Some(fields) = self.0.columns() else {
             return Ok(py.None().into_pyobject(py)?);
         };
 

--- a/vortex-scalar/src/arrow/tests.rs
+++ b/vortex-scalar/src/arrow/tests.rs
@@ -214,10 +214,10 @@ fn test_null_decimal_to_arrow() {
 #[test]
 #[should_panic(expected = "struct scalar conversion")]
 fn test_struct_scalar_to_arrow_todo() {
-    use vortex_dtype::{FieldDType, StructFields};
+    use vortex_dtype::{FieldDType, Fields};
 
     let struct_dtype = DType::Struct(
-        StructFields::from_iter([(
+        Fields::from_iter([(
             "field1",
             FieldDType::from(DType::Primitive(PType::I32, Nullability::NonNullable)),
         )]),

--- a/vortex-scalar/src/display.rs
+++ b/vortex-scalar/src/display.rs
@@ -30,7 +30,7 @@ mod tests {
     use vortex_buffer::ByteBuffer;
     use vortex_dtype::Nullability::{NonNullable, Nullable};
     use vortex_dtype::datetime::{DATE_ID, TIME_ID, TIMESTAMP_ID, TemporalMetadata, TimeUnit};
-    use vortex_dtype::{DType, ExtDType, ExtMetadata, FieldName, PType, StructFields};
+    use vortex_dtype::{DType, ExtDType, ExtMetadata, FieldName, PType, Fields};
 
     use crate::{InnerScalarValue, PValue, Scalar, ScalarValue};
 
@@ -95,7 +95,7 @@ mod tests {
     #[test]
     fn display_empty_struct() {
         fn dtype() -> DType {
-            DType::Struct(StructFields::new(Default::default(), vec![]), Nullable)
+            DType::Struct(Fields::new(Default::default(), vec![]), Nullable)
         }
 
         assert_eq!(format!("{}", Scalar::null(dtype())), "null");
@@ -107,7 +107,7 @@ mod tests {
     fn display_one_field_struct() {
         fn dtype() -> DType {
             DType::Struct(
-                StructFields::new(
+                Fields::new(
                     [FieldName::from("foo")].into(),
                     vec![DType::Primitive(PType::U32, Nullable)],
                 ),
@@ -140,7 +140,7 @@ mod tests {
         let f1 = DType::Bool(Nullable);
         let f2 = DType::Primitive(PType::U32, Nullable);
         let dtype = DType::Struct(
-            StructFields::new(
+            Fields::new(
                 [FieldName::from("foo"), FieldName::from("bar")].into(),
                 vec![f1.clone(), f2.clone()],
             ),

--- a/vortex-scalar/src/display.rs
+++ b/vortex-scalar/src/display.rs
@@ -30,7 +30,7 @@ mod tests {
     use vortex_buffer::ByteBuffer;
     use vortex_dtype::Nullability::{NonNullable, Nullable};
     use vortex_dtype::datetime::{DATE_ID, TIME_ID, TIMESTAMP_ID, TemporalMetadata, TimeUnit};
-    use vortex_dtype::{DType, ExtDType, ExtMetadata, FieldName, PType, Fields};
+    use vortex_dtype::{DType, ExtDType, ExtMetadata, FieldName, Fields, PType};
 
     use crate::{InnerScalarValue, PValue, Scalar, ScalarValue};
 

--- a/vortex-scalar/src/null.rs
+++ b/vortex-scalar/src/null.rs
@@ -125,10 +125,10 @@ mod tests {
 
     #[test]
     fn test_null_struct() {
-        use vortex_dtype::{FieldDType, StructFields};
+        use vortex_dtype::{FieldDType, Fields};
 
         let struct_dtype = DType::Struct(
-            StructFields::from_iter([("field1", FieldDType::from(DType::Null))]),
+            Fields::from_iter([("field1", FieldDType::from(DType::Null))]),
             Nullability::Nullable,
         );
 

--- a/vortex-scalar/src/proto.rs
+++ b/vortex-scalar/src/proto.rs
@@ -174,7 +174,7 @@ mod tests {
     use rstest::rstest;
     use vortex_buffer::BufferString;
     use vortex_dtype::half::f16;
-    use vortex_dtype::{DType, DecimalDType, FieldDType, Nullability, PType, StructFields};
+    use vortex_dtype::{DType, DecimalDType, FieldDType, Nullability, PType, Fields};
     use vortex_error::vortex_panic;
     use vortex_proto::scalar as pb;
 
@@ -281,7 +281,7 @@ mod tests {
     #[case(Scalar::list(Arc::new(PType::U8.into()), vec![Scalar::primitive(1u8, Nullability::NonNullable)], Nullability::NonNullable
     ))]
     #[case(Scalar::struct_(DType::Struct(
-        StructFields::from_iter([
+        Fields::from_iter([
             ("a", FieldDType::from(DType::Primitive(PType::U32, Nullability::NonNullable))),
             ("b", FieldDType::from(DType::Primitive(PType::F16, Nullability::NonNullable))),
         ]),
@@ -292,7 +292,7 @@ mod tests {
         ],
     ))]
     #[case(Scalar::struct_(DType::Struct(
-        StructFields::from_iter([
+        Fields::from_iter([
             ("a", FieldDType::from(DType::Primitive(PType::U64, Nullability::NonNullable))),
             ("b", FieldDType::from(DType::Primitive(PType::F32, Nullability::NonNullable))),
             ("c", FieldDType::from(DType::Primitive(PType::F16, Nullability::NonNullable))),

--- a/vortex-scalar/src/proto.rs
+++ b/vortex-scalar/src/proto.rs
@@ -174,7 +174,7 @@ mod tests {
     use rstest::rstest;
     use vortex_buffer::BufferString;
     use vortex_dtype::half::f16;
-    use vortex_dtype::{DType, DecimalDType, FieldDType, Nullability, PType, Fields};
+    use vortex_dtype::{DType, DecimalDType, FieldDType, Fields, Nullability, PType};
     use vortex_error::vortex_panic;
     use vortex_proto::scalar as pb;
 

--- a/vortex-scalar/src/scalar.rs
+++ b/vortex-scalar/src/scalar.rs
@@ -177,7 +177,7 @@ impl Scalar {
                 .map_or(0, |s| s.len()),
             DType::Struct(_dtype, _) => self
                 .as_struct()
-                .fields()
+                .columns()
                 .map(|fields| fields.into_iter().map(|f| f.nbytes()).sum::<usize>())
                 .unwrap_or_default(),
             DType::List(..) | DType::FixedSizeList(..) => self

--- a/vortex-scalar/src/struct_.rs
+++ b/vortex-scalar/src/struct_.rs
@@ -8,7 +8,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use itertools::Itertools;
-use vortex_dtype::{DType, FieldName, FieldNames, StructFields};
+use vortex_dtype::{DType, FieldName, FieldNames, Fields};
 use vortex_error::{
     VortexError, VortexExpect, VortexResult, vortex_bail, vortex_err, vortex_panic,
 };
@@ -34,7 +34,7 @@ impl Display for StructScalar<'_> {
                 let formatted_fields = self
                     .names()
                     .iter()
-                    .zip_eq(self.struct_fields().fields())
+                    .zip_eq(self.fields().fields())
                     .zip_eq(fields.iter())
                     .map(|((name, dtype), value)| {
                         let val = Scalar::new(dtype, value.clone());
@@ -54,7 +54,7 @@ impl PartialEq for StructScalar<'_> {
             return false;
         }
 
-        match (self.fields(), other.fields()) {
+        match (self.columns(), other.columns()) {
             (Some(lhs), Some(rhs)) => lhs.zip(rhs).all(|(l_s, r_s)| l_s == r_s),
             (None, None) => true,
             (Some(_), None) | (None, Some(_)) => false,
@@ -71,7 +71,7 @@ impl PartialOrd for StructScalar<'_> {
             return None;
         }
 
-        match (self.fields(), other.fields()) {
+        match (self.columns(), other.columns()) {
             (Some(lhs), Some(rhs)) => {
                 for (l_s, r_s) in lhs.zip(rhs) {
                     match l_s.partial_cmp(&r_s)? {
@@ -93,7 +93,7 @@ impl PartialOrd for StructScalar<'_> {
 impl Hash for StructScalar<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.dtype.hash(state);
-        if let Some(fields) = self.fields() {
+        if let Some(fields) = self.columns() {
             for f in fields {
                 f.hash(state);
             }
@@ -122,7 +122,7 @@ impl<'a> StructScalar<'a> {
 
     /// Returns the struct field definitions.
     #[inline]
-    pub fn struct_fields(&self) -> &StructFields {
+    pub fn fields(&self) -> &Fields {
         self.dtype
             .as_struct_fields_opt()
             .vortex_expect("StructScalar always has struct dtype")
@@ -130,7 +130,7 @@ impl<'a> StructScalar<'a> {
 
     /// Returns the field names of the struct.
     pub fn names(&self) -> &FieldNames {
-        self.struct_fields().names()
+        self.fields().names()
     }
 
     /// Returns true if the struct is null.
@@ -142,7 +142,7 @@ impl<'a> StructScalar<'a> {
     ///
     /// Returns None if the field doesn't exist.
     pub fn field(&self, name: impl AsRef<str>) -> Option<Scalar> {
-        let idx = self.struct_fields().find(name)?;
+        let idx = self.fields().find(name)?;
         self.field_by_idx(idx)
     }
 
@@ -158,18 +158,18 @@ impl<'a> StructScalar<'a> {
             .fields
             .vortex_expect("Can't take field out of null struct scalar");
         Some(Scalar::new(
-            self.struct_fields().field_by_index(idx)?,
+            self.fields().field_by_index(idx)?,
             fields[idx].clone(),
         ))
     }
 
-    /// Returns the fields of the struct scalar, or None if the scalar is null.
-    pub fn fields(&self) -> Option<impl ExactSizeIterator<Item = Scalar>> {
+    /// Returns the values of the struct scalar, or None if the scalar is null.
+    pub fn columns(&self) -> Option<impl ExactSizeIterator<Item = Scalar>> {
         let fields = self.fields?;
         Some(
             fields
                 .iter()
-                .zip(self.struct_fields().fields())
+                .zip(self.fields().fields())
                 .map(|(v, dtype)| Scalar::new(dtype, v.clone())),
         )
     }
@@ -190,7 +190,7 @@ impl<'a> StructScalar<'a> {
                 dtype
             )
         };
-        let own_st = self.struct_fields();
+        let own_st = self.fields();
 
         if st.fields().len() != own_st.fields().len() {
             vortex_bail!(
@@ -308,7 +308,7 @@ impl<'a> TryFrom<&'a Scalar> for StructScalar<'a> {
 #[cfg(test)]
 mod tests {
     use vortex_dtype::PType::I32;
-    use vortex_dtype::{DType, Nullability, StructFields};
+    use vortex_dtype::{DType, Fields, Nullability};
 
     use super::*;
 
@@ -317,7 +317,7 @@ mod tests {
         let f1_dt = DType::Utf8(Nullability::NonNullable);
 
         let dtype = DType::Struct(
-            StructFields::new(["a", "b"].into(), vec![f0_dt.clone(), f1_dt.clone()]),
+            Fields::new(["a", "b"].into(), vec![f0_dt.clone(), f1_dt.clone()]),
             Nullability::Nullable,
         );
 
@@ -388,7 +388,7 @@ mod tests {
     }
 
     #[test]
-    fn test_struct_field_by_name() {
+    fn test_struct_column_by_name() {
         let (_, _, dtype) = setup_types();
         let f0_val = Scalar::primitive::<i32>(42, Nullability::NonNullable);
         let f1_val = Scalar::utf8("world", Nullability::NonNullable);
@@ -424,7 +424,7 @@ mod tests {
 
         let scalar = Scalar::struct_(dtype, vec![f0_val, f1_val]);
 
-        let fields = scalar.as_struct().fields().unwrap().collect::<Vec<_>>();
+        let fields = scalar.as_struct().columns().unwrap().collect::<Vec<_>>();
         assert_eq!(fields.len(), 2);
         assert_eq!(fields[0].as_primitive().typed_value::<i32>().unwrap(), 100);
         assert_eq!(fields[1].as_utf8().value().unwrap(), "test".into());
@@ -436,14 +436,14 @@ mod tests {
         let null_scalar = Scalar::null(dtype);
 
         assert!(null_scalar.as_struct().is_null());
-        assert!(null_scalar.as_struct().fields().is_none());
+        assert!(null_scalar.as_struct().columns().is_none());
         assert!(null_scalar.as_struct().field_values().is_none());
     }
 
     #[test]
     fn test_struct_cast_to_struct() {
         // Create source struct
-        let source_fields = StructFields::new(
+        let source_fields = Fields::new(
             ["x", "y"].into(),
             vec![
                 DType::Primitive(I32, Nullability::NonNullable),
@@ -453,7 +453,7 @@ mod tests {
         let source_dtype = DType::Struct(source_fields, Nullability::NonNullable);
 
         // Create target struct with different field types
-        let target_fields = StructFields::new(
+        let target_fields = Fields::new(
             ["x", "y"].into(),
             vec![
                 DType::Primitive(vortex_dtype::PType::I64, Nullability::NonNullable),
@@ -470,20 +470,20 @@ mod tests {
         let result = source_scalar.as_struct().cast(&target_dtype).unwrap();
         assert_eq!(result.dtype(), &target_dtype);
 
-        let fields = result.as_struct().fields().unwrap().collect::<Vec<_>>();
+        let fields = result.as_struct().columns().unwrap().collect::<Vec<_>>();
         assert_eq!(fields[0].as_primitive().typed_value::<i64>().unwrap(), 42);
         assert_eq!(fields[1].as_primitive().typed_value::<i64>().unwrap(), 123);
     }
 
     #[test]
     fn test_struct_cast_mismatched_fields() {
-        let source_fields = StructFields::new(
+        let source_fields = Fields::new(
             ["a"].into(),
             vec![DType::Primitive(I32, Nullability::NonNullable)],
         );
         let source_dtype = DType::Struct(source_fields, Nullability::NonNullable);
 
-        let target_fields = StructFields::new(
+        let target_fields = Fields::new(
             ["a", "b"].into(),
             vec![
                 DType::Primitive(I32, Nullability::NonNullable),
@@ -533,7 +533,7 @@ mod tests {
         assert_eq!(projected_struct.names().len(), 1);
         assert_eq!(projected_struct.names()[0].as_ref(), "b");
 
-        let fields = projected_struct.fields().unwrap().collect::<Vec<_>>();
+        let fields = projected_struct.columns().unwrap().collect::<Vec<_>>();
         assert_eq!(fields.len(), 1);
         assert_eq!(fields[0].as_utf8().value().unwrap().as_str(), "hello");
     }
@@ -604,7 +604,7 @@ mod tests {
 
         // Different struct types cannot be compared
         let other_dtype = DType::Struct(
-            StructFields::new(
+            Fields::new(
                 ["c"].into(),
                 vec![DType::Primitive(I32, Nullability::NonNullable)],
             ),

--- a/vortex-scalar/src/tests/casting.rs
+++ b/vortex-scalar/src/tests/casting.rs
@@ -8,7 +8,7 @@ mod tests {
     use std::sync::Arc;
 
     use vortex_dtype::half::f16;
-    use vortex_dtype::{DType, ExtDType, ExtID, FieldDType, Nullability, PType, StructFields};
+    use vortex_dtype::{DType, ExtDType, ExtID, FieldDType, Fields, Nullability, PType};
     use vortex_error::VortexExpect;
 
     use crate::{InnerScalarValue, PValue, Scalar, ScalarValue};
@@ -168,7 +168,7 @@ mod tests {
         let f32_value = std::f32::consts::PI;
 
         let struct_dtype = DType::Struct(
-            StructFields::from_iter([
+            Fields::from_iter([
                 (
                     "a",
                     FieldDType::from(DType::Primitive(PType::U32, Nullability::NonNullable)),
@@ -199,7 +199,7 @@ mod tests {
         );
 
         let struct_scalar = scalar.as_struct();
-        let fields = struct_scalar.fields().unwrap().collect::<Vec<_>>();
+        let fields = struct_scalar.columns().unwrap().collect::<Vec<_>>();
 
         // Check first field (no coercion needed)
         assert_eq!(fields[0].as_primitive().pvalue().unwrap(), PValue::U32(42));
@@ -315,7 +315,7 @@ mod tests {
         // Create an extension type with struct storage that contains f16 field
         let ext_id = ExtID::new("test_struct_ext".into());
         let struct_dtype = Arc::new(DType::Struct(
-            StructFields::from_iter([
+            Fields::from_iter([
                 (
                     "id",
                     FieldDType::from(DType::Primitive(PType::U32, Nullability::NonNullable)),
@@ -348,7 +348,7 @@ mod tests {
             .as_extension()
             .storage()
             .as_struct()
-            .fields()
+            .columns()
             .vortex_expect("non null")
             .collect::<Vec<_>>();
         assert_eq!(

--- a/vortex-tui/src/browse/ui/layouts.rs
+++ b/vortex-tui/src/browse/ui/layouts.rs
@@ -132,7 +132,7 @@ fn render_array(app: &AppState<'_>, area: Rect, buf: &mut Buffer, is_stats_table
         // Render the stats table horizontally
         let struct_array = array.to_struct();
         // add 1 for the chunk column
-        let field_count = struct_array.struct_fields().nfields() + 1;
+        let field_count = struct_array.fields().nfields() + 1;
         let header = std::iter::once("chunk")
             .chain(struct_array.names().iter().map(|x| x.as_ref()))
             .map(Cell::from)
@@ -142,7 +142,7 @@ fn render_array(app: &AppState<'_>, area: Rect, buf: &mut Buffer, is_stats_table
 
         assert_eq!(app.cursor.dtype(), array.dtype());
 
-        let field_arrays: Vec<ArrayRef> = struct_array.fields().to_vec();
+        let field_arrays: Vec<ArrayRef> = struct_array.columns().to_vec();
 
         // TODO: trim the number of displayed rows and allow paging through column stats.
         let rows = (0..array.len()).map(|chunk_id| {


### PR DESCRIPTION
We currently call a StructArray's children "columns" in some places and "fields" in others, but "fields" is used inconsistently, sometimes its just the types and sometimes its the child arrays. This PR tries to clear up two concepts, making the API hopefully more intuitive and consistent. After this PR the split should be:
1. Fields - essentially a struct dtype (sans its top level nullability). An array of `Field`, where each field has a name, and a dtype.
2. Columns - the array's (or scalar's) values, stored in arrays matching the fields.

