### PR TITLE
Dont publish vortex-gpu-kernels

### DIFF
--- a/vortex-gpu-kernels/Cargo.toml
+++ b/vortex-gpu-kernels/Cargo.toml
@@ -12,6 +12,7 @@ readme = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
+publish = false
 
 [lib]
 name = "vortex_gpu_kernels"


### PR DESCRIPTION
Just as the title says, seems to follow from the fact that we don't currently want to publish `vortex-gpu`