### PR TITLE
do not export spans by default on benchmarks

### DIFF
--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -194,7 +194,6 @@ jobs:
           target/release_debug/query_bench ${{ matrix.subcommand }} \
             -d gh-json \
             --targets ${{ matrix.targets }} \
-            --export-spans \
             ${{ matrix.scale_factor }} \
             --delete-duckdb-database \
             -o results.json
@@ -213,7 +212,6 @@ jobs:
           target/release_debug/query_bench ${{ matrix.subcommand }} \
               --use-remote-data-dir ${{ matrix.remote_storage }} \
               --targets ${{ matrix.targets }} \
-              --export-spans \
               ${{ matrix.scale_factor }} \
               -d gh-json \
               --delete-duckdb-database \


### PR DESCRIPTION
Disable exporting spans to grafana by default. Kept the functionality because it should work with all otel endpoints, so we can use a jaeger or datadog trace viewer when we want to debug benchmarks with traces