### PR TITLE
Split the publish flow into two flows

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,141 @@
+name: Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to set (e.g., 0.1.0)"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to set (e.g., 0.1.0)"
+        required: true
+        type: string
+
+jobs:
+  prepare-python:
+    runs-on: ${{ matrix.target.runs-on }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - { os: macos, runs-on: "macos-latest", target: aarch64-apple-darwin }
+          - { os: macos, runs-on: "macos-13", target: x86_64-apple-darwin }
+          - { os: ubuntu, runs-on: "ubuntu-latest", target: aarch64-unknown-linux-gnu }
+          - { os: ubuntu, runs-on: "ubuntu-latest", target: x86_64-unknown-linux-gnu }
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          targets: ${{ matrix.target.target }}
+
+      - name: Cargo Set Version
+        run: |
+          cargo install cargo-edit
+          cargo set-version --workspace ${{ inputs.version }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        # Latest macOS doesn't allow maturin to install stuff into the global Python interpreter
+        if: "${{ matrix.target.runs-on == 'macos-latest' }}"
+        with:
+          python-version: "3.11"
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          target: ${{ matrix.target.target }}
+          args: >
+            ${{ (matrix.target.os == 'ubuntu' && '--zig') || '' }}
+            --compatibility manylinux2014
+            --release
+            --manifest-path vortex-python/Cargo.toml
+            --out dist
+            --interpreter python3.11
+        env:
+          MATURIN_PEP517_USE_BASE_PYTHON: "true"
+          # Keep this constant to avoid pyo3 invalidating itself
+          PYO3_ENVIRONMENT_SIGNATURE: "cpython3"
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: "wheels-${{ matrix.target.target }}.zip"
+          path: dist/
+          retention-days: 7
+
+  prepare-java-macos:
+    runs-on: "macos-latest"
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "corretto"
+          java-version: "17"
+      - uses: ./.github/actions/setup-rust
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - run: cargo build --release --package vortex-jni
+      - uses: actions/upload-artifact@v4
+        with:
+          name: "libvortex_jni_aarch64-apple-darwin.zip"
+          path: "target/release/libvortex_jni.dylib"
+          retention-days: 7
+          if-no-files-found: error
+
+  prepare-java-linux:
+    runs-on: ${{ matrix.target.runs-on }}
+    container:
+      image: "ubuntu:20.04"
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - { os: ubuntu, runs-on: "ubuntu-24.04-arm", target: aarch64-unknown-linux-gnu }
+          - { os: ubuntu, runs-on: "ubuntu-24.04", target: x86_64-unknown-linux-gnu }
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - run: |
+          apt update
+          apt install -y wget curl build-essential
+      - name: Print GLIBC version
+        run: ldd --version
+      - name: Verify GLIBC version
+        run: |
+          set -eux
+
+          ldd --version | grep 'GLIBC 2.31'
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "corretto"
+          java-version: "17"
+      - uses: ./.github/actions/setup-rust
+        with:
+          targets: ${{ matrix.target.target }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - run: cargo build --release --package vortex-jni
+      - uses: actions/upload-artifact@v4
+        with:
+          name: "libvortex_jni_${{ matrix.target.target }}.zip"
+          path: "target/release/libvortex_jni.so"
+          retention-days: 7
+          if-no-files-found: error
+
+  prepare-all:
+    needs: [prepare-python, prepare-java-macos, prepare-java-linux]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All packages built successfully"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,140 +8,16 @@ on:
     types: [published]
 
 jobs:
-  prepare-python:
-    runs-on: ${{ matrix.target.runs-on }}
-    timeout-minutes: 120
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - { os: macos, runs-on: "macos-latest", target: aarch64-apple-darwin }
-          - { os: macos, runs-on: "macos-13", target: x86_64-apple-darwin }
-          - { os: ubuntu, runs-on: "ubuntu-latest", target: aarch64-unknown-linux-gnu }
-          - { os: ubuntu, runs-on: "ubuntu-latest", target: x86_64-unknown-linux-gnu }
-    environment:
-      name: pypi
-      url: https://pypi.org/p/vortex-data
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/actions/setup-rust
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          targets: ${{ matrix.target.target }}
-
-      - name: Cargo Set Version
-        run: |
-          cargo install cargo-edit
-          cargo set-version --workspace ${{ github.event.release.tag_name || github.event.inputs.version }}
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        # Latest macOS doesn't allow maturin to install stuff into the global Python interpreter
-        if: "${{ matrix.target.runs-on == 'macos-latest' }}"
-        with:
-          python-version: "3.11"
-
-      - name: Build wheel
-        uses: PyO3/maturin-action@v1
-        with:
-          command: build
-          target: ${{ matrix.target.target }}
-          args: >
-            ${{ (matrix.target.os == 'ubuntu' && '--zig') || '' }}
-            --compatibility manylinux2014
-            --release
-            --manifest-path vortex-python/Cargo.toml
-            --out dist
-            --interpreter python3.11
-        env:
-          MATURIN_PEP517_USE_BASE_PYTHON: "true"
-          # Keep this constant to avoid pyo3 invalidating itself
-          PYO3_ENVIRONMENT_SIGNATURE: "cpython3"
-
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: "wheels-${{ matrix.target.target }}.zip"
-          path: dist/
-
-  prepare-java-macos:
-    runs-on: "macos-latest"
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-java@v5
-        with:
-          distribution: "corretto"
-          java-version: "17"
-      - uses: ./.github/actions/setup-rust
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: cargo build --release --package vortex-jni
-      - uses: actions/upload-artifact@v4
-        with:
-          name: "libvortex_jni_aarch64-apple-darwin.zip"
-          path: "target/release/libvortex_jni.dylib"
-          retention-days: 1
-          if-no-files-found: error
-
-  prepare-java-linux:
-    runs-on: ${{ matrix.target.runs-on }}
-    container:
-      image: "ubuntu:20.04"
-    timeout-minutes: 120
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - { os: ubuntu, runs-on: "ubuntu-24.04-arm", target: aarch64-unknown-linux-gnu }
-          - { os: ubuntu, runs-on: "ubuntu-24.04", target: x86_64-unknown-linux-gnu }
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - run: |
-          apt update
-          apt install -y wget curl build-essential
-      - name: Print GLIBC version
-        run: ldd --version
-      - name: Verify GLIBC version
-        run: |
-          set -eux
-
-          ldd --version | grep 'GLIBC 2.31'
-      - uses: actions/setup-java@v5
-        with:
-          distribution: "corretto"
-          java-version: "17"
-      - uses: ./.github/actions/setup-rust
-        with:
-          targets: ${{ matrix.target.target }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: cargo build --release --package vortex-jni
-      - uses: actions/upload-artifact@v4
-        with:
-          name: "libvortex_jni_${{ matrix.target.target }}.zip"
-          path: "target/release/libvortex_jni.so"
-          retention-days: 1
-          if-no-files-found: error
-
-  prepare-all:
-    needs: [prepare-python, prepare-java-macos, prepare-java-linux]
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo built  # GitHub requires at least one step.
+  package:
+    uses: ./.github/workflows/package.yml
+    with:
+      version: ${{ github.event.release.tag_name }}
+    secrets: inherit
 
   publish-rust:
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    needs: [prepare-all]
+    needs: [package]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -154,7 +30,7 @@ jobs:
       - name: Cargo Set Version
         run: |
           cargo install cargo-edit
-          cargo set-version --workspace ${{ github.event.release.tag_name || github.event.inputs.version }}
+          cargo set-version --workspace ${{ github.event.release.tag_name }}
 
       - name: Release
         run: |
@@ -171,7 +47,7 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   publish-python:
-    needs: [prepare-all]
+    needs: [package]
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -197,12 +73,12 @@ jobs:
           skip-existing: true  # Idempotent releases
 
   publish-java:
-    needs: [prepare-all]
+    needs: [package]
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
       # Picked up by gradle-git-version
-      GIT_VERSION: ${{ github.event.release.tag_name || github.event.inputs.version }}
+      GIT_VERSION: ${{ github.event.release.tag_name }}
     defaults:
       run:
         working-directory: ./java


### PR DESCRIPTION
Split the build publish into two workflows to make it easier to test each in isolation.