### PR TITLE
chore: avoid copy when building chunk_offsets in chunked layout reader

### DIFF
--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -38,12 +38,11 @@ impl ChunkedReader {
     ) -> Self {
         let nchildren = layout.nchildren();
 
-        let mut chunk_offsets = vec![0; nchildren];
+        let mut chunk_offsets = vec![0; nchildren + 1];
         for i in 1..nchildren {
             chunk_offsets[i] = chunk_offsets[i - 1] + layout.children.child_row_count(i - 1);
         }
-        chunk_offsets.push(layout.row_count());
-        debug_assert_eq!(chunk_offsets.len(), nchildren + 1);
+        chunk_offsets[nchildren] = layout.row_count();
 
         let lazy_children = LazyReaderChildren::new(layout.children.clone(), segment_source);
 


### PR DESCRIPTION
Signed-off-by: Robert Kruszewski <github@robertk.io>
