### PR TITLE
FIx java bindings packaging

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -110,7 +110,7 @@ jobs:
           fetch-depth: 0
       - run: |
           apt update
-          apt install -y wget curl build-essential
+          apt install -y wget curl build-essential unzip
       - name: Print GLIBC version
         run: ldd --version
       - name: Verify GLIBC version


### PR DESCRIPTION
Seems to work [here](https://github.com/vortex-data/vortex/actions/runs/18659973729/job/53197925411). My general thinking is that `setup-protoc` runs on the provided `container` config that's required only for the JNI build. That image lacks unzip, so we just install it.