### PR TITLE
pickling support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9248,7 +9248,6 @@ dependencies = [
  "tokio",
  "url",
  "vortex",
- "vortex-ipc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6292,6 +6292,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3-bytes"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f01f356a8686c821ce6ec5ac74a442ffbda3ce1fb26a113d4120fd78faf9f726"
+dependencies = [
+ "bytes",
+ "pyo3",
+]
+
+[[package]]
 name = "pyo3-ffi"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9227,15 +9237,18 @@ dependencies = [
  "arrow-array",
  "arrow-data",
  "arrow-schema",
+ "bytes",
  "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
  "pyo3",
+ "pyo3-bytes",
  "pyo3-log",
  "tokio",
  "url",
  "vortex",
+ "vortex-ipc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,6 +163,7 @@ prost = "0.14"
 prost-build = "0.14"
 prost-types = "0.14"
 pyo3 = { version = "0.26.0" }
+pyo3-bytes = "0.4"
 pyo3-log = "0.13.0"
 rand = "0.9.0"
 rand_distr = "0.5"

--- a/vortex-python/Cargo.toml
+++ b/vortex-python/Cargo.toml
@@ -25,12 +25,15 @@ crate-type = ["rlib", "cdylib"]
 arrow-array = { workspace = true }
 arrow-data = { workspace = true }
 arrow-schema = { workspace = true }
+bytes = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 object_store = { workspace = true, features = ["aws", "gcp", "azure", "http"] }
 parking_lot = { workspace = true }
 pyo3 = { workspace = true, features = ["abi3", "abi3-py311"] }
+pyo3-bytes = { workspace = true }
 pyo3-log = { workspace = true }
 tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
 url = { workspace = true }
 vortex = { workspace = true, features = ["object_store", "python", "tokio"] }
+vortex-ipc = { workspace = true }

--- a/vortex-python/Cargo.toml
+++ b/vortex-python/Cargo.toml
@@ -36,4 +36,3 @@ pyo3-log = { workspace = true }
 tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
 url = { workspace = true }
 vortex = { workspace = true, features = ["object_store", "python", "tokio"] }
-vortex-ipc = { workspace = true }

--- a/vortex-python/benchmark/conftest.py
+++ b/vortex-python/benchmark/conftest.py
@@ -4,6 +4,7 @@
 import hashlib
 import math
 import os
+from typing import cast
 
 import pyarrow as pa
 import pytest
@@ -34,3 +35,9 @@ def vxf(tmpdir_factory: pytest.TempPathFactory, request: pytest.FixtureRequest) 
         a = vx.array(pa.table(columns))  # pyright: ignore[reportCallIssue, reportUnknownArgumentType, reportArgumentType]
         vx.io.write(a, str(fname))
     return vx.open(str(fname))
+
+
+@pytest.fixture(scope="session", params=[10_000, 2_000_000], ids=["small", "large"])
+def array_fixture(request: pytest.FixtureRequest) -> vx.Array:
+    size = cast(int, request.param)
+    return vx.array(pa.table({"x": list(range(size))}))

--- a/vortex-python/benchmark/test_serialization.py
+++ b/vortex-python/benchmark/test_serialization.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+import pickle
+
+import pytest
+from pytest_benchmark.fixture import BenchmarkFixture  # pyright: ignore[reportMissingTypeStubs]
+
+import vortex as vx
+
+
+@pytest.mark.parametrize("protocol", [4, 5], ids=lambda p: f"p{p}")  # pyright: ignore[reportAny]
+@pytest.mark.parametrize("operation", ["dumps", "loads", "roundtrip"])
+@pytest.mark.benchmark(disable_gc=True)
+def test_pickle(
+    benchmark: BenchmarkFixture,
+    array_fixture: vx.Array,
+    protocol: int,
+    operation: str,
+):
+    benchmark.group = f"pickle_p{protocol}"
+
+    if operation == "dumps":
+        benchmark(lambda: pickle.dumps(array_fixture, protocol=protocol))
+    elif operation == "loads":
+        pickled_data = pickle.dumps(array_fixture, protocol=protocol)
+        benchmark(lambda: pickle.loads(pickled_data))  # pyright: ignore[reportAny]
+    elif operation == "roundtrip":
+        benchmark(lambda: pickle.loads(pickle.dumps(array_fixture, protocol=protocol)))  # pyright: ignore[reportAny]

--- a/vortex-python/python/vortex/__init__.py
+++ b/vortex-python/python/vortex/__init__.py
@@ -74,7 +74,6 @@ from .arrays import (
     Array,
     PyArray,
     _unpickle_array,  # pyright: ignore[reportPrivateUsage]
-    _unpickle_array_p5,  # pyright: ignore[reportPrivateUsage]
     array,
 )
 from .file import VortexFile, open
@@ -163,7 +162,6 @@ __all__ = [
     "ArrayParts",
     # Pickle
     "_unpickle_array",
-    "_unpickle_array_p5",
     # File
     "VortexFile",
     "open",

--- a/vortex-python/python/vortex/__init__.py
+++ b/vortex-python/python/vortex/__init__.py
@@ -70,7 +70,13 @@ from ._lib.scalar import (  # pyright: ignore[reportMissingModuleSource]
     scalar,
 )
 from ._lib.serde import ArrayContext, ArrayParts  # pyright: ignore[reportMissingModuleSource]
-from .arrays import Array, PyArray, array
+from .arrays import (
+    Array,
+    PyArray,
+    _unpickle_array,  # pyright: ignore[reportPrivateUsage]
+    _unpickle_array_p5,  # pyright: ignore[reportPrivateUsage]
+    array,
+)
 from .file import VortexFile, open
 from .scan import RepeatedScan
 
@@ -155,6 +161,9 @@ __all__ = [
     # Serde
     "ArrayContext",
     "ArrayParts",
+    # Pickle
+    "_unpickle_array",
+    "_unpickle_array_p5",
     # File
     "VortexFile",
     "open",

--- a/vortex-python/python/vortex/_lib/serde.pyi
+++ b/vortex-python/python/vortex/_lib/serde.pyi
@@ -1,6 +1,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #  SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+from collections.abc import Sequence
 from typing import final
 
 import pyarrow as pa
@@ -30,5 +31,5 @@ class ArrayContext:
 
 def decode_ipc_array(array_bytes: bytes, dtype_bytes: bytes) -> Array: ...
 def decode_ipc_array_buffers(
-    array_buffers: list[bytes | memoryview], dtype_buffers: list[bytes | memoryview]
+    array_buffers: Sequence[bytes | memoryview], dtype_buffers: Sequence[bytes | memoryview]
 ) -> Array: ...

--- a/vortex-python/python/vortex/_lib/serde.pyi
+++ b/vortex-python/python/vortex/_lib/serde.pyi
@@ -5,6 +5,7 @@ from typing import final
 
 import pyarrow as pa
 
+from .arrays import Array
 from .dtype import DType
 
 @final
@@ -26,3 +27,8 @@ class ArrayParts:
 @final
 class ArrayContext:
     def __len__(self) -> int: ...
+
+def decode_ipc_array(array_bytes: bytes, dtype_bytes: bytes) -> Array: ...
+def decode_ipc_array_buffers(
+    array_buffers: list[bytes | memoryview], dtype_buffers: list[bytes | memoryview]
+) -> Array: ...

--- a/vortex-python/python/vortex/arrays.py
+++ b/vortex-python/python/vortex/arrays.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import abc
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any
 
 import pyarrow
@@ -14,7 +14,6 @@ from vortex._lib.dtype import DType  # pyright: ignore[reportMissingModuleSource
 from vortex._lib.serde import (  # pyright: ignore[reportMissingModuleSource]
     ArrayContext,
     ArrayParts,
-    decode_ipc_array,
     decode_ipc_array_buffers,
 )
 
@@ -473,19 +472,13 @@ class PyArray(Array, metaclass=abc.ABCMeta):
         """
 
 
-def _unpickle_array(array_bytes: bytes, dtype_bytes: bytes) -> Array:  # pyright: ignore[reportUnusedFunction]
-    """Unpickle a Vortex array from IPC-encoded bytes.
+def _unpickle_array(array_buffers: Sequence[bytes | memoryview], dtype_buffers: Sequence[bytes | memoryview]) -> Array:  # pyright: ignore[reportUnusedFunction]
+    """Unpickle a Vortex array from IPC-encoded buffer lists.
 
-    This is an internal function used by the pickle module.
-    """
-    return decode_ipc_array(array_bytes, dtype_bytes)
+    This is an internal function used by the pickle module for both protocol 4 and 5.
 
-
-def _unpickle_array_p5(array_buffers: list[bytes | memoryview], dtype_buffers: list[bytes | memoryview]) -> Array:  # pyright: ignore[reportUnusedFunction]
-    """Unpickle a Vortex array from out-of-band PickleBuffers.
-
-    This is an internal function used by the pickle module. When
-    pickle protocol 5 is supported, this methods will be called on unpickle,
-    saving one extra copy operation for array buffers.
+    For protocol 4, receives list[bytes] from __reduce__.
+    For protocol 5, receives list[PickleBuffer/memoryview] from __reduce_ex__.
+    Both use decode_ipc_array_buffers which concatenates the buffers during deserialization.
     """
     return decode_ipc_array_buffers(array_buffers, dtype_buffers)

--- a/vortex-python/python/vortex/arrays.py
+++ b/vortex-python/python/vortex/arrays.py
@@ -11,7 +11,12 @@ from typing_extensions import override
 
 import vortex._lib.arrays as _arrays  # pyright: ignore[reportMissingModuleSource]
 from vortex._lib.dtype import DType  # pyright: ignore[reportMissingModuleSource]
-from vortex._lib.serde import ArrayContext, ArrayParts  # pyright: ignore[reportMissingModuleSource]
+from vortex._lib.serde import (  # pyright: ignore[reportMissingModuleSource]
+    ArrayContext,
+    ArrayParts,
+    decode_ipc_array,
+    decode_ipc_array_buffers,
+)
 
 try:
     import pandas
@@ -466,3 +471,21 @@ class PyArray(Array, metaclass=abc.ABCMeta):
         current array. Implementations of this function should validate this information, and then construct
         a new array.
         """
+
+
+def _unpickle_array(array_bytes: bytes, dtype_bytes: bytes) -> Array:  # pyright: ignore[reportUnusedFunction]
+    """Unpickle a Vortex array from IPC-encoded bytes.
+
+    This is an internal function used by the pickle module.
+    """
+    return decode_ipc_array(array_bytes, dtype_bytes)
+
+
+def _unpickle_array_p5(array_buffers: list[bytes | memoryview], dtype_buffers: list[bytes | memoryview]) -> Array:  # pyright: ignore[reportUnusedFunction]
+    """Unpickle a Vortex array from out-of-band PickleBuffers.
+
+    This is an internal function used by the pickle module. When
+    pickle protocol 5 is supported, this methods will be called on unpickle,
+    saving one extra copy operation for array buffers.
+    """
+    return decode_ipc_array_buffers(array_buffers, dtype_buffers)

--- a/vortex-python/src/arrays/mod.rs
+++ b/vortex-python/src/arrays/mod.rs
@@ -20,8 +20,8 @@ use vortex::arrow::IntoArrowArray;
 use vortex::compute::{Operator, compare, take};
 use vortex::dtype::{DType, Nullability, PType, match_each_integer_ptype};
 use vortex::error::VortexError;
+use vortex::ipc::messages::{EncoderMessage, MessageEncoder};
 use vortex::{Array, ArrayRef, ToCanonical};
-use vortex_ipc::messages::{EncoderMessage, MessageEncoder};
 
 use crate::arrays::native::PyNativeArray;
 use crate::arrays::py::{PyPythonArray, PythonArray};

--- a/vortex-python/src/arrays/mod.rs
+++ b/vortex-python/src/arrays/mod.rs
@@ -670,29 +670,23 @@ impl PyArray {
         let mut encoder = MessageEncoder::default();
         let buffers = encoder.encode(EncoderMessage::Array(&*array));
 
-        // concat all buffers
-        let mut serialized = Vec::new();
-        for buf in buffers.iter() {
-            serialized.extend_from_slice(buf);
-        }
+        // Return buffers as a list instead of concatenating
+        let array_buffers: Vec<Vec<u8>> = buffers.iter().map(|b| b.to_vec()).collect();
 
         let dtype_buffers = encoder.encode(EncoderMessage::DType(array.dtype()));
-        let mut dtype_bytes = Vec::new();
-        for buf in dtype_buffers.iter() {
-            dtype_bytes.extend_from_slice(buf);
-        }
+        let dtype_buffers: Vec<Vec<u8>> = dtype_buffers.iter().map(|b| b.to_vec()).collect();
 
         let vortex_module = PyModule::import(py, "vortex")?;
         let unpickle_fn = vortex_module.getattr("_unpickle_array")?;
 
-        let args = (serialized, dtype_bytes).into_pyobject(py)?;
+        let args = (array_buffers, dtype_buffers).into_pyobject(py)?;
         Ok((unpickle_fn, args.into_any()))
     }
 
-    /// Support for Python's pickle protocol with protocol version awareness.
+    /// Support for Python's pickle protocol for protocol >= 5
     ///
-    /// When protocol >= 5, this uses PickleBuffer for out-of-band buffer transfer,
-    /// which avoids copying large data buffers.
+    /// uses PickleBuffer for out-of-band buffer transfer,
+    /// which potentially avoids copying large data buffers.
     fn __reduce_ex__<'py>(
         slf: &'py Bound<'py, Self>,
         protocol: i32,
@@ -729,7 +723,7 @@ impl PyArray {
         }
 
         let vortex_module = PyModule::import(py, "vortex")?;
-        let unpickle_fn = vortex_module.getattr("_unpickle_array_p5")?;
+        let unpickle_fn = vortex_module.getattr("_unpickle_array")?;
 
         let args = (pickle_buffers, dtype_pickle_buffers).into_pyobject(py)?;
         Ok((unpickle_fn, args.into_any()))

--- a/vortex-python/src/arrays/mod.rs
+++ b/vortex-python/src/arrays/mod.rs
@@ -10,15 +10,18 @@ pub(crate) mod py;
 mod range_to_sequence;
 
 use arrow_array::{Array as ArrowArray, ArrayRef as ArrowArrayRef};
+use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyRange, PyRangeMethods};
+use pyo3_bytes::PyBytes;
 use vortex::arrays::ChunkedVTable;
 use vortex::arrow::IntoArrowArray;
 use vortex::compute::{Operator, compare, take};
 use vortex::dtype::{DType, Nullability, PType, match_each_integer_ptype};
 use vortex::error::VortexError;
 use vortex::{Array, ArrayRef, ToCanonical};
+use vortex_ipc::messages::{EncoderMessage, MessageEncoder};
 
 use crate::arrays::native::PyNativeArray;
 use crate::arrays::py::{PyPythonArray, PythonArray};
@@ -652,5 +655,83 @@ impl PyArray {
             .into_iter()
             .map(|buffer| buffer.to_vec())
             .collect())
+    }
+
+    /// Support for Python's pickle protocol.
+    ///
+    /// This method serializes the array using Vortex IPC format and returns
+    /// the data needed for pickle to reconstruct the array.
+    fn __reduce__<'py>(
+        slf: &'py Bound<'py, Self>,
+    ) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
+        let py = slf.py();
+        let array = PyArrayRef::extract_bound(slf.as_any())?.into_inner();
+
+        let mut encoder = MessageEncoder::default();
+        let buffers = encoder.encode(EncoderMessage::Array(&*array));
+
+        // concat all buffers
+        let mut serialized = Vec::new();
+        for buf in buffers.iter() {
+            serialized.extend_from_slice(buf);
+        }
+
+        let dtype_buffers = encoder.encode(EncoderMessage::DType(array.dtype()));
+        let mut dtype_bytes = Vec::new();
+        for buf in dtype_buffers.iter() {
+            dtype_bytes.extend_from_slice(buf);
+        }
+
+        let vortex_module = PyModule::import(py, "vortex")?;
+        let unpickle_fn = vortex_module.getattr("_unpickle_array")?;
+
+        let args = (serialized, dtype_bytes).into_pyobject(py)?;
+        Ok((unpickle_fn, args.into_any()))
+    }
+
+    /// Support for Python's pickle protocol with protocol version awareness.
+    ///
+    /// When protocol >= 5, this uses PickleBuffer for out-of-band buffer transfer,
+    /// which avoids copying large data buffers.
+    fn __reduce_ex__<'py>(
+        slf: &'py Bound<'py, Self>,
+        protocol: i32,
+    ) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
+        let py = slf.py();
+
+        if protocol < 5 {
+            return Self::__reduce__(slf);
+        }
+
+        let array = PyArrayRef::extract_bound(slf.as_any())?.into_inner();
+
+        let mut encoder = MessageEncoder::default();
+        let array_buffers = encoder.encode(EncoderMessage::Array(&*array));
+        let dtype_buffers = encoder.encode(EncoderMessage::DType(array.dtype()));
+
+        let pickle_module = PyModule::import(py, "pickle")?;
+        let pickle_buffer_class = pickle_module.getattr("PickleBuffer")?;
+
+        let mut pickle_buffers = Vec::new();
+        for buf in array_buffers.into_iter() {
+            // PyBytes wraps bytes::Bytes and implements the buffer protocol
+            // This allows PickleBuffer to reference the data without copying
+            let py_bytes = PyBytes::new(buf).into_py_any(py)?;
+            let pickle_buffer = pickle_buffer_class.call1((py_bytes,))?;
+            pickle_buffers.push(pickle_buffer);
+        }
+
+        let mut dtype_pickle_buffers = Vec::new();
+        for buf in dtype_buffers.into_iter() {
+            let py_bytes = PyBytes::new(buf).into_py_any(py)?;
+            let pickle_buffer = pickle_buffer_class.call1((py_bytes,))?;
+            dtype_pickle_buffers.push(pickle_buffer);
+        }
+
+        let vortex_module = PyModule::import(py, "vortex")?;
+        let unpickle_fn = vortex_module.getattr("_unpickle_array_p5")?;
+
+        let args = (pickle_buffers, dtype_pickle_buffers).into_pyobject(py)?;
+        Ok((unpickle_fn, args.into_any()))
     }
 }

--- a/vortex-python/src/serde/mod.rs
+++ b/vortex-python/src/serde/mod.rs
@@ -8,11 +8,12 @@ use bytes::Bytes;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::{Bound, Python};
-use vortex::ArrayRegistry;
+use vortex::ArraySessionExt;
 use vortex_ipc::messages::{DecoderMessage, MessageDecoder, PollRead};
 
 use crate::arrays::PyArrayRef;
 use crate::install_module;
+use crate::SESSION;
 use crate::serde::context::PyArrayContext;
 use crate::serde::parts::PyArrayParts;
 
@@ -48,7 +49,7 @@ pub(crate) fn init(py: Python, parent: &Bound<PyModule>) -> PyResult<()> {
 ///     The decoded Vortex array
 #[pyfunction]
 fn decode_ipc_array(array_bytes: Vec<u8>, dtype_bytes: Vec<u8>) -> PyResult<PyArrayRef> {
-    let registry = ArrayRegistry::canonical_only();
+    let registry = SESSION.arrays().registry().clone();
     let mut decoder = MessageDecoder::new(registry);
 
     let mut dtype_buf = Bytes::from(dtype_bytes);
@@ -102,7 +103,7 @@ fn decode_ipc_array_buffers<'py>(
 ) -> PyResult<PyArrayRef> {
     use pyo3::buffer::PyBuffer;
 
-    let registry = ArrayRegistry::canonical_only();
+    let registry = SESSION.arrays().registry().clone();
     let mut decoder = MessageDecoder::new(registry);
 
     // Concatenate dtype buffers

--- a/vortex-python/src/serde/mod.rs
+++ b/vortex-python/src/serde/mod.rs
@@ -9,7 +9,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::{Bound, Python};
 use vortex::ArraySessionExt;
-use vortex_ipc::messages::{DecoderMessage, MessageDecoder, PollRead};
+use vortex::ipc::messages::{DecoderMessage, MessageDecoder, PollRead};
 
 use crate::arrays::PyArrayRef;
 use crate::serde::context::PyArrayContext;

--- a/vortex-python/src/serde/mod.rs
+++ b/vortex-python/src/serde/mod.rs
@@ -4,9 +4,14 @@
 pub(crate) mod context;
 pub(crate) mod parts;
 
+use bytes::Bytes;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::{Bound, Python};
+use vortex::ArrayRegistry;
+use vortex_ipc::messages::{DecoderMessage, MessageDecoder, PollRead};
 
+use crate::arrays::PyArrayRef;
 use crate::install_module;
 use crate::serde::context::PyArrayContext;
 use crate::serde::parts::PyArrayParts;
@@ -19,6 +24,137 @@ pub(crate) fn init(py: Python, parent: &Bound<PyModule>) -> PyResult<()> {
 
     m.add_class::<PyArrayParts>()?;
     m.add_class::<PyArrayContext>()?;
+    m.add_function(wrap_pyfunction!(decode_ipc_array, &m)?)?;
+    m.add_function(wrap_pyfunction!(decode_ipc_array_buffers, &m)?)?;
 
     Ok(())
+}
+
+/// Decode a Vortex array from IPC-encoded bytes.
+///
+/// This function decodes both the dtype and array messages from IPC format
+/// and returns the reconstructed array.
+///
+/// Parameters
+/// ----------
+/// array_bytes : bytes
+///     The IPC-encoded array message
+/// dtype_bytes : bytes
+///     The IPC-encoded dtype message
+///
+/// Returns
+/// -------
+/// Array
+///     The decoded Vortex array
+#[pyfunction]
+fn decode_ipc_array(array_bytes: Vec<u8>, dtype_bytes: Vec<u8>) -> PyResult<PyArrayRef> {
+    let registry = ArrayRegistry::canonical_only();
+    let mut decoder = MessageDecoder::new(registry);
+
+    let mut dtype_buf = Bytes::from(dtype_bytes);
+    let dtype = match decoder.read_next(&mut dtype_buf)? {
+        PollRead::Some(DecoderMessage::DType(dtype)) => dtype,
+        PollRead::Some(_) => {
+            return Err(PyValueError::new_err("Expected DType message"));
+        }
+        PollRead::NeedMore(_) => {
+            return Err(PyValueError::new_err("Incomplete DType message"));
+        }
+    };
+
+    let mut array_buf = Bytes::from(array_bytes);
+    let array = match decoder.read_next(&mut array_buf)? {
+        PollRead::Some(DecoderMessage::Array((parts, ctx, row_count))) => {
+            parts.decode(&ctx, &dtype, row_count)?
+        }
+        PollRead::Some(_) => {
+            return Err(PyValueError::new_err("Expected Array message"));
+        }
+        PollRead::NeedMore(_) => {
+            return Err(PyValueError::new_err("Incomplete Array message"));
+        }
+    };
+
+    Ok(PyArrayRef::from(array))
+}
+
+/// Decode a Vortex array from IPC-encoded buffer protocol objects
+///
+/// This function accepts lists of buffer protocol objects (memoryviews) and decodes
+/// them without copying by using PyO3's buffer protocol support.
+///
+/// Parameters
+/// ----------
+/// array_buffers : list of buffer protocol objects
+///     List of IPC-encoded array message buffers
+/// dtype_buffers : list of buffer protocol objects
+///     List of IPC-encoded dtype message buffers
+///
+/// Returns
+/// -------
+/// Array
+///     The decoded Vortex array
+#[pyfunction]
+fn decode_ipc_array_buffers<'py>(
+    py: Python<'py>,
+    array_buffers: Vec<Bound<'py, PyAny>>,
+    dtype_buffers: Vec<Bound<'py, PyAny>>,
+) -> PyResult<PyArrayRef> {
+    use pyo3::buffer::PyBuffer;
+
+    let registry = ArrayRegistry::canonical_only();
+    let mut decoder = MessageDecoder::new(registry);
+
+    // Concatenate dtype buffers
+    // Note: PyBuffer returns &[ReadOnlyCell<u8>] which requires copying to get &[u8]
+    let mut dtype_bytes_vec = Vec::new();
+    for buf_obj in dtype_buffers {
+        let buffer = PyBuffer::<u8>::get(&buf_obj)?;
+        let slice = buffer
+            .as_slice(py)
+            .ok_or_else(|| PyValueError::new_err("Buffer is not contiguous"))?;
+        for cell in slice {
+            dtype_bytes_vec.push(cell.get());
+        }
+    }
+    let mut dtype_buf = Bytes::from(dtype_bytes_vec);
+
+    // Decode dtype
+    let dtype = match decoder.read_next(&mut dtype_buf)? {
+        PollRead::Some(DecoderMessage::DType(dtype)) => dtype,
+        PollRead::Some(_) => {
+            return Err(PyValueError::new_err("Expected DType message"));
+        }
+        PollRead::NeedMore(_) => {
+            return Err(PyValueError::new_err("Incomplete DType message"));
+        }
+    };
+
+    // Concatenate array buffers
+    let mut array_bytes_vec = Vec::new();
+    for buf_obj in array_buffers {
+        let buffer = PyBuffer::<u8>::get(&buf_obj)?;
+        let slice = buffer
+            .as_slice(py)
+            .ok_or_else(|| PyValueError::new_err("Buffer is not contiguous"))?;
+        for cell in slice {
+            array_bytes_vec.push(cell.get());
+        }
+    }
+    let mut array_buf = Bytes::from(array_bytes_vec);
+
+    // Decode array
+    let array = match decoder.read_next(&mut array_buf)? {
+        PollRead::Some(DecoderMessage::Array((parts, ctx, row_count))) => {
+            parts.decode(&ctx, &dtype, row_count)?
+        }
+        PollRead::Some(_) => {
+            return Err(PyValueError::new_err("Expected Array message"));
+        }
+        PollRead::NeedMore(_) => {
+            return Err(PyValueError::new_err("Incomplete Array message"));
+        }
+    };
+
+    Ok(PyArrayRef::from(array))
 }

--- a/vortex-python/src/serde/mod.rs
+++ b/vortex-python/src/serde/mod.rs
@@ -12,10 +12,9 @@ use vortex::ArraySessionExt;
 use vortex_ipc::messages::{DecoderMessage, MessageDecoder, PollRead};
 
 use crate::arrays::PyArrayRef;
-use crate::install_module;
-use crate::SESSION;
 use crate::serde::context::PyArrayContext;
 use crate::serde::parts::PyArrayParts;
+use crate::{SESSION, install_module};
 
 /// Register serde functions and classes.
 pub(crate) fn init(py: Python, parent: &Bound<PyModule>) -> PyResult<()> {

--- a/vortex-python/test/test_pickle.py
+++ b/vortex-python/test/test_pickle.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+import pickle
+
+import pyarrow as pa
+
+import vortex as vx
+
+
+def test_pickle_simple_array():
+    arr = vx.array([1, 2, 3, 4, 5])
+    pickled = pickle.dumps(arr)
+    restored: vx.Array = pickle.loads(pickled)  # pyright: ignore[reportAny]
+
+    assert restored.to_arrow_array() == arr.to_arrow_array()
+
+
+def test_pickle_array_with_nulls():
+    arr = vx.array([1, None, 3, None, 5])
+    pickled = pickle.dumps(arr)
+    restored: vx.Array = pickle.loads(pickled)  # pyright: ignore[reportAny]
+
+    assert restored.to_arrow_array() == arr.to_arrow_array()
+
+
+def test_pickle_string_array():
+    arr = vx.array(["hello", "world", "foo", "bar"])
+    pickled = pickle.dumps(arr)
+    restored: vx.Array = pickle.loads(pickled)  # pyright: ignore[reportAny]
+
+    assert restored.to_arrow_array() == arr.to_arrow_array()
+
+
+def test_pickle_struct_array():
+    arr = vx.array(
+        [
+            {"name": "Alice", "age": 30},
+            {"name": "Bob", "age": 25},
+            {"name": "Charlie", "age": 35},
+        ]
+    )
+    pickled = pickle.dumps(arr)
+    restored: vx.Array = pickle.loads(pickled)  # pyright: ignore[reportAny]
+
+    assert restored.to_arrow_table() == arr.to_arrow_table()
+
+
+def test_pickle_chunked_array():
+    arr = vx.array(pa.chunked_array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]))
+    pickled = pickle.dumps(arr)
+    restored: vx.Array = pickle.loads(pickled)  # pyright: ignore[reportAny]
+
+    assert restored.to_arrow_array() == arr.to_arrow_array()
+
+
+def test_pickle_large_array():
+    arr = vx.array(list(range(100_000)))
+    pickled = pickle.dumps(arr)
+    restored: vx.Array = pickle.loads(pickled)  # pyright: ignore[reportAny]
+
+    assert restored.to_arrow_array() == arr.to_arrow_array()
+
+
+def test_pickle_empty_array():
+    arr = vx.array(pa.array([], type=pa.int64()))
+    pickled = pickle.dumps(arr)
+    restored: vx.Array = pickle.loads(pickled)  # pyright: ignore[reportAny]
+
+    assert restored.to_arrow_array() == arr.to_arrow_array()
+
+
+def test_pickle_different_protocols():
+    arr = vx.array([1, 2, 3, 4, 5])
+
+    for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
+        pickled = pickle.dumps(arr, protocol=protocol)
+        restored: vx.Array = pickle.loads(pickled)  # pyright: ignore[reportAny]
+        assert restored.to_arrow_array() == arr.to_arrow_array()
+
+
+def test_pickle_preserves_dtype():
+    arr = vx.array([1, 2, 3, 4, 5])
+    original_dtype = arr.dtype
+
+    pickled = pickle.dumps(arr)
+    restored: vx.Array = pickle.loads(pickled)  # pyright: ignore[reportAny]
+
+    assert str(restored.dtype) == str(original_dtype)
+
+
+def test_pickle_float_array():
+    arr = vx.array([1.5, 2.7, 3.14, 4.0, 5.5])
+    pickled = pickle.dumps(arr)
+    restored: vx.Array = pickle.loads(pickled)  # pyright: ignore[reportAny]
+
+    assert restored.to_arrow_array() == arr.to_arrow_array()
+
+
+def test_pickle_binary_array():
+    arr = vx.array([b"hello", b"world", b"foo"])
+    pickled = pickle.dumps(arr)
+    restored: vx.Array = pickle.loads(pickled)  # pyright: ignore[reportAny]
+
+    assert restored.to_arrow_array() == arr.to_arrow_array()
+
+
+def test_pickle_protocol_5_simple():
+    arr = vx.array([1, 2, 3, 4, 5])
+    pickled = pickle.dumps(arr, protocol=5)
+    restored: vx.Array = pickle.loads(pickled)  # pyright: ignore[reportAny]
+
+    assert restored.to_arrow_array() == arr.to_arrow_array()
+
+
+def test_pickle_protocol_5_with_nulls():
+    arr = vx.array([1, None, 3, None, 5])
+    pickled = pickle.dumps(arr, protocol=5)
+    restored: vx.Array = pickle.loads(pickled)  # pyright: ignore[reportAny]
+
+    assert restored.to_arrow_array() == arr.to_arrow_array()
+
+
+def test_pickle_protocol_5_large_array():
+    arr = vx.array(list(range(1_000_000)))
+    pickled = pickle.dumps(arr, protocol=5)
+    restored: vx.Array = pickle.loads(pickled)  # pyright: ignore[reportAny]
+
+    assert restored.to_arrow_array() == arr.to_arrow_array()
+
+
+def test_pickle_protocol_5_string_array():
+    arr = vx.array(["hello", "world", "protocol", "five"])
+    pickled = pickle.dumps(arr, protocol=5)
+    restored: vx.Array = pickle.loads(pickled)  # pyright: ignore[reportAny]
+
+    assert restored.to_arrow_array() == arr.to_arrow_array()
+
+
+def test_pickle_protocol_5_struct_array():
+    arr = vx.array(
+        [
+            {"name": "Alice", "age": 30},
+            {"name": "Bob", "age": 25},
+            {"name": "Charlie", "age": 35},
+        ]
+    )
+    pickled = pickle.dumps(arr, protocol=5)
+    restored: vx.Array = pickle.loads(pickled)  # pyright: ignore[reportAny]
+
+    assert restored.to_arrow_table() == arr.to_arrow_table()
+
+
+def test_pickle_protocol_comparison():
+    arr = vx.array(list(range(10_000)))
+
+    pickled_p4 = pickle.dumps(arr, protocol=4)
+    pickled_p5 = pickle.dumps(arr, protocol=5)
+
+    restored_p4: vx.Array = pickle.loads(pickled_p4)  # pyright: ignore[reportAny]
+    restored_p5: vx.Array = pickle.loads(pickled_p5)  # pyright: ignore[reportAny]
+
+    assert restored_p4.to_arrow_array() == arr.to_arrow_array()
+    assert restored_p5.to_arrow_array() == arr.to_arrow_array()
+    assert restored_p4.to_arrow_array() == restored_p5.to_arrow_array()
+
+
+def test_pickle_protocol_5_preserves_dtype():
+    arr = vx.array([1.5, 2.7, 3.14])
+    original_dtype = arr.dtype
+
+    pickled = pickle.dumps(arr, protocol=5)
+    restored: vx.Array = pickle.loads(pickled)  # pyright: ignore[reportAny]
+
+    assert str(restored.dtype) == str(original_dtype)
+
+
+def test_pickle_protocol_5_chunked_array():
+    arr = vx.array(pa.chunked_array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]))
+    pickled = pickle.dumps(arr, protocol=5)
+    restored: vx.Array = pickle.loads(pickled)  # pyright: ignore[reportAny]
+
+    assert restored.to_arrow_array() == arr.to_arrow_array()


### PR DESCRIPTION
Implements `__reduce__` and `__reduce_ex__` methods to enable pickling of Vortex arrays in Python. Arrays are serialized using the Vortex IPC format.
For pickle protocol 5+ (Python 3.8+, PEP 574), uses PickleBuffer to keep array buffers separate from the main pickle stream rather than copying them inline. This enables us to use shared memory in the future to potentially zero-copy large arrays even across process boundaries. Protocol 4 and below serialise buffers inline as bytes.
Both protocols share the same deserialization path via `decode_ipc_array_buffers`, which reconstructs arrays from IPC-encoded buffer lists (or memoryviews).