### PR TITLE
Make array metadata mandatory

### DIFF
--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -13,6 +13,7 @@ use vortex_dtype::{DType, PType};
 use vortex_error::{VortexExpect, VortexResult, vortex_ensure};
 
 use crate::ALPFloat;
+use crate::alp::serde::ALPMetadata;
 use crate::alp::{Exponents, decompress};
 
 vtable!(ALP);
@@ -20,6 +21,7 @@ vtable!(ALP);
 impl VTable for ALPVTable {
     type Array = ALPArray;
     type Encoding = ALPEncoding;
+    type Metadata = vortex_array::ProstMetadata<ALPMetadata>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/encodings/alp/src/alp/serde.rs
+++ b/encodings/alp/src/alp/serde.rs
@@ -3,7 +3,7 @@
 
 use vortex_array::patches::{Patches, PatchesMetadata};
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable::{EncodeVTable, SerdeVTable, VisitorVTable};
+use vortex_array::vtable::{EncodeVTable, SerdeVTable, VTable, VisitorVTable};
 use vortex_array::{
     ArrayBufferVisitor, ArrayChildVisitor, Canonical, DeserializeMetadata, ProstMetadata,
 };
@@ -25,20 +25,6 @@ pub struct ALPMetadata {
 }
 
 impl SerdeVTable<ALPVTable> for ALPVTable {
-    type Metadata = ProstMetadata<ALPMetadata>;
-
-    fn metadata(array: &ALPArray) -> VortexResult<Option<Self::Metadata>> {
-        let exponents = array.exponents();
-        Ok(Some(ProstMetadata(ALPMetadata {
-            exp_e: exponents.e as u32,
-            exp_f: exponents.f as u32,
-            patches: array
-                .patches()
-                .map(|p| p.to_metadata(array.len(), array.dtype()))
-                .transpose()?,
-        })))
-    }
-
     /// Deserialize an ALPArray from its components.
     ///
     /// Note that the layout depends on whether patches and chunk_offsets are present:
@@ -48,7 +34,7 @@ impl SerdeVTable<ALPVTable> for ALPVTable {
         _encoding: &ALPEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &<Self::Metadata as DeserializeMetadata>::Output,
+        metadata: &<<ALPVTable as VTable>::Metadata as DeserializeMetadata>::Output,
         _buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ALPArray> {
@@ -105,6 +91,18 @@ impl EncodeVTable<ALPVTable> for ALPVTable {
 }
 
 impl VisitorVTable<ALPVTable> for ALPVTable {
+    fn metadata(array: &ALPArray) -> <ALPVTable as VTable>::Metadata {
+        let exponents = array.exponents();
+        ProstMetadata(ALPMetadata {
+            exp_e: exponents.e as u32,
+            exp_f: exponents.f as u32,
+            patches: array.patches().map(|p| {
+                p.to_metadata(array.len(), array.dtype())
+                    .expect("Failed to get patches metadata")
+            }),
+        })
+    }
+
     fn visit_buffers(_array: &ALPArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(array: &ALPArray, visitor: &mut dyn ArrayChildVisitor) {

--- a/encodings/alp/src/alp/serde.rs
+++ b/encodings/alp/src/alp/serde.rs
@@ -96,10 +96,7 @@ impl VisitorVTable<ALPVTable> for ALPVTable {
         ProstMetadata(ALPMetadata {
             exp_e: exponents.e as u32,
             exp_f: exponents.f as u32,
-            patches: array.patches().map(|p| {
-                p.to_metadata(array.len(), array.dtype())
-                    .expect("Failed to get patches metadata")
-            }),
+            patches: array.patches().map(|p| p.to_metadata(array.len())),
         })
     }
 

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -16,12 +16,14 @@ use vortex_dtype::{DType, PType};
 use vortex_error::{VortexResult, vortex_bail};
 
 use crate::alp_rd::alp_rd_decode;
+use crate::alp_rd::serde::ALPRDMetadata;
 
 vtable!(ALPRD);
 
 impl VTable for ALPRDVTable {
     type Array = ALPRDArray;
     type Encoding = ALPRDEncoding;
+    type Metadata = vortex_array::ProstMetadata<ALPRDMetadata>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/encodings/alp/src/alp_rd/serde.rs
+++ b/encodings/alp/src/alp_rd/serde.rs
@@ -8,7 +8,7 @@ use vortex_array::vtable::{EncodeVTable, SerdeVTable, VTable, VisitorVTable};
 use vortex_array::{Array, ArrayBufferVisitor, ArrayChildVisitor, Canonical, ProstMetadata};
 use vortex_buffer::{Buffer, ByteBuffer};
 use vortex_dtype::{DType, Nullability, PType};
-use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_bail, vortex_err};
+use vortex_error::{VortexError, VortexResult, vortex_bail, vortex_err};
 
 use super::{ALPRDEncoding, RDEncoder};
 use crate::{ALPRDArray, ALPRDVTable};
@@ -140,12 +140,10 @@ impl VisitorVTable<ALPRDVTable> for ALPRDVTable {
             right_bit_width: array.right_bit_width() as u32,
             dict_len: array.left_parts_dictionary().len() as u32,
             dict,
-            left_parts_ptype: PType::try_from(array.left_parts().dtype())
-                .vortex_expect("Must be a valid PType") as i32,
-            patches: array.left_parts_patches().map(|p| {
-                p.to_metadata(array.len(), array.left_parts().dtype())
-                    .expect("Failed to get patches metadata")
-            }),
+            left_parts_ptype: array.left_parts().dtype().as_ptype() as i32,
+            patches: array
+                .left_parts_patches()
+                .map(|p| p.to_metadata(array.len())),
         })
     }
 

--- a/encodings/alp/src/alp_rd/serde.rs
+++ b/encodings/alp/src/alp_rd/serde.rs
@@ -4,7 +4,7 @@
 use itertools::Itertools;
 use vortex_array::patches::{Patches, PatchesMetadata};
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable::{EncodeVTable, SerdeVTable, VisitorVTable};
+use vortex_array::vtable::{EncodeVTable, SerdeVTable, VTable, VisitorVTable};
 use vortex_array::{Array, ArrayBufferVisitor, ArrayChildVisitor, Canonical, ProstMetadata};
 use vortex_buffer::{Buffer, ByteBuffer};
 use vortex_dtype::{DType, Nullability, PType};
@@ -28,33 +28,11 @@ pub struct ALPRDMetadata {
 }
 
 impl SerdeVTable<ALPRDVTable> for ALPRDVTable {
-    type Metadata = ProstMetadata<ALPRDMetadata>;
-
-    fn metadata(array: &ALPRDArray) -> VortexResult<Option<Self::Metadata>> {
-        let dict = array
-            .left_parts_dictionary()
-            .iter()
-            .map(|&i| i as u32)
-            .collect::<Vec<_>>();
-
-        Ok(Some(ProstMetadata(ALPRDMetadata {
-            right_bit_width: array.right_bit_width() as u32,
-            dict_len: array.left_parts_dictionary().len() as u32,
-            dict,
-            left_parts_ptype: PType::try_from(array.left_parts().dtype())
-                .vortex_expect("Must be a valid PType") as i32,
-            patches: array
-                .left_parts_patches()
-                .map(|p| p.to_metadata(array.len(), array.left_parts().dtype()))
-                .transpose()?,
-        })))
-    }
-
     fn build(
         _encoding: &ALPRDEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &ALPRDMetadata,
+        metadata: &<<ALPRDVTable as VTable>::Metadata as vortex_array::DeserializeMetadata>::Output,
         _buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ALPRDArray> {
@@ -151,6 +129,26 @@ impl EncodeVTable<ALPRDVTable> for ALPRDVTable {
 }
 
 impl VisitorVTable<ALPRDVTable> for ALPRDVTable {
+    fn metadata(array: &ALPRDArray) -> <ALPRDVTable as VTable>::Metadata {
+        let dict = array
+            .left_parts_dictionary()
+            .iter()
+            .map(|&i| i as u32)
+            .collect::<Vec<_>>();
+
+        ProstMetadata(ALPRDMetadata {
+            right_bit_width: array.right_bit_width() as u32,
+            dict_len: array.left_parts_dictionary().len() as u32,
+            dict,
+            left_parts_ptype: PType::try_from(array.left_parts().dtype())
+                .vortex_expect("Must be a valid PType") as i32,
+            patches: array.left_parts_patches().map(|p| {
+                p.to_metadata(array.len(), array.left_parts().dtype())
+                    .expect("Failed to get patches metadata")
+            }),
+        })
+    }
+
     fn visit_buffers(_array: &ALPRDArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(array: &ALPRDArray, visitor: &mut dyn ArrayChildVisitor) {

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -23,6 +23,7 @@ vtable!(ByteBool);
 impl VTable for ByteBoolVTable {
     type Array = ByteBoolArray;
     type Encoding = ByteBoolEncoding;
+    type Metadata = vortex_array::EmptyMetadata;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/encodings/bytebool/src/serde.rs
+++ b/encodings/bytebool/src/serde.rs
@@ -4,7 +4,7 @@
 use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
 use vortex_array::vtable::{SerdeVTable, ValidityHelper, VisitorVTable};
-use vortex_array::{ArrayBufferVisitor, ArrayChildVisitor, DeserializeMetadata, EmptyMetadata};
+use vortex_array::{ArrayBufferVisitor, ArrayChildVisitor, EmptyMetadata};
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_bail};

--- a/encodings/bytebool/src/serde.rs
+++ b/encodings/bytebool/src/serde.rs
@@ -12,17 +12,11 @@ use vortex_error::{VortexResult, vortex_bail};
 use crate::{ByteBoolArray, ByteBoolEncoding, ByteBoolVTable};
 
 impl SerdeVTable<ByteBoolVTable> for ByteBoolVTable {
-    type Metadata = EmptyMetadata;
-
-    fn metadata(_array: &ByteBoolArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(EmptyMetadata))
-    }
-
     fn build(
         _encoding: &ByteBoolEncoding,
         dtype: &DType,
         len: usize,
-        _metadata: &<Self::Metadata as DeserializeMetadata>::Output,
+        _metadata: &<ByteBoolVTable as vortex_array::vtable::VTable>::Metadata,
         buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ByteBoolArray> {
@@ -45,6 +39,10 @@ impl SerdeVTable<ByteBoolVTable> for ByteBoolVTable {
 }
 
 impl VisitorVTable<ByteBoolVTable> for ByteBoolVTable {
+    fn metadata(_array: &ByteBoolArray) -> EmptyMetadata {
+        EmptyMetadata
+    }
+
     fn visit_buffers(array: &ByteBoolArray, visitor: &mut dyn ArrayBufferVisitor) {
         visitor.visit_buffer(array.buffer());
     }

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -7,8 +7,8 @@ use vortex_array::stats::{ArrayStats, StatsSetRef};
 use vortex_array::vtable::{
     ArrayVTable, NotSupported, VTable, ValidityChild, ValidityVTableFromChild,
 };
-use vortex_array::{Array, ArrayRef, EncodingId, EncodingRef, vtable};
-use vortex_dtype::DType;
+use vortex_array::{Array, ArrayRef, EncodingId, EncodingRef, ProstMetadata, vtable};
+use vortex_dtype::{DType, PType};
 use vortex_error::{VortexResult, vortex_bail};
 
 vtable!(DateTimeParts);
@@ -16,6 +16,7 @@ vtable!(DateTimeParts);
 impl VTable for DateTimePartsVTable {
     type Array = DateTimePartsArray;
     type Encoding = DateTimePartsEncoding;
+    type Metadata = ProstMetadata<DateTimePartsMetadata>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;
@@ -47,6 +48,19 @@ pub struct DateTimePartsArray {
 
 #[derive(Clone, Debug)]
 pub struct DateTimePartsEncoding;
+
+#[derive(Clone, prost::Message)]
+#[repr(C)]
+pub struct DateTimePartsMetadata {
+    // Validity lives in the days array
+    // TODO(ngates): we should actually model this with a Tuple array when we have one.
+    #[prost(enumeration = "PType", tag = "1")]
+    pub days_ptype: i32,
+    #[prost(enumeration = "PType", tag = "2")]
+    pub seconds_ptype: i32,
+    #[prost(enumeration = "PType", tag = "3")]
+    pub subseconds_ptype: i32,
+}
 
 impl DateTimePartsArray {
     pub fn try_new(

--- a/encodings/datetime-parts/src/serde.rs
+++ b/encodings/datetime-parts/src/serde.rs
@@ -3,45 +3,24 @@
 
 use vortex_array::arrays::TemporalArray;
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable::{EncodeVTable, SerdeVTable, VisitorVTable};
+use vortex_array::vtable::{EncodeVTable, SerdeVTable, VTable, VisitorVTable};
 use vortex_array::{
     Array, ArrayBufferVisitor, ArrayChildVisitor, Canonical, DeserializeMetadata, ProstMetadata,
 };
 use vortex_buffer::ByteBuffer;
-use vortex_dtype::{DType, Nullability, PType};
+use vortex_dtype::{DType, Nullability};
 use vortex_error::{VortexResult, vortex_bail};
 
-use crate::{DateTimePartsArray, DateTimePartsEncoding, DateTimePartsVTable};
-
-#[derive(Clone, prost::Message)]
-#[repr(C)]
-pub struct DateTimePartsMetadata {
-    // Validity lives in the days array
-    // TODO(ngates): we should actually model this with a Tuple array when we have one.
-    #[prost(enumeration = "PType", tag = "1")]
-    days_ptype: i32,
-    #[prost(enumeration = "PType", tag = "2")]
-    seconds_ptype: i32,
-    #[prost(enumeration = "PType", tag = "3")]
-    subseconds_ptype: i32,
-}
+use crate::{
+    DateTimePartsArray, DateTimePartsEncoding, DateTimePartsMetadata, DateTimePartsVTable,
+};
 
 impl SerdeVTable<DateTimePartsVTable> for DateTimePartsVTable {
-    type Metadata = ProstMetadata<DateTimePartsMetadata>;
-
-    fn metadata(array: &DateTimePartsArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(ProstMetadata(DateTimePartsMetadata {
-            days_ptype: PType::try_from(array.days().dtype())? as i32,
-            seconds_ptype: PType::try_from(array.seconds().dtype())? as i32,
-            subseconds_ptype: PType::try_from(array.subseconds().dtype())? as i32,
-        })))
-    }
-
     fn build(
         _encoding: &DateTimePartsEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &<Self::Metadata as DeserializeMetadata>::Output,
+        metadata: &<<DateTimePartsVTable as VTable>::Metadata as DeserializeMetadata>::Output,
         _buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<DateTimePartsArray> {
@@ -86,6 +65,14 @@ impl EncodeVTable<DateTimePartsVTable> for DateTimePartsVTable {
 }
 
 impl VisitorVTable<DateTimePartsVTable> for DateTimePartsVTable {
+    fn metadata(array: &DateTimePartsArray) -> <DateTimePartsVTable as VTable>::Metadata {
+        ProstMetadata(DateTimePartsMetadata {
+            days_ptype: array.days().dtype().as_ptype() as i32,
+            seconds_ptype: array.seconds().dtype().as_ptype() as i32,
+            subseconds_ptype: array.subseconds().dtype().as_ptype() as i32,
+        })
+    }
+
     fn visit_buffers(_array: &DateTimePartsArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(array: &DateTimePartsArray, visitor: &mut dyn ArrayChildVisitor) {

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -24,6 +24,7 @@ vtable!(DecimalByteParts);
 impl VTable for DecimalBytePartsVTable {
     type Array = DecimalBytePartsArray;
     type Encoding = DecimalBytePartsEncoding;
+    type Metadata = vortex_array::ProstMetadata<serde::DecimalBytesPartsMetadata>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/serde.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/serde.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable::{SerdeVTable, VisitorVTable};
+use vortex_array::vtable::{SerdeVTable, VTable, VisitorVTable};
 use vortex_array::{
     Array, ArrayBufferVisitor, ArrayChildVisitor, DeserializeMetadata, ProstMetadata,
 };
@@ -21,20 +21,11 @@ pub struct DecimalBytesPartsMetadata {
 }
 
 impl SerdeVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
-    type Metadata = ProstMetadata<DecimalBytesPartsMetadata>;
-
-    fn metadata(array: &DecimalBytePartsArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(ProstMetadata(DecimalBytesPartsMetadata {
-            zeroth_child_ptype: PType::try_from(array.msp.dtype())? as i32,
-            lower_part_count: 0,
-        })))
-    }
-
     fn build(
         _encoding: &DecimalBytePartsEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &<Self::Metadata as DeserializeMetadata>::Output,
+        metadata: &<<DecimalBytePartsVTable as VTable>::Metadata as DeserializeMetadata>::Output,
         _buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<DecimalBytePartsArray> {
@@ -56,6 +47,13 @@ impl SerdeVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
 }
 
 impl VisitorVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
+    fn metadata(array: &DecimalBytePartsArray) -> <DecimalBytePartsVTable as VTable>::Metadata {
+        ProstMetadata(DecimalBytesPartsMetadata {
+            zeroth_child_ptype: array.msp.dtype().as_ptype() as i32,
+            lower_part_count: 0,
+        })
+    }
+
     fn visit_buffers(_array: &DecimalBytePartsArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(array: &DecimalBytePartsArray, visitor: &mut dyn ArrayChildVisitor) {

--- a/encodings/dict/src/array.rs
+++ b/encodings/dict/src/array.rs
@@ -16,6 +16,7 @@ vtable!(Dict);
 impl VTable for DictVTable {
     type Array = DictArray;
     type Encoding = DictEncoding;
+    type Metadata = vortex_array::ProstMetadata<crate::serde::DictMetadata>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/encodings/dict/src/serde.rs
+++ b/encodings/dict/src/serde.rs
@@ -2,13 +2,13 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable::{EncodeVTable, SerdeVTable, VisitorVTable};
+use vortex_array::vtable::{EncodeVTable, SerdeVTable, VTable, VisitorVTable};
 use vortex_array::{
     Array, ArrayBufferVisitor, ArrayChildVisitor, Canonical, DeserializeMetadata, ProstMetadata,
 };
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, Nullability, PType};
-use vortex_error::{VortexResult, vortex_bail, vortex_err};
+use vortex_error::{VortexResult, vortex_bail};
 
 use crate::builders::dict_encode;
 use crate::{DictArray, DictEncoding, DictVTable};
@@ -16,35 +16,20 @@ use crate::{DictArray, DictEncoding, DictVTable};
 #[derive(Clone, prost::Message)]
 pub struct DictMetadata {
     #[prost(uint32, tag = "1")]
-    values_len: u32,
+    pub values_len: u32,
     #[prost(enumeration = "PType", tag = "2")]
-    codes_ptype: i32,
+    pub codes_ptype: i32,
     // nullable codes are optional since they were added after stabilisation
     #[prost(optional, bool, tag = "3")]
-    is_nullable_codes: Option<bool>,
+    pub is_nullable_codes: Option<bool>,
 }
 
 impl SerdeVTable<DictVTable> for DictVTable {
-    type Metadata = ProstMetadata<DictMetadata>;
-
-    fn metadata(array: &DictArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(ProstMetadata(DictMetadata {
-            codes_ptype: PType::try_from(array.codes().dtype())? as i32,
-            values_len: u32::try_from(array.values().len()).map_err(|_| {
-                vortex_err!(
-                    "Dictionary values size {} overflowed u32",
-                    array.values().len()
-                )
-            })?,
-            is_nullable_codes: Some(array.codes().dtype().is_nullable()),
-        })))
-    }
-
     fn build(
         _encoding: &DictEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &<Self::Metadata as DeserializeMetadata>::Output,
+        metadata: &<<DictVTable as VTable>::Metadata as DeserializeMetadata>::Output,
         _buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<DictArray> {
@@ -79,6 +64,15 @@ impl EncodeVTable<DictVTable> for DictVTable {
 }
 
 impl VisitorVTable<DictVTable> for DictVTable {
+    fn metadata(array: &DictArray) -> <DictVTable as VTable>::Metadata {
+        ProstMetadata(DictMetadata {
+            codes_ptype: array.codes().dtype().as_ptype() as i32,
+            values_len: u32::try_from(array.values().len())
+                .expect("Dictionary values size overflowed u32"),
+            is_nullable_codes: Some(array.codes().dtype().is_nullable()),
+        })
+    }
+
     fn visit_buffers(_array: &DictArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(array: &DictArray, visitor: &mut dyn ArrayChildVisitor) {

--- a/encodings/dict/src/serde.rs
+++ b/encodings/dict/src/serde.rs
@@ -8,7 +8,7 @@ use vortex_array::{
 };
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, Nullability, PType};
-use vortex_error::{VortexResult, vortex_bail};
+use vortex_error::{VortexExpect, VortexResult, vortex_bail};
 
 use crate::builders::dict_encode;
 use crate::{DictArray, DictEncoding, DictVTable};
@@ -68,7 +68,7 @@ impl VisitorVTable<DictVTable> for DictVTable {
         ProstMetadata(DictMetadata {
             codes_ptype: array.codes().dtype().as_ptype() as i32,
             values_len: u32::try_from(array.values().len())
-                .expect("Dictionary values size overflowed u32"),
+                .vortex_expect("Dictionary values size overflowed u32"),
             is_nullable_codes: Some(array.codes().dtype().is_nullable()),
         })
     }

--- a/encodings/fastlanes/src/bitpacking/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/mod.rs
@@ -26,6 +26,7 @@ mod compute;
 pub mod operator;
 mod ops;
 mod serde;
+pub use serde::BitPackedMetadata;
 pub mod unpack_iter;
 
 vtable!(BitPacked);
@@ -33,6 +34,7 @@ vtable!(BitPacked);
 impl VTable for BitPackedVTable {
     type Array = BitPackedArray;
     type Encoding = BitPackedEncoding;
+    type Metadata = vortex_array::ProstMetadata<BitPackedMetadata>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/encodings/fastlanes/src/bitpacking/serde.rs
+++ b/encodings/fastlanes/src/bitpacking/serde.rs
@@ -4,7 +4,7 @@
 use vortex_array::patches::{Patches, PatchesMetadata};
 use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
-use vortex_array::vtable::{EncodeVTable, SerdeVTable, ValidityHelper, VisitorVTable};
+use vortex_array::vtable::{EncodeVTable, SerdeVTable, VTable, ValidityHelper, VisitorVTable};
 use vortex_array::{ArrayBufferVisitor, ArrayChildVisitor, Canonical, ProstMetadata};
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, PType};
@@ -24,19 +24,6 @@ pub struct BitPackedMetadata {
 }
 
 impl SerdeVTable<BitPackedVTable> for BitPackedVTable {
-    type Metadata = ProstMetadata<BitPackedMetadata>;
-
-    fn metadata(array: &BitPackedArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(ProstMetadata(BitPackedMetadata {
-            bit_width: array.bit_width() as u32,
-            offset: array.offset() as u32,
-            patches: array
-                .patches()
-                .map(|p| p.to_metadata(array.len(), array.dtype()))
-                .transpose()?,
-        })))
-    }
-
     /// Deserialize a BitPackedArray from its components.
     ///
     /// Note that the layout depends on whether patches and chunk_offsets are present:
@@ -46,7 +33,7 @@ impl SerdeVTable<BitPackedVTable> for BitPackedVTable {
         _encoding: &BitPackedEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &BitPackedMetadata,
+        metadata: &<<BitPackedVTable as VTable>::Metadata as vortex_array::DeserializeMetadata>::Output,
         buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<BitPackedArray> {
@@ -162,6 +149,17 @@ impl EncodeVTable<BitPackedVTable> for BitPackedVTable {
 }
 
 impl VisitorVTable<BitPackedVTable> for BitPackedVTable {
+    fn metadata(array: &BitPackedArray) -> <BitPackedVTable as VTable>::Metadata {
+        ProstMetadata(BitPackedMetadata {
+            bit_width: array.bit_width() as u32,
+            offset: array.offset() as u32,
+            patches: array.patches().map(|p| {
+                p.to_metadata(array.len(), array.dtype())
+                    .expect("Failed to get patches metadata")
+            }),
+        })
+    }
+
     fn visit_buffers(array: &BitPackedArray, visitor: &mut dyn ArrayBufferVisitor) {
         visitor.visit_buffer(array.packed());
     }

--- a/encodings/fastlanes/src/bitpacking/serde.rs
+++ b/encodings/fastlanes/src/bitpacking/serde.rs
@@ -153,10 +153,7 @@ impl VisitorVTable<BitPackedVTable> for BitPackedVTable {
         ProstMetadata(BitPackedMetadata {
             bit_width: array.bit_width() as u32,
             offset: array.offset() as u32,
-            patches: array.patches().map(|p| {
-                p.to_metadata(array.len(), array.dtype())
-                    .expect("Failed to get patches metadata")
-            }),
+            patches: array.patches().map(|p| p.to_metadata(array.len())),
         })
     }
 

--- a/encodings/fastlanes/src/delta/mod.rs
+++ b/encodings/fastlanes/src/delta/mod.rs
@@ -21,12 +21,14 @@ mod compress;
 mod compute;
 mod ops;
 mod serde;
+pub use serde::DeltaMetadata;
 
 vtable!(Delta);
 
 impl VTable for DeltaVTable {
     type Array = DeltaArray;
     type Encoding = DeltaEncoding;
+    type Metadata = vortex_array::ProstMetadata<DeltaMetadata>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/encodings/fastlanes/src/delta/serde.rs
+++ b/encodings/fastlanes/src/delta/serde.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable::{SerdeVTable, VisitorVTable};
+use vortex_array::vtable::{SerdeVTable, VTable, VisitorVTable};
 use vortex_array::{
     Array, ArrayBufferVisitor, ArrayChildVisitor, DeserializeMetadata, ProstMetadata,
 };
@@ -23,20 +23,11 @@ pub struct DeltaMetadata {
 }
 
 impl SerdeVTable<DeltaVTable> for DeltaVTable {
-    type Metadata = ProstMetadata<DeltaMetadata>;
-
-    fn metadata(array: &DeltaArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(ProstMetadata(DeltaMetadata {
-            deltas_len: array.deltas().len() as u64,
-            offset: array.offset() as u32,
-        })))
-    }
-
     fn build(
         _encoding: &DeltaEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &<Self::Metadata as DeserializeMetadata>::Output,
+        metadata: &<<DeltaVTable as VTable>::Metadata as DeserializeMetadata>::Output,
         _buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<DeltaArray> {
@@ -60,6 +51,13 @@ impl SerdeVTable<DeltaVTable> for DeltaVTable {
 }
 
 impl VisitorVTable<DeltaVTable> for DeltaVTable {
+    fn metadata(array: &DeltaArray) -> <DeltaVTable as VTable>::Metadata {
+        ProstMetadata(DeltaMetadata {
+            deltas_len: array.deltas().len() as u64,
+            offset: array.offset() as u32,
+        })
+    }
+
     fn visit_buffers(_array: &DeltaArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(array: &DeltaArray, visitor: &mut dyn ArrayChildVisitor) {

--- a/encodings/fastlanes/src/for/mod.rs
+++ b/encodings/fastlanes/src/for/mod.rs
@@ -17,12 +17,14 @@ mod compute;
 mod ops;
 mod pipeline;
 mod serde;
+pub use serde::ScalarValueMetadata;
 
 vtable!(FoR);
 
 impl VTable for FoRVTable {
     type Array = FoRArray;
     type Encoding = FoREncoding;
+    type Metadata = ScalarValueMetadata;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/encodings/fastlanes/src/for/serde.rs
+++ b/encodings/fastlanes/src/for/serde.rs
@@ -4,7 +4,7 @@
 use std::fmt::{Debug, Formatter};
 
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable::{EncodeVTable, SerdeVTable, VisitorVTable};
+use vortex_array::vtable::{EncodeVTable, SerdeVTable, VTable, VisitorVTable};
 use vortex_array::{
     ArrayBufferVisitor, ArrayChildVisitor, Canonical, DeserializeMetadata, SerializeMetadata,
 };
@@ -17,19 +17,11 @@ use super::FoREncoding;
 use crate::{FoRArray, FoRVTable};
 
 impl SerdeVTable<FoRVTable> for FoRVTable {
-    type Metadata = ScalarValueMetadata;
-
-    fn metadata(array: &FoRArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(ScalarValueMetadata(
-            array.reference_scalar().value().clone(),
-        )))
-    }
-
     fn build(
         _encoding: &FoREncoding,
         dtype: &DType,
         len: usize,
-        metadata: &ScalarValue,
+        metadata: &<<FoRVTable as VTable>::Metadata as DeserializeMetadata>::Output,
         _buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<FoRArray> {
@@ -59,6 +51,10 @@ impl EncodeVTable<FoRVTable> for FoRVTable {
 }
 
 impl VisitorVTable<FoRVTable> for FoRVTable {
+    fn metadata(array: &FoRArray) -> <FoRVTable as VTable>::Metadata {
+        ScalarValueMetadata(array.reference_scalar().value().clone())
+    }
+
     fn visit_buffers(_array: &FoRArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(array: &FoRArray, visitor: &mut dyn ArrayChildVisitor) {

--- a/encodings/fastlanes/src/rle/mod.rs
+++ b/encodings/fastlanes/src/rle/mod.rs
@@ -19,12 +19,14 @@ mod compress;
 mod compute;
 mod ops;
 mod serde;
+pub use serde::RLEMetadata;
 
 vtable!(RLE);
 
 impl VTable for RLEVTable {
     type Array = RLEArray;
     type Encoding = RLEEncoding;
+    type Metadata = vortex_array::ProstMetadata<RLEMetadata>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/encodings/fastlanes/src/rle/serde.rs
+++ b/encodings/fastlanes/src/rle/serde.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable::{EncodeVTable, SerdeVTable, VisitorVTable};
+use vortex_array::vtable::{EncodeVTable, SerdeVTable, VTable, VisitorVTable};
 use vortex_array::{
     ArrayBufferVisitor, ArrayChildVisitor, Canonical, DeserializeMetadata, ProstMetadata,
 };
@@ -28,23 +28,11 @@ pub struct RLEMetadata {
 }
 
 impl SerdeVTable<RLEVTable> for RLEVTable {
-    type Metadata = ProstMetadata<RLEMetadata>;
-
-    fn metadata(array: &RLEArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(ProstMetadata(RLEMetadata {
-            values_len: array.values().len() as u64,
-            indices_len: array.indices().len() as u64,
-            indices_ptype: PType::try_from(array.indices().dtype())? as i32,
-            values_idx_offsets_len: array.values_idx_offsets().len() as u64,
-            values_idx_offsets_ptype: PType::try_from(array.values_idx_offsets().dtype())? as i32,
-        })))
-    }
-
     fn build(
         _encoding: &RLEEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &<Self::Metadata as DeserializeMetadata>::Output,
+        metadata: &<<RLEVTable as VTable>::Metadata as DeserializeMetadata>::Output,
         _buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<RLEArray> {
@@ -85,6 +73,16 @@ impl EncodeVTable<RLEVTable> for RLEVTable {
 }
 
 impl VisitorVTable<RLEVTable> for RLEVTable {
+    fn metadata(array: &RLEArray) -> <RLEVTable as VTable>::Metadata {
+        ProstMetadata(RLEMetadata {
+            values_len: array.values().len() as u64,
+            indices_len: array.indices().len() as u64,
+            indices_ptype: array.indices().dtype().as_ptype() as i32,
+            values_idx_offsets_len: array.values_idx_offsets().len() as u64,
+            values_idx_offsets_ptype: array.values_idx_offsets().dtype().as_ptype() as i32,
+        })
+    }
+
     fn visit_buffers(_array: &RLEArray, _visitor: &mut dyn ArrayBufferVisitor) {
         // RLE stores all data in child arrays, no direct buffers
     }

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -20,6 +20,7 @@ vtable!(FSST);
 impl VTable for FSSTVTable {
     type Array = FSSTArray;
     type Encoding = FSSTEncoding;
+    type Metadata = vortex_array::ProstMetadata<crate::serde::FSSTMetadata>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/encodings/fsst/src/serde.rs
+++ b/encodings/fsst/src/serde.rs
@@ -4,7 +4,7 @@
 use fsst::{Compressor, Symbol};
 use vortex_array::arrays::VarBinVTable;
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable::{EncodeVTable, SerdeVTable, VisitorVTable};
+use vortex_array::vtable::{EncodeVTable, SerdeVTable, VTable, VisitorVTable};
 use vortex_array::{
     Array, ArrayBufferVisitor, ArrayChildVisitor, Canonical, DeserializeMetadata, ProstMetadata,
 };
@@ -21,20 +21,11 @@ pub struct FSSTMetadata {
 }
 
 impl SerdeVTable<FSSTVTable> for FSSTVTable {
-    type Metadata = ProstMetadata<FSSTMetadata>;
-
-    fn metadata(array: &FSSTArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(ProstMetadata(FSSTMetadata {
-            uncompressed_lengths_ptype: PType::try_from(array.uncompressed_lengths().dtype())?
-                as i32,
-        })))
-    }
-
     fn build(
         _encoding: &FSSTEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &<Self::Metadata as DeserializeMetadata>::Output,
+        metadata: &<<FSSTVTable as VTable>::Metadata as DeserializeMetadata>::Output,
         buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<FSSTArray> {
@@ -94,6 +85,12 @@ impl EncodeVTable<FSSTVTable> for FSSTVTable {
 }
 
 impl VisitorVTable<FSSTVTable> for FSSTVTable {
+    fn metadata(array: &FSSTArray) -> <FSSTVTable as VTable>::Metadata {
+        ProstMetadata(FSSTMetadata {
+            uncompressed_lengths_ptype: array.uncompressed_lengths().dtype().as_ptype() as i32,
+        })
+    }
+
     fn visit_buffers(array: &FSSTArray, visitor: &mut dyn ArrayBufferVisitor) {
         visitor.visit_buffer(&array.symbols().clone().into_byte_buffer());
         visitor.visit_buffer(&array.symbol_lengths().clone().into_byte_buffer());

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -51,6 +51,7 @@ vtable!(Pco);
 impl VTable for PcoVTable {
     type Array = PcoArray;
     type Encoding = PcoEncoding;
+    type Metadata = vortex_array::ProstMetadata<PcoMetadata>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/encodings/pco/src/lib.rs
+++ b/encodings/pco/src/lib.rs
@@ -8,4 +8,4 @@ mod serde;
 mod test;
 
 pub use array::*;
-pub use serde::*;
+pub use serde::{PcoChunkInfo, PcoMetadata, PcoPageInfo};

--- a/encodings/pco/src/serde.rs
+++ b/encodings/pco/src/serde.rs
@@ -3,7 +3,7 @@
 
 use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
-use vortex_array::vtable::{EncodeVTable, SerdeVTable, VisitorVTable};
+use vortex_array::vtable::{EncodeVTable, SerdeVTable, VTable, VisitorVTable};
 use vortex_array::{ArrayBufferVisitor, ArrayChildVisitor, ProstMetadata};
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
@@ -38,17 +38,11 @@ pub struct PcoMetadata {
 }
 
 impl SerdeVTable<PcoVTable> for PcoVTable {
-    type Metadata = ProstMetadata<PcoMetadata>;
-
-    fn metadata(array: &PcoArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(ProstMetadata(array.metadata.clone())))
-    }
-
     fn build(
         _encoding: &PcoEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &PcoMetadata,
+        metadata: &<<PcoVTable as VTable>::Metadata as vortex_array::DeserializeMetadata>::Output,
         buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<PcoArray> {
@@ -85,7 +79,7 @@ impl SerdeVTable<PcoVTable> for PcoVTable {
 
 impl EncodeVTable<PcoVTable> for PcoVTable {
     fn encode(
-        _encoding: &<PcoVTable as vortex_array::vtable::VTable>::Encoding,
+        _encoding: &<PcoVTable as VTable>::Encoding,
         canonical: &vortex_array::Canonical,
         _like: Option<&PcoArray>,
     ) -> VortexResult<Option<PcoArray>> {
@@ -96,6 +90,10 @@ impl EncodeVTable<PcoVTable> for PcoVTable {
 }
 
 impl VisitorVTable<PcoVTable> for PcoVTable {
+    fn metadata(array: &PcoArray) -> <PcoVTable as VTable>::Metadata {
+        ProstMetadata(array.metadata.clone())
+    }
+
     fn visit_buffers(array: &PcoArray, visitor: &mut dyn ArrayBufferVisitor) {
         for buffer in &array.chunk_metas {
             visitor.visit_buffer(buffer);

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -8,7 +8,8 @@ use vortex_array::search_sorted::{SearchSorted, SearchSortedSide};
 use vortex_array::stats::{ArrayStats, StatsSetRef};
 use vortex_array::vtable::{ArrayVTable, CanonicalVTable, NotSupported, VTable, ValidityVTable};
 use vortex_array::{
-    Array, ArrayRef, Canonical, EncodingId, EncodingRef, IntoArray, ToCanonical, vtable,
+    Array, ArrayRef, Canonical, EncodingId, EncodingRef, IntoArray, ProstMetadata, ToCanonical,
+    vtable,
 };
 use vortex_dtype::DType;
 use vortex_error::{VortexExpect as _, VortexResult, vortex_bail, vortex_ensure, vortex_panic};
@@ -16,12 +17,14 @@ use vortex_mask::Mask;
 use vortex_scalar::PValue;
 
 use crate::compress::{runend_decode_bools, runend_decode_primitive, runend_encode};
+use crate::serde::RunEndMetadata;
 
 vtable!(RunEnd);
 
 impl VTable for RunEndVTable {
     type Array = RunEndArray;
     type Encoding = RunEndEncoding;
+    type Metadata = ProstMetadata<RunEndMetadata>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/encodings/runend/src/serde.rs
+++ b/encodings/runend/src/serde.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable::{EncodeVTable, SerdeVTable, VisitorVTable};
+use vortex_array::vtable::{EncodeVTable, SerdeVTable, VTable, VisitorVTable};
 use vortex_array::{
     Array, ArrayBufferVisitor, ArrayChildVisitor, Canonical, DeserializeMetadata, ProstMetadata,
 };
@@ -24,22 +24,11 @@ pub struct RunEndMetadata {
 }
 
 impl SerdeVTable<RunEndVTable> for RunEndVTable {
-    type Metadata = ProstMetadata<RunEndMetadata>;
-
-    fn metadata(array: &RunEndArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(ProstMetadata(RunEndMetadata {
-            ends_ptype: PType::try_from(array.ends().dtype()).vortex_expect("Must be a valid PType")
-                as i32,
-            num_runs: array.ends().len() as u64,
-            offset: array.offset() as u64,
-        })))
-    }
-
     fn build(
         _encoding: &RunEndEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &<Self::Metadata as DeserializeMetadata>::Output,
+        metadata: &<<RunEndVTable as VTable>::Metadata as DeserializeMetadata>::Output,
         _buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<RunEndArray> {
@@ -80,6 +69,14 @@ impl EncodeVTable<RunEndVTable> for RunEndVTable {
 }
 
 impl VisitorVTable<RunEndVTable> for RunEndVTable {
+    fn metadata(array: &RunEndArray) -> <RunEndVTable as VTable>::Metadata {
+        ProstMetadata(RunEndMetadata {
+            ends_ptype: array.ends().dtype().as_ptype() as i32,
+            num_runs: array.ends().len() as u64,
+            offset: array.offset() as u64,
+        })
+    }
+
     fn visit_buffers(_array: &RunEndArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(array: &RunEndArray, visitor: &mut dyn ArrayChildVisitor) {

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -8,11 +8,8 @@ use vortex_array::arrays::PrimitiveArray;
 use vortex_array::stats::{ArrayStats, StatsSetRef};
 use vortex_array::vtable::{
     ArrayVTable, CanonicalVTable, NotSupported, OperationsVTable, VTable, ValidityVTable,
-    VisitorVTable,
 };
-use vortex_array::{
-    ArrayBufferVisitor, ArrayChildVisitor, ArrayRef, Canonical, EncodingId, EncodingRef, vtable,
-};
+use vortex_array::{ArrayRef, Canonical, EncodingId, EncodingRef, vtable};
 use vortex_buffer::BufferMut;
 use vortex_dtype::{
     DType, NativePType, Nullability, PType, match_each_integer_ptype, match_each_native_ptype,
@@ -20,6 +17,8 @@ use vortex_dtype::{
 use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
 use vortex_mask::Mask;
 use vortex_scalar::{PValue, Scalar, ScalarValue};
+
+use crate::SequenceMetadata;
 
 vtable!(Sequence);
 
@@ -149,6 +148,7 @@ impl SequenceArray {
 impl VTable for SequenceVTable {
     type Array = SequenceArray;
     type Encoding = SequenceEncoding;
+    type Metadata = vortex_array::ProstMetadata<SequenceMetadata>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;
@@ -235,14 +235,6 @@ impl ValidityVTable<SequenceVTable> for SequenceVTable {
     fn validity_mask(array: &SequenceArray) -> Mask {
         Mask::AllTrue(array.len())
     }
-}
-
-impl VisitorVTable<SequenceVTable> for SequenceVTable {
-    fn visit_buffers(_array: &SequenceArray, _visitor: &mut dyn ArrayBufferVisitor) {
-        // TODO(joe): expose scalar values
-    }
-
-    fn visit_children(_array: &SequenceArray, _visitor: &mut dyn ArrayChildVisitor) {}
 }
 
 #[derive(Clone, Debug)]

--- a/encodings/sequence/src/lib.rs
+++ b/encodings/sequence/src/lib.rs
@@ -6,11 +6,11 @@ mod compress;
 mod compute;
 mod operator;
 mod serde;
-
 /// Represents the equation A\[i\] = a * i + b.
 /// This can be used for compression, fast comparisons and also for row ids.
 pub use array::{SequenceArray, SequenceEncoding, SequenceVTable};
 pub use compress::sequence_encode;
+pub use serde::SequenceMetadata;
 
 // TODO(joe): hook up to the compressor
 // TODO(joe): support comparisons with other operators

--- a/encodings/sequence/src/serde.rs
+++ b/encodings/sequence/src/serde.rs
@@ -2,8 +2,10 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable::{EncodeVTable, SerdeVTable};
-use vortex_array::{Canonical, DeserializeMetadata, ProstMetadata};
+use vortex_array::vtable::{EncodeVTable, SerdeVTable, VTable, VisitorVTable};
+use vortex_array::{
+    ArrayBufferVisitor, ArrayChildVisitor, Canonical, DeserializeMetadata, ProstMetadata,
+};
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability::NonNullable;
@@ -33,20 +35,11 @@ impl EncodeVTable<SequenceVTable> for SequenceVTable {
 }
 
 impl SerdeVTable<SequenceVTable> for SequenceVTable {
-    type Metadata = ProstMetadata<SequenceMetadata>;
-
-    fn metadata(array: &SequenceArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(ProstMetadata(SequenceMetadata {
-            base: Some((&array.base()).into()),
-            multiplier: Some((&array.multiplier()).into()),
-        })))
-    }
-
     fn build(
         _encoding: &SequenceEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &<Self::Metadata as DeserializeMetadata>::Output,
+        metadata: &<<SequenceVTable as VTable>::Metadata as DeserializeMetadata>::Output,
         _buffers: &[ByteBuffer],
         _children: &dyn ArrayChildren,
     ) -> VortexResult<SequenceArray> {
@@ -85,6 +78,21 @@ impl SerdeVTable<SequenceVTable> for SequenceVTable {
             len,
         ))
     }
+}
+
+impl VisitorVTable<SequenceVTable> for SequenceVTable {
+    fn metadata(array: &SequenceArray) -> <SequenceVTable as VTable>::Metadata {
+        ProstMetadata(SequenceMetadata {
+            base: Some((&array.base()).into()),
+            multiplier: Some((&array.multiplier()).into()),
+        })
+    }
+
+    fn visit_buffers(_array: &SequenceArray, _visitor: &mut dyn ArrayBufferVisitor) {
+        // TODO(joe): expose scalar values
+    }
+
+    fn visit_children(_array: &SequenceArray, _visitor: &mut dyn ArrayChildVisitor) {}
 }
 
 #[cfg(test)]

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -21,12 +21,14 @@ mod canonical;
 mod compute;
 mod ops;
 mod serde;
+pub use serde::SparseMetadata;
 
 vtable!(Sparse);
 
 impl VTable for SparseVTable {
     type Array = SparseArray;
     type Encoding = SparseEncoding;
+    type Metadata = vortex_array::ProstMetadata<SparseMetadata>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/encodings/sparse/src/serde.rs
+++ b/encodings/sparse/src/serde.rs
@@ -74,10 +74,7 @@ impl EncodeVTable<SparseVTable> for SparseVTable {
 impl VisitorVTable<SparseVTable> for SparseVTable {
     fn metadata(array: &SparseArray) -> <SparseVTable as VTable>::Metadata {
         ProstMetadata(SparseMetadata {
-            patches: array
-                .patches()
-                .to_metadata(array.len(), array.dtype())
-                .expect("Failed to get patches metadata"),
+            patches: array.patches().to_metadata(array.len()),
         })
     }
 

--- a/encodings/sparse/src/serde.rs
+++ b/encodings/sparse/src/serde.rs
@@ -3,7 +3,7 @@
 
 use vortex_array::patches::PatchesMetadata;
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable::{EncodeVTable, SerdeVTable, VisitorVTable};
+use vortex_array::vtable::{EncodeVTable, SerdeVTable, VTable, VisitorVTable};
 use vortex_array::{
     ArrayBufferVisitor, ArrayChildVisitor, Canonical, DeserializeMetadata, ProstMetadata,
 };
@@ -22,19 +22,11 @@ pub struct SparseMetadata {
 }
 
 impl SerdeVTable<SparseVTable> for SparseVTable {
-    type Metadata = ProstMetadata<SparseMetadata>;
-
-    fn metadata(array: &SparseArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(ProstMetadata(SparseMetadata {
-            patches: array.patches().to_metadata(array.len(), array.dtype())?,
-        })))
-    }
-
     fn build(
         _encoding: &SparseEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &<Self::Metadata as DeserializeMetadata>::Output,
+        metadata: &<<SparseVTable as VTable>::Metadata as DeserializeMetadata>::Output,
         buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<SparseArray> {
@@ -80,6 +72,15 @@ impl EncodeVTable<SparseVTable> for SparseVTable {
 }
 
 impl VisitorVTable<SparseVTable> for SparseVTable {
+    fn metadata(array: &SparseArray) -> <SparseVTable as VTable>::Metadata {
+        ProstMetadata(SparseMetadata {
+            patches: array
+                .patches()
+                .to_metadata(array.len(), array.dtype())
+                .expect("Failed to get patches metadata"),
+        })
+    }
+
     fn visit_buffers(array: &SparseArray, visitor: &mut dyn ArrayBufferVisitor) {
         let fill_value_buffer = array
             .fill_value

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -24,6 +24,7 @@ vtable!(ZigZag);
 impl VTable for ZigZagVTable {
     type Array = ZigZagArray;
     type Encoding = ZigZagEncoding;
+    type Metadata = vortex_array::EmptyMetadata;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/encodings/zigzag/src/serde.rs
+++ b/encodings/zigzag/src/serde.rs
@@ -13,17 +13,11 @@ use vortex_error::{VortexResult, vortex_bail};
 use crate::{ZigZagArray, ZigZagEncoding, ZigZagVTable, zigzag_encode};
 
 impl SerdeVTable<ZigZagVTable> for ZigZagVTable {
-    type Metadata = EmptyMetadata;
-
-    fn metadata(_array: &ZigZagArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(EmptyMetadata))
-    }
-
     fn build(
         _encoding: &ZigZagEncoding,
         dtype: &DType,
         len: usize,
-        _metadata: &<Self::Metadata as DeserializeMetadata>::Output,
+        _metadata: &<ZigZagVTable as vortex_array::vtable::VTable>::Metadata,
         _buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ZigZagArray> {
@@ -60,6 +54,10 @@ impl EncodeVTable<ZigZagVTable> for ZigZagVTable {
 }
 
 impl VisitorVTable<ZigZagVTable> for ZigZagVTable {
+    fn metadata(_array: &ZigZagArray) -> EmptyMetadata {
+        EmptyMetadata
+    }
+
     fn visit_buffers(_array: &ZigZagArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(array: &ZigZagArray, visitor: &mut dyn ArrayChildVisitor) {

--- a/encodings/zigzag/src/serde.rs
+++ b/encodings/zigzag/src/serde.rs
@@ -3,9 +3,7 @@
 
 use vortex_array::serde::ArrayChildren;
 use vortex_array::vtable::{EncodeVTable, SerdeVTable, VisitorVTable};
-use vortex_array::{
-    ArrayBufferVisitor, ArrayChildVisitor, Canonical, DeserializeMetadata, EmptyMetadata,
-};
+use vortex_array::{ArrayBufferVisitor, ArrayChildVisitor, Canonical, EmptyMetadata};
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, PType};
 use vortex_error::{VortexResult, vortex_bail};

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -23,7 +23,8 @@ use vortex_error::{VortexError, VortexExpect, VortexResult, vortex_err, vortex_p
 use vortex_mask::AllOr;
 use vortex_scalar::Scalar;
 
-use crate::serde::{ZstdFrameMetadata, ZstdMetadata};
+pub(crate) use crate::serde::ZstdFrameMetadata;
+use crate::serde::ZstdMetadata;
 
 // Zstd doesn't support training dictionaries on very few samples.
 const MIN_SAMPLES_FOR_DICTIONARY: usize = 8;
@@ -52,6 +53,7 @@ vtable!(Zstd);
 impl VTable for ZstdVTable {
     type Array = ZstdArray;
     type Encoding = ZstdEncoding;
+    type Metadata = vortex_array::ProstMetadata<ZstdMetadata>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/encodings/zstd/src/serde.rs
+++ b/encodings/zstd/src/serde.rs
@@ -3,7 +3,7 @@
 
 use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
-use vortex_array::vtable::{EncodeVTable, SerdeVTable, VisitorVTable};
+use vortex_array::vtable::{EncodeVTable, SerdeVTable, VTable, VisitorVTable};
 use vortex_array::{ArrayBufferVisitor, ArrayChildVisitor, ProstMetadata};
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
@@ -29,17 +29,11 @@ pub struct ZstdMetadata {
 }
 
 impl SerdeVTable<ZstdVTable> for ZstdVTable {
-    type Metadata = ProstMetadata<ZstdMetadata>;
-
-    fn metadata(array: &ZstdArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(ProstMetadata(array.metadata.clone())))
-    }
-
     fn build(
         _encoding: &ZstdEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &ZstdMetadata,
+        metadata: &<<ZstdVTable as VTable>::Metadata as vortex_array::DeserializeMetadata>::Output,
         buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ZstdArray> {
@@ -73,7 +67,7 @@ impl SerdeVTable<ZstdVTable> for ZstdVTable {
 
 impl EncodeVTable<ZstdVTable> for ZstdVTable {
     fn encode(
-        _encoding: &<ZstdVTable as vortex_array::vtable::VTable>::Encoding,
+        _encoding: &<ZstdVTable as VTable>::Encoding,
         canonical: &vortex_array::Canonical,
         _like: Option<&ZstdArray>,
     ) -> VortexResult<Option<ZstdArray>> {
@@ -82,6 +76,10 @@ impl EncodeVTable<ZstdVTable> for ZstdVTable {
 }
 
 impl VisitorVTable<ZstdVTable> for ZstdVTable {
+    fn metadata(array: &ZstdArray) -> <ZstdVTable as VTable>::Metadata {
+        ProstMetadata(array.metadata.clone())
+    }
+
     fn visit_buffers(array: &ZstdArray, visitor: &mut dyn ArrayBufferVisitor) {
         if let Some(buffer) = &array.dictionary {
             visitor.visit_buffer(buffer);

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -27,8 +27,8 @@ use crate::operator::OperatorRef;
 use crate::serde::ArrayChildren;
 use crate::stats::{Precision, Stat, StatsProviderExt, StatsSetRef};
 use crate::vtable::{
-    ArrayVTable, CanonicalVTable, ComputeVTable, OperationsVTable, PipelineVTable, SerdeVTable,
-    VTable, ValidityVTable, VisitorVTable,
+    ArrayVTable, CanonicalVTable, ComputeVTable, OperationsVTable, PipelineVTable, VTable,
+    ValidityVTable, VisitorVTable,
 };
 use crate::{Canonical, EncodingId, EncodingRef, SerializeMetadata};
 

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -719,14 +719,13 @@ impl<V: VTable> ArrayVisitor for ArrayAdapter<V> {
     }
 
     fn metadata(&self) -> VortexResult<Option<Vec<u8>>> {
-        Ok(<V::SerdeVTable as SerdeVTable<V>>::metadata(&self.0)?.map(|m| m.serialize()))
+        Ok(Some(
+            <V::VisitorVTable as VisitorVTable<V>>::metadata(&self.0).serialize(),
+        ))
     }
 
     fn metadata_fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match <V::SerdeVTable as SerdeVTable<V>>::metadata(&self.0) {
-            Err(e) => write!(f, "<serde error: {e}>"),
-            Ok(None) => write!(f, "<serde not supported>"),
-            Ok(Some(metadata)) => Debug::fmt(&metadata, f),
-        }
+        let metadata = <V::VisitorVTable as VisitorVTable<V>>::metadata(&self.0);
+        Debug::fmt(&metadata, f)
     }
 }

--- a/vortex-array/src/arrays/bool/vtable/mod.rs
+++ b/vortex-array/src/arrays/bool/vtable/mod.rs
@@ -17,6 +17,7 @@ vtable!(Bool);
 impl VTable for BoolVTable {
     type Array = BoolArray;
     type Encoding = BoolEncoding;
+    type Metadata = crate::ProstMetadata<serde::BoolMetadata>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/vortex-array/src/arrays/bool/vtable/serde.rs
+++ b/vortex-array/src/arrays/bool/vtable/serde.rs
@@ -3,10 +3,9 @@
 
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
-use vortex_error::{VortexResult, vortex_bail, vortex_err};
+use vortex_error::{VortexResult, vortex_bail};
 
 use super::BoolArray;
-use crate::ProstMetadata;
 use crate::arrays::BoolVTable;
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
@@ -20,20 +19,11 @@ pub struct BoolMetadata {
 }
 
 impl SerdeVTable<BoolVTable> for BoolVTable {
-    type Metadata = ProstMetadata<BoolMetadata>;
-
-    fn metadata(array: &BoolArray) -> VortexResult<Option<Self::Metadata>> {
-        let bit_offset = array.boolean_buffer().offset();
-        let bit_offset = u32::try_from(bit_offset)
-            .map_err(|_| vortex_err!("bit_offset {bit_offset} overflows u32"))?;
-        Ok(Some(ProstMetadata(BoolMetadata { offset: bit_offset })))
-    }
-
     fn build(
         _encoding: &<BoolVTable as VTable>::Encoding,
         dtype: &DType,
         len: usize,
-        metadata: &BoolMetadata,
+        metadata: &<<BoolVTable as VTable>::Metadata as crate::DeserializeMetadata>::Output,
         buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<BoolArray> {

--- a/vortex-array/src/arrays/bool/vtable/visitor.rs
+++ b/vortex-array/src/arrays/bool/vtable/visitor.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_buffer::{Alignment, ByteBuffer};
+use vortex_error::VortexExpect;
 
 use super::serde::BoolMetadata;
 use crate::arrays::{BoolArray, BoolVTable};
@@ -12,7 +13,7 @@ impl VisitorVTable<BoolVTable> for BoolVTable {
     fn metadata(array: &BoolArray) -> <BoolVTable as VTable>::Metadata {
         let bit_offset = array.boolean_buffer().offset();
         let bit_offset =
-            u32::try_from(bit_offset).expect(&format!("bit_offset {bit_offset} overflows u32"));
+            u32::try_from(bit_offset).vortex_expect("bit_offset {bit_offset} overflows u32");
         ProstMetadata(BoolMetadata { offset: bit_offset })
     }
 

--- a/vortex-array/src/arrays/bool/vtable/visitor.rs
+++ b/vortex-array/src/arrays/bool/vtable/visitor.rs
@@ -3,11 +3,19 @@
 
 use vortex_buffer::{Alignment, ByteBuffer};
 
+use super::serde::BoolMetadata;
 use crate::arrays::{BoolArray, BoolVTable};
-use crate::vtable::VisitorVTable;
-use crate::{ArrayBufferVisitor, ArrayChildVisitor};
+use crate::vtable::{VTable, VisitorVTable};
+use crate::{ArrayBufferVisitor, ArrayChildVisitor, ProstMetadata};
 
 impl VisitorVTable<BoolVTable> for BoolVTable {
+    fn metadata(array: &BoolArray) -> <BoolVTable as VTable>::Metadata {
+        let bit_offset = array.boolean_buffer().offset();
+        let bit_offset =
+            u32::try_from(bit_offset).expect(&format!("bit_offset {bit_offset} overflows u32"));
+        ProstMetadata(BoolMetadata { offset: bit_offset })
+    }
+
     fn visit_buffers(array: &BoolArray, visitor: &mut dyn ArrayBufferVisitor) {
         visitor.visit_buffer(&ByteBuffer::from_arrow_buffer(
             array.boolean_buffer().clone().into_inner(),

--- a/vortex-array/src/arrays/chunked/vtable/mod.rs
+++ b/vortex-array/src/arrays/chunked/vtable/mod.rs
@@ -18,6 +18,7 @@ vtable!(Chunked);
 impl VTable for ChunkedVTable {
     type Array = ChunkedArray;
     type Encoding = ChunkedEncoding;
+    type Metadata = crate::EmptyMetadata;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/vortex-array/src/arrays/chunked/vtable/serde.rs
+++ b/vortex-array/src/arrays/chunked/vtable/serde.rs
@@ -6,23 +6,17 @@ use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, Nullability, PType};
 use vortex_error::{VortexResult, vortex_bail, vortex_err};
 
+use crate::ToCanonical;
 use crate::arrays::{ChunkedArray, ChunkedEncoding, ChunkedVTable};
 use crate::serde::ArrayChildren;
-use crate::vtable::SerdeVTable;
-use crate::{EmptyMetadata, ToCanonical};
+use crate::vtable::{SerdeVTable, VTable};
 
 impl SerdeVTable<ChunkedVTable> for ChunkedVTable {
-    type Metadata = EmptyMetadata;
-
-    fn metadata(_array: &ChunkedArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(EmptyMetadata))
-    }
-
     fn build(
         _encoding: &ChunkedEncoding,
         dtype: &DType,
         _len: usize,
-        _metadata: &Self::Metadata,
+        _metadata: &<ChunkedVTable as VTable>::Metadata,
         _buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ChunkedArray> {

--- a/vortex-array/src/arrays/chunked/vtable/visitor.rs
+++ b/vortex-array/src/arrays/chunked/vtable/visitor.rs
@@ -4,9 +4,13 @@
 use crate::arrays::{ChunkedArray, ChunkedVTable, PrimitiveArray};
 use crate::validity::Validity;
 use crate::vtable::VisitorVTable;
-use crate::{ArrayBufferVisitor, ArrayChildVisitor};
+use crate::{ArrayBufferVisitor, ArrayChildVisitor, EmptyMetadata};
 
 impl VisitorVTable<ChunkedVTable> for ChunkedVTable {
+    fn metadata(_array: &ChunkedArray) -> EmptyMetadata {
+        EmptyMetadata
+    }
+
     fn visit_buffers(_array: &ChunkedArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(array: &ChunkedArray, visitor: &mut dyn ArrayChildVisitor) {

--- a/vortex-array/src/arrays/constant/vtable/mod.rs
+++ b/vortex-array/src/arrays/constant/vtable/mod.rs
@@ -22,6 +22,7 @@ pub struct ConstantEncoding;
 impl VTable for ConstantVTable {
     type Array = ConstantArray;
     type Encoding = ConstantEncoding;
+    type Metadata = crate::EmptyMetadata;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/vortex-array/src/arrays/constant/vtable/serde.rs
+++ b/vortex-array/src/arrays/constant/vtable/serde.rs
@@ -6,23 +6,16 @@ use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_bail};
 use vortex_scalar::{Scalar, ScalarValue};
 
-use crate::EmptyMetadata;
 use crate::arrays::{ConstantArray, ConstantEncoding, ConstantVTable};
 use crate::serde::ArrayChildren;
-use crate::vtable::SerdeVTable;
+use crate::vtable::{SerdeVTable, VTable};
 
 impl SerdeVTable<ConstantVTable> for ConstantVTable {
-    type Metadata = EmptyMetadata;
-
-    fn metadata(_array: &ConstantArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(EmptyMetadata))
-    }
-
     fn build(
         _encoding: &ConstantEncoding,
         dtype: &DType,
         len: usize,
-        _metadata: &Self::Metadata,
+        _metadata: &<ConstantVTable as VTable>::Metadata,
         buffers: &[ByteBuffer],
         _children: &dyn ArrayChildren,
     ) -> VortexResult<ConstantArray> {

--- a/vortex-array/src/arrays/constant/vtable/visitor.rs
+++ b/vortex-array/src/arrays/constant/vtable/visitor.rs
@@ -5,9 +5,13 @@ use vortex_buffer::ByteBufferMut;
 
 use crate::arrays::{ConstantArray, ConstantVTable};
 use crate::vtable::VisitorVTable;
-use crate::{ArrayBufferVisitor, ArrayChildVisitor};
+use crate::{ArrayBufferVisitor, ArrayChildVisitor, EmptyMetadata};
 
 impl VisitorVTable<ConstantVTable> for ConstantVTable {
+    fn metadata(_array: &ConstantArray) -> EmptyMetadata {
+        EmptyMetadata
+    }
+
     fn visit_buffers(array: &ConstantArray, visitor: &mut dyn ArrayBufferVisitor) {
         let buffer = array
             .scalar

--- a/vortex-array/src/arrays/decimal/vtable/mod.rs
+++ b/vortex-array/src/arrays/decimal/vtable/mod.rs
@@ -17,6 +17,7 @@ vtable!(Decimal);
 impl VTable for DecimalVTable {
     type Array = DecimalArray;
     type Encoding = DecimalEncoding;
+    type Metadata = crate::ProstMetadata<serde::DecimalMetadata>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/vortex-array/src/arrays/decimal/vtable/serde.rs
+++ b/vortex-array/src/arrays/decimal/vtable/serde.rs
@@ -9,11 +9,10 @@ use vortex_error::{VortexResult, vortex_bail, vortex_ensure};
 use vortex_scalar::{DecimalValueType, NativeDecimalType, match_each_decimal_value_type};
 
 use super::{DecimalArray, DecimalEncoding};
-use crate::ProstMetadata;
 use crate::arrays::DecimalVTable;
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable::SerdeVTable;
+use crate::vtable::{SerdeVTable, VTable};
 
 // The type of the values can be determined by looking at the type info...right?
 #[derive(prost::Message)]
@@ -23,19 +22,11 @@ pub struct DecimalMetadata {
 }
 
 impl SerdeVTable<DecimalVTable> for DecimalVTable {
-    type Metadata = ProstMetadata<DecimalMetadata>;
-
-    fn metadata(array: &DecimalArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(ProstMetadata(DecimalMetadata {
-            values_type: array.values_type() as i32,
-        })))
-    }
-
     fn build(
         _encoding: &DecimalEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &DecimalMetadata,
+        metadata: &<<DecimalVTable as VTable>::Metadata as crate::DeserializeMetadata>::Output,
         buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<DecimalArray> {

--- a/vortex-array/src/arrays/decimal/vtable/visitor.rs
+++ b/vortex-array/src/arrays/decimal/vtable/visitor.rs
@@ -1,11 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use super::serde::DecimalMetadata;
 use crate::arrays::{DecimalArray, DecimalVTable};
-use crate::vtable::{ValidityHelper, VisitorVTable};
-use crate::{ArrayBufferVisitor, ArrayChildVisitor};
+use crate::vtable::{VTable, ValidityHelper, VisitorVTable};
+use crate::{ArrayBufferVisitor, ArrayChildVisitor, ProstMetadata};
 
 impl VisitorVTable<DecimalVTable> for DecimalVTable {
+    fn metadata(array: &DecimalArray) -> <DecimalVTable as VTable>::Metadata {
+        ProstMetadata(DecimalMetadata {
+            values_type: array.values_type() as i32,
+        })
+    }
+
     fn visit_buffers(array: &DecimalArray, visitor: &mut dyn ArrayBufferVisitor) {
         visitor.visit_buffer(&array.values);
     }

--- a/vortex-array/src/arrays/extension/vtable/mod.rs
+++ b/vortex-array/src/arrays/extension/vtable/mod.rs
@@ -17,6 +17,7 @@ vtable!(Extension);
 impl VTable for ExtensionVTable {
     type Array = ExtensionArray;
     type Encoding = ExtensionEncoding;
+    type Metadata = crate::EmptyMetadata;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/vortex-array/src/arrays/extension/vtable/serde.rs
+++ b/vortex-array/src/arrays/extension/vtable/serde.rs
@@ -5,23 +5,16 @@ use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_bail};
 
-use crate::EmptyMetadata;
 use crate::arrays::extension::{ExtensionArray, ExtensionEncoding, ExtensionVTable};
 use crate::serde::ArrayChildren;
-use crate::vtable::SerdeVTable;
+use crate::vtable::{SerdeVTable, VTable};
 
 impl SerdeVTable<ExtensionVTable> for ExtensionVTable {
-    type Metadata = EmptyMetadata;
-
-    fn metadata(_array: &ExtensionArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(EmptyMetadata))
-    }
-
     fn build(
         _encoding: &ExtensionEncoding,
         dtype: &DType,
         len: usize,
-        _metadata: &Self::Metadata,
+        _metadata: &<ExtensionVTable as VTable>::Metadata,
         _buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ExtensionArray> {

--- a/vortex-array/src/arrays/extension/vtable/visitor.rs
+++ b/vortex-array/src/arrays/extension/vtable/visitor.rs
@@ -3,9 +3,13 @@
 
 use crate::arrays::extension::{ExtensionArray, ExtensionVTable};
 use crate::vtable::VisitorVTable;
-use crate::{ArrayBufferVisitor, ArrayChildVisitor};
+use crate::{ArrayBufferVisitor, ArrayChildVisitor, EmptyMetadata};
 
 impl VisitorVTable<ExtensionVTable> for ExtensionVTable {
+    fn metadata(_array: &ExtensionArray) -> EmptyMetadata {
+        EmptyMetadata
+    }
+
     fn visit_buffers(_array: &ExtensionArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(array: &ExtensionArray, visitor: &mut dyn ArrayChildVisitor) {

--- a/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
@@ -20,6 +20,7 @@ pub struct FixedSizeListEncoding;
 impl VTable for FixedSizeListVTable {
     type Array = FixedSizeListArray;
     type Encoding = FixedSizeListEncoding;
+    type Metadata = crate::EmptyMetadata;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/vortex-array/src/arrays/fixed_size_list/vtable/serde.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/serde.rs
@@ -6,19 +6,12 @@ use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_bail, vortex_ensure};
 
 use super::{FixedSizeListArray, FixedSizeListVTable};
-use crate::EmptyMetadata;
 use crate::arrays::FixedSizeListEncoding;
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable::SerdeVTable;
+use crate::vtable::{SerdeVTable, VTable};
 
 impl SerdeVTable<FixedSizeListVTable> for FixedSizeListVTable {
-    type Metadata = EmptyMetadata;
-
-    fn metadata(_array: &FixedSizeListArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(EmptyMetadata))
-    }
-
     /// Builds a [`FixedSizeListArray`].
     ///
     /// This method expects 1 or 2 children (a second child indicates a validity array).
@@ -26,7 +19,7 @@ impl SerdeVTable<FixedSizeListVTable> for FixedSizeListVTable {
         _encoding: &FixedSizeListEncoding,
         dtype: &DType,
         len: usize,
-        _metadata: &EmptyMetadata,
+        _metadata: &<FixedSizeListVTable as VTable>::Metadata,
         buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<FixedSizeListArray> {

--- a/vortex-array/src/arrays/fixed_size_list/vtable/visitor.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/visitor.rs
@@ -3,9 +3,13 @@
 
 use crate::arrays::{FixedSizeListArray, FixedSizeListVTable};
 use crate::vtable::{ValidityHelper, VisitorVTable};
-use crate::{ArrayBufferVisitor, ArrayChildVisitor};
+use crate::{ArrayBufferVisitor, ArrayChildVisitor, EmptyMetadata};
 
 impl VisitorVTable<FixedSizeListVTable> for FixedSizeListVTable {
+    fn metadata(_array: &FixedSizeListArray) -> EmptyMetadata {
+        EmptyMetadata
+    }
+
     fn visit_buffers(_array: &FixedSizeListArray, _visitor: &mut dyn ArrayBufferVisitor) {
         // `FixedSizeListArray` has no byte buffers.
     }

--- a/vortex-array/src/arrays/list/vtable/mod.rs
+++ b/vortex-array/src/arrays/list/vtable/mod.rs
@@ -17,6 +17,7 @@ vtable!(List);
 impl VTable for ListVTable {
     type Array = ListArray;
     type Encoding = ListEncoding;
+    type Metadata = crate::ProstMetadata<serde::ListMetadata>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/vortex-array/src/arrays/list/vtable/serde.rs
+++ b/vortex-array/src/arrays/list/vtable/serde.rs
@@ -6,35 +6,25 @@ use vortex_dtype::{DType, Nullability, PType};
 use vortex_error::{VortexResult, vortex_bail};
 
 use super::ListArray;
-use crate::ProstMetadata;
 use crate::arrays::{ListEncoding, ListVTable};
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable::SerdeVTable;
+use crate::vtable::{SerdeVTable, VTable};
 
 #[derive(Clone, prost::Message)]
 pub struct ListMetadata {
     #[prost(uint64, tag = "1")]
-    elements_len: u64,
+    pub(super) elements_len: u64,
     #[prost(enumeration = "PType", tag = "2")]
-    offset_ptype: i32,
+    pub(super) offset_ptype: i32,
 }
 
 impl SerdeVTable<ListVTable> for ListVTable {
-    type Metadata = ProstMetadata<ListMetadata>;
-
-    fn metadata(array: &ListArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(ProstMetadata(ListMetadata {
-            elements_len: array.elements().len() as u64,
-            offset_ptype: PType::try_from(array.offsets().dtype())? as i32,
-        })))
-    }
-
     fn build(
         _encoding: &ListEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &ListMetadata,
+        metadata: &<<ListVTable as VTable>::Metadata as crate::DeserializeMetadata>::Output,
         _buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ListArray> {

--- a/vortex-array/src/arrays/list/vtable/visitor.rs
+++ b/vortex-array/src/arrays/list/vtable/visitor.rs
@@ -1,11 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_dtype::PType;
+
+use super::serde::ListMetadata;
 use crate::arrays::{ListArray, ListVTable};
-use crate::vtable::{ValidityHelper, VisitorVTable};
-use crate::{ArrayBufferVisitor, ArrayChildVisitor};
+use crate::vtable::{VTable, ValidityHelper, VisitorVTable};
+use crate::{ArrayBufferVisitor, ArrayChildVisitor, ProstMetadata};
 
 impl VisitorVTable<ListVTable> for ListVTable {
+    fn metadata(array: &ListArray) -> <ListVTable as VTable>::Metadata {
+        ProstMetadata(ListMetadata {
+            elements_len: array.elements().len() as u64,
+            offset_ptype: PType::try_from(array.offsets().dtype())
+                .expect("Invalid PType for offsets") as i32,
+        })
+    }
+
     fn visit_buffers(_array: &ListArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(array: &ListArray, visitor: &mut dyn ArrayChildVisitor) {

--- a/vortex-array/src/arrays/list/vtable/visitor.rs
+++ b/vortex-array/src/arrays/list/vtable/visitor.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_dtype::PType;
-
 use super::serde::ListMetadata;
 use crate::arrays::{ListArray, ListVTable};
 use crate::vtable::{VTable, ValidityHelper, VisitorVTable};
@@ -12,8 +10,7 @@ impl VisitorVTable<ListVTable> for ListVTable {
     fn metadata(array: &ListArray) -> <ListVTable as VTable>::Metadata {
         ProstMetadata(ListMetadata {
             elements_len: array.elements().len() as u64,
-            offset_ptype: PType::try_from(array.offsets().dtype())
-                .expect("Invalid PType for offsets") as i32,
+            offset_ptype: array.offsets().dtype().as_ptype() as i32,
         })
     }
 

--- a/vortex-array/src/arrays/listview/vtable/mod.rs
+++ b/vortex-array/src/arrays/listview/vtable/mod.rs
@@ -20,6 +20,7 @@ pub struct ListViewEncoding;
 impl VTable for ListViewVTable {
     type Array = ListViewArray;
     type Encoding = ListViewEncoding;
+    type Metadata = crate::ProstMetadata<serde::ListViewMetadata>;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/vortex-array/src/arrays/listview/vtable/serde.rs
+++ b/vortex-array/src/arrays/listview/vtable/serde.rs
@@ -9,7 +9,6 @@ use crate::arrays::{ListViewArray, ListViewEncoding, ListViewVTable};
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
 use crate::vtable::SerdeVTable;
-use crate::{Array, ProstMetadata};
 
 #[derive(Clone, prost::Message)]
 pub struct ListViewMetadata {

--- a/vortex-array/src/arrays/listview/vtable/serde.rs
+++ b/vortex-array/src/arrays/listview/vtable/serde.rs
@@ -14,29 +14,19 @@ use crate::{Array, ProstMetadata};
 #[derive(Clone, prost::Message)]
 pub struct ListViewMetadata {
     #[prost(uint64, tag = "1")]
-    elements_len: u64,
+    pub(super) elements_len: u64,
     #[prost(enumeration = "PType", tag = "2")]
-    offset_ptype: i32,
+    pub(super) offset_ptype: i32,
     #[prost(enumeration = "PType", tag = "3")]
-    size_ptype: i32,
+    pub(super) size_ptype: i32,
 }
 
 impl SerdeVTable<ListViewVTable> for ListViewVTable {
-    type Metadata = ProstMetadata<ListViewMetadata>;
-
-    fn metadata(array: &ListViewArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(ProstMetadata(ListViewMetadata {
-            elements_len: array.elements().len() as u64,
-            offset_ptype: PType::try_from(array.offsets().dtype())? as i32,
-            size_ptype: PType::try_from(array.sizes().dtype())? as i32,
-        })))
-    }
-
     fn build(
         _encoding: &ListViewEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &ListViewMetadata,
+        metadata: &<<ListViewVTable as crate::vtable::VTable>::Metadata as crate::DeserializeMetadata>::Output,
         buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ListViewArray> {

--- a/vortex-array/src/arrays/listview/vtable/visitor.rs
+++ b/vortex-array/src/arrays/listview/vtable/visitor.rs
@@ -1,11 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_dtype::PType;
+
+use super::serde::ListViewMetadata;
 use crate::arrays::{ListViewArray, ListViewVTable};
-use crate::vtable::{ValidityHelper, VisitorVTable};
-use crate::{ArrayBufferVisitor, ArrayChildVisitor};
+use crate::vtable::{VTable, ValidityHelper, VisitorVTable};
+use crate::{ArrayBufferVisitor, ArrayChildVisitor, ProstMetadata};
 
 impl VisitorVTable<ListViewVTable> for ListViewVTable {
+    fn metadata(array: &ListViewArray) -> <ListViewVTable as VTable>::Metadata {
+        ProstMetadata(ListViewMetadata {
+            elements_len: array.elements().len() as u64,
+            offset_ptype: PType::try_from(array.offsets().dtype())
+                .expect("Invalid PType for offsets") as i32,
+            size_ptype: PType::try_from(array.sizes().dtype()).expect("Invalid PType for sizes")
+                as i32,
+        })
+    }
+
     fn visit_buffers(_array: &ListViewArray, _visitor: &mut dyn ArrayBufferVisitor) {
         // ListView has no byte buffers.
     }

--- a/vortex-array/src/arrays/listview/vtable/visitor.rs
+++ b/vortex-array/src/arrays/listview/vtable/visitor.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_dtype::PType;
-
 use super::serde::ListViewMetadata;
 use crate::arrays::{ListViewArray, ListViewVTable};
 use crate::vtable::{VTable, ValidityHelper, VisitorVTable};
@@ -12,10 +10,8 @@ impl VisitorVTable<ListViewVTable> for ListViewVTable {
     fn metadata(array: &ListViewArray) -> <ListViewVTable as VTable>::Metadata {
         ProstMetadata(ListViewMetadata {
             elements_len: array.elements().len() as u64,
-            offset_ptype: PType::try_from(array.offsets().dtype())
-                .expect("Invalid PType for offsets") as i32,
-            size_ptype: PType::try_from(array.sizes().dtype()).expect("Invalid PType for sizes")
-                as i32,
+            offset_ptype: array.offsets().dtype().as_ptype() as i32,
+            size_ptype: array.sizes().dtype().as_ptype() as i32,
         })
     }
 

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -19,6 +19,7 @@ pub struct MaskedEncoding;
 impl VTable for MaskedVTable {
     type Array = MaskedArray;
     type Encoding = MaskedEncoding;
+    type Metadata = crate::EmptyMetadata;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/vortex-array/src/arrays/masked/vtable/serde.rs
+++ b/vortex-array/src/arrays/masked/vtable/serde.rs
@@ -8,21 +8,15 @@ use vortex_error::{VortexResult, vortex_bail};
 use crate::arrays::{MaskedArray, MaskedEncoding, MaskedVTable};
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable::{SerdeVTable, VisitorVTable};
+use crate::vtable::{SerdeVTable, VTable, VisitorVTable};
 use crate::{ArrayBufferVisitor, ArrayChildVisitor, EmptyMetadata};
 
 impl SerdeVTable<MaskedVTable> for MaskedVTable {
-    type Metadata = EmptyMetadata;
-
-    fn metadata(_array: &MaskedArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(EmptyMetadata))
-    }
-
     fn build(
         _encoding: &MaskedEncoding,
         dtype: &DType,
         len: usize,
-        _metadata: &Self::Metadata,
+        _metadata: &<MaskedVTable as VTable>::Metadata,
         buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<MaskedArray> {
@@ -49,6 +43,10 @@ impl SerdeVTable<MaskedVTable> for MaskedVTable {
 }
 
 impl VisitorVTable<MaskedVTable> for MaskedVTable {
+    fn metadata(_array: &MaskedArray) -> EmptyMetadata {
+        EmptyMetadata
+    }
+
     fn visit_buffers(_array: &MaskedArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(array: &MaskedArray, visitor: &mut dyn ArrayChildVisitor) {

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -27,6 +27,7 @@ vtable!(Null);
 impl VTable for NullVTable {
     type Array = NullArray;
     type Encoding = NullEncoding;
+    type Metadata = EmptyMetadata;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;
@@ -104,17 +105,11 @@ impl ArrayVTable<NullVTable> for NullVTable {
 }
 
 impl SerdeVTable<NullVTable> for NullVTable {
-    type Metadata = EmptyMetadata;
-
-    fn metadata(_array: &NullArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(EmptyMetadata))
-    }
-
     fn build(
         _encoding: &NullEncoding,
         _dtype: &DType,
         len: usize,
-        _metadata: &Self::Metadata,
+        _metadata: &<NullVTable as VTable>::Metadata,
         _buffers: &[ByteBuffer],
         _children: &dyn ArrayChildren,
     ) -> VortexResult<NullArray> {
@@ -123,6 +118,10 @@ impl SerdeVTable<NullVTable> for NullVTable {
 }
 
 impl VisitorVTable<NullVTable> for NullVTable {
+    fn metadata(_array: &NullArray) -> EmptyMetadata {
+        EmptyMetadata
+    }
+
     fn visit_buffers(_array: &NullArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(_array: &NullArray, _visitor: &mut dyn ArrayChildVisitor) {}

--- a/vortex-array/src/arrays/primitive/vtable/mod.rs
+++ b/vortex-array/src/arrays/primitive/vtable/mod.rs
@@ -18,6 +18,7 @@ vtable!(Primitive);
 impl VTable for PrimitiveVTable {
     type Array = PrimitiveArray;
     type Encoding = PrimitiveEncoding;
+    type Metadata = crate::EmptyMetadata;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/vortex-array/src/arrays/primitive/vtable/serde.rs
+++ b/vortex-array/src/arrays/primitive/vtable/serde.rs
@@ -6,24 +6,17 @@ use vortex_dtype::{DType, PType, match_each_native_ptype};
 use vortex_error::{VortexResult, vortex_bail};
 
 use super::PrimitiveArray;
-use crate::EmptyMetadata;
 use crate::arrays::{PrimitiveEncoding, PrimitiveVTable};
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable::SerdeVTable;
+use crate::vtable::{SerdeVTable, VTable};
 
 impl SerdeVTable<PrimitiveVTable> for PrimitiveVTable {
-    type Metadata = EmptyMetadata;
-
-    fn metadata(_array: &PrimitiveArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(EmptyMetadata))
-    }
-
     fn build(
         _encoding: &PrimitiveEncoding,
         dtype: &DType,
         len: usize,
-        _metadata: &Self::Metadata,
+        _metadata: &<PrimitiveVTable as VTable>::Metadata,
         buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<PrimitiveArray> {

--- a/vortex-array/src/arrays/primitive/vtable/visitor.rs
+++ b/vortex-array/src/arrays/primitive/vtable/visitor.rs
@@ -3,9 +3,13 @@
 
 use crate::arrays::{PrimitiveArray, PrimitiveVTable};
 use crate::vtable::{ValidityHelper, VisitorVTable};
-use crate::{ArrayBufferVisitor, ArrayChildVisitor};
+use crate::{ArrayBufferVisitor, ArrayChildVisitor, EmptyMetadata};
 
 impl VisitorVTable<PrimitiveVTable> for PrimitiveVTable {
+    fn metadata(_array: &PrimitiveArray) -> EmptyMetadata {
+        EmptyMetadata
+    }
+
     fn visit_buffers(array: &PrimitiveArray, visitor: &mut dyn ArrayBufferVisitor) {
         visitor.visit_buffer(array.byte_buffer());
     }

--- a/vortex-array/src/arrays/struct_/vtable/mod.rs
+++ b/vortex-array/src/arrays/struct_/vtable/mod.rs
@@ -18,6 +18,7 @@ vtable!(Struct);
 impl VTable for StructVTable {
     type Array = StructArray;
     type Encoding = StructEncoding;
+    type Metadata = crate::EmptyMetadata;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/vortex-array/src/arrays/struct_/vtable/serde.rs
+++ b/vortex-array/src/arrays/struct_/vtable/serde.rs
@@ -6,24 +6,17 @@ use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
 use vortex_error::{VortexExpect, VortexResult, vortex_bail};
 
-use crate::EmptyMetadata;
 use crate::arrays::struct_::{StructArray, StructEncoding, StructVTable};
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable::SerdeVTable;
+use crate::vtable::{SerdeVTable, VTable};
 
 impl SerdeVTable<StructVTable> for StructVTable {
-    type Metadata = EmptyMetadata;
-
-    fn metadata(_array: &StructArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(EmptyMetadata))
-    }
-
     fn build(
         _encoding: &StructEncoding,
         dtype: &DType,
         len: usize,
-        _metadata: &Self::Metadata,
+        _metadata: &<StructVTable as VTable>::Metadata,
         _buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<StructArray> {

--- a/vortex-array/src/arrays/struct_/vtable/visitor.rs
+++ b/vortex-array/src/arrays/struct_/vtable/visitor.rs
@@ -5,9 +5,13 @@ use itertools::Itertools;
 
 use crate::arrays::struct_::{StructArray, StructVTable};
 use crate::vtable::{ValidityHelper, VisitorVTable};
-use crate::{ArrayBufferVisitor, ArrayChildVisitor};
+use crate::{ArrayBufferVisitor, ArrayChildVisitor, EmptyMetadata};
 
 impl VisitorVTable<StructVTable> for StructVTable {
+    fn metadata(_array: &StructArray) -> EmptyMetadata {
+        EmptyMetadata
+    }
+
     fn visit_buffers(_array: &StructArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(array: &StructArray, visitor: &mut dyn ArrayChildVisitor) {

--- a/vortex-array/src/arrays/varbin/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbin/vtable/mod.rs
@@ -17,6 +17,7 @@ vtable!(VarBin);
 impl VTable for VarBinVTable {
     type Array = VarBinArray;
     type Encoding = VarBinEncoding;
+    type Metadata = crate::ProstMetadata<serde::VarBinMetadata>;
     type ArrayVTable = Self;
     type CanonicalVTable = Self;
     type OperationsVTable = Self;

--- a/vortex-array/src/arrays/varbin/vtable/serde.rs
+++ b/vortex-array/src/arrays/varbin/vtable/serde.rs
@@ -3,14 +3,13 @@
 
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::{DType, Nullability, PType};
-use vortex_error::{VortexExpect, VortexResult, vortex_bail};
+use vortex_error::{VortexResult, vortex_bail};
 
 use super::VarBinEncoding;
 use crate::arrays::{VarBinArray, VarBinVTable};
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
 use crate::vtable::SerdeVTable;
-use crate::{Array, ProstMetadata};
 
 #[derive(Clone, prost::Message)]
 pub struct VarBinMetadata {

--- a/vortex-array/src/arrays/varbin/vtable/serde.rs
+++ b/vortex-array/src/arrays/varbin/vtable/serde.rs
@@ -15,24 +15,15 @@ use crate::{Array, ProstMetadata};
 #[derive(Clone, prost::Message)]
 pub struct VarBinMetadata {
     #[prost(enumeration = "PType", tag = "1")]
-    pub(crate) offsets_ptype: i32,
+    pub(super) offsets_ptype: i32,
 }
 
 impl SerdeVTable<VarBinVTable> for VarBinVTable {
-    type Metadata = ProstMetadata<VarBinMetadata>;
-
-    fn metadata(array: &VarBinArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(ProstMetadata(VarBinMetadata {
-            offsets_ptype: PType::try_from(array.offsets().dtype())
-                .vortex_expect("Must be a valid PType") as i32,
-        })))
-    }
-
     fn build(
         _encoding: &VarBinEncoding,
         dtype: &DType,
         len: usize,
-        metadata: &VarBinMetadata,
+        metadata: &<<VarBinVTable as crate::vtable::VTable>::Metadata as crate::DeserializeMetadata>::Output,
         buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<VarBinArray> {

--- a/vortex-array/src/arrays/varbin/vtable/visitor.rs
+++ b/vortex-array/src/arrays/varbin/vtable/visitor.rs
@@ -1,11 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_dtype::PType;
+use vortex_error::VortexExpect;
+
+use super::serde::VarBinMetadata;
 use crate::arrays::{VarBinArray, VarBinVTable};
-use crate::vtable::{ValidityHelper, VisitorVTable};
-use crate::{ArrayBufferVisitor, ArrayChildVisitor};
+use crate::vtable::{VTable, ValidityHelper, VisitorVTable};
+use crate::{ArrayBufferVisitor, ArrayChildVisitor, ProstMetadata};
 
 impl VisitorVTable<VarBinVTable> for VarBinVTable {
+    fn metadata(array: &VarBinArray) -> <VarBinVTable as VTable>::Metadata {
+        ProstMetadata(VarBinMetadata {
+            offsets_ptype: PType::try_from(array.offsets().dtype())
+                .vortex_expect("Must be a valid PType") as i32,
+        })
+    }
+
     fn visit_buffers(array: &VarBinArray, visitor: &mut dyn ArrayBufferVisitor) {
         visitor.visit_buffer(array.bytes()); // TODO(ngates): sliced bytes?
     }

--- a/vortex-array/src/arrays/varbinview/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/mod.rs
@@ -17,6 +17,7 @@ vtable!(VarBinView);
 impl VTable for VarBinViewVTable {
     type Array = VarBinViewArray;
     type Encoding = VarBinViewEncoding;
+    type Metadata = crate::EmptyMetadata;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;

--- a/vortex-array/src/arrays/varbinview/vtable/serde.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/serde.rs
@@ -8,25 +8,18 @@ use vortex_dtype::DType;
 use vortex_error::{VortexExpect, VortexResult, vortex_bail};
 
 use super::VarBinViewVTable;
-use crate::EmptyMetadata;
 use crate::arrays::binary_view::BinaryView;
 use crate::arrays::{VarBinViewArray, VarBinViewEncoding};
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable::SerdeVTable;
+use crate::vtable::{SerdeVTable, VTable};
 
 impl SerdeVTable<VarBinViewVTable> for VarBinViewVTable {
-    type Metadata = EmptyMetadata;
-
-    fn metadata(_array: &VarBinViewArray) -> VortexResult<Option<Self::Metadata>> {
-        Ok(Some(EmptyMetadata))
-    }
-
     fn build(
         _encoding: &VarBinViewEncoding,
         dtype: &DType,
         len: usize,
-        _metadata: &Self::Metadata,
+        _metadata: &<VarBinViewVTable as VTable>::Metadata,
         buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<VarBinViewArray> {

--- a/vortex-array/src/arrays/varbinview/vtable/visitor.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/visitor.rs
@@ -4,9 +4,13 @@
 use super::VarBinViewVTable;
 use crate::arrays::VarBinViewArray;
 use crate::vtable::{ValidityHelper, VisitorVTable};
-use crate::{ArrayBufferVisitor, ArrayChildVisitor};
+use crate::{ArrayBufferVisitor, ArrayChildVisitor, EmptyMetadata};
 
 impl VisitorVTable<VarBinViewVTable> for VarBinViewVTable {
+    fn metadata(_array: &VarBinViewArray) -> EmptyMetadata {
+        EmptyMetadata
+    }
+
     fn visit_buffers(array: &VarBinViewArray, visitor: &mut dyn ArrayBufferVisitor) {
         for buffer in array.buffers().as_ref() {
             visitor.visit_buffer(buffer);

--- a/vortex-array/src/arrow/array.rs
+++ b/vortex-array/src/arrow/array.rs
@@ -27,6 +27,7 @@ vtable!(Arrow);
 impl VTable for ArrowVTable {
     type Array = ArrowArray;
     type Encoding = ArrowEncoding;
+    type Metadata = crate::EmptyMetadata;
     type ArrayVTable = Self;
     type CanonicalVTable = Self;
     type OperationsVTable = Self;
@@ -132,6 +133,10 @@ impl ValidityVTable<ArrowVTable> for ArrowVTable {
 }
 
 impl VisitorVTable<ArrowVTable> for ArrowVTable {
+    fn metadata(_array: &ArrowArray) -> crate::EmptyMetadata {
+        crate::EmptyMetadata
+    }
+
     fn visit_buffers(_array: &ArrowArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(_array: &ArrowArray, _visitor: &mut dyn ArrayChildVisitor) {}

--- a/vortex-array/src/encoding.rs
+++ b/vortex-array/src/encoding.rs
@@ -91,10 +91,7 @@ impl<V: VTable> Encoding for EncodingAdapter<V> {
         buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ArrayRef> {
-        let metadata =
-            <<V::SerdeVTable as SerdeVTable<V>>::Metadata as DeserializeMetadata>::deserialize(
-                metadata,
-            )?;
+        let metadata = <<V as VTable>::Metadata as DeserializeMetadata>::deserialize(metadata)?;
         let array = <V::SerdeVTable as SerdeVTable<V>>::build(
             &self.0, dtype, len, &metadata, buffers, children,
         )?;

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -266,35 +266,29 @@ impl Patches {
 
     #[inline]
     pub fn indices_ptype(&self) -> PType {
-        PType::try_from(self.indices.dtype()).vortex_expect("primitive indices")
+        self.indices.dtype().as_ptype()
     }
 
-    pub fn to_metadata(&self, len: usize, dtype: &DType) -> VortexResult<PatchesMetadata> {
-        if self.indices.len() > len {
-            vortex_bail!(
+    pub fn to_metadata(&self, array_len: usize) -> PatchesMetadata {
+        if self.indices.len() > array_len {
+            vortex_panic!(
                 "Patch indices {} are longer than the array length {}",
                 self.indices.len(),
-                len
+                array_len
             );
         }
-        if self.values.dtype() != dtype {
-            vortex_bail!(
-                "Patch values dtype {} does not match array dtype {}",
-                self.values.dtype(),
-                dtype
-            );
-        }
+
         let chunk_offsets_len = self.chunk_offsets.as_ref().map(|co| co.len());
         let chunk_offsets_ptype = self.chunk_offsets.as_ref().map(|co| co.dtype().as_ptype());
 
-        Ok(PatchesMetadata::new(
+        PatchesMetadata::new(
             self.indices.len(),
             self.offset,
             self.indices.dtype().as_ptype(),
             chunk_offsets_len,
             chunk_offsets_ptype,
             self.offset_within_chunk,
-        ))
+        )
     }
 
     pub fn cast_values(self, values_dtype: &DType) -> VortexResult<Self> {

--- a/vortex-array/src/vtable/mod.rs
+++ b/vortex-array/src/vtable/mod.rs
@@ -46,6 +46,7 @@ use crate::{Array, Encoding, EncodingId, EncodingRef, IntoArray};
 pub trait VTable: 'static + Sized + Send + Sync + Debug {
     type Array: 'static + Send + Sync + Clone + Debug + Deref<Target = dyn Array> + IntoArray;
     type Encoding: 'static + Send + Sync + Clone + Deref<Target = dyn Encoding>;
+    type Metadata: Debug + crate::SerializeMetadata + crate::DeserializeMetadata;
 
     type ArrayVTable: ArrayVTable<Self>;
     type CanonicalVTable: CanonicalVTable<Self>;

--- a/vortex-array/src/vtable/serde.rs
+++ b/vortex-array/src/vtable/serde.rs
@@ -15,17 +15,6 @@ use crate::{DeserializeMetadata, EmptyMetadata, SerializeMetadata};
 ///
 /// # Guarantees
 pub trait SerdeVTable<V: VTable> {
-    type Metadata: Debug + SerializeMetadata + DeserializeMetadata;
-
-    /// Exports metadata for an array.
-    ///
-    /// All other parts of the array are exported using the [`crate::vtable::VisitorVTable`].
-    ///
-    /// * If the array does not require serialized metadata, it should return
-    ///   [`crate::metadata::EmptyMetadata`].
-    /// * If the array does not support serialization, it should return `None`.
-    fn metadata(array: &V::Array) -> VortexResult<Option<Self::Metadata>>;
-
     /// Build an array from components.
     ///
     /// This is called on the file and IPC deserialization pathways, to reconstruct the array from
@@ -61,24 +50,18 @@ pub trait SerdeVTable<V: VTable> {
         encoding: &V::Encoding,
         dtype: &DType,
         len: usize,
-        metadata: &<Self::Metadata as DeserializeMetadata>::Output,
+        metadata: &<V::Metadata as DeserializeMetadata>::Output,
         buffers: &[ByteBuffer],
         children: &dyn ArrayChildren,
     ) -> VortexResult<V::Array>;
 }
 
 impl<V: VTable> SerdeVTable<V> for NotSupported {
-    type Metadata = EmptyMetadata;
-
-    fn metadata(_array: &V::Array) -> VortexResult<Option<Self::Metadata>> {
-        Ok(None)
-    }
-
     fn build(
         encoding: &V::Encoding,
         _dtype: &DType,
         _len: usize,
-        _metadata: &Self::Metadata,
+        _metadata: &<V::Metadata as DeserializeMetadata>::Output,
         _buffers: &[ByteBuffer],
         _children: &dyn ArrayChildren,
     ) -> VortexResult<V::Array> {

--- a/vortex-array/src/vtable/serde.rs
+++ b/vortex-array/src/vtable/serde.rs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::fmt::Debug;
-
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
 use vortex_error::{VortexResult, vortex_bail};
 
+use crate::DeserializeMetadata;
 use crate::serde::ArrayChildren;
 use crate::vtable::{NotSupported, VTable};
-use crate::{DeserializeMetadata, EmptyMetadata, SerializeMetadata};
 
 /// VTable trait for building an array from its serialized components.
 ///

--- a/vortex-array/src/vtable/visitor.rs
+++ b/vortex-array/src/vtable/visitor.rs
@@ -7,6 +7,11 @@ use crate::vtable::VTable;
 use crate::{Array, ArrayBufferVisitor, ArrayChildVisitor};
 
 pub trait VisitorVTable<V: VTable> {
+    /// Exports metadata for an array.
+    ///
+    /// If the array does not have any metadata, it can return [`crate::metadata::EmptyMetadata`].
+    fn metadata(array: &V::Array) -> V::Metadata;
+
     /// Visit the buffers of the array.
     fn visit_buffers(array: &V::Array, visitor: &mut dyn ArrayBufferVisitor);
 

--- a/vortex-python/src/arrays/py/vtable.rs
+++ b/vortex-python/src/arrays/py/vtable.rs
@@ -5,11 +5,11 @@ use std::ops::Range;
 
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
-use pyo3::{Python, intern};
+use pyo3::Python;
 use vortex::buffer::ByteBuffer;
 use vortex::compute::{ComputeFn, InvocationArgs, Output};
 use vortex::dtype::DType;
-use vortex::error::{VortexResult, vortex_err};
+use vortex::error::{VortexExpect, VortexResult};
 use vortex::mask::Mask;
 use vortex::scalar::Scalar;
 use vortex::serde::ArrayChildren;
@@ -19,8 +19,8 @@ use vortex::vtable::{
     SerdeVTable, VTable, ValidityVTable, VisitorVTable,
 };
 use vortex::{
-    ArrayBufferVisitor, ArrayChildVisitor, ArrayRef, Canonical, DeserializeMetadata, EncodingId,
-    EncodingRef, RawMetadata, vtable,
+    vtable, ArrayBufferVisitor, ArrayChildVisitor, ArrayRef, Canonical, DeserializeMetadata,
+    EncodingId, EncodingRef, RawMetadata,
 };
 
 use crate::arrays::py::{PythonArray, PythonEncoding};
@@ -30,6 +30,7 @@ vtable!(Python);
 impl VTable for PythonVTable {
     type Array = PythonArray;
     type Encoding = PythonEncoding;
+    type Metadata = RawMetadata;
 
     type ArrayVTable = Self;
     type CanonicalVTable = Self;
@@ -99,6 +100,25 @@ impl ValidityVTable<PythonVTable> for PythonVTable {
 }
 
 impl VisitorVTable<PythonVTable> for PythonVTable {
+    fn metadata(array: &PythonArray) -> <PythonVTable as VTable>::Metadata {
+        // TODO(ngates): metadata should be extracted in the constructor and stored in the array
+        // so it can be returned here without error. For now we use expect which will panic
+        // if the Python call fails.
+        Python::attach(|py| {
+            let obj = array.object.bind(py);
+
+            let bytes = obj
+                .call_method("__vx_metadata__", (), None)
+                .vortex_expect("Failed to call __vx_metadata__")
+                .downcast::<PyBytes>()
+                .vortex_expect("Expected array metadata to be Python bytes")
+                .as_bytes()
+                .to_vec();
+
+            RawMetadata(bytes)
+        })
+    }
+
     fn visit_buffers(_array: &PythonArray, _visitor: &mut dyn ArrayBufferVisitor) {
         todo!()
     }
@@ -129,32 +149,11 @@ impl EncodeVTable<PythonVTable> for PythonVTable {
 }
 
 impl SerdeVTable<PythonVTable> for PythonVTable {
-    type Metadata = RawMetadata;
-
-    fn metadata(array: &PythonArray) -> VortexResult<Option<Self::Metadata>> {
-        Python::attach(|py| {
-            let obj = array.object.bind(py);
-            if !obj.hasattr(intern!(py, "metadata"))? {
-                // The class does not have a metadata attribute so does not support serialization.
-                return Ok(None);
-            }
-
-            let bytes = obj
-                .call_method("__vx_metadata__", (), None)?
-                .downcast::<PyBytes>()
-                .map_err(|_| vortex_err!("Expected array metadata to be Python bytes"))?
-                .as_bytes()
-                .to_vec();
-
-            Ok(Some(RawMetadata(bytes)))
-        })
-    }
-
     fn build(
         _encoding: &PythonEncoding,
         _dtype: &DType,
         _len: usize,
-        _metadata: &<Self::Metadata as DeserializeMetadata>::Output,
+        _metadata: &<<PythonVTable as VTable>::Metadata as DeserializeMetadata>::Output,
         _buffers: &[ByteBuffer],
         _children: &dyn ArrayChildren,
     ) -> VortexResult<PythonArray> {

--- a/vortex-python/src/arrays/py/vtable.rs
+++ b/vortex-python/src/arrays/py/vtable.rs
@@ -3,13 +3,13 @@
 
 use std::ops::Range;
 
+use pyo3::Python;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
-use pyo3::Python;
 use vortex::buffer::ByteBuffer;
 use vortex::compute::{ComputeFn, InvocationArgs, Output};
 use vortex::dtype::DType;
-use vortex::error::{VortexExpect, VortexResult};
+use vortex::error::{VortexExpect, VortexResult, vortex_err};
 use vortex::mask::Mask;
 use vortex::scalar::Scalar;
 use vortex::serde::ArrayChildren;
@@ -19,8 +19,8 @@ use vortex::vtable::{
     SerdeVTable, VTable, ValidityVTable, VisitorVTable,
 };
 use vortex::{
-    vtable, ArrayBufferVisitor, ArrayChildVisitor, ArrayRef, Canonical, DeserializeMetadata,
-    EncodingId, EncodingRef, RawMetadata,
+    ArrayBufferVisitor, ArrayChildVisitor, ArrayRef, Canonical, DeserializeMetadata, EncodingId,
+    EncodingRef, RawMetadata, vtable,
 };
 
 use crate::arrays::py::{PythonArray, PythonEncoding};
@@ -109,9 +109,16 @@ impl VisitorVTable<PythonVTable> for PythonVTable {
 
             let bytes = obj
                 .call_method("__vx_metadata__", (), None)
-                .vortex_expect("Failed to call __vx_metadata__")
+                .map_err(|e| vortex_err!("Failed to get metadata from Python array: {}", e))
+                .vortex_expect("Failed to get metadata from Python array")
                 .downcast::<PyBytes>()
-                .vortex_expect("Expected array metadata to be Python bytes")
+                .map_err(|e| {
+                    vortex_err!(
+                        "Expected bytes from __vx_metadata__, got different type: {}",
+                        e
+                    )
+                })
+                .vortex_expect("Failed to get metadata from Python array")
                 .as_bytes()
                 .to_vec();
 


### PR DESCRIPTION
As part of #4492 - makes array metadata mandatory.

Next step is to rename EncodeVTable to EncodingVTable, and move SerdeVTable::build to EncodingVTable (in effect, making serde mandatory)