### PR TITLE
change gharchive query to reduce memory blowup, disable Delta

### DIFF
--- a/bench-vortex/src/realnest/gharchive.rs
+++ b/bench-vortex/src/realnest/gharchive.rs
@@ -34,7 +34,7 @@ fn raw_json_url(hour: usize) -> String {
 }
 
 const QUERIES: &[&str] = &[
-    "select * from events where payload.ref = 'refs/heads/main'",
+    "select count(*) from events where payload.ref = 'refs/heads/main'",
     "select distinct repo.name from events where repo.name like 'spiraldb/%'",
     "select distinct org.id as org_id from events order by org_id limit 100",
     "select actor.login, count() as freq from events group by actor.login order by freq desc limit 10",
@@ -253,5 +253,6 @@ pub async fn register_table(
         .await?;
     let listing_table = Arc::new(ListingTable::try_new(config)?);
     session.register_table("events", listing_table)?;
+    info!("finished registering table for GHARCHIVE: {base_url}");
     Ok(())
 }

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -765,9 +765,7 @@ mod tests {
     use vortex_sparse::SparseEncoding;
     use vortex_utils::aliases::hash_set::HashSet;
 
-    use crate::integer::{
-        IntCompressor, IntegerStats, RLE_INTEGER_SCHEME, SequenceScheme, SparseScheme,
-    };
+    use crate::integer::{IntCompressor, IntegerStats, SequenceScheme, SparseScheme};
     use crate::{Compressor, CompressorStats, Scheme};
 
     #[test]
@@ -881,19 +879,19 @@ mod tests {
         assert_eq!(decoded.as_slice::<i32>(), values.as_slice());
     }
 
-    #[test]
-    fn test_rle_compression() {
-        let mut values = Vec::new();
-        values.extend(iter::repeat_n(42i32, 100));
-        values.extend(iter::repeat_n(123i32, 200));
-        values.extend(iter::repeat_n(987i32, 150));
+    //#[test]
+    //fn test_rle_compression() {
+    //    let mut values = Vec::new();
+    //    values.extend(iter::repeat_n(42i32, 100));
+    //    values.extend(iter::repeat_n(123i32, 200));
+    //    values.extend(iter::repeat_n(987i32, 150));
 
-        let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
-        let compressed = RLE_INTEGER_SCHEME
-            .compress(&IntegerStats::generate(&array), false, 3, &[])
-            .unwrap();
+    //    let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
+    //    let compressed = RLE_INTEGER_SCHEME
+    //        .compress(&IntegerStats::generate(&array), false, 3, &[])
+    //        .unwrap();
 
-        let decoded = compressed.to_primitive();
-        assert_eq!(decoded.as_slice::<i32>(), values.as_slice());
-    }
+    //    let decoded = compressed.to_primitive();
+    //    assert_eq!(decoded.as_slice::<i32>(), values.as_slice());
+    //}
 }

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -749,8 +749,6 @@ impl Scheme for SequenceScheme {
 
 #[cfg(test)]
 mod tests {
-    use std::iter;
-
     use itertools::Itertools;
     use log::LevelFilter;
     use rand::rngs::StdRng;

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -749,6 +749,8 @@ impl Scheme for SequenceScheme {
 
 #[cfg(test)]
 mod tests {
+    use std::iter;
+
     use itertools::Itertools;
     use log::LevelFilter;
     use rand::rngs::StdRng;
@@ -763,7 +765,9 @@ mod tests {
     use vortex_sparse::SparseEncoding;
     use vortex_utils::aliases::hash_set::HashSet;
 
-    use crate::integer::{IntCompressor, IntegerStats, SequenceScheme, SparseScheme};
+    use crate::integer::{
+        IntCompressor, IntegerStats, RLE_INTEGER_SCHEME, SequenceScheme, SparseScheme,
+    };
     use crate::{Compressor, CompressorStats, Scheme};
 
     #[test]
@@ -877,19 +881,19 @@ mod tests {
         assert_eq!(decoded.as_slice::<i32>(), values.as_slice());
     }
 
-    //#[test]
-    //fn test_rle_compression() {
-    //    let mut values = Vec::new();
-    //    values.extend(iter::repeat_n(42i32, 100));
-    //    values.extend(iter::repeat_n(123i32, 200));
-    //    values.extend(iter::repeat_n(987i32, 150));
+    #[test]
+    fn test_rle_compression() {
+        let mut values = Vec::new();
+        values.extend(iter::repeat_n(42i32, 100));
+        values.extend(iter::repeat_n(123i32, 200));
+        values.extend(iter::repeat_n(987i32, 150));
 
-    //    let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
-    //    let compressed = RLE_INTEGER_SCHEME
-    //        .compress(&IntegerStats::generate(&array), false, 3, &[])
-    //        .unwrap();
+        let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
+        let compressed = RLE_INTEGER_SCHEME
+            .compress(&IntegerStats::generate(&array), false, 3, &[])
+            .unwrap();
 
-    //    let decoded = compressed.to_primitive();
-    //    assert_eq!(decoded.as_slice::<i32>(), values.as_slice());
-    //}
+        let decoded = compressed.to_primitive();
+        assert_eq!(decoded.as_slice::<i32>(), values.as_slice());
+    }
 }

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -23,7 +23,7 @@ use vortex_zigzag::{ZigZagArray, zigzag_encode};
 
 use crate::integer::dictionary::dictionary_encode;
 use crate::patches::compress_patches;
-use crate::rle::RLEScheme;
+//use crate::rle::RLEScheme;
 use crate::{
     Compressor, CompressorStats, GenerateStatsOptions, Scheme,
     estimate_compression_ratio_with_sampling,
@@ -47,7 +47,7 @@ impl Compressor for IntCompressor {
             &DictScheme,
             &RunEndScheme,
             &SequenceScheme,
-            &RLE_INTEGER_SCHEME,
+            // &RLE_INTEGER_SCHEME,
         ]
     }
 
@@ -103,7 +103,7 @@ const SPARSE_SCHEME: IntCode = IntCode(5);
 const DICT_SCHEME: IntCode = IntCode(6);
 const RUN_END_SCHEME: IntCode = IntCode(7);
 const SEQUENCE_SCHEME: IntCode = IntCode(8);
-const RUN_LENGTH_SCHEME: IntCode = IntCode(9);
+//const RUN_LENGTH_SCHEME: IntCode = IntCode(9);
 
 #[derive(Debug, Copy, Clone)]
 pub struct UncompressedScheme;
@@ -135,12 +135,12 @@ pub struct SequenceScheme;
 /// Threshold for the average run length in an array before we consider run-end encoding.
 const RUN_END_THRESHOLD: u32 = 4;
 
-pub const RLE_INTEGER_SCHEME: RLEScheme<IntegerStats, IntCode> = RLEScheme::new(
-    RUN_LENGTH_SCHEME,
-    |values, is_sample, allowed_cascading, excludes| {
-        IntCompressor::compress_no_dict(values, is_sample, allowed_cascading, excludes)
-    },
-);
+//pub const RLE_INTEGER_SCHEME: RLEScheme<IntegerStats, IntCode> = RLEScheme::new(
+//    RUN_LENGTH_SCHEME,
+//    |values, is_sample, allowed_cascading, excludes| {
+//        IntCompressor::compress_no_dict(values, is_sample, allowed_cascading, excludes)
+//    },
+//);
 
 impl Scheme for UncompressedScheme {
     type StatsType = IntegerStats;

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -23,7 +23,7 @@ use vortex_zigzag::{ZigZagArray, zigzag_encode};
 
 use crate::integer::dictionary::dictionary_encode;
 use crate::patches::compress_patches;
-//use crate::rle::RLEScheme;
+use crate::rle::RLEScheme;
 use crate::{
     Compressor, CompressorStats, GenerateStatsOptions, Scheme,
     estimate_compression_ratio_with_sampling,
@@ -47,7 +47,7 @@ impl Compressor for IntCompressor {
             &DictScheme,
             &RunEndScheme,
             &SequenceScheme,
-            // &RLE_INTEGER_SCHEME,
+            &RLE_INTEGER_SCHEME,
         ]
     }
 
@@ -103,7 +103,7 @@ const SPARSE_SCHEME: IntCode = IntCode(5);
 const DICT_SCHEME: IntCode = IntCode(6);
 const RUN_END_SCHEME: IntCode = IntCode(7);
 const SEQUENCE_SCHEME: IntCode = IntCode(8);
-//const RUN_LENGTH_SCHEME: IntCode = IntCode(9);
+const RUN_LENGTH_SCHEME: IntCode = IntCode(9);
 
 #[derive(Debug, Copy, Clone)]
 pub struct UncompressedScheme;
@@ -135,12 +135,12 @@ pub struct SequenceScheme;
 /// Threshold for the average run length in an array before we consider run-end encoding.
 const RUN_END_THRESHOLD: u32 = 4;
 
-//pub const RLE_INTEGER_SCHEME: RLEScheme<IntegerStats, IntCode> = RLEScheme::new(
-//    RUN_LENGTH_SCHEME,
-//    |values, is_sample, allowed_cascading, excludes| {
-//        IntCompressor::compress_no_dict(values, is_sample, allowed_cascading, excludes)
-//    },
-//);
+pub const RLE_INTEGER_SCHEME: RLEScheme<IntegerStats, IntCode> = RLEScheme::new(
+    RUN_LENGTH_SCHEME,
+    |values, is_sample, allowed_cascading, excludes| {
+        IntCompressor::compress_no_dict(values, is_sample, allowed_cascading, excludes)
+    },
+);
 
 impl Scheme for UncompressedScheme {
     type StatsType = IntegerStats;

--- a/vortex-btrblocks/src/rle.rs
+++ b/vortex-btrblocks/src/rle.rs
@@ -8,8 +8,6 @@ use vortex_array::arrays::PrimitiveArray;
 use vortex_array::{ArrayRef, IntoArray, ToCanonical};
 use vortex_error::VortexResult;
 use vortex_fastlanes::RLEArray;
-#[cfg(feature = "unstable_encodings")]
-use {crate::Compressor, crate::integer::IntCode};
 
 use crate::integer::IntCompressor;
 use crate::{CompressorStats, Scheme, estimate_compression_ratio_with_sampling};
@@ -114,17 +112,19 @@ where
             &new_excludes,
         )?;
 
+        // NOTE(aduffy): this encoding appears to be faulty, and was causing Undefined Behavior
+        //  checks to trigger in the gharchive benchmark dataset decompression.
         // Delta in an unstable encoding, once we deem it stable we can switch over to this always.
-        #[cfg(feature = "unstable_encodings")]
-        // For indices and offsets, we always use integer compression without dictionary encoding.
-        let compressed_indices = try_compress_delta(
-            &rle_array.indices().to_primitive().narrow()?,
-            is_sample,
-            allowed_cascading - 1,
-            &[],
-        )?;
+        // #[cfg(feature = "unstable_encodings")]
+        // // For indices and offsets, we always use integer compression without dictionary encoding.
+        // let compressed_indices = try_compress_delta(
+        //     &rle_array.indices().to_primitive().narrow()?,
+        //     is_sample,
+        //     allowed_cascading - 1,
+        //     &[],
+        // )?;
 
-        #[cfg(not(feature = "unstable_encodings"))]
+        // #[cfg(not(feature = "unstable_encodings"))]
         let compressed_indices = IntCompressor::compress_no_dict(
             &rle_array.indices().to_primitive().narrow()?,
             is_sample,
@@ -154,20 +154,20 @@ where
     }
 }
 
-#[cfg(feature = "unstable_encodings")]
-fn try_compress_delta(
-    primitive_array: &PrimitiveArray,
-    is_sample: bool,
-    allowed_cascading: usize,
-    excludes: &[IntCode],
-) -> VortexResult<ArrayRef> {
-    use vortex_fastlanes::{DeltaArray, delta_compress};
-
-    let (bases, deltas) = delta_compress(primitive_array)?;
-    let compressed_bases = IntCompressor::compress(&bases, is_sample, allowed_cascading, excludes)?;
-    let compressed_deltas =
-        IntCompressor::compress_no_dict(&deltas, is_sample, allowed_cascading, excludes)?;
-
-    DeltaArray::try_from_delta_compress_parts(compressed_bases, compressed_deltas)
-        .map(DeltaArray::into_array)
-}
+// #[cfg(feature = "unstable_encodings")]
+// fn try_compress_delta(
+//     primitive_array: &PrimitiveArray,
+//     is_sample: bool,
+//     allowed_cascading: usize,
+//     excludes: &[IntCode],
+// ) -> VortexResult<ArrayRef> {
+//     use vortex_fastlanes::{DeltaArray, delta_compress};
+//
+//     let (bases, deltas) = delta_compress(primitive_array)?;
+//     let compressed_bases = IntCompressor::compress(&bases, is_sample, allowed_cascading, excludes)?;
+//     let compressed_deltas =
+//         IntCompressor::compress_no_dict(&deltas, is_sample, allowed_cascading, excludes)?;
+//
+//     DeltaArray::try_from_delta_compress_parts(compressed_bases, compressed_deltas)
+//         .map(DeltaArray::into_array)
+// }


### PR DESCRIPTION
Disable RLE scheme, change `select *` to `select count(*)`. That in combination with #5024 stops us from OOMing every time we run this benchmark.