### PR TITLE
Chore: Remove nullability from Vectors

### DIFF
--- a/vortex-vector/src/bool/vector.rs
+++ b/vortex-vector/src/bool/vector.rs
@@ -11,28 +11,24 @@ use crate::VectorOps;
 
 /// An immutable vector of boolean values.
 ///
-/// Internally, the boolean values are stored as the bits of a [`BitBuffer`] plus an optional
-/// [`Mask`] for null booleans (where `true` represents a _valid_ boolean and `false` represents a
-/// `null` boolean).
-///
 /// The mutable equivalent of this type is [`BoolVectorMut`].
 #[derive(Debug, Clone)]
 pub struct BoolVector {
     pub(super) bits: BitBuffer,
-    pub(super) validity: Option<Mask>,
+    pub(super) validity: Mask,
 }
 
 impl VectorOps for BoolVector {
     type Mutable = BoolVectorMut;
 
     fn len(&self) -> usize {
-        debug_assert!(
-            self.validity
-                .as_ref()
-                .is_none_or(|mask| mask.len() == self.bits.len())
-        );
+        debug_assert!(self.validity.len() == self.bits.len());
 
         self.bits.len()
+    }
+
+    fn validity(&self) -> &Mask {
+        &self.validity
     }
 
     fn try_into_mut(self) -> Result<Self::Mutable, Self>
@@ -49,19 +45,15 @@ impl VectorOps for BoolVector {
             }
         };
 
-        let validity = match self.validity {
-            Some(v) => match v.try_into_mut() {
-                Ok(v) => Some(v),
-                Err(v) => {
-                    return Err(BoolVector {
-                        bits: bits.freeze(),
-                        validity: Some(v),
-                    });
-                }
-            },
-            None => None,
-        };
-
-        Ok(BoolVectorMut { bits, validity })
+        match self.validity.try_into_mut() {
+            Ok(validity_mut) => Ok(BoolVectorMut {
+                bits,
+                validity: validity_mut,
+            }),
+            Err(validity) => Err(BoolVector {
+                bits: bits.freeze(),
+                validity,
+            }),
+        }
     }
 }

--- a/vortex-vector/src/bool/vector.rs
+++ b/vortex-vector/src/bool/vector.rs
@@ -4,7 +4,6 @@
 //! Definition and implementation of [`BoolVector`].
 
 use vortex_buffer::BitBuffer;
-use vortex_dtype::Nullability;
 use vortex_mask::Mask;
 
 use super::BoolVectorMut;
@@ -25,10 +24,6 @@ pub struct BoolVector {
 
 impl VectorOps for BoolVector {
     type Mutable = BoolVectorMut;
-
-    fn nullability(&self) -> Nullability {
-        Nullability::from(self.validity.is_some())
-    }
 
     fn len(&self) -> usize {
         debug_assert!(

--- a/vortex-vector/src/bool/vector_mut.rs
+++ b/vortex-vector/src/bool/vector_mut.rs
@@ -4,36 +4,26 @@
 //! Definition and implementation of [`BoolVectorMut`].
 
 use vortex_buffer::BitBufferMut;
-use vortex_dtype::Nullability;
-use vortex_error::vortex_panic;
 use vortex_mask::MaskMut;
 
 use super::BoolVector;
-use crate::VectorMutOps;
+use crate::{VectorMutOps, VectorOps};
 
 /// A mutable vector of boolean values.
-///
-/// Internally, the boolean values are stored as the bits of a [`BitBufferMut`] plus an optional
-/// [`MaskMut`] for null booleans (where `true` represents a _valid_ boolean and `false` represents
-/// a `null` boolean).
 ///
 /// The immutable equivalent of this type is [`BoolVector`].
 #[derive(Debug, Clone)]
 pub struct BoolVectorMut {
     pub(super) bits: BitBufferMut,
-    pub(super) validity: Option<MaskMut>,
+    pub(super) validity: MaskMut,
 }
 
 impl BoolVectorMut {
-    /// Creates a new mutable boolean vector with the given `capacity` and `nullability`.
-    pub fn with_capacity(capacity: usize, nullability: Nullability) -> Self {
-        let validity = nullability
-            .is_nullable()
-            .then(|| MaskMut::with_capacity(capacity));
-
+    /// Creates a new mutable boolean vector with the given `capacity`.
+    pub fn with_capacity(capacity: usize) -> Self {
         Self {
             bits: BitBufferMut::with_capacity(capacity),
-            validity,
+            validity: MaskMut::with_capacity(capacity),
         }
     }
 }
@@ -42,11 +32,7 @@ impl VectorMutOps for BoolVectorMut {
     type Immutable = BoolVector;
 
     fn len(&self) -> usize {
-        debug_assert!(
-            self.validity
-                .as_ref()
-                .is_none_or(|mask| mask.len() == self.bits.len())
-        );
+        debug_assert!(self.validity.len() == self.bits.len());
 
         self.bits.len()
     }
@@ -57,66 +43,35 @@ impl VectorMutOps for BoolVectorMut {
 
     fn reserve(&mut self, additional: usize) {
         self.bits.reserve(additional);
-
-        if let Some(v) = self.validity.as_mut() {
-            v.reserve(additional);
-        }
+        self.validity.reserve(additional);
     }
 
     fn extend_from_vector(&mut self, other: &BoolVector) {
         self.bits.append_buffer(&other.bits);
-
-        match (&mut self.validity, &other.validity) {
-            (Some(self_v), Some(other_v)) => self_v.append_mask(other_v),
-            (Some(self_v), None) => self_v.append_n(true, other.bits.len()),
-            (None, Some(other_v)) => {
-                let mut new_validity = MaskMut::new_true(self.bits.len() - other.bits.len());
-                new_validity.append_mask(other_v);
-                self.validity = Some(new_validity);
-            }
-            (None, None) => {}
-        }
+        self.validity.append_mask(other.validity());
     }
 
     fn append_nulls(&mut self, n: usize) {
-        let Some(mask) = &mut self.validity else {
-            vortex_panic!("tried to append nulls to a non-nullable vector")
-        };
-
-        mask.append_n(false, n);
-
         self.bits.append_n(false, n);
+        self.validity.append_n(false, n);
     }
 
     fn freeze(self) -> Self::Immutable {
         BoolVector {
             bits: self.bits.freeze(),
-            validity: self.validity.map(|v| v.freeze()),
+            validity: self.validity.freeze(),
         }
     }
 
     fn split_off(&mut self, at: usize) -> Self {
         BoolVectorMut {
             bits: self.bits.split_off(at),
-            validity: self.validity.as_mut().map(|v| v.split_off(at)),
+            validity: self.validity.split_off(at),
         }
     }
 
     fn unsplit(&mut self, other: Self) {
-        // TODO(connor): We must check `other`'s nullability in relation to `self`.
-
-        let other_len = other.bits.len();
         self.bits.unsplit(other.bits);
-
-        match (&mut self.validity, other.validity) {
-            (Some(self_v), Some(other_v)) => self_v.unsplit(other_v),
-            (Some(self_v), None) => self_v.append_n(true, other_len),
-            (None, Some(other_v)) => {
-                let mut new_validity = MaskMut::new_true(self.bits.len() - other_len);
-                new_validity.unsplit(other_v);
-                self.validity = Some(new_validity);
-            }
-            (None, None) => {}
-        }
+        self.validity.unsplit(other.validity);
     }
 }

--- a/vortex-vector/src/bool/vector_mut.rs
+++ b/vortex-vector/src/bool/vector_mut.rs
@@ -9,7 +9,7 @@ use vortex_error::vortex_panic;
 use vortex_mask::MaskMut;
 
 use super::BoolVector;
-use crate::{VectorMutOps, VectorOps};
+use crate::VectorMutOps;
 
 /// A mutable vector of boolean values.
 ///
@@ -41,10 +41,6 @@ impl BoolVectorMut {
 impl VectorMutOps for BoolVectorMut {
     type Immutable = BoolVector;
 
-    fn nullability(&self) -> Nullability {
-        Nullability::from(self.validity.is_some())
-    }
-
     fn len(&self) -> usize {
         debug_assert!(
             self.validity
@@ -68,14 +64,6 @@ impl VectorMutOps for BoolVectorMut {
     }
 
     fn extend_from_vector(&mut self, other: &BoolVector) {
-        assert_eq!(
-            self.nullability(),
-            other.nullability(),
-            "tried to extend a vector with nullability {} with another vector with nullability {}",
-            self.nullability(),
-            other.nullability(),
-        );
-
         self.bits.append_buffer(&other.bits);
 
         match (&mut self.validity, &other.validity) {

--- a/vortex-vector/src/null/vector.rs
+++ b/vortex-vector/src/null/vector.rs
@@ -3,6 +3,8 @@
 
 //! Definition and implementation of [`NullVector`].
 
+use vortex_mask::Mask;
+
 use crate::{NullVectorMut, VectorOps};
 
 /// An immutable vector of null values.
@@ -11,15 +13,19 @@ use crate::{NullVectorMut, VectorOps};
 /// single `length` counter.
 ///
 /// The mutable equivalent of this type is [`NullVectorMut`].
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct NullVector {
     pub(super) len: usize,
+    pub(super) validity: Mask,
 }
 
 impl NullVector {
     /// Creates a new immutable vector of nulls with the given length.
     pub fn new(len: usize) -> Self {
-        Self { len }
+        Self {
+            len,
+            validity: Mask::AllFalse(len),
+        }
     }
 }
 
@@ -28,6 +34,10 @@ impl VectorOps for NullVector {
 
     fn len(&self) -> usize {
         self.len
+    }
+
+    fn validity(&self) -> &Mask {
+        &self.validity
     }
 
     fn try_into_mut(self) -> Result<Self::Mutable, Self>

--- a/vortex-vector/src/null/vector.rs
+++ b/vortex-vector/src/null/vector.rs
@@ -3,8 +3,6 @@
 
 //! Definition and implementation of [`NullVector`].
 
-use vortex_dtype::Nullability;
-
 use crate::{NullVectorMut, VectorOps};
 
 /// An immutable vector of null values.
@@ -27,10 +25,6 @@ impl NullVector {
 
 impl VectorOps for NullVector {
     type Mutable = NullVectorMut;
-
-    fn nullability(&self) -> Nullability {
-        Nullability::Nullable
-    }
 
     fn len(&self) -> usize {
         self.len

--- a/vortex-vector/src/null/vector_mut.rs
+++ b/vortex-vector/src/null/vector_mut.rs
@@ -3,8 +3,6 @@
 
 //! Definition and implementation of [`NullVectorMut`].
 
-use vortex_dtype::Nullability;
-
 use super::NullVector;
 use crate::VectorMutOps;
 
@@ -28,10 +26,6 @@ impl NullVectorMut {
 
 impl VectorMutOps for NullVectorMut {
     type Immutable = NullVector;
-
-    fn nullability(&self) -> Nullability {
-        Nullability::Nullable
-    }
 
     fn len(&self) -> usize {
         self.len

--- a/vortex-vector/src/ops.rs
+++ b/vortex-vector/src/ops.rs
@@ -4,6 +4,8 @@
 //! Definition and implementation of [`VectorOps`] and [`VectorMutOps`] for [`Vector`] and
 //! [`VectorMut`], respectively.
 
+use vortex_mask::Mask;
+
 use crate::{Vector, VectorMut, private};
 
 /// Common operations for immutable vectors (all the variants of [`Vector`]).
@@ -18,6 +20,14 @@ pub trait VectorOps: private::Sealed + Into<Vector> {
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Returns the validity mask of the vector, where `true` represents a _valid_ element and
+    /// `false` represents a `null` element.
+    ///
+    /// Note that vectors are **always** considered nullable. "Non-nullable" data will simply have a
+    /// [`Mask`] of [`AllTrue(len)`](Mask::AllTrue). It is on the caller to ensure that they do not
+    /// add nullable data to a vector they want to keep as non-nullable.
+    fn validity(&self) -> &Mask;
 
     /// Tries to convert `self` into a mutable vector (implementing [`VectorMutOps`]).
     ///
@@ -60,20 +70,12 @@ pub trait VectorMutOps: private::Sealed + Into<VectorMut> {
     fn reserve(&mut self, additional: usize);
 
     /// Extends the vector by appending elements from another vector.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `other` does not have the same nullability as `self`.
     fn extend_from_vector(&mut self, other: &Self::Immutable);
 
-    /// Appends `n` null elements to the vector (if it is nullable).
+    /// Appends `n` null elements to the vector.
     ///
     /// Implementors should ensure that they correctly append "null" or garbage values to their
-    /// elements in addition to adding nulls to their validity mask.
-    ///
-    /// # Panics
-    ///
-    /// If `self` is a non-nullable vector, implementors should ensure that this function panics.
+    /// elements in addition to adding nulls to their validity mask.s.
     fn append_nulls(&mut self, n: usize);
 
     /// Converts `self` into an immutable vector.

--- a/vortex-vector/src/ops.rs
+++ b/vortex-vector/src/ops.rs
@@ -4,24 +4,12 @@
 //! Definition and implementation of [`VectorOps`] and [`VectorMutOps`] for [`Vector`] and
 //! [`VectorMut`], respectively.
 
-use vortex_dtype::Nullability;
-
 use crate::{Vector, VectorMut, private};
 
 /// Common operations for immutable vectors (all the variants of [`Vector`]).
 pub trait VectorOps: private::Sealed + Into<Vector> {
     /// The mutable equivalent of this immutable vector.
     type Mutable: VectorMutOps<Immutable = Self>;
-
-    /// Returns the [`Nullability`] of the vector.
-    fn nullability(&self) -> Nullability;
-
-    /// Returns `true` if the nullability of this vector is [`Nullable`].
-    ///
-    /// [`Nullable`]: Nullability::Nullable
-    fn is_nullable(&self) -> bool {
-        self.nullability().is_nullable()
-    }
 
     /// Returns the number of elements in the vector, also referred to as its "length".
     fn len(&self) -> usize;
@@ -49,16 +37,6 @@ pub trait VectorOps: private::Sealed + Into<Vector> {
 pub trait VectorMutOps: private::Sealed + Into<VectorMut> {
     /// The immutable equivalent of this mutable vector.
     type Immutable: VectorOps<Mutable = Self>;
-
-    /// Returns the [`Nullability`] of the vector.
-    fn nullability(&self) -> Nullability;
-
-    /// Returns `true` if the nullability of this vector is [`Nullable`].
-    ///
-    /// [`Nullable`]: Nullability::Nullable
-    fn is_nullable(&self) -> bool {
-        self.nullability().is_nullable()
-    }
 
     /// Returns the number of elements in the vector, also referred to as its "length".
     fn len(&self) -> usize;
@@ -115,7 +93,6 @@ pub trait VectorMutOps: private::Sealed + Into<VectorMut> {
     /// `at > capacity`).
     fn split_off(&mut self, at: usize) -> Self;
 
-    // TODO(connor): Should this panic if other has a different nullability?
     /// Absorbs a mutable vector that was previously split off.
     ///
     /// If the two vectors were previously contiguous and not mutated in a way that causes

--- a/vortex-vector/src/primitive/generic.rs
+++ b/vortex-vector/src/primitive/generic.rs
@@ -4,7 +4,7 @@
 //! Definition and implementation of [`PVector<T>`].
 
 use vortex_buffer::Buffer;
-use vortex_dtype::{NativePType, Nullability};
+use vortex_dtype::NativePType;
 use vortex_mask::Mask;
 
 use crate::{PVectorMut, VectorOps};
@@ -25,10 +25,6 @@ pub struct PVector<T> {
 
 impl<T: NativePType> VectorOps for PVector<T> {
     type Mutable = PVectorMut<T>;
-
-    fn nullability(&self) -> Nullability {
-        Nullability::from(self.validity.is_some())
-    }
 
     fn len(&self) -> usize {
         self.elements.len()

--- a/vortex-vector/src/primitive/generic.rs
+++ b/vortex-vector/src/primitive/generic.rs
@@ -12,15 +12,13 @@ use crate::{PVectorMut, VectorOps};
 /// An immutable vector of generic primitive values.
 ///
 /// `T` is expected to be bound by [`NativePType`], which templates an internal [`Buffer<T>`] that
-/// stores the elements of the vector. Additionally, an optional [`Mask`] is stored to track null
-/// primitive elements (where `true` represents a _valid_ primitive and `false` represents a `null`
-/// primitive).
+/// stores the elements of the vector.
 ///
 /// The mutable equivalent of this type is [`PVectorMut<T>`].
 #[derive(Debug, Clone)]
 pub struct PVector<T> {
     pub(super) elements: Buffer<T>,
-    pub(super) validity: Option<Mask>,
+    pub(super) validity: Mask,
 }
 
 impl<T: NativePType> VectorOps for PVector<T> {
@@ -28,6 +26,10 @@ impl<T: NativePType> VectorOps for PVector<T> {
 
     fn len(&self) -> usize {
         self.elements.len()
+    }
+
+    fn validity(&self) -> &Mask {
+        &self.validity
     }
 
     /// Try to convert self into a mutable vector.
@@ -42,19 +44,15 @@ impl<T: NativePType> VectorOps for PVector<T> {
             }
         };
 
-        let validity = match self.validity {
-            Some(v) => match v.try_into_mut() {
-                Ok(v) => Some(v),
-                Err(v) => {
-                    return Err(PVector {
-                        elements: elements.freeze(),
-                        validity: Some(v),
-                    });
-                }
-            },
-            None => None,
-        };
-
-        Ok(PVectorMut { elements, validity })
+        match self.validity.try_into_mut() {
+            Ok(validity_mut) => Ok(PVectorMut {
+                elements,
+                validity: validity_mut,
+            }),
+            Err(validity) => Err(PVector {
+                elements: elements.freeze(),
+                validity,
+            }),
+        }
     }
 }

--- a/vortex-vector/src/primitive/generic_mut.rs
+++ b/vortex-vector/src/primitive/generic_mut.rs
@@ -8,7 +8,7 @@ use vortex_dtype::{NativePType, Nullability};
 use vortex_error::vortex_panic;
 use vortex_mask::MaskMut;
 
-use crate::{PVector, VectorMutOps, VectorOps};
+use crate::{PVector, VectorMutOps};
 
 /// A mutable vector of generic primitive values.
 ///
@@ -41,10 +41,6 @@ impl<T: NativePType> PVectorMut<T> {
 impl<T: NativePType> VectorMutOps for PVectorMut<T> {
     type Immutable = PVector<T>;
 
-    fn nullability(&self) -> Nullability {
-        Nullability::from(self.validity.is_some())
-    }
-
     fn len(&self) -> usize {
         self.elements.len()
     }
@@ -62,14 +58,6 @@ impl<T: NativePType> VectorMutOps for PVectorMut<T> {
 
     /// Extends the vector by appending elements from another vector.
     fn extend_from_vector(&mut self, other: &PVector<T>) {
-        assert_eq!(
-            self.nullability(),
-            other.nullability(),
-            "tried to extend a vector with nullability {} with another vector with nullability {}",
-            self.nullability(),
-            other.nullability(),
-        );
-
         self.elements.extend_from_slice(other.elements.as_slice());
 
         match (&mut self.validity, &other.validity) {

--- a/vortex-vector/src/primitive/generic_mut.rs
+++ b/vortex-vector/src/primitive/generic_mut.rs
@@ -4,36 +4,29 @@
 //! Definition and implementation of [`PVectorMut<T>`].
 
 use vortex_buffer::BufferMut;
-use vortex_dtype::{NativePType, Nullability};
-use vortex_error::vortex_panic;
+use vortex_dtype::NativePType;
 use vortex_mask::MaskMut;
 
-use crate::{PVector, VectorMutOps};
+use crate::{PVector, VectorMutOps, VectorOps};
 
 /// A mutable vector of generic primitive values.
 ///
 /// `T` is expected to be bound by [`NativePType`], which templates an internal [`BufferMut<T>`]
-/// that stores the elements of the vector. Additionally, an optional [`MaskMut`] is stored to track
-/// null primitive elements (where `true` represents a _valid_ element and `false` represents a
-/// `null` element).
+/// that stores the elements of the vector.
 ///
 /// The immutable equivalent of this type is [`PVector<T>`].
 #[derive(Debug, Clone)]
 pub struct PVectorMut<T> {
     pub(super) elements: BufferMut<T>,
-    pub(super) validity: Option<MaskMut>,
+    pub(super) validity: MaskMut,
 }
 
 impl<T: NativePType> PVectorMut<T> {
-    /// Create a new mutable primitive vector with the given capacity and nullability.
-    pub fn with_capacity(capacity: usize, nullability: Nullability) -> Self {
-        let validity = nullability
-            .is_nullable()
-            .then(|| MaskMut::with_capacity(capacity));
-
+    /// Create a new mutable primitive vector with the given capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
         Self {
             elements: BufferMut::with_capacity(capacity),
-            validity,
+            validity: MaskMut::with_capacity(capacity),
         }
     }
 }
@@ -51,65 +44,37 @@ impl<T: NativePType> VectorMutOps for PVectorMut<T> {
 
     fn reserve(&mut self, additional: usize) {
         self.elements.reserve(additional);
-        if let Some(v) = self.validity.as_mut() {
-            v.reserve(additional);
-        }
+        self.validity.reserve(additional);
     }
 
     /// Extends the vector by appending elements from another vector.
     fn extend_from_vector(&mut self, other: &PVector<T>) {
         self.elements.extend_from_slice(other.elements.as_slice());
-
-        match (&mut self.validity, &other.validity) {
-            (Some(self_v), Some(other_v)) => self_v.append_mask(other_v),
-            (Some(self_v), None) => self_v.append_n(true, other.elements.len()),
-            (None, Some(other_v)) => {
-                let mut new_validity =
-                    MaskMut::new_true(self.elements.len() - other.elements.len());
-                new_validity.append_mask(other_v);
-                self.validity = Some(new_validity);
-            }
-            (None, None) => {}
-        }
+        self.validity.append_mask(other.validity());
     }
 
     fn append_nulls(&mut self, n: usize) {
-        let Some(mask) = &mut self.validity else {
-            vortex_panic!("tried to append nulls to a non-nullable vector")
-        };
-
-        mask.append_n(false, n);
-
-        self.elements.push_n(T::zero(), n)
+        self.elements.push_n(T::zero(), n);
+        self.validity.append_n(false, n);
     }
 
     /// Freeze the vector into an immutable one.
     fn freeze(self) -> PVector<T> {
         PVector {
             elements: self.elements.freeze(),
-            validity: self.validity.map(|v| v.freeze()),
+            validity: self.validity.freeze(),
         }
     }
 
     fn split_off(&mut self, at: usize) -> Self {
         PVectorMut {
             elements: self.elements.split_off(at),
-            validity: self.validity.as_mut().map(|v| v.split_off(at)),
+            validity: self.validity.split_off(at),
         }
     }
 
     fn unsplit(&mut self, other: Self) {
-        let other_len = other.elements.len();
         self.elements.unsplit(other.elements);
-        match (&mut self.validity, other.validity) {
-            (Some(self_v), Some(other_v)) => self_v.unsplit(other_v),
-            (Some(self_v), None) => self_v.append_n(true, other_len),
-            (None, Some(other_v)) => {
-                let mut new_validity = MaskMut::new_true(self.elements.len() - other_len);
-                new_validity.unsplit(other_v);
-                self.validity = Some(new_validity);
-            }
-            (None, None) => {}
-        }
+        self.validity.unsplit(other.validity);
     }
 }

--- a/vortex-vector/src/primitive/vector.rs
+++ b/vortex-vector/src/primitive/vector.rs
@@ -4,7 +4,7 @@
 //! Definition and implementation of [`PrimitiveVector`].
 
 use vortex_dtype::half::f16;
-use vortex_dtype::{NativePType, Nullability, PTypeUpcast};
+use vortex_dtype::{NativePType, PTypeUpcast};
 
 use super::{PVector, PrimitiveVectorMut};
 use crate::{VectorOps, match_each_pvector};
@@ -43,10 +43,6 @@ pub enum PrimitiveVector {
 
 impl VectorOps for PrimitiveVector {
     type Mutable = PrimitiveVectorMut;
-
-    fn nullability(&self) -> Nullability {
-        match_each_pvector!(self, |v| { v.nullability() })
-    }
 
     fn len(&self) -> usize {
         match_each_pvector!(self, |v| { v.len() })

--- a/vortex-vector/src/primitive/vector.rs
+++ b/vortex-vector/src/primitive/vector.rs
@@ -48,6 +48,10 @@ impl VectorOps for PrimitiveVector {
         match_each_pvector!(self, |v| { v.len() })
     }
 
+    fn validity(&self) -> &vortex_mask::Mask {
+        match_each_pvector!(self, |v| { v.validity() })
+    }
+
     fn try_into_mut(self) -> Result<Self::Mutable, Self>
     where
         Self: Sized,

--- a/vortex-vector/src/primitive/vector_mut.rs
+++ b/vortex-vector/src/primitive/vector_mut.rs
@@ -4,7 +4,7 @@
 //! Definition and implementation of [`PrimitiveVectorMut`].
 
 use vortex_dtype::half::f16;
-use vortex_dtype::{NativePType, Nullability, PType, PTypeUpcast};
+use vortex_dtype::{NativePType, PType, PTypeUpcast};
 
 use crate::{
     PVectorMut, PrimitiveVector, VectorMutOps, match_each_pvector_mut,
@@ -44,20 +44,20 @@ pub enum PrimitiveVectorMut {
 }
 
 impl PrimitiveVectorMut {
-    /// Create a new mutable primitive vector with the given capacity, primitive type, and nullability.
-    pub fn with_capacity(capacity: usize, ptype: PType, nullability: Nullability) -> Self {
+    /// Create a new mutable primitive vector with the given primitive type and capacity.
+    pub fn with_capacity(ptype: PType, capacity: usize) -> Self {
         match ptype {
-            PType::U8 => PVectorMut::<u8>::with_capacity(capacity, nullability).into(),
-            PType::U16 => PVectorMut::<u16>::with_capacity(capacity, nullability).into(),
-            PType::U32 => PVectorMut::<u32>::with_capacity(capacity, nullability).into(),
-            PType::U64 => PVectorMut::<u64>::with_capacity(capacity, nullability).into(),
-            PType::I8 => PVectorMut::<i8>::with_capacity(capacity, nullability).into(),
-            PType::I16 => PVectorMut::<i16>::with_capacity(capacity, nullability).into(),
-            PType::I32 => PVectorMut::<i32>::with_capacity(capacity, nullability).into(),
-            PType::I64 => PVectorMut::<i64>::with_capacity(capacity, nullability).into(),
-            PType::F16 => PVectorMut::<f16>::with_capacity(capacity, nullability).into(),
-            PType::F32 => PVectorMut::<f32>::with_capacity(capacity, nullability).into(),
-            PType::F64 => PVectorMut::<f64>::with_capacity(capacity, nullability).into(),
+            PType::U8 => PVectorMut::<u8>::with_capacity(capacity).into(),
+            PType::U16 => PVectorMut::<u16>::with_capacity(capacity).into(),
+            PType::U32 => PVectorMut::<u32>::with_capacity(capacity).into(),
+            PType::U64 => PVectorMut::<u64>::with_capacity(capacity).into(),
+            PType::I8 => PVectorMut::<i8>::with_capacity(capacity).into(),
+            PType::I16 => PVectorMut::<i16>::with_capacity(capacity).into(),
+            PType::I32 => PVectorMut::<i32>::with_capacity(capacity).into(),
+            PType::I64 => PVectorMut::<i64>::with_capacity(capacity).into(),
+            PType::F16 => PVectorMut::<f16>::with_capacity(capacity).into(),
+            PType::F32 => PVectorMut::<f32>::with_capacity(capacity).into(),
+            PType::F64 => PVectorMut::<f64>::with_capacity(capacity).into(),
         }
     }
 }

--- a/vortex-vector/src/primitive/vector_mut.rs
+++ b/vortex-vector/src/primitive/vector_mut.rs
@@ -65,10 +65,6 @@ impl PrimitiveVectorMut {
 impl VectorMutOps for PrimitiveVectorMut {
     type Immutable = PrimitiveVector;
 
-    fn nullability(&self) -> Nullability {
-        match_each_pvector_mut!(self, |v| { v.nullability() })
-    }
-
     fn len(&self) -> usize {
         match_each_pvector_mut!(self, |v| { v.len() })
     }

--- a/vortex-vector/src/vector.rs
+++ b/vortex-vector/src/vector.rs
@@ -4,8 +4,6 @@
 //! Definition of the [`Vector`] type, which represent immutable and fully decompressed (canonical)
 //! array data.
 
-use vortex_dtype::Nullability;
-
 use crate::{BoolVector, NullVector, PrimitiveVector, VectorMut, VectorOps, match_each_vector};
 
 /// An enum over all kinds of immutable vectors, which represent fully decompressed (canonical)
@@ -42,10 +40,6 @@ pub enum Vector {
 
 impl VectorOps for Vector {
     type Mutable = VectorMut;
-
-    fn nullability(&self) -> Nullability {
-        match_each_vector!(self, |v| { v.nullability() })
-    }
 
     fn len(&self) -> usize {
         match_each_vector!(self, |v| { v.len() })

--- a/vortex-vector/src/vector.rs
+++ b/vortex-vector/src/vector.rs
@@ -9,9 +9,12 @@ use crate::{BoolVector, NullVector, PrimitiveVector, VectorMut, VectorOps, match
 /// An enum over all kinds of immutable vectors, which represent fully decompressed (canonical)
 /// array data.
 ///
-/// Most of the behavior of `Vector` is described by the [`VectorOps`] trait.
+/// Most of the behavior of `Vector` is described by the [`VectorOps`] trait. Note that vectors are
+/// **always** considered as nullable, and it is the responsibility of the user to not add any
+/// nullable data to a vector they want to keep as non-nullable.
 ///
-/// The mutable equivalent of this type is [`VectorMut`], which implements.
+/// The mutable equivalent of this type is [`VectorMut`], which implements the
+/// [`VectorMutOps`](crate::VectorMutOps) trait.
 #[derive(Debug, Clone)]
 pub enum Vector {
     /// Null
@@ -43,6 +46,10 @@ impl VectorOps for Vector {
 
     fn len(&self) -> usize {
         match_each_vector!(self, |v| { v.len() })
+    }
+
+    fn validity(&self) -> &vortex_mask::Mask {
+        match_each_vector!(self, |v| { v.validity() })
     }
 
     fn try_into_mut(self) -> Result<Self::Mutable, Self>

--- a/vortex-vector/src/vector_mut.rs
+++ b/vortex-vector/src/vector_mut.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_dtype::{DType, Nullability};
+use vortex_dtype::DType;
 use vortex_error::vortex_panic;
 
 use crate::{
@@ -43,10 +43,6 @@ impl VectorMut {
 
 impl VectorMutOps for VectorMut {
     type Immutable = Vector;
-
-    fn nullability(&self) -> Nullability {
-        match_each_vector_mut!(self, |v| { v.nullability() })
-    }
 
     fn len(&self) -> usize {
         match_each_vector_mut!(self, |v| { v.len() })

--- a/vortex-vector/src/vector_mut.rs
+++ b/vortex-vector/src/vector_mut.rs
@@ -12,11 +12,12 @@ use crate::{
 /// An enum over all kinds of mutable vectors, which represent fully decompressed (canonical) array
 /// data.
 ///
-/// Most of the behavior of `VectorMut` is described by the [`VectorMutOps`] trait.
+/// Most of the behavior of `VectorMut` is described by the [`VectorMutOps`] trait. Note that
+/// vectors are **always** considered as nullable, and it is the responsibility of the user to not
+/// add any nullable data to a vector they want to keep as non-nullable.
 ///
-/// The immutable equivalent of this type is [`Vector`].
-///
-/// [`VectorMutOps`]: crate::VectorMutOps
+/// The immutable equivalent of this type is [`Vector`], which implements the
+/// [`VectorOps`](crate::VectorOps) trait.
 #[derive(Debug, Clone)]
 pub enum VectorMut {
     /// Null
@@ -32,9 +33,9 @@ impl VectorMut {
     pub fn with_capacity(capacity: usize, dtype: &DType) -> Self {
         match dtype {
             DType::Null => NullVectorMut::new(0).into(), // `NullVector` has `usize::MAX` capacity.
-            DType::Bool(n) => BoolVectorMut::with_capacity(capacity, *n).into(),
-            DType::Primitive(ptype, nullability) => {
-                PrimitiveVectorMut::with_capacity(capacity, *ptype, *nullability).into()
+            DType::Bool(_) => BoolVectorMut::with_capacity(capacity).into(),
+            DType::Primitive(ptype, _) => {
+                PrimitiveVectorMut::with_capacity(*ptype, capacity).into()
             }
             _ => vortex_panic!("Unsupported dtype for VectorMut"),
         }


### PR DESCRIPTION
Tracking Issue: https://github.com/vortex-data/vortex/issues/5028

Removes explicit nullability in Vectors, meaning our physical vectors now behave even more like Arrow.