### PR TITLE
chore[tui]: tree display layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9096,6 +9096,7 @@ dependencies = [
  "prost 0.14.1",
  "rstest",
  "rustc-hash",
+ "termtree",
  "tokio",
  "tracing",
  "uuid",
@@ -9304,6 +9305,7 @@ dependencies = [
  "parquet",
  "ratatui",
  "taffy",
+ "termtree",
  "tokio",
  "vortex",
 ]

--- a/vortex-layout/Cargo.toml
+++ b/vortex-layout/Cargo.toml
@@ -37,6 +37,7 @@ pco = { workspace = true }
 pin-project-lite = { workspace = true }
 prost = { workspace = true }
 rustc-hash = { workspace = true }
+termtree = { workspace = true }
 tokio = { workspace = true, features = ["rt"], optional = true }
 # Needed to pickup the "js" feature for wasm targets from the workspace configuration
 tracing = { workspace = true }

--- a/vortex-layout/src/display.rs
+++ b/vortex-layout/src/display.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use termtree::Tree;
+use vortex_error::VortexResult;
+
+use crate::LayoutRef;
+
+/// Display wrapper for layout tree visualization
+pub struct DisplayLayoutTree(pub LayoutRef);
+
+impl std::fmt::Display for DisplayLayoutTree {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn make_tree(layout: LayoutRef) -> VortexResult<Tree<String>> {
+            // Build the node label with encoding, dtype, and metadata
+            let mut node_parts = vec![
+                format!("{}", layout.encoding()),
+                format!("dtype: {}", layout.dtype()),
+            ];
+
+            // Add child count if there are children
+            let nchildren = layout.nchildren();
+            if nchildren > 0 {
+                node_parts.push(format!("children: {}", nchildren));
+            }
+
+            let node_name = node_parts.join(", ");
+
+            // Get children and child names directly from the layout (not loading arrays)
+            let children = layout.children()?;
+            let child_names: Vec<_> = layout.child_names().collect();
+
+            // Build child trees
+            let child_trees: VortexResult<Vec<Tree<String>>> =
+                if !children.is_empty() && child_names.len() == children.len() {
+                    // If we have names for all children, use them
+                    children
+                        .into_iter()
+                        .zip(child_names.iter())
+                        .map(|(child, name)| {
+                            let child_tree = make_tree(child)?;
+                            Ok(Tree::new(format!("{}: {}", name, child_tree.root))
+                                .with_leaves(child_tree.leaves))
+                        })
+                        .collect()
+                } else if !children.is_empty() {
+                    // No names available, just show children
+                    children.into_iter().map(make_tree).collect()
+                } else {
+                    // Leaf node - no children
+                    Ok(Vec::new())
+                };
+
+            Ok(Tree::new(node_name).with_leaves(child_trees?))
+        }
+
+        match make_tree(self.0.clone()) {
+            Ok(tree) => write!(f, "{}", tree),
+            Err(e) => write!(f, "Error building layout tree: {}", e),
+        }
+    }
+}

--- a/vortex-layout/src/layout.rs
+++ b/vortex-layout/src/layout.rs
@@ -189,6 +189,11 @@ impl dyn Layout + '_ {
             stack: vec![self.to_layout()],
         }
     }
+
+    /// Display the layout as a tree structure.
+    pub fn display_tree(&self) -> crate::display::DisplayLayoutTree {
+        crate::display::DisplayLayoutTree(self.to_layout())
+    }
 }
 
 #[repr(transparent)]

--- a/vortex-layout/src/layout.rs
+++ b/vortex-layout/src/layout.rs
@@ -11,6 +11,7 @@ use vortex_array::SerializeMetadata;
 use vortex_dtype::{DType, FieldName};
 use vortex_error::{VortexExpect, VortexResult, vortex_err};
 
+use crate::display::DisplayLayoutTree;
 use crate::segments::{SegmentId, SegmentSource};
 use crate::{LayoutEncodingId, LayoutEncodingRef, LayoutReaderRef, VTable};
 
@@ -191,8 +192,8 @@ impl dyn Layout + '_ {
     }
 
     /// Display the layout as a tree structure.
-    pub fn display_tree(&self) -> crate::display::DisplayLayoutTree {
-        crate::display::DisplayLayoutTree(self.to_layout())
+    pub fn display_tree(&self) -> DisplayLayoutTree {
+        DisplayLayoutTree(self.to_layout())
     }
 }
 

--- a/vortex-layout/src/lib.rs
+++ b/vortex-layout/src/lib.rs
@@ -14,6 +14,7 @@ pub use strategy::*;
 pub use vtable::*;
 pub mod aliases;
 mod children;
+pub mod display;
 mod encoding;
 mod flatbuffers;
 mod layout;

--- a/vortex-tui/Cargo.toml
+++ b/vortex-tui/Cargo.toml
@@ -27,6 +27,7 @@ itertools = { workspace = true }
 parquet = { workspace = true, features = ["arrow", "async"] }
 ratatui = { workspace = true }
 taffy = { workspace = true }
+termtree = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 vortex = { workspace = true, features = ["tokio"] }
 

--- a/vortex-tui/src/main.rs
+++ b/vortex-tui/src/main.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 use browse::exec_tui;
 use clap::{CommandFactory, Parser};
-use tree::exec_tree;
+use tree::{TreeArgs, exec_tree};
 use vortex::error::VortexExpect;
 
 use crate::inspect::InspectArgs;
@@ -24,8 +24,8 @@ struct Cli {
 
 #[derive(Debug, clap::Subcommand)]
 enum Commands {
-    /// Print the encoding tree of a Vortex file.
-    Tree { file: PathBuf },
+    /// Print tree views of a Vortex file (layout tree or array tree)
+    Tree(TreeArgs),
     /// Convert a Parquet file to a Vortex file. Chunking occurs on Parquet RowGroup boundaries.
     Convert(#[command(flatten)] convert::Flags),
     /// Interactively browse the Vortex file.
@@ -37,7 +37,8 @@ enum Commands {
 impl Commands {
     fn file_path(&self) -> &PathBuf {
         match self {
-            Commands::Tree { file } | Commands::Browse { file } => file,
+            Commands::Tree(args) => &args.file,
+            Commands::Browse { file } => file,
             Commands::Convert(flags) => &flags.file,
             Commands::Inspect(args) => &args.file,
         }
@@ -64,7 +65,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     match cli.command {
-        Commands::Tree { file } => exec_tree(file).await?,
+        Commands::Tree(args) => exec_tree(args).await?,
         Commands::Convert(flags) => convert::exec_convert(flags).await?,
         Commands::Browse { file } => exec_tui(file).await?,
         Commands::Inspect(args) => inspect::exec_inspect(args).await?,

--- a/vortex-tui/src/main.rs
+++ b/vortex-tui/src/main.rs
@@ -37,7 +37,10 @@ enum Commands {
 impl Commands {
     fn file_path(&self) -> &PathBuf {
         match self {
-            Commands::Tree(args) => &args.file,
+            Commands::Tree(args) => match &args.mode {
+                tree::TreeMode::Array { file } => file,
+                tree::TreeMode::Layout { file } => file,
+            },
             Commands::Browse { file } => file,
             Commands::Convert(flags) => &flags.file,
             Commands::Inspect(args) => &args.file,

--- a/vortex-tui/src/tree.rs
+++ b/vortex-tui/src/tree.rs
@@ -1,15 +1,44 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use vortex::error::VortexResult;
 use vortex::file::VortexOpenOptions;
 use vortex::stream::ArrayStreamExt;
 
-pub async fn exec_tree(file: impl AsRef<Path>) -> VortexResult<()> {
+#[derive(Debug, clap::Parser)]
+pub struct TreeArgs {
+    /// What tree to display
+    #[clap(subcommand)]
+    pub mode: Option<TreeMode>,
+
+    /// Path to the Vortex file
+    pub file: PathBuf,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum TreeMode {
+    /// Display the array encoding tree (loads and materializes arrays)
+    Array,
+    /// Display the layout tree structure (metadata only, no array loading)
+    Layout,
+}
+
+pub async fn exec_tree(args: TreeArgs) -> VortexResult<()> {
+    let mode = args.mode.unwrap_or(TreeMode::Array);
+
+    match mode {
+        TreeMode::Array => exec_array_tree(&args.file).await?,
+        TreeMode::Layout => exec_layout_tree(&args.file).await?,
+    }
+
+    Ok(())
+}
+
+async fn exec_array_tree(file: &Path) -> VortexResult<()> {
     let full = VortexOpenOptions::new()
-        .open(file.as_ref())
+        .open(file)
         .await?
         .scan()?
         .into_array_stream()?
@@ -17,6 +46,15 @@ pub async fn exec_tree(file: impl AsRef<Path>) -> VortexResult<()> {
         .await?;
 
     println!("{}", full.display_tree());
+
+    Ok(())
+}
+
+async fn exec_layout_tree(file: &Path) -> VortexResult<()> {
+    let vxf = VortexOpenOptions::new().open(file).await?;
+    let footer = vxf.footer();
+
+    println!("{}", footer.layout().display_tree());
 
     Ok(())
 }

--- a/vortex-tui/src/tree.rs
+++ b/vortex-tui/src/tree.rs
@@ -11,26 +11,27 @@ use vortex::stream::ArrayStreamExt;
 pub struct TreeArgs {
     /// What tree to display
     #[clap(subcommand)]
-    pub mode: Option<TreeMode>,
-
-    /// Path to the Vortex file
-    pub file: PathBuf,
+    pub mode: TreeMode,
 }
 
 #[derive(Debug, clap::Subcommand)]
 pub enum TreeMode {
     /// Display the array encoding tree (loads and materializes arrays)
-    Array,
+    Array {
+        /// Path to the Vortex file
+        file: PathBuf,
+    },
     /// Display the layout tree structure (metadata only, no array loading)
-    Layout,
+    Layout {
+        /// Path to the Vortex file
+        file: PathBuf,
+    },
 }
 
 pub async fn exec_tree(args: TreeArgs) -> VortexResult<()> {
-    let mode = args.mode.unwrap_or(TreeMode::Array);
-
-    match mode {
-        TreeMode::Array => exec_array_tree(&args.file).await?,
-        TreeMode::Layout => exec_layout_tree(&args.file).await?,
+    match args.mode {
+        TreeMode::Array { file } => exec_array_tree(&file).await?,
+        TreeMode::Layout { file } => exec_layout_tree(&file).await?,
     }
 
     Ok(())


### PR DESCRIPTION
Its helpful to be able to print out the whole layout tree of a file (`vx tree layout <FILE>`), not just the array.

```
vortex.struct, dtype: {p_partkey=i64, p_name=utf8, p_mfgr=utf8, p_brand=utf8, p_type=utf8, p_size=i32, p_container=utf8, p_retailprice=decimal(15,2), p_comment=utf8}, children: 9
├── p_partkey: vortex.stats, dtype: i64, children: 2
│   ├── data: vortex.chunked, dtype: i64, children: 2
│   │   ├── [0]: vortex.flat, dtype: i64
│   │   └── [1]: vortex.flat, dtype: i64
│   └── zones: vortex.flat, dtype: {max=i64?, max_is_truncated=bool, min=i64?, min_is_truncated=bool, sum=i64?, null_count=u64?}
├── p_name: vortex.stats, dtype: utf8, children: 2
│   ├── data: vortex.chunked, dtype: utf8, children: 25
│   │   ├── [0]: vortex.flat, dtype: utf8
│   │   ├── [1]: vortex.flat, dtype: utf8
│   │   ├── [2]: vortex.flat, dtype: utf8
│   │   ├── [3]: vortex.flat, dtype: utf8
│   │   ├── [4]: vortex.flat, dtype: utf8
│   │   ├── [5]: vortex.flat, dtype: utf8
│   │   ├── [6]: vortex.flat, dtype: utf8
│   │   ├── [7]: vortex.flat, dtype: utf8
│   │   ├── [8]: vortex.flat, dtype: utf8
│   │   ├── [9]: vortex.flat, dtype: utf8
│   │   ├── [10]: vortex.flat, dtype: utf8
│   │   ├── [11]: vortex.flat, dtype: utf8
│   │   ├── [12]: vortex.flat, dtype: utf8
│   │   ├── [13]: vortex.flat, dtype: utf8
│   │   ├── [14]: vortex.flat, dtype: utf8
│   │   ├── [15]: vortex.flat, dtype: utf8
│   │   ├── [16]: vortex.flat, dtype: utf8
│   │   ├── [17]: vortex.flat, dtype: utf8
...
```