### PR TITLE
Simplify the serde implementation for StructFields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8735,6 +8735,7 @@ dependencies = [
  "arrow-schema",
  "flatbuffers",
  "half",
+ "insta",
  "itertools 0.14.0",
  "jiff",
  "num-traits",

--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -60,7 +60,7 @@ tabled = { workspace = true, optional = true, default-features = false, features
 ] }
 termtree = { workspace = true }
 vortex-buffer = { workspace = true, features = ["arrow"] }
-vortex-dtype = { workspace = true, features = ["arrow", "serde"] }
+vortex-dtype = { workspace = true, features = ["arrow"] }
 vortex-error = { workspace = true, features = ["prost"] }
 vortex-flatbuffers = { workspace = true, features = ["array"] }
 vortex-mask = { workspace = true }

--- a/vortex-dtype/Cargo.toml
+++ b/vortex-dtype/Cargo.toml
@@ -36,6 +36,7 @@ vortex-proto = { workspace = true, features = ["dtype"] }
 vortex-utils = { workspace = true }
 
 [dev-dependencies]
+insta = { workspace = true }
 rstest = { workspace = true }
 serde_json = { workspace = true }
 serde_test = { workspace = true }

--- a/vortex-dtype/src/serde/mod.rs
+++ b/vortex-dtype/src/serde/mod.rs
@@ -59,4 +59,66 @@ mod test {
     fn test_serde_nullability() {
         assert_tokens(&Nullability::NonNullable, &[Token::Bool(false)]);
     }
+
+    #[test]
+    fn test_serde_struct_dtype_json() {
+        use crate::StructFields;
+
+        // Create a struct dtype with various field types
+        let fields = StructFields::from_iter([
+            ("name", DType::Utf8(Nullability::NonNullable)),
+            ("age", DType::Primitive(PType::I32, Nullability::Nullable)),
+            ("active", DType::Bool(Nullability::NonNullable)),
+        ]);
+        let struct_dtype = DType::Struct(fields, Nullability::Nullable);
+
+        // Serialize to JSON
+        let json = serde_json::to_string_pretty(&struct_dtype).unwrap();
+
+        // Assert the JSON representation hasn't changed
+        insta::assert_snapshot!(json, @r#"
+        {
+          "Struct": [
+            {
+              "names": [
+                "name",
+                "age",
+                "active"
+              ],
+              "dtypes": [
+                {
+                  "inner": {
+                    "Owned": {
+                      "Utf8": false
+                    }
+                  }
+                },
+                {
+                  "inner": {
+                    "Owned": {
+                      "Primitive": [
+                        "i32",
+                        true
+                      ]
+                    }
+                  }
+                },
+                {
+                  "inner": {
+                    "Owned": {
+                      "Bool": false
+                    }
+                  }
+                }
+              ]
+            },
+            true
+          ]
+        }
+        "#);
+
+        // Deserialize back and verify round-trip
+        let deserialized: DType = serde_json::from_str(&json).unwrap();
+        assert_eq!(struct_dtype, deserialized);
+    }
 }

--- a/vortex-dtype/src/struct_.rs
+++ b/vortex-dtype/src/struct_.rs
@@ -217,10 +217,12 @@ impl Display for StructFields {
 }
 
 #[derive(Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct StructFieldsInner {
     names: FieldNames,
     dtypes: Arc<[FieldDType]>,
     // Derived from names, maps from field name to first index.
+    #[cfg_attr(feature = "serde", serde(skip))]
     indices: OnceLock<HashMap<FieldName, usize>>,
 }
 
@@ -256,38 +258,6 @@ impl Hash for StructFieldsInner {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.names.hash(state);
         self.dtypes.hash(state);
-    }
-}
-
-#[cfg(feature = "serde")]
-impl serde::Serialize for StructFieldsInner {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeStruct;
-
-        let mut state = serializer.serialize_struct("StructFieldsInner", 2)?;
-        state.serialize_field("names", &self.names)?;
-        state.serialize_field("dtypes", &self.dtypes)?;
-        state.end()
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for StructFieldsInner {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[derive(serde::Deserialize)]
-        struct StructFieldsInnerHelper {
-            names: FieldNames,
-            dtypes: Arc<[FieldDType]>,
-        }
-
-        let helper = StructFieldsInnerHelper::deserialize(deserializer)?;
-        Ok(StructFieldsInner::from_fields(helper.names, helper.dtypes))
     }
 }
 


### PR DESCRIPTION
Was just curious if its possible to this, and apparently it is. I don't think there is any compile time difference, it just saves on some code.