### PR TITLE
Chore: rename `PVector` to `PVec`

### DIFF
--- a/vortex-vector/src/lib.rs
+++ b/vortex-vector/src/lib.rs
@@ -23,6 +23,6 @@ mod vector_mut;
 pub use bool::{BoolVector, BoolVectorMut};
 pub use null::{NullVector, NullVectorMut};
 pub use ops::{VectorMutOps, VectorOps};
-pub use primitive::{PVector, PVectorMut, PrimitiveVector, PrimitiveVectorMut};
+pub use primitive::{PVec, PVecMut, PrimitiveVector, PrimitiveVectorMut};
 pub use vector::Vector;
 pub use vector_mut::VectorMut;

--- a/vortex-vector/src/primitive/from_iter.rs
+++ b/vortex-vector/src/primitive/from_iter.rs
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! [`FromIterator`] and related implementations for [`PVectorMut<T>`].
+//! [`FromIterator`] and related implementations for [`PVecMut<T>`].
 
 use vortex_buffer::BufferMut;
 use vortex_dtype::NativePType;
 use vortex_mask::MaskMut;
 
-use crate::PVectorMut;
+use crate::PVecMut;
 
-impl<T: NativePType> FromIterator<Option<T>> for PVectorMut<T> {
-    /// Creates a new [`PVectorMut<T>`] from an iterator of `Option<T>` values.
+impl<T: NativePType> FromIterator<Option<T>> for PVecMut<T> {
+    /// Creates a new [`PVecMut<T>`] from an iterator of `Option<T>` values.
     ///
     /// `None` values will be marked as invalid in the validity mask.
     ///
     /// # Examples
     ///
     /// ```
-    /// use vortex_vector::{PVectorMut, VectorMutOps};
+    /// use vortex_vector::{PVecMut, VectorMutOps};
     ///
-    /// let mut vec = PVectorMut::<i32>::from_iter([Some(1), None, Some(3)]);
+    /// let mut vec = PVecMut::<i32>::from_iter([Some(1), None, Some(3)]);
     /// assert_eq!(vec.len(), 3);
     /// ```
     fn from_iter<I>(iter: I) -> Self
@@ -45,24 +45,24 @@ impl<T: NativePType> FromIterator<Option<T>> for PVectorMut<T> {
             }
         }
 
-        PVectorMut {
+        PVecMut {
             elements: BufferMut::from_iter(elements),
             validity,
         }
     }
 }
 
-impl<T: NativePType> FromIterator<T> for PVectorMut<T> {
-    /// Creates a new [`PVectorMut<T>`] from an iterator of `T` values.
+impl<T: NativePType> FromIterator<T> for PVecMut<T> {
+    /// Creates a new [`PVecMut<T>`] from an iterator of `T` values.
     ///
     /// All values will be treated as non-null.
     ///
     /// # Examples
     ///
     /// ```
-    /// use vortex_vector::{PVectorMut, VectorMutOps};
+    /// use vortex_vector::{PVecMut, VectorMutOps};
     ///
-    /// let mut vec = PVectorMut::<i32>::from_iter([1, 2, 3, 4]);
+    /// let mut vec = PVecMut::<i32>::from_iter([1, 2, 3, 4]);
     /// assert_eq!(vec.len(), 4);
     /// ```
     fn from_iter<I>(iter: I) -> Self
@@ -72,7 +72,7 @@ impl<T: NativePType> FromIterator<T> for PVectorMut<T> {
         let buffer = BufferMut::from_iter(iter);
         let validity = MaskMut::new_true(buffer.len());
 
-        PVectorMut {
+        PVecMut {
             elements: buffer,
             validity,
         }

--- a/vortex-vector/src/primitive/generic.rs
+++ b/vortex-vector/src/primitive/generic.rs
@@ -1,44 +1,44 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Definition and implementation of [`PVector<T>`].
+//! Definition and implementation of [`PVec<T>`].
 
 use vortex_buffer::Buffer;
 use vortex_dtype::NativePType;
 use vortex_error::{VortexExpect, VortexResult, vortex_ensure};
 use vortex_mask::Mask;
 
-use crate::{PVectorMut, VectorOps};
+use crate::{PVecMut, VectorOps};
 
 /// An immutable vector of generic primitive values.
 ///
 /// `T` is expected to be bound by [`NativePType`], which templates an internal [`Buffer<T>`] that
 /// stores the elements of the vector.
 ///
-/// `PVector<T>` can be considered a borrowed / frozen  version of [`PVectorMut<T>`], which is
+/// `PVec<T>` can be considered a borrowed / frozen  version of [`PVecMut<T>`], which is
 /// created via the [`freeze`](crate::VectorMutOps::freeze) method.
 ///
-/// See the documentation for [`PVectorMut<T>`] for more information.
+/// See the documentation for [`PVecMut<T>`] for more information.
 #[derive(Debug, Clone)]
-pub struct PVector<T> {
+pub struct PVec<T> {
     /// The buffer representing the vector elements.
     pub(super) elements: Buffer<T>,
     /// The validity mask (where `true` represents an element is **not** null).
     pub(super) validity: Mask,
 }
 
-impl<T: NativePType> PVector<T> {
-    /// Creates a new [`PVector<T>`] from the given elements buffer and validity mask.
+impl<T: NativePType> PVec<T> {
+    /// Creates a new [`PVec<T>`] from the given elements buffer and validity mask.
     ///
     /// # Panics
     ///
     /// Panics if the length of the validity mask does not match the length of the elements buffer.
     pub fn new(elements: Buffer<T>, validity: Mask) -> Self {
         Self::try_new(elements, validity)
-            .vortex_expect("`PVector` validity mask must have the same length as elements")
+            .vortex_expect("`PVec` validity mask must have the same length as elements")
     }
 
-    /// Tries to create a new [`PVector<T>`] from the given elements buffer and validity mask.
+    /// Tries to create a new [`PVec<T>`] from the given elements buffer and validity mask.
     ///
     /// # Errors
     ///
@@ -47,13 +47,13 @@ impl<T: NativePType> PVector<T> {
     pub fn try_new(elements: Buffer<T>, validity: Mask) -> VortexResult<Self> {
         vortex_ensure!(
             validity.len() == elements.len(),
-            "`PVector` validity mask must have the same length as elements"
+            "`PVec` validity mask must have the same length as elements"
         );
 
         Ok(Self { elements, validity })
     }
 
-    /// Creates a new [`PVector<T>`] from the given elements buffer and validity mask without
+    /// Creates a new [`PVec<T>`] from the given elements buffer and validity mask without
     /// validation.
     ///
     /// # Safety
@@ -63,15 +63,15 @@ impl<T: NativePType> PVector<T> {
         debug_assert_eq!(
             validity.len(),
             elements.len(),
-            "`PVector` validity mask must have the same length as elements"
+            "`PVec` validity mask must have the same length as elements"
         );
 
         Self { elements, validity }
     }
 }
 
-impl<T: NativePType> VectorOps for PVector<T> {
-    type Mutable = PVectorMut<T>;
+impl<T: NativePType> VectorOps for PVec<T> {
+    type Mutable = PVecMut<T>;
 
     fn len(&self) -> usize {
         self.elements.len()
@@ -82,11 +82,11 @@ impl<T: NativePType> VectorOps for PVector<T> {
     }
 
     /// Try to convert self into a mutable vector.
-    fn try_into_mut(self) -> Result<PVectorMut<T>, Self> {
+    fn try_into_mut(self) -> Result<PVecMut<T>, Self> {
         let elements = match self.elements.try_into_mut() {
             Ok(elements) => elements,
             Err(elements) => {
-                return Err(PVector {
+                return Err(PVec {
                     elements,
                     validity: self.validity,
                 });
@@ -94,11 +94,11 @@ impl<T: NativePType> VectorOps for PVector<T> {
         };
 
         match self.validity.try_into_mut() {
-            Ok(validity_mut) => Ok(PVectorMut {
+            Ok(validity_mut) => Ok(PVecMut {
                 elements,
                 validity: validity_mut,
             }),
-            Err(validity) => Err(PVector {
+            Err(validity) => Err(PVec {
                 elements: elements.freeze(),
                 validity,
             }),

--- a/vortex-vector/src/primitive/generic_mut.rs
+++ b/vortex-vector/src/primitive/generic_mut.rs
@@ -1,22 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Definition and implementation of [`PVectorMut<T>`].
+//! Definition and implementation of [`PVecMut<T>`].
 
 use vortex_buffer::BufferMut;
 use vortex_dtype::NativePType;
 use vortex_error::{VortexExpect, VortexResult, vortex_ensure};
 use vortex_mask::MaskMut;
 
-use crate::{PVector, VectorMutOps, VectorOps};
+use crate::{PVec, VectorMutOps, VectorOps};
 
 /// A mutable vector of generic primitive values.
 ///
 /// `T` is expected to be bound by [`NativePType`], which templates an internal [`BufferMut<T>`]
 /// that stores the elements of the vector.
 ///
-/// `PVectorMut<T>` is the primary way to construct primitive vectors. It provides efficient methods
-/// for building vectors incrementally before converting them to an immutable [`PVector<T>`] using
+/// `PVecMut<T>` is the primary way to construct primitive vectors. It provides efficient methods
+/// for building vectors incrementally before converting them to an immutable [`PVec<T>`] using
 /// the [`freeze`](crate::VectorMutOps::freeze) method.
 ///
 /// # Examples
@@ -24,29 +24,29 @@ use crate::{PVector, VectorMutOps, VectorOps};
 /// ## Creating and building a vector
 ///
 /// ```
-/// use vortex_vector::{PVectorMut, VectorMutOps};
+/// use vortex_vector::{PVecMut, VectorMutOps};
 ///
 /// // Create with initial capacity for i32 values.
-/// let mut vec = PVectorMut::<i32>::with_capacity(10);
+/// let mut vec = PVecMut::<i32>::with_capacity(10);
 /// assert_eq!(vec.len(), 0);
 /// assert!(vec.capacity() >= 10);
 ///
 /// // Create from an iterator of optional values.
-/// let mut vec = PVectorMut::<i32>::from_iter([Some(1), None, Some(3)]);
+/// let mut vec = PVecMut::<i32>::from_iter([Some(1), None, Some(3)]);
 /// assert_eq!(vec.len(), 3);
 ///
 /// // Works with different primitive types.
-/// let mut f64_vec = PVectorMut::<f64>::from_iter([1.5, 2.5, 3.5].map(Some));
+/// let mut f64_vec = PVecMut::<f64>::from_iter([1.5, 2.5, 3.5].map(Some));
 /// assert_eq!(f64_vec.len(), 3);
 /// ```
 ///
 /// ## Extending and appending
 ///
 /// ```
-/// use vortex_vector::{PVectorMut, VectorMutOps};
+/// use vortex_vector::{PVecMut, VectorMutOps};
 ///
-/// let mut vec1 = PVectorMut::<i32>::from_iter([1, 2].map(Some));
-/// let vec2 = PVectorMut::<i32>::from_iter([3, 4].map(Some)).freeze();
+/// let mut vec1 = PVecMut::<i32>::from_iter([1, 2].map(Some));
+/// let vec2 = PVecMut::<i32>::from_iter([3, 4].map(Some)).freeze();
 ///
 /// // Extend from another vector.
 /// vec1.extend_from_vector(&vec2);
@@ -60,9 +60,9 @@ use crate::{PVector, VectorMutOps, VectorOps};
 /// ## Splitting and unsplitting
 ///
 /// ```
-/// use vortex_vector::{PVectorMut, VectorMutOps};
+/// use vortex_vector::{PVecMut, VectorMutOps};
 ///
-/// let mut vec = PVectorMut::<i64>::from_iter([10, 20, 30, 40, 50].map(Some));
+/// let mut vec = PVecMut::<i64>::from_iter([10, 20, 30, 40, 50].map(Some));
 ///
 /// // Split the vector at index 3.
 /// let mut second_half = vec.split_off(3);
@@ -77,10 +77,10 @@ use crate::{PVector, VectorMutOps, VectorOps};
 /// ## Working with nulls
 ///
 /// ```
-/// use vortex_vector::{PVectorMut, VectorMutOps};
+/// use vortex_vector::{PVecMut, VectorMutOps};
 ///
 /// // Create a vector with some null values.
-/// let mut vec = PVectorMut::<u32>::from_iter([Some(100), None, Some(200), None]);
+/// let mut vec = PVecMut::<u32>::from_iter([Some(100), None, Some(200), None]);
 /// assert_eq!(vec.len(), 4);
 ///
 /// // Add more nulls.
@@ -91,34 +91,34 @@ use crate::{PVector, VectorMutOps, VectorOps};
 /// ## Converting to immutable
 ///
 /// ```
-/// use vortex_vector::{PVectorMut, VectorMutOps, VectorOps};
+/// use vortex_vector::{PVecMut, VectorMutOps, VectorOps};
 ///
-/// let mut vec = PVectorMut::<f32>::from_iter([1.0, 2.0, 3.0].map(Some));
+/// let mut vec = PVecMut::<f32>::from_iter([1.0, 2.0, 3.0].map(Some));
 ///
 /// // Freeze into an immutable vector.
 /// let immutable = vec.freeze();
 /// assert_eq!(immutable.len(), 3);
 /// ```
 #[derive(Debug, Clone)]
-pub struct PVectorMut<T> {
+pub struct PVecMut<T: NativePType> {
     /// The mutable buffer representing the vector elements.
     pub(super) elements: BufferMut<T>,
     /// The validity mask (where `true` represents an element is **not** null).
     pub(super) validity: MaskMut,
 }
 
-impl<T> PVectorMut<T> {
-    /// Creates a new [`PVectorMut<T>`] from the given elements buffer and validity mask.
+impl<T: NativePType> PVecMut<T> {
+    /// Creates a new [`PVecMut<T>`] from the given elements buffer and validity mask.
     ///
     /// # Panics
     ///
     /// Panics if the length of the validity mask does not match the length of the elements buffer.
     pub fn new(elements: BufferMut<T>, validity: MaskMut) -> Self {
         Self::try_new(elements, validity)
-            .vortex_expect("`PVectorMut` validity mask must have the same length as elements")
+            .vortex_expect("`PVecMut` validity mask must have the same length as elements")
     }
 
-    /// Tries to create a new [`PVectorMut<T>`] from the given elements buffer and validity mask.
+    /// Tries to create a new [`PVecMut<T>`] from the given elements buffer and validity mask.
     ///
     /// # Errors
     ///
@@ -127,13 +127,13 @@ impl<T> PVectorMut<T> {
     pub fn try_new(elements: BufferMut<T>, validity: MaskMut) -> VortexResult<Self> {
         vortex_ensure!(
             validity.len() == elements.len(),
-            "`PVectorMut` validity mask must have the same length as elements"
+            "`PVecMut` validity mask must have the same length as elements"
         );
 
         Ok(Self { elements, validity })
     }
 
-    /// Creates a new [`PVectorMut<T>`] from the given elements buffer and validity mask without
+    /// Creates a new [`PVecMut<T>`] from the given elements buffer and validity mask without
     /// validation.
     ///
     /// # Safety
@@ -146,7 +146,7 @@ impl<T> PVectorMut<T> {
         debug_assert_eq!(
             elements.len(),
             validity.len(),
-            "`PVectorMut` validity mask must have the same length as elements"
+            "`PVecMut` validity mask must have the same length as elements"
         );
 
         Self { elements, validity }
@@ -161,8 +161,8 @@ impl<T> PVectorMut<T> {
     }
 }
 
-impl<T: NativePType> VectorMutOps for PVectorMut<T> {
-    type Immutable = PVector<T>;
+impl<T: NativePType> VectorMutOps for PVecMut<T> {
+    type Immutable = PVec<T>;
 
     fn len(&self) -> usize {
         self.elements.len()
@@ -178,7 +178,7 @@ impl<T: NativePType> VectorMutOps for PVectorMut<T> {
     }
 
     /// Extends the vector by appending elements from another vector.
-    fn extend_from_vector(&mut self, other: &PVector<T>) {
+    fn extend_from_vector(&mut self, other: &PVec<T>) {
         self.elements.extend_from_slice(other.elements.as_slice());
         self.validity.append_mask(other.validity());
     }
@@ -189,15 +189,15 @@ impl<T: NativePType> VectorMutOps for PVectorMut<T> {
     }
 
     /// Freeze the vector into an immutable one.
-    fn freeze(self) -> PVector<T> {
-        PVector {
+    fn freeze(self) -> PVec<T> {
+        PVec {
             elements: self.elements.freeze(),
             validity: self.validity.freeze(),
         }
     }
 
     fn split_off(&mut self, at: usize) -> Self {
-        PVectorMut {
+        PVecMut {
             elements: self.elements.split_off(at),
             validity: self.validity.split_off(at),
         }

--- a/vortex-vector/src/primitive/macros.rs
+++ b/vortex-vector/src/primitive/macros.rs
@@ -17,20 +17,20 @@
 /// # Examples
 ///
 /// ```ignore
-/// use vortex_vector::{PrimitiveVector, PVectorMut, VectorOps, VectorMutOps};
+/// use vortex_vector::{PrimitiveVector, PVecMut, VectorOps, VectorMutOps};
 ///
 /// fn get_primitive_len(vector: &PrimitiveVector) -> usize {
 ///     match_each_pvector!(vector, |v| { v.len() })
 /// }
 ///
 /// // Works with `I32` primitive vectors.
-/// let i32_vec: PrimitiveVector = PVectorMut::<i32>::from_iter([1, 2, 3].map(Some))
+/// let i32_vec: PrimitiveVector = PVecMut::<i32>::from_iter([1, 2, 3].map(Some))
 ///     .freeze()
 ///     .into();
 /// assert_eq!(get_primitive_len(&i32_vec), 3);
 ///
 /// // Works with `F64` primitive vectors.
-/// let f64_vec: PrimitiveVector = PVectorMut::<f64>::from_iter([1.0, 2.5].map(Some))
+/// let f64_vec: PrimitiveVector = PVecMut::<f64>::from_iter([1.0, 2.5].map(Some))
 ///     .freeze()
 ///     .into();
 /// assert_eq!(get_primitive_len(&f64_vec), 2);
@@ -40,7 +40,7 @@
 ///
 /// [`PrimitiveVector`]: crate::PrimitiveVector
 /// [`VectorOps`]: crate::VectorOps
-macro_rules! match_each_pvector {
+macro_rules! match_each_pvec {
     ($self:expr, | $vec:ident | $body:block) => {{
         match $self {
             $crate::PrimitiveVector::U8(v) => {
@@ -91,7 +91,7 @@ macro_rules! match_each_pvector {
     }};
 }
 
-pub(crate) use match_each_pvector;
+pub(crate) use match_each_pvec;
 
 /// Matches on all primitive type variants of [`PrimitiveVectorMut`] and executes the same code
 /// for each variant branch.
@@ -103,19 +103,19 @@ pub(crate) use match_each_pvector;
 /// # Examples
 ///
 /// ```ignore
-/// use vortex_vector::{PrimitiveVectorMut, PVectorMut, VectorMutOps};
+/// use vortex_vector::{PrimitiveVectorMut, PVecMut, VectorMutOps};
 ///
 /// fn reserve_primitive_space(vector: &mut PrimitiveVectorMut, additional: usize) {
 ///     match_each_pvector_mut!(vector, |v| { v.reserve(additional) })
 /// }
 ///
 /// // Works with `U8` mutable primitive vectors.
-/// let mut u8_vec: PrimitiveVectorMut = PVectorMut::<u8>::from_iter([1, 2].map(Some)).into();
+/// let mut u8_vec: PrimitiveVectorMut = PVecMut::<u8>::from_iter([1, 2].map(Some)).into();
 /// reserve_primitive_space(&mut u8_vec, 10);
 /// assert!(u8_vec.capacity() >= 12);
 ///
 /// // Works with `I64` mutable primitive vectors.
-/// let mut i64_vec: PrimitiveVectorMut = PVectorMut::<i64>::from_iter([100].map(Some)).into();
+/// let mut i64_vec: PrimitiveVectorMut = PVecMut::<i64>::from_iter([100].map(Some)).into();
 /// reserve_primitive_space(&mut i64_vec, 5);
 /// assert!(i64_vec.capacity() >= 6);
 /// ```
@@ -124,7 +124,7 @@ pub(crate) use match_each_pvector;
 ///
 /// [`PrimitiveVectorMut`]: crate::PrimitiveVectorMut
 /// [`VectorMutOps`]: crate::VectorMutOps
-macro_rules! match_each_pvector_mut {
+macro_rules! match_each_pvec_mut {
     ($self:expr, | $vec:ident | $body:block) => {{
         match $self {
             $crate::PrimitiveVectorMut::U8(v) => {
@@ -175,4 +175,4 @@ macro_rules! match_each_pvector_mut {
     }};
 }
 
-pub(crate) use match_each_pvector_mut;
+pub(crate) use match_each_pvec_mut;

--- a/vortex-vector/src/primitive/mod.rs
+++ b/vortex-vector/src/primitive/mod.rs
@@ -3,22 +3,22 @@
 
 //! Definitions and implementations of native primitive vector types.
 //!
-//! The types that hold data are [`PVector`] and [`PVectorMut`], which are generic over types `T`
-//! that implement [`NativePType`] (which are just the integer and floating-point types that are
-//! native to Rust plus [`f16`]).
+//! The types that hold data are [`PVec`] and [`PVecMut`], which are generic over types `T` that
+//! implement [`NativePType`] (which are just the integer and floating-point types that are native
+//! to Rust plus [`f16`]).
 //!
 //! [`PrimitiveVector`] and [`PrimitiveVectorMut`] are enums that wrap all of the different possible
-//! [`PVector`]s. There are several macros defined in this crate to make working with these
-//! primitive vector types easier.
+//! [`PVec`]s. There are several macros defined in this crate to make working with these primitive
+//! vector types easier.
 //!
 //! [`NativePType`]: vortex_dtype::NativePType
 //! [`f16`]: vortex_dtype::half::f16
 
 mod generic;
-pub use generic::PVector;
+pub use generic::PVec;
 
 mod generic_mut;
-pub use generic_mut::PVectorMut;
+pub use generic_mut::PVecMut;
 
 mod vector;
 pub use vector::PrimitiveVector;
@@ -40,8 +40,8 @@ impl From<PrimitiveVector> for Vector {
     }
 }
 
-impl<T: NativePType> From<PVector<T>> for Vector {
-    fn from(v: PVector<T>) -> Self {
+impl<T: NativePType> From<PVec<T>> for Vector {
+    fn from(v: PVec<T>) -> Self {
         Self::Primitive(PrimitiveVector::from(v))
     }
 }
@@ -52,8 +52,8 @@ impl From<PrimitiveVectorMut> for VectorMut {
     }
 }
 
-impl<T: NativePType> From<PVectorMut<T>> for VectorMut {
-    fn from(val: PVectorMut<T>) -> Self {
+impl<T: NativePType> From<PVecMut<T>> for VectorMut {
+    fn from(val: PVecMut<T>) -> Self {
         Self::Primitive(PrimitiveVectorMut::from(val))
     }
 }

--- a/vortex-vector/src/primitive/vector.rs
+++ b/vortex-vector/src/primitive/vector.rs
@@ -7,59 +7,59 @@ use vortex_dtype::half::f16;
 use vortex_dtype::{NativePType, PTypeDowncast, PTypeUpcast};
 use vortex_error::vortex_panic;
 
-use super::macros::match_each_pvector;
-use crate::{PVector, PrimitiveVectorMut, VectorOps};
+use super::macros::match_each_pvec;
+use crate::{PVec, PrimitiveVectorMut, VectorOps};
 
 /// An immutable vector of primitive values.
 ///
 /// The mutable equivalent of this type is [`PrimitiveVectorMut`].
 ///
-/// `PrimitiveVector` is represented by an enum over all possible [`PVector`] types (which are
+/// `PrimitiveVector` is represented by an enum over all possible [`PVec`] types (which are
 /// templated by the types that implement [`NativePType`]).
 ///
-/// See the documentation for [`PVector`] for more information.
+/// See the documentation for [`PVec`] for more information.
 #[derive(Debug, Clone)]
 pub enum PrimitiveVector {
     /// U8
-    U8(PVector<u8>),
+    U8(PVec<u8>),
     /// U16
-    U16(PVector<u16>),
+    U16(PVec<u16>),
     /// U32
-    U32(PVector<u32>),
+    U32(PVec<u32>),
     /// U64
-    U64(PVector<u64>),
+    U64(PVec<u64>),
     /// I8
-    I8(PVector<i8>),
+    I8(PVec<i8>),
     /// I16
-    I16(PVector<i16>),
+    I16(PVec<i16>),
     /// I32
-    I32(PVector<i32>),
+    I32(PVec<i32>),
     /// I64
-    I64(PVector<i64>),
+    I64(PVec<i64>),
     /// F16
-    F16(PVector<f16>),
+    F16(PVec<f16>),
     /// F32
-    F32(PVector<f32>),
+    F32(PVec<f32>),
     /// F64
-    F64(PVector<f64>),
+    F64(PVec<f64>),
 }
 
 impl VectorOps for PrimitiveVector {
     type Mutable = PrimitiveVectorMut;
 
     fn len(&self) -> usize {
-        match_each_pvector!(self, |v| { v.len() })
+        match_each_pvec!(self, |v| { v.len() })
     }
 
     fn validity(&self) -> &vortex_mask::Mask {
-        match_each_pvector!(self, |v| { v.validity() })
+        match_each_pvec!(self, |v| { v.validity() })
     }
 
     fn try_into_mut(self) -> Result<Self::Mutable, Self>
     where
         Self: Sized,
     {
-        match_each_pvector!(self, |v| {
+        match_each_pvec!(self, |v| {
             v.try_into_mut()
                 .map(PrimitiveVectorMut::from)
                 .map_err(PrimitiveVector::from)
@@ -67,14 +67,14 @@ impl VectorOps for PrimitiveVector {
     }
 }
 
-impl<T: NativePType> From<PVector<T>> for PrimitiveVector {
-    fn from(v: PVector<T>) -> Self {
+impl<T: NativePType> From<PVec<T>> for PrimitiveVector {
+    fn from(v: PVec<T>) -> Self {
         T::upcast(v)
     }
 }
 
 impl PTypeUpcast for PrimitiveVector {
-    type Input<T: NativePType> = PVector<T>;
+    type Input<T: NativePType> = PVec<T>;
 
     fn from_u8(input: Self::Input<u8>) -> Self {
         PrimitiveVector::U8(input)
@@ -122,7 +122,7 @@ impl PTypeUpcast for PrimitiveVector {
 }
 
 impl PTypeDowncast for PrimitiveVector {
-    type Output<T: NativePType> = PVector<T>;
+    type Output<T: NativePType> = PVec<T>;
 
     fn into_u8(self) -> Self::Output<u8> {
         if let PrimitiveVector::U8(v) = self {

--- a/vortex-vector/src/primitive/vector_mut.rs
+++ b/vortex-vector/src/primitive/vector_mut.rs
@@ -7,58 +7,58 @@ use vortex_dtype::half::f16;
 use vortex_dtype::{NativePType, PType, PTypeDowncast, PTypeUpcast};
 use vortex_error::vortex_panic;
 
-use super::macros::match_each_pvector_mut;
-use crate::{PVectorMut, PrimitiveVector, VectorMutOps};
+use super::macros::match_each_pvec_mut;
+use crate::{PVecMut, PrimitiveVector, VectorMutOps};
 
 /// A mutable vector of primitive values.
 ///
 /// The immutable equivalent of this type is [`PrimitiveVector`].
 ///
-/// `PrimitiveVector` is represented by an enum over all possible [`PVectorMut`] types (which are
+/// `PrimitiveVector` is represented by an enum over all possible [`PVecMut`] types (which are
 /// templated by the types that implement [`NativePType`]).
 ///
-/// See the documentation for [`PVectorMut`] for more information.
+/// See the documentation for [`PVecMut`] for more information.
 #[derive(Debug, Clone)]
 pub enum PrimitiveVectorMut {
     /// U8
-    U8(PVectorMut<u8>),
+    U8(PVecMut<u8>),
     /// U16
-    U16(PVectorMut<u16>),
+    U16(PVecMut<u16>),
     /// U32
-    U32(PVectorMut<u32>),
+    U32(PVecMut<u32>),
     /// U64
-    U64(PVectorMut<u64>),
+    U64(PVecMut<u64>),
     /// I8
-    I8(PVectorMut<i8>),
+    I8(PVecMut<i8>),
     /// I16
-    I16(PVectorMut<i16>),
+    I16(PVecMut<i16>),
     /// I32
-    I32(PVectorMut<i32>),
+    I32(PVecMut<i32>),
     /// I64
-    I64(PVectorMut<i64>),
+    I64(PVecMut<i64>),
     /// F16
-    F16(PVectorMut<f16>),
+    F16(PVecMut<f16>),
     /// F32
-    F32(PVectorMut<f32>),
+    F32(PVecMut<f32>),
     /// F64
-    F64(PVectorMut<f64>),
+    F64(PVecMut<f64>),
 }
 
 impl PrimitiveVectorMut {
     /// Create a new mutable primitive vector with the given primitive type and capacity.
     pub fn with_capacity(ptype: PType, capacity: usize) -> Self {
         match ptype {
-            PType::U8 => PVectorMut::<u8>::with_capacity(capacity).into(),
-            PType::U16 => PVectorMut::<u16>::with_capacity(capacity).into(),
-            PType::U32 => PVectorMut::<u32>::with_capacity(capacity).into(),
-            PType::U64 => PVectorMut::<u64>::with_capacity(capacity).into(),
-            PType::I8 => PVectorMut::<i8>::with_capacity(capacity).into(),
-            PType::I16 => PVectorMut::<i16>::with_capacity(capacity).into(),
-            PType::I32 => PVectorMut::<i32>::with_capacity(capacity).into(),
-            PType::I64 => PVectorMut::<i64>::with_capacity(capacity).into(),
-            PType::F16 => PVectorMut::<f16>::with_capacity(capacity).into(),
-            PType::F32 => PVectorMut::<f32>::with_capacity(capacity).into(),
-            PType::F64 => PVectorMut::<f64>::with_capacity(capacity).into(),
+            PType::U8 => PVecMut::<u8>::with_capacity(capacity).into(),
+            PType::U16 => PVecMut::<u16>::with_capacity(capacity).into(),
+            PType::U32 => PVecMut::<u32>::with_capacity(capacity).into(),
+            PType::U64 => PVecMut::<u64>::with_capacity(capacity).into(),
+            PType::I8 => PVecMut::<i8>::with_capacity(capacity).into(),
+            PType::I16 => PVecMut::<i16>::with_capacity(capacity).into(),
+            PType::I32 => PVecMut::<i32>::with_capacity(capacity).into(),
+            PType::I64 => PVecMut::<i64>::with_capacity(capacity).into(),
+            PType::F16 => PVecMut::<f16>::with_capacity(capacity).into(),
+            PType::F32 => PVecMut::<f32>::with_capacity(capacity).into(),
+            PType::F64 => PVecMut::<f64>::with_capacity(capacity).into(),
         }
     }
 }
@@ -67,15 +67,15 @@ impl VectorMutOps for PrimitiveVectorMut {
     type Immutable = PrimitiveVector;
 
     fn len(&self) -> usize {
-        match_each_pvector_mut!(self, |v| { v.len() })
+        match_each_pvec_mut!(self, |v| { v.len() })
     }
 
     fn capacity(&self) -> usize {
-        match_each_pvector_mut!(self, |v| { v.capacity() })
+        match_each_pvec_mut!(self, |v| { v.capacity() })
     }
 
     fn reserve(&mut self, additional: usize) {
-        match_each_pvector_mut!(self, |v| { v.reserve(additional) })
+        match_each_pvec_mut!(self, |v| { v.reserve(additional) })
     }
 
     fn extend_from_vector(&mut self, other: &Self::Immutable) {
@@ -96,15 +96,15 @@ impl VectorMutOps for PrimitiveVectorMut {
     }
 
     fn append_nulls(&mut self, n: usize) {
-        match_each_pvector_mut!(self, |v| { v.append_nulls(n) })
+        match_each_pvec_mut!(self, |v| { v.append_nulls(n) })
     }
 
     fn freeze(self) -> Self::Immutable {
-        match_each_pvector_mut!(self, |v| { v.freeze().into() })
+        match_each_pvec_mut!(self, |v| { v.freeze().into() })
     }
 
     fn split_off(&mut self, at: usize) -> Self {
-        match_each_pvector_mut!(self, |v| { v.split_off(at).into() })
+        match_each_pvec_mut!(self, |v| { v.split_off(at).into() })
     }
 
     fn unsplit(&mut self, other: Self) {
@@ -125,14 +125,14 @@ impl VectorMutOps for PrimitiveVectorMut {
     }
 }
 
-impl<T: NativePType> From<PVectorMut<T>> for PrimitiveVectorMut {
-    fn from(v: PVectorMut<T>) -> Self {
+impl<T: NativePType> From<PVecMut<T>> for PrimitiveVectorMut {
+    fn from(v: PVecMut<T>) -> Self {
         T::upcast(v)
     }
 }
 
 impl PTypeUpcast for PrimitiveVectorMut {
-    type Input<T: NativePType> = PVectorMut<T>;
+    type Input<T: NativePType> = PVecMut<T>;
 
     fn from_u8(input: Self::Input<u8>) -> Self {
         PrimitiveVectorMut::U8(input)
@@ -180,7 +180,7 @@ impl PTypeUpcast for PrimitiveVectorMut {
 }
 
 impl PTypeDowncast for PrimitiveVectorMut {
-    type Output<T: NativePType> = PVectorMut<T>;
+    type Output<T: NativePType> = PVecMut<T>;
 
     fn into_u8(self) -> Self::Output<u8> {
         if let PrimitiveVectorMut::U8(v) = self {
@@ -269,18 +269,18 @@ mod tests {
     fn test_from_iter_with_options() {
         // Test FromIterator<Option<T>> with different types.
         let vec_i32: PrimitiveVectorMut =
-            PVectorMut::<i32>::from_iter(vec![Some(1), None, Some(3), None, Some(5)]).into();
+            PVecMut::<i32>::from_iter(vec![Some(1), None, Some(3), None, Some(5)]).into();
         assert_eq!(vec_i32.len(), 5);
         let frozen = vec_i32.freeze();
         assert_eq!(frozen.validity().true_count(), 3);
 
         // Test empty iterator.
         let vec_empty: PrimitiveVectorMut =
-            PVectorMut::<f64>::from_iter(std::iter::empty::<Option<f64>>()).into();
+            PVecMut::<f64>::from_iter(std::iter::empty::<Option<f64>>()).into();
         assert_eq!(vec_empty.len(), 0);
 
         // Test that None values use T::default().
-        let vec_nulls: PrimitiveVectorMut = PVectorMut::<i32>::from_iter([None, None, None]).into();
+        let vec_nulls: PrimitiveVectorMut = PVecMut::<i32>::from_iter([None, None, None]).into();
         // Check that validity is all false for nulls.
         let frozen = vec_nulls.freeze();
         assert_eq!(frozen.validity().true_count(), 0);
@@ -290,12 +290,12 @@ mod tests {
     fn test_from_iter_non_null() {
         // Test FromIterator<T> for different primitive types.
         let vec_f64: PrimitiveVectorMut =
-            PVectorMut::<f64>::from_iter([1.5, 2.5, 3.5, 4.5, 5.5]).into();
+            PVecMut::<f64>::from_iter([1.5, 2.5, 3.5, 4.5, 5.5]).into();
         assert_eq!(vec_f64.len(), 5);
         let frozen = vec_f64.freeze();
         assert_eq!(frozen.validity().true_count(), 5); // All valid.
 
-        let vec_u16: PrimitiveVectorMut = PVectorMut::<u16>::from_iter([1u16, 2, 3, 4, 5]).into();
+        let vec_u16: PrimitiveVectorMut = PVecMut::<u16>::from_iter([1u16, 2, 3, 4, 5]).into();
         assert_eq!(vec_u16.len(), 5);
         let frozen = vec_u16.freeze();
         assert_eq!(frozen.validity().true_count(), 5);
@@ -305,7 +305,7 @@ mod tests {
     fn test_operations_preserve_validity() {
         // Test split/unsplit/extend with different primitive types.
         let mut vec: PrimitiveVectorMut =
-            PVectorMut::<i64>::from_iter([Some(100), None, Some(300), None, Some(500)]).into();
+            PVecMut::<i64>::from_iter([Some(100), None, Some(300), None, Some(500)]).into();
 
         let second_half = vec.split_off(2);
         assert_eq!(vec.len(), 2);
@@ -317,8 +317,8 @@ mod tests {
         assert_eq!(second_frozen.validity().true_count(), 2);
 
         // Test unsplit.
-        let mut vec1: PrimitiveVectorMut = PVectorMut::<u32>::from_iter([Some(1000), None]).into();
-        let vec2: PrimitiveVectorMut = PVectorMut::<u32>::from_iter([None, Some(2000)]).into();
+        let mut vec1: PrimitiveVectorMut = PVecMut::<u32>::from_iter([Some(1000), None]).into();
+        let vec2: PrimitiveVectorMut = PVecMut::<u32>::from_iter([None, Some(2000)]).into();
         vec1.unsplit(vec2);
         assert_eq!(vec1.len(), 4);
         let frozen = vec1.freeze();

--- a/vortex-vector/src/private.rs
+++ b/vortex-vector/src/private.rs
@@ -26,5 +26,5 @@ impl Sealed for BoolVectorMut {}
 
 impl Sealed for PrimitiveVector {}
 impl Sealed for PrimitiveVectorMut {}
-impl<T: NativePType> Sealed for PVector<T> {}
-impl<T: NativePType> Sealed for PVectorMut<T> {}
+impl<T: NativePType> Sealed for PVec<T> {}
+impl<T: NativePType> Sealed for PVecMut<T> {}

--- a/vortex-vector/src/vector.rs
+++ b/vortex-vector/src/vector.rs
@@ -29,7 +29,7 @@ pub enum Vector {
     /// Primitive vectors.
     ///
     /// Note that [`PrimitiveVector`] is an enum over the different possible (generic)
-    /// [`PVector<T>`](crate::PVector)s. See the documentation for more information.
+    /// [`PVec<T>`](crate::PVec)s. See the documentation for more information.
     Primitive(PrimitiveVector),
     // Decimal
     // Decimal(DecimalVector),

--- a/vortex-vector/src/vector_mut.rs
+++ b/vortex-vector/src/vector_mut.rs
@@ -30,7 +30,7 @@ pub enum VectorMut {
     /// Primitive mutable vectors.
     ///
     /// Note that [`PrimitiveVectorMut`] is an enum over the different possible (generic)
-    /// [`PVectorMut<T>`](crate::PVectorMut)s. See the documentation for more information.
+    /// [`PVecMut<T>`](crate::PVecMut)s. See the documentation for more information.
     Primitive(PrimitiveVectorMut),
 }
 
@@ -125,7 +125,7 @@ mod tests {
     use vortex_dtype::{Nullability, PType};
 
     use super::*;
-    use crate::{PVectorMut, VectorOps};
+    use crate::{PVecMut, VectorOps};
 
     #[test]
     fn test_with_capacity() {
@@ -188,7 +188,7 @@ mod tests {
         assert!(bool_vec.capacity() >= 100); // Since len is 0.
 
         // Test with primitive vector too.
-        let mut prim_vec: VectorMut = PVectorMut::<i32>::with_capacity(10).into();
+        let mut prim_vec: VectorMut = PVecMut::<i32>::with_capacity(10).into();
         prim_vec.reserve(100);
         assert!(prim_vec.capacity() >= prim_vec.len() + 100);
 
@@ -215,11 +215,11 @@ mod tests {
     #[test]
     fn test_extend_from_vector() {
         // Test extending a primitive vector with data from another vector.
-        let mut vec: VectorMut = PVectorMut::<i32>::from_iter([1, 2, 3].map(Some)).into();
+        let mut vec: VectorMut = PVecMut::<i32>::from_iter([1, 2, 3].map(Some)).into();
         assert_eq!(vec.len(), 3);
 
         // Create an immutable vector to extend from.
-        let to_append: Vector = PVectorMut::<i32>::from_iter([4, 5, 6].map(Some))
+        let to_append: Vector = PVecMut::<i32>::from_iter([4, 5, 6].map(Some))
             .freeze()
             .into();
         assert_eq!(to_append.len(), 3);


### PR DESCRIPTION
Since it will be quite similar to `Vec` from the standard library.