### PR TITLE
fix: patch chunk offsets for alp encode

### DIFF
--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -63,7 +63,7 @@ where
 {
     let values_slice = values.as_slice::<T>();
 
-    let (exponents, encoded, exceptional_positions, exceptional_values, chunk_offsets) =
+    let (exponents, encoded, exceptional_positions, exceptional_values, mut chunk_offsets) =
         T::encode(values_slice, exponents);
 
     let encoded_array = PrimitiveArray::new(encoded, values.validity().clone()).into_array();
@@ -82,7 +82,16 @@ where
                 let (pos, vals): (BufferMut<u64>, BufferMut<T>) = exceptional_positions
                     .into_iter()
                     .zip_eq(exceptional_values)
-                    .filter(|(index, _)| is_valid.value(*index as usize))
+                    .filter(|(index, _)| {
+                        let is_valid = is_valid.value(*index as usize);
+                        if !is_valid {
+                            let patch_chunk = *index as usize / 1024;
+                            for chunk_idx in (patch_chunk + 1)..chunk_offsets.len() {
+                                chunk_offsets[chunk_idx] -= 1;
+                            }
+                        }
+                        is_valid
+                    })
                     .unzip();
                 (pos.freeze(), vals.freeze())
             }

--- a/encodings/alp/src/alp/mod.rs
+++ b/encodings/alp/src/alp/mod.rs
@@ -127,7 +127,7 @@ pub trait ALPFloat: private::Sealed + Float + Display + NativePType {
         Buffer<Self::ALPInt>,
         Buffer<u64>,
         Buffer<Self>,
-        Buffer<u64>,
+        BufferMut<u64>,
     ) {
         let exp = exponents.unwrap_or_else(|| Self::find_best_exponents(values));
 
@@ -158,7 +158,7 @@ pub trait ALPFloat: private::Sealed + Float + Display + NativePType {
             encoded_output.freeze(),
             patch_indices.freeze(),
             patch_values.freeze(),
-            chunk_offsets.freeze(),
+            chunk_offsets,
         )
     }
 


### PR DESCRIPTION
Patches get filtered after the `T::encode` call in case they are null. Therefore patches-chunk-offsets need to be adjusted as part of filtering. Subject to be cleaned up in a follow up.