### PR TITLE
chore: deny let_underscore_drop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,6 +273,7 @@ package = "getrandom"
 version = "0.3.1"
 
 [workspace.lints.rust]
+let_underscore_drop = "deny"
 macro_use_extern_crate = "deny"
 redundant_lifetimes = "deny"
 unsafe_op_in_unsafe_fn = "deny"

--- a/bench-vortex/src/clickbench/clickbench_data.rs
+++ b/bench-vortex/src/clickbench/clickbench_data.rs
@@ -399,7 +399,7 @@ impl Flavor {
                 let pool = rayon::ThreadPoolBuilder::new()
                     .thread_name(|i| format!("clickbench download {i}"))
                     .build()?;
-                let _ = pool.install(|| (0_u32..100).into_par_iter().map(|idx| {
+                let _unused = pool.install(|| (0_u32..100).into_par_iter().map(|idx| {
                     let output_path = basepath.join(Format::Parquet.name()).join(format!("hits_{idx}.parquet"));
                     idempotent(&output_path, |output_path| {
                         info!("Downloading file {idx}");

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -399,7 +399,7 @@ mod test {
     #[should_panic(expected = "out of bounds")]
     fn test_scalar_at_oob() {
         let array = sparse_array(nullable_fill());
-        let _ = array.scalar_at(10);
+        array.scalar_at(10);
     }
 
     #[test]

--- a/encodings/zstd/src/test.rs
+++ b/encodings/zstd/src/test.rs
@@ -196,5 +196,5 @@ fn test_sliced_array_children() {
     let compressed =
         ZstdArray::from_primitive(&PrimitiveArray::from_option_iter(data), 0, 100).unwrap();
     let sliced = compressed.slice(0..4);
-    let _ = sliced.children();
+    sliced.children();
 }

--- a/vortex-array/src/arrays/datetime/test.rs
+++ b/vortex-array/src/arrays/datetime/test.rs
@@ -159,7 +159,7 @@ fn test_timestamp_fails_i32() {
     let ts = buffer![100i32].into_array();
     let ts_array = ts.into_array();
 
-    let _ = TemporalArray::new_timestamp(ts_array, TimeUnit::Seconds, None);
+    TemporalArray::new_timestamp(ts_array, TimeUnit::Seconds, None);
 }
 
 #[rstest]

--- a/vortex-array/src/arrays/list/tests.rs
+++ b/vortex-array/src/arrays/list/tests.rs
@@ -776,7 +776,7 @@ fn test_negative_offset_values() {
     let offsets = buffer![-1i32, 2, 4, 5].into_array();
     let validity = Validity::AllValid;
 
-    let _ = ListArray::try_new(elements, offsets, validity).unwrap();
+    ListArray::try_new(elements, offsets, validity).unwrap();
 }
 
 #[test]
@@ -786,7 +786,7 @@ fn test_unsorted_offsets() {
     let offsets = buffer![0u32, 3, 2, 5].into_array();
     let validity = Validity::AllValid;
 
-    let _ = ListArray::try_new(elements, offsets, validity).unwrap();
+    ListArray::try_new(elements, offsets, validity).unwrap();
 }
 
 #[test]
@@ -796,7 +796,7 @@ fn test_offset_exceeding_elements_length() {
     let offsets = buffer![0u32, 2, 4, 7].into_array();
     let validity = Validity::AllValid;
 
-    let _ = ListArray::try_new(elements, offsets, validity).unwrap();
+    ListArray::try_new(elements, offsets, validity).unwrap();
 }
 
 #[test]
@@ -809,7 +809,7 @@ fn test_validity_length_mismatch() {
         Nullability::Nullable,
     );
 
-    let _ = ListArray::try_new(elements, offsets, validity).unwrap();
+    ListArray::try_new(elements, offsets, validity).unwrap();
 }
 
 #[test]
@@ -819,7 +819,7 @@ fn test_nullable_offsets() {
     let offsets = PrimitiveArray::from_option_iter([Some(0u32), Some(2), None, Some(5)]);
     let validity = Validity::AllValid;
 
-    let _ = ListArray::try_new(elements, offsets.into_array(), validity).unwrap();
+    ListArray::try_new(elements, offsets.into_array(), validity).unwrap();
 }
 
 #[test]
@@ -829,7 +829,7 @@ fn test_empty_offsets_array() {
     let offsets = PrimitiveArray::empty::<u32>(Nullability::NonNullable);
     let validity = Validity::AllValid;
 
-    let _ = ListArray::try_new(elements, offsets.into_array(), validity).unwrap();
+    ListArray::try_new(elements, offsets.into_array(), validity).unwrap();
 }
 
 #[test]
@@ -839,7 +839,7 @@ fn test_non_integer_offsets() {
     let offsets = buffer![0.0f32, 2.0, 4.0, 5.0].into_array();
     let validity = Validity::AllValid;
 
-    let _ = ListArray::try_new(elements, offsets, validity).unwrap();
+    ListArray::try_new(elements, offsets, validity).unwrap();
 }
 
 #[test]

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -1675,7 +1675,7 @@ mod test {
 
         // Mask with wrong length
         let mask = Mask::from_iter([false, false, true, false, false]);
-        let _ = patches.mask(&mask).unwrap();
+        patches.mask(&mask).unwrap();
     }
 
     #[test]

--- a/vortex-cxx/src/lib.rs
+++ b/vortex-cxx/src/lib.rs
@@ -32,6 +32,7 @@ pub(crate) static SESSION: LazyLock<VortexSession> =
     LazyLock::new(|| VortexSession::default().with_handle(RUNTIME.handle()));
 
 #[cxx::bridge(namespace = "vortex::ffi")]
+#[allow(let_underscore_drop)]
 mod ffi {
     extern "Rust" {
         type DType;

--- a/vortex-datafusion/src/persistent/sink.rs
+++ b/vortex-datafusion/src/persistent/sink.rs
@@ -392,7 +392,7 @@ mod tests {
         register_vortex_format_factory(factory, &mut session_state_builder);
         let session = SessionContext::new_with_state(session_state_builder.build());
 
-        let _ = session
+        let _unused = session
             .sql(&format!(
                 "CREATE EXTERNAL TABLE my_tbl \
                 (c1 VARCHAR NOT NULL, c2 INT NOT NULL) \

--- a/vortex-dtype/src/arrow.rs
+++ b/vortex-dtype/src/arrow.rs
@@ -337,7 +337,7 @@ mod test {
     #[test]
     #[should_panic]
     fn test_dtype_conversion_panics() {
-        let _unused = DType::Extension(Arc::new(ExtDType::new(
+        DType::Extension(Arc::new(ExtDType::new(
             ExtID::from("my-fake-ext-dtype"),
             Arc::new(DType::Utf8(Nullability::NonNullable)),
             None,
@@ -380,6 +380,6 @@ mod test {
     #[should_panic]
     fn test_schema_conversion_panics(the_struct: StructFields) {
         let schema_null = DType::Struct(the_struct, Nullability::Nullable);
-        let _unused = schema_null.to_arrow_schema().unwrap();
+        schema_null.to_arrow_schema().unwrap();
     }
 }

--- a/vortex-dtype/src/arrow.rs
+++ b/vortex-dtype/src/arrow.rs
@@ -337,7 +337,7 @@ mod test {
     #[test]
     #[should_panic]
     fn test_dtype_conversion_panics() {
-        let _ = DType::Extension(Arc::new(ExtDType::new(
+        let _unused = DType::Extension(Arc::new(ExtDType::new(
             ExtID::from("my-fake-ext-dtype"),
             Arc::new(DType::Utf8(Nullability::NonNullable)),
             None,
@@ -380,6 +380,6 @@ mod test {
     #[should_panic]
     fn test_schema_conversion_panics(the_struct: StructFields) {
         let schema_null = DType::Struct(the_struct, Nullability::Nullable);
-        let _ = schema_null.to_arrow_schema().unwrap();
+        let _unused = schema_null.to_arrow_schema().unwrap();
     }
 }

--- a/vortex-duckdb/build.rs
+++ b/vortex-duckdb/build.rs
@@ -44,7 +44,7 @@ fn download_duckdb_lib_archive() -> Result<PathBuf, Box<dyn std::error::Error>> 
     let archive_path = duckdb_dir.join(&archive_name);
 
     // Recreate the duckdb directory
-    let _ = fs::remove_dir_all(&duckdb_dir);
+    drop(fs::remove_dir_all(&duckdb_dir));
     fs::create_dir_all(&duckdb_dir)?;
 
     if !archive_path.exists() {
@@ -192,7 +192,7 @@ fn build_duckdb(duckdb_source_root: &Path) -> Result<PathBuf, Box<dyn std::error
     let target_dir = manifest_dir.parent().unwrap().join("target");
     let duckdb_library_dir = target_dir.join("duckdb-lib");
 
-    let _ = fs::remove_dir_all(&duckdb_library_dir);
+    drop(fs::remove_dir_all(&duckdb_library_dir));
     fs::create_dir_all(&duckdb_library_dir)?;
 
     // Copy .dylib and .so files (macOS and Linux).
@@ -223,7 +223,7 @@ fn main() {
     // Download, extract and symlink DuckDB source code.
     let zip_source_path = download_duckdb_source_archive().unwrap();
     let extracted_source_path = extract_duckdb_source(zip_source_path).unwrap();
-    let _ = fs::remove_dir_all(&duckdb_repo);
+    drop(fs::remove_dir_all(&duckdb_repo));
     std::os::unix::fs::symlink(&extracted_source_path, &duckdb_repo).unwrap();
 
     let library_path =

--- a/vortex-duckdb/build.rs
+++ b/vortex-duckdb/build.rs
@@ -3,6 +3,7 @@
 
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::expect_used)]
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
@@ -44,7 +45,10 @@ fn download_duckdb_lib_archive() -> Result<PathBuf, Box<dyn std::error::Error>> 
     let archive_path = duckdb_dir.join(&archive_name);
 
     // Recreate the duckdb directory
-    drop(fs::remove_dir_all(&duckdb_dir));
+    match fs::remove_dir_all(&duckdb_dir) {
+        Err(err) if err.kind() == ErrorKind::NotFound => (),
+        otherwise => otherwise?,
+    }
     fs::create_dir_all(&duckdb_dir)?;
 
     if !archive_path.exists() {
@@ -192,7 +196,10 @@ fn build_duckdb(duckdb_source_root: &Path) -> Result<PathBuf, Box<dyn std::error
     let target_dir = manifest_dir.parent().unwrap().join("target");
     let duckdb_library_dir = target_dir.join("duckdb-lib");
 
-    drop(fs::remove_dir_all(&duckdb_library_dir));
+    match fs::remove_dir_all(&duckdb_library_dir) {
+        Err(err) if err.kind() == ErrorKind::NotFound => (),
+        otherwise => otherwise?,
+    }
     fs::create_dir_all(&duckdb_library_dir)?;
 
     // Copy .dylib and .so files (macOS and Linux).

--- a/vortex-duckdb/src/duckdb/object_cache.rs
+++ b/vortex-duckdb/src/duckdb/object_cache.rs
@@ -12,7 +12,7 @@ use crate::{cpp, lifetime_wrapper};
 unsafe extern "C-unwind" fn rust_box_deleter<T>(ptr: *mut c_void) {
     if !ptr.is_null() {
         unsafe {
-            let _ = Box::from_raw(ptr as *mut T);
+            drop(Box::from_raw(ptr as *mut T));
         }
     }
 }

--- a/vortex-expr/src/exprs/cast.rs
+++ b/vortex-expr/src/exprs/cast.rs
@@ -135,6 +135,7 @@ mod tests {
     use vortex_array::arrays::StructArray;
     use vortex_buffer::buffer;
     use vortex_dtype::{DType, Nullability, PType};
+    use vortex_error::VortexUnwrap as _;
 
     use super::cast;
     use crate::exprs::get_item::get_item;
@@ -155,7 +156,7 @@ mod tests {
     #[test]
     fn replace_children() {
         let expr = cast(root(), DType::Bool(Nullability::Nullable));
-        let _ = expr.with_children([root()]);
+        expr.with_children(vec![root()]).vortex_unwrap();
     }
 
     #[test]

--- a/vortex-expr/src/exprs/is_null.rs
+++ b/vortex-expr/src/exprs/is_null.rs
@@ -99,6 +99,7 @@ mod tests {
     use vortex_array::stats::Stat;
     use vortex_buffer::buffer;
     use vortex_dtype::{DType, Field, FieldPath, FieldPathSet, Nullability};
+    use vortex_error::VortexUnwrap as _;
     use vortex_scalar::Scalar;
     use vortex_utils::aliases::hash_map::HashMap;
 
@@ -122,7 +123,7 @@ mod tests {
     #[test]
     fn replace_children() {
         let expr = is_null(root());
-        let _ = expr.with_children([root()]);
+        expr.with_children([root()]).vortex_unwrap();
     }
 
     #[test]

--- a/vortex-gpu/src/jit/run.rs
+++ b/vortex-gpu/src/jit/run.rs
@@ -69,11 +69,12 @@ pub fn create_run_jit_kernel(
             .record_event(Some(CU_EVENT_DEFAULT))
             .ok()
             .vortex_expect("Failed to record event");
-        let _ = unsafe {
+        let launched = unsafe {
             launch_builder
                 .launch(launch_config)
                 .map_err(|e| vortex_err!("failed to launch kernel {e}"))?
         };
+        drop(launched);
         let end = stream
             .record_event(Some(CU_EVENT_DEFAULT))
             .ok()

--- a/vortex-io/src/file/read/mod.rs
+++ b/vortex-io/src/file/read/mod.rs
@@ -124,7 +124,7 @@ impl Drop for ReadFuture {
     fn drop(&mut self) {
         // When the FileHandle is dropped, we can send a shutdown event to the I/O stream.
         // If the I/O stream has already been dropped, this will fail silently.
-        let _ = self.events.unbounded_send(ReadEvent::Dropped(self.id));
+        drop(self.events.unbounded_send(ReadEvent::Dropped(self.id)));
     }
 }
 

--- a/vortex-io/src/io_buf.rs
+++ b/vortex-io/src/io_buf.rs
@@ -446,14 +446,14 @@ mod tests {
     fn test_owned_slice_invalid_range() {
         let data = vec![1, 2, 3];
         #[allow(clippy::reversed_empty_ranges)]
-        let _ = data.slice_owned(5..3); // start > end
+        let _unused = data.slice_owned(5..3); // start > end
     }
 
     #[test]
     #[should_panic(expected = "exceeds buffer length")]
     fn test_owned_slice_out_of_bounds() {
         let data = vec![1, 2, 3];
-        let _ = data.slice_owned(1..10); // end > len
+        let _unused = data.slice_owned(1..10); // end > len
     }
 
     #[test]
@@ -467,7 +467,7 @@ mod tests {
     #[should_panic(expected = "exceeds buffer length")]
     fn test_owned_slice_start_out_of_bounds() {
         let data = vec![1, 2, 3];
-        let _ = data.slice_owned(10..11); // start > len
+        let _unused = data.slice_owned(10..11); // start > len
     }
 
     // Buffer overflow protection tests

--- a/vortex-io/src/io_buf.rs
+++ b/vortex-io/src/io_buf.rs
@@ -446,14 +446,14 @@ mod tests {
     fn test_owned_slice_invalid_range() {
         let data = vec![1, 2, 3];
         #[allow(clippy::reversed_empty_ranges)]
-        let _unused = data.slice_owned(5..3); // start > end
+        data.slice_owned(5..3); // start > end
     }
 
     #[test]
     #[should_panic(expected = "exceeds buffer length")]
     fn test_owned_slice_out_of_bounds() {
         let data = vec![1, 2, 3];
-        let _unused = data.slice_owned(1..10); // end > len
+        data.slice_owned(1..10); // end > len
     }
 
     #[test]
@@ -467,7 +467,7 @@ mod tests {
     #[should_panic(expected = "exceeds buffer length")]
     fn test_owned_slice_start_out_of_bounds() {
         let data = vec![1, 2, 3];
-        let _unused = data.slice_owned(10..11); // start > len
+        data.slice_owned(10..11); // start > len
     }
 
     // Buffer overflow protection tests

--- a/vortex-io/src/limit.rs
+++ b/vortex-io/src/limit.rs
@@ -259,7 +259,7 @@ mod tests {
         assert!(result.is_err());
 
         // After consuming, should be able to push again
-        let _ = stream.next().await;
+        let _unused = stream.next().await;
         assert_eq!(stream.bytes_available(), 10);
 
         let result = stream.try_push(Box::pin(async { vec![1u8; 5] }), 5);

--- a/vortex-io/src/limit.rs
+++ b/vortex-io/src/limit.rs
@@ -259,7 +259,7 @@ mod tests {
         assert!(result.is_err());
 
         // After consuming, should be able to push again
-        let _unused = stream.next().await;
+        assert!(stream.next().await.is_some());
         assert_eq!(stream.bytes_available(), 10);
 
         let result = stream.try_push(Box::pin(async { vec![1u8; 5] }), 5);

--- a/vortex-io/src/limit.rs
+++ b/vortex-io/src/limit.rs
@@ -259,7 +259,10 @@ mod tests {
         assert!(result.is_err());
 
         // After consuming, should be able to push again
-        assert!(stream.next().await.is_some());
+        stream
+            .next()
+            .await
+            .expect("The 10 byte vector ought to be in there!");
         assert_eq!(stream.bytes_available(), 10);
 
         let result = stream.try_push(Box::pin(async { vec![1u8; 5] }), 5);

--- a/vortex-io/src/runtime/handle.rs
+++ b/vortex-io/src/runtime/handle.rs
@@ -67,7 +67,7 @@ impl Handle {
         let abort_handle = self.runtime().spawn(
             async move {
                 // Task::detach allows the receiver to be dropped, so we ignore send errors.
-                let _ = send.send(f.await);
+                drop(send.send(f.await));
             }
             .boxed(),
         );
@@ -106,7 +106,7 @@ impl Handle {
             // Optimistically avoid the work if the result won't be used.
             if !send.is_closed() {
                 // Task::detach allows the receiver to be dropped, so we ignore send errors.
-                let _ = send.send(f());
+                drop(send.send(f()));
             }
         }));
         Task {
@@ -126,7 +126,7 @@ impl Handle {
             // Optimistically avoid the work if the result won't be used.
             if !send.is_closed() {
                 // Task::detach allows the receiver to be dropped, so we ignore send errors.
-                let _ = send.send(f());
+                drop(send.send(f()));
             }
         }));
         Task {

--- a/vortex-io/src/runtime/single.rs
+++ b/vortex-io/src/runtime/single.rs
@@ -56,9 +56,11 @@ impl Sender {
                 while let Ok(spawn) = scheduling_recv.as_async().recv().await {
                     if let Some(local) = weak_local2.upgrade() {
                         // Ignore send errors since it means the caller immediately detached.
-                        let _ = spawn
-                            .task_callback
-                            .send(SmolAbortHandle::new_handle(local.spawn(spawn.future)));
+                        drop(
+                            spawn
+                                .task_callback
+                                .send(SmolAbortHandle::new_handle(local.spawn(spawn.future))),
+                        );
                     }
                 }
             })
@@ -72,9 +74,9 @@ impl Sender {
                     if let Some(local) = weak_local2.upgrade() {
                         let work = spawn.sync;
                         // Ignore send errors since it means the caller immediately detached.
-                        let _ = spawn.task_callback.send(SmolAbortHandle::new_handle(
+                        drop(spawn.task_callback.send(SmolAbortHandle::new_handle(
                             local.spawn(async move { work() }),
-                        ));
+                        )));
                     }
                 }
             })
@@ -88,9 +90,9 @@ impl Sender {
                     if let Some(local) = weak_local2.upgrade() {
                         let work = spawn.sync;
                         // Ignore send errors since it means the caller immediately detached.
-                        let _ = spawn.task_callback.send(SmolAbortHandle::new_handle(
+                        drop(spawn.task_callback.send(SmolAbortHandle::new_handle(
                             local.spawn(async move { work() }),
-                        ));
+                        )));
                     }
                 }
             })

--- a/vortex-io/src/runtime/tests.rs
+++ b/vortex-io/src/runtime/tests.rs
@@ -290,9 +290,9 @@ async fn test_custom_io_source() {
     let file_read = handle.open_read(source, Default::default()).unwrap();
 
     // Perform several reads
-    let _ = file_read.read_at(0, 5, Alignment::new(1)).await.unwrap();
-    let _ = file_read.read_at(5, 5, Alignment::new(1)).await.unwrap();
-    let _ = file_read.read_at(10, 5, Alignment::new(1)).await.unwrap();
+    let _unused = file_read.read_at(0, 5, Alignment::new(1)).await.unwrap();
+    let _unused = file_read.read_at(5, 5, Alignment::new(1)).await.unwrap();
+    let _unused = file_read.read_at(10, 5, Alignment::new(1)).await.unwrap();
 
     // Check that our custom IoSource was called 3 times
     assert_eq!(read_count.load(Ordering::SeqCst), 3);

--- a/vortex-io/src/runtime/tests.rs
+++ b/vortex-io/src/runtime/tests.rs
@@ -290,9 +290,9 @@ async fn test_custom_io_source() {
     let file_read = handle.open_read(source, Default::default()).unwrap();
 
     // Perform several reads
-    let _unused = file_read.read_at(0, 5, Alignment::new(1)).await.unwrap();
-    let _unused = file_read.read_at(5, 5, Alignment::new(1)).await.unwrap();
-    let _unused = file_read.read_at(10, 5, Alignment::new(1)).await.unwrap();
+    file_read.read_at(0, 5, Alignment::new(1)).await.unwrap();
+    file_read.read_at(5, 5, Alignment::new(1)).await.unwrap();
+    file_read.read_at(10, 5, Alignment::new(1)).await.unwrap();
 
     // Check that our custom IoSource was called 3 times
     assert_eq!(read_count.load(Ordering::SeqCst), 3);

--- a/vortex-layout/src/layouts/dict/writer.rs
+++ b/vortex-layout/src/layouts/dict/writer.rs
@@ -370,7 +370,7 @@ impl Stream for DictionaryTransformer {
                         // Receiver dropped, close this group
                         self.active_codes_tx = None;
                         if let Some(values_tx) = self.active_values_tx.take() {
-                            let _ = values_tx.send(Err(vortex_err!("values receiver dropped")));
+                            drop(values_tx.send(Err(vortex_err!("values receiver dropped"))));
                         }
                     }
                     Poll::Pending => {
@@ -423,14 +423,14 @@ impl Stream for DictionaryTransformer {
                 Poll::Ready(Some(Ok(DictionaryChunk::Values(values)))) => {
                     // Complete the current group
                     if let Some(values_tx) = self.active_values_tx.take() {
-                        let _ = values_tx.send(Ok(values));
+                        drop(values_tx.send(Ok(values)));
                     }
                     self.active_codes_tx = None; // Close codes stream
                 }
                 Poll::Ready(Some(Err(e))) => {
                     // Send error to active channels if any
                     if let Some(values_tx) = self.active_values_tx.take() {
-                        let _ = values_tx.send(Err(e));
+                        drop(values_tx.send(Err(e)));
                     }
                     self.active_codes_tx = None;
                     // And terminate the stream
@@ -439,7 +439,7 @@ impl Stream for DictionaryTransformer {
                 Poll::Ready(None) => {
                     // Handle any incomplete group
                     if let Some(values_tx) = self.active_values_tx.take() {
-                        let _ = values_tx.send(Err(vortex_err!("Incomplete dictionary group")));
+                        drop(values_tx.send(Err(vortex_err!("Incomplete dictionary group"))));
                     }
                     self.active_codes_tx = None;
                     return Poll::Ready(None);

--- a/vortex-mask/src/bitops.rs
+++ b/vortex-mask/src/bitops.rs
@@ -181,7 +181,7 @@ mod tests {
     fn test_bitand_different_lengths() {
         let mask1 = Mask::new_true(5);
         let mask2 = Mask::new_true(3);
-        let _ = &mask1 & &mask2;
+        let _unused = &mask1 & &mask2;
     }
 
     #[test]

--- a/vortex-mask/src/intersect_by_rank.rs
+++ b/vortex-mask/src/intersect_by_rank.rs
@@ -149,7 +149,7 @@ mod test {
     fn test_intersect_by_rank_wrong_length() {
         let m1 = Mask::from_indices(10, vec![2, 5, 7]); // 3 true values
         let m2 = Mask::new_true(5); // 5 true values - doesn't match
-        let _ = m1.intersect_by_rank(&m2);
+        let _unused = m1.intersect_by_rank(&m2);
     }
 
     #[rstest]

--- a/vortex-mask/src/intersect_by_rank.rs
+++ b/vortex-mask/src/intersect_by_rank.rs
@@ -149,7 +149,7 @@ mod test {
     fn test_intersect_by_rank_wrong_length() {
         let m1 = Mask::from_indices(10, vec![2, 5, 7]); // 3 true values
         let m2 = Mask::new_true(5); // 5 true values - doesn't match
-        let _unused = m1.intersect_by_rank(&m2);
+        m1.intersect_by_rank(&m2);
     }
 
     #[rstest]

--- a/vortex-mask/src/mask_mut.rs
+++ b/vortex-mask/src/mask_mut.rs
@@ -555,7 +555,7 @@ mod tests {
     #[should_panic(expected = "split_off index out of bounds")]
     fn test_split_off_out_of_bounds() {
         let mut mask = MaskMut::new_true(10);
-        let _unused = mask.split_off(11);
+        mask.split_off(11);
     }
 
     #[test]

--- a/vortex-mask/src/mask_mut.rs
+++ b/vortex-mask/src/mask_mut.rs
@@ -555,7 +555,7 @@ mod tests {
     #[should_panic(expected = "split_off index out of bounds")]
     fn test_split_off_out_of_bounds() {
         let mut mask = MaskMut::new_true(10);
-        let _ = mask.split_off(11);
+        let _unused = mask.split_off(11);
     }
 
     #[test]

--- a/vortex-mask/src/tests.rs
+++ b/vortex-mask/src/tests.rs
@@ -141,7 +141,7 @@ fn test_mask_slice() {
 #[should_panic]
 fn test_mask_slice_out_of_bounds() {
     let mask = Mask::new_true(5);
-    let _unused = mask.slice(3..8); // offset + length > len
+    mask.slice(3..8); // offset + length > len
 }
 
 // Limit operations
@@ -374,7 +374,7 @@ fn test_mask_valid_counts_for_indices() {
 fn test_mask_valid_counts_for_indices_error() {
     let mask = Mask::from_buffer(BitBuffer::from_iter([true, false, true]));
     let indices = vec![0, 2, 5]; // 5 is out of bounds
-    let _unused = mask.valid_counts_for_indices(&indices);
+    mask.valid_counts_for_indices(&indices);
 }
 
 // FromIterator tests
@@ -441,37 +441,37 @@ fn test_mask_from_iter_with_empty_masks() {
 #[test]
 #[should_panic]
 fn test_mask_from_indices_unsorted() {
-    let _unused = Mask::from_indices(5, vec![2, 0, 3]); // Not sorted
+    Mask::from_indices(5, vec![2, 0, 3]); // Not sorted
 }
 
 #[test]
 #[should_panic]
 fn test_mask_from_indices_out_of_bounds() {
-    let _unused = Mask::from_indices(5, vec![0, 2, 5]); // 5 is out of bounds
+    Mask::from_indices(5, vec![0, 2, 5]); // 5 is out of bounds
 }
 
 #[test]
 #[should_panic]
 fn test_mask_from_slices_invalid_range() {
-    let _unused = Mask::from_slices(5, vec![(2, 2)]); // Invalid range where start == end
+    Mask::from_slices(5, vec![(2, 2)]); // Invalid range where start == end
 }
 
 #[test]
 #[should_panic]
 fn test_mask_from_slices_out_of_bounds() {
-    let _unused = Mask::from_slices(5, vec![(0, 6)]); // end > len
+    Mask::from_slices(5, vec![(0, 6)]); // end > len
 }
 
 #[test]
 #[should_panic]
 fn test_mask_from_slices_unsorted() {
-    let _unused = Mask::from_slices(5, vec![(2, 3), (0, 1)]); // Not sorted
+    Mask::from_slices(5, vec![(2, 3), (0, 1)]); // Not sorted
 }
 
 #[test]
 #[should_panic]
 fn test_mask_from_slices_overlapping() {
-    let _unused = Mask::from_slices(5, vec![(0, 3), (2, 4)]); // Overlapping ranges
+    Mask::from_slices(5, vec![(0, 3), (2, 4)]); // Overlapping ranges
 }
 
 // Threshold iterator tests

--- a/vortex-mask/src/tests.rs
+++ b/vortex-mask/src/tests.rs
@@ -141,7 +141,7 @@ fn test_mask_slice() {
 #[should_panic]
 fn test_mask_slice_out_of_bounds() {
     let mask = Mask::new_true(5);
-    let _ = mask.slice(3..8); // offset + length > len
+    let _unused = mask.slice(3..8); // offset + length > len
 }
 
 // Limit operations
@@ -374,7 +374,7 @@ fn test_mask_valid_counts_for_indices() {
 fn test_mask_valid_counts_for_indices_error() {
     let mask = Mask::from_buffer(BitBuffer::from_iter([true, false, true]));
     let indices = vec![0, 2, 5]; // 5 is out of bounds
-    let _ = mask.valid_counts_for_indices(&indices);
+    let _unused = mask.valid_counts_for_indices(&indices);
 }
 
 // FromIterator tests
@@ -441,37 +441,37 @@ fn test_mask_from_iter_with_empty_masks() {
 #[test]
 #[should_panic]
 fn test_mask_from_indices_unsorted() {
-    let _ = Mask::from_indices(5, vec![2, 0, 3]); // Not sorted
+    let _unused = Mask::from_indices(5, vec![2, 0, 3]); // Not sorted
 }
 
 #[test]
 #[should_panic]
 fn test_mask_from_indices_out_of_bounds() {
-    let _ = Mask::from_indices(5, vec![0, 2, 5]); // 5 is out of bounds
+    let _unused = Mask::from_indices(5, vec![0, 2, 5]); // 5 is out of bounds
 }
 
 #[test]
 #[should_panic]
 fn test_mask_from_slices_invalid_range() {
-    let _ = Mask::from_slices(5, vec![(2, 2)]); // Invalid range where start == end
+    let _unused = Mask::from_slices(5, vec![(2, 2)]); // Invalid range where start == end
 }
 
 #[test]
 #[should_panic]
 fn test_mask_from_slices_out_of_bounds() {
-    let _ = Mask::from_slices(5, vec![(0, 6)]); // end > len
+    let _unused = Mask::from_slices(5, vec![(0, 6)]); // end > len
 }
 
 #[test]
 #[should_panic]
 fn test_mask_from_slices_unsorted() {
-    let _ = Mask::from_slices(5, vec![(2, 3), (0, 1)]); // Not sorted
+    let _unused = Mask::from_slices(5, vec![(2, 3), (0, 1)]); // Not sorted
 }
 
 #[test]
 #[should_panic]
 fn test_mask_from_slices_overlapping() {
-    let _ = Mask::from_slices(5, vec![(0, 3), (2, 4)]); // Overlapping ranges
+    let _unused = Mask::from_slices(5, vec![(0, 3), (2, 4)]); // Overlapping ranges
 }
 
 // Threshold iterator tests

--- a/vortex-scalar/src/arrow/tests.rs
+++ b/vortex-scalar/src/arrow/tests.rs
@@ -228,7 +228,7 @@ fn test_struct_scalar_to_arrow_todo() {
         struct_dtype,
         vec![Scalar::primitive(42i32, Nullability::NonNullable)],
     );
-    let _ = Arc::<dyn Datum>::try_from(&struct_scalar);
+    Arc::<dyn Datum>::try_from(&struct_scalar).unwrap();
 }
 
 #[test]
@@ -244,7 +244,7 @@ fn test_list_scalar_to_arrow_todo() {
         Nullability::NonNullable,
     );
 
-    let _ = Arc::<dyn Datum>::try_from(&list_scalar);
+    Arc::<dyn Datum>::try_from(&list_scalar).unwrap();
 }
 
 #[test]
@@ -263,7 +263,7 @@ fn test_non_temporal_extension_to_arrow_todo() {
         Scalar::primitive(42i32, Nullability::NonNullable),
     );
 
-    let _ = Arc::<dyn Datum>::try_from(&scalar);
+    Arc::<dyn Datum>::try_from(&scalar).unwrap();
 }
 
 #[rstest]

--- a/vortex-scalar/src/list.rs
+++ b/vortex-scalar/src/list.rs
@@ -549,7 +549,7 @@ mod tests {
         let children = vec![
             Scalar::primitive(1i64, Nullability::NonNullable), // Wrong type!
         ];
-        let _ = Scalar::list(element_dtype, children, Nullability::NonNullable);
+        Scalar::list(element_dtype, children, Nullability::NonNullable);
     }
 
     #[test]

--- a/vortex/examples/tracing_vortex.rs
+++ b/vortex/examples/tracing_vortex.rs
@@ -169,7 +169,7 @@ struct ShutdownSignal {
 impl ShutdownSignal {
     fn signal(self) {
         // Drop the sender, signaling to any receiver that it is finished writing.
-        let _ = self.inner.lock().unwrap().take();
+        drop(self.inner.lock().unwrap().take());
     }
 }
 
@@ -221,7 +221,7 @@ where
         };
 
         // Send to async writer (non-blocking)
-        let _ = sender.send(trace_event);
+        let _unused = sender.send(trace_event);
     }
 }
 


### PR DESCRIPTION
I'm curious for opinions on this.

I stubbed my toe recently on:

```
let _ = span.enter();
```

Which does not enter the span for the remainder of the function (it immediately drops the span). There is already a by-default-deny lint for `let _ = lock()` but no such lint for other guard-like things:

- [`tracing::Span::enter()`](https://docs.rs/tracing/latest/tracing/struct.Span.html#method.enter)
- [`xshell::Shell::push_dir`](https://docs.rs/xshell/latest/xshell/struct.Shell.html#method.push_dir)