### PR TITLE
Feature: Conversion from `PrimitiveVector` to `PrimitiveArray`

### DIFF
--- a/vortex-array/src/arrays/primitive/array/conversion.rs
+++ b/vortex-array/src/arrays/primitive/array/conversion.rs
@@ -4,8 +4,9 @@
 //! Conversion methods and trait implementations of [`From`] and [`Into`] for [`PrimitiveArray`].
 
 use vortex_buffer::{BitBufferMut, Buffer, BufferMut};
-use vortex_dtype::NativePType;
-use vortex_error::vortex_panic;
+use vortex_dtype::{NativePType, Nullability};
+use vortex_error::{VortexResult, vortex_ensure, vortex_panic};
+use vortex_vector::{PrimitiveVector, VectorOps, match_each_pvector};
 
 use crate::arrays::PrimitiveArray;
 use crate::validity::Validity;
@@ -13,6 +14,34 @@ use crate::vtable::ValidityHelper;
 use crate::{ArrayRef, IntoArray};
 
 impl PrimitiveArray {
+    /// Attempts to create a `PrimitiveArray` from a [`PrimitiveVector`] given a [`Nullability`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the nullability is [`NonNullable`](Nullability::NonNullable) and there
+    /// are nulls present in the vector.
+    pub fn try_from_vector(
+        primitive_vector: PrimitiveVector,
+        nullability: Nullability,
+    ) -> VortexResult<Self> {
+        // If we want to create a non-nullable array, then the vector should not have any nulls.
+        vortex_ensure!(
+            nullability.is_nullable() || primitive_vector.validity().all_true(),
+            "tried to create a non-nullable `PrimitiveArray` from a `PrimitiveVector` that had nulls"
+        );
+
+        match_each_pvector!(primitive_vector, |v| {
+            let (buffer, mask) = v.into_parts();
+            debug_assert_eq!(buffer.len(), mask.len());
+
+            let validity = Validity::from_mask(mask, nullability);
+
+            // SAFETY: Since the buffer and the mask came from a valid vector, we know that the
+            // length of the buffer and the validity are the same.
+            Ok(unsafe { Self::new_unchecked(buffer, validity) })
+        })
+    }
+
     /// Create a PrimitiveArray from an iterator of `T`.
     /// NOTE: we cannot impl FromIterator trait since it conflicts with `FromIterator<T>`.
     pub fn from_option_iter<T: NativePType, I: IntoIterator<Item = Option<T>>>(iter: I) -> Self {
@@ -105,5 +134,71 @@ impl<T: NativePType> IntoArray for Buffer<T> {
 impl<T: NativePType> IntoArray for BufferMut<T> {
     fn into_array(self) -> ArrayRef {
         self.freeze().into_array()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_buffer::BufferMut;
+    use vortex_dtype::{Nullability, PType};
+    use vortex_mask::MaskMut;
+    use vortex_vector::PVector;
+
+    use super::*;
+
+    #[test]
+    fn test_try_from_vector_with_nulls_nullable() {
+        // Create a vector with some null values: [Some(1), None, Some(3), Some(4), None].
+        let mut values = BufferMut::<i32>::with_capacity(5);
+        values.extend_from_slice(&[1, 0, 3, 4, 0]);
+
+        let mut validity = MaskMut::with_capacity(5);
+        validity.append_n(true, 1);
+        validity.append_n(false, 1);
+        validity.append_n(true, 1);
+        validity.append_n(true, 1);
+        validity.append_n(false, 1);
+
+        let pvector =
+            PVector::try_new(values.freeze(), validity.freeze()).expect("Failed to create PVector");
+
+        // This should succeed since we're allowing nulls.
+        let result =
+            PrimitiveArray::try_from_vector(pvector.into(), Nullability::Nullable).unwrap();
+
+        assert_eq!(result.len(), 5);
+        assert_eq!(result.ptype(), PType::I32);
+        assert!(result.is_valid(0));
+        assert!(!result.is_valid(1));
+        assert!(result.is_valid(2));
+        assert!(result.is_valid(3));
+        assert!(!result.is_valid(4));
+    }
+
+    #[test]
+    fn test_try_from_vector_non_nullable_with_nulls_errors() {
+        // Create a vector with null values: [Some(1), None, Some(3)].
+        let mut values = BufferMut::<i32>::with_capacity(3);
+        values.extend_from_slice(&[1, 0, 3]);
+
+        let mut validity = MaskMut::with_capacity(3);
+        validity.append_n(true, 1);
+        validity.append_n(false, 1);
+        validity.append_n(true, 1);
+
+        let pvector =
+            PVector::try_new(values.freeze(), validity.freeze()).expect("Failed to create PVector");
+
+        // This should fail because we're trying to create a non-nullable array from data with
+        // nulls.
+        let result = PrimitiveArray::try_from_vector(pvector.into(), Nullability::NonNullable);
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("non-nullable `PrimitiveArray`")
+        );
     }
 }

--- a/vortex-vector/src/macros.rs
+++ b/vortex-vector/src/macros.rs
@@ -11,8 +11,10 @@
 ///
 /// # Examples
 ///
-/// ```ignore
-/// use vortex_vector::{Vector, BoolVectorMut, NullVector, VectorOps, VectorMutOps};
+/// ```
+/// use vortex_vector::{
+///     Vector, BoolVectorMut, NullVector, VectorOps, VectorMutOps, match_each_vector
+/// };
 ///
 /// fn get_vector_length(vector: &Vector) -> usize {
 ///     match_each_vector!(vector, |v| { v.len() })
@@ -66,8 +68,10 @@ pub(crate) use match_each_vector;
 ///
 /// # Examples
 ///
-/// ```ignore
-/// use vortex_vector::{VectorMut, BoolVectorMut, NullVectorMut, VectorMutOps};
+/// ```
+/// use vortex_vector::{
+///     VectorMut, BoolVectorMut, NullVectorMut, VectorMutOps, match_each_vector_mut
+/// };
 ///
 /// fn reserve_space(vector: &mut VectorMut, additional: usize) {
 ///     match_each_vector_mut!(vector, |v| { v.reserve(additional) })

--- a/vortex-vector/src/primitive/macros.rs
+++ b/vortex-vector/src/primitive/macros.rs
@@ -16,8 +16,8 @@
 ///
 /// # Examples
 ///
-/// ```ignore
-/// use vortex_vector::{PrimitiveVector, PVectorMut, VectorOps, VectorMutOps};
+/// ```
+/// use vortex_vector::{PrimitiveVector, PVectorMut, VectorOps, VectorMutOps, match_each_pvector};
 ///
 /// fn get_primitive_len(vector: &PrimitiveVector) -> usize {
 ///     match_each_pvector!(vector, |v| { v.len() })
@@ -103,8 +103,8 @@ pub(crate) use match_each_pvector;
 ///
 /// # Examples
 ///
-/// ```ignore
-/// use vortex_vector::{PrimitiveVectorMut, PVectorMut, VectorMutOps};
+/// ```
+/// use vortex_vector::{PrimitiveVectorMut, PVectorMut, VectorMutOps, match_each_pvector_mut};
 ///
 /// fn reserve_primitive_space(vector: &mut PrimitiveVectorMut, additional: usize) {
 ///     match_each_pvector_mut!(vector, |v| { v.reserve(additional) })
@@ -125,6 +125,7 @@ pub(crate) use match_each_pvector;
 ///
 /// [`PrimitiveVectorMut`]: crate::PrimitiveVectorMut
 /// [`VectorMutOps`]: crate::VectorMutOps
+#[macro_export]
 macro_rules! match_each_pvector_mut {
     ($self:expr, | $vec:ident | $body:block) => {{
         match $self {


### PR DESCRIPTION
Tracking Issue: https://github.com/vortex-data/vortex/issues/5028

Eventually, we want to have a general `Vector` -> `Array` function that takes a `DType`, but we can wait for when we have more vectors implemented.