### PR TITLE
Remove mimalloc from vortex-python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9222,7 +9222,6 @@ dependencies = [
  "arrow-schema",
  "itertools 0.14.0",
  "log",
- "mimalloc",
  "object_store",
  "parking_lot",
  "pyo3",

--- a/vortex-python/Cargo.toml
+++ b/vortex-python/Cargo.toml
@@ -27,7 +27,6 @@ arrow-data = { workspace = true }
 arrow-schema = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
-mimalloc = { workspace = true }
 object_store = { workspace = true, features = ["aws", "gcp", "azure", "http"] }
 parking_lot = { workspace = true }
 pyo3 = { workspace = true, features = ["abi3", "abi3-py311"] }

--- a/vortex-python/src/lib.rs
+++ b/vortex-python/src/lib.rs
@@ -29,9 +29,6 @@ use tokio::runtime::Runtime;
 use vortex::error::{VortexError, VortexExpect as _};
 use vortex::io::runtime::tokio::TokioRuntime;
 
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 static TOKIO_RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
     Runtime::new()
         .map_err(VortexError::from)


### PR DESCRIPTION
This can cause issues with other packages that play around with allocators. It might be solvable but for now I think it makes more sense to just just remove it.