### PR TITLE
Performance: `ListViewArray` zero-copyable to `ListArray` optimizations

### DIFF
--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -931,9 +931,16 @@ mod test {
         // List 3: [2] at offset 3, size 1
         let offsets = buffer![0u32, 1, 2, 3].into_array();
         let sizes = buffer![1u32, 1, 1, 1].into_array();
-        let lists = ListViewArray::try_new(elements, offsets, sizes, Validity::AllValid)
-            .unwrap()
-            .into_array();
+        let lists = unsafe {
+            ListViewArray::new_unchecked(
+                elements,
+                offsets,
+                sizes,
+                Validity::AllValid,
+                true, // Is zero-copy to list.
+            )
+        }
+        .into_array();
 
         let indices = buffer![0u8, 3u8, 4u8, 5u8].into_array();
         let fill_value = Scalar::null(lists.dtype().clone());
@@ -978,9 +985,16 @@ mod test {
         let elements = buffer![1i32, 2, 1, 2, 1, 2, 1, 2].into_array();
         let offsets = buffer![0u32, 1, 2, 3, 4, 5, 6, 7].into_array();
         let sizes = buffer![1u32, 1, 1, 1, 1, 1, 1, 1].into_array();
-        let lists = ListViewArray::try_new(elements, offsets, sizes, Validity::AllValid)
-            .unwrap()
-            .into_array();
+        let lists = unsafe {
+            ListViewArray::new_unchecked(
+                elements,
+                offsets,
+                sizes,
+                Validity::AllValid,
+                true, // Is zero-copy to list.
+            )
+        }
+        .into_array();
 
         // Slice to get lists 2..6, which are: [1], [2], [1], [2]
         let lists = lists.slice(2..6);
@@ -1022,9 +1036,16 @@ mod test {
         let elements = buffer![1i32, 2, 1, 2].into_array();
         let offsets = buffer![0u32, 1, 2, 3].into_array();
         let sizes = buffer![1u32, 1, 1, 1].into_array();
-        let lists = ListViewArray::try_new(elements, offsets, sizes, Validity::AllValid)
-            .unwrap()
-            .into_array();
+        let lists = unsafe {
+            ListViewArray::new_unchecked(
+                elements,
+                offsets,
+                sizes,
+                Validity::AllValid,
+                true, // Is zero-copy to list.
+            )
+        }
+        .into_array();
 
         let indices = buffer![0u8, 3u8, 4u8, 5u8].into_array();
         let fill_value = Scalar::from(Some(vec![5i32, 6, 7, 8]));
@@ -1384,8 +1405,15 @@ mod test {
         let offsets = buffer![0u32, 3, 5].into_array();
         let sizes = buffer![3u32, 2, 4].into_array();
 
-        let list_view =
-            ListViewArray::try_new(elements.clone(), offsets, sizes, Validity::AllValid).unwrap();
+        let list_view = unsafe {
+            ListViewArray::new_unchecked(
+                elements.clone(),
+                offsets,
+                sizes,
+                Validity::AllValid,
+                true, // Is zero-copy to list.
+            )
+        };
 
         let list_dtype = list_view.dtype().clone();
 
@@ -1460,9 +1488,16 @@ mod test {
         let offsets = buffer![0u32, 2, 5, 6, 8].into_array();
         let sizes = buffer![2u32, 3, 1, 2, 2].into_array();
 
-        let full_listview = ListViewArray::try_new(elements, offsets, sizes, Validity::AllValid)
-            .unwrap()
-            .into_array();
+        let full_listview = unsafe {
+            ListViewArray::new_unchecked(
+                elements,
+                offsets,
+                sizes,
+                Validity::AllValid,
+                true, // Is zero-copy to list.
+            )
+        }
+        .into_array();
 
         // Slice to get lists 1, 2, 3 (indices 1..4)
         // This gives us lists with elements:

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -932,13 +932,8 @@ mod test {
         let offsets = buffer![0u32, 1, 2, 3].into_array();
         let sizes = buffer![1u32, 1, 1, 1].into_array();
         let lists = unsafe {
-            ListViewArray::new_unchecked(
-                elements,
-                offsets,
-                sizes,
-                Validity::AllValid,
-                true, // Is zero-copy to list.
-            )
+            ListViewArray::new_unchecked(elements, offsets, sizes, Validity::AllValid)
+                .with_zero_copy_to_list(true)
         }
         .into_array();
 
@@ -986,13 +981,8 @@ mod test {
         let offsets = buffer![0u32, 1, 2, 3, 4, 5, 6, 7].into_array();
         let sizes = buffer![1u32, 1, 1, 1, 1, 1, 1, 1].into_array();
         let lists = unsafe {
-            ListViewArray::new_unchecked(
-                elements,
-                offsets,
-                sizes,
-                Validity::AllValid,
-                true, // Is zero-copy to list.
-            )
+            ListViewArray::new_unchecked(elements, offsets, sizes, Validity::AllValid)
+                .with_zero_copy_to_list(true)
         }
         .into_array();
 
@@ -1037,13 +1027,8 @@ mod test {
         let offsets = buffer![0u32, 1, 2, 3].into_array();
         let sizes = buffer![1u32, 1, 1, 1].into_array();
         let lists = unsafe {
-            ListViewArray::new_unchecked(
-                elements,
-                offsets,
-                sizes,
-                Validity::AllValid,
-                true, // Is zero-copy to list.
-            )
+            ListViewArray::new_unchecked(elements, offsets, sizes, Validity::AllValid)
+                .with_zero_copy_to_list(true)
         }
         .into_array();
 
@@ -1406,13 +1391,8 @@ mod test {
         let sizes = buffer![3u32, 2, 4].into_array();
 
         let list_view = unsafe {
-            ListViewArray::new_unchecked(
-                elements.clone(),
-                offsets,
-                sizes,
-                Validity::AllValid,
-                true, // Is zero-copy to list.
-            )
+            ListViewArray::new_unchecked(elements.clone(), offsets, sizes, Validity::AllValid)
+                .with_zero_copy_to_list(true)
         };
 
         let list_dtype = list_view.dtype().clone();
@@ -1489,13 +1469,8 @@ mod test {
         let sizes = buffer![2u32, 3, 1, 2, 2].into_array();
 
         let full_listview = unsafe {
-            ListViewArray::new_unchecked(
-                elements,
-                offsets,
-                sizes,
-                Validity::AllValid,
-                true, // Is zero-copy to list.
-            )
+            ListViewArray::new_unchecked(elements, offsets, sizes, Validity::AllValid)
+                .with_zero_copy_to_list(true)
         }
         .into_array();
 

--- a/fuzz/src/array/mask.rs
+++ b/fuzz/src/array/mask.rs
@@ -57,13 +57,18 @@ pub fn mask_canonical_array(canonical: Canonical, mask: &Mask) -> VortexResult<A
         }
         Canonical::List(array) => {
             let new_validity = apply_mask_to_validity(array.validity(), mask);
-            ListViewArray::try_new(
-                array.elements().clone(),
-                array.offsets().clone(),
-                array.sizes().clone(),
-                new_validity,
-            )
-            .vortex_unwrap()
+
+            // SAFETY: Since we are only masking the validity and everything else comes from an
+            // already valid `ListViewArray`, all of the invariants are still upheld.
+            unsafe {
+                ListViewArray::new_unchecked(
+                    array.elements().clone(),
+                    array.offsets().clone(),
+                    array.sizes().clone(),
+                    new_validity,
+                    array.is_zero_copy_to_list(),
+                )
+            }
             .into_array()
         }
         Canonical::FixedSizeList(array) => {
@@ -243,9 +248,15 @@ mod tests {
         let elements = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5, 6]).into_array();
         let offsets = PrimitiveArray::from_iter([0i32, 2, 4]).into_array();
         let sizes = PrimitiveArray::from_iter([2i32, 2, 2]).into_array();
-        let array =
-            ListViewArray::try_new(elements, offsets, sizes, Nullability::NonNullable.into())
-                .unwrap();
+        let array = unsafe {
+            ListViewArray::new_unchecked(
+                elements,
+                offsets,
+                sizes,
+                Nullability::NonNullable.into(),
+                true, // Is zero-copy to list.
+            )
+        };
 
         let mask = Mask::from_iter([false, true, false]);
 

--- a/fuzz/src/array/mask.rs
+++ b/fuzz/src/array/mask.rs
@@ -66,8 +66,8 @@ pub fn mask_canonical_array(canonical: Canonical, mask: &Mask) -> VortexResult<A
                     array.offsets().clone(),
                     array.sizes().clone(),
                     new_validity,
-                    array.is_zero_copy_to_list(),
                 )
+                .with_zero_copy_to_list(array.is_zero_copy_to_list())
             }
             .into_array()
         }
@@ -249,13 +249,8 @@ mod tests {
         let offsets = PrimitiveArray::from_iter([0i32, 2, 4]).into_array();
         let sizes = PrimitiveArray::from_iter([2i32, 2, 2]).into_array();
         let array = unsafe {
-            ListViewArray::new_unchecked(
-                elements,
-                offsets,
-                sizes,
-                Nullability::NonNullable.into(),
-                true, // Is zero-copy to list.
-            )
+            ListViewArray::new_unchecked(elements, offsets, sizes, Nullability::NonNullable.into())
+                .with_zero_copy_to_list(true)
         };
 
         let mask = Mask::from_iter([false, true, false]);

--- a/fuzz/src/array/slice.rs
+++ b/fuzz/src/array/slice.rs
@@ -78,13 +78,8 @@ pub fn slice_canonical_array(
             // only causes there to be leading and trailing garbage data, which is still
             // zero-copyable to a `ListArray`.
             Ok(unsafe {
-                ListViewArray::new_unchecked(
-                    elements,
-                    offsets,
-                    sizes,
-                    validity,
-                    list_array.is_zero_copy_to_list(),
-                )
+                ListViewArray::new_unchecked(elements, offsets, sizes, validity)
+                    .with_zero_copy_to_list(list_array.is_zero_copy_to_list())
             }
             .into_array())
         }

--- a/fuzz/src/array/slice.rs
+++ b/fuzz/src/array/slice.rs
@@ -74,7 +74,19 @@ pub fn slice_canonical_array(
             // Since the list view elements can be stored out of order, we cannot slice it.
             let elements = list_array.elements().clone();
 
-            ListViewArray::try_new(elements, offsets, sizes, validity).map(|a| a.into_array())
+            // SAFETY: If the array was already zero-copyable to list, slicing the offsets and sizes
+            // only causes there to be leading and trailing garbage data, which is still
+            // zero-copyable to a `ListArray`.
+            Ok(unsafe {
+                ListViewArray::new_unchecked(
+                    elements,
+                    offsets,
+                    sizes,
+                    validity,
+                    list_array.is_zero_copy_to_list(),
+                )
+            }
+            .into_array())
         }
         DType::FixedSizeList(..) => {
             let fsl_array = array.to_fixed_size_list();

--- a/vortex-array/src/arrays/chunked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/chunked/vtable/canonical.rs
@@ -163,16 +163,17 @@ fn swizzle_list_chunks(
     let offsets = PrimitiveArray::new(offsets.freeze(), Validity::NonNullable).into_array();
     let sizes = PrimitiveArray::new(sizes.freeze(), Validity::NonNullable).into_array();
 
-    // Since we made sure that all chunk were zero-copyable to list above, we know that the final
-    // output is also zero-copyable to a list.
-    let is_zctl = true;
-
     // SAFETY:
     // - `offsets` and `sizes` are non-nullable u64 arrays of the same length
     // - Each `offset[i] + size[i]` list view is within bounds of elements array because it came
     //   from valid chunks
     // - Validity came from the outer chunked array so it must have the same length
-    unsafe { ListViewArray::new_unchecked(chunked_elements, offsets, sizes, validity, is_zctl) }
+    // - Since we made sure that all chunks were zero-copyable to a list above, we know that the
+    //   final concatenated output is also zero-copyable to a list.
+    unsafe {
+        ListViewArray::new_unchecked(chunked_elements, offsets, sizes, validity)
+            .with_zero_copy_to_list(true)
+    }
 }
 
 #[cfg(test)]

--- a/vortex-array/src/arrays/chunked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/chunked/vtable/canonical.rs
@@ -5,7 +5,9 @@ use vortex_buffer::BufferMut;
 use vortex_dtype::{DType, Nullability, PType, StructFields};
 use vortex_error::VortexExpect;
 
-use crate::arrays::{ChunkedArray, ChunkedVTable, ListViewArray, PrimitiveArray, StructArray};
+use crate::arrays::{
+    ChunkedArray, ChunkedVTable, ListViewArray, ListViewRebuildMode, PrimitiveArray, StructArray,
+};
 use crate::builders::{ArrayBuilder, builder_with_capacity};
 use crate::compute::cast;
 use crate::validity::Validity;
@@ -121,6 +123,9 @@ fn swizzle_list_chunks(
 
     for chunk in chunks {
         let chunk_array = chunk.to_listview();
+        // By rebuilding as zero-copy to `List` and trimming all elements (to prevent gaps), we make
+        // the final output `ListView` also zero-copyable to `List`.
+        let chunk_array = chunk_array.rebuild(ListViewRebuildMode::MakeExact);
 
         // Add the `elements` of the current array as a new chunk.
         list_elements_chunks.push(chunk_array.elements().clone());
@@ -158,12 +163,16 @@ fn swizzle_list_chunks(
     let offsets = PrimitiveArray::new(offsets.freeze(), Validity::NonNullable).into_array();
     let sizes = PrimitiveArray::new(sizes.freeze(), Validity::NonNullable).into_array();
 
+    // Since we made sure that all chunk were zero-copyable to list above, we know that the final
+    // output is also zero-copyable to a list.
+    let is_zctl = true;
+
     // SAFETY:
     // - `offsets` and `sizes` are non-nullable u64 arrays of the same length
     // - Each `offset[i] + size[i]` list view is within bounds of elements array because it came
     //   from valid chunks
     // - Validity came from the outer chunked array so it must have the same length
-    unsafe { ListViewArray::new_unchecked(chunked_elements, offsets, sizes, validity) }
+    unsafe { ListViewArray::new_unchecked(chunked_elements, offsets, sizes, validity, is_zctl) }
 }
 
 #[cfg(test)]

--- a/vortex-array/src/arrays/constant/vtable/canonical.rs
+++ b/vortex-array/src/arrays/constant/vtable/canonical.rs
@@ -253,10 +253,13 @@ fn constant_canonical_list_array(scalar: &Scalar, len: usize) -> ListViewArray {
     debug_assert!(!offsets.dtype().is_nullable());
     debug_assert!(!sizes.dtype().is_nullable());
 
+    // Since all views are pointing to the same exact thing, it is not zero-copyable to `ListArray`.
+    let is_zctl = false;
+
     // SAFETY: All views point to the same range [0, list.len()) in the elements array.
     // The elements array contains `len` copies of the same value, offsets are all 0,
     // and sizes are all equal to the list length. The validity matches the scalar's nullability.
-    unsafe { ListViewArray::new_unchecked(elements, offsets, sizes, validity) }
+    unsafe { ListViewArray::new_unchecked(elements, offsets, sizes, validity, is_zctl) }
 }
 
 fn constant_canonical_fixed_size_list_array(

--- a/vortex-array/src/arrays/constant/vtable/canonical.rs
+++ b/vortex-array/src/arrays/constant/vtable/canonical.rs
@@ -253,13 +253,10 @@ fn constant_canonical_list_array(scalar: &Scalar, len: usize) -> ListViewArray {
     debug_assert!(!offsets.dtype().is_nullable());
     debug_assert!(!sizes.dtype().is_nullable());
 
-    // Since all views are pointing to the same exact thing, it is not zero-copyable to `ListArray`.
-    let is_zctl = false;
-
     // SAFETY: All views point to the same range [0, list.len()) in the elements array.
     // The elements array contains `len` copies of the same value, offsets are all 0,
     // and sizes are all equal to the list length. The validity matches the scalar's nullability.
-    unsafe { ListViewArray::new_unchecked(elements, offsets, sizes, validity, is_zctl) }
+    unsafe { ListViewArray::new_unchecked(elements, offsets, sizes, validity) }
 }
 
 fn constant_canonical_fixed_size_list_array(

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use num_traits::AsPrimitive;
-use vortex_dtype::{DType, match_each_integer_ptype, match_each_native_ptype};
+use vortex_dtype::{DType, NativePType, match_each_integer_ptype, match_each_native_ptype};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_ensure};
 
 use crate::arrays::{ListVTable, PrimitiveVTable};
@@ -191,8 +191,11 @@ impl ListArray {
 
                 vortex_ensure!(
                     max_offset
-                        <= P::try_from(elements.len())
-                            .vortex_expect("Offsets type must be able to fit elements length"),
+                        <= P::try_from(elements.len()).vortex_expect(&format!(
+                            "Offsets type {} must be able to fit elements length {}",
+                            <P as NativePType>::PTYPE,
+                            elements.len()
+                        )),
                     "Max offset {max_offset} is beyond the length of the elements array {}",
                     elements.len()
                 );
@@ -265,6 +268,11 @@ impl ListArray {
     pub fn elements(&self) -> &ArrayRef {
         &self.elements
     }
+
+    // TODO(connor)[ListView]: Create 2 functions `reset_offsets` and `recursive_reset_offsets`,
+    // where `reset_offsets` is infallible.
+    // Also, `reset_offsets` can be made more efficient by replacing `sub_scalar` with a match on
+    // the offset type and manual subtraction and fast path where `offsets[0] == 0`.
 
     /// Create a copy of this array by adjusting `offsets` to start at `0` and removing elements not
     /// referenced by the `offsets`.

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 
 use num_traits::AsPrimitive;
 use vortex_dtype::{DType, IntegerPType, match_each_integer_ptype};
-use vortex_error::{VortexExpect, VortexResult, vortex_ensure, vortex_err};
+use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_ensure, vortex_err};
 
-use crate::arrays::PrimitiveVTable;
+use crate::arrays::{PrimitiveArray, PrimitiveVTable, bool};
 use crate::stats::ArrayStats;
 use crate::validity::Validity;
 use crate::{Array, ArrayRef, ToCanonical};
@@ -50,12 +50,12 @@ use crate::{Array, ArrayRef, ToCanonical};
 /// let offsets = buffer![2u32, 0, 1].into_array();  // Out-of-order offsets
 /// let sizes = buffer![2u32, 1, 2].into_array();  // The sizes cause overlaps
 ///
-/// let list_view = ListViewArray::try_new(
+/// let list_view = ListViewArray::new(
 ///     elements.into_array(),
 ///     offsets.into_array(),
 ///     sizes.into_array(),
 ///     Validity::NonNullable,
-/// ).unwrap();
+/// );
 ///
 /// assert_eq!(list_view.len(), 3);
 ///
@@ -94,6 +94,15 @@ pub struct ListViewArray {
     /// we want to access.
     sizes: ArrayRef,
 
+    // TODO(connor)[ListView]: Add the n+1 memory allocation optimization.
+    /// A flag denoting if the array is zero-copyable* to a [`ListArray`](crate::arrays::ListArray).
+    ///
+    /// We use this information to help us more efficiently rebuild / compact our data.
+    ///
+    /// When this flag is true (indicating sorted offsets with no gaps and no overlaps), conversions
+    /// can bypass the very expensive rebuild process (which just calls `append_scalar` in a loop).
+    is_zero_copy_to_list: bool,
+
     /// The validity / null map of the array.
     ///
     /// Note that this null map refers to which list scalars are null, **not** which sub-elements of
@@ -113,7 +122,7 @@ impl ListViewArray {
     /// in [`ListViewArray::new_unchecked`].
     pub fn new(elements: ArrayRef, offsets: ArrayRef, sizes: ArrayRef, validity: Validity) -> Self {
         Self::try_new(elements, offsets, sizes, validity)
-            .vortex_expect("ListViewArray construction failed")
+            .vortex_expect("`ListViewArray` construction failed")
     }
 
     /// Constructs a new `ListViewArray`.
@@ -128,13 +137,29 @@ impl ListViewArray {
         sizes: ArrayRef,
         validity: Validity,
     ) -> VortexResult<Self> {
-        Self::validate(&elements, &offsets, &sizes, &validity)?;
+        Self::validate(&elements, &offsets, &sizes, &validity, false)?;
 
-        // SAFETY: validate ensures all invariants are met.
-        Ok(unsafe { Self::new_unchecked(elements, offsets, sizes, validity) })
+        Ok(Self {
+            dtype: DType::List(Arc::new(elements.dtype().clone()), validity.nullability()),
+            elements,
+            offsets,
+            sizes,
+            validity,
+            is_zero_copy_to_list: false,
+            stats_set: Default::default(),
+        })
     }
 
     /// Creates a new [`ListViewArray`] without validation.
+    ///
+    /// Note that this constructor is slightly different from [`new()`] and [`try_new()`] in that it
+    /// also takes an `is_zctl` flag. This is an optimization flag that allows conversion to a
+    /// [`ListArray`] more efficient. The caller must ensure that the flag is correct when passing
+    /// it to this unsafe constructor.
+    ///
+    /// [`ListArray`]: crate::arrays::ListArray
+    /// [`new()`]: Self::new
+    /// [`try_new()`]: Self::try_new
     ///
     /// # Safety
     ///
@@ -143,17 +168,22 @@ impl ListViewArray {
     /// - `offsets` and `sizes` must be non-nullable integer arrays.
     /// - `offsets` and `sizes` must have the same length.
     /// - Size integer width must be smaller than or equal to offset type (to prevent overflow).
-    /// - For each `i`, `offsets[i] + sizes[i]` must not overflow and must be `<= elements.len()`.
+    /// - For each `i`, `offsets[i] + sizes[i]` must not overflow and must be `<= elements.len()`
+    ///   (even if the corresponding view is defined as null by the validity array).
     /// - If validity is an array, its length must equal `offsets.len()`.
+    /// - If the `is_zctl` flag is true, then the [`ListViewArray`] is zero-copyable to a
+    ///   [`ListArray`].
     pub unsafe fn new_unchecked(
         elements: ArrayRef,
         offsets: ArrayRef,
         sizes: ArrayRef,
         validity: Validity,
+        is_zctl: bool,
     ) -> Self {
-        #[cfg(debug_assertions)]
-        Self::validate(&elements, &offsets, &sizes, &validity)
-            .vortex_expect("[Debug Assertion]: Invalid `ListViewArray` parameters");
+        if cfg!(debug_assertions) {
+            Self::validate(&elements, &offsets, &sizes, &validity, is_zctl)
+                .vortex_expect("Failed to crate `ListViewArray`");
+        }
 
         Self {
             dtype: DType::List(Arc::new(elements.dtype().clone()), validity.nullability()),
@@ -161,6 +191,7 @@ impl ListViewArray {
             offsets,
             sizes,
             validity,
+            is_zero_copy_to_list: is_zctl,
             stats_set: Default::default(),
         }
     }
@@ -171,6 +202,7 @@ impl ListViewArray {
         offsets: &dyn Array,
         sizes: &dyn Array,
         validity: &Validity,
+        is_zctl: bool,
     ) -> VortexResult<()> {
         // Check that offsets and sizes are integer arrays and non-nullable.
         vortex_ensure!(
@@ -207,6 +239,15 @@ impl ListViewArray {
             offset_max
         );
 
+        // If a validity array is present, it must be the same length as the `ListViewArray`.
+        if let Some(validity_len) = validity.maybe_len() {
+            vortex_ensure!(
+                validity_len == offsets.len(),
+                "validity with size {validity_len} does not match array size {}",
+                offsets.len()
+            );
+        }
+
         let offsets_primitive = offsets.to_primitive();
         let sizes_primitive = sizes.to_primitive();
 
@@ -224,13 +265,9 @@ impl ListViewArray {
             })
         });
 
-        // If a validity array is present, it must be the same length as the ListView.
-        if let Some(validity_len) = validity.maybe_len() {
-            vortex_ensure!(
-                validity_len == offsets.len(),
-                "validity with size {validity_len} does not match array size {}",
-                offsets.len()
-            );
+        // Validate the zero-copy to `ListArray` flag.
+        if is_zctl {
+            validate_zctl(elements, offsets_primitive, sizes_primitive)?;
         }
 
         Ok(())
@@ -310,6 +347,12 @@ impl ListViewArray {
     pub fn elements(&self) -> &ArrayRef {
         &self.elements
     }
+
+    /// Returns true if the `ListViewArray` is zero-copyable to a
+    /// [`ListArray`](crate::arrays::ListArray).
+    pub fn is_zero_copy_to_list(&self) -> bool {
+        self.is_zero_copy_to_list
+    }
 }
 
 /// Helper function to validate `offsets` and `sizes` with specific types.
@@ -345,11 +388,87 @@ where
             vortex_err!("offset[{i}] ({offset_u64}) + size[{i}] ({size_u64}) would overflow u64")
         })?;
 
+        if offset_u64 == elements_len {
+            vortex_ensure!(
+                size_u64 == 0,
+                "views to the end of the elements array (length {elements_len}) must have size 0"
+            );
+        }
+
         vortex_ensure!(
             end <= elements_len,
-            "offset[{i}] + size[{i}] = {end} exceeds elements length {elements_len}",
+            "offset[{i}] + size[{i}] = {offset_u64} + {size_u64} = {end} \
+            exceeds elements length {elements_len}",
         );
     }
+
+    Ok(())
+}
+
+/// Helper function to validate if the [`ListViewArray`] components are actually zero-copyable to
+/// [`ListArray`](crate::arrays::ListArray).
+fn validate_zctl(
+    elements: &dyn Array,
+    offsets_primitive: PrimitiveArray,
+    sizes_primitive: PrimitiveArray,
+) -> VortexResult<()> {
+    // Offsets must be sorted (but not strictly sorted, zero-length lists are allowed), even
+    // if there are null views.
+    if let Some(is_sorted) = offsets_primitive.statistics().compute_is_sorted() {
+        vortex_ensure!(is_sorted, "offsets must be sorted");
+    } else {
+        vortex_bail!("offsets must report is_sorted statistic");
+    }
+
+    // TODO(connor)[ListView]: Making this allocation is expensive, but the more efficient
+    // implementation would be even more complicated than this. We could use a bit buffer denoting
+    // if positions in `elements` are used, and then additionally store a separate flag that tells
+    // us if a position is used more than once.
+    let mut element_references = vec![0u8; elements.len()];
+
+    fn count_references<O: IntegerPType, S: IntegerPType>(
+        element_references: &mut [u8],
+        offsets_primitive: PrimitiveArray,
+        sizes_primitive: PrimitiveArray,
+    ) {
+        let offsets_slice = offsets_primitive.as_slice::<O>();
+        let sizes_slice = sizes_primitive.as_slice::<S>();
+
+        // Note that we ignore nulls here, as the "null" view metadata must still maintain the same
+        // invariants as non-null views, even for a `bool` information.
+        for i in 0..offsets_slice.len() {
+            let offset: usize = offsets_slice[i].as_();
+            let size: usize = sizes_slice[i].as_();
+            for j in offset..offset + size {
+                element_references[j] = element_references[j].saturating_add(1);
+            }
+        }
+    }
+
+    match_each_integer_ptype!(offsets_primitive.ptype(), |O| {
+        match_each_integer_ptype!(sizes_primitive.ptype(), |S| {
+            count_references::<O, S>(&mut element_references, offsets_primitive, sizes_primitive);
+        })
+    });
+
+    // Allow leading and trailing unreferenced elements, but not gaps in the middle.
+    let leftmost_used = element_references
+        .iter()
+        .position(|&references| references != 0);
+    let rightmost_used = element_references
+        .iter()
+        .rposition(|&references| references != 0);
+
+    if let (Some(first_ref), Some(last_ref)) = (leftmost_used, rightmost_used) {
+        vortex_ensure!(
+            element_references[first_ref..=last_ref]
+                .iter()
+                .all(|&references| references != 0),
+            "found gap in elements array between first and last referenced elements"
+        );
+    }
+
+    vortex_ensure!(element_references.iter().all(|&references| references <= 1));
 
     Ok(())
 }

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -137,7 +137,7 @@ impl ListViewArray {
         sizes: ArrayRef,
         validity: Validity,
     ) -> VortexResult<Self> {
-        Self::validate(&elements, &offsets, &sizes, &validity, false)?;
+        Self::validate(&elements, &offsets, &sizes, &validity)?;
 
         Ok(Self {
             dtype: DType::List(Arc::new(elements.dtype().clone()), validity.nullability()),
@@ -152,10 +152,8 @@ impl ListViewArray {
 
     /// Creates a new [`ListViewArray`] without validation.
     ///
-    /// Note that this constructor is slightly different from [`new()`] and [`try_new()`] in that it
-    /// also takes an `is_zctl` flag. This is an optimization flag that allows conversion to a
-    /// [`ListArray`] more efficient. The caller must ensure that the flag is correct when passing
-    /// it to this unsafe constructor.
+    /// This unsafe function does not check the validity of the data. Prefer calling [`new()`] or
+    /// [`try_new()`] over this function, as they will check the validity of the data.
     ///
     /// [`ListArray`]: crate::arrays::ListArray
     /// [`new()`]: Self::new
@@ -171,17 +169,14 @@ impl ListViewArray {
     /// - For each `i`, `offsets[i] + sizes[i]` must not overflow and must be `<= elements.len()`
     ///   (even if the corresponding view is defined as null by the validity array).
     /// - If validity is an array, its length must equal `offsets.len()`.
-    /// - If the `is_zctl` flag is true, then the [`ListViewArray`] is zero-copyable to a
-    ///   [`ListArray`].
     pub unsafe fn new_unchecked(
         elements: ArrayRef,
         offsets: ArrayRef,
         sizes: ArrayRef,
         validity: Validity,
-        is_zctl: bool,
     ) -> Self {
         if cfg!(debug_assertions) {
-            Self::validate(&elements, &offsets, &sizes, &validity, is_zctl)
+            Self::validate(&elements, &offsets, &sizes, &validity)
                 .vortex_expect("Failed to crate `ListViewArray`");
         }
 
@@ -191,7 +186,7 @@ impl ListViewArray {
             offsets,
             sizes,
             validity,
-            is_zero_copy_to_list: is_zctl,
+            is_zero_copy_to_list: false,
             stats_set: Default::default(),
         }
     }
@@ -202,7 +197,6 @@ impl ListViewArray {
         offsets: &dyn Array,
         sizes: &dyn Array,
         validity: &Validity,
-        is_zctl: bool,
     ) -> VortexResult<()> {
         // Check that offsets and sizes are integer arrays and non-nullable.
         vortex_ensure!(
@@ -265,12 +259,63 @@ impl ListViewArray {
             })
         });
 
-        // Validate the zero-copy to `ListArray` flag.
-        if is_zctl {
-            validate_zctl(elements, offsets_primitive, sizes_primitive)?;
-        }
-
         Ok(())
+    }
+
+    /// Sets whether this [`ListViewArray`] is zero-copyable to a [`ListArray`].
+    ///
+    /// This is an optimization flag that enables more efficient conversion to [`ListArray`] without
+    /// needing to copy or reorganize the data.
+    ///
+    /// [`ListArray`]: crate::arrays::ListArray
+    ///
+    /// # Safety
+    ///
+    /// When setting `is_zctl` to `true`, the caller must ensure that the [`ListViewArray`] is
+    /// actually zero-copyable to a [`ListArray`]. This means:
+    ///
+    /// - Offsets must be sorted (but not strictly sorted, zero-length lists are allowed).
+    /// - No gaps in elements between first and last referenced elements.
+    /// - No overlapping list views (each element referenced at most once).
+    ///
+    /// Note that leading and trailing unreferenced elements **ARE** allowed.
+    pub unsafe fn with_zero_copy_to_list(mut self, is_zctl: bool) -> Self {
+        if cfg!(debug_assertions) && is_zctl {
+            validate_zctl(
+                &self.elements,
+                self.offsets.to_primitive(),
+                self.sizes.to_primitive(),
+            )
+            .vortex_expect("Failed to validate zero-copy to list flag");
+        }
+        self.is_zero_copy_to_list = is_zctl;
+        self
+    }
+
+    /// Verifies that the `ListViewArray` is zero-copyable to a [`ListArray`].
+    ///
+    /// This will run an expensive validation of the `ListViewArray`'s components. It will check the
+    /// following things:
+    ///
+    /// - Offsets must be sorted (but not strictly sorted, zero-length lists are allowed).
+    /// - No gaps in elements between first and last referenced elements.
+    /// - No overlapping list views (each element referenced at most once).
+    ///
+    /// Note that leading and trailing unreferenced elements **ARE** allowed.
+    ///
+    /// This method should really only be called if the caller knows that the `ListViewArray` will
+    /// be converted into a [`ListArray`] in the future, and the caller wants to set the
+    /// optimization flag to `true` with the unsafe [`with_zero_copy_to_list`] method.
+    ///
+    /// [`ListArray`]: crate::arrays::ListArray
+    /// [`with_zero_copy_to_list`]: Self::with_zero_copy_to_list
+    pub fn verify_is_zero_copy_to_list(&self) -> bool {
+        validate_zctl(
+            &self.elements,
+            self.offsets.to_primitive(),
+            self.sizes.to_primitive(),
+        )
+        .is_ok()
     }
 
     /// Returns the offset at the given index.

--- a/vortex-array/src/arrays/listview/compute/cast.rs
+++ b/vortex-array/src/arrays/listview/compute/cast.rs
@@ -7,7 +7,7 @@ use vortex_error::VortexResult;
 use crate::arrays::{ListViewArray, ListViewVTable};
 use crate::compute::{self, CastKernel, CastKernelAdapter};
 use crate::vtable::ValidityHelper;
-use crate::{ArrayRef, register_kernel};
+use crate::{ArrayRef, IntoArray, register_kernel};
 
 impl CastKernel for ListViewVTable {
     fn cast(&self, array: &ListViewArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
@@ -31,10 +31,10 @@ impl CastKernel for ListViewVTable {
                     array.offsets().clone(),
                     array.sizes().clone(),
                     validity,
-                    array.is_zero_copy_to_list(),
                 )
+                .with_zero_copy_to_list(array.is_zero_copy_to_list())
             }
-            .to_array(),
+            .into_array(),
         ))
     }
 }

--- a/vortex-array/src/arrays/listview/compute/cast.rs
+++ b/vortex-array/src/arrays/listview/compute/cast.rs
@@ -31,6 +31,7 @@ impl CastKernel for ListViewVTable {
                     array.offsets().clone(),
                     array.sizes().clone(),
                     validity,
+                    array.is_zero_copy_to_list(),
                 )
             }
             .to_array(),

--- a/vortex-array/src/arrays/listview/compute/filter.rs
+++ b/vortex-array/src/arrays/listview/compute/filter.rs
@@ -55,14 +55,7 @@ impl FilterKernel for ListViewVTable {
         // - Offsets and sizes have the same length (both filtered by `selection_mask`).
         // - Validity matches the filtered array's nullability.
         let new_array = unsafe {
-            ListViewArray::new_unchecked(
-                elements.clone(),
-                new_offsets,
-                new_sizes,
-                new_validity,
-                // Filters will create gaps of unused elements.
-                false,
-            )
+            ListViewArray::new_unchecked(elements.clone(), new_offsets, new_sizes, new_validity)
         };
 
         // TODO(connor)[ListView]: Ideally, we would only rebuild after all `take`s and `filter`

--- a/vortex-array/src/arrays/listview/compute/filter.rs
+++ b/vortex-array/src/arrays/listview/compute/filter.rs
@@ -9,6 +9,7 @@ use crate::compute::{self, FilterKernel, FilterKernelAdapter};
 use crate::vtable::ValidityHelper;
 use crate::{ArrayRef, IntoArray, register_kernel};
 
+// TODO(connor)[ListView]: Make use of this threshold after we start migrating operators.
 /// The threshold for triggering a rebuild of the [`ListViewArray`].
 ///
 /// By default, we will not touch the underlying `elements` array of the [`ListViewArray`] since it
@@ -46,8 +47,6 @@ impl FilterKernel for ListViewVTable {
         );
 
         // Simply filter the offsets and sizes arrays.
-        // Filters keep scalars in order, and it cannot cause overlaps to form. However, filters
-        // **will** create gaps of unused elements.
         let new_offsets = compute::filter(offsets.as_ref(), selection_mask)?;
         let new_sizes = compute::filter(sizes.as_ref(), selection_mask)?;
 
@@ -56,7 +55,14 @@ impl FilterKernel for ListViewVTable {
         // - Offsets and sizes have the same length (both filtered by `selection_mask`).
         // - Validity matches the filtered array's nullability.
         let new_array = unsafe {
-            ListViewArray::new_unchecked(elements.clone(), new_offsets, new_sizes, new_validity)
+            ListViewArray::new_unchecked(
+                elements.clone(),
+                new_offsets,
+                new_sizes,
+                new_validity,
+                // Filters will create gaps of unused elements.
+                false,
+            )
         };
 
         // TODO(connor)[ListView]: Ideally, we would only rebuild after all `take`s and `filter`

--- a/vortex-array/src/arrays/listview/compute/mask.rs
+++ b/vortex-array/src/arrays/listview/compute/mask.rs
@@ -11,13 +11,18 @@ use crate::{ArrayRef, IntoArray, register_kernel};
 
 impl MaskKernel for ListViewVTable {
     fn mask(&self, array: &ListViewArray, mask: &Mask) -> VortexResult<ArrayRef> {
-        ListViewArray::try_new(
-            array.elements().clone(),
-            array.offsets().clone(),
-            array.sizes().clone(),
-            array.validity().mask(mask),
-        )
-        .map(|a| a.into_array())
+        // SAFETY: Since we are only masking the validity and everything else comes from an already
+        // valid `ListViewArray`, all of the invariants are still upheld.
+        Ok(unsafe {
+            ListViewArray::new_unchecked(
+                array.elements().clone(),
+                array.offsets().clone(),
+                array.sizes().clone(),
+                array.validity().mask(mask),
+                array.is_zero_copy_to_list(),
+            )
+        }
+        .into_array())
     }
 }
 

--- a/vortex-array/src/arrays/listview/compute/mask.rs
+++ b/vortex-array/src/arrays/listview/compute/mask.rs
@@ -19,8 +19,8 @@ impl MaskKernel for ListViewVTable {
                 array.offsets().clone(),
                 array.sizes().clone(),
                 array.validity().mask(mask),
-                array.is_zero_copy_to_list(),
             )
+            .with_zero_copy_to_list(array.is_zero_copy_to_list())
         }
         .into_array())
     }

--- a/vortex-array/src/arrays/listview/compute/take.rs
+++ b/vortex-array/src/arrays/listview/compute/take.rs
@@ -6,11 +6,12 @@ use vortex_dtype::{Nullability, match_each_integer_ptype};
 use vortex_error::VortexResult;
 use vortex_scalar::Scalar;
 
-use crate::arrays::{ListViewArray, ListViewRebuildMode, ListViewVTable};
+use crate::arrays::{ListViewArray, ListViewVTable};
 use crate::compute::{self, TakeKernel, TakeKernelAdapter};
 use crate::vtable::ValidityHelper;
 use crate::{Array, ArrayRef, IntoArray, register_kernel};
 
+// TODO(connor)[ListView]: Make use of this threshold after we start migrating operators.
 /// The threshold for triggering a rebuild of the [`ListViewArray`].
 ///
 /// By default, we will not touch the underlying `elements` array of the [`ListViewArray`] since it
@@ -63,7 +64,6 @@ impl TakeKernel for ListViewVTable {
                 &Scalar::primitive(S::zero(), Nullability::NonNullable),
             )?
         });
-
         // SAFETY: Take operation maintains all `ListViewArray` invariants:
         // - `new_offsets` and `new_sizes` are derived from existing valid child arrays.
         // - `new_offsets` and `new_sizes` are non-nullable.
@@ -71,16 +71,18 @@ impl TakeKernel for ListViewVTable {
         //   `indices`).
         // - Validity correctly reflects the combination of array and indices validity.
         let new_array = unsafe {
-            ListViewArray::new_unchecked(elements.clone(), new_offsets, new_sizes, new_validity)
+            ListViewArray::new_unchecked(
+                elements.clone(),
+                new_offsets,
+                new_sizes,
+                new_validity,
+                // Take can reorder offsets, create gaps, and may introduce overlaps if the
+                // `indices` contain duplicates.
+                false,
+            )
         };
 
-        // TODO(connor)[ListView]: Ideally, we would only rebuild after all `take`s and `filter`
-        // compute functions have run, at the "top" of the operator tree. However, we cannot do this
-        // right now, so we will just rebuild every time (similar to `ListArray`).
-
-        Ok(new_array
-            .rebuild(ListViewRebuildMode::MakeZeroCopyToList)
-            .into_array())
+        Ok(new_array.into_array())
     }
 }
 

--- a/vortex-array/src/arrays/listview/compute/take.rs
+++ b/vortex-array/src/arrays/listview/compute/take.rs
@@ -6,7 +6,7 @@ use vortex_dtype::{Nullability, match_each_integer_ptype};
 use vortex_error::VortexResult;
 use vortex_scalar::Scalar;
 
-use crate::arrays::{ListViewArray, ListViewVTable};
+use crate::arrays::{ListViewArray, ListViewRebuildMode, ListViewVTable};
 use crate::compute::{self, TakeKernel, TakeKernelAdapter};
 use crate::vtable::ValidityHelper;
 use crate::{Array, ArrayRef, IntoArray, register_kernel};
@@ -71,18 +71,16 @@ impl TakeKernel for ListViewVTable {
         //   `indices`).
         // - Validity correctly reflects the combination of array and indices validity.
         let new_array = unsafe {
-            ListViewArray::new_unchecked(
-                elements.clone(),
-                new_offsets,
-                new_sizes,
-                new_validity,
-                // Take can reorder offsets, create gaps, and may introduce overlaps if the
-                // `indices` contain duplicates.
-                false,
-            )
+            ListViewArray::new_unchecked(elements.clone(), new_offsets, new_sizes, new_validity)
         };
 
-        Ok(new_array.into_array())
+        // TODO(connor)[ListView]: Ideally, we would only rebuild after all `take`s and `filter`
+        // compute functions have run, at the "top" of the operator tree. However, we cannot do this
+        // right now, so we will just rebuild every time (similar to `ListArray`).
+
+        Ok(new_array
+            .rebuild(ListViewRebuildMode::MakeZeroCopyToList)
+            .into_array())
     }
 }
 

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -43,14 +43,15 @@ pub fn list_view_from_list(list: ListArray) -> ListViewArray {
 
     // SAFETY: Since everything came from an existing valid `ListArray`, and the `sizes` were
     // derived from valid and in-order `offsets`, we know these fields are valid.
+    // We also just came directly from a `ListArray`, so we know this is zero-copyable.
     unsafe {
         ListViewArray::new_unchecked(
             list.elements().clone(),
             adjusted_offsets,
             sizes,
             list.validity().clone(),
-            true, // We just came directly from a `ListArray`, so we know this is zero-copyable.
         )
+        .with_zero_copy_to_list(true)
     }
 }
 
@@ -217,8 +218,8 @@ pub fn recursive_list_from_list_view(array: ArrayRef) -> ArrayRef {
                             listview.offsets().clone(),
                             listview.sizes().clone(),
                             listview.validity().clone(),
-                            listview.is_zero_copy_to_list(),
                         )
+                        .with_zero_copy_to_list(listview.is_zero_copy_to_list())
                     }
                 } else {
                     listview
@@ -537,8 +538,8 @@ mod tests {
                 inner_offsets,
                 inner_sizes,
                 Validity::NonNullable,
-                true, // Is zero-copy to list.
             )
+            .with_zero_copy_to_list(true)
         };
 
         let outer_offsets = buffer![0u32, 1].into_array();
@@ -549,8 +550,8 @@ mod tests {
                 outer_offsets,
                 outer_sizes,
                 Validity::NonNullable,
-                true, // Is zero-copy to list.
             )
+            .with_zero_copy_to_list(true)
         };
 
         let result = recursive_list_from_list_view(outer_listview.clone().into_array());
@@ -589,8 +590,8 @@ mod tests {
                 lv1_offsets,
                 lv1_sizes,
                 Validity::NonNullable,
-                true, // Is zero-copy to list.
             )
+            .with_zero_copy_to_list(true)
         };
 
         let lv2_elements = buffer![3i32, 4].into_array();
@@ -602,8 +603,8 @@ mod tests {
                 lv2_offsets,
                 lv2_sizes,
                 Validity::NonNullable,
-                true, // Is zero-copy to list.
             )
+            .with_zero_copy_to_list(true)
         };
 
         let dtype = lv1.dtype().clone();
@@ -631,8 +632,8 @@ mod tests {
                 innermost_offsets,
                 innermost_sizes,
                 Validity::NonNullable,
-                true, // Is zero-copy to list.
             )
+            .with_zero_copy_to_list(true)
         };
 
         let struct_array = StructArray::try_new(
@@ -651,8 +652,8 @@ mod tests {
                 outer_offsets,
                 outer_sizes,
                 Validity::NonNullable,
-                true, // Is zero-copy to list.
             )
+            .with_zero_copy_to_list(true)
         };
 
         let result = recursive_list_from_list_view(outer_listview.clone().into_array());

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -12,6 +12,9 @@ use crate::vtable::ValidityHelper;
 use crate::{Array, ArrayRef, Canonical, IntoArray, ToCanonical};
 
 /// Creates a [`ListViewArray`] from a [`ListArray`] by computing `sizes` from `offsets`.
+///
+/// The output [`ListViewArray`] will be zero-copyable back to a [`ListArray`], and additionally it
+/// will not have any leading or trailing garbage data.
 pub fn list_view_from_list(list: ListArray) -> ListViewArray {
     // If the list is empty, create an empty `ListViewArray` with the same offset `DType` as the
     // input.
@@ -19,19 +22,24 @@ pub fn list_view_from_list(list: ListArray) -> ListViewArray {
         return Canonical::empty(list.dtype()).into_listview();
     }
 
-    let len = list.len();
+    // We reset the offsets here because mostly for convenience, and also because callers of this
+    // function might not expect the output `ListViewArray` to have a bunch of leading and trailing
+    // garbage data when they turn it back into a `ListArray`.
+    let list = list
+        .reset_offsets(false)
+        .vortex_expect("TODO(connor)[ListView]: This can't fail");
 
-    // Get the `offsets` array directly from the `ListArray` (preserving its type).
     let list_offsets = list.offsets().clone();
 
-    // We need to slice the `offsets` to remove the last element (`ListArray` has n+1 offsets).
-    let adjusted_offsets = list_offsets.slice(0..len);
-
-    // Create sizes array by computing differences between consecutive offsets.
-    // Use the same dtype as the offsets array to ensure compatibility.
+    // Create `sizes` array by computing differences between consecutive offsets.
+    // We use the same `DType` for the sizes as the `offsets` array to ensure compatibility.
     let sizes = match_each_integer_ptype!(list_offsets.dtype().as_ptype(), |O| {
         build_sizes_from_offsets::<O>(&list)
     });
+
+    // We need to slice the `offsets` to remove the last element (`ListArray` has `n + 1` offsets).
+    debug_assert_eq!(list_offsets.len(), list.len() + 1);
+    let adjusted_offsets = list_offsets.slice(0..list.len());
 
     // SAFETY: Since everything came from an existing valid `ListArray`, and the `sizes` were
     // derived from valid and in-order `offsets`, we know these fields are valid.
@@ -41,6 +49,7 @@ pub fn list_view_from_list(list: ListArray) -> ListViewArray {
             adjusted_offsets,
             sizes,
             list.validity().clone(),
+            true, // We just came directly from a `ListArray`, so we know this is zero-copyable.
         )
     }
 }
@@ -52,8 +61,11 @@ fn build_sizes_from_offsets<O: IntegerPType>(list: &ListArray) -> ArrayRef {
 
     // Create `UninitRange` for direct memory access.
     let mut sizes_range = sizes_builder.uninit_range(len);
+
     let offsets = list.offsets().to_primitive();
     let offsets_slice = offsets.as_slice::<O>();
+    debug_assert_eq!(len + 1, offsets_slice.len());
+    debug_assert!(offsets_slice.is_sorted());
 
     // Compute sizes as the difference between consecutive offsets.
     for i in 0..len {
@@ -69,8 +81,41 @@ fn build_sizes_from_offsets<O: IntegerPType>(list: &ListArray) -> ArrayRef {
     sizes_builder.finish_into_primitive().into_array()
 }
 
-/// Creates a [`ListArray`] from a [`ListViewArray`].
+// TODO(connor)[ListView]: Note that it is not exactly zero-copy because we have to add a single
+// offset at the end, but it is fast enough.
+/// Creates a [`ListArray`] from a [`ListViewArray`]. The resulting [`ListArray`] will not have any
+/// leading or trailing garbage data.
+///
+/// If [`ListViewArray::is_zero_copy_to_list`] is `true`, then this operation is fast
+///
+/// Otherwise, this function fall back to the (very) expensive path and will rebuild the
+/// [`ListArray`] from scratch.
 pub fn list_from_list_view(list_view: ListViewArray) -> ListArray {
+    // Fast path if the array is zero-copyable to a `ListArray`.
+    if list_view.is_zero_copy_to_list() {
+        let list_offsets = match_each_integer_ptype!(list_view.offsets().dtype().as_ptype(), |O| {
+            // SAFETY: We checked that the array is zero-copyable to `ListArray`, so the safety
+            // contract is upheld.
+            unsafe { build_list_offsets_from_list_view::<O>(&list_view) }
+        });
+
+        // SAFETY: Because the shape of the `ListViewArray` is zero-copyable to a `ListArray`, we
+        // can simply reuse all of the data (besides the offsets).
+        let new_array = unsafe {
+            ListArray::new_unchecked(
+                list_view.elements().clone(),
+                list_offsets,
+                list_view.validity().clone(),
+            )
+        };
+
+        let new_array = new_array
+            .reset_offsets(false)
+            .vortex_expect("TODO(connor)[ListView]: This can't fail");
+
+        return new_array;
+    }
+
     let elements_dtype = list_view
         .dtype()
         .as_list_element_opt()
@@ -98,6 +143,54 @@ pub fn list_from_list_view(list_view: ListViewArray) -> ListArray {
     })
 }
 
+// TODO(connor)[ListView]: We can optimize this by always keeping extra memory in `ListViewArray`
+// offsets for an `n+1`th offset.
+/// Builds a [`ListArray`] offsets array from a [`ListViewArray`] by constructing `n+1` offsets.
+/// The last offset is computed as `last_offset + last_size`.
+///
+/// # Safety
+///
+/// The [`ListViewArray`] must have offsets that are sorted, and every size must be equal to the gap
+/// between `offset[i]` and `offset[i + 1]`.
+unsafe fn build_list_offsets_from_list_view<O: IntegerPType>(
+    list_view: &ListViewArray,
+) -> ArrayRef {
+    let len = list_view.len();
+    let mut offsets_builder =
+        PrimitiveBuilder::<O>::with_capacity(Nullability::NonNullable, len + 1);
+
+    // Create uninit range for direct memory access.
+    let mut offsets_range = offsets_builder.uninit_range(len + 1);
+
+    let offsets = list_view.offsets().to_primitive();
+    let offsets_slice = offsets.as_slice::<O>();
+
+    // Copy the existing n offsets.
+    offsets_range.copy_from_slice(0, offsets_slice);
+
+    // Append the final offset (last offset + last size).
+    let final_offset = if len != 0 {
+        let last_offset = offsets_slice[len - 1];
+
+        let last_size = list_view.size_at(len - 1);
+        let last_size =
+            O::from_usize(last_size).vortex_expect("size somehow did not fit into offsets");
+
+        last_offset + last_size
+    } else {
+        O::zero()
+    };
+
+    offsets_range.set_value(len, final_offset);
+
+    // SAFETY: We have initialized all values in the range.
+    unsafe {
+        offsets_range.finish();
+    }
+
+    offsets_builder.finish_into_primitive().into_array()
+}
+
 /// Recursively converts all [`ListViewArray`]s to [`ListArray`]s in a nested array structure.
 ///
 /// The conversion happens bottom-up, processing children before parents.
@@ -111,17 +204,22 @@ pub fn recursive_list_from_list_view(array: ArrayRef) -> ArrayRef {
     match canonical {
         Canonical::List(listview) => {
             let converted_elements = recursive_list_from_list_view(listview.elements().clone());
+            debug_assert_eq!(converted_elements.len(), listview.elements().len());
 
             // Avoid cloning if elements didn't change.
             let listview_with_converted_elements =
                 if !Arc::ptr_eq(&converted_elements, listview.elements()) {
-                    ListViewArray::try_new(
-                        converted_elements,
-                        listview.offsets().clone(),
-                        listview.sizes().clone(),
-                        listview.validity().clone(),
-                    )
-                    .vortex_expect("ListView reconstruction should not fail with valid components")
+                    // SAFETY: We are effectively just replacing the child elements array, which
+                    // must have the same length, so all invariants are maintained.
+                    unsafe {
+                        ListViewArray::new_unchecked(
+                            converted_elements,
+                            listview.offsets().clone(),
+                            listview.sizes().clone(),
+                            listview.validity().clone(),
+                            listview.is_zero_copy_to_list(),
+                        )
+                    }
                 } else {
                     listview
                 };
@@ -433,23 +531,27 @@ mod tests {
         let inner_elements = buffer![1i32, 2, 3].into_array();
         let inner_offsets = buffer![0u32, 2].into_array();
         let inner_sizes = buffer![2u32, 1].into_array();
-        let inner_listview = ListViewArray::try_new(
-            inner_elements,
-            inner_offsets,
-            inner_sizes,
-            Validity::NonNullable,
-        )
-        .unwrap();
+        let inner_listview = unsafe {
+            ListViewArray::new_unchecked(
+                inner_elements,
+                inner_offsets,
+                inner_sizes,
+                Validity::NonNullable,
+                true, // Is zero-copy to list.
+            )
+        };
 
         let outer_offsets = buffer![0u32, 1].into_array();
         let outer_sizes = buffer![1u32, 1].into_array();
-        let outer_listview = ListViewArray::try_new(
-            inner_listview.into_array(),
-            outer_offsets,
-            outer_sizes,
-            Validity::NonNullable,
-        )
-        .unwrap();
+        let outer_listview = unsafe {
+            ListViewArray::new_unchecked(
+                inner_listview.into_array(),
+                outer_offsets,
+                outer_sizes,
+                Validity::NonNullable,
+                true, // Is zero-copy to list.
+            )
+        };
 
         let result = recursive_list_from_list_view(outer_listview.clone().into_array());
 
@@ -481,16 +583,28 @@ mod tests {
         let lv1_elements = buffer![1i32, 2].into_array();
         let lv1_offsets = buffer![0u32].into_array();
         let lv1_sizes = buffer![2u32].into_array();
-        let lv1 =
-            ListViewArray::try_new(lv1_elements, lv1_offsets, lv1_sizes, Validity::NonNullable)
-                .unwrap();
+        let lv1 = unsafe {
+            ListViewArray::new_unchecked(
+                lv1_elements,
+                lv1_offsets,
+                lv1_sizes,
+                Validity::NonNullable,
+                true, // Is zero-copy to list.
+            )
+        };
 
         let lv2_elements = buffer![3i32, 4].into_array();
         let lv2_offsets = buffer![0u32].into_array();
         let lv2_sizes = buffer![2u32].into_array();
-        let lv2 =
-            ListViewArray::try_new(lv2_elements, lv2_offsets, lv2_sizes, Validity::NonNullable)
-                .unwrap();
+        let lv2 = unsafe {
+            ListViewArray::new_unchecked(
+                lv2_elements,
+                lv2_offsets,
+                lv2_sizes,
+                Validity::NonNullable,
+                true, // Is zero-copy to list.
+            )
+        };
 
         let dtype = lv1.dtype().clone();
         let chunked_listviews =
@@ -511,13 +625,15 @@ mod tests {
         let innermost_elements = buffer![1i32, 2, 3].into_array();
         let innermost_offsets = buffer![0u32, 2].into_array();
         let innermost_sizes = buffer![2u32, 1].into_array();
-        let innermost_listview = ListViewArray::try_new(
-            innermost_elements,
-            innermost_offsets,
-            innermost_sizes,
-            Validity::NonNullable,
-        )
-        .unwrap();
+        let innermost_listview = unsafe {
+            ListViewArray::new_unchecked(
+                innermost_elements,
+                innermost_offsets,
+                innermost_sizes,
+                Validity::NonNullable,
+                true, // Is zero-copy to list.
+            )
+        };
 
         let struct_array = StructArray::try_new(
             FieldNames::from(["inner_lists"]),
@@ -529,13 +645,15 @@ mod tests {
 
         let outer_offsets = buffer![0u32, 1].into_array();
         let outer_sizes = buffer![1u32, 1].into_array();
-        let outer_listview = ListViewArray::try_new(
-            struct_array.into_array(),
-            outer_offsets,
-            outer_sizes,
-            Validity::NonNullable,
-        )
-        .unwrap();
+        let outer_listview = unsafe {
+            ListViewArray::new_unchecked(
+                struct_array.into_array(),
+                outer_offsets,
+                outer_sizes,
+                Validity::NonNullable,
+                true, // Is zero-copy to list.
+            )
+        };
 
         let result = recursive_list_from_list_view(outer_listview.clone().into_array());
 

--- a/vortex-array/src/arrays/listview/mod.rs
+++ b/vortex-array/src/arrays/listview/mod.rs
@@ -4,13 +4,13 @@
 mod array;
 pub use array::ListViewArray;
 
-mod conversion;
-pub use conversion::{list_from_list_view, list_view_from_list, recursive_list_from_list_view};
-
 mod compute;
 
 mod vtable;
 pub use vtable::{ListViewEncoding, ListViewVTable};
+
+mod conversion;
+pub use conversion::{list_from_list_view, list_view_from_list, recursive_list_from_list_view};
 
 mod rebuild;
 pub use rebuild::ListViewRebuildMode;

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -111,6 +111,8 @@ impl ListViewArray {
     fn rebuild_trim_elements(&self) -> ListViewArray {
         let start = if self.is_zero_copy_to_list() {
             // If offsets are sorted, then the minimum offset is the first offset.
+            // Note that even if the first view is null, offsets must always be valid, so it is
+            // completely fine for us to use this as a lower-bounded start of the `elements`.
             self.offset_at(0)
         } else {
             self.offsets().statistics().compute_min().vortex_expect(
@@ -152,15 +154,16 @@ impl ListViewArray {
 
         // SAFETY: The only thing we changed was the elements (which we verify through mins and
         // maxes that all adjusted offsets + sizes are within the correct bounds), so the parameters
-        // are valid.
+        // are valid. And if the original array was zero-copyable to list, trimming elements doesn't
+        // change that property.
         unsafe {
             ListViewArray::new_unchecked(
                 sliced_elements,
                 adjusted_offsets,
                 self.sizes().clone(),
                 self.validity().clone(),
-                self.is_zero_copy_to_list(),
             )
+            .with_zero_copy_to_list(self.is_zero_copy_to_list())
         }
     }
 

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use num_traits::FromPrimitive;
 use vortex_dtype::{IntegerPType, Nullability, match_each_integer_ptype};
 use vortex_error::VortexExpect;
+use vortex_scalar::Scalar;
 
 use crate::arrays::ListViewArray;
-use crate::builders::{ArrayBuilder, ListViewBuilder, PrimitiveBuilder, builder_with_capacity};
+use crate::builders::{ArrayBuilder, ListViewBuilder};
 use crate::vtable::ValidityHelper;
-use crate::{Array, IntoArray, ToCanonical};
+use crate::{Array, compute};
 
 /// Modes for rebuilding a [`ListViewArray`].
 pub enum ListViewRebuildMode {
@@ -20,11 +22,17 @@ pub enum ListViewRebuildMode {
     /// [`ListArray`]: crate::arrays::ListArray
     MakeZeroCopyToList,
 
-    /// Removes any unused data from the underlying `elements` array.
+    /// Removes any leading or trailing elements that are unused / not referenced by any views in
+    /// the [`ListViewArray`].
+    TrimElements,
+
+    /// Equivalent to `MakeZeroCopyToList` plus `TrimElements`.
     ///
-    /// This mode will rebuild the `elements` array in the process, but it will keep any overlapping
-    /// lists if they exist.
-    RemoveGaps,
+    /// This is useful when concatenating multiple [`ListViewArray`]s together to create a new
+    /// [`ListViewArray`] that is also zero-copy to a [`ListArray`].
+    ///
+    /// [`ListArray`]: crate::arrays::ListArray
+    MakeExact,
 
     // TODO(connor)[ListView]: Implement some version of this.
     /// Finds the shortest packing / overlapping of list elements.
@@ -38,9 +46,14 @@ pub enum ListViewRebuildMode {
 impl ListViewArray {
     /// Rebuilds the [`ListViewArray`] according to the specified mode.
     pub fn rebuild(&self, mode: ListViewRebuildMode) -> ListViewArray {
+        if self.is_empty() {
+            return self.clone();
+        }
+
         match mode {
-            ListViewRebuildMode::RemoveGaps => self.rebuild_remove_gaps(),
             ListViewRebuildMode::MakeZeroCopyToList => self.rebuild_zero_copy_to_list(),
+            ListViewRebuildMode::TrimElements => self.rebuild_trim_elements(),
+            ListViewRebuildMode::MakeExact => self.rebuild_make_exact(),
             ListViewRebuildMode::OverlapCompression => unimplemented!("Does P=NP?"),
         }
     }
@@ -53,121 +66,111 @@ impl ListViewArray {
     ///
     /// [`ListArray`]: crate::arrays::ListArray
     fn rebuild_zero_copy_to_list(&self) -> ListViewArray {
-        let element_dtype = self
-            .dtype()
-            .as_list_element_opt()
-            .vortex_expect("somehow had a canonical list that was not a list");
+        if self.is_zero_copy_to_list() {
+            // Note that since everything in `ListViewArray` is `Arc`ed, this is quite cheap.
+            return self.clone();
+        }
 
         let offsets_ptype = self.offsets().dtype().as_ptype();
         let sizes_ptype = self.sizes().dtype().as_ptype();
 
         match_each_integer_ptype!(offsets_ptype, |O| {
-            match_each_integer_ptype!(sizes_ptype, |S| {
-                let mut builder = ListViewBuilder::<O, S>::with_capacity(
-                    element_dtype.clone(),
-                    self.dtype().nullability(),
-                    self.elements().len(),
-                    self.len(),
-                );
-
-                builder.extend_from_array(self.as_ref());
-                builder.finish_into_listview()
-            })
+            match_each_integer_ptype!(sizes_ptype, |S| { self.naive_rebuild::<O, S>() })
         })
     }
 
-    /// Rebuilds a [`ListViewArray`] by removing unreferenced elements while preserving overlaps.
-    ///
-    /// This removes "garbage" elements that are not referenced by any list. Unlike
-    /// [`rebuild_flatten()`], this preserves overlap structure where multiple lists may reference
-    /// the same elements.
-    ///
-    /// [`rebuild_flatten()`]: Self::rebuild_flatten
-    fn rebuild_remove_gaps(&self) -> ListViewArray {
-        if self.is_empty() {
-            return self.clone();
-        }
+    /// The inner function for `rebuild_zero_copy_to_list`, which naively rebuilds a `ListViewArray`
+    /// via `append_scalar`.
+    fn naive_rebuild<O: IntegerPType, S: IntegerPType>(&self) -> ListViewArray {
+        let element_dtype = self
+            .dtype()
+            .as_list_element_opt()
+            .vortex_expect("somehow had a canonical list that was not a list");
 
-        let offset_ptype = self.offsets().dtype().as_ptype();
-        let size_ptype = self.sizes().dtype().as_ptype();
+        let mut builder = ListViewBuilder::<O, S>::with_capacity(
+            element_dtype.clone(),
+            self.dtype().nullability(),
+            self.elements().len(),
+            self.len(),
+        );
 
-        match_each_integer_ptype!(offset_ptype, |O| {
-            match_each_integer_ptype!(size_ptype, |S| { self.rebuild_remove_gaps_inner::<O, S>() })
-        })
-    }
-
-    fn rebuild_remove_gaps_inner<O, S>(&self) -> ListViewArray
-    where
-        O: IntegerPType,
-        S: IntegerPType,
-    {
-        let offsets_primitive = self.offsets().to_primitive();
-        let sizes_primitive = self.sizes().to_primitive();
-        let offsets_slice = offsets_primitive.as_slice::<O>();
-        let sizes_slice = sizes_primitive.as_slice::<S>();
-
-        // Mark which elements in the elements array are referenced by at least one list.
-        let mut referenced_elements = vec![false; self.elements().len()];
         for i in 0..self.len() {
-            let offset: usize = offsets_slice[i].as_();
-            let size: usize = sizes_slice[i].as_();
-            for j in offset..offset + size {
-                referenced_elements[j] = true;
-            }
+            let list = self.scalar_at(i);
+
+            builder
+                .append_scalar(&list)
+                .vortex_expect("was unable to extend the `ListViewBuilder`")
         }
 
-        // Fast path: if all elements are referenced, no garbage collection needed.
-        if referenced_elements
-            .iter()
-            .all(|&is_referenced| is_referenced)
-        {
-            return self.clone();
-        }
+        builder.finish_into_listview()
+    }
 
-        // Build a prefix sum that maps each old element index to its new compacted index.
-        // For example, if elements [0, 2, 3] are used, the prefix sum maps: 0->0, 1->1, 2->1, 3->2.
-        let mut prefix_sum = vec![0; self.elements().len()];
-        let mut cumulative_sum = 0;
-        for i in 0..referenced_elements.len() {
-            prefix_sum[i] = cumulative_sum;
-            if referenced_elements[i] {
-                cumulative_sum += 1;
-            }
-        }
+    /// Rebuilds a [`ListViewArray`] by trimming any unused / unreferenced leading and trailing
+    /// elements, which is defined as a contiguous run of values in the `elements` array that are
+    /// not referecened by any views in the corresponding [`ListViewArray`].
+    fn rebuild_trim_elements(&self) -> ListViewArray {
+        let start = if self.is_zero_copy_to_list() {
+            // If offsets are sorted, then the minimum offset is the first offset.
+            self.offset_at(0)
+        } else {
+            self.offsets().statistics().compute_min().vortex_expect(
+                "[ListViewArray::rebuild]: `offsets` must report min statistic that is a `usize`",
+            )
+        };
 
-        // Copy only the referenced elements into a new compacted elements array.
-        let mut elements_builder = builder_with_capacity(self.elements().dtype(), cumulative_sum);
-        for (i, &is_referenced) in referenced_elements.iter().enumerate() {
-            if is_referenced {
-                elements_builder
-                    .append_scalar(&self.elements().scalar_at(i))
-                    .vortex_expect("append scalar");
-            }
-        }
+        let end = if self.is_zero_copy_to_list() {
+            // If offsets are sorted and there are no overlaps (views are always "increasing"), we
+            // can just grab the last offset and last size.
+            let last_offset = self.offset_at(self.len() - 1);
+            let last_size = self.size_at(self.len() - 1);
+            last_offset + last_size
+        } else {
+            let min_max = compute::min_max(
+                &compute::add(self.offsets(), self.sizes())
+                    .vortex_expect("`offsets + sizes` somehow overflowed"),
+            )
+            .vortex_expect("Something went wrong while computing min and max")
+            .vortex_expect("We checked that the array was not empty in the top-level `rebuild`");
 
-        // Remap each old offset to its corresponding new offset in the compacted array.
-        let mut new_offsets_builder =
-            PrimitiveBuilder::<O>::with_capacity(Nullability::NonNullable, self.len());
-        for &old_offset in offsets_slice {
-            let new_offset = prefix_sum[old_offset.as_()];
-            let offset_value =
-                O::from_usize(new_offset).vortex_expect("offset must fit in offset type");
-            new_offsets_builder.append_value(offset_value);
-        }
+            min_max
+                .max
+                .as_primitive()
+                .as_::<usize>()
+                .vortex_expect("unable to interpret the max `offset + size` as a `usize`")
+        };
 
-        // SAFETY: The new offsets array is guaranteed to be valid because:
-        // 1. Each new offset is derived from prefix_sum[old_offset], which maps to a valid index
-        //    in the compacted elements array (guaranteed by the prefix sum construction).
-        // 2. The sizes array is unchanged, so each (new_offset, size) pair still describes a
-        //    valid range within the compacted elements array.
-        // 3. The validity is unchanged and still matches the array length.
+        let adjusted_offsets = match_each_integer_ptype!(self.offsets().dtype().as_ptype(), |O| {
+            let offset = <O as FromPrimitive>::from_usize(start)
+                .vortex_expect("unable to convert the min offset `start` into a `usize`");
+            let scalar = Scalar::primitive(offset, Nullability::NonNullable);
+
+            compute::sub_scalar(self.offsets(), scalar)
+                .vortex_expect("was somehow unable to adjust offsets down by their minimum")
+        });
+
+        let sliced_elements = self.elements().slice(start..end);
+
+        // SAFETY: The only thing we changed was the elements (which we verify through mins and
+        // maxes that all adjusted offsets + sizes are within the correct bounds), so the parameters
+        // are valid.
         unsafe {
             ListViewArray::new_unchecked(
-                elements_builder.finish(),
-                new_offsets_builder.finish().into_array(),
+                sliced_elements,
+                adjusted_offsets,
                 self.sizes().clone(),
                 self.validity().clone(),
+                self.is_zero_copy_to_list(),
             )
+        }
+    }
+
+    fn rebuild_make_exact(&self) -> ListViewArray {
+        if self.is_zero_copy_to_list() {
+            self.rebuild_trim_elements()
+        } else {
+            // When we completely rebuild the `ListViewArray`, we get the benefit that we also trim
+            // any leading and trailing garbage data.
+            self.rebuild_zero_copy_to_list()
         }
     }
 }
@@ -177,159 +180,11 @@ mod tests {
     use vortex_buffer::BitBuffer;
     use vortex_dtype::Nullability;
 
+    use super::ListViewRebuildMode;
     use crate::arrays::{ListViewArray, PrimitiveArray};
     use crate::validity::Validity;
     use crate::vtable::ValidityHelper;
     use crate::{IntoArray, ToCanonical};
-
-    #[test]
-    fn test_rebuild_remove_gaps_with_leading_garbage() {
-        // Create a list view with garbage at the beginning: [_, _, A, B, C]
-        // List 0: offset=2, size=2 -> [A, B]
-        // List 1: offset=3, size=2 -> [B, C]
-        let elements = PrimitiveArray::from_iter(vec![99i32, 98, 1, 2, 3]).into_array();
-        let offsets = PrimitiveArray::from_iter(vec![2u32, 3]).into_array();
-        let sizes = PrimitiveArray::from_iter(vec![2u32, 2]).into_array();
-
-        let listview =
-            ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap();
-
-        let compacted = listview.rebuild_remove_gaps();
-
-        // After GC: elements should be [A, B, C] = [1, 2, 3]
-        assert_eq!(compacted.elements().len(), 3);
-
-        // Offsets should be remapped: old offset 2 -> new offset 0, old offset 3 -> new offset 1
-        assert_eq!(compacted.offset_at(0), 0);
-        assert_eq!(compacted.size_at(0), 2);
-        assert_eq!(compacted.offset_at(1), 1);
-        assert_eq!(compacted.size_at(1), 2);
-
-        // Verify the data is correct by reading the lists
-        let list0 = compacted.list_elements_at(0).to_primitive();
-        assert_eq!(list0.as_slice::<i32>(), &[1, 2]);
-
-        let list1 = compacted.list_elements_at(1).to_primitive();
-        assert_eq!(list1.as_slice::<i32>(), &[2, 3]);
-    }
-
-    #[test]
-    fn test_rebuild_remove_gaps_with_trailing_garbage() {
-        // Create a list view with garbage at the end: [A, B, C, _, _]
-        // List 0: offset=0, size=2 -> [A, B]
-        // List 1: offset=1, size=2 -> [B, C]
-        let elements = PrimitiveArray::from_iter(vec![1i32, 2, 3, 99, 98]).into_array();
-        let offsets = PrimitiveArray::from_iter(vec![0u32, 1]).into_array();
-        let sizes = PrimitiveArray::from_iter(vec![2u32, 2]).into_array();
-
-        let listview =
-            ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap();
-
-        let compacted = listview.rebuild_remove_gaps();
-
-        // After GC: elements should be [A, B, C] = [1, 2, 3]
-        assert_eq!(compacted.elements().len(), 3);
-
-        // Offsets should remain the same since no leading garbage
-        assert_eq!(compacted.offset_at(0), 0);
-        assert_eq!(compacted.offset_at(1), 1);
-    }
-
-    #[test]
-    fn test_rebuild_remove_gaps_no_garbage() {
-        // Create a list view with no garbage: [A, B, C]
-        // List 0: offset=0, size=2 -> [A, B]
-        // List 1: offset=2, size=1 -> [C]
-        let elements = PrimitiveArray::from_iter(vec![1i32, 2, 3]).into_array();
-        let offsets = PrimitiveArray::from_iter(vec![0u32, 2]).into_array();
-        let sizes = PrimitiveArray::from_iter(vec![2u32, 1]).into_array();
-
-        let listview =
-            ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap();
-
-        let compacted = listview.rebuild_remove_gaps();
-
-        // Should be unchanged (fast path)
-        assert_eq!(compacted.elements().len(), 3);
-        assert_eq!(compacted.offset_at(0), 0);
-        assert_eq!(compacted.offset_at(1), 2);
-    }
-
-    #[test]
-    fn test_rebuild_remove_gaps_preserves_overlaps() {
-        // Create a list view with overlapping lists and garbage: [_, A, B, C, _]
-        // List 0: offset=1, size=3 -> [A, B, C]
-        // List 1: offset=2, size=2 -> [B, C] (overlaps with List 0)
-        let elements = PrimitiveArray::from_iter(vec![99i32, 1, 2, 3, 98]).into_array();
-        let offsets = PrimitiveArray::from_iter(vec![1u32, 2]).into_array();
-        let sizes = PrimitiveArray::from_iter(vec![3u32, 2]).into_array();
-
-        let listview =
-            ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap();
-
-        let compacted = listview.rebuild_remove_gaps();
-
-        // After GC: elements should be [A, B, C] = [1, 2, 3]
-        assert_eq!(compacted.elements().len(), 3);
-
-        // Offsets should be remapped but still overlapping:
-        // old offset 1 -> new offset 0, old offset 2 -> new offset 1
-        assert_eq!(compacted.offset_at(0), 0);
-        assert_eq!(compacted.size_at(0), 3);
-        assert_eq!(compacted.offset_at(1), 1);
-        assert_eq!(compacted.size_at(1), 2);
-
-        // Verify both lists still overlap and contain correct data
-        let list0 = compacted.list_elements_at(0).to_primitive();
-        assert_eq!(list0.as_slice::<i32>(), &[1, 2, 3]);
-
-        let list1 = compacted.list_elements_at(1).to_primitive();
-        assert_eq!(list1.as_slice::<i32>(), &[2, 3]);
-    }
-
-    #[test]
-    fn test_rebuild_remove_gaps_multiple_gaps() {
-        // Create a list view with multiple gaps:
-        // [_, A, B, _, C, D, _, E, F, _]
-        //  0  1  2  3  4  5  6  7  8  9
-        // List 0: offset=1, size=2 -> [A, B]
-        // List 1: offset=4, size=2 -> [C, D]
-        // List 2: offset=7, size=2 -> [E, F]
-        // Gaps at: 0, 3, 6, 9
-        let elements =
-            PrimitiveArray::from_iter(vec![99i32, 1, 2, 98, 3, 4, 97, 5, 6, 96]).into_array();
-        let offsets = PrimitiveArray::from_iter(vec![1u32, 4, 7]).into_array();
-        let sizes = PrimitiveArray::from_iter(vec![2u32, 2, 2]).into_array();
-
-        let listview =
-            ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap();
-
-        let compacted = listview.rebuild_remove_gaps();
-
-        // After GC: elements should be [A, B, C, D, E, F] = [1, 2, 3, 4, 5, 6]
-        assert_eq!(compacted.elements().len(), 6);
-
-        // Verify offset remapping:
-        // old offset 1 -> new offset 0 (after removing leading gap)
-        // old offset 4 -> new offset 2 (after removing gaps at 0, 3)
-        // old offset 7 -> new offset 4 (after removing gaps at 0, 3, 6)
-        assert_eq!(compacted.offset_at(0), 0);
-        assert_eq!(compacted.size_at(0), 2);
-        assert_eq!(compacted.offset_at(1), 2);
-        assert_eq!(compacted.size_at(1), 2);
-        assert_eq!(compacted.offset_at(2), 4);
-        assert_eq!(compacted.size_at(2), 2);
-
-        // Verify the data is correct
-        let list0 = compacted.list_elements_at(0).to_primitive();
-        assert_eq!(list0.as_slice::<i32>(), &[1, 2]);
-
-        let list1 = compacted.list_elements_at(1).to_primitive();
-        assert_eq!(list1.as_slice::<i32>(), &[3, 4]);
-
-        let list2 = compacted.list_elements_at(2).to_primitive();
-        assert_eq!(list2.as_slice::<i32>(), &[5, 6]);
-    }
 
     #[test]
     fn test_rebuild_flatten_removes_overlaps() {
@@ -340,10 +195,9 @@ mod tests {
         let offsets = PrimitiveArray::from_iter(vec![0u32, 1]).into_array();
         let sizes = PrimitiveArray::from_iter(vec![3u32, 2]).into_array();
 
-        let listview =
-            ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap();
+        let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable);
 
-        let flattened = listview.rebuild_zero_copy_to_list();
+        let flattened = listview.rebuild(ListViewRebuildMode::MakeZeroCopyToList);
 
         // After flatten: elements should be [A, B, C, B, C] = [1, 2, 3, 2, 3]
         // Lists should be sequential with no overlaps
@@ -379,9 +233,9 @@ mod tests {
             .into_array(),
         );
 
-        let listview = ListViewArray::try_new(elements, offsets, sizes, validity).unwrap();
+        let listview = ListViewArray::new(elements, offsets, sizes, validity);
 
-        let flattened = listview.rebuild_zero_copy_to_list();
+        let flattened = listview.rebuild(ListViewRebuildMode::MakeZeroCopyToList);
 
         // Verify nullability is preserved
         assert_eq!(flattened.dtype().nullability(), Nullability::Nullable);
@@ -395,5 +249,44 @@ mod tests {
 
         let list2 = flattened.list_elements_at(2).to_primitive();
         assert_eq!(list2.as_slice::<i32>(), &[3]);
+    }
+
+    #[test]
+    fn test_rebuild_trim_elements_basic() {
+        // Test trimming both leading and trailing unused elements while preserving gaps in the
+        // middle.
+        // Elements: [_, _, A, B, _, C, D, _, _]
+        //            0  1  2  3  4  5  6  7  8
+        // List 0: offset=2, size=2 -> [A, B]
+        // List 1: offset=5, size=2 -> [C, D]
+        // Should trim to: [A, B, _, C, D] with adjusted offsets.
+        let elements =
+            PrimitiveArray::from_iter(vec![99i32, 98, 1, 2, 97, 3, 4, 96, 95]).into_array();
+        let offsets = PrimitiveArray::from_iter(vec![2u32, 5]).into_array();
+        let sizes = PrimitiveArray::from_iter(vec![2u32, 2]).into_array();
+
+        let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable);
+
+        let trimmed = listview.rebuild(ListViewRebuildMode::TrimElements);
+
+        // After trimming: elements should be [A, B, _, C, D] = [1, 2, 97, 3, 4].
+        assert_eq!(trimmed.elements().len(), 5);
+
+        // Offsets should be adjusted: old offset 2 -> new offset 0, old offset 5 -> new offset 3.
+        assert_eq!(trimmed.offset_at(0), 0);
+        assert_eq!(trimmed.size_at(0), 2);
+        assert_eq!(trimmed.offset_at(1), 3);
+        assert_eq!(trimmed.size_at(1), 2);
+
+        // Verify the data is correct.
+        let list0 = trimmed.list_elements_at(0).to_primitive();
+        assert_eq!(list0.as_slice::<i32>(), &[1, 2]);
+
+        let list1 = trimmed.list_elements_at(1).to_primitive();
+        assert_eq!(list1.as_slice::<i32>(), &[3, 4]);
+
+        // Note that element at index 2 (97) is preserved as a gap.
+        let all_elements = trimmed.elements().to_primitive();
+        assert_eq!(all_elements.scalar_at(2), 97i32.into());
     }
 }

--- a/vortex-array/src/arrays/listview/tests/basic.rs
+++ b/vortex-array/src/arrays/listview/tests/basic.rs
@@ -23,13 +23,8 @@ fn test_basic_listview_comprehensive() {
     let sizes = buffer![3i32, 2, 4].into_array();
 
     let listview = unsafe {
-        ListViewArray::new_unchecked(
-            elements.into_array(),
-            offsets,
-            sizes,
-            Validity::NonNullable,
-            true, // Is zero-copy to list.
-        )
+        ListViewArray::new_unchecked(elements.into_array(), offsets, sizes, Validity::NonNullable)
+            .with_zero_copy_to_list(true)
     };
 
     assert_eq!(listview.len(), 3);
@@ -107,13 +102,8 @@ fn test_empty_listview() {
     let sizes = buffer![0i32; 0].into_array();
 
     let listview = unsafe {
-        ListViewArray::new_unchecked(
-            elements.into_array(),
-            offsets,
-            sizes,
-            Validity::NonNullable,
-            true, // Is zero-copy to list.
-        )
+        ListViewArray::new_unchecked(elements.into_array(), offsets, sizes, Validity::NonNullable)
+            .with_zero_copy_to_list(true)
     };
 
     assert_eq!(listview.len(), 0);
@@ -179,13 +169,8 @@ fn test_listview_with_constant_arrays(#[case] const_sizes: bool, #[case] const_o
     let is_zctl = !const_offsets;
 
     let listview = unsafe {
-        ListViewArray::new_unchecked(
-            elements.into_array(),
-            offsets,
-            sizes,
-            Validity::NonNullable,
-            is_zctl,
-        )
+        ListViewArray::new_unchecked(elements.into_array(), offsets, sizes, Validity::NonNullable)
+            .with_zero_copy_to_list(is_zctl)
     };
     assert_eq!(listview.len(), 3);
 
@@ -377,4 +362,29 @@ fn test_validate_u64_overflow() {
         err.to_string().contains("overflow"),
         "Unexpected error: {err}"
     );
+}
+
+#[test]
+fn test_verify_is_zero_copy_to_list() {
+    // Create a ListView that IS zero-copyable to List.
+    // Logical lists: [[1,2], [3,4], [5]]
+    let elements = buffer![1i32, 2, 3, 4, 5].into_array();
+    let offsets = buffer![0i32, 2, 4].into_array(); // Sorted, no gaps
+    let sizes = buffer![2i32, 2, 1].into_array(); // No overlaps
+
+    let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable);
+
+    // Should return true since offsets are sorted and no overlaps exist.
+    assert!(listview.verify_is_zero_copy_to_list());
+
+    // Create a ListView that is NOT zero-copyable to List due to overlapping views.
+    // Logical lists: [[1,2], [2,3,4], [3,4]]
+    let elements = buffer![1i32, 2, 3, 4, 5].into_array();
+    let offsets = buffer![0i32, 1, 2].into_array(); // Sorted but overlapping
+    let sizes = buffer![2i32, 3, 2].into_array(); // These cause overlaps
+
+    let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable);
+
+    // Should return false due to overlapping list views.
+    assert!(!listview.verify_is_zero_copy_to_list());
 }

--- a/vortex-array/src/arrays/listview/tests/basic.rs
+++ b/vortex-array/src/arrays/listview/tests/basic.rs
@@ -17,11 +17,20 @@ use crate::{Array, IntoArray};
 #[test]
 fn test_basic_listview_comprehensive() {
     // Comprehensive test for basic ListView functionality including scalar_at.
+    // Logical lists: [[1,2,3], [4,5], [6,7,8,9]]
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
     let offsets = buffer![0i32, 3, 5].into_array();
     let sizes = buffer![3i32, 2, 4].into_array();
 
-    let listview = ListViewArray::new(elements.into_array(), offsets, sizes, Validity::NonNullable);
+    let listview = unsafe {
+        ListViewArray::new_unchecked(
+            elements.into_array(),
+            offsets,
+            sizes,
+            Validity::NonNullable,
+            true, // Is zero-copy to list.
+        )
+    };
 
     assert_eq!(listview.len(), 3);
     assert!(!listview.is_empty());
@@ -67,8 +76,9 @@ fn test_basic_listview_comprehensive() {
 #[test]
 fn test_out_of_order_offsets() {
     // ListView-specific: Tests that offsets can be non-sequential and out-of-order.
+    // Logical lists: [[7,8,9], [1,2,3], [4,5,6]]
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
-    let offsets = buffer![6i32, 0, 3].into_array(); // Out-of-order: [7,8,9], [1,2,3], [4,5,6].
+    let offsets = buffer![6i32, 0, 3].into_array(); // Out-of-order offsets.
     let sizes = buffer![3i32, 3, 3].into_array();
 
     let listview = ListViewArray::new(elements.into_array(), offsets, sizes, Validity::NonNullable);
@@ -91,13 +101,20 @@ fn test_out_of_order_offsets() {
 #[test]
 fn test_empty_listview() {
     // Test empty ListView array (0 lists).
+    // Logical lists: [] (empty ListView)
     let elements = buffer![1i32].into_array(); // Dummy element.
     let offsets = buffer![0i32; 0].into_array();
     let sizes = buffer![0i32; 0].into_array();
 
-    let listview =
-        ListViewArray::try_new(elements.into_array(), offsets, sizes, Validity::NonNullable)
-            .unwrap();
+    let listview = unsafe {
+        ListViewArray::new_unchecked(
+            elements.into_array(),
+            offsets,
+            sizes,
+            Validity::NonNullable,
+            true, // Is zero-copy to list.
+        )
+    };
 
     assert_eq!(listview.len(), 0);
     assert!(listview.is_empty());
@@ -106,6 +123,7 @@ fn test_empty_listview() {
 #[test]
 fn test_from_list_array() {
     // Test conversion from ListArray to ListViewArray.
+    // Logical lists: [[1,2], null, [5,6,7]]
     let offsets = buffer![0i64, 2, 4, 7].into_array();
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7].into_array();
     let validity = Validity::from_iter([true, false, true]);
@@ -156,7 +174,19 @@ fn test_listview_with_constant_arrays(#[case] const_sizes: bool, #[case] const_o
         buffer![3i32, 2, 1].into_array()
     };
 
-    let listview = ListViewArray::new(elements.into_array(), offsets, sizes, Validity::NonNullable);
+    // Determine if the array is zero-copy to list based on test case.
+    // The array is NOT zero-copy when there are overlaps (const_offsets case).
+    let is_zctl = !const_offsets;
+
+    let listview = unsafe {
+        ListViewArray::new_unchecked(
+            elements.into_array(),
+            offsets,
+            sizes,
+            Validity::NonNullable,
+            is_zctl,
+        )
+    };
     assert_eq!(listview.len(), 3);
 
     if const_sizes && const_offsets {
@@ -328,8 +358,7 @@ fn test_validate_different_int_types() {
     let offsets = buffer![0u64, 2, 1].into_array();
     let sizes = buffer![2u32, 1, 2].into_array();
 
-    let result = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable);
-    assert!(result.is_ok());
+    let _listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable);
 }
 
 #[test]

--- a/vortex-array/src/arrays/listview/tests/common.rs
+++ b/vortex-array/src/arrays/listview/tests/common.rs
@@ -14,7 +14,15 @@ pub fn create_basic_listview() -> ListViewArray {
     let elements = buffer![0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
     let offsets = buffer![0u32, 3, 5, 7].into_array();
     let sizes = buffer![3u32, 2, 2, 3].into_array();
-    ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap()
+    unsafe {
+        ListViewArray::new_unchecked(
+            elements,
+            offsets,
+            sizes,
+            Validity::NonNullable,
+            true, // Is zero-copy to list.
+        )
+    }
 }
 
 /// Creates a nullable ListView: [[10,20], null, [50]]
@@ -23,7 +31,11 @@ pub fn create_nullable_listview() -> ListViewArray {
     let offsets = buffer![0u32, 2, 4].into_array();
     let sizes = buffer![2u32, 2, 1].into_array();
     let validity = Validity::Array(BoolArray::from_iter(vec![true, false, true]).into_array());
-    ListViewArray::try_new(elements, offsets, sizes, validity).unwrap()
+    unsafe {
+        ListViewArray::new_unchecked(
+            elements, offsets, sizes, validity, true, // Is zero-copy to list.
+        )
+    }
 }
 
 /// Creates a ListView with empty lists: [[], [], [], []]
@@ -31,7 +43,15 @@ pub fn create_empty_lists_listview() -> ListViewArray {
     let elements = buffer![99i32].into_array();
     let offsets = buffer![0u32, 0, 0, 0].into_array();
     let sizes = buffer![0u32, 0, 0, 0].into_array();
-    ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap()
+    unsafe {
+        ListViewArray::new_unchecked(
+            elements,
+            offsets,
+            sizes,
+            Validity::NonNullable,
+            true, // Is zero-copy to list.
+        )
+    }
 }
 
 /// Creates a ListView with overlapping lists and out-of-order offsets
@@ -40,7 +60,7 @@ pub fn create_overlapping_listview() -> ListViewArray {
     let elements = buffer![0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
     let offsets = buffer![5u32, 2, 8, 0, 1].into_array();
     let sizes = buffer![3u32, 2, 2, 2, 4].into_array();
-    ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap()
+    ListViewArray::new(elements, offsets, sizes, Validity::NonNullable)
 }
 
 /// Creates a large ListView for performance testing
@@ -48,5 +68,5 @@ pub fn create_large_listview() -> ListViewArray {
     let elements = PrimitiveArray::from_iter(0i32..1000).into_array();
     let offsets = buffer![0u32, 100, 200, 300, 400, 500, 600, 700, 800, 900].into_array();
     let sizes = buffer![50u32, 50, 50, 50, 50, 50, 50, 50, 50, 50].into_array();
-    ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap()
+    ListViewArray::new(elements, offsets, sizes, Validity::NonNullable)
 }

--- a/vortex-array/src/arrays/listview/tests/common.rs
+++ b/vortex-array/src/arrays/listview/tests/common.rs
@@ -15,13 +15,8 @@ pub fn create_basic_listview() -> ListViewArray {
     let offsets = buffer![0u32, 3, 5, 7].into_array();
     let sizes = buffer![3u32, 2, 2, 3].into_array();
     unsafe {
-        ListViewArray::new_unchecked(
-            elements,
-            offsets,
-            sizes,
-            Validity::NonNullable,
-            true, // Is zero-copy to list.
-        )
+        ListViewArray::new_unchecked(elements, offsets, sizes, Validity::NonNullable)
+            .with_zero_copy_to_list(true)
     }
 }
 
@@ -32,9 +27,8 @@ pub fn create_nullable_listview() -> ListViewArray {
     let sizes = buffer![2u32, 2, 1].into_array();
     let validity = Validity::Array(BoolArray::from_iter(vec![true, false, true]).into_array());
     unsafe {
-        ListViewArray::new_unchecked(
-            elements, offsets, sizes, validity, true, // Is zero-copy to list.
-        )
+        ListViewArray::new_unchecked(elements, offsets, sizes, validity)
+            .with_zero_copy_to_list(true)
     }
 }
 
@@ -44,13 +38,8 @@ pub fn create_empty_lists_listview() -> ListViewArray {
     let offsets = buffer![0u32, 0, 0, 0].into_array();
     let sizes = buffer![0u32, 0, 0, 0].into_array();
     unsafe {
-        ListViewArray::new_unchecked(
-            elements,
-            offsets,
-            sizes,
-            Validity::NonNullable,
-            true, // Is zero-copy to list.
-        )
+        ListViewArray::new_unchecked(elements, offsets, sizes, Validity::NonNullable)
+            .with_zero_copy_to_list(true)
     }
 }
 

--- a/vortex-array/src/arrays/listview/tests/filter.rs
+++ b/vortex-array/src/arrays/listview/tests/filter.rs
@@ -31,16 +31,14 @@ fn test_filter_listview_conformance(#[case] listview: ListViewArray) {
 fn test_filter_preserves_unreferenced_elements() {
     // ListView-specific: Test that filter preserves the entire elements array.
     //
-    //
     // Logical list: [[5,6,7], [2,3], [8,9], [0,1], [1,2,3,4]]
     // Elements: [0,1,2,3,4,5,6,7,8,9]
     let elements = buffer![0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
     let offsets = buffer![5u32, 2, 8, 0, 1].into_array();
     let sizes = buffer![3u32, 2, 2, 2, 4].into_array();
 
-    let listview = ListViewArray::try_new(elements.clone(), offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview =
+        ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).to_array();
 
     // Filter to keep only 2 lists.
     let mask = Mask::from_iter([true, false, false, true, false]);
@@ -73,9 +71,8 @@ fn test_filter_with_gaps() {
     let offsets = buffer![0u32, 6, 10, 1, 7].into_array();
     let sizes = buffer![3u32, 3, 2, 2, 2].into_array();
 
-    let listview = ListViewArray::try_new(elements.clone(), offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview =
+        ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).to_array();
 
     // Filter to keep lists with gaps and overlaps.
     let mask = Mask::from_iter([false, true, true, true, false]);
@@ -114,13 +111,12 @@ fn test_filter_constant_arrays() {
     let constant_offsets = ConstantArray::new(2u32, 4).into_array();
     let varying_sizes = buffer![1u32, 2, 3, 4].into_array();
 
-    let const_offset_list = ListViewArray::try_new(
+    let const_offset_list = ListViewArray::new(
         elements.clone(),
         constant_offsets,
         varying_sizes,
         Validity::NonNullable,
     )
-    .unwrap()
     .to_array();
 
     let mask1 = Mask::from_iter([true, false, true, false]);
@@ -138,13 +134,12 @@ fn test_filter_constant_arrays() {
     let both_constant_offsets = ConstantArray::new(1u32, 3).into_array();
     let both_constant_sizes = ConstantArray::new(3u32, 3).into_array();
 
-    let both_const_list = ListViewArray::try_new(
+    let both_const_list = ListViewArray::new(
         elements,
         both_constant_offsets,
         both_constant_sizes,
         Validity::NonNullable,
     )
-    .unwrap()
     .to_array();
 
     let mask2 = Mask::from_iter([true, false, true]);
@@ -169,9 +164,8 @@ fn test_filter_extreme_offsets() {
     let offsets = buffer![0u32, 4999, 9995, 2500, 7500].into_array();
     let sizes = buffer![5u32, 2, 5, 3, 4].into_array();
 
-    let listview = ListViewArray::try_new(elements.clone(), offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview =
+        ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).to_array();
 
     // Filter to keep only 2 lists, demonstrating we keep all 10000 elements.
     let mask = Mask::from_iter([false, true, false, false, true]);

--- a/vortex-array/src/arrays/listview/tests/nested.rs
+++ b/vortex-array/src/arrays/listview/tests/nested.rs
@@ -30,8 +30,7 @@ fn test_listview_of_listview_with_overlapping() {
     let inner_sizes = buffer![3u32, 3, 3, 3, 2, 2].into_array();
 
     let inner_listview =
-        ListViewArray::try_new(elements, inner_offsets, inner_sizes, Validity::NonNullable)
-            .unwrap();
+        ListViewArray::new(elements, inner_offsets, inner_sizes, Validity::NonNullable);
 
     // Create outer ListView that groups the inner lists:
     // Logical outer lists: [inner[0..3], inner[3..6]]
@@ -40,13 +39,15 @@ fn test_listview_of_listview_with_overlapping() {
     let outer_offsets = buffer![0u32, 3].into_array();
     let outer_sizes = buffer![3u32, 3].into_array();
 
-    let outer_listview = ListViewArray::try_new(
-        inner_listview.into_array(),
-        outer_offsets,
-        outer_sizes,
-        Validity::NonNullable,
-    )
-    .unwrap();
+    let outer_listview = unsafe {
+        ListViewArray::new_unchecked(
+            inner_listview.into_array(),
+            outer_offsets,
+            outer_sizes,
+            Validity::NonNullable,
+            true, // Is zero-copy to list.,
+        )
+    };
 
     assert_eq!(outer_listview.len(), 2);
 
@@ -91,8 +92,7 @@ fn test_deeply_nested_out_of_order() {
     let l1_offsets = buffer![8u32, 0, 4, 12, 2, 10, 6, 14].into_array();
     let l1_sizes = buffer![2u32, 2, 2, 2, 2, 2, 2, 2].into_array();
 
-    let level1 =
-        ListViewArray::try_new(elements, l1_offsets, l1_sizes, Validity::NonNullable).unwrap();
+    let level1 = ListViewArray::new(elements, l1_offsets, l1_sizes, Validity::NonNullable);
 
     // Level 2: Group level1 lists, also out-of-order.
     // 4 lists of 2 inner lists each.
@@ -100,13 +100,12 @@ fn test_deeply_nested_out_of_order() {
     let l2_offsets = buffer![6u32, 2, 0, 4].into_array();
     let l2_sizes = buffer![2u32, 2, 2, 2].into_array();
 
-    let level2 = ListViewArray::try_new(
+    let level2 = ListViewArray::new(
         level1.into_array(),
         l2_offsets,
         l2_sizes,
         Validity::NonNullable,
-    )
-    .unwrap();
+    );
 
     // Level 3: Top level groups.
     // 2 lists of 2 level2 lists each.
@@ -114,13 +113,12 @@ fn test_deeply_nested_out_of_order() {
     let l3_offsets = buffer![2u32, 0].into_array();
     let l3_sizes = buffer![2u32, 2].into_array();
 
-    let level3 = ListViewArray::try_new(
+    let level3 = ListViewArray::new(
         level2.into_array(),
         l3_offsets,
         l3_sizes,
         Validity::NonNullable,
-    )
-    .unwrap();
+    );
 
     assert_eq!(level3.len(), 2);
 
@@ -162,13 +160,12 @@ fn test_mixed_offset_size_types() {
     let inner_offsets = buffer![0u32, 10, 20, 30, 40, 50, 100, 150, 200].into_array();
     let inner_sizes = buffer![5u16, 8, 10, 7, 15, 20, 25, 30, 50].into_array();
 
-    let inner_listview = ListViewArray::try_new(
+    let inner_listview = ListViewArray::new(
         elements,
         inner_offsets.clone(),
         inner_sizes.clone(),
         Validity::NonNullable,
-    )
-    .unwrap();
+    );
 
     // Outer ListView with u64 offsets and u8 sizes.
     // Using small sizes that fit in u8 to test the type difference.
@@ -176,13 +173,12 @@ fn test_mixed_offset_size_types() {
     let outer_offsets = buffer![0u64, 3, 6].into_array();
     let outer_sizes = buffer![3u8, 3, 3].into_array();
 
-    let outer_listview = ListViewArray::try_new(
+    let outer_listview = ListViewArray::new(
         inner_listview.into_array(),
         outer_offsets,
         outer_sizes,
         Validity::NonNullable,
-    )
-    .unwrap();
+    );
 
     assert_eq!(outer_listview.len(), 3);
 
@@ -223,8 +219,7 @@ fn test_listview_zero_and_overlapping() {
     let inner_sizes = buffer![0u32, 3, 0, 3, 1, 0, 5, 0].into_array();
 
     let inner_listview =
-        ListViewArray::try_new(elements, inner_offsets, inner_sizes, Validity::NonNullable)
-            .unwrap();
+        ListViewArray::new(elements, inner_offsets, inner_sizes, Validity::NonNullable);
 
     // Create outer lists that group these:
     // Logical lists: [inner[0..3], inner[3..6], inner[6..8]]
@@ -234,13 +229,12 @@ fn test_listview_zero_and_overlapping() {
     let outer_offsets = buffer![0u32, 3, 6].into_array();
     let outer_sizes = buffer![3u32, 3, 2].into_array();
 
-    let outer_listview = ListViewArray::try_new(
+    let outer_listview = ListViewArray::new(
         inner_listview.into_array(),
         outer_offsets,
         outer_sizes,
         Validity::NonNullable,
-    )
-    .unwrap();
+    );
 
     assert_eq!(outer_listview.len(), 3);
 
@@ -317,13 +311,12 @@ fn test_listview_of_struct_with_nulls() {
     let offsets = buffer![0u32, 1, 3].into_array();
     let sizes = buffer![2u32, 3, 3].into_array();
 
-    let listview = ListViewArray::try_new(
+    let listview = ListViewArray::new(
         struct_array.into_array(),
         offsets,
         sizes,
         Validity::NonNullable,
-    )
-    .unwrap();
+    );
 
     assert_eq!(listview.len(), 3);
 

--- a/vortex-array/src/arrays/listview/tests/nested.rs
+++ b/vortex-array/src/arrays/listview/tests/nested.rs
@@ -45,8 +45,8 @@ fn test_listview_of_listview_with_overlapping() {
             outer_offsets,
             outer_sizes,
             Validity::NonNullable,
-            true, // Is zero-copy to list.,
         )
+        .with_zero_copy_to_list(true)
     };
 
     assert_eq!(outer_listview.len(), 2);

--- a/vortex-array/src/arrays/listview/tests/nullability.rs
+++ b/vortex-array/src/arrays/listview/tests/nullability.rs
@@ -22,9 +22,8 @@ fn test_nullable_listview_comprehensive() {
     let validity = Validity::from_iter([true, false, true]);
 
     let listview = unsafe {
-        ListViewArray::new_unchecked(
-            elements, offsets, sizes, validity, true, // Is zero-copy to list.
-        )
+        ListViewArray::new_unchecked(elements, offsets, sizes, validity)
+            .with_zero_copy_to_list(true)
     };
 
     assert_eq!(listview.len(), 3);
@@ -84,12 +83,7 @@ fn test_nullable_patterns(#[case] validity: Validity, #[case] expected_validity:
     let offsets = buffer![0i32, 2, 4].into_array();
     let sizes = buffer![2i32, 2, 2].into_array();
 
-    let listview = unsafe {
-        ListViewArray::new_unchecked(
-            elements, offsets, sizes, validity,
-            false, // Don't bother checking this in this test.
-        )
-    };
+    let listview = unsafe { ListViewArray::new_unchecked(elements, offsets, sizes, validity) };
 
     for (i, &expected) in expected_validity.iter().enumerate() {
         assert_eq!(listview.is_valid(i), expected);
@@ -107,13 +101,8 @@ fn test_nullable_elements() {
     let sizes = buffer![2i32, 2, 2].into_array();
 
     let listview = unsafe {
-        ListViewArray::new_unchecked(
-            elements,
-            offsets,
-            sizes,
-            Validity::AllValid,
-            true, // Is zero-copy to list.
-        )
+        ListViewArray::new_unchecked(elements, offsets, sizes, Validity::AllValid)
+            .with_zero_copy_to_list(true)
     };
 
     // First list: [Some(1), None].

--- a/vortex-array/src/arrays/listview/tests/nullability.rs
+++ b/vortex-array/src/arrays/listview/tests/nullability.rs
@@ -21,7 +21,11 @@ fn test_nullable_listview_comprehensive() {
     let sizes = buffer![2i32, 2, 2].into_array();
     let validity = Validity::from_iter([true, false, true]);
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, validity).unwrap();
+    let listview = unsafe {
+        ListViewArray::new_unchecked(
+            elements, offsets, sizes, validity, true, // Is zero-copy to list.
+        )
+    };
 
     assert_eq!(listview.len(), 3);
 
@@ -80,7 +84,12 @@ fn test_nullable_patterns(#[case] validity: Validity, #[case] expected_validity:
     let offsets = buffer![0i32, 2, 4].into_array();
     let sizes = buffer![2i32, 2, 2].into_array();
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, validity).unwrap();
+    let listview = unsafe {
+        ListViewArray::new_unchecked(
+            elements, offsets, sizes, validity,
+            false, // Don't bother checking this in this test.
+        )
+    };
 
     for (i, &expected) in expected_validity.iter().enumerate() {
         assert_eq!(listview.is_valid(i), expected);
@@ -97,7 +106,15 @@ fn test_nullable_elements() {
     let offsets = buffer![0i32, 2, 4].into_array();
     let sizes = buffer![2i32, 2, 2].into_array();
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::AllValid).unwrap();
+    let listview = unsafe {
+        ListViewArray::new_unchecked(
+            elements,
+            offsets,
+            sizes,
+            Validity::AllValid,
+            true, // Is zero-copy to list.
+        )
+    };
 
     // First list: [Some(1), None].
     let first_list = listview.list_elements_at(0);

--- a/vortex-array/src/arrays/listview/tests/operations.rs
+++ b/vortex-array/src/arrays/listview/tests/operations.rs
@@ -27,9 +27,7 @@ fn test_slice_comprehensive() {
     let offsets = buffer![0i32, 3, 5, 7].into_array();
     let sizes = buffer![3i32, 2, 3, 2].into_array();
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .into_array();
+    let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable).to_array();
 
     // Test basic slice [1..3] - middle portion.
     let sliced = listview.slice(1..3);
@@ -70,9 +68,7 @@ fn test_slice_out_of_order() {
     let offsets = buffer![6i32, 0, 3, 8, 2].into_array(); // Out of order.
     let sizes = buffer![2i32, 3, 3, 1, 1].into_array();
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .into_array();
+    let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable).to_array();
 
     // Slice [1..4] should maintain the out-of-order offsets.
     let sliced = listview.slice(1..4);
@@ -123,9 +119,12 @@ fn test_slice_with_nulls() {
     let validity =
         Validity::Array(BoolArray::from_iter(vec![true, false, true, false]).into_array());
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, validity)
-        .unwrap()
-        .into_array();
+    let listview = unsafe {
+        ListViewArray::new_unchecked(
+            elements, offsets, sizes, validity, true, // Is zero-copy to list.
+        )
+    }
+    .into_array();
 
     // Slice [1..3] should preserve nulls.
     let sliced = listview.slice(1..3);
@@ -156,9 +155,16 @@ fn test_slice_edge_cases(
     let offsets = buffer![0i32, 2, 4].into_array();
     let sizes = buffer![2i32, 2, 2].into_array();
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .into_array();
+    let listview = unsafe {
+        ListViewArray::new_unchecked(
+            elements,
+            offsets,
+            sizes,
+            Validity::NonNullable,
+            true, // Is zero-copy to list.
+        )
+    }
+    .into_array();
 
     match expected_len {
         Some(len) => {
@@ -204,9 +210,16 @@ fn test_cast_numeric_types(#[case] from_ptype: PType, #[case] to_ptype: PType) {
         _ => panic!("Unexpected type"),
     };
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview = unsafe {
+        ListViewArray::new_unchecked(
+            elements,
+            offsets,
+            sizes,
+            Validity::NonNullable,
+            true, // Is zero-copy to list.
+        )
+    }
+    .to_array();
 
     let target_dtype = DType::List(
         Arc::new(DType::Primitive(to_ptype, Nullability::NonNullable)),
@@ -238,9 +251,12 @@ fn test_cast_with_nulls() {
     let sizes = buffer![2u32, 2].into_array();
     let validity = Validity::Array(BoolArray::from_iter(vec![true, false]).into_array());
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, validity)
-        .unwrap()
-        .to_array();
+    let listview = unsafe {
+        ListViewArray::new_unchecked(
+            elements, offsets, sizes, validity, true, // Is zero-copy to list.
+        )
+    }
+    .to_array();
 
     let target_dtype = DType::List(
         Arc::new(DType::Primitive(PType::I64, Nullability::NonNullable)),
@@ -277,9 +293,7 @@ fn test_cast_special_patterns(#[case] expected_sizes: Vec<usize>, #[case] list_c
         )
     };
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable).to_array();
 
     let target_dtype = if is_empty_case {
         DType::List(
@@ -314,9 +328,16 @@ fn test_cast_large_dataset() {
     .into_array();
     let sizes = buffer![4u32; 20].into_array();
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview = unsafe {
+        ListViewArray::new_unchecked(
+            elements,
+            offsets,
+            sizes,
+            Validity::NonNullable,
+            true, // Is zero-copy to list.
+        )
+    }
+    .to_array();
 
     let target_dtype = DType::List(
         Arc::new(DType::Primitive(PType::U32, Nullability::NonNullable)),
@@ -380,14 +401,13 @@ fn test_is_constant_basic(
     #[case] validity: Validity,
     #[case] expected: bool,
 ) {
-    let listview = ListViewArray::try_new(
+    let listview = ListViewArray::new(
         elements.into_array(),
         offsets.into_array(),
         sizes.into_array(),
         validity,
     )
-    .unwrap()
-    .into_array();
+    .to_array();
 
     assert_eq!(is_constant(&listview).unwrap(), Some(expected));
 }
@@ -400,9 +420,16 @@ fn test_constant_with_constant_elements() {
     let offsets = buffer![0i32, 2, 4].into_array();
     let sizes = buffer![2i32, 2, 2].into_array();
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .into_array();
+    let listview = unsafe {
+        ListViewArray::new_unchecked(
+            elements,
+            offsets,
+            sizes,
+            Validity::NonNullable,
+            true, // Is zero-copy to list.
+        )
+    }
+    .into_array();
 
     // All lists contain [42, 42] so should be constant.
     assert_eq!(is_constant(&listview).unwrap(), Some(true));
@@ -418,25 +445,29 @@ fn test_constant_with_nulls() {
 
     // Case 1: Mixed valid and null - not constant.
     let validity_mixed = Validity::Array(BoolArray::from_iter(vec![true, false]).into_array());
-    let listview_mixed = ListViewArray::try_new(
-        elements.clone(),
-        offsets.clone(),
-        sizes.clone(),
-        validity_mixed,
-    )
-    .unwrap()
+    let listview_mixed = unsafe {
+        ListViewArray::new_unchecked(
+            elements.clone(),
+            offsets.clone(),
+            sizes.clone(),
+            validity_mixed,
+            true, // Is zero-copy to list.
+        )
+    }
     .into_array();
     assert_eq!(is_constant(&listview_mixed).unwrap(), Some(false));
 
     // Case 2: All nulls - should be constant.
     let validity_all_null = Validity::AllInvalid;
-    let listview_all_null = ListViewArray::try_new(
-        elements.clone(),
-        offsets.clone(),
-        sizes.clone(),
-        validity_all_null,
-    )
-    .unwrap()
+    let listview_all_null = unsafe {
+        ListViewArray::new_unchecked(
+            elements.clone(),
+            offsets.clone(),
+            sizes.clone(),
+            validity_all_null,
+            true, // Is zero-copy to list.
+        )
+    }
     .into_array();
     assert_eq!(is_constant(&listview_all_null).unwrap(), Some(true));
 }
@@ -449,9 +480,7 @@ fn test_constant_repeated_same_lists() {
     let offsets = buffer![0i32, 0, 0, 0].into_array(); // All point to same start.
     let sizes = buffer![3i32, 3, 3, 3].into_array(); // All same size.
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .into_array();
+    let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable).to_array();
 
     // All lists are [10, 20, 30] so should be constant.
     assert_eq!(is_constant(&listview).unwrap(), Some(true));
@@ -478,9 +507,16 @@ fn test_mask_preserves_structure() {
     let offsets = buffer![0u32, 2, 4, 6].into_array();
     let sizes = buffer![2u32, 2, 2, 2].into_array();
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview = unsafe {
+        ListViewArray::new_unchecked(
+            elements,
+            offsets,
+            sizes,
+            Validity::NonNullable,
+            true, // Is zero-copy to list.
+        )
+    }
+    .to_array();
 
     // Mask sets elements to null where true.
     let selection = Mask::from_iter([true, false, true, true]);
@@ -515,9 +551,12 @@ fn test_mask_with_existing_nulls() {
     let sizes = buffer![2u32, 2, 2].into_array();
     let validity = Validity::Array(BoolArray::from_iter(vec![true, false, true]).into_array());
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, validity)
-        .unwrap()
-        .to_array();
+    let listview = unsafe {
+        ListViewArray::new_unchecked(
+            elements, offsets, sizes, validity, true, // Is zero-copy to list.
+        )
+    }
+    .to_array();
 
     // Mask additional elements.
     let selection = Mask::from_iter([false, true, true]);
@@ -538,9 +577,7 @@ fn test_mask_with_gaps() {
     let offsets = buffer![0u32, 4, 8].into_array();
     let sizes = buffer![2u32, 2, 2].into_array();
 
-    let listview = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable).to_array();
 
     let selection = Mask::from_iter([true, false, false]);
     let result = mask(&listview, &selection).unwrap();
@@ -566,13 +603,12 @@ fn test_mask_constant_arrays() {
     let constant_offsets = ConstantArray::new(1u32, 3).into_array();
     let constant_sizes = ConstantArray::new(2u32, 3).into_array();
 
-    let const_list = ListViewArray::try_new(
+    let const_list = ListViewArray::new(
         elements,
         constant_offsets,
         constant_sizes,
         Validity::NonNullable,
     )
-    .unwrap()
     .to_array();
 
     let selection = Mask::from_iter([false, true, false]);

--- a/vortex-array/src/arrays/listview/tests/operations.rs
+++ b/vortex-array/src/arrays/listview/tests/operations.rs
@@ -120,9 +120,8 @@ fn test_slice_with_nulls() {
         Validity::Array(BoolArray::from_iter(vec![true, false, true, false]).into_array());
 
     let listview = unsafe {
-        ListViewArray::new_unchecked(
-            elements, offsets, sizes, validity, true, // Is zero-copy to list.
-        )
+        ListViewArray::new_unchecked(elements, offsets, sizes, validity)
+            .with_zero_copy_to_list(true)
     }
     .into_array();
 
@@ -156,13 +155,8 @@ fn test_slice_edge_cases(
     let sizes = buffer![2i32, 2, 2].into_array();
 
     let listview = unsafe {
-        ListViewArray::new_unchecked(
-            elements,
-            offsets,
-            sizes,
-            Validity::NonNullable,
-            true, // Is zero-copy to list.
-        )
+        ListViewArray::new_unchecked(elements, offsets, sizes, Validity::NonNullable)
+            .with_zero_copy_to_list(true)
     }
     .into_array();
 
@@ -211,13 +205,8 @@ fn test_cast_numeric_types(#[case] from_ptype: PType, #[case] to_ptype: PType) {
     };
 
     let listview = unsafe {
-        ListViewArray::new_unchecked(
-            elements,
-            offsets,
-            sizes,
-            Validity::NonNullable,
-            true, // Is zero-copy to list.
-        )
+        ListViewArray::new_unchecked(elements, offsets, sizes, Validity::NonNullable)
+            .with_zero_copy_to_list(true)
     }
     .to_array();
 
@@ -252,9 +241,8 @@ fn test_cast_with_nulls() {
     let validity = Validity::Array(BoolArray::from_iter(vec![true, false]).into_array());
 
     let listview = unsafe {
-        ListViewArray::new_unchecked(
-            elements, offsets, sizes, validity, true, // Is zero-copy to list.
-        )
+        ListViewArray::new_unchecked(elements, offsets, sizes, validity)
+            .with_zero_copy_to_list(true)
     }
     .to_array();
 
@@ -329,13 +317,8 @@ fn test_cast_large_dataset() {
     let sizes = buffer![4u32; 20].into_array();
 
     let listview = unsafe {
-        ListViewArray::new_unchecked(
-            elements,
-            offsets,
-            sizes,
-            Validity::NonNullable,
-            true, // Is zero-copy to list.
-        )
+        ListViewArray::new_unchecked(elements, offsets, sizes, Validity::NonNullable)
+            .with_zero_copy_to_list(true)
     }
     .to_array();
 
@@ -421,13 +404,8 @@ fn test_constant_with_constant_elements() {
     let sizes = buffer![2i32, 2, 2].into_array();
 
     let listview = unsafe {
-        ListViewArray::new_unchecked(
-            elements,
-            offsets,
-            sizes,
-            Validity::NonNullable,
-            true, // Is zero-copy to list.
-        )
+        ListViewArray::new_unchecked(elements, offsets, sizes, Validity::NonNullable)
+            .with_zero_copy_to_list(true)
     }
     .into_array();
 
@@ -451,8 +429,8 @@ fn test_constant_with_nulls() {
             offsets.clone(),
             sizes.clone(),
             validity_mixed,
-            true, // Is zero-copy to list.
         )
+        .with_zero_copy_to_list(true)
     }
     .into_array();
     assert_eq!(is_constant(&listview_mixed).unwrap(), Some(false));
@@ -465,8 +443,8 @@ fn test_constant_with_nulls() {
             offsets.clone(),
             sizes.clone(),
             validity_all_null,
-            true, // Is zero-copy to list.
         )
+        .with_zero_copy_to_list(true)
     }
     .into_array();
     assert_eq!(is_constant(&listview_all_null).unwrap(), Some(true));
@@ -508,13 +486,8 @@ fn test_mask_preserves_structure() {
     let sizes = buffer![2u32, 2, 2, 2].into_array();
 
     let listview = unsafe {
-        ListViewArray::new_unchecked(
-            elements,
-            offsets,
-            sizes,
-            Validity::NonNullable,
-            true, // Is zero-copy to list.
-        )
+        ListViewArray::new_unchecked(elements, offsets, sizes, Validity::NonNullable)
+            .with_zero_copy_to_list(true)
     }
     .to_array();
 
@@ -552,9 +525,8 @@ fn test_mask_with_existing_nulls() {
     let validity = Validity::Array(BoolArray::from_iter(vec![true, false, true]).into_array());
 
     let listview = unsafe {
-        ListViewArray::new_unchecked(
-            elements, offsets, sizes, validity, true, // Is zero-copy to list.
-        )
+        ListViewArray::new_unchecked(elements, offsets, sizes, validity)
+            .with_zero_copy_to_list(true)
     }
     .to_array();
 

--- a/vortex-array/src/arrays/listview/tests/take.rs
+++ b/vortex-array/src/arrays/listview/tests/take.rs
@@ -36,9 +36,8 @@ fn test_take_preserves_unreferenced_elements() {
     let offsets = buffer![5u32, 2, 8, 0, 1].into_array();
     let sizes = buffer![3u32, 2, 2, 2, 4].into_array();
 
-    let listview = ListViewArray::try_new(elements.clone(), offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview =
+        ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).to_array();
 
     // Take only 2 lists.
     let indices = buffer![1u32, 3].into_array();
@@ -68,9 +67,8 @@ fn test_take_with_gaps() {
     let offsets = buffer![0u32, 6, 10, 1, 7].into_array();
     let sizes = buffer![3u32, 3, 2, 2, 2].into_array();
 
-    let listview = ListViewArray::try_new(elements.clone(), offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview =
+        ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).to_array();
 
     let indices = buffer![1u32, 3, 4, 2].into_array();
     let result = take(&listview, &indices).unwrap();
@@ -100,13 +98,12 @@ fn test_take_constant_arrays() {
     let constant_offsets = ConstantArray::new(2u32, 4).into_array();
     let varying_sizes = buffer![1u32, 2, 3, 4].into_array();
 
-    let const_offset_list = ListViewArray::try_new(
+    let const_offset_list = ListViewArray::new(
         elements.clone(),
         constant_offsets,
         varying_sizes,
         Validity::NonNullable,
     )
-    .unwrap()
     .to_array();
 
     let indices = buffer![3u32, 0, 2].into_array();
@@ -125,13 +122,12 @@ fn test_take_constant_arrays() {
     let both_constant_offsets = ConstantArray::new(1u32, 3).into_array();
     let both_constant_sizes = ConstantArray::new(3u32, 3).into_array();
 
-    let both_const_list = ListViewArray::try_new(
+    let both_const_list = ListViewArray::new(
         elements,
         both_constant_offsets,
         both_constant_sizes,
         Validity::NonNullable,
     )
-    .unwrap()
     .to_array();
 
     let indices2 = buffer![2u32, 0].into_array();
@@ -156,9 +152,8 @@ fn test_take_extreme_offsets() {
     let offsets = buffer![0u32, 4999, 9995, 2500, 7500].into_array();
     let sizes = buffer![5u32, 2, 5, 3, 4].into_array();
 
-    let listview = ListViewArray::try_new(elements.clone(), offsets, sizes, Validity::NonNullable)
-        .unwrap()
-        .to_array();
+    let listview =
+        ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).to_array();
 
     // Take only 2 lists, demonstrating we keep all 10000 elements.
     let indices = buffer![1u32, 4].into_array();

--- a/vortex-array/src/arrays/listview/vtable/operations.rs
+++ b/vortex-array/src/arrays/listview/vtable/operations.rs
@@ -30,8 +30,8 @@ impl OperationsVTable<ListViewVTable> for ListViewVTable {
                 array.offsets().slice(start..end),
                 array.sizes().slice(start..end),
                 array.validity().slice(start..end),
-                array.is_zero_copy_to_list(),
             )
+            .with_zero_copy_to_list(array.is_zero_copy_to_list())
         }
         .into_array()
     }

--- a/vortex-array/src/arrays/listview/vtable/operations.rs
+++ b/vortex-array/src/arrays/listview/vtable/operations.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use vortex_scalar::Scalar;
 
 use crate::arrays::{ListViewArray, ListViewVTable};
-use crate::vtable::OperationsVTable;
+use crate::vtable::{OperationsVTable, ValidityHelper};
 use crate::{ArrayRef, IntoArray};
 
 impl OperationsVTable<ListViewVTable> for ListViewVTable {
@@ -21,12 +21,16 @@ impl OperationsVTable<ListViewVTable> for ListViewVTable {
 
         // SAFETY: The preconditions of `slice` mean that the bounds have already been checked, and
         // slicing the components of an existing valid array is still valid.
+        // Additionally, slicing elements of a `ListViewArray` that is already zero-copyable to a
+        // `ListArray` does not reorder or create gaps and overlaps, slicing maintains whatever
+        // `is_zero_copy_to_list` flag it already had.
         unsafe {
             ListViewArray::new_unchecked(
                 array.elements().clone(),
                 array.offsets().slice(start..end),
                 array.sizes().slice(start..end),
-                array.validity.slice(start..end),
+                array.validity().slice(start..end),
+                array.is_zero_copy_to_list(),
             )
         }
         .into_array()

--- a/vortex-array/src/arrow/compute/to_arrow/canonical.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/canonical.rs
@@ -885,13 +885,15 @@ mod tests {
         let offsets = PrimitiveArray::new(buffer![0i32, 3], Validity::NonNullable);
         let sizes = PrimitiveArray::new(buffer![3i32, 2], Validity::NonNullable);
 
-        let list_array = ListViewArray::try_new(
-            elements.into_array(),
-            offsets.into_array(),
-            sizes.into_array(),
-            Validity::AllValid,
-        )
-        .unwrap();
+        let list_array = unsafe {
+            ListViewArray::new_unchecked(
+                elements.into_array(),
+                offsets.into_array(),
+                sizes.into_array(),
+                Validity::AllValid,
+                true, // Is zero-copy to list.
+            )
+        };
 
         // Convert to Arrow List with i32 offsets.
         let field = Field::new("item", DataType::Int32, false);
@@ -940,13 +942,15 @@ mod tests {
         let offsets = PrimitiveArray::new(buffer![0i64, 2], Validity::NonNullable);
         let sizes = PrimitiveArray::new(buffer![2i64, 1], Validity::NonNullable);
 
-        let list_array = ListViewArray::try_new(
-            elements.into_array(),
-            offsets.into_array(),
-            sizes.into_array(),
-            Validity::AllValid,
-        )
-        .unwrap();
+        let list_array = unsafe {
+            ListViewArray::new_unchecked(
+                elements.into_array(),
+                offsets.into_array(),
+                sizes.into_array(),
+                Validity::AllValid,
+                true, // Is zero-copy to list.
+            )
+        };
 
         // Convert to Arrow LargeList with i64 offsets.
         let field = Field::new("item", DataType::Int64, false);
@@ -974,13 +978,12 @@ mod tests {
         let offsets = PrimitiveArray::new(buffer![0i32, 1, 2], Validity::NonNullable);
         let sizes = PrimitiveArray::new(buffer![2i32, 2, 2], Validity::NonNullable);
 
-        let list_array = ListViewArray::try_new(
+        let list_array = ListViewArray::new(
             elements.into_array(),
             offsets.into_array(),
             sizes.into_array(),
             Validity::AllValid,
-        )
-        .unwrap();
+        );
 
         // Convert to Arrow ListView with i32 offsets.
         let field = Field::new("item", DataType::Int32, false);
@@ -1027,13 +1030,15 @@ mod tests {
         let sizes = PrimitiveArray::new(buffer![1i64, 0, 2], Validity::NonNullable);
         let validity = Validity::from_iter([true, false, true]);
 
-        let list_array = ListViewArray::try_new(
-            elements.into_array(),
-            offsets.into_array(),
-            sizes.into_array(),
-            validity,
-        )
-        .unwrap();
+        let list_array = unsafe {
+            ListViewArray::new_unchecked(
+                elements.into_array(),
+                offsets.into_array(),
+                sizes.into_array(),
+                validity,
+                true, // Is zero-copy to list.
+            )
+        };
 
         // Convert to Arrow LargeListView with i64 offsets.
         let field = Field::new("item", DataType::Int64, false);

--- a/vortex-array/src/arrow/compute/to_arrow/canonical.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/canonical.rs
@@ -891,8 +891,8 @@ mod tests {
                 offsets.into_array(),
                 sizes.into_array(),
                 Validity::AllValid,
-                true, // Is zero-copy to list.
             )
+            .with_zero_copy_to_list(true)
         };
 
         // Convert to Arrow List with i32 offsets.
@@ -948,8 +948,8 @@ mod tests {
                 offsets.into_array(),
                 sizes.into_array(),
                 Validity::AllValid,
-                true, // Is zero-copy to list.
             )
+            .with_zero_copy_to_list(true)
         };
 
         // Convert to Arrow LargeList with i64 offsets.
@@ -1036,8 +1036,8 @@ mod tests {
                 offsets.into_array(),
                 sizes.into_array(),
                 validity,
-                true, // Is zero-copy to list.
             )
+            .with_zero_copy_to_list(true)
         };
 
         // Convert to Arrow LargeListView with i64 offsets.

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -7,21 +7,23 @@
 //!
 //! Unlike [`ListArray`] which only tracks offsets, [`ListViewArray`] stores both offsets and sizes
 //! in separate arrays for better compression.
+//!
+//! [`ListArray`]: crate::arrays::ListArray
 
 use std::sync::Arc;
 
-use vortex_dtype::{DType, IntegerPType, Nullability};
+use vortex_dtype::{DType, IntegerPType, Nullability, match_each_integer_ptype};
 use vortex_error::{VortexExpect, VortexResult, vortex_ensure, vortex_panic};
 use vortex_mask::Mask;
 use vortex_scalar::{ListScalar, Scalar};
 
 use crate::array::{Array, ArrayRef, IntoArray};
-use crate::arrays::ListViewArray;
+use crate::arrays::{ListViewArray, ListViewRebuildMode, PrimitiveArray};
 use crate::builders::lazy_null_builder::LazyBitBufferBuilder;
 use crate::builders::{
-    ArrayBuilder, DEFAULT_BUILDER_CAPACITY, PrimitiveBuilder, builder_with_capacity,
+    ArrayBuilder, DEFAULT_BUILDER_CAPACITY, PrimitiveBuilder, UninitRange, builder_with_capacity,
 };
-use crate::{Canonical, ToCanonical};
+use crate::{Canonical, ToCanonical, compute};
 
 /// A builder for creating [`ListViewArray`] instances, parameterized by the [`IntegerPType`] of
 /// the `offsets` and the `sizes` builders.
@@ -36,7 +38,7 @@ pub struct ListViewBuilder<O: IntegerPType, S: IntegerPType> {
     /// The [`DType`] of the [`ListViewArray`]. This **must** be a [`DType::List`].
     dtype: DType,
 
-    /// The builder for the underlying elements of the [`ListArray`].
+    /// The builder for the underlying elements of the [`ListArray`](crate::arrays::ListArray).
     elements_builder: Box<dyn ArrayBuilder>,
 
     /// The builder for the `offsets` into the `elements` array.
@@ -122,9 +124,14 @@ impl<O: IntegerPType, S: IntegerPType> ListViewBuilder<O, S> {
         let curr_offset = self.elements_builder.len();
         let num_elements = elements.len();
 
+        // We must assert this even in release mode to ensure that the safety comment in
+        // `finish_into_listview` is correct.
+        assert!(
+            ((curr_offset + num_elements) as u64) < O::max_value_as_u64(),
+            "appending this list would cause an offset overflow"
+        );
+
         for scalar in elements {
-            // TODO(connor): This is slow, we should be able to append multiple values at once, or
-            // the list scalar should hold an Array
             self.elements_builder.append_scalar(&scalar)?;
         }
         self.nulls.append_non_null();
@@ -149,8 +156,16 @@ impl<O: IntegerPType, S: IntegerPType> ListViewBuilder<O, S> {
         let sizes = self.sizes_builder.finish();
         let validity = self.nulls.finish_with_nullability(self.dtype.nullability());
 
-        ListViewArray::try_new(elements, offsets, sizes, validity)
-            .vortex_expect("Failed to create ListViewArray")
+        // SAFETY:
+        // - Both the offsets and the sizes are non-nullable.
+        // - The offsets, sizes, and validity have the same length since we always appended the same
+        //   amount.
+        // - We checked on construction that the sizes type fits into the offsets.
+        // - In every method that adds values to this builder (`append_value`, `append_scalar`, and
+        //   `extend_from_array_unchecked`), we checked that `offset + size` does not overflow.
+        // - We constructed everything in a way that builds the `ListViewArray` similar to the shape
+        //   of a `ListArray`, so we know the resulting array is zero-copyable to a `ListArray`.
+        unsafe { ListViewArray::new_unchecked(elements, offsets, sizes, validity, true) }
     }
 
     /// The [`DType`] of the inner elements. Note that this is **not** the same as the [`DType`] of
@@ -232,25 +247,65 @@ impl<O: IntegerPType, S: IntegerPType> ArrayBuilder for ListViewBuilder<O, S> {
     }
 
     unsafe fn extend_from_array_unchecked(&mut self, array: &dyn Array) {
-        let listview_array = array.to_listview();
-        if listview_array.is_empty() {
+        let listview = array.to_listview();
+        if listview.is_empty() {
             return;
         }
 
-        // TODO(connor)[ListView]: We could potentially concatenate the new elements on top of the
-        // existing elements and recalculate offsets (and then use `UninitRange`). However, that
-        // would mean we lose the guarantee that the output `ListViewArray` does not look like a
-        // `ListArray` (because the incoming array could have garbage data).
+        // If we do not have the guarantee that the array is zero-copyable to a list, then we have
+        // to manually append each scalar.
+        if !listview.is_zero_copy_to_list() {
+            for i in 0..listview.len() {
+                let list = listview.scalar_at(i);
 
-        // We assume the worst case scenario, where the list view array is stored completely out of
-        // order, with many out-of-order offsets, and lots of garbage data. Thus, we simply iterate
-        // over all of the lists in the array and copy the data into this builder.
-        for i in 0..listview_array.len() {
-            let list = listview_array.scalar_at(i);
+                self.append_scalar(&list)
+                    .vortex_expect("was unable to extend the `ListViewBuilder`")
+            }
 
-            self.append_scalar(&list)
-                .vortex_expect("was unable to extend the `ListViewBuilder`")
+            return;
         }
+
+        // Otherwise, after removing any leading and trailing elements, we can simply bulk append
+        // the entire array.
+        let listview = listview.rebuild(ListViewRebuildMode::MakeExact);
+        debug_assert!(listview.is_zero_copy_to_list());
+
+        self.nulls.append_validity_mask(array.validity_mask());
+
+        // Bulk append the new elements (which should have no gaps or overlaps).
+        let old_elements_len = self.elements_builder.len();
+        self.elements_builder
+            .reserve_exact(listview.elements().len());
+        self.elements_builder.extend_from_array(listview.elements());
+        let new_elements_len = self.elements_builder.len();
+
+        // Reserve enough space for the new views.
+        let extend_length = listview.len();
+        self.sizes_builder.reserve_exact(extend_length);
+        self.offsets_builder.reserve_exact(extend_length);
+
+        // The incoming sizes might have a different type than the builder, so we need to cast.
+        let cast_sizes = compute::cast(listview.sizes(), self.sizes_builder.dtype()).vortex_expect(
+            "was somehow unable to cast the new sizes to the type of the builder sizes",
+        );
+        self.sizes_builder.extend_from_array(cast_sizes.as_ref());
+
+        // Now we need to adjust all of the offsets by adding the current number of elements in the
+        // builder.
+
+        let uninit_range = self.offsets_builder.uninit_range(extend_length);
+
+        // This should be cheap because we didn't compress after rebuilding.
+        let new_offsets = listview.offsets().to_primitive();
+
+        match_each_integer_ptype!(new_offsets.ptype(), |A| {
+            adjust_and_extend_offsets::<O, A>(
+                uninit_range,
+                new_offsets,
+                old_elements_len,
+                new_elements_len,
+            );
+        })
     }
 
     fn reserve_exact(&mut self, capacity: usize) {
@@ -272,6 +327,46 @@ impl<O: IntegerPType, S: IntegerPType> ArrayBuilder for ListViewBuilder<O, S> {
     fn finish_into_canonical(&mut self) -> Canonical {
         Canonical::List(self.finish_into_listview())
     }
+}
+
+/// Given new offsets, adds them to the `UninitRange` after adding the `old_elements_len` to each
+/// offset.
+fn adjust_and_extend_offsets<'a, O: IntegerPType, A: IntegerPType>(
+    mut uninit_range: UninitRange<'a, O>,
+    new_offsets: PrimitiveArray,
+    old_elements_len: usize,
+    new_elements_len: usize,
+) {
+    let new_offsets_slice = new_offsets.as_slice::<A>();
+    let old_elements_len = O::from_usize(old_elements_len)
+        .vortex_expect("the old elements length did not fit into the offset type (impossible)");
+    let new_elements_len = O::from_usize(new_elements_len)
+        .vortex_expect("the current elements length did not fit into the offset type (impossible)");
+
+    for i in 0..uninit_range.len() {
+        let new_offset = O::from_usize(
+            new_offsets_slice[i]
+                .to_usize()
+                .vortex_expect("Offsets must always fit in usize"),
+        )
+        .vortex_expect("New offset somehow did not fit into the builder's offset type");
+
+        // We have to check this even in release mode to ensure the final `new_unchecked`
+        // construction in `finish_into_listview` is valid.
+        let adjusted_new_offset = new_offset + old_elements_len;
+        assert!(
+            adjusted_new_offset <= new_elements_len,
+            "[{i}/{}]: {new_offset} + {old_elements_len} \
+                = {adjusted_new_offset} <= {new_elements_len} failed",
+            uninit_range.len()
+        );
+
+        uninit_range.set_value(i, adjusted_new_offset);
+    }
+
+    // SAFETY: We have set all the values in the range, and since `offsets` are non-nullable, we are
+    // done.
+    unsafe { uninit_range.finish() };
 }
 
 #[cfg(test)]
@@ -474,9 +569,7 @@ mod tests {
             .unwrap();
 
         // Extend from the ListArray.
-        unsafe {
-            builder.extend_from_array_unchecked(&source.into_array());
-        }
+        builder.extend_from_array(&source.into_array());
 
         // Extend from empty array (should be no-op).
         let empty_source = ListArray::from_iter_opt_slow::<u32, _, Vec<i32>>(
@@ -484,9 +577,7 @@ mod tests {
             Arc::new(I32.into()),
         )
         .unwrap();
-        unsafe {
-            builder.extend_from_array_unchecked(&empty_source.into_array());
-        }
+        builder.extend_from_array(&empty_source.into_array());
 
         let listview = builder.finish_into_listview();
         assert_eq!(listview.len(), 4);

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -165,7 +165,10 @@ impl<O: IntegerPType, S: IntegerPType> ListViewBuilder<O, S> {
         //   `extend_from_array_unchecked`), we checked that `offset + size` does not overflow.
         // - We constructed everything in a way that builds the `ListViewArray` similar to the shape
         //   of a `ListArray`, so we know the resulting array is zero-copyable to a `ListArray`.
-        unsafe { ListViewArray::new_unchecked(elements, offsets, sizes, validity, true) }
+        unsafe {
+            ListViewArray::new_unchecked(elements, offsets, sizes, validity)
+                .with_zero_copy_to_list(true)
+        }
     }
 
     /// The [`DType`] of the inner elements. Note that this is **not** the same as the [`DType`] of

--- a/vortex-array/src/compute/list_contains.rs
+++ b/vortex-array/src/compute/list_contains.rs
@@ -71,8 +71,8 @@ pub(crate) fn warm_up_vtable() -> usize {
 ///         offsets,
 ///         sizes,
 ///         Validity::NonNullable,
-///         true, // Is zero-copy to list.
 ///     )
+///     .with_zero_copy_to_list(true)
 /// };
 ///
 /// let matches = compute::list_contains(
@@ -606,8 +606,8 @@ mod tests {
                 offsets,
                 sizes,
                 Validity::NonNullable,
-                true, // Is zero-copy to list.
             )
+            .with_zero_copy_to_list(true)
         };
 
         // Test with a non-null search value
@@ -635,8 +635,8 @@ mod tests {
                 offsets,
                 sizes,
                 Validity::NonNullable,
-                true, // Is zero-copy to list.
             )
+            .with_zero_copy_to_list(true)
         };
 
         // Test searching for a null value

--- a/vortex-array/src/compute/list_contains.rs
+++ b/vortex-array/src/compute/list_contains.rs
@@ -64,8 +64,16 @@ pub(crate) fn warm_up_vtable() -> usize {
 ///         vec!["a", "a", "b", "a", "c"], DType::Utf8(false.into())).into_array();
 /// let offsets = buffer![0u32, 1, 3].into_array();
 /// let sizes = buffer![1u32, 2, 2].into_array();
-/// let list_array =
-///     ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable).unwrap();
+/// // SAFETY: The components are the same as a `ListArray`.
+/// let list_array = unsafe {
+///     ListViewArray::new_unchecked(
+///         elements,
+///         offsets,
+///         sizes,
+///         Validity::NonNullable,
+///         true, // Is zero-copy to list.
+///     )
+/// };
 ///
 /// let matches = compute::list_contains(
 ///     list_array.as_ref(),
@@ -293,8 +301,8 @@ fn list_contains_scalar(
     .into_array())
 }
 
-/// Returns a [`BooleanBuffer`] where each bit represents if a list contains the scalar, derived
-/// from a [`BoolArray`] of matches on the child elements array.
+/// Returns a [`BitBuffer`] where each bit represents if a list contains the scalar, derived from a
+/// [`BoolArray`] of matches on the child elements array.
 fn process_matches<O, S>(
     matches: BoolArray,
     list_array_len: usize,
@@ -592,13 +600,15 @@ mod tests {
         let offsets = Buffer::from_iter([0u32, 0, 0, 0]).into_array();
         let sizes = Buffer::from_iter([0u32, 0, 0, 0]).into_array();
 
-        let list_array = ListViewArray::try_new(
-            empty_elements.into_array(),
-            offsets,
-            sizes,
-            Validity::NonNullable,
-        )
-        .unwrap();
+        let list_array = unsafe {
+            ListViewArray::new_unchecked(
+                empty_elements.into_array(),
+                offsets,
+                sizes,
+                Validity::NonNullable,
+                true, // Is zero-copy to list.
+            )
+        };
 
         // Test with a non-null search value
         let search = ConstantArray::new(Scalar::from(42i32), list_array.len());
@@ -619,9 +629,15 @@ mod tests {
         let offsets = Buffer::from_iter([0u32, 2, 4]).into_array();
         let sizes = Buffer::from_iter([2u32, 2, 1]).into_array();
 
-        let list_array =
-            ListViewArray::try_new(elements.into_array(), offsets, sizes, Validity::NonNullable)
-                .unwrap();
+        let list_array = unsafe {
+            ListViewArray::new_unchecked(
+                elements.into_array(),
+                offsets,
+                sizes,
+                Validity::NonNullable,
+                true, // Is zero-copy to list.
+            )
+        };
 
         // Test searching for a null value
         let null_search = ConstantArray::new(
@@ -658,8 +674,7 @@ mod tests {
         let sizes = Buffer::from_iter([1u32, 2, 1, 0]).into_array();
 
         let list_array =
-            ListViewArray::try_new(elements.into_array(), offsets, sizes, Validity::NonNullable)
-                .unwrap();
+            ListViewArray::new(elements.into_array(), offsets, sizes, Validity::NonNullable);
 
         // Test searching for value 2, which appears only in list 1
         let search = ConstantArray::new(Scalar::from(2i32), list_array.len());
@@ -692,8 +707,7 @@ mod tests {
         let sizes = Buffer::from_iter([50u8, 50, 54, 2]).into_array(); // Last list goes to index 255
 
         let list_array =
-            ListViewArray::try_new(elements.into_array(), offsets, sizes, Validity::NonNullable)
-                .unwrap();
+            ListViewArray::new(elements.into_array(), offsets, sizes, Validity::NonNullable);
 
         // Search for value 255 which should only be in the last list
         let search = ConstantArray::new(Scalar::from(255i32), list_array.len());

--- a/vortex-btrblocks/src/lib.rs
+++ b/vortex-btrblocks/src/lib.rs
@@ -403,10 +403,16 @@ impl BtrBlocksCompressor {
                 // list and list view.
                 let list_array = list_from_list_view(list_view_array);
 
+                // Reset the offsets to remove garbage data that might prevent us from narrowing our
+                // offsets (there could be a large amount of trailing garbage data that the current
+                // views do not reference at all).
+                let list_array = list_array.reset_offsets(true)?;
+
                 let compressed_elems = self.compress(list_array.elements())?;
 
-                // Note that since the type of our offsets are not encoded in our `DType`,
-                // we may narrow the widths.
+                // Note that since the type of our offsets are not encoded in our `DType`, and since
+                // we guarantee above that all elements are referenced by offsets, we may narrow the
+                // widths.
 
                 let compressed_offsets = IntCompressor::compress_no_dict(
                     &list_array.offsets().to_primitive().narrow()?,

--- a/vortex-duckdb/src/exporter/list.rs
+++ b/vortex-duckdb/src/exporter/list.rs
@@ -152,13 +152,15 @@ mod tests {
     #[test]
     #[ignore = "TODO(connor)[4809]: Exporters do not correctly handle empty vectors"]
     fn test_export_empty_list() {
-        let list = ListViewArray::try_new(
-            Buffer::<u32>::empty().into_array(),
-            Buffer::<u32>::empty().into_array(),
-            Buffer::<u32>::empty().into_array(),
-            Validity::AllValid,
-        )
-        .unwrap()
+        let list = unsafe {
+            ListViewArray::new_unchecked(
+                Buffer::<u32>::empty().into_array(),
+                Buffer::<u32>::empty().into_array(),
+                Buffer::<u32>::empty().into_array(),
+                Validity::AllValid,
+                true, // Is zero-copy to list.
+            )
+        }
         .into_array();
 
         let list_type = LogicalType::list_type(LogicalType::int32()).vortex_unwrap();
@@ -180,13 +182,15 @@ mod tests {
 
     #[test]
     fn test_export_non_empty_list_with_preceding_and_trailing_garbage() {
-        let list = ListViewArray::try_new(
-            buffer![0, 1, 2, 3, 4, 5].into_array(),
-            buffer![1u8, 2, 3].into_array(),
-            buffer![1u8, 1, 1].into_array(),
-            Validity::AllValid,
-        )
-        .unwrap()
+        let list = unsafe {
+            ListViewArray::new_unchecked(
+                buffer![0, 1, 2, 3, 4, 5].into_array(),
+                buffer![1u8, 2, 3].into_array(),
+                buffer![1u8, 1, 1].into_array(),
+                Validity::AllValid,
+                true, // Is zero-copy to list.
+            )
+        }
         .into_array();
 
         let list_type = LogicalType::list_type(LogicalType::int32()).vortex_unwrap();
@@ -208,19 +212,21 @@ mod tests {
 
     #[test]
     fn test_export_non_empty_list_of_strings() {
-        let list = ListViewArray::try_new(
-            <VarBinArray as FromIterator<_>>::from_iter([
-                Some("abc"),
-                Some("def"),
-                None,
-                Some("ghi"),
-            ])
-            .into_array(),
-            buffer![0u8, 0, 3, 4].into_array(),
-            buffer![0u8, 3, 1, 0].into_array(),
-            Validity::from_iter([true, true, false, true]),
-        )
-        .unwrap()
+        let list = unsafe {
+            ListViewArray::new_unchecked(
+                <VarBinArray as FromIterator<_>>::from_iter([
+                    Some("abc"),
+                    Some("def"),
+                    None,
+                    Some("ghi"),
+                ])
+                .into_array(),
+                buffer![0u8, 0, 3, 4].into_array(),
+                buffer![0u8, 3, 1, 0].into_array(),
+                Validity::from_iter([true, true, false, true]),
+                true, // Is zero-copy to list.
+            )
+        }
         .into_array();
 
         let list_type = LogicalType::list_type(LogicalType::varchar()).vortex_unwrap();

--- a/vortex-duckdb/src/exporter/list.rs
+++ b/vortex-duckdb/src/exporter/list.rs
@@ -158,8 +158,8 @@ mod tests {
                 Buffer::<u32>::empty().into_array(),
                 Buffer::<u32>::empty().into_array(),
                 Validity::AllValid,
-                true, // Is zero-copy to list.
             )
+            .with_zero_copy_to_list(true)
         }
         .into_array();
 
@@ -188,8 +188,8 @@ mod tests {
                 buffer![1u8, 2, 3].into_array(),
                 buffer![1u8, 1, 1].into_array(),
                 Validity::AllValid,
-                true, // Is zero-copy to list.
             )
+            .with_zero_copy_to_list(true)
         }
         .into_array();
 
@@ -224,8 +224,8 @@ mod tests {
                 buffer![0u8, 0, 3, 4].into_array(),
                 buffer![0u8, 3, 1, 0].into_array(),
                 Validity::from_iter([true, true, false, true]),
-                true, // Is zero-copy to list.
             )
+            .with_zero_copy_to_list(true)
         }
         .into_array();
 

--- a/vortex-layout/src/layouts/compact.rs
+++ b/vortex-layout/src/layouts/compact.rs
@@ -145,14 +145,15 @@ impl CompactCompressor {
                 // SAFETY: Since compression does not change the logical values of arrays, this is
                 // effectively the same array but represented differently, so all invariants that
                 // were previously upheld by the valid `ListViewArray` are still upheld.
+                // If the original was zero-copyable to list, compression maintains that property.
                 unsafe {
                     ListViewArray::new_unchecked(
                         compressed_elems,
                         compressed_offsets,
                         compressed_sizes,
                         listview.validity().clone(),
-                        listview.is_zero_copy_to_list(),
                     )
+                    .with_zero_copy_to_list(listview.is_zero_copy_to_list())
                 }
                 .into_array()
             }

--- a/vortex-layout/src/layouts/compact.rs
+++ b/vortex-layout/src/layouts/compact.rs
@@ -132,32 +132,38 @@ impl CompactCompressor {
                 )?
                 .into_array()
             }
-            Canonical::List(list_array) => {
-                let compressed_elems = self.compress(list_array.elements())?;
+            Canonical::List(listview) => {
+                let compressed_elems = self.compress(listview.elements())?;
 
                 // Note that since the type of our offsets and sizes is not encoded in our `DType`,
                 // we can narrow the widths.
                 let compressed_offsets =
-                    self.compress(&list_array.offsets().to_primitive().narrow()?.into_array())?;
+                    self.compress(&listview.offsets().to_primitive().narrow()?.into_array())?;
                 let compressed_sizes =
-                    self.compress(&list_array.sizes().to_primitive().narrow()?.into_array())?;
+                    self.compress(&listview.sizes().to_primitive().narrow()?.into_array())?;
 
-                ListViewArray::try_new(
-                    compressed_elems,
-                    compressed_offsets,
-                    compressed_sizes,
-                    list_array.validity().clone(),
-                )?
+                // SAFETY: Since compression does not change the logical values of arrays, this is
+                // effectively the same array but represented differently, so all invariants that
+                // were previously upheld by the valid `ListViewArray` are still upheld.
+                unsafe {
+                    ListViewArray::new_unchecked(
+                        compressed_elems,
+                        compressed_offsets,
+                        compressed_sizes,
+                        listview.validity().clone(),
+                        listview.is_zero_copy_to_list(),
+                    )
+                }
                 .into_array()
             }
-            Canonical::FixedSizeList(list_array) => {
-                let compressed_elems = self.compress(list_array.elements())?;
+            Canonical::FixedSizeList(fsl) => {
+                let compressed_elems = self.compress(fsl.elements())?;
 
                 FixedSizeListArray::try_new(
                     compressed_elems,
-                    list_array.list_size(),
-                    list_array.validity().clone(),
-                    list_array.len(),
+                    fsl.list_size(),
+                    fsl.validity().clone(),
+                    fsl.len(),
                 )?
                 .into_array()
             }


### PR DESCRIPTION
Tracking Issue: https://github.com/vortex-data/vortex/issues/4699
Closes: https://github.com/vortex-data/vortex/issues/5053

This PR introduces a performance optimization for `ListViewArray` by adding an `is_zero_copy_to_list` flag that tracks whether the `ListViewArray` can be (near) constant-time converted to a `ListArray` without copying data.

When this flag is true (indicating sorted offsets with no gaps and no overlaps), conversions can bypass the very expensive rebuild process (which just calls `append_scalar` in a loop). 

Additionally, this PR refactors all `ListViewArray` constructor call sites and compute operations throughout the codebase to properly maintain this new invariant. The only time you can set this flag is via the `new_unchecked` constructor which is unsafe, which means the caller better be careful to know what they are doing.

Some things that are not included in this PR:
- Making conversion _actually_ zero-copy would require implementing logic to always allocate an additional `offsets` slot for an `n+1`th offset in `ListViewArray`. This is because `ListArray` has `n+1` offsets, and from a plain `ListViewArray` we have to reallocate the offsets to make space.
- `reset_offsets` right now is probably more expensive than it could be since it uses the `sub_scalar` compute function. We know in advance that `reset_offsets` should _never_ fail in the non-recursive case.
- Validation of this `is_zctl` flag is **SUPER** expensive, but it can be made a bit less expensive by using a `BitBuffer` to track references + a flag for overlaps.
- It would probably be nice to have an `check_is_zero_copy_to_list` function on `ListViewArray` that sets the flag if it detects it is zero-copyable to a `ListArray`. This would be nice when we are reading from disk or converting from an Arrow `GenericListView`.
- This PR **does not** change the on-disk format, which means we lose this metadata when writing to disk. I think that this flag is somewhat similar to the `is_sorted` statistic, but at the same time I feel like it is not correct to store this as a statistic? Not sure.