### PR TITLE
feat: error instead of panic on too many buffers

### DIFF
--- a/vortex-array/src/serde.rs
+++ b/vortex-array/src/serde.rs
@@ -155,6 +155,13 @@ impl<'a> ArrayNodeFlatBuffer<'a> {
                 );
             }
         }
+        let n_buffers_recursive = array.nbuffers_recursive();
+        if u16::try_from(n_buffers_recursive).is_err() {
+            vortex_bail!(
+                "Array and all descendent arrays can have at most u16::MAX buffers: {}",
+                n_buffers_recursive
+            );
+        };
         Ok(Self {
             ctx,
             array,

--- a/vortex-array/src/serde.rs
+++ b/vortex-array/src/serde.rs
@@ -156,7 +156,7 @@ impl<'a> ArrayNodeFlatBuffer<'a> {
             }
         }
         let n_buffers_recursive = array.nbuffers_recursive();
-        if u16::try_from(n_buffers_recursive).is_err() {
+        if n_buffers_recursive > u16::MAX as usize {
             vortex_bail!(
                 "Array and all descendent arrays can have at most u16::MAX buffers: {}",
                 n_buffers_recursive


### PR DESCRIPTION
Currently this panics in `write_flatbuffer`. Panics print a double stack trace and are a bit weird when they happen in a future.