### PR TITLE
Chore: use actual type names in `vortex-vector`

### DIFF
--- a/vortex-vector/src/binaryview/vector.rs
+++ b/vortex-vector/src/binaryview/vector.rs
@@ -38,7 +38,7 @@ impl<T: BinaryViewType> BinaryViewVector<T> {
     /// components.
     ///
     /// The caller must uphold all validation that would otherwise be validated by
-    /// the [safe constructor][Self::try_new].
+    /// the [safe constructor](Self::try_new).
     pub unsafe fn new_unchecked(
         views: Buffer<BinaryView>,
         buffers: Arc<Box<[ByteBuffer]>>,
@@ -60,8 +60,8 @@ impl<T: BinaryViewType> BinaryViewVector<T> {
     ///
     /// # Errors
     ///
-    /// This function will panic if any of the validation checks performed by [`try_new`][Self::try_new]
-    /// fails.
+    /// This function will panic if any of the validation checks performed by
+    /// [`try_new`](Self::try_new) fails.
     pub fn new(views: Buffer<BinaryView>, buffers: Arc<Box<[ByteBuffer]>>, validity: Mask) -> Self {
         Self::try_new(views, buffers, validity).vortex_expect("Failed to create `BinaryViewVector`")
     }
@@ -153,7 +153,7 @@ impl<T: BinaryViewType> VectorOps for BinaryViewVector<T> {
         &self.validity
     }
 
-    fn try_into_mut(self) -> Result<Self::Mutable, Self>
+    fn try_into_mut(self) -> Result<BinaryViewVectorMut<T>, Self>
     where
         Self: Sized,
     {

--- a/vortex-vector/src/binaryview/vector_mut.rs
+++ b/vortex-vector/src/binaryview/vector_mut.rs
@@ -166,7 +166,7 @@ impl<T: BinaryViewType> VectorMutOps for BinaryViewVectorMut<T> {
         self.validity.reserve(additional);
     }
 
-    fn extend_from_vector(&mut self, other: &Self::Immutable) {
+    fn extend_from_vector(&mut self, other: &BinaryViewVector<T>) {
         // Close any existing views into a new buffer
         if let Some(open) = self.open_buffer.take() {
             self.buffers.push(open.freeze());
@@ -195,7 +195,7 @@ impl<T: BinaryViewType> VectorMutOps for BinaryViewVectorMut<T> {
         self.validity.append_n(false, n);
     }
 
-    fn freeze(mut self) -> Self::Immutable {
+    fn freeze(mut self) -> BinaryViewVector<T> {
         // Freeze all components, close any in-progress views
         if let Some(open) = self.open_buffer.take() {
             self.buffers.push(open.freeze());

--- a/vortex-vector/src/bool/vector.rs
+++ b/vortex-vector/src/bool/vector.rs
@@ -83,7 +83,7 @@ impl VectorOps for BoolVector {
         &self.validity
     }
 
-    fn try_into_mut(self) -> Result<Self::Mutable, Self>
+    fn try_into_mut(self) -> Result<BoolVectorMut, Self>
     where
         Self: Sized,
     {

--- a/vortex-vector/src/bool/vector_mut.rs
+++ b/vortex-vector/src/bool/vector_mut.rs
@@ -152,7 +152,7 @@ impl VectorMutOps for BoolVectorMut {
         self.validity.append_n(false, n);
     }
 
-    fn freeze(self) -> Self::Immutable {
+    fn freeze(self) -> BoolVector {
         BoolVector {
             bits: self.bits.freeze(),
             validity: self.validity.freeze(),

--- a/vortex-vector/src/decimal/generic.rs
+++ b/vortex-vector/src/decimal/generic.rs
@@ -97,7 +97,7 @@ impl<D: NativeDecimalType> VectorOps for DVector<D> {
         &self.validity
     }
 
-    fn try_into_mut(self) -> Result<Self::Mutable, Self>
+    fn try_into_mut(self) -> Result<DVectorMut<D>, Self>
     where
         Self: Sized,
     {

--- a/vortex-vector/src/decimal/generic_mut.rs
+++ b/vortex-vector/src/decimal/generic_mut.rs
@@ -31,7 +31,7 @@ impl<D: NativeDecimalType> VectorMutOps for DVectorMut<D> {
         self.validity.reserve(additional);
     }
 
-    fn extend_from_vector(&mut self, other: &Self::Immutable) {
+    fn extend_from_vector(&mut self, other: &DVector<D>) {
         self.elements.extend_from_slice(&other.elements);
         self.validity.append_mask(other.validity());
     }
@@ -41,7 +41,7 @@ impl<D: NativeDecimalType> VectorMutOps for DVectorMut<D> {
         self.validity.append_n(false, n);
     }
 
-    fn freeze(self) -> Self::Immutable {
+    fn freeze(self) -> DVector<D> {
         DVector {
             ps: self.ps,
             elements: self.elements.freeze(),

--- a/vortex-vector/src/decimal/vector.rs
+++ b/vortex-vector/src/decimal/vector.rs
@@ -36,7 +36,7 @@ impl VectorOps for DecimalVector {
         match_each_dvector!(self, |v| { v.validity() })
     }
 
-    fn try_into_mut(self) -> Result<Self::Mutable, Self>
+    fn try_into_mut(self) -> Result<DecimalVectorMut, Self>
     where
         Self: Sized,
     {

--- a/vortex-vector/src/decimal/vector_mut.rs
+++ b/vortex-vector/src/decimal/vector_mut.rs
@@ -39,7 +39,7 @@ impl VectorMutOps for DecimalVectorMut {
         match_each_dvector_mut!(self, |d| { d.reserve(additional) })
     }
 
-    fn extend_from_vector(&mut self, other: &Self::Immutable) {
+    fn extend_from_vector(&mut self, other: &DecimalVector) {
         match (self, other) {
             (DecimalVectorMut::D8(s), DecimalVector::D8(o)) => s.extend_from_vector(o),
             (DecimalVectorMut::D16(s), DecimalVector::D16(o)) => s.extend_from_vector(o),
@@ -55,7 +55,7 @@ impl VectorMutOps for DecimalVectorMut {
         match_each_dvector_mut!(self, |d| { d.append_nulls(n) })
     }
 
-    fn freeze(self) -> Self::Immutable {
+    fn freeze(self) -> DecimalVector {
         match_each_dvector_mut!(self, |d| { d.freeze().into() })
     }
 

--- a/vortex-vector/src/null/vector.rs
+++ b/vortex-vector/src/null/vector.rs
@@ -43,7 +43,7 @@ impl VectorOps for NullVector {
         &self.validity
     }
 
-    fn try_into_mut(self) -> Result<Self::Mutable, Self>
+    fn try_into_mut(self) -> Result<NullVectorMut, Self>
     where
         Self: Sized,
     {

--- a/vortex-vector/src/null/vector_mut.rs
+++ b/vortex-vector/src/null/vector_mut.rs
@@ -39,7 +39,7 @@ impl VectorMutOps for NullVectorMut {
         // We do not allocate memory for `NullVector`, so this is a no-op.
     }
 
-    fn extend_from_vector(&mut self, other: &Self::Immutable) {
+    fn extend_from_vector(&mut self, other: &NullVector) {
         self.len += other.len;
     }
 
@@ -47,7 +47,7 @@ impl VectorMutOps for NullVectorMut {
         self.len += n;
     }
 
-    fn freeze(self) -> Self::Immutable {
+    fn freeze(self) -> NullVector {
         NullVector::new(self.len)
     }
 

--- a/vortex-vector/src/primitive/vector.rs
+++ b/vortex-vector/src/primitive/vector.rs
@@ -73,7 +73,7 @@ impl VectorOps for PrimitiveVector {
         match_each_pvector!(self, |v| { v.validity() })
     }
 
-    fn try_into_mut(self) -> Result<Self::Mutable, Self>
+    fn try_into_mut(self) -> Result<PrimitiveVectorMut, Self>
     where
         Self: Sized,
     {

--- a/vortex-vector/src/primitive/vector_mut.rs
+++ b/vortex-vector/src/primitive/vector_mut.rs
@@ -96,7 +96,7 @@ impl VectorMutOps for PrimitiveVectorMut {
         match_each_pvector_mut!(self, |v| { v.reserve(additional) })
     }
 
-    fn extend_from_vector(&mut self, other: &Self::Immutable) {
+    fn extend_from_vector(&mut self, other: &PrimitiveVector) {
         match (self, other) {
             (PrimitiveVectorMut::U8(a), PrimitiveVector::U8(b)) => a.extend_from_vector(b),
             (PrimitiveVectorMut::U16(a), PrimitiveVector::U16(b)) => a.extend_from_vector(b),
@@ -117,7 +117,7 @@ impl VectorMutOps for PrimitiveVectorMut {
         match_each_pvector_mut!(self, |v| { v.append_nulls(n) })
     }
 
-    fn freeze(self) -> Self::Immutable {
+    fn freeze(self) -> PrimitiveVector {
         match_each_pvector_mut!(self, |v| { v.freeze().into() })
     }
 

--- a/vortex-vector/src/struct_/vector.rs
+++ b/vortex-vector/src/struct_/vector.rs
@@ -132,7 +132,7 @@ impl VectorOps for StructVector {
         &self.validity
     }
 
-    fn try_into_mut(self) -> Result<Self::Mutable, Self>
+    fn try_into_mut(self) -> Result<StructVectorMut, Self>
     where
         Self: Sized,
     {

--- a/vortex-vector/src/struct_/vector_mut.rs
+++ b/vortex-vector/src/struct_/vector_mut.rs
@@ -279,7 +279,7 @@ impl VectorMutOps for StructVectorMut {
         debug_assert_eq!(self.len, self.validity.len());
     }
 
-    fn freeze(self) -> Self::Immutable {
+    fn freeze(self) -> StructVector {
         let frozen_fields: Vec<Vector> = self
             .fields
             .into_iter()

--- a/vortex-vector/src/vector.rs
+++ b/vortex-vector/src/vector.rs
@@ -58,7 +58,7 @@ impl VectorOps for Vector {
         match_each_vector!(self, |v| { v.validity() })
     }
 
-    fn try_into_mut(self) -> Result<Self::Mutable, Self>
+    fn try_into_mut(self) -> Result<VectorMut, Self>
     where
         Self: Sized,
     {

--- a/vortex-vector/src/vector_mut.rs
+++ b/vortex-vector/src/vector_mut.rs
@@ -82,7 +82,7 @@ impl VectorMutOps for VectorMut {
         match_each_vector_mut!(self, |v| { v.reserve(additional) })
     }
 
-    fn extend_from_vector(&mut self, other: &Self::Immutable) {
+    fn extend_from_vector(&mut self, other: &Vector) {
         match_vector_pair!(self, other, |a: VectorMut, b: Vector| {
             a.extend_from_vector(b)
         })
@@ -92,7 +92,7 @@ impl VectorMutOps for VectorMut {
         match_each_vector_mut!(self, |v| { v.append_nulls(n) })
     }
 
-    fn freeze(self) -> Self::Immutable {
+    fn freeze(self) -> Vector {
         match_each_vector_mut!(self, |v| { v.freeze().into() })
     }
 


### PR DESCRIPTION
Imo this is more readable when using associated types