### PR TITLE
Chore: use `Self` in more places in vectors

### DIFF
--- a/vortex-vector/src/bool/vector.rs
+++ b/vortex-vector/src/bool/vector.rs
@@ -85,7 +85,7 @@ impl VectorOps for BoolVector {
         let bits = match self.bits.try_into_mut() {
             Ok(bits) => bits,
             Err(bits) => {
-                return Err(BoolVector {
+                return Err(Self {
                     bits,
                     validity: self.validity,
                 });
@@ -97,7 +97,7 @@ impl VectorOps for BoolVector {
                 bits,
                 validity: validity_mut,
             }),
-            Err(validity) => Err(BoolVector {
+            Err(validity) => Err(Self {
                 bits: bits.freeze(),
                 validity,
             }),

--- a/vortex-vector/src/bool/vector_mut.rs
+++ b/vortex-vector/src/bool/vector_mut.rs
@@ -115,7 +115,7 @@ impl VectorMutOps for BoolVectorMut {
     }
 
     fn split_off(&mut self, at: usize) -> Self {
-        BoolVectorMut {
+        Self {
             bits: self.bits.split_off(at),
             validity: self.validity.split_off(at),
         }

--- a/vortex-vector/src/decimal/generic.rs
+++ b/vortex-vector/src/decimal/generic.rs
@@ -159,7 +159,7 @@ impl<D: NativeDecimalType> VectorOps for DVector<D> {
         let elements = match self.elements.try_into_mut() {
             Ok(elements) => elements,
             Err(elements) => {
-                return Err(DVector {
+                return Err(Self {
                     ps: self.ps,
                     elements,
                     validity: self.validity,
@@ -173,7 +173,7 @@ impl<D: NativeDecimalType> VectorOps for DVector<D> {
                 elements,
                 validity: validity_mut,
             }),
-            Err(validity) => Err(DVector {
+            Err(validity) => Err(Self {
                 ps: self.ps,
                 elements: elements.freeze(),
                 validity,

--- a/vortex-vector/src/decimal/vector.rs
+++ b/vortex-vector/src/decimal/vector.rs
@@ -42,7 +42,7 @@ impl VectorOps for DecimalVector {
         match_each_dvector!(self, |v| {
             v.try_into_mut()
                 .map(DecimalVectorMut::from)
-                .map_err(DecimalVector::from)
+                .map_err(Self::from)
         })
     }
 }
@@ -51,42 +51,42 @@ impl DecimalTypeDowncast for DecimalVector {
     type Output<T: NativeDecimalType> = DVector<T>;
 
     fn into_i8(self) -> Self::Output<i8> {
-        if let DecimalVector::D8(vec) = self {
+        if let Self::D8(vec) = self {
             return vec;
         }
         vortex_panic!("DecimalVector is not of type D8");
     }
 
     fn into_i16(self) -> Self::Output<i16> {
-        if let DecimalVector::D16(vec) = self {
+        if let Self::D16(vec) = self {
             return vec;
         }
         vortex_panic!("DecimalVector is not of type D16");
     }
 
     fn into_i32(self) -> Self::Output<i32> {
-        if let DecimalVector::D32(vec) = self {
+        if let Self::D32(vec) = self {
             return vec;
         }
         vortex_panic!("DecimalVector is not of type D32");
     }
 
     fn into_i64(self) -> Self::Output<i64> {
-        if let DecimalVector::D64(vec) = self {
+        if let Self::D64(vec) = self {
             return vec;
         }
         vortex_panic!("DecimalVector is not of type D64");
     }
 
     fn into_i128(self) -> Self::Output<i128> {
-        if let DecimalVector::D128(vec) = self {
+        if let Self::D128(vec) = self {
             return vec;
         }
         vortex_panic!("DecimalVector is not of type D128");
     }
 
     fn into_i256(self) -> Self::Output<i256> {
-        if let DecimalVector::D256(vec) = self {
+        if let Self::D256(vec) = self {
             return vec;
         }
         vortex_panic!("DecimalVector is not of type D256");
@@ -97,26 +97,26 @@ impl DecimalTypeUpcast for DecimalVector {
     type Input<T: NativeDecimalType> = DVector<T>;
 
     fn from_i8(input: Self::Input<i8>) -> Self {
-        DecimalVector::D8(input)
+        Self::D8(input)
     }
 
     fn from_i16(input: Self::Input<i16>) -> Self {
-        DecimalVector::D16(input)
+        Self::D16(input)
     }
 
     fn from_i32(input: Self::Input<i32>) -> Self {
-        DecimalVector::D32(input)
+        Self::D32(input)
     }
 
     fn from_i64(input: Self::Input<i64>) -> Self {
-        DecimalVector::D64(input)
+        Self::D64(input)
     }
 
     fn from_i128(input: Self::Input<i128>) -> Self {
-        DecimalVector::D128(input)
+        Self::D128(input)
     }
 
     fn from_i256(input: Self::Input<i256>) -> Self {
-        DecimalVector::D256(input)
+        Self::D256(input)
     }
 }

--- a/vortex-vector/src/decimal/vector_mut.rs
+++ b/vortex-vector/src/decimal/vector_mut.rs
@@ -35,23 +35,21 @@ impl DecimalVectorMut {
         let decimal_kind = DecimalType::smallest_decimal_value_type(decimal_dtype);
 
         match decimal_kind {
-            DecimalType::I8 => {
-                DecimalVectorMut::D8(DVectorMut::<i8>::with_capacity(decimal_dtype, capacity))
-            }
+            DecimalType::I8 => Self::D8(DVectorMut::<i8>::with_capacity(decimal_dtype, capacity)),
             DecimalType::I16 => {
-                DecimalVectorMut::D16(DVectorMut::<i16>::with_capacity(decimal_dtype, capacity))
+                Self::D16(DVectorMut::<i16>::with_capacity(decimal_dtype, capacity))
             }
             DecimalType::I32 => {
-                DecimalVectorMut::D32(DVectorMut::<i32>::with_capacity(decimal_dtype, capacity))
+                Self::D32(DVectorMut::<i32>::with_capacity(decimal_dtype, capacity))
             }
             DecimalType::I64 => {
-                DecimalVectorMut::D64(DVectorMut::<i64>::with_capacity(decimal_dtype, capacity))
+                Self::D64(DVectorMut::<i64>::with_capacity(decimal_dtype, capacity))
             }
             DecimalType::I128 => {
-                DecimalVectorMut::D128(DVectorMut::<i128>::with_capacity(decimal_dtype, capacity))
+                Self::D128(DVectorMut::<i128>::with_capacity(decimal_dtype, capacity))
             }
             DecimalType::I256 => {
-                DecimalVectorMut::D256(DVectorMut::<i256>::with_capacity(decimal_dtype, capacity))
+                Self::D256(DVectorMut::<i256>::with_capacity(decimal_dtype, capacity))
             }
         }
     }
@@ -78,12 +76,12 @@ impl VectorMutOps for DecimalVectorMut {
 
     fn extend_from_vector(&mut self, other: &DecimalVector) {
         match (self, other) {
-            (DecimalVectorMut::D8(s), DecimalVector::D8(o)) => s.extend_from_vector(o),
-            (DecimalVectorMut::D16(s), DecimalVector::D16(o)) => s.extend_from_vector(o),
-            (DecimalVectorMut::D32(s), DecimalVector::D32(o)) => s.extend_from_vector(o),
-            (DecimalVectorMut::D64(s), DecimalVector::D64(o)) => s.extend_from_vector(o),
-            (DecimalVectorMut::D128(s), DecimalVector::D128(o)) => s.extend_from_vector(o),
-            (DecimalVectorMut::D256(s), DecimalVector::D256(o)) => s.extend_from_vector(o),
+            (Self::D8(s), DecimalVector::D8(o)) => s.extend_from_vector(o),
+            (Self::D16(s), DecimalVector::D16(o)) => s.extend_from_vector(o),
+            (Self::D32(s), DecimalVector::D32(o)) => s.extend_from_vector(o),
+            (Self::D64(s), DecimalVector::D64(o)) => s.extend_from_vector(o),
+            (Self::D128(s), DecimalVector::D128(o)) => s.extend_from_vector(o),
+            (Self::D256(s), DecimalVector::D256(o)) => s.extend_from_vector(o),
             _ => vortex_panic!("Mismatched decimal vector types in extend_from_vector"),
         }
     }
@@ -102,12 +100,12 @@ impl VectorMutOps for DecimalVectorMut {
 
     fn unsplit(&mut self, other: Self) {
         match (self, other) {
-            (DecimalVectorMut::D8(s), DecimalVectorMut::D8(o)) => s.unsplit(o),
-            (DecimalVectorMut::D16(s), DecimalVectorMut::D16(o)) => s.unsplit(o),
-            (DecimalVectorMut::D32(s), DecimalVectorMut::D32(o)) => s.unsplit(o),
-            (DecimalVectorMut::D64(s), DecimalVectorMut::D64(o)) => s.unsplit(o),
-            (DecimalVectorMut::D128(s), DecimalVectorMut::D128(o)) => s.unsplit(o),
-            (DecimalVectorMut::D256(s), DecimalVectorMut::D256(o)) => s.unsplit(o),
+            (Self::D8(s), Self::D8(o)) => s.unsplit(o),
+            (Self::D16(s), Self::D16(o)) => s.unsplit(o),
+            (Self::D32(s), Self::D32(o)) => s.unsplit(o),
+            (Self::D64(s), Self::D64(o)) => s.unsplit(o),
+            (Self::D128(s), Self::D128(o)) => s.unsplit(o),
+            (Self::D256(s), Self::D256(o)) => s.unsplit(o),
             _ => vortex_panic!("Mismatched decimal vector types in unsplit"),
         }
     }
@@ -117,42 +115,42 @@ impl DecimalTypeDowncast for DecimalVectorMut {
     type Output<T: NativeDecimalType> = DVectorMut<T>;
 
     fn into_i8(self) -> Self::Output<i8> {
-        if let DecimalVectorMut::D8(vec) = self {
+        if let Self::D8(vec) = self {
             return vec;
         }
         vortex_panic!("DecimalVectorMut is not of type D8");
     }
 
     fn into_i16(self) -> Self::Output<i16> {
-        if let DecimalVectorMut::D16(vec) = self {
+        if let Self::D16(vec) = self {
             return vec;
         }
         vortex_panic!("DecimalVectorMut is not of type D16");
     }
 
     fn into_i32(self) -> Self::Output<i32> {
-        if let DecimalVectorMut::D32(vec) = self {
+        if let Self::D32(vec) = self {
             return vec;
         }
         vortex_panic!("DecimalVectorMut is not of type D32");
     }
 
     fn into_i64(self) -> Self::Output<i64> {
-        if let DecimalVectorMut::D64(vec) = self {
+        if let Self::D64(vec) = self {
             return vec;
         }
         vortex_panic!("DecimalVectorMut is not of type D64");
     }
 
     fn into_i128(self) -> Self::Output<i128> {
-        if let DecimalVectorMut::D128(vec) = self {
+        if let Self::D128(vec) = self {
             return vec;
         }
         vortex_panic!("DecimalVectorMut is not of type D128");
     }
 
     fn into_i256(self) -> Self::Output<i256> {
-        if let DecimalVectorMut::D256(vec) = self {
+        if let Self::D256(vec) = self {
             return vec;
         }
         vortex_panic!("DecimalVectorMut is not of type D256");
@@ -163,26 +161,26 @@ impl DecimalTypeUpcast for DecimalVectorMut {
     type Input<T: NativeDecimalType> = DVectorMut<T>;
 
     fn from_i8(input: Self::Input<i8>) -> Self {
-        DecimalVectorMut::D8(input)
+        Self::D8(input)
     }
 
     fn from_i16(input: Self::Input<i16>) -> Self {
-        DecimalVectorMut::D16(input)
+        Self::D16(input)
     }
 
     fn from_i32(input: Self::Input<i32>) -> Self {
-        DecimalVectorMut::D32(input)
+        Self::D32(input)
     }
 
     fn from_i64(input: Self::Input<i64>) -> Self {
-        DecimalVectorMut::D64(input)
+        Self::D64(input)
     }
 
     fn from_i128(input: Self::Input<i128>) -> Self {
-        DecimalVectorMut::D128(input)
+        Self::D128(input)
     }
 
     fn from_i256(input: Self::Input<i256>) -> Self {
-        DecimalVectorMut::D256(input)
+        Self::D256(input)
     }
 }

--- a/vortex-vector/src/fixed_size_list/vector_mut.rs
+++ b/vortex-vector/src/fixed_size_list/vector_mut.rs
@@ -189,7 +189,7 @@ impl VectorMutOps for FixedSizeListVectorMut {
         self.elements.reserve(additional * self.list_size as usize);
     }
 
-    fn extend_from_vector(&mut self, other: &Self::Immutable) {
+    fn extend_from_vector(&mut self, other: &FixedSizeListVector) {
         match_vector_pair!(
             self.elements.as_mut(),
             other.elements.as_ref(),
@@ -211,7 +211,7 @@ impl VectorMutOps for FixedSizeListVectorMut {
         debug_assert_eq!(self.len, self.validity.len());
     }
 
-    fn freeze(self) -> Self::Immutable {
+    fn freeze(self) -> FixedSizeListVector {
         FixedSizeListVector {
             elements: Arc::new(self.elements.freeze()),
             list_size: self.list_size,

--- a/vortex-vector/src/primitive/generic.rs
+++ b/vortex-vector/src/primitive/generic.rs
@@ -124,7 +124,7 @@ impl<T: NativePType> VectorOps for PVector<T> {
         let elements = match self.elements.try_into_mut() {
             Ok(elements) => elements,
             Err(elements) => {
-                return Err(PVector {
+                return Err(Self {
                     elements,
                     validity: self.validity,
                 });
@@ -136,7 +136,7 @@ impl<T: NativePType> VectorOps for PVector<T> {
                 elements,
                 validity: validity_mut,
             }),
-            Err(validity) => Err(PVector {
+            Err(validity) => Err(Self {
                 elements: elements.freeze(),
                 validity,
             }),

--- a/vortex-vector/src/primitive/generic_mut.rs
+++ b/vortex-vector/src/primitive/generic_mut.rs
@@ -119,7 +119,7 @@ impl<T: NativePType> VectorMutOps for PVectorMut<T> {
     }
 
     fn split_off(&mut self, at: usize) -> Self {
-        PVectorMut {
+        Self {
             elements: self.elements.split_off(at),
             validity: self.validity.split_off(at),
         }

--- a/vortex-vector/src/primitive/vector.rs
+++ b/vortex-vector/src/primitive/vector.rs
@@ -49,17 +49,17 @@ impl PrimitiveVector {
     /// Returns the [`PType`] of this [`PrimitiveVector`].
     pub fn ptype(&self) -> PType {
         match self {
-            PrimitiveVector::U8(_) => PType::U8,
-            PrimitiveVector::U16(_) => PType::U16,
-            PrimitiveVector::U32(_) => PType::U32,
-            PrimitiveVector::U64(_) => PType::U64,
-            PrimitiveVector::I8(_) => PType::I8,
-            PrimitiveVector::I16(_) => PType::I16,
-            PrimitiveVector::I32(_) => PType::I32,
-            PrimitiveVector::I64(_) => PType::I64,
-            PrimitiveVector::F16(_) => PType::F16,
-            PrimitiveVector::F32(_) => PType::F32,
-            PrimitiveVector::F64(_) => PType::F64,
+            Self::U8(_) => PType::U8,
+            Self::U16(_) => PType::U16,
+            Self::U32(_) => PType::U32,
+            Self::U64(_) => PType::U64,
+            Self::I8(_) => PType::I8,
+            Self::I16(_) => PType::I16,
+            Self::I32(_) => PType::I32,
+            Self::I64(_) => PType::I64,
+            Self::F16(_) => PType::F16,
+            Self::F32(_) => PType::F32,
+            Self::F64(_) => PType::F64,
         }
     }
 }
@@ -79,7 +79,7 @@ impl VectorOps for PrimitiveVector {
         match_each_pvector!(self, |v| {
             v.try_into_mut()
                 .map(PrimitiveVectorMut::from)
-                .map_err(PrimitiveVector::from)
+                .map_err(Self::from)
         })
     }
 }
@@ -88,47 +88,47 @@ impl PTypeUpcast for PrimitiveVector {
     type Input<T: NativePType> = PVector<T>;
 
     fn from_u8(input: Self::Input<u8>) -> Self {
-        PrimitiveVector::U8(input)
+        Self::U8(input)
     }
 
     fn from_u16(input: Self::Input<u16>) -> Self {
-        PrimitiveVector::U16(input)
+        Self::U16(input)
     }
 
     fn from_u32(input: Self::Input<u32>) -> Self {
-        PrimitiveVector::U32(input)
+        Self::U32(input)
     }
 
     fn from_u64(input: Self::Input<u64>) -> Self {
-        PrimitiveVector::U64(input)
+        Self::U64(input)
     }
 
     fn from_i8(input: Self::Input<i8>) -> Self {
-        PrimitiveVector::I8(input)
+        Self::I8(input)
     }
 
     fn from_i16(input: Self::Input<i16>) -> Self {
-        PrimitiveVector::I16(input)
+        Self::I16(input)
     }
 
     fn from_i32(input: Self::Input<i32>) -> Self {
-        PrimitiveVector::I32(input)
+        Self::I32(input)
     }
 
     fn from_i64(input: Self::Input<i64>) -> Self {
-        PrimitiveVector::I64(input)
+        Self::I64(input)
     }
 
     fn from_f16(input: Self::Input<f16>) -> Self {
-        PrimitiveVector::F16(input)
+        Self::F16(input)
     }
 
     fn from_f32(input: Self::Input<f32>) -> Self {
-        PrimitiveVector::F32(input)
+        Self::F32(input)
     }
 
     fn from_f64(input: Self::Input<f64>) -> Self {
-        PrimitiveVector::F64(input)
+        Self::F64(input)
     }
 }
 
@@ -136,77 +136,77 @@ impl PTypeDowncast for PrimitiveVector {
     type Output<T: NativePType> = PVector<T>;
 
     fn into_u8(self) -> Self::Output<u8> {
-        if let PrimitiveVector::U8(v) = self {
+        if let Self::U8(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVector::U8, got {self:?}");
     }
 
     fn into_u16(self) -> Self::Output<u16> {
-        if let PrimitiveVector::U16(v) = self {
+        if let Self::U16(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVector::U16, got {self:?}");
     }
 
     fn into_u32(self) -> Self::Output<u32> {
-        if let PrimitiveVector::U32(v) = self {
+        if let Self::U32(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVector::U32, got {self:?}");
     }
 
     fn into_u64(self) -> Self::Output<u64> {
-        if let PrimitiveVector::U64(v) = self {
+        if let Self::U64(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVector::U64, got {self:?}");
     }
 
     fn into_i8(self) -> Self::Output<i8> {
-        if let PrimitiveVector::I8(v) = self {
+        if let Self::I8(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVector::I8, got {self:?}");
     }
 
     fn into_i16(self) -> Self::Output<i16> {
-        if let PrimitiveVector::I16(v) = self {
+        if let Self::I16(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVector::I16, got {self:?}");
     }
 
     fn into_i32(self) -> Self::Output<i32> {
-        if let PrimitiveVector::I32(v) = self {
+        if let Self::I32(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVector::I32, got {self:?}");
     }
 
     fn into_i64(self) -> Self::Output<i64> {
-        if let PrimitiveVector::I64(v) = self {
+        if let Self::I64(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVector::I64, got {self:?}");
     }
 
     fn into_f16(self) -> Self::Output<f16> {
-        if let PrimitiveVector::F16(v) = self {
+        if let Self::F16(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVector::F16, got {self:?}");
     }
 
     fn into_f32(self) -> Self::Output<f32> {
-        if let PrimitiveVector::F32(v) = self {
+        if let Self::F32(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVector::F32, got {self:?}");
     }
 
     fn into_f64(self) -> Self::Output<f64> {
-        if let PrimitiveVector::F64(v) = self {
+        if let Self::F64(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVector::F64, got {self:?}");

--- a/vortex-vector/src/primitive/vector_mut.rs
+++ b/vortex-vector/src/primitive/vector_mut.rs
@@ -49,17 +49,17 @@ impl PrimitiveVectorMut {
     /// Returns the [`PType`] of this [`PrimitiveVectorMut`].
     pub fn ptype(&self) -> PType {
         match self {
-            PrimitiveVectorMut::U8(_) => PType::U8,
-            PrimitiveVectorMut::U16(_) => PType::U16,
-            PrimitiveVectorMut::U32(_) => PType::U32,
-            PrimitiveVectorMut::U64(_) => PType::U64,
-            PrimitiveVectorMut::I8(_) => PType::I8,
-            PrimitiveVectorMut::I16(_) => PType::I16,
-            PrimitiveVectorMut::I32(_) => PType::I32,
-            PrimitiveVectorMut::I64(_) => PType::I64,
-            PrimitiveVectorMut::F16(_) => PType::F16,
-            PrimitiveVectorMut::F32(_) => PType::F32,
-            PrimitiveVectorMut::F64(_) => PType::F64,
+            Self::U8(_) => PType::U8,
+            Self::U16(_) => PType::U16,
+            Self::U32(_) => PType::U32,
+            Self::U64(_) => PType::U64,
+            Self::I8(_) => PType::I8,
+            Self::I16(_) => PType::I16,
+            Self::I32(_) => PType::I32,
+            Self::I64(_) => PType::I64,
+            Self::F16(_) => PType::F16,
+            Self::F32(_) => PType::F32,
+            Self::F64(_) => PType::F64,
         }
     }
 
@@ -102,17 +102,17 @@ impl VectorMutOps for PrimitiveVectorMut {
 
     fn extend_from_vector(&mut self, other: &PrimitiveVector) {
         match (self, other) {
-            (PrimitiveVectorMut::U8(a), PrimitiveVector::U8(b)) => a.extend_from_vector(b),
-            (PrimitiveVectorMut::U16(a), PrimitiveVector::U16(b)) => a.extend_from_vector(b),
-            (PrimitiveVectorMut::U32(a), PrimitiveVector::U32(b)) => a.extend_from_vector(b),
-            (PrimitiveVectorMut::U64(a), PrimitiveVector::U64(b)) => a.extend_from_vector(b),
-            (PrimitiveVectorMut::I8(a), PrimitiveVector::I8(b)) => a.extend_from_vector(b),
-            (PrimitiveVectorMut::I16(a), PrimitiveVector::I16(b)) => a.extend_from_vector(b),
-            (PrimitiveVectorMut::I32(a), PrimitiveVector::I32(b)) => a.extend_from_vector(b),
-            (PrimitiveVectorMut::I64(a), PrimitiveVector::I64(b)) => a.extend_from_vector(b),
-            (PrimitiveVectorMut::F16(a), PrimitiveVector::F16(b)) => a.extend_from_vector(b),
-            (PrimitiveVectorMut::F32(a), PrimitiveVector::F32(b)) => a.extend_from_vector(b),
-            (PrimitiveVectorMut::F64(a), PrimitiveVector::F64(b)) => a.extend_from_vector(b),
+            (Self::U8(a), PrimitiveVector::U8(b)) => a.extend_from_vector(b),
+            (Self::U16(a), PrimitiveVector::U16(b)) => a.extend_from_vector(b),
+            (Self::U32(a), PrimitiveVector::U32(b)) => a.extend_from_vector(b),
+            (Self::U64(a), PrimitiveVector::U64(b)) => a.extend_from_vector(b),
+            (Self::I8(a), PrimitiveVector::I8(b)) => a.extend_from_vector(b),
+            (Self::I16(a), PrimitiveVector::I16(b)) => a.extend_from_vector(b),
+            (Self::I32(a), PrimitiveVector::I32(b)) => a.extend_from_vector(b),
+            (Self::I64(a), PrimitiveVector::I64(b)) => a.extend_from_vector(b),
+            (Self::F16(a), PrimitiveVector::F16(b)) => a.extend_from_vector(b),
+            (Self::F32(a), PrimitiveVector::F32(b)) => a.extend_from_vector(b),
+            (Self::F64(a), PrimitiveVector::F64(b)) => a.extend_from_vector(b),
             _ => ::vortex_error::vortex_panic!("Mismatched primitive vector types"),
         }
     }
@@ -131,17 +131,17 @@ impl VectorMutOps for PrimitiveVectorMut {
 
     fn unsplit(&mut self, other: Self) {
         match (self, other) {
-            (PrimitiveVectorMut::U8(a), PrimitiveVectorMut::U8(b)) => a.unsplit(b),
-            (PrimitiveVectorMut::U16(a), PrimitiveVectorMut::U16(b)) => a.unsplit(b),
-            (PrimitiveVectorMut::U32(a), PrimitiveVectorMut::U32(b)) => a.unsplit(b),
-            (PrimitiveVectorMut::U64(a), PrimitiveVectorMut::U64(b)) => a.unsplit(b),
-            (PrimitiveVectorMut::I8(a), PrimitiveVectorMut::I8(b)) => a.unsplit(b),
-            (PrimitiveVectorMut::I16(a), PrimitiveVectorMut::I16(b)) => a.unsplit(b),
-            (PrimitiveVectorMut::I32(a), PrimitiveVectorMut::I32(b)) => a.unsplit(b),
-            (PrimitiveVectorMut::I64(a), PrimitiveVectorMut::I64(b)) => a.unsplit(b),
-            (PrimitiveVectorMut::F16(a), PrimitiveVectorMut::F16(b)) => a.unsplit(b),
-            (PrimitiveVectorMut::F32(a), PrimitiveVectorMut::F32(b)) => a.unsplit(b),
-            (PrimitiveVectorMut::F64(a), PrimitiveVectorMut::F64(b)) => a.unsplit(b),
+            (Self::U8(a), Self::U8(b)) => a.unsplit(b),
+            (Self::U16(a), Self::U16(b)) => a.unsplit(b),
+            (Self::U32(a), Self::U32(b)) => a.unsplit(b),
+            (Self::U64(a), Self::U64(b)) => a.unsplit(b),
+            (Self::I8(a), Self::I8(b)) => a.unsplit(b),
+            (Self::I16(a), Self::I16(b)) => a.unsplit(b),
+            (Self::I32(a), Self::I32(b)) => a.unsplit(b),
+            (Self::I64(a), Self::I64(b)) => a.unsplit(b),
+            (Self::F16(a), Self::F16(b)) => a.unsplit(b),
+            (Self::F32(a), Self::F32(b)) => a.unsplit(b),
+            (Self::F64(a), Self::F64(b)) => a.unsplit(b),
             _ => ::vortex_error::vortex_panic!("Mismatched primitive vector types"),
         }
     }
@@ -151,47 +151,47 @@ impl PTypeUpcast for PrimitiveVectorMut {
     type Input<T: NativePType> = PVectorMut<T>;
 
     fn from_u8(input: Self::Input<u8>) -> Self {
-        PrimitiveVectorMut::U8(input)
+        Self::U8(input)
     }
 
     fn from_u16(input: Self::Input<u16>) -> Self {
-        PrimitiveVectorMut::U16(input)
+        Self::U16(input)
     }
 
     fn from_u32(input: Self::Input<u32>) -> Self {
-        PrimitiveVectorMut::U32(input)
+        Self::U32(input)
     }
 
     fn from_u64(input: Self::Input<u64>) -> Self {
-        PrimitiveVectorMut::U64(input)
+        Self::U64(input)
     }
 
     fn from_i8(input: Self::Input<i8>) -> Self {
-        PrimitiveVectorMut::I8(input)
+        Self::I8(input)
     }
 
     fn from_i16(input: Self::Input<i16>) -> Self {
-        PrimitiveVectorMut::I16(input)
+        Self::I16(input)
     }
 
     fn from_i32(input: Self::Input<i32>) -> Self {
-        PrimitiveVectorMut::I32(input)
+        Self::I32(input)
     }
 
     fn from_i64(input: Self::Input<i64>) -> Self {
-        PrimitiveVectorMut::I64(input)
+        Self::I64(input)
     }
 
     fn from_f16(input: Self::Input<f16>) -> Self {
-        PrimitiveVectorMut::F16(input)
+        Self::F16(input)
     }
 
     fn from_f32(input: Self::Input<f32>) -> Self {
-        PrimitiveVectorMut::F32(input)
+        Self::F32(input)
     }
 
     fn from_f64(input: Self::Input<f64>) -> Self {
-        PrimitiveVectorMut::F64(input)
+        Self::F64(input)
     }
 }
 
@@ -199,77 +199,77 @@ impl PTypeDowncast for PrimitiveVectorMut {
     type Output<T: NativePType> = PVectorMut<T>;
 
     fn into_u8(self) -> Self::Output<u8> {
-        if let PrimitiveVectorMut::U8(v) = self {
+        if let Self::U8(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVectorMut::U8, got {self:?}");
     }
 
     fn into_u16(self) -> Self::Output<u16> {
-        if let PrimitiveVectorMut::U16(v) = self {
+        if let Self::U16(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVectorMut::U16, got {self:?}");
     }
 
     fn into_u32(self) -> Self::Output<u32> {
-        if let PrimitiveVectorMut::U32(v) = self {
+        if let Self::U32(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVectorMut::U32, got {self:?}");
     }
 
     fn into_u64(self) -> Self::Output<u64> {
-        if let PrimitiveVectorMut::U64(v) = self {
+        if let Self::U64(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVectorMut::U64, got {self:?}");
     }
 
     fn into_i8(self) -> Self::Output<i8> {
-        if let PrimitiveVectorMut::I8(v) = self {
+        if let Self::I8(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVectorMut::I8, got {self:?}");
     }
 
     fn into_i16(self) -> Self::Output<i16> {
-        if let PrimitiveVectorMut::I16(v) = self {
+        if let Self::I16(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVectorMut::I16, got {self:?}");
     }
 
     fn into_i32(self) -> Self::Output<i32> {
-        if let PrimitiveVectorMut::I32(v) = self {
+        if let Self::I32(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVectorMut::I32, got {self:?}");
     }
 
     fn into_i64(self) -> Self::Output<i64> {
-        if let PrimitiveVectorMut::I64(v) = self {
+        if let Self::I64(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVectorMut::I64, got {self:?}");
     }
 
     fn into_f16(self) -> Self::Output<f16> {
-        if let PrimitiveVectorMut::F16(v) = self {
+        if let Self::F16(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVectorMut::F16, got {self:?}");
     }
 
     fn into_f32(self) -> Self::Output<f32> {
-        if let PrimitiveVectorMut::F32(v) = self {
+        if let Self::F32(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVectorMut::F32, got {self:?}");
     }
 
     fn into_f64(self) -> Self::Output<f64> {
-        if let PrimitiveVectorMut::F64(v) = self {
+        if let Self::F64(v) = self {
             return v;
         }
         vortex_panic!("Expected PrimitiveVectorMut::F64, got {self:?}");

--- a/vortex-vector/src/struct_/vector.rs
+++ b/vortex-vector/src/struct_/vector.rs
@@ -136,13 +136,13 @@ impl VectorOps for StructVector {
 
         let fields = match Arc::try_unwrap(self.fields) {
             Ok(fields) => fields,
-            Err(fields) => return Err(StructVector { fields, ..self }),
+            Err(fields) => return Err(Self { fields, ..self }),
         };
 
         let validity = match self.validity.try_into_mut() {
             Ok(validity) => validity,
             Err(validity) => {
-                return Err(StructVector {
+                return Err(Self {
                     fields: Arc::new(fields),
                     validity,
                     len,
@@ -171,7 +171,7 @@ impl VectorOps for StructVector {
                     all_fields.push(immutable_field);
                     all_fields.extend(fields_iter);
 
-                    return Err(StructVector {
+                    return Err(Self {
                         fields: Arc::new(all_fields.into_boxed_slice()),
                         len: self.len,
                         validity: validity.freeze(),


### PR DESCRIPTION
This makes it easier to read the code since the immutable vs mutable names are so similar.

This is a purely cosmetic change