### PR TITLE
fix: Remove erroneous chunk offset calculation from Patches::take_search

### DIFF
--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -1078,9 +1078,6 @@ mod test {
             primitive_values.validity_mask(),
             Mask::from_iter([true, false])
         );
-
-        let chunk_offsets = taken.chunk_offsets().as_ref().unwrap().to_primitive();
-        assert_eq!(chunk_offsets.as_slice::<u64>(), &[0]);
     }
 
     #[test]
@@ -1104,9 +1101,6 @@ mod test {
         let primitive_values = taken.values().to_primitive();
         assert_eq!(taken.array_len(), 3);
         assert_eq!(primitive_values.as_slice::<i32>(), [20, 30]);
-
-        let chunk_offsets = taken.chunk_offsets().as_ref().unwrap().to_primitive();
-        assert_eq!(chunk_offsets.as_slice::<u64>(), &[0]);
     }
 
     #[test]
@@ -1150,9 +1144,6 @@ mod test {
         let primitive_values = taken.values().to_primitive();
         assert_eq!(taken.array_len(), 4);
         assert_eq!(primitive_values.as_slice::<i32>(), [200, 300]);
-
-        let chunk_offsets = taken.chunk_offsets().as_ref().unwrap().to_primitive();
-        assert_eq!(chunk_offsets.as_slice::<u64>(), &[0]);
     }
 
     #[test]
@@ -1174,15 +1165,6 @@ mod test {
             .unwrap();
 
         assert_eq!(taken.array_len(), 1500);
-        assert_eq!(
-            taken
-                .chunk_offsets()
-                .as_ref()
-                .unwrap()
-                .to_primitive()
-                .as_slice::<u64>(),
-            &[0, 1024]
-        );
     }
 
     #[test]

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -730,16 +730,7 @@ impl Patches {
 
         let new_indices = new_indices.into_array();
         let new_array_len = take_indices.len();
-        let num_chunks = new_array_len.div_ceil(PATCH_CHUNK_SIZE);
         let values_validity = take_indices_validity.take(&new_indices)?;
-
-        // Indices are rewritten during take such that they are strictly
-        // monotonically increasing, starting from 0. Therefore, we know
-        // that there's 1024 entries per chunk, except for the last.
-        let mut chunk_offsets_buf = BufferMut::<u64>::with_capacity(num_chunks);
-        for chunk_idx in 0..num_chunks {
-            chunk_offsets_buf.push((chunk_idx * PATCH_CHUNK_SIZE) as u64);
-        }
 
         Ok(Some(Self {
             array_len: new_array_len,
@@ -749,7 +740,7 @@ impl Patches {
                 self.values(),
                 &PrimitiveArray::new(values_indices, values_validity).into_array(),
             )?,
-            chunk_offsets: Some(chunk_offsets_buf.into_array()),
+            chunk_offsets: None,
             offset_within_chunk: Some(0), // Reset when creating new Patches.
         }))
     }


### PR DESCRIPTION
Signed-off-by: Robert Kruszewski <github@robertk.io>
