### PR TITLE
Chore: remove feature gates from vortex-compute

### DIFF
--- a/vortex-compute/Cargo.toml
+++ b/vortex-compute/Cargo.toml
@@ -32,11 +32,5 @@ arrow-schema = { workspace = true, optional = true }
 num-traits = { workspace = true }
 
 [features]
-default = ["arithmetic", "arrow", "comparison", "filter", "logical", "mask"]
-
-arithmetic = []
+default = ["arrow"]
 arrow = ["dep:arrow-array", "dep:arrow-buffer", "dep:arrow-schema"]
-comparison = []
-filter = []
-logical = []
-mask = []

--- a/vortex-compute/src/lib.rs
+++ b/vortex-compute/src/lib.rs
@@ -7,15 +7,10 @@
 #![deny(clippy::missing_panics_doc)]
 #![deny(clippy::missing_safety_doc)]
 
-#[cfg(feature = "arithmetic")]
 pub mod arithmetic;
 #[cfg(feature = "arrow")]
 pub mod arrow;
-#[cfg(feature = "comparison")]
 pub mod comparison;
-#[cfg(feature = "filter")]
 pub mod filter;
-#[cfg(feature = "logical")]
 pub mod logical;
-#[cfg(feature = "mask")]
 pub mod mask;


### PR DESCRIPTION
I left arrow in there because we have arrow gated by features in other places in the codebase