### PR TITLE
chore: constrain the lifetime of SessionExt::get

### DIFF
--- a/vortex-array/src/expr/session.rs
+++ b/vortex-array/src/expr/session.rs
@@ -74,7 +74,7 @@ impl Default for ExprSession {
 /// Extension trait for accessing expression session data.
 pub trait ExprSessionExt: SessionExt {
     /// Returns the expression vtable registry.
-    fn expressions(&self) -> Ref<'_, ExprSession> {
+    fn expressions<'a>(&'a self) -> Ref<'a, ExprSession> {
         self.get::<ExprSession>()
     }
 }

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -124,7 +124,7 @@ impl Default for ArraySession {
 /// Session data for Vortex arrays.
 pub trait ArraySessionExt: SessionExt {
     /// Returns the array encoding registry.
-    fn arrays(&self) -> Ref<'_, ArraySession> {
+    fn arrays<'a>(&'a self) -> Ref<'a, ArraySession> {
         self.get::<ArraySession>()
     }
 }

--- a/vortex-layout/src/session.rs
+++ b/vortex-layout/src/session.rs
@@ -56,7 +56,7 @@ impl Default for LayoutSession {
 /// Extension trait for accessing layout session data.
 pub trait LayoutSessionExt: SessionExt {
     /// Returns the layout encoding registry.
-    fn layouts(&self) -> Ref<'_, LayoutSession> {
+    fn layouts<'a>(&'a self) -> Ref<'a, LayoutSession> {
         self.get::<LayoutSession>()
     }
 }

--- a/vortex-session/src/lib.rs
+++ b/vortex-session/src/lib.rs
@@ -54,12 +54,12 @@ pub trait SessionExt: Sized + private::Sealed {
     fn session(&self) -> VortexSession;
 
     /// Returns the scope variable of type `V`, or inserts a default one if it does not exist.
-    fn get<V: SessionVar>(&self) -> Ref<'_, V>;
+    fn get<'a, V: SessionVar>(&'a self) -> Ref<'a, V>;
 
     /// Returns the scope variable of type `V`, or inserts a default one if it does not exist.
     ///
     /// Note that the returned value internally holds a lock on the variable.
-    fn get_mut<V: SessionVar>(&self) -> RefMut<'_, V>;
+    fn get_mut<'a, V: SessionVar>(&'a self) -> RefMut<'a, V>;
 }
 
 mod private {
@@ -73,7 +73,7 @@ impl SessionExt for VortexSession {
     }
 
     /// Returns the scope variable of type `V`, or inserts a default one if it does not exist.
-    fn get<V: SessionVar>(&self) -> Ref<'_, V> {
+    fn get<'a, V: SessionVar>(&'a self) -> Ref<'a, V> {
         Ref(self
             .0
             .get(&TypeId::of::<V>())
@@ -91,7 +91,7 @@ impl SessionExt for VortexSession {
     /// Returns the scope variable of type `V`, or inserts a default one if it does not exist.
     ///
     /// Note that the returned value internally holds a lock on the variable.
-    fn get_mut<V: SessionVar>(&self) -> RefMut<'_, V> {
+    fn get_mut<'a, V: SessionVar>(&'a self) -> RefMut<'a, V> {
         RefMut(
             self.0
                 .get_mut(&TypeId::of::<V>())


### PR DESCRIPTION
Seems pretty reasonable that it should live at least as long as the Session itself, right?