### PR TITLE
handle null views correctly on varbinview compaction

### DIFF
--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -695,6 +695,13 @@ impl PrecomputedViewAdjustment {
                     .as_ref()
                     .map(|o| o[b_idx as usize])
                     .unwrap_or_default();
+
+                // If offset < offset_shift, this view was invalid and wasn't counted in buffer_utilizations.
+                // Return an empty view to match how invalid views are handled in the Rewriting path.
+                if view_ref.offset < offset_shift {
+                    return BinaryView::empty_view();
+                }
+
                 view_ref
                     .with_buffer_and_offset(b_idx + buffer_offset, view_ref.offset - offset_shift)
             }
@@ -708,6 +715,13 @@ impl PrecomputedViewAdjustment {
                     .as_ref()
                     .map(|o| o[b_idx as usize])
                     .unwrap_or_default();
+
+                // If offset < offset_shift, this view was invalid and wasn't counted in buffer_utilizations.
+                // Return an empty view to match how invalid views are handled in the Rewriting path.
+                if view_ref.offset < offset_shift {
+                    return BinaryView::empty_view();
+                }
+
                 view_ref.with_buffer_and_offset(buffer, view_ref.offset - offset_shift)
             }
         }


### PR DESCRIPTION
Fix: https://github.com/vortex-data/vortex/issues/5265

while iterating on buffers of a varbinview array in compaction to decide how to compact each of them, we calculate utilisations. We only include valid (non-null) views in these calculations. 
Then during compaction we adjust the views based on their new compacted locations, but the fast path we have doesn't check validity of views, so if an invalid view was excluded in compaction, we would panic because it would now point to an invalid offset.

Now if this happens we return an emtpy view because the only explanation to see a view that is outside the pre-computed ranges is that it was invalid and we skipped including that view
