### PR TITLE
perf: optimize `expand`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8643,6 +8643,7 @@ dependencies = [
  "log",
  "memmap2",
  "num-traits",
+ "rstest",
  "serde",
  "simdutf8",
  "vortex-error",

--- a/vortex-buffer/Cargo.toml
+++ b/vortex-buffer/Cargo.toml
@@ -42,6 +42,7 @@ workspace = true
 [dev-dependencies]
 arrow-buffer = { workspace = true }
 divan = { workspace = true }
+rstest = { workspace = true }
 
 [[bench]]
 name = "vortex_buffer"

--- a/vortex-buffer/src/bit/buf.rs
+++ b/vortex-buffer/src/bit/buf.rs
@@ -440,14 +440,13 @@ impl BitBuffer {
             for bit_idx in 0..bits_in_first_byte {
                 let is_set = (byte & (1 << (start_bit_in_byte + bit_idx))) != 0;
                 f(bit_pos, is_set);
-                bit_pos += 1;
             }
 
+            bit_pos += bits_in_first_byte;
             current_byte += 1;
         }
 
-        let bits_remaining = total_bits - bit_pos;
-        let complete_bytes = bits_remaining / 8;
+        let complete_bytes = (total_bits - bit_pos) / 8;
 
         // Process complete bytes.
         for byte_idx in 0..complete_bytes {
@@ -458,87 +457,17 @@ impl BitBuffer {
                 f(bit_pos + byte_idx * 8 + bit_idx, is_set);
             }
         }
+        bit_pos += complete_bytes * 8;
         current_byte += complete_bytes;
 
         // Handle remaining bits at the end.
-        let remaining_bits = bits_remaining % 8;
+        let remaining_bits = (total_bits - bit_pos) % 8;
         if remaining_bits > 0 {
-            let bit_idx_start = bit_pos + complete_bytes * 8;
             let byte = unsafe { *buffer_ptr.add(current_byte) };
 
             for bit_idx in 0..remaining_bits {
                 let is_set = (byte & (1 << bit_idx)) != 0;
-                f(bit_idx_start + bit_idx, is_set);
-            }
-        }
-    }
-
-    /// Iterate through bits in a buffer in reverse.
-    ///
-    /// # Arguments
-    ///
-    /// * `f` - Callback function taking (bit_index, is_set)
-    ///
-    /// # Panics
-    ///
-    /// Panics if the range is outside valid bounds of the buffer.
-    #[inline]
-    pub fn iter_bits_reverse<F>(&self, mut f: F)
-    where
-        F: FnMut(usize, bool),
-    {
-        let total_bits = self.len;
-        if total_bits == 0 {
-            return;
-        }
-
-        let buffer_ptr = self.buffer.as_ptr();
-        let offset = self.offset;
-        let start_byte = offset / 8;
-        let start_bit_in_byte = offset % 8;
-        let mut bit_pos = total_bits;
-
-        let bits_in_first_byte = if start_bit_in_byte > 0 {
-            (8 - start_bit_in_byte).min(total_bits)
-        } else {
-            0
-        };
-
-        let bits_after_first = total_bits - bits_in_first_byte;
-        let first_byte_offset = if start_bit_in_byte > 0 { 1 } else { 0 };
-        let complete_bytes = (bits_after_first - bits_after_first % 8) / 8;
-        let trailing_bits = bits_after_first % 8;
-
-        // Handle remaining bit at the end.
-        if trailing_bits > 0 {
-            let byte = unsafe { *buffer_ptr.add(start_byte + first_byte_offset + complete_bytes) };
-
-            for bit_idx in (0..trailing_bits).rev() {
-                bit_pos -= 1;
-                let is_set = (byte & (1 << bit_idx)) != 0;
-                f(bit_pos, is_set);
-            }
-        }
-
-        // Process complete bytes.
-        for byte_idx in (0..complete_bytes).rev() {
-            let byte = unsafe { *buffer_ptr.add(start_byte + first_byte_offset + byte_idx) };
-
-            for bit_idx in (0..8).rev() {
-                bit_pos -= 1;
-                let is_set = (byte & (1 << bit_idx)) != 0;
-                f(bit_pos, is_set);
-            }
-        }
-
-        // Handle incomplete first byte.
-        if bits_in_first_byte > 0 {
-            let byte = unsafe { *buffer_ptr.add(start_byte) };
-
-            for bit_idx in (0..bits_in_first_byte).rev() {
-                bit_pos -= 1;
-                let is_set = (byte & (1 << (start_bit_in_byte + bit_idx))) != 0;
-                f(bit_pos, is_set);
+                f(bit_pos + bit_idx, is_set);
             }
         }
     }
@@ -658,31 +587,6 @@ mod tests {
     }
 
     #[rstest]
-    #[case(5)]
-    #[case(8)]
-    #[case(10)]
-    #[case(13)]
-    #[case(16)]
-    #[case(23)]
-    #[case(100)]
-    fn test_iter_bits_reverse(#[case] len: usize) {
-        let buf = BitBuffer::collect_bool(len, |i| i % 2 == 0);
-
-        let mut collected = Vec::new();
-        buf.iter_bits_reverse(|idx, is_set| {
-            collected.push((idx, is_set));
-        });
-
-        assert_eq!(collected.len(), len);
-
-        for (i, (idx, is_set)) in collected.iter().enumerate() {
-            let expected_idx = len - 1 - i;
-            assert_eq!(*idx, expected_idx);
-            assert_eq!(*is_set, expected_idx % 2 == 0);
-        }
-    }
-
-    #[rstest]
     #[case(3, 5)]
     #[case(3, 8)]
     #[case(5, 10)]
@@ -702,31 +606,6 @@ mod tests {
         for (idx, is_set) in collected {
             // The bits should match the original buffer at positions offset + idx
             assert_eq!(is_set, (offset + idx) % 2 == 0);
-        }
-    }
-
-    #[rstest]
-    #[case(3, 5)]
-    #[case(3, 8)]
-    #[case(5, 10)]
-    #[case(2, 16)]
-    fn test_iter_bits_reverse_with_offset(#[case] offset: usize, #[case] len: usize) {
-        let total_bits = offset + len;
-        let buf = BitBuffer::collect_bool(total_bits, |i| i % 2 == 0);
-        let buf_with_offset = BitBuffer::new_with_offset(buf.inner().clone(), len, offset);
-
-        let mut collected = Vec::new();
-        buf_with_offset.iter_bits_reverse(|idx, is_set| {
-            collected.push((idx, is_set));
-        });
-
-        assert_eq!(collected.len(), len);
-
-        for (i, (idx, is_set)) in collected.iter().enumerate() {
-            let expected_idx = len - 1 - i;
-            assert_eq!(*idx, expected_idx);
-            // The bits should match the original buffer at positions offset + expected_idx
-            assert_eq!(*is_set, (offset + expected_idx) % 2 == 0);
         }
     }
 }

--- a/vortex-buffer/src/bit/buf.rs
+++ b/vortex-buffer/src/bit/buf.rs
@@ -426,48 +426,45 @@ impl BitBuffer {
             return;
         }
 
-        let buffer_ptr = self.buffer.as_ptr();
-        let offset = self.offset;
-        let mut current_byte = offset / 8;
-        let start_bit_in_byte = offset % 8;
+        let is_bit_set = |byte: u8, bit_idx: usize| (byte & (1 << bit_idx)) != 0;
+
+        let mut buffer_ptr = unsafe { self.buffer.as_ptr().add(self.offset / 8) };
+        let start_bit_in_byte = self.offset % 8;
         let mut bit_pos = 0;
 
         // Handle incomplete first byte.
         if start_bit_in_byte > 0 {
             let bits_in_first_byte = (8 - start_bit_in_byte).min(total_bits);
-            let byte = unsafe { *buffer_ptr.add(current_byte) };
+            let byte = unsafe { *buffer_ptr };
 
             for bit_idx in 0..bits_in_first_byte {
-                let is_set = (byte & (1 << (start_bit_in_byte + bit_idx))) != 0;
-                f(bit_pos, is_set);
+                f(bit_pos, is_bit_set(byte, start_bit_in_byte + bit_idx));
             }
 
             bit_pos += bits_in_first_byte;
-            current_byte += 1;
+            buffer_ptr = unsafe { buffer_ptr.add(1) };
         }
 
         let complete_bytes = (total_bits - bit_pos) / 8;
 
         // Process complete bytes.
         for byte_idx in 0..complete_bytes {
-            let byte = unsafe { *buffer_ptr.add(current_byte + byte_idx) };
+            let byte = unsafe { *buffer_ptr };
 
             for bit_idx in 0..8 {
-                let is_set = (byte & (1 << bit_idx)) != 0;
-                f(bit_pos + byte_idx * 8 + bit_idx, is_set);
+                f(bit_pos + byte_idx * 8 + bit_idx, is_bit_set(byte, bit_idx));
             }
+            buffer_ptr = unsafe { buffer_ptr.add(1) };
         }
         bit_pos += complete_bytes * 8;
-        current_byte += complete_bytes;
 
         // Handle remaining bits at the end.
         let remaining_bits = (total_bits - bit_pos) % 8;
         if remaining_bits > 0 {
-            let byte = unsafe { *buffer_ptr.add(current_byte) };
+            let byte = unsafe { *buffer_ptr };
 
             for bit_idx in 0..remaining_bits {
-                let is_set = (byte & (1 << bit_idx)) != 0;
-                f(bit_pos + bit_idx, is_set);
+                f(bit_pos + bit_idx, is_bit_set(byte, bit_idx));
             }
         }
     }

--- a/vortex-buffer/src/bit/buf.rs
+++ b/vortex-buffer/src/bit/buf.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::ops::{BitAnd, BitOr, BitXor, Not, RangeBounds};
+use std::ops::{BitAnd, BitOr, BitXor, Not, Range, RangeBounds};
 
 use crate::bit::ops::{bitwise_binary_op, bitwise_unary_op};
 use crate::bit::{
@@ -418,7 +418,7 @@ impl BitBuffer {
     ///
     /// Panics if the range is outside valid bounds of the buffer.
     #[inline]
-    pub fn iter_bits<F>(&self, range: std::ops::Range<usize>, mut f: F)
+    pub fn iter_bits<F>(&self, range: Range<usize>, mut f: F)
     where
         F: FnMut(usize, bool),
     {
@@ -462,14 +462,14 @@ impl BitBuffer {
     ///
     /// # Arguments
     ///
-    /// * `range` - Bit range to iterate through in reverse (start inclusive, end exclusive)
+    /// * `range` - Bit range to iterate through in reverse
     /// * `f` - Callback function taking (bit_index, is_set)
     ///
     /// # Panics
     ///
     /// Panics if the range is outside valid bounds of the buffer.
     #[inline]
-    pub fn iter_bits_reverse<F>(&self, range: std::ops::Range<usize>, mut f: F)
+    pub fn iter_bits_reverse<F>(&self, range: Range<usize>, mut f: F)
     where
         F: FnMut(usize, bool),
     {

--- a/vortex-buffer/src/bit/buf.rs
+++ b/vortex-buffer/src/bit/buf.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::ops::{BitAnd, BitOr, BitXor, Not, Range, RangeBounds};
+use std::ops::{BitAnd, BitOr, BitXor, Not, RangeBounds};
 
 use crate::bit::ops::{bitwise_binary_op, bitwise_unary_op};
 use crate::bit::{
@@ -411,49 +411,64 @@ impl BitBuffer {
     ///
     /// # Arguments
     ///
-    /// * `range` - Bit range to iterate through
     /// * `f` - Callback function taking (bit_index, is_set)
     ///
     /// # Panics
     ///
     /// Panics if the range is outside valid bounds of the buffer.
     #[inline]
-    pub fn iter_bits<F>(&self, range: Range<usize>, mut f: F)
+    pub fn iter_bits<F>(&self, mut f: F)
     where
         F: FnMut(usize, bool),
     {
-        let start = range.start;
-        let end = range.end;
-
-        assert!(start <= end);
-        assert!(end <= self.len);
+        let total_bits = self.len;
+        if total_bits == 0 {
+            return;
+        }
 
         let buffer_ptr = self.buffer.as_ptr();
         let offset = self.offset;
+        let mut current_byte = offset / 8;
+        let start_bit_in_byte = offset % 8;
+        let mut bit_pos = 0;
 
-        let full_bytes = (end - start) / 8;
-        let remaining_bits = (end - start) % 8;
+        // Handle incomplete first byte.
+        if start_bit_in_byte > 0 {
+            let bits_in_first_byte = (8 - start_bit_in_byte).min(total_bits);
+            let byte = unsafe { *buffer_ptr.add(current_byte) };
 
-        for byte_idx in 0..full_bytes {
-            let bit_offset = offset + start + byte_idx * 8;
-            let byte_offset = bit_offset / 8;
-            let byte = unsafe { *buffer_ptr.add(byte_offset) };
+            for bit_idx in 0..bits_in_first_byte {
+                let is_set = (byte & (1 << (start_bit_in_byte + bit_idx))) != 0;
+                f(bit_pos, is_set);
+                bit_pos += 1;
+            }
+
+            current_byte += 1;
+        }
+
+        let bits_remaining = total_bits - bit_pos;
+        let complete_bytes = bits_remaining / 8;
+
+        // Process complete bytes.
+        for byte_idx in 0..complete_bytes {
+            let byte = unsafe { *buffer_ptr.add(current_byte + byte_idx) };
 
             for bit_idx in 0..8 {
                 let is_set = (byte & (1 << bit_idx)) != 0;
-                f(start + byte_idx * 8 + bit_idx, is_set);
+                f(bit_pos + byte_idx * 8 + bit_idx, is_set);
             }
         }
+        current_byte += complete_bytes;
 
+        // Handle remaining bits at the end.
+        let remaining_bits = bits_remaining % 8;
         if remaining_bits > 0 {
-            let bit_idx_start = start + full_bytes * 8;
-            let bit_offset = offset + bit_idx_start;
-            let byte_offset = bit_offset / 8;
-            let byte = unsafe { *buffer_ptr.add(byte_offset) };
+            let bit_idx_start = bit_pos + complete_bytes * 8;
+            let byte = unsafe { *buffer_ptr.add(current_byte) };
 
-            for i in 0..remaining_bits {
-                let is_set = (byte & (1 << i)) != 0;
-                f(bit_idx_start + i, is_set);
+            for bit_idx in 0..remaining_bits {
+                let is_set = (byte & (1 << bit_idx)) != 0;
+                f(bit_idx_start + bit_idx, is_set);
             }
         }
     }
@@ -462,49 +477,68 @@ impl BitBuffer {
     ///
     /// # Arguments
     ///
-    /// * `range` - Bit range to iterate through in reverse
     /// * `f` - Callback function taking (bit_index, is_set)
     ///
     /// # Panics
     ///
     /// Panics if the range is outside valid bounds of the buffer.
     #[inline]
-    pub fn iter_bits_reverse<F>(&self, range: Range<usize>, mut f: F)
+    pub fn iter_bits_reverse<F>(&self, mut f: F)
     where
         F: FnMut(usize, bool),
     {
-        let start = range.start;
-        let end = range.end;
-
-        assert!(start <= end);
-        assert!(end <= self.len);
+        let total_bits = self.len;
+        if total_bits == 0 {
+            return;
+        }
 
         let buffer_ptr = self.buffer.as_ptr();
         let offset = self.offset;
+        let start_byte = offset / 8;
+        let start_bit_in_byte = offset % 8;
+        let mut bit_pos = total_bits;
 
-        let full_bytes = (end - start) / 8;
-        let remaining_bits = (end - start) % 8;
+        let bits_in_first_byte = if start_bit_in_byte > 0 {
+            (8 - start_bit_in_byte).min(total_bits)
+        } else {
+            0
+        };
 
-        if remaining_bits > 0 {
-            let bit_idx_start = start + full_bytes * 8;
-            let bit_offset = offset + bit_idx_start;
-            let byte_offset = bit_offset / 8;
-            let byte = unsafe { *buffer_ptr.add(byte_offset) };
+        let bits_after_first = total_bits - bits_in_first_byte;
+        let first_byte_offset = if start_bit_in_byte > 0 { 1 } else { 0 };
+        let complete_bytes = (bits_after_first - bits_after_first % 8) / 8;
+        let trailing_bits = bits_after_first % 8;
 
-            for bit_idx in (0..remaining_bits).rev() {
+        // Handle remaining bit at the end.
+        if trailing_bits > 0 {
+            let byte = unsafe { *buffer_ptr.add(start_byte + first_byte_offset + complete_bytes) };
+
+            for bit_idx in (0..trailing_bits).rev() {
+                bit_pos -= 1;
                 let is_set = (byte & (1 << bit_idx)) != 0;
-                f(bit_idx_start + bit_idx, is_set);
+                f(bit_pos, is_set);
             }
         }
 
-        for byte_idx in (0..full_bytes).rev() {
-            let bit_offset = offset + start + byte_idx * 8;
-            let byte_offset = bit_offset / 8;
-            let byte = unsafe { *buffer_ptr.add(byte_offset) };
+        // Process complete bytes.
+        for byte_idx in (0..complete_bytes).rev() {
+            let byte = unsafe { *buffer_ptr.add(start_byte + first_byte_offset + byte_idx) };
 
             for bit_idx in (0..8).rev() {
+                bit_pos -= 1;
                 let is_set = (byte & (1 << bit_idx)) != 0;
-                f(start + byte_idx * 8 + bit_idx, is_set);
+                f(bit_pos, is_set);
+            }
+        }
+
+        // Handle incomplete first byte.
+        if bits_in_first_byte > 0 {
+            let byte = unsafe { *buffer_ptr.add(start_byte) };
+
+            for bit_idx in (0..bits_in_first_byte).rev() {
+                bit_pos -= 1;
+                let is_set = (byte & (1 << (start_bit_in_byte + bit_idx))) != 0;
+                f(bit_pos, is_set);
             }
         }
     }
@@ -593,6 +627,13 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_slice_offset_calculation() {
+        let buf = BitBuffer::collect_bool(16, |_| true);
+        let sliced = buf.slice(10..16);
+        assert_eq!(sliced.offset(), 10);
+    }
+
     #[rstest]
     #[case(5)]
     #[case(8)]
@@ -605,7 +646,7 @@ mod tests {
         let buf = BitBuffer::collect_bool(len, |i| i % 2 == 0);
 
         let mut collected = Vec::new();
-        buf.iter_bits(0..len, |idx, is_set| {
+        buf.iter_bits(|idx, is_set| {
             collected.push((idx, is_set));
         });
 
@@ -628,7 +669,7 @@ mod tests {
         let buf = BitBuffer::collect_bool(len, |i| i % 2 == 0);
 
         let mut collected = Vec::new();
-        buf.iter_bits_reverse(0..len, |idx, is_set| {
+        buf.iter_bits_reverse(|idx, is_set| {
             collected.push((idx, is_set));
         });
 
@@ -638,6 +679,54 @@ mod tests {
             let expected_idx = len - 1 - i;
             assert_eq!(*idx, expected_idx);
             assert_eq!(*is_set, expected_idx % 2 == 0);
+        }
+    }
+
+    #[rstest]
+    #[case(3, 5)]
+    #[case(3, 8)]
+    #[case(5, 10)]
+    #[case(2, 16)]
+    fn test_iter_bits_with_offset(#[case] offset: usize, #[case] len: usize) {
+        let total_bits = offset + len;
+        let buf = BitBuffer::collect_bool(total_bits, |i| i % 2 == 0);
+        let buf_with_offset = BitBuffer::new_with_offset(buf.inner().clone(), len, offset);
+
+        let mut collected = Vec::new();
+        buf_with_offset.iter_bits(|idx, is_set| {
+            collected.push((idx, is_set));
+        });
+
+        assert_eq!(collected.len(), len);
+
+        for (idx, is_set) in collected {
+            // The bits should match the original buffer at positions offset + idx
+            assert_eq!(is_set, (offset + idx) % 2 == 0);
+        }
+    }
+
+    #[rstest]
+    #[case(3, 5)]
+    #[case(3, 8)]
+    #[case(5, 10)]
+    #[case(2, 16)]
+    fn test_iter_bits_reverse_with_offset(#[case] offset: usize, #[case] len: usize) {
+        let total_bits = offset + len;
+        let buf = BitBuffer::collect_bool(total_bits, |i| i % 2 == 0);
+        let buf_with_offset = BitBuffer::new_with_offset(buf.inner().clone(), len, offset);
+
+        let mut collected = Vec::new();
+        buf_with_offset.iter_bits_reverse(|idx, is_set| {
+            collected.push((idx, is_set));
+        });
+
+        assert_eq!(collected.len(), len);
+
+        for (i, (idx, is_set)) in collected.iter().enumerate() {
+            let expected_idx = len - 1 - i;
+            assert_eq!(*idx, expected_idx);
+            // The bits should match the original buffer at positions offset + expected_idx
+            assert_eq!(*is_set, (offset + expected_idx) % 2 == 0);
         }
     }
 }

--- a/vortex-buffer/src/bit/buf.rs
+++ b/vortex-buffer/src/bit/buf.rs
@@ -427,44 +427,43 @@ impl BitBuffer {
         }
 
         let is_bit_set = |byte: u8, bit_idx: usize| (byte & (1 << bit_idx)) != 0;
-
+        let bit_offset = self.offset % 8;
         let mut buffer_ptr = unsafe { self.buffer.as_ptr().add(self.offset / 8) };
-        let start_bit_in_byte = self.offset % 8;
-        let mut bit_pos = 0;
+        let mut callback_idx = 0;
 
         // Handle incomplete first byte.
-        if start_bit_in_byte > 0 {
-            let bits_in_first_byte = (8 - start_bit_in_byte).min(total_bits);
+        if bit_offset > 0 {
+            let bits_in_first_byte = (8 - bit_offset).min(total_bits);
             let byte = unsafe { *buffer_ptr };
 
             for bit_idx in 0..bits_in_first_byte {
-                f(bit_pos, is_bit_set(byte, start_bit_in_byte + bit_idx));
+                f(callback_idx, is_bit_set(byte, bit_offset + bit_idx));
+                callback_idx += 1;
             }
 
-            bit_pos += bits_in_first_byte;
             buffer_ptr = unsafe { buffer_ptr.add(1) };
         }
 
-        let complete_bytes = (total_bits - bit_pos) / 8;
-
         // Process complete bytes.
-        for byte_idx in 0..complete_bytes {
+        let complete_bytes = (total_bits - callback_idx) / 8;
+        for _ in 0..complete_bytes {
             let byte = unsafe { *buffer_ptr };
 
             for bit_idx in 0..8 {
-                f(bit_pos + byte_idx * 8 + bit_idx, is_bit_set(byte, bit_idx));
+                f(callback_idx, is_bit_set(byte, bit_idx));
+                callback_idx += 1;
             }
             buffer_ptr = unsafe { buffer_ptr.add(1) };
         }
-        bit_pos += complete_bytes * 8;
 
         // Handle remaining bits at the end.
-        let remaining_bits = (total_bits - bit_pos) % 8;
+        let remaining_bits = total_bits - callback_idx;
         if remaining_bits > 0 {
             let byte = unsafe { *buffer_ptr };
 
             for bit_idx in 0..remaining_bits {
-                f(bit_pos + bit_idx, is_bit_set(byte, bit_idx));
+                f(callback_idx, is_bit_set(byte, bit_idx));
+                callback_idx += 1;
             }
         }
     }

--- a/vortex-buffer/src/bit/buf.rs
+++ b/vortex-buffer/src/bit/buf.rs
@@ -406,6 +406,108 @@ impl BitBuffer {
     pub fn bitand_not(&self, rhs: &BitBuffer) -> BitBuffer {
         bitwise_binary_op(self, rhs, |a, b| a & !b)
     }
+
+    /// Iterate through bits in a buffer.
+    ///
+    /// # Arguments
+    ///
+    /// * `range` - Bit range to iterate through
+    /// * `f` - Callback function taking (bit_index, is_set)
+    ///
+    /// # Panics
+    ///
+    /// Panics if the range is outside valid bounds of the buffer.
+    #[inline]
+    pub fn iter_bits<F>(&self, range: std::ops::Range<usize>, mut f: F)
+    where
+        F: FnMut(usize, bool),
+    {
+        let start = range.start;
+        let end = range.end;
+
+        assert!(start <= end);
+        assert!(end <= self.len);
+
+        let buffer_ptr = self.buffer.as_ptr();
+        let offset = self.offset;
+
+        let full_bytes = (end - start) / 8;
+        let remaining_bits = (end - start) % 8;
+
+        for byte_idx in 0..full_bytes {
+            let bit_offset = offset + start + byte_idx * 8;
+            let byte_offset = bit_offset / 8;
+            let byte = unsafe { *buffer_ptr.add(byte_offset) };
+
+            for bit_idx in 0..8 {
+                let is_set = (byte & (1 << bit_idx)) != 0;
+                f(start + byte_idx * 8 + bit_idx, is_set);
+            }
+        }
+
+        if remaining_bits > 0 {
+            let bit_idx_start = start + full_bytes * 8;
+            let bit_offset = offset + bit_idx_start;
+            let byte_offset = bit_offset / 8;
+            let byte = unsafe { *buffer_ptr.add(byte_offset) };
+
+            for i in 0..remaining_bits {
+                let is_set = (byte & (1 << i)) != 0;
+                f(bit_idx_start + i, is_set);
+            }
+        }
+    }
+
+    /// Iterate through bits in a buffer in reverse.
+    ///
+    /// # Arguments
+    ///
+    /// * `range` - Bit range to iterate through in reverse (start inclusive, end exclusive)
+    /// * `f` - Callback function taking (bit_index, is_set)
+    ///
+    /// # Panics
+    ///
+    /// Panics if the range is outside valid bounds of the buffer.
+    #[inline]
+    pub fn iter_bits_reverse<F>(&self, range: std::ops::Range<usize>, mut f: F)
+    where
+        F: FnMut(usize, bool),
+    {
+        let start = range.start;
+        let end = range.end;
+
+        assert!(start <= end);
+        assert!(end <= self.len);
+
+        let buffer_ptr = self.buffer.as_ptr();
+        let offset = self.offset;
+
+        let full_bytes = (end - start) / 8;
+        let remaining_bits = (end - start) % 8;
+
+        if remaining_bits > 0 {
+            let bit_idx_start = start + full_bytes * 8;
+            let bit_offset = offset + bit_idx_start;
+            let byte_offset = bit_offset / 8;
+            let byte = unsafe { *buffer_ptr.add(byte_offset) };
+
+            for bit_idx in (0..remaining_bits).rev() {
+                let is_set = (byte & (1 << bit_idx)) != 0;
+                f(bit_idx_start + bit_idx, is_set);
+            }
+        }
+
+        for byte_idx in (0..full_bytes).rev() {
+            let bit_offset = offset + start + byte_idx * 8;
+            let byte_offset = bit_offset / 8;
+            let byte = unsafe { *buffer_ptr.add(byte_offset) };
+
+            for bit_idx in (0..8).rev() {
+                let is_set = (byte & (1 << bit_idx)) != 0;
+                f(start + byte_idx * 8 + bit_idx, is_set);
+            }
+        }
+    }
 }
 
 impl<'a> IntoIterator for &'a BitBuffer {
@@ -419,6 +521,8 @@ impl<'a> IntoIterator for &'a BitBuffer {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use crate::bit::BitBuffer;
     use crate::{ByteBuffer, buffer};
 
@@ -487,5 +591,53 @@ mod tests {
             buf2.slice(32..64),
             "Buffer slices with different bits should not be equal (`PartialEq` needs `iter_padded()`)"
         );
+    }
+
+    #[rstest]
+    #[case(5)]
+    #[case(8)]
+    #[case(10)]
+    #[case(13)]
+    #[case(16)]
+    #[case(23)]
+    #[case(100)]
+    fn test_iter_bits(#[case] len: usize) {
+        let buf = BitBuffer::collect_bool(len, |i| i % 2 == 0);
+
+        let mut collected = Vec::new();
+        buf.iter_bits(0..len, |idx, is_set| {
+            collected.push((idx, is_set));
+        });
+
+        assert_eq!(collected.len(), len);
+
+        for (idx, is_set) in collected {
+            assert_eq!(is_set, idx % 2 == 0);
+        }
+    }
+
+    #[rstest]
+    #[case(5)]
+    #[case(8)]
+    #[case(10)]
+    #[case(13)]
+    #[case(16)]
+    #[case(23)]
+    #[case(100)]
+    fn test_iter_bits_reverse(#[case] len: usize) {
+        let buf = BitBuffer::collect_bool(len, |i| i % 2 == 0);
+
+        let mut collected = Vec::new();
+        buf.iter_bits_reverse(0..len, |idx, is_set| {
+            collected.push((idx, is_set));
+        });
+
+        assert_eq!(collected.len(), len);
+
+        for (i, (idx, is_set)) in collected.iter().enumerate() {
+            let expected_idx = len - 1 - i;
+            assert_eq!(*idx, expected_idx);
+            assert_eq!(*is_set, expected_idx % 2 == 0);
+        }
     }
 }

--- a/vortex-compute/benches/expand_buffer.rs
+++ b/vortex-compute/benches/expand_buffer.rs
@@ -3,20 +3,29 @@
 
 //! Expand benchmarks for `Buffer`.
 
-use divan::Bencher;
-use vortex_buffer::{Buffer, BufferMut};
+use vortex_buffer::Buffer;
 use vortex_compute::expand::Expand;
 use vortex_mask::Mask;
+
+// buffer size, selectivity
+const PARAMETERS: &[(usize, f64)] = &[
+    (256, 0.1),
+    (256, 0.5),
+    (256, 0.9),
+    (1024, 0.1),
+    (1024, 0.5),
+    (1024, 0.9),
+    (4096, 0.1),
+    (4096, 0.5),
+    (4096, 0.9),
+    (16384, 0.1),
+    (16384, 0.5),
+    (16384, 0.9),
+];
 
 fn main() {
     divan::main();
 }
-
-const BUFFER_SIZE: usize = 1024;
-
-const SELECTIVITIES: &[f64] = &[
-    0.01, 0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90, 0.99,
-];
 
 fn create_test_buffer<T>(size: usize) -> Buffer<T>
 where
@@ -28,18 +37,6 @@ where
         data.push(T::from((i % 256) as u8));
     }
     Buffer::from(data)
-}
-
-fn create_test_buffer_mut<T>(size: usize) -> BufferMut<T>
-where
-    T: Copy + Default + From<u8> + Send + 'static,
-{
-    let mut data = Vec::with_capacity(size);
-    for i in 0..size {
-        #[expect(clippy::cast_possible_truncation)]
-        data.push(T::from((i % 256) as u8));
-    }
-    Buffer::from(data).into_mut()
 }
 
 fn generate_mask(len: usize, selectivity: f64) -> Mask {
@@ -61,35 +58,20 @@ fn generate_mask(len: usize, selectivity: f64) -> Mask {
     Mask::from_iter(selection)
 }
 
-#[divan::bench(types = [u8, u32, u64], args = SELECTIVITIES, sample_count = 1000)]
-fn expand_copy<T: Copy + Default + From<u8> + Send + 'static>(bencher: Bencher, selectivity: f64) {
+#[divan::bench(types = [u8, u32, u64], args = PARAMETERS, sample_count = 1000)]
+fn expand_buffer<T: Copy + Default + From<u8> + Send + 'static>(
+    bencher: divan::Bencher,
+    (buffer_size, selectivity): (usize, f64),
+) {
     bencher
         .with_inputs(|| {
-            let mask = generate_mask(BUFFER_SIZE, selectivity);
+            let mask = generate_mask(buffer_size, selectivity);
             let true_count = mask.true_count();
             let buffer = create_test_buffer::<T>(true_count);
             (buffer, mask)
         })
-        .bench_values(|(buffer, mask)| {
-            let result = buffer.expand(&mask);
+        .bench_refs(|(buffer, mask)| {
+            let result = buffer.expand(mask);
             divan::black_box(result);
-        });
-}
-
-#[divan::bench(types = [u8, u32, u64], args = SELECTIVITIES, sample_count = 1000)]
-fn expand_inplace<T: Copy + Default + From<u8> + Send + 'static>(
-    bencher: Bencher,
-    selectivity: f64,
-) {
-    bencher
-        .with_inputs(|| {
-            let mask = generate_mask(BUFFER_SIZE, selectivity);
-            let true_count = mask.true_count();
-            let buffer = create_test_buffer_mut::<T>(true_count);
-            (buffer, mask)
-        })
-        .bench_values(|(mut buffer, mask)| {
-            (&mut buffer).expand(&mask);
-            divan::black_box(buffer);
         });
 }

--- a/vortex-compute/benches/expand_buffer.rs
+++ b/vortex-compute/benches/expand_buffer.rs
@@ -89,7 +89,7 @@ fn expand_inplace<T: Copy + Default + From<u8> + Send + 'static>(
             (buffer, mask)
         })
         .bench_values(|(mut buffer, mask)| {
-            let result = buffer.expand(&mask);
-            divan::black_box(result);
+            (&mut buffer).expand(&mask);
+            divan::black_box(buffer);
         });
 }

--- a/vortex-compute/benches/expand_buffer.rs
+++ b/vortex-compute/benches/expand_buffer.rs
@@ -4,7 +4,7 @@
 //! Expand benchmarks for `Buffer`.
 
 use divan::Bencher;
-use vortex_buffer::Buffer;
+use vortex_buffer::{Buffer, BufferMut};
 use vortex_compute::expand::Expand;
 use vortex_mask::Mask;
 
@@ -30,6 +30,18 @@ where
     Buffer::from(data)
 }
 
+fn create_test_buffer_mut<T>(size: usize) -> BufferMut<T>
+where
+    T: Copy + Default + From<u8> + Send + 'static,
+{
+    let mut data = Vec::with_capacity(size);
+    for i in 0..size {
+        #[expect(clippy::cast_possible_truncation)]
+        data.push(T::from((i % 256) as u8));
+    }
+    Buffer::from(data).into_mut()
+}
+
 fn generate_mask(len: usize, selectivity: f64) -> Mask {
     let mut selection = vec![false; len];
     let mut indices: Vec<usize> = (0..len).collect();
@@ -50,10 +62,7 @@ fn generate_mask(len: usize, selectivity: f64) -> Mask {
 }
 
 #[divan::bench(types = [u8, u32, u64], args = SELECTIVITIES, sample_count = 1000)]
-fn expand_selectivity<T: Copy + Default + From<u8> + Send + 'static>(
-    bencher: Bencher,
-    selectivity: f64,
-) {
+fn expand_copy<T: Copy + Default + From<u8> + Send + 'static>(bencher: Bencher, selectivity: f64) {
     bencher
         .with_inputs(|| {
             let mask = generate_mask(BUFFER_SIZE, selectivity);
@@ -62,6 +71,24 @@ fn expand_selectivity<T: Copy + Default + From<u8> + Send + 'static>(
             (buffer, mask)
         })
         .bench_values(|(buffer, mask)| {
+            let result = buffer.expand(&mask);
+            divan::black_box(result);
+        });
+}
+
+#[divan::bench(types = [u8, u32, u64], args = SELECTIVITIES, sample_count = 1000)]
+fn expand_inplace<T: Copy + Default + From<u8> + Send + 'static>(
+    bencher: Bencher,
+    selectivity: f64,
+) {
+    bencher
+        .with_inputs(|| {
+            let mask = generate_mask(BUFFER_SIZE, selectivity);
+            let true_count = mask.true_count();
+            let buffer = create_test_buffer_mut::<T>(true_count);
+            (buffer, mask)
+        })
+        .bench_values(|(mut buffer, mask)| {
             let result = buffer.expand(&mask);
             divan::black_box(result);
         });

--- a/vortex-compute/src/expand/buffer.rs
+++ b/vortex-compute/src/expand/buffer.rs
@@ -99,7 +99,7 @@ fn expand_inplace<T: Copy>(buf_mut: &mut BufferMut<T>, mask_values: &MaskValues)
     let bit_buffer = mask_values.bit_buffer();
 
     // Iterate backwards through the mask to avoid overwriting unprocessed elements.
-    bit_buffer.iter_bits_reverse(0..mask_len, |idx, is_valid| {
+    bit_buffer.iter_bits_reverse(|idx, is_valid| {
         if is_valid {
             element_idx -= 1;
             unsafe { *buf_slice.get_unchecked_mut(idx) = buf_slice[element_idx] };
@@ -133,7 +133,7 @@ fn expand_copy<T: Copy>(src: &[T], mask_values: &MaskValues) -> Buffer<T> {
 
     let bit_buffer = mask_values.bit_buffer();
 
-    bit_buffer.iter_bits(0..mask_len, |mask_idx, is_valid| {
+    bit_buffer.iter_bits(|mask_idx, is_valid| {
         if is_valid {
             unsafe {
                 target_slice

--- a/vortex-compute/src/expand/buffer.rs
+++ b/vortex-compute/src/expand/buffer.rs
@@ -6,35 +6,7 @@ use vortex_mask::{Mask, MaskValues};
 
 use crate::expand::Expand;
 
-impl<T: Copy> Expand for Buffer<T> {
-    type Output = Buffer<T>;
-
-    fn expand(self, mask: &Mask) -> Self::Output {
-        assert_eq!(
-            mask.true_count(),
-            self.len(),
-            "Expand mask true count must equal the buffer length"
-        );
-
-        match mask {
-            Mask::AllTrue(_) => self,
-            Mask::AllFalse(_) => self,
-            Mask::Values(mask_values) => {
-                // Try to get exclusive access to expand in-place.
-                match self.try_into_mut() {
-                    Ok(mut buf_mut) => {
-                        (&mut buf_mut).expand(mask);
-                        buf_mut.freeze()
-                    }
-                    // Otherwise, expand into a new buffer.
-                    Err(buffer) => expand_copy(buffer.as_slice(), mask_values),
-                }
-            }
-        }
-    }
-}
-
-impl<T: Copy> Expand for &Buffer<T> {
+impl<T: Copy + Default> Expand for &Buffer<T> {
     type Output = Buffer<T>;
 
     fn expand(self, mask: &Mask) -> Self::Output {
@@ -47,16 +19,15 @@ impl<T: Copy> Expand for &Buffer<T> {
         match mask {
             Mask::AllTrue(_) => self.clone(),
             Mask::AllFalse(_) => self.clone(),
-            // Expand into new buffer unconditionally as `try_into_mut` can never succeed on `&Buffer`.
-            Mask::Values(mask_values) => expand_copy(self.as_slice(), mask_values),
+            Mask::Values(mask_values) => expand(self.as_slice(), mask_values),
         }
     }
 }
 
-impl<T: Copy> Expand for &mut BufferMut<T> {
-    type Output = ();
+impl<T: Copy + Default> Expand for BufferMut<T> {
+    type Output = BufferMut<T>;
 
-    fn expand(self, mask: &Mask) {
+    fn expand(self, mask: &Mask) -> Self::Output {
         assert_eq!(
             mask.true_count(),
             self.len(),
@@ -64,49 +35,11 @@ impl<T: Copy> Expand for &mut BufferMut<T> {
         );
 
         match mask {
-            Mask::AllTrue(_) => {}
-            Mask::AllFalse(_) => {}
-            Mask::Values(mask_values) => {
-                expand_inplace(self, mask_values);
-            }
+            Mask::AllTrue(_) => self,
+            Mask::AllFalse(_) => self,
+            Mask::Values(mask_values) => expand(self.as_slice(), mask_values).into_mut(),
         }
     }
-}
-
-/// Scatters elements from a mutable buffer into itself at positions marked true in the mask.
-/// Used for in-place expansion where source and destination are the same buffer.
-///
-/// # Arguments
-///
-/// * `buf_mut` - The mutable buffer to expand in-place
-/// * `mask_values` - The mask indicating where elements should be placed
-fn expand_inplace<T: Copy>(buf_mut: &mut BufferMut<T>, mask_values: &MaskValues) {
-    let buf_len = buf_mut.len();
-    let mask_len = mask_values.len();
-
-    buf_mut.reserve(mask_len - buf_len);
-
-    // SAFETY: Sufficient capacity has been reserved.
-    unsafe { buf_mut.set_len(mask_len) };
-    let buf_slice = buf_mut.as_mut_slice();
-
-    // Pick the first value as a default value. The buffer is not empty, and we
-    // know that the first value is guaranteed to be initialized. By doing this
-    // T does not require to implement `Default`.
-    let pseudo_default_value = buf_slice[0];
-
-    let mut element_idx = buf_len;
-    let bit_buffer = mask_values.bit_buffer();
-
-    // Iterate backwards through the mask to avoid overwriting unprocessed elements.
-    bit_buffer.iter_bits_reverse(|idx, is_valid| {
-        if is_valid {
-            element_idx -= 1;
-            unsafe { *buf_slice.get_unchecked_mut(idx) = buf_slice[element_idx] };
-        } else {
-            unsafe { *buf_slice.get_unchecked_mut(idx) = pseudo_default_value };
-        }
-    });
 }
 
 /// Expands a slice into a new buffer at the target size, scattering elements to
@@ -120,15 +53,13 @@ fn expand_inplace<T: Copy>(buf_mut: &mut BufferMut<T>, mask_values: &MaskValues)
 /// # Returns
 ///
 /// A new `Buffer<T>` with length equal to `mask.len`, with elements from `src` scattered
-/// to positions marked true in the mask. Positions marked false can have arbitrary values.
-fn expand_copy<T: Copy>(src: &[T], mask_values: &MaskValues) -> Buffer<T> {
+/// to positions marked true in the mask. Positions marked false are set to `T::default`.
+fn expand<T: Copy + Default>(src: &[T], mask_values: &MaskValues) -> Buffer<T> {
     let mask_len = mask_values.len();
 
     let mut target_buf = BufferMut::<T>::with_capacity(mask_len);
     let target_slice = target_buf.spare_capacity_mut();
 
-    // Pick the first value as a default value.
-    let pseudo_default_value = src[0];
     let mut element_idx = 0;
 
     let bit_buffer = mask_values.bit_buffer();
@@ -143,9 +74,7 @@ fn expand_copy<T: Copy>(src: &[T], mask_values: &MaskValues) -> Buffer<T> {
             element_idx += 1;
         } else {
             unsafe {
-                target_slice
-                    .get_unchecked_mut(mask_idx)
-                    .write(pseudo_default_value);
+                target_slice.get_unchecked_mut(mask_idx).write(T::default());
             };
         }
     });
@@ -158,7 +87,7 @@ fn expand_copy<T: Copy>(src: &[T], mask_values: &MaskValues) -> Buffer<T> {
 
 #[cfg(test)]
 mod tests {
-    use vortex_buffer::{buffer, buffer_mut};
+    use vortex_buffer::buffer;
     use vortex_mask::Mask;
 
     use super::*;
@@ -226,7 +155,6 @@ mod tests {
         buf.expand(&mask);
     }
 
-    // Tests for &Buffer<T>
     #[test]
     fn test_expand_ref_scattered() {
         let buf = buffer![100u32, 200, 300];
@@ -248,86 +176,6 @@ mod tests {
         assert_eq!(result, buffer![10u32, 20, 30]);
     }
 
-    // Tests for &mut BufferMut<T>
-    #[test]
-    fn test_expand_mut_scattered() {
-        let mut buf = buffer_mut![100u32, 200, 300];
-        let mask = Mask::from_iter([true, false, true, false, true]);
-
-        (&mut buf).expand(&mask);
-        assert_eq!(buf.len(), 5);
-        assert_eq!(buf.as_slice()[0], 100);
-        assert_eq!(buf.as_slice()[2], 200);
-        assert_eq!(buf.as_slice()[4], 300);
-    }
-
-    #[test]
-    fn test_expand_mut_all_true() {
-        let mut buf = buffer_mut![10u32, 20, 30];
-        let mask = Mask::new_true(3);
-
-        (&mut buf).expand(&mask);
-        assert_eq!(buf.as_slice(), &[10, 20, 30]);
-    }
-
-    #[test]
-    fn test_expand_mut_all_false() {
-        let mut buf: BufferMut<u32> = BufferMut::with_capacity(0);
-        let mask = Mask::new_false(0);
-
-        (&mut buf).expand(&mask);
-        assert!(buf.is_empty());
-    }
-
-    #[test]
-    fn test_expand_mut_contiguous_start() {
-        let mut buf = buffer_mut![10u32, 20, 30, 40];
-        let mask = Mask::from_iter([true, true, true, true, false, false, false]);
-
-        (&mut buf).expand(&mask);
-        assert_eq!(buf.len(), 7);
-        assert_eq!(buf.as_slice()[0..4], [10u32, 20, 30, 40]);
-    }
-
-    #[test]
-    fn test_expand_mut_contiguous_end() {
-        let mut buf = buffer_mut![100u32, 200, 300];
-        let mask = Mask::from_iter([false, false, false, false, true, true, true]);
-
-        (&mut buf).expand(&mask);
-        assert_eq!(buf.len(), 7);
-        assert_eq!(buf.as_slice()[4..7], [100u32, 200, 300]);
-    }
-
-    #[test]
-    #[should_panic(expected = "Expand mask true count must equal the buffer length")]
-    fn test_expand_mut_mismatch_true_count() {
-        let mut buf = buffer_mut![10u32, 20];
-        let mask = Mask::from_iter([true, true, true, false]);
-        (&mut buf).expand(&mask);
-    }
-
-    #[test]
-    fn test_expand_inplace() {
-        let mut buf = BufferMut::from_iter([10u32, 20, 30, 40, 50]);
-        // Alternating pattern with gaps: [T, F, T, F, T, F, T, F, T, F]
-        let mask = Mask::from_iter([
-            true, false, true, false, true, false, true, false, true, false,
-        ]);
-
-        let Mask::Values(mask_values) = mask else {
-            panic!("Expected Mask::Values");
-        };
-
-        expand_inplace(&mut buf, &mask_values);
-        assert_eq!(buf.len(), 10);
-        assert_eq!(buf.as_slice()[0], 10);
-        assert_eq!(buf.as_slice()[2], 20);
-        assert_eq!(buf.as_slice()[4], 30);
-        assert_eq!(buf.as_slice()[6], 40);
-        assert_eq!(buf.as_slice()[8], 50);
-    }
-
     #[test]
     fn test_expand_copy() {
         let src = [10u32, 20, 30, 40, 50];
@@ -340,7 +188,7 @@ mod tests {
             panic!("Expected Mask::Values");
         };
 
-        let result = expand_copy(&src, &mask_values);
+        let result = expand(&src, &mask_values);
         assert_eq!(result.len(), 10);
         assert_eq!(result.as_slice()[0], 10);
         assert_eq!(result.as_slice()[2], 20);

--- a/vortex-compute/src/expand/buffer.rs
+++ b/vortex-compute/src/expand/buffer.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
 use vortex_buffer::{Buffer, BufferMut};
 use vortex_mask::{Mask, MaskValues};
 
@@ -96,37 +97,17 @@ fn expand_inplace<T: Copy>(buf_mut: &mut BufferMut<T>, mask_values: &MaskValues)
     let pseudo_default_value = buf_slice[0];
 
     let mut element_idx = buf_len;
+    let bit_buffer = mask_values.bit_buffer();
 
     // Iterate backwards through the mask to avoid overwriting unprocessed elements.
-    for (mask_idx, is_valid) in mask_values
-        .bit_buffer()
-        .slice(buf_len..)
-        .iter()
-        .rev()
-        .enumerate()
-    {
+    iter_bits_reverse(bit_buffer, 0..mask_len, |idx, is_valid| {
         if is_valid {
             element_idx -= 1;
-            unsafe { *buf_slice.get_unchecked_mut(mask_idx) = buf_slice[element_idx] };
+            unsafe { *buf_slice.get_unchecked_mut(idx) = buf_slice[element_idx] };
         } else {
-            // Initialize with a pseudo-default value.
-            unsafe { *buf_slice.get_unchecked_mut(mask_idx) = pseudo_default_value };
+            unsafe { *buf_slice.get_unchecked_mut(idx) = pseudo_default_value };
         }
-    }
-
-    for (mask_idx, is_valid) in mask_values
-        .bit_buffer()
-        .slice(..buf_len)
-        .iter()
-        .rev()
-        .enumerate()
-    {
-        if is_valid {
-            element_idx -= 1;
-            unsafe { *buf_slice.get_unchecked_mut(mask_idx) = buf_slice[element_idx] };
-        }
-        // For the range up to buffer length, all positions are already initialized.
-    }
+    });
 }
 
 /// Expands a slice into a new buffer at the target size, scattering elements to
@@ -151,7 +132,9 @@ fn expand_copy<T: Copy>(src: &[T], mask_values: &MaskValues) -> Buffer<T> {
     let pseudo_default_value = src[0];
     let mut element_idx = 0;
 
-    for (mask_idx, is_valid) in mask_values.bit_buffer().iter().enumerate() {
+    let bit_buffer = mask_values.bit_buffer();
+
+    iter_bits(bit_buffer, 0..mask_len, |mask_idx, is_valid| {
         if is_valid {
             unsafe {
                 target_slice
@@ -160,20 +143,122 @@ fn expand_copy<T: Copy>(src: &[T], mask_values: &MaskValues) -> Buffer<T> {
             };
             element_idx += 1;
         } else {
-            // Initialize with a pseudo-default value. In case we expand
-            // into a new buffer all false positions need to be initialized.
             unsafe {
                 target_slice
                     .get_unchecked_mut(mask_idx)
-                    .write(pseudo_default_value)
+                    .write(pseudo_default_value);
             };
         }
-    }
+    });
 
     // SAFETY: Buffer has sufficient capacity and all elements have been initialized.
     unsafe { target_buf.set_len(mask_len) };
 
     target_buf.freeze()
+}
+
+/// Iterate through bits in a buffer.
+///
+/// # Arguments
+///
+/// * `bit_buffer` - The bit buffer to iterate through
+/// * `range` - Bit range to iterate through
+/// * `f` - Callback function taking (bit_index, is_set)
+///
+/// # Safety
+///
+/// The caller must ensure that the range is within valid bounds of the bit buffer.
+#[inline]
+fn iter_bits<F>(bit_buffer: &vortex_buffer::BitBuffer, range: Range<usize>, mut f: F)
+where
+    F: FnMut(usize, bool),
+{
+    let start = range.start;
+    let end = range.end;
+
+    assert!(start <= end);
+    assert!(end <= bit_buffer.len());
+
+    let buffer_ptr = bit_buffer.inner().as_ptr();
+    let offset = bit_buffer.offset();
+
+    let full_bytes = (end - start) / 8;
+    let remaining_bits = (end - start) % 8;
+
+    for byte_idx in 0..full_bytes {
+        let bit_offset = offset + start + byte_idx * 8;
+        let byte_offset = bit_offset / 8;
+        let byte = unsafe { *buffer_ptr.add(byte_offset) };
+
+        for bit_idx in 0..8 {
+            let is_set = (byte & (1 << bit_idx)) != 0;
+            f(start + byte_idx * 8 + bit_idx, is_set);
+        }
+    }
+
+    if remaining_bits > 0 {
+        let bit_idx_start = start + full_bytes * 8;
+        let bit_offset = offset + bit_idx_start;
+        let byte_offset = bit_offset / 8;
+        let byte = unsafe { *buffer_ptr.add(byte_offset) };
+
+        for i in 0..remaining_bits {
+            let is_set = (byte & (1 << i)) != 0;
+            f(bit_idx_start + i, is_set);
+        }
+    }
+}
+
+/// Iterate through bits in a buffer in reverse.
+///
+/// # Arguments
+///
+/// * `bit_buffer` - The bit buffer to iterate through
+/// * `range` - Bit range to iterate through in reverse (start inclusive, end exclusive)
+/// * `f` - Callback function taking (bit_index, is_set)
+///
+/// # Safety
+///
+/// The caller must ensure that the range is within valid bounds of the bit buffer.
+#[inline]
+fn iter_bits_reverse<F>(bit_buffer: &vortex_buffer::BitBuffer, range: Range<usize>, mut f: F)
+where
+    F: FnMut(usize, bool),
+{
+    let start = range.start;
+    let end = range.end;
+
+    assert!(start <= end);
+    assert!(end <= bit_buffer.len());
+
+    let buffer_ptr = bit_buffer.inner().as_ptr();
+    let offset = bit_buffer.offset();
+
+    let full_bytes = (end - start) / 8;
+    let remaining_bits = (end - start) % 8;
+
+    if remaining_bits > 0 {
+        let bit_idx_start = start + full_bytes * 8;
+        let bit_offset = offset + bit_idx_start;
+        let byte_offset = bit_offset / 8;
+        let byte = unsafe { *buffer_ptr.add(byte_offset) };
+
+        for bit_idx in (0..remaining_bits).rev() {
+            let is_set = (byte & (1 << bit_idx)) != 0;
+            f(bit_idx_start + bit_idx, is_set);
+        }
+    }
+
+    for byte_idx in (0..full_bytes).rev() {
+        let bit_offset = offset + start + byte_idx * 8;
+        let byte_offset = bit_offset / 8;
+        let byte = unsafe { *buffer_ptr.add(byte_offset) };
+
+        for bit_idx in (0..8).rev() {
+            let is_set = (byte & (1 << bit_idx)) != 0;
+            f(start + byte_idx * 8 + bit_idx, is_set);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/vortex-compute/src/expand/buffer.rs
+++ b/vortex-compute/src/expand/buffer.rs
@@ -88,7 +88,6 @@ fn expand_inplace<T: Copy>(buf_mut: &mut BufferMut<T>, mask_values: &MaskValues)
 
     // SAFETY: Sufficient capacity has been reserved.
     unsafe { buf_mut.set_len(mask_len) };
-
     let buf_slice = buf_mut.as_mut_slice();
 
     // Pick the first value as a default value. The buffer is not empty, and we
@@ -99,21 +98,32 @@ fn expand_inplace<T: Copy>(buf_mut: &mut BufferMut<T>, mask_values: &MaskValues)
     let mut element_idx = buf_len;
 
     // Iterate backwards through the mask to avoid overwriting unprocessed elements.
-    for mask_idx in (buf_len..mask_len).rev() {
-        // NOTE(0ax1): .value is slow => optimize
-        if mask_values.value(mask_idx) {
+    for (mask_idx, is_valid) in mask_values
+        .bit_buffer()
+        .slice(buf_len..)
+        .iter()
+        .rev()
+        .enumerate()
+    {
+        if is_valid {
             element_idx -= 1;
-            buf_slice[mask_idx] = buf_slice[element_idx];
+            unsafe { *buf_slice.get_unchecked_mut(mask_idx) = buf_slice[element_idx] };
         } else {
             // Initialize with a pseudo-default value.
-            buf_slice[mask_idx] = pseudo_default_value;
+            unsafe { *buf_slice.get_unchecked_mut(mask_idx) = pseudo_default_value };
         }
     }
 
-    for mask_idx in (0..buf_len).rev() {
-        if mask_values.value(mask_idx) {
+    for (mask_idx, is_valid) in mask_values
+        .bit_buffer()
+        .slice(..buf_len)
+        .iter()
+        .rev()
+        .enumerate()
+    {
+        if is_valid {
             element_idx -= 1;
-            buf_slice[mask_idx] = buf_slice[element_idx];
+            unsafe { *buf_slice.get_unchecked_mut(mask_idx) = buf_slice[element_idx] };
         }
         // For the range up to buffer length, all positions are already initialized.
     }
@@ -139,20 +149,24 @@ fn expand_copy<T: Copy>(src: &[T], mask_values: &MaskValues) -> Buffer<T> {
 
     // Pick the first value as a default value.
     let pseudo_default_value = src[0];
+    let mut element_idx = 0;
 
-    let src_len = src.len();
-    let mut element_idx = src_len;
-
-    // Iterate backwards through the mask to avoid any issues.
-    for mask_idx in (0..mask_len).rev() {
-        // NOTE(0ax1): .value is slow => optimize
-        if mask_values.value(mask_idx) {
-            element_idx -= 1;
-            target_slice[mask_idx].write(src[element_idx]);
+    for (mask_idx, is_valid) in mask_values.bit_buffer().iter().enumerate() {
+        if is_valid {
+            unsafe {
+                target_slice
+                    .get_unchecked_mut(mask_idx)
+                    .write(src[element_idx])
+            };
+            element_idx += 1;
         } else {
-            // Initialize with a pseudo-default value. In case we expand into a
-            // new buffer all false positions need to be initialized.
-            target_slice[mask_idx].write(pseudo_default_value);
+            // Initialize with a pseudo-default value. In case we expand
+            // into a new buffer all false positions need to be initialized.
+            unsafe {
+                target_slice
+                    .get_unchecked_mut(mask_idx)
+                    .write(pseudo_default_value)
+            };
         }
     }
 
@@ -306,22 +320,6 @@ mod tests {
     }
 
     #[test]
-    fn test_expand_mut_dense() {
-        let mut buf = buffer_mut![1u32, 2, 3, 4, 5];
-        let mask = Mask::from_iter([
-            true, false, true, true, false, true, true, false, false, false,
-        ]);
-
-        (&mut buf).expand(&mask);
-        assert_eq!(buf.len(), 10);
-        assert_eq!(buf.as_slice()[0], 1);
-        assert_eq!(buf.as_slice()[2], 2);
-        assert_eq!(buf.as_slice()[3], 3);
-        assert_eq!(buf.as_slice()[5], 4);
-        assert_eq!(buf.as_slice()[6], 5);
-    }
-
-    #[test]
     #[should_panic(expected = "Expand mask true count must equal the buffer length")]
     fn test_expand_mut_mismatch_true_count() {
         let mut buf = buffer_mut![10u32, 20];
@@ -330,7 +328,28 @@ mod tests {
     }
 
     #[test]
-    fn test_expand_into_new_buffer() {
+    fn test_expand_inplace() {
+        let mut buf = BufferMut::from_iter([10u32, 20, 30, 40, 50]);
+        // Alternating pattern with gaps: [T, F, T, F, T, F, T, F, T, F]
+        let mask = Mask::from_iter([
+            true, false, true, false, true, false, true, false, true, false,
+        ]);
+
+        let Mask::Values(mask_values) = mask else {
+            panic!("Expected Mask::Values");
+        };
+
+        expand_inplace(&mut buf, &mask_values);
+        assert_eq!(buf.len(), 10);
+        assert_eq!(buf.as_slice()[0], 10);
+        assert_eq!(buf.as_slice()[2], 20);
+        assert_eq!(buf.as_slice()[4], 30);
+        assert_eq!(buf.as_slice()[6], 40);
+        assert_eq!(buf.as_slice()[8], 50);
+    }
+
+    #[test]
+    fn test_expand_copy() {
         let src = [10u32, 20, 30, 40, 50];
         // Alternating pattern with gaps: [T, F, T, F, T, F, T, F, T, F]
         let mask = Mask::from_iter([

--- a/vortex-compute/src/expand/buffer.rs
+++ b/vortex-compute/src/expand/buffer.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::ops::Range;
 use vortex_buffer::{Buffer, BufferMut};
 use vortex_mask::{Mask, MaskValues};
 
@@ -100,7 +99,7 @@ fn expand_inplace<T: Copy>(buf_mut: &mut BufferMut<T>, mask_values: &MaskValues)
     let bit_buffer = mask_values.bit_buffer();
 
     // Iterate backwards through the mask to avoid overwriting unprocessed elements.
-    iter_bits_reverse(bit_buffer, 0..mask_len, |idx, is_valid| {
+    bit_buffer.iter_bits_reverse(0..mask_len, |idx, is_valid| {
         if is_valid {
             element_idx -= 1;
             unsafe { *buf_slice.get_unchecked_mut(idx) = buf_slice[element_idx] };
@@ -134,7 +133,7 @@ fn expand_copy<T: Copy>(src: &[T], mask_values: &MaskValues) -> Buffer<T> {
 
     let bit_buffer = mask_values.bit_buffer();
 
-    iter_bits(bit_buffer, 0..mask_len, |mask_idx, is_valid| {
+    bit_buffer.iter_bits(0..mask_len, |mask_idx, is_valid| {
         if is_valid {
             unsafe {
                 target_slice
@@ -155,110 +154,6 @@ fn expand_copy<T: Copy>(src: &[T], mask_values: &MaskValues) -> Buffer<T> {
     unsafe { target_buf.set_len(mask_len) };
 
     target_buf.freeze()
-}
-
-/// Iterate through bits in a buffer.
-///
-/// # Arguments
-///
-/// * `bit_buffer` - The bit buffer to iterate through
-/// * `range` - Bit range to iterate through
-/// * `f` - Callback function taking (bit_index, is_set)
-///
-/// # Safety
-///
-/// The caller must ensure that the range is within valid bounds of the bit buffer.
-#[inline]
-fn iter_bits<F>(bit_buffer: &vortex_buffer::BitBuffer, range: Range<usize>, mut f: F)
-where
-    F: FnMut(usize, bool),
-{
-    let start = range.start;
-    let end = range.end;
-
-    assert!(start <= end);
-    assert!(end <= bit_buffer.len());
-
-    let buffer_ptr = bit_buffer.inner().as_ptr();
-    let offset = bit_buffer.offset();
-
-    let full_bytes = (end - start) / 8;
-    let remaining_bits = (end - start) % 8;
-
-    for byte_idx in 0..full_bytes {
-        let bit_offset = offset + start + byte_idx * 8;
-        let byte_offset = bit_offset / 8;
-        let byte = unsafe { *buffer_ptr.add(byte_offset) };
-
-        for bit_idx in 0..8 {
-            let is_set = (byte & (1 << bit_idx)) != 0;
-            f(start + byte_idx * 8 + bit_idx, is_set);
-        }
-    }
-
-    if remaining_bits > 0 {
-        let bit_idx_start = start + full_bytes * 8;
-        let bit_offset = offset + bit_idx_start;
-        let byte_offset = bit_offset / 8;
-        let byte = unsafe { *buffer_ptr.add(byte_offset) };
-
-        for i in 0..remaining_bits {
-            let is_set = (byte & (1 << i)) != 0;
-            f(bit_idx_start + i, is_set);
-        }
-    }
-}
-
-/// Iterate through bits in a buffer in reverse.
-///
-/// # Arguments
-///
-/// * `bit_buffer` - The bit buffer to iterate through
-/// * `range` - Bit range to iterate through in reverse (start inclusive, end exclusive)
-/// * `f` - Callback function taking (bit_index, is_set)
-///
-/// # Safety
-///
-/// The caller must ensure that the range is within valid bounds of the bit buffer.
-#[inline]
-fn iter_bits_reverse<F>(bit_buffer: &vortex_buffer::BitBuffer, range: Range<usize>, mut f: F)
-where
-    F: FnMut(usize, bool),
-{
-    let start = range.start;
-    let end = range.end;
-
-    assert!(start <= end);
-    assert!(end <= bit_buffer.len());
-
-    let buffer_ptr = bit_buffer.inner().as_ptr();
-    let offset = bit_buffer.offset();
-
-    let full_bytes = (end - start) / 8;
-    let remaining_bits = (end - start) % 8;
-
-    if remaining_bits > 0 {
-        let bit_idx_start = start + full_bytes * 8;
-        let bit_offset = offset + bit_idx_start;
-        let byte_offset = bit_offset / 8;
-        let byte = unsafe { *buffer_ptr.add(byte_offset) };
-
-        for bit_idx in (0..remaining_bits).rev() {
-            let is_set = (byte & (1 << bit_idx)) != 0;
-            f(bit_idx_start + bit_idx, is_set);
-        }
-    }
-
-    for byte_idx in (0..full_bytes).rev() {
-        let bit_offset = offset + start + byte_idx * 8;
-        let byte_offset = bit_offset / 8;
-        let byte = unsafe { *buffer_ptr.add(byte_offset) };
-
-        for bit_idx in (0..8).rev() {
-            let is_set = (byte & (1 << bit_idx)) != 0;
-            f(start + byte_idx * 8 + bit_idx, is_set);
-        }
-    }
 }
 
 #[cfg(test)]

--- a/vortex-compute/src/expand/mod.rs
+++ b/vortex-compute/src/expand/mod.rs
@@ -10,15 +10,14 @@ use vortex_mask::Mask;
 /// Function for expanding values of `self` to the true positions of a mask.
 pub trait Expand {
     /// The result type after expansion.
-    type Output;
+    type Output: Default;
 
     /// Expands `self` using the provided mask.
     ///
     ///
     /// The result will have length equal to the mask. All values of `self` are
-    /// then scattered to the true positions of the mask. False positions can have
-    /// any value that `Output` allows for. No assumption can be made that false
-    /// positions are set to the default value of `Output`.
+    /// scattered to the true positions of the mask. False positions are set to
+    /// `Output::default`.
     ///
     ///
     /// # Panics


### PR DESCRIPTION
prev:
```
╰─ expand_selectivity                │               │               │               │         │
   ├─ u8                             │               │               │               │         │
   │  ├─ 0.01          749.7 ns      │ 2.52 µs       │ 838.4 ns      │ 841.1 ns      │ 1000    │ 8000
   │  ├─ 0.1           739.2 ns      │ 2.182 µs      │ 833.1 ns      │ 835.9 ns      │ 1000    │ 8000
   │  ├─ 0.2           728.9 ns      │ 1.796 µs      │ 817.5 ns      │ 819.9 ns      │ 1000    │ 8000
   │  ├─ 0.3           723.6 ns      │ 2.635 µs      │ 812.2 ns      │ 810.9 ns      │ 1000    │ 8000
   │  ├─ 0.4           708 ns        │ 6.885 µs      │ 801.7 ns      │ 803.6 ns      │ 1000    │ 4000
   │  ├─ 0.5           687.2 ns      │ 3.541 µs      │ 781 ns        │ 770.9 ns      │ 1000    │ 4000
   │  ├─ 0.6           682 ns        │ 2.072 µs      │ 765.4 ns      │ 756.5 ns      │ 1000    │ 8000
   │  ├─ 0.7           661.2 ns      │ 2.354 µs      │ 744.6 ns      │ 742.9 ns      │ 1000    │ 8000
   │  ├─ 0.8           650.7 ns      │ 2.104 µs      │ 729 ns        │ 733.6 ns      │ 1000    │ 8000
   │  ├─ 0.9           630 ns        │ 1.421 µs      │ 713.4 ns      │ 710.9 ns      │ 1000    │ 8000
   │  ╰─ 0.99          598.7 ns      │ 2.197 µs      │ 676.9 ns      │ 660.7 ns      │ 1000    │ 8000
   ├─ u32                            │               │               │               │         │
   │  ├─ 0.01          760 ns        │ 1.645 µs      │ 854 ns        │ 852.6 ns      │ 1000    │ 4000
   │  ├─ 0.1           760 ns        │ 3.656 µs      │ 854 ns        │ 862.5 ns      │ 1000    │ 4000
   │  ├─ 0.2           749.7 ns      │ 2.567 µs      │ 848.7 ns      │ 850.2 ns      │ 1000    │ 8000
   │  ├─ 0.3           728.9 ns      │ 2.291 µs      │ 827.9 ns      │ 827.7 ns      │ 1000    │ 8000
   │  ├─ 0.4           708 ns        │ 2.176 µs      │ 801.7 ns      │ 797.4 ns      │ 1000    │ 8000
   │  ├─ 0.5           687.2 ns      │ 2.208 µs      │ 775.7 ns      │ 767.6 ns      │ 1000    │ 8000
   │  ├─ 0.6           676.9 ns      │ 2.432 µs      │ 770.5 ns      │ 757.1 ns      │ 1000    │ 8000
   │  ├─ 0.7           656 ns        │ 2.255 µs      │ 749.7 ns      │ 739.2 ns      │ 1000    │ 8000
   │  ├─ 0.8           650.7 ns      │ 1.697 µs      │ 734.1 ns      │ 725.9 ns      │ 1000    │ 8000
   │  ├─ 0.9           629.9 ns      │ 3.629 µs      │ 713.2 ns      │ 691.3 ns      │ 1000    │ 8000
   │  ╰─ 0.99          604 ns        │ 2.984 µs      │ 687.2 ns      │ 672.7 ns      │ 1000    │ 8000
   ╰─ u64                            │               │               │               │         │
      ├─ 0.01          546.6 ns      │ 1.885 µs      │ 635.1 ns      │ 635.8 ns      │ 1000    │ 8000
      ├─ 0.1           572.6 ns      │ 1.546 µs      │ 661.2 ns      │ 659.5 ns      │ 1000    │ 8000
      ├─ 0.2           572.6 ns      │ 3.031 µs      │ 661.2 ns      │ 661.3 ns      │ 1000    │ 8000
      ├─ 0.3           577.9 ns      │ 2.447 µs      │ 666.4 ns      │ 666.8 ns      │ 1000    │ 8000
      ├─ 0.4           583.1 ns      │ 1.791 µs      │ 666.4 ns      │ 655 ns        │ 1000    │ 8000
      ├─ 0.5           598.6 ns      │ 2.265 µs      │ 687.2 ns      │ 682.3 ns      │ 1000    │ 8000
      ├─ 0.6           598.7 ns      │ 2.296 µs      │ 687.2 ns      │ 685.9 ns      │ 1000    │ 8000
      ├─ 0.7           614.2 ns      │ 2.114 µs      │ 692.5 ns      │ 691.3 ns      │ 1000    │ 8000
      ├─ 0.8           609.1 ns      │ 2.171 µs      │ 697.6 ns      │ 688.8 ns      │ 1000    │ 8000
      ├─ 0.9           614.2 ns      │ 2.093 µs      │ 697.6 ns      │ 687.9 ns      │ 1000    │ 8000
      ╰─ 0.99          609.1 ns      │ 2.468 µs      │ 692.4 ns      │ 683.3 ns      │ 1000    │ 8000
```

now:
```
expand_buffer          fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ expand_buffer                     │               │               │               │         │
   ├─ u8                             │               │               │               │         │
   │  ├─ (256, 0.1)    73.33 ns      │ 222.4 ns      │ 82.46 ns      │ 81.68 ns      │ 1000    │ 64000
   │  ├─ (256, 0.5)    79.85 ns      │ 273.8 ns      │ 90.91 ns      │ 89.55 ns      │ 1000    │ 64000
   │  ├─ (256, 0.9)    89.61 ns      │ 390.4 ns      │ 96.11 ns      │ 98.66 ns      │ 1000    │ 32000
   │  ├─ (1024, 0.1)   161.2 ns      │ 238 ns        │ 182 ns        │ 176.4 ns      │ 1000    │ 32000
   │  ├─ (1024, 0.5)   195 ns        │ 463.3 ns      │ 210.7 ns      │ 215.1 ns      │ 1000    │ 32000
   │  ├─ (1024, 0.9)   236.7 ns      │ 1.692 µs      │ 247.2 ns      │ 260.1 ns      │ 1000    │ 16000
   │  ├─ (4096, 0.1)   520.5 ns      │ 1.228 µs      │ 588.2 ns      │ 570.5 ns      │ 1000    │ 8000
   │  ├─ (4096, 0.5)   702.9 ns      │ 1.067 µs      │ 718.5 ns      │ 750.1 ns      │ 1000    │ 8000
   │  ├─ (4096, 0.9)   885.1 ns      │ 2.546 µs      │ 895.6 ns      │ 930.1 ns      │ 1000    │ 8000
   │  ├─ (16384, 0.1)  2.041 µs      │ 9.291 µs      │ 2.291 µs      │ 2.22 µs       │ 1000    │ 2000
   │  ├─ (16384, 0.5)  2.749 µs      │ 10.83 µs      │ 2.895 µs      │ 3.002 µs      │ 1000    │ 2000
   │  ╰─ (16384, 0.9)  3.457 µs      │ 6.332 µs      │ 3.541 µs      │ 3.679 µs      │ 1000    │ 1000
   ├─ u32                            │               │               │               │         │
   │  ├─ (256, 0.1)    57.06 ns      │ 116.6 ns      │ 64.55 ns      │ 63.1 ns       │ 1000    │ 128000
   │  ├─ (256, 0.5)    61.61 ns      │ 92.21 ns      │ 69.44 ns      │ 67.91 ns      │ 1000    │ 64000
   │  ├─ (256, 0.9)    75.29 ns      │ 284.2 ns      │ 77.9 ns       │ 81.76 ns      │ 1000    │ 64000
   │  ├─ (1024, 0.1)   146.9 ns      │ 515.4 ns      │ 165.1 ns      │ 161.9 ns      │ 1000    │ 32000
   │  ├─ (1024, 0.5)   193.7 ns      │ 292.7 ns      │ 204.2 ns      │ 211.2 ns      │ 1000    │ 32000
   │  ├─ (1024, 0.9)   239.3 ns      │ 2.669 µs      │ 244.5 ns      │ 259.7 ns      │ 1000    │ 16000
   │  ├─ (4096, 0.1)   520.6 ns      │ 3.687 µs      │ 538.8 ns      │ 570.3 ns      │ 1000    │ 8000
   │  ├─ (4096, 0.5)   697.5 ns      │ 4.614 µs      │ 728.7 ns      │ 763.2 ns      │ 1000    │ 4000
   │  ├─ (4096, 0.9)   885 ns        │ 4.624 µs      │ 906 ns        │ 950.2 ns      │ 1000    │ 4000
   │  ├─ (16384, 0.1)  2.207 µs      │ 5.041 µs      │ 2.479 µs      │ 2.411 µs      │ 1000    │ 1000
   │  ├─ (16384, 0.5)  2.812 µs      │ 10.49 µs      │ 2.874 µs      │ 2.994 µs      │ 1000    │ 2000
   │  ╰─ (16384, 0.9)  3.499 µs      │ 40.16 µs      │ 3.583 µs      │ 3.765 µs      │ 1000    │ 1000
   ╰─ u64                            │               │               │               │         │
      ├─ (256, 0.1)    56.41 ns      │ 104.9 ns      │ 63.57 ns      │ 62.17 ns      │ 1000    │ 128000
      ├─ (256, 0.5)    62.91 ns      │ 95.47 ns      │ 71.38 ns      │ 69.82 ns      │ 1000    │ 64000
      ├─ (256, 0.9)    77.9 ns       │ 230.9 ns      │ 88.32 ns      │ 85.89 ns      │ 1000    │ 64000
      ├─ (1024, 0.1)   145.6 ns      │ 348.7 ns      │ 166.4 ns      │ 161.5 ns      │ 1000    │ 32000
      ├─ (1024, 0.5)   192.4 ns      │ 291.4 ns      │ 197.7 ns      │ 206.2 ns      │ 1000    │ 16000
      ├─ (1024, 0.9)   244.5 ns      │ 892.9 ns      │ 252.3 ns      │ 267.6 ns      │ 1000    │ 16000
      ├─ (4096, 0.1)   525.7 ns      │ 2.541 µs      │ 588.4 ns      │ 613 ns        │ 1000    │ 8000
      ├─ (4096, 0.5)   713.2 ns      │ 2.598 µs      │ 728.9 ns      │ 781.7 ns      │ 1000    │ 8000
      ├─ (4096, 0.9)   895.5 ns      │ 4.593 µs      │ 926.7 ns      │ 987.1 ns      │ 1000    │ 4000
      ├─ (16384, 0.1)  2.416 µs      │ 9.708 µs      │ 2.749 µs      │ 2.75 µs       │ 1000    │ 1000
      ├─ (16384, 0.5)  2.978 µs      │ 9.291 µs      │ 3.041 µs      │ 3.289 µs      │ 1000    │ 2000
      ╰─ (16384, 0.9)  3.54 µs       │ 14.74 µs      │ 3.624 µs      │ 3.932 µs      │ 1000    │ 1000
```