### PR TITLE
Feature: implement filter for primitive vector (and mask)

### DIFF
--- a/vortex-compute/src/filter/bitbuffer.rs
+++ b/vortex-compute/src/filter/bitbuffer.rs
@@ -10,7 +10,7 @@ use crate::filter::Filter;
 // TODO(ngates): we need more experimentation to determine the best threshold here.
 const FILTER_SLICES_DENSITY_THRESHOLD: f64 = 0.8;
 
-impl Filter for &BitBuffer {
+impl Filter<Mask> for &BitBuffer {
     type Output = BitBuffer;
 
     fn filter(self, selection_mask: &Mask) -> BitBuffer {

--- a/vortex-compute/src/filter/buffer.rs
+++ b/vortex-compute/src/filter/buffer.rs
@@ -9,7 +9,7 @@ use crate::filter::Filter;
 // This is modeled after the constant with the equivalent name in arrow-rs.
 const FILTER_SLICES_SELECTIVITY_THRESHOLD: f64 = 0.8;
 
-impl<T: Copy> Filter for &Buffer<T> {
+impl<T: Copy> Filter<Mask> for &Buffer<T> {
     type Output = Buffer<T>;
 
     fn filter(self, selection_mask: &Mask) -> Buffer<T> {
@@ -32,7 +32,7 @@ impl<T: Copy> Filter for &Buffer<T> {
     }
 }
 
-impl<T: Copy> Filter for &mut BufferMut<T> {
+impl<T: Copy> Filter<Mask> for &mut BufferMut<T> {
     type Output = ();
 
     fn filter(self, selection_mask: &Mask) {
@@ -69,7 +69,7 @@ impl<T: Copy> Filter for &mut BufferMut<T> {
     }
 }
 
-impl<T: Copy> Filter for Buffer<T> {
+impl<T: Copy> Filter<Mask> for Buffer<T> {
     type Output = Self;
 
     fn filter(self, selection_mask: &Mask) -> Self {

--- a/vortex-compute/src/filter/mask.rs
+++ b/vortex-compute/src/filter/mask.rs
@@ -5,7 +5,7 @@ use vortex_mask::{Mask, MaskMut};
 
 use crate::filter::Filter;
 
-impl Filter for &Mask {
+impl Filter<Mask> for &Mask {
     type Output = Mask;
 
     fn filter(self, selection_mask: &Mask) -> Mask {
@@ -28,7 +28,7 @@ impl Filter for &Mask {
     }
 }
 
-impl Filter for &mut MaskMut {
+impl Filter<Mask> for &mut MaskMut {
     type Output = ();
 
     fn filter(self, selection_mask: &Mask) {

--- a/vortex-compute/src/filter/mask.rs
+++ b/vortex-compute/src/filter/mask.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_mask::Mask;
+use vortex_mask::{Mask, MaskMut};
 
 use crate::filter::Filter;
 
@@ -25,5 +25,21 @@ impl Filter for &Mask {
                 Mask::from(v1.bit_buffer().filter(selection_mask))
             }
         }
+    }
+}
+
+impl Filter for &mut MaskMut {
+    type Output = ();
+
+    fn filter(self, selection_mask: &Mask) {
+        assert_eq!(
+            selection_mask.len(),
+            self.len(),
+            "Selection mask length must equal the mask length"
+        );
+
+        // TODO(connor): There is definitely a better way to do this (in place).
+        let filtered = self.clone().freeze().filter(selection_mask).into_mut();
+        *self = filtered;
     }
 }

--- a/vortex-compute/src/filter/mod.rs
+++ b/vortex-compute/src/filter/mod.rs
@@ -8,10 +8,8 @@ mod buffer;
 mod mask;
 mod vector;
 
-use vortex_mask::Mask;
-
 /// Function for filtering based on a selection mask.
-pub trait Filter {
+pub trait Filter<Rhs> {
     /// The result type after performing the operation.
     type Output;
 
@@ -22,5 +20,5 @@ pub trait Filter {
     /// # Panics
     ///
     /// If the length of the mask does not equal the length of the value being filtered.
-    fn filter(self, selection_mask: &Mask) -> Self::Output;
+    fn filter(self, selection: &Rhs) -> Self::Output;
 }

--- a/vortex-compute/src/filter/vector/bool.rs
+++ b/vortex-compute/src/filter/vector/bool.rs
@@ -7,7 +7,7 @@ use vortex_vector::bool::BoolVector;
 
 use crate::filter::Filter;
 
-impl Filter for &BoolVector {
+impl Filter<Mask> for &BoolVector {
     type Output = BoolVector;
 
     fn filter(self, mask: &Mask) -> BoolVector {

--- a/vortex-compute/src/filter/vector/mod.rs
+++ b/vortex-compute/src/filter/vector/mod.rs
@@ -10,7 +10,7 @@ mod bool;
 mod primitive;
 mod pvector;
 
-impl Filter for &mut VectorMut {
+impl Filter<Mask> for &mut VectorMut {
     type Output = ();
 
     fn filter(self, selection_mask: &Mask) {

--- a/vortex-compute/src/filter/vector/primitive.rs
+++ b/vortex-compute/src/filter/vector/primitive.rs
@@ -2,15 +2,37 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_mask::Mask;
-use vortex_vector::match_each_pvector_mut;
-use vortex_vector::primitive::PrimitiveVectorMut;
+use vortex_vector::primitive::{PrimitiveVector, PrimitiveVectorMut};
+use vortex_vector::{VectorOps, match_each_pvector, match_each_pvector_mut};
 
 use crate::filter::Filter;
+
+impl Filter for &PrimitiveVector {
+    type Output = PrimitiveVector;
+
+    fn filter(self, selection_mask: &Mask) -> PrimitiveVector {
+        match_each_pvector!(self, |v| { v.filter(selection_mask).into() })
+    }
+}
 
 impl Filter for &mut PrimitiveVectorMut {
     type Output = ();
 
     fn filter(self, selection_mask: &Mask) {
         match_each_pvector_mut!(self, |v| { v.filter(selection_mask) })
+    }
+}
+
+impl Filter for PrimitiveVector {
+    type Output = Self;
+
+    fn filter(self, selection_mask: &Mask) -> Self {
+        assert_eq!(
+            selection_mask.len(),
+            self.len(),
+            "Selection mask length must equal the buffer length"
+        );
+
+        match_each_pvector!(self, |v| { v.filter(selection_mask).into() })
     }
 }

--- a/vortex-compute/src/filter/vector/primitive.rs
+++ b/vortex-compute/src/filter/vector/primitive.rs
@@ -3,11 +3,11 @@
 
 use vortex_mask::Mask;
 use vortex_vector::primitive::{PrimitiveVector, PrimitiveVectorMut};
-use vortex_vector::{VectorOps, match_each_pvector, match_each_pvector_mut};
+use vortex_vector::{match_each_pvector, match_each_pvector_mut};
 
 use crate::filter::Filter;
 
-impl Filter for &PrimitiveVector {
+impl Filter<Mask> for &PrimitiveVector {
     type Output = PrimitiveVector;
 
     fn filter(self, selection_mask: &Mask) -> PrimitiveVector {
@@ -15,7 +15,7 @@ impl Filter for &PrimitiveVector {
     }
 }
 
-impl Filter for &mut PrimitiveVectorMut {
+impl Filter<Mask> for &mut PrimitiveVectorMut {
     type Output = ();
 
     fn filter(self, selection_mask: &Mask) {
@@ -23,16 +23,10 @@ impl Filter for &mut PrimitiveVectorMut {
     }
 }
 
-impl Filter for PrimitiveVector {
+impl Filter<Mask> for PrimitiveVector {
     type Output = Self;
 
     fn filter(self, selection_mask: &Mask) -> Self {
-        assert_eq!(
-            selection_mask.len(),
-            self.len(),
-            "Selection mask length must equal the buffer length"
-        );
-
         match_each_pvector!(self, |v| { v.filter(selection_mask).into() })
     }
 }

--- a/vortex-compute/src/filter/vector/pvector.rs
+++ b/vortex-compute/src/filter/vector/pvector.rs
@@ -8,7 +8,7 @@ use vortex_vector::{VectorMutOps, VectorOps};
 
 use crate::filter::Filter;
 
-impl<T: NativePType> Filter for &PVector<T> {
+impl<T: NativePType> Filter<Mask> for &PVector<T> {
     type Output = PVector<T>;
 
     fn filter(self, selection_mask: &Mask) -> PVector<T> {
@@ -27,7 +27,7 @@ impl<T: NativePType> Filter for &PVector<T> {
     }
 }
 
-impl<T: NativePType> Filter for &mut PVectorMut<T> {
+impl<T: NativePType> Filter<Mask> for &mut PVectorMut<T> {
     type Output = ();
 
     fn filter(self, selection_mask: &Mask) {
@@ -46,7 +46,7 @@ impl<T: NativePType> Filter for &mut PVectorMut<T> {
     }
 }
 
-impl<T: NativePType> Filter for PVector<T> {
+impl<T: NativePType> Filter<Mask> for PVector<T> {
     type Output = Self;
 
     fn filter(self, selection_mask: &Mask) -> Self {

--- a/vortex-compute/src/filter/vector/pvector.rs
+++ b/vortex-compute/src/filter/vector/pvector.rs
@@ -3,10 +3,29 @@
 
 use vortex_dtype::NativePType;
 use vortex_mask::Mask;
-use vortex_vector::VectorMutOps;
-use vortex_vector::primitive::PVectorMut;
+use vortex_vector::primitive::{PVector, PVectorMut};
+use vortex_vector::{VectorMutOps, VectorOps};
 
 use crate::filter::Filter;
+
+impl<T: NativePType> Filter for &PVector<T> {
+    type Output = PVector<T>;
+
+    fn filter(self, selection_mask: &Mask) -> PVector<T> {
+        assert_eq!(
+            selection_mask.len(),
+            self.len(),
+            "Selection mask length must equal the vector length"
+        );
+
+        let filtered_elements = self.elements().filter(selection_mask);
+        let filtered_validity = self.validity().filter(selection_mask);
+
+        // SAFETY: We filtered both components by the same mask, so the length invariants are
+        // upheld.
+        unsafe { PVector::new_unchecked(filtered_elements, filtered_validity) }
+    }
+}
 
 impl<T: NativePType> Filter for &mut PVectorMut<T> {
     type Output = ();
@@ -18,13 +37,33 @@ impl<T: NativePType> Filter for &mut PVectorMut<T> {
             "Selection mask length must equal the vector length"
         );
 
-        unimplemented!()
-
         // SAFETY: We filter the two components of the vector at the same time, so the length
         // invariants remain true.
-        // unsafe {
-        //     self.elements_mut().filter(selection_mask);
-        //     self.validity_mut().filter(selection_mask);
-        // }
+        unsafe {
+            self.elements_mut().filter(selection_mask);
+            self.validity_mut().filter(selection_mask);
+        }
+    }
+}
+
+impl<T: NativePType> Filter for PVector<T> {
+    type Output = Self;
+
+    fn filter(self, selection_mask: &Mask) -> Self {
+        assert_eq!(
+            selection_mask.len(),
+            self.len(),
+            "Selection mask length must equal the buffer length"
+        );
+
+        // If we have exclusive access, we can perform the filter in place.
+        match self.try_into_mut() {
+            Ok(mut vector_mut) => {
+                (&mut vector_mut).filter(selection_mask);
+                vector_mut.freeze()
+            }
+            // Otherwise, allocate a new buffer and fill it in (delegate to the `&PVector` impl).
+            Err(vector) => (&vector).filter(selection_mask),
+        }
     }
 }


### PR DESCRIPTION
Implements filter for primitive vectors (which needed a filter implementation for `MaskMut`, and I was too lazy to figure out how to do it in place).