### PR TITLE
chore: make ArrayAccessor infallible

### DIFF
--- a/encodings/fsst/benches/fsst_compress.rs
+++ b/encodings/fsst/benches/fsst_compress.rs
@@ -38,15 +38,15 @@ const BENCH_ARGS: &[(usize, usize, u8)] = &[
 #[divan::bench(args = BENCH_ARGS)]
 fn compress_fsst(bencher: Bencher, (string_count, avg_len, unique_chars): (usize, usize, u8)) {
     let array = generate_test_data(string_count, avg_len, unique_chars);
-    let compressor = fsst_train_compressor(array.as_ref()).unwrap();
-    bencher.bench(|| fsst_compress(array.as_ref(), &compressor).unwrap())
+    let compressor = fsst_train_compressor(&array);
+    bencher.bench(|| fsst_compress(&array, &compressor))
 }
 
 #[divan::bench(args = BENCH_ARGS)]
 fn decompress_fsst(bencher: Bencher, (string_count, avg_len, unique_chars): (usize, usize, u8)) {
     let array = generate_test_data(string_count, avg_len, unique_chars);
-    let compressor = fsst_train_compressor(array.as_ref()).unwrap();
-    let encoded = fsst_compress(array.as_ref(), &compressor).unwrap();
+    let compressor = fsst_train_compressor(&array);
+    let encoded = fsst_compress(array, &compressor);
 
     bencher
         .with_inputs(|| encoded.clone())
@@ -56,14 +56,14 @@ fn decompress_fsst(bencher: Bencher, (string_count, avg_len, unique_chars): (usi
 #[divan::bench(args = BENCH_ARGS)]
 fn train_compressor(bencher: Bencher, (string_count, avg_len, unique_chars): (usize, usize, u8)) {
     let array = generate_test_data(string_count, avg_len, unique_chars);
-    bencher.bench(|| fsst_train_compressor(array.as_ref()).unwrap())
+    bencher.bench(|| fsst_train_compressor(&array))
 }
 
 #[divan::bench(args = BENCH_ARGS)]
 fn pushdown_compare(bencher: Bencher, (string_count, avg_len, unique_chars): (usize, usize, u8)) {
     let array = generate_test_data(string_count, avg_len, unique_chars);
-    let compressor = fsst_train_compressor(array.as_ref()).unwrap();
-    let fsst_array = fsst_compress(array.as_ref(), &compressor).unwrap();
+    let compressor = fsst_train_compressor(&array);
+    let fsst_array = fsst_compress(&array, &compressor);
     let constant = ConstantArray::new(Scalar::from(&b"const"[..]), array.len());
 
     bencher
@@ -79,8 +79,8 @@ fn canonicalize_compare(
     (string_count, avg_len, unique_chars): (usize, usize, u8),
 ) {
     let array = generate_test_data(string_count, avg_len, unique_chars);
-    let compressor = fsst_train_compressor(array.as_ref()).unwrap();
-    let fsst_array = fsst_compress(array.as_ref(), &compressor).unwrap();
+    let compressor = fsst_train_compressor(&array);
+    let fsst_array = fsst_compress(&array, &compressor);
     let constant = ConstantArray::new(Scalar::from(&b"const"[..]), array.len());
 
     bencher
@@ -168,11 +168,9 @@ fn generate_chunked_test_data(
 ) -> ChunkedArray {
     (0..chunk_size)
         .map(|_| {
-            let array = generate_test_data(string_count, avg_len, unique_chars).into_array();
-            let compressor = fsst_train_compressor(array.as_ref()).unwrap();
-            fsst_compress(array.as_ref(), &compressor)
-                .unwrap()
-                .into_array()
+            let array = generate_test_data(string_count, avg_len, unique_chars);
+            let compressor = fsst_train_compressor(&array);
+            fsst_compress(array, &compressor).into_array()
         })
         .collect::<ChunkedArray>()
 }

--- a/encodings/fsst/src/canonical.rs
+++ b/encodings/fsst/src/canonical.rs
@@ -105,7 +105,7 @@ mod tests {
 
     use crate::{fsst_compress, fsst_train_compressor};
 
-    fn make_data() -> (ArrayRef, Vec<Option<Vec<u8>>>) {
+    fn make_data() -> (VarBinArray, Vec<Option<Vec<u8>>>) {
         const STRING_COUNT: usize = 1000;
         let mut rng = StdRng::seed_from_u64(0);
         let mut strings = Vec::with_capacity(STRING_COUNT);
@@ -133,8 +133,7 @@ mod tests {
                     .into_iter()
                     .map(|opt_s| opt_s.map(Vec::into_boxed_slice)),
                 DType::Binary(Nullability::Nullable),
-            )
-            .into_array(),
+            ),
             strings,
         )
     }
@@ -144,11 +143,8 @@ mod tests {
         let (arr_vec, data_vec): (Vec<ArrayRef>, Vec<Vec<Option<Vec<u8>>>>) = (0..10)
             .map(|_| {
                 let (array, data) = make_data();
-                let compressor = fsst_train_compressor(&array).unwrap();
-                (
-                    fsst_compress(&array, &compressor).unwrap().into_array(),
-                    data,
-                )
+                let compressor = fsst_train_compressor(&array);
+                (fsst_compress(&array, &compressor).into_array(), data)
             })
             .unzip();
 
@@ -168,17 +164,15 @@ mod tests {
 
         {
             let arr = builder.finish_into_canonical().into_varbinview();
-            let res1 = arr
-                .with_iterator(|iter| iter.map(|b| b.map(|v| v.to_vec())).collect::<Vec<_>>())
-                .unwrap();
+            let res1 =
+                arr.with_iterator(|iter| iter.map(|b| b.map(|v| v.to_vec())).collect::<Vec<_>>());
             assert_eq!(data, res1);
         };
 
         {
             let arr2 = chunked_arr.to_varbinview();
-            let res2 = arr2
-                .with_iterator(|iter| iter.map(|b| b.map(|v| v.to_vec())).collect::<Vec<_>>())
-                .unwrap();
+            let res2 =
+                arr2.with_iterator(|iter| iter.map(|b| b.map(|v| v.to_vec())).collect::<Vec<_>>());
             assert_eq!(data, res2)
         };
     }

--- a/encodings/fsst/src/compress.rs
+++ b/encodings/fsst/src/compress.rs
@@ -6,42 +6,21 @@
 use fsst::{Compressor, Symbol};
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::builder::VarBinBuilder;
-use vortex_array::arrays::{VarBinVTable, VarBinViewVTable};
 use vortex_array::{Array, IntoArray};
 use vortex_buffer::{Buffer, BufferMut};
 use vortex_dtype::DType;
-use vortex_error::{VortexExpect, VortexResult, VortexUnwrap, vortex_bail};
+use vortex_error::{VortexExpect, VortexUnwrap};
 
 use crate::FSSTArray;
 
-/// Compress an array using FSST.
-///
-/// # Panics
-///
-/// If the `strings` array is not encoded as either [`vortex_array::arrays::VarBinArray`] or
-/// [`vortex_array::arrays::VarBinViewArray`].
-pub fn fsst_compress(strings: &dyn Array, compressor: &Compressor) -> VortexResult<FSSTArray> {
-    let len = strings.len();
-    let dtype = strings.dtype().clone();
-
-    // Compress VarBinArray
-    if let Some(varbin) = strings.as_opt::<VarBinVTable>() {
-        return varbin
-            .with_iterator(|iter| fsst_compress_iter(iter, len, dtype, compressor))
-            .map_err(|err| err.with_context("Failed to compress VarBinArray with FSST"));
-    }
-
-    // Compress VarBinViewArray
-    if let Some(varbin_view) = strings.as_opt::<VarBinViewVTable>() {
-        return varbin_view
-            .with_iterator(|iter| fsst_compress_iter(iter, len, dtype, compressor))
-            .map_err(|err| err.with_context("Failed to compress VarBinViewArray with FSST"));
-    }
-
-    vortex_bail!(
-        "cannot fsst_compress array with unsupported encoding {:?}",
-        strings.encoding_id()
-    )
+/// Compress a string array using FSST.
+pub fn fsst_compress<A: ArrayAccessor<[u8]> + AsRef<dyn Array>>(
+    strings: A,
+    compressor: &Compressor,
+) -> FSSTArray {
+    let len = strings.as_ref().len();
+    let dtype = strings.as_ref().dtype().clone();
+    strings.with_iterator(|iter| fsst_compress_iter(iter, len, dtype, compressor))
 }
 
 /// Train a compressor from an array.
@@ -49,21 +28,8 @@ pub fn fsst_compress(strings: &dyn Array, compressor: &Compressor) -> VortexResu
 /// # Panics
 ///
 /// If the provided array is not FSST compressible.
-pub fn fsst_train_compressor(array: &dyn Array) -> VortexResult<Compressor> {
-    if let Some(varbin) = array.as_opt::<VarBinVTable>() {
-        varbin
-            .with_iterator(|iter| fsst_train_compressor_iter(iter))
-            .map_err(|err| err.with_context("Failed to train FSST Compressor from VarBinArray"))
-    } else if let Some(varbin_view) = array.as_opt::<VarBinViewVTable>() {
-        varbin_view
-            .with_iterator(|iter| fsst_train_compressor_iter(iter))
-            .map_err(|err| err.with_context("Failed to train FSST Compressor from VarBinViewArray"))
-    } else {
-        vortex_bail!(
-            "cannot fsst_compress array with unsupported encoding {:?}",
-            array.encoding_id()
-        )
-    }
+pub fn fsst_train_compressor<A: ArrayAccessor<[u8]>>(array: &A) -> Compressor {
+    array.with_iterator(|iter| fsst_train_compressor_iter(iter))
 }
 
 /// Train a [compressor][Compressor] from an iterator of bytestrings.

--- a/encodings/fsst/src/compute/cast.rs
+++ b/encodings/fsst/src/compute/cast.rs
@@ -55,8 +55,8 @@ mod tests {
             DType::Utf8(Nullability::NonNullable),
         );
 
-        let compressor = fsst_train_compressor(strings.as_ref()).unwrap();
-        let fsst = fsst_compress(strings.as_ref(), &compressor).unwrap();
+        let compressor = fsst_train_compressor(&strings);
+        let fsst = fsst_compress(strings, &compressor);
 
         // Cast to nullable
         let casted = cast(fsst.as_ref(), &DType::Utf8(Nullability::Nullable)).unwrap();
@@ -77,8 +77,8 @@ mod tests {
         DType::Utf8(Nullability::NonNullable)
     ))]
     fn test_cast_fsst_conformance(#[case] array: VarBinArray) {
-        let compressor = fsst_train_compressor(array.as_ref()).unwrap();
-        let fsst = fsst_compress(array.as_ref(), &compressor).unwrap();
+        let compressor = fsst_train_compressor(&array);
+        let fsst = fsst_compress(&array, &compressor);
         test_cast_conformance(fsst.as_ref());
     }
 }

--- a/encodings/fsst/src/compute/compare.rs
+++ b/encodings/fsst/src/compute/compare.rs
@@ -131,8 +131,8 @@ mod tests {
             ],
             DType::Utf8(Nullability::Nullable),
         );
-        let compressor = fsst_train_compressor(lhs.as_ref()).unwrap();
-        let lhs = fsst_compress(lhs.as_ref(), &compressor).unwrap();
+        let compressor = fsst_train_compressor(&lhs);
+        let lhs = fsst_compress(lhs, &compressor);
 
         let rhs = ConstantArray::new("world", lhs.len());
 

--- a/encodings/fsst/src/compute/filter.rs
+++ b/encodings/fsst/src/compute/filter.rs
@@ -46,8 +46,8 @@ mod test {
         builder.append_value(b"world");
         let varbin = builder.finish(DType::Utf8(Nullability::NonNullable));
 
-        let compressor = fsst_train_compressor(varbin.as_ref()).unwrap();
-        let array = fsst_compress(varbin.as_ref(), &compressor).unwrap();
+        let compressor = fsst_train_compressor(&varbin);
+        let array = fsst_compress(&varbin, &compressor);
         test_filter_conformance(array.as_ref());
 
         // Test with longer strings that benefit from compression
@@ -59,8 +59,8 @@ mod test {
         builder.append_value(b"the lazy dog sleeps");
         let varbin = builder.finish(DType::Utf8(Nullability::NonNullable));
 
-        let compressor = fsst_train_compressor(varbin.as_ref()).unwrap();
-        let array = fsst_compress(varbin.as_ref(), &compressor).unwrap();
+        let compressor = fsst_train_compressor(&varbin);
+        let array = fsst_compress(&varbin, &compressor);
         test_filter_conformance(array.as_ref());
 
         // Test with nullable strings
@@ -72,8 +72,8 @@ mod test {
         builder.append_null();
         let varbin = builder.finish(DType::Utf8(Nullability::Nullable));
 
-        let compressor = fsst_train_compressor(varbin.as_ref()).unwrap();
-        let array = fsst_compress(varbin.as_ref(), &compressor).unwrap();
+        let compressor = fsst_train_compressor(&varbin);
+        let array = fsst_compress(&varbin, &compressor);
         test_filter_conformance(array.as_ref());
     }
 }

--- a/encodings/fsst/src/compute/mod.rs
+++ b/encodings/fsst/src/compute/mod.rs
@@ -54,8 +54,8 @@ mod tests {
     #[test]
     fn test_take_null() {
         let arr = VarBinArray::from_iter([Some("h")], DType::Utf8(Nullability::NonNullable));
-        let compr = fsst_train_compressor(arr.as_ref()).unwrap();
-        let fsst = fsst_compress(arr.as_ref(), &compr).unwrap();
+        let compr = fsst_train_compressor(&arr);
+        let fsst = fsst_compress(&arr, &compr);
 
         let idx1: PrimitiveArray = (0..1).collect();
 
@@ -86,8 +86,8 @@ mod tests {
         DType::Utf8(Nullability::NonNullable),
     ))]
     fn test_take_fsst_conformance(#[case] varbin: VarBinArray) {
-        let compressor = fsst_train_compressor(varbin.as_ref()).unwrap();
-        let array = fsst_compress(varbin.as_ref(), &compressor).unwrap();
+        let compressor = fsst_train_compressor(&varbin);
+        let array = fsst_compress(&varbin, &compressor);
         test_take_conformance(array.as_ref());
     }
 
@@ -98,8 +98,8 @@ mod tests {
             ["hello world", "testing fsst", "compression test", "data array", "vortex encoding"].map(Some),
             DType::Utf8(Nullability::NonNullable),
         );
-        let compressor = fsst_train_compressor(varbin.as_ref()).unwrap();
-        fsst_compress(varbin.as_ref(), &compressor).unwrap()
+        let compressor = fsst_train_compressor(&varbin);
+        fsst_compress(&varbin, &compressor)
     })]
     // Nullable strings
     #[case::fsst_nullable({
@@ -107,8 +107,8 @@ mod tests {
             [Some("hello"), None, Some("world"), Some("test"), None],
             DType::Utf8(Nullability::Nullable),
         );
-        let compressor = fsst_train_compressor(varbin.as_ref()).unwrap();
-        fsst_compress(varbin.as_ref(), &compressor).unwrap()
+        let compressor = fsst_train_compressor(&varbin);
+        fsst_compress(varbin, &compressor)
     })]
     // Repetitive patterns (good for FSST compression)
     #[case::fsst_repetitive({
@@ -116,8 +116,8 @@ mod tests {
             ["http://example.com", "http://test.com", "http://vortex.dev", "http://data.org"].map(Some),
             DType::Utf8(Nullability::NonNullable),
         );
-        let compressor = fsst_train_compressor(varbin.as_ref()).unwrap();
-        fsst_compress(varbin.as_ref(), &compressor).unwrap()
+        let compressor = fsst_train_compressor(&varbin);
+        fsst_compress(&varbin, &compressor)
     })]
     // Edge cases
     #[case::fsst_single({
@@ -125,16 +125,16 @@ mod tests {
             ["single element"].map(Some),
             DType::Utf8(Nullability::NonNullable),
         );
-        let compressor = fsst_train_compressor(varbin.as_ref()).unwrap();
-        fsst_compress(varbin.as_ref(), &compressor).unwrap()
+        let compressor = fsst_train_compressor(&varbin);
+        fsst_compress(&varbin, &compressor)
     })]
     #[case::fsst_empty_strings({
         let varbin = VarBinArray::from_iter(
             ["", "test", "", "hello", ""].map(Some),
             DType::Utf8(Nullability::NonNullable),
         );
-        let compressor = fsst_train_compressor(varbin.as_ref()).unwrap();
-        fsst_compress(varbin.as_ref(), &compressor).unwrap()
+        let compressor = fsst_train_compressor(&varbin);
+        fsst_compress(varbin, &compressor)
     })]
     // Large arrays
     #[case::fsst_large({
@@ -153,8 +153,8 @@ mod tests {
             }))
             .collect();
         let varbin = VarBinArray::from_iter(data, DType::Utf8(Nullability::NonNullable));
-        let compressor = fsst_train_compressor(varbin.as_ref()).unwrap();
-        fsst_compress(varbin.as_ref(), &compressor).unwrap()
+        let compressor = fsst_train_compressor(&varbin);
+        fsst_compress(varbin, &compressor)
     })]
 
     fn test_fsst_consistency(#[case] array: FSSTArray) {

--- a/encodings/fsst/src/serde.rs
+++ b/encodings/fsst/src/serde.rs
@@ -86,10 +86,10 @@ impl EncodeVTable<FSSTVTable> for FSSTVTable {
 
         let compressor = match like {
             Some(like) => Compressor::rebuild_from(like.symbols(), like.symbol_lengths()),
-            None => fsst_train_compressor(array.as_ref())?,
+            None => fsst_train_compressor(&array),
         };
 
-        Ok(Some(fsst_compress(array.as_ref(), &compressor)?))
+        Ok(Some(fsst_compress(array, &compressor)))
     }
 }
 

--- a/encodings/fsst/src/test_utils.rs
+++ b/encodings/fsst/src/test_utils.rs
@@ -33,11 +33,9 @@ pub fn gen_fsst_test_data(len: usize, avg_str_len: usize, unique_chars: u8) -> A
             .map(|opt_s| opt_s.map(Vec::into_boxed_slice)),
         DType::Binary(Nullability::NonNullable),
     );
-    let compressor = fsst_train_compressor(varbin.as_ref()).vortex_unwrap();
+    let compressor = fsst_train_compressor(&varbin);
 
-    fsst_compress(varbin.as_ref(), &compressor)
-        .vortex_unwrap()
-        .into_array()
+    fsst_compress(varbin, &compressor).into_array()
 }
 
 pub fn gen_dict_fsst_test_data<T: NativePType>(

--- a/encodings/fsst/src/tests.rs
+++ b/encodings/fsst/src/tests.rs
@@ -26,10 +26,8 @@ pub(crate) fn build_fsst_array() -> ArrayRef {
     input_array.append_value(b"Nothing in present history can contradict them");
     let input_array = input_array.finish(DType::Utf8(Nullability::NonNullable));
 
-    let compressor = fsst_train_compressor(input_array.as_ref()).unwrap();
-    fsst_compress(input_array.as_ref(), &compressor)
-        .unwrap()
-        .into_array()
+    let compressor = fsst_train_compressor(&input_array);
+    fsst_compress(input_array, &compressor).into_array()
 }
 
 #[test]

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -131,7 +131,7 @@ fn collect_valid_vbv(vbv: &VarBinViewArray) -> VortexResult<(ByteBuffer, Vec<usi
                     buffer.extend_from_slice(value);
                 }
                 Ok::<_, VortexError>(())
-            })??;
+            })?;
             (buffer.freeze(), value_byte_indices)
         }
     };

--- a/fuzz/src/array/compare.rs
+++ b/fuzz/src/array/compare.rs
@@ -8,20 +8,13 @@ use vortex_array::validity::Validity;
 use vortex_array::{Array, ArrayRef, IntoArray, ToCanonical};
 use vortex_buffer::BitBuffer;
 use vortex_dtype::{DType, Nullability, match_each_decimal_value_type, match_each_native_ptype};
-use vortex_error::{VortexExpect, VortexResult, vortex_err};
+use vortex_error::{VortexExpect, vortex_panic};
 use vortex_scalar::Scalar;
 
-pub fn compare_canonical_array(
-    array: &dyn Array,
-    value: &Scalar,
-    operator: Operator,
-) -> VortexResult<ArrayRef> {
+pub fn compare_canonical_array(array: &dyn Array, value: &Scalar, operator: Operator) -> ArrayRef {
     if value.is_null() {
-        return Ok(BoolArray::from_bit_buffer(
-            BitBuffer::new_unset(array.len()),
-            Validity::AllInvalid,
-        )
-        .into_array());
+        return BoolArray::from_bit_buffer(BitBuffer::new_unset(array.len()), Validity::AllInvalid)
+            .into_array();
     }
 
     let result_nullability = array.dtype().nullability() | value.dtype().nullability();
@@ -32,7 +25,7 @@ pub fn compare_canonical_array(
                 .as_bool()
                 .value()
                 .vortex_expect("nulls handled before");
-            Ok(compare_to(
+            compare_to(
                 array
                     .to_bool()
                     .bit_buffer()
@@ -42,7 +35,7 @@ pub fn compare_canonical_array(
                 bool,
                 operator,
                 result_nullability,
-            ))
+            )
         }
         DType::Primitive(p, _) => {
             let primitive = value.as_primitive();
@@ -51,7 +44,7 @@ pub fn compare_canonical_array(
                 let pval = primitive
                     .typed_value::<P>()
                     .vortex_expect("nulls handled before");
-                Ok(compare_to(
+                compare_to(
                     primitive_array
                         .as_slice::<P>()
                         .iter()
@@ -61,7 +54,7 @@ pub fn compare_canonical_array(
                     NativeValue(pval),
                     operator,
                     result_nullability,
-                ))
+                )
             })
         }
         DType::Decimal(..) => {
@@ -72,9 +65,9 @@ pub fn compare_canonical_array(
                     .decimal_value()
                     .vortex_expect("nulls handled before")
                     .cast::<D>()
-                    .ok_or_else(|| vortex_err!("todo: handle upcast of decimal array"))?;
+                    .unwrap_or_else(|| vortex_panic!("todo: handle upcast of decimal array"));
                 let buf = decimal_array.buffer::<D>();
-                Ok(compare_to(
+                compare_to(
                     buf.as_slice()
                         .iter()
                         .copied()
@@ -83,7 +76,7 @@ pub fn compare_canonical_array(
                     dval,
                     operator,
                     result_nullability,
-                ))
+                )
             })
         }
         DType::Utf8(_) => array.to_varbinview().with_iterator(|iter| {
@@ -114,12 +107,12 @@ pub fn compare_canonical_array(
         }),
         DType::Struct(..) | DType::List(..) | DType::FixedSizeList(..) => {
             let scalar_vals: Vec<Scalar> = (0..array.len()).map(|i| array.scalar_at(i)).collect();
-            Ok(BoolArray::from_iter(
+            BoolArray::from_iter(
                 scalar_vals
                     .iter()
                     .map(|v| scalar_cmp(v, value, operator).as_bool().value()),
             )
-            .into_array())
+            .into_array()
         }
         d @ (DType::Null | DType::Extension(_)) => {
             unreachable!("DType {d} not supported for fuzzing")

--- a/fuzz/src/array/filter.rs
+++ b/fuzz/src/array/filter.rs
@@ -77,7 +77,7 @@ pub fn filter_canonical_array(array: &dyn Array, filter: &[bool]) -> VortexResul
                     .filter(|(_, f)| **f)
                     .map(|(v, _)| v.map(|u| u.to_vec()))
                     .collect::<Vec<_>>()
-            })?;
+            });
             Ok(VarBinViewArray::from_iter(values, array.dtype().clone()).into_array())
         }
         DType::Struct(..) => {

--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -255,8 +255,7 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                     };
 
                     let op = u.arbitrary()?;
-                    current_array =
-                        compare_canonical_array(&current_array, &scalar, op).vortex_unwrap();
+                    current_array = compare_canonical_array(&current_array, &scalar, op);
                     (
                         Action::Compare(scalar, op),
                         ExpectedValue::Array(current_array.to_array()),

--- a/fuzz/src/array/search_sorted.rs
+++ b/fuzz/src/array/search_sorted.rs
@@ -108,7 +108,7 @@ pub fn search_sorted_canonical_array(
         DType::Utf8(_) | DType::Binary(_) => {
             let utf8 = array.to_varbinview();
             let opt_values =
-                utf8.with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())?;
+                utf8.with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>());
             let to_find = if matches!(array.dtype(), DType::Utf8(_)) {
                 BufferString::try_from(scalar)?.as_str().as_bytes().to_vec()
             } else {

--- a/fuzz/src/array/slice.rs
+++ b/fuzz/src/array/slice.rs
@@ -42,7 +42,7 @@ pub fn slice_canonical_array(
         DType::Utf8(_) | DType::Binary(_) => {
             let utf8 = array.to_varbinview();
             let values =
-                utf8.with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())?;
+                utf8.with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>());
             Ok(VarBinViewArray::from_iter(
                 values[start..stop].iter().cloned(),
                 array.dtype().clone(),

--- a/fuzz/src/array/sort.rs
+++ b/fuzz/src/array/sort.rs
@@ -56,7 +56,7 @@ pub fn sort_canonical_array(array: &dyn Array) -> VortexResult<ArrayRef> {
         DType::Utf8(_) | DType::Binary(_) => {
             let utf8 = array.to_varbinview();
             let mut opt_values =
-                utf8.with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())?;
+                utf8.with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>());
             opt_values.sort();
             Ok(VarBinViewArray::from_iter(opt_values, array.dtype().clone()).into_array())
         }

--- a/fuzz/src/array/take.rs
+++ b/fuzz/src/array/take.rs
@@ -86,7 +86,7 @@ pub fn take_canonical_array(
         DType::Utf8(_) | DType::Binary(_) => {
             let utf8 = array.to_varbinview();
             let values =
-                utf8.with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>())?;
+                utf8.with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>());
             Ok(VarBinViewArray::from_iter(
                 indices
                     .iter()

--- a/vortex-array/benches/dict_compare.rs
+++ b/vortex-array/benches/dict_compare.rs
@@ -54,9 +54,7 @@ fn bench_compare_primitive(bencher: divan::Bencher, (len, uniqueness): (usize, u
 fn bench_compare_varbin(bencher: divan::Bencher, (len, uniqueness): (usize, usize)) {
     let varbin_arr = VarBinArray::from(gen_varbin_words(len, uniqueness));
     let dict = dict_encode(varbin_arr.as_ref()).unwrap();
-    let bytes = varbin_arr
-        .with_iterator(|i| i.next().unwrap().unwrap().to_vec())
-        .unwrap();
+    let bytes = varbin_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
 
     bencher.with_inputs(|| dict.clone()).bench_refs(|dict| {
@@ -73,9 +71,7 @@ fn bench_compare_varbin(bencher: divan::Bencher, (len, uniqueness): (usize, usiz
 fn bench_compare_varbinview(bencher: divan::Bencher, (len, uniqueness): (usize, usize)) {
     let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(len, uniqueness));
     let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
-    let bytes = varbinview_arr
-        .with_iterator(|i| i.next().unwrap().unwrap().to_vec())
-        .unwrap();
+    let bytes = varbinview_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
     bencher.with_inputs(|| dict.clone()).bench_refs(|dict| {
         compare(
@@ -127,9 +123,7 @@ fn bench_compare_sliced_dict_varbinview(
     let varbin_arr = VarBinArray::from(gen_varbin_words(codes_len.max(values_len), values_len));
     let dict = dict_encode(varbin_arr.as_ref()).unwrap();
     let dict = dict.slice(0..codes_len);
-    let bytes = varbin_arr
-        .with_iterator(|i| i.next().unwrap().unwrap().to_vec())
-        .unwrap();
+    let bytes = varbin_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
 
     bencher.with_inputs(|| dict.clone()).bench_refs(|dict| {

--- a/vortex-array/src/accessor.rs
+++ b/vortex-array/src/accessor.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_error::VortexResult;
-
 /// Trait for arrays that support iterative access to their elements.
 pub trait ArrayAccessor<Item: ?Sized> {
     /// Iterate over each element of the array, in-order.
@@ -10,7 +8,7 @@ pub trait ArrayAccessor<Item: ?Sized> {
     /// The function `f` will be passed an [`Iterator`], it can call [`next`][Iterator::next] on the
     /// iterator [`len`][crate::Array::len] times. Iterator elements are `Option` types,
     /// regardless of the nullability of the underlying array data.
-    fn with_iterator<F, R>(&self, f: F) -> VortexResult<R>
+    fn with_iterator<F, R>(&self, f: F) -> R
     where
         F: for<'a> FnOnce(&mut dyn Iterator<Item = Option<&'a Item>>) -> R;
 }

--- a/vortex-array/src/arrays/chunked/tests.rs
+++ b/vortex-array/src/arrays/chunked/tests.rs
@@ -153,12 +153,10 @@ pub fn pack_nested_structs() {
     let canonical_struct = chunked.to_struct();
     let canonical_varbin = canonical_struct.fields()[0].to_varbinview();
     let original_varbin = struct_array.fields()[0].to_varbinview();
-    let orig_values = original_varbin
-        .with_iterator(|it| it.map(|a| a.map(|v| v.to_vec())).collect::<Vec<_>>())
-        .unwrap();
-    let canon_values = canonical_varbin
-        .with_iterator(|it| it.map(|a| a.map(|v| v.to_vec())).collect::<Vec<_>>())
-        .unwrap();
+    let orig_values =
+        original_varbin.with_iterator(|it| it.map(|a| a.map(|v| v.to_vec())).collect::<Vec<_>>());
+    let canon_values =
+        canonical_varbin.with_iterator(|it| it.map(|a| a.map(|v| v.to_vec())).collect::<Vec<_>>());
     assert_eq!(orig_values, canon_values);
 }
 

--- a/vortex-array/src/arrays/chunked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/chunked/vtable/canonical.rs
@@ -214,11 +214,9 @@ mod tests {
         let canonical_varbin = canonical_struct.fields()[0].to_varbinview();
         let original_varbin = struct_array.fields()[0].to_varbinview();
         let orig_values = original_varbin
-            .with_iterator(|it| it.map(|a| a.map(|v| v.to_vec())).collect::<Vec<_>>())
-            .unwrap();
+            .with_iterator(|it| it.map(|a| a.map(|v| v.to_vec())).collect::<Vec<_>>());
         let canon_values = canonical_varbin
-            .with_iterator(|it| it.map(|a| a.map(|v| v.to_vec())).collect::<Vec<_>>())
-            .unwrap();
+            .with_iterator(|it| it.map(|a| a.map(|v| v.to_vec())).collect::<Vec<_>>());
         assert_eq!(orig_values, canon_values);
     }
 

--- a/vortex-array/src/arrays/dict/compute/mod.rs
+++ b/vortex-array/src/arrays/dict/compute/mod.rs
@@ -107,16 +107,12 @@ mod test {
         let dict = dict_encode(reference.as_ref()).unwrap();
         let flattened_dict = dict.to_varbinview();
         assert_eq!(
-            flattened_dict
-                .with_iterator(|iter| iter
-                    .map(|slice| slice.map(|s| s.to_vec()))
-                    .collect::<Vec<_>>())
-                .unwrap(),
-            reference
-                .with_iterator(|iter| iter
-                    .map(|slice| slice.map(|s| s.to_vec()))
-                    .collect::<Vec<_>>())
-                .unwrap(),
+            flattened_dict.with_iterator(|iter| iter
+                .map(|slice| slice.map(|s| s.to_vec()))
+                .collect::<Vec<_>>()),
+            reference.with_iterator(|iter| iter
+                .map(|slice| slice.map(|s| s.to_vec()))
+                .collect::<Vec<_>>()),
         );
     }
 

--- a/vortex-array/src/arrays/primitive/array/accessor.rs
+++ b/vortex-array/src/arrays/primitive/array/accessor.rs
@@ -4,7 +4,6 @@
 use std::iter;
 
 use vortex_dtype::NativePType;
-use vortex_error::VortexResult;
 
 use crate::ToCanonical;
 use crate::accessor::ArrayAccessor;
@@ -13,16 +12,16 @@ use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
 impl<T: NativePType> ArrayAccessor<T> for PrimitiveArray {
-    fn with_iterator<F, R>(&self, f: F) -> VortexResult<R>
+    fn with_iterator<F, R>(&self, f: F) -> R
     where
         F: for<'a> FnOnce(&mut dyn Iterator<Item = Option<&'a T>>) -> R,
     {
         match self.validity() {
             Validity::NonNullable | Validity::AllValid => {
                 let mut iter = self.as_slice::<T>().iter().map(Some);
-                Ok(f(&mut iter))
+                f(&mut iter)
             }
-            Validity::AllInvalid => Ok(f(&mut iter::repeat_n(None, self.len()))),
+            Validity::AllInvalid => f(&mut iter::repeat_n(None, self.len())),
             Validity::Array(v) => {
                 let validity = v.to_bool();
                 let mut iter = self
@@ -30,7 +29,7 @@ impl<T: NativePType> ArrayAccessor<T> for PrimitiveArray {
                     .iter()
                     .zip(validity.bit_buffer().iter())
                     .map(|(value, valid)| valid.then_some(value));
-                Ok(f(&mut iter))
+                f(&mut iter)
             }
         }
     }

--- a/vortex-array/src/arrays/varbin/accessor.rs
+++ b/vortex-array/src/arrays/varbin/accessor.rs
@@ -4,7 +4,6 @@
 use std::iter;
 
 use vortex_dtype::match_each_integer_ptype;
-use vortex_error::VortexResult;
 
 use crate::ToCanonical;
 use crate::accessor::ArrayAccessor;
@@ -13,7 +12,7 @@ use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
 impl ArrayAccessor<[u8]> for VarBinArray {
-    fn with_iterator<F, R>(&self, f: F) -> VortexResult<R>
+    fn with_iterator<F, R>(&self, f: F) -> R
     where
         F: for<'a> FnOnce(&mut dyn Iterator<Item = Option<&'a [u8]>>) -> R,
     {
@@ -32,18 +31,27 @@ impl ArrayAccessor<[u8]> for VarBinArray {
                     let mut iter = offsets
                         .windows(2)
                         .map(|w| Some(&bytes[w[0] as usize..w[1] as usize]));
-                    Ok(f(&mut iter))
+                    f(&mut iter)
                 }
-                Validity::AllInvalid => Ok(f(&mut iter::repeat_n(None, self.len()))),
+                Validity::AllInvalid => f(&mut iter::repeat_n(None, self.len())),
                 Validity::Array(v) => {
                     let validity = v.to_bool();
                     let mut iter = offsets
                         .windows(2)
                         .zip(validity.bit_buffer())
                         .map(|(w, valid)| valid.then(|| &bytes[w[0] as usize..w[1] as usize]));
-                    Ok(f(&mut iter))
+                    f(&mut iter)
                 }
             }
         })
+    }
+}
+
+impl ArrayAccessor<[u8]> for &VarBinArray {
+    fn with_iterator<F, R>(&self, f: F) -> R
+    where
+        F: for<'a> FnOnce(&mut dyn Iterator<Item = Option<&'a [u8]>>) -> R,
+    {
+        <VarBinArray as ArrayAccessor<[u8]>>::with_iterator(*self, f)
     }
 }

--- a/vortex-array/src/arrays/varbin/compute/is_constant.rs
+++ b/vortex-array/src/arrays/varbin/compute/is_constant.rs
@@ -17,7 +17,7 @@ impl IsConstantKernel for VarBinVTable {
         if opts.is_negligible_cost() {
             return Ok(None);
         }
-        array.with_iterator(compute_is_constant).map(Some)
+        Ok(Some(array.with_iterator(compute_is_constant)))
     }
 }
 

--- a/vortex-array/src/arrays/varbin/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/varbin/compute/is_sorted.rs
@@ -10,15 +10,15 @@ use crate::register_kernel;
 
 impl IsSortedKernel for VarBinVTable {
     fn is_sorted(&self, array: &VarBinArray) -> VortexResult<Option<bool>> {
-        array
-            .with_iterator(|bytes_iter| bytes_iter.is_sorted())
-            .map(Some)
+        Ok(Some(
+            array.with_iterator(|bytes_iter| bytes_iter.is_sorted()),
+        ))
     }
 
     fn is_strict_sorted(&self, array: &VarBinArray) -> VortexResult<Option<bool>> {
-        array
-            .with_iterator(|bytes_iter| bytes_iter.is_strict_sorted())
-            .map(Some)
+        Ok(Some(
+            array.with_iterator(|bytes_iter| bytes_iter.is_strict_sorted()),
+        ))
     }
 }
 

--- a/vortex-array/src/arrays/varbin/compute/min_max.rs
+++ b/vortex-array/src/arrays/varbin/compute/min_max.rs
@@ -14,7 +14,7 @@ use crate::register_kernel;
 
 impl MinMaxKernel for VarBinVTable {
     fn min_max(&self, array: &VarBinArray) -> VortexResult<Option<MinMaxResult>> {
-        varbin_compute_min_max(array, array.dtype())
+        Ok(varbin_compute_min_max(array, array.dtype()))
     }
 }
 
@@ -24,8 +24,8 @@ register_kernel!(MinMaxKernelAdapter(VarBinVTable).lift());
 pub(crate) fn varbin_compute_min_max<T: ArrayAccessor<[u8]>>(
     array: &T,
     dtype: &DType,
-) -> VortexResult<Option<MinMaxResult>> {
-    let minmax = array.with_iterator(|iter| match iter.flatten().minmax() {
+) -> Option<MinMaxResult> {
+    array.with_iterator(|iter| match iter.flatten().minmax() {
         itertools::MinMaxResult::NoElements => None,
         itertools::MinMaxResult::OneElement(value) => {
             let scalar = make_scalar(dtype, value);
@@ -38,9 +38,7 @@ pub(crate) fn varbin_compute_min_max<T: ArrayAccessor<[u8]>>(
             min: make_scalar(dtype, min),
             max: make_scalar(dtype, max),
         }),
-    })?;
-
-    Ok(minmax)
+    })
 }
 
 /// Helper function to make sure that min/max has the right [`Scalar`] type.

--- a/vortex-array/src/arrays/varbinview/accessor.rs
+++ b/vortex-array/src/arrays/varbinview/accessor.rs
@@ -3,8 +3,6 @@
 
 use std::iter;
 
-use vortex_error::VortexResult;
-
 use crate::ToCanonical;
 use crate::accessor::ArrayAccessor;
 use crate::arrays::varbinview::VarBinViewArray;
@@ -15,7 +13,7 @@ impl ArrayAccessor<[u8]> for VarBinViewArray {
     fn with_iterator<F: for<'a> FnOnce(&mut dyn Iterator<Item = Option<&'a [u8]>>) -> R, R>(
         &self,
         f: F,
-    ) -> VortexResult<R> {
+    ) -> R {
         let bytes = (0..self.nbuffers())
             .map(|i| self.buffer(i))
             .collect::<Vec<_>>();
@@ -33,9 +31,9 @@ impl ArrayAccessor<[u8]> for VarBinViewArray {
                         )
                     }
                 });
-                Ok(f(&mut iter))
+                f(&mut iter)
             }
-            Validity::AllInvalid => Ok(f(&mut iter::repeat_n(None, views.len()))),
+            Validity::AllInvalid => f(&mut iter::repeat_n(None, views.len())),
             Validity::Array(v) => {
                 let validity = v.to_bool();
                 let mut iter = views
@@ -55,8 +53,17 @@ impl ArrayAccessor<[u8]> for VarBinViewArray {
                             None
                         }
                     });
-                Ok(f(&mut iter))
+                f(&mut iter)
             }
         }
+    }
+}
+
+impl ArrayAccessor<[u8]> for &VarBinViewArray {
+    fn with_iterator<F, R>(&self, f: F) -> R
+    where
+        F: for<'a> FnOnce(&mut dyn Iterator<Item = Option<&'a [u8]>>) -> R,
+    {
+        <VarBinViewArray as ArrayAccessor<[u8]>>::with_iterator(*self, f)
     }
 }

--- a/vortex-array/src/arrays/varbinview/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/varbinview/compute/is_sorted.rs
@@ -10,15 +10,15 @@ use crate::register_kernel;
 
 impl IsSortedKernel for VarBinViewVTable {
     fn is_sorted(&self, array: &VarBinViewArray) -> VortexResult<Option<bool>> {
-        array
-            .with_iterator(|bytes_iter| bytes_iter.is_sorted())
-            .map(Some)
+        Ok(Some(
+            array.with_iterator(|bytes_iter| bytes_iter.is_sorted()),
+        ))
     }
 
     fn is_strict_sorted(&self, array: &VarBinViewArray) -> VortexResult<Option<bool>> {
-        array
-            .with_iterator(|bytes_iter| bytes_iter.is_strict_sorted())
-            .map(Some)
+        Ok(Some(
+            array.with_iterator(|bytes_iter| bytes_iter.is_strict_sorted()),
+        ))
     }
 }
 

--- a/vortex-array/src/arrays/varbinview/compute/min_max.rs
+++ b/vortex-array/src/arrays/varbinview/compute/min_max.rs
@@ -9,7 +9,7 @@ use crate::register_kernel;
 
 impl MinMaxKernel for VarBinViewVTable {
     fn min_max(&self, array: &VarBinViewArray) -> VortexResult<Option<MinMaxResult>> {
-        varbin_compute_min_max(array, array.dtype())
+        Ok(varbin_compute_min_max(array, array.dtype()))
     }
 }
 

--- a/vortex-array/src/arrays/varbinview/compute/mod.rs
+++ b/vortex-array/src/arrays/varbinview/compute/mod.rs
@@ -35,12 +35,9 @@ mod tests {
 
         assert!(taken.dtype().is_nullable());
         assert_eq!(
-            taken
-                .to_varbinview()
-                .with_iterator(|it| it
-                    .map(|v| v.map(|b| unsafe { String::from_utf8_unchecked(b.to_vec()) }))
-                    .collect::<Vec<_>>())
-                .unwrap(),
+            taken.to_varbinview().with_iterator(|it| it
+                .map(|v| v.map(|b| unsafe { String::from_utf8_unchecked(b.to_vec()) }))
+                .collect::<Vec<_>>()),
             [Some("one".to_string()), Some("four".to_string())]
         );
     }

--- a/vortex-array/src/arrays/varbinview/compute/take.rs
+++ b/vortex-array/src/arrays/varbinview/compute/take.rs
@@ -85,12 +85,9 @@ mod tests {
 
         assert!(taken.dtype().is_nullable());
         assert_eq!(
-            taken
-                .to_varbinview()
-                .with_iterator(|it| it
-                    .map(|v| v.map(|b| unsafe { String::from_utf8_unchecked(b.to_vec()) }))
-                    .collect::<Vec<_>>())
-                .unwrap(),
+            taken.to_varbinview().with_iterator(|it| it
+                .map(|v| v.map(|b| unsafe { String::from_utf8_unchecked(b.to_vec()) }))
+                .collect::<Vec<_>>()),
             [Some("one".to_string()), Some("four".to_string())]
         );
     }
@@ -107,12 +104,9 @@ mod tests {
 
         assert!(taken.dtype().is_nullable());
         assert_eq!(
-            taken
-                .to_varbinview()
-                .with_iterator(|it| it
-                    .map(|v| v.map(|b| unsafe { String::from_utf8_unchecked(b.to_vec()) }))
-                    .collect::<Vec<_>>())
-                .unwrap(),
+            taken.to_varbinview().with_iterator(|it| it
+                .map(|v| v.map(|b| unsafe { String::from_utf8_unchecked(b.to_vec()) }))
+                .collect::<Vec<_>>()),
             [Some("two".to_string()), None]
         );
     }

--- a/vortex-array/src/builders/dict/bytes.rs
+++ b/vortex-array/src/builders/dict/bytes.rs
@@ -7,13 +7,14 @@ use std::sync::Arc;
 
 use vortex_buffer::{BitBufferMut, BufferMut, ByteBufferMut};
 use vortex_dtype::{DType, UnsignedPType};
-use vortex_error::{VortexExpect, VortexResult, VortexUnwrap, vortex_bail, vortex_panic};
+use vortex_error::{VortexExpect, VortexUnwrap, vortex_panic};
 use vortex_utils::aliases::hash_map::{DefaultHashBuilder, HashTable, HashTableEntry, RandomState};
 use vortex_vector::binaryview::BinaryView;
 
 use super::{DictConstraints, DictEncoder};
 use crate::accessor::ArrayAccessor;
 use crate::arrays::{PrimitiveArray, VarBinVTable, VarBinViewArray, VarBinViewVTable};
+use crate::canonical::ToCanonical;
 use crate::validity::Validity;
 use crate::{Array, ArrayRef, IntoArray};
 
@@ -120,11 +121,7 @@ impl<Code: UnsignedPType> BytesDictBuilder<Code> {
         }
     }
 
-    fn encode_bytes<A: ArrayAccessor<[u8]>>(
-        &mut self,
-        accessor: &A,
-        len: usize,
-    ) -> VortexResult<ArrayRef> {
+    fn encode_bytes<A: ArrayAccessor<[u8]>>(&mut self, accessor: &A, len: usize) -> ArrayRef {
         let mut local_lookup = self.lookup.take().vortex_expect("Must have a lookup dict");
         let mut codes: BufferMut<Code> = BufferMut::with_capacity(len);
 
@@ -133,26 +130,27 @@ impl<Code: UnsignedPType> BytesDictBuilder<Code> {
                 let Some(code) = self.encode_value(&mut local_lookup, value) else {
                     break;
                 };
+                // SAFETY: we reserved capacity in the buffer for `len` elements
                 unsafe { codes.push_unchecked(code) }
             }
-        })?;
+        });
 
         // Restore lookup dictionary back into the struct
         self.lookup = Some(local_lookup);
 
-        Ok(PrimitiveArray::new(codes, Validity::NonNullable).into_array())
+        PrimitiveArray::new(codes, Validity::NonNullable).into_array()
     }
 }
 
 impl<Code: UnsignedPType> DictEncoder for BytesDictBuilder<Code> {
-    fn encode(&mut self, array: &dyn Array) -> VortexResult<ArrayRef> {
-        if &self.dtype != array.dtype() {
-            vortex_bail!(
-                "Array DType {} does not match builder dtype {}",
-                array.dtype(),
-                self.dtype
-            );
-        }
+    fn encode(&mut self, array: &dyn Array) -> ArrayRef {
+        debug_assert_eq!(
+            &self.dtype,
+            array.dtype(),
+            "Array DType {} does not match builder dtype {}",
+            array.dtype(),
+            self.dtype
+        );
 
         let len = array.len();
         if let Some(varbinview) = array.as_opt::<VarBinViewVTable>() {
@@ -160,24 +158,27 @@ impl<Code: UnsignedPType> DictEncoder for BytesDictBuilder<Code> {
         } else if let Some(varbin) = array.as_opt::<VarBinVTable>() {
             self.encode_bytes(varbin, len)
         } else {
-            vortex_bail!("Can only dictionary encode VarBin and VarBinView arrays");
+            // NOTE(aduffy): it is very rare that this path would be taken, only e.g.
+            //  if we're performing dictionary encoding downstream of some other compression.
+            self.encode_bytes(&array.to_varbinview(), len)
         }
     }
 
-    fn values(&mut self) -> VortexResult<ArrayRef> {
+    fn reset(&mut self) -> ArrayRef {
+        let views = mem::take(&mut self.views).freeze();
+        let buffer = mem::take(&mut self.values).freeze();
+        let value_nulls = mem::take(&mut self.values_nulls).freeze();
+
         // SAFETY: we build the views explicitly and the bytes should be checked before feeding
         //  to the encoder.
         unsafe {
-            Ok(VarBinViewArray::new_unchecked(
-                self.views.clone().freeze(),
-                Arc::from([self.values.clone().freeze()]),
+            VarBinViewArray::new_unchecked(
+                views,
+                Arc::from([buffer]),
                 self.dtype.clone(),
-                Validity::from_bit_buffer(
-                    mem::take(&mut self.values_nulls).freeze(),
-                    self.dtype.nullability(),
-                ),
+                Validity::from_bit_buffer(value_nulls, self.dtype.nullability()),
             )
-            .into_array())
+            .into_array()
         }
     }
 }
@@ -199,17 +200,14 @@ mod test {
             dict.codes().to_primitive().as_slice::<u8>(),
             &[0, 1, 0, 2, 1]
         );
-        dict.values()
-            .to_varbinview()
-            .with_iterator(|iter| {
-                assert_eq!(
-                    iter.flatten()
-                        .map(|b| unsafe { str::from_utf8_unchecked(b) })
-                        .collect::<Vec<_>>(),
-                    vec!["hello", "world", "again"]
-                );
-            })
-            .unwrap();
+        dict.values().to_varbinview().with_iterator(|iter| {
+            assert_eq!(
+                iter.flatten()
+                    .map(|b| unsafe { str::from_utf8_unchecked(b) })
+                    .collect::<Vec<_>>(),
+                vec!["hello", "world", "again"]
+            );
+        });
     }
 
     #[test]
@@ -231,33 +229,27 @@ mod test {
             dict.codes().to_primitive().as_slice::<u8>(),
             &[0, 1, 2, 0, 1, 3, 2, 1]
         );
-        dict.values()
-            .to_varbinview()
-            .with_iterator(|iter| {
-                assert_eq!(
-                    iter.map(|b| b.map(|v| unsafe { str::from_utf8_unchecked(v) }))
-                        .collect::<Vec<_>>(),
-                    vec![Some("hello"), None, Some("world"), Some("again")]
-                );
-            })
-            .unwrap();
+        dict.values().to_varbinview().with_iterator(|iter| {
+            assert_eq!(
+                iter.map(|b| b.map(|v| unsafe { str::from_utf8_unchecked(v) }))
+                    .collect::<Vec<_>>(),
+                vec![Some("hello"), None, Some("world"), Some("again")]
+            );
+        });
     }
 
     #[test]
     fn repeated_values() {
         let arr = VarBinArray::from(vec!["a", "a", "b", "b", "a", "b", "a", "b"]);
         let dict = dict_encode(arr.as_ref()).unwrap();
-        dict.values()
-            .to_varbinview()
-            .with_iterator(|iter| {
-                assert_eq!(
-                    iter.flatten()
-                        .map(|b| unsafe { str::from_utf8_unchecked(b) })
-                        .collect::<Vec<_>>(),
-                    vec!["a", "b"]
-                );
-            })
-            .unwrap();
+        dict.values().to_varbinview().with_iterator(|iter| {
+            assert_eq!(
+                iter.flatten()
+                    .map(|b| unsafe { str::from_utf8_unchecked(b) })
+                    .collect::<Vec<_>>(),
+                vec!["a", "b"]
+            );
+        });
         assert_eq!(
             dict.codes().to_primitive().as_slice::<u8>(),
             &[0, 0, 1, 1, 0, 1, 0, 1]

--- a/vortex-array/src/builders/dict/mod.rs
+++ b/vortex-array/src/builders/dict/mod.rs
@@ -4,7 +4,7 @@
 use bytes::bytes_dict_builder;
 use primitive::primitive_dict_builder;
 use vortex_dtype::match_each_native_ptype;
-use vortex_error::{VortexResult, vortex_bail};
+use vortex_error::{VortexResult, vortex_bail, vortex_panic};
 
 use crate::arrays::{DictArray, PrimitiveVTable, VarBinVTable, VarBinViewVTable};
 use crate::{Array, ArrayRef, IntoArray, ToCanonical};
@@ -25,15 +25,13 @@ pub const UNCONSTRAINED: DictConstraints = DictConstraints {
 
 pub trait DictEncoder: Send {
     /// Assign dictionary codes to the given input array.
-    fn encode(&mut self, array: &dyn Array) -> VortexResult<ArrayRef>;
+    fn encode(&mut self, array: &dyn Array) -> ArrayRef;
 
-    fn values(&mut self) -> VortexResult<ArrayRef>;
+    /// Clear the encoder state to make it ready for a new round of decoding.
+    fn reset(&mut self) -> ArrayRef;
 }
 
-pub fn dict_encoder(
-    array: &dyn Array,
-    constraints: &DictConstraints,
-) -> VortexResult<Box<dyn DictEncoder>> {
+pub fn dict_encoder(array: &dyn Array, constraints: &DictConstraints) -> Box<dyn DictEncoder> {
     let dict_builder: Box<dyn DictEncoder> = if let Some(pa) = array.as_opt::<PrimitiveVTable>() {
         match_each_native_ptype!(pa.ptype(), |P| {
             primitive_dict_builder::<P>(pa.dtype().nullability(), constraints)
@@ -43,22 +41,22 @@ pub fn dict_encoder(
     } else if let Some(vb) = array.as_opt::<VarBinVTable>() {
         bytes_dict_builder(vb.dtype().clone(), constraints)
     } else {
-        vortex_bail!("Can only encode primitive or varbin/view arrays")
+        vortex_panic!("Can only encode primitive or varbin/view arrays")
     };
-    Ok(dict_builder)
+    dict_builder
 }
 
 pub fn dict_encode_with_constraints(
     array: &dyn Array,
     constraints: &DictConstraints,
 ) -> VortexResult<DictArray> {
-    let mut encoder = dict_encoder(array, constraints)?;
-    let codes = encoder.encode(array)?.to_primitive().narrow()?;
+    let mut encoder = dict_encoder(array, constraints);
+    let codes = encoder.encode(array).to_primitive().narrow()?;
     // SAFETY: The encoding process will produce a value set of codes and values
     unsafe {
         Ok(DictArray::new_unchecked(
             codes.into_array(),
-            encoder.values()?,
+            encoder.reset(),
         ))
     }
 }

--- a/vortex-array/src/builders/dict/primitive.rs
+++ b/vortex-array/src/builders/dict/primitive.rs
@@ -6,8 +6,8 @@ use std::mem;
 
 use rustc_hash::FxBuildHasher;
 use vortex_buffer::{BitBufferMut, BufferMut};
-use vortex_dtype::{NativePType, Nullability, PType, UnsignedPType};
-use vortex_error::{VortexResult, vortex_bail, vortex_panic};
+use vortex_dtype::{NativePType, Nullability, UnsignedPType};
+use vortex_error::vortex_panic;
 use vortex_utils::aliases::hash_map::{Entry, HashMap};
 
 use super::{DictConstraints, DictEncoder};
@@ -114,10 +114,7 @@ where
     NativeValue<T>: Hash + Eq,
     Code: UnsignedPType,
 {
-    fn encode(&mut self, array: &dyn Array) -> VortexResult<ArrayRef> {
-        if T::PTYPE != PType::try_from(array.dtype())? {
-            vortex_bail!("Can only encode arrays of {}", T::PTYPE);
-        }
+    fn encode(&mut self, array: &dyn Array) -> ArrayRef {
         let mut codes = BufferMut::<Code>::with_capacity(array.len());
 
         array.to_primitive().with_iterator(|it| {
@@ -127,17 +124,17 @@ where
                 };
                 unsafe { codes.push_unchecked(code) }
             }
-        })?;
+        });
 
-        Ok(PrimitiveArray::new(codes, Validity::NonNullable).into_array())
+        PrimitiveArray::new(codes, Validity::NonNullable).into_array()
     }
 
-    fn values(&mut self) -> VortexResult<ArrayRef> {
-        Ok(PrimitiveArray::new(
+    fn reset(&mut self) -> ArrayRef {
+        PrimitiveArray::new(
             self.values.clone(),
             Validity::from_bit_buffer(mem::take(&mut self.values_nulls).freeze(), self.nullability),
         )
-        .into_array())
+        .into_array()
     }
 }
 

--- a/vortex-btrblocks/src/string.rs
+++ b/vortex-btrblocks/src/string.rs
@@ -252,8 +252,8 @@ impl Scheme for FSSTScheme {
         allowed_cascading: usize,
         _excludes: &[StringCode],
     ) -> VortexResult<ArrayRef> {
-        let compressor = fsst_train_compressor(&stats.src.clone().into_array())?;
-        let fsst = fsst_compress(&stats.src.clone().into_array(), &compressor)?;
+        let compressor = fsst_train_compressor(&stats.src);
+        let fsst = fsst_compress(&stats.src, &compressor);
 
         let compressed_original_lengths = IntCompressor::compress(
             &fsst.uncompressed_lengths().to_primitive().narrow()?,

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -517,20 +517,16 @@ async fn filter_or() {
     assert_eq!(result.len(), 1);
     let names = result[0].to_struct().fields()[0].clone();
     assert_eq!(
-        names
-            .to_varbinview()
-            .with_iterator(|iter| iter
-                .flatten()
-                .map(|s| unsafe { String::from_utf8_unchecked(s.to_vec()) })
-                .collect::<Vec<_>>())
-            .unwrap(),
+        names.to_varbinview().with_iterator(|iter| iter
+            .flatten()
+            .map(|s| unsafe { String::from_utf8_unchecked(s.to_vec()) })
+            .collect::<Vec<_>>()),
         vec!["Joseph".to_string(), "Angela".to_string()]
     );
     let ages = result[0].to_struct().fields()[1].clone();
     assert_eq!(
         ages.to_primitive()
-            .with_iterator(|iter| iter.map(|x| x.cloned()).collect::<Vec<_>>())
-            .unwrap(),
+            .with_iterator(|iter| iter.map(|x| x.cloned()).collect::<Vec<_>>()),
         vec![Some(25), None]
     );
 }
@@ -1487,7 +1483,7 @@ async fn test_writer_with_complex_types() -> VortexResult<()> {
     let strings = strings_field.to_varbinview().with_iterator(|iter| {
         iter.map(|s| s.map(|st| unsafe { String::from_utf8_unchecked(st.to_vec()) }))
             .collect::<Vec<_>>()
-    })?;
+    });
     assert_eq!(
         strings,
         vec![

--- a/vortex-layout/src/layouts/dict/writer.rs
+++ b/vortex-layout/src/layouts/dict/writer.rs
@@ -236,7 +236,7 @@ fn dict_encode_stream(
                     let chunks = state.encode(&mut labeler, chunk);
                     drop(labeler);
                     for dict_chunk in chunks {
-                        yield dict_chunk?;
+                        yield dict_chunk;
                     }
                 }
                 None => {
@@ -246,7 +246,7 @@ fn dict_encode_stream(
                     let drained = state.drain_values(&mut labeler);
                     drop(labeler);
                     for dict_chunk in encoded.into_iter().chain(drained.into_iter()) {
-                        yield dict_chunk?;
+                        yield dict_chunk;
                     }
                 }
             }
@@ -260,58 +260,42 @@ struct DictStreamState {
 }
 
 impl DictStreamState {
-    fn encode(
-        &mut self,
-        labeler: &mut DictChunkLabeler,
-        chunk: ArrayRef,
-    ) -> Vec<VortexResult<DictionaryChunk>> {
-        self.try_encode(labeler, chunk)
-            .unwrap_or_else(|e| vec![Err(e)])
-    }
-
-    fn try_encode(
-        &mut self,
-        labeler: &mut DictChunkLabeler,
-        chunk: ArrayRef,
-    ) -> VortexResult<Vec<VortexResult<DictionaryChunk>>> {
+    fn encode(&mut self, labeler: &mut DictChunkLabeler, chunk: ArrayRef) -> Vec<DictionaryChunk> {
         let mut res = Vec::new();
         let mut to_be_encoded = Some(chunk);
         while let Some(remaining) = to_be_encoded.take() {
             match self.encoder.take() {
-                None => match start_encoding(&self.constraints, &remaining)? {
+                None => match start_encoding(&self.constraints, &remaining) {
                     EncodingState::Continue((encoder, encoded)) => {
-                        res.push(Ok(labeler.codes(encoded)));
+                        res.push(labeler.codes(encoded));
                         self.encoder = Some(encoder);
                     }
                     EncodingState::Done((values, encoded, unencoded)) => {
-                        res.push(Ok(labeler.codes(encoded)));
-                        res.push(Ok(labeler.values(values)));
+                        res.push(labeler.codes(encoded));
+                        res.push(labeler.values(values));
                         to_be_encoded = Some(unencoded);
                     }
                 },
-                Some(encoder) => match encode_chunk(encoder, &remaining)? {
+                Some(encoder) => match encode_chunk(encoder, &remaining) {
                     EncodingState::Continue((encoder, encoded)) => {
-                        res.push(Ok(labeler.codes(encoded)));
+                        res.push(labeler.codes(encoded));
                         self.encoder = Some(encoder);
                     }
                     EncodingState::Done((values, encoded, unencoded)) => {
-                        res.push(Ok(labeler.codes(encoded)));
-                        res.push(Ok(labeler.values(values)));
+                        res.push(labeler.codes(encoded));
+                        res.push(labeler.values(values));
                         to_be_encoded = Some(unencoded);
                     }
                 },
             }
         }
-        Ok(res)
+        res
     }
 
-    fn drain_values(
-        &mut self,
-        labeler: &mut DictChunkLabeler,
-    ) -> Vec<VortexResult<DictionaryChunk>> {
+    fn drain_values(&mut self, labeler: &mut DictChunkLabeler) -> Vec<DictionaryChunk> {
         match self.encoder.as_mut() {
             None => Vec::new(),
-            Some(encoder) => vec![encoder.values().map(|val| labeler.values(val))],
+            Some(encoder) => vec![labeler.values(encoder.reset())],
         }
     }
 }
@@ -493,20 +477,17 @@ enum EncodingState {
     Done((ArrayRef, ArrayRef, ArrayRef)),
 }
 
-fn start_encoding(constraints: &DictConstraints, chunk: &dyn Array) -> VortexResult<EncodingState> {
-    let encoder = dict_encoder(chunk, constraints)?;
+fn start_encoding(constraints: &DictConstraints, chunk: &dyn Array) -> EncodingState {
+    let encoder = dict_encoder(chunk, constraints);
     encode_chunk(encoder, chunk)
 }
 
-fn encode_chunk(
-    mut encoder: Box<dyn DictEncoder>,
-    chunk: &dyn Array,
-) -> VortexResult<EncodingState> {
-    let encoded = encoder.encode(chunk)?;
-    Ok(match remainder(chunk, encoded.len()) {
+fn encode_chunk(mut encoder: Box<dyn DictEncoder>, chunk: &dyn Array) -> EncodingState {
+    let encoded = encoder.encode(chunk);
+    match remainder(chunk, encoded.len()) {
         None => EncodingState::Continue((encoder, encoded)),
-        Some(unencoded) => EncodingState::Done((encoder.values()?, encoded, unencoded)),
-    })
+        Some(unencoded) => EncodingState::Done((encoder.reset(), encoded, unencoded)),
+    }
 }
 
 fn remainder(array: &dyn Array, encoded_len: usize) -> Option<ArrayRef> {

--- a/vortex/benches/common_encoding_tree_throughput.rs
+++ b/vortex/benches/common_encoding_tree_throughput.rs
@@ -185,9 +185,9 @@ fn setup_dict_fsst_varbin_string() -> ArrayRef {
         .collect();
 
     // Train and compress unique values with FSST
-    let unique_varbinview = VarBinViewArray::from_iter_str(unique_strings).into_array();
-    let fsst_compressor = fsst_train_compressor(&unique_varbinview).unwrap();
-    let fsst_values = fsst_compress(&unique_varbinview, &fsst_compressor).unwrap();
+    let unique_varbinview = VarBinViewArray::from_iter_str(unique_strings);
+    let fsst_compressor = fsst_train_compressor(&unique_varbinview);
+    let fsst_values = fsst_compress(&unique_varbinview, &fsst_compressor);
 
     // Create codes array (random indices into unique values)
     let codes: Vec<u32> = (0..NUM_VALUES)
@@ -217,9 +217,9 @@ fn setup_dict_fsst_varbin_bp_string() -> ArrayRef {
         .collect();
 
     // Train and compress unique values with FSST
-    let unique_varbinview = VarBinViewArray::from_iter_str(unique_strings).into_array();
-    let fsst_compressor = fsst_train_compressor(&unique_varbinview).unwrap();
-    let fsst = fsst_compress(&unique_varbinview, &fsst_compressor).unwrap();
+    let unique_varbinview = VarBinViewArray::from_iter_str(unique_strings);
+    let fsst_compressor = fsst_train_compressor(&unique_varbinview);
+    let fsst = fsst_compress(&unique_varbinview, &fsst_compressor);
 
     // Compress the VarBin offsets with BitPacked
     let codes = fsst.codes();

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -310,19 +310,19 @@ fn bench_dict_decompress_string(bencher: Bencher) {
 #[divan::bench(name = "fsst_compress_string")]
 fn bench_fsst_compress_string(bencher: Bencher) {
     let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-    let fsst_compressor = fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
+    let fsst_compressor = fsst_train_compressor(&varbinview_arr);
     let nbytes = varbinview_arr.nbytes() as u64;
 
     with_counter!(bencher, nbytes)
         .with_inputs(|| varbinview_arr.clone())
-        .bench_values(|a| fsst_compress(&a.into_array(), &fsst_compressor).unwrap());
+        .bench_values(|a| fsst_compress(&a, &fsst_compressor));
 }
 
 #[divan::bench(name = "fsst_decompress_string")]
 fn bench_fsst_decompress_string(bencher: Bencher) {
     let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-    let fsst_compressor = fsst_train_compressor(&varbinview_arr.clone().into_array()).unwrap();
-    let fsst_array = fsst_compress(&varbinview_arr.clone().into_array(), &fsst_compressor).unwrap();
+    let fsst_compressor = fsst_train_compressor(&varbinview_arr);
+    let fsst_array = fsst_compress(&varbinview_arr, &fsst_compressor);
     let nbytes = varbinview_arr.into_array().nbytes() as u64;
 
     with_counter!(bencher, nbytes)


### PR DESCRIPTION
Long overdue follow up from #4177 / #4412

There was no reason why ArrayAccessor needed to return an error, so we just remove the dummy `Ok()` wrapping and update the types.

Turns out this was quite infectious and also allows us to cleanup a bunch of things with FSST and DictEncoder
