### PR TITLE
fix: cfg disable unix-specific operations

### DIFF
--- a/vortex-io/src/file/mod.rs
+++ b/vortex-io/src/file/mod.rs
@@ -6,7 +6,7 @@ mod driver;
 #[cfg(feature = "object_store")]
 pub mod object_store;
 mod read;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(unix, not(target_arch = "wasm32")))]
 mod std_file;
 
 pub(crate) use driver::*;

--- a/vortex-io/src/file/object_store.rs
+++ b/vortex-io/src/file/object_store.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::io;
+#[cfg(unix)]
 use std::os::unix::fs::FileExt;
 use std::sync::Arc;
 
@@ -129,10 +130,18 @@ impl ReadSource for ObjectStoreIoSource {
                             // The read_exact_at call will either fill the entire buffer or return an error,
                             // ensuring no uninitialized memory is exposed.
                             unsafe { buffer.set_len(len) };
+
                             handle
                                 .spawn_blocking(move || {
-                                    file.read_exact_at(&mut buffer, range.start)?;
-                                    Ok::<_, io::Error>(buffer)
+                                    #[cfg(unix)] {
+                                        file.read_exact_at(&mut buffer, range.start)?;
+                                        Ok::<_, io::Error>(buffer)
+                                    }
+                                    #[cfg(not(unix))] {
+                                        file.seek(range.start)?;
+                                        file.read_exact(&mut buffer)?;
+                                        Ok::<_, io::Error>(buffer)
+                                    }
                                 })
                                 .await
                                 .map_err(io::Error::other)?


### PR DESCRIPTION
Fixes #5311.

I think seek-then-read is safe because we own this File. No one else should be relying on its cursor.

vortex_io::file::std_file appears to only be used in tests.