### PR TITLE
Fix ListViewArray size/offset type mismatch after compression

### DIFF
--- a/vortex-array/src/arrays/primitive/array/cast.rs
+++ b/vortex-array/src/arrays/primitive/array/cast.rs
@@ -43,8 +43,16 @@ impl PrimitiveArray {
         PrimitiveArray::from_byte_buffer(self.byte_buffer().clone(), ptype, self.validity().clone())
     }
 
-    /// Narrow the array to the smallest possible integer type that can represent all values.
-    pub fn narrow(&self) -> VortexResult<PrimitiveArray> {
+    /// Narrow the array to the smallest possible integer type that can represent all values,
+    /// with a minimum byte size constraint.
+    ///
+    /// This method will narrow to the smallest type that can hold the values and has at least
+    /// `min_size` bytes. For example, if values fit in U8 but `min_size` is 2, the result
+    /// will be U16.
+    ///
+    /// # Arguments
+    /// * `min_size` - Minimum byte width for the result type (0 means no constraint)
+    pub fn narrow_min(&self, min_size: usize) -> VortexResult<PrimitiveArray> {
         if !self.ptype().is_int() {
             return Ok(self.clone());
         }
@@ -67,7 +75,7 @@ impl PrimitiveArray {
 
         if min < 0 || max < 0 {
             // Signed
-            if min >= i8::MIN as i64 && max <= i8::MAX as i64 {
+            if min >= i8::MIN as i64 && max <= i8::MAX as i64 && min_size <= 1 {
                 return Ok(cast(
                     self.as_ref(),
                     &DType::Primitive(PType::I8, self.dtype().nullability()),
@@ -75,7 +83,7 @@ impl PrimitiveArray {
                 .to_primitive());
             }
 
-            if min >= i16::MIN as i64 && max <= i16::MAX as i64 {
+            if min >= i16::MIN as i64 && max <= i16::MAX as i64 && min_size <= 2 {
                 return Ok(cast(
                     self.as_ref(),
                     &DType::Primitive(PType::I16, self.dtype().nullability()),
@@ -83,7 +91,7 @@ impl PrimitiveArray {
                 .to_primitive());
             }
 
-            if min >= i32::MIN as i64 && max <= i32::MAX as i64 {
+            if min >= i32::MIN as i64 && max <= i32::MAX as i64 && min_size <= 4 {
                 return Ok(cast(
                     self.as_ref(),
                     &DType::Primitive(PType::I32, self.dtype().nullability()),
@@ -92,7 +100,7 @@ impl PrimitiveArray {
             }
         } else {
             // Unsigned
-            if max <= u8::MAX as i64 {
+            if max <= u8::MAX as i64 && min_size <= 1 {
                 return Ok(cast(
                     self.as_ref(),
                     &DType::Primitive(PType::U8, self.dtype().nullability()),
@@ -100,7 +108,7 @@ impl PrimitiveArray {
                 .to_primitive());
             }
 
-            if max <= u16::MAX as i64 {
+            if max <= u16::MAX as i64 && min_size <= 2 {
                 return Ok(cast(
                     self.as_ref(),
                     &DType::Primitive(PType::U16, self.dtype().nullability()),
@@ -108,7 +116,7 @@ impl PrimitiveArray {
                 .to_primitive());
             }
 
-            if max <= u32::MAX as i64 {
+            if max <= u32::MAX as i64 && min_size <= 4 {
                 return Ok(cast(
                     self.as_ref(),
                     &DType::Primitive(PType::U32, self.dtype().nullability()),
@@ -118,6 +126,11 @@ impl PrimitiveArray {
         }
 
         Ok(self.clone())
+    }
+
+    /// Narrow the array to the smallest possible integer type that can represent all values.
+    pub fn narrow(&self) -> VortexResult<PrimitiveArray> {
+        self.narrow_min(0)
     }
 }
 
@@ -227,5 +240,69 @@ mod tests {
         // Empty arrays should not have their validity changed
         assert_eq!(result.validity, Validity::AllInvalid);
         assert_eq!(result2.validity, Validity::NonNullable);
+    }
+
+    #[rstest]
+    #[case(vec![0_i64, 255], 0, PType::U8)] // No constraint, fits in U8
+    #[case(vec![0_i64, 255], 1, PType::U8)] // Min 1 byte, fits in U8
+    #[case(vec![0_i64, 255], 2, PType::U16)] // Min 2 bytes, needs U16
+    #[case(vec![0_i64, 255], 4, PType::U32)] // Min 4 bytes, needs U32
+    #[case(vec![0_i64, 100], 2, PType::U16)] // Min 2 bytes, even though values fit in U8
+    #[case(vec![0_i64, 127], 0, PType::U8)] // No constraint, unsigned U8
+    #[case(vec![-1_i64, 127], 0, PType::I8)] // No constraint, signed I8
+    #[case(vec![-1_i64, 127], 2, PType::I16)] // Min 2 bytes, needs I16
+    #[case(vec![0_i64, 256], 1, PType::U16)] // Naturally needs U16, min 1 byte
+    #[case(vec![0_i64, 256], 2, PType::U16)] // Naturally needs U16, min 2 bytes
+    fn test_narrow_min(
+        #[case] values: Vec<i64>,
+        #[case] min_size: usize,
+        #[case] expected_ptype: PType,
+    ) {
+        let array = PrimitiveArray::from_iter(values);
+        let result = array.narrow_min(min_size).unwrap();
+        assert_eq!(
+            result.ptype(),
+            expected_ptype,
+            "narrow_min({}) failed",
+            min_size
+        );
+    }
+
+    #[test]
+    fn test_narrow_min_preserves_values() {
+        // Values fit in U8 but we request minimum 2 bytes
+        let values = vec![0_u32, 100, 200];
+        let array = PrimitiveArray::from_iter(values);
+        let result = array.narrow_min(2).unwrap();
+
+        // Should be U16
+        assert_eq!(result.ptype(), PType::U16);
+        // Values should be preserved
+        let result_values: Vec<u16> = result.as_slice::<u16>().to_vec();
+        assert_eq!(result_values, vec![0_u16, 100, 200]);
+    }
+
+    #[test]
+    fn test_narrow_min_signed() {
+        // Values fit in I8 but we request minimum 4 bytes
+        let values = vec![-50_i64, 0, 50];
+        let array = PrimitiveArray::from_iter(values);
+        let result = array.narrow_min(4).unwrap();
+
+        // Should be I32
+        assert_eq!(result.ptype(), PType::I32);
+        let result_values: Vec<i32> = result.as_slice::<i32>().to_vec();
+        assert_eq!(result_values, vec![-50_i32, 0, 50]);
+    }
+
+    #[test]
+    fn test_narrow_min_respects_natural_size() {
+        // Values naturally need U32, requesting min 2 bytes shouldn't downgrade
+        let values = vec![0_u64, u32::MAX as u64];
+        let array = PrimitiveArray::from_iter(values);
+        let result = array.narrow_min(2).unwrap();
+
+        // Should stay U32 (can't fit in U16)
+        assert_eq!(result.ptype(), PType::U32);
     }
 }

--- a/vortex-layout/src/layouts/compact.rs
+++ b/vortex-layout/src/layouts/compact.rs
@@ -146,16 +146,17 @@ impl CompactCompressor {
                 let sizes_ptype = narrowed_sizes.ptype();
                 let offsets_ptype = narrowed_offsets.ptype();
 
-                let (final_offsets, final_sizes) = if sizes_ptype.byte_width() > offsets_ptype.byte_width() {
-                    // Cast offsets to match sizes type
-                    let casted_offsets = vortex_array::compute::cast(
-                        &narrowed_offsets.into_array(),
-                        narrowed_sizes.dtype(),
-                    )?;
-                    (casted_offsets, narrowed_sizes.into_array())
-                } else {
-                    (narrowed_offsets.into_array(), narrowed_sizes.into_array())
-                };
+                let (final_offsets, final_sizes) =
+                    if sizes_ptype.byte_width() > offsets_ptype.byte_width() {
+                        // Cast offsets to match sizes type
+                        let casted_offsets = vortex_array::compute::cast(
+                            &narrowed_offsets.into_array(),
+                            narrowed_sizes.dtype(),
+                        )?;
+                        (casted_offsets, narrowed_sizes.into_array())
+                    } else {
+                        (narrowed_offsets.into_array(), narrowed_sizes.into_array())
+                    };
 
                 let compressed_offsets = self.compress(&final_offsets)?;
                 let compressed_sizes = self.compress(&final_sizes)?;
@@ -300,8 +301,7 @@ mod tests {
         )
         .into_array();
 
-        let listview =
-            ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).unwrap();
+        let listview = ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable);
 
         // This should not panic - the fix ensures compatible types
         let compressed = compressor.compress(listview.as_ref()).unwrap();

--- a/vortex-layout/src/layouts/compact.rs
+++ b/vortex-layout/src/layouts/compact.rs
@@ -138,28 +138,18 @@ impl CompactCompressor {
                 // Note that since the type of our offsets and sizes is not encoded in our `DType`,
                 // we can narrow the widths. However, we must ensure that the size type can fit
                 // within the offset type, so we need to determine compatible types.
-                let narrowed_offsets = listview.offsets().to_primitive().narrow()?;
+                // First narrow sizes to find the minimum size needed
                 let narrowed_sizes = listview.sizes().to_primitive().narrow()?;
+                let sizes_byte_width = narrowed_sizes.ptype().byte_width();
 
-                // Ensure compatible types: if sizes have a larger type than offsets,
-                // we need to cast offsets to match
-                let sizes_ptype = narrowed_sizes.ptype();
-                let offsets_ptype = narrowed_offsets.ptype();
+                // Then narrow offsets to at least the same width as sizes
+                let narrowed_offsets = listview
+                    .offsets()
+                    .to_primitive()
+                    .narrow_min(sizes_byte_width)?;
 
-                let (final_offsets, final_sizes) =
-                    if sizes_ptype.byte_width() > offsets_ptype.byte_width() {
-                        // Cast offsets to match sizes type
-                        let casted_offsets = vortex_array::compute::cast(
-                            &narrowed_offsets.into_array(),
-                            narrowed_sizes.dtype(),
-                        )?;
-                        (casted_offsets, narrowed_sizes.into_array())
-                    } else {
-                        (narrowed_offsets.into_array(), narrowed_sizes.into_array())
-                    };
-
-                let compressed_offsets = self.compress(&final_offsets)?;
-                let compressed_sizes = self.compress(&final_sizes)?;
+                let compressed_offsets = self.compress(&narrowed_offsets.into_array())?;
+                let compressed_sizes = self.compress(&narrowed_sizes.into_array())?;
 
                 // SAFETY: Since compression does not change the logical values of arrays, this is
                 // effectively the same array but represented differently, so all invariants that

--- a/vortex-layout/src/layouts/compact.rs
+++ b/vortex-layout/src/layouts/compact.rs
@@ -136,11 +136,29 @@ impl CompactCompressor {
                 let compressed_elems = self.compress(listview.elements())?;
 
                 // Note that since the type of our offsets and sizes is not encoded in our `DType`,
-                // we can narrow the widths.
-                let compressed_offsets =
-                    self.compress(&listview.offsets().to_primitive().narrow()?.into_array())?;
-                let compressed_sizes =
-                    self.compress(&listview.sizes().to_primitive().narrow()?.into_array())?;
+                // we can narrow the widths. However, we must ensure that the size type can fit
+                // within the offset type, so we need to determine compatible types.
+                let narrowed_offsets = listview.offsets().to_primitive().narrow()?;
+                let narrowed_sizes = listview.sizes().to_primitive().narrow()?;
+
+                // Ensure compatible types: if sizes have a larger type than offsets,
+                // we need to cast offsets to match
+                let sizes_ptype = narrowed_sizes.ptype();
+                let offsets_ptype = narrowed_offsets.ptype();
+
+                let (final_offsets, final_sizes) = if sizes_ptype.byte_width() > offsets_ptype.byte_width() {
+                    // Cast offsets to match sizes type
+                    let casted_offsets = vortex_array::compute::cast(
+                        &narrowed_offsets.into_array(),
+                        narrowed_sizes.dtype(),
+                    )?;
+                    (casted_offsets, narrowed_sizes.into_array())
+                } else {
+                    (narrowed_offsets.into_array(), narrowed_sizes.into_array())
+                };
+
+                let compressed_offsets = self.compress(&final_offsets)?;
+                let compressed_sizes = self.compress(&final_sizes)?;
 
                 // SAFETY: Since compression does not change the logical values of arrays, this is
                 // effectively the same array but represented differently, so all invariants that
@@ -250,5 +268,46 @@ mod tests {
 
             assert_arrays_eq!(decompressed_array.as_ref(), columns[i].as_ref());
         }
+    }
+
+    #[test]
+    fn test_listview_narrow_compatible_types() {
+        use vortex_array::arrays::ListViewArray;
+
+        let compressor = CompactCompressor::default();
+
+        // Create a ListViewArray where after narrowing:
+        // - offsets would narrow to U8 (all values < 255)
+        // - sizes would narrow to U16 (some values > 255)
+        // This reproduces the fuzzer crash where sizes had a larger type than offsets
+        let elements = PrimitiveArray::new(
+            buffer![1u32; 300], // 300 elements of value 1
+            Validity::NonNullable,
+        )
+        .into_array();
+
+        // Offsets that fit in U8 (all < 255)
+        let offsets = PrimitiveArray::new(
+            buffer![0u32, 10, 20, 30], // All offsets < 255
+            Validity::NonNullable,
+        )
+        .into_array();
+
+        // Sizes where at least one exceeds U8 max (255)
+        let sizes = PrimitiveArray::new(
+            buffer![10u32, 10, 10, 260], // Last size is 260 > 255, requires U16
+            Validity::NonNullable,
+        )
+        .into_array();
+
+        let listview =
+            ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).unwrap();
+
+        // This should not panic - the fix ensures compatible types
+        let compressed = compressor.compress(listview.as_ref()).unwrap();
+
+        // Verify the compressed array is still valid
+        let decompressed = compressed.to_canonical().into_array();
+        assert_eq!(decompressed.len(), 4);
     }
 }


### PR DESCRIPTION
Fixes issue where CompactCompressor independently narrowed offset and size arrays for ListViewArray, resulting in incompatible types (e.g., U8 offsets with U16 sizes).

## Solution

This PR introduces a new `narrow_min(min_size: usize)` method on `PrimitiveArray` that narrows to the smallest type that can hold the values while respecting a minimum byte width constraint. The existing `narrow()` method now calls `narrow_min(0)`.

The fix ensures that offsets are narrowed to at least the same byte width as sizes, preventing type mismatches without the need for explicit casting.

### Changes:
- Added `PrimitiveArray::narrow_min(min_size: usize)` method
- Refactored `narrow()` to call `narrow_min(0)` 
- Simplified ListViewArray narrowing logic in `CompactCompressor`
- Added comprehensive tests for the new functionality

This resolves the fuzzing crash:
\`'size type U16 (max 65535) must fit within offset type U8 (max 255)'\`

Includes regression test that reproduces the crash scenario.

@connortsui20 - Does this approach using \`narrow_min\` look good to you? It's cleaner than the cast-based approach and ensures compatible types by construction.

Fixes #5322