### PR TITLE
chore: drop duckdb install from gh actions

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -56,12 +56,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install DuckDB
-        run: |
-          wget -qO- https://github.com/duckdb/duckdb/releases/download/v1.3.2/duckdb_cli-linux-amd64.zip | funzip > duckdb
-          chmod +x duckdb
-          echo "$PWD" >> $GITHUB_PATH
-
       - name: Build binary
         shell: bash
         env:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -57,12 +57,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install DuckDB
-        run: |
-          wget -qO- https://github.com/duckdb/duckdb/releases/download/v1.3.2/duckdb_cli-linux-amd64.zip | funzip > duckdb
-          chmod +x duckdb
-          echo "$PWD" >> $GITHUB_PATH
-
       - name: Build binary
         shell: bash
         env:

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -134,11 +134,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install DuckDB
-        run: |
-          wget -qO- https://github.com/duckdb/duckdb/releases/download/v1.3.2/duckdb_cli-linux-amd64.zip | funzip > duckdb
-          chmod +x duckdb
-          echo "$PWD" >> $GITHUB_PATH
       - name: Build binary
         shell: bash
         env:


### PR DESCRIPTION
~~The binary is no longer used in our SQL benchmarks.~~ => still used in `compress`