### PR TITLE
fix: add permissions to fuzzer fix automation workflow

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -129,6 +129,11 @@ jobs:
     name: "Attempt Fix for IO Fuzz Crash"
     needs: report-io-fuzz-failures
     if: needs.report-io-fuzz-failures.outputs.issue_number != ''
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
     uses: ./.github/workflows/fuzzer-fix-automation.yml
     with:
       issue_number: ${{ needs.report-io-fuzz-failures.outputs.issue_number }}


### PR DESCRIPTION
## Summary

Fixes the GitHub Actions workflow validation error in `fuzz.yml` by adding the required permissions to the `attempt-fix-io` job.

## Problem

The workflow was failing validation with:
```
The nested job 'attempt-fix' is requesting 'contents: write, issues: write, 
pull-requests: write, id-token: write', but is only allowed 'contents: read, 
issues: none, pull-requests: none, id-token: none'.
```

## Solution

Added explicit `permissions` block to the `attempt-fix-io` job that calls `fuzzer-fix-automation.yml`. When using `workflow_call`, the called workflow inherits permissions from the caller, so we need to explicitly grant the required permissions.

## Changes

- Added `permissions` block to `attempt-fix-io` job in `.github/workflows/fuzz.yml`:
  - `contents: write`
  - `issues: write`
  - `pull-requests: write`
  - `id-token: write`

## Test plan

- [x] Workflow validation should pass
- [ ] Trigger the fuzz workflow on this branch to verify it works correctly

Generated with [Claude Code](https://claude.com/claude-code)