### PR TITLE
chore: bug is not a sufficient label

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -28,7 +28,6 @@ jobs:
         run: |
           REQUIRED_LABELS=(
             "chore"
-            "bug"
             "feature"
             "fix"
             "performance"


### PR DESCRIPTION
Labels should correspond to a category in release-drafter.yml.

This actually happened in the wild: PR #5235 was dumped into a generic "Changes" section of [release 0.55.0](https://github.com/vortex-data/vortex/releases/tag/0.55.0) rather than the bug fix section.

Further in the past, #3587 was likewise uncategorized in [0.40.0](https://github.com/vortex-data/vortex/releases/tag/0.40.0).