### PR TITLE
chore: gpu_bitunpack bench is behind cfg flag

### DIFF
--- a/vortex-gpu/benches/gpu_bitunpack.rs
+++ b/vortex-gpu/benches/gpu_bitunpack.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 #![allow(clippy::unwrap_used)]
+#![cfg(gpu_unstable)]
 
 use std::sync::Arc;
 use std::time::Duration;


### PR DESCRIPTION
Signed-off-by: Robert Kruszewski <github@robertk.io>
