### PR TITLE
Use the specified concurrency value when reading from a ObjectStoreIoSource

### DIFF
--- a/vortex-io/src/file/object_store.rs
+++ b/vortex-io/src/file/object_store.rs
@@ -98,6 +98,7 @@ impl ReadSource for ObjectStoreIoSource {
         requests: BoxStream<'static, IoRequest>,
     ) -> BoxFuture<'static, ()> {
         let self2 = self.clone();
+        let concurrency = self.io.concurrency;
         requests
             .map(move |req| {
                 let handle = self.handle.clone();
@@ -170,7 +171,7 @@ impl ReadSource for ObjectStoreIoSource {
                 async move { req.resolve(Compat::new(read).await) }
             })
             .map(move |f| self2.handle.spawn(f))
-            .buffer_unordered(CONCURRENCY)
+            .buffer_unordered(concurrency)
             .collect::<()>()
             .boxed()
     }


### PR DESCRIPTION
Previously, `ObjectStoreIoSource` always used the default value, even if it was overridden using `ObjectStoreReadSource::with_concurrency`.

Sorry, I have no idea how to nicely test this.