### PR TITLE
chore[vortex-array]: rename `reduce_children` -> `reduce`

### DIFF
--- a/vortex-array/src/array/operator.rs
+++ b/vortex-array/src/array/operator.rs
@@ -27,7 +27,7 @@ pub trait ArrayOperator: 'static + Send + Sync {
     fn execute_batch(&self, selection: &Mask, ctx: &mut dyn ExecutionCtx) -> VortexResult<Vector>;
 
     /// Optimize the array by running the optimization rules.
-    fn reduce_children(&self) -> VortexResult<Option<ArrayRef>>;
+    fn reduce(&self) -> VortexResult<Option<ArrayRef>>;
 
     /// Optimize the array by pushing down a parent array.
     fn reduce_parent(&self, parent: &ArrayRef, child_idx: usize) -> VortexResult<Option<ArrayRef>>;
@@ -48,8 +48,8 @@ impl ArrayOperator for Arc<dyn Array> {
         self.as_ref().execute_batch(selection, ctx)
     }
 
-    fn reduce_children(&self) -> VortexResult<Option<ArrayRef>> {
-        self.as_ref().reduce_children()
+    fn reduce(&self) -> VortexResult<Option<ArrayRef>> {
+        self.as_ref().reduce()
     }
 
     fn reduce_parent(&self, parent: &ArrayRef, child_idx: usize) -> VortexResult<Option<ArrayRef>> {
@@ -96,8 +96,8 @@ impl<V: VTable> ArrayOperator for ArrayAdapter<V> {
         Ok(vector)
     }
 
-    fn reduce_children(&self) -> VortexResult<Option<ArrayRef>> {
-        <V::OperatorVTable as OperatorVTable<V>>::reduce_children(&self.0)
+    fn reduce(&self) -> VortexResult<Option<ArrayRef>> {
+        <V::OperatorVTable as OperatorVTable<V>>::reduce(&self.0)
     }
 
     fn reduce_parent(&self, parent: &ArrayRef, child_idx: usize) -> VortexResult<Option<ArrayRef>> {

--- a/vortex-array/src/compute/arrays/arithmetic.rs
+++ b/vortex-array/src/compute/arrays/arithmetic.rs
@@ -178,7 +178,7 @@ impl SerdeVTable<ArithmeticVTable> for ArithmeticVTable {
 }
 
 impl OperatorVTable<ArithmeticVTable> for ArithmeticVTable {
-    fn reduce_children(array: &ArithmeticArray) -> VortexResult<Option<ArrayRef>> {
+    fn reduce(array: &ArithmeticArray) -> VortexResult<Option<ArrayRef>> {
         match (array.lhs.as_constant(), array.rhs.as_constant()) {
             // If both sides are constant, we compute the value now.
             (Some(lhs), Some(rhs)) => {

--- a/vortex-array/src/vtable/operator.rs
+++ b/vortex-array/src/vtable/operator.rs
@@ -70,16 +70,16 @@ pub trait OperatorVTable<V: VTable> {
         )
     }
 
-    /// Attempt to optimize this array by analyzing its children.
+    /// Attempt to optimize this array tree looking at itself and its children.
     ///
     /// For example, if all the children are constant, this function should perform constant
     /// folding and return a constant operator.
     ///
     /// This function should typically be implemented only for self-contained optimizations based
-    /// on child properties.
+    /// Self and child properties.
     ///
     /// Returns `None` if no optimization is possible.
-    fn reduce_children(_array: &V::Array) -> VortexResult<Option<ArrayRef>> {
+    fn reduce(_array: &V::Array) -> VortexResult<Option<ArrayRef>> {
         Ok(None)
     }
 


### PR DESCRIPTION
`reduce_children` is confusing this is reduce/simplify in datafusion.