### PR TITLE
DNM check semver on PR

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,0 +1,24 @@
+name: Semver check
+on:
+  pull_request: { }
+  push:
+    branches: [ "develop" ]
+
+jobs:
+  semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: runs-on/action@v2
+        with:
+          sccache: s3
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-rust
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - run:
+          echo "BASELINE=$(gh release view --json tagName -t '{{.tagName}}')" >> $GITHUB_OUTPUT
+        id: latest_release
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          baseline-version: '${{ steps.latest_release.outputs.BASELINE}}'

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,8 +1,8 @@
 name: Semver check
 on:
-  pull_request: { }
+  pull_request: {}
   push:
-    branches: [ "develop" ]
+    branches: ["develop"]
 
 jobs:
   semver:
@@ -23,4 +23,5 @@ jobs:
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
-          baseline-version: '${{ steps.latest_release.outputs.BASELINE}}'
+          baseline-version: ${{ steps.latest_release.outputs.BASELINE}}
+          feature-group: default-features

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -18,6 +18,8 @@ jobs:
       - run:
           echo "BASELINE=$(gh release view --json tagName -t '{{.tagName}}')" >> $GITHUB_OUTPUT
         id: latest_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Automatically provided token
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:


### PR DESCRIPTION
Seems like this and cargo public-api are the two most common ones, and this one is more popular/more configurable.

There's some friction with how we use `0.1.0` as our Cargo.toml versions everywhere which means that we need to explicitly lookup and pass the latest GH release to the check