### PR TITLE
fix: cast must cast its stats too

### DIFF
--- a/vortex-array/src/expr/exprs/cast.rs
+++ b/vortex-array/src/expr/exprs/cast.rs
@@ -91,7 +91,9 @@ impl VTable for Cast {
         expr: &ExpressionView<Self>,
         catalog: &mut dyn StatsCatalog,
     ) -> Option<Expression> {
-        expr.children()[0].stat_max(catalog)
+        expr.child(0)
+            .stat_max(catalog)
+            .map(|x| cast(x, expr.data().clone()))
     }
 
     fn stat_min(
@@ -99,7 +101,9 @@ impl VTable for Cast {
         expr: &ExpressionView<Self>,
         catalog: &mut dyn StatsCatalog,
     ) -> Option<Expression> {
-        expr.children()[0].stat_min(catalog)
+        expr.child(0)
+            .stat_min(catalog)
+            .map(|x| cast(x, expr.data().clone()))
     }
 
     fn stat_nan_count(
@@ -107,7 +111,7 @@ impl VTable for Cast {
         expr: &ExpressionView<Self>,
         catalog: &mut dyn StatsCatalog,
     ) -> Option<Expression> {
-        expr.children()[0].stat_nan_count(catalog)
+        expr.child(0).stat_nan_count(catalog)
     }
 
     fn stat_field_path(&self, expr: &ExpressionView<Self>) -> Option<FieldPath> {

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -14,7 +14,8 @@ use vortex_array::arrays::{
     StructArray, VarBinArray, VarBinViewArray,
 };
 use vortex_array::expr::{
-    Pack, PackOptions, VTableExt, and, eq, get_item, gt, gt_eq, lit, lt, lt_eq, or, root, select,
+    Pack, PackOptions, VTableExt, and, cast, eq, get_item, gt, gt_eq, lit, lt, lt_eq, or, root,
+    select,
 };
 use vortex_array::stats::PRUNING_STATS;
 use vortex_array::stream::{ArrayStreamAdapter, ArrayStreamExt};
@@ -419,6 +420,45 @@ async fn test_empty_varbin_array_roundtrip() {
 
     assert_eq!(result.len(), 0);
     assert_eq!(result.dtype(), st.dtype());
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn issue_5385_filter_casted_column() {
+    let array = StructArray::try_from_iter([("x", buffer![1u8, 2, 3, 4, 5])])
+        .unwrap()
+        .into_array();
+
+    let mut buf = ByteBufferMut::empty();
+    SESSION
+        .write_options()
+        .write(&mut buf, array.to_array_stream())
+        .await
+        .unwrap();
+
+    let result = SESSION
+        .open_options()
+        .open_buffer(buf)
+        .unwrap()
+        .scan()
+        .unwrap()
+        .with_filter(eq(
+            cast(
+                get_item("x", root()),
+                DType::Primitive(PType::U16, Nullability::NonNullable),
+            ),
+            lit(1u16),
+        ))
+        .into_array_stream()
+        .unwrap()
+        .read_all()
+        .await
+        .unwrap();
+
+    assert_arrays_eq!(
+        result,
+        StructArray::try_from_iter([("x", buffer![1u8])]).unwrap()
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #5385.

On develop:

```
thread 'tests::issue_5385_filter_casted_column' panicked at vortex-file/src/tests.rs:456:10:
called `Result::unwrap()` on an `Err` value: Cannot compare different DTypes u8? and u16
Backtrace:
disabled backtrace
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```