### PR TITLE
chore: better expression error messages on failure

### DIFF
--- a/vortex-error/src/lib.rs
+++ b/vortex-error/src/lib.rs
@@ -181,7 +181,7 @@ impl Display for VortexError {
                 write!(f, "{msg}\nBacktrace:\n{backtrace}")
             }
             VortexError::Context(msg, inner) => {
-                write!(f, "{msg}: {inner}")
+                write!(f, "{msg}:\n  {inner}")
             }
             VortexError::Shared(inner) => Display::fmt(inner, f),
             VortexError::ArrowError(err, backtrace) => {

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -199,8 +199,13 @@ impl LayoutReader for ChunkedReader {
 
         for (chunk_idx, chunk_range, mask_range) in self.ranges(row_range) {
             let chunk_reader = self.chunk_reader(chunk_idx)?;
-            let chunk_eval =
-                chunk_reader.pruning_evaluation(&chunk_range, expr, mask.slice(mask_range))?;
+            let chunk_eval = chunk_reader
+                .pruning_evaluation(&chunk_range, expr, mask.slice(mask_range))
+                .map_err(|err| {
+                    err.with_context(format!(
+                        "While evaluating pruning filter on chunk {chunk_idx}"
+                    ))
+                })?;
 
             chunk_evals.push(chunk_eval);
         }
@@ -236,8 +241,11 @@ impl LayoutReader for ChunkedReader {
 
         for (chunk_idx, chunk_range, mask_range) in self.ranges(row_range) {
             let chunk_reader = self.chunk_reader(chunk_idx)?;
-            let chunk_eval =
-                chunk_reader.filter_evaluation(&chunk_range, expr, mask.slice(mask_range))?;
+            let chunk_eval = chunk_reader
+                .filter_evaluation(&chunk_range, expr, mask.slice(mask_range))
+                .map_err(|err| {
+                    err.with_context(format!("While evaluating filter on chunk {chunk_idx}"))
+                })?;
             chunk_evals.push(chunk_eval);
         }
 
@@ -269,8 +277,11 @@ impl LayoutReader for ChunkedReader {
 
         for (chunk_idx, chunk_range, mask_range) in self.ranges(row_range) {
             let chunk_reader = self.chunk_reader(chunk_idx)?;
-            let chunk_eval =
-                chunk_reader.projection_evaluation(&chunk_range, expr, mask.slice(mask_range))?;
+            let chunk_eval = chunk_reader
+                .projection_evaluation(&chunk_range, expr, mask.slice(mask_range))
+                .map_err(|err| {
+                    err.with_context(format!("While evaluating projection on chunk {chunk_idx}"))
+                })?;
             chunk_evals.push(chunk_eval);
         }
 

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -190,7 +190,10 @@ impl LayoutReader for DictReader {
         mask: MaskFuture,
     ) -> VortexResult<BoxFuture<'static, VortexResult<ArrayRef>>> {
         let values_eval = self.values_eval(root());
-        let codes_eval = self.codes.projection_evaluation(row_range, &root(), mask)?;
+        let codes_eval = self
+            .codes
+            .projection_evaluation(row_range, &root(), mask)
+            .map_err(|err| err.with_context("While evaluating projection on codes"))?;
         let expr = expr.clone();
 
         Ok(async move {

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -137,11 +137,16 @@ impl LayoutReader for FlatReader {
                 // TODO(joe): fixme casting null to false is *VERY* unsound, if the expression in the filter
                 // can inspect nulls (e.g. `is_null`).
                 // you will need to call the array evaluation instead of the mask evaluation.
-                let array_mask = expr.evaluate(&array)?.try_to_mask_fill_null_false()?;
+                let array_mask = expr
+                    .evaluate(&array)
+                    .map_err(|err| err.with_context(format!("While evaluating filter {}", expr)))?
+                    .try_to_mask_fill_null_false()?;
                 mask.intersect_by_rank(&array_mask)
             } else {
                 // Evaluate all rows, avoiding the more expensive rank intersection.
-                array = expr.evaluate(&array)?;
+                array = expr
+                    .evaluate(&array)
+                    .map_err(|err| err.with_context(format!("While evaluating filter {}", expr)))?;
                 let array_mask = array.try_to_mask_fill_null_false()?;
                 mask.bitand(&array_mask)
             };
@@ -190,7 +195,9 @@ impl LayoutReader for FlatReader {
 
             // Evaluate the projection expression.
             if !is_root(&expr) {
-                array = expr.evaluate(&array)?;
+                array = expr.evaluate(&array).map_err(|err| {
+                    err.with_context(format!("While evaluating projection {}", expr))
+                })?;
             }
 
             Ok(array)

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -238,7 +238,10 @@ impl LayoutReader for StructReader {
         match &self.partition_expr(expr.clone()) {
             Partitioned::Single(name, partition) => self
                 .field_reader(name)?
-                .pruning_evaluation(row_range, partition, mask),
+                .pruning_evaluation(row_range, partition, mask)
+                .map_err(|err| {
+                    err.with_context(format!("While evaluating pruning filter partition {name}"))
+                }),
             Partitioned::Multi(_) => {
                 // TODO(ngates): if all partitions are boolean, we can use a pruning evaluation. Otherwise
                 //  there's not much we can do? Maybe... it's complicated...
@@ -257,16 +260,27 @@ impl LayoutReader for StructReader {
         match &self.partition_expr(expr.clone()) {
             Partitioned::Single(name, partition) => self
                 .field_reader(name)?
-                .filter_evaluation(row_range, partition, mask),
+                .filter_evaluation(row_range, partition, mask)
+                .map_err(|err| {
+                    err.with_context(format!("While evaluating filter partition {name}"))
+                }),
             Partitioned::Multi(partitioned) => partitioned.clone().into_mask_future(
                 mask,
                 |name, expr, mask| {
                     self.field_reader(name)?
                         .filter_evaluation(row_range, expr, mask)
+                        .map_err(|err| {
+                            err.with_context(format!("While evaluating filter partition {name}"))
+                        })
                 },
                 |name, expr, mask| {
                     self.field_reader(name)?
                         .projection_evaluation(row_range, expr, mask)
+                        .map_err(|err| {
+                            err.with_context(format!(
+                                "While evaluating projection partition {name}"
+                            ))
+                        })
                 },
             ),
         }
@@ -287,7 +301,10 @@ impl LayoutReader for StructReader {
         let (projected, is_pack_merge) = match &self.partition_expr(expr.clone()) {
             Partitioned::Single(name, partition) => (
                 self.field_reader(name)?
-                    .projection_evaluation(row_range, partition, mask_fut)?,
+                    .projection_evaluation(row_range, partition, mask_fut)
+                    .map_err(|err| {
+                        err.with_context(format!("While evaluating projection partition {name}"))
+                    })?,
                 partition.is::<Pack>() || partition.is::<Merge>(),
             ),
 
@@ -297,6 +314,11 @@ impl LayoutReader for StructReader {
                     .into_array_future(mask_fut, |name, expr, mask| {
                         self.field_reader(name)?
                             .projection_evaluation(row_range, expr, mask)
+                            .map_err(|err| {
+                                err.with_context(format!(
+                                    "While evaluating projection partition {name}"
+                                ))
+                            })
                     })?,
                 partitioned.root.is::<Pack>() || partitioned.root.is::<Merge>(),
             ),

--- a/vortex-layout/src/layouts/zoned/reader.rs
+++ b/vortex-layout/src/layouts/zoned/reader.rs
@@ -350,7 +350,7 @@ impl PruningResult {
         let next_mask = self.zone_map.prune(&self.predicate).map_err(|err| {
             err.with_context(format!(
                 "While evaluating pruning predicate {}",
-                predicate, expr
+                self.predicate
             ))
         })?;
         *guard = (version, next_mask.clone());

--- a/vortex-layout/src/layouts/zoned/reader.rs
+++ b/vortex-layout/src/layouts/zoned/reader.rs
@@ -146,7 +146,12 @@ impl ZonedReader {
                     Some(
                         async move {
                             let zone_map = zone_map.await?;
-                            let initial_mask = zone_map.prune(&predicate)?;
+                            let initial_mask = zone_map.prune(&predicate).map_err(|err| {
+                                err.with_context(format!(
+                                    "While evaluating pruning predicate {} (derived from {})",
+                                    predicate, expr
+                                ))
+                            })?;
                             Ok(Arc::new(PruningResult {
                                 zone_map,
                                 predicate,
@@ -342,7 +347,12 @@ impl PruningResult {
             self.predicate
         );
 
-        let next_mask = self.zone_map.prune(&self.predicate)?;
+        let next_mask = self.zone_map.prune(&self.predicate).map_err(|err| {
+            err.with_context(format!(
+                "While evaluating pruning predicate {}",
+                predicate, expr
+            ))
+        })?;
         *guard = (version, next_mask.clone());
 
         Ok(next_mask)

--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -139,7 +139,13 @@ impl ZoneMap {
     /// All zones where the predicate evaluates to `true` can be skipped entirely.
     pub fn prune(&self, predicate: &Expression) -> VortexResult<Mask> {
         predicate
-            .evaluate(&self.array.to_array())?
+            .evaluate(&self.array.to_array())
+            .map_err(|err| {
+                err.with_context(format!(
+                    "While evaluating ZoneMap pruning filter {}",
+                    predicate
+                ))
+            })?
             .try_to_mask_fill_null_false()
     }
 }

--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -139,13 +139,7 @@ impl ZoneMap {
     /// All zones where the predicate evaluates to `true` can be skipped entirely.
     pub fn prune(&self, predicate: &Expression) -> VortexResult<Mask> {
         predicate
-            .evaluate(&self.array.to_array())
-            .map_err(|err| {
-                err.with_context(format!(
-                    "While evaluating ZoneMap pruning filter {}",
-                    predicate
-                ))
-            })?
+            .evaluate(&self.array.to_array())?
             .try_to_mask_fill_null_false()
     }
 }


### PR DESCRIPTION
For example, executing a scan with a filter like `root() > pa.scalar(3.3, type=pa.float16())`, you currently get this error:

```
Cannot compare different DTypes f64? and f16?
```

Which is fine, but, particularly when these expressions are machine generated, you are missing necessary context. This is a bit better:

```
Vortex error: While evaluating ZoneMap pruning filter ((($.nan_count = 0u64) and (0u64 = 0u64)) and ($.max <= 3.3007813f16)):
  Cannot compare different DTypes f64? and f16?
```