### PR TITLE
fix: vx_struct_fields_field_dtype takes usize instead of u64

### DIFF
--- a/vortex-ffi/cinclude/vortex.h
+++ b/vortex-ffi/cinclude/vortex.h
@@ -805,7 +805,7 @@ const vx_string *vx_struct_fields_field_name(const vx_struct_fields *dtype, size
  *
  * Returns null if the index is out of bounds or if the field dtype cannot be parsed.
  */
-const vx_dtype *vx_struct_fields_field_dtype(const vx_struct_fields *dtype, uint64_t idx);
+const vx_dtype *vx_struct_fields_field_dtype(const vx_struct_fields *dtype, size_t idx);
 
 /**
  * Free an owned [`vx_struct_fields_builder`] object.

--- a/vortex-ffi/src/struct_fields.rs
+++ b/vortex-ffi/src/struct_fields.rs
@@ -61,16 +61,11 @@ pub unsafe extern "C-unwind" fn vx_struct_fields_field_dtype(
     let ptr = unsafe { dtype.as_ref() }.vortex_expect("null ptr");
     let struct_dtype = &ptr.0;
 
-    let idx_usize = match usize::try_from(idx) {
-        Ok(i) => i,
-        Err(_) => return ptr::null(),
-    };
-
-    if idx_usize >= struct_dtype.nfields() {
+    if idx >= struct_dtype.nfields() {
         return ptr::null();
     }
 
-    match struct_dtype.field_by_index(idx_usize) {
+    match struct_dtype.field_by_index(idx) {
         Some(field_dtype) => vx_dtype::new(Arc::new(field_dtype)),
         None => ptr::null(),
     }

--- a/vortex-ffi/src/struct_fields.rs
+++ b/vortex-ffi/src/struct_fields.rs
@@ -56,7 +56,7 @@ pub unsafe extern "C-unwind" fn vx_struct_fields_field_name(
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_struct_fields_field_dtype(
     dtype: *const vx_struct_fields,
-    idx: u64,
+    idx: usize,
 ) -> *const vx_dtype {
     let ptr = unsafe { dtype.as_ref() }.vortex_expect("null ptr");
     let struct_dtype = &ptr.0;


### PR DESCRIPTION
fix #5391 

Signed-off-by: Robert Kruszewski <github@robertk.io>
