### PR TITLE
feat[vortex-expr]: `reduce_parent` has typed parent

### DIFF
--- a/vortex-array/src/expr/session/mod.rs
+++ b/vortex-array/src/expr/session/mod.rs
@@ -23,7 +23,9 @@ use crate::expr::exprs::pack::Pack;
 use crate::expr::exprs::root::Root;
 use crate::expr::exprs::select::Select;
 use crate::expr::exprs::select::transform::RemoveSelectRule;
-use crate::expr::transform::rules::{AnyParent, ParentReduceRule, ReduceRule, RuleContext, TypedRuleContext};
+use crate::expr::transform::rules::{
+    AnyParent, ParentReduceRule, ReduceRule, RuleContext, TypedRuleContext,
+};
 use crate::expr::{ExprVTable, VTable};
 
 /// Registry of expression vtables.

--- a/vortex-array/src/expr/session/mod.rs
+++ b/vortex-array/src/expr/session/mod.rs
@@ -79,23 +79,35 @@ impl ExprSession {
     }
 
     /// Register a parent reduce rule in the session.
-    pub fn register_parent_rule<V, R>(&mut self, vtable: &'static V, rule: R)
-    where
-        V: VTable,
+    pub fn register_parent_rule<Child, Parent, R>(
+        &mut self,
+        child_vtable: &'static Child,
+        parent_vtable: &'static Parent,
+        rule: R,
+    ) where
+        Child: VTable,
+        Parent: VTable,
         R: 'static,
-        R: ParentReduceRule<V, RuleContext>,
+        R: ParentReduceRule<Child, Parent, RuleContext>,
     {
-        self.rewrite_rules.register_parent_rule(vtable, rule);
+        self.rewrite_rules
+            .register_parent_rule(child_vtable, parent_vtable, rule);
     }
 
     /// Register a typed parent reduce rule in the session.
-    pub fn register_typed_parent_rule<V, R>(&mut self, vtable: &'static V, rule: R)
-    where
-        V: VTable,
+    pub fn register_typed_parent_rule<Child, Parent, R>(
+        &mut self,
+        child_vtable: &'static Child,
+        parent_vtable: &'static Parent,
+        rule: R,
+    ) where
+        Child: VTable,
+        Parent: VTable,
         R: 'static,
-        R: ParentReduceRule<V, TypedRuleContext>,
+        R: ParentReduceRule<Child, Parent, TypedRuleContext>,
     {
-        self.rewrite_rules.register_typed_parent_rule(vtable, rule);
+        self.rewrite_rules
+            .register_typed_parent_rule(child_vtable, parent_vtable, rule);
     }
 }
 

--- a/vortex-array/src/expr/session/mod.rs
+++ b/vortex-array/src/expr/session/mod.rs
@@ -78,7 +78,7 @@ impl ExprSession {
         self.rewrite_rules.register_reduce_rule(vtable, rule);
     }
 
-    /// Register a parent reduce rule in the session.
+    /// Register a parent reduce rule for a specific parent type.
     pub fn register_parent_rule<Child, Parent, R>(
         &mut self,
         child_vtable: &'static Child,
@@ -91,10 +91,21 @@ impl ExprSession {
         R: ParentReduceRule<Child, Parent, RuleContext>,
     {
         self.rewrite_rules
-            .register_parent_rule(child_vtable, parent_vtable, rule);
+            .register_parent_rule_specific(child_vtable, parent_vtable, rule);
     }
 
-    /// Register a typed parent reduce rule in the session.
+    /// Register a parent rule that matches ANY parent type (wildcard).
+    pub fn register_any_parent_rule<Child, R>(&mut self, child_vtable: &'static Child, rule: R)
+    where
+        Child: VTable,
+        R: 'static,
+        R: ParentReduceRule<Child, crate::expr::transform::rules::AnyParent, RuleContext>,
+    {
+        self.rewrite_rules
+            .register_parent_rule_any(child_vtable, rule);
+    }
+
+    /// Register a typed parent reduce rule for a specific parent type.
     pub fn register_typed_parent_rule<Child, Parent, R>(
         &mut self,
         child_vtable: &'static Child,
@@ -107,7 +118,21 @@ impl ExprSession {
         R: ParentReduceRule<Child, Parent, TypedRuleContext>,
     {
         self.rewrite_rules
-            .register_typed_parent_rule(child_vtable, parent_vtable, rule);
+            .register_typed_parent_rule_specific(child_vtable, parent_vtable, rule);
+    }
+
+    /// Register a typed parent rule that matches ANY parent type (wildcard).
+    pub fn register_typed_any_parent_rule<Child, R>(
+        &mut self,
+        child_vtable: &'static Child,
+        rule: R,
+    ) where
+        Child: VTable,
+        R: 'static,
+        R: ParentReduceRule<Child, crate::expr::transform::rules::AnyParent, TypedRuleContext>,
+    {
+        self.rewrite_rules
+            .register_typed_parent_rule_any(child_vtable, rule);
     }
 }
 

--- a/vortex-array/src/expr/session/mod.rs
+++ b/vortex-array/src/expr/session/mod.rs
@@ -23,7 +23,7 @@ use crate::expr::exprs::pack::Pack;
 use crate::expr::exprs::root::Root;
 use crate::expr::exprs::select::Select;
 use crate::expr::exprs::select::transform::RemoveSelectRule;
-use crate::expr::transform::rules::{ParentReduceRule, ReduceRule, RuleContext, TypedRuleContext};
+use crate::expr::transform::rules::{AnyParent, ParentReduceRule, ReduceRule, RuleContext, TypedRuleContext};
 use crate::expr::{ExprVTable, VTable};
 
 /// Registry of expression vtables.
@@ -99,7 +99,7 @@ impl ExprSession {
     where
         Child: VTable,
         R: 'static,
-        R: ParentReduceRule<Child, crate::expr::transform::rules::AnyParent, RuleContext>,
+        R: ParentReduceRule<Child, AnyParent, RuleContext>,
     {
         self.rewrite_rules
             .register_parent_rule_any(child_vtable, rule);
@@ -129,7 +129,7 @@ impl ExprSession {
     ) where
         Child: VTable,
         R: 'static,
-        R: ParentReduceRule<Child, crate::expr::transform::rules::AnyParent, TypedRuleContext>,
+        R: ParentReduceRule<Child, AnyParent, TypedRuleContext>,
     {
         self.rewrite_rules
             .register_typed_parent_rule_any(child_vtable, rule);

--- a/vortex-array/src/expr/session/rewrite.rs
+++ b/vortex-array/src/expr/session/rewrite.rs
@@ -8,7 +8,9 @@ use std::sync::Arc;
 use vortex_error::VortexResult;
 use vortex_utils::aliases::hash_map::HashMap;
 
-use crate::expr::transform::rules::{ParentReduceRule, ReduceRule, RuleContext, TypedRuleContext};
+use crate::expr::transform::rules::{
+    AnyParent, ParentMatcher, ParentReduceRule, ReduceRule, RuleContext, TypedRuleContext,
+};
 use crate::expr::transform::{
     DynParentReduceRule, DynReduceRule, DynTypedParentReduceRule, DynTypedReduceRule,
 };
@@ -21,7 +23,7 @@ struct ReduceRuleAdapter<V: VTable, R> {
 }
 
 /// Adapter for ParentReduceRule
-struct ReduceParentRuleAdapter<Child: VTable, Parent: VTable, R> {
+struct ReduceParentRuleAdapter<Child: VTable, Parent: ParentMatcher, R> {
     rule: R,
     _phantom: PhantomData<(Child, Parent)>,
 }
@@ -59,7 +61,7 @@ where
 impl<Child, Parent, R> DynParentReduceRule for ReduceParentRuleAdapter<Child, Parent, R>
 where
     Child: VTable,
-    Parent: VTable,
+    Parent: ParentMatcher,
     R: ParentReduceRule<Child, Parent, RuleContext>,
 {
     fn reduce_parent(
@@ -72,17 +74,17 @@ where
         let Some(view) = expr.as_opt::<Child>() else {
             return Ok(None);
         };
-        let Some(parent_view) = parent.as_opt::<Parent>() else {
+        let Some(parent_view) = Parent::try_match(parent) else {
             return Ok(None);
         };
-        self.rule.reduce_parent(&view, &parent_view, child_idx, ctx)
+        self.rule.reduce_parent(&view, parent_view, child_idx, ctx)
     }
 }
 
 impl<Child, Parent, R> DynTypedParentReduceRule for ReduceParentRuleAdapter<Child, Parent, R>
 where
     Child: VTable,
-    Parent: VTable,
+    Parent: ParentMatcher,
     R: ParentReduceRule<Child, Parent, TypedRuleContext>,
 {
     fn reduce_parent(
@@ -95,10 +97,10 @@ where
         let Some(view) = expr.as_opt::<Child>() else {
             return Ok(None);
         };
-        let Some(parent_view) = parent.as_opt::<Parent>() else {
+        let Some(parent_view) = Parent::try_match(parent) else {
             return Ok(None);
         };
-        self.rule.reduce_parent(&view, &parent_view, child_idx, ctx)
+        self.rule.reduce_parent(&view, parent_view, child_idx, ctx)
     }
 }
 
@@ -115,10 +117,14 @@ pub struct RewriteRuleRegistry {
     typed_reduce_rules: RuleRegistry<dyn DynTypedReduceRule>,
     /// Untyped reduce rules (require only RewriteContext), indexed by expression ID
     reduce_rules: RuleRegistry<dyn DynReduceRule>,
-    /// Parent reduce rules, indexed by (child_id, parent_id)
+    /// Parent reduce rules for specific parent types, indexed by (child_id, parent_id)
     typed_parent_rules: ParentRuleRegistry<dyn DynTypedParentReduceRule>,
-    /// Parent reduce rules, indexed by (child_id, parent_id)
+    /// Parent reduce rules for specific parent types, indexed by (child_id, parent_id)
     parent_rules: ParentRuleRegistry<dyn DynParentReduceRule>,
+    /// Wildcard parent rules (match any parent), indexed by child_id only
+    typed_any_parent_rules: RuleRegistry<dyn DynTypedParentReduceRule>,
+    /// Wildcard parent rules (match any parent), indexed by child_id only
+    any_parent_rules: RuleRegistry<dyn DynParentReduceRule>,
 }
 
 // TODO(joe): follow up with rule debug info.
@@ -129,6 +135,11 @@ impl Debug for RewriteRuleRegistry {
             .field("reduce_rules_count", &self.reduce_rules.len())
             .field("typed_parent_rules", &self.typed_parent_rules.len())
             .field("parent_rules_count", &self.parent_rules.len())
+            .field(
+                "typed_any_parent_rules_count",
+                &self.typed_any_parent_rules.len(),
+            )
+            .field("any_parent_rules_count", &self.any_parent_rules.len())
             .finish()
     }
 }
@@ -174,7 +185,8 @@ impl RewriteRuleRegistry {
             .push(Arc::new(adapter));
     }
 
-    pub fn register_parent_rule<Child, Parent, R>(
+    /// Register a parent rule for a specific parent type.
+    pub fn register_parent_rule_specific<Child, Parent, R>(
         &mut self,
         child_vtable: &'static Child,
         parent_vtable: &'static Parent,
@@ -195,15 +207,25 @@ impl RewriteRuleRegistry {
             .push(Arc::new(adapter));
     }
 
-    /// Register a typed parent reduce rule.
-    ///
-    /// # Type Parameters
-    /// * `Child` - The child expression VTable type
-    /// * `Parent` - The parent expression VTable type
-    /// * `R` - The rule implementation
-    ///
-    /// The rule will only be invoked when both the child has type Child and the parent has type Parent.
-    pub fn register_typed_parent_rule<Child, Parent, R>(
+    /// Register a parent rule that matches ANY parent type (wildcard).
+    pub fn register_parent_rule_any<Child, R>(&mut self, child_vtable: &'static Child, rule: R)
+    where
+        Child: VTable,
+        R: 'static,
+        R: ParentReduceRule<Child, AnyParent, RuleContext>,
+    {
+        let adapter = ReduceParentRuleAdapter {
+            rule,
+            _phantom: PhantomData,
+        };
+        self.any_parent_rules
+            .entry(child_vtable.id())
+            .or_default()
+            .push(Arc::new(adapter));
+    }
+
+    /// Register a typed parent rule for a specific parent type.
+    pub fn register_typed_parent_rule_specific<Child, Parent, R>(
         &mut self,
         child_vtable: &'static Child,
         parent_vtable: &'static Parent,
@@ -220,6 +242,26 @@ impl RewriteRuleRegistry {
         };
         self.typed_parent_rules
             .entry((child_vtable.id(), parent_vtable.id()))
+            .or_default()
+            .push(Arc::new(adapter));
+    }
+
+    /// Register a typed parent rule that matches ANY parent type (wildcard).
+    pub fn register_typed_parent_rule_any<Child, R>(
+        &mut self,
+        child_vtable: &'static Child,
+        rule: R,
+    ) where
+        Child: VTable,
+        R: 'static,
+        R: ParentReduceRule<Child, AnyParent, TypedRuleContext>,
+    {
+        let adapter = ReduceParentRuleAdapter {
+            rule,
+            _phantom: PhantomData,
+        };
+        self.typed_any_parent_rules
+            .entry(child_vtable.id())
             .or_default()
             .push(Arc::new(adapter));
     }
@@ -241,26 +283,52 @@ impl RewriteRuleRegistry {
     }
 
     /// Get all untyped parent reduce rules for a given child and parent expression ID pair.
+    /// Returns both specific parent rules AND wildcard "any parent" rules.
     pub(crate) fn parent_rules_for(
         &self,
         child_id: &ExprId,
         parent_id: &ExprId,
-    ) -> &[Arc<dyn DynParentReduceRule>] {
-        self.parent_rules
+    ) -> Vec<Arc<dyn DynParentReduceRule>> {
+        let mut rules = Vec::new();
+
+        // Add specific parent rules first
+        if let Some(specific) = self
+            .parent_rules
             .get(&(child_id.clone(), parent_id.clone()))
-            .map(|v| v.as_slice())
-            .unwrap_or_default()
+        {
+            rules.extend_from_slice(specific);
+        }
+
+        // Add wildcard "any parent" rules
+        if let Some(wildcard) = self.any_parent_rules.get(child_id) {
+            rules.extend_from_slice(wildcard);
+        }
+
+        rules
     }
 
     /// Get all the typed parent reduce rules for a given child and parent expression ID pair.
+    /// Returns both specific parent rules AND wildcard "any parent" rules.
     pub(crate) fn typed_parent_rules_for(
         &self,
         child_id: &ExprId,
         parent_id: &ExprId,
-    ) -> &[Arc<dyn DynTypedParentReduceRule>] {
-        self.typed_parent_rules
+    ) -> Vec<Arc<dyn DynTypedParentReduceRule>> {
+        let mut rules = Vec::new();
+
+        // Add specific parent rules first
+        if let Some(specific) = self
+            .typed_parent_rules
             .get(&(child_id.clone(), parent_id.clone()))
-            .map(|v| v.as_slice())
-            .unwrap_or_default()
+        {
+            rules.extend_from_slice(specific);
+        }
+
+        // Add wildcard "any parent" rules
+        if let Some(wildcard) = self.typed_any_parent_rules.get(child_id) {
+            rules.extend_from_slice(wildcard);
+        }
+
+        rules
     }
 }

--- a/vortex-array/src/expr/session/rewrite.rs
+++ b/vortex-array/src/expr/session/rewrite.rs
@@ -283,7 +283,8 @@ impl RewriteRuleRegistry {
     }
 
     /// Get all untyped parent reduce rules for a given child and parent expression ID pair.
-    /// Returns both specific parent rules AND wildcard "any parent" rules.
+    ///
+    /// Returns both specific parent rules and wildcard "any parent" rules.
     pub(crate) fn parent_rules_for(
         &self,
         child_id: &ExprId,
@@ -291,7 +292,6 @@ impl RewriteRuleRegistry {
     ) -> Vec<Arc<dyn DynParentReduceRule>> {
         let mut rules = Vec::new();
 
-        // Add specific parent rules first
         if let Some(specific) = self
             .parent_rules
             .get(&(child_id.clone(), parent_id.clone()))
@@ -299,7 +299,6 @@ impl RewriteRuleRegistry {
             rules.extend_from_slice(specific);
         }
 
-        // Add wildcard "any parent" rules
         if let Some(wildcard) = self.any_parent_rules.get(child_id) {
             rules.extend_from_slice(wildcard);
         }
@@ -308,7 +307,8 @@ impl RewriteRuleRegistry {
     }
 
     /// Get all the typed parent reduce rules for a given child and parent expression ID pair.
-    /// Returns both specific parent rules AND wildcard "any parent" rules.
+    ///
+    /// Returns both specific parent rules and wildcard "any parent" rules.
     pub(crate) fn typed_parent_rules_for(
         &self,
         child_id: &ExprId,
@@ -316,7 +316,6 @@ impl RewriteRuleRegistry {
     ) -> Vec<Arc<dyn DynTypedParentReduceRule>> {
         let mut rules = Vec::new();
 
-        // Add specific parent rules first
         if let Some(specific) = self
             .typed_parent_rules
             .get(&(child_id.clone(), parent_id.clone()))
@@ -324,7 +323,6 @@ impl RewriteRuleRegistry {
             rules.extend_from_slice(specific);
         }
 
-        // Add wildcard "any parent" rules
         if let Some(wildcard) = self.typed_any_parent_rules.get(child_id) {
             rules.extend_from_slice(wildcard);
         }

--- a/vortex-array/src/expr/session/rewrite.rs
+++ b/vortex-array/src/expr/session/rewrite.rs
@@ -267,19 +267,22 @@ impl RewriteRuleRegistry {
     }
 
     /// Get all typed reduce rules for a given expression ID.
-    pub(crate) fn typed_reduce_rules_for(&self, id: &ExprId) -> &[Arc<dyn DynTypedReduceRule>] {
+    pub(crate) fn typed_reduce_rules_for(
+        &self,
+        id: &ExprId,
+    ) -> impl Iterator<Item = &Arc<dyn DynTypedReduceRule>> {
         self.typed_reduce_rules
             .get(id)
-            .map(|v| v.as_slice())
-            .unwrap_or_default()
+            .into_iter()
+            .flat_map(|v| v.iter())
     }
 
     /// Get all untyped reduce rules for a given expression ID.
-    pub(crate) fn reduce_rules_for(&self, id: &ExprId) -> &[Arc<dyn DynReduceRule>] {
-        self.reduce_rules
-            .get(id)
-            .map(|v| v.as_slice())
-            .unwrap_or_default()
+    pub(crate) fn reduce_rules_for(
+        &self,
+        id: &ExprId,
+    ) -> impl Iterator<Item = &Arc<dyn DynReduceRule>> {
+        self.reduce_rules.get(id).into_iter().flat_map(|v| v.iter())
     }
 
     /// Get all untyped parent reduce rules for a given child and parent expression ID pair.
@@ -289,21 +292,20 @@ impl RewriteRuleRegistry {
         &self,
         child_id: &ExprId,
         parent_id: &ExprId,
-    ) -> Vec<Arc<dyn DynParentReduceRule>> {
-        let mut rules = Vec::new();
-
-        if let Some(specific) = self
+    ) -> impl Iterator<Item = &Arc<dyn DynParentReduceRule>> {
+        let specific = self
             .parent_rules
             .get(&(child_id.clone(), parent_id.clone()))
-        {
-            rules.extend_from_slice(specific);
-        }
+            .into_iter()
+            .flat_map(|v| v.iter());
 
-        if let Some(wildcard) = self.any_parent_rules.get(child_id) {
-            rules.extend_from_slice(wildcard);
-        }
+        let wildcard = self
+            .any_parent_rules
+            .get(child_id)
+            .into_iter()
+            .flat_map(|v| v.iter());
 
-        rules
+        specific.chain(wildcard)
     }
 
     /// Get all the typed parent reduce rules for a given child and parent expression ID pair.
@@ -313,20 +315,19 @@ impl RewriteRuleRegistry {
         &self,
         child_id: &ExprId,
         parent_id: &ExprId,
-    ) -> Vec<Arc<dyn DynTypedParentReduceRule>> {
-        let mut rules = Vec::new();
-
-        if let Some(specific) = self
+    ) -> impl Iterator<Item = &Arc<dyn DynTypedParentReduceRule>> {
+        let specific = self
             .typed_parent_rules
             .get(&(child_id.clone(), parent_id.clone()))
-        {
-            rules.extend_from_slice(specific);
-        }
+            .into_iter()
+            .flat_map(|v| v.iter());
 
-        if let Some(wildcard) = self.typed_any_parent_rules.get(child_id) {
-            rules.extend_from_slice(wildcard);
-        }
+        let wildcard = self
+            .typed_any_parent_rules
+            .get(child_id)
+            .into_iter()
+            .flat_map(|v| v.iter());
 
-        rules
+        specific.chain(wildcard)
     }
 }

--- a/vortex-array/src/expr/session/rewrite.rs
+++ b/vortex-array/src/expr/session/rewrite.rs
@@ -14,22 +14,19 @@ use crate::expr::transform::{
 };
 use crate::expr::{ExprId, Expression, VTable};
 
-/// Universal adapter for both ReduceRule and ParentReduceRule with any context type.
-struct RuleAdapter<V: VTable, R> {
+/// Adapter for ReduceRule
+struct ReduceRuleAdapter<V: VTable, R> {
     rule: R,
     _phantom: PhantomData<V>,
 }
 
-impl<V: VTable, R> RuleAdapter<V, R> {
-    fn new(rule: R) -> Self {
-        Self {
-            rule,
-            _phantom: PhantomData,
-        }
-    }
+/// Adapter for ParentReduceRule
+struct ReduceParentRuleAdapter<Child: VTable, Parent: VTable, R> {
+    rule: R,
+    _phantom: PhantomData<(Child, Parent)>,
 }
 
-impl<V, R> DynReduceRule for RuleAdapter<V, R>
+impl<V, R> DynReduceRule for ReduceRuleAdapter<V, R>
 where
     V: VTable,
     R: ReduceRule<V, RuleContext>,
@@ -42,7 +39,7 @@ where
     }
 }
 
-impl<V, R> DynTypedReduceRule for RuleAdapter<V, R>
+impl<V, R> DynTypedReduceRule for ReduceRuleAdapter<V, R>
 where
     V: VTable,
     R: ReduceRule<V, TypedRuleContext>,
@@ -59,10 +56,11 @@ where
     }
 }
 
-impl<V, R> DynParentReduceRule for RuleAdapter<V, R>
+impl<Child, Parent, R> DynParentReduceRule for ReduceParentRuleAdapter<Child, Parent, R>
 where
-    V: VTable,
-    R: ParentReduceRule<V, RuleContext>,
+    Child: VTable,
+    Parent: VTable,
+    R: ParentReduceRule<Child, Parent, RuleContext>,
 {
     fn reduce_parent(
         &self,
@@ -71,17 +69,21 @@ where
         child_idx: usize,
         ctx: &RuleContext,
     ) -> VortexResult<Option<Expression>> {
-        let Some(view) = expr.as_opt::<V>() else {
+        let Some(view) = expr.as_opt::<Child>() else {
             return Ok(None);
         };
-        self.rule.reduce_parent(&view, parent, child_idx, ctx)
+        let Some(parent_view) = parent.as_opt::<Parent>() else {
+            return Ok(None);
+        };
+        self.rule.reduce_parent(&view, &parent_view, child_idx, ctx)
     }
 }
 
-impl<V, R> DynTypedParentReduceRule for RuleAdapter<V, R>
+impl<Child, Parent, R> DynTypedParentReduceRule for ReduceParentRuleAdapter<Child, Parent, R>
 where
-    V: VTable,
-    R: ParentReduceRule<V, TypedRuleContext>,
+    Child: VTable,
+    Parent: VTable,
+    R: ParentReduceRule<Child, Parent, TypedRuleContext>,
 {
     fn reduce_parent(
         &self,
@@ -90,14 +92,18 @@ where
         child_idx: usize,
         ctx: &TypedRuleContext,
     ) -> VortexResult<Option<Expression>> {
-        let Some(view) = expr.as_opt::<V>() else {
+        let Some(view) = expr.as_opt::<Child>() else {
             return Ok(None);
         };
-        self.rule.reduce_parent(&view, parent, child_idx, ctx)
+        let Some(parent_view) = parent.as_opt::<Parent>() else {
+            return Ok(None);
+        };
+        self.rule.reduce_parent(&view, &parent_view, child_idx, ctx)
     }
 }
 
 type RuleRegistry<Rule> = HashMap<ExprId, Vec<Arc<Rule>>>;
+type ParentRuleRegistry<Rule> = HashMap<(ExprId, ExprId), Vec<Arc<Rule>>>;
 
 /// Registry of expression rewrite rules.
 ///
@@ -109,10 +115,10 @@ pub struct RewriteRuleRegistry {
     typed_reduce_rules: RuleRegistry<dyn DynTypedReduceRule>,
     /// Untyped reduce rules (require only RewriteContext), indexed by expression ID
     reduce_rules: RuleRegistry<dyn DynReduceRule>,
-    /// Parent reduce rules, indexed by expression ID
-    typed_parent_rules: RuleRegistry<dyn DynTypedParentReduceRule>,
-    /// Parent reduce rules, indexed by expression ID
-    parent_rules: RuleRegistry<dyn DynParentReduceRule>,
+    /// Parent reduce rules, indexed by (child_id, parent_id)
+    typed_parent_rules: ParentRuleRegistry<dyn DynTypedParentReduceRule>,
+    /// Parent reduce rules, indexed by (child_id, parent_id)
+    parent_rules: ParentRuleRegistry<dyn DynParentReduceRule>,
 }
 
 // TODO(joe): follow up with rule debug info.
@@ -140,7 +146,10 @@ impl RewriteRuleRegistry {
         R: 'static,
         R: ReduceRule<V, TypedRuleContext>,
     {
-        let adapter = RuleAdapter::new(rule);
+        let adapter = ReduceRuleAdapter {
+            rule,
+            _phantom: PhantomData,
+        };
         self.typed_reduce_rules
             .entry(vtable.id())
             .or_default()
@@ -155,36 +164,62 @@ impl RewriteRuleRegistry {
         R: 'static,
         R: ReduceRule<V, RuleContext>,
     {
-        let adapter = RuleAdapter::new(rule);
+        let adapter = ReduceRuleAdapter {
+            rule,
+            _phantom: PhantomData,
+        };
         self.reduce_rules
             .entry(vtable.id())
             .or_default()
             .push(Arc::new(adapter));
     }
 
-    pub fn register_parent_rule<V, R>(&mut self, vtable: &'static V, rule: R)
-    where
-        V: VTable,
+    pub fn register_parent_rule<Child, Parent, R>(
+        &mut self,
+        child_vtable: &'static Child,
+        parent_vtable: &'static Parent,
+        rule: R,
+    ) where
+        Child: VTable,
+        Parent: VTable,
         R: 'static,
-        R: ParentReduceRule<V, RuleContext>,
+        R: ParentReduceRule<Child, Parent, RuleContext>,
     {
-        let adapter = RuleAdapter::new(rule);
+        let adapter = ReduceParentRuleAdapter {
+            rule,
+            _phantom: PhantomData,
+        };
         self.parent_rules
-            .entry(vtable.id())
+            .entry((child_vtable.id(), parent_vtable.id()))
             .or_default()
             .push(Arc::new(adapter));
     }
 
-    /// Register a parent reduce rule.
-    pub fn register_typed_parent_rule<V, R>(&mut self, vtable: &'static V, rule: R)
-    where
-        V: VTable,
+    /// Register a typed parent reduce rule.
+    ///
+    /// # Type Parameters
+    /// * `Child` - The child expression VTable type
+    /// * `Parent` - The parent expression VTable type
+    /// * `R` - The rule implementation
+    ///
+    /// The rule will only be invoked when both the child has type Child and the parent has type Parent.
+    pub fn register_typed_parent_rule<Child, Parent, R>(
+        &mut self,
+        child_vtable: &'static Child,
+        parent_vtable: &'static Parent,
+        rule: R,
+    ) where
+        Child: VTable,
+        Parent: VTable,
         R: 'static,
-        R: ParentReduceRule<V, TypedRuleContext>,
+        R: ParentReduceRule<Child, Parent, TypedRuleContext>,
     {
-        let adapter = RuleAdapter::new(rule);
+        let adapter = ReduceParentRuleAdapter {
+            rule,
+            _phantom: PhantomData,
+        };
         self.typed_parent_rules
-            .entry(vtable.id())
+            .entry((child_vtable.id(), parent_vtable.id()))
             .or_default()
             .push(Arc::new(adapter));
     }
@@ -205,21 +240,26 @@ impl RewriteRuleRegistry {
             .unwrap_or_default()
     }
 
-    /// Get all untyped parent reduce rules for a given expression ID.
-    pub(crate) fn parent_rules_for(&self, id: &ExprId) -> &[Arc<dyn DynParentReduceRule>] {
+    /// Get all untyped parent reduce rules for a given child and parent expression ID pair.
+    pub(crate) fn parent_rules_for(
+        &self,
+        child_id: &ExprId,
+        parent_id: &ExprId,
+    ) -> &[Arc<dyn DynParentReduceRule>] {
         self.parent_rules
-            .get(id)
+            .get(&(child_id.clone(), parent_id.clone()))
             .map(|v| v.as_slice())
             .unwrap_or_default()
     }
 
-    /// Get all the typed parent reduce rules for a given expression ID.
+    /// Get all the typed parent reduce rules for a given child and parent expression ID pair.
     pub(crate) fn typed_parent_rules_for(
         &self,
-        id: &ExprId,
+        child_id: &ExprId,
+        parent_id: &ExprId,
     ) -> &[Arc<dyn DynTypedParentReduceRule>] {
         self.typed_parent_rules
-            .get(id)
+            .get(&(child_id.clone(), parent_id.clone()))
             .map(|v| v.as_slice())
             .unwrap_or_default()
     }

--- a/vortex-array/src/expr/transform/rules.rs
+++ b/vortex-array/src/expr/transform/rules.rs
@@ -11,6 +11,36 @@ use vortex_error::VortexResult;
 
 use crate::expr::{Expression, ExpressionView, VTable};
 
+/// Trait that abstracts over parent matching - allows both specific and wildcard parent types.
+pub trait ParentMatcher: Send + Sync + 'static {
+    /// The view type returned when matching succeeds.
+    type View<'a>;
+
+    /// Try to match/downcast the parent expression.
+    /// Returns Some if the parent matches this matcher's criteria, None otherwise.
+    fn try_match(parent: &Expression) -> Option<Self::View<'_>>;
+}
+
+/// Marker type representing "any parent" - matches all parent expressions.
+pub struct AnyParent;
+
+impl ParentMatcher for AnyParent {
+    type View<'a> = &'a Expression;
+
+    fn try_match(parent: &Expression) -> Option<Self::View<'_>> {
+        Some(parent) // Always matches!
+    }
+}
+
+/// All VTable types can be used as specific parent matchers.
+impl<V: VTable> ParentMatcher for V {
+    type View<'a> = ExpressionView<'a, V>;
+
+    fn try_match(parent: &Expression) -> Option<Self::View<'_>> {
+        parent.as_opt::<V>()
+    }
+}
+
 /// A rewrite rule that transforms expressions without needing context.
 ///
 /// Called during bottom-up traversal after children have been processed.
@@ -42,15 +72,18 @@ pub trait ReduceRule<V: VTable, C: RewriteContext>: Send + Sync {
 /// # Type Parameters
 /// * `Child` - The VTable type this rule applies to (the child expression type). The rule will only
 ///   be invoked for expressions with this vtable type, providing compile-time type safety.
-/// * `Parent` - The VTable type of the parent expression. The rule will only be invoked when
-///   the parent has this vtable type, providing compile-time type safety.
+/// * `Parent` - The parent matcher. Can be a specific VTable type (e.g., `Binary`) for typed parent
+///   access, or `AnyParent` to match any parent type with untyped access.
 /// * `C` - The rewrite context type (RuleContext or TypedRuleContext)
-pub trait ParentReduceRule<Child: VTable, Parent: VTable, C: RewriteContext>: Send + Sync {
+pub trait ParentReduceRule<Child: VTable, Parent: ParentMatcher, C: RewriteContext>:
+    Send + Sync
+{
     /// Try to rewrite an expression based on its parent.
     ///
     /// # Arguments
     /// * `expr` - The expression to potentially rewrite (already downcast to type Child)
-    /// * `parent` - The parent expression (already downcast to type Parent)
+    /// * `parent` - The parent view (type depends on Parent matcher - typed for specific VTables,
+    ///              untyped `&Expression` for `AnyParent`)
     /// * `child_idx` - The index of the child expression within the parent.
     /// * `ctx` - Context for the rewrite (dtype, etc.)
     ///
@@ -60,7 +93,7 @@ pub trait ParentReduceRule<Child: VTable, Parent: VTable, C: RewriteContext>: Se
     fn reduce_parent(
         &self,
         expr: &ExpressionView<Child>,
-        parent: &ExpressionView<Parent>,
+        parent: Parent::View<'_>,
         child_idx: usize,
         ctx: &C,
     ) -> VortexResult<Option<Expression>>;
@@ -103,9 +136,6 @@ pub struct RuleContext;
 
 impl private::Sealed for RuleContext {}
 impl RewriteContext for RuleContext {}
-
-impl private::Sealed for &RuleContext {}
-impl RewriteContext for &RuleContext {}
 
 /// Type-erased wrappers that allows dynamic dispatch.
 pub(crate) trait DynReduceRule: Send + Sync {

--- a/vortex-array/src/expr/transform/rules.rs
+++ b/vortex-array/src/expr/transform/rules.rs
@@ -28,7 +28,7 @@ impl ParentMatcher for AnyParent {
     type View<'a> = &'a Expression;
 
     fn try_match(parent: &Expression) -> Option<Self::View<'_>> {
-        Some(parent) // Always matches!
+        Some(parent)
     }
 }
 
@@ -83,7 +83,7 @@ pub trait ParentReduceRule<Child: VTable, Parent: ParentMatcher, C: RewriteConte
     /// # Arguments
     /// * `expr` - The expression to potentially rewrite (already downcast to type Child)
     /// * `parent` - The parent view (type depends on Parent matcher - typed for specific VTables,
-    ///              untyped `&Expression` for `AnyParent`)
+    ///   untyped `&Expression` for `AnyParent`)
     /// * `child_idx` - The index of the child expression within the parent.
     /// * `ctx` - Context for the rewrite (dtype, etc.)
     ///

--- a/vortex-array/src/expr/transform/rules.rs
+++ b/vortex-array/src/expr/transform/rules.rs
@@ -40,14 +40,17 @@ pub trait ReduceRule<V: VTable, C: RewriteContext>: Send + Sync {
 /// Note: This rule is only called for non-root expressions (i.e., when there is a parent).
 ///
 /// # Type Parameters
-/// * `V` - The VTable type this rule applies to. The rule will only be invoked for expressions
-///   with this vtable type, providing compile-time type safety.
-pub trait ParentReduceRule<V: VTable, C: RewriteContext>: Send + Sync {
+/// * `Child` - The VTable type this rule applies to (the child expression type). The rule will only
+///   be invoked for expressions with this vtable type, providing compile-time type safety.
+/// * `Parent` - The VTable type of the parent expression. The rule will only be invoked when
+///   the parent has this vtable type, providing compile-time type safety.
+/// * `C` - The rewrite context type (RuleContext or TypedRuleContext)
+pub trait ParentReduceRule<Child: VTable, Parent: VTable, C: RewriteContext>: Send + Sync {
     /// Try to rewrite an expression based on its parent.
     ///
     /// # Arguments
-    /// * `expr` - The expression to potentially rewrite (already downcast to type V)
-    /// * `parent` - The parent expression (always present - rule not called for root)
+    /// * `expr` - The expression to potentially rewrite (already downcast to type Child)
+    /// * `parent` - The parent expression (already downcast to type Parent)
     /// * `child_idx` - The index of the child expression within the parent.
     /// * `ctx` - Context for the rewrite (dtype, etc.)
     ///
@@ -56,8 +59,8 @@ pub trait ParentReduceRule<V: VTable, C: RewriteContext>: Send + Sync {
     /// * `None` if the rule does not apply
     fn reduce_parent(
         &self,
-        expr: &ExpressionView<V>,
-        parent: &Expression,
+        expr: &ExpressionView<Child>,
+        parent: &ExpressionView<Parent>,
         child_idx: usize,
         ctx: &C,
     ) -> VortexResult<Option<Expression>>;
@@ -93,9 +96,6 @@ impl TypedRuleContext {
 
 impl private::Sealed for TypedRuleContext {}
 impl RewriteContext for TypedRuleContext {}
-
-impl private::Sealed for &TypedRuleContext {}
-impl RewriteContext for &TypedRuleContext {}
 
 /// A context for rewrite rules that don't need dtype information.
 #[derive(Debug, Clone, Copy, Default)]

--- a/vortex-array/src/expr/transform/simplify.rs
+++ b/vortex-array/src/expr/transform/simplify.rs
@@ -108,40 +108,42 @@ mod tests {
         }
     }
 
-    /// Test rule: removes any literal "1" regardless of parent type (wildcard rule)
-    struct RemoveOneLiteralRule;
+    /// Test rule: remove identity 0 + x -> x without matching parent directly (equiv to above).
+    struct AddZeroRuleAnyParent;
 
-    impl ParentReduceRule<Literal, AnyParent, RuleContext> for RemoveOneLiteralRule {
+    impl ParentReduceRule<Literal, AnyParent, RuleContext> for AddZeroRuleAnyParent {
         fn reduce_parent(
             &self,
             expr: &ExpressionView<Literal>,
-            parent: &Expression, // ← Untyped! AnyParent gives us &Expression
+            parent: &Expression,
             child_idx: usize,
             _ctx: &RuleContext,
         ) -> VortexResult<Option<Expression>> {
-            // Check if this literal is 1
-            let one_scalar = Scalar::from(1i32);
-            if expr.data() != &one_scalar {
+            // Only apply if the parent is an Add operation
+            let Some(parent) = parent.as_opt::<Binary>() else {
+                return Ok(None);
+            };
+            if parent.operator() != Operator::Add {
                 return Ok(None);
             }
 
-            // Return the OTHER child from the parent (works for any binary parent)
-            if parent.children().len() == 2 {
-                let other_idx = if child_idx == 0 { 1 } else { 0 };
-                return Ok(Some(parent.child(other_idx).clone()));
+            // Check if this literal is zero
+            let zero_scalar = Scalar::from(0i32);
+            if expr.data() != &zero_scalar {
+                return Ok(None);
             }
 
-            Ok(None)
+            // Return the other child (not this zero)
+            let other_idx = if child_idx == 0 { 1 } else { 0 };
+            Ok(Some(parent.child(other_idx).clone()))
         }
     }
 
     #[test]
-    fn test_add_zero_parent_rule_basic() {
-        // Create a session and register the rule (specific parent: Binary)
+    fn test_add_zero_with_specific_parent_rule() {
         let mut session = ExprSession::default();
         session.register_parent_rule(&Literal, &Binary, AddZeroRule);
 
-        // Test: 0 + x should simplify to x
         let x = col("x");
         let zero = lit(0);
         let expr = checked_add(zero, x.clone());
@@ -152,91 +154,31 @@ mod tests {
     }
 
     #[test]
-    fn test_add_zero_parent_rule_left() {
+    fn test_add_zero_with_any_parent_rule() {
         let mut session = ExprSession::default();
-        session.register_parent_rule(&Literal, &Binary, AddZeroRule);
+        session.register_any_parent_rule(&Literal, AddZeroRuleAnyParent);
 
-        // Test: 0 + (0 + x) should simplify to 0 + x, then to x
-        let x = col("x");
-        let zero = lit(0);
-        let zero_plus_x = checked_add(lit(0), x.clone());
-        let expr = checked_add(zero, zero_plus_x);
-
-        let result = simplify(expr, &session).unwrap();
-
-        assert_eq!(&result, &x);
-    }
-
-    #[test]
-    fn test_add_zero_parent_rule_right() {
-        let mut session = ExprSession::default();
-        session.register_parent_rule(&Literal, &Binary, AddZeroRule);
-
-        // Test: x + 0 should simplify to x
-        let x = col("x");
-        let zero = lit(0);
-        let expr = checked_add(x.clone(), zero);
-
-        let result = simplify(expr, &session).unwrap();
-
-        assert_eq!(&result, &x);
-    }
-
-    #[test]
-    fn test_add_zero_parent_rule_nested() {
-        let mut session = ExprSession::default();
-        session.register_parent_rule(&Literal, &Binary, AddZeroRule);
-
-        // Test: (0 + x) + 0 should simplify to x
-        let x = col("x");
-        let zero = lit(0);
-        let zero_plus_x = checked_add(lit(0), x.clone());
-        let expr = checked_add(zero_plus_x, zero);
-
-        let result = simplify(expr, &session).unwrap();
-
-        assert_eq!(&result, &x);
-    }
-
-    #[test]
-    fn test_any_parent_wildcard_rule() {
-        // Test AnyParent - rule works with ANY parent type
-        let mut session = ExprSession::default();
-        session.register_any_parent_rule(&Literal, RemoveOneLiteralRule);
-
-        // Test: x + 1 should simplify to x (works with Add)
-        let x = col("x");
-        let one = lit(1);
-        let expr = checked_add(x.clone(), one);
-
-        let result = simplify(expr, &session).unwrap();
-
-        assert_eq!(&result, &x);
-    }
-
-    #[test]
-    fn test_specific_and_wildcard_rules_together() {
-        // Test both specific and wildcard rules registered at the same time
-        let mut session = ExprSession::default();
-
-        // Specific rule: removes 0 from Add operations only
-        session.register_parent_rule(&Literal, &Binary, AddZeroRule);
-
-        // Wildcard rule: removes 1 from ANY operation
-        session.register_any_parent_rule(&Literal, RemoveOneLiteralRule);
-
-        // Test 1: 0 + x -> x (specific rule applies)
         let x = col("x");
         let zero = lit(0);
         let expr = checked_add(zero, x.clone());
-        let result = simplify(expr, &session).unwrap();
-        assert_eq!(&result, &x);
 
-        // Test 2: 1 + y -> y (wildcard rule applies)
-        let y = col("y");
-        let one = lit(1);
-        let expr = checked_add(one, y.clone());
         let result = simplify(expr, &session).unwrap();
-        assert_eq!(&result, &y);
+
+        assert_eq!(&result, &x);
+    }
+
+    #[test]
+    fn test_add_zero_with_both_rules() {
+        let mut session = ExprSession::default();
+        session.register_parent_rule(&Literal, &Binary, AddZeroRule);
+        session.register_any_parent_rule(&Literal, AddZeroRuleAnyParent);
+
+        let x = col("x");
+        let zero = lit(0);
+        let expr = checked_add(zero, x.clone());
+
+        let result = simplify(expr, &session).unwrap();
+
+        assert_eq!(&result, &x);
     }
 }

--- a/vortex-array/src/expr/transform/simplify.rs
+++ b/vortex-array/src/expr/transform/simplify.rs
@@ -30,7 +30,10 @@ fn apply_parent_rules(
 ) -> VortexResult<Expression> {
     expr.transform_up(|node| {
         for (idx, child) in node.children().iter().enumerate() {
-            for rule in session.rewrite_rules().parent_rules_for(&child.id()) {
+            for rule in session
+                .rewrite_rules()
+                .parent_rules_for(&child.id(), &node.id())
+            {
                 if let Some(new_expr) = rule.reduce_parent(child, &node, idx, ctx)? {
                     return Ok(Transformed::yes(new_expr));
                 }
@@ -80,20 +83,16 @@ mod tests {
     /// Test rule: simplifies addition with zero: 0 + x -> x when literal zero is a child of an Add
     struct AddZeroRule;
 
-    impl ParentReduceRule<Literal, RuleContext> for AddZeroRule {
+    impl ParentReduceRule<Literal, Binary, RuleContext> for AddZeroRule {
         fn reduce_parent(
             &self,
             expr: &ExpressionView<Literal>,
-            parent: &Expression,
+            parent: &ExpressionView<Binary>,
             child_idx: usize,
             _ctx: &RuleContext,
         ) -> VortexResult<Option<Expression>> {
             // Only apply if the parent is an Add operation
-            let Some(bin) = parent.as_opt::<Binary>() else {
-                return Ok(None);
-            };
-
-            if bin.operator() != Operator::Add {
+            if parent.operator() != Operator::Add {
                 return Ok(None);
             }
 
@@ -113,7 +112,7 @@ mod tests {
     fn test_add_zero_parent_rule_basic() {
         // Create a session and register the rule
         let mut session = ExprSession::default();
-        session.register_parent_rule(&Literal, AddZeroRule);
+        session.register_parent_rule(&Literal, &Binary, AddZeroRule);
 
         // Test: 0 + x should simplify to x
         let x = col("x");
@@ -128,7 +127,7 @@ mod tests {
     #[test]
     fn test_add_zero_parent_rule_left() {
         let mut session = ExprSession::default();
-        session.register_parent_rule(&Literal, AddZeroRule);
+        session.register_parent_rule(&Literal, &Binary, AddZeroRule);
 
         // Test: 0 + (0 + x) should simplify to 0 + x, then to x
         let x = col("x");
@@ -144,7 +143,7 @@ mod tests {
     #[test]
     fn test_add_zero_parent_rule_right() {
         let mut session = ExprSession::default();
-        session.register_parent_rule(&Literal, AddZeroRule);
+        session.register_parent_rule(&Literal, &Binary, AddZeroRule);
 
         // Test: x + 0 should simplify to x
         let x = col("x");
@@ -159,7 +158,7 @@ mod tests {
     #[test]
     fn test_add_zero_parent_rule_nested() {
         let mut session = ExprSession::default();
-        session.register_parent_rule(&Literal, AddZeroRule);
+        session.register_parent_rule(&Literal, &Binary, AddZeroRule);
 
         // Test: (0 + x) + 0 should simplify to x
         let x = col("x");

--- a/vortex-array/src/expr/transform/simplify.rs
+++ b/vortex-array/src/expr/transform/simplify.rs
@@ -77,7 +77,7 @@ mod tests {
     use crate::expr::exprs::literal::{Literal, lit};
     use crate::expr::exprs::operators::Operator;
     use crate::expr::session::ExprSession;
-    use crate::expr::transform::rules::{ParentReduceRule, RuleContext};
+    use crate::expr::transform::rules::{AnyParent, ParentReduceRule, RuleContext};
     use crate::expr::{Expression, ExpressionView, col};
 
     /// Test rule: simplifies addition with zero: 0 + x -> x when literal zero is a child of an Add
@@ -87,7 +87,7 @@ mod tests {
         fn reduce_parent(
             &self,
             expr: &ExpressionView<Literal>,
-            parent: &ExpressionView<Binary>,
+            parent: ExpressionView<Binary>,
             child_idx: usize,
             _ctx: &RuleContext,
         ) -> VortexResult<Option<Expression>> {
@@ -108,9 +108,36 @@ mod tests {
         }
     }
 
+    /// Test rule: removes any literal "1" regardless of parent type (wildcard rule)
+    struct RemoveOneLiteralRule;
+
+    impl ParentReduceRule<Literal, AnyParent, RuleContext> for RemoveOneLiteralRule {
+        fn reduce_parent(
+            &self,
+            expr: &ExpressionView<Literal>,
+            parent: &Expression, // ← Untyped! AnyParent gives us &Expression
+            child_idx: usize,
+            _ctx: &RuleContext,
+        ) -> VortexResult<Option<Expression>> {
+            // Check if this literal is 1
+            let one_scalar = Scalar::from(1i32);
+            if expr.data() != &one_scalar {
+                return Ok(None);
+            }
+
+            // Return the OTHER child from the parent (works for any binary parent)
+            if parent.children().len() == 2 {
+                let other_idx = if child_idx == 0 { 1 } else { 0 };
+                return Ok(Some(parent.child(other_idx).clone()));
+            }
+
+            Ok(None)
+        }
+    }
+
     #[test]
     fn test_add_zero_parent_rule_basic() {
-        // Create a session and register the rule
+        // Create a session and register the rule (specific parent: Binary)
         let mut session = ExprSession::default();
         session.register_parent_rule(&Literal, &Binary, AddZeroRule);
 
@@ -169,5 +196,47 @@ mod tests {
         let result = simplify(expr, &session).unwrap();
 
         assert_eq!(&result, &x);
+    }
+
+    #[test]
+    fn test_any_parent_wildcard_rule() {
+        // Test AnyParent - rule works with ANY parent type
+        let mut session = ExprSession::default();
+        session.register_any_parent_rule(&Literal, RemoveOneLiteralRule);
+
+        // Test: x + 1 should simplify to x (works with Add)
+        let x = col("x");
+        let one = lit(1);
+        let expr = checked_add(x.clone(), one);
+
+        let result = simplify(expr, &session).unwrap();
+
+        assert_eq!(&result, &x);
+    }
+
+    #[test]
+    fn test_specific_and_wildcard_rules_together() {
+        // Test both specific and wildcard rules registered at the same time
+        let mut session = ExprSession::default();
+
+        // Specific rule: removes 0 from Add operations only
+        session.register_parent_rule(&Literal, &Binary, AddZeroRule);
+
+        // Wildcard rule: removes 1 from ANY operation
+        session.register_any_parent_rule(&Literal, RemoveOneLiteralRule);
+
+        // Test 1: 0 + x -> x (specific rule applies)
+        let x = col("x");
+        let zero = lit(0);
+        let expr = checked_add(zero, x.clone());
+        let result = simplify(expr, &session).unwrap();
+        assert_eq!(&result, &x);
+
+        // Test 2: 1 + y -> y (wildcard rule applies)
+        let y = col("y");
+        let one = lit(1);
+        let expr = checked_add(one, y.clone());
+        let result = simplify(expr, &session).unwrap();
+        assert_eq!(&result, &y);
     }
 }

--- a/vortex-array/src/expr/transform/simplify_typed.rs
+++ b/vortex-array/src/expr/transform/simplify_typed.rs
@@ -65,14 +65,20 @@ fn apply_parent_rules_impl_typed(
 ) -> VortexResult<Expression> {
     expr.transform_up(|node| {
         for (idx, child) in node.children().iter().enumerate() {
-            for rule in session.rewrite_rules().typed_parent_rules_for(&child.id()) {
+            for rule in session
+                .rewrite_rules()
+                .typed_parent_rules_for(&child.id(), &node.id())
+            {
                 if let Some(new_expr) = rule.reduce_parent(child, &node, idx, ctx)? {
                     return Ok(Transformed::yes(new_expr));
                 }
             }
             // Typed rules can also be applied with untyped context
             let untyped_ctx = crate::expr::transform::rules::RuleContext;
-            for rule in session.rewrite_rules().parent_rules_for(&child.id()) {
+            for rule in session
+                .rewrite_rules()
+                .parent_rules_for(&child.id(), &node.id())
+            {
                 if let Some(new_expr) = rule.reduce_parent(child, &node, idx, &untyped_ctx)? {
                     return Ok(Transformed::yes(new_expr));
                 }


### PR DESCRIPTION
Allows for parent rules to be typed and if a specific. parent Expression type is given only applied to that