### PR TITLE
fix: add missing dependency: typing-extensions

### DIFF
--- a/vortex-python/pyproject.toml
+++ b/vortex-python/pyproject.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 dependencies = [
     "pyarrow>=17.0.0",
     "substrait>=0.23.0",
+    "typing-extensions>=4.5.0",
 ]
 requires-python = ">= 3.11"
 classifiers = [


### PR DESCRIPTION
We use override which was most recently updated in 4.5.0.