### PR TITLE
refactor(bench): use composable argument groups to prevent unused args

### DIFF
--- a/bench-vortex/src/bin/query_bench.rs
+++ b/bench-vortex/src/bin/query_bench.rs
@@ -47,9 +47,9 @@ enum Commands {
     GhArchive(GhArchiveArgs),
 }
 
-/// Common arguments shared across benchmarks
+/// Core execution arguments - used by ALL benchmarks
 #[derive(Parser, Debug)]
-struct CommonArgs {
+struct CoreArgs {
     #[arg(short, long, default_value_t = 5)]
     iterations: usize,
 
@@ -61,37 +61,50 @@ struct CommonArgs {
 
     #[arg(long)]
     tracing: bool,
+}
 
-    #[arg(long)]
-    export_spans: bool,
+/// Query filtering arguments - used by benchmarks with multiple queries
+#[derive(Parser, Debug)]
+struct QueryFilterArgs {
+    #[arg(short, long, value_delimiter = ',')]
+    queries: Option<Vec<usize>>,
 
+    #[arg(short, long, value_delimiter = ',')]
+    exclude_queries: Option<Vec<usize>>,
+}
+
+/// Output configuration arguments
+#[derive(Parser, Debug)]
+struct OutputArgs {
     #[arg(short, long, default_value_t, value_enum)]
     display_format: DisplayFormat,
 
+    #[arg(short)]
+    output_path: Option<PathBuf>,
+
+    #[arg(long, default_value_t = false)]
+    hide_progress_bar: bool,
+}
+
+/// Engine configuration arguments
+#[derive(Parser, Debug)]
+struct EngineArgs {
     /// TODO(joe): remove this flag and add a cache flag to common.
     #[arg(long, default_value_t = false)]
     disable_datafusion_cache: bool,
 
     #[arg(long, default_value_t = false)]
     delete_duckdb_database: bool,
+}
 
-    #[arg(short, long, value_delimiter = ',')]
-    queries: Option<Vec<usize>>,
-
-    #[arg(short, long, value_delimiter = ',')]
-    exclude_queries: Option<Vec<usize>>,
-
-    #[arg(short)]
-    output_path: Option<PathBuf>,
+/// Debugging/analysis arguments
+#[derive(Parser, Debug)]
+struct DebugArgs {
+    #[arg(long)]
+    export_spans: bool,
 
     #[arg(long, default_value_t = false)]
     show_metrics: bool,
-
-    #[arg(long, default_value_t = false)]
-    hide_progress_bar: bool,
-
-    #[arg(long)]
-    use_remote_data_dir: Option<String>,
 
     #[arg(long, default_value_t = false)]
     emit_plan: bool,
@@ -100,19 +113,48 @@ struct CommonArgs {
     track_memory: bool,
 
     #[arg(long, default_value_t = false)]
-    skip_generate: bool,
-
-    #[arg(long, default_value_t = false)]
     explain: bool,
 
     #[arg(long, default_value_t = false)]
     explain_analyze: bool,
 }
 
+/// Data generation arguments
+#[derive(Parser, Debug)]
+struct DataArgs {
+    #[arg(long, default_value_t = false)]
+    skip_generate: bool,
+}
+
+/// Remote data configuration (only for benchmarks that support it)
+#[derive(Parser, Debug)]
+struct RemoteDataArgs {
+    #[arg(long)]
+    use_remote_data_dir: Option<String>,
+}
+
 #[derive(Parser, Debug)]
 struct ClickBenchArgs {
     #[command(flatten)]
-    common: CommonArgs,
+    core: CoreArgs,
+
+    #[command(flatten)]
+    query_filter: QueryFilterArgs,
+
+    #[command(flatten)]
+    output: OutputArgs,
+
+    #[command(flatten)]
+    engine: EngineArgs,
+
+    #[command(flatten)]
+    debug: DebugArgs,
+
+    #[command(flatten)]
+    data: DataArgs,
+
+    #[command(flatten)]
+    remote_data: RemoteDataArgs,
 
     #[arg(long, value_delimiter = ',', value_parser = value_parser!(Target),
         default_values = vec![
@@ -137,7 +179,25 @@ struct ClickBenchArgs {
 #[derive(Parser, Debug)]
 struct TpcHArgs {
     #[command(flatten)]
-    common: CommonArgs,
+    core: CoreArgs,
+
+    #[command(flatten)]
+    query_filter: QueryFilterArgs,
+
+    #[command(flatten)]
+    output: OutputArgs,
+
+    #[command(flatten)]
+    engine: EngineArgs,
+
+    #[command(flatten)]
+    debug: DebugArgs,
+
+    #[command(flatten)]
+    data: DataArgs,
+
+    #[command(flatten)]
+    remote_data: RemoteDataArgs,
 
     #[arg(long, value_delimiter = ',', value_parser = value_parser!(Target),
         default_values = vec![
@@ -160,7 +220,25 @@ struct TpcHArgs {
 #[derive(Parser, Debug)]
 struct TpcDSArgs {
     #[command(flatten)]
-    common: CommonArgs,
+    core: CoreArgs,
+
+    #[command(flatten)]
+    query_filter: QueryFilterArgs,
+
+    #[command(flatten)]
+    output: OutputArgs,
+
+    #[command(flatten)]
+    engine: EngineArgs,
+
+    #[command(flatten)]
+    debug: DebugArgs,
+
+    #[command(flatten)]
+    data: DataArgs,
+
+    #[command(flatten)]
+    remote_data: RemoteDataArgs,
 
     #[arg(long, value_delimiter = ',', value_parser = value_parser!(Target),
         default_values = vec![
@@ -182,8 +260,24 @@ struct TpcDSArgs {
 #[derive(Parser, Debug)]
 struct StatPopGenArgs {
     #[command(flatten)]
-    common: CommonArgs,
+    core: CoreArgs,
 
+    #[command(flatten)]
+    query_filter: QueryFilterArgs,
+
+    #[command(flatten)]
+    output: OutputArgs,
+
+    #[command(flatten)]
+    engine: EngineArgs,
+
+    #[command(flatten)]
+    debug: DebugArgs,
+
+    #[command(flatten)]
+    data: DataArgs,
+
+    // Note: No remote_data - this benchmark doesn't support use_remote_data_dir
     #[arg(long, value_delimiter = ',', value_parser = value_parser!(Target),
           default_values = vec![
               // DataFusion does not support list_aggregate and simulating it with an UNNEST and GROUP
@@ -213,8 +307,27 @@ struct StatPopGenArgs {
 #[derive(Parser, Debug)]
 struct FinewebArgs {
     #[command(flatten)]
-    common: CommonArgs,
+    core: CoreArgs,
 
+    #[command(flatten)]
+    query_filter: QueryFilterArgs,
+
+    #[command(flatten)]
+    output: OutputArgs,
+
+    #[command(flatten)]
+    engine: EngineArgs,
+
+    #[command(flatten)]
+    debug: DebugArgs,
+
+    #[command(flatten)]
+    data: DataArgs,
+
+    #[command(flatten)]
+    remote_data: RemoteDataArgs,
+
+    // Note: No scale_factor - this benchmark doesn't support scale_factor
     #[arg(long, value_delimiter = ',', value_parser = value_parser!(Target),
         default_values = vec![
               "duckdb:parquet",
@@ -226,17 +339,32 @@ struct FinewebArgs {
           ]
     )]
     targets: Vec<Target>,
-
-    // Dummy, unused but we are required to accept it to make the CI automation happy
-    #[arg(long)]
-    scale_factor: u64,
 }
 
 #[derive(Parser, Debug)]
 struct GhArchiveArgs {
     #[command(flatten)]
-    common: CommonArgs,
+    core: CoreArgs,
 
+    #[command(flatten)]
+    query_filter: QueryFilterArgs,
+
+    #[command(flatten)]
+    output: OutputArgs,
+
+    #[command(flatten)]
+    engine: EngineArgs,
+
+    #[command(flatten)]
+    debug: DebugArgs,
+
+    #[command(flatten)]
+    data: DataArgs,
+
+    #[command(flatten)]
+    remote_data: RemoteDataArgs,
+
+    // Note: No scale_factor - this benchmark doesn't support scale_factor
     #[arg(long, value_delimiter = ',', value_parser = value_parser!(Target),
         default_values = vec![
               "duckdb:parquet",
@@ -248,10 +376,6 @@ struct GhArchiveArgs {
           ]
     )]
     targets: Vec<Target>,
-
-    // Dummy, unused but we are required to accept it to make the CI automation happy
-    #[arg(long)]
-    scale_factor: u64,
 }
 
 fn validate_scale_factor(val: &str) -> Result<String, String> {
@@ -288,66 +412,65 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn run_clickbench(args: ClickBenchArgs) -> anyhow::Result<()> {
-    setup_logging_and_tracing(args.common.verbose, args.common.tracing)?;
+    setup_logging_and_tracing(args.core.verbose, args.core.tracing)?;
 
     // Create benchmark instance
     let benchmark = ClickBenchBenchmark::new(
         args.flavor,
         args.queries_file.map(|p| p.to_string_lossy().to_string()),
-        args.common.use_remote_data_dir,
+        args.remote_data.use_remote_data_dir,
     )?;
 
     // Configure driver
     let config = DriverConfig {
         targets: args.targets,
-        iterations: args.common.iterations,
-        threads: args.common.threads,
-        display_format: args.common.display_format,
-        disable_datafusion_cache: args.common.disable_datafusion_cache,
-        delete_duckdb_database: args.common.delete_duckdb_database,
-        queries: args.common.queries,
-        exclude_queries: args.common.exclude_queries,
-        output_path: args.common.output_path,
-        emit_plan: args.common.emit_plan,
-        export_spans: args.common.export_spans,
-        show_metrics: args.common.show_metrics,
-        hide_progress_bar: args.common.hide_progress_bar,
-        track_memory: args.common.track_memory,
-        skip_generate: args.common.skip_generate,
-        explain: args.common.explain,
-        explain_analyze: args.common.explain_analyze,
+        iterations: args.core.iterations,
+        threads: args.core.threads,
+        display_format: args.output.display_format,
+        disable_datafusion_cache: args.engine.disable_datafusion_cache,
+        delete_duckdb_database: args.engine.delete_duckdb_database,
+        queries: args.query_filter.queries,
+        exclude_queries: args.query_filter.exclude_queries,
+        output_path: args.output.output_path,
+        emit_plan: args.debug.emit_plan,
+        export_spans: args.debug.export_spans,
+        show_metrics: args.debug.show_metrics,
+        hide_progress_bar: args.output.hide_progress_bar,
+        track_memory: args.debug.track_memory,
+        skip_generate: args.data.skip_generate,
+        explain: args.debug.explain,
+        explain_analyze: args.debug.explain_analyze,
     };
 
-    // Determine data URL
     // Run benchmark using the trait system
     run_benchmark(benchmark, config)
 }
 
 fn run_tpch(args: TpcHArgs) -> anyhow::Result<()> {
-    setup_logging_and_tracing(args.common.verbose, args.common.tracing)?;
+    setup_logging_and_tracing(args.core.verbose, args.core.tracing)?;
 
     // Create benchmark instance
-    let benchmark = TpcHBenchmark::new(args.scale_factor, args.common.use_remote_data_dir)?;
+    let benchmark = TpcHBenchmark::new(args.scale_factor, args.remote_data.use_remote_data_dir)?;
 
     // Configure driver
     let config = DriverConfig {
         targets: args.targets,
-        iterations: args.common.iterations,
-        threads: args.common.threads,
-        display_format: args.common.display_format,
-        disable_datafusion_cache: args.common.disable_datafusion_cache,
-        delete_duckdb_database: args.common.delete_duckdb_database,
-        queries: args.common.queries,
-        exclude_queries: args.common.exclude_queries,
-        output_path: args.common.output_path,
-        emit_plan: args.common.emit_plan,
-        export_spans: args.common.export_spans,
-        show_metrics: args.common.show_metrics,
-        hide_progress_bar: args.common.hide_progress_bar,
-        track_memory: args.common.track_memory,
-        skip_generate: args.common.skip_generate,
-        explain: args.common.explain,
-        explain_analyze: args.common.explain_analyze,
+        iterations: args.core.iterations,
+        threads: args.core.threads,
+        display_format: args.output.display_format,
+        disable_datafusion_cache: args.engine.disable_datafusion_cache,
+        delete_duckdb_database: args.engine.delete_duckdb_database,
+        queries: args.query_filter.queries,
+        exclude_queries: args.query_filter.exclude_queries,
+        output_path: args.output.output_path,
+        emit_plan: args.debug.emit_plan,
+        export_spans: args.debug.export_spans,
+        show_metrics: args.debug.show_metrics,
+        hide_progress_bar: args.output.hide_progress_bar,
+        track_memory: args.debug.track_memory,
+        skip_generate: args.data.skip_generate,
+        explain: args.debug.explain,
+        explain_analyze: args.debug.explain_analyze,
     };
 
     // Run benchmark using the trait system
@@ -357,30 +480,30 @@ fn run_tpch(args: TpcHArgs) -> anyhow::Result<()> {
 }
 
 fn run_tpcds(args: TpcDSArgs) -> anyhow::Result<()> {
-    setup_logging_and_tracing(args.common.verbose, args.common.tracing)?;
+    setup_logging_and_tracing(args.core.verbose, args.core.tracing)?;
 
     // Create benchmark instance
-    let benchmark = TpcDsBenchmark::new(args.scale_factor, args.common.use_remote_data_dir)?;
+    let benchmark = TpcDsBenchmark::new(args.scale_factor, args.remote_data.use_remote_data_dir)?;
 
     // Configure driver
     let config = DriverConfig {
         targets: args.targets,
-        iterations: args.common.iterations,
-        threads: args.common.threads,
-        display_format: args.common.display_format,
-        disable_datafusion_cache: args.common.disable_datafusion_cache,
-        delete_duckdb_database: args.common.delete_duckdb_database,
-        queries: args.common.queries,
-        exclude_queries: args.common.exclude_queries,
-        output_path: args.common.output_path,
-        emit_plan: args.common.emit_plan,
-        export_spans: args.common.export_spans,
-        show_metrics: args.common.show_metrics,
-        hide_progress_bar: args.common.hide_progress_bar,
-        track_memory: args.common.track_memory,
-        skip_generate: args.common.skip_generate,
-        explain: args.common.explain,
-        explain_analyze: args.common.explain_analyze,
+        iterations: args.core.iterations,
+        threads: args.core.threads,
+        display_format: args.output.display_format,
+        disable_datafusion_cache: args.engine.disable_datafusion_cache,
+        delete_duckdb_database: args.engine.delete_duckdb_database,
+        queries: args.query_filter.queries,
+        exclude_queries: args.query_filter.exclude_queries,
+        output_path: args.output.output_path,
+        emit_plan: args.debug.emit_plan,
+        export_spans: args.debug.export_spans,
+        show_metrics: args.debug.show_metrics,
+        hide_progress_bar: args.output.hide_progress_bar,
+        track_memory: args.debug.track_memory,
+        skip_generate: args.data.skip_generate,
+        explain: args.debug.explain,
+        explain_analyze: args.debug.explain_analyze,
     };
 
     // Run benchmark using the trait system
@@ -390,7 +513,7 @@ fn run_tpcds(args: TpcDSArgs) -> anyhow::Result<()> {
 }
 
 fn run_statpopgen(args: StatPopGenArgs) -> anyhow::Result<()> {
-    setup_logging_and_tracing(args.common.verbose, args.common.tracing)?;
+    setup_logging_and_tracing(args.core.verbose, args.core.tracing)?;
 
     // Create benchmark instance
     let data_url = Url::from_directory_path("statpopgen".to_data_path())
@@ -400,22 +523,22 @@ fn run_statpopgen(args: StatPopGenArgs) -> anyhow::Result<()> {
     // Configure driver
     let config = DriverConfig {
         targets: args.targets,
-        iterations: args.common.iterations,
-        threads: args.common.threads,
-        display_format: args.common.display_format,
-        disable_datafusion_cache: args.common.disable_datafusion_cache,
-        delete_duckdb_database: args.common.delete_duckdb_database,
-        queries: args.common.queries,
-        exclude_queries: args.common.exclude_queries,
-        output_path: args.common.output_path,
-        emit_plan: args.common.emit_plan,
-        export_spans: args.common.export_spans,
-        show_metrics: args.common.show_metrics,
-        hide_progress_bar: args.common.hide_progress_bar,
-        track_memory: args.common.track_memory,
-        skip_generate: args.common.skip_generate,
-        explain: args.common.explain,
-        explain_analyze: args.common.explain_analyze,
+        iterations: args.core.iterations,
+        threads: args.core.threads,
+        display_format: args.output.display_format,
+        disable_datafusion_cache: args.engine.disable_datafusion_cache,
+        delete_duckdb_database: args.engine.delete_duckdb_database,
+        queries: args.query_filter.queries,
+        exclude_queries: args.query_filter.exclude_queries,
+        output_path: args.output.output_path,
+        emit_plan: args.debug.emit_plan,
+        export_spans: args.debug.export_spans,
+        show_metrics: args.debug.show_metrics,
+        hide_progress_bar: args.output.hide_progress_bar,
+        track_memory: args.debug.track_memory,
+        skip_generate: args.data.skip_generate,
+        explain: args.debug.explain,
+        explain_analyze: args.debug.explain_analyze,
     };
 
     // Run benchmark using the trait system
@@ -423,56 +546,56 @@ fn run_statpopgen(args: StatPopGenArgs) -> anyhow::Result<()> {
 }
 
 fn run_fineweb(args: FinewebArgs) -> anyhow::Result<()> {
-    setup_logging_and_tracing(args.common.verbose, args.common.tracing)?;
+    setup_logging_and_tracing(args.core.verbose, args.core.tracing)?;
 
-    let benchmark = Fineweb::with_remote_data_dir(args.common.use_remote_data_dir)?;
+    let benchmark = Fineweb::with_remote_data_dir(args.remote_data.use_remote_data_dir)?;
 
     let config = DriverConfig {
         targets: args.targets,
-        iterations: args.common.iterations,
-        threads: args.common.threads,
-        display_format: args.common.display_format,
-        disable_datafusion_cache: args.common.disable_datafusion_cache,
-        delete_duckdb_database: args.common.delete_duckdb_database,
-        queries: args.common.queries,
-        exclude_queries: args.common.exclude_queries,
-        output_path: args.common.output_path,
-        emit_plan: args.common.emit_plan,
-        export_spans: args.common.export_spans,
-        show_metrics: args.common.show_metrics,
-        hide_progress_bar: args.common.hide_progress_bar,
-        track_memory: args.common.track_memory,
-        skip_generate: args.common.skip_generate,
-        explain: args.common.explain,
-        explain_analyze: args.common.explain_analyze,
+        iterations: args.core.iterations,
+        threads: args.core.threads,
+        display_format: args.output.display_format,
+        disable_datafusion_cache: args.engine.disable_datafusion_cache,
+        delete_duckdb_database: args.engine.delete_duckdb_database,
+        queries: args.query_filter.queries,
+        exclude_queries: args.query_filter.exclude_queries,
+        output_path: args.output.output_path,
+        emit_plan: args.debug.emit_plan,
+        export_spans: args.debug.export_spans,
+        show_metrics: args.debug.show_metrics,
+        hide_progress_bar: args.output.hide_progress_bar,
+        track_memory: args.debug.track_memory,
+        skip_generate: args.data.skip_generate,
+        explain: args.debug.explain,
+        explain_analyze: args.debug.explain_analyze,
     };
 
     run_benchmark(benchmark, config)
 }
 
 fn run_gharchive(args: GhArchiveArgs) -> anyhow::Result<()> {
-    setup_logging_and_tracing(args.common.verbose, args.common.tracing)?;
+    setup_logging_and_tracing(args.core.verbose, args.core.tracing)?;
 
-    let benchmark = GithubArchive::with_remote_data_dir(args.common.use_remote_data_dir)?;
+    let benchmark = GithubArchive::with_remote_data_dir(args.remote_data.use_remote_data_dir)?;
 
     let config = DriverConfig {
         targets: args.targets,
-        iterations: args.common.iterations,
-        threads: args.common.threads,
-        display_format: args.common.display_format,
-        disable_datafusion_cache: args.common.disable_datafusion_cache,
-        delete_duckdb_database: args.common.delete_duckdb_database,
-        queries: args.common.queries,
-        exclude_queries: args.common.exclude_queries,
-        output_path: args.common.output_path,
-        emit_plan: args.common.emit_plan,
-        export_spans: args.common.export_spans,
-        show_metrics: args.common.show_metrics,
-        hide_progress_bar: args.common.hide_progress_bar,
-        track_memory: args.common.track_memory,
-        skip_generate: args.common.skip_generate,
-        explain: args.common.explain,
-        explain_analyze: args.common.explain_analyze,
+        iterations: args.core.iterations,
+        threads: args.core.threads,
+        display_format: args.output.display_format,
+        disable_datafusion_cache: args.engine.disable_datafusion_cache,
+        delete_duckdb_database: args.engine.delete_duckdb_database,
+        queries: args.query_filter.queries,
+        exclude_queries: args.query_filter.exclude_queries,
+        output_path: args.output.output_path,
+        emit_plan: args.debug.emit_plan,
+        export_spans: args.debug.export_spans,
+        show_metrics: args.debug.show_metrics,
+        hide_progress_bar: args.output.hide_progress_bar,
+        track_memory: args.debug.track_memory,
+        skip_generate: args.data.skip_generate,
+        explain: args.debug.explain,
+        explain_analyze: args.debug.explain_analyze,
     };
 
     run_benchmark(benchmark, config)


### PR DESCRIPTION
Previously, all benchmarks accepted a single CommonArgs struct via flatten, which meant benchmarks would silently accept arguments they didn't use (e.g., fineweb accepting --scale-factor, statpopgen accepting --use-remote-data-dir).

This refactor splits CommonArgs into focused, semantically-related groups:
- CoreArgs: execution basics (iterations, threads, verbose, tracing)
- QueryFilterArgs: query selection (queries, exclude_queries)
- OutputArgs: display configuration (display_format, output_path, hide_progress_bar)
- EngineArgs: engine settings (disable_datafusion_cache, delete_duckdb_database)
- DebugArgs: debugging/analysis (export_spans, show_metrics, emit_plan, track_memory, explain, explain_analyze)
- DataArgs: data generation (skip_generate)
- RemoteDataArgs: remote data configuration (use_remote_data_dir)

Benchmarks now explicitly flatten only the groups they support:
- TPC-H/TPC-DS/ClickBench/Fineweb/GhArchive: all groups (including RemoteDataArgs)
- StatPopGen: all except RemoteDataArgs (doesn't support remote data)

Benefits:
- Compile-time safety: benchmarks can only access args they explicitly include
- Self-documenting: struct definition shows what each benchmark supports
- clap rejects unknown args: users get immediate feedback if they pass unsupported args
- No runtime validation needed: architectural guarantee prevents unused args

🤖 Generated with [Claude Code](https://claude.com/claude-code)