### PR TITLE
Chore: rename unpack functions

### DIFF
--- a/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
@@ -17,18 +17,18 @@ use vortex_scalar::Scalar;
 use crate::BitPackedArray;
 use crate::unpack_iter::BitPacked;
 
-pub fn unpack(array: &BitPackedArray) -> PrimitiveArray {
-    match_each_integer_ptype!(array.ptype(), |P| { unpack_primitive::<P>(array) })
+pub fn unpack_array(array: &BitPackedArray) -> PrimitiveArray {
+    match_each_integer_ptype!(array.ptype(), |P| { unpack_primitive_array::<P>(array) })
 }
 
-pub fn unpack_primitive<T: BitPacked>(array: &BitPackedArray) -> PrimitiveArray {
+pub fn unpack_primitive_array<T: BitPacked>(array: &BitPackedArray) -> PrimitiveArray {
     let mut builder = PrimitiveBuilder::with_capacity(array.dtype().nullability(), array.len());
-    unpack_into::<T>(array, &mut builder);
+    unpack_into_primitive_builder::<T>(array, &mut builder);
     assert_eq!(builder.len(), array.len());
     builder.finish_into_primitive()
 }
 
-pub(crate) fn unpack_into<T: BitPacked>(
+pub(crate) fn unpack_into_primitive_builder<T: BitPacked>(
     array: &BitPackedArray,
     // TODO(ngates): do we want to use fastlanes alignment for this buffer?
     builder: &mut PrimitiveBuilder<T>,
@@ -207,7 +207,7 @@ mod tests {
     fn test_all_zeros() {
         let zeros = buffer![0u16, 0, 0, 0].into_array().to_primitive();
         let bitpacked = bitpack_encode(&zeros, 0, None).unwrap();
-        let actual = unpack(&bitpacked);
+        let actual = unpack_array(&bitpacked);
         assert_arrays_eq!(actual, PrimitiveArray::from_iter([0u16, 0, 0, 0]));
     }
 
@@ -215,7 +215,7 @@ mod tests {
     fn test_simple_patches() {
         let zeros = buffer![0u16, 1, 0, 1].into_array().to_primitive();
         let bitpacked = bitpack_encode(&zeros, 0, None).unwrap();
-        let actual = unpack(&bitpacked);
+        let actual = unpack_array(&bitpacked);
         assert_arrays_eq!(actual, PrimitiveArray::from_iter([0u16, 1, 0, 1]));
     }
 
@@ -223,7 +223,7 @@ mod tests {
     fn test_one_full_chunk() {
         let zeros = BufferMut::from_iter(0u16..1024).into_array().to_primitive();
         let bitpacked = bitpack_encode(&zeros, 10, None).unwrap();
-        let actual = unpack(&bitpacked);
+        let actual = unpack_array(&bitpacked);
         assert_arrays_eq!(actual, PrimitiveArray::from_iter(0u16..1024));
     }
 
@@ -234,7 +234,7 @@ mod tests {
             .to_primitive();
         let bitpacked = bitpack_encode(&zeros, 10, None).unwrap();
         assert!(bitpacked.patches().is_some());
-        let actual = unpack(&bitpacked);
+        let actual = unpack_array(&bitpacked);
         assert_arrays_eq!(
             actual,
             PrimitiveArray::from_iter((5u16..1029).chain(5u16..1029).chain(5u16..1029))
@@ -246,7 +246,7 @@ mod tests {
         let zeros = BufferMut::from_iter(0u16..1025).into_array().to_primitive();
         let bitpacked = bitpack_encode(&zeros, 11, None).unwrap();
         assert!(bitpacked.patches().is_none());
-        let actual = unpack(&bitpacked);
+        let actual = unpack_array(&bitpacked);
         assert_arrays_eq!(actual, PrimitiveArray::from_iter(0u16..1025));
     }
 
@@ -258,7 +258,7 @@ mod tests {
         let bitpacked = bitpack_encode(&zeros, 10, None).unwrap();
         assert_eq!(bitpacked.len(), 1025);
         assert!(bitpacked.patches().is_some());
-        let actual = unpack(&bitpacked);
+        let actual = unpack_array(&bitpacked);
         assert_arrays_eq!(actual, PrimitiveArray::from_iter(512u16..1537));
     }
 
@@ -271,7 +271,7 @@ mod tests {
         assert_eq!(bitpacked.len(), 1025);
         assert!(bitpacked.patches().is_some());
         let bitpacked = bitpacked.slice(1023..1025);
-        let actual = unpack(bitpacked.as_::<BitPackedVTable>());
+        let actual = unpack_array(bitpacked.as_::<BitPackedVTable>());
         assert_arrays_eq!(actual, PrimitiveArray::from_iter([1535u16, 1536]));
     }
 
@@ -284,7 +284,7 @@ mod tests {
         assert_eq!(bitpacked.len(), 2229);
         assert!(bitpacked.patches().is_some());
         let bitpacked = bitpacked.slice(1023..2049);
-        let actual = unpack(bitpacked.as_::<BitPackedVTable>());
+        let actual = unpack_array(bitpacked.as_::<BitPackedVTable>());
         assert_arrays_eq!(
             actual,
             PrimitiveArray::from_iter((1023u16..2049).map(|x| x + 512))
@@ -297,7 +297,7 @@ mod tests {
         let bitpacked = bitpack_encode(&empty, 0, None).unwrap();
 
         let mut builder = PrimitiveBuilder::<u32>::new(Nullability::NonNullable);
-        unpack_into(&bitpacked, &mut builder);
+        unpack_into_primitive_builder(&bitpacked, &mut builder);
 
         let result = builder.finish_into_primitive();
         assert_eq!(
@@ -320,7 +320,7 @@ mod tests {
 
         // Unpack into a new builder.
         let mut builder = PrimitiveBuilder::<u32>::with_capacity(Nullability::Nullable, 5);
-        unpack_into(&bitpacked, &mut builder);
+        unpack_into_primitive_builder(&bitpacked, &mut builder);
 
         let result = builder.finish_into_primitive();
 
@@ -351,7 +351,7 @@ mod tests {
 
         // Unpack into a new builder.
         let mut builder = PrimitiveBuilder::<u32>::with_capacity(Nullability::NonNullable, 100);
-        unpack_into(&bitpacked, &mut builder);
+        unpack_into_primitive_builder(&bitpacked, &mut builder);
 
         let result = builder.finish_into_primitive();
 

--- a/encodings/fastlanes/src/bitpacking/vtable/canonical.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/canonical.rs
@@ -7,17 +7,17 @@ use vortex_array::vtable::CanonicalVTable;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexExpect;
 
-use crate::bitpack_decompress::{unpack, unpack_into};
+use crate::bitpack_decompress::{unpack_array, unpack_into_primitive_builder};
 use crate::{BitPackedArray, BitPackedVTable};
 
 impl CanonicalVTable<BitPackedVTable> for BitPackedVTable {
     fn canonicalize(array: &BitPackedArray) -> Canonical {
-        Canonical::Primitive(unpack(array))
+        Canonical::Primitive(unpack_array(array))
     }
 
     fn append_to_builder(array: &BitPackedArray, builder: &mut dyn ArrayBuilder) {
         match_each_integer_ptype!(array.ptype(), |T| {
-            unpack_into::<T>(
+            unpack_into_primitive_builder::<T>(
                 array,
                 builder
                     .as_any_mut()


### PR DESCRIPTION
Just so the new unpack functions that work with vectors dont name collide