### PR TITLE
fix: benchmark input handling

### DIFF
--- a/encodings/fastlanes/benches/bitpacking_decompress_selection.rs
+++ b/encodings/fastlanes/benches/bitpacking_decompress_selection.rs
@@ -32,15 +32,16 @@ fn decompress_bitpacking_early_filter<T: IntegerPType>(bencher: Bencher, fractio
         .collect::<BufferMut<T>>()
         .into_array()
         .to_primitive();
-
     let array = bitpack_to_best_bit_width(&values).unwrap();
-
     let mask = (0..100_000)
         .map(|_| rng.random_bool(fraction_kept))
         .collect();
-    let mask = &Mask::from_buffer(mask);
 
-    bencher.bench(|| filter(array.as_ref(), mask).unwrap().to_canonical());
+    let mask = Mask::from_buffer(mask);
+
+    bencher
+        .with_inputs(|| (array.clone(), mask.clone()))
+        .bench_refs(|(array, mask)| filter(array.as_ref(), mask).unwrap().to_canonical());
 }
 
 // #[divan::bench(types = [i8, i16, i32, i64], args = [0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999])]
@@ -58,9 +59,10 @@ fn decompress_bitpacking_late_filter<T: IntegerPType>(bencher: Bencher, fraction
     let mask = (0..100_000)
         .map(|_| rng.random_bool(fraction_kept))
         .collect();
-    let mask = &Mask::from_buffer(mask);
+
+    let mask = Mask::from_buffer(mask);
 
     bencher
-        .with_inputs(|| array.clone())
-        .bench_values(|array| filter(array.to_canonical().as_ref(), mask).unwrap());
+        .with_inputs(|| (array.clone(), mask.clone()))
+        .bench_refs(|(array, mask)| filter(array.to_canonical().as_ref(), mask).unwrap());
 }

--- a/encodings/fastlanes/benches/canonicalize_bench.rs
+++ b/encodings/fastlanes/benches/canonicalize_bench.rs
@@ -46,7 +46,7 @@ fn into_canonical_non_nullable(
 
     bencher
         .with_inputs(|| chunked.clone())
-        .bench_values(|chunked| chunked.to_canonical());
+        .bench_refs(|chunked| chunked.to_canonical());
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -65,7 +65,7 @@ fn canonical_into_non_nullable(
 
     bencher
         .with_inputs(|| chunked.clone())
-        .bench_values(|chunked| {
+        .bench_refs(|chunked| {
             let mut primitive_builder = PrimitiveBuilder::<i32>::with_capacity(
                 chunked.dtype().nullability(),
                 chunk_len * chunk_count,
@@ -102,7 +102,7 @@ fn into_canonical_nullable(
 
     bencher
         .with_inputs(|| chunked.clone())
-        .bench_values(|chunked| chunked.to_canonical());
+        .bench_refs(|chunked| chunked.to_canonical());
 }
 
 #[divan::bench(args = NULLABLE_BENCH_ARGS)]
@@ -122,7 +122,7 @@ fn canonical_into_nullable(
 
     bencher
         .with_inputs(|| chunked.clone())
-        .bench_values(|chunked| {
+        .bench_refs(|chunked| {
             let mut primitive_builder = PrimitiveBuilder::<i32>::with_capacity(
                 chunked.dtype().nullability(),
                 chunk_len * chunk_count,

--- a/encodings/fastlanes/benches/compute_between.rs
+++ b/encodings/fastlanes/benches/compute_between.rs
@@ -86,7 +86,7 @@ mod primitive {
         let mut rng = StdRng::seed_from_u64(0);
         let arr = generate_primitive_array::<T>(&mut rng, len);
 
-        bencher.with_inputs(|| arr.clone()).bench_values(|arr| {
+        bencher.with_inputs(|| arr.clone()).bench_refs(|arr| {
             boolean(
                 &compare(
                     arr.as_ref(),
@@ -120,7 +120,7 @@ mod primitive {
         let mut rng = StdRng::seed_from_u64(0);
         let arr = generate_primitive_array::<T>(&mut rng, len);
 
-        bencher.with_inputs(|| arr.clone()).bench_values(|arr| {
+        bencher.with_inputs(|| arr.clone()).bench_refs(|arr| {
             between(
                 arr.as_ref(),
                 ConstantArray::new(min, arr.len()).as_ref(),
@@ -164,7 +164,7 @@ mod bitpack {
         let mut rng = StdRng::seed_from_u64(0);
         let arr = generate_bit_pack_primitive_array::<T>(&mut rng, len);
 
-        bencher.with_inputs(|| arr.clone()).bench_values(|arr| {
+        bencher.with_inputs(|| arr.clone()).bench_refs(|arr| {
             boolean(
                 &compare(
                     arr.as_ref(),
@@ -197,7 +197,7 @@ mod bitpack {
         let mut rng = StdRng::seed_from_u64(0);
         let arr = generate_bit_pack_primitive_array::<T>(&mut rng, len);
 
-        bencher.with_inputs(|| arr.clone()).bench_values(|arr| {
+        bencher.with_inputs(|| arr.clone()).bench_refs(|arr| {
             between(
                 arr.as_ref(),
                 ConstantArray::new(min, arr.len()).as_ref(),
@@ -240,7 +240,7 @@ mod alp {
         let mut rng = StdRng::seed_from_u64(0);
         let arr = generate_alp_bit_pack_primitive_array::<T>(&mut rng, len);
 
-        bencher.with_inputs(|| arr.clone()).bench_values(|arr| {
+        bencher.with_inputs(|| arr.clone()).bench_refs(|arr| {
             boolean(
                 &compare(
                     arr.as_ref(),
@@ -273,7 +273,7 @@ mod alp {
         let mut rng = StdRng::seed_from_u64(0);
         let arr = generate_alp_bit_pack_primitive_array::<T>(&mut rng, len);
 
-        bencher.with_inputs(|| arr.clone()).bench_values(|arr| {
+        bencher.with_inputs(|| arr.clone()).bench_refs(|arr| {
             between(
                 arr.as_ref(),
                 ConstantArray::new(min, arr.len()).as_ref(),

--- a/encodings/fastlanes/benches/pipeline_bitpacking.rs
+++ b/encodings/fastlanes/benches/pipeline_bitpacking.rs
@@ -43,7 +43,7 @@ pub fn decompress_bitpacking_early_filter<T: NativePType>(bencher: Bencher, frac
     bencher
         // Be sure to reconstruct the mask to avoid cached set_indices
         .with_inputs(|| Mask::from_buffer(mask.clone()))
-        .bench_local_values(|mask| filter(array.as_ref(), &mask).unwrap().to_canonical());
+        .bench_refs(|mask| filter(array.as_ref(), mask).unwrap().to_canonical());
 }
 
 #[divan::bench(types = [i8, i16, i32, i64], args = TRUE_COUNT)]
@@ -63,7 +63,7 @@ pub fn decompress_bitpacking_late_filter<T: NativePType>(bencher: Bencher, fract
 
     bencher
         .with_inputs(|| Mask::from_buffer(mask.clone()))
-        .bench_values(|mask| filter(array.to_canonical().as_ref(), &mask).unwrap());
+        .bench_refs(|mask| filter(array.to_canonical().as_ref(), mask).unwrap());
 }
 
 #[divan::bench(types = [i8, i16, i32, i64], args = TRUE_COUNT)]
@@ -82,5 +82,5 @@ pub fn decompress_bitpacking_pipeline_filter<T: NativePType>(bencher: Bencher, f
 
     bencher
         .with_inputs(|| Mask::from(mask.clone()))
-        .bench_local_values(|mask| array.execute_with_selection(&mask).unwrap());
+        .bench_refs(|mask| array.execute_with_selection(mask).unwrap());
 }

--- a/encodings/fastlanes/benches/pipeline_bitpacking_compare_scalar.rs
+++ b/encodings/fastlanes/benches/pipeline_bitpacking_compare_scalar.rs
@@ -65,9 +65,9 @@ pub fn eval<T: NativePType + Into<Scalar>>(bencher: Bencher, fraction_kept: f64)
     bencher
         // Be sure to reconstruct the mask to avoid cached set_indices
         .with_inputs(|| (Mask::from_buffer(mask.clone()), array.clone()))
-        .bench_local_values(|(mask, array)| {
+        .bench_refs(|(mask, array)| {
             // We run the filter first, then compare.
-            let array = filter(array.as_ref(), &mask).unwrap();
+            let array = filter(array.as_ref(), mask).unwrap();
             expr.evaluate(&array).unwrap().to_canonical()
         });
 }

--- a/encodings/fastlanes/benches/pipeline_for.rs
+++ b/encodings/fastlanes/benches/pipeline_for.rs
@@ -64,7 +64,7 @@ pub fn decompress_for_early_filter<T: NativePType>(bencher: Bencher, fraction_ke
 
     bencher
         .with_inputs(|| Mask::from_buffer(mask.clone()))
-        .bench_local_values(|mask| filter(array.as_ref(), &mask).unwrap().to_canonical());
+        .bench_refs(|mask| filter(array.as_ref(), mask).unwrap().to_canonical());
 }
 
 // TODO(ngates): bring back benchmarks once operator API is stable.

--- a/encodings/fastlanes/benches/pipeline_rle.rs
+++ b/encodings/fastlanes/benches/pipeline_rle.rs
@@ -71,5 +71,5 @@ fn decompress<T: IntegerPType>(bencher: Bencher, (length, run_step): (usize, usi
 
     bencher
         .with_inputs(|| rle_array.clone())
-        .bench_values(|rle_array| rle_array.to_canonical());
+        .bench_refs(|rle_array| rle_array.to_canonical());
 }

--- a/encodings/fastlanes/benches/pipeline_v2_bitpacking_basic.rs
+++ b/encodings/fastlanes/benches/pipeline_v2_bitpacking_basic.rs
@@ -30,46 +30,42 @@ const BENCH_PARAMS: &[(usize, f64)] = &[
 
 #[divan::bench(args = BENCH_PARAMS)]
 fn bitpack_pipeline_unpack(bencher: Bencher, (num_elements, validity_pct): (usize, f64)) {
+    let mut rng = StdRng::seed_from_u64(42);
+
+    // Create array with randomized validity.
+    // Keep values small enough to fit in the bit width (0-1023 for 10 bits).
+    let values = (0..num_elements).map(|_| {
+        let is_valid = rng.random_bool(validity_pct);
+        is_valid.then(|| rng.random_range(0u32..1024))
+    });
+
+    let primitive = PrimitiveArray::from_option_iter(values).to_array();
+
+    // Encode with 10-bit width (supports values up to 1023).
+    let bitpacked = BitPackedArray::encode(&primitive, 10).unwrap();
+
     bencher
-        .with_inputs(|| {
-            let mut rng = StdRng::seed_from_u64(42);
-
-            // Create array with randomized validity.
-            // Keep values small enough to fit in the bit width (0-1023 for 10 bits).
-            let values = (0..num_elements).map(|_| {
-                let is_valid = rng.random_bool(validity_pct);
-                is_valid.then(|| rng.random_range(0u32..1024))
-            });
-
-            let primitive = PrimitiveArray::from_option_iter(values).to_array();
-
-            // Encode with 10-bit width (supports values up to 1023).
-            let bitpacked = BitPackedArray::encode(&primitive, 10).unwrap();
-
-            bitpacked.to_array()
-        })
-        .bench_local_values(|array| array.execute().unwrap());
+        .with_inputs(|| bitpacked.to_array())
+        .bench_refs(|array| array.execute().unwrap());
 }
 
 #[divan::bench(args = BENCH_PARAMS)]
 fn bitpack_canonical_unpack(bencher: Bencher, (num_elements, validity_pct): (usize, f64)) {
+    let mut rng = StdRng::seed_from_u64(42);
+
+    // Create array with randomized validity.
+    // Keep values small enough to fit in the bit width (0-1023 for 10 bits).
+    let values = (0..num_elements).map(|_| {
+        let is_valid = rng.random_bool(validity_pct);
+        is_valid.then(|| rng.random_range(0u32..1024))
+    });
+
+    let primitive = PrimitiveArray::from_option_iter(values).to_array();
+
+    // Encode with 10-bit width (supports values up to 1023).
+    let bitpacked = BitPackedArray::encode(&primitive, 10).unwrap();
+
     bencher
-        .with_inputs(|| {
-            let mut rng = StdRng::seed_from_u64(42);
-
-            // Create array with randomized validity.
-            // Keep values small enough to fit in the bit width (0-1023 for 10 bits).
-            let values = (0..num_elements).map(|_| {
-                let is_valid = rng.random_bool(validity_pct);
-                is_valid.then(|| rng.random_range(0u32..1024))
-            });
-
-            let primitive = PrimitiveArray::from_option_iter(values).to_array();
-
-            // Encode with 10-bit width (supports values up to 1023).
-            let bitpacked = BitPackedArray::encode(&primitive, 10).unwrap();
-
-            bitpacked.to_array()
-        })
-        .bench_local_values(|array| array.to_canonical());
+        .with_inputs(|| bitpacked.to_array())
+        .bench_refs(|array| array.to_canonical());
 }

--- a/encodings/runend/benches/run_end_filter.rs
+++ b/encodings/runend/benches/run_end_filter.rs
@@ -42,12 +42,11 @@ const BENCH_ARGS: &[(usize, usize, f64)] = &[
 
 #[divan::bench(args = BENCH_ARGS)]
 fn take_indices(bencher: Bencher, (n, run_step, filter_density): (usize, usize, f64)) {
-    let (array, mask) = fixture(n, run_step, filter_density);
-
-    let indices = mask.values().unwrap().indices();
-
     bencher
-        .with_inputs(|| (&array, indices))
+        .with_inputs(|| {
+            let (array, mask) = fixture(n, run_step, filter_density);
+            (array, mask.values().unwrap().indices().to_owned())
+        })
         .bench_refs(|(array, indices)| {
             take_indices_unchecked(array, indices, &Validity::NonNullable).unwrap()
         });
@@ -55,10 +54,8 @@ fn take_indices(bencher: Bencher, (n, run_step, filter_density): (usize, usize, 
 
 #[divan::bench(args = BENCH_ARGS)]
 fn filter_runend(bencher: Bencher, (n, run_step, filter_density): (usize, usize, f64)) {
-    let (array, mask) = fixture(n, run_step, filter_density);
-
     bencher
-        .with_inputs(|| (&array, &mask))
+        .with_inputs(|| fixture(n, run_step, filter_density))
         .bench_refs(|(array, mask)| filter_run_end(array, mask).unwrap());
 }
 

--- a/vortex/benches/pipeline.rs
+++ b/vortex/benches/pipeline.rs
@@ -795,79 +795,79 @@ fn compare_outputs(function_name: &str, expected: &[f32], actual: &[f32], expect
 
 #[divan::bench(consts = BENCHMARK_SIZES)]
 fn batch<const SIZE: usize>(bencher: Bencher) {
-    let (input_data, mut buffers) = setup(SIZE);
-
-    bencher.bench_local(|| {
-        decompress_batch(
-            &input_data.bitpacked,
-            input_data.reference,
-            input_data.exponents,
-            &mut buffers.bitpacked_output,
-            &mut buffers.for_decoded,
-            &mut buffers.alp_decoded,
-        );
-    });
+    bencher
+        .with_inputs(|| setup(SIZE))
+        .bench_refs(|(input_data, buffers)| {
+            decompress_batch(
+                &input_data.bitpacked,
+                input_data.reference,
+                input_data.exponents,
+                &mut buffers.bitpacked_output,
+                &mut buffers.for_decoded,
+                &mut buffers.alp_decoded,
+            );
+        });
 }
 
 #[divan::bench(consts = BENCHMARK_SIZES)]
 fn pipeline<const SIZE: usize>(bencher: Bencher) {
-    let (input_data, mut buffers) = setup(SIZE);
-
-    bencher.bench_local(|| {
-        decompress_pipeline(
-            &input_data.bitpacked,
-            input_data.reference,
-            input_data.exponents,
-            &mut buffers.bitpacked_output,
-            &mut buffers.for_decoded,
-            &mut buffers.pipeline_output,
-        );
-    });
+    bencher
+        .with_inputs(|| setup(SIZE))
+        .bench_refs(|(input_data, buffers)| {
+            decompress_pipeline(
+                &input_data.bitpacked,
+                input_data.reference,
+                input_data.exponents,
+                &mut buffers.bitpacked_output,
+                &mut buffers.for_decoded,
+                &mut buffers.pipeline_output,
+            );
+        });
 }
 
 #[divan::bench(consts = BENCHMARK_SIZES)]
 fn pipeline_extra_copy<const SIZE: usize>(bencher: Bencher) {
-    let (input_data, mut buffers) = setup(SIZE);
-
-    bencher.bench_local(|| {
-        decompress_pipeline_extra_copy(
-            &input_data.bitpacked,
-            input_data.reference,
-            input_data.exponents,
-            &mut buffers.bitpacked_output,
-            &mut buffers.for_decoded,
-            &mut buffers.alp_decoded,
-            &mut buffers.pipeline_output,
-        );
-    });
+    bencher
+        .with_inputs(|| setup(SIZE))
+        .bench_refs(|(input_data, buffers)| {
+            decompress_pipeline_extra_copy(
+                &input_data.bitpacked,
+                input_data.reference,
+                input_data.exponents,
+                &mut buffers.bitpacked_output,
+                &mut buffers.for_decoded,
+                &mut buffers.alp_decoded,
+                &mut buffers.pipeline_output,
+            );
+        });
 }
 
 #[divan::bench(consts = BENCHMARK_SIZES)]
 fn in_place_batch<const SIZE: usize>(bencher: Bencher) {
-    let (input_data, mut buffers) = setup(SIZE);
-
-    bencher.bench_local(|| {
-        decompress_in_place_batch(
-            &input_data.bitpacked,
-            input_data.reference,
-            input_data.exponents,
-            &mut buffers.alp_decoded_inplace_batch,
-        );
-    });
+    bencher
+        .with_inputs(|| setup(SIZE))
+        .bench_refs(|(input_data, buffers)| {
+            decompress_in_place_batch(
+                &input_data.bitpacked,
+                input_data.reference,
+                input_data.exponents,
+                &mut buffers.alp_decoded_inplace_batch,
+            );
+        });
 }
 
 #[divan::bench(consts = BENCHMARK_SIZES)]
 fn in_place_pipeline<const SIZE: usize>(bencher: Bencher) {
-    let (input_data, mut buffers) = setup(SIZE);
-
-    bencher.bench_local(|| {
-        decompress_in_place_pipeline(
-            &input_data.bitpacked,
-            input_data.reference,
-            input_data.exponents,
-            &mut buffers.alp_decoded_inplace_pipeline,
-        );
-    });
+    bencher
+        .with_inputs(|| setup(SIZE))
+        .bench_refs(|(input_data, buffers)| {
+            decompress_in_place_pipeline(
+                &input_data.bitpacked,
+                input_data.reference,
+                input_data.exponents,
+                &mut buffers.alp_decoded_inplace_pipeline,
+            );
+        });
 }
 
 // Correctness verification benchmarks.
@@ -877,82 +877,82 @@ fn in_place_pipeline<const SIZE: usize>(bencher: Bencher) {
 
 #[divan::bench(consts = VERIFICATION_SIZES)]
 fn verify_all_methods<const SIZE: usize>(bencher: Bencher) {
-    bencher.bench_local(|| {
-        let (mut input_data, mut buffers) = setup(SIZE);
+    bencher
+        .with_inputs(|| setup(SIZE))
+        .bench_refs(|(input_data, buffers)| {
+            // Create a filtered version of the original values for comparison.
+            // SAFETY: f32 and u32 have the same size and alignment.
+            let original_as_u32 = unsafe {
+                std::slice::from_raw_parts_mut(
+                    input_data.original.as_mut_ptr() as *mut u32,
+                    input_data.original.len(),
+                )
+            };
+            let expected_filtered_len = filter_scalar(original_as_u32);
 
-        // Create a filtered version of the original values for comparison.
-        // SAFETY: f32 and u32 have the same size and alignment.
-        let original_as_u32 = unsafe {
-            std::slice::from_raw_parts_mut(
-                input_data.original.as_mut_ptr() as *mut u32,
-                input_data.original.len(),
-            )
-        };
-        let expected_filtered_len = filter_scalar(original_as_u32);
+            // Run batch decompression (our reference implementation).
+            decompress_batch(
+                &input_data.bitpacked,
+                input_data.reference,
+                input_data.exponents,
+                &mut buffers.bitpacked_output,
+                &mut buffers.for_decoded,
+                &mut buffers.alp_decoded,
+            );
 
-        // Run batch decompression (our reference implementation).
-        decompress_batch(
-            &input_data.bitpacked,
-            input_data.reference,
-            input_data.exponents,
-            &mut buffers.bitpacked_output,
-            &mut buffers.for_decoded,
-            &mut buffers.alp_decoded,
-        );
+            // Verify batch decompression is correct.
+            // Note: for_decoded is not filtered, but alp_decoded is filtered.
+            verify(
+                "batch",
+                &buffers.for_decoded,
+                &buffers.alp_decoded,
+                &input_data.alp_encoded,
+                &input_data.original, // This is now filtered.
+                &input_data.patches,
+            );
 
-        // Verify batch decompression is correct.
-        // Note: for_decoded is not filtered, but alp_decoded is filtered.
-        verify(
-            "batch",
-            &buffers.for_decoded,
-            &buffers.alp_decoded,
-            &input_data.alp_encoded,
-            &input_data.original, // This is now filtered.
-            &input_data.patches,
-        );
+            // Run pipeline decompression and compare with batch.
+            decompress_pipeline(
+                &input_data.bitpacked,
+                input_data.reference,
+                input_data.exponents,
+                &mut buffers.bitpacked_output,
+                &mut buffers.for_decoded,
+                &mut buffers.pipeline_output,
+            );
+            compare_outputs(
+                "pipeline",
+                &buffers.alp_decoded,
+                &buffers.pipeline_output,
+                expected_filtered_len,
+            );
 
-        // Run pipeline decompression and compare with batch.
-        decompress_pipeline(
-            &input_data.bitpacked,
-            input_data.reference,
-            input_data.exponents,
-            &mut buffers.bitpacked_output,
-            &mut buffers.for_decoded,
-            &mut buffers.pipeline_output,
-        );
-        compare_outputs(
-            "pipeline",
-            &buffers.alp_decoded,
-            &buffers.pipeline_output,
-            expected_filtered_len,
-        );
+            // Run in-place batch decompression and compare with batch.
+            decompress_in_place_batch(
+                &input_data.bitpacked,
+                input_data.reference,
+                input_data.exponents,
+                &mut buffers.alp_decoded_inplace_batch,
+            );
+            compare_outputs(
+                "in_place_batch",
+                &buffers.alp_decoded,
+                &buffers.alp_decoded_inplace_batch,
+                expected_filtered_len,
+            );
 
-        // Run in-place batch decompression and compare with batch.
-        decompress_in_place_batch(
-            &input_data.bitpacked,
-            input_data.reference,
-            input_data.exponents,
-            &mut buffers.alp_decoded_inplace_batch,
-        );
-        compare_outputs(
-            "in_place_batch",
-            &buffers.alp_decoded,
-            &buffers.alp_decoded_inplace_batch,
-            expected_filtered_len,
-        );
-
-        // Run in-place pipeline decompression and compare with batch.
-        decompress_in_place_pipeline(
-            &input_data.bitpacked,
-            input_data.reference,
-            input_data.exponents,
-            &mut buffers.alp_decoded_inplace_pipeline,
-        );
-        compare_outputs(
-            "in_place_pipeline",
-            &buffers.alp_decoded,
-            &buffers.alp_decoded_inplace_pipeline,
-            expected_filtered_len,
-        );
-    });
+            // Run in-place pipeline decompression and compare with batch.
+            decompress_in_place_pipeline(
+                &input_data.bitpacked,
+                input_data.reference,
+                input_data.exponents,
+                &mut buffers.alp_decoded_inplace_pipeline,
+            );
+            compare_outputs(
+                "in_place_pipeline",
+                &buffers.alp_decoded,
+                &buffers.alp_decoded_inplace_pipeline,
+                expected_filtered_len,
+            );
+        });
 }


### PR DESCRIPTION
Inputs should be passed `with_inputs` to black box input args and benchmarked with `bench_refs` to exclude `drop`.