### PR TITLE
chore: benchmark hygiene

### DIFF
--- a/encodings/alp/benches/alp_compress.rs
+++ b/encodings/alp/benches/alp_compress.rs
@@ -105,7 +105,10 @@ fn decompress_alp<T: ALPFloat + NativePType>(bencher: Bencher, args: (usize, f64
 fn compress_rd<T: ALPRDFloat>(bencher: Bencher, n: usize) {
     let primitive = PrimitiveArray::new(buffer![T::from(1.23).unwrap(); n], Validity::NonNullable);
     let encoder = RDEncoder::new(&[T::from(1.23).unwrap()]);
-    bencher.bench(|| encoder.encode(&primitive));
+
+    bencher
+        .with_inputs(|| &primitive)
+        .bench_refs(|primitive| encoder.encode(primitive))
 }
 
 #[divan::bench(types = [f32, f64], args = [10_000, 100_000])]
@@ -115,6 +118,6 @@ fn decompress_rd<T: ALPRDFloat>(bencher: Bencher, n: usize) {
     let encoded = encoder.encode(&primitive);
 
     bencher
-        .with_inputs(move || encoded.clone())
-        .bench_values(|encoded| encoded.to_canonical());
+        .with_inputs(|| &encoded)
+        .bench_refs(|encoded| encoded.to_canonical());
 }

--- a/encodings/alp/benches/alp_compress.rs
+++ b/encodings/alp/benches/alp_compress.rs
@@ -64,12 +64,11 @@ fn compress_alp<T: ALPFloat + NativePType>(bencher: Bencher, args: (usize, f64, 
         Validity::NonNullable
     };
     let values = values.freeze();
+    let array = PrimitiveArray::new(values, validity);
 
     bencher
-        .with_inputs(|| (values.clone(), validity.clone()))
-        .bench_values(|(values, validity)| {
-            alp_encode(&PrimitiveArray::new(values, validity), None).unwrap()
-        })
+        .with_inputs(|| &array)
+        .bench_values(|array| alp_encode(array, None).unwrap())
 }
 
 #[divan::bench(types = [f32, f64], args = BENCH_ARGS)]
@@ -107,8 +106,8 @@ fn compress_rd<T: ALPRDFloat>(bencher: Bencher, n: usize) {
     let encoder = RDEncoder::new(&[T::from(1.23).unwrap()]);
 
     bencher
-        .with_inputs(|| &primitive)
-        .bench_refs(|primitive| encoder.encode(primitive))
+        .with_inputs(|| (&primitive, &encoder))
+        .bench_refs(|(primitive, encoder)| encoder.encode(primitive))
 }
 
 #[divan::bench(types = [f32, f64], args = [10_000, 100_000])]

--- a/encodings/fastlanes/benches/compute_between.rs
+++ b/encodings/fastlanes/benches/compute_between.rs
@@ -93,7 +93,7 @@ mod primitive {
         let mut rng = StdRng::seed_from_u64(0);
         let arr = generate_primitive_array::<T>(&mut rng, len);
 
-        bencher.with_inputs(|| arr.clone()).bench_refs(|arr| {
+        bencher.with_inputs(|| &arr).bench_refs(|arr| {
             boolean(
                 &compare(
                     arr.as_ref(),
@@ -127,7 +127,7 @@ mod primitive {
         let mut rng = StdRng::seed_from_u64(0);
         let arr = generate_primitive_array::<T>(&mut rng, len);
 
-        bencher.with_inputs(|| arr.clone()).bench_refs(|arr| {
+        bencher.with_inputs(|| &arr).bench_refs(|arr| {
             between(
                 arr.as_ref(),
                 ConstantArray::new(min, arr.len()).as_ref(),
@@ -175,7 +175,7 @@ mod bitpack {
         let mut rng = StdRng::seed_from_u64(0);
         let arr = generate_bit_pack_primitive_array::<T>(&mut rng, len);
 
-        bencher.with_inputs(|| arr.clone()).bench_refs(|arr| {
+        bencher.with_inputs(|| &arr).bench_refs(|arr| {
             boolean(
                 &compare(
                     arr.as_ref(),
@@ -208,7 +208,7 @@ mod bitpack {
         let mut rng = StdRng::seed_from_u64(0);
         let arr = generate_bit_pack_primitive_array::<T>(&mut rng, len);
 
-        bencher.with_inputs(|| arr.clone()).bench_refs(|arr| {
+        bencher.with_inputs(|| &arr).bench_refs(|arr| {
             between(
                 arr.as_ref(),
                 ConstantArray::new(min, arr.len()).as_ref(),

--- a/encodings/fastlanes/benches/pipeline_bitpacking_compare_scalar.rs
+++ b/encodings/fastlanes/benches/pipeline_bitpacking_compare_scalar.rs
@@ -72,8 +72,8 @@ pub fn eval<T: NativePType + Into<Scalar>>(bencher: Bencher, fraction_kept: f64)
 
     bencher
         // Be sure to reconstruct the mask to avoid cached set_indices
-        .with_inputs(|| (Mask::from_buffer(mask.clone()), array.clone()))
-        .bench_refs(|(mask, array)| {
+        .with_inputs(|| (&array, Mask::from_buffer(mask.clone())))
+        .bench_refs(|(array, mask)| {
             // We run the filter first, then compare.
             let array = filter(array.as_ref(), mask).unwrap();
             expr.evaluate(&array).unwrap().to_canonical()

--- a/encodings/fastlanes/benches/pipeline_rle.rs
+++ b/encodings/fastlanes/benches/pipeline_rle.rs
@@ -48,7 +48,7 @@ fn compress(bencher: Bencher, (length, run_step): (usize, usize)) {
     );
 
     bencher
-        .with_inputs(|| values.clone())
+        .with_inputs(|| &values)
         .bench_refs(|values| RLEArray::encode(values).unwrap());
 }
 

--- a/encodings/fastlanes/benches/pipeline_v2_bitpacking_basic.rs
+++ b/encodings/fastlanes/benches/pipeline_v2_bitpacking_basic.rs
@@ -44,9 +44,10 @@ fn bitpack_pipeline_unpack(bencher: Bencher, (num_elements, validity_pct): (usiz
 
     // Encode with 10-bit width (supports values up to 1023).
     let bitpacked = BitPackedArray::encode(&primitive, 10).unwrap();
+    let array = bitpacked.to_array();
 
     bencher
-        .with_inputs(|| bitpacked.to_array())
+        .with_inputs(|| &array)
         .bench_refs(|array| array.execute().unwrap());
 }
 

--- a/encodings/fsst/benches/chunked_dict_fsst_builder.rs
+++ b/encodings/fsst/benches/chunked_dict_fsst_builder.rs
@@ -43,7 +43,7 @@ fn chunked_dict_fsst_canonical_into(
 ) {
     let chunk = make_dict_fsst_chunks::<u16>(len, unique_values, chunk_count);
 
-    bencher.with_inputs(|| chunk.clone()).bench_values(|chunk| {
+    bencher.with_inputs(|| &chunk).bench_refs(|chunk| {
         let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
         chunk.append_to_builder(builder.as_mut());
         builder.finish()
@@ -58,6 +58,6 @@ fn chunked_dict_fsst_into_canonical(
     let chunk = make_dict_fsst_chunks::<u16>(len, unique_values, chunk_count);
 
     bencher
-        .with_inputs(|| chunk.clone())
-        .bench_values(|chunk| chunk.to_canonical())
+        .with_inputs(|| &chunk)
+        .bench_refs(|chunk| chunk.to_canonical())
 }

--- a/encodings/fsst/benches/fsst_compress.rs
+++ b/encodings/fsst/benches/fsst_compress.rs
@@ -47,7 +47,9 @@ const BENCH_ARGS: &[(usize, usize, u8)] = &[
 fn compress_fsst(bencher: Bencher, (string_count, avg_len, unique_chars): (usize, usize, u8)) {
     let array = generate_test_data(string_count, avg_len, unique_chars);
     let compressor = fsst_train_compressor(&array);
-    bencher.bench(|| fsst_compress(&array, &compressor))
+    bencher
+        .with_inputs(|| (&array, &compressor))
+        .bench_refs(|(array, compressor)| fsst_compress(*array, compressor))
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -64,7 +66,9 @@ fn decompress_fsst(bencher: Bencher, (string_count, avg_len, unique_chars): (usi
 #[divan::bench(args = BENCH_ARGS)]
 fn train_compressor(bencher: Bencher, (string_count, avg_len, unique_chars): (usize, usize, u8)) {
     let array = generate_test_data(string_count, avg_len, unique_chars);
-    bencher.bench(|| fsst_train_compressor(&array))
+    bencher
+        .with_inputs(|| &array)
+        .bench_refs(|array| fsst_train_compressor(array))
 }
 
 #[divan::bench(args = BENCH_ARGS)]

--- a/encodings/fsst/benches/fsst_compress.rs
+++ b/encodings/fsst/benches/fsst_compress.rs
@@ -57,8 +57,8 @@ fn decompress_fsst(bencher: Bencher, (string_count, avg_len, unique_chars): (usi
     let encoded = fsst_compress(array, &compressor);
 
     bencher
-        .with_inputs(|| encoded.clone())
-        .bench_values(|encoded| encoded.to_canonical())
+        .with_inputs(|| &encoded)
+        .bench_refs(|encoded| encoded.to_canonical())
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -75,7 +75,7 @@ fn pushdown_compare(bencher: Bencher, (string_count, avg_len, unique_chars): (us
     let constant = ConstantArray::new(Scalar::from(&b"const"[..]), array.len());
 
     bencher
-        .with_inputs(|| (fsst_array.clone(), constant.clone()))
+        .with_inputs(|| (&fsst_array, &constant))
         .bench_refs(|(fsst_array, constant)| {
             compare(fsst_array.as_ref(), constant.as_ref(), Operator::Eq).unwrap();
         })
@@ -92,7 +92,7 @@ fn canonicalize_compare(
     let constant = ConstantArray::new(Scalar::from(&b"const"[..]), array.len());
 
     bencher
-        .with_inputs(|| (fsst_array.clone(), constant.clone()))
+        .with_inputs(|| (&fsst_array, &constant))
         .bench_refs(|(fsst_array, constant)| {
             compare(
                 fsst_array.to_canonical().as_ref(),
@@ -123,7 +123,7 @@ fn chunked_canonicalize_into(
 ) {
     let array = generate_chunked_test_data(chunk_size, string_count, avg_len, unique_chars);
 
-    bencher.with_inputs(|| array.clone()).bench_values(|array| {
+    bencher.with_inputs(|| &array).bench_refs(|array| {
         let mut builder =
             VarBinViewBuilder::with_capacity(DType::Binary(Nullability::NonNullable), array.len());
         array.append_to_builder(&mut builder);
@@ -139,8 +139,8 @@ fn chunked_into_canonical(
     let array = generate_chunked_test_data(chunk_size, string_count, avg_len, unique_chars);
 
     bencher
-        .with_inputs(|| array.clone())
-        .bench_values(|array| array.to_canonical());
+        .with_inputs(|| &array)
+        .bench_refs(|array| array.to_canonical());
 }
 
 /// Helper function to generate random string data.

--- a/encodings/pco/benches/pco.rs
+++ b/encodings/pco/benches/pco.rs
@@ -54,8 +54,9 @@ pub fn pco_pipeline(bencher: Bencher, (size, selectivity): (usize, f64)) {
         .collect::<BitBuffer>();
 
     bencher
-        .with_inputs(|| (Mask::from_buffer(mask.clone()), pco_array.clone()))
-        .bench_refs(|(mask, pco_array)| pco_array.execute_with_selection(mask).unwrap());
+        // Be sure to reconstruct the mask to avoid cached set_indices
+        .with_inputs(|| (&pco_array, Mask::from_buffer(mask.clone())))
+        .bench_refs(|(pco_array, mask)| pco_array.execute_with_selection(mask).unwrap());
 }
 
 #[divan::bench(args = [
@@ -87,6 +88,7 @@ pub fn pco_canonical(bencher: Bencher, (size, selectivity): (usize, f64)) {
         .collect::<BitBuffer>();
 
     bencher
-        .with_inputs(|| (Mask::from_buffer(mask.clone()), pco_array.clone()))
-        .bench_refs(|(mask, pco_array)| filter(pco_array.to_canonical().as_ref(), mask).unwrap());
+        // Be sure to reconstruct the mask to avoid cached set_indices
+        .with_inputs(|| (&pco_array, Mask::from_buffer(mask.clone())))
+        .bench_refs(|(pco_array, mask)| filter(pco_array.to_canonical().as_ref(), mask).unwrap());
 }

--- a/encodings/runend/benches/run_end_compress.rs
+++ b/encodings/runend/benches/run_end_compress.rs
@@ -53,7 +53,7 @@ fn compress(bencher: Bencher, (length, run_step): (usize, usize)) {
     );
 
     bencher
-        .with_inputs(|| values.clone())
+        .with_inputs(|| &values)
         .bench_refs(|values| runend_encode(values));
 }
 
@@ -71,10 +71,11 @@ fn decompress<T: IntegerPType>(bencher: Bencher, (length, run_step): (usize, usi
         .into_array();
 
     let run_end_array = RunEndArray::new(ends, values);
+    let array = run_end_array.to_array();
 
     bencher
-        .with_inputs(|| run_end_array.to_array())
-        .bench_values(|array| array.to_canonical());
+        .with_inputs(|| &array)
+        .bench_refs(|array| array.to_canonical());
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -90,9 +91,11 @@ fn take_indices(bencher: Bencher, (length, run_step): (usize, usize)) {
 
     let source_array = PrimitiveArray::from_iter(0..(length as i32)).into_array();
     let (ends, values) = runend_encode(&values);
-    let runend_array = RunEndArray::try_new(ends.into_array(), values).unwrap();
+    let runend_array = RunEndArray::try_new(ends.into_array(), values)
+        .unwrap()
+        .to_array();
 
     bencher
-        .with_inputs(|| (source_array.clone(), runend_array.to_array()))
-        .bench_refs(|(array, indices)| take(array, indices).unwrap());
+        .with_inputs(|| (&source_array, &runend_array))
+        .bench_refs(|(array, indices)| take(array.as_ref(), indices.as_ref()).unwrap());
 }

--- a/encodings/runend/benches/run_end_null_count.rs
+++ b/encodings/runend/benches/run_end_null_count.rs
@@ -52,7 +52,7 @@ fn null_count_run_end(bencher: Bencher, (n, run_step, valid_density): (usize, us
     let array = fixture(n, run_step, valid_density).into_array();
 
     bencher
-        .with_inputs(|| array.clone())
+        .with_inputs(|| &array)
         .bench_refs(|array| array.invalid_count());
 }
 

--- a/encodings/zstd/benches/listview_rebuild.rs
+++ b/encodings/zstd/benches/listview_rebuild.rs
@@ -30,7 +30,9 @@ fn rebuild_naive(bencher: Bencher) {
 
     let list_view = ListViewArray::new(dudes, offsets, sizes, Validity::NonNullable);
 
-    bencher.bench_local(|| list_view.rebuild(ListViewRebuildMode::MakeZeroCopyToList))
+    bencher
+        .with_inputs(|| &list_view)
+        .bench_refs(|list_view| list_view.rebuild(ListViewRebuildMode::MakeZeroCopyToList))
 }
 
 fn main() {

--- a/vortex-array/benches/chunk_array_builder.rs
+++ b/vortex-array/benches/chunk_array_builder.rs
@@ -30,7 +30,7 @@ const BENCH_ARGS: &[(usize, usize)] = &[
 fn chunked_bool_canonical_into(bencher: Bencher, (len, chunk_count): (usize, usize)) {
     let chunk = make_bool_chunks(len, chunk_count);
 
-    bencher.with_inputs(|| chunk.clone()).bench_values(|chunk| {
+    bencher.with_inputs(|| &chunk).bench_refs(|chunk| {
         let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
         chunk.append_to_builder(builder.as_mut());
         builder.finish()
@@ -41,9 +41,9 @@ fn chunked_bool_canonical_into(bencher: Bencher, (len, chunk_count): (usize, usi
 fn chunked_opt_bool_canonical_into(bencher: Bencher, (len, chunk_count): (usize, usize)) {
     let chunk = make_opt_bool_chunks(len, chunk_count);
 
-    bencher.with_inputs(|| chunk.clone()).bench_values(|chunk| {
+    bencher.with_inputs(|| &chunk).bench_refs(|chunk| {
         let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
-        chunk.clone().append_to_builder(builder.as_mut());
+        chunk.append_to_builder(builder.as_mut());
         builder.finish()
     })
 }
@@ -53,8 +53,8 @@ fn chunked_bool_into_canonical(bencher: Bencher, (len, chunk_count): (usize, usi
     let chunk = make_bool_chunks(len, chunk_count);
 
     bencher
-        .with_inputs(|| chunk.clone())
-        .bench_values(|chunk| chunk.to_canonical())
+        .with_inputs(|| &chunk)
+        .bench_refs(|chunk| chunk.to_canonical())
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -62,24 +62,22 @@ fn chunked_opt_bool_into_canonical(bencher: Bencher, (len, chunk_count): (usize,
     let chunk = make_opt_bool_chunks(len, chunk_count);
 
     bencher
-        .with_inputs(|| chunk.clone())
-        .bench_values(|chunk| chunk.to_canonical())
+        .with_inputs(|| &chunk)
+        .bench_refs(|chunk| chunk.to_canonical())
 }
 
 #[divan::bench(args = BENCH_ARGS)]
 fn chunked_varbinview_canonical_into(bencher: Bencher, (len, chunk_count): (usize, usize)) {
     let chunks = make_string_chunks(false, len, chunk_count);
 
-    bencher
-        .with_inputs(|| chunks.clone())
-        .bench_values(|chunk| {
-            let mut builder = VarBinViewBuilder::with_capacity(
-                DType::Utf8(chunk.dtype().nullability()),
-                len * chunk_count,
-            );
-            chunk.append_to_builder(&mut builder);
-            builder.finish()
-        })
+    bencher.with_inputs(|| &chunks).bench_refs(|chunk| {
+        let mut builder = VarBinViewBuilder::with_capacity(
+            DType::Utf8(chunk.dtype().nullability()),
+            len * chunk_count,
+        );
+        chunk.append_to_builder(&mut builder);
+        builder.finish()
+    })
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -87,24 +85,22 @@ fn chunked_varbinview_into_canonical(bencher: Bencher, (len, chunk_count): (usiz
     let chunks = make_string_chunks(false, len, chunk_count);
 
     bencher
-        .with_inputs(|| chunks.clone())
-        .bench_values(|chunk| chunk.to_canonical())
+        .with_inputs(|| &chunks)
+        .bench_refs(|chunk| chunk.to_canonical())
 }
 
 #[divan::bench(args = BENCH_ARGS)]
 fn chunked_varbinview_opt_canonical_into(bencher: Bencher, (len, chunk_count): (usize, usize)) {
     let chunks = make_string_chunks(true, len, chunk_count);
 
-    bencher
-        .with_inputs(|| chunks.clone())
-        .bench_values(|chunk| {
-            let mut builder = VarBinViewBuilder::with_capacity(
-                DType::Utf8(chunk.dtype().nullability()),
-                len * chunk_count,
-            );
-            chunk.append_to_builder(&mut builder);
-            builder.finish()
-        })
+    bencher.with_inputs(|| &chunks).bench_refs(|chunk| {
+        let mut builder = VarBinViewBuilder::with_capacity(
+            DType::Utf8(chunk.dtype().nullability()),
+            len * chunk_count,
+        );
+        chunk.append_to_builder(&mut builder);
+        builder.finish()
+    })
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -112,8 +108,8 @@ fn chunked_varbinview_opt_into_canonical(bencher: Bencher, (len, chunk_count): (
     let chunks = make_string_chunks(true, len, chunk_count);
 
     bencher
-        .with_inputs(|| chunks.clone())
-        .bench_values(|chunk| chunk.to_canonical())
+        .with_inputs(|| &chunks)
+        .bench_refs(|chunk| chunk.to_canonical())
 }
 
 fn make_opt_bool_chunks(len: usize, chunk_count: usize) -> ArrayRef {

--- a/vortex-array/benches/chunked_dict_builder.rs
+++ b/vortex-array/benches/chunked_dict_builder.rs
@@ -33,7 +33,7 @@ fn chunked_dict_primitive_canonical_into<T: NativePType>(
 {
     let chunk = gen_dict_primitive_chunks::<T, u16>(len, unique_values, chunk_count);
 
-    bencher.with_inputs(|| chunk.clone()).bench_values(|chunk| {
+    bencher.with_inputs(|| &chunk).bench_refs(|chunk| {
         let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
         chunk.append_to_builder(builder.as_mut());
         builder.finish()
@@ -50,6 +50,6 @@ fn chunked_dict_primitive_into_canonical<T: NativePType>(
     let chunk = gen_dict_primitive_chunks::<T, u16>(len, unique_values, chunk_count);
 
     bencher
-        .with_inputs(|| chunk.clone())
-        .bench_values(|chunk| chunk.to_canonical())
+        .with_inputs(|| &chunk)
+        .bench_refs(|chunk| chunk.to_canonical())
 }

--- a/vortex-array/benches/dict_compare.rs
+++ b/vortex-array/benches/dict_compare.rs
@@ -45,7 +45,7 @@ fn bench_compare_primitive(bencher: divan::Bencher, (len, uniqueness): (usize, u
     let dict = dict_encode(primitive_arr.as_ref()).unwrap();
     let value = primitive_arr.as_slice::<i32>()[0];
 
-    bencher.with_inputs(|| dict.clone()).bench_refs(|dict| {
+    bencher.with_inputs(|| &dict).bench_refs(|dict| {
         compare(
             dict.as_ref(),
             ConstantArray::new(value, len).as_ref(),
@@ -62,7 +62,7 @@ fn bench_compare_varbin(bencher: divan::Bencher, (len, uniqueness): (usize, usiz
     let bytes = varbin_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
 
-    bencher.with_inputs(|| dict.clone()).bench_refs(|dict| {
+    bencher.with_inputs(|| &dict).bench_refs(|dict| {
         compare(
             dict.as_ref(),
             ConstantArray::new(value, len).as_ref(),
@@ -78,7 +78,7 @@ fn bench_compare_varbinview(bencher: divan::Bencher, (len, uniqueness): (usize, 
     let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
     let bytes = varbinview_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
-    bencher.with_inputs(|| dict.clone()).bench_refs(|dict| {
+    bencher.with_inputs(|| &dict).bench_refs(|dict| {
         compare(
             dict.as_ref(),
             ConstantArray::new(value, len).as_ref(),
@@ -110,9 +110,9 @@ fn bench_compare_sliced_dict_primitive(
     let dict = dict.slice(0..codes_len);
     let value = primitive_arr.as_slice::<i32>()[0];
 
-    bencher.with_inputs(|| dict.clone()).bench_refs(|dict| {
+    bencher.with_inputs(|| &dict).bench_refs(|dict| {
         compare(
-            dict,
+            dict.as_ref(),
             ConstantArray::new(value, codes_len).as_ref(),
             Operator::Eq,
         )
@@ -131,9 +131,9 @@ fn bench_compare_sliced_dict_varbinview(
     let bytes = varbin_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
 
-    bencher.with_inputs(|| dict.clone()).bench_refs(|dict| {
+    bencher.with_inputs(|| &dict).bench_refs(|dict| {
         compare(
-            dict,
+            dict.as_ref(),
             ConstantArray::new(value, codes_len).as_ref(),
             Operator::Eq,
         )

--- a/vortex-array/benches/dict_compress.rs
+++ b/vortex-array/benches/dict_compress.rs
@@ -44,7 +44,7 @@ where
     let primitive_arr = gen_primitive_for_dict::<T>(len, unique_values);
 
     bencher
-        .with_inputs(|| primitive_arr.clone())
+        .with_inputs(|| &primitive_arr)
         .bench_refs(|arr| dict_encode(arr.as_ref()));
 }
 
@@ -53,7 +53,7 @@ fn encode_varbin(bencher: Bencher, (len, unique_values): (usize, usize)) {
     let varbin_arr = VarBinArray::from(gen_varbin_words(len, unique_values));
 
     bencher
-        .with_inputs(|| varbin_arr.clone())
+        .with_inputs(|| &varbin_arr)
         .bench_refs(|arr| dict_encode(arr.as_ref()));
 }
 
@@ -62,7 +62,7 @@ fn encode_varbinview(bencher: Bencher, (len, unique_values): (usize, usize)) {
     let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(len, unique_values));
 
     bencher
-        .with_inputs(|| varbinview_arr.clone())
+        .with_inputs(|| &varbinview_arr)
         .bench_refs(|arr| dict_encode(arr.as_ref()));
 }
 
@@ -76,8 +76,8 @@ where
     let dict = dict_encode(primitive_arr.as_ref()).unwrap();
 
     bencher
-        .with_inputs(|| dict.clone())
-        .bench_values(|dict| dict.to_canonical());
+        .with_inputs(|| &dict)
+        .bench_refs(|dict| dict.to_canonical());
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -86,8 +86,8 @@ fn decode_varbin(bencher: Bencher, (len, unique_values): (usize, usize)) {
     let dict = dict_encode(varbin_arr.as_ref()).unwrap();
 
     bencher
-        .with_inputs(|| dict.clone())
-        .bench_values(|dict| dict.to_canonical());
+        .with_inputs(|| &dict)
+        .bench_refs(|dict| dict.to_canonical());
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -96,6 +96,6 @@ fn decode_varbinview(bencher: Bencher, (len, unique_values): (usize, usize)) {
     let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
 
     bencher
-        .with_inputs(|| dict.clone())
-        .bench_values(|dict| dict.to_canonical());
+        .with_inputs(|| &dict)
+        .bench_refs(|dict| dict.to_canonical());
 }

--- a/vortex-array/benches/dict_mask.rs
+++ b/vortex-array/benches/dict_mask.rs
@@ -59,7 +59,6 @@ fn bench_dict_mask(bencher: Bencher, (fraction_valid, fraction_masked): (f64, f6
     let values = PrimitiveArray::from_option_iter([None, Some(42i32)]).into_array();
     let array = DictArray::try_new(codes, values).unwrap().into_array();
     let filter_mask = filter_mask(len, fraction_masked, &mut rng);
-
     bencher
         .with_inputs(|| (&array, &filter_mask))
         .bench_refs(|(array, filter_mask)| mask(array.as_ref(), filter_mask).unwrap());

--- a/vortex-array/benches/dict_mask.rs
+++ b/vortex-array/benches/dict_mask.rs
@@ -59,7 +59,8 @@ fn bench_dict_mask(bencher: Bencher, (fraction_valid, fraction_masked): (f64, f6
     let values = PrimitiveArray::from_option_iter([None, Some(42i32)]).into_array();
     let array = DictArray::try_new(codes, values).unwrap().into_array();
     let filter_mask = filter_mask(len, fraction_masked, &mut rng);
+
     bencher
-        .with_inputs(|| (&array, filter_mask.clone()))
-        .bench_values(|(array, filter_mask)| mask(array, &filter_mask).unwrap());
+        .with_inputs(|| (&array, &filter_mask))
+        .bench_refs(|(array, filter_mask)| mask(array.as_ref(), filter_mask).unwrap());
 }

--- a/vortex-array/benches/dict_unreferenced_mask.rs
+++ b/vortex-array/benches/dict_unreferenced_mask.rs
@@ -42,8 +42,8 @@ fn bench_many_codes_few_values(bencher: Bencher, num_values: i32) {
     let array = DictArray::try_new(codes, values).unwrap();
 
     bencher
-        .with_inputs(|| array.clone())
-        .bench_values(|array| array.compute_referenced_values_mask(false).unwrap());
+        .with_inputs(|| &array)
+        .bench_refs(|array| array.compute_referenced_values_mask(false).unwrap());
 }
 
 /// Benchmark with many nulls in the codes array.
@@ -74,8 +74,8 @@ fn bench_many_nulls(bencher: Bencher, fraction_valid: f64) {
     let array = DictArray::try_new(codes, values).unwrap();
 
     bencher
-        .with_inputs(|| array.clone())
-        .bench_values(|array| array.compute_referenced_values_mask(false).unwrap());
+        .with_inputs(|| &array)
+        .bench_refs(|array| array.compute_referenced_values_mask(false).unwrap());
 }
 
 /// Benchmark with sparse code coverage (many unreferenced values).
@@ -108,6 +108,6 @@ fn bench_sparse_coverage(bencher: Bencher, fraction_coverage: f64) {
     let array = DictArray::try_new(codes, values).unwrap();
 
     bencher
-        .with_inputs(|| array.clone())
-        .bench_values(|array| array.compute_referenced_values_mask(false).unwrap());
+        .with_inputs(|| &array)
+        .bench_refs(|array| array.compute_referenced_values_mask(false).unwrap());
 }

--- a/vortex-array/benches/expr/large_struct_pack.rs
+++ b/vortex-array/benches/expr/large_struct_pack.rs
@@ -38,5 +38,7 @@ fn pack_return_dtype(bencher: Bencher, num_fields: usize) {
     let pack_expr = pack(children, Nullability::Nullable);
 
     // return_dtype should be fast, it is assumed cheap in some expression simplifiers
-    bencher.bench(|| pack_expr.return_dtype(&dtype).unwrap());
+    bencher
+        .with_inputs(|| (&pack_expr, &dtype))
+        .bench_refs(|(pack_expr, dtype)| pack_expr.return_dtype(dtype).unwrap());
 }

--- a/vortex-array/benches/take_patches.rs
+++ b/vortex-array/benches/take_patches.rs
@@ -49,8 +49,8 @@ fn take_search(bencher: Bencher, (patches_sparsity, index_multiple): (f64, f64))
     );
 
     bencher
-        .with_inputs(|| (&patches, indices.clone()))
-        .bench_values(|(patches, indices)| patches.take_search(indices.to_primitive(), false));
+        .with_inputs(|| (&patches, &indices))
+        .bench_refs(|(patches, indices)| patches.take_search(indices.to_primitive(), false));
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -64,8 +64,8 @@ fn take_search_chunked(bencher: Bencher, (patches_sparsity, index_multiple): (f6
     );
 
     bencher
-        .with_inputs(|| (&patches, indices.clone()))
-        .bench_values(|(patches, indices)| patches.take_search(indices.to_primitive(), false));
+        .with_inputs(|| (&patches, &indices))
+        .bench_refs(|(patches, indices)| patches.take_search(indices.to_primitive(), false));
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -79,8 +79,8 @@ fn take_map(bencher: Bencher, (patches_sparsity, index_multiple): (f64, f64)) {
     );
 
     bencher
-        .with_inputs(|| (&patches, indices.clone()))
-        .bench_values(|(patches, indices)| patches.take_map(indices.to_primitive(), false));
+        .with_inputs(|| (&patches, &indices))
+        .bench_refs(|(patches, indices)| patches.take_map(indices.to_primitive(), false));
 }
 
 fn fixture(len: usize, sparsity: f64, rng: &mut StdRng) -> Patches {

--- a/vortex-array/benches/varbinview_compact.rs
+++ b/vortex-array/benches/varbinview_compact.rs
@@ -42,24 +42,22 @@ fn compact_impl(bencher: Bencher, (output_size, utilization_pct): (usize, usize)
     let base_size = (output_size * 100) / utilization_pct;
     let base_array = build_varbinview_fixture(base_size);
     let indices = random_indices(output_size, base_size);
+    let taken = take(base_array.as_ref(), &indices).vortex_unwrap();
+    let array = taken.to_varbinview();
 
     bencher
-        .with_inputs(|| {
-            let taken = take(base_array.as_ref(), &indices).vortex_unwrap();
-            taken.to_varbinview()
-        })
+        .with_inputs(|| &array)
         .bench_refs(|array| array.compact_buffers().vortex_unwrap())
 }
 
 fn compact_sliced_impl(bencher: Bencher, (output_size, utilization_pct): (usize, usize)) {
     let base_size = (output_size * 100) / utilization_pct;
     let base_array = build_varbinview_fixture(base_size);
+    let sliced = base_array.as_ref().slice(0..output_size);
+    let array = sliced.to_varbinview();
 
     bencher
-        .with_inputs(|| {
-            let sliced = base_array.as_ref().slice(0..output_size);
-            sliced.to_varbinview()
-        })
+        .with_inputs(|| &array)
         .bench_refs(|array| array.compact_buffers().vortex_unwrap())
 }
 

--- a/vortex-array/benches/varbinview_compact.rs
+++ b/vortex-array/benches/varbinview_compact.rs
@@ -20,7 +20,7 @@ fn main() {
     divan::main();
 }
 
-const SMALL_ARGS: &[(usize, usize)] = &[
+const ARGS: &[(usize, usize)] = &[
     // (output_size, buffer_utilization_pct)
     (1 << 12, 10),
     (1 << 12, 90),
@@ -28,29 +28,13 @@ const SMALL_ARGS: &[(usize, usize)] = &[
     (1 << 14, 90),
 ];
 
-const LARGE_ARGS: &[(usize, usize)] = &[
-    // (output_size, buffer_utilization_pct)
-    (1 << 19, 10),
-    (1 << 19, 90),
-];
-
-#[divan::bench(args = SMALL_ARGS)]
+#[divan::bench(args = ARGS)]
 fn compact(bencher: Bencher, args: (usize, usize)) {
     compact_impl(bencher, args);
 }
 
-#[divan::bench(args = LARGE_ARGS, sample_count = 10)]
-fn compact_large(bencher: Bencher, args: (usize, usize)) {
-    compact_impl(bencher, args);
-}
-
-#[divan::bench(args = SMALL_ARGS)]
+#[divan::bench(args = ARGS)]
 fn compact_sliced(bencher: Bencher, args: (usize, usize)) {
-    compact_sliced_impl(bencher, args);
-}
-
-#[divan::bench(args = LARGE_ARGS, sample_count = 10)]
-fn compact_sliced_large(bencher: Bencher, args: (usize, usize)) {
     compact_sliced_impl(bencher, args);
 }
 
@@ -64,7 +48,7 @@ fn compact_impl(bencher: Bencher, (output_size, utilization_pct): (usize, usize)
             let taken = take(base_array.as_ref(), &indices).vortex_unwrap();
             taken.to_varbinview()
         })
-        .bench_values(|array| array.compact_buffers().vortex_unwrap())
+        .bench_refs(|array| array.compact_buffers().vortex_unwrap())
 }
 
 fn compact_sliced_impl(bencher: Bencher, (output_size, utilization_pct): (usize, usize)) {
@@ -76,7 +60,7 @@ fn compact_sliced_impl(bencher: Bencher, (output_size, utilization_pct): (usize,
             let sliced = base_array.as_ref().slice(0..output_size);
             sliced.to_varbinview()
         })
-        .bench_values(|array| array.compact_buffers().vortex_unwrap())
+        .bench_refs(|array| array.compact_buffers().vortex_unwrap())
 }
 
 /// Creates a base VarBinViewArray with mix of inlined and outlined strings.

--- a/vortex-btrblocks/benches/stats_calc.rs
+++ b/vortex-btrblocks/benches/stats_calc.rs
@@ -57,7 +57,7 @@ mod benchmarks {
             Distribution::LongRuns => generate_runs(64),
         };
 
-        bencher.with_inputs(|| values.clone()).bench_refs(|values| {
+        bencher.with_inputs(|| &values).bench_refs(|values| {
             IntegerStats::generate_opts(values, GenerateStatsOptions::default());
         });
     }
@@ -70,7 +70,7 @@ mod benchmarks {
             Distribution::LongRuns => generate_runs(64),
         };
 
-        bencher.with_inputs(|| values.clone()).bench_refs(|values| {
+        bencher.with_inputs(|| &values).bench_refs(|values| {
             IntegerStats::generate_opts(
                 values,
                 GenerateStatsOptions {

--- a/vortex-buffer/benches/vortex_bitbuffer.rs
+++ b/vortex-buffer/benches/vortex_bitbuffer.rs
@@ -117,7 +117,7 @@ fn append_buffer_arrow_buffer(bencher: Bencher, length: usize) {
 #[divan::bench(args = INPUT_SIZE)]
 fn value_vortex_buffer(bencher: Bencher, length: usize) {
     let buffer = BitBuffer::from_iter((0..length).map(|i| i % 2 == 0));
-    bencher.bench_local(|| {
+    bencher.with_inputs(|| &buffer).bench_refs(|buffer| {
         for idx in 0..length {
             divan::black_box(buffer.value(idx));
         }
@@ -127,7 +127,7 @@ fn value_vortex_buffer(bencher: Bencher, length: usize) {
 #[divan::bench(args = INPUT_SIZE)]
 fn value_arrow_buffer(bencher: Bencher, length: usize) {
     let buffer = Arrow(BooleanBuffer::from_iter((0..length).map(|i| i % 2 == 0)));
-    bencher.bench_local(|| {
+    bencher.with_inputs(|| &buffer).bench_refs(|buffer| {
         for idx in 0..length {
             divan::black_box(buffer.0.value(idx));
         }
@@ -136,28 +136,28 @@ fn value_arrow_buffer(bencher: Bencher, length: usize) {
 
 #[divan::bench(args = INPUT_SIZE)]
 fn slice_vortex_buffer(bencher: Bencher, length: usize) {
+    let buffer = BitBuffer::from_iter((0..length).map(|i| i % 2 == 0));
     bencher
-        .with_inputs(|| BitBuffer::from_iter((0..length).map(|i| i % 2 == 0)))
-        .bench_values(|buffer| {
-            let mid = length / 2;
+        .with_inputs(|| (&buffer, length / 2))
+        .bench_refs(|(buffer, mid)| {
+            let mid = *mid;
             divan::black_box(buffer.slice(mid / 2..mid + mid / 2));
         });
 }
 
 #[divan::bench(args = INPUT_SIZE)]
 fn slice_arrow_buffer(bencher: Bencher, length: usize) {
-    bencher
-        .with_inputs(|| Arrow(BooleanBuffer::from_iter((0..length).map(|i| i % 2 == 0))))
-        .bench_values(|buffer| {
-            let mid = length / 2;
-            divan::black_box(buffer.0.slice(mid / 2, mid / 2));
-        });
+    let buffer = Arrow(BooleanBuffer::from_iter((0..length).map(|i| i % 2 == 0)));
+    bencher.with_inputs(|| &buffer).bench_refs(|buffer| {
+        let mid = length / 2;
+        divan::black_box(buffer.0.slice(mid / 2, mid / 2));
+    });
 }
 
 #[divan::bench(args = INPUT_SIZE)]
 fn true_count_vortex_buffer(bencher: Bencher, length: usize) {
     let buffer = BitBuffer::from_iter((0..length).map(|i| i % 2 == 0));
-    bencher.bench_local(|| {
+    bencher.with_inputs(|| &buffer).bench_refs(|buffer| {
         divan::black_box(buffer.true_count());
     })
 }
@@ -165,7 +165,7 @@ fn true_count_vortex_buffer(bencher: Bencher, length: usize) {
 #[divan::bench(args = INPUT_SIZE)]
 fn true_count_arrow_buffer(bencher: Bencher, length: usize) {
     let buffer = Arrow(BooleanBuffer::from_iter((0..length).map(|i| i % 2 == 0)));
-    bencher.bench_local(|| {
+    bencher.with_inputs(|| &buffer).bench_refs(|buffer| {
         divan::black_box(buffer.0.count_set_bits());
     });
 }
@@ -185,15 +185,11 @@ fn bitwise_and_vortex_buffer(bencher: Bencher, length: usize) {
 
 #[divan::bench(args = INPUT_SIZE)]
 fn bitwise_and_arrow_buffer(bencher: Bencher, length: usize) {
-    bencher
-        .with_inputs(|| {
-            let a = Arrow(BooleanBuffer::from_iter((0..length).map(|i| i % 2 == 0)));
-            let b = Arrow(BooleanBuffer::from_iter((0..length).map(|i| i % 3 == 0)));
-            (a, b)
-        })
-        .bench_values(|(a, b)| {
-            divan::black_box(&a.0 & &b.0);
-        });
+    let a = Arrow(BooleanBuffer::from_iter((0..length).map(|i| i % 2 == 0)));
+    let b = Arrow(BooleanBuffer::from_iter((0..length).map(|i| i % 3 == 0)));
+    bencher.with_inputs(|| (&a, &b)).bench_refs(|(a, b)| {
+        divan::black_box(&a.0 & &b.0);
+    });
 }
 
 #[divan::bench(args = INPUT_SIZE)]
@@ -211,15 +207,11 @@ fn bitwise_or_vortex_buffer(bencher: Bencher, length: usize) {
 
 #[divan::bench(args = INPUT_SIZE)]
 fn bitwise_or_arrow_buffer(bencher: Bencher, length: usize) {
-    bencher
-        .with_inputs(|| {
-            let a = Arrow(BooleanBuffer::from_iter((0..length).map(|i| i % 2 == 0)));
-            let b = Arrow(BooleanBuffer::from_iter((0..length).map(|i| i % 3 == 0)));
-            (a, b)
-        })
-        .bench_values(|(a, b)| {
-            divan::black_box(&a.0 | &b.0);
-        });
+    let a = Arrow(BooleanBuffer::from_iter((0..length).map(|i| i % 2 == 0)));
+    let b = Arrow(BooleanBuffer::from_iter((0..length).map(|i| i % 3 == 0)));
+    bencher.with_inputs(|| (&a, &b)).bench_refs(|(a, b)| {
+        divan::black_box(&a.0 | &b.0);
+    });
 }
 
 #[divan::bench(args = INPUT_SIZE)]

--- a/vortex-buffer/benches/vortex_bitbuffer.rs
+++ b/vortex-buffer/benches/vortex_bitbuffer.rs
@@ -244,7 +244,7 @@ fn bitwise_not_arrow_buffer(bencher: Bencher, length: usize) {
 #[divan::bench(args = INPUT_SIZE)]
 fn iter_vortex_buffer(bencher: Bencher, length: usize) {
     let buffer = BitBuffer::from_iter((0..length).map(|i| i % 2 == 0));
-    bencher.bench_local(|| {
+    bencher.with_inputs(|| &buffer).bench_refs(|buffer| {
         for value in buffer.iter() {
             divan::black_box(value);
         }
@@ -254,7 +254,7 @@ fn iter_vortex_buffer(bencher: Bencher, length: usize) {
 #[divan::bench(args = INPUT_SIZE)]
 fn iter_arrow_buffer(bencher: Bencher, length: usize) {
     let buffer = Arrow(BooleanBuffer::from_iter((0..length).map(|i| i % 2 == 0)));
-    bencher.bench_local(|| {
+    bencher.with_inputs(|| &buffer).bench_refs(|buffer| {
         for value in buffer.0.iter() {
             divan::black_box(value);
         }
@@ -264,7 +264,7 @@ fn iter_arrow_buffer(bencher: Bencher, length: usize) {
 #[divan::bench(args = INPUT_SIZE)]
 fn set_indices_vortex_buffer(bencher: Bencher, length: usize) {
     let buffer = BitBuffer::from_iter((0..length).map(|i| i % 2 == 0));
-    bencher.bench_local(|| {
+    bencher.with_inputs(|| &buffer).bench_refs(|buffer| {
         for idx in buffer.set_indices() {
             divan::black_box(idx);
         }
@@ -274,7 +274,7 @@ fn set_indices_vortex_buffer(bencher: Bencher, length: usize) {
 #[divan::bench(args = INPUT_SIZE)]
 fn set_indices_arrow_buffer(bencher: Bencher, length: usize) {
     let buffer = Arrow(BooleanBuffer::from_iter((0..length).map(|i| i % 2 == 0)));
-    bencher.bench_local(|| {
+    bencher.with_inputs(|| &buffer).bench_refs(|buffer| {
         for idx in buffer.0.set_indices() {
             divan::black_box(idx);
         }

--- a/vortex-buffer/benches/vortex_buffer.rs
+++ b/vortex-buffer/benches/vortex_buffer.rs
@@ -145,7 +145,7 @@ fn map_new_output(bencher: Bencher, n: i32) {
                 BufferMut::with_capacity(n as usize),
             )
         })
-        .bench_values(|(buffer, mut out)| {
+        .bench_refs(|(buffer, out)| {
             buffer
                 .iter()
                 .for_each(|&i| unsafe { out.push_unchecked((i as u32) + 1) })

--- a/vortex-compute/benches/filter_buffer_mut.rs
+++ b/vortex-compute/benches/filter_buffer_mut.rs
@@ -64,13 +64,10 @@ impl From<u8> for LargeElement {
 #[divan::bench(types = [u8, u32, u64, LargeElement], args = SELECTIVITIES, sample_count = 1000)]
 fn filter_selectivity<T: Copy + Default + From<u8>>(bencher: Bencher, selectivity: f64) {
     let mask = generate_mask(BUFFER_SIZE, selectivity);
+
     bencher
-        .with_inputs(|| {
-            let buffer = create_test_buffer::<T>(BUFFER_SIZE);
-            (buffer, mask.clone())
-        })
-        .bench_values(|(mut buffer, mask)| {
+        .with_inputs(|| create_test_buffer::<T>(BUFFER_SIZE))
+        .bench_refs(|buffer| {
             buffer.filter(&mask);
-            divan::black_box(buffer);
         });
 }

--- a/vortex/benches/common_encoding_tree_throughput.rs
+++ b/vortex/benches/common_encoding_tree_throughput.rs
@@ -349,6 +349,6 @@ fn decompress(bencher: Bencher, (name, setup_fn): (&str, fn() -> ArrayRef)) {
     let nbytes = compressed.nbytes();
 
     with_counter!(bencher, nbytes)
-        .with_inputs(|| compressed.clone())
-        .bench_values(|a| a.to_canonical());
+        .with_inputs(|| &compressed)
+        .bench_refs(|a| a.to_canonical());
 }

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -133,7 +133,7 @@ fn bench_delta_compress_u32(bencher: Bencher) {
     let (uint_array, ..) = setup_primitive_arrays();
 
     with_counter!(bencher, NUM_VALUES * 4)
-        .with_inputs(|| uint_array.clone())
+        .with_inputs(|| &uint_array)
         .bench_refs(|a| {
             let (bases, deltas) = delta_compress(a).unwrap();
             DeltaArray::try_from_delta_compress_parts(bases.into_array(), deltas.into_array())
@@ -248,7 +248,7 @@ fn bench_alp_rd_decompress_f64(bencher: Bencher) {
     let compressed = encoder.encode(&float_array);
 
     with_counter!(bencher, NUM_VALUES * 8)
-        .with_inputs(|| compressed.clone())
+        .with_inputs(|| &compressed)
         .bench_refs(|a| a.to_canonical());
 }
 
@@ -321,8 +321,8 @@ fn bench_fsst_compress_string(bencher: Bencher) {
     let nbytes = varbinview_arr.nbytes() as u64;
 
     with_counter!(bencher, nbytes)
-        .with_inputs(|| varbinview_arr.clone())
-        .bench_values(|a| fsst_compress(&a, &fsst_compressor));
+        .with_inputs(|| &varbinview_arr)
+        .bench_refs(|a| fsst_compress(*a, &fsst_compressor));
 }
 
 #[divan::bench(name = "fsst_decompress_string")]
@@ -356,6 +356,6 @@ fn bench_zstd_decompress_string(bencher: Bencher) {
     let nbytes = varbinview_arr.into_array().nbytes() as u64;
 
     with_counter!(bencher, nbytes)
-        .with_inputs(|| compressed.clone())
+        .with_inputs(|| &compressed)
         .bench_refs(|a| a.to_canonical());
 }

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -275,7 +275,7 @@ fn bench_pcodec_decompress_f64(bencher: Bencher) {
 #[divan::bench(name = "zstd_compress_u32")]
 fn bench_zstd_compress_u32(bencher: Bencher) {
     let (uint_array, ..) = setup_primitive_arrays();
-    let array = uint_array.clone().into_array();
+    let array = uint_array.into_array();
 
     with_counter!(bencher, NUM_VALUES * 4)
         .with_inputs(|| array.clone())

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -92,8 +92,8 @@ fn bench_bitpacked_compress_u32(bencher: Bencher) {
     let bit_width = 8;
 
     with_counter!(bencher, NUM_VALUES * 4)
-        .with_inputs(|| uint_array.clone())
-        .bench_values(|a| unsafe { bitpack_encode_unchecked(a, bit_width).unwrap() });
+        .with_inputs(|| &uint_array)
+        .bench_refs(|a| unsafe { bitpack_encode_unchecked(a.clone(), bit_width).unwrap() });
 }
 
 #[divan::bench(name = "bitpacked_decompress_u32")]
@@ -114,8 +114,8 @@ fn bench_runend_compress_u32(bencher: Bencher) {
     let (uint_array, ..) = setup_primitive_arrays();
 
     with_counter!(bencher, NUM_VALUES * 4)
-        .with_inputs(|| uint_array.clone())
-        .bench_values(|a| RunEndArray::encode(a.into_array()).unwrap());
+        .with_inputs(|| &uint_array)
+        .bench_refs(|a| RunEndArray::encode(a.clone().into_array()).unwrap());
 }
 
 #[divan::bench(name = "runend_decompress_u32")]
@@ -158,8 +158,8 @@ fn bench_for_compress_i32(bencher: Bencher) {
     let (_, int_array, _) = setup_primitive_arrays();
 
     with_counter!(bencher, NUM_VALUES * 4)
-        .with_inputs(|| int_array.clone())
-        .bench_values(|a| FoRArray::encode(a).unwrap());
+        .with_inputs(|| &int_array)
+        .bench_refs(|a| FoRArray::encode(a.clone()).unwrap());
 }
 
 #[divan::bench(name = "for_decompress_i32")]
@@ -196,8 +196,8 @@ fn bench_zigzag_compress_i32(bencher: Bencher) {
     let (_, int_array, _) = setup_primitive_arrays();
 
     with_counter!(bencher, NUM_VALUES * 4)
-        .with_inputs(|| int_array.clone())
-        .bench_values(|a| zigzag_encode(a).unwrap());
+        .with_inputs(|| &int_array)
+        .bench_refs(|a| zigzag_encode(a.clone()).unwrap());
 }
 
 #[divan::bench(name = "zigzag_decompress_i32")]
@@ -275,10 +275,11 @@ fn bench_pcodec_decompress_f64(bencher: Bencher) {
 #[divan::bench(name = "zstd_compress_u32")]
 fn bench_zstd_compress_u32(bencher: Bencher) {
     let (uint_array, ..) = setup_primitive_arrays();
+    let array = uint_array.clone().into_array();
 
     with_counter!(bencher, NUM_VALUES * 4)
-        .with_inputs(|| uint_array.clone())
-        .bench_values(|a| ZstdArray::from_array(a.into_array(), 3, 8192).unwrap());
+        .with_inputs(|| array.clone())
+        .bench_values(|a| ZstdArray::from_array(a, 3, 8192).unwrap());
 }
 
 #[cfg(feature = "zstd")]
@@ -342,10 +343,11 @@ fn bench_fsst_decompress_string(bencher: Bencher) {
 fn bench_zstd_compress_string(bencher: Bencher) {
     let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
     let nbytes = varbinview_arr.nbytes() as u64;
+    let array = varbinview_arr.into_array();
 
     with_counter!(bencher, nbytes)
-        .with_inputs(|| varbinview_arr.clone())
-        .bench_values(|a| ZstdArray::from_array(a.into_array(), 3, 8192).unwrap());
+        .with_inputs(|| array.clone())
+        .bench_values(|a| ZstdArray::from_array(a, 3, 8192).unwrap());
 }
 
 #[cfg(feature = "zstd")]


### PR DESCRIPTION
- black box via `with_inputs`
- minimize work done in `with_inputs` to minimize total time to run the benchmarks
- only `clone` the input if the argument is consumed by the benchmarked function
- pass argument by ref `bench_refs` to exclude `drop` from being benchmarked