### PR TITLE
Chore: Fully qualify imported items

### DIFF
--- a/bench-vortex/rustfmt.toml
+++ b/bench-vortex/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/encodings/alp/rustfmt.toml
+++ b/encodings/alp/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/encodings/bytebool/rustfmt.toml
+++ b/encodings/bytebool/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/encodings/datetime-parts/rustfmt.toml
+++ b/encodings/datetime-parts/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/encodings/decimal-byte-parts/rustfmt.toml
+++ b/encodings/decimal-byte-parts/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/encodings/fastlanes/rustfmt.toml
+++ b/encodings/fastlanes/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/encodings/fsst/rustfmt.toml
+++ b/encodings/fsst/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/encodings/pco/rustfmt.toml
+++ b/encodings/pco/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/encodings/runend/rustfmt.toml
+++ b/encodings/runend/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/encodings/sequence/rustfmt.toml
+++ b/encodings/sequence/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/encodings/sparse/rustfmt.toml
+++ b/encodings/sparse/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/encodings/zigzag/rustfmt.toml
+++ b/encodings/zigzag/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/encodings/zstd/rustfmt.toml
+++ b/encodings/zstd/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/fuzz/rustfmt.toml
+++ b/fuzz/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,5 +4,5 @@ format_macro_bodies = true
 group_imports = "StdExternalCrate"
 unstable_features = true
 use_field_init_shorthand = true
-imports_granularity = "Module"
+imports_granularity = "Item"
 style_edition = "2024"

--- a/vortex-array/rustfmt.toml
+++ b/vortex-array/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-btrblocks/rustfmt.toml
+++ b/vortex-btrblocks/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-buffer/rustfmt.toml
+++ b/vortex-buffer/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-compute/rustfmt.toml
+++ b/vortex-compute/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-cxx/rustfmt.toml
+++ b/vortex-cxx/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-datafusion/rustfmt.toml
+++ b/vortex-datafusion/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-dtype/rustfmt.toml
+++ b/vortex-dtype/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-duckdb/rustfmt.toml
+++ b/vortex-duckdb/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-error/rustfmt.toml
+++ b/vortex-error/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-ffi/rustfmt.toml
+++ b/vortex-ffi/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-file/rustfmt.toml
+++ b/vortex-file/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-flatbuffers/rustfmt.toml
+++ b/vortex-flatbuffers/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-gpu-kernels/rustfmt.toml
+++ b/vortex-gpu-kernels/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-gpu/rustfmt.toml
+++ b/vortex-gpu/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-io/rustfmt.toml
+++ b/vortex-io/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-ipc/rustfmt.toml
+++ b/vortex-ipc/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-jni/rustfmt.toml
+++ b/vortex-jni/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-layout/rustfmt.toml
+++ b/vortex-layout/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-mask/rustfmt.toml
+++ b/vortex-mask/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-metrics/rustfmt.toml
+++ b/vortex-metrics/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-proto/rustfmt.toml
+++ b/vortex-proto/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-python/rustfmt.toml
+++ b/vortex-python/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-scalar/rustfmt.toml
+++ b/vortex-scalar/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-scan/rustfmt.toml
+++ b/vortex-scan/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-session/rustfmt.toml
+++ b/vortex-session/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-tui/rustfmt.toml
+++ b/vortex-tui/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-utils/rustfmt.toml
+++ b/vortex-utils/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex-vector/rustfmt.toml
+++ b/vortex-vector/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/vortex/rustfmt.toml
+++ b/vortex/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/wasm-test/rustfmt.toml
+++ b/wasm-test/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/xtask/rustfmt.toml
+++ b/xtask/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"


### PR DESCRIPTION
Instead of having a huge PR that changes basically every file in the codebase, we can do this incrementally by setting a global setting and overrides in each subcrate, and when we want to make the change we can just delete the subcrate `rustfmt.toml` file.

Just to reiterate, we want this because it will prevent merge conflicts every time an import gets added or deleted.