### PR TITLE
Fix: ConstantArray float sum behaves the same way as primitive array

### DIFF
--- a/vortex-array/src/arrays/constant/compute/sum.rs
+++ b/vortex-array/src/arrays/constant/compute/sum.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use arrow_array::ArrowNativeTypeOp;
-use num_traits::{CheckedAdd, CheckedMul, ToPrimitive};
+use num_traits::{CheckedAdd, CheckedMul};
 use vortex_dtype::{DType, DecimalDType, NativePType, Nullability, i256, match_each_native_ptype};
 use vortex_error::{VortexExpect, VortexResult, vortex_bail, vortex_err};
 use vortex_scalar::{DecimalScalar, DecimalValue, PrimitiveScalar, Scalar, ScalarValue};
@@ -138,21 +137,19 @@ fn sum_float(
     array_len: usize,
     accumulator: &Scalar,
 ) -> VortexResult<Option<f64>> {
-    let v = primitive_scalar
-        .as_::<f64>()
-        .vortex_expect("cannot be null");
-    let array_len = array_len
-        .to_f64()
-        .ok_or_else(|| vortex_err!("array_len must fit the sum type"))?;
-
-    let Ok(array_sum) = v.mul_checked(array_len) else {
-        return Ok(None);
-    };
     let initial = accumulator
         .as_primitive()
         .as_::<f64>()
         .vortex_expect("cannot be null");
-    Ok(Some(initial + array_sum))
+    let v = primitive_scalar
+        .as_::<f64>()
+        .vortex_expect("cannot be null");
+
+    let mut sum = initial;
+    for _ in 0..array_len {
+        sum += v;
+    }
+    Ok(Some(sum))
 }
 
 register_kernel!(SumKernelAdapter(ConstantVTable).lift());
@@ -161,10 +158,11 @@ register_kernel!(SumKernelAdapter(ConstantVTable).lift());
 mod tests {
     use vortex_dtype::Nullability::Nullable;
     use vortex_dtype::{DType, DecimalDType, Nullability, PType, i256};
+    use vortex_error::VortexUnwrap;
     use vortex_scalar::{DecimalValue, Scalar};
 
     use crate::arrays::ConstantArray;
-    use crate::compute::sum;
+    use crate::compute::{sum, sum_with_accumulator};
     use crate::stats::Stat;
     use crate::{Array, IntoArray};
 
@@ -267,6 +265,18 @@ mod tests {
         assert_eq!(
             result.as_decimal().decimal_value(),
             Some(DecimalValue::I256(i256::from_i128(99_999_999_900)))
+        );
+    }
+
+    #[test]
+    fn test_sum_float_non_multiply() {
+        let acc = -2048669276050936500000000000f64;
+        let array = ConstantArray::new(6.1811675e16f64, 25);
+        let sum =
+            sum_with_accumulator(array.as_ref(), &Scalar::primitive(acc, Nullable)).vortex_unwrap();
+        assert_eq!(
+            sum,
+            Scalar::primitive(-2048669274505641600000000000f64, Nullable)
         );
     }
 }

--- a/vortex-array/src/arrays/constant/compute/sum.rs
+++ b/vortex-array/src/arrays/constant/compute/sum.rs
@@ -145,6 +145,7 @@ fn sum_float(
         .as_::<f64>()
         .vortex_expect("cannot be null");
 
+    // Preserve numerical behaviour of summation of floats by using a loop instead of simplifying to multiplication.
     let mut sum = initial;
     for _ in 0..array_len {
         sum += v;

--- a/vortex-array/src/compute/sum.rs
+++ b/vortex-array/src/compute/sum.rs
@@ -108,14 +108,15 @@ impl ComputeFnVTable for Sum {
                 DType::Primitive(p, _) => {
                     if p.is_float() && accumulator.is_zero() {
                         return Ok(sum.into());
+                    } else if p.is_int() {
+                        let sum_from_stat = accumulator
+                            .as_primitive()
+                            .checked_add(&sum.as_primitive())
+                            .map(Scalar::from);
+                        return Ok(sum_from_stat
+                            .unwrap_or_else(|| Scalar::null(sum_dtype))
+                            .into());
                     }
-                    let sum_from_stat = accumulator
-                        .as_primitive()
-                        .checked_add(&sum.as_primitive())
-                        .map(Scalar::from);
-                    return Ok(sum_from_stat
-                        .unwrap_or_else(|| Scalar::null(sum_dtype))
-                        .into());
                 }
                 DType::Decimal(..) => {
                     let sum_from_stat = accumulator


### PR DESCRIPTION
fix #5508

Signed-off-by: Robert Kruszewski <github@robertk.io>
