### PR TITLE
Chore: remove redundant rustfmt.toml from pco, datetime-parts, fastlanes

### DIFF
--- a/encodings/datetime-parts/rustfmt.toml
+++ b/encodings/datetime-parts/rustfmt.toml
@@ -1,1 +1,0 @@
-imports_granularity = "Module"

--- a/encodings/fastlanes/rustfmt.toml
+++ b/encodings/fastlanes/rustfmt.toml
@@ -1,1 +1,0 @@
-imports_granularity = "Module"

--- a/encodings/pco/rustfmt.toml
+++ b/encodings/pco/rustfmt.toml
@@ -1,1 +1,0 @@
-imports_granularity = "Module"


### PR DESCRIPTION
## Summary
- Remove per-crate `rustfmt.toml` files from `encodings/pco`, `encodings/datetime-parts`, and `encodings/fastlanes`
- These files only contained `imports_granularity = "Module"` which is now handled by the root `rustfmt.toml`

## Test plan
- [x] Files removed are redundant configuration only

🤖 Generated with [Claude Code](https://claude.com/claude-code)