### PR TITLE
Feature: make `Cast` trait have arbitrary outputs

### DIFF
--- a/vortex-compute/src/cast/mod.rs
+++ b/vortex-compute/src/cast/mod.rs
@@ -1,34 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Lossless casting of Vortex vectors for different logical data types.
-
-mod bool;
-mod null;
-mod pvector;
+//! Cast function.
 
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
-use vortex_error::vortex_bail;
-use vortex_vector::Vector;
 
-/// Trait for casting vectors to different data types.
+mod vector;
+
+/// Trait for casting objects to different data types.
 pub trait Cast {
-    /// Cast the vector to the specified data type.
-    fn cast(&self, dtype: &DType) -> VortexResult<Vector>;
-}
+    /// The result type after performing the cast.
+    type Output;
 
-impl Cast for Vector {
-    fn cast(&self, dtype: &DType) -> VortexResult<Vector> {
-        // Switch to macro once all vector types implement Cast
-        // match_each_vector!(self, |v| { Cast::cast(v, dtype) })
-        match self {
-            Vector::Null(v) => Cast::cast(v, dtype),
-            Vector::Bool(v) => Cast::cast(v, dtype),
-            Vector::Primitive(v) => Cast::cast(v, dtype),
-            _ => {
-                vortex_bail!("Casting not implemented for vector type {:?}", self);
-            }
-        }
-    }
+    /// Cast the object to the specified data type.
+    fn cast(&self, dtype: &DType) -> VortexResult<Self::Output>;
 }

--- a/vortex-compute/src/cast/vector/bool.rs
+++ b/vortex-compute/src/cast/vector/bool.rs
@@ -17,6 +17,8 @@ use vortex_vector::primitive::PVector;
 use crate::cast::Cast;
 
 impl Cast for BoolVector {
+    type Output = Vector;
+
     fn cast(&self, dtype: &DType) -> VortexResult<Vector> {
         match dtype {
             DType::Null if self.validity().all_false() => {

--- a/vortex-compute/src/cast/vector/mod.rs
+++ b/vortex-compute/src/cast/vector/mod.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Lossless casting of Vortex vectors for different logical data types.
+
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_vector::Vector;
+
+use crate::cast::Cast;
+
+mod bool;
+mod null;
+mod primitive;
+
+impl Cast for Vector {
+    type Output = Vector;
+
+    fn cast(&self, dtype: &DType) -> VortexResult<Vector> {
+        // Switch to macro once all vector types implement Cast
+        // match_each_vector!(self, |v| { Cast::cast(v, dtype) })
+        match self {
+            Vector::Null(v) => Cast::cast(v, dtype),
+            Vector::Bool(v) => Cast::cast(v, dtype),
+            Vector::Primitive(v) => Cast::cast(v, dtype),
+            _ => {
+                vortex_bail!("Casting not implemented for vector type {:?}", self);
+            }
+        }
+    }
+}

--- a/vortex-compute/src/cast/vector/null.rs
+++ b/vortex-compute/src/cast/vector/null.rs
@@ -13,6 +13,8 @@ use vortex_vector::null::NullVector;
 use crate::cast::Cast;
 
 impl Cast for NullVector {
+    type Output = Vector;
+
     fn cast(&self, dtype: &DType) -> VortexResult<Vector> {
         if dtype.is_nullable() {
             // We can create an all-null vector of _any_ type.

--- a/vortex-compute/src/cast/vector/primitive.rs
+++ b/vortex-compute/src/cast/vector/primitive.rs
@@ -15,12 +15,16 @@ use vortex_vector::primitive::PrimitiveVector;
 use crate::cast::Cast;
 
 impl Cast for PrimitiveVector {
+    type Output = Vector;
+
     fn cast(&self, dtype: &DType) -> VortexResult<Vector> {
         match_each_pvector!(self, |v| { Cast::cast(v, dtype) })
     }
 }
 
 impl<T: NativePType> Cast for PVector<T> {
+    type Output = Vector;
+
     fn cast(&self, dtype: &DType) -> VortexResult<Vector> {
         match dtype {
             // Can cast an all-null PVector to NullVector.


### PR DESCRIPTION
We should allow `Cast` to operate over things other than vectors.

(I need this to implement some things for f16)