### PR TITLE
fix: assert_arrays_eq macro reexports format function to hide itertools dep

### DIFF
--- a/vortex-array/src/arrays/assertions.rs
+++ b/vortex-array/src/arrays/assertions.rs
@@ -1,6 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::fmt::Display;
+
+use itertools::Itertools;
+
+pub fn format_indices<I: IntoIterator<Item = usize>>(indices: I) -> impl Display {
+    indices.into_iter().format(",")
+}
+
 #[macro_export]
 macro_rules! assert_arrays_eq {
     ($left:expr, $right:expr) => {{
@@ -32,7 +40,7 @@ macro_rules! assert_arrays_eq {
         if mismatched_indices.len() != 0 {
             panic!(
                 "assertion left == right failed: arrays do not match at indices: {}.\n  left: {}\n right: {}",
-                itertools::Itertools::format(mismatched_indices.into_iter(), ", "),
+                $crate::arrays::format_indices(mismatched_indices),
                 left.display_values(),
                 right.display_values()
             )

--- a/vortex-array/src/arrays/mod.rs
+++ b/vortex-array/src/arrays/mod.rs
@@ -6,6 +6,9 @@
 #[cfg(any(test, feature = "test-harness"))]
 mod assertions;
 
+#[cfg(any(test, feature = "test-harness"))]
+pub use assertions::format_indices;
+
 #[cfg(test)]
 mod validation_tests;
 


### PR DESCRIPTION
fix: #5544

Signed-off-by: Robert Kruszewski <github@robertk.io>
