### PR TITLE
Chore: bump rust version from 1.89 to 1.91

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -646,13 +646,11 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          toolchain: nightly-2025-06-26
           targets: "wasm32-wasip1"
-          components: "rust-src"
       - name: Setup Wasmer
         uses: wasmerio/setup-wasmer@v3.1
         # there is a compiler bug in nightly (but not in nightly-2025-06-26)
-      - run: cargo +nightly-2025-06-26 -Zbuild-std=panic_abort,std build --target wasm32-wasip1
+      - run: cargo build --target wasm32-wasip1
         working-directory: ./wasm-test
       - run: wasmer run ./target/wasm32-wasip1/debug/wasm-test.wasm
         working-directory: ./wasm-test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ keywords = ["vortex"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/spiraldb/vortex"
-rust-version = "1.89"
+rust-version = "1.91"
 version = "0.1.0"
 
 [workspace.dependencies]

--- a/bench-vortex/src/bin/compress.rs
+++ b/bench-vortex/src/bin/compress.rs
@@ -92,7 +92,7 @@ fn compress(
         .map(|f| Target::new(Engine::default(), *f))
         .collect_vec();
 
-    let structlistofints = vec![
+    let structlistofints = [
         StructListOfInts::new(100, 1000, 1),
         StructListOfInts::new(1000, 1000, 1),
         StructListOfInts::new(10000, 1000, 1),

--- a/bench-vortex/src/compress/bench.rs
+++ b/bench-vortex/src/compress/bench.rs
@@ -22,6 +22,7 @@ use {
         bench_run::run_with_setup,
         utils::{convert_utf8view_batch, convert_utf8view_schema},
     },
+    anyhow::Context,
     arrow_array::RecordBatch,
     parking_lot::Mutex,
     std::fs,
@@ -126,9 +127,7 @@ pub fn benchmark_vortex_decompress(
     bench_name: &str,
 ) -> Result<(Duration, CompressionTimingMeasurement)> {
     let mut buf = Vec::new();
-    runtime
-        .block_on(vortex_compress_write(uncompressed, &mut buf))
-        .expect("Failed to compress with vortex for decompression test");
+    runtime.block_on(vortex_compress_write(uncompressed, &mut buf))?;
     let buffer = Bytes::from(buf);
 
     // Run the benchmark and measure time.
@@ -250,7 +249,7 @@ pub fn benchmark_lance_compress(
         .collect::<Result<Vec<_>, _>>()?;
     let converted_schema = convert_utf8view_schema(&schema);
 
-    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let temp_dir = tempfile::tempdir().context("Failed to create temp dir")?;
     let iteration_paths: Arc<Mutex<Vec<PathBuf>>> = Arc::new(Mutex::new(Vec::new()));
     let iteration_counter = AtomicU64::new(0);
 
@@ -284,7 +283,7 @@ pub fn benchmark_lance_compress(
     // Calculate size from the last iteration.
     let paths = iteration_paths.lock();
     let lance_compressed_size_val = if let Some(last_path) = paths.last() {
-        calculate_lance_size(last_path).expect("Failed to calculate Lance size")
+        calculate_lance_size(last_path).context("Failed to calculate Lance size")?
     } else {
         0
     };
@@ -315,7 +314,7 @@ pub fn benchmark_lance_decompress(
     // NOTE: Lance requires filesystem access unlike Parquet/Vortex which use in-memory buffers.
     let chunked = uncompressed.as_::<ChunkedVTable>().clone();
     let (batches, schema) = chunked_to_vec_record_batch(chunked);
-    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let temp_dir = tempfile::tempdir().context("Failed to create temp dir")?;
 
     // Write the Lance dataset once for all iterations.
     let dataset_path = runtime.block_on(async {

--- a/bench-vortex/src/engines/df/mod.rs
+++ b/bench-vortex/src/engines/df/mod.rs
@@ -97,8 +97,7 @@ pub fn make_object_store(
             let s3 = Arc::new(
                 AmazonS3Builder::from_env()
                     .with_bucket_name(bucket_name)
-                    .build()
-                    .unwrap(),
+                    .build()?,
             );
             df.register_object_store(&Url::parse(&format!("s3://{bucket_name}/"))?, s3.clone());
             Ok(s3)
@@ -108,8 +107,7 @@ pub fn make_object_store(
             let gcs = Arc::new(
                 GoogleCloudStorageBuilder::from_env()
                     .with_bucket_name(bucket_name)
-                    .build()
-                    .unwrap(),
+                    .build()?,
             );
             df.register_object_store(&Url::parse(&format!("gs://{bucket_name}/"))?, gcs.clone());
             Ok(gcs)

--- a/bench-vortex/src/realnest/gharchive.rs
+++ b/bench-vortex/src/realnest/gharchive.rs
@@ -119,11 +119,7 @@ impl GithubArchive {
 
 impl Benchmark for GithubArchive {
     fn queries(&self) -> anyhow::Result<Vec<(usize, String)>> {
-        Ok(QUERIES
-            .iter()
-            .map(|s| (s.to_string()))
-            .enumerate()
-            .collect())
+        Ok(QUERIES.iter().map(|s| s.to_string()).enumerate().collect())
     }
 
     fn generate_data(&self, target: &Target) -> anyhow::Result<()> {

--- a/encodings/fastlanes/benches/bitpacking_take.rs
+++ b/encodings/fastlanes/benches/bitpacking_take.rs
@@ -238,7 +238,7 @@ fn patched_take_10k_adversarial(bencher: Bencher) {
         (0..(NUM_EXCEPTIONS + 1024) / 1024)
             .cycle()
             .map(|chunk_idx| BIG_BASE2 - 1024 + chunk_idx * 1024)
-            .flat_map(|base_idx| (base_idx..(base_idx + per_chunk_count)))
+            .flat_map(|base_idx| base_idx..(base_idx + per_chunk_count))
             .take(10000),
     );
 

--- a/encodings/fastlanes/src/delta/array/mod.rs
+++ b/encodings/fastlanes/src/delta/array/mod.rs
@@ -122,7 +122,7 @@ impl DeltaArray {
 
         let lanes = lane_count(ptype);
 
-        if (deltas.len() % 1024 == 0) != (bases.len() % lanes == 0) {
+        if deltas.len().is_multiple_of(1024) != bases.len().is_multiple_of(lanes) {
             vortex_bail!(
                 "deltas length ({}) is a multiple of 1024 iff bases length ({}) is a multiple of LANES ({})",
                 deltas.len(),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.89"
+channel = "1.91"
 components = ["rust-src", "rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/vortex-array/benches/chunk_array_builder.rs
+++ b/vortex-array/benches/chunk_array_builder.rs
@@ -116,7 +116,7 @@ fn make_opt_bool_chunks(len: usize, chunk_count: usize) -> ArrayRef {
     let mut rng = StdRng::seed_from_u64(0);
 
     const SPAN_LEN: usize = 10;
-    assert!(len % SPAN_LEN == 0);
+    assert!(len.is_multiple_of(SPAN_LEN));
 
     (0..chunk_count)
         .map(|_| {

--- a/vortex-array/benches/varbinview_zip.rs
+++ b/vortex-array/benches/varbinview_zip.rs
@@ -78,5 +78,5 @@ fn alternating_mask(len: usize) -> Mask {
 }
 
 fn block_mask(len: usize, block: usize) -> Mask {
-    Mask::from_iter((0..len).map(|i| (i / block) % 2 == 0))
+    Mask::from_iter((0..len).map(|i| (i / block).is_multiple_of(2)))
 }

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -192,7 +192,7 @@ pub trait ArrayBuilder: Send {
     ///
     /// # Safety
     ///
-    /// Given validity must have an equal length to [`self.len()`].
+    /// Given validity must have an equal length to [`self.len()`](Self::len).
     unsafe fn set_validity_unchecked(&mut self, validity: Mask);
 
     /// Constructs an Array from the builder components.

--- a/vortex-array/src/compute/conformance/filter.rs
+++ b/vortex-array/src/compute/conformance/filter.rs
@@ -54,7 +54,9 @@ pub fn create_sparse_pattern(len: usize, true_ratio: f64) -> Vec<bool> {
 }
 
 pub fn create_runs_pattern(len: usize, run_length: usize) -> Vec<bool> {
-    (0..len).map(|i| (i / run_length) % 2 == 0).collect()
+    (0..len)
+        .map(|i| (i / run_length).is_multiple_of(2))
+        .collect()
 }
 
 /// Tests that filtering with an all-true mask returns all elements unchanged

--- a/vortex-array/src/expr/exprs/dynamic.rs
+++ b/vortex-array/src/expr/exprs/dynamic.rs
@@ -194,7 +194,7 @@ impl Display for DynamicComparisonExpr {
             "{} {}",
             self.operator,
             self.scalar()
-                .map_or("<none>".to_string(), |v| v.to_string())
+                .map_or_else(|| "<none>".to_string(), |v| v.to_string())
         )
     }
 }

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -364,6 +364,9 @@ impl Patches {
     ///   position in the patches array
     /// * [`SearchResult::NotFound(insertion_point)`] - If no patch exists, returns where
     ///   a patch at this index would be inserted to maintain sorted order
+    ///
+    /// [`SearchResult::Found(patch_idx)`]: SearchResult::Found
+    /// [`SearchResult::NotFound(insertion_point)`]: SearchResult::NotFound
     pub fn search_index(&self, index: usize) -> SearchResult {
         if self.chunk_offsets.is_some() {
             return self.search_index_chunked(index);

--- a/vortex-buffer/src/bit/buf.rs
+++ b/vortex-buffer/src/bit/buf.rs
@@ -265,7 +265,7 @@ impl BitBuffer {
 
     /// Created a new BitBuffer with offset reset to 0
     pub fn sliced(&self) -> Self {
-        if self.offset % 8 == 0 {
+        if self.offset.is_multiple_of(8) {
             return Self::new(
                 self.buffer.slice(self.offset / 8..self.len.div_ceil(8)),
                 self.len,
@@ -601,7 +601,7 @@ mod tests {
 
         for (idx, is_set) in collected {
             // The bits should match the original buffer at positions offset + idx
-            assert_eq!(is_set, (offset + idx) % 2 == 0);
+            assert_eq!(is_set, (offset + idx).is_multiple_of(2));
         }
     }
 
@@ -627,7 +627,7 @@ mod tests {
         for (idx, is_set) in collected {
             let bit_position = offset + idx;
             let byte_index = bit_position / 8;
-            let expected_is_set = byte_index % 2 == 0;
+            let expected_is_set = byte_index.is_multiple_of(2);
 
             assert_eq!(
                 is_set, expected_is_set,

--- a/vortex-buffer/src/bit/buf_mut.rs
+++ b/vortex-buffer/src/bit/buf_mut.rs
@@ -514,7 +514,7 @@ impl BitBufferMut {
         // If we are splitting on a byte boundary, we can just slice the buffer
         // Or if `at > self.len`, then the tail is empty anyway and we can just return as much
         // of the existing capacity as possible.
-        if at > self.len() || ((self.offset + at) % 8 == 0) {
+        if at > self.len() || (self.offset + at).is_multiple_of(8) {
             let tail_buffer = self.buffer.split_off(byte_pos);
             self.len = self.len.min(at);
 
@@ -546,7 +546,7 @@ impl BitBufferMut {
     ///
     /// Otherwise, this method degenerates to self.append_buffer(&other).
     pub fn unsplit(&mut self, other: Self) {
-        if (self.offset + self.len) % 8 == 0 && other.offset == 0 {
+        if (self.offset + self.len).is_multiple_of(8) && other.offset == 0 {
             // We are aligned and can just append the buffers
             self.buffer.unsplit(other.buffer);
             self.len += other.len;

--- a/vortex-buffer/src/bit/view.rs
+++ b/vortex-buffer/src/bit/view.rs
@@ -60,7 +60,7 @@ impl<'a, const NB: usize> BitView<'a, NB> {
     pub const N_WORDS: usize = NB * 8 / (usize::BITS as usize);
 
     const _ASSERT_MULTIPLE_OF_8: () = assert!(
-        NB % 8 == 0,
+        NB.is_multiple_of(8),
         "NB must be a multiple of 8 for N to be a multiple of 64"
     );
 

--- a/vortex-buffer/src/buffer.rs
+++ b/vortex-buffer/src/buffer.rs
@@ -181,7 +181,7 @@ impl<T> Buffer<T> {
                 alignment,
             );
         }
-        if bytes.len() % size_of::<T>() != 0 {
+        if !bytes.len().is_multiple_of(size_of::<T>()) {
             vortex_panic!(
                 "Bytes length {} must be a multiple of the scalar type's size {}",
                 bytes.len(),

--- a/vortex-duckdb/src/scan.rs
+++ b/vortex-duckdb/src/scan.rs
@@ -363,7 +363,7 @@ impl TableFunction for VortexTableFunction {
             &projection_expr,
             filter_expr
                 .as_ref()
-                .map_or("true".to_string(), |f| f.to_string())
+                .map_or_else(|| "true".to_string(), |f| f.to_string())
         );
 
         // Use the max_threads from bind_data (read from vortex_max_threads setting)

--- a/vortex-layout/src/layouts/compact.rs
+++ b/vortex-layout/src/layouts/compact.rs
@@ -221,7 +221,7 @@ mod tests {
         let compressor = CompactCompressor::default();
 
         // Create a struct array containing various types
-        let columns = vec![
+        let columns = [
             // Pco types
             PrimitiveArray::new(buffer![1.0f64, 2.0, 3.0, 4.0, 5.0], Validity::NonNullable),
             PrimitiveArray::new(buffer![10i32, 20, 30, 40, 50], Validity::NonNullable),

--- a/vortex-scan/src/arrow.rs
+++ b/vortex-scan/src/arrow.rs
@@ -152,10 +152,7 @@ mod tests {
         let schema = create_arrow_schema();
         let data_type = DataType::Struct(schema.fields().clone());
 
-        let result = to_record_batch(vortex_array, &data_type);
-        assert!(result.is_ok());
-
-        let batch = result.unwrap();
+        let batch = to_record_batch(vortex_array, &data_type)?;
         assert_eq!(batch.num_columns(), 2);
         assert_eq!(batch.num_rows(), 4);
 

--- a/wasm-test/Cargo.toml
+++ b/wasm-test/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 version = "0.0.1"
 publish = false
 edition = "2024"
-rust-version = "1.86"
+rust-version = "1.91"
 
 #[lib]
 #crate-type = ["cdylib"]


### PR DESCRIPTION
Bumps Vortex up to 1.91 (even though 1.92 is just around the corner).

Fixes the clippy lints that come along with that.