### PR TITLE
Chore: use item imports in bench-vortex

### DIFF
--- a/bench-vortex/rustfmt.toml
+++ b/bench-vortex/rustfmt.toml
@@ -1,1 +1,0 @@
-imports_granularity = "Module"

--- a/bench-vortex/src/bench_run.rs
+++ b/bench-vortex/src/bench_run.rs
@@ -3,7 +3,8 @@
 
 use std::future::Future;
 use std::hint::black_box;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use std::time::Instant;
 
 use tokio::runtime::Runtime;
 

--- a/bench-vortex/src/benchmark_driver.rs
+++ b/bench-vortex/src/benchmark_driver.rs
@@ -12,15 +12,25 @@ use log::warn;
 use vortex::error::VortexExpect;
 use vortex_datafusion::metrics::VortexMetricsFinder;
 
+use crate::Engine;
+use crate::Format;
+use crate::Target;
 use crate::benchmark_trait::Benchmark;
+use crate::df;
 use crate::display::DisplayFormat;
-use crate::engines::{EngineCtx, benchmark_datafusion_query};
-use crate::measurements::{MemoryMeasurement, QueryMeasurement};
+use crate::engines::EngineCtx;
+use crate::engines::benchmark_datafusion_query;
+use crate::measurements::MemoryMeasurement;
+use crate::measurements::QueryMeasurement;
 use crate::memory::BenchmarkMemoryTracker;
-use crate::metrics::{MetricsSetExt, export_plan_spans};
-use crate::query_bench::{filter_queries, print_memory_usage, print_results};
-use crate::utils::{new_tokio_runtime, url_scheme_to_storage};
-use crate::{Engine, Format, Target, df, vortex_panic};
+use crate::metrics::MetricsSetExt;
+use crate::metrics::export_plan_spans;
+use crate::query_bench::filter_queries;
+use crate::query_bench::print_memory_usage;
+use crate::query_bench::print_results;
+use crate::utils::new_tokio_runtime;
+use crate::utils::url_scheme_to_storage;
+use crate::vortex_panic;
 
 /// Mode for EXPLAIN queries
 #[derive(Debug, Clone, Copy)]

--- a/bench-vortex/src/benchmark_trait.rs
+++ b/bench-vortex/src/benchmark_trait.rs
@@ -6,8 +6,12 @@
 use anyhow::Result;
 use url::Url;
 
+use crate::BenchmarkDataset;
+use crate::Engine;
+use crate::Format;
+use crate::Target;
+use crate::df;
 use crate::engines::EngineCtx;
-use crate::{BenchmarkDataset, Engine, Format, Target, df};
 
 /// Core benchmark operations that all benchmark types implement
 pub trait Benchmark {

--- a/bench-vortex/src/bin/compress.rs
+++ b/bench-vortex/src/bin/compress.rs
@@ -2,31 +2,48 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::fs::File;
-use std::io::{Write, stdout};
+use std::io::Write;
+use std::io::stdout;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use bench_vortex::compress::bench::{self as compress, CompressMeasurements, CompressOp};
+use bench_vortex::Engine;
+use bench_vortex::Format;
+use bench_vortex::Target;
+use bench_vortex::compress::bench::CompressMeasurements;
+use bench_vortex::compress::bench::CompressOp;
+use bench_vortex::compress::bench::{self as compress};
 use bench_vortex::datasets::Dataset;
 use bench_vortex::datasets::struct_list_of_ints::StructListOfInts;
 use bench_vortex::datasets::taxi_data::TaxiData;
-use bench_vortex::datasets::tpch_l_comment::{TPCHLCommentCanonical, TPCHLCommentChunked};
-use bench_vortex::display::{DisplayFormat, print_measurements_json, render_table};
+use bench_vortex::datasets::tpch_l_comment::TPCHLCommentCanonical;
+use bench_vortex::datasets::tpch_l_comment::TPCHLCommentChunked;
+use bench_vortex::display::DisplayFormat;
+use bench_vortex::display::print_measurements_json;
+use bench_vortex::display::render_table;
 use bench_vortex::downloadable_dataset::DownloadableDataset;
-use bench_vortex::measurements::{CompressionTimingMeasurement, CustomUnitMeasurement};
+use bench_vortex::measurements::CompressionTimingMeasurement;
+use bench_vortex::measurements::CustomUnitMeasurement;
 use bench_vortex::public_bi::PBI_DATASETS;
-use bench_vortex::public_bi::PBIDataset::{Arade, Bimbo, CMSprovider, Euro2016, Food, HashTags};
+use bench_vortex::public_bi::PBIDataset::Arade;
+use bench_vortex::public_bi::PBIDataset::Bimbo;
+use bench_vortex::public_bi::PBIDataset::CMSprovider;
+use bench_vortex::public_bi::PBIDataset::Euro2016;
+use bench_vortex::public_bi::PBIDataset::Food;
+use bench_vortex::public_bi::PBIDataset::HashTags;
+use bench_vortex::setup_logging_and_tracing;
 use bench_vortex::utils::new_tokio_runtime;
-use bench_vortex::{Engine, Format, Target, setup_logging_and_tracing};
 use clap::Parser;
 use indicatif::ProgressBar;
 use itertools::Itertools;
 use regex::Regex;
 use tokio::runtime::Runtime;
-use vortex::arrays::{ChunkedArray, ChunkedVTable};
+use vortex::Array;
+use vortex::IntoArray;
+use vortex::arrays::ChunkedArray;
+use vortex::arrays::ChunkedVTable;
 use vortex::builders::builder_with_capacity;
 use vortex::utils::aliases::hash_map::HashMap;
-use vortex::{Array, IntoArray};
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]

--- a/bench-vortex/src/bin/public_bi.rs
+++ b/bench-vortex/src/bin/public_bi.rs
@@ -2,22 +2,34 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::fs::File;
-use std::io::{Write, stdout};
+use std::io::Write;
+use std::io::stdout;
 use std::path::PathBuf;
 use std::time::Instant;
 
-use bench_vortex::display::{DisplayFormat, print_measurements_json, render_table};
+use bench_vortex::BenchmarkDataset;
+use bench_vortex::Format;
+use bench_vortex::Target;
+use bench_vortex::df;
+use bench_vortex::display::DisplayFormat;
+use bench_vortex::display::print_measurements_json;
+use bench_vortex::display::render_table;
 use bench_vortex::measurements::QueryMeasurement;
 use bench_vortex::metrics::MetricsSetExt;
-use bench_vortex::public_bi::{FileType, PBI_DATASETS, PBIDataset};
+use bench_vortex::public_bi::FileType;
+use bench_vortex::public_bi::PBI_DATASETS;
+use bench_vortex::public_bi::PBIDataset;
+use bench_vortex::setup_logging_and_tracing;
 use bench_vortex::utils::constants::STORAGE_NVME;
 use bench_vortex::utils::new_tokio_runtime;
-use bench_vortex::{BenchmarkDataset, Format, Target, df, setup_logging_and_tracing};
-use clap::{Parser, value_parser};
+use clap::Parser;
+use clap::value_parser;
 use indicatif::ProgressBar;
 use itertools::Itertools;
-use tracing::{Instrument, info_span};
-use vortex::error::{VortexExpect, vortex_panic};
+use tracing::Instrument;
+use tracing::info_span;
+use vortex::error::VortexExpect;
+use vortex::error::vortex_panic;
 use vortex_datafusion::metrics::VortexMetricsFinder;
 
 #[derive(Parser, Debug)]

--- a/bench-vortex/src/bin/query_bench.rs
+++ b/bench-vortex/src/bin/query_bench.rs
@@ -3,16 +3,22 @@
 
 use std::path::PathBuf;
 
-use bench_vortex::benchmark_driver::{DriverConfig, run_benchmark};
-use bench_vortex::clickbench::{ClickBenchBenchmark, Flavor};
+use bench_vortex::IdempotentPath as _;
+use bench_vortex::Target;
+use bench_vortex::benchmark_driver::DriverConfig;
+use bench_vortex::benchmark_driver::run_benchmark;
+use bench_vortex::clickbench::ClickBenchBenchmark;
+use bench_vortex::clickbench::Flavor;
 use bench_vortex::display::DisplayFormat;
 use bench_vortex::fineweb::Fineweb;
 use bench_vortex::realnest::gharchive::GithubArchive;
+use bench_vortex::setup_logging_and_tracing;
 use bench_vortex::statpopgen::StatPopGenBenchmark;
 use bench_vortex::tpcds::TpcDsBenchmark;
 use bench_vortex::tpch::tpch_benchmark::TpcHBenchmark;
-use bench_vortex::{IdempotentPath as _, Target, setup_logging_and_tracing};
-use clap::{Parser, Subcommand, value_parser};
+use clap::Parser;
+use clap::Subcommand;
+use clap::value_parser;
 use url::Url;
 
 #[derive(Parser, Debug)]

--- a/bench-vortex/src/bin/random_access.rs
+++ b/bench-vortex/src/bin/random_access.rs
@@ -3,27 +3,37 @@
 
 use std::fs::File;
 use std::future::Future;
-use std::io::{Write, stdout};
+use std::io::Write;
+use std::io::stdout;
 use std::path::PathBuf;
 
+use bench_vortex::Engine;
+use bench_vortex::Format;
+use bench_vortex::Target;
 use bench_vortex::bench_run::run_timed_with_setup;
 use bench_vortex::datasets::taxi_data::*;
-use bench_vortex::display::{DisplayFormat, print_measurements_json, render_table};
+use bench_vortex::display::DisplayFormat;
+use bench_vortex::display::print_measurements_json;
+use bench_vortex::display::render_table;
 use bench_vortex::measurements::TimingMeasurement;
 #[cfg(feature = "lance")]
 use bench_vortex::random_access::take::take_lance;
-use bench_vortex::random_access::take::{take_parquet, take_vortex_tokio};
+use bench_vortex::random_access::take::take_parquet;
+use bench_vortex::random_access::take::take_vortex_tokio;
+use bench_vortex::setup_logging_and_tracing;
 use bench_vortex::utils::constants::STORAGE_NVME;
 use bench_vortex::utils::new_tokio_runtime;
-use bench_vortex::{Engine, Format, Target, setup_logging_and_tracing};
 use clap::Parser;
 use indicatif::ProgressBar;
 use tokio::runtime::Runtime;
-use vortex::buffer::{Buffer, buffer};
+use vortex::Array;
+use vortex::ArrayRef;
+use vortex::ToCanonical;
+use vortex::buffer::Buffer;
+use vortex::buffer::buffer;
 use vortex::dtype::Nullability::NonNullable;
 use vortex::error::VortexExpect;
 use vortex::scalar::Scalar;
-use vortex::{Array, ArrayRef, ToCanonical};
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]

--- a/bench-vortex/src/clickbench/clickbench_benchmark.rs
+++ b/bench-vortex/src/clickbench/clickbench_benchmark.rs
@@ -9,10 +9,14 @@ use tokio::runtime::Runtime;
 use url::Url;
 use vortex::error::VortexExpect;
 
+use crate::BenchmarkDataset;
+use crate::CompactionStrategy;
+use crate::Format;
+use crate::IdempotentPath;
+use crate::Target;
 use crate::benchmark_trait::Benchmark;
 use crate::clickbench::*;
 use crate::engines::EngineCtx;
-use crate::{BenchmarkDataset, CompactionStrategy, Format, IdempotentPath, Target};
 
 /// ClickBench benchmark implementation
 pub struct ClickBenchBenchmark {

--- a/bench-vortex/src/clickbench/clickbench_data.rs
+++ b/bench-vortex/src/clickbench/clickbench_data.rs
@@ -1,39 +1,55 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::fmt;
 use std::fmt::Display;
+use std::fs;
 use std::fs::File;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, LazyLock};
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::LazyLock;
 use std::time::Duration;
-use std::{fmt, fs};
 
-use arrow_schema::{DataType, Field, Schema, TimeUnit};
+use arrow_schema::DataType;
+use arrow_schema::Field;
+use arrow_schema::Schema;
+use arrow_schema::TimeUnit;
 use clap::ValueEnum;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
-use datafusion::datasource::listing::{
-    ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
-};
+use datafusion::datasource::listing::ListingOptions;
+use datafusion::datasource::listing::ListingTable;
+use datafusion::datasource::listing::ListingTableConfig;
+use datafusion::datasource::listing::ListingTableUrl;
 use datafusion::prelude::SessionContext;
-use futures::{StreamExt, TryStreamExt, stream};
+use futures::StreamExt;
+use futures::TryStreamExt;
+use futures::stream;
 use glob::Pattern;
 use log::trace;
-use rayon::prelude::{IntoParallelIterator, ParallelIterator};
+use rayon::prelude::IntoParallelIterator;
+use rayon::prelude::ParallelIterator;
 use reqwest::IntoUrl;
 use reqwest::blocking::Response;
 use serde::Serialize;
-use tokio::fs::{OpenOptions, create_dir_all};
-use tracing::{Instrument, info, warn};
+use tokio::fs::OpenOptions;
+use tokio::fs::create_dir_all;
+use tracing::Instrument;
+use tracing::info;
+use tracing::warn;
 use url::Url;
 use vortex::error::VortexExpect;
 use vortex::file::WriteOptionsSessionExt;
 use vortex_datafusion::VortexFormat;
 
+use crate::CompactionStrategy;
+use crate::Format;
+use crate::SESSION;
 use crate::conversions::parquet_to_vortex;
 #[cfg(feature = "lance")]
 use crate::utils;
-use crate::utils::file_utils::{idempotent, idempotent_async};
-use crate::{CompactionStrategy, Format, SESSION};
+use crate::utils::file_utils::idempotent;
+use crate::utils::file_utils::idempotent_async;
 
 pub static HITS_SCHEMA: LazyLock<Schema> = LazyLock::new(|| {
     use DataType::*;

--- a/bench-vortex/src/compress/bench.rs
+++ b/bench-vortex/src/compress/bench.rs
@@ -3,25 +3,27 @@
 
 use std::borrow::Cow;
 use std::fmt;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::Result;
 use bytes::Bytes;
 use clap::ValueEnum;
-use parquet::basic::{Compression, ZstdLevel};
+use parquet::basic::Compression;
+use parquet::basic::ZstdLevel;
 use serde::Serialize;
 use tokio::runtime::Runtime;
 use vortex::Array;
 use vortex::arrays::ChunkedVTable;
 use vortex::utils::aliases::hash_map::HashMap;
 #[cfg(feature = "lance")]
+#[rustfmt::skip]
 use {
     super::lance::*,
-    crate::{
-        bench_run::run_with_setup,
-        utils::{convert_utf8view_batch, convert_utf8view_schema},
-    },
+    crate::bench_run::run_with_setup,
+    crate::utils::convert_utf8view_batch,
+    crate::utils::convert_utf8view_schema,
     arrow_array::RecordBatch,
     parking_lot::Mutex,
     std::fs,
@@ -32,9 +34,12 @@ use {
 use crate::Format;
 use crate::bench_run::run;
 use crate::compress::chunked_to_vec_record_batch;
-use crate::compress::parquet::{parquet_compress_write, parquet_decompress_read};
-use crate::compress::vortex::{vortex_compress_write, vortex_decompress_read};
-use crate::measurements::{CompressionTimingMeasurement, CustomUnitMeasurement};
+use crate::compress::parquet::parquet_compress_write;
+use crate::compress::parquet::parquet_decompress_read;
+use crate::compress::vortex::vortex_compress_write;
+use crate::compress::vortex::vortex_decompress_read;
+use crate::measurements::CompressionTimingMeasurement;
+use crate::measurements::CustomUnitMeasurement;
 
 #[derive(Default)]
 pub struct CompressMeasurements {

--- a/bench-vortex/src/compress/lance.rs
+++ b/bench-vortex/src/compress/lance.rs
@@ -17,14 +17,17 @@ use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 
-use arrow_array::{RecordBatch, RecordBatchIterator};
+use arrow_array::RecordBatch;
+use arrow_array::RecordBatchIterator;
 use arrow_schema::Schema;
 use futures::StreamExt;
-use lance::dataset::{Dataset, WriteParams};
+use lance::dataset::Dataset;
+use lance::dataset::WriteParams;
 use lance_encoding::version::LanceFileVersion;
 use tempfile::TempDir;
 
-use crate::utils::parquet_utils::{convert_utf8view_batch, convert_utf8view_schema};
+use crate::utils::parquet_utils::convert_utf8view_batch;
+use crate::utils::parquet_utils::convert_utf8view_schema;
 
 /// Write pre-converted [`RecordBatch`]es to Lance format.
 pub async fn lance_compress_write_only(

--- a/bench-vortex/src/compress/mod.rs
+++ b/bench-vortex/src/compress/mod.rs
@@ -3,7 +3,8 @@
 
 use std::sync::Arc;
 
-use ::vortex::arrays::{ChunkedArray, recursive_list_from_list_view};
+use ::vortex::arrays::ChunkedArray;
+use ::vortex::arrays::recursive_list_from_list_view;
 use arrow_array::RecordBatch;
 use arrow_schema::Schema;
 

--- a/bench-vortex/src/compress/vortex.rs
+++ b/bench-vortex/src/compress/vortex.rs
@@ -5,9 +5,11 @@ use std::io::Cursor;
 use std::sync::Arc;
 
 use bytes::Bytes;
-use futures::{StreamExt, pin_mut};
+use futures::StreamExt;
+use futures::pin_mut;
 use vortex::Array;
-use vortex::file::{OpenOptionsSessionExt, WriteOptionsSessionExt};
+use vortex::file::OpenOptionsSessionExt;
+use vortex::file::WriteOptionsSessionExt;
 
 use crate::SESSION;
 

--- a/bench-vortex/src/conversions.rs
+++ b/bench-vortex/src/conversions.rs
@@ -11,7 +11,8 @@ use vortex::arrow::FromArrowArray;
 use vortex::dtype::DType;
 use vortex::dtype::arrow::FromArrowType;
 use vortex::error::VortexError;
-use vortex::iter::{ArrayIteratorAdapter, ArrayIteratorExt};
+use vortex::iter::ArrayIteratorAdapter;
+use vortex::iter::ArrayIteratorExt;
 use vortex::stream::ArrayStream;
 
 pub fn parquet_to_vortex(parquet_path: PathBuf) -> anyhow::Result<impl ArrayStream> {

--- a/bench-vortex/src/datasets/data_downloads.rs
+++ b/bench-vortex/src/datasets/data_downloads.rs
@@ -2,18 +2,21 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::fs::File;
-use std::io::{Read, Write};
+use std::io::Read;
+use std::io::Write;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::Context;
+use anyhow::Result;
 use bzip2::read::BzDecoder;
 use log::info;
 use reqwest::Client;
 use tokio::fs::File as TokioFile;
 use tokio::io::AsyncWriteExt;
 
-use crate::utils::file_utils::{idempotent, idempotent_async};
+use crate::utils::file_utils::idempotent;
+use crate::utils::file_utils::idempotent_async;
 
 pub async fn download_data(fname: PathBuf, data_url: &str) -> Result<PathBuf> {
     idempotent_async(&fname, async |path| {

--- a/bench-vortex/src/datasets/file.rs
+++ b/bench-vortex/src/datasets/file.rs
@@ -6,16 +6,22 @@ use std::sync::Arc;
 use anyhow::Result;
 use arrow_schema::Schema;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
-use datafusion::datasource::listing::{
-    ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
-};
+use datafusion::datasource::listing::ListingOptions;
+use datafusion::datasource::listing::ListingTable;
+use datafusion::datasource::listing::ListingTableConfig;
+use datafusion::datasource::listing::ListingTableUrl;
 use datafusion::prelude::SessionContext;
 use glob::Pattern;
 use tracing::info;
 use url::Url;
 use vortex_datafusion::VortexFormat;
 #[cfg(feature = "lance")]
-use {crate::Format, lance::datafusion::LanceTableProvider, lance::dataset::Dataset};
+#[rustfmt::skip]
+use {
+    crate::Format,
+    lance::datafusion::LanceTableProvider,
+    lance::dataset::Dataset
+};
 
 use crate::SESSION;
 use crate::datasets::BenchmarkDataset;

--- a/bench-vortex/src/datasets/mod.rs
+++ b/bench-vortex/src/datasets/mod.rs
@@ -10,11 +10,14 @@ use serde::Serialize;
 use url::Url;
 use vortex::ArrayRef;
 
+use crate::Format;
+use crate::clickbench;
 use crate::clickbench::Flavor;
 #[cfg(feature = "lance")]
 use crate::file::register_lance_files;
+use crate::fineweb;
 use crate::realnest::gharchive;
-use crate::{Format, clickbench, fineweb, statpopgen};
+use crate::statpopgen;
 
 pub mod data_downloads;
 pub mod file;

--- a/bench-vortex/src/datasets/struct_list_of_ints.rs
+++ b/bench-vortex/src/datasets/struct_list_of_ints.rs
@@ -3,11 +3,16 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use rand::{Rng, SeedableRng};
-use vortex::arrays::{ChunkedArray, ListArray, PrimitiveArray, StructArray};
+use rand::Rng;
+use rand::SeedableRng;
+use vortex::ArrayRef;
+use vortex::IntoArray;
+use vortex::arrays::ChunkedArray;
+use vortex::arrays::ListArray;
+use vortex::arrays::PrimitiveArray;
+use vortex::arrays::StructArray;
 use vortex::dtype::FieldNames;
 use vortex::validity::Validity;
-use vortex::{ArrayRef, IntoArray};
 
 use crate::datasets::Dataset;
 

--- a/bench-vortex/src/datasets/taxi_data.rs
+++ b/bench-vortex/src/datasets/taxi_data.rs
@@ -8,20 +8,26 @@ use async_trait::async_trait;
 use tokio::fs::File as TokioFile;
 use tokio::io::AsyncWriteExt;
 use vortex::ArrayRef;
-use vortex::file::{OpenOptionsSessionExt, WriteOptionsSessionExt};
+use vortex::file::OpenOptionsSessionExt;
+use vortex::file::WriteOptionsSessionExt;
 use vortex::stream::ArrayStreamExt;
 #[cfg(feature = "lance")]
+#[rustfmt::skip]
 use {
-    lance::dataset::{Dataset as LanceDataset, WriteParams},
+    lance::dataset::Dataset as LanceDataset,
+    lance::dataset::WriteParams,
     lance_encoding::version::LanceFileVersion,
     parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder,
     std::fs::File,
 };
 
+use crate::CompactionStrategy;
+use crate::IdempotentPath;
+use crate::SESSION;
 use crate::conversions::parquet_to_vortex;
 use crate::datasets::Dataset;
 use crate::datasets::data_downloads::download_data;
-use crate::{CompactionStrategy, IdempotentPath, SESSION, idempotent_async};
+use crate::idempotent_async;
 
 pub struct TaxiData;
 

--- a/bench-vortex/src/datasets/tpch_l_comment.rs
+++ b/bench-vortex/src/datasets/tpch_l_comment.rs
@@ -5,15 +5,22 @@ use anyhow::Result;
 use async_trait::async_trait;
 use futures::TryStreamExt;
 use glob::glob;
+use vortex::Array;
+use vortex::ArrayRef;
+use vortex::IntoArray;
+use vortex::ToCanonical;
 use vortex::arrays::ChunkedArray;
 use vortex::dtype::Nullability::NonNullable;
-use vortex::expr::{col, pack};
+use vortex::expr::col;
+use vortex::expr::pack;
 use vortex::file::OpenOptionsSessionExt;
-use vortex::{Array, ArrayRef, IntoArray, ToCanonical};
 
+use crate::Format;
+use crate::IdempotentPath;
+use crate::SESSION;
 use crate::datasets::Dataset;
-use crate::tpch::tpchgen::{TpchGenOptions, generate_tpch_tables};
-use crate::{Format, IdempotentPath, SESSION};
+use crate::tpch::tpchgen::TpchGenOptions;
+use crate::tpch::tpchgen::generate_tpch_tables;
 
 pub struct TPCHLCommentChunked;
 

--- a/bench-vortex/src/display.rs
+++ b/bench-vortex/src/display.rs
@@ -7,12 +7,16 @@ use std::iter;
 use clap::ValueEnum;
 use itertools::Itertools;
 use tabled::builder::Builder;
+use tabled::settings::Color;
+use tabled::settings::Style;
 use tabled::settings::themes::Colorization;
-use tabled::settings::{Color, Style};
 use vortex::utils::aliases::hash_map::HashMap;
 
 use crate::Target;
-use crate::measurements::{MeasurementValue, TableValue, ToJson, ToTable};
+use crate::measurements::MeasurementValue;
+use crate::measurements::TableValue;
+use crate::measurements::ToJson;
+use crate::measurements::ToTable;
 
 #[derive(ValueEnum, Default, Clone, Debug)]
 pub enum DisplayFormat {

--- a/bench-vortex/src/downloadable_dataset.rs
+++ b/bench-vortex/src/downloadable_dataset.rs
@@ -4,13 +4,16 @@
 use async_trait::async_trait;
 use tokio::fs::File;
 use vortex::ArrayRef;
-use vortex::file::{OpenOptionsSessionExt, WriteOptionsSessionExt};
+use vortex::file::OpenOptionsSessionExt;
+use vortex::file::WriteOptionsSessionExt;
 use vortex::stream::ArrayStreamExt;
 
+use crate::IdempotentPath;
+use crate::SESSION;
 use crate::conversions::parquet_to_vortex;
 use crate::datasets::Dataset;
 use crate::datasets::data_downloads::download_data;
-use crate::{IdempotentPath, SESSION, idempotent_async};
+use crate::idempotent_async;
 
 /// Datasets which can be downloaded over HTTP in Parquet format.
 ///

--- a/bench-vortex/src/engines/ddb/mod.rs
+++ b/bench-vortex/src/engines/ddb/mod.rs
@@ -2,17 +2,22 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::path::PathBuf;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use std::time::Instant;
 
 use anyhow::Result;
 use log::trace;
 use url::Url;
 use vortex::error::VortexExpect;
-use vortex_duckdb::duckdb::{Config, Connection, Database};
+use vortex_duckdb::duckdb::Config;
+use vortex_duckdb::duckdb::Connection;
+use vortex_duckdb::duckdb::Database;
 use vortex_duckdb::register_extension_options;
 
+use crate::BenchmarkDataset;
+use crate::Format;
+use crate::IdempotentPath;
 use crate::statpopgen::StatPopGenBenchmark;
-use crate::{BenchmarkDataset, Format, IdempotentPath};
 
 #[derive(Debug, Clone)]
 enum DuckDBObject {

--- a/bench-vortex/src/engines/df/mod.rs
+++ b/bench-vortex/src/engines/df/mod.rs
@@ -3,16 +3,19 @@
 
 use std::fs;
 use std::process::Command;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
+use std::sync::LazyLock;
 
 use arrow_array::RecordBatch;
 use datafusion::datasource::provider::DefaultTableFactory;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::cache::cache_manager::CacheManagerConfig;
-use datafusion::execution::cache::cache_unit::{DefaultFileStatisticsCache, DefaultListFilesCache};
+use datafusion::execution::cache::cache_unit::DefaultFileStatisticsCache;
+use datafusion::execution::cache::cache_unit::DefaultListFilesCache;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::physical_plan::collect;
-use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion::prelude::SessionConfig;
+use datafusion::prelude::SessionContext;
 use datafusion_common::GetExt;
 use datafusion_physical_plan::ExecutionPlan;
 use datafusion_physical_plan::display::DisplayableExecutionPlan;

--- a/bench-vortex/src/engines/mod.rs
+++ b/bench-vortex/src/engines/mod.rs
@@ -10,8 +10,10 @@ use std::time::Duration;
 use datafusion::prelude::SessionContext;
 use vortex::error::VortexExpect;
 
+use crate::BenchmarkDataset;
+use crate::Engine;
 pub use crate::Format;
-use crate::{BenchmarkDataset, Engine, vortex_panic};
+use crate::vortex_panic;
 
 pub enum EngineCtx {
     DataFusion(df::DataFusionCtx),

--- a/bench-vortex/src/fineweb/mod.rs
+++ b/bench-vortex/src/fineweb/mod.rs
@@ -5,22 +5,28 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use datafusion::datasource::file_format::parquet::ParquetFormat;
-use datafusion::datasource::listing::{
-    ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
-};
+use datafusion::datasource::listing::ListingOptions;
+use datafusion::datasource::listing::ListingTable;
+use datafusion::datasource::listing::ListingTableConfig;
+use datafusion::datasource::listing::ListingTableUrl;
 use datafusion::prelude::SessionContext;
 use futures::StreamExt;
 use log::info;
 use parquet::arrow::async_writer::AsyncFileWriter;
 use url::Url;
 use vortex::compressor::CompactCompressor;
-use vortex::file::{WriteOptionsSessionExt, WriteStrategyBuilder};
+use vortex::file::WriteOptionsSessionExt;
+use vortex::file::WriteStrategyBuilder;
 use vortex_datafusion::VortexFormat;
 
+use crate::BenchmarkDataset;
+use crate::Format;
+use crate::SESSION;
+use crate::Target;
 use crate::benchmark_trait::Benchmark;
 use crate::conversions::parquet_to_vortex;
 use crate::engines::EngineCtx;
-use crate::{BenchmarkDataset, Format, SESSION, Target, idempotent_async};
+use crate::idempotent_async;
 
 /// URL to the sample file
 const SAMPLE_URL: &str = "https://huggingface.co/datasets/HuggingFaceFW/fineweb/resolve/v1.4.0/sample/10BT/001_00000.parquet";

--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -14,8 +14,10 @@ use itertools::Itertools;
 use serde::Serialize;
 pub use utils::file_utils::*;
 pub use utils::logging::*;
-use vortex::error::{VortexUnwrap, vortex_err};
-use vortex::file::{VortexWriteOptions, WriteStrategyBuilder};
+use vortex::error::VortexUnwrap;
+use vortex::error::vortex_err;
+use vortex::file::VortexWriteOptions;
+use vortex::file::WriteStrategyBuilder;
 use vortex::layout::layouts::compact::CompactCompressor;
 
 pub mod bench_run;
@@ -41,7 +43,8 @@ pub mod tpcds;
 pub mod tpch;
 pub mod utils;
 
-pub use datasets::{BenchmarkDataset, file};
+pub use datasets::BenchmarkDataset;
+pub use datasets::file;
 pub use engines::df;
 use vortex::VortexSessionDefault;
 pub use vortex::error::vortex_panic;

--- a/bench-vortex/src/measurements.rs
+++ b/bench-vortex/src/measurements.rs
@@ -3,17 +3,25 @@
 
 use std::borrow::Cow;
 use std::cmp::Ordering;
-use std::fmt::{Display, Formatter};
-use std::ops::{Add, Div, Sub};
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::ops::Add;
+use std::ops::Div;
+use std::ops::Sub;
 use std::time::Duration;
 
 use itertools::Itertools;
-use serde::{Serialize, Serializer};
+use serde::Serialize;
+use serde::Serializer;
 use target_lexicon::Triple;
-use vortex::error::{VortexUnwrap, vortex_panic};
+use vortex::error::VortexUnwrap;
+use vortex::error::vortex_panic;
 
+use crate::BenchmarkDataset;
+use crate::Engine;
+use crate::Format;
+use crate::Target;
 use crate::engines::df::GIT_COMMIT_ID;
-use crate::{BenchmarkDataset, Engine, Format, Target};
 
 pub trait ToJson {
     fn to_json(&self) -> Box<dyn erased_serde::Serialize>;

--- a/bench-vortex/src/memory.rs
+++ b/bench-vortex/src/memory.rs
@@ -4,7 +4,10 @@
 //! Memory measurement and reclamation utilities for benchmarks
 
 use parking_lot::Mutex;
-use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System};
+use sysinfo::ProcessRefreshKind;
+use sysinfo::ProcessesToUpdate;
+use sysinfo::RefreshKind;
+use sysinfo::System;
 
 /// Memory statistics for a process
 #[derive(Debug, Clone, Copy)]

--- a/bench-vortex/src/metrics.rs
+++ b/bench-vortex/src/metrics.rs
@@ -2,17 +2,31 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
+use std::time::SystemTime;
 
-use datafusion::physical_plan::metrics::{Label, MetricValue, MetricsSet};
-use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanVisitor, Metric, accept};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::ExecutionPlanVisitor;
+use datafusion::physical_plan::Metric;
+use datafusion::physical_plan::accept;
+use datafusion::physical_plan::metrics::Label;
+use datafusion::physical_plan::metrics::MetricValue;
+use datafusion::physical_plan::metrics::MetricsSet;
 use itertools::Itertools;
-use opentelemetry::trace::{SpanContext, Status, TraceId};
-use opentelemetry::{InstrumentationScope, KeyValue, SpanId, TraceFlags};
+use opentelemetry::InstrumentationScope;
+use opentelemetry::KeyValue;
+use opentelemetry::SpanId;
+use opentelemetry::TraceFlags;
+use opentelemetry::trace::SpanContext;
+use opentelemetry::trace::Status;
+use opentelemetry::trace::TraceId;
 use opentelemetry_otlp::SpanExporter as OtlpSpanExporter;
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::error::OTelSdkResult;
-use opentelemetry_sdk::trace::{IdGenerator, RandomIdGenerator, SpanData, SpanExporter};
+use opentelemetry_sdk::trace::IdGenerator;
+use opentelemetry_sdk::trace::RandomIdGenerator;
+use opentelemetry_sdk::trace::SpanData;
+use opentelemetry_sdk::trace::SpanExporter;
 use vortex::utils::aliases::hash_map::HashMap;
 
 use crate::Format;

--- a/bench-vortex/src/public_bi.rs
+++ b/bench-vortex/src/public_bi.rs
@@ -2,27 +2,39 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::borrow::Cow;
-use std::fmt::{self, Display};
+use std::fmt::Display;
+use std::fmt::{self};
 use std::fs;
 use std::os::unix::fs::MetadataExt;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
+use std::sync::LazyLock;
 
-use anyhow::{Context, anyhow, bail};
-use arrow_schema::{DataType, Field, Schema};
+use anyhow::Context;
+use anyhow::anyhow;
+use anyhow::bail;
+use arrow_schema::DataType;
+use arrow_schema::Field;
+use arrow_schema::Schema;
 use async_trait::async_trait;
 use clap::ValueEnum;
 use datafusion::datasource::file_format::FileFormat;
 use datafusion::datasource::file_format::csv::CsvFormat;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
-use datafusion::datasource::listing::{
-    ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
-};
+use datafusion::datasource::listing::ListingOptions;
+use datafusion::datasource::listing::ListingTable;
+use datafusion::datasource::listing::ListingTableConfig;
+use datafusion::datasource::listing::ListingTableUrl;
 use datafusion::prelude::SessionContext;
-use datafusion_common::{DFSchema, Result, TableReference};
-use futures::future::{join_all, try_join_all};
-use humansize::{DECIMAL, format_size};
+use datafusion_common::DFSchema;
+use datafusion_common::Result;
+use datafusion_common::TableReference;
+use futures::future::join_all;
+use futures::future::try_join_all;
+use humansize::DECIMAL;
+use humansize::format_size;
 use log::trace;
 use regex::Regex;
 use tokio::fs::File;
@@ -30,16 +42,22 @@ use tokio::process::Command as TokioCommand;
 use tracing::info;
 use url::Url;
 use vortex::ArrayRef;
-use vortex::error::{VortexResult, vortex_err};
-use vortex::file::{OpenOptionsSessionExt, WriteOptionsSessionExt};
+use vortex::error::VortexResult;
+use vortex::error::vortex_err;
+use vortex::file::OpenOptionsSessionExt;
+use vortex::file::WriteOptionsSessionExt;
 use vortex::stream::ArrayStreamExt;
 use vortex::utils::aliases::hash_map::HashMap;
 use vortex_datafusion::VortexFormat;
 
+use crate::IdempotentPath;
+use crate::SESSION;
 use crate::conversions::parquet_to_vortex;
 use crate::datasets::Dataset;
-use crate::datasets::data_downloads::{decompress_bz2, download_data};
-use crate::{IdempotentPath, SESSION, idempotent_async, vortex_panic};
+use crate::datasets::data_downloads::decompress_bz2;
+use crate::datasets::data_downloads::download_data;
+use crate::idempotent_async;
+use crate::vortex_panic;
 
 pub static PBI_DATASETS: LazyLock<PBIDatasets> = LazyLock::new(|| {
     PBIDatasets::try_new(fetch_schemas_and_queries().expect("failed to fetch public bi queries"))

--- a/bench-vortex/src/query_bench.rs
+++ b/bench-vortex/src/query_bench.rs
@@ -4,12 +4,16 @@
 //! Unified benchmark infrastructure
 
 use std::fs::File;
-use std::io::{Write, stdout};
+use std::io::Write;
+use std::io::stdout;
 use std::path::PathBuf;
 
 use crate::Target;
-use crate::display::{DisplayFormat, print_measurements_json, render_table};
-use crate::measurements::{MemoryMeasurement, QueryMeasurement};
+use crate::display::DisplayFormat;
+use crate::display::print_measurements_json;
+use crate::display::render_table;
+use crate::measurements::MemoryMeasurement;
+use crate::measurements::QueryMeasurement;
 
 /// Common benchmark configuration
 #[derive(Debug, Clone)]

--- a/bench-vortex/src/random_access/take.rs
+++ b/bench-vortex/src/random_access/take.rs
@@ -4,24 +4,31 @@
 use std::iter;
 use std::path::Path;
 
+use arrow_array::PrimitiveArray;
+use arrow_array::RecordBatch;
 use arrow_array::types::Int64Type;
-use arrow_array::{PrimitiveArray, RecordBatch};
 use arrow_select::concat::concat_batches;
 use arrow_select::take::take_record_batch;
 use futures::stream;
 use itertools::Itertools;
 #[cfg(feature = "lance")]
-use lance::dataset::{Dataset, ProjectionRequest};
+#[rustfmt::skip]
+use lance::dataset::{
+    Dataset, 
+    ProjectionRequest
+};
 use parquet::arrow::ParquetRecordBatchStreamBuilder;
 use parquet::arrow::arrow_reader::ArrowReaderOptions;
 use parquet::arrow::async_reader::AsyncFileReader;
 use parquet::file::metadata::RowGroupMetaData;
 use stream::StreamExt;
+use vortex::Array;
+use vortex::ArrayRef;
+use vortex::IntoArray;
 use vortex::buffer::Buffer;
 use vortex::file::OpenOptionsSessionExt;
 use vortex::stream::ArrayStreamExt;
 use vortex::utils::aliases::hash_map::HashMap;
-use vortex::{Array, ArrayRef, IntoArray};
 
 use crate::SESSION;
 

--- a/bench-vortex/src/realnest/gharchive.rs
+++ b/bench-vortex/src/realnest/gharchive.rs
@@ -10,22 +10,29 @@ use std::process::Command;
 use std::sync::Arc;
 
 use datafusion::datasource::file_format::parquet::ParquetFormat;
-use datafusion::datasource::listing::{
-    ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
-};
+use datafusion::datasource::listing::ListingOptions;
+use datafusion::datasource::listing::ListingTable;
+use datafusion::datasource::listing::ListingTableConfig;
+use datafusion::datasource::listing::ListingTableUrl;
 use datafusion::prelude::SessionContext;
 use futures::StreamExt;
 use log::info;
 use parquet::arrow::async_writer::AsyncFileWriter;
 use url::Url;
 use vortex::compressor::CompactCompressor;
-use vortex::file::{WriteOptionsSessionExt, WriteStrategyBuilder};
+use vortex::file::WriteOptionsSessionExt;
+use vortex::file::WriteStrategyBuilder;
 use vortex_datafusion::VortexFormat;
 
+use crate::BenchmarkDataset;
+use crate::Format;
+use crate::SESSION;
+use crate::Target;
 use crate::benchmark_trait::Benchmark;
 use crate::conversions::parquet_to_vortex;
 use crate::engines::EngineCtx;
-use crate::{BenchmarkDataset, Format, SESSION, Target, idempotent, idempotent_async};
+use crate::idempotent;
+use crate::idempotent_async;
 
 /// Template URL for raw JSON dataset
 fn raw_json_url(hour: usize) -> String {

--- a/bench-vortex/src/statpopgen/builder.rs
+++ b/bench-vortex/src/statpopgen/builder.rs
@@ -3,17 +3,26 @@
 
 use std::sync::Arc;
 
-use arrow_array::builder::{
-    ArrayBuilder, BooleanBuilder, Float32Builder, Int32Builder, ListBuilder, StringBuilder,
-    UInt64Builder,
-};
-use arrow_array::{ArrayRef, RecordBatch};
-use arrow_schema::{ArrowError, SchemaRef};
+use arrow_array::ArrayRef;
+use arrow_array::RecordBatch;
+use arrow_array::builder::ArrayBuilder;
+use arrow_array::builder::BooleanBuilder;
+use arrow_array::builder::Float32Builder;
+use arrow_array::builder::Int32Builder;
+use arrow_array::builder::ListBuilder;
+use arrow_array::builder::StringBuilder;
+use arrow_array::builder::UInt64Builder;
+use arrow_schema::ArrowError;
+use arrow_schema::SchemaRef;
 use itertools::Itertools as _;
+use noodles_vcf::Header;
+use noodles_vcf::Record;
 use noodles_vcf::record::Info;
 use noodles_vcf::variant::record::info::field::Value;
-use noodles_vcf::{Header, Record};
-use vortex::error::{VortexExpect as _, VortexResult, vortex_bail, vortex_err};
+use vortex::error::VortexExpect as _;
+use vortex::error::VortexResult;
+use vortex::error::vortex_bail;
+use vortex::error::vortex_err;
 use vortex::utils::aliases::hash_map::HashMap;
 use vortex::utils::aliases::hash_set::HashSet;
 

--- a/bench-vortex/src/statpopgen/download_vcf.rs
+++ b/bench-vortex/src/statpopgen/download_vcf.rs
@@ -3,13 +3,18 @@
 
 use std::io;
 
-use anyhow::{Context, Result, bail};
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::bail;
 use futures::StreamExt;
-use indicatif::{ProgressBar, ProgressStyle};
+use indicatif::ProgressBar;
+use indicatif::ProgressStyle;
 use noodles_vcf::Record;
-use parquet::arrow::{AsyncArrowWriter, ParquetRecordBatchStreamBuilder};
+use parquet::arrow::AsyncArrowWriter;
+use parquet::arrow::ParquetRecordBatchStreamBuilder;
 use reqwest::Client;
-use tokio::fs::{File, create_dir_all};
+use tokio::fs::File;
+use tokio::fs::create_dir_all;
 use tokio::io::BufReader;
 use tokio_util::io::StreamReader;
 use tracing::info;
@@ -19,13 +24,16 @@ use vortex::compressor::CompactCompressor;
 use vortex::dtype::DType;
 use vortex::dtype::arrow::FromArrowType;
 use vortex::error::VortexError;
-use vortex::file::{WriteOptionsSessionExt, WriteStrategyBuilder};
+use vortex::file::WriteOptionsSessionExt;
+use vortex::file::WriteStrategyBuilder;
 use vortex::stream::ArrayStreamAdapter;
 
 use super::StatPopGenBenchmark;
+use crate::Format;
+use crate::SESSION;
+use crate::idempotent_async;
 use crate::statpopgen::builder::GnomADBuilder;
 use crate::statpopgen::schema::schema_from_vcf_header;
-use crate::{Format, SESSION, idempotent_async};
 
 // DuckDB parallelizes parquet at row-group granularity. Each of our rows are quite big (~4000
 // genotypes each with tens of bytes of data).

--- a/bench-vortex/src/statpopgen/schema.rs
+++ b/bench-vortex/src/statpopgen/schema.rs
@@ -3,8 +3,11 @@
 
 use std::sync::Arc;
 
+use arrow_schema::DataType;
 use arrow_schema::DataType::*;
-use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use arrow_schema::Field;
+use arrow_schema::Schema;
+use arrow_schema::SchemaRef;
 use noodles_vcf::Header;
 
 use crate::statpopgen::vcf_conversion::data_type_from_info;

--- a/bench-vortex/src/statpopgen/statpopgen_benchmark.rs
+++ b/bench-vortex/src/statpopgen/statpopgen_benchmark.rs
@@ -2,22 +2,27 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Result;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
-use datafusion::datasource::listing::{
-    ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
-};
+use datafusion::datasource::listing::ListingOptions;
+use datafusion::datasource::listing::ListingTable;
+use datafusion::datasource::listing::ListingTableConfig;
+use datafusion::datasource::listing::ListingTableUrl;
 use datafusion::prelude::SessionContext;
 use tracing::info;
 use url::Url;
 use vortex_datafusion::VortexFormat;
 
+use crate::BenchmarkDataset;
+use crate::Format;
+use crate::SESSION;
+use crate::Target;
 use crate::benchmark_trait::Benchmark;
 use crate::engines::EngineCtx;
-use crate::{BenchmarkDataset, Format, SESSION, Target};
 
 /// Statistical population genetics benchmark implementation.
 ///

--- a/bench-vortex/src/statpopgen/vcf_conversion.rs
+++ b/bench-vortex/src/statpopgen/vcf_conversion.rs
@@ -4,18 +4,21 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
+use arrow_schema::DataType;
 use arrow_schema::DataType::*;
-use arrow_schema::{DataType, Field};
+use arrow_schema::Field;
 use itertools::Itertools as _;
 use noodles_vcf::header::record::value::Map;
 use noodles_vcf::header::record::value::map::Info;
-use noodles_vcf::header::record::value::map::info::{Number, Type};
+use noodles_vcf::header::record::value::map::info::Number;
+use noodles_vcf::header::record::value::map::info::Type;
+use noodles_vcf::variant::record::info::field::value::Array;
+use noodles_vcf::variant::record::info::field::value::Value;
 use noodles_vcf::variant::record::info::field::value::array::Values;
-use noodles_vcf::variant::record::info::field::value::{Array, Value};
-use noodles_vcf::variant::record::samples::series::value::{
-    Array as EntryArray, Value as EntryValue,
-};
-use vortex::error::{VortexResult, vortex_bail};
+use noodles_vcf::variant::record::samples::series::value::Array as EntryArray;
+use noodles_vcf::variant::record::samples::series::value::Value as EntryValue;
+use vortex::error::VortexResult;
+use vortex::error::vortex_bail;
 
 use crate::statpopgen::builder::InfoArrayBuilder;
 

--- a/bench-vortex/src/tpcds/tpcds_benchmark.rs
+++ b/bench-vortex/src/tpcds/tpcds_benchmark.rs
@@ -3,16 +3,20 @@
 
 //! TPC-DS benchmark implementation
 
-use anyhow::{Result, anyhow};
+use anyhow::Result;
+use anyhow::anyhow;
 use datafusion::prelude::SessionContext;
 use log::info;
 use url::Url;
 
+use crate::BenchmarkDataset;
+use crate::Format;
+use crate::IdempotentPath;
+use crate::Target;
 use crate::benchmark_trait::Benchmark;
 use crate::engines::EngineCtx;
 use crate::tpcds::duckdb::generate_tpcds;
 use crate::tpcds::tpcds_queries;
-use crate::{BenchmarkDataset, Format, IdempotentPath, Target};
 
 /// TPC-DS benchmark implementation
 pub struct TpcDsBenchmark {
@@ -151,9 +155,10 @@ impl TpcDsBenchmark {
         base_dir: &Url,
         format: Format,
     ) -> Result<()> {
-        use crate::tpch::{
-            register_arrow, register_parquet, register_vortex_compact_file, register_vortex_file,
-        };
+        use crate::tpch::register_arrow;
+        use crate::tpch::register_parquet;
+        use crate::tpch::register_vortex_compact_file;
+        use crate::tpch::register_vortex_file;
 
         let dataset = self.dataset();
         let files = dataset

--- a/bench-vortex/src/tpch/dbgen.rs
+++ b/bench-vortex/src/tpch/dbgen.rs
@@ -6,10 +6,17 @@
 /// This is a simple wrapper around the `dbgen` tool.
 ///
 /// For more information, see the [dbgen](https://github.com/vortex-data/tpch-dbgen) project.
-use std::fmt::{Display, Formatter};
+use std::fmt::Display;
+/// Download TPC-H data via Docker.
+///
+/// This is a simple wrapper around the `dbgen` tool.
+///
+/// For more information, see the [dbgen](https://github.com/vortex-data/tpch-dbgen) project.
+use std::fmt::Formatter;
 use std::fs::File;
 use std::io::copy;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 
 use dirs::cache_dir;

--- a/bench-vortex/src/tpch/mod.rs
+++ b/bench-vortex/src/tpch/mod.rs
@@ -12,7 +12,8 @@ use datafusion::prelude::SessionContext;
 use glob::Pattern;
 use url::Url;
 
-use crate::{BenchmarkDataset, datasets};
+use crate::BenchmarkDataset;
+use crate::datasets;
 
 pub mod dbgen;
 pub mod schema;

--- a/bench-vortex/src/tpch/schema.rs
+++ b/bench-vortex/src/tpch/schema.rs
@@ -6,7 +6,15 @@ use std::sync::LazyLock;
 /// Arrow schemas for TPC-H tables.
 ///
 /// Adapted from the SQL definitions in https://github.com/dimitri/tpch-citus/blob/master/schema/tpch-schema.sql
-use arrow_schema::{DataType, Field, Schema};
+use arrow_schema::DataType;
+/// Arrow schemas for TPC-H tables.
+///
+/// Adapted from the SQL definitions in https://github.com/dimitri/tpch-citus/blob/master/schema/tpch-schema.sql
+use arrow_schema::Field;
+/// Arrow schemas for TPC-H tables.
+///
+/// Adapted from the SQL definitions in https://github.com/dimitri/tpch-citus/blob/master/schema/tpch-schema.sql
+use arrow_schema::Schema;
 
 pub static NATION: LazyLock<Schema> = LazyLock::new(|| {
     Schema::new(vec![

--- a/bench-vortex/src/tpch/tpch_benchmark.rs
+++ b/bench-vortex/src/tpch/tpch_benchmark.rs
@@ -3,29 +3,53 @@
 
 //! TPCH benchmark implementation
 
-use std::path::{Path, PathBuf};
-use std::{env, fs};
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
 
-use anyhow::{Result, anyhow};
+use anyhow::Result;
+use anyhow::anyhow;
 use datafusion::prelude::SessionContext;
 use ddb::DuckDBCtx;
 use glob::Pattern;
-use log::{info, warn};
-use similar::{ChangeTag, TextDiff};
+use log::info;
+use log::warn;
+use similar::ChangeTag;
+use similar::TextDiff;
 use tokio::runtime::Runtime;
 use url::Url;
-#[cfg(feature = "lance")]
-use {crate::file::register_lance_files, crate::utils};
 
+use crate::BenchmarkDataset;
+use crate::Format;
+use crate::IdempotentPath;
+use crate::Target;
 use crate::benchmark_trait::Benchmark;
-use crate::engines::{EngineCtx, ddb};
-use crate::tpch::schema::{CUSTOMER, LINEITEM, NATION, ORDERS, PART, PARTSUPP, REGION, SUPPLIER};
+use crate::engines::EngineCtx;
+use crate::engines::ddb;
+use crate::tpch::EXPECTED_ROW_COUNTS_SF1;
+use crate::tpch::EXPECTED_ROW_COUNTS_SF10;
+use crate::tpch::register_arrow;
+use crate::tpch::register_parquet;
+use crate::tpch::register_vortex_compact_file;
+use crate::tpch::register_vortex_file;
+use crate::tpch::schema::CUSTOMER;
+use crate::tpch::schema::LINEITEM;
+use crate::tpch::schema::NATION;
+use crate::tpch::schema::ORDERS;
+use crate::tpch::schema::PART;
+use crate::tpch::schema::PARTSUPP;
+use crate::tpch::schema::REGION;
+use crate::tpch::schema::SUPPLIER;
+use crate::tpch::tpch_queries;
+use crate::tpch::tpchgen;
 use crate::tpch::tpchgen::TpchGenOptions;
-use crate::tpch::{
-    EXPECTED_ROW_COUNTS_SF1, EXPECTED_ROW_COUNTS_SF10, register_arrow, register_parquet,
-    register_vortex_compact_file, register_vortex_file, tpch_queries, tpchgen,
+#[cfg(feature = "lance")]
+#[rustfmt::skip]
+use crate::{
+    file::register_lance_files, 
+    utils,
 };
-use crate::{BenchmarkDataset, Format, IdempotentPath, Target};
 
 /// TPCH benchmark implementation
 pub struct TpcHBenchmark {

--- a/bench-vortex/src/tpch/tpchgen.rs
+++ b/bench-vortex/src/tpch/tpchgen.rs
@@ -3,13 +3,17 @@
 
 use std::fs;
 use std::future::Future;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 use std::pin::Pin;
 
-use anyhow::{Result, anyhow};
+use anyhow::Result;
+use anyhow::anyhow;
 use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef;
-use futures::{StreamExt, TryStreamExt, stream};
+use futures::StreamExt;
+use futures::TryStreamExt;
+use futures::stream;
 use log::info;
 use parquet::arrow::AsyncArrowWriter;
 use parquet::basic::Compression;
@@ -17,10 +21,14 @@ use parquet::file::properties::WriterProperties;
 use tokio::fs::File as TokioFile;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
-use tpchgen::generators::{
-    CustomerGenerator, LineItemGenerator, NationGenerator, OrderGenerator, PartGenerator,
-    PartSuppGenerator, RegionGenerator, SupplierGenerator,
-};
+use tpchgen::generators::CustomerGenerator;
+use tpchgen::generators::LineItemGenerator;
+use tpchgen::generators::NationGenerator;
+use tpchgen::generators::OrderGenerator;
+use tpchgen::generators::PartGenerator;
+use tpchgen::generators::PartSuppGenerator;
+use tpchgen::generators::RegionGenerator;
+use tpchgen::generators::SupplierGenerator;
 use tpchgen_arrow::RecordBatchIterator;
 use vortex::ArrayRef;
 use vortex::arrow::FromArrowArray;
@@ -30,8 +38,11 @@ use vortex::error::VortexExpect;
 use vortex::file::WriteOptionsSessionExt;
 use vortex::stream::ArrayStreamAdapter;
 
+use crate::CompactionStrategy;
+use crate::Format;
+use crate::IdempotentPath;
+use crate::SESSION;
 use crate::utils::file_utils::idempotent_async;
-use crate::{CompactionStrategy, Format, IdempotentPath, SESSION};
 
 type TableFuture<'a> = Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
 

--- a/bench-vortex/src/utils/file_utils.rs
+++ b/bench-vortex/src/utils/file_utils.rs
@@ -3,9 +3,12 @@
 
 use std::fs::create_dir_all;
 use std::future::Future;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 
-use anyhow::{Context, Result, bail};
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::bail;
 use url::Url;
 
 /// Creates a file if it doesn't already exist.
@@ -78,7 +81,9 @@ impl IdempotentPath for PathBuf {
 /// - A storage type string ("s3", "gcs", "nvme")
 /// - Or an error if the scheme is unknown
 pub fn url_scheme_to_storage(url: &Url) -> Result<String> {
-    use super::constants::{STORAGE_GCS, STORAGE_NVME, STORAGE_S3};
+    use super::constants::STORAGE_GCS;
+    use super::constants::STORAGE_NVME;
+    use super::constants::STORAGE_S3;
 
     match url.scheme() {
         STORAGE_S3 => Ok(STORAGE_S3.to_owned()),

--- a/bench-vortex/src/utils/parquet_utils.rs
+++ b/bench-vortex/src/utils/parquet_utils.rs
@@ -2,23 +2,30 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::fs::File;
-#[cfg(not(feature = "lance"))]
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::anyhow;
-use arrow_array::{RecordBatch, RecordBatchReader};
+use arrow_array::RecordBatch;
+use arrow_array::RecordBatchReader;
 use arrow_cast::cast;
-use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef};
+use arrow_schema::ArrowError;
+use arrow_schema::DataType;
+use arrow_schema::Field;
+use arrow_schema::Schema;
+use arrow_schema::SchemaRef;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
 #[cfg(feature = "lance")]
+#[rustfmt::skip]
 use {
     crate::utils::idempotent_async,
-    lance::dataset::{Dataset as LanceDataset, WriteParams},
+    lance::dataset::Dataset as LanceDataset,
+    lance::dataset::WriteParams,
     lance_encoding::version::LanceFileVersion,
     log::info,
     std::fs,
-    std::path::{Path, PathBuf},
+    std::path::Path,
     tokio::fs::create_dir_all,
 };
 

--- a/bench-vortex/src/utils/runtime.rs
+++ b/bench-vortex/src/utils/runtime.rs
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use anyhow::{Context, Result, bail};
-use tokio::runtime::{Builder, Runtime};
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::bail;
+use tokio::runtime::Builder;
+use tokio::runtime::Runtime;
 
 /// Creates a Tokio runtime based on the provided thread count configuration.
 ///


### PR DESCRIPTION
I'm guessing we didnt do this before because of the lance feature flags, I just added `#[rustfmt::skip]` in those cases 