### PR TITLE
feat[gpu]: use BufferHandle to the array vtable build

### DIFF
--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -32,7 +32,7 @@ use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityChild;
 use vortex_array::vtable::ValidityVTableFromChild;
 use vortex_array::vtable::VisitorVTable;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_dtype::PType;
 use vortex_error::VortexError;
@@ -97,7 +97,7 @@ impl VTable for ALPVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        _buffers: &[ByteBuffer],
+        _buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ALPArray> {
         let encoded_ptype = match &dtype {

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -37,7 +37,7 @@ use vortex_array::vtable::ValidityChild;
 use vortex_array::vtable::ValidityVTableFromChild;
 use vortex_array::vtable::VisitorVTable;
 use vortex_buffer::Buffer;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_dtype::PType;
@@ -122,7 +122,7 @@ impl VTable for ALPRDVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        _buffers: &[ByteBuffer],
+        _buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ALPRDArray> {
         if children.len() < 2 {

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -32,6 +32,7 @@ use vortex_array::vtable::ValidityHelper;
 use vortex_array::vtable::ValidityVTableFromValidityHelper;
 use vortex_array::vtable::VisitorVTable;
 use vortex_buffer::BitBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
@@ -80,7 +81,7 @@ impl VTable for ByteBoolVTable {
         dtype: &DType,
         len: usize,
         _metadata: &Self::Metadata,
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ByteBoolArray> {
         let validity = if children.is_empty() {
@@ -95,7 +96,7 @@ impl VTable for ByteBoolVTable {
         if buffers.len() != 1 {
             vortex_bail!("Expected 1 buffer, got {}", buffers.len());
         }
-        let buffer = buffers[0].clone();
+        let buffer = buffers[0].clone().try_to_bytes()?;
 
         Ok(ByteBoolArray::new(buffer, validity))
     }

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -30,7 +30,7 @@ use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityChild;
 use vortex_array::vtable::ValidityVTableFromChild;
 use vortex_array::vtable::VisitorVTable;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_dtype::PType;
@@ -115,7 +115,7 @@ impl VTable for DateTimePartsVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        _buffers: &[ByteBuffer],
+        _buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<DateTimePartsArray> {
         if children.len() != 3 {

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -36,7 +36,7 @@ use vortex_array::vtable::ValidityChild;
 use vortex_array::vtable::ValidityHelper;
 use vortex_array::vtable::ValidityVTableFromChild;
 use vortex_array::vtable::VisitorVTable;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_dtype::DecimalDType;
 use vortex_dtype::PType;
@@ -99,7 +99,7 @@ impl VTable for DecimalBytePartsVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        _buffers: &[ByteBuffer],
+        _buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<DecimalBytePartsArray> {
         let Some(decimal_dtype) = dtype.as_decimal_opt() else {

--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -16,7 +16,7 @@ use vortex_array::vtable::ArrayVTableExt;
 use vortex_array::vtable::NotSupported;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTableFromValidityHelper;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_dtype::PType;
 use vortex_error::VortexError;
@@ -100,13 +100,13 @@ impl VTable for BitPackedVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<BitPackedArray> {
         if buffers.len() != 1 {
             vortex_bail!("Expected 1 buffer, got {}", buffers.len());
         }
-        let packed = buffers[0].clone();
+        let packed = buffers[0].clone().try_to_bytes()?;
 
         let load_validity = |child_idx: usize| {
             if children.len() == child_idx {

--- a/encodings/fastlanes/src/delta/vtable/mod.rs
+++ b/encodings/fastlanes/src/delta/vtable/mod.rs
@@ -12,7 +12,7 @@ use vortex_array::vtable::ArrayVTableExt;
 use vortex_array::vtable::NotSupported;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTableFromChildSliceHelper;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_dtype::PType;
 use vortex_dtype::match_each_unsigned_integer_ptype;
@@ -80,7 +80,7 @@ impl VTable for DeltaVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        _buffers: &[ByteBuffer],
+        _buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<DeltaArray> {
         assert_eq!(children.len(), 2);

--- a/encodings/fastlanes/src/for/vtable/mod.rs
+++ b/encodings/fastlanes/src/for/vtable/mod.rs
@@ -14,7 +14,7 @@ use vortex_array::vtable::ArrayVTableExt;
 use vortex_array::vtable::NotSupported;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTableFromChild;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -74,7 +74,7 @@ impl VTable for FoRVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        _buffers: &[ByteBuffer],
+        _buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<FoRArray> {
         if children.len() != 1 {

--- a/encodings/fastlanes/src/rle/vtable/mod.rs
+++ b/encodings/fastlanes/src/rle/vtable/mod.rs
@@ -11,7 +11,7 @@ use vortex_array::vtable::ArrayVTableExt;
 use vortex_array::vtable::NotSupported;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTableFromChildSliceHelper;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_dtype::PType;
@@ -90,7 +90,7 @@ impl VTable for RLEVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        _buffers: &[ByteBuffer],
+        _buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<RLEArray> {
         let metadata = &metadata.0;

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -38,7 +38,7 @@ use vortex_array::vtable::ValidityChild;
 use vortex_array::vtable::ValidityVTableFromChild;
 use vortex_array::vtable::VisitorVTable;
 use vortex_buffer::Buffer;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_dtype::PType;
@@ -108,14 +108,14 @@ impl VTable for FSSTVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<FSSTArray> {
         if buffers.len() != 2 {
             vortex_bail!(InvalidArgument: "Expected 2 buffers, got {}", buffers.len());
         }
-        let symbols = Buffer::<Symbol>::from_byte_buffer(buffers[0].clone());
-        let symbol_lengths = Buffer::<u8>::from_byte_buffer(buffers[1].clone());
+        let symbols = Buffer::<Symbol>::from_byte_buffer(buffers[0].clone().try_to_bytes()?);
+        let symbol_lengths = Buffer::<u8>::from_byte_buffer(buffers[1].clone().try_to_bytes()?);
 
         if children.len() != 2 {
             vortex_bail!(InvalidArgument: "Expected 2 children, got {}", children.len());

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -49,6 +49,7 @@ use vortex_array::vtable::ValidityHelper;
 use vortex_array::vtable::ValiditySliceHelper;
 use vortex_array::vtable::ValidityVTableFromValiditySliceHelper;
 use vortex_array::vtable::VisitorVTable;
+use vortex_buffer::BufferHandle;
 use vortex_buffer::BufferMut;
 use vortex_buffer::ByteBuffer;
 use vortex_buffer::ByteBufferMut;
@@ -128,7 +129,7 @@ impl VTable for PcoVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<PcoArray> {
         let validity = if children.is_empty() {
@@ -141,8 +142,14 @@ impl VTable for PcoVTable {
         };
 
         vortex_ensure!(buffers.len() >= metadata.0.chunks.len());
-        let chunk_metas = buffers[..metadata.0.chunks.len()].to_vec();
-        let pages = buffers[metadata.0.chunks.len()..].to_vec();
+        let chunk_metas = buffers[..metadata.0.chunks.len()]
+            .iter()
+            .map(|b| b.clone().try_to_bytes())
+            .collect::<VortexResult<Vec<_>>>()?;
+        let pages = buffers[metadata.0.chunks.len()..]
+            .iter()
+            .map(|b| b.clone().try_to_bytes())
+            .collect::<VortexResult<Vec<_>>>()?;
 
         let expected_n_pages = metadata
             .0

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -30,7 +30,7 @@ use vortex_array::vtable::CanonicalVTable;
 use vortex_array::vtable::NotSupported;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTable;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_dtype::PType;
@@ -103,7 +103,7 @@ impl VTable for RunEndVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        _buffers: &[ByteBuffer],
+        _buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<RunEndArray> {
         let ends_dtype = DType::Primitive(metadata.ends_ptype(), Nullability::NonNullable);

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -31,8 +31,8 @@ use vortex_array::vtable::OperationsVTable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTable;
 use vortex_array::vtable::VisitorVTable;
+use vortex_buffer::BufferHandle;
 use vortex_buffer::BufferMut;
-use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
 use vortex_dtype::NativePType;
 use vortex_dtype::Nullability;
@@ -228,7 +228,7 @@ impl VTable for SequenceVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        _buffers: &[ByteBuffer],
+        _buffers: &[BufferHandle],
         _children: &dyn ArrayChildren,
     ) -> VortexResult<SequenceArray> {
         let ptype = dtype.as_ptype();

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -41,7 +41,7 @@ use vortex_array::vtable::ValidityVTable;
 use vortex_array::vtable::VisitorVTable;
 use vortex_buffer::BitBufferMut;
 use vortex_buffer::Buffer;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_buffer::ByteBufferMut;
 use vortex_dtype::DType;
 use vortex_dtype::NativePType;
@@ -110,7 +110,7 @@ impl VTable for SparseVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<SparseArray> {
         if children.len() != 2 {
@@ -135,7 +135,10 @@ impl VTable for SparseVTable {
         if buffers.len() != 1 {
             vortex_bail!("Expected 1 buffer, got {}", buffers.len());
         }
-        let fill_value = Scalar::new(dtype.clone(), ScalarValue::from_protobytes(&buffers[0])?);
+        let fill_value = Scalar::new(
+            dtype.clone(),
+            ScalarValue::from_protobytes(&buffers[0].clone().try_to_bytes()?)?,
+        );
 
         SparseArray::try_new(patch_indices, patch_values, len, fill_value)
     }

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -31,7 +31,7 @@ use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityChild;
 use vortex_array::vtable::ValidityVTableFromChild;
 use vortex_array::vtable::VisitorVTable;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_dtype::PType;
 use vortex_dtype::match_each_unsigned_integer_ptype;
@@ -86,7 +86,7 @@ impl VTable for ZigZagVTable {
         dtype: &DType,
         len: usize,
         _metadata: &Self::Metadata,
-        _buffers: &[ByteBuffer],
+        _buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ZigZagArray> {
         if children.len() != 1 {

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -43,6 +43,7 @@ use vortex_array::vtable::ValidityVTableFromValiditySliceHelper;
 use vortex_array::vtable::VisitorVTable;
 use vortex_buffer::Alignment;
 use vortex_buffer::Buffer;
+use vortex_buffer::BufferHandle;
 use vortex_buffer::BufferMut;
 use vortex_buffer::ByteBuffer;
 use vortex_buffer::ByteBufferMut;
@@ -123,7 +124,7 @@ impl VTable for ZstdVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ZstdArray> {
         let validity = if children.is_empty() {
@@ -137,10 +138,22 @@ impl VTable for ZstdVTable {
 
         let (dictionary_buffer, compressed_buffers) = if metadata.0.dictionary_size == 0 {
             // no dictionary
-            (None, buffers.to_vec())
+            (
+                None,
+                buffers
+                    .iter()
+                    .map(|b| b.clone().try_to_bytes())
+                    .collect::<VortexResult<Vec<_>>>()?,
+            )
         } else {
             // with dictionary
-            (Some(buffers[0].clone()), buffers[1..].to_vec())
+            (
+                Some(buffers[0].clone().try_to_bytes()?),
+                buffers[1..]
+                    .iter()
+                    .map(|b| b.clone().try_to_bytes())
+                    .collect::<VortexResult<Vec<_>>>()?,
+            )
         };
 
         Ok(ZstdArray::new(

--- a/vortex-array/src/arrays/bool/vtable/mod.rs
+++ b/vortex-array/src/arrays/bool/vtable/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
@@ -87,7 +87,7 @@ impl VTable for BoolVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<BoolArray> {
         if buffers.len() != 1 {
@@ -103,7 +103,8 @@ impl VTable for BoolVTable {
             vortex_bail!("Expected 0 or 1 child, got {}", children.len());
         };
 
-        BoolArray::try_new(buffers[0].clone(), metadata.offset as usize, len, validity)
+        let buffer = buffers[0].clone().try_to_bytes()?;
+        BoolArray::try_new(buffer, metadata.offset as usize, len, validity)
     }
 
     fn execute(array: &Self::Array, _ctx: &mut dyn ExecutionCtx) -> VortexResult<Vector> {

--- a/vortex-array/src/arrays/chunked/vtable/mod.rs
+++ b/vortex-array/src/arrays/chunked/vtable/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use itertools::Itertools;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_dtype::PType;
@@ -76,7 +76,7 @@ impl VTable for ChunkedVTable {
         dtype: &DType,
         _len: usize,
         _metadata: &Self::Metadata,
-        _buffers: &[ByteBuffer],
+        _buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ChunkedArray> {
         if children.is_empty() {

--- a/vortex-array/src/arrays/constant/vtable/mod.rs
+++ b/vortex-array/src/arrays/constant/vtable/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -74,13 +74,14 @@ impl VTable for ConstantVTable {
         dtype: &DType,
         len: usize,
         _metadata: &Self::Metadata,
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         _children: &dyn ArrayChildren,
     ) -> VortexResult<ConstantArray> {
         if buffers.len() != 1 {
             vortex_bail!("Expected 1 buffer, got {}", buffers.len());
         }
-        let sv = ScalarValue::from_protobytes(&buffers[0])?;
+        let buffer = buffers[0].clone().try_to_bytes()?;
+        let sv = ScalarValue::from_protobytes(&buffer)?;
         let scalar = Scalar::new(dtype.clone(), sv);
         Ok(ConstantArray::new(scalar, len))
     }

--- a/vortex-array/src/arrays/decimal/vtable/mod.rs
+++ b/vortex-array/src/arrays/decimal/vtable/mod.rs
@@ -3,7 +3,7 @@
 
 use vortex_buffer::Alignment;
 use vortex_buffer::Buffer;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_dtype::NativeDecimalType;
 use vortex_dtype::PrecisionScale;
@@ -91,13 +91,13 @@ impl VTable for DecimalVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<DecimalArray> {
         if buffers.len() != 1 {
             vortex_bail!("Expected 1 buffer, got {}", buffers.len());
         }
-        let buffer = buffers[0].clone();
+        let buffer = buffers[0].clone().try_to_bytes()?;
 
         let validity = if children.is_empty() {
             Validity::from(dtype.nullability())

--- a/vortex-array/src/arrays/dict/vtable/mod.rs
+++ b/vortex-array/src/arrays/dict/vtable/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_dtype::PType;
@@ -84,7 +84,7 @@ impl VTable for DictVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        _buffers: &[ByteBuffer],
+        _buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<DictArray> {
         if children.len() != 2 {

--- a/vortex-array/src/arrays/expr/vtable/mod.rs
+++ b/vortex-array/src/arrays/expr/vtable/mod.rs
@@ -10,7 +10,7 @@ mod visitor;
 use std::fmt::Debug;
 
 pub use operator::ExprOptimizationRule;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -73,7 +73,7 @@ impl VTable for ExprVTable {
         dtype: &DType,
         len: usize,
         ExprArrayMetadata((expr, root_dtype)): &Self::Metadata,
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ExprArray> {
         if !buffers.is_empty() {

--- a/vortex-array/src/arrays/extension/vtable/mod.rs
+++ b/vortex-array/src/arrays/extension/vtable/mod.rs
@@ -8,7 +8,7 @@ mod operator;
 mod validity;
 mod visitor;
 
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -68,7 +68,7 @@ impl VTable for ExtensionVTable {
         dtype: &DType,
         len: usize,
         _metadata: &Self::Metadata,
-        _buffers: &[ByteBuffer],
+        _buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ExtensionArray> {
         let DType::Extension(ext_dtype) = dtype else {

--- a/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -78,7 +78,7 @@ impl VTable for FixedSizeListVTable {
         dtype: &DType,
         len: usize,
         _metadata: &Self::Metadata,
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<FixedSizeListArray> {
         vortex_ensure!(

--- a/vortex-array/src/arrays/list/vtable/mod.rs
+++ b/vortex-array/src/arrays/list/vtable/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_dtype::PType;
@@ -82,7 +82,7 @@ impl VTable for ListVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        _buffers: &[ByteBuffer],
+        _buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ListArray> {
         let validity = if children.len() == 2 {

--- a/vortex-array/src/arrays/listview/vtable/mod.rs
+++ b/vortex-array/src/arrays/listview/vtable/mod.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_dtype::PType;
@@ -95,7 +95,7 @@ impl VTable for ListViewVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ListViewArray> {
         vortex_ensure!(

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -7,7 +7,7 @@ mod operations;
 mod operator;
 mod validity;
 
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_compute::mask::MaskValidity;
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
@@ -84,7 +84,7 @@ impl VTable for MaskedVTable {
         dtype: &DType,
         len: usize,
         _metadata: &Self::Metadata,
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<MaskedArray> {
         if !buffers.is_empty() {

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -4,7 +4,7 @@
 use std::hash::Hash;
 use std::ops::Range;
 
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
@@ -82,7 +82,7 @@ impl VTable for NullVTable {
         _dtype: &DType,
         len: usize,
         _metadata: &Self::Metadata,
-        _buffers: &[ByteBuffer],
+        _buffers: &[BufferHandle],
         _children: &dyn ArrayChildren,
     ) -> VortexResult<NullArray> {
         Ok(NullArray::new(len))

--- a/vortex-array/src/arrays/primitive/vtable/array.rs
+++ b/vortex-array/src/arrays/primitive/vtable/array.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::hash::Hash;
+use std::hash::Hasher;
 
 use vortex_dtype::DType;
 
@@ -26,11 +27,7 @@ impl BaseArrayVTable<PrimitiveVTable> for PrimitiveVTable {
         array.stats_set.to_ref(array.as_ref())
     }
 
-    fn array_hash<H: std::hash::Hasher>(
-        array: &PrimitiveArray,
-        state: &mut H,
-        precision: Precision,
-    ) {
+    fn array_hash<H: Hasher>(array: &PrimitiveArray, state: &mut H, precision: Precision) {
         array.dtype.hash(state);
         array.buffer.array_hash(state, precision);
         array.validity.array_hash(state, precision);

--- a/vortex-array/src/arrays/primitive/vtable/mod.rs
+++ b/vortex-array/src/arrays/primitive/vtable/mod.rs
@@ -3,7 +3,7 @@
 
 use vortex_buffer::Alignment;
 use vortex_buffer::Buffer;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_dtype::PType;
 use vortex_dtype::match_each_native_ptype;
@@ -76,13 +76,13 @@ impl VTable for PrimitiveVTable {
         dtype: &DType,
         len: usize,
         _metadata: &Self::Metadata,
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<PrimitiveArray> {
         if buffers.len() != 1 {
             vortex_bail!("Expected 1 buffer, got {}", buffers.len());
         }
-        let buffer = buffers[0].clone();
+        let buffer = buffers[0].clone().try_to_bytes()?;
 
         let validity = if children.is_empty() {
             Validity::from(dtype.nullability())

--- a/vortex-array/src/arrays/struct_/vtable/mod.rs
+++ b/vortex-array/src/arrays/struct_/vtable/mod.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use itertools::Itertools;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
@@ -78,7 +78,7 @@ impl VTable for StructVTable {
         dtype: &DType,
         len: usize,
         _metadata: &Self::Metadata,
-        _buffers: &[ByteBuffer],
+        _buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<StructArray> {
         let DType::Struct(struct_dtype, nullability) = dtype else {

--- a/vortex-array/src/arrays/varbin/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbin/vtable/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_dtype::PType;
@@ -82,7 +82,7 @@ impl VTable for VarBinVTable {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<VarBinArray> {
         let validity = if children.len() == 1 {
@@ -103,7 +103,7 @@ impl VTable for VarBinVTable {
         if buffers.len() != 1 {
             vortex_bail!("Expected 1 buffer, got {}", buffers.len());
         }
-        let bytes = buffers[0].clone();
+        let bytes = buffers[0].clone().try_to_bytes()?;
 
         VarBinArray::try_new(offsets, bytes, dtype.clone(), validity)
     }

--- a/vortex-array/src/arrays/varbinview/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/mod.rs
@@ -4,6 +4,7 @@
 use std::sync::Arc;
 
 use vortex_buffer::Buffer;
+use vortex_buffer::BufferHandle;
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
 use vortex_error::VortexExpect;
@@ -75,13 +76,16 @@ impl VTable for VarBinViewVTable {
         dtype: &DType,
         len: usize,
         _metadata: &Self::Metadata,
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<VarBinViewArray> {
         if buffers.is_empty() {
             vortex_bail!("Expected at least 1 buffer, got {}", buffers.len());
         }
-        let mut buffers: Vec<ByteBuffer> = buffers.to_vec();
+        let mut buffers: Vec<ByteBuffer> = buffers
+            .iter()
+            .map(|b| b.clone().try_to_bytes())
+            .collect::<VortexResult<Vec<_>>>()?;
         let views = buffers.pop().vortex_expect("buffers non-empty");
 
         let views = Buffer::<BinaryView>::from_byte_buffer(views);

--- a/vortex-array/src/arrow/array.rs
+++ b/vortex-array/src/arrow/array.rs
@@ -6,7 +6,7 @@ use std::hash::Hash;
 use std::ops::Range;
 
 use arrow_array::ArrayRef as ArrowArrayRef;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_dtype::arrow::FromArrowType;
@@ -81,7 +81,7 @@ impl VTable for ArrowVTable {
         _dtype: &DType,
         _len: usize,
         _metadata: &Self::Metadata,
-        _buffers: &[ByteBuffer],
+        _buffers: &[BufferHandle],
         _children: &dyn ArrayChildren,
     ) -> VortexResult<Self::Array> {
         vortex_bail!("ArrowArray cannot be deserialized")

--- a/vortex-array/src/hash.rs
+++ b/vortex-array/src/hash.rs
@@ -7,6 +7,7 @@ use std::hash::Hasher;
 
 use vortex_buffer::BitBuffer;
 use vortex_buffer::Buffer;
+use vortex_buffer::BufferHandle;
 use vortex_mask::Mask;
 
 use crate::Array;
@@ -251,5 +252,24 @@ impl ArrayEq for Patches {
             && self.offset() == other.offset()
             && self.indices().array_eq(other.indices(), precision)
             && self.values().array_eq(other.values(), precision)
+    }
+}
+
+impl ArrayHash for BufferHandle {
+    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
+        match self {
+            BufferHandle::Buffer(b) => b.array_hash(state, precision),
+            BufferHandle::DeviceBuffer => (),
+        }
+    }
+}
+
+impl ArrayEq for BufferHandle {
+    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
+        match (self, other) {
+            (BufferHandle::Buffer(b), BufferHandle::Buffer(b2)) => b.array_eq(b2, precision),
+            (BufferHandle::DeviceBuffer, BufferHandle::DeviceBuffer) => true,
+            _ => false,
+        }
     }
 }

--- a/vortex-array/src/serde.rs
+++ b/vortex-array/src/serde.rs
@@ -12,6 +12,7 @@ use flatbuffers::WIPOffset;
 use flatbuffers::root;
 use itertools::Itertools;
 use vortex_buffer::Alignment;
+use vortex_buffer::BufferHandle;
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
 use vortex_dtype::TryFromBytes;
@@ -272,7 +273,7 @@ pub struct ArrayParts {
     flatbuffer: FlatBuffer,
     // The location of the current fb::ArrayNode
     flatbuffer_loc: usize,
-    buffers: Arc<[ByteBuffer]>,
+    buffers: Arc<[BufferHandle]>,
 }
 
 impl Debug for ArrayParts {
@@ -298,7 +299,7 @@ impl ArrayParts {
             .ok_or_else(|| vortex_err!("Unknown encoding: {}", encoding_id))?;
 
         let buffers: Vec<_> = (0..self.nbuffers())
-            .map(|idx| self.buffer(idx).map(vortex_buffer::BufferHandle::Buffer))
+            .map(|idx| self.buffer(idx))
             .try_collect()?;
 
         let children = ArrayPartsChildren { parts: self, ctx };
@@ -384,7 +385,7 @@ impl ArrayParts {
     }
 
     /// Returns the nth buffer of the current array.
-    pub fn buffer(&self, idx: usize) -> VortexResult<ByteBuffer> {
+    pub fn buffer(&self, idx: usize) -> VortexResult<BufferHandle> {
         let buffer_idx = self
             .flatbuffer()
             .buffers()
@@ -456,7 +457,7 @@ impl TryFrom<ByteBuffer> for ArrayParts {
         let fb_root = fb_array.root().vortex_expect("Array must have a root node");
 
         let mut offset = 0;
-        let buffers: Arc<[ByteBuffer]> = fb_array
+        let buffers: Arc<[_]> = fb_array
             .buffers()
             .unwrap_or_default()
             .iter()
@@ -472,7 +473,7 @@ impl TryFrom<ByteBuffer> for ArrayParts {
                     .aligned(Alignment::from_exponent(fb_buffer.alignment_exponent()));
 
                 offset += buffer_len;
-                buffer
+                BufferHandle::Buffer(buffer)
             })
             .collect();
 

--- a/vortex-array/src/serde.rs
+++ b/vortex-array/src/serde.rs
@@ -298,7 +298,7 @@ impl ArrayParts {
             .ok_or_else(|| vortex_err!("Unknown encoding: {}", encoding_id))?;
 
         let buffers: Vec<_> = (0..self.nbuffers())
-            .map(|idx| self.buffer(idx))
+            .map(|idx| self.buffer(idx).map(vortex_buffer::BufferHandle::Buffer))
             .try_collect()?;
 
         let children = ArrayPartsChildren { parts: self, ctx };

--- a/vortex-array/src/vtable/dyn_.rs
+++ b/vortex-array/src/vtable/dyn_.rs
@@ -9,7 +9,7 @@ use std::mem::transmute;
 use std::sync::Arc;
 
 use arcref::ArcRef;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
@@ -42,7 +42,7 @@ pub trait DynVTable: 'static + private::Sealed + Send + Sync + Debug {
         dtype: &DType,
         len: usize,
         metadata: &[u8],
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ArrayRef>;
 
@@ -84,7 +84,7 @@ impl<V: VTable> DynVTable for ArrayVTableAdapter<V> {
         dtype: &DType,
         len: usize,
         metadata_bytes: &[u8],
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<ArrayRef> {
         let metadata = V::deserialize(metadata_bytes)?;
@@ -99,12 +99,17 @@ impl<V: VTable> DynVTable for ArrayVTableAdapter<V> {
         array: &dyn Array,
         children: &dyn ArrayChildren,
     ) -> VortexResult<ArrayRef> {
+        let buffers: Vec<BufferHandle> = array
+            .buffers()
+            .into_iter()
+            .map(BufferHandle::Buffer)
+            .collect();
         V::build(
             &self.0,
             array.dtype(),
             array.len(),
             &V::metadata(array.as_::<V>())?,
-            array.buffers().as_slice(),
+            &buffers,
             children,
         )
         .map(|a| a.into_array())

--- a/vortex-array/src/vtable/mod.rs
+++ b/vortex-array/src/vtable/mod.rs
@@ -25,7 +25,7 @@ pub use operations::*;
 pub use operator::*;
 pub use validity::*;
 pub use visitor::*;
-use vortex_buffer::ByteBuffer;
+use vortex_buffer::BufferHandle;
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -130,7 +130,7 @@ pub trait VTable: 'static + Sized + Send + Sync + Debug {
         dtype: &DType,
         len: usize,
         metadata: &Self::Metadata,
-        buffers: &[ByteBuffer],
+        buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
     ) -> VortexResult<Self::Array>;
 

--- a/vortex-buffer/src/lib.rs
+++ b/vortex-buffer/src/lib.rs
@@ -55,6 +55,8 @@ pub use buffer_mut::*;
 pub use bytes::*;
 pub use r#const::*;
 pub use string::*;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
 
 mod alignment;
 #[cfg(feature = "arrow")]
@@ -83,3 +85,41 @@ pub type ByteBufferMut = BufferMut<u8>;
 
 /// A const-aligned buffer of u8.
 pub type ConstByteBuffer<const A: usize> = ConstBuffer<u8, A>;
+
+#[derive(Debug, Clone)]
+/// A buffer can be either on the CPU or on an attached device (e.g. GPU).
+/// The Device implementation will come later.
+pub enum BufferHandle {
+    /// On the host/cpu.
+    Buffer(ByteBuffer),
+    /// On the device.
+    // TODO: impl this.
+    DeviceBuffer,
+}
+
+impl BufferHandle {
+    /// Fetches the cpu buffer and fails otherwise.
+    pub fn bytes(&self) -> &ByteBuffer {
+        match self {
+            BufferHandle::Buffer(b) => b,
+            BufferHandle::DeviceBuffer => todo!(),
+        }
+    }
+
+    /// Fetches the cpu buffer and fails otherwise.
+    pub fn into_bytes(self) -> ByteBuffer {
+        match self {
+            BufferHandle::Buffer(b) => b,
+            BufferHandle::DeviceBuffer => todo!(),
+        }
+    }
+
+    /// Attempts to convert this handle into a CPU ByteBuffer.
+    /// Returns an error if the buffer is on a device.
+    pub fn try_to_bytes(self) -> VortexResult<ByteBuffer> {
+        match self {
+            BufferHandle::Buffer(b) => Ok(b),
+            BufferHandle::DeviceBuffer => vortex_bail!("cannot move device_buffer to buffer"),
+        }
+    }
+}

--- a/vortex-python/src/arrays/py/vtable.rs
+++ b/vortex-python/src/arrays/py/vtable.rs
@@ -18,7 +18,7 @@ use vortex::Canonical;
 use vortex::Precision;
 use vortex::RawMetadata;
 use vortex::SerializeMetadata;
-use vortex::buffer::ByteBuffer;
+use vortex::buffer::BufferHandle;
 use vortex::compute::ComputeFn;
 use vortex::compute::InvocationArgs;
 use vortex::compute::Output;
@@ -134,7 +134,7 @@ impl VTable for PythonVTable {
         _dtype: &DType,
         _len: usize,
         _metadata: &Self::Metadata,
-        _buffers: &[ByteBuffer],
+        _buffers: &[BufferHandle],
         _children: &dyn ArrayChildren,
     ) -> VortexResult<PythonArray> {
         todo!()

--- a/vortex-python/src/serde/parts.rs
+++ b/vortex-python/src/serde/parts.rs
@@ -81,7 +81,7 @@ impl PyArrayParts {
 
         let mut buffers = Vec::with_capacity(slf.nbuffers());
         for buffer in (0..slf.nbuffers()).map(|i| slf.buffer(i)) {
-            let buffer: ByteBuffer = buffer?;
+            let buffer: ByteBuffer = buffer.map(|b| b.into_bytes())?;
 
             let addr = buffer.as_ptr() as usize;
             let size = buffer.len();


### PR DESCRIPTION
We want to have array which are backed by either CPU or GPU/device buffers. 

The first stage is to create that enum and change the build array method.
Then add this to the segment source and array construction.
Then we can go through each array and support non-cpu buffers.


There is an open question if we want to have this logical-scan-plann have buffers or BufferIDs