### PR TITLE
ci: add cache-suffix to isolate sanitizer build cache

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -15,6 +15,10 @@ inputs:
   targets:
     description: "optional targets override (e.g. wasm32-unknown-unknown)"
     required: false
+  cache-suffix:
+    description: "optional suffix for cache key to isolate builds with different RUSTFLAGS (e.g. 'sanitizer')"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -48,7 +52,7 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref_name == 'develop' }}
-        shared-key: "rust-cache-${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-${{ steps.toolchain-config.outputs.toolchain }}-${{ steps.toolchain-config.outputs.targets }}"
+        shared-key: "rust-cache-${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-${{ steps.toolchain-config.outputs.toolchain }}-${{ steps.toolchain-config.outputs.targets }}${{ inputs.cache-suffix && format('-{0}', inputs.cache-suffix) || '' }}"
 
     - name: Rust Compile Cache
       uses: mozilla-actions/sccache-action@v0.0.9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,6 +421,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           toolchain: nightly
           components: "rust-src, rustfmt, clippy, llvm-tools-preview"
+          cache-suffix: "sanitizer"
       - name: Install build dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Summary
- Add `cache-suffix` input to `setup-rust` action to allow jobs with different RUSTFLAGS to use separate caches
- Use `cache-suffix: "sanitizer"` for the sanitizer test job to prevent cache pollution between sanitizer and non-sanitizer builds

## Test plan
- [x] Verify CI jobs pass
- [x] Confirm sanitizer job uses separate cache key

🤖 Generated with [Claude Code](https://claude.com/claude-code)