### PR TITLE
ci: add runs-on.yml that points to prebuilt AMI

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,0 +1,4 @@
+images:
+  vortex-ci:
+    name: "vortex-ci-*"
+    owner: "375504701696"


### PR DESCRIPTION
We need to merge this first before we can do #5618 

<img width="784" height="167" alt="image" src="https://github.com/user-attachments/assets/86d796bc-9d5a-4490-97c9-ac5adc06e03a" />
