### PR TITLE
fix: cargo-deny for rustls-pemfile

### DIFF
--- a/bench-vortex/Cargo.toml
+++ b/bench-vortex/Cargo.toml
@@ -51,7 +51,7 @@ log = { workspace = true, features = ["max_level_debug"] }
 mimalloc = { workspace = true }
 noodles-bgzf = { workspace = true, features = ["async"] }
 noodles-vcf = { workspace = true, features = ["async"] }
-object_store = { workspace = true, features = ["aws", "gcp"] }
+object_store = { workspace = true, features = ["aws"] }
 opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true, features = ["trace"] }
 opentelemetry_sdk = { workspace = true }


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2025-0134.html

Removing the GCP feature flag prevents us bringing in the transitive dep, and I believe all of our benchmarking infra is off GCP now anyway.