### PR TITLE
vx layout display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9146,6 +9146,8 @@ version = "0.1.0"
 dependencies = [
  "dashmap",
  "hashbrown 0.16.1",
+ "parking_lot",
+ "vortex-error",
 ]
 
 [[package]]

--- a/vortex-array/src/serde.rs
+++ b/vortex-array/src/serde.rs
@@ -403,6 +403,43 @@ impl ArrayParts {
             })
     }
 
+    /// Returns the buffer lengths as stored in the flatbuffer metadata.
+    ///
+    /// This reads the buffer descriptors from the flatbuffer, which contain the
+    /// serialized length of each buffer. This is useful for displaying buffer sizes
+    /// without needing to access the actual buffer data.
+    pub fn buffer_lengths(&self) -> Vec<usize> {
+        let fb_array = root::<fba::Array>(self.flatbuffer.as_ref())
+            .vortex_expect("ArrayParts flatbuffer must be a valid Array");
+        fb_array
+            .buffers()
+            .map(|buffers| buffers.iter().map(|b| b.length() as usize).collect())
+            .unwrap_or_default()
+    }
+
+    /// Create an [`ArrayParts`] from a raw array tree flatbuffer (metadata only).
+    ///
+    /// This constructor creates an `ArrayParts` with no buffer data, useful for
+    /// inspecting the metadata when the actual buffer data is not needed
+    /// (e.g., displaying buffer sizes from inlined array tree metadata).
+    ///
+    /// Note: Calling `buffer()` on the returned `ArrayParts` will fail since
+    /// no actual buffer data is available.
+    pub fn from_array_tree(array_tree: impl Into<ByteBuffer>) -> VortexResult<Self> {
+        let fb_buffer = FlatBuffer::align_from(array_tree.into());
+        let fb_array = root::<fba::Array>(fb_buffer.as_ref())?;
+        let fb_root = fb_array
+            .root()
+            .ok_or_else(|| vortex_err!("Array must have a root node"))?;
+        let flatbuffer_loc = fb_root._tab.loc();
+
+        Ok(ArrayParts {
+            flatbuffer: fb_buffer,
+            flatbuffer_loc,
+            buffers: Arc::new([]),
+        })
+    }
+
     /// Returns the root ArrayNode flatbuffer.
     fn flatbuffer(&self) -> fba::ArrayNode<'_> {
         unsafe { fba::ArrayNode::follow(self.flatbuffer.as_ref(), self.flatbuffer_loc) }

--- a/vortex-layout/Cargo.toml
+++ b/vortex-layout/Cargo.toml
@@ -61,6 +61,7 @@ rstest = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 vortex-array = { path = "../vortex-array", features = ["test-harness"] }
 vortex-io = { path = "../vortex-io", features = ["tokio"] }
+vortex-utils = { workspace = true, features = ["test-harness"] }
 
 [features]
 test-harness = []

--- a/vortex-layout/src/display.rs
+++ b/vortex-layout/src/display.rs
@@ -335,11 +335,12 @@ vortex.struct, dtype: {numbers=i64?, strings=utf8}, children: 2, rows: 5
     /// Test display_tree_with_segments using async segment source to fetch buffer sizes.
     #[test]
     fn test_display_tree_with_segment_source() {
-        // Ensure inline array node is disabled for this test
         let _guard = EnvVarGuard::remove("FLAT_LAYOUT_INLINE_ARRAY_NODE");
+        println!("{:?}", std::env::var("FLAT_LAYOUT_INLINE_ARRAY_NODE"));
         block_on(|handle| async move {
             let ctx = ArrayContext::empty();
             let segments = Arc::new(TestSegments::default());
+            println!("{:?}", std::env::var("FLAT_LAYOUT_INLINE_ARRAY_NODE"));
 
             // Create simple i32 array
             let (ptr1, eof1) = SequenceId::root().split();
@@ -381,6 +382,7 @@ vortex.struct, dtype: {numbers=i64?, strings=utf8}, children: 2, rows: 5
                 .display_tree_with_segments(segments)
                 .await
                 .unwrap();
+            println!("{:?}", std::env::var("FLAT_LAYOUT_INLINE_ARRAY_NODE"));
 
             let expected = "\
 vortex.chunked, dtype: i32, children: 2, rows: 10

--- a/vortex-layout/src/display.rs
+++ b/vortex-layout/src/display.rs
@@ -1,98 +1,477 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::sync::Arc;
+
+use futures::future::try_join_all;
 use termtree::Tree;
+use vortex_array::serde::ArrayParts;
 use vortex_error::VortexResult;
+use vortex_utils::aliases::hash_map::HashMap;
 
 use crate::LayoutRef;
+use crate::layouts::flat::FlatLayout;
+use crate::layouts::flat::FlatVTable;
+use crate::segments::SegmentId;
+use crate::segments::SegmentSource;
 
-/// Display wrapper for layout tree visualization
+/// Display the layout as a tree, fetching segment sizes from the segment source.
+///
+/// # Warning
+///
+/// This function performs IO to fetch each segment's buffer. For layouts with
+/// many segments, this may result in significant IO overhead.
+pub(super) async fn display_tree_with_segment_sizes(
+    layout: LayoutRef,
+    segment_source: Arc<dyn SegmentSource>,
+) -> VortexResult<DisplayLayoutTree> {
+    // First, collect all segment IDs from the layout tree (excluding those with inline array_tree)
+    let mut segments_to_fetch = Vec::new();
+    collect_segments_to_fetch(&layout, &mut segments_to_fetch)?;
+
+    // Fetch segments in parallel and parse buffer info
+    let fetch_futures = segments_to_fetch.iter().map(|&segment_id| {
+        let segment_source = segment_source.clone();
+        async move {
+            let buffer = segment_source.request(segment_id).await?;
+            let parts = ArrayParts::try_from(buffer)?;
+            VortexResult::Ok((segment_id, parts.buffer_lengths()))
+        }
+    });
+    let results = try_join_all(fetch_futures).await?;
+    let segment_buffer_sizes: HashMap<SegmentId, Vec<usize>> = results.into_iter().collect();
+
+    Ok(DisplayLayoutTree {
+        layout,
+        segment_buffer_sizes: Some(segment_buffer_sizes),
+        verbose: true,
+    })
+}
+
+/// Collect segment IDs that need to be fetched (those without inline array_tree).
+fn collect_segments_to_fetch(
+    layout: &LayoutRef,
+    segment_ids: &mut Vec<SegmentId>,
+) -> VortexResult<()> {
+    // For FlatLayout, only add if there's no inline array_tree
+    if let Some(flat_layout) = layout.as_opt::<FlatVTable>() {
+        if flat_layout.array_tree().is_none() {
+            segment_ids.push(flat_layout.segment_id());
+        }
+    } else {
+        // For other layouts, add all segment IDs
+        segment_ids.extend(layout.segment_ids());
+    }
+
+    // Recurse into children
+    for child in layout.children()? {
+        collect_segments_to_fetch(&child, segment_ids)?;
+    }
+    Ok(())
+}
+
+/// Build a tree node for a FlatLayout, showing buffer sizes.
+fn format_flat_layout_buffers(
+    flat_layout: &FlatLayout,
+    segment_buffer_sizes: Option<&HashMap<SegmentId, Vec<usize>>>,
+) -> String {
+    let segment_id = flat_layout.segment_id();
+
+    // First, try to get buffer info from inline array_tree
+    if let Some(array_tree) = flat_layout.array_tree()
+        && let Ok(parts) = ArrayParts::from_array_tree(array_tree.as_ref().to_vec())
+    {
+        return format_buffer_sizes(&parts.buffer_lengths(), *segment_id);
+    }
+
+    // Otherwise, try to get from fetched segment info
+    if let Some(sizes_map) = segment_buffer_sizes
+        && let Some(buffer_sizes) = sizes_map.get(&segment_id)
+    {
+        return format_buffer_sizes(buffer_sizes, *segment_id);
+    }
+
+    // Fallback: just show segment ID
+    format!("segment: {}", *segment_id)
+}
+
+fn format_buffer_sizes(buffer_sizes: &[usize], segment_id: u32) -> String {
+    let buffer_sizes_str: Vec<String> = buffer_sizes.iter().map(|s| format!("{}B", s)).collect();
+    let total: usize = buffer_sizes.iter().sum();
+    format!(
+        "segment {}, buffers=[{}], total={}B",
+        segment_id,
+        buffer_sizes_str.join(", "),
+        total
+    )
+}
+
+/// Display wrapper for layout tree visualization.
 pub struct DisplayLayoutTree {
     layout: LayoutRef,
+    segment_buffer_sizes: Option<HashMap<SegmentId, Vec<usize>>>,
     verbose: bool,
 }
 
 impl DisplayLayoutTree {
+    /// Create a new display tree without pre-fetched segment buffer sizes.
     pub fn new(layout: LayoutRef, verbose: bool) -> Self {
-        Self { layout, verbose }
+        Self {
+            layout,
+            segment_buffer_sizes: None,
+            verbose,
+        }
     }
-}
 
-impl std::fmt::Display for DisplayLayoutTree {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        fn make_tree(layout: LayoutRef, verbose: bool) -> VortexResult<Tree<String>> {
-            // Build the node label with encoding, dtype, and metadata
-            let mut node_parts = vec![
-                format!("{}", layout.encoding()),
-                format!("dtype: {}", layout.dtype()),
-            ];
+    fn make_tree(&self, layout: LayoutRef) -> VortexResult<Tree<String>> {
+        // Build the node label with encoding, dtype, and metadata
+        let mut node_parts = vec![
+            format!("{}", layout.encoding()),
+            format!("dtype: {}", layout.dtype()),
+        ];
 
-            // Add child count if there are children
-            let nchildren = layout.nchildren();
-            if nchildren > 0 {
-                node_parts.push(format!("children: {}", nchildren));
+        // Add child count if there are children
+        let nchildren = layout.nchildren();
+        if nchildren > 0 {
+            node_parts.push(format!("children: {}", nchildren));
+        }
+
+        // Add metadata and row count if verbose
+        if self.verbose {
+            let metadata = layout.metadata();
+            if !metadata.is_empty() {
+                node_parts.push(format!("metadata: {} bytes", metadata.len()));
             }
+            node_parts.push(format!("rows: {}", layout.row_count()));
+        }
 
-            // Add metadata information if verbose mode is enabled
-            if verbose {
-                let metadata = layout.metadata();
-                if !metadata.is_empty() {
-                    node_parts.push(format!("metadata: {} bytes", metadata.len()));
-                }
-
-                // Add segment IDs
+        // For FlatLayout, show buffer info
+        if let Some(flat_layout) = layout.as_opt::<FlatVTable>() {
+            node_parts.push(format_flat_layout_buffers(
+                flat_layout,
+                self.segment_buffer_sizes.as_ref(),
+            ));
+        } else {
+            // Not a FlatLayout - show segment IDs if any (for verbose mode)
+            if self.verbose {
                 let segment_ids = layout.segment_ids();
                 if !segment_ids.is_empty() {
                     node_parts.push(format!(
                         "segments: [{}]",
                         segment_ids
                             .iter()
-                            .map(|s| s.to_string())
+                            .map(|s| format!("{}", **s))
                             .collect::<Vec<_>>()
                             .join(", ")
                     ));
                 }
-
-                // Add row count
-                node_parts.push(format!("rows: {}", layout.row_count()));
             }
-
-            let node_name = node_parts.join(", ");
-
-            // Get children and child names directly from the layout (not loading arrays)
-            let children = layout.children()?;
-            let child_names: Vec<_> = layout.child_names().collect();
-
-            // Build child trees
-            let child_trees: VortexResult<Vec<Tree<String>>> =
-                if !children.is_empty() && child_names.len() == children.len() {
-                    // If we have names for all children, use them
-                    children
-                        .into_iter()
-                        .zip(child_names.iter())
-                        .map(|(child, name)| {
-                            let child_tree = make_tree(child, verbose)?;
-                            Ok(Tree::new(format!("{}: {}", name, child_tree.root))
-                                .with_leaves(child_tree.leaves))
-                        })
-                        .collect()
-                } else if !children.is_empty() {
-                    // No names available, just show children
-                    children
-                        .into_iter()
-                        .map(|c| make_tree(c, verbose))
-                        .collect()
-                } else {
-                    // Leaf node - no children
-                    Ok(Vec::new())
-                };
-
-            Ok(Tree::new(node_name).with_leaves(child_trees?))
         }
 
-        match make_tree(self.layout.clone(), self.verbose) {
+        let node_name = node_parts.join(", ");
+
+        // Get children and child names directly from the layout
+        let children = layout.children()?;
+        let child_names: Vec<_> = layout.child_names().collect();
+
+        // Build child trees
+        let child_trees: VortexResult<Vec<Tree<String>>> =
+            if !children.is_empty() && child_names.len() == children.len() {
+                // If we have names for all children, use them
+                children
+                    .into_iter()
+                    .zip(child_names.iter())
+                    .map(|(child, name)| {
+                        let child_tree = self.make_tree(child)?;
+                        Ok(Tree::new(format!("{}: {}", name, child_tree.root))
+                            .with_leaves(child_tree.leaves))
+                    })
+                    .collect()
+            } else if !children.is_empty() {
+                // No names available, just show children
+                children.into_iter().map(|c| self.make_tree(c)).collect()
+            } else {
+                // Leaf node - no children
+                Ok(Vec::new())
+            };
+
+        Ok(Tree::new(node_name).with_leaves(child_trees?))
+    }
+}
+
+impl std::fmt::Display for DisplayLayoutTree {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.make_tree(self.layout.clone()) {
             Ok(tree) => write!(f, "{}", tree),
             Err(e) => write!(f, "Error building layout tree: {}", e),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use vortex_array::ArrayContext;
+    use vortex_array::IntoArray;
+    use vortex_array::arrays::BoolArray;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::builders::ArrayBuilder;
+    use vortex_array::builders::VarBinViewBuilder;
+    use vortex_array::validity::Validity;
+    use vortex_buffer::BitBufferMut;
+    use vortex_buffer::buffer;
+    use vortex_dtype::DType;
+    use vortex_dtype::FieldName;
+    use vortex_dtype::Nullability;
+    use vortex_dtype::Nullability::NonNullable;
+    use vortex_dtype::PType;
+    use vortex_dtype::StructFields;
+    use vortex_io::runtime::single::block_on;
+
+    use crate::IntoLayout;
+    use crate::OwnedLayoutChildren;
+    use crate::layouts::chunked::ChunkedLayout;
+    use crate::layouts::flat::writer::FlatLayoutStrategy;
+    use crate::layouts::struct_::StructLayout;
+    use crate::segments::TestSegments;
+    use crate::sequence::SequenceId;
+    use crate::sequence::SequentialArrayStreamExt;
+    use crate::strategy::LayoutStrategy;
+
+    /// Test display_tree with inline array_tree metadata (no segment source needed).
+    #[test]
+    fn test_display_tree_inline_array_tree() {
+        block_on(|handle| async move {
+            let ctx = ArrayContext::empty();
+            let segments = Arc::new(TestSegments::default());
+
+            // Create nullable i64 array (2 buffers: data + validity)
+            let (ptr1, eof1) = SequenceId::root().split();
+            let mut validity_builder = BitBufferMut::with_capacity(5);
+            for b in [true, false, true, true, false] {
+                validity_builder.append(b);
+            }
+            let validity = Validity::Array(
+                BoolArray::from_bit_buffer(validity_builder.freeze(), Validity::NonNullable)
+                    .into_array(),
+            );
+            let array1 = PrimitiveArray::new(buffer![1i64, 2, 3, 4, 5], validity);
+            let layout1 = FlatLayoutStrategy::default()
+                .write_stream(
+                    ctx.clone(),
+                    segments.clone(),
+                    array1.to_array_stream().sequenced(ptr1),
+                    eof1,
+                    handle.clone(),
+                )
+                .await
+                .unwrap();
+
+            // Create utf8 array (2 buffers: views + data)
+            let (ptr2, eof2) = SequenceId::root().split();
+            let mut builder = VarBinViewBuilder::with_capacity(DType::Utf8(NonNullable), 5);
+            for s in [
+                "hello world this is long",
+                "another long string",
+                "short",
+                "medium str",
+                "x",
+            ] {
+                builder.append_value(s);
+            }
+            let layout2 = FlatLayoutStrategy::default()
+                .write_stream(
+                    ctx.clone(),
+                    segments.clone(),
+                    builder.finish().to_array_stream().sequenced(ptr2),
+                    eof2,
+                    handle.clone(),
+                )
+                .await
+                .unwrap();
+
+            // Create struct layout
+            let struct_layout = StructLayout::new(
+                5,
+                DType::Struct(
+                    StructFields::new(
+                        vec![FieldName::from("numbers"), FieldName::from("strings")].into(),
+                        vec![
+                            DType::Primitive(PType::I64, Nullability::Nullable),
+                            DType::Utf8(NonNullable),
+                        ],
+                    ),
+                    NonNullable,
+                ),
+                vec![
+                    ChunkedLayout::new(
+                        5,
+                        DType::Primitive(PType::I64, Nullability::Nullable),
+                        OwnedLayoutChildren::layout_children(vec![layout1]),
+                    )
+                    .into_layout(),
+                    layout2,
+                ],
+            )
+            .into_layout();
+
+            let output = format!("{}", struct_layout.display_tree_verbose(true));
+
+            let expected = "\
+vortex.struct, dtype: {numbers=i64?, strings=utf8}, children: 2, rows: 5
+├── numbers: vortex.chunked, dtype: i64?, children: 1, rows: 5
+│   └── [0]: vortex.flat, dtype: i64?, metadata: 171 bytes, rows: 5, segment 0, buffers=[40B, 1B], total=41B
+└── strings: vortex.flat, dtype: utf8, metadata: 110 bytes, rows: 5, segment 1, buffers=[43B, 80B], total=123B
+";
+            assert_eq!(output, expected);
+        })
+    }
+
+    /// Test display_tree_with_segments using async segment source to fetch buffer sizes.
+    #[test]
+    fn test_display_tree_with_segment_source() {
+        block_on(|handle| async move {
+            let ctx = ArrayContext::empty();
+            let segments = Arc::new(TestSegments::default());
+
+            // Create simple i32 array
+            let (ptr1, eof1) = SequenceId::root().split();
+            let array1 = PrimitiveArray::new(buffer![1i32, 2, 3, 4, 5], Validity::NonNullable);
+            let layout1 = FlatLayoutStrategy::default()
+                .write_stream(
+                    ctx.clone(),
+                    segments.clone(),
+                    array1.to_array_stream().sequenced(ptr1),
+                    eof1,
+                    handle.clone(),
+                )
+                .await
+                .unwrap();
+
+            // Create another i32 array
+            let (ptr2, eof2) = SequenceId::root().split();
+            let array2 = PrimitiveArray::new(buffer![6i32, 7, 8, 9, 10], Validity::NonNullable);
+            let layout2 = FlatLayoutStrategy::default()
+                .write_stream(
+                    ctx.clone(),
+                    segments.clone(),
+                    array2.to_array_stream().sequenced(ptr2),
+                    eof2,
+                    handle.clone(),
+                )
+                .await
+                .unwrap();
+
+            // Create chunked layout
+            let chunked_layout = ChunkedLayout::new(
+                10,
+                DType::Primitive(PType::I32, NonNullable),
+                OwnedLayoutChildren::layout_children(vec![layout1, layout2]),
+            )
+            .into_layout();
+
+            let output = chunked_layout
+                .display_tree_with_segments(segments)
+                .await
+                .unwrap();
+
+            let expected = "\
+vortex.chunked, dtype: i32, children: 2, rows: 10
+├── [0]: vortex.flat, dtype: i32, metadata: 98 bytes, rows: 5, segment 0, buffers=[20B], total=20B
+└── [1]: vortex.flat, dtype: i32, metadata: 98 bytes, rows: 5, segment 1, buffers=[20B], total=20B
+";
+            assert_eq!(format!("{}", output), expected);
+        })
+    }
+
+    /// Test display_array_tree with inline array node metadata.
+    #[test]
+    fn test_display_array_tree_with_inline_node() {
+        // Set the env var to enable inlined array node
+        // SAFETY: This test is single-threaded and we're only setting an env var
+        unsafe {
+            std::env::set_var("FLAT_LAYOUT_INLINE_ARRAY_NODE", "1");
+        }
+
+        block_on(|handle| async {
+            let ctx = ArrayContext::empty();
+            let segments = Arc::new(TestSegments::default());
+            let (ptr, eof) = SequenceId::root().split();
+
+            // Create a simple primitive array
+            let array = PrimitiveArray::new(buffer![1i32, 2, 3, 4, 5], Validity::AllValid);
+
+            let layout = FlatLayoutStrategy::default()
+                .write_stream(
+                    ctx.clone(),
+                    segments.clone(),
+                    array.to_array_stream().sequenced(ptr),
+                    eof,
+                    handle,
+                )
+                .await
+                .unwrap();
+
+            // Downcast to FlatLayout to access the array_tree
+            use vortex_array::serde::ArrayParts;
+
+            use crate::layouts::flat::FlatVTable;
+
+            let flat_layout = layout.as_::<FlatVTable>();
+
+            // Verify that array_tree is populated when FLAT_LAYOUT_INLINE_ARRAY_NODE is set
+            let array_tree = flat_layout
+                .array_tree()
+                .expect("array_tree should be populated when FLAT_LAYOUT_INLINE_ARRAY_NODE is set");
+
+            // Verify from_array_tree works on the inline metadata
+            let parts = ArrayParts::from_array_tree(array_tree.as_ref().to_vec())
+                .expect("should parse array_tree");
+            assert_eq!(parts.buffer_lengths(), vec![20]); // 5 i32 values = 20 bytes
+
+            // Test display_array_tree exact output
+            let array_tree_display = flat_layout.display_array_tree();
+            assert_eq!(
+                format!("{}", array_tree_display),
+                "ArrayTree(vortex.primitive, buffers=[20B])"
+            );
+
+            // Test display_tree exact output
+            assert_eq!(
+                format!("{}", layout.display_tree()),
+                "vortex.flat, dtype: i32?, segment 0, buffers=[20B], total=20B\n"
+            );
+        })
+    }
+
+    /// Test display_tree without inline array node (shows segment ID).
+    #[test]
+    fn test_display_tree_without_inline_node() {
+        block_on(|handle| async {
+            let ctx = ArrayContext::empty();
+            let segments = Arc::new(TestSegments::default());
+            let (ptr, eof) = SequenceId::root().split();
+
+            // Create a simple primitive array
+            let array = PrimitiveArray::new(buffer![10i64, 20, 30], Validity::NonNullable);
+
+            let layout = FlatLayoutStrategy::default()
+                .write_stream(
+                    ctx,
+                    segments.clone(),
+                    array.to_array_stream().sequenced(ptr),
+                    eof,
+                    handle,
+                )
+                .await
+                .unwrap();
+
+            // Test display_tree exact output (with inline array_tree enabled by env var from other test)
+            assert_eq!(
+                format!("{}", layout.display_tree()),
+                "vortex.flat, dtype: i64, segment 0, buffers=[24B], total=24B\n"
+            );
+        })
     }
 }

--- a/vortex-layout/src/display.rs
+++ b/vortex-layout/src/display.rs
@@ -229,6 +229,7 @@ mod tests {
     use vortex_dtype::PType;
     use vortex_dtype::StructFields;
     use vortex_io::runtime::single::block_on;
+    use vortex_utils::env::EnvVarGuard;
 
     use crate::IntoLayout;
     use crate::OwnedLayoutChildren;
@@ -244,6 +245,7 @@ mod tests {
     /// Test display_tree with inline array_tree metadata (no segment source needed).
     #[test]
     fn test_display_tree_inline_array_tree() {
+        let _guard = EnvVarGuard::set("FLAT_LAYOUT_INLINE_ARRAY_NODE", "1");
         block_on(|handle| async move {
             let ctx = ArrayContext::empty();
             let segments = Arc::new(TestSegments::default());
@@ -333,6 +335,8 @@ vortex.struct, dtype: {numbers=i64?, strings=utf8}, children: 2, rows: 5
     /// Test display_tree_with_segments using async segment source to fetch buffer sizes.
     #[test]
     fn test_display_tree_with_segment_source() {
+        // Ensure inline array node is disabled for this test
+        let _guard = EnvVarGuard::remove("FLAT_LAYOUT_INLINE_ARRAY_NODE");
         block_on(|handle| async move {
             let ctx = ArrayContext::empty();
             let segments = Arc::new(TestSegments::default());
@@ -380,31 +384,26 @@ vortex.struct, dtype: {numbers=i64?, strings=utf8}, children: 2, rows: 5
 
             let expected = "\
 vortex.chunked, dtype: i32, children: 2, rows: 10
-├── [0]: vortex.flat, dtype: i32, metadata: 98 bytes, rows: 5, segment 0, buffers=[20B], total=20B
-└── [1]: vortex.flat, dtype: i32, metadata: 98 bytes, rows: 5, segment 1, buffers=[20B], total=20B
+├── [0]: vortex.flat, dtype: i32, rows: 5, segment 0, buffers=[20B], total=20B
+└── [1]: vortex.flat, dtype: i32, rows: 5, segment 1, buffers=[20B], total=20B
 ";
-            assert_eq!(format!("{}", output), expected);
+            assert_eq!(output.to_string(), expected);
         })
     }
 
     /// Test display_array_tree with inline array node metadata.
     #[test]
     fn test_display_array_tree_with_inline_node() {
-        // Set the env var to enable inlined array node
-        // SAFETY: This test is single-threaded and we're only setting an env var
-        unsafe {
-            std::env::set_var("FLAT_LAYOUT_INLINE_ARRAY_NODE", "1");
-        }
+        let _guard = EnvVarGuard::set("FLAT_LAYOUT_INLINE_ARRAY_NODE", "1");
 
-        block_on(|handle| async {
-            let ctx = ArrayContext::empty();
-            let segments = Arc::new(TestSegments::default());
-            let (ptr, eof) = SequenceId::root().split();
+        let ctx = ArrayContext::empty();
+        let segments = Arc::new(TestSegments::default());
+        let (ptr, eof) = SequenceId::root().split();
 
-            // Create a simple primitive array
-            let array = PrimitiveArray::new(buffer![1i32, 2, 3, 4, 5], Validity::AllValid);
-
-            let layout = FlatLayoutStrategy::default()
+        // Create a simple primitive array
+        let array = PrimitiveArray::new(buffer![1i32, 2, 3, 4, 5], Validity::AllValid);
+        let layout = block_on(|handle| async {
+            FlatLayoutStrategy::default()
                 .write_stream(
                     ctx.clone(),
                     segments.clone(),
@@ -413,39 +412,40 @@ vortex.chunked, dtype: i32, children: 2, rows: 10
                     handle,
                 )
                 .await
-                .unwrap();
+                .unwrap()
+        });
 
-            let flat_layout = layout.as_::<FlatVTable>();
+        let flat_layout = layout.as_::<FlatVTable>();
 
-            let array_tree = flat_layout
-                .array_tree()
-                .expect("array_tree should be populated when FLAT_LAYOUT_INLINE_ARRAY_NODE is set");
+        let array_tree = flat_layout
+            .array_tree()
+            .expect("array_tree should be populated when FLAT_LAYOUT_INLINE_ARRAY_NODE is set");
 
-            let parts = ArrayParts::from_array_tree(array_tree.as_ref().to_vec())
-                .expect("should parse array_tree");
-            assert_eq!(parts.buffer_lengths(), vec![20]); // 5 i32 values = 20 bytes
+        let parts = ArrayParts::from_array_tree(array_tree.as_ref().to_vec())
+            .expect("should parse array_tree");
+        assert_eq!(parts.buffer_lengths(), vec![20]); // 5 i32 values = 20 bytes
 
-            assert_eq!(
-                layout.display_tree().to_string(),
-                "\
+        assert_eq!(
+            layout.display_tree().to_string(),
+            "\
 vortex.flat, dtype: i32?, segment 0, buffers=[20B], total=20B
 "
-            );
-        })
+        );
     }
 
     /// Test display_tree without inline array node (shows segment ID).
     #[test]
     fn test_display_tree_without_inline_node() {
-        block_on(|handle| async {
-            let ctx = ArrayContext::empty();
-            let segments = Arc::new(TestSegments::default());
-            let (ptr, eof) = SequenceId::root().split();
+        let _guard = EnvVarGuard::set("FLAT_LAYOUT_INLINE_ARRAY_NODE", "1");
 
-            // Create a simple primitive array
-            let array = PrimitiveArray::new(buffer![10i64, 20, 30], Validity::NonNullable);
+        let ctx = ArrayContext::empty();
+        let segments = Arc::new(TestSegments::default());
+        let (ptr, eof) = SequenceId::root().split();
 
-            let layout = FlatLayoutStrategy::default()
+        // Create a simple primitive array
+        let array = PrimitiveArray::new(buffer![10i64, 20, 30], Validity::NonNullable);
+        let layout = block_on(|handle| async {
+            FlatLayoutStrategy::default()
                 .write_stream(
                     ctx,
                     segments.clone(),
@@ -454,15 +454,15 @@ vortex.flat, dtype: i32?, segment 0, buffers=[20B], total=20B
                     handle,
                 )
                 .await
-                .unwrap();
+                .unwrap()
+        });
 
-            // Test display_tree exact output (with inline array_tree enabled by env var from other test)
-            assert_eq!(
-                layout.display_tree().to_string(),
-                "\
+        // Test display_tree exact output (with inline array_tree enabled by env var from other test)
+        assert_eq!(
+            layout.display_tree().to_string(),
+            "\
 vortex.flat, dtype: i64, segment 0, buffers=[24B], total=24B
 "
-            );
-        })
+        );
     }
 }

--- a/vortex-layout/src/display.rs
+++ b/vortex-layout/src/display.rs
@@ -218,6 +218,7 @@ mod tests {
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::builders::ArrayBuilder;
     use vortex_array::builders::VarBinViewBuilder;
+    use vortex_array::serde::ArrayParts;
     use vortex_array::validity::Validity;
     use vortex_buffer::BitBufferMut;
     use vortex_buffer::buffer;
@@ -232,6 +233,7 @@ mod tests {
     use crate::IntoLayout;
     use crate::OwnedLayoutChildren;
     use crate::layouts::chunked::ChunkedLayout;
+    use crate::layouts::flat::FlatVTable;
     use crate::layouts::flat::writer::FlatLayoutStrategy;
     use crate::layouts::struct_::StructLayout;
     use crate::segments::TestSegments;
@@ -413,34 +415,21 @@ vortex.chunked, dtype: i32, children: 2, rows: 10
                 .await
                 .unwrap();
 
-            // Downcast to FlatLayout to access the array_tree
-            use vortex_array::serde::ArrayParts;
-
-            use crate::layouts::flat::FlatVTable;
-
             let flat_layout = layout.as_::<FlatVTable>();
 
-            // Verify that array_tree is populated when FLAT_LAYOUT_INLINE_ARRAY_NODE is set
             let array_tree = flat_layout
                 .array_tree()
                 .expect("array_tree should be populated when FLAT_LAYOUT_INLINE_ARRAY_NODE is set");
 
-            // Verify from_array_tree works on the inline metadata
             let parts = ArrayParts::from_array_tree(array_tree.as_ref().to_vec())
                 .expect("should parse array_tree");
             assert_eq!(parts.buffer_lengths(), vec![20]); // 5 i32 values = 20 bytes
 
-            // Test display_array_tree exact output
-            let array_tree_display = flat_layout.display_array_tree();
             assert_eq!(
-                format!("{}", array_tree_display),
-                "ArrayTree(vortex.primitive, buffers=[20B])"
-            );
-
-            // Test display_tree exact output
-            assert_eq!(
-                format!("{}", layout.display_tree()),
-                "vortex.flat, dtype: i32?, segment 0, buffers=[20B], total=20B\n"
+                layout.display_tree().to_string(),
+                "\
+vortex.flat, dtype: i32?, segment 0, buffers=[20B], total=20B
+"
             );
         })
     }
@@ -469,8 +458,10 @@ vortex.chunked, dtype: i32, children: 2, rows: 10
 
             // Test display_tree exact output (with inline array_tree enabled by env var from other test)
             assert_eq!(
-                format!("{}", layout.display_tree()),
-                "vortex.flat, dtype: i64, segment 0, buffers=[24B], total=24B\n"
+                layout.display_tree().to_string(),
+                "\
+vortex.flat, dtype: i64, segment 0, buffers=[24B], total=24B
+"
             );
         })
     }

--- a/vortex-layout/src/display.rs
+++ b/vortex-layout/src/display.rs
@@ -28,6 +28,7 @@ pub(super) async fn display_tree_with_segment_sizes(
     // First, collect all segment IDs from the layout tree (excluding those with inline array_tree)
     let mut segments_to_fetch = Vec::new();
     collect_segments_to_fetch(&layout, &mut segments_to_fetch)?;
+    segments_to_fetch.dedup();
 
     // Fetch segments in parallel and parse buffer info
     let fetch_futures = segments_to_fetch.iter().map(|&segment_id| {
@@ -335,12 +336,11 @@ vortex.struct, dtype: {numbers=i64?, strings=utf8}, children: 2, rows: 5
     /// Test display_tree_with_segments using async segment source to fetch buffer sizes.
     #[test]
     fn test_display_tree_with_segment_source() {
+        // Ensure inline array node is disabled for this test
         let _guard = EnvVarGuard::remove("FLAT_LAYOUT_INLINE_ARRAY_NODE");
-        println!("{:?}", std::env::var("FLAT_LAYOUT_INLINE_ARRAY_NODE"));
         block_on(|handle| async move {
             let ctx = ArrayContext::empty();
             let segments = Arc::new(TestSegments::default());
-            println!("{:?}", std::env::var("FLAT_LAYOUT_INLINE_ARRAY_NODE"));
 
             // Create simple i32 array
             let (ptr1, eof1) = SequenceId::root().split();
@@ -382,7 +382,6 @@ vortex.struct, dtype: {numbers=i64?, strings=utf8}, children: 2, rows: 5
                 .display_tree_with_segments(segments)
                 .await
                 .unwrap();
-            println!("{:?}", std::env::var("FLAT_LAYOUT_INLINE_ARRAY_NODE"));
 
             let expected = "\
 vortex.chunked, dtype: i32, children: 2, rows: 10

--- a/vortex-layout/src/layout.rs
+++ b/vortex-layout/src/layout.rs
@@ -3,6 +3,7 @@
 
 use std::any::Any;
 use std::fmt::Debug;
+use std::fmt::Display;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
@@ -21,6 +22,7 @@ use crate::LayoutEncodingRef;
 use crate::LayoutReaderRef;
 use crate::VTable;
 use crate::display::DisplayLayoutTree;
+use crate::display::display_tree_with_segment_sizes;
 use crate::segments::SegmentId;
 use crate::segments::SegmentSource;
 
@@ -212,6 +214,48 @@ impl dyn Layout + '_ {
     /// Display the layout as a tree structure with optional verbose metadata.
     pub fn display_tree_verbose(&self, verbose: bool) -> DisplayLayoutTree {
         DisplayLayoutTree::new(self.to_layout(), verbose)
+    }
+
+    /// Display the layout as a tree structure, fetching segment buffer sizes from the segment source.
+    ///
+    /// # Warning
+    ///
+    /// This function performs IO to fetch each segment's buffer. For layouts with
+    /// many segments, this may result in significant IO overhead.
+    pub async fn display_tree_with_segments(
+        &self,
+        segment_source: Arc<dyn SegmentSource>,
+    ) -> VortexResult<DisplayLayoutTree> {
+        display_tree_with_segment_sizes(self.to_layout(), segment_source).await
+    }
+}
+
+/// Display the encoding, dtype, row count, and segment IDs of this layout.
+impl Display for dyn Layout + '_ {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let segment_ids = self.segment_ids();
+        if segment_ids.is_empty() {
+            write!(
+                f,
+                "{}({}, rows={})",
+                self.encoding_id(),
+                self.dtype(),
+                self.row_count()
+            )
+        } else {
+            write!(
+                f,
+                "{}({}, rows={}, segments=[{}])",
+                self.encoding_id(),
+                self.dtype(),
+                self.row_count(),
+                segment_ids
+                    .iter()
+                    .map(|s| format!("{}", **s))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        }
     }
 }
 
@@ -440,5 +484,119 @@ mod tests {
             assert_eq!(field.name(), field_name);
             assert_eq!(field.row_offset(), Some(0));
         }
+    }
+
+    #[test]
+    fn test_struct_layout_display() {
+        use vortex_array::ArrayContext;
+        use vortex_dtype::Nullability::NonNullable;
+        use vortex_dtype::PType;
+        use vortex_dtype::StructFields;
+
+        use crate::IntoLayout;
+        use crate::layouts::chunked::ChunkedLayout;
+        use crate::layouts::dict::DictLayout;
+        use crate::layouts::flat::FlatLayout;
+        use crate::layouts::struct_::StructLayout;
+        use crate::segments::SegmentId;
+
+        let ctx = ArrayContext::empty();
+
+        // Create a flat layout for dict values (utf8 strings)
+        let dict_values =
+            FlatLayout::new(3, DType::Utf8(NonNullable), SegmentId::from(0), ctx.clone())
+                .into_layout();
+
+        // Test flat layout display shows segment
+        assert_eq!(
+            format!("{}", dict_values),
+            "vortex.flat(utf8, rows=3, segments=[0])"
+        );
+
+        // Create a flat layout for dict codes
+        let dict_codes = FlatLayout::new(
+            10,
+            DType::Primitive(PType::U16, NonNullable),
+            SegmentId::from(1),
+            ctx.clone(),
+        )
+        .into_layout();
+
+        // Test flat layout display shows segment
+        assert_eq!(
+            format!("{}", dict_codes),
+            "vortex.flat(u16, rows=10, segments=[1])"
+        );
+
+        // Create dict layout (column "name")
+        let dict_layout = DictLayout::new(dict_values.clone(), dict_codes.clone()).into_layout();
+
+        // Test dict layout display (no direct segments)
+        assert_eq!(format!("{}", dict_layout), "vortex.dict(utf8, rows=10)");
+
+        // Create flat layouts for chunks
+        let chunk1 = FlatLayout::new(
+            5,
+            DType::Primitive(PType::I64, NonNullable),
+            SegmentId::from(2),
+            ctx.clone(),
+        )
+        .into_layout();
+
+        let chunk2 = FlatLayout::new(
+            5,
+            DType::Primitive(PType::I64, NonNullable),
+            SegmentId::from(3),
+            ctx,
+        )
+        .into_layout();
+
+        // Create chunked layout (column "value")
+        let chunked_layout = ChunkedLayout::new(
+            10,
+            DType::Primitive(PType::I64, NonNullable),
+            crate::OwnedLayoutChildren::layout_children(vec![chunk1.clone(), chunk2.clone()]),
+        )
+        .into_layout();
+
+        // Test chunked layout display (no direct segments)
+        assert_eq!(
+            format!("{}", chunked_layout),
+            "vortex.chunked(i64, rows=10)"
+        );
+
+        // Test chunk displays show segments
+        assert_eq!(
+            format!("{}", chunk1),
+            "vortex.flat(i64, rows=5, segments=[2])"
+        );
+        assert_eq!(
+            format!("{}", chunk2),
+            "vortex.flat(i64, rows=5, segments=[3])"
+        );
+
+        // Create struct layout with two fields
+        let field_names: Vec<Arc<str>> = vec!["name".into(), "value".into()];
+        let struct_dtype = DType::Struct(
+            StructFields::new(
+                field_names.into(),
+                vec![
+                    DType::Utf8(NonNullable),
+                    DType::Primitive(PType::I64, NonNullable),
+                ],
+            ),
+            NonNullable,
+        );
+
+        let struct_layout =
+            StructLayout::new(10, struct_dtype, vec![dict_layout, chunked_layout]).into_layout();
+
+        println!("{}", struct_layout.display_tree_verbose(true));
+
+        // Test Display impl for struct (no direct segments)
+        assert_eq!(
+            format!("{}", struct_layout),
+            "vortex.struct({name=utf8, value=i64}, rows=10)"
+        );
     }
 }

--- a/vortex-layout/src/layouts/flat/mod.rs
+++ b/vortex-layout/src/layouts/flat/mod.rs
@@ -6,7 +6,6 @@ pub mod writer;
 
 use std::env;
 use std::sync::Arc;
-use std::sync::LazyLock;
 
 use vortex_array::ArrayContext;
 use vortex_array::DeserializeMetadata;
@@ -30,8 +29,11 @@ use crate::segments::SegmentId;
 use crate::segments::SegmentSource;
 use crate::vtable;
 
-static FLAT_LAYOUT_INLINE_ARRAY_NODE: LazyLock<bool> =
-    LazyLock::new(|| env::var("FLAT_LAYOUT_INLINE_ARRAY_NODE").is_ok());
+/// Check if inline array node is enabled.
+/// This checks the env var each time to allow tests to toggle the behavior.
+pub(super) fn flat_layout_inline_array_node() -> bool {
+    env::var("FLAT_LAYOUT_INLINE_ARRAY_NODE").is_ok()
+}
 
 vtable!(Flat);
 
@@ -183,65 +185,6 @@ impl FlatLayout {
     #[inline]
     pub fn array_tree(&self) -> Option<&ByteBuffer> {
         self.array_tree.as_ref()
-    }
-}
-
-/// Display wrapper for the array tree metadata stored in a FlatLayout.
-pub struct ArrayTreeDisplay {
-    array_tree: Option<ByteBuffer>,
-    segment_id: SegmentId,
-    ctx: ArrayContext,
-}
-
-impl std::fmt::Display for ArrayTreeDisplay {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        use flatbuffers::root;
-        use vortex_flatbuffers::FlatBuffer;
-        use vortex_flatbuffers::array as fba;
-
-        let Some(array_tree) = &self.array_tree else {
-            return write!(f, "segment {}", *self.segment_id);
-        };
-
-        let fb_buffer = FlatBuffer::align_from(array_tree.clone());
-        let Ok(fb_array) = root::<fba::Array>(fb_buffer.as_ref()) else {
-            return write!(f, "<invalid flatbuffer>");
-        };
-
-        let Some(fb_root) = fb_array.root() else {
-            return write!(f, "<missing root node>");
-        };
-
-        // Get the encoding name from context
-        let encoding_id = fb_root.encoding();
-        let encoding_name = self
-            .ctx
-            .lookup_encoding(encoding_id)
-            .map(|v| v.id().to_string())
-            .unwrap_or_else(|| format!("encoding#{}", encoding_id));
-
-        write!(f, "ArrayTree({}", encoding_name)?;
-
-        // Show children count
-        let nchildren = fb_root.children().map_or(0, |c| c.len());
-        if nchildren > 0 {
-            write!(f, ", children={}", nchildren)?;
-        }
-
-        // Show buffer info
-        if let Some(buffers) = fb_array.buffers() {
-            write!(f, ", buffers=[")?;
-            for (i, buf) in buffers.iter().enumerate() {
-                if i > 0 {
-                    write!(f, ", ")?;
-                }
-                write!(f, "{}B", buf.length())?;
-            }
-            write!(f, "]")?;
-        }
-
-        write!(f, ")")?;
-        Ok(())
     }
 }
 

--- a/vortex-layout/src/layouts/flat/mod.rs
+++ b/vortex-layout/src/layouts/flat/mod.rs
@@ -184,6 +184,78 @@ impl FlatLayout {
     pub fn array_tree(&self) -> Option<&ByteBuffer> {
         self.array_tree.as_ref()
     }
+
+    /// Returns a display-friendly representation of the array tree metadata.
+    ///
+    /// When `FLAT_LAYOUT_INLINE_ARRAY_NODE` is enabled, this parses the inlined flatbuffer
+    /// and displays information about the array encoding tree and buffer descriptors.
+    /// When the array tree is not inlined, displays the segment ID instead.
+    pub fn display_array_tree(&self) -> ArrayTreeDisplay {
+        ArrayTreeDisplay {
+            array_tree: self.array_tree.clone(),
+            segment_id: self.segment_id,
+            ctx: self.ctx.clone(),
+        }
+    }
+}
+
+/// Display wrapper for the array tree metadata stored in a FlatLayout.
+pub struct ArrayTreeDisplay {
+    array_tree: Option<ByteBuffer>,
+    segment_id: SegmentId,
+    ctx: ArrayContext,
+}
+
+impl std::fmt::Display for ArrayTreeDisplay {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use flatbuffers::root;
+        use vortex_flatbuffers::FlatBuffer;
+        use vortex_flatbuffers::array as fba;
+
+        let Some(array_tree) = &self.array_tree else {
+            return write!(f, "segment {}", *self.segment_id);
+        };
+
+        let fb_buffer = FlatBuffer::align_from(array_tree.clone());
+        let Ok(fb_array) = root::<fba::Array>(fb_buffer.as_ref()) else {
+            return write!(f, "<invalid flatbuffer>");
+        };
+
+        let Some(fb_root) = fb_array.root() else {
+            return write!(f, "<missing root node>");
+        };
+
+        // Get the encoding name from context
+        let encoding_id = fb_root.encoding();
+        let encoding_name = self
+            .ctx
+            .lookup_encoding(encoding_id)
+            .map(|v| v.id().to_string())
+            .unwrap_or_else(|| format!("encoding#{}", encoding_id));
+
+        write!(f, "ArrayTree({}", encoding_name)?;
+
+        // Show children count
+        let nchildren = fb_root.children().map_or(0, |c| c.len());
+        if nchildren > 0 {
+            write!(f, ", children={}", nchildren)?;
+        }
+
+        // Show buffer info
+        if let Some(buffers) = fb_array.buffers() {
+            write!(f, ", buffers=[")?;
+            for (i, buf) in buffers.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{}B", buf.length())?;
+            }
+            write!(f, "]")?;
+        }
+
+        write!(f, ")")?;
+        Ok(())
+    }
 }
 
 #[derive(prost::Message)]

--- a/vortex-layout/src/layouts/flat/mod.rs
+++ b/vortex-layout/src/layouts/flat/mod.rs
@@ -184,19 +184,6 @@ impl FlatLayout {
     pub fn array_tree(&self) -> Option<&ByteBuffer> {
         self.array_tree.as_ref()
     }
-
-    /// Returns a display-friendly representation of the array tree metadata.
-    ///
-    /// When `FLAT_LAYOUT_INLINE_ARRAY_NODE` is enabled, this parses the inlined flatbuffer
-    /// and displays information about the array encoding tree and buffer descriptors.
-    /// When the array tree is not inlined, displays the segment ID instead.
-    pub fn display_array_tree(&self) -> ArrayTreeDisplay {
-        ArrayTreeDisplay {
-            array_tree: self.array_tree.clone(),
-            segment_id: self.segment_id,
-            ctx: self.ctx.clone(),
-        }
-    }
 }
 
 /// Display wrapper for the array tree metadata stored in a FlatLayout.

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -262,6 +262,11 @@ mod test {
                 .await
                 .unwrap();
 
+            assert_eq!(
+                format!("{}", layout),
+                "vortex.flat(i32?, rows=5, segments=[0])"
+            );
+
             let result = layout
                 .new_reader("".into(), segments, &SESSION)
                 .unwrap()

--- a/vortex-layout/src/layouts/flat/writer.rs
+++ b/vortex-layout/src/layouts/flat/writer.rs
@@ -17,8 +17,8 @@ use vortex_io::runtime::Handle;
 use crate::IntoLayout;
 use crate::LayoutRef;
 use crate::LayoutStrategy;
-use crate::layouts::flat::FLAT_LAYOUT_INLINE_ARRAY_NODE;
 use crate::layouts::flat::FlatLayout;
+use crate::layouts::flat::flat_layout_inline_array_node;
 use crate::layouts::zoned::lower_bound;
 use crate::layouts::zoned::upper_bound;
 use crate::segments::SegmentSinkRef;
@@ -134,7 +134,7 @@ impl LayoutStrategy for FlatLayoutStrategy {
         // there is at least the flatbuffer and the length
         assert!(buffers.len() >= 2);
         let array_node =
-            (*FLAT_LAYOUT_INLINE_ARRAY_NODE).then(|| buffers[buffers.len() - 2].clone());
+            flat_layout_inline_array_node().then(|| buffers[buffers.len() - 2].clone());
         let segment_id = segment_sink.write(sequence_id, buffers).await?;
 
         let None = stream.next().await else {

--- a/vortex-tui/src/tree.rs
+++ b/vortex-tui/src/tree.rs
@@ -28,7 +28,7 @@ pub enum TreeMode {
     Layout {
         /// Path to the Vortex file
         file: PathBuf,
-        /// Show additional metadata information
+        /// Show additional metadata information including buffer sizes (requires fetching segments)
         #[arg(short, long)]
         verbose: bool,
     },
@@ -60,9 +60,19 @@ async fn exec_array_tree(file: &Path) -> VortexResult<()> {
 
 async fn exec_layout_tree(file: &Path, verbose: bool) -> VortexResult<()> {
     let vxf = SESSION.open_options().open(file).await?;
-    let footer = vxf.footer();
 
-    println!("{}", footer.layout().display_tree_verbose(verbose));
+    if verbose {
+        // In verbose mode, fetch segments to display buffer sizes
+        let output = vxf
+            .footer()
+            .layout()
+            .display_tree_with_segments(vxf.segment_source())
+            .await?;
+        println!("{}", output);
+    } else {
+        // In non-verbose mode, just display layout tree without fetching segments
+        println!("{}", vxf.footer().layout().display_tree());
+    }
 
     Ok(())
 }

--- a/vortex-utils/Cargo.toml
+++ b/vortex-utils/Cargo.toml
@@ -16,9 +16,12 @@ version = { workspace = true }
 [dependencies]
 dashmap = { workspace = true, optional = true }
 hashbrown = { workspace = true }
+parking_lot = { workspace = true, optional = true }
+vortex-error = { workspace = true }
 
 [lints]
 workspace = true
 
 [features]
 dyn-traits = []
+test-harness = ["dashmap", "parking_lot"]

--- a/vortex-utils/src/env.rs
+++ b/vortex-utils/src/env.rs
@@ -114,7 +114,6 @@ impl Drop for EnvVarGuard {
         unsafe {
             std::env::remove_var(self.key);
         }
-        // lock_guard is dropped here, releasing the mutex
     }
 }
 

--- a/vortex-utils/src/env.rs
+++ b/vortex-utils/src/env.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Environment variable utilities for testing.
+
+/// RAII guard to set/remove an environment variable for the duration of a scope.
+///
+/// Removes the variable when dropped, ensuring test isolation.
+///
+/// # Example
+///
+/// ```
+/// use vortex_utils::env::EnvVarGuard;
+///
+/// // Set an env var for the duration of this scope
+/// let _guard = EnvVarGuard::set("MY_TEST_VAR", "1");
+/// assert_eq!(std::env::var("MY_TEST_VAR").ok(), Some("1".to_string()));
+///
+/// // Or remove an env var
+/// let _guard2 = EnvVarGuard::remove("MY_TEST_VAR");
+/// assert!(std::env::var("MY_TEST_VAR").is_err());
+/// ```
+///
+/// # Safety
+///
+/// Environment variable modification is inherently unsafe in multi-threaded contexts.
+/// This guard is intended for use in tests that are run serially or where env var
+/// races are acceptable.
+pub struct EnvVarGuard(&'static str);
+
+impl EnvVarGuard {
+    /// Set an environment variable for the duration of this guard's lifetime.
+    pub fn set(key: &'static str, value: &str) -> Self {
+        // SAFETY: Tests are run serially or we accept env var race risk.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self(key)
+    }
+
+    /// Remove an environment variable for the duration of this guard's lifetime.
+    pub fn remove(key: &'static str) -> Self {
+        // SAFETY: Tests are run serially or we accept env var race risk.
+        unsafe {
+            std::env::remove_var(key);
+        }
+        Self(key)
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: See above.
+        unsafe {
+            std::env::remove_var(self.0);
+        }
+    }
+}

--- a/vortex-utils/src/env.rs
+++ b/vortex-utils/src/env.rs
@@ -3,9 +3,32 @@
 
 //! Environment variable utilities for testing.
 
+use dashmap::DashMap;
+use parking_lot::Mutex;
+use vortex_error::vortex_panic;
+
+/// Global registry of locks per environment variable key.
+///
+/// Each mutex is lazily created and leaked to get a 'static lifetime.
+/// This is acceptable for test utilities that live for the process duration.
+static ENV_LOCKS: std::sync::LazyLock<DashMap<&'static str, &'static Mutex<()>>> =
+    std::sync::LazyLock::new(DashMap::new);
+
+/// Get or create a static mutex for the given key.
+fn get_or_create_lock(key: &'static str) -> &'static Mutex<()> {
+    *ENV_LOCKS
+        .entry(key)
+        .or_insert_with(|| Box::leak(Box::new(Mutex::new(()))))
+}
+
 /// RAII guard to set/remove an environment variable for the duration of a scope.
 ///
 /// Removes the variable when dropped, ensuring test isolation.
+///
+/// This guard holds a mutex lock for the specific environment variable key,
+/// ensuring that only one guard can exist for a given key at a time. This
+/// prevents tests from accidentally having overlapping guards for the same
+/// env var.
 ///
 /// # Example
 ///
@@ -17,42 +40,159 @@
 /// assert_eq!(std::env::var("MY_TEST_VAR").ok(), Some("1".to_string()));
 ///
 /// // Or remove an env var
-/// let _guard2 = EnvVarGuard::remove("MY_TEST_VAR");
-/// assert!(std::env::var("MY_TEST_VAR").is_err());
+/// let _guard2 = EnvVarGuard::remove("OTHER_VAR");
+/// assert!(std::env::var("OTHER_VAR").is_err());
 /// ```
+///
+/// # Panics
+///
+/// Panics if a guard already exists for the same environment variable key
+/// (detected via mutex lock contention).
 ///
 /// # Safety
 ///
 /// Environment variable modification is inherently unsafe in multi-threaded contexts.
 /// This guard is intended for use in tests that are run serially or where env var
-/// races are acceptable.
-pub struct EnvVarGuard(&'static str);
+/// races are acceptable. The per-key locking ensures that the same env var isn't
+/// modified concurrently by multiple guards.
+pub struct EnvVarGuard {
+    key: &'static str,
+    /// We store this to ensure the mutex stays locked for our lifetime.
+    /// The () is just a dummy value - we only care about the lock.
+    #[allow(dead_code)]
+    lock_guard: parking_lot::MutexGuard<'static, ()>,
+}
+
+/// Timeout for waiting on an env var lock.
+const LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 impl EnvVarGuard {
+    /// Acquire the lock for this key, waiting up to 10 seconds.
+    ///
+    /// If another guard holds the lock, this will wait for it to be released.
+    /// If the lock isn't released within 10 seconds, this panics to avoid deadlocks.
+    fn acquire_lock(key: &'static str) -> parking_lot::MutexGuard<'static, ()> {
+        let mutex = get_or_create_lock(key);
+        match mutex.try_lock_for(LOCK_TIMEOUT) {
+            Some(guard) => guard,
+            None => vortex_panic!(
+                "EnvVarGuard: timed out after {LOCK_TIMEOUT:?} waiting for environment variable '{key}'. \
+                 This likely indicates a deadlock - ensure guards for the same key are properly scoped \
+                 taken in lexicographical order and dropped before acquiring a new one."
+            ),
+        }
+    }
+
     /// Set an environment variable for the duration of this guard's lifetime.
     pub fn set(key: &'static str, value: &str) -> Self {
-        // SAFETY: Tests are run serially or we accept env var race risk.
+        let lock_guard = Self::acquire_lock(key);
+
+        // SAFETY: We hold an exclusive lock for this key.
         unsafe {
             std::env::set_var(key, value);
         }
-        Self(key)
+
+        Self { key, lock_guard }
     }
 
     /// Remove an environment variable for the duration of this guard's lifetime.
     pub fn remove(key: &'static str) -> Self {
-        // SAFETY: Tests are run serially or we accept env var race risk.
+        let lock_guard = Self::acquire_lock(key);
+
+        // SAFETY: We hold an exclusive lock for this key.
         unsafe {
             std::env::remove_var(key);
         }
-        Self(key)
+
+        Self { key, lock_guard }
     }
 }
 
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
-        // SAFETY: See above.
+        // SAFETY: We hold an exclusive lock for this key.
         unsafe {
-            std::env::remove_var(self.0);
+            std::env::remove_var(self.key);
         }
+        // lock_guard is dropped here, releasing the mutex
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_set_and_remove() {
+        let key = "VORTEX_TEST_ENV_VAR_SET";
+
+        // Initially not set
+        assert!(std::env::var(key).is_err());
+
+        {
+            let _guard = EnvVarGuard::set(key, "test_value");
+            assert_eq!(std::env::var(key).unwrap(), "test_value");
+        }
+
+        // After guard drops, var is removed
+        assert!(std::env::var(key).is_err());
+    }
+
+    #[test]
+    fn test_remove() {
+        let key = "VORTEX_TEST_ENV_VAR_REMOVE";
+
+        // Set it first
+        unsafe {
+            std::env::set_var(key, "initial");
+        }
+
+        {
+            let _guard = EnvVarGuard::remove(key);
+            assert!(std::env::var(key).is_err());
+        }
+
+        // After guard drops, var is still removed
+        assert!(std::env::var(key).is_err());
+    }
+
+    /// Test that a second guard waits for the first to be released.
+    #[test]
+    fn test_second_guard_waits_for_first() {
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicBool;
+        use std::sync::atomic::Ordering;
+        use std::thread;
+        use std::time::Duration;
+
+        let key = "VORTEX_TEST_ENV_VAR_WAIT";
+        let second_acquired = Arc::new(AtomicBool::new(false));
+        let second_acquired_clone = second_acquired.clone();
+
+        // First guard in main thread
+        let _guard1 = EnvVarGuard::set(key, "first");
+        assert_eq!(std::env::var(key).unwrap(), "first");
+
+        // Spawn thread that will wait for the lock
+        let handle = thread::spawn(move || {
+            let _guard2 = EnvVarGuard::set(key, "second");
+            second_acquired_clone.store(true, Ordering::SeqCst);
+            assert_eq!(std::env::var(key).unwrap(), "second");
+        });
+
+        // Give the thread time to start waiting
+        thread::sleep(Duration::from_millis(50));
+
+        // Second guard should NOT have acquired yet (still waiting)
+        assert!(!second_acquired.load(Ordering::SeqCst));
+
+        // Drop the first guard - this should allow the second to proceed
+        drop(_guard1);
+
+        // Wait for second thread to complete
+        handle.join().unwrap();
+
+        // Now the second guard should have acquired and set the value
+        assert!(second_acquired.load(Ordering::SeqCst));
     }
 }

--- a/vortex-utils/src/lib.rs
+++ b/vortex-utils/src/lib.rs
@@ -9,3 +9,4 @@ pub mod aliases;
 pub mod debug_with;
 #[cfg(feature = "dyn-traits")]
 pub mod dyn_traits;
+pub mod env;

--- a/vortex-utils/src/lib.rs
+++ b/vortex-utils/src/lib.rs
@@ -9,4 +9,5 @@ pub mod aliases;
 pub mod debug_with;
 #[cfg(feature = "dyn-traits")]
 pub mod dyn_traits;
+#[cfg(feature = "test-harness")]
 pub mod env;


### PR DESCRIPTION
```
vortex.chunked, dtype: i32, children: 2, rows: 10
├── [0]: vortex.flat, dtype: i32, metadata: 98 bytes, rows: 5, segment 0, buffers=[20B], total=20B
└── [1]: vortex.flat, dtype: i32, metadata: 98 bytes, rows: 5, segment 1, buffers=[20B], total=20B
```