### PR TITLE
Feature: Implement `take` on more vectors + stubs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8453,6 +8453,8 @@ dependencies = [
  "arrow-schema",
  "codspeed-divan-compat",
  "half",
+ "itertools 0.14.0",
+ "log",
  "multiversion",
  "num-traits",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ jiff = "0.2.0"
 kanal = "0.1.1"
 lending-iterator = "0.1.7"
 libfuzzer-sys = "0.4"
-log = { version = "0.4" }
+log = { version = "0.4.21" }
 loom = { version = "0.7", features = ["checkpoint"] }
 memmap2 = "0.9.5"
 mimalloc = "0.1.42"

--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -159,5 +159,9 @@ harness = false
 name = "take_primitive"
 harness = false
 
+[[bench]]
+name = "take_struct"
+harness = false
+
 [package.metadata.cargo-machete]
 ignored = ["getrandom_v03"]

--- a/vortex-array/benches/take_struct.rs
+++ b/vortex-array/benches/take_struct.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+#![allow(clippy::unwrap_used)]
+
+use divan::Bencher;
+use rand::Rng;
+use rand::SeedableRng;
+use rand::distr::Uniform;
+use rand::rngs::StdRng;
+use vortex_array::IntoArray;
+use vortex_array::arrays::StructArray;
+use vortex_array::compute::take;
+use vortex_array::validity::Validity;
+use vortex_buffer::Buffer;
+use vortex_dtype::FieldNames;
+
+fn main() {
+    divan::main();
+}
+
+const ARRAY_SIZE: usize = 100_000;
+const TAKE_SIZE: usize = 1000;
+
+#[divan::bench]
+fn take_struct_simple(bencher: Bencher) {
+    let mut rng = StdRng::seed_from_u64(0);
+    let range = Uniform::new(0i64, 100_000_000).unwrap();
+
+    // Create single field for the struct
+    let field = (0..ARRAY_SIZE)
+        .map(|_| rng.sample(range))
+        .collect::<Buffer<i64>>()
+        .into_array();
+
+    let struct_array = StructArray::try_new(
+        FieldNames::from(["value"]),
+        vec![field],
+        ARRAY_SIZE,
+        Validity::NonNullable,
+    )
+    .unwrap();
+
+    let indices: Buffer<u64> = (0..TAKE_SIZE)
+        .map(|_| rng.random_range(0..ARRAY_SIZE) as u64)
+        .collect();
+    let indices_array = indices.into_array();
+
+    bencher
+        .with_inputs(|| (&struct_array, &indices_array))
+        .bench_refs(|(array, indices)| take(array.as_ref(), indices.as_ref()).unwrap());
+}
+
+#[divan::bench(args = [8])]
+fn take_struct_wide(bencher: Bencher, width: usize) {
+    let mut rng = StdRng::seed_from_u64(0);
+    let range = Uniform::new(0i64, 100_000_000).unwrap();
+
+    let fields: Vec<_> = (0..width)
+        .map(|_| {
+            (0..ARRAY_SIZE)
+                .map(|_| rng.sample(range))
+                .collect::<Buffer<i64>>()
+                .into_array()
+        })
+        .collect();
+
+    let field_names = FieldNames::from([
+        "field1", "field2", "field3", "field4", "field5", "field6", "field7", "field8",
+    ]);
+
+    let struct_array =
+        StructArray::try_new(field_names, fields, ARRAY_SIZE, Validity::NonNullable).unwrap();
+
+    let indices: Buffer<u64> = (0..TAKE_SIZE)
+        .map(|_| rng.random_range(0..ARRAY_SIZE) as u64)
+        .collect();
+    let indices_array = indices.into_array();
+
+    bencher
+        .with_inputs(|| (&struct_array, &indices_array))
+        .bench_refs(|(array, indices)| take(array.as_ref(), indices.as_ref()).unwrap());
+}
+
+#[divan::bench]
+fn take_struct_sequential_indices(bencher: Bencher) {
+    let mut rng = StdRng::seed_from_u64(0);
+    let range = Uniform::new(0i64, 100_000_000).unwrap();
+
+    // Create single field for the struct
+    let field = (0..ARRAY_SIZE)
+        .map(|_| rng.sample(range))
+        .collect::<Buffer<i64>>()
+        .into_array();
+
+    let struct_array = StructArray::try_new(
+        FieldNames::from(["value"]),
+        vec![field],
+        ARRAY_SIZE,
+        Validity::NonNullable,
+    )
+    .unwrap();
+
+    // Sequential indices for better cache performance
+    let indices: Buffer<u64> = (0..TAKE_SIZE as u64).collect();
+    let indices_array = indices.into_array();
+
+    bencher
+        .with_inputs(|| (&struct_array, &indices_array))
+        .bench_refs(|(array, indices)| take(array.as_ref(), indices.as_ref()).unwrap());
+}

--- a/vortex-compute/Cargo.toml
+++ b/vortex-compute/Cargo.toml
@@ -30,6 +30,8 @@ arrow-array = { workspace = true, optional = true }
 arrow-buffer = { workspace = true, optional = true }
 arrow-schema = { workspace = true, optional = true }
 half = { workspace = true }
+itertools = { workspace = true }
+log = { workspace = true }
 multiversion = { workspace = true }
 num-traits = { workspace = true }
 paste = { workspace = true }

--- a/vortex-compute/src/take/bit_buffer.rs
+++ b/vortex-compute/src/take/bit_buffer.rs
@@ -58,3 +58,29 @@ fn take_bool<I: UnsignedPType>(bools: &BitBuffer, indices: &[I]) -> BitBuffer {
         get_bit(buffer, offset + bool_idx)
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::take::Take;
+
+    #[test]
+    fn test_bit_buffer_take_small_and_large() {
+        use vortex_buffer::BitBuffer;
+
+        // Small buffer (uses take_byte_bool path).
+        let small: BitBuffer = [true, false, true, true, false, true, false, false]
+            .into_iter()
+            .collect();
+        let result = (&small).take(&[7u32, 0, 2, 5, 1][..]);
+
+        let values: Vec<bool> = (0..result.len()).map(|i| result.value(i)).collect();
+        assert_eq!(values, vec![false, true, true, true, false]);
+
+        // Large buffer (uses take_bool path, len > 4096).
+        let large: BitBuffer = (0..5000).map(|i| i % 3 == 0).collect();
+        let result = (&large).take(&[4999u32, 0, 1, 2, 3, 4998][..]);
+
+        let values: Vec<bool> = (0..result.len()).map(|i| result.value(i)).collect();
+        assert_eq!(values, vec![false, true, false, false, true, true]);
+    }
+}

--- a/vortex-compute/src/take/bit_buffer.rs
+++ b/vortex-compute/src/take/bit_buffer.rs
@@ -64,7 +64,7 @@ mod tests {
     use crate::take::Take;
 
     #[test]
-    fn test_bit_buffer_take_small_and_large() {
+    fn test_take_bit_buffer_take_small_and_large() {
         use vortex_buffer::BitBuffer;
 
         // Small buffer (uses take_byte_bool path).

--- a/vortex-compute/src/take/vector/binaryview.rs
+++ b/vortex-compute/src/take/vector/binaryview.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+// use std::ops::Deref;
+
+// use num_traits::AsPrimitive;
+// use vortex_buffer::Buffer;
+use vortex_dtype::UnsignedPType;
+use vortex_vector::VectorOps;
+// use vortex_vector::binaryview::BinaryView;
+use vortex_vector::binaryview::BinaryViewType;
+use vortex_vector::binaryview::BinaryViewVector;
+use vortex_vector::primitive::PVector;
+
+use crate::take::Take;
+
+impl<T: BinaryViewType, I: UnsignedPType> Take<PVector<I>> for &BinaryViewVector<T> {
+    type Output = BinaryViewVector<T>;
+
+    fn take(self, indices: &PVector<I>) -> BinaryViewVector<T> {
+        if indices.validity().all_true() {
+            self.take(indices.elements().as_slice())
+        } else {
+            take_nullable(self, indices)
+        }
+    }
+}
+
+impl<T: BinaryViewType, I: UnsignedPType> Take<[I]> for &BinaryViewVector<T> {
+    type Output = BinaryViewVector<T>;
+
+    fn take(self, _indices: &[I]) -> BinaryViewVector<T> {
+        todo!("TODO(connor): Implement `take` for `BinaryViewVector` and figure out rebuilding");
+
+        /*
+
+        let taken_views = take_views(self.views(), indices);
+        let taken_validity = self.validity().take(indices);
+
+        debug_assert_eq!(taken_views.len(), taken_validity.len());
+
+        // SAFETY: We called take on views and validity with the same indices, so the new components
+        // must have the same length. The views still point into the same buffers which we clone via
+        // Arc, so all view references remain valid.
+        unsafe {
+            BinaryViewVector::new_unchecked(taken_views, self.buffers().clone(), taken_validity)
+        }
+
+        */
+    }
+}
+
+fn take_nullable<T: BinaryViewType, I: UnsignedPType>(
+    _bvector: &BinaryViewVector<T>,
+    _indices: &PVector<I>,
+) -> BinaryViewVector<T> {
+    todo!("TODO(connor): Implement `take` for `BinaryViewVector` and figure out rebuilding");
+
+    /*
+
+    // We ignore nullability when taking the views since we can let the `Mask` implementation
+    // determine which elements are null.
+    let taken_views = take_views(bvector.views(), indices.elements().as_slice());
+    let taken_validity = bvector.validity().take(indices);
+
+    debug_assert_eq!(taken_views.len(), taken_validity.len());
+
+    // SAFETY: We used the same indices to take from both components, so they should still have the
+    // same length. The views still point into the same buffers which we clone via Arc, so all view
+    // references remain valid.
+    unsafe {
+        BinaryViewVector::new_unchecked(taken_views, bvector.buffers().clone(), taken_validity)
+    }
+
+    */
+}
+
+/*
+
+/// Takes views at the given indices.
+fn take_views<I: AsPrimitive<usize>>(
+    views: &Buffer<BinaryView>,
+    indices: &[I],
+) -> Buffer<BinaryView> {
+    let views_ref = views.deref();
+    Buffer::<BinaryView>::from_trusted_len_iter(indices.iter().map(|i| views_ref[(*i).as_()]))
+}
+
+*/

--- a/vortex-compute/src/take/vector/decimal.rs
+++ b/vortex-compute/src/take/vector/decimal.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::UnsignedPType;
+use vortex_vector::VectorOps;
+use vortex_vector::decimal::DecimalVector;
+use vortex_vector::match_each_dvector;
+use vortex_vector::primitive::PVector;
+
+use crate::take::Take;
+
+impl<I: UnsignedPType> Take<PVector<I>> for &DecimalVector {
+    type Output = DecimalVector;
+
+    fn take(self, indices: &PVector<I>) -> DecimalVector {
+        // If all the indices are valid, we can delegate to the slice indices implementation.
+        if indices.validity().all_true() {
+            return self.take(indices.elements().as_slice());
+        }
+
+        match_each_dvector!(self, |v| { v.take(indices).into() })
+    }
+}
+
+impl<I: UnsignedPType> Take<[I]> for &DecimalVector {
+    type Output = DecimalVector;
+
+    fn take(self, indices: &[I]) -> DecimalVector {
+        match_each_dvector!(self, |v| { v.take(indices).into() })
+    }
+}

--- a/vortex-compute/src/take/vector/dvector.rs
+++ b/vortex-compute/src/take/vector/dvector.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::NativeDecimalType;
+use vortex_dtype::UnsignedPType;
+use vortex_vector::VectorOps;
+use vortex_vector::decimal::DVector;
+use vortex_vector::primitive::PVector;
+
+use crate::take::Take;
+
+impl<D: NativeDecimalType, I: UnsignedPType> Take<PVector<I>> for &DVector<D> {
+    type Output = DVector<D>;
+
+    fn take(self, indices: &PVector<I>) -> DVector<D> {
+        if indices.validity().all_true() {
+            self.take(indices.elements().as_slice())
+        } else {
+            take_nullable(self, indices)
+        }
+    }
+}
+
+impl<D: NativeDecimalType, I: UnsignedPType> Take<[I]> for &DVector<D> {
+    type Output = DVector<D>;
+
+    fn take(self, _indices: &[I]) -> DVector<D> {
+        todo!("TODO(connor): Implement `take` for `DVector` and figure out trait bounds");
+
+        /*
+
+        let taken_elements = self.elements().take(indices);
+        let taken_validity = self.validity().take(indices);
+
+        debug_assert_eq!(taken_elements.len(), taken_validity.len());
+
+        // SAFETY: We called take on both components of the vector with the same indices, so the new
+        // components must have the same length. The elements are unchanged, so they must still be
+        // within the precision/scale bounds.
+        unsafe { DVector::new_unchecked(self.precision_scale(), taken_elements, taken_validity) }
+
+        */
+    }
+}
+
+fn take_nullable<D: NativeDecimalType, I: UnsignedPType>(
+    _dvector: &DVector<D>,
+    _indices: &PVector<I>,
+) -> DVector<D> {
+    todo!("TODO(connor): Implement `take` for `DVector` and figure out trait bounds");
+
+    /*
+
+    // We ignore nullability when taking the elements since we can let the `Mask` implementation
+    // determine which elements are null.
+    let taken_elements = dvector.elements().take(indices.elements().as_slice());
+    let taken_validity = dvector.validity().take(indices);
+
+    debug_assert_eq!(taken_elements.len(), taken_validity.len());
+
+    // SAFETY: We used the same indices to take from both components, so they should still have the
+    // same length. The elements are unchanged, so they must still be within the precision/scale
+    // bounds.
+    unsafe { DVector::new_unchecked(dvector.precision_scale(), taken_elements, taken_validity) }
+
+    */
+}

--- a/vortex-compute/src/take/vector/dvector.rs
+++ b/vortex-compute/src/take/vector/dvector.rs
@@ -24,11 +24,7 @@ impl<D: NativeDecimalType, I: UnsignedPType> Take<PVector<I>> for &DVector<D> {
 impl<D: NativeDecimalType, I: UnsignedPType> Take<[I]> for &DVector<D> {
     type Output = DVector<D>;
 
-    fn take(self, _indices: &[I]) -> DVector<D> {
-        todo!("TODO(connor): Implement `take` for `DVector` and figure out trait bounds");
-
-        /*
-
+    fn take(self, indices: &[I]) -> DVector<D> {
         let taken_elements = self.elements().take(indices);
         let taken_validity = self.validity().take(indices);
 
@@ -38,19 +34,13 @@ impl<D: NativeDecimalType, I: UnsignedPType> Take<[I]> for &DVector<D> {
         // components must have the same length. The elements are unchanged, so they must still be
         // within the precision/scale bounds.
         unsafe { DVector::new_unchecked(self.precision_scale(), taken_elements, taken_validity) }
-
-        */
     }
 }
 
 fn take_nullable<D: NativeDecimalType, I: UnsignedPType>(
-    _dvector: &DVector<D>,
-    _indices: &PVector<I>,
+    dvector: &DVector<D>,
+    indices: &PVector<I>,
 ) -> DVector<D> {
-    todo!("TODO(connor): Implement `take` for `DVector` and figure out trait bounds");
-
-    /*
-
     // We ignore nullability when taking the elements since we can let the `Mask` implementation
     // determine which elements are null.
     let taken_elements = dvector.elements().take(indices.elements().as_slice());
@@ -62,6 +52,4 @@ fn take_nullable<D: NativeDecimalType, I: UnsignedPType>(
     // same length. The elements are unchanged, so they must still be within the precision/scale
     // bounds.
     unsafe { DVector::new_unchecked(dvector.precision_scale(), taken_elements, taken_validity) }
-
-    */
 }

--- a/vortex-compute/src/take/vector/fixed_size_list.rs
+++ b/vortex-compute/src/take/vector/fixed_size_list.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::sync::Arc;
+
+use itertools::Either;
+use vortex_dtype::UnsignedPType;
+use vortex_vector::VectorOps;
+use vortex_vector::fixed_size_list::FixedSizeListVector;
+use vortex_vector::primitive::PVector;
+
+use crate::take::Take;
+
+impl<I: UnsignedPType> Take<PVector<I>> for &FixedSizeListVector {
+    type Output = FixedSizeListVector;
+
+    fn take(self, indices: &PVector<I>) -> FixedSizeListVector {
+        if indices.validity().all_true() {
+            self.take(indices.elements().as_slice())
+        } else {
+            take_nullable(self, indices)
+        }
+    }
+}
+
+impl<I: UnsignedPType> Take<[I]> for &FixedSizeListVector {
+    type Output = FixedSizeListVector;
+
+    fn take(self, indices: &[I]) -> FixedSizeListVector {
+        let list_size = self.list_size() as usize;
+        let taken_validity = self.validity().take(indices);
+
+        // If we are in the degenerate case (`list_size == 0`), then we just need to `take` on the
+        // validity (since there is no backing data).
+        if list_size == 0 {
+            debug_assert!(
+                self.elements().is_empty(),
+                "The elements of a degenerate `FixedSizeListVector` is somehow non-empty"
+            );
+
+            // SAFETY: `list_size` is 0 and elements array is empty, so the invariant is maintained.
+            return unsafe {
+                FixedSizeListVector::new_unchecked(
+                    self.elements().clone(),
+                    self.list_size(),
+                    taken_validity,
+                )
+            };
+        }
+
+        let element_indices = expand_indices(indices, self.list_size());
+        let taken_elements = self.elements().take(element_indices.as_slice());
+
+        debug_assert_eq!(taken_elements.len(), indices.len() * list_size);
+        debug_assert_eq!(taken_validity.len(), indices.len());
+
+        // SAFETY: We took elements at expanded indices and validity at list indices, maintaining
+        // the invariant that `elements.len() == validity.len() * list_size`.
+        unsafe {
+            FixedSizeListVector::new_unchecked(
+                Arc::new(taken_elements),
+                self.list_size(),
+                taken_validity,
+            )
+        }
+    }
+}
+
+fn take_nullable<I: UnsignedPType>(
+    fsl: &FixedSizeListVector,
+    indices: &PVector<I>,
+) -> FixedSizeListVector {
+    let list_size = fsl.list_size() as usize;
+    let taken_validity = fsl.validity().take(indices);
+
+    // If we are in the degenerate case (`list_size == 0`), then we just need to `take` on the
+    // validity (since there is no backing data).
+    if list_size == 0 {
+        debug_assert!(
+            fsl.elements().is_empty(),
+            "The elements of a degenerate `FixedSizeListVector` is somehow non-empty"
+        );
+
+        // SAFETY: `list_size` is 0 and elements array is empty, so the invariant is maintained.
+        return unsafe {
+            FixedSizeListVector::new_unchecked(
+                fsl.elements().clone(),
+                fsl.list_size(),
+                taken_validity,
+            )
+        };
+    }
+
+    let expanded_nullable_indices = expand_nullable_indices(indices, list_size);
+    let taken_elements = fsl.elements().take(expanded_nullable_indices.as_slice());
+
+    debug_assert_eq!(taken_elements.len(), indices.len() * list_size);
+    debug_assert_eq!(taken_validity.len(), indices.len());
+
+    // SAFETY: We took elements at expanded indices and validity at list indices, maintaining the
+    // invariant that `elements.len() == validity.len() * list_size`.
+    unsafe {
+        FixedSizeListVector::new_unchecked(
+            Arc::new(taken_elements),
+            fsl.list_size(),
+            taken_validity,
+        )
+    }
+}
+
+// TODO(connor): Ideally we match on the pointe width and return either a `Vec<u64>` or `Vec<u32>`
+// (feature gated by `#[cfg(target_pointer_width = "64")]`), but that is probably overkill.
+/// "Expands" the given indices by constructing new indices where for each list index `i`, we fill
+/// add indices `[i*list_size..(i+1)*list_size]`.
+///
+/// The resulting indices vector will have length `indices.len() * list_size`.
+fn expand_indices<I: UnsignedPType>(indices: &[I], list_size: u32) -> Vec<u64> {
+    let list_size_u64 = list_size as u64;
+
+    // Expand list indices to element indices.
+    let expanded_indices: Vec<u64> = indices
+        .iter()
+        .flat_map(|idx| {
+            let list_idx = (*idx).as_() as u64;
+            let start = list_idx * list_size_u64;
+            let end = (list_idx + 1) * list_size_u64;
+            start..end
+        })
+        .collect();
+
+    debug_assert_eq!(indices.len() * list_size as usize, expanded_indices.len());
+    expanded_indices
+}
+
+// TODO(connor): Ideally we match on the pointe width and return either a `Vec<u64>` or `Vec<u32>`
+// (feature gated by `#[cfg(target_pointer_width = "64")]`), but that is probably overkill.
+/// "Expands" the given indices by constructing new indices where for each list index `i`, we fill
+/// add indices `[i*list_size..(i+1)*list_size]`.
+///
+/// The resulting indices vector will have length `indices.len() * list_size`.
+///
+/// For null indices that we need to expand, we use index 0 as a placeholder for all of them since
+/// the validity will mask them out anyway.
+fn expand_nullable_indices<I: UnsignedPType>(indices: &PVector<I>, list_size: usize) -> Vec<u64> {
+    let indices_validity = indices.validity();
+    let list_size_u64 = list_size as u64;
+
+    indices_validity.iter_bools(|validity_iter| {
+        let expanded_indices: Vec<u64> = indices
+            .elements()
+            .iter()
+            .zip(validity_iter)
+            .flat_map(|(idx, is_valid)| {
+                if is_valid {
+                    let list_idx = (*idx).as_() as u64;
+                    let start = list_idx * list_size_u64;
+                    let end = (list_idx + 1) * list_size_u64;
+                    Either::Left(start..end)
+                } else {
+                    Either::Right(std::iter::repeat_n(0u64, list_size))
+                }
+            })
+            .collect();
+
+        debug_assert_eq!(indices.len() * list_size, expanded_indices.len());
+        expanded_indices
+    })
+}

--- a/vortex-compute/src/take/vector/listview.rs
+++ b/vortex-compute/src/take/vector/listview.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::UnsignedPType;
+use vortex_vector::VectorOps;
+use vortex_vector::listview::ListViewVector;
+use vortex_vector::primitive::PVector;
+
+use crate::take::Take;
+
+impl<I: UnsignedPType> Take<PVector<I>> for &ListViewVector {
+    type Output = ListViewVector;
+
+    fn take(self, indices: &PVector<I>) -> ListViewVector {
+        if indices.validity().all_true() {
+            self.take(indices.elements().as_slice())
+        } else {
+            take_nullable(self, indices)
+        }
+    }
+}
+
+impl<I: UnsignedPType> Take<[I]> for &ListViewVector {
+    type Output = ListViewVector;
+
+    fn take(self, _indices: &[I]) -> ListViewVector {
+        todo!("TODO(connor): Implement `take` for `ListViewVector` and figure out rebuilding");
+
+        /*
+
+        let taken_offsets = self.offsets().take(indices);
+        let taken_sizes = self.sizes().take(indices);
+        let taken_validity = self.validity().take(indices);
+
+        debug_assert_eq!(taken_offsets.len(), taken_validity.len());
+        debug_assert_eq!(taken_sizes.len(), taken_validity.len());
+
+        // SAFETY: We called take on offsets, sizes, and validity with the same indices, so the new
+        // components must have the same length. The offsets and sizes still point into the same
+        // elements array which we clone via Arc, so all view references remain valid.
+        unsafe {
+            ListViewVector::new_unchecked(
+                self.elements().clone(),
+                taken_offsets,
+                taken_sizes,
+                taken_validity,
+            )
+        }
+
+        */
+    }
+}
+
+fn take_nullable<I: UnsignedPType>(
+    _lvector: &ListViewVector,
+    _indices: &PVector<I>,
+) -> ListViewVector {
+    todo!("TODO(connor): Implement `take` for `ListViewVector` and figure out rebuilding");
+
+    /*
+
+    // We ignore nullability when taking the offsets and sizes since we can let the `Mask`
+    // implementation determine which elements are null.
+    let taken_offsets = lvector.offsets().take(indices.elements().as_slice());
+    let taken_sizes = lvector.sizes().take(indices.elements().as_slice());
+    let taken_validity = lvector.validity().take(indices);
+
+    debug_assert_eq!(taken_offsets.len(), taken_validity.len());
+    debug_assert_eq!(taken_sizes.len(), taken_validity.len());
+
+    // SAFETY: We used the same indices to take from all components, so they should still have the
+    // same length. The offsets and sizes still point into the same elements array which we clone
+    // via Arc, so all view references remain valid.
+    unsafe {
+        ListViewVector::new_unchecked(
+            lvector.elements().clone(),
+            taken_offsets,
+            taken_sizes,
+            taken_validity,
+        )
+    }
+
+    */
+}

--- a/vortex-compute/src/take/vector/mod.rs
+++ b/vortex-compute/src/take/vector/mod.rs
@@ -1,18 +1,44 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_dtype::UnsignedPType;
+use vortex_vector::Vector;
 use vortex_vector::match_each_unsigned_pvector;
+use vortex_vector::match_each_vector;
 use vortex_vector::primitive::PVector;
 use vortex_vector::primitive::PrimitiveVector;
 
 use crate::take::Take;
 
+mod binaryview;
 mod bool;
+mod decimal;
+mod dvector;
+mod fixed_size_list;
+mod listview;
+mod null;
 mod primitive;
 mod pvector;
+mod struct_;
 
 #[cfg(test)]
 mod tests;
+
+impl<I: UnsignedPType> Take<PVector<I>> for &Vector {
+    type Output = Vector;
+
+    fn take(self, indices: &PVector<I>) -> Vector {
+        match_each_vector!(self, |v| { v.take(indices).into() })
+    }
+}
+
+impl<I: UnsignedPType> Take<[I]> for &Vector {
+    type Output = Vector;
+
+    fn take(self, indices: &[I]) -> Vector {
+        match_each_vector!(self, |v| { v.take(indices).into() })
+    }
+}
 
 impl<T> Take<PrimitiveVector> for &T
 where

--- a/vortex-compute/src/take/vector/null.rs
+++ b/vortex-compute/src/take/vector/null.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::UnsignedPType;
+use vortex_vector::VectorOps;
+use vortex_vector::null::NullVector;
+use vortex_vector::primitive::PVector;
+
+use crate::take::Take;
+
+impl<I: UnsignedPType> Take<PVector<I>> for &NullVector {
+    type Output = NullVector;
+
+    fn take(self, indices: &PVector<I>) -> NullVector {
+        // NullVector is always all-null, so the result is just a new NullVector with the same
+        // length as the indices. We don't need to check index validity since the result is all-null
+        // regardless.
+        NullVector::new(indices.len())
+    }
+}
+
+impl<I: UnsignedPType> Take<[I]> for &NullVector {
+    type Output = NullVector;
+
+    fn take(self, indices: &[I]) -> NullVector {
+        // NullVector is always all-null, so the result is just a new NullVector with the same
+        // length as the indices.
+        NullVector::new(indices.len())
+    }
+}

--- a/vortex-compute/src/take/vector/struct_.rs
+++ b/vortex-compute/src/take/vector/struct_.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::sync::Arc;
+
+use vortex_dtype::UnsignedPType;
+use vortex_vector::Vector;
+use vortex_vector::VectorOps;
+use vortex_vector::primitive::PVector;
+use vortex_vector::struct_::StructVector;
+
+use crate::take::Take;
+
+impl<I: UnsignedPType> Take<PVector<I>> for &StructVector {
+    type Output = StructVector;
+
+    fn take(self, indices: &PVector<I>) -> StructVector {
+        if indices.validity().all_true() {
+            self.take(indices.elements().as_slice())
+        } else {
+            take_nullable(self, indices)
+        }
+    }
+}
+
+impl<I: UnsignedPType> Take<[I]> for &StructVector {
+    type Output = StructVector;
+
+    fn take(self, indices: &[I]) -> StructVector {
+        let taken_fields: Box<[Vector]> = self
+            .fields()
+            .iter()
+            .map(|field| field.take(indices))
+            .collect();
+        let taken_validity = self.validity().take(indices);
+
+        // SAFETY: We called take on all fields and validity with the same indices, so all fields
+        // must have the same length as each other and as the validity.
+        unsafe { StructVector::new_unchecked(Arc::new(taken_fields), taken_validity) }
+    }
+}
+
+fn take_nullable<I: UnsignedPType>(svector: &StructVector, indices: &PVector<I>) -> StructVector {
+    // We ignore nullability when taking the fields since we can let the `Mask` implementation
+    // determine which elements are null.
+    let taken_fields: Box<[Vector]> = svector
+        .fields()
+        .iter()
+        .map(|field| field.take(indices.elements().as_slice()))
+        .collect();
+
+    // NB: This is the nullable version of `take`, so this is not the same as the `take`
+    // implementation `indices: &[I]` above.
+    let taken_validity = svector.validity().take(indices);
+
+    // SAFETY: We called take on all fields and validity with the same indices, so all fields must
+    // have the same length as each other and as the validity.
+    unsafe { StructVector::new_unchecked(Arc::new(taken_fields), taken_validity) }
+}

--- a/vortex-compute/src/take/vector/tests.rs
+++ b/vortex-compute/src/take/vector/tests.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_buffer::BitBuffer;
 use vortex_dtype::NativePType;
-use vortex_mask::Mask;
 use vortex_vector::VectorMutOps;
 use vortex_vector::VectorOps;
 use vortex_vector::bool::BoolVector;
@@ -84,64 +82,6 @@ fn test_bool_vector_take_with_primitive_vector_indices() {
 }
 
 #[test]
-fn test_bit_buffer_take_small_and_large() {
-    // Small buffer (uses take_byte_bool path).
-    let small: BitBuffer = [true, false, true, true, false, true, false, false]
-        .into_iter()
-        .collect();
-    let result = small.take(&[7u32, 0, 2, 5, 1][..]);
-
-    let values: Vec<bool> = result.iter().collect();
-    assert_eq!(values, vec![false, true, true, true, false]);
-
-    // Large buffer (uses take_bool path, len > 4096).
-    let large: BitBuffer = (0..5000).map(|i| i % 3 == 0).collect();
-    let result = large.take(&[4999u32, 0, 1, 2, 3, 4998][..]);
-
-    let values: Vec<bool> = result.iter().collect();
-    assert_eq!(values, vec![false, true, false, false, true, true]);
-}
-
-#[test]
-fn test_mask_take_all_variants() {
-    // AllTrue with slice indices.
-    let result = Mask::AllTrue(10).take(&[9u32, 0, 5][..]);
-    assert!(result.all_true());
-    assert_eq!(result.len(), 3);
-
-    // AllFalse with slice indices.
-    let result = Mask::AllFalse(10).take(&[9u32, 0, 5][..]);
-    assert!(result.all_false());
-    assert_eq!(result.len(), 3);
-
-    // Values with slice indices.
-    let values = Mask::from_iter([true, false, true, true, false, true]);
-    let result = values.take(&[5u32, 1, 0, 4][..]);
-    let bools: Vec<bool> = (0..result.len()).map(|i| result.value(i)).collect();
-    assert_eq!(bools, vec![true, false, true, false]);
-
-    // AllTrue with nullable PVector indices.
-    let indices: PVector<u32> =
-        PVectorMut::from_iter([Some(0), None, Some(5), None, Some(9)]).freeze();
-    let result = Mask::AllTrue(10).take(&indices);
-    let bools: Vec<bool> = (0..result.len()).map(|i| result.value(i)).collect();
-    assert_eq!(bools, vec![true, false, true, false, true]);
-
-    // AllFalse with nullable PVector indices.
-    let result = Mask::AllFalse(10).take(&indices);
-    assert!(result.all_false());
-    assert_eq!(result.len(), 5);
-
-    // Values with nullable PVector indices.
-    let values = Mask::from_iter([true, false, true, false, true, false]);
-    let indices: PVector<u32> =
-        PVectorMut::from_iter([Some(0), None, Some(1), Some(4), None]).freeze();
-    let result = values.take(&indices);
-    let bools: Vec<bool> = (0..result.len()).map(|i| result.value(i)).collect();
-    assert_eq!(bools, vec![true, false, false, true, false]);
-}
-
-#[test]
 fn test_primitive_vector_take_with_pvector_indices() {
     let data: PrimitiveVector =
         PVectorMut::from_iter([Some(10i32), Some(20), None, Some(40), Some(50)])
@@ -159,4 +99,204 @@ fn test_primitive_vector_take_with_pvector_indices() {
         collect_pvector(&result),
         vec![Some(50), None, None, Some(10), None]
     );
+}
+
+#[test]
+fn test_null_vector_take() {
+    use vortex_vector::VectorOps;
+    use vortex_vector::null::NullVector;
+
+    let data = NullVector::new(10);
+
+    // Take with slice indices.
+    let result = (&data).take(&[0u32, 5, 9, 2][..]);
+    assert_eq!(result.len(), 4);
+    assert!(result.validity().all_false());
+
+    // Take with nullable PVector indices.
+    let indices: PVector<u32> = PVectorMut::from_iter([Some(0), None, Some(5), None]).freeze();
+    let result = (&data).take(&indices);
+    assert_eq!(result.len(), 4);
+    assert!(result.validity().all_false());
+}
+
+#[ignore = "TODO(connor): Implement `DecimalVector::take`."]
+#[test]
+fn test_dvector_take() {
+    use vortex_buffer::buffer;
+    use vortex_dtype::PrecisionScale;
+    use vortex_mask::Mask;
+    use vortex_vector::VectorOps;
+    use vortex_vector::decimal::DVector;
+
+    let ps = PrecisionScale::<i64>::new(10, 2);
+    let data = DVector::new(
+        ps,
+        buffer![100i64, 200, 300, 400, 500],
+        Mask::from_iter([true, true, false, true, true]),
+    );
+
+    // Take with slice indices.
+    let result = (&data).take(&[4u32, 2, 0, 1][..]);
+    assert_eq!(result.elements().as_slice(), &[500i64, 300, 100, 200]);
+    let validity: Vec<bool> = (0..result.len())
+        .map(|i| result.validity().value(i))
+        .collect();
+    assert_eq!(validity, vec![true, false, true, true]);
+    assert_eq!(result.precision_scale(), ps);
+
+    // Take with nullable indices.
+    let indices: PVector<u32> = PVectorMut::from_iter([Some(0), None, Some(4), None]).freeze();
+    let result = (&data).take(&indices);
+    let validity: Vec<bool> = (0..result.len())
+        .map(|i| result.validity().value(i))
+        .collect();
+    assert_eq!(validity, vec![true, false, true, false]);
+}
+
+#[ignore = "TODO(connor): Implement `DecimalVector::take`."]
+#[test]
+fn test_decimal_vector_take() {
+    use vortex_buffer::buffer;
+    use vortex_dtype::PrecisionScale;
+    use vortex_mask::Mask;
+    use vortex_vector::decimal::DVector;
+    use vortex_vector::decimal::DecimalVector;
+
+    let ps = PrecisionScale::<i32>::new(5, 1);
+    let data: DecimalVector =
+        DVector::new(ps, buffer![10i32, 20, 30, 40, 50], Mask::new_true(5)).into();
+
+    let result = (&data).take(&[4u32, 0, 2][..]);
+
+    let DecimalVector::D32(result) = result else {
+        panic!("Expected D32 variant")
+    };
+    assert_eq!(result.elements().as_slice(), &[50i32, 10, 30]);
+}
+
+#[test]
+fn test_struct_vector_take() {
+    use std::sync::Arc;
+
+    use vortex_mask::Mask;
+    use vortex_vector::Vector;
+    use vortex_vector::VectorOps;
+    use vortex_vector::struct_::StructVector;
+
+    let field1: Vector =
+        PVectorMut::from_iter([Some(10i32), Some(20), Some(30), Some(40), Some(50)])
+            .freeze()
+            .into();
+    let field2: Vector =
+        BoolVectorMut::from_iter([Some(true), Some(false), Some(true), Some(false), Some(true)])
+            .freeze()
+            .into();
+    let data = StructVector::new(
+        Arc::new(vec![field1, field2].into()),
+        Mask::from_iter([true, true, false, true, true]),
+    );
+
+    // Take with slice indices.
+    let result = (&data).take(&[4u32, 2, 0][..]);
+    let validity: Vec<bool> = (0..result.len())
+        .map(|i| result.validity().value(i))
+        .collect();
+    assert_eq!(validity, vec![true, false, true]);
+
+    let Vector::Primitive(PrimitiveVector::I32(f0)) = &result.fields()[0] else {
+        panic!("Expected I32")
+    };
+    assert_eq!(f0.elements().as_slice(), &[50i32, 30, 10]);
+
+    // Take with nullable indices.
+    let indices: PVector<u32> = PVectorMut::from_iter([Some(0), None, Some(4)]).freeze();
+    let result = (&data).take(&indices);
+    let validity: Vec<bool> = (0..result.len())
+        .map(|i| result.validity().value(i))
+        .collect();
+    assert_eq!(validity, vec![true, false, true]);
+}
+
+#[test]
+fn test_fixed_size_list_vector_take() {
+    use std::sync::Arc;
+
+    use vortex_mask::Mask;
+    use vortex_vector::Vector;
+    use vortex_vector::VectorOps;
+    use vortex_vector::fixed_size_list::FixedSizeListVector;
+
+    // Elements: [1..12], grouped as 4 lists of size 3.
+    let elements: Vector = PVectorMut::from_iter((1..=12).map(Some)).freeze().into();
+    let data = FixedSizeListVector::new(
+        Arc::new(elements),
+        3,
+        Mask::from_iter([true, true, false, true]),
+    );
+
+    // Take lists [3, 1, 0] -> elements [10,11,12], [4,5,6], [1,2,3].
+    let result = (&data).take(&[3u32, 1, 0][..]);
+    assert_eq!(result.len(), 3);
+    assert_eq!(result.list_size(), 3);
+
+    let validity: Vec<bool> = (0..result.len())
+        .map(|i| result.validity().value(i))
+        .collect();
+    assert_eq!(validity, vec![true, true, true]);
+
+    let Vector::Primitive(PrimitiveVector::I32(elems)) = result.elements().as_ref() else {
+        panic!("Expected I32")
+    };
+    assert_eq!(elems.elements().as_slice(), &[10, 11, 12, 4, 5, 6, 1, 2, 3]);
+
+    // Take with nullable indices.
+    let indices: PVector<u32> = PVectorMut::from_iter([Some(2), None, Some(0)]).freeze();
+    let result = (&data).take(&indices);
+    let validity: Vec<bool> = (0..result.len())
+        .map(|i| result.validity().value(i))
+        .collect();
+    assert_eq!(validity, vec![false, false, true]);
+}
+
+#[test]
+fn test_fixed_size_list_vector_take_degenerate() {
+    use std::sync::Arc;
+
+    use vortex_mask::Mask;
+    use vortex_vector::Vector;
+    use vortex_vector::VectorOps;
+    use vortex_vector::fixed_size_list::FixedSizeListVector;
+
+    // Degenerate FSL with list_size=0.
+    let elements: Vector = PVectorMut::<i32>::from_iter(std::iter::empty::<Option<i32>>())
+        .freeze()
+        .into();
+    let data = FixedSizeListVector::new(Arc::new(elements), 0, Mask::new_true(5));
+
+    let result = (&data).take(&[4u32, 0, 2][..]);
+    assert_eq!(result.len(), 3);
+    assert_eq!(result.list_size(), 0);
+    assert!(result.elements().is_empty());
+}
+
+#[test]
+fn test_vector_enum_take() {
+    use vortex_vector::Vector;
+    use vortex_vector::VectorOps;
+
+    let data: Vector = PVectorMut::from_iter([Some(100i32), Some(200), None, Some(400), Some(500)])
+        .freeze()
+        .into();
+
+    let result = (&data).take(&[4u32, 2, 0][..]);
+
+    let Vector::Primitive(PrimitiveVector::I32(result)) = result else {
+        panic!("Expected I32")
+    };
+    assert_eq!(result.elements().as_slice(), &[500i32, 0, 100]);
+    let validity: Vec<bool> = (0..result.len())
+        .map(|i| result.validity().value(i))
+        .collect();
+    assert_eq!(validity, vec![true, false, true]);
 }


### PR DESCRIPTION
Tracking Issue: https://github.com/vortex-data/vortex/issues/5652

https://github.com/vortex-data/vortex/pull/5540 has to be merged first.

Implements `take` on the remaining vectors, except for `DecimalVector`, `BinaryViewVector`, and `ListViewVector`

For `DecimalVector` we cannot trivially reuse the existing `take` compute on slices and buffers because it has a bound of `NativePType`. We can relax this bound to `Copy` instead, but that will require some more work. Note that the current `DecimalArray` `take` implementation is fully scalar right now so we can definitely improve that in the new world.

For the view vectors I believe we want to think through how we "rebuild" those in the array plan (we probably want to place rebuild nodes at good places after just doing a `take` on the existing views).

So this PR implements:
- `FixedSizeListVector`
- `NullVector`
- `StructVector`

Edit: Now that https://github.com/vortex-data/vortex/pull/5666 has merged, this also implements `DecimalVector`.