### PR TITLE
Temp fix: Make `take` bound by `Copy` instead of `NativePType`

### DIFF
--- a/vortex-compute/src/take/buffer.rs
+++ b/vortex-compute/src/take/buffer.rs
@@ -2,12 +2,11 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_buffer::Buffer;
-use vortex_dtype::NativePType;
 use vortex_dtype::UnsignedPType;
 
 use crate::take::Take;
 
-impl<T: NativePType, I: UnsignedPType> Take<[I]> for &Buffer<T> {
+impl<T: Copy, I: UnsignedPType> Take<[I]> for &Buffer<T> {
     type Output = Buffer<T>;
 
     fn take(self, indices: &[I]) -> Buffer<T> {

--- a/vortex-compute/src/take/slice/mod.rs
+++ b/vortex-compute/src/take/slice/mod.rs
@@ -4,7 +4,6 @@
 //! Take function implementations on slices.
 
 use vortex_buffer::Buffer;
-use vortex_dtype::NativePType;
 use vortex_dtype::UnsignedPType;
 
 use crate::take::Take;
@@ -13,7 +12,7 @@ pub mod avx2;
 pub mod portable;
 
 /// Specialized implementation for non-nullable indices.
-impl<T: NativePType, I: UnsignedPType> Take<[I]> for &[T] {
+impl<T: Copy, I: UnsignedPType> Take<[I]> for &[T] {
     type Output = Buffer<T>;
 
     fn take(self, indices: &[I]) -> Buffer<T> {
@@ -40,6 +39,6 @@ impl<T: NativePType, I: UnsignedPType> Take<[I]> for &[T] {
     reason = "Compiler may see this as unused based on enabled features"
 )]
 #[inline]
-fn take_scalar<T: NativePType, I: UnsignedPType>(buffer: &[T], indices: &[I]) -> Buffer<T> {
+fn take_scalar<T: Copy, I: UnsignedPType>(buffer: &[T], indices: &[I]) -> Buffer<T> {
     indices.iter().map(|idx| buffer[idx.as_()]).collect()
 }

--- a/vortex-compute/src/take/slice/mod.rs
+++ b/vortex-compute/src/take/slice/mod.rs
@@ -16,6 +16,9 @@ impl<T: Copy, I: UnsignedPType> Take<[I]> for &[T] {
     type Output = Buffer<T>;
 
     fn take(self, indices: &[I]) -> Buffer<T> {
+        // TODO(connor): Make the SIMD implementations bound by `Copy` instead of `NativePType`.
+        /*
+
         #[cfg(vortex_nightly)]
         {
             return portable::take_portable(self, indices);
@@ -28,6 +31,8 @@ impl<T: Copy, I: UnsignedPType> Take<[I]> for &[T] {
                 return unsafe { avx2::take_avx2(self, indices) };
             }
         }
+
+        */
 
         #[allow(unreachable_code, reason = "`vortex_nightly` path returns early")]
         take_scalar(self, indices)


### PR DESCRIPTION
Just so we don't have to refactor the SIMD code to not rely on the `PTYPE` constant of `NativePType`.

This will unblock being able to implement `take` for `DecimalVector` and then `batch_execute` for `DictArray`.