### PR TITLE
Fix: claude action concurrency group

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -2,8 +2,8 @@ name: Claude Code
 
 concurrency:
   # We shouldn't have multiple instances of Claude running on the same PR.
-  group: ${{ github.event.issue.number || github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   issue_comment:


### PR DESCRIPTION
I originally thought that claude can only be triggered from the PR itself.