### PR TITLE
Immutable session + registries

### DIFF
--- a/bench-vortex/src/lib.rs
+++ b/bench-vortex/src/lib.rs
@@ -48,15 +48,16 @@ pub use datasets::file;
 pub use engines::df;
 use vortex::VortexSessionDefault;
 pub use vortex::error::vortex_panic;
-use vortex::io::session::RuntimeSessionExt;
+use vortex::io::session::RuntimeSessionMutExt;
 use vortex::session::VortexSession;
+use vortex::session::VortexSessionRef;
 
 // All benchmarks run with mimalloc for consistency.
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-pub static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::default().with_tokio());
+pub static SESSION: LazyLock<VortexSessionRef> =
+    LazyLock::new(|| VortexSession::new_with_defaults().with_tokio().freeze());
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize)]
 pub struct Target {

--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -460,11 +460,12 @@ mod tests {
     use vortex_array::vtable::ValidityHelper;
     use vortex_dtype::PTypeDowncast;
     use vortex_session::VortexSession;
+    use vortex_session::VortexSessionRef;
     use vortex_vector::VectorOps;
 
     use super::*;
 
-    static SESSION: LazyLock<VortexSession> = LazyLock::new(VortexSession::empty);
+    static SESSION: LazyLock<VortexSessionRef> = LazyLock::new(|| VortexSession::empty().freeze());
 
     #[rstest]
     #[case(0)]

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
@@ -211,6 +211,7 @@ mod tests {
     use vortex_buffer::buffer;
     use vortex_dtype::Nullability;
     use vortex_session::VortexSession;
+    use vortex_session::VortexSessionRef;
     use vortex_vector::VectorMutOps;
     use vortex_vector::VectorOps;
 
@@ -218,7 +219,7 @@ mod tests {
     use crate::BitPackedVTable;
     use crate::bitpack_compress::bitpack_encode;
 
-    static SESSION: LazyLock<VortexSession> = LazyLock::new(VortexSession::empty);
+    static SESSION: LazyLock<VortexSessionRef> = LazyLock::new(|| VortexSession::empty().freeze());
 
     fn compression_roundtrip(n: usize) {
         let values = PrimitiveArray::from_iter((0..n).map(|i| (i % 2047) as u16));

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -26,12 +26,16 @@ mod native_runtime {
     use vortex::VortexSessionDefault;
     use vortex_io::runtime::BlockingRuntime;
     use vortex_io::runtime::current::CurrentThreadRuntime;
-    use vortex_io::session::RuntimeSessionExt;
+    use vortex_io::session::RuntimeSessionMutExt;
     use vortex_session::VortexSession;
+    use vortex_session::VortexSessionRef;
 
     pub static RUNTIME: LazyLock<CurrentThreadRuntime> = LazyLock::new(CurrentThreadRuntime::new);
-    pub static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::default().with_handle(RUNTIME.handle()));
+    pub static SESSION: LazyLock<VortexSessionRef> = LazyLock::new(|| {
+        VortexSession::new_with_defaults()
+            .with_handle(RUNTIME.handle())
+            .freeze()
+    });
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -46,10 +50,10 @@ mod wasm_runtime {
     use vortex::VortexSessionDefault;
     use vortex_io::runtime::wasm::WasmRuntime;
     use vortex_io::session::RuntimeSessionExt;
-    use vortex_session::VortexSession;
+    use vortex_session::VortexSessionRef;
 
-    pub static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::default().with_handle(WasmRuntime::handle()));
+    pub static SESSION: LazyLock<VortexSessionRef> =
+        LazyLock::new(|| VortexSession::empty().with_handle(WasmRuntime::handle()));
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/java/testfiles/src/main.rs
+++ b/java/testfiles/src/main.rs
@@ -16,7 +16,7 @@ use vortex::dtype::Nullability;
 use vortex::file::WriteOptionsSessionExt;
 use vortex::io::runtime::current::CurrentThreadRuntime;
 use vortex::io::runtime::BlockingRuntime;
-use vortex::io::session::RuntimeSessionExt;
+use vortex::io::session::RuntimeSessionMutExt;
 use vortex::session::VortexSession;
 use vortex::VortexSessionDefault;
 

--- a/java/testfiles/src/main.rs
+++ b/java/testfiles/src/main.rs
@@ -6,9 +6,13 @@
 use std::path::Path;
 
 use vortex::array::arrays::StructArray;
-use vortex::array::builders::{ArrayBuilder, DecimalBuilder, VarBinViewBuilder};
+use vortex::array::builders::ArrayBuilder;
+use vortex::array::builders::DecimalBuilder;
+use vortex::array::builders::VarBinViewBuilder;
 use vortex::array::validity::Validity;
-use vortex::dtype::{DType, DecimalDType, Nullability};
+use vortex::dtype::DType;
+use vortex::dtype::DecimalDType;
+use vortex::dtype::Nullability;
 use vortex::file::WriteOptionsSessionExt;
 use vortex::io::runtime::current::CurrentThreadRuntime;
 use vortex::io::runtime::BlockingRuntime;
@@ -32,7 +36,9 @@ use vortex::VortexSessionDefault;
 /// | John   | 10000  | VA    |
 fn main() {
     let runtime = CurrentThreadRuntime::new();
-    let session = VortexSession::default().with_handle(runtime.handle());
+    let session = VortexSession::new_with_defaults()
+        .with_handle(runtime.handle())
+        .freeze();
 
     let mut names = VarBinViewBuilder::with_capacity(DType::Utf8(Nullability::NonNullable), 10);
     names.append_value("Alice");

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -22,7 +22,7 @@ use vortex_error::vortex_ensure;
 use vortex_error::vortex_panic;
 use vortex_mask::Mask;
 use vortex_scalar::Scalar;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 use vortex_vector::Vector;
 use vortex_vector::VectorOps;
 
@@ -366,7 +366,7 @@ impl dyn Array + '_ {
     /// Execute the array and return the resulting vector.
     ///
     /// This entry-point function will choose an appropriate CPU-based execution strategy.
-    pub fn execute(&self, session: &VortexSession) -> VortexResult<Vector> {
+    pub fn execute(&self, session: &VortexSessionRef) -> VortexResult<Vector> {
         let mut ctx = ExecutionCtx::new(session.clone());
         self.batch_execute(&mut ctx)
     }

--- a/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
@@ -19,6 +19,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 use vortex_vector::Vector;
 
 use crate::Array;
@@ -43,8 +44,8 @@ use crate::vtable::VTable;
 // TODO(ngates): canonicalize doesn't currently take a session, therefore we cannot dispatch
 //  to registered scalar function kernels. We therefore hold our own non-pluggable session here
 //  that contains all the built-in kernels while we migrate over to "execute" instead of canonicalize.
-static SCALAR_FN_SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SCALAR_FN_SESSION: LazyLock<VortexSessionRef> =
+    LazyLock::new(|| VortexSession::empty().with::<ArraySession>().freeze());
 
 vtable!(ScalarFn);
 

--- a/vortex-array/src/execution/mod.rs
+++ b/vortex-array/src/execution/mod.rs
@@ -7,24 +7,24 @@ mod validity;
 
 pub use batch::*;
 pub use mask::*;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 /// Execution context for batch array compute.
 // NOTE(ngates): This context will eventually hold cached resources for execution, such as CSE
 //  nodes, and may well eventually support a type-map interface for arrays to stash arbitrary
 //  execution-related data.
 pub struct ExecutionCtx {
-    session: VortexSession,
+    session: VortexSessionRef,
 }
 
 impl ExecutionCtx {
     /// Create a new execution context with the given session.
-    pub(crate) fn new(session: VortexSession) -> Self {
+    pub(crate) fn new(session: VortexSessionRef) -> Self {
         Self { session }
     }
 
     /// Get the session associated with this execution context.
-    pub fn session(&self) -> &VortexSession {
+    pub fn session(&self) -> &VortexSessionRef {
         &self.session
     }
 }

--- a/vortex-array/src/expr/functions/session.rs
+++ b/vortex-array/src/expr/functions/session.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_session::Ref;
 use vortex_session::SessionExt;
 use vortex_session::registry::Registry;
 
@@ -19,7 +18,7 @@ impl FunctionSession {
 }
 
 pub trait ScalarFuncSessionExt: SessionExt {
-    fn functions(&self) -> Ref<'_, FunctionSession> {
+    fn functions(&self) -> &FunctionSession {
         self.get::<FunctionSession>()
     }
 }

--- a/vortex-array/src/expr/session/mod.rs
+++ b/vortex-array/src/expr/session/mod.rs
@@ -4,7 +4,6 @@
 mod rewrite;
 
 pub use rewrite::RewriteRuleRegistry;
-use vortex_session::Ref;
 use vortex_session::SessionExt;
 use vortex_session::registry::Registry;
 
@@ -54,12 +53,12 @@ impl ExprSession {
     }
 
     /// Register an expression vtable in the session, replacing any existing vtable with the same ID.
-    pub fn register(&self, expr: ExprVTable) {
+    pub fn register(&mut self, expr: ExprVTable) {
         self.registry.register(expr)
     }
 
     /// Register expression vtables in the session, replacing any existing vtables with the same IDs.
-    pub fn register_many(&self, exprs: impl IntoIterator<Item = ExprVTable>) {
+    pub fn register_many(&mut self, exprs: impl IntoIterator<Item = ExprVTable>) {
         self.registry.register_many(exprs);
     }
 
@@ -151,7 +150,7 @@ impl ExprSession {
 
 impl Default for ExprSession {
     fn default() -> Self {
-        let expressions = ExprRegistry::default();
+        let mut expressions = ExprRegistry::default();
 
         // Register built-in expressions here if needed.
         expressions.register_many([
@@ -187,7 +186,7 @@ impl Default for ExprSession {
 /// Extension trait for accessing expression session data.
 pub trait ExprSessionExt: SessionExt {
     /// Returns the expression vtable registry.
-    fn expressions(&self) -> Ref<'_, ExprSession> {
+    fn expressions(&self) -> &ExprSession {
         self.get::<ExprSession>()
     }
 }

--- a/vortex-array/src/session/mod.rs
+++ b/vortex-array/src/session/mod.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_session::Ref;
 use vortex_session::SessionExt;
 use vortex_session::registry::Registry;
 
@@ -52,19 +51,19 @@ impl ArraySession {
     }
 
     /// Register a new array encoding, replacing any existing encoding with the same ID.
-    pub fn register(&self, encoding: ArrayVTable) {
+    pub fn register(&mut self, encoding: ArrayVTable) {
         self.registry.register(encoding)
     }
 
     /// Register many array encodings, replacing any existing encodings with the same ID.
-    pub fn register_many(&self, encodings: impl IntoIterator<Item = ArrayVTable>) {
+    pub fn register_many(&mut self, encodings: impl IntoIterator<Item = ArrayVTable>) {
         self.registry.register_many(encodings);
     }
 }
 
 impl Default for ArraySession {
     fn default() -> Self {
-        let encodings = ArrayRegistry::default();
+        let mut encodings = ArrayRegistry::default();
 
         // Register the canonical encodings.
         encodings.register_many([
@@ -108,7 +107,7 @@ impl Default for ArraySession {
 /// Session data for Vortex arrays.
 pub trait ArraySessionExt: SessionExt {
     /// Returns the array encoding registry.
-    fn arrays(&self) -> Ref<'_, ArraySession> {
+    fn arrays(&self) -> &ArraySession {
         self.get::<ArraySession>()
     }
 }

--- a/vortex-cxx/src/lib.rs
+++ b/vortex-cxx/src/lib.rs
@@ -17,8 +17,9 @@ use scalar::*;
 use vortex::VortexSessionDefault;
 use vortex::io::runtime::BlockingRuntime;
 use vortex::io::runtime::current::CurrentThreadRuntime;
-use vortex::io::session::RuntimeSessionExt;
+use vortex::io::session::RuntimeSessionMutExt;
 use vortex::session::VortexSession;
+use vortex::session::VortexSessionRef;
 use write::*;
 
 /// By default, the C++ API uses a current-thread runtime, providing control of the threading
@@ -28,8 +29,11 @@ use write::*;
 //  this runtime.
 pub(crate) static RUNTIME: LazyLock<CurrentThreadRuntime> =
     LazyLock::new(CurrentThreadRuntime::new);
-pub(crate) static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::default().with_handle(RUNTIME.handle()));
+pub(crate) static SESSION: LazyLock<VortexSessionRef> = LazyLock::new(|| {
+    VortexSession::new_with_defaults()
+        .with_handle(RUNTIME.handle())
+        .freeze()
+});
 
 #[cxx::bridge(namespace = "vortex::ffi")]
 #[allow(let_underscore_drop)]

--- a/vortex-datafusion/examples/vortex_table.rs
+++ b/vortex-datafusion/examples/vortex_table.rs
@@ -19,13 +19,13 @@ use vortex::array::validity::Validity;
 use vortex::buffer::buffer;
 use vortex::error::vortex_err;
 use vortex::file::WriteOptionsSessionExt;
-use vortex::io::session::RuntimeSessionExt;
+use vortex::io::session::RuntimeSessionMutExt;
 use vortex::session::VortexSession;
 use vortex_datafusion::VortexFormat;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let session = VortexSession::default().with_tokio();
+    let session = VortexSession::new_with_defaults().with_tokio().freeze();
 
     let temp_dir = tempdir()?;
     let strings = ChunkedArray::from_iter([

--- a/vortex-datafusion/src/persistent/cache.rs
+++ b/vortex-datafusion/src/persistent/cache.rs
@@ -25,14 +25,14 @@ use vortex::file::VortexFile;
 use vortex::layout::segments::SegmentCache;
 use vortex::layout::segments::SegmentId;
 use vortex::metrics::MetricsSessionExt;
-use vortex::session::VortexSession;
+use vortex::session::VortexSessionRef;
 use vortex::utils::aliases::DefaultHashBuilder;
 
 #[derive(Clone)]
 pub(crate) struct VortexFileCache {
     file_cache: Cache<FileKey, VortexFile, DefaultHashBuilder>,
     segment_cache: Cache<SegmentKey, ByteBuffer, DefaultHashBuilder>,
-    session: VortexSession,
+    session: VortexSessionRef,
 }
 
 /// Cache key for a [`VortexFile`].
@@ -59,7 +59,7 @@ struct SegmentKey {
 }
 
 impl VortexFileCache {
-    pub fn new(size_mb: usize, segment_size_mb: usize, session: VortexSession) -> Self {
+    pub fn new(size_mb: usize, segment_size_mb: usize, session: VortexSessionRef) -> Self {
         let file_cache = Cache::builder()
             .max_capacity(size_mb as u64 * (1 << 20))
             .eviction_listener(|k: Arc<FileKey>, _v: VortexFile, cause| {

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -54,6 +54,7 @@ use vortex::expr::stats::Stat;
 use vortex::file::VORTEX_FILE_EXTENSION;
 use vortex::scalar::Scalar;
 use vortex::session::VortexSession;
+use vortex::session::VortexSessionRef;
 
 use super::cache::VortexFileCache;
 use super::sink::VortexSink;
@@ -63,7 +64,7 @@ use crate::convert::TryToDataFusion;
 
 /// Vortex implementation of a DataFusion [`FileFormat`].
 pub struct VortexFormat {
-    session: VortexSession,
+    session: VortexSessionRef,
     file_cache: VortexFileCache,
     opts: VortexOptions,
 }
@@ -95,7 +96,7 @@ impl Eq for VortexOptions {}
 /// Minimal factory to create [`VortexFormat`] instances.
 #[derive(Debug)]
 pub struct VortexFormatFactory {
-    session: VortexSession,
+    session: VortexSessionRef,
     options: Option<VortexOptions>,
 }
 
@@ -106,7 +107,7 @@ impl GetExt for VortexFormatFactory {
 }
 
 impl VortexFormatFactory {
-    /// Creates a new instance with a default [`VortexSession`] and default options.
+    /// Creates a new instance with a default [`VortexSessionRef`] and default options.
     #[expect(
         clippy::new_without_default,
         reason = "FormatFactory defines `default` method, so having `Default` implementation is confusing"
@@ -121,7 +122,7 @@ impl VortexFormatFactory {
     /// Creates a new instance with customized session and default options for all [`VortexFormat`] instances created from this factory.
     ///
     /// The options can be overridden by table-level configuration pass in [`FileFormatFactory::create`].
-    pub fn new_with_options(session: VortexSession, options: VortexOptions) -> Self {
+    pub fn new_with_options(session: VortexSessionRef, options: VortexOptions) -> Self {
         Self {
             session,
             options: Some(options),
@@ -175,12 +176,12 @@ impl FileFormatFactory for VortexFormatFactory {
 
 impl VortexFormat {
     /// Create a new instance with default options.
-    pub fn new(session: VortexSession) -> Self {
+    pub fn new(session: VortexSessionRef) -> Self {
         Self::new_with_options(session, VortexOptions::default())
     }
 
     /// Creates a new instance with configured by a [`VortexOptions`].
-    pub fn new_with_options(session: VortexSession, opts: VortexOptions) -> Self {
+    pub fn new_with_options(session: VortexSessionRef, opts: VortexOptions) -> Self {
         Self {
             session: session.clone(),
             file_cache: VortexFileCache::new(

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -40,7 +40,7 @@ use vortex::expr::select;
 use vortex::layout::LayoutReader;
 use vortex::metrics::VortexMetrics;
 use vortex::scan::ScanBuilder;
-use vortex::session::VortexSession;
+use vortex::session::VortexSessionRef;
 use vortex_utils::aliases::dash_map::DashMap;
 use vortex_utils::aliases::dash_map::Entry;
 
@@ -50,7 +50,7 @@ use crate::convert::exprs::make_vortex_predicate;
 
 #[derive(Clone)]
 pub(crate) struct VortexOpener {
-    pub session: VortexSession,
+    pub session: VortexSessionRef,
     pub object_store: Arc<dyn ObjectStore>,
     /// Projection by index of the file's columns
     pub projection: Option<Arc<[usize]>>,
@@ -437,10 +437,11 @@ mod tests {
     use vortex::io::ObjectStoreWriter;
     use vortex::io::VortexWrite;
     use vortex::session::VortexSession;
+    use vortex::session::VortexSessionRef;
 
     use super::*;
 
-    static SESSION: LazyLock<VortexSession> = LazyLock::new(VortexSession::default);
+    static SESSION: LazyLock<VortexSessionRef> = LazyLock::new(VortexSession::default);
 
     #[rstest]
     #[case(0..100, 100, 100, 0..100)]

--- a/vortex-datafusion/src/persistent/sink.rs
+++ b/vortex-datafusion/src/persistent/sink.rs
@@ -35,16 +35,16 @@ use vortex::error::VortexResult;
 use vortex::file::WriteOptionsSessionExt;
 use vortex::io::ObjectStoreWriter;
 use vortex::io::VortexWrite;
-use vortex::session::VortexSession;
+use vortex::session::VortexSessionRef;
 
 pub struct VortexSink {
     config: FileSinkConfig,
     schema: SchemaRef,
-    session: VortexSession,
+    session: VortexSessionRef,
 }
 
 impl VortexSink {
-    pub fn new(config: FileSinkConfig, schema: SchemaRef, session: VortexSession) -> Self {
+    pub fn new(config: FileSinkConfig, schema: SchemaRef, session: VortexSessionRef) -> Self {
         Self {
             config,
             schema,

--- a/vortex-datafusion/src/persistent/source.rs
+++ b/vortex-datafusion/src/persistent/source.rs
@@ -32,7 +32,7 @@ use vortex::error::VortexExpect as _;
 use vortex::file::VORTEX_FILE_EXTENSION;
 use vortex::layout::LayoutReader;
 use vortex::metrics::MetricsSessionExt;
-use vortex::session::VortexSession;
+use vortex::session::VortexSessionRef;
 use vortex_utils::aliases::dash_map::DashMap;
 
 use super::cache::VortexFileCache;
@@ -45,7 +45,7 @@ use crate::convert::exprs::can_be_pushed_down;
 /// [`DataSourceExec`]: datafusion_datasource::source::DataSourceExec
 #[derive(Clone)]
 pub struct VortexSource {
-    pub(crate) session: VortexSession,
+    pub(crate) session: VortexSessionRef,
     pub(crate) file_cache: VortexFileCache,
     /// Combined predicate expression containing all filters from DataFusion query planning.
     /// Used with FilePruner to skip files based on statistics and partition values.
@@ -67,7 +67,7 @@ pub struct VortexSource {
 }
 
 impl VortexSource {
-    pub(crate) fn new(session: VortexSession, file_cache: VortexFileCache) -> Self {
+    pub(crate) fn new(session: VortexSessionRef, file_cache: VortexFileCache) -> Self {
         Self {
             session,
             file_cache,

--- a/vortex-duckdb/src/lib.rs
+++ b/vortex-duckdb/src/lib.rs
@@ -12,8 +12,9 @@ use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::io::runtime::BlockingRuntime;
 use vortex::io::runtime::current::CurrentThreadRuntime;
-use vortex::io::session::RuntimeSessionExt;
+use vortex::io::session::RuntimeSessionMutExt;
 use vortex::session::VortexSession;
+use vortex::session::VortexSessionRef;
 
 use crate::copy::VortexCopyFunction;
 use crate::duckdb::Config;
@@ -41,8 +42,11 @@ mod e2e_test;
 
 // A global runtime for Vortex operations within DuckDB.
 static RUNTIME: LazyLock<CurrentThreadRuntime> = LazyLock::new(CurrentThreadRuntime::new);
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::default().with_handle(RUNTIME.handle()));
+static SESSION: LazyLock<VortexSessionRef> = LazyLock::new(|| {
+    VortexSession::new_with_defaults()
+        .with_handle(RUNTIME.handle())
+        .freeze()
+});
 
 /// Register Vortex extension configuration options with DuckDB.
 /// This must be called before `register_table_functions` to take effect.

--- a/vortex-ffi/examples/hello_vortex.rs
+++ b/vortex-ffi/examples/hello_vortex.rs
@@ -30,12 +30,16 @@ use vortex::file::WriteOptionsSessionExt;
 use vortex::io::VortexWrite;
 use vortex::io::runtime::BlockingRuntime;
 use vortex::io::runtime::current::CurrentThreadRuntime;
-use vortex::io::session::RuntimeSessionExt;
+use vortex::io::session::RuntimeSessionMutExt;
 use vortex::session::VortexSession;
+use vortex::session::VortexSessionRef;
 
 static RUNTIME: LazyLock<CurrentThreadRuntime> = LazyLock::new(CurrentThreadRuntime::new);
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::default().with_handle(RUNTIME.handle()));
+static SESSION: LazyLock<VortexSessionRef> = LazyLock::new(|| {
+    VortexSession::new_with_defaults()
+        .with_handle(RUNTIME.handle())
+        .freeze()
+});
 
 const BIN_NAME: &str = "hello_vortex";
 

--- a/vortex-ffi/src/file.rs
+++ b/vortex-ffi/src/file.rs
@@ -42,7 +42,7 @@ use vortex::io::runtime::BlockingRuntime;
 use vortex::proto::expr::Expr;
 use vortex::scan::ScanBuilder;
 use vortex::scan::SplitBy;
-use vortex::session::VortexSession;
+use vortex::session::VortexSessionRef;
 
 use crate::RUNTIME;
 use crate::arc_wrapper;
@@ -126,7 +126,7 @@ impl vx_file_scan_options {
     /// Processes FFI scan options.
     ///
     /// Extracts and converts a scan configuration from an FFI options struct.
-    fn process_scan_options(&self, session: &VortexSession) -> VortexResult<ScanOptions> {
+    fn process_scan_options(&self, session: &VortexSessionRef) -> VortexResult<ScanOptions> {
         // Extract field names for projection.
         let projection_expr = extract_expression(
             session.expressions().registry(),

--- a/vortex-ffi/src/session.rs
+++ b/vortex-ffi/src/session.rs
@@ -3,15 +3,16 @@
 
 use vortex::VortexSessionDefault;
 use vortex::io::runtime::BlockingRuntime;
-use vortex::io::session::RuntimeSessionExt;
+use vortex::io::session::RuntimeSessionMutExt;
 use vortex::session::VortexSession;
+use vortex::session::VortexSessionRef;
 
 use crate::RUNTIME;
 use crate::box_wrapper;
 
 box_wrapper!(
     /// A handle to a Vortex session.
-    VortexSession,
+    VortexSessionRef,
     vx_session
 );
 
@@ -21,6 +22,8 @@ box_wrapper!(
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_session_new() -> *mut vx_session {
     vx_session::new(Box::new(
-        VortexSession::default().with_handle(RUNTIME.handle()),
+        VortexSession::new_with_defaults()
+            .with_handle(RUNTIME.handle())
+            .freeze(),
     ))
 }

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -25,7 +25,7 @@ use vortex_layout::segments::SegmentSource;
 use vortex_metrics::VortexMetrics;
 use vortex_scan::ScanBuilder;
 use vortex_scan::SplitBy;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 use vortex_utils::aliases::hash_map::HashMap;
 
 use crate::footer::Footer;
@@ -45,7 +45,7 @@ pub struct VortexFile {
     /// Metrics tied to the file.
     pub(crate) metrics: VortexMetrics,
     /// The Vortex session used to open this file
-    pub(crate) session: VortexSession,
+    pub(crate) session: VortexSessionRef,
 }
 
 impl VortexFile {

--- a/vortex-file/src/footer/deserializer.rs
+++ b/vortex-file/src/footer/deserializer.rs
@@ -12,7 +12,7 @@ use vortex_error::vortex_err;
 use vortex_flatbuffers::FlatBuffer;
 use vortex_flatbuffers::ReadFlatBuffer;
 use vortex_flatbuffers::dtype as fbd;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 use crate::EOF_SIZE;
 use crate::Footer;
@@ -30,7 +30,7 @@ pub struct FooterDeserializer {
     // the caller.
     buffer: ByteBuffer,
     // The session to use for deserialization.
-    session: VortexSession,
+    session: VortexSessionRef,
     // The DType, if provided externally.
     dtype: Option<DType>,
 
@@ -43,7 +43,7 @@ pub struct FooterDeserializer {
 }
 
 impl FooterDeserializer {
-    pub(super) fn new(initial_read: ByteBuffer, session: VortexSession) -> Self {
+    pub(super) fn new(initial_read: ByteBuffer, session: VortexSessionRef) -> Self {
         Self {
             buffer: initial_read,
             session,

--- a/vortex-file/src/footer/mod.rs
+++ b/vortex-file/src/footer/mod.rs
@@ -38,7 +38,7 @@ use vortex_layout::LayoutContext;
 use vortex_layout::LayoutRef;
 use vortex_layout::layout_from_flatbuffer;
 use vortex_layout::session::LayoutSessionExt;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 /// Captures the layout information of a Vortex file.
 #[derive(Debug, Clone)]
@@ -71,7 +71,7 @@ impl Footer {
         layout_bytes: FlatBuffer,
         dtype: DType,
         statistics: Option<FileStatistics>,
-        session: &VortexSession,
+        session: &VortexSessionRef,
     ) -> VortexResult<Self> {
         let fb_footer = root::<fb::Footer>(&footer_bytes)?;
 
@@ -145,7 +145,7 @@ impl Footer {
     }
 
     /// Create a deserializer for a Vortex file footer.
-    pub fn deserializer(eof_buffer: ByteBuffer, session: VortexSession) -> FooterDeserializer {
+    pub fn deserializer(eof_buffer: ByteBuffer, session: VortexSessionRef) -> FooterDeserializer {
         FooterDeserializer::new(eof_buffer, session)
     }
 }

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -109,7 +109,7 @@ pub use strategy::*;
 use vortex_alp::ALPRDVTable;
 use vortex_alp::ALPVTable;
 use vortex_array::arrays::DictVTable;
-use vortex_array::session::ArraySessionExt;
+use vortex_array::session::ArraySession;
 use vortex_array::vtable::ArrayVTableExt;
 use vortex_bytebool::ByteBoolVTable;
 use vortex_datetime_parts::DateTimePartsVTable;
@@ -163,8 +163,8 @@ mod forever_constant {
 ///
 /// NOTE: this function will be changed in the future to encapsulate logic for using different
 /// Vortex "Editions" that may support different sets of encodings.
-pub fn register_default_encodings(session: &VortexSession) {
-    session.arrays().register_many([
+pub fn register_default_encodings(session: &mut VortexSession) {
+    session.get_mut::<ArraySession>().register_many([
         ALPVTable.as_vtable(),
         ALPRDVTable.as_vtable(),
         BitPackedVTable.as_vtable(),

--- a/vortex-file/src/open.rs
+++ b/vortex-file/src/open.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use futures::executor::block_on;
 use parking_lot::RwLock;
-use vortex_array::session::ArraySessionExt;
 use vortex_buffer::Alignment;
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
@@ -22,10 +21,9 @@ use vortex_layout::segments::SegmentCacheMetrics;
 use vortex_layout::segments::SegmentCacheSourceAdapter;
 use vortex_layout::segments::SegmentId;
 use vortex_layout::segments::SharedSegmentSource;
-use vortex_layout::session::LayoutSessionExt;
 use vortex_metrics::MetricsSessionExt;
 use vortex_metrics::VortexMetrics;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 use vortex_utils::aliases::hash_map::HashMap;
 
 use crate::DeserializeStep;
@@ -41,7 +39,7 @@ const INITIAL_READ_SIZE: usize = 1 << 20; // 1 MB
 /// Open options for a Vortex file reader.
 pub struct VortexOpenOptions {
     /// The session to use for opening the file.
-    session: VortexSession,
+    session: VortexSessionRef,
     /// Cache to use for file segments.
     segment_cache: Arc<dyn SegmentCache>,
     /// The number of bytes to read when parsing the footer.
@@ -58,13 +56,15 @@ pub struct VortexOpenOptions {
     metrics: VortexMetrics,
 }
 
-pub trait OpenOptionsSessionExt:
-    ArraySessionExt + LayoutSessionExt + MetricsSessionExt + RuntimeSessionExt
-{
+pub trait OpenOptionsSessionExt {
     /// Create a new [`VortexOpenOptions`] using the provided session to open a file.
+    fn open_options(&self) -> VortexOpenOptions;
+}
+
+impl OpenOptionsSessionExt for VortexSessionRef {
     fn open_options(&self) -> VortexOpenOptions {
         VortexOpenOptions {
-            session: self.session(),
+            session: self.clone(),
             segment_cache: Arc::new(NoOpSegmentCache),
             initial_read_size: INITIAL_READ_SIZE,
             file_size: None,
@@ -74,10 +74,6 @@ pub trait OpenOptionsSessionExt:
             metrics: self.metrics(),
         }
     }
-}
-impl<S: ArraySessionExt + LayoutSessionExt + MetricsSessionExt + RuntimeSessionExt>
-    OpenOptionsSessionExt for S
-{
 }
 
 impl VortexOpenOptions {

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -63,6 +63,7 @@ use vortex_metrics::VortexMetrics;
 use vortex_scalar::Scalar;
 use vortex_scan::ScanBuilder;
 use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 use crate::OpenOptionsSessionExt;
 use crate::V1_FOOTER_FBS_SIZE;
@@ -70,17 +71,17 @@ use crate::VERSION;
 use crate::VortexFile;
 use crate::WriteOptionsSessionExt;
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-    let session = VortexSession::empty()
+static SESSION: LazyLock<VortexSessionRef> = LazyLock::new(|| {
+    let mut session = VortexSession::empty()
         .with::<VortexMetrics>()
         .with::<ArraySession>()
         .with::<LayoutSession>()
         .with::<ExprSession>()
         .with::<RuntimeSession>();
 
-    crate::register_default_encodings(&session);
+    crate::register_default_encodings(&mut session);
 
-    session
+    session.freeze()
 });
 
 #[tokio::test]

--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -41,8 +41,7 @@ use vortex_layout::layouts::file_stats::accumulate_stats;
 use vortex_layout::sequence::SequenceId;
 use vortex_layout::sequence::SequentialStreamAdapter;
 use vortex_layout::sequence::SequentialStreamExt;
-use vortex_session::SessionExt;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 use crate::Footer;
 use crate::MAGIC_BYTES;
@@ -57,18 +56,23 @@ use crate::segments::writer::BufferedSegmentSink;
 /// Unless overridden, the default [write strategy][crate::WriteStrategyBuilder] will be used with no
 /// additional configuration.
 pub struct VortexWriteOptions {
-    session: VortexSession,
+    session: VortexSessionRef,
     strategy: Arc<dyn LayoutStrategy>,
     exclude_dtype: bool,
     max_variable_length_statistics_size: usize,
     file_statistics: Vec<Stat>,
 }
 
-pub trait WriteOptionsSessionExt: SessionExt {
+pub trait WriteOptionsSessionExt {
+    /// Create [`VortexWriteOptions`] for writing to a Vortex file.
+    fn write_options(&self) -> VortexWriteOptions;
+}
+
+impl WriteOptionsSessionExt for VortexSessionRef {
     /// Create [`VortexWriteOptions`] for writing to a Vortex file.
     fn write_options(&self) -> VortexWriteOptions {
         VortexWriteOptions {
-            session: self.session(),
+            session: self.clone(),
             strategy: WriteStrategyBuilder::new().build(),
             exclude_dtype: false,
             file_statistics: PRUNING_STATS.to_vec(),
@@ -76,11 +80,10 @@ pub trait WriteOptionsSessionExt: SessionExt {
         }
     }
 }
-impl<S: SessionExt> WriteOptionsSessionExt for S {}
 
 impl VortexWriteOptions {
     /// Create a new [`VortexWriteOptions`] with the given session.
-    pub fn new(session: VortexSession) -> Self {
+    pub fn new(session: VortexSessionRef) -> Self {
         VortexWriteOptions {
             session,
             strategy: WriteStrategyBuilder::new().build(),

--- a/vortex-io/src/session.rs
+++ b/vortex-io/src/session.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 
 use vortex_error::VortexExpect;
 use vortex_session::SessionExt;
+use vortex_session::VortexSession;
 
 use crate::runtime::Handle;
 
@@ -12,6 +13,8 @@ use crate::runtime::Handle;
 pub struct RuntimeSession {
     handle: Option<Handle>,
 }
+
+impl RuntimeSession {}
 
 impl Default for RuntimeSession {
     fn default() -> Self {
@@ -27,6 +30,32 @@ impl Debug for RuntimeSession {
     }
 }
 
+/// Extension trait for setting runtime session data.
+pub trait RuntimeSessionMutExt: Sized {
+    /// Configure the runtime session to use the application's Tokio runtime.
+    ///
+    /// For example, if the application is launched using `#[tokio::main]`.
+    #[cfg(feature = "tokio")]
+    fn with_tokio(self) -> Self;
+
+    /// Configure the runtime session to use a specific Vortex runtime handle.
+    fn with_handle(self, handle: Handle) -> Self;
+}
+
+impl RuntimeSessionMutExt for VortexSession {
+    #[cfg(feature = "tokio")]
+    fn with_tokio(mut self) -> Self {
+        self.get_mut::<RuntimeSession>().handle =
+            Some(crate::runtime::tokio::TokioRuntime::current());
+        self
+    }
+
+    fn with_handle(mut self, handle: Handle) -> Self {
+        self.get_mut::<RuntimeSession>().handle = Some(handle);
+        self
+    }
+}
+
 /// Extension trait for accessing runtime session data.
 pub trait RuntimeSessionExt: SessionExt {
     /// Returns a handle for this session's runtime.
@@ -35,22 +64,6 @@ pub trait RuntimeSessionExt: SessionExt {
                 .as_ref()
                 .vortex_expect("Runtime handle not configured in Vortex session. Please setup a `CurrentThreadRuntime`, or configure the session for `with_tokio`.")
                 .clone()
-    }
-
-    /// Configure the runtime session to use the application's Tokio runtime.
-    ///
-    /// For example, if the application is launched using `#[tokio::main]`.
-    #[cfg(feature = "tokio")]
-    fn with_tokio(self) -> Self {
-        self.get_mut::<RuntimeSession>().handle =
-            Some(crate::runtime::tokio::TokioRuntime::current());
-        self
-    }
-
-    /// Configure the runtime session to use a specific Vortex runtime handle.
-    fn with_handle(self, handle: Handle) -> Self {
-        self.get_mut::<RuntimeSession>().handle = Some(handle);
-        self
     }
 }
 impl<S: SessionExt> RuntimeSessionExt for S {}

--- a/vortex-jni/src/lib.rs
+++ b/vortex-jni/src/lib.rs
@@ -10,8 +10,9 @@ use vortex::VortexSessionDefault;
 use vortex::error::VortexExpect;
 use vortex::io::runtime::BlockingRuntime;
 use vortex::io::runtime::tokio::TokioRuntime;
-use vortex::io::session::RuntimeSessionExt;
+use vortex::io::session::RuntimeSessionMutExt;
 use vortex::session::VortexSession;
+use vortex::session::VortexSessionRef;
 
 macro_rules! throw_runtime {
     ($($tt:tt)*) => {
@@ -38,5 +39,8 @@ static TOKIO_RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
 static RUNTIME: LazyLock<TokioRuntime> =
     LazyLock::new(|| TokioRuntime::from(TOKIO_RUNTIME.handle().clone()));
 /// Shared Vortex session for the JNI instance.
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::default().with_handle(RUNTIME.handle()));
+static SESSION: LazyLock<VortexSessionRef> = LazyLock::new(|| {
+    VortexSession::new_with_defaults()
+        .with_handle(RUNTIME.handle())
+        .freeze()
+});

--- a/vortex-layout/src/layout.rs
+++ b/vortex-layout/src/layout.rs
@@ -15,7 +15,7 @@ use vortex_dtype::FieldName;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 use crate::LayoutEncodingId;
 use crate::LayoutEncodingRef;
@@ -74,7 +74,7 @@ pub trait Layout: 'static + Send + Sync + Debug + private::Sealed {
         &self,
         name: Arc<str>,
         segment_source: Arc<dyn SegmentSource>,
-        session: &VortexSession,
+        session: &VortexSessionRef,
     ) -> VortexResult<LayoutReaderRef>;
 }
 
@@ -327,7 +327,7 @@ impl<V: VTable> Layout for LayoutAdapter<V> {
         &self,
         name: Arc<str>,
         segment_source: Arc<dyn SegmentSource>,
-        session: &VortexSession,
+        session: &VortexSessionRef,
     ) -> VortexResult<LayoutReaderRef> {
         V::new_reader(&self.0, name, segment_source, session)
     }

--- a/vortex-layout/src/layouts/chunked/mod.rs
+++ b/vortex-layout/src/layouts/chunked/mod.rs
@@ -11,7 +11,7 @@ use vortex_array::DeserializeMetadata;
 use vortex_array::EmptyMetadata;
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 use crate::LayoutChildType;
 use crate::LayoutEncodingRef;
@@ -72,7 +72,7 @@ impl VTable for ChunkedVTable {
         layout: &Self::Layout,
         name: Arc<str>,
         segment_source: Arc<dyn SegmentSource>,
-        session: &VortexSession,
+        session: &VortexSessionRef,
     ) -> VortexResult<LayoutReaderRef> {
         Ok(Arc::new(ChunkedReader::new(
             layout.clone(),

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -20,7 +20,7 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 use vortex_mask::Mask;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 use crate::LayoutReaderRef;
 use crate::LazyReaderChildren;
@@ -42,7 +42,7 @@ impl ChunkedReader {
         layout: ChunkedLayout,
         name: Arc<str>,
         segment_source: Arc<dyn SegmentSource>,
-        session: &VortexSession,
+        session: &VortexSessionRef,
     ) -> Self {
         let nchildren = layout.nchildren();
 

--- a/vortex-layout/src/layouts/dict/mod.rs
+++ b/vortex-layout/src/layouts/dict/mod.rs
@@ -17,7 +17,7 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_panic;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 use crate::LayoutChildType;
 use crate::LayoutEncodingRef;
@@ -89,7 +89,7 @@ impl VTable for DictVTable {
         layout: &Self::Layout,
         name: Arc<str>,
         segment_source: Arc<dyn SegmentSource>,
-        session: &VortexSession,
+        session: &VortexSessionRef,
     ) -> VortexResult<LayoutReaderRef> {
         Ok(Arc::new(DictReader::try_new(
             layout.clone(),

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -27,7 +27,7 @@ use vortex_error::VortexError;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 use vortex_utils::aliases::dash_map::DashMap;
 
 use super::DictLayout;
@@ -57,7 +57,7 @@ impl DictReader {
         layout: DictLayout,
         name: Arc<str>,
         segment_source: Arc<dyn SegmentSource>,
-        session: &VortexSession,
+        session: &VortexSessionRef,
     ) -> VortexResult<Self> {
         let values_len = usize::try_from(layout.values.row_count())?;
         let values = layout.values.new_reader(

--- a/vortex-layout/src/layouts/flat/mod.rs
+++ b/vortex-layout/src/layouts/flat/mod.rs
@@ -15,7 +15,7 @@ use vortex_dtype::DType;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_panic;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 use crate::LayoutChildType;
 use crate::LayoutEncodingRef;
@@ -84,7 +84,7 @@ impl VTable for FlatVTable {
         layout: &Self::Layout,
         name: Arc<str>,
         segment_source: Arc<dyn SegmentSource>,
-        _session: &VortexSession,
+        _session: &VortexSessionRef,
     ) -> VortexResult<LayoutReaderRef> {
         Ok(Arc::new(FlatReader::new(
             layout.clone(),

--- a/vortex-layout/src/layouts/row_idx/mod.rs
+++ b/vortex-layout/src/layouts/row_idx/mod.rs
@@ -37,7 +37,7 @@ use vortex_error::VortexResult;
 use vortex_mask::Mask;
 use vortex_scalar::PValue;
 use vortex_sequence::SequenceArray;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 use vortex_utils::aliases::dash_map::DashMap;
 
 use crate::ArrayFuture;
@@ -53,8 +53,8 @@ pub struct RowIdxLayoutReader {
 }
 
 impl RowIdxLayoutReader {
-    pub fn new(row_offset: u64, child: Arc<dyn LayoutReader>, session: &VortexSession) -> Self {
-        let expr_optimizer = ExprOptimizer::new(&session.expressions());
+    pub fn new(row_offset: u64, child: Arc<dyn LayoutReader>, session: &VortexSessionRef) -> Self {
+        let expr_optimizer = ExprOptimizer::new(session.expressions());
         Self {
             name: child.name().clone(),
             row_offset,

--- a/vortex-layout/src/layouts/struct_/mod.rs
+++ b/vortex-layout/src/layouts/struct_/mod.rs
@@ -20,8 +20,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
-use vortex_session::SessionExt;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 use crate::LayoutChildType;
 use crate::LayoutEncodingRef;
@@ -114,13 +113,13 @@ impl VTable for StructVTable {
         layout: &Self::Layout,
         name: Arc<str>,
         segment_source: Arc<dyn SegmentSource>,
-        session: &VortexSession,
+        session: &VortexSessionRef,
     ) -> VortexResult<LayoutReaderRef> {
         Ok(Arc::new(StructReader::try_new(
             layout.clone(),
             name,
             segment_source,
-            session.session(),
+            session.clone(),
         )?))
     }
 

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -36,7 +36,7 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 use vortex_mask::Mask;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 use vortex_utils::aliases::dash_map::DashMap;
 use vortex_utils::aliases::hash_map::HashMap;
 
@@ -68,7 +68,7 @@ impl StructReader {
         layout: StructLayout,
         name: Arc<str>,
         segment_source: Arc<dyn SegmentSource>,
-        session: VortexSession,
+        session: VortexSessionRef,
     ) -> VortexResult<Self> {
         let struct_dt = layout.struct_fields();
 
@@ -106,7 +106,7 @@ impl StructReader {
         let expanded_root_expr = replace_root_fields(root(), struct_dt);
 
         // Create the expression optimizer once during construction
-        let expr_optimizer = ExprOptimizer::new(&session.expressions());
+        let expr_optimizer = ExprOptimizer::new(session.expressions());
 
         // This is where we need to do some complex things with the scan in order to split it into
         // different scans for different fields.

--- a/vortex-layout/src/layouts/zoned/mod.rs
+++ b/vortex-layout/src/layouts/zoned/mod.rs
@@ -24,7 +24,7 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_panic;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 use crate::LayoutChildType;
 use crate::LayoutEncodingRef;
@@ -101,7 +101,7 @@ impl VTable for ZonedVTable {
         layout: &Self::Layout,
         name: Arc<str>,
         segment_source: Arc<dyn SegmentSource>,
-        session: &VortexSession,
+        session: &VortexSessionRef,
     ) -> VortexResult<LayoutReaderRef> {
         Ok(Arc::new(ZonedReader::try_new(
             layout.clone(),

--- a/vortex-layout/src/layouts/zoned/reader.rs
+++ b/vortex-layout/src/layouts/zoned/reader.rs
@@ -31,7 +31,7 @@ use vortex_error::VortexError;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 use vortex_utils::aliases::dash_map::DashMap;
 
 use crate::LayoutReader;
@@ -66,7 +66,7 @@ impl ZonedReader {
         layout: ZonedLayout,
         name: Arc<str>,
         segment_source: Arc<dyn SegmentSource>,
-        session: VortexSession,
+        session: VortexSessionRef,
     ) -> VortexResult<Self> {
         let dtypes = vec![
             layout.dtype.clone(),

--- a/vortex-layout/src/reader.rs
+++ b/vortex-layout/src/reader.rs
@@ -16,7 +16,7 @@ use vortex_dtype::FieldMask;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_mask::Mask;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 use crate::children::LayoutChildren;
 use crate::segments::SegmentSource;
@@ -108,7 +108,7 @@ pub struct LazyReaderChildren {
     dtypes: Vec<DType>,
     names: Vec<Arc<str>>,
     segment_source: Arc<dyn SegmentSource>,
-    session: VortexSession,
+    session: VortexSessionRef,
     // TODO(ngates): we may want a hash map of some sort here?
     cache: Vec<OnceCell<LayoutReaderRef>>,
 }
@@ -119,7 +119,7 @@ impl LazyReaderChildren {
         dtypes: Vec<DType>,
         names: Vec<Arc<str>>,
         segment_source: Arc<dyn SegmentSource>,
-        session: VortexSession,
+        session: VortexSessionRef,
     ) -> Self {
         let nchildren = children.nchildren();
         let cache = (0..nchildren).map(|_| OnceCell::new()).collect();

--- a/vortex-layout/src/session.rs
+++ b/vortex-layout/src/session.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_session::Ref;
 use vortex_session::SessionExt;
 use vortex_session::registry::Registry;
 
@@ -22,12 +21,12 @@ pub struct LayoutSession {
 
 impl LayoutSession {
     /// Register a layout encoding in the session, replacing any existing encoding with the same ID.
-    pub fn register(&self, layout: LayoutEncodingRef) {
+    pub fn register(&mut self, layout: LayoutEncodingRef) {
         self.registry.register(layout);
     }
 
     /// Register layout encodings in the session, replacing any existing encodings with the same IDs.
-    pub fn register_many(&self, layouts: impl IntoIterator<Item = LayoutEncodingRef>) {
+    pub fn register_many(&mut self, layouts: impl IntoIterator<Item = LayoutEncodingRef>) {
         self.registry.register_many(layouts);
     }
 
@@ -39,7 +38,7 @@ impl LayoutSession {
 
 impl Default for LayoutSession {
     fn default() -> Self {
-        let layouts = LayoutRegistry::default();
+        let mut layouts = LayoutRegistry::default();
 
         // Register the built-in layout encodings.
         layouts.register_many([
@@ -57,7 +56,7 @@ impl Default for LayoutSession {
 /// Extension trait for accessing layout session data.
 pub trait LayoutSessionExt: SessionExt {
     /// Returns the layout encoding registry.
-    fn layouts(&self) -> Ref<'_, LayoutSession> {
+    fn layouts(&self) -> &LayoutSession {
         self.get::<LayoutSession>()
     }
 }

--- a/vortex-layout/src/test.rs
+++ b/vortex-layout/src/test.rs
@@ -8,14 +8,16 @@ use vortex_array::session::ArraySession;
 use vortex_io::session::RuntimeSession;
 use vortex_metrics::VortexMetrics;
 use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 use crate::session::LayoutSession;
 
-pub static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
+pub static SESSION: LazyLock<VortexSessionRef> = LazyLock::new(|| {
     VortexSession::empty()
         .with::<VortexMetrics>()
         .with::<ArraySession>()
         .with::<LayoutSession>()
         .with::<ExprSession>()
         .with::<RuntimeSession>()
+        .freeze()
 });

--- a/vortex-layout/src/vtable.rs
+++ b/vortex-layout/src/vtable.rs
@@ -10,7 +10,7 @@ use vortex_array::DeserializeMetadata;
 use vortex_array::SerializeMetadata;
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 use crate::IntoLayout;
 use crate::Layout;
@@ -61,7 +61,7 @@ pub trait VTable: 'static + Sized + Send + Sync + Debug {
         layout: &Self::Layout,
         name: Arc<str>,
         segment_source: Arc<dyn SegmentSource>,
-        session: &VortexSession,
+        session: &VortexSessionRef,
     ) -> VortexResult<LayoutReaderRef>;
 
     #[cfg(gpu_unstable)]

--- a/vortex-python/python/vortex/registry.py
+++ b/vortex-python/python/vortex/registry.py
@@ -1,6 +1,2 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright the Vortex contributors
-
-from vortex._lib.registry import register  # pyright: ignore[reportMissingModuleSource]
-
-__all__ = ["register"]

--- a/vortex-python/src/lib.rs
+++ b/vortex-python/src/lib.rs
@@ -32,8 +32,9 @@ use vortex::error::VortexError;
 use vortex::error::VortexExpect as _;
 use vortex::io::runtime::BlockingRuntime;
 use vortex::io::runtime::tokio::TokioRuntime;
-use vortex::io::session::RuntimeSessionExt;
+use vortex::io::session::RuntimeSessionMutExt;
 use vortex::session::VortexSession;
+use vortex::session::VortexSessionRef;
 
 static TOKIO_RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
     Runtime::new()
@@ -42,8 +43,11 @@ static TOKIO_RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
 });
 static RUNTIME: LazyLock<TokioRuntime> =
     LazyLock::new(|| TokioRuntime::new(TOKIO_RUNTIME.handle().clone()));
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::default().with_handle(RUNTIME.handle()));
+static SESSION: LazyLock<VortexSessionRef> = LazyLock::new(|| {
+    VortexSession::new_with_defaults()
+        .with_handle(RUNTIME.handle())
+        .freeze()
+});
 
 /// Vortex is an Apache Arrow-compatible toolkit for working with compressed array data.
 #[pymodule]

--- a/vortex-python/src/registry.rs
+++ b/vortex-python/src/registry.rs
@@ -5,11 +5,7 @@ use pyo3::Bound;
 use pyo3::PyResult;
 use pyo3::Python;
 use pyo3::prelude::*;
-use vortex::array::session::ArraySessionExt;
-use vortex::array::vtable::ArrayVTableExt;
 
-use crate::SESSION;
-use crate::arrays::py::PythonVTable;
 use crate::install_module;
 
 /// Register serde functions and classes.
@@ -18,17 +14,18 @@ pub(crate) fn init(py: Python, parent: &Bound<PyModule>) -> PyResult<()> {
     parent.add_submodule(&m)?;
     install_module("vortex._lib.registry", &m)?;
 
-    m.add_function(wrap_pyfunction!(register, &m)?)?;
+    // m.add_function(wrap_pyfunction!(register, &m)?)?;
 
     Ok(())
 }
 
-/// Register an array encoding implemented by subclassing `PyArray`.
-///
-/// It's not currently possible to register a layout encoding from Python.
-#[pyfunction]
-pub(crate) fn register(cls: PythonVTable) -> PyResult<()> {
-    let vtable = ArrayVTableExt::into_vtable(cls);
-    SESSION.arrays().register(vtable);
-    Ok(())
-}
+// TODO(ngates): add a session builder to the Python API.
+// /// Register an array encoding implemented by subclassing `PyArray`.
+// ///
+// /// It's not currently possible to register a layout encoding from Python.
+// #[pyfunction]
+// pub(crate) fn register(cls: PythonVTable) -> PyResult<()> {
+//     let vtable = ArrayVTableExt::into_vtable(cls);
+//     SESSION.arrays().register(vtable);
+//     Ok(())
+// }

--- a/vortex-python/test/test_pyarray.py
+++ b/vortex-python/test/test_pyarray.py
@@ -35,23 +35,21 @@ class PCodecArray(vx.PyArray):
         return self._dtype
 
     def __init__(
-            self,
-            length: int,
-            dtype: vx.DType,
-            file_header: memoryview,
-            chunk_header: memoryview,
-            data: memoryview,
+        self,
+        length: int,
+        dtype: vx.DType,
+        file_header: memoryview,
+        chunk_header: memoryview,
+        data: memoryview,
     ):
-        (fd, _bytes_read) = pco.FileDecompressor.new(
-            file_header)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+        (fd, _bytes_read) = pco.FileDecompressor.new(file_header)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
 
         if dtype == vx.int_(64, nullable=True):
             dt = "i64"
         else:
             raise ValueError(f"Unsupported dtype: {dtype}")
 
-        (cd, _bytes_read) = fd.read_chunk_meta(chunk_header,
-                                               dt)  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+        (cd, _bytes_read) = fd.read_chunk_meta(chunk_header, dt)  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
 
         dst = np.array([0] * length, dtype=np.int64)
         cd.read_page_into(  # pyright: ignore[reportUnknownMemberType]
@@ -67,8 +65,7 @@ class PCodecArray(vx.PyArray):
         self._data = data
 
     @classmethod
-    def encode(cls, array: pa.Array[pa.Scalar[pa.DataType]],
-               config: ChunkConfig | None = None) -> PCodecArray:  # pyright: ignore[reportUnknownParameterType]
+    def encode(cls, array: pa.Array[pa.Scalar[pa.DataType]], config: ChunkConfig | None = None) -> PCodecArray:  # pyright: ignore[reportUnknownParameterType]
         assert array.null_count == 0, "Cannot compress arrays with nulls"
 
         config = config or ChunkConfig()  # pyright: ignore[reportUnknownVariableType]
@@ -76,13 +73,11 @@ class PCodecArray(vx.PyArray):
         fc = pco.FileCompressor()  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
         file_header = fc.write_header()  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
 
-        cc = fc.chunk_compressor(array.to_numpy(),
-                                 config)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+        cc = fc.chunk_compressor(array.to_numpy(), config)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
         chunk_header = cc.write_chunk_meta()  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
 
         data = b""
-        for i, _n in enumerate(
-                cc.n_per_page()):  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType, reportUnknownVariableType]
+        for i, _n in enumerate(cc.n_per_page()):  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType, reportUnknownVariableType]
             data += cc.write_page(i)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
 
         return PCodecArray(

--- a/vortex-python/test/test_pyarray.py
+++ b/vortex-python/test/test_pyarray.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import final
-
 import numpy as np
 import pyarrow as pa
 import pytest
@@ -14,6 +12,7 @@ from pcodec import (  # pyright: ignore[reportMissingTypeStubs]
 from pcodec import (  # pyright: ignore[reportMissingTypeStubs]
     wrapped as pco,  # pyright: ignore[reportAttributeAccessIssue, reportUnknownVariableType]
 )
+from typing import final
 from typing_extensions import override
 
 import vortex as vx
@@ -36,21 +35,23 @@ class PCodecArray(vx.PyArray):
         return self._dtype
 
     def __init__(
-        self,
-        length: int,
-        dtype: vx.DType,
-        file_header: memoryview,
-        chunk_header: memoryview,
-        data: memoryview,
+            self,
+            length: int,
+            dtype: vx.DType,
+            file_header: memoryview,
+            chunk_header: memoryview,
+            data: memoryview,
     ):
-        (fd, _bytes_read) = pco.FileDecompressor.new(file_header)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+        (fd, _bytes_read) = pco.FileDecompressor.new(
+            file_header)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
 
         if dtype == vx.int_(64, nullable=True):
             dt = "i64"
         else:
             raise ValueError(f"Unsupported dtype: {dtype}")
 
-        (cd, _bytes_read) = fd.read_chunk_meta(chunk_header, dt)  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+        (cd, _bytes_read) = fd.read_chunk_meta(chunk_header,
+                                               dt)  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
 
         dst = np.array([0] * length, dtype=np.int64)
         cd.read_page_into(  # pyright: ignore[reportUnknownMemberType]
@@ -66,7 +67,8 @@ class PCodecArray(vx.PyArray):
         self._data = data
 
     @classmethod
-    def encode(cls, array: pa.Array[pa.Scalar[pa.DataType]], config: ChunkConfig | None = None) -> PCodecArray:  # pyright: ignore[reportUnknownParameterType]
+    def encode(cls, array: pa.Array[pa.Scalar[pa.DataType]],
+               config: ChunkConfig | None = None) -> PCodecArray:  # pyright: ignore[reportUnknownParameterType]
         assert array.null_count == 0, "Cannot compress arrays with nulls"
 
         config = config or ChunkConfig()  # pyright: ignore[reportUnknownVariableType]
@@ -74,11 +76,13 @@ class PCodecArray(vx.PyArray):
         fc = pco.FileCompressor()  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
         file_header = fc.write_header()  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
 
-        cc = fc.chunk_compressor(array.to_numpy(), config)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+        cc = fc.chunk_compressor(array.to_numpy(),
+                                 config)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
         chunk_header = cc.write_chunk_meta()  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
 
         data = b""
-        for i, _n in enumerate(cc.n_per_page()):  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType, reportUnknownVariableType]
+        for i, _n in enumerate(
+                cc.n_per_page()):  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType, reportUnknownVariableType]
             data += cc.write_page(i)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
 
         return PCodecArray(
@@ -101,4 +105,4 @@ class PCodecArray(vx.PyArray):
 def test_pcodec():
     _ = PCodecArray.encode(pa.array([0, 1, 2, 3, 4]))  # pyright: ignore[reportUnknownMemberType]
 
-    vx.registry.register(PCodecArray)
+    # vx.registry.register(PCodecArray)

--- a/vortex-python/test/test_pyarray.py
+++ b/vortex-python/test/test_pyarray.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from typing import final
+
 import numpy as np
 import pyarrow as pa
 import pytest
@@ -12,7 +14,6 @@ from pcodec import (  # pyright: ignore[reportMissingTypeStubs]
 from pcodec import (  # pyright: ignore[reportMissingTypeStubs]
     wrapped as pco,  # pyright: ignore[reportAttributeAccessIssue, reportUnknownVariableType]
 )
-from typing import final
 from typing_extensions import override
 
 import vortex as vx

--- a/vortex-scan/src/gpu/gpubuilder.rs
+++ b/vortex-scan/src/gpu/gpubuilder.rs
@@ -14,21 +14,21 @@ use vortex_gpu::GpuVector;
 use vortex_io::runtime::BlockingRuntime;
 use vortex_io::session::RuntimeSessionExt;
 use vortex_layout::gpu::GpuLayoutReaderRef;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 use crate::gpu::GpuScan;
 use crate::gpu::gputask::TaskFuture;
 use crate::scan_builder::filter_and_projection_masks;
 
 pub struct GpuScanBuilder<A> {
-    session: VortexSession,
+    session: VortexSessionRef,
     layout_reader: GpuLayoutReaderRef,
     projection: Expression,
     map_fn: Arc<dyn Fn(Vec<GpuVector>) -> VortexResult<Vec<A>> + Send + Sync>,
 }
 
 impl GpuScanBuilder<GpuVector> {
-    pub fn new(session: VortexSession, layout_reader: GpuLayoutReaderRef) -> Self {
+    pub fn new(session: VortexSessionRef, layout_reader: GpuLayoutReaderRef) -> Self {
         Self {
             session,
             layout_reader,

--- a/vortex-scan/src/repeated_scan.rs
+++ b/vortex-scan/src/repeated_scan.rs
@@ -21,7 +21,7 @@ use vortex_error::VortexResult;
 use vortex_io::runtime::BlockingRuntime;
 use vortex_io::session::RuntimeSessionExt;
 use vortex_layout::LayoutReaderRef;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 use crate::filter::FilterExpr;
 use crate::selection::Selection;
@@ -34,7 +34,7 @@ use crate::tasks::split_exec;
 /// The method of this struct enable, possibly concurrent, scanning of multiple row ranges of this
 /// data source.
 pub struct RepeatedScan<A: 'static + Send> {
-    session: VortexSession,
+    session: VortexSessionRef,
     layout_reader: LayoutReaderRef,
     projection: Expression,
     filter: Option<Expression>,
@@ -84,7 +84,7 @@ impl<A: 'static + Send> RepeatedScan<A> {
         reason = "all arguments are needed for scan construction"
     )]
     pub(super) fn new(
-        session: VortexSession,
+        session: VortexSessionRef,
         layout_reader: LayoutReaderRef,
         projection: Expression,
         filter: Option<Expression>,

--- a/vortex-scan/src/scan_builder.rs
+++ b/vortex-scan/src/scan_builder.rs
@@ -31,7 +31,7 @@ use vortex_layout::LayoutReader;
 use vortex_layout::LayoutReaderRef;
 use vortex_layout::layouts::row_idx::RowIdxLayoutReader;
 use vortex_metrics::VortexMetrics;
-use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 use crate::RepeatedScan;
 use crate::selection::Selection;
@@ -42,7 +42,7 @@ use crate::splits::attempt_split_ranges;
 /// A struct for building a scan operation.
 pub struct ScanBuilder<A> {
     expr_optimizer: ExprOptimizer,
-    session: VortexSession,
+    session: VortexSessionRef,
     layout_reader: LayoutReaderRef,
     projection: Expression,
     filter: Option<Expression>,
@@ -70,8 +70,8 @@ pub struct ScanBuilder<A> {
 }
 
 impl ScanBuilder<ArrayRef> {
-    pub fn new(session: VortexSession, layout_reader: Arc<dyn LayoutReader>) -> Self {
-        let expr_optimizer = ExprOptimizer::new(&session.expressions());
+    pub fn new(session: VortexSessionRef, layout_reader: Arc<dyn LayoutReader>) -> Self {
+        let expr_optimizer = ExprOptimizer::new(session.expressions());
         Self {
             expr_optimizer,
             session,

--- a/vortex-scan/src/test.rs
+++ b/vortex-scan/src/test.rs
@@ -9,12 +9,14 @@ use vortex_io::session::RuntimeSession;
 use vortex_layout::session::LayoutSession;
 use vortex_metrics::VortexMetrics;
 use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
-pub static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
+pub static SESSION: LazyLock<VortexSessionRef> = LazyLock::new(|| {
     VortexSession::empty()
         .with::<VortexMetrics>()
         .with::<ArraySession>()
         .with::<LayoutSession>()
         .with::<ExprSession>()
         .with::<RuntimeSession>()
+        .freeze()
 });

--- a/vortex-session/src/lib.rs
+++ b/vortex-session/src/lib.rs
@@ -65,9 +65,11 @@ impl VortexSession {
     ///
     /// Note that the returned value internally holds a lock on the variable.
     pub fn get_mut<V: SessionVar + Default>(&mut self) -> &mut V {
-        self.0
+        let v = self
+            .0
             .entry(TypeId::of::<V>())
-            .or_insert_with(|| Box::new(V::default()))
+            .or_insert_with(|| Box::new(V::default()));
+        (**v)
             .as_any_mut()
             .downcast_mut::<V>()
             .vortex_expect("Type mismatch - this is a bug")

--- a/vortex-session/src/lib.rs
+++ b/vortex-session/src/lib.rs
@@ -13,17 +13,20 @@ use std::ops::Deref;
 use std::ops::DerefMut;
 use std::sync::Arc;
 
-use dashmap::DashMap;
-use dashmap::Entry;
 use vortex_error::VortexExpect;
+use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
+use vortex_utils::aliases::hash_map::Entry;
+use vortex_utils::aliases::hash_map::HashMap;
+
+pub type VortexSessionRef = Arc<VortexSession>;
 
 /// A Vortex session encapsulates the set of extensible arrays, layouts, compute functions, dtypes,
 /// etc. that are available for use in a given context.
 ///
 /// It is also the entry-point passed to dynamic libraries to initialize Vortex plugins.
-#[derive(Clone, Debug)]
-pub struct VortexSession(Arc<SessionVars>);
+#[derive(Debug)]
+pub struct VortexSession(SessionVars);
 
 impl VortexSession {
     /// Create a new [`VortexSession`] with no session state.
@@ -33,12 +36,17 @@ impl VortexSession {
         Self(Default::default())
     }
 
+    /// Freeze the session into an Arc for sharing.
+    pub fn freeze(self) -> VortexSessionRef {
+        Arc::new(self)
+    }
+
     /// Inserts a new session variable of type `V` with its default value.
     ///
     /// # Panics
     ///
     /// If a variable of that type already exists.
-    pub fn with<V: SessionVar + Default>(self) -> Self {
+    pub fn with<V: SessionVar + Default>(mut self) -> Self {
         match self.0.entry(TypeId::of::<V>()) {
             Entry::Occupied(_) => {
                 vortex_panic!(
@@ -52,97 +60,62 @@ impl VortexSession {
         }
         self
     }
+
+    /// Returns the mutable scope variable of type `V`, or inserts a default one if it does not exist.
+    ///
+    /// Note that the returned value internally holds a lock on the variable.
+    pub fn get_mut<V: SessionVar + Default>(&mut self) -> &mut V {
+        self.0
+            .entry(TypeId::of::<V>())
+            .or_insert_with(|| Box::new(V::default()))
+            .as_any_mut()
+            .downcast_mut::<V>()
+            .vortex_expect("Type mismatch - this is a bug")
+    }
 }
 
 /// Trait for accessing and modifying the state of a Vortex session.
 pub trait SessionExt: Sized + private::Sealed {
-    /// Returns the [`VortexSession`].
-    fn session(&self) -> VortexSession;
+    // Returns the [`VortexSessionRef`].
+    // fn session(&self) -> VortexSessionRef;
 
-    /// Returns the scope variable of type `V`, or inserts a default one if it does not exist.
-    fn get<V: SessionVar + Default>(&self) -> Ref<'_, V>;
+    /// Returns the scope variable of type `V`.
+    fn get<V: SessionVar>(&self) -> &V;
 
-    /// Returns the scope variable of type `V` if it exists.
-    fn get_opt<V: SessionVar>(&self) -> Option<Ref<'_, V>>;
+    /// Returns the scope variable of type `V`.
+    fn get_opt<V: SessionVar>(&self) -> Option<&V>;
+}
 
-    /// Returns the scope variable of type `V`, or inserts a default one if it does not exist.
-    ///
-    /// Note that the returned value internally holds a lock on the variable.
-    fn get_mut<V: SessionVar + Default>(&self) -> RefMut<'_, V>;
+impl SessionExt for VortexSession {
+    fn get<V: SessionVar>(&self) -> &V {
+        self.get_opt::<V>()
+            .ok_or_else(|| {
+                vortex_err!(
+                    "Session variable of type {} does not exist",
+                    type_name::<V>()
+                )
+            })
+            .vortex_expect("Session variable missing")
+    }
 
-    /// Returns the scope variable of type `V`, if it exists.
-    ///
-    /// Note that the returned value internally holds a lock on the variable.
-    fn get_mut_opt<V: SessionVar>(&self) -> Option<RefMut<'_, V>>;
+    fn get_opt<V: SessionVar>(&self) -> Option<&V> {
+        self.0.get(&TypeId::of::<V>()).map(|v| {
+            (**v)
+                .as_any()
+                .downcast_ref::<V>()
+                .vortex_expect("Type mismatch - this is a bug")
+        })
+    }
 }
 
 mod private {
     pub trait Sealed {}
     impl Sealed for super::VortexSession {}
-}
-
-impl SessionExt for VortexSession {
-    fn session(&self) -> VortexSession {
-        self.clone()
-    }
-
-    /// Returns the scope variable of type `V`, or inserts a default one if it does not exist.
-    fn get<V: SessionVar + Default>(&self) -> Ref<'_, V> {
-        Ref(self
-            .0
-            .entry(TypeId::of::<V>())
-            .or_insert_with(|| Box::new(V::default()))
-            .downgrade()
-            .map(|v| {
-                (**v)
-                    .as_any()
-                    .downcast_ref::<V>()
-                    .vortex_expect("Type mismatch - this is a bug")
-            }))
-    }
-
-    fn get_opt<V: SessionVar>(&self) -> Option<Ref<'_, V>> {
-        self.0.get(&TypeId::of::<V>()).map(|v| {
-            Ref(v.map(|v| {
-                (**v)
-                    .as_any()
-                    .downcast_ref::<V>()
-                    .vortex_expect("Type mismatch - this is a bug")
-            }))
-        })
-    }
-
-    /// Returns the scope variable of type `V`, or inserts a default one if it does not exist.
-    ///
-    /// Note that the returned value internally holds a lock on the variable.
-    fn get_mut<V: SessionVar + Default>(&self) -> RefMut<'_, V> {
-        RefMut(
-            self.0
-                .entry(TypeId::of::<V>())
-                .or_insert_with(|| Box::new(V::default()))
-                .map(|v| {
-                    (**v)
-                        .as_any_mut()
-                        .downcast_mut::<V>()
-                        .vortex_expect("Type mismatch - this is a bug")
-                }),
-        )
-    }
-
-    fn get_mut_opt<V: SessionVar>(&self) -> Option<RefMut<'_, V>> {
-        self.0.get_mut(&TypeId::of::<V>()).map(|v| {
-            RefMut(v.map(|v| {
-                (**v)
-                    .as_any_mut()
-                    .downcast_mut::<V>()
-                    .vortex_expect("Type mismatch - this is a bug")
-            }))
-        })
-    }
+    impl Sealed for super::VortexSessionRef {}
 }
 
 /// A TypeMap based on `https://docs.rs/http/1.2.0/src/http/extensions.rs.html#41-266`.
-type SessionVars = DashMap<TypeId, Box<dyn SessionVar>, BuildHasherDefault<IdHasher>>;
+type SessionVars = HashMap<TypeId, Box<dyn SessionVar>, BuildHasherDefault<IdHasher>>;
 
 /// With TypeIds as keys, there's no need to hash them. They are already hashes
 /// themselves, coming from the compiler. The IdHasher just holds the u64 of

--- a/vortex-session/src/registry.rs
+++ b/vortex-session/src/registry.rs
@@ -6,14 +6,13 @@
 
 use std::fmt::Display;
 use std::ops::Deref;
-use std::sync::Arc;
 
-use vortex_utils::aliases::dash_map::DashMap;
+use vortex_utils::aliases::hash_map::HashMap;
 
 /// A registry of items that are keyed by a string identifier.
 // TODO(ngates): define a RegistryItem trait that has a custom key to avoid to_string calls.
 #[derive(Clone, Debug)]
-pub struct Registry<T>(Arc<DashMap<String, T>>);
+pub struct Registry<T>(HashMap<String, T>);
 
 impl<T> Default for Registry<T> {
     fn default() -> Self {
@@ -28,7 +27,7 @@ impl<T: Clone + Display + Eq> Registry<T> {
 
     /// List the items in the registry.
     pub fn items(&self) -> impl Iterator<Item = T> + '_ {
-        self.0.iter().map(|i| i.value().clone())
+        self.0.iter().map(|(_key, item)| item.clone())
     }
 
     /// Return the items with the given IDs.
@@ -41,16 +40,16 @@ impl<T: Clone + Display + Eq> Registry<T> {
 
     /// Find the item with the given ID.
     pub fn find(&self, id: &str) -> Option<T> {
-        self.0.get(id).as_deref().cloned()
+        self.0.get(id).cloned()
     }
 
     /// Register a new item, replacing any existing item with the same ID.
-    pub fn register(&self, item: T) {
+    pub fn register(&mut self, item: T) {
         self.0.insert(item.to_string(), item);
     }
 
     /// Register a new item, replacing any existing item with the same ID.
-    pub fn register_many<I: IntoIterator<Item = T>>(&self, items: I) {
+    pub fn register_many<I: IntoIterator<Item = T>>(&mut self, items: I) {
         for item in items {
             self.0.insert(item.to_string(), item);
         }

--- a/vortex-tui/src/main.rs
+++ b/vortex-tui/src/main.rs
@@ -17,8 +17,9 @@ use tree::TreeArgs;
 use tree::exec_tree;
 use vortex::VortexSessionDefault;
 use vortex::error::VortexExpect;
-use vortex::io::session::RuntimeSessionExt;
+use vortex::io::session::RuntimeSessionMutExt;
 use vortex::session::VortexSession;
+use vortex::session::VortexSessionRef;
 
 use crate::inspect::InspectArgs;
 
@@ -55,8 +56,8 @@ impl Commands {
     }
 }
 
-pub(crate) static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::default().with_tokio());
+pub(crate) static SESSION: LazyLock<VortexSessionRef> =
+    LazyLock::new(|| VortexSession::new_with_defaults().with_tokio().freeze());
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/vortex/examples/tracing_vortex.rs
+++ b/vortex/examples/tracing_vortex.rs
@@ -46,6 +46,7 @@ use vortex_array::stream::ArrayStreamExt;
 use vortex_file::OpenOptionsSessionExt;
 use vortex_file::WriteOptionsSessionExt;
 use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -189,7 +190,7 @@ impl ShutdownSignal {
 
 impl VortexLayer {
     async fn new(
-        session: VortexSession,
+        session: VortexSessionRef,
         output_dir: PathBuf,
         batch_size: usize,
     ) -> (Self, WriterHandle, ShutdownSignal) {
@@ -273,7 +274,7 @@ struct WriterHandle {
 
 impl WriterHandle {
     fn spawn(
-        session: VortexSession,
+        session: VortexSessionRef,
         mut rx: mpsc::UnboundedReceiver<TraceEvent>,
         output_dir: PathBuf,
         batch_size: usize,
@@ -310,7 +311,7 @@ impl WriterHandle {
 
 /// Writes a batch of events to a Vortex file
 async fn write_batch_to_vortex(
-    session: VortexSession,
+    session: VortexSessionRef,
     output_dir: &Path,
     events: &[TraceEvent],
     file_index: usize,
@@ -409,7 +410,7 @@ async fn write_batch_to_vortex(
 
 /// Reads and displays trace files
 async fn read_trace_files(
-    session: &VortexSession,
+    session: &VortexSessionRef,
     output_dir: &Path,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut entries = tokio::fs::read_dir(output_dir).await?;

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -15,6 +15,7 @@ use vortex_io::session::RuntimeSession;
 use vortex_layout::session::LayoutSession;
 use vortex_metrics::VortexMetrics;
 use vortex_session::VortexSession;
+use vortex_session::VortexSessionRef;
 
 // We re-export like so in order to allow users to search inside subcrates when using the Rust docs.
 
@@ -140,14 +141,24 @@ pub mod encodings {
 }
 
 /// Extension trait to create a default Vortex session.
-pub trait VortexSessionDefault {
+pub trait VortexSessionDefault: Sized {
+    /// Creates a new [`VortexSession`] with defaults enabled.
+    fn new_with_defaults() -> VortexSession;
+
+    /// Enables the standard arrays, layouts, and expressions.
+    fn with_defaults(self) -> VortexSession;
+
     /// Creates a default Vortex session with the standard arrays, layouts, and expressions.
-    fn default() -> VortexSession;
+    fn default() -> VortexSessionRef;
 }
 
 impl VortexSessionDefault for VortexSession {
-    fn default() -> VortexSession {
-        let session = VortexSession::empty()
+    fn new_with_defaults() -> VortexSession {
+        VortexSession::empty().with_defaults()
+    }
+
+    fn with_defaults(self) -> VortexSession {
+        let mut this = self
             .with::<VortexMetrics>()
             .with::<ArraySession>()
             .with::<LayoutSession>()
@@ -155,9 +166,13 @@ impl VortexSessionDefault for VortexSession {
             .with::<RuntimeSession>();
 
         #[cfg(feature = "files")]
-        file::register_default_encodings(&session);
+        file::register_default_encodings(&mut this);
 
-        session
+        this
+    }
+
+    fn default() -> VortexSessionRef {
+        VortexSession::empty().with_defaults().freeze()
     }
 }
 
@@ -183,9 +198,9 @@ mod test {
     use vortex_file::WriteOptionsSessionExt;
     use vortex_file::WriteStrategyBuilder;
     use vortex_layout::layouts::compact::CompactCompressor;
-    use vortex_session::VortexSession;
 
     use crate as vortex;
+    use crate::VortexSession;
     use crate::VortexSessionDefault;
 
     #[test]

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -157,6 +157,7 @@ impl VortexSessionDefault for VortexSession {
         VortexSession::empty().with_defaults()
     }
 
+    #[allow(unused_mut)]
     fn with_defaults(self) -> VortexSession {
         let mut this = self
             .with::<VortexMetrics>()


### PR DESCRIPTION
The current session does get_or_insert semantics, which takes a lock on the entry in the dashmap and causes contention.

We could either:
* Panic / return option.
* Make everything immutable HashMap after startup.

This PR explores the second option. Let's see what performance impact it has.