### PR TITLE
Feature: implement `DictArray` batched execute

### DIFF
--- a/vortex-array/src/arrays/dict/vtable/mod.rs
+++ b/vortex-array/src/arrays/dict/vtable/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_buffer::BufferHandle;
+use vortex_compute::take::Take;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_dtype::PType;
@@ -16,6 +17,9 @@ use crate::ArrayRef;
 use crate::DeserializeMetadata;
 use crate::ProstMetadata;
 use crate::SerializeMetadata;
+use crate::kernel::BindCtx;
+use crate::kernel::KernelRef;
+use crate::kernel::kernel;
 use crate::serde::ArrayChildren;
 use crate::vtable;
 use crate::vtable::ArrayId;
@@ -123,5 +127,17 @@ impl VTable for DictVTable {
         array.codes = codes;
         array.values = values;
         Ok(())
+    }
+
+    fn bind_kernel(array: &Self::Array, ctx: &mut BindCtx) -> VortexResult<KernelRef> {
+        let values_kernel = array.values().bind_kernel(ctx)?;
+        let codes_kernel = array.codes().bind_kernel(ctx)?;
+
+        Ok(kernel(move || {
+            let values = values_kernel.execute()?;
+            let codes = codes_kernel.execute()?.into_primitive();
+
+            Ok(values.take(&codes))
+        }))
     }
 }


### PR DESCRIPTION
Tracking Issue: https://github.com/vortex-data/vortex/issues/5652

Adds batched execution to `DictArray`, which is just implemented as `take` on the child `values` vector with the codes as indices.

~~Additionally adds an optimization for `BoolVector::take` which is similar to the optimization we have for `BoolArray`'s `canonicalize` function, but does an additional check for zero or one `false`s (instead of just zero or one `true`s). That code is located at https://github.com/vortex-data/vortex/blob/develop/vortex-array/src/arrays/dict/vtable/canonical.rs.~~

~~The difference here is that I use a heuristic check on the default `take` implementation on `BoolVector` (instead of only use this optimization for dictionary decompression) because I don't think there is any reason not to utilize this in general.~~

~~I still need to add some benchmarks.~~

Also note that we don't need to specialize for the string types like in https://github.com/vortex-data/vortex/pull/1146 since we are _always_ decompressing the children immediately.