### PR TITLE
Chore: use `is_null` instead of `is_invalid` for scalars

### DIFF
--- a/vortex-array/src/expr/exprs/is_null.rs
+++ b/vortex-array/src/expr/exprs/is_null.rs
@@ -94,7 +94,7 @@ impl VTable for IsNull {
     fn execute(&self, _data: &Self::Options, mut args: ExecutionArgs) -> VortexResult<Datum> {
         let child = args.datums.pop().vortex_expect("Missing input child");
         Ok(match child {
-            Datum::Scalar(s) => Datum::Scalar(BoolScalar::new(Some(s.is_invalid())).into()),
+            Datum::Scalar(s) => Datum::Scalar(BoolScalar::new(Some(s.is_null())).into()),
             Datum::Vector(v) => Datum::Vector(
                 BoolVector::new(v.validity().to_bit_buffer().not(), Mask::new_true(v.len())).into(),
             ),

--- a/vortex-vector/src/lib.rs
+++ b/vortex-vector/src/lib.rs
@@ -118,7 +118,7 @@ pub fn vector_matches_dtype(vector: &Vector, dtype: &DType) -> bool {
 
 /// Returns true if the scalar's is compatible with the provided data type.
 pub fn scalar_matches_dtype(scalar: &Scalar, dtype: &DType) -> bool {
-    if !dtype.is_nullable() && scalar.is_invalid() {
+    if !dtype.is_nullable() && scalar.is_null() {
         // Non-nullable dtype cannot have nulls in the scalar.
         return false;
     }

--- a/vortex-vector/src/listview/vector_mut.rs
+++ b/vortex-vector/src/listview/vector_mut.rs
@@ -411,7 +411,7 @@ impl VectorMutOps for ListViewVectorMut {
     }
 
     fn append_scalars(&mut self, scalar: &ListViewScalar, n: usize) {
-        if scalar.is_invalid() {
+        if scalar.is_null() {
             self.append_nulls(n);
             return;
         }

--- a/vortex-vector/src/scalar.rs
+++ b/vortex-vector/src/scalar.rs
@@ -44,10 +44,6 @@ impl ScalarOps for Scalar {
         match_each_scalar!(self, |v| { v.is_valid() })
     }
 
-    fn is_invalid(&self) -> bool {
-        !self.is_valid()
-    }
-
     fn mask_validity(&mut self, mask: bool) {
         match_each_scalar!(self, |v| { v.mask_validity(mask) })
     }

--- a/vortex-vector/src/scalar_ops.rs
+++ b/vortex-vector/src/scalar_ops.rs
@@ -11,7 +11,7 @@ pub trait ScalarOps: private::Sealed + Sized + Into<Scalar> {
     fn is_valid(&self) -> bool;
 
     /// Returns true if the scalar is null.
-    fn is_invalid(&self) -> bool {
+    fn is_null(&self) -> bool {
         !self.is_valid()
     }
 


### PR DESCRIPTION
I promise there's a reason for this

Edit: https://github.com/vortex-data/vortex/pull/5705