### PR TITLE
Feature: add some `Cast` infrastructure

### DIFF
--- a/vortex-compute/src/cast/binaryview.rs
+++ b/vortex-compute/src/cast/binaryview.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_vector::Scalar;
+use vortex_vector::ScalarOps;
+use vortex_vector::Vector;
+use vortex_vector::VectorOps;
+use vortex_vector::binaryview::BinaryViewScalar;
+use vortex_vector::binaryview::BinaryViewType;
+use vortex_vector::binaryview::BinaryViewVector;
+
+use crate::cast::Cast;
+use crate::cast::try_cast_scalar_common;
+use crate::cast::try_cast_vector_common;
+
+impl<T: BinaryViewType> Cast for BinaryViewVector<T> {
+    type Output = Vector;
+
+    /// Casts to Utf8 or Binary (identity cast with compatible nullability).
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Vector> {
+        if let Some(result) = try_cast_vector_common(self, target_dtype)? {
+            return Ok(result);
+        }
+
+        match target_dtype {
+            // Identity cast: same type with compatible nullability.
+            dt if T::matches_dtype(dt) && (dt.is_nullable() || self.validity().all_true()) => {
+                Ok(self.clone().into())
+            }
+            // Cross-cast between Utf8 and Binary is not supported.
+            DType::Utf8(_) | DType::Binary(_) => {
+                vortex_bail!(
+                    "Cannot cast BinaryViewVector to {} (cross-cast not supported)",
+                    target_dtype
+                );
+            }
+            _ => {
+                vortex_bail!("Cannot cast BinaryViewVector to {}", target_dtype);
+            }
+        }
+    }
+}
+
+impl<T: BinaryViewType> Cast for BinaryViewScalar<T> {
+    type Output = Scalar;
+
+    /// Casts to Utf8 or Binary (identity cast with compatible nullability).
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Scalar> {
+        if let Some(result) = try_cast_scalar_common(self, target_dtype)? {
+            return Ok(result);
+        }
+
+        match target_dtype {
+            // Identity cast: same type with compatible nullability.
+            dt if T::matches_dtype(dt) && (dt.is_nullable() || self.is_valid()) => {
+                Ok(self.clone().into())
+            }
+            // Cross-cast between Utf8 and Binary is not supported.
+            DType::Utf8(_) | DType::Binary(_) => {
+                vortex_bail!(
+                    "Cannot cast BinaryViewScalar to {} (cross-cast not supported)",
+                    target_dtype
+                );
+            }
+            _ => {
+                vortex_bail!("Cannot cast BinaryViewScalar to {}", target_dtype);
+            }
+        }
+    }
+}

--- a/vortex-compute/src/cast/bool.rs
+++ b/vortex-compute/src/cast/bool.rs
@@ -8,29 +8,33 @@ use vortex_dtype::DType;
 use vortex_dtype::match_each_native_ptype;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_vector::Scalar;
+use vortex_vector::ScalarOps;
 use vortex_vector::Vector;
 use vortex_vector::VectorOps;
+use vortex_vector::bool::BoolScalar;
 use vortex_vector::bool::BoolVector;
-use vortex_vector::null::NullVector;
+use vortex_vector::primitive::PScalar;
 use vortex_vector::primitive::PVector;
 
 use crate::cast::Cast;
+use crate::cast::try_cast_scalar_common;
+use crate::cast::try_cast_vector_common;
 
 impl Cast for BoolVector {
     type Output = Vector;
 
-    fn cast(&self, dtype: &DType) -> VortexResult<Vector> {
-        match dtype {
-            DType::Null if self.validity().all_false() => {
-                // Can cast an all-null BoolVector to NullVector.
-                Ok(NullVector::new(self.len()).into())
-            }
+    /// Casts to Bool (identity) or Primitive (as 0/1).
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Vector> {
+        if let Some(result) = try_cast_vector_common(self, target_dtype)? {
+            return Ok(result);
+        }
+
+        match target_dtype {
             DType::Bool(n) if n.is_nullable() || self.validity().all_true() => {
-                // If the target dtype is nullable, or if the source BoolVector has no nulls,
-                // we can cast directly to BoolVector.
                 Ok(self.clone().into())
             }
-            DType::Primitive(ptype, _) => {
+            DType::Primitive(ptype, n) if n.is_nullable() || self.validity().all_true() => {
                 match_each_native_ptype!(ptype, |T| {
                     Ok(PVector::<T>::new(
                         Buffer::<T>::from_trusted_len_iter(
@@ -43,9 +47,31 @@ impl Cast for BoolVector {
                     .into())
                 })
             }
-            DType::Extension(ext_dtype) => self.cast(ext_dtype.storage_dtype()),
             _ => {
-                vortex_bail!("Cannot cast BoolVector to type {}", dtype);
+                vortex_bail!("Cannot cast BoolVector to {}", target_dtype);
+            }
+        }
+    }
+}
+
+impl Cast for BoolScalar {
+    type Output = Scalar;
+
+    /// Casts to Bool (identity) or Primitive (as 0/1).
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Scalar> {
+        if let Some(result) = try_cast_scalar_common(self, target_dtype)? {
+            return Ok(result);
+        }
+        match target_dtype {
+            DType::Bool(n) if n.is_nullable() || self.is_valid() => Ok(self.clone().into()),
+            DType::Primitive(ptype, n) if n.is_nullable() || self.is_valid() => {
+                match_each_native_ptype!(ptype, |T| {
+                    let value = self.value().map(|b| if b { T::one() } else { T::zero() });
+                    Ok(PScalar::<T>::new(value).into())
+                })
+            }
+            _ => {
+                vortex_bail!("Cannot cast BoolScalar to {}", target_dtype);
             }
         }
     }

--- a/vortex-compute/src/cast/decimal.rs
+++ b/vortex-compute/src/cast/decimal.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+use vortex_vector::Scalar;
+use vortex_vector::Vector;
+use vortex_vector::decimal::DecimalScalar;
+use vortex_vector::decimal::DecimalVector;
+use vortex_vector::match_each_dscalar;
+use vortex_vector::match_each_dvector;
+
+use crate::cast::Cast;
+
+impl Cast for DecimalVector {
+    type Output = Vector;
+
+    /// Dispatches to the underlying [`DVector<D>`](vortex_vector::decimal::DVector) implementation.
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Vector> {
+        match_each_dvector!(self, |v| { Cast::cast(v, target_dtype) })
+    }
+}
+
+impl Cast for DecimalScalar {
+    type Output = Scalar;
+
+    /// Dispatches to the underlying [`DScalar<D>`](vortex_vector::decimal::DScalar) implementation.
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Scalar> {
+        match_each_dscalar!(self, |s| { Cast::cast(s, target_dtype) })
+    }
+}

--- a/vortex-compute/src/cast/dvector.rs
+++ b/vortex-compute/src/cast/dvector.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::DType;
+use vortex_dtype::NativeDecimalType;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_vector::Scalar;
+use vortex_vector::ScalarOps;
+use vortex_vector::Vector;
+use vortex_vector::VectorOps;
+use vortex_vector::decimal::DScalar;
+use vortex_vector::decimal::DVector;
+
+use crate::cast::Cast;
+use crate::cast::try_cast_scalar_common;
+use crate::cast::try_cast_vector_common;
+
+impl<D: NativeDecimalType> Cast for DVector<D> {
+    type Output = Vector;
+
+    /// Casts to Decimal (identity with same precision/scale and compatible nullability).
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Vector> {
+        if let Some(result) = try_cast_vector_common(self, target_dtype)? {
+            return Ok(result);
+        }
+
+        match target_dtype {
+            // Identity cast: same precision, scale, and compatible nullability.
+            DType::Decimal(ddt, n)
+                if ddt.precision() == self.precision()
+                    && ddt.scale() == self.scale()
+                    && (n.is_nullable() || self.validity().all_true()) =>
+            {
+                Ok(self.clone().into())
+            }
+            // TODO(connor): cast to different precision/scale
+            DType::Decimal(..) => {
+                vortex_bail!(
+                    "Casting DVector to {} with different precision/scale not yet implemented",
+                    target_dtype
+                );
+            }
+            _ => {
+                vortex_bail!("Cannot cast DVector to {}", target_dtype);
+            }
+        }
+    }
+}
+
+impl<D: NativeDecimalType> Cast for DScalar<D> {
+    type Output = Scalar;
+
+    /// Casts to Decimal (identity with same precision/scale and compatible nullability).
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Scalar> {
+        if let Some(result) = try_cast_scalar_common(self, target_dtype)? {
+            return Ok(result);
+        }
+
+        match target_dtype {
+            // Identity cast: same precision, scale, and compatible nullability.
+            DType::Decimal(ddt, n)
+                if ddt.precision() == self.precision()
+                    && ddt.scale() == self.scale()
+                    && (n.is_nullable() || self.is_valid()) =>
+            {
+                Ok(self.clone().into())
+            }
+            // TODO(connor): cast to different precision/scale
+            DType::Decimal(..) => {
+                vortex_bail!(
+                    "Casting DScalar to {} with different precision/scale not yet implemented",
+                    target_dtype
+                );
+            }
+            _ => {
+                vortex_bail!("Cannot cast DScalar to {}", target_dtype);
+            }
+        }
+    }
+}

--- a/vortex-compute/src/cast/fixed_size_list.rs
+++ b/vortex-compute/src/cast/fixed_size_list.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_vector::Scalar;
+use vortex_vector::ScalarOps;
+use vortex_vector::Vector;
+use vortex_vector::VectorOps;
+use vortex_vector::fixed_size_list::FixedSizeListScalar;
+use vortex_vector::fixed_size_list::FixedSizeListVector;
+use vortex_vector::vector_matches_dtype;
+
+use crate::cast::Cast;
+use crate::cast::try_cast_scalar_common;
+use crate::cast::try_cast_vector_common;
+
+impl Cast for FixedSizeListVector {
+    type Output = Vector;
+
+    /// Casts to FixedSizeList (identity with same element dtype, size, and compatible nullability).
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Vector> {
+        if let Some(result) = try_cast_vector_common(self, target_dtype)? {
+            return Ok(result);
+        }
+
+        match target_dtype {
+            // Identity cast: same element dtype, size, and compatible nullability.
+            DType::FixedSizeList(element_dtype, size, n)
+                if *size == self.list_size()
+                    && vector_matches_dtype(self.elements(), element_dtype)
+                    && (n.is_nullable() || self.validity().all_true()) =>
+            {
+                Ok(self.clone().into())
+            }
+            DType::FixedSizeList(..) => {
+                vortex_bail!(
+                    "Cannot cast FixedSizeListVector to {} (incompatible element type or size)",
+                    target_dtype
+                );
+            }
+            _ => {
+                vortex_bail!("Cannot cast FixedSizeListVector to {}", target_dtype);
+            }
+        }
+    }
+}
+
+impl Cast for FixedSizeListScalar {
+    type Output = Scalar;
+
+    /// Casts to FixedSizeList (identity with same element dtype, size, and compatible nullability).
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Scalar> {
+        if let Some(result) = try_cast_scalar_common(self, target_dtype)? {
+            return Ok(result);
+        }
+
+        match target_dtype {
+            // Identity cast: same element dtype, size, and compatible nullability.
+            // We check by verifying the scalar's underlying vector matches the target dtype.
+            DType::FixedSizeList(element_dtype, size, n)
+                if *size == self.value().list_size()
+                    && vector_matches_dtype(self.value().elements(), element_dtype)
+                    && (n.is_nullable() || self.is_valid()) =>
+            {
+                Ok(self.clone().into())
+            }
+            DType::FixedSizeList(..) => {
+                vortex_bail!(
+                    "Cannot cast FixedSizeListScalar to {} (incompatible element type, size, or nullability)",
+                    target_dtype
+                );
+            }
+            _ => {
+                vortex_bail!("Cannot cast FixedSizeListScalar to {}", target_dtype);
+            }
+        }
+    }
+}

--- a/vortex-compute/src/cast/list.rs
+++ b/vortex-compute/src/cast/list.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_vector::Scalar;
+use vortex_vector::ScalarOps;
+use vortex_vector::Vector;
+use vortex_vector::VectorOps;
+use vortex_vector::listview::ListViewScalar;
+use vortex_vector::listview::ListViewVector;
+use vortex_vector::vector_matches_dtype;
+
+use crate::cast::Cast;
+use crate::cast::try_cast_scalar_common;
+use crate::cast::try_cast_vector_common;
+
+impl Cast for ListViewVector {
+    type Output = Vector;
+
+    /// Casts to List (identity with same element dtype and compatible nullability).
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Vector> {
+        if let Some(result) = try_cast_vector_common(self, target_dtype)? {
+            return Ok(result);
+        }
+
+        match target_dtype {
+            // Identity cast: same element dtype and compatible nullability.
+            DType::List(element_dtype, n)
+                if vector_matches_dtype(self.elements(), element_dtype)
+                    && (n.is_nullable() || self.validity().all_true()) =>
+            {
+                Ok(self.clone().into())
+            }
+            DType::List(..) => {
+                vortex_bail!(
+                    "Cannot cast ListViewVector to {} (incompatible element type or nullability)",
+                    target_dtype
+                );
+            }
+            _ => {
+                vortex_bail!("Cannot cast ListViewVector to {}", target_dtype);
+            }
+        }
+    }
+}
+
+impl Cast for ListViewScalar {
+    type Output = Scalar;
+
+    /// Casts to List (identity with same element dtype and compatible nullability).
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Scalar> {
+        if let Some(result) = try_cast_scalar_common(self, target_dtype)? {
+            return Ok(result);
+        }
+
+        match target_dtype {
+            // Identity cast: same element dtype and compatible nullability.
+            DType::List(element_dtype, n)
+                if vector_matches_dtype(self.value().elements(), element_dtype)
+                    && (n.is_nullable() || self.is_valid()) =>
+            {
+                Ok(self.clone().into())
+            }
+            DType::List(..) => {
+                vortex_bail!(
+                    "Cannot cast ListViewScalar to {} (incompatible element type or nullability)",
+                    target_dtype
+                );
+            }
+            _ => {
+                vortex_bail!("Cannot cast ListViewScalar to {}", target_dtype);
+            }
+        }
+    }
+}

--- a/vortex-compute/src/cast/mod.rs
+++ b/vortex-compute/src/cast/mod.rs
@@ -1,35 +1,62 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Lossless casting of Vortex vectors for different logical data types.
+//! Lossless casting of Vortex vectors and scalars for different logical data types.
 
+mod binaryview;
 mod bool;
+mod decimal;
+mod dvector;
+mod fixed_size_list;
+mod list;
 mod null;
+mod primitive;
 mod pvector;
+mod struct_;
 
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
-use vortex_error::vortex_bail;
 use vortex_vector::Datum;
 use vortex_vector::Scalar;
+use vortex_vector::ScalarOps;
 use vortex_vector::Vector;
+use vortex_vector::VectorOps;
+use vortex_vector::match_each_scalar;
+use vortex_vector::match_each_vector;
+use vortex_vector::null::NullScalar;
+use vortex_vector::null::NullVector;
 
-/// Trait for casting vectors to different data types.
+/// Trait for casting vectors and scalars to different data types.
+///
+/// # Nullability Requirements
+///
+/// Casting a source that contains null values to a non-nullable target dtype will return an error.
+/// This invariant is not checked by the common helper functions, so each implementation is
+/// responsible for enforcing it.
+///
+/// # Common Casting Behaviors
+///
+/// All implementations share these behaviors:
+/// - **Identity**: Casting to the same dtype (with compatible nullability) returns a clone.
+/// - **Null casting**: Any all-null vector can be cast to [`DType::Null`], and any null scalar
+///   can be cast to a [`NullScalar`].
+/// - **Extension types**: Casting to an extension type delegates to casting to its storage dtype.
 pub trait Cast {
     /// The output type after casting.
     type Output;
 
-    /// Cast the vector to the specified data type.
-    fn cast(&self, dtype: &DType) -> VortexResult<Self::Output>;
+    /// Cast the vector or scalar to the specified data type.
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Self::Output>;
 }
 
 impl Cast for Datum {
     type Output = Datum;
 
-    fn cast(&self, dtype: &DType) -> VortexResult<Datum> {
+    /// Dispatches to the contained [`Scalar`] or [`Vector`] cast implementation.
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Datum> {
         Ok(match self {
-            Datum::Scalar(scalar) => scalar.cast(dtype)?.into(),
-            Datum::Vector(vector) => vector.cast(dtype)?.into(),
+            Datum::Scalar(scalar) => scalar.cast(target_dtype)?.into(),
+            Datum::Vector(vector) => vector.cast(target_dtype)?.into(),
         })
     }
 }
@@ -37,24 +64,47 @@ impl Cast for Datum {
 impl Cast for Scalar {
     type Output = Scalar;
 
-    fn cast(&self, _dtype: &DType) -> VortexResult<Scalar> {
-        vortex_bail!("Casting not implemented for scalar type {:?}", self);
+    /// Dispatches to the underlying typed scalar implementation.
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Scalar> {
+        match_each_scalar!(self, |s| { Cast::cast(s, target_dtype) })
     }
 }
 
 impl Cast for Vector {
     type Output = Vector;
 
-    fn cast(&self, dtype: &DType) -> VortexResult<Vector> {
-        // Switch to macro once all vector types implement Cast
-        // match_each_vector!(self, |v| { Cast::cast(v, dtype) })
-        match self {
-            Vector::Null(v) => Cast::cast(v, dtype),
-            Vector::Bool(v) => Cast::cast(v, dtype),
-            Vector::Primitive(v) => Cast::cast(v, dtype),
-            _ => {
-                vortex_bail!("Casting not implemented for vector type {:?}", self);
-            }
+    /// Dispatches to the underlying typed vector implementation.
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Vector> {
+        match_each_vector!(self, |v| { Cast::cast(v, target_dtype) })
+    }
+}
+
+/// Handles common vector cast cases: Null (if all-null) and Extension (delegate to storage).
+///
+/// Returns `Ok(Some(...))` if handled, `Err(...)` on error, or `Ok(None)` to fall through.
+pub(crate) fn try_cast_vector_common<V: Cast<Output = Vector> + VectorOps>(
+    vector: &V,
+    target_dtype: &DType,
+) -> VortexResult<Option<Vector>> {
+    match target_dtype {
+        DType::Null if vector.validity().all_false() => {
+            Ok(Some(NullVector::new(vector.len()).into()))
         }
+        DType::Extension(ext_dtype) => vector.cast(ext_dtype.storage_dtype()).map(Some),
+        _ => Ok(None),
+    }
+}
+
+/// Handles common scalar cast cases: Null (if null) and Extension (delegate to storage).
+///
+/// Returns `Ok(Some(...))` if handled, `Err(...)` on error, or `Ok(None)` to fall through.
+pub(crate) fn try_cast_scalar_common<S: Cast<Output = Scalar> + ScalarOps>(
+    scalar: &S,
+    target_dtype: &DType,
+) -> VortexResult<Option<Scalar>> {
+    match target_dtype {
+        DType::Null if !scalar.is_valid() => Ok(Some(NullScalar.into())),
+        DType::Extension(ext_dtype) => scalar.cast(ext_dtype.storage_dtype()).map(Some),
+        _ => Ok(None),
     }
 }

--- a/vortex-compute/src/cast/null.rs
+++ b/vortex-compute/src/cast/null.rs
@@ -4,10 +4,12 @@
 use vortex_dtype::DType;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_vector::Scalar;
 use vortex_vector::Vector;
 use vortex_vector::VectorMut;
 use vortex_vector::VectorMutOps;
 use vortex_vector::VectorOps;
+use vortex_vector::null::NullScalar;
 use vortex_vector::null::NullVector;
 
 use crate::cast::Cast;
@@ -15,14 +17,34 @@ use crate::cast::Cast;
 impl Cast for NullVector {
     type Output = Vector;
 
-    fn cast(&self, dtype: &DType) -> VortexResult<Vector> {
-        if dtype.is_nullable() {
+    /// Casts to any nullable target type by creating an all-null vector.
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Vector> {
+        if target_dtype.is_nullable() {
             // We can create an all-null vector of _any_ type.
-            let mut vec = VectorMut::with_capacity(dtype, self.len());
+            let mut vec = VectorMut::with_capacity(target_dtype, self.len());
             vec.append_nulls(self.len());
             Ok(vec.freeze())
         } else {
-            vortex_bail!("Cannot cast NullVector to non-nullable type {}", dtype);
+            vortex_bail!(
+                "Cannot cast NullVector to non-nullable type {}",
+                target_dtype
+            );
+        }
+    }
+}
+
+impl Cast for NullScalar {
+    type Output = Scalar;
+
+    /// Casts to any nullable target type by creating a null scalar.
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Scalar> {
+        if target_dtype.is_nullable() {
+            Ok(Scalar::null(target_dtype))
+        } else {
+            vortex_bail!(
+                "Cannot cast NullScalar to non-nullable type {}",
+                target_dtype
+            );
         }
     }
 }

--- a/vortex-compute/src/cast/primitive.rs
+++ b/vortex-compute/src/cast/primitive.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+use vortex_vector::Scalar;
+use vortex_vector::Vector;
+use vortex_vector::match_each_pscalar;
+use vortex_vector::match_each_pvector;
+use vortex_vector::primitive::PrimitiveScalar;
+use vortex_vector::primitive::PrimitiveVector;
+
+use crate::cast::Cast;
+
+impl Cast for PrimitiveVector {
+    type Output = Vector;
+
+    /// Dispatches to the underlying [`PVector<T>`](vortex_vector::primitive::PVector)
+    /// implementation.
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Vector> {
+        match_each_pvector!(self, |v| { Cast::cast(v, target_dtype) })
+    }
+}
+
+impl Cast for PrimitiveScalar {
+    type Output = Scalar;
+
+    /// Dispatches to the underlying [`PScalar<T>`](vortex_vector::primitive::PScalar)
+    /// implementation.
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Scalar> {
+        match_each_pscalar!(self, |s| { Cast::cast(s, target_dtype) })
+    }
+}

--- a/vortex-compute/src/cast/pvector.rs
+++ b/vortex-compute/src/cast/pvector.rs
@@ -5,30 +5,27 @@ use vortex_dtype::DType;
 use vortex_dtype::NativePType;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_vector::Scalar;
+use vortex_vector::ScalarOps;
 use vortex_vector::Vector;
 use vortex_vector::VectorOps;
-use vortex_vector::match_each_pvector;
-use vortex_vector::null::NullVector;
+use vortex_vector::primitive::PScalar;
 use vortex_vector::primitive::PVector;
-use vortex_vector::primitive::PrimitiveVector;
 
 use crate::cast::Cast;
-
-impl Cast for PrimitiveVector {
-    type Output = Vector;
-
-    fn cast(&self, dtype: &DType) -> VortexResult<Vector> {
-        match_each_pvector!(self, |v| { Cast::cast(v, dtype) })
-    }
-}
+use crate::cast::try_cast_scalar_common;
+use crate::cast::try_cast_vector_common;
 
 impl<T: NativePType> Cast for PVector<T> {
     type Output = Vector;
 
-    fn cast(&self, dtype: &DType) -> VortexResult<Vector> {
-        match dtype {
-            // Can cast an all-null PVector to NullVector.
-            DType::Null if self.validity().all_false() => Ok(NullVector::new(self.len()).into()),
+    /// Casts to Primitive (same PType identity).
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Vector> {
+        if let Some(result) = try_cast_vector_common(self, target_dtype)? {
+            return Ok(result);
+        }
+
+        match target_dtype {
             // We're already the correct PType, and we have compatible nullability.
             DType::Primitive(target_ptype, n)
                 if *target_ptype == T::PTYPE && (n.is_nullable() || self.validity().all_true()) =>
@@ -38,14 +35,44 @@ impl<T: NativePType> Cast for PVector<T> {
             // We're not the correct PType, but we do have compatible nullability.
             DType::Primitive(target_ptype, n) if n.is_nullable() || self.validity().all_true() => {
                 vortex_bail!(
-                    "Casting from PType {} to PType {} not yet implemented",
+                    "Casting PVector from PType {} to PType {} not yet implemented",
                     T::PTYPE,
                     target_ptype
                 );
             }
-            DType::Extension(ext_dtype) => self.cast(ext_dtype.storage_dtype()),
             _ => {
-                vortex_bail!("Cannot cast {:?} to dtype {}", self, dtype);
+                vortex_bail!("Cannot cast PVector<{}> to {}", T::PTYPE, target_dtype);
+            }
+        }
+    }
+}
+
+impl<T: NativePType> Cast for PScalar<T> {
+    type Output = Scalar;
+
+    /// Casts to Primitive (same PType identity).
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Scalar> {
+        if let Some(result) = try_cast_scalar_common(self, target_dtype)? {
+            return Ok(result);
+        }
+
+        match target_dtype {
+            // We're already the correct PType, and we have compatible nullability.
+            DType::Primitive(target_ptype, n)
+                if *target_ptype == T::PTYPE && (n.is_nullable() || self.is_valid()) =>
+            {
+                Ok(self.clone().into())
+            }
+            // We're not the correct PType, but we do have compatible nullability.
+            DType::Primitive(target_ptype, n) if n.is_nullable() || self.is_valid() => {
+                vortex_bail!(
+                    "Casting PScalar from PType {} to PType {} not yet implemented",
+                    T::PTYPE,
+                    target_ptype
+                );
+            }
+            _ => {
+                vortex_bail!("Cannot cast PScalar<{}> to {}", T::PTYPE, target_dtype);
             }
         }
     }

--- a/vortex-compute/src/cast/struct_.rs
+++ b/vortex-compute/src/cast/struct_.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_dtype::DType;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_vector::Scalar;
+use vortex_vector::ScalarOps;
+use vortex_vector::Vector;
+use vortex_vector::VectorOps;
+use vortex_vector::struct_::StructScalar;
+use vortex_vector::struct_::StructVector;
+use vortex_vector::vector_matches_dtype;
+
+use crate::cast::Cast;
+use crate::cast::try_cast_scalar_common;
+use crate::cast::try_cast_vector_common;
+
+/// Checks if a struct vector's fields match the given struct fields dtype.
+fn struct_fields_match(vector: &StructVector, fields: &vortex_dtype::StructFields) -> bool {
+    if fields.nfields() != vector.fields().len() {
+        return false;
+    }
+    for (field_dtype, field_vector) in fields.fields().zip(vector.fields().iter()) {
+        if !vector_matches_dtype(field_vector, &field_dtype) {
+            return false;
+        }
+    }
+    true
+}
+
+impl Cast for StructVector {
+    type Output = Vector;
+
+    /// Casts to Struct (identity with same fields and compatible nullability).
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Vector> {
+        if let Some(result) = try_cast_vector_common(self, target_dtype)? {
+            return Ok(result);
+        }
+
+        match target_dtype {
+            // Identity cast: same fields and compatible nullability.
+            DType::Struct(fields, n)
+                if struct_fields_match(self, fields)
+                    && (n.is_nullable() || self.validity().all_true()) =>
+            {
+                Ok(self.clone().into())
+            }
+            DType::Struct(..) => {
+                vortex_bail!(
+                    "Cannot cast StructVector to {} (incompatible fields or nullability)",
+                    target_dtype
+                );
+            }
+            _ => {
+                vortex_bail!("Cannot cast StructVector to {}", target_dtype);
+            }
+        }
+    }
+}
+
+impl Cast for StructScalar {
+    type Output = Scalar;
+
+    /// Casts to Struct (identity with same fields and compatible nullability).
+    fn cast(&self, target_dtype: &DType) -> VortexResult<Scalar> {
+        if let Some(result) = try_cast_scalar_common(self, target_dtype)? {
+            return Ok(result);
+        }
+
+        match target_dtype {
+            // Identity cast: same fields and compatible nullability.
+            DType::Struct(fields, n)
+                if struct_fields_match(self.value(), fields)
+                    && (n.is_nullable() || self.is_valid()) =>
+            {
+                Ok(self.clone().into())
+            }
+            DType::Struct(..) => {
+                vortex_bail!(
+                    "Cannot cast StructScalar to {} (incompatible fields or nullability)",
+                    target_dtype
+                );
+            }
+            _ => {
+                vortex_bail!("Cannot cast StructScalar to {}", target_dtype);
+            }
+        }
+    }
+}

--- a/vortex-compute/src/filter/vector/mod.rs
+++ b/vortex-compute/src/filter/vector/mod.rs
@@ -30,6 +30,10 @@
 //! the recursive trait bounds (e.g. from [`StructVector`] requiring `Vector: Filter<M>` for its
 //! fields) by manually implementing [`Filter`] for [`Vector`] and [`VectorMut`] for each concrete
 //! mask type in this file.
+//!
+//! [`VectorOps::try_into_mut`]: vortex_vector::VectorOps::try_into_mut
+//! [`VectorMutOps::freeze`]: vortex_vector::VectorMutOps::freeze
+//! [`StructVector`]: vortex_vector::struct_::StructVector
 
 use vortex_buffer::BitView;
 use vortex_mask::Mask;

--- a/vortex-vector/src/binaryview/types.rs
+++ b/vortex-vector/src/binaryview/types.rs
@@ -27,7 +27,7 @@ impl<T: BinaryViewType> From<BinaryViewVectorMut<T>> for VectorMut {
 }
 
 /// Trait to mark supported binary view types.
-pub trait BinaryViewType: Debug + Sized + Send + Sync + 'static + private::Sealed {
+pub trait BinaryViewType: Clone + Debug + Sized + Send + Sync + 'static + private::Sealed {
     /// The slice type for this variable binary type.
     type Slice: ?Sized + AsRef<[u8]>;
     /// The scalar type for this variable binary type.

--- a/vortex-vector/src/decimal/macros.rs
+++ b/vortex-vector/src/decimal/macros.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Helper macros for working with the different variants of [`DecimalVector`] and
-//! [`DecimalVectorMut`].
+//! Helper macros for working with the different variants of [`DecimalVector`], [`DecimalScalar`],
+//! and [`DecimalVectorMut`].
 //!
 //! [`DecimalVector`]: super::DecimalVector
+//! [`DecimalScalar`]: super::DecimalScalar
 //! [`DecimalVectorMut`]: super::DecimalVectorMut
 
 /// Matches on all decimal type variants of [`DecimalVector`] and executes the same code for
@@ -45,6 +46,30 @@ macro_rules! match_each_dvector_mut {
             $crate::decimal::DecimalVectorMut::D64($vec) => $body,
             $crate::decimal::DecimalVectorMut::D128($vec) => $body,
             $crate::decimal::DecimalVectorMut::D256($vec) => $body,
+        }
+    }};
+}
+
+/// Matches on all decimal type variants of [`DecimalScalar`] and executes the same code for
+/// each variant branch.
+///
+/// This macro eliminates repetitive match statements when implementing operations that need to work
+/// uniformly across all decimal type variants (`D8`, `D16`, `D32`, `D64`, `D128`, `D256`).
+///
+/// Works with both owned `DecimalScalar` and `&DecimalScalar` (the bound variable will be
+/// `DScalar<D>` or `&DScalar<D>` respectively due to Rust's match ergonomics).
+///
+/// [`DecimalScalar`]: super::DecimalScalar
+#[macro_export]
+macro_rules! match_each_dscalar {
+    ($self:expr, | $scalar:ident | $body:block) => {{
+        match $self {
+            $crate::decimal::DecimalScalar::D8($scalar) => $body,
+            $crate::decimal::DecimalScalar::D16($scalar) => $body,
+            $crate::decimal::DecimalScalar::D32($scalar) => $body,
+            $crate::decimal::DecimalScalar::D64($scalar) => $body,
+            $crate::decimal::DecimalScalar::D128($scalar) => $body,
+            $crate::decimal::DecimalScalar::D256($scalar) => $body,
         }
     }};
 }

--- a/vortex-vector/src/decimal/scalar.rs
+++ b/vortex-vector/src/decimal/scalar.rs
@@ -155,6 +155,21 @@ impl<D: NativeDecimalType> DScalar<D> {
         self.value
     }
 
+    /// Get the precision/scale of the decimal scalar.
+    pub fn precision_scale(&self) -> PrecisionScale<D> {
+        self.ps
+    }
+
+    /// Returns the precision of the decimal scalar.
+    pub fn precision(&self) -> u8 {
+        self.ps.precision()
+    }
+
+    /// Returns the scale of the decimal scalar.
+    pub fn scale(&self) -> i8 {
+        self.ps.scale()
+    }
+
     /// Creates a zero decimal scalar of the given [`DecimalDType`].
     pub fn zero(decimal_dtype: &DecimalDType) -> Self {
         let ps = PrecisionScale::<D>::new(decimal_dtype.precision(), decimal_dtype.scale());


### PR DESCRIPTION
Adds the very basic implementations of `Cast` to `vortex-compute`.

The only things that are implemented are:
- Cast to `NullVector`/`NullScalar`
- Passthrough cast to the extension storage type
- Identity cast (a cast that is just cloning `self`)

All of the non-extremely-trivial cast implementations have not been added, but this PR makes it a lot easier to see what is missing and a lot easier to add those impls.

Note that I've also constrained the cast implementations so that we cannot cast nullable data to a non-nullable `DType`, and this is just checked by calling `self.validity().all_true()` on the vector which should rarely be expensive.