### PR TITLE
Make sure all encodings are enabled for DF

### DIFF
--- a/vortex-datafusion/Cargo.toml
+++ b/vortex-datafusion/Cargo.toml
@@ -36,7 +36,7 @@ object_store = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "fs"] }
 tokio-stream = { workspace = true }
 tracing = { workspace = true, features = ["std", "attributes"] }
-vortex = { workspace = true, features = ["object_store", "tokio"] }
+vortex = { workspace = true, features = ["object_store", "tokio", "files"] }
 vortex-utils = { workspace = true, features = ["dashmap"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Its already enabled for benchmarks because `vortex-duckdb` makes sure to enable it, but if a user only pulls DF they won't get all the encodings unless they all pull `vortex` with the feature.