### PR TITLE
Perf: optimize `take_scalar`

### DIFF
--- a/vortex-compute/src/take/slice/mod.rs
+++ b/vortex-compute/src/take/slice/mod.rs
@@ -4,6 +4,7 @@
 //! Take function implementations on slices.
 
 use vortex_buffer::Buffer;
+use vortex_buffer::BufferMut;
 use vortex_dtype::UnsignedPType;
 
 use crate::take::Take;
@@ -43,7 +44,21 @@ impl<T: Copy, I: UnsignedPType> Take<[I]> for &[T] {
     unused,
     reason = "Compiler may see this as unused based on enabled features"
 )]
-#[inline]
 fn take_scalar<T: Copy, I: UnsignedPType>(buffer: &[T], indices: &[I]) -> Buffer<T> {
-    indices.iter().map(|idx| buffer[idx.as_()]).collect()
+    // NB: The simpler `indices.iter().map(|idx| buff1er[idx.as_()]).collect()` generates suboptimal
+    // assembly where the buffer length is repeatedly loaded from the stack on each iteration.
+
+    let mut result = BufferMut::with_capacity(indices.len());
+    let ptr = result.spare_capacity_mut().as_mut_ptr().cast::<T>();
+
+    // This explicit loop with pointer writes keeps the length in a register and avoids per-element
+    // capacity checks from `push()`.
+    for (i, idx) in indices.iter().enumerate() {
+        // SAFETY: We reserved `indices.len()` capacity, so `ptr.add(i)` is valid.
+        unsafe { ptr.add(i).write(buffer[idx.as_()]) };
+    }
+
+    // SAFETY: We just wrote exactly `indices.len()` elements.
+    unsafe { result.set_len(indices.len()) };
+    result.freeze()
 }


### PR DESCRIPTION
This change optimizes the scalar `take` compute function over slices.

I wanted to optimize this before I start benchmarking the hand-written SIMD code we will bring back in https://github.com/vortex-data/vortex/pull/5722

It is pretty crazy how the compiler was not able to figure this out on its own...

We can look at the codspeed numbers but on my machine (AMD 7950X) this is ~10% faster:

Original:

<details>

```
take_primitive           fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ pvector_take_uniform                │               │               │               │         │
│  ├─ 16                               │               │               │               │         │
│  │  ├─ 1000            302.2 ns      │ 5.807 µs      │ 309.7 ns      │ 311.4 ns      │ 100000  │ 400000
│  │  ├─ 10000           2.489 µs      │ 29.7 µs       │ 2.529 µs      │ 2.617 µs      │ 100000  │ 100000
│  │  ╰─ 100000          24.34 µs      │ 115.5 µs      │ 24.76 µs      │ 24.89 µs      │ 100000  │ 100000
│  ├─ 256                              │               │               │               │         │
│  │  ├─ 1000            272.2 ns      │ 1.327 µs      │ 279.7 ns      │ 280.4 ns      │ 100000  │ 400000
│  │  ├─ 10000           2.489 µs      │ 8.309 µs      │ 2.519 µs      │ 2.53 µs       │ 100000  │ 100000
│  │  ╰─ 100000          24.74 µs      │ 107.3 µs      │ 24.87 µs      │ 25.06 µs      │ 100000  │ 100000
│  ├─ 2048                             │               │               │               │         │
│  │  ├─ 1000            272.2 ns      │ 3.007 µs      │ 279.7 ns      │ 281.7 ns      │ 100000  │ 400000
│  │  ├─ 10000           2.499 µs      │ 8.799 µs      │ 2.529 µs      │ 2.54 µs       │ 100000  │ 100000
│  │  ╰─ 100000          24.73 µs      │ 108.7 µs      │ 24.83 µs      │ 24.98 µs      │ 100000  │ 100000
│  ╰─ 8192                             │               │               │               │         │
│     ├─ 1000            304.7 ns      │ 1.589 µs      │ 314.7 ns      │ 316.4 ns      │ 100000  │ 400000
│     ├─ 10000           2.589 µs      │ 13.7 µs       │ 2.639 µs      │ 2.65 µs       │ 100000  │ 100000
│     ╰─ 100000          25.43 µs      │ 118.1 µs      │ 25.57 µs      │ 25.71 µs      │ 100000  │ 100000
╰─ pvector_take_zipfian                │               │               │               │         │
   ├─ 16                               │               │               │               │         │
   │  ├─ 1000            269.7 ns      │ 1.744 µs      │ 277.2 ns      │ 279.8 ns      │ 100000  │ 400000
   │  ├─ 10000           2.469 µs      │ 9.289 µs      │ 2.519 µs      │ 2.531 µs      │ 100000  │ 100000
   │  ╰─ 100000          24.5 µs       │ 106.4 µs      │ 24.77 µs      │ 24.91 µs      │ 100000  │ 100000
   ├─ 256                              │               │               │               │         │
   │  ├─ 1000            272.2 ns      │ 1.452 µs      │ 277.2 ns      │ 279.8 ns      │ 100000  │ 400000
   │  ├─ 10000           2.489 µs      │ 7.209 µs      │ 2.519 µs      │ 2.53 µs       │ 100000  │ 100000
   │  ╰─ 100000          24.41 µs      │ 106.1 µs      │ 24.86 µs      │ 25.01 µs      │ 100000  │ 100000
   ├─ 2048                             │               │               │               │         │
   │  ├─ 1000            267.2 ns      │ 1.422 µs      │ 277.2 ns      │ 279.1 ns      │ 100000  │ 400000
   │  ├─ 10000           2.459 µs      │ 7.339 µs      │ 2.519 µs      │ 2.528 µs      │ 100000  │ 100000
   │  ╰─ 100000          24.31 µs      │ 113.7 µs      │ 24.79 µs      │ 24.9 µs       │ 100000  │ 100000
   ╰─ 8192                             │               │               │               │         │
      ├─ 1000            279.7 ns      │ 1.289 µs      │ 292.2 ns      │ 292.3 ns      │ 100000  │ 400000
      ├─ 10000           2.489 µs      │ 10.74 µs      │ 2.55 µs       │ 2.562 µs      │ 100000  │ 100000
      ╰─ 100000          24.72 µs      │ 109.8 µs      │ 25.22 µs      │ 25.37 µs      │ 100000  │ 100000
```

</details>

New:

<details>

```
take_primitive           fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ pvector_take_uniform                │               │               │               │         │
│  ├─ 16                               │               │               │               │         │
│  │  ├─ 1000            259.8 ns      │ 4.559 µs      │ 264.8 ns      │ 266.9 ns      │ 100000  │ 400000
│  │  ├─ 10000           2.349 µs      │ 29.49 µs      │ 2.389 µs      │ 2.403 µs      │ 100000  │ 100000
│  │  ╰─ 100000          23.19 µs      │ 165.3 µs      │ 23.68 µs      │ 23.83 µs      │ 100000  │ 100000
│  ├─ 256                              │               │               │               │         │
│  │  ├─ 1000            259.8 ns      │ 7.234 µs      │ 264.8 ns      │ 265.4 ns      │ 100000  │ 400000
│  │  ├─ 10000           2.319 µs      │ 24.78 µs      │ 2.369 µs      │ 2.383 µs      │ 100000  │ 100000
│  │  ╰─ 100000          23.09 µs      │ 103.7 µs      │ 23.44 µs      │ 23.58 µs      │ 100000  │ 100000
│  ├─ 2048                             │               │               │               │         │
│  │  ├─ 1000            262.3 ns      │ 6.077 µs      │ 267.3 ns      │ 269.4 ns      │ 100000  │ 400000
│  │  ├─ 10000           2.369 µs      │ 29.22 µs      │ 2.429 µs      │ 2.434 µs      │ 100000  │ 100000
│  │  ╰─ 100000          23.45 µs      │ 114.8 µs      │ 23.65 µs      │ 23.88 µs      │ 100000  │ 100000
│  ╰─ 8192                             │               │               │               │         │
│     ├─ 1000            289.8 ns      │ 3.692 µs      │ 302.3 ns      │ 303.3 ns      │ 100000  │ 400000
│     ├─ 10000           2.529 µs      │ 33.29 µs      │ 2.579 µs      │ 2.599 µs      │ 100000  │ 100000
│     ╰─ 100000          25.24 µs      │ 113.6 µs      │ 25.51 µs      │ 25.68 µs      │ 100000  │ 100000
╰─ pvector_take_zipfian                │               │               │               │         │
   ├─ 16                               │               │               │               │         │
   │  ├─ 1000            259.8 ns      │ 2.439 µs      │ 264.8 ns      │ 265.6 ns      │ 100000  │ 400000
   │  ├─ 10000           2.349 µs      │ 16.86 µs      │ 2.379 µs      │ 2.388 µs      │ 100000  │ 100000
   │  ╰─ 100000          23.44 µs      │ 106.8 µs      │ 23.63 µs      │ 23.77 µs      │ 100000  │ 100000
   ├─ 256                              │               │               │               │         │
   │  ├─ 1000            259.8 ns      │ 1.409 µs      │ 264.8 ns      │ 266.5 ns      │ 100000  │ 400000
   │  ├─ 10000           2.339 µs      │ 48.63 µs      │ 2.379 µs      │ 2.384 µs      │ 100000  │ 100000
   │  ╰─ 100000          23.41 µs      │ 111.6 µs      │ 23.6 µs       │ 23.75 µs      │ 100000  │ 100000
   ├─ 2048                             │               │               │               │         │
   │  ├─ 1000            262.3 ns      │ 1.432 µs      │ 267.3 ns      │ 268.8 ns      │ 100000  │ 400000
   │  ├─ 10000           2.409 µs      │ 10.32 µs      │ 2.449 µs      │ 2.459 µs      │ 100000  │ 100000
   │  ╰─ 100000          23.58 µs      │ 109.2 µs      │ 23.87 µs      │ 24.05 µs      │ 100000  │ 100000
   ╰─ 8192                             │               │               │               │         │
      ├─ 1000            264.8 ns      │ 1.484 µs      │ 272.3 ns      │ 272.9 ns      │ 100000  │ 400000
      ├─ 10000           2.429 µs      │ 10.99 µs      │ 2.469 µs      │ 2.483 µs      │ 100000  │ 100000
      ╰─ 100000          24.21 µs      │ 110.2 µs      │ 24.46 µs      │ 24.62 µs      │ 100000  │ 100000
```

</details>

Edit: Accidentally used the wrong numbers, seems to be about 10% faster in general