### PR TITLE
Disable GHArchive benchmarks to unblock perf reference in CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -178,20 +178,4 @@ jobs:
             "targets": "datafusion:parquet,datafusion:vortex,datafusion:vortex-compact,duckdb:parquet,duckdb:vortex,duckdb:vortex-compact",
             "scale_factor": "--scale-factor 100"
           },
-          {
-            "id": "gharchive-nvme",
-            "subcommand": "gharchive",
-            "name": "GitHub Archive (NVMe)",
-            "targets": "datafusion:parquet,datafusion:vortex,datafusion:vortex-compact,duckdb:parquet,duckdb:vortex,duckdb:vortex-compact",
-            "scale_factor": "--scale-factor 100"
-          },
-          {
-            "id": "gharchive-s3",
-            "subcommand": "gharchive",
-            "name": "GitHub Archive (S3)",
-            "local_dir": "bench-vortex/data/gharchive",
-            "remote_storage": "s3://vortex-bench-dev-eu/${{github.ref_name}}/${{github.run_id}}/gharchive/",
-            "targets": "datafusion:parquet,datafusion:vortex,datafusion:vortex-compact,duckdb:parquet,duckdb:vortex,duckdb:vortex-compact",
-            "scale_factor": "--scale-factor 100"
-          },
         ]

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -85,22 +85,6 @@ on:
               "targets": "datafusion:parquet,datafusion:vortex,datafusion:vortex-compact,duckdb:parquet,duckdb:vortex,duckdb:vortex-compact",
               "scale_factor": "--scale-factor 100"
             },
-            {
-              "id": "gharchive-nvme",
-              "subcommand": "gharchive",
-              "name": "GitHub Archive (NVMe)",
-              "targets": "datafusion:parquet,datafusion:vortex,datafusion:vortex-compact,duckdb:parquet,duckdb:vortex,duckdb:vortex-compact",
-              "scale_factor": "--scale-factor 100"
-            },
-            {
-              "id": "gharchive-s3",
-              "subcommand": "gharchive",
-              "name": "GitHub Archive (S3)",
-              "local_dir": "bench-vortex/data/gharchive",
-              "remote_storage": "s3://vortex-bench-dev-eu/${{github.ref_name}}/${{github.run_id}}/gharchive/",
-              "targets": "datafusion:parquet,datafusion:vortex,datafusion:vortex-compact,duckdb:parquet,duckdb:vortex,duckdb:vortex-compact",
-              "scale_factor": "--scale-factor 100"
-            },
           ]
 
 jobs:


### PR DESCRIPTION
The current failures of GHArchive is making the reference be stale (over a month old), this PR just stops running them so we can get more up to date results, and I'll sync with @a10y once he's back about the issue/timeline 