### PR TITLE
fix: downcast in list `new_vector_exporter`

### DIFF
--- a/vortex-duckdb/src/exporter/list.rs
+++ b/vortex-duckdb/src/exporter/list.rs
@@ -214,7 +214,7 @@ pub(crate) fn new_vector_exporter(
                 validity: array.validity().to_mask(array.len()),
                 duckdb_elements: shared_elements,
                 offsets: offsets.downcast::<O>(),
-                sizes: sizes.downcast::<O>(),
+                sizes: sizes.downcast::<S>(),
                 num_elements,
             }) as Box<dyn ColumnExporter>
         })


### PR DESCRIPTION
Fixes `RUST_BACKTRACE=1 RUST_LOG=off VORTEX_OPERATORS=true cargo run --profile release_debug --bin query_bench -- statpopgen --targets duckdb:parquet,duckdb:vortex,duckdb:vortex-compact -i1 --scale-factor 100`