### PR TITLE
ci: Disable polar-signals deployments

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -19,7 +19,6 @@ permissions:
   contents: read
   pull-requests: write  # for commenting on PRs
   id-token: write  # enables AWS-GitHub OIDC
-  deployments: write  # for Polar Signals profiling
 
 jobs:
   label_trigger:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,7 +10,6 @@ permissions:
   id-token: write  # enables AWS-GitHub OIDC
   actions: read
   contents: write
-  deployments: write
 
 jobs:
   commit-metadata:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,6 +51,8 @@ jobs:
           path: docs/_build/html
 
   deploy:
+    permissions:
+      deployments: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -15,7 +15,6 @@ permissions:
   id-token: write  # enables AWS-GitHub OIDC
   actions: read
   contents: write
-  deployments: write
 
 jobs:
   sql:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,7 @@ jobs:
     timeout-minutes: 120
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
+      deployments: write
     environment:
       name: push-to-pypi
       url: https://pypi.org/p/vortex-data

--- a/.github/workflows/sql-pr.yml
+++ b/.github/workflows/sql-pr.yml
@@ -17,7 +17,6 @@ permissions:
   contents: read
   pull-requests: write  # for commenting on PRs
   id-token: write  # enables AWS-GitHub OIDC
-  deployments: write  # for Polar Signals profiling
 
 jobs:
   label_trigger:


### PR DESCRIPTION
This PR disables deployment permissions for the polar-signals action. The current deployments create a ton of visual noise in long-running PRs (https://github.com/vortex-data/vortex/pull/5676) which makes it really hard to follow what's actually going on.
I've added explicit deployment permission to actions that use github deployments (docs and publishing), and the polar-signals actions should still work even if it can't deploy.