### PR TITLE
Fix: support widening of `ListViewVector` offsets and sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9103,6 +9103,7 @@ dependencies = [
 name = "vortex-vector"
 version = "0.1.0"
 dependencies = [
+ "num-traits",
  "paste",
  "static_assertions",
  "vortex-buffer",

--- a/vortex-array/src/arrays/list/vtable/kernel/filter.rs
+++ b/vortex-array/src/arrays/list/vtable/kernel/filter.rs
@@ -63,6 +63,7 @@ impl ExecuteParentKernel<ListVTable> for ListFilterKernel {
                 let mut vec = ListViewVectorMut::with_capacity(
                     array.elements().dtype(),
                     selection.true_count(),
+                    0,
                 );
                 vec.append_nulls(selection.true_count());
                 return Ok(Some(vec.freeze().into()));

--- a/vortex-compute/src/cast/pvector.rs
+++ b/vortex-compute/src/cast/pvector.rs
@@ -2,16 +2,12 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use num_traits::NumCast;
-use vortex_buffer::Buffer;
-use vortex_buffer::BufferMut;
 use vortex_dtype::DType;
 use vortex_dtype::NativePType;
 use vortex_dtype::match_each_native_ptype;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
-use vortex_mask::AllOr;
-use vortex_mask::Mask;
 use vortex_vector::Scalar;
 use vortex_vector::ScalarOps;
 use vortex_vector::Vector;
@@ -20,6 +16,7 @@ use vortex_vector::primitive::PScalar;
 use vortex_vector::primitive::PVector;
 use vortex_vector::primitive::PrimitiveScalar;
 use vortex_vector::primitive::PrimitiveVector;
+use vortex_vector::primitive::cast;
 
 use crate::cast::Cast;
 use crate::cast::try_cast_scalar_common;
@@ -44,55 +41,13 @@ impl<T: NativePType> Cast for PVector<T> {
             // We can possibly convert to the target `PType` and we have compatible nullability.
             DType::Primitive(target_ptype, n) if n.is_nullable() || self.validity().all_true() => {
                 match_each_native_ptype!(*target_ptype, |Dst| {
-                    let result = cast_pvector::<T, Dst>(self)?;
+                    let result = cast::cast_pvector::<T, Dst>(self)?;
                     Ok(PrimitiveVector::from(result).into())
                 })
             }
             _ => {
                 vortex_bail!("Cannot cast PVector<{}> to {}", T::PTYPE, target_dtype);
             }
-        }
-    }
-}
-
-/// Cast a [`PVector<F>`] to a [`PVector<T>`] by converting each element.
-///
-/// Returns an error if any valid element cannot be converted (e.g., overflow).
-fn cast_pvector<Src: NativePType, Dst: NativePType>(
-    src: &PVector<Src>,
-) -> VortexResult<PVector<Dst>> {
-    let elements: &[Src] = src.as_ref();
-    match src.validity().bit_buffer() {
-        AllOr::All => {
-            let mut buffer = BufferMut::with_capacity(elements.len());
-            for &item in elements {
-                let converted = <Dst as NumCast>::from(item).ok_or_else(
-                    || vortex_err!(ComputeError: "Failed to cast {} to {:?}", item, Dst::PTYPE),
-                )?;
-                // SAFETY: We pre-allocated the required capacity.
-                unsafe { buffer.push_unchecked(converted) }
-            }
-            Ok(PVector::from(buffer.freeze()))
-        }
-        AllOr::None => Ok(PVector::new(
-            Buffer::zeroed(elements.len()),
-            Mask::new_false(elements.len()),
-        )),
-        AllOr::Some(bit_buffer) => {
-            let mut buffer = BufferMut::with_capacity(elements.len());
-            for (&item, valid) in elements.iter().zip(bit_buffer.iter()) {
-                if valid {
-                    let converted = <Dst as NumCast>::from(item).ok_or_else(
-                        || vortex_err!(ComputeError: "Failed to cast {} to {:?}", item, Dst::PTYPE),
-                    )?;
-                    // SAFETY: We pre-allocated the required capacity.
-                    unsafe { buffer.push_unchecked(converted) }
-                } else {
-                    // SAFETY: We pre-allocated the required capacity.
-                    unsafe { buffer.push_unchecked(Dst::default()) }
-                }
-            }
-            Ok(PVector::new(buffer.freeze(), src.validity().clone()))
         }
     }
 }

--- a/vortex-dtype/src/ptype.rs
+++ b/vortex-dtype/src/ptype.rs
@@ -767,6 +767,56 @@ impl PType {
             }
         }
     }
+
+    /// Returns the minimum unsigned integer [`PType`] that can represent the given value.
+    #[inline]
+    pub const fn min_unsigned_ptype_for_value(value: u64) -> Self {
+        if value <= u8::MAX as u64 {
+            Self::U8
+        } else if value <= u16::MAX as u64 {
+            Self::U16
+        } else if value <= u32::MAX as u64 {
+            Self::U32
+        } else {
+            Self::U64
+        }
+    }
+
+    /// Returns the minimum signed integer [`PType`] that can represent the given value.
+    #[inline]
+    pub const fn min_signed_ptype_for_value(value: i64) -> Self {
+        if value >= i8::MIN as i64 && value <= i8::MAX as i64 {
+            Self::I8
+        } else if value >= i16::MIN as i64 && value <= i16::MAX as i64 {
+            Self::I16
+        } else if value >= i32::MIN as i64 && value <= i32::MAX as i64 {
+            Self::I32
+        } else {
+            Self::I64
+        }
+    }
+
+    /// Returns the wider of two unsigned integer [`PType`]s based on byte width.
+    #[inline]
+    pub const fn max_unsigned_ptype(self, other: Self) -> Self {
+        debug_assert!(self.is_unsigned_int() && other.is_unsigned_int());
+        if self.byte_width() >= other.byte_width() {
+            self
+        } else {
+            other
+        }
+    }
+
+    /// Returns the wider of two signed integer [`PType`]s based on byte width.
+    #[inline]
+    pub const fn max_signed_ptype(self, other: Self) -> Self {
+        debug_assert!(self.is_signed_int() && other.is_signed_int());
+        if self.byte_width() >= other.byte_width() {
+            self
+        } else {
+            other
+        }
+    }
 }
 
 impl Display for PType {

--- a/vortex-scalar/src/vectors.rs
+++ b/vortex-scalar/src/vectors.rs
@@ -72,7 +72,7 @@ impl Scalar {
                 let lscalar = self.as_list();
                 match lscalar.elements() {
                     None => {
-                        let mut list_view = ListViewVectorMut::with_capacity(elems_dtype, 1);
+                        let mut list_view = ListViewVectorMut::with_capacity(elems_dtype, 1, 0);
                         list_view.append_nulls(1);
                         ListViewScalar::new(list_view.freeze()).into()
                     }

--- a/vortex-vector/Cargo.toml
+++ b/vortex-vector/Cargo.toml
@@ -25,5 +25,6 @@ vortex-dtype = { workspace = true }
 vortex-error = { workspace = true }
 vortex-mask = { workspace = true }
 
+num-traits = { workspace = true }
 paste = { workspace = true }
 static_assertions = { workspace = true }

--- a/vortex-vector/src/listview/tests.rs
+++ b/vortex-vector/src/listview/tests.rs
@@ -412,3 +412,66 @@ fn test_try_into_mut() {
     let original = mut_result2.unwrap_err();
     assert_eq!(original.len(), 2);
 }
+
+#[test]
+fn test_extend_upcasts_offset_and_size_types() {
+    use vortex_dtype::PType;
+
+    // Create first list with u8 offsets/sizes and u8::MAX elements
+    // This forces upcasting when extended with larger types
+    let elements1 = PVectorMut::from_iter((0..u8::MAX as i32).map(Some));
+    let offsets1 = PVectorMut::from_iter([0u8]).into();
+    let sizes1 = PVectorMut::from_iter([u8::MAX]).into();
+    let validity1 = MaskMut::new_true(1);
+
+    let mut list = ListViewVectorMut::new(Box::new(elements1.into()), offsets1, sizes1, validity1);
+
+    // Verify initial types
+    assert_eq!(list.offsets().ptype(), PType::U8);
+    assert_eq!(list.sizes().ptype(), PType::U8);
+
+    // Create second list with u32 offsets and u16 sizes, with u16::MAX elements
+    let elements2: PrimitiveVector = PVectorMut::from_iter((0..u16::MAX as i32).map(Some))
+        .freeze()
+        .into();
+    let offsets2: PrimitiveVector = PVectorMut::from_iter([0u32]).freeze().into();
+    let sizes2: PrimitiveVector = PVectorMut::from_iter([u16::MAX]).freeze().into();
+    let validity2 = Mask::new_true(1);
+
+    let list2 = ListViewVector::new(Arc::new(elements2.into()), offsets2, sizes2, validity2);
+
+    // Extend - this should upcast offsets to u32 and sizes to u16
+    list.extend_from_vector(&list2);
+
+    // Verify types were upcasted
+    assert_eq!(list.offsets().ptype(), PType::U32);
+    assert_eq!(list.sizes().ptype(), PType::U16);
+
+    // Verify lengths
+    assert_eq!(list.len(), 2);
+
+    let frozen = list.freeze();
+
+    // Check that first list's offset is still 0 and size is u8::MAX
+    let offsets = frozen.offsets();
+    let sizes = frozen.sizes();
+
+    let (o0, o1) = match offsets {
+        PrimitiveVector::U32(pvec) => (*pvec.get(0).unwrap(), *pvec.get(1).unwrap()),
+        _ => panic!("Expected U32 offsets"),
+    };
+    let (s0, s1) = match sizes {
+        PrimitiveVector::U16(pvec) => (*pvec.get(0).unwrap(), *pvec.get(1).unwrap()),
+        _ => panic!("Expected U16 sizes"),
+    };
+
+    assert_eq!(o0, 0);
+    assert_eq!(s0, u8::MAX as u16);
+    // Second list's offset should be adjusted by first list's element count (u8::MAX)
+    assert_eq!(o1, u8::MAX as u32);
+    assert_eq!(s1, u16::MAX);
+
+    // Verify element count
+    let total_elements = (u8::MAX as usize) + (u16::MAX as usize);
+    assert_eq!(frozen.elements().len(), total_elements);
+}

--- a/vortex-vector/src/listview/vector_mut.rs
+++ b/vortex-vector/src/listview/vector_mut.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 
+use num_traits::NumCast;
 use vortex_dtype::DType;
 use vortex_dtype::PType;
 use vortex_error::VortexExpect;
@@ -184,12 +185,17 @@ impl ListViewVectorMut {
     }
 
     /// Creates a new [`ListViewVectorMut`] with the specified capacity.
-    pub fn with_capacity(element_dtype: &DType, capacity: usize) -> Self {
+    pub fn with_capacity(element_dtype: &DType, capacity: usize, elements_capacity: usize) -> Self {
+        let offsets_ptype = PType::min_unsigned_ptype_for_value(elements_capacity as u64);
+        let sizes_ptype = offsets_ptype;
+
+        // SAFETY: Everything is empty and the offsets and sizes `PType` is the same, so all
+        // invariants are satisfied.
         unsafe {
             Self::new_unchecked(
                 Box::new(VectorMut::with_capacity(element_dtype, 0)),
-                PrimitiveVectorMut::with_capacity(PType::U64, capacity),
-                PrimitiveVectorMut::with_capacity(PType::U32, capacity),
+                PrimitiveVectorMut::with_capacity(offsets_ptype, capacity),
+                PrimitiveVectorMut::with_capacity(sizes_ptype, capacity),
                 MaskMut::with_capacity(capacity),
             )
         }
@@ -300,26 +306,22 @@ impl VectorMutOps for ListViewVectorMut {
         self.len = self.validity.len();
     }
 
-    /// This will also panic if we try to extend the `ListViewVector` beyond the maximum offset
-    /// representable by the type of the `offsets` primitive vector.
     fn extend_from_vector(&mut self, other: &ListViewVector) {
         // Extend the elements with the other's elements.
         let old_elements_len = self.elements.len() as u64;
         self.elements.extend_from_vector(&other.elements);
         let new_elements_len = self.elements.len() as u64;
 
-        // Then extend the sizes with the other's sizes (these do not need any adjustment).
-        self.sizes.extend_from_vector(&other.sizes);
+        // Extend sizes with automatic upcasting (does not panic on type mismatch).
+        self.sizes.extend_from_vector_with_upcast(&other.sizes);
 
-        // We need this assertion to ensure that the casts below are infallible.
-        assert!(
-            new_elements_len < self.offsets.ptype().max_value_as_u64(),
-            "the elements length {new_elements_len} is not representable by the offsets type {}",
-            self.offsets.ptype()
+        // Extend offsets with adjustment and automatic upcasting based on `new_elements_len`.
+        adjust_and_extend_offsets(
+            &mut self.offsets,
+            &other.offsets,
+            old_elements_len,
+            new_elements_len,
         );
-
-        // Finally, extend the offsets after adding the old `elements` length to each.
-        adjust_and_extend_offsets(&mut self.offsets, &other.offsets, old_elements_len);
 
         self.validity.append_mask(&other.validity);
         self.len += other.len;
@@ -505,39 +507,60 @@ fn validate_views_bound(
     Ok(())
 }
 
-// TODO(connor): It would be better to separate everything inside the macros into its own function,
-// but that would require adding another macro that sets a type `$type` to be used by the caller.
-/// Checks that all views are `<= elements_len`.
+/// Adjusts and extends offsets from `new_offsets` into `curr_offsets`, upcasting if needed.
+///
+/// Each offset from `new_offsets` is adjusted by adding `old_elements_len` before appending.
+///
+/// If the resulting offsets would exceed the current offset type's capacity, the offset vector is
+/// automatically upcasted to a wider type.
 #[expect(
     clippy::cognitive_complexity,
     reason = "complexity from nested match_each_* macros"
 )]
 fn adjust_and_extend_offsets(
-    our_offsets: &mut PrimitiveVectorMut,
-    other: &PrimitiveVector,
+    curr_offsets: &mut PrimitiveVectorMut,
+    new_offsets: &PrimitiveVector,
     old_elements_len: u64,
+    new_elements_len: u64,
 ) {
-    our_offsets.reserve(other.len());
+    // Make sure we use the correct width to fit all offsets.
+    let target_ptype = PType::min_unsigned_ptype_for_value(new_elements_len)
+        .max_unsigned_ptype(curr_offsets.ptype())
+        .max_unsigned_ptype(new_offsets.ptype());
 
-    // Adjust each offset from `other` by adding the current elements length to each of the
+    if curr_offsets.ptype() != target_ptype {
+        let old_offsets = std::mem::replace(
+            curr_offsets,
+            PrimitiveVectorMut::with_capacity(target_ptype, 0),
+        );
+        *curr_offsets = old_offsets.upcast(target_ptype);
+    }
+
+    curr_offsets.reserve(new_offsets.len());
+
+    // Adjust each offset from `new_offsets` by adding the current elements length to each of the
     // incoming offsets.
-    match_each_integer_pvector_mut!(our_offsets, |self_offsets| {
-        match_each_integer_pvector!(other, |other_offsets| {
-            let other_offsets_slice = other_offsets.as_ref();
+    match_each_integer_pvector_mut!(curr_offsets, |curr| {
+        match_each_integer_pvector!(new_offsets, |new| {
+            let new_offsets_slice = new.as_ref();
 
-            // Append each offset from `other`, adjusted by the elements_offset.
-            for i in 0..other.len() {
-                // All offset types are representable via a `u64` since we also ensure offsets
-                // are always non-negative.
+            // Append each offset from `new_offsets`, adjusted by the elements_offset.
+            for i in 0..new.len() {
+                // All offset types are representable via a `u64` since we also ensure offsets are
+                // always non-negative.
                 #[allow(clippy::unnecessary_cast)]
-                let adjusted_offset = other_offsets_slice[i] as u64 + old_elements_len;
+                let adjusted_offset = new_offsets_slice[i] as u64 + old_elements_len;
+                debug_assert!(
+                    adjusted_offset < new_elements_len,
+                    "new list view offset is somehow out of bounds, something has gone wrong"
+                );
 
-                // SAFETY: We just reserved capacity for `other.len()` elements above, and we
-                // also know the cast is fine because we verified above that the maximum
-                // possible offset is representable by the offset type.
-                #[allow(clippy::cast_possible_truncation)]
+                let converted = NumCast::from(adjusted_offset)
+                    .vortex_expect("offset conversion should succeed after upcast");
+
+                // SAFETY: We reserved capacity for `new_offsets.len()` elements above.
                 unsafe {
-                    self_offsets.push_unchecked(adjusted_offset as _);
+                    curr.push_unchecked(converted);
                 }
             }
         });

--- a/vortex-vector/src/primitive/cast.rs
+++ b/vortex-vector/src/primitive/cast.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Casting utilities for primitive vectors.
+
+use num_traits::NumCast;
+use vortex_buffer::Buffer;
+use vortex_buffer::BufferMut;
+use vortex_dtype::NativePType;
+use vortex_dtype::PType;
+use vortex_dtype::match_each_signed_integer_ptype;
+use vortex_dtype::match_each_unsigned_integer_ptype;
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_error::vortex_err;
+use vortex_mask::AllOr;
+use vortex_mask::Mask;
+
+use super::PVector;
+use super::PrimitiveVector;
+use super::PrimitiveVectorMut;
+use crate::VectorMutOps;
+use crate::VectorOps;
+use crate::match_each_integer_pvector;
+use crate::match_each_integer_pvector_mut;
+
+/// Cast a [`PVector<Src>`] to a [`PVector<Dst>`] by converting each element.
+///
+/// # Errors
+///
+/// Returns an error if any valid element cannot be converted (e.g., overflow).
+pub fn cast_pvector<Src: NativePType, Dst: NativePType>(
+    src: &PVector<Src>,
+) -> VortexResult<PVector<Dst>> {
+    let elements: &[Src] = src.as_ref();
+    match src.validity().bit_buffer() {
+        AllOr::All => {
+            let mut buffer = BufferMut::with_capacity(elements.len());
+            for &item in elements {
+                let converted = <Dst as NumCast>::from(item).ok_or_else(
+                    || vortex_err!(ComputeError: "Failed to cast {} to {:?}", item, Dst::PTYPE),
+                )?;
+                // SAFETY: We pre-allocated the required capacity.
+                unsafe { buffer.push_unchecked(converted) }
+            }
+            Ok(PVector::from(buffer.freeze()))
+        }
+        AllOr::None => Ok(PVector::new(
+            Buffer::zeroed(elements.len()),
+            Mask::new_false(elements.len()),
+        )),
+        AllOr::Some(bit_buffer) => {
+            let mut buffer = BufferMut::with_capacity(elements.len());
+            for (&item, valid) in elements.iter().zip(bit_buffer.iter()) {
+                if valid {
+                    let converted = <Dst as NumCast>::from(item).ok_or_else(
+                        || vortex_err!(ComputeError: "Failed to cast {} to {:?}", item, Dst::PTYPE),
+                    )?;
+                    // SAFETY: We pre-allocated the required capacity.
+                    unsafe { buffer.push_unchecked(converted) }
+                } else {
+                    // SAFETY: We pre-allocated the required capacity.
+                    unsafe { buffer.push_unchecked(Dst::default()) }
+                }
+            }
+            Ok(PVector::new(buffer.freeze(), src.validity().clone()))
+        }
+    }
+}
+
+impl PrimitiveVectorMut {
+    /// Upcasts this integer vector to a wider integer type with matching signedness.
+    ///
+    /// Returns self unchanged if the target type is the same or smaller in byte width.
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "complexity from nested match_each_* macros"
+    )]
+    pub fn upcast(self, target: PType) -> Self {
+        debug_assert!(self.ptype().is_int());
+        debug_assert!(target.is_int());
+        debug_assert!(
+            (self.ptype().is_signed_int() && target.is_signed_int())
+                || (self.ptype().is_unsigned_int() && target.is_unsigned_int())
+        );
+
+        // No-op if already at target or target is same/smaller
+        if self.ptype() == target || target.byte_width() <= self.ptype().byte_width() {
+            return self;
+        }
+
+        // Freeze to immutable, cast, then convert back to mutable
+        let frozen = self.freeze();
+        match_each_integer_pvector!(&frozen, |src_vec| {
+            if target.is_unsigned_int() {
+                match_each_unsigned_integer_ptype!(target, |Dst| {
+                    let casted = cast_pvector::<_, Dst>(src_vec)
+                        .vortex_expect("upcast should never fail for widening casts");
+                    casted.into_mut().into()
+                })
+            } else {
+                match_each_signed_integer_ptype!(target, |Dst| {
+                    let casted = cast_pvector::<_, Dst>(src_vec)
+                        .vortex_expect("upcast should never fail for widening casts");
+                    casted.into_mut().into()
+                })
+            }
+        })
+    }
+
+    /// Extends this vector from another, automatically upcasting if needed.
+    ///
+    /// Unlike [`VectorMutOps::extend_from_vector`](VectorMutOps::extend_from_vector), this does
+    /// **NOT** panic on type mismatch. Instead, it upcasts `self` to the wider of the two types.
+    ///
+    /// Returns the new [`PType`] after any upcasting.
+    pub fn extend_from_vector_with_upcast(&mut self, other: &PrimitiveVector) -> PType {
+        debug_assert!(self.ptype().is_int());
+        debug_assert!(other.ptype().is_int());
+
+        let target = self
+            .ptype()
+            .to_unsigned()
+            .max_unsigned_ptype(other.ptype().to_unsigned());
+
+        if self.ptype() != target {
+            let old_self = std::mem::replace(self, Self::with_capacity(target, 0));
+            *self = old_self.upcast(target);
+        }
+
+        // Now extend with casting from other
+        self.reserve(other.len());
+        extend_with_cast(self, other);
+        self.ptype()
+    }
+}
+
+/// Extends `dst` with values from `src`, casting each element.
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "complexity from nested match_each_* macros"
+)]
+fn extend_with_cast(dst: &mut PrimitiveVectorMut, src: &PrimitiveVector) {
+    match_each_integer_pvector_mut!(dst, |dst_vec| {
+        match_each_integer_pvector!(src, |src_vec| {
+            let src_slice = src_vec.as_ref();
+            let src_validity = src_vec.validity();
+            for i in 0..src_vec.len() {
+                if src_validity.value(i) {
+                    #[allow(clippy::unnecessary_cast)]
+                    let converted = <_ as NumCast>::from(src_slice[i])
+                        .vortex_expect("conversion should succeed after upcast");
+                    dst_vec.push_opt(Some(converted));
+                } else {
+                    dst_vec.push_opt(None);
+                }
+            }
+        });
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_dtype::PType;
+    use vortex_dtype::PTypeDowncast;
+
+    use super::*;
+    use crate::primitive::PVectorMut;
+
+    #[test]
+    fn test_upcast_unsigned() {
+        let mut vec: PrimitiveVectorMut =
+            PVectorMut::<u8>::from_iter([0u8, u8::MAX].map(Some)).into();
+        let other: PrimitiveVector = PVectorMut::<u32>::from_iter([u32::MAX].map(Some))
+            .freeze()
+            .into();
+
+        vec.extend_from_vector_with_upcast(&other);
+        assert_eq!(vec.ptype(), PType::U32);
+
+        let frozen = vec.freeze().into_u32();
+        assert_eq!(frozen.as_ref(), &[0, u8::MAX as u32, u32::MAX]);
+    }
+
+    #[test]
+    fn test_upcast_signed() {
+        let vec: PrimitiveVectorMut =
+            PVectorMut::<i8>::from_iter([i8::MIN, i8::MAX].map(Some)).into();
+
+        let mut vec = vec.upcast(PType::I32);
+        let other: PrimitiveVector = PVectorMut::<i32>::from_iter([i32::MIN, i32::MAX].map(Some))
+            .freeze()
+            .into();
+        extend_with_cast(&mut vec, &other);
+
+        let frozen = vec.freeze().into_i32();
+        assert_eq!(
+            frozen.as_ref(),
+            &[i8::MIN as i32, i8::MAX as i32, i32::MIN, i32::MAX]
+        );
+    }
+}

--- a/vortex-vector/src/primitive/mod.rs
+++ b/vortex-vector/src/primitive/mod.rs
@@ -99,6 +99,8 @@
 //!
 //! [`f16`]: vortex_dtype::half::f16
 
+pub mod cast;
+
 mod generic;
 pub use generic::PVector;
 

--- a/vortex-vector/src/vector_mut.rs
+++ b/vortex-vector/src/vector_mut.rs
@@ -87,7 +87,9 @@ impl VectorMut {
             DType::Binary(..) => BinaryVectorMut::with_capacity(capacity).into(),
             DType::Extension(ext) => VectorMut::with_capacity(ext.storage_dtype(), capacity),
             DType::List(elem, ..) => {
-                ListViewVectorMut::with_capacity(elem.as_ref(), capacity).into()
+                // We arbitrarily choose 2 times the number of list scalars for the capacity of the
+                // elements since we cannot know this ahead of time.
+                ListViewVectorMut::with_capacity(elem.as_ref(), capacity, 2 * capacity).into()
             }
         }
     }


### PR DESCRIPTION
Since the list view "logical" type does not include the sizes and offsets as part of its type, we should allow resizing. 