### PR TITLE
Fix: bring back lance compression benchmark

### DIFF
--- a/benchmarks/compress-bench/src/lib.rs
+++ b/benchmarks/compress-bench/src/lib.rs
@@ -7,7 +7,8 @@ use ::vortex::array::arrays::ChunkedArray;
 use ::vortex::array::arrays::recursive_list_from_list_view;
 use arrow_array::RecordBatch;
 use arrow_schema::Schema;
-
+#[cfg(feature = "lance")]
+pub use lance_bench::compress::LanceCompressor;
 pub mod parquet;
 pub mod vortex;
 

--- a/benchmarks/compress-bench/src/main.rs
+++ b/benchmarks/compress-bench/src/main.rs
@@ -5,6 +5,8 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use clap::Parser;
+#[cfg(feature = "lance")]
+use compress_bench::LanceCompressor;
 use compress_bench::parquet::ParquetCompressor;
 use compress_bench::vortex::VortexCompressor;
 use indicatif::ProgressBar;
@@ -92,7 +94,7 @@ fn get_compressor(format: Format) -> Box<dyn Compressor> {
         Format::OnDiskVortex => Box::new(VortexCompressor),
         Format::Parquet => Box::new(ParquetCompressor::new()),
         #[cfg(feature = "lance")]
-        Format::Lance => todo!(),
+        Format::Lance => Box::new(LanceCompressor),
         _ => unimplemented!("Compress bench not implemented for {format}"),
     }
 }


### PR DESCRIPTION
Closes https://github.com/vortex-data/vortex/issues/5837

Turns out it was already implemented, but that one thing wasn't imported.