### PR TITLE
feat: teach TemporalMetadata about its relationship to DTypes

### DIFF
--- a/vortex-dtype/src/datetime/temporal.rs
+++ b/vortex-dtype/src/datetime/temporal.rs
@@ -16,9 +16,12 @@ use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 
+use crate::DType;
 use crate::ExtDType;
 use crate::ExtID;
 use crate::ExtMetadata;
+use crate::Nullability;
+use crate::PType;
 use crate::datetime::unit::TimeUnit;
 
 /// ID for the Vortex time type.
@@ -119,6 +122,60 @@ impl TemporalMetadata {
                     .in_tz(tz)?,
             )),
         }
+    }
+
+    /// The (only) allowed storage PType for this temporal type.
+    ///
+    /// Each temporal extension type has exactly one allowed representation. This function returns
+    /// that representation.
+    pub fn storage_ptype(&self) -> VortexResult<PType> {
+        let storage_ptype = match self {
+            TemporalMetadata::Time(TimeUnit::Nanoseconds | TimeUnit::Microseconds) => PType::I64,
+            TemporalMetadata::Time(TimeUnit::Milliseconds | TimeUnit::Seconds) => PType::I32,
+            TemporalMetadata::Time(TimeUnit::Days) => {
+                vortex_bail!("invalid TimeUnit days for vortex.time");
+            }
+            TemporalMetadata::Date(
+                unit @ (TimeUnit::Nanoseconds | TimeUnit::Microseconds | TimeUnit::Seconds),
+            ) => vortex_bail!("invalid TimeUnit {unit} for vortex.time"),
+            TemporalMetadata::Date(TimeUnit::Milliseconds) => PType::I64,
+            TemporalMetadata::Date(TimeUnit::Days) => PType::I32,
+            TemporalMetadata::Timestamp(
+                TimeUnit::Nanoseconds
+                | TimeUnit::Microseconds
+                | TimeUnit::Milliseconds
+                | TimeUnit::Seconds,
+                ..,
+            ) => PType::I64,
+            TemporalMetadata::Timestamp(TimeUnit::Days, ..) => {
+                vortex_bail!("invalid TimeUnit days for vortex.time");
+            }
+        };
+
+        Ok(storage_ptype)
+    }
+
+    /// The Extension (DType) ID for this temporal type.
+    pub fn extension_id(&self) -> ExtID {
+        match self {
+            TemporalMetadata::Time(..) => TIME_ID.clone(),
+            TemporalMetadata::Date(..) => DATE_ID.clone(),
+            TemporalMetadata::Timestamp(..) => TIMESTAMP_ID.clone(),
+        }
+    }
+
+    /// The (only) allowed storage DType for this temporal type.
+    ///
+    /// Each temporal extension type has exactly one allowed representation for a given
+    /// nullability. This function returns that representation.
+    pub fn dtype(self, nullability: Nullability) -> VortexResult<DType> {
+        let extension_id = self.extension_id();
+        let storage_ptype = self.storage_ptype()?;
+        let metadata = ExtMetadata::from(self);
+        let storage_dtype = DType::Primitive(storage_ptype, nullability);
+        let ext_dtype = ExtDType::new(extension_id, Arc::new(storage_dtype), Some(metadata));
+
+        Ok(DType::Extension(Arc::new(ext_dtype)))
     }
 }
 

--- a/vortex-dtype/src/datetime/temporal.rs
+++ b/vortex-dtype/src/datetime/temporal.rs
@@ -137,7 +137,7 @@ impl TemporalMetadata {
             }
             TemporalMetadata::Date(
                 unit @ (TimeUnit::Nanoseconds | TimeUnit::Microseconds | TimeUnit::Seconds),
-            ) => vortex_bail!("invalid TimeUnit {unit} for vortex.time"),
+            ) => vortex_bail!("invalid TimeUnit {unit} for vortex.date"),
             TemporalMetadata::Date(TimeUnit::Milliseconds) => PType::I64,
             TemporalMetadata::Date(TimeUnit::Days) => PType::I32,
             TemporalMetadata::Timestamp(
@@ -148,7 +148,7 @@ impl TemporalMetadata {
                 ..,
             ) => PType::I64,
             TemporalMetadata::Timestamp(TimeUnit::Days, ..) => {
-                vortex_bail!("invalid TimeUnit days for vortex.time");
+                vortex_bail!("invalid TimeUnit days for vortex.timestamp");
             }
         };
 


### PR DESCRIPTION
I discovered this implicit mapping from TemporalMetadata to DType by trial-and-error and looking at arrays/datetime/mod.rs. AFAIK, this relationship between temporal type and bitwidth comes from [the arrow
specification](https://github.com/apache/arrow/blob/7151dcd6faa6a507d99b33ecc797f3d6a74f45ae/format/Schema.fbs#L246-L277).

For arrays, TemporalArray already addresses these issues [1], but for Vortex users who create or manipulate scalars, these methods are valuable.

[1] Insofar as temporal array expects you to give it a valid PType (it panics if the width is
    wrong) but will construct the extension DType for you.