### PR TITLE
fix[ci]: pin maturin due to fix upstream error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,9 @@ jobs:
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           rust-toolchain: ${{ steps.rust-toolchain.outputs.channel }}
+          # vortex-buffer 0.56.0 on crates.io has a bug where serde feature doesn't enable derive.
+          # This prevents the baseline from building, so we exclude it until the next release.
+          exclude: vortex-buffer
 
 
   rust-coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
           rm -rf ../target/wheels/
 
           uv venv
-          uv pip install "maturin[zig]==1.11.1"
+          uv pip install "maturin[zig]==1.11"
           uv tool run maturin build --interpreter python3.11 --zig
           uv tool run maturin build --interpreter python3.11 --zig --sdist
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
           rm -rf ../target/wheels/
 
           uv venv
-          uv pip install "maturin[zig]==1.11"
+          uv pip install "maturin[zig]==1.10"
           uv tool run maturin build --interpreter python3.11 --zig
           uv tool run maturin build --interpreter python3.11 --zig --sdist
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
           rm -rf ../target/wheels/
 
           uv venv
-          uv pip install "maturin[zig]"
+          uv pip install "maturin[zig]==1.11.1"
           uv tool run maturin build --interpreter python3.11 --zig
           uv tool run maturin build --interpreter python3.11 --zig --sdist
 
@@ -363,18 +363,8 @@ jobs:
           cargo install cargo-edit
           cargo set-version --workspace ${{ steps.latest-tag.outputs.tag }}
 
-      - name: Get Rust toolchain version
-        id: rust-toolchain
-        run: echo "channel=$(grep '^channel' rust-toolchain.toml | cut -d'"' -f2)" >> $GITHUB_OUTPUT
-
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
-        with:
-          rust-toolchain: ${{ steps.rust-toolchain.outputs.channel }}
-          # vortex-buffer 0.56.0 on crates.io has a bug where serde feature doesn't enable derive.
-          # This prevents the baseline from building, so we exclude it until the next release.
-          exclude: vortex-buffer
-
 
   rust-coverage:
     name: "Rust tests (coverage)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,9 +145,8 @@ jobs:
           rm -rf ../target/wheels/
 
           uv venv
-          uv pip install "maturin[zig]==1.10"
-          uv tool run maturin build --interpreter python3.11 --zig
-          uv tool run maturin build --interpreter python3.11 --zig --sdist
+          uv tool run maturin@1.10 build --interpreter python3.11 --zig
+          uv tool run maturin@1.10 build --interpreter python3.11 --zig --sdist
 
           file_count=$(ls -1 ../target/wheels/ | wc -l)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,8 +363,15 @@ jobs:
           cargo install cargo-edit
           cargo set-version --workspace ${{ steps.latest-tag.outputs.tag }}
 
+      - name: Get Rust toolchain version
+        id: rust-toolchain
+        run: echo "channel=$(grep '^channel' rust-toolchain.toml | cut -d'"' -f2)" >> $GITHUB_OUTPUT
+
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          rust-toolchain: ${{ steps.rust-toolchain.outputs.channel }}
+
 
   rust-coverage:
     name: "Rust tests (coverage)"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -56,6 +56,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
+          maturin-version: v1.11.1
           target: ${{ matrix.target.target }}
           args: >
             ${{ (matrix.target.os == 'ubuntu' && '--zig') || '' }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -56,7 +56,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          maturin-version: v1.11.1
+          maturin-version: v1.11
           target: ${{ matrix.target.target }}
           args: >
             ${{ (matrix.target.os == 'ubuntu' && '--zig') || '' }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -56,7 +56,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          maturin-version: v1.11
+          maturin-version: v1.10
           target: ${{ matrix.target.target }}
           args: >
             ${{ (matrix.target.os == 'ubuntu' && '--zig') || '' }}

--- a/vortex-buffer/Cargo.toml
+++ b/vortex-buffer/Cargo.toml
@@ -28,7 +28,7 @@ bitvec = { workspace = true }
 bytes = { workspace = true }
 itertools = { workspace = true }
 memmap2 = { workspace = true, optional = true }
-serde = { workspace = true, optional = true, features = ["derive"] }
+serde = { workspace = true, optional = true }
 simdutf8 = { workspace = true }
 tracing = { workspace = true, optional = true }
 vortex-error = { workspace = true }

--- a/vortex-buffer/Cargo.toml
+++ b/vortex-buffer/Cargo.toml
@@ -28,7 +28,7 @@ bitvec = { workspace = true }
 bytes = { workspace = true }
 itertools = { workspace = true }
 memmap2 = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true, optional = true, features = ["derive"] }
 simdutf8 = { workspace = true }
 tracing = { workspace = true, optional = true }
 vortex-error = { workspace = true }


### PR DESCRIPTION
the PR that was incorrect: https://github.com/PyO3/maturin/pull/2901

However I think we should pin maturin going forward?