### PR TITLE
fix: enable all features for vortex-mask docsrs and enable serde-derive when serde is enabled

### DIFF
--- a/vortex-buffer/Cargo.toml
+++ b/vortex-buffer/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 [features]
 arrow = []
 memmap2 = ["dep:memmap2"]
-serde = ["dep:serde"]
+serde = ["dep:serde", "serde/serde_derive"]
 warn-copy = ["dep:tracing"]
 
 [dependencies]
@@ -40,7 +40,6 @@ cudarc = { workspace = true }
 workspace = true
 
 [dev-dependencies]
-arrow-buffer = { workspace = true }
 divan = { workspace = true }
 num-traits = { workspace = true }
 rstest = { workspace = true }

--- a/vortex-mask/Cargo.toml
+++ b/vortex-mask/Cargo.toml
@@ -17,6 +17,9 @@ version = { workspace = true }
 arrow = ["dep:arrow-buffer"]
 serde = ["dep:serde", "vortex-buffer/serde"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 arrow-buffer = { workspace = true, optional = true }
 itertools = { workspace = true }


### PR DESCRIPTION
Signed-off-by: Robert Kruszewski <github@robertk.io>
