### PR TITLE
[ci] Pull less build dependencies for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,9 +537,9 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install Visual Studio Build Tools (Windows)
         if: matrix.os == 'windows-x64'
-        shell: bash
         run: |
-          choco install visualstudio2022buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --passive" -y
+          choco install visualstudio2022buildtools --package-parameters `
+            "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows11SDK.26100 --passive" -y
       - name: Setup Python (Windows)
         if: matrix.os == 'windows-x64'
         uses: actions/setup-python@v5


### PR DESCRIPTION
We're currently pulling a full desktop dev setup for the windows CI, so this is an attempt to make it a faster. It seems to save just over a minute per CI run.