### PR TITLE
Fix: struct cast for arrays with duplicate fields if cast doesn't change column names

### DIFF
--- a/vortex-array/src/arrays/struct_/compute/cast.rs
+++ b/vortex-array/src/arrays/struct_/compute/cast.rs
@@ -26,11 +26,12 @@ impl CastKernel for StructVTable {
 
         let source_sdtype = array.struct_fields();
 
-        let fields_match_order = target_sdtype
-            .names()
-            .iter()
-            .zip_eq(source_sdtype.names().iter())
-            .all(|(f1, f2)| f1 == f2);
+        let fields_match_order = target_sdtype.nfields() == source_sdtype.nfields()
+            && target_sdtype
+                .names()
+                .iter()
+                .zip(source_sdtype.names().iter())
+                .all(|(f1, f2)| f1 == f2);
 
         let mut cast_fields = Vec::with_capacity(target_sdtype.nfields());
         if fields_match_order {

--- a/vortex-array/src/arrays/struct_/compute/cast.rs
+++ b/vortex-array/src/arrays/struct_/compute/cast.rs
@@ -36,7 +36,6 @@ impl CastKernel for StructVTable {
         let mut cast_fields = Vec::with_capacity(target_sdtype.nfields());
         if fields_match_order {
             for (field, target_type) in array.fields().iter().zip_eq(target_sdtype.fields()) {
-                // Field exists in source field. Cast it to the target type.
                 let cast_field = cast(field, &target_type)?;
                 cast_fields.push(cast_field);
             }

--- a/vortex-array/src/arrays/struct_/compute/cast.rs
+++ b/vortex-array/src/arrays/struct_/compute/cast.rs
@@ -35,7 +35,7 @@ impl CastKernel for StructVTable {
 
         let mut cast_fields = Vec::with_capacity(target_sdtype.nfields());
         if fields_match_order {
-            for (field, target_type) in array.fields.iter().zip_eq(target_sdtype.fields()) {
+            for (field, target_type) in array.fields().iter().zip_eq(target_sdtype.fields()) {
                 // Field exists in source field. Cast it to the target type.
                 let cast_field = cast(field, &target_type)?;
                 cast_fields.push(cast_field);
@@ -89,10 +89,12 @@ mod tests {
     use rstest::rstest;
     use vortex_buffer::buffer;
     use vortex_dtype::DType;
+    use vortex_dtype::DecimalDType;
     use vortex_dtype::FieldNames;
     use vortex_dtype::Nullability;
     use vortex_dtype::PType;
 
+    use crate::Array;
     use crate::IntoArray;
     use crate::ToCanonical;
     use crate::arrays::PrimitiveArray;
@@ -203,5 +205,31 @@ mod tests {
         assert_eq!(result.dtype(), &target_dtype);
         assert_eq!(result.len(), 3);
         assert_eq!(result.to_struct().fields().len(), 2);
+    }
+
+    #[test]
+    fn cast_add_fields() {
+        let names = FieldNames::from(["a", "b"]);
+        let field1 = buffer![1i32, 2, 3].into_array();
+        let field2 = buffer![10i64, 20, 30].into_array();
+        let target_dtype = DType::struct_(
+            [
+                ("a", field1.dtype().clone()),
+                ("b", field2.dtype().clone()),
+                (
+                    "c",
+                    DType::Decimal(DecimalDType::new(38, 10), Nullability::Nullable),
+                ),
+            ],
+            Nullability::NonNullable,
+        );
+
+        let struct_array =
+            StructArray::try_new(names, vec![field1, field2], 3, Validity::NonNullable).unwrap();
+
+        let result = crate::compute::cast(struct_array.as_ref(), &target_dtype).unwrap();
+        assert_eq!(result.dtype(), &target_dtype);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result.to_struct().fields().len(), 3);
     }
 }

--- a/vortex-array/src/arrays/struct_/compute/cast.rs
+++ b/vortex-array/src/arrays/struct_/compute/cast.rs
@@ -3,7 +3,6 @@
 
 use itertools::Itertools;
 use vortex_dtype::DType;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_scalar::Scalar;
@@ -25,33 +24,44 @@ impl CastKernel for StructVTable {
             return Ok(None);
         };
 
-        let source_sdtype = array
-            .dtype()
-            .as_struct_fields_opt()
-            .vortex_expect("struct array must have struct dtype");
+        let source_sdtype = array.struct_fields();
 
-        // Re-order, handle fields by value instead.
-        let mut cast_fields = vec![];
-        for (target_name, target_type) in
-            target_sdtype.names().iter().zip_eq(target_sdtype.fields())
-        {
-            match source_sdtype.find(target_name) {
-                None => {
-                    // No source field with this name => evolve the schema compatibly.
-                    // If the field is nullable, we add a new ConstantArray field with the type.
-                    vortex_ensure!(
-                        target_type.is_nullable(),
-                        "CAST for struct only supports added nullable fields"
-                    );
+        let fields_match_order = target_sdtype
+            .names()
+            .iter()
+            .zip_eq(source_sdtype.names().iter())
+            .all(|(f1, f2)| f1 == f2);
 
-                    cast_fields.push(
-                        ConstantArray::new(Scalar::null(target_type), array.len).into_array(),
-                    );
-                }
-                Some(src_field_idx) => {
-                    // Field exists in source field. Cast it to the target type.
-                    let cast_field = cast(array.fields()[src_field_idx].as_ref(), &target_type)?;
-                    cast_fields.push(cast_field);
+        let mut cast_fields = Vec::with_capacity(target_sdtype.nfields());
+        if fields_match_order {
+            for (field, target_type) in array.fields.iter().zip_eq(target_sdtype.fields()) {
+                // Field exists in source field. Cast it to the target type.
+                let cast_field = cast(field, &target_type)?;
+                cast_fields.push(cast_field);
+            }
+        } else {
+            // Re-order, handle fields by value instead.
+            for (target_name, target_type) in
+                target_sdtype.names().iter().zip_eq(target_sdtype.fields())
+            {
+                match source_sdtype.find(target_name) {
+                    None => {
+                        // No source field with this name => evolve the schema compatibly.
+                        // If the field is nullable, we add a new ConstantArray field with the type.
+                        vortex_ensure!(
+                            target_type.is_nullable(),
+                            "CAST for struct only supports added nullable fields"
+                        );
+
+                        cast_fields.push(
+                            ConstantArray::new(Scalar::null(target_type), array.len()).into_array(),
+                        );
+                    }
+                    Some(src_field_idx) => {
+                        // Field exists in source field. Cast it to the target type.
+                        let cast_field = cast(&array.fields()[src_field_idx], &target_type)?;
+                        cast_fields.push(cast_field);
+                    }
                 }
             }
         }
@@ -83,6 +93,7 @@ mod tests {
     use vortex_dtype::PType;
 
     use crate::IntoArray;
+    use crate::ToCanonical;
     use crate::arrays::PrimitiveArray;
     use crate::arrays::StructArray;
     use crate::arrays::VarBinArray;
@@ -174,5 +185,22 @@ mod tests {
         let result = crate::compute::cast(&empty_struct, &target_dtype).unwrap();
         assert_eq!(result.dtype(), &target_dtype);
         assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn cast_duplicate_field_names_to_nullable() {
+        let names = FieldNames::from(["a", "a"]);
+        let field1 = buffer![1i32, 2, 3].into_array();
+        let field2 = buffer![10i64, 20, 30].into_array();
+
+        let struct_array =
+            StructArray::try_new(names, vec![field1, field2], 3, Validity::NonNullable).unwrap();
+
+        let target_dtype = struct_array.dtype().as_nullable();
+
+        let result = crate::compute::cast(struct_array.as_ref(), &target_dtype).unwrap();
+        assert_eq!(result.dtype(), &target_dtype);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result.to_struct().fields().len(), 2);
     }
 }

--- a/vortex-array/src/compute/cast.rs
+++ b/vortex-array/src/compute/cast.rs
@@ -35,7 +35,13 @@ pub(crate) fn warm_up_vtable() -> usize {
 ///
 /// Some array support the ability to narrow or upcast.
 /// Struct DType casting is nominal and will resolve fields by their name and not their position.
-/// Consequently, struct casting can reorder fields and add missing fields to match the target dtype.
+///
+/// Casting allows you:
+/// 1. Cast array/field to a different dtype.
+/// 2. Add fields to a struct with null value.
+/// 3. Reorder fields in a struct.
+/// 4. Remove fields from a struct.
+/// 5. Cast top level struct nullability
 pub fn cast(array: &dyn Array, dtype: &DType) -> VortexResult<ArrayRef> {
     CAST_FN
         .invoke(&InvocationArgs {

--- a/vortex-array/src/compute/cast.rs
+++ b/vortex-array/src/compute/cast.rs
@@ -34,6 +34,8 @@ pub(crate) fn warm_up_vtable() -> usize {
 /// Attempt to cast an array to a desired DType.
 ///
 /// Some array support the ability to narrow or upcast.
+/// Struct DType casting is nominal and will resolve fields by their name and not their position.
+/// Consequently, struct casting can reorder fields and add missing fields to match the target dtype.
 pub fn cast(array: &dyn Array, dtype: &DType) -> VortexResult<ArrayRef> {
     CAST_FN
         .invoke(&InvocationArgs {

--- a/vortex-array/src/compute/mask.rs
+++ b/vortex-array/src/compute/mask.rs
@@ -118,12 +118,11 @@ impl ComputeFnVTable for MaskFn {
 
         if matches!(mask, Mask::AllTrue(_)) {
             // Fast-path for full mask.
-            return Ok(ConstantArray::new(
-                Scalar::null(array.dtype().clone().as_nullable()),
-                array.len(),
-            )
-            .into_array()
-            .into());
+            return Ok(
+                ConstantArray::new(Scalar::null(array.dtype().as_nullable()), array.len())
+                    .into_array()
+                    .into(),
+            );
         }
 
         // Do nothing if the array is already all nulls.


### PR DESCRIPTION
This has started to fail after DF 51 upgrade where we added additional logic to cast to support reordering
