### PR TITLE
[CI] Don't remove label if running from fork

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -28,8 +28,10 @@ jobs:
     steps:
       # We remove the benchmark label first so that the workflow can be re-triggered.
       - uses: actions-ecosystem/action-remove-labels@v1
+        if: ${{ github.event.pull_request.head.repo.full_name == 'vortex-data/vortex' }}
         with:
           labels: benchmark
+          fail_on_error: true
 
   bench:
     needs: label_trigger

--- a/.github/workflows/sql-pr.yml
+++ b/.github/workflows/sql-pr.yml
@@ -21,13 +21,15 @@ permissions:
 jobs:
   label_trigger:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 2
     if: ${{ contains(github.event.head_commit.message, '[benchmark-sql]') || github.event.label.name == 'benchmark-sql' && github.event_name == 'pull_request' }}
     steps:
       # We remove the benchmark label first so that the workflow can be re-triggered.
       - uses: actions-ecosystem/action-remove-labels@v1
+        if: ${{ github.event.pull_request.head.repo.full_name == 'vortex-data/vortex' }}
         with:
           labels: benchmark-sql
+          fail_on_error: true
 
   sql:
     needs: label_trigger


### PR DESCRIPTION
Removing a label requires `contents: write` permissions, which we don't want to grant to forks.