### PR TITLE
Add benchmark compare to action summary

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -121,8 +121,10 @@ jobs:
           echo '' >> comment.md
           uv run --no-project scripts/compare-benchmark-jsons.py base.json results.json "${{ matrix.benchmark.name }}" \
             >> comment.md
+          cat comment.md >> $GITHUB_STEP_SUMMARY
 
       - name: Comment PR
+        if: inputs.mode != 'pr' && github.event.pull_request.head.repo.fork == false
         uses: thollander/actions-comment-pull-request@v3
         with:
           file-path: comment.md

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -231,9 +231,10 @@ jobs:
           echo '' >> comment.md
           uv run --no-project scripts/compare-benchmark-jsons.py base.json results.json "${{ matrix.name }}" \
             >> comment.md
+          cat comment.md >> $GITHUB_STEP_SUMMARY
 
       - name: Comment PR
-        if: inputs.mode == 'pr'
+        if: inputs.mode != 'pr' && github.event.pull_request.head.repo.fork == false
         uses: thollander/actions-comment-pull-request@v3
         with:
           file-path: comment.md


### PR DESCRIPTION
Taken from the [docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#adding-a-job-summary), also only try to comment on the PR if its not coming from a fork.