### PR TITLE
Fix expression downcast

### DIFF
--- a/vortex-array/src/expr/expression.rs
+++ b/vortex-array/src/expr/expression.rs
@@ -11,7 +11,6 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 use vortex_dtype::DType;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 
@@ -19,7 +18,6 @@ use crate::ArrayRef;
 use crate::expr::Root;
 use crate::expr::ScalarFn;
 use crate::expr::StatsCatalog;
-use crate::expr::VTable;
 use crate::expr::display::DisplayTreeExpr;
 use crate::expr::stats::Stat;
 
@@ -62,22 +60,6 @@ impl Expression {
             scalar_fn,
             children,
         })
-    }
-
-    /// Returns true if this expression is of the given vtable type.
-    pub fn is<V: VTable>(&self) -> bool {
-        self.vtable().is::<V>()
-    }
-
-    /// Returns the typed options for this expression if it matches the given vtable type.
-    pub fn as_opt<V: VTable>(&self) -> Option<&V::Options> {
-        self.options().as_any().downcast_ref::<V::Options>()
-    }
-
-    /// Returns the typed options for this expression if it matches the given vtable type.
-    pub fn as_<V: VTable>(&self) -> &V::Options {
-        self.as_opt::<V>()
-            .vortex_expect("Expression options type mismatch")
     }
 
     /// Returns the scalar fn vtable for this expression.

--- a/vortex-array/src/expr/scalar_fn.rs
+++ b/vortex-array/src/expr/scalar_fn.rs
@@ -85,16 +85,12 @@ impl ScalarFn {
 
     /// Returns the typed options for this `ScalarFn` if it matches the given vtable type.
     pub fn as_opt<V: VTable>(&self) -> Option<&V::Options> {
-        if self.vtable.is::<V>() {
-            Some(
-                self.options()
-                    .as_any()
-                    .downcast_ref::<V::Options>()
-                    .vortex_expect("Expression options type mismatch"),
-            )
-        } else {
-            None
-        }
+        self.vtable.is::<V>().then(|| {
+            self.options()
+                .as_any()
+                .downcast_ref::<V::Options>()
+                .vortex_expect("Expression options type mismatch")
+        })
     }
 
     /// Returns the typed options for this `ScalarFn` if it matches the given vtable type.

--- a/vortex-array/src/expr/scalar_fn.rs
+++ b/vortex-array/src/expr/scalar_fn.rs
@@ -10,7 +10,8 @@ use std::hash::Hasher;
 use std::ops::Deref;
 
 use vortex_dtype::DType;
-use vortex_error::{VortexExpect, VortexResult};
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
 use vortex_utils::debug_with::DebugWith;
 use vortex_vector::Datum;
 

--- a/vortex-array/src/expr/scalar_fn.rs
+++ b/vortex-array/src/expr/scalar_fn.rs
@@ -10,7 +10,7 @@ use std::hash::Hasher;
 use std::ops::Deref;
 
 use vortex_dtype::DType;
-use vortex_error::VortexResult;
+use vortex_error::{VortexExpect, VortexResult};
 use vortex_utils::debug_with::DebugWith;
 use vortex_vector::Datum;
 
@@ -82,11 +82,25 @@ impl ScalarFn {
         self.vtable.is::<V>()
     }
 
-    /// Returns the typed options for this expression if it matches the given vtable type.
+    /// Returns the typed options for this `ScalarFn` if it matches the given vtable type.
     pub fn as_opt<V: VTable>(&self) -> Option<&V::Options> {
-        self.options().as_any().downcast_ref::<V::Options>()
+        if self.vtable.is::<V>() {
+            Some(
+                self.options()
+                    .as_any()
+                    .downcast_ref::<V::Options>()
+                    .vortex_expect("Expression options type mismatch"),
+            )
+        } else {
+            None
+        }
     }
 
+    /// Returns the typed options for this `ScalarFn` if it matches the given vtable type.
+    pub fn as_<V: VTable>(&self) -> &V::Options {
+        self.as_opt::<V>()
+            .vortex_expect("Expression options type mismatch")
+    }
     /// Signature information for this expression.
     pub fn signature(&self) -> ExpressionSignature<'_> {
         ExpressionSignature {


### PR DESCRIPTION
Previously we only checked that options were the correct type, and not that the vtable itself was the same. We had multiple expressions in SpiralDB that use `Options = FieldName` and they falsely matched the downcast.