### PR TITLE
Add execute function via Executable trait

### DIFF
--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -480,7 +480,6 @@ mod tests {
 
     use rstest::rstest;
     use vortex_array::ToCanonical;
-    use vortex_array::VectorExecutor;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::session::ArraySession;
@@ -508,7 +507,7 @@ mod tests {
 
         let result_canonical = {
             let mut ctx = SESSION.create_execution_ctx();
-            encoded.to_array().execute(&mut ctx).unwrap()
+            encoded.to_array().execute::<Canonical>(&mut ctx).unwrap()
         };
         // Compare against the traditional array-based decompress path
         let expected = decompress_into_array(encoded);
@@ -538,7 +537,7 @@ mod tests {
 
         let result_canonical = {
             let mut ctx = SESSION.create_execution_ctx();
-            encoded.to_array().execute(&mut ctx).unwrap()
+            encoded.to_array().execute::<Canonical>(&mut ctx).unwrap()
         };
         // Compare against the traditional array-based decompress path
         let expected = decompress_into_array(encoded);
@@ -574,7 +573,7 @@ mod tests {
 
         let result_canonical = {
             let mut ctx = SESSION.create_execution_ctx();
-            encoded.to_array().execute(&mut ctx).unwrap()
+            encoded.to_array().execute::<Canonical>(&mut ctx).unwrap()
         };
         // Compare against the traditional array-based decompress path
         let expected = decompress_into_array(encoded);
@@ -608,7 +607,7 @@ mod tests {
 
         let result_canonical = {
             let mut ctx = SESSION.create_execution_ctx();
-            encoded.to_array().execute(&mut ctx).unwrap()
+            encoded.to_array().execute::<Canonical>(&mut ctx).unwrap()
         };
         // Compare against the traditional array-based decompress path
         let expected = decompress_into_array(encoded);
@@ -653,7 +652,7 @@ mod tests {
 
         let result_canonical = {
             let mut ctx = SESSION.create_execution_ctx();
-            encoded.to_array().execute(&mut ctx).unwrap()
+            encoded.to_array().execute::<Canonical>(&mut ctx).unwrap()
         };
         // Compare against the traditional array-based decompress path
         let expected = decompress_into_array(encoded);
@@ -701,7 +700,7 @@ mod tests {
 
         let result_canonical = {
             let mut ctx = SESSION.create_execution_ctx();
-            sliced_encoded.execute(&mut ctx).unwrap()
+            sliced_encoded.execute::<Canonical>(&mut ctx).unwrap()
         };
         let result_primitive = result_canonical.into_primitive();
 

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
@@ -565,7 +565,7 @@ mod tests {
                 let mut ctx = SESSION.create_execution_ctx();
                 unpacked_array
                     .into_array()
-                    .execute(&mut ctx)
+                    .execute::<Canonical>(&mut ctx)
                     .unwrap()
                     .into_primitive()
             };
@@ -602,7 +602,7 @@ mod tests {
         let unpacked_array = unpack_array(sliced_bp);
         let executed = {
             let mut ctx = SESSION.create_execution_ctx();
-            sliced.execute(&mut ctx).unwrap()
+            sliced.execute::<Canonical>(&mut ctx).unwrap()
         };
 
         assert_eq!(

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
@@ -203,8 +203,8 @@ pub fn count_exceptions(bit_width: u8, bit_width_freq: &[usize]) -> usize {
 mod tests {
     use std::sync::LazyLock;
 
+    use vortex_array::Canonical;
     use vortex_array::IntoArray;
-    use vortex_array::VectorExecutor;
     use vortex_array::VortexSessionExecute;
     use vortex_array::assert_arrays_eq;
     use vortex_array::validity::Validity;
@@ -537,7 +537,10 @@ mod tests {
             // Method 3: Using the execute() method (this is what would be used in production).
             let executed = {
                 let mut ctx = SESSION.create_execution_ctx();
-                bitpacked.into_array().execute(&mut ctx).unwrap()
+                bitpacked
+                    .into_array()
+                    .execute::<Canonical>(&mut ctx)
+                    .unwrap()
             };
 
             // All three should produce the same length.

--- a/encodings/fsst/src/kernel.rs
+++ b/encodings/fsst/src/kernel.rs
@@ -8,13 +8,11 @@ use num_traits::AsPrimitive;
 use vortex_array::Array;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
-use vortex_array::VectorExecutor;
 use vortex_array::arrays::FilterArray;
 use vortex_array::arrays::FilterVTable;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::kernel::ExecuteParentKernel;
 use vortex_array::kernel::ParentKernelSet;
-use vortex_array::mask::MaskExecutor;
 use vortex_array::matchers::Exact;
 use vortex_array::validity::Validity;
 use vortex_array::vectors::VectorIntoArray;
@@ -68,7 +66,7 @@ impl ExecuteParentKernel<FSSTVTable> for FSSTFilterKernel {
         let uncompressed_lens = array
             .uncompressed_lengths()
             .filter(parent.filter_mask().clone())?
-            .execute(ctx)?
+            .execute::<Canonical>(ctx)?
             .into_primitive();
 
         // Extract the filtered validity
@@ -77,7 +75,7 @@ impl ExecuteParentKernel<FSSTVTable> for FSSTFilterKernel {
                 Mask::new_true(parent.filter_mask().true_count())
             }
             Validity::AllInvalid => Mask::new_false(parent.filter_mask().true_count()),
-            Validity::Array(a) => a.execute_mask(ctx)?,
+            Validity::Array(a) => a.execute::<Mask>(ctx)?,
         };
 
         // First we unpack the codes VarBinArray to get access to the raw data.
@@ -86,7 +84,7 @@ impl ExecuteParentKernel<FSSTVTable> for FSSTFilterKernel {
             .codes()
             .offsets()
             .cast(DType::Primitive(PType::U32, Nullability::NonNullable))?
-            .execute(ctx)?
+            .execute::<Canonical>(ctx)?
             .into_primitive()
             .buffer::<u32>();
 

--- a/encodings/sequence/src/kernel.rs
+++ b/encodings/sequence/src/kernel.rs
@@ -4,7 +4,6 @@
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::VectorExecutor;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::ConstantVTable;

--- a/vortex-array/src/arrays/dict/vtable/mod.rs
+++ b/vortex-array/src/arrays/dict/vtable/mod.rs
@@ -16,7 +16,6 @@ use crate::Canonical;
 use crate::DeserializeMetadata;
 use crate::ProstMetadata;
 use crate::SerializeMetadata;
-use crate::VectorExecutor;
 use crate::arrays::vtable::rules::PARENT_RULES;
 use crate::buffer::BufferHandle;
 use crate::compute::take;

--- a/vortex-array/src/arrays/filter/vtable.rs
+++ b/vortex-array/src/arrays/filter/vtable.rs
@@ -25,7 +25,6 @@ use crate::Canonical;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
 use crate::Precision;
-use crate::VectorExecutor;
 use crate::VortexSessionExecute;
 use crate::arrays::filter::array::FilterArray;
 use crate::arrays::filter::rules::PARENT_RULES;

--- a/vortex-array/src/arrays/fixed_size_list/array.rs
+++ b/vortex-array/src/arrays/fixed_size_list/array.rs
@@ -166,6 +166,10 @@ impl FixedSizeListArray {
         }
     }
 
+    pub fn into_parts(self) -> (ArrayRef, Validity) {
+        (self.elements, self.validity)
+    }
+
     /// Validates the components that would be used to create a [`FixedSizeListArray`].
     ///
     /// This function checks all the invariants required by [`FixedSizeListArray::new_unchecked`].

--- a/vortex-array/src/arrays/list/vtable/kernel/filter.rs
+++ b/vortex-array/src/arrays/list/vtable/kernel/filter.rs
@@ -8,6 +8,7 @@ use vortex_dtype::PTypeDowncastExt;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
+use vortex_vector::Vector;
 use vortex_vector::VectorMutOps;
 use vortex_vector::listview::ListViewVector;
 use vortex_vector::listview::ListViewVectorMut;
@@ -17,14 +18,12 @@ use vortex_vector::primitive::PrimitiveVector;
 use crate::Array;
 use crate::Canonical;
 use crate::ExecutionCtx;
-use crate::VectorExecutor;
 use crate::arrays::FilterArray;
 use crate::arrays::FilterVTable;
 use crate::arrays::ListArray;
 use crate::arrays::ListVTable;
 use crate::arrays::list::compute::element_mask_from_offsets;
 use crate::kernel::ExecuteParentKernel;
-use crate::mask::MaskExecutor;
 use crate::matchers::Exact;
 use crate::validity::Validity;
 use crate::vectors::VectorIntoArray;
@@ -56,8 +55,8 @@ impl ExecuteParentKernel<ListVTable> for ListFilterKernel {
         // TODO(ngates): for ultra-sparse masks, we don't need to optimize the entire offsets.
         let offsets = array
             .offsets()
-            .execute(ctx)?
-            .to_vector(ctx)?
+            .clone()
+            .execute::<Vector>(ctx)?
             .into_primitive();
 
         let new_validity = match array.validity() {
@@ -71,7 +70,9 @@ impl ExecuteParentKernel<ListVTable> for ListFilterKernel {
                 vec.append_nulls(selection.true_count());
                 return Ok(Some(vec.freeze().into_array(array.dtype()).to_canonical()));
             }
-            Validity::Array(a) => a.filter(parent.filter_mask().clone())?.execute_mask(ctx)?,
+            Validity::Array(a) => a
+                .filter(parent.filter_mask().clone())?
+                .execute::<Mask>(ctx)?,
         };
 
         let (new_offsets, new_sizes) = match_each_integer_ptype!(offsets.ptype(), |O| {
@@ -110,8 +111,7 @@ impl ExecuteParentKernel<ListVTable> for ListFilterKernel {
         let new_elements = array
             .sliced_elements()
             .filter(element_mask)?
-            .execute(ctx)?
-            .to_vector(ctx)?;
+            .execute::<Vector>(ctx)?;
 
         Ok(Some(
             unsafe {

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -17,7 +17,6 @@ use crate::ArrayChildVisitor;
 use crate::ArrayRef;
 use crate::Canonical;
 use crate::EmptyMetadata;
-use crate::VectorExecutor;
 use crate::arrays::masked::MaskedArray;
 use crate::buffer::BufferHandle;
 use crate::compute::mask;

--- a/vortex-array/src/arrays/scalar_fn/vtable/canonical.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/canonical.rs
@@ -11,7 +11,6 @@ use crate::VortexSessionExecute;
 use crate::arrays::scalar_fn::array::ScalarFnArray;
 use crate::arrays::scalar_fn::vtable::ScalarFnVTable;
 use crate::executor::CanonicalOutput;
-use crate::executor::VectorExecutor;
 use crate::expr::ExecutionArgs;
 use crate::vectors::VectorIntoArray;
 use crate::vtable::CanonicalVTable;
@@ -23,8 +22,8 @@ impl CanonicalVTable<ScalarFnVTable> for ScalarFnVTable {
 
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut child_datums = Vec::with_capacity(array.children.len());
-        for child in array.children.iter() {
-            let datum = match child.execute_output(&mut ctx).vortex_expect(
+        for child in array.children.iter().cloned() {
+            let datum = match child.execute::<CanonicalOutput>(&mut ctx).vortex_expect(
                 "Failed to execute child array during canonicalization of ScalarFnArray",
             ) {
                 CanonicalOutput::Constant(c) => Datum::Scalar(c.scalar().to_vector_scalar()),

--- a/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
@@ -17,12 +17,12 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_vector::Datum;
+use vortex_vector::Vector;
 
 use crate::Array;
 use crate::ArrayRef;
 use crate::Canonical;
 use crate::IntoArray;
-use crate::VectorExecutor;
 use crate::arrays::ConstantVTable;
 use crate::arrays::scalar_fn::array::ScalarFnArray;
 use crate::arrays::scalar_fn::metadata::ScalarFnMetadata;
@@ -146,7 +146,7 @@ impl VTable for ScalarFnVTable {
         let mut input_dtypes = Vec::with_capacity(array.children.len());
         for child in array.children.iter() {
             match child.as_opt::<ConstantVTable>() {
-                None => datums.push(Datum::Vector(child.execute(ctx)?.to_vector(ctx)?)),
+                None => datums.push(Datum::Vector(child.clone().execute::<Vector>(ctx)?)),
                 Some(constant) => datums.push(Datum::Scalar(constant.scalar().to_vector_scalar())),
             }
             input_dtypes.push(child.dtype().clone());

--- a/vortex-array/src/arrays/scalar_fn/vtable/validity.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/validity.rs
@@ -15,7 +15,6 @@ use crate::VortexSessionExecute;
 use crate::arrays::scalar_fn::array::ScalarFnArray;
 use crate::arrays::scalar_fn::vtable::ScalarFnVTable;
 use crate::executor::CanonicalOutput;
-use crate::executor::VectorExecutor;
 use crate::expr::ExecutionArgs;
 use crate::validity::Validity;
 use crate::vtable::ValidityVTable;
@@ -91,7 +90,7 @@ impl ValidityVTable<ScalarFnVTable> for ScalarFnVTable {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let output = array
             .to_array()
-            .execute_output(&mut ctx)
+            .execute::<CanonicalOutput>(&mut ctx)
             .vortex_expect("Validity mask computation should be fallible");
         match output {
             CanonicalOutput::Constant(c) => Mask::new(array.len, c.scalar().is_valid()),

--- a/vortex-array/src/arrow/compute/to_arrow/canonical.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/canonical.rs
@@ -54,12 +54,12 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 use vortex_scalar::DecimalType;
+use vortex_vector::Vector;
 
 use crate::Array as _;
 use crate::Canonical;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
-use crate::VectorExecutor;
 use crate::VortexSessionExecute;
 use crate::arrays::DecimalArray;
 use crate::arrays::FixedSizeListArray;
@@ -536,8 +536,7 @@ fn to_arrow_list<O: IntegerPType + OffsetSizeTrait>(
     let offsets = list_array
         .offsets()
         .cast(DType::from(O::PTYPE))?
-        .execute(&mut ctx)?
-        .to_vector(&mut ctx)?
+        .execute::<Vector>(&mut ctx)?
         .into_primitive()
         .downcast::<O>()
         .into_nonnull_buffer()
@@ -563,8 +562,7 @@ fn to_arrow_listview<O: IntegerPType + OffsetSizeTrait>(
     let offsets = array
         .offsets()
         .cast(offsets_dtype.clone())?
-        .execute(&mut ctx)?
-        .to_vector(&mut ctx)?
+        .execute::<Vector>(&mut ctx)?
         .into_primitive()
         .downcast::<O>()
         .into_nonnull_buffer()
@@ -572,8 +570,7 @@ fn to_arrow_listview<O: IntegerPType + OffsetSizeTrait>(
     let sizes = array
         .sizes()
         .cast(offsets_dtype)?
-        .execute(&mut ctx)?
-        .to_vector(&mut ctx)?
+        .execute::<Vector>(&mut ctx)?
         .into_primitive()
         .downcast::<O>()
         .into_nonnull_buffer()

--- a/vortex-array/src/arrow/compute/to_arrow/list.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/list.rs
@@ -14,10 +14,10 @@ use vortex_dtype::IntegerPType;
 use vortex_dtype::PTypeDowncastExt;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_vector::Vector;
 
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
-use crate::VectorExecutor;
 use crate::VortexSessionExecute;
 use crate::arrays::ListArray;
 use crate::arrays::ListVTable;
@@ -69,8 +69,7 @@ fn list_array_to_arrow_list<O: IntegerPType + OffsetSizeTrait>(
     let offsets = array
         .offsets()
         .cast(DType::Primitive(O::PTYPE, array.dtype().nullability()))?
-        .execute(&mut ctx)?
-        .to_vector(&mut ctx)?
+        .execute::<Vector>(&mut ctx)?
         .into_primitive()
         .downcast::<O>()
         .into_nonnull_buffer();

--- a/vortex-array/src/arrow/compute/to_arrow/temporal.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/temporal.rs
@@ -28,10 +28,10 @@ use vortex_dtype::datetime::is_temporal_ext_type;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_vector::Vector;
 
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
-use crate::VectorExecutor;
 use crate::VortexSessionExecute;
 use crate::arrays::ExtensionVTable;
 use crate::arrays::TemporalArray;
@@ -133,8 +133,7 @@ where
     let values = array
         .temporal_values()
         .cast(values_dtype)?
-        .execute(&mut ctx)?
-        .to_vector(&mut ctx)?
+        .execute::<Vector>(&mut ctx)?
         .into_primitive()
         .downcast::<T::Native>();
 

--- a/vortex-array/src/arrow/compute/to_arrow/varbin.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/varbin.rs
@@ -16,10 +16,10 @@ use vortex_dtype::PTypeDowncastExt;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_panic;
+use vortex_vector::Vector;
 
 use crate::Array;
 use crate::LEGACY_SESSION;
-use crate::VectorExecutor;
 use crate::VortexSessionExecute;
 use crate::arrays::VarBinArray;
 use crate::arrays::VarBinVTable;
@@ -86,8 +86,7 @@ fn to_arrow<O: IntegerPType + OffsetSizeTrait>(array: &VarBinArray) -> VortexRes
         array.offsets(),
         &DType::Primitive(O::PTYPE, Nullability::NonNullable),
     )?
-    .execute(&mut ctx)?
-    .to_vector(&mut ctx)?
+    .execute::<Vector>(&mut ctx)?
     .into_primitive()
     .downcast::<O>()
     .into_nonnull_buffer();

--- a/vortex-array/src/arrow/executor/bool.rs
+++ b/vortex-array/src/arrow/executor/bool.rs
@@ -8,8 +8,8 @@ use arrow_array::BooleanArray as ArrowBooleanArray;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::Canonical;
 use crate::ExecutionCtx;
-use crate::VectorExecutor;
 use crate::arrays::BoolArray;
 use crate::arrow::null_buffer::to_null_buffer;
 
@@ -25,6 +25,6 @@ pub(super) fn to_arrow_bool(
     array: ArrayRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrowArrayRef> {
-    let bool_array = array.execute(ctx)?.into_bool();
+    let bool_array = array.execute::<Canonical>(ctx)?.into_bool();
     Ok(canonical_bool_to_arrow(&bool_array))
 }

--- a/vortex-array/src/arrow/executor/byte.rs
+++ b/vortex-array/src/arrow/executor/byte.rs
@@ -12,10 +12,11 @@ use vortex_dtype::NativePType;
 use vortex_dtype::Nullability;
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
+use vortex_vector::Vector;
 
 use crate::ArrayRef;
+use crate::Canonical;
 use crate::ExecutionCtx;
-use crate::VectorExecutor;
 use crate::arrays::VarBinArray;
 use crate::arrays::VarBinVTable;
 use crate::arrow::executor::validity::to_arrow_null_buffer;
@@ -36,7 +37,7 @@ where
     }
 
     // Otherwise, we execute the array to a BinaryView vector and cast from there.
-    let binary_view = array.execute(ctx)?.to_vector(ctx)?.into_arrow()?;
+    let binary_view = array.execute::<Vector>(ctx)?.into_arrow()?;
     arrow_cast::cast(&binary_view, &T::DATA_TYPE).map_err(VortexError::from)
 }
 
@@ -52,7 +53,7 @@ where
     let offsets = array
         .offsets()
         .cast(DType::Primitive(T::Offset::PTYPE, Nullability::NonNullable))?
-        .execute(ctx)?
+        .execute::<Canonical>(ctx)?
         .into_primitive()
         .buffer::<T::Offset>()
         .into_arrow_offset_buffer();

--- a/vortex-array/src/arrow/executor/byte_view.rs
+++ b/vortex-array/src/arrow/executor/byte_view.rs
@@ -13,8 +13,8 @@ use vortex_dtype::arrow::FromArrowType;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::Canonical;
 use crate::ExecutionCtx;
-use crate::VectorExecutor;
 use crate::arrays::VarBinViewArray;
 use crate::arrow::null_buffer::to_null_buffer;
 use crate::builtins::ArrayBuiltins;
@@ -44,6 +44,6 @@ pub(super) fn to_arrow_byte_view<T: ByteViewType>(
     // flexible since there's no prescribed nullability in Arrow types.
     let array = array.cast(DType::from_arrow((&T::DATA_TYPE, Nullability::Nullable)))?;
 
-    let varbinview = array.execute(ctx)?.into_varbinview();
+    let varbinview = array.execute::<Canonical>(ctx)?.into_varbinview();
     Ok(canonical_varbinview_to_arrow::<T>(&varbinview))
 }

--- a/vortex-array/src/arrow/executor/decimal.rs
+++ b/vortex-array/src/arrow/executor/decimal.rs
@@ -14,10 +14,10 @@ use vortex_dtype::Nullability;
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
+use vortex_vector::Vector;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
-use crate::VectorExecutor;
 use crate::arrow::null_buffer::to_null_buffer;
 use crate::builtins::ArrayBuiltins;
 
@@ -45,7 +45,7 @@ pub(super) fn to_arrow_decimal<D: DecimalType, N: NativeDecimalType>(
     ))?;
 
     // Execute the array as a vector and downcast to our native type.
-    let vector = array.execute(ctx)?.to_vector(ctx)?.into_decimal();
+    let vector = array.execute::<Vector>(ctx)?.into_decimal();
     vortex_ensure!(
         vector.decimal_type() == N::DECIMAL_TYPE,
         "Decimal array conversion produced unexpected decimal type: expected {:?}, got {:?}",

--- a/vortex-array/src/arrow/executor/fixed_size_list.rs
+++ b/vortex-array/src/arrow/executor/fixed_size_list.rs
@@ -8,10 +8,10 @@ use vortex_compute::arrow::IntoArrow;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
+use vortex_vector::Vector;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
-use crate::VectorExecutor;
 use crate::arrays::FixedSizeListArray;
 use crate::arrays::FixedSizeListVTable;
 use crate::arrow::ArrowArrayExecutor;
@@ -31,8 +31,7 @@ pub(super) fn to_arrow_fixed_list(
 
     // Otherwise, we execute the array to become a FixedSizeListArray.
     let vector = array
-        .execute(ctx)?
-        .to_vector(ctx)?
+        .execute::<Vector>(ctx)?
         .into_fixed_size_list_opt()
         .ok_or_else(|| vortex_err!("Failed to convert array to FixedSizeListArray"))?;
     vortex_ensure!(

--- a/vortex-array/src/arrow/executor/list.rs
+++ b/vortex-array/src/arrow/executor/list.rs
@@ -66,7 +66,6 @@ pub(super) fn to_arrow_list<O: OffsetSizeTrait + NativePType>(
     let elements_dtype = array
         .dtype()
         .as_list_element_opt()
-        .clone()
         .ok_or_else(|| vortex_err!("Cannot convert non-list array to Arrow ListArray"))?;
     let nullability = array.dtype().nullability();
     let list_view = array.clone().execute::<Vector>(ctx)?.into_list();

--- a/vortex-array/src/arrow/executor/list.rs
+++ b/vortex-array/src/arrow/executor/list.rs
@@ -17,12 +17,13 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
+use vortex_vector::Vector;
 
 use crate::Array;
 use crate::ArrayRef;
+use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::VectorExecutor;
 use crate::arrays::ListArray;
 use crate::arrays::ListVTable;
 use crate::arrays::ListViewArray;
@@ -65,8 +66,10 @@ pub(super) fn to_arrow_list<O: OffsetSizeTrait + NativePType>(
     let elements_dtype = array
         .dtype()
         .as_list_element_opt()
+        .clone()
         .ok_or_else(|| vortex_err!("Cannot convert non-list array to Arrow ListArray"))?;
-    let list_view = array.execute(ctx)?.to_vector(ctx)?.into_list();
+    let nullability = array.dtype().nullability();
+    let list_view = array.clone().execute::<Vector>(ctx)?.into_list();
     let (elements, offsets, sizes, validity) = list_view.into_parts();
     let offset_dtype = DType::Primitive(O::PTYPE, Nullability::NonNullable);
     let list_view = unsafe {
@@ -74,7 +77,7 @@ pub(super) fn to_arrow_list<O: OffsetSizeTrait + NativePType>(
             (*elements).clone().into_array(elements_dtype),
             offsets.cast(&offset_dtype)?.into_array(&offset_dtype),
             sizes.cast(&offset_dtype)?.into_array(&offset_dtype),
-            Validity::from_mask(validity, array.dtype().nullability()),
+            Validity::from_mask(validity, nullability),
         )
     };
 
@@ -100,7 +103,7 @@ fn list_to_list<O: OffsetSizeTrait + NativePType>(
     let offsets = array
         .offsets()
         .cast(DType::Primitive(O::PTYPE, Nullability::NonNullable))?
-        .execute(ctx)?
+        .execute::<Canonical>(ctx)?
         .into_primitive()
         .buffer::<O>()
         .into_arrow_offset_buffer();
@@ -145,7 +148,7 @@ fn list_view_zctl<O: OffsetSizeTrait + NativePType>(
 
     let offsets = offsets
         .cast(DType::Primitive(O::PTYPE, Nullability::NonNullable))?
-        .execute(ctx)?
+        .execute::<Canonical>(ctx)?
         .into_primitive()
         .buffer::<O>();
 
@@ -190,12 +193,12 @@ fn list_view_to_list<O: OffsetSizeTrait + NativePType>(
 
     let offsets = offsets
         .cast(DType::Primitive(O::PTYPE, Nullability::NonNullable))?
-        .execute(ctx)?
+        .execute::<Canonical>(ctx)?
         .into_primitive()
         .buffer::<O>();
     let sizes = sizes
         .cast(DType::Primitive(O::PTYPE, Nullability::NonNullable))?
-        .execute(ctx)?
+        .execute::<Canonical>(ctx)?
         .into_primitive()
         .buffer::<O>();
 

--- a/vortex-array/src/arrow/executor/list_view.rs
+++ b/vortex-array/src/arrow/executor/list_view.rs
@@ -14,11 +14,12 @@ use vortex_dtype::Nullability::NonNullable;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
+use vortex_vector::Vector;
 use vortex_vector::listview::ListViewVector;
 
 use crate::ArrayRef;
+use crate::Canonical;
 use crate::ExecutionCtx;
-use crate::VectorExecutor;
 use crate::arrays::ListViewArray;
 use crate::arrays::ListViewVTable;
 use crate::arrow::ArrowArrayExecutor;
@@ -38,8 +39,7 @@ pub(super) fn to_arrow_list_view<O: OffsetSizeTrait + IntegerPType>(
 
     // Otherwise, we execute as a vector and convert.
     let mut vector = array
-        .execute(ctx)?
-        .to_vector(ctx)?
+        .execute::<Vector>(ctx)?
         .into_list_opt()
         .ok_or_else(|| vortex_err!("Failed to convert array to ListVector"))?;
 
@@ -73,13 +73,13 @@ fn list_view_to_list_view<O: OffsetSizeTrait + IntegerPType>(
 
     let offsets = offsets
         .cast(DType::Primitive(O::PTYPE, NonNullable))?
-        .execute(ctx)?
+        .execute::<Canonical>(ctx)?
         .into_primitive()
         .buffer::<O>()
         .into_arrow_scalar_buffer();
     let sizes = sizes
         .cast(DType::Primitive(O::PTYPE, NonNullable))?
-        .execute(ctx)?
+        .execute::<Canonical>(ctx)?
         .into_primitive()
         .buffer::<O>()
         .into_arrow_scalar_buffer();

--- a/vortex-array/src/arrow/executor/null.rs
+++ b/vortex-array/src/arrow/executor/null.rs
@@ -8,8 +8,8 @@ use arrow_array::NullArray as ArrowNullArray;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::Canonical;
 use crate::ExecutionCtx;
-use crate::VectorExecutor;
 use crate::arrays::NullArray;
 
 /// Convert a canonical NullArray directly to Arrow.
@@ -21,6 +21,6 @@ pub(super) fn to_arrow_null(
     array: ArrayRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrowArrayRef> {
-    let canonical = array.execute(ctx)?.into_null();
+    let canonical = array.execute::<Canonical>(ctx)?.into_null();
     Ok(canonical_null_to_arrow(&canonical))
 }

--- a/vortex-array/src/arrow/executor/primitive.rs
+++ b/vortex-array/src/arrow/executor/primitive.rs
@@ -12,8 +12,8 @@ use vortex_dtype::Nullability;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::Canonical;
 use crate::ExecutionCtx;
-use crate::VectorExecutor;
 use crate::arrays::PrimitiveArray;
 use crate::arrow::null_buffer::to_null_buffer;
 use crate::builtins::ArrayBuiltins;
@@ -38,6 +38,6 @@ where
 {
     // We use nullable here so we can essentially ignore nullability during the cast.
     let array = array.cast(DType::Primitive(T::Native::PTYPE, Nullability::Nullable))?;
-    let primitive = array.execute(ctx)?.into_primitive();
+    let primitive = array.execute::<Canonical>(ctx)?.into_primitive();
     Ok(canonical_primitive_to_arrow::<T>(primitive))
 }

--- a/vortex-array/src/arrow/executor/struct_.rs
+++ b/vortex-array/src/arrow/executor/struct_.rs
@@ -16,13 +16,13 @@ use vortex_dtype::arrow::FromArrowType;
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
+use vortex_vector::Vector;
 
 use crate::Array;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::ToCanonical;
-use crate::VectorExecutor;
 use crate::arrays::ChunkedVTable;
 use crate::arrays::ScalarFnVTable;
 use crate::arrays::StructVTable;
@@ -79,11 +79,7 @@ pub(super) fn to_arrow_struct(
         vortex_dtype::Nullability::Nullable,
     ))?;
 
-    let struct_array = array
-        .execute(ctx)?
-        .to_vector(ctx)?
-        .into_struct()
-        .into_arrow()?;
+    let struct_array = array.execute::<Vector>(ctx)?.into_struct().into_arrow()?;
 
     // Finally, we cast to Arrow to ensure any types not representable by Vortex (e.g. Dictionary)
     // are properly converted.

--- a/vortex-array/src/arrow/executor/temporal.rs
+++ b/vortex-array/src/arrow/executor/temporal.rs
@@ -30,8 +30,8 @@ use vortex_error::vortex_ensure;
 
 use crate::Array;
 use crate::ArrayRef;
+use crate::Canonical;
 use crate::ExecutionCtx;
-use crate::VectorExecutor;
 use crate::arrow::null_buffer::to_null_buffer;
 
 pub(super) fn to_arrow_temporal(
@@ -126,7 +126,7 @@ fn to_arrow_temporal_primitive<T: ArrowTemporalType>(
 where
     T::Native: NativePType,
 {
-    let primitive = array.execute(ctx)?.into_primitive();
+    let primitive = array.execute::<Canonical>(ctx)?.into_primitive();
     vortex_ensure!(
         primitive.ptype() == T::Native::PTYPE,
         "Expected temporal array to produce vector of width {}, found {}",

--- a/vortex-array/src/arrow/executor/validity.rs
+++ b/vortex-array/src/arrow/executor/validity.rs
@@ -3,10 +3,10 @@
 
 use arrow_buffer::NullBuffer;
 use vortex_error::VortexResult;
+use vortex_mask::Mask;
 
 use crate::ExecutionCtx;
 use crate::arrow::null_buffer::to_null_buffer;
-use crate::mask::MaskExecutor;
 use crate::validity::Validity;
 
 pub(super) fn to_arrow_null_buffer(
@@ -17,6 +17,6 @@ pub(super) fn to_arrow_null_buffer(
     Ok(match validity {
         Validity::NonNullable | Validity::AllValid => None,
         Validity::AllInvalid => Some(NullBuffer::new_null(len)),
-        Validity::Array(array) => to_null_buffer(array.execute_mask(ctx)?),
+        Validity::Array(array) => to_null_buffer(array.clone().execute::<Mask>(ctx)?),
     })
 }

--- a/vortex-array/src/canonical_to_vector.rs
+++ b/vortex-array/src/canonical_to_vector.rs
@@ -10,6 +10,7 @@ use vortex_dtype::PrecisionScale;
 use vortex_dtype::match_each_decimal_value_type;
 use vortex_dtype::match_each_native_ptype;
 use vortex_error::VortexResult;
+use vortex_mask::Mask;
 use vortex_vector::Vector;
 use vortex_vector::binaryview::BinaryVector;
 use vortex_vector::binaryview::StringVector;
@@ -21,9 +22,23 @@ use vortex_vector::null::NullVector;
 use vortex_vector::primitive::PVector;
 use vortex_vector::struct_::StructVector;
 
+use crate::ArrayRef;
 use crate::Canonical;
+use crate::Executable;
 use crate::ExecutionCtx;
-use crate::VectorExecutor;
+
+impl Executable for Vector {
+    type Options = ();
+
+    fn execute_with_options(
+        array: ArrayRef,
+        ctx: &mut ExecutionCtx,
+        _options: Self::Options,
+    ) -> VortexResult<Self> {
+        let canonical = array.execute::<Canonical>(ctx)?;
+        canonical.to_vector(ctx)
+    }
+}
 
 impl Canonical {
     /// Convert a Canonical array to a Vector.
@@ -77,10 +92,12 @@ impl Canonical {
                 }
             }
             Canonical::List(a) => {
-                let validity = a.validity_mask();
-                let elements_vector = a.elements().execute(ctx)?.to_vector(ctx)?;
-                let offsets = a.offsets().execute(ctx)?.into_primitive();
-                let sizes = a.sizes().execute(ctx)?.into_primitive();
+                let (elements, offsets, sizes, validity) = a.into_parts();
+
+                let validity = validity.to_array(offsets.len()).execute::<Mask>(ctx)?;
+                let elements_vector = elements.execute::<Vector>(ctx)?;
+                let offsets = offsets.execute::<Canonical>(ctx)?.into_primitive();
+                let sizes = sizes.execute::<Canonical>(ctx)?.into_primitive();
                 let offsets_ptype = offsets.ptype();
                 let sizes_ptype = sizes.ptype();
 
@@ -108,7 +125,7 @@ impl Canonical {
             Canonical::FixedSizeList(a) => {
                 let validity = a.validity_mask();
                 let list_size = a.list_size();
-                let elements_vector = a.elements().execute(ctx)?.to_vector(ctx)?;
+                let elements_vector = a.elements().clone().execute::<Vector>(ctx)?;
                 Vector::FixedSizeList(unsafe {
                     FixedSizeListVector::new_unchecked(
                         Arc::new(elements_vector),
@@ -120,15 +137,15 @@ impl Canonical {
             Canonical::Struct(a) => {
                 let validity = a.validity_mask();
                 let mut fields = Vec::with_capacity(a.fields().len());
-                for f in a.fields().iter() {
-                    fields.push(f.execute(ctx)?.to_vector(ctx)?);
+                for f in a.fields().iter().cloned() {
+                    fields.push(f.execute::<Vector>(ctx)?);
                 }
                 let fields: Box<[Vector]> = fields.into_boxed_slice();
                 Vector::Struct(StructVector::new(Arc::new(fields), validity))
             }
             Canonical::Extension(a) => {
                 // For extension arrays, convert the underlying storage
-                a.storage().execute(ctx)?.to_vector(ctx)?
+                a.storage().clone().execute::<Vector>(ctx)?
             }
         })
     }

--- a/vortex-array/src/canonical_to_vector.rs
+++ b/vortex-array/src/canonical_to_vector.rs
@@ -28,13 +28,7 @@ use crate::Executable;
 use crate::ExecutionCtx;
 
 impl Executable for Vector {
-    type Options = ();
-
-    fn execute_with_options(
-        array: ArrayRef,
-        ctx: &mut ExecutionCtx,
-        _options: Self::Options,
-    ) -> VortexResult<Self> {
+    fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
         let canonical = array.execute::<Canonical>(ctx)?;
         canonical.to_vector(ctx)
     }

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::sync::Arc;
+
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;
 
@@ -9,6 +11,39 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::arrays::ConstantArray;
 use crate::arrays::ConstantVTable;
+
+/// Marker trait for types that can be executed.
+pub trait Executable: Sized {
+    /// Options for execution.
+    type Options: Default;
+
+    /// Execute the given array to produce [`Self`].
+    fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
+        Self::execute_with_options(array, ctx, Self::Options::default())
+    }
+
+    fn execute_with_options(
+        array: ArrayRef,
+        ctx: &mut ExecutionCtx,
+        options: Self::Options,
+    ) -> VortexResult<Self>;
+}
+
+impl dyn Array + '_ {
+    /// Execute this array to produce an instance of `E`.
+    pub fn execute<E: Executable>(self: Arc<Self>, ctx: &mut ExecutionCtx) -> VortexResult<E> {
+        E::execute(self, ctx)
+    }
+
+    /// Execute this array to produce an instance of `E` with options.
+    pub fn execute_with_options<E: Executable>(
+        self: Arc<Self>,
+        ctx: &mut ExecutionCtx,
+        options: E::Options,
+    ) -> VortexResult<E> {
+        E::execute_with_options(self, ctx, options)
+    }
+}
 
 /// The result of executing an array, which can either be a constant (scalar repeated)
 /// or a fully materialized canonical array.
@@ -40,32 +75,27 @@ impl ExecutionCtx {
     }
 }
 
-/// Executor for exporting Vortex arrays to canonical form.
-pub trait VectorExecutor {
-    /// Recursively execute the array to canonical form.
-    /// This will replace the recursive usage of `to_canonical()`.
-    /// An `ExecutionCtx` is will be used to limit access to buffers.
-    fn execute(&self, ctx: &mut ExecutionCtx) -> VortexResult<Canonical>;
+/// Recursively execute the array to canonical form.
+/// This will replace the recursive usage of `to_canonical()`.
+/// An `ExecutionCtx` is will be used to limit access to buffers.
+impl Executable for Canonical {
+    type Options = ();
 
-    /// Execute the array and return a [`CanonicalOutput`].
-    ///
-    /// This may short-circuit for constant arrays, returning [`CanonicalOutput::Constant`]
-    /// instead of fully materializing the array.
-    fn execute_output(&self, ctx: &mut ExecutionCtx) -> VortexResult<CanonicalOutput>;
-}
-
-impl VectorExecutor for ArrayRef {
-    fn execute(&self, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
+    fn execute_with_options(
+        array: ArrayRef,
+        ctx: &mut ExecutionCtx,
+        _options: Self::Options,
+    ) -> VortexResult<Self> {
         // Try and dispatch to a child that can optimize execution.
-        for (child_idx, child) in self.children().iter().enumerate() {
+        for (child_idx, child) in array.children().iter().enumerate() {
             if let Some(result) = child
                 .encoding()
                 .as_dyn()
-                .execute_canonical_parent(child, self, child_idx, ctx)?
+                .execute_canonical_parent(child, &array, child_idx, ctx)?
             {
                 tracing::debug!(
                     "Executed array {} via child {} optimization.",
-                    self.encoding_id(),
+                    array.encoding_id(),
                     child.encoding_id()
                 );
                 return Ok(result);
@@ -73,20 +103,32 @@ impl VectorExecutor for ArrayRef {
         }
 
         // Otherwise fall back to the default execution.
-        self.encoding().as_dyn().execute_canonical(self, ctx)
+        array.encoding().as_dyn().execute_canonical(&array, ctx)
     }
+}
 
-    fn execute_output(&self, ctx: &mut ExecutionCtx) -> VortexResult<CanonicalOutput> {
+/// Execute the array and return a [`CanonicalOutput`].
+///
+/// This may short-circuit for constant arrays, returning [`CanonicalOutput::Constant`]
+/// instead of fully materializing the array.
+impl Executable for CanonicalOutput {
+    type Options = ();
+
+    fn execute_with_options(
+        array: ArrayRef,
+        ctx: &mut ExecutionCtx,
+        _options: Self::Options,
+    ) -> VortexResult<Self> {
         // Attempt to short-circuit constant arrays.
-        if let Some(constant) = self.as_opt::<ConstantVTable>() {
+        if let Some(constant) = array.as_opt::<ConstantVTable>() {
             return Ok(CanonicalOutput::Constant(ConstantArray::new(
                 constant.scalar().clone(),
                 constant.len(),
             )));
         }
 
-        tracing::debug!("Executing array {}:\n{}", self, self.display_tree());
-        Ok(CanonicalOutput::Array(self.execute(ctx)?))
+        tracing::debug!("Executing array {}:\n{}", array, array.display_tree());
+        Ok(CanonicalOutput::Array(array.execute(ctx)?))
     }
 }
 

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -14,34 +14,13 @@ use crate::arrays::ConstantVTable;
 
 /// Marker trait for types that can be executed.
 pub trait Executable: Sized {
-    /// Options for execution.
-    type Options: Default;
-
-    /// Execute the given array to produce [`Self`].
-    fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
-        Self::execute_with_options(array, ctx, Self::Options::default())
-    }
-
-    fn execute_with_options(
-        array: ArrayRef,
-        ctx: &mut ExecutionCtx,
-        options: Self::Options,
-    ) -> VortexResult<Self>;
+    fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self>;
 }
 
 impl dyn Array + '_ {
     /// Execute this array to produce an instance of `E`.
     pub fn execute<E: Executable>(self: Arc<Self>, ctx: &mut ExecutionCtx) -> VortexResult<E> {
         E::execute(self, ctx)
-    }
-
-    /// Execute this array to produce an instance of `E` with options.
-    pub fn execute_with_options<E: Executable>(
-        self: Arc<Self>,
-        ctx: &mut ExecutionCtx,
-        options: E::Options,
-    ) -> VortexResult<E> {
-        E::execute_with_options(self, ctx, options)
     }
 }
 
@@ -79,13 +58,7 @@ impl ExecutionCtx {
 /// This will replace the recursive usage of `to_canonical()`.
 /// An `ExecutionCtx` is will be used to limit access to buffers.
 impl Executable for Canonical {
-    type Options = ();
-
-    fn execute_with_options(
-        array: ArrayRef,
-        ctx: &mut ExecutionCtx,
-        _options: Self::Options,
-    ) -> VortexResult<Self> {
+    fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
         // Try and dispatch to a child that can optimize execution.
         for (child_idx, child) in array.children().iter().enumerate() {
             if let Some(result) = child
@@ -112,13 +85,7 @@ impl Executable for Canonical {
 /// This may short-circuit for constant arrays, returning [`CanonicalOutput::Constant`]
 /// instead of fully materializing the array.
 impl Executable for CanonicalOutput {
-    type Options = ();
-
-    fn execute_with_options(
-        array: ArrayRef,
-        ctx: &mut ExecutionCtx,
-        _options: Self::Options,
-    ) -> VortexResult<Self> {
+    fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
         // Attempt to short-circuit constant arrays.
         if let Some(constant) = array.as_opt::<ConstantVTable>() {
             return Ok(CanonicalOutput::Constant(ConstantArray::new(

--- a/vortex-array/src/mask.rs
+++ b/vortex-array/src/mask.rs
@@ -10,25 +10,32 @@ use vortex_mask::Mask;
 
 use crate::Array;
 use crate::ArrayRef;
+use crate::Executable;
 use crate::ExecutionCtx;
+use crate::arrays::ConstantVTable;
 use crate::executor::CanonicalOutput;
-use crate::executor::VectorExecutor;
 
-/// Executor for exporting a Vortex [`Mask`] from an [`ArrayRef`].
-pub trait MaskExecutor {
-    /// Execute the array to produce a mask.
-    fn execute_mask(&self, ctx: &mut ExecutionCtx) -> VortexResult<Mask>;
-}
+impl Executable for Mask {
+    type Options = ();
 
-impl MaskExecutor for ArrayRef {
-    fn execute_mask(&self, ctx: &mut ExecutionCtx) -> VortexResult<Mask> {
-        if !matches!(self.dtype(), DType::Bool(_)) {
-            vortex_bail!("Mask array must have boolean dtype, not {}", self.dtype());
+    fn execute_with_options(
+        array: ArrayRef,
+        ctx: &mut ExecutionCtx,
+        _options: Self::Options,
+    ) -> VortexResult<Self> {
+        if !matches!(array.dtype(), DType::Bool(_)) {
+            vortex_bail!("Mask array must have boolean dtype, not {}", array.dtype());
         }
 
-        Ok(match self.execute_output(ctx)? {
+        if let Some(constant) = array.as_opt::<ConstantVTable>() {
+            let mask_value = constant.scalar().as_bool().value().unwrap_or(false);
+            return Ok(Mask::new(array.len(), mask_value));
+        }
+
+        let array_len = array.len();
+        Ok(match array.execute(ctx)? {
             CanonicalOutput::Constant(c) => {
-                Mask::new(self.len(), c.scalar().as_bool().value().unwrap_or(false))
+                Mask::new(array_len, c.scalar().as_bool().value().unwrap_or(false))
             }
             CanonicalOutput::Array(a) => {
                 let (bits, mask) = a.to_vector(ctx)?.into_bool().into_parts();

--- a/vortex-array/src/mask.rs
+++ b/vortex-array/src/mask.rs
@@ -16,13 +16,7 @@ use crate::arrays::ConstantVTable;
 use crate::executor::CanonicalOutput;
 
 impl Executable for Mask {
-    type Options = ();
-
-    fn execute_with_options(
-        array: ArrayRef,
-        ctx: &mut ExecutionCtx,
-        _options: Self::Options,
-    ) -> VortexResult<Self> {
+    fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
         if !matches!(array.dtype(), DType::Bool(_)) {
             vortex_bail!("Mask array must have boolean dtype, not {}", array.dtype());
         }

--- a/vortex-array/src/vtable/mod.rs
+++ b/vortex-array/src/vtable/mod.rs
@@ -142,9 +142,6 @@ pub trait VTable: 'static + Sized + Send + Sync + Debug {
     ///
     /// Debug builds will panic if the returned array is of the wrong type, wrong length, or
     /// incorrectly contains null values.
-    ///
-    /// Implementations should recursively call [`crate::executor::VectorExecutor::execute`]
-    /// on child arrays as needed.
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
         // TODO(ngates): convert arrays to canonicalize over vectors, so remove default impl.
         Ok(Self::CanonicalVTable::canonicalize(array))

--- a/vortex-bench/src/random_access/take.rs
+++ b/vortex-bench/src/random_access/take.rs
@@ -19,8 +19,8 @@ use parquet::file::metadata::RowGroupMetaData;
 use stream::StreamExt;
 use vortex::array::Array;
 use vortex::array::ArrayRef;
+use vortex::array::Canonical;
 use vortex::array::IntoArray;
-use vortex::array::VectorExecutor;
 use vortex::array::VortexSessionExecute;
 use vortex::array::stream::ArrayStreamExt;
 use vortex::buffer::Buffer;
@@ -146,7 +146,7 @@ async fn take_vortex(reader: impl AsRef<Path>, indices: Buffer<u64>) -> anyhow::
     // We canonicalize / decompress for equivalence to Arrow's `RecordBatch`es.
     Ok(if *USE_VORTEX_OPERATORS {
         let mut ctx = SESSION.create_execution_ctx();
-        array.execute(&mut ctx)?.into_array()
+        array.execute::<Canonical>(&mut ctx)?.into_array()
     } else {
         array.to_canonical().into_array()
     })

--- a/vortex-duckdb/src/exporter/dict.rs
+++ b/vortex-duckdb/src/exporter/dict.rs
@@ -8,16 +8,15 @@ use bitvec::macros::internal::funty::Fundamental;
 use num_traits::AsPrimitive;
 use parking_lot::Mutex;
 use vortex::array::Array;
+use vortex::array::Canonical;
 use vortex::array::ExecutionCtx;
 use vortex::array::IntoArray;
 use vortex::array::ToCanonical;
-use vortex::array::VectorExecutor;
 use vortex::array::arrays::ConstantArray;
 use vortex::array::arrays::ConstantVTable;
 use vortex::array::arrays::DictArray;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::builtins::ArrayBuiltins;
-use vortex::array::mask::MaskExecutor;
 use vortex::array::validity::Validity;
 use vortex::array::vtable::ValidityHelper;
 use vortex::compute;
@@ -177,12 +176,16 @@ pub(crate) fn new_operator_exporter_with_flatten(
     if let Some(constant) = values.as_opt::<ConstantVTable>() {
         return constant::new_exporter_with_mask(
             &ConstantArray::new(constant.scalar().clone(), array.codes().len()),
-            array.codes().is_null()?.not()?.execute_mask(ctx)?,
+            array.codes().is_null()?.not()?.execute::<Mask>(ctx)?,
             cache,
         );
     }
 
-    let codes = array.codes().execute(ctx)?.into_primitive();
+    let codes = array
+        .codes()
+        .clone()
+        .execute::<Canonical>(ctx)?
+        .into_primitive();
 
     match codes.validity() {
         Validity::AllValid | Validity::NonNullable => {}
@@ -217,7 +220,7 @@ pub(crate) fn new_operator_exporter_with_flatten(
         return new_operator_array_exporter(
             unsafe { DictArray::new_unchecked(codes.into_array(), canonical.into_array()) }
                 .into_array()
-                .execute(ctx)?
+                .execute::<Canonical>(ctx)?
                 .into_array(),
             // Take::take(values, &codes).into_array(array.dtype()),
             cache,

--- a/vortex-duckdb/src/exporter/list.rs
+++ b/vortex-duckdb/src/exporter/list.rs
@@ -5,9 +5,9 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
+use vortex::array::Canonical;
 use vortex::array::ExecutionCtx;
 use vortex::array::ToCanonical;
-use vortex::array::VectorExecutor;
 use vortex::array::arrays::ListArray;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::dtype::IntegerPType;
@@ -177,7 +177,11 @@ pub(crate) fn new_operator_exporter(
         }
     };
 
-    let offsets = array.offsets().execute(ctx)?.into_primitive();
+    let offsets = array
+        .offsets()
+        .clone()
+        .execute::<Canonical>(ctx)?
+        .into_primitive();
 
     let boxed = match_each_integer_ptype!(offsets.ptype(), |O| {
         Box::new(ListExporter {

--- a/vortex-duckdb/src/exporter/list_view.rs
+++ b/vortex-duckdb/src/exporter/list_view.rs
@@ -6,9 +6,9 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 use vortex::array::Array;
+use vortex::array::Canonical;
 use vortex::array::ExecutionCtx;
 use vortex::array::ToCanonical;
-use vortex::array::VectorExecutor;
 use vortex::array::arrays::ListViewArray;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::dtype::IntegerPType;
@@ -187,8 +187,16 @@ pub(crate) fn new_operator_exporter(
         }
     };
 
-    let offsets = array.offsets().execute(ctx)?.into_primitive();
-    let sizes = array.sizes().execute(ctx)?.into_primitive();
+    let offsets = array
+        .offsets()
+        .clone()
+        .execute::<Canonical>(ctx)?
+        .into_primitive();
+    let sizes = array
+        .sizes()
+        .clone()
+        .execute::<Canonical>(ctx)?
+        .into_primitive();
 
     let boxed = match_each_integer_ptype!(offsets.ptype(), |O| {
         match_each_integer_ptype!(sizes.ptype(), |S| {

--- a/vortex-duckdb/src/exporter/mod.rs
+++ b/vortex-duckdb/src/exporter/mod.rs
@@ -27,7 +27,6 @@ use vortex::array::Array;
 use vortex::array::ArrayRef;
 use vortex::array::Canonical;
 use vortex::array::ExecutionCtx;
-use vortex::array::VectorExecutor;
 use vortex::array::arrays::ConstantVTable;
 use vortex::array::arrays::DictVTable;
 use vortex::array::arrays::ListVTable;
@@ -211,8 +210,8 @@ fn new_array_operator_exporter_with_flatten(
     }
 
     // Otherwise, we fall back to canonical
-    match array.execute(ctx)? {
-        Canonical::Null(_) => Ok(all_invalid::new_exporter(array.len(), &LogicalType::null())),
+    match array.execute::<Canonical>(ctx)? {
+        Canonical::Null(array) => Ok(all_invalid::new_exporter(array.len(), &LogicalType::null())),
         Canonical::Bool(array) => bool::new_exporter(array),
         Canonical::Primitive(array) => primitive::new_exporter(array),
         Canonical::Decimal(array) => decimal::new_exporter(array),

--- a/vortex-duckdb/src/exporter/run_end.rs
+++ b/vortex-duckdb/src/exporter/run_end.rs
@@ -4,9 +4,9 @@
 use std::marker::PhantomData;
 
 use vortex::array::ArrayRef;
+use vortex::array::Canonical;
 use vortex::array::ExecutionCtx;
 use vortex::array::ToCanonical;
-use vortex::array::VectorExecutor;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::search_sorted::SearchSorted;
 use vortex::array::search_sorted::SearchSortedSide;
@@ -58,7 +58,11 @@ pub(crate) fn new_operator_exporter(
     cache: &ConversionCache,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Box<dyn ColumnExporter>> {
-    let ends = array.ends().execute(ctx)?.into_primitive();
+    let ends = array
+        .ends()
+        .clone()
+        .execute::<Canonical>(ctx)?
+        .into_primitive();
     let values = array.values().clone();
     let values_exporter = new_operator_array_exporter(values.clone(), cache, ctx)?;
 

--- a/vortex-duckdb/src/exporter/temporal.rs
+++ b/vortex-duckdb/src/exporter/temporal.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex::array::Canonical;
 use vortex::array::ExecutionCtx;
 use vortex::array::ToCanonical;
-use vortex::array::VectorExecutor;
 use vortex::array::arrays::TemporalArray;
 use vortex::error::VortexResult;
 
@@ -35,7 +35,11 @@ pub(crate) fn new_operator_exporter(
 ) -> VortexResult<Box<dyn ColumnExporter>> {
     Ok(Box::new(TemporalExporter {
         storage_type_exporter: primitive::new_exporter(
-            array.temporal_values().execute(ctx)?.into_primitive(),
+            array
+                .temporal_values()
+                .clone()
+                .execute::<Canonical>(ctx)?
+                .into_primitive(),
         )?,
     }))
 }

--- a/vortex-duckdb/src/scan.rs
+++ b/vortex-duckdb/src/scan.rs
@@ -25,9 +25,9 @@ use num_traits::AsPrimitive;
 use url::Url;
 use vortex::VortexSessionDefault;
 use vortex::array::ArrayRef;
+use vortex::array::Canonical;
 use vortex::array::ExecutionCtx;
 use vortex::array::ToCanonical;
-use vortex::array::VectorExecutor;
 use vortex::array::arrays::ScalarFnVTable;
 use vortex::array::arrays::StructArray;
 use vortex::array::arrays::StructVTable;
@@ -342,7 +342,9 @@ impl TableFunction for VortexTableFunction {
                             pack_options.nullability.into(),
                         )
                     } else {
-                        array_result.execute(&mut global_state.ctx)?.into_struct()
+                        array_result
+                            .execute::<Canonical>(&mut global_state.ctx)?
+                            .into_struct()
                     }
                 } else {
                     array_result.to_struct()

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -12,7 +12,6 @@ use std::sync::Arc;
 use itertools::Itertools;
 use vortex_array::ArrayRef;
 use vortex_array::CanonicalOutput;
-use vortex_array::VectorExecutor;
 use vortex_array::VortexSessionExecute;
 use vortex_array::expr::Expression;
 use vortex_array::expr::pruning::checked_pruning_expr;
@@ -162,7 +161,7 @@ impl VortexFile {
 
         Ok(if *USE_VORTEX_OPERATORS {
             let mut ctx = self.session.create_execution_ctx();
-            match file_stats.execute_output(&mut ctx)? {
+            match file_stats.execute::<CanonicalOutput>(&mut ctx)? {
                 CanonicalOutput::Constant(c) => c.scalar().as_bool().value() == Some(true),
                 CanonicalOutput::Array(_) => false,
             }

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -13,10 +13,10 @@ use futures::future::BoxFuture;
 use futures::try_join;
 use vortex_array::Array;
 use vortex_array::ArrayRef;
+use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::MaskFuture;
-use vortex_array::VectorExecutor;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::DictArray;
 use vortex_array::compute::MinMaxResult;
@@ -24,7 +24,6 @@ use vortex_array::compute::min_max;
 use vortex_array::compute::take;
 use vortex_array::expr::Expression;
 use vortex_array::expr::root;
-use vortex_array::mask::MaskExecutor;
 use vortex_array::optimizer::ArrayOptimizer;
 use vortex_dtype::DType;
 use vortex_dtype::FieldMask;
@@ -109,7 +108,7 @@ impl DictReader {
                             // We execute the array to avoid re-evaluating for every split.
                             let array = array?;
                             let mut ctx = ExecutionCtx::new(session);
-                            Ok(array.execute(&mut ctx)?.into_array())
+                            Ok(array.execute::<Canonical>(&mut ctx)?.into_array())
                         } else {
                             Ok(array?.to_canonical().into_array())
                         }
@@ -135,7 +134,7 @@ impl DictReader {
                             let array = array?.apply(&expr)?;
                             // We execute the array to avoid re-evaluating for every split.
                             let mut ctx = ExecutionCtx::new(session);
-                            Ok(array.execute(&mut ctx)?.into_array())
+                            Ok(array.execute::<Canonical>(&mut ctx)?.into_array())
                         } else {
                             expr.evaluate(&array?).map_err(Arc::new)
                         }
@@ -209,7 +208,7 @@ impl LayoutReader for DictReader {
 
             let dict_mask = if *USE_VORTEX_OPERATORS {
                 let mut ctx = session.create_execution_ctx();
-                values.take(codes)?.execute_mask(&mut ctx)?
+                values.take(codes)?.execute::<Mask>(&mut ctx)?
             } else {
                 // Short-circuit when the values are all true/false.
                 if values.all_valid()

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -15,7 +15,6 @@ use vortex_array::VortexSessionExecute;
 use vortex_array::compute::filter;
 use vortex_array::expr::Expression;
 use vortex_array::expr::Root;
-use vortex_array::mask::MaskExecutor;
 use vortex_array::serde::ArrayParts;
 use vortex_dtype::DType;
 use vortex_dtype::FieldMask;
@@ -155,14 +154,14 @@ impl LayoutReader for FlatReader {
                     let array = array.apply(&expr)?;
                     let array = array.filter(mask.clone())?;
                     let mut ctx = session.create_execution_ctx();
-                    let array_mask = array.execute_mask(&mut ctx)?;
+                    let array_mask = array.execute::<Mask>(&mut ctx)?;
 
                     mask.intersect_by_rank(&array_mask)
                 } else {
                     // Run over the full array, with a simpler bitand at the end.
                     let array = array.apply(&expr)?;
                     let mut ctx = session.create_execution_ctx();
-                    let array_mask = array.execute_mask(&mut ctx)?;
+                    let array_mask = array.execute::<Mask>(&mut ctx)?;
 
                     mask.bitand(&array_mask)
                 }

--- a/vortex-layout/src/layouts/partitioned.rs
+++ b/vortex-layout/src/layouts/partitioned.rs
@@ -13,12 +13,12 @@ use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::StructArray;
 use vortex_array::expr::Expression;
 use vortex_array::expr::transform::PartitionedExpr;
-use vortex_array::mask::MaskExecutor;
 use vortex_array::validity::Validity;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
+use vortex_mask::Mask;
 use vortex_session::VortexSession;
 
 use crate::ArrayFuture;
@@ -92,7 +92,7 @@ impl<P: Send + Sync + 'static> PartitionedExprEval<P> for PartitionedExpr<P> {
 
             let root_mask = if *USE_VORTEX_OPERATORS {
                 let mut ctx = session.create_execution_ctx();
-                root_scope.apply(&self.root)?.execute_mask(&mut ctx)?
+                root_scope.apply(&self.root)?.execute::<Mask>(&mut ctx)?
             } else {
                 self.root
                     .evaluate(&root_scope)?

--- a/vortex-layout/src/layouts/row_idx/mod.rs
+++ b/vortex-layout/src/layouts/row_idx/mod.rs
@@ -26,7 +26,6 @@ use vortex_array::expr::root;
 use vortex_array::expr::transform::PartitionedExpr;
 use vortex_array::expr::transform::partition;
 use vortex_array::expr::transform::replace;
-use vortex_array::mask::MaskExecutor;
 use vortex_dtype::DType;
 use vortex_dtype::FieldMask;
 use vortex_dtype::FieldName;
@@ -266,7 +265,7 @@ fn row_idx_mask_future(
 
         let result_mask = if *USE_VORTEX_OPERATORS {
             let mut ctx = session.create_execution_ctx();
-            array.apply(&expr)?.execute_mask(&mut ctx)
+            array.apply(&expr)?.execute::<Mask>(&mut ctx)
         } else {
             expr.evaluate(&array)?.try_to_mask_fill_null_false()
         }?;

--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -13,7 +13,6 @@ use vortex_array::expr::Expression;
 use vortex_array::expr::stats::Precision;
 use vortex_array::expr::stats::Stat;
 use vortex_array::expr::stats::StatsProvider;
-use vortex_array::mask::MaskExecutor;
 use vortex_array::stats::StatsSet;
 use vortex_array::validity::Validity;
 use vortex_dtype::DType;
@@ -157,7 +156,7 @@ impl ZoneMap {
             self.array
                 .to_array()
                 .apply(predicate)?
-                .execute_mask(&mut ctx)
+                .execute::<Mask>(&mut ctx)
         } else {
             predicate
                 .evaluate(&self.array.to_array())?


### PR DESCRIPTION
Unifies the `execute_*` APIs into a single `execute::<E>()` function.