### PR TITLE
feat[array]: use execute in canonical

### DIFF
--- a/vortex-array/benches/dict_compare.rs
+++ b/vortex-array/benches/dict_compare.rs
@@ -5,6 +5,8 @@
 
 use std::str::from_utf8;
 
+use vortex_array::Canonical;
+use vortex_array::VortexSessionExecute;
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::VarBinArray;
@@ -15,6 +17,10 @@ use vortex_array::builders::dict::dict_encode;
 use vortex_array::compute::Operator;
 use vortex_array::compute::compare;
 use vortex_array::compute::warm_up_vtables;
+use vortex_array::expr::eq;
+use vortex_array::expr::lit;
+use vortex_array::expr::root;
+use vortex_session::VortexSession;
 
 fn main() {
     warm_up_vtables();
@@ -109,14 +115,14 @@ fn bench_compare_sliced_dict_primitive(
     let dict = dict_encode(primitive_arr.as_ref()).unwrap();
     let dict = dict.slice(0..codes_len);
     let value = primitive_arr.as_slice::<i32>()[0];
+    let session = VortexSession::empty();
 
     bencher.with_inputs(|| &dict).bench_refs(|dict| {
-        compare(
-            dict.as_ref(),
-            ConstantArray::new(value, codes_len).as_ref(),
-            Operator::Eq,
-        )
-        .unwrap()
+        let mut ctx = session.create_execution_ctx();
+        dict.apply(&eq(root(), lit(value)))
+            .unwrap()
+            .execute::<Canonical>(&mut ctx)
+            .unwrap()
     })
 }
 
@@ -130,13 +136,13 @@ fn bench_compare_sliced_dict_varbinview(
     let dict = dict.slice(0..codes_len);
     let bytes = varbin_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
+    let session = VortexSession::empty();
 
     bencher.with_inputs(|| &dict).bench_refs(|dict| {
-        compare(
-            dict.as_ref(),
-            ConstantArray::new(value, codes_len).as_ref(),
-            Operator::Eq,
-        )
-        .unwrap()
+        let mut ctx = session.create_execution_ctx();
+        dict.apply(&eq(root(), lit(value)))
+            .unwrap()
+            .execute::<Canonical>(&mut ctx)
+            .unwrap()
     })
 }

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -29,9 +29,6 @@ use crate::ArrayHash;
 use crate::Canonical;
 use crate::DynArrayEq;
 use crate::DynArrayHash;
-use crate::LEGACY_SESSION;
-use crate::USE_VORTEX_OPERATORS;
-use crate::VortexSessionExecute;
 use crate::arrays::BoolVTable;
 use crate::arrays::ConstantVTable;
 use crate::arrays::DecimalVTable;
@@ -628,12 +625,7 @@ impl<V: VTable> Array for ArrayAdapter<V> {
     }
 
     fn to_canonical(&self) -> Canonical {
-        let canonical = if *USE_VORTEX_OPERATORS {
-            V::execute(&self.0, &mut LEGACY_SESSION.create_execution_ctx())
-                .vortex_expect("legacy to_canonical cannot panic")
-        } else {
-            <V::CanonicalVTable as CanonicalVTable<V>>::canonicalize(&self.0)
-        };
+        let canonical = <V::CanonicalVTable as CanonicalVTable<V>>::canonicalize(&self.0);
 
         assert_eq!(
             self.len(),

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -29,6 +29,9 @@ use crate::ArrayHash;
 use crate::Canonical;
 use crate::DynArrayEq;
 use crate::DynArrayHash;
+use crate::LEGACY_SESSION;
+use crate::USE_VORTEX_OPERATORS;
+use crate::VortexSessionExecute;
 use crate::arrays::BoolVTable;
 use crate::arrays::ConstantVTable;
 use crate::arrays::DecimalVTable;
@@ -625,7 +628,13 @@ impl<V: VTable> Array for ArrayAdapter<V> {
     }
 
     fn to_canonical(&self) -> Canonical {
-        let canonical = <V::CanonicalVTable as CanonicalVTable<V>>::canonicalize(&self.0);
+        let canonical = if *USE_VORTEX_OPERATORS {
+            V::execute(&self.0, &mut LEGACY_SESSION.create_execution_ctx())
+                .vortex_expect("legacy to_canonical cannot panic")
+        } else {
+            <V::CanonicalVTable as CanonicalVTable<V>>::canonicalize(&self.0)
+        };
+
         assert_eq!(
             self.len(),
             canonical.as_ref().len(),

--- a/vortex-array/src/arrays/dict/vtable/rules.rs
+++ b/vortex-array/src/arrays/dict/vtable/rules.rs
@@ -78,6 +78,12 @@ impl ArrayParentReduceRule<DictVTable> for DictionaryScalarFnValuesPushDownRule 
             return Ok(None);
         }
 
+        // If the dictionary has less codes than values don't push down this might
+        // happen if the dictionary is sliced.
+        if array.values().len() > array.codes().len() {
+            return Ok(None);
+        }
+
         // If the scalar function is fallible, we cannot push it down since it may fail over a
         // value that isn't referenced by any code.
         if !array.all_values_referenced && sig.is_fallible() {

--- a/vortex-array/src/arrow/compute/to_arrow/mod.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/mod.rs
@@ -22,7 +22,6 @@ use vortex_error::vortex_err;
 
 use crate::Array;
 use crate::LEGACY_SESSION;
-use crate::USE_VORTEX_OPERATORS;
 use crate::VortexSessionExecute;
 use crate::arrow::ArrowArrayExecutor;
 use crate::arrow::array::ArrowArray;
@@ -129,23 +128,12 @@ impl ComputeFnVTable for ToArrow {
         }
 
         if !array.is_canonical() {
-            let arrow_array = if *USE_VORTEX_OPERATORS {
-                let arrow_type = arrow_type
-                    .cloned()
-                    .map(Ok)
-                    .unwrap_or_else(|| array.dtype().to_arrow_dtype())?;
-                let mut ctx = LEGACY_SESSION.create_execution_ctx();
-                array.to_array().execute_arrow(&arrow_type, &mut ctx)?
-            } else {
-                // Fall back to canonicalizing and then converting.
-                let canonical_array = array.to_canonical();
-                to_arrow_opts(
-                    canonical_array.as_ref(),
-                    &ToArrowOptions {
-                        arrow_type: arrow_type.cloned(),
-                    },
-                )?
-            };
+            let arrow_type = arrow_type
+                .cloned()
+                .map(Ok)
+                .unwrap_or_else(|| array.dtype().to_arrow_dtype())?;
+            let mut ctx = LEGACY_SESSION.create_execution_ctx();
+            let arrow_array = array.to_array().execute_arrow(&arrow_type, &mut ctx)?;
 
             return Ok(ArrowArray::new(arrow_array, array.dtype().nullability())
                 .to_array()

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -69,12 +69,6 @@ pub mod flatbuffers {
     pub use vortex_flatbuffers::array::*;
 }
 
-static USE_VORTEX_OPERATORS: LazyLock<bool> = LazyLock::new(|| {
-    std::env::var("VORTEX_OPERATORS")
-        .map(|v| v != "0" && v.to_lowercase() != "false")
-        .unwrap_or(true)
-});
-
 // TODO(ngates): canonicalize doesn't currently take a session, therefore we cannot invoke execute
 //  from the new array encodings to support back-compat for legacy encodings. So we hold a session
 //  here...

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -71,8 +71,8 @@ pub mod flatbuffers {
 
 static USE_VORTEX_OPERATORS: LazyLock<bool> = LazyLock::new(|| {
     std::env::var("VORTEX_OPERATORS")
-        .map(|v| v == "1" || v.to_lowercase() == "true")
-        .unwrap_or(false)
+        .map(|v| v != "0" && v.to_lowercase() != "false")
+        .unwrap_or(true)
 });
 
 // TODO(ngates): canonicalize doesn't currently take a session, therefore we cannot invoke execute

--- a/vortex-bench/src/random_access/take.rs
+++ b/vortex-bench/src/random_access/take.rs
@@ -25,7 +25,6 @@ use vortex::array::VortexSessionExecute;
 use vortex::array::stream::ArrayStreamExt;
 use vortex::buffer::Buffer;
 use vortex::file::OpenOptionsSessionExt;
-use vortex::layout::layouts::USE_VORTEX_OPERATORS;
 use vortex::utils::aliases::hash_map::HashMap;
 
 use crate::Format;
@@ -144,12 +143,9 @@ async fn take_vortex(reader: impl AsRef<Path>, indices: Buffer<u64>) -> anyhow::
         .await?;
 
     // We canonicalize / decompress for equivalence to Arrow's `RecordBatch`es.
-    Ok(if *USE_VORTEX_OPERATORS {
-        let mut ctx = SESSION.create_execution_ctx();
-        array.execute::<Canonical>(&mut ctx)?.into_array()
-    } else {
-        array.to_canonical().into_array()
-    })
+    let mut ctx = SESSION.create_execution_ctx();
+    // TODO(joe): should we go to a vector.
+    Ok(array.execute::<Canonical>(&mut ctx)?.into_array())
 }
 
 pub async fn take_parquet(path: &Path, indices: Vec<u64>) -> anyhow::Result<RecordBatch> {

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -8,7 +8,6 @@ use std::sync::Weak;
 use arrow_schema::ArrowError;
 use datafusion_common::DataFusionError;
 use datafusion_common::Result as DFResult;
-use datafusion_common::arrow::array::RecordBatch;
 use datafusion_datasource::FileRange;
 use datafusion_datasource::PartitionedFile;
 use datafusion_datasource::TableSchema;
@@ -40,7 +39,6 @@ use vortex::error::vortex_err;
 use vortex::expr::root;
 use vortex::expr::select;
 use vortex::layout::LayoutReader;
-use vortex::layout::layouts::USE_VORTEX_OPERATORS;
 use vortex::metrics::VortexMetrics;
 use vortex::scan::ScanBuilder;
 use vortex::session::VortexSession;
@@ -296,13 +294,9 @@ impl FileOpener for VortexOpener {
                 .with_some_filter(filter)
                 .with_ordered(has_output_ordering)
                 .map(move |chunk| {
-                    if *USE_VORTEX_OPERATORS {
-                        let schema = chunk.dtype().to_arrow_schema()?;
-                        let mut ctx = chunk_session.create_execution_ctx();
-                        chunk.execute_record_batch(&schema, &mut ctx)
-                    } else {
-                        RecordBatch::try_from(chunk.as_ref())
-                    }
+                    let schema = chunk.dtype().to_arrow_schema()?;
+                    let mut ctx = chunk_session.create_execution_ctx();
+                    chunk.execute_record_batch(&schema, &mut ctx)
                 })
                 .into_stream()
                 .map_err(|e| {

--- a/vortex-duckdb/src/exporter/mod.rs
+++ b/vortex-duckdb/src/exporter/mod.rs
@@ -39,7 +39,6 @@ use vortex::encodings::sequence::SequenceVTable;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_bail;
-use vortex::layout::layouts::USE_VORTEX_OPERATORS;
 
 use crate::duckdb::DUCKDB_STANDARD_VECTOR_SIZE;
 use crate::duckdb::DataChunk;
@@ -62,13 +61,7 @@ impl ArrayExporter {
         let fields = array
             .fields()
             .iter()
-            .map(|field| {
-                if *USE_VORTEX_OPERATORS {
-                    new_operator_array_exporter(field.clone(), cache, ctx)
-                } else {
-                    new_array_exporter(field.as_ref(), cache)
-                }
-            })
+            .map(|field| new_operator_array_exporter(field.clone(), cache, ctx))
             .collect::<VortexResult<Vec<_>>>()?;
         Ok(Self {
             fields,

--- a/vortex-duckdb/src/scan.rs
+++ b/vortex-duckdb/src/scan.rs
@@ -27,7 +27,6 @@ use vortex::VortexSessionDefault;
 use vortex::array::ArrayRef;
 use vortex::array::Canonical;
 use vortex::array::ExecutionCtx;
-use vortex::array::ToCanonical;
 use vortex::array::arrays::ScalarFnVTable;
 use vortex::array::arrays::StructArray;
 use vortex::array::arrays::StructVTable;
@@ -48,7 +47,6 @@ use vortex::file::VortexFile;
 use vortex::file::VortexOpenOptions;
 use vortex::io::runtime::BlockingRuntime;
 use vortex::io::runtime::current::ThreadSafeIterator;
-use vortex::layout::layouts::USE_VORTEX_OPERATORS;
 use vortex::session::VortexSession;
 use vortex_utils::aliases::hash_set::HashSet;
 
@@ -328,26 +326,22 @@ impl TableFunction for VortexTableFunction {
 
                 let (array_result, conversion_cache) = result?;
 
-                let array_result = if *USE_VORTEX_OPERATORS {
-                    let array_result = array_result.optimize_recursive()?;
-                    if let Some(array) = array_result.as_opt::<StructVTable>() {
-                        array.clone()
-                    } else if let Some(array) = array_result.as_opt::<ScalarFnVTable>()
-                        && let Some(pack_options) = array.scalar_fn().as_opt::<Pack>()
-                    {
-                        StructArray::new(
-                            pack_options.names.clone(),
-                            array.children(),
-                            array.len(),
-                            pack_options.nullability.into(),
-                        )
-                    } else {
-                        array_result
-                            .execute::<Canonical>(&mut global_state.ctx)?
-                            .into_struct()
-                    }
+                let array_result = array_result.optimize_recursive()?;
+                let array_result = if let Some(array) = array_result.as_opt::<StructVTable>() {
+                    array.clone()
+                } else if let Some(array) = array_result.as_opt::<ScalarFnVTable>()
+                    && let Some(pack_options) = array.scalar_fn().as_opt::<Pack>()
+                {
+                    StructArray::new(
+                        pack_options.names.clone(),
+                        array.children(),
+                        array.len(),
+                        pack_options.nullability.into(),
+                    )
                 } else {
-                    array_result.to_struct()
+                    array_result
+                        .execute::<Canonical>(&mut global_state.ctx)?
+                        .into_struct()
                 };
 
                 local_state.exporter = Some(ArrayExporter::try_new(

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -23,7 +23,6 @@ use vortex_dtype::FieldPath;
 use vortex_dtype::FieldPathSet;
 use vortex_error::VortexResult;
 use vortex_layout::LayoutReader;
-use vortex_layout::layouts::USE_VORTEX_OPERATORS;
 use vortex_layout::segments::SegmentSource;
 use vortex_metrics::VortexMetrics;
 use vortex_scan::ScanBuilder;
@@ -159,18 +158,16 @@ impl VortexFile {
             return Ok(false);
         };
 
-        Ok(if *USE_VORTEX_OPERATORS {
-            let mut ctx = self.session.create_execution_ctx();
-            match file_stats.execute::<CanonicalOutput>(&mut ctx)? {
+        let mut ctx = self.session.create_execution_ctx();
+        Ok(
+            match file_stats
+                .apply(&predicate)?
+                .execute::<CanonicalOutput>(&mut ctx)?
+            {
                 CanonicalOutput::Constant(c) => c.scalar().as_bool().value() == Some(true),
                 CanonicalOutput::Array(_) => false,
-            }
-        } else {
-            predicate
-                .evaluate(&file_stats)?
-                .as_constant()
-                .is_some_and(|result| result.as_bool().value() == Some(true))
-        })
+            },
+        )
     }
 
     pub fn splits(&self) -> VortexResult<Vec<Range<u64>>> {

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -19,9 +19,6 @@ use vortex_array::IntoArray;
 use vortex_array::MaskFuture;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::DictArray;
-use vortex_array::compute::MinMaxResult;
-use vortex_array::compute::min_max;
-use vortex_array::compute::take;
 use vortex_array::expr::Expression;
 use vortex_array::expr::root;
 use vortex_array::optimizer::ArrayOptimizer;
@@ -38,7 +35,6 @@ use super::DictLayout;
 use crate::LayoutReader;
 use crate::LayoutReaderRef;
 use crate::layouts::SharedArrayFuture;
-use crate::layouts::USE_VORTEX_OPERATORS;
 use crate::segments::SegmentSource;
 
 pub struct DictReader {
@@ -104,14 +100,10 @@ impl DictReader {
                     .vortex_expect("must construct dict values array evaluation")
                     .map_err(Arc::new)
                     .map(move |array| {
-                        if *USE_VORTEX_OPERATORS {
-                            // We execute the array to avoid re-evaluating for every split.
-                            let array = array?;
-                            let mut ctx = ExecutionCtx::new(session);
-                            Ok(array.execute::<Canonical>(&mut ctx)?.into_array())
-                        } else {
-                            Ok(array?.to_canonical().into_array())
-                        }
+                        // We execute the array to avoid re-evaluating for every split.
+                        let array = array?;
+                        let mut ctx = ExecutionCtx::new(session);
+                        Ok(array.execute::<Canonical>(&mut ctx)?.into_array())
                     })
                     .boxed()
                     .shared()
@@ -130,14 +122,10 @@ impl DictReader {
             .or_insert_with(|| {
                 self.values_array()
                     .map(move |array| {
-                        if *USE_VORTEX_OPERATORS {
-                            let array = array?.apply(&expr)?;
-                            // We execute the array to avoid re-evaluating for every split.
-                            let mut ctx = ExecutionCtx::new(session);
-                            Ok(array.execute::<Canonical>(&mut ctx)?.into_array())
-                        } else {
-                            expr.evaluate(&array?).map_err(Arc::new)
-                        }
+                        let array = array?.apply(&expr)?;
+                        // We execute the array to avoid re-evaluating for every split.
+                        let mut ctx = ExecutionCtx::new(session);
+                        Ok(array.execute::<Canonical>(&mut ctx)?.into_array())
                     })
                     .boxed()
                     .shared()
@@ -206,35 +194,8 @@ impl LayoutReader for DictReader {
             let (codes, values) = try_join!(codes_eval, values_eval.map_err(VortexError::from))?;
             let mask = mask.await?;
 
-            let dict_mask = if *USE_VORTEX_OPERATORS {
-                let mut ctx = session.create_execution_ctx();
-                values.take(codes)?.execute::<Mask>(&mut ctx)?
-            } else {
-                // Short-circuit when the values are all true/false.
-                if values.all_valid()
-                    && let Some(MinMaxResult { min, max }) = min_max(&values)?
-                {
-                    #[expect(clippy::bool_comparison, reason = "easy to follow")]
-                    if max.as_bool().value().vortex_expect("non null") == false {
-                        // All values are false
-                        return Ok(Mask::AllFalse(mask.len()));
-                    }
-                    #[expect(clippy::bool_comparison, reason = "easy to follow")]
-                    if min.as_bool().value().vortex_expect("not null") == true {
-                        // All values are true, but we still need to respect codes validity
-                        return Ok(mask.bitand(&codes.validity_mask()));
-                    }
-                }
-
-                // Creating a mask from the dict array would canonicalize it,
-                // it should be fine for now as long as values is already canonical,
-                // so different row ranges do not canonicalize to the same array
-                // multiple times.
-                // TODO(joe): fixme casting null to false is *VERY* unsound, if the expression in the filter
-                // can inspect nulls (e.g. `is_null`).
-                // See `FlatEvaluation` for more details.
-                take(&values, &codes)?.try_to_mask_fill_null_false()?
-            };
+            let mut ctx = session.create_execution_ctx();
+            let dict_mask = values.take(codes)?.execute::<Mask>(&mut ctx)?;
 
             Ok(mask.bitand(&dict_mask))
         }))
@@ -270,11 +231,7 @@ impl LayoutReader for DictReader {
             .to_array()
             .optimize()?;
 
-            if *USE_VORTEX_OPERATORS {
-                array.apply(&expr)
-            } else {
-                expr.evaluate(&array)
-            }
+            array.apply(&expr)
         }
         .boxed())
     }

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -12,9 +12,7 @@ use vortex_array::Array;
 use vortex_array::ArrayRef;
 use vortex_array::MaskFuture;
 use vortex_array::VortexSessionExecute;
-use vortex_array::compute::filter;
 use vortex_array::expr::Expression;
-use vortex_array::expr::Root;
 use vortex_array::serde::ArrayParts;
 use vortex_dtype::DType;
 use vortex_dtype::FieldMask;
@@ -25,7 +23,6 @@ use vortex_session::VortexSession;
 
 use crate::LayoutReader;
 use crate::layouts::SharedArrayFuture;
-use crate::layouts::USE_VORTEX_OPERATORS;
 use crate::layouts::flat::FlatLayout;
 use crate::segments::SegmentSource;
 
@@ -146,52 +143,23 @@ impl LayoutReader for FlatReader {
                 array = array.slice(row_range.clone());
             }
 
-            let array_mask = if *USE_VORTEX_OPERATORS {
-                if mask.density() < EXPR_EVAL_THRESHOLD {
-                    // We have the choice to apply the filter or the expression first, we apply the
-                    // expression first so that it can try pushing down itself and then the filter
-                    // after this.
-                    let array = array.apply(&expr)?;
-                    let array = array.filter(mask.clone())?;
-                    let mut ctx = session.create_execution_ctx();
-                    let array_mask = array.execute::<Mask>(&mut ctx)?;
+            let array_mask = if mask.density() < EXPR_EVAL_THRESHOLD {
+                // We have the choice to apply the filter or the expression first, we apply the
+                // expression first so that it can try pushing down itself and then the filter
+                // after this.
+                let array = array.apply(&expr)?;
+                let array = array.filter(mask.clone())?;
+                let mut ctx = session.create_execution_ctx();
+                let array_mask = array.execute::<Mask>(&mut ctx)?;
 
-                    mask.intersect_by_rank(&array_mask)
-                } else {
-                    // Run over the full array, with a simpler bitand at the end.
-                    let array = array.apply(&expr)?;
-                    let mut ctx = session.create_execution_ctx();
-                    let array_mask = array.execute::<Mask>(&mut ctx)?;
-
-                    mask.bitand(&array_mask)
-                }
+                mask.intersect_by_rank(&array_mask)
             } else {
-                // TODO(ngates): the mask may actually be dense within a range, as is often the case when
-                //  we have approximate mask results from a zone map. In which case we could look at
-                //  the true_count between the mask's first and last true positions.
-                // TODO(ngates): we could also track runtime statistics about whether it's worth selecting
-                //   or not.
-                if mask.density() < EXPR_EVAL_THRESHOLD {
-                    // Evaluate only the selected rows of the mask.
-                    array = filter(&array, &mask)?;
-                    // TODO(joe): fixme casting null to false is *VERY* unsound, if the expression in the filter
-                    // can inspect nulls (e.g. `is_null`).
-                    // you will need to call the array evaluation instead of the mask evaluation.
-                    let array_mask = expr
-                        .evaluate(&array)
-                        .map_err(|err| {
-                            err.with_context(format!("While evaluating filter {}", expr))
-                        })?
-                        .try_to_mask_fill_null_false()?;
-                    mask.intersect_by_rank(&array_mask)
-                } else {
-                    // Evaluate all rows, avoiding the more expensive rank intersection.
-                    array = expr.evaluate(&array).map_err(|err| {
-                        err.with_context(format!("While evaluating filter {}", expr))
-                    })?;
-                    let array_mask = array.try_to_mask_fill_null_false()?;
-                    mask.bitand(&array_mask)
-                }
+                // Run over the full array, with a simpler bitand at the end.
+                let array = array.apply(&expr)?;
+                let mut ctx = session.create_execution_ctx();
+                let array_mask = array.execute::<Mask>(&mut ctx)?;
+
+                mask.bitand(&array_mask)
             };
 
             tracing::debug!(
@@ -231,33 +199,18 @@ impl LayoutReader for FlatReader {
                 array = array.slice(row_range.clone());
             }
 
-            Ok(if *USE_VORTEX_OPERATORS {
-                // First apply the filter to the array.
-                // NOTE(ngates): we *must* filter first before applying the expression, as the
-                // expression may depend on the filtered rows being removed e.g.
-                //  `CAST(a, u8) WHERE a < 256`
-                if !mask.all_true() {
-                    array = array.filter(mask)?;
-                }
+            // First apply the filter to the array.
+            // NOTE(ngates): we *must* filter first before applying the expression, as the
+            // expression may depend on the filtered rows being removed e.g.
+            //  `CAST(a, u8) WHERE a < 256`
+            if !mask.all_true() {
+                array = array.filter(mask)?;
+            }
 
-                // Evaluate the projection expression.
-                array = array.apply(&expr)?;
+            // Evaluate the projection expression.
+            array = array.apply(&expr)?;
 
-                array
-            } else {
-                // Filter the array based on the row mask.
-                if !mask.all_true() {
-                    array = filter(&array, &mask)?;
-                }
-
-                // Evaluate the projection expression.
-                if !expr.is::<Root>() {
-                    array = expr.evaluate(&array).map_err(|err| {
-                        err.with_context(format!("While evaluating projection {}", expr))
-                    })?;
-                }
-                array
-            })
+            Ok(array)
         }
         .boxed())
     }

--- a/vortex-layout/src/layouts/mod.rs
+++ b/vortex-layout/src/layouts/mod.rs
@@ -3,7 +3,6 @@
 
 //! A collection of built-in layouts for Vortex
 
-use std::sync::LazyLock;
 
 use futures::future::BoxFuture;
 use futures::future::Shared;
@@ -27,9 +26,3 @@ pub mod table;
 pub mod zoned;
 
 pub type SharedArrayFuture = Shared<BoxFuture<'static, SharedVortexResult<ArrayRef>>>;
-
-pub static USE_VORTEX_OPERATORS: LazyLock<bool> = LazyLock::new(|| {
-    std::env::var("VORTEX_OPERATORS")
-        .map(|v| v == "1" || v.to_lowercase() == "true")
-        .unwrap_or(false)
-});

--- a/vortex-layout/src/layouts/mod.rs
+++ b/vortex-layout/src/layouts/mod.rs
@@ -3,7 +3,6 @@
 
 //! A collection of built-in layouts for Vortex
 
-
 use futures::future::BoxFuture;
 use futures::future::Shared;
 use vortex_array::ArrayRef;

--- a/vortex-layout/src/layouts/partitioned.rs
+++ b/vortex-layout/src/layouts/partitioned.rs
@@ -22,7 +22,6 @@ use vortex_mask::Mask;
 use vortex_session::VortexSession;
 
 use crate::ArrayFuture;
-use crate::layouts::USE_VORTEX_OPERATORS;
 
 pub trait PartitionedExprEval<P> {
     fn into_mask_future(
@@ -90,14 +89,8 @@ impl<P: Send + Sync + 'static> PartitionedExprEval<P> for PartitionedExpr<P> {
             )?
             .into_array();
 
-            let root_mask = if *USE_VORTEX_OPERATORS {
-                let mut ctx = session.create_execution_ctx();
-                root_scope.apply(&self.root)?.execute::<Mask>(&mut ctx)?
-            } else {
-                self.root
-                    .evaluate(&root_scope)?
-                    .try_to_mask_fill_null_false()?
-            };
+            let mut ctx = session.create_execution_ctx();
+            let root_mask = root_scope.apply(&self.root)?.execute::<Mask>(&mut ctx)?;
 
             let mask = mask.bitand(&root_mask);
 
@@ -131,11 +124,7 @@ impl<P: Send + Sync + 'static> PartitionedExprEval<P> for PartitionedExpr<P> {
             )?
             .into_array();
 
-            if *USE_VORTEX_OPERATORS {
-                root_scope.apply(&self.root)
-            } else {
-                self.root.evaluate(&root_scope)
-            }
+            root_scope.apply(&self.root)
         }))
     }
 }

--- a/vortex-layout/src/layouts/row_idx/mod.rs
+++ b/vortex-layout/src/layouts/row_idx/mod.rs
@@ -41,7 +41,6 @@ use vortex_utils::aliases::dash_map::DashMap;
 
 use crate::ArrayFuture;
 use crate::LayoutReader;
-use crate::layouts::USE_VORTEX_OPERATORS;
 use crate::layouts::partitioned::PartitionedExprEval;
 
 pub struct RowIdxLayoutReader {
@@ -263,12 +262,8 @@ fn row_idx_mask_future(
     MaskFuture::new(mask.len(), async move {
         let array = idx_array(row_offset, &row_range).into_array();
 
-        let result_mask = if *USE_VORTEX_OPERATORS {
-            let mut ctx = session.create_execution_ctx();
-            array.apply(&expr)?.execute::<Mask>(&mut ctx)
-        } else {
-            expr.evaluate(&array)?.try_to_mask_fill_null_false()
-        }?;
+        let mut ctx = session.create_execution_ctx();
+        let result_mask = array.apply(&expr)?.execute::<Mask>(&mut ctx)?;
 
         Ok(result_mask.bitand(&mask.await?))
     })
@@ -285,11 +280,7 @@ fn row_idx_array_future(
     async move {
         let array = idx_array(row_offset, &row_range).into_array();
         let array = filter(&array, &mask.await?)?;
-        if *USE_VORTEX_OPERATORS {
-            array.apply(&expr)
-        } else {
-            expr.evaluate(&array)
-        }
+        array.apply(&expr)
     }
     .boxed()
 }

--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -25,7 +25,6 @@ use vortex_error::vortex_bail;
 use vortex_mask::Mask;
 use vortex_session::VortexSession;
 
-use crate::layouts::USE_VORTEX_OPERATORS;
 use crate::layouts::zoned::builder::MAX_IS_TRUNCATED;
 use crate::layouts::zoned::builder::MIN_IS_TRUNCATED;
 use crate::layouts::zoned::builder::StatsArrayBuilder;
@@ -151,17 +150,11 @@ impl ZoneMap {
     ///
     /// All zones where the predicate evaluates to `true` can be skipped entirely.
     pub fn prune(&self, predicate: &Expression, session: &VortexSession) -> VortexResult<Mask> {
-        if *USE_VORTEX_OPERATORS {
-            let mut ctx = session.create_execution_ctx();
-            self.array
-                .to_array()
-                .apply(predicate)?
-                .execute::<Mask>(&mut ctx)
-        } else {
-            predicate
-                .evaluate(&self.array.to_array())?
-                .try_to_mask_fill_null_false()
-        }
+        let mut ctx = session.create_execution_ctx();
+        self.array
+            .to_array()
+            .apply(predicate)?
+            .execute::<Mask>(&mut ctx)
     }
 }
 

--- a/vortex-scan/src/arrow.rs
+++ b/vortex-scan/src/arrow.rs
@@ -13,10 +13,8 @@ use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrow::ArrowArrayExecutor;
-use vortex_array::arrow::IntoArrowArray;
 use vortex_error::VortexResult;
 use vortex_io::runtime::BlockingRuntime;
-use vortex_layout::layouts::USE_VORTEX_OPERATORS;
 
 use crate::ScanBuilder;
 
@@ -69,13 +67,8 @@ fn to_record_batch(
     data_type: &DataType,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<RecordBatch> {
-    if *USE_VORTEX_OPERATORS {
-        let arrow = chunk.execute_arrow(data_type, ctx)?;
-        Ok(RecordBatch::from(arrow.as_struct().clone()))
-    } else {
-        let arrow = chunk.into_arrow(data_type)?;
-        Ok(RecordBatch::from(arrow.as_struct().clone()))
-    }
+    let arrow = chunk.execute_arrow(data_type, ctx)?;
+    Ok(RecordBatch::from(arrow.as_struct().clone()))
 }
 
 /// We create an adapter for record batch iterators that supports clone.


### PR DESCRIPTION
Remove the `VORTEX_OPERATORS` remove the old `to_canonical` method and using `execute::<E>` in its place.

This cause CPU compute to return canonical (Not `ArrayRef` as before). see https://github.com/vortex-data/vortex/pull/5895