### PR TITLE
Make sure to materialize data before de/compression measurement

### DIFF
--- a/benchmarks/compress-bench/src/parquet.rs
+++ b/benchmarks/compress-bench/src/parquet.rs
@@ -65,7 +65,7 @@ impl Compressor for ParquetCompressor {
         Ok((size as u64, elapsed))
     }
 
-    async fn decompress(&self, parquet_path: &Path) -> anyhow::Result<usize> {
+    async fn decompress(&self, parquet_path: &Path) -> anyhow::Result<Duration> {
         // First compress to get the bytes we'll decompress
         let file = File::open(parquet_path)?;
         let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
@@ -76,8 +76,12 @@ impl Compressor for ParquetCompressor {
         let mut buf = Vec::new();
         parquet_compress_write(batches, schema, self.compression, &mut buf)?;
 
+        let buf = Bytes::from(buf);
+
         // Now decompress
-        parquet_decompress_read(Bytes::from(buf))
+        let timer = Instant::now();
+        parquet_decompress_read(buf)?;
+        Ok(timer.elapsed())
     }
 }
 

--- a/benchmarks/compress-bench/src/vortex.rs
+++ b/benchmarks/compress-bench/src/vortex.rs
@@ -30,14 +30,14 @@ impl Compressor for VortexCompressor {
 
     async fn compress(&self, parquet_path: &Path) -> Result<(u64, Duration)> {
         // Read the parquet file as an array stream
-        let array_stream = parquet_to_vortex(parquet_path.to_path_buf())?;
+        let uncompressed = parquet_to_vortex(parquet_path.to_path_buf()).await?;
 
         let mut buf = Vec::new();
         let start = Instant::now();
         let mut cursor = Cursor::new(&mut buf);
         SESSION
             .write_options()
-            .write(&mut cursor, array_stream)
+            .write(&mut cursor, uncompressed.to_array_stream())
             .await?;
         let elapsed = start.elapsed();
 
@@ -46,12 +46,12 @@ impl Compressor for VortexCompressor {
 
     async fn decompress(&self, parquet_path: &Path) -> Result<usize> {
         // First compress to get the bytes we'll decompress
-        let array_stream = parquet_to_vortex(parquet_path.to_path_buf())?;
+        let uncompressed = parquet_to_vortex(parquet_path.to_path_buf()).await?;
         let mut buf = Vec::new();
         let mut cursor = Cursor::new(&mut buf);
         SESSION
             .write_options()
-            .write(&mut cursor, array_stream)
+            .write(&mut cursor, uncompressed.to_array_stream())
             .await?;
 
         // Now decompress

--- a/benchmarks/compress-bench/src/vortex.rs
+++ b/benchmarks/compress-bench/src/vortex.rs
@@ -44,7 +44,7 @@ impl Compressor for VortexCompressor {
         Ok((buf.len() as u64, elapsed))
     }
 
-    async fn decompress(&self, parquet_path: &Path) -> Result<usize> {
+    async fn decompress(&self, parquet_path: &Path) -> Result<Duration> {
         // First compress to get the bytes we'll decompress
         let uncompressed = parquet_to_vortex(parquet_path.to_path_buf()).await?;
         let mut buf = Vec::new();
@@ -55,6 +55,7 @@ impl Compressor for VortexCompressor {
             .await?;
 
         // Now decompress
+        let start = Instant::now();
         let data = Bytes::from(buf);
         let scan = SESSION.open_options().open_buffer(data)?.scan()?;
         let schema = Arc::new(scan.dtype()?.to_arrow_schema()?);
@@ -62,10 +63,9 @@ impl Compressor for VortexCompressor {
         let stream = scan.into_record_batch_stream(schema)?;
         pin_mut!(stream);
 
-        let mut nbytes = 0;
         while let Some(batch) = stream.next().await {
-            nbytes += batch?.get_array_memory_size()
+            let _batch = batch?;
         }
-        Ok(nbytes)
+        Ok(start.elapsed())
     }
 }

--- a/benchmarks/lance-bench/src/compress.rs
+++ b/benchmarks/lance-bench/src/compress.rs
@@ -127,7 +127,7 @@ impl Compressor for LanceCompressor {
         Ok((size, elapsed))
     }
 
-    async fn decompress(&self, parquet_path: &Path) -> anyhow::Result<usize> {
+    async fn decompress(&self, parquet_path: &Path) -> anyhow::Result<Duration> {
         // First compress to get the Lance dataset
         let file = File::open(parquet_path)?;
         let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
@@ -157,6 +157,8 @@ impl Compressor for LanceCompressor {
         Dataset::write(reader_iter, path_str, Some(write_params)).await?;
 
         // Now decompress
-        lance_decompress_read(path_str).await
+        let start = Instant::now();
+        lance_decompress_read(path_str).await?;
+        Ok(start.elapsed())
     }
 }

--- a/vortex-bench/src/compress/mod.rs
+++ b/vortex-bench/src/compress/mod.rs
@@ -5,7 +5,6 @@ use std::borrow::Cow;
 use std::fmt;
 use std::path::Path;
 use std::time::Duration;
-use std::time::Instant;
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -97,7 +96,7 @@ pub trait Compressor: Send + Sync {
     ///
     /// This method first compresses the data to the target format, then decompresses it.
     /// The timing returned should only measure the decompression phase.
-    async fn decompress(&self, parquet_path: &Path) -> Result<usize>;
+    async fn decompress(&self, parquet_path: &Path) -> Result<Duration>;
 }
 
 /// Run a compression benchmark for the given compressor.
@@ -154,9 +153,7 @@ pub async fn benchmark_decompress(
     let mut fastest = Duration::MAX;
 
     for _ in 0..iterations {
-        let start = Instant::now();
-        let _ = compressor.decompress(parquet_path).await?;
-        let elapsed = start.elapsed();
+        let elapsed = compressor.decompress(parquet_path).await?;
 
         fastest = fastest.min(elapsed);
     }

--- a/vortex-bench/src/conversions.rs
+++ b/vortex-bench/src/conversions.rs
@@ -2,27 +2,22 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::fs;
-use std::fs::File;
 use std::path::Path;
 use std::path::PathBuf;
 
-use arrow_array::RecordBatchReader;
 use futures::StreamExt;
 use futures::TryStreamExt;
-use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::arrow::ParquetRecordBatchStreamBuilder;
+use tokio::fs::File;
 use tokio::fs::OpenOptions;
 use tokio::fs::create_dir_all;
 use tracing::Instrument;
 use tracing::info;
 use tracing::trace;
 use vortex::array::ArrayRef;
+use vortex::array::arrays::ChunkedArray;
 use vortex::array::arrow::FromArrowArray;
-use vortex::array::iter::ArrayIteratorAdapter;
-use vortex::array::iter::ArrayIteratorExt;
-use vortex::array::stream::ArrayStream;
-use vortex::dtype::DType;
-use vortex::dtype::arrow::FromArrowType;
-use vortex::error::VortexError;
+use vortex::array::builders::builder_with_capacity;
 use vortex::file::WriteOptionsSessionExt;
 
 use crate::CompactionStrategy;
@@ -31,18 +26,23 @@ use crate::SESSION;
 use crate::utils::file::idempotent_async;
 
 /// Read a Parquet file and return it as a Vortex ArrayStream.
-pub fn parquet_to_vortex(parquet_path: PathBuf) -> anyhow::Result<impl ArrayStream> {
-    let reader = ParquetRecordBatchReaderBuilder::try_new(File::open(parquet_path)?)?.build()?;
+pub async fn parquet_to_vortex(parquet_path: PathBuf) -> anyhow::Result<ChunkedArray> {
+    let file = File::open(parquet_path).await?;
+    let mut reader = ParquetRecordBatchStreamBuilder::new(file).await?.build()?;
+    let mut chunks = vec![];
 
-    let array_iter = ArrayIteratorAdapter::new(
-        DType::from_arrow(reader.schema()),
-        reader.map(|br| {
-            br.map_err(VortexError::from)
-                .map(|b| ArrayRef::from_arrow(b, false))
-        }),
-    );
+    while let Some(rb) = reader.next().await {
+        let rb = rb?;
+        let chunk = ArrayRef::from_arrow(rb, false);
 
-    Ok(array_iter.into_array_stream())
+        // Make sure data is uncompressed and canonicalized
+        let mut builder = builder_with_capacity(chunk.dtype(), chunk.len());
+        chunk.append_to_builder(builder.as_mut());
+        let chunk = builder.finish();
+        chunks.push(chunk);
+    }
+
+    Ok(ChunkedArray::from_iter(chunks))
 }
 
 /// Convert all Parquet files in a directory to Vortex format.
@@ -94,7 +94,7 @@ pub async fn convert_parquet_to_vortex(
                             "Processing file '{filename}' with {:?} strategy",
                             compaction
                         );
-                        let array_stream = parquet_to_vortex(parquet_file_path)?;
+                        let chunked_array = parquet_to_vortex(parquet_file_path).await?;
                         let mut f = OpenOptions::new()
                             .write(true)
                             .truncate(true)
@@ -104,7 +104,9 @@ pub async fn convert_parquet_to_vortex(
 
                         let write_options = compaction.apply_options(SESSION.write_options());
 
-                        write_options.write(&mut f, array_stream).await?;
+                        write_options
+                            .write(&mut f, chunked_array.to_array_stream())
+                            .await?;
 
                         anyhow::Ok(())
                     })

--- a/vortex-bench/src/datasets/taxi_data.rs
+++ b/vortex-bench/src/datasets/taxi_data.rs
@@ -60,12 +60,12 @@ pub async fn taxi_data_vortex() -> Result<PathBuf> {
     idempotent_async("taxi/taxi.vortex", |output_fname| async move {
         let buf = output_fname.to_path_buf();
         let mut output_file = TokioFile::create(output_fname).await?;
+
+        let data = parquet_to_vortex(taxi_data_parquet().await?).await?;
+
         SESSION
             .write_options()
-            .write(
-                &mut output_file,
-                parquet_to_vortex(taxi_data_parquet().await?)?,
-            )
+            .write(&mut output_file, data.to_array_stream())
             .await?;
         output_file.flush().await?;
         Ok(buf)
@@ -81,11 +81,10 @@ pub async fn taxi_data_vortex_compact() -> Result<PathBuf> {
         // This is the only difference to `taxi_data_vortex`.
         let write_options = CompactionStrategy::Compact.apply_options(SESSION.write_options());
 
+        let data = parquet_to_vortex(taxi_data_parquet().await?).await?;
+
         write_options
-            .write(
-                &mut output_file,
-                parquet_to_vortex(taxi_data_parquet().await?)?,
-            )
+            .write(&mut output_file, data.to_array_stream())
             .await?;
 
         output_file.flush().await?;

--- a/vortex-bench/src/downloadable_dataset.rs
+++ b/vortex-bench/src/downloadable_dataset.rs
@@ -60,6 +60,8 @@ impl Dataset for DownloadableDataset {
         let parquet = self.to_parquet_path().await?;
         let dir = format!("{}/", self.name()).to_data_path();
         let vortex = dir.join(format!("{}.vortex", self.name()));
+
+        let data = parquet_to_vortex(parquet).await?;
         idempotent_async(&vortex, async |path| -> anyhow::Result<()> {
             SESSION
                 .write_options()
@@ -67,7 +69,7 @@ impl Dataset for DownloadableDataset {
                     &mut File::create(path)
                         .await
                         .map_err(|e| anyhow::anyhow!("Failed to create file: {}", e))?,
-                    parquet_to_vortex(parquet)?,
+                    data.to_array_stream(),
                 )
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to write vortex file: {}", e))?;

--- a/vortex-bench/src/public_bi.rs
+++ b/vortex-bench/src/public_bi.rs
@@ -360,7 +360,9 @@ impl PBIData {
         let to_vortex_futures = self.tables.iter().map(|table| {
             let parquet = self.get_file_path(&table.name, FileType::Parquet);
             let vortex = self.get_file_path(&table.name, FileType::Vortex);
+
             async move {
+                let data = parquet_to_vortex(parquet).await?;
                 let vortex_file =
                     idempotent_async(&vortex, async |output_path| -> anyhow::Result<()> {
                         SESSION
@@ -369,7 +371,7 @@ impl PBIData {
                                 &mut File::create(output_path)
                                     .await
                                     .map_err(|e| anyhow::anyhow!("Failed to create file: {}", e))?,
-                                parquet_to_vortex(parquet)?,
+                                data.to_array_stream(),
                             )
                             .await
                             .map_err(|e| anyhow::anyhow!("Failed to write vortex file: {}", e))?;


### PR DESCRIPTION
This PR attempts to bring some compression/decompression benchmarks back to where they were before #5676. As far as I can tell any difference is only a result of mistakenly measuring incidental work that was previously done before the actual measurement.