### PR TITLE
Add scan concurrency config for datafusion source

### DIFF
--- a/benchmarks/datafusion-bench/src/lib.rs
+++ b/benchmarks/datafusion-bench/src/lib.rs
@@ -28,7 +28,7 @@ use vortex_bench::Format;
 use vortex_bench::SESSION;
 use vortex_datafusion::VortexFormat;
 use vortex_datafusion::VortexFormatFactory;
-use vortex_datafusion::VortexOptions;
+use vortex_datafusion::VortexTableOptions;
 
 #[allow(clippy::expect_used)]
 pub fn get_session_context() -> SessionContext {
@@ -45,7 +45,7 @@ pub fn get_session_context() -> SessionContext {
         .build_arc()
         .expect("could not build runtime environment");
 
-    let factory = VortexFormatFactory::new().with_options(VortexOptions {
+    let factory = VortexFormatFactory::new().with_options(VortexTableOptions {
         projection_pushdown: true,
         ..Default::default()
     });

--- a/vortex-datafusion/public-api.lock
+++ b/vortex-datafusion/public-api.lock
@@ -18,20 +18,6 @@ pub type vortex_datafusion::metrics::VortexMetricsFinder::Error = core::convert:
 
 pub fn vortex_datafusion::metrics::VortexMetricsFinder::pre_visit(&mut self, plan: &dyn datafusion_physical_plan::execution_plan::ExecutionPlan) -> core::result::Result<bool, Self::Error>
 
-pub struct vortex_datafusion::DefaultVortexReaderFactory
-
-impl vortex_datafusion::DefaultVortexReaderFactory
-
-pub fn vortex_datafusion::DefaultVortexReaderFactory::new(object_store: alloc::sync::Arc<dyn object_store::ObjectStore>) -> Self
-
-impl core::fmt::Debug for vortex_datafusion::DefaultVortexReaderFactory
-
-pub fn vortex_datafusion::DefaultVortexReaderFactory::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_datafusion::VortexReaderFactory for vortex_datafusion::DefaultVortexReaderFactory
-
-pub fn vortex_datafusion::DefaultVortexReaderFactory::create_reader(&self, path: &str, session: &vortex_session::VortexSession) -> datafusion_common::error::Result<alloc::sync::Arc<dyn vortex_io::read::VortexReadAt>>
-
 pub struct vortex_datafusion::VortexAccessPlan
 
 impl vortex_datafusion::VortexAccessPlan
@@ -52,9 +38,9 @@ impl vortex_datafusion::VortexFormat
 
 pub fn vortex_datafusion::VortexFormat::new(session: vortex_session::VortexSession) -> Self
 
-pub fn vortex_datafusion::VortexFormat::new_with_options(session: vortex_session::VortexSession, opts: vortex_datafusion::VortexOptions) -> Self
+pub fn vortex_datafusion::VortexFormat::new_with_options(session: vortex_session::VortexSession, opts: vortex_datafusion::VortexTableOptions) -> Self
 
-pub fn vortex_datafusion::VortexFormat::options(&self) -> &vortex_datafusion::VortexOptions
+pub fn vortex_datafusion::VortexFormat::options(&self) -> &vortex_datafusion::VortexTableOptions
 
 impl core::fmt::Debug for vortex_datafusion::VortexFormat
 
@@ -86,9 +72,9 @@ impl vortex_datafusion::VortexFormatFactory
 
 pub fn vortex_datafusion::VortexFormatFactory::new() -> Self
 
-pub fn vortex_datafusion::VortexFormatFactory::new_with_options(session: vortex_session::VortexSession, options: vortex_datafusion::VortexOptions) -> Self
+pub fn vortex_datafusion::VortexFormatFactory::new_with_options(session: vortex_session::VortexSession, options: vortex_datafusion::VortexTableOptions) -> Self
 
-pub fn vortex_datafusion::VortexFormatFactory::with_options(self, options: vortex_datafusion::VortexOptions) -> Self
+pub fn vortex_datafusion::VortexFormatFactory::with_options(self, options: vortex_datafusion::VortexTableOptions) -> Self
 
 impl core::fmt::Debug for vortex_datafusion::VortexFormatFactory
 
@@ -106,40 +92,6 @@ pub fn vortex_datafusion::VortexFormatFactory::create(&self, _state: &dyn datafu
 
 pub fn vortex_datafusion::VortexFormatFactory::default(&self) -> alloc::sync::Arc<dyn datafusion_datasource::file_format::FileFormat>
 
-pub struct vortex_datafusion::VortexOptions
-
-pub vortex_datafusion::VortexOptions::footer_initial_read_size_bytes: usize
-
-pub vortex_datafusion::VortexOptions::projection_pushdown: bool
-
-impl core::clone::Clone for vortex_datafusion::VortexOptions
-
-pub fn vortex_datafusion::VortexOptions::clone(&self) -> vortex_datafusion::VortexOptions
-
-impl core::cmp::Eq for vortex_datafusion::VortexOptions
-
-impl core::cmp::PartialEq for vortex_datafusion::VortexOptions
-
-pub fn vortex_datafusion::VortexOptions::eq(&self, other: &vortex_datafusion::VortexOptions) -> bool
-
-impl core::default::Default for vortex_datafusion::VortexOptions
-
-pub fn vortex_datafusion::VortexOptions::default() -> Self
-
-impl core::fmt::Debug for vortex_datafusion::VortexOptions
-
-pub fn vortex_datafusion::VortexOptions::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::marker::StructuralPartialEq for vortex_datafusion::VortexOptions
-
-impl datafusion_common::config::ConfigField for vortex_datafusion::VortexOptions
-
-pub fn vortex_datafusion::VortexOptions::reset(&mut self, key: &str) -> datafusion_common::error::Result<()>
-
-pub fn vortex_datafusion::VortexOptions::set(&mut self, key: &str, value: &str) -> datafusion_common::error::Result<()>
-
-pub fn vortex_datafusion::VortexOptions::visit<V: datafusion_common::config::Visit>(&self, v: &mut V, key_prefix: &str, _description: &'static str)
-
 pub struct vortex_datafusion::VortexSource
 
 impl vortex_datafusion::VortexSource
@@ -148,13 +100,19 @@ pub fn vortex_datafusion::VortexSource::metrics_registry(&self) -> &alloc::sync:
 
 pub fn vortex_datafusion::VortexSource::new(table_schema: datafusion_datasource::table_schema::TableSchema, session: vortex_session::VortexSession) -> Self
 
+pub fn vortex_datafusion::VortexSource::options(&self) -> &vortex_datafusion::VortexTableOptions
+
 pub fn vortex_datafusion::VortexSource::with_expression_convertor(self, expr_convertor: alloc::sync::Arc<dyn vortex_datafusion::ExpressionConvertor>) -> Self
 
 pub fn vortex_datafusion::VortexSource::with_file_metadata_cache(self, file_metadata_cache: alloc::sync::Arc<dyn datafusion_execution::cache::cache_manager::FileMetadataCache>) -> Self
 
+pub fn vortex_datafusion::VortexSource::with_options(self, opts: vortex_datafusion::VortexTableOptions) -> Self
+
 pub fn vortex_datafusion::VortexSource::with_projection_pushdown(self, enabled: bool) -> Self
 
-pub fn vortex_datafusion::VortexSource::with_vortex_reader_factory(self, vortex_reader_factory: alloc::sync::Arc<dyn vortex_datafusion::VortexReaderFactory>) -> Self
+pub fn vortex_datafusion::VortexSource::with_scan_concurrency(self, scan_concurrency: usize) -> Self
+
+pub fn vortex_datafusion::VortexSource::with_vortex_reader_factory(self, vortex_reader_factory: alloc::sync::Arc<dyn vortex_datafusion::persistent::reader::VortexReaderFactory>) -> Self
 
 impl core::clone::Clone for vortex_datafusion::VortexSource
 
@@ -186,6 +144,42 @@ pub fn vortex_datafusion::VortexSource::try_pushdown_projection(&self, projectio
 
 pub fn vortex_datafusion::VortexSource::with_batch_size(&self, batch_size: usize) -> alloc::sync::Arc<dyn datafusion_datasource::file::FileSource>
 
+pub struct vortex_datafusion::VortexTableOptions
+
+pub vortex_datafusion::VortexTableOptions::footer_initial_read_size_bytes: usize
+
+pub vortex_datafusion::VortexTableOptions::projection_pushdown: bool
+
+pub vortex_datafusion::VortexTableOptions::scan_concurrency: core::option::Option<usize>
+
+impl core::clone::Clone for vortex_datafusion::VortexTableOptions
+
+pub fn vortex_datafusion::VortexTableOptions::clone(&self) -> vortex_datafusion::VortexTableOptions
+
+impl core::cmp::Eq for vortex_datafusion::VortexTableOptions
+
+impl core::cmp::PartialEq for vortex_datafusion::VortexTableOptions
+
+pub fn vortex_datafusion::VortexTableOptions::eq(&self, other: &vortex_datafusion::VortexTableOptions) -> bool
+
+impl core::default::Default for vortex_datafusion::VortexTableOptions
+
+pub fn vortex_datafusion::VortexTableOptions::default() -> Self
+
+impl core::fmt::Debug for vortex_datafusion::VortexTableOptions
+
+pub fn vortex_datafusion::VortexTableOptions::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::marker::StructuralPartialEq for vortex_datafusion::VortexTableOptions
+
+impl datafusion_common::config::ConfigField for vortex_datafusion::VortexTableOptions
+
+pub fn vortex_datafusion::VortexTableOptions::reset(&mut self, key: &str) -> datafusion_common::error::Result<()>
+
+pub fn vortex_datafusion::VortexTableOptions::set(&mut self, key: &str, value: &str) -> datafusion_common::error::Result<()>
+
+pub fn vortex_datafusion::VortexTableOptions::visit<V: datafusion_common::config::Visit>(&self, v: &mut V, key_prefix: &str, _description: &'static str)
+
 pub trait vortex_datafusion::ExpressionConvertor: core::marker::Send + core::marker::Sync
 
 pub fn vortex_datafusion::ExpressionConvertor::can_be_pushed_down(&self, expr: &alloc::sync::Arc<dyn datafusion_physical_expr_common::physical_expr::PhysicalExpr>, schema: &arrow_schema::schema::Schema) -> bool
@@ -195,11 +189,3 @@ pub fn vortex_datafusion::ExpressionConvertor::convert(&self, expr: &dyn datafus
 pub fn vortex_datafusion::ExpressionConvertor::no_pushdown_projection(&self, source_projection: datafusion_physical_expr::projection::ProjectionExprs, input_schema: &arrow_schema::schema::Schema) -> datafusion_common::error::Result<vortex_datafusion::convert::exprs::ProcessedProjection>
 
 pub fn vortex_datafusion::ExpressionConvertor::split_projection(&self, source_projection: datafusion_physical_expr::projection::ProjectionExprs, input_schema: &arrow_schema::schema::Schema, output_schema: &arrow_schema::schema::Schema) -> datafusion_common::error::Result<vortex_datafusion::convert::exprs::ProcessedProjection>
-
-pub trait vortex_datafusion::VortexReaderFactory: core::fmt::Debug + core::marker::Send + core::marker::Sync + 'static
-
-pub fn vortex_datafusion::VortexReaderFactory::create_reader(&self, path: &str, session: &vortex_session::VortexSession) -> datafusion_common::error::Result<alloc::sync::Arc<dyn vortex_io::read::VortexReadAt>>
-
-impl vortex_datafusion::VortexReaderFactory for vortex_datafusion::DefaultVortexReaderFactory
-
-pub fn vortex_datafusion::DefaultVortexReaderFactory::create_reader(&self, path: &str, session: &vortex_session::VortexSession) -> datafusion_common::error::Result<alloc::sync::Arc<dyn vortex_io::read::VortexReadAt>>

--- a/vortex-datafusion/src/lib.rs
+++ b/vortex-datafusion/src/lib.rs
@@ -75,7 +75,7 @@ mod common_tests {
     use vortex::session::VortexSession;
 
     use crate::VortexFormatFactory;
-    use crate::VortexOptions;
+    use crate::VortexTableOptions;
 
     static VX_SESSION: LazyLock<VortexSession> = LazyLock::new(VortexSession::default);
 
@@ -94,7 +94,7 @@ mod common_tests {
         /// Create a new test session context with the given projection pushdown setting.
         pub fn new(projection_pushdown: bool) -> Self {
             let store = Arc::new(InMemory::new());
-            let opts = VortexOptions {
+            let opts = VortexTableOptions {
                 projection_pushdown,
                 ..Default::default()
             };

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -154,9 +154,9 @@ impl VortexFormatFactory {
     ///
     /// For example:
     /// ```rust
-    /// use vortex_datafusion::{VortexFormatFactory, VortexOptions};
+    /// use vortex_datafusion::{VortexFormatFactory, VortexTableOptions};
     ///
-    /// let factory = VortexFormatFactory::new().with_options(VortexOptions::default());
+    /// let factory = VortexFormatFactory::new().with_options(VortexTableOptions::default());
     /// ```
     pub fn with_options(mut self, options: VortexTableOptions) -> Self {
         self.options = Some(options);

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -71,7 +71,7 @@ const DEFAULT_FOOTER_INITIAL_READ_SIZE_BYTES: usize = MAX_POSTSCRIPT_SIZE as usi
 /// Vortex implementation of a DataFusion [`FileFormat`].
 pub struct VortexFormat {
     session: VortexSession,
-    opts: VortexOptions,
+    opts: VortexTableOptions,
 }
 
 impl Debug for VortexFormat {
@@ -88,7 +88,11 @@ config_namespace! {
     /// Can be set through a DataFusion [`SessionConfig`].
     ///
     /// [`SessionConfig`]: https://docs.rs/datafusion/latest/datafusion/prelude/struct.SessionConfig.html
-    pub struct VortexOptions {
+    pub struct VortexTableOptions {
+        /// The size of the in-memory [`vortex::file::Footer`] cache.
+        pub footer_cache_size_mb: usize, default = 64
+        /// The size of the in-memory segment cache.
+        pub segment_cache_size_mb: usize, default = 0
         /// The number of bytes to read when parsing a file footer.
         ///
         /// Values smaller than `MAX_POSTSCRIPT_SIZE + EOF_SIZE` will be clamped to that minimum
@@ -101,17 +105,20 @@ config_namespace! {
         /// all expressions are evaluated after the scan.
         pub projection_pushdown: bool, default = false
         /// The per-file Vortex scan concurrency.
+        /// The intra-partition scan concurrency, controlling the number of row splits to process
+        /// concurrently per-thread within each file. This does not affect the overall parallelism
+        /// across partitions, which is controlled by DataFusion's execution configuration.
         pub scan_concurrency: Option<usize>, default = None
     }
 }
 
-impl Eq for VortexOptions {}
+impl Eq for VortexTableOptions {}
 
 /// Minimal factory to create [`VortexFormat`] instances.
 #[derive(Debug)]
 pub struct VortexFormatFactory {
     session: VortexSession,
-    options: Option<VortexOptions>,
+    options: Option<VortexTableOptions>,
 }
 
 impl GetExt for VortexFormatFactory {
@@ -136,7 +143,7 @@ impl VortexFormatFactory {
     /// Creates a new instance with customized session and default options for all [`VortexFormat`] instances created from this factory.
     ///
     /// The options can be overridden by table-level configuration pass in [`FileFormatFactory::create`].
-    pub fn new_with_options(session: VortexSession, options: VortexOptions) -> Self {
+    pub fn new_with_options(session: VortexSession, options: VortexTableOptions) -> Self {
         Self {
             session,
             options: Some(options),
@@ -151,7 +158,7 @@ impl VortexFormatFactory {
     ///
     /// let factory = VortexFormatFactory::new().with_options(VortexOptions::default());
     /// ```
-    pub fn with_options(mut self, options: VortexOptions) -> Self {
+    pub fn with_options(mut self, options: VortexTableOptions) -> Self {
         self.options = Some(options);
         self
     }
@@ -191,16 +198,16 @@ impl FileFormatFactory for VortexFormatFactory {
 impl VortexFormat {
     /// Create a new instance with default options.
     pub fn new(session: VortexSession) -> Self {
-        Self::new_with_options(session, VortexOptions::default())
+        Self::new_with_options(session, VortexTableOptions::default())
     }
 
-    /// Creates a new instance with configured by a [`VortexOptions`].
-    pub fn new_with_options(session: VortexSession, opts: VortexOptions) -> Self {
+    /// Creates a new instance with configured by a [`VortexTableOptions`].
+    pub fn new_with_options(session: VortexSession, opts: VortexTableOptions) -> Self {
         Self { session, opts }
     }
 
     /// Return the format specific configuration
-    pub fn options(&self) -> &VortexOptions {
+    pub fn options(&self) -> &VortexTableOptions {
         &self.opts
     }
 }
@@ -565,7 +572,7 @@ mod tests {
 
     #[test]
     fn format_plumbs_footer_initial_read_size() {
-        let mut opts = VortexOptions::default();
+        let mut opts = VortexTableOptions::default();
         opts.set("footer_initial_read_size_bytes", "12345").unwrap();
 
         let format = VortexFormat::new_with_options(VortexSession::default(), opts);

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -100,9 +100,10 @@ config_namespace! {
         /// the scan. When disabled, Vortex reads only the referenced columns and
         /// all expressions are evaluated after the scan.
         pub projection_pushdown: bool, default = false
-        /// The per-file Vortex scan concurrency.
         /// The intra-partition scan concurrency, controlling the number of row splits to process
-        /// concurrently per-thread within each file. This does not affect the overall parallelism
+        /// concurrently per-thread within each file.
+        ///
+        /// This does not affect the overall parallelism
         /// across partitions, which is controlled by DataFusion's execution configuration.
         pub scan_concurrency: Option<usize>, default = None
     }

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -89,10 +89,6 @@ config_namespace! {
     ///
     /// [`SessionConfig`]: https://docs.rs/datafusion/latest/datafusion/prelude/struct.SessionConfig.html
     pub struct VortexTableOptions {
-        /// The size of the in-memory [`vortex::file::Footer`] cache.
-        pub footer_cache_size_mb: usize, default = 64
-        /// The size of the in-memory segment cache.
-        pub segment_cache_size_mb: usize, default = 0
         /// The number of bytes to read when parsing a file footer.
         ///
         /// Values smaller than `MAX_POSTSCRIPT_SIZE + EOF_SIZE` will be clamped to that minimum

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -100,6 +100,8 @@ config_namespace! {
         /// the scan. When disabled, Vortex reads only the referenced columns and
         /// all expressions are evaluated after the scan.
         pub projection_pushdown: bool, default = false
+        /// The per-file Vortex scan concurrency.
+        pub scan_concurrency: Option<usize>, default = None
     }
 }
 
@@ -507,10 +509,14 @@ impl FileFormat for VortexFormat {
     }
 
     fn file_source(&self, table_schema: TableSchema) -> Arc<dyn FileSource> {
-        Arc::new(
-            VortexSource::new(table_schema, self.session.clone())
-                .with_projection_pushdown(self.opts.projection_pushdown),
-        )
+        let mut source = VortexSource::new(table_schema, self.session.clone())
+            .with_projection_pushdown(self.opts.projection_pushdown);
+
+        if let Some(scan_concurrency) = self.opts.scan_concurrency {
+            source = source.with_scan_concurrency(scan_concurrency);
+        }
+
+        Arc::new(source) as _
     }
 }
 
@@ -548,7 +554,7 @@ mod tests {
                 (c1 VARCHAR NOT NULL, c2 INT NOT NULL) \
                 STORED AS vortex \
                 LOCATION 'table/' \
-                OPTIONS( footer_initial_read_size_bytes '12345' );",
+                OPTIONS( footer_initial_read_size_bytes '12345', scan_concurrency '3' );",
             )
             .await?
             .collect()

--- a/vortex-datafusion/src/persistent/mod.rs
+++ b/vortex-datafusion/src/persistent/mod.rs
@@ -15,9 +15,7 @@ mod stream;
 pub use access_plan::VortexAccessPlan;
 pub use format::VortexFormat;
 pub use format::VortexFormatFactory;
-pub use format::VortexOptions;
-pub use reader::DefaultVortexReaderFactory;
-pub use reader::VortexReaderFactory;
+pub use format::VortexTableOptions;
 pub use source::VortexSource;
 
 #[cfg(test)]

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -47,7 +47,6 @@ use vortex_utils::aliases::dash_map::DashMap;
 use vortex_utils::aliases::dash_map::Entry;
 
 use crate::VortexAccessPlan;
-use crate::VortexReaderFactory;
 use crate::convert::exprs::ExpressionConvertor;
 use crate::convert::exprs::ProcessedProjection;
 use crate::convert::exprs::make_vortex_predicate;
@@ -55,6 +54,7 @@ use crate::convert::schema::calculate_physical_schema;
 use crate::metrics::PARTITION_LABEL;
 use crate::metrics::PATH_LABEL;
 use crate::persistent::cache::CachedVortexMetadata;
+use crate::persistent::reader::VortexReaderFactory;
 use crate::persistent::stream::PrunableStream;
 
 #[derive(Clone)]
@@ -484,9 +484,9 @@ mod tests {
     use vortex::session::VortexSession;
 
     use super::*;
-    use crate::DefaultVortexReaderFactory;
     use crate::VortexAccessPlan;
     use crate::convert::exprs::DefaultExpressionConvertor;
+    use crate::persistent::reader::DefaultVortexReaderFactory;
 
     static SESSION: LazyLock<VortexSession> = LazyLock::new(VortexSession::default);
 

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -95,6 +95,7 @@ pub(crate) struct VortexOpener {
     pub file_metadata_cache: Option<Arc<dyn FileMetadataCache>>,
     /// Whether to enable expression pushdown into the underlying Vortex scan.
     pub projection_pushdown: bool,
+    pub scan_concurrency: Option<usize>,
 }
 
 impl FileOpener for VortexOpener {
@@ -125,6 +126,7 @@ impl FileOpener for VortexOpener {
         let limit = self.limit;
         let layout_reader = self.layout_readers.clone();
         let has_output_ordering = self.has_output_ordering;
+        let scan_concurrency = self.scan_concurrency;
 
         let expr_convertor = self.expression_convertor.clone();
         let projection_pushdown = self.projection_pushdown;
@@ -350,6 +352,10 @@ impl FileOpener for VortexOpener {
                 scan_builder = scan_builder.with_limit(limit);
             }
 
+            if let Some(concurrency) = scan_concurrency {
+                scan_builder = scan_builder.with_concurrency(concurrency);
+            }
+
             let stream = scan_builder
                 .with_metrics_registry(metrics_registry)
                 .with_projection(scan_projection)
@@ -566,6 +572,7 @@ mod tests {
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
             file_metadata_cache: None,
             projection_pushdown: false,
+            scan_concurrency: None,
         }
     }
 
@@ -659,6 +666,7 @@ mod tests {
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
             file_metadata_cache: None,
             projection_pushdown: false,
+            scan_concurrency: None,
         };
 
         let filter = col("a").lt(lit(100_i32));
@@ -744,9 +752,9 @@ mod tests {
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
             file_metadata_cache: None,
             projection_pushdown: false,
+            scan_concurrency: None,
         };
 
-        // The opener should successfully open the file and reorder columns
         let stream = opener.open(file)?.await?;
 
         let format_opts = FormatOptions::new().with_types_info(true);
@@ -898,6 +906,7 @@ mod tests {
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
             file_metadata_cache: None,
             projection_pushdown: false,
+            scan_concurrency: None,
         };
 
         // This should succeed and return the correctly projected and cast data
@@ -956,6 +965,7 @@ mod tests {
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
             file_metadata_cache: None,
             projection_pushdown: false,
+            scan_concurrency: None,
         }
     }
 
@@ -1156,6 +1166,7 @@ mod tests {
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
             file_metadata_cache: None,
             projection_pushdown: false,
+            scan_concurrency: None,
         };
 
         let file = PartitionedFile::new(file_path.to_string(), data_size);

--- a/vortex-datafusion/src/persistent/source.rs
+++ b/vortex-datafusion/src/persistent/source.rs
@@ -26,7 +26,7 @@ use datafusion_physical_plan::filter_pushdown::PushedDownPredicate;
 use datafusion_physical_plan::metrics::ExecutionPlanMetricsSet;
 use object_store::ObjectStore;
 use object_store::path::Path;
-use vortex::error::VortexExpect as _;
+use vortex::error::VortexExpect;
 use vortex::file::VORTEX_FILE_EXTENSION;
 use vortex::layout::LayoutReader;
 use vortex::metrics::DefaultMetricsRegistry;
@@ -35,10 +35,11 @@ use vortex::session::VortexSession;
 use vortex_utils::aliases::dash_map::DashMap;
 
 use super::opener::VortexOpener;
-use crate::DefaultVortexReaderFactory;
-use crate::VortexReaderFactory;
+use crate::VortexTableOptions;
 use crate::convert::exprs::DefaultExpressionConvertor;
 use crate::convert::exprs::ExpressionConvertor;
+use crate::persistent::reader::DefaultVortexReaderFactory;
+use crate::persistent::reader::VortexReaderFactory;
 
 /// Execution plan for reading one or more Vortex files, intended to be consumed by [`DataSourceExec`].
 ///
@@ -65,8 +66,7 @@ pub struct VortexSource {
     vx_metrics_registry: Arc<dyn MetricsRegistry>,
     file_metadata_cache: Option<Arc<dyn FileMetadataCache>>,
     /// Whether to enable expression pushdown into the underlying Vortex scan.
-    projection_pushdown: bool,
-    scan_concurrency: Option<usize>,
+    options: VortexTableOptions,
 }
 
 impl VortexSource {
@@ -92,14 +92,13 @@ impl VortexSource {
             vortex_reader_factory: None,
             vx_metrics_registry: Arc::new(DefaultMetricsRegistry::default()),
             file_metadata_cache: None,
-            projection_pushdown: false,
-            scan_concurrency: None,
+            options: VortexTableOptions::default(),
         }
     }
 
     /// Enable or disable expression pushdown into the underlying Vortex scan.
     pub fn with_projection_pushdown(mut self, enabled: bool) -> Self {
-        self.projection_pushdown = enabled;
+        self.options.projection_pushdown = enabled;
         self
     }
 
@@ -139,7 +138,18 @@ impl VortexSource {
 
     /// Set the underlying scan concurrency. This limit is used per Vortex scan operations.
     pub fn with_scan_concurrency(mut self, scan_concurrency: usize) -> Self {
-        self.scan_concurrency = Some(scan_concurrency);
+        self.options.scan_concurrency = Some(scan_concurrency);
+        self
+    }
+
+    /// Returns the table options for this source.
+    pub fn options(&self) -> &VortexTableOptions {
+        &self.options
+    }
+
+    /// Set the table options for this source.
+    pub fn with_options(mut self, opts: VortexTableOptions) -> Self {
+        self.options = opts;
         self
     }
 }
@@ -181,8 +191,8 @@ impl FileSource for VortexSource {
             has_output_ordering: !base_config.output_ordering.is_empty(),
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
             file_metadata_cache: self.file_metadata_cache.clone(),
-            projection_pushdown: self.projection_pushdown,
-            scan_concurrency: self.scan_concurrency,
+            projection_pushdown: self.options.projection_pushdown,
+            scan_concurrency: self.options.scan_concurrency,
         };
 
         Ok(Arc::new(opener))

--- a/vortex-datafusion/src/persistent/source.rs
+++ b/vortex-datafusion/src/persistent/source.rs
@@ -66,6 +66,7 @@ pub struct VortexSource {
     file_metadata_cache: Option<Arc<dyn FileMetadataCache>>,
     /// Whether to enable expression pushdown into the underlying Vortex scan.
     projection_pushdown: bool,
+    scan_concurrency: Option<usize>,
 }
 
 impl VortexSource {
@@ -92,6 +93,7 @@ impl VortexSource {
             vx_metrics_registry: Arc::new(DefaultMetricsRegistry::default()),
             file_metadata_cache: None,
             projection_pushdown: false,
+            scan_concurrency: None,
         }
     }
 
@@ -134,6 +136,12 @@ impl VortexSource {
         self.file_metadata_cache = Some(file_metadata_cache);
         self
     }
+
+    /// Set the underlying scan concurrency. This limit is used per Vortex scan operations.
+    pub fn with_scan_concurrency(mut self, scan_concurrency: usize) -> Self {
+        self.scan_concurrency = Some(scan_concurrency);
+        self
+    }
 }
 
 impl FileSource for VortexSource {
@@ -174,6 +182,7 @@ impl FileSource for VortexSource {
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
             file_metadata_cache: self.file_metadata_cache.clone(),
             projection_pushdown: self.projection_pushdown,
+            scan_concurrency: self.scan_concurrency,
         };
 
         Ok(Arc::new(opener))


### PR DESCRIPTION
This PR adds a new configuration to the `FileSource` based API, allowing users to control the intra-partition scan concurrency.