### PR TITLE
[CI] Auto close inactive PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: Close inactive PRs
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          # After 30 days of no activity, a PR will be marked as stale
+          days-before-pr-stale: 30
+          # PR has 7 more days to become active, otherwise it will be closed.
+          days-before-pr-close: 7
+          stale-pr-label: "stale"
+          stale-pr-message: "This PR has been marked as stale because it has been open for 30 days with no activity. Please comment or remove the stale label if you wish to keep it active, otherwise it will be closed in 7 days"
+          close-pr-message: "This PR was closed because it has been inactive for 7 days since being marked as stale."
+          days-before-issue-stale: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
This PR introduces a new nightly job that will close stale PRs, defined as a PR that had no activity for 30 (+ 7) days.