### PR TITLE
fix: canonicalize sliced VarBinArray failure

### DIFF
--- a/vortex-array/src/arrays/varbin/array.rs
+++ b/vortex-array/src/arrays/varbin/array.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use num_traits::AsPrimitive;
+use vortex_buffer::Buffer;
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
 use vortex_dtype::IntegerPType;
@@ -14,6 +15,7 @@ use vortex_error::vortex_err;
 
 use crate::Array;
 use crate::ArrayRef;
+use crate::IntoArray;
 use crate::ToCanonical;
 use crate::arrays::varbin::builder::VarBinBuilder;
 use crate::stats::ArrayStats;
@@ -304,6 +306,58 @@ impl VarBinArray {
     /// the `offsets` array, and the `validity`.
     pub fn into_parts(self) -> (DType, ByteBuffer, ArrayRef, Validity) {
         (self.dtype, self.bytes, self.offsets, self.validity)
+    }
+}
+
+impl VarBinArray {
+    /// Return an array containing the same data, but where the internal `offsets` start at zero
+    /// and all wasted space in the bytes child has been clipped.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use vortex_array::arrays::VarBinArray;
+    /// # use vortex_array::arrays::VarBinVTable;
+    /// # use vortex_dtype::DType;
+    /// # use vortex_dtype::Nullability::NonNullable;
+    /// let items = VarBinArray::from_iter_nonnull(["abc", "def", "ghi"], DType::Utf8(NonNullable));
+    /// let sliced = items.slice(1..3).as_::<VarBinVTable>().clone();
+    ///
+    /// // After slicing, there is some unused data at the front of the bytes.
+    /// assert_eq!(sliced.offset_at(0), 3);
+    ///
+    /// // But after zeroing the offsets, the extraneous data is gone.
+    /// let truncated = sliced.zero_offsets();
+    /// assert_eq!(truncated.offset_at(0), 0);
+    /// assert_eq!(truncated.len(), 2);
+    /// ```
+    #[doc(hidden)]
+    pub fn zero_offsets(self) -> Self {
+        if self.is_empty() {
+            return self;
+        }
+
+        let first = self.offset_at(0);
+
+        let bytes = self.sliced_bytes();
+        let dtype = self.dtype;
+        let validity = self.validity;
+        let offsets = self.offsets;
+
+        let offsets = if first == 0 {
+            offsets
+        } else {
+            let offsets = offsets.to_primitive();
+            match_each_integer_ptype!(offsets.ptype(), |P| {
+                let offsets = offsets.as_slice::<P>();
+                let buffer: Buffer<P> = offsets.iter().map(|index| index - offsets[0]).collect();
+                buffer.into_array()
+            })
+        };
+
+        // SAFETY: we make the first offset start at zero, and slice the bytes accordingly,
+        //  so all offsets stay valid.
+        unsafe { Self::new_unchecked(offsets, bytes, dtype, validity) }
     }
 }
 

--- a/vortex-array/src/arrays/varbin/vtable/canonical.rs
+++ b/vortex-array/src/arrays/varbin/vtable/canonical.rs
@@ -24,6 +24,9 @@ impl CanonicalVTable<VarBinVTable> for VarBinVTable {
         let dtype = array.dtype().clone();
         let nullable = dtype.is_nullable();
 
+        let array = array.clone().zero_offsets();
+        assert_eq!(array.offset_at(0), 0);
+
         let array_ref = array
             .to_array()
             .into_arrow_preferred()

--- a/vortex-python/test/test_dataset.py
+++ b/vortex-python/test/test_dataset.py
@@ -193,15 +193,7 @@ def test_fragment_to_batch_size(ds: vx.dataset.VortexDataset, batch_size: int):
 def test_fragment_to_table(ds: vx.dataset.VortexDataset):
     fragments = list(ds.get_fragments())
 
-    # The first fragment contains none of the matching records
-    tbl = fragments[0].to_table(columns=["bool", "float"], filter=pc.field("float") > 100)
-    assert len(tbl.slice(0, 10)) == 0
-
-    # From the second fragment onwards all records match
-    tbl = fragments[1].to_table(columns=["bool", "float"], filter=pc.field("float") > 100)
-    assert tbl.slice(0, 10) == pa.Table.from_struct_array(
-        pa.array([record(x, columns={"float", "bool"}) for x in range(10001, 10011)])
-    )
+    frag_row_count = 0
 
     for f in fragments:
         assert f.to_table(columns=["bool", "string"]).schema == pa.schema(
@@ -211,9 +203,13 @@ def test_fragment_to_table(ds: vx.dataset.VortexDataset):
             [("string", pa.string_view()), ("bool", pa.bool_())]
         )
 
+        frag_row_count += len(f.to_table(columns=["bool", "float"], filter=pc.field("float") > 100))
+
+    assert frag_row_count == 989_999
+
 
 def test_get_fragments(ds: vx.dataset.VortexDataset):
-    assert len(list(ds.get_fragments())) == 123
+    assert len(list(ds.get_fragments())) == 26
 
     assert ds.count_rows() == sum(f.count_rows() for f in ds.get_fragments())
 


### PR DESCRIPTION
A user report came in with the following stacktrace:

```
                 at /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/arrow-array-56.2.0/src/builder/generic_bytes_view_builder.rs:176:9
      12: <arrow_array::array::byte_view_array::GenericByteViewArray<V> as core::convert::From<&arrow_array::array::byte_array::GenericByteArray<FROM>>>::from
                 at /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/arrow-array-56.2.0/src/array/byte_view_array.rs:913:39
      13: vortex_array::arrays::varbin::vtable::canonical::<impl vortex_array::vtable::canonical::CanonicalVTable<vortex_array::arrays::varbin::vtable::VarBinVTable> for vortex_array::arrays::varbin::vtable::VarBinVTable>::canonicalize
                 at /usr/local/cargo/git/checkouts/vortex-e8ac85adeb77362c/f1b2ae9/vortex-array/src/arrays/varbin/vtable/canonical.rs:38:26
      14: <vortex_array::array::ArrayAdapter<V> as vortex_array::array::Array>::to_canonical
                 at /usr/local/cargo/git/checkouts/vortex-e8ac85adeb77362c/f1b2ae9/vortex-array/src/array/mod.rs:609:25
      15: <A as vortex_array::canonical::ToCanonical>::to_varbinview
                 at /usr/local/cargo/git/checkouts/vortex-e8ac85adeb77362c/f1b2ae9/vortex-array/src/canonical.rs:374:14
      16: <vortex_array::builders::varbinview::VarBinViewBuilder as vortex_array::builders::ArrayBuilder>::extend_from_array_unchecked
                 at /usr/local/cargo/git/checkouts/vortex-e8ac85adeb77362c/f1b2ae9/vortex-array/src/builders/varbinview.rs:278:27
      17: <vortex_array::builders::fixed_size_list::FixedSizeListBuilder as vortex_array::builders::ArrayBuilder>::extend_from_array_unchecked
                 at /usr/local/cargo/git/checkouts/vortex-e8ac85adeb77362c/f1b2ae9/vortex-array/src/builders/fixed_size_list.rs:243:31
      18: vortex_array::stats::array::StatsSetRef::compute_stat
                 at /usr/local/cargo/git/checkouts/vortex-e8ac85adeb77362c/f1b2ae9/vortex-array/src/stats/array.rs:177:29
      19: vortex_array::stats::array::StatsSetRef::compute_all
                 at /usr/local/cargo/git/checkouts/vortex-e8ac85adeb77362c/f1b2ae9/vortex-array/src/stats/array.rs:200:35
      20: <vortex_layout::layouts::compressed::CompressingStrategy as vortex_layout::strategy::LayoutStrategy>::write_stream::{{closure}}::{{closure}}::{{closure}}
                 at /usr/local/cargo/git/checkouts/vortex-e8ac85adeb77362c/f1b2ae9/vortex-layout/src/layouts/compressed.rs:144:26
```

The failure is inside of arrow-rs, in its conversion from LargeStringArray -> StringViewArray.

Arrow checks that the final offset is < i32::MAX, and then pushes the buffer. This will not work if we're trying to convert a large VarBinArray that's been sliced, so that the final offset is not the maximum size of the buffer.

Upstream arrow-rs should get a fix as well, but in the meantime, this should fix the behavior of compressing large chunks, by rezeroing offsets before we canonicalize VarBin.