### PR TITLE
chore: use `assert_arrays_eq!` in listview tests

### DIFF
--- a/vortex-array/src/arrays/listview/tests/basic.rs
+++ b/vortex-array/src/arrays/listview/tests/basic.rs
@@ -18,6 +18,7 @@ use crate::arrays::ListArray;
 use crate::arrays::ListViewArray;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::list_view_from_list;
+use crate::assert_arrays_eq;
 use crate::validity::Validity;
 
 #[test]
@@ -44,11 +45,10 @@ fn test_basic_listview_comprehensive() {
     ));
 
     // Check individual list elements.
-    let first_list = listview.list_elements_at(0);
-    assert_eq!(first_list.len(), 3);
-    assert_eq!(first_list.scalar_at(0), 1i32.into());
-    assert_eq!(first_list.scalar_at(1), 2i32.into());
-    assert_eq!(first_list.scalar_at(2), 3i32.into());
+    assert_arrays_eq!(
+        listview.list_elements_at(0),
+        PrimitiveArray::from_iter([1i32, 2, 3])
+    );
 
     // Test scalar_at which returns entire lists as Scalar values.
     let first_scalar = listview.scalar_at(0);
@@ -61,17 +61,15 @@ fn test_basic_listview_comprehensive() {
         )
     );
 
-    let second_list = listview.list_elements_at(1);
-    assert_eq!(second_list.len(), 2);
-    assert_eq!(second_list.scalar_at(0), 4i32.into());
-    assert_eq!(second_list.scalar_at(1), 5i32.into());
+    assert_arrays_eq!(
+        listview.list_elements_at(1),
+        PrimitiveArray::from_iter([4i32, 5])
+    );
 
-    let third_list = listview.list_elements_at(2);
-    assert_eq!(third_list.len(), 4);
-    assert_eq!(third_list.scalar_at(0), 6i32.into());
-    assert_eq!(third_list.scalar_at(1), 7i32.into());
-    assert_eq!(third_list.scalar_at(2), 8i32.into());
-    assert_eq!(third_list.scalar_at(3), 9i32.into());
+    assert_arrays_eq!(
+        listview.list_elements_at(2),
+        PrimitiveArray::from_iter([6i32, 7, 8, 9])
+    );
 }
 
 #[test]
@@ -87,16 +85,16 @@ fn test_out_of_order_offsets() {
     assert_eq!(listview.len(), 3);
 
     // First list starts at offset 6: [7, 8, 9].
-    let first = listview.list_elements_at(0);
-    assert_eq!(first.scalar_at(0), 7i32.into());
-    assert_eq!(first.scalar_at(1), 8i32.into());
-    assert_eq!(first.scalar_at(2), 9i32.into());
+    assert_arrays_eq!(
+        listview.list_elements_at(0),
+        PrimitiveArray::from_iter([7i32, 8, 9])
+    );
 
     // Second list starts at offset 0: [1, 2, 3].
-    let second = listview.list_elements_at(1);
-    assert_eq!(second.scalar_at(0), 1i32.into());
-    assert_eq!(second.scalar_at(1), 2i32.into());
-    assert_eq!(second.scalar_at(2), 3i32.into());
+    assert_arrays_eq!(
+        listview.list_elements_at(1),
+        PrimitiveArray::from_iter([1i32, 2, 3])
+    );
 }
 
 #[test]
@@ -130,9 +128,10 @@ fn test_from_list_array() {
     assert_eq!(list_view.len(), 3);
 
     // Check first list.
-    let first = list_view.list_elements_at(0);
-    assert_eq!(first.scalar_at(0), 1i32.into());
-    assert_eq!(first.scalar_at(1), 2i32.into());
+    assert_arrays_eq!(
+        list_view.list_elements_at(0),
+        PrimitiveArray::from_iter([1i32, 2])
+    );
 
     // Check validity is preserved.
     assert!(list_view.is_valid(0));
@@ -140,10 +139,10 @@ fn test_from_list_array() {
     assert!(list_view.is_valid(2));
 
     // Check third list.
-    let third = list_view.list_elements_at(2);
-    assert_eq!(third.scalar_at(0), 5i32.into());
-    assert_eq!(third.scalar_at(1), 6i32.into());
-    assert_eq!(third.scalar_at(2), 7i32.into());
+    assert_arrays_eq!(
+        list_view.list_elements_at(2),
+        PrimitiveArray::from_iter([5i32, 6, 7])
+    );
 }
 
 // Parameterized tests for ConstantArray scenarios.
@@ -182,11 +181,9 @@ fn test_listview_with_constant_arrays(#[case] const_sizes: bool, #[case] const_o
 
     if const_sizes && const_offsets {
         // All lists are identical [1, 2, 3] (overlapping).
+        let expected = PrimitiveArray::from_iter([1i32, 2, 3]);
         for i in 0..3 {
-            let list = listview.list_elements_at(i);
-            assert_eq!(list.scalar_at(0), 1i32.into());
-            assert_eq!(list.scalar_at(1), 2i32.into());
-            assert_eq!(list.scalar_at(2), 3i32.into());
+            assert_arrays_eq!(listview.list_elements_at(i), expected);
         }
     } else if const_sizes {
         // All lists have size 3, different offsets (no overlap).

--- a/vortex-array/src/arrays/listview/tests/filter.rs
+++ b/vortex-array/src/arrays/listview/tests/filter.rs
@@ -96,10 +96,10 @@ fn test_filter_with_gaps() {
     assert_eq!(result_list.offset_at(2), 1); // List 3: [2,3] (overlapping)
 
     // Verify the lists still read correctly.
-    let list0 = result_list.list_elements_at(0);
-    assert_eq!(list0.scalar_at(0).as_primitive().as_::<i32>().unwrap(), 7);
-    assert_eq!(list0.scalar_at(1).as_primitive().as_::<i32>().unwrap(), 8);
-    assert_eq!(list0.scalar_at(2).as_primitive().as_::<i32>().unwrap(), 9);
+    assert_arrays_eq!(
+        result_list.list_elements_at(0),
+        PrimitiveArray::from_iter([7i32, 8, 9])
+    );
 }
 
 #[ignore = "TODO(connor)[ListView]: Don't rebuild ListView after every `filter`"]

--- a/vortex-array/src/arrays/listview/tests/operations.rs
+++ b/vortex-array/src/arrays/listview/tests/operations.rs
@@ -20,6 +20,8 @@ use crate::arrays::BoolArray;
 use crate::arrays::ConstantArray;
 use crate::arrays::ListViewArray;
 use crate::arrays::ListViewVTable;
+use crate::arrays::PrimitiveArray;
+use crate::assert_arrays_eq;
 use crate::compute::cast;
 use crate::compute::conformance::mask::test_mask_conformance;
 use crate::compute::is_constant;
@@ -110,14 +112,18 @@ fn test_slice_out_of_order() {
     assert_eq!(sliced_list.size_at(2), 1, "Third list should have size 1");
 
     // Verify the actual list contents are correct.
-    let list0 = sliced_list.list_elements_at(0);
-    assert_eq!(list0.scalar_at(0).as_primitive().as_::<i32>().unwrap(), 10);
-
-    let list1 = sliced_list.list_elements_at(1);
-    assert_eq!(list1.scalar_at(0).as_primitive().as_::<i32>().unwrap(), 40);
-
-    let list2 = sliced_list.list_elements_at(2);
-    assert_eq!(list2.scalar_at(0).as_primitive().as_::<i32>().unwrap(), 90);
+    assert_arrays_eq!(
+        sliced_list.list_elements_at(0),
+        PrimitiveArray::from_iter([10i32, 20, 30])
+    );
+    assert_arrays_eq!(
+        sliced_list.list_elements_at(1),
+        PrimitiveArray::from_iter([40i32, 50, 60])
+    );
+    assert_arrays_eq!(
+        sliced_list.list_elements_at(2),
+        PrimitiveArray::from_iter([90i32])
+    );
 }
 
 #[test]

--- a/vortex-array/src/arrays/listview/tests/take.rs
+++ b/vortex-array/src/arrays/listview/tests/take.rs
@@ -86,10 +86,10 @@ fn test_take_with_gaps() {
     );
 
     // Verify the lists still read correctly despite gaps.
-    let list0 = result_list.list_elements_at(0);
-    assert_eq!(list0.scalar_at(0).as_primitive().as_::<i32>().unwrap(), 7);
-    assert_eq!(list0.scalar_at(1).as_primitive().as_::<i32>().unwrap(), 8);
-    assert_eq!(list0.scalar_at(2).as_primitive().as_::<i32>().unwrap(), 9);
+    assert_arrays_eq!(
+        result_list.list_elements_at(0),
+        PrimitiveArray::from_iter([7i32, 8, 9])
+    );
 }
 
 #[ignore = "TODO(connor)[ListView]: Don't rebuild ListView after every `take`"]

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -477,24 +477,22 @@ mod tests {
         assert_eq!(listview.len(), 4);
 
         // Check first list: [1, 2, 3].
-        let first_list = listview.list_elements_at(0);
-        assert_eq!(first_list.len(), 3);
-        assert_eq!(first_list.scalar_at(0), 1i32.into());
-        assert_eq!(first_list.scalar_at(1), 2i32.into());
-        assert_eq!(first_list.scalar_at(2), 3i32.into());
+        assert_arrays_eq!(
+            listview.list_elements_at(0),
+            PrimitiveArray::from_iter([1i32, 2, 3])
+        );
 
         // Check empty list.
-        let empty_list = listview.list_elements_at(1);
-        assert_eq!(empty_list.len(), 0);
+        assert_eq!(listview.list_elements_at(1).len(), 0);
 
         // Check null list.
         assert!(!listview.validity().is_valid(2));
 
         // Check last list: [4, 5].
-        let last_list = listview.list_elements_at(3);
-        assert_eq!(last_list.len(), 2);
-        assert_eq!(last_list.scalar_at(0), 4i32.into());
-        assert_eq!(last_list.scalar_at(1), 5i32.into());
+        assert_arrays_eq!(
+            listview.list_elements_at(3),
+            PrimitiveArray::from_iter([4i32, 5])
+        );
     }
 
     #[test]
@@ -525,15 +523,16 @@ mod tests {
         assert_eq!(listview.len(), 2);
 
         // Verify first list: [1, 2].
-        let first = listview.list_elements_at(0);
-        assert_eq!(first.scalar_at(0), 1i32.into());
-        assert_eq!(first.scalar_at(1), 2i32.into());
+        assert_arrays_eq!(
+            listview.list_elements_at(0),
+            PrimitiveArray::from_iter([1i32, 2])
+        );
 
         // Verify second list: [3, 4, 5].
-        let second = listview.list_elements_at(1);
-        assert_eq!(second.scalar_at(0), 3i32.into());
-        assert_eq!(second.scalar_at(1), 4i32.into());
-        assert_eq!(second.scalar_at(2), 5i32.into());
+        assert_arrays_eq!(
+            listview.list_elements_at(1),
+            PrimitiveArray::from_iter([3i32, 4, 5])
+        );
 
         // Test u64 offsets with u16 sizes.
         let dtype2: Arc<DType> = Arc::new(I32.into());
@@ -553,9 +552,10 @@ mod tests {
 
         // Verify the values: [0], [10], [20], [30], [40].
         for i in 0..5i32 {
-            let list = listview2.list_elements_at(i as usize);
-            assert_eq!(list.len(), 1);
-            assert_eq!(list.scalar_at(0), (i * 10).into());
+            assert_arrays_eq!(
+                listview2.list_elements_at(i as usize),
+                PrimitiveArray::from_iter([i * 10])
+            );
         }
     }
 
@@ -591,10 +591,10 @@ mod tests {
         assert!(!listview.validity().is_valid(3));
 
         // Last is the regular list: [10, 20].
-        let last_list = listview.list_elements_at(4);
-        assert_eq!(last_list.len(), 2);
-        assert_eq!(last_list.scalar_at(0), 10i32.into());
-        assert_eq!(last_list.scalar_at(1), 20i32.into());
+        assert_arrays_eq!(
+            listview.list_elements_at(4),
+            PrimitiveArray::from_iter([10i32, 20])
+        );
     }
 
     #[test]
@@ -631,25 +631,25 @@ mod tests {
 
         // Check the extended data.
         // First list: [0] (initial data).
-        let first = listview.list_elements_at(0);
-        assert_eq!(first.len(), 1);
-        assert_eq!(first.scalar_at(0), 0i32.into());
+        assert_arrays_eq!(
+            listview.list_elements_at(0),
+            PrimitiveArray::from_iter([0i32])
+        );
 
         // Second list: [1, 2, 3] (from source).
-        let second = listview.list_elements_at(1);
-        assert_eq!(second.len(), 3);
-        assert_eq!(second.scalar_at(0), 1i32.into());
-        assert_eq!(second.scalar_at(1), 2i32.into());
-        assert_eq!(second.scalar_at(2), 3i32.into());
+        assert_arrays_eq!(
+            listview.list_elements_at(1),
+            PrimitiveArray::from_iter([1i32, 2, 3])
+        );
 
         // Third list: null (from source).
         assert!(!listview.validity().is_valid(2));
 
         // Fourth list: [4, 5] (from source).
-        let fourth = listview.list_elements_at(3);
-        assert_eq!(fourth.len(), 2);
-        assert_eq!(fourth.scalar_at(0), 4i32.into());
-        assert_eq!(fourth.scalar_at(1), 5i32.into());
+        assert_arrays_eq!(
+            listview.list_elements_at(3),
+            PrimitiveArray::from_iter([4i32, 5])
+        );
     }
 
     #[test]


### PR DESCRIPTION
Replace manual scalar_at assertions with assert_arrays_eq! macro
for clearer and more concise test assertions in listview builder
tests and basic listview tests.

Signed-off-by: Claude <noreply@anthropic.com>