### PR TITLE
Use `ObjectStoreRegistry` to share `ObjectStore` instances

### DIFF
--- a/vortex-python/Cargo.toml
+++ b/vortex-python/Cargo.toml
@@ -28,7 +28,13 @@ arrow-schema = { workspace = true }
 bytes = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
-object_store = { workspace = true, features = ["aws", "gcp", "azure", "http"] }
+object_store = { workspace = true, features = [
+    "fs",
+    "aws",
+    "gcp",
+    "azure",
+    "http",
+] }
 parking_lot = { workspace = true }
 pyo3 = { workspace = true, features = ["abi3", "abi3-py311"] }
 pyo3-bytes = { workspace = true }

--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -110,7 +110,7 @@ impl PyVortexDataset {
     }
 
     pub async fn from_url(url: &str) -> VortexResult<Self> {
-        let (_scheme, object_store, path) = object_store_from_url(url)?;
+        let (object_store, path) = object_store_from_url(url)?;
         PyVortexDataset::try_new(
             SESSION
                 .open_options()

--- a/vortex-python/src/object_store_urls.rs
+++ b/vortex-python/src/object_store_urls.rs
@@ -2,47 +2,20 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::sync::Arc;
+use std::sync::LazyLock;
 
 use object_store::ObjectStore;
-use object_store::ObjectStoreScheme;
-use object_store::aws::AmazonS3Builder;
-use object_store::azure::MicrosoftAzureBuilder;
-use object_store::gcp::GoogleCloudStorageBuilder;
-use object_store::http::HttpBuilder;
-use object_store::local::LocalFileSystem;
 use object_store::path::Path;
+use object_store::registry::DefaultObjectStoreRegistry;
+use object_store::registry::ObjectStoreRegistry;
 use url::Url;
 use vortex::error::VortexResult;
-use vortex::error::vortex_bail;
 
-pub(crate) fn object_store_from_url(
-    url_str: &str,
-) -> VortexResult<(ObjectStoreScheme, Arc<dyn ObjectStore>, Path)> {
-    let url = Url::parse(url_str)?;
+static REGISTRY: LazyLock<DefaultObjectStoreRegistry> =
+    LazyLock::new(DefaultObjectStoreRegistry::new);
 
-    let (scheme, path) = ObjectStoreScheme::parse(&url).map_err(object_store::Error::from)?;
-    let store: Arc<dyn ObjectStore> = match scheme {
-        ObjectStoreScheme::Local => Arc::new(LocalFileSystem::default()),
-        ObjectStoreScheme::AmazonS3 => {
-            Arc::new(AmazonS3Builder::from_env().with_url(url_str).build()?)
-        }
-        ObjectStoreScheme::GoogleCloudStorage => Arc::new(
-            GoogleCloudStorageBuilder::from_env()
-                .with_url(url_str)
-                .build()?,
-        ),
-        ObjectStoreScheme::MicrosoftAzure => Arc::new(
-            MicrosoftAzureBuilder::from_env()
-                .with_url(url_str)
-                .build()?,
-        ),
-        ObjectStoreScheme::Http => Arc::new(
-            HttpBuilder::new()
-                .with_url(&url[..url::Position::BeforePath])
-                .build()?,
-        ),
-        otherwise => vortex_bail!("unrecognized object store scheme: {:?}", otherwise),
-    };
-
-    Ok((scheme, store, path))
+pub(crate) fn object_store_from_url(url_str: &str) -> VortexResult<(Arc<dyn ObjectStore>, Path)> {
+    let parsed_url = Url::parse(url_str)?;
+    let (store, path) = REGISTRY.resolve(&parsed_url)?;
+    Ok((store, path))
 }


### PR DESCRIPTION
Make sure we re-use the underlying HTTP connections if they point at the same endpoints and buckets, to avoid any pathological usage that might cause a user to DOS themselves.