### PR TITLE
Fix: arrow struct comparison

### DIFF
--- a/vortex-array/src/compute/compare.rs
+++ b/vortex-array/src/compute/compare.rs
@@ -319,6 +319,38 @@ where
     lengths.map(cmp_fn).collect()
 }
 
+/// Compare two Arrow arrays element-wise using [`make_comparator`].
+///
+/// This function is required for nested types (Struct, List, FixedSizeList) because Arrow's
+/// vectorized comparison kernels ([`cmp::eq`], [`cmp::neq`], etc.) do not support them.
+///
+/// The vectorized kernels are faster but only work on primitive types, so for non-nested types,
+/// prefer using the vectorized kernels directly for better performance.
+pub(crate) fn compare_nested_arrow_arrays(
+    lhs: &dyn arrow_array::Array,
+    rhs: &dyn arrow_array::Array,
+    operator: Operator,
+) -> VortexResult<BooleanArray> {
+    let cmp = make_comparator(lhs, rhs, SortOptions::default())?;
+
+    let values = (0..lhs.len())
+        .map(|i| {
+            let cmp_result = cmp(i, i);
+            match operator {
+                Operator::Eq => cmp_result.is_eq(),
+                Operator::NotEq => cmp_result.is_ne(),
+                Operator::Gt => cmp_result.is_gt(),
+                Operator::Gte => cmp_result.is_ge(),
+                Operator::Lt => cmp_result.is_lt(),
+                Operator::Lte => cmp_result.is_le(),
+            }
+        })
+        .collect();
+    let nulls = NullBuffer::union(lhs.nulls(), rhs.nulls());
+
+    Ok(BooleanArray::new(values, nulls))
+}
+
 /// Implementation of `CompareFn` using the Arrow crate.
 fn arrow_compare(
     left: &dyn Array,
@@ -329,6 +361,9 @@ fn arrow_compare(
 
     let nullable = left.dtype().is_nullable() || right.dtype().is_nullable();
 
+    // Arrow's vectorized comparison kernels (`cmp::eq`, etc.) are faster but don't support nested
+    // types. For nested types, we fall back to `make_comparator` which does element-wise
+    // comparison.
     let array = if left.dtype().is_nested() || right.dtype().is_nested() {
         let rhs = right.to_array().into_arrow_preferred()?;
         let lhs = left.to_array().into_arrow(rhs.data_type())?;
@@ -340,24 +375,9 @@ fn arrow_compare(
             rhs.data_type()
         );
 
-        let cmp = make_comparator(lhs.as_ref(), rhs.as_ref(), SortOptions::default())?;
-        let len = left.len();
-        let values = (0..len)
-            .map(|i| {
-                let cmp = cmp(i, i);
-                match operator {
-                    Operator::Eq => cmp.is_eq(),
-                    Operator::NotEq => cmp.is_ne(),
-                    Operator::Gt => cmp.is_gt(),
-                    Operator::Gte => cmp.is_gt() || cmp.is_eq(),
-                    Operator::Lt => cmp.is_lt(),
-                    Operator::Lte => cmp.is_lt() || cmp.is_eq(),
-                }
-            })
-            .collect();
-        let nulls = NullBuffer::union(lhs.nulls(), rhs.nulls());
-        BooleanArray::new(values, nulls)
+        compare_nested_arrow_arrays(lhs.as_ref(), rhs.as_ref(), operator)?
     } else {
+        // Fast path: use vectorized kernels for primitive types.
         let lhs = Datum::try_new(left)?;
         let rhs = Datum::try_new_with_target_datatype(right, lhs.data_type())?;
 

--- a/vortex-array/src/expr/exprs/binary.rs
+++ b/vortex-array/src/expr/exprs/binary.rs
@@ -23,6 +23,7 @@ use crate::compute;
 use crate::compute::add;
 use crate::compute::and_kleene;
 use crate::compute::compare;
+use crate::compute::compare_nested_arrow_arrays;
 use crate::compute::div;
 use crate::compute::mul;
 use crate::compute::or_kleene;
@@ -136,6 +137,7 @@ impl VTable for Binary {
             .try_into()
             .map_err(|_| vortex_err!("Wrong arg count"))?;
 
+        // Handle logical operators.
         match op {
             Operator::And => {
                 return Ok(LogicalAndKleene::and_kleene(&lhs.into_bool(), &rhs.into_bool()).into());
@@ -146,10 +148,33 @@ impl VTable for Binary {
             _ => {}
         }
 
+        // Arrow's vectorized comparison kernels (`cmp::eq`, etc.) don't support nested types
+        // (Struct, List, FixedSizeList). For those, we use `compare_nested_arrow_arrays` which does
+        // element-wise comparison via `make_comparator`.
+        if let Some(cmp_op) = op.maybe_cmp_operator()
+            && (lhs.is_nested() || rhs.is_nested())
+        {
+            // Treat scalars as 1-element arrow arrays.
+            let lhs_arr = lhs.into_arrow()?;
+            let rhs_arr = rhs.into_arrow()?;
+
+            let bool_array = compare_nested_arrow_arrays(lhs_arr.get().0, rhs_arr.get().0, cmp_op)?;
+            let vector = bool_array.into_vector()?;
+
+            let both_are_scalar = lhs_arr.get().1 && rhs_arr.get().1;
+
+            return Ok(if both_are_scalar {
+                Datum::Scalar(vortex_vector::Scalar::Bool(vector.scalar_at(0)))
+            } else {
+                Datum::Vector(vortex_vector::Vector::Bool(vector))
+            });
+        }
+
         let lhs = lhs.into_arrow()?;
         let rhs = rhs.into_arrow()?;
 
         let vector = match op {
+            // Handle comparison operators.
             Operator::Eq => cmp::eq(lhs.as_ref(), rhs.as_ref())?.into_vector()?.into(),
             Operator::NotEq => cmp::neq(lhs.as_ref(), rhs.as_ref())?.into_vector()?.into(),
             Operator::Gt => cmp::gt(lhs.as_ref(), rhs.as_ref())?.into_vector()?.into(),
@@ -161,6 +186,7 @@ impl VTable for Binary {
                 .into_vector()?
                 .into(),
 
+            // Handle arithmetic operators.
             Operator::Add => {
                 arrow_arith::numeric::add(lhs.as_ref(), rhs.as_ref())?.into_vector()?
             }
@@ -173,17 +199,18 @@ impl VTable for Binary {
             Operator::Div => {
                 arrow_arith::numeric::div(lhs.as_ref(), rhs.as_ref())?.into_vector()?
             }
-            Operator::And | Operator::Or => {
-                unreachable!("Already dealt with above")
-            }
+
+            // Logical operators were handled above.
+            Operator::And | Operator::Or => unreachable!("Already dealt with above"),
         };
 
-        // If both inputs are scalars, return a scalar datum.
-        if lhs.get().1 && rhs.get().1 {
-            return Ok(Datum::Scalar(vector.scalar_at(0)));
-        }
+        let both_are_scalar = lhs.get().1 && rhs.get().1;
 
-        Ok(Datum::Vector(vector))
+        Ok(if both_are_scalar {
+            Datum::Scalar(vector.scalar_at(0))
+        } else {
+            Datum::Vector(vector)
+        })
     }
 
     fn stat_falsification(
@@ -567,18 +594,14 @@ pub fn checked_add(lhs: Expression, rhs: Expression) -> Expression {
 #[cfg(test)]
 mod tests {
     use vortex_dtype::DType;
+    use vortex_dtype::FieldNames;
     use vortex_dtype::Nullability;
+    use vortex_dtype::PType;
+    use vortex_dtype::StructFields;
+    use vortex_scalar::Scalar;
+    use vortex_vector::ScalarOps;
 
-    use super::and;
-    use super::and_collect;
-    use super::and_collect_right;
-    use super::eq;
-    use super::gt;
-    use super::gt_eq;
-    use super::lt;
-    use super::lt_eq;
-    use super::not_eq;
-    use super::or;
+    use super::*;
     use crate::expr::Expression;
     use crate::expr::exprs::get_item::col;
     use crate::expr::exprs::literal::lit;
@@ -664,5 +687,88 @@ mod tests {
     fn test_display_print() {
         let expr = gt(lit(1), lit(2));
         assert_eq!(format!("{expr}"), "(1i32 > 2i32)");
+    }
+
+    /// Regression test for GitHub issue #5947: struct comparison in filter expressions should work
+    /// using `make_comparator` instead of Arrow's `cmp` functions which don't support nested types.
+    #[test]
+    fn test_struct_comparison() {
+        // Create a struct dtype for testing.
+        let struct_dtype = DType::Struct(
+            StructFields::new(
+                FieldNames::from(["a", "b"]),
+                vec![
+                    DType::Primitive(PType::I32, Nullability::NonNullable),
+                    DType::Primitive(PType::I32, Nullability::NonNullable),
+                ],
+            ),
+            Nullability::NonNullable,
+        );
+
+        // Test 1: Equal structs should return true.
+        let lhs_scalar = Scalar::struct_(
+            struct_dtype.clone(),
+            vec![Scalar::from(1i32), Scalar::from(3i32)],
+        );
+        let rhs_scalar = Scalar::struct_(
+            struct_dtype.clone(),
+            vec![Scalar::from(1i32), Scalar::from(3i32)],
+        );
+
+        let lhs_datum = Datum::Scalar(lhs_scalar.to_vector_scalar());
+        let rhs_datum = Datum::Scalar(rhs_scalar.to_vector_scalar());
+
+        let result = Binary.bind(Operator::Eq).execute(ExecutionArgs {
+            datums: vec![lhs_datum, rhs_datum],
+            dtypes: vec![struct_dtype.clone(), struct_dtype.clone()],
+            row_count: 1,
+            return_dtype: DType::Bool(Nullability::NonNullable),
+        });
+
+        assert!(result.is_ok(), "Expected success, but got: {:?}", result);
+        let datum = result.unwrap();
+        if let Datum::Scalar(vortex_vector::Scalar::Bool(bool_scalar)) = datum {
+            assert!(bool_scalar.is_valid());
+            assert_eq!(
+                bool_scalar.value(),
+                Some(true),
+                "Equal structs should be equal"
+            );
+        } else {
+            panic!("Expected Scalar::Bool, got {:?}", datum);
+        }
+
+        // Test 2: Different structs should return false.
+        let lhs_scalar = Scalar::struct_(
+            struct_dtype.clone(),
+            vec![Scalar::from(1i32), Scalar::from(3i32)],
+        );
+        let rhs_scalar = Scalar::struct_(
+            struct_dtype.clone(),
+            vec![Scalar::from(1i32), Scalar::from(4i32)], // Different value.
+        );
+
+        let lhs_datum = Datum::Scalar(lhs_scalar.to_vector_scalar());
+        let rhs_datum = Datum::Scalar(rhs_scalar.to_vector_scalar());
+
+        let result = Binary.bind(Operator::Eq).execute(ExecutionArgs {
+            datums: vec![lhs_datum, rhs_datum],
+            dtypes: vec![struct_dtype.clone(), struct_dtype],
+            row_count: 1,
+            return_dtype: DType::Bool(Nullability::NonNullable),
+        });
+
+        assert!(result.is_ok(), "Expected success, but got: {:?}", result);
+        let datum = result.unwrap();
+        if let Datum::Scalar(vortex_vector::Scalar::Bool(bool_scalar)) = datum {
+            assert!(bool_scalar.is_valid());
+            assert_eq!(
+                bool_scalar.value(),
+                Some(false),
+                "Different structs should not be equal"
+            );
+        } else {
+            panic!("Expected Scalar::Bool, got {:?}", datum);
+        }
     }
 }

--- a/vortex-vector/src/datum.rs
+++ b/vortex-vector/src/datum.rs
@@ -104,6 +104,20 @@ impl Datum {
             Datum::Vector(vector) => Some(vector),
         }
     }
+
+    /// Returns `true` if the datum contains a nested type (List, FixedSizeList, or Struct).
+    pub fn is_nested(&self) -> bool {
+        match self {
+            Datum::Scalar(s) => matches!(
+                s,
+                Scalar::List(_) | Scalar::FixedSizeList(_) | Scalar::Struct(_)
+            ),
+            Datum::Vector(v) => matches!(
+                v,
+                Vector::List(_) | Vector::FixedSizeList(_) | Vector::Struct(_)
+            ),
+        }
+    }
 }
 
 impl Datum {


### PR DESCRIPTION
Fixes: https://github.com/vortex-data/vortex/issues/5947

Adds support for comparing struct arrays via Arrow. The existing code uses the vectorized comparisons which are not implemented for the nested types. This adds that in as well as documents the Arrow behavior more explicitly.

Also adds a regression test similar to the fuzzer crash.