### PR TITLE
chore: return CUDA events from kernel launch

### DIFF
--- a/vortex-cuda/src/executor.rs
+++ b/vortex-cuda/src/executor.rs
@@ -28,6 +28,15 @@ use vortex_session::VortexSession;
 use crate::CudaSession;
 use crate::session::CudaSessionExt;
 
+/// CUDA kernel events recorded before and after kernel launch.
+#[derive(Debug)]
+pub struct CudaKernelEvents {
+    /// Event recorded before kernel launch.
+    pub before_launch: CudaEvent,
+    /// Event recorded after kernel launch.
+    pub after_launch: CudaEvent,
+}
+
 /// Convenience macro to launch a CUDA kernel.
 ///
 /// The kernel gets launched on the stream of the execution context.
@@ -89,7 +98,7 @@ pub fn launch_cuda_kernel_impl(
     launch_builder: &mut LaunchArgs,
     event_flags: CUevent_flags,
     array_len: usize,
-) -> VortexResult<(CudaEvent, CudaEvent)> {
+) -> VortexResult<CudaKernelEvents> {
     let num_chunks = u32::try_from(array_len.div_ceil(2048))?;
 
     let config = cudarc::driver::LaunchConfig {
@@ -104,7 +113,14 @@ pub fn launch_cuda_kernel_impl(
         launch_builder
             .launch(config)
             .map_err(|e| vortex_err!("Failed to launch kernel: {}", e))
-            .and_then(|events| events.ok_or_else(|| vortex_err!("CUDA events not recorded")))
+            .and_then(|events| {
+                events
+                    .ok_or_else(|| vortex_err!("CUDA events not recorded"))
+                    .map(|(before_launch, after_launch)| CudaKernelEvents {
+                        before_launch,
+                        after_launch,
+                    })
+            })
     }
 }
 

--- a/vortex-cuda/src/executor.rs
+++ b/vortex-cuda/src/executor.rs
@@ -89,7 +89,7 @@ pub fn launch_cuda_kernel_impl(
     launch_builder: &mut LaunchArgs,
     event_flags: CUevent_flags,
     array_len: usize,
-) -> VortexResult<Option<(CudaEvent, CudaEvent)>> {
+) -> VortexResult<(CudaEvent, CudaEvent)> {
     let num_chunks = u32::try_from(array_len.div_ceil(2048))?;
 
     let config = cudarc::driver::LaunchConfig {
@@ -104,6 +104,7 @@ pub fn launch_cuda_kernel_impl(
         launch_builder
             .launch(config)
             .map_err(|e| vortex_err!("Failed to launch kernel: {}", e))
+            .and_then(|events| events.ok_or_else(|| vortex_err!("CUDA events not recorded")))
     }
 }
 

--- a/vortex-cuda/src/executor.rs
+++ b/vortex-cuda/src/executor.rs
@@ -46,7 +46,7 @@ use crate::session::CudaSessionExt;
 ///
 /// # Returns
 ///
-/// Returns a pair of CUDA events submitted before and after the kernel.
+/// A pair of CUDA events submitted before and after the kernel.
 /// Depending on `CUevent_flags` these events can contain timestamps. Use
 /// `CU_EVENT_DISABLE_TIMING` for minimal overhead and `CU_EVENT_DEFAULT` to
 /// enable timestamps.
@@ -81,7 +81,7 @@ macro_rules! launch_cuda_kernel {
 ///
 /// # Returns
 ///
-/// Returns a pair of CUDA events submitted before and after the kernel.
+/// A pair of CUDA events submitted before and after the kernel.
 /// Depending on `CUevent_flags` these events can contain timestamps. Use
 /// `CU_EVENT_DISABLE_TIMING` for minimal overhead and `CU_EVENT_DEFAULT` to
 /// enable timestamps.

--- a/vortex-cuda/src/executor.rs
+++ b/vortex-cuda/src/executor.rs
@@ -5,12 +5,14 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use cudarc::driver::CudaEvent;
 use cudarc::driver::CudaFunction;
 use cudarc::driver::CudaSlice;
 use cudarc::driver::CudaStream;
 use cudarc::driver::DeviceRepr;
 use cudarc::driver::LaunchArgs;
 use cudarc::driver::ValidAsZeroBits;
+use cudarc::driver::sys::CUevent_flags;
 use vortex_array::Array;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
@@ -41,6 +43,13 @@ use crate::session::CudaSessionExt;
 /// The last block and thread are allowed to have less elements.
 ///
 /// Note: A macro is necessary to unroll the launch builder arguments.
+///
+/// # Returns
+///
+/// Returns a pair of CUDA events submitted before and after the kernel.
+/// Depending on `CUevent_flags` these events can contain timestamps. Use
+/// `CU_EVENT_DISABLE_TIMING` for minimal overhead and `CU_EVENT_DEFAULT` to
+/// enable timestamps.
 #[macro_export]
 macro_rules! launch_cuda_kernel {
     (
@@ -48,6 +57,7 @@ macro_rules! launch_cuda_kernel {
         module: $module:expr,
         ptypes: $ptypes:expr,
         launch_args: [$($arg:expr),* $(,)?],
+        event_recording: $event_recording:expr,
         array_len: $len:expr
     ) => {{
         let cuda_function = $ctx.load_function($module, $ptypes)?;
@@ -58,7 +68,7 @@ macro_rules! launch_cuda_kernel {
             launch_builder.arg(&$arg);
         )*
 
-        $crate::executor::launch_cuda_kernel_impl(&mut launch_builder, $len)?
+        $crate::executor::launch_cuda_kernel_impl(&mut launch_builder, $event_recording, $len)?
     }};
 }
 
@@ -68,10 +78,18 @@ macro_rules! launch_cuda_kernel {
 ///
 /// * `launch_builder` - Configured launch builder
 /// * `array_len` - Length of the array to process
+///
+/// # Returns
+///
+/// Returns a pair of CUDA events submitted before and after the kernel.
+/// Depending on `CUevent_flags` these events can contain timestamps. Use
+/// `CU_EVENT_DISABLE_TIMING` for minimal overhead and `CU_EVENT_DEFAULT` to
+/// enable timestamps.
 pub fn launch_cuda_kernel_impl(
     launch_builder: &mut LaunchArgs,
+    event_flags: CUevent_flags,
     array_len: usize,
-) -> VortexResult<()> {
+) -> VortexResult<Option<(CudaEvent, CudaEvent)>> {
     let num_chunks = u32::try_from(array_len.div_ceil(2048))?;
 
     let config = cudarc::driver::LaunchConfig {
@@ -80,13 +98,13 @@ pub fn launch_cuda_kernel_impl(
         shared_mem_bytes: 0,
     };
 
+    launch_builder.record_kernel_launch(event_flags);
+
     unsafe {
         launch_builder
             .launch(config)
-            .map_err(|e| vortex_err!("Failed to launch kernel: {}", e))?
-    };
-
-    Ok(())
+            .map_err(|e| vortex_err!("Failed to launch kernel: {}", e))
+    }
 }
 
 /// CUDA execution context.

--- a/vortex-cuda/src/for_.rs
+++ b/vortex-cuda/src/for_.rs
@@ -75,7 +75,7 @@ async fn execute_for_typed<P: DeviceRepr + NativePType + FromPrimitiveOrF16>(
     let device_data = ctx.to_device(unpacked_slice)?;
 
     let array_len = array.len() as u64;
-    launch_cuda_kernel!(
+    let _kernel_events = launch_cuda_kernel!(
         execution_ctx: ctx,
         module: "for",
         ptypes: &[array.ptype()],

--- a/vortex-cuda/src/for_.rs
+++ b/vortex-cuda/src/for_.rs
@@ -4,9 +4,12 @@
 use async_trait::async_trait;
 use cudarc::driver::DeviceRepr;
 use cudarc::driver::PushKernelArg;
+use cudarc::driver::sys::CUevent_flags::CU_EVENT_DISABLE_TIMING;
 use vortex_array::Array;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::validity::Validity::NonNullable;
 use vortex_dtype::FromPrimitiveOrF16;
 use vortex_dtype::NativePType;
 use vortex_dtype::match_each_native_simd_ptype;
@@ -77,6 +80,10 @@ async fn execute_for_typed<P: DeviceRepr + NativePType + FromPrimitiveOrF16>(
         module: "for",
         ptypes: &[array.ptype()],
         launch_args: [device_data, reference, array_len],
+        // CUDA events are submitted before and after the kernel launch. This
+        // enables waiting for a single kernel to finish without doing a global
+        // synchronize on the stream. Timing is disabled to keep the overhead low.
+        event_recording: CU_EVENT_DISABLE_TIMING,
         array_len: array.len()
     );
 
@@ -87,11 +94,7 @@ async fn execute_for_typed<P: DeviceRepr + NativePType + FromPrimitiveOrF16>(
         vortex_buffer::Alignment::of::<P>(),
     )?;
 
-    let primitive = vortex_array::arrays::PrimitiveArray::new(
-        result,
-        vortex_array::validity::Validity::NonNullable,
-    )
-    .reinterpret_cast(array.ptype());
+    let primitive = PrimitiveArray::new(result, NonNullable).reinterpret_cast(array.ptype());
 
     Ok(Canonical::Primitive(primitive))
 }
@@ -100,7 +103,6 @@ async fn execute_for_typed<P: DeviceRepr + NativePType + FromPrimitiveOrF16>(
 mod tests {
     use vortex_array::IntoArray;
     use vortex_array::arrays::PrimitiveArray;
-    use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
     use vortex_error::VortexExpect;
     use vortex_fastlanes::FoRArray;
@@ -122,7 +124,7 @@ mod tests {
         let for_array = FoRArray::try_new(
             PrimitiveArray::new(
                 Buffer::from((0u32..5000).collect::<Vec<u32>>()),
-                Validity::NonNullable,
+                NonNullable,
             )
             .into_array(),
             10u32.into(),

--- a/vortex-cuda/src/lib.rs
+++ b/vortex-cuda/src/lib.rs
@@ -10,6 +10,7 @@ mod session;
 
 use std::process::Command;
 
+pub use executor::CudaKernelEvents;
 use for_::ForExecutor;
 use session::CudaSession;
 


### PR DESCRIPTION
This PR changes the launch kernel API in vortex-cuda to propagate the pair of CUDA events returned from `cudarc::LaunchArgs:launch`.

When launching a kernel, CUDAs events are automatically submitted before and after. 
The events can be used to wait for a particular kernel to finish or to benchmark a CUDA kernel.