### PR TITLE
 chore: fallible canonical

### DIFF
--- a/benchmarks/compress-bench/src/lib.rs
+++ b/benchmarks/compress-bench/src/lib.rs
@@ -23,7 +23,7 @@ pub fn chunked_to_vec_record_batch(
         .map(|array| {
             // TODO(connor)[ListView]: The rust Parquet implementation does not support writing
             // `ListView` to Parquet files yet.
-            let converted_array = recursive_list_from_list_view(array.clone());
+            let converted_array = recursive_list_from_list_view(array.clone())?;
             Ok(RecordBatch::try_from(converted_array.as_ref())?)
         })
         .collect::<anyhow::Result<Vec<_>>>()?;

--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -460,8 +460,8 @@ impl BaseArrayVTable<ALPVTable> for ALPVTable {
 }
 
 impl CanonicalVTable<ALPVTable> for ALPVTable {
-    fn canonicalize(array: &ALPArray) -> Canonical {
-        Canonical::Primitive(decompress_into_array(array.clone()))
+    fn canonicalize(array: &ALPArray) -> VortexResult<Canonical> {
+        Ok(Canonical::Primitive(decompress_into_array(array.clone())))
     }
 }
 

--- a/encodings/alp/src/alp/compute/cast.rs
+++ b/encodings/alp/src/alp/compute/cast.rs
@@ -60,56 +60,58 @@ mod tests {
     use vortex_dtype::DType;
     use vortex_dtype::Nullability;
     use vortex_dtype::PType;
+    use vortex_error::VortexExpect;
+    use vortex_error::VortexResult;
 
     use crate::ALPVTable;
 
     #[test]
-    fn test_cast_alp_f32_to_f64() {
+    fn test_cast_alp_f32_to_f64() -> VortexResult<()> {
         let values = buffer![1.5f32, 2.5, 3.5, 4.5].into_array();
         let alp = ALPVTable
             .as_vtable()
-            .encode(&values.to_canonical(), None)
-            .unwrap()
-            .unwrap();
+            .encode(&values.to_canonical()?, None)?
+            .vortex_expect("must encode");
 
         let casted = cast(
             alp.as_ref(),
             &DType::Primitive(PType::F64, Nullability::NonNullable),
-        )
-        .unwrap();
+        )?;
         assert_eq!(
             casted.dtype(),
             &DType::Primitive(PType::F64, Nullability::NonNullable)
         );
 
-        let decoded = casted.to_canonical().into_primitive();
+        let decoded = casted.to_canonical()?.into_primitive();
         let values = decoded.as_slice::<f64>();
         assert_eq!(values.len(), 4);
         assert!((values[0] - 1.5).abs() < f64::EPSILON);
         assert!((values[1] - 2.5).abs() < f64::EPSILON);
+
+        Ok(())
     }
 
     #[test]
-    fn test_cast_alp_to_int() {
+    fn test_cast_alp_to_int() -> VortexResult<()> {
         let values = buffer![1.0f32, 2.0, 3.0, 4.0].into_array();
         let alp = ALPVTable
             .as_vtable()
-            .encode(&values.to_canonical(), None)
-            .unwrap()
-            .unwrap();
+            .encode(&values.to_canonical()?, None)?
+            .vortex_expect("must encode");
 
         let casted = cast(
             alp.as_ref(),
             &DType::Primitive(PType::I32, Nullability::NonNullable),
-        )
-        .unwrap();
+        )?;
         assert_eq!(
             casted.dtype(),
             &DType::Primitive(PType::I32, Nullability::NonNullable)
         );
 
-        let decoded = casted.to_canonical().into_primitive();
+        let decoded = casted.to_canonical()?.into_primitive();
         assert_arrays_eq!(decoded, PrimitiveArray::from_iter([1i32, 2, 3, 4]));
+
+        Ok(())
     }
 
     #[rstest]
@@ -118,12 +120,13 @@ mod tests {
     #[case(PrimitiveArray::from_option_iter([Some(1.1f32), None, Some(2.2), Some(3.3), None]).into_array())]
     #[case(buffer![42.42f64].into_array())]
     #[case(buffer![0.0f32, -1.5, 2.5, -3.5, 4.5].into_array())]
-    fn test_cast_alp_conformance(#[case] array: vortex_array::ArrayRef) {
+    fn test_cast_alp_conformance(#[case] array: vortex_array::ArrayRef) -> VortexResult<()> {
         let alp = ALPVTable
             .as_vtable()
-            .encode(&array.to_canonical(), None)
-            .unwrap()
-            .unwrap();
+            .encode(&array.to_canonical()?, None)?
+            .vortex_expect("cannot fail");
         test_cast_conformance(alp.as_ref());
+
+        Ok(())
     }
 }

--- a/encodings/alp/src/alp/compute/filter.rs
+++ b/encodings/alp/src/alp/compute/filter.rs
@@ -59,7 +59,7 @@ mod test {
     fn test_filter_alp_conformance(#[case] array: ArrayRef) {
         let alp = ALPVTable
             .as_vtable()
-            .encode(&array.to_canonical(), None)
+            .encode(&array.to_canonical().unwrap(), None)
             .unwrap()
             .unwrap();
         test_filter_conformance(alp.as_ref());

--- a/encodings/alp/src/alp/compute/mask.rs
+++ b/encodings/alp/src/alp/compute/mask.rs
@@ -57,7 +57,7 @@ mod test {
     fn test_mask_alp_conformance(#[case] array: vortex_array::ArrayRef) {
         let alp = ALPVTable
             .as_vtable()
-            .encode(&array.to_canonical(), None)
+            .encode(&array.to_canonical().unwrap(), None)
             .unwrap()
             .unwrap();
         test_mask_conformance(alp.as_ref());

--- a/encodings/alp/src/alp/compute/take.rs
+++ b/encodings/alp/src/alp/compute/take.rs
@@ -54,7 +54,7 @@ mod test {
     fn test_take_alp_conformance(#[case] array: vortex_array::ArrayRef) {
         let alp = ALPVTable
             .as_vtable()
-            .encode(&array.to_canonical(), None)
+            .encode(&array.to_canonical().unwrap(), None)
             .unwrap()
             .unwrap();
         test_take_conformance(alp.as_ref());

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -430,7 +430,7 @@ impl BaseArrayVTable<ALPRDVTable> for ALPRDVTable {
 }
 
 impl CanonicalVTable<ALPRDVTable> for ALPRDVTable {
-    fn canonicalize(array: &ALPRDArray) -> Canonical {
+    fn canonicalize(array: &ALPRDArray) -> VortexResult<Canonical> {
         let left_parts = array.left_parts().to_primitive();
         let right_parts = array.right_parts().to_primitive();
 
@@ -461,7 +461,7 @@ impl CanonicalVTable<ALPRDVTable> for ALPRDVTable {
             )
         };
 
-        Canonical::Primitive(decoded_array)
+        Ok(Canonical::Primitive(decoded_array))
     }
 }
 

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -215,10 +215,13 @@ impl BaseArrayVTable<ByteBoolVTable> for ByteBoolVTable {
 }
 
 impl CanonicalVTable<ByteBoolVTable> for ByteBoolVTable {
-    fn canonicalize(array: &ByteBoolArray) -> Canonical {
+    fn canonicalize(array: &ByteBoolArray) -> VortexResult<Canonical> {
         let boolean_buffer = BitBuffer::from(array.as_slice());
         let validity = array.validity().clone();
-        Canonical::Bool(BoolArray::from_bit_buffer(boolean_buffer, validity))
+        Ok(Canonical::Bool(BoolArray::from_bit_buffer(
+            boolean_buffer,
+            validity,
+        )))
     }
 }
 

--- a/encodings/datetime-parts/src/canonical.rs
+++ b/encodings/datetime-parts/src/canonical.rs
@@ -17,14 +17,15 @@ use vortex_dtype::datetime::TemporalMetadata;
 use vortex_dtype::datetime::TimeUnit;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexExpect as _;
+use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 
 use crate::DateTimePartsArray;
 use crate::DateTimePartsVTable;
 
 impl CanonicalVTable<DateTimePartsVTable> for DateTimePartsVTable {
-    fn canonicalize(array: &DateTimePartsArray) -> Canonical {
-        Canonical::Extension(decode_to_temporal(array).into())
+    fn canonicalize(array: &DateTimePartsArray) -> VortexResult<Canonical> {
+        Ok(Canonical::Extension(decode_to_temporal(array).into()))
     }
 }
 

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -235,13 +235,13 @@ impl BaseArrayVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
 }
 
 impl CanonicalVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
-    fn canonicalize(array: &DecimalBytePartsArray) -> Canonical {
+    fn canonicalize(array: &DecimalBytePartsArray) -> VortexResult<Canonical> {
         // TODO(joe): support parts len != 1
         let prim = array.msp.to_primitive();
         // Depending on the decimal type and the min/max of the primitive array we can choose
         // the correct buffer size
 
-        match_each_signed_integer_ptype!(prim.ptype(), |P| {
+        Ok(match_each_signed_integer_ptype!(prim.ptype(), |P| {
             // SAFETY: The primitive array's buffer is already validated with correct type.
             // The decimal dtype matches the array's dtype, and validity is preserved.
             Canonical::Decimal(unsafe {
@@ -251,7 +251,7 @@ impl CanonicalVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
                     prim.validity().clone(),
                 )
             })
-        })
+        }))
     }
 }
 

--- a/encodings/fastlanes/benches/bitpacking_decompress_selection.rs
+++ b/encodings/fastlanes/benches/bitpacking_decompress_selection.rs
@@ -67,5 +67,5 @@ fn decompress_bitpacking_late_filter<T: IntegerPType>(bencher: Bencher, fraction
     bencher
         // Be sure to reconstruct the mask to avoid cached set_indices
         .with_inputs(|| (&array, Mask::from_buffer(mask.clone())))
-        .bench_refs(|(array, mask)| filter(array.to_canonical().as_ref(), mask).unwrap());
+        .bench_refs(|(array, mask)| filter(array.to_canonical().unwrap().as_ref(), mask).unwrap());
 }

--- a/encodings/fastlanes/benches/canonicalize_bench.rs
+++ b/encodings/fastlanes/benches/canonicalize_bench.rs
@@ -70,7 +70,9 @@ fn canonical_into_non_nullable(
             chunked.dtype().nullability(),
             chunk_len * chunk_count,
         );
-        chunked.append_to_builder(&mut primitive_builder);
+        chunked
+            .append_to_builder(&mut primitive_builder)
+            .vortex_expect("append failed");
         primitive_builder.finish()
     });
 }
@@ -125,7 +127,9 @@ fn canonical_into_nullable(
             chunked.dtype().nullability(),
             chunk_len * chunk_count,
         );
-        chunked.append_to_builder(&mut primitive_builder);
+        chunked
+            .append_to_builder(&mut primitive_builder)
+            .vortex_expect("append failed");
         primitive_builder.finish()
     });
 }

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
@@ -463,7 +463,7 @@ mod test {
     }
 
     #[test]
-    fn canonicalize_chunked_of_bitpacked() {
+    fn canonicalize_chunked_of_bitpacked() -> VortexResult<()> {
         let mut rng = StdRng::seed_from_u64(0);
 
         let chunks = (0..10)
@@ -474,7 +474,7 @@ mod test {
         let into_ca = chunked.clone().to_primitive();
         let mut primitive_builder =
             PrimitiveBuilder::<i32>::with_capacity(chunked.dtype().nullability(), 10 * 100);
-        chunked.clone().append_to_builder(&mut primitive_builder);
+        chunked.clone().append_to_builder(&mut primitive_builder)?;
         let ca_into = primitive_builder.finish();
 
         assert_arrays_eq!(into_ca, ca_into);
@@ -485,6 +485,8 @@ mod test {
         let ca_into = primitive_builder.finish();
 
         assert_arrays_eq!(into_ca, ca_into);
+
+        Ok(())
     }
 
     #[test]

--- a/encodings/fastlanes/src/bitpacking/compute/between.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/between.rs
@@ -27,7 +27,7 @@ impl BetweenKernel for BitPackedVTable {
         };
 
         between(
-            &array.clone().to_canonical().into_array(),
+            &array.clone().to_canonical()?.into_array(),
             lower,
             upper,
             options,

--- a/encodings/fastlanes/src/bitpacking/vtable/canonical.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/canonical.rs
@@ -6,6 +6,7 @@ use vortex_array::builders::ArrayBuilder;
 use vortex_array::vtable::CanonicalVTable;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
 
 use crate::BitPackedArray;
 use crate::BitPackedVTable;
@@ -13,11 +14,14 @@ use crate::bitpack_decompress::unpack_array;
 use crate::bitpack_decompress::unpack_into_primitive_builder;
 
 impl CanonicalVTable<BitPackedVTable> for BitPackedVTable {
-    fn canonicalize(array: &BitPackedArray) -> Canonical {
-        Canonical::Primitive(unpack_array(array))
+    fn canonicalize(array: &BitPackedArray) -> VortexResult<Canonical> {
+        Ok(Canonical::Primitive(unpack_array(array)))
     }
 
-    fn append_to_builder(array: &BitPackedArray, builder: &mut dyn ArrayBuilder) {
+    fn append_to_builder(
+        array: &BitPackedArray,
+        builder: &mut dyn ArrayBuilder,
+    ) -> VortexResult<()> {
         match_each_integer_ptype!(array.ptype(), |T| {
             unpack_into_primitive_builder::<T>(
                 array,
@@ -26,6 +30,7 @@ impl CanonicalVTable<BitPackedVTable> for BitPackedVTable {
                     .downcast_mut()
                     .vortex_expect("bit packed array must canonicalize into a primitive array"),
             )
-        })
+        });
+        Ok(())
     }
 }

--- a/encodings/fastlanes/src/bitpacking/vtable/kernels/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/kernels/filter.rs
@@ -127,7 +127,7 @@ impl ExecuteParentKernel<BitPackedVTable> for BitPackingFilterKernel {
             primitive_vector
                 .freeze()
                 .into_array(parent.dtype())
-                .to_canonical(),
+                .to_canonical()?,
         ))
     }
 }

--- a/encodings/fastlanes/src/delta/vtable/canonical.rs
+++ b/encodings/fastlanes/src/delta/vtable/canonical.rs
@@ -3,13 +3,14 @@
 
 use vortex_array::Canonical;
 use vortex_array::vtable::CanonicalVTable;
+use vortex_error::VortexResult;
 
 use super::DeltaVTable;
 use crate::DeltaArray;
 use crate::delta::array::delta_decompress::delta_decompress;
 
 impl CanonicalVTable<DeltaVTable> for DeltaVTable {
-    fn canonicalize(array: &DeltaArray) -> Canonical {
-        Canonical::Primitive(delta_decompress(array))
+    fn canonicalize(array: &DeltaArray) -> VortexResult<Canonical> {
+        Ok(Canonical::Primitive(delta_decompress(array)))
     }
 }

--- a/encodings/fastlanes/src/for/vtable/canonical.rs
+++ b/encodings/fastlanes/src/for/vtable/canonical.rs
@@ -3,13 +3,14 @@
 
 use vortex_array::Canonical;
 use vortex_array::vtable::CanonicalVTable;
+use vortex_error::VortexResult;
 
 use super::FoRVTable;
 use crate::FoRArray;
 use crate::r#for::array::for_decompress::decompress;
 
 impl CanonicalVTable<FoRVTable> for FoRVTable {
-    fn canonicalize(array: &FoRArray) -> Canonical {
-        Canonical::Primitive(decompress(array))
+    fn canonicalize(array: &FoRArray) -> VortexResult<Canonical> {
+        Ok(Canonical::Primitive(decompress(array)))
     }
 }

--- a/encodings/fastlanes/src/rle/array/mod.rs
+++ b/encodings/fastlanes/src/rle/array/mod.rs
@@ -351,7 +351,11 @@ mod tests {
         .unwrap();
 
         // TODO(joe): replace with compute null count
-        let invalid_slice = rle_array.slice(2..5).to_canonical().into_primitive();
+        let invalid_slice = rle_array
+            .slice(2..5)
+            .to_canonical()
+            .unwrap()
+            .into_primitive();
         assert!(invalid_slice.all_invalid());
 
         let mixed_slice = rle_array.slice(1..4);

--- a/encodings/fastlanes/src/rle/vtable/canonical.rs
+++ b/encodings/fastlanes/src/rle/vtable/canonical.rs
@@ -3,13 +3,14 @@
 
 use vortex_array::Canonical;
 use vortex_array::vtable::CanonicalVTable;
+use vortex_error::VortexResult;
 
 use super::RLEVTable;
 use crate::RLEArray;
 use crate::rle::array::rle_decompress::rle_decompress;
 
 impl CanonicalVTable<RLEVTable> for RLEVTable {
-    fn canonicalize(array: &RLEArray) -> Canonical {
-        Canonical::Primitive(rle_decompress(array))
+    fn canonicalize(array: &RLEArray) -> VortexResult<Canonical> {
+        Ok(Canonical::Primitive(rle_decompress(array)))
     }
 }

--- a/encodings/fsst/benches/chunked_dict_fsst_builder.rs
+++ b/encodings/fsst/benches/chunked_dict_fsst_builder.rs
@@ -9,6 +9,7 @@ use vortex_array::arrays::ChunkedArray;
 use vortex_array::builders::builder_with_capacity;
 use vortex_array::compute::warm_up_vtables;
 use vortex_dtype::NativePType;
+use vortex_error::VortexExpect;
 use vortex_fsst::test_utils::gen_dict_fsst_test_data;
 
 fn main() {
@@ -45,7 +46,9 @@ fn chunked_dict_fsst_canonical_into(
 
     bencher.with_inputs(|| &chunk).bench_refs(|chunk| {
         let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
-        chunk.append_to_builder(builder.as_mut());
+        chunk
+            .append_to_builder(builder.as_mut())
+            .vortex_expect("append failed");
         builder.finish()
     })
 }

--- a/encodings/fsst/benches/fsst_compress.rs
+++ b/encodings/fsst/benches/fsst_compress.rs
@@ -99,7 +99,7 @@ fn canonicalize_compare(
         .with_inputs(|| (&fsst_array, &constant))
         .bench_refs(|(fsst_array, constant)| {
             compare(
-                fsst_array.to_canonical().as_ref(),
+                fsst_array.to_canonical().unwrap().as_ref(),
                 constant.as_ref(),
                 Operator::Eq,
             )
@@ -130,7 +130,7 @@ fn chunked_canonicalize_into(
     bencher.with_inputs(|| &array).bench_refs(|array| {
         let mut builder =
             VarBinViewBuilder::with_capacity(DType::Binary(Nullability::NonNullable), array.len());
-        array.append_to_builder(&mut builder);
+        array.append_to_builder(&mut builder).unwrap();
         builder.finish()
     });
 }

--- a/encodings/fsst/src/canonical.rs
+++ b/encodings/fsst/src/canonical.rs
@@ -16,29 +16,31 @@ use vortex_buffer::BufferMut;
 use vortex_buffer::ByteBuffer;
 use vortex_buffer::ByteBufferMut;
 use vortex_dtype::match_each_integer_ptype;
+use vortex_error::VortexResult;
 use vortex_vector::binaryview::BinaryView;
 
 use crate::FSSTArray;
 use crate::FSSTVTable;
 
 impl CanonicalVTable<FSSTVTable> for FSSTVTable {
-    fn canonicalize(array: &FSSTArray) -> Canonical {
+    fn canonicalize(array: &FSSTArray) -> VortexResult<Canonical> {
         let (buffer, views) = fsst_decode_views(array, 0);
         // SAFETY: FSST already validates the bytes for binary/UTF-8. We build views directly on
         //  top of them, so the view pointers will all be valid.
-        unsafe {
+        Ok(unsafe {
             Canonical::VarBinView(VarBinViewArray::new_unchecked(
                 views,
                 Arc::new([buffer]),
                 array.dtype().clone(),
                 array.codes().validity().clone(),
             ))
-        }
+        })
     }
 
-    fn append_to_builder(array: &FSSTArray, builder: &mut dyn ArrayBuilder) {
+    fn append_to_builder(array: &FSSTArray, builder: &mut dyn ArrayBuilder) -> VortexResult<()> {
         let Some(builder) = builder.as_any_mut().downcast_mut::<VarBinViewBuilder>() else {
-            return builder.extend_from_array(&array.to_canonical().into_array());
+            builder.extend_from_array(&array.to_canonical()?.into_array());
+            return Ok(());
         };
 
         // Decompress the whole block of data into a new buffer, and create some views
@@ -47,6 +49,7 @@ impl CanonicalVTable<FSSTVTable> for FSSTVTable {
         let (buffer, views) = fsst_decode_views(array, builder.completed_block_count());
 
         builder.push_buffer_and_adjusted_views(&[buffer], &views, array.validity_mask());
+        Ok(())
     }
 }
 
@@ -119,6 +122,7 @@ mod tests {
     use vortex_array::builders::VarBinViewBuilder;
     use vortex_dtype::DType;
     use vortex_dtype::Nullability;
+    use vortex_error::VortexResult;
 
     use crate::fsst_compress;
     use crate::fsst_train_compressor;
@@ -173,12 +177,12 @@ mod tests {
     }
 
     #[test]
-    fn test_to_canonical() {
+    fn test_to_canonical() -> VortexResult<()> {
         let (chunked_arr, data) = make_data_chunked();
 
         let mut builder =
             VarBinViewBuilder::with_capacity(chunked_arr.dtype().clone(), chunked_arr.len());
-        chunked_arr.append_to_builder(&mut builder);
+        chunked_arr.append_to_builder(&mut builder)?;
 
         {
             let arr = builder.finish_into_canonical().into_varbinview();
@@ -193,5 +197,6 @@ mod tests {
                 arr2.with_iterator(|iter| iter.map(|b| b.map(|v| v.to_vec())).collect::<Vec<_>>());
             assert_eq!(data, res2)
         };
+        Ok(())
     }
 }

--- a/encodings/fsst/src/kernel.rs
+++ b/encodings/fsst/src/kernel.rs
@@ -116,7 +116,7 @@ impl ExecuteParentKernel<FSSTVTable> for FSSTFilterKernel {
             _ => unreachable!("Not a supported FSST DType"),
         };
 
-        Ok(Some(canonical))
+        canonical.map(Some)
     }
 }
 

--- a/encodings/pco/benches/pco.rs
+++ b/encodings/pco/benches/pco.rs
@@ -56,5 +56,7 @@ pub fn pco_canonical(bencher: Bencher, (size, selectivity): (usize, f64)) {
     bencher
         // Be sure to reconstruct the mask to avoid cached set_indices
         .with_inputs(|| (&pco_array, Mask::from_buffer(mask.clone())))
-        .bench_refs(|(pco_array, mask)| filter(pco_array.to_canonical().as_ref(), mask).unwrap());
+        .bench_refs(|(pco_array, mask)| {
+            filter(pco_array.to_canonical().unwrap().as_ref(), mask).unwrap()
+        });
 }

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -528,7 +528,7 @@ impl BaseArrayVTable<PcoVTable> for PcoVTable {
 }
 
 impl CanonicalVTable<PcoVTable> for PcoVTable {
-    fn canonicalize(array: &PcoArray) -> Canonical {
+    fn canonicalize(array: &PcoArray) -> VortexResult<Canonical> {
         array.decompress().to_canonical()
     }
 }

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -478,9 +478,9 @@ impl ValidityVTable<RunEndVTable> for RunEndVTable {
 }
 
 impl CanonicalVTable<RunEndVTable> for RunEndVTable {
-    fn canonicalize(array: &RunEndArray) -> Canonical {
+    fn canonicalize(array: &RunEndArray) -> VortexResult<Canonical> {
         let pends = array.ends().to_primitive();
-        match array.dtype() {
+        Ok(match array.dtype() {
             DType::Bool(_) => {
                 let bools = array.values().to_bool();
                 Canonical::Bool(runend_decode_bools(
@@ -500,7 +500,7 @@ impl CanonicalVTable<RunEndVTable> for RunEndVTable {
                 ))
             }
             _ => vortex_panic!("Only Primitive and Bool values are supported"),
-        }
+        })
     }
 }
 

--- a/encodings/runend/src/compute/is_sorted.rs
+++ b/encodings/runend/src/compute/is_sorted.rs
@@ -17,7 +17,7 @@ impl IsSortedKernel for RunEndVTable {
     }
 
     fn is_strict_sorted(&self, array: &RunEndArray) -> VortexResult<Option<bool>> {
-        is_strict_sorted(array.to_canonical().as_ref())
+        is_strict_sorted(array.to_canonical()?.as_ref())
     }
 }
 

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -387,7 +387,7 @@ impl BaseArrayVTable<SequenceVTable> for SequenceVTable {
 }
 
 impl CanonicalVTable<SequenceVTable> for SequenceVTable {
-    fn canonicalize(array: &SequenceArray) -> Canonical {
+    fn canonicalize(array: &SequenceArray) -> VortexResult<Canonical> {
         let prim = match_each_native_ptype!(array.ptype(), |P| {
             let base = array.base().cast::<P>();
             let multiplier = array.multiplier().cast::<P>();
@@ -398,7 +398,7 @@ impl CanonicalVTable<SequenceVTable> for SequenceVTable {
             PrimitiveArray::new(values, array.dtype.nullability().into())
         });
 
-        Canonical::Primitive(prim)
+        Ok(Canonical::Primitive(prim))
     }
 }
 

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -44,6 +44,7 @@ use vortex_dtype::match_each_native_ptype;
 use vortex_dtype::match_smallest_offset_type;
 use vortex_error::VortexError;
 use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 use vortex_scalar::DecimalScalar;
 use vortex_scalar::ListScalar;
@@ -55,12 +56,12 @@ use crate::SparseArray;
 use crate::SparseVTable;
 
 impl CanonicalVTable<SparseVTable> for SparseVTable {
-    fn canonicalize(array: &SparseArray) -> Canonical {
+    fn canonicalize(array: &SparseArray) -> VortexResult<Canonical> {
         if array.patches().num_patches() == 0 {
             return ConstantArray::new(array.fill_scalar().clone(), array.len()).to_canonical();
         }
 
-        match array.dtype() {
+        Ok(match array.dtype() {
             DType::Null => {
                 assert!(array.fill_scalar().is_null());
                 Canonical::Null(NullArray::new(array.len()))
@@ -112,7 +113,7 @@ impl CanonicalVTable<SparseVTable> for SparseVTable {
                 canonicalize_sparse_fixed_size_list(array, *nullability)
             }
             DType::Extension(_ext_dtype) => todo!(),
-        }
+        })
     }
 }
 
@@ -523,6 +524,8 @@ mod test {
     use vortex_dtype::Nullability::Nullable;
     use vortex_dtype::PType;
     use vortex_dtype::StructFields;
+    use vortex_error::VortexExpect;
+    use vortex_error::VortexResult;
     use vortex_mask::Mask;
     use vortex_scalar::DecimalValue;
     use vortex_scalar::Scalar;
@@ -943,7 +946,7 @@ mod test {
     }
 
     #[test]
-    fn test_sparse_list_null_fill() {
+    fn test_sparse_list_null_fill() -> VortexResult<()> {
         // Use ListViewArray consistently
         let elements = buffer![1i32, 2, 1, 2].into_array();
         // Create ListView with offsets and sizes
@@ -965,7 +968,7 @@ mod test {
             .unwrap()
             .into_array();
 
-        let actual = sparse.to_canonical().into_array();
+        let actual = sparse.to_canonical()?.into_array();
         let result_listview = actual.to_listview();
 
         // Check the structure
@@ -994,6 +997,8 @@ mod test {
 
         let list5_offset = result_listview.offset_at(5);
         assert_eq!(elements_slice[list5_offset], 2);
+
+        Ok(())
     }
 
     #[test]
@@ -1017,7 +1022,7 @@ mod test {
             .unwrap()
             .into_array();
 
-        let actual = sparse.to_canonical().into_array();
+        let actual = sparse.to_canonical().vortex_expect("no fail").into_array();
         let result_listview = actual.to_listview();
 
         // Check the structure
@@ -1043,7 +1048,7 @@ mod test {
     }
 
     #[test]
-    fn test_sparse_list_non_null_fill() {
+    fn test_sparse_list_non_null_fill() -> VortexResult<()> {
         // Create ListViewArray with 4 single-element lists
         let elements = buffer![1i32, 2, 1, 2].into_array();
         let offsets = buffer![0u32, 1, 2, 3].into_array();
@@ -1060,7 +1065,7 @@ mod test {
             .unwrap()
             .into_array();
 
-        let actual = sparse.to_canonical().into_array();
+        let actual = sparse.to_canonical()?.into_array();
         let result_listview = actual.to_listview();
 
         // Check the structure
@@ -1109,6 +1114,7 @@ mod test {
         // List 5: [2]
         let list5_offset = result_listview.offset_at(5) as usize;
         assert_eq!(elements_slice[list5_offset], 2);
+        Ok(())
     }
 
     #[test]
@@ -1153,7 +1159,7 @@ mod test {
     }
 
     #[test]
-    fn test_sparse_fixed_size_list_null_fill() {
+    fn test_sparse_fixed_size_list_null_fill() -> VortexResult<()> {
         // Create a FixedSizeListArray with 3 lists of size 3.
         let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
         let fsl = FixedSizeListArray::try_new(elements, 3, Validity::AllValid, 3)
@@ -1170,7 +1176,7 @@ mod test {
             .unwrap()
             .into_array();
 
-        let actual = sparse.to_canonical().into_array();
+        let actual = sparse.to_canonical()?.into_array();
 
         // Expected: [1,2,3], null, [4,5,6], [7,8,9], null.
         let expected_elements =
@@ -1185,10 +1191,11 @@ mod test {
         .into_array();
 
         assert_arrays_eq!(actual, expected);
+        Ok(())
     }
 
     #[test]
-    fn test_sparse_fixed_size_list_non_null_fill() {
+    fn test_sparse_fixed_size_list_non_null_fill() -> VortexResult<()> {
         let elements = buffer![1i32, 2, 3, 4, 5, 6].into_array();
         let fsl = FixedSizeListArray::try_new(elements, 2, Validity::AllValid, 3)
             .unwrap()
@@ -1207,7 +1214,7 @@ mod test {
             .unwrap()
             .into_array();
 
-        let actual = sparse.to_canonical().into_array();
+        let actual = sparse.to_canonical()?.into_array();
 
         // Expected: [1,2], [99,88], [3,4], [99,88], [5,6], [99,88].
         let expected_elements = buffer![1i32, 2, 99, 88, 3, 4, 99, 88, 5, 6, 99, 88].into_array();
@@ -1216,10 +1223,11 @@ mod test {
             .into_array();
 
         assert_arrays_eq!(actual, expected);
+        Ok(())
     }
 
     #[test]
-    fn test_sparse_fixed_size_list_with_validity() {
+    fn test_sparse_fixed_size_list_with_validity() -> VortexResult<()> {
         // Create FSL values with some nulls.
         let elements = buffer![10i32, 20, 30, 40, 50, 60].into_array();
         let fsl = FixedSizeListArray::try_new(
@@ -1244,7 +1252,7 @@ mod test {
             .unwrap()
             .into_array();
 
-        let actual = sparse.to_canonical().into_array();
+        let actual = sparse.to_canonical()?.into_array();
 
         // Expected validity: [true, true, true, false, true, true].
         // Expected elements: [7,8], [10,20], [7,8], [30,40], [50,60], [7,8].
@@ -1261,10 +1269,11 @@ mod test {
         .into_array();
 
         assert_arrays_eq!(actual, expected);
+        Ok(())
     }
 
     #[test]
-    fn test_sparse_fixed_size_list_truly_sparse() {
+    fn test_sparse_fixed_size_list_truly_sparse() -> VortexResult<()> {
         // Test with a truly sparse array where most values are the fill value.
         // This demonstrates the compression benefit of sparse encoding.
 
@@ -1291,7 +1300,7 @@ mod test {
             .unwrap()
             .into_array();
 
-        let actual = sparse.to_canonical().into_array();
+        let actual = sparse.to_canonical()?.into_array();
 
         // Build expected: 97 copies of [99,99] with patches at positions 5, 50, 95.
         let mut expected_elements_vec = Vec::with_capacity(200);
@@ -1324,10 +1333,11 @@ mod test {
                 .into_array();
 
         assert_arrays_eq!(actual, expected);
+        Ok(())
     }
 
     #[test]
-    fn test_sparse_fixed_size_list_single_element() {
+    fn test_sparse_fixed_size_list_single_element() -> VortexResult<()> {
         // Test with a single element FSL array.
         let elements = buffer![42i32, 43].into_array();
         let fsl = FixedSizeListArray::try_new(elements, 2, Validity::AllValid, 1)
@@ -1347,7 +1357,7 @@ mod test {
             .unwrap()
             .into_array();
 
-        let actual = sparse.to_canonical().into_array();
+        let actual = sparse.to_canonical()?.into_array();
 
         // Expected: just [42, 43].
         let expected_elements = buffer![42i32, 43].into_array();
@@ -1356,10 +1366,11 @@ mod test {
             .into_array();
 
         assert_arrays_eq!(actual, expected);
+        Ok(())
     }
 
     #[test]
-    fn test_sparse_list_grows_offset_type() {
+    fn test_sparse_list_grows_offset_type() -> VortexResult<()> {
         let elements = buffer![1i32, 2, 1, 2].into_array();
         let offsets = buffer![0u8, 1, 2, 3, 4].into_array();
         let lists = ListArray::try_new(elements, offsets, Validity::AllValid)
@@ -1372,7 +1383,7 @@ mod test {
             .unwrap()
             .into_array();
 
-        let actual = sparse.to_canonical().into_array();
+        let actual = sparse.to_canonical()?.into_array();
         let mut expected_elements = buffer_mut![1, 2, 1, 2];
         expected_elements.extend(buffer![42i32; 252]);
         let expected = ListArray::try_new(
@@ -1395,10 +1406,11 @@ mod test {
         let expected = expected.into_arrow(&arrow_dtype).unwrap();
 
         assert_eq!(actual.data_type(), expected.data_type());
+        Ok(())
     }
 
     #[test]
-    fn test_sparse_listview_null_fill_with_gaps() {
+    fn test_sparse_listview_null_fill_with_gaps() -> VortexResult<()> {
         // This test specifically catches the bug where the old implementation
         // incorrectly tracked `last_valid_offset` as the START of the last list
         // instead of properly handling ListView's offset/size pairs.
@@ -1438,7 +1450,7 @@ mod test {
         .unwrap();
 
         // Convert to canonical form - this triggers the function we're testing
-        let canonical = sparse.to_canonical().into_array();
+        let canonical = sparse.to_canonical()?.into_array();
         let result_listview = canonical.to_listview();
 
         // Verify the structure
@@ -1470,10 +1482,11 @@ mod test {
         assert_eq!(get_list_values(7), vec![30, 31, 32, 33]); // sparse index 2
         assert_eq!(get_list_values(8), empty); // null
         assert_eq!(get_list_values(9), empty); // null
+        Ok(())
     }
 
     #[test]
-    fn test_sparse_listview_sliced_values_null_fill() {
+    fn test_sparse_listview_sliced_values_null_fill() -> VortexResult<()> {
         // This test uses sliced ListView values to ensure proper handling
         // of non-zero starting offsets in the source data.
 
@@ -1516,7 +1529,7 @@ mod test {
         let sparse =
             SparseArray::try_new(indices, values, 5, Scalar::null(sliced.dtype().clone())).unwrap();
 
-        let canonical = sparse.to_canonical().into_array();
+        let canonical = sparse.to_canonical()?.into_array();
         let result_listview = canonical.to_listview();
 
         assert_eq!(result_listview.len(), 5);
@@ -1548,5 +1561,6 @@ mod test {
         // The bug in the old implementation would have incorrectly used
         // offsets[sparse_index] for filling nulls, which would be wrong
         // when dealing with sliced arrays that have non-zero starting offsets.
+        Ok(())
     }
 }

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -181,8 +181,10 @@ impl BaseArrayVTable<ZigZagVTable> for ZigZagVTable {
 }
 
 impl CanonicalVTable<ZigZagVTable> for ZigZagVTable {
-    fn canonicalize(array: &ZigZagArray) -> Canonical {
-        Canonical::Primitive(zigzag_decode(array.encoded().to_primitive()))
+    fn canonicalize(array: &ZigZagArray) -> VortexResult<Canonical> {
+        Ok(Canonical::Primitive(zigzag_decode(
+            array.encoded().to_primitive(),
+        )))
     }
 }
 
@@ -250,9 +252,9 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_compute_statistics() {
+    fn test_compute_statistics() -> VortexResult<()> {
         let array = buffer![1i32, -5i32, 2, 3, 4, 5, 6, 7, 8, 9, 10].into_array();
-        let canonical = array.to_canonical();
+        let canonical = array.to_canonical()?;
         let zigzag = ZigZagVTable
             .as_vtable()
             .encode(&canonical, None)
@@ -288,5 +290,6 @@ mod test {
             sliced.statistics().compute_is_constant(),
             array.statistics().compute_is_constant()
         );
+        Ok(())
     }
 }

--- a/encodings/zigzag/src/compute/mod.rs
+++ b/encodings/zigzag/src/compute/mod.rs
@@ -86,6 +86,7 @@ mod tests {
     use vortex_buffer::BitBuffer;
     use vortex_buffer::buffer;
     use vortex_dtype::Nullability;
+    use vortex_error::VortexResult;
     use vortex_scalar::Scalar;
 
     use crate::ZigZagArray;
@@ -93,11 +94,11 @@ mod tests {
     use crate::zigzag_encode;
 
     #[test]
-    pub fn nullable_scalar_at() {
+    pub fn nullable_scalar_at() -> VortexResult<()> {
         let zigzag = ZigZagVTable
             .as_vtable()
             .encode(
-                &PrimitiveArray::new(buffer![-189, -160, 1], Validity::AllValid).to_canonical(),
+                &PrimitiveArray::new(buffer![-189, -160, 1], Validity::AllValid).to_canonical()?,
                 None,
             )
             .unwrap()
@@ -106,13 +107,14 @@ mod tests {
             zigzag.scalar_at(1),
             Scalar::primitive(-160, Nullability::Nullable)
         );
+        Ok(())
     }
 
     #[test]
-    fn take_zigzag() {
+    fn take_zigzag() -> VortexResult<()> {
         let zigzag = ZigZagVTable
             .as_vtable()
-            .encode(&buffer![-189, -160, 1].into_array().to_canonical(), None)
+            .encode(&buffer![-189, -160, 1].into_array().to_canonical()?, None)
             .unwrap()
             .unwrap();
 
@@ -120,31 +122,33 @@ mod tests {
         let actual = take(&zigzag, &indices).unwrap();
         let expected = ZigZagVTable
             .as_vtable()
-            .encode(&buffer![-189, 1].into_array().to_canonical(), None)
+            .encode(&buffer![-189, 1].into_array().to_canonical()?, None)
             .unwrap()
             .unwrap();
         assert_arrays_eq!(actual, expected);
+        Ok(())
     }
 
     #[test]
-    fn filter_zigzag() {
+    fn filter_zigzag() -> VortexResult<()> {
         let zigzag = ZigZagVTable
             .as_vtable()
-            .encode(&buffer![-189, -160, 1].into_array().to_canonical(), None)
+            .encode(&buffer![-189, -160, 1].into_array().to_canonical()?, None)
             .unwrap()
             .unwrap();
         let filter_mask = BitBuffer::from(vec![true, false, true]).into();
         let actual = filter(&zigzag, &filter_mask).unwrap();
         let expected = ZigZagVTable
             .as_vtable()
-            .encode(&buffer![-189, 1].into_array().to_canonical(), None)
+            .encode(&buffer![-189, 1].into_array().to_canonical()?, None)
             .unwrap()
             .unwrap();
         assert_arrays_eq!(actual, expected);
+        Ok(())
     }
 
     #[test]
-    fn test_filter_conformance() {
+    fn test_filter_conformance() -> VortexResult<()> {
         use vortex_array::compute::conformance::filter::test_filter_conformance;
 
         // Test with i32 values
@@ -153,7 +157,7 @@ mod tests {
             .encode(
                 &buffer![-189i32, -160, 1, 42, -73]
                     .into_array()
-                    .to_canonical(),
+                    .to_canonical()?,
                 None,
             )
             .unwrap()
@@ -166,7 +170,7 @@ mod tests {
             .encode(
                 &buffer![1000i64, -2000, 3000, -4000, 5000]
                     .into_array()
-                    .to_canonical(),
+                    .to_canonical()?,
                 None,
             )
             .unwrap()
@@ -178,14 +182,15 @@ mod tests {
             PrimitiveArray::from_option_iter([Some(-10i16), None, Some(20), Some(-30), None]);
         let zigzag = ZigZagVTable
             .as_vtable()
-            .encode(&array.to_canonical(), None)
+            .encode(&array.to_canonical()?, None)
             .unwrap()
             .unwrap();
         test_filter_conformance(zigzag.as_ref());
+        Ok(())
     }
 
     #[test]
-    fn test_mask_conformance() {
+    fn test_mask_conformance() -> VortexResult<()> {
         use vortex_array::compute::conformance::mask::test_mask_conformance;
 
         // Test with i32 values
@@ -194,7 +199,7 @@ mod tests {
             .encode(
                 &buffer![-100i32, 200, -300, 400, -500]
                     .into_array()
-                    .to_canonical(),
+                    .to_canonical()?,
                 None,
             )
             .unwrap()
@@ -205,12 +210,13 @@ mod tests {
         let zigzag = ZigZagVTable
             .as_vtable()
             .encode(
-                &buffer![-127i8, 0, 127, -1, 1].into_array().to_canonical(),
+                &buffer![-127i8, 0, 127, -1, 1].into_array().to_canonical()?,
                 None,
             )
             .unwrap()
             .unwrap();
         test_mask_conformance(zigzag.as_ref());
+        Ok(())
     }
 
     #[rstest]
@@ -218,15 +224,16 @@ mod tests {
     #[case(buffer![1000i64, -2000, 3000, -4000, 5000].into_array())]
     #[case(PrimitiveArray::from_option_iter([Some(-10i16), None, Some(20), Some(-30), None]).into_array())]
     #[case(buffer![42i32].into_array())]
-    fn test_take_zigzag_conformance(#[case] array: ArrayRef) {
+    fn test_take_zigzag_conformance(#[case] array: ArrayRef) -> VortexResult<()> {
         use vortex_array::compute::conformance::take::test_take_conformance;
 
         let zigzag = ZigZagVTable
             .as_vtable()
-            .encode(&array.to_canonical(), None)
+            .encode(&array.to_canonical()?, None)
             .unwrap()
             .unwrap();
         test_take_conformance(zigzag.as_ref());
+        Ok(())
     }
 
     #[rstest]

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -483,7 +483,7 @@ impl ZstdArray {
     }
 
     pub fn from_array(array: ArrayRef, level: i32, values_per_frame: usize) -> VortexResult<Self> {
-        Self::from_canonical(&array.to_canonical(), level, values_per_frame)?
+        Self::from_canonical(&array.to_canonical()?, level, values_per_frame)?
             .ok_or_else(|| vortex_err!("Zstd can only encode Primitive and VarBinView arrays"))
     }
 
@@ -775,7 +775,7 @@ impl BaseArrayVTable<ZstdVTable> for ZstdVTable {
 }
 
 impl CanonicalVTable<ZstdVTable> for ZstdVTable {
-    fn canonicalize(array: &ZstdArray) -> Canonical {
+    fn canonicalize(array: &ZstdArray) -> VortexResult<Canonical> {
         array.decompress().to_canonical()
     }
 }

--- a/fuzz/src/array/fill_null.rs
+++ b/fuzz/src/array/fill_null.rs
@@ -272,7 +272,7 @@ mod tests {
         let array = PrimitiveArray::from_option_iter([Some(1i32), None, Some(3), None, Some(5)]);
         let fill_value = Scalar::from(42i32);
 
-        let result = fill_null_canonical_array(array.to_canonical(), &fill_value).unwrap();
+        let result = fill_null_canonical_array(array.to_canonical().unwrap(), &fill_value).unwrap();
 
         let expected = PrimitiveArray::from_iter([1i32, 42, 3, 42, 5]);
         assert_arrays_eq!(expected, result);
@@ -285,7 +285,7 @@ mod tests {
         let array = BoolArray::from_bit_buffer(data_buffer, Validity::from(validity_buffer));
         let fill_value = Scalar::from(true);
 
-        let result = fill_null_canonical_array(array.to_canonical(), &fill_value).unwrap();
+        let result = fill_null_canonical_array(array.to_canonical().unwrap(), &fill_value).unwrap();
 
         let expected = BoolArray::from(BitBuffer::from(vec![true, true, false, true]));
         assert_arrays_eq!(expected, result);
@@ -299,7 +299,7 @@ mod tests {
         );
         let fill_value = Scalar::utf8("default", Nullability::NonNullable);
 
-        let result = fill_null_canonical_array(array.to_canonical(), &fill_value).unwrap();
+        let result = fill_null_canonical_array(array.to_canonical().unwrap(), &fill_value).unwrap();
 
         let expected = VarBinViewArray::from_iter_str(["hello", "default", "world"]);
         assert_arrays_eq!(expected, result);
@@ -310,7 +310,7 @@ mod tests {
         let array = PrimitiveArray::from_option_iter([None::<i32>, None, None]);
         let fill_value = Scalar::from(100i32);
 
-        let result = fill_null_canonical_array(array.to_canonical(), &fill_value).unwrap();
+        let result = fill_null_canonical_array(array.to_canonical().unwrap(), &fill_value).unwrap();
 
         let expected = PrimitiveArray::from_iter([100i32, 100, 100]);
         assert_arrays_eq!(expected, result);
@@ -321,7 +321,7 @@ mod tests {
         let array = PrimitiveArray::from_iter([1i32, 2, 3]);
         let fill_value = Scalar::from(42i32);
 
-        let result = fill_null_canonical_array(array.to_canonical(), &fill_value).unwrap();
+        let result = fill_null_canonical_array(array.to_canonical().unwrap(), &fill_value).unwrap();
 
         let expected = PrimitiveArray::from_iter([1i32, 2, 3]);
         assert_arrays_eq!(expected, result);
@@ -333,7 +333,7 @@ mod tests {
         let array = PrimitiveArray::from_option_iter([Some(1i32), None, Some(3)]);
         let fill_value = Scalar::null(DType::Primitive(PType::I32, Nullability::Nullable));
 
-        let result = fill_null_canonical_array(array.to_canonical(), &fill_value);
+        let result = fill_null_canonical_array(array.to_canonical().unwrap(), &fill_value);
 
         assert!(result.is_err());
         assert!(
@@ -356,7 +356,7 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let result = fill_null_canonical_array(array.to_canonical(), &fill_value).unwrap();
+        let result = fill_null_canonical_array(array.to_canonical().unwrap(), &fill_value).unwrap();
 
         let expected = DecimalArray::from_iter(
             [100i32, 999i32, 300i32, 999i32, 500i32],
@@ -377,7 +377,7 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let result = fill_null_canonical_array(array.to_canonical(), &fill_value).unwrap();
+        let result = fill_null_canonical_array(array.to_canonical().unwrap(), &fill_value).unwrap();
 
         let expected =
             DecimalArray::from_iter([1000i64, 9999i64, 3000i64], DecimalDType::new(15, 3));
@@ -396,7 +396,7 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let result = fill_null_canonical_array(array.to_canonical(), &fill_value).unwrap();
+        let result = fill_null_canonical_array(array.to_canonical().unwrap(), &fill_value).unwrap();
 
         let expected = DecimalArray::from_iter(
             [10000i128, 99999i128, 30000i128, 99999i128],
@@ -415,7 +415,7 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let result = fill_null_canonical_array(array.to_canonical(), &fill_value).unwrap();
+        let result = fill_null_canonical_array(array.to_canonical().unwrap(), &fill_value).unwrap();
 
         let expected = cast(
             &DecimalArray::from_option_iter(
@@ -441,7 +441,7 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let result = fill_null_canonical_array(array.to_canonical(), &fill_value).unwrap();
+        let result = fill_null_canonical_array(array.to_canonical().unwrap(), &fill_value).unwrap();
 
         let expected = cast(
             &DecimalArray::from_option_iter(

--- a/fuzz/src/array/mask.rs
+++ b/fuzz/src/array/mask.rs
@@ -99,7 +99,7 @@ pub fn mask_canonical_array(canonical: Canonical, mask: &Mask) -> VortexResult<A
         }
         Canonical::Extension(array) => {
             // Recursively mask the storage array
-            let masked_storage = mask_canonical_array(array.storage().to_canonical(), mask)
+            let masked_storage = mask_canonical_array(array.storage().to_canonical()?, mask)
                 .vortex_expect("mask_canonical_array should succeed in fuzz test");
 
             if masked_storage.dtype().nullability()
@@ -144,7 +144,7 @@ mod tests {
         let array = NullArray::new(5);
         let mask = Mask::from_iter([true, false, true, false, true]);
 
-        let result = mask_canonical_array(array.to_canonical(), &mask).unwrap();
+        let result = mask_canonical_array(array.to_canonical().unwrap(), &mask).unwrap();
 
         assert_eq!(result.len(), 5);
         // All values should still be null
@@ -158,7 +158,7 @@ mod tests {
         let array = BoolArray::from_iter([true, false, true, false, true]);
         let mask = Mask::from_iter([true, false, false, true, false]);
 
-        let result = mask_canonical_array(array.to_canonical(), &mask).unwrap();
+        let result = mask_canonical_array(array.to_canonical().unwrap(), &mask).unwrap();
 
         let expected = BoolArray::from_iter([None, Some(false), Some(true), None, Some(true)]);
         assert_arrays_eq!(result, expected);
@@ -169,7 +169,7 @@ mod tests {
         let array = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5]);
         let mask = Mask::from_iter([false, true, false, true, false]);
 
-        let result = mask_canonical_array(array.to_canonical(), &mask).unwrap();
+        let result = mask_canonical_array(array.to_canonical().unwrap(), &mask).unwrap();
 
         let expected = PrimitiveArray::from_option_iter([Some(1i32), None, Some(3), None, Some(5)]);
         assert_arrays_eq!(result, expected);
@@ -180,7 +180,7 @@ mod tests {
         let array = PrimitiveArray::from_option_iter([Some(1i32), None, Some(3), Some(4), None]);
         let mask = Mask::from_iter([true, false, false, true, false]);
 
-        let result = mask_canonical_array(array.to_canonical(), &mask).unwrap();
+        let result = mask_canonical_array(array.to_canonical().unwrap(), &mask).unwrap();
 
         let expected = PrimitiveArray::from_option_iter([None, None, Some(3i32), None, None]);
         assert_arrays_eq!(result, expected);
@@ -195,7 +195,7 @@ mod tests {
         );
         let mask = Mask::from_iter([false, false, true, false, false]);
 
-        let result = mask_canonical_array(array.to_canonical(), &mask).unwrap();
+        let result = mask_canonical_array(array.to_canonical().unwrap(), &mask).unwrap();
 
         let expected =
             DecimalArray::from_option_iter([Some(1i128), Some(2), None, Some(4), Some(5)], dtype);
@@ -207,7 +207,7 @@ mod tests {
         let array = VarBinViewArray::from_iter_str(["one", "two", "three", "four", "five"]);
         let mask = Mask::from_iter([true, false, true, false, true]);
 
-        let result = mask_canonical_array(array.to_canonical(), &mask).unwrap();
+        let result = mask_canonical_array(array.to_canonical().unwrap(), &mask).unwrap();
 
         let expected =
             VarBinViewArray::from_iter_nullable_str([None, Some("two"), None, Some("four"), None]);
@@ -226,7 +226,7 @@ mod tests {
 
         let mask = Mask::from_iter([false, true, false]);
 
-        let result = mask_canonical_array(array.to_canonical(), &mask).unwrap();
+        let result = mask_canonical_array(array.to_canonical().unwrap(), &mask).unwrap();
 
         assert_eq!(result.len(), 3);
         assert!(result.is_valid(0));
@@ -242,7 +242,7 @@ mod tests {
 
         let mask = Mask::from_iter([true, false, true]);
 
-        let result = mask_canonical_array(array.to_canonical(), &mask).unwrap();
+        let result = mask_canonical_array(array.to_canonical().unwrap(), &mask).unwrap();
 
         assert_eq!(result.len(), 3);
         assert!(!result.is_valid(0));
@@ -266,7 +266,7 @@ mod tests {
 
         let mask = Mask::from_iter([false, true, false]);
 
-        let result = mask_canonical_array(array.to_canonical(), &mask).unwrap();
+        let result = mask_canonical_array(array.to_canonical().unwrap(), &mask).unwrap();
 
         assert_eq!(result.len(), 3);
         assert!(result.is_valid(0));
@@ -279,7 +279,7 @@ mod tests {
         let array = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5]);
         let mask = Mask::AllTrue(5);
 
-        let result = mask_canonical_array(array.to_canonical(), &mask).unwrap();
+        let result = mask_canonical_array(array.to_canonical().unwrap(), &mask).unwrap();
 
         let expected = PrimitiveArray::from_option_iter([None, None, None, None, None::<i32>]);
         assert_arrays_eq!(result, expected);
@@ -290,7 +290,7 @@ mod tests {
         let array = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5]);
         let mask = Mask::AllFalse(5);
 
-        let result = mask_canonical_array(array.to_canonical(), &mask).unwrap();
+        let result = mask_canonical_array(array.to_canonical().unwrap(), &mask).unwrap();
 
         let expected =
             PrimitiveArray::from_option_iter([Some(1i32), Some(2), Some(3), Some(4), Some(5)]);
@@ -302,7 +302,7 @@ mod tests {
         let array = PrimitiveArray::from_iter(Vec::<i32>::new());
         let mask = Mask::AllFalse(0);
 
-        let result = mask_canonical_array(array.to_canonical(), &mask).unwrap();
+        let result = mask_canonical_array(array.to_canonical().unwrap(), &mask).unwrap();
 
         assert_eq!(result.len(), 0);
     }

--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -306,14 +306,22 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                     }
 
                     // Sum - returns a scalar, does NOT update current_array (terminal operation)
-                    let sum_result = sum_canonical_array(current_array.to_canonical())
-                        .vortex_expect("sum_canonical_array should succeed in fuzz test");
+                    let sum_result = sum_canonical_array(
+                        current_array
+                            .to_canonical()
+                            .vortex_expect("to_canonical should succeed in fuzz test"),
+                    )
+                    .vortex_expect("sum_canonical_array should succeed in fuzz test");
                     (Action::Sum, ExpectedValue::Scalar(sum_result))
                 }
                 ActionType::MinMax => {
                     // MinMax - returns a scalar, does NOT update current_array (terminal operation)
-                    let min_max_result = min_max_canonical_array(current_array.to_canonical())
-                        .vortex_expect("min_max_canonical_array should succeed in fuzz test");
+                    let min_max_result = min_max_canonical_array(
+                        current_array
+                            .to_canonical()
+                            .vortex_expect("to_canonical should succeed in fuzz test"),
+                    )
+                    .vortex_expect("min_max_canonical_array should succeed in fuzz test");
                     (Action::MinMax, ExpectedValue::MinMax(min_max_result))
                 }
                 ActionType::FillNull => {
@@ -337,9 +345,13 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                     }
 
                     // Compute expected result on canonical form
-                    let expected_result =
-                        fill_null_canonical_array(current_array.to_canonical(), &fill_value)
-                            .vortex_expect("fill_null_canonical_array should succeed in fuzz test");
+                    let expected_result = fill_null_canonical_array(
+                        current_array
+                            .to_canonical()
+                            .vortex_expect("to_canonical should succeed in fuzz test"),
+                        &fill_value,
+                    )
+                    .vortex_expect("fill_null_canonical_array should succeed in fuzz test");
                     // Update current_array to the result for chaining
                     current_array = expected_result.clone();
                     (
@@ -355,7 +367,9 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
 
                     // Compute expected result on canonical form
                     let expected_result = mask_canonical_array(
-                        current_array.to_canonical(),
+                        current_array
+                            .to_canonical()
+                            .vortex_expect("to_canonical should succeed in fuzz test"),
                         &Mask::from_iter(mask.iter().copied()),
                     )
                     .vortex_expect("mask_canonical_array should succeed in fuzz test");
@@ -385,10 +399,13 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                     let expected_scalars: Vec<Scalar> = indices_vec
                         .iter()
                         .map(|&idx| {
-                            scalar_at_canonical_array(current_array.to_canonical(), idx)
-                                .vortex_expect(
-                                    "scalar_at_canonical_array should succeed in fuzz test",
-                                )
+                            scalar_at_canonical_array(
+                                current_array
+                                    .to_canonical()
+                                    .vortex_expect("to_canonical should succeed in fuzz test"),
+                                idx,
+                            )
+                            .vortex_expect("scalar_at_canonical_array should succeed in fuzz test")
                         })
                         .collect();
 
@@ -538,7 +555,9 @@ pub fn run_fuzz_action(fuzz_action: FuzzArrayAction) -> crate::error::VortexFuzz
     for (i, (action, expected)) in actions.into_iter().enumerate() {
         match action {
             Action::Compress(strategy) => {
-                let canonical = current_array.to_canonical();
+                let canonical = current_array
+                    .to_canonical()
+                    .vortex_expect("to_canonical should succeed in fuzz test");
                 current_array = compress_array(canonical.as_ref(), strategy);
                 assert_array_eq(&expected.array(), &current_array, i)?;
             }

--- a/fuzz/src/array/scalar_at.rs
+++ b/fuzz/src/array/scalar_at.rs
@@ -45,8 +45,12 @@ pub fn scalar_at_canonical_array(canonical: Canonical, index: usize) -> VortexRe
             let list = array.list_elements_at(index);
             let children: Vec<Scalar> = (0..list.len())
                 .map(|i| {
-                    scalar_at_canonical_array(list.to_canonical(), i)
-                        .vortex_expect("scalar_at_canonical_array should succeed in fuzz test")
+                    scalar_at_canonical_array(
+                        list.to_canonical()
+                            .vortex_expect("to_canonical should succeed in fuzz test"),
+                        i,
+                    )
+                    .vortex_expect("scalar_at_canonical_array should succeed in fuzz test")
                 })
                 .collect();
             Scalar::list(
@@ -59,8 +63,12 @@ pub fn scalar_at_canonical_array(canonical: Canonical, index: usize) -> VortexRe
             let list = array.fixed_size_list_elements_at(index);
             let children: Vec<Scalar> = (0..list.len())
                 .map(|i| {
-                    scalar_at_canonical_array(list.to_canonical(), i)
-                        .vortex_expect("scalar_at_canonical_array should succeed in fuzz test")
+                    scalar_at_canonical_array(
+                        list.to_canonical()
+                            .vortex_expect("to_canonical should succeed in fuzz test"),
+                        i,
+                    )
+                    .vortex_expect("scalar_at_canonical_array should succeed in fuzz test")
                 })
                 .collect();
             Scalar::fixed_size_list(list.dtype().clone(), children, array.dtype().nullability())
@@ -70,14 +78,19 @@ pub fn scalar_at_canonical_array(canonical: Canonical, index: usize) -> VortexRe
                 .fields()
                 .iter()
                 .map(|field| {
-                    scalar_at_canonical_array(field.to_canonical(), index)
-                        .vortex_expect("scalar_at_canonical_array should succeed in fuzz test")
+                    scalar_at_canonical_array(
+                        field
+                            .to_canonical()
+                            .vortex_expect("to_canonical should succeed in fuzz test"),
+                        index,
+                    )
+                    .vortex_expect("scalar_at_canonical_array should succeed in fuzz test")
                 })
                 .collect();
             Scalar::struct_(array.dtype().clone(), field_scalars)
         }
         Canonical::Extension(array) => {
-            let storage_scalar = scalar_at_canonical_array(array.storage().to_canonical(), index)?;
+            let storage_scalar = scalar_at_canonical_array(array.storage().to_canonical()?, index)?;
             Scalar::extension(array.ext_dtype().clone(), storage_scalar)
         }
     })

--- a/vortex-array/benches/chunk_array_builder.rs
+++ b/vortex-array/benches/chunk_array_builder.rs
@@ -14,6 +14,7 @@ use vortex_array::builders::ArrayBuilder;
 use vortex_array::builders::VarBinViewBuilder;
 use vortex_array::builders::builder_with_capacity;
 use vortex_dtype::DType;
+use vortex_error::VortexExpect;
 
 fn main() {
     divan::main();
@@ -32,7 +33,9 @@ fn chunked_bool_canonical_into(bencher: Bencher, (len, chunk_count): (usize, usi
 
     bencher.with_inputs(|| &chunk).bench_refs(|chunk| {
         let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
-        chunk.append_to_builder(builder.as_mut());
+        chunk
+            .append_to_builder(builder.as_mut())
+            .vortex_expect("append failed");
         builder.finish()
     })
 }
@@ -43,7 +46,9 @@ fn chunked_opt_bool_canonical_into(bencher: Bencher, (len, chunk_count): (usize,
 
     bencher.with_inputs(|| &chunk).bench_refs(|chunk| {
         let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
-        chunk.append_to_builder(builder.as_mut());
+        chunk
+            .append_to_builder(builder.as_mut())
+            .vortex_expect("append failed");
         builder.finish()
     })
 }
@@ -75,7 +80,9 @@ fn chunked_varbinview_canonical_into(bencher: Bencher, (len, chunk_count): (usiz
             DType::Utf8(chunk.dtype().nullability()),
             len * chunk_count,
         );
-        chunk.append_to_builder(&mut builder);
+        chunk
+            .append_to_builder(&mut builder)
+            .vortex_expect("append failed");
         builder.finish()
     })
 }
@@ -98,7 +105,9 @@ fn chunked_varbinview_opt_canonical_into(bencher: Bencher, (len, chunk_count): (
             DType::Utf8(chunk.dtype().nullability()),
             len * chunk_count,
         );
-        chunk.append_to_builder(&mut builder);
+        chunk
+            .append_to_builder(&mut builder)
+            .vortex_expect("append failed");
         builder.finish()
     })
 }

--- a/vortex-array/benches/chunked_dict_builder.rs
+++ b/vortex-array/benches/chunked_dict_builder.rs
@@ -9,6 +9,7 @@ use vortex_array::arrays::dict_test::gen_dict_primitive_chunks;
 use vortex_array::builders::builder_with_capacity;
 use vortex_array::compute::warm_up_vtables;
 use vortex_dtype::NativePType;
+use vortex_error::VortexExpect;
 
 fn main() {
     warm_up_vtables();
@@ -35,7 +36,9 @@ fn chunked_dict_primitive_canonical_into<T: NativePType>(
 
     bencher.with_inputs(|| &chunk).bench_refs(|chunk| {
         let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
-        chunk.append_to_builder(builder.as_mut());
+        chunk
+            .append_to_builder(builder.as_mut())
+            .vortex_expect("append failed");
         builder.finish()
     })
 }

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -169,12 +169,12 @@ pub trait Array:
     fn validity_mask(&self) -> Mask;
 
     /// Returns the canonical representation of the array.
-    fn to_canonical(&self) -> Canonical;
+    fn to_canonical(&self) -> VortexResult<Canonical>;
 
     /// Writes the array into the canonical builder.
     ///
     /// The [`DType`] of the builder must match that of the array.
-    fn append_to_builder(&self, builder: &mut dyn ArrayBuilder);
+    fn append_to_builder(&self, builder: &mut dyn ArrayBuilder) -> VortexResult<()>;
 
     /// Returns the statistics of the array.
     // TODO(ngates): change how this works. It's weird.
@@ -296,11 +296,11 @@ impl Array for Arc<dyn Array> {
         self.as_ref().validity_mask()
     }
 
-    fn to_canonical(&self) -> Canonical {
+    fn to_canonical(&self) -> VortexResult<Canonical> {
         self.as_ref().to_canonical()
     }
 
-    fn append_to_builder(&self, builder: &mut dyn ArrayBuilder) {
+    fn append_to_builder(&self, builder: &mut dyn ArrayBuilder) -> VortexResult<()> {
         self.as_ref().append_to_builder(builder)
     }
 
@@ -629,8 +629,8 @@ impl<V: VTable> Array for ArrayAdapter<V> {
         mask
     }
 
-    fn to_canonical(&self) -> Canonical {
-        let canonical = <V::CanonicalVTable as CanonicalVTable<V>>::canonicalize(&self.0);
+    fn to_canonical(&self) -> VortexResult<Canonical> {
+        let canonical = <V::CanonicalVTable as CanonicalVTable<V>>::canonicalize(&self.0)?;
 
         assert_eq!(
             self.len(),
@@ -652,10 +652,10 @@ impl<V: VTable> Array for ArrayAdapter<V> {
             .as_ref()
             .statistics()
             .inherit_from(self.statistics());
-        canonical
+        Ok(canonical)
     }
 
-    fn append_to_builder(&self, builder: &mut dyn ArrayBuilder) {
+    fn append_to_builder(&self, builder: &mut dyn ArrayBuilder) -> VortexResult<()> {
         if builder.dtype() != self.dtype() {
             vortex_panic!(
                 "Builder dtype mismatch: expected {}, got {}",
@@ -665,13 +665,14 @@ impl<V: VTable> Array for ArrayAdapter<V> {
         }
         let len = builder.len();
 
-        <V::CanonicalVTable as CanonicalVTable<V>>::append_to_builder(&self.0, builder);
+        <V::CanonicalVTable as CanonicalVTable<V>>::append_to_builder(&self.0, builder)?;
         assert_eq!(
             len + self.len(),
             builder.len(),
             "Builder length mismatch after writing array for encoding {}",
             self.encoding_id(),
         );
+        Ok(())
     }
 
     fn statistics(&self) -> StatsSetRef<'_> {

--- a/vortex-array/src/arrays/bool/vtable/canonical.rs
+++ b/vortex-array/src/arrays/bool/vtable/canonical.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_error::VortexResult;
+
 use crate::Canonical;
 use crate::arrays::BoolArray;
 use crate::arrays::BoolVTable;
@@ -8,11 +10,12 @@ use crate::builders::ArrayBuilder;
 use crate::vtable::CanonicalVTable;
 
 impl CanonicalVTable<BoolVTable> for BoolVTable {
-    fn canonicalize(array: &BoolArray) -> Canonical {
-        Canonical::Bool(array.clone())
+    fn canonicalize(array: &BoolArray) -> VortexResult<Canonical> {
+        Ok(Canonical::Bool(array.clone()))
     }
 
-    fn append_to_builder(array: &BoolArray, builder: &mut dyn ArrayBuilder) {
-        builder.extend_from_array(array.as_ref())
+    fn append_to_builder(array: &BoolArray, builder: &mut dyn ArrayBuilder) -> VortexResult<()> {
+        builder.extend_from_array(array.as_ref());
+        Ok(())
     }
 }

--- a/vortex-array/src/arrays/chunked/array.rs
+++ b/vortex-array/src/arrays/chunked/array.rs
@@ -175,7 +175,7 @@ impl ChunkedArray {
                     // All chunks are guaranteed to be valid arrays matching self.dtype().
                     unsafe {
                         ChunkedArray::new_unchecked(chunks_to_combine, self.dtype().clone())
-                            .to_canonical()
+                            .to_canonical()?
                             .into_array()
                     },
                 );
@@ -199,7 +199,7 @@ impl ChunkedArray {
                 // SAFETY: chunks_to_combine contains valid chunks of the same dtype as self.
                 // All chunks are guaranteed to be valid arrays matching self.dtype().
                 ChunkedArray::new_unchecked(chunks_to_combine, self.dtype().clone())
-                    .to_canonical()
+                    .to_canonical()?
                     .into_array()
             });
         }

--- a/vortex-array/src/arrays/chunked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/chunked/vtable/canonical.rs
@@ -7,6 +7,7 @@ use vortex_dtype::Nullability;
 use vortex_dtype::PType;
 use vortex_dtype::StructFields;
 use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
 
 use crate::Array;
 use crate::ArrayRef;
@@ -26,15 +27,15 @@ use crate::validity::Validity;
 use crate::vtable::CanonicalVTable;
 
 impl CanonicalVTable<ChunkedVTable> for ChunkedVTable {
-    fn canonicalize(array: &ChunkedArray) -> Canonical {
+    fn canonicalize(array: &ChunkedArray) -> VortexResult<Canonical> {
         if array.nchunks() == 0 {
-            return Canonical::empty(array.dtype());
+            return Ok(Canonical::empty(array.dtype()));
         }
         if array.nchunks() == 1 {
             return array.chunks()[0].to_canonical();
         }
 
-        match array.dtype() {
+        Ok(match array.dtype() {
             DType::Struct(struct_dtype, _) => {
                 let struct_array = pack_struct_chunks(
                     array.chunks(),
@@ -47,19 +48,20 @@ impl CanonicalVTable<ChunkedVTable> for ChunkedVTable {
                 array.chunks(),
                 Validity::copy_from_array(array.as_ref()),
                 elem_dtype,
-            )),
+            )?),
             _ => {
                 let mut builder = builder_with_capacity(array.dtype(), array.len());
-                array.append_to_builder(builder.as_mut());
+                array.append_to_builder(builder.as_mut())?;
                 builder.finish_into_canonical()
             }
-        }
+        })
     }
 
-    fn append_to_builder(array: &ChunkedArray, builder: &mut dyn ArrayBuilder) {
+    fn append_to_builder(array: &ChunkedArray, builder: &mut dyn ArrayBuilder) -> VortexResult<()> {
         for chunk in array.chunks() {
-            chunk.append_to_builder(builder);
+            chunk.append_to_builder(builder)?;
         }
+        Ok(())
     }
 }
 
@@ -107,7 +109,7 @@ fn swizzle_list_chunks(
     chunks: &[ArrayRef],
     validity: Validity,
     elem_dtype: &DType,
-) -> ListViewArray {
+) -> VortexResult<ListViewArray> {
     let len: usize = chunks.iter().map(|c| c.len()).sum();
 
     assert_eq!(
@@ -136,7 +138,7 @@ fn swizzle_list_chunks(
         let chunk_array = chunk.to_listview();
         // By rebuilding as zero-copy to `List` and trimming all elements (to prevent gaps), we make
         // the final output `ListView` also zero-copyable to `List`.
-        let chunk_array = chunk_array.rebuild(ListViewRebuildMode::MakeExact);
+        let chunk_array = chunk_array.rebuild(ListViewRebuildMode::MakeExact)?;
 
         // Add the `elements` of the current array as a new chunk.
         list_elements_chunks.push(chunk_array.elements().clone());
@@ -181,10 +183,10 @@ fn swizzle_list_chunks(
     // - Validity came from the outer chunked array so it must have the same length
     // - Since we made sure that all chunks were zero-copyable to a list above, we know that the
     //   final concatenated output is also zero-copyable to a list.
-    unsafe {
+    Ok(unsafe {
         ListViewArray::new_unchecked(chunked_elements, offsets, sizes, validity)
             .with_zero_copy_to_list(true)
-    }
+    })
 }
 
 #[cfg(test)]

--- a/vortex-array/src/arrays/constant/vtable/canonical.rs
+++ b/vortex-array/src/arrays/constant/vtable/canonical.rs
@@ -13,6 +13,7 @@ use vortex_dtype::match_each_decimal_value;
 use vortex_dtype::match_each_decimal_value_type;
 use vortex_dtype::match_each_native_ptype;
 use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
 use vortex_scalar::BinaryScalar;
 use vortex_scalar::BoolScalar;
 use vortex_scalar::DecimalValue;
@@ -41,7 +42,7 @@ use crate::validity::Validity;
 use crate::vtable::CanonicalVTable;
 
 impl CanonicalVTable<ConstantVTable> for ConstantVTable {
-    fn canonicalize(array: &ConstantArray) -> Canonical {
+    fn canonicalize(array: &ConstantArray) -> VortexResult<Canonical> {
         let scalar = array.scalar();
 
         let validity = match array.dtype().nullability() {
@@ -52,7 +53,7 @@ impl CanonicalVTable<ConstantVTable> for ConstantVTable {
             },
         };
 
-        match array.dtype() {
+        Ok(match array.dtype() {
             DType::Null => Canonical::Null(NullArray::new(array.len())),
             DType::Bool(..) => Canonical::Bool(BoolArray::from_bit_buffer(
                 if BoolScalar::try_from(scalar)
@@ -96,7 +97,7 @@ impl CanonicalVTable<ConstantVTable> for ConstantVTable {
                             )
                         }
                     });
-                    return Canonical::Decimal(all_null);
+                    return Ok(Canonical::Decimal(all_null));
                 };
 
                 let decimal_array = match_each_decimal_value!(value, |value| {
@@ -176,7 +177,7 @@ impl CanonicalVTable<ConstantVTable> for ConstantVTable {
                 let storage_self = ConstantArray::new(storage_scalar, array.len()).into_array();
                 Canonical::Extension(ExtensionArray::new(ext_dtype.clone(), storage_self))
             }
-        }
+        })
     }
 }
 
@@ -329,6 +330,7 @@ mod tests {
     use vortex_dtype::Nullability;
     use vortex_dtype::PType;
     use vortex_dtype::half::f16;
+    use vortex_error::VortexResult;
     use vortex_scalar::Scalar;
 
     use crate::Array;
@@ -366,14 +368,14 @@ mod tests {
     }
 
     #[test]
-    fn test_canonicalize_propagates_stats() {
+    fn test_canonicalize_propagates_stats() -> VortexResult<()> {
         let scalar = Scalar::bool(true, Nullability::NonNullable);
         let const_array = ConstantArray::new(scalar, 4).into_array();
         let stats = const_array
             .statistics()
             .compute_all(&all::<Stat>().collect_vec())
             .unwrap();
-        let canonical = const_array.to_canonical();
+        let canonical = const_array.to_canonical()?;
         let canonical_stats = canonical.as_ref().statistics();
 
         let stats_ref = stats.as_typed_ref(canonical.as_ref().dtype());
@@ -388,6 +390,7 @@ mod tests {
                 "stat mismatch {stat}"
             );
         }
+        Ok(())
     }
 
     #[test]
@@ -404,7 +407,7 @@ mod tests {
     }
 
     #[test]
-    fn test_canonicalize_lists() {
+    fn test_canonicalize_lists() -> VortexResult<()> {
         let list_scalar = Scalar::list(
             Arc::new(DType::Primitive(PType::U64, Nullability::NonNullable)),
             vec![1u64.into(), 2u64.into()],
@@ -412,7 +415,7 @@ mod tests {
         );
         let const_array = ConstantArray::new(list_scalar, 2).into_array();
         let canonical_const = const_array.to_listview();
-        let list_array = canonical_const.rebuild(ListViewRebuildMode::MakeZeroCopyToList);
+        let list_array = canonical_const.rebuild(ListViewRebuildMode::MakeZeroCopyToList)?;
         assert_arrays_eq!(
             list_array.elements().to_primitive(),
             PrimitiveArray::from_iter([1u64, 2, 1, 2])
@@ -425,6 +428,7 @@ mod tests {
             list_array.sizes().to_primitive(),
             PrimitiveArray::from_iter([2u64, 2])
         );
+        Ok(())
     }
 
     #[test]

--- a/vortex-array/src/arrays/decimal/vtable/canonical.rs
+++ b/vortex-array/src/arrays/decimal/vtable/canonical.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_error::VortexResult;
+
 use crate::Canonical;
 use crate::arrays::DecimalArray;
 use crate::arrays::DecimalVTable;
@@ -8,11 +10,12 @@ use crate::builders::ArrayBuilder;
 use crate::vtable::CanonicalVTable;
 
 impl CanonicalVTable<DecimalVTable> for DecimalVTable {
-    fn canonicalize(array: &DecimalArray) -> Canonical {
-        Canonical::Decimal(array.clone())
+    fn canonicalize(array: &DecimalArray) -> VortexResult<Canonical> {
+        Ok(Canonical::Decimal(array.clone()))
     }
 
-    fn append_to_builder(array: &DecimalArray, builder: &mut dyn ArrayBuilder) {
-        builder.extend_from_array(array.as_ref())
+    fn append_to_builder(array: &DecimalArray, builder: &mut dyn ArrayBuilder) -> VortexResult<()> {
+        builder.extend_from_array(array.as_ref());
+        Ok(())
     }
 }

--- a/vortex-array/src/arrays/dict/array.rs
+++ b/vortex-array/src/arrays/dict/array.rs
@@ -219,6 +219,7 @@ mod test {
     use vortex_dtype::PType;
     use vortex_dtype::UnsignedPType;
     use vortex_error::VortexExpect;
+    use vortex_error::VortexResult;
     use vortex_error::vortex_panic;
     use vortex_mask::AllOr;
 
@@ -339,7 +340,7 @@ mod test {
     }
 
     #[test]
-    fn test_dict_array_from_primitive_chunks() {
+    fn test_dict_array_from_primitive_chunks() -> VortexResult<()> {
         let len = 2;
         let chunk_count = 2;
         let array = make_dict_primitive_chunks::<u64, u64>(len, 2, chunk_count);
@@ -348,12 +349,13 @@ mod test {
             &DType::Primitive(PType::U64, NonNullable),
             len * chunk_count,
         );
-        array.clone().append_to_builder(builder.as_mut());
+        array.clone().append_to_builder(builder.as_mut())?;
 
         let into_prim = array.to_primitive();
         let prim_into = builder.finish_into_canonical().into_primitive();
 
         assert_arrays_eq!(into_prim, prim_into);
+        Ok(())
     }
 
     #[cfg_attr(miri, ignore)]

--- a/vortex-array/src/arrays/dict/compute/binary_numeric.rs
+++ b/vortex-array/src/arrays/dict/compute/binary_numeric.rs
@@ -64,6 +64,7 @@ register_kernel!(NumericKernelAdapter(DictVTable).lift());
 #[cfg(test)]
 mod tests {
     use vortex_buffer::buffer;
+    use vortex_error::VortexResult;
     use vortex_scalar::NumericOperator;
 
     use crate::IntoArray;
@@ -74,7 +75,7 @@ mod tests {
     use crate::compute::numeric;
 
     #[test]
-    fn test_add_const() {
+    fn test_add_const() -> VortexResult<()> {
         // Create a dict with all_values_referenced = true
         let dict = unsafe {
             DictArray::new_unchecked(
@@ -92,11 +93,12 @@ mod tests {
         .unwrap();
 
         let expected = PrimitiveArray::from_iter([15i32, 25, 35, 15, 25]);
-        assert_arrays_eq!(res.to_canonical().into_array(), expected.to_array());
+        assert_arrays_eq!(res.to_canonical()?.into_array(), expected.to_array());
+        Ok(())
     }
 
     #[test]
-    fn test_mul_const() {
+    fn test_mul_const() -> VortexResult<()> {
         // Create a dict with all_values_referenced = true
         let dict = unsafe {
             DictArray::new_unchecked(
@@ -114,11 +116,12 @@ mod tests {
         .unwrap();
 
         let expected = PrimitiveArray::from_iter([20i32, 30, 50, 30, 20]);
-        assert_arrays_eq!(res.to_canonical().into_array(), expected.to_array());
+        assert_arrays_eq!(res.to_canonical()?.into_array(), expected.to_array());
+        Ok(())
     }
 
     #[test]
-    fn test_no_pushdown_when_not_all_values_referenced() {
+    fn test_no_pushdown_when_not_all_values_referenced() -> VortexResult<()> {
         // Create a dict with all_values_referenced = false (default)
         let dict = DictArray::try_new(
             buffer![0u32, 1, 0, 1].into_array(),
@@ -136,11 +139,12 @@ mod tests {
 
         // Verify the result by canonicalizing
         let expected = PrimitiveArray::from_iter([15i32, 25, 15, 25]);
-        assert_arrays_eq!(res.to_canonical().into_array(), expected.to_array());
+        assert_arrays_eq!(res.to_canonical()?.into_array(), expected.to_array());
+        Ok(())
     }
 
     #[test]
-    fn test_sub_const() {
+    fn test_sub_const() -> VortexResult<()> {
         // Create a dict with all_values_referenced = true
         let dict = unsafe {
             DictArray::new_unchecked(
@@ -158,6 +162,7 @@ mod tests {
         .unwrap();
 
         let expected = PrimitiveArray::from_iter([90i32, 40, 15]);
-        assert_arrays_eq!(res.to_canonical().into_array(), expected.to_array());
+        assert_arrays_eq!(res.to_canonical()?.into_array(), expected.to_array());
+        Ok(())
     }
 }

--- a/vortex-array/src/arrays/dict/compute/compare.rs
+++ b/vortex-array/src/arrays/dict/compute/compare.rs
@@ -43,7 +43,7 @@ impl CompareKernel for DictVTable {
             };
 
             // We canonicalize the result because dictionary-encoded bools is dumb.
-            return Ok(Some(result.to_canonical().into_array()));
+            return Ok(Some(result.to_canonical()?.into_array()));
         }
 
         // It's a little more complex, but we could perform a comparison against the dictionary

--- a/vortex-array/src/arrays/dict/compute/fill_null.rs
+++ b/vortex-array/src/arrays/dict/compute/fill_null.rs
@@ -34,7 +34,7 @@ impl FillNullKernel for DictVTable {
             // No fill values found, so we must canonicalize and fill_null.
             // TODO(ngates): compute kernels should all return Option<ArrayRef> to support this
             //  fall back.
-            return fill_null(&array.to_canonical().into_array(), fill_value);
+            return fill_null(&array.to_canonical()?.into_array(), fill_value);
         };
 
         // Now we rewrite the nullable codes to point at the fill value.

--- a/vortex-array/src/arrays/dict/vtable/canonical.rs
+++ b/vortex-array/src/arrays/dict/vtable/canonical.rs
@@ -30,25 +30,25 @@ use crate::validity::Validity;
 use crate::vtable::CanonicalVTable;
 
 impl CanonicalVTable<DictVTable> for DictVTable {
-    fn canonicalize(array: &DictArray) -> Canonical {
-        match array.dtype() {
+    fn canonicalize(array: &DictArray) -> VortexResult<Canonical> {
+        Ok(match array.dtype() {
             // NOTE: Utf8 and Binary will decompress into VarBinViewArray, which requires a full
             // decompression to construct the views child array.
             // For this case, it is *always* faster to decompress the values first and then create
             // copies of the view pointers.
             DType::Utf8(_) | DType::Binary(_) => {
-                let canonical_values: ArrayRef = array.values().to_canonical().into_array();
+                let canonical_values: ArrayRef = array.values().to_canonical()?.into_array();
                 take(&canonical_values, array.codes())
                     .vortex_expect("taking codes from dictionary values shouldn't fail")
-                    .to_canonical()
+                    .to_canonical()?
             }
             DType::Bool(_) => {
                 dict_bool_take(array).vortex_expect("Canonicalizing dict bool array shouldn't fail")
             }
             _ => take(array.values(), array.codes())
                 .vortex_expect("taking codes from dictionary values shouldn't fail")
-                .to_canonical(),
-        }
+                .to_canonical()?,
+        })
     }
 }
 
@@ -79,17 +79,17 @@ fn dict_bool_take(dict_array: &DictArray) -> VortexResult<Canonical> {
                 BitBuffer::new_unset(codes.len()),
                 Validity::copy_from_array(codes).union_nullability(result_nullability),
             )
-            .to_canonical(),
+            .to_canonical()?,
             Mask::AllFalse(_) => ConstantArray::new(
                 Scalar::null(DType::Bool(Nullability::Nullable)),
                 codes.len(),
             )
-            .to_canonical(),
+            .to_canonical()?,
             Mask::Values(_) => BoolArray::from_bit_buffer(
                 BitBuffer::new_unset(codes.len()),
                 Validity::from_mask(result_validity, result_nullability).take(codes)?,
             )
-            .to_canonical(),
+            .to_canonical()?,
         },
         // We found a single matching value so we can compare the codes directly.
         (Some(code), None) => match result_validity {
@@ -104,12 +104,12 @@ fn dict_bool_take(dict_array: &DictArray) -> VortexResult<Canonical> {
                 )?,
                 &DType::Bool(result_nullability),
             )?
-            .to_canonical(),
+            .to_canonical()?,
             Mask::AllFalse(_) => ConstantArray::new(
                 Scalar::null(DType::Bool(Nullability::Nullable)),
                 codes.len(),
             )
-            .to_canonical(),
+            .to_canonical()?,
             Mask::Values(rv) => mask(
                 &compare(
                     codes,
@@ -126,11 +126,11 @@ fn dict_bool_take(dict_array: &DictArray) -> VortexResult<Canonical> {
                         .not(),
                 ),
             )?
-            .to_canonical(),
+            .to_canonical()?,
         },
         // More than one value matches.
         _ => take(bool_values.as_ref(), codes)
             .vortex_expect("taking codes from dictionary values shouldn't fail")
-            .to_canonical(),
+            .to_canonical()?,
     })
 }

--- a/vortex-array/src/arrays/extension/vtable/canonical.rs
+++ b/vortex-array/src/arrays/extension/vtable/canonical.rs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_error::VortexResult;
+
 use crate::Canonical;
 use crate::arrays::extension::ExtensionArray;
 use crate::arrays::extension::ExtensionVTable;
 use crate::vtable::CanonicalVTable;
 
 impl CanonicalVTable<ExtensionVTable> for ExtensionVTable {
-    fn canonicalize(array: &ExtensionArray) -> Canonical {
-        Canonical::Extension(array.clone())
+    fn canonicalize(array: &ExtensionArray) -> VortexResult<Canonical> {
+        Ok(Canonical::Extension(array.clone()))
     }
 }

--- a/vortex-array/src/arrays/filter/execute.rs
+++ b/vortex-array/src/arrays/filter/execute.rs
@@ -138,6 +138,7 @@ fn filter_listview(array: &ListViewArray, mask: &Mask) -> ListViewArray {
         .as_::<ListViewVTable>()
         .clone()
         .rebuild(ListViewRebuildMode::MakeZeroCopyToList)
+        .vortex_expect("rebuild listview array")
 }
 
 fn filter_fixed_size_list(array: &FixedSizeListArray, mask: &Mask) -> FixedSizeListArray {

--- a/vortex-array/src/arrays/filter/vtable.rs
+++ b/vortex-array/src/arrays/filter/vtable.rs
@@ -198,9 +198,8 @@ impl BaseArrayVTable<FilterVTable> for FilterVTable {
 }
 
 impl CanonicalVTable<FilterVTable> for FilterVTable {
-    fn canonicalize(array: &FilterArray) -> Canonical {
+    fn canonicalize(array: &FilterArray) -> VortexResult<Canonical> {
         FilterVTable::execute(array, &mut LEGACY_SESSION.create_execution_ctx())
-            .vortex_expect("Canonicalize should be fallible")
     }
 }
 

--- a/vortex-array/src/arrays/fixed_size_list/vtable/canonical.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/canonical.rs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_error::VortexResult;
+
 use crate::Canonical;
 use crate::arrays::FixedSizeListArray;
 use crate::arrays::FixedSizeListVTable;
 use crate::vtable::CanonicalVTable;
 
 impl CanonicalVTable<FixedSizeListVTable> for FixedSizeListVTable {
-    fn canonicalize(array: &FixedSizeListArray) -> Canonical {
-        Canonical::FixedSizeList(array.clone())
+    fn canonicalize(array: &FixedSizeListArray) -> VortexResult<Canonical> {
+        Ok(Canonical::FixedSizeList(array.clone()))
     }
 }

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -290,7 +290,7 @@ impl ListArray {
     pub fn reset_offsets(&self, recurse: bool) -> VortexResult<Self> {
         let mut elements = self.sliced_elements();
         if recurse && elements.is_canonical() {
-            elements = elements.to_canonical().compact()?.into_array();
+            elements = elements.to_canonical()?.compact()?.into_array();
         } else if recurse && let Some(child_list_array) = elements.as_opt::<ListVTable>() {
             elements = child_list_array.reset_offsets(recurse)?.into_array();
         }

--- a/vortex-array/src/arrays/list/vtable/canonical.rs
+++ b/vortex-array/src/arrays/list/vtable/canonical.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_error::VortexResult;
+
 use crate::Canonical;
 use crate::arrays::ListArray;
 use crate::arrays::ListVTable;
@@ -8,7 +10,7 @@ use crate::arrays::list_view_from_list;
 use crate::vtable::CanonicalVTable;
 
 impl CanonicalVTable<ListVTable> for ListVTable {
-    fn canonicalize(array: &ListArray) -> Canonical {
-        Canonical::List(list_view_from_list(array.clone()))
+    fn canonicalize(array: &ListArray) -> VortexResult<Canonical> {
+        Ok(Canonical::List(list_view_from_list(array.clone())))
     }
 }

--- a/vortex-array/src/arrays/list/vtable/kernel/filter.rs
+++ b/vortex-array/src/arrays/list/vtable/kernel/filter.rs
@@ -68,7 +68,7 @@ impl ExecuteParentKernel<ListVTable> for ListFilterKernel {
                     0,
                 );
                 vec.append_nulls(selection.true_count());
-                return Ok(Some(vec.freeze().into_array(array.dtype()).to_canonical()));
+                return Ok(Some(vec.freeze().into_array(array.dtype()).to_canonical()?));
             }
             Validity::Array(a) => a
                 .filter(parent.filter_mask().clone())?
@@ -123,7 +123,7 @@ impl ExecuteParentKernel<ListVTable> for ListFilterKernel {
                 )
             }
             .into_array(array.dtype())
-            .to_canonical(),
+            .to_canonical()?,
         ))
     }
 }

--- a/vortex-array/src/arrays/listview/compute/filter.rs
+++ b/vortex-array/src/arrays/listview/compute/filter.rs
@@ -69,7 +69,7 @@ impl FilterKernel for ListViewVTable {
         // right now, so we will just rebuild every time (similar to `ListArray`).
 
         Ok(new_array
-            .rebuild(ListViewRebuildMode::MakeZeroCopyToList)
+            .rebuild(ListViewRebuildMode::MakeZeroCopyToList)?
             .into_array())
     }
 }

--- a/vortex-array/src/arrays/listview/compute/take.rs
+++ b/vortex-array/src/arrays/listview/compute/take.rs
@@ -87,7 +87,7 @@ impl TakeKernel for ListViewVTable {
         // right now, so we will just rebuild every time (similar to `ListArray`).
 
         Ok(new_array
-            .rebuild(ListViewRebuildMode::MakeZeroCopyToList)
+            .rebuild(ListViewRebuildMode::MakeZeroCopyToList)?
             .into_array())
     }
 }

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -7,6 +7,7 @@ use vortex_dtype::IntegerPType;
 use vortex_dtype::Nullability;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
 
 use crate::Array;
 use crate::ArrayRef;
@@ -102,9 +103,9 @@ fn build_sizes_from_offsets<O: IntegerPType>(list: &ListArray) -> ArrayRef {
 ///
 /// Otherwise, this function fall back to the (very) expensive path and will rebuild the
 /// [`ListArray`] from scratch.
-pub fn list_from_list_view(list_view: ListViewArray) -> ListArray {
+pub fn list_from_list_view(list_view: ListViewArray) -> VortexResult<ListArray> {
     // Rebuild as zero-copyable to list array and also trim all leading and trailing elements.
-    let zctl_array = list_view.rebuild(ListViewRebuildMode::MakeExact);
+    let zctl_array = list_view.rebuild(ListViewRebuildMode::MakeExact)?;
     debug_assert!(zctl_array.is_zero_copy_to_list());
 
     let list_offsets = match_each_integer_ptype!(zctl_array.offsets().dtype().as_ptype(), |O| {
@@ -116,13 +117,13 @@ pub fn list_from_list_view(list_view: ListViewArray) -> ListArray {
     // SAFETY: Because the shape of the `ListViewArray` is zero-copyable to a `ListArray`, we
     // can simply reuse all of the data (besides the offsets). We also trim all of the elements to
     // make it easier for the caller to use the `ListArray`.
-    unsafe {
+    Ok(unsafe {
         ListArray::new_unchecked(
             zctl_array.elements().clone(),
             list_offsets,
             zctl_array.validity().clone(),
         )
-    }
+    })
 }
 
 // TODO(connor)[ListView]: We can optimize this by always keeping extra memory in `ListViewArray`
@@ -177,16 +178,16 @@ unsafe fn build_list_offsets_from_list_view<O: IntegerPType>(
 /// Recursively converts all [`ListViewArray`]s to [`ListArray`]s in a nested array structure.
 ///
 /// The conversion happens bottom-up, processing children before parents.
-pub fn recursive_list_from_list_view(array: ArrayRef) -> ArrayRef {
+pub fn recursive_list_from_list_view(array: ArrayRef) -> VortexResult<ArrayRef> {
     if !array.dtype().is_nested() {
-        return array;
+        return Ok(array);
     }
 
-    let canonical = array.to_canonical();
+    let canonical = array.to_canonical()?;
 
-    match canonical {
+    Ok(match canonical {
         Canonical::List(listview) => {
-            let converted_elements = recursive_list_from_list_view(listview.elements().clone());
+            let converted_elements = recursive_list_from_list_view(listview.elements().clone())?;
             debug_assert_eq!(converted_elements.len(), listview.elements().len());
 
             // Avoid cloning if elements didn't change.
@@ -208,12 +209,12 @@ pub fn recursive_list_from_list_view(array: ArrayRef) -> ArrayRef {
                 };
 
             // Make the conversion to `ListArray`.
-            let list_array = list_from_list_view(listview_with_converted_elements);
+            let list_array = list_from_list_view(listview_with_converted_elements)?;
             list_array.into_array()
         }
         Canonical::FixedSizeList(fixed_size_list) => {
             let converted_elements =
-                recursive_list_from_list_view(fixed_size_list.elements().clone());
+                recursive_list_from_list_view(fixed_size_list.elements().clone())?;
 
             // Avoid cloning if elements didn't change.
             if !Arc::ptr_eq(&converted_elements, fixed_size_list.elements()) {
@@ -237,7 +238,7 @@ pub fn recursive_list_from_list_view(array: ArrayRef) -> ArrayRef {
             let mut any_changed = false;
 
             for field in fields.iter() {
-                let converted_field = recursive_list_from_list_view(field.clone());
+                let converted_field = recursive_list_from_list_view(field.clone())?;
                 // Avoid cloning if elements didn't change.
                 any_changed |= !Arc::ptr_eq(&converted_field, field);
                 converted_fields.push(converted_field);
@@ -257,7 +258,7 @@ pub fn recursive_list_from_list_view(array: ArrayRef) -> ArrayRef {
             }
         }
         Canonical::Extension(ext_array) => {
-            let converted_storage = recursive_list_from_list_view(ext_array.storage().clone());
+            let converted_storage = recursive_list_from_list_view(ext_array.storage().clone())?;
 
             // Avoid cloning if elements didn't change.
             if !Arc::ptr_eq(&converted_storage, ext_array.storage()) {
@@ -267,7 +268,7 @@ pub fn recursive_list_from_list_view(array: ArrayRef) -> ArrayRef {
             }
         }
         _ => unreachable!(),
-    }
+    })
 }
 
 #[cfg(test)]
@@ -276,6 +277,7 @@ mod tests {
 
     use vortex_buffer::buffer;
     use vortex_dtype::FieldNames;
+    use vortex_error::VortexResult;
 
     use super::super::tests::common::create_basic_listview;
     use super::super::tests::common::create_empty_lists_listview;
@@ -322,9 +324,9 @@ mod tests {
     }
 
     #[test]
-    fn test_listview_to_list_zero_copy() {
+    fn test_listview_to_list_zero_copy() -> VortexResult<()> {
         let list_view = create_basic_listview();
-        let list_array = list_from_list_view(list_view.clone());
+        let list_array = list_from_list_view(list_view.clone())?;
 
         // Should have same elements.
         assert_arrays_eq!(list_view.elements().clone(), list_array.elements().clone());
@@ -336,10 +338,11 @@ mod tests {
 
         // Verify data integrity.
         assert_arrays_eq!(list_view, list_array);
+        Ok(())
     }
 
     #[test]
-    fn test_empty_array_conversions() {
+    fn test_empty_array_conversions() -> VortexResult<()> {
         // Empty ListArray to ListViewArray.
         let empty_elements = PrimitiveArray::from_iter::<[i32; 0]>([]).into_array();
         let empty_offsets = buffer![0u32].into_array();
@@ -353,15 +356,16 @@ mod tests {
         assert_eq!(empty_list_view.len(), 0);
 
         // Convert back.
-        let converted_back = list_from_list_view(empty_list_view);
+        let converted_back = list_from_list_view(empty_list_view)?;
         assert_eq!(converted_back.len(), 0);
         // For empty arrays, we can't use assert_arrays_eq directly since the offsets might differ.
         // Just check that it's empty.
         assert_eq!(empty_list.len(), converted_back.len());
+        Ok(())
     }
 
     #[test]
-    fn test_nullable_conversions() {
+    fn test_nullable_conversions() -> VortexResult<()> {
         // Create nullable ListArray: [[10,20], null, [50]].
         let elements = buffer![10i32, 20, 30, 40, 50].into_array();
         let offsets = buffer![0u32, 2, 4, 5].into_array();
@@ -376,15 +380,16 @@ mod tests {
         assert_eq!(nullable_list_view.len(), 3);
 
         // Round-trip conversion.
-        let converted_back = list_from_list_view(nullable_list_view);
+        let converted_back = list_from_list_view(nullable_list_view)?;
         assert_arrays_eq!(nullable_list, converted_back);
+        Ok(())
     }
 
     #[test]
-    fn test_non_zero_copy_listview_to_list() {
+    fn test_non_zero_copy_listview_to_list() -> VortexResult<()> {
         // Create ListViewArray with overlapping lists (not zero-copyable).
         let list_view = create_overlapping_listview();
-        let list_array = list_from_list_view(list_view.clone());
+        let list_array = list_from_list_view(list_view.clone())?;
 
         // The resulting ListArray should have monotonic offsets.
         for i in 0..list_array.len() {
@@ -395,14 +400,15 @@ mod tests {
 
         // The data should still be correct even though it required a rebuild.
         assert_arrays_eq!(list_view, list_array);
+        Ok(())
     }
 
     #[test]
-    fn test_empty_sublists() {
+    fn test_empty_sublists() -> VortexResult<()> {
         let empty_lists_view = create_empty_lists_listview();
 
         // Convert to ListArray.
-        let list_array = list_from_list_view(empty_lists_view.clone());
+        let list_array = list_from_list_view(empty_lists_view.clone())?;
         assert_eq!(list_array.len(), 4);
 
         // All sublists should be empty.
@@ -413,6 +419,7 @@ mod tests {
         // Round-trip.
         let converted_back = list_view_from_list(list_array);
         assert_arrays_eq!(empty_lists_view, converted_back);
+        Ok(())
     }
 
     #[test]
@@ -444,29 +451,30 @@ mod tests {
     }
 
     #[test]
-    fn test_round_trip_conversions() {
+    fn test_round_trip_conversions() -> VortexResult<()> {
         // Test 1: Basic round-trip.
         let original = create_basic_listview();
-        let to_list = list_from_list_view(original.clone());
+        let to_list = list_from_list_view(original.clone())?;
         let back_to_view = list_view_from_list(to_list);
         assert_arrays_eq!(original, back_to_view);
 
         // Test 2: Nullable round-trip.
         let nullable = create_nullable_listview();
-        let nullable_to_list = list_from_list_view(nullable.clone());
+        let nullable_to_list = list_from_list_view(nullable.clone())?;
         let nullable_back = list_view_from_list(nullable_to_list);
         assert_arrays_eq!(nullable, nullable_back);
 
         // Test 3: Non-zero-copyable round-trip.
         let overlapping = create_overlapping_listview();
 
-        let overlapping_to_list = list_from_list_view(overlapping.clone());
+        let overlapping_to_list = list_from_list_view(overlapping.clone())?;
         let overlapping_back = list_view_from_list(overlapping_to_list);
         assert_arrays_eq!(overlapping, overlapping_back);
+        Ok(())
     }
 
     #[test]
-    fn test_single_element_lists() {
+    fn test_single_element_lists() -> VortexResult<()> {
         // Create lists with single elements: [[100], [200], [300]].
         let elements = buffer![100i32, 200, 300].into_array();
         let offsets = buffer![0u32, 1, 2, 3].into_array();
@@ -481,12 +489,13 @@ mod tests {
         assert_arrays_eq!(expected_sizes, list_view.sizes().clone());
 
         // Round-trip.
-        let converted_back = list_from_list_view(list_view);
+        let converted_back = list_from_list_view(list_view)?;
         assert_arrays_eq!(single_elem_list, converted_back);
+        Ok(())
     }
 
     #[test]
-    fn test_mixed_empty_and_non_empty_lists() {
+    fn test_mixed_empty_and_non_empty_lists() -> VortexResult<()> {
         // Create: [[1,2], [], [3], [], [4,5,6]].
         let elements = buffer![1i32, 2, 3, 4, 5, 6].into_array();
         let offsets = buffer![0u32, 2, 2, 3, 3, 6].into_array();
@@ -501,21 +510,23 @@ mod tests {
         assert_arrays_eq!(expected_sizes, list_view.sizes().clone());
 
         // Round-trip.
-        let converted_back = list_from_list_view(list_view);
+        let converted_back = list_from_list_view(list_view)?;
         assert_arrays_eq!(mixed_list, converted_back);
+        Ok(())
     }
 
     #[test]
-    fn test_recursive_simple_listview() {
+    fn test_recursive_simple_listview() -> VortexResult<()> {
         let list_view = create_basic_listview();
-        let result = recursive_list_from_list_view(list_view.clone().into_array());
+        let result = recursive_list_from_list_view(list_view.clone().into_array())?;
 
         assert_eq!(result.len(), list_view.len());
         assert_arrays_eq!(list_view.into_array(), result);
+        Ok(())
     }
 
     #[test]
-    fn test_recursive_nested_listview() {
+    fn test_recursive_nested_listview() -> VortexResult<()> {
         let inner_elements = buffer![1i32, 2, 3].into_array();
         let inner_offsets = buffer![0u32, 2].into_array();
         let inner_sizes = buffer![2u32, 1].into_array();
@@ -541,14 +552,15 @@ mod tests {
             .with_zero_copy_to_list(true)
         };
 
-        let result = recursive_list_from_list_view(outer_listview.clone().into_array());
+        let result = recursive_list_from_list_view(outer_listview.clone().into_array())?;
 
         assert_eq!(result.len(), 2);
         assert_arrays_eq!(outer_listview.into_array(), result);
+        Ok(())
     }
 
     #[test]
-    fn test_recursive_struct_with_listview_fields() {
+    fn test_recursive_struct_with_listview_fields() -> VortexResult<()> {
         let listview_field = create_basic_listview().into_array();
         let primitive_field = buffer![10i32, 20, 30, 40].into_array();
 
@@ -560,14 +572,15 @@ mod tests {
         )
         .unwrap();
 
-        let result = recursive_list_from_list_view(struct_array.clone().into_array());
+        let result = recursive_list_from_list_view(struct_array.clone().into_array())?;
 
         assert_eq!(result.len(), 4);
         assert_arrays_eq!(struct_array.into_array(), result);
+        Ok(())
     }
 
     #[test]
-    fn test_recursive_fixed_size_list_with_listview_elements() {
+    fn test_recursive_fixed_size_list_with_listview_elements() -> VortexResult<()> {
         let lv1_elements = buffer![1i32, 2].into_array();
         let lv1_offsets = buffer![0u32].into_array();
         let lv1_sizes = buffer![2u32].into_array();
@@ -602,14 +615,15 @@ mod tests {
         let fixed_list =
             FixedSizeListArray::new(chunked_listviews.into_array(), 1, Validity::NonNullable, 2);
 
-        let result = recursive_list_from_list_view(fixed_list.clone().into_array());
+        let result = recursive_list_from_list_view(fixed_list.clone().into_array())?;
 
         assert_eq!(result.len(), 2);
         assert_arrays_eq!(fixed_list.into_array(), result);
+        Ok(())
     }
 
     #[test]
-    fn test_recursive_deep_nesting() {
+    fn test_recursive_deep_nesting() -> VortexResult<()> {
         let innermost_elements = buffer![1i32, 2, 3].into_array();
         let innermost_offsets = buffer![0u32, 2].into_array();
         let innermost_sizes = buffer![2u32, 1].into_array();
@@ -643,25 +657,27 @@ mod tests {
             .with_zero_copy_to_list(true)
         };
 
-        let result = recursive_list_from_list_view(outer_listview.clone().into_array());
+        let result = recursive_list_from_list_view(outer_listview.clone().into_array())?;
 
         assert_eq!(result.len(), 2);
         assert_arrays_eq!(outer_listview.into_array(), result);
+        Ok(())
     }
 
     #[test]
-    fn test_recursive_primitive_unchanged() {
+    fn test_recursive_primitive_unchanged() -> VortexResult<()> {
         let prim = buffer![1i32, 2, 3].into_array();
         let prim_clone = prim.clone();
-        let result = recursive_list_from_list_view(prim);
+        let result = recursive_list_from_list_view(prim)?;
 
         assert!(Arc::ptr_eq(&result, &prim_clone));
+        Ok(())
     }
 
     #[test]
-    fn test_recursive_mixed_listview_and_list() {
+    fn test_recursive_mixed_listview_and_list() -> VortexResult<()> {
         let listview = create_basic_listview();
-        let list = list_from_list_view(listview.clone());
+        let list = list_from_list_view(listview.clone())?;
 
         let struct_array = StructArray::try_new(
             FieldNames::from(["listview_field", "list_field"]),
@@ -671,9 +687,10 @@ mod tests {
         )
         .unwrap();
 
-        let result = recursive_list_from_list_view(struct_array.clone().into_array());
+        let result = recursive_list_from_list_view(struct_array.clone().into_array())?;
 
         assert_eq!(result.len(), 4);
         assert_arrays_eq!(struct_array.into_array(), result);
+        Ok(())
     }
 }

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -7,6 +7,7 @@ use vortex_dtype::IntegerPType;
 use vortex_dtype::Nullability;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
 use vortex_scalar::Scalar;
 
 use crate::Array;
@@ -51,14 +52,14 @@ pub enum ListViewRebuildMode {
 
 impl ListViewArray {
     /// Rebuilds the [`ListViewArray`] according to the specified mode.
-    pub fn rebuild(&self, mode: ListViewRebuildMode) -> ListViewArray {
+    pub fn rebuild(&self, mode: ListViewRebuildMode) -> VortexResult<ListViewArray> {
         if self.is_empty() {
-            return self.clone();
+            return Ok(self.clone());
         }
 
         match mode {
             ListViewRebuildMode::MakeZeroCopyToList => self.rebuild_zero_copy_to_list(),
-            ListViewRebuildMode::TrimElements => self.rebuild_trim_elements(),
+            ListViewRebuildMode::TrimElements => Ok(self.rebuild_trim_elements()),
             ListViewRebuildMode::MakeExact => self.rebuild_make_exact(),
             ListViewRebuildMode::OverlapCompression => unimplemented!("Does P=NP?"),
         }
@@ -71,10 +72,10 @@ impl ListViewArray {
     /// a [`ListArray`].
     ///
     /// [`ListArray`]: crate::arrays::ListArray
-    fn rebuild_zero_copy_to_list(&self) -> ListViewArray {
+    fn rebuild_zero_copy_to_list(&self) -> VortexResult<ListViewArray> {
         if self.is_zero_copy_to_list() {
             // Note that since everything in `ListViewArray` is `Arc`ed, this is quite cheap.
-            return self.clone();
+            return Ok(self.clone());
         }
 
         let offsets_ptype = self.offsets().dtype().as_ptype();
@@ -108,7 +109,7 @@ impl ListViewArray {
     /// by piece.
     fn naive_rebuild<O: IntegerPType, NewOffset: IntegerPType, S: IntegerPType>(
         &self,
-    ) -> ListViewArray {
+    ) -> VortexResult<ListViewArray> {
         let element_dtype = self
             .dtype()
             .as_list_element_opt()
@@ -129,7 +130,11 @@ impl ListViewArray {
         let mut new_sizes = BufferMut::<S>::with_capacity(len);
 
         // Canonicalize the elements up front as we will be slicing the elements quite a lot.
-        let elements_canonical = self.elements().to_canonical().into_array();
+        let elements_canonical = self
+            .elements()
+            .to_canonical()
+            .vortex_expect("canonicalize elements for rebuild")
+            .into_array();
 
         // Note that we do not know what the exact capacity should be of the new elements since
         // there could be overlaps in the existing `ListViewArray`.
@@ -177,10 +182,10 @@ impl ListViewArray {
         // - The validity array is preserved from the original array unchanged
         // - The array satisfies the zero-copy-to-list property by having sorted offsets, no gaps,
         //   and no overlaps.
-        unsafe {
+        Ok(unsafe {
             ListViewArray::new_unchecked(elements, offsets, sizes, self.validity.clone())
                 .with_zero_copy_to_list(true)
-        }
+        })
     }
 
     /// Rebuilds a [`ListViewArray`] by trimming any unused / unreferenced leading and trailing
@@ -245,9 +250,9 @@ impl ListViewArray {
         }
     }
 
-    fn rebuild_make_exact(&self) -> ListViewArray {
+    fn rebuild_make_exact(&self) -> VortexResult<ListViewArray> {
         if self.is_zero_copy_to_list() {
-            self.rebuild_trim_elements()
+            Ok(self.rebuild_trim_elements())
         } else {
             // When we completely rebuild the `ListViewArray`, we get the benefit that we also trim
             // any leading and trailing garbage data.
@@ -260,6 +265,7 @@ impl ListViewArray {
 mod tests {
     use vortex_buffer::BitBuffer;
     use vortex_dtype::Nullability;
+    use vortex_error::VortexResult;
 
     use super::ListViewRebuildMode;
     use crate::IntoArray;
@@ -271,7 +277,7 @@ mod tests {
     use crate::vtable::ValidityHelper;
 
     #[test]
-    fn test_rebuild_flatten_removes_overlaps() {
+    fn test_rebuild_flatten_removes_overlaps() -> VortexResult<()> {
         // Create a list view with overlapping lists: [A, B, C]
         // List 0: offset=0, size=3 -> [A, B, C]
         // List 1: offset=1, size=2 -> [B, C] (overlaps with List 0)
@@ -281,7 +287,7 @@ mod tests {
 
         let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable);
 
-        let flattened = listview.rebuild(ListViewRebuildMode::MakeZeroCopyToList);
+        let flattened = listview.rebuild(ListViewRebuildMode::MakeZeroCopyToList)?;
 
         // After flatten: elements should be [A, B, C, B, C] = [1, 2, 3, 2, 3]
         // Lists should be sequential with no overlaps
@@ -303,10 +309,11 @@ mod tests {
             flattened.list_elements_at(1),
             PrimitiveArray::from_iter([2i32, 3])
         );
+        Ok(())
     }
 
     #[test]
-    fn test_rebuild_flatten_with_nullable() {
+    fn test_rebuild_flatten_with_nullable() -> VortexResult<()> {
         use crate::arrays::BoolArray;
 
         // Create a nullable list view with a null list
@@ -323,7 +330,7 @@ mod tests {
 
         let listview = ListViewArray::new(elements, offsets, sizes, validity);
 
-        let flattened = listview.rebuild(ListViewRebuildMode::MakeZeroCopyToList);
+        let flattened = listview.rebuild(ListViewRebuildMode::MakeZeroCopyToList)?;
 
         // Verify nullability is preserved
         assert_eq!(flattened.dtype().nullability(), Nullability::Nullable);
@@ -341,10 +348,11 @@ mod tests {
             flattened.list_elements_at(2),
             PrimitiveArray::from_iter([3i32])
         );
+        Ok(())
     }
 
     #[test]
-    fn test_rebuild_trim_elements_basic() {
+    fn test_rebuild_trim_elements_basic() -> VortexResult<()> {
         // Test trimming both leading and trailing unused elements while preserving gaps in the
         // middle.
         // Elements: [_, _, A, B, _, C, D, _, _]
@@ -359,7 +367,7 @@ mod tests {
 
         let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable);
 
-        let trimmed = listview.rebuild(ListViewRebuildMode::TrimElements);
+        let trimmed = listview.rebuild(ListViewRebuildMode::TrimElements)?;
 
         // After trimming: elements should be [A, B, _, C, D] = [1, 2, 97, 3, 4].
         assert_eq!(trimmed.elements().len(), 5);
@@ -384,10 +392,11 @@ mod tests {
         // Note that element at index 2 (97) is preserved as a gap.
         let all_elements = trimmed.elements().to_primitive();
         assert_eq!(all_elements.scalar_at(2), 97i32.into());
+        Ok(())
     }
 
     #[test]
-    fn test_rebuild_with_trailing_nulls_regression() {
+    fn test_rebuild_with_trailing_nulls_regression() -> VortexResult<()> {
         // Regression test for issue #5412
         // Tests that zero-copy-to-list arrays with trailing NULLs correctly calculate
         // offsets for NULL items to maintain no-overlap invariant
@@ -401,7 +410,7 @@ mod tests {
         let listview = ListViewArray::new(elements, offsets, sizes, validity);
 
         // First rebuild to make it zero-copy-to-list
-        let rebuilt = listview.rebuild(ListViewRebuildMode::MakeZeroCopyToList);
+        let rebuilt = listview.rebuild(ListViewRebuildMode::MakeZeroCopyToList)?;
         assert!(rebuilt.is_zero_copy_to_list());
 
         // Verify NULL items have correct offsets (should not reuse previous offsets)
@@ -419,7 +428,7 @@ mod tests {
 
         // Now rebuild with MakeExact (which calls naive_rebuild then trim_elements)
         // This should not panic (issue #5412)
-        let exact = rebuilt.rebuild(ListViewRebuildMode::MakeExact);
+        let exact = rebuilt.rebuild(ListViewRebuildMode::MakeExact)?;
 
         // Verify the result is still valid
         assert!(exact.is_valid(0));
@@ -437,5 +446,6 @@ mod tests {
             exact.list_elements_at(1),
             PrimitiveArray::from_iter([3i32, 4])
         );
+        Ok(())
     }
 }

--- a/vortex-array/src/arrays/listview/vtable/canonical.rs
+++ b/vortex-array/src/arrays/listview/vtable/canonical.rs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_error::VortexResult;
+
 use crate::Canonical;
 use crate::arrays::ListViewArray;
 use crate::arrays::ListViewVTable;
 use crate::vtable::CanonicalVTable;
 
 impl CanonicalVTable<ListViewVTable> for ListViewVTable {
-    fn canonicalize(array: &ListViewArray) -> Canonical {
-        Canonical::List(array.clone())
+    fn canonicalize(array: &ListViewArray) -> VortexResult<Canonical> {
+        Ok(Canonical::List(array.clone()))
     }
 }

--- a/vortex-array/src/arrays/masked/execute.rs
+++ b/vortex-array/src/arrays/masked/execute.rs
@@ -7,6 +7,7 @@ use std::ops::BitAnd;
 
 use vortex_dtype::Nullability;
 use vortex_dtype::match_each_decimal_value_type;
+use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
 use crate::Canonical;
@@ -28,8 +29,11 @@ use crate::vtable::ValidityHelper;
 ///
 /// This is the core operation for MaskedArray execution - it intersects the child's
 /// validity with the provided mask, marking additional positions as invalid.
-pub fn mask_validity_canonical(canonical: Canonical, validity_mask: &Mask) -> Canonical {
-    match canonical {
+pub fn mask_validity_canonical(
+    canonical: Canonical,
+    validity_mask: &Mask,
+) -> VortexResult<Canonical> {
+    Ok(match canonical {
         Canonical::Null(a) => Canonical::Null(mask_validity_null(a, validity_mask)),
         Canonical::Bool(a) => Canonical::Bool(mask_validity_bool(a, validity_mask)),
         Canonical::Primitive(a) => Canonical::Primitive(mask_validity_primitive(a, validity_mask)),
@@ -42,8 +46,8 @@ pub fn mask_validity_canonical(canonical: Canonical, validity_mask: &Mask) -> Ca
             Canonical::FixedSizeList(mask_validity_fixed_size_list(a, validity_mask))
         }
         Canonical::Struct(a) => Canonical::Struct(mask_validity_struct(a, validity_mask)),
-        Canonical::Extension(a) => Canonical::Extension(mask_validity_extension(a, validity_mask)),
-    }
+        Canonical::Extension(a) => Canonical::Extension(mask_validity_extension(a, validity_mask)?),
+    })
 }
 
 fn combine_validity(validity: &Validity, mask: &Mask, len: usize) -> Validity {
@@ -137,9 +141,12 @@ fn mask_validity_struct(array: StructArray, mask: &Mask) -> StructArray {
     unsafe { StructArray::new_unchecked(fields, struct_fields, len, new_validity) }
 }
 
-fn mask_validity_extension(array: ExtensionArray, mask: &Mask) -> ExtensionArray {
+fn mask_validity_extension(array: ExtensionArray, mask: &Mask) -> VortexResult<ExtensionArray> {
     // For extension arrays, we need to mask the underlying storage
-    let storage = array.storage().to_canonical();
-    let masked_storage = mask_validity_canonical(storage, mask);
-    ExtensionArray::new(array.ext_dtype().clone(), masked_storage.into_array())
+    let storage = array.storage().to_canonical()?;
+    let masked_storage = mask_validity_canonical(storage, mask)?;
+    Ok(ExtensionArray::new(
+        array.ext_dtype().clone(),
+        masked_storage.into_array(),
+    ))
 }

--- a/vortex-array/src/arrays/masked/tests.rs
+++ b/vortex-array/src/arrays/masked/tests.rs
@@ -4,6 +4,7 @@
 use rstest::rstest;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
+use vortex_error::VortexResult;
 
 use super::*;
 use crate::Array;
@@ -37,13 +38,14 @@ fn test_dtype_nullability_with_nullable_child() {
 }
 
 #[test]
-fn test_canonical_dtype_matches_array_dtype() {
+fn test_canonical_dtype_matches_array_dtype() -> VortexResult<()> {
     // The canonical form should have the same nullability as the array's dtype.
     let child = PrimitiveArray::from_iter([1i32, 2, 3]).into_array();
     let array = MaskedArray::try_new(child, Validity::AllValid).unwrap();
 
-    let canonical = array.to_canonical();
+    let canonical = array.to_canonical()?;
     assert_eq!(canonical.as_ref().dtype(), array.dtype());
+    Ok(())
 }
 
 #[test]

--- a/vortex-array/src/arrays/masked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/masked/vtable/canonical.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
 
 use crate::Array;
 use crate::Canonical;
@@ -12,11 +13,11 @@ use crate::compute::mask;
 use crate::vtable::CanonicalVTable;
 
 impl CanonicalVTable<MaskedVTable> for MaskedVTable {
-    fn canonicalize(array: &MaskedArray) -> Canonical {
+    fn canonicalize(array: &MaskedArray) -> VortexResult<Canonical> {
         if array.child.is::<ConstantVTable>() {
             // To allow constant array to produce masked array from mask call, we have to unwrap constant here and canonicalize it first
             mask(
-                array.child.to_canonical().as_ref(),
+                array.child.to_canonical()?.as_ref(),
                 &!array.validity.to_mask(array.len()),
             )
             .vortex_expect("constant masked to canonical")
@@ -34,6 +35,7 @@ impl CanonicalVTable<MaskedVTable> for MaskedVTable {
 mod tests {
     use rstest::rstest;
     use vortex_dtype::Nullability;
+    use vortex_error::VortexResult;
 
     use super::*;
     use crate::IntoArray;
@@ -59,24 +61,25 @@ mod tests {
     fn test_canonical_nullability(
         #[case] array: MaskedArray,
         #[case] expected_nullability: Nullability,
-    ) {
-        let canonical = array.to_canonical();
+    ) -> VortexResult<()> {
+        let canonical = array.to_canonical()?;
         assert_eq!(
             canonical.as_ref().dtype().nullability(),
             expected_nullability
         );
         assert_eq!(canonical.as_ref().dtype(), array.dtype());
+        Ok(())
     }
 
     #[test]
-    fn test_canonical_with_nulls() {
+    fn test_canonical_with_nulls() -> VortexResult<()> {
         let array = MaskedArray::try_new(
             PrimitiveArray::from_iter([1i32, 2, 3, 4, 5]).into_array(),
             Validity::from_iter([true, false, true, false, true]),
         )
         .unwrap();
 
-        let canonical = array.to_canonical();
+        let canonical = array.to_canonical()?;
         let prim = canonical.as_ref().to_primitive();
 
         // Check that null positions match validity.
@@ -86,21 +89,23 @@ mod tests {
         assert!(prim.is_valid(2));
         assert!(!prim.is_valid(3));
         assert!(prim.is_valid(4));
+        Ok(())
     }
 
     #[test]
-    fn test_canonical_all_valid() {
+    fn test_canonical_all_valid() -> VortexResult<()> {
         let array = MaskedArray::try_new(
             PrimitiveArray::from_iter([10i32, 20, 30]).into_array(),
             Validity::AllValid,
         )
         .unwrap();
 
-        let canonical = array.to_canonical();
+        let canonical = array.to_canonical()?;
         assert_eq!(canonical.as_ref().valid_count(), 3);
         assert_eq!(
             canonical.as_ref().dtype().nullability(),
             Nullability::Nullable
         );
+        Ok(())
     }
 }

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -135,19 +135,19 @@ impl VTable for MaskedVTable {
         }
 
         let child = array.child().clone().execute::<Canonical>(ctx)?;
-        let canonical = mask_validity_canonical(child, &array.validity_mask());
+        let canonical = mask_validity_canonical(child, &array.validity_mask())?;
 
         vortex_ensure!(
-            canonical.as_ref().dtype() == array.dtype(),
+            canonical.as_ref().dtype().clone() == array.dtype().clone(),
             "Mask result dtype mismatch: expected {:?}, got {:?}",
             array.dtype(),
             canonical.as_ref().dtype()
         );
         vortex_ensure!(
-            canonical.as_ref().len() == array.len(),
+            canonical.len() == array.len(),
             "Mask result length mismatch: expected {}, got {}",
             array.len(),
-            canonical.as_ref().len()
+            canonical.len()
         );
 
         Ok(canonical)

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -138,7 +138,7 @@ impl VTable for MaskedVTable {
         let canonical = mask_validity_canonical(child, &array.validity_mask())?;
 
         vortex_ensure!(
-            canonical.as_ref().dtype().clone() == array.dtype().clone(),
+            canonical.as_ref().dtype() == array.dtype(),
             "Mask result dtype mismatch: expected {:?}, got {:?}",
             array.dtype(),
             canonical.as_ref().dtype()

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -167,8 +167,8 @@ impl VisitorVTable<NullVTable> for NullVTable {
 }
 
 impl CanonicalVTable<NullVTable> for NullVTable {
-    fn canonicalize(array: &NullArray) -> Canonical {
-        Canonical::Null(array.clone())
+    fn canonicalize(array: &NullArray) -> VortexResult<Canonical> {
+        Ok(Canonical::Null(array.clone()))
     }
 }
 

--- a/vortex-array/src/arrays/primitive/vtable/canonical.rs
+++ b/vortex-array/src/arrays/primitive/vtable/canonical.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_error::VortexResult;
+
 use crate::Canonical;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::PrimitiveVTable;
@@ -8,11 +10,15 @@ use crate::builders::ArrayBuilder;
 use crate::vtable::CanonicalVTable;
 
 impl CanonicalVTable<PrimitiveVTable> for PrimitiveVTable {
-    fn canonicalize(array: &PrimitiveArray) -> Canonical {
-        Canonical::Primitive(array.clone())
+    fn canonicalize(array: &PrimitiveArray) -> VortexResult<Canonical> {
+        Ok(Canonical::Primitive(array.clone()))
     }
 
-    fn append_to_builder(array: &PrimitiveArray, builder: &mut dyn ArrayBuilder) {
-        builder.extend_from_array(array.as_ref())
+    fn append_to_builder(
+        array: &PrimitiveArray,
+        builder: &mut dyn ArrayBuilder,
+    ) -> VortexResult<()> {
+        builder.extend_from_array(array.as_ref());
+        Ok(())
     }
 }

--- a/vortex-array/src/arrays/scalar_fn/vtable/canonical.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/canonical.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
 
 use crate::Canonical;
 use crate::LEGACY_SESSION;
@@ -12,11 +12,8 @@ use crate::vtable::CanonicalVTable;
 
 impl CanonicalVTable<ScalarFnVTable> for ScalarFnVTable {
     // TODO(joe): fixme move to execute
-    fn canonicalize(array: &ScalarFnArray) -> Canonical {
+    fn canonicalize(array: &ScalarFnArray) -> VortexResult<Canonical> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        array
-            .to_array()
-            .execute::<Canonical>(&mut ctx)
-            .vortex_expect("should handle panic")
+        array.to_array().execute::<Canonical>(&mut ctx)
     }
 }

--- a/vortex-array/src/arrays/slice/vtable.rs
+++ b/vortex-array/src/arrays/slice/vtable.rs
@@ -121,7 +121,7 @@ impl VTable for SliceVTable {
             array.dtype()
         );
         // TODO(joe): this is a downcast not a execute.
-        Ok(result.to_canonical())
+        result.to_canonical()
     }
 
     fn reduce(array: &Self::Array) -> VortexResult<Option<ArrayRef>> {
@@ -165,9 +165,8 @@ impl BaseArrayVTable<SliceVTable> for SliceVTable {
 }
 
 impl CanonicalVTable<SliceVTable> for SliceVTable {
-    fn canonicalize(array: &SliceArray) -> Canonical {
+    fn canonicalize(array: &SliceArray) -> VortexResult<Canonical> {
         SliceVTable::execute(array, &mut LEGACY_SESSION.create_execution_ctx())
-            .vortex_expect("Canonicalize should be fallible")
     }
 }
 

--- a/vortex-array/src/arrays/struct_/tests.rs
+++ b/vortex-array/src/arrays/struct_/tests.rs
@@ -7,6 +7,7 @@ use vortex_dtype::FieldName;
 use vortex_dtype::FieldNames;
 use vortex_dtype::Nullability;
 use vortex_dtype::PType;
+use vortex_error::VortexResult;
 
 use crate::Array;
 use crate::IntoArray;
@@ -132,7 +133,7 @@ fn test_duplicate_field_names() {
 }
 
 #[test]
-fn test_uncompressed_size_in_bytes() {
+fn test_uncompressed_size_in_bytes() -> VortexResult<()> {
     let struct_array = StructArray::new(
         FieldNames::from(["integers"]),
         vec![ConstantArray::new(5, 1000).into_array()],
@@ -140,11 +141,12 @@ fn test_uncompressed_size_in_bytes() {
         Validity::NonNullable,
     );
 
-    let canonical_size = struct_array.to_canonical().into_array().nbytes();
+    let canonical_size = struct_array.to_canonical()?.into_array().nbytes();
     let uncompressed_size = struct_array
         .statistics()
         .compute_uncompressed_size_in_bytes();
 
     assert_eq!(canonical_size, 2);
     assert_eq!(uncompressed_size, Some(4000));
+    Ok(())
 }

--- a/vortex-array/src/arrays/struct_/vtable/canonical.rs
+++ b/vortex-array/src/arrays/struct_/vtable/canonical.rs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_error::VortexResult;
+
 use crate::Canonical;
 use crate::arrays::struct_::StructArray;
 use crate::arrays::struct_::StructVTable;
 use crate::vtable::CanonicalVTable;
 
 impl CanonicalVTable<StructVTable> for StructVTable {
-    fn canonicalize(array: &StructArray) -> Canonical {
-        Canonical::Struct(array.clone())
+    fn canonicalize(array: &StructArray) -> VortexResult<Canonical> {
+        Ok(Canonical::Struct(array.clone()))
     }
 }

--- a/vortex-array/src/arrays/varbin/vtable/canonical.rs
+++ b/vortex-array/src/arrays/varbin/vtable/canonical.rs
@@ -9,6 +9,7 @@ use arrow_array::cast::AsArray;
 use arrow_schema::DataType;
 use vortex_dtype::DType;
 use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::Canonical;
@@ -20,7 +21,7 @@ use crate::arrow::IntoArrowArray;
 use crate::vtable::CanonicalVTable;
 
 impl CanonicalVTable<VarBinVTable> for VarBinVTable {
-    fn canonicalize(array: &VarBinArray) -> Canonical {
+    fn canonicalize(array: &VarBinArray) -> VortexResult<Canonical> {
         let dtype = array.dtype().clone();
         let nullable = dtype.is_nullable();
 
@@ -54,7 +55,9 @@ impl CanonicalVTable<VarBinVTable> for VarBinVTable {
             }
             _ => unreachable!("VarBinArray must have Utf8 or Binary dtype, instead got: {dtype}",),
         };
-        Canonical::VarBinView(ArrayRef::from_arrow(array.as_ref(), nullable).to_varbinview())
+        Ok(Canonical::VarBinView(
+            ArrayRef::from_arrow(array.as_ref(), nullable).to_varbinview(),
+        ))
     }
 }
 

--- a/vortex-array/src/arrays/varbinview/vtable/canonical.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/canonical.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_error::VortexResult;
+
 use crate::Canonical;
 use crate::arrays::VarBinViewVTable;
 use crate::arrays::varbinview::VarBinViewArray;
@@ -8,11 +10,15 @@ use crate::builders::ArrayBuilder;
 use crate::vtable::CanonicalVTable;
 
 impl CanonicalVTable<VarBinViewVTable> for VarBinViewVTable {
-    fn canonicalize(array: &VarBinViewArray) -> Canonical {
-        Canonical::VarBinView(array.clone())
+    fn canonicalize(array: &VarBinViewArray) -> VortexResult<Canonical> {
+        Ok(Canonical::VarBinView(array.clone()))
     }
 
-    fn append_to_builder(array: &VarBinViewArray, builder: &mut dyn ArrayBuilder) {
-        builder.extend_from_array(array.as_ref())
+    fn append_to_builder(
+        array: &VarBinViewArray,
+        builder: &mut dyn ArrayBuilder,
+    ) -> VortexResult<()> {
+        builder.extend_from_array(array.as_ref());
+        Ok(())
     }
 }

--- a/vortex-array/src/arrow/array.rs
+++ b/vortex-array/src/arrow/array.rs
@@ -151,7 +151,7 @@ impl BaseArrayVTable<ArrowVTable> for ArrowVTable {
 }
 
 impl CanonicalVTable<ArrowVTable> for ArrowVTable {
-    fn canonicalize(array: &ArrowArray) -> Canonical {
+    fn canonicalize(array: &ArrowArray) -> VortexResult<Canonical> {
         ArrayRef::from_arrow(array.inner.as_ref(), array.dtype.is_nullable()).to_canonical()
     }
 }

--- a/vortex-array/src/arrow/compute/to_arrow/canonical.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/canonical.rs
@@ -107,7 +107,7 @@ impl Kernel for ToArrowCanonical {
         // preferred Arrow type if the array has child arrays (struct, list, and fixed-size list).
         let to_preferred = arrow_type_opt.is_none();
 
-        let arrow_array = match (array.to_canonical(), &arrow_type) {
+        let arrow_array = match (array.to_canonical()?, &arrow_type) {
             (Canonical::Null(array), DataType::Null) => Ok(canonical_null_to_arrow(&array)),
             (Canonical::Bool(array), DataType::Boolean) => Ok(canonical_bool_to_arrow(&array)),
             (Canonical::Primitive(array), DataType::Int8) if matches!(array.ptype(), PType::I8) => {
@@ -508,7 +508,7 @@ fn to_arrow_list<O: IntegerPType + OffsetSizeTrait>(
     // Convert listview -> list, via the fast path when possible.
     // TODO(aduffy): extend list_from_list_view to support target offsets/size PTypes
     //   to avoid the copy below
-    let list_array = list_from_list_view(array);
+    let list_array = list_from_list_view(array)?;
 
     let (elements, element_field) = {
         if let Some(element_field) = element_field {

--- a/vortex-array/src/arrow/record_batch.rs
+++ b/vortex-array/src/arrow/record_batch.rs
@@ -20,7 +20,7 @@ impl TryFrom<&dyn Array> for RecordBatch {
     type Error = VortexError;
 
     fn try_from(value: &dyn Array) -> VortexResult<Self> {
-        let Canonical::Struct(struct_array) = value.to_canonical() else {
+        let Canonical::Struct(struct_array) = value.to_canonical()? else {
             vortex_bail!("RecordBatch can only be constructed from ")
         };
 

--- a/vortex-array/src/builders/bool.rs
+++ b/vortex-array/src/builders/bool.rs
@@ -146,6 +146,7 @@ mod tests {
     use rand::prelude::StdRng;
     use vortex_dtype::DType;
     use vortex_dtype::Nullability;
+    use vortex_error::VortexResult;
     use vortex_scalar::Scalar;
 
     use crate::ArrayRef;
@@ -178,19 +179,20 @@ mod tests {
     }
 
     #[test]
-    fn tests() {
+    fn tests() -> VortexResult<()> {
         let len = 1000;
         let chunk_count = 10;
         let chunk = make_opt_bool_chunks(len, chunk_count);
 
         let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
-        chunk.clone().append_to_builder(builder.as_mut());
+        chunk.clone().append_to_builder(builder.as_mut())?;
 
         let canon_into = builder.finish().to_bool();
         let into_canon = chunk.to_bool();
 
         assert_eq!(canon_into.validity(), into_canon.validity());
         assert_eq!(canon_into.bit_buffer(), into_canon.bit_buffer());
+        Ok(())
     }
 
     #[test]

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -311,7 +311,9 @@ impl<O: IntegerPType, S: IntegerPType> ArrayBuilder for ListViewBuilder<O, S> {
 
         // Otherwise, after removing any leading and trailing elements, we can simply bulk append
         // the entire array.
-        let listview = listview.rebuild(ListViewRebuildMode::MakeExact);
+        let listview = listview
+            .rebuild(ListViewRebuildMode::MakeExact)
+            .vortex_expect("rebuild should succeed");
         debug_assert!(listview.is_zero_copy_to_list());
 
         self.nulls.append_validity_mask(array.validity_mask());

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -313,7 +313,7 @@ impl<O: IntegerPType, S: IntegerPType> ArrayBuilder for ListViewBuilder<O, S> {
         // the entire array.
         let listview = listview
             .rebuild(ListViewRebuildMode::MakeExact)
-            .vortex_expect("rebuild should succeed");
+            .vortex_expect("ListViewArray::rebuild(MakeExact) failed in extend_from_array");
         debug_assert!(listview.is_zero_copy_to_list());
 
         self.nulls.append_validity_mask(array.validity_mask());

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -33,6 +33,7 @@ use std::any::Any;
 use vortex_dtype::DType;
 use vortex_dtype::match_each_decimal_value_type;
 use vortex_dtype::match_each_native_ptype;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 use vortex_mask::Mask;
@@ -212,7 +213,9 @@ pub trait ArrayBuilder: Send {
     /// then converts it to canonical form. Specific builders can override this with optimized
     /// implementations that avoid the intermediate [`Array`] creation.
     fn finish_into_canonical(&mut self) -> Canonical {
-        self.finish().to_canonical()
+        self.finish()
+            .to_canonical()
+            .vortex_expect("finish_into_canonical failed")
     }
 }
 

--- a/vortex-array/src/builders/struct_.rs
+++ b/vortex-array/src/builders/struct_.rs
@@ -169,13 +169,8 @@ impl ArrayBuilder for StructBuilder {
     unsafe fn extend_from_array_unchecked(&mut self, array: &dyn Array) {
         let array = array.to_struct();
 
-        for (a, builder) in array
-            .fields()
-            .iter()
-            .cloned()
-            .zip_eq(self.builders.iter_mut())
-        {
-            a.append_to_builder(builder.as_mut());
+        for (a, builder) in array.fields().iter().zip_eq(self.builders.iter_mut()) {
+            builder.extend_from_array(a.as_ref());
         }
 
         self.nulls.append_validity_mask(array.validity_mask());

--- a/vortex-array/src/builders/tests.rs
+++ b/vortex-array/src/builders/tests.rs
@@ -12,6 +12,7 @@ use vortex_dtype::Nullability;
 use vortex_dtype::PType;
 use vortex_dtype::StructFields;
 use vortex_dtype::half::f16;
+use vortex_error::VortexExpect;
 use vortex_scalar::Scalar;
 
 use crate::builders::ArrayBuilder;
@@ -243,7 +244,10 @@ where
 
     // Get canonical arrays using both methods.
     let canonical_direct = builder1.finish_into_canonical();
-    let canonical_indirect = builder2.finish().to_canonical();
+    let canonical_indirect = builder2
+        .finish()
+        .to_canonical()
+        .vortex_expect("to_canonical failed");
 
     // Convert both to arrays for comparison.
     let array_direct = canonical_direct.into_array();

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -776,6 +776,7 @@ impl RewritingViewAdjustment {
 mod tests {
     use vortex_dtype::DType;
     use vortex_dtype::Nullability;
+    use vortex_error::VortexResult;
 
     use crate::IntoArray;
     use crate::arrays::VarBinViewArray;
@@ -839,7 +840,7 @@ mod tests {
     }
 
     #[test]
-    fn test_buffer_deduplication() {
+    fn test_buffer_deduplication() -> VortexResult<()> {
         let array = {
             let mut builder =
                 VarBinViewBuilder::with_capacity(DType::Utf8(Nullability::Nullable), 10);
@@ -852,11 +853,11 @@ mod tests {
         let mut builder =
             VarBinViewBuilder::with_buffer_deduplication(DType::Utf8(Nullability::Nullable), 10);
 
-        array.append_to_builder(&mut builder);
+        array.append_to_builder(&mut builder)?;
         assert_eq!(builder.completed_block_count(), 1);
 
-        array.slice(1..2).append_to_builder(&mut builder);
-        array.slice(0..1).append_to_builder(&mut builder);
+        array.slice(1..2).append_to_builder(&mut builder)?;
+        array.slice(0..1).append_to_builder(&mut builder)?;
         assert_eq!(builder.completed_block_count(), 1);
 
         let array2 = {
@@ -866,12 +867,13 @@ mod tests {
             builder.finish_into_varbinview()
         };
 
-        array2.append_to_builder(&mut builder);
+        array2.append_to_builder(&mut builder)?;
         assert_eq!(builder.completed_block_count(), 2);
 
-        array.slice(0..1).append_to_builder(&mut builder);
-        array2.slice(0..1).append_to_builder(&mut builder);
+        array.slice(0..1).append_to_builder(&mut builder)?;
+        array2.slice(0..1).append_to_builder(&mut builder)?;
         assert_eq!(builder.completed_block_count(), 2);
+        Ok(())
     }
 
     #[test]

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -4,6 +4,7 @@
 //! Encodings that enable zero-copy sharing of data with Arrow.
 
 use vortex_dtype::DType;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 
@@ -143,7 +144,7 @@ impl Canonical {
         match self {
             Canonical::VarBinView(array) => Ok(Canonical::VarBinView(array.compact_buffers()?)),
             Canonical::List(array) => Ok(Canonical::List(
-                array.rebuild(ListViewRebuildMode::MakeZeroCopyToList),
+                array.rebuild(ListViewRebuildMode::MakeZeroCopyToList)?,
             )),
             _ => Ok(self.clone()),
         }
@@ -371,39 +372,57 @@ pub trait ToCanonical {
 // Blanket impl for all Array encodings.
 impl<A: Array + ?Sized> ToCanonical for A {
     fn to_null(&self) -> NullArray {
-        self.to_canonical().into_null()
+        self.to_canonical()
+            .vortex_expect("to_canonical failed")
+            .into_null()
     }
 
     fn to_bool(&self) -> BoolArray {
-        self.to_canonical().into_bool()
+        self.to_canonical()
+            .vortex_expect("to_canonical failed")
+            .into_bool()
     }
 
     fn to_primitive(&self) -> PrimitiveArray {
-        self.to_canonical().into_primitive()
+        self.to_canonical()
+            .vortex_expect("to_canonical failed")
+            .into_primitive()
     }
 
     fn to_decimal(&self) -> DecimalArray {
-        self.to_canonical().into_decimal()
+        self.to_canonical()
+            .vortex_expect("to_canonical failed")
+            .into_decimal()
     }
 
     fn to_struct(&self) -> StructArray {
-        self.to_canonical().into_struct()
+        self.to_canonical()
+            .vortex_expect("to_canonical failed")
+            .into_struct()
     }
 
     fn to_listview(&self) -> ListViewArray {
-        self.to_canonical().into_listview()
+        self.to_canonical()
+            .vortex_expect("to_canonical failed")
+            .into_listview()
     }
 
     fn to_fixed_size_list(&self) -> FixedSizeListArray {
-        self.to_canonical().into_fixed_size_list()
+        self.to_canonical()
+            .vortex_expect("to_canonical failed")
+            .into_fixed_size_list()
     }
 
     fn to_varbinview(&self) -> VarBinViewArray {
-        self.to_canonical().into_varbinview()
+        self.to_canonical()
+            .vortex_expect("to_canonical failed")
+            .into_varbinview()
     }
 
     fn to_extension(&self) -> ExtensionArray {
-        self.to_canonical().into_extension()
+        self.to_canonical()
+            .vortex_expect("to_canonical failed")
+            .into_extension()
     }
 }
 

--- a/vortex-array/src/compute/cast.rs
+++ b/vortex-array/src/compute/cast.rs
@@ -93,7 +93,7 @@ impl ComputeFnVTable for Cast {
             );
         }
 
-        Ok(cast(array.to_canonical().as_ref(), dtype)?.into())
+        Ok(cast(array.to_canonical()?.as_ref(), dtype)?.into())
     }
 
     fn return_dtype(&self, args: &InvocationArgs) -> VortexResult<DType> {

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -837,7 +837,7 @@ fn test_slice_aggregate_consistency(array: &dyn Array) {
 
     // Get sliced array and canonical slice
     let sliced = array.slice(start..end);
-    let canonical = array.to_canonical();
+    let canonical = array.to_canonical().vortex_expect("to_canonical failed");
     let canonical_sliced = canonical.as_ref().slice(start..end);
 
     // Test null count through invalid_count
@@ -926,7 +926,7 @@ fn test_cast_slice_consistency(array: &dyn Array) {
     let end = 7.min(len - 2).max(start + 1); // Ensure we have at least 1 element
 
     // Get canonical form of the original array
-    let canonical = array.to_canonical();
+    let canonical = array.to_canonical().vortex_expect("to_canonical failed");
 
     // Choose appropriate target dtype based on the array's type
     let target_dtypes = match array.dtype() {

--- a/vortex-array/src/compute/conformance/take.rs
+++ b/vortex-array/src/compute/conformance/take.rs
@@ -62,7 +62,14 @@ fn test_take_all(array: &dyn Array) {
     assert_eq!(result.dtype(), array.dtype());
 
     // Verify elements match
-    match (&array.to_canonical(), &result.to_canonical()) {
+    match (
+        array
+            .to_canonical()
+            .vortex_expect("to_canonical failed on array"),
+        result
+            .to_canonical()
+            .vortex_expect("to_canonical failed on result"),
+    ) {
         (Canonical::Primitive(orig_prim), Canonical::Primitive(result_prim)) => {
             assert_eq!(
                 orig_prim.buffer_handle().to_host(),

--- a/vortex-array/src/compute/fill_null.rs
+++ b/vortex-array/src/compute/fill_null.rs
@@ -129,7 +129,7 @@ impl ComputeFnVTable for FillNull {
 
         tracing::debug!("FillNullFn not implemented for {}", array.encoding_id());
         if !array.is_canonical() {
-            let canonical_arr = array.to_canonical().into_array();
+            let canonical_arr = array.to_canonical()?.into_array();
             return Ok(fill_null(canonical_arr.as_ref(), fill_value)?.into());
         }
 

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -135,7 +135,7 @@ impl ComputeFnVTable for Filter {
         tracing::debug!("No filter implementation found for {}", array.encoding_id(),);
 
         if !array.is_canonical() {
-            let canonical = array.to_canonical().into_array();
+            let canonical = array.to_canonical()?.into_array();
             return filter(&canonical, mask).map(Into::into);
         };
 

--- a/vortex-array/src/compute/is_constant.rs
+++ b/vortex-array/src/compute/is_constant.rs
@@ -191,7 +191,7 @@ fn is_constant_impl(
     );
 
     if options.cost == Cost::Canonicalize && !array.is_canonical() {
-        let array = array.to_canonical();
+        let array = array.to_canonical()?;
         let is_constant = is_constant_opts(array.as_ref(), options)?;
         return Ok(is_constant);
     }

--- a/vortex-array/src/compute/is_sorted.rs
+++ b/vortex-array/src/compute/is_sorted.rs
@@ -290,7 +290,7 @@ fn is_sorted_impl(
         );
 
         // Recurse to canonical implementation
-        let array = array.to_canonical();
+        let array = array.to_canonical()?;
 
         return if strict {
             is_strict_sorted(array.as_ref())

--- a/vortex-array/src/compute/min_max.rs
+++ b/vortex-array/src/compute/min_max.rs
@@ -185,7 +185,7 @@ fn min_max_impl(
     }
 
     if !array.is_canonical() {
-        let array = array.to_canonical();
+        let array = array.to_canonical()?;
         return min_max(array.as_ref());
     }
 

--- a/vortex-array/src/compute/nan_count.rs
+++ b/vortex-array/src/compute/nan_count.rs
@@ -151,7 +151,7 @@ fn nan_count_impl(array: &dyn Array, kernels: &[ArcRef<dyn Kernel>]) -> VortexRe
     }
 
     if !array.is_canonical() {
-        let canonical = array.to_canonical();
+        let canonical = array.to_canonical()?;
         return nan_count(canonical.as_ref());
     }
 

--- a/vortex-array/src/compute/sum.rs
+++ b/vortex-array/src/compute/sum.rs
@@ -264,7 +264,7 @@ pub fn sum_impl(
             array.encoding_id()
         );
     }
-    sum_with_accumulator(array.to_canonical().as_ref(), accumulator)
+    sum_with_accumulator(array.to_canonical()?.as_ref(), accumulator)
 }
 
 #[cfg(test)]

--- a/vortex-array/src/compute/take.rs
+++ b/vortex-array/src/compute/take.rs
@@ -186,7 +186,7 @@ fn take_impl(
     // Otherwise, canonicalize and try again.
     if !array.is_canonical() {
         tracing::debug!("No take implementation found for {}", array.encoding_id());
-        let canonical = array.to_canonical();
+        let canonical = array.to_canonical()?;
         return take(canonical.as_ref(), indices);
     }
 

--- a/vortex-array/src/compute/zip.rs
+++ b/vortex-array/src/compute/zip.rs
@@ -87,16 +87,16 @@ impl ComputeFnVTable for Zip {
 
         if !if_true.is_canonical() || !if_false.is_canonical() {
             return zip(
-                if_true.to_canonical().as_ref(),
-                if_false.to_canonical().as_ref(),
+                if_true.to_canonical()?.as_ref(),
+                if_false.to_canonical()?.as_ref(),
                 mask,
             )
             .map(Into::into);
         }
 
         Ok(zip_impl(
-            if_true.to_canonical().as_ref(),
-            if_false.to_canonical().as_ref(),
+            if_true.to_canonical()?.as_ref(),
+            if_false.to_canonical()?.as_ref(),
             mask,
         )?
         .into())

--- a/vortex-array/src/vtable/canonical.rs
+++ b/vortex-array/src/vtable/canonical.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_error::vortex_panic;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
 
 use crate::Canonical;
 use crate::builders::ArrayBuilder;
@@ -15,21 +16,22 @@ pub trait CanonicalVTable<V: VTable> {
     /// - The length is equal to that of the input array.
     /// - The [`vortex_dtype::DType`] is equal to that of the input array.
     // TODO(ngates): rename to `decode`
-    fn canonicalize(array: &V::Array) -> Canonical;
+    fn canonicalize(array: &V::Array) -> VortexResult<Canonical>;
 
     /// Writes the array into a canonical builder.
     ///
     /// ## Post-conditions
     /// - The length of the builder is incremented by the length of the input array.
-    fn append_to_builder(array: &V::Array, builder: &mut dyn ArrayBuilder) {
-        let canonical = Self::canonicalize(array);
-        builder.extend_from_array(canonical.as_ref())
+    fn append_to_builder(array: &V::Array, builder: &mut dyn ArrayBuilder) -> VortexResult<()> {
+        let canonical = Self::canonicalize(array)?;
+        builder.extend_from_array(canonical.as_ref());
+        Ok(())
     }
 }
 
 impl<V: VTable> CanonicalVTable<V> for NotSupported {
-    fn canonicalize(array: &V::Array) -> Canonical {
-        vortex_panic!(
+    fn canonicalize(array: &V::Array) -> VortexResult<Canonical> {
+        vortex_bail!(
             "Legacy canonicalize is not supported for {} arrays",
             array.encoding_id()
         )

--- a/vortex-array/src/vtable/dyn_.rs
+++ b/vortex-array/src/vtable/dyn_.rs
@@ -283,7 +283,7 @@ fn downcast<V: VTable>(array: &ArrayRef) -> &V::Array {
     array
         .as_any()
         .downcast_ref::<ArrayAdapter<V>>()
-        .vortex_expect("Invalid options type for expression")
+        .vortex_expect("Failed to downcast array to expected encoding type")
         .as_inner()
 }
 

--- a/vortex-array/src/vtable/mod.rs
+++ b/vortex-array/src/vtable/mod.rs
@@ -145,7 +145,7 @@ pub trait VTable: 'static + Sized + Send + Sync + Debug {
     /// incorrectly contains null values.
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
         // TODO(ngates): convert arrays to canonicalize over vectors, so remove default impl.
-        Ok(Self::CanonicalVTable::canonicalize(array))
+        Self::CanonicalVTable::canonicalize(array)
     }
 
     /// Attempt to execute the parent of this array to produce a [`Canonical`].

--- a/vortex-bench/src/conversions.rs
+++ b/vortex-bench/src/conversions.rs
@@ -37,7 +37,7 @@ pub async fn parquet_to_vortex(parquet_path: PathBuf) -> anyhow::Result<ChunkedA
 
         // Make sure data is uncompressed and canonicalized
         let mut builder = builder_with_capacity(chunk.dtype(), chunk.len());
-        chunk.append_to_builder(builder.as_mut());
+        chunk.append_to_builder(builder.as_mut())?;
         let chunk = builder.finish();
         chunks.push(chunk);
     }

--- a/vortex-bench/src/datasets/struct_list_of_ints.rs
+++ b/vortex-bench/src/datasets/struct_list_of_ints.rs
@@ -122,7 +122,7 @@ impl Dataset for StructListOfInts {
             let mut writer: Option<ArrowWriter<File>> = None;
 
             for chunk in chunks.iter() {
-                let converted = recursive_list_from_list_view(chunk.clone());
+                let converted = recursive_list_from_list_view(chunk.clone())?;
                 let batch = RecordBatch::try_from(converted.as_ref())?;
 
                 if writer.is_none() {

--- a/vortex-bench/src/datasets/tpch_l_comment.rs
+++ b/vortex-bench/src/datasets/tpch_l_comment.rs
@@ -77,7 +77,7 @@ impl Dataset for TPCHLCommentChunked {
             let file_chunks: Vec<_> = file
                 .scan()?
                 .with_projection(pack(vec![("l_comment", col("l_comment"))], NonNullable))
-                .map(|a| Ok(a.to_canonical().into_array()))
+                .map(|a| Ok(a.to_canonical()?.into_array()))
                 .into_array_stream()?
                 .try_collect()
                 .await?;

--- a/vortex-btrblocks/src/float.rs
+++ b/vortex-btrblocks/src/float.rs
@@ -241,7 +241,7 @@ impl Scheme for ALPScheme {
     ) -> VortexResult<ArrayRef> {
         let alp_encoded = ALPVTable
             .as_vtable()
-            .encode(&stats.source().to_canonical(), None)?
+            .encode(&stats.source().to_canonical()?, None)?
             .vortex_expect("Input is a supported floating point array");
         let alp = alp_encoded.as_::<ALPVTable>();
         let alp_ints = alp.encoded().to_primitive();

--- a/vortex-btrblocks/src/lib.rs
+++ b/vortex-btrblocks/src/lib.rs
@@ -383,7 +383,7 @@ impl BtrBlocksCompressor {
     /// First canonicalizes and compacts the array, then applies optimal compression schemes.
     pub fn compress(&self, array: &dyn Array) -> VortexResult<ArrayRef> {
         // Canonicalize the array
-        let canonical = array.to_canonical();
+        let canonical = array.to_canonical()?;
 
         // Compact it, removing any wasted space before we attempt to compress it
         let compact = canonical.compact()?;
@@ -429,7 +429,7 @@ impl BtrBlocksCompressor {
             Canonical::List(list_view_array) => {
                 // TODO(joe): We might want to write list views in the future and chose between
                 // list and list view.
-                let list_array = list_from_list_view(list_view_array);
+                let list_array = list_from_list_view(list_view_array)?;
 
                 // Reset the offsets to remove garbage data that might prevent us from narrowing our
                 // offsets (there could be a large amount of trailing garbage data that the current

--- a/vortex-cuda/src/executor.rs
+++ b/vortex-cuda/src/executor.rs
@@ -260,7 +260,7 @@ pub trait CudaArrayExt: Array {
 impl CudaArrayExt for ArrayRef {
     async fn execute_cuda(self, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
         if self.is_canonical() {
-            return Ok(self.to_canonical());
+            return self.to_canonical();
         }
 
         let Some(support) = ctx.cuda_session.kernel(&self.encoding_id()) else {

--- a/vortex-cuda/src/for_.rs
+++ b/vortex-cuda/src/for_.rs
@@ -45,7 +45,7 @@ impl CudaExecute for ForExecutor {
 
 async fn execute_for(array: &FoRArray, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
     if array.is_empty() {
-        return Ok(array.to_array().to_canonical());
+        return array.to_array().to_canonical();
     }
 
     // Excludes f16 support.

--- a/vortex-duckdb/src/exporter/constant.rs
+++ b/vortex-duckdb/src/exporter/constant.rs
@@ -31,7 +31,7 @@ pub fn new_exporter_with_mask(
         // TODO(joe): we can splat the constant in a specific exporter and save a copy.
         return Ok(validity::new_exporter(
             mask,
-            new_array_exporter(array.to_canonical().as_ref(), cache)?,
+            new_array_exporter(array.to_canonical()?.as_ref(), cache)?,
         ));
     }
 

--- a/vortex-duckdb/src/exporter/dict.rs
+++ b/vortex-duckdb/src/exporter/dict.rs
@@ -85,7 +85,7 @@ pub(crate) fn new_exporter_with_flatten(
         let canonical = match canonical {
             Some(c) => c,
             None => {
-                let canonical = values.to_canonical();
+                let canonical = values.to_canonical()?;
                 cache
                     .canonical_cache
                     .insert(values_key, (values.clone(), canonical.clone()));
@@ -209,7 +209,7 @@ pub(crate) fn new_operator_exporter_with_flatten(
         let canonical = match canonical {
             Some(c) => c,
             None => {
-                let canonical = values.to_canonical();
+                let canonical = values.to_canonical()?;
                 cache
                     .canonical_cache
                     .insert(values_key, (values.clone(), canonical.clone()));
@@ -275,6 +275,7 @@ mod tests {
     use vortex::array::arrays::DictArray;
     use vortex::array::arrays::PrimitiveArray;
     use vortex::buffer::Buffer;
+    use vortex::error::VortexExpect;
     use vortex::error::VortexResult;
     use vortex::session::VortexSession;
 
@@ -391,10 +392,15 @@ mod tests {
         let mut flat_chunk =
             DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_INTEGER)]);
 
-        new_array_exporter(arr.to_canonical().as_ref(), &ConversionCache::default())
-            .unwrap()
-            .export(0, 3, &mut flat_chunk.get_vector(0))
-            .unwrap();
+        new_array_exporter(
+            arr.to_canonical()
+                .vortex_expect("to_canonical failed")
+                .as_ref(),
+            &ConversionCache::default(),
+        )
+        .unwrap()
+        .export(0, 3, &mut flat_chunk.get_vector(0))
+        .unwrap();
         flat_chunk.set_len(3);
 
         assert_eq!(

--- a/vortex-duckdb/src/exporter/mod.rs
+++ b/vortex-duckdb/src/exporter/mod.rs
@@ -147,7 +147,7 @@ fn new_array_exporter_with_flatten(
     }
 
     // Otherwise, we fall back to canonical
-    match array.to_canonical() {
+    match array.to_canonical()? {
         Canonical::Null(_) => Ok(all_invalid::new_exporter(array.len(), &LogicalType::null())),
         Canonical::Bool(array) => bool::new_exporter(array),
         Canonical::Primitive(array) => primitive::new_exporter(array),

--- a/vortex-layout/src/layouts/compact.rs
+++ b/vortex-layout/src/layouts/compact.rs
@@ -68,7 +68,7 @@ impl CompactCompressor {
     }
 
     pub fn compress(&self, array: &dyn Array) -> VortexResult<ArrayRef> {
-        self.compress_canonical(array.to_canonical())
+        self.compress_canonical(array.to_canonical()?)
     }
 
     /// Compress a single array using the compact strategy

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -259,6 +259,7 @@ mod tests {
     use vortex_dtype::FieldName;
     use vortex_dtype::FieldNames;
     use vortex_dtype::Nullability;
+    use vortex_error::VortexExpect;
     use vortex_io::runtime::single::block_on;
 
     use crate::LayoutId;
@@ -479,7 +480,13 @@ mod tests {
                 .await
                 .unwrap();
             let expected = array.validity_mask().into_array();
-            assert_arrays_eq!(actual.to_canonical().into_array(), expected);
+            assert_arrays_eq!(
+                actual
+                    .to_canonical()
+                    .vortex_expect("to_canonical failed")
+                    .into_array(),
+                expected
+            );
         })
     }
 }

--- a/vortex-layout/src/layouts/repartition.rs
+++ b/vortex-layout/src/layouts/repartition.rs
@@ -71,7 +71,7 @@ impl LayoutStrategy for RepartitionStrategy {
                 dtype.clone(),
                 stream.map(|chunk| {
                     let (sequence_id, chunk) = chunk?;
-                    VortexResult::Ok((sequence_id, chunk.to_canonical().into_array()))
+                    VortexResult::Ok((sequence_id, chunk.to_canonical()?.into_array()))
                 }),
             )
             .sendable()
@@ -104,7 +104,7 @@ impl LayoutStrategy for RepartitionStrategy {
                         if !chunked.is_empty() {
                             yield (
                                 sequence_pointer.advance(),
-                                chunked.to_canonical().into_array(),
+                                chunked.to_canonical()?.into_array(),
                             )
                         }
                     }
@@ -117,7 +117,7 @@ impl LayoutStrategy for RepartitionStrategy {
                     if !to_flush.is_empty() {
                         yield (
                             sequence_pointer.advance(),
-                            to_flush.to_canonical().into_array(),
+                            to_flush.to_canonical()?.into_array(),
                         )
                     }
                 }

--- a/vortex-python/src/arrays/py/vtable.rs
+++ b/vortex-python/src/arrays/py/vtable.rs
@@ -178,7 +178,7 @@ impl BaseArrayVTable<PythonVTable> for PythonVTable {
 }
 
 impl CanonicalVTable<PythonVTable> for PythonVTable {
-    fn canonicalize(_array: &PythonArray) -> Canonical {
+    fn canonicalize(_array: &PythonArray) -> VortexResult<Canonical> {
         todo!()
     }
 }


### PR DESCRIPTION
Adding `ScalarFnArray` meant now canonical can fail

# break

`to_canonical` now return a `VortexResult<Canonical>`
`append_to_builder` now return `VortexResult<()>`