### PR TITLE
chore: validate the error type during testing

### DIFF
--- a/vortex-array/src/arrays/validation_tests.rs
+++ b/vortex-array/src/arrays/validation_tests.rs
@@ -16,6 +16,7 @@ mod tests {
     use vortex_dtype::DType;
     use vortex_dtype::Nullability;
     use vortex_dtype::PType;
+    use vortex_error::VortexError;
     use vortex_vector::binaryview::BinaryView;
 
     use crate::IntoArray;
@@ -37,6 +38,8 @@ mod tests {
         let chunk1 = buffer![1i32, 2, 3].into_array();
         let chunk2 = buffer![4i64, 5, 6].into_array();
         let result = ChunkedArray::try_new(vec![chunk1, chunk2], PType::I32.into());
+
+        assert!(matches!(result, Err(VortexError::MismatchedTypes(_, _, _))));
         assert!(result.is_err());
     }
 
@@ -56,6 +59,8 @@ mod tests {
         let validity = Validity::from_iter([true, false]); // Length 2, buffer is length 3.
         let decimal_dtype = vortex_dtype::DecimalDType::new(10, 2);
         let result = DecimalArray::try_new(buffer, decimal_dtype, validity);
+
+        assert!(matches!(result, Err(VortexError::InvalidArgument(_, _))));
         assert!(result.is_err());
     }
 
@@ -73,6 +78,8 @@ mod tests {
         let buffer = Buffer::from_iter([1i32, 2, 3]);
         let validity = Validity::from_iter([true, false]); // Length 2, buffer is length 3.
         let result = PrimitiveArray::try_new(buffer, validity);
+
+        assert!(matches!(result, Err(VortexError::InvalidArgument(_, _))));
         assert!(result.is_err());
     }
 
@@ -101,6 +108,8 @@ mod tests {
             DType::Binary(Nullability::NonNullable),
             Validity::NonNullable,
         );
+
+        assert!(matches!(result, Err(VortexError::InvalidArgument(_, _))));
         assert!(result.is_err());
     }
 
@@ -119,6 +128,8 @@ mod tests {
         let elements = buffer![1i32, 2, 3].into_array();
         let offsets = buffer![0i64, 2, 5].into_array(); // 5 > 3.
         let result = ListArray::try_new(elements, offsets, Validity::NonNullable);
+
+        assert!(matches!(result, Err(VortexError::InvalidArgument(_, _))));
         assert!(result.is_err());
     }
 
@@ -135,6 +146,8 @@ mod tests {
         // Invalid case: elements length doesn't match list_size * len.
         let elements = buffer![1i32, 2, 3, 4, 5].into_array(); // 5 elements.
         let result = FixedSizeListArray::try_new(elements, 2, Validity::NonNullable, 3); // Expects 2 * 3 = 6.
+
+        assert!(matches!(result, Err(VortexError::InvalidArgument(_, _))));
         assert!(result.is_err());
     }
 
@@ -171,6 +184,8 @@ mod tests {
             DType::Binary(Nullability::NonNullable),
             Validity::NonNullable,
         );
+
+        assert!(matches!(result, Err(VortexError::InvalidArgument(_, _))));
         assert!(result.is_err());
     }
 
@@ -193,6 +208,8 @@ mod tests {
         let fields = vec![field1, field2];
         let names = ["a", "b"];
         let result = StructArray::try_new(names.into(), fields, 3, Validity::NonNullable);
+
+        assert!(matches!(result, Err(VortexError::InvalidArgument(_, _))));
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
The current test only checks for errors, but doesn't check the error type. Perhaps this could be improved.

example
```
    fn test_primitive_array_validation_failure_length_mismatch() {
        // Invalid case: validity length doesn't match buffer length.
        let buffer = Buffer::from_iter([1i32, 2, 3]);
        let validity = Validity::from_iter([true, false]); // Length 2, buffer is length 3.
        let result = PrimitiveArray::try_new(buffer, validity);

        assert!(matches!(result, Err(VortexError::InvalidArgument(_, _))));
        assert!(result.is_err());
    }
```