### PR TITLE
feat: optimize repeatedScan for limit == 0

### DIFF
--- a/vortex-scan/src/repeated_scan.rs
+++ b/vortex-scan/src/repeated_scan.rs
@@ -161,15 +161,21 @@ impl<A: 'static + Send> RepeatedScan<A> {
         };
 
         let mut limit = self.limit;
-        ranges
-            .filter_map(|range| {
-                if range.start >= range.end || limit.is_some_and(|l| l == 0) {
-                    None
-                } else {
-                    Some(split_exec(ctx.clone(), range, limit.as_mut()))
-                }
-            })
-            .try_collect()
+        let mut tasks = Vec::new();
+
+        for range in ranges {
+            if range.start >= range.end {
+                continue;
+            }
+
+            if limit.is_some_and(|l| l == 0) {
+                break;
+            }
+
+            tasks.push(split_exec(ctx.clone(), range, limit.as_mut())?);
+        }
+
+        Ok(tasks)
     }
 
     pub fn execute_stream(


### PR DESCRIPTION
Problem Description:
In the original implementation, even after the limit had decreased to 0 in the previous splits, the iterator would still continue traversing thousands of subsequent intervals. Although each interval only performed the `is_some_and` check once, it still incurred unnecessary traversal overhead.

Solution: This optimization immediately executes `break` when `limit == 0` is detected, ensuring that subsequent intervals are no longer traversed.