### PR TITLE
chore: clarify Scalar::cast_to_non_extension invariant assert message

### DIFF
--- a/vortex-scalar/src/scalar.rs
+++ b/vortex-scalar/src/scalar.rs
@@ -133,7 +133,10 @@ impl Scalar {
     }
 
     fn cast_to_non_extension(&self, target: &DType) -> VortexResult<Self> {
-        assert!(!matches!(target, DType::Extension(..)));
+        assert!(
+            !matches!(target, DType::Extension(..)),
+            "cast_to_non_extension must not be called with an Extension dtype (got {target})",
+        );
 
         if self.is_null() {
             if target.is_nullable() {


### PR DESCRIPTION
Improve the Scalar::cast_to_non_extension invariant by adding a descriptive assert message when called with an Extension dtype. This keeps the internal contract strict (panic on misuse) while making debugging easier if the invariant is ever violated.