### PR TITLE
perf: CUDA FoR loop unrolling

### DIFF
--- a/vortex-cuda/benches/for_cuda.rs
+++ b/vortex-cuda/benches/for_cuda.rs
@@ -31,37 +31,69 @@ const BENCH_ARGS: &[(usize, &str)] = &[
     (100_000, "100K"),
     (1_000_000, "1M"),
     (10_000_000, "10M"),
-    (100_000_000, "100M"),
 ];
 
-/// Creates a FoR array for the given size.
-fn make_for_array(len: usize) -> FoRArray {
+/// Creates a FoR array of u8 for the given size.
+fn make_for_array_u8(len: usize) -> FoRArray {
+    let data: Vec<u8> = (0..len as u8).map(|i| i.wrapping_add(10)).collect();
+    let primitive_array = PrimitiveArray::new(
+        Buffer::from(data),
+        vortex_array::validity::Validity::NonNullable,
+    )
+    .into_array();
+
+    FoRArray::try_new(primitive_array, 10u8.into()).vortex_expect("failed to create FoR array")
+}
+
+/// Creates a FoR array of u16 for the given size.
+fn make_for_array_u16(len: usize) -> FoRArray {
+    let data: Vec<u16> = (0..len as u16).map(|i| i.wrapping_add(10)).collect();
+    let primitive_array = PrimitiveArray::new(
+        Buffer::from(data),
+        vortex_array::validity::Validity::NonNullable,
+    )
+    .into_array();
+
+    FoRArray::try_new(primitive_array, 10u16.into()).vortex_expect("failed to create FoR array")
+}
+
+/// Creates a FoR array of u32 for the given size.
+fn make_for_array_u32(len: usize) -> FoRArray {
     let primitive_array = PrimitiveArray::new(
         Buffer::from((0u32..len as u32).collect::<Vec<u32>>()),
         vortex_array::validity::Validity::NonNullable,
     )
     .into_array();
 
-    let for_offset = 10u32;
+    FoRArray::try_new(primitive_array, 10u32.into()).vortex_expect("failed to create FoR array")
+}
 
-    FoRArray::try_new(primitive_array, for_offset.into())
-        .vortex_expect("failed to create FoR array")
+/// Creates a FoR array of u64 for the given size.
+fn make_for_array_u64(len: usize) -> FoRArray {
+    let data: Vec<u64> = (0..len as u64).map(|i| i.wrapping_add(10)).collect();
+    let primitive_array = PrimitiveArray::new(
+        Buffer::from(data),
+        vortex_array::validity::Validity::NonNullable,
+    )
+    .into_array();
+
+    FoRArray::try_new(primitive_array, 10u64.into()).vortex_expect("failed to create FoR array")
 }
 
 /// Launches FoR decompression kernel and returns elapsed GPU time in seconds.
-fn launch_for_kernel_timed(
+fn launch_for_kernel_timed_u8(
     for_array: &FoRArray,
-    reference: u32,
-    device_data: cudarc::driver::CudaSlice<u32>,
+    device_data: cudarc::driver::CudaSlice<u8>,
+    reference: u8,
     cuda_ctx: &mut CudaExecutionCtx,
 ) -> vortex_error::VortexResult<Duration> {
-    let array_len = for_array.len() as u64;
+    let array_len_u64 = for_array.len() as u64;
 
     let events = vortex_cuda::launch_cuda_kernel!(
         execution_ctx: cuda_ctx,
         module: "for",
         ptypes: &[for_array.ptype()],
-        launch_args: [device_data, reference, array_len],
+        launch_args: [device_data, reference, array_len_u64],
         event_recording: CU_EVENT_BLOCKING_SYNC,
         array_len: for_array.len()
     );
@@ -74,17 +106,189 @@ fn launch_for_kernel_timed(
     Ok(Duration::from_secs_f32(elapsed_ms / 1000.0))
 }
 
-fn benchmark_for_cuda(c: &mut Criterion) {
-    if !has_nvcc() {
-        eprintln!("nvcc not found, skipping CUDA benchmarks");
-        return;
-    }
+/// Launches FoR decompression kernel and returns elapsed GPU time in seconds.
+fn launch_for_kernel_timed_u16(
+    for_array: &FoRArray,
+    device_data: cudarc::driver::CudaSlice<u16>,
+    reference: u16,
+    cuda_ctx: &mut CudaExecutionCtx,
+) -> vortex_error::VortexResult<Duration> {
+    let array_len_u64 = for_array.len() as u64;
 
-    let mut group = c.benchmark_group("FoR_cuda");
+    let events = vortex_cuda::launch_cuda_kernel!(
+        execution_ctx: cuda_ctx,
+        module: "for",
+        ptypes: &[for_array.ptype()],
+        launch_args: [device_data, reference, array_len_u64],
+        event_recording: CU_EVENT_BLOCKING_SYNC,
+        array_len: for_array.len()
+    );
+
+    let elapsed_ms = events
+        .before_launch
+        .elapsed_ms(&events.after_launch) // synchronizes
+        .map_err(|e| vortex_error::vortex_err!("failed to get elapsed time: {}", e))?;
+
+    Ok(Duration::from_secs_f32(elapsed_ms / 1000.0))
+}
+
+/// Launches FoR decompression kernel and returns elapsed GPU time in seconds.
+fn launch_for_kernel_timed_u32(
+    for_array: &FoRArray,
+    device_data: cudarc::driver::CudaSlice<u32>,
+    reference: u32,
+    cuda_ctx: &mut CudaExecutionCtx,
+) -> vortex_error::VortexResult<Duration> {
+    let array_len_u64 = for_array.len() as u64;
+
+    let events = vortex_cuda::launch_cuda_kernel!(
+        execution_ctx: cuda_ctx,
+        module: "for",
+        ptypes: &[for_array.ptype()],
+        launch_args: [device_data, reference, array_len_u64],
+        event_recording: CU_EVENT_BLOCKING_SYNC,
+        array_len: for_array.len()
+    );
+
+    let elapsed_ms = events
+        .before_launch
+        .elapsed_ms(&events.after_launch) // synchronizes
+        .map_err(|e| vortex_error::vortex_err!("failed to get elapsed time: {}", e))?;
+
+    Ok(Duration::from_secs_f32(elapsed_ms / 1000.0))
+}
+
+/// Launches FoR decompression kernel and returns elapsed GPU time in seconds.
+fn launch_for_kernel_timed_u64(
+    for_array: &FoRArray,
+    device_data: cudarc::driver::CudaSlice<u64>,
+    reference: u64,
+    cuda_ctx: &mut CudaExecutionCtx,
+) -> vortex_error::VortexResult<Duration> {
+    let array_len_u64 = for_array.len() as u64;
+
+    let events = vortex_cuda::launch_cuda_kernel!(
+        execution_ctx: cuda_ctx,
+        module: "for",
+        ptypes: &[for_array.ptype()],
+        launch_args: [device_data, reference, array_len_u64],
+        event_recording: CU_EVENT_BLOCKING_SYNC,
+        array_len: for_array.len()
+    );
+
+    let elapsed_ms = events
+        .before_launch
+        .elapsed_ms(&events.after_launch) // synchronizes
+        .map_err(|e| vortex_error::vortex_err!("failed to get elapsed time: {}", e))?;
+
+    Ok(Duration::from_secs_f32(elapsed_ms / 1000.0))
+}
+
+/// Benchmark u8 FoR decompression
+fn benchmark_for_u8(c: &mut Criterion) {
+    let mut group = c.benchmark_group("FoR_cuda_u8");
     group.sample_size(10);
 
     for (len, label) in BENCH_ARGS {
-        let for_array = make_for_array(*len);
+        let for_array = make_for_array_u8(*len);
+
+        group.throughput(Throughput::Bytes((len * size_of::<u8>()) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("u8_FoR", label),
+            &for_array,
+            |b, for_array| {
+                b.iter_custom(|iters| {
+                    let mut cuda_ctx = CudaSession::new_ctx(VortexSession::empty())
+                        .vortex_expect("failed to create execution context");
+
+                    let encoded = for_array.encoded();
+                    let unpacked_array = encoded.to_primitive();
+                    let unpacked_slice = unpacked_array.as_slice::<u8>();
+
+                    let reference = 10u8;
+                    let mut total_time = Duration::ZERO;
+
+                    for _ in 0..iters {
+                        let device_data = cuda_ctx
+                            .to_device(unpacked_slice)
+                            .vortex_expect("failed to copy to device");
+
+                        let kernel_time = launch_for_kernel_timed_u8(
+                            for_array,
+                            device_data,
+                            reference,
+                            &mut cuda_ctx,
+                        )
+                        .vortex_expect("kernel launch failed");
+
+                        total_time += kernel_time;
+                    }
+
+                    total_time
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark u16 FoR decompression
+fn benchmark_for_u16(c: &mut Criterion) {
+    let mut group = c.benchmark_group("FoR_cuda_u16");
+    group.sample_size(10);
+
+    for (len, label) in BENCH_ARGS {
+        let for_array = make_for_array_u16(*len);
+
+        group.throughput(Throughput::Bytes((len * size_of::<u16>()) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("u16_FoR", label),
+            &for_array,
+            |b, for_array| {
+                b.iter_custom(|iters| {
+                    let mut cuda_ctx = CudaSession::new_ctx(VortexSession::empty())
+                        .vortex_expect("failed to create execution context");
+
+                    let encoded = for_array.encoded();
+                    let unpacked_array = encoded.to_primitive();
+                    let unpacked_slice = unpacked_array.as_slice::<u16>();
+
+                    let reference = 10u16;
+                    let mut total_time = Duration::ZERO;
+
+                    for _ in 0..iters {
+                        let device_data = cuda_ctx
+                            .to_device(unpacked_slice)
+                            .vortex_expect("failed to copy to device");
+
+                        let kernel_time = launch_for_kernel_timed_u16(
+                            for_array,
+                            device_data,
+                            reference,
+                            &mut cuda_ctx,
+                        )
+                        .vortex_expect("kernel launch failed");
+
+                        total_time += kernel_time;
+                    }
+
+                    total_time
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark u32 FoR decompression
+fn benchmark_for_u32(c: &mut Criterion) {
+    let mut group = c.benchmark_group("FoR_cuda_u32");
+    group.sample_size(10);
+
+    for (len, label) in BENCH_ARGS {
+        let for_array = make_for_array_u32(*len);
 
         group.throughput(Throughput::Bytes((len * size_of::<u32>()) as u64));
         group.bench_with_input(
@@ -107,10 +311,10 @@ fn benchmark_for_cuda(c: &mut Criterion) {
                             .to_device(unpacked_slice)
                             .vortex_expect("failed to copy to device");
 
-                        let kernel_time = launch_for_kernel_timed(
+                        let kernel_time = launch_for_kernel_timed_u32(
                             for_array,
-                            reference,
                             device_data,
+                            reference,
                             &mut cuda_ctx,
                         )
                         .vortex_expect("kernel launch failed");
@@ -125,6 +329,67 @@ fn benchmark_for_cuda(c: &mut Criterion) {
     }
 
     group.finish();
+}
+
+/// Benchmark u64 FoR decompression
+fn benchmark_for_u64(c: &mut Criterion) {
+    let mut group = c.benchmark_group("FoR_cuda_u64");
+    group.sample_size(10);
+
+    for (len, label) in BENCH_ARGS {
+        let for_array = make_for_array_u64(*len);
+
+        group.throughput(Throughput::Bytes((len * size_of::<u64>()) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("u64_FoR", label),
+            &for_array,
+            |b, for_array| {
+                b.iter_custom(|iters| {
+                    let mut cuda_ctx = CudaSession::new_ctx(VortexSession::empty())
+                        .vortex_expect("failed to create execution context");
+
+                    let encoded = for_array.encoded();
+                    let unpacked_array = encoded.to_primitive();
+                    let unpacked_slice = unpacked_array.as_slice::<u64>();
+
+                    let reference = 10u64;
+                    let mut total_time = Duration::ZERO;
+
+                    for _ in 0..iters {
+                        let device_data = cuda_ctx
+                            .to_device(unpacked_slice)
+                            .vortex_expect("failed to copy to device");
+
+                        let kernel_time = launch_for_kernel_timed_u64(
+                            for_array,
+                            device_data,
+                            reference,
+                            &mut cuda_ctx,
+                        )
+                        .vortex_expect("kernel launch failed");
+
+                        total_time += kernel_time;
+                    }
+
+                    total_time
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn benchmark_for_cuda(c: &mut Criterion) {
+    if !has_nvcc() {
+        eprintln!("nvcc not found, skipping CUDA benchmarks");
+        return;
+    }
+
+    benchmark_for_u8(c);
+    benchmark_for_u16(c);
+    benchmark_for_u32(c);
+    benchmark_for_u64(c);
 }
 
 criterion_group!(benches, benchmark_for_cuda);

--- a/vortex-cuda/kernels/for.cu
+++ b/vortex-cuda/kernels/for.cu
@@ -6,38 +6,57 @@
 #include <stdint.h>
 
 template<typename ValueT>
-__device__ void for_(
+__device__ void for_kernel(
     ValueT *const __restrict values_in_out_array,
     ValueT reference,
     uint64_t array_len
 ) {
-    // Each block handles 2048 elements with 64 threads. Each thread handles 32 elements.
     const uint32_t elements_per_block = 2048;
     const uint64_t block_start = static_cast<uint64_t>(blockIdx.x) * elements_per_block;
     const uint64_t block_end = (block_start + elements_per_block < array_len)
-                               ? (block_start + elements_per_block)
-                               : array_len;
+    ? (block_start + elements_per_block)
+    : array_len;
 
-    for (uint64_t idx = block_start + threadIdx.x; idx < block_end; idx += blockDim.x) {
+
+    // Determine the number of loop iterations at compile time. Unroll to process 16 bytes per iteration.
+    constexpr auto VALUES_PER_LOOP = 16 / sizeof(ValueT);
+    const auto block_start_vec = block_start / VALUES_PER_LOOP;
+    const auto block_end_vec = block_end / VALUES_PER_LOOP;
+
+    for (uint64_t idx = block_start_vec + threadIdx.x; idx < block_end_vec; idx += blockDim.x) {
+        uint64_t base_idx = idx * VALUES_PER_LOOP;
+
+        // The loop can be unrolled, as `values per loop` is `constexpr`.
+        #pragma unroll
+        for (uint64_t i = 0; i < VALUES_PER_LOOP; ++i) {
+            values_in_out_array[base_idx + i] += reference;
+        }
+    }
+
+    uint64_t remaining_start = block_end_vec * VALUES_PER_LOOP;
+    for (uint64_t idx = remaining_start + threadIdx.x; idx < block_end; idx += blockDim.x) {
         values_in_out_array[idx] = values_in_out_array[idx] + reference;
     }
 }
 
-#define GENERATE_KERNEL(value_suffix, ValueType) \
+// Macro for all types
+#define GENERATE_FOR_KERNEL(value_suffix, ValueType) \
 extern "C" __global__ void for_##value_suffix( \
     ValueType *const __restrict values, \
     ValueType reference, \
     uint64_t array_len \
 ) { \
-    for_(values, reference, array_len); \
+    for_kernel<ValueType>(values, reference, array_len); \
 }
 
-GENERATE_KERNEL(u8, uint8_t)
-GENERATE_KERNEL(u16, uint16_t)
-GENERATE_KERNEL(u32, uint32_t)
-GENERATE_KERNEL(u64, uint64_t)
+GENERATE_FOR_KERNEL(u8, uint8_t)
+GENERATE_FOR_KERNEL(i8, int8_t)
 
-GENERATE_KERNEL(i8, int8_t)
-GENERATE_KERNEL(i16, int16_t)
-GENERATE_KERNEL(i32, int32_t)
-GENERATE_KERNEL(i64, int64_t)
+GENERATE_FOR_KERNEL(u16, uint16_t)
+GENERATE_FOR_KERNEL(i16, int16_t)
+
+GENERATE_FOR_KERNEL(u32, uint32_t)
+GENERATE_FOR_KERNEL(i32, int32_t)
+
+GENERATE_FOR_KERNEL(u64, uint64_t)
+GENERATE_FOR_KERNEL(i64, int64_t)

--- a/vortex-cuda/src/for_.rs
+++ b/vortex-cuda/src/for_.rs
@@ -113,7 +113,7 @@ mod tests {
     use crate::session::CudaSession;
 
     #[tokio::test]
-    async fn test_cuda_for_decompression() {
+    async fn test_cuda_for_decompression_u8() {
         if !has_nvcc() {
             return;
         }
@@ -121,13 +121,77 @@ mod tests {
         let mut cuda_ctx = CudaSession::new_ctx(VortexSession::empty())
             .vortex_expect("failed to create execution context");
 
+        // Create u8 offset values that cycle through 0-255, creating 5000 elements
+        #[allow(clippy::cast_possible_truncation)]
+        let input_data: Vec<u8> = (0..5000).map(|i| (i % 256) as u8).collect();
+
         let for_array = FoRArray::try_new(
-            PrimitiveArray::new(
-                Buffer::from((0u32..5000).collect::<Vec<u32>>()),
-                NonNullable,
-            )
-            .into_array(),
-            10u32.into(),
+            PrimitiveArray::new(Buffer::from(input_data.clone()), NonNullable).into_array(),
+            10u8.into(),
+        )
+        .vortex_expect("failed to create FoR array");
+
+        // Decompress on the GPU.
+        let result = execute_for(&for_array, &mut cuda_ctx)
+            .await
+            .vortex_expect("GPU decompression failed");
+
+        assert_eq!(
+            result.as_primitive().as_slice::<u8>(),
+            input_data
+                .iter()
+                .map(|&val| val.wrapping_add(10))
+                .collect::<Vec<u8>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cuda_for_decompression_u16() {
+        if !has_nvcc() {
+            return;
+        }
+
+        let mut cuda_ctx = CudaSession::new_ctx(VortexSession::empty())
+            .vortex_expect("failed to create execution context");
+
+        // Create u16 offset values that cycle through 0-5000, creating 5000 elements
+        let input_data: Vec<u16> = (0..5000).map(|i| (i % 5000) as u16).collect();
+
+        let for_array = FoRArray::try_new(
+            PrimitiveArray::new(Buffer::from(input_data.clone()), NonNullable).into_array(),
+            1000u16.into(),
+        )
+        .vortex_expect("failed to create FoR array");
+
+        // Decompress on the GPU.
+        let result = execute_for(&for_array, &mut cuda_ctx)
+            .await
+            .vortex_expect("GPU decompression failed");
+
+        assert_eq!(
+            result.as_primitive().as_slice::<u16>(),
+            input_data
+                .iter()
+                .map(|&val| val.wrapping_add(1000))
+                .collect::<Vec<u16>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cuda_for_decompression_u32() {
+        if !has_nvcc() {
+            return;
+        }
+
+        let mut cuda_ctx = CudaSession::new_ctx(VortexSession::empty())
+            .vortex_expect("failed to create execution context");
+
+        // Create u32 offset values that cycle through 0-5000, creating 5000 elements
+        let input_data: Vec<u32> = (0..5000).map(|i| (i % 5000) as u32).collect();
+
+        let for_array = FoRArray::try_new(
+            PrimitiveArray::new(Buffer::from(input_data.clone()), NonNullable).into_array(),
+            100000u32.into(),
         )
         .vortex_expect("failed to create FoR array");
 
@@ -138,7 +202,42 @@ mod tests {
 
         assert_eq!(
             result.as_primitive().as_slice::<u32>(),
-            (10u32..5010).collect::<Vec<u32>>()
+            input_data
+                .iter()
+                .map(|&val| val.wrapping_add(100000))
+                .collect::<Vec<u32>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cuda_for_decompression_u64() {
+        if !has_nvcc() {
+            return;
+        }
+
+        let mut cuda_ctx = CudaSession::new_ctx(VortexSession::empty())
+            .vortex_expect("failed to create execution context");
+
+        // Create u64 offset values that cycle through 0-5000, creating 5000 elements
+        let input_data: Vec<u64> = (0..5000).map(|i| (i % 5000) as u64).collect();
+
+        let for_array = FoRArray::try_new(
+            PrimitiveArray::new(Buffer::from(input_data.clone()), NonNullable).into_array(),
+            1000000u64.into(),
+        )
+        .vortex_expect("failed to create FoR array");
+
+        // Decompress on the GPU.
+        let result = execute_for(&for_array, &mut cuda_ctx)
+            .await
+            .vortex_expect("GPU decompression failed");
+
+        assert_eq!(
+            result.as_primitive().as_slice::<u64>(),
+            input_data
+                .iter()
+                .map(|&val| val.wrapping_add(1000000u64))
+                .collect::<Vec<u64>>()
         );
     }
 }


### PR DESCRIPTION
This PR changes the FoR impl to use loop unrolling which in some scenarios leads up to a ~85% speedup. As part of that, new benchmarks and tests are introduced.

Benchmarks were run on an A10:
```
FoR_cuda_u8/u8_FoR/1K   time:   [4.6619 µs 4.6818 µs 4.7073 µs]
                        thrpt:  [202.59 MiB/s 203.70 MiB/s 204.57 MiB/s]
                 change:
                        time:   [−6.9968% −6.1892% −5.2750%] (p = 0.00 < 0.05)
                        thrpt:  [+5.5687% +6.5976% +7.5232%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
FoR_cuda_u8/u8_FoR/10K  time:   [4.4583 µs 4.4809 µs 4.5139 µs]
                        thrpt:  [2.0632 GiB/s 2.0784 GiB/s 2.0890 GiB/s]
                 change:
                        time:   [−0.0233% +0.7648% +1.5942%] (p = 0.10 > 0.05)
                        thrpt:  [−1.5692% −0.7590% +0.0233%]
                        No change in performance detected.
FoR_cuda_u8/u8_FoR/100K time:   [4.5262 µs 4.5439 µs 4.5736 µs]
                        thrpt:  [20.363 GiB/s 20.496 GiB/s 20.576 GiB/s]
                 change:
                        time:   [−8.9445% −7.7897% −6.6445%] (p = 0.00 < 0.05)
                        thrpt:  [+7.1175% +8.4477% +9.8231%]
                        Performance has improved.
FoR_cuda_u8/u8_FoR/1M   time:   [4.4380 µs 4.4598 µs 4.4891 µs]
                        thrpt:  [207.46 GiB/s 208.83 GiB/s 209.85 GiB/s]
                 change:
                        time:   [+0.0679% +0.9488% +1.7990%] (p = 0.05 > 0.05)
                        thrpt:  [−1.7672% −0.9399% −0.0679%]
                        No change in performance detected.
FoR_cuda_u8/u8_FoR/10M  time:   [4.4880 µs 4.5013 µs 4.5293 µs]
                        thrpt:  [2056.2 GiB/s 2069.0 GiB/s 2075.2 GiB/s]
                 change:
                        time:   [−3.4123% −2.6199% −1.6909%] (p = 0.00 < 0.05)
                        thrpt:  [+1.7200% +2.6903% +3.5328%]
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild

FoR_cuda_u16/u16_FoR/1K time:   [4.7696 µs 4.7820 µs 4.8017 µs]
                        thrpt:  [397.22 MiB/s 398.86 MiB/s 399.90 MiB/s]
                 change:
                        time:   [−31.818% −31.216% −30.430%] (p = 0.00 < 0.05)
                        thrpt:  [+43.739% +45.384% +46.666%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
FoR_cuda_u16/u16_FoR/10K
                        time:   [4.9942 µs 5.0030 µs 5.0114 µs]
                        thrpt:  [3.7168 GiB/s 3.7231 GiB/s 3.7296 GiB/s]
                 change:
                        time:   [−46.715% −46.619% −46.535%] (p = 0.00 < 0.05)
                        thrpt:  [+87.039% +87.332% +87.671%]
                        Performance has improved.
FoR_cuda_u16/u16_FoR/100K
                        time:   [11.371 µs 11.387 µs 11.396 µs]
                        thrpt:  [16.345 GiB/s 16.358 GiB/s 16.381 GiB/s]
                 change:
                        time:   [−26.577% −26.455% −26.344%] (p = 0.00 < 0.05)
                        thrpt:  [+35.767% +35.972% +36.197%]
                        Performance has improved.
FoR_cuda_u16/u16_FoR/1M time:   [4.9764 µs 4.9958 µs 5.0073 µs]
                        thrpt:  [371.98 GiB/s 372.84 GiB/s 374.29 GiB/s]
                 change:
                        time:   [−46.584% −46.382% −46.210%] (p = 0.00 < 0.05)
                        thrpt:  [+85.906% +86.503% +87.210%]
                        Performance has improved.
FoR_cuda_u16/u16_FoR/10M
                        time:   [11.157 µs 11.211 µs 11.248 µs]
                        thrpt:  [1656.0 GiB/s 1661.4 GiB/s 1669.5 GiB/s]
                 change:
                        time:   [−26.916% −26.493% −26.164%] (p = 0.00 < 0.05)
                        thrpt:  [+35.435% +36.042% +36.828%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild

FoR_cuda_u32/u32_FoR/1K time:   [5.2116 µs 5.2613 µs 5.3102 µs]
                        thrpt:  [718.37 MiB/s 725.05 MiB/s 731.96 MiB/s]
                 change:
                        time:   [−26.511% −25.998% −25.368%] (p = 0.00 < 0.05)
                        thrpt:  [+33.990% +35.132% +36.075%]
                        Performance has improved.
FoR_cuda_u32/u32_FoR/10K
                        time:   [5.5475 µs 5.5554 µs 5.5633 µs]
                        thrpt:  [6.6962 GiB/s 6.7057 GiB/s 6.7152 GiB/s]
                 change:
                        time:   [−39.450% −39.349% −39.240%] (p = 0.00 < 0.05)
                        thrpt:  [+64.582% +64.877% +65.153%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
FoR_cuda_u32/u32_FoR/100K
                        time:   [9.3362 µs 9.3806 µs 9.4250 µs]
                        thrpt:  [39.525 GiB/s 39.713 GiB/s 39.902 GiB/s]
                 change:
                        time:   [−25.760% −25.359% −24.988%] (p = 0.00 < 0.05)
                        thrpt:  [+33.312% +33.974% +34.698%]
                        Performance has improved.
FoR_cuda_u32/u32_FoR/1M time:   [13.072 µs 13.168 µs 13.267 µs]
                        thrpt:  [280.78 GiB/s 282.91 GiB/s 284.98 GiB/s]
                 change:
                        time:   [−18.493% −14.861% −9.3593%] (p = 0.00 < 0.05)
                        thrpt:  [+10.326% +17.455% +22.689%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
FoR_cuda_u32/u32_FoR/10M
                        time:   [174.68 µs 174.95 µs 175.20 µs]
                        thrpt:  [212.63 GiB/s 212.94 GiB/s 213.26 GiB/s]
                 change:
                        time:   [−1.4814% −1.2404% −1.0022%] (p = 0.00 < 0.05)
                        thrpt:  [+1.0124% +1.2560% +1.5036%]
                        Performance has improved.

FoR_cuda_u64/u64_FoR/1K time:   [5.8007 µs 5.8204 µs 5.8478 µs]
                        thrpt:  [1.2741 GiB/s 1.2801 GiB/s 1.2844 GiB/s]
                 change:
                        time:   [−18.401% −18.040% −17.687%] (p = 0.00 < 0.05)
                        thrpt:  [+21.488% +22.010% +22.551%]
                        Performance has improved.
FoR_cuda_u64/u64_FoR/10K
                        time:   [13.322 µs 13.378 µs 13.445 µs]
                        thrpt:  [5.5417 GiB/s 5.5695 GiB/s 5.5925 GiB/s]
                 change:
                        time:   [−17.451% −17.049% −16.645%] (p = 0.00 < 0.05)
                        thrpt:  [+19.969% +20.553% +21.140%]
                        Performance has improved.
FoR_cuda_u64/u64_FoR/100K
                        time:   [12.205 µs 12.319 µs 12.462 µs]
                        thrpt:  [59.788 GiB/s 60.478 GiB/s 61.044 GiB/s]
                 change:
                        time:   [−19.829% −19.168% −18.499%] (p = 0.00 < 0.05)
                        thrpt:  [+22.697% +23.713% +24.734%]
                        Performance has improved.
FoR_cuda_u64/u64_FoR/1M time:   [33.368 µs 33.405 µs 33.464 µs]
                        thrpt:  [222.65 GiB/s 223.04 GiB/s 223.28 GiB/s]
                 change:
                        time:   [−7.8447% −7.4612% −7.0847%] (p = 0.00 < 0.05)
                        thrpt:  [+7.6249% +8.0627% +8.5124%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
FoR_cuda_u64/u64_FoR/10M
                        time:   [341.44 µs 341.72 µs 342.10 µs]
                        thrpt:  [217.79 GiB/s 218.03 GiB/s 218.21 GiB/s]
                 change:
                        time:   [−1.8864% −1.6840% −1.4901%] (p = 0.00 < 0.05)
                        thrpt:  [+1.5126% +1.7128% +1.9226%]
                        Performance has improved.
```