### PR TITLE
propagate is_sorted for runend ends child

### DIFF
--- a/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
@@ -4,7 +4,6 @@
 use fastlanes::BitPacking;
 use itertools::Itertools;
 use num_traits::PrimInt;
-use vortex_array::Array;
 use vortex_array::IntoArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::patches::Patches;
@@ -72,8 +71,8 @@ pub fn bitpack_encode(
         .flatten();
 
     // SAFETY: all components validated above
-    unsafe {
-        let bitpacked = BitPackedArray::new_unchecked(
+    let bitpacked = unsafe {
+        BitPackedArray::new_unchecked(
             packed,
             array.dtype().clone(),
             array.validity().clone(),
@@ -81,13 +80,13 @@ pub fn bitpack_encode(
             bit_width,
             array.len(),
             0,
-        );
-        bitpacked
-            .stats_set
-            .to_ref(&bitpacked)
-            .inherit_from(array.statistics());
-        Ok(bitpacked)
-    }
+        )
+    };
+    bitpacked
+        .stats_set
+        .to_ref(bitpacked.as_ref())
+        .inherit_from(array.statistics());
+    Ok(bitpacked)
 }
 
 /// Bitpack an array into the specified bit-width without checking statistics.
@@ -106,8 +105,8 @@ pub unsafe fn bitpack_encode_unchecked(
     let packed = unsafe { bitpack_unchecked(&array, bit_width)? };
 
     // SAFETY: checked by bitpack_unchecked
-    unsafe {
-        let bitpacked = BitPackedArray::new_unchecked(
+    let bitpacked = unsafe {
+        BitPackedArray::new_unchecked(
             packed,
             array.dtype().clone(),
             array.validity().clone(),
@@ -115,13 +114,13 @@ pub unsafe fn bitpack_encode_unchecked(
             bit_width,
             array.len(),
             0,
-        );
-        bitpacked
-            .stats_set
-            .to_ref(&bitpacked)
-            .inherit_from(array.statistics());
-        Ok(bitpacked)
-    }
+        )
+    };
+    bitpacked
+        .stats_set
+        .to_ref(bitpacked.as_ref())
+        .inherit_from(array.statistics());
+    Ok(bitpacked)
 }
 
 /// Bitpack a [PrimitiveArray] to the given width.

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
@@ -4,6 +4,7 @@
 use fastlanes::BitPacking;
 use itertools::Itertools;
 use num_traits::PrimInt;
+use vortex_array::Array;
 use vortex_array::IntoArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::patches::Patches;
@@ -72,7 +73,7 @@ pub fn bitpack_encode(
 
     // SAFETY: all components validated above
     unsafe {
-        Ok(BitPackedArray::new_unchecked(
+        let bitpacked = BitPackedArray::new_unchecked(
             packed,
             array.dtype().clone(),
             array.validity().clone(),
@@ -80,7 +81,12 @@ pub fn bitpack_encode(
             bit_width,
             array.len(),
             0,
-        ))
+        );
+        bitpacked
+            .stats_set
+            .to_ref(&bitpacked)
+            .inherit_from(array.statistics());
+        Ok(bitpacked)
     }
 }
 
@@ -101,7 +107,7 @@ pub unsafe fn bitpack_encode_unchecked(
 
     // SAFETY: checked by bitpack_unchecked
     unsafe {
-        Ok(BitPackedArray::new_unchecked(
+        let bitpacked = BitPackedArray::new_unchecked(
             packed,
             array.dtype().clone(),
             array.validity().clone(),
@@ -109,7 +115,12 @@ pub unsafe fn bitpack_encode_unchecked(
             bit_width,
             array.len(),
             0,
-        ))
+        );
+        bitpacked
+            .stats_set
+            .to_ref(&bitpacked)
+            .inherit_from(array.statistics());
+        Ok(bitpacked)
     }
 }
 

--- a/encodings/fastlanes/src/for/array/for_compress.rs
+++ b/encodings/fastlanes/src/for/array/for_compress.rs
@@ -3,7 +3,6 @@
 
 use num_traits::PrimInt;
 use num_traits::WrappingSub;
-use vortex_array::Array;
 use vortex_array::IntoArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::expr::stats::Stat;

--- a/encodings/fastlanes/src/for/array/for_compress.rs
+++ b/encodings/fastlanes/src/for/array/for_compress.rs
@@ -3,9 +3,11 @@
 
 use num_traits::PrimInt;
 use num_traits::WrappingSub;
+use vortex_array::Array;
 use vortex_array::IntoArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::expr::stats::Stat;
+use vortex_array::stats::ArrayStats;
 use vortex_dtype::NativePType;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexResult;
@@ -15,6 +17,7 @@ use crate::FoRArray;
 
 impl FoRArray {
     pub fn encode(array: PrimitiveArray) -> VortexResult<FoRArray> {
+        let stats = ArrayStats::from(array.statistics().to_owned());
         let min = array
             .statistics()
             .compute_stat(Stat::Min)?
@@ -23,7 +26,12 @@ impl FoRArray {
         let encoded = match_each_integer_ptype!(array.ptype(), |T| {
             compress_primitive::<T>(array, T::try_from(&min)?)?.into_array()
         });
-        FoRArray::try_new(encoded, min)
+        let for_array = FoRArray::try_new(encoded, min)?;
+        for_array
+            .stats_set()
+            .to_ref(for_array.as_ref())
+            .inherit_from(stats.to_ref(for_array.as_ref()));
+        Ok(for_array)
     }
 }
 

--- a/encodings/runend/src/compress.rs
+++ b/encodings/runend/src/compress.rs
@@ -2,12 +2,15 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use itertools::Itertools;
+use vortex_array::Array;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::ToCanonical;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
+use vortex_array::expr::stats::Precision;
+use vortex_array::expr::stats::Stat;
 use vortex_array::validity::Validity;
 use vortex_array::vtable::ValidityHelper;
 use vortex_buffer::BitBuffer;
@@ -32,8 +35,11 @@ pub fn runend_encode(array: &PrimitiveArray) -> (PrimitiveArray, ArrayRef) {
         Validity::AllValid => None,
         Validity::AllInvalid => {
             // We can trivially return an all-null REE array
+            let ends = PrimitiveArray::new(buffer![array.len() as u64], Validity::NonNullable);
+            ends.statistics()
+                .set(Stat::IsStrictSorted, Precision::Exact(true.into()));
             return (
-                PrimitiveArray::new(buffer![array.len() as u64], Validity::NonNullable),
+                ends,
                 ConstantArray::new(Scalar::null(array.dtype().clone()), 1).into_array(),
             );
         }
@@ -66,6 +72,9 @@ pub fn runend_encode(array: &PrimitiveArray) -> (PrimitiveArray, ArrayRef) {
         .narrow()
         .vortex_expect("Ends must succeed downcasting")
         .to_primitive();
+
+    ends.statistics()
+        .set(Stat::IsStrictSorted, Precision::Exact(true.into()));
 
     (ends, values)
 }

--- a/encodings/runend/src/compress.rs
+++ b/encodings/runend/src/compress.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use itertools::Itertools;
-use vortex_array::Array;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::ToCanonical;

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -8,6 +8,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 pub use stats::IntegerStats;
+use vortex_array::Array;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::ToCanonical;
@@ -22,7 +23,6 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 use vortex_fastlanes::FoRArray;
-use vortex_array::Array;
 use vortex_fastlanes::bitpack_compress::bit_width_histogram;
 use vortex_fastlanes::bitpack_compress::bitpack_encode;
 use vortex_fastlanes::bitpack_compress::find_best_bit_width;

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -8,7 +8,6 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 pub use stats::IntegerStats;
-use vortex_array::Array;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::ToCanonical;

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -22,6 +22,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 use vortex_fastlanes::FoRArray;
+use vortex_array::Array;
 use vortex_fastlanes::bitpack_compress::bit_width_histogram;
 use vortex_fastlanes::bitpack_compress::bitpack_encode;
 use vortex_fastlanes::bitpack_compress::find_best_bit_width;
@@ -320,7 +321,12 @@ impl Scheme for FORScheme {
         //  as well.
         let compressed = BitPackingScheme.compress(&biased_stats, is_sample, 0, excludes)?;
 
-        Ok(FoRArray::try_new(compressed, for_array.reference_scalar().clone())?.into_array())
+        let for_compressed = FoRArray::try_new(compressed, for_array.reference_scalar().clone())?;
+        for_compressed
+            .as_ref()
+            .statistics()
+            .inherit_from(for_array.as_ref().statistics());
+        Ok(for_compressed.into_array())
     }
 }
 

--- a/vortex-python/src/io.rs
+++ b/vortex-python/src/io.rs
@@ -222,7 +222,7 @@ impl PyVortexWriteOptions {
     /// >>> vx.io.VortexWriteOptions.default().write_path(sprl, "chonky.vortex")
     /// >>> import os
     /// >>> os.path.getsize('chonky.vortex')
-    /// 215996
+    /// 216156
     /// ```
     ///
     /// Wow, Vortex manages to use about two bytes per integer! So advanced. So tiny.


### PR DESCRIPTION
I am testing locally on a clickbench file, after these we get 100% of the runend -> end arrays have is_sorted set, before it was 0%

Also a note for checking this again in future, with runend validation on we will compute is_sorted when decoding the array, so to get the stored stats we have to disable runend validation