### PR TITLE
do not validate is_sorted on runend

### DIFF
--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -202,12 +202,13 @@ impl RunEndArray {
             return Ok(());
         }
 
-        // Verify that the ends are strictly monotonic.
-        if let Some(is_sorted) = ends.statistics().compute_is_strict_sorted() {
-            vortex_ensure!(is_sorted, "run ends must be monotonic");
-        } else {
-            // TODO(aduffy): fallback to slow scalar scanning if computefn impl not available?
-            vortex_bail!("run ends must report IsStrictSorted");
+        // Avoid building a non-empty array with zero logical length.
+        if length == 0 {
+            vortex_ensure!(
+                ends.is_empty(),
+                "run ends must be empty when length is zero"
+            );
+            return Ok(());
         }
 
         // Validate the offset and length are valid for the given ends and values
@@ -216,6 +217,14 @@ impl RunEndArray {
             if first_run_end <= offset {
                 vortex_bail!("First run end {first_run_end} must be bigger than offset {offset}");
             }
+        }
+
+        let last_run_end: usize = ends.scalar_at(ends.len() - 1).as_ref().try_into()?;
+        let min_required_end = offset + length;
+        if last_run_end < min_required_end {
+            vortex_bail!(
+                "Last run end {last_run_end} must be >= offset+length {min_required_end}"
+            );
         }
 
         Ok(())

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -262,9 +262,6 @@ impl RunEndArray {
     /// The `ends` must be non-nullable unsigned integers. The values may be `Bool` or `Primitive`
     /// types.
     ///
-    /// All `ends` must be strictly monotonic. A run cannot be empty, therefore there can be no
-    /// duplicates in the `ends`.
-    ///
     /// # Examples
     ///
     /// ```
@@ -272,13 +269,6 @@ impl RunEndArray {
     /// # use vortex_array::IntoArray;
     /// # use vortex_buffer::buffer;
     /// # use vortex_runend::RunEndArray;
-    ///
-    /// // Error to provide duplicate ends!
-    /// let result = RunEndArray::try_new(
-    ///     buffer![1u8, 1u8, 2u8].into_array(),
-    ///     buffer![100i32, 200i32, 300i32].into_array(),
-    /// );
-    /// assert!(result.is_err());
     ///
     /// // Error to provide incorrectly-typed values!
     /// let result = RunEndArray::try_new(

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -222,9 +222,7 @@ impl RunEndArray {
         let last_run_end: usize = ends.scalar_at(ends.len() - 1).as_ref().try_into()?;
         let min_required_end = offset + length;
         if last_run_end < min_required_end {
-            vortex_bail!(
-                "Last run end {last_run_end} must be >= offset+length {min_required_end}"
-            );
+            vortex_bail!("Last run end {last_run_end} must be >= offset+length {min_required_end}");
         }
 
         Ok(())

--- a/encodings/runend/src/compress.rs
+++ b/encodings/runend/src/compress.rs
@@ -263,12 +263,6 @@ pub fn runend_decode_typed_bool(
         Mask::AllTrue(_) => {
             let mut decoded = BitBufferMut::with_capacity(length);
             for (end, value) in run_ends.zip_eq(values.iter()) {
-                assert!(
-                    end >= decoded.len(),
-                    "Runend ends must be monotonic, got {end} after {}",
-                    decoded.len()
-                );
-                assert!(end <= length, "Runend end must be less than overall length");
                 decoded.append_n(value, end - decoded.len());
             }
             BoolArray::from_bit_buffer(decoded.freeze(), values_nullability.into())
@@ -285,12 +279,6 @@ pub fn runend_decode_typed_bool(
                     .zip(mask.bit_buffer().iter())
                     .map(|(v, is_valid)| is_valid.then_some(v)),
             ) {
-                assert!(
-                    end >= decoded.len(),
-                    "Runend ends must be monotonic, got {end} after {}",
-                    decoded.len()
-                );
-                assert!(end <= length, "Runend end must be less than overall length");
                 match value {
                     None => {
                         decoded_validity.append_n(false, end - decoded.len());

--- a/encodings/runend/src/compress.rs
+++ b/encodings/runend/src/compress.rs
@@ -204,6 +204,11 @@ pub fn runend_decode_typed_primitive<T: NativePType>(
         Mask::AllTrue(_) => {
             let mut decoded: BufferMut<T> = BufferMut::with_capacity(length);
             for (end, value) in run_ends.zip_eq(values) {
+                assert!(
+                    end >= decoded.len(),
+                    "Runend ends must be monotonic, got {end} after {}",
+                    decoded.len()
+                );
                 assert!(end <= length, "Runend end must be less than overall length");
                 // SAFETY:
                 // We preallocate enough capacity because we know the total length
@@ -221,6 +226,11 @@ pub fn runend_decode_typed_primitive<T: NativePType>(
                     .zip(mask.bit_buffer().iter())
                     .map(|(&v, is_valid)| is_valid.then_some(v)),
             ) {
+                assert!(
+                    end >= decoded.len(),
+                    "Runend ends must be monotonic, got {end} after {}",
+                    decoded.len()
+                );
                 assert!(end <= length, "Runend end must be less than overall length");
                 match value {
                     None => {
@@ -253,6 +263,12 @@ pub fn runend_decode_typed_bool(
         Mask::AllTrue(_) => {
             let mut decoded = BitBufferMut::with_capacity(length);
             for (end, value) in run_ends.zip_eq(values.iter()) {
+                assert!(
+                    end >= decoded.len(),
+                    "Runend ends must be monotonic, got {end} after {}",
+                    decoded.len()
+                );
+                assert!(end <= length, "Runend end must be less than overall length");
                 decoded.append_n(value, end - decoded.len());
             }
             BoolArray::from_bit_buffer(decoded.freeze(), values_nullability.into())
@@ -269,6 +285,12 @@ pub fn runend_decode_typed_bool(
                     .zip(mask.bit_buffer().iter())
                     .map(|(v, is_valid)| is_valid.then_some(v)),
             ) {
+                assert!(
+                    end >= decoded.len(),
+                    "Runend ends must be monotonic, got {end} after {}",
+                    decoded.len()
+                );
+                assert!(end <= length, "Runend end must be less than overall length");
                 match value {
                     None => {
                         decoded_validity.append_n(false, end - decoded.len());

--- a/encodings/runend/src/iter.rs
+++ b/encodings/runend/src/iter.rs
@@ -29,7 +29,12 @@ pub fn trimmed_ends_iter<E: IntegerPType>(
     run_ends
         .iter()
         .copied()
-        .map(move |v| v - offset_e)
+        .map(move |v| {
+            if v < offset_e {
+                vortex_panic!("run end {v} must be >= offset {offset}");
+            }
+            v - offset_e
+        })
         .map(move |v| min(v, length_e))
         .map(|v| v.as_())
 }


### PR DESCRIPTION
assert no invalid memory access will happen on decoding time instead.

I think with https://github.com/vortex-data/vortex/pull/6024 we won't hit this with new files, but there is nothing preventing this to come back when we add a new encoding into the mix, and this will also speed up decoding old files that didn't have the stat propagated