### PR TITLE
Fix semver check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,8 @@ jobs:
 
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          exclude: vortex-cuda
 
   rust-coverage:
     name: "Rust tests (coverage) (${{ matrix.suite }})"
@@ -604,10 +606,10 @@ jobs:
       matrix:
         include:
           - { shard: 1, name: "Core foundation", packages: "vortex-buffer vortex-dtype vortex-error" }
-          - { shard: 2, name: "Array types", packages: "vortex-array vortex-scalar vortex-vector", features: "--features test-harness" }
+          - { shard: 2, name: "Array types", packages: "vortex-array vortex-scalar vortex-vector", features: "--features _test-harness" }
           - { shard: 3, name: "Main library", packages: "vortex vortex-compute" }
           - { shard: 4, name: "Encodings 1", packages: "vortex-alp vortex-bytebool vortex-datetime-parts" }
-          - { shard: 5, name: "Encodings 2", packages: "vortex-decimal-byte-parts vortex-fastlanes vortex-fsst", features: "--features test-harness" }
+          - { shard: 5, name: "Encodings 2", packages: "vortex-decimal-byte-parts vortex-fastlanes vortex-fsst", features: "--features _test-harness" }
           - { shard: 6, name: "Encodings 3", packages: "vortex-pco vortex-runend vortex-sequence" }
           - { shard: 7, name: "Encodings 4", packages: "vortex-sparse vortex-zigzag vortex-zstd" }
           - { shard: 8, name: "Storage formats", packages: "vortex-flatbuffers vortex-proto vortex-btrblocks" }

--- a/encodings/alp/Cargo.toml
+++ b/encodings/alp/Cargo.toml
@@ -36,7 +36,7 @@ vortex-vector = { workspace = true }
 divan = { workspace = true }
 rand = { workspace = true }
 rstest = { workspace = true }
-vortex-array = { workspace = true, features = ["test-harness"] }
+vortex-array = { workspace = true, features = ["_test-harness"] }
 
 [[bench]]
 name = "alp_compress"

--- a/encodings/bytebool/Cargo.toml
+++ b/encodings/bytebool/Cargo.toml
@@ -27,4 +27,4 @@ vortex-scalar = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
-vortex-array = { workspace = true, features = ["test-harness"] }
+vortex-array = { workspace = true, features = ["_test-harness"] }

--- a/encodings/datetime-parts/Cargo.toml
+++ b/encodings/datetime-parts/Cargo.toml
@@ -28,4 +28,4 @@ vortex-scalar = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
-vortex-array = { workspace = true, features = ["test-harness"] }
+vortex-array = { workspace = true, features = ["_test-harness"] }

--- a/encodings/decimal-byte-parts/Cargo.toml
+++ b/encodings/decimal-byte-parts/Cargo.toml
@@ -28,4 +28,4 @@ vortex-scalar = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
-vortex-array = { path = "../../vortex-array", features = ["test-harness"] }
+vortex-array = { path = "../../vortex-array", features = ["_test-harness"] }

--- a/encodings/fastlanes/Cargo.toml
+++ b/encodings/fastlanes/Cargo.toml
@@ -40,11 +40,11 @@ itertools = { workspace = true }
 rand = { workspace = true }
 rstest = { workspace = true }
 vortex-alp = { path = "../alp" }
-vortex-array = { workspace = true, features = ["test-harness"] }
-vortex-fastlanes = { path = ".", features = ["test-harness"] }
+vortex-array = { workspace = true, features = ["_test-harness"] }
+vortex-fastlanes = { path = ".", features = ["_test-harness"] }
 
 [features]
-test-harness = ["dep:rand"]
+_test-harness = ["dep:rand"]
 
 [[bench]]
 name = "bitpacking_take"
@@ -57,9 +57,9 @@ harness = false
 [[bench]]
 name = "canonicalize_bench"
 harness = false
-required-features = ["test-harness"]
+required-features = ["_test-harness"]
 
 [[bench]]
 name = "compute_between"
 harness = false
-required-features = ["test-harness"]
+required-features = ["_test-harness"]

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
@@ -365,7 +365,7 @@ fn bytes_per_exception(ptype: PType) -> usize {
     ptype.byte_width() + 4
 }
 
-#[cfg(feature = "test-harness")]
+#[cfg(feature = "_test-harness")]
 pub mod test_harness {
     use rand::Rng as _;
     use rand::rngs::StdRng;

--- a/encodings/fsst/Cargo.toml
+++ b/encodings/fsst/Cargo.toml
@@ -30,13 +30,13 @@ vortex-scalar = { workspace = true }
 vortex-vector = { workspace = true }
 
 [features]
-test-harness = ["dep:rand", "vortex-array/test-harness"]
+_test-harness = ["dep:rand", "vortex-array/_test-harness"]
 
 [dev-dependencies]
 divan = { workspace = true }
 rand = { workspace = true }
 rstest = { workspace = true }
-vortex-array = { workspace = true, features = ["test-harness"] }
+vortex-array = { workspace = true, features = ["_test-harness"] }
 
 [[bench]]
 name = "fsst_compress"
@@ -45,7 +45,7 @@ harness = false
 [[bench]]
 name = "chunked_dict_fsst_builder"
 harness = false
-required-features = ["test-harness"]
+required-features = ["_test-harness"]
 
 [package.metadata.cargo-machete]
 ignored = ["fsst-rs"]

--- a/encodings/fsst/src/lib.rs
+++ b/encodings/fsst/src/lib.rs
@@ -17,7 +17,7 @@ mod compress;
 mod compute;
 mod kernel;
 mod ops;
-#[cfg(feature = "test-harness")]
+#[cfg(feature = "_test-harness")]
 pub mod test_utils;
 #[cfg(test)]
 mod tests;

--- a/encodings/pco/Cargo.toml
+++ b/encodings/pco/Cargo.toml
@@ -31,7 +31,7 @@ divan = { workspace = true }
 mimalloc = { workspace = true }
 rand = { workspace = true }
 rstest = { workspace = true }
-vortex-array = { workspace = true, features = ["test-harness"] }
+vortex-array = { workspace = true, features = ["_test-harness"] }
 
 [[bench]]
 name = "pco"

--- a/encodings/runend/Cargo.toml
+++ b/encodings/runend/Cargo.toml
@@ -34,7 +34,7 @@ divan = { workspace = true }
 itertools = { workspace = true }
 rand = { workspace = true }
 rstest = { workspace = true }
-vortex-array = { workspace = true, features = ["test-harness"] }
+vortex-array = { workspace = true, features = ["_test-harness"] }
 
 [features]
 arrow = ["dep:arrow-array"]

--- a/encodings/sequence/Cargo.toml
+++ b/encodings/sequence/Cargo.toml
@@ -29,7 +29,7 @@ vortex-vector = { workspace = true }
 [dev-dependencies]
 itertools = { workspace = true }
 rstest = { workspace = true }
-vortex-array = { path = "../../vortex-array", features = ["test-harness"] }
+vortex-array = { path = "../../vortex-array", features = ["_test-harness"] }
 vortex-file = { path = "../../vortex-file", features = ["tokio"] }
 vortex-layout = { path = "../../vortex-layout" }
 vortex-session = { path = "../../vortex-session" }

--- a/encodings/sparse/Cargo.toml
+++ b/encodings/sparse/Cargo.toml
@@ -31,4 +31,4 @@ vortex-vector = { workspace = true }
 [dev-dependencies]
 itertools = { workspace = true }
 rstest = { workspace = true }
-vortex-array = { workspace = true, features = ["test-harness"] }
+vortex-array = { workspace = true, features = ["_test-harness"] }

--- a/encodings/zigzag/Cargo.toml
+++ b/encodings/zigzag/Cargo.toml
@@ -24,7 +24,7 @@ zigzag = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
-vortex-array = { workspace = true, features = ["test-harness"] }
+vortex-array = { workspace = true, features = ["_test-harness"] }
 
 [lints]
 workspace = true

--- a/encodings/zstd/Cargo.toml
+++ b/encodings/zstd/Cargo.toml
@@ -31,7 +31,7 @@ zstd = { workspace = true }
 [dev-dependencies]
 divan = { workspace = true }
 rstest = { workspace = true }
-vortex-array = { workspace = true, features = ["test-harness"] }
+vortex-array = { workspace = true, features = ["_test-harness"] }
 
 [[bench]]
 name = "listview_rebuild"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -31,7 +31,7 @@ strum = { workspace = true, features = ["derive"] }
 
 # Vortex core - no default features for WASM compatibility (files feature pulls in tokio)
 vortex = { path = "../vortex", default-features = false }
-vortex-array = { workspace = true, features = ["arbitrary", "test-harness"] }
+vortex-array = { workspace = true, features = ["arbitrary", "_test-harness"] }
 vortex-btrblocks = { workspace = true }
 vortex-buffer = { workspace = true }
 vortex-dtype = { workspace = true, features = ["arbitrary"] }

--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -78,7 +78,7 @@ arbitrary = [
 ]
 canonical_counter = []
 table-display = ["dep:tabled"]
-test-harness = ["dep:goldenfile", "dep:rstest", "dep:rstest_reuse"]
+_test-harness = ["dep:goldenfile", "dep:rstest", "dep:rstest_reuse"]
 serde = [
     "dep:serde",
     "vortex-buffer/serde",
@@ -94,7 +94,7 @@ futures = { workspace = true, features = ["executor"] }
 insta = { workspace = true }
 rand_distr = { workspace = true }
 rstest = { workspace = true }
-vortex-array = { path = ".", features = ["test-harness", "table-display"] }
+vortex-array = { path = ".", features = ["_test-harness", "table-display"] }
 
 [[bench]]
 name = "search_sorted"
@@ -132,17 +132,17 @@ harness = false
 [[bench]]
 name = "chunked_dict_builder"
 harness = false
-required-features = ["test-harness"]
+required-features = ["_test-harness"]
 
 [[bench]]
 name = "dict_compress"
 harness = false
-required-features = ["test-harness"]
+required-features = ["_test-harness"]
 
 [[bench]]
 name = "dict_compare"
 harness = false
-required-features = ["test-harness"]
+required-features = ["_test-harness"]
 
 [[bench]]
 name = "dict_mask"

--- a/vortex-array/src/arrays/bool/mod.rs
+++ b/vortex-array/src/arrays/bool/mod.rs
@@ -12,5 +12,5 @@ mod vtable;
 pub use vtable::BoolMaskedValidityRule;
 pub use vtable::BoolVTable;
 
-#[cfg(feature = "test-harness")]
+#[cfg(feature = "_test-harness")]
 mod test_harness;

--- a/vortex-array/src/arrays/list/mod.rs
+++ b/vortex-array/src/arrays/list/mod.rs
@@ -9,7 +9,7 @@ mod compute;
 mod vtable;
 pub use vtable::ListVTable;
 
-#[cfg(feature = "test-harness")]
+#[cfg(feature = "_test-harness")]
 mod test_harness;
 
 #[cfg(test)]

--- a/vortex-array/src/arrays/mod.rs
+++ b/vortex-array/src/arrays/mod.rs
@@ -3,16 +3,16 @@
 
 //! All the built-in encoding schemes and arrays.
 
-#[cfg(any(test, feature = "test-harness"))]
+#[cfg(any(test, feature = "_test-harness"))]
 mod assertions;
 
-#[cfg(any(test, feature = "test-harness"))]
+#[cfg(any(test, feature = "_test-harness"))]
 pub use assertions::format_indices;
 
 #[cfg(test)]
 mod validation_tests;
 
-#[cfg(any(test, feature = "test-harness"))]
+#[cfg(any(test, feature = "_test-harness"))]
 pub mod dict_test;
 
 mod bool;

--- a/vortex-array/src/compute/mod.rs
+++ b/vortex-array/src/compute/mod.rs
@@ -53,7 +53,7 @@ mod between;
 mod boolean;
 mod cast;
 mod compare;
-#[cfg(feature = "test-harness")]
+#[cfg(feature = "_test-harness")]
 pub mod conformance;
 mod fill_null;
 mod filter;

--- a/vortex-array/src/expr/mod.rs
+++ b/vortex-array/src/expr/mod.rs
@@ -103,7 +103,7 @@ impl Hash for ExactExpr {
     }
 }
 
-#[cfg(feature = "test-harness")]
+#[cfg(feature = "_test-harness")]
 pub mod test_harness {
     use vortex_dtype::DType;
     use vortex_dtype::Nullability;

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -57,7 +57,7 @@ pub mod serde;
 pub mod session;
 pub mod stats;
 pub mod stream;
-#[cfg(any(test, feature = "test-harness"))]
+#[cfg(any(test, feature = "_test-harness"))]
 pub mod test_harness;
 pub mod validity;
 pub mod variants;

--- a/vortex-btrblocks/Cargo.toml
+++ b/vortex-btrblocks/Cargo.toml
@@ -40,7 +40,7 @@ vortex-zigzag = { workspace = true }
 [dev-dependencies]
 divan = { workspace = true }
 test-with = { workspace = true }
-vortex-array = { workspace = true, features = ["test-harness"] }
+vortex-array = { workspace = true, features = ["_test-harness"] }
 
 [features]
 # This feature enabled unstable encodings for which we don't guarantee stability.

--- a/vortex-duckdb/Cargo.toml
+++ b/vortex-duckdb/Cargo.toml
@@ -44,7 +44,7 @@ vortex-utils = { workspace = true, features = ["dashmap"] }
 [dev-dependencies]
 jiff = { workspace = true }
 rstest = { workspace = true }
-vortex-array = { workspace = true, features = ["test-harness"] }
+vortex-array = { workspace = true, features = ["_test-harness"] }
 vortex-runend = { workspace = true }
 vortex-sequence = { workspace = true }
 

--- a/vortex-file/Cargo.toml
+++ b/vortex-file/Cargo.toml
@@ -58,7 +58,7 @@ vortex-zstd = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-vortex-array = { workspace = true, features = ["test-harness"] }
+vortex-array = { workspace = true, features = ["_test-harness"] }
 vortex-io = { workspace = true, features = ["tokio"] }
 vortex-scan = { workspace = true }
 

--- a/vortex-gpu/Cargo.toml
+++ b/vortex-gpu/Cargo.toml
@@ -27,7 +27,7 @@ vortex-mask = { workspace = true }
 criterion = { version = "0.7", features = ["html_reports"] }
 rand = { workspace = true }
 rstest = { workspace = true }
-vortex-array = { workspace = true, features = ["test-harness"] }
+vortex-array = { workspace = true, features = ["_test-harness"] }
 
 [build-dependencies]
 vortex-gpu-kernels = { workspace = true }

--- a/vortex-layout/Cargo.toml
+++ b/vortex-layout/Cargo.toml
@@ -59,12 +59,12 @@ vortex-zstd = { workspace = true, optional = true }
 futures = { workspace = true, features = ["executor"] }
 rstest = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
-vortex-array = { path = "../vortex-array", features = ["test-harness"] }
+vortex-array = { path = "../vortex-array", features = ["_test-harness"] }
 vortex-io = { path = "../vortex-io", features = ["tokio"] }
-vortex-utils = { workspace = true, features = ["test-harness"] }
+vortex-utils = { workspace = true, features = ["_test-harness"] }
 
 [features]
-test-harness = []
+_test-harness = []
 tokio = ["dep:tokio", "vortex-error/tokio"]
 zstd = ["dep:vortex-zstd"]
 

--- a/vortex-layout/src/segments/mod.rs
+++ b/vortex-layout/src/segments/mod.rs
@@ -6,7 +6,7 @@ mod shared;
 mod sink;
 mod source;
 
-#[cfg(any(test, feature = "test-harness"))]
+#[cfg(any(test, feature = "_test-harness"))]
 mod test;
 
 use std::fmt::Display;
@@ -16,7 +16,7 @@ pub use cache::*;
 pub use shared::*;
 pub use sink::*;
 pub use source::*;
-#[cfg(any(test, feature = "test-harness"))]
+#[cfg(any(test, feature = "_test-harness"))]
 pub use test::*;
 use vortex_error::VortexError;
 

--- a/vortex-python/Cargo.toml
+++ b/vortex-python/Cargo.toml
@@ -46,4 +46,4 @@ url = { workspace = true }
 vortex = { workspace = true, features = ["object_store", "python", "tokio"] }
 
 [dev-dependencies]
-vortex-array = { workspace = true, features = ["test-harness"] }
+vortex-array = { workspace = true, features = ["_test-harness"] }

--- a/vortex-scan/Cargo.toml
+++ b/vortex-scan/Cargo.toml
@@ -38,7 +38,7 @@ sketches-ddsketch = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-vortex-layout = { workspace = true, features = ["test-harness"] }
+vortex-layout = { workspace = true, features = ["_test-harness"] }
 
 [features]
 default = []

--- a/vortex-utils/Cargo.toml
+++ b/vortex-utils/Cargo.toml
@@ -24,4 +24,4 @@ workspace = true
 
 [features]
 dyn-traits = []
-test-harness = ["dashmap", "parking_lot"]
+_test-harness = ["dashmap", "parking_lot"]

--- a/vortex-utils/src/lib.rs
+++ b/vortex-utils/src/lib.rs
@@ -9,5 +9,5 @@ pub mod aliases;
 pub mod debug_with;
 #[cfg(feature = "dyn-traits")]
 pub mod dyn_traits;
-#[cfg(feature = "test-harness")]
+#[cfg(feature = "_test-harness")]
 pub mod env;


### PR DESCRIPTION
1. Hide `vortex-cuda` which is not released yet (Do we want to release it in the next release?)
2. Rename the `test-harness` feature into `_test-harness`, which makes `cargo-semver-check` to ignore it.