### PR TITLE
ci: Cache clippy runs in different key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,7 @@ jobs:
           toolchain: nightly
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           timestamp: "true"
+          cache-suffix: "clippy"
       - name: Rust Lint - Format
         run: cargo +nightly fmt --all --check
       - name: Rustc check
@@ -321,6 +322,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           timestamp: "true"
+          cache-suffix: "clippy"
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       - name: Rust Lint - Clippy No Default Features


### PR DESCRIPTION
There's a bigger effort here to potentially untangle some of the caching keys, but for clippy it definitely needs a different key than steps that build/test.