### PR TITLE
Modify rust cache shared-key

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -53,6 +53,7 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref_name == 'develop' }}
+        # os and arch by default
         shared-key: "rust-cache-${{ github.job }}-${{ runner.environment }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ inputs.targets }}${{ inputs.cache-suffix && format('-{0}', inputs.cache-suffix) || '' }}"
         env-vars: "RUSTFLAGS"
 

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -53,7 +53,8 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref_name == 'develop' }}
-        shared-key: "rust-cache-${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ inputs.targets }}${{ inputs.cache-suffix && format('-{0}', inputs.cache-suffix) || '' }}"
+        shared-key: "rust-cache-${{ github.job }}-${{ runner.environment }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ inputs.targets }}${{ inputs.cache-suffix && format('-{0}', inputs.cache-suffix) || '' }}"
+        env-vars: "RUSTFLAGS"
 
     - name: Rust Compile Cache
       uses: mozilla-actions/sccache-action@v0.0.9


### PR DESCRIPTION
From reading the action's source code:
1. Job ID is only included if we don't provide da `shared-key`, which I think we do want to include.
2. OS and architecture always gets added by the actions
3. We should include `RUSTFLAGS` in the cache key, as actions that don't agree on it will end up re-compiling the world.