### PR TITLE
refactor: replace to_canonical/to_primitive with execute in execute path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10343,6 +10343,7 @@ dependencies = [
  "vortex-error",
  "vortex-mask",
  "vortex-scalar",
+ "vortex-session",
 ]
 
 [[package]]
@@ -10551,6 +10552,7 @@ dependencies = [
  "vortex-error",
  "vortex-mask",
  "vortex-scalar",
+ "vortex-session",
  "vortex-vector",
 ]
 

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -18,7 +18,6 @@ use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
 use vortex_array::SerializeMetadata;
-use vortex_array::ToCanonical;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::patches::Patches;
@@ -245,9 +244,9 @@ impl VTable for ALPRDVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
-        let left_parts = array.left_parts().to_primitive();
-        let right_parts = array.right_parts().to_primitive();
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
+        let left_parts = array.left_parts().clone().execute::<PrimitiveArray>(ctx)?;
+        let right_parts = array.right_parts().clone().execute::<PrimitiveArray>(ctx)?;
 
         // Decode the left_parts using our builtin dictionary.
         let left_parts_dict = array.left_parts_dictionary();

--- a/encodings/datetime-parts/Cargo.toml
+++ b/encodings/datetime-parts/Cargo.toml
@@ -29,3 +29,5 @@ vortex-scalar = { workspace = true }
 [dev-dependencies]
 rstest = { workspace = true }
 vortex-array = { workspace = true, features = ["_test-harness"] }
+vortex-error = { workspace = true }
+vortex-session = { workspace = true }

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -162,8 +162,8 @@ impl VTable for DateTimePartsVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
-        Ok(Canonical::Extension(decode_to_temporal(array).into()))
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
+        Ok(Canonical::Extension(decode_to_temporal(array, ctx)?.into()))
     }
 
     fn reduce_parent(

--- a/encodings/datetime-parts/src/canonical.rs
+++ b/encodings/datetime-parts/src/canonical.rs
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use num_traits::AsPrimitive;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::ToCanonical;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::TemporalArray;
 use vortex_array::compute::cast;
@@ -15,6 +15,7 @@ use vortex_dtype::datetime::TemporalMetadata;
 use vortex_dtype::datetime::TimeUnit;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexExpect as _;
+use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 
 use crate::DateTimePartsArray;
@@ -22,7 +23,10 @@ use crate::DateTimePartsArray;
 /// Decode an [Array] into a [TemporalArray].
 ///
 /// Enforces that the passed array is actually a [DateTimePartsArray] with proper metadata.
-pub fn decode_to_temporal(array: &DateTimePartsArray) -> TemporalArray {
+pub fn decode_to_temporal(
+    array: &DateTimePartsArray,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<TemporalArray> {
     let DType::Extension(ext) = array.dtype().clone() else {
         vortex_panic!(ComputeError: "expected dtype to be DType::Extension variant")
     };
@@ -44,7 +48,7 @@ pub fn decode_to_temporal(array: &DateTimePartsArray) -> TemporalArray {
         &DType::Primitive(PType::I64, array.dtype().nullability()),
     )
     .vortex_expect("must be able to cast days to i64")
-    .to_primitive();
+    .execute::<PrimitiveArray>(ctx)?;
 
     // We start with the days component, which is always present.
     // And then add the seconds and subseconds components.
@@ -64,7 +68,7 @@ pub fn decode_to_temporal(array: &DateTimePartsArray) -> TemporalArray {
             *v += seconds;
         }
     } else {
-        let seconds_buf = array.seconds().to_primitive();
+        let seconds_buf = array.seconds().clone().execute::<PrimitiveArray>(ctx)?;
         match_each_integer_ptype!(seconds_buf.ptype(), |S| {
             for (v, second) in values.iter_mut().zip(seconds_buf.as_slice::<S>()) {
                 let second: i64 = second.as_();
@@ -82,7 +86,7 @@ pub fn decode_to_temporal(array: &DateTimePartsArray) -> TemporalArray {
             *v += subseconds;
         }
     } else {
-        let subseconds_buf = array.subseconds().to_primitive();
+        let subseconds_buf = array.subseconds().clone().execute::<PrimitiveArray>(ctx)?;
         match_each_integer_ptype!(subseconds_buf.ptype(), |S| {
             for (v, subseconds) in values.iter_mut().zip(subseconds_buf.as_slice::<S>()) {
                 let subseconds: i64 = subseconds.as_();
@@ -91,17 +95,18 @@ pub fn decode_to_temporal(array: &DateTimePartsArray) -> TemporalArray {
         });
     }
 
-    TemporalArray::new_timestamp(
+    Ok(TemporalArray::new_timestamp(
         PrimitiveArray::new(values.freeze(), Validity::copy_from_array(array.as_ref()))
             .into_array(),
         temporal_metadata.time_unit(),
         temporal_metadata.time_zone().map(ToString::to_string),
-    )
+    ))
 }
 
 #[cfg(test)]
 mod test {
     use rstest::rstest;
+    use vortex_array::ExecutionCtx;
     use vortex_array::IntoArray;
     use vortex_array::ToCanonical;
     use vortex_array::arrays::PrimitiveArray;
@@ -111,6 +116,8 @@ mod test {
     use vortex_array::vtable::ValidityHelper;
     use vortex_buffer::buffer;
     use vortex_dtype::datetime::TimeUnit;
+    use vortex_error::VortexResult;
+    use vortex_session::VortexSession;
 
     use crate::DateTimePartsArray;
     use crate::canonical::decode_to_temporal;
@@ -120,7 +127,7 @@ mod test {
     #[case(Validity::AllValid)]
     #[case(Validity::AllInvalid)]
     #[case(Validity::from_iter([true, true, false, false, true, true]))]
-    fn test_decode_to_temporal(#[case] validity: Validity) {
+    fn test_decode_to_temporal(#[case] validity: Validity) -> VortexResult<()> {
         let milliseconds = PrimitiveArray::new(
             buffer![
                 86_400i64, // element with only day component
@@ -144,11 +151,13 @@ mod test {
             validity.to_mask(date_times.len())
         );
 
-        let primitive_values = decode_to_temporal(&date_times)
+        let mut ctx = ExecutionCtx::new(VortexSession::empty());
+        let primitive_values = decode_to_temporal(&date_times, &mut ctx)?
             .temporal_values()
             .to_primitive();
 
         assert_arrays_eq!(primitive_values, milliseconds);
         assert_eq!(primitive_values.validity(), &validity);
+        Ok(())
     }
 }

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -20,8 +20,8 @@ use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
 use vortex_array::SerializeMetadata;
-use vortex_array::ToCanonical;
 use vortex_array::arrays::DecimalArray;
+use vortex_array::arrays::PrimitiveArray;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::stats::ArrayStats;
@@ -145,8 +145,8 @@ impl VTable for DecimalBytePartsVTable {
         }))
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
-        to_canonical_decimal(array)
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
+        to_canonical_decimal(array, ctx)
     }
 }
 
@@ -237,9 +237,12 @@ impl BaseArrayVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
 }
 
 /// Converts a DecimalBytePartsArray to its canonical DecimalArray representation.
-fn to_canonical_decimal(array: &DecimalBytePartsArray) -> VortexResult<Canonical> {
+fn to_canonical_decimal(
+    array: &DecimalBytePartsArray,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Canonical> {
     // TODO(joe): support parts len != 1
-    let prim = array.msp.to_primitive();
+    let prim = array.msp.clone().execute::<PrimitiveArray>(ctx)?;
     // Depending on the decimal type and the min/max of the primitive array we can choose
     // the correct buffer size
 

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
@@ -3,7 +3,7 @@
 
 use fastlanes::BitPacking;
 use itertools::Itertools;
-use vortex_array::ToCanonical;
+use vortex_array::ExecutionCtx;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::builders::ArrayBuilder;
 use vortex_array::builders::PrimitiveBuilder;
@@ -15,6 +15,7 @@ use vortex_dtype::NativePType;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_dtype::match_each_unsigned_integer_ptype;
 use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 use vortex_mask::Mask;
 use vortex_scalar::Scalar;
@@ -61,25 +62,34 @@ pub fn unpack_to_pvector<P: BitPacked>(array: &BitPackedArray) -> PVectorMut<P> 
     unsafe { PVectorMut::new_unchecked(elements, validity) }
 }
 
-pub fn unpack_array(array: &BitPackedArray) -> PrimitiveArray {
-    match_each_integer_ptype!(array.ptype(), |P| { unpack_primitive_array::<P>(array) })
+pub fn unpack_array(
+    array: &BitPackedArray,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<PrimitiveArray> {
+    match_each_integer_ptype!(array.ptype(), |P| {
+        unpack_primitive_array::<P>(array, ctx)
+    })
 }
 
-pub fn unpack_primitive_array<T: BitPacked>(array: &BitPackedArray) -> PrimitiveArray {
+pub fn unpack_primitive_array<T: BitPacked>(
+    array: &BitPackedArray,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<PrimitiveArray> {
     let mut builder = PrimitiveBuilder::with_capacity(array.dtype().nullability(), array.len());
-    unpack_into_primitive_builder::<T>(array, &mut builder);
+    unpack_into_primitive_builder::<T>(array, &mut builder, ctx)?;
     assert_eq!(builder.len(), array.len());
-    builder.finish_into_primitive()
+    Ok(builder.finish_into_primitive())
 }
 
 pub(crate) fn unpack_into_primitive_builder<T: BitPacked>(
     array: &BitPackedArray,
     // TODO(ngates): do we want to use fastlanes alignment for this buffer?
     builder: &mut PrimitiveBuilder<T>,
-) {
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<()> {
     // If the array is empty, then we don't need to add anything to the builder.
     if array.is_empty() {
-        return;
+        return Ok(());
     }
 
     let mut uninit_range = builder.uninit_range(array.len());
@@ -97,7 +107,7 @@ pub(crate) fn unpack_into_primitive_builder<T: BitPacked>(
     bit_packed_iter.decode_into(uninit_slice);
 
     if let Some(patches) = array.patches() {
-        apply_patches_to_uninit_range(&mut uninit_range, patches);
+        apply_patches_to_uninit_range(&mut uninit_range, patches, ctx)?;
     };
 
     // SAFETY: We have set a correct validity mask via `append_mask` with `array.len()` values and
@@ -105,21 +115,27 @@ pub(crate) fn unpack_into_primitive_builder<T: BitPacked>(
     unsafe {
         uninit_range.finish();
     }
+    Ok(())
 }
 
-pub fn apply_patches_to_uninit_range<T: NativePType>(dst: &mut UninitRange<T>, patches: &Patches) {
-    apply_patches_to_uninit_range_fn(dst, patches, |x| x)
+pub fn apply_patches_to_uninit_range<T: NativePType>(
+    dst: &mut UninitRange<T>,
+    patches: &Patches,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<()> {
+    apply_patches_to_uninit_range_fn(dst, patches, ctx, |x| x)
 }
 
 pub fn apply_patches_to_uninit_range_fn<T: NativePType, F: Fn(T) -> T>(
     dst: &mut UninitRange<T>,
     patches: &Patches,
+    ctx: &mut ExecutionCtx,
     f: F,
-) {
+) -> VortexResult<()> {
     assert_eq!(patches.array_len(), dst.len());
 
-    let indices = patches.indices().to_primitive();
-    let values = patches.values().to_primitive();
+    let indices = patches.indices().clone().execute::<PrimitiveArray>(ctx)?;
+    let values = patches.values().clone().execute::<PrimitiveArray>(ctx)?;
     let validity = values.validity_mask();
     let values = values.as_slice::<T>();
 
@@ -133,6 +149,7 @@ pub fn apply_patches_to_uninit_range_fn<T: NativePType, F: Fn(T) -> T>(
             f,
         )
     });
+    Ok(())
 }
 
 fn insert_values_and_validity_at_indices_to_uninit_range<

--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -34,6 +34,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
+use vortex_session::VortexSession;
 
 use crate::BitPackedArray;
 use crate::bitpack_decompress::unpack_array;
@@ -254,6 +255,7 @@ impl VTable for BitPackedVTable {
         array: &BitPackedArray,
         builder: &mut dyn ArrayBuilder,
     ) -> VortexResult<()> {
+        let mut ctx = ExecutionCtx::new(VortexSession::empty());
         match_each_integer_ptype!(array.ptype(), |T| {
             unpack_into_primitive_builder::<T>(
                 array,
@@ -261,13 +263,13 @@ impl VTable for BitPackedVTable {
                     .as_any_mut()
                     .downcast_mut()
                     .vortex_expect("bit packed array must canonicalize into a primitive array"),
+                &mut ctx,
             )
-        });
-        Ok(())
+        })
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
-        Ok(Canonical::Primitive(unpack_array(array)))
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
+        Ok(Canonical::Primitive(unpack_array(array, ctx)?))
     }
 
     fn execute_parent(

--- a/encodings/fastlanes/src/delta/array/delta_decompress.rs
+++ b/encodings/fastlanes/src/delta/array/delta_decompress.rs
@@ -7,19 +7,23 @@ use fastlanes::Delta;
 use fastlanes::FastLanes;
 use fastlanes::Transpose;
 use num_traits::WrappingAdd;
-use vortex_array::ToCanonical;
+use vortex_array::ExecutionCtx;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
 use vortex_dtype::NativePType;
 use vortex_dtype::match_each_unsigned_integer_ptype;
+use vortex_error::VortexResult;
 
 use crate::DeltaArray;
 
-pub fn delta_decompress(array: &DeltaArray) -> PrimitiveArray {
-    let bases = array.bases().to_primitive();
-    let deltas = array.deltas().to_primitive();
+pub fn delta_decompress(
+    array: &DeltaArray,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<PrimitiveArray> {
+    let bases = array.bases().clone().execute::<PrimitiveArray>(ctx)?;
+    let deltas = array.deltas().clone().execute::<PrimitiveArray>(ctx)?;
 
     let start = array.offset();
     let end = start + array.len();
@@ -29,14 +33,14 @@ pub fn delta_decompress(array: &DeltaArray) -> PrimitiveArray {
     let validity = Validity::from_mask(array.deltas().validity_mask(), array.dtype().nullability());
     let validity = validity.slice(start..end);
 
-    match_each_unsigned_integer_ptype!(deltas.ptype(), |T| {
+    Ok(match_each_unsigned_integer_ptype!(deltas.ptype(), |T| {
         const LANES: usize = T::LANES;
 
         let buffer = decompress_primitive::<T, LANES>(bases.as_slice(), deltas.as_slice());
         let buffer = buffer.slice(start..end);
 
         PrimitiveArray::new(buffer, validity)
-    })
+    }))
 }
 
 // TODO(ngates): can we re-use the deltas buffer for the result? Might be tricky given the

--- a/encodings/fastlanes/src/delta/vtable/mod.rs
+++ b/encodings/fastlanes/src/delta/vtable/mod.rs
@@ -148,8 +148,8 @@ impl VTable for DeltaVTable {
         DeltaArray::try_new(bases, deltas, metadata.0.offset as usize, len)
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
-        Ok(Canonical::Primitive(delta_decompress(array)))
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
+        Ok(Canonical::Primitive(delta_decompress(array, ctx)?))
     }
 }
 

--- a/encodings/fastlanes/src/for/array/for_decompress.rs
+++ b/encodings/fastlanes/src/for/array/for_decompress.rs
@@ -4,7 +4,7 @@
 use fastlanes::FoR;
 use num_traits::PrimInt;
 use num_traits::WrappingAdd;
-use vortex_array::ToCanonical;
+use vortex_array::ExecutionCtx;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::builders::PrimitiveBuilder;
 use vortex_array::vtable::ValidityHelper;
@@ -16,6 +16,7 @@ use vortex_dtype::UnsignedPType;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_dtype::match_each_unsigned_integer_ptype;
 use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
 
 use crate::BitPackedArray;
 use crate::BitPackedVTable;
@@ -44,7 +45,7 @@ impl<T: PhysicalPType<Physical = T> + FoR> UnpackStrategy<T> for FoRStrategy<T> 
     }
 }
 
-pub fn decompress(array: &FoRArray) -> PrimitiveArray {
+pub fn decompress(array: &FoRArray, ctx: &mut ExecutionCtx) -> VortexResult<PrimitiveArray> {
     let ptype = array.ptype();
 
     // Try to do fused unpack.
@@ -52,15 +53,15 @@ pub fn decompress(array: &FoRArray) -> PrimitiveArray {
         && let Some(bp) = array.encoded().as_opt::<BitPackedVTable>()
     {
         return match_each_unsigned_integer_ptype!(array.ptype(), |T| {
-            fused_decompress::<T>(array, bp)
+            fused_decompress::<T>(array, bp, ctx)
         });
     }
 
     // TODO(ngates): Do we need this to be into_encoded() somehow?
-    let encoded = array.encoded().to_primitive();
+    let encoded = array.encoded().clone().execute::<PrimitiveArray>(ctx)?;
     let validity = encoded.validity().clone();
 
-    match_each_integer_ptype!(ptype, |T| {
+    Ok(match_each_integer_ptype!(ptype, |T| {
         let min = array
             .reference_scalar()
             .as_primitive()
@@ -74,7 +75,7 @@ pub fn decompress(array: &FoRArray) -> PrimitiveArray {
                 validity,
             )
         }
-    })
+    }))
 }
 
 pub(crate) fn fused_decompress<
@@ -82,7 +83,8 @@ pub(crate) fn fused_decompress<
 >(
     for_: &FoRArray,
     bp: &BitPackedArray,
-) -> PrimitiveArray {
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<PrimitiveArray> {
     let ref_ = for_
         .reference_scalar()
         .as_primitive()
@@ -117,9 +119,12 @@ pub(crate) fn fused_decompress<
     unpacked.decode_into(uninit_slice);
 
     if let Some(patches) = bp.patches() {
-        bitpack_decompress::apply_patches_to_uninit_range_fn(&mut uninit_range, patches, |v| {
-            v.wrapping_add(&ref_)
-        });
+        bitpack_decompress::apply_patches_to_uninit_range_fn(
+            &mut uninit_range,
+            patches,
+            ctx,
+            |v| v.wrapping_add(&ref_),
+        )?;
     };
 
     // SAFETY: We have set a correct validity mask via `append_mask` with `array.len()` values and
@@ -128,7 +133,7 @@ pub(crate) fn fused_decompress<
         uninit_range.finish();
     }
 
-    builder.finish_into_primitive()
+    Ok(builder.finish_into_primitive())
 }
 
 fn decompress_primitive<T: NativePType + WrappingAdd + PrimInt>(

--- a/encodings/fastlanes/src/for/vtable/mod.rs
+++ b/encodings/fastlanes/src/for/vtable/mod.rs
@@ -127,8 +127,8 @@ impl VTable for FoRVTable {
         }))
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
-        Ok(Canonical::Primitive(decompress(array)))
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
+        Ok(Canonical::Primitive(decompress(array, ctx)?))
     }
 }
 

--- a/encodings/fastlanes/src/rle/array/rle_decompress.rs
+++ b/encodings/fastlanes/src/rle/array/rle_decompress.rs
@@ -6,13 +6,14 @@ use arrayref::array_ref;
 use fastlanes::RLE;
 use num_traits::AsPrimitive;
 use vortex_array::Array;
-use vortex_array::ToCanonical;
+use vortex_array::ExecutionCtx;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::validity::Validity;
 use vortex_buffer::BufferMut;
 use vortex_dtype::NativePType;
 use vortex_dtype::match_each_native_ptype;
 use vortex_dtype::match_each_unsigned_integer_ptype;
+use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 
 use crate::FL_CHUNK_SIZE;
@@ -23,13 +24,13 @@ use crate::RLEArray;
     clippy::cognitive_complexity,
     reason = "complexity is from nested match_each_* macros"
 )]
-pub fn rle_decompress(array: &RLEArray) -> PrimitiveArray {
+pub fn rle_decompress(array: &RLEArray, ctx: &mut ExecutionCtx) -> VortexResult<PrimitiveArray> {
     match_each_native_ptype!(array.values().dtype().as_ptype(), |V| {
         match_each_unsigned_integer_ptype!(array.values_idx_offsets().dtype().as_ptype(), |O| {
             // RLE indices are always u16 (or u8 if downcasted).
             match array.indices().dtype().as_ptype() {
-                PType::U8 => rle_decode_typed::<V, u8, O>(array),
-                PType::U16 => rle_decode_typed::<V, u16, O>(array),
+                PType::U8 => rle_decode_typed::<V, u8, O>(array, ctx),
+                PType::U16 => rle_decode_typed::<V, u16, O>(array, ctx),
                 _ => vortex_panic!(
                     "Unsupported index type for RLE decoding: {}",
                     array.indices().dtype().as_ptype()
@@ -40,16 +41,19 @@ pub fn rle_decompress(array: &RLEArray) -> PrimitiveArray {
 }
 
 /// Decompresses an `RLEArray` into to a primitive array of unsigned integers.
-fn rle_decode_typed<V, I, O>(array: &RLEArray) -> PrimitiveArray
+fn rle_decode_typed<V, I, O>(
+    array: &RLEArray,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<PrimitiveArray>
 where
     V: NativePType + RLE + Clone + Copy,
     I: NativePType + Into<usize>,
     O: NativePType + AsPrimitive<u64>,
 {
-    let values = array.values().to_primitive();
+    let values = array.values().clone().execute::<PrimitiveArray>(ctx)?;
     let values = values.as_slice::<V>();
 
-    let indices = array.indices().to_primitive();
+    let indices = array.indices().clone().execute::<PrimitiveArray>(ctx)?;
     let indices = indices.as_slice::<I>();
     assert_eq!(indices.len() % FL_CHUNK_SIZE, 0);
 
@@ -60,7 +64,10 @@ where
     let mut buffer = BufferMut::<V>::with_capacity(num_chunks * FL_CHUNK_SIZE);
     let buffer_uninit = buffer.spare_capacity_mut();
 
-    let values_idx_offsets = array.values_idx_offsets().to_primitive();
+    let values_idx_offsets = array
+        .values_idx_offsets()
+        .clone()
+        .execute::<PrimitiveArray>(ctx)?;
     let values_idx_offsets = values_idx_offsets.as_slice::<O>();
 
     for chunk_idx in 0..num_chunks {
@@ -91,10 +98,10 @@ where
 
     let offset_within_chunk = array.offset();
 
-    PrimitiveArray::new(
+    Ok(PrimitiveArray::new(
         buffer
             .freeze()
             .slice(offset_within_chunk..(offset_within_chunk + array.len())),
         Validity::copy_from_array(array.as_ref()),
-    )
+    ))
 }

--- a/encodings/fastlanes/src/rle/vtable/mod.rs
+++ b/encodings/fastlanes/src/rle/vtable/mod.rs
@@ -195,8 +195,8 @@ impl VTable for RLEVTable {
         PARENT_KERNELS.execute(array, parent, child_idx, ctx)
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
-        Ok(Canonical::Primitive(rle_decompress(array)))
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
+        Ok(Canonical::Primitive(rle_decompress(array, ctx)?))
     }
 
     fn reduce_parent(

--- a/encodings/fsst/Cargo.toml
+++ b/encodings/fsst/Cargo.toml
@@ -27,6 +27,7 @@ vortex-dtype = { workspace = true }
 vortex-error = { workspace = true }
 vortex-mask = { workspace = true }
 vortex-scalar = { workspace = true }
+vortex-session = { workspace = true }
 vortex-vector = { workspace = true }
 
 [features]

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -191,14 +191,15 @@ impl VTable for FSSTVTable {
 
         // Decompress the whole block of data into a new buffer, and create some views
         // from it instead.
-        let (buffer, views) = fsst_decode_views(array, builder.completed_block_count());
+        let mut ctx = ExecutionCtx::new(vortex_session::VortexSession::empty());
+        let (buffer, views) = fsst_decode_views(array, builder.completed_block_count(), &mut ctx)?;
 
         builder.push_buffer_and_adjusted_views(&[buffer], &views, array.validity_mask());
         Ok(())
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
-        canonicalize_fsst(array)
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
+        canonicalize_fsst(array, ctx)
     }
 
     fn execute_parent(

--- a/encodings/fsst/src/canonical.rs
+++ b/encodings/fsst/src/canonical.rs
@@ -4,7 +4,8 @@
 use std::sync::Arc;
 
 use vortex_array::Canonical;
-use vortex_array::ToCanonical;
+use vortex_array::ExecutionCtx;
+use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::VarBinViewArray;
 use vortex_array::vtable::ValidityHelper;
 use vortex_buffer::Buffer;
@@ -17,8 +18,11 @@ use vortex_vector::binaryview::BinaryView;
 
 use crate::FSSTArray;
 
-pub(super) fn canonicalize_fsst(array: &FSSTArray) -> VortexResult<Canonical> {
-    let (buffer, views) = fsst_decode_views(array, 0);
+pub(super) fn canonicalize_fsst(
+    array: &FSSTArray,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Canonical> {
+    let (buffer, views) = fsst_decode_views(array, 0, ctx)?;
     // SAFETY: FSST already validates the bytes for binary/UTF-8. We build views directly on
     //  top of them, so the view pointers will all be valid.
     Ok(unsafe {
@@ -38,7 +42,8 @@ pub(super) fn canonicalize_fsst(array: &FSSTArray) -> VortexResult<Canonical> {
 pub(super) fn fsst_decode_views(
     fsst_array: &FSSTArray,
     buf_index: u32,
-) -> (ByteBuffer, Buffer<BinaryView>) {
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<(ByteBuffer, Buffer<BinaryView>)> {
     // FSSTArray has two child arrays:
     //  1. A VarBinArray, which holds the string heap of the compressed codes.
     //  2. An uncompressed_lengths primitive array, storing the length of each original
@@ -48,7 +53,10 @@ pub(super) fn fsst_decode_views(
     // necessary for a VarBinViewArray and construct the canonical array.
     let bytes = fsst_array.codes().sliced_bytes();
 
-    let uncompressed_lens_array = fsst_array.uncompressed_lengths().to_primitive();
+    let uncompressed_lens_array = fsst_array
+        .uncompressed_lengths()
+        .clone()
+        .execute::<PrimitiveArray>(ctx)?;
 
     // Decompress the full dataset.
     #[allow(clippy::cast_possible_truncation)]
@@ -85,7 +93,7 @@ pub(super) fn fsst_decode_views(
         }
     });
 
-    (uncompressed_bytes.freeze(), views.freeze())
+    Ok((uncompressed_bytes.freeze(), views.freeze()))
 }
 
 #[cfg(test)]

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -151,8 +151,8 @@ impl VTable for RunEndVTable {
         PARENT_KERNELS.execute(array, parent, child_idx, ctx)
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
-        run_end_canonicalize(array)
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
+        run_end_canonicalize(array, ctx)
     }
 }
 
@@ -475,11 +475,14 @@ impl ValidityVTable<RunEndVTable> for RunEndVTable {
     }
 }
 
-pub(super) fn run_end_canonicalize(array: &RunEndArray) -> VortexResult<Canonical> {
-    let pends = array.ends().to_primitive();
+pub(super) fn run_end_canonicalize(
+    array: &RunEndArray,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Canonical> {
+    let pends = array.ends().clone().execute(ctx)?;
     Ok(match array.dtype() {
         DType::Bool(_) => {
-            let bools = array.values().to_bool();
+            let bools = array.values().clone().execute(ctx)?;
             Canonical::Bool(runend_decode_bools(
                 pends,
                 bools,
@@ -488,7 +491,7 @@ pub(super) fn run_end_canonicalize(array: &RunEndArray) -> VortexResult<Canonica
             ))
         }
         DType::Primitive(..) => {
-            let pvalues = array.values().to_primitive();
+            let pvalues = array.values().clone().execute(ctx)?;
             Canonical::Primitive(runend_decode_primitive(
                 pends,
                 pvalues,

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -7,7 +7,8 @@ use itertools::Itertools;
 use num_traits::NumCast;
 use vortex_array::Array;
 use vortex_array::Canonical;
-use vortex_array::ToCanonical;
+use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::FixedSizeListArray;
@@ -53,9 +54,14 @@ use vortex_vector::binaryview::BinaryView;
 
 use crate::SparseArray;
 
-pub(super) fn canonicalize_sparse(array: &SparseArray) -> VortexResult<Canonical> {
+pub(super) fn canonicalize_sparse(
+    array: &SparseArray,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Canonical> {
     if array.patches().num_patches() == 0 {
-        return ConstantArray::new(array.fill_scalar().clone(), array.len()).to_canonical();
+        return ConstantArray::new(array.fill_scalar().clone(), array.len())
+            .into_array()
+            .execute(ctx);
     }
 
     Ok(match array.dtype() {
@@ -79,7 +85,8 @@ pub(super) fn canonicalize_sparse(array: &SparseArray) -> VortexResult<Canonical
             array.dtype(),
             array.patches(),
             array.len(),
-        ),
+            ctx,
+        )?,
         DType::Decimal(decimal_dtype, nullability) => {
             let canonical_decimal_value_type =
                 DecimalType::smallest_decimal_value_type(decimal_dtype);
@@ -97,17 +104,17 @@ pub(super) fn canonicalize_sparse(array: &SparseArray) -> VortexResult<Canonical
         dtype @ DType::Utf8(..) => {
             let fill_value = array.fill_scalar().as_utf8().value();
             let fill_value = fill_value.map(BufferString::into_inner);
-            canonicalize_varbin(array, dtype.clone(), fill_value)
+            canonicalize_varbin(array, dtype.clone(), fill_value, ctx)?
         }
         dtype @ DType::Binary(..) => {
             let fill_value = array.fill_scalar().as_binary().value();
-            canonicalize_varbin(array, dtype.clone(), fill_value)
+            canonicalize_varbin(array, dtype.clone(), fill_value, ctx)?
         }
         DType::List(values_dtype, nullability) => {
-            canonicalize_sparse_lists(array, values_dtype.clone(), *nullability)
+            canonicalize_sparse_lists(array, values_dtype.clone(), *nullability, ctx)?
         }
         DType::FixedSizeList(.., nullability) => {
-            canonicalize_sparse_fixed_size_list(array, *nullability)
+            canonicalize_sparse_fixed_size_list(array, *nullability, ctx)?
         }
         DType::Extension(_ext_dtype) => todo!(),
     })
@@ -121,11 +128,18 @@ fn canonicalize_sparse_lists(
     array: &SparseArray,
     values_dtype: Arc<DType>,
     nullability: Nullability,
-) -> Canonical {
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Canonical> {
     let resolved_patches = array.resolved_patches();
 
-    let indices = resolved_patches.indices().to_primitive();
-    let values = resolved_patches.values().to_listview();
+    let indices = resolved_patches
+        .indices()
+        .clone()
+        .execute::<PrimitiveArray>(ctx)?;
+    let values = resolved_patches
+        .values()
+        .clone()
+        .execute::<ListViewArray>(ctx)?;
     let fill_value = array.fill_scalar().as_list();
 
     let n_filled = array.len() - resolved_patches.num_patches();
@@ -133,7 +147,7 @@ fn canonicalize_sparse_lists(
 
     let validity = Validity::from_mask(array.validity_mask(), nullability);
 
-    match_each_integer_ptype!(indices.ptype(), |I| {
+    Ok(match_each_integer_ptype!(indices.ptype(), |I| {
         match_smallest_offset_type!(total_canonical_values, |O| {
             canonicalize_sparse_lists_inner::<I, O>(
                 indices.as_slice(),
@@ -145,7 +159,7 @@ fn canonicalize_sparse_lists(
                 validity,
             )
         })
-    })
+    }))
 }
 
 fn canonicalize_sparse_lists_inner<I: IntegerPType, O: IntegerPType>(
@@ -195,15 +209,25 @@ fn canonicalize_sparse_lists_inner<I: IntegerPType, O: IntegerPType>(
 }
 
 /// Canonicalize a sparse [`FixedSizeListArray`] by expanding it into a dense representation.
-fn canonicalize_sparse_fixed_size_list(array: &SparseArray, nullability: Nullability) -> Canonical {
+fn canonicalize_sparse_fixed_size_list(
+    array: &SparseArray,
+    nullability: Nullability,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Canonical> {
     let resolved_patches = array.resolved_patches();
-    let indices = resolved_patches.indices().to_primitive();
-    let values = resolved_patches.values().to_fixed_size_list();
+    let indices = resolved_patches
+        .indices()
+        .clone()
+        .execute::<PrimitiveArray>(ctx)?;
+    let values = resolved_patches
+        .values()
+        .clone()
+        .execute::<FixedSizeListArray>(ctx)?;
     let fill_value = array.fill_scalar().as_list();
 
     let validity = Validity::from_mask(array.validity_mask(), nullability);
 
-    match_each_integer_ptype!(indices.ptype(), |I| {
+    Ok(match_each_integer_ptype!(indices.ptype(), |I| {
         canonicalize_sparse_fixed_size_list_inner::<I>(
             indices.as_slice(),
             values,
@@ -211,7 +235,7 @@ fn canonicalize_sparse_fixed_size_list(array: &SparseArray, nullability: Nullabi
             array.len(),
             validity,
         )
-    })
+    }))
 }
 
 /// Build a canonical [`FixedSizeListArray`] from sparse patches by interleaving patch values with
@@ -356,7 +380,8 @@ fn canonicalize_sparse_struct(
     // Resolution is unnecessary b/c we're just pushing the patches into the fields.
     unresolved_patches: &Patches,
     len: usize,
-) -> Canonical {
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Canonical> {
     let (fill_values, top_level_fill_validity) = match fill_struct.fields() {
         Some(fill_values) => (fill_values.collect::<Vec<_>>(), Validity::AllValid),
         None => (
@@ -367,7 +392,10 @@ fn canonicalize_sparse_struct(
             Validity::AllInvalid,
         ),
     };
-    let patch_values_as_struct = unresolved_patches.values().to_struct();
+    let patch_values_as_struct = unresolved_patches
+        .values()
+        .clone()
+        .execute::<StructArray>(ctx)?;
     let columns_patch_values = patch_values_as_struct.fields();
     let names = patch_values_as_struct.names();
     let validity = if dtype.is_nullable() {
@@ -405,7 +433,6 @@ fn canonicalize_sparse_struct(
         validity,
     )
     .map(Canonical::Struct)
-    .vortex_expect("Creating struct array")
 }
 
 fn canonicalize_sparse_decimal<D: NativeDecimalType>(
@@ -438,17 +465,18 @@ fn canonicalize_varbin(
     array: &SparseArray,
     dtype: DType,
     fill_value: Option<ByteBuffer>,
-) -> Canonical {
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Canonical> {
     let patches = array.resolved_patches();
-    let indices = patches.indices().to_primitive();
-    let values = patches.values().to_varbinview();
+    let indices = patches.indices().clone().execute::<PrimitiveArray>(ctx)?;
+    let values = patches.values().clone().execute::<VarBinViewArray>(ctx)?;
     let validity = Validity::from_mask(array.validity_mask(), dtype.nullability());
     let len = array.len();
 
-    match_each_integer_ptype!(indices.ptype(), |I| {
+    Ok(match_each_integer_ptype!(indices.ptype(), |I| {
         let indices = indices.to_buffer::<I>();
         canonicalize_varbin_inner::<I>(fill_value, indices, values, dtype, validity, len)
-    })
+    }))
 }
 
 fn canonicalize_varbin_inner<I: IntegerPType>(

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -190,8 +190,8 @@ impl VTable for SparseVTable {
         ))
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
-        canonicalize_sparse(array)
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
+        canonicalize_sparse(array, ctx)
     }
 }
 

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -15,7 +15,6 @@ use vortex_array::EmptyMetadata;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::Precision;
-use vortex_array::ToCanonical;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::stats::ArrayStats;
@@ -112,9 +111,9 @@ impl VTable for ZigZagVTable {
         ))
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
         Ok(Canonical::Primitive(zigzag_decode(
-            array.encoded().to_primitive(),
+            array.encoded().clone().execute(ctx)?,
         )))
     }
 }
@@ -220,6 +219,7 @@ impl VisitorVTable<ZigZagVTable> for ZigZagVTable {
 #[cfg(test)]
 mod test {
     use vortex_array::IntoArray;
+    use vortex_array::ToCanonical;
     use vortex_buffer::buffer;
     use vortex_scalar::Scalar;
 

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -179,8 +179,8 @@ impl VTable for ZstdVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
-        array.decompress().to_canonical()
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
+        array.decompress().execute(ctx)
     }
 
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {

--- a/vortex-array/src/arrays/chunked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/chunked/vtable/canonical.rs
@@ -12,8 +12,8 @@ use vortex_error::VortexResult;
 use crate::Array;
 use crate::ArrayRef;
 use crate::Canonical;
+use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::ToCanonical;
 use crate::arrays::ChunkedArray;
 use crate::arrays::ListViewArray;
 use crate::arrays::ListViewRebuildMode;
@@ -23,12 +23,15 @@ use crate::builders::builder_with_capacity;
 use crate::compute::cast;
 use crate::validity::Validity;
 
-pub(super) fn _canonicalize(array: &ChunkedArray) -> VortexResult<Canonical> {
+pub(super) fn _canonicalize(
+    array: &ChunkedArray,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Canonical> {
     if array.nchunks() == 0 {
         return Ok(Canonical::empty(array.dtype()));
     }
     if array.nchunks() == 1 {
-        return array.chunks()[0].to_canonical();
+        return array.chunks()[0].clone().execute::<Canonical>(ctx);
     }
 
     Ok(match array.dtype() {
@@ -37,13 +40,15 @@ pub(super) fn _canonicalize(array: &ChunkedArray) -> VortexResult<Canonical> {
                 array.chunks(),
                 Validity::copy_from_array(array.as_ref()),
                 struct_dtype,
-            );
+                ctx,
+            )?;
             Canonical::Struct(struct_array)
         }
         DType::List(elem_dtype, _) => Canonical::List(swizzle_list_chunks(
             array.chunks(),
             Validity::copy_from_array(array.as_ref()),
             elem_dtype,
+            ctx,
         )?),
         _ => {
             let mut builder = builder_with_capacity(array.dtype(), array.len());
@@ -61,21 +66,22 @@ fn pack_struct_chunks(
     chunks: &[ArrayRef],
     validity: Validity,
     struct_dtype: &StructFields,
-) -> StructArray {
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<StructArray> {
     let len = chunks.iter().map(|chunk| chunk.len()).sum();
     let mut field_arrays = Vec::new();
 
     for (field_idx, field_dtype) in struct_dtype.fields().enumerate() {
-        let field_chunks = chunks
-            .iter()
-            .map(|c| {
-                c.to_struct()
-                    .fields()
-                    .get(field_idx)
-                    .vortex_expect("Invalid field index")
-                    .to_array()
-            })
-            .collect::<Vec<_>>();
+        let mut field_chunks = Vec::with_capacity(chunks.len());
+        for c in chunks {
+            let struct_array = c.clone().execute::<StructArray>(ctx)?;
+            let field = struct_array
+                .fields()
+                .get(field_idx)
+                .vortex_expect("Invalid field index")
+                .to_array();
+            field_chunks.push(field);
+        }
 
         // SAFETY: field_chunks are extracted from valid StructArrays with matching dtypes.
         // Each chunk's field array is guaranteed to be valid for field_dtype.
@@ -85,7 +91,7 @@ fn pack_struct_chunks(
 
     // SAFETY: field_arrays are built from corresponding chunks of same length, dtypes match by
     // construction.
-    unsafe { StructArray::new_unchecked(field_arrays, struct_dtype.clone(), len, validity) }
+    Ok(unsafe { StructArray::new_unchecked(field_arrays, struct_dtype.clone(), len, validity) })
 }
 
 /// Packs [`ListViewArray`]s together into a chunked `ListViewArray`.
@@ -97,6 +103,7 @@ fn swizzle_list_chunks(
     chunks: &[ArrayRef],
     validity: Validity,
     elem_dtype: &DType,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<ListViewArray> {
     let len: usize = chunks.iter().map(|c| c.len()).sum();
 
@@ -123,7 +130,7 @@ fn swizzle_list_chunks(
     let mut sizes = BufferMut::<u64>::with_capacity(len);
 
     for chunk in chunks {
-        let chunk_array = chunk.to_listview();
+        let chunk_array = chunk.clone().execute::<ListViewArray>(ctx)?;
         // By rebuilding as zero-copy to `List` and trimming all elements (to prevent gaps), we make
         // the final output `ListView` also zero-copyable to `List`.
         let chunk_array = chunk_array.rebuild(ListViewRebuildMode::MakeExact)?;
@@ -137,14 +144,14 @@ fn swizzle_list_chunks(
             &DType::Primitive(PType::U64, Nullability::NonNullable),
         )
         .vortex_expect("Must be able to fit array offsets in u64")
-        .to_primitive();
+        .execute::<PrimitiveArray>(ctx)?;
 
         let sizes_arr = cast(
             chunk_array.sizes(),
             &DType::Primitive(PType::U64, Nullability::NonNullable),
         )
         .vortex_expect("Must be able to fit array offsets in u64")
-        .to_primitive();
+        .execute::<PrimitiveArray>(ctx)?;
 
         let offsets_slice = offsets_arr.as_slice::<u64>();
         let sizes_slice = sizes_arr.as_slice::<u64>();

--- a/vortex-array/src/arrays/chunked/vtable/mod.rs
+++ b/vortex-array/src/arrays/chunked/vtable/mod.rs
@@ -170,8 +170,8 @@ impl VTable for ChunkedVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
-        _canonicalize(array)
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
+        _canonicalize(array, ctx)
     }
 
     fn reduce(array: &Self::Array) -> VortexResult<Option<ArrayRef>> {

--- a/vortex-array/src/arrays/list/vtable/mod.rs
+++ b/vortex-array/src/arrays/list/vtable/mod.rs
@@ -157,8 +157,8 @@ impl VTable for ListVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
-        Ok(Canonical::List(list_view_from_list(array.clone())))
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
+        Ok(Canonical::List(list_view_from_list(array.clone(), ctx)?))
     }
 
     fn execute_parent(

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -12,6 +12,7 @@ use vortex_error::VortexResult;
 use crate::Array;
 use crate::ArrayRef;
 use crate::Canonical;
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::ToCanonical;
 use crate::arrays::ExtensionArray;
@@ -19,6 +20,7 @@ use crate::arrays::FixedSizeListArray;
 use crate::arrays::ListArray;
 use crate::arrays::ListViewArray;
 use crate::arrays::ListViewRebuildMode;
+use crate::arrays::PrimitiveArray;
 use crate::arrays::StructArray;
 use crate::builders::PrimitiveBuilder;
 use crate::vtable::ValidityHelper;
@@ -27,11 +29,11 @@ use crate::vtable::ValidityHelper;
 ///
 /// The output [`ListViewArray`] will be zero-copyable back to a [`ListArray`], and additionally it
 /// will not have any leading or trailing garbage data.
-pub fn list_view_from_list(list: ListArray) -> ListViewArray {
+pub fn list_view_from_list(list: ListArray, ctx: &mut ExecutionCtx) -> VortexResult<ListViewArray> {
     // If the list is empty, create an empty `ListViewArray` with the same offset `DType` as the
     // input.
     if list.is_empty() {
-        return Canonical::empty(list.dtype()).into_listview();
+        return Ok(Canonical::empty(list.dtype()).into_listview());
     }
 
     // We reset the offsets here because mostly for convenience, and also because callers of this
@@ -46,7 +48,7 @@ pub fn list_view_from_list(list: ListArray) -> ListViewArray {
     // Create `sizes` array by computing differences between consecutive offsets.
     // We use the same `DType` for the sizes as the `offsets` array to ensure compatibility.
     let sizes = match_each_integer_ptype!(list_offsets.dtype().as_ptype(), |O| {
-        build_sizes_from_offsets::<O>(&list)
+        build_sizes_from_offsets::<O>(&list, ctx)?
     });
 
     // We need to slice the `offsets` to remove the last element (`ListArray` has `n + 1` offsets).
@@ -56,7 +58,7 @@ pub fn list_view_from_list(list: ListArray) -> ListViewArray {
     // SAFETY: Since everything came from an existing valid `ListArray`, and the `sizes` were
     // derived from valid and in-order `offsets`, we know these fields are valid.
     // We also just came directly from a `ListArray`, so we know this is zero-copyable.
-    unsafe {
+    Ok(unsafe {
         ListViewArray::new_unchecked(
             list.elements().clone(),
             adjusted_offsets,
@@ -64,18 +66,21 @@ pub fn list_view_from_list(list: ListArray) -> ListViewArray {
             list.validity().clone(),
         )
         .with_zero_copy_to_list(true)
-    }
+    })
 }
 
 /// Builds a sizes array from a [`ListArray`] by computing differences between consecutive offsets.
-fn build_sizes_from_offsets<O: IntegerPType>(list: &ListArray) -> ArrayRef {
+fn build_sizes_from_offsets<O: IntegerPType>(
+    list: &ListArray,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
     let len = list.len();
     let mut sizes_builder = PrimitiveBuilder::<O>::with_capacity(Nullability::NonNullable, len);
 
     // Create `UninitRange` for direct memory access.
     let mut sizes_range = sizes_builder.uninit_range(len);
 
-    let offsets = list.offsets().to_primitive();
+    let offsets = list.offsets().clone().execute::<PrimitiveArray>(ctx)?;
     let offsets_slice = offsets.as_slice::<O>();
     debug_assert_eq!(len + 1, offsets_slice.len());
     debug_assert!(offsets_slice.is_sorted());
@@ -91,7 +96,7 @@ fn build_sizes_from_offsets<O: IntegerPType>(list: &ListArray) -> ArrayRef {
         sizes_range.finish();
     }
 
-    sizes_builder.finish_into_primitive().into_array()
+    Ok(sizes_builder.finish_into_primitive().into_array())
 }
 
 // TODO(connor)[ListView]: Note that it is not exactly zero-copy because we have to add a single
@@ -285,6 +290,8 @@ mod tests {
     use super::super::tests::common::create_overlapping_listview;
     use super::recursive_list_from_list_view;
     use crate::IntoArray;
+    use crate::LEGACY_SESSION;
+    use crate::VortexSessionExecute;
     use crate::arrays::BoolArray;
     use crate::arrays::FixedSizeListArray;
     use crate::arrays::ListArray;
@@ -298,14 +305,15 @@ mod tests {
     use crate::vtable::ValidityHelper;
 
     #[test]
-    fn test_list_to_listview_basic() {
+    fn test_list_to_listview_basic() -> VortexResult<()> {
         // Create a basic ListArray: [[0,1,2], [3,4], [5,6], [7,8,9]].
         let elements = buffer![0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
         let offsets = buffer![0u32, 3, 5, 7, 10].into_array();
         let list_array =
             ListArray::try_new(elements.clone(), offsets.clone(), Validity::NonNullable).unwrap();
 
-        let list_view = list_view_from_list(list_array.clone());
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let list_view = list_view_from_list(list_array.clone(), &mut ctx)?;
 
         // Verify structure.
         assert_eq!(list_view.len(), 4);
@@ -321,6 +329,7 @@ mod tests {
 
         // Verify data integrity.
         assert_arrays_eq!(list_array, list_view);
+        Ok(())
     }
 
     #[test]
@@ -352,7 +361,8 @@ mod tests {
 
         // This conversion will create an empty ListViewArray.
         // Note: list_view_from_list handles the empty case specially.
-        let empty_list_view = list_view_from_list(empty_list.clone());
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let empty_list_view = list_view_from_list(empty_list.clone(), &mut ctx)?;
         assert_eq!(empty_list_view.len(), 0);
 
         // Convert back.
@@ -373,7 +383,8 @@ mod tests {
         let nullable_list =
             ListArray::try_new(elements.clone(), offsets.clone(), validity.clone()).unwrap();
 
-        let nullable_list_view = list_view_from_list(nullable_list.clone());
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let nullable_list_view = list_view_from_list(nullable_list.clone(), &mut ctx)?;
 
         // Verify validity is preserved.
         assert_eq!(nullable_list_view.validity(), &validity);
@@ -417,13 +428,14 @@ mod tests {
         }
 
         // Round-trip.
-        let converted_back = list_view_from_list(list_array);
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let converted_back = list_view_from_list(list_array, &mut ctx)?;
         assert_arrays_eq!(empty_lists_view, converted_back);
         Ok(())
     }
 
     #[test]
-    fn test_different_offset_types() {
+    fn test_different_offset_types() -> VortexResult<()> {
         // Test with i32 offsets.
         let elements = buffer![1i32, 2, 3, 4, 5].into_array();
         let i32_offsets = buffer![0i32, 2, 5].into_array();
@@ -431,7 +443,8 @@ mod tests {
             ListArray::try_new(elements.clone(), i32_offsets.clone(), Validity::NonNullable)
                 .unwrap();
 
-        let list_view_i32 = list_view_from_list(list_i32.clone());
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let list_view_i32 = list_view_from_list(list_i32.clone(), &mut ctx)?;
         assert_eq!(list_view_i32.offsets().dtype(), i32_offsets.dtype());
         assert_eq!(list_view_i32.sizes().dtype(), i32_offsets.dtype());
 
@@ -441,34 +454,37 @@ mod tests {
             ListArray::try_new(elements.clone(), i64_offsets.clone(), Validity::NonNullable)
                 .unwrap();
 
-        let list_view_i64 = list_view_from_list(list_i64.clone());
+        let list_view_i64 = list_view_from_list(list_i64.clone(), &mut ctx)?;
         assert_eq!(list_view_i64.offsets().dtype(), i64_offsets.dtype());
         assert_eq!(list_view_i64.sizes().dtype(), i64_offsets.dtype());
 
         // Verify data integrity.
         assert_arrays_eq!(list_i32, list_view_i32);
         assert_arrays_eq!(list_i64, list_view_i64);
+        Ok(())
     }
 
     #[test]
     fn test_round_trip_conversions() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+
         // Test 1: Basic round-trip.
         let original = create_basic_listview();
         let to_list = list_from_list_view(original.clone())?;
-        let back_to_view = list_view_from_list(to_list);
+        let back_to_view = list_view_from_list(to_list, &mut ctx)?;
         assert_arrays_eq!(original, back_to_view);
 
         // Test 2: Nullable round-trip.
         let nullable = create_nullable_listview();
         let nullable_to_list = list_from_list_view(nullable.clone())?;
-        let nullable_back = list_view_from_list(nullable_to_list);
+        let nullable_back = list_view_from_list(nullable_to_list, &mut ctx)?;
         assert_arrays_eq!(nullable, nullable_back);
 
         // Test 3: Non-zero-copyable round-trip.
         let overlapping = create_overlapping_listview();
 
         let overlapping_to_list = list_from_list_view(overlapping.clone())?;
-        let overlapping_back = list_view_from_list(overlapping_to_list);
+        let overlapping_back = list_view_from_list(overlapping_to_list, &mut ctx)?;
         assert_arrays_eq!(overlapping, overlapping_back);
         Ok(())
     }
@@ -481,7 +497,8 @@ mod tests {
         let single_elem_list =
             ListArray::try_new(elements.clone(), offsets, Validity::NonNullable).unwrap();
 
-        let list_view = list_view_from_list(single_elem_list.clone());
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let list_view = list_view_from_list(single_elem_list.clone(), &mut ctx)?;
         assert_eq!(list_view.len(), 3);
 
         // Verify sizes are all 1.
@@ -502,7 +519,8 @@ mod tests {
         let mixed_list =
             ListArray::try_new(elements.clone(), offsets.clone(), Validity::NonNullable).unwrap();
 
-        let list_view = list_view_from_list(mixed_list.clone());
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let list_view = list_view_from_list(mixed_list.clone(), &mut ctx)?;
         assert_eq!(list_view.len(), 5);
 
         // Verify sizes.

--- a/vortex-array/src/arrays/listview/tests/basic.rs
+++ b/vortex-array/src/arrays/listview/tests/basic.rs
@@ -8,10 +8,13 @@ use vortex_buffer::buffer;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_dtype::PType;
+use vortex_error::VortexResult;
 use vortex_scalar::Scalar;
 
 use crate::Array;
 use crate::IntoArray;
+use crate::LEGACY_SESSION;
+use crate::VortexSessionExecute;
 use crate::arrays::BoolArray;
 use crate::arrays::ConstantArray;
 use crate::arrays::ListArray;
@@ -115,7 +118,7 @@ fn test_empty_listview() {
 }
 
 #[test]
-fn test_from_list_array() {
+fn test_from_list_array() -> VortexResult<()> {
     // Test conversion from ListArray to ListViewArray.
     // Logical lists: [[1,2], null, [5,6,7]]
     let offsets = buffer![0i64, 2, 4, 7].into_array();
@@ -123,7 +126,8 @@ fn test_from_list_array() {
     let validity = Validity::from_iter([true, false, true]);
 
     let list_array = ListArray::try_new(elements, offsets, validity).unwrap();
-    let list_view = list_view_from_list(list_array);
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let list_view = list_view_from_list(list_array, &mut ctx)?;
 
     assert_eq!(list_view.len(), 3);
 
@@ -143,6 +147,7 @@ fn test_from_list_array() {
         list_view.list_elements_at(2),
         PrimitiveArray::from_iter([5i32, 6, 7])
     );
+    Ok(())
 }
 
 // Parameterized tests for ConstantArray scenarios.

--- a/vortex-array/src/arrays/masked/execute.rs
+++ b/vortex-array/src/arrays/masked/execute.rs
@@ -21,6 +21,7 @@ use crate::arrays::NullArray;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::StructArray;
 use crate::arrays::VarBinViewArray;
+use crate::executor::ExecutionCtx;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
@@ -32,6 +33,7 @@ use crate::vtable::ValidityHelper;
 pub fn mask_validity_canonical(
     canonical: Canonical,
     validity_mask: &Mask,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<Canonical> {
     Ok(match canonical {
         Canonical::Null(a) => Canonical::Null(mask_validity_null(a, validity_mask)),
@@ -46,7 +48,9 @@ pub fn mask_validity_canonical(
             Canonical::FixedSizeList(mask_validity_fixed_size_list(a, validity_mask))
         }
         Canonical::Struct(a) => Canonical::Struct(mask_validity_struct(a, validity_mask)),
-        Canonical::Extension(a) => Canonical::Extension(mask_validity_extension(a, validity_mask)?),
+        Canonical::Extension(a) => {
+            Canonical::Extension(mask_validity_extension(a, validity_mask, ctx)?)
+        }
     })
 }
 
@@ -141,10 +145,14 @@ fn mask_validity_struct(array: StructArray, mask: &Mask) -> StructArray {
     unsafe { StructArray::new_unchecked(fields, struct_fields, len, new_validity) }
 }
 
-fn mask_validity_extension(array: ExtensionArray, mask: &Mask) -> VortexResult<ExtensionArray> {
+fn mask_validity_extension(
+    array: ExtensionArray,
+    mask: &Mask,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ExtensionArray> {
     // For extension arrays, we need to mask the underlying storage
-    let storage = array.storage().to_canonical()?;
-    let masked_storage = mask_validity_canonical(storage, mask)?;
+    let storage = array.storage().clone().execute::<Canonical>(ctx)?;
+    let masked_storage = mask_validity_canonical(storage, mask, ctx)?;
     Ok(ExtensionArray::new(
         array.ext_dtype().clone(),
         masked_storage.into_array(),

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -144,7 +144,7 @@ impl VTable for MaskedVTable {
         // `AllTrue` masks (no data copying), so there's no benefit.
 
         let child = array.child().clone().execute::<Canonical>(ctx)?;
-        let canonical = mask_validity_canonical(child, &validity_mask)?;
+        let canonical = mask_validity_canonical(child, &validity_mask, ctx)?;
 
         vortex_ensure!(
             canonical.as_ref().dtype() == array.dtype(),

--- a/vortex-array/src/arrays/slice/vtable.rs
+++ b/vortex-array/src/arrays/slice/vtable.rs
@@ -116,7 +116,7 @@ impl VTable for SliceVTable {
             array.dtype()
         );
         // TODO(joe): this is a downcast not a execute.
-        result.to_canonical()
+        result.execute::<Canonical>(ctx)
     }
 
     fn reduce(array: &Self::Array) -> VortexResult<Option<ArrayRef>> {

--- a/vortex-array/src/arrays/varbin/vtable/canonical.rs
+++ b/vortex-array/src/arrays/varbin/vtable/canonical.rs
@@ -11,19 +11,23 @@ use vortex_error::VortexResult;
 use vortex_vector::binaryview::BinaryView;
 
 use crate::Canonical;
-use crate::ToCanonical;
+use crate::ExecutionCtx;
+use crate::arrays::PrimitiveArray;
 use crate::arrays::VarBinViewArray;
 use crate::arrays::varbin::VarBinArray;
 
 /// Converts a VarBinArray to its canonical form (VarBinViewArray).
 ///
 /// This is a shared helper used by both `canonicalize` and `execute`.
-pub(crate) fn varbin_to_canonical(array: &VarBinArray) -> VortexResult<Canonical> {
+pub(crate) fn varbin_to_canonical(
+    array: &VarBinArray,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Canonical> {
     // Zero the offsets first to ensure the bytes buffer starts at 0
     let array = array.clone().zero_offsets();
     let (dtype, bytes, offsets, validity) = array.into_parts();
 
-    let offsets = offsets.to_primitive();
+    let offsets = offsets.execute::<PrimitiveArray>(ctx)?;
 
     // Build views directly from offsets
     #[expect(clippy::cast_possible_truncation, reason = "BinaryView offset is u32")]

--- a/vortex-array/src/arrays/varbin/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbin/vtable/mod.rs
@@ -149,8 +149,8 @@ impl VTable for VarBinVTable {
         }))
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
-        varbin_to_canonical(array)
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
+        varbin_to_canonical(array, ctx)
     }
 }
 

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -22,13 +22,11 @@ use crate::Array;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::ListArray;
-use crate::arrays::list_view_from_list;
 use crate::builders::ArrayBuilder;
 use crate::builders::DEFAULT_BUILDER_CAPACITY;
 use crate::builders::LazyBitBufferBuilder;
 use crate::builders::PrimitiveBuilder;
 use crate::builders::builder_with_capacity;
-use crate::canonical::Canonical;
 use crate::canonical::ToCanonical;
 
 /// The builder for building a [`ListArray`], parametrized by the [`IntegerPType`] of the `offsets`
@@ -294,10 +292,6 @@ impl<O: IntegerPType> ArrayBuilder for ListBuilder<O> {
 
     fn finish(&mut self) -> ArrayRef {
         self.finish_into_list().into_array()
-    }
-
-    fn finish_into_canonical(&mut self) -> Canonical {
-        Canonical::List(list_view_from_list(self.finish_into_list()))
     }
 }
 

--- a/vortex-array/src/compute/list_contains.rs
+++ b/vortex-array/src/compute/list_contains.rs
@@ -438,23 +438,17 @@ mod tests {
     use crate::arrays::ListViewArray;
     use crate::arrays::PrimitiveArray;
     use crate::arrays::VarBinArray;
-    use crate::arrays::list_view_from_list;
     use crate::canonical::ToCanonical;
     use crate::compute::list_contains;
     use crate::validity::Validity;
     use crate::vtable::ValidityHelper;
 
     fn nonnull_strings(values: Vec<Vec<&str>>) -> ArrayRef {
-        list_view_from_list(
-            ListArray::from_iter_slow::<u64, _>(
-                values,
-                Arc::new(DType::Utf8(Nullability::NonNullable)),
-            )
+        ListArray::from_iter_slow::<u64, _>(values, Arc::new(DType::Utf8(Nullability::NonNullable)))
             .unwrap()
             .as_::<ListVTable>()
-            .clone(),
-        )
-        .into_array()
+            .to_listview()
+            .into_array()
     }
 
     fn null_strings(values: Vec<Vec<Option<&str>>>) -> ArrayRef {
@@ -473,7 +467,9 @@ mod tests {
         let elements =
             VarBinArray::from_iter(elements, DType::Utf8(Nullability::Nullable)).into_array();
 
-        list_view_from_list(ListArray::try_new(elements, offsets, Validity::NonNullable).unwrap())
+        ListArray::try_new(elements, offsets, Validity::NonNullable)
+            .unwrap()
+            .to_listview()
             .into_array()
     }
 


### PR DESCRIPTION
Replace calls to `to_canonical()`, `to_primitive()`, `to_struct()`, and
`to_listview()` with `execute::<T>(ctx)` within the execute recursion to
ensure consistent execution context usage.

Changes:
- slice/vtable.rs: Use execute instead of to_canonical on sliced result
- chunked/vtable/canonical.rs: Pass ctx to helper functions, use
  execute for struct chunks, listview conversion, and primitive casts
- masked/execute.rs: Pass ctx through mask_validity_canonical chain
- varbin/vtable/canonical.rs: Use execute for offsets conversion
- listview/conversion.rs: Pass ctx to list_view_from_list and helpers
- list/vtable/mod.rs: Pass ctx to list_view_from_list

Signed-off-by: Claude <noreply@anthropic.com>