### PR TITLE
Make `prost` a mandatory dependency of vortex-error

### DIFF
--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -61,7 +61,7 @@ tracing = { workspace = true }
 vortex-buffer = { workspace = true, features = ["arrow"] }
 vortex-compute = { workspace = true, default-features = true }
 vortex-dtype = { workspace = true, features = ["arrow", "serde"] }
-vortex-error = { workspace = true, features = ["prost"] }
+vortex-error = { workspace = true }
 vortex-flatbuffers = { workspace = true, features = ["array"] }
 vortex-mask = { workspace = true }
 vortex-proto = { workspace = true, features = ["expr"] }

--- a/vortex-error/Cargo.toml
+++ b/vortex-error/Cargo.toml
@@ -26,7 +26,7 @@ arrow-schema = { workspace = true }
 flatbuffers = { workspace = true, optional = true }
 jiff = { workspace = true }
 object_store = { workspace = true, optional = true }
-prost = { workspace = true, optional = true }
+prost = { workspace = true }
 pyo3 = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt"], optional = true }

--- a/vortex-error/src/lib.rs
+++ b/vortex-error/src/lib.rs
@@ -126,18 +126,11 @@ pub enum VortexError {
     UrlError(url::ParseError, Box<Backtrace>),
     /// Wrap errors for fallible integer casting.
     TryFromInt(TryFromIntError, Box<Backtrace>),
+    /// Wrap protobuf-related errors
+    Prost(Box<dyn Error + Send + Sync + 'static>, Box<Backtrace>),
     /// Wrap serde and serde json errors
     #[cfg(feature = "serde")]
     SerdeJsonError(serde_json::Error, Box<Backtrace>),
-    /// Wrap prost encode error
-    #[cfg(feature = "prost")]
-    ProstEncodeError(prost::EncodeError, Box<Backtrace>),
-    /// Wrap prost decode error
-    #[cfg(feature = "prost")]
-    ProstDecodeError(prost::DecodeError, Box<Backtrace>),
-    /// Wrap prost unknown enum value
-    #[cfg(feature = "prost")]
-    ProstUnknownEnumValue(prost::UnknownEnumValue, Box<Backtrace>),
 }
 
 impl VortexError {
@@ -232,17 +225,8 @@ impl Display for VortexError {
             VortexError::SerdeJsonError(err, backtrace) => {
                 write!(f, "{err}\nBacktrace:\n{backtrace}")
             }
-            #[cfg(feature = "prost")]
-            VortexError::ProstEncodeError(err, backtrace) => {
-                write!(f, "{err}\nBacktrace:\n{backtrace}")
-            }
-            #[cfg(feature = "prost")]
-            VortexError::ProstDecodeError(err, backtrace) => {
-                write!(f, "{err}\nBacktrace:\n{backtrace}")
-            }
-            #[cfg(feature = "prost")]
-            VortexError::ProstUnknownEnumValue(err, backtrace) => {
-                write!(f, "{err}\nBacktrace:\n{backtrace}")
+            VortexError::Prost(err, backtrace) => {
+                write!(f, "Protobuf error: {err}\nBacktrace:\n{backtrace}")
             }
         }
     }
@@ -266,12 +250,7 @@ impl Error for VortexError {
             VortexError::UrlError(err, _) => Some(err),
             #[cfg(feature = "serde")]
             VortexError::SerdeJsonError(err, _) => Some(err),
-            #[cfg(feature = "prost")]
-            VortexError::ProstEncodeError(err, _) => Some(err),
-            #[cfg(feature = "prost")]
-            VortexError::ProstDecodeError(err, _) => Some(err),
-            #[cfg(feature = "prost")]
-            VortexError::ProstUnknownEnumValue(err, _) => Some(err),
+            VortexError::Prost(err, _) => Some(err.as_ref()),
             _ => None,
         }
     }
@@ -536,24 +515,21 @@ impl From<serde_json::Error> for VortexError {
     }
 }
 
-#[cfg(feature = "prost")]
 impl From<prost::EncodeError> for VortexError {
     fn from(value: prost::EncodeError) -> Self {
-        VortexError::ProstEncodeError(value, Box::new(Backtrace::capture()))
+        Self::Prost(Box::new(value), Box::new(Backtrace::capture()))
     }
 }
 
-#[cfg(feature = "prost")]
 impl From<prost::DecodeError> for VortexError {
     fn from(value: prost::DecodeError) -> Self {
-        VortexError::ProstDecodeError(value, Box::new(Backtrace::capture()))
+        Self::Prost(Box::new(value), Box::new(Backtrace::capture()))
     }
 }
 
-#[cfg(feature = "prost")]
 impl From<prost::UnknownEnumValue> for VortexError {
     fn from(value: prost::UnknownEnumValue) -> Self {
-        VortexError::ProstUnknownEnumValue(value, Box::new(Backtrace::capture()))
+        Self::Prost(Box::new(value), Box::new(Backtrace::capture()))
     }
 }
 

--- a/vortex-scalar/src/scalar_value.rs
+++ b/vortex-scalar/src/scalar_value.rs
@@ -82,17 +82,13 @@ impl ScalarValue {
         let mut buf = B::default();
         pb_scalar
             .encode(&mut buf)
-            .map_err(|e| vortex_err!("Failed to serialize protobuf {e}"))
             .vortex_expect("protobuf encoding should succeed");
         buf
     }
 
     /// Deserializes a scalar value from Protocol Buffers format.
     pub fn from_protobytes(buf: &[u8]) -> VortexResult<Self> {
-        ScalarValue::try_from(
-            &pb::ScalarValue::decode(buf)
-                .map_err(|e| vortex_err!("Failed to deserialize protobuf {e}"))?,
-        )
+        ScalarValue::try_from(&pb::ScalarValue::decode(buf)?)
     }
 }
 


### PR DESCRIPTION
1. Its already enabled by `vortex-array`, which basically everything will pull.
2. Its unnecessarily avoided in `vortex-scalar`, which even more things pull.
3. We really don't need three different variants here, surely one is enough.
4. This has benefits in CI, just reducing the overall size of the internal dependency matrix.