### PR TITLE
feat: introduce `CudaDeviceBuffer`

### DIFF
--- a/vortex-array/src/buffer.rs
+++ b/vortex-array/src/buffer.rs
@@ -41,8 +41,11 @@ enum Inner {
     Device(Arc<dyn DeviceBuffer>),
 }
 
-/// A buffer that is stored on a device (e.g. GPU).
+/// A buffer that is stored on the GPU.
 pub trait DeviceBuffer: 'static + Send + Sync + Debug + DynEq + DynHash {
+    /// Returns a reference as `Any` to enable downcasting.
+    fn as_any(&self) -> &dyn Any;
+
     /// Returns the length of the buffer in bytes.
     fn len(&self) -> usize;
 
@@ -61,9 +64,6 @@ pub trait DeviceBuffer: 'static + Send + Sync + Debug + DynEq + DynHash {
     /// Create a new buffer that references a subrange of this buffer at the given
     /// slice indices.
     fn slice(&self, range: Range<usize>) -> Arc<dyn DeviceBuffer>;
-
-    /// Returns a reference as `Any` to enable downcasting.
-    fn as_any(&self) -> &dyn Any;
 }
 
 impl Hash for dyn DeviceBuffer {

--- a/vortex-array/src/buffer.rs
+++ b/vortex-array/src/buffer.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::any::Any;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::hash::Hasher;
@@ -60,6 +61,9 @@ pub trait DeviceBuffer: 'static + Send + Sync + Debug + DynEq + DynHash {
     /// Create a new buffer that references a subrange of this buffer at the given
     /// slice indices.
     fn slice(&self, range: Range<usize>) -> Arc<dyn DeviceBuffer>;
+
+    /// Returns a reference as `Any` to enable downcasting.
+    fn as_any(&self) -> &dyn Any;
 }
 
 impl Hash for dyn DeviceBuffer {

--- a/vortex-cuda/benches/for_cuda.rs
+++ b/vortex-cuda/benches/for_cuda.rs
@@ -12,6 +12,7 @@ use criterion::Criterion;
 use criterion::Throughput;
 use criterion::criterion_group;
 use criterion::criterion_main;
+use cudarc::driver::CudaView;
 use cudarc::driver::PushKernelArg;
 use cudarc::driver::sys::CUevent_flags::CU_EVENT_BLOCKING_SYNC;
 use vortex_array::IntoArray;
@@ -83,7 +84,7 @@ fn make_for_array_u64(len: usize) -> FoRArray {
 /// Launches FoR decompression kernel and returns elapsed GPU time in seconds.
 fn launch_for_kernel_timed_u8(
     for_array: &FoRArray,
-    device_data: &cudarc::driver::CudaSlice<u8>,
+    device_data: CudaView<'_, u8>,
     reference: u8,
     cuda_ctx: &mut CudaExecutionCtx,
 ) -> vortex_error::VortexResult<Duration> {
@@ -93,7 +94,7 @@ fn launch_for_kernel_timed_u8(
         execution_ctx: cuda_ctx,
         module: "for",
         ptypes: &[for_array.ptype()],
-        launch_args: [*device_data, reference, array_len_u64],
+        launch_args: [device_data, reference, array_len_u64],
         event_recording: CU_EVENT_BLOCKING_SYNC,
         array_len: for_array.len()
     );
@@ -109,7 +110,7 @@ fn launch_for_kernel_timed_u8(
 /// Launches FoR decompression kernel and returns elapsed GPU time in seconds.
 fn launch_for_kernel_timed_u16(
     for_array: &FoRArray,
-    device_data: &cudarc::driver::CudaSlice<u16>,
+    device_data: CudaView<'_, u16>,
     reference: u16,
     cuda_ctx: &mut CudaExecutionCtx,
 ) -> vortex_error::VortexResult<Duration> {
@@ -119,7 +120,7 @@ fn launch_for_kernel_timed_u16(
         execution_ctx: cuda_ctx,
         module: "for",
         ptypes: &[for_array.ptype()],
-        launch_args: [*device_data, reference, array_len_u64],
+        launch_args: [device_data, reference, array_len_u64],
         event_recording: CU_EVENT_BLOCKING_SYNC,
         array_len: for_array.len()
     );
@@ -135,7 +136,7 @@ fn launch_for_kernel_timed_u16(
 /// Launches FoR decompression kernel and returns elapsed GPU time in seconds.
 fn launch_for_kernel_timed_u32(
     for_array: &FoRArray,
-    device_data: &cudarc::driver::CudaSlice<u32>,
+    device_data: CudaView<'_, u32>,
     reference: u32,
     cuda_ctx: &mut CudaExecutionCtx,
 ) -> vortex_error::VortexResult<Duration> {
@@ -145,7 +146,7 @@ fn launch_for_kernel_timed_u32(
         execution_ctx: cuda_ctx,
         module: "for",
         ptypes: &[for_array.ptype()],
-        launch_args: [*device_data, reference, array_len_u64],
+        launch_args: [device_data, reference, array_len_u64],
         event_recording: CU_EVENT_BLOCKING_SYNC,
         array_len: for_array.len()
     );
@@ -161,7 +162,7 @@ fn launch_for_kernel_timed_u32(
 /// Launches FoR decompression kernel and returns elapsed GPU time in seconds.
 fn launch_for_kernel_timed_u64(
     for_array: &FoRArray,
-    device_data: &cudarc::driver::CudaSlice<u64>,
+    device_data: CudaView<'_, u64>,
     reference: u64,
     cuda_ctx: &mut CudaExecutionCtx,
 ) -> vortex_error::VortexResult<Duration> {
@@ -171,7 +172,7 @@ fn launch_for_kernel_timed_u64(
         execution_ctx: cuda_ctx,
         module: "for",
         ptypes: &[for_array.ptype()],
-        launch_args: [*device_data, reference, array_len_u64],
+        launch_args: [device_data, reference, array_len_u64],
         event_recording: CU_EVENT_BLOCKING_SYNC,
         array_len: for_array.len()
     );
@@ -215,7 +216,7 @@ fn benchmark_for_u8(c: &mut Criterion) {
 
                         let kernel_time = launch_for_kernel_timed_u8(
                             for_array,
-                            device_data.cuda_slice(),
+                            device_data.as_view(),
                             reference,
                             &mut cuda_ctx,
                         )
@@ -264,7 +265,7 @@ fn benchmark_for_u16(c: &mut Criterion) {
 
                         let kernel_time = launch_for_kernel_timed_u16(
                             for_array,
-                            device_data.cuda_slice(),
+                            device_data.as_view(),
                             reference,
                             &mut cuda_ctx,
                         )
@@ -313,7 +314,7 @@ fn benchmark_for_u32(c: &mut Criterion) {
 
                         let kernel_time = launch_for_kernel_timed_u32(
                             for_array,
-                            device_data.cuda_slice(),
+                            device_data.as_view(),
                             reference,
                             &mut cuda_ctx,
                         )
@@ -362,7 +363,7 @@ fn benchmark_for_u64(c: &mut Criterion) {
 
                         let kernel_time = launch_for_kernel_timed_u64(
                             for_array,
-                            device_data.cuda_slice(),
+                            device_data.as_view(),
                             reference,
                             &mut cuda_ctx,
                         )

--- a/vortex-cuda/src/device_buffer.rs
+++ b/vortex-cuda/src/device_buffer.rs
@@ -9,7 +9,6 @@ use cudarc::driver::CudaSlice;
 use cudarc::driver::CudaView;
 use cudarc::driver::DevicePtr;
 use cudarc::driver::DeviceRepr;
-use cudarc::driver::sys::CUdeviceptr;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::buffer::DeviceBuffer;
 use vortex_buffer::Alignment;
@@ -23,27 +22,26 @@ pub struct CudaDeviceBuffer<T> {
     inner: Arc<CudaSlice<T>>,
     offset: usize,
     len: usize,
+    device_ptr: u64,
 }
 
 impl<T: DeviceRepr> CudaDeviceBuffer<T> {
     /// Creates a new CUDA device buffer from a [`CudaSlice`].
     pub fn new(cuda_slice: CudaSlice<T>) -> Self {
         let len = cuda_slice.len();
+        let device_ptr = cuda_slice.device_ptr(cuda_slice.stream()).0;
+
         Self {
             inner: Arc::new(cuda_slice),
             offset: 0,
             len,
+            device_ptr,
         }
     }
 
     /// Returns a [`CudaView`] to the CUDA device buffer.
     pub fn as_view(&self) -> CudaView<'_, T> {
         self.inner.slice(self.offset..self.offset + self.len)
-    }
-
-    /// Returns the device pointer for this buffer.
-    fn device_ptr(&self) -> CUdeviceptr {
-        self.inner.device_ptr(self.inner.stream()).0
     }
 }
 
@@ -80,7 +78,7 @@ impl CudaBufferExt for BufferHandle {
 impl<T: DeviceRepr> Debug for CudaDeviceBuffer<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CudaDeviceBuffer")
-            .field("device_ptr", &self.device_ptr())
+            .field("device_ptr", &self.device_ptr)
             .field("offset", &self.offset)
             .field("len", &self.len)
             .finish()
@@ -89,7 +87,7 @@ impl<T: DeviceRepr> Debug for CudaDeviceBuffer<T> {
 
 impl<T: DeviceRepr> std::hash::Hash for CudaDeviceBuffer<T> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.device_ptr().hash(state);
+        self.device_ptr.hash(state);
         self.len.hash(state);
         self.offset.hash(state);
     }
@@ -97,9 +95,7 @@ impl<T: DeviceRepr> std::hash::Hash for CudaDeviceBuffer<T> {
 
 impl<T: DeviceRepr> PartialEq for CudaDeviceBuffer<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.device_ptr() == other.device_ptr()
-            && self.len == other.len
-            && self.offset == other.offset
+        self.device_ptr == other.device_ptr && self.len == other.len && self.offset == other.offset
     }
 }
 
@@ -150,6 +146,7 @@ impl<T: DeviceRepr + Send + Sync + 'static> DeviceBuffer for CudaDeviceBuffer<T>
             inner: Arc::clone(&self.inner),
             offset: new_offset,
             len: new_len,
+            device_ptr: self.device_ptr,
         })
     }
 

--- a/vortex-cuda/src/device_buffer.rs
+++ b/vortex-cuda/src/device_buffer.rs
@@ -2,13 +2,15 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::fmt::Debug;
-use std::hash::Hash;
-use std::hash::Hasher;
 use std::ops::Range;
 use std::sync::Arc;
 
 use cudarc::driver::CudaSlice;
+use cudarc::driver::CudaView;
+use cudarc::driver::DevicePtr;
 use cudarc::driver::DeviceRepr;
+use cudarc::driver::sys::CUdeviceptr;
+use vortex_array::buffer::BufferHandle;
 use vortex_array::buffer::DeviceBuffer;
 use vortex_buffer::Alignment;
 use vortex_buffer::BufferMut;
@@ -16,81 +18,115 @@ use vortex_buffer::ByteBuffer;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 
-/// A CUDA device buffer wrapping a [`CudaSlice<T>`].
+/// A CUDA device buffer with offset and length tracking.
 pub struct CudaDeviceBuffer<T> {
-    cuda_slice: CudaSlice<T>,
+    inner: Arc<CudaSlice<T>>,
+    offset: usize,
+    len: usize,
 }
 
-impl<T> CudaDeviceBuffer<T> {
+impl<T: DeviceRepr> CudaDeviceBuffer<T> {
     /// Creates a new CUDA device buffer from a [`CudaSlice`].
     pub fn new(cuda_slice: CudaSlice<T>) -> Self {
-        Self { cuda_slice }
+        let len = cuda_slice.len();
+        Self {
+            inner: Arc::new(cuda_slice),
+            offset: 0,
+            len,
+        }
     }
 
-    /// Returns a reference to the underlying [`CudaSlice<T>`].
-    pub fn cuda_slice(&self) -> &CudaSlice<T> {
-        &self.cuda_slice
+    /// Returns a [`CudaView`] to the CUDA device buffer.
+    pub fn as_view(&self) -> CudaView<'_, T> {
+        self.inner.slice(self.offset..self.offset + self.len)
+    }
+
+    /// Returns the device pointer for this buffer.
+    fn device_ptr(&self) -> CUdeviceptr {
+        self.inner.device_ptr(self.inner.stream()).0
     }
 }
 
-impl<T> Debug for CudaDeviceBuffer<T> {
+/// Extension trait for getting a [`CudaView`] from a [`BufferHandle`].
+pub trait CudaBufferExt {
+    /// Returns a [`CudaView`] for the buffer handle.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer is not on the device.
+    fn cuda_view<T: DeviceRepr + Send + Sync + 'static>(&self) -> VortexResult<CudaView<'_, T>>;
+}
+
+impl CudaBufferExt for BufferHandle {
+    fn cuda_view<T: DeviceRepr + Send + Sync + 'static>(&self) -> VortexResult<CudaView<'_, T>> {
+        let device_buffer = self
+            .as_device_opt()
+            .ok_or_else(|| vortex_err!("Buffer is not on device, call ensure_on_device first"))?;
+
+        let cuda_buf = device_buffer
+            .as_any()
+            .downcast_ref::<CudaDeviceBuffer<T>>()
+            .ok_or_else(|| {
+                vortex_err!(
+                    "Device buffer is not a CUDA device buffer for type {}",
+                    std::any::type_name::<T>()
+                )
+            })?;
+
+        Ok(cuda_buf.as_view())
+    }
+}
+
+impl<T: DeviceRepr> Debug for CudaDeviceBuffer<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CudaDeviceBuffer")
-            .field(
-                "address",
-                &(&raw const self.cuda_slice as *const _ as usize),
-            )
-            .field("num_bytes", &self.cuda_slice.num_bytes())
+            .field("device_ptr", &self.device_ptr())
+            .field("offset", &self.offset)
+            .field("len", &self.len)
             .finish()
     }
 }
 
-impl<T: 'static> Hash for CudaDeviceBuffer<T> {
-    /// Hash the buffer pointer address.
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        (&raw const self.cuda_slice).hash(state);
+impl<T: DeviceRepr> std::hash::Hash for CudaDeviceBuffer<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.device_ptr().hash(state);
+        self.len.hash(state);
+        self.offset.hash(state);
     }
 }
 
-impl<T: 'static> PartialEq for CudaDeviceBuffer<T> {
-    /// Compares two buffers by pointer address.
+impl<T: DeviceRepr> PartialEq for CudaDeviceBuffer<T> {
     fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(&raw const self.cuda_slice, &raw const other.cuda_slice)
+        self.device_ptr() == other.device_ptr()
+            && self.len == other.len
+            && self.offset == other.offset
     }
 }
 
-impl<T: DeviceRepr + Clone + Send + Sync + 'static> DeviceBuffer for CudaDeviceBuffer<T> {
-    /// Returns the number of elements in the CUDA device buffer of type T.
+impl<T: DeviceRepr + Send + Sync + 'static> DeviceBuffer for CudaDeviceBuffer<T> {
+    /// Returns the number of elements in the buffer of type T.
     fn len(&self) -> usize {
-        self.cuda_slice.len()
+        self.len
     }
 
-    /// Copies the CUDA device buffer to host memory.
-    ///
-    /// Allocates a host buffer with the specified alignment and copies the data
-    /// from the device to the host. The operation is implicitly synchronized
-    /// when the underlying event is dropped.
+    /// Synchronous copy of CUDA device to host memory.
     ///
     /// # Arguments
     ///
-    /// * `alignment` - The byte alignment for the allocated host buffer.
+    /// * `alignment` - The memory alignment to use for the host buffer.
     ///
-    /// # Returns
+    /// # Errors
     ///
-    /// A `ByteBuffer` containing the copied data, or an error if the copy fails.
+    /// Returns an error if the CUDA memory copy operation fails.
     fn copy_to_host(&self, alignment: Alignment) -> VortexResult<ByteBuffer> {
-        let len = self.cuda_slice.len();
-        let mut host_buffer = BufferMut::<T>::with_capacity_aligned(len, alignment);
+        let mut host_buffer = BufferMut::<T>::with_capacity_aligned(self.len, alignment);
 
-        // TODO(0ax1): Make the memcopy to host async. Even though `memcpy_dtoh`
-        // uses into `memcpy_dtoh_async`, it implicitly calls synchronize on the
-        // stream when dropping the `SyncOnDrop` `_record_dst` event at the end
-        // of the function.
-        self.cuda_slice
+        let view = self.as_view();
+        self.inner
             .stream()
-            .memcpy_dtoh(&self.cuda_slice, unsafe {
-                // SAFETY: We allocated sufficient capacity and fill the entire buffer.
-                host_buffer.set_len(len);
+            // TODO(0ax1): make the copy async
+            .memcpy_dtoh(&view, unsafe {
+                host_buffer.set_len(self.len);
                 host_buffer.as_mut_slice()
             })
             .map_err(|e| vortex_err!("Failed to copy from device to host: {}", e))?;
@@ -99,8 +135,25 @@ impl<T: DeviceRepr + Clone + Send + Sync + 'static> DeviceBuffer for CudaDeviceB
     }
 
     /// Slices the CUDA device buffer to a subrange.
-    fn slice(&self, _range: Range<usize>) -> Arc<dyn DeviceBuffer> {
-        // TODO(0ax1): impl slice on CUDA slice
-        unimplemented!("CudaDeviceBuffer::slice is not yet implemented")
+    fn slice(&self, range: Range<usize>) -> Arc<dyn DeviceBuffer> {
+        let new_offset = self.offset + range.start;
+        let new_len = range.end - range.start;
+
+        assert!(
+            range.end <= self.len,
+            "Slice range end {} exceeds buffer length {}",
+            range.end,
+            self.len
+        );
+
+        Arc::new(CudaDeviceBuffer {
+            inner: Arc::clone(&self.inner),
+            offset: new_offset,
+            len: new_len,
+        })
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }

--- a/vortex-cuda/src/executor.rs
+++ b/vortex-cuda/src/executor.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::fmt::Debug;
+use std::mem::size_of;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -17,6 +18,7 @@ use vortex_array::Array;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::VortexSessionExecute;
+use vortex_array::buffer::BufferHandle;
 use vortex_dtype::PType;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
@@ -70,7 +72,6 @@ macro_rules! launch_cuda_kernel {
         let cuda_function = $ctx.load_function($module, $ptypes)?;
         let mut launch_builder = $ctx.launch_builder(&cuda_function);
 
-        // Unroll launch builder arguments.
         $(
             launch_builder.arg(&$arg);
         )*
@@ -185,9 +186,7 @@ impl CudaExecutionCtx {
     }
 
     /// Copies host data to the device, returning a [`CudaDeviceBuffer`].
-    ///
-    /// This is the primary way to get data onto the GPU for kernel execution.
-    pub fn copy_buffer_to_device<T: DeviceRepr + Clone + Send + Sync + 'static>(
+    pub fn copy_buffer_to_device<T: DeviceRepr>(
         &self,
         data: &[T],
     ) -> VortexResult<CudaDeviceBuffer<T>> {
@@ -196,6 +195,32 @@ impl CudaExecutionCtx {
             .clone_htod(data)
             .map_err(|e| vortex_err!("Failed to copy to device: {}", e))?;
         Ok(CudaDeviceBuffer::new(cuda_slice))
+    }
+
+    /// Ensures the buffer is on the CUDA device.
+    ///
+    /// Copies the data from host to device if the input buffer is on the host.
+    pub fn ensure_on_device<T: DeviceRepr + Send + Sync + 'static>(
+        &self,
+        handle: &BufferHandle,
+    ) -> VortexResult<BufferHandle> {
+        if handle.is_on_device() {
+            return Ok(handle.clone());
+        }
+
+        let host_buffer = handle
+            .as_host_opt()
+            .ok_or_else(|| vortex_err!("Buffer is neither on host nor device"))?;
+
+        let typed_slice: &[T] = unsafe {
+            std::slice::from_raw_parts(
+                host_buffer.as_ptr().cast(),
+                host_buffer.len() / size_of::<T>(),
+            )
+        };
+
+        let cuda_buf = self.copy_buffer_to_device(typed_slice)?;
+        Ok(BufferHandle::new_device(Arc::new(cuda_buf)))
     }
 }
 

--- a/vortex-cuda/src/for_.rs
+++ b/vortex-cuda/src/for_.rs
@@ -9,10 +9,6 @@ use vortex_array::Array;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::buffer::DeviceBuffer;
-use vortex_array::validity::Validity::NonNullable;
-use vortex_buffer::Alignment;
-use vortex_dtype::FromPrimitiveOrF16;
 use vortex_dtype::NativePType;
 use vortex_dtype::match_each_native_simd_ptype;
 use vortex_error::VortexExpect;
@@ -20,6 +16,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 use vortex_fastlanes::FoRArray;
 
+use crate::CudaBufferExt;
 use crate::executor::CudaArrayExt;
 use crate::executor::CudaExecute;
 use crate::executor::CudaExecutionCtx;
@@ -56,7 +53,7 @@ async fn execute_for(array: &FoRArray, ctx: &mut CudaExecutionCtx) -> VortexResu
     })
 }
 
-async fn execute_for_typed<P: DeviceRepr + NativePType + FromPrimitiveOrF16>(
+async fn execute_for_typed<P: DeviceRepr + NativePType>(
     array: &FoRArray,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<Canonical> {
@@ -66,40 +63,36 @@ async fn execute_for_typed<P: DeviceRepr + NativePType + FromPrimitiveOrF16>(
         .as_::<P>()
         .vortex_expect("Cannot have a null reference");
 
-    let encoded = array.encoded().clone();
-    // Recursively decompresss the child.
-    let unpacked_canonical = encoded.execute_cuda(ctx).await?;
-
-    let unpacked_array = unpacked_canonical.as_primitive();
-    let unpacked_slice = unpacked_array.as_slice::<P>();
-
-    // TODO(0ax1): Check whether buffer is already on device.
-    let device_data = ctx.copy_buffer_to_device(unpacked_slice)?;
-
+    let encoded = array.encoded().clone().execute_cuda(ctx).await?;
+    let (dtype, buffer_handle, validity, ..) = encoded.into_primitive().into_parts();
+    let device_buffer_handle = ctx.ensure_on_device::<P>(&buffer_handle)?;
+    let cuda_view = device_buffer_handle.cuda_view::<P>()?;
     let array_len = array.len() as u64;
-    let _kernel_events = launch_cuda_kernel!(
+
+    // Ignore the CUDA events returned from the kernel launch, as the CUDA slice,
+    // owned by the buffer handle, holds CUDA events that can be checked for completion.
+    let _cuda_events = launch_cuda_kernel!(
         execution_ctx: ctx,
         module: "for",
         ptypes: &[array.ptype()],
-        launch_args: [*device_data.cuda_slice(), reference, array_len],
-        // CUDA events are submitted before and after the kernel launch. This
-        // enables waiting for a single kernel to finish without doing a global
-        // synchronize on the stream. Timing is disabled to keep the overhead low.
+        launch_args: [cuda_view, reference, array_len],
+        // CUDA events are automatically submitted before and after the kernel launch.
         event_recording: CU_EVENT_DISABLE_TIMING,
         array_len: array.len()
     );
 
-    // TODO: Don't copy back after the end of each run.
-    let host_bytes = device_data.copy_to_host(Alignment::of::<P>())?;
-    let primitive = PrimitiveArray::from_byte_buffer(host_bytes, array.ptype(), NonNullable);
-
-    Ok(Canonical::Primitive(primitive))
+    Ok(Canonical::Primitive(PrimitiveArray::from_buffer_handle(
+        device_buffer_handle,
+        dtype.as_ptype(),
+        validity,
+    )))
 }
 
 #[cfg(test)]
 mod tests {
     use vortex_array::IntoArray;
     use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::validity::Validity::NonNullable;
     use vortex_buffer::Buffer;
     use vortex_error::VortexExpect;
     use vortex_fastlanes::FoRArray;
@@ -133,8 +126,11 @@ mod tests {
             .await
             .vortex_expect("GPU decompression failed");
 
+        let result_buf =
+            Buffer::<u8>::from_byte_buffer(result.as_primitive().buffer_handle().to_host());
+
         assert_eq!(
-            result.as_primitive().as_slice::<u8>(),
+            result_buf,
             input_data
                 .iter()
                 .map(|&val| val.wrapping_add(10))
@@ -165,8 +161,11 @@ mod tests {
             .await
             .vortex_expect("GPU decompression failed");
 
+        let result_buf =
+            Buffer::<u16>::from_byte_buffer(result.as_primitive().buffer_handle().to_host());
+
         assert_eq!(
-            result.as_primitive().as_slice::<u16>(),
+            result_buf,
             input_data
                 .iter()
                 .map(|&val| val.wrapping_add(1000))
@@ -197,8 +196,11 @@ mod tests {
             .await
             .vortex_expect("GPU decompression failed");
 
+        let result_buf =
+            Buffer::<u32>::from_byte_buffer(result.as_primitive().buffer_handle().to_host());
+
         assert_eq!(
-            result.as_primitive().as_slice::<u32>(),
+            result_buf,
             input_data
                 .iter()
                 .map(|&val| val.wrapping_add(100000))
@@ -229,8 +231,11 @@ mod tests {
             .await
             .vortex_expect("GPU decompression failed");
 
+        let result_buf =
+            Buffer::<u64>::from_byte_buffer(result.as_primitive().buffer_handle().to_host());
+
         assert_eq!(
-            result.as_primitive().as_slice::<u64>(),
+            result_buf,
             input_data
                 .iter()
                 .map(|&val| val.wrapping_add(1000000u64))

--- a/vortex-cuda/src/lib.rs
+++ b/vortex-cuda/src/lib.rs
@@ -11,6 +11,7 @@ mod session;
 
 use std::process::Command;
 
+pub use device_buffer::CudaBufferExt;
 pub use device_buffer::CudaDeviceBuffer;
 pub use executor::CudaExecutionCtx;
 pub use executor::CudaKernelEvents;


### PR DESCRIPTION
As part of this, FoR kernel execution is now async. GPU tests still pass and the benchmarks show unchanged performance.