### PR TITLE
Don't run clippy on each crate with no default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,41 +301,6 @@ jobs:
         if: ${{ github.ref_name == 'develop' && steps.setup-rust.outputs.deps-cache-hit != 'true' }}
         run: cargo sweep --file
 
-  rust-lint-no-default:
-    name: "Rust (lint, no default, ${{ matrix.partition }}/2)"
-    timeout-minutes: 120
-    strategy:
-      fail-fast: false
-      matrix:
-        partition: [1, 2]
-    runs-on:
-      - runs-on=${{ github.run_id }}
-      - family=m7i+m7i-flex+m7a
-      - cpu=16
-      - image=ubuntu24-full-x64
-      - extras=s3-cache
-      - tag=rust-lint-no-default-${{ matrix.partition }}
-    steps:
-      - uses: runs-on/action@v2
-        with:
-          sccache: s3
-      - uses: actions/checkout@v6
-      - id: setup-rust
-        uses: ./.github/actions/setup-rust
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          timestamp: "true"
-      - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
-      - name: Rust Lint - Clippy No Default Features
-        shell: bash
-        run: |
-          # https://spiraldb.slack.com/archives/C07BV3GKAJ2/p1732736281946729
-          cargo hack clippy --no-default-features --partition ${{ matrix.partition }}/2 -- -D warnings
-      - name: Prune cache
-        if: ${{ github.ref_name == 'develop' && steps.setup-rust.outputs.deps-cache-hit != 'true' }}
-        run: cargo sweep --file
-
   rust-semver:
     name: "Rust (semver checks)"
     timeout-minutes: 120


### PR DESCRIPTION
Opened a discussion on the community slack, will require and admin to make it not mandatory.