### PR TITLE
Remove the `rust-action` based cache

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -49,13 +49,13 @@ runs:
         targets: "${{ inputs.targets }}"
         components: "${{ inputs.components || 'clippy, rustfmt' }}"
 
-    - name: Rust Dependency Cache
-      uses: Swatinem/rust-cache@v2
-      with:
-        save-if: ${{ github.ref_name == 'develop' }}
-        # os and arch by default
-        shared-key: "rust-cache-${{ github.job }}-${{ runner.environment }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ inputs.targets }}${{ inputs.cache-suffix && format('-{0}', inputs.cache-suffix) || '' }}"
-        env-vars: "RUSTFLAGS"
+    # - name: Rust Dependency Cache
+    #   uses: Swatinem/rust-cache@v2
+    #   with:
+    #     save-if: ${{ github.ref_name == 'develop' }}
+    #     # os and arch by default
+    #     shared-key: "rust-cache-${{ github.job }}-${{ runner.environment }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ inputs.targets }}${{ inputs.cache-suffix && format('-{0}', inputs.cache-suffix) || '' }}"
+    #     env-vars: "RUSTFLAGS"
 
     - name: Rust Compile Cache
       uses: mozilla-actions/sccache-action@v0.0.9

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -57,4 +57,3 @@ runs:
       with:
         version: "29.3"
         repo-token: ${{ inputs.repo-token }}
-

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -16,6 +16,10 @@ inputs:
   targets:
     description: "optional targets override (e.g. wasm32-unknown-unknown)"
     required: false
+  enable-sccache:
+    description: "Should sccache be enabled, true by default."
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -44,6 +48,7 @@ runs:
         components: "${{ inputs.components }}"
 
     - name: Rust Compile Cache
+      if: inputs.enable-sccache == 'true'
       uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Install Protoc (for lance-encoding build step)

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -11,17 +11,11 @@ inputs:
     required: false
   components:
     description: "optional override for the components to install for the step (e.g. clippy, rustfmt, miri)"
+    default: "clippy, rustfmt"
     required: false
   targets:
     description: "optional targets override (e.g. wasm32-unknown-unknown)"
     required: false
-  cache-suffix:
-    description: "optional suffix for cache key to isolate builds with different RUSTFLAGS (e.g. 'sanitizer')"
-    required: false
-    default: ""
-  timestamp:
-    description: "Timestamp cache with cargo sweep"
-    default: "false"
 
 runs:
   using: "composite"
@@ -47,15 +41,7 @@ runs:
       with:
         toolchain: "${{ steps.toolchain-config.outputs.toolchain }}"
         targets: "${{ inputs.targets }}"
-        components: "${{ inputs.components || 'clippy, rustfmt' }}"
-
-    # - name: Rust Dependency Cache
-    #   uses: Swatinem/rust-cache@v2
-    #   with:
-    #     save-if: ${{ github.ref_name == 'develop' }}
-    #     # os and arch by default
-    #     shared-key: "rust-cache-${{ github.job }}-${{ runner.environment }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ inputs.targets }}${{ inputs.cache-suffix && format('-{0}', inputs.cache-suffix) || '' }}"
-    #     env-vars: "RUSTFLAGS"
+        components: "${{ inputs.components }}"
 
     - name: Rust Compile Cache
       uses: mozilla-actions/sccache-action@v0.0.9
@@ -67,12 +53,3 @@ runs:
         version: "29.3"
         repo-token: ${{ inputs.repo-token }}
 
-    - name: Install Sweep
-      shell: bash
-      if: ${{ inputs.timestamp == 'true' && github.ref_name == 'develop' }}
-      run: cargo install cargo-sweep
-
-    - name: Timestamp Cache
-      shell: bash
-      if: ${{ inputs.timestamp == 'true' && github.ref_name == 'develop' }}
-      run: cargo sweep --stamp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
       - id: setup-rust
         uses: ./.github/actions/setup-rust
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }} 
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install wasm32 target
         if: ${{ matrix.config.target == 'wasm32-unknown-unknown' }}
         run: rustup target add wasm32-unknown-unknown
@@ -286,7 +286,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           toolchain: nightly
-          repo-token: ${{ secrets.GITHUB_TOKEN }}       
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Rust Lint - Format
         run: cargo +nightly fmt --all --check
       - name: Rustc check
@@ -398,7 +398,7 @@ jobs:
       - id: setup-rust
         uses: ./.github/actions/setup-rust
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}   
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install grcov
         uses: taiki-e/install-action@grcov
       - name: Install nextest
@@ -533,7 +533,7 @@ jobs:
       - id: setup-rust
         uses: ./.github/actions/setup-rust
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}         
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install nextest
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,7 @@ jobs:
       - id: setup-rust
         uses: ./.github/actions/setup-rust
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          timestamp: "true"
+          repo-token: ${{ secrets.GITHUB_TOKEN }} 
       - name: Install wasm32 target
         if: ${{ matrix.config.target == 'wasm32-unknown-unknown' }}
         run: rustup target add wasm32-unknown-unknown
@@ -240,9 +239,6 @@ jobs:
         run: |
           git status --porcelain
           test -z "$(git status --porcelain)"
-      - name: Prune cache
-        if: ${{ github.ref_name == 'develop' && steps.setup-rust.outputs.deps-cache-hit != 'true' }}
-        run: cargo sweep --file
 
   check-min-deps:
     name: "Check build with minimal dependencies"
@@ -285,8 +281,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           toolchain: nightly
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          timestamp: "true"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}       
       - name: Rust Lint - Format
         run: cargo +nightly fmt --all --check
       - name: Rustc check
@@ -297,9 +292,6 @@ jobs:
         run: cargo clippy --locked --all-features --all-targets -- -D warnings
       - name: Rust Lint - Clippy Default Features
         run: cargo clippy --locked --all-targets -- -D warnings
-      - name: Prune cache
-        if: ${{ github.ref_name == 'develop' && steps.setup-rust.outputs.deps-cache-hit != 'true' }}
-        run: cargo sweep --file
 
   rust-lint-no-default:
     name: "Rust (lint, no default, ${{ matrix.partition }}/2)"
@@ -324,7 +316,6 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          timestamp: "true"
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       - name: Rust Lint - Clippy No Default Features
@@ -332,9 +323,6 @@ jobs:
         run: |
           # https://spiraldb.slack.com/archives/C07BV3GKAJ2/p1732736281946729
           cargo hack clippy --no-default-features --partition ${{ matrix.partition }}/2 -- -D warnings
-      - name: Prune cache
-        if: ${{ github.ref_name == 'develop' && steps.setup-rust.outputs.deps-cache-hit != 'true' }}
-        run: cargo sweep --file
 
   rust-semver:
     name: "Rust (semver checks)"
@@ -358,7 +346,6 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       # We have to set the correct Cargo.toml versions so semver checks uses the previous release.
       - name: Latest Tag
         id: latest-tag
@@ -406,8 +393,7 @@ jobs:
       - id: setup-rust
         uses: ./.github/actions/setup-rust
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          timestamp: "true"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}   
       - name: Install grcov
         uses: taiki-e/install-action@grcov
       - name: Install nextest
@@ -441,14 +427,6 @@ jobs:
           disable_search: true
           flags: ${{ matrix.suite }}
           use_oidc: true
-      - name: Cleanup coverage file
-        shell: bash
-        run: |
-          du -sh target/coverage/
-          rm -rf target/coverage/
-      - name: Prune cache
-        if: ${{ github.ref_name == 'develop' && steps.setup-rust.outputs.deps-cache-hit != 'true' }}
-        run: cargo sweep --file
 
   rust-test:
     name: "Rust tests (sanitizer)"
@@ -488,7 +466,6 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           toolchain: nightly
           components: "rust-src, rustfmt, clippy, llvm-tools-preview"
-          timestamp: "true"
       - name: Install build dependencies
         run: |
           sudo apt-get update
@@ -512,9 +489,6 @@ jobs:
             --no-fail-fast \
             --target x86_64-unknown-linux-gnu \
             -p vortex-buffer -p vortex-ffi -p vortex-fastlanes -p vortex-fsst -p vortex-alp -p vortex-array
-      - name: Prune cache
-        if: ${{ github.ref_name == 'develop' && steps.setup-rust.outputs.deps-cache-hit != 'true' }}
-        run: cargo sweep --file
 
   rust-test-other:
     name: "Rust tests (${{ matrix.os }})"
@@ -554,8 +528,7 @@ jobs:
       - id: setup-rust
         uses: ./.github/actions/setup-rust
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          timestamp: "true"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}         
       - name: Install nextest
         uses: taiki-e/install-action@v2
         with:
@@ -567,9 +540,6 @@ jobs:
       - name: Rust Tests (Other)
         if: matrix.os != 'windows-x64'
         run: cargo nextest run --locked --workspace --all-features --no-fail-fast --exclude vortex-bench --exclude xtask
-      - name: Prune cache
-        if: ${{ github.ref_name == 'develop' && steps.setup-rust.outputs.deps-cache-hit != 'true' }}
-        run: cargo sweep --file
 
   build-java:
     name: "Java"
@@ -673,7 +643,6 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          timestamp: "true"
       - name: Build and run C++ unit tests
         run: |
           mkdir -p vortex-cxx/build
@@ -685,9 +654,6 @@ jobs:
           cmake -S vortex-cxx/examples -B vortex-cxx/examples/build -DCMAKE_BUILD_TYPE=Release
           cmake --build vortex-cxx/examples/build --parallel $(nproc)
           vortex-cxx/examples/build/hello-vortex vortex-cxx/examples/goldenfiles/example.vortex
-      - name: Prune cache
-        if: ${{ github.ref_name == 'develop' && steps.setup-rust.outputs.deps-cache-hit != 'true' }}
-        run: cargo sweep --file
 
   wasm-integration:
     name: "wasm-integration"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,9 +132,14 @@ jobs:
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v6
+      - name: Rust Dependency Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref_name == 'develop' }}
       - uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          enable-sccache: "false"
       - uses: mlugg/setup-zig@v2
       - name: Install uv
         uses: spiraldb/actions/.github/actions/setup-uv@0.18.5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          enable-sccache: "false"
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/fuzzer-fix-automation.yml
+++ b/.github/workflows/fuzzer-fix-automation.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           toolchain: nightly
+          enable-sccache: "false"
 
       - name: Install llvm
         uses: aminya/setup-cpp@v1

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           targets: ${{ matrix.target.target }}
+          enable-sccache: "false"
 
       - name: Cargo Set Version
         run: |
@@ -90,6 +91,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          enable-sccache: "false"
       - run: cargo build --release --package vortex-jni
       - uses: actions/upload-artifact@v5
         with:
@@ -131,6 +133,7 @@ jobs:
         with:
           targets: ${{ matrix.target.target }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          enable-sccache: "false"
       - run: cargo build --release --package vortex-jni
       - uses: actions/upload-artifact@v5
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          enable-sccache: "false"
 
       - name: Cargo Set Version
         run: |

--- a/.github/workflows/wasm-fuzz.yml
+++ b/.github/workflows/wasm-fuzz.yml
@@ -32,6 +32,7 @@ jobs:
           toolchain: nightly
           targets: "wasm32-wasip1"
           components: "rust-src"
+          enable-sccache: "false"
 
       - name: Build WASM fuzz target
         run: |


### PR DESCRIPTION
Experimenting showed that just using sccache is generally better or roughly equal, at least for our current setup with runs-on backed storage. 
I've audited all of our CI setup, and found a few places where we run on github runners so using sccache is wasteful and disabled it, and also found a few places where `rust-cache` should still be useful.