### PR TITLE
fix[vortex-array]: lookup target fields by name in StructCastPushdownRule

### DIFF
--- a/vortex-array/src/arrays/struct_/vtable/rules.rs
+++ b/vortex-array/src/arrays/struct_/vtable/rules.rs
@@ -50,38 +50,27 @@ impl ArrayParentReduceRule<StructVTable> for StructCastPushDownRule {
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         let target_fields = parent.options.as_struct_fields();
-        let source_field_count = array.fields.len();
-        let target_field_count = target_fields.nfields();
+        let mut new_fields = Vec::with_capacity(target_fields.nfields());
 
-        // Target must have at least as many fields as source
-        vortex_ensure!(
-            target_field_count >= source_field_count,
-            "Cannot cast struct: target has fewer fields ({}) than source ({})",
-            target_field_count,
-            source_field_count
-        );
-
-        let mut new_fields = Vec::with_capacity(target_field_count);
-
-        // Cast existing source fields to target types
-        for (field_array, field_dtype) in array
-            .fields
-            .iter()
-            .zip(target_fields.fields().take(source_field_count))
+        for (target_name, target_dtype) in target_fields.names().iter().zip(target_fields.fields())
         {
-            new_fields.push(field_array.cast(field_dtype)?);
-        }
-
-        // Add null arrays for any extra target fields (schema evolution)
-        for field_dtype in target_fields.fields().skip(source_field_count) {
-            vortex_ensure!(
-                field_dtype.is_nullable(),
-                "Cannot add non-nullable field during struct cast (schema evolution only supports nullable fields)"
-            );
-            new_fields.push(
-                ConstantArray::new(vortex_scalar::Scalar::null(field_dtype), array.len())
-                    .into_array(),
-            );
+            match array.field_by_name(target_name).ok() {
+                Some(field) => {
+                    new_fields.push(field.cast(target_dtype)?);
+                }
+                None => {
+                    // Not found - create NULL array (schema evolution)
+                    vortex_ensure!(
+                        target_dtype.is_nullable(),
+                        "Cannot add non-nullable field '{}' during struct cast",
+                        target_name
+                    );
+                    new_fields.push(
+                        ConstantArray::new(vortex_scalar::Scalar::null(target_dtype), array.len())
+                            .into_array(),
+                    );
+                }
+            }
         }
 
         let validity = if parent.options.is_nullable() {
@@ -144,5 +133,62 @@ impl ArrayParentReduceRule<StructVTable> for StructGetItemRule {
                     .map(Some)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_dtype::DType;
+    use vortex_dtype::FieldNames;
+    use vortex_dtype::Nullability;
+    use vortex_dtype::StructFields;
+    use vortex_scalar::Scalar;
+
+    use crate::IntoArray;
+    use crate::arrays::ConstantArray;
+    use crate::arrays::StructArray;
+    use crate::arrays::VarBinViewArray;
+    use crate::assert_arrays_eq;
+    use crate::builtins::ArrayBuiltins;
+    use crate::canonical::ToCanonical;
+    use crate::validity::Validity;
+
+    #[test]
+    fn test_struct_cast_field_reorder() {
+        // Source: {a, b}, Target: {c, b, a} - reordered + new null field
+        let source = StructArray::try_new(
+            FieldNames::from(["a", "b"]),
+            vec![
+                VarBinViewArray::from_iter_str(["A"]).into_array(),
+                VarBinViewArray::from_iter_str(["B"]).into_array(),
+            ],
+            1,
+            Validity::NonNullable,
+        )
+        .unwrap();
+
+        let utf8_null = DType::Utf8(Nullability::Nullable);
+        let target = DType::Struct(
+            StructFields::new(
+                FieldNames::from(["c", "b", "a"]),
+                vec![utf8_null.clone(); 3],
+            ),
+            Nullability::NonNullable,
+        );
+
+        // Use ArrayBuiltins::cast which goes through the optimizer and applies StructCastPushDownRule
+        let result = source.into_array().cast(target).unwrap().to_struct();
+        assert_arrays_eq!(
+            result.field_by_name("a").unwrap(),
+            VarBinViewArray::from_iter_nullable_str([Some("A")])
+        );
+        assert_arrays_eq!(
+            result.field_by_name("b").unwrap(),
+            VarBinViewArray::from_iter_nullable_str([Some("B")])
+        );
+        assert_arrays_eq!(
+            result.field_by_name("c").unwrap(),
+            ConstantArray::new(Scalar::null(utf8_null), 1)
+        );
     }
 }

--- a/vortex-datafusion/tests/schema_evolution.rs
+++ b/vortex-datafusion/tests/schema_evolution.rs
@@ -526,3 +526,100 @@ async fn test_schema_evolution_struct_of_dict() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_schema_evolution_struct_field_order() {
+    let (ctx, store) = make_session_ctx();
+
+    // File1: labels = {region, service} - service at position 1
+    let file1_labels: ArrowArrayRef = Arc::new(StructArray::new(
+        Fields::from(vec![
+            Field::new("region", DataType::Utf8, true),
+            Field::new("service", DataType::Utf8, true),
+        ]),
+        vec![
+            create_array!(Utf8, vec![Some("us-east"), Some("us-west")]),
+            create_array!(Utf8, vec![Some("api"), Some("api")]),
+        ],
+        None,
+    ));
+    write_file(
+        &store,
+        "reorder/file1.vortex",
+        &RecordBatch::try_from_iter([("labels", file1_labels)]).unwrap(),
+    )
+    .await;
+
+    // File2: labels = {service, instance, job} - service at position 0
+    let file2_labels: ArrowArrayRef = Arc::new(StructArray::new(
+        Fields::from(vec![
+            Field::new("service", DataType::Utf8, true),
+            Field::new("instance", DataType::Utf8, true),
+            Field::new("job", DataType::Utf8, true),
+        ]),
+        vec![
+            create_array!(Utf8, vec![Some("api"), Some("api")]),
+            create_array!(Utf8, vec![Some("host-0"), Some("host-1")]),
+            create_array!(Utf8, vec![Some("scraper"), Some("scraper")]),
+        ],
+        None,
+    ));
+    write_file(
+        &store,
+        "reorder/file2.vortex",
+        &RecordBatch::try_from_iter([("labels", file2_labels)]).unwrap(),
+    )
+    .await;
+
+    let target_schema = Arc::new(Schema::new(vec![Field::new(
+        "labels",
+        DataType::Struct(Fields::from(vec![
+            Field::new("region", DataType::Utf8, true),
+            Field::new("service", DataType::Utf8, true),
+            Field::new("instance", DataType::Utf8, true),
+            Field::new("job", DataType::Utf8, true),
+        ])),
+        true,
+    )]));
+
+    let table_url = ListingTableUrl::parse("s3://in-memory/reorder").unwrap();
+    let list_opts = ListingOptions::new(Arc::new(VortexFormat::new(SESSION.clone())))
+        .with_session_config_options(ctx.state().config())
+        .with_file_extension("vortex");
+    let table = Arc::new(
+        ListingTable::try_new(
+            ListingTableConfig::new(table_url)
+                .with_listing_options(list_opts)
+                .with_schema(target_schema),
+        )
+        .unwrap(),
+    );
+
+    let result = ctx
+        .read_table(table)
+        .unwrap()
+        .select(vec![
+            get_field(col("labels"), "region").alias("region"),
+            get_field(col("labels"), "service").alias("service"),
+            get_field(col("labels"), "instance").alias("instance"),
+            get_field(col("labels"), "job").alias("job"),
+        ])
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    assert_batches_sorted_eq!(
+        [
+            "+---------+---------+----------+---------+",
+            "| region  | service | instance | job     |",
+            "+---------+---------+----------+---------+",
+            "| us-east | api     |          |         |",
+            "| us-west | api     |          |         |",
+            "|         | api     | host-0   | scraper |",
+            "|         | api     | host-1   | scraper |",
+            "+---------+---------+----------+---------+",
+        ],
+        &result
+    );
+}


### PR DESCRIPTION
The previous code was assuming that target fields were in the same order as source fields and all target fields existing in the source schema were the first k fields. This would cause incorrect query results.